### PR TITLE
Instrument the realm-server search path with a request→response timeline (CS-11363)

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: indexing-diagnostics
-description: Investigate slow or failing indexing using the diagnostics persisted on every `boxel_index` row (`diagnostics` JSONB column, mirrored onto `error_doc.diagnostics` for error rows) plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most, (3) enumerating cards with broken `linksTo` / `linksToMany` targets via `diagnostics.brokenLinks` (those cards index cleanly, so this is the only indexed signal), and (4) verifying the module pre-warm phase populates the definition cache under a key the indexer / on-demand prerender reads actually hit — i.e. it isn't a silent no-op — via the `definition-cache-key` hit/miss log channel. Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, when investigating the CS-10820 saturation class of incidents, or when asked to list / count cards with broken links in a realm. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
+description: Investigate slow or failing indexing using the diagnostics persisted on every `boxel_index` row (`diagnostics` JSONB column, mirrored onto `error_doc.diagnostics` for error rows) plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most, (3) enumerating cards with broken `linksTo` / `linksToMany` targets via `diagnostics.brokenLinks` (those cards index cleanly, so this is the only indexed signal), (4) verifying the module pre-warm phase populates the definition cache under a key the indexer / on-demand prerender reads actually hit — i.e. it isn't a silent no-op — via the `definition-cache-key` hit/miss log channel, and (5) attributing a slow in-render `_search` round-trip to the realm-server's own request→response stages (parse / SQL / loadLinks / serialize / queue) via the `realm:search-timing`, `realm:requests` (`dur=`), and `realm:health` log channels keyed by the `x-boxel-logging-correlation-id` correlation id. Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, when investigating the CS-10820 saturation class of incidents, when a render stalls in `waiting-stability` on a `_search` whose SQL is fast but whose response is slow to come back, or when asked to list / count cards with broken links in a realm. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
@@ -12,17 +12,19 @@ Every indexer write (`IndexWriter.updateEntry`) persists a diagnostic blob on th
 - **A reindex that was slow but succeeded** — attribute wall-clock across the cards that got re-rendered, find the real culprit in the fan-out.
 - **Which cards have broken links** — enumerate cards with a broken `linksTo` / `linksToMany` target straight from the column; those cards index cleanly, so `diagnostics.brokenLinks` is the only indexed signal. See [Mode E](#mode-e--enumerate-cards-with-broken-links).
 - **Whether module pre-warm is effective** — confirm the pre-warm phase populates the definition cache under a key the indexer / on-demand reads actually hit (not a silent no-op), using the `definition-cache-key` hit/miss log channel. This one isn't about the `diagnostics` column — it reads the logs. See [Mode F](#mode-f--module-pre-warm-and-definition-cache-hitmiss).
+- **Why an in-render `_search` was slow to come back** — when a render stalls in `waiting-stability` waiting on a query-backed `linksTo` / `linksToMany` search (the `boxel_index.diagnostics` shows it client-side as `queryLoadsInFlight` aging) but the SQL is fast, attribute the realm-server's request→response time across its stages (parse / SQL / loadLinks / serialize) and tell handler-time from queued-before-handler / event-loop saturation. Log-based, keyed by the correlation id. See [Mode G](#mode-g--an-in-render-_search-was-slow-server-side-search-timing).
 
-The first three read from the same `diagnostics` column; the difference is the query you start with. Mode F is log-based.
+The first three read from the same `diagnostics` column; the difference is the query you start with. Modes F and G are log-based.
 
 ## Where the diagnostics live
 
 Four places, all correlated:
 
-1. **`boxel_index.diagnostics` (and `boxel_index_working.diagnostics`)** — JSONB column, populated for **every** row the indexer writes, regardless of `has_error`. Source of truth for **card** renders. Carries the full `RenderTimeoutDiagnostics` payload plus three write-side stamps: `invalidationId`, `indexedAt`, `requestId`. It also carries a `brokenLinks` array on any card row whose render found a broken `linksTo` / `linksToMany` target — see [Mode E](#mode-e--enumerate-cards-with-broken-links). Note this is the one block that isn't about *timing*: a card with broken links still indexes as a clean `type='instance'` (the broken slot renders a placeholder), so `brokenLinks` is the only indexed signal that the row has a broken reference.
+1. **`boxel_index.diagnostics` (and `boxel_index_working.diagnostics`)** — JSONB column, populated for **every** row the indexer writes, regardless of `has_error`. Source of truth for **card** renders. Carries the full `RenderTimeoutDiagnostics` payload plus three write-side stamps: `invalidationId`, `indexedAt`, `requestId`. It also carries a `brokenLinks` array on any card row whose render found a broken `linksTo` / `linksToMany` target — see [Mode E](#mode-e--enumerate-cards-with-broken-links). Note this is the one block that isn't about _timing_: a card with broken links still indexes as a clean `type='instance'` (the broken slot renders a placeholder), so `brokenLinks` is the only indexed signal that the row has a broken reference.
 2. **`modules.diagnostics`** — JSONB column, populated for every row `persistModuleCacheEntry` writes (success and error paths). Source of truth for **module** renders (`prerenderModule` → definition extraction). Same `RenderTimeoutDiagnostics` shape with `requestId` flattened in; no `invalidationId` (modules don't go through `Batch.invalidate`). The row's existing `created_at` column is the wall-clock stamp for cross-table joins. See [Mode D](#mode-d--a-module-render-was-slow-or-hung) below.
 3. **`error_doc.diagnostics`** — derived copy of `diagnostics`, written only for error rows on `boxel_index`. Exists so the existing UI read path (`error_doc` → `CardErrorJSONAPI.meta.diagnostics` via `formattedError`) keeps working without a schema rename. Non-error rows have `error_doc = null`; go to `diagnostics` directly.
 4. **Logs** — `prerender-server`, `manager`, and `remote-prerenderer` lines all carry `requestId=…`. `grep requestId=<uuid>` collates one call across all three processes. The same `requestId` lands on both `boxel_index.diagnostics->>'requestId'` and `modules.diagnostics->>'requestId'`, so a hung card render and the module renders it triggered (via `getDefinition`) can be joined back to one investigation. For saturation incidents there's also the periodic `prerender-queue-snapshot` line on each prerender server.
+5. **Realm-server search-timing logs** — separate from the prerender `requestId` chain above. The realm-server emits, per instrumented `_federated-search`, a `realm:search-timing` line (request→response stage breakdown) and a `realm:requests` `-->` line with `dur=` (total) — both keyed by `corr=<id>`, the `x-boxel-logging-correlation-id` the prerendered host stamps. A periodic `realm:health` line reports event-loop lag + in-flight `_search` count during saturation windows. These are the _server's_ view of the search the card is blocked on; the card's `boxel_index.diagnostics` only has the _client's_ view (`queryLoadsInFlight`). See [Mode G](#mode-g--an-in-render-_search-was-slow-server-side-search-timing).
 
 For UI triage you'll typically read the JSON error response (which surfaces `error_doc.diagnostics` as `meta.diagnostics`). For operator / SQL triage — especially slow non-failing reindexes — query the `diagnostics` column directly.
 
@@ -41,7 +43,7 @@ Every slow or timed-out render falls into one of:
 
 - **Launch stall**: the request waited in the render-semaphore or tab queue and never got a real render attempt. Fix is capacity, not host code.
 - **Loader stall**: the render started but was still pulling `.gts` modules when the timer fired. Fix is module graph / network.
-- **Data stall**: the render got past module load but is still fetching cards, file-meta, or query-field results. Fix is the host data layer or the backend search.
+- **Data stall**: the render got past module load but is still fetching cards, file-meta, or query-field results. Fix is the host data layer or the backend search. When it's a query-field `_search` (`queryLoadsInFlight` aging), [Mode G](#mode-g--an-in-render-_search-was-slow-server-side-search-timing) attributes the backend search to the realm-server's own request→response stages.
 - **Render stall**: the render is in DOM rendering / stability-wait but nothing is in flight. Fix is Glimmer / template side.
 
 If you pick the wrong category you waste a day. The diagnostic fields in the [Classify in one pass](#classify-in-one-pass) table below pick it for you.
@@ -588,7 +590,7 @@ A short rubric for the most common shapes:
 
 Module renders (`prerenderModule`, used by `getDefinition` to convert filter JSON into SQL on `_federated-search`, plus everywhere else a card definition is needed without a card render) go through the same prerender pipeline as card renders, but they land in the `modules` table — not `boxel_index`. The `diagnostics` JSONB column on `modules` carries the same `RenderTimeoutDiagnostics`-with-`requestId` shape, so the field-by-field reading and the [Classify in one pass](#classify-in-one-pass) table apply unchanged. Only the lookup queries differ.
 
-**When to use this mode:** a card render hung waiting on `getDefinition` (Mode A captured `cardDocLoadsInFlight = 0`, `queryLoadsInFlight = 0`, but the realm-server's reply to `_federated-search` itself was slow); an investigation needs to attribute time across both card renders and the module renders they triggered; or you want to find the slowest module renders fleet-wide. Same payload shape, queryable via SQL.
+**When to use this mode:** a card render hung waiting on `getDefinition` (Mode A captured `cardDocLoadsInFlight = 0`, `queryLoadsInFlight = 0`, but the realm-server's reply to `_federated-search` itself was slow — and if the stall was on a query-field search rather than a definition lookup, i.e. `queryLoadsInFlight > 0`, use [Mode G](#mode-g--an-in-render-_search-was-slow-server-side-search-timing) instead); an investigation needs to attribute time across both card renders and the module renders they triggered; or you want to find the slowest module renders fleet-wide. Same payload shape, queryable via SQL.
 
 **Step 1 — slowest module renders in a realm.**
 
@@ -647,7 +649,7 @@ WHERE diagnostics->>'requestId' = '<request-id>';
 
 ## Mode E — enumerate cards with broken links
 
-Unlike Modes A–D, this isn't a perf investigation: it's a realm-health / content-integrity query. A card whose `linksTo` / `linksToMany` target is unreachable (deleted, 404, upstream 5xx, network failure) **still indexes as a clean `type='instance'`** — the broken slot renders the placeholder template and the broken reference is preserved on the wire as `relationships.<field>.links.self`, identical to a not-yet-loaded link. So `has_error` is `false` and `error_doc` is `null`; nothing in the row's *status* tells you the link is broken.
+Unlike Modes A–D, this isn't a perf investigation: it's a realm-health / content-integrity query. A card whose `linksTo` / `linksToMany` target is unreachable (deleted, 404, upstream 5xx, network failure) **still indexes as a clean `type='instance'`** — the broken slot renders the placeholder template and the broken reference is preserved on the wire as `relationships.<field>.links.self`, identical to a not-yet-loaded link. So `has_error` is `false` and `error_doc` is `null`; nothing in the row's _status_ tells you the link is broken.
 
 What records it is `diagnostics.brokenLinks` — an array the host's `render.meta` route builds by running `getBrokenLinks(instance)` on the settled instance and attaching the findings to the diagnostics block. Each finding is the minimal queryable summary:
 
@@ -702,13 +704,13 @@ Caveats:
 
 ## Mode F — module pre-warm and definition-cache hit/miss
 
-Use this when you're asking *"is the module pre-warm actually populating the definition cache, and are the indexer / prerender reads hitting it — or silently re-computing?"* This is about **cache effectiveness**, not render timing.
+Use this when you're asking _"is the module pre-warm actually populating the definition cache, and are the indexer / prerender reads hitting it — or silently re-computing?"_ This is about **cache effectiveness**, not render timing.
 
 ### What pre-warm is
 
 A from-scratch (and incremental) index runs a **pre-warm phase** before the visit phase: `IndexRunner.preWarmModulesTable` walks the realm's modules and calls `definitionLookup.populateDefinitionCacheEntry(...)`, which prerenders each module's definitions and persists them to the `modules` table. The intent is that the subsequent **visit phase** (indexing instances) and **on-demand reads** (the realm-server serving `getDefinition` to prerender tabs) then find those rows already cached instead of re-prerendering them.
 
-The original failure this guards against: a worker pre-warm that ran with a self-resolved *null* cache context wrote nothing (or wrote under a key nobody reads), so pre-warm was a silent no-op. The diagnostic below tells you definitively whether that's happening.
+The original failure this guards against: a worker pre-warm that ran with a self-resolved _null_ cache context wrote nothing (or wrote under a key nobody reads), so pre-warm was a silent no-op. The diagnostic below tells you definitively whether that's happening.
 
 ### The cache key
 
@@ -736,21 +738,22 @@ Deployed: set `LOG_LEVELS` in the worker's SSM param and redeploy (same mechanic
 
 Three events are emitted (all via the framework `logger`, so the lines carry **no `[category]` prefix** — grep the message text, not the word `definition-cache-key`):
 
-| Line | Where | Meaning |
-| --- | --- | --- |
-| `WRITE module=<u> scope=<s> user=<id\|(empty)> realm=<r>` | `persistDefinitionCacheEntry` | A definition was persisted. The `user=` shown is the **normalized stored key** (public → `(empty)`), not the render identity. |
-| `HIT module=<u> scope=<s> user=<…> realm=<r> alias=<a>` | `readFromDatabaseCache` | A DB read found the row. Always a real hit (logged at the read choke point, covers worker + realm-server). |
-| `MISS source=pre-warm\|on-demand module=<u> …` | `loadDefinitionCacheEntryUncached` | A lookup **exhausted the cache** (primary URL + every alias/extension candidate) and committed to a prerender. Logged **once per logical lookup** — not per alias probe. `source=pre-warm` is the pre-warm phase's own cold probe; `source=on-demand` is a visit-phase / live read. |
+| Line                                                      | Where                              | Meaning                                                                                                                                                                                                                                                                             |
+| --------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WRITE module=<u> scope=<s> user=<id\|(empty)> realm=<r>` | `persistDefinitionCacheEntry`      | A definition was persisted. The `user=` shown is the **normalized stored key** (public → `(empty)`), not the render identity.                                                                                                                                                       |
+| `HIT module=<u> scope=<s> user=<…> realm=<r> alias=<a>`   | `readFromDatabaseCache`            | A DB read found the row. Always a real hit (logged at the read choke point, covers worker + realm-server).                                                                                                                                                                          |
+| `MISS source=pre-warm\|on-demand module=<u> …`            | `loadDefinitionCacheEntryUncached` | A lookup **exhausted the cache** (primary URL + every alias/extension candidate) and committed to a prerender. Logged **once per logical lookup** — not per alias probe. `source=pre-warm` is the pre-warm phase's own cold probe; `source=on-demand` is a visit-phase / live read. |
 
 > Two logging facts that will mislead you if you don't know them:
-> 1. **Category overrides only take effect because `setup-logger.ts` calls `reapplyLogLevels()`** after installing `_logDefinitions`. Module-scope `logger()` calls (like this one) are evaluated during the barrel import *before* `_logDefinitions` exists, so without the re-apply they stay stuck at loglevel's default and `definition-cache-key=debug` silently no-ops. If you add a new module-scope category and it won't emit, this is why.
+>
+> 1. **Category overrides only take effect because `setup-logger.ts` calls `reapplyLogLevels()`** after installing `_logDefinitions`. Module-scope `logger()` calls (like this one) are evaluated during the barrel import _before_ `_logDefinitions` exists, so without the re-apply they stay stuck at loglevel's default and `definition-cache-key=debug` silently no-ops. If you add a new module-scope category and it won't emit, this is why.
 > 2. A bare `readFromDatabaseCache` returning no rows is **not** a real miss — it's one probe (the reader tries `foo`, `foo.ts`, `foo.js`, `foo.gts`, `foo.gjs`). Counting those as misses inflates the number ~5×. The `MISS source=…` line is the de-duplicated, real signal; trust it over raw DB-read counts.
 
 ### The healthy shape
 
 For a cold from-scratch of a single realm, healthy looks like:
 
-- `MISS source=pre-warm` ≈ one per module being warmed. **These are expected** — they *are* the warming (probe cold → prerender → `WRITE`).
+- `MISS source=pre-warm` ≈ one per module being warmed. **These are expected** — they _are_ the warming (probe cold → prerender → `WRITE`).
 - `MISS source=on-demand` = **0**.
 - Realm-server on-demand reads = all HIT, **0 miss**, after the pre-warm phase.
 
@@ -789,11 +792,75 @@ Run it once on a **private** realm and once on a **public** realm — the public
 
 ### Pre-warm concurrency
 
-Pre-warm is **serial by default** (`INDEXER_PREWARM_CONCURRENCY=1`). It's opt-in tunable — a bounded worker pool over `populateDefinitionCacheEntry`. On a cold / shared prerender pool, raising it can be *slower* (tab materialization cost vs warm-tab reuse), so measure the pre-warm-phase wall-clock (the `modules.created_at` min→max window for the realm) before and after rather than assuming parallel wins. Align the ceiling with the prerender affinity tab budget (`PRERENDER_AFFINITY_TAB_MAX`); beyond that you just queue inside the prerender server.
+Pre-warm is **serial by default** (`INDEXER_PREWARM_CONCURRENCY=1`). It's opt-in tunable — a bounded worker pool over `populateDefinitionCacheEntry`. On a cold / shared prerender pool, raising it can be _slower_ (tab materialization cost vs warm-tab reuse), so measure the pre-warm-phase wall-clock (the `modules.created_at` min→max window for the realm) before and after rather than assuming parallel wins. Align the ceiling with the prerender affinity tab budget (`PRERENDER_AFFINITY_TAB_MAX`); beyond that you just queue inside the prerender server.
 
 ### What Mode F can't tell you
 
-Pre-warm only populates module **definitions**. A realm whose card-authored modules fail to *evaluate* (e.g. a circular-dependency TDZ in a bundled module — `Cannot access 'X' before initialization`) will still fail the **visit phase** instance renders regardless of a clean pre-warm; those show up as `boxel_index` error rows, not cache misses. Mode F confirms the cache is keyed and populated correctly; it says nothing about whether the modules themselves render.
+Pre-warm only populates module **definitions**. A realm whose card-authored modules fail to _evaluate_ (e.g. a circular-dependency TDZ in a bundled module — `Cannot access 'X' before initialization`) will still fail the **visit phase** instance renders regardless of a clean pre-warm; those show up as `boxel_index` error rows, not cache misses. Mode F confirms the cache is keyed and populated correctly; it says nothing about whether the modules themselves render.
+
+## Mode G — an in-render `_search` was slow (server-side search timing)
+
+**When to use this mode.** Mode A classified a timed-out (or slow-but-succeeded) card render as a **data stall on a `_search`**: `renderStage=waiting-stability`, `cardDocLoadsInFlight=0`, and a `queryLoadsInFlight` entry whose `ageMs` is most of the render's wall-clock. The card is blocked waiting for the realm-server to answer a query-backed `linksTo` / `linksToMany` search (e.g. a `policies` getter). The `boxel_index.diagnostics` blob is the **client's** view — it tells you the host waited N ms on query Q, but nothing about where the realm-server spent that time. The decisive tell: if `pg_stat_activity` shows no SQL running longer than ~1s while the host waited tens of seconds, the wait is realm-server _delivery_, not query execution — and that's invisible without this mode. Mode G is the server-side complement that localizes it. (Also the right mode for "a slow `_federated-search` whose SQL is fast" in general, even outside a timeout.)
+
+**The correlation id.** The prerendered host stamps `x-boxel-logging-correlation-id` on each `_federated-search` fetch it issues — prerender-gated, so live SPA / external traffic never stamps it and never emits these lines. The realm-server reads it back out and keys two lines on `corr=<id>`:
+
+- `realm:search-timing` — the request→response stage breakdown.
+- `realm:requests` `-->` — the total round-trip `dur=` (includes body read + send, i.e. the outer bound).
+
+It is **not** persisted in `boxel_index.diagnostics` (that's the client side). So bridge a stuck card to its server lines by **job + time window + the query** in `queryLoadsInFlight[].query`, then use `corr=` to tie the server's own lines together once you've found the request.
+
+**The lines.**
+
+```
+corr=<id> job=<jobId> handler=Nms parse=… resolveRealms=… sql=… loadLinks=… populate=… stringify=… coalescedWait=… | results=… cacheHit=… cacheMiss=…    (realm:search-timing)
+--> QUERY <accept> <url>: 200 [job: <jobId>] corr=<id> dur=Nms                                                                                            (realm:requests)
+eventLoopLagMs(mean/p99/max)=…/…/… inFlightSearch=… heapMB=…                                                                                              (realm:health)
+```
+
+Stage meanings (wall-clock ms, accumulated across the request):
+
+- `parse` — request body → Query parse.
+- `resolveRealms` — federated realm resolution / lazy-mount.
+- `sql` — the `IndexQueryEngine.searchCards` query (the actual SQL).
+- `loadLinks` — the post-SQL relationship-assembly pass over the result set.
+- `populate` — within loadLinks, the per-instance query-field assembly (definition lookup + field-tree walk).
+- `cacheRead` / `cacheWrite` + `cacheHit` / `cacheMiss` — the per-instance wire-format cache (`job_scoped_instance_cache`) round-trips.
+- `stringify` — `JSON.stringify` of the response wire-format.
+- `coalescedWait` — this request coalesced onto an already-in-flight identical search (CS-11121 dedup) and waited for it; the real sql/loadLinks work is on the **leader's** line, not this one.
+- `handler=` — handler entry → response assembled (≈ the sum of the stages above).
+
+**Reading it — the decision tree.**
+
+1. **`sql=` is the bulk of `handler`** → a genuinely slow query. Rare here (the premise is fast SQL); confirm with `pg_stat_activity` / `EXPLAIN`. Fast SQL but large `sql=` means lock / connection-pool wait inside the query call.
+2. **`loadLinks` / `populate` dominate** → the post-SQL relationship/query-field assembly is the cost (the per-instance wire-format work). Check `cacheHit` / `cacheMiss`: a low hit rate means the instance cache isn't helping (e.g. unique-per-card queries).
+3. **`stringify` dominates** → serializing a large federated response. Look at `results=` for a fat result set.
+4. **`dur` (realm:requests) ≫ `handler` (realm:search-timing)** → the time is NOT inside the handler. It was spent **queued before the handler ran** (or sending). This is the saturation fingerprint: cross-reference `realm:health` near the same timestamp — if `eventLoopLagMs` spiked into the hundreds/thousands with `inFlightSearch` high, the single-threaded realm-server's event loop was starved (synchronous post-SQL serialization across many concurrent searches), so the request sat unserviced even though, once it ran, the handler was fast. That is the CS-10820 saturation class seen from the server side.
+5. **`coalescedWait` dominates** → this follower waited on another in-flight identical search. Find the leader (same job + query, overlapping time); its line carries the real breakdown.
+
+**Getting the logs.** These emit from the **realm-server** process (`handle-search` → `searchRealms`). Reach them with the `tail-logs` skill (Loki, realm-server family) or, for staging/prod CloudWatch, the `aws-access` skill:
+
+```sh
+# CloudWatch (staging), via an aws-access session.
+# All search-timing lines for the run (corr ids + stage breakdowns):
+aws --profile claude-staging logs filter-log-events \
+  --log-group-name ecs-boxel-realm-server-staging \
+  --filter-pattern 'handler=' --start-time <epoch-ms> \
+  --query 'events[*].message' --output text
+
+# Event-loop saturation windows during the same run:
+aws --profile claude-staging logs filter-log-events \
+  --log-group-name ecs-boxel-realm-server-staging \
+  --filter-pattern 'eventLoopLagMs' --start-time <epoch-ms> \
+  --query 'events[*].message' --output text
+```
+
+The boxel logger does **not** print the namespace, so the on-disk line is the bare `corr=… handler=…` / `eventLoopLagMs=…` text — grep the _content_ (`corr=`, `handler=`, `eventLoopLagMs`, `dur=`), not a `realm:search-timing` prefix. `LOG_LEVELS` unset resolves to `*=info`, so these emit by default.
+
+### What Mode G can't tell you
+
+- It only fires for **prerender / indexer** traffic — the correlation id is prerender-gated. A slow `_search` from a live SPA or external API caller emits nothing, by design, to keep normal traffic silent.
+- The correlation id isn't in `boxel_index.diagnostics`, so there's no SQL join from a stuck card row to its server line; bridge by job + time + query as above.
+- `realm:health` is sampled and emitted only during saturation windows (lag over threshold OR a search in flight). A quiet period legitimately produces no line — silence means "not saturated," not "no data."
 
 ## Field-by-field reading
 

--- a/packages/host/app/lib/prerender-fetch-headers.ts
+++ b/packages/host/app/lib/prerender-fetch-headers.ts
@@ -2,7 +2,7 @@ import {
   DURING_PRERENDER_HEADER,
   X_BOXEL_CONSUMING_REALM_HEADER,
   X_BOXEL_JOB_ID_HEADER,
-  X_BOXEL_REQUEST_ID_HEADER,
+  X_BOXEL_LOGGING_CORRELATION_ID_HEADER,
 } from '@cardstack/runtime-common';
 
 // Set by the prerender server's `evaluateOnNewDocument` before the
@@ -50,19 +50,19 @@ export function jobIdHeader(): Record<string, string> {
 
 // Per-search correlation id. Minted fresh for each `_federated-search`
 // fetch the SPA issues while rendering inside a prerender tab, and stamped
-// as `x-boxel-request-id`. The realm-server reads it back out and keys its
+// as `x-boxel-logging-correlation-id`. The realm-server reads it back out and keys its
 // `realm:search-timing` line on it, so a search the prerender observes as
 // slow (surfaced in its `queryLoadsInFlight` diagnostics) can be joined to
 // the realm-server's stage-by-stage view of the same request. Gated on the
 // prerender context — exactly like the job-id / consuming-realm headers —
 // so live SPA traffic is unaffected and emits no server-side timing line.
-export function requestIdHeader(): Record<string, string> {
+export function loggingCorrelationIdHeader(): Record<string, string> {
   let flag = (globalThis as unknown as { __boxelRenderContext?: boolean })
     .__boxelRenderContext;
   if (flag !== true) {
     return {};
   }
-  return { [X_BOXEL_REQUEST_ID_HEADER]: newCorrelationId() };
+  return { [X_BOXEL_LOGGING_CORRELATION_ID_HEADER]: newCorrelationId() };
 }
 
 function newCorrelationId(): string {

--- a/packages/host/app/lib/prerender-fetch-headers.ts
+++ b/packages/host/app/lib/prerender-fetch-headers.ts
@@ -2,6 +2,7 @@ import {
   DURING_PRERENDER_HEADER,
   X_BOXEL_CONSUMING_REALM_HEADER,
   X_BOXEL_JOB_ID_HEADER,
+  X_BOXEL_REQUEST_ID_HEADER,
 } from '@cardstack/runtime-common';
 
 // Set by the prerender server's `evaluateOnNewDocument` before the
@@ -45,4 +46,34 @@ export function consumingRealmHeader(): Record<string, string> {
 export function jobIdHeader(): Record<string, string> {
   let j = (globalThis as unknown as { __boxelJobId?: string }).__boxelJobId;
   return j ? { [X_BOXEL_JOB_ID_HEADER]: j } : {};
+}
+
+// Per-search correlation id. Minted fresh for each `_federated-search`
+// fetch the SPA issues while rendering inside a prerender tab, and stamped
+// as `x-boxel-request-id`. The realm-server reads it back out and keys its
+// `realm:search-timing` line on it, so a search the prerender observes as
+// slow (surfaced in its `queryLoadsInFlight` diagnostics) can be joined to
+// the realm-server's stage-by-stage view of the same request. Gated on the
+// prerender context — exactly like the job-id / consuming-realm headers —
+// so live SPA traffic is unaffected and emits no server-side timing line.
+export function requestIdHeader(): Record<string, string> {
+  let flag = (globalThis as unknown as { __boxelRenderContext?: boolean })
+    .__boxelRenderContext;
+  if (flag !== true) {
+    return {};
+  }
+  return { [X_BOXEL_REQUEST_ID_HEADER]: newCorrelationId() };
+}
+
+function newCorrelationId(): string {
+  let c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c?.randomUUID) {
+    return c.randomUUID();
+  }
+  // Fallback for the rare environment without `crypto.randomUUID` — the id
+  // only needs to disambiguate concurrent searches in a log line, not be
+  // cryptographically strong.
+  return `r-${Date.now().toString(36)}-${Math.floor(
+    Math.random() * 1e9,
+  ).toString(36)}`;
 }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -89,7 +89,7 @@ import {
   consumingRealmHeader,
   duringPrerenderHeaders,
   jobIdHeader,
-  requestIdHeader,
+  loggingCorrelationIdHeader,
 } from '../lib/prerender-fetch-headers';
 import { searchCacheKey } from '../lib/search-cache-key';
 import { searchInFlightKey } from '../lib/search-in-flight-key';
@@ -1154,7 +1154,7 @@ export default class StoreService extends Service implements StoreInterface {
           ...consumingRealmHeader(),
           ...jobIdHeader(),
           ...jobPriorityHeader(),
-          ...requestIdHeader(),
+          ...loggingCorrelationIdHeader(),
         },
         body: JSON.stringify({ ...query, realms }),
       },

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -89,6 +89,7 @@ import {
   consumingRealmHeader,
   duringPrerenderHeaders,
   jobIdHeader,
+  requestIdHeader,
 } from '../lib/prerender-fetch-headers';
 import { searchCacheKey } from '../lib/search-cache-key';
 import { searchInFlightKey } from '../lib/search-in-flight-key';
@@ -1153,6 +1154,7 @@ export default class StoreService extends Service implements StoreInterface {
           ...consumingRealmHeader(),
           ...jobIdHeader(),
           ...jobPriorityHeader(),
+          ...requestIdHeader(),
         },
         body: JSON.stringify({ ...query, realms }),
       },

--- a/packages/host/tests/helpers/realm-server-mock/routes.ts
+++ b/packages/host/tests/helpers/realm-server-mock/routes.ts
@@ -7,11 +7,11 @@ import {
   parseSearchQueryFromPayload,
   parseSearchRequestPayload,
   SearchRequestError,
-  sanitizeRequestId,
+  sanitizeLoggingCorrelationId,
   searchPrerenderedRealms,
   searchRealms,
   SupportedMimeType,
-  X_BOXEL_REQUEST_ID_HEADER,
+  X_BOXEL_LOGGING_CORRELATION_ID_HEADER,
   type RealmInfo,
   type Query,
 } from '@cardstack/runtime-common';
@@ -124,13 +124,13 @@ function registerSearchRoutes() {
       // correlation id off the request and thread it into searchRealms, so
       // the real `realm:search-timing` line is emitted (and observable by
       // host integration tests) keyed by the id the client minted.
-      let requestId = sanitizeRequestId(
-        req.headers.get(X_BOXEL_REQUEST_ID_HEADER),
+      let loggingCorrelationId = sanitizeLoggingCorrelationId(
+        req.headers.get(X_BOXEL_LOGGING_CORRELATION_ID_HEADER),
       );
       let combined = await searchRealms(
         realmList.map((realmURL) => getSearchableRealmForURL(realmURL)),
         cardsQuery,
-        requestId ? { requestId } : undefined,
+        loggingCorrelationId ? { loggingCorrelationId } : undefined,
       );
 
       return new Response(JSON.stringify(combined), {

--- a/packages/host/tests/helpers/realm-server-mock/routes.ts
+++ b/packages/host/tests/helpers/realm-server-mock/routes.ts
@@ -7,9 +7,11 @@ import {
   parseSearchQueryFromPayload,
   parseSearchRequestPayload,
   SearchRequestError,
+  sanitizeRequestId,
   searchPrerenderedRealms,
   searchRealms,
   SupportedMimeType,
+  X_BOXEL_REQUEST_ID_HEADER,
   type RealmInfo,
   type Query,
 } from '@cardstack/runtime-common';
@@ -118,9 +120,17 @@ function registerSearchRoutes() {
         throw e;
       }
 
+      // Mirror the realm-server's `handle-search`: read the client's
+      // correlation id off the request and thread it into searchRealms, so
+      // the real `realm:search-timing` line is emitted (and observable by
+      // host integration tests) keyed by the id the client minted.
+      let requestId = sanitizeRequestId(
+        req.headers.get(X_BOXEL_REQUEST_ID_HEADER),
+      );
       let combined = await searchRealms(
         realmList.map((realmURL) => getSearchableRealmForURL(realmURL)),
         cardsQuery,
+        requestId ? { requestId } : undefined,
       );
 
       return new Response(JSON.stringify(combined), {

--- a/packages/host/tests/integration/search-correlation-id-test.gts
+++ b/packages/host/tests/integration/search-correlation-id-test.gts
@@ -8,7 +8,7 @@ import {
   baseRealm,
   rri,
   setSearchTimingSinkForTests,
-  X_BOXEL_REQUEST_ID_HEADER,
+  X_BOXEL_LOGGING_CORRELATION_ID_HEADER,
 } from '@cardstack/runtime-common';
 import type { Loader } from '@cardstack/runtime-common/loader';
 import type { Query } from '@cardstack/runtime-common/query';
@@ -26,14 +26,14 @@ import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupRenderingTest } from '../helpers/setup';
 
 // End-to-end coverage for the search correlation id: the in-realm browser
-// (the prerendered host SPA) mints `x-boxel-request-id` on its
+// (the prerendered host SPA) mints `x-boxel-logging-correlation-id` on its
 // `_federated-search` fetch, and the realm-server's search path emits a
 // `realm:search-timing` line keyed by that same id. This proves the id
 // threads all the way from the client that originated it through to the
 // server log a triage would join against.
 //
 // The host test exercises the *real* code on both ends: the SPA's
-// `requestIdHeader()` stamps the header, and the realm-server-mock hands it
+// `loggingCorrelationIdHeader()` stamps the header, and the realm-server-mock hands it
 // to the real `searchRealms`, which emits the line. Only the prerender
 // context flag is simulated (the host normally sets it inside a prerender
 // tab).
@@ -108,7 +108,7 @@ module('Integration | search correlation id', function (hooks) {
     let sentRequestIds: string[] = [];
     let spy = async (request: Request) => {
       if (new URL(request.url).pathname.endsWith('/_federated-search')) {
-        let id = request.headers.get(X_BOXEL_REQUEST_ID_HEADER);
+        let id = request.headers.get(X_BOXEL_LOGGING_CORRELATION_ID_HEADER);
         if (id) {
           sentRequestIds.push(id);
         }
@@ -139,7 +139,9 @@ module('Integration | search correlation id', function (hooks) {
       `client-minted correlation id looks well-formed (${sentId})`,
     );
 
-    let matching = timingLines.filter((line) => line.includes(`req=${sentId}`));
+    let matching = timingLines.filter((line) =>
+      line.includes(`corr=${sentId}`),
+    );
     assert.strictEqual(
       matching.length,
       1,
@@ -168,7 +170,7 @@ module('Integration | search correlation id', function (hooks) {
     let spy = async (request: Request) => {
       if (
         new URL(request.url).pathname.endsWith('/_federated-search') &&
-        request.headers.get(X_BOXEL_REQUEST_ID_HEADER)
+        request.headers.get(X_BOXEL_LOGGING_CORRELATION_ID_HEADER)
       ) {
         sawHeader = true;
       }
@@ -184,7 +186,7 @@ module('Integration | search correlation id', function (hooks) {
     assert.strictEqual(results.length, 2, 'the search still returns results');
     assert.false(
       sawHeader,
-      'live (non-prerender) traffic sends no x-boxel-request-id header',
+      'live (non-prerender) traffic sends no x-boxel-logging-correlation-id header',
     );
     assert.strictEqual(
       timingLines.length,

--- a/packages/host/tests/integration/search-correlation-id-test.gts
+++ b/packages/host/tests/integration/search-correlation-id-test.gts
@@ -1,0 +1,195 @@
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { settled } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  rri,
+  setSearchTimingSinkForTests,
+  X_BOXEL_REQUEST_ID_HEADER,
+} from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+import type { Query } from '@cardstack/runtime-common/query';
+
+import type NetworkService from '@cardstack/host/services/network';
+import type StoreService from '@cardstack/host/services/store';
+
+import {
+  testRealmURL,
+  setupCardLogs,
+  setupLocalIndexing,
+  setupIntegrationTestRealm,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupRenderingTest } from '../helpers/setup';
+
+// End-to-end coverage for the search correlation id: the in-realm browser
+// (the prerendered host SPA) mints `x-boxel-request-id` on its
+// `_federated-search` fetch, and the realm-server's search path emits a
+// `realm:search-timing` line keyed by that same id. This proves the id
+// threads all the way from the client that originated it through to the
+// server log a triage would join against.
+//
+// The host test exercises the *real* code on both ends: the SPA's
+// `requestIdHeader()` stamps the header, and the realm-server-mock hands it
+// to the real `searchRealms`, which emits the line. Only the prerender
+// context flag is simulated (the host normally sets it inside a prerender
+// tab).
+
+const personModule = `
+  import { contains, field, CardDef } from 'https://cardstack.com/base/card-api';
+  import StringField from 'https://cardstack.com/base/string';
+
+  export class Person extends CardDef {
+    static displayName = 'Person';
+    @field name = contains(StringField);
+  }
+`;
+
+let loader: Loader;
+
+module('Integration | search correlation id', function (hooks) {
+  setupRenderingTest(hooks);
+  setupLocalIndexing(hooks);
+  let mockMatrixUtils = setupMockMatrix(hooks);
+
+  hooks.beforeEach(function (this: RenderingTestContext) {
+    loader = getService('loader-service').loader;
+  });
+
+  setupCardLogs(
+    hooks,
+    async () => await loader.import(`${baseRealm.url}card-api`),
+  );
+
+  hooks.beforeEach(async function () {
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'person.gts': personModule,
+        'person-1.json': {
+          data: {
+            attributes: { name: 'Alice' },
+            meta: { adoptsFrom: { module: './person', name: 'Person' } },
+          },
+        },
+        'person-2.json': {
+          data: {
+            attributes: { name: 'Bob' },
+            meta: { adoptsFrom: { module: './person', name: 'Person' } },
+          },
+        },
+      },
+    });
+  });
+
+  // Restore globals + sink between tests so a failure can't leak into the
+  // next test or the rest of the suite.
+  hooks.afterEach(function () {
+    delete (globalThis as Record<string, unknown>).__boxelRenderContext;
+    setSearchTimingSinkForTests(undefined);
+  });
+
+  const personQuery: Query = {
+    filter: { type: { module: rri(`${testRealmURL}person`), name: 'Person' } },
+  };
+
+  test('a client-issued search threads its correlation id into the server timing log', async function (assert) {
+    let store = getService('store') as StoreService;
+    let network = getService('network') as NetworkService;
+
+    // Capture the realm-server's `realm:search-timing` emissions.
+    let timingLines: string[] = [];
+    setSearchTimingSinkForTests((line) => timingLines.push(line));
+
+    // Capture the correlation id the client actually puts on the wire.
+    let sentRequestIds: string[] = [];
+    let spy = async (request: Request) => {
+      if (new URL(request.url).pathname.endsWith('/_federated-search')) {
+        let id = request.headers.get(X_BOXEL_REQUEST_ID_HEADER);
+        if (id) {
+          sentRequestIds.push(id);
+        }
+      }
+      // Return null to fall through to the realm-server-mock route.
+      return null;
+    };
+    network.virtualNetwork.mount(spy, { prepend: true });
+
+    // Simulate the prerender context, which is what gates the host's
+    // correlation-id stamping (mirrors a card rendering inside a prerender
+    // tab issuing a query-backed search).
+    (globalThis as Record<string, unknown>).__boxelRenderContext = true;
+
+    let results = await store.search(personQuery, [testRealmURL]);
+    await settled();
+
+    assert.strictEqual(results.length, 2, 'the search returned both people');
+
+    assert.strictEqual(
+      sentRequestIds.length,
+      1,
+      'the client stamped exactly one correlation id on its _federated-search fetch',
+    );
+    let sentId = sentRequestIds[0];
+    assert.ok(
+      /^[A-Za-z0-9._:-]{8,}$/.test(sentId),
+      `client-minted correlation id looks well-formed (${sentId})`,
+    );
+
+    let matching = timingLines.filter((line) => line.includes(`req=${sentId}`));
+    assert.strictEqual(
+      matching.length,
+      1,
+      `the server emitted exactly one realm:search-timing line keyed by the client's id (lines: ${JSON.stringify(
+        timingLines,
+      )})`,
+    );
+    assert.ok(
+      /\bsql=\d+\b/.test(matching[0]),
+      `the timing line carries the sql stage (${matching[0]})`,
+    );
+    assert.ok(
+      /\bloadLinks=\d+\b/.test(matching[0]),
+      `the timing line carries the loadLinks stage (${matching[0]})`,
+    );
+  });
+
+  test('a non-prerender search stamps no id and emits no timing line', async function (assert) {
+    let store = getService('store') as StoreService;
+    let network = getService('network') as NetworkService;
+
+    let timingLines: string[] = [];
+    setSearchTimingSinkForTests((line) => timingLines.push(line));
+
+    let sawHeader = false;
+    let spy = async (request: Request) => {
+      if (
+        new URL(request.url).pathname.endsWith('/_federated-search') &&
+        request.headers.get(X_BOXEL_REQUEST_ID_HEADER)
+      ) {
+        sawHeader = true;
+      }
+      return null;
+    };
+    network.virtualNetwork.mount(spy, { prepend: true });
+
+    // No __boxelRenderContext: live SPA traffic must not stamp the header
+    // (so it pays nothing and the server emits no timing line).
+    let results = await store.search(personQuery, [testRealmURL]);
+    await settled();
+
+    assert.strictEqual(results.length, 2, 'the search still returns results');
+    assert.false(
+      sawHeader,
+      'live (non-prerender) traffic sends no x-boxel-request-id header',
+    );
+    assert.strictEqual(
+      timingLines.length,
+      0,
+      'no realm:search-timing line is emitted without a correlation id',
+    );
+  });
+});

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -10,8 +10,8 @@ import {
   sanitizeConsumingRealmHeader,
   SearchRequestError,
   searchRealms,
-  sanitizeRequestId,
-  X_BOXEL_REQUEST_ID_HEADER,
+  sanitizeLoggingCorrelationId,
+  X_BOXEL_LOGGING_CORRELATION_ID_HEADER,
   RequestTimings,
   emitSearchTiming,
 } from '@cardstack/runtime-common';
@@ -47,8 +47,11 @@ export default function handleSearch(opts: {
     // outermost request→response bound (incl. body read + send) is the
     // `realm:requests` middleware's `dur=`, keyed by the same id.
     let handlerStart = Date.now();
-    let requestId = sanitizeRequestId(ctxt.get(X_BOXEL_REQUEST_ID_HEADER));
-    let timings = requestId !== null ? new RequestTimings() : undefined;
+    let loggingCorrelationId = sanitizeLoggingCorrelationId(
+      ctxt.get(X_BOXEL_LOGGING_CORRELATION_ID_HEADER),
+    );
+    let timings =
+      loggingCorrelationId !== null ? new RequestTimings() : undefined;
 
     let { realmList } = getMultiRealmAuthorization(ctxt);
 
@@ -123,7 +126,7 @@ export default function handleSearch(opts: {
     if (prerenderJobId) searchOpts.jobIdentity = prerenderJobId;
     let normalizedSearchOpts =
       Object.keys(searchOpts).length > 0 ? searchOpts : undefined;
-    // `requestId` / `timings` are deliberately kept OUT of `searchOpts`:
+    // `loggingCorrelationId` / `timings` are deliberately kept OUT of `searchOpts`:
     // that object is the job-scoped search cache's key material (see
     // `computeETag` / `getOrPopulate` below), and per-request values would
     // make every key unique and defeat the cache. They only need to reach
@@ -131,10 +134,10 @@ export default function handleSearch(opts: {
     // collector this handler emits), so they ride on the run-time opts and
     // never touch the cache key.
     let runSearchOpts =
-      requestId !== null
+      loggingCorrelationId !== null
         ? {
             ...(normalizedSearchOpts ?? {}),
-            requestId,
+            loggingCorrelationId,
             ...(timings ? { timings } : {}),
           }
         : normalizedSearchOpts;
@@ -168,11 +171,11 @@ export default function handleSearch(opts: {
     // error early returns above, which never reach here). No-op without a
     // correlation id.
     let emitTimeline = () => {
-      if (!timings || requestId === null) {
+      if (!timings || loggingCorrelationId === null) {
         return;
       }
       emitSearchTiming(
-        `req=${requestId}` +
+        `corr=${loggingCorrelationId}` +
           (prerenderJobId ? ` job=${prerenderJobId}` : '') +
           ` handler=${Date.now() - handlerStart}ms ` +
           timings.toLogFragment(),

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -10,6 +10,10 @@ import {
   sanitizeConsumingRealmHeader,
   SearchRequestError,
   searchRealms,
+  sanitizeRequestId,
+  X_BOXEL_REQUEST_ID_HEADER,
+  RequestTimings,
+  emitSearchTiming,
 } from '@cardstack/runtime-common';
 import {
   fetchRequestFromContext,
@@ -36,16 +40,29 @@ export default function handleSearch(opts: {
 }): (ctxt: Koa.Context) => Promise<void> {
   let { reconciler, searchCache } = opts;
   return async function (ctxt: Koa.Context) {
+    // Hoof-to-snout server-side timing for one search: from the moment the
+    // handler is entered through to the response being assembled. Stamped
+    // only when the client supplied a correlation id (prerender traffic);
+    // live / external callers allocate nothing and emit no line. The
+    // outermost request→response bound (incl. body read + send) is the
+    // `realm:requests` middleware's `dur=`, keyed by the same id.
+    let handlerStart = Date.now();
+    let requestId = sanitizeRequestId(ctxt.get(X_BOXEL_REQUEST_ID_HEADER));
+    let timings = requestId !== null ? new RequestTimings() : undefined;
+
     let { realmList } = getMultiRealmAuthorization(ctxt);
 
     let cardsQuery;
     let request = await fetchRequestFromContext(ctxt);
     try {
       let payload = getSearchRequestPayload(ctxt);
-      cardsQuery =
+      let parseQuery = async () =>
         payload !== undefined
           ? parseSearchQueryFromPayload(payload)
           : await parseSearchQueryFromRequest(request);
+      cardsQuery = timings
+        ? await timings.time('parse', parseQuery)
+        : await parseQuery();
     } catch (e) {
       if (e instanceof SearchRequestError) {
         if (e.code === 'invalid-query') {
@@ -106,6 +123,21 @@ export default function handleSearch(opts: {
     if (prerenderJobId) searchOpts.jobIdentity = prerenderJobId;
     let normalizedSearchOpts =
       Object.keys(searchOpts).length > 0 ? searchOpts : undefined;
+    // `requestId` / `timings` are deliberately kept OUT of `searchOpts`:
+    // that object is the job-scoped search cache's key material (see
+    // `computeETag` / `getOrPopulate` below), and per-request values would
+    // make every key unique and defeat the cache. They only need to reach
+    // `searchRealms` (which stamps the SQL + loadLinks stages onto the same
+    // collector this handler emits), so they ride on the run-time opts and
+    // never touch the cache key.
+    let runSearchOpts =
+      requestId !== null
+        ? {
+            ...(normalizedSearchOpts ?? {}),
+            requestId,
+            ...(timings ? { timings } : {}),
+          }
+        : normalizedSearchOpts;
     // `consumingRealm` is read unconditionally — even when the
     // job-scoped search cache is disabled, `resolveRealmsForFederatedRequest`
     // uses it to scope CS-11259's self-mount fast-path. The cache gate
@@ -116,15 +148,34 @@ export default function handleSearch(opts: {
     // Lazy-mount inside runSearch so cache hits (304 / cached body)
     // skip the lazy-mount work entirely.
     let runSearch = async () => {
-      let realmInstances = await resolveRealmsForFederatedRequest(
-        reconciler,
-        realmList,
-        { consumingRealm },
-      );
-      return JSON.stringify(
-        await searchRealms(realmInstances, cardsQuery, normalizedSearchOpts),
-        null,
-        2,
+      let resolveRealms = () =>
+        resolveRealmsForFederatedRequest(reconciler, realmList, {
+          consumingRealm,
+        });
+      let realmInstances = timings
+        ? await timings.time('resolveRealms', resolveRealms)
+        : await resolveRealms();
+      // `searchRealms` stamps `sql` / `loadLinks` / `populate` / cache stages
+      // onto `runSearchOpts.timings`; because the handler passed a collector
+      // it won't emit its own line — this handler emits the complete one.
+      let doc = await searchRealms(realmInstances, cardsQuery, runSearchOpts);
+      let stringify = async () => JSON.stringify(doc, null, 2);
+      return timings ? await timings.time('stringify', stringify) : stringify();
+    };
+
+    // Emit the complete request→response stage breakdown. Called on every
+    // terminal path that produced a response (skipped only on the parse-
+    // error early returns above, which never reach here). No-op without a
+    // correlation id.
+    let emitTimeline = () => {
+      if (!timings || requestId === null) {
+        return;
+      }
+      emitSearchTiming(
+        `req=${requestId}` +
+          (prerenderJobId ? ` job=${prerenderJobId}` : '') +
+          ` handler=${Date.now() - handlerStart}ms ` +
+          timings.toLogFragment(),
       );
     };
 
@@ -181,6 +232,7 @@ export default function handleSearch(opts: {
         if (cached !== undefined) {
           ctxt.status = 304;
           ctxt.set('ETag', expectedEtag);
+          emitTimeline();
           return;
         }
       }
@@ -200,6 +252,7 @@ export default function handleSearch(opts: {
           },
         }),
       );
+      emitTimeline();
       return;
     }
 
@@ -210,5 +263,6 @@ export default function handleSearch(opts: {
         headers: { 'content-type': SupportedMimeType.CardJson },
       }),
     );
+    emitTimeline();
   };
 }

--- a/packages/realm-server/health-sampler.ts
+++ b/packages/realm-server/health-sampler.ts
@@ -1,0 +1,65 @@
+import { monitorEventLoopDelay, type IntervalHistogram } from 'node:perf_hooks';
+import { logger } from '@cardstack/runtime-common';
+import { getSearchInFlight } from './search-inflight';
+
+// Periodically samples the realm-server process's event-loop health and
+// in-flight search count, logging a `realm:health` line whenever there's a
+// saturation signal worth capturing.
+//
+// Why: during a from-scratch index, prerendered cards block in
+// `waiting-stability` on `_search` round-trips that the realm-server is slow
+// to answer — yet the SQL behind them runs in milliseconds. The missing
+// piece is whether the single-threaded realm-server's event loop is starved
+// (by the synchronous, CPU-bound post-SQL JSON serialization across many
+// concurrent searches) so requests sit unserviced. Event-loop lag rising in
+// lockstep with `inFlightSearch` is the fingerprint of exactly that.
+//
+// `monitorEventLoopDelay` measures the delay between when a timer was
+// scheduled and when it actually fired — i.e. how long synchronous work kept
+// the loop from turning. Values are nanoseconds.
+export interface HealthSamplerOptions {
+  // How often to sample + maybe log. Defaults to 5s.
+  intervalMs?: number;
+  // Only log when peak loop lag in the window exceeds this (or a search is
+  // in flight). Keeps the line quiet on an idle/healthy server. Defaults to
+  // 200ms.
+  lagThresholdMs?: number;
+}
+
+export function startHealthSampler(
+  opts: HealthSamplerOptions = {},
+): () => void {
+  let intervalMs = opts.intervalMs ?? 5000;
+  let lagThresholdMs = opts.lagThresholdMs ?? 200;
+  // Created here (not at module load) to avoid racing the circular import
+  // that installs the logger factory; startup calls this well after boot.
+  let log = logger('realm:health');
+  let histogram: IntervalHistogram = monitorEventLoopDelay({ resolution: 20 });
+  histogram.enable();
+
+  let timer = setInterval(() => {
+    let toMs = (ns: number) => (Number.isFinite(ns) ? ns / 1e6 : 0);
+    let maxLagMs = toMs(histogram.max);
+    let meanLagMs = toMs(histogram.mean);
+    let p99LagMs = toMs(histogram.percentile(99));
+    histogram.reset();
+    let inFlightSearch = getSearchInFlight();
+    // Stay silent when the loop is healthy and nothing is in flight — only
+    // the saturation windows are interesting.
+    if (maxLagMs < lagThresholdMs && inFlightSearch === 0) {
+      return;
+    }
+    let heapMB = Math.round(process.memoryUsage().heapUsed / (1024 * 1024));
+    log.info(
+      `eventLoopLagMs(mean/p99/max)=${meanLagMs.toFixed(0)}/${p99LagMs.toFixed(0)}/${maxLagMs.toFixed(0)} ` +
+        `inFlightSearch=${inFlightSearch} heapMB=${heapMB}`,
+    );
+  }, intervalMs);
+  // Don't keep the process alive solely for sampling.
+  timer.unref?.();
+
+  return () => {
+    clearInterval(timer);
+    histogram.disable();
+  };
+}

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -43,6 +43,7 @@ import { ModuleCacheCoordinator } from './lib/module-cache-coordination';
 import { JobsFinishedListener } from './lib/jobs-finished-listener';
 import { JobScopedSearchCache } from './job-scoped-search-cache';
 import { JobScopedInstanceCache } from './job-scoped-instance-cache';
+import { startHealthSampler } from './health-sampler';
 import { resolveFullIndexOnStartup } from './lib/full-index-on-startup';
 import { PUBLISHED_DIRECTORY_NAME } from '@cardstack/runtime-common';
 
@@ -391,6 +392,11 @@ const smokeTestHostApp = async () => {
   // JobsFinishedListener below) and the age-based janitor backstop.
   let instanceCache = new JobScopedInstanceCache(dbAdapter);
   instanceCache.startJanitor();
+  // Periodic event-loop-lag + in-flight-search sampler. Emits a
+  // `realm:health` line only during saturation windows, so a stalled
+  // `_search` can be checked against whether the process's event loop was
+  // starved at the time.
+  let stopHealthSampler = startHealthSampler();
   let reconciler: RealmRegistryReconciler | undefined;
   let fileChangesListener: RealmFileChangesListener | undefined;
   let indexUpdatedListener: RealmIndexUpdatedListener | undefined;
@@ -642,6 +648,7 @@ const smokeTestHostApp = async () => {
     }
     searchCache.stopJanitor();
     instanceCache.stopJanitor();
+    stopHealthSampler();
     httpServer.close(() => {
       (async () => {
         await Promise.all([

--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -4,8 +4,8 @@ import type { ResponseWithNodeStream } from '@cardstack/runtime-common';
 import {
   logger as getLogger,
   webStreamToText,
-  sanitizeRequestId,
-  X_BOXEL_REQUEST_ID_HEADER,
+  sanitizeLoggingCorrelationId,
+  X_BOXEL_LOGGING_CORRELATION_ID_HEADER,
 } from '@cardstack/runtime-common';
 import type Koa from 'koa';
 import mime from 'mime-types';
@@ -173,10 +173,12 @@ export function httpLogging(ctxt: Koa.Context, next: Koa.Next) {
   // joins to the realm-server's view of the same request. The matching
   // `realm:search-timing` line (emitted by `searchRealms`) is keyed by the
   // same value.
-  let requestId = sanitizeRequestId(ctxt.get(X_BOXEL_REQUEST_ID_HEADER));
-  let reqTag = requestId ? ` req=${requestId}` : '';
-  if (requestId) {
-    ctxt.set(X_BOXEL_REQUEST_ID_HEADER, requestId);
+  let loggingCorrelationId = sanitizeLoggingCorrelationId(
+    ctxt.get(X_BOXEL_LOGGING_CORRELATION_ID_HEADER),
+  );
+  let corrTag = loggingCorrelationId ? ` corr=${loggingCorrelationId}` : '';
+  if (loggingCorrelationId) {
+    ctxt.set(X_BOXEL_LOGGING_CORRELATION_ID_HEADER, loggingCorrelationId);
   }
   let startedAt = Date.now();
 
@@ -199,7 +201,7 @@ export function httpLogging(ctxt: Koa.Context, next: Koa.Next) {
   logger.info(
     `<-- ${ctxt.method} ${ctxt.req.headers.accept} ${
       fullRequestURL(ctxt).href
-    }${jobTag}${reqTag}`,
+    }${jobTag}${corrTag}`,
   );
 
   let onSettled = () => {
@@ -209,7 +211,7 @@ export function httpLogging(ctxt: Koa.Context, next: Koa.Next) {
     logger.info(
       `--> ${ctxt.method} ${ctxt.req.headers.accept} ${
         fullRequestURL(ctxt).href
-      }: ${ctxt.status}${jobTag}${reqTag} dur=${Date.now() - startedAt}ms`,
+      }: ${ctxt.status}${jobTag}${corrTag} dur=${Date.now() - startedAt}ms`,
     );
     logger.debug(JSON.stringify(ctxt.req.headers));
   };

--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -4,6 +4,8 @@ import type { ResponseWithNodeStream } from '@cardstack/runtime-common';
 import {
   logger as getLogger,
   webStreamToText,
+  sanitizeRequestId,
+  X_BOXEL_REQUEST_ID_HEADER,
 } from '@cardstack/runtime-common';
 import type Koa from 'koa';
 import mime from 'mime-types';
@@ -18,6 +20,16 @@ import {
   PRERENDER_JOB_ID_HEADER,
   sanitizePrerenderJobId,
 } from '../prerender/prerender-constants';
+import {
+  incrementSearchInFlight,
+  decrementSearchInFlight,
+} from '../search-inflight';
+
+// Matches the realm-server's search endpoints (`/_search`,
+// `/_search-prerendered`, `/_federated-search`,
+// `/_federated-search-prerendered`) so the request middleware can track how
+// many searches are in flight for the health sampler.
+const SEARCH_PATH_PATTERN = /(^|\/)_(federated-)?search(-prerendered)?$/;
 
 const REQUEST_BODY_STATE = 'requestBody';
 
@@ -156,20 +168,58 @@ export function httpLogging(ctxt: Koa.Context, next: Koa.Next) {
   // realm-server lines for an indexing job alongside worker lines.
   let jobId = sanitizePrerenderJobId(ctxt.get(PRERENDER_JOB_ID_HEADER));
   let jobTag = jobId ? ` [job: ${jobId}]` : '';
+  // Correlation id minted by the client; echoed onto both request log
+  // lines (and into the response header) so a client-observed slow search
+  // joins to the realm-server's view of the same request. The matching
+  // `realm:search-timing` line (emitted by `searchRealms`) is keyed by the
+  // same value.
+  let requestId = sanitizeRequestId(ctxt.get(X_BOXEL_REQUEST_ID_HEADER));
+  let reqTag = requestId ? ` req=${requestId}` : '';
+  if (requestId) {
+    ctxt.set(X_BOXEL_REQUEST_ID_HEADER, requestId);
+  }
+  let startedAt = Date.now();
+
+  // Track in-flight search load for the health sampler across the request's
+  // full lifecycle (queue → parse → SQL → serialize → send), which is the
+  // window during which a saturated event loop would leave it unserviced.
+  let isSearch = SEARCH_PATH_PATTERN.test(ctxt.path);
+  let releasedInFlight = false;
+  let releaseInFlight = () => {
+    if (releasedInFlight) {
+      return;
+    }
+    releasedInFlight = true;
+    decrementSearchInFlight();
+  };
+  if (isSearch) {
+    incrementSearchInFlight();
+  }
 
   logger.info(
     `<-- ${ctxt.method} ${ctxt.req.headers.accept} ${
       fullRequestURL(ctxt).href
-    }${jobTag}`,
+    }${jobTag}${reqTag}`,
   );
 
-  ctxt.res.on('finish', () => {
+  let onSettled = () => {
+    if (isSearch) {
+      releaseInFlight();
+    }
     logger.info(
       `--> ${ctxt.method} ${ctxt.req.headers.accept} ${
         fullRequestURL(ctxt).href
-      }: ${ctxt.status}${jobTag}`,
+      }: ${ctxt.status}${jobTag}${reqTag} dur=${Date.now() - startedAt}ms`,
     );
     logger.debug(JSON.stringify(ctxt.req.headers));
+  };
+  // `finish` fires on a fully-sent response; `close` covers a connection
+  // torn down before that (so the in-flight count can't leak on aborts).
+  ctxt.res.on('finish', onSettled);
+  ctxt.res.on('close', () => {
+    if (isSearch) {
+      releaseInFlight();
+    }
   });
   return next();
 }

--- a/packages/realm-server/search-inflight.ts
+++ b/packages/realm-server/search-inflight.ts
@@ -1,0 +1,21 @@
+// Count of `_federated-search` requests the realm-server is currently
+// handling. Incremented at the search handler's entry and decremented when
+// it settles. Read by the health sampler so a spike in concurrent searches
+// can be correlated with event-loop lag — the signature of the realm-server
+// process being saturated while prerenders wait on in-render `_search`
+// round-trips. A plain module-level counter (the realm-server is a single
+// process) kept separate from the sampler so the search handler doesn't pull
+// in `perf_hooks`.
+let inFlight = 0;
+
+export function incrementSearchInFlight(): void {
+  inFlight++;
+}
+
+export function decrementSearchInFlight(): void {
+  inFlight = inFlight > 0 ? inFlight - 1 : 0;
+}
+
+export function getSearchInFlight(): number {
+  return inFlight;
+}

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -728,7 +728,7 @@ export class RealmServer {
         cors({
           origin: '*',
           allowHeaders:
-            'Authorization, Content-Type, If-Match, If-None-Match, X-Requested-With, X-Boxel-Client-Request-Id, X-Boxel-Assume-User, X-HTTP-Method-Override, X-Boxel-Disable-Module-Cache, X-Filename, X-Boxel-During-Prerender, X-Boxel-Consuming-Realm, X-Boxel-Job-Id, X-Boxel-Job-Priority, X-Grafana-Device-Id, X-Grafana-Action',
+            'Authorization, Content-Type, If-Match, If-None-Match, X-Requested-With, X-Boxel-Client-Request-Id, X-Boxel-Assume-User, X-HTTP-Method-Override, X-Boxel-Disable-Module-Cache, X-Filename, X-Boxel-During-Prerender, X-Boxel-Consuming-Realm, X-Boxel-Job-Id, X-Boxel-Job-Priority, X-Boxel-Logging-Correlation-Id, X-Grafana-Device-Id, X-Grafana-Action',
           // Without an explicit expose list, @koa/cors only emits the
           // CORS-safelisted response headers (cache-control, content-*,
           // expires, last-modified, pragma). ETag is not on that list,

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -705,6 +705,7 @@ export * from './resource-types';
 export * from './prerender-headers';
 export * from './query';
 export * from './search-utils';
+export * from './request-timings';
 export * from './prerendered-html-format';
 export * from './query-field-utils';
 export * from './relationship-utils';

--- a/packages/runtime-common/prerender-headers.ts
+++ b/packages/runtime-common/prerender-headers.ts
@@ -93,3 +93,27 @@ export function sanitizeJobPriorityHeader(
   if (!Number.isSafeInteger(n) || n < 0 || n > JOB_PRIORITY_MAX) return null;
   return n;
 }
+
+// Per-search correlation id minted by the host SPA on each
+// `_federated-search` fetch it issues while rendering inside a prerender
+// tab. The realm-server's search path reads it back out and emits a
+// `realm:search-timing` line keyed by it, so a client-observed slow
+// search (visible in the prerender's `queryLoadsInFlight` diagnostics)
+// can be joined to where the realm-server actually spent the time. Lives
+// here so the host SPA can import the header name without depending on
+// the realm-server package.
+export const X_BOXEL_REQUEST_ID_HEADER = 'x-boxel-request-id';
+
+// Sanitize the inbound request-id header. It's echoed into log lines, so
+// admit only a bounded run of URL-safe id characters (covers a UUID and
+// then some) and reject anything with whitespace or control characters
+// that could forge a log line.
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+export function sanitizeRequestId(
+  raw: string | null | undefined,
+): string | null {
+  if (typeof raw !== 'string') return null;
+  let trimmed = raw.trim();
+  if (!trimmed) return null;
+  return REQUEST_ID_PATTERN.test(trimmed) ? trimmed : null;
+}

--- a/packages/runtime-common/prerender-headers.ts
+++ b/packages/runtime-common/prerender-headers.ts
@@ -102,14 +102,15 @@ export function sanitizeJobPriorityHeader(
 // can be joined to where the realm-server actually spent the time. Lives
 // here so the host SPA can import the header name without depending on
 // the realm-server package.
-export const X_BOXEL_REQUEST_ID_HEADER = 'x-boxel-request-id';
+export const X_BOXEL_LOGGING_CORRELATION_ID_HEADER =
+  'x-boxel-logging-correlation-id';
 
 // Sanitize the inbound request-id header. It's echoed into log lines, so
 // admit only a bounded run of URL-safe id characters (covers a UUID and
 // then some) and reject anything with whitespace or control characters
 // that could forge a log line.
 const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
-export function sanitizeRequestId(
+export function sanitizeLoggingCorrelationId(
   raw: string | null | undefined,
 ): string | null {
   if (typeof raw !== 'string') return null;

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -227,10 +227,19 @@ export function searchInFlightKey(
   // values inside query/opts — e.g. a `matches: 'a|b'` string — can never
   // collide with the delimiter and cause unrelated searches to coalesce.
   try {
+    // `timings` is a per-request diagnostic collector, not part of the
+    // result-shaping opts. Exclude it from the key so it can't perturb the
+    // in-flight coalescing — two otherwise-identical searches must still
+    // dedupe even though each carries its own collector.
+    let keyOpts = opts;
+    if (opts && 'timings' in opts) {
+      let { timings: _omitTimings, ...rest } = opts;
+      keyOpts = rest;
+    }
     return JSON.stringify([
       realmURL,
       normalizeQueryForSignature(query),
-      opts ? sortKeysDeep(opts) : null,
+      keyOpts ? sortKeysDeep(keyOpts) : null,
     ]);
   } catch {
     return undefined;
@@ -341,7 +350,15 @@ export class RealmIndexQueryEngine {
     if (key !== undefined) {
       let existing = this.#inFlightSearch.get(key);
       if (existing) {
-        return await existing;
+        // A concurrent identical search is already running; this follower
+        // awaits its result instead of re-running the work. Record that wait
+        // as `coalescedWait` on the follower's own collector so its
+        // `realm:search-timing` line reflects the time spent — otherwise the
+        // follower would show no `sql`/`loadLinks` and look misleadingly
+        // instant exactly under the concurrent search load we're diagnosing.
+        return opts?.timings
+          ? await opts.timings.time('coalescedWait', () => existing)
+          : await existing;
       }
       let pending = this.searchCardsUncoalesced(query, opts).finally(() => {
         // Identity-check before deletion: a concurrent invalidation path

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -35,6 +35,7 @@ import type { Realm } from './realm';
 import type { VirtualNetwork } from './virtual-network';
 import { FILE_META_RESERVED_KEYS } from './realm';
 import { RealmPaths } from './paths';
+import type { RequestTimings } from './request-timings';
 import type {
   RealmResourceIdentifier,
   RealmIdentifier,
@@ -168,6 +169,13 @@ type Options = {
   // for live / external callers, which therefore never read or write the
   // cache.
   jobIdentity?: string;
+  // Per-request wall-clock collector, threaded from `searchRealms` when a
+  // request carries a correlation id. The post-SQL stages here — the SQL
+  // query, the `loadLinks` relationship assembly, and the per-instance
+  // cache reads/writes — stamp their elapsed time on it so the handler can
+  // attribute the request's server-side time across stages. Absent (and so
+  // a no-op) for everything except instrumented `_federated-search` calls.
+  timings?: RequestTimings;
 } & QueryOptions;
 
 type SearchResult = SearchResultDoc | SearchResultError;
@@ -376,11 +384,15 @@ export class RealmIndexQueryEngine {
         meta,
       };
     } else {
-      let { cards, meta } = await this.#indexQueryEngine.searchCards(
-        new URL(this.#realm.url),
-        query,
-        opts,
-      );
+      let runCardSql = () =>
+        this.#indexQueryEngine.searchCards(
+          new URL(this.#realm.url),
+          query,
+          opts,
+        );
+      let { cards, meta } = opts?.timings
+        ? await opts.timings.time('sql', runCardSql)
+        : await runCardSql();
       let cardResources = cards.map((resource) => ({
         ...resource,
         ...{ links: { self: resource.id } },
@@ -408,14 +420,18 @@ export class RealmIndexQueryEngine {
       // Process all root resources together so a single batched DB query
       // resolves their first-level links (1+1 instead of N+M sequential
       // round-trips). See CS-11038.
-      let included = await this.loadLinks(
-        {
-          realmURL: this.realmURL,
-          rootResources: doc.data,
-          omit,
-        },
-        linkOpts,
-      );
+      let runLoadLinks = () =>
+        this.loadLinks(
+          {
+            realmURL: this.realmURL,
+            rootResources: doc.data,
+            omit,
+          },
+          linkOpts,
+        );
+      let included = opts?.timings
+        ? await opts.timings.time('loadLinks', runLoadLinks)
+        : await runLoadLinks();
       if (included.length > 0) {
         doc.included = included;
       }
@@ -1373,14 +1389,18 @@ export class RealmIndexQueryEngine {
               : opts?.linkFields
                 ? { ...opts, linkFields: undefined }
                 : opts;
+            let timings = popOpts?.timings;
             let cacheKey = this.#instanceCacheKey(resource, popOpts);
             if (cacheKey) {
-              let cached = await this.#readCachedRelationships(
-                cacheKey.jobId,
-                cacheKey.url,
-              );
+              let ck = cacheKey;
+              let cached = timings
+                ? await timings.time('cacheRead', () =>
+                    this.#readCachedRelationships(ck.jobId, ck.url),
+                  )
+                : await this.#readCachedRelationships(ck.jobId, ck.url);
               if (cached !== undefined) {
                 recordInstanceCacheEvent(cacheKey.jobId, true);
+                timings?.incr('cacheHit');
                 // Hit: reuse this instance's assembled query-field
                 // relationships from an earlier occurrence in the same job,
                 // skipping the definition lookup + field-tree walk. The
@@ -1396,28 +1416,43 @@ export class RealmIndexQueryEngine {
                 return;
               }
               recordInstanceCacheEvent(cacheKey.jobId, false);
+              timings?.incr('cacheMiss');
             }
             let storedDefs = (
               resource.meta as {
                 queryFieldDefs?: Record<string, QueryFieldMeta>;
               }
             )?.queryFieldDefs;
-            if (popOpts?.cacheOnlyDefinitions && storedDefs) {
-              await this.populateQueryFieldsFromMeta(
-                resource,
-                realmURL,
-                storedDefs,
-                popOpts,
-              );
+            // The relationship/query-field assembly — the definition lookup +
+            // field-tree walk — is the post-SQL "wire-format prep" the timeline
+            // attributes under `populate`.
+            let runPopulate = () =>
+              popOpts?.cacheOnlyDefinitions && storedDefs
+                ? this.populateQueryFieldsFromMeta(
+                    resource,
+                    realmURL,
+                    storedDefs,
+                    popOpts,
+                  )
+                : this.populateQueryFields(resource, realmURL, popOpts);
+            if (timings) {
+              await timings.time('populate', runPopulate);
             } else {
-              await this.populateQueryFields(resource, realmURL, popOpts);
+              await runPopulate();
             }
             if (cacheKey) {
-              await this.#writeCachedRelationships(
-                cacheKey.jobId,
-                cacheKey.url,
-                (resource as { relationships?: unknown }).relationships,
-              );
+              let ck = cacheKey;
+              let writeCache = () =>
+                this.#writeCachedRelationships(
+                  ck.jobId,
+                  ck.url,
+                  (resource as { relationships?: unknown }).relationships,
+                );
+              if (timings) {
+                await timings.time('cacheWrite', writeCache);
+              } else {
+                await writeCache();
+              }
             }
           }),
         );

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -5175,6 +5175,7 @@ export class Realm {
       // `!== undefined` so an explicit priority 0 (system-initiated) survives.
       ...(opts?.priority !== undefined ? { priority: opts.priority } : {}),
       ...(opts?.jobIdentity ? { jobIdentity: opts.jobIdentity } : {}),
+      ...(opts?.timings ? { timings: opts.timings } : {}),
     });
   }
 

--- a/packages/runtime-common/request-timings.ts
+++ b/packages/runtime-common/request-timings.ts
@@ -1,0 +1,64 @@
+// A request-scoped wall-clock collector for the realm-server search path.
+//
+// One instance is created per instrumented `_search` request in
+// `handle-search` and threaded into search opts. Each stage of the
+// server-side pipeline that runs *after* the request is received —
+// the SQL query, the post-SQL `loadLinks` relationship assembly (the
+// per-instance cache reads/writes), and the JSON wire-format
+// serialization — stamps its elapsed time here, so the handler can emit
+// a single line attributing the request's wall-clock across stages.
+//
+// It is deliberately plain (no Node-only APIs) so it can live in
+// runtime-common alongside the search pipeline it instruments. In
+// practice it is only ever instantiated by the realm-server: the host's
+// store fetches search results over HTTP and never runs
+// `RealmIndexQueryEngine`, so in the browser the threaded collector is
+// always `undefined` and every `opts?.timings?.…` call is a no-op.
+export class RequestTimings {
+  #stages = new Map<string, number>();
+  #counters = new Map<string, number>();
+
+  // Time an async stage and accumulate its elapsed ms under `stage`.
+  // Repeated stages (e.g. one `loadLinks` per realm in a federated
+  // search) sum, so the line reports total time in each stage.
+  async time<T>(stage: string, fn: () => Promise<T>): Promise<T> {
+    let start = Date.now();
+    try {
+      return await fn();
+    } finally {
+      this.add(stage, Date.now() - start);
+    }
+  }
+
+  add(stage: string, ms: number): void {
+    this.#stages.set(stage, (this.#stages.get(stage) ?? 0) + ms);
+  }
+
+  // Integer tallies that aren't durations — result counts, per-instance
+  // cache hit/miss counts.
+  incr(counter: string, n = 1): void {
+    this.#counters.set(counter, (this.#counters.get(counter) ?? 0) + n);
+  }
+
+  stages(): Record<string, number> {
+    let out: Record<string, number> = {};
+    for (let [k, v] of this.#stages) {
+      out[k] = Math.round(v);
+    }
+    return out;
+  }
+
+  counters(): Record<string, number> {
+    return Object.fromEntries(this.#counters);
+  }
+
+  // Compact fragment for a single log line, e.g.
+  //   `sql=41 loadLinks=120 stringify=210 | results=312 cacheHit=18 cacheMiss=3`
+  toLogFragment(): string {
+    let stages = [...this.#stages]
+      .map(([k, v]) => `${k}=${Math.round(v)}`)
+      .join(' ');
+    let counters = [...this.#counters].map(([k, v]) => `${k}=${v}`).join(' ');
+    return counters ? `${stages} | ${counters}` : stages;
+  }
+}

--- a/packages/runtime-common/search-utils.ts
+++ b/packages/runtime-common/search-utils.ts
@@ -329,14 +329,14 @@ export type SearchOpts = {
   priority?: number;
   jobIdentity?: string;
   // Correlation id minted by the client (the prerendered host stamps
-  // `x-boxel-request-id` on its `_federated-search` fetch) and read back
+  // `x-boxel-logging-correlation-id` on its `_federated-search` fetch) and read back
   // out by the request handler into opts. When present, `searchRealms`
   // instruments the server-side search pipeline and emits one
   // `realm:search-timing` line keyed by this id, so a client-observed
   // slow search can be joined to where the realm-server spent the time.
-  requestId?: string;
+  loggingCorrelationId?: string;
   // Per-request wall-clock collector. `searchRealms` creates it when a
-  // `requestId` is present and threads it down through `Realm.search` →
+  // `loggingCorrelationId` is present and threads it down through `Realm.search` →
   // `searchCards` → `loadLinks` so each post-SQL stage stamps its
   // elapsed time. Callers never supply this directly.
   timings?: RequestTimings;
@@ -384,9 +384,9 @@ export async function searchRealms(
   // Two callers: the realm-server's `handle-search` threads a collector it
   // owns (so it can emit one complete request→response line itself —
   // `opts.timings` is set, `ownsTimings` is false, we don't emit), and the
-  // host-test realm-server mock calls us with just a `requestId` (we create
+  // host-test realm-server mock calls us with just a `loggingCorrelationId` (we create
   // the collector and emit the line ourselves, which the host test observes).
-  let ownsTimings = Boolean(opts?.requestId) && !opts?.timings;
+  let ownsTimings = Boolean(opts?.loggingCorrelationId) && !opts?.timings;
   let timings =
     opts?.timings ?? (ownsTimings ? new RequestTimings() : undefined);
   let perRealmOpts = ownsTimings && opts ? { ...opts, timings } : opts;
@@ -425,7 +425,7 @@ export async function searchRealms(
   }
   if (ownsTimings && timings) {
     emitSearchTiming(
-      `req=${opts!.requestId}` +
+      `corr=${opts!.loggingCorrelationId}` +
         (opts!.jobIdentity ? ` job=${opts!.jobIdentity}` : '') +
         ` realms=${realmEntries.length}` +
         ` total=${Date.now() - startedAt}ms ` +

--- a/packages/runtime-common/search-utils.ts
+++ b/packages/runtime-common/search-utils.ts
@@ -1,6 +1,8 @@
 import type { RealmResourceIdentifier } from './card-reference-resolver';
+import { logger } from './log';
 import { ensureTrailingSlash } from './paths';
 import { assertQuery, InvalidQueryError, type Query } from './query';
+import { RequestTimings } from './request-timings';
 import {
   isValidPrerenderedHtmlFormat,
   PRERENDERED_HTML_FORMATS,
@@ -326,6 +328,18 @@ export type SearchOpts = {
   omitIncluded?: boolean;
   priority?: number;
   jobIdentity?: string;
+  // Correlation id minted by the client (the prerendered host stamps
+  // `x-boxel-request-id` on its `_federated-search` fetch) and read back
+  // out by the request handler into opts. When present, `searchRealms`
+  // instruments the server-side search pipeline and emits one
+  // `realm:search-timing` line keyed by this id, so a client-observed
+  // slow search can be joined to where the realm-server spent the time.
+  requestId?: string;
+  // Per-request wall-clock collector. `searchRealms` creates it when a
+  // `requestId` is present and threads it down through `Realm.search` →
+  // `searchCards` → `loadLinks` so each post-SQL stage stamps its
+  // elapsed time. Callers never supply this directly.
+  timings?: RequestTimings;
 };
 
 type SearchableRealm = {
@@ -336,11 +350,47 @@ type SearchableRealm = {
   url?: string;
 };
 
+// Indirection so a host integration test can deterministically capture
+// the emitted timing line: loglevel rebinds a logger's methods on every
+// `setLevel`, so a test that monkeypatches a direct logger handle would
+// race the next `logger('realm:search-timing')` call. A settable sink
+// sidesteps that. Defaults to the `realm:search-timing` logger.
+let searchTimingSink: ((line: string) => void) | undefined;
+let searchTimingLog: ReturnType<typeof logger> | undefined;
+export function setSearchTimingSinkForTests(
+  sink: ((line: string) => void) | undefined,
+): void {
+  searchTimingSink = sink;
+}
+export function emitSearchTiming(line: string): void {
+  if (searchTimingSink) {
+    searchTimingSink(line);
+    return;
+  }
+  // Lazy: a module-load `logger()` call races the circular import that
+  // installs the logger factory. First emission happens well after boot.
+  (searchTimingLog ??= logger('realm:search-timing')).info(line);
+}
+
 export async function searchRealms(
   realms: Array<SearchableRealm | null | undefined>,
   query: Query,
   opts?: SearchOpts,
 ): Promise<LinkableCollectionDocument> {
+  // Instrument only when the caller threaded a correlation id. The
+  // prerendered host stamps one; live SPA / API traffic does not — so
+  // normal traffic allocates no collector and emits no line.
+  //
+  // Two callers: the realm-server's `handle-search` threads a collector it
+  // owns (so it can emit one complete request→response line itself —
+  // `opts.timings` is set, `ownsTimings` is false, we don't emit), and the
+  // host-test realm-server mock calls us with just a `requestId` (we create
+  // the collector and emit the line ourselves, which the host test observes).
+  let ownsTimings = Boolean(opts?.requestId) && !opts?.timings;
+  let timings =
+    opts?.timings ?? (ownsTimings ? new RequestTimings() : undefined);
+  let perRealmOpts = ownsTimings && opts ? { ...opts, timings } : opts;
+  let startedAt = ownsTimings ? Date.now() : 0;
   let realmEntries = realms
     .filter((realm): realm is SearchableRealm => Boolean(realm))
     .map((realm) => ({
@@ -348,7 +398,7 @@ export async function searchRealms(
       label: realm.url ? String(realm.url) : undefined,
     }));
   let searchPromises = realmEntries.map(({ realm }) =>
-    Promise.resolve().then(() => realm.search(query, opts)),
+    Promise.resolve().then(() => realm.search(query, perRealmOpts)),
   );
   let results = await Promise.allSettled(searchPromises);
   let queryLabel = '[unserializable query]';
@@ -369,7 +419,20 @@ export async function searchRealms(
   let docs = results.flatMap((result) =>
     result.status === 'fulfilled' ? [result.value] : [],
   );
-  return combineSearchResults(docs);
+  let combined = combineSearchResults(docs);
+  if (timings) {
+    timings.incr('results', combined.data?.length ?? 0);
+  }
+  if (ownsTimings && timings) {
+    emitSearchTiming(
+      `req=${opts!.requestId}` +
+        (opts!.jobIdentity ? ` job=${opts!.jobIdentity}` : '') +
+        ` realms=${realmEntries.length}` +
+        ` total=${Date.now() - startedAt}ms ` +
+        timings.toLogFragment(),
+    );
+  }
+  return combined;
 }
 
 type PrerenderedSearchableRealm = {


### PR DESCRIPTION
## What this does

Adds server-side timing instrumentation to the realm-server's federated-search path, so we can answer **where** a slow `_search` spends its time — from request receipt to response sent ("hoof to snout") — instead of guessing.

## Why

During a from-scratch index of a query-field-heavy realm, prerendered cards stall in the `waiting-stability` stage for tens of seconds — up to the 90s render timeout — waiting on an in-render `_search` round-trip (a query-backed `linksToMany` getter, e.g. a customer's `policies` field). The card's own `queryLoadsInFlight` diagnostics show the search in flight for ~88s, yet `pg_stat_activity` shows **zero** SQL running longer than a second. So the time is not query execution — the realm-server (a single Node process) is slow to *deliver* the response, and we had no way to see why.

The gap: the host-side `boxel_index.diagnostics` column already captures the *client's* view (`queryLoadsInFlight`/`recentQueryLoads` — that's how we know it waited 88s), but the **server** side of that same request was completely unmetered. The whole pipeline — receipt → SQL → the post-SQL `loadLinks` relationship/query-field assembly → the per-instance cache round-trips → `JSON.stringify` of the wire-format → send — emitted nothing, there was no per-request duration, and nothing linked the client's view to the server's.

## How it fits together

The search request flows: prerendered host SPA issues `_federated-search` → realm-server `handle-search` → `searchRealms` → per-realm `Realm.search` → `RealmIndexQueryEngine.searchCards` → `loadLinks` → SQL. The instrumentation threads a small `RequestTimings` collector down that existing path (via the shared `SearchOpts`, alongside the job-id/priority already threaded there) and emits one line per request.

**The four pieces:**

1. **Correlation id (client → server).** `requestIdHeader()` mints `x-boxel-request-id` on the prerendered host's `_federated-search` fetch, gated on the prerender context exactly like the existing job-id / consuming-realm headers — so live SPA traffic stamps nothing. It's a *join key only*; no new client-side measurement (the client wait is already in the diagnostics column). The realm-server reads it back out and keys its timeline on it.

2. **Request→response timeline.** `handle-search` owns a `RequestTimings` collector (created only when a correlation id is present) and stamps `parse`, `resolveRealms`, and `stringify` directly; `searchRealms`/`searchCards`/`loadLinks` stamp `sql`, `loadLinks`, `populate` (the relationship/query-field assembly), and the per-instance `cacheRead`/`cacheWrite` + hit/miss counts onto the same collector. The handler emits one `realm:search-timing` line: `req=… job=… handler=Nms parse=… resolveRealms=… sql=… loadLinks=… populate=… stringify=… | results=… cacheHit=… cacheMiss=…`. The correlation id is deliberately kept out of the job-scoped search cache's key material so it can't blow up the cache.

3. **Request duration + id in the request log.** The `realm:requests` middleware now logs the `<-- … -->` round-trip `dur=` and the `req=` id — the outermost request→response bound (includes body read + send), and the join key tying the timeline line, the request line, and the client diagnostics together.

4. **Event-loop health sampler.** A periodic `realm:health` line (only during saturation windows) reporting event-loop lag (mean/p99/max) alongside the in-flight `_search` count and heap. This is the signal that confirms or refutes the prime suspect for the 88s — the single-threaded process's event loop being starved (by synchronous post-SQL serialization across many concurrent searches) so requests sit unserviced. The gap between the middleware `dur=` total and the handler's stage sum, read against event-loop lag at the time, localizes queue-before-handler time.

Everything is gated on the presence of a correlation id, so normal/live traffic allocates no collector and emits no extra lines. `RequestTimings` is threaded through runtime-common but only ever *runs* in the realm-server (`RealmIndexQueryEngine` needs the Postgres adapter the browser doesn't have), so the host is unaffected.

## Test

A host integration test exercises the whole path end-to-end through the in-realm browser: the SPA mints the correlation id (real `requestIdHeader()`), issues a real `store.search`, and the test asserts the id lands in the server's `realm:search-timing` line (with the `sql`/`loadLinks` stage breakdown), via the realm-server mock handing the header to the real `searchRealms`. A second case asserts that non-prerender traffic stamps no header and emits no line.

## Scope

Measurement only — this localizes *where* the latency is so we can fix it; it does not change the search behavior or fix the latency itself.

Linear: CS-11363
