### PR TITLE
Skip file-meta operations in listing install

### DIFF
--- a/packages/host/app/commands/listing-install.ts
+++ b/packages/host/app/commands/listing-install.ts
@@ -36,6 +36,35 @@ import type NetworkService from '../services/network';
 
 const log = logger('catalog:install');
 
+export type InstanceOperation = {
+  op: 'add';
+  href: string;
+  data: LooseCardResource;
+};
+
+// file-meta resources are JSON projections of binary files in the source
+// realm. The atomic endpoint only accepts card/source types; binaries continue
+// to resolve cross-realm via the parent card's relationship data.id, so we
+// drop file-meta documents rather than try to copy them.
+export function buildInstanceOperation(
+  doc: unknown,
+  copyInstanceMeta: CopyInstanceMeta,
+  realmIdentifier: string,
+): InstanceOperation | undefined {
+  if (!doc || typeof doc !== 'object' || !('data' in doc)) {
+    throw new Error('We are only expecting single documents returned');
+  }
+  let data = (doc as { data: { type?: string } }).data;
+  if (data?.type === 'file-meta') {
+    return undefined;
+  }
+  delete (doc as any).data.id;
+  delete (doc as any).included;
+  let cardResource = (doc as any).data as LooseCardResource;
+  let href = join(realmIdentifier, copyInstanceMeta.lid) + '.json';
+  return { op: 'add', href, data: cardResource };
+}
+
 export default class ListingInstallCommand extends HostBaseCommand<
   typeof BaseCommandModule.ListingInstallInput,
   typeof BaseCommandModule.ListingInstallResult
@@ -125,19 +154,16 @@ export default class ListingInstallCommand extends HostBaseCommand<
         let { document: doc } = await new FetchCardJsonCommand(
           this.commandContext,
         ).execute({ cardIdentifier: sourceCard.id });
-        if (!doc || !('data' in doc)) {
-          throw new Error('We are only expecting single documents returned');
-        }
-        delete (doc as any).data.id;
-        delete (doc as any).included;
-        let cardResource: LooseCardResource = (doc as any)
-          .data as LooseCardResource;
-        let href = join(realmIdentifier, copyInstanceMeta.lid) + '.json';
-        return { op: 'add' as const, href, data: cardResource };
+        return buildInstanceOperation(doc, copyInstanceMeta, realmIdentifier);
       }),
     );
 
-    const operations = [...sourceOperations, ...instanceOperations];
+    const operations = [
+      ...sourceOperations,
+      ...instanceOperations.filter(
+        (op): op is InstanceOperation => op !== undefined,
+      ),
+    ];
 
     let atomicResults;
     try {

--- a/packages/host/app/commands/listing-install.ts
+++ b/packages/host/app/commands/listing-install.ts
@@ -51,11 +51,17 @@ export function buildInstanceOperation(
   copyInstanceMeta: CopyInstanceMeta,
   realmIdentifier: string,
 ): InstanceOperation | undefined {
-  if (!doc || typeof doc !== 'object' || !('data' in doc)) {
+  if (
+    !doc ||
+    typeof doc !== 'object' ||
+    !('data' in doc) ||
+    !(doc as { data: unknown }).data ||
+    typeof (doc as { data: unknown }).data !== 'object'
+  ) {
     throw new Error('We are only expecting single documents returned');
   }
   let data = (doc as { data: { type?: string } }).data;
-  if (data?.type === 'file-meta') {
+  if (data.type === 'file-meta') {
     return undefined;
   }
   delete (doc as any).data.id;

--- a/packages/host/tests/unit/listing-install-build-operation-test.ts
+++ b/packages/host/tests/unit/listing-install-build-operation-test.ts
@@ -116,4 +116,28 @@ module('Unit | Catalog | listing-install buildInstanceOperation', function () {
       /We are only expecting single documents returned/,
     );
   });
+
+  test('throws when data is null', function (assert) {
+    assert.throws(
+      () =>
+        buildInstanceOperation(
+          { data: null } as unknown,
+          copyMeta('listing-xyz/something'),
+          realmIdentifier,
+        ),
+      /We are only expecting single documents returned/,
+    );
+  });
+
+  test('throws when data is undefined', function (assert) {
+    assert.throws(
+      () =>
+        buildInstanceOperation(
+          { data: undefined } as unknown,
+          copyMeta('listing-xyz/something'),
+          realmIdentifier,
+        ),
+      /We are only expecting single documents returned/,
+    );
+  });
 });

--- a/packages/host/tests/unit/listing-install-build-operation-test.ts
+++ b/packages/host/tests/unit/listing-install-build-operation-test.ts
@@ -1,0 +1,118 @@
+import { module, test } from 'qunit';
+
+import type { CopyInstanceMeta } from '@cardstack/runtime-common/catalog';
+
+import { buildInstanceOperation } from '@cardstack/host/commands/listing-install';
+
+const realmIdentifier = 'https://localhost:4201/experiments/';
+
+function copyMeta(lid: string): CopyInstanceMeta {
+  return {
+    sourceCard: { id: `https://localhost:4201/catalog/${lid}` } as any,
+    lid,
+    targetCodeRef: {
+      module: 'https://localhost:4201/experiments/example',
+      name: 'Example',
+    },
+  };
+}
+
+module('Unit | Catalog | listing-install buildInstanceOperation', function () {
+  test('returns undefined for file-meta documents so they do not reach the atomic batch', function (assert) {
+    let fileMetaDoc = {
+      data: {
+        type: 'file-meta',
+        id: 'https://localhost:4201/catalog/listing/avatar.jpg',
+        attributes: {
+          name: 'avatar.jpg',
+          contentType: 'image/jpeg',
+          contentHash: 'abc123',
+          contentSize: 1024,
+        },
+      },
+    };
+
+    let result = buildInstanceOperation(
+      fileMetaDoc,
+      copyMeta('listing-xyz/avatar.jpg'),
+      realmIdentifier,
+    );
+
+    assert.strictEqual(
+      result,
+      undefined,
+      'file-meta documents are filtered out',
+    );
+  });
+
+  test('returns an add operation for card documents', function (assert) {
+    let cardDoc = {
+      data: {
+        type: 'card',
+        id: 'https://localhost:4201/catalog/listing/Person/alice',
+        attributes: { name: 'Alice' },
+        meta: { adoptsFrom: { module: './person', name: 'Person' } },
+      },
+    };
+
+    let result = buildInstanceOperation(
+      cardDoc,
+      copyMeta('listing-xyz/Person/alice'),
+      realmIdentifier,
+    );
+
+    assert.ok(result, 'card document produces an operation');
+    assert.strictEqual(result!.op, 'add');
+    assert.strictEqual(
+      result!.href,
+      'https://localhost:4201/experiments/listing-xyz/Person/alice.json',
+    );
+    assert.strictEqual(
+      result!.data.type,
+      'card',
+      'data.type is preserved as card',
+    );
+    assert.strictEqual(
+      (result!.data as any).id,
+      undefined,
+      'source id is stripped from the card resource',
+    );
+  });
+
+  test('strips included resources from the card document before producing the operation', function (assert) {
+    let cardDoc = {
+      data: {
+        type: 'card',
+        id: 'https://localhost:4201/catalog/listing/Person/bob',
+        attributes: { name: 'Bob' },
+        meta: { adoptsFrom: { module: './person', name: 'Person' } },
+      },
+      included: [{ type: 'card', id: 'irrelevant' }],
+    };
+
+    let result = buildInstanceOperation(
+      cardDoc,
+      copyMeta('listing-xyz/Person/bob'),
+      realmIdentifier,
+    );
+
+    assert.ok(result);
+    assert.strictEqual(
+      (cardDoc as any).included,
+      undefined,
+      'included is stripped',
+    );
+  });
+
+  test('throws when the document is missing a data property', function (assert) {
+    assert.throws(
+      () =>
+        buildInstanceOperation(
+          {} as unknown,
+          copyMeta('listing-xyz/something'),
+          realmIdentifier,
+        ),
+      /We are only expecting single documents returned/,
+    );
+  });
+});

--- a/packages/host/tests/unit/listing-install-build-operation-test.ts
+++ b/packages/host/tests/unit/listing-install-build-operation-test.ts
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 
+import { rri } from '@cardstack/runtime-common';
 import type { CopyInstanceMeta } from '@cardstack/runtime-common/catalog';
 
 import { buildInstanceOperation } from '@cardstack/host/commands/listing-install';
@@ -11,7 +12,7 @@ function copyMeta(lid: string): CopyInstanceMeta {
     sourceCard: { id: `https://localhost:4201/catalog/${lid}` } as any,
     lid,
     targetCodeRef: {
-      module: 'https://localhost:4201/experiments/example',
+      module: rri('https://localhost:4201/experiments/example'),
       name: 'Example',
     },
   };


### PR DESCRIPTION
## Background and Goal

Remixing a catalog listing whose example cards link to a FileDef-typed binary (avatar, thumbnail, etc.) silently fails. The install command sends a JSON:API atomic batch that includes operations with `data.type: 'file-meta'`, but the atomic handler at `packages/runtime-common/realm.ts:2107-2117` only accepts `card`/`source` resource types and returns 422 for anything else.

The breaking change was the rename of FileDef JSON:API resources from `type: 'card'` to `type: 'file-meta'`. Before the rename, atomic happily accepted the operation and wrote a `.json` sidecar at the binary's `.jpg.json` path — but **no binary bytes were ever copied**. The image still rendered because the parent card's `cardInfo.cardThumbnail.data.id` is an absolute source-catalog URL, so the remixed card linked back cross-realm. The rename didn't break a working feature — it surfaced a long-broken step (the sidecar tax) as a hard 422.

## Fix

Drop documents with `data.type === 'file-meta'` from the install command's per-instance operation builder. Binaries continue to resolve cross-realm via the parent card's relationship `data.id`, which is what was actually working pre-rename minus the no-op sidecar.

The operation-building was also extracted into `buildInstanceOperation` so the filter behavior is directly unit-testable.

## Test plan
- [x] Unit test in `listing-install-build-operation-test.ts` covers the filter behavior (file-meta → undefined, card → operation, malformed → throws)
- [x] Verify a listing with FileDef-linked thumbnails remixes successfully (staging or local with the right fixture)
- [x] Confirm remixed thumbnails still render via cross-realm reference

## Out of scope

- **Surface atomic errors in the UI.** The silent-422 swallow happens upstream of `RemixCommand` and needs its own design (the host's `ErrorDisplayService` is registry-based, not imperative). Filing as a follow-up.
- **Real binary copy + reference rewriting.** True "remix owns its binaries" is a separate feature: it requires moving bytes server-to-server AND rewriting every reference (linksTo `data.id`, hardcoded URLs in `.gts` / templates / CSS / markdown). Out of scope for this bug fix.