### PR TITLE
Standardize dropdown trigger arrow, sizing, and primary focus ring

### DIFF
--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -165,8 +165,12 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
           transparent
         );
       }
+      /* Keyboard focus ring sits just outside the button. Set the full
+         outline shorthand (not just the color) so the ring renders
+         regardless of the UA's default outline-style. */
       .boxel-button:focus-visible {
-        outline-color: var(--ring, var(--boxel-highlight));
+        outline: var(--boxel-outline-width) var(--boxel-outline-style)
+          var(--ring, var(--boxel-highlight));
         outline-offset: 2px;
       }
 
@@ -249,6 +253,11 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
       .kind-primary:not(:disabled):hover,
       .kind-primary:not(:disabled):active {
         --boxel-button-color: var(--primary, var(--boxel-highlight-hover));
+      }
+      /* When the fill darkens, the focus ring darkens to match. */
+      .kind-primary:not(:disabled):focus-visible:hover,
+      .kind-primary:not(:disabled):focus-visible:active {
+        outline-color: var(--ring, var(--boxel-highlight-hover));
       }
 
       .kind-secondary {

--- a/packages/boxel-ui/addon/src/components/selection-menu/index.gts
+++ b/packages/boxel-ui/addon/src/components/selection-menu/index.gts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import type { MenuDivider } from '../../helpers/menu-divider.ts';
 import type { MenuItem } from '../../helpers/menu-item.ts';
-import { DropdownArrowDown } from '../../icons.gts';
+import CaretDown from '../../icons/caret-down.gts';
 import BoxelButton from '../button/index.gts';
 import BoxelDropdown from '../dropdown/index.gts';
 import Menu from '../menu/index.gts';
@@ -66,7 +66,7 @@ export default class SelectionMenu extends Component<Signature> {
           >
             <SelectionCheckmark class='selection-menu-icon' />
             <span class='selection-menu-count'>{{@selectedCount}}</span>
-            <DropdownArrowDown
+            <CaretDown
               class='selection-menu-caret'
               width='13px'
               height='13px'
@@ -102,16 +102,16 @@ export default class SelectionMenu extends Component<Signature> {
         --boxel-button-padding: var(--boxel-sp-5xs) var(--boxel-sp-xs);
         --boxel-button-min-width: 0;
       }
-      /* Keyboard focus ring just outside the button. (Set explicitly so it
-         renders regardless of the global button outline setup.) */
-      .selection-menu-trigger:focus-visible {
-        outline: var(--boxel-outline-width) var(--boxel-outline-style)
-          var(--boxel-highlight);
-        outline-offset: 2px;
-      }
+      /* Focus ring comes from BoxelButton's standard :focus-visible (full
+         outline, 2px outside). */
       /* Deepen the fill while the menu is open, matching Button's hover. */
       .selection-menu-trigger[aria-expanded='true'] {
         --boxel-button-color: var(--boxel-highlight-hover);
+      }
+      /* When open-and-keyboard-focused, darken the ring to match the fill,
+         mirroring Button's hover/active focus behavior. */
+      .selection-menu-trigger[aria-expanded='true']:focus-visible {
+        outline-color: var(--ring, var(--boxel-highlight-hover));
       }
       .selection-menu-icon {
         width: 0.875rem;
@@ -121,6 +121,12 @@ export default class SelectionMenu extends Component<Signature> {
       .selection-menu-count {
         line-height: 1;
         white-space: nowrap;
+        /* Reserve a stable width (and equal-width digits) so the trigger
+           doesn't shift when the count crosses 1↔2 digits, e.g. during a
+           Select All that jumps 9→10. */
+        min-width: 2ch;
+        text-align: center;
+        font-variant-numeric: tabular-nums;
       }
       .selection-menu-caret {
         flex-shrink: 0;

--- a/packages/boxel-ui/addon/src/components/sort-dropdown/index.gts
+++ b/packages/boxel-ui/addon/src/components/sort-dropdown/index.gts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import { MenuDivider } from '../../helpers/menu-divider.ts';
 import { MenuItem } from '../../helpers/menu-item.ts';
-import DropdownIcon from '../../icons/dropdown-arrow-down.gts';
+import CaretDown from '../../icons/caret-down.gts';
 import BoxelButton from '../button/index.gts';
 import BoxelDropdown from '../dropdown/index.gts';
 import BoxelMenu from '../menu/index.gts';
@@ -34,7 +34,7 @@ export default class SortDropdown extends Component<Signature> {
               {{bindings}}
             >
               {{if @selectedOption @selectedOption.displayName 'Please Select'}}
-              <DropdownIcon width='12px' height='12px' />
+              <CaretDown class='sort-button-caret' width='12px' height='12px' />
             </BoxelButton>
           </:trigger>
           <:content as |dd|>
@@ -65,8 +65,15 @@ export default class SortDropdown extends Component<Signature> {
           padding-left: var(--boxel-sp-sm);
           padding-right: var(--boxel-sp-sm);
         }
-        .sort-button > svg {
+        .sort-button-caret {
           margin-left: auto;
+          transition: transform var(--boxel-transition);
+        }
+        /* Flip the caret while the menu is open, matching boxel-ui's
+           select/dropdown triggers. BoxelDropdown sets aria-expanded on the
+           trigger button via the yielded bindings. */
+        .sort-button[aria-expanded='true'] .sort-button-caret {
+          transform: rotate(180deg);
         }
       }
     </style>


### PR DESCRIPTION
Three boxel-ui trigger-polish items from Burcu's review of #5083, scoped to the card-chooser/toolbar triggers (not the unrelated host chrome).

## [CS-11326](https://linear.app/cardstack/issue/CS-11326) — one standard arrow + flip on open
- The sort menu used the filled `DropdownArrowDown` and **never flipped** on open (the regression). boxel-ui's form controls (select, multi-select, picker, dropdown) already use the thin `CaretDown` chevron and flip.
- Switched the `sort-dropdown` and `selection-menu` triggers to `CaretDown`, and the sort button now flips its caret on open via its `aria-expanded` state.
- Scope decision: toolbar triggers only — the ~8 host-chrome `DropdownArrowDown` usages (file tree, submode switcher, realm dropdown, etc.) are intentionally left alone.

## [CS-11327](https://linear.app/cardstack/issue/CS-11327) — trigger doesn't shift when count changes
- The `selection-menu` count now reserves a stable 2-ch, tabular-figure width, so the trigger no longer jumps when the count crosses 1↔2 digits (e.g. a Select All going 9→10).
- Height already matches the adjacent sort button via the shared `--boxel-button-sm` min-height; the old "squished padding" was the pre-rebuild trigger.

## [CS-11328](https://linear.app/cardstack/issue/CS-11328) — primary button focus ring
- Base `BoxelButton:focus-visible` now sets the full outline shorthand (`--boxel-outline-width`/`-style`, i.e. 2px solid) instead of only `outline-color` — previously it relied on the UA default outline-style. Ring sits 2px outside.
- The primary ring darkens to match the fill on hover/active.
- The `selection-menu`'s local focus-ring override is now redundant and removed.
- Note: this `:focus-visible` change is on the shared `BoxelButton`, so every button's keyboard focus ring is now explicitly `2px solid` rather than the browser default — intended (it's the design-system `--boxel-outline`).

## Base branch
Targets `cs-11325-…` (PR #5100, the shared `SelectionMenu`), same as #5102 — keeps this diff scoped. Will rebase onto `main` and retarget once #5100 lands.

## Testing
- eslint + glint clean.
- No existing test asserts on the sort arrow or the button outline; the one `selection-menu` test targets the checkmark's `circle` (the caret has none, so it stays unambiguous).
- Behavioral checks (sort caret flip, focus-ring darkening, count not shifting) pending in-browser verification after a host rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)