### PR TITLE
fix fitted spec template crop

### DIFF
--- a/packages/base/spec.gts
+++ b/packages/base/spec.gts
@@ -767,6 +767,11 @@ class Fitted extends Component<typeof Spec> {
         .spec-fitted {
           align-items: center;
         }
+        @container fitted-card (aspect-ratio <= 1 / 1) and (150px <= width) and (170px <= height <= 250px) {
+          .spec-fitted :deep(.thumbnail-section) {
+            flex: 1;
+          }
+        }
       }
     </style>
   </template>


### PR DESCRIPTION
Before:
<img width="400" height="789" alt="spec-before" src="https://github.com/user-attachments/assets/f782a9a3-2f5e-40e2-9f18-fdd69fb68ee1" />

After:
<img width="367" height="787" alt="spec-after" src="https://github.com/user-attachments/assets/a2a3367a-37b8-4a22-9a7c-9f7899e025ee" />
