### PR TITLE
fix extraneous horizontal scroll caused by sidebar positioning; fix group-by menu item display

### DIFF
--- a/packages/boxel-ui/addon/src/components/kanban/plane-inner.gts
+++ b/packages/boxel-ui/addon/src/components/kanban/plane-inner.gts
@@ -332,6 +332,7 @@ export class KanbanPlaneInner extends Component<{
         height: 100%;
         padding: 0.75rem;
         overflow-x: auto;
+        overflow-y: hidden;
         outline: none;
         background-color: var(--_kanban-bg);
         color: var(--_kanban-fg);
@@ -364,6 +365,7 @@ export class KanbanPlaneInner extends Component<{
       .col-body {
         flex: 1;
         overflow-y: auto;
+        overflow-x: hidden;
         display: flex;
         flex-direction: column;
         gap: var(--_kanban-col-gap);
@@ -435,6 +437,7 @@ export class KanbanPlaneInner extends Component<{
       .hidden-tray-body {
         flex: 1;
         overflow-y: auto;
+        overflow-x: hidden;
         display: flex;
         flex-direction: column;
         gap: 0.25rem;

--- a/packages/software-factory/realm/issue-tracker.gts
+++ b/packages/software-factory/realm/issue-tracker.gts
@@ -319,7 +319,6 @@ class IssueIsolated extends Component<typeof Issue> {
         gap: var(--boxel-sp-xl);
         align-content: start;
         overflow-y: auto;
-        overflow-x: hidden;
       }
       .content-section {
         display: grid;
@@ -1564,12 +1563,11 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
         --boxel-kanban-border: var(--board-border);
 
         height: 100%;
-        overflow-y: auto;
-        overflow-x: hidden;
         display: flex;
         flex-direction: column;
         background-color: var(--board-bg);
         color: var(--board-fg);
+        overflow: hidden;
       }
       .kanban-toolbar {
         display: flex;
@@ -1675,10 +1673,7 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
         border-radius: inherit;
       }
       .kanban-config-sidebar-wrap {
-        position: absolute;
-        right: 0;
-        top: 0;
-        bottom: 0;
+        flex-shrink: 0;
         width: 0;
         overflow: hidden;
         transition: width var(--boxel-transition);
@@ -1686,6 +1681,9 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
       }
       .kanban-config-sidebar-wrap.is-open {
         width: 19rem;
+      }
+      .kanban-config-sidebar-wrap > :deep(aside) {
+        border-top: none;
       }
     </style>
   </template>

--- a/packages/software-factory/realm/issue-tracker.gts
+++ b/packages/software-factory/realm/issue-tracker.gts
@@ -255,6 +255,7 @@ class IssueIsolated extends Component<typeof Issue> {
       .issue-isolated {
         height: 100%;
         overflow-y: auto;
+        overflow-x: hidden;
         display: flex;
         flex-direction: column;
         background: var(--background, var(--boxel-light));
@@ -318,6 +319,7 @@ class IssueIsolated extends Component<typeof Issue> {
         gap: var(--boxel-sp-xl);
         align-content: start;
         overflow-y: auto;
+        overflow-x: hidden;
       }
       .content-section {
         display: grid;
@@ -380,6 +382,7 @@ class IssueIsolated extends Component<typeof Issue> {
         gap: var(--boxel-sp-lg);
         align-content: start;
         overflow-y: auto;
+        overflow-x: hidden;
         height: 100%;
         box-sizing: border-box;
       }
@@ -1562,6 +1565,7 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
 
         height: 100%;
         overflow-y: auto;
+        overflow-x: hidden;
         display: flex;
         flex-direction: column;
         background-color: var(--board-bg);
@@ -1657,6 +1661,7 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
         min-height: 0;
         display: flex;
         overflow: hidden;
+        position: relative;
       }
       .kanban-area {
         flex: 1;
@@ -1670,10 +1675,14 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
         border-radius: inherit;
       }
       .kanban-config-sidebar-wrap {
-        flex-shrink: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+        bottom: 0;
         width: 0;
         overflow: hidden;
         transition: width var(--boxel-transition);
+        z-index: 1;
       }
       .kanban-config-sidebar-wrap.is-open {
         width: 19rem;
@@ -1685,7 +1694,7 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
 // ── IssueTracker ──────────────────────────────────────────────────────
 
 export class IssueTracker extends KanbanBoard {
-  static displayName = 'Issue Tracker Board';
+  static displayName = 'Issue Tracker';
 
   @field project = linksTo(() => Project);
   @field groupBy = contains(GroupByField);

--- a/packages/software-factory/realm/kanban-config.gts
+++ b/packages/software-factory/realm/kanban-config.gts
@@ -148,5 +148,5 @@ export const ProjectStatusField = enumField(StringField, {
 });
 
 export const GroupByField = enumField(StringField, {
-  options: defaultColumns.map(({ key, label }) => ({ key, label })),
+  options: defaultColumns.map(({ key, label }) => ({ key, label, value: key })),
 });


### PR DESCRIPTION
2 bug fixes:
1- Extra horizontal scroll on the kanban board:
<img width="1094" height="872" alt="scroll-bug" src="https://github.com/user-attachments/assets/0645f3c4-57ec-48f9-affa-5caf0f1597f2" />

2- Group-by dropdown menu items were missing the `value` property:
<img width="789" height="211" alt="group-by-bug" src="https://github.com/user-attachments/assets/53f260ba-64c7-4c15-9ac8-56569657f70e" />

<img width="779" height="211" alt="fixed" src="https://github.com/user-attachments/assets/29d5d49b-1d49-4a83-bb95-1d636b662cc8" />
