### PR TITLE
Fix search-timing: record concurrent loadLinks work as busy-time, not wall-clock

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -812,27 +812,32 @@ It is **not** persisted in `boxel_index.diagnostics` (that's the client side). S
 **The lines.**
 
 ```
-corr=<id> job=<jobId> handler=Nms parse=… resolveRealms=… sql=… loadLinks=… populate=… stringify=… coalescedWait=… | results=… cacheHit=… cacheMiss=…    (realm:search-timing)
+corr=<id> job=<jobId> handler=Nms parse=… resolveRealms=… sql=… loadLinks=… stringify=… coalescedWait=… | busyMs(parallel-sum) populate=… cacheRead=… cacheWrite=… | results=… cacheHit=… cacheMiss=…    (realm:search-timing)
 --> QUERY <accept> <url>: 200 [job: <jobId>] corr=<id> dur=Nms                                                                                            (realm:requests)
 eventLoopLagMs(mean/p99/max)=…/…/… inFlightSearch=… heapMB=…                                                                                              (realm:health)
 ```
 
-Stage meanings (wall-clock ms, accumulated across the request):
+The first `|`-section is the **sequential wall-clock timeline** (these sum to ≈ `handler`). The `busyMs(parallel-sum)` section is the inner per-result work that runs **concurrently** inside `loadLinks`'s `Promise.all`, so it is summed across N parallel ops and is **NOT wall-clock** — `populate` can read as millions of ms on a large result set. Read it as a **ratio** (which sub-step dominates within `loadLinks`) or divide by `results` for a per-item average; never add it to the timeline.
+
+Wall-clock timeline stages:
 
 - `parse` — request body → Query parse.
 - `resolveRealms` — federated realm resolution / lazy-mount.
 - `sql` — the `IndexQueryEngine.searchCards` query (the actual SQL).
-- `loadLinks` — the post-SQL relationship-assembly pass over the result set.
-- `populate` — within loadLinks, the per-instance query-field assembly (definition lookup + field-tree walk).
-- `cacheRead` / `cacheWrite` + `cacheHit` / `cacheMiss` — the per-instance wire-format cache (`job_scoped_instance_cache`) round-trips.
+- `loadLinks` — the post-SQL relationship-assembly pass over the whole result set (the wall-clock of the parallel `populate`/cache work below).
 - `stringify` — `JSON.stringify` of the response wire-format.
 - `coalescedWait` — this request coalesced onto an already-in-flight identical search (CS-11121 dedup) and waited for it; the real sql/loadLinks work is on the **leader's** line, not this one.
-- `handler=` — handler entry → response assembled (≈ the sum of the stages above).
+- `handler=` — handler entry → response assembled (≈ the sum of the wall-clock stages).
+
+Busy-time (parallel-sum, NOT wall-clock):
+
+- `populate` — the per-instance query-field assembly (definition lookup + field-tree walk), summed across all results.
+- `cacheRead` / `cacheWrite` (+ `cacheHit` / `cacheMiss` counters) — the per-instance wire-format cache (`job_scoped_instance_cache`) round-trips, summed across all results.
 
 **Reading it — the decision tree.**
 
 1. **`sql=` is the bulk of `handler`** → a genuinely slow query. Rare here (the premise is fast SQL); confirm with `pg_stat_activity` / `EXPLAIN`. Fast SQL but large `sql=` means lock / connection-pool wait inside the query call.
-2. **`loadLinks` / `populate` dominate** → the post-SQL relationship/query-field assembly is the cost (the per-instance wire-format work). Check `cacheHit` / `cacheMiss`: a low hit rate means the instance cache isn't helping (e.g. unique-per-card queries).
+2. **`loadLinks` dominates `handler`** → the post-SQL relationship/query-field assembly is the cost (the per-instance wire-format work). Use the `busyMs(parallel-sum)` ratio to see what _inside_ loadLinks dominates: `populate ≫ cacheRead/cacheWrite` means it's the CPU field-walk, not the cache DB round-trips. Check `cacheHit` / `cacheMiss`: a low hit rate means the instance cache isn't helping (e.g. unique-per-card queries) so every result is assembled from scratch.
 3. **`stringify` dominates** → serializing a large federated response. Look at `results=` for a fat result set.
 4. **`dur` (realm:requests) ≫ `handler` (realm:search-timing)** → the time is NOT inside the handler. It was spent **queued before the handler ran** (or sending). This is the saturation fingerprint: cross-reference `realm:health` near the same timestamp — if `eventLoopLagMs` spiked into the hundreds/thousands with `inFlightSearch` high, the single-threaded realm-server's event loop was starved (synchronous post-SQL serialization across many concurrent searches), so the request sat unserviced even though, once it ran, the handler was fast. That is the CS-10820 saturation class seen from the server side.
 5. **`coalescedWait` dominates** → this follower waited on another in-flight identical search. Find the leader (same job + query, overlapping time); its line carries the real breakdown.

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -1432,8 +1432,12 @@ export class RealmIndexQueryEngine {
             let cacheKey = this.#instanceCacheKey(resource, popOpts);
             if (cacheKey) {
               let ck = cacheKey;
+              // `busyTime`, not `time`: this callback is one of N running
+              // concurrently in the layer's `Promise.all`, so summing each
+              // op's elapsed would overcount wall-clock. Recorded as
+              // aggregate busy-time instead (see RequestTimings).
               let cached = timings
-                ? await timings.time('cacheRead', () =>
+                ? await timings.busyTime('cacheRead', () =>
                     this.#readCachedRelationships(ck.jobId, ck.url),
                   )
                 : await this.#readCachedRelationships(ck.jobId, ck.url);
@@ -1464,7 +1468,9 @@ export class RealmIndexQueryEngine {
             )?.queryFieldDefs;
             // The relationship/query-field assembly — the definition lookup +
             // field-tree walk — is the post-SQL "wire-format prep" the timeline
-            // attributes under `populate`.
+            // attributes under `populate`. Recorded as busy-time (this runs
+            // concurrently across the layer); the wall-clock of the whole pass
+            // is the outer `loadLinks` stage.
             let runPopulate = () =>
               popOpts?.cacheOnlyDefinitions && storedDefs
                 ? this.populateQueryFieldsFromMeta(
@@ -1475,7 +1481,7 @@ export class RealmIndexQueryEngine {
                   )
                 : this.populateQueryFields(resource, realmURL, popOpts);
             if (timings) {
-              await timings.time('populate', runPopulate);
+              await timings.busyTime('populate', runPopulate);
             } else {
               await runPopulate();
             }
@@ -1488,7 +1494,7 @@ export class RealmIndexQueryEngine {
                   (resource as { relationships?: unknown }).relationships,
                 );
               if (timings) {
-                await timings.time('cacheWrite', writeCache);
+                await timings.busyTime('cacheWrite', writeCache);
               } else {
                 await writeCache();
               }

--- a/packages/runtime-common/request-timings.ts
+++ b/packages/runtime-common/request-timings.ts
@@ -1,26 +1,39 @@
 // A request-scoped wall-clock collector for the realm-server search path.
 //
 // One instance is created per instrumented `_search` request in
-// `handle-search` and threaded into search opts. Each stage of the
-// server-side pipeline that runs *after* the request is received —
-// the SQL query, the post-SQL `loadLinks` relationship assembly (the
-// per-instance cache reads/writes), and the JSON wire-format
-// serialization — stamps its elapsed time here, so the handler can emit
-// a single line attributing the request's wall-clock across stages.
+// `handle-search` and threaded into search opts. Each *sequential* stage of
+// the server-side pipeline that runs after the request is received — the SQL
+// query, the post-SQL `loadLinks` relationship assembly, the JSON wire-format
+// serialization — stamps its elapsed time via `time()`, so the handler can
+// emit a single line attributing the request's wall-clock across stages.
 //
-// It is deliberately plain (no Node-only APIs) so it can live in
-// runtime-common alongside the search pipeline it instruments. In
-// practice it is only ever instantiated by the realm-server: the host's
-// store fetches search results over HTTP and never runs
-// `RealmIndexQueryEngine`, so in the browser the threaded collector is
-// always `undefined` and every `opts?.timings?.…` call is a no-op.
+// Work that runs CONCURRENTLY (the per-result populate + per-instance cache
+// round-trips inside `loadLinks`'s `Promise.all`) is recorded separately via
+// `busyTime()`: summing each concurrent op's elapsed time overcounts
+// wall-clock (N parallel ops summed ≫ the wall-clock window they ran in), so
+// mixing it into the sequential `stages` would make the timeline lie. It's
+// kept in its own bucket and rendered with an explicit `busyMs(parallel-sum)`
+// label — read it as a ratio (which sub-step dominates) or divide by the
+// relevant count for a per-item average, never as wall-clock.
+//
+// Deliberately plain (no Node-only APIs) so it can live in runtime-common
+// alongside the search pipeline it instruments. In practice it is only ever
+// instantiated by the realm-server: the host's store fetches search results
+// over HTTP and never runs `RealmIndexQueryEngine`, so in the browser the
+// threaded collector is always `undefined` and every `opts?.timings?.…` call
+// is a no-op.
 export class RequestTimings {
+  // Sequential wall-clock stages. Adding these up approximates `handler`.
   #stages = new Map<string, number>();
+  // Aggregate busy-time for concurrent work — summed across parallel ops, so
+  // NOT wall-clock. Kept apart from `#stages` so it never inflates the
+  // timeline. See the class comment.
+  #busy = new Map<string, number>();
   #counters = new Map<string, number>();
 
-  // Time an async stage and accumulate its elapsed ms under `stage`.
-  // Repeated stages (e.g. one `loadLinks` per realm in a federated
-  // search) sum, so the line reports total time in each stage.
+  // Time a SEQUENTIAL stage and accumulate its elapsed ms under `stage`.
+  // Repeated stages (e.g. one `loadLinks` per realm in a federated search)
+  // sum, which is still wall-clock because those run in sequence.
   async time<T>(stage: string, fn: () => Promise<T>): Promise<T> {
     let start = Date.now();
     try {
@@ -34,6 +47,22 @@ export class RequestTimings {
     this.#stages.set(stage, (this.#stages.get(stage) ?? 0) + ms);
   }
 
+  // Time CONCURRENT work — accumulates into the separate busy bucket. Use for
+  // ops launched together in a `Promise.all` (their elapsed times overlap, so
+  // the sum is busy-time, not wall-clock).
+  async busyTime<T>(stage: string, fn: () => Promise<T>): Promise<T> {
+    let start = Date.now();
+    try {
+      return await fn();
+    } finally {
+      this.addBusy(stage, Date.now() - start);
+    }
+  }
+
+  addBusy(stage: string, ms: number): void {
+    this.#busy.set(stage, (this.#busy.get(stage) ?? 0) + ms);
+  }
+
   // Integer tallies that aren't durations — result counts, per-instance
   // cache hit/miss counts.
   incr(counter: string, n = 1): void {
@@ -41,11 +70,11 @@ export class RequestTimings {
   }
 
   stages(): Record<string, number> {
-    let out: Record<string, number> = {};
-    for (let [k, v] of this.#stages) {
-      out[k] = Math.round(v);
-    }
-    return out;
+    return roundedEntries(this.#stages);
+  }
+
+  busy(): Record<string, number> {
+    return roundedEntries(this.#busy);
   }
 
   counters(): Record<string, number> {
@@ -53,12 +82,28 @@ export class RequestTimings {
   }
 
   // Compact fragment for a single log line, e.g.
-  //   `sql=41 loadLinks=120 stringify=210 | results=312 cacheHit=18 cacheMiss=3`
+  //   sql=41 loadLinks=120 stringify=210 | busyMs(parallel-sum) populate=900 cacheRead=120 cacheWrite=80 | results=312 cacheHit=18 cacheMiss=3
+  // The `busyMs(parallel-sum)` section is summed across concurrent ops, so it
+  // is NOT wall-clock — read it as a ratio, or divide by `results` for a
+  // per-item average. Only the first section is the wall-clock timeline.
   toLogFragment(): string {
-    let stages = [...this.#stages]
-      .map(([k, v]) => `${k}=${Math.round(v)}`)
-      .join(' ');
-    let counters = [...this.#counters].map(([k, v]) => `${k}=${v}`).join(' ');
-    return counters ? `${stages} | ${counters}` : stages;
+    let render = (m: Map<string, number>) =>
+      [...m].map(([k, v]) => `${k}=${Math.round(v)}`).join(' ');
+    let out = render(this.#stages);
+    if (this.#busy.size > 0) {
+      out += ` | busyMs(parallel-sum) ${render(this.#busy)}`;
+    }
+    if (this.#counters.size > 0) {
+      out += ` | ${[...this.#counters].map(([k, v]) => `${k}=${v}`).join(' ')}`;
+    }
+    return out;
   }
+}
+
+function roundedEntries(m: Map<string, number>): Record<string, number> {
+  let out: Record<string, number> = {};
+  for (let [k, v] of m) {
+    out[k] = Math.round(v);
+  }
+  return out;
 }


### PR DESCRIPTION
## What this fixes

Follow-up to CS-11363 (the realm-server search-timing instrumentation), caught by dogfooding those logs on a live staging reindex.

The `realm:search-timing` line timed the per-result `populate` / `cacheRead` / `cacheWrite` work with the same accumulating `time()` used for the sequential request stages. But that inner work runs **concurrently** — `loadLinks` processes the whole result set in a `Promise.all` — so summing each op's elapsed time massively overcounts wall-clock. A real staging line:

```
corr=… handler=3829ms parse=0 resolveRealms=0 sql=330 cacheRead=127785 populate=1736213 cacheWrite=153786 loadLinks=3419 stringify=14 | cacheMiss=779 results=779
```

`populate=1736213` (1.7 **million** ms) on a `handler=3829ms` request reads as nonsense sitting next to the genuine wall-clock stages on the same line — it's the sum of 779 concurrent populate ops, not wall-clock.

## The fix

Split the collector into two buckets:

- **Sequential wall-clock timeline** (`parse`, `sql`, `loadLinks`, `stringify`) — timed with `time()` as before; these sum to ≈ `handler`.
- **Concurrent busy-time** (`populate`, `cacheRead`, `cacheWrite`) — timed with a new `busyTime()` and rendered in a clearly-labeled `busyMs(parallel-sum)` section, so it never masquerades as wall-clock.

The numbers themselves are unchanged; they're just no longer presented as if they were sequential wall-clock. Read the busy section as a **ratio** (which sub-step dominates inside `loadLinks` — e.g. `populate ≫ cacheRead/cacheWrite` means the CPU field-walk, not the cache DB round-trips) or divide by `results` for a per-item average. The outer `loadLinks` stage stays the wall-clock of the whole parallel pass, so `handler` still ≈ the sum of the timeline stages.

New line shape:

```
corr=… handler=Nms parse=… sql=… loadLinks=… stringify=… coalescedWait=… | busyMs(parallel-sum) populate=… cacheRead=… cacheWrite=… | results=… cacheHit=… cacheMiss=…
```

Mode G of the `indexing-diagnostics` skill is updated to document the two sections and how to read the busy aggregate.

## Scope

Instrumentation-only; no behavior change to search or indexing. Same gating as CS-11363 — emits only for prerender traffic carrying a correlation id.

Linear: CS-11390
