### PR TITLE
CS-11327: reserve a stable width for the selection-menu count

### DIFF
--- a/packages/boxel-ui/addon/src/components/selection-menu/index.gts
+++ b/packages/boxel-ui/addon/src/components/selection-menu/index.gts
@@ -121,6 +121,12 @@ export default class SelectionMenu extends Component<Signature> {
       .selection-menu-count {
         line-height: 1;
         white-space: nowrap;
+        /* Reserve a stable width (and equal-width digits) so the trigger
+           doesn't shift when the count crosses 1↔2 digits, e.g. during a
+           Select All that jumps 9→10. */
+        min-width: 2ch;
+        text-align: center;
+        font-variant-numeric: tabular-nums;
       }
       .selection-menu-caret {
         flex-shrink: 0;


### PR DESCRIPTION
[CS-11327](https://linear.app/cardstack/issue/CS-11327). Give the selection-menu count a 2ch minimum width with tabular figures so the trigger doesn't shift when the count crosses 1↔2 digits (e.g. a Select All jumping 9→10). Trigger height already matches the adjacent sort button via the shared `--boxel-button-sm` min-height.

Second of three PRs split out of #5105. **Stacked on [CS-11326](../../pull/?head=cs-11326-standardize-dropdown-arrow)** — review/merge that first; this PR's diff is just the count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)