### PR TITLE
Fix card-selection border weight in the card chooser (CS-11329)

### DIFF
--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -443,6 +443,18 @@ export default class ItemButton extends Component<Signature> {
       .catalog-item.adorn.selected {
         border-color: transparent;
       }
+      /* Selection ring for adorn catalog items. Defined here on the item
+         itself (rather than relying on AdornContext's :deep stroke rule,
+         which the portaled catalog item didn't reliably inherit — leaving
+         only the thin 1px button border) so the ring stays a full-weight
+         4px whether or not the item is hovered, darkening on hover to match
+         the rest of the Adorn treatment. */
+      .catalog-item.adorn.selected {
+        box-shadow: 0 0 0 0.25rem var(--boxel-highlight);
+      }
+      .catalog-item.adorn.selected:hover {
+        box-shadow: 0 0 0 0.25rem var(--boxel-highlight-hover);
+      }
       /* The type-label tab is placed by the shared positionAdornLabel
          modifier (inline position/top/left), so this class only carries
          the consumer's concerns: keep it out of pointer events and fade


### PR DESCRIPTION
Resolves [CS-11329](https://linear.app/cardstack/issue/CS-11329). Split out of #5111.

In the card chooser, a selected item showed only the thin 1px button border — the intended teal ring relied on `AdornContext`'s `:deep(.adorn-stroke.selected)` rule, which the portaled catalog item didn't pick up (computed `box-shadow` on a selected item was `rgba(0,0,0,0) 0 0 0 0`).

**Fix:** define the ring directly on `.catalog-item.adorn.selected` — a 4px `--boxel-highlight` ring, darkening to `--boxel-highlight-hover` on hover — so it stays full-weight whether or not the item is hovered. (Operator-mode overlays already rendered a correct 4px ring, so this is scoped to the chooser/search `item-button`.)

Base: `main`. First of a 4-PR split of #5111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
