### PR TITLE
Sync the card-chooser selection ring with the tag (CS-11330)

### DIFF
--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -448,9 +448,15 @@ export default class ItemButton extends Component<Signature> {
          which the portaled catalog item didn't reliably inherit — leaving
          only the thin 1px button border) so the ring stays a full-weight
          4px whether or not the item is hovered, darkening on hover to match
-         the rest of the Adorn treatment. */
-      .catalog-item.adorn.selected {
+         the rest of the Adorn treatment. `transition: none` makes the ring
+         appear in lockstep with the selection tag/chip (which render
+         instantly) instead of fading in ~0.2s later — and it's needed on the
+         hover variant too, since a card is normally hovered at the moment
+         it's clicked to select, so that rule governs the ring's first paint. */
+      .catalog-item.adorn.selected,
+      .catalog-item.adorn.selected:hover {
         box-shadow: 0 0 0 0.25rem var(--boxel-highlight);
+        transition: none;
       }
       .catalog-item.adorn.selected:hover {
         box-shadow: 0 0 0 0.25rem var(--boxel-highlight-hover);


### PR DESCRIPTION
Resolves [CS-11330](https://linear.app/cardstack/issue/CS-11330). Split out of #5111.

The selected ring faded in over `box-shadow 0.2s` while the selection tag/chip render instantly, so the border appeared ~0.2s after the tag.

**Fix:** `transition: none` on the selected ring — including the `:hover` variant, since a card is normally hovered at the moment it's clicked to select, so that rule governs the ring's first paint — so the ring and tag appear together.

⚠️ **Stacked on #5117** (base branch `cs-11329-selection-ring`). Review/merge after #5117; the diff here is only the transition change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
