### PR TITLE
Raise AI-room sliding-sync timeline_limit after initial sync (CS-11369)

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -25,7 +25,7 @@ import {
 import { validateAICredits } from '@cardstack/billing/ai-billing';
 import {
   SLIDING_SYNC_AI_ROOM_LIST_NAME,
-  SLIDING_SYNC_LIST_TIMELINE_LIMIT,
+  INITIAL_SLIDING_SYNC_LIST_TIMELINE_LIMIT,
   SLIDING_SYNC_TIMEOUT,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE,
 } from '@cardstack/runtime-common/matrix-constants';
@@ -693,13 +693,13 @@ Common issues are:
     filters: {
       is_dm: false,
     },
-    timeline_limit: SLIDING_SYNC_LIST_TIMELINE_LIMIT,
+    timeline_limit: INITIAL_SLIDING_SYNC_LIST_TIMELINE_LIMIT,
     required_state: [['*', '*']],
   });
   let slidingSync = new SlidingSync(
     client.baseUrl,
     lists,
-    { timeline_limit: SLIDING_SYNC_LIST_TIMELINE_LIMIT },
+    { timeline_limit: INITIAL_SLIDING_SYNC_LIST_TIMELINE_LIMIT },
     client,
     SLIDING_SYNC_TIMEOUT,
   );

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -61,11 +61,12 @@ import {
   DEFAULT_FALLBACK_MODELS,
   APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
   APP_BOXEL_STOP_GENERATING_EVENT_TYPE,
+  INITIAL_SLIDING_SYNC_LIST_TIMELINE_LIMIT,
   SLIDING_SYNC_AI_ROOM_LIST_NAME,
+  SLIDING_SYNC_AI_ROOM_TIMELINE_LIMIT,
   SLIDING_SYNC_AUTH_ROOM_LIST_NAME,
   SLIDING_SYNC_AUTH_ROOM_TIMELINE_LIMIT,
   SLIDING_SYNC_LIST_RANGE_END,
-  SLIDING_SYNC_LIST_TIMELINE_LIMIT,
   SLIDING_SYNC_TIMEOUT,
   type LLMMode,
   APP_BOXEL_COMMAND_REQUESTS_KEY,
@@ -871,16 +872,23 @@ export default class MatrixService extends Service {
     }
   }
 
-  private async initSlidingSync(accountData?: { realms: string[] } | null) {
-    let lists: Map<string, MSC3575List> = new Map();
-    lists.set(SLIDING_SYNC_AI_ROOM_LIST_NAME, {
+  private aiRoomListConfig(timelineLimit: number): MSC3575List {
+    return {
       ranges: [[0, SLIDING_SYNC_LIST_RANGE_END]],
       filters: {
         is_dm: false,
       },
-      timeline_limit: SLIDING_SYNC_LIST_TIMELINE_LIMIT,
+      timeline_limit: timelineLimit,
       required_state: [['*', '*']],
-    });
+    };
+  }
+
+  private async initSlidingSync(accountData?: { realms: string[] } | null) {
+    let lists: Map<string, MSC3575List> = new Map();
+    lists.set(
+      SLIDING_SYNC_AI_ROOM_LIST_NAME,
+      this.aiRoomListConfig(INITIAL_SLIDING_SYNC_LIST_TIMELINE_LIMIT),
+    );
     lists.set(SLIDING_SYNC_AUTH_ROOM_LIST_NAME, {
       ranges: [[0, accountData?.realms.length ?? SLIDING_SYNC_LIST_RANGE_END]],
       filters: {
@@ -893,7 +901,7 @@ export default class MatrixService extends Service {
       this.client.baseUrl,
       lists,
       {
-        timeline_limit: SLIDING_SYNC_LIST_TIMELINE_LIMIT,
+        timeline_limit: INITIAL_SLIDING_SYNC_LIST_TIMELINE_LIMIT,
       },
       this.client as any,
       SLIDING_SYNC_TIMEOUT,
@@ -925,6 +933,10 @@ export default class MatrixService extends Service {
           ]).then(() => {
             this.initialSyncCompleted = true;
             this.initialSyncCompletedDeferred.fulfill();
+            this.slidingSync?.setList(
+              SLIDING_SYNC_AI_ROOM_LIST_NAME,
+              this.aiRoomListConfig(SLIDING_SYNC_AI_ROOM_TIMELINE_LIMIT),
+            );
           });
         }
         roomIds.forEach((id) => this.roomsWaitingForSync.get(id)?.fulfill());

--- a/packages/host/tests/helpers/mock-matrix/_sliding-sync.ts
+++ b/packages/host/tests/helpers/mock-matrix/_sliding-sync.ts
@@ -14,6 +14,7 @@ export class MockSlidingSync extends SlidingSync {
   private _client: MatrixSDK.MatrixClient;
   private _lists: Record<string, MSC3575List>;
   private lifecycleCallbacks: Function[] = [];
+  setListCalls: Array<{ listKey: string; list: MSC3575List }> = [];
 
   constructor(
     proxyBaseUrl: string,
@@ -79,6 +80,12 @@ export class MockSlidingSync extends SlidingSync {
   async setListRanges(listKey: string, ranges: number[][]) {
     this._lists[listKey].ranges = ranges;
     return await this.resend();
+  }
+
+  setList(listKey: string, list: MSC3575List) {
+    this.setListCalls.push({ listKey, list });
+    this._lists[listKey] = list;
+    void this.resend();
   }
 
   async resend() {

--- a/packages/host/tests/integration/matrix-service-sliding-sync-test.ts
+++ b/packages/host/tests/integration/matrix-service-sliding-sync-test.ts
@@ -1,0 +1,76 @@
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm } from '@cardstack/runtime-common';
+import {
+  SLIDING_SYNC_AI_ROOM_LIST_NAME,
+  SLIDING_SYNC_AI_ROOM_TIMELINE_LIMIT,
+} from '@cardstack/runtime-common/matrix-constants';
+
+import type MatrixService from '@cardstack/host/services/matrix-service';
+
+import {
+  testRealmURL,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+} from '../helpers';
+
+import { setupBaseRealm } from '../helpers/base-realm';
+
+import { setupMockMatrix } from '../helpers/mock-matrix';
+
+import { setupRenderingTest } from '../helpers/setup';
+
+import type { MockSlidingSync } from '../helpers/mock-matrix/_sliding-sync';
+
+module(
+  'Integration | matrix-service | sliding-sync timeline_limit bump',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupLocalIndexing(hooks);
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [baseRealm.url, testRealmURL],
+      autostart: true,
+    });
+
+    setupBaseRealm(hooks);
+
+    hooks.beforeEach(async function (this: RenderingTestContext) {
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {},
+      });
+    });
+
+    test('raises AI-room list timeline_limit via setList after the first SlidingSyncState.Complete fires', async function (assert) {
+      let matrixService = getService('matrix-service') as MatrixService;
+      let slidingSync = (matrixService as unknown as { slidingSync?: unknown })
+        .slidingSync as MockSlidingSync | undefined;
+
+      assert.ok(slidingSync, 'matrix-service has a slidingSync instance');
+
+      let aiListCalls = slidingSync!.setListCalls.filter(
+        (c) => c.listKey === SLIDING_SYNC_AI_ROOM_LIST_NAME,
+      );
+      assert.strictEqual(
+        aiListCalls.length,
+        1,
+        'setList is called exactly once for the AI-room list',
+      );
+      assert.strictEqual(
+        aiListCalls[0]?.list.timeline_limit,
+        SLIDING_SYNC_AI_ROOM_TIMELINE_LIMIT,
+        'AI-room list is bumped to the steady-state timeline_limit',
+      );
+      assert.deepEqual(
+        aiListCalls[0]?.list.filters,
+        { is_dm: false },
+        'AI-room list filters preserved across the bump',
+      );
+    });
+  },
+);

--- a/packages/runtime-common/matrix-constants.ts
+++ b/packages/runtime-common/matrix-constants.ts
@@ -103,20 +103,37 @@ export const DEFAULT_FALLBACK_MODEL_ID = 'anthropic/claude-sonnet-4.6';
 export const SLIDING_SYNC_AI_ROOM_LIST_NAME = 'ai-room';
 export const SLIDING_SYNC_AUTH_ROOM_LIST_NAME = 'auth-room';
 export const SLIDING_SYNC_LIST_RANGE_END = 9;
-// AI rooms (ai-room list) emit one event per message and rely on the host's
-// loadAllTimelineEvents scrollback (which calls /messages with an m.replace
-// filter) to backfill older history on demand, so a per-room timeline_limit
-// of 1 is sufficient.
+// Sliding-sync per-room timeline_limit is sized differently per list, and the
+// AI-room list also uses a two-stage value: small during the very first sync
+// (cold-start latency), then bumped after the initial sync completes so live
+// streaming bursts can't be dropped.
 //
-// Realm session rooms (auth-room list) instead receive a burst of multiple
-// events per write or delete — incremental-index-initiation → update →
-// incremental, plus an extra initiation per file in multi-file batches. The
-// `update` event sits in the middle of that burst and is what DirectoryResource
-// subscribes to for live file-tree refresh; with timeline_limit=1, sliding
-// sync only delivers the latest event of any burst that arrives in the same
-// poll window, so the `update` event gets silently dropped (it remains in the
-// room but never reaches the live Room.timeline listener). The higher limit
-// on the auth-room list keeps the full burst in each /sync response.
-export const SLIDING_SYNC_LIST_TIMELINE_LIMIT = 1;
+// INITIAL_SLIDING_SYNC_LIST_TIMELINE_LIMIT — the conservative value used for
+// the AI-room list on the first /sync request and as the SlidingSync
+// constructor's default for any list/subscription we haven't otherwise
+// overridden. Keeping it at 1 keeps the initial sync fast when many AI rooms
+// exist.
+//
+// SLIDING_SYNC_AI_ROOM_TIMELINE_LIMIT — the steady-state value applied to the
+// AI-room list via setList() immediately after the first SlidingSyncState.Complete
+// event. AI streaming responses are not one-event-per-message: the bot emits an
+// initial m.room.message with isStreamingFinished:false, then many m.replace
+// events (~250 ms throttle), then a final m.replace with isStreamingFinished:true.
+// If more than one replace lands in the same sliding-sync poll window,
+// timeline_limit=1 only delivers the latest; any event landing after the
+// finalization replace in that same window displaces it, the host's tracked
+// Message stays at isStreamingFinished:false, and the assistant panel hangs
+// in "generating results" until a manual page reload. The higher steady-state
+// value keeps the full streaming burst (and any trailing room churn) in each
+// /sync response.
+//
+// SLIDING_SYNC_AUTH_ROOM_TIMELINE_LIMIT — realm session rooms (auth-room list)
+// receive a burst of multiple events per write or delete (incremental-index-
+// initiation → update → incremental, plus an extra initiation per file in
+// multi-file batches). The `update` event sits in the middle of that burst and
+// is what DirectoryResource subscribes to for live file-tree refresh; without
+// the higher limit it gets silently dropped from the live Room.timeline.
+export const INITIAL_SLIDING_SYNC_LIST_TIMELINE_LIMIT = 1;
+export const SLIDING_SYNC_AI_ROOM_TIMELINE_LIMIT = 20;
 export const SLIDING_SYNC_AUTH_ROOM_TIMELINE_LIMIT = 20;
 export const SLIDING_SYNC_TIMEOUT = 30000;


### PR DESCRIPTION
## Summary

- Two-stage `timeline_limit` for the AI-room sliding-sync list: keeps the existing `= 1` for the initial sync (cold-start latency), then bumps the list to a dedicated `SLIDING_SYNC_AI_ROOM_TIMELINE_LIMIT = 20` via `slidingSync.setList()` on the first `SlidingSyncState.Complete`.
- Renames `SLIDING_SYNC_LIST_TIMELINE_LIMIT` -> `INITIAL_SLIDING_SYNC_LIST_TIMELINE_LIMIT` so the role of the small value is explicit at every call site (host matrix-service, ai-bot main).
- Fixes the stuck "generating results" state that occurs when an AI streaming response's finalization `m.replace` (the one carrying `isStreamingFinished: true`) is displaced by any sibling event landing in the same sliding-sync poll window. With the elevated steady-state limit, the full streaming burst (and any trailing room churn) stays in each `/sync` response.

Linear: [CS-11369](https://linear.app/cardstack/issue/CS-11369)

## Test plan

- [x] `pnpm test:ember --filter "sliding-sync timeline_limit"` in `packages/host` exercises the new integration test that drives `matrix-service` end-to-end through `setupMockMatrix` + `setupIntegrationTestRealm` and asserts `setList` is called exactly once for the AI-room list with `timeline_limit: 20`.
- [x] Manual: `mise run dev-all`, open the AI assistant, watch DevTools Network for the sliding-sync requests. First request carries `timeline_limit: 1` on the ai-room list; the next request (right after the initial response completes) carries `timeline_limit: 20`, with `pos` carried forward (no full resync).
- [x] Manual: trigger a long streaming response (multi-second reply with reasoning + tool calls so the bot emits many `m.replace` events). Confirm the panel transitions out of "generating" without stranding, even when followed by unrelated activity in the same room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)