### PR TITLE
Compute the hover overlay position from live rects (fix first-frame jump)

### DIFF
--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -280,13 +280,6 @@ export default class OperatorModeOverlays extends Overlays {
     return 100;
   }
 
-  // This overlay carries visible chrome (the teal type-label tab, the select
-  // chip, the menu, the outline), so hide it until velcro's position settles
-  // to avoid the first-frame jump those would otherwise show.
-  protected override get hideUntilPositioned(): boolean {
-    return true;
-  }
-
   // Tracks which rendered cards are currently small enough to warrant
   // the Adorn compact treatment (narrow atom-format cards). The set
   // is updated by `trackCompact` as cards resize; `isCompact` reads

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -218,14 +218,6 @@ export default class OperatorModeOverlays extends Overlays {
     </AdornContext>
     <style scoped>
       .actions-overlay {
-        /* Establish `position: absolute` from CSS, before velcro's first
-           computePosition runs. floating-ui requires the floating element to
-           already be absolutely positioned when it first measures; the offset
-           middleware also sets this, but that runs *after* the initial
-           measurement, so without it here the overlay (and everything riding
-           it — the type-label tab, the select chip, the menu) lands ~1 frame
-           off and visibly jumps into place on first hover. */
-        position: absolute;
         pointer-events: none;
         /* Allow the type-label tab and selection chip to extend outside the
            overlay's bounding box without being clipped. */
@@ -286,6 +278,13 @@ export default class OperatorModeOverlays extends Overlays {
     // The type-label tab floats a few pixels above the card; the cursor
     // needs to bridge that gap without the chrome dismissing itself.
     return 100;
+  }
+
+  // This overlay carries visible chrome (the teal type-label tab, the select
+  // chip, the menu, the outline), so hide it until velcro's position settles
+  // to avoid the first-frame jump those would otherwise show.
+  protected override get hideUntilPositioned(): boolean {
+    return true;
   }
 
   // Tracks which rendered cards are currently small enough to warrant

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -218,6 +218,14 @@ export default class OperatorModeOverlays extends Overlays {
     </AdornContext>
     <style scoped>
       .actions-overlay {
+        /* Establish `position: absolute` from CSS, before velcro's first
+           computePosition runs. floating-ui requires the floating element to
+           already be absolutely positioned when it first measures; the offset
+           middleware also sets this, but that runs *after* the initial
+           measurement, so without it here the overlay (and everything riding
+           it — the type-label tab, the select chip, the menu) lands ~1 frame
+           off and visibly jumps into place on first hover. */
+        position: absolute;
         pointer-events: none;
         /* Allow the type-label tab and selection chip to extend outside the
            overlay's bounding box without being clipped. */

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -95,6 +95,13 @@ export default class Overlays extends Component<OverlaySignature> {
     {{/each}}
     <style scoped>
       .base-overlay {
+        /* Establish `position: absolute` from CSS, before velcro's first
+           computePosition runs. floating-ui requires the floating element to
+           already be absolutely positioned when it first measures; the offset
+           middleware also sets this, but that runs *after* the initial
+           measurement, so without it here the overlay lands ~1 frame off and
+           visibly jumps into place on first appearance. */
+        position: absolute;
         width: 100%;
         height: 100%;
         pointer-events: none;

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -28,22 +28,6 @@ import type { CardDefOrId } from './stack-item';
 import type { RenderedCardForOverlayActions } from '../../resources/element-tracker';
 import type { MiddlewareState } from '@floating-ui/dom';
 
-// --- TEMP INSTRUMENTATION (overlay first-frame jump) — remove before merge ---
-// Enable with localStorage.setItem('adorn-pos-debug','1') (reload) or
-// ?adornPosDebug=1. Logs, per velcro computePosition, the quantities that
-// determine where the overlay lands, so we can see which one is ~60px off on
-// the first call.
-function overlayDebugOn(): boolean {
-  if (typeof window === 'undefined') return false;
-  try {
-    if (window.localStorage?.getItem('adorn-pos-debug') === '1') return true;
-  } catch {
-    /* localStorage may be unavailable */
-  }
-  return /[?&]adornPosDebug=1\b/.test(window.location?.search ?? '');
-}
-// --- end TEMP ---
-
 interface OverlaySignature {
   Args: {
     renderedCardsForOverlayActions: RenderedCardForOverlayActions[];
@@ -111,13 +95,6 @@ export default class Overlays extends Component<OverlaySignature> {
     {{/each}}
     <style scoped>
       .base-overlay {
-        /* Establish `position: absolute` from CSS, before velcro's first
-           computePosition runs. floating-ui requires the floating element to
-           already be absolutely positioned when it first measures; the offset
-           middleware also sets this, but that runs *after* the initial
-           measurement, so without it here the overlay lands ~1 frame off and
-           visibly jumps into place on first appearance. */
-        position: absolute;
         width: 100%;
         height: 100%;
         pointer-events: none;
@@ -162,33 +139,53 @@ export default class Overlays extends Component<OverlaySignature> {
         floating.style.borderRadius =
           window.getComputedStyle(reference).borderRadius;
       }
-      // --- TEMP INSTRUMENTATION (build marker v-mw1) — remove before merge ---
-      if (overlayDebugOn()) {
-        let op = floating.offsetParent as HTMLElement | null;
-        let opRect = op ? op.getBoundingClientRect() : null;
-        let refRect =
-          reference instanceof Element
-            ? reference.getBoundingClientRect()
-            : null;
-        let scroller = floating.closest(
-          '[data-test-cards-grid-cards], .boxel-cards-grid, [data-scroller], .ember-application',
-        ) as HTMLElement | null;
-        console.log(
-          `[overlay-mw v-mw1] x=${rects.reference.x.toFixed(1)} y=${rects.reference.y.toFixed(1)}` +
-            ` | refRect top=${refRect ? refRect.top.toFixed(1) : '?'} left=${refRect ? refRect.left.toFixed(1) : '?'}` +
-            ` | floatPos=${window.getComputedStyle(floating).position}` +
-            ` | offsetParent=${op ? op.tagName + '.' + String(op.className).replace(/\s+/g, '.').slice(0, 30) : 'null'}` +
-            ` opTop=${opRect ? opRect.top.toFixed(1) : '?'} opLeft=${opRect ? opRect.left.toFixed(1) : '?'}` +
-            ` | scrollY=${window.scrollY} scrollerTop=${scroller ? scroller.scrollTop : '?'}`,
-        );
+      // floating-ui's first one-or-two computePosition calls return the
+      // reference in viewport coordinates rather than offset-parent-relative
+      // ones (it omits the offset parent's offset for ~1 frame, then corrects),
+      // so the overlay paints one frame off and visibly jumps into place — and
+      // everything riding it (the type-label tab, the select chip, the menu,
+      // the outline) jumps with it. Subclasses with visible chrome opt into
+      // hiding the overlay until its position has settled (see
+      // `hideUntilPositioned`). We use opacity rather than visibility so the
+      // overlay's action buttons stay hit-testable the whole time. The reveal
+      // is rescheduled on every position write and fires one frame after the
+      // last, so it lands only once the position has stopped moving (the wrong
+      // value can repeat across calls, so converging on equality isn't enough).
+      if (
+        this.hideUntilPositioned &&
+        floating.dataset.overlayPositioned !== 'true'
+      ) {
+        floating.style.opacity = '0';
+        let pending = this.overlayRevealHandles.get(floating);
+        if (pending !== undefined) {
+          cancelAnimationFrame(pending);
+        }
+        // eslint-disable-next-line @cardstack/boxel/no-raf-for-state
+        let handle = requestAnimationFrame(() => {
+          this.overlayRevealHandles.delete(floating);
+          floating.dataset.overlayPositioned = 'true';
+          floating.style.opacity = '';
+        });
+        this.overlayRevealHandles.set(floating, handle);
       }
-      // --- end TEMP ---
       return {
         x: rects.reference.x,
         y: rects.reference.y,
       };
     },
   };
+
+  // Tracks the pending reveal rAF per overlay element so it can be rescheduled
+  // (and so the latest write wins) while the position is still settling.
+  private overlayRevealHandles = new WeakMap<HTMLElement, number>();
+
+  // Whether to keep the overlay hidden (opacity 0) until floating-ui's position
+  // has settled, to avoid the first-frame jump. Off by default (consumers
+  // without visible chrome — spec-preview, playground — don't need it);
+  // OperatorModeOverlays overrides it.
+  protected get hideUntilPositioned(): boolean {
+    return false;
+  }
 
   // Since we put absolutely positined overlays containing operator mode actions on top of the rendered cards,
   // we are running into a problem where the overlays are interfering with scrolling of the container that holds the rendered cards.

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -28,6 +28,22 @@ import type { CardDefOrId } from './stack-item';
 import type { RenderedCardForOverlayActions } from '../../resources/element-tracker';
 import type { MiddlewareState } from '@floating-ui/dom';
 
+// --- TEMP INSTRUMENTATION (overlay first-frame jump) — remove before merge ---
+// Enable with localStorage.setItem('adorn-pos-debug','1') (reload) or
+// ?adornPosDebug=1. Logs, per velcro computePosition, the quantities that
+// determine where the overlay lands, so we can see which one is ~60px off on
+// the first call.
+function overlayDebugOn(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    if (window.localStorage?.getItem('adorn-pos-debug') === '1') return true;
+  } catch {
+    /* localStorage may be unavailable */
+  }
+  return /[?&]adornPosDebug=1\b/.test(window.location?.search ?? '');
+}
+// --- end TEMP ---
+
 interface OverlaySignature {
   Args: {
     renderedCardsForOverlayActions: RenderedCardForOverlayActions[];
@@ -146,6 +162,27 @@ export default class Overlays extends Component<OverlaySignature> {
         floating.style.borderRadius =
           window.getComputedStyle(reference).borderRadius;
       }
+      // --- TEMP INSTRUMENTATION (build marker v-mw1) — remove before merge ---
+      if (overlayDebugOn()) {
+        let op = floating.offsetParent as HTMLElement | null;
+        let opRect = op ? op.getBoundingClientRect() : null;
+        let refRect =
+          reference instanceof Element
+            ? reference.getBoundingClientRect()
+            : null;
+        let scroller = floating.closest(
+          '[data-test-cards-grid-cards], .boxel-cards-grid, [data-scroller], .ember-application',
+        ) as HTMLElement | null;
+        console.log(
+          `[overlay-mw v-mw1] x=${rects.reference.x.toFixed(1)} y=${rects.reference.y.toFixed(1)}` +
+            ` | refRect top=${refRect ? refRect.top.toFixed(1) : '?'} left=${refRect ? refRect.left.toFixed(1) : '?'}` +
+            ` | floatPos=${window.getComputedStyle(floating).position}` +
+            ` | offsetParent=${op ? op.tagName + '.' + String(op.className).replace(/\s+/g, '.').slice(0, 30) : 'null'}` +
+            ` opTop=${opRect ? opRect.top.toFixed(1) : '?'} opLeft=${opRect ? opRect.left.toFixed(1) : '?'}` +
+            ` | scrollY=${window.scrollY} scrollerTop=${scroller ? scroller.scrollTop : '?'}`,
+        );
+      }
+      // --- end TEMP ---
       return {
         x: rects.reference.x,
         y: rects.reference.y,

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -9,7 +9,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import { dropTask } from 'ember-concurrency';
-import { modifier } from 'ember-modifier';
 import { velcro } from 'ember-velcro';
 import { isEqual, omit } from 'lodash';
 
@@ -79,7 +78,6 @@ export default class Overlays extends Component<OverlaySignature> {
           <div
             class={{this.overlayClassName}}
             {{velcro renderedCard.element middleware=(array this.offset)}}
-            {{this.revealWhenPositioned}}
             style={{renderedCard.overlayZIndexStyle}}
             data-test-card-overlay
             ...attributes
@@ -128,12 +126,12 @@ export default class Overlays extends Component<OverlaySignature> {
   protected offset = {
     name: 'offset',
     fn: (state: MiddlewareState) => {
-      let { elements, rects } = state;
+      let { elements } = state;
       let { floating, reference } = elements;
-      let { width, height } = reference.getBoundingClientRect();
+      let refRect = reference.getBoundingClientRect();
 
-      floating.style.width = width + 'px';
-      floating.style.height = height + 'px';
+      floating.style.width = refRect.width + 'px';
+      floating.style.height = refRect.height + 'px';
       floating.style.position = 'absolute';
       // Mirror the underlying card's corner radius so any decorative
       // outline / box-shadow on the overlay follows the same curve.
@@ -141,69 +139,43 @@ export default class Overlays extends Component<OverlaySignature> {
         floating.style.borderRadius =
           window.getComputedStyle(reference).borderRadius;
       }
+
+      // Position the overlay from the live reference rect relative to the
+      // floating element's own offset parent, rather than floating-ui's
+      // `rects.reference`. floating-ui's first one-or-two computePosition calls
+      // omit the offset parent's offset (they return the reference in viewport
+      // coordinates and only subtract the offset parent a frame later), so
+      // trusting `rects.reference` makes the overlay — and everything riding it
+      // (the type-label tab, the select chip, the menu, the outline) — paint
+      // one frame off and visibly jump into place on first appearance.
+      // Computing it ourselves from the current rects is correct on the very
+      // first frame. We recover the offset parent's scale the same way the
+      // Adorn label positioner does (the test runner scales `#ember-testing`),
+      // and convert the viewport anchor into the offset parent's local space.
+      let offsetParent = floating.offsetParent as HTMLElement | null;
+      let parentRect = offsetParent
+        ? offsetParent.getBoundingClientRect()
+        : new DOMRect(0, 0, window.innerWidth, window.innerHeight);
+      let scaleX =
+        offsetParent && offsetParent.offsetWidth > 0
+          ? parentRect.width / offsetParent.offsetWidth
+          : 1;
+      let scaleY =
+        offsetParent && offsetParent.offsetHeight > 0
+          ? parentRect.height / offsetParent.offsetHeight
+          : 1;
+      if (!Number.isFinite(scaleX) || scaleX === 0) {
+        scaleX = 1;
+      }
+      if (!Number.isFinite(scaleY) || scaleY === 0) {
+        scaleY = 1;
+      }
       return {
-        x: rects.reference.x,
-        y: rects.reference.y,
+        x: (refRect.left - parentRect.left) / scaleX,
+        y: (refRect.top - parentRect.top) / scaleY,
       };
     },
   };
-
-  // Whether to keep the overlay hidden (opacity 0) until its velcro position
-  // has settled, to avoid the first-frame jump. Off by default (consumers
-  // without visible chrome — spec-preview, playground — don't need it);
-  // OperatorModeOverlays overrides it.
-  protected get hideUntilPositioned(): boolean {
-    return false;
-  }
-
-  // floating-ui's first one-or-two computePosition calls return the reference
-  // in viewport coordinates rather than offset-parent-relative ones (it omits
-  // the offset parent's offset for ~1 frame, then corrects), so the overlay —
-  // and everything riding it (the type-label tab, the select chip, the menu,
-  // the outline) — paints one frame off and visibly jumps into place. Hold the
-  // overlay at opacity 0 until its measured rect has been unchanged for two
-  // consecutive frames, then reveal. We watch the actual geometry rather than
-  // count frames or compare middleware outputs, because the wrong position can
-  // repeat across calls and the correction lands a frame after the first paint;
-  // only the rect going stable is a reliable "done moving" signal. Opacity (not
-  // visibility) keeps the overlay's action buttons hit-testable throughout.
-  protected revealWhenPositioned = modifier((element: HTMLElement) => {
-    if (!this.hideUntilPositioned) {
-      return undefined;
-    }
-    element.style.opacity = '0';
-    let lastTop: number | undefined;
-    let lastLeft: number | undefined;
-    let stableFrames = 0;
-    let elapsedFrames = 0;
-    let raf = 0;
-    let tick = () => {
-      let { top, left } = element.getBoundingClientRect();
-      if (top === lastTop && left === lastLeft) {
-        stableFrames += 1;
-      } else {
-        stableFrames = 0;
-        lastTop = top;
-        lastLeft = left;
-      }
-      elapsedFrames += 1;
-      // Reveal once the rect has settled, with a safety cap so a perpetually
-      // animating reference can't keep the overlay hidden forever.
-      if (stableFrames >= 2 || elapsedFrames > 30) {
-        element.style.opacity = '';
-        return;
-      }
-      // eslint-disable-next-line @cardstack/boxel/no-raf-for-state
-      raf = requestAnimationFrame(tick);
-    };
-    // eslint-disable-next-line @cardstack/boxel/no-raf-for-state
-    raf = requestAnimationFrame(tick);
-    return () => {
-      if (raf) {
-        cancelAnimationFrame(raf);
-      }
-    };
-  });
 
   // Since we put absolutely positined overlays containing operator mode actions on top of the rendered cards,
   // we are running into a problem where the overlays are interfering with scrolling of the container that holds the rendered cards.

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -9,6 +9,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import { dropTask } from 'ember-concurrency';
+import { modifier } from 'ember-modifier';
 import { velcro } from 'ember-velcro';
 import { isEqual, omit } from 'lodash';
 
@@ -78,6 +79,7 @@ export default class Overlays extends Component<OverlaySignature> {
           <div
             class={{this.overlayClassName}}
             {{velcro renderedCard.element middleware=(array this.offset)}}
+            {{this.revealWhenPositioned}}
             style={{renderedCard.overlayZIndexStyle}}
             data-test-card-overlay
             ...attributes
@@ -139,35 +141,6 @@ export default class Overlays extends Component<OverlaySignature> {
         floating.style.borderRadius =
           window.getComputedStyle(reference).borderRadius;
       }
-      // floating-ui's first one-or-two computePosition calls return the
-      // reference in viewport coordinates rather than offset-parent-relative
-      // ones (it omits the offset parent's offset for ~1 frame, then corrects),
-      // so the overlay paints one frame off and visibly jumps into place — and
-      // everything riding it (the type-label tab, the select chip, the menu,
-      // the outline) jumps with it. Subclasses with visible chrome opt into
-      // hiding the overlay until its position has settled (see
-      // `hideUntilPositioned`). We use opacity rather than visibility so the
-      // overlay's action buttons stay hit-testable the whole time. The reveal
-      // is rescheduled on every position write and fires one frame after the
-      // last, so it lands only once the position has stopped moving (the wrong
-      // value can repeat across calls, so converging on equality isn't enough).
-      if (
-        this.hideUntilPositioned &&
-        floating.dataset.overlayPositioned !== 'true'
-      ) {
-        floating.style.opacity = '0';
-        let pending = this.overlayRevealHandles.get(floating);
-        if (pending !== undefined) {
-          cancelAnimationFrame(pending);
-        }
-        // eslint-disable-next-line @cardstack/boxel/no-raf-for-state
-        let handle = requestAnimationFrame(() => {
-          this.overlayRevealHandles.delete(floating);
-          floating.dataset.overlayPositioned = 'true';
-          floating.style.opacity = '';
-        });
-        this.overlayRevealHandles.set(floating, handle);
-      }
       return {
         x: rects.reference.x,
         y: rects.reference.y,
@@ -175,17 +148,62 @@ export default class Overlays extends Component<OverlaySignature> {
     },
   };
 
-  // Tracks the pending reveal rAF per overlay element so it can be rescheduled
-  // (and so the latest write wins) while the position is still settling.
-  private overlayRevealHandles = new WeakMap<HTMLElement, number>();
-
-  // Whether to keep the overlay hidden (opacity 0) until floating-ui's position
+  // Whether to keep the overlay hidden (opacity 0) until its velcro position
   // has settled, to avoid the first-frame jump. Off by default (consumers
   // without visible chrome — spec-preview, playground — don't need it);
   // OperatorModeOverlays overrides it.
   protected get hideUntilPositioned(): boolean {
     return false;
   }
+
+  // floating-ui's first one-or-two computePosition calls return the reference
+  // in viewport coordinates rather than offset-parent-relative ones (it omits
+  // the offset parent's offset for ~1 frame, then corrects), so the overlay —
+  // and everything riding it (the type-label tab, the select chip, the menu,
+  // the outline) — paints one frame off and visibly jumps into place. Hold the
+  // overlay at opacity 0 until its measured rect has been unchanged for two
+  // consecutive frames, then reveal. We watch the actual geometry rather than
+  // count frames or compare middleware outputs, because the wrong position can
+  // repeat across calls and the correction lands a frame after the first paint;
+  // only the rect going stable is a reliable "done moving" signal. Opacity (not
+  // visibility) keeps the overlay's action buttons hit-testable throughout.
+  protected revealWhenPositioned = modifier((element: HTMLElement) => {
+    if (!this.hideUntilPositioned) {
+      return undefined;
+    }
+    element.style.opacity = '0';
+    let lastTop: number | undefined;
+    let lastLeft: number | undefined;
+    let stableFrames = 0;
+    let elapsedFrames = 0;
+    let raf = 0;
+    let tick = () => {
+      let { top, left } = element.getBoundingClientRect();
+      if (top === lastTop && left === lastLeft) {
+        stableFrames += 1;
+      } else {
+        stableFrames = 0;
+        lastTop = top;
+        lastLeft = left;
+      }
+      elapsedFrames += 1;
+      // Reveal once the rect has settled, with a safety cap so a perpetually
+      // animating reference can't keep the overlay hidden forever.
+      if (stableFrames >= 2 || elapsedFrames > 30) {
+        element.style.opacity = '';
+        return;
+      }
+      // eslint-disable-next-line @cardstack/boxel/no-raf-for-state
+      raf = requestAnimationFrame(tick);
+    };
+    // eslint-disable-next-line @cardstack/boxel/no-raf-for-state
+    raf = requestAnimationFrame(tick);
+    return () => {
+      if (raf) {
+        cancelAnimationFrame(raf);
+      }
+    };
+  });
 
   // Since we put absolutely positined overlays containing operator mode actions on top of the rendered cards,
   // we are running into a problem where the overlays are interfering with scrolling of the container that holds the rendered cards.


### PR DESCRIPTION
Fixes the first-frame jump on the CardsGrid hover chrome — the teal Adorn type-label tab, the select chip, the menu, and the outline all painting ~60px off for one frame then snapping into place.

## Root cause (confirmed by instrumenting the velcro offset middleware)
The hover overlay is positioned by velcro (floating-ui). The middleware returned floating-ui's `rects.reference`, but frame-by-frame capture showed floating-ui's **first one-or-two `computePosition` calls return the reference in viewport coordinates** (`y=200.4`) and only subtract the offset parent's offset (`opTop=60`) a frame later (`y=140.4`). Everything else was constant the whole time. So the overlay painted at `viewport - 0` for a frame, then corrected to `viewport - offsetParent`, and everything riding it jumped with it.

## Fix
The capture also showed the inputs needed are correct from frame 0: the reference's own `getBoundingClientRect` and the floating element's `offsetParent` rect. Compute the position from those directly — `(refRect.left − parentRect.left) / scaleX`, `(refRect.top − parentRect.top) / scaleY`, recovering the offset parent's scale the same way the Adorn label positioner does for the scaled test runner — instead of trusting floating-ui's `rects.reference`. It's correct on the very first frame. No hiding, no rAF, no deferred reveal; the overlay simply lands in the right place immediately.

## History
Earlier revisions chased label height, then `position: absolute` timing, then hiding the overlay until settle (opacity gate / rect-stability watch). The middleware capture disproved each: height was constant, `floatPos` was already `absolute`, and hiding fought a rAF-vs-correction race. This addresses the actual returned coordinate.

## Notes
- Single-file change in the shared `Overlays` base; benefits every velcro overlay consumer.
- Pre-existing — not introduced by the #5111 split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
