### PR TITLE
Stop search-sheet result captions being cropped behind the horizontal scrollbar (CS-11332)

### DIFF
--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -617,6 +617,12 @@ export default class SearchContent extends Component<Signature> {
       .search-sheet-content.compact {
         flex-direction: row;
         flex-wrap: nowrap;
+        /* Top-align the result cards so each keeps its natural height
+           (title + realm caption) instead of stretching to the row and
+           clipping the caption. The slack then falls below the cards,
+           where it leaves room for the horizontal scrollbar — so the
+           bottom caption clears it instead of being cropped behind it. */
+        align-items: flex-start;
         padding-inline: var(--boxel-sp-xs);
         /* `overflow-y: hidden` (needed so only the row scrolls
            horizontally) would clip the Adorn outline stroke and the

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -305,7 +305,7 @@ export default class SearchSheet extends Component<Signature> {
             var(--operator-mode-spacing)
         );
         --search-sheet-closed-width: var(--container-button-size);
-        --search-sheet-prompt-height: 9.45rem;
+        --search-sheet-prompt-height: 10.45rem;
       }
 
       .search-sheet {


### PR DESCRIPTION
[CS-11332](https://linear.app/cardstack/issue/CS-11332). In the search sheet's compact recent-cards row, the bottom realm caption ("in <Workspace>") was cropped — content overflowed its padding and sat behind the horizontal scrollbar.

## Cause
Each result card stretched to the row height (`align-items: normal`), but its natural content (title + caption) is ~4px taller than the available area, so the caption overflowed the card into the row's bottom padding. When the row overflowed horizontally and the scrollbar was the classic, layout-taking kind (Windows/Linux, or macOS "always show scroll bars"), that ~15px scrollbar cropped the caption. (On overlay-scrollbar setups it's invisible, which is why it slipped through.)

## Fix
- **Top-align the cards** (`align-items: flex-start` on the compact row) so each keeps its natural height and the slack falls *below* the cards rather than stretching/clipping them.
- **Raise `--search-sheet-prompt-height`** (9.45rem → 10.45rem) so that slack leaves room for the scrollbar beneath the caption.

## Verified live
With the fix: the card renders at its natural height (60.8px, previously clipped to 56.7), the caption no longer overflows the card (0px), and there's ~28px of clearance below the caption — comfortably above a ~15px scrollbar. Screenshot-checked in the search sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)