### PR TITLE
Hold the public realm-server port across the SF harness startup gap

### DIFF
--- a/packages/realm-test-harness/src/api.ts
+++ b/packages/realm-test-harness/src/api.ts
@@ -49,6 +49,7 @@ import {
   type FactoryRealmTemplate,
   type FactorySupportContext,
   type FactoryTestContext,
+  type PortReservation,
   type RealmAction,
   type RealmConfig,
   type StartedFactoryRealm,
@@ -82,22 +83,33 @@ export { startFactorySupportServices };
 
 export async function startFactoryGlobalContext(
   options: FactoryRealmOptions,
+  internal: { publicPortReservation?: PortReservation } = {},
 ): Promise<FactoryGlobalContextHandle> {
   return await logTimed(harnessLog, 'startFactoryGlobalContext', async () => {
     let realms = resolveRealms(options.realms);
-    let realmServerURL = await resolveFactoryRealmServerURL(
-      options.realmServerURL,
-      options.compatRealmServerPort,
-    );
+    let { url: realmServerURL, portReservation } =
+      await resolveFactoryRealmServerURL(
+        options.realmServerURL,
+        options.compatRealmServerPort,
+      );
+    // Prefer a holder the caller already owns (startFactoryRealmServer
+    // resolved + held the port before delegating here). Our own
+    // portReservation is undefined in that case, since options.realmServerURL
+    // is set.
+    let publicPortReservation =
+      internal.publicPortReservation ?? portReservation;
     let primaryRealmURL = realmURLWithinServer(realmServerURL, realms[0].path);
     let support = await startFactorySupportServices();
     try {
-      let template = await ensureFactoryRealmTemplate({
-        ...options,
-        realms,
-        realmServerURL,
-        context: support.context,
-      });
+      let template = await ensureFactoryRealmTemplate(
+        {
+          ...options,
+          realms,
+          realmServerURL,
+          context: support.context,
+        },
+        { publicPortReservation },
+      );
 
       let context: FactoryTestContext = {
         ...support.context,
@@ -116,6 +128,12 @@ export async function startFactoryGlobalContext(
     } catch (error) {
       await support.stop();
       throw error;
+    } finally {
+      // The public port is only bound transiently, by the template build's
+      // compat proxy. The global context never holds it once built, so
+      // release the holder (idempotent: the build already released it just
+      // before binding; on a cache hit it was never consumed).
+      await publicPortReservation?.release().catch(() => undefined);
     }
   });
 }
@@ -132,6 +150,7 @@ function resolveRealms(realms: RealmConfig[]): RealmConfig[] {
 
 export async function ensureFactoryRealmTemplate(
   options: FactoryRealmOptions & { forceRebuild?: boolean },
+  internal: { publicPortReservation?: PortReservation } = {},
 ): Promise<FactoryRealmTemplate> {
   return await logTimed(harnessLog, 'ensureFactoryRealmTemplate', async () => {
     let realms = resolveRealms(options.realms);
@@ -139,10 +158,20 @@ export async function ensureFactoryRealmTemplate(
       options.context && hasTemplateDatabaseName(options.context)
         ? new URL(options.context.realmServerURL)
         : undefined;
-    let realmServerURL = await resolveFactoryRealmServerURL(
-      options.realmServerURL ?? contextRealmServerURL,
-      options.compatRealmServerPort,
-    );
+    let { url: realmServerURL, portReservation } =
+      await resolveFactoryRealmServerURL(
+        options.realmServerURL ?? contextRealmServerURL,
+        options.compatRealmServerPort,
+      );
+    // `portReservation` is the holder for a port we freshly allocated here
+    // (only when no caller supplied a URL — e.g. the cache:prepare path).
+    // The caller's `internal.publicPortReservation`, when present, is the
+    // one that's actually held; we own only our own. Either way the build
+    // path's startIsolatedRealmStack releases the effective holder right
+    // before the compat proxy binds; we release our own at the early
+    // (cache-hit) and finally exits as an idempotent backstop.
+    let publicPortReservation =
+      internal.publicPortReservation ?? portReservation;
     let primaryRealmURL = realmURLWithinServer(realmServerURL, realms[0].path);
     let realmsHash = hashRealms(realms);
     let cacheKey = hashString(
@@ -163,6 +192,9 @@ export async function ensureFactoryRealmTemplate(
       hasTemplateDatabase &&
       cachedTemplateMetadata
     ) {
+      // No build, so nothing will consume the holder we allocated above —
+      // release it (a no-op when the caller owns it and we hold nothing).
+      await portReservation?.release().catch(() => undefined);
       return {
         cacheKey,
         templateDatabaseName,
@@ -211,6 +243,7 @@ export async function ensureFactoryRealmTemplate(
         context,
         cacheKey,
         templateDatabaseName,
+        publicPortReservation,
       });
       writePreparedTemplateMetadata({
         realmDir: realms[0].dir,
@@ -231,6 +264,10 @@ export async function ensureFactoryRealmTemplate(
     } finally {
       configureLogger(originalLogLevels);
       await withSilentConsole(async () => ownedSupport?.stop());
+      // Backstop for the holder we own: a no-op once startIsolatedRealmStack
+      // has released it before the compat-proxy bind, but covers a throw
+      // before the build reached that point.
+      await portReservation?.release().catch(() => undefined);
     }
   });
 }
@@ -297,10 +334,11 @@ export async function startFactoryRealmServer(
       existingContext && hasTemplateDatabaseName(existingContext)
         ? new URL(existingContext.realmServerURL)
         : undefined;
-    let realmServerURL = await resolveFactoryRealmServerURL(
-      options.realmServerURL ?? contextRealmServerURL,
-      options.compatRealmServerPort,
-    );
+    let { url: realmServerURL, portReservation: publicPortReservation } =
+      await resolveFactoryRealmServerURL(
+        options.realmServerURL ?? contextRealmServerURL,
+        options.compatRealmServerPort,
+      );
     let primaryRealmURL = realmURLWithinServer(
       realmServerURL,
       primaryRealm.path,
@@ -311,11 +349,17 @@ export async function startFactoryRealmServer(
     let ownedGlobalContext: FactoryGlobalContextHandle | undefined;
     let context = existingContext;
     if (!context) {
-      ownedGlobalContext = await startFactoryGlobalContext({
-        ...options,
-        realms,
-        realmServerURL,
-      });
+      // Hand the public-port holder to the template build so it's held
+      // across that build's port allocations and released right before its
+      // compat-proxy binds.
+      ownedGlobalContext = await startFactoryGlobalContext(
+        {
+          ...options,
+          realms,
+          realmServerURL,
+        },
+        { publicPortReservation },
+      );
       context = ownedGlobalContext.context;
     }
 
@@ -323,12 +367,15 @@ export async function startFactoryRealmServer(
       templateDatabaseName = hasTemplateDatabaseName(context)
         ? context.templateDatabaseName
         : (
-            await ensureFactoryRealmTemplate({
-              ...options,
-              realms,
-              realmServerURL,
-              context,
-            })
+            await ensureFactoryRealmTemplate(
+              {
+                ...options,
+                realms,
+                realmServerURL,
+                context,
+              },
+              { publicPortReservation },
+            )
           ).templateDatabaseName;
     }
 
@@ -380,6 +427,11 @@ export async function startFactoryRealmServer(
         }
       }
 
+      // The template build (above) already released this holder before its
+      // own compat-proxy bind; release again (idempotent) so the runtime
+      // stack's compat proxy can re-acquire the same public port via its
+      // own short-lived hold.
+      await publicPortReservation?.release().catch(() => undefined);
       stack = await startIsolatedRealmStack({
         realms,
         realmServerURL,
@@ -393,6 +445,10 @@ export async function startFactoryRealmServer(
       });
     } catch (error) {
       let cleanupError: unknown;
+
+      // Backstop: release the public-port holder if an error fired before it
+      // was handed off (idempotent — a no-op once already released).
+      await publicPortReservation?.release().catch(() => undefined);
 
       try {
         await dropDatabase(databaseName);

--- a/packages/realm-test-harness/src/api.ts
+++ b/packages/realm-test-harness/src/api.ts
@@ -163,13 +163,14 @@ export async function ensureFactoryRealmTemplate(
         options.realmServerURL ?? contextRealmServerURL,
         options.compatRealmServerPort,
       );
-    // `portReservation` is the holder for a port we freshly allocated here
-    // (only when no caller supplied a URL — e.g. the cache:prepare path).
-    // The caller's `internal.publicPortReservation`, when present, is the
-    // one that's actually held; we own only our own. Either way the build
-    // path's startIsolatedRealmStack releases the effective holder right
-    // before the compat proxy binds; we release our own at the early
-    // (cache-hit) and finally exits as an idempotent backstop.
+    // The effective public-port holder: the caller's delegated reservation
+    // when present, otherwise the one we freshly allocated above (e.g. the
+    // cache:prepare path). On the build path startIsolatedRealmStack
+    // releases it right before the compat proxy binds; we release it again
+    // at the early (cache-hit) and finally exits as an idempotent backstop.
+    // Releasing the *effective* holder (not just our own) matters when a
+    // caller delegates it but the build throws before startIsolatedRealmStack
+    // takes ownership — otherwise the delegated holder socket leaks.
     let publicPortReservation =
       internal.publicPortReservation ?? portReservation;
     let primaryRealmURL = realmURLWithinServer(realmServerURL, realms[0].path);
@@ -192,9 +193,9 @@ export async function ensureFactoryRealmTemplate(
       hasTemplateDatabase &&
       cachedTemplateMetadata
     ) {
-      // No build, so nothing will consume the holder we allocated above —
-      // release it (a no-op when the caller owns it and we hold nothing).
-      await portReservation?.release().catch(() => undefined);
+      // No build, so nothing downstream will consume the holder — release
+      // the effective one (our own or a caller's delegated reservation).
+      await publicPortReservation?.release().catch(() => undefined);
       return {
         cacheKey,
         templateDatabaseName,
@@ -264,10 +265,11 @@ export async function ensureFactoryRealmTemplate(
     } finally {
       configureLogger(originalLogLevels);
       await withSilentConsole(async () => ownedSupport?.stop());
-      // Backstop for the holder we own: a no-op once startIsolatedRealmStack
-      // has released it before the compat-proxy bind, but covers a throw
-      // before the build reached that point.
-      await portReservation?.release().catch(() => undefined);
+      // Backstop for the effective holder (our own or a caller's delegated
+      // reservation): a no-op once startIsolatedRealmStack has released it
+      // before the compat-proxy bind, but covers a throw before the build
+      // reached that point (e.g. a Postgres drop/clone failure).
+      await publicPortReservation?.release().catch(() => undefined);
     }
   });
 }

--- a/packages/realm-test-harness/src/database.ts
+++ b/packages/realm-test-harness/src/database.ts
@@ -14,6 +14,7 @@ import {
   templateLog,
   waitUntil,
   type FactorySupportContext,
+  type PortReservation,
   type RealmConfig,
   type RealmPermissions,
 } from './shared';
@@ -707,12 +708,20 @@ export async function buildCombinedTemplateDatabase({
   context,
   cacheKey,
   templateDatabaseName,
+  publicPortReservation,
 }: {
   realms: RealmConfig[];
   realmServerURL: URL;
   context: FactorySupportContext;
   cacheKey: string;
   templateDatabaseName: string;
+  /** Holder for the public realm-server port, allocated and held upstream
+   *  in `resolveFactoryRealmServerURL`. Threaded straight into
+   *  `startIsolatedRealmStack`, which releases it right before the compat
+   *  proxy binds. Keeping it held across this build keeps the
+   *  worker-manager hold below (and the support-service ports allocated
+   *  before this call) from being handed the public port number. */
+  publicPortReservation?: PortReservation;
 }): Promise<void> {
   if (realms.length === 0) {
     throw new Error(
@@ -787,6 +796,7 @@ export async function buildCombinedTemplateDatabase({
           migrateDB: !hasMigratedTemplate,
           fullIndexOnStartup: true,
           workerManagerPort: wmReservation,
+          publicPortReservation,
         });
       } catch (error) {
         progress.stop();

--- a/packages/realm-test-harness/src/index.ts
+++ b/packages/realm-test-harness/src/index.ts
@@ -22,6 +22,7 @@ export {
   buildServerToken,
   diagnosePortConflict,
   findAndHoldAvailablePort,
+  holdSpecificPort,
   isFactorySupportContext,
   type PortReservation,
 } from './shared';

--- a/packages/realm-test-harness/src/isolated-realm-stack.ts
+++ b/packages/realm-test-harness/src/isolated-realm-stack.ts
@@ -623,9 +623,10 @@ export async function startIsolatedRealmStack({
    *  upstream by `resolveFactoryRealmServerURL` and threaded down through
    *  the template build. We adopt it (so the sibling worker-manager /
    *  realm-server allocations below can't steal the number) and release it
-   *  immediately before the compat proxy binds. When omitted, the public
-   *  port came from a reused context, so we hold the specific number
-   *  ourselves. */
+   *  immediately before the compat proxy binds. Omitted whenever the public
+   *  port wasn't freshly allocated with a holder — a reused context, a
+   *  caller-supplied `realmServerURL`, or an explicit `compatRealmServerPort`
+   *  — in which case we hold the specific number ourselves. */
   publicPortReservation?: PortReservation;
 }): Promise<RunningFactoryStack> {
   if (realms.length === 0) {

--- a/packages/realm-test-harness/src/isolated-realm-stack.ts
+++ b/packages/realm-test-harness/src/isolated-realm-stack.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_REALM_LOG_LEVELS,
   diagnosePortConflict,
   findAndHoldAvailablePort,
+  holdSpecificPort,
   FIXTURE_REALM_SERVER_URL_PLACEHOLDER,
   FULL_INDEX_REALM_STARTUP_TIMEOUT_MS,
   INCLUDE_SKILLS,
@@ -430,7 +431,25 @@ export async function startCompatRealmProxy({
     },
   );
   await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
+    server.once('error', (error: NodeJS.ErrnoException) => {
+      // The public port is supposed to be held from the moment it was
+      // allocated until just before this bind. If it still collides, probe
+      // the contested port so the failed-job log names which interface/pid
+      // holds it instead of failing with an opaque EADDRINUSE.
+      if (error.code === 'EADDRINUSE') {
+        diagnosePortConflict(listenPort)
+          .catch(() => '')
+          .then((diagnostic) => {
+            realmLog.warn(
+              `startCompatRealmProxy: EADDRINUSE binding 127.0.0.1:${listenPort}` +
+                (diagnostic ? `\n${diagnostic}` : ''),
+            );
+            reject(error);
+          });
+        return;
+      }
+      reject(error);
+    });
     server.listen(listenPort, '127.0.0.1', () => resolve());
   });
   let address = server.address();
@@ -571,6 +590,7 @@ export async function startIsolatedRealmStack({
   realmServerPort: explicitRealmServerPort,
   prerenderURL: explicitPrerenderURL,
   noCompatProxy,
+  publicPortReservation: explicitPublicPortReservation,
 }: {
   realms: RealmConfig[];
   realmServerURL: URL;
@@ -599,6 +619,14 @@ export async function startIsolatedRealmStack({
    *  calls `setTargetPort` on it itself once the realm-server binds).
    *  The returned stack's `compatProxy` is `undefined` in that case. */
   noCompatProxy?: boolean;
+  /** Holder for the public (compat-proxy) port, freshly allocated and held
+   *  upstream by `resolveFactoryRealmServerURL` and threaded down through
+   *  the template build. We adopt it (so the sibling worker-manager /
+   *  realm-server allocations below can't steal the number) and release it
+   *  immediately before the compat proxy binds. When omitted, the public
+   *  port came from a reused context, so we hold the specific number
+   *  ourselves. */
+  publicPortReservation?: PortReservation;
 }): Promise<RunningFactoryStack> {
   if (realms.length === 0) {
     throw new Error('startIsolatedRealmStack requires at least one realm');
@@ -607,28 +635,59 @@ export async function startIsolatedRealmStack({
   let workerManagerMetadataFile = join(rootDir, 'worker-manager.runtime.json');
   let realmServerMetadataFile = join(rootDir, 'realm-server.runtime.json');
 
+  // Hold the public (compat-proxy) port BEFORE allocating the
+  // worker-manager / realm-server child ports below. Those allocations ask
+  // the OS for an ephemeral port-0, and the public port — chosen earlier in
+  // resolveFactoryRealmServerURL — is fair game for the allocator unless
+  // something keeps it bound. Without this hold a sibling allocation can be
+  // handed the public port number and bind it first, so the compat-proxy
+  // bind further down dies with EADDRINUSE. Adopt the caller's reservation
+  // when they freshly allocated and held it upstream; otherwise the port
+  // came from a reused context, so hold the specific number ourselves.
+  // Released right before the compat proxy binds it (mirrors the
+  // worker-manager release-before-spawn handoff). Skipped entirely under
+  // noCompatProxy, where the caller owns the proxy out-of-band.
+  let compatPortHold: PortReservation | undefined;
+  if (noCompatProxy) {
+    // We won't bind the public port here; release any caller-held holder so
+    // it doesn't leak until process exit.
+    await explicitPublicPortReservation?.release().catch(() => {});
+  } else if (explicitPublicPortReservation) {
+    compatPortHold = explicitPublicPortReservation;
+  } else {
+    compatPortHold = await holdSpecificPort(Number(realmServerURL.port));
+  }
+
   // Hold the worker-manager and realm-server ports across the (multi-second)
   // gap between allocation and actual child bind. Without the hold, sibling
   // findAvailablePort() calls inside this same process — for the prerender
   // server, host serve, etc — can be handed back the same port number by
   // the OS port-0 allocator, and the child process eventually races us and
   // dies with EADDRINUSE.
-  let workerManagerPortInfo = await resolvePortReservation(
-    explicitWorkerManagerPort,
-  );
+  let workerManagerPortInfo: ResolvedPortReservation;
+  try {
+    workerManagerPortInfo = await resolvePortReservation(
+      explicitWorkerManagerPort,
+    );
+  } catch (error) {
+    await compatPortHold?.release().catch(() => {});
+    throw error;
+  }
   let realmServerPortInfo: ResolvedPortReservation;
   try {
     realmServerPortInfo = await resolvePortReservation(explicitRealmServerPort);
   } catch (error) {
     await workerManagerPortInfo.releaseHolder();
+    await compatPortHold?.release().catch(() => {});
     throw error;
   }
   let actualWorkerManagerPort = workerManagerPortInfo.port;
   let actualRealmServerPort = realmServerPortInfo.port;
-  // From this point on, any thrown error must release both port holders so
+  // From this point on, any thrown error must release all port holders so
   // they don't leak until process exit. The releases are idempotent: the
-  // happy path releases each holder just before its respective child is
-  // spawned, and the cleanup below is a no-op for already-released holders.
+  // happy path releases each holder just before its respective child binds
+  // (or, for the public port, just before the compat proxy listens), and
+  // the cleanup below is a no-op for already-released holders.
   let releaseHoldersOnFailure = async () => {
     try {
       await workerManagerPortInfo.releaseHolder();
@@ -637,6 +696,11 @@ export async function startIsolatedRealmStack({
     }
     try {
       await realmServerPortInfo.releaseHolder();
+    } catch {
+      // best effort
+    }
+    try {
+      await compatPortHold?.release();
     } catch {
       // best effort
     }
@@ -692,11 +756,18 @@ export async function startIsolatedRealmStack({
         username,
       });
     }
-    let compatProxy = noCompatProxy
-      ? undefined
-      : await startCompatRealmProxy({
-          listenPort: Number(realmServerURL.port),
-        });
+    let compatProxy: StartedCompatRealmProxy | undefined;
+    if (noCompatProxy) {
+      compatProxy = undefined;
+    } else {
+      // Release the holder the instant before the proxy binds the same
+      // port. Nothing else allocates a port between here and the bind, so
+      // the OS can't re-hand the number in this window.
+      await compatPortHold?.release();
+      compatProxy = await startCompatRealmProxy({
+        listenPort: Number(realmServerURL.port),
+      });
+    }
     // The software-factory Playwright harness can keep prerender alive for the
     // lifetime of a Playwright testWorker even though the realm stack itself is
     // recreated per test. When provided, reuse that long-lived prerender URL so

--- a/packages/realm-test-harness/src/shared.ts
+++ b/packages/realm-test-harness/src/shared.ts
@@ -483,23 +483,99 @@ export async function findAndHoldAvailablePort(): Promise<PortReservation> {
   });
 }
 
+/**
+ * Hold a *specific* port (rather than an OS-chosen one) with a holder
+ * socket, so a known port the harness is about to bind can't be handed to a
+ * sibling `findAndHoldAvailablePort()` in the gap before the real bind.
+ * Mirrors `findAndHoldAvailablePort` but for a port the caller already
+ * committed to (e.g. the public realm-server port baked into a reused
+ * FactoryTestContext). Binds the dual-stack wildcard for the same reason
+ * `findAndHoldAvailablePort` does — so the hold covers every interface the
+ * eventual bind might use. Rejects when the port is already taken, with a
+ * port-conflict probe appended to the error so the collision surfaces
+ * immediately and names its holder rather than failing opaquely later.
+ */
+export async function holdSpecificPort(port: number): Promise<PortReservation> {
+  return await new Promise<PortReservation>((resolveOuter, rejectOuter) => {
+    let server = createNetServer((socket) => socket.destroy());
+    let onError = (error: NodeJS.ErrnoException) => {
+      server.close();
+      if (error.code === 'EADDRINUSE') {
+        diagnosePortConflict(port)
+          .catch(() => '')
+          .then((diagnostic) => {
+            if (diagnostic) {
+              error.message = `${error.message}\n${diagnostic}`;
+            }
+            rejectOuter(error);
+          });
+        return;
+      }
+      rejectOuter(error);
+    };
+    server.once('error', onError);
+    server.listen(port, () => {
+      server.off('error', onError);
+      // Swallow late errors after a successful bind so they don't surface
+      // as unhandled 'error' events.
+      server.on('error', () => {});
+      let released = false;
+      resolveOuter({
+        port,
+        release: () =>
+          new Promise<void>((resolveClose, rejectClose) => {
+            if (released) {
+              resolveClose();
+              return;
+            }
+            released = true;
+            server.close((closeError) => {
+              if (closeError) {
+                rejectClose(closeError);
+              } else {
+                resolveClose();
+              }
+            });
+          }),
+      });
+    });
+  });
+}
+
+/**
+ * Resolve the public-facing realm-server URL the harness exposes — the port
+ * the in-stack compat proxy binds. When the port is freshly allocated here,
+ * the returned `portReservation` keeps a holder socket bound to it. Hold it
+ * across the gap between this allocation and the compat-proxy bind deep
+ * inside `startIsolatedRealmStack`, then release it right before the proxy
+ * listens. Without the hold, the sibling `findAndHoldAvailablePort()`
+ * allocations made in between (support services, worker-manager,
+ * realm-server child, prerender) can be handed this same port number by the
+ * OS port-0 allocator and bind it first, so the compat-proxy bind dies with
+ * EADDRINUSE. `portReservation` is `undefined` for a caller-supplied or
+ * pre-configured URL/port — the caller owns those.
+ */
 export async function resolveFactoryRealmServerURL(
   realmServerURL?: URL,
   compatRealmServerPort?: number,
-): Promise<URL> {
+): Promise<{ url: URL; portReservation?: PortReservation }> {
   if (realmServerURL) {
-    return new URL(realmServerURL.href);
+    return { url: new URL(realmServerURL.href) };
   }
 
   if (CONFIGURED_REALM_SERVER_URL) {
-    return new URL(CONFIGURED_REALM_SERVER_URL.href);
+    return { url: new URL(CONFIGURED_REALM_SERVER_URL.href) };
   }
 
-  let port =
-    compatRealmServerPort && compatRealmServerPort !== 0
-      ? compatRealmServerPort
-      : await findAvailablePort();
-  return new URL(`http://localhost:${port}/`);
+  if (compatRealmServerPort && compatRealmServerPort !== 0) {
+    return { url: new URL(`http://localhost:${compatRealmServerPort}/`) };
+  }
+
+  let portReservation = await findAndHoldAvailablePort();
+  return {
+    url: new URL(`http://localhost:${portReservation.port}/`),
+    portReservation,
+  };
 }
 
 export function baseRealmURLFor(realmServerURL: URL): URL {

--- a/packages/realm-test-harness/src/shared.ts
+++ b/packages/realm-test-harness/src/shared.ts
@@ -499,7 +499,14 @@ export async function holdSpecificPort(port: number): Promise<PortReservation> {
   return await new Promise<PortReservation>((resolveOuter, rejectOuter) => {
     let server = createNetServer((socket) => socket.destroy());
     let onError = (error: NodeJS.ErrnoException) => {
-      server.close();
+      // The bind failed, so the server never listened — close() hits the
+      // not-running case. Guard it so a synchronous throw here can't strand
+      // the outer promise without settling it.
+      try {
+        server.close();
+      } catch {
+        // never listened — nothing to close
+      }
       if (error.code === 'EADDRINUSE') {
         diagnosePortConflict(port)
           .catch(() => '')
@@ -519,9 +526,16 @@ export async function holdSpecificPort(port: number): Promise<PortReservation> {
       // Swallow late errors after a successful bind so they don't surface
       // as unhandled 'error' events.
       server.on('error', () => {});
+      // Report the actually-bound port. For a concrete non-zero port that's
+      // the requested number; if a caller ever passes 0, listen() picks an
+      // ephemeral port and this reports the real one instead of a misleading
+      // 0.
+      let address = server.address();
+      let boundPort =
+        address && typeof address !== 'string' ? address.port : port;
       let released = false;
       resolveOuter({
-        port,
+        port: boundPort,
         release: () =>
           new Promise<void>((resolveClose, rejectClose) => {
             if (released) {

--- a/packages/software-factory/tests/hold-specific-port.test.ts
+++ b/packages/software-factory/tests/hold-specific-port.test.ts
@@ -1,0 +1,126 @@
+import { createServer } from 'node:net';
+import { module, test } from 'qunit';
+
+import {
+  findAndHoldAvailablePort,
+  holdSpecificPort,
+} from '@cardstack/realm-test-harness';
+
+async function bindOn(port: number): Promise<{
+  ok: boolean;
+  code?: string;
+  close: () => Promise<void>;
+}> {
+  return await new Promise((resolve) => {
+    let s = createServer();
+    s.once('error', (err: NodeJS.ErrnoException) =>
+      resolve({
+        ok: false,
+        code: err.code,
+        close: async () => {},
+      }),
+    );
+    s.listen(port, () => {
+      resolve({
+        ok: true,
+        close: () =>
+          new Promise<void>((resolveClose) => s.close(() => resolveClose())),
+      });
+    });
+  });
+}
+
+module('holdSpecificPort', function () {
+  test('holds exactly the requested port', async function (assert) {
+    // Pick a known-free port via the OS, release it, then re-acquire that
+    // exact number — the scenario where a public port chosen earlier needs
+    // to be re-held across a runtime restart.
+    let probe = await findAndHoldAvailablePort();
+    let port = probe.port;
+    await probe.release();
+
+    let reservation = await holdSpecificPort(port);
+    try {
+      assert.strictEqual(reservation.port, port, 'holds the requested port');
+      let attempt = await bindOn(port);
+      assert.false(attempt.ok, `port ${port} bind attempt fails while held`);
+      assert.strictEqual(attempt.code, 'EADDRINUSE', 'reports EADDRINUSE');
+    } finally {
+      await reservation.release();
+    }
+  });
+
+  test('release frees the port and is idempotent', async function (assert) {
+    let probe = await findAndHoldAvailablePort();
+    let port = probe.port;
+    await probe.release();
+
+    let reservation = await holdSpecificPort(port);
+    await reservation.release();
+    // Second release must not throw.
+    await reservation.release();
+
+    let attempt = await bindOn(port);
+    assert.true(attempt.ok, `port ${port} is free after release`);
+    await attempt.close();
+  });
+
+  test('rejects with a port-conflict probe when the port is already taken', async function (assert) {
+    // The fail-fast path: if the public port was stolen before we could
+    // hold it, surface the collision immediately with the holder's identity
+    // rather than as an opaque late EADDRINUSE on the compat-proxy bind.
+    let probe = await findAndHoldAvailablePort();
+    let port = probe.port;
+    await probe.release();
+
+    let occupier = await bindOn(port);
+    assert.true(occupier.ok, 'occupier bound the port first');
+    try {
+      let error: NodeJS.ErrnoException | undefined;
+      try {
+        let reservation = await holdSpecificPort(port);
+        await reservation.release();
+      } catch (e) {
+        error = e as NodeJS.ErrnoException;
+      }
+      assert.ok(error, 'holdSpecificPort rejected on a taken port');
+      assert.strictEqual(error?.code, 'EADDRINUSE', 'error is EADDRINUSE');
+      assert.ok(
+        error?.message.includes('port-conflict probe'),
+        'error message carries the diagnostic probe',
+      );
+    } finally {
+      await occupier.close();
+    }
+  });
+
+  test('a held specific port is not handed to a sibling allocator', async function (assert) {
+    // The core invariant the fix relies on: while the public port is held
+    // here, the sibling findAndHoldAvailablePort() calls (worker-manager,
+    // realm-server child, prerender) the harness makes before the
+    // compat-proxy bind must never be handed this number back.
+    let probe = await findAndHoldAvailablePort();
+    let port = probe.port;
+    await probe.release();
+
+    let held = await holdSpecificPort(port);
+    try {
+      let siblings = await Promise.all(
+        Array.from({ length: 16 }, () => findAndHoldAvailablePort()),
+      );
+      try {
+        for (let sibling of siblings) {
+          assert.notStrictEqual(
+            sibling.port,
+            port,
+            `sibling allocation ${sibling.port} avoided the held port ${port}`,
+          );
+        }
+      } finally {
+        await Promise.allSettled(siblings.map((s) => s.release()));
+      }
+    } finally {
+      await held.release();
+    }
+  });
+});


### PR DESCRIPTION
The software-factory test harness intermittently fails to start with `EADDRINUSE` on its public realm-server port — e.g. [this run](https://github.com/cardstack/boxel/actions/runs/27002941407/job/79687500665?pr=5128), where `buildCombinedTemplateDatabase` died with `listen EADDRINUSE: address already in use 127.0.0.1:43569`.

## Cause

The harness exposes a fixed public (compat-proxy) realm-server port that tests connect to. That port was allocated with the non-holding `findAvailablePort()`: it probe-binds an ephemeral port, closes the probe, and returns the bare number — leaving the port free until the in-stack compat proxy binds it much later. Between those two moments the harness makes several *holding* `findAndHoldAvailablePort()` allocations (support services, worker-manager, realm-server child, prerender). The OS port-0 allocator can legitimately hand one of them the public port's number, and it binds first — so the compat-proxy bind dies with `EADDRINUSE`. Every other harness port was already converted to the hold-across-the-gap pattern; the public port was the last one still on the racy path.

## Fix

`resolveFactoryRealmServerURL` now holds the freshly-allocated public port with a holder socket and returns the reservation. The reservation is threaded through the template build into `startIsolatedRealmStack`, which adopts it and releases it the instant before the compat proxy binds — the same release-before-bind handoff the worker-manager and realm-server ports already use. When the public port is inherited from a reused context (no upstream holder), `startIsolatedRealmStack` holds the specific number itself via the new `holdSpecificPort()`.

## If it ever recurs

`holdSpecificPort()` and the compat-proxy bind both run `diagnosePortConflict()` on `EADDRINUSE`, so a residual collision lands in the failed-job log naming the interface/pid that holds the port instead of an opaque error.

## Tests

Unit tests in `hold-specific-port.test.ts` cover the holder, idempotent release, the fail-fast-with-probe path, and the core invariant that a held specific port is never handed to a sibling `findAndHoldAvailablePort()`. The realm-bench and software-factory CI jobs exercise the harness-bootstrap path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
