### PR TITLE
fix(boxel-cli): serve a stub icon module so self-contained boxel test loads cards

### DIFF
--- a/packages/boxel-cli/src/commands/test.ts
+++ b/packages/boxel-cli/src/commands/test.ts
@@ -19,6 +19,59 @@ import { readdirSync } from 'node:fs';
 import { sep } from 'node:path';
 import { transpileJS } from '@cardstack/runtime-common/transpile';
 
+// The host rewrites every bare `@cardstack/boxel-icons/<name>` import to
+// a module fetch against `iconsURL`, which the bundled host config points
+// at the monorepo's boxel-icons dev server (localhost:4206) — not running
+// in a self-contained `boxel test`. We intercept those fetches in the
+// browser (see `page.route` in `runQunitInBrowser`) and answer every one
+// with this single stub: every real icon module is structurally the same,
+// a template-only component rendering an SVG as its default export.
+//
+// This is a deliberate tradeoff, not a shortcut to revisit later. The real
+// icons dist is ~6,300 modules; we intentionally do not ship it purely so
+// headless tests can run. The cost is that `boxel test` can't see real
+// glyphs — every icon renders as this one placeholder, so a test can't
+// meaningfully assert on a specific icon, and a card with a wrong or
+// missing icon still passes locally. That's acceptable here: the suite
+// exercises card logic and templates, not glyphs, and base modules only
+// need the icon import to *resolve* so they load (card-api's field icons,
+// the card-info `NameIcon`, the `link-off` a `linksTo` field pulls in).
+// Same "stub, don't bundle" tack `scripts/build-types.ts` takes for the
+// `parse` side's `@cardstack/boxel-icons/*` ambient `any` shim. The SVG
+// mirrors boxel-icons' `error-404` glyph.
+const ICON_STUB_GTS = `const IconComponent = <template>
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    width='24'
+    height='24'
+    fill='none'
+    stroke='currentColor'
+    stroke-linecap='round'
+    stroke-linejoin='round'
+    stroke-width='2'
+    viewBox='0 0 24 24'
+    ...attributes
+  ><path stroke='none' d='M0 0h24v24H0z' /><path
+      d='M3 8v3a1 1 0 0 0 1 1h3M7 8v8M17 8v3a1 1 0 0 0 1 1h3M21 8v8M10 10v4a2 2 0 1 0 4 0v-4a2 2 0 1 0-4 0'
+    /></svg>
+</template>;
+export default IconComponent;
+`;
+
+let iconStubModule: Promise<string> | undefined;
+
+// Compiled once and reused for every icon request; the output is
+// identical regardless of which icon name was requested.
+export function getIconStubModule(): Promise<string> {
+  if (!iconStubModule) {
+    iconStubModule = transpileJS(
+      ICON_STUB_GTS,
+      '/@cardstack/boxel-icons/v1/icons/icon-stub.gts',
+    );
+  }
+  return iconStubModule;
+}
+
 // `@playwright/test` ships as a runtime dependency (it has to, since
 // `boxel test` drives chromium) but it's marked external in our
 // esbuild config — it bundles native binaries that esbuild can't
@@ -439,6 +492,25 @@ async function runQunitInBrowser(options: QunitRunnerOptions): Promise<{
         process.stderr.write(`[browser pageerror] ${err.message}\n`);
       });
     }
+
+    // Fulfill every boxel-icons module fetch with the stub, regardless of
+    // where the baked `iconsURL` points (it's the never-running monorepo
+    // dev server). Intercepting here covers both local and `--realm` mode
+    // without touching the host config or the asset server.
+    //
+    // `iconsURL` is a different origin from the QUnit page (localhost:4206
+    // vs the 127.0.0.1 asset server), so the loader's cross-origin module
+    // fetch needs CORS — match the asset server's own responses, which all
+    // send `Access-Control-Allow-Origin: *`.
+    let iconStub = await getIconStubModule();
+    await page.route('**/@cardstack/boxel-icons/v1/icons/*.js', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        headers: { 'Access-Control-Allow-Origin': '*' },
+        body: iconStub,
+      }),
+    );
 
     // Realm-server auth only applies in remote mode — the local module
     // mounts on this same server don't gate on tokens.

--- a/packages/boxel-cli/tests/commands/icon-stub.test.ts
+++ b/packages/boxel-cli/tests/commands/icon-stub.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+
+import { getIconStubModule } from '../../src/commands/test.js';
+
+// `boxel test` serves this stub for every
+// `/@cardstack/boxel-icons/v1/icons/<name>.js` request so base modules
+// load without the monorepo's boxel-icons dev server (CS-11376). If the
+// stub stops compiling to a valid component module, every CardDef render
+// breaks at module-load time, so guard the compiled shape here rather
+// than only catching it in a full browser run.
+describe('getIconStubModule', () => {
+  it('compiles to a module with a default export', async () => {
+    let mod = await getIconStubModule();
+    expect(mod.length).toBeGreaterThan(0);
+    expect(mod).toMatch(/default/);
+  });
+
+  it('compiles the glimmer template (not raw <template> source)', async () => {
+    let mod = await getIconStubModule();
+    // content-tag + the ember template plugin turn `<template>` into a
+    // precompiled template; the raw tag must not survive into the output.
+    expect(mod).not.toContain('<template>');
+    expect(mod).toMatch(/setComponentTemplate|template-factory|precompile/);
+  });
+
+  it('caches: repeat calls return the same Promise (no recompile)', () => {
+    // Compare Promise identity, not the resolved strings — two separate
+    // compilations would produce equal strings and pass a value check,
+    // so that wouldn't prove the result is cached.
+    expect(getIconStubModule()).toBe(getIconStubModule());
+  });
+});


### PR DESCRIPTION
_(Written by Claude on Matic's behalf.)_

Closes [CS-11376](https://linear.app/cardstack/issue/CS-11376/boxel-test-bundled-harness-cant-load-icons-iconsurl-hardcoded-to).

## TL;DR

Self-contained `boxel test` couldn't render any card — icons failed to load and took every `CardDef` render down with them. This stubs out icon fetches in the test browser so cards load, **without bundling the icons** into the CLI.

**The one decision to sign off on:** we intentionally do *not* ship the icons dist (~6,300 modules) just so tests can run. The price is that `boxel test` can't verify real glyphs. See [Why stub, not bundle](#why-stub-not-bundle).

**Where to look:** `packages/boxel-cli/src/commands/test.ts` — the `page.route(...)` block in `runQunitInBrowser` (~15 lines + the stub constant). Everything else is the comment explaining the tradeoff and a unit test.

---

## Why this breaks

Cards don't import icons by path — the host rewrites every bare `@cardstack/boxel-icons/<name>` import to a module fetch against `config.iconsURL`. Icons are a first-class part of the card type system: `card-api` gives fields a `static icon`, the `card-info` template renders a `NameIcon`, and a `linksTo` field pulls in `link-off`. So **every** CardDef render depends on these modules resolving at load time.

The bundled host config bakes `iconsURL = http://localhost:4206` (the monorepo's boxel-icons dev server). A published CLI never starts that server and ships no icons, so the fetch fails with `ERR_CONNECTION_REFUSED` and the module — and the whole render — dies.

## The fix

Intercept the fetches in the Playwright page and answer them ourselves:

```js
let iconStub = await getIconStubModule();
await page.route('**/@cardstack/boxel-icons/v1/icons/*.js', (route) =>
  route.fulfill({ status: 200, contentType: 'application/javascript', body: iconStub }));
```

Every real icon module is structurally identical — a template-only component rendering an SVG as its `default` export — so **one stub satisfies all names**. The stub is compiled once from a tiny `<template>` SVG through the host's existing `transpileJS`.

Intercepting at the browser layer means the baked `iconsURL` is simply never contacted, so this covers both local and `--realm` mode with no host-config or asset-server changes.

## <a name="why-stub-not-bundle"></a>Why stub, not bundle

The icons dist is ~6,300 files / ~12 MB. Bundling it would make `boxel test` faithful (real glyphs render, tests could assert on icons) but bloats the published package purely to satisfy a test harness.

We stub instead, and accept the tradeoff: **`boxel test` can't see real icons.** Every icon renders as one placeholder, so a test can't meaningfully assert on a specific icon, and a card with a wrong/missing icon still passes locally. That's fine for this suite — it exercises card logic and templates, not glyphs — and base modules only need the import to *resolve* so they load.

This mirrors the precedent already in this package: `scripts/build-types.ts` stubs `@cardstack/boxel-icons/*` to an ambient `any` for the `parse` side rather than shipping ~50 MB of icon `.d.ts`.

## Verification

| Check | Result |
|---|---|
| `eslint` + `tsc --noEmit` | clean |
| New `tests/commands/icon-stub.test.ts` (stub compiles, template precompiled, cached) | pass |
| Full boxel-cli unit suite | 293/293 |
| **End-to-end**: `boxel test` on a fresh `CardDef` + `linksTo` + render-test workspace, nothing on `4206` | `passed` (was `ERR_CONNECTION_REFUSED`) |
| `--realm` mode | not live-tested — same interception path, needs a remote realm + auth |

## Footprint

One source file + one test. **Zero bundled bytes** — no `bundled-icons/`, no build-script change, no new published files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)