### PR TITLE
Add virtual network access in templates for `MarkdownField`

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -11,6 +11,7 @@ import {
 import {
   getBoxComponent,
   type BoxComponent,
+  CardContextConsumer,
   CardCrudFunctionsConsumer,
   DefaultFormatsConsumer,
 } from './field-component';
@@ -2858,12 +2859,26 @@ export class MarkdownField extends StringField {
   static embedded = class MarkdownViewTemplate extends Component<
     typeof MarkdownField
   > {
-    <template><MarkdownTemplate @content={{@model}} /></template>
+    <template>
+      <CardContextConsumer as |context|>
+        <MarkdownTemplate
+          @content={{@model}}
+          @cardReferenceVirtualNetwork={{context.store.virtualNetwork}}
+        />
+      </CardContextConsumer>
+    </template>
   };
   static atom = class MarkdownViewTemplate extends Component<
     typeof MarkdownField
   > {
-    <template><MarkdownTemplate @content={{@model}} /></template>
+    <template>
+      <CardContextConsumer as |context|>
+        <MarkdownTemplate
+          @content={{@model}}
+          @cardReferenceVirtualNetwork={{context.store.virtualNetwork}}
+        />
+      </CardContextConsumer>
+    </template>
   };
 
   static edit = class Edit extends Component<typeof this> {

--- a/packages/base/default-templates/markdown.gts
+++ b/packages/base/default-templates/markdown.gts
@@ -67,21 +67,12 @@ interface RenderSlot {
 function resolveUrl(
   raw: string,
   baseUrl: string | null | undefined,
-  virtualNetwork: VirtualNetwork | undefined,
+  virtualNetwork: VirtualNetwork,
 ): string {
-  // With a VN, resolve through it so prefix-form bases and registered
-  // prefix-form refs round-trip correctly. Without a VN, plain
-  // `new URL(raw, baseUrl)` still handles the common case — URL-form
-  // refs (with or without a base) and relative refs against a URL-form
-  // base. Prefix-form bases need a VN; `new URL()` throws on those and
-  // we fall back to the raw ref.
   try {
-    if (virtualNetwork) {
-      return trimJsonExtension(
-        virtualNetwork.resolveURL(raw, baseUrl || undefined).href,
-      );
-    }
-    return trimJsonExtension(new URL(raw, baseUrl || undefined).href);
+    return trimJsonExtension(
+      virtualNetwork.resolveURL(raw, baseUrl || undefined).href,
+    );
   } catch {
     return trimJsonExtension(raw);
   }
@@ -92,7 +83,7 @@ export default class MarkDownTemplate extends GlimmerComponent<{
     content: string | null | undefined;
     linkedCards?: CardDef[] | null;
     cardReferenceBaseUrl?: string | null;
-    cardReferenceVirtualNetwork?: VirtualNetwork;
+    cardReferenceVirtualNetwork: VirtualNetwork;
   };
 }> {
   @tracked monacoContextInternal: any = undefined;

--- a/packages/base/markdown-file-def.gts
+++ b/packages/base/markdown-file-def.gts
@@ -130,6 +130,17 @@ class Isolated extends Component<typeof MarkdownDef> {
     return Boolean(this.args.model?.content?.trim());
   }
 
+  get virtualNetwork(): VirtualNetwork {
+    // Detached models (no store-attached VN) fall back to an empty VN
+    // so MarkdownTemplate's required cardReferenceVirtualNetwork is
+    // satisfied; prefix-form refs in such contexts just won't resolve
+    // since there are no realm mappings.
+    return (
+      (this.args.model ? virtualNetworkFor(this.args.model) : undefined) ??
+      new VirtualNetwork()
+    );
+  }
+
   <template>
     <article class='markdown-isolated' data-test-markdown-isolated>
       {{#if this.hasContent}}
@@ -137,6 +148,7 @@ class Isolated extends Component<typeof MarkdownDef> {
           @content={{this.content}}
           @linkedCards={{@model.linkedCards}}
           @cardReferenceBaseUrl={{@model.id}}
+          @cardReferenceVirtualNetwork={{this.virtualNetwork}}
         />
       {{else}}
         <header class='markdown-isolated__title'>{{this.title}}</header>
@@ -189,6 +201,17 @@ class Embedded extends Component<typeof MarkdownDef> {
     return headingText === this.title;
   }
 
+  get virtualNetwork(): VirtualNetwork {
+    // Detached models (no store-attached VN) fall back to an empty VN
+    // so MarkdownTemplate's required cardReferenceVirtualNetwork is
+    // satisfied; prefix-form refs in such contexts just won't resolve
+    // since there are no realm mappings.
+    return (
+      (this.args.model ? virtualNetworkFor(this.args.model) : undefined) ??
+      new VirtualNetwork()
+    );
+  }
+
   <template>
     <article class='markdown-embedded' data-test-markdown-embedded>
       {{#unless this.contentStartsWithTitle}}
@@ -199,6 +222,7 @@ class Embedded extends Component<typeof MarkdownDef> {
           @content={{this.content}}
           @linkedCards={{@model.linkedCards}}
           @cardReferenceBaseUrl={{@model.id}}
+          @cardReferenceVirtualNetwork={{this.virtualNetwork}}
         />
       </div>
     </article>

--- a/packages/base/rich-markdown.gts
+++ b/packages/base/rich-markdown.gts
@@ -83,8 +83,15 @@ export class RichMarkdownField extends FieldDef {
     get content() {
       return this.args.model?.content ?? null;
     }
-    get virtualNetwork() {
-      return this.args.model ? virtualNetworkFor(this.args.model) : undefined;
+    get virtualNetwork(): VirtualNetwork {
+      // Detached models (no store-attached VN) fall back to an empty VN
+      // so MarkdownTemplate's required cardReferenceVirtualNetwork is
+      // satisfied; prefix-form refs in such contexts just won't resolve
+      // since there are no realm mappings.
+      return (
+        (this.args.model ? virtualNetworkFor(this.args.model) : undefined) ??
+        new VirtualNetwork()
+      );
     }
     get baseUrl(): string | null {
       let model = this.args.model;
@@ -110,8 +117,15 @@ export class RichMarkdownField extends FieldDef {
     get content() {
       return this.args.model?.content ?? null;
     }
-    get virtualNetwork() {
-      return this.args.model ? virtualNetworkFor(this.args.model) : undefined;
+    get virtualNetwork(): VirtualNetwork {
+      // Detached models (no store-attached VN) fall back to an empty VN
+      // so MarkdownTemplate's required cardReferenceVirtualNetwork is
+      // satisfied; prefix-form refs in such contexts just won't resolve
+      // since there are no realm mappings.
+      return (
+        (this.args.model ? virtualNetworkFor(this.args.model) : undefined) ??
+        new VirtualNetwork()
+      );
     }
     get baseUrl(): string | null {
       let model = this.args.model;
@@ -155,8 +169,15 @@ export class RichMarkdownField extends FieldDef {
     updateContent = (markdown: string) => {
       this.args.model.content = markdown;
     };
-    get virtualNetwork() {
-      return this.args.model ? virtualNetworkFor(this.args.model) : undefined;
+    get virtualNetwork(): VirtualNetwork {
+      // Detached models (no store-attached VN) fall back to an empty VN
+      // so MarkdownTemplate's required cardReferenceVirtualNetwork is
+      // satisfied; prefix-form refs in such contexts just won't resolve
+      // since there are no realm mappings.
+      return (
+        (this.args.model ? virtualNetworkFor(this.args.model) : undefined) ??
+        new VirtualNetwork()
+      );
     }
     get baseUrl(): string | null {
       let model = this.args.model;

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -302,6 +302,10 @@ export default class StoreService extends Service implements StoreInterface {
     });
   }
 
+  get virtualNetwork() {
+    return this.network.virtualNetwork;
+  }
+
   protected renderContextBlocksPersistence() {
     return (
       this.isRenderStore && Boolean((globalThis as any).__boxelRenderContext)

--- a/packages/host/tests/integration/components/markdown-field-test.gts
+++ b/packages/host/tests/integration/components/markdown-field-test.gts
@@ -1,0 +1,141 @@
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  PermissionsContextName,
+  type Permissions,
+  baseRealm,
+} from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import {
+  provideConsumeContext,
+  setupCardLogs,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+} from '../../helpers';
+import {
+  setupBaseRealm,
+  CardDef,
+  Component,
+  MarkdownField,
+  contains,
+  field,
+} from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { renderCard } from '../../helpers/render-component';
+import { setupRenderingTest } from '../../helpers/setup';
+
+let loader: Loader;
+
+module('Integration | MarkdownField', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks);
+
+  setupBaseRealm(hooks);
+
+  hooks.beforeEach(function (this: RenderingTestContext) {
+    let permissions: Permissions = {
+      canWrite: true,
+      canRead: true,
+    };
+    provideConsumeContext(PermissionsContextName, permissions);
+    loader = getService('loader-service').loader;
+  });
+  setupLocalIndexing(hooks);
+
+  setupCardLogs(
+    hooks,
+    async () => await loader.import(`${baseRealm.url}card-api`),
+  );
+
+  test('embedded renders inline :card references as BFM elements for URL-form refs', async function (assert) {
+    class TestCard extends CardDef {
+      @field body = contains(MarkdownField);
+      static embedded = class Embedded extends Component<typeof this> {
+        <template><@fields.body /></template>
+      };
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'test-card.gts': { TestCard },
+      },
+    });
+
+    let card = new TestCard({
+      body: 'See :card[https://example.com/cards/1] for details.',
+    });
+    let root = await renderCard(loader, card, 'embedded');
+    assert
+      .dom(root.querySelector('[data-boxel-bfm-inline-ref]'))
+      .exists('inline card reference is rendered as BFM element');
+    assert
+      .dom(root.querySelector('[data-boxel-bfm-inline-ref]'))
+      .hasAttribute('data-boxel-bfm-inline-ref', 'https://example.com/cards/1');
+  });
+
+  test('embedded renders inline :card references for prefix-form refs without crashing', async function (assert) {
+    // Regression test for the CardContextConsumer plumbing in
+    // MarkdownField.embedded. Before VN was threaded through the field
+    // default, prefix-form refs in MarkdownField content couldn't be
+    // resolved at all (no VN reached the resolveUrl helper); with VN
+    // required at the MarkdownTemplate boundary, this render would
+    // throw if the consumer plumbing weren't in place.
+    class TestCard extends CardDef {
+      @field body = contains(MarkdownField);
+      static embedded = class Embedded extends Component<typeof this> {
+        <template><@fields.body /></template>
+      };
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'test-card.gts': { TestCard },
+      },
+    });
+
+    let card = new TestCard({
+      body: 'See :card[@cardstack/catalog/Card/foo] for details.',
+    });
+    let root = await renderCard(loader, card, 'embedded');
+    assert
+      .dom(root.querySelector('[data-boxel-bfm-inline-ref]'))
+      .exists('prefix-form card reference renders as BFM element');
+    assert
+      .dom(root.querySelector('[data-boxel-bfm-inline-ref]'))
+      .hasAttribute('data-boxel-bfm-inline-ref', '@cardstack/catalog/Card/foo');
+  });
+
+  test('atom renders inline :card references as BFM elements', async function (assert) {
+    class TestCard extends CardDef {
+      @field body = contains(MarkdownField);
+      static atom = class Atom extends Component<typeof this> {
+        <template><@fields.body /></template>
+      };
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'test-card.gts': { TestCard },
+      },
+    });
+
+    let card = new TestCard({
+      body: 'See :card[https://example.com/cards/2] for details.',
+    });
+    let root = await renderCard(loader, card, 'atom');
+    assert
+      .dom(root.querySelector('[data-boxel-bfm-inline-ref]'))
+      .exists('inline card reference is rendered in atom format');
+    assert
+      .dom(root.querySelector('[data-boxel-bfm-inline-ref]'))
+      .hasAttribute('data-boxel-bfm-inline-ref', 'https://example.com/cards/2');
+  });
+});

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -992,6 +992,10 @@ export interface AddOptions extends CreateOptions {
 export type StoreReadType = 'card' | 'file-meta';
 
 export interface Store {
+  // The VirtualNetwork that owns the store's realm mappings — used by
+  // store consumers (e.g. field templates obtaining VN through
+  // CardContext) for prefix/RRI resolution at render time.
+  virtualNetwork: VirtualNetwork;
   save(id: string): void;
   create(
     doc: LooseSingleCardDocument,


### PR DESCRIPTION
This is a small continuation from 5109, which changed all `VirtualNetwork` parameters to be required but one: `MarkdownField`, which needs one to resolve `@cardstack/whatever`-style card references in markdown.

The CI failure about the title is because of rebasing, this doesn’t have anything to do with Boxel CLI.