### PR TITLE
Split realm-server search-timing sql stage into compile vs sqlExec

### DIFF
--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -73,6 +73,7 @@ import {
 import { isScopedCSSRequest } from './scoped-css';
 import type { FileMetaResource } from './resource-types';
 import type { VirtualNetwork } from './virtual-network';
+import type { RequestTimings } from './request-timings';
 
 export interface IndexedFile {
   type: 'file';
@@ -139,7 +140,8 @@ interface InstanceError extends Partial<
 export type InstanceOrError = IndexedInstance | InstanceError;
 
 type GetEntryOptions = WIPOptions;
-export type QueryOptions = WIPOptions & PrerenderedCardOptions;
+export type QueryOptions = WIPOptions &
+  PrerenderedCardOptions & { timings?: RequestTimings };
 
 interface PrerenderedCardOptions {
   htmlFormat?: PrerenderedHtmlFormat;
@@ -197,8 +199,20 @@ export class IndexQueryEngine {
     return await query(this.#dbAdapter, expression, coerceTypes);
   }
 
-  async #queryCards(query: CardExpression) {
-    return this.#query(await this.makeExpression(query));
+  // Split the two phases so the search-timing line can attribute the SQL
+  // stage. `makeExpression` resolves the filter tree to SQL — that resolution
+  // runs a `getDefinition` card-definition lookup per type/field (a cache
+  // read, or a module prerender on a miss), so it can dominate a search whose
+  // actual row fetch is tiny. `#query` is the DB round-trip itself. The data
+  // and count queries run concurrently, so these accumulate into the
+  // parallel-sum `busy` bucket rather than the wall-clock stages.
+  async #queryCards(query: CardExpression, timings?: RequestTimings) {
+    let expression = timings
+      ? await timings.busyTime('compile', () => this.makeExpression(query))
+      : await this.makeExpression(query);
+    return timings
+      ? await timings.busyTime('sqlExec', () => this.#query(expression))
+      : this.#query(expression);
   }
 
   async getInstance(
@@ -608,8 +622,8 @@ export class IndexQueryEngine {
       ];
 
       let [results, totalResults] = await Promise.all([
-        this.#queryCards(query),
-        this.#queryCards(queryCount),
+        this.#queryCards(query, opts.timings),
+        this.#queryCards(queryCount, opts.timings),
       ]);
 
       return {


### PR DESCRIPTION
The realm-server search-timing line (`realm:search-timing`) attributes a `sql`
stage that wraps `IndexQueryEngine.searchCards`. That call does two things: it
resolves the query filter to SQL via `makeExpression` — which runs a
`getDefinition` card-definition lookup for each type/field referenced in the
filter (a cache read, or a module prerender on a cache miss) — and it executes
the resulting query against the index.

When a search filters by card type or a field path, the definition-resolution
work can dominate the `sql` stage even when the query itself fetches very few
rows, so a single `sql` number can't tell whether time went to Postgres or to
definition lookups.

This splits `#queryCards` into two measurements reported in the parallel-sum
`busyMs` section of the search-timing line:

- `compile` — resolving the filter tree to SQL (includes the `getDefinition`
  lookups)
- `sqlExec` — the database round-trip itself

The data and count queries run concurrently, so the values land in the
parallel-sum bucket (read as a ratio, not wall-clock). A large `compile` beside
a small `sqlExec` points at definition resolution; the reverse points at the
query. The split is inert for searches that don't carry a timings collector
(non-prerender traffic), so there's no added overhead there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
