### PR TITLE
Fix flaky Matrix Client Tests (3/3): keep renamed AI sessions on top of past-sessions after reload

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1342,7 +1342,23 @@ export default class MatrixService extends Service {
   getLastActiveTimestamp(roomId: string, defaultTimestamp: number) {
     let matrixRoom = this.client.getRoom(roomId);
     let lastMatrixEvent = matrixRoom?.getLastActiveTimestamp();
-    return lastMatrixEvent ?? defaultTimestamp;
+    // Renaming a session counts as activity and moves it to the top of the
+    // past-sessions list. A rename is recorded as an `m.room.name` state event,
+    // but `getLastActiveTimestamp()` only inspects the live timeline. After a
+    // reload the fresh sync can surface that rename as current room state rather
+    // than a timeline event, so the room's last-active time would otherwise
+    // regress to its last message and the rename's ordering would be lost. Fold
+    // the rename's timestamp in so a renamed session keeps its place.
+    let nameEventTimestamp = matrixRoom?.currentState
+      ?.getStateEvents('m.room.name', '')
+      ?.getTs();
+    let candidates = [lastMatrixEvent, nameEventTimestamp].filter(
+      (timestamp): timestamp is number => typeof timestamp === 'number',
+    );
+    if (candidates.length === 0) {
+      return defaultTimestamp;
+    }
+    return Math.max(...candidates);
   }
 
   async requestRegisterEmailToken(

--- a/packages/matrix/tests/room-creation.spec.ts
+++ b/packages/matrix/tests/room-creation.spec.ts
@@ -514,9 +514,33 @@ test.describe('Room creation', () => {
     await reloadAndOpenAiAssistant(page);
     await isInRoom(page, room2);
     await page.locator(`[data-test-past-sessions-button]`).click();
-    await expect(
-      page.locator(`[data-test-joined-room]:nth-of-type(1) .name`),
-      'updated order is preserved on reload',
-    ).toHaveText('test room 3');
+    try {
+      await expect(
+        page.locator(`[data-test-joined-room]:nth-of-type(1) .name`),
+        'updated order is preserved on reload',
+      ).toHaveText('test room 3');
+    } catch (e) {
+      // The list is ordered by last-active timestamp. If the renamed room
+      // (room3) is not on top, dump every room's id/name/last-active so the
+      // failure shows which room jumped ahead and by what margin — the rename's
+      // `m.room.name` timestamp can be dropped after a reload (see
+      // matrix-service `getLastActiveTimestamp`).
+      let rooms = await page
+        .locator('[data-test-joined-room]')
+        .evaluateAll((els) =>
+          els.map((el) => ({
+            roomId: el.getAttribute('data-test-joined-room'),
+            name: el.querySelector('.name')?.textContent?.trim(),
+            lastActive: el
+              .querySelector('[data-test-last-active]')
+              ?.getAttribute('data-test-last-active'),
+          })),
+        );
+      throw new Error(
+        `${(e as Error).message}\n` +
+          `expected renamed room ${room3} ("test room 3") on top; ` +
+          `actual order: ${JSON.stringify(rooms, null, 2)}`,
+      );
+    }
   });
 });


### PR DESCRIPTION
> **This fixes the flaky `Matrix Client Tests (3, 3)` shard** — specifically `room-creation.spec.ts › "it orders past-sessions list items based on last activity in reverse chronological order [CS-7603]"`, which has been intermittently failing CI (seen on PR #5132 and twice on PR #5104).

## What

The flaky test renames a session ("test room 3") so it becomes the most-recently-active, reloads, and expects it to stay at the top of the past-sessions list — but it sometimes drops below an unnamed "New AI Assistant Chat" session:

```
expect(locator).toHaveText(expected) failed
Locator:  [data-test-joined-room]:nth-of-type(1) .name
Expected: "test room 3"
Received: "New AI Assistant Chat"
```

## Root cause

The past-sessions list is sorted by `MatrixService.getLastActiveTimestamp(roomId)`, which derives a room's last-active time from the matrix-js-sdk **live timeline** (`Room.getLastActiveTimestamp()` returns the last live-timeline event's `origin_server_ts`).

A session rename is recorded as an `m.room.name` **state event**. While the session is live, that event is in the timeline, so the rename correctly bumps the session to the top. After a reload, the fresh `/sync` can deliver the rename as **current room state** rather than as a live-timeline event. When that happens, the room's name still renders correctly (it comes from room state), but its computed last-active time regresses to its last *message*. A different session whose last message is newer (e.g. a still-unnamed "New AI Assistant Chat") then sorts above the renamed one — and the assertion fails.

It's flaky because whether the rename lands in the rebuilt live timeline vs. current state depends on the sync shape on a given reload.

## Fix

Fold the `m.room.name` current-state timestamp into `getLastActiveTimestamp` (it takes the max of the live-timeline timestamp and the rename's timestamp). A renamed session then keeps its place in the recents list regardless of whether the rename is in the live timeline after a reload. This also keeps the displayed last-active time consistent with the ordering, since both flow through this method. When the room isn't in the client it falls back to the provided default, so behavior is unchanged for non-renamed rooms.

## Diagnostics

If the e2e ordering assertion fails again, it now dumps every room's id / name / last-active timestamp, so a future failure shows which session jumped ahead and by what margin without needing to pull the Playwright trace.
