### PR TITLE
Add Cloudfront material to AWS Claude skill

### DIFF
--- a/.claude/skills/aws-access/SKILL.md
+++ b/.claude/skills/aws-access/SKILL.md
@@ -11,7 +11,7 @@ This skill exists because:
 1. The team's existing `staging` / `prod` shell aliases export AWS credentials into the user's interactive shell, but Claude's Bash tool spawns its own shell that does not inherit them.
 2. The boxel staging/prod RDS instances are not publicly reachable — they live inside the AWS VPC.
 
-The flow below solves both: a wrapper script that mints a scoped STS session and writes its credentials to a *named profile* in `~/.aws/credentials` so Claude can read them from any shell, plus the SSM port-forward pattern for talking to the in-VPC database.
+The flow below solves both: a wrapper script that mints a scoped STS session and writes its credentials to a _named profile_ in `~/.aws/credentials` so Claude can read them from any shell, plus the SSM port-forward pattern for talking to the in-VPC database.
 
 The script and mise task are in this repo:
 
@@ -25,7 +25,7 @@ Profile convention is fixed (don't change without a heads-up):
 
 ## Identity model (CS-10962)
 
-The credentials in `[claude-staging]` / `[claude-prod]` are *not* the user's IAM identity. The script does:
+The credentials in `[claude-staging]` / `[claude-prod]` are _not_ the user's IAM identity. The script does:
 
 1. Reads the user's long-lived IAM access keys (held in their source profile, e.g. `cardstack`).
 2. Calls `sts:AssumeRole arn:aws:iam::<account>:role/boxel-claude-readonly` directly, passing the user's MFA token via `--serial-number` and `--token-code`. The role's trust policy requires `aws:MultiFactorAuthPresent: true`, which is satisfied by these flags. This is the MFA gate.
@@ -46,7 +46,7 @@ The user needs:
 - `aws` CLI installed.
 - `jq` installed (`brew install jq` / `apt install jq`).
 - `session-manager-plugin` installed — required for the SSM port-forward tunnel to RDS. Install instructions: <https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html>. macOS: `brew install --cask session-manager-plugin`. Ubuntu: download the deb from the page and `sudo dpkg -i`.
-- A working AWS named profile in `~/.aws/credentials` for staging (typically `cardstack`) and for prod (typically `cardstack-prod`). These hold the user's long-lived access keys; they're what the team sets up via `aws configure --profile <name>` on day one. The script uses these as the *source* profile to mint an STS session — the user can name them whatever they want and the script will prompt the first time it runs.
+- A working AWS named profile in `~/.aws/credentials` for staging (typically `cardstack`) and for prod (typically `cardstack-prod`). These hold the user's long-lived access keys; they're what the team sets up via `aws configure --profile <name>` on day one. The script uses these as the _source_ profile to mint an STS session — the user can name them whatever they want and the script will prompt the first time it runs.
 - An MFA device registered on the IAM user. The script auto-detects the MFA ARN via `aws iam list-mfa-devices`, so the user does not edit anything.
 - IAM permission to `sts:AssumeRole` on `boxel-claude-readonly` in the target account. The infra side of CS-10962 grants this to the `read-only` and `full-access` groups in both staging and prod, so any teammate already set up to use staging/prod has it automatically.
 
@@ -81,14 +81,14 @@ After that, Claude can run any `aws --profile claude-staging ...` or `aws --prof
 
 ### Troubleshooting walkthrough
 
-| Symptom | What to tell the user |
-|---|---|
-| `mise ERROR no task claude-aws found` | They typed it wrong (common: `cluade-aws`) or the mise task file is missing — re-clone or pull main. |
-| `An error occurred (AccessDenied) … MultiFactorAuthentication failed with invalid MFA one time pass code` | The token expired before they hit enter. Wait for a fresh code and try again. |
-| `No source AWS profile is configured for 'staging'.` followed by a list | Expected on first run. Type the source profile name (most teammates use `cardstack` / `cardstack-prod` but it varies). |
-| `No MFA device registered for profile <name>` | They picked the wrong source profile (cached on first run). List MFA devices: `aws iam list-mfa-devices --profile <profile>`. To clear the bad choice and re-prompt, run `mise run claude-aws --reset`, then re-run with the right profile. |
+| Symptom                                                                                                                                                                                   | What to tell the user                                                                                                                                                                                                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mise ERROR no task claude-aws found`                                                                                                                                                     | They typed it wrong (common: `cluade-aws`) or the mise task file is missing — re-clone or pull main.                                                                                                                                                                                                  |
+| `An error occurred (AccessDenied) … MultiFactorAuthentication failed with invalid MFA one time pass code`                                                                                 | The token expired before they hit enter. Wait for a fresh code and try again.                                                                                                                                                                                                                         |
+| `No source AWS profile is configured for 'staging'.` followed by a list                                                                                                                   | Expected on first run. Type the source profile name (most teammates use `cardstack` / `cardstack-prod` but it varies).                                                                                                                                                                                |
+| `No MFA device registered for profile <name>`                                                                                                                                             | They picked the wrong source profile (cached on first run). List MFA devices: `aws iam list-mfa-devices --profile <profile>`. To clear the bad choice and re-prompt, run `mise run claude-aws --reset`, then re-run with the right profile.                                                           |
 | `An error occurred (AccessDenied) when calling the AssumeRole operation: User: ... is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::...:role/boxel-claude-readonly` | Either the infra side of CS-10962 hasn't been applied to that account yet (so the role doesn't exist or doesn't trust the user's group), or the user's IAM user isn't in `read-only` or `full-access`. Check role existence: `aws --profile <source> iam get-role --role-name boxel-claude-readonly`. |
-| `An error occurred (NoRegion)` when Claude later runs `aws --profile claude-staging …` | They ran the script on an old version that didn't carry region forward. Either re-run `mise run claude-aws <env> <token>` (the current script copies the region from the source profile), or set it manually: `aws configure set region us-east-1 --profile claude-staging`. |
+| `An error occurred (NoRegion)` when Claude later runs `aws --profile claude-staging …`                                                                                                    | They ran the script on an old version that didn't carry region forward. Either re-run `mise run claude-aws <env> <token>` (the current script copies the region from the source profile), or set it manually: `aws configure set region us-east-1 --profile claude-staging`.                          |
 
 ## How Claude uses the session
 
@@ -124,6 +124,22 @@ Claude operates against staging and prod **only as the `boxel-claude-readonly` I
 
 The role is provisioned by infra-side configuration tracked under CS-10962. Anything that would require a permission outside the role's policy is out of scope for Claude — the user should run that operation themselves through whatever channel the team uses for it. This is by design: the role is the AWS-side complement to the claude-readonly-only DB rule below, and together they make accidental writes structurally hard to issue.
 
+### Global read-only control-plane APIs (CloudFront, etc.)
+
+Some services Claude reads are **global control-plane APIs that need none of the SSM-tunnel / ECS machinery** below — just call them directly with the session profile, no region tunnel, no DB/EFS hop:
+
+```sh
+aws --profile claude-staging cloudfront list-distributions
+aws --profile claude-prod    cloudfront get-distribution-config --id <id>
+```
+
+For **CloudFront** specifically, the role grants read across the relevant surface in both accounts: `list-distributions`, `get-distribution-config`, `list-invalidations`, `get-invalidation`, `list-tags-for-resource`, and the policy lookups (`get-cache-policy` / `get-origin-request-policy` / `get-response-headers-policy`). **Writes are denied** — `create-invalidation`, `update-distribution`, `tag-resource`, etc. all `AccessDenied`, consistent with the read-only boundary. So a full CloudFront audit (distributions, origins/behaviors, TLS, custom errors, invalidation history, tags) is doable end-to-end as the role; cache-busting and config changes are not.
+
+Two operational notes when fanning these out:
+
+- CloudFront throttles aggressively — firing ~60 calls at once gets `Throttling: Rate exceeded` on some. Cap concurrency or fall back to sequential with a small `sleep`.
+- AWS CLI v2 prints **nothing** (empty output, exit 0) when a list result is genuinely empty — e.g. `list-invalidations` for a distribution that has never been invalidated. Empty output is "zero items," not an error.
+
 ## Connecting to the boxel RDS database
 
 The staging/prod boxel Postgres instances are **private** (`PubliclyAccessible: false`) and live inside the cardstack VPC. They are not directly reachable from a developer laptop. The only path Claude uses is SSM port-forwarding through the realm-server ECS task, authenticated as the read-only `claude_readonly_user` DB user.
@@ -136,15 +152,16 @@ This opens an SSM tunnel through the realm-server container to the RDS endpoint,
 
 Verified on staging via `has_table_privilege(current_user, 'boxel_index', '...')`:
 
-| Privilege | Result |
-|---|---|
-| SELECT | ✓ (granted via `readonly_role` membership) |
-| INSERT / UPDATE / DELETE / TRUNCATE | ✗ |
-| superuser / createrole / createdb / bypassrls | all `f` |
+| Privilege                                     | Result                                     |
+| --------------------------------------------- | ------------------------------------------ |
+| SELECT                                        | ✓ (granted via `readonly_role` membership) |
+| INSERT / UPDATE / DELETE / TRUNCATE           | ✗                                          |
+| superuser / createrole / createdb / bypassrls | all `f`                                    |
 
 The user is dedicated to Claude so `pg_stat_activity` and slow-query logs cleanly identify triage traffic. It inherits from `readonly_role`, which is where the SELECT-on-public grants live — defined once, applied to whichever users are members.
 
 Source of truth:
+
 - `readonly_role` — defined in `packages/postgres/migrations/1751981407344_setup-grafana-db-user.js` (`CONNECT` on `boxel` / `USAGE` on `public` / `SELECT` on all current tables, plus default privileges so future tables inherit). The filename is historical; the role itself is general.
 - `claude_readonly_user` — defined in `packages/postgres/migrations/1777413435523_setup-claude-readonly-db-user.js`, granted `readonly_role`. Both migrations gate on `REALM_SENTRY_ENVIRONMENT in (staging, production)`, so they only run in deployed environments.
 
@@ -258,7 +275,7 @@ When constructing a query, the cheapest sanity check is: does the SQL begin with
 
 ### What's actually in the database
 
-The `indexing-diagnostics` skill is the right entry point for `boxel_index` / `boxel_index_working` / `error_doc` exploration — it documents the schema, the `diagnostics` JSONB shape, and the canonical query patterns. This skill only covers *getting connected*; the queries themselves live there.
+The `indexing-diagnostics` skill is the right entry point for `boxel_index` / `boxel_index_working` / `error_doc` exploration — it documents the schema, the `diagnostics` JSONB shape, and the canonical query patterns. This skill only covers _getting connected_; the queries themselves live there.
 
 ## Browsing the EFS filesystem (read-only)
 
@@ -351,12 +368,12 @@ CloudWatch read access is part of the `boxel-claude-readonly` role's policy, so 
 
 The boxel deployed services all log to CloudWatch under predictable group names:
 
-| Group (staging) | Group (prod, verify with `describe-log-groups`) | What lives there |
-|---|---|---|
-| `ecs-boxel-realm-server-staging` | `ecs-boxel-realm-server-production` | Realm-server requests, indexer drive lines, prerender-client (manager) calls. The main place to grep `requestId=…`. |
-| `ecs-boxel-prerender-server-staging` | `ecs-boxel-prerender-server-production` | Prerender-server endpoint logs (per-render breakdown), the periodic `prerender-queue-snapshot` line, page-pool warnings. |
-| `ecs-boxel-prerender-manager-staging` | `ecs-boxel-prerender-manager-production` | Manager proxy decisions (queueMs, target assignment). |
-| `ecs-boxel-worker-staging` | `ecs-boxel-worker-production` | Background worker / job queue (the realm-server itself runs the worker manager — there is no separate worker-manager log group). |
+| Group (staging)                       | Group (prod, verify with `describe-log-groups`) | What lives there                                                                                                                 |
+| ------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `ecs-boxel-realm-server-staging`      | `ecs-boxel-realm-server-production`             | Realm-server requests, indexer drive lines, prerender-client (manager) calls. The main place to grep `requestId=…`.              |
+| `ecs-boxel-prerender-server-staging`  | `ecs-boxel-prerender-server-production`         | Prerender-server endpoint logs (per-render breakdown), the periodic `prerender-queue-snapshot` line, page-pool warnings.         |
+| `ecs-boxel-prerender-manager-staging` | `ecs-boxel-prerender-manager-production`        | Manager proxy decisions (queueMs, target assignment).                                                                            |
+| `ecs-boxel-worker-staging`            | `ecs-boxel-worker-production`                   | Background worker / job queue (the realm-server itself runs the worker manager — there is no separate worker-manager log group). |
 
 Cross-component grep is the bread-and-butter pattern: every request carries `requestId=<uuid>` through realm-server → manager → prerender-server, so a single `requestId` filter will collate the whole call.
 
@@ -412,7 +429,7 @@ For long-running tails or when you want to know which log stream / task each eve
 
 ### Timezones — confirm, convert to UTC yourself, then run
 
-CloudWatch stores all event timestamps in UTC, and `cw` defaults to UTC for `--start` / `--end` unless you pass `-l` / `--local`. The host running `cw` is **not** necessarily in the user's timezone (Claude often runs on Linux boxes set to UTC), so `-l` is unsafe — it interprets times in the *cw host's* local zone, not the user's.
+CloudWatch stores all event timestamps in UTC, and `cw` defaults to UTC for `--start` / `--end` unless you pass `-l` / `--local`. The host running `cw` is **not** necessarily in the user's timezone (Claude often runs on Linux boxes set to UTC), so `-l` is unsafe — it interprets times in the _cw host's_ local zone, not the user's.
 
 Workflow when a user asks for a time-bounded slice:
 

--- a/.claude/skills/aws-access/SKILL.md
+++ b/.claude/skills/aws-access/SKILL.md
@@ -138,7 +138,7 @@ For **CloudFront** specifically, the role grants read across the relevant surfac
 Two operational notes when fanning these out:
 
 - CloudFront throttles aggressively — firing ~60 calls at once gets `Throttling: Rate exceeded` on some. Cap concurrency or fall back to sequential with a small `sleep`.
-- AWS CLI v2 prints **nothing** (empty output, exit 0) when a list result is genuinely empty — e.g. `list-invalidations` for a distribution that has never been invalidated. Empty output is "zero items," not an error.
+- AWS CLI v2 auto-pagination quirk: for _paginated_ list operations (e.g. `list-invalidations`, `list-distributions`), the CLI prints **nothing** (empty stdout, exit 0) when there are zero items — including under the default/JSON output. This is the pagination layer, not the output format: `--no-paginate` returns the normal `{"InvalidationList": { … "Quantity": 0 }}` payload, and non-paginated calls like `list-tags-for-resource` print `{"Items": []}` for an empty result. So empty stdout _from a paginated list_ means "zero items," not an error — but don't generalize that to other commands, which return a normal JSON payload for empty results.
 
 ## Connecting to the boxel RDS database
 


### PR DESCRIPTION
The unrelated changes here are lint autofixes for Markdown.