### PR TITLE
add coalesce helper to boxel-ui helpers

### DIFF
--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -29,7 +29,7 @@ import {
   uuidv4,
   isCardInstance,
 } from '@cardstack/runtime-common';
-import { cn } from '@cardstack/boxel-ui/helpers';
+import { cn, coalesce } from '@cardstack/boxel-ui/helpers';
 import { IconTrash, FourLines, IconPlus } from '@cardstack/boxel-ui/icons';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
@@ -269,10 +269,6 @@ function getPluralChildFormat(effectiveFormat: Format, model: Box<FieldDef>) {
     return 'atom';
   }
   return effectiveFormat;
-}
-
-function coalesce<T>(arg1: T | undefined, arg2: T): T {
-  return arg1 ?? arg2;
 }
 
 const componentCache = initSharedState(

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -17,7 +17,10 @@ import {
   brokenLinkFormat,
 } from './card-api';
 import BrokenLinkTemplate from './default-templates/broken-link-template';
-import { getRelationshipMembershipState, type RelationshipState } from './field-support';
+import {
+  getRelationshipMembershipState,
+  type RelationshipState,
+} from './field-support';
 import { rawArrayValues } from './watched-array';
 import {
   BoxComponentSignature,
@@ -50,7 +53,7 @@ import {
   FourLines,
   IconPlus,
 } from '@cardstack/boxel-ui/icons';
-import { cn, eq } from '@cardstack/boxel-ui/helpers';
+import { cn, coalesce, eq } from '@cardstack/boxel-ui/helpers';
 import { consume } from 'ember-provide-consume-context';
 import {
   SortableGroupModifier as sortableGroup,
@@ -578,10 +581,6 @@ function getPluralChildFormat(
     return 'fitted';
   }
   return effectiveFormat;
-}
-
-function coalesce<T>(arg1: T | undefined, arg2: T): T {
-  return arg1 ?? arg2;
 }
 
 function shouldRenderEditor(

--- a/packages/boxel-ui/addon/src/helpers.ts
+++ b/packages/boxel-ui/addon/src/helpers.ts
@@ -51,6 +51,7 @@ import {
 import {
   and,
   bool,
+  coalesce,
   eq,
   gt,
   gte,
@@ -73,6 +74,7 @@ export {
   buildCssGroups,
   buildCssVariableName,
   cn,
+  coalesce,
   compact,
   copyCardURLToClipboard,
   cssVar,

--- a/packages/boxel-ui/addon/src/helpers/truth-helpers.ts
+++ b/packages/boxel-ui/addon/src/helpers/truth-helpers.ts
@@ -46,3 +46,7 @@ export function not<T>(val: T): boolean {
 export function bool<T>(val: T): boolean {
   return Boolean(val);
 }
+
+export function coalesce<T>(arg1: T | undefined | null, arg2: T): T {
+  return arg1 ?? arg2;
+}

--- a/packages/boxel-ui/test-app/tests/unit/truth-helpers-test.ts
+++ b/packages/boxel-ui/test-app/tests/unit/truth-helpers-test.ts
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+
+import { coalesce } from '@cardstack/boxel-ui/helpers';
+
+module('Unit | helpers | coalesce', function () {
+  test('returns the first argument when it is a non-null string', function (assert) {
+    assert.strictEqual(coalesce('hello', 'fallback'), 'hello');
+  });
+
+  test('returns the second argument when the first is null', function (assert) {
+    assert.strictEqual(coalesce(null, 'fallback'), 'fallback');
+  });
+
+  test('returns the second argument when the first is undefined', function (assert) {
+    assert.strictEqual(coalesce(undefined, 'fallback'), 'fallback');
+  });
+
+  test('returns the first argument when it is 0', function (assert) {
+    assert.strictEqual(coalesce(0, 42), 0);
+  });
+
+  test('returns the first argument when it is an empty string', function (assert) {
+    assert.strictEqual(coalesce('', 'fallback'), '');
+  });
+
+  test('returns the first argument when it is false', function (assert) {
+    assert.false(coalesce(false, true));
+  });
+
+  test('returns the second argument when both are null/undefined', function (assert) {
+    assert.strictEqual(coalesce(null, 'default'), 'default');
+    assert.strictEqual(coalesce(undefined, 'default'), 'default');
+  });
+
+  test('works with object values', function (assert) {
+    const obj = { x: 1 };
+    assert.strictEqual(coalesce(obj, { x: 2 }), obj);
+    assert.deepEqual(coalesce(null, { x: 2 }), { x: 2 });
+  });
+
+  test('works with number values', function (assert) {
+    assert.strictEqual(coalesce(42, 99), 42);
+    assert.strictEqual(coalesce(null, 99), 99);
+  });
+});


### PR DESCRIPTION
Extracts the `coalesce` helper (null-coalescing `arg1 ?? arg2`) into `@cardstack/boxel-ui/helpers` and removes the two local copies that existed in `contains-many-component.gts` and `links-to-many-component.gts`.