### PR TITLE
Standardize on one checkmark glyph across host UI chrome

### DIFF
--- a/packages/boxel-ui/addon/src/components/picker/option-row.gts
+++ b/packages/boxel-ui/addon/src/components/picker/option-row.gts
@@ -202,19 +202,22 @@ export default class PickerOptionRow extends Component<OptionRowSignature> {
         box-shadow: 0 0 0 2px var(--boxel-dark-teal);
       }
 
+      /* Checked treatment matches the canonical BoxelInput checkbox
+         (highlight fill, dark border, #333 checkmark) so every checkbox in
+         the host UI chrome reads as the same control. */
       .picker-option-row__checkbox--selected {
-        border-color: var(--boxel-dark-teal);
-        background-color: var(--boxel-dark-teal);
+        border-color: var(--boxel-dark);
+        background-color: var(--boxel-highlight);
       }
 
       .picker-option-row__check-icon {
-        --icon-color: var(--boxel-dark-teal);
+        --icon-color: var(--boxel-highlight);
         visibility: collapse;
         display: contents;
       }
 
       .picker-option-row__check-icon--selected {
-        --icon-color: var(--boxel-dark);
+        --icon-color: #333;
         visibility: visible;
       }
 

--- a/packages/boxel-ui/addon/src/components/selection-checkmark/index.gts
+++ b/packages/boxel-ui/addon/src/components/selection-checkmark/index.gts
@@ -1,5 +1,7 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
+import CheckMark from '../../icons/check-mark.gts';
+
 // SelectionCheckmark: the dark-circle-with-highlight-check artwork used by
 // selection affordances — the SelectionMenu trigger and its inert count
 // header, and the card-header utility-menu trigger. The circle reads as the
@@ -7,10 +9,16 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 // out against a highlight-colored surface. It is a two-color composite (not
 // a monochrome, currentColor icon), so it lives here as a component rather
 // than in the generated icon set.
+//
+// The tick is the shared CheckMark glyph (nested as its own viewport, tinted
+// via --icon-color) rather than a hand-rolled path, so every checkmark across
+// the host UI chrome — menu items, checkboxes, and this pill — is the same
+// glyph; only the surrounding chrome (circle vs. square) differs.
 const SelectionCheckmark: TemplateOnlyComponent<{
   Element: SVGSVGElement;
 }> = <template>
   <svg
+    class='selection-checkmark'
     viewBox='0 0 14 14'
     fill='none'
     xmlns='http://www.w3.org/2000/svg'
@@ -18,14 +26,14 @@ const SelectionCheckmark: TemplateOnlyComponent<{
     ...attributes
   >
     <circle cx='7' cy='7' r='7' fill='var(--boxel-highlight-foreground)' />
-    <path
-      d='M3.5 7.5L5.5 9.5L10.5 4.5'
-      stroke='var(--boxel-highlight)'
-      stroke-width='1.5'
-      stroke-linecap='round'
-      stroke-linejoin='round'
-    />
+    <CheckMark x='3' y='3' width='8' height='8' />
   </svg>
+  <style scoped>
+    /* Tint the nested CheckMark glyph; the circle keeps its own fill. */
+    .selection-checkmark {
+      --icon-color: var(--boxel-highlight);
+    }
+  </style>
 </template>;
 
 export default SelectionCheckmark;

--- a/packages/host/app/components/adorn/adorn-select-checkmark.gts
+++ b/packages/host/app/components/adorn/adorn-select-checkmark.gts
@@ -1,5 +1,7 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
+import { CheckMark } from '@cardstack/boxel-ui/icons';
+
 // The Adorn selection-chip artwork as standalone Icon components, so the
 // selection control can be a shared boxel-ui ContextButton: the consumer
 // passes the empty variant when unselected and the checked variant when
@@ -48,6 +50,7 @@ export const AdornCheckmarkEmpty: TemplateOnlyComponent<Signature> = <template>
 export const AdornCheckmarkSelected: TemplateOnlyComponent<Signature> =
   <template>
     <svg
+      class='adorn-checkmark-selected'
       viewBox='0 0 20 20'
       fill='none'
       xmlns='http://www.w3.org/2000/svg'
@@ -61,12 +64,12 @@ export const AdornCheckmarkSelected: TemplateOnlyComponent<Signature> =
         fill='var(--adorn-chip-bg, var(--adorn-accent-light))'
       />
       <circle cx='10' cy='10' r='7' fill='var(--boxel-highlight-foreground)' />
-      <path
-        d='M6.5 10.5L8.5 12.5L13.5 7.5'
-        stroke='var(--adorn-accent-light)'
-        stroke-width='1.5'
-        stroke-linecap='round'
-        stroke-linejoin='round'
-      />
+      <CheckMark x='6' y='6' width='8' height='8' />
     </svg>
+    <style scoped>
+      /* Tint the nested CheckMark glyph; the chip and circle keep their fills. */
+      .adorn-checkmark-selected {
+        --icon-color: var(--adorn-accent-light);
+      }
+    </style>
   </template>;


### PR DESCRIPTION
## What

The card chooser surfaced three different checkmark treatments side by side: the realm-dropdown item checkbox, the selection-pill teal-circle check, and the "Show only" checkbox. The two checkboxes used different fill and check colors, and the selection pill (plus the operator-mode card-overlay chip) drew its own hand-rolled tick.

This unifies them on the single shared `CheckMark` glyph. Only the surrounding chrome (square checkbox vs. circular pill) now differs.

## Changes

- **`picker/option-row.gts`** — already used the `CheckMark` glyph; the checked checkbox now uses the canonical `BoxelInput` colors (`--boxel-highlight` fill, `--boxel-dark` border, `#333` check) so both checkboxes read as the same control.
- **`selection-checkmark/index.gts`** — the pill's dark circle now contains the shared `CheckMark` glyph (nested as its own viewport, tinted teal via a scoped `--icon-color`) instead of a bespoke path.
- **`adorn/adorn-select-checkmark.gts`** — the operator-mode card-overlay chip's tick (a fourth glyph) now uses the same shared glyph.

The "Show only" checkbox (`BoxelInput`) was already canonical and is unchanged.

## Test plan

- `boxel-ui` and `host` type-check clean (`ember-tsc --noEmit`); eslint + template-lint clean on all three files.
- Existing assertions are class/presence-based (`.picker-option-row__checkbox--selected`, the selection-trigger `svg circle`) and unaffected; no test asserts the changed colors or path data.
- Rendered the two composites standalone to confirm the nested glyph stays centered in both the 14×14 circle and the 20×20 chip, and that the scoped `--icon-color` cascades to tint it.

Resolves CS-11333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)