### PR TITLE
Serve singular scalar string eq filters with a GIN `@>` containment predicate

### DIFF
--- a/packages/realm-server/tests/eq-containment-integration-test.ts
+++ b/packages/realm-server/tests/eq-containment-integration-test.ts
@@ -11,9 +11,16 @@ import {
   type CodeRef,
   type Definition,
   type DefinitionLookup,
+  type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
 
 import { setupDB } from './helpers';
+
+// Build a resolved code ref; the cast brands the module URL as the
+// RealmResourceIdentifier the CodeRef types expect.
+function ref(module: string, name: string): ResolvedCodeRef {
+  return { module: module as ResolvedCodeRef['module'], name };
+}
 
 // Exercises the singular-path scalar `eq` -> `search_doc @>` containment
 // rewrite against real Postgres. The engine emits a `@>` predicate (GIN
@@ -25,31 +32,13 @@ import { setupDB } from './helpers';
 
 const testRealmURL = 'http://eq-containment-test/';
 
-const stringRef: CodeRef = {
-  module: 'https://cardstack.com/base/string',
-  name: 'default',
-};
-const numberRef: CodeRef = {
-  module: 'https://cardstack.com/base/number',
-  name: 'default',
-};
-const booleanRef: CodeRef = {
-  module: 'https://cardstack.com/base/boolean',
-  name: 'default',
-};
-const policyRef: CodeRef = { module: `${testRealmURL}policy`, name: 'Policy' };
-const customerRef: CodeRef = {
-  module: `${testRealmURL}customer`,
-  name: 'Customer',
-};
-const metadataRef: CodeRef = {
-  module: `${testRealmURL}policy`,
-  name: 'Metadata',
-};
-const contactRef: CodeRef = {
-  module: `${testRealmURL}policy`,
-  name: 'Contact',
-};
+const stringRef = ref('https://cardstack.com/base/string', 'default');
+const numberRef = ref('https://cardstack.com/base/number', 'default');
+const booleanRef = ref('https://cardstack.com/base/boolean', 'default');
+const policyRef = ref(`${testRealmURL}policy`, 'Policy');
+const customerRef = ref(`${testRealmURL}customer`, 'Customer');
+const metadataRef = ref(`${testRealmURL}policy`, 'Metadata');
+const contactRef = ref(`${testRealmURL}policy`, 'Contact');
 
 // Customer (linked card): a string `id` leaf + a string `name`.
 const customerDef: Definition = {
@@ -176,13 +165,15 @@ function refsEqual(a: CodeRef, b: CodeRef): boolean {
 
 function makeDefinitionLookup(): DefinitionLookup {
   const lookup: DefinitionLookup = {
-    async lookupDefinition(codeRef: CodeRef) {
+    async lookupDefinition(codeRef: ResolvedCodeRef): Promise<Definition> {
       for (let def of [policyDef, customerDef, metadataDef, contactDef]) {
         if (refsEqual(codeRef, def.codeRef)) {
           return def;
         }
       }
-      return undefined;
+      throw new Error(
+        `unexpected definition lookup: ${codeRef.module}/${codeRef.name}`,
+      );
     },
     async lookupCachedDefinition() {
       return undefined;
@@ -333,8 +324,10 @@ module(basename(__filename), function () {
       return cards.map((c) => c.id!).sort();
     }
 
+    // Only the search queries matter for asserting the predicate form; the
+    // per-test seeding INSERTs are captured too, so exclude them.
     function lastFilterSql(): string {
-      return executedSql.join('\n');
+      return executedSql.filter((sql) => !/^\s*INSERT\b/i.test(sql)).join('\n');
     }
 
     test('singular string eq is served by `@>` containment', async function (assert) {

--- a/packages/realm-server/tests/eq-containment-integration-test.ts
+++ b/packages/realm-server/tests/eq-containment-integration-test.ts
@@ -1,0 +1,482 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+
+import type { PgAdapter } from '@cardstack/postgres';
+import {
+  IndexQueryEngine,
+  internalKeyFor,
+  param,
+  query,
+  VirtualNetwork,
+  type CodeRef,
+  type Definition,
+  type DefinitionLookup,
+} from '@cardstack/runtime-common';
+
+import { setupDB } from './helpers';
+
+// Exercises the singular-path scalar `eq` -> `search_doc @>` containment
+// rewrite against real Postgres. The engine emits a `@>` predicate (GIN
+// servable) only for a positive-polarity, singular, string-valued leaf;
+// numeric/boolean leaves, plural paths, and negated contexts keep the `->>`
+// extraction form. We assert both the result set AND which SQL form was
+// emitted (by capturing the executed SQL) so a correct result can't mask the
+// rewrite silently not firing.
+
+const testRealmURL = 'http://eq-containment-test/';
+
+const stringRef: CodeRef = {
+  module: 'https://cardstack.com/base/string',
+  name: 'default',
+};
+const numberRef: CodeRef = {
+  module: 'https://cardstack.com/base/number',
+  name: 'default',
+};
+const booleanRef: CodeRef = {
+  module: 'https://cardstack.com/base/boolean',
+  name: 'default',
+};
+const policyRef: CodeRef = { module: `${testRealmURL}policy`, name: 'Policy' };
+const customerRef: CodeRef = {
+  module: `${testRealmURL}customer`,
+  name: 'Customer',
+};
+const metadataRef: CodeRef = {
+  module: `${testRealmURL}policy`,
+  name: 'Metadata',
+};
+const contactRef: CodeRef = {
+  module: `${testRealmURL}policy`,
+  name: 'Contact',
+};
+
+// Customer (linked card): a string `id` leaf + a string `name`.
+const customerDef: Definition = {
+  type: 'card-def',
+  codeRef: customerRef,
+  displayName: 'Customer',
+  fields: { id: 'f0', name: 'f1' },
+  fieldDefs: {
+    f0: {
+      type: 'contains',
+      isPrimitive: true,
+      isComputed: false,
+      fieldOrCard: stringRef,
+    },
+    f1: {
+      type: 'contains',
+      isPrimitive: true,
+      isComputed: false,
+      fieldOrCard: stringRef,
+    },
+  },
+};
+
+// Metadata (contains-composite field): a string `region` leaf.
+const metadataDef: Definition = {
+  type: 'field-def',
+  codeRef: metadataRef,
+  displayName: 'Metadata',
+  fields: { region: 'f0' },
+  fieldDefs: {
+    f0: {
+      type: 'contains',
+      isPrimitive: true,
+      isComputed: false,
+      fieldOrCard: stringRef,
+    },
+  },
+};
+
+// Contact (composite field reached through a PLURAL `contacts` field): a
+// string `email` leaf. `contacts.email` crosses an array at an interior
+// segment, so it must NOT use `@>`.
+const contactDef: Definition = {
+  type: 'field-def',
+  codeRef: contactRef,
+  displayName: 'Contact',
+  fields: { email: 'f0' },
+  fieldDefs: {
+    f0: {
+      type: 'contains',
+      isPrimitive: true,
+      isComputed: false,
+      fieldOrCard: stringRef,
+    },
+  },
+};
+
+const policyDef: Definition = {
+  type: 'card-def',
+  codeRef: policyRef,
+  displayName: 'Policy',
+  fields: {
+    policyId: 'f0',
+    count: 'f1',
+    active: 'f2',
+    customer: 'f3',
+    tags: 'f4',
+    metadata: 'f5',
+    contacts: 'f6',
+  },
+  fieldDefs: {
+    f0: {
+      type: 'contains',
+      isPrimitive: true,
+      isComputed: false,
+      fieldOrCard: stringRef,
+    },
+    f1: {
+      type: 'contains',
+      isPrimitive: true,
+      isComputed: false,
+      fieldOrCard: numberRef,
+      serializerName: 'number',
+    },
+    f2: {
+      type: 'contains',
+      isPrimitive: true,
+      isComputed: false,
+      fieldOrCard: booleanRef,
+      serializerName: 'boolean',
+    },
+    f3: {
+      type: 'linksTo',
+      isPrimitive: false,
+      isComputed: false,
+      fieldOrCard: customerRef,
+    },
+    f4: {
+      type: 'containsMany',
+      isPrimitive: true,
+      isComputed: false,
+      fieldOrCard: stringRef,
+    },
+    f5: {
+      type: 'contains',
+      isPrimitive: false,
+      isComputed: false,
+      fieldOrCard: metadataRef,
+    },
+    f6: {
+      type: 'containsMany',
+      isPrimitive: false,
+      isComputed: false,
+      fieldOrCard: contactRef,
+    },
+  },
+};
+
+function refsEqual(a: CodeRef, b: CodeRef): boolean {
+  return (
+    'module' in a && 'module' in b && a.module === b.module && a.name === b.name
+  );
+}
+
+function makeDefinitionLookup(): DefinitionLookup {
+  const lookup: DefinitionLookup = {
+    async lookupDefinition(codeRef: CodeRef) {
+      for (let def of [policyDef, customerDef, metadataDef, contactDef]) {
+        if (refsEqual(codeRef, def.codeRef)) {
+          return def;
+        }
+      }
+      return undefined;
+    },
+    async lookupCachedDefinition() {
+      return undefined;
+    },
+    async invalidate() {
+      return [];
+    },
+    async clearRealmDefinitions() {},
+    async clearAllDefinitions() {},
+    registerRealm() {},
+    async getCachedDefinitions() {
+      return undefined;
+    },
+    async populateDefinitionCacheEntry() {
+      return undefined;
+    },
+    async getCachedDefinitionsBatch() {
+      return {};
+    },
+    forRealm() {
+      return lookup;
+    },
+  };
+  return lookup;
+}
+
+interface SeededPolicy {
+  url: string;
+  searchDoc: Record<string, unknown>;
+}
+
+const c1 = `${testRealmURL}Customer/c1`;
+const c2 = `${testRealmURL}Customer/c2`;
+
+const policies: SeededPolicy[] = [
+  {
+    url: `${testRealmURL}Policy/p1`,
+    searchDoc: {
+      policyId: 'P1',
+      count: 5,
+      active: true,
+      customer: { id: c1, name: 'Acme' },
+      tags: ['vip', 'new'],
+      metadata: { region: 'EU' },
+      contacts: [{ email: 'p1@x.com' }, { email: 'shared@x.com' }],
+    },
+  },
+  {
+    url: `${testRealmURL}Policy/p2`,
+    searchDoc: {
+      policyId: 'P2',
+      count: 10,
+      active: false,
+      customer: { id: c2, name: 'Beta' },
+      tags: ['new'],
+      metadata: { region: 'US' },
+      contacts: [{ email: 'p2@x.com' }],
+    },
+  },
+  {
+    url: `${testRealmURL}Policy/p3`,
+    searchDoc: {
+      policyId: 'P3',
+      count: 5,
+      active: true,
+      customer: { id: c1, name: 'Acme' },
+      tags: ['vip'],
+      metadata: { region: 'EU' },
+      contacts: [{ email: 'shared@x.com' }],
+    },
+  },
+  {
+    // No policyId at all: exercises the absent-path NULL semantics that `@>`
+    // cannot reproduce under negation.
+    url: `${testRealmURL}Policy/p4`,
+    searchDoc: {
+      count: 5,
+      active: true,
+      customer: { id: c2, name: 'Beta' },
+      tags: [],
+      metadata: { region: 'US' },
+      contacts: [],
+    },
+  },
+];
+
+async function seedPolicy(
+  dbAdapter: PgAdapter,
+  vn: VirtualNetwork,
+  { url, searchDoc }: SeededPolicy,
+) {
+  let typeKey = internalKeyFor(policyRef, undefined, vn);
+  await query(dbAdapter, [
+    `INSERT INTO boxel_index (url, file_alias, realm_url, realm_version, type, pristine_doc, search_doc, deps, types, is_deleted, has_error, indexed_at) VALUES (`,
+    param(url),
+    `,`,
+    param(url),
+    `,`,
+    param(testRealmURL),
+    `,`,
+    param(1),
+    `,`,
+    param('instance'),
+    `,`,
+    param(JSON.stringify({ id: url, type: 'card' })),
+    `::jsonb,`,
+    param(JSON.stringify(searchDoc)),
+    `::jsonb,`,
+    `'[]'::jsonb,`,
+    param(JSON.stringify([typeKey])),
+    `::jsonb,`,
+    param(false),
+    `,`,
+    param(false),
+    `,`,
+    param(Date.now()),
+    `)`,
+  ]);
+}
+
+module(basename(__filename), function () {
+  module('eq containment (Postgres integration)', function (hooks) {
+    let dbAdapter: PgAdapter;
+    let engine: IndexQueryEngine;
+    let executedSql: string[];
+
+    setupDB(hooks, {
+      beforeEach: async (_dbAdapter) => {
+        dbAdapter = _dbAdapter;
+        executedSql = [];
+        // Capture every SQL string the engine executes so each test can assert
+        // which predicate form (`@>` vs `->>`) was emitted.
+        let originalExecute = dbAdapter.execute.bind(dbAdapter);
+        (dbAdapter as any).execute = (sql: string, opts: any) => {
+          executedSql.push(sql);
+          return originalExecute(sql, opts);
+        };
+
+        let vn = new VirtualNetwork();
+        engine = new IndexQueryEngine(dbAdapter, makeDefinitionLookup(), vn);
+        for (let policy of policies) {
+          await seedPolicy(dbAdapter, vn, policy);
+        }
+      },
+    });
+
+    function ids(cards: { id?: string }[]): string[] {
+      return cards.map((c) => c.id!).sort();
+    }
+
+    function lastFilterSql(): string {
+      return executedSql.join('\n');
+    }
+
+    test('singular string eq is served by `@>` containment', async function (assert) {
+      let { cards, meta } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { on: policyRef, eq: { policyId: 'P1' } },
+      });
+      assert.strictEqual(meta.page.total, 1, 'one row matches');
+      assert.deepEqual(ids(cards), [`${testRealmURL}Policy/p1`]);
+      assert.ok(
+        lastFilterSql().includes('@>'),
+        'a `@>` containment predicate was emitted',
+      );
+    });
+
+    test('singular linksTo `.id` eq is served by `@>` containment', async function (assert) {
+      let { cards, meta } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { on: policyRef, eq: { 'customer.id': c1 } },
+      });
+      assert.strictEqual(meta.page.total, 2, 'two policies link to c1');
+      assert.deepEqual(ids(cards), [
+        `${testRealmURL}Policy/p1`,
+        `${testRealmURL}Policy/p3`,
+      ]);
+      assert.ok(
+        lastFilterSql().includes('@>'),
+        'the linksTo `.id` path uses `@>` from the root',
+      );
+    });
+
+    test('nested contains-composite eq is served by `@>` containment', async function (assert) {
+      let { cards, meta } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { on: policyRef, eq: { 'metadata.region': 'EU' } },
+      });
+      assert.strictEqual(meta.page.total, 2);
+      assert.deepEqual(ids(cards), [
+        `${testRealmURL}Policy/p1`,
+        `${testRealmURL}Policy/p3`,
+      ]);
+      assert.ok(lastFilterSql().includes('@>'), 'nested object path uses `@>`');
+    });
+
+    test('numeric eq keeps the `->>` extraction form', async function (assert) {
+      let { cards, meta } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { on: policyRef, eq: { count: 5 } },
+      });
+      assert.strictEqual(meta.page.total, 3, 'three rows have count=5');
+      assert.deepEqual(ids(cards), [
+        `${testRealmURL}Policy/p1`,
+        `${testRealmURL}Policy/p3`,
+        `${testRealmURL}Policy/p4`,
+      ]);
+      assert.notOk(
+        lastFilterSql().includes('@>'),
+        'numeric leaf is excluded from containment',
+      );
+    });
+
+    test('boolean eq keeps the `->>` extraction form', async function (assert) {
+      let { cards, meta } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { on: policyRef, eq: { active: true } },
+      });
+      assert.strictEqual(meta.page.total, 3);
+      assert.notOk(
+        lastFilterSql().includes('@>'),
+        'boolean leaf is excluded from containment',
+      );
+      assert.deepEqual(ids(cards), [
+        `${testRealmURL}Policy/p1`,
+        `${testRealmURL}Policy/p3`,
+        `${testRealmURL}Policy/p4`,
+      ]);
+    });
+
+    test('plural-field eq keeps the json_tree machinery (no `@>`)', async function (assert) {
+      let { cards, meta } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { on: policyRef, eq: { tags: 'vip' } },
+      });
+      assert.strictEqual(meta.page.total, 2, 'two policies are tagged vip');
+      assert.deepEqual(ids(cards), [
+        `${testRealmURL}Policy/p1`,
+        `${testRealmURL}Policy/p3`,
+      ]);
+      assert.notOk(
+        lastFilterSql().includes('@>'),
+        'plural path stays on json_tree, never `@>`',
+      );
+    });
+
+    test('nested eq through an INTERIOR plural field stays on json_tree (no `@>`)', async function (assert) {
+      // `contacts` is plural, so `contacts.email` crosses an array at an
+      // interior segment. `@>` with a nested object would lose the
+      // per-element positional binding, so the walk must divert to json_tree.
+      let { cards, meta } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { on: policyRef, eq: { 'contacts.email': 'shared@x.com' } },
+      });
+      assert.strictEqual(
+        meta.page.total,
+        2,
+        'two policies have a shared contact',
+      );
+      assert.deepEqual(ids(cards), [
+        `${testRealmURL}Policy/p1`,
+        `${testRealmURL}Policy/p3`,
+      ]);
+      assert.notOk(
+        lastFilterSql().includes('@>'),
+        'an interior plural segment forces json_tree, never `@>`',
+      );
+      assert.ok(
+        lastFilterSql().includes('fullkey'),
+        'the json_tree `fullkey LIKE` path-anchor is used instead',
+      );
+    });
+
+    test('negated eq keeps `->>` and preserves NULL-on-absent-path semantics', async function (assert) {
+      let { cards, meta } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { not: { on: policyRef, eq: { policyId: 'P1' } } },
+      });
+      // p2/p3 have a different policyId (kept); p1 matches (excluded); p4 has no
+      // policyId so `->>` yields NULL and `NOT NULL` drops it — `@>` would have
+      // wrongly kept p4.
+      assert.deepEqual(ids(cards), [
+        `${testRealmURL}Policy/p2`,
+        `${testRealmURL}Policy/p3`,
+      ]);
+      assert.strictEqual(meta.page.total, 2);
+      assert.notOk(
+        lastFilterSql().includes('@>'),
+        'negated eq must not use `@>` (FALSE vs NULL diverges under NOT)',
+      );
+    });
+
+    test('double-negated eq returns to positive polarity and uses `@>`', async function (assert) {
+      let { cards, meta } = await engine.searchCards(new URL(testRealmURL), {
+        filter: { not: { not: { on: policyRef, eq: { policyId: 'P1' } } } },
+      });
+      assert.strictEqual(meta.page.total, 1);
+      assert.deepEqual(ids(cards), [`${testRealmURL}Policy/p1`]);
+      assert.ok(
+        lastFilterSql().includes('@>'),
+        'two NOTs cancel: positive polarity uses `@>`',
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -276,6 +276,7 @@ const ALL_TEST_FILES: string[] = [
   './command-parsing-utils-test',
   './query-matches-filter-test',
   './matches-filter-integration-test',
+  './eq-containment-integration-test',
   './search-in-flight-key-test',
   './coerce-error-message-test',
   './fallback-models-test',

--- a/packages/runtime-common/expression.ts
+++ b/packages/runtime-common/expression.ts
@@ -10,6 +10,7 @@ export type Expression = (
   | Param
   | TableValuedEach
   | TableValuedTree
+  | JsonContains
   | DBSpecificExpression
 )[];
 
@@ -70,6 +71,29 @@ export interface TableValuedTree {
   treeColumn: string;
 }
 
+// Deferred (pass-1 input) node for a non-null `eq` predicate. The first pass
+// resolves it against the field schema and decides — based on the leaf field's
+// serializer — whether it can become a GIN-servable `JsonContains`. It is the
+// `eq` analogue of FieldQuery.
+export interface JsonContainsQuery {
+  kind: 'json-contains-query';
+  path: string;
+  type: CodeRef;
+  value: CardExpression;
+}
+
+// Resolved (pass-2 input) node describing JSON containment of `column` by the
+// object formed from `segments` with `value` at the leaf — e.g. segments
+// ['customer','id'] => {"customer":{"id": <value>}}. Like TableValuedTree it
+// carries no SQL text and no schema dependence; expressionToSql renders it per
+// adapter (Postgres `@>`, SQLite `-> / ->>` extraction).
+export interface JsonContains {
+  kind: 'json-contains';
+  column: string;
+  segments: string[];
+  value: Param;
+}
+
 export interface FieldArity {
   type: CodeRef;
   path: string;
@@ -86,6 +110,8 @@ export type CardExpression = (
   | DBSpecificExpression
   | TableValuedEach
   | TableValuedTree
+  | JsonContains
+  | JsonContainsQuery
   | FieldQuery
   | FieldValue
   | FieldArity
@@ -179,6 +205,19 @@ export function tableValuedTree(
     rootPath,
     fieldPath,
     treeColumn,
+  };
+}
+
+export function jsonContainsQuery(
+  path: string,
+  type: CodeRef,
+  value: CardExpression,
+): JsonContainsQuery {
+  return {
+    kind: 'json-contains-query',
+    path,
+    type,
+    value,
   };
 }
 
@@ -479,6 +518,29 @@ export function expressionToSql(
         });
       }
       return name;
+    } else if (element.kind === 'json-contains') {
+      // Render the containment of `column` by {segments: value}. Both branches
+      // re-use renderElement so binds are pushed in left-to-right order.
+      let { column, segments, value } = element;
+      if (dbAdapterKind === 'sqlite') {
+        // SQLite has no `@>`; navigate the singular object path: interior
+        // segments with `->`, the leaf with `->>`, then compare. (Only string
+        // leaves reach here, so `->>` text-equality matches the value.)
+        let frag: Expression = [column];
+        segments.forEach((segment, i) => {
+          frag.push(i === segments.length - 1 ? '->>' : '->', param(segment));
+        });
+        frag.push('=', value);
+        return frag.map(renderElement).join(' ');
+      }
+      // Postgres: GIN-servable containment, full nested object from the root.
+      let nested = segments.reduceRight<JSONTypes.Value>(
+        (acc, segment) => ({ [segment]: acc }),
+        (value[dbAdapterKind] ?? value.param ?? null) as JSONTypes.Value,
+      );
+      return [column, '@>', param(nested as JSONTypes.Object), '::jsonb']
+        .map(renderElement)
+        .join(' ');
     } else {
       throw assertNever(element);
     }

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -23,6 +23,7 @@ import {
   type FieldQuery,
   type FieldValue,
   type FieldArity,
+  type JsonContainsQuery,
   param,
   isParam,
   tableValuedEach,
@@ -34,6 +35,7 @@ import {
   fieldQuery,
   fieldValue,
   fieldArity,
+  jsonContainsQuery,
   tableValuedFunctionsPlaceholder,
   query,
   dbExpression,
@@ -179,6 +181,16 @@ export const generalSortFields: Record<string, string> = {
 };
 
 export { isValidPrerenderedHtmlFormat };
+
+// Whether a predicate sits under an even (`positive`) or odd (`negated`) number
+// of enclosing `not` filters. The `@>` containment rewrite is only equivalent
+// to `->>` extraction at positive polarity: on an absent path `->>` yields SQL
+// NULL while `@>` yields FALSE, and `NOT NULL` vs `NOT FALSE` diverge.
+type FilterPolarity = 'positive' | 'negated';
+
+function flipPolarity(polarity: FilterPolarity): FilterPolarity {
+  return polarity === 'positive' ? 'negated' : 'positive';
+}
 
 export class IndexQueryEngine {
   #dbAdapter: DBAdapter;
@@ -599,7 +611,7 @@ export class IndexQueryEngine {
       }
 
       if (filter) {
-        conditions.push(this.filterCondition(filter, baseCardRef));
+        conditions.push(this.filterCondition(filter, baseCardRef, 'positive'));
       }
 
       let everyCondition = every(conditions);
@@ -975,7 +987,11 @@ export class IndexQueryEngine {
     return normalizeRealmMetaValue(results[0]?.value);
   }
 
-  private filterCondition(filter: Filter, onRef: CodeRef): CardExpression {
+  private filterCondition(
+    filter: Filter,
+    onRef: CodeRef,
+    polarity: FilterPolarity,
+  ): CardExpression {
     let typeRef = (filter as { type?: CodeRef }).type;
     let onProp = 'on' in filter ? filter.on : undefined;
     let on = onProp ?? typeRef ?? onRef;
@@ -986,13 +1002,13 @@ export class IndexQueryEngine {
     }
 
     if ('eq' in filter) {
-      return this.eqCondition(filter, on, typeConditionRef);
+      return this.eqCondition(filter, on, typeConditionRef, polarity);
     } else if ('in' in filter) {
       return this.inCondition(filter, on, typeConditionRef);
     } else if ('contains' in filter) {
       return this.containsCondition(filter, on, typeConditionRef);
     } else if ('not' in filter) {
-      return this.notCondition(filter, on, typeConditionRef);
+      return this.notCondition(filter, on, typeConditionRef, polarity);
     } else if ('range' in filter) {
       return this.rangeCondition(filter, on, typeConditionRef);
     } else if ('matches' in filter) {
@@ -1000,12 +1016,12 @@ export class IndexQueryEngine {
     } else if ('every' in filter) {
       return every([
         ...(typeConditionRef ? [this.typeCondition(typeConditionRef)] : []),
-        ...filter.every.map((i) => this.filterCondition(i, on)),
+        ...filter.every.map((i) => this.filterCondition(i, on, polarity)),
       ]);
     } else if ('any' in filter) {
       return every([
         ...(typeConditionRef ? [this.typeCondition(typeConditionRef)] : []),
-        any([...filter.any.map((i) => this.filterCondition(i, on))]),
+        any([...filter.any.map((i) => this.filterCondition(i, on, polarity))]),
       ]);
     } else {
       if (isCardTypeFilter(filter)) {
@@ -1029,12 +1045,13 @@ export class IndexQueryEngine {
     filter: EqFilter,
     on: CodeRef,
     typeConditionRef?: CodeRef,
+    polarity: FilterPolarity = 'positive',
   ): CardExpression {
     let typeRef = typeConditionRef;
     return every([
       ...(typeRef ? [this.typeCondition(typeRef)] : []),
       ...Object.entries(filter.eq).map(([key, value]) => {
-        return this.fieldEqFilter(key, value, on);
+        return this.fieldEqFilter(key, value, on, polarity);
       }),
     ]);
   }
@@ -1071,11 +1088,17 @@ export class IndexQueryEngine {
     filter: NotFilter,
     on: CodeRef,
     typeConditionRef?: CodeRef,
+    polarity: FilterPolarity = 'positive',
   ): CardExpression {
     let typeRef = typeConditionRef;
     return every([
       ...(typeRef ? [this.typeCondition(typeRef)] : []),
-      ['NOT', ...addExplicitParens(this.filterCondition(filter.not, on))],
+      [
+        'NOT',
+        ...addExplicitParens(
+          this.filterCondition(filter.not, on, flipPolarity(polarity)),
+        ),
+      ],
     ]);
   }
 
@@ -1134,6 +1157,7 @@ export class IndexQueryEngine {
     key: string,
     value: JSONTypes.Value,
     onRef: CodeRef,
+    polarity: FilterPolarity = 'positive',
   ): CardExpression {
     if (value === null) {
       let query = fieldQuery(key, onRef, true, 'filter');
@@ -1150,6 +1174,24 @@ export class IndexQueryEngine {
     }
     let query = fieldQuery(key, onRef, false, 'filter');
     let v = fieldValue(key, [param(value)], onRef, 'filter');
+    // At positive polarity a singular-path string `eq` can be served by the GIN
+    // `search_doc` index via a `@>` containment predicate. fieldArity routes on
+    // cardinality only: the singular branch resolves the containment-capable
+    // node (which itself falls back to `->>` extraction for numeric/non-string
+    // leaves), while a plural path anywhere uses the json_tree machinery. At
+    // negated polarity we keep plain extraction, whose NULL-on-absent-path
+    // semantics `@>` cannot reproduce under `NOT`.
+    if (polarity === 'positive') {
+      return [
+        fieldArity({
+          type: onRef,
+          path: key,
+          value: [jsonContainsQuery(key, onRef, [param(value)])],
+          pluralValue: [query, '=', v],
+          errorHint: 'filter',
+        }),
+      ];
+    }
     return [
       fieldArity({
         type: onRef,
@@ -1277,7 +1319,8 @@ export class IndexQueryEngine {
             isDbExpression(element) ||
             typeof element === 'string' ||
             element.kind === 'table-valued-each' ||
-            element.kind === 'table-valued-tree'
+            element.kind === 'table-valued-tree' ||
+            element.kind === 'json-contains'
           ) {
             return Promise.resolve([element]);
           } else if (element.kind === 'field-query') {
@@ -1286,6 +1329,8 @@ export class IndexQueryEngine {
             return this.handleFieldValue(element);
           } else if (element.kind === 'field-arity') {
             return this.handleFieldArity(element);
+          } else if (element.kind === 'json-contains-query') {
+            return this.handleJsonContainsQuery(element);
           } else {
             throw assertNever(element);
           }
@@ -1489,6 +1534,42 @@ export class IndexQueryEngine {
         return [param(queryValue)];
       },
     );
+  }
+
+  // Resolves a non-null `eq` predicate that fieldArity routed to a singular
+  // path (no plural segment was crossed). When the leaf is a string-valued,
+  // non-numeric field the predicate becomes a GIN-servable `JsonContains`
+  // node; otherwise it degrades to the same `->>` extraction equality the
+  // engine has always emitted — numeric leaves keep their `::numeric` cast
+  // semantics, non-string values keep text equality.
+  private async handleJsonContainsQuery(
+    node: JsonContainsQuery,
+  ): Promise<Expression> {
+    let { path, type, value } = node;
+    let resolvedValue = await this.makeExpression([
+      fieldValue(path, value, type, 'filter'),
+    ]);
+    let [leaf] = resolvedValue;
+    let definition = await this.getDefinition(type);
+    let leafField = await getField(definition, path, this.#definitionLookup);
+    let isNumericLeaf =
+      leafField.serializerName === 'number' ||
+      leafField.serializerName === 'big-integer';
+    if (isParam(leaf) && typeof leaf.param === 'string' && !isNumericLeaf) {
+      return [
+        {
+          kind: 'json-contains',
+          column: 'search_doc',
+          segments: path.split('.'),
+          value: leaf,
+        },
+      ];
+    }
+    return await this.makeExpression([
+      fieldQuery(path, type, false, 'filter'),
+      '=',
+      ...resolvedValue,
+    ]);
   }
 
   private async walkFilterFieldPath(


### PR DESCRIPTION
## What

On the realm-server search path, a singular-path scalar `eq` filter — e.g. `eq: { 'customer.id': X }` from a query-backed `linksToMany` getter — compiled to:

```sql
search_doc -> 'customer' ->> 'id' = $1
```

That `->>` path-extraction **cannot use the existing GIN `search_doc` index**, so Postgres narrows to the card type and then **heap-scans every row of that type**, discarding the non-matches. This PR rewrites such predicates as a containment:

```sql
search_doc @> '{"customer":{"id":X}}'::jsonb
```

which the existing `gin (search_doc)` index serves directly (bitmap index scan instead of a heap scan). On staging this was a ~33× win on the measured filter (200 ms → 6 ms, cold) for the same rows.

## How

The rewrite is a two-pass concern, modeled parallel to the existing table-valued (`json_tree`) machinery:

- **Pass 1 (schema-aware).** A new `JsonContainsQuery` node, emitted by `fieldEqFilter`. `fieldArity` still routes on **cardinality only** (singular → this node, plural → the existing `json_tree` + `fullkey LIKE` path). The resolver emits a `JsonContains` node only when the leaf is a **string-valued, non-numeric** field; otherwise it falls back to today's `->>` extraction.
- **Pass 2 (dialect).** `expressionToSql` renders `JsonContains` per adapter — Postgres `search_doc @> $n::jsonb` (nested object from the path segments), SQLite `search_doc -> 'a' ->> 'b' = $n`. SQLite has no `@>`, so it keeps the extraction form.

## Why the scope is exactly these three gates

The rewrite is applied only where `@>` containment is **provably equivalent** to the `->>` extraction equality it replaces:

1. **Singular paths only.** A plural segment *anywhere* in the path keeps the `json_tree` machinery — `@>`'s array containment is order-insensitive and "discard non-matching elements", so it loses the per-element positional binding that `fullkey LIKE '$.…[%]…'` enforces.
2. **String, non-numeric leaves only.** Numeric leaves (`number`/`big-integer`) keep their `::numeric` cast — JSON numeric normalization (`5` vs `5.0`) differs from text equality. Booleans never reach the branch (a boolean value isn't a string).
3. **Positive polarity only.** On an absent path `->>` yields SQL `NULL` while `@>` yields `FALSE`; identical in a positive filter, but under `not` they diverge (`NOT NULL` drops the row, `NOT FALSE` keeps it). A polarity flag is threaded through `filterCondition` (flipped at each `not`), and negated `eq` keeps extraction.

`@>` is also anchored from the document root (object containment is key-matched recursively from the top), so `{"customer":{"id":X}}` matches exactly `search_doc.customer.id == X` and never a stray `id` elsewhere — equivalent to the `-> … ->>` navigation, at any nesting depth.

## Behavior / compatibility

- **SQLite output is byte-identical** to before, so the host test suite (sqlite-backed) is unaffected.
- Plural-field, numeric, boolean, range, `in`, `contains`, `matches`, and negated filters are unchanged.

## Tests

Adds `eq-containment-integration-test.ts`, a Postgres integration test that asserts both the result set **and** which SQL form was emitted (by capturing executed SQL), covering: top-level string eq, `linksTo .id`, nested contains-composite, numeric, boolean, plural-leaf, interior-plural (`contacts.email` → `json_tree`), negated (preserving NULL-on-absent-path row exclusion), and double-negation (back to `@>`).
