### PR TITLE
Add instance-based filter matcher and sort comparator to runtime-common

### DIFF
--- a/packages/host/tests/unit/instance-filter-matcher-test.ts
+++ b/packages/host/tests/unit/instance-filter-matcher-test.ts
@@ -1,0 +1,561 @@
+import { module, test } from 'qunit';
+
+import {
+  Loader,
+  VirtualNetwork,
+  baseRealm,
+  fetcher,
+  maybeHandleScopedCSSRequest,
+  rri,
+  matchInstanceAgainstFilter,
+  isClientEvaluable,
+  makeInstanceComparator,
+  type CardAPIForMatching,
+  type Filter,
+  type Sort,
+  type CodeRef,
+} from '@cardstack/runtime-common';
+
+import ENV from '@cardstack/host/config/environment';
+import { shimExternals } from '@cardstack/host/lib/externals';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+
+import { testRealmURL, p } from '../helpers';
+
+let { resolvedBaseRealmURL } = ENV;
+
+module('Unit | instance-filter-matcher', function (hooks) {
+  let loader: Loader;
+  let api: CardAPIForMatching;
+  let personRef: CodeRef;
+  let fancyPersonRef: CodeRef;
+  let catRef: CodeRef;
+  let eventRef: CodeRef;
+  let cards: Record<string, CardDef> = {};
+
+  hooks.beforeEach(async function () {
+    let virtualNetwork = new VirtualNetwork();
+    virtualNetwork.addURLMapping(
+      new URL(baseRealm.url),
+      new URL(resolvedBaseRealmURL),
+    );
+    virtualNetwork.addImportMap('@cardstack/boxel-icons/', (rest) => {
+      return `${ENV.iconsURL}/@cardstack/boxel-icons/v1/icons/${rest}.js`;
+    });
+    shimExternals(virtualNetwork);
+    let fetch = fetcher(virtualNetwork.fetch, [
+      async (req, next) => {
+        return (await maybeHandleScopedCSSRequest(req)) || next(req);
+      },
+    ]);
+    loader = new Loader(fetch, virtualNetwork.resolveImport, {
+      virtualNetwork,
+    });
+
+    let cardApi = await loader.import<
+      typeof import('https://cardstack.com/base/card-api')
+    >(`${baseRealm.url}card-api`);
+    let string = await loader.import<any>(`${baseRealm.url}string`);
+    let number = await loader.import<any>(`${baseRealm.url}number`);
+    let boolean = await loader.import<any>(`${baseRealm.url}boolean`);
+    let date = await loader.import<any>(`${baseRealm.url}date`);
+
+    api = {
+      getQueryableValue: cardApi.getQueryableValue,
+      formatQueryValue: cardApi.formatQueryValue,
+      peekAtField: cardApi.peekAtField,
+      isNonPresentLink: cardApi.isNonPresentLink,
+      getCardMeta: cardApi.getCardMeta as CardAPIForMatching['getCardMeta'],
+      primitive: cardApi.primitive,
+    };
+
+    let {
+      field,
+      contains,
+      containsMany,
+      linksTo,
+      linksToMany,
+      CardDef,
+      FieldDef,
+      setCardAsSavedForTest,
+    } = cardApi;
+    let { default: StringField } = string;
+    let { default: NumberField } = number;
+    let { default: BooleanField } = boolean;
+    let { default: DateField } = date;
+
+    class Address extends FieldDef {
+      @field street = contains(StringField);
+      @field city = contains(StringField);
+    }
+    class Person extends CardDef {
+      @field name = contains(StringField);
+      @field nickNames = containsMany(StringField);
+      @field address = contains(Address);
+      @field bestFriend = linksTo(() => Person);
+      @field friends = linksToMany(() => Person);
+      @field age = contains(NumberField);
+      @field isHairy = contains(BooleanField);
+    }
+    class FancyPerson extends Person {
+      @field favoriteColor = contains(StringField);
+    }
+    class Cat extends CardDef {
+      @field name = contains(StringField);
+    }
+    class Event extends CardDef {
+      @field cardTitle = contains(StringField);
+      @field venue = contains(StringField);
+      @field date = contains(DateField);
+    }
+
+    loader.shimModule(`${testRealmURL}person`, { Person });
+    loader.shimModule(`${testRealmURL}fancy-person`, { FancyPerson });
+    loader.shimModule(`${testRealmURL}cat`, { Cat });
+    loader.shimModule(`${testRealmURL}event`, { Event });
+
+    personRef = { module: `${testRealmURL}person`, name: 'Person' };
+    fancyPersonRef = {
+      module: `${testRealmURL}fancy-person`,
+      name: 'FancyPerson',
+    };
+    catRef = { module: `${testRealmURL}cat`, name: 'Cat' };
+    eventRef = { module: `${testRealmURL}event`, name: 'Event' };
+
+    let ringo = new Person({
+      name: 'Ringo',
+      nickNames: ['Ring', 'Star'],
+      address: new Address({ street: '100 Treat Street', city: 'Waggington' }),
+      age: 5,
+      isHairy: true,
+    });
+    let vangogh = new Person({
+      name: 'Van Gogh',
+      nickNames: ['Vango'],
+      address: new Address({ street: '456 Grand Blvd', city: 'Barksville' }),
+      age: 7,
+      isHairy: false,
+      bestFriend: ringo,
+      friends: [ringo],
+    });
+    let mango = new FancyPerson({
+      name: 'Mango',
+      nickNames: ['Mang', 'Go'],
+      address: new Address({ street: '123 Main Street', city: 'Barksville' }),
+      age: 3,
+      isHairy: true,
+      favoriteColor: 'orange',
+      bestFriend: vangogh,
+      friends: [vangogh, ringo],
+    });
+    let paper = new Cat({ name: 'Paper' });
+    let mangoBirthday = new Event({
+      cardTitle: "Mango's Birthday",
+      venue: 'Dog Park',
+      date: p('2024-10-30'),
+    });
+    let vangoghBirthday = new Event({
+      cardTitle: "Van Gogh's Birthday",
+      venue: 'Backyard',
+      date: p('2024-11-19'),
+    });
+
+    cards = { ringo, vangogh, mango, paper, mangoBirthday, vangoghBirthday };
+    for (let [name, card] of Object.entries(cards)) {
+      card.id = rri(`${testRealmURL}${name}`);
+      setCardAsSavedForTest(card);
+    }
+  });
+
+  function match(card: CardDef, filter: Filter) {
+    return matchInstanceAgainstFilter(card, filter, api);
+  }
+
+  // -- eq ---------------------------------------------------------------------
+
+  test('eq on a string field', function (assert) {
+    let { mango, ringo } = cards;
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { name: 'Mango' } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(ringo, { on: personRef, eq: { name: 'Mango' } }),
+      'no-match',
+    );
+  });
+
+  test('eq on a nested contains field', function (assert) {
+    let { mango, ringo } = cards;
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { 'address.city': 'Barksville' } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(ringo, { on: personRef, eq: { 'address.city': 'Barksville' } }),
+      'no-match',
+    );
+  });
+
+  test('eq on number and boolean fields', function (assert) {
+    let { mango, ringo } = cards;
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { age: 3 } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(ringo, { on: personRef, eq: { age: 3 } }),
+      'no-match',
+    );
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { isHairy: true } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(cards.vangogh, { on: personRef, eq: { isHairy: true } }),
+      'no-match',
+    );
+  });
+
+  test('eq null matches an unset linksTo field', function (assert) {
+    let { ringo, mango } = cards;
+    // ringo has no bestFriend set; mango does.
+    assert.strictEqual(
+      match(ringo, { on: personRef, eq: { bestFriend: null } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { bestFriend: null } }),
+      'no-match',
+    );
+  });
+
+  test('eq across a linksTo field path', function (assert) {
+    let { mango } = cards;
+    // mango.bestFriend == vangogh
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { 'bestFriend.name': 'Van Gogh' } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { 'bestFriend.name': 'Ringo' } }),
+      'no-match',
+    );
+  });
+
+  // -- in ---------------------------------------------------------------------
+
+  test('in matches when the value is in the set', function (assert) {
+    let { mango, paper } = cards;
+    assert.strictEqual(
+      match(mango, { on: personRef, in: { name: ['Mango', 'Ringo'] } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(paper, { on: catRef, in: { name: ['Mango', 'Ringo'] } }),
+      'no-match',
+    );
+  });
+
+  test('in with an empty set matches nothing', function (assert) {
+    let { mango } = cards;
+    assert.strictEqual(
+      match(mango, { on: personRef, in: { name: [] } }),
+      'no-match',
+    );
+  });
+
+  // -- contains ---------------------------------------------------------------
+
+  test('contains is a case-insensitive substring match', function (assert) {
+    let { mango, ringo } = cards;
+    assert.strictEqual(
+      match(mango, { on: personRef, contains: { name: 'ang' } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(mango, { on: personRef, contains: { name: 'MANG' } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(ringo, { on: personRef, contains: { name: 'ang' } }),
+      'no-match',
+    );
+  });
+
+  test('contains matches existentially over a containsMany field', function (assert) {
+    let { mango, ringo } = cards;
+    // mango.nickNames = ['Mang', 'Go']
+    assert.strictEqual(
+      match(mango, { on: personRef, contains: { nickNames: 'go' } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(ringo, { on: personRef, contains: { nickNames: 'go' } }),
+      'no-match',
+    );
+  });
+
+  // -- range ------------------------------------------------------------------
+
+  test('range on a number field', function (assert) {
+    let { mango, vangogh } = cards;
+    assert.strictEqual(
+      match(vangogh, { on: personRef, range: { age: { gt: 5 } } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(mango, { on: personRef, range: { age: { gt: 5 } } }),
+      'no-match',
+    );
+    assert.strictEqual(
+      match(mango, { on: personRef, range: { age: { gte: 3, lte: 5 } } }),
+      'match',
+    );
+  });
+
+  test('range on a date field', function (assert) {
+    let { mangoBirthday, vangoghBirthday } = cards;
+    assert.strictEqual(
+      match(vangoghBirthday, {
+        on: eventRef,
+        range: { date: { gt: '2024-11-01' } },
+      }),
+      'match',
+    );
+    assert.strictEqual(
+      match(mangoBirthday, {
+        on: eventRef,
+        range: { date: { gt: '2024-11-01' } },
+      }),
+      'no-match',
+    );
+  });
+
+  // -- type / on --------------------------------------------------------------
+
+  test('a pure type filter walks the adoptsFrom chain', function (assert) {
+    let { mango, paper } = cards;
+    // mango is a FancyPerson, which adopts from Person
+    assert.strictEqual(match(mango, { type: personRef }), 'match');
+    assert.strictEqual(match(mango, { type: fancyPersonRef }), 'match');
+    assert.strictEqual(match(paper, { type: personRef }), 'no-match');
+    assert.strictEqual(match(paper, { type: catRef }), 'match');
+  });
+
+  test('an on-scoped predicate gates by type', function (assert) {
+    let { mango, vangogh } = cards;
+    assert.strictEqual(
+      match(mango, { on: fancyPersonRef, eq: { favoriteColor: 'orange' } }),
+      'match',
+    );
+    // vangogh is a plain Person, not a FancyPerson, so the gate fails.
+    assert.strictEqual(
+      match(vangogh, { on: fancyPersonRef, eq: { favoriteColor: 'orange' } }),
+      'no-match',
+    );
+  });
+
+  // -- boolean composition ----------------------------------------------------
+
+  test('every requires all sub-filters', function (assert) {
+    let { mango } = cards;
+    assert.strictEqual(
+      match(mango, {
+        on: personRef,
+        every: [{ eq: { name: 'Mango' } }, { eq: { age: 3 } }],
+      }),
+      'match',
+    );
+    assert.strictEqual(
+      match(mango, {
+        on: personRef,
+        every: [{ eq: { name: 'Mango' } }, { eq: { age: 99 } }],
+      }),
+      'no-match',
+    );
+  });
+
+  test('any requires at least one sub-filter', function (assert) {
+    let { mango } = cards;
+    assert.strictEqual(
+      match(mango, {
+        on: personRef,
+        any: [{ eq: { name: 'Nobody' } }, { eq: { age: 3 } }],
+      }),
+      'match',
+    );
+    assert.strictEqual(
+      match(mango, {
+        on: personRef,
+        any: [{ eq: { name: 'Nobody' } }, { eq: { age: 99 } }],
+      }),
+      'no-match',
+    );
+  });
+
+  test('not negates its child', function (assert) {
+    let { mango, ringo } = cards;
+    assert.strictEqual(
+      match(ringo, { on: personRef, not: { eq: { name: 'Mango' } } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(mango, { on: personRef, not: { eq: { name: 'Mango' } } }),
+      'no-match',
+    );
+  });
+
+  test('deeply nested every/any/not tree', function (assert) {
+    let { mango } = cards;
+    let filter: Filter = {
+      on: personRef,
+      every: [
+        { any: [{ eq: { name: 'Mango' } }, { eq: { name: 'Ringo' } }] },
+        { not: { eq: { age: 99 } } },
+        { range: { age: { lt: 10 } } },
+      ],
+    };
+    assert.strictEqual(match(mango, filter), 'match');
+  });
+
+  test('existential match over a linksToMany path', function (assert) {
+    let { mango } = cards;
+    // mango.friends = [vangogh, ringo]
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { 'friends.name': 'Ringo' } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { 'friends.name': 'Nobody' } }),
+      'no-match',
+    );
+  });
+
+  // -- unresolvable -----------------------------------------------------------
+
+  test('a not-loaded linksTo target is reported as unresolvable', async function (assert) {
+    let cardApi = await loader.import<any>(`${baseRealm.url}card-api`);
+    let doc = {
+      data: {
+        id: `${testRealmURL}lonely`,
+        type: 'card' as const,
+        attributes: { name: 'Lonely' },
+        relationships: {
+          bestFriend: { links: { self: `${testRealmURL}ghost` } },
+        },
+        meta: { adoptsFrom: personRef },
+      },
+    };
+    let lonely = (await cardApi.createFromSerialized(
+      doc.data,
+      doc,
+      new URL(testRealmURL),
+    )) as CardDef;
+
+    assert.strictEqual(
+      match(lonely, { on: personRef, eq: { 'bestFriend.name': 'Van Gogh' } }),
+      'unresolvable',
+      'a predicate over an unloaded link is unresolvable, never no-match',
+    );
+    // not() over an unresolvable predicate stays unresolvable — the integration
+    // layer must not remove the card on this basis.
+    assert.strictEqual(
+      match(lonely, {
+        on: personRef,
+        not: { eq: { 'bestFriend.name': 'Van Gogh' } },
+      }),
+      'unresolvable',
+    );
+    // A resolvable predicate on the same card still works.
+    assert.strictEqual(
+      match(lonely, { on: personRef, eq: { name: 'Lonely' } }),
+      'match',
+    );
+  });
+
+  // -- isClientEvaluable ------------------------------------------------------
+
+  test('isClientEvaluable rejects matches and unsupported operators', function (assert) {
+    assert.false(isClientEvaluable({ matches: 'hello' }));
+    assert.false(
+      isClientEvaluable({
+        on: personRef,
+        every: [{ eq: { name: 'x' } }, { matches: 'y' }],
+      }),
+    );
+    assert.false(isClientEvaluable({ on: personRef, any: [{ matches: 'y' }] }));
+    assert.false(isClientEvaluable({ not: { matches: 'y' } }));
+  });
+
+  test('isClientEvaluable accepts every supported operator', function (assert) {
+    assert.true(isClientEvaluable({ on: personRef, eq: { name: 'x' } }));
+    assert.true(isClientEvaluable({ on: personRef, in: { name: ['x'] } }));
+    assert.true(isClientEvaluable({ on: personRef, contains: { name: 'x' } }));
+    assert.true(
+      isClientEvaluable({ on: personRef, range: { age: { gt: 1 } } }),
+    );
+    assert.true(isClientEvaluable({ type: personRef }));
+    assert.true(
+      isClientEvaluable({
+        on: personRef,
+        every: [
+          { any: [{ eq: { name: 'x' } }, { not: { eq: { age: 1 } } }] },
+          { range: { age: { lt: 9 } } },
+        ],
+      }),
+    );
+  });
+
+  // -- comparator -------------------------------------------------------------
+
+  test('comparator orders by a single on-field key with direction', function (assert) {
+    let { mango, vangogh, ringo } = cards;
+    let sort: Sort = [{ on: personRef, by: 'name', direction: 'asc' }];
+    let sorted = [vangogh, ringo, mango].sort(
+      makeInstanceComparator(sort, api),
+    );
+    assert.deepEqual(
+      sorted.map((c) => (c as any).name),
+      ['Mango', 'Ringo', 'Van Gogh'],
+    );
+
+    let desc: Sort = [{ on: personRef, by: 'name', direction: 'desc' }];
+    let sortedDesc = [mango, ringo, vangogh].sort(
+      makeInstanceComparator(desc, api),
+    );
+    assert.deepEqual(
+      sortedDesc.map((c) => (c as any).name),
+      ['Van Gogh', 'Ringo', 'Mango'],
+    );
+  });
+
+  test('comparator orders by multiple keys', function (assert) {
+    let { mango, vangogh, ringo } = cards;
+    // city asc, then name desc. mango & vangogh share 'Barksville'.
+    let sort: Sort = [
+      { on: personRef, by: 'address.city', direction: 'asc' },
+      { on: personRef, by: 'name', direction: 'desc' },
+    ];
+    let sorted = [ringo, mango, vangogh].sort(
+      makeInstanceComparator(sort, api),
+    );
+    assert.deepEqual(
+      sorted.map((c) => (c as any).name),
+      ['Van Gogh', 'Mango', 'Ringo'],
+      'Barksville (Van Gogh, Mango by name desc) then Waggington (Ringo)',
+    );
+  });
+
+  test('comparator falls back to card URL as a deterministic tiebreak', function (assert) {
+    let { mango, ringo } = cards;
+    // No sort keys → order purely by id (cardURL) ascending.
+    let sorted = [ringo, mango].sort(makeInstanceComparator(undefined, api));
+    assert.deepEqual(
+      sorted.map((c) => c.id),
+      [mango.id, ringo.id],
+      'mango sorts before ringo by URL',
+    );
+  });
+});

--- a/packages/host/tests/unit/instance-filter-matcher-test.ts
+++ b/packages/host/tests/unit/instance-filter-matcher-test.ts
@@ -115,13 +115,13 @@ module('Unit | instance-filter-matcher', function (hooks) {
     loader.shimModule(`${testRealmURL}cat`, { Cat });
     loader.shimModule(`${testRealmURL}event`, { Event });
 
-    personRef = { module: `${testRealmURL}person`, name: 'Person' };
+    personRef = { module: rri(`${testRealmURL}person`), name: 'Person' };
     fancyPersonRef = {
-      module: `${testRealmURL}fancy-person`,
+      module: rri(`${testRealmURL}fancy-person`),
       name: 'FancyPerson',
     };
-    catRef = { module: `${testRealmURL}cat`, name: 'Cat' };
-    eventRef = { module: `${testRealmURL}event`, name: 'Event' };
+    catRef = { module: rri(`${testRealmURL}cat`), name: 'Cat' };
+    eventRef = { module: rri(`${testRealmURL}event`), name: 'Event' };
 
     let ringo = new Person({
       name: 'Ringo',

--- a/packages/host/tests/unit/instance-filter-matcher-test.ts
+++ b/packages/host/tests/unit/instance-filter-matcher-test.ts
@@ -244,6 +244,26 @@ module('Unit | instance-filter-matcher', function (hooks) {
     );
   });
 
+  test('an unset interior linksTo resolves to NULL at the leaf', function (assert) {
+    let { ringo } = cards;
+    // ringo.bestFriend is unset (present-and-null, not not-loaded). The server
+    // traverses `bestFriend -> name` to SQL NULL, so `eq null` matches and a
+    // non-null eq does not. Distinct from the not-loaded case, which is
+    // unresolvable.
+    assert.strictEqual(
+      match(ringo, { on: personRef, eq: { 'bestFriend.name': null } }),
+      'match',
+    );
+    assert.strictEqual(
+      match(ringo, { on: personRef, eq: { 'bestFriend.name': 'Van Gogh' } }),
+      'no-match',
+    );
+    assert.strictEqual(
+      match(ringo, { on: personRef, in: { 'bestFriend.name': [null] } }),
+      'match',
+    );
+  });
+
   // -- in ---------------------------------------------------------------------
 
   test('in matches when the value is in the set', function (assert) {

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -690,6 +690,7 @@ export * from './authorization-middleware';
 export * from './resource-types';
 export * from './prerender-headers';
 export * from './query';
+export * from './instance-filter-matcher';
 export * from './search-utils';
 export * from './request-timings';
 export * from './prerendered-html-format';

--- a/packages/runtime-common/instance-filter-matcher.ts
+++ b/packages/runtime-common/instance-filter-matcher.ts
@@ -187,6 +187,12 @@ function resolvePath(
 
   // Walk interior segments, descending into contained / linked instances.
   let sawUnresolvable = false;
+  // Count branches that bottom out at a null/unset interior segment. The
+  // server's JSON-path traversal yields a NULL leaf in that case (e.g.
+  // `search_doc -> 'bestFriend' -> 'name'` with `bestFriend` null is SQL
+  // NULL), so each such branch contributes one `null` leaf value below — only
+  // a null-valued predicate (`eq`/`in`/`contains` null) can match it.
+  let nullLeafCount = 0;
   for (let i = 0; i < segments.length - 1; i++) {
     let segment = segments[i];
     let next: BaseDef[] = [];
@@ -211,12 +217,15 @@ function resolvePath(
       let elements = isPlural ? (Array.isArray(raw) ? raw : []) : [raw];
       for (let element of elements) {
         if (api.isNonPresentLink(element)) {
+          // A not-loaded link can't be followed — distinct from present-and-null.
           sawUnresolvable = true;
           continue;
         }
-        if (element != null) {
-          next.push(element);
+        if (element == null) {
+          nullLeafCount++;
+          continue;
         }
+        next.push(element);
       }
     }
     nodes = next;
@@ -226,6 +235,9 @@ function resolvePath(
   let leaf = segments[segments.length - 1];
   let values: any[] = [];
   let leafField: Field<any> | undefined;
+  for (let i = 0; i < nullLeafCount; i++) {
+    values.push(null);
+  }
   for (let node of nodes) {
     if (node == null) {
       continue;

--- a/packages/runtime-common/instance-filter-matcher.ts
+++ b/packages/runtime-common/instance-filter-matcher.ts
@@ -1,0 +1,508 @@
+import isEqual from 'lodash/isEqual';
+
+import { getField, identifyCard } from './code-ref';
+import {
+  isAnyFilter,
+  isCardTypeFilter,
+  isEveryFilter,
+  isInFilter,
+  isMatchesFilter,
+  isNotFilter,
+  isRangeFilter,
+  type Filter,
+  type RangeFilterValue,
+  type RangeOperator,
+  type Sort,
+} from './query';
+
+import type { CodeRef } from './code-ref';
+import type {
+  BaseDef,
+  CardDef,
+  Field,
+} from 'https://cardstack.com/base/card-api';
+
+// The client-side counterpart to the server's `filterCondition()` /
+// `orderExpression()` in `index-query-engine.ts`. Those compile a `Query` to
+// SQL that runs against the flattened `search_doc`; the primitives here
+// evaluate the same `Filter` / `Sort` against a hydrated card-api instance by
+// reading its field values through the card-api module.
+//
+// A leaf comparison is kept faithful to the server by computing the field's
+// queryable value (`getQueryableValue`) and formatting the filter's value the
+// same way the server binds its parameters (`formatQueryValue`) before
+// comparing — i.e. both sides pass through the field's serializer, exactly as
+// they do in `handleFieldValue`.
+
+// The slice of the card-api module the matcher and comparator depend on. Card
+// instances are loaded at runtime, so the module is injected rather than
+// imported — runtime-common has no static dependency on `base/card-api`.
+export interface CardAPIForMatching {
+  getQueryableValue(fieldOrCard: any, value: any, stack?: BaseDef[]): any;
+  formatQueryValue(field: Field<any>, queryValue: any): any;
+  peekAtField(instance: BaseDef, fieldName: string): any;
+  isNonPresentLink(value: any): boolean;
+  getCardMeta(
+    card: BaseDef,
+    metaKey: 'lastModified' | 'resourceCreatedAt',
+  ): any;
+  primitive: symbol;
+}
+
+// Three-valued result, deliberately not a boolean. The integration layer needs
+// to tell "the instance fails the filter" apart from "the filter can't be
+// evaluated from loaded state" (e.g. a `linksTo` target absent from the Store),
+// so it never removes a server-returned card on the basis of a predicate it
+// couldn't actually resolve.
+export type MatchResult = 'match' | 'no-match' | 'unresolvable';
+
+const GENERAL_SORT_FIELDS = new Set(['lastModified', 'createdAt', 'cardURL']);
+
+// Operators the matcher can replicate in JS. `matches` (full-text) and any
+// operator not in this set force the caller to fall back to server-only
+// evaluation.
+export function isClientEvaluable(filter: Filter): boolean {
+  if (isMatchesFilter(filter)) {
+    return false;
+  }
+  if (isAnyFilter(filter)) {
+    return filter.any.every(isClientEvaluable);
+  }
+  if (isEveryFilter(filter)) {
+    return filter.every.every(isClientEvaluable);
+  }
+  if (isNotFilter(filter)) {
+    return isClientEvaluable(filter.not);
+  }
+  if (
+    'eq' in filter ||
+    isInFilter(filter) ||
+    'contains' in filter ||
+    isRangeFilter(filter) ||
+    isCardTypeFilter(filter)
+  ) {
+    return true;
+  }
+  // Unknown / non-replicable operator.
+  return false;
+}
+
+export function matchInstanceAgainstFilter(
+  instance: CardDef,
+  filter: Filter,
+  api: CardAPIForMatching,
+): MatchResult {
+  // A node may carry an `on`/`type` that gates which instances the predicate
+  // applies to, mirroring the server's `every([typeCondition, …])` wrapping.
+  // `on` takes precedence over `type` for the gate, matching `filterCondition`.
+  let onProp = 'on' in filter ? filter.on : undefined;
+  let typeRef = (filter as { type?: CodeRef }).type;
+  let typeGate: CodeRef | undefined = onProp ?? typeRef;
+
+  // Pure card-type filter — `{ type }` with no other predicate. A node that
+  // carries `type` *and* an operator (e.g. `{ type, eq }`) is not pure; there
+  // `type` only gates, exactly as the server treats it.
+  if (typeRef && Object.keys(filter).length === 1) {
+    return instanceIsType(instance, typeRef) ? 'match' : 'no-match';
+  }
+
+  // Any other node with an `on`/`type` is gated: if the instance isn't of that
+  // type the whole node is a no-match before we look at fields.
+  if (typeGate && !instanceIsType(instance, typeGate)) {
+    return 'no-match';
+  }
+
+  if (isEveryFilter(filter)) {
+    return combineAnd(
+      filter.every.map((f) => matchInstanceAgainstFilter(instance, f, api)),
+    );
+  }
+  if (isAnyFilter(filter)) {
+    return combineOr(
+      filter.any.map((f) => matchInstanceAgainstFilter(instance, f, api)),
+    );
+  }
+  if (isNotFilter(filter)) {
+    return negate(matchInstanceAgainstFilter(instance, filter.not, api));
+  }
+  if ('eq' in filter) {
+    return combineAnd(
+      Object.entries(filter.eq).map(([path, value]) =>
+        matchEq(instance, path, value, api),
+      ),
+    );
+  }
+  if (isInFilter(filter)) {
+    return combineAnd(
+      Object.entries(filter.in).map(([path, values]) =>
+        matchIn(instance, path, values as any[], api),
+      ),
+    );
+  }
+  if ('contains' in filter) {
+    return combineAnd(
+      Object.entries(filter.contains).map(([path, value]) =>
+        matchContains(instance, path, value, api),
+      ),
+    );
+  }
+  if (isRangeFilter(filter)) {
+    return combineAnd(
+      Object.entries(filter.range).map(([path, constraints]) =>
+        matchRange(instance, path, constraints as RangeFilterValue, api),
+      ),
+    );
+  }
+
+  // A `matches` filter, or anything else, isn't client-evaluable. Callers are
+  // expected to gate on `isClientEvaluable` first; treat as unresolvable rather
+  // than silently failing.
+  return 'unresolvable';
+}
+
+// -- field path resolution ---------------------------------------------------
+
+interface PathResolution {
+  // Queryable leaf values gathered across every resolvable branch of the path.
+  // Plural fields fan out, so this can hold more than one value even for a
+  // single starting instance — predicates match existentially over it.
+  values: any[];
+  // The leaf field definition, used to format the filter's value through the
+  // same serializer. Undefined when the path doesn't resolve to a field on the
+  // instance's type.
+  leafField: Field<any> | undefined;
+  // True if some branch couldn't be followed from loaded state (a `linksTo` /
+  // `linksToMany` target not in the Store). Lets predicates report
+  // `unresolvable` instead of a false `no-match`.
+  sawUnresolvable: boolean;
+}
+
+function resolvePath(
+  instance: BaseDef,
+  path: string,
+  api: CardAPIForMatching,
+): PathResolution {
+  let segments = path.split('.');
+  let nodes: BaseDef[] = [instance];
+
+  // Walk interior segments, descending into contained / linked instances.
+  let sawUnresolvable = false;
+  for (let i = 0; i < segments.length - 1; i++) {
+    let segment = segments[i];
+    let next: BaseDef[] = [];
+    for (let node of nodes) {
+      if (node == null) {
+        continue;
+      }
+      let field = getField(node, segment);
+      if (!field) {
+        // Field absent on this (possibly polymorphic) instance — this branch
+        // contributes no values.
+        continue;
+      }
+      let raw = api.peekAtField(node, segment);
+      let isPlural =
+        field.fieldType === 'containsMany' || field.fieldType === 'linksToMany';
+      let isPrimitiveCard = (api.primitive as any) in field.card;
+      // Can't traverse deeper into a primitive value.
+      if (isPrimitiveCard) {
+        continue;
+      }
+      let elements = isPlural ? (Array.isArray(raw) ? raw : []) : [raw];
+      for (let element of elements) {
+        if (api.isNonPresentLink(element)) {
+          sawUnresolvable = true;
+          continue;
+        }
+        if (element != null) {
+          next.push(element);
+        }
+      }
+    }
+    nodes = next;
+  }
+
+  // Leaf segment.
+  let leaf = segments[segments.length - 1];
+  let values: any[] = [];
+  let leafField: Field<any> | undefined;
+  for (let node of nodes) {
+    if (node == null) {
+      continue;
+    }
+    let field = getField(node, leaf);
+    if (!field) {
+      continue;
+    }
+    leafField = field;
+    let raw = api.peekAtField(node, leaf);
+    let queryable = api.getQueryableValue(field, raw);
+    let isPlural =
+      field.fieldType === 'containsMany' || field.fieldType === 'linksToMany';
+    if (isPlural && Array.isArray(queryable)) {
+      values.push(...queryable);
+    } else {
+      values.push(queryable);
+    }
+  }
+
+  return { values, leafField, sawUnresolvable };
+}
+
+// -- per-operator predicates -------------------------------------------------
+
+function matchEq(
+  instance: BaseDef,
+  path: string,
+  value: any,
+  api: CardAPIForMatching,
+): MatchResult {
+  let { values, leafField, sawUnresolvable } = resolvePath(instance, path, api);
+  // `eq: null` compiles to `IS NULL` on the server, which matches a field whose
+  // queryable value is null/absent.
+  if (value === null) {
+    return existential(values, sawUnresolvable, (lv) => lv == null);
+  }
+  let formatted = formatValue(leafField, value, api);
+  return existential(values, sawUnresolvable, (leafValue) =>
+    isEqual(leafValue, formatted),
+  );
+}
+
+function matchIn(
+  instance: BaseDef,
+  path: string,
+  rawValues: any[],
+  api: CardAPIForMatching,
+): MatchResult {
+  // The server compiles an empty `in` list to FALSE.
+  if (rawValues.length === 0) {
+    return 'no-match';
+  }
+  let { values, leafField, sawUnresolvable } = resolvePath(instance, path, api);
+  let hasNull = rawValues.some((v) => v === null);
+  let formatted = rawValues
+    .filter((v) => v !== null)
+    .map((v) => formatValue(leafField, v, api));
+  return existential(
+    values,
+    sawUnresolvable,
+    (leafValue) =>
+      (hasNull && leafValue == null) ||
+      formatted.some((fv) => isEqual(leafValue, fv)),
+  );
+}
+
+function matchContains(
+  instance: BaseDef,
+  path: string,
+  value: any,
+  api: CardAPIForMatching,
+): MatchResult {
+  let { values, leafField, sawUnresolvable } = resolvePath(instance, path, api);
+  // Server treats `contains: null` like `eq: null` (IS NULL).
+  if (value === null) {
+    return existential(values, sawUnresolvable, (lv) => lv == null);
+  }
+  let formatted = formatValue(leafField, value, api);
+  let needle = String(formatted).toLowerCase();
+  // Mirrors the server's case-insensitive `ILIKE %value%` substring match.
+  return existential(
+    values,
+    sawUnresolvable,
+    (lv) => typeof lv === 'string' && lv.toLowerCase().includes(needle),
+  );
+}
+
+function matchRange(
+  instance: BaseDef,
+  path: string,
+  constraints: RangeFilterValue,
+  api: CardAPIForMatching,
+): MatchResult {
+  let { values, leafField, sawUnresolvable } = resolvePath(instance, path, api);
+  let formattedConstraints = Object.entries(constraints).map(
+    ([operator, bound]) => {
+      if (bound == null) {
+        throw new Error(`'null' is not a permitted value in a 'range' filter`);
+      }
+      return [
+        operator as RangeOperator,
+        formatValue(leafField, bound, api),
+      ] as [RangeOperator, any];
+    },
+  );
+  return existential(values, sawUnresolvable, (leafValue) => {
+    if (leafValue == null) {
+      return false;
+    }
+    return formattedConstraints.every(([operator, bound]) =>
+      compareRange(leafValue, operator, bound),
+    );
+  });
+}
+
+function compareRange(
+  value: any,
+  operator: RangeOperator,
+  bound: any,
+): boolean {
+  switch (operator) {
+    case 'gt':
+      return value > bound;
+    case 'gte':
+      return value >= bound;
+    case 'lt':
+      return value < bound;
+    case 'lte':
+      return value <= bound;
+  }
+}
+
+// -- helpers -----------------------------------------------------------------
+
+function formatValue(
+  leafField: Field<any> | undefined,
+  value: any,
+  api: CardAPIForMatching,
+): any {
+  if (!leafField || value == null) {
+    return value;
+  }
+  return api.formatQueryValue(leafField, value);
+}
+
+function existential(
+  values: any[],
+  sawUnresolvable: boolean,
+  predicate: (value: any) => boolean,
+): MatchResult {
+  if (values.some(predicate)) {
+    return 'match';
+  }
+  return sawUnresolvable ? 'unresolvable' : 'no-match';
+}
+
+function combineAnd(results: MatchResult[]): MatchResult {
+  if (results.some((r) => r === 'no-match')) {
+    return 'no-match';
+  }
+  if (results.some((r) => r === 'unresolvable')) {
+    return 'unresolvable';
+  }
+  return 'match';
+}
+
+function combineOr(results: MatchResult[]): MatchResult {
+  if (results.some((r) => r === 'match')) {
+    return 'match';
+  }
+  if (results.some((r) => r === 'unresolvable')) {
+    return 'unresolvable';
+  }
+  return 'no-match';
+}
+
+function negate(result: MatchResult): MatchResult {
+  if (result === 'match') {
+    return 'no-match';
+  }
+  if (result === 'no-match') {
+    return 'match';
+  }
+  return 'unresolvable';
+}
+
+function instanceIsType(instance: BaseDef, ref: CodeRef): boolean {
+  let klass: typeof BaseDef | null =
+    (instance.constructor as typeof BaseDef) ?? null;
+  while (klass) {
+    let codeRef = identifyCard(klass);
+    if (codeRef && codeRefEquals(codeRef, ref)) {
+      return true;
+    }
+    klass = Object.getPrototypeOf(klass) as typeof BaseDef | null;
+  }
+  return false;
+}
+
+function codeRefEquals(a: CodeRef, b: CodeRef): boolean {
+  if (a && b && 'module' in a && 'name' in a && 'module' in b && 'name' in b) {
+    return a.module === b.module && a.name === b.name;
+  }
+  return isEqual(a, b);
+}
+
+// -- sort comparator ---------------------------------------------------------
+
+// Produces a comparator over instances that mirrors the server's ORDER BY:
+// each sort key in turn, NULLS LAST (independent of direction), with the card
+// URL (id) as the final, ascending tiebreak for deterministic ordering.
+export function makeInstanceComparator(
+  sort: Sort | undefined,
+  api: CardAPIForMatching,
+): (a: CardDef, b: CardDef) => number {
+  return (a: CardDef, b: CardDef) => {
+    for (let expression of sort ?? []) {
+      let direction = expression.direction === 'desc' ? -1 : 1;
+      let valueA = sortValue(a, expression, api);
+      let valueB = sortValue(b, expression, api);
+      let nullA = valueA == null;
+      let nullB = valueB == null;
+      if (nullA && nullB) {
+        continue;
+      }
+      // NULLS LAST regardless of direction.
+      if (nullA) {
+        return 1;
+      }
+      if (nullB) {
+        return -1;
+      }
+      let base = rawCompare(valueA, valueB);
+      if (base !== 0) {
+        return base * direction;
+      }
+    }
+    // Final deterministic tiebreak on the card URL, ascending.
+    return rawCompare(a.id, b.id);
+  };
+}
+
+function sortValue(
+  instance: CardDef,
+  expression: Sort[number],
+  api: CardAPIForMatching,
+): any {
+  if ('on' in expression && expression.on) {
+    let { values } = resolvePath(instance, expression.by, api);
+    return values.find((v) => v != null) ?? null;
+  }
+  switch (expression.by) {
+    case 'lastModified':
+      return api.getCardMeta(instance, 'lastModified') ?? null;
+    case 'createdAt':
+      return api.getCardMeta(instance, 'resourceCreatedAt') ?? null;
+    case 'cardURL':
+      return instance.id ?? null;
+    default:
+      return null;
+  }
+}
+
+function rawCompare(a: any, b: any): number {
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a - b;
+  }
+  let sa = String(a);
+  let sb = String(b);
+  if (sa < sb) {
+    return -1;
+  }
+  if (sa > sb) {
+    return 1;
+  }
+  return 0;
+}
+
+export { GENERAL_SORT_FIELDS };


### PR DESCRIPTION
## What

Adds the client-side evaluation primitives that the upcoming Store filtering step builds on (CS-11415). They live in `runtime-common` next to `query.ts` and are the instance-based counterpart to the server's `filterCondition()` / `orderExpression()` in `index-query-engine.ts`: where the server compiles a `Query` to SQL over the indexed `search_doc`, these evaluate the same `Filter` / `Sort` against a hydrated card-api instance.

New `packages/runtime-common/instance-filter-matcher.ts`:

- **`matchInstanceAgainstFilter(instance, filter, api)`** → three-valued `'match' | 'no-match' | 'unresolvable'`. The third state lets the integration layer distinguish a failed predicate from one that can't be evaluated from loaded state (e.g. a `linksTo` target absent from the Store), so it never removes a server-returned card on the basis of an unresolvable predicate.
- **`isClientEvaluable(filter)`** → `false` for `matches` (full-text) or any non-replicable operator, so a query can fall back to server-only.
- **`makeInstanceComparator(sort, api)`** → JS comparator mirroring the server's ORDER BY: multi-key, direction, NULLS LAST, with the card URL as the deterministic tiebreak.

Supported operators: `eq`, `in`, `contains`, `range`, `type`/`on`, `every`, `any`, `not`.

The card-api module is injected (not imported) so `runtime-common` keeps no static dependency on `base/card-api`.

## Semantics / parity notes

- Leaf comparisons run both sides through the field serializer — `getQueryableValue` on the instance value, `formatQueryValue` on the filter value — exactly as the server does in `handleFieldValue`.
- `type`/`on` is evaluated against the instance's `adoptsFrom` chain.
- Plural fields (`containsMany` / `linksToMany`) match existentially.
- `eq`/`in`/`contains` with `null` mirror the server's `IS NULL`.
- A field path that crosses a not-loaded `linksTo` / `linksToMany` target is reported `unresolvable`, never a false `no-match`.

No host integration in this PR — pure `runtime-common` primitives + tests.

## Testing

- `packages/host/tests/unit/instance-filter-matcher-test.ts` (new): 24 tests / 57 assertions covering every supported operator, nested `every`/`any`/`not` trees, `on`-scoped gating, `eq null`, existential plural paths, the unresolvable not-loaded-link case (including `not` over it), `isClientEvaluable`, and single/multi-key sort with direction + URL tiebreak.
- `ember-tsc --noEmit` clean in both `runtime-common` and `host`.
- Suite green: **24 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)