### PR TITLE
Support creating a catalog listing for a component

### DIFF
--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -1,3 +1,5 @@
+import { service } from '@ember/service';
+
 import type {
   LooseSingleCardDocument,
   ResolvedCodeRef,
@@ -23,6 +25,11 @@ import type { Spec } from 'https://cardstack.com/base/spec';
 
 import HostBaseCommand from '../lib/host-base-command';
 
+import {
+  findDeclarationByName,
+  isComponentDeclaration,
+} from '../services/module-contents-service';
+
 import AuthedFetchCommand from './authed-fetch';
 import CreateSpecCommand from './create-specs';
 import GenerateThumbnailCommand from './generate-thumbnail';
@@ -35,7 +42,9 @@ import SearchAndChooseCommand from './search-and-choose';
 import { SearchCardsByTypeAndTitleCommand } from './search-cards';
 import StoreAddCommand from './store-add';
 
-type ListingType = 'card' | 'skill' | 'theme' | 'field';
+import type ModuleContentsService from '../services/module-contents-service';
+
+type ListingType = 'card' | 'skill' | 'theme' | 'field' | 'component';
 
 const BASE_CARD_API_MODULE = 'https://cardstack.com/base/card-api';
 const BASE_SKILL_MODULE = 'https://cardstack.com/base/skill';
@@ -45,12 +54,15 @@ const listingSubClass: Record<ListingType, string> = {
   skill: 'SkillListing',
   theme: 'ThemeListing',
   field: 'FieldListing',
+  component: 'ComponentListing',
 };
 
 export default class ListingCreateCommand extends HostBaseCommand<
   typeof BaseCommandModule.ListingCreateInput,
   typeof BaseCommandModule.ListingCreateResult
 > {
+  @service declare private moduleContentsService: ModuleContentsService;
+
   static actionVerb = 'Create';
   description = 'Create a catalog listing for an example card';
 
@@ -190,6 +202,12 @@ export default class ListingCreateCommand extends HostBaseCommand<
   private async guessListingType(
     codeRef: ResolvedCodeRef,
   ): Promise<ListingType> {
+    // A Glimmer component isn't a card/field def, so loadCardDef can't classify
+    // it — detect it from the module's declarations before falling through.
+    if (await this.isComponentExport(codeRef)) {
+      return 'component';
+    }
+
     let cardDef;
     try {
       cardDef = await loadCardDef(codeRef, {
@@ -209,6 +227,18 @@ export default class ListingCreateCommand extends HostBaseCommand<
       return 'skill';
     }
     return 'card';
+  }
+
+  private async isComponentExport(codeRef: ResolvedCodeRef): Promise<boolean> {
+    try {
+      let declarations = await this.moduleContentsService.assemble(
+        codeRef.module,
+      );
+      let declaration = findDeclarationByName(codeRef.name, declarations);
+      return declaration ? isComponentDeclaration(declaration) : false;
+    } catch {
+      return false;
+    }
   }
 
   private isAncestor(

--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -64,7 +64,8 @@ export default class ListingCreateCommand extends HostBaseCommand<
   @service declare private moduleContentsService: ModuleContentsService;
 
   static actionVerb = 'Create';
-  description = 'Create a catalog listing for an example card';
+  description =
+    'Create a catalog listing for a card, field, skill, theme, or component';
 
   private async getCatalogRealm(): Promise<string> {
     const { realmIdentifiers } = await new GetCatalogRealmIdentifiersCommand(

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -50,6 +50,7 @@ import {
   type ModuleDeclaration,
   isCardOrFieldDeclaration,
   isCommandDeclaration,
+  isComponentDeclaration,
   isReexportCardOrField,
 } from '@cardstack/host/resources/module-contents';
 
@@ -219,6 +220,14 @@ export default class DetailPanel extends Component<Signature> {
     );
   }
 
+  private get showComponentPanel() {
+    return (
+      this.isModule &&
+      this.args.selectedDeclaration &&
+      isComponentDeclaration(this.args.selectedDeclaration)
+    );
+  }
+
   private get cardType() {
     if (
       this.args.selectedDeclaration &&
@@ -241,9 +250,27 @@ export default class DetailPanel extends Component<Signature> {
   private get definitionActions() {
     if (
       this.args.selectedDeclaration &&
-      !isCardOrFieldDeclaration(this.args.selectedDeclaration)
+      !isCardOrFieldDeclaration(this.args.selectedDeclaration) &&
+      !isComponentDeclaration(this.args.selectedDeclaration)
     ) {
       return [];
+    }
+    // A component declaration isn't instantiable or inheritable like a card def,
+    // so the only definition action it supports is being published as a listing.
+    if (
+      this.args.selectedDeclaration &&
+      isComponentDeclaration(this.args.selectedDeclaration)
+    ) {
+      return this.realm.canWrite(this.args.readyFile.url) &&
+        this.args.selectedDeclaration.exportName
+        ? [
+            {
+              label: 'Create Listing',
+              icon: Package,
+              handler: this.createListing,
+            },
+          ]
+        : [];
     }
     return [
       // internal cards are not really meant to be addressable instances, but
@@ -448,7 +475,19 @@ export default class DetailPanel extends Component<Signature> {
       }
       await command.execute({ openCardIds, codeRef, targetRealm });
     } else {
-      const codeRef: ResolvedCodeRef = this.selectedDeclarationAsCodeRef;
+      let codeRef: ResolvedCodeRef = this.selectedDeclarationAsCodeRef;
+      // A default-exported component surfaces with exportName 'default'; use the
+      // class's local name so the listing and its spec read as the component
+      // (e.g. "SubmissionTestComponent") rather than "default".
+      let decl = this.args.selectedDeclaration;
+      if (
+        decl &&
+        isComponentDeclaration(decl) &&
+        codeRef.name === 'default' &&
+        decl.localName
+      ) {
+        codeRef = { ...codeRef, name: decl.localName };
+      }
       let openCardIds: string[] = this.args.cardInstance?.id
         ? [this.args.cardInstance.id]
         : [];
@@ -763,6 +802,24 @@ export default class DetailPanel extends Component<Signature> {
           </PanelHeader>
           <ModuleDefinitionContainer
             @title='Command'
+            @fileURL={{@readyFile.url}}
+            @name={{this.selectedDeclarationName}}
+            @fileExtension={{this.fileExtension}}
+            @isActive={{true}}
+            @actions={{this.definitionActions}}
+            @infoText={{this.lastModified.value}}
+          />
+        </PanelSection>
+      {{else if this.showComponentPanel}}
+        <PanelSection as |PanelHeader|>
+          <PanelHeader
+            aria-label='Component Panel Header'
+            data-test-component-panel-header
+          >
+            Component
+          </PanelHeader>
+          <ModuleDefinitionContainer
+            @title='Component'
             @fileURL={{@readyFile.url}}
             @name={{this.selectedDeclarationName}}
             @fileExtension={{this.fileExtension}}

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -248,13 +248,6 @@ export default class DetailPanel extends Component<Signature> {
   }
 
   private get definitionActions() {
-    if (
-      this.args.selectedDeclaration &&
-      !isCardOrFieldDeclaration(this.args.selectedDeclaration) &&
-      !isComponentDeclaration(this.args.selectedDeclaration)
-    ) {
-      return [];
-    }
     // A component declaration isn't instantiable or inheritable like a card def,
     // so the only definition action it supports is being published as a listing.
     if (
@@ -271,6 +264,12 @@ export default class DetailPanel extends Component<Signature> {
             },
           ]
         : [];
+    }
+    if (
+      this.args.selectedDeclaration &&
+      !isCardOrFieldDeclaration(this.args.selectedDeclaration)
+    ) {
+      return [];
     }
     return [
       // internal cards are not really meant to be addressable instances, but

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -20,6 +20,7 @@ import {
   type CommandDeclaration,
   isCardOrFieldDeclaration,
   isCommandDeclaration,
+  isComponentDeclaration,
   isReexportCardOrField,
 } from '@cardstack/host/services/module-contents-service';
 import type NetworkService from '@cardstack/host/services/network';
@@ -27,6 +28,7 @@ import type NetworkService from '@cardstack/host/services/network';
 export {
   isCardOrFieldDeclaration,
   isCommandDeclaration,
+  isComponentDeclaration,
   isReexportCardOrField,
   type ModuleDeclaration,
   type CardOrFieldDeclaration,

--- a/packages/host/app/services/module-contents-service.ts
+++ b/packages/host/app/services/module-contents-service.ts
@@ -90,9 +90,7 @@ export function isComponentDeclaration(
   let { name, module } = declaration.super;
   return (
     module === '@glimmer/component' ||
-    (name === 'Component' &&
-      module === 'https://cardstack.com/base/card-api') ||
-    name === 'GlimmerComponent'
+    (name === 'Component' && module === 'https://cardstack.com/base/card-api')
   );
 }
 

--- a/packages/host/app/services/module-contents-service.ts
+++ b/packages/host/app/services/module-contents-service.ts
@@ -77,6 +77,25 @@ export function isReexportCardOrField(
   );
 }
 
+export function isComponentDeclaration(
+  declaration: ModuleDeclaration,
+): boolean {
+  if (
+    !('super' in declaration) ||
+    !declaration.super ||
+    declaration.super.type !== 'external'
+  ) {
+    return false;
+  }
+  let { name, module } = declaration.super;
+  return (
+    module === '@glimmer/component' ||
+    (name === 'Component' &&
+      module === 'https://cardstack.com/base/card-api') ||
+    name === 'GlimmerComponent'
+  );
+}
+
 function hasCardOrFieldProperties(declaration: ModuleDeclaration) {
   return (
     (declaration as CardOrField).cardType !== undefined &&


### PR DESCRIPTION
## Summary

Lets a Glimmer **component** be turned into a catalog listing from code mode. Previously the code-mode detail panel showed no actions for a component declaration, and `ListingCreateCommand` classified everything non-card/field as a `CardListing`.

- **detail-panel**: renders a **Component** panel that exposes the **Create Listing** action for component declarations (nothing rendered before for non-card/field declarations). For default-exported components it passes the class's local name so the listing and its spec read as the component rather than `default`.
- **module-contents-service**: adds an `isComponentDeclaration` helper (detects `@glimmer/component` / base `Component` supers), re-exported via `resources/module-contents`.
- **listing-create** (host): detects a component export from the module's declarations so `guessListingType` returns `component` → `ComponentListing`.

The catalog-content side (the `ComponentListing` subclass, the catalog `listing-create` detection, and the submission `collect-submission-files` fix) lives in the boxel-catalog repo: cardstack/boxel-catalog#595.

Addresses CS-11378, CS-11379, CS-11380.

## Testing
In code mode, open a component module, select the export, and use **Create Listing** → a `ComponentListing` is created with a spec per dependency module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)