### PR TITLE
Re-evaluate SystemCard when active card is deleted in-tab

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -216,6 +216,11 @@ export default class MatrixService extends Service {
   @tracked private _systemCardLoadFailed = false;
   private _userChoiceId: string | undefined;
   private _systemCardInvalidationUnsub: (() => void) | undefined;
+  // Sticky "the active SystemCard was deleted in-session" signal. Bridges the
+  // synchronous failure detection in `onSystemCardInvalidated` with the
+  // asynchronous re-entry into `setSystemCard(undefined)` from the matrix
+  // account-data echo. Cleared whenever `setSystemCard` resolves a card.
+  private _systemCardWasLost = false;
   agentId: string | undefined;
 
   constructor(owner: Owner) {
@@ -1517,6 +1522,7 @@ export default class MatrixService extends Service {
     this._systemCardInvalidationUnsub?.();
     this._systemCardInvalidationUnsub = undefined;
     this._userChoiceId = undefined;
+    this._systemCardWasLost = false;
     this._systemCard = undefined;
     this._systemCardLoadFailed = false;
     this.startedAtTs = -1;
@@ -2387,8 +2393,15 @@ export default class MatrixService extends Service {
       }
     }
 
+    // Clear the post-loss signal before deriving the banner state so a
+    // successful resolution in this call does not re-trip the third clause.
+    if (loadedCard) {
+      this._systemCardWasLost = false;
+    }
     this._systemCardLoadFailed =
-      envDefaultFailed || (userChoiceFailed && !envDefaultId);
+      envDefaultFailed ||
+      (userChoiceFailed && !envDefaultId) ||
+      (this._systemCardWasLost && !loadedCard);
 
     if (loadedCard?.id !== this._systemCard?.id) {
       this._systemCardInvalidationUnsub?.();
@@ -2421,19 +2434,13 @@ export default class MatrixService extends Service {
     this._systemCardInvalidationUnsub = undefined;
     this.store.dropReference(this._systemCard?.id);
     this._systemCard = undefined;
+    // Sticky signal that survives the asynchronous matrix account-data echo
+    // below — keeps `_systemCardLoadFailed` true through any re-entry into
+    // `setSystemCard(undefined)` until a replacement card actually resolves.
+    this._systemCardWasLost = true;
     await this.setSystemCard(this._userChoiceId);
-    let chainStillBroken = this._systemCardLoadFailed;
     if (wasUserChoice) {
       await this.setUserSystemCard(undefined);
-      // Clearing the preference round-trips through the account-data event
-      // and re-enters setSystemCard(undefined). When no env default is
-      // configured that path looks identical to MVP steady state and writes
-      // `_systemCardLoadFailed = false` — but we are *not* in steady state
-      // here; the user just lost their chosen card with no fallback to take
-      // over. Re-assert the broken signal so the banner persists.
-      if (chainStillBroken) {
-        this._systemCardLoadFailed = true;
-      }
     }
   };
 

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -214,6 +214,8 @@ export default class MatrixService extends Service {
   private roomsWaitingForSync: Map<string, Deferred<void>> = new Map();
   @tracked private _systemCard: SystemCard | undefined;
   @tracked private _systemCardLoadFailed = false;
+  private _userChoiceId: string | undefined;
+  private _systemCardInvalidationUnsub: (() => void) | undefined;
   agentId: string | undefined;
 
   constructor(owner: Owner) {
@@ -1512,6 +1514,9 @@ export default class MatrixService extends Service {
     this.initialSyncCompleted = false;
     this.initialSyncCompletedDeferred = new Deferred<void>();
     this.roomsWaitingForSync.clear();
+    this._systemCardInvalidationUnsub?.();
+    this._systemCardInvalidationUnsub = undefined;
+    this._userChoiceId = undefined;
     this._systemCard = undefined;
     this._systemCardLoadFailed = false;
     this.startedAtTs = -1;
@@ -2347,6 +2352,7 @@ export default class MatrixService extends Service {
   }
 
   private async setSystemCard(userChoiceId: string | undefined) {
+    this._userChoiceId = userChoiceId;
     let envDefaultId = ENV.defaultSystemCardId;
 
     if (userChoiceId && userChoiceId === this._systemCard?.id) {
@@ -2385,13 +2391,51 @@ export default class MatrixService extends Service {
       envDefaultFailed || (userChoiceFailed && !envDefaultId);
 
     if (loadedCard?.id !== this._systemCard?.id) {
+      this._systemCardInvalidationUnsub?.();
+      this._systemCardInvalidationUnsub = undefined;
       this.store.dropReference(this._systemCard?.id);
       if (loadedCard) {
         this.store.addReference(loadedCard.id);
+        // Capture the id in the closure — by the time the callback fires, the
+        // store has evicted the card, so we cannot read it off `_systemCard`.
+        let subscribedId = loadedCard.id;
+        this._systemCardInvalidationUnsub =
+          this.store.subscribeToCardInvalidation(subscribedId, () =>
+            this.onSystemCardInvalidated(subscribedId),
+          );
       }
       this._systemCard = loadedCard;
     }
   }
+
+  // Fires when the active SystemCard is deleted in the same session (either
+  // via the in-tab UI or via a matrix-auth-room invalidation originating
+  // elsewhere). Re-evaluate the chain so the fallback banner surfaces or the
+  // env-default silently takes over, and clear the matrix preference when the
+  // dangling id was the user's own pick so it does not keep being rebroadcast.
+  private onSystemCardInvalidated = async (invalidatedId: string) => {
+    let wasUserChoice = this._userChoiceId === invalidatedId;
+    // Drop the doomed reference so setSystemCard does not take its id-match
+    // fast path against the now-evicted instance.
+    this._systemCardInvalidationUnsub?.();
+    this._systemCardInvalidationUnsub = undefined;
+    this.store.dropReference(this._systemCard?.id);
+    this._systemCard = undefined;
+    await this.setSystemCard(this._userChoiceId);
+    let chainStillBroken = this._systemCardLoadFailed;
+    if (wasUserChoice) {
+      await this.setUserSystemCard(undefined);
+      // Clearing the preference round-trips through the account-data event
+      // and re-enters setSystemCard(undefined). When no env default is
+      // configured that path looks identical to MVP steady state and writes
+      // `_systemCardLoadFailed = false` — but we are *not* in steady state
+      // here; the user just lost their chosen card with no fallback to take
+      // over. Re-assert the broken signal so the banner persists.
+      if (chainStillBroken) {
+        this._systemCardLoadFailed = true;
+      }
+    }
+  };
 
   async setUserSystemCard(systemCardId: string | undefined) {
     // This sets the users account data for their preferred system card

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -431,9 +431,23 @@ export default class StoreService extends Service implements StoreInterface {
       return;
     }
     // Snapshot to tolerate unsubscribe-from-callback without skipping siblings.
+    // Subscribers may be async — catch rejections that escape the synchronous
+    // try/catch so a failure in one handler does not become an unhandled
+    // promise rejection or starve sibling handlers.
     for (let cb of [...subscribers]) {
       try {
-        cb();
+        let maybePromise = cb() as unknown;
+        if (
+          maybePromise &&
+          typeof (maybePromise as PromiseLike<unknown>).then === 'function'
+        ) {
+          (maybePromise as Promise<unknown>).catch((err) =>
+            console.error(
+              `card invalidation subscriber for ${normalizedId} rejected`,
+              err,
+            ),
+          );
+        }
       } catch (err) {
         console.error(
           `card invalidation subscriber for ${normalizedId} threw`,

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -224,6 +224,7 @@ export default class StoreService extends Service implements StoreInterface {
   @service declare private operatorModeStateService: OperatorModeStateService;
   @service declare private realmServer: RealmServerService;
   private subscriptions: Map<string, { unsubscribe: () => void }> = new Map();
+  private cardInvalidationSubscribers: Map<string, Set<() => void>> = new Map();
   private referenceCount: ReferenceCount = new Map();
   private newReferencePromises: Promise<void>[] = [];
   private autoSaveStates: TrackedMap<string, AutoSaveState> = new TrackedMap();
@@ -323,6 +324,7 @@ export default class StoreService extends Service implements StoreInterface {
   resetState() {
     clearInterval(this.gcInterval);
     this.subscriptions = new Map();
+    this.cardInvalidationSubscribers = new Map();
     this.onSaveSubscriber = undefined;
     this.referenceCount = new Map();
     this.newReferencePromises = [];
@@ -394,6 +396,51 @@ export default class StoreService extends Service implements StoreInterface {
     storeLogger.debug(`resetting store for code change${reasonSuffix}`);
     this.store.reset();
     this.reestablishReferences.perform();
+  }
+
+  // Notify-on-delete for callers that hold a card by direct JS reference rather
+  // than by linksTo. `consumersOf` only walks linksTo refs, so a direct holder
+  // (e.g. MatrixService's `_systemCard`) would otherwise stay pinned to a
+  // now-evicted instance until the next reload. Subscribers fire from both
+  // delete paths — `delete()` (in-tab UI) and the `reloadTask` 404 branch
+  // (matrix-auth-room invalidation for cross-tab / cross-machine deletes).
+  subscribeToCardInvalidation(id: string, cb: () => void): () => void {
+    let normalizedId = asURL(id, this.network.virtualNetwork);
+    let subscribers = this.cardInvalidationSubscribers.get(normalizedId);
+    if (!subscribers) {
+      subscribers = new Set();
+      this.cardInvalidationSubscribers.set(normalizedId, subscribers);
+    }
+    subscribers.add(cb);
+    return () => {
+      let current = this.cardInvalidationSubscribers.get(normalizedId);
+      if (!current) {
+        return;
+      }
+      current.delete(cb);
+      if (current.size === 0) {
+        this.cardInvalidationSubscribers.delete(normalizedId);
+      }
+    };
+  }
+
+  private notifyCardInvalidationSubscribers(id: string) {
+    let normalizedId = asURL(id, this.network.virtualNetwork);
+    let subscribers = this.cardInvalidationSubscribers.get(normalizedId);
+    if (!subscribers) {
+      return;
+    }
+    // Snapshot to tolerate unsubscribe-from-callback without skipping siblings.
+    for (let cb of [...subscribers]) {
+      try {
+        cb();
+      } catch (err) {
+        console.error(
+          `card invalidation subscriber for ${normalizedId} threw`,
+          err,
+        );
+      }
+    }
   }
 
   dropReference(id: string | undefined) {
@@ -809,6 +856,11 @@ export default class StoreService extends Service implements StoreInterface {
       }
     }
     await this.cardService.fetchJSON(id, { method: 'DELETE' });
+    // Notify direct-reference holders (e.g. MatrixService's `_systemCard`)
+    // only AFTER the server DELETE completes — these subscribers typically
+    // re-evaluate by calling `store.get(id)`, which is cache-first and would
+    // otherwise refetch the still-extant file and miss the deletion.
+    this.notifyCardInvalidationSubscribers(id);
   }
 
   async patch<T extends CardDef = CardDef>(
@@ -1660,6 +1712,10 @@ export default class StoreService extends Service implements StoreInterface {
         for (let consumer of consumers) {
           api.notifyLinksToTargetDeleted(consumer, instance.id);
         }
+        // Notify direct-reference holders after the local eviction so their
+        // re-evaluation does not return the cached pre-delete instance.
+        // (The server is already gone — we got here from a 404 reload.)
+        this.notifyCardInvalidationSubscribers(instance.id);
       }
     } finally {
       this.finishTrackingCardLoad(instance.id, reloadTracker);

--- a/packages/host/tests/integration/components/ai-assistant-panel/fallback-banner-live-delete-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/fallback-banner-live-delete-test.gts
@@ -1,0 +1,361 @@
+import { settled, waitFor } from '@ember/test-helpers';
+
+import GlimmerComponent from '@glimmer/component';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm, type Realm } from '@cardstack/runtime-common';
+
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import OperatorMode from '@cardstack/host/components/operator-mode/container';
+
+import ENV from '@cardstack/host/config/environment';
+
+import type AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type StoreService from '@cardstack/host/services/store';
+
+import {
+  testRealmURL,
+  setupCardLogs,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupOnSave,
+  setupOperatorModeStateCleanup,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../../helpers';
+import { setupBaseRealm } from '../../../helpers/base-realm';
+import { setupMockMatrix } from '../../../helpers/mock-matrix';
+import { renderComponent } from '../../../helpers/render-component';
+import { setupRenderingTest } from '../../../helpers/setup';
+
+const USER_CHOICE_ID = `${testRealmURL}SystemCard/user-choice`;
+const ENV_DEFAULT_ID = `${testRealmURL}SystemCard/env-default`;
+
+const SYSTEM_CARD_CONTENT = {
+  data: {
+    type: 'card',
+    attributes: {},
+    meta: {
+      adoptsFrom: {
+        module: 'https://cardstack.com/base/system-card',
+        name: 'SystemCard',
+      },
+    },
+  },
+};
+
+function envDefaultGuard(hooks: NestedHooks) {
+  let original: string | undefined;
+  hooks.beforeEach(function () {
+    original = ENV.defaultSystemCardId;
+  });
+  hooks.afterEach(function () {
+    ENV.defaultSystemCardId = original;
+  });
+}
+
+function commonSetup(hooks: NestedHooks) {
+  let loader: Loader;
+
+  setupRenderingTest(hooks);
+  setupOperatorModeStateCleanup(hooks);
+  setupBaseRealm(hooks);
+  envDefaultGuard(hooks);
+
+  hooks.beforeEach(function () {
+    loader = getService('loader-service').loader;
+  });
+
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+  setupCardLogs(
+    hooks,
+    async () => await loader.import(`${baseRealm.url}card-api`),
+  );
+  setupRealmCacheTeardown(hooks);
+}
+
+async function seedRealm(
+  mockMatrixUtils: ReturnType<typeof setupMockMatrix>,
+  opts: { withEnvDefault: boolean; withUserChoice: boolean },
+): Promise<Realm> {
+  let contents: Record<string, unknown> = {
+    '.realm.json': `{ "name": "Fallback Banner Live Delete Test Realm" }`,
+  };
+  if (opts.withUserChoice) {
+    contents['SystemCard/user-choice.json'] = SYSTEM_CARD_CONTENT;
+  }
+  if (opts.withEnvDefault) {
+    contents['SystemCard/env-default.json'] = SYSTEM_CARD_CONTENT;
+  }
+  let realm!: Realm;
+  await withCachedRealmSetup(async () => {
+    let setup = await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents,
+    });
+    realm = setup.realm;
+    return setup;
+  });
+  return realm;
+}
+
+async function openAiAssistantPanel(): Promise<void> {
+  let operatorModeStateService = getService(
+    'operator-mode-state-service',
+  ) as OperatorModeStateService;
+  operatorModeStateService.restore({ stacks: [[]] });
+
+  await renderComponent(
+    class TestDriver extends GlimmerComponent {
+      noop = () => {};
+      <template><OperatorMode @onClose={{this.noop}} /></template>
+    },
+  );
+
+  let aiAssistantPanelService = getService(
+    'ai-assistant-panel-service',
+  ) as AiAssistantPanelService;
+  aiAssistantPanelService.openPanel();
+  await settled();
+  await waitFor('[data-test-close-ai-assistant]');
+}
+
+module(
+  'Integration | ai-assistant-panel | fallback-banner | live delete | in-tab UI delete of user-chosen card, no env default',
+  function (hooks) {
+    commonSetup(hooks);
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
+      autostart: false,
+      systemCardAccountData: { id: USER_CHOICE_ID },
+    });
+
+    hooks.beforeEach(async function () {
+      ENV.defaultSystemCardId = undefined;
+      await seedRealm(mockMatrixUtils, {
+        withUserChoice: true,
+        withEnvDefault: false,
+      });
+      let matrixService = getService('matrix-service') as MatrixService;
+      await matrixService.ready;
+      await matrixService.start();
+    });
+
+    test('deleting the active SystemCard in-tab surfaces the fallback banner and clears the user preference', async function (assert) {
+      await openAiAssistantPanel();
+      let matrixService = getService('matrix-service') as MatrixService;
+      assert.strictEqual(
+        matrixService.systemCard?.id,
+        USER_CHOICE_ID,
+        'precondition: the user-chosen SystemCard is active',
+      );
+      assert
+        .dom('[data-test-fallback-banner]')
+        .doesNotExist('precondition: banner is not shown while the card loads');
+
+      let storeService = getService('store') as StoreService;
+      await storeService.delete(USER_CHOICE_ID);
+      await settled();
+
+      assert
+        .dom('[data-test-fallback-banner]')
+        .exists('banner appears after the active SystemCard is deleted in-tab');
+      assert.true(
+        matrixService.isUsingFallbackSystemCard,
+        'chain reported as broken once the active card is gone',
+      );
+      assert.strictEqual(
+        matrixService.systemCard,
+        undefined,
+        'the deleted card is no longer the active SystemCard',
+      );
+      assert.deepEqual(
+        mockMatrixUtils.getSystemCardAccountData(),
+        { id: undefined },
+        'matrix account-data preference is cleared so the dangling id is not rebroadcast',
+      );
+    });
+  },
+);
+
+module(
+  'Integration | ai-assistant-panel | fallback-banner | live delete | cross-machine delete of user-chosen card, no env default',
+  function (hooks) {
+    commonSetup(hooks);
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
+      autostart: false,
+      systemCardAccountData: { id: USER_CHOICE_ID },
+    });
+    let realm!: Realm;
+
+    hooks.beforeEach(async function () {
+      ENV.defaultSystemCardId = undefined;
+      realm = await seedRealm(mockMatrixUtils, {
+        withUserChoice: true,
+        withEnvDefault: false,
+      });
+      let matrixService = getService('matrix-service') as MatrixService;
+      await matrixService.ready;
+      await matrixService.start();
+    });
+
+    test('a delete originating elsewhere (realm invalidation) surfaces the banner and clears the user preference', async function (assert) {
+      await openAiAssistantPanel();
+      let matrixService = getService('matrix-service') as MatrixService;
+      assert.strictEqual(
+        matrixService.systemCard?.id,
+        USER_CHOICE_ID,
+        'precondition: the user-chosen SystemCard is active',
+      );
+
+      // Bypass StoreService.delete — simulate the other-tab / other-machine
+      // path where the realm deletes the file and broadcasts an invalidation
+      // event into the realm auth room.
+      await realm.delete('SystemCard/user-choice.json');
+      await settled();
+
+      assert
+        .dom('[data-test-fallback-banner]')
+        .exists('banner appears after the cross-machine deletion propagates');
+      assert.true(
+        matrixService.isUsingFallbackSystemCard,
+        'chain reported as broken once the realm invalidation arrives',
+      );
+      assert.strictEqual(
+        matrixService.systemCard,
+        undefined,
+        'the deleted card is no longer the active SystemCard',
+      );
+      assert.deepEqual(
+        mockMatrixUtils.getSystemCardAccountData(),
+        { id: undefined },
+        'matrix account-data preference is cleared on cross-machine deletion too',
+      );
+    });
+  },
+);
+
+module(
+  'Integration | ai-assistant-panel | fallback-banner | live delete | env default deleted with no user choice',
+  function (hooks) {
+    commonSetup(hooks);
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
+      autostart: false,
+    });
+    let realm!: Realm;
+
+    hooks.beforeEach(async function () {
+      ENV.defaultSystemCardId = ENV_DEFAULT_ID;
+      realm = await seedRealm(mockMatrixUtils, {
+        withUserChoice: false,
+        withEnvDefault: true,
+      });
+      let matrixService = getService('matrix-service') as MatrixService;
+      await matrixService.ready;
+      await matrixService.start();
+    });
+
+    test('deleting the env-default SystemCard surfaces the banner without touching account data', async function (assert) {
+      await openAiAssistantPanel();
+      let matrixService = getService('matrix-service') as MatrixService;
+      assert.strictEqual(
+        matrixService.systemCard?.id,
+        ENV_DEFAULT_ID,
+        'precondition: env default is the active SystemCard',
+      );
+      assert.strictEqual(
+        mockMatrixUtils.getSystemCardAccountData(),
+        undefined,
+        'precondition: no user preference is recorded',
+      );
+
+      await realm.delete('SystemCard/env-default.json');
+      await settled();
+
+      assert
+        .dom('[data-test-fallback-banner]')
+        .exists('banner appears after the env-default card is deleted');
+      assert.true(
+        matrixService.isUsingFallbackSystemCard,
+        'chain reported as broken once env default is gone',
+      );
+      assert.strictEqual(
+        matrixService.systemCard,
+        undefined,
+        'no SystemCard is active after the env default is deleted',
+      );
+      assert.strictEqual(
+        mockMatrixUtils.getSystemCardAccountData(),
+        undefined,
+        'no account-data write occurs when the deleted card was the env default, not a user pick',
+      );
+    });
+  },
+);
+
+module(
+  'Integration | ai-assistant-panel | fallback-banner | live delete | user-chosen card deleted, env default takes over silently',
+  function (hooks) {
+    commonSetup(hooks);
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
+      autostart: false,
+      systemCardAccountData: { id: USER_CHOICE_ID },
+    });
+
+    hooks.beforeEach(async function () {
+      ENV.defaultSystemCardId = ENV_DEFAULT_ID;
+      await seedRealm(mockMatrixUtils, {
+        withUserChoice: true,
+        withEnvDefault: true,
+      });
+      let matrixService = getService('matrix-service') as MatrixService;
+      await matrixService.ready;
+      await matrixService.start();
+    });
+
+    test('env default silently takes over and the user preference is cleared, no banner', async function (assert) {
+      await openAiAssistantPanel();
+      let matrixService = getService('matrix-service') as MatrixService;
+      assert.strictEqual(
+        matrixService.systemCard?.id,
+        USER_CHOICE_ID,
+        'precondition: the user-chosen SystemCard is active',
+      );
+
+      let storeService = getService('store') as StoreService;
+      await storeService.delete(USER_CHOICE_ID);
+      await settled();
+
+      assert
+        .dom('[data-test-fallback-banner]')
+        .doesNotExist('no banner — env default takes over silently');
+      assert.false(
+        matrixService.isUsingFallbackSystemCard,
+        'chain is healthy once env default takes over',
+      );
+      assert.strictEqual(
+        matrixService.systemCard?.id,
+        ENV_DEFAULT_ID,
+        'env default is the active SystemCard after deletion',
+      );
+      assert.deepEqual(
+        mockMatrixUtils.getSystemCardAccountData(),
+        { id: undefined },
+        'matrix account-data preference is cleared even when env default rescues us',
+      );
+    });
+  },
+);

--- a/packages/host/tests/integration/components/ai-assistant-panel/fallback-banner-live-delete-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/fallback-banner-live-delete-test.gts
@@ -84,15 +84,15 @@ async function seedRealm(
   mockMatrixUtils: ReturnType<typeof setupMockMatrix>,
   opts: { withEnvDefault: boolean; withUserChoice: boolean },
 ): Promise<Realm> {
-  let contents: Record<string, unknown> = {
+  let contents = {
     '.realm.json': `{ "name": "Fallback Banner Live Delete Test Realm" }`,
+    ...(opts.withUserChoice && {
+      'SystemCard/user-choice.json': SYSTEM_CARD_CONTENT,
+    }),
+    ...(opts.withEnvDefault && {
+      'SystemCard/env-default.json': SYSTEM_CARD_CONTENT,
+    }),
   };
-  if (opts.withUserChoice) {
-    contents['SystemCard/user-choice.json'] = SYSTEM_CARD_CONTENT;
-  }
-  if (opts.withEnvDefault) {
-    contents['SystemCard/env-default.json'] = SYSTEM_CARD_CONTENT;
-  }
   let realm!: Realm;
   await withCachedRealmSetup(async () => {
     let setup = await setupIntegrationTestRealm({

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -1273,6 +1273,140 @@ module('Integration | Store', function (hooks) {
     assert.strictEqual(file, undefined, 'file no longer exists');
   });
 
+  test('subscribeToCardInvalidation fires the callback when the card is deleted', async function (assert) {
+    storeService.addReference(`${testRealmURL}Person/boris`);
+    await storeService.flush();
+
+    let fired = 0;
+    let unsubscribe = storeService.subscribeToCardInvalidation(
+      `${testRealmURL}Person/boris`,
+      () => {
+        fired += 1;
+      },
+    );
+
+    await storeService.delete(`${testRealmURL}Person/boris`);
+
+    assert.strictEqual(
+      fired,
+      1,
+      'the invalidation subscriber fires exactly once on delete',
+    );
+    unsubscribe();
+  });
+
+  test('subscribeToCardInvalidation unsubscribe stops firing the callback', async function (assert) {
+    storeService.addReference(`${testRealmURL}Person/boris`);
+    await storeService.flush();
+
+    let fired = 0;
+    let unsubscribe = storeService.subscribeToCardInvalidation(
+      `${testRealmURL}Person/boris`,
+      () => {
+        fired += 1;
+      },
+    );
+    unsubscribe();
+
+    await storeService.delete(`${testRealmURL}Person/boris`);
+
+    assert.strictEqual(fired, 0, 'no callbacks fire after unsubscribe');
+  });
+
+  test('a synchronously throwing invalidation subscriber does not break siblings', async function (assert) {
+    storeService.addReference(`${testRealmURL}Person/boris`);
+    await storeService.flush();
+
+    let originalError = console.error;
+    let captured: unknown[] = [];
+    console.error = (...args: unknown[]) => {
+      captured.push(args);
+    };
+
+    let secondFired = 0;
+    let unsubscribeA = storeService.subscribeToCardInvalidation(
+      `${testRealmURL}Person/boris`,
+      () => {
+        throw new Error('intentional sync throw from invalidation subscriber');
+      },
+    );
+    let unsubscribeB = storeService.subscribeToCardInvalidation(
+      `${testRealmURL}Person/boris`,
+      () => {
+        secondFired += 1;
+      },
+    );
+
+    try {
+      await storeService.delete(`${testRealmURL}Person/boris`);
+
+      assert.strictEqual(
+        secondFired,
+        1,
+        'the second subscriber still runs after the first one throws',
+      );
+      assert.strictEqual(
+        captured.length,
+        1,
+        'the synchronous throw is reported via console.error exactly once',
+      );
+    } finally {
+      unsubscribeA();
+      unsubscribeB();
+      console.error = originalError;
+    }
+  });
+
+  test('an async-rejecting invalidation subscriber does not break siblings and does not surface as an unhandled rejection', async function (assert) {
+    storeService.addReference(`${testRealmURL}Person/boris`);
+    await storeService.flush();
+
+    let originalError = console.error;
+    let captured: unknown[] = [];
+    console.error = (...args: unknown[]) => {
+      captured.push(args);
+    };
+
+    let secondFired = 0;
+    let unsubscribeA = storeService.subscribeToCardInvalidation(
+      `${testRealmURL}Person/boris`,
+      async () => {
+        await Promise.resolve();
+        throw new Error(
+          'intentional async rejection from invalidation subscriber',
+        );
+      },
+    );
+    let unsubscribeB = storeService.subscribeToCardInvalidation(
+      `${testRealmURL}Person/boris`,
+      () => {
+        secondFired += 1;
+      },
+    );
+
+    try {
+      await storeService.delete(`${testRealmURL}Person/boris`);
+      // Drain the microtask queue so the rejected promise's catch handler runs
+      // and any unhandled-rejection event would have already fired.
+      await settled();
+
+      assert.strictEqual(
+        secondFired,
+        1,
+        'the second subscriber still runs alongside the async-rejecting one',
+      );
+      assert.strictEqual(
+        captured.length,
+        1,
+        'the async rejection is reported via console.error exactly once',
+      );
+    } finally {
+      unsubscribeA();
+      unsubscribeB();
+      console.error = originalError;
+    }
+  });
+
   test('can patch an instance', async function (assert) {
     let instance = await storeService.patch(`${testRealmURL}Person/hassan`, {
       attributes: {


### PR DESCRIPTION
## Summary

`MatrixService` holds the active `SystemCard` via a direct JS reference plus a `store.addReference`. The store's existing consumer rewrite on delete walks `linksTo` only, so a direct-reference holder is never notified — the cached card stays stale and the CS-11254 fallback banner does not surface until the next reload.

This change adds a narrow id-keyed signal:

- `StoreService.subscribeToCardInvalidation(id, cb)` returns an unsubscribe handle. It fires from both delete sites — `StoreService.delete()` after the server DELETE completes, and the `reloadTask` 404 branch after local eviction (the path matrix-auth-room invalidations take when the delete originates in another tab or on another machine). Notification is ordered after the cache and the source of truth are in agreement so that a subscriber's `store.get` re-fetch sees the 404.
- `MatrixService` subscribes when it sets `_systemCard` and unsubscribes alongside `dropReference`. It caches `_userChoiceId` so the recovery call to `setSystemCard` does not need to re-read account data. On invalidation it drops the doomed reference, clears `_systemCard` (to defeat the existing id-match fast path), re-runs `setSystemCard`, and — when the deleted id was the user's pick — clears the matrix preference via `setUserSystemCard(undefined)` so the dangling id is not rebroadcast. Where no env default is configured the broken-chain signal is re-asserted after the clear, since the account-data round-trip would otherwise look like MVP steady state and hide the failure.

Linear: [CS-11315](https://linear.app/cardstack/issue/CS-11315/re-evaluate-systemcard-chain-in-tab-when-the-active-card-is-deleted)

## Test plan

New module `packages/host/tests/integration/components/ai-assistant-panel/fallback-banner-live-delete-test.gts` covers four scenarios:

- [x] In-tab UI delete of user-chosen card, no env default → banner appears, account data cleared
- [x] Cross-machine delete (via `realm.delete` → auth-room invalidation) of user-chosen card, no env default → banner appears, account data cleared
- [x] Env-default deletion with no user choice → banner appears, account data untouched
- [x] User-chosen card deleted with env default configured → env default takes over silently, no banner, account data cleared

All four pass (22/22 assertions). Existing `fallback-banner` reload-path tests still pass (18/18, 44/44 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)