### PR TITLE
fix(boxel-cli): auto-bump unstable version on manual publish

### DIFF
--- a/.github/workflows/boxel-cli-publish.yml
+++ b/.github/workflows/boxel-cli-publish.yml
@@ -239,6 +239,32 @@ jobs:
           git push origin main --follow-tags
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 
+      - name: Bump to next unstable version
+        # Manual (`workflow_dispatch`, blank confirm) path only. The push path
+        # already computes/commits a fresh `-unstable.<n>` via compute-release.ts;
+        # this step gives the manual path the same guarantee without that
+        # machinery. The manual path deliberately doesn't commit the bump back
+        # to main, so the repo can't track the counter — npm is the source of
+        # truth. We read the published versions and pick the next free
+        # `<base>-unstable.<n>`, so a manual publish can never collide with an
+        # already-published version (the E403 this step exists to prevent).
+        if: github.event_name == 'workflow_dispatch'
+        working-directory: packages/boxel-cli
+        run: |
+          set -euo pipefail
+          node -e '
+            const { execSync } = require("child_process"), fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            // Drop any existing -unstable.<n> to get the base we iterate on.
+            const base = pkg.version.split("-unstable.")[0];
+            const pub = JSON.parse(execSync("npm view @cardstack/boxel-cli versions --json"));
+            const re = new RegExp("^" + base.replace(/\./g, "\\.") + "-unstable\\.(\\d+)$");
+            const ns = pub.map((v) => (v.match(re) || [])[1]).filter((x) => x != null).map(Number);
+            pkg.version = base + "-unstable." + (ns.length ? Math.max(...ns) + 1 : 0);
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+            console.log("next unstable version → " + pkg.version);
+          '
+
       - name: Publish to npm
         if: github.event_name == 'workflow_dispatch' || (steps.pr.outputs.skip != 'true' && steps.release.outputs.npmBump != 'none')
         working-directory: packages/boxel-cli

--- a/.github/workflows/boxel-cli-publish.yml
+++ b/.github/workflows/boxel-cli-publish.yml
@@ -9,9 +9,11 @@ name: boxel-cli publish
 #         tag, and publish `@cardstack/boxel-cli@<v>-unstable.<n>` under
 #         dist-tag `unstable`.
 #       - Via "Run workflow" with the `confirm` field left blank — skip the
-#         bump/commit/tag dance and publish whatever version is currently in
-#         `packages/boxel-cli/package.json` under dist-tag `unstable`. Fails
-#         loudly if that version is already on npm (npm refuses to clobber).
+#         PR-driven bump/commit/tag dance, derive the next free
+#         `<base>-unstable.<n>` from npm (npm is the source of truth; the bump
+#         is not committed back to main), and publish it under dist-tag
+#         `unstable`. Resolving the counter from npm keeps the manual path from
+#         clobbering an existing version or colliding with the push path.
 #
 #   • `stable` job — "Run workflow" with `confirm = promote`. Strips
 #     `-unstable.<n>` from the current version and publishes the resulting
@@ -241,13 +243,14 @@ jobs:
 
       - name: Bump to next unstable version
         # Manual (`workflow_dispatch`, blank confirm) path only. The push path
-        # already computes/commits a fresh `-unstable.<n>` via compute-release.ts;
-        # this step gives the manual path the same guarantee without that
-        # machinery. The manual path deliberately doesn't commit the bump back
-        # to main, so the repo can't track the counter — npm is the source of
-        # truth. We read the published versions and pick the next free
-        # `<base>-unstable.<n>`, so a manual publish can never collide with an
-        # already-published version (the E403 this step exists to prevent).
+        # already computes a fresh `-unstable.<n>` via compute-release.ts; this
+        # step gives the manual path the same guarantee. The manual path
+        # deliberately doesn't commit the bump back to main, so the repo can't
+        # track the counter — npm is the source of truth. The script reads the
+        # published versions and picks the next free `<base>-unstable.<n>`, so a
+        # manual publish can never collide with an already-published version
+        # (the E403 this step exists to prevent). The push path resolves its
+        # counter from npm too (compute-release.ts), so they can't collide either.
         if: github.event_name == 'workflow_dispatch'
         working-directory: packages/boxel-cli
         run: |
@@ -257,7 +260,9 @@ jobs:
             const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
             // Drop any existing -unstable.<n> to get the base we iterate on.
             const base = pkg.version.split("-unstable.")[0];
-            const pub = JSON.parse(execSync("npm view @cardstack/boxel-cli versions --json"));
+            // `npm view ... versions --json` is an array, or a bare string when
+            // exactly one version is published; `[].concat` normalizes both.
+            const pub = [].concat(JSON.parse(execSync("npm view @cardstack/boxel-cli versions --json")));
             const re = new RegExp("^" + base.replace(/\./g, "\\.") + "-unstable\\.(\\d+)$");
             const ns = pub.map((v) => (v.match(re) || [])[1]).filter((x) => x != null).map(Number);
             pkg.version = base + "-unstable." + (ns.length ? Math.max(...ns) + 1 : 0);

--- a/.github/workflows/boxel-cli-publish.yml
+++ b/.github/workflows/boxel-cli-publish.yml
@@ -262,9 +262,12 @@ jobs:
             const base = pkg.version.split("-unstable.")[0];
             // `npm view ... versions --json` is an array, or a bare string when
             // exactly one version is published; `[].concat` normalizes both.
+            // A non-zero exit (npm outage) is left to abort the run rather than
+            // be treated as "nothing published" — the latter would pick
+            // -unstable.0 and re-create the collision this step prevents.
             const pub = [].concat(JSON.parse(execSync("npm view @cardstack/boxel-cli versions --json")));
             const re = new RegExp("^" + base.replace(/\./g, "\\.") + "-unstable\\.(\\d+)$");
-            const ns = pub.map((v) => (v.match(re) || [])[1]).filter((x) => x != null).map(Number);
+            const ns = pub.filter((v) => typeof v === "string").map((v) => (v.match(re) || [])[1]).filter((x) => x != null).map(Number);
             pkg.version = base + "-unstable." + (ns.length ? Math.max(...ns) + 1 : 0);
             fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
             console.log("next unstable version → " + pkg.version);

--- a/packages/boxel-cli/package.json
+++ b/packages/boxel-cli/package.json
@@ -52,6 +52,7 @@
     "@cardstack/runtime-common": "workspace:*",
     "@types/jsonwebtoken": "catalog:",
     "@types/node": "catalog:",
+    "@types/semver": "^7.7.0",
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "concurrently": "catalog:",
@@ -60,6 +61,7 @@
     "eslint-plugin-n": "catalog:",
     "eslint-plugin-prettier": "catalog:",
     "prettier": "catalog:",
+    "semver": "^7.7.0",
     "ts-node": "^10.9.1",
     "vite": "catalog:",
     "vitest": "catalog:"

--- a/packages/boxel-cli/scripts/compute-release.ts
+++ b/packages/boxel-cli/scripts/compute-release.ts
@@ -244,29 +244,32 @@ function readJsonVersion(path: string): string {
   return json.version;
 }
 
-function npmUnstableCounters(base: string): number[] {
-  // `npm view ... versions --json` yields an array, or a bare string when
-  // exactly one version is published; `[].concat` normalizes both. Empty when
-  // the package was never published (E404 → non-zero exit).
-  let raw: string;
-  try {
-    raw = execSync('npm view @cardstack/boxel-cli versions --json', {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-      .toString()
-      .trim();
-  } catch {
-    return [];
-  }
-  if (!raw) return [];
-  const versions: string[] = [].concat(JSON.parse(raw));
+// Pure: the `-unstable.<n>` counters already published for `base`. Tolerates
+// any npm output shape — non-string entries are dropped rather than throwing.
+export function unstableCounters(base: string, versions: unknown[]): number[] {
   const re = new RegExp(
     '^' + base.replace(/\./g, '\\.') + '-unstable\\.(\\d+)$',
   );
   return versions
+    .filter((v): v is string => typeof v === 'string')
     .map((v) => (v.match(re) || [])[1])
     .filter((x): x is string => x != null)
     .map(Number);
+}
+
+function fetchNpmVersions(): unknown[] {
+  // `npm view ... versions --json` yields an array, or a bare string when
+  // exactly one version is published; `[].concat` normalizes both. We
+  // deliberately don't swallow a non-zero exit (npm outage / registry error):
+  // treating it as "nothing published" would pick `-unstable.0` and re-create
+  // the version collision this whole change exists to prevent. The package
+  // already exists on npm, so the first-publish E404 case isn't reachable.
+  const raw = execSync('npm view @cardstack/boxel-cli versions --json', {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+    .toString()
+    .trim();
+  return raw ? [].concat(JSON.parse(raw)) : [];
 }
 
 function main(): void {
@@ -309,7 +312,7 @@ function main(): void {
   });
   if (result.nextNpm) {
     const base = result.nextNpm.replace(/-unstable\.\d+$/, '');
-    const counters = npmUnstableCounters(base);
+    const counters = unstableCounters(base, fetchNpmVersions());
     const n = counters.length ? Math.max(...counters) + 1 : 0;
     result.nextNpm = `${base}-unstable.${n}`;
     result.prereleaseN = n;

--- a/packages/boxel-cli/scripts/compute-release.ts
+++ b/packages/boxel-cli/scripts/compute-release.ts
@@ -13,6 +13,8 @@ import { readFileSync } from 'fs';
 import { execSync } from 'child_process';
 import { resolve } from 'path';
 
+import semver from 'semver';
+
 import bumpByPrefixJson from './release-prefixes.json';
 import { lastStableTag } from './lib/tags';
 
@@ -101,38 +103,20 @@ export function detectSurfaces(changedFiles: string[]): {
   return { npmTouched, pluginTouched };
 }
 
-export interface ParsedVersion {
-  major: number;
-  minor: number;
-  patch: number;
-  prerelease: string | null;
-}
-
-export function parseSemver(version: string): ParsedVersion {
-  const m = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/);
-  if (!m) {
+function parse(version: string): semver.SemVer {
+  const parsed = semver.parse(version);
+  if (!parsed) {
     throw new Error(`Invalid semver: ${version}`);
   }
-  return {
-    major: parseInt(m[1], 10),
-    minor: parseInt(m[2], 10),
-    patch: parseInt(m[3], 10),
-    prerelease: m[4] ?? null,
-  };
+  return parsed;
 }
 
+// Apply a release bump to the stable `major.minor.patch` of `baseVersion`,
+// discarding any prerelease suffix. `none` returns that clean base unchanged.
 function applyBump(baseVersion: string, bump: BumpLevel): string {
-  const { major, minor, patch } = parseSemver(baseVersion);
-  switch (bump) {
-    case 'major':
-      return `${major + 1}.0.0`;
-    case 'minor':
-      return `${major}.${minor + 1}.0`;
-    case 'patch':
-      return `${major}.${minor}.${patch + 1}`;
-    case 'none':
-      return `${major}.${minor}.${patch}`;
-  }
+  const { major, minor, patch } = parse(baseVersion);
+  const base = `${major}.${minor}.${patch}`;
+  return bump === 'none' ? base : semver.inc(base, bump)!;
 }
 
 const BUMP_RANK: Record<BumpLevel, number> = {
@@ -147,12 +131,10 @@ function maxBump(a: BumpLevel, b: BumpLevel): BumpLevel {
 }
 
 function impliedBumpBetween(stable: string, prereleaseBase: string): BumpLevel {
-  const s = parseSemver(stable);
-  const p = parseSemver(prereleaseBase);
-  if (p.major > s.major) return 'major';
-  if (p.minor > s.minor) return 'minor';
-  if (p.patch > s.patch) return 'patch';
-  return 'none';
+  // Both arguments are clean `major.minor.patch` strings, so semver.diff only
+  // ever yields 'major' | 'minor' | 'patch' | null (equal → no bump).
+  const d = semver.diff(stable, prereleaseBase);
+  return d === 'major' || d === 'minor' || d === 'patch' ? d : 'none';
 }
 
 function nextUnstableVersion(
@@ -161,8 +143,8 @@ function nextUnstableVersion(
   bump: BumpLevel,
   prereleaseN: number,
 ): string {
-  const current = parseSemver(currentNpm);
-  if (current.prerelease) {
+  const current = parse(currentNpm);
+  if (current.prerelease.length > 0) {
     // Already on a prerelease base. Decide whether this commit's bump
     // escalates the base or stays.
     const currentBase = `${current.major}.${current.minor}.${current.patch}`;
@@ -245,16 +227,31 @@ function readJsonVersion(path: string): string {
 }
 
 // Pure: the `-unstable.<n>` counters already published for `base`. Tolerates
-// any npm output shape — non-string entries are dropped rather than throwing.
+// any npm output shape — non-string / unparseable entries are dropped rather
+// than throwing, and semver's own parsing keeps the `0.3.20` vs `0.3.2` bases
+// distinct (patch 20 ≠ 2) where a naive prefix match would conflate them.
 export function unstableCounters(base: string, versions: unknown[]): number[] {
-  const re = new RegExp(
-    '^' + base.replace(/\./g, '\\.') + '-unstable\\.(\\d+)$',
-  );
-  return versions
-    .filter((v): v is string => typeof v === 'string')
-    .map((v) => (v.match(re) || [])[1])
-    .filter((x): x is string => x != null)
-    .map(Number);
+  const b = parse(base);
+  const counters: number[] = [];
+  for (const v of versions) {
+    if (typeof v !== 'string') continue;
+    const p = semver.parse(v);
+    if (
+      !p ||
+      p.major !== b.major ||
+      p.minor !== b.minor ||
+      p.patch !== b.patch
+    ) {
+      continue;
+    }
+    // semver coerces a numeric prerelease identifier to a number, so a
+    // `<base>-unstable.<n>` version parses to prerelease `['unstable', <n>]`.
+    const [tag, n] = p.prerelease;
+    if (tag === 'unstable' && typeof n === 'number') {
+      counters.push(n);
+    }
+  }
+  return counters;
 }
 
 function fetchNpmVersions(): unknown[] {

--- a/packages/boxel-cli/scripts/compute-release.ts
+++ b/packages/boxel-cli/scripts/compute-release.ts
@@ -239,18 +239,34 @@ function changedFilesAgainstHead1(root: string): string[] {
   return [...set];
 }
 
-function prereleaseCount(stableTag: string): number {
-  // Count commits on HEAD since the last stable tag. Each unstable publish
-  // gets a monotonically increasing N, even across reruns.
-  const out = execSync(
-    `git rev-list --count boxel-cli-v${stableTag}..HEAD`,
-  ).toString();
-  return parseInt(out.trim(), 10);
-}
-
 function readJsonVersion(path: string): string {
   const json = JSON.parse(readFileSync(path, 'utf8'));
   return json.version;
+}
+
+function npmUnstableCounters(base: string): number[] {
+  // `npm view ... versions --json` yields an array, or a bare string when
+  // exactly one version is published; `[].concat` normalizes both. Empty when
+  // the package was never published (E404 → non-zero exit).
+  let raw: string;
+  try {
+    raw = execSync('npm view @cardstack/boxel-cli versions --json', {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+  const versions: string[] = [].concat(JSON.parse(raw));
+  const re = new RegExp(
+    '^' + base.replace(/\./g, '\\.') + '-unstable\\.(\\d+)$',
+  );
+  return versions
+    .map((v) => (v.match(re) || [])[1])
+    .filter((x): x is string => x != null)
+    .map(Number);
 }
 
 function main(): void {
@@ -276,18 +292,28 @@ function main(): void {
     resolve(root, 'packages/boxel-cli/plugin/.claude-plugin/plugin.json'),
   );
   const stableBase = lastStableTag();
-  const prereleaseN = prereleaseCount(stableBase);
   const changedFiles = changedFilesAgainstHead1(root);
 
+  // Resolve the bumped base with a placeholder counter, then pick the next
+  // counter free for that base on npm. npm is the source of truth: the manual
+  // publish path publishes counters this run's git history never sees, so a
+  // git-commit count could collide with one of them.
   const result = computeRelease({
     prTitle,
     prBody,
     changedFiles,
     currentNpm,
     currentPlugin,
-    prereleaseN,
+    prereleaseN: 0,
     lastStableNpmBase: stableBase,
   });
+  if (result.nextNpm) {
+    const base = result.nextNpm.replace(/-unstable\.\d+$/, '');
+    const counters = npmUnstableCounters(base);
+    const n = counters.length ? Math.max(...counters) + 1 : 0;
+    result.nextNpm = `${base}-unstable.${n}`;
+    result.prereleaseN = n;
+  }
 
   process.stdout.write(JSON.stringify(result) + '\n');
 }

--- a/packages/boxel-cli/scripts/lib/tags.ts
+++ b/packages/boxel-cli/scripts/lib/tags.ts
@@ -9,26 +9,7 @@
 
 import { execSync } from 'child_process';
 
-export interface ParsedSemver {
-  major: number;
-  minor: number;
-  patch: number;
-}
-
-export function parseSemver(version: string): ParsedSemver {
-  const base = version.split('-')[0];
-  const [major, minor, patch] = base.split('.').map((n) => parseInt(n, 10));
-  return { major, minor, patch };
-}
-
-export function compareSemver(a: string, b: string): number {
-  const A = parseSemver(a);
-  const B = parseSemver(b);
-  if (A.major !== B.major) return A.major - B.major;
-  if (A.minor !== B.minor) return A.minor - B.minor;
-  if (A.patch !== B.patch) return A.patch - B.patch;
-  return 0;
-}
+import semver from 'semver';
 
 function listBoxelCliTags(): string[] {
   return execSync("git tag --list 'boxel-cli-v*'")
@@ -46,7 +27,7 @@ export function lastStableTag(): string {
   const versions = listBoxelCliTags()
     .filter((t) => !t.includes('-unstable.'))
     .map((t) => t.replace(/^boxel-cli-v/, ''))
-    .sort(compareSemver);
+    .sort(semver.compare);
   if (versions.length === 0) {
     throw new Error(
       'No stable boxel-cli-v* tag found. Cannot compute prerelease counter.',
@@ -82,7 +63,7 @@ export function previousStableTag(): string | null {
   const versions = listBoxelCliTags()
     .filter((t) => !t.includes('-unstable.'))
     .map((t) => t.replace(/^boxel-cli-v/, ''))
-    .sort(compareSemver);
+    .sort(semver.compare);
   if (versions.length === 0) return null;
   return `boxel-cli-v${versions[versions.length - 1]}`;
 }

--- a/packages/boxel-cli/tests/scripts/compute-release.test.ts
+++ b/packages/boxel-cli/tests/scripts/compute-release.test.ts
@@ -4,6 +4,7 @@ import {
   computeRelease,
   detectSurfaces,
   parseSemver,
+  unstableCounters,
   type ComputeReleaseInput,
 } from '../../scripts/compute-release';
 
@@ -146,6 +147,39 @@ describe('parseSemver', () => {
 
   it('throws on invalid input', () => {
     expect(() => parseSemver('not-a-version')).toThrow();
+  });
+});
+
+describe('unstableCounters', () => {
+  it('returns max-candidate counters for the matching base', () => {
+    const versions = [
+      '0.3.2-unstable.0',
+      '0.3.2-unstable.1',
+      '0.3.2-unstable.5',
+    ];
+    expect(unstableCounters('0.3.2', versions)).toEqual([0, 1, 5]);
+  });
+
+  it('ignores other bases (and treats a different base as non-matching)', () => {
+    const versions = [
+      '0.3.1-unstable.9',
+      '0.3.20-unstable.4', // must NOT match base 0.3.2
+      '0.4.0-unstable.3',
+      '0.3.2-unstable.2',
+    ];
+    expect(unstableCounters('0.3.2', versions)).toEqual([2]);
+  });
+
+  it('is empty when nothing matches or the list is empty', () => {
+    expect(unstableCounters('0.3.2', ['0.3.1', '0.3.2'])).toEqual([]);
+    expect(unstableCounters('0.3.2', [])).toEqual([]);
+  });
+
+  it('tolerates non-string npm output shapes without throwing', () => {
+    // `npm view ... versions --json` is normally string | string[], but guard
+    // against null / unexpected entries rather than crashing the publish run.
+    const versions = [null, 42, { v: 'x' }, '0.3.2-unstable.7'];
+    expect(unstableCounters('0.3.2', versions)).toEqual([7]);
   });
 });
 

--- a/packages/boxel-cli/tests/scripts/compute-release.test.ts
+++ b/packages/boxel-cli/tests/scripts/compute-release.test.ts
@@ -3,7 +3,6 @@ import {
   classifyBumpFromTitle,
   computeRelease,
   detectSurfaces,
-  parseSemver,
   unstableCounters,
   type ComputeReleaseInput,
 } from '../../scripts/compute-release';
@@ -123,30 +122,6 @@ describe('detectSurfaces', () => {
   it('neither touched when only docs at repo root changed', () => {
     const s = detectSurfaces(['docs/cs-11112-plan.md', 'README.md']);
     expect(s).toEqual({ npmTouched: false, pluginTouched: false });
-  });
-});
-
-describe('parseSemver', () => {
-  it('parses stable versions', () => {
-    expect(parseSemver('0.1.4')).toEqual({
-      major: 0,
-      minor: 1,
-      patch: 4,
-      prerelease: null,
-    });
-  });
-
-  it('parses unstable prereleases', () => {
-    expect(parseSemver('0.2.0-unstable.5')).toEqual({
-      major: 0,
-      minor: 2,
-      patch: 0,
-      prerelease: 'unstable.5',
-    });
-  });
-
-  it('throws on invalid input', () => {
-    expect(() => parseSemver('not-a-version')).toThrow();
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1080,6 +1080,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.1
       '@typescript-eslint/eslint-plugin':
         specifier: 'catalog:'
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
@@ -1104,6 +1107,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
+      semver:
+        specifier: ^7.7.0
+        version: 7.8.0
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@24.12.4)(typescript@5.9.3)


### PR DESCRIPTION
## Problem

The `boxel-cli publish` workflow's manual `workflow_dispatch` path (run with `confirm` blank → "publish current main as unstable") publishes whatever raw version is in `packages/boxel-cli/package.json`. Right after a stable cut, that version is a clean stable (e.g. `0.3.1`) already on npm, so npm rejects it:

```
[E403] 403 Forbidden - PUT https://registry.npmjs.org/@cardstack%2fboxel-cli
You cannot publish over the previously published versions: 0.3.1.
```

Failed run: https://github.com/cardstack/boxel/actions/runs/27122373728/job/80042319268

The automated **push** path doesn't hit this because `compute-release.ts` derives a fresh `<base>-unstable.<n>` from the merged PR. The manual path skips all of that and publishes the raw version.

## Fix

Add a step to the `unstable` job, gated to the manual path (`github.event_name == 'workflow_dispatch'`), that computes the next free `<base>-unstable.<n>` and writes it to `package.json` before "Publish to npm".

The manual path deliberately doesn't commit the bump back to main, so the repo can't track the counter — **npm is the source of truth**. The step reads published versions and picks the next available counter on the current base, so a manual publish can never collide with an already-published version.

This intentionally does **not** reuse the PR-title/surface-detection machinery in `compute-release.ts` — none of that applies to a manual run with no PR.

### Note on semver ordering

With `package.json` at a clean stable `0.3.1`, this publishes `0.3.1-unstable.<n>`, which sorts *below* the shipped `0.3.1` stable. For an `unstable` dist-tag installed explicitly that's fine. If we want manual unstables to sort *above* the last stable (like the push path guarantees), we can patch-bump the base first — happy to add that if preferred.

Closes CS-11422

🤖 Generated with [Claude Code](https://claude.com/claude-code)