### PR TITLE
Clamp adorn overlay label to card tile and truncate

### DIFF
--- a/packages/host/app/modifiers/position-adorn-label.ts
+++ b/packages/host/app/modifiers/position-adorn-label.ts
@@ -11,10 +11,10 @@ export interface PositionAdornLabelSignature {
 // Builds a modifier that positions an Adorn type-label tab manually
 // inside the containing card's footprint, so its slope stays anchored
 // to the card and long type-names get truncated with an ellipsis when
-// they would otherwise spill into the chrome around the card. Attach
-// the returned modifier to the label element and pass the anchor
-// `cardEl`; it bounds growth to the region resolved by the
-// `getBoundaryElement` baked in here.
+// they would otherwise spill past the card's edges. Attach the returned
+// modifier to the label element and pass the anchor `cardEl`; the
+// boundary resolved by the `getBoundaryElement` baked in here is used
+// only to decide whether the tab sits above or below the card.
 //
 // AdornContext calls this factory with its own boundary resolver and
 // yields the resulting `positionLabel` modifier, so consumers go
@@ -32,10 +32,9 @@ export interface PositionAdornLabelSignature {
 //   flips below; a [data-side] attribute drives the CSS that mirrors
 //   the clip-path vertically so the slope still points toward the
 //   card.
-// - The label's max-width is capped to the space available between
-//   the anchored edge and the boundary; CSS text-overflow:ellipsis
-//   truncates the type-name rather than letting the label spill
-//   outside the boundary.
+// - The label's max-width is capped to the card's own width; CSS
+//   text-overflow:ellipsis truncates the type-name rather than letting
+//   the label spill past the card tile's edges.
 //
 // The boundary is resolved from the label itself (the label is always
 // rendered inside the AdornContext subtree, whereas the anchor card may
@@ -96,19 +95,23 @@ export function makePositionAdornLabel(
       if (shouldOverflow) {
         let anchorRightX = cardRect.right - (radius - 4);
         let unclampedLeft = anchorRightX - labelWidth;
-        let boundaryLeftLimit = boundaryRect.left + 4;
-        if (unclampedLeft >= boundaryLeftLimit) {
-          // Natural width fits inside the boundary — use max-content so
-          // the browser sizes to the true intrinsic width (scrollWidth is
+        // Don't let the label spill past the card tile's own left edge —
+        // pin its left edge to the card (matching the non-overflow anchor)
+        // and let text-overflow:ellipsis truncate the type-name so the tab
+        // never exceeds the tile's footprint.
+        let cardLeftLimit = cardRect.left - 4;
+        if (unclampedLeft >= cardLeftLimit) {
+          // Natural width fits inside the card — use max-content so the
+          // browser sizes to the true intrinsic width (scrollWidth is
           // integer-rounded, so writing it back as `max-width: Npx` would
           // shave a sub-pixel remainder and trip text-overflow:ellipsis
           // even though there's room to spare).
           anchorLeftX = unclampedLeft;
           label.style.maxWidth = 'max-content';
         } else {
-          // Label can't fit inside the boundary at natural width; clamp
-          // the un-anchored edge and let the ellipsis show.
-          anchorLeftX = boundaryLeftLimit;
+          // Label can't fit inside the card at natural width; clamp the
+          // un-anchored edge to the card and let the ellipsis show.
+          anchorLeftX = cardLeftLimit;
           let width = Math.max(0, anchorRightX - anchorLeftX);
           label.style.maxWidth = width + 'px';
         }

--- a/packages/host/app/modifiers/position-adorn-label.ts
+++ b/packages/host/app/modifiers/position-adorn-label.ts
@@ -96,7 +96,8 @@ export function makePositionAdornLabel(
         let anchorRightX = cardRect.right - (radius - 4);
         let unclampedLeft = anchorRightX - labelWidth;
         // Don't let the label spill past the card tile's own left edge —
-        // pin its left edge to the card (matching the non-overflow anchor)
+        // pin its left edge to the card's left edge plus the 4px stroke
+        // bleed (`cardRect.left - 4`, matching the non-overflow anchor)
         // and let text-overflow:ellipsis truncate the type-name so the tab
         // never exceeds the tile's footprint.
         let cardLeftLimit = cardRect.left - 4;

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -362,15 +362,16 @@ module('Integration | overlay-menu-items', function (hooks) {
     if (label.hasAttribute('data-overflow')) {
       // Long-name case: right edge sits at the start of the card's
       // top-right corner radius (with the 4px stroke bleed), and the
-      // left edge is clamped to the card's own left edge — the type-name
-      // truncates with an ellipsis rather than spilling off the tile.
+      // left edge is clamped to the card's left edge plus that same 4px
+      // bleed (`cardRect.left - 4`) — the type-name truncates with an
+      // ellipsis rather than spilling off the tile.
       assert.ok(
         Math.abs(cardRect.right - labelRect.right - (radius - 4)) <= 2,
         "overflowing label's right edge sits at the card's corner-radius point",
       );
       assert.ok(
         Math.abs(labelRect.left - (cardRect.left - 4)) <= 2,
-        "overflowing label's left edge is clamped to the card's left edge",
+        "overflowing label's left edge is clamped to the card's left edge (with the 4px stroke bleed)",
       );
     } else {
       // Short-name case: hugs the card's left edge with the 4px bleed.

--- a/packages/host/tests/integration/components/overlay-menu-items-test.gts
+++ b/packages/host/tests/integration/components/overlay-menu-items-test.gts
@@ -362,14 +362,15 @@ module('Integration | overlay-menu-items', function (hooks) {
     if (label.hasAttribute('data-overflow')) {
       // Long-name case: right edge sits at the start of the card's
       // top-right corner radius (with the 4px stroke bleed), and the
-      // extra width spills off the card's left edge.
+      // left edge is clamped to the card's own left edge — the type-name
+      // truncates with an ellipsis rather than spilling off the tile.
       assert.ok(
         Math.abs(cardRect.right - labelRect.right - (radius - 4)) <= 2,
         "overflowing label's right edge sits at the card's corner-radius point",
       );
       assert.ok(
-        labelRect.left < cardRect.left,
-        'overflowing label extends past the card left edge',
+        Math.abs(labelRect.left - (cardRect.left - 4)) <= 2,
+        "overflowing label's left edge is clamped to the card's left edge",
       );
     } else {
       // Short-name case: hugs the card's left edge with the 4px bleed.


### PR DESCRIPTION
Before: 

<img width="444" height="512" alt="image" src="https://github.com/user-attachments/assets/9000ac55-e373-42b5-8e43-3df266a0d354" />


After:

<img width="250" height="323" alt="image" src="https://github.com/user-attachments/assets/32e2a692-b7dc-4dfb-aa22-3b0e855c48f8" />
