### PR TITLE
fix: resolve alias-form card id before sending to realm server in screenshot

### DIFF
--- a/packages/host/app/commands/screenshot-card.ts
+++ b/packages/host/app/commands/screenshot-card.ts
@@ -73,6 +73,11 @@ export default class ScreenshotCardCommand extends HostBaseCommand<
       );
     }
 
+    // Resolve alias-form RRI to HTTP URL — the realm server does not know
+    // the alias mapping and will fail to construct a URL from alias form.
+    let vn = this.loaderService.loader.getVirtualNetwork()!;
+    cardId = vn.toURL(cardId).href;
+
     // Target realm = the card's own realm. If the caller can't write there,
     // fail fast — no silent fallback to a different realm.
     let cardRealm = this.realm.realmOf(rri(cardId));

--- a/packages/host/app/commands/screenshot-card.ts
+++ b/packages/host/app/commands/screenshot-card.ts
@@ -76,17 +76,17 @@ export default class ScreenshotCardCommand extends HostBaseCommand<
     // Resolve alias-form RRI to HTTP URL — the realm server does not know
     // the alias mapping and will fail to construct a URL from alias form.
     let vn = this.loaderService.loader.getVirtualNetwork()!;
-    cardId = vn.toURL(cardId).href;
+    let cardURL = vn.toURL(cardId).href;
 
     // Target realm = the card's own realm. If the caller can't write there,
     // fail fast — no silent fallback to a different realm.
-    let cardRealm = this.realm.realmOf(rri(cardId));
+    let cardRealm = this.realm.realmOf(rri(cardURL));
     if (!cardRealm) {
-      throw new Error(`Cannot determine realm for card ${cardId}.`);
+      throw new Error(`Cannot determine realm for card ${cardURL}.`);
     }
     if (!this.realm.canWrite(cardRealm)) {
       throw new Error(
-        `Cannot screenshot ${cardId}: no write access to its realm ${cardRealm}.`,
+        `Cannot screenshot ${cardURL}: no write access to its realm ${cardRealm}.`,
       );
     }
 
@@ -105,7 +105,7 @@ export default class ScreenshotCardCommand extends HostBaseCommand<
           type: 'screenshot-card',
           attributes: {
             realmURL: cardRealm,
-            cardId,
+            cardId: cardURL, // wire field name kept as-is; CS-11458 will update endpoint to accept RRI
             format: normalizedFormat,
           },
         },
@@ -128,7 +128,7 @@ export default class ScreenshotCardCommand extends HostBaseCommand<
 
     // Write binary to the card's realm under Screenshots/. The realm indexer
     // promotes the PNG into a PngDef / ImageDef card automatically.
-    let filename = `${generateFilenameFromCard(cardId)}.png`;
+    let filename = `${generateFilenameFromCard(cardURL)}.png`;
     let filePath = `Screenshots/${filename}`;
     let writeResult = await new WriteBinaryFileCommand(
       this.commandContext,


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-11427/fix-screenshot-command-failing-in-alias-prefix-realms

Root cause:

ScreenshotCardCommand takes the card's in-memory id directly and POSTs it to /_screenshot-card on the realm server. In alias-prefix realms, card.id is alias form (@cardstack/catalog/SimpleCard/uuid). The realm server has no alias mapping — it only knows HTTP URLs — so when it tries to construct a URL from the alias string it throws Invalid URL and the screenshot job fails.


## Fix

- `screenshot-card.ts`: Resolve alias-form card id to HTTP URL via
  `vn.toURL()` before POSTing to `/_screenshot-card` — the realm server
  has no alias mapping and throws `Invalid URL` when given an alias-form
  id directly

## Test plan
- [x] Create a listing from an alias-prefix realm
- [x] Verify `images` field is populated after listing creation completes
