### PR TITLE
Correct realm-server HTTP/2 diagnostics comment

### DIFF
--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -42,9 +42,12 @@ const TLS_KEY_FILE_ENV = 'REALM_SERVER_TLS_KEY_FILE';
 // Opt-in HTTP/2 stall diagnostics (see installHttp2Diagnostics). Off by
 // default; set in the host-test CI job so an intermittent "request accepted
 // but never answered" h2 stall dumps its full session/stream state instead of
-// surfacing only as an opaque 60s host-test timeout. The h2 path is never
-// reached in production (BOXEL_ENVIRONMENT short-circuits to plain HTTP above),
-// so this only ever runs in local dev / CI.
+// surfacing only as an opaque 60s host-test timeout. The h2 path is taken only
+// when a TLS cert/key is provided (see createListener): local dev and CI
+// provision an mkcert leaf, so they run h2, while staging/prod set no cert and
+// so fall into the no-cert branch and serve plain HTTP/1.1 (TLS terminates at
+// the proxy in front). BOXEL_ENVIRONMENT is the local Traefik-in-front mode,
+// not the production mechanism.
 const HTTP2_DIAGNOSTICS_ENV = 'REALM_SERVER_HTTP2_DIAGNOSTICS';
 
 export type RealmHttpServer =


### PR DESCRIPTION
## What

Fixes the misleading comment above `HTTP2_DIAGNOSTICS_ENV` in `packages/realm-server/server.ts`, called out in CS-11444's acceptance criteria.

The comment claimed the realm-server's h2 path is unreachable in production because `BOXEL_ENVIRONMENT` "short-circuits to plain HTTP." That's not the real mechanism:

- Staging/prod start scripts (`start-staging.sh`, `start-production.sh`) set **no** `BOXEL_ENVIRONMENT` and **no** TLS cert/key.
- So `createListener` falls into the **no-cert branch** and serves plain HTTP/1.1; TLS terminates at the proxy in front.
- `BOXEL_ENVIRONMENT` is the **local Traefik-in-front** mode, not the production mechanism.

Comment-only change; no behavior change. Groundwork for the larger CS-11444 effort (enabling h2 in staging/prod), which is primarily infra/terraform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)