### PR TITLE
Add decorator and namespace eslint guards for erasable syntax

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,19 @@ const NO_COMPILATION_REQUIRED_TS_SELECTORS = [
     message:
       '`export =` syntax requires TypeScript compilation. Use a standard ES module `export default` (or named exports) instead.',
   },
+  {
+    selector: 'Decorator',
+    message:
+      "Decorators are not erasable and require compilation, so they break under Node's native `--experimental-strip-types`. Avoid decorators here (e.g. replace `@Memoize()` with a manual cache).",
+  },
+  {
+    // Non-ambient `namespace`/`module` blocks emit runtime code. Ambient
+    // declarations (`declare module`, `declare global`, `declare namespace`)
+    // are type-only and erasable, so they are exempt via `:not([declare=true])`.
+    selector: 'TSModuleDeclaration:not([declare=true])',
+    message:
+      'TypeScript `namespace`/`module` blocks emit runtime code and are not erasable. Use standard ES modules instead.',
+  },
 ];
 
 const DATA_TEST_SELECTORS = [
@@ -145,6 +158,28 @@ module.exports = {
           'error',
           ...NO_COMPILATION_REQUIRED_TS_SELECTORS.filter(
             (s) => s.selector !== 'TSEnumDeclaration',
+          ),
+        ],
+      },
+    },
+    {
+      // Files exempted only for the `Decorator` selector because they use
+      // `@Memoize()` from typescript-memoize, which is not erasable. The
+      // remaining erasable-syntax guards still apply here. This exemption is
+      // removed once typescript-memoize is dropped from node-run code. Do not
+      // add new files here; remove the decorator to remove the entry.
+      files: [
+        'packages/realm-server/server.ts',
+        'packages/runtime-common/index-runner.ts',
+        'packages/runtime-common/index-writer.ts',
+        'packages/runtime-common/realm-index-query-engine.ts',
+        'packages/runtime-common/realm-index-updater.ts',
+      ],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          ...NO_COMPILATION_REQUIRED_TS_SELECTORS.filter(
+            (s) => s.selector !== 'Decorator',
           ),
         ],
       },

--- a/packages/ai-bot/.eslintrc.js
+++ b/packages/ai-bot/.eslintrc.js
@@ -20,6 +20,19 @@ const NO_COMPILATION_REQUIRED_TS_SELECTORS = [
     message:
       '`export =` syntax requires TypeScript compilation. Use a standard ES module `export default` (or named exports) instead.',
   },
+  {
+    selector: 'Decorator',
+    message:
+      "Decorators are not erasable and require compilation, so they break under Node's native `--experimental-strip-types`. Avoid decorators here (e.g. replace `@Memoize()` with a manual cache).",
+  },
+  {
+    // Non-ambient `namespace`/`module` blocks emit runtime code. Ambient
+    // declarations (`declare module`, `declare global`, `declare namespace`)
+    // are type-only and erasable, so they are exempt via `:not([declare=true])`.
+    selector: 'TSModuleDeclaration:not([declare=true])',
+    message:
+      'TypeScript `namespace`/`module` blocks emit runtime code and are not erasable. Use standard ES modules instead.',
+  },
 ];
 
 module.exports = {


### PR DESCRIPTION
## What

The `no-restricted-syntax` guardrail in the root and ai-bot eslint configs already blocks the TypeScript syntax that Node's native type-stripping can't run — `enum`, `import =`, `export =`, and parameter properties — so new code stays runnable without ts-node. But it missed two more non-erasable constructs:

- **decorators** (`Decorator`)
- **runtime `namespace`/`module` blocks** (`TSModuleDeclaration`)

Both are fatal under `--experimental-strip-types`. `@Memoize()` decorators are already live on the realm-server/indexing path, so the prior guardrail gave false confidence.

This PR adds selectors for both to `.eslintrc.js` and the mirrored `packages/ai-bot/.eslintrc.js`. With these, the guardrail now covers the **complete** set of non-erasable TS syntax.

## Details

- The namespace selector is `TSModuleDeclaration:not([declare=true])` — ambient declarations (`declare module`, `declare global`, `declare namespace`) are type-only and erasable, so they stay allowed. Verified against the existing `declare module`/`declare global` usages in `runtime-common`/`boxel-cli`.
- The five existing `@Memoize()` files (`realm-server/server.ts` + four `runtime-common` index files) are grandfathered via an override that lifts **only** the `Decorator` selector — the other erasability guards still apply there. That override is removed when `typescript-memoize` is dropped from node-run code.

## Verification

- `lint:js` passes clean on all root-inheriting node-run packages (`runtime-common`, `realm-server`, `boxel-cli`, `postgres`, `billing`, `software-factory`, `vscode-boxel-tools`, `realm-test-harness`) and on `ai-bot`.
- A throwaway probe confirmed the selectors fire on a new `namespace` block and a new decorator, while `declare module`/`declare global` are correctly exempt.

## Why not `erasableSyntaxOnly` here

The ticket also suggests adopting `erasableSyntaxOnly`. That can't land in this PR: it's a whole-program tsconfig flag, and every node-run package transitively imports `runtime-common` + the base realm cards as source (`nodenext` + `allowImportingTsExtensions`), so it fails on exactly the grandfathered parameter-properties/enums and `@Memoize()` decorators that the follow-up cleanup tickets remove. Even the cleanest package produced 25 `TS1294` errors. Flipping the flag is the final step once that backlog is burned down; it's tracked on the cleanup ticket.

No production behavior change — guardrails only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)