### PR TITLE
Prerender render-timeout diagnostics: main-thread responsiveness, CDP CPU metrics, and pending fetches

### DIFF
--- a/packages/realm-server/prerender/network-inflight-tracker.ts
+++ b/packages/realm-server/prerender/network-inflight-tracker.ts
@@ -1,0 +1,163 @@
+// Out-of-process in-flight network tracker for prerender pages.
+//
+// Why this module exists:
+//
+//   When a render hangs, the most useful question is often "which
+//   resource fetch is it waiting on?" The host's own
+//   `__boxelRenderDiagnostics()` can answer that — but only while the
+//   page's JS thread is responsive. The render-hang failure mode we
+//   most want to discriminate is the one where the JS thread is wedged
+//   (a runaway sync loop, or a never-settling Glimmer render), and in
+//   that case any `page.evaluate(...)` call blocks until the timeout
+//   path tears the tab down, so the host diagnostic comes back null.
+//
+//   CDP's Network domain runs in the browser process, out of band from
+//   the page's JS thread. It keeps reporting request lifecycle events
+//   even while the page's main thread is pegged. That makes a passive
+//   CDP-side request map the one signal that survives exactly the
+//   conditions where the in-page hook goes dark — so on the timeout
+//   path we can still name the fetch (or fetches) that never came back.
+//
+// Cost model:
+//
+//   This runs for EVERY render, not just the ones that time out, so it
+//   must stay cheap: a single Map keyed by CDP requestId, mutated on
+//   request start / finish / fail, with no per-request logging. Reading
+//   the pending list (sort + cap + URL truncation) happens only on the
+//   timeout path, where the work is already bounded by a torn-down tab.
+//
+// Lifecycle:
+//
+//   `attachNetworkInflightTracker` creates a per-page CDP session and
+//   registers the tracker in a module-level `WeakMap<Page, …>` so the
+//   timeout path can look it up from just the page handle, without
+//   any global mutable state. Puppeteer auto-detaches the CDP session
+//   when the page closes, and the WeakMap entry is collected with the
+//   page, so there is no explicit teardown. Attach failures (a race
+//   with page teardown, transient CDP errors) are logged at debug and
+//   resolve without throwing — this is best-effort observability and
+//   must never break or slow the render path.
+
+import type { CDPSession, Page } from 'puppeteer';
+import { logger } from '@cardstack/runtime-common';
+
+const log = logger('prerenderer');
+
+// Hard caps so a pathological page (thousands of concurrent fetches)
+// can't turn the timeout-path read into expensive work or bloat the
+// persisted diagnostics row.
+const MAX_PENDING_REPORTED = 20;
+const MAX_URL_LENGTH = 200;
+
+// Local subset of the CDP `Network.*` event payloads we read. We
+// deliberately don't import `devtools-protocol` (a transitive, not
+// direct, dependency of puppeteer) — declaring just the fields used
+// keeps the import graph honest. Full shapes:
+//   https://chromedevtools.github.io/devtools-protocol/tot/Network/
+interface CdpRequestWillBeSentEvent {
+  requestId: string;
+  request: { url: string };
+}
+interface CdpLoadingFinishedEvent {
+  requestId: string;
+}
+interface CdpLoadingFailedEvent {
+  requestId: string;
+}
+
+export interface PendingNetworkRequest {
+  url: string;
+  ageMs: number;
+}
+
+export class NetworkInflightTracker {
+  // requestId -> { url, startedAt }. Bare Map mutated on the CDP
+  // event stream; never iterated except on the timeout path.
+  #inFlight = new Map<string, { url: string; startedAt: number }>();
+
+  recordStarted(requestId: string, url: string): void {
+    this.#inFlight.set(requestId, { url, startedAt: Date.now() });
+  }
+
+  recordSettled(requestId: string): void {
+    this.#inFlight.delete(requestId);
+  }
+
+  // Snapshot of requests still outstanding, oldest first (the longest-
+  // hanging fetch is the most interesting), capped and URL-truncated so
+  // the result is safe to log and persist. Called only on the timeout
+  // path.
+  getPending(): PendingNetworkRequest[] {
+    let now = Date.now();
+    let pending = Array.from(this.#inFlight.values())
+      .map(({ url, startedAt }) => ({
+        url: url.length > MAX_URL_LENGTH ? url.slice(0, MAX_URL_LENGTH) : url,
+        ageMs: now - startedAt,
+      }))
+      .sort((a, b) => b.ageMs - a.ageMs);
+    return pending.slice(0, MAX_PENDING_REPORTED);
+  }
+}
+
+// Page handle -> its tracker. A WeakMap so the entry is reclaimed with
+// the page; the timeout path resolves the tracker from just the page,
+// so no global mutable registry is needed.
+const trackersByPage = new WeakMap<Page, NetworkInflightTracker>();
+
+export async function attachNetworkInflightTracker(page: Page): Promise<void> {
+  let tracker = new NetworkInflightTracker();
+  let client: CDPSession;
+  try {
+    client = await page.createCDPSession();
+    // Register listeners BEFORE awaiting `Network.enable` so we don't
+    // miss requests delivered in the window between enable arriving at
+    // the browser and the local handlers being subscribed.
+    client.on(
+      'Network.requestWillBeSent',
+      (event: CdpRequestWillBeSentEvent) => {
+        try {
+          tracker.recordStarted(event.requestId, event.request?.url ?? '');
+        } catch {
+          // Best-effort: a malformed event must not perturb the render.
+        }
+      },
+    );
+    client.on('Network.loadingFinished', (event: CdpLoadingFinishedEvent) => {
+      try {
+        tracker.recordSettled(event.requestId);
+      } catch {
+        // Best-effort.
+      }
+    });
+    client.on('Network.loadingFailed', (event: CdpLoadingFailedEvent) => {
+      try {
+        tracker.recordSettled(event.requestId);
+      } catch {
+        // Best-effort.
+      }
+    });
+    await client.send('Network.enable');
+  } catch (e) {
+    // CDP session creation can race with page teardown — best-effort.
+    log.debug('Failed to attach Network in-flight tracker:', e);
+    return;
+  }
+  trackersByPage.set(page, tracker);
+}
+
+// Reads the pending-request snapshot for a page if a tracker is
+// attached. Returns null when no tracker exists (attach raced teardown,
+// or this is a test stub page) so the caller can omit the field.
+export function getPendingNetworkRequests(
+  page: Page,
+): PendingNetworkRequest[] | null {
+  let tracker = trackersByPage.get(page);
+  if (!tracker) {
+    return null;
+  }
+  try {
+    return tracker.getPending();
+  } catch {
+    return null;
+  }
+}

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -11,6 +11,7 @@ import type { BrowserManager } from './browser-manager';
 import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel';
 import { AsyncSemaphore } from './async-semaphore';
 import { attachRuntimeExceptionCapture } from './runtime-exception-capture';
+import { attachNetworkInflightTracker } from './network-inflight-tracker';
 
 type RenderSemaphore = {
   acquire(signal?: AbortSignal, priority?: number): Promise<() => void>;
@@ -2679,6 +2680,11 @@ export class PagePool {
     // immediately if an exception lands during attach.
     this.#affinityKeyByPageId.set(pageId, affinityKey);
     this.#attachPageConsole(page, affinityKey, pageId);
+    // Passive out-of-process CDP Network tracker. Runs for every page so
+    // the timeout path can name the fetch a wedged render is waiting on
+    // even when the page's JS thread is too pegged to answer an
+    // in-page diagnostic. Best-effort: attach failures resolve cleanly.
+    await attachNetworkInflightTracker(page);
     await attachRuntimeExceptionCapture({
       page,
       // Resolved at log-emit time so adoption / re-tagging that

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -10,7 +10,7 @@ import {
 import { prerenderRenderTimeoutMs } from './prerender-constants';
 import { getPendingNetworkRequests } from './network-inflight-tracker';
 
-import type { Page } from 'puppeteer';
+import type { CDPSession, Page } from 'puppeteer';
 
 const log = logger('prerenderer');
 
@@ -1299,15 +1299,22 @@ export async function captureScreenshot(
 // the condition where the in-page `__boxelRenderDiagnostics` hook also
 // goes dark. Never throws — resolves to a boolean.
 async function probeMainThreadResponsive(page: Page): Promise<boolean> {
-  return Promise.race([
-    page
-      .evaluate(() => true)
-      .then(() => true)
-      .catch(() => false),
-    new Promise<boolean>((r) =>
-      setTimeout(() => r(false), RESPONSIVENESS_PROBE_MS),
-    ),
-  ]);
+  // Clear the loser timer so a fast `evaluate` doesn't leave a pending
+  // timeout holding the event loop for the rest of the probe window.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      page
+        .evaluate(() => true)
+        .then(() => true)
+        .catch(() => false),
+      new Promise<boolean>((r) => {
+        timer = setTimeout(() => r(false), RESPONSIVENESS_PROBE_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 // Best-effort CPU / heap capture via the CDP `Performance` domain. Runs
@@ -1323,7 +1330,7 @@ async function captureCpuMetrics(page: Page): Promise<{
   taskBusyFraction?: number;
   jsHeapUsedMB?: number;
 }> {
-  let client;
+  let client: CDPSession | undefined;
   try {
     client = await page.createCDPSession();
     await client.send('Performance.enable');
@@ -1389,7 +1396,11 @@ export async function withTimeout<T>(
   // one stalled on its own.
   activeRenderCount++;
   let concurrentRenders = activeRenderCount;
-  let result;
+  let result!: T | { timeout: true };
+  // Capture the timeout timer so we can clear it once the race settles —
+  // otherwise a render that finishes fast leaves a pending timer holding
+  // the event loop for the full `timeoutMs`.
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
   try {
     result = await Promise.race([
       fn().catch((err) => {
@@ -1400,15 +1411,16 @@ export async function withTimeout<T>(
         }
         throw err;
       }),
-      new Promise<{ timeout: true }>((r) =>
-        setTimeout(() => {
+      new Promise<{ timeout: true }>((r) => {
+        timeoutTimer = setTimeout(() => {
           r({ timeout: true });
-        }, timeoutMs),
-      ),
+        }, timeoutMs);
+      }),
     ]);
     concurrentRenders = activeRenderCount;
   } finally {
     activeRenderCount--;
+    clearTimeout(timeoutTimer);
   }
   if (
     result &&

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -8,10 +8,29 @@ import {
   type RenderTimeoutDiagnostics,
 } from '@cardstack/runtime-common';
 import { prerenderRenderTimeoutMs } from './prerender-constants';
+import { getPendingNetworkRequests } from './network-inflight-tracker';
 
 import type { Page } from 'puppeteer';
 
 const log = logger('prerenderer');
+
+// Number of renders this prerender process is running concurrently.
+// Every render funnels through `withTimeout`, which increments on entry
+// and decrements when the race resolves, so on the timeout path this is
+// the live count of co-tenant renders competing for the same Node
+// process and shared Chrome — the signal that distinguishes a render
+// starved by neighbours from one stalled on its own.
+let activeRenderCount = 0;
+
+// CDP `Performance` reports cumulative ScriptDuration / TaskDuration in
+// seconds and JSHeapUsedSize in bytes. We sample twice across this
+// window and diff against wall-clock to derive the busy fractions, so
+// the window must be long enough for V8 to accrue a meaningful delta
+// but short enough not to materially extend the already-timed-out call.
+const CPU_SAMPLE_WINDOW_MS = 750;
+// Budget for the main-thread responsiveness probe. If a trivial
+// `page.evaluate` can't return inside this, the JS thread is wedged.
+const RESPONSIVENESS_PROBE_MS = 2000;
 export const cardRenderTimeout = prerenderRenderTimeoutMs;
 export const renderTimeoutMs = cardRenderTimeout;
 
@@ -1273,26 +1292,124 @@ export async function captureScreenshot(
   return { base64, width: dims.width, height: dims.height };
 }
 
+// Best-effort main-thread responsiveness probe. Races a trivial
+// `page.evaluate` against a short timer: if the evaluate can't even
+// return `true` within the budget, the page's JS thread is wedged
+// (a runaway sync loop or a never-settling render), which is exactly
+// the condition where the in-page `__boxelRenderDiagnostics` hook also
+// goes dark. Never throws — resolves to a boolean.
+async function probeMainThreadResponsive(page: Page): Promise<boolean> {
+  return Promise.race([
+    page
+      .evaluate(() => true)
+      .then(() => true)
+      .catch(() => false),
+    new Promise<boolean>((r) =>
+      setTimeout(() => r(false), RESPONSIVENESS_PROBE_MS),
+    ),
+  ]);
+}
+
+// Best-effort CPU / heap capture via the CDP `Performance` domain. Runs
+// out-of-process, so it works even when the page's JS thread is pegged
+// and `page.evaluate` would block. Samples `Performance.getMetrics`
+// twice ~CPU_SAMPLE_WINDOW_MS apart and diffs the cumulative
+// ScriptDuration / TaskDuration (seconds) against wall-clock to derive
+// the fraction of the window the main thread spent running JS / any
+// task; reads JSHeapUsedSize (bytes) for the in-use heap. Any field
+// that can't be read is omitted. Never throws.
+async function captureCpuMetrics(page: Page): Promise<{
+  scriptBusyFraction?: number;
+  taskBusyFraction?: number;
+  jsHeapUsedMB?: number;
+}> {
+  let client;
+  try {
+    client = await page.createCDPSession();
+    await client.send('Performance.enable');
+    let readMetrics = async (): Promise<Map<string, number>> => {
+      let { metrics } = (await client!.send('Performance.getMetrics')) as {
+        metrics: Array<{ name: string; value: number }>;
+      };
+      let map = new Map<string, number>();
+      for (let m of metrics) {
+        map.set(m.name, m.value);
+      }
+      return map;
+    };
+    let firstWall = Date.now();
+    let first = await readMetrics();
+    await new Promise((r) => setTimeout(r, CPU_SAMPLE_WINDOW_MS));
+    let secondWall = Date.now();
+    let second = await readMetrics();
+
+    let wallSec = (secondWall - firstWall) / 1000;
+    let result: {
+      scriptBusyFraction?: number;
+      taskBusyFraction?: number;
+      jsHeapUsedMB?: number;
+    } = {};
+
+    let s1 = first.get('ScriptDuration');
+    let s2 = second.get('ScriptDuration');
+    if (typeof s1 === 'number' && typeof s2 === 'number' && wallSec > 0) {
+      result.scriptBusyFraction = (s2 - s1) / wallSec;
+    }
+    let t1 = first.get('TaskDuration');
+    let t2 = second.get('TaskDuration');
+    if (typeof t1 === 'number' && typeof t2 === 'number' && wallSec > 0) {
+      result.taskBusyFraction = (t2 - t1) / wallSec;
+    }
+    let heap = second.get('JSHeapUsedSize');
+    if (typeof heap === 'number') {
+      result.jsHeapUsedMB = heap / (1024 * 1024);
+    }
+    return result;
+  } catch {
+    // CDP unavailable (page closing, session race) — omit these fields.
+    return {};
+  } finally {
+    try {
+      await client?.detach();
+    } catch {
+      // Session may already be gone with the page; ignore.
+    }
+  }
+}
+
 export async function withTimeout<T>(
   page: Page,
   fn: () => Promise<T>,
   timeoutMs = cardRenderTimeout,
 ): Promise<T | RenderError> {
-  let result = await Promise.race([
-    fn().catch((err) => {
-      // Puppeteer's own TimeoutError (from waitForFunction/waitForSelector)
-      // should be treated the same as our outer timeout
-      if (err instanceof Error && err.name === 'TimeoutError') {
-        return { timeout: true } as { timeout: true };
-      }
-      throw err;
-    }),
-    new Promise<{ timeout: true }>((r) =>
-      setTimeout(() => {
-        r({ timeout: true });
-      }, timeoutMs),
-    ),
-  ]);
+  // Every render funnels through here, so this counter is the live
+  // count of concurrent renders in this process. Capture it (including
+  // this render) at the moment the race resolves — the timeout block
+  // below reports it to distinguish a render starved by neighbours from
+  // one stalled on its own.
+  activeRenderCount++;
+  let concurrentRenders = activeRenderCount;
+  let result;
+  try {
+    result = await Promise.race([
+      fn().catch((err) => {
+        // Puppeteer's own TimeoutError (from waitForFunction/waitForSelector)
+        // should be treated the same as our outer timeout
+        if (err instanceof Error && err.name === 'TimeoutError') {
+          return { timeout: true } as { timeout: true };
+        }
+        throw err;
+      }),
+      new Promise<{ timeout: true }>((r) =>
+        setTimeout(() => {
+          r({ timeout: true });
+        }, timeoutMs),
+      ),
+    ]);
+    concurrentRenders = activeRenderCount;
+  } finally {
+    activeRenderCount--;
+  }
   if (
     result &&
     typeof result == 'object' &&
@@ -1375,6 +1492,35 @@ export async function withTimeout<T>(
         timerSummary = null;
       }
     }
+
+    // Render-hang discriminators. All best-effort and run only here on
+    // the timeout path — the responsiveness probe and CPU sampling do
+    // real work, so they must never touch the success path. Together
+    // they tell apart a CPU-spinning render (unresponsive thread,
+    // scriptBusyFraction ≈ 1) from a render waiting on a resource
+    // (responsive thread, low script fraction → look at
+    // pendingNetworkRequests for the hung fetch).
+    let mainThreadResponsive: boolean | null = null;
+    let cpuMetrics: {
+      scriptBusyFraction?: number;
+      taskBusyFraction?: number;
+      jsHeapUsedMB?: number;
+    } = {};
+    if (!page.isClosed()) {
+      try {
+        mainThreadResponsive = await probeMainThreadResponsive(page);
+      } catch {
+        mainThreadResponsive = null;
+      }
+      cpuMetrics = await captureCpuMetrics(page);
+    }
+    // Out-of-band CDP view of fetches still outstanding — survives a
+    // wedged JS thread, so it's available even when the in-page hooks
+    // above returned null. The longest-lived entry is what a waiting
+    // render is hung on.
+    let pendingNetworkRequests = getPendingNetworkRequests(page);
+
+    let topPending = pendingNetworkRequests?.[0];
     log.warn(
       `render of ${id} timed out after ${timeoutMs}ms` +
         ` stage=${richDiagnostics?.renderStage ?? '<unknown>'}` +
@@ -1383,6 +1529,15 @@ export async function withTimeout<T>(
         ` fileMetaDocsInFlight=${richDiagnostics?.fileMetaDocsInFlight?.length ?? 0}` +
         ` inFlightModuleImports=${richDiagnostics?.inFlightModuleImports?.length ?? 0}` +
         ` evaluating=${richDiagnostics?.currentlyEvaluatingModule ?? 'none'}` +
+        ` mainThreadResponsive=${mainThreadResponsive ?? '<unknown>'}` +
+        ` scriptBusy=${
+          typeof cpuMetrics.scriptBusyFraction === 'number'
+            ? cpuMetrics.scriptBusyFraction.toFixed(2)
+            : '<unknown>'
+        }` +
+        ` pendingFetches=${pendingNetworkRequests?.length ?? '<unknown>'}` +
+        (topPending ? `(top: ${topPending.url} ${topPending.ageMs}ms)` : '') +
+        ` concurrentRenders=${concurrentRenders}` +
         ` DOM:\n${dom?.trim()}`,
     );
     // Diagnostics ride on the outer `RenderError.diagnostics` as a
@@ -1450,6 +1605,20 @@ export async function withTimeout<T>(
       ...(typeof timerSummary === 'string' && timerSummary.trim()
         ? { blockedTimerSummary: timerSummary.trim() }
         : {}),
+      ...(typeof mainThreadResponsive === 'boolean'
+        ? { mainThreadResponsive }
+        : {}),
+      ...(typeof cpuMetrics.scriptBusyFraction === 'number'
+        ? { scriptBusyFraction: cpuMetrics.scriptBusyFraction }
+        : {}),
+      ...(typeof cpuMetrics.taskBusyFraction === 'number'
+        ? { taskBusyFraction: cpuMetrics.taskBusyFraction }
+        : {}),
+      ...(typeof cpuMetrics.jsHeapUsedMB === 'number'
+        ? { jsHeapUsedMB: cpuMetrics.jsHeapUsedMB }
+        : {}),
+      ...(pendingNetworkRequests ? { pendingNetworkRequests } : {}),
+      concurrentRenders,
     };
     let timeoutError: RenderError = {
       type: 'instance-error',

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -1420,7 +1420,44 @@ export async function withTimeout<T>(
     let [_a, _b, encodedId] = url.pathname.split('/');
     let id = encodedId ? decodeURIComponent(encodedId) : undefined;
 
-    // Capture diagnostics only if the page is still alive; timeouts can close the target.
+    // Render-hang discriminators, captured here only on the timeout
+    // path — the responsiveness probe and CPU sampling do real work, so
+    // they must never touch the success path. Order matters: the
+    // out-of-process / bounded signals run FIRST because they survive a
+    // wedged JS thread (the probe races a short timer; CPU capture and
+    // the network tracker read via CDP / a passive Map). The in-page
+    // `page.evaluate` diagnostics run LAST and only when the thread is
+    // responsive — on a CPU-spinning render (exactly what this is meant
+    // to diagnose) an evaluate blocks until the protocol timeout and
+    // would starve the RenderError we owe the caller.
+    let mainThreadResponsive: boolean | null = null;
+    let cpuMetrics: {
+      scriptBusyFraction?: number;
+      taskBusyFraction?: number;
+      jsHeapUsedMB?: number;
+    } = {};
+    if (!page.isClosed()) {
+      try {
+        mainThreadResponsive = await probeMainThreadResponsive(page);
+      } catch {
+        mainThreadResponsive = null;
+      }
+      cpuMetrics = await captureCpuMetrics(page);
+    }
+    // Out-of-band CDP view of fetches still outstanding — survives a
+    // wedged JS thread, so it's available even when the in-page hooks
+    // below are skipped. The longest-lived entry is what a waiting
+    // render is hung on.
+    let pendingNetworkRequests = getPendingNetworkRequests(page);
+
+    // In-page diagnostics last. Together with the signals above they
+    // tell apart a CPU-spinning render (unresponsive thread,
+    // scriptBusyFraction ≈ 1) from a render waiting on a resource
+    // (responsive thread, low script fraction → look at
+    // pendingNetworkRequests for the hung fetch). Gate on a responsive
+    // thread: a wedged one can't service `page.evaluate`, so these would
+    // block until the protocol timeout — skip them and lean on the
+    // out-of-process signals above.
     let dom: string | null = null;
     let docsInFlight: number | null = null;
     let richDiagnostics: {
@@ -1439,7 +1476,7 @@ export async function withTimeout<T>(
       recentQueryLoads?: unknown[];
     } | null = null;
     let timerSummary: string | null = null;
-    if (!page.isClosed()) {
+    if (mainThreadResponsive === true && !page.isClosed()) {
       try {
         dom = await page.evaluate(() => {
           let el = document.querySelector('[data-prerender]');
@@ -1449,9 +1486,9 @@ export async function withTimeout<T>(
           let err = document.querySelector('[data-prerender-error]');
           return err?.outerHTML ?? null;
         });
-        // CS-10872: prefer the richer per-URL diagnostic hook when the
-        // host exposes it; fall back to the count-only `__docsInFlight`
-        // so the old host build path still produces a sensible log.
+        // Prefer the richer per-URL diagnostic hook when the host
+        // exposes it; fall back to the count-only `__docsInFlight` so the
+        // old host build path still produces a sensible log.
         richDiagnostics = await page.evaluate(() => {
           try {
             let diag = (globalThis as any).__boxelRenderDiagnostics;
@@ -1492,33 +1529,6 @@ export async function withTimeout<T>(
         timerSummary = null;
       }
     }
-
-    // Render-hang discriminators. All best-effort and run only here on
-    // the timeout path — the responsiveness probe and CPU sampling do
-    // real work, so they must never touch the success path. Together
-    // they tell apart a CPU-spinning render (unresponsive thread,
-    // scriptBusyFraction ≈ 1) from a render waiting on a resource
-    // (responsive thread, low script fraction → look at
-    // pendingNetworkRequests for the hung fetch).
-    let mainThreadResponsive: boolean | null = null;
-    let cpuMetrics: {
-      scriptBusyFraction?: number;
-      taskBusyFraction?: number;
-      jsHeapUsedMB?: number;
-    } = {};
-    if (!page.isClosed()) {
-      try {
-        mainThreadResponsive = await probeMainThreadResponsive(page);
-      } catch {
-        mainThreadResponsive = null;
-      }
-      cpuMetrics = await captureCpuMetrics(page);
-    }
-    // Out-of-band CDP view of fetches still outstanding — survives a
-    // wedged JS thread, so it's available even when the in-page hooks
-    // above returned null. The longest-lived entry is what a waiting
-    // render is hung on.
-    let pendingNetworkRequests = getPendingNetworkRequests(page);
 
     let topPending = pendingNetworkRequests?.[0];
     log.warn(

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -184,6 +184,7 @@ const ALL_TEST_FILES: string[] = [
   './listener-dispatcher-test',
   './module-cache-race-test',
   './module-syntax-test',
+  './network-inflight-tracker-test',
   './permissions/permission-checker-test',
   './prerendering-test',
   './prerender-server-test',

--- a/packages/realm-server/tests/network-inflight-tracker-test.ts
+++ b/packages/realm-server/tests/network-inflight-tracker-test.ts
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { NetworkInflightTracker } from '../prerender/network-inflight-tracker';
+
+// The tracker is the one render-hang signal that survives a wedged page
+// JS thread: a passive CDP-side map of in-flight requests, read only on
+// the timeout path. These tests pin the read-side contract the timeout
+// diagnostics depend on — settling drops a request, the snapshot is
+// oldest-first (the longest-hanging fetch is the interesting one), and
+// both the count and per-URL length are capped so a pathological page
+// can't bloat the persisted diagnostics row.
+module('network-inflight-tracker', function () {
+  test('a started request is reported until it settles', function (assert) {
+    let tracker = new NetworkInflightTracker();
+    tracker.recordStarted('1', 'https://example.com/a');
+    tracker.recordStarted('2', 'https://example.com/b');
+    assert.strictEqual(tracker.getPending().length, 2, 'both in flight');
+
+    tracker.recordSettled('1');
+    let pending = tracker.getPending();
+    assert.strictEqual(pending.length, 1, 'settled request dropped');
+    assert.strictEqual(pending[0].url, 'https://example.com/b');
+  });
+
+  test('settling an unknown request id is a no-op', function (assert) {
+    let tracker = new NetworkInflightTracker();
+    tracker.recordStarted('1', 'https://example.com/a');
+    tracker.recordSettled('does-not-exist');
+    assert.strictEqual(tracker.getPending().length, 1);
+  });
+
+  test('the snapshot is ordered oldest-first', function (assert) {
+    let tracker = new NetworkInflightTracker();
+    for (let i = 0; i < 5; i++) {
+      tracker.recordStarted(String(i), `https://example.com/${i}`);
+    }
+    // recordStarted stamps startedAt at call time, so the snapshot must
+    // come back with ageMs monotonically non-increasing (oldest first).
+    let ages = tracker.getPending().map((r) => r.ageMs);
+    let descending = [...ages].sort((a, b) => b - a);
+    assert.deepEqual(ages, descending, 'ageMs is non-increasing');
+  });
+
+  test('the reported list is capped', function (assert) {
+    let tracker = new NetworkInflightTracker();
+    for (let i = 0; i < 25; i++) {
+      tracker.recordStarted(String(i), `https://example.com/${i}`);
+    }
+    assert.strictEqual(
+      tracker.getPending().length,
+      20,
+      'capped at MAX_PENDING_REPORTED',
+    );
+  });
+
+  test('long URLs are truncated to the prefix', function (assert) {
+    let tracker = new NetworkInflightTracker();
+    let longUrl = 'https://example.com/' + 'x'.repeat(500);
+    tracker.recordStarted('1', longUrl);
+    let [only] = tracker.getPending();
+    assert.strictEqual(only.url.length, 200, 'truncated to MAX_URL_LENGTH');
+    assert.ok(longUrl.startsWith(only.url), 'truncation keeps the prefix');
+  });
+});

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -271,6 +271,48 @@ export interface RenderTimeoutDiagnostics {
   computedCacheHits?: number;
   serializeMs?: number;
   searchDocMs?: number;
+  // The following four are captured server-side on the timeout path
+  // only (the in-page hooks above can come back empty when the render's
+  // JS thread is wedged). Together they discriminate the render-hang
+  // failure mode: an unresponsive main thread with `scriptBusyFraction`
+  // near 1 is a CPU-spinning render (runaway loop / never-settling
+  // Glimmer, possibly starved by co-tenant renders — see
+  // `concurrentRenders`); a responsive main thread with a low script
+  // fraction is a render *waiting* on something, in which case
+  // `pendingNetworkRequests` names the fetch it never got back.
+  //
+  // Whether a probe `page.evaluate` could even round-trip within a
+  // short budget. `false` means the page's JS thread is wedged (it
+  // couldn't run a trivial expression), which is the signature of a
+  // CPU-bound stall as opposed to a waiting one.
+  mainThreadResponsive?: boolean;
+  // Fraction of wall-clock the renderer's main thread spent running JS
+  // (CDP `Performance` ScriptDuration delta / wall delta) over a short
+  // sampling window at timeout. ~1.0 means the thread is pegged
+  // executing JavaScript — a runaway sync loop or a render that never
+  // settles. Near 0 means the thread is idle-waiting.
+  scriptBusyFraction?: number;
+  // Fraction of wall-clock spent in any main-thread task (CDP
+  // `Performance` TaskDuration delta / wall delta) — a superset of
+  // `scriptBusyFraction` that also counts layout / style / GC. High
+  // task but low script points at non-JS main-thread work.
+  taskBusyFraction?: number;
+  // Renderer JS heap in use at timeout (CDP `Performance`
+  // JSHeapUsedSize, bytes → MB). A climbing heap alongside a pegged
+  // thread suggests an allocation-heavy runaway rather than a tight
+  // CPU loop.
+  jsHeapUsedMB?: number;
+  // Requests the browser process still had outstanding at timeout,
+  // observed out-of-band via CDP `Network` so they survive a wedged
+  // JS thread. Oldest first; capped. The longest-lived entry is the
+  // resource a *waiting* render is hung on.
+  pendingNetworkRequests?: Array<{ url: string; ageMs: number }>;
+  // How many renders this prerender process was running concurrently
+  // when the timeout fired (every render passes through the same
+  // server-side timeout wrapper, which keeps the count). A high value
+  // alongside an unresponsive thread points at CPU starvation by
+  // co-tenant renders rather than a single render's own runaway.
+  concurrentRenders?: number;
 }
 
 export interface RenderError extends ErrorEntry {


### PR DESCRIPTION
When a prerender render hangs and times out producing nothing, the existing capture often comes back blind: an empty DOM, nothing in-flight, and a null `__boxelRenderDiagnostics()` because the in-page hook can't run when the render's JS thread is wedged. This adds four signals captured on the timeout path that, taken together, tell apart the distinct ways a render can hang.

## The four signals

- **`mainThreadResponsive`** — a short `page.evaluate` raced against a 2s timer. If a trivial expression can't round-trip, the page's JS thread is wedged. This is the primary discriminator: an unresponsive thread means a CPU-bound stall, a responsive one means the render is waiting on something.
- **`scriptBusyFraction` / `taskBusyFraction` / `jsHeapUsedMB`** — sampled twice ~750ms apart via the CDP `Performance` domain and diffed against wall-clock. `ScriptDuration` and `TaskDuration` are cumulative seconds, so `Δ/wall` gives the fraction of the window the main thread spent running JS (script) or in any main-thread task (script + layout/style/GC). `JSHeapUsedSize` (bytes) is reported as MB. These run out-of-process, so they work even when the JS thread is pegged. `scriptBusyFraction ≈ 1` is the signature of a runaway sync loop or a never-settling Glimmer render.
- **`pendingNetworkRequests`** — a passive per-page CDP `Network` tracker (a cheap `requestId → {url, startedAt}` Map, no per-request logging) whose pending snapshot is read only on timeout. Because CDP runs in the browser process, this survives a wedged JS thread — exactly when the in-page hook goes dark — so it can name the resource a *waiting* render is hung on. Oldest-first, capped, URLs truncated.
- **`concurrentRenders`** — the live count of renders sharing this prerender process, read from the single server-side timeout wrapper every render funnels through. A high value alongside an unresponsive thread points at CPU starvation by co-tenant renders rather than a single render's own runaway.

## How they discriminate the failure modes

- **CPU-spinning** (runaway loop / never-settles): `mainThreadResponsive=false`, `scriptBusyFraction ≈ 1`.
- **CPU starvation by co-tenants**: the spinning signature *plus* a high `concurrentRenders`.
- **App-boot / module-load stall**: `mainThreadResponsive=true`, low script fraction, a boot fetch outstanding in `pendingNetworkRequests`.
- **A specific resource fetch hangs silently**: `mainThreadResponsive=true`, low script fraction, and the hung URL is the longest-lived entry in `pendingNetworkRequests`.

## Scope and safety

All capture is best-effort and **gated to the timeout branch** — the responsiveness probe and the CPU sampling never touch the success render path. The network tracker is a passive Map populated by out-of-process CDP events with no per-request work, so it adds nothing measurable to the render. Every capture is wrapped so it can neither throw into the render nor slow it; when CDP is unavailable the relevant fields are simply omitted. Output rides the existing `prerenderer` warn line and the `RenderTimeoutDiagnostics` object, so it flows to logs and, where a row is written, to `boxel_index.diagnostics`.

Host-side boot breadcrumbs (render route + loader) and indexer abort-path diagnostics persistence are deliberate follow-ups, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
