### PR TITLE
Remove typescript-memoize (@Memoize) from node-run code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -162,27 +162,5 @@ module.exports = {
         ],
       },
     },
-    {
-      // Files exempted only for the `Decorator` selector because they use
-      // `@Memoize()` from typescript-memoize, which is not erasable. The
-      // remaining erasable-syntax guards still apply here. This exemption is
-      // removed once typescript-memoize is dropped from node-run code. Do not
-      // add new files here; remove the decorator to remove the entry.
-      files: [
-        'packages/realm-server/server.ts',
-        'packages/runtime-common/index-runner.ts',
-        'packages/runtime-common/index-writer.ts',
-        'packages/runtime-common/realm-index-query-engine.ts',
-        'packages/runtime-common/realm-index-updater.ts',
-      ],
-      rules: {
-        'no-restricted-syntax': [
-          'error',
-          ...NO_COMPILATION_REQUIRED_TS_SELECTORS.filter(
-            (s) => s.selector !== 'Decorator',
-          ),
-        ],
-      },
-    },
   ],
 };

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -83,7 +83,6 @@
     "tmp": "catalog:",
     "ts-node": "^10.9.1",
     "typescript": "catalog:",
-    "typescript-memoize": "catalog:",
     "undici": "catalog:",
     "uuid": "catalog:",
     "wait-for-localhost-cli": "catalog:",

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -1,6 +1,5 @@
 import Koa from 'koa';
 import cors from '@koa/cors';
-import { Memoize } from 'typescript-memoize';
 import http from 'http';
 import http2 from 'http2';
 import net from 'net';
@@ -602,6 +601,7 @@ export class RealmServer {
   private prerenderer: Prerenderer | undefined;
   private reconciler: RealmRegistryReconciler;
   private searchCache: JobScopedSearchCache;
+  private cachedApp: ReturnType<RealmServer['buildApp']> | undefined;
 
   constructor({
     serverURL,
@@ -697,8 +697,11 @@ export class RealmServer {
     this.searchCache = searchCache ?? new JobScopedSearchCache(dbAdapter);
   }
 
-  @Memoize()
   get app() {
+    return (this.cachedApp ??= this.buildApp());
+  }
+
+  private buildApp() {
     let { serveIndex, serveHostApp } = createServeIndex({
       serverURL: this.serverURL,
       assetsURL: this.assetsURL,

--- a/packages/runtime-common/card-document-shape.ts
+++ b/packages/runtime-common/card-document-shape.ts
@@ -6,17 +6,17 @@
  * to know whether a payload *looks* like a card document can import them
  * without pulling the transitive runtime chain rooted at
  * `resource-types.ts` → `realm-identifiers.ts` → `loader.ts` →
- * `realm.ts` → `realm-index-query-engine.ts`. The latter uses
- * `@Memoize()` decorators that some downstream TS loaders (notably
- * Playwright's) can't compile.
+ * `realm.ts` → `realm-index-query-engine.ts` — a heavy, Node-oriented
+ * chain that lightweight callers (e.g. browser or Playwright loaders)
+ * should not have to pull in just to shape-check a payload.
  *
  * This module only `import type`s from those neighbors — all runtime
  * type-guards are defined inline — so it has no runtime dependency on
- * anything that reaches the decorator chain.
+ * that chain.
  *
  * The original `code-ref.ts` / `resource-types.ts` / `document-types.ts`
  * re-export these predicates for backward compat, so existing imports
- * keep working; new callers that must avoid the decorator chain should
+ * keep working; new callers that must avoid the heavy chain should
  * import from `@cardstack/runtime-common/card-document-shape` directly.
  */
 

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -4,8 +4,6 @@ import ignore, { type Ignore } from 'ignore';
 // `crypto.randomUUID` is not available).
 import { v4 as uuidv4 } from '@lukeed/uuid';
 
-import { Memoize } from 'typescript-memoize';
-
 import {
   logger,
   hasCardExtension,
@@ -85,6 +83,7 @@ export class IndexRunner {
   #perfLog = logger('index-perf');
   #realmPaths: RealmPaths;
   #ignoreData: Record<string, string>;
+  #ignoreMap: Map<string, Ignore> | undefined;
   #prerenderer: Prerenderer;
   #auth: string;
   #realmURL: URL;
@@ -889,12 +888,15 @@ export class IndexRunner {
     return true;
   }
 
-  @Memoize()
   private get ignoreMap() {
+    if (this.#ignoreMap) {
+      return this.#ignoreMap;
+    }
     let ignoreMap = new Map<string, Ignore>();
     for (let [url, contents] of Object.entries(this.#ignoreData)) {
       ignoreMap.set(url, ignore().add(contents));
     }
+    this.#ignoreMap = ignoreMap;
     return ignoreMap;
   }
 

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -1,4 +1,3 @@
-import { Memoize } from 'typescript-memoize';
 import flatten from 'lodash/flatten';
 import flattenDeep from 'lodash/flattenDeep';
 import {
@@ -172,6 +171,7 @@ export interface FileEntry {
 export class Batch {
   readonly ready: Promise<void>;
   #invalidations = new Set<string>();
+  #nodeResolvedInvalidations: string[] | undefined;
   // URLs already written to boxel_index_working by an earlier attempt
   // of *this same job*, with the last_modified value the previous
   // attempt observed. Populated during `ready`. The visit loop in
@@ -313,11 +313,10 @@ export class Batch {
     return getContentMeta(this.#dbAdapter, this.realmURL.href, localPath);
   }
 
-  @Memoize()
   private get nodeResolvedInvalidations() {
-    return [...this.invalidations].map((href) =>
-      trimExecutableExtension(rri(href)),
-    );
+    return (this.#nodeResolvedInvalidations ??= [...this.invalidations].map(
+      (href) => trimExecutableExtension(rri(href)),
+    ));
   }
 
   async getModifiedTimes(): Promise<LastModifiedTimes> {

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -79,7 +79,6 @@
     "safe-stable-stringify": "catalog:",
     "super-fast-md5": "catalog:",
     "transform-modules-amd-plugin": "workspace:*",
-    "typescript-memoize": "catalog:",
     "uuid": "catalog:",
     "zod": "^3.24.4"
   },

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -1,4 +1,3 @@
-import { Memoize } from 'typescript-memoize';
 import { isScopedCSSRequest } from './scoped-css';
 import cloneDeep from 'lodash/cloneDeep';
 import {
@@ -213,6 +212,7 @@ function absolutizeInstanceURL(
 
 export class RealmIndexQueryEngine {
   #realm: Realm;
+  #realmURL: URL | undefined;
   #fetch: typeof globalThis.fetch;
   #indexQueryEngine: IndexQueryEngine;
   #definitionLookup: DefinitionLookup;
@@ -278,9 +278,8 @@ export class RealmIndexQueryEngine {
     this.#fetch = fetch;
   }
 
-  @Memoize()
   private get realmURL() {
-    return new URL(this.#realm.url);
+    return (this.#realmURL ??= new URL(this.#realm.url));
   }
 
   async searchCards(

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -1,4 +1,3 @@
-import { Memoize } from 'typescript-memoize';
 import {
   IndexWriter,
   Deferred,
@@ -26,6 +25,7 @@ import ignore, { type Ignore } from 'ignore';
 
 export class RealmIndexUpdater {
   #realm: Realm;
+  #realmURL: URL | undefined;
   #log = logger('realm-index-updater');
   #ignoreData: Record<string, string> = {};
   // Bumped every time a from-scratch result writes #ignoreData. Concurrent
@@ -78,9 +78,8 @@ export class RealmIndexUpdater {
     return this.#stats;
   }
 
-  @Memoize()
   private get realmURL() {
-    return new URL(this.#realm.url);
+    return (this.#realmURL ??= new URL(this.#realm.url));
   }
 
   private get ignoreMap() {

--- a/packages/software-factory/src/instantiate-execution.ts
+++ b/packages/software-factory/src/instantiate-execution.ts
@@ -485,11 +485,11 @@ async function prepareExampleInstance(
   // `CodeRef`. Running it first means the nested accesses below cannot
   // throw.
   //
-  // NB: we import from the decorator-free `/card-document-shape` subpath
-  // (not the `/document-types` barrel entry that re-exports it) because
-  // this module is exercised by the software-factory Playwright harness,
-  // which can't compile the `@Memoize()` decorators reachable through
-  // the heavier runtime-common entry points.
+  // NB: we import from the lightweight `/card-document-shape` subpath
+  // (not the `/document-types` barrel entry that re-exports it) so the
+  // software-factory Playwright harness that exercises this module does
+  // not have to pull in the heavier, Node-oriented runtime-common entry
+  // points.
   if (!isSingleCardDocument(parsedDoc)) {
     return {
       error: `Example "${exampleUrl}" is not a valid card document (missing or malformed "data" / "data.meta.adoptsFrom").`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,9 +657,6 @@ catalogs:
     typescript:
       specifier: ~5.9.3
       version: 5.9.3
-    typescript-memoize:
-      specifier: ^1.1.1
-      version: 1.1.1
     undici:
       specifier: ^7.22.0
       version: 7.25.0
@@ -2804,9 +2801,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
-      typescript-memoize:
-        specifier: 'catalog:'
-        version: 1.1.1
       undici:
         specifier: 'catalog:'
         version: 7.25.0
@@ -3077,9 +3071,6 @@ importers:
       transform-modules-amd-plugin:
         specifier: workspace:*
         version: link:../../vendor/transform-modules-amd-plugin
-      typescript-memoize:
-        specifier: 'catalog:'
-        version: 1.1.1
       uuid:
         specifier: 'catalog:'
         version: 9.0.1
@@ -18710,7 +18701,10 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-command@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -18727,7 +18721,10 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-doctor@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -18763,7 +18760,10 @@ snapshots:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
       yaml: 2.9.0
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-upload@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -18771,7 +18771,10 @@ snapshots:
       fast-glob: 3.3.3
       image-size: 1.2.1
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli@1.31.13(typescript@5.9.3)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -240,7 +240,6 @@ catalog:
   tmp: ^0.2.1
   tracked-built-ins: ^4.0.0
   typescript: ~5.9.3
-  typescript-memoize: ^1.1.1
   undici: ^7.22.0
   uuid: ^9.0.1
   validate-peer-dependencies: ^1.1.0


### PR DESCRIPTION
Stacked on #5153 (CS-11445). Review/merge that one first; this PR's base is the CS-11445 branch.

## What

`@Memoize()` (from `typescript-memoize`) is a legacy decorator and isn't erasable — it hard-errors under Node's native type-stripping, and Node won't support legacy decorators (they wait on the TC39 runtime proposal). This removes the five usages so the realm-server/indexing path can eventually run without ts-node.

Each `@Memoize()` getter becomes a plain lazily-cached private field, preserving the same **compute-once, per-instance** semantics:

| File | Getter | Replacement |
|---|---|---|
| `runtime-common/realm-index-updater.ts` | `realmURL` | `#realmURL ??= new URL(...)` |
| `runtime-common/realm-index-query-engine.ts` | `realmURL` | `#realmURL ??= new URL(...)` |
| `runtime-common/index-writer.ts` | `nodeResolvedInvalidations` | `#nodeResolvedInvalidations ??= [...]` |
| `runtime-common/index-runner.ts` | `ignoreMap` | lazy `#ignoreMap` (loop body) |
| `realm-server/server.ts` | `app` | extract `buildApp()`, cache via `#`-equivalent field |

For `server.ts`, the Koa build moved into a private `buildApp()` and the cache field is typed `ReturnType<RealmServer['buildApp']>`, so the public `app` getter's type is unchanged (the chained `.use(...)` context type is preserved rather than narrowed).

## Also

- Dropped `typescript-memoize` from `realm-server` + `runtime-common` `package.json` and the now-unused `pnpm-workspace.yaml` catalog entry (it remains in the lockfile only as a transitive dep of ember build tooling).
- Removed the decorator grandfather override added in CS-11445 — with the decorators gone, those five files now pass the `Decorator` selector on their own.
- Updated two comments (`card-document-shape.ts`, `software-factory/instantiate-execution.ts`) that justified the decorator-free module split by pointing at the `@Memoize` chain; the split now stands on the heavy-transitive-chain coupling alone. (Fully unwinding that split is possible now but deliberately left out of scope.)

## Verification

- `lint:js` clean on `runtime-common`, `realm-server`, `software-factory`.
- `lint:types` (`ember-tsc --noEmit`) clean on `runtime-common` and `realm-server`.
- No `@Memoize` / `typescript-memoize` references remain in source.

No production behavior change — the memoization semantics are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)