### PR TITLE
Fix flaky past-sessions read-receipt assertion

### DIFF
--- a/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
@@ -1,4 +1,4 @@
-import { waitFor, click } from '@ember/test-helpers';
+import { waitFor, waitUntil, click } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
 import { getService } from '@universal-ember/test-support';
@@ -252,7 +252,7 @@ module('Integration | ai-assistant-panel | past sessions', function (hooks) {
       name: 'Another Room',
     });
 
-    simulateRemoteMessage(
+    let backgroundMessageEventId = simulateRemoteMessage(
       anotherRoomId,
       '@aibot:localhost',
       {
@@ -298,6 +298,27 @@ module('Integration | ai-assistant-panel | past sessions', function (hooks) {
       .doesNotHaveAttribute('data-is-current-room');
 
     await click(`[data-test-enter-room='${anotherRoomId}']`);
+
+    // Entering the room marks its background message read, but the receipt path
+    // is IntersectionObserver → afterRender schedule → matrix client → Receipt
+    // event → addEventReadReceipt, none of which settles on the runloop or a DOM
+    // mutation. Wait for the receipt to land before asserting the unseen-message
+    // state has cleared. ([read-receipt-trace] logs in room.gts surface which
+    // step stalled if this ever times out.)
+    let matrixService = getService('matrix-service');
+    await waitUntil(
+      () =>
+        matrixService.currentUserEventReadReceipts.has(
+          backgroundMessageEventId,
+        ),
+      {
+        timeout: 5000,
+        timeoutMessage:
+          `read receipt for ${anotherRoomId}'s background message ` +
+          `(event ${backgroundMessageEventId}) never landed after entering the room`,
+      },
+    );
+
     assert
       .dom(
         `[data-test-joined-room='${anotherRoomId}'] [data-test-is-unseen-message]`,


### PR DESCRIPTION
The `Integration | ai-assistant-panel | past sessions` test *"it animates the sessions dropdown button when there are other sessions that have activity which was not seen by the user yet"* is intermittently failing CI:

```
Element [data-test-joined-room='mock_room_1'] does not include text "Updated"
```

## Root cause

The test enters a second room and then, after reopening the past-sessions menu, asserts that room's "Updated" unseen-message badge has cleared. The badge clears only once a read receipt for the room's latest message is recorded in `currentUserEventReadReceipts`. That receipt travels an async path that `settled()` cannot see end-to-end:

> IntersectionObserver (fires when the message scrolls into view) → `schedule('afterRender')` → matrix client `sendReadReceipt` → `Receipt` event → `addEventReadReceipt`

The `afterRender` schedule and the mock client's receipt round-trip are synchronous/runloop-tracked, but the **IntersectionObserver callback that kicks the whole thing off is browser-scheduled and outside Ember's test-waiter awareness**. So the assertion occasionally runs before the receipt lands and still sees the badge.

This is the same class of flake — and the same mechanism — that was already fixed for the sibling read-receipt test in `general-test.gts`; this test simply wasn't covered by that change.

## Fix

Capture the background message's event id and `waitUntil` its read receipt is recorded in `currentUserEventReadReceipts` before asserting the unseen-message state has cleared. This waits on the precise completion signal rather than the runloop, matching the established pattern. The existing `[read-receipt-trace]` logs in `room.gts` already report which step stalled, so a future timeout (now carrying a message that names the awaited event) stays diagnosable.

A test waiter around the IntersectionObserver itself was considered and rejected: a message can legitimately never intersect (scrolled out of view, room torn down before its initial callback), which would leave a waiter token pending forever and hang `settled()` for the whole test — strictly worse than a bounded wait on the actual state.
