### PR TITLE
Add publishing command types and shared published-realm URL helper

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -614,6 +614,87 @@ export class ExecuteAtomicOperationsResult extends CardDef {
   @field results = containsMany(JsonField);
 }
 
+// A publish destination for a realm. 'type' is 'subdirectory' (a Boxel Space
+// under the user's space domain, where 'name' is the realm-name path segment)
+// or 'custom' (a claimed custom domain, where 'name' is the full hostname).
+export class PublishTarget extends FieldDef {
+  @field type = contains(StringField);
+  @field name = contains(StringField);
+}
+
+export class PublishRealmInput extends CardDef {
+  @field realmURL = contains(StringField);
+  @field targets = containsMany(PublishTarget);
+  // Whether to wait for publish (copy + reindex) to finish before resolving.
+  // Defaults to true when omitted (the command applies the default).
+  @field wait = contains(BooleanField);
+  // How long to wait when wait is true, in milliseconds; on expiry the
+  // command returns the current pending state with timedOut set.
+  @field timeoutMs = contains(NumberField);
+  // Bypass the pre-publish publishability gate (private-dependency and
+  // error-document violations). Defaults to false.
+  @field force = contains(BooleanField);
+}
+
+// Per-target outcome. 'status' is 'published' | 'pending' | 'error'.
+export class PublishTargetResult extends FieldDef {
+  @field publishedRealmURL = contains(StringField);
+  @field status = contains(StringField);
+  @field error = contains(StringField);
+}
+
+export class PublishRealmResult extends CardDef {
+  @field results = containsMany(PublishTargetResult);
+  // True if wait elapsed before every target finished (targets still pending).
+  @field timedOut = contains(BooleanField);
+}
+
+export class UnpublishRealmInput extends CardDef {
+  @field realmURL = contains(StringField);
+  // Supply either a typed target or a fully-resolved publishedRealmURL.
+  @field target = contains(PublishTarget);
+  @field publishedRealmURL = contains(StringField);
+  @field wait = contains(BooleanField);
+  @field timeoutMs = contains(NumberField);
+}
+
+// 'status' is 'unpublished' | 'pending' | 'error'.
+export class UnpublishRealmResult extends CardDef {
+  @field publishedRealmURL = contains(StringField);
+  @field status = contains(StringField);
+  @field timedOut = contains(BooleanField);
+  @field error = contains(StringField);
+}
+
+export class GetPublishedRealmsInput extends CardDef {
+  @field realmURL = contains(StringField);
+}
+
+// One published destination for a source realm. lastPublishedAt is an
+// ISO-8601 timestamp string (empty when never published).
+export class PublishedRealmInfo extends FieldDef {
+  @field publishedRealmURL = contains(StringField);
+  @field lastPublishedAt = contains(StringField);
+  @field isPublishing = contains(BooleanField);
+}
+
+export class GetPublishedRealmsResult extends CardDef {
+  @field results = containsMany(PublishedRealmInfo);
+}
+
+// 'type' is 'subdirectory' | 'custom'; 'name' matches PublishTarget.name.
+export class CheckDomainAvailabilityInput extends CardDef {
+  @field type = contains(StringField);
+  @field name = contains(StringField);
+  @field realmURL = contains(StringField);
+}
+
+export class CheckDomainAvailabilityResult extends CardDef {
+  @field available = contains(BooleanField);
+  @field publishedRealmURL = contains(StringField);
+  @field reason = contains(StringField);
+}
+
 export class StoreAddInput extends CardDef {
   @field document = contains(JsonField);
   @field realm = contains(StringField);

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -670,8 +670,9 @@ export class GetPublishedRealmsInput extends CardDef {
   @field realmURL = contains(StringField);
 }
 
-// One published destination for a source realm. lastPublishedAt is an
-// ISO-8601 timestamp string (empty when never published).
+// One published destination for a source realm. lastPublishedAt mirrors the
+// realm-server value: epoch milliseconds rendered as a string (Date.now()
+// .toString()); absent when the realm has never been published.
 export class PublishedRealmInfo extends FieldDef {
   @field publishedRealmURL = contains(StringField);
   @field lastPublishedAt = contains(StringField);

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -625,18 +625,14 @@ export class PublishTarget extends FieldDef {
 export class PublishRealmInput extends CardDef {
   @field realmURL = contains(StringField);
   @field targets = containsMany(PublishTarget);
-  // Whether to wait for publish (copy + reindex) to finish before resolving.
-  // Defaults to true when omitted (the command applies the default).
-  @field wait = contains(BooleanField);
-  // How long to wait when wait is true, in milliseconds; on expiry the
-  // command returns the current pending state with timedOut set.
-  @field timeoutMs = contains(NumberField);
   // Bypass the pre-publish publishability gate (private-dependency and
   // error-document violations). Defaults to false.
   @field force = contains(BooleanField);
 }
 
-// Per-target outcome. 'status' is 'published' | 'pending' | 'error'.
+// Per-target outcome. The command resolves once the publish request is
+// accepted (the realm-server reindex then runs in the background), so 'status'
+// is 'published' (request accepted) or 'error'.
 export class PublishTargetResult extends FieldDef {
   @field publishedRealmURL = contains(StringField);
   @field status = contains(StringField);
@@ -645,8 +641,6 @@ export class PublishTargetResult extends FieldDef {
 
 export class PublishRealmResult extends CardDef {
   @field results = containsMany(PublishTargetResult);
-  // True if wait elapsed before every target finished (targets still pending).
-  @field timedOut = contains(BooleanField);
 }
 
 export class UnpublishRealmInput extends CardDef {
@@ -654,15 +648,12 @@ export class UnpublishRealmInput extends CardDef {
   // Supply either a typed target or a fully-resolved publishedRealmURL.
   @field target = contains(PublishTarget);
   @field publishedRealmURL = contains(StringField);
-  @field wait = contains(BooleanField);
-  @field timeoutMs = contains(NumberField);
 }
 
-// 'status' is 'unpublished' | 'pending' | 'error'.
+// 'status' is 'unpublished' or 'error'.
 export class UnpublishRealmResult extends CardDef {
   @field publishedRealmURL = contains(StringField);
   @field status = contains(StringField);
-  @field timedOut = contains(BooleanField);
   @field error = contains(StringField);
 }
 

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -32,6 +32,10 @@ import PrivateDependencyViolationComponent from '@cardstack/host/components/oper
 import WithLoadedRealm from '@cardstack/host/components/with-loaded-realm';
 
 import config from '@cardstack/host/config/environment';
+import {
+  deriveRealmName,
+  resolvePublishedRealmUrl,
+} from '@cardstack/host/lib/published-realm-url';
 
 import type HostModeService from '@cardstack/host/services/host-mode-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
@@ -319,12 +323,14 @@ export default class PublishRealmModal extends Component<Signature> {
   }
 
   get subdirectoryRealmUrl() {
-    const protocol = this.getProtocol();
-    const matrixUsername = this.getMatrixUsername();
-    const domain = this.getDefaultPublishedRealmDomain();
-    const realmName = this.getRealmName();
-
-    return `${protocol}://${matrixUsername}.${domain}/${realmName}/`;
+    return resolvePublishedRealmUrl(
+      { type: 'subdirectory', name: this.getRealmName() },
+      {
+        protocol: this.getProtocol(),
+        matrixUsername: this.getMatrixUsername(),
+        spaceDomain: this.getDefaultPublishedRealmDomain(),
+      },
+    );
   }
 
   get subdirectoryRealmParts() {
@@ -366,8 +372,10 @@ export default class PublishRealmModal extends Component<Signature> {
   }
 
   private buildPublishedRealmUrl(hostname: string): string {
-    let protocol = this.getProtocol();
-    return `${protocol}://${hostname}/`;
+    return resolvePublishedRealmUrl(
+      { type: 'custom', name: hostname },
+      { protocol: this.getProtocol() },
+    );
   }
 
   private clearCustomSubdomainFeedback() {
@@ -476,24 +484,7 @@ export default class PublishRealmModal extends Component<Signature> {
     if (!realmUrl) {
       throw new Error('Current realm URL is not available');
     }
-
-    try {
-      const pathSegments = new URL(realmUrl).pathname
-        .split('/')
-        .filter((segment) => segment);
-      const lastSegment = pathSegments[pathSegments.length - 1];
-
-      if (!lastSegment) {
-        throw new Error('Could not extract realm name from URL path');
-      }
-
-      return lastSegment.toLowerCase();
-    } catch (error) {
-      if (error instanceof Error) {
-        throw new Error(`Failed to parse realm URL: ${error.message}`);
-      }
-      throw new Error('Failed to parse realm URL');
-    }
+    return deriveRealmName(realmUrl);
   }
 
   @action

--- a/packages/host/app/lib/published-realm-url.ts
+++ b/packages/host/app/lib/published-realm-url.ts
@@ -54,27 +54,55 @@ export function deriveRealmName(realmURL: string): string {
   return lastSegment.toLowerCase();
 }
 
-// Strips a leading protocol and any trailing slash from a hostname so a caller
-// may pass either "host:port" or "https://host:port/".
-function normalizeHostname(value: string): string {
-  return value.replace(/^[a-z]+:\/\//i, '').replace(/\/+$/, '');
+// Parses a custom-domain target's name into a bare host (with port when
+// present). A custom target maps to `https://<host>/`, so anything beyond a
+// hostname — credentials, a path, a query, or a fragment — means the caller
+// passed a URL or made a mistake, and is rejected rather than silently
+// producing a non-root published-realm URL. A leading protocol is tolerated so
+// callers may pass either "host:port" or "https://host:port/".
+function parseCustomHostname(value: string): string {
+  let trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('A custom publish target requires a hostname in `name`');
+  }
+  let withProtocol = /^[a-z]+:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  let url: URL;
+  try {
+    url = new URL(withProtocol);
+  } catch {
+    throw new Error(`Invalid custom publish target hostname: "${value}"`);
+  }
+  if (url.username || url.password) {
+    throw new Error(
+      `A custom publish target hostname must not include credentials: "${value}"`,
+    );
+  }
+  if ((url.pathname && url.pathname !== '/') || url.search || url.hash) {
+    throw new Error(
+      `A custom publish target must be a bare hostname, not a URL with a path, query, or fragment: "${value}"`,
+    );
+  }
+  return url.host; // host includes the port when present
+}
+
+// Normalizes a caller-supplied protocol to a bare scheme so a value like
+// "https" or an accidental "https://" both yield "https".
+function normalizeProtocol(protocol: string): string {
+  return protocol.replace(/:\/*$/, '');
 }
 
 export function resolvePublishedRealmUrl(
   target: PublishTargetSpec,
   ctx: PublishedRealmUrlContext = {},
 ): string {
-  let protocol = ctx.protocol ?? DEFAULT_PROTOCOL;
+  let protocol = normalizeProtocol(ctx.protocol ?? DEFAULT_PROTOCOL);
 
   switch (target.type) {
     case 'custom': {
-      let hostname = normalizeHostname((target.name ?? '').trim());
-      if (!hostname) {
-        throw new Error(
-          'A custom publish target requires a hostname in `name`',
-        );
-      }
-      return `${protocol}://${hostname}/`;
+      let host = parseCustomHostname(target.name ?? '');
+      return `${protocol}://${host}/`;
     }
     case 'subdirectory': {
       let realmName = (target.name ?? '').trim();

--- a/packages/host/app/lib/published-realm-url.ts
+++ b/packages/host/app/lib/published-realm-url.ts
@@ -1,0 +1,107 @@
+// Resolves a typed publish target to the published-realm URL it maps to.
+//
+// Two target shapes are supported, mirroring the publish UI
+// (`operator-mode/publish-realm-modal.gts`):
+//
+//   - 'subdirectory': a Boxel Space under the user's space domain. The URL is
+//     `https://<matrixUsername>.<spaceDomain>/<realmName>/`, where `name` is the
+//     realm-name path segment (defaults to the last segment of the source realm
+//     URL when omitted).
+//   - 'custom': a claimed custom domain. The URL is `https://<hostname>/`, where
+//     `name` is the full hostname (e.g. "mysite.boxel.site" or
+//     "mysite.localhost:4201").
+//
+// Keep this in sync with the modal — both must produce identical URLs.
+
+export type PublishTargetType = 'subdirectory' | 'custom';
+
+export interface PublishTargetSpec {
+  type: PublishTargetType;
+  // For 'subdirectory', the realm-name path segment (optional; derived from
+  // `sourceRealmURL` when blank). For 'custom', the full hostname.
+  name?: string;
+}
+
+export interface PublishedRealmUrlContext {
+  // Required for 'subdirectory' targets.
+  matrixUsername?: string;
+  // Required for 'subdirectory' targets (e.g. config.publishedRealmBoxelSpaceDomain).
+  spaceDomain?: string;
+  // Used to derive the realm name for 'subdirectory' targets when `name` is blank.
+  sourceRealmURL?: string;
+  // Defaults to 'https'. The local dev stack and every deployed environment
+  // serve published realms over https.
+  protocol?: string;
+}
+
+const DEFAULT_PROTOCOL = 'https';
+
+// Extracts the realm-name path segment from a realm URL: the last non-empty
+// path segment, lowercased. Matches the modal's `getRealmName`.
+export function deriveRealmName(realmURL: string): string {
+  let url: URL;
+  try {
+    url = new URL(realmURL);
+  } catch (error) {
+    let message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse realm URL "${realmURL}": ${message}`);
+  }
+  let segments = url.pathname.split('/').filter((segment) => segment);
+  let lastSegment = segments[segments.length - 1];
+  if (!lastSegment) {
+    throw new Error(`Could not extract realm name from URL path "${realmURL}"`);
+  }
+  return lastSegment.toLowerCase();
+}
+
+// Strips a leading protocol and any trailing slash from a hostname so a caller
+// may pass either "host:port" or "https://host:port/".
+function normalizeHostname(value: string): string {
+  return value.replace(/^[a-z]+:\/\//i, '').replace(/\/+$/, '');
+}
+
+export function resolvePublishedRealmUrl(
+  target: PublishTargetSpec,
+  ctx: PublishedRealmUrlContext = {},
+): string {
+  let protocol = ctx.protocol ?? DEFAULT_PROTOCOL;
+
+  switch (target.type) {
+    case 'custom': {
+      let hostname = normalizeHostname((target.name ?? '').trim());
+      if (!hostname) {
+        throw new Error(
+          'A custom publish target requires a hostname in `name`',
+        );
+      }
+      return `${protocol}://${hostname}/`;
+    }
+    case 'subdirectory': {
+      let realmName = (target.name ?? '').trim();
+      if (!realmName) {
+        if (!ctx.sourceRealmURL) {
+          throw new Error(
+            'A subdirectory publish target requires either `name` or a `sourceRealmURL` to derive it from',
+          );
+        }
+        realmName = deriveRealmName(ctx.sourceRealmURL);
+      } else {
+        realmName = realmName.toLowerCase();
+      }
+      if (!ctx.matrixUsername) {
+        throw new Error(
+          'A subdirectory publish target requires `matrixUsername`',
+        );
+      }
+      if (!ctx.spaceDomain) {
+        throw new Error('A subdirectory publish target requires `spaceDomain`');
+      }
+      return `${protocol}://${ctx.matrixUsername}.${ctx.spaceDomain}/${realmName}/`;
+    }
+    default: {
+      throw new Error(
+        `Unknown publish target type: ${(target as PublishTargetSpec).type}`,
+      );
+    }
+  }
+}

--- a/packages/host/tests/unit/published-realm-url-test.ts
+++ b/packages/host/tests/unit/published-realm-url-test.ts
@@ -1,0 +1,166 @@
+import { module, test } from 'qunit';
+
+import {
+  deriveRealmName,
+  resolvePublishedRealmUrl,
+} from '@cardstack/host/lib/published-realm-url';
+
+module('Unit | published-realm-url', function () {
+  module('deriveRealmName', function () {
+    test('returns the last path segment, lowercased', function (assert) {
+      assert.strictEqual(
+        deriveRealmName('https://realms.example/mike/Game-Mechanics/'),
+        'game-mechanics',
+      );
+    });
+
+    test('ignores a missing trailing slash', function (assert) {
+      assert.strictEqual(
+        deriveRealmName('https://realms.example/mike/notes'),
+        'notes',
+      );
+    });
+
+    test('throws when there is no path segment', function (assert) {
+      assert.throws(
+        () => deriveRealmName('https://realms.example/'),
+        /Could not extract realm name/,
+      );
+    });
+
+    test('throws on an unparseable URL', function (assert) {
+      assert.throws(() => deriveRealmName('not a url'), /Failed to parse/);
+    });
+  });
+
+  module('resolvePublishedRealmUrl — subdirectory', function () {
+    test('builds a Boxel Space URL from username, domain, and name', function (assert) {
+      assert.strictEqual(
+        resolvePublishedRealmUrl(
+          { type: 'subdirectory', name: 'game-mechanics' },
+          { matrixUsername: 'mike', spaceDomain: 'boxel.space' },
+        ),
+        'https://mike.boxel.space/game-mechanics/',
+      );
+    });
+
+    test('lowercases the provided name', function (assert) {
+      assert.strictEqual(
+        resolvePublishedRealmUrl(
+          { type: 'subdirectory', name: 'Game-Mechanics' },
+          { matrixUsername: 'mike', spaceDomain: 'boxel.space' },
+        ),
+        'https://mike.boxel.space/game-mechanics/',
+      );
+    });
+
+    test('derives the name from sourceRealmURL when blank', function (assert) {
+      assert.strictEqual(
+        resolvePublishedRealmUrl(
+          { type: 'subdirectory' },
+          {
+            matrixUsername: 'mike',
+            spaceDomain: 'boxel.space',
+            sourceRealmURL: 'https://realms.example/mike/Notes/',
+          },
+        ),
+        'https://mike.boxel.space/notes/',
+      );
+    });
+
+    test('honors a custom protocol', function (assert) {
+      assert.strictEqual(
+        resolvePublishedRealmUrl(
+          { type: 'subdirectory', name: 'notes' },
+          {
+            matrixUsername: 'mike',
+            spaceDomain: 'boxel.space',
+            protocol: 'http',
+          },
+        ),
+        'http://mike.boxel.space/notes/',
+      );
+    });
+
+    test('throws when name is blank and no sourceRealmURL is given', function (assert) {
+      assert.throws(
+        () =>
+          resolvePublishedRealmUrl(
+            { type: 'subdirectory' },
+            { matrixUsername: 'mike', spaceDomain: 'boxel.space' },
+          ),
+        /requires either `name` or a `sourceRealmURL`/,
+      );
+    });
+
+    test('throws when matrixUsername is missing', function (assert) {
+      assert.throws(
+        () =>
+          resolvePublishedRealmUrl(
+            { type: 'subdirectory', name: 'notes' },
+            { spaceDomain: 'boxel.space' },
+          ),
+        /requires `matrixUsername`/,
+      );
+    });
+
+    test('throws when spaceDomain is missing', function (assert) {
+      assert.throws(
+        () =>
+          resolvePublishedRealmUrl(
+            { type: 'subdirectory', name: 'notes' },
+            { matrixUsername: 'mike' },
+          ),
+        /requires `spaceDomain`/,
+      );
+    });
+  });
+
+  module('resolvePublishedRealmUrl — custom', function () {
+    test('builds a URL from a bare hostname', function (assert) {
+      assert.strictEqual(
+        resolvePublishedRealmUrl({ type: 'custom', name: 'mysite.boxel.site' }),
+        'https://mysite.boxel.site/',
+      );
+    });
+
+    test('preserves a port in the hostname', function (assert) {
+      assert.strictEqual(
+        resolvePublishedRealmUrl({
+          type: 'custom',
+          name: 'mysite.localhost:4201',
+        }),
+        'https://mysite.localhost:4201/',
+      );
+    });
+
+    test('strips a leading protocol and trailing slash', function (assert) {
+      assert.strictEqual(
+        resolvePublishedRealmUrl({
+          type: 'custom',
+          name: 'https://mysite.boxel.site/',
+        }),
+        'https://mysite.boxel.site/',
+      );
+    });
+
+    test('throws when the hostname is blank', function (assert) {
+      assert.throws(
+        () => resolvePublishedRealmUrl({ type: 'custom', name: '' }),
+        /requires a hostname/,
+      );
+    });
+  });
+
+  test('throws on an unknown target type', function (assert) {
+    assert.throws(
+      () =>
+        resolvePublishedRealmUrl({
+          // @ts-expect-error intentionally invalid type
+          type: 'bogus',
+          name: 'x',
+        }),
+      /Unknown publish target type/,
+    );
+  });
+});

--- a/packages/host/tests/unit/published-realm-url-test.ts
+++ b/packages/host/tests/unit/published-realm-url-test.ts
@@ -150,6 +150,57 @@ module('Unit | published-realm-url', function () {
         /requires a hostname/,
       );
     });
+
+    test('rejects a hostname that includes a path', function (assert) {
+      assert.throws(
+        () =>
+          resolvePublishedRealmUrl({
+            type: 'custom',
+            name: 'mysite.boxel.site/foo',
+          }),
+        /path, query, or fragment/,
+      );
+    });
+
+    test('rejects a hostname that includes credentials', function (assert) {
+      assert.throws(
+        () =>
+          resolvePublishedRealmUrl({
+            type: 'custom',
+            name: 'user:pass@mysite.boxel.site',
+          }),
+        /must not include credentials/,
+      );
+    });
+
+    test('rejects a hostname that includes a query or fragment', function (assert) {
+      assert.throws(
+        () =>
+          resolvePublishedRealmUrl({
+            type: 'custom',
+            name: 'mysite.boxel.site?a=1',
+          }),
+        /path, query, or fragment/,
+      );
+      assert.throws(
+        () =>
+          resolvePublishedRealmUrl({
+            type: 'custom',
+            name: 'mysite.boxel.site#frag',
+          }),
+        /path, query, or fragment/,
+      );
+    });
+
+    test('normalizes an accidental protocol passed in ctx', function (assert) {
+      assert.strictEqual(
+        resolvePublishedRealmUrl(
+          { type: 'custom', name: 'mysite.boxel.site' },
+          { protocol: 'https://' },
+        ),
+        'https://mysite.boxel.site/',
+      );
+    });
   });
 
   test('throws on an unknown target type', function (assert) {


### PR DESCRIPTION
Foundation for command-based publishing: the shared types and URL logic the publish/unpublish/status/domain-availability host commands build on. No command wiring yet — those land in follow-up PRs.

## Changes
- **`packages/base/command.gts`** — input/result card types for the four commands: `PublishTarget`, `PublishRealmInput`/`PublishTargetResult`/`PublishRealmResult`, `UnpublishRealmInput`/`UnpublishRealmResult`, `GetPublishedRealmsInput`/`PublishedRealmInfo`/`GetPublishedRealmsResult`, `CheckDomainAvailabilityInput`/`CheckDomainAvailabilityResult`. Follows the existing `CardDef`/`FieldDef` + `contains`/`containsMany` conventions.
- **`packages/host/app/lib/published-realm-url.ts`** (new) — pure `resolvePublishedRealmUrl(target, ctx)` + `deriveRealmName(url)`. Subdirectory targets resolve to `https://<user>.<spaceDomain>/<realmName>/`; custom targets to `https://<hostname>/` (tolerates a leading protocol / trailing slash, preserves ports).
- **`publish-realm-modal.gts`** — `subdirectoryRealmUrl`, `buildPublishedRealmUrl`, and `getRealmName` now delegate to the helper, so the modal and the commands build published-realm URLs from one source of truth.
- **`published-realm-url-test.ts`** (new) — unit coverage for both target types, name derivation, protocol/port handling, and the error paths.

## Validation
- ESLint clean on changed files (prettier autofix applied).
- `ember-tsc --noEmit`: no type errors attributable to these changes (remaining errors in a fresh worktree are unbuilt `@cardstack/boxel-ui` / `boxel-icons` declarations, identical on `main`).
- Unit test runs in CI (host test harness doesn't run standalone locally); assertions traced by hand against the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)