### PR TITLE
Add PublishRealmCommand host command

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -625,6 +625,10 @@ export class PublishTarget extends FieldDef {
 export class PublishRealmInput extends CardDef {
   @field realmURL = contains(StringField);
   @field targets = containsMany(PublishTarget);
+  // Pre-resolved published-realm URLs. The publish UI builds these with live
+  // Matrix state, so it passes them directly instead of typed targets; they are
+  // merged with any resolved 'targets'. Provide at least one of the two.
+  @field publishedRealmURLs = containsMany(StringField);
   // Bypass the pre-publish publishability gate (private-dependency and
   // error-document violations). Defaults to false.
   @field force = contains(BooleanField);

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -62,6 +62,7 @@ import * as PatchThemeCommandModule from './patch-theme';
 import * as PersistModuleInspectorViewCommandModule from './persist-module-inspector-view';
 import * as PopulateWithSampleDataCommandModule from './populate-with-sample-data';
 import * as PreviewFormatCommandModule from './preview-format';
+import * as PublishRealmCommandModule from './publish-realm';
 import * as ReadBinaryFileCommandModule from './read-binary-file';
 import * as ReadCardForAiAssistantCommandModule from './read-card-for-ai-assistant';
 import * as ReadFileForAiAssistantCommandModule from './read-file-for-ai-assistant';
@@ -263,6 +264,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/preview-format',
     PreviewFormatCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/publish-realm',
+    PublishRealmCommandModule,
   );
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/read-binary-file',
@@ -549,6 +554,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   PersistModuleInspectorViewCommandModule.default,
   PopulateWithSampleDataCommandModule.default,
   PreviewFormatCommandModule.default,
+  PublishRealmCommandModule.default,
   ReadBinaryFileCommandModule.default,
   ReadCardForAiAssistantCommandModule.default,
   ReadFileForAiAssistantCommandModule.default,

--- a/packages/host/app/commands/publish-realm.ts
+++ b/packages/host/app/commands/publish-realm.ts
@@ -1,0 +1,130 @@
+import { service } from '@ember/service';
+
+import { getMatrixUsername } from '@cardstack/runtime-common/matrix-client';
+
+import config from '@cardstack/host/config/environment';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+import {
+  resolvePublishedRealmUrl,
+  type PublishTargetType,
+} from '../lib/published-realm-url';
+
+import type RealmService from '../services/realm';
+import type { PublishabilityViolation } from '../services/realm';
+
+// Publishes a realm to one or more destinations (subdirectory Boxel Spaces or
+// custom domains). The command resolves once the realm-server accepts each
+// publish request; the published-realm reindex then runs in the background.
+// There is no completion-wait in v1 — see CS-11453 for why (no reindex-done
+// signal is observable from the run-command context).
+export default class PublishRealmCommand extends HostBaseCommand<
+  typeof BaseCommandModule.PublishRealmInput,
+  typeof BaseCommandModule.PublishRealmResult
+> {
+  @service declare private realm: RealmService;
+
+  static actionVerb = 'Publish';
+  description = 'Publish a realm to one or more destinations';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    return commandModule.PublishRealmInput;
+  }
+
+  requireInputFields = ['realmURL', 'targets'];
+
+  protected async run(
+    input: BaseCommandModule.PublishRealmInput,
+  ): Promise<BaseCommandModule.PublishRealmResult> {
+    let commandModule = await this.loadCommandModule();
+    let { PublishRealmResult, PublishTargetResult } = commandModule;
+
+    let realmURL = input.realmURL;
+    let matrixUsername = this.matrixUsernameFor(realmURL);
+
+    let publishedRealmURLs = input.targets.map((target) =>
+      resolvePublishedRealmUrl(
+        { type: target.type as PublishTargetType, name: target.name },
+        {
+          sourceRealmURL: realmURL,
+          matrixUsername,
+          spaceDomain: config.publishedRealmBoxelSpaceDomain,
+        },
+      ),
+    );
+
+    // Pre-publish gate: refuse to publish a realm with private-dependency or
+    // error-document violations unless the caller explicitly forces it.
+    if (!input.force) {
+      let report = await this.realm.fetchPrivateDependencyReport(realmURL);
+      if (!report.publishable) {
+        throw new Error(describeViolations(report.violations));
+      }
+    }
+
+    let settled = await this.realm.publish(realmURL, publishedRealmURLs);
+
+    let results = publishedRealmURLs.map((publishedRealmURL, i) => {
+      let outcome = settled?.[i];
+      if (outcome?.status === 'fulfilled') {
+        return new PublishTargetResult({
+          publishedRealmURL,
+          status: 'published',
+        });
+      }
+      return new PublishTargetResult({
+        publishedRealmURL,
+        status: 'error',
+        error:
+          outcome?.status === 'rejected'
+            ? errorMessage(outcome.reason)
+            : 'Publish request did not complete',
+      });
+    });
+
+    return new PublishRealmResult({ results });
+  }
+
+  // The matrix username (used to form subdirectory Boxel Space URLs) is read
+  // from the realm session claims rather than MatrixService, since the matrix
+  // client is not started in the headless run-command context.
+  private matrixUsernameFor(realmURL: string): string | undefined {
+    let userId = this.realm.getOrCreateRealmResource(realmURL).claims?.user;
+    return userId ? getMatrixUsername(userId) : undefined;
+  }
+}
+
+function describeViolations(violations: PublishabilityViolation[]): string {
+  let privateCount = violations.filter(
+    (v) => v.kind === 'private-dependency',
+  ).length;
+  let errorCount = violations.filter((v) => v.kind === 'error-document').length;
+
+  let parts: string[] = [];
+  if (privateCount) {
+    parts.push(`${privateCount} private-dependency violation(s)`);
+  }
+  if (errorCount) {
+    parts.push(`${errorCount} error-document violation(s)`);
+  }
+  let summary = parts.length
+    ? parts.join(', ')
+    : `${violations.length} violation(s)`;
+
+  let resources = violations
+    .map((v) => v.resource)
+    .filter(Boolean)
+    .slice(0, 5)
+    .join(', ');
+
+  return `Realm is not publishable (${summary}). Resolve them or pass force=true to override.${
+    resources ? ` Affected: ${resources}` : ''
+  }`;
+}
+
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason);
+}

--- a/packages/host/app/commands/publish-realm.ts
+++ b/packages/host/app/commands/publish-realm.ts
@@ -1,5 +1,6 @@
 import { service } from '@ember/service';
 
+import { ensureTrailingSlash } from '@cardstack/runtime-common';
 import { getMatrixUsername } from '@cardstack/runtime-common/matrix-client';
 
 import config from '@cardstack/host/config/environment';
@@ -42,7 +43,10 @@ export default class PublishRealmCommand extends HostBaseCommand<
     let commandModule = await this.loadCommandModule();
     let { PublishRealmResult, PublishTargetResult } = commandModule;
 
-    let realmURL = input.realmURL;
+    // Normalize so endpoint URLs like `${realmURL}_publishability` are well
+    // formed and the cached RealmResource (token/claims) is found even when the
+    // caller omits the trailing slash.
+    let realmURL = ensureTrailingSlash(input.realmURL);
     let matrixUsername = this.matrixUsernameFor(realmURL);
 
     let publishedRealmURLs = input.targets.map((target) =>

--- a/packages/host/app/commands/publish-realm.ts
+++ b/packages/host/app/commands/publish-realm.ts
@@ -18,9 +18,10 @@ import type { PublishabilityViolation } from '../services/realm';
 
 // Publishes a realm to one or more destinations (subdirectory Boxel Spaces or
 // custom domains). The command resolves once the realm-server accepts each
-// publish request; the published-realm reindex then runs in the background.
-// There is no completion-wait in v1 — see CS-11453 for why (no reindex-done
-// signal is observable from the run-command context).
+// publish request and reports per-target status. Indexed-and-viewable
+// readiness is not awaited here: realm `index` events aren't delivered to the
+// run-command/prerender context, so a caller that needs the published realm
+// ready polls its `_readiness-check` over HTTP instead.
 export default class PublishRealmCommand extends HostBaseCommand<
   typeof BaseCommandModule.PublishRealmInput,
   typeof BaseCommandModule.PublishRealmResult

--- a/packages/host/app/commands/publish-realm.ts
+++ b/packages/host/app/commands/publish-realm.ts
@@ -35,7 +35,7 @@ export default class PublishRealmCommand extends HostBaseCommand<
     return commandModule.PublishRealmInput;
   }
 
-  requireInputFields = ['realmURL', 'targets'];
+  requireInputFields = ['realmURL'];
 
   protected async run(
     input: BaseCommandModule.PublishRealmInput,
@@ -49,7 +49,10 @@ export default class PublishRealmCommand extends HostBaseCommand<
     let realmURL = ensureTrailingSlash(input.realmURL);
     let matrixUsername = this.matrixUsernameFor(realmURL);
 
-    let publishedRealmURLs = input.targets.map((target) =>
+    // Targets are resolved to published-realm URLs; callers that already hold
+    // resolved URLs (e.g. the publish UI) pass them via `publishedRealmURLs`.
+    // Merge both, de-duplicated, preserving order.
+    let resolvedFromTargets = (input.targets ?? []).map((target) =>
       resolvePublishedRealmUrl(
         { type: target.type as PublishTargetType, name: target.name },
         {
@@ -59,6 +62,14 @@ export default class PublishRealmCommand extends HostBaseCommand<
         },
       ),
     );
+    let publishedRealmURLs = [
+      ...new Set([...resolvedFromTargets, ...(input.publishedRealmURLs ?? [])]),
+    ];
+    if (publishedRealmURLs.length === 0) {
+      throw new Error(
+        'Provide at least one entry in `targets` or `publishedRealmURLs`',
+      );
+    }
 
     // Pre-publish gate: refuse to publish a realm with private-dependency or
     // error-document violations unless the caller explicitly forces it.

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -15,10 +15,12 @@ import perform from 'ember-concurrency/helpers/perform';
 import { BoxelButton, Tooltip } from '@cardstack/boxel-ui/components';
 import { PublishSiteIcon } from '@cardstack/boxel-ui/icons';
 
+import PublishRealmCommand from '@cardstack/host/commands/publish-realm';
 import OpenSitePopover from '@cardstack/host/components/operator-mode/host-submode/open-site-popover';
 import PublishingRealmPopover from '@cardstack/host/components/operator-mode/host-submode/publishing-realm-popover';
 import PublishRealmModal from '@cardstack/host/components/operator-mode/publish-realm-modal';
 
+import type CommandService from '@cardstack/host/services/command-service';
 import type HostModeService from '@cardstack/host/services/host-mode-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
@@ -44,6 +46,7 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
   @service declare private store: StoreService;
   @service declare private realm: RealmService;
   @service declare private hostModeService: HostModeService;
+  @service declare private commandService: CommandService;
 
   @tracked isPublishRealmModalOpen = false;
   @tracked isPublishingRealmPopoverOpen = false;
@@ -94,19 +97,24 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
   }
 
   handlePublishTask = restartableTask(async (publishedRealmURLs: string[]) => {
-    const results = await this.realm.publish(this.realmURL, publishedRealmURLs);
+    // Publish through the same command exposed to boxel-cli so the UI and
+    // headless callers share one path. The modal already enforces the
+    // publishability gate, so force past the command's redundant re-check.
+    let command = new PublishRealmCommand(this.commandService.commandContext);
+    let result = await command.execute({
+      realmURL: this.realmURL,
+      publishedRealmURLs,
+      force: true,
+    });
 
     const errors = new Map<string, string>();
-    if (results) {
-      results.forEach((result, index) => {
-        if (result.status === 'rejected') {
-          const url = publishedRealmURLs[index];
-          const error = result as PromiseRejectedResult;
-          const errorMessage =
-            error.reason?.message || 'Failed to publish to this domain';
-          errors.set(url, errorMessage);
-        }
-      });
+    for (let target of result.results) {
+      if (target.status === 'error') {
+        errors.set(
+          target.publishedRealmURL,
+          target.error || 'Failed to publish to this domain',
+        );
+      }
     }
 
     if (errors.size > 0) {

--- a/packages/host/tests/integration/commands/publish-realm-test.gts
+++ b/packages/host/tests/integration/commands/publish-realm-test.gts
@@ -150,6 +150,42 @@ module('Integration | commands | publish-realm', function (hooks) {
     assert.strictEqual(result.results[0].status, 'published');
   });
 
+  test('publishes pre-resolved publishedRealmURLs (the publish UI path)', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+
+    let result = await makeCommand().execute({
+      realmURL,
+      publishedRealmURLs: [
+        'https://mysite.example.com/',
+        'https://other.example.com/',
+      ],
+    });
+
+    assert.deepEqual(publishedURLs, [
+      'https://mysite.example.com/',
+      'https://other.example.com/',
+    ]);
+    assert.deepEqual(
+      result.results.map((r) => [r.publishedRealmURL, r.status]),
+      [
+        ['https://mysite.example.com/', 'published'],
+        ['https://other.example.com/', 'published'],
+      ],
+    );
+  });
+
+  test('throws when neither targets nor publishedRealmURLs are provided', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+
+    await assert.rejects(
+      makeCommand().execute({ realmURL }),
+      /at least one entry in `targets` or `publishedRealmURLs`/,
+    );
+    assert.deepEqual(publishedURLs, [], 'did not call the publish endpoint');
+  });
+
   test('derives a subdirectory URL from the realm session username', async function (assert) {
     let realmServer = getService('realm-server');
     let realmURL = new URL('test/', realmServer.url).href;

--- a/packages/host/tests/integration/commands/publish-realm-test.gts
+++ b/packages/host/tests/integration/commands/publish-realm-test.gts
@@ -4,8 +4,12 @@ import type { RenderingTestContext } from '@ember/test-helpers';
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
+import { baseRealm, type Loader } from '@cardstack/runtime-common';
+
 import PublishRealmCommand from '@cardstack/host/commands/publish-realm';
 import RealmService from '@cardstack/host/services/realm';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import {
   setupIntegrationTestRealm,
@@ -37,6 +41,8 @@ let publishabilityResponse: {
 let publishShouldFail: boolean;
 let publishabilityRequested: boolean;
 let publishedURLs: string[];
+let loader: Loader;
+let PublishTarget: typeof BaseCommandModule.PublishTarget;
 
 module('Integration | commands | publish-realm', function (hooks) {
   setupRenderingTest(hooks);
@@ -97,6 +103,10 @@ module('Integration | commands | publish-realm', function (hooks) {
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
     getOwner(this)!.register('service:realm', StubRealmService);
+    loader = getService('loader-service').loader;
+    PublishTarget = (
+      await loader.import<typeof BaseCommandModule>(`${baseRealm.url}command`)
+    ).PublishTarget;
     publishabilityResponse = { publishable: true, violations: [] };
     publishShouldFail = false;
     publishabilityRequested = false;
@@ -122,7 +132,9 @@ module('Integration | commands | publish-realm', function (hooks) {
 
     let result = await makeCommand().execute({
       realmURL,
-      targets: [{ type: 'custom', name: 'mysite.example.com' }] as any,
+      targets: [
+        new PublishTarget({ type: 'custom', name: 'mysite.example.com' }),
+      ],
     });
 
     assert.deepEqual(
@@ -144,7 +156,7 @@ module('Integration | commands | publish-realm', function (hooks) {
 
     let result = await makeCommand().execute({
       realmURL,
-      targets: [{ type: 'subdirectory', name: 'my-space' }] as any,
+      targets: [new PublishTarget({ type: 'subdirectory', name: 'my-space' })],
     });
 
     assert.strictEqual(publishedURLs.length, 1);
@@ -173,7 +185,9 @@ module('Integration | commands | publish-realm', function (hooks) {
     await assert.rejects(
       makeCommand().execute({
         realmURL,
-        targets: [{ type: 'custom', name: 'mysite.example.com' }] as any,
+        targets: [
+          new PublishTarget({ type: 'custom', name: 'mysite.example.com' }),
+        ],
       }),
       /not publishable/,
       'rejects with a publishability error',
@@ -188,7 +202,9 @@ module('Integration | commands | publish-realm', function (hooks) {
 
     let result = await makeCommand().execute({
       realmURL,
-      targets: [{ type: 'custom', name: 'mysite.example.com' }] as any,
+      targets: [
+        new PublishTarget({ type: 'custom', name: 'mysite.example.com' }),
+      ],
       force: true,
     });
 
@@ -207,7 +223,9 @@ module('Integration | commands | publish-realm', function (hooks) {
 
     let result = await makeCommand().execute({
       realmURL,
-      targets: [{ type: 'custom', name: 'mysite.example.com' }] as any,
+      targets: [
+        new PublishTarget({ type: 'custom', name: 'mysite.example.com' }),
+      ],
     });
 
     assert.strictEqual(result.results[0].status, 'error');

--- a/packages/host/tests/integration/commands/publish-realm-test.gts
+++ b/packages/host/tests/integration/commands/publish-realm-test.gts
@@ -1,0 +1,219 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import PublishRealmCommand from '@cardstack/host/commands/publish-realm';
+import RealmService from '@cardstack/host/services/realm';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmServerEndpoints,
+  testRealmInfo,
+  testRealmURL,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+}
+
+// Mutable per-test fixtures controlling the mocked realm-server responses.
+let publishabilityResponse: {
+  publishable: boolean;
+  violations: unknown[];
+};
+let publishShouldFail: boolean;
+let publishabilityRequested: boolean;
+let publishedURLs: string[];
+
+module('Integration | commands | publish-realm', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  setupRealmServerEndpoints(hooks, [
+    {
+      route: 'test/_publishability',
+      getResponse: async (req: Request) => {
+        publishabilityRequested = true;
+        return new Response(
+          JSON.stringify({
+            data: {
+              type: 'realm-publishability',
+              attributes: {
+                publishable: publishabilityResponse.publishable,
+                realmURL: new URL(req.url).origin + '/test/',
+                violations: publishabilityResponse.violations,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      },
+    },
+    {
+      route: '_publish-realm',
+      getResponse: async (req: Request) => {
+        let body = (await req.json()) as { publishedRealmURL: string };
+        publishedURLs.push(body.publishedRealmURL);
+        if (publishShouldFail) {
+          return new Response('boom', { status: 500 });
+        }
+        return new Response(
+          JSON.stringify({
+            data: {
+              type: 'published-realm',
+              attributes: {
+                publishedRealmURL: body.publishedRealmURL,
+                lastPublishedAt: '1700000000000',
+              },
+            },
+          }),
+          { status: 202 },
+        );
+      },
+    },
+  ]);
+
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    publishabilityResponse = { publishable: true, violations: [] };
+    publishShouldFail = false;
+    publishabilityRequested = false;
+    publishedURLs = [];
+
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {},
+      }),
+    );
+  });
+
+  function makeCommand() {
+    let commandService = getService('command-service');
+    return new PublishRealmCommand(commandService.commandContext);
+  }
+
+  test('publishes a custom-domain target and reports it published', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+
+    let result = await makeCommand().execute({
+      realmURL,
+      targets: [{ type: 'custom', name: 'mysite.example.com' }] as any,
+    });
+
+    assert.deepEqual(
+      publishedURLs,
+      ['https://mysite.example.com/'],
+      'realm-server received the resolved custom published-realm URL',
+    );
+    assert.strictEqual(result.results.length, 1);
+    assert.strictEqual(
+      result.results[0].publishedRealmURL,
+      'https://mysite.example.com/',
+    );
+    assert.strictEqual(result.results[0].status, 'published');
+  });
+
+  test('derives a subdirectory URL from the realm session username', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+
+    let result = await makeCommand().execute({
+      realmURL,
+      targets: [{ type: 'subdirectory', name: 'my-space' }] as any,
+    });
+
+    assert.strictEqual(publishedURLs.length, 1);
+    assert.ok(
+      /^https:\/\/testuser\..+\/my-space\/$/.test(publishedURLs[0]),
+      `subdirectory URL "${publishedURLs[0]}" uses the testuser subdomain and my-space path`,
+    );
+    assert.strictEqual(result.results[0].status, 'published');
+  });
+
+  test('blocks publishing when the realm is not publishable', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+    publishabilityResponse = {
+      publishable: false,
+      violations: [
+        {
+          kind: 'private-dependency',
+          resource: `${realmURL}card`,
+          externalDependencies: [],
+        },
+        { kind: 'error-document', resource: `${realmURL}broken` },
+      ],
+    };
+
+    await assert.rejects(
+      makeCommand().execute({
+        realmURL,
+        targets: [{ type: 'custom', name: 'mysite.example.com' }] as any,
+      }),
+      /not publishable/,
+      'rejects with a publishability error',
+    );
+    assert.deepEqual(publishedURLs, [], 'did not call the publish endpoint');
+  });
+
+  test('force bypasses the publishability gate', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+    publishabilityResponse = { publishable: false, violations: [] };
+
+    let result = await makeCommand().execute({
+      realmURL,
+      targets: [{ type: 'custom', name: 'mysite.example.com' }] as any,
+      force: true,
+    });
+
+    assert.false(
+      publishabilityRequested,
+      'force skips the publishability check',
+    );
+    assert.deepEqual(publishedURLs, ['https://mysite.example.com/']);
+    assert.strictEqual(result.results[0].status, 'published');
+  });
+
+  test('reports an error when the publish request fails', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+    publishShouldFail = true;
+
+    let result = await makeCommand().execute({
+      realmURL,
+      targets: [{ type: 'custom', name: 'mysite.example.com' }] as any,
+    });
+
+    assert.strictEqual(result.results[0].status, 'error');
+    assert.ok(
+      result.results[0].error,
+      'includes an error message for the failed target',
+    );
+  });
+});


### PR DESCRIPTION
Adds the `publish-realm` host command (specifier `@cardstack/boxel-host/commands/publish-realm/default`) and **routes the publish UI through it**, so the operator-mode publish flow and boxel-cli share one publish path.

**Stacked on #5161** (base command types + URL helper) — its base is the CS-11452 branch, so the diff here is the command, its registration, the UI wiring, and tests.

## What it does
- `PublishRealmCommand`: resolves typed `targets` (`{ type, name }`) to published-realm URLs via the shared helper (subdirectory username from the realm **session claims**, since the matrix client isn't started in the headless run-command context), and also accepts pre-resolved `publishedRealmURLs`. Enforces the publishability gate (`_publishability`) unless `force: true`, then `await realm.publish(...)` and maps per-URL results to `{ publishedRealmURL, status: 'published' | 'error', error? }`.
- Normalizes `realmURL` with `ensureTrailingSlash` so endpoint URLs and the cached `RealmResource` lookup are correct.
- Registered in `commands/index.ts` (import, shim, `HostCommandClasses`).

## UI now uses the command
`host-submode.gts`'s `handlePublishTask` executes `PublishRealmCommand` instead of calling `realm.publish` directly, passing the modal's already-resolved `publishedRealmURLs` and `force: true` (the modal already enforces the publishability gate). The command calls `realm.publish` on the same `RealmService` singleton, so the UI's reactive "Publishing…" state and `lastPublishedAt` are unchanged. This is the only place in the host that publishes.

## v1 scope note — no wait
A spike (CS-11453) confirmed the run-command/prerender context receives no realm index events and there's no realm-served "indexing done" signal, so v1 resolves once the publish request is accepted (202; reindex runs in the background). `wait`/`timeoutMs`/`timedOut` were dropped from the types in #5161.

## Tests
`tests/integration/commands/publish-realm-test.gts` — custom target, subdirectory derivation, pre-resolved `publishedRealmURLs`, missing-input guard, gate-block, force-bypass, publish-failure. The existing `host-submode-test.gts` publish acceptance test continues to exercise the flow end-to-end through the command.

Lint + `ember-tsc` clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)