### PR TITLE
Add UnpublishRealmCommand host command

### DIFF
--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -89,6 +89,7 @@ import * as SummarizeSessionCommandModule from './summarize-session';
 import * as SwitchSubmodeCommandModule from './switch-submode';
 import * as SyncOpenRouterModelsCommandModule from './sync-openrouter-models';
 import * as TransformCardsCommandModule from './transform-cards';
+import * as UnpublishRealmCommandModule from './unpublish-realm';
 import * as UnregisterBotCommandModule from './unregister-bot';
 import * as UpdateCodePathWithSelectionCommandModule from './update-code-path-with-selection';
 import * as UpdatePlaygroundSelectionCommandModule from './update-playground-selection';
@@ -366,6 +367,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
     TransformCardsCommandModule,
   );
   virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/unpublish-realm',
+    UnpublishRealmCommandModule,
+  );
+  virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/unregister-bot',
     UnregisterBotCommandModule,
   );
@@ -581,6 +586,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   SwitchSubmodeCommandModule.default,
   SyncOpenRouterModelsCommandModule.default,
   TransformCardsCommandModule.default,
+  UnpublishRealmCommandModule.default,
   UnregisterBotCommandModule.default,
   CancelIndexingJobCommandModule.default,
   CheckCorrectnessCommandModule.default,

--- a/packages/host/app/commands/unpublish-realm.ts
+++ b/packages/host/app/commands/unpublish-realm.ts
@@ -1,0 +1,89 @@
+import { service } from '@ember/service';
+
+import { getMatrixUsername } from '@cardstack/runtime-common/matrix-client';
+
+import config from '@cardstack/host/config/environment';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+import {
+  resolvePublishedRealmUrl,
+  type PublishTargetType,
+} from '../lib/published-realm-url';
+
+import type RealmService from '../services/realm';
+import type RealmServerService from '../services/realm-server';
+
+// Unpublishes a realm from a single published destination. Resolves once the
+// realm-server accepts the request; there is no reindex on unpublish (the
+// published realm is removed), so v1 has no completion-wait.
+export default class UnpublishRealmCommand extends HostBaseCommand<
+  typeof BaseCommandModule.UnpublishRealmInput,
+  typeof BaseCommandModule.UnpublishRealmResult
+> {
+  @service declare private realm: RealmService;
+  @service declare private realmServer: RealmServerService;
+
+  static actionVerb = 'Unpublish';
+  description = 'Unpublish a realm from a published destination';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    return commandModule.UnpublishRealmInput;
+  }
+
+  requireInputFields = ['realmURL'];
+
+  protected async run(
+    input: BaseCommandModule.UnpublishRealmInput,
+  ): Promise<BaseCommandModule.UnpublishRealmResult> {
+    let commandModule = await this.loadCommandModule();
+    let { UnpublishRealmResult } = commandModule;
+
+    let publishedRealmURL = this.resolvePublishedRealmURL(input);
+
+    // Call the realm server directly rather than RealmService.unpublish: the
+    // latter swallows errors (it only updates UI bookkeeping) and always
+    // resolves to undefined, so it can't report a failed unpublish.
+    try {
+      await this.realmServer.unpublishRealm(publishedRealmURL);
+      return new UnpublishRealmResult({
+        publishedRealmURL,
+        status: 'unpublished',
+      });
+    } catch (e) {
+      return new UnpublishRealmResult({
+        publishedRealmURL,
+        status: 'error',
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  private resolvePublishedRealmURL(
+    input: BaseCommandModule.UnpublishRealmInput,
+  ): string {
+    if (input.publishedRealmURL) {
+      return input.publishedRealmURL;
+    }
+    if (!input.target) {
+      throw new Error(
+        'Provide either a `target` or a `publishedRealmURL` to unpublish',
+      );
+    }
+    let userId = this.realm.getOrCreateRealmResource(input.realmURL).claims
+      ?.user;
+    return resolvePublishedRealmUrl(
+      {
+        type: input.target.type as PublishTargetType,
+        name: input.target.name,
+      },
+      {
+        sourceRealmURL: input.realmURL,
+        matrixUsername: userId ? getMatrixUsername(userId) : undefined,
+        spaceDomain: config.publishedRealmBoxelSpaceDomain,
+      },
+    );
+  }
+}

--- a/packages/host/app/commands/unpublish-realm.ts
+++ b/packages/host/app/commands/unpublish-realm.ts
@@ -68,7 +68,10 @@ export default class UnpublishRealmCommand extends HostBaseCommand<
     realmURL: string,
   ): string {
     if (input.publishedRealmURL) {
-      return input.publishedRealmURL;
+      // Normalize so the lookup keys (_unPublishingRealms,
+      // info.lastPublishedAt) match the trailing-slash URLs produced by
+      // resolvePublishedRealmUrl and stored on publish.
+      return ensureTrailingSlash(input.publishedRealmURL);
     }
     // `target` is a contains field, so it's an empty PublishTarget instance
     // (not undefined) when unset — check that it actually carries a type.

--- a/packages/host/app/commands/unpublish-realm.ts
+++ b/packages/host/app/commands/unpublish-realm.ts
@@ -1,5 +1,6 @@
 import { service } from '@ember/service';
 
+import { ensureTrailingSlash } from '@cardstack/runtime-common';
 import { getMatrixUsername } from '@cardstack/runtime-common/matrix-client';
 
 import config from '@cardstack/host/config/environment';
@@ -72,15 +73,17 @@ export default class UnpublishRealmCommand extends HostBaseCommand<
         'Provide either a `target` or a `publishedRealmURL` to unpublish',
       );
     }
-    let userId = this.realm.getOrCreateRealmResource(input.realmURL).claims
-      ?.user;
+    // Normalize so the cached RealmResource (token/claims) is found even when
+    // the caller omits the trailing slash.
+    let realmURL = ensureTrailingSlash(input.realmURL);
+    let userId = this.realm.getOrCreateRealmResource(realmURL).claims?.user;
     return resolvePublishedRealmUrl(
       {
         type: input.target.type as PublishTargetType,
         name: input.target.name,
       },
       {
-        sourceRealmURL: input.realmURL,
+        sourceRealmURL: realmURL,
         matrixUsername: userId ? getMatrixUsername(userId) : undefined,
         spaceDomain: config.publishedRealmBoxelSpaceDomain,
       },

--- a/packages/host/app/commands/unpublish-realm.ts
+++ b/packages/host/app/commands/unpublish-realm.ts
@@ -70,7 +70,9 @@ export default class UnpublishRealmCommand extends HostBaseCommand<
     if (input.publishedRealmURL) {
       return input.publishedRealmURL;
     }
-    if (!input.target) {
+    // `target` is a contains field, so it's an empty PublishTarget instance
+    // (not undefined) when unset — check that it actually carries a type.
+    if (!input.target?.type) {
       throw new Error(
         'Provide either a `target` or a `publishedRealmURL` to unpublish',
       );

--- a/packages/host/app/commands/unpublish-realm.ts
+++ b/packages/host/app/commands/unpublish-realm.ts
@@ -14,7 +14,6 @@ import {
 } from '../lib/published-realm-url';
 
 import type RealmService from '../services/realm';
-import type RealmServerService from '../services/realm-server';
 
 // Unpublishes a realm from a single published destination. Resolves once the
 // realm-server accepts the request; there is no reindex on unpublish (the
@@ -24,7 +23,6 @@ export default class UnpublishRealmCommand extends HostBaseCommand<
   typeof BaseCommandModule.UnpublishRealmResult
 > {
   @service declare private realm: RealmService;
-  @service declare private realmServer: RealmServerService;
 
   static actionVerb = 'Unpublish';
   description = 'Unpublish a realm from a published destination';
@@ -42,13 +40,16 @@ export default class UnpublishRealmCommand extends HostBaseCommand<
     let commandModule = await this.loadCommandModule();
     let { UnpublishRealmResult } = commandModule;
 
-    let publishedRealmURL = this.resolvePublishedRealmURL(input);
+    // Normalize so the cached RealmResource (token/claims, _unPublishingRealms
+    // tracking the UI observes) is the one the request acts on.
+    let realmURL = ensureTrailingSlash(input.realmURL);
+    let publishedRealmURL = this.resolvePublishedRealmURL(input, realmURL);
 
-    // Call the realm server directly rather than RealmService.unpublish: the
-    // latter swallows errors (it only updates UI bookkeeping) and always
-    // resolves to undefined, so it can't report a failed unpublish.
+    // Go through RealmService.unpublish so the UI's reactive unpublish state
+    // (_unPublishingRealms, info.lastPublishedAt) updates. It now propagates
+    // failures, which we map to an error result.
     try {
-      await this.realmServer.unpublishRealm(publishedRealmURL);
+      await this.realm.unpublish(realmURL, publishedRealmURL);
       return new UnpublishRealmResult({
         publishedRealmURL,
         status: 'unpublished',
@@ -64,6 +65,7 @@ export default class UnpublishRealmCommand extends HostBaseCommand<
 
   private resolvePublishedRealmURL(
     input: BaseCommandModule.UnpublishRealmInput,
+    realmURL: string,
   ): string {
     if (input.publishedRealmURL) {
       return input.publishedRealmURL;
@@ -73,9 +75,6 @@ export default class UnpublishRealmCommand extends HostBaseCommand<
         'Provide either a `target` or a `publishedRealmURL` to unpublish',
       );
     }
-    // Normalize so the cached RealmResource (token/claims) is found even when
-    // the caller omits the trailing slash.
-    let realmURL = ensureTrailingSlash(input.realmURL);
     let userId = this.realm.getOrCreateRealmResource(realmURL).claims?.user;
     return resolvePublishedRealmUrl(
       {

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -16,6 +16,7 @@ import { BoxelButton, Tooltip } from '@cardstack/boxel-ui/components';
 import { PublishSiteIcon } from '@cardstack/boxel-ui/icons';
 
 import PublishRealmCommand from '@cardstack/host/commands/publish-realm';
+import UnpublishRealmCommand from '@cardstack/host/commands/unpublish-realm';
 import OpenSitePopover from '@cardstack/host/components/operator-mode/host-submode/open-site-popover';
 import PublishingRealmPopover from '@cardstack/host/components/operator-mode/host-submode/publishing-realm-popover';
 import PublishRealmModal from '@cardstack/host/components/operator-mode/publish-realm-modal';
@@ -143,7 +144,10 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
   }
 
   handleUnpublish = restartableTask(async (publishedRealmURL: string) => {
-    await this.realm.unpublish(this.realmURL, publishedRealmURL);
+    // Unpublish through the same command exposed to boxel-cli so the UI and
+    // headless callers share one path.
+    let command = new UnpublishRealmCommand(this.commandService.commandContext);
+    await command.execute({ realmURL: this.realmURL, publishedRealmURL });
   });
 
   get defaultPublishedSiteURL(): string | undefined {

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -692,6 +692,11 @@ class RealmResource {
           ...this.info,
         };
       }
+    } catch (error) {
+      // Log for observability, then propagate so callers (e.g.
+      // UnpublishRealmCommand) can report the failure.
+      console.error(`Error unpublishing from URL ${url}:`, error);
+      throw error;
     } finally {
       this._unPublishingRealms.splice(this._unPublishingRealms.indexOf(url), 1);
     }

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -692,9 +692,6 @@ class RealmResource {
           ...this.info,
         };
       }
-    } catch (error) {
-      console.error(`Error unpublishing from URL ${url}:`, error);
-      return;
     } finally {
       this._unPublishingRealms.splice(this._unPublishingRealms.indexOf(url), 1);
     }

--- a/packages/host/tests/integration/commands/unpublish-realm-test.gts
+++ b/packages/host/tests/integration/commands/unpublish-realm-test.gts
@@ -4,8 +4,12 @@ import type { RenderingTestContext } from '@ember/test-helpers';
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
+import { baseRealm, type Loader } from '@cardstack/runtime-common';
+
 import UnpublishRealmCommand from '@cardstack/host/commands/unpublish-realm';
 import RealmService from '@cardstack/host/services/realm';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import {
   setupIntegrationTestRealm,
@@ -31,6 +35,8 @@ class StubRealmService extends RealmService {
 
 let unpublishShouldFail: boolean;
 let unpublishedURLs: string[];
+let loader: Loader;
+let PublishTarget: typeof BaseCommandModule.PublishTarget;
 
 module('Integration | commands | unpublish-realm', function (hooks) {
   setupRenderingTest(hooks);
@@ -69,6 +75,10 @@ module('Integration | commands | unpublish-realm', function (hooks) {
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
     getOwner(this)!.register('service:realm', StubRealmService);
+    loader = getService('loader-service').loader;
+    PublishTarget = (
+      await loader.import<typeof BaseCommandModule>(`${baseRealm.url}command`)
+    ).PublishTarget;
     unpublishShouldFail = false;
     unpublishedURLs = [];
 
@@ -106,7 +116,7 @@ module('Integration | commands | unpublish-realm', function (hooks) {
 
     let result = await makeCommand().execute({
       realmURL,
-      target: { type: 'subdirectory', name: 'my-space' } as any,
+      target: new PublishTarget({ type: 'subdirectory', name: 'my-space' }),
     });
 
     assert.strictEqual(unpublishedURLs.length, 1);

--- a/packages/host/tests/integration/commands/unpublish-realm-test.gts
+++ b/packages/host/tests/integration/commands/unpublish-realm-test.gts
@@ -1,0 +1,148 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import UnpublishRealmCommand from '@cardstack/host/commands/unpublish-realm';
+import RealmService from '@cardstack/host/services/realm';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmServerEndpoints,
+  testRealmInfo,
+  testRealmURL,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+}
+
+let unpublishShouldFail: boolean;
+let unpublishedURLs: string[];
+
+module('Integration | commands | unpublish-realm', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  setupRealmServerEndpoints(hooks, [
+    {
+      route: '_unpublish-realm',
+      getResponse: async (req: Request) => {
+        let body = (await req.json()) as { publishedRealmURL: string };
+        unpublishedURLs.push(body.publishedRealmURL);
+        if (unpublishShouldFail) {
+          return new Response('boom', { status: 500 });
+        }
+        return new Response(
+          JSON.stringify({
+            data: {
+              type: 'published-realm',
+              attributes: { publishedRealmURL: body.publishedRealmURL },
+            },
+          }),
+          { status: 200 },
+        );
+      },
+    },
+  ]);
+
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    unpublishShouldFail = false;
+    unpublishedURLs = [];
+
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {},
+      }),
+    );
+  });
+
+  function makeCommand() {
+    let commandService = getService('command-service');
+    return new UnpublishRealmCommand(commandService.commandContext);
+  }
+
+  test('unpublishes an explicit published-realm URL', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+
+    let result = await makeCommand().execute({
+      realmURL,
+      publishedRealmURL: 'https://mysite.example.com/',
+    });
+
+    assert.deepEqual(unpublishedURLs, ['https://mysite.example.com/']);
+    assert.strictEqual(result.publishedRealmURL, 'https://mysite.example.com/');
+    assert.strictEqual(result.status, 'unpublished');
+  });
+
+  test('resolves a typed subdirectory target before unpublishing', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+
+    let result = await makeCommand().execute({
+      realmURL,
+      target: { type: 'subdirectory', name: 'my-space' } as any,
+    });
+
+    assert.strictEqual(unpublishedURLs.length, 1);
+    assert.ok(
+      /^https:\/\/testuser\..+\/my-space\/$/.test(unpublishedURLs[0]),
+      `resolved subdirectory URL "${unpublishedURLs[0]}"`,
+    );
+    assert.strictEqual(result.status, 'unpublished');
+  });
+
+  test('reports an error when the unpublish request fails', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+    unpublishShouldFail = true;
+
+    let result = await makeCommand().execute({
+      realmURL,
+      publishedRealmURL: 'https://mysite.example.com/',
+    });
+
+    assert.strictEqual(result.status, 'error');
+    assert.ok(result.error, 'includes an error message');
+  });
+
+  test('throws when neither target nor publishedRealmURL is provided', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+
+    await assert.rejects(
+      makeCommand().execute({ realmURL }),
+      /Provide either a `target` or a `publishedRealmURL`/,
+    );
+    assert.deepEqual(
+      unpublishedURLs,
+      [],
+      'did not call the unpublish endpoint',
+    );
+  });
+});


### PR DESCRIPTION
Adds the `unpublish-realm` host command (specifier `@cardstack/boxel-host/commands/unpublish-realm/default`) and **routes the unpublish UI through it**, so the operator-mode unpublish flow and boxel-cli share one path.

**Stacked on #5162** (publish command + UI wiring), which is stacked on #5161 (base types). Review/merge in that order; this PR's diff is just the unpublish delta.

## What it does
- `UnpublishRealmCommand`: accepts a typed `target` or an explicit `publishedRealmURL`, resolves via the shared helper (subdirectory username from session claims), and returns `{ publishedRealmURL, status: 'unpublished' | 'error', error? }`.
- Registered in `commands/index.ts` (import, shim, `HostCommandClasses`); `realmURL` normalized with `ensureTrailingSlash`.

## UI now uses the command
`host-submode.gts`'s `handleUnpublish` executes `UnpublishRealmCommand` instead of calling `realm.unpublish` directly. This is the only place in the host that unpublishes.

## Why the command calls `realm.unpublish` (not the realm server directly)
The unpublish UI depends on `RealmService`'s reactive state — `isUnpublishingRealm` / `isUnpublishingAnyRealms` (the `_unPublishingRealms` array) drive the modal's disabled/“unpublishing” states, and `info.lastPublishedAt` is cleared on success. So the command goes through `realm.unpublish` to preserve those side effects. `realm.unpublish` previously **swallowed** errors (returned `undefined`), which would have made the command unable to report failures — so this PR changes it to **propagate** errors (keeping the `_unPublishingRealms` cleanup in `finally`); the command maps a throw to `status: 'error'`. The only callers are the command and (now) the UI, which ignores unpublish errors today as before.

## Tests
`tests/integration/commands/unpublish-realm-test.gts` — explicit-URL unpublish, typed subdirectory resolution, failure → error status, missing-input guard. The existing `host-submode-test.gts` unpublish acceptance flow continues to exercise it end-to-end through the command.

Lint + `ember-tsc` clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)