### PR TITLE
fix: exempt catalog contents from no-erasable-decorator lint rule

### DIFF
--- a/packages/catalog/.eslintrc.cjs
+++ b/packages/catalog/.eslintrc.cjs
@@ -3,6 +3,14 @@
 module.exports = {
   overrides: [
     {
+      // contents/ .ts files are Boxel card/command modules that go through the
+      // realm compilation pipeline — decorators are valid here.
+      files: ['contents/**/*.ts'],
+      rules: {
+        'no-restricted-syntax': 'off',
+      },
+    },
+    {
       files: ['contents/**/*.gts'],
       parser: 'ember-eslint-parser',
       parserOptions: {
@@ -27,6 +35,10 @@ module.exports = {
         'plugin:prettier/recommended',
       ],
       rules: {
+        // .gts files always go through the Ember build pipeline, so decorators
+        // like @tracked and @action are valid here — the no-erasable-syntax
+        // restriction only applies to Node-native strip-types contexts.
+        'no-restricted-syntax': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-unused-vars': [
           'error',


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-11461/allow-decorators-in-catalog-gts-content-files

Lint failure at Pr: 
https://github.com/cardstack/boxel-catalog/actions/runs/27181574684/job/80241602204?pr=598
<img width="1630" height="712" alt="image" src="https://github.com/user-attachments/assets/57bd5777-34c5-46b8-b4b5-b7143d51ac16" />


Root cause: The root .eslintrc.js globally bans decorators via no-restricted-syntax to protect Node CLI scripts from --experimental-strip-types. But contents/ files (both .ts card/command modules and .gts Glimmer components) always go through the realm/Ember compilation pipeline — decorators like @tracked, @action, and @field are valid there.

Fix: Added two overrides in packages/catalog/.eslintrc.cjs to exempt contents/**/*.ts and contents/**/*.gts from the no-restricted-syntax decorator restriction. The .ts and .gts files need separate overrides because .gts requires ember-eslint-parser while .ts uses the default TypeScript parser.