### PR TITLE
fix: resolve realm image URLs as FileDef on cold load

### DIFF
--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -8,8 +8,11 @@ import { isTesting } from '@embroider/macros';
 import window from 'ember-window-mock';
 import stringify from 'safe-stable-stringify';
 
+import { isFileDefInstance } from '@cardstack/runtime-common/code-ref';
+
 import { Submodes } from '@cardstack/host/components/submode-switcher';
 import ENV from '@cardstack/host/config/environment';
+import type { StackItemType } from '@cardstack/host/lib/stack-item';
 
 import type BillingService from '@cardstack/host/services/billing-service';
 import type CardService from '@cardstack/host/services/card-service';
@@ -129,16 +132,17 @@ export default class Card extends Route {
 
     let pathOrCardPath = cardPath ?? params.path;
 
-    let cardUrl: string | undefined = pathOrCardPath
-      ? await this.getCardUrl(pathOrCardPath)
+    let resolvedItem = pathOrCardPath
+      ? await this.resolvePathToStackItem(pathOrCardPath)
       : undefined;
-    let stacks: { id: string; format: string }[][] = [];
-    if (cardUrl) {
+    let stacks: { id: string; format: string; type?: StackItemType }[][] = [];
+    if (resolvedItem) {
       stacks = [
         [
           {
-            id: cardUrl,
+            id: resolvedItem.id,
             format: 'isolated',
+            type: resolvedItem.type,
           },
         ],
       ];
@@ -217,7 +221,9 @@ export default class Card extends Route {
     await this.hostModeService.updateHeadTemplate(headCardId);
   }
 
-  private async getCardUrl(cardPath: string): Promise<string | undefined> {
+  private async resolvePathToStackItem(
+    cardPath: string,
+  ): Promise<{ id: string; type: StackItemType } | undefined> {
     let cardUrl;
     if (hostsOwnAssets) {
       // availableRealmIdentifiers is set in matrixService.start(), so we can use it here
@@ -249,18 +255,23 @@ export default class Card extends Route {
       cardUrl = new URL(cardPath, window.location.origin).href;
     }
 
-    // we only get a card to understand its canonical URL so it's ok to fetch
-    // a card that is detached from the store as we only care about it's ID.
-    let canonicalCardUrl: string | undefined;
-    // the peek takes advantage of the store cache so this should be quick
-    canonicalCardUrl = (await this.store.get(cardUrl))?.id;
-    if (!canonicalCardUrl) {
+    // we only get an instance to understand its canonical URL so it's ok to
+    // fetch one that is detached from the store as we only care about its id.
+    // For a URL pointing at a binary file (e.g. an image), the store's card
+    // path auto-reroutes to a file-meta load and returns a FileDef — so the
+    // resulting stack item lands on FileDef isolated rendering instead of
+    // failing to hydrate the URL as a CardDef.
+    let resolved = await this.store.get(cardUrl);
+    let canonicalUrl = resolved?.id;
+    if (!canonicalUrl) {
       // TODO: show a 404 page
       // https://linear.app/cardstack/issue/CS-7364/show-user-a-clear-message-when-they-try-to-access-a-realm-they-cannot
       alert(`Card not found: ${cardUrl}`);
+      return undefined;
     }
-    cardUrl = canonicalCardUrl;
-
-    return cardUrl;
+    return {
+      id: canonicalUrl,
+      type: isFileDefInstance(resolved) ? 'file' : 'card',
+    };
   }
 }

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -137,15 +137,19 @@ export default class Card extends Route {
       : undefined;
     let stacks: { id: string; format: string; type?: StackItemType }[][] = [];
     if (resolvedItem) {
-      stacks = [
-        [
-          {
-            id: resolvedItem.id,
-            format: 'isolated',
-            type: resolvedItem.type,
-          },
-        ],
-      ];
+      // Only carry `type` when the resolved instance is a file. The canonical
+      // serializer (OperatorModeStateService.rawStateWithSavedCardsOnly)
+      // omits `type` for cards, so emitting `type: 'card'` here would diverge
+      // from the canonical string and trip the equality guard on every
+      // subsequent model refresh.
+      let stackItem: { id: string; format: string; type?: StackItemType } = {
+        id: resolvedItem.id,
+        format: 'isolated',
+      };
+      if (resolvedItem.type === 'file') {
+        stackItem.type = 'file';
+      }
+      stacks = [[stackItem]];
     }
     let operatorModeStateObject = operatorModeState
       ? JSON.parse(operatorModeState)

--- a/packages/host/tests/acceptance/image-def/open-image-in-new-tab-test.gts
+++ b/packages/host/tests/acceptance/image-def/open-image-in-new-tab-test.gts
@@ -1,0 +1,80 @@
+import { visit, currentURL, waitFor } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import { Submodes } from '@cardstack/host/components/submode-switcher';
+
+import {
+  setupAcceptanceTestRealm,
+  setupAuthEndpoints,
+  setupLocalIndexing,
+  setupOnSave,
+  setupRealmCacheTeardown,
+  setupUserSubscription,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  testRealmURL,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupApplicationTest } from '../../helpers/setup';
+import { setupTestRealmServiceWorker } from '../../helpers/test-realm-service-worker';
+
+// 1x1 transparent PNG, base64 decoded.
+function makeRenderablePng(): Uint8Array {
+  let base64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+yF9kAAAAASUVORK5CYII=';
+  let binary = atob(base64);
+  let bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+module(
+  'Acceptance | image def | opening an image URL in a new tab',
+  function (hooks) {
+    setupApplicationTest(hooks);
+    setupLocalIndexing(hooks);
+    setupOnSave(hooks);
+    setupRealmCacheTeardown(hooks);
+    setupTestRealmServiceWorker(hooks);
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
+    });
+
+    hooks.beforeEach(async function () {
+      setupUserSubscription();
+      setupAuthEndpoints();
+      await withCachedRealmSetup(async () =>
+        setupAcceptanceTestRealm({
+          mockMatrixUtils,
+          contents: {
+            ...SYSTEM_CARD_FIXTURE_CONTENTS,
+            'open-in-tab.png': makeRenderablePng(),
+          },
+        }),
+      );
+    });
+
+    test('cold-loading a binary image URL hydrates the stack as a FileDef item', async function (assert) {
+      await visit('/test/open-in-tab.png');
+
+      let imageUrl = `${testRealmURL}open-in-tab.png`;
+
+      assert.operatorModeParametersMatch(currentURL(), {
+        stacks: [[{ id: imageUrl, format: 'isolated', type: 'file' }]],
+        submode: Submodes.Interact,
+      });
+
+      await waitFor(`img[src="${imageUrl}"]`);
+      assert
+        .dom(`img[src="${imageUrl}"]`)
+        .exists(
+          'the ImageDef isolated template renders the image at its realm URL',
+        );
+    });
+  },
+);


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-11048/open-image-in-new-tab-should-work-for-a-realm-resident-image

## Summary

When a user opens a realm-resident image URL in a new browser tab (via the
browser's "Open Image in New Tab" context menu), interact submode now renders
that image using the `ImageDef` (a `FileDef` subclass) **isolated** template,
instead of failing to load the URL as a card.

### Root cause

`packages/host/app/routes/index.gts` resolves the URL via `store.get(cardUrl)`.
For a binary file the store already auto-reroutes through file-meta and
returns a `FileDef` (`packages/host/app/services/store.ts:1915-1932`), but
the model hook was throwing that file-vs-card signal away — every cold-load
stack item was built without a `type` field, so `deserialize` defaulted it
to `'card'` and the downstream `CardResource` failed to hydrate.

### Change

- Renamed `getCardUrl` → `resolvePathToStackItem` and widened its return
  type to `{ id, type } | undefined`. `type` is `'file'` when
  `isFileDefInstance(resolved)` is true, `'card'` otherwise.
- Model hook propagates `type` into the serialized stack entry. The rest of
  the wiring (`SerializedItem.type?`, `StackItem` constructor, the FileDef
  / ImageDef isolated templates) was already in place.
- 404 alert behavior preserved.

## Test plan

- [x] `packages/host/tests/acceptance/image-def/open-image-in-new-tab-test.gts` — cold-loads a realm-resident PNG URL via the catch-all route, asserts the resulting `operatorModeState` has one `{type: 'file', format: 'isolated'}` stack item, and asserts the `<img>` renders at the realm URL.
- [x] Manual verification: drove a real browser at `https://localhost:4201/user/left-bat-92/undo-arrow.svg`. URL hydrated with `type: 'file'`, FileDef (SvgDef) isolated template rendered the SVG. Card-URL regression check (a regular Repro card) still hydrates as `type: 'card'`.