### PR TITLE
Add GetPublishedRealmsCommand host command

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -671,7 +671,6 @@ export class GetPublishedRealmsInput extends CardDef {
 export class PublishedRealmInfo extends FieldDef {
   @field publishedRealmURL = contains(StringField);
   @field lastPublishedAt = contains(StringField);
-  @field isPublishing = contains(BooleanField);
 }
 
 export class GetPublishedRealmsResult extends CardDef {

--- a/packages/host/app/commands/get-published-realms.ts
+++ b/packages/host/app/commands/get-published-realms.ts
@@ -42,14 +42,16 @@ export default class GetPublishedRealmsCommand extends HostBaseCommand<
 
     // For a source realm lastPublishedAt is a { publishedRealmURL: at } map; a
     // plain string (the realm is itself a published realm) or null means no
-    // publications to report.
+    // publications to report. A published destination is reported even if its
+    // timestamp is missing — coerce to a string so the result keeps the
+    // declared StringField contract rather than dropping a real publication.
     let results =
       lastPublishedAt && typeof lastPublishedAt === 'object'
         ? Object.entries(lastPublishedAt).map(
             ([publishedRealmURL, at]) =>
               new PublishedRealmInfo({
                 publishedRealmURL,
-                lastPublishedAt: at,
+                lastPublishedAt: at == null ? '' : String(at),
               }),
           )
         : [];

--- a/packages/host/app/commands/get-published-realms.ts
+++ b/packages/host/app/commands/get-published-realms.ts
@@ -1,0 +1,59 @@
+import { service } from '@ember/service';
+
+import { ensureTrailingSlash } from '@cardstack/runtime-common';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+
+import type RealmService from '../services/realm';
+
+// Lists a source realm's published destinations and when each was last
+// published. The data comes from the source realm's `_info` response, whose
+// `lastPublishedAt` is a { publishedRealmURL: lastPublishedAt } map populated
+// server-side from the realm_registry.
+export default class GetPublishedRealmsCommand extends HostBaseCommand<
+  typeof BaseCommandModule.GetPublishedRealmsInput,
+  typeof BaseCommandModule.GetPublishedRealmsResult
+> {
+  @service declare private realm: RealmService;
+
+  static actionVerb = 'Get Published Realms';
+  description =
+    "Get a source realm's published destinations and when each was last published";
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    return commandModule.GetPublishedRealmsInput;
+  }
+
+  requireInputFields = ['realmURL'];
+
+  protected async run(
+    input: BaseCommandModule.GetPublishedRealmsInput,
+  ): Promise<BaseCommandModule.GetPublishedRealmsResult> {
+    let commandModule = await this.loadCommandModule();
+    let { GetPublishedRealmsResult, PublishedRealmInfo } = commandModule;
+
+    let realmURL = ensureTrailingSlash(input.realmURL);
+    // Force a fresh _info fetch so lastPublishedAt reflects the registry.
+    await this.realm.ensureRealmMeta(realmURL);
+    let { lastPublishedAt } = this.realm.info(realmURL);
+
+    // For a source realm lastPublishedAt is a { publishedRealmURL: at } map; a
+    // plain string (the realm is itself a published realm) or null means no
+    // publications to report.
+    let results =
+      lastPublishedAt && typeof lastPublishedAt === 'object'
+        ? Object.entries(lastPublishedAt).map(
+            ([publishedRealmURL, at]) =>
+              new PublishedRealmInfo({
+                publishedRealmURL,
+                lastPublishedAt: at,
+              }),
+          )
+        : [];
+
+    return new GetPublishedRealmsResult({ results });
+  }
+}

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -36,6 +36,7 @@ import * as GetCardTypeSchemaCommandModule from './get-card-type-schema';
 import * as GetCatalogRealmIdentifiersCommandModule from './get-catalog-realm-identifiers';
 import * as GetDefaultWritableRealmCommandModule from './get-default-writable-realm';
 import * as GetEventsFromRoomCommandModule from './get-events-from-room';
+import * as GetPublishedRealmsCommandModule from './get-published-realms';
 import * as GetRealmOfResourceIdentifierCommandModule from './get-realm-of-resource-identifier';
 import * as GetUserSystemCardCommandModule from './get-user-system-card';
 import * as InstantiateCardCommandModule from './instantiate-card';
@@ -181,6 +182,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/get-events-from-room',
     GetEventsFromRoomCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/get-published-realms',
+    GetPublishedRealmsCommandModule,
   );
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/invite-user-to-room',
@@ -492,6 +497,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   GetCardTypeSchemaCommandModule.default,
   GetUserSystemCardCommandModule.default,
   GetEventsFromRoomCommandModule.default,
+  GetPublishedRealmsCommandModule.default,
   InviteUserToRoomCommandModule.default,
   InvalidateRealmIdentifiersCommandModule.default,
   LintAndFixCommandModule.default,

--- a/packages/host/tests/integration/commands/get-published-realms-test.gts
+++ b/packages/host/tests/integration/commands/get-published-realms-test.gts
@@ -1,0 +1,117 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import GetPublishedRealmsCommand from '@cardstack/host/commands/get-published-realms';
+import RealmService from '@cardstack/host/services/realm';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmServerEndpoints,
+  testRealmInfo,
+  testRealmURL,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+// The command reads RealmService.info(realmURL).lastPublishedAt; the stub lets
+// each test control that value. (The real value is sourced from realm_registry
+// via the realm's _info, which is empty in the integration harness.)
+let lastPublishedAtFixture: string | Record<string, string> | null;
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+
+  async ensureRealmMeta() {}
+
+  info = (_url: string) =>
+    ({
+      ...testRealmInfo,
+      isIndexing: false,
+      isPublic: false,
+      lastPublishedAt: lastPublishedAtFixture,
+    }) as ReturnType<RealmService['info']>;
+}
+
+module('Integration | commands | get-published-realms', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  setupRealmServerEndpoints(hooks);
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    lastPublishedAtFixture = null;
+
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {},
+      }),
+    );
+  });
+
+  function makeCommand() {
+    let commandService = getService('command-service');
+    return new GetPublishedRealmsCommand(commandService.commandContext);
+  }
+
+  test('returns each published destination from the lastPublishedAt map', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+    lastPublishedAtFixture = {
+      'https://mike.boxel.space/game-mechanics/': '1700000000000',
+      'https://mysite.boxel.site/': '1700000005000',
+    };
+
+    let result = await makeCommand().execute({ realmURL });
+
+    assert.deepEqual(
+      result.results.map((r) => [r.publishedRealmURL, r.lastPublishedAt]),
+      [
+        ['https://mike.boxel.space/game-mechanics/', '1700000000000'],
+        ['https://mysite.boxel.site/', '1700000005000'],
+      ],
+    );
+  });
+
+  test('returns an empty list when the realm has never been published', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+    lastPublishedAtFixture = null;
+
+    let result = await makeCommand().execute({ realmURL });
+
+    assert.strictEqual(result.results.length, 0);
+  });
+
+  test('returns an empty list when lastPublishedAt is a plain string', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+    lastPublishedAtFixture = '1700000000000';
+
+    let result = await makeCommand().execute({ realmURL });
+
+    assert.strictEqual(result.results.length, 0);
+  });
+});

--- a/packages/host/tests/integration/commands/get-published-realms-test.gts
+++ b/packages/host/tests/integration/commands/get-published-realms-test.gts
@@ -114,4 +114,19 @@ module('Integration | commands | get-published-realms', function (hooks) {
 
     assert.strictEqual(result.results.length, 0);
   });
+
+  test('keeps a published destination whose timestamp is missing, coerced to a string', async function (assert) {
+    let realmServer = getService('realm-server');
+    let realmURL = new URL('test/', realmServer.url).href;
+    lastPublishedAtFixture = {
+      'https://mysite.boxel.site/': null as unknown as string,
+    };
+
+    let result = await makeCommand().execute({ realmURL });
+
+    assert.deepEqual(
+      result.results.map((r) => [r.publishedRealmURL, r.lastPublishedAt]),
+      [['https://mysite.boxel.site/', '']],
+    );
+  });
 });

--- a/packages/host/tests/integration/commands/get-published-realms-test.gts
+++ b/packages/host/tests/integration/commands/get-published-realms-test.gts
@@ -1,11 +1,10 @@
-import { getOwner } from '@ember/owner';
 import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import GetPublishedRealmsCommand from '@cardstack/host/commands/get-published-realms';
-import RealmService from '@cardstack/host/services/realm';
+import type RealmService from '@cardstack/host/services/realm';
 
 import {
   setupIntegrationTestRealm,
@@ -20,29 +19,11 @@ import { setupBaseRealm } from '../../helpers/base-realm';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
 
-// The command reads RealmService.info(realmURL).lastPublishedAt; the stub lets
-// each test control that value. (The real value is sourced from realm_registry
-// via the realm's _info, which is empty in the integration harness.)
+// The command reads RealmService.info(realmURL).lastPublishedAt; each test
+// controls that value via lastPublishedAtFixture. The real value comes from
+// realm_registry via the realm's _info (empty in this harness), so beforeEach
+// patches the resolved service's info to serve the fixture directly.
 let lastPublishedAtFixture: string | Record<string, string> | null;
-
-class StubRealmService extends RealmService {
-  get defaultReadableRealm() {
-    return {
-      path: testRealmURL,
-      info: testRealmInfo,
-    };
-  }
-
-  async ensureRealmMeta() {}
-
-  info = (_url: string) =>
-    ({
-      ...testRealmInfo,
-      isIndexing: false,
-      isPublic: false,
-      lastPublishedAt: lastPublishedAtFixture,
-    }) as ReturnType<RealmService['info']>;
-}
 
 module('Integration | commands | get-published-realms', function (hooks) {
   setupRenderingTest(hooks);
@@ -59,7 +40,6 @@ module('Integration | commands | get-published-realms', function (hooks) {
   setupRealmCacheTeardown(hooks);
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
-    getOwner(this)!.register('service:realm', StubRealmService);
     lastPublishedAtFixture = null;
 
     await withCachedRealmSetup(async () =>
@@ -69,6 +49,17 @@ module('Integration | commands | get-published-realms', function (hooks) {
         contents: {},
       }),
     );
+
+    // Patch the resolved singleton the command uses: skip the _info fetch and
+    // serve the per-test lastPublishedAt fixture.
+    let realm = getService('realm') as RealmService;
+    realm.ensureRealmMeta = (async () => {}) as RealmService['ensureRealmMeta'];
+    realm.info = ((_url: string) => ({
+      ...testRealmInfo,
+      isIndexing: false,
+      isPublic: false,
+      lastPublishedAt: lastPublishedAtFixture,
+    })) as RealmService['info'];
   });
 
   function makeCommand() {


### PR DESCRIPTION
Adds the `get-published-realms` host command (specifier `@cardstack/boxel-host/commands/get-published-realms/default`).

**Stacked on #5161** (base command types + URL helper) — base is the CS-11452 branch, sibling of #5162. Diff here is the command, its registration, the `PublishedRealmInfo` type tweak, and tests.

## What it does
Given a source `realmURL`, returns each published destination and when it was last published: `results: { publishedRealmURL, lastPublishedAt }[]`.

- Reads `RealmService.info(realmURL).lastPublishedAt` after `ensureRealmMeta` (a fresh `_info` fetch). For a source realm that's a `{ publishedRealmURL: lastPublishedAt }` map, populated **server-side from `realm_registry.source_url`** (`querySourceRealmPublications`) — so no new endpoint was needed. A plain-string or `null` value (the realm isn't a source, or was never published) yields `[]`.
- `realmURL` normalized with `ensureTrailingSlash`; registered in `commands/index.ts`.

## Open question resolved (CS-11455)
- **Data source:** reuse `_info`'s `lastPublishedAt` map (vs. a new `_published-realms` endpoint) — the data already has an HTTP surface.
- **`isPublishing` dropped** from `PublishedRealmInfo`: it's transient client state (`_publishingRealms`) with no server persistence, so a headless command can't report it truthfully. Result is `{ publishedRealmURL, lastPublishedAt }`.

## Tests
`tests/integration/commands/get-published-realms-test.gts` — a `StubRealmService` controls `info().lastPublishedAt`: map → mapped results; `null` → `[]`; plain string → `[]`. (The real map comes from `realm_registry`, empty in the integration harness, so the stub is the seam.)

Lint + `ember-tsc` clean for the changed files (the `command.gts` pre-commit parse warning is the known single-file-lint artifact, clean under glob / on the base branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)