### PR TITLE
Add CheckDomainAvailabilityCommand host command

### DIFF
--- a/packages/host/app/commands/check-domain-availability.ts
+++ b/packages/host/app/commands/check-domain-availability.ts
@@ -43,18 +43,22 @@ export default class CheckDomainAvailabilityCommand extends HostBaseCommand<
       );
     }
 
-    // `name` is the subdomain (e.g. "my-site"); the result URL appends the
-    // configured custom-site base domain.
+    // `name` is the subdomain (e.g. "my-site"). The server returns the
+    // canonical hostname (built from its own custom-site base domain); use it
+    // so the published URL can't drift from the server's config, falling back
+    // to the client config only if it's somehow absent.
     let result = await this.realmServer.checkDomainAvailability(input.name);
+    let hostname =
+      result.hostname ||
+      `${input.name}.${config.publishedRealmBoxelSiteDomain}`;
     let publishedRealmURL = resolvePublishedRealmUrl({
       type: 'custom',
-      name: `${input.name}.${config.publishedRealmBoxelSiteDomain}`,
+      name: hostname,
     });
 
     return new CheckDomainAvailabilityResult({
       available: result.available,
       publishedRealmURL,
-      reason: result.error,
     });
   }
 }

--- a/packages/host/app/commands/check-domain-availability.ts
+++ b/packages/host/app/commands/check-domain-availability.ts
@@ -1,0 +1,60 @@
+import { service } from '@ember/service';
+
+import config from '@cardstack/host/config/environment';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+import { resolvePublishedRealmUrl } from '../lib/published-realm-url';
+
+import type RealmServerService from '../services/realm-server';
+
+// Checks whether a custom published-realm subdomain is available to claim, and
+// reports the published-realm URL it would map to. Only custom Boxel Site
+// subdomains have a server-side availability check; subdirectory Boxel Spaces
+// are namespaced to the owner and have no contention, so they are not checked
+// here.
+export default class CheckDomainAvailabilityCommand extends HostBaseCommand<
+  typeof BaseCommandModule.CheckDomainAvailabilityInput,
+  typeof BaseCommandModule.CheckDomainAvailabilityResult
+> {
+  @service declare private realmServer: RealmServerService;
+
+  static actionVerb = 'Check Availability';
+  description =
+    'Check whether a custom published-realm domain is available to claim';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    return commandModule.CheckDomainAvailabilityInput;
+  }
+
+  requireInputFields = ['type', 'name'];
+
+  protected async run(
+    input: BaseCommandModule.CheckDomainAvailabilityInput,
+  ): Promise<BaseCommandModule.CheckDomainAvailabilityResult> {
+    let commandModule = await this.loadCommandModule();
+    let { CheckDomainAvailabilityResult } = commandModule;
+
+    if (input.type !== 'custom') {
+      throw new Error(
+        `Availability checks apply to custom domains only; got type '${input.type}'`,
+      );
+    }
+
+    // `name` is the subdomain (e.g. "my-site"); the result URL appends the
+    // configured custom-site base domain.
+    let result = await this.realmServer.checkDomainAvailability(input.name);
+    let publishedRealmURL = resolvePublishedRealmUrl({
+      type: 'custom',
+      name: `${input.name}.${config.publishedRealmBoxelSiteDomain}`,
+    });
+
+    return new CheckDomainAvailabilityResult({
+      available: result.available,
+      publishedRealmURL,
+      reason: result.error,
+    });
+  }
+}

--- a/packages/host/app/commands/check-domain-availability.ts
+++ b/packages/host/app/commands/check-domain-availability.ts
@@ -59,6 +59,9 @@ export default class CheckDomainAvailabilityCommand extends HostBaseCommand<
     return new CheckDomainAvailabilityResult({
       available: result.available,
       publishedRealmURL,
+      // The server only returns an error for a rejected (e.g. invalid) name;
+      // pass it through as the reason, omitting it otherwise.
+      ...(result.error ? { reason: result.error } : {}),
     });
   }
 }

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -11,6 +11,7 @@ import * as SendBotTriggerEventCommandModule from './bot-requests/send-bot-trigg
 import * as CanReadRealmCommandModule from './can-read-realm';
 import * as CancelIndexingJobCommandModule from './cancel-indexing-job';
 import * as CheckCorrectnessCommandModule from './check-correctness';
+import * as CheckDomainAvailabilityCommandModule from './check-domain-availability';
 import * as CopyAndEditCommandModule from './copy-and-edit';
 import * as CopyCardToRealmModule from './copy-card';
 import * as CopyCardAsMarkdownCommandModule from './copy-card-as-markdown';
@@ -155,6 +156,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/check-correctness',
     CheckCorrectnessCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/check-domain-availability',
+    CheckDomainAvailabilityCommandModule,
   );
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/evaluate-module',
@@ -578,6 +583,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   UnregisterBotCommandModule.default,
   CancelIndexingJobCommandModule.default,
   CheckCorrectnessCommandModule.default,
+  CheckDomainAvailabilityCommandModule.default,
   EvaluateModuleCommandModule.default,
   InstantiateCardCommandModule.default,
   UpdateCodePathWithSelectionCommandModule.default,

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -27,6 +27,7 @@ import { IconX, Warning as WarningIcon } from '@cardstack/boxel-ui/icons';
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
 import { getPublishedRealmDomainOverrides } from '@cardstack/runtime-common/constants';
 
+import CheckDomainAvailabilityCommand from '@cardstack/host/commands/check-domain-availability';
 import ModalContainer from '@cardstack/host/components/modal-container';
 import PrivateDependencyViolationComponent from '@cardstack/host/components/operator-mode/private-dependency-violation';
 import WithLoadedRealm from '@cardstack/host/components/with-loaded-realm';
@@ -37,6 +38,7 @@ import {
   resolvePublishedRealmUrl,
 } from '@cardstack/host/lib/published-realm-url';
 
+import type CommandService from '@cardstack/host/services/command-service';
 import type HostModeService from '@cardstack/host/services/host-mode-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import type RealmService from '@cardstack/host/services/realm';
@@ -75,6 +77,7 @@ export default class PublishRealmModal extends Component<Signature> {
   @service declare private matrixService: MatrixService;
   @service declare private realm: RealmService;
   @service declare private realmServer: RealmServerService;
+  @service declare private commandService: CommandService;
 
   @tracked selectedPublishedRealmURLs: string[] = [];
   @tracked private customSubdomainSelection: CustomSubdomainSelection | null =
@@ -588,8 +591,17 @@ export default class PublishRealmModal extends Component<Signature> {
       this.clearCustomSubdomainFeedback();
 
       try {
-        let result = await this.realmServer.checkDomainAvailability(subdomain);
-        this.customSubdomainAvailability = result;
+        // Check availability through the same command exposed to boxel-cli so
+        // the UI and headless callers share one path.
+        let command = new CheckDomainAvailabilityCommand(
+          this.commandService.commandContext,
+        );
+        let result = await command.execute({ type: 'custom', name: subdomain });
+        this.customSubdomainAvailability = {
+          available: result.available,
+          domain: subdomain,
+          error: result.reason,
+        };
 
         if (result.available) {
           // Keep the full domain including port if present (e.g., "localhost:4201")
@@ -630,7 +642,7 @@ export default class PublishRealmModal extends Component<Signature> {
           }
         } else {
           this.customSubdomainError =
-            result.error ?? 'This name is already taken';
+            result.reason ?? 'This name is already taken';
           this.setCustomSubdomainSelection(null);
         }
       } catch (error) {

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -599,8 +599,7 @@ export default class PublishRealmModal extends Component<Signature> {
         let result = await command.execute({ type: 'custom', name: subdomain });
         this.customSubdomainAvailability = {
           available: result.available,
-          domain: subdomain,
-          error: result.reason,
+          hostname: `${subdomain}.${this.customSubdomainBase}`,
         };
 
         if (result.available) {

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -46,8 +46,7 @@ export interface RealmServerTokenClaims {
 
 export interface SubdomainAvailabilityResult {
   available: boolean;
-  domain: string;
-  error?: string;
+  hostname: string;
 }
 
 export interface ClaimedDomain {

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -47,6 +47,9 @@ export interface RealmServerTokenClaims {
 export interface SubdomainAvailabilityResult {
   available: boolean;
   hostname: string;
+  // Validation message when the subdomain is rejected (e.g. punycode); absent
+  // when the name is simply already taken.
+  error?: string;
 }
 
 export interface ClaimedDomain {

--- a/packages/host/tests/integration/commands/check-domain-availability-test.gts
+++ b/packages/host/tests/integration/commands/check-domain-availability-test.gts
@@ -30,7 +30,11 @@ class StubRealmService extends RealmService {
 }
 
 // Matches the realm-server /_check-boxel-domain-availability response shape.
-let availabilityResponse: { available: boolean; hostname: string };
+let availabilityResponse: {
+  available: boolean;
+  hostname: string;
+  error?: string;
+};
 let checkedSubdomains: string[];
 
 module('Integration | commands | check-domain-availability', function (hooks) {
@@ -102,6 +106,25 @@ module('Integration | commands | check-domain-availability', function (hooks) {
     let result = await makeCommand().execute({ type: 'custom', name: 'taken' });
 
     assert.false(result.available);
+  });
+
+  test('passes through the server validation error as the reason', async function (assert) {
+    availabilityResponse = {
+      available: false,
+      hostname: 'xn--bad.boxel.test',
+      error: 'Punycode domains are not allowed for security reasons',
+    };
+
+    let result = await makeCommand().execute({
+      type: 'custom',
+      name: 'xn--bad',
+    });
+
+    assert.false(result.available);
+    assert.strictEqual(
+      result.reason,
+      'Punycode domains are not allowed for security reasons',
+    );
   });
 
   test('rejects a non-custom target type', async function (assert) {

--- a/packages/host/tests/integration/commands/check-domain-availability-test.gts
+++ b/packages/host/tests/integration/commands/check-domain-availability-test.gts
@@ -1,0 +1,125 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import CheckDomainAvailabilityCommand from '@cardstack/host/commands/check-domain-availability';
+import RealmService from '@cardstack/host/services/realm';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmServerEndpoints,
+  testRealmInfo,
+  testRealmURL,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+}
+
+let availabilityResponse: {
+  available: boolean;
+  domain: string;
+  error?: string;
+};
+let checkedSubdomains: string[];
+
+module('Integration | commands | check-domain-availability', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  setupRealmServerEndpoints(hooks, [
+    {
+      route: '_check-boxel-domain-availability',
+      getResponse: async (req: Request) => {
+        checkedSubdomains.push(
+          new URL(req.url).searchParams.get('subdomain') ?? '',
+        );
+        return new Response(JSON.stringify(availabilityResponse), {
+          status: 200,
+        });
+      },
+    },
+  ]);
+
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    availabilityResponse = { available: true, domain: '' };
+    checkedSubdomains = [];
+
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {},
+      }),
+    );
+  });
+
+  function makeCommand() {
+    let commandService = getService('command-service');
+    return new CheckDomainAvailabilityCommand(commandService.commandContext);
+  }
+
+  test('reports an available custom subdomain with its published URL', async function (assert) {
+    availabilityResponse = { available: true, domain: 'my-site' };
+
+    let result = await makeCommand().execute({
+      type: 'custom',
+      name: 'my-site',
+    });
+
+    assert.deepEqual(checkedSubdomains, ['my-site'], 'checked the subdomain');
+    assert.true(result.available);
+    assert.ok(
+      /^https:\/\/my-site\..+\/$/.test(result.publishedRealmURL),
+      `publishedRealmURL "${result.publishedRealmURL}" is the my-site custom URL`,
+    );
+  });
+
+  test('reports an unavailable subdomain with the reason', async function (assert) {
+    availabilityResponse = {
+      available: false,
+      domain: 'taken',
+      error: 'This name is already taken',
+    };
+
+    let result = await makeCommand().execute({ type: 'custom', name: 'taken' });
+
+    assert.false(result.available);
+    assert.strictEqual(result.reason, 'This name is already taken');
+  });
+
+  test('rejects a non-custom target type', async function (assert) {
+    await assert.rejects(
+      makeCommand().execute({ type: 'subdirectory', name: 'my-space' }),
+      /custom domains only/,
+    );
+    assert.deepEqual(
+      checkedSubdomains,
+      [],
+      'did not hit the availability endpoint',
+    );
+  });
+});

--- a/packages/host/tests/integration/commands/check-domain-availability-test.gts
+++ b/packages/host/tests/integration/commands/check-domain-availability-test.gts
@@ -29,11 +29,8 @@ class StubRealmService extends RealmService {
   }
 }
 
-let availabilityResponse: {
-  available: boolean;
-  domain: string;
-  error?: string;
-};
+// Matches the realm-server /_check-boxel-domain-availability response shape.
+let availabilityResponse: { available: boolean; hostname: string };
 let checkedSubdomains: string[];
 
 module('Integration | commands | check-domain-availability', function (hooks) {
@@ -65,7 +62,7 @@ module('Integration | commands | check-domain-availability', function (hooks) {
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
     getOwner(this)!.register('service:realm', StubRealmService);
-    availabilityResponse = { available: true, domain: '' };
+    availabilityResponse = { available: true, hostname: '' };
     checkedSubdomains = [];
 
     await withCachedRealmSetup(async () =>
@@ -82,8 +79,8 @@ module('Integration | commands | check-domain-availability', function (hooks) {
     return new CheckDomainAvailabilityCommand(commandService.commandContext);
   }
 
-  test('reports an available custom subdomain with its published URL', async function (assert) {
-    availabilityResponse = { available: true, domain: 'my-site' };
+  test('reports an available custom subdomain, deriving the URL from the server hostname', async function (assert) {
+    availabilityResponse = { available: true, hostname: 'my-site.boxel.test' };
 
     let result = await makeCommand().execute({
       type: 'custom',
@@ -92,23 +89,19 @@ module('Integration | commands | check-domain-availability', function (hooks) {
 
     assert.deepEqual(checkedSubdomains, ['my-site'], 'checked the subdomain');
     assert.true(result.available);
-    assert.ok(
-      /^https:\/\/my-site\..+\/$/.test(result.publishedRealmURL),
-      `publishedRealmURL "${result.publishedRealmURL}" is the my-site custom URL`,
+    assert.strictEqual(
+      result.publishedRealmURL,
+      'https://my-site.boxel.test/',
+      'published URL is built from the canonical hostname the server returned',
     );
   });
 
-  test('reports an unavailable subdomain with the reason', async function (assert) {
-    availabilityResponse = {
-      available: false,
-      domain: 'taken',
-      error: 'This name is already taken',
-    };
+  test('reports an unavailable subdomain', async function (assert) {
+    availabilityResponse = { available: false, hostname: 'taken.boxel.test' };
 
     let result = await makeCommand().execute({ type: 'custom', name: 'taken' });
 
     assert.false(result.available);
-    assert.strictEqual(result.reason, 'This name is already taken');
   });
 
   test('rejects a non-custom target type', async function (assert) {


### PR DESCRIPTION
Adds the `check-domain-availability` host command (specifier `@cardstack/boxel-host/commands/check-domain-availability/default`) and routes the publish modal's subdomain check through it.

**Stacked on #5161** (base command types + URL helper) — base is the CS-11452 branch, sibling of #5162/#5172. This is the last of the four commands.

## What it does
- Given `{ type: 'custom', name }` (where `name` is the subdomain), calls `realmServer.checkDomainAvailability` and returns `{ available, publishedRealmURL, reason? }`, where `publishedRealmURL` is `https://<name>.<publishedRealmBoxelSiteDomain>/`.
- Registered in `commands/index.ts` (import, shim, `HostCommandClasses`).

## UI now uses the command
`publish-realm-modal.gts`'s `handleClaimCustomSubdomainTask` runs the availability check through `CheckDomainAvailabilityCommand` (the claim step stays in the modal). The availability check is an **action** (user clicks "claim"), so — like publish/unpublish (#5162/#5163) — it routes through the command. (Contrast with #5172's status/list, which stays on reactive getters.)

## v1 scope — custom only
Only custom Boxel **Site** subdomains have a server-side availability check (subdomain contention). Subdirectory Boxel **Spaces** are namespaced to the owner with no contention, so the command **errors** for `type: 'subdirectory'` rather than fabricating an "available" answer. A follow-up could add subdirectory handling if a use case appears.

## Tests
`tests/integration/commands/check-domain-availability-test.gts` — available (with resolved URL), unavailable (with reason), and the non-custom-type rejection.

Lint + `ember-tsc` clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)