### PR TITLE
Fix `ember-cli-deploy` deprecations

### DIFF
--- a/packages/host/config/deploy.js
+++ b/packages/host/config/deploy.js
@@ -5,7 +5,6 @@ module.exports = function (deployTarget) {
     pipeline: {
       activateOnDeploy: true,
     },
-    plugins: ['build', 'smart-compress', 'revision-data', 's3', 'cloudfront'],
     build: {},
     s3: {
       allowOverwrite: true,
@@ -29,7 +28,8 @@ module.exports = function (deployTarget) {
 
   if (deployTarget === 'build-only') {
     ENV.build.environment = 'production';
-    ENV.plugins = ['build'];
+    // Run only the build; skip S3 upload, CloudFront, compression, etc.
+    ENV.pipeline.disabled = { allExcept: ['build'] };
   }
 
   if (


### PR DESCRIPTION
This was a side quest from #5094 that turned out to be a red herring. But it silences deployment deprecation warnings like [this](https://github.com/cardstack/boxel/actions/runs/27153811839/job/80152110190#step:8:82).