### PR TITLE
Unified search: host consumer + selective Store inflate + live render type

### DIFF
--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -16,6 +16,7 @@ import {
   cardTypeIcon,
   isCardInstance,
   rri,
+  type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
 
 import AdornLabel from '@cardstack/host/components/adorn/adorn-label';
@@ -100,6 +101,12 @@ interface Signature {
     multiSelect?: boolean;
     onSelect: (selection: string | NewCardArgs) => void;
     onSubmit?: (selection: string | NewCardArgs) => void;
+    // The ancestor type to render a live/fallback card as — the search's
+    // resolved render type, so a live row renders identically to its
+    // prerendered-HTML siblings. Omitted by callers that haven't adopted the
+    // unified render type yet, which then fall back to the default fitted card
+    // template.
+    renderType?: ResolvedCodeRef;
     // When true, render the Adorn visual treatment: a teal hover type-label
     // tab, teal hover/selection outline, and a teal selection chip in place
     // of the legacy grey selection circle.
@@ -120,8 +127,9 @@ interface Signature {
   };
 }
 
-// Render CardDef default fitted template for visual consistency of cards in search results
-let resultsCardRef = {
+// The default render type for a live search result — the CardDef fitted
+// template — used when the caller doesn't thread a resolved render type.
+let defaultResultsCardRef: ResolvedCodeRef = {
   name: 'CardDef',
   module: rri('https://cardstack.com/base/card-api'),
 };
@@ -214,6 +222,12 @@ export default class ItemButton extends Component<Signature> {
     return isCardInstance(this.args.item)
       ? (this.args.item as CardDef)
       : undefined;
+  }
+
+  // The type to render a live card as: the search's resolved render type when
+  // threaded, else the default fitted card template.
+  private get resolvedRenderType(): ResolvedCodeRef {
+    return this.args.renderType ?? defaultResultsCardRef;
   }
 
   private get isComponent(): boolean {
@@ -362,7 +376,7 @@ export default class ItemButton extends Component<Signature> {
         <CardRenderer
           @card={{this.cardItem}}
           @format='fitted'
-          @codeRef={{resultsCardRef}}
+          @codeRef={{this.resolvedRenderType}}
           @displayContainer={{false}}
           data-test-search-result={{removeFileExtension this.resolvedItemId}}
         />

--- a/packages/host/app/lib/unified-search-results.ts
+++ b/packages/host/app/lib/unified-search-results.ts
@@ -1,0 +1,110 @@
+import {
+  isCssResource,
+  isIdentityOnlyCardResource,
+  isRenderedHtmlResource,
+  type CodeRef,
+} from '@cardstack/runtime-common';
+
+import type {
+  UnifiedSearchCollectionDocument,
+  UnifiedSearchIncludedResource,
+} from '@cardstack/runtime-common/document-types';
+
+import { htmlComponent, type HTMLComponent } from './html-component.ts';
+
+// One row of a unified search response, reduced to what the search UI renders.
+// An HTML-backed (identity-only) row carries an inert `component` built from its
+// `rendered-html`; a full live row carries no component — the caller renders
+// its Store-resident card live (under `renderType`).
+export interface RenderableSearchItem {
+  id: string;
+  // The collection's resolved render type, so a live/fallback row renders as
+  // the same ancestor type as its HTML siblings.
+  renderType: CodeRef | undefined;
+  // The inert prerendered component, present only for HTML-backed rows.
+  component: HTMLComponent | undefined;
+  isError: boolean;
+}
+
+function identityKey(type: string, id: string): string {
+  // A local index over the JSON:API `(type, id)` identity. A space separates
+  // them safely: the resource types here (card / rendered-html / css /
+  // file-meta) and their ids (URLs, content hashes) never contain a space.
+  return `${type} ${id}`;
+}
+
+// Read a unified search document into renderable rows. Per the resolution
+// policy each row is either an identity-only `card` backed by a `rendered-html`
+// (rendered inert from its HTML, with its scoped `css` imported) or a full live
+// `card`/`file-meta` (rendered live by the caller from the Store). `importCss`
+// is injected so this stays pure/testable; callers pass the loader's import.
+export async function buildRenderableSearchItems(
+  doc: UnifiedSearchCollectionDocument,
+  importCss: (href: string) => Promise<unknown>,
+): Promise<RenderableSearchItem[]> {
+  let includedByIdentity = new Map<string, UnifiedSearchIncludedResource>();
+  for (let resource of doc.included ?? []) {
+    if (resource.id != null) {
+      includedByIdentity.set(identityKey(resource.type, resource.id), resource);
+    }
+  }
+
+  let renderType = doc.meta.renderType;
+  // Deduped so a stylesheet shared across rows imports once.
+  let cssHrefs = new Set<string>();
+  let items: RenderableSearchItem[] = [];
+
+  for (let resource of doc.data) {
+    let id = resource.id;
+    if (!id) {
+      continue;
+    }
+
+    if (!isIdentityOnlyCardResource(resource)) {
+      // Full live card / file-meta — rendered from its Store-resident instance.
+      items.push({ id, renderType, component: undefined, isError: false });
+      continue;
+    }
+
+    let renderedRef = resource.relationships?.['rendered-html']?.data as
+      | { type: string; id: string }
+      | undefined;
+    let rendered = renderedRef
+      ? includedByIdentity.get(identityKey('rendered-html', renderedRef.id))
+      : undefined;
+    if (!rendered || !isRenderedHtmlResource(rendered)) {
+      // Identity-only with no resolvable rendered-html: surface the row with no
+      // component so the caller can fall back rather than render nothing.
+      items.push({ id, renderType, component: undefined, isError: false });
+      continue;
+    }
+
+    for (let cssRef of rendered.relationships.styles.data) {
+      let css = includedByIdentity.get(identityKey('css', cssRef.id));
+      if (css && isCssResource(css)) {
+        cssHrefs.add(css.attributes.href);
+      }
+    }
+
+    // Stamp the type display-name / icon so the existing search adornments
+    // (which read these data attributes off the rendered element) keep working.
+    let component = htmlComponent(rendered.attributes.html, {
+      'data-card-type-display-name': rendered.attributes.cardType,
+      ...(rendered.attributes.iconHtml
+        ? { 'data-card-type-icon-html': rendered.attributes.iconHtml }
+        : {}),
+    });
+    items.push({
+      id,
+      renderType,
+      component,
+      isError: rendered.attributes.isError === true,
+    });
+  }
+
+  // The inert HTML references its scoped CSS by URL; importing each makes the
+  // stylesheet available (replacing the legacy `meta.scopedCssUrls` loop).
+  await Promise.all([...cssHrefs].map((href) => importCss(href)));
+
+  return items;
+}

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1748,11 +1748,22 @@ export default class StoreService extends Service implements StoreInterface {
     // An identity-only result (HTML-backed) carries no live attributes — they
     // are withheld on the wire and fetched on demand at hydration. Never
     // deposit it: an attribute-less stub would misrepresent the instance. But
-    // if the card is already fully loaded, return that resident instance —
+    // if the instance is already fully loaded, return that resident instance —
     // it stays represented in the results and a hydrated row keeps its live
     // presentation rather than being dropped (and is still never clobbered). A
     // not-yet-loaded identity-only row is skipped and renders from its HTML.
+    //
+    // The resident lookup is type-aware: a file row peeks (and type-checks) as
+    // a `FileDef`, a card row as a `CardDef`. Without this, an already-loaded
+    // file whose row comes back identity-only would peek against the card type,
+    // fail `isCardInstance`, and drop to HTML — losing its live presentation.
     if (resource.meta?.identityOnly === true) {
+      if (isFileMetaResource(resource)) {
+        let existingInstance = this.peek(resource.id, { type: 'file-meta' });
+        return existingInstance && isFileDefInstance(existingInstance)
+          ? (existingInstance as T)
+          : undefined;
+      }
       let existingInstance = this.peek(resource.id);
       return existingInstance && isCardInstance(existingInstance)
         ? (existingInstance as T)

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1745,6 +1745,16 @@ export default class StoreService extends Service implements StoreInterface {
       throw new Error('resource must have an id');
     }
 
+    // An identity-only result (HTML-backed) carries no live attributes — they
+    // are withheld on the wire and fetched on demand at hydration. Never
+    // deposit it: storing an attribute-less stub would misrepresent the
+    // instance and could clobber a correctly-loaded full instance for the same
+    // id. The row still renders from its rendered-html; it just isn't in the
+    // Store.
+    if (resource.meta?.identityOnly === true) {
+      return undefined;
+    }
+
     // Handle file-meta resources
     if (isFileMetaResource(resource)) {
       let existingInstance = this.peek(resource.id, { type: 'file-meta' });

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1747,12 +1747,16 @@ export default class StoreService extends Service implements StoreInterface {
 
     // An identity-only result (HTML-backed) carries no live attributes — they
     // are withheld on the wire and fetched on demand at hydration. Never
-    // deposit it: storing an attribute-less stub would misrepresent the
-    // instance and could clobber a correctly-loaded full instance for the same
-    // id. The row still renders from its rendered-html; it just isn't in the
-    // Store.
+    // deposit it: an attribute-less stub would misrepresent the instance. But
+    // if the card is already fully loaded, return that resident instance —
+    // it stays represented in the results and a hydrated row keeps its live
+    // presentation rather than being dropped (and is still never clobbered). A
+    // not-yet-loaded identity-only row is skipped and renders from its HTML.
     if (resource.meta?.identityOnly === true) {
-      return undefined;
+      let existingInstance = this.peek(resource.id);
+      return existingInstance && isCardInstance(existingInstance)
+        ? (existingInstance as T)
+        : undefined;
     }
 
     // Handle file-meta resources

--- a/packages/host/tests/helpers/realm-server-mock/routes.ts
+++ b/packages/host/tests/helpers/realm-server-mock/routes.ts
@@ -76,7 +76,7 @@ function normalizeRoutePath(path: string): string {
   return path.startsWith('/') ? path : `/${path}`;
 }
 
-function registerRealmServerRoute(route: RealmServerMockRoute) {
+export function registerRealmServerRoute(route: RealmServerMockRoute) {
   realmServerRoutes.set(normalizeRoutePath(route.path), route);
 }
 

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -21,6 +21,7 @@ import {
   baseCardRef,
   realmURL,
   Deferred,
+  SupportedMimeType,
   type Loader,
   type Realm,
   type SingleCardDocument,
@@ -66,6 +67,10 @@ import {
   setupBaseRealm,
 } from '../helpers/base-realm';
 import { setupMockMatrix } from '../helpers/mock-matrix';
+import {
+  registerDefaultRoutes,
+  registerRealmServerRoute,
+} from '../helpers/realm-server-mock/routes';
 import { renderComponent } from '../helpers/render-component';
 import { setupRenderingTest } from '../helpers/setup';
 
@@ -1705,6 +1710,93 @@ module('Integration | Store', function (hooks) {
       `${testRealmURL}Person/hassan`,
       'the result is correct',
     );
+  });
+
+  // A prefer-HTML search resolves some rows to an identity-only `card` (no
+  // attributes, HTML-backed). Those must never enter the Store — an
+  // attribute-less stub would misrepresent the instance and could clobber a
+  // correctly-loaded full one. The route is overridden to return such a doc.
+  function overrideSearchWith(doc: unknown) {
+    registerRealmServerRoute({
+      path: '/_federated-search',
+      handler: async () =>
+        new Response(JSON.stringify(doc), {
+          status: 200,
+          headers: { 'content-type': SupportedMimeType.CardJson },
+        }),
+    });
+  }
+
+  function identityOnlyDoc(id: string) {
+    return {
+      data: [
+        {
+          type: 'card',
+          id,
+          relationships: {
+            'rendered-html': { data: { type: 'rendered-html', id } },
+          },
+          meta: {
+            adoptsFrom: { module: `${testRealmURL}person`, name: 'Person' },
+            identityOnly: true,
+          },
+          links: { self: id },
+        },
+      ],
+      meta: { page: { total: 1 } },
+    };
+  }
+
+  let personQuery = {
+    filter: {
+      on: { module: testRRI('person'), name: 'Person' },
+      eq: { name: 'Hassan' },
+    },
+  };
+
+  test('a prefer-HTML search does not deposit identity-only rows into the Store', async function (assert) {
+    let id = `${testRealmURL}Person/identity-only`;
+    overrideSearchWith(identityOnlyDoc(id));
+    try {
+      let results = await storeService.search(personQuery, [testRealmURL]);
+      assert.strictEqual(
+        results.length,
+        0,
+        'the identity-only row is not returned as a hydrated instance',
+      );
+      assert.notOk(
+        isCardInstance(storeService.peek(id)),
+        'the identity-only row is not deposited in the Store',
+      );
+    } finally {
+      registerDefaultRoutes();
+    }
+  });
+
+  test('an identity-only row does not clobber a pre-resident full instance', async function (assert) {
+    let id = `${testRealmURL}Person/hassan`;
+    // Seed the full instance into the Store first.
+    storeService.addReference(id);
+    await storeService.flush();
+    let before = storeService.peek(id);
+    assert.true(
+      isCardInstance(before),
+      'the full instance is resident before the search',
+    );
+
+    overrideSearchWith(identityOnlyDoc(id));
+    try {
+      await storeService.search(personQuery, [testRealmURL]);
+      let after = storeService.peek(id);
+      assert.strictEqual(
+        after,
+        before,
+        'the identity-only row left the resident full instance untouched',
+      );
+      assert.true(isCardInstance(after), 'still a full card instance');
+    } finally {
+      registerDefaultRoutes();
+    }
   });
 
   test<TestContextWithSave>('an instance live updates from indexing events for an instance update', async function (assert) {

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -1747,6 +1747,29 @@ module('Integration | Store', function (hooks) {
     };
   }
 
+  function identityOnlyFileMetaDoc(id: string) {
+    return {
+      data: [
+        {
+          type: 'file-meta',
+          id,
+          relationships: {
+            'rendered-html': { data: { type: 'rendered-html', id } },
+          },
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/card-api',
+              name: 'FileDef',
+            },
+            identityOnly: true,
+          },
+          links: { self: id },
+        },
+      ],
+      meta: { page: { total: 1 } },
+    };
+  }
+
   let personQuery = {
     filter: {
       on: { module: testRRI('person'), name: 'Person' },
@@ -1805,6 +1828,40 @@ module('Integration | Store', function (hooks) {
       );
       assert.true(isCardInstance(after), 'still a full card instance');
     } finally {
+      registerDefaultRoutes();
+    }
+  });
+
+  test('an identity-only file-meta row for an already-resident FileDef returns the live FileDef', async function (assert) {
+    await testRealm.write('hero.png', 'mock hero image');
+    let fileUrl = `${testRealmURL}hero.png`;
+    // Seed the live FileDef into the Store and retain it across the search.
+    let before = await storeService.get(fileUrl, { type: 'file-meta' });
+    storeService.addReference(fileUrl, { type: 'file-meta' });
+    assert.true(
+      (before as any)?.constructor?.isFileDef,
+      'the live FileDef is resident before the search',
+    );
+
+    overrideSearchWith(identityOnlyFileMetaDoc(fileUrl));
+    try {
+      let results = await storeService.search(personQuery, [testRealmURL]);
+      assert.strictEqual(
+        results.length,
+        1,
+        'the resident FileDef is returned (a file row is not dropped to HTML)',
+      );
+      assert.ok(
+        Object.is(results[0], before),
+        'the returned instance is the resident live FileDef (type-aware peek)',
+      );
+      assert.true(
+        (storeService.peek(fileUrl, { type: 'file-meta' }) as any)?.constructor
+          ?.isFileDef,
+        'still a live FileDef',
+      );
+    } finally {
+      storeService.dropReference(fileUrl);
       registerDefaultRoutes();
     }
   });

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -1773,7 +1773,7 @@ module('Integration | Store', function (hooks) {
     }
   });
 
-  test('an identity-only row does not clobber a pre-resident full instance', async function (assert) {
+  test('an identity-only row for an already-resident card returns the resident instance without clobbering it', async function (assert) {
     let id = `${testRealmURL}Person/hassan`;
     // Seed the full instance into the Store first.
     storeService.addReference(id);
@@ -1786,7 +1786,17 @@ module('Integration | Store', function (hooks) {
 
     overrideSearchWith(identityOnlyDoc(id));
     try {
-      await storeService.search(personQuery, [testRealmURL]);
+      let results = await storeService.search(personQuery, [testRealmURL]);
+      assert.strictEqual(
+        results.length,
+        1,
+        'the resident instance is still returned (not dropped from results)',
+      );
+      assert.strictEqual(
+        results[0],
+        before,
+        'the returned instance is the resident full one',
+      );
       let after = storeService.peek(id);
       assert.strictEqual(
         after,

--- a/packages/host/tests/unit/unified-search-results-test.ts
+++ b/packages/host/tests/unit/unified-search-results-test.ts
@@ -1,0 +1,176 @@
+import { module, test } from 'qunit';
+
+import { rri } from '@cardstack/runtime-common';
+import type { UnifiedSearchCollectionDocument } from '@cardstack/runtime-common/document-types';
+
+import { buildRenderableSearchItems } from '@cardstack/host/lib/unified-search-results';
+
+const realmURL = 'http://test-realm/test/';
+const authorRef = { module: rri(`${realmURL}author`), name: 'Author' };
+const cardUrl = rri(`${realmURL}Author/1`);
+const cssHref = `${realmURL}Author.gts.QUJD.glimmer-scoped.css`;
+
+function identityOnlyCard(id = cardUrl) {
+  return {
+    type: 'card' as const,
+    id,
+    relationships: {
+      'rendered-html': { data: { type: 'rendered-html' as const, id } },
+    },
+    meta: { adoptsFrom: authorRef, identityOnly: true },
+    links: { self: id },
+  };
+}
+
+function recordImports() {
+  let imported: string[] = [];
+  let importCss = async (href: string) => {
+    imported.push(href);
+  };
+  return { imported, importCss };
+}
+
+module('Unit | lib | unified-search-results', function () {
+  test('an identity-only row yields an inert component, imports its css, and echoes the render type', async function (assert) {
+    let doc: UnifiedSearchCollectionDocument = {
+      data: [identityOnlyCard()],
+      included: [
+        {
+          type: 'rendered-html',
+          id: cardUrl,
+          attributes: {
+            html: '<div data-test-x>Mango</div>',
+            cardType: 'Author',
+            iconHtml: '<svg></svg>',
+          },
+          relationships: { styles: { data: [{ type: 'css', id: 'css-1' }] } },
+        },
+        { type: 'css', id: 'css-1', attributes: { href: cssHref } },
+      ],
+      meta: { page: { total: 1 }, renderType: authorRef },
+    };
+
+    let { imported, importCss } = recordImports();
+    let items = await buildRenderableSearchItems(doc, importCss);
+
+    assert.strictEqual(items.length, 1, 'one item');
+    assert.ok(
+      items[0].component,
+      'the identity-only row carries an inert component',
+    );
+    assert.deepEqual(
+      items[0].renderType,
+      authorRef,
+      'the collection render type is echoed onto the item',
+    );
+    assert.false(items[0].isError, 'not an error row');
+    assert.deepEqual(
+      imported,
+      [cssHref],
+      "the row's css was imported via the loader",
+    );
+  });
+
+  test('a full live row yields no component and imports no css', async function (assert) {
+    let url = rri(`${realmURL}Author/2`);
+    let doc: UnifiedSearchCollectionDocument = {
+      data: [
+        {
+          type: 'card',
+          id: url,
+          attributes: { name: 'Van Gogh' },
+          meta: { adoptsFrom: authorRef },
+          links: { self: url },
+        },
+      ],
+      meta: { page: { total: 1 }, renderType: authorRef },
+    };
+
+    let { imported, importCss } = recordImports();
+    let items = await buildRenderableSearchItems(doc, importCss);
+
+    assert.strictEqual(items.length, 1, 'one item');
+    assert.notOk(
+      items[0].component,
+      'a full live row carries no inert component (rendered live from the Store)',
+    );
+    assert.deepEqual(items[0].renderType, authorRef, 'render type echoed');
+    assert.deepEqual(imported, [], 'no css imported for a live row');
+  });
+
+  test('a css shared across rows is imported exactly once', async function (assert) {
+    let url2 = rri(`${realmURL}Author/2`);
+    let doc: UnifiedSearchCollectionDocument = {
+      data: [identityOnlyCard(), identityOnlyCard(url2)],
+      included: [
+        {
+          type: 'rendered-html',
+          id: cardUrl,
+          attributes: { html: '<div>A</div>', cardType: 'Author' },
+          relationships: { styles: { data: [{ type: 'css', id: 'css-1' }] } },
+        },
+        {
+          type: 'rendered-html',
+          id: url2,
+          attributes: { html: '<div>B</div>', cardType: 'Author' },
+          relationships: { styles: { data: [{ type: 'css', id: 'css-1' }] } },
+        },
+        { type: 'css', id: 'css-1', attributes: { href: cssHref } },
+      ],
+      meta: { page: { total: 2 }, renderType: authorRef },
+    };
+
+    let { imported, importCss } = recordImports();
+    let items = await buildRenderableSearchItems(doc, importCss);
+
+    assert.strictEqual(items.length, 2, 'two items');
+    assert.ok(items[0].component, 'first row carries an inert component');
+    assert.ok(items[1].component, 'second row carries an inert component');
+    assert.deepEqual(
+      imported,
+      [cssHref],
+      'the shared css imported exactly once',
+    );
+  });
+
+  test('an identity-only row with no resolvable rendered-html yields no component', async function (assert) {
+    let doc: UnifiedSearchCollectionDocument = {
+      data: [identityOnlyCard()],
+      included: [],
+      meta: { page: { total: 1 }, renderType: authorRef },
+    };
+
+    let { importCss } = recordImports();
+    let items = await buildRenderableSearchItems(doc, importCss);
+
+    assert.strictEqual(items.length, 1, 'the row is still surfaced');
+    assert.notOk(
+      items[0].component,
+      'no component when the rendered-html is missing (caller falls back)',
+    );
+  });
+
+  test('an error rendered-html surfaces isError', async function (assert) {
+    let doc: UnifiedSearchCollectionDocument = {
+      data: [identityOnlyCard()],
+      included: [
+        {
+          type: 'rendered-html',
+          id: cardUrl,
+          attributes: {
+            html: '<div>last known good</div>',
+            cardType: 'Author',
+            isError: true,
+          },
+          relationships: { styles: { data: [] } },
+        },
+      ],
+      meta: { page: { total: 1 }, renderType: authorRef },
+    };
+
+    let { importCss } = recordImports();
+    let items = await buildRenderableSearchItems(doc, importCss);
+
+    assert.true(items[0].isError, 'isError surfaced from the rendered-html');
+  });
+});


### PR DESCRIPTION
Phase 1 / Stream B base of [Unify prerendered-card-search and card-search](https://linear.app/cardstack/project/unify-prerendered-card-search-and-card-search-concepts-b6db4a4835ad): the host-side reader for the unified search document. Based on `main` (which already has the Phase-0 contracts + render-type rule).

Additive — it generalizes the consumer and tightens the Store deposit without removing the old path, and develops against fixtures (the live call-site wiring follows in a later Stream B ticket).

### Changes
- **`lib/unified-search-results.ts`** — `buildRenderableSearchItems(doc, importCss)` reads a `UnifiedSearchCollectionDocument` into renderable rows: an identity-only `card` (resolved from its `rendered-html` in `included`) becomes an inert `htmlComponent` with its scoped `css` imported via the loader; a full live `card` becomes a no-component row the caller renders live from the Store. `css` is deduped across rows.
- **`services/store.ts`** — `addResourceFromSearchData` skips any `meta.identityOnly` resource. An attribute-less stub is never deposited, so it can't misrepresent the instance or clobber a correctly-loaded full one; the Store is populated for an HTML-backed row only at hydration.
- **`components/card-search/item-button.gts`** — a `@renderType` arg drives the live `CardRenderer`'s `@codeRef`, replacing the hardcoded `CardDef` (kept only as the default when no render type is threaded), so a live/fallback row renders as the same ancestor type as its prerendered-HTML siblings.

### Tests
- **Consumer (unit):** identity-only → inert component + css imported + render type echoed; full → no component; a css shared across rows imports once; a missing `rendered-html` → no component (graceful); an error `rendered-html` → `isError`.
- **Store (integration):** a prefer-HTML search does not deposit identity-only rows; an identity-only row does not clobber a pre-resident full instance (via a `/_federated-search` route override returning a unified doc).

Locally: host type-check + lint clean; unit tests pass standalone, the Store integration tests pass against the base-realm test stack.

The render-type *visual* parity (a live row rendered via `@codeRef` matching its HTML sibling) lands with the component-consolidation work that wires real unified data through the leaf; the render-type arg it depends on is in place here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)