### PR TITLE
Unified search: FileDef parity on the server (HTML-backed file-meta)

### DIFF
--- a/packages/realm-server/tests/server-endpoints/search-test.ts
+++ b/packages/realm-server/tests/server-endpoints/search-test.ts
@@ -631,6 +631,15 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
         htmlFile.meta?.renderType,
         'a file carries no renderType (renders natively)',
       );
+      // A `.md` file's most-derived type is the FileDef subclass `MarkdownDef`.
+      // `adoptsFrom` must be that subclass — not the `FileDef` ancestor — even
+      // though the file-meta query targets `FileDef`: files render natively, so
+      // the card-side render type is never coerced onto a file.
+      assert.strictEqual(
+        htmlFile.meta?.adoptsFrom?.name,
+        'MarkdownDef',
+        'adoptsFrom is the file’s own most-derived type, never a coerced ancestor',
+      );
       assert.deepEqual(
         htmlFile.relationships?.['rendered-html']?.data,
         { type: 'rendered-html', id: htmlUrl },

--- a/packages/realm-server/tests/server-endpoints/search-test.ts
+++ b/packages/realm-server/tests/server-endpoints/search-test.ts
@@ -44,7 +44,11 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
 
     let ownerUserId = '@mango:localhost';
 
-    let realmFileSystem: Record<string, LooseSingleCardDocument> = {
+    let realmFileSystem: Record<string, LooseSingleCardDocument | string> = {
+      // Two markdown files (FileDef rows that get prerendered HTML) for the
+      // file-meta prefer-HTML test. They don't appear in card queries.
+      'hello.md': '# Hello from a FileDef',
+      'world.md': '# World from a FileDef',
       'test-card.json': {
         data: {
           type: 'card',
@@ -561,6 +565,165 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
       assert.notOk(
         included.find((r) => r.type === 'rendered-html' && r.id === liveUrl),
         'no rendered-html is emitted for the live fallback row',
+      );
+    });
+
+    // File-meta parity: the same mixed-index manufacture for FileDef rows. A
+    // prefer-HTML search over file-meta emits an identity-only `file-meta` +
+    // `rendered-html` for the HTML-backed file and a full live `file-meta` for
+    // the HTML-nulled file. A file renders natively, so it carries no renderType.
+    test('QUERY /_federated-search prefer-HTML emits identity-only file-meta + rendered-html for HTML files and a full live file-meta for HTML-absent files', async function (assert) {
+      let realmServerToken = createRealmServerJWT(
+        { user: ownerUserId, sessionRoom: 'session-room-test' },
+        realmSecretSeed,
+      );
+      let htmlUrl = `${testRealm.url}hello.md`; // keeps its rendered HTML
+      let liveUrl = `${testRealm.url}world.md`; // HTML nulled → live fallback
+
+      // Null the fitted HTML for one file row. The file index `url` is the bare
+      // file URL (no `.json`).
+      await query(dbAdapter, [
+        `UPDATE boxel_index SET fitted_html = NULL WHERE url =`,
+        param(liveUrl),
+        `AND realm_url =`,
+        param(testRealm.url),
+      ] as Expression);
+
+      let searchURL = new URL('/_federated-search', testRealm.url);
+      let response = await request
+        .post(`${searchURL.pathname}${searchURL.search}`)
+        .set('Accept', 'application/vnd.card+json')
+        .set('Content-Type', 'application/json')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Authorization', `Bearer ${realmServerToken}`)
+        // A pure `type: FileDef` filter → a file-meta query spanning the
+        // realm's .md files (FileDef rows). No `filter.on`, so the render type
+        // resolves to native — a file renders as itself and carries no
+        // renderType.
+        .send({
+          realms: [testRealm.url],
+          filter: {
+            type: {
+              module: rri('https://cardstack.com/base/card-api'),
+              name: 'FileDef',
+            },
+          },
+          render: { format: 'fitted' },
+        });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200');
+      let data = response.body.data as any[];
+      let included = (response.body.included ?? []) as any[];
+      let byId = new Map<string, any>(data.map((r) => [r.id, r]));
+
+      assert.ok(byId.has(htmlUrl), 'the HTML-backed file is in data');
+      assert.ok(byId.has(liveUrl), 'the HTML-absent file is in data');
+
+      // HTML-backed file → identity-only file-meta + rendered-html.
+      let htmlFile = byId.get(htmlUrl);
+      assert.strictEqual(htmlFile.type, 'file-meta', 'HTML row is a file-meta');
+      assert.notOk(
+        htmlFile.attributes,
+        'the HTML-backed file-meta is identity-only (no attributes)',
+      );
+      assert.true(htmlFile.meta?.identityOnly, 'marked meta.identityOnly');
+      assert.notOk(
+        htmlFile.meta?.renderType,
+        'a file carries no renderType (renders natively)',
+      );
+      assert.deepEqual(
+        htmlFile.relationships?.['rendered-html']?.data,
+        { type: 'rendered-html', id: htmlUrl },
+        'the file-meta links to its rendered-html by the shared id',
+      );
+      assert.strictEqual(
+        htmlFile.links?.self,
+        htmlUrl,
+        'links.self is the hydration target',
+      );
+
+      let rendered = included.find(
+        (r) => r.type === 'rendered-html' && r.id === htmlUrl,
+      );
+      assert.ok(
+        rendered,
+        'a rendered-html for the HTML file rides in included',
+      );
+      assert.ok(
+        rendered.attributes.html?.length > 0,
+        'the prerendered html is non-empty',
+      );
+      assert.notOk(
+        rendered.meta?.renderType,
+        'the file rendered-html carries no renderType',
+      );
+
+      // HTML-absent file → full live file-meta, nothing in included for it.
+      let liveFile = byId.get(liveUrl);
+      assert.strictEqual(liveFile.type, 'file-meta', 'live row is a file-meta');
+      assert.ok(
+        liveFile.attributes,
+        'the HTML-absent file is a full live file-meta (attributes present)',
+      );
+      assert.notOk(
+        liveFile.meta?.identityOnly,
+        'the live fallback file-meta is not identity-only',
+      );
+      assert.notOk(
+        included.find((r) => r.type === 'rendered-html' && r.id === liveUrl),
+        'no rendered-html is emitted for the live fallback file',
+      );
+    });
+
+    // File-meta parity for the live (no-render) path: a `dataOnly` file query
+    // returns the full live file-meta document, byte-identical to a plain
+    // (no-render) file query — the prefer-HTML emission never touches it.
+    test('QUERY /_federated-search dataOnly over a file query is byte-identical to the live file-meta document', async function (assert) {
+      let realmServerToken = createRealmServerJWT(
+        { user: ownerUserId, sessionRoom: 'session-room-test' },
+        realmSecretSeed,
+      );
+      let searchURL = new URL('/_federated-search', testRealm.url);
+      let fileFilter = {
+        type: {
+          module: rri('https://cardstack.com/base/card-api'),
+          name: 'FileDef',
+        },
+      };
+      let post = (body: Record<string, unknown>) =>
+        request
+          .post(`${searchURL.pathname}${searchURL.search}`)
+          .set('Accept', 'application/vnd.card+json')
+          .set('Content-Type', 'application/json')
+          .set('X-HTTP-Method-Override', 'QUERY')
+          .set('Authorization', `Bearer ${realmServerToken}`)
+          .send({ realms: [testRealm.url], filter: fileFilter, ...body });
+
+      let plain = await post({});
+      let dataOnly = await post({ dataOnly: true });
+      assert.strictEqual(plain.status, 200, 'plain: HTTP 200');
+      assert.strictEqual(dataOnly.status, 200, 'dataOnly: HTTP 200');
+      assert.ok(
+        (dataOnly.body.data as any[]).length > 0,
+        'the realm returns file rows (the parity check is not vacuous)',
+      );
+      assert.deepEqual(
+        dataOnly.body,
+        plain.body,
+        'dataOnly is byte-identical to a plain (no-render) live file query',
+      );
+      assert.notOk(
+        (dataOnly.body.included ?? []).some(
+          (r: any) => r.type === 'rendered-html' || r.type === 'css',
+        ),
+        'dataOnly emits no rendered-html / css',
+      );
+      assert.ok(
+        (dataOnly.body.data as any[]).every(
+          (r) =>
+            r.type === 'file-meta' && r.attributes && !r.meta?.identityOnly,
+        ),
+        'every dataOnly row is a full live file-meta (attributes present, not identity-only)',
       );
     });
 

--- a/packages/realm-server/tests/unified-search-contracts-test.ts
+++ b/packages/realm-server/tests/unified-search-contracts-test.ts
@@ -3,12 +3,15 @@ import { basename } from 'path';
 import {
   buildCssResource,
   buildIdentityOnlyCard,
+  buildIdentityOnlyFileMeta,
   buildRenderedHtmlResource,
   combineSearchResults,
   cssResourceId,
   isCardResource,
   isCssResource,
+  isFileMetaResource,
   isIdentityOnlyCardResource,
+  isIdentityOnlyFileMetaResource,
   isRenderedHtmlResource,
   parseUnifiedSearchRequestFromPayload,
   parseUsedRenderType,
@@ -16,6 +19,7 @@ import {
   scopedCssHrefsFromDeps,
   type CardResource,
   type CssResource,
+  type FileMetaResource,
   type RenderedHtmlResource,
   type UnifiedSearchCollectionDocument,
 } from '@cardstack/runtime-common';
@@ -49,6 +53,36 @@ function identityOnlyCard(): CardResource {
     },
     meta: { adoptsFrom: authorRef, identityOnly: true },
     links: { self: cardUrl },
+  };
+}
+
+const fileUrl = rri(`${realmURL}hero.png`);
+const fileDefRef = {
+  module: rri('https://cardstack.com/base/card-api'),
+  name: 'FileDef',
+};
+
+function fullFileMeta(): FileMetaResource {
+  return {
+    type: 'file-meta',
+    id: fileUrl,
+    attributes: { name: 'hero.png' },
+    meta: { adoptsFrom: fileDefRef },
+    links: { self: fileUrl },
+  };
+}
+
+function identityOnlyFileMeta(): FileMetaResource {
+  return {
+    type: 'file-meta',
+    id: fileUrl,
+    relationships: {
+      'rendered-html': {
+        data: { type: 'rendered-html', id: fileUrl },
+      },
+    },
+    meta: { adoptsFrom: fileDefRef, identityOnly: true },
+    links: { self: fileUrl },
   };
 }
 
@@ -106,6 +140,30 @@ module(basename(__filename), function () {
       assert.false(
         isIdentityOnlyCardResource(noAttributesNoFlag),
         'a full card that merely lacks attributes is not identity-only',
+      );
+    });
+
+    test('isIdentityOnlyFileMetaResource keys on meta.identityOnly', function (assert) {
+      assert.true(
+        isFileMetaResource(fullFileMeta()),
+        'full file-meta is a file-meta resource',
+      );
+      assert.false(
+        isIdentityOnlyFileMetaResource(fullFileMeta()),
+        'a full file-meta (no flag) is not identity-only',
+      );
+      assert.true(
+        isIdentityOnlyFileMetaResource(identityOnlyFileMeta()),
+        'a flagged identity-only file-meta is identity-only',
+      );
+      // The card and file-meta predicates don't cross over.
+      assert.false(
+        isIdentityOnlyFileMetaResource(identityOnlyCard()),
+        'an identity-only card is not an identity-only file-meta',
+      );
+      assert.false(
+        isIdentityOnlyCardResource(identityOnlyFileMeta()),
+        'an identity-only file-meta is not an identity-only card',
       );
     });
 
@@ -569,6 +627,33 @@ module(basename(__filename), function () {
         card.meta.renderType,
         authorRef,
         'carries the render type',
+      );
+    });
+
+    test('buildIdentityOnlyFileMeta builds an attribute-less identity-only file-meta (no renderType — renders natively)', function (assert) {
+      let fileMeta = buildIdentityOnlyFileMeta({
+        url: fileUrl,
+        adoptsFrom: fileDefRef,
+      });
+      assert.true(
+        isIdentityOnlyFileMetaResource(fileMeta),
+        'is an identity-only file-meta resource',
+      );
+      assert.notOk(fileMeta.attributes, 'no attributes are shipped');
+      assert.deepEqual(
+        fileMeta.relationships?.['rendered-html']?.data,
+        { type: 'rendered-html', id: fileUrl },
+        'links to its rendered-html by the shared id',
+      );
+      assert.strictEqual(
+        fileMeta.links?.self,
+        fileUrl,
+        'links.self is the hydration target',
+      );
+      assert.deepEqual(
+        fileMeta.meta.adoptsFrom,
+        fileDefRef,
+        'carries the file type',
       );
     });
   });

--- a/packages/runtime-common/card-document-shape.ts
+++ b/packages/runtime-common/card-document-shape.ts
@@ -348,6 +348,19 @@ export function isIdentityOnlyCardResource(
   return resource.meta?.identityOnly === true;
 }
 
+// The `file-meta` counterpart of `isIdentityOnlyCardResource`: an HTML-backed
+// file row the server emits as identity + a `rendered-html` relationship with
+// no `attributes`, flagged `meta.identityOnly`. Hydrates to a live `FileDef`
+// via `links.self`. (A file carries no `renderType` — it renders natively.)
+export function isIdentityOnlyFileMetaResource(
+  resource: any,
+): resource is FileMetaResource {
+  if (!isFileMetaResource(resource)) {
+    return false;
+  }
+  return resource.meta?.identityOnly === true;
+}
+
 // ---------------------------------------------------------------------------
 // Documents
 // ---------------------------------------------------------------------------

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -69,6 +69,7 @@ import type { PrerenderedHtmlFormat } from './prerendered-html-format.ts';
 import {
   buildCssResource,
   buildIdentityOnlyCard,
+  buildIdentityOnlyFileMeta,
   buildRenderedHtmlResource,
   parseUsedRenderType,
   scopedCssHrefsFromDeps,
@@ -425,8 +426,9 @@ export class RealmIndexQueryEngine {
   //     exactly as the data-only path returns it.
   // Only the no-HTML fallback cards go through `loadLinks` — an identity-only
   // card has no relationships to expand. `css` resources dedupe by their
-  // content-hash id across rows. A query that targets file-meta has no HTML
-  // projection, so it resolves to the full live file-meta document.
+  // content-hash id across rows. A query that targets file-meta resolves
+  // through `searchFiles` (the `render` projection is instance-only) and gets
+  // the same prefer-HTML treatment per file — see `searchUnifiedFileMeta`.
   async searchUnified(
     query: Query,
     opts: Options & {
@@ -434,7 +436,7 @@ export class RealmIndexQueryEngine {
     },
   ): Promise<UnifiedSearchCollectionDocument> {
     if (await this.queryTargetsFileMeta(query.filter, opts)) {
-      return await this.searchCardsUncoalesced(query, opts);
+      return await this.searchUnifiedFileMeta(query, opts);
     }
 
     // `includeErrors` so error rows reach the mapper as `rendered-html` with
@@ -566,6 +568,123 @@ export class RealmIndexQueryEngine {
     // and are echoed on each `rendered-html` instead.
     if (opts.render.renderType) {
       doc.meta.renderType = opts.render.renderType;
+    }
+    await this.attachRealmInfo(doc);
+    return doc;
+  }
+
+  // The file-meta counterpart of `searchUnified`. Files are indexed as
+  // `type: 'file'` rows, which the instance-only `render` projection skips, so
+  // they resolve through `searchFiles` (per-type HTML + the full `file-meta`
+  // resource). Same prefer-HTML policy per file: HTML present → identity-only
+  // `file-meta` + `rendered-html` (+ deduped `css`); no HTML → the full live
+  // `file-meta`. A file renders natively, so its `rendered-html` carries no
+  // `renderType` and the identity-only `file-meta`'s `adoptsFrom` is its own
+  // resolved type.
+  private async searchUnifiedFileMeta(
+    query: Query,
+    opts: Options & {
+      render: { format: PrerenderedHtmlFormat; renderType?: CodeRef };
+    },
+  ): Promise<UnifiedSearchCollectionDocument> {
+    // File-meta search returns non-error rows (matching the prerendered file
+    // path); the per-file HTML is selected in `fileEntryToPrerenderedCard`.
+    let { includeErrors: _includeErrors, ...rest } = opts;
+    let fileOpts = {
+      ...rest,
+      htmlFormat: opts.render.format,
+      renderType: opts.render.renderType as ResolvedCodeRef | undefined,
+    };
+    let runSql = () =>
+      this.#indexQueryEngine.searchFiles(
+        new URL(this.#realm.url),
+        query,
+        fileOpts,
+      );
+    let { files, meta } = opts?.timings
+      ? await opts.timings.time('sql', runSql)
+      : await runSql();
+
+    let data: (CardResource<Saved> | FileMetaResource)[] = [];
+    let renderedResources: UnifiedSearchIncludedResource[] = [];
+    let cssById = new Map<string, CssResource>();
+    let fallbackRoots: (CardResource<Saved> | FileMetaResource)[] = [];
+
+    for (let file of files) {
+      let { url, html, cardType, iconHtml, usedRenderType } =
+        this.fileEntryToPrerenderedCard(file, fileOpts);
+      if (!url) {
+        continue;
+      }
+      if (html != null) {
+        // HTML-backed file → rendered-html + identity-only file-meta.
+        let cssIds: string[] = [];
+        for (let href of scopedCssHrefsFromDeps(file.deps)) {
+          let css = buildCssResource(href);
+          if (!cssById.has(css.id)) {
+            cssById.set(css.id, css);
+          }
+          cssIds.push(css.id);
+        }
+        renderedResources.push(
+          buildRenderedHtmlResource({
+            url,
+            html,
+            cardType: cardType ?? '',
+            iconHtml,
+            cssIds,
+          }),
+        );
+        if (usedRenderType) {
+          data.push(
+            buildIdentityOnlyFileMeta({ url, adoptsFrom: usedRenderType }),
+          );
+        }
+      } else {
+        // No HTML → the full live file-meta, exactly as the data-only path.
+        let pristine = file.resource;
+        if (pristine && pristine.id) {
+          let fileMeta: FileMetaResource = {
+            ...pristine,
+            links: { self: pristine.id },
+          };
+          if (query.fields?.['file-meta'] !== undefined) {
+            fileMeta = applySparseFieldset(
+              fileMeta,
+              query.fields['file-meta'],
+            ) as FileMetaResource;
+          }
+          data.push(fileMeta);
+          fallbackRoots.push(fileMeta);
+        }
+      }
+    }
+
+    let included: UnifiedSearchIncludedResource[] = [
+      ...renderedResources,
+      ...cssById.values(),
+    ];
+
+    // Only the no-HTML fallback rows expand links (an identity-only file-meta
+    // has none); same gating as the card path.
+    if (fallbackRoots.length > 0 && opts?.loadLinks && !opts?.omitIncluded) {
+      let linkFields = query.fields?.['file-meta'];
+      let linkOpts = linkFields ? { ...opts, linkFields } : opts;
+      let omit = data.map((r) => r.id).filter(Boolean) as string[];
+      let runLoadLinks = () =>
+        this.loadLinks(
+          { realmURL: this.realmURL, rootResources: fallbackRoots, omit },
+          linkOpts,
+        );
+      let fallbackIncluded = opts?.timings
+        ? await opts.timings.time('loadLinks', runLoadLinks)
+        : await runLoadLinks();
+      included.push(...fallbackIncluded);
+    }
+
+    let doc: UnifiedSearchCollectionDocument = { data, meta };
+    if (included.length > 0) {
+      doc.included = included;
     }
     await this.attachRealmInfo(doc);
     return doc;

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -589,11 +589,23 @@ export class RealmIndexQueryEngine {
   ): Promise<UnifiedSearchCollectionDocument> {
     // File-meta search returns non-error rows (matching the prerendered file
     // path); the per-file HTML is selected in `fileEntryToPrerenderedCard`.
-    let { includeErrors: _includeErrors, ...rest } = opts;
+    //
+    // A file renders natively: its prerendered HTML is keyed by the file's own
+    // most-derived type, never by an ancestor a caller asked *cards* to render
+    // as. So the card-side render type — which `resolveRenderType` may default
+    // to `filter.on` — is deliberately dropped here rather than threaded into
+    // the file lookup. `fileEntryToPrerenderedCard` then selects each file's
+    // own `types[0]`, and that is the type `buildIdentityOnlyFileMeta` stamps
+    // as `adoptsFrom`; letting an ancestor type leak in would mismatch a
+    // FileDef subclass's HTML against its identity.
+    let {
+      includeErrors: _includeErrors,
+      renderType: _renderType,
+      ...rest
+    } = opts;
     let fileOpts = {
       ...rest,
       htmlFormat: opts.render.format,
-      renderType: opts.render.renderType as ResolvedCodeRef | undefined,
     };
     let runSql = () =>
       this.#indexQueryEngine.searchFiles(

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -231,6 +231,7 @@ export {
   isRenderedHtmlResource,
   isCssResource,
   isIdentityOnlyCardResource,
+  isIdentityOnlyFileMetaResource,
 } from './card-document-shape.ts';
 
 // The `css` resource id: a content hash of the (base64-embedding) scoped-CSS

--- a/packages/runtime-common/unified-search.ts
+++ b/packages/runtime-common/unified-search.ts
@@ -3,6 +3,7 @@ import {
   cssResourceId,
   type CardResource,
   type CssResource,
+  type FileMetaResource,
   type RenderedHtmlResource,
   type Saved,
 } from './resource-types';
@@ -102,6 +103,30 @@ export function buildIdentityOnlyCard(args: {
       adoptsFrom,
       identityOnly: true,
       ...(renderType ? { renderType } : {}),
+    },
+    links: { self: url },
+  };
+}
+
+// The identity-only `file-meta` paired with a `rendered-html` row — the file
+// counterpart of `buildIdentityOnlyCard`. A file renders natively (its own
+// FileDef component, no ancestor coercion), so unlike a card it carries no
+// `renderType`; `adoptsFrom` is the file's own type and hydration renders the
+// live `FileDef` with no `@codeRef`.
+export function buildIdentityOnlyFileMeta(args: {
+  url: string;
+  adoptsFrom: CodeRef;
+}): FileMetaResource {
+  let { url, adoptsFrom } = args;
+  return {
+    type: 'file-meta',
+    id: url as Saved,
+    relationships: {
+      'rendered-html': { data: { type: 'rendered-html', id: url } },
+    },
+    meta: {
+      adoptsFrom,
+      identityOnly: true,
     },
     links: { self: url },
   };


### PR DESCRIPTION
## What

Brings FileDef rows to parity with card rows in unified prefer-HTML search. A prefer-HTML search over `FileDef` now emits the identity-only `file-meta` + `rendered-html` shape (just like cards), rather than always returning a full live `file-meta` document.

## Why this shape

Files are indexed as `type: 'file'` rows. The unified `render` projection is instance-only, so files never flow through the card path — they resolve through `searchFiles`. `searchUnifiedFileMeta` mirrors the card path's per-row prefer-HTML policy:

- **HTML present** → identity-only `file-meta` (id + `links.self` + a `rendered-html` relationship, `meta.identityOnly: true`, no `attributes`) plus the `rendered-html` resource and its deduped `css`.
- **No HTML** → the full live `file-meta`, honoring any sparse fieldset and link-expanded exactly as the data-only path.

A file renders **natively** (its own FileDef component, no ancestor coercion), so unlike a card it carries **no `renderType`**: the `rendered-html` has none and the identity-only `file-meta`'s `adoptsFrom` is the file's own resolved type. The host hydrates it to a live `FileDef` with no `@codeRef`.

## Surface

- `buildIdentityOnlyFileMeta` — the file counterpart of `buildIdentityOnlyCard`.
- `isIdentityOnlyFileMetaResource` — keys on `meta.identityOnly`, re-exported from `resource-types`.
- `searchUnified` routes file-meta-targeting queries to `searchUnifiedFileMeta`.

No behavior change for callers that don't request `render`: a plain or `dataOnly` file-meta query is byte-identical to before.

## Test plan

- **Contracts** (`unified-search-contracts-test.ts`): the new builder produces an attribute-less identity-only file-meta with no `renderType`; the predicate keys on `meta.identityOnly` and does not cross over with the card predicate.
- **Endpoint** (`search-test.ts`): a mixed-index realm with two `.md` files — one keeps its prerendered HTML, one has its `fitted_html` nulled. A `type: FileDef` prefer-HTML query returns an identity-only `file-meta` + `rendered-html` (no `renderType`) for the HTML file and a full live `file-meta` for the HTML-absent file, in one `data` array.
- Full `search-test.ts` module green (21/21); the card mixed-index regression unaffected.
