### PR TITLE
Unified search: FileDef parity in the host consumer (identity-only file-meta rows)

### DIFF
--- a/packages/host/app/lib/unified-search-results.ts
+++ b/packages/host/app/lib/unified-search-results.ts
@@ -1,8 +1,10 @@
 import {
   isCssResource,
   isIdentityOnlyCardResource,
+  isIdentityOnlyFileMetaResource,
   isRenderedHtmlResource,
   type CodeRef,
+  type StoreReadType,
 } from '@cardstack/runtime-common';
 
 import type {
@@ -15,11 +17,16 @@ import { htmlComponent, type HTMLComponent } from './html-component.ts';
 // One row of a unified search response, reduced to what the search UI renders.
 // An HTML-backed (identity-only) row carries an inert `component` built from its
 // `rendered-html`; a full live row carries no component — the caller renders
-// its Store-resident card live (under `renderType`).
+// its Store-resident instance live (under `renderType`).
 export interface RenderableSearchItem {
   id: string;
-  // The collection's resolved render type, so a live/fallback row renders as
-  // the same ancestor type as its HTML siblings.
+  // The row's resource kind — `card` or `file-meta` — threaded to the
+  // hydratable card's `@type` so the consumer resolves a file row to a live
+  // `FileDef` rather than a `CardDef`.
+  type: StoreReadType;
+  // The collection's resolved render type, so a live/fallback card row renders
+  // as the same ancestor type as its HTML siblings. A `file-meta` row carries
+  // none — files render natively, with no ancestor render type.
   renderType: CodeRef | undefined;
   // The inert prerendered component, present only for HTML-backed rows.
   component: HTMLComponent | undefined;
@@ -34,10 +41,11 @@ function identityKey(type: string, id: string): string {
 }
 
 // Read a unified search document into renderable rows. Per the resolution
-// policy each row is either an identity-only `card` backed by a `rendered-html`
-// (rendered inert from its HTML, with its scoped `css` imported) or a full live
-// `card`/`file-meta` (rendered live by the caller from the Store). `importCss`
-// is injected so this stays pure/testable; callers pass the loader's import.
+// policy each row is either an identity-only `card`/`file-meta` backed by a
+// `rendered-html` (rendered inert from its HTML, with its scoped `css`
+// imported) or a full live `card`/`file-meta` (rendered live by the caller
+// from the Store). `importCss` is injected so this stays pure/testable;
+// callers pass the loader's import.
 export async function buildRenderableSearchItems(
   doc: UnifiedSearchCollectionDocument,
   importCss: (href: string) => Promise<unknown>,
@@ -60,9 +68,25 @@ export async function buildRenderableSearchItems(
       continue;
     }
 
-    if (!isIdentityOnlyCardResource(resource)) {
+    // The row's JSON:API type, threaded onto the item so the consumer hydrates
+    // it as the right kind. Files render natively (their own FileRender), so a
+    // `file-meta` row carries no ancestor `renderType`; a card echoes the
+    // collection's resolved render type.
+    let type: StoreReadType = resource.type;
+    let itemRenderType = type === 'file-meta' ? undefined : renderType;
+
+    if (
+      !isIdentityOnlyCardResource(resource) &&
+      !isIdentityOnlyFileMetaResource(resource)
+    ) {
       // Full live card / file-meta — rendered from its Store-resident instance.
-      items.push({ id, renderType, component: undefined, isError: false });
+      items.push({
+        id,
+        type,
+        renderType: itemRenderType,
+        component: undefined,
+        isError: false,
+      });
       continue;
     }
 
@@ -75,7 +99,13 @@ export async function buildRenderableSearchItems(
     if (!rendered || !isRenderedHtmlResource(rendered)) {
       // Identity-only with no resolvable rendered-html: surface the row with no
       // component so the caller can fall back rather than render nothing.
-      items.push({ id, renderType, component: undefined, isError: false });
+      items.push({
+        id,
+        type,
+        renderType: itemRenderType,
+        component: undefined,
+        isError: false,
+      });
       continue;
     }
 
@@ -96,7 +126,8 @@ export async function buildRenderableSearchItems(
     });
     items.push({
       id,
-      renderType,
+      type,
+      renderType: itemRenderType,
       component,
       isError: rendered.attributes.isError === true,
     });

--- a/packages/host/tests/unit/unified-search-results-test.ts
+++ b/packages/host/tests/unit/unified-search-results-test.ts
@@ -22,6 +22,27 @@ function identityOnlyCard(id = cardUrl) {
   };
 }
 
+const fileUrl = rri(`${realmURL}hero.png`);
+// A file adopts from FileDef and has no userland ancestor type — it renders
+// natively, so its row carries no `renderType`.
+const fileDefRef = {
+  module: rri('https://cardstack.com/base/card-api'),
+  name: 'FileDef',
+};
+const fileCssHref = `${realmURL}hero.png.RkRF.glimmer-scoped.css`;
+
+function identityOnlyFileMeta(id = fileUrl) {
+  return {
+    type: 'file-meta' as const,
+    id,
+    relationships: {
+      'rendered-html': { data: { type: 'rendered-html' as const, id } },
+    },
+    meta: { adoptsFrom: fileDefRef, identityOnly: true },
+    links: { self: id },
+  };
+}
+
 function recordImports() {
   let imported: string[] = [];
   let importCss = async (href: string) => {
@@ -58,6 +79,7 @@ module('Unit | lib | unified-search-results', function () {
       items[0].component,
       'the identity-only row carries an inert component',
     );
+    assert.strictEqual(items[0].type, 'card', 'the row is typed as a card');
     assert.deepEqual(
       items[0].renderType,
       authorRef,
@@ -172,5 +194,88 @@ module('Unit | lib | unified-search-results', function () {
     let items = await buildRenderableSearchItems(doc, importCss);
 
     assert.true(items[0].isError, 'isError surfaced from the rendered-html');
+  });
+
+  test('an identity-only file-meta row yields an inert component typed file-meta, with no render type', async function (assert) {
+    let doc: UnifiedSearchCollectionDocument = {
+      data: [identityOnlyFileMeta()],
+      included: [
+        {
+          type: 'rendered-html',
+          id: fileUrl,
+          attributes: {
+            html: '<div data-test-file>hero.png</div>',
+            cardType: 'hero.png',
+          },
+          relationships: {
+            styles: { data: [{ type: 'css', id: 'file-css-1' }] },
+          },
+        },
+        { type: 'css', id: 'file-css-1', attributes: { href: fileCssHref } },
+      ],
+      // The collection carries a card render type; a file row must NOT inherit
+      // it — files render natively, with no ancestor render type.
+      meta: { page: { total: 1 }, renderType: authorRef },
+    };
+
+    let { imported, importCss } = recordImports();
+    let items = await buildRenderableSearchItems(doc, importCss);
+
+    assert.strictEqual(items.length, 1, 'one item');
+    assert.ok(
+      items[0].component,
+      'the identity-only file-meta row carries an inert component',
+    );
+    assert.strictEqual(
+      items[0].type,
+      'file-meta',
+      'the row is typed file-meta so it hydrates to a live FileDef',
+    );
+    assert.strictEqual(
+      items[0].renderType,
+      undefined,
+      'a file row carries no render type even when the collection has one',
+    );
+    assert.false(items[0].isError, 'not an error row');
+    assert.deepEqual(
+      imported,
+      [fileCssHref],
+      "the file row's css was imported via the loader",
+    );
+  });
+
+  test('a full live file-meta row yields no component, is typed file-meta, and carries no render type', async function (assert) {
+    let doc: UnifiedSearchCollectionDocument = {
+      data: [
+        {
+          type: 'file-meta',
+          id: fileUrl,
+          attributes: { name: 'hero.png' },
+          meta: { adoptsFrom: fileDefRef },
+          links: { self: fileUrl },
+        },
+      ],
+      meta: { page: { total: 1 }, renderType: authorRef },
+    };
+
+    let { imported, importCss } = recordImports();
+    let items = await buildRenderableSearchItems(doc, importCss);
+
+    assert.strictEqual(items.length, 1, 'one item');
+    assert.notOk(
+      items[0].component,
+      'a full live file-meta row carries no inert component (rendered live from the Store)',
+    );
+    assert.strictEqual(
+      items[0].type,
+      'file-meta',
+      'the row is typed file-meta',
+    );
+    assert.strictEqual(
+      items[0].renderType,
+      undefined,
+      'a file row carries no render type',
+    );
+    assert.deepEqual(imported, [], 'no css imported for a live row');
   });
 });


### PR DESCRIPTION
Extends the unified-search host consumer with FileDef parity: an HTML-backed file search result renders from prerendered HTML and hydrates to a live `FileDef`, the same treatment a card already gets.

`buildRenderableSearchItems` (`packages/host/app/lib/unified-search-results.ts`):

- Recognizes an identity-only `file-meta` row (`isIdentityOnlyFileMetaResource`) alongside the card case, builds the inert component from its `rendered-html`, and imports its scoped `css`. File rows previously fell through to the full-live branch.
- Carries each row's resource type (`card` / `file-meta`) on the renderable item, threaded to `HydratableCard @type` so a file row resolves to a live `FileDef` rather than a `CardDef`.
- A `file-meta` row carries no render type — files render natively, not as an ancestor type — even when the collection resolves one for its cards.

Additive: card rows are unchanged, and file rows keep rendering through the existing prerendered path until the UI migration adopts the unified consumer.

The selective Store inflate already keys on `meta.identityOnly` (type-agnostic), so an identity-only file row is never deposited as an attribute-less stub.

**Tests:** `buildRenderableSearchItems` over an identity-only file-meta row (inert component, `type: 'file-meta'`, css imported, no render type) and over a full-live file-meta row; card rows now assert `type: 'card'`. (`HydratableCard` file-meta hover-hydration to a live `FileDef` is covered by the hydration PR.)

---

**Stacking.** This sits on top of two open PRs:

- **#5177** (host consumer + hydration) — the base of this PR.
- **#5178** (server FileDef parity) — provides `isIdentityOnlyFileMetaResource`. Its commits appear in this diff until it lands on `main`; once both land I'll retarget this PR's base to `main` for a clean diff.

Linear: CS-11471
