### PR TITLE
Document host startup hint in dev-minimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ mise-tasks/
     bot-runner                 # Bot runner
   dev                          # Full dev stack (realm server + workers + test realms)
   dev-all                      # Host app + full dev stack (single command)
-  dev-minimal                  # Dev stack without optional realms
+  dev-minimal                  # Dev stack without optional realms (host started separately)
   dev-without-matrix           # Dev stack (expects Matrix already running)
   build:ui                     # Build boxel-icons + boxel-ui (in dependency order)
   test-services:host           # Services for host test suite
@@ -142,7 +142,7 @@ Live reloads are not available in this mode, however, if you use start the serve
 
 #### Using `mise run dev`
 
-Instead of running `mise run services:realm-server-base`, you can alternatively use `mise run dev` which also serves a few other realms on other ports--this is convenient if you wish to switch between the app and the tests without having to restart servers. For faster startup, `mise run dev-minimal` skips experiments, catalog, homepage, and submission realms. Use the environment variable `WORKER_HIGH_PRIORITY_COUNT` to add additional workers that service only user initiated requests and `WORKER_ALL_PRIORITY_COUNT` to add workers that service all jobs (system or user initiated). By default there is 1 all priority worker for each realm server.
+Instead of running `mise run services:realm-server-base`, you can alternatively use `mise run dev` which also serves a few other realms on other ports--this is convenient if you wish to switch between the app and the tests without having to restart servers. For faster startup, `mise run dev-minimal` skips experiments, catalog, homepage, and submission realms. `dev-minimal` does not start the host app — run it in a second terminal with `mise exec -- pnpm -C packages/host start` (the `mise exec` prefix loads the HTTPS dev cert env so host comes up on `https://localhost:4200`). Use the environment variable `WORKER_HIGH_PRIORITY_COUNT` to add additional workers that service only user initiated requests and `WORKER_ALL_PRIORITY_COUNT` to add workers that service all jobs (system or user initiated). By default there is 1 all priority worker for each realm server.
 
 ##### Turbo mode
 

--- a/mise-tasks/dev-minimal
+++ b/mise-tasks/dev-minimal
@@ -1,6 +1,18 @@
 #!/bin/sh
-#MISE description="Start dev stack without optional realms (experiments, catalog, homepage, submission)"
+#MISE description="Start dev stack without optional realms (experiments, catalog, homepage, submission); start host separately with 'mise exec -- pnpm -C packages/host start'"
 #MISE dir="packages/realm-server"
+
+# Host is intentionally NOT started by this task — keeping host out lets a dev
+# restart realms without losing host hot-reload state. Surface the start
+# command here so the requirement to use `mise exec` (which loads the HTTPS
+# env from lib/env-vars.sh — REALM_SERVER_TLS_CERT_FILE / _KEY_FILE / HOST_URL)
+# is visible at task start, not buried in README. A bare `pnpm -C packages/host
+# start` would bring host up plain-HTTP and break the realm-server handshake.
+cat <<'BANNER'
+[dev-minimal] Host is NOT started by this task. In a second terminal run:
+[dev-minimal]   mise exec -- pnpm -C packages/host start
+[dev-minimal] (`mise exec` is required so host picks up the HTTPS dev cert env.)
+BANNER
 
 export PATH="./node_modules/.bin:$PATH"
 


### PR DESCRIPTION
## Summary

- `mise run dev-minimal` does not start the host app (matches `mise run dev`; differs from `mise run dev-all`). Devs have to start host themselves, and the `mise exec` prefix needed to load the HTTPS dev-cert env was undocumented — a bare `pnpm -C packages/host start` brings host up plain-HTTP and breaks the realm-server handshake.
- Adds a three-line banner at the top of `mise-tasks/dev-minimal` pointing devs to `mise exec -- pnpm -C packages/host start`, extends `#MISE description=` so `mise tasks` lists the hint, and updates README's task table line and `#### Using mise run dev` prose mention to spell out the command and the `mise exec` rationale.
- No behavior change to the realm-server stack.

Closes [CS-11479](https://linear.app/cardstack/issue/CS-11479).

## Test plan

- [x] `mise tasks info dev-minimal` shows the host-startup hint in the description.
- [x] `mise run dev-minimal` prints the three-line banner before service output begins.
- [x] Following the banner — `mise exec -- pnpm -C packages/host start` in a second terminal — brings host up on `https://localhost:4200` and the realm-server is reachable from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)