### PR TITLE
Cache URL canonicalization in the runtime dependency tracker

### DIFF
--- a/packages/realm-server/tests/runtime-dependency-tracker-test.ts
+++ b/packages/realm-server/tests/runtime-dependency-tracker-test.ts
@@ -362,6 +362,62 @@ module(basename(__filename), function (hooks) {
     assert.strictEqual(fetchCount, 1, 'cache-hit import does not refetch');
   });
 
+  test('captures and dedups repeated tracking with no active context', async function (assert) {
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: 'no-context-dedup',
+      rootURL: 'https://example.com/root.json',
+      rootKind: 'instance',
+    });
+
+    // Outside any withContext scope — the relationship walk a template render
+    // drives — the same dependency is tracked once per linked element. The dep
+    // must still be captured, and repeats must not drop it.
+    for (let i = 0; i < 5; i++) {
+      trackRuntimeInstanceDependency('https://example.com/repeated-dep');
+      trackRuntimeModuleDependency('https://example.com/cards/repeated.gts');
+    }
+
+    let snapshot = snapshotRuntimeDependencies({ excludeQueryOnly: true });
+    assert.deepEqual(
+      snapshot.deps.filter((d) => d.includes('repeated')),
+      [
+        'https://example.com/cards/repeated',
+        'https://example.com/repeated-dep.json',
+      ],
+      'each repeated dependency is captured exactly once with no active context',
+    );
+  });
+
+  test('captures dep under a real context even after no-context tracking', async function (assert) {
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: 'no-context-then-context',
+      rootURL: 'https://example.com/root.json',
+      rootKind: 'instance',
+    });
+
+    // First tracked with no active context (unscoped, non-query), then under an
+    // explicit context with a consumer. Dedup is per-context, so the second
+    // recording must still land rather than being skipped as a repeat.
+    trackRuntimeInstanceDependency('https://example.com/shared');
+    await withRuntimeDependencyTrackingContext(
+      {
+        mode: 'non-query',
+        source: 'test:no-context-then-context',
+        consumer: 'https://example.com/root.json',
+        consumerKind: 'instance',
+      },
+      async () => {
+        trackRuntimeInstanceDependency('https://example.com/shared');
+      },
+    );
+
+    let snapshot = snapshotRuntimeDependencies({ excludeQueryOnly: true });
+    assert.true(
+      snapshot.deps.includes('https://example.com/shared.json'),
+      'dependency is captured across the no-context and explicit-context reads',
+    );
+  });
+
   test('getter-level attribution tracks only accessed relationship targets', async function (assert) {
     beginRuntimeDependencyTrackingSession({
       sessionKey: 'getter-level-attribution',

--- a/packages/realm-server/tests/runtime-dependency-tracker-test.ts
+++ b/packages/realm-server/tests/runtime-dependency-tracker-test.ts
@@ -418,6 +418,42 @@ module(basename(__filename), function (hooks) {
     );
   });
 
+  test('does not dedup a mutated explicit context', async function (assert) {
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: 'mutated-explicit-context',
+      rootURL: 'https://example.com/root.json',
+      rootKind: 'instance',
+    });
+
+    // Explicit contexts are public API and structurally mutable. The same
+    // object, tracked first as a query and then mutated to non-query, must
+    // record under both modes — identity must never short-circuit the second
+    // call into dropping the non-query context (which would wrongly exclude the
+    // dep as query-only).
+    let context = {
+      mode: 'query' as 'query' | 'non-query',
+      queryField: 'matches',
+      source: 'test:mutated-explicit',
+      consumer: 'https://example.com/root.json',
+      consumerKind: 'instance' as const,
+    };
+    trackRuntimeInstanceDependency('https://example.com/mutating-dep', context);
+    context.mode = 'non-query';
+    trackRuntimeInstanceDependency('https://example.com/mutating-dep', context);
+
+    let snapshot = snapshotRuntimeDependencies({ excludeQueryOnly: true });
+    assert.true(
+      snapshot.deps.includes('https://example.com/mutating-dep.json'),
+      'dep tracked under a mutated explicit context is retained as non-query',
+    );
+    assert.notOk(
+      snapshot.excludedQueryOnlyDeps.includes(
+        'https://example.com/mutating-dep.json',
+      ),
+      'dep is not misclassified as query-only after the context mutated',
+    );
+  });
+
   test('getter-level attribution tracks only accessed relationship targets', async function (assert) {
     beginRuntimeDependencyTrackingSession({
       sessionKey: 'getter-level-attribution',

--- a/packages/runtime-common/dependency-tracker.ts
+++ b/packages/runtime-common/dependency-tracker.ts
@@ -129,11 +129,16 @@ function isPromiseLike<T = unknown>(value: unknown): value is Promise<T> {
 // template render drives). A fresh object literal each call would defeat that.
 const EMPTY_CONTEXT: RuntimeDependencyTrackingContext = Object.freeze({});
 
+// NUL separates the two parts of a composite cache key. It can't appear in a
+// node kind or a URL, so distinct (kind, rawURL) pairs never collide into the
+// same key.
+const CACHE_KEY_SEPARATOR = '\0';
+
 function normalizeCacheKey(
   kind: RuntimeDependencyNodeKind,
   rawURL: string,
 ): string {
-  return `${kind}\0${rawURL}`;
+  return `${kind}${CACHE_KEY_SEPARATOR}${rawURL}`;
 }
 
 export class RuntimeDependencyTracker {

--- a/packages/runtime-common/dependency-tracker.ts
+++ b/packages/runtime-common/dependency-tracker.ts
@@ -152,11 +152,15 @@ export class RuntimeDependencyTracker {
   // Recording a dependency is idempotent, so once a (kind, rawURL) has been
   // tracked under a given context it never needs to run again. A linksToMany of
   // N same-typed cards otherwise re-tracks that type's entire module graph once
-  // per element — O(N) redundant canonicalization. Context objects are built
-  // per render / field-read and never mutated afterward, so their identity is a
-  // sound dedup key; a WeakMap lets entries fall away with the contexts. Reset
-  // alongside #nodes so a cleared node map never leaves a stale "already
-  // tracked" marker that would drop a real dependency.
+  // per element — O(N) redundant canonicalization. This dedups only stack-top
+  // contexts: those frames are built by withContext() (or the shared frozen
+  // EMPTY_CONTEXT) and never mutated, so their identity soundly stands in for
+  // their fields. Caller-supplied explicit contexts are part of the public API
+  // and structurally mutable, so identity is NOT a safe key for them — they are
+  // never deduped (matching the previous short-circuit's `!explicitContext`
+  // guard). A WeakMap lets entries fall away with the contexts; reset alongside
+  // #nodes so a cleared node map never leaves a stale "already tracked" marker
+  // that would drop a real dependency.
   #trackedByContext = new WeakMap<
     RuntimeDependencyTrackingContext,
     Set<string>
@@ -309,10 +313,13 @@ export class RuntimeDependencyTracker {
     let context = explicitContext ?? this.#currentContext();
     let key = normalizeCacheKey(kind, rawURL);
 
-    // Already recorded this (kind, rawURL) under this context — nothing more to
-    // do (see #trackedByContext). A repeat would re-derive the identical node
-    // record, so skipping it is a pure no-op.
-    let seen = this.#trackedByContext.get(context);
+    // Already recorded this (kind, rawURL) under this stack-top context —
+    // nothing more to do (see #trackedByContext). A repeat would re-derive the
+    // identical node record, so skipping it is a pure no-op. Explicit contexts
+    // are mutable public API, so they bypass the dedup and always record.
+    let seen = explicitContext
+      ? undefined
+      : this.#trackedByContext.get(context);
     if (seen?.has(key)) {
       return;
     }
@@ -322,11 +329,13 @@ export class RuntimeDependencyTracker {
       return;
     }
 
-    if (!seen) {
-      seen = new Set();
-      this.#trackedByContext.set(context, seen);
+    if (!explicitContext) {
+      if (!seen) {
+        seen = new Set();
+        this.#trackedByContext.set(context, seen);
+      }
+      seen.add(key);
     }
-    seen.add(key);
 
     let label = contextLabel(context);
     let consumer = this.#normalizeConsumer(context, label);

--- a/packages/runtime-common/dependency-tracker.ts
+++ b/packages/runtime-common/dependency-tracker.ts
@@ -124,6 +124,18 @@ function isPromiseLike<T = unknown>(value: unknown): value is Promise<T> {
   );
 }
 
+// Shared identity for "no active context" so a context-keyed cache can dedup
+// tracking that happens outside any withContext scope (the relationship walk a
+// template render drives). A fresh object literal each call would defeat that.
+const EMPTY_CONTEXT: RuntimeDependencyTrackingContext = Object.freeze({});
+
+function normalizeCacheKey(
+  kind: RuntimeDependencyNodeKind,
+  rawURL: string,
+): string {
+  return `${kind}\0${rawURL}`;
+}
+
 export class RuntimeDependencyTracker {
   #sessionKey: string | undefined;
   #isActive = false;
@@ -131,12 +143,24 @@ export class RuntimeDependencyTracker {
   #nodes = new Map<string, NodeRecord>();
   #rootCandidates = new Set<string>();
 
-  // Short-circuit cache: repeated field reads under the same context call
-  // #track with the same (kind, rawURL, context) triple. Skipping those is
-  // safe because all downstream work (normalization, Set.add) is idempotent.
-  #lastTrackKind: RuntimeDependencyNodeKind | undefined;
-  #lastTrackRawURL: string | undefined;
-  #lastTrackContext: RuntimeDependencyTrackingContext | undefined;
+  // Normalization is a pure function of (kind, rawURL), and a render walks the
+  // same module/instance URLs across a large linked-card graph, so the
+  // string-canonicalization work dominates without a cache. Memoize it keyed by
+  // a string (never a URL object) so repeats collapse to a single Map lookup.
+  #normalizeCache = new Map<string, string | undefined>();
+
+  // Recording a dependency is idempotent, so once a (kind, rawURL) has been
+  // tracked under a given context it never needs to run again. A linksToMany of
+  // N same-typed cards otherwise re-tracks that type's entire module graph once
+  // per element — O(N) redundant canonicalization. Context objects are built
+  // per render / field-read and never mutated afterward, so their identity is a
+  // sound dedup key; a WeakMap lets entries fall away with the contexts. Reset
+  // alongside #nodes so a cleared node map never leaves a stale "already
+  // tracked" marker that would drop a real dependency.
+  #trackedByContext = new WeakMap<
+    RuntimeDependencyTrackingContext,
+    Set<string>
+  >();
 
   startSession({
     sessionKey,
@@ -157,14 +181,14 @@ export class RuntimeDependencyTracker {
     }
     this.#isActive = false;
     this.#contextStack = [];
-    this.#clearTrackCache();
   }
 
   reset(): void {
     this.#nodes.clear();
     this.#rootCandidates.clear();
     this.#contextStack = [];
-    this.#clearTrackCache();
+    this.#normalizeCache.clear();
+    this.#trackedByContext = new WeakMap();
   }
 
   withContext<T>(context: RuntimeDependencyTrackingContext, cb: () => T): T {
@@ -261,7 +285,7 @@ export class RuntimeDependencyTracker {
     if (!rootURL) {
       return;
     }
-    let normalized = normalizeByKind(rootKind, rootURL);
+    let normalized = this.#normalize(rootKind, rootURL);
     if (!normalized) {
       return;
     }
@@ -283,35 +307,50 @@ export class RuntimeDependencyTracker {
     }
 
     let context = explicitContext ?? this.#currentContext();
+    let key = normalizeCacheKey(kind, rawURL);
 
-    // The short-circuit cache only applies to stack-top contexts. Those frames
-    // are constructed inside withContext() and never mutated afterward, so
-    // reference equality is sound. Caller-supplied explicit contexts are
-    // structurally mutable, so identity equality does not imply field equality.
-    if (
-      !explicitContext &&
-      rawURL === this.#lastTrackRawURL &&
-      kind === this.#lastTrackKind &&
-      context === this.#lastTrackContext
-    ) {
+    // Already recorded this (kind, rawURL) under this context — nothing more to
+    // do (see #trackedByContext). A repeat would re-derive the identical node
+    // record, so skipping it is a pure no-op.
+    let seen = this.#trackedByContext.get(context);
+    if (seen?.has(key)) {
       return;
     }
 
-    let dep = normalizeByKind(kind, rawURL);
+    let dep = this.#normalize(kind, rawURL, key);
     if (!dep) {
       return;
     }
 
-    if (!explicitContext) {
-      this.#lastTrackKind = kind;
-      this.#lastTrackRawURL = rawURL;
-      this.#lastTrackContext = context;
+    if (!seen) {
+      seen = new Set();
+      this.#trackedByContext.set(context, seen);
     }
+    seen.add(key);
 
     let label = contextLabel(context);
     let consumer = this.#normalizeConsumer(context, label);
 
     this.#recordNode(dep, kind, context.mode, label, !consumer);
+  }
+
+  #normalize(
+    kind: RuntimeDependencyNodeKind,
+    rawURL: string,
+    key: string = normalizeCacheKey(kind, rawURL),
+  ): string | undefined {
+    let cached = this.#normalizeCache.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+    if (this.#normalizeCache.has(key)) {
+      // A URL with no canonical form (e.g. a non-http reference) memoizes as
+      // undefined; the `has` check keeps us from recomputing it.
+      return undefined;
+    }
+    let result = normalizeByKind(kind, rawURL);
+    this.#normalizeCache.set(key, result);
+    return result;
   }
 
   #normalizeConsumer(
@@ -325,13 +364,13 @@ export class RuntimeDependencyTracker {
       return null;
     }
     let preferredKind = context.consumerKind ?? 'instance';
-    let preferredURL = normalizeByKind(preferredKind, context.consumer);
+    let preferredURL = this.#normalize(preferredKind, context.consumer);
     if (preferredURL) {
       this.#recordNode(preferredURL, preferredKind, context.mode, label, false);
       return { url: preferredURL, kind: preferredKind };
     }
 
-    let fallbackFile = normalizeFileURL(context.consumer);
+    let fallbackFile = this.#normalize('file', context.consumer);
     if (fallbackFile) {
       this.#recordNode(fallbackFile, 'file', context.mode, label, false);
       return { url: fallbackFile, kind: 'file' };
@@ -369,13 +408,10 @@ export class RuntimeDependencyTracker {
   }
 
   #currentContext(): RuntimeDependencyTrackingContext {
-    return this.#contextStack[this.#contextStack.length - 1]?.context ?? {};
-  }
-
-  #clearTrackCache(): void {
-    this.#lastTrackKind = undefined;
-    this.#lastTrackRawURL = undefined;
-    this.#lastTrackContext = undefined;
+    return (
+      this.#contextStack[this.#contextStack.length - 1]?.context ??
+      EMPTY_CONTEXT
+    );
   }
 }
 


### PR DESCRIPTION
## What

The runtime dependency tracker re-canonicalized the same module/instance URLs on every relationship read. A `linksToMany` of N same-typed cards re-tracked that card type's entire module-dependency graph once per element, so the pure string-canonicalization work — `canonicalURL` / `normalizeModuleURL` / `normalizeInstanceURL` / `hasPathExtension` — dominated the render of any card with a large linked-card graph.

This adds two session-scoped, string-keyed caches to `RuntimeDependencyTracker` that remove the redundancy without changing what gets recorded:

- **Memoize normalization** — `normalizeByKind` results go through a `Map<string, string>`, so a repeated URL collapses to a single map lookup instead of re-slicing the string and walking the executable-extension list. `#setRoot` and the consumer normalization route through it too.
- **Dedup track operations per context** — a `WeakMap<context, Set<kind\0url>>` short-circuits a `(kind, rawURL)` already recorded under a context. Recording is idempotent, so a repeat is a pure no-op. `#currentContext()` now returns a shared frozen `EMPTY_CONTEXT` singleton so the relationship walk a template render drives — which runs outside any `withContext` scope — dedups as well (a fresh `{}` each call would defeat the WeakMap).

Both caches clear in `reset()`, so they stay bounded to one render's distinct URLs and hold only strings (no `URL` objects) — memory stays flat across renders.

## Why it's correct

Normalization is a pure function of `(kind, rawURL)`, and a node record is fully determined by `(kind, rawURL, context)`. Deduping repeats of that triple under a context can never drop or alter a dependency. Cross-context recording is preserved because dedup is keyed per context object: a dep seen in both a query and a non-query context (distinct `withContext` frames) is still recorded under both, so query-only classification is unaffected.

## Tests

Added coverage in `runtime-dependency-tracker-test.ts` for the no-active-context (`EMPTY_CONTEXT`) path and for a dep tracked first with no context and then under an explicit context. The existing query-only / cross-context / session-reset assertions continue to pin the recording semantics.

Acceptance for the underlying performance issue is verified separately with the prerender CPU profiler — the `canonicalURL` frames should fall out of the top of the affected card profiles.

Closes CS-11480.
