### PR TITLE
Fix realm config chooser restriction in code submode

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1568,6 +1568,7 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
           displayContainer?: boolean;
           typeConstraint?: ResolvedCodeRef;
           lockConsumingRealm?: boolean;
+          consumingRealm?: URL;
         };
       };
       Blocks: {};
@@ -1585,6 +1586,7 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
                   @brokenLink={{broken}}
                   @typeConstraint={{@typeConstraint}}
                   @lockConsumingRealm={{@lockConsumingRealm}}
+                  @consumingRealm={{@consumingRealm}}
                   @createCard={{cardCrudFunctions.createCard}}
                   ...attributes
                 />

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -57,6 +57,15 @@ export interface BoxComponentSignature {
        * a card from another realm. UI hint only; no runtime validation.
        */
       lockConsumingRealm?: boolean;
+      /**
+       * Explicit consuming-realm URL passed through to the linksTo /
+       * linksToMany editor. The editor normally derives this from a
+       * `RealmURLContext` provided by the surrounding stack item; this
+       * lets callers in contexts without a stack item (e.g. code
+       * submode's spec preview) thread the owning card's realm in
+       * directly.
+       */
+      consumingRealm?: URL;
     };
   };
   Blocks: {};

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -51,19 +51,22 @@ export interface BoxComponentSignature {
       displayContainer?: boolean;
       typeConstraint?: ResolvedCodeRef;
       /**
-       * When true (only meaningful on linksTo / linksToMany editors),
-       * hard-scope the card chooser to the consuming realm — the realm
-       * picker in the catalog modal is locked and the user cannot pick
-       * a card from another realm. UI hint only; no runtime validation.
+       * Only honoured by the `linksTo` editor today — the
+       * `linksToMany` editor does not yet thread this arg through.
+       * When true, hard-scope the card chooser to the consuming
+       * realm: the realm picker in the catalog modal is locked and
+       * the user cannot pick a card from another realm. UI hint
+       * only; no runtime validation.
        */
       lockConsumingRealm?: boolean;
       /**
-       * Explicit consuming-realm URL passed through to the linksTo /
-       * linksToMany editor. The editor normally derives this from a
-       * `RealmURLContext` provided by the surrounding stack item; this
-       * lets callers in contexts without a stack item (e.g. code
-       * submode's spec preview) thread the owning card's realm in
-       * directly.
+       * Only honoured by the `linksTo` editor today — the
+       * `linksToMany` editor does not yet thread this arg through.
+       * Explicit consuming-realm URL passed through to LinksToEditor.
+       * The editor normally derives this from a `RealmURLContext`
+       * provided by the surrounding stack item; this lets callers in
+       * contexts without a stack item (e.g. code submode's spec
+       * preview) thread the owning card's realm in directly.
        */
       consumingRealm?: URL;
     };

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -57,6 +57,16 @@ interface Signature {
      * is locked. UI hint only; no runtime validation.
      */
     lockConsumingRealm?: boolean;
+    /**
+     * Explicit consuming-realm override. Without this, the editor
+     * derives the consuming realm from the `RealmURLContext` provided
+     * by the surrounding stack item — but in code submode the rule
+     * editor renders outside any stack item, so context is absent.
+     * Callers that know the owning card's realm (e.g. by reading
+     * `model[realmURL]`) can pass it directly here so the chooser
+     * filters correctly in both interact and code submodes.
+     */
+    consumingRealm?: URL;
     createCard?: CreateCardFn;
   };
 }
@@ -231,16 +241,22 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
     if (this.args.typeConstraint) {
       type = await getNarrowestType(this.args.typeConstraint, type, myLoader());
     }
+    // Prefer the explicit `@consumingRealm` arg over the
+    // `RealmURLContext` consumption, so callers in contexts that don't
+    // provide the context (e.g. code submode's playground / spec
+    // preview, where there is no stack item) can still scope the
+    // chooser to the owning card's realm.
+    let consumingRealm = this.args.consumingRealm ?? this.realmURL;
     let cardId = await chooseCard(
       { filter: { type } },
       {
         offerToCreate: {
           ref: type,
           relativeTo: undefined,
-          realmURL: this.realmURL,
+          realmURL: consumingRealm,
         },
         createNewCard: this.args.createCard,
-        consumingRealm: this.realmURL,
+        consumingRealm,
         lockConsumingRealm: this.args.lockConsumingRealm,
       },
     );

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -247,6 +247,14 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
     // preview, where there is no stack item) can still scope the
     // chooser to the owning card's realm.
     let consumingRealm = this.args.consumingRealm ?? this.realmURL;
+    // Only honor `@lockConsumingRealm` when a realm is actually known.
+    // Locking without a consuming realm leaves the picker disabled but
+    // unscoped — search results would span every realm and the user
+    // couldn't change the (effectively empty) selection. Treat the
+    // lock as advisory and let the picker stay interactive if there's
+    // no realm to lock to.
+    let lockConsumingRealm =
+      this.args.lockConsumingRealm === true && consumingRealm != null;
     let cardId = await chooseCard(
       { filter: { type } },
       {
@@ -257,7 +265,7 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
         },
         createNewCard: this.args.createCard,
         consumingRealm,
-        lockConsumingRealm: this.args.lockConsumingRealm,
+        lockConsumingRealm,
       },
     );
     if (cardId) {

--- a/packages/base/realm-config.gts
+++ b/packages/base/realm-config.gts
@@ -6,6 +6,7 @@ import {
   contains,
   containsMany,
   linksTo,
+  realmURL,
 } from './card-api';
 import BooleanField from './boolean';
 import StringField from './string';
@@ -102,6 +103,19 @@ class RoutingRuleEdit extends Component<typeof RoutingRuleField> {
     this.args.model.path = `/${trimmed}`;
   }
 
+  // The chooser is locked to the consuming realm; pass it through
+  // explicitly rather than letting LinksToEditor read it from
+  // `RealmURLContext`. The context is only provided by the operator-mode
+  // stack item, so in code submode (where the realm config renders via
+  // the playground / spec preview, outside any stack item) `this.realmURL`
+  // in LinksToEditor is undefined and the chooser falls back to
+  // unscoped search across every realm. The field's own `[realmURL]`
+  // getter is populated by `propagateRealmContext` when the owning
+  // RealmConfig card loads, so it works in either submode.
+  get consumingRealm(): URL | undefined {
+    return this.args.model[realmURL];
+  }
+
   <template>
     <div class='routing-rule-edit' data-test-routing-rule-edit>
       <div class='row'>
@@ -118,7 +132,10 @@ class RoutingRuleEdit extends Component<typeof RoutingRuleField> {
         </div>
         <span class='arrow' aria-hidden='true'>→</span>
         <div class='instance-cell'>
-          <@fields.instance @lockConsumingRealm={{true}} />
+          <@fields.instance
+            @lockConsumingRealm={{true}}
+            @consumingRealm={{this.consumingRealm}}
+          />
         </div>
       </div>
       {{#if this.pathWarning}}

--- a/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
+++ b/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
@@ -281,6 +281,10 @@ module(
           realmConfig as InstanceType<typeof cardApi.CardDef>,
           'edit',
         );
+        // Wait for the routing-rule editor to render its inner
+        // LinksToEditor, which only happens once the card's containsMany
+        // iteration mounts each rule.
+        await waitFor('[data-test-add-new="instance"]');
         await click('[data-test-add-new="instance"]');
 
         assert.ok(capturedOpts, 'chooseCard was invoked');

--- a/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
+++ b/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
@@ -5,12 +5,17 @@ import { getService } from '@universal-ember/test-support';
 
 import { module, test } from 'qunit';
 
-import { baseRealm } from '@cardstack/runtime-common';
+import {
+  baseRealm,
+  PermissionsContextName,
+  type Permissions,
+} from '@cardstack/runtime-common';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
 import {
   testRealmURL,
+  provideConsumeContext,
   setupLocalIndexing,
   setupIntegrationTestRealm,
   setupOperatorModeStateCleanup,
@@ -275,39 +280,22 @@ module(
         },
       };
 
+      // LinksToEditor only renders its add-new affordance when
+      // `permissions.canWrite` is truthy — that's normally provided by
+      // the stack item (interact) or the playground panel (code) via
+      // `PermissionsContext`. Without operator-mode mounted, the test
+      // has to provide it explicitly, otherwise LinksToEditor renders
+      // its "- Empty -" placeholder and `[data-test-add-new]` is
+      // missing.
+      let permissions: Permissions = { canRead: true, canWrite: true };
+      provideConsumeContext(PermissionsContextName, permissions);
+
       try {
         await renderCard(
           getService('loader-service').loader,
           realmConfig as InstanceType<typeof cardApi.CardDef>,
           'edit',
         );
-        // [diagnostic] surface what actually rendered
-        console.log(
-          '[lock-diag] renderCard state',
-          JSON.stringify({
-            realmConfigExists: !!realmConfig,
-            realmConfigConstructor:
-              (realmConfig as any)?.constructor?.name ?? null,
-            hostRoutingRulesLength:
-              (realmConfig as any)?.hostRoutingRules?.length ?? null,
-            hasRealmConfigEdit: !!document.querySelector(
-              '[data-test-realm-config-edit]',
-            ),
-            hasRoutingRuleEdit: !!document.querySelector(
-              '[data-test-routing-rule-edit]',
-            ),
-            hasLinksToEditor: !!document.querySelector(
-              '[data-test-links-to-editor]',
-            ),
-            hasAddNew: !!document.querySelector(
-              '[data-test-add-new="instance"]',
-            ),
-            bodyTextSample: document.body?.innerText?.slice(0, 200) ?? null,
-          }),
-        );
-        // Wait for the routing-rule editor to render its inner
-        // LinksToEditor, which only happens once the card's containsMany
-        // iteration mounts each rule.
         await waitFor('[data-test-add-new="instance"]');
         await click('[data-test-add-new="instance"]');
 

--- a/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
+++ b/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
@@ -123,6 +123,24 @@ module(
       assert
         .dom('[data-test-card-catalog-modal] [data-test-realm-picker]')
         .hasAttribute('aria-disabled', 'true', 'the realm picker is locked');
+      // The picker's selected pill must show the consuming realm, not
+      // the "All" select-all option. If `consumingRealm` doesn't reach
+      // the chooser, `initialSelectedRealmsForPanel` returns undefined,
+      // `selectedRealms` stays empty, and `pickerSelected` falls back to
+      // the `Select All (...)` option labeled "All" — which means the
+      // search is unscoped (the original code-submode bug).
+      assert
+        .dom('[data-test-card-catalog-modal] [data-test-realm-picker]')
+        .containsText(
+          realmName,
+          'the realm picker is scoped to the consuming realm',
+        );
+      assert
+        .dom('[data-test-card-catalog-modal] [data-test-realm-picker]')
+        .doesNotIncludeText(
+          'Select All',
+          'the picker is not showing the unscoped "Select All" pill',
+        );
       assert
         .dom(
           '[data-test-card-catalog-modal] [data-test-realm-picker] [data-test-boxel-picker-remove-button]',

--- a/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
+++ b/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
@@ -16,7 +16,7 @@ import {
   setupOperatorModeStateCleanup,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
-import { renderComponent } from '../../helpers/render-component';
+import { renderCard, renderComponent } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
 
 const realmName = 'Local Workspace';
@@ -215,6 +215,87 @@ module(
       assert
         .dom('[data-test-duplicate-path-warning]')
         .containsText('/', 'the duplicate banner names the conflicting path');
+    });
+
+    test('the chooser gets a consuming realm even when no RealmURLContext is provided (code submode)', async function (assert) {
+      // The interact-submode test above renders the realm config
+      // through an operator-mode stack item, which provides
+      // `RealmURLContext` — so LinksToEditor could derive
+      // `consumingRealm` either from that context or from the
+      // explicit `@consumingRealm` arg threaded by RoutingRuleEdit.
+      // In code submode the realm config renders through the
+      // playground / spec preview, OUTSIDE any stack item, so
+      // `RealmURLContext` is absent.
+      //
+      // Reproduce that condition directly: load the realm config from
+      // the realm (so its FieldDef instances have `[realmContext]`
+      // populated by `propagateRealmContext`) and render it via
+      // `renderCard`, which does not provide any operator-mode
+      // context. Then stub the global card-chooser registration to
+      // capture the opts that `chooseCard()` was invoked with, so the
+      // test can prove `consumingRealm` (and a derived
+      // `lockConsumingRealm`) flow through the model-level derivation
+      // rather than the context fallback.
+      let cardApi: typeof import('https://cardstack.com/base/card-api') =
+        await getService('loader-service').loader.import(
+          `${baseRealm.url}card-api`,
+        );
+
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        permissions: {
+          '@testuser:localhost': ['read', 'write', 'realm-owner'],
+        },
+        contents: {
+          '.realm.json': `{ "name": "${realmName}" }`,
+          'realm.json': {
+            data: {
+              type: 'card',
+              attributes: { hostRoutingRules: [{ path: '/docs' }] },
+              meta: {
+                adoptsFrom: {
+                  module: 'https://cardstack.com/base/realm-config',
+                  name: 'RealmConfig',
+                },
+              },
+            },
+          },
+        },
+      });
+
+      let store = getService('store');
+      let realmConfig = await store.get(`${testRealmURL}realm`);
+
+      let capturedOpts: any;
+      let originalChooser = (globalThis as any)._CARDSTACK_CARD_CHOOSER;
+      (globalThis as any)._CARDSTACK_CARD_CHOOSER = {
+        chooseCard: async (_query: any, opts: any) => {
+          capturedOpts = opts;
+          return undefined;
+        },
+      };
+
+      try {
+        await renderCard(
+          getService('loader-service').loader,
+          realmConfig as InstanceType<typeof cardApi.CardDef>,
+          'edit',
+        );
+        await click('[data-test-add-new="instance"]');
+
+        assert.ok(capturedOpts, 'chooseCard was invoked');
+        assert.strictEqual(
+          (capturedOpts?.consumingRealm as URL | undefined)?.href,
+          testRealmURL,
+          'consumingRealm reaches the chooser via @consumingRealm, not RealmURLContext',
+        );
+        assert.true(
+          capturedOpts?.lockConsumingRealm,
+          'lockConsumingRealm is honored when a consumingRealm is actually present',
+        );
+      } finally {
+        (globalThis as any)._CARDSTACK_CARD_CHOOSER = originalChooser;
+      }
     });
 
     test('typing into the path input always stores a leading slash', async function (assert) {

--- a/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
+++ b/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
@@ -281,6 +281,30 @@ module(
           realmConfig as InstanceType<typeof cardApi.CardDef>,
           'edit',
         );
+        // [diagnostic] surface what actually rendered
+        console.log(
+          '[lock-diag] renderCard state',
+          JSON.stringify({
+            realmConfigExists: !!realmConfig,
+            realmConfigConstructor:
+              (realmConfig as any)?.constructor?.name ?? null,
+            hostRoutingRulesLength:
+              (realmConfig as any)?.hostRoutingRules?.length ?? null,
+            hasRealmConfigEdit: !!document.querySelector(
+              '[data-test-realm-config-edit]',
+            ),
+            hasRoutingRuleEdit: !!document.querySelector(
+              '[data-test-routing-rule-edit]',
+            ),
+            hasLinksToEditor: !!document.querySelector(
+              '[data-test-links-to-editor]',
+            ),
+            hasAddNew: !!document.querySelector(
+              '[data-test-add-new="instance"]',
+            ),
+            bodyTextSample: document.body?.innerText?.slice(0, 200) ?? null,
+          }),
+        );
         // Wait for the routing-rule editor to render its inner
         // LinksToEditor, which only happens once the card's containsMany
         // iteration mounts each rule.

--- a/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
+++ b/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
@@ -123,23 +123,22 @@ module(
       assert
         .dom('[data-test-card-catalog-modal] [data-test-realm-picker]')
         .hasAttribute('aria-disabled', 'true', 'the realm picker is locked');
-      // The picker's selected pill must show the consuming realm, not
-      // the "All" select-all option. If `consumingRealm` doesn't reach
-      // the chooser, `initialSelectedRealmsForPanel` returns undefined,
-      // `selectedRealms` stays empty, and `pickerSelected` falls back to
-      // the `Select All (...)` option labeled "All" — which means the
+      // The picker's selected pill must NOT be the "All" / "Select All"
+      // option. If `consumingRealm` doesn't reach the chooser,
+      // `initialSelectedRealmsForPanel` returns undefined,
+      // `selectedRealms` stays empty, and `pickerSelected` falls back
+      // to the `Select All (...)` option (labeled "All") — meaning
       // search is unscoped (the original code-submode bug).
+      // Check the selected-pill's own `data-test-boxel-picker-selected-item`
+      // value rather than the realm name, because the user-visible
+      // realm name comes from `realm.info()` and shows the
+      // "Unnamed Workspace" placeholder until that async fetch resolves.
       assert
-        .dom('[data-test-card-catalog-modal] [data-test-realm-picker]')
-        .containsText(
-          realmName,
-          'the realm picker is scoped to the consuming realm',
-        );
-      assert
-        .dom('[data-test-card-catalog-modal] [data-test-realm-picker]')
-        .doesNotIncludeText(
-          'Select All',
-          'the picker is not showing the unscoped "Select All" pill',
+        .dom(
+          '[data-test-card-catalog-modal] [data-test-realm-picker] [data-test-boxel-picker-selected-item="All"]',
+        )
+        .doesNotExist(
+          'the realm picker is scoped to a specific realm, not the unscoped "All" select-all pill',
         );
       assert
         .dom(


### PR DESCRIPTION
The chooser restriction for host routing rules is working in interact submode:

<img width="3134" height="2008" alt="CleanShot 2026-06-10 at 10 27 12@2x" src="https://github.com/user-attachments/assets/7c3ac8d9-a5cd-419b-b439-c9aa30028138" />

but not code submode:

<img width="3134" height="2008" alt="CleanShot 2026-06-10 at 10 27 59@2x" src="https://github.com/user-attachments/assets/6143f6ab-559b-4c8f-b08e-3ff9a24acdca" />

Now it does:

<img width="2742" height="2164" alt="CleanShot 2026-06-10 at 14 47 10@2x" src="https://github.com/user-attachments/assets/a1f4b44c-5cd4-437c-bccf-eaef9b64aa9f" />
