### PR TITLE
host: Restore Ember Inspector with Vite

### DIFF
--- a/packages/host/app/app.ts
+++ b/packages/host/app/app.ts
@@ -3,6 +3,7 @@ import './lib/public-path'; // this should be first
 import './lib/setup-globals'; // This should be second
 import './deprecation-workflow';
 import Application from '@ember/application';
+import { importSync, isDevelopingApp, macroCondition } from '@embroider/macros';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
@@ -17,6 +18,16 @@ export default class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver.withModules(compatModules);
+
+  // Let ember-inspector reach ember-source modules in development. The macro
+  // strips this assignment (and the import) from production builds entirely.
+  inspector = macroCondition(isDevelopingApp())
+    ? (
+        importSync('@embroider/legacy-inspector-support/ember-source-4.12') as {
+          default: (app: Application) => void;
+        }
+      ).default(this)
+    : undefined;
 }
 
 loadInitializers(App, config.modulePrefix, compatModules);

--- a/packages/host/app/app.ts
+++ b/packages/host/app/app.ts
@@ -3,7 +3,7 @@ import './lib/public-path'; // this should be first
 import './lib/setup-globals'; // This should be second
 import './deprecation-workflow';
 import Application from '@ember/application';
-import { importSync, isDevelopingApp, macroCondition } from '@embroider/macros';
+import setupInspector from '@embroider/legacy-inspector-support/ember-source-4.12';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
@@ -19,15 +19,7 @@ export default class App extends Application {
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver.withModules(compatModules);
 
-  // Let ember-inspector reach ember-source modules in development. The macro
-  // strips this assignment (and the import) from production builds entirely.
-  inspector = macroCondition(isDevelopingApp())
-    ? (
-        importSync('@embroider/legacy-inspector-support/ember-source-4.12') as {
-          default: (app: Application) => void;
-        }
-      ).default(this)
-    : undefined;
+  inspector = setupInspector(this);
 }
 
 loadInitializers(App, config.modulePrefix, compatModules);

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -60,6 +60,7 @@
     "@embroider/compat": "^4.0.3",
     "@embroider/config-meta-loader": "^1.0.0",
     "@embroider/core": "^4.0.3",
+    "@embroider/legacy-inspector-support": "^0.1.3",
     "@embroider/macros": "^1.16.5",
     "@embroider/vite": "^1.1.1",
     "@floating-ui/dom": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1504,10 +1504,10 @@ importers:
         version: 1.16.13(@glint/template@1.7.7)
       '@embroider/test-setup':
         specifier: ^4.0.0
-        version: 4.0.0(@embroider/compat@3.9.4(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.10(@glint/template@1.7.7))(@glint/template@1.7.7))(@embroider/core@3.5.10(@glint/template@1.7.7))(@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14)))
+        version: 4.0.0(@embroider/compat@3.9.4(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.10(@glint/template@1.7.7))(@glint/template@1.7.7))(@embroider/core@3.5.10(@glint/template@1.7.7))(@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2))
       '@embroider/webpack':
         specifier: ^4.0.4
-        version: 4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14))
+        version: 4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.1.1
@@ -1558,7 +1558,7 @@ importers:
         version: 8.0.1(@babel/core@7.29.0)(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/test-waiters@4.1.1(@glint/template@1.7.7))(axe-core@4.11.4)(qunit@2.25.0)
       ember-auto-import:
         specifier: ^2.7.2
-        version: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
+        version: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
       ember-cli:
         specifier: ^5.4.1
         version: 5.12.0(@babel/core@7.29.0)(@types/node@24.12.4)
@@ -1609,7 +1609,7 @@ importers:
         version: 1.0.0(patch_hash=0e5253a008cc7bf02424d786e7a8fb2397bc48962f3cd1443f2c0fdd8200c96d)
       ember-freestyle:
         specifier: ^0.22.0
-        version: 0.22.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2(postcss@8.5.14))
+        version: 0.22.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2)
       ember-load-initializers:
         specifier: ^3.0.0
         version: 3.0.1(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
@@ -1687,7 +1687,7 @@ importers:
         version: 5.9.3
       webpack:
         specifier: 'catalog:'
-        version: 5.106.2(postcss@8.5.14)
+        version: 5.106.2
 
   packages/catalog:
     dependencies:
@@ -2038,6 +2038,9 @@ importers:
       '@embroider/core':
         specifier: ^4.0.3
         version: 4.4.7(@glint/template@1.7.7)
+      '@embroider/legacy-inspector-support':
+        specifier: ^0.1.3
+        version: 0.1.3
       '@embroider/macros':
         specifier: ^1.16.5
         version: 1.16.13(@glint/template@1.7.7)
@@ -2070,7 +2073,7 @@ importers:
         version: 1.31.13(typescript@5.9.3)
       '@percy/ember':
         specifier: 'catalog:'
-        version: 5.0.1(@babel/core@7.29.0)(@glint/template@1.7.7)(webpack@5.106.2)
+        version: 5.0.1(@babel/core@7.29.0)(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
       '@rollup/plugin-babel':
         specifier: ^6.0.4
         version: 6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.3)
@@ -2178,7 +2181,7 @@ importers:
         version: 1.0.3(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
       ember-auto-import:
         specifier: ^2.7.2
-        version: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
+        version: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
       ember-basic-dropdown:
         specifier: 8.0.4
         version: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
@@ -2229,13 +2232,13 @@ importers:
         version: 2.0.0(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
       ember-exam:
         specifier: ^10.1.0
-        version: 10.1.0(@glint/template@1.7.7)(ember-qunit@9.0.4(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.106.2)
+        version: 10.1.0(@glint/template@1.7.7)(ember-qunit@9.0.4(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.106.2(postcss@8.5.14))
       ember-focus-trap:
         specifier: ^1.0.1
         version: 1.2.0(@babel/core@7.29.0)
       ember-freestyle:
         specifier: ^0.20.0
-        version: 0.20.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2)
+        version: 0.20.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2(postcss@8.5.14))
       ember-keyboard:
         specifier: ^8.2.1
         version: 8.2.1(@babel/core@7.29.0)(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))
@@ -4300,6 +4303,9 @@ packages:
     peerDependencies:
       '@embroider/core': ^3.5.9
       webpack: ^5
+
+  '@embroider/legacy-inspector-support@0.1.3':
+    resolution: {integrity: sha512-0VzD1xExkT78a1CUiW8wZ5VZDL4bVyMSc3t8E/RiAW1X6TlyKIA/m6zoQgsQtQIiiTPPxH0/1Tdd0F7b5//etw==}
 
   '@embroider/macros@1.16.13':
     resolution: {integrity: sha512-2oGZh0m1byBYQFWEa8b2cvHJB2LzaF3DdMCLCqcRAccABMROt1G3sultnNCT30NhfdGWMEsJOT3Jm4nFxXmTRw==}
@@ -16951,11 +16957,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/babel-loader-9@3.1.3(@embroider/core@3.5.10(@glint/template@1.7.7))(supports-color@8.1.1)(webpack@5.106.2(postcss@8.5.14))':
+  '@embroider/babel-loader-9@3.1.3(@embroider/core@3.5.10(@glint/template@1.7.7))(supports-color@8.1.1)(webpack@5.106.2)':
     dependencies:
       '@babel/core': 7.29.0(supports-color@8.1.1)
       '@embroider/core': 3.5.10(@glint/template@1.7.7)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.2(postcss@8.5.14))
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.2)
     transitivePeerDependencies:
       - supports-color
       - webpack
@@ -17138,10 +17144,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/hbs-loader@3.0.5(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14))':
+  '@embroider/hbs-loader@3.0.5(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2)':
     dependencies:
       '@embroider/core': 3.5.10(@glint/template@1.7.7)
-      webpack: 5.106.2(postcss@8.5.14)
+      webpack: 5.106.2
+
+  '@embroider/legacy-inspector-support@0.1.3':
+    dependencies:
+      '@embroider/addon-shim': 1.10.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@embroider/macros@1.16.13(@glint/template@1.7.7)':
     dependencies:
@@ -17231,14 +17243,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/test-setup@4.0.0(@embroider/compat@3.9.4(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.10(@glint/template@1.7.7))(@glint/template@1.7.7))(@embroider/core@3.5.10(@glint/template@1.7.7))(@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14)))':
+  '@embroider/test-setup@4.0.0(@embroider/compat@3.9.4(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.10(@glint/template@1.7.7))(@glint/template@1.7.7))(@embroider/core@3.5.10(@glint/template@1.7.7))(@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2))':
     dependencies:
       lodash: 4.18.1
       resolve: 1.22.12
     optionalDependencies:
       '@embroider/compat': 3.9.4(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.10(@glint/template@1.7.7))(@glint/template@1.7.7)
       '@embroider/core': 3.5.10(@glint/template@1.7.7)
-      '@embroider/webpack': 4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14))
+      '@embroider/webpack': 4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2)
 
   '@embroider/util@1.13.1(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))':
     dependencies:
@@ -17277,32 +17289,32 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14))':
+  '@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2)':
     dependencies:
       '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/preset-env': 7.29.5(@babel/core@7.29.0)(supports-color@8.1.1)
-      '@embroider/babel-loader-9': 3.1.3(@embroider/core@3.5.10(@glint/template@1.7.7))(supports-color@8.1.1)(webpack@5.106.2(postcss@8.5.14))
+      '@embroider/babel-loader-9': 3.1.3(@embroider/core@3.5.10(@glint/template@1.7.7))(supports-color@8.1.1)(webpack@5.106.2)
       '@embroider/core': 3.5.10(@glint/template@1.7.7)
-      '@embroider/hbs-loader': 3.0.5(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14))
+      '@embroider/hbs-loader': 3.0.5(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2)
       '@embroider/shared-internals': 2.9.2(supports-color@8.1.1)
       '@types/supports-color': 8.1.3
       assert-never: 1.4.0
-      babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.106.2(postcss@8.5.14))
-      css-loader: 5.2.7(webpack@5.106.2(postcss@8.5.14))
+      babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.106.2)
+      css-loader: 5.2.7(webpack@5.106.2)
       csso: 4.2.0
       debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       fs-extra: 9.1.0
       jsdom: 25.0.1(supports-color@8.1.1)
       lodash: 4.18.1
-      mini-css-extract-plugin: 2.10.2(webpack@5.106.2(postcss@8.5.14))
+      mini-css-extract-plugin: 2.10.2(webpack@5.106.2)
       semver: 7.8.0
       source-map-url: 0.4.1
-      style-loader: 2.0.0(patch_hash=579dd92e6adabd45669f9a99a01c6c28c97488c7bf4ee0d6c1c622a14592e4c8)(webpack@5.106.2(postcss@8.5.14))
+      style-loader: 2.0.0(patch_hash=579dd92e6adabd45669f9a99a01c6c28c97488c7bf4ee0d6c1c622a14592e4c8)(webpack@5.106.2)
       supports-color: 8.1.1
       terser: 5.47.1
-      thread-loader: 3.0.4(webpack@5.106.2(postcss@8.5.14))
-      webpack: 5.106.2(postcss@8.5.14)
+      thread-loader: 3.0.4(webpack@5.106.2)
+      webpack: 5.106.2
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -18849,10 +18861,10 @@ snapshots:
 
   '@percy/dom@1.31.13': {}
 
-  '@percy/ember@5.0.1(@babel/core@7.29.0)(@glint/template@1.7.7)(webpack@5.106.2)':
+  '@percy/ember@5.0.1(@babel/core@7.29.0)(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))':
     dependencies:
       '@percy/sdk-utils': 1.31.13
-      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
+      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
       ember-cli-babel: 8.3.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -20706,12 +20718,12 @@ snapshots:
       schema-utils: 2.7.1
       webpack: 5.106.2
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.2(postcss@8.5.14)):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.2):
     dependencies:
       '@babel/core': 7.29.0(supports-color@8.1.1)
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.106.2(postcss@8.5.14)
+      webpack: 5.106.2
 
   babel-plugin-debug-macros@0.2.0(@babel/core@7.29.0):
     dependencies:
@@ -23553,13 +23565,13 @@ snapshots:
       content-tag: 4.2.0
       oxc-parser: 0.130.0
 
-  ember-exam@10.1.0(@glint/template@1.7.7)(ember-qunit@9.0.4(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.106.2):
+  ember-exam@10.1.0(@glint/template@1.7.7)(ember-qunit@9.0.4(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.106.2(postcss@8.5.14)):
     dependencies:
       '@babel/core': 7.29.0(supports-color@8.1.1)
       chalk: 5.6.2
       cli-table3: 0.6.5
       debug: 4.4.3(supports-color@8.1.1)
-      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
+      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
       ember-cli-babel: 8.3.1(@babel/core@7.29.0)
       ember-qunit: 9.0.4(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0)
       ember-source: 6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5)
@@ -23584,6 +23596,31 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
+
+  ember-freestyle@0.20.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2(postcss@8.5.14)):
+    dependencies:
+      '@ember/render-modifiers': 2.1.0(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
+      '@ember/string': 4.0.1
+      '@glimmer/component': 2.1.1
+      '@glimmer/tracking': 1.1.2
+      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
+      ember-cli-babel: 7.26.11
+      ember-cli-htmlbars: 6.3.0
+      ember-cli-typescript: 5.3.0
+      ember-focus-trap: 1.2.0(@babel/core@7.29.0)
+      ember-modifier: 4.3.0(@babel/core@7.29.0)
+      ember-named-blocks-polyfill: 0.2.5
+      ember-truth-helpers: 4.0.3(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
+      json-formatter-js: 2.5.23
+      macro-decorators: 0.1.2
+      strip-indent: 3.0.0
+      tracked-built-ins: 4.1.2(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - ember-source
+      - supports-color
+      - webpack
 
   ember-freestyle@0.20.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2):
     dependencies:
@@ -23610,12 +23647,12 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-freestyle@0.22.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2(postcss@8.5.14)):
+  ember-freestyle@0.22.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2):
     dependencies:
       '@ember/string': 4.0.1
       '@glimmer/component': 2.1.1
       '@glimmer/tracking': 1.1.2
-      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
+      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
       ember-cli-babel: 8.3.1(@babel/core@7.29.0)
       ember-cli-htmlbars: 6.3.0
       ember-cli-typescript: 5.3.0
@@ -29853,14 +29890,14 @@ snapshots:
     dependencies:
       editions: 6.22.0
 
-  thread-loader@3.0.4(webpack@5.106.2(postcss@8.5.14)):
+  thread-loader@3.0.4(webpack@5.106.2):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.2
       loader-utils: 2.0.4
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      webpack: 5.106.2(postcss@8.5.14)
+      webpack: 5.106.2
 
   through2@3.0.2:
     dependencies:


### PR DESCRIPTION
The inspector hasn’t been working:

<img width="2742" height="2164" alt="CleanShot 2026-06-10 at 10 36 01@2x" src="https://github.com/user-attachments/assets/f81ca228-ae4e-40c7-8965-802ee5ebf405" />

This restores it:

<img width="3134" height="2300" alt="CleanShot 2026-06-10 at 11 34 14@2x" src="https://github.com/user-attachments/assets/e45f63ab-167c-4642-8b5a-611b1444ca63" />
