### PR TITLE
Stabilize flaky matrix host-mode published-realm navigations

### DIFF
--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -950,6 +950,65 @@ export async function waitUntil<T>(
   throw new Error('Timeout waiting for condition');
 }
 
+// Poll the server-rendered HTML at `url` until it contains `marker`. The
+// `_publish-realm` POST returns before the published realm has finished
+// re-indexing/prerendering, so navigating "cold" races that work and is the
+// source of the flaky `page.goto` timeouts the host-mode suites hit. Gate any
+// navigation to a freshly published realm on this so the document render is
+// warm before the browser asks for it.
+//
+// Budget generously (not waitUntil's 10s default): this is the readiness gate
+// for a realm that may still be indexing under CI load, so a tight poll would
+// fail a slow-but-eventually-ready realm earlier than a bare navigation (which
+// is bounded by the 60s test timeout). 45s stays under that test timeout while
+// leaving headroom for the navigation/assertions that follow.
+//
+// On timeout, throw with the last observed HTTP status and whether a body
+// arrived without the marker. A bare `page.goto` failure only reports "timeout
+// exceeded"; this distinguishes "still erroring" (publish/index not done) from
+// "served but missing the marker" (indexed, wrong/stale content) from "request
+// kept failing" — so the next CI failure is diagnosable without a re-run.
+export async function waitForPublishedMarker(
+  page: Page,
+  url: string,
+  marker: string,
+  timeout = 45_000,
+) {
+  let lastStatus: number | undefined;
+  let lastBodyMissingMarker = false;
+  let lastError: string | undefined;
+  try {
+    await waitUntil(async () => {
+      try {
+        let response = await page.request.get(url, {
+          headers: { Accept: 'text/html' },
+        });
+        lastStatus = response.status();
+        lastError = undefined;
+        if (!response.ok()) {
+          lastBodyMissingMarker = false;
+          return false;
+        }
+        let text = await response.text();
+        lastBodyMissingMarker = !text.includes(marker);
+        return !lastBodyMissingMarker;
+      } catch (e) {
+        lastError = e instanceof Error ? e.message : String(e);
+        return false;
+      }
+    }, timeout);
+  } catch {
+    let detail = lastError
+      ? `last request error: ${lastError}`
+      : lastBodyMissingMarker
+        ? `last response HTTP ${lastStatus} served without marker "${marker}" (realm reachable but still indexing or rendering other content)`
+        : `last response HTTP ${lastStatus ?? 'none'} not OK (publish/index not ready)`;
+    throw new Error(
+      `waitForPublishedMarker timed out after ${timeout}ms for ${url}; ${detail}`,
+    );
+  }
+}
+
 async function waitForRealmToken(page: Page, realmURL: string): Promise<void> {
   await page.waitForFunction(
     (url) => {

--- a/packages/matrix/tests/download-realm.spec.ts
+++ b/packages/matrix/tests/download-realm.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './fixtures.ts';
+import { readFileSync } from 'fs';
 import { appURL } from '../support/isolated-realm-server.ts';
 import {
   createSubscribedUser,
@@ -51,24 +52,18 @@ test.describe('Download Realm', () => {
     // Verify the download filename ends with .zip
     expect(download.suggestedFilename()).toMatch(/\.zip$/);
 
-    // Read the downloaded content to verify it's a valid zip file
-    const stream = await download.createReadStream();
-    const chunks: Buffer[] = [];
-    for await (const chunk of stream) {
-      chunks.push(chunk);
-      // Only need first few bytes to verify zip signature
-      if (chunks.reduce((acc, c) => acc + c.length, 0) >= 4) {
-        break;
-      }
-    }
-    const buffer = Buffer.concat(chunks);
+    // Verify the download completed and the file is a valid zip. Read from
+    // the saved path rather than consuming `createReadStream()` and breaking
+    // out after the first chunk: a half-consumed download stream left open
+    // throws `readableStreamImpl._read: Test ended` during teardown, which
+    // Playwright reports as an error "not a part of any test" and fails the
+    // run with a non-zero exit even when every test itself passed.
+    const path = await download.path();
+    expect(path).toBeTruthy();
+    const buffer = readFileSync(path!);
 
     // ZIP files start with 'PK' (0x50 0x4B)
     expect(buffer[0]).toBe(0x50);
     expect(buffer[1]).toBe(0x4b);
-
-    // Verify the download completed (streaming worked)
-    const path = await download.path();
-    expect(path).toBeTruthy();
   });
 });

--- a/packages/matrix/tests/head-tags.spec.ts
+++ b/packages/matrix/tests/head-tags.spec.ts
@@ -8,6 +8,7 @@ import {
   createSubscribedUserAndLogin,
   openRoot,
   postCardSource,
+  waitForPublishedMarker,
 } from '../helpers/index.ts';
 
 test.describe('Head tags', () => {
@@ -102,7 +103,7 @@ test.describe('Head tags', () => {
       displayName: realmName,
     });
 
-    await page.goto(realmURL);
+    await page.goto(realmURL, { waitUntil: 'domcontentloaded' });
     await page.locator('[data-test-stack-item-content]').first().waitFor();
 
     let defaultHeadCardSource = `
@@ -273,7 +274,19 @@ test.describe('Head tags', () => {
     let publishedRealmURL = `https://${user.username}.localhost:4205/${realmName}/`;
     let defaultCardURL = `${publishedRealmURL}default-head-card.json`;
 
-    await page.goto(defaultCardURL);
+    // Publishing returns before the published realm finishes re-indexing
+    // and prerendering, so navigating "cold" races that work — the source
+    // of the flaky 60s `page.goto`/`waitFor` timeouts here. Gate on the
+    // card's SSR marker (`data-test-default-head-card`, from the isolated
+    // template) so the document render is warm before the browser asks
+    // for it.
+    await waitForPublishedMarker(
+      page,
+      defaultCardURL,
+      'data-test-default-head-card',
+    );
+
+    await page.goto(defaultCardURL, { waitUntil: 'domcontentloaded' });
 
     // Wait for Ember to take over
     await page.locator('[data-test-host-mode-content]').waitFor();

--- a/packages/matrix/tests/host-mode.spec.ts
+++ b/packages/matrix/tests/host-mode.spec.ts
@@ -5,6 +5,7 @@ import {
   logout,
   postCardSource,
   setRealmRedirects,
+  waitForPublishedMarker,
   waitUntil,
 } from '../helpers/index.ts';
 import { appURL } from '../support/isolated-realm-server.ts';
@@ -292,34 +293,6 @@ async function createAndPublishHostModeRealm(
   };
 }
 
-// Poll the server-rendered HTML at `url` until it contains `marker`. The
-// `_publish-realm` POST returns before the published realm has finished
-// re-indexing/prerendering, so navigating "cold" races that work and is the
-// source of the flaky `page.goto` timeouts this suite previously hit.
-//
-// Budget generously (not waitUntil's 10s default): this is the readiness gate
-// for a realm that may still be indexing under CI load, so a tight poll would
-// fail a slow-but-eventually-ready realm earlier than the old bare navigation
-// (which was bounded by the 60s test timeout). 45s stays under that test
-// timeout while leaving headroom for the navigation/assertions that follow.
-async function waitForPublishedMarker(
-  page: Page,
-  url: string,
-  marker: string,
-  timeout = 45_000,
-) {
-  await waitUntil(async () => {
-    let response = await page.request.get(url, {
-      headers: { Accept: 'text/html' },
-    });
-    if (!response.ok()) {
-      return false;
-    }
-    let text = await response.text();
-    return text.includes(marker);
-  }, timeout);
-}
-
 // Read-only tests share a single published realm created once per worker.
 // Publishing fans out a full reindex + prerender; doing it once instead of in
 // a per-test `beforeEach` removes the prerender storm that drove the flake.
@@ -562,6 +535,12 @@ test.describe('Host mode routing rules', () => {
     );
 
     let noSlashURL = realm.publishedRealmURL.replace(/\/$/, '');
+    // The no-slash URL is a distinct server-render path from the
+    // trailing-slash one gated above; warm it on its own before
+    // navigating so `page.goto` doesn't race a cold render of this
+    // variant under prerender-pool load (a cold no-slash render that
+    // outruns the 60s test timeout is the flake this gate closes).
+    await waitForPublishedMarker(page, noSlashURL, 'data-test-white-paper');
     await page.goto(noSlashURL, { waitUntil: 'domcontentloaded' });
     // `[data-test-host-mode-card="<id>"]` is set by the host SPA's
     // CardRenderer — that attribute exists ONLY post-hydration (it's


### PR DESCRIPTION
## What

Fixes the intermittent failures in the `Matrix Client Tests` shard where two host-mode tests time out at 60s and the shard exits non-zero.

Both flaky tests navigate to a **freshly published realm** before its async reindex + prerender has finished, so `page.goto`/`waitFor` races a cold server-side render. Under prerender-pool contention (two parallel workers each publishing realms, plus the base realm) that render can outrun the 60s test timeout.

- **`head-tags.spec.ts` — "host mode updates head tags when navigating between cards"**: navigated cold to the published card with no readiness gate. The `host-mode.spec.ts` suite already gates its navigations with a marker poll, but that gate never covered `head-tags`.
- **`host-mode.spec.ts` — "routing rule for `/` resolves … without a trailing slash"**: warmed only the trailing-slash URL, then navigated the **no-slash** URL cold. The no-slash URL is a distinct server-render path, so it needs its own warm-up.

The same shard also exits non-zero from an error "not a part of any test": `download-realm.spec.ts` half-consumes the download stream and `break`s, leaving a dangling read that throws `readableStreamImpl._read: Test ended` during teardown.

## Changes

- Promote `waitForPublishedMarker` from a `host-mode.spec.ts` local to a shared `helpers/index.ts` export, and gate both the head-tags card navigation and the host-mode no-slash navigation on it.
- The shared helper now throws on timeout with the last observed HTTP status and whether a body arrived without the marker, so a future failure distinguishes "publish/index not ready" from "served but missing the marker" from "request kept failing" — diagnosable without a re-run.
- Switch the head-tags navigations to `waitUntil: 'domcontentloaded'`.
- `download-realm.spec.ts`: read the saved file via `download.path()` instead of streaming-and-breaking, eliminating the teardown read.

## Note for the prerender owners (not addressed here)

The realm-server logs for the failing run show the prerender pool pinned at `maxPages=4` (the configured `PRERENDER_PAGE_POOL_MIN`) and stealing tabs cross-affinity on nearly every published-realm render — the `MIN 4 → MAX 8` dynamic burst never engaged. `#tryExpand` only fires on render-semaphore saturation, but this workload saturates on tab/affinity exhaustion (`standbys=0 creating=1`), not concurrent-render count, so expansion is never triggered. That's a separate, higher-leverage fix in the prerender pool; this PR keeps the tests robust to the current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
