### PR TITLE
Expand prerender page pool on tab/affinity exhaustion

### DIFF
--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -2136,11 +2136,22 @@ export class PagePool {
       // realm. (`#tryExpand` is a no-op at the tier ceiling or under a
       // fixed-size pool, so this degrades cleanly back to the steal.)
       if (this.#tryExpand(priority)) {
-        if (this.#currentStandbyCount() < this.#desiredStandbyCount()) {
-          let startedAt = Date.now();
-          await this.#ensureStandbyPool();
-          tabStartupMs += Date.now() - startedAt;
-        }
+        // Await the refill UNCONDITIONALLY here — not gated on
+        // `#currentStandbyCount() < #desiredStandbyCount()`. When a
+        // post-acquire `#kickStandbyRefill` is already creating a
+        // standby, `#creatingStandbys` inflates `#currentStandbyCount()`
+        // up to the desired count while `#standbys` is still empty, so a
+        // guarded await would skip, the commandeer below would find no
+        // *ready* standby, and the caller would fall through to the very
+        // cross-affinity steal this expansion exists to avoid. The await
+        // dedups onto any in-flight creation via `#ensuringStandbys` and
+        // returns fast when the pool is already warm; only this caller
+        // (which genuinely needs a fresh tab) pays the wait, attributed
+        // to `tabStartupMs`. Same in-flight-refill race the non-file
+        // spawn path above handles with an unconditional await.
+        let startedAt = Date.now();
+        await this.#ensureStandbyPool();
+        tabStartupMs += Date.now() - startedAt;
         let expandedCommandeered = this.#commandeerDormantTab(affinityKey, {
           standbyOnly: true,
         });

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -2118,10 +2118,50 @@ export class PagePool {
           tabStartupMs,
         };
       }
+      // Tab/affinity exhaustion is itself a saturation signal — one the
+      // render-semaphore-fullness heuristic in
+      // `#maybeExpandUnderSaturation` (the acquire-time expansion hook)
+      // cannot see. A distinct affinity has arrived with no warm tab of
+      // its own, no orphan context, and no commandeer-able standby, and
+      // the refill above couldn't conjure one because the live cap
+      // (`#maxPages`) is the binding limit here — not concurrent render
+      // count. The tabs we'd otherwise steal below are idle, not
+      // rendering, so the render semaphore reads as un-saturated and the
+      // acquire-time hook never fires. Under a workload that contends on
+      // many distinct affinities (N affinities, only `#maxPages` tabs)
+      // this is the steady state: without expanding here the pool stays
+      // pinned at its idle floor no matter how high `#maxBurstPages` is.
+      // If the pool can still grow, lift the cap and spawn a fresh tab
+      // for this affinity rather than stealing a warm tab from another
+      // realm. (`#tryExpand` is a no-op at the tier ceiling or under a
+      // fixed-size pool, so this degrades cleanly back to the steal.)
+      if (this.#tryExpand(priority)) {
+        if (this.#currentStandbyCount() < this.#desiredStandbyCount()) {
+          let startedAt = Date.now();
+          await this.#ensureStandbyPool();
+          tabStartupMs += Date.now() - startedAt;
+        }
+        let expandedCommandeered = this.#commandeerDormantTab(affinityKey, {
+          standbyOnly: true,
+        });
+        if (expandedCommandeered) {
+          let releaseTab = await expandedCommandeered.queue.acquire(
+            signal,
+            priority,
+          );
+          return {
+            entry: expandedCommandeered,
+            reused: false,
+            releaseTab,
+            tabStartupMs,
+          };
+        }
+      }
       // Refill couldn't produce a tab (e.g. `createBrowserContext`
-      // exhausted retries). Fall back to cross-affinity steal so the
-      // caller has *some* path to a tab — better than throwing while
-      // there are idle tabs on other affinities.
+      // exhausted retries) and the pool is at its ceiling (or fixed
+      // size). Fall back to cross-affinity steal so the caller has
+      // *some* path to a tab — better than throwing while there are
+      // idle tabs on other affinities.
       let crossAffinityEntries: PoolEntry[] = [];
       for (let [assignedAffinity, entries] of this.#affinityPages.entries()) {
         if (assignedAffinity === affinityKey) continue;

--- a/packages/realm-server/tests/page-pool-expansion-test.ts
+++ b/packages/realm-server/tests/page-pool-expansion-test.ts
@@ -464,6 +464,123 @@ module(basename(__filename), function () {
       );
     });
 
+    // Affinity/tab exhaustion is a saturation signal the acquire-time
+    // `#maybeExpandUnderSaturation` hook is blind to: it only fires when
+    // the render semaphore is full, but a workload that contends on many
+    // distinct realm affinities saturates on per-affinity tab ownership,
+    // not concurrent render count. With more affinities than `#maxPages`
+    // tabs, an arriving affinity finds no tab of its own and no ready
+    // standby, and the tabs it could steal are idle (the render
+    // semaphore reads un-saturated). These tests pin down that
+    // `#selectEntryForAffinity` treats that state as a trigger to expand
+    // the live cap rather than silently cross-affinity-stealing at a
+    // pinned MIN.
+    //
+    // `disableStandbyRefill: true` is load-bearing here: it keeps the
+    // render semaphore idle (no held slots) while still exhausting tabs,
+    // which isolates the affinity-exhaustion trigger from the render-
+    // semaphore-fullness one. The production path (refill enabled) spawns
+    // a fresh tab after expanding; the full no-steal flow runs under the
+    // real-Chrome integration tests in `prerendering-test.ts`.
+    test('tab/affinity exhaustion expands the cap even when the render semaphore is idle', async function (assert) {
+      await withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '2',
+          PRERENDER_PAGE_POOL_MAX: '4',
+          // Long cooldown so contraction can't shrink mid-test.
+          PRERENDER_POOL_IDLE_CONTRACTION_MS: '60000',
+        },
+        async () => {
+          let semaphore = new AsyncSemaphore(2); // tracks MIN
+          let { pool } = track(
+            makeStubPool({ maxPages: 4, renderSemaphore: semaphore }),
+          );
+          assert.strictEqual(pool.currentMaxPages, 2, 'starts at MIN');
+
+          // Warm two distinct affinities up to the live cap, releasing
+          // each so its tab stays resident but holds no render-semaphore
+          // slot. Tabs are now exhausted (one per affinity, count ===
+          // #maxPages) while the semaphore is idle.
+          let a = await pool.getPage('realm-a');
+          a.release();
+          let b = await pool.getPage('realm-b');
+          b.release();
+
+          assert.strictEqual(
+            semaphore.inUseCount,
+            0,
+            'render semaphore is idle — any expansion is NOT the saturation hook',
+          );
+          assert.strictEqual(
+            pool.currentMaxPages,
+            2,
+            'still pinned at MIN before the new affinity arrives',
+          );
+
+          // A third, brand-new affinity arrives with no warm tab, no
+          // orphan, and no ready standby. The acquire-time hook sees an
+          // idle semaphore and does nothing; the old behaviour would
+          // cross-affinity-steal with the cap pinned at MIN. The fix
+          // lifts the cap instead.
+          let c = await pool.getPage('realm-c');
+          assert.strictEqual(
+            pool.currentMaxPages,
+            3,
+            'pool expanded on tab/affinity exhaustion (2 → 3)',
+          );
+          assert.strictEqual(
+            semaphore.capacity,
+            3,
+            'render semaphore tracks the new cap',
+          );
+          c.release();
+        },
+      );
+    });
+
+    test('many-affinity load walks the cap up to maxBurstPages, then stops', async function (assert) {
+      await withEnv(
+        {
+          PRERENDER_PAGE_POOL_MIN: '2',
+          PRERENDER_PAGE_POOL_MAX: '4',
+          PRERENDER_POOL_IDLE_CONTRACTION_MS: '60000',
+        },
+        async () => {
+          let semaphore = new AsyncSemaphore(2);
+          let { pool } = track(
+            makeStubPool({ maxPages: 4, renderSemaphore: semaphore }),
+          );
+
+          // Warm the cap with two affinities (released → semaphore idle).
+          for (let key of ['realm-a', 'realm-b']) {
+            let held = await pool.getPage(key);
+            held.release();
+          }
+          assert.strictEqual(pool.currentMaxPages, 2, 'starts pinned at MIN');
+
+          // Each subsequent brand-new affinity lifts the cap by one
+          // until it reaches maxBurstPages; past that, expansion is a
+          // no-op and the steal path takes over without further growth.
+          let trajectory: number[] = [];
+          for (let key of ['realm-c', 'realm-d', 'realm-e']) {
+            let held = await pool.getPage(key);
+            trajectory.push(pool.currentMaxPages);
+            held.release();
+          }
+          assert.deepEqual(
+            trajectory,
+            [3, 4, 4],
+            `cap climbs to MAX and holds (observed ${trajectory.join(',')})`,
+          );
+          assert.strictEqual(
+            semaphore.capacity,
+            4,
+            'render semaphore tracks the final cap',
+          );
+        },
+      );
+    });
+
     test('contraction respects cooldown: no shrink within idle window', async function (assert) {
       await withEnv(
         {


### PR DESCRIPTION
The dynamic prerender page-pool envelope (`PRERENDER_PAGE_POOL_MIN` → `PRERENDER_PAGE_POOL_MAX`) only expands when the **render semaphore** is full. That's the wrong signal for a workload that contends on *many distinct realm affinities*: it doesn't saturate on concurrent render count, it saturates on per-affinity tab ownership. With more affinities than `#maxPages` tabs, an arriving affinity finds no tab of its own and no ready standby, and the idle tabs it would steal leave the render semaphore un-saturated. So `#maybeExpandUnderSaturation` never fires, the live cap stays pinned at MIN, and the pool runs as a fixed MIN-sized pool that cross-affinity-steals on nearly every new affinity — the MAX/burst envelope (and the high-priority tier above it) are inert in this regime.

In the matrix harness (MIN=4, MAX=8) this means the configured burst-to-8 runs as a fixed 4-tab pool, which is the systemic driver behind the recurring host-mode `page.goto` 60s timeouts: a saturated 4-tab pool serving two parallel workers' worth of publish + render storms intermittently can't render a published realm within the test timeout, and no test-side wait makes a saturated pool serve faster. The same "never bursts" behavior holds in any deployed environment where a single prerender pool fronts many realms.

## Fix

Treat tab/affinity exhaustion as a saturation signal. In `#selectEntryForAffinity`, when a brand-new affinity has no warm tab of its own, no orphan context, and no commandeer-able standby — the exact point it would otherwise cross-affinity-steal — try `#tryExpand` and spawn a fresh tab first. This is the existing expand-then-refill-then-commandeer pattern already used by the dynamic-pool deadlock escape hatch, applied at the steal site.

`#tryExpand` is a no-op at the tier ceiling and under a legacy fixed-size pool (where `#minPages === #maxBurstPages`), so the cross-affinity steal remains the fallback whenever the pool genuinely can't grow. The acquire-time `#maybeExpandUnderSaturation` hook is unchanged.

## Tests

New unit tests in `page-pool-expansion-test.ts` drive the many-affinity scenario through `getPage` with the render semaphore **idle** — which isolates the affinity-exhaustion trigger from the render-semaphore-fullness one — and assert the live cap climbs from MIN toward `maxBurstPages` and then stops:

- a brand-new affinity arriving against an exhausted, idle-semaphore pool lifts the cap (2 → 3) instead of stealing at a pinned MIN;
- successive new affinities walk the cap up to `maxBurstPages` and hold there.

Both tests fail on `main` (every steal logs `maxPages=2`, no expansion) and pass with this change (`maxPages` climbs 2 → 3 → 4). The full no-steal production flow — expand, then spawn a fresh tab — is exercised by the real-Chrome integration suite in `prerendering-test.ts`. The existing cross-affinity-steal tests run in legacy fixed-pool mode, where `#tryExpand` is a no-op, so they're unaffected.

Fixes CS-11481.
