### PR TITLE
Stream full prerender profiler artifacts (CPU profiles / traces / heap) to S3

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: indexing-diagnostics
-description: Investigate slow or failing indexing using the diagnostics persisted on every `boxel_index` row (`diagnostics` JSONB column, mirrored onto `error_doc.diagnostics` for error rows) plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most, (3) enumerating cards with broken `linksTo` / `linksToMany` targets via `diagnostics.brokenLinks` (those cards index cleanly, so this is the only indexed signal), (4) verifying the module pre-warm phase populates the definition cache under a key the indexer / on-demand prerender reads actually hit — i.e. it isn't a silent no-op — via the `definition-cache-key` hit/miss log channel, and (5) attributing a slow in-render `_search` round-trip to the realm-server's own request→response stages (parse / SQL / loadLinks / serialize / queue) via the `realm:search-timing`, `realm:requests` (`dur=`), and `realm:health` log channels keyed by the `x-boxel-logging-correlation-id` correlation id. Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, when investigating the CS-10820 saturation class of incidents, when a render stalls in `waiting-stability` on a `_search` whose SQL is fast but whose response is slow to come back, or when asked to list / count cards with broken links in a realm. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
+description: Investigate slow or failing indexing using the diagnostics persisted on every `boxel_index` row (`diagnostics` JSONB column, mirrored onto `error_doc.diagnostics` for error rows) plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most, (3) enumerating cards with broken `linksTo` / `linksToMany` targets via `diagnostics.brokenLinks` (those cards index cleanly, so this is the only indexed signal), (4) verifying the module pre-warm phase populates the definition cache under a key the indexer / on-demand prerender reads actually hit — i.e. it isn't a silent no-op — via the `definition-cache-key` hit/miss log channel, and (5) attributing a slow in-render `_search` round-trip to the realm-server's own request→response stages (parse / SQL / loadLinks / serialize / queue) via the `realm:search-timing`, `realm:requests` (`dur=`), and `realm:health` log channels keyed by the `x-boxel-logging-correlation-id` correlation id, and (6) capturing full CPU profiles / CDP traces / heap-allocation profiles to the prerender S3 artifact bucket (`boxel-prerender-artifacts-<env>`) when the summary signals name a hot function but you need the whole call tree, a JS-vs-GC-vs-layout breakdown, or a heap-growth story — the streaming trace is the only capture that survives a fully-wedged renderer; gated behind `PRERENDER_PROFILE_AFFINITY` + per-mode SSM flags and pulled with the `boxel-claude-readonly` S3 read grant. Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, when investigating the CS-10820 saturation class of incidents, when a render stalls in `waiting-stability` on a `_search` whose SQL is fast but whose response is slow to come back, or when asked to list / count cards with broken links in a realm. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
@@ -861,6 +861,71 @@ The boxel logger does **not** print the namespace, so the on-disk line is the ba
 - It only fires for **prerender / indexer** traffic — the correlation id is prerender-gated. A slow `_search` from a live SPA or external API caller emits nothing, by design, to keep normal traffic silent.
 - The correlation id isn't in `boxel_index.diagnostics`, so there's no SQL join from a stuck card row to its server line; bridge by job + time + query as above.
 - `realm:health` is sampled and emitted only during saturation windows (lag over threshold OR a search in flight). A quiet period legitimately produces no line — silence means "not saturated," not "no data."
+
+## Mode H — capturing full CPU profiles / traces / heap snapshots
+
+When the summary signals (Mode A's `cpuTopFrames`, Mode D) name a hot or looping function but you need the full picture — the complete call tree, a JS-vs-GC-vs-layout breakdown, or a heap-growth story — capture the heavyweight artifacts. They're far too big for a log line, so they stream to a dedicated S3 bucket instead.
+
+### Two tiers — pick by what you need
+
+| Tier | What | Where it lands | Captures the hard wedge? |
+|------|------|----------------|--------------------------|
+| 1 (always on for targeted realms) | Top-N self-time **summary** | `prerenderer` log: `affinity CPU profile …` | No — `Profiler.stop` needs the renderer thread |
+| 2 — `.cpuprofile` | Full V8 CPU profile (whole call tree) | S3 `…/<ts>.cpuprofile` | No — same `Profiler.stop` limit |
+| 2 — trace (`.trace.json`) | CDP/Perfetto trace, **streamed** — separates JS / GC / compile / layout / paint | S3 `…/<ts>.trace.json` | **Yes** — buffered on browser threads, drained out-of-band; the one capture that survives a fully-pegged renderer |
+| 2 — heap (`.heapprofile`) | Cumulative allocation-sampling profile, flushed per render | S3 `…/<ts>.heapprofile` | No — `getSamplingProfile` needs the renderer thread |
+
+Rule of thumb: a render that **completes but is heavy** → `.cpuprofile` (+ heap for allocation growth). A render that **fully wedges** (no `cpuTopFrames`, `scriptBusy=<unknown>`) → the **trace**, which is the only thing that comes back. If the trace returns idle (no hot frame), the wedge isn't CPU-spinning — pivot to "what is it blocked on" (Mode A's `pendingFetches`).
+
+### The knobs (SSM parameters)
+
+All live at `/<env>/boxel/<NAME>` (Systems Manager → Parameter Store). The bucket itself (`PRERENDER_ARTIFACTS_BUCKET`) and the key prefix (`PRERENDER_ARTIFACTS_ENV`) are wired by Terraform — don't set them by hand.
+
+| Parameter | Values | Effect |
+|-----------|--------|--------|
+| `PRERENDER_PROFILE_AFFINITY` | comma-separated affinity keys, e.g. `realm:https://realms.cardstack.com/team/foo/` | **Required to target.** Only renders whose affinity key exactly matches are profiled at all (Tier 1 + Tier 2). Empty / `off` → everything inert. |
+| `PRERENDER_PROFILE_CPUPROFILE` | `true` / `false` | Persist the full `.cpuprofile` for targeted renders. |
+| `PRERENDER_PROFILE_TRACE` | `true` / `false` | Capture the streaming trace for targeted renders. |
+| `PRERENDER_PROFILE_HEAP` | `true` / `false` | Capture the heap allocation-sampling profile for targeted renders. |
+| `PRERENDER_PROFILE_MAX_SESSION_BYTES` | positive integer, or `0` for the default | Soft per-process byte budget across all artifacts. `0`/unset → 5 GiB. Once spent, the task declines further uploads (in-flight ones finish, so blobs are never truncated). |
+
+The mode flags are Terraform-seeded sentinels (default `false` / `0`); `PRERENDER_PROFILE_AFFINITY` is operator-managed and must already exist. The affinity key is `realm:` + the realm's canonical URL **with trailing slash** — the same value Mode A/B logs print as `affinity=…`.
+
+> **The container reads these at task start.** ECS injects SSM values when a task launches, so a change only takes effect on a fresh task. After editing the parameters, force a new deployment of the prerender service so tasks restart with the new env:
+> ```
+> aws ecs update-service --cluster <env> --service boxel-prerender-server-<env> --force-new-deployment
+> ```
+
+### Running a capture session
+
+1. **Target the realm.** Set `PRERENDER_PROFILE_AFFINITY` to its affinity key and turn on the mode flag(s) you need (start with `PRERENDER_PROFILE_TRACE` for a wedge, `PRERENDER_PROFILE_CPUPROFILE` for a heavy-but-completing render).
+2. **Restart the service** (`--force-new-deployment` above) so the tasks pick up the values.
+3. **Generate renders.** Trigger a reindex of the targeted realm (see *Triggering a reindex* below) — the indexer's per-card visits are what produce artifacts. Confirm captures are happening in the `prerenderer` log: `artifact-sink uploaded <kind> key=… bytes=… sessionBytes=…/…`.
+4. **Pull the artifacts** (below).
+5. **Turn it off.** Set the mode flags back to `false` (and clear `PRERENDER_PROFILE_AFFINITY` if done), then force one more deployment. Leftover artifacts auto-expire after 14 days regardless.
+
+### Pulling the artifacts
+
+The `boxel-claude-readonly` role has `s3:GetObject` + `s3:ListBucket` on `boxel-prerender-artifacts-*`, so use the `aws-access` skill's session (`mise run claude-aws`) and plain S3:
+
+```
+aws s3 ls --recursive s3://boxel-prerender-artifacts-<env>/<env>/<realm-segment>/
+aws s3 cp s3://boxel-prerender-artifacts-<env>/<key> ./local-name
+```
+
+The key schema is `env/realm/jobId/card/step/<timestamp>-<seq>.<suffix>` — every segment sanitized (protocol/host stripped, unsafe characters collapsed to `-`). So one job's artifacts share a `…/<realm>/<jobId>/` prefix, and one render's three artifacts share everything up to the suffix. `jobId` is `no-job` for on-demand (non-indexer) renders.
+
+### Reading each artifact
+
+- **`.cpuprofile`** — Chrome DevTools (Performance panel → *Load profile…*) or [speedscope](https://www.speedscope.app/). Self-time flame graph of the whole render; the summary's top frames are just the peak of this.
+- **`.trace.json`** — [Perfetto UI](https://ui.perfetto.dev/) or Chrome DevTools Performance → *Load profile…*. Separate tracks for JS execution, V8 GC, compile, and layout/paint — this is how you tell a JS spin (`v8.execute` saturated) from GC thrash (`v8.gc` saturated) when the summary couldn't say.
+- **`.heapprofile`** — Chrome DevTools Memory → *Allocation sampling* → *Load profile…*. Each upload is the cumulative profile **at that render**, so download two from different points in the session and compare to see which call sites kept allocating.
+
+### What Mode H can't tell you
+
+- The `.cpuprofile` and `.heapprofile` need the renderer thread to serialize, so a **fully-wedged** render produces neither — only the streaming trace comes back. That's by design (Tier 1's summary has the same limit); the trace is the wedge tool.
+- Browser-wide tracing is **single-flight** — only one trace runs at a time across the whole pool. Concurrent targeted renders skip their trace (logged at `debug`), so don't expect a trace for *every* render under load; constrain concurrency or accept the gaps. The summary and the cpuprofile/heap captures are per-render and unaffected.
+- Captured artifacts are anonymized only at the key level (host stripped). The blobs themselves contain card URLs and code paths — treat them as you would any prerender diagnostic.
 
 ## Field-by-field reading
 

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -144,6 +144,8 @@
     "stripe": "docker run --rm --add-host=host.docker.internal:host-gateway -it stripe/stripe-cli:latest"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1065.0",
+    "@aws-sdk/lib-storage": "^3.1065.0",
     "morphdom": "^2.7.8",
     "puppeteer": "^24.8.2"
   }

--- a/packages/realm-server/prerender/artifact-sink.ts
+++ b/packages/realm-server/prerender/artifact-sink.ts
@@ -1,0 +1,281 @@
+// Durable S3 sink for the prerender profiler's heavyweight artifacts —
+// full `.cpuprofile`s, CDP trace streams, and heap-allocation profiles.
+//
+// Why this module exists:
+//
+//   The CPU profiler (`cpu-profiler.ts`) can only afford to log a compact
+//   top-N self-time summary: a render that wedges for a ~40-minute
+//   single-realm reindex produces full artifacts that run to GBs, far past
+//   what a log line can carry. Those full artifacts are what load into
+//   Chrome DevTools / speedscope / Perfetto for the deep analysis a
+//   summary can't support. The prerender task renders untrusted card code
+//   and is deliberately segregated from the realm-server, so it can't
+//   reuse the realm-server's EFS; this sink writes to its own provisioned
+//   S3 bucket instead.
+//
+// Operating contract:
+//
+//   * Entirely opt-in and best-effort. With no bucket configured the sink
+//     is inert; every upload swallows its own errors so a failed flush can
+//     never perturb a render.
+//   * One artifact is flushed per render (the callers hand over a finished
+//     blob or a live stream), so a crash loses at most the in-flight
+//     render's data — never a whole session's.
+//   * A per-session byte budget bounds total volume on top of the bucket's
+//     lifecycle expiry: once the process has written its budget, further
+//     uploads are declined (in-flight ones are allowed to finish, so the
+//     budget is a soft ceiling, never a source of truncated/!invalid
+//     blobs).
+//
+// In ECS the bucket write grant rides on the task role, which the AWS SDK
+// resolves automatically from the container credentials endpoint — there
+// are no access keys or profiles to configure here.
+
+import type { Readable } from 'stream';
+import { S3Client } from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
+import { logger } from '@cardstack/runtime-common';
+
+const log = logger('prerenderer');
+
+// Default per-session byte budget when `PRERENDER_PROFILE_MAX_SESSION_BYTES`
+// is unset or not a positive integer. Generous enough to capture a useful
+// slice of a multi-GB reindex session while still bounding cost alongside
+// the bucket's lifecycle expiry; an operator targeting a long session can
+// raise it.
+const DEFAULT_MAX_SESSION_BYTES = 5 * 1024 * 1024 * 1024; // 5 GiB
+// Fallback S3 region. Both deployed environments live in us-east-1; an
+// operator can override per-process without a code change.
+const DEFAULT_REGION = 'us-east-1';
+
+// The artifact formats this sink carries. Each maps to a file suffix the
+// usual tools recognise: `.cpuprofile` (Chrome DevTools / speedscope),
+// `.trace.json` (Chrome tracing / Perfetto), `.heapprofile` (DevTools
+// allocation-sampling view).
+export type ArtifactKind = 'cpuprofile' | 'trace' | 'heap';
+
+const SUFFIX_BY_KIND: Record<ArtifactKind, string> = {
+  cpuprofile: 'cpuprofile',
+  trace: 'trace.json',
+  heap: 'heapprofile',
+};
+
+// The render-identifying fields that key an artifact. All but `kind` are
+// optional: an on-demand render carries no indexing `jobId`, and a render
+// that never resolved an affinity still produces a sensibly-keyed blob.
+export interface ArtifactKeyParts {
+  // Realm being rendered (recovered from the render's affinity key).
+  realm?: string;
+  // Indexing job id — set only for indexer-driven visits.
+  jobId?: string;
+  // Card / module url being rendered.
+  card?: string;
+  // Render step / pass (e.g. `card isolated/0`, `screenshot png`).
+  step?: string;
+  kind: ArtifactKind;
+}
+
+export interface ArtifactUpload extends ArtifactKeyParts {
+  // A finished blob (cpuprofile / heap profile) or a live stream (the CDP
+  // trace, drained as it is produced). Streams are uploaded with the SDK's
+  // managed multipart upload, so memory stays bounded regardless of size.
+  body: Buffer | Readable;
+  contentType?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration — read at call time (never frozen at module load) so tests
+// and operators can flip env without a stale process snapshot, mirroring
+// `cpu-profiler.ts`.
+// ---------------------------------------------------------------------------
+
+function artifactBucket(): string | undefined {
+  let raw = process.env.PRERENDER_ARTIFACTS_BUCKET;
+  let bucket = typeof raw === 'string' ? raw.trim() : '';
+  return bucket.length > 0 ? bucket : undefined;
+}
+
+function artifactEnv(): string {
+  let raw = process.env.PRERENDER_ARTIFACTS_ENV;
+  let env = typeof raw === 'string' ? raw.trim() : '';
+  return env.length > 0 ? env : 'unknown';
+}
+
+function artifactRegion(): string {
+  return (
+    process.env.PRERENDER_ARTIFACTS_REGION?.trim() ||
+    process.env.AWS_REGION?.trim() ||
+    DEFAULT_REGION
+  );
+}
+
+// The configured per-session byte budget, or the built-in default when the
+// value is unset / non-positive / unparseable. Exported for the unit tests
+// and for callers that want to short-circuit a capture before doing CDP
+// work.
+export function getMaxSessionBytes(): number {
+  let raw = process.env.PRERENDER_PROFILE_MAX_SESSION_BYTES;
+  if (typeof raw === 'string') {
+    let parsed = Number.parseInt(raw.trim(), 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_MAX_SESSION_BYTES;
+}
+
+// True when a destination bucket is configured. The capture paths gate on
+// this before issuing any CDP calls, so an unconfigured sink costs nothing.
+export function artifactSinkEnabled(): boolean {
+  return artifactBucket() !== undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Per-mode capture flags. Each heavyweight capture is gated by both the
+// affinity trigger (one deliberately-targeted realm) AND its own flag, so a
+// realm can be summarised in logs without paying to also persist a full
+// blob. Read at call time; absent / anything but "true" leaves the mode off.
+// ---------------------------------------------------------------------------
+
+function flagEnabled(name: string): boolean {
+  return process.env[name]?.trim() === 'true';
+}
+
+export function shouldCaptureCpuProfile(): boolean {
+  return flagEnabled('PRERENDER_PROFILE_CPUPROFILE');
+}
+
+export function shouldCaptureTrace(): boolean {
+  return flagEnabled('PRERENDER_PROFILE_TRACE');
+}
+
+export function shouldCaptureHeap(): boolean {
+  return flagEnabled('PRERENDER_PROFILE_HEAP');
+}
+
+// True when the sink is configured AND at least one heavyweight capture is
+// enabled — the cheap gate the per-render orchestration checks before
+// touching CDP.
+export function anyArtifactCaptureEnabled(): boolean {
+  return (
+    artifactSinkEnabled() &&
+    (shouldCaptureCpuProfile() || shouldCaptureTrace() || shouldCaptureHeap())
+  );
+}
+
+// ---------------------------------------------------------------------------
+// S3 key construction (pure).
+// ---------------------------------------------------------------------------
+
+// `env/realm/jobId/card/step/<timestamp>-<seq>.<suffix>`. Every dynamic
+// segment is reduced to a filesystem-/key-safe token so the object browses
+// cleanly and carries no host origin. `seq` disambiguates two artifacts
+// that would otherwise collide within the same millisecond.
+export function buildArtifactKey(
+  parts: ArtifactKeyParts,
+  now: Date,
+  seq: number,
+): string {
+  let timestamp = now.toISOString().replace(/[:.]/g, '-');
+  let segments = [
+    sanitizeSegment(artifactEnv()),
+    sanitizeSegment(parts.realm) || 'no-realm',
+    sanitizeSegment(parts.jobId) || 'no-job',
+    sanitizeSegment(parts.card) || 'no-card',
+    sanitizeSegment(parts.step) || 'no-step',
+    `${timestamp}-${seq}.${SUFFIX_BY_KIND[parts.kind]}`,
+  ];
+  return segments.join('/');
+}
+
+// Reduces an arbitrary value (url, job id, step label) to a single safe key
+// segment: the protocol/host noise is dropped, every run of unsafe
+// characters collapses to a dash, and the result is length-capped so a long
+// url can't blow out the key. Returns '' for empty/whitespace input.
+function sanitizeSegment(value: string | undefined): string {
+  if (!value) {
+    return '';
+  }
+  let trimmed = value.trim().replace(/^https?:\/\//, '');
+  let safe = trimmed
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 200);
+  return safe;
+}
+
+// ---------------------------------------------------------------------------
+// Upload — best-effort, never throws.
+// ---------------------------------------------------------------------------
+
+let client: S3Client | undefined;
+function getClient(): S3Client {
+  if (!client) {
+    client = new S3Client({ region: artifactRegion() });
+  }
+  return client;
+}
+
+// Process-lifetime ("session") accounting. The process is one prerender
+// task; the budget bounds how much it writes across all renders it serves.
+let sessionBytesUsed = 0;
+let uploadSeq = 0;
+let budgetExhaustedLogged = false;
+
+// Uploads one artifact. Resolves once the object is durable in S3 (so a
+// per-render `await` genuinely persists before the next render), or sooner
+// if the sink is disabled / the budget is spent / the upload fails — none
+// of which ever throw or reject. Declines (does not truncate) once the
+// session budget is reached, so it never produces an invalid blob.
+export async function uploadArtifact(upload: ArtifactUpload): Promise<void> {
+  let bucket = artifactBucket();
+  if (!bucket) {
+    return;
+  }
+  if (sessionBytesUsed >= getMaxSessionBytes()) {
+    if (!budgetExhaustedLogged) {
+      budgetExhaustedLogged = true;
+      log.warn(
+        `artifact-sink session byte budget (${getMaxSessionBytes()}) reached; ` +
+          `declining further artifact uploads for this process`,
+      );
+    }
+    return;
+  }
+
+  let key = buildArtifactKey(upload, new Date(), uploadSeq++);
+  let loaded = 0;
+  try {
+    let managed = new Upload({
+      client: getClient(),
+      params: {
+        Bucket: bucket,
+        Key: key,
+        Body: upload.body,
+        ContentType: upload.contentType ?? 'application/json',
+      },
+    });
+    managed.on('httpUploadProgress', (progress) => {
+      if (typeof progress.loaded === 'number') {
+        loaded = progress.loaded;
+      }
+    });
+    await managed.done();
+    sessionBytesUsed += loaded;
+    log.info(
+      `artifact-sink uploaded ${upload.kind} key=${key} bytes=${loaded} ` +
+        `sessionBytes=${sessionBytesUsed}/${getMaxSessionBytes()}`,
+    );
+  } catch (e) {
+    // Best-effort: a failed flush is a missing diagnostic, not a render
+    // failure. Count nothing against the budget.
+    log.warn(`artifact-sink failed to upload ${upload.kind} key=${key}:`, e);
+  }
+}
+
+// Test-only: reset the process-lifetime accounting between cases.
+export function __resetArtifactSinkSessionForTests(): void {
+  sessionBytesUsed = 0;
+  uploadSeq = 0;
+  budgetExhaustedLogged = false;
+}

--- a/packages/realm-server/prerender/cpu-profiler.ts
+++ b/packages/realm-server/prerender/cpu-profiler.ts
@@ -119,6 +119,15 @@ export interface ProfileWindowOptions {
   // accrued, and `run` is left to settle on its own. Omitted (the
   // timeout trigger's short fixed window) means "wait for `run`".
   maxRunMs?: number;
+  // Optional sink for the complete `Profiler.stop` profile. The raw CDP
+  // profile object IS the `.cpuprofile` format Chrome DevTools / speedscope
+  // load, so a caller that wants the full artifact (not just the logged
+  // summary) passes a hook here to persist it. Invoked at most once, only
+  // when a profile was actually recovered — a fully-wedged renderer defeats
+  // `Profiler.stop`, so this never fires for the hard wedge (that case is
+  // the streaming trace capture's job). Best-effort: awaited but its errors
+  // are swallowed, so it never perturbs the summary or the render.
+  onRawProfile?: (rawProfile: unknown) => void | Promise<void>;
 }
 
 // Runs a CDP CPU profile across the window defined by `run` (or by
@@ -177,6 +186,16 @@ export async function profileWindow(
 
   if (!profile) {
     return null;
+  }
+  // Hand the full profile to the optional sink before summarizing. Awaited
+  // so a per-render caller can flush it durably, but best-effort: a failed
+  // persist must not cost the caller its summary.
+  if (options.onRawProfile) {
+    try {
+      await options.onRawProfile(profile);
+    } catch (e) {
+      log.debug('CPU profiler onRawProfile hook failed:', e);
+    }
   }
   return summarizeProfile(profile, durationMs, topFrames);
 }

--- a/packages/realm-server/prerender/heap-sampler.ts
+++ b/packages/realm-server/prerender/heap-sampler.ts
@@ -1,0 +1,134 @@
+// HeapProfiler allocation sampling for prerender pages.
+//
+// Why allocation sampling (not full heap snapshots):
+//
+//   The question this answers is "where is the store/heap growing across a
+//   realm's render session", and an affinity tab is reused across many
+//   renders. The sampling allocation profiler is the right tool: started
+//   once per tab, it accrues a lightweight, statistically-sampled record of
+//   allocation call stacks for the life of the tab. Reading the cumulative
+//   profile after each render and flushing it gives a per-render series
+//   whose diffs show what kept allocating — at a tiny fraction of the cost
+//   (and the multi-GB size) of full `takeHeapSnapshot`s, and without the
+//   long main-thread pause a full snapshot walk imposes.
+//
+//   Like the CPU profiler's `Profiler.stop`, `getSamplingProfile` needs the
+//   renderer's own thread to serialize the profile, so it captures
+//   heavy-but-completing renders rather than a fully-wedged one — which is
+//   the right division of labour: the streaming trace owns the hard wedge,
+//   and heap growth is a property of the renders that complete.
+//
+// Sampling is enabled once per page and persists on the V8 isolate across
+// the renders that reuse the tab; the cumulative profile read per render is
+// the `.heapprofile` format the DevTools "Allocation sampling" view loads.
+
+import type { CDPSession, Page } from 'puppeteer';
+import { logger } from '@cardstack/runtime-common';
+
+const log = logger('prerenderer');
+
+// Average bytes between allocation samples. Coarse enough to keep the
+// per-allocation overhead negligible over a long session while still
+// resolving the call sites that dominate growth.
+const SAMPLING_INTERVAL_BYTES = 32768;
+// Hard ceiling on the cumulative-profile read. `getSamplingProfile` needs
+// the renderer thread; time-boxing it keeps a wedged render from stalling
+// the pool, mirroring the CPU profiler's `Profiler.stop` guard.
+const GET_PROFILE_TIMEOUT_MS = 5000;
+
+// Local subset of the CDP shape read. As elsewhere we avoid importing
+// `devtools-protocol` and declare only what's used.
+//   https://chromedevtools.github.io/devtools-protocol/tot/HeapProfiler/
+interface GetSamplingProfileResult {
+  profile?: unknown;
+}
+
+// One CDP session per page, holding the sampling profiler open for the life
+// of the tab. The session is created when sampling is first enabled and
+// reused for every cumulative read; it dies with the page (puppeteer
+// auto-detaches), so no explicit teardown is needed.
+let heapSessions = new WeakMap<Page, CDPSession>();
+
+// Ensures the allocation sampler is running on this page. Idempotent: the
+// first call per page enables and starts sampling; later calls are no-ops,
+// so the profile keeps accruing across the renders that reuse the tab
+// (re-starting would reset the cumulative record). Best-effort — never
+// throws; on any CDP error sampling simply stays off for this page.
+export async function ensureHeapSampling(page: Page): Promise<void> {
+  if (heapSessions.has(page)) {
+    return;
+  }
+  let client: CDPSession | undefined;
+  try {
+    client = await page.createCDPSession();
+    await client.send('HeapProfiler.enable');
+    await client.send('HeapProfiler.startSampling', {
+      samplingInterval: SAMPLING_INTERVAL_BYTES,
+    });
+    heapSessions.set(page, client);
+  } catch (e) {
+    log.debug('heap sampling failed to start:', e);
+    await detachQuietly(client);
+  }
+}
+
+// Reads the cumulative allocation-sampling profile as a `.heapprofile`
+// buffer, or `null` if sampling isn't running on this page or the read
+// fails / times out. Does NOT stop sampling — the profiler keeps accruing
+// so the next render's read continues the series. Never throws.
+export async function captureHeapSamplingProfile(
+  page: Page,
+): Promise<Buffer | null> {
+  let client = heapSessions.get(page);
+  if (!client) {
+    return null;
+  }
+  try {
+    let result = await raceTimeout(
+      client.send(
+        'HeapProfiler.getSamplingProfile',
+      ) as Promise<GetSamplingProfileResult>,
+      GET_PROFILE_TIMEOUT_MS,
+    );
+    if (!result || result.profile === undefined) {
+      return null;
+    }
+    return Buffer.from(JSON.stringify(result.profile), 'utf8');
+  } catch (e) {
+    log.debug('heap sampling profile read failed:', e);
+    return null;
+  }
+}
+
+// Resolves with the command result, or `null` if it doesn't return within
+// `ms`. Never throws — a wedged renderer can leave `getSamplingProfile`
+// pending, and abandoning it keeps the pool moving.
+async function raceTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.catch(() => null),
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function detachQuietly(client: CDPSession | undefined): Promise<void> {
+  try {
+    await client?.detach();
+  } catch {
+    // Session may already be gone with the page; ignore.
+  }
+}
+
+// Test-only: drop the per-page session map between cases.
+export function __resetHeapSamplerForTests(): void {
+  heapSessions = new WeakMap<Page, CDPSession>();
+}

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -179,8 +179,12 @@ export class RenderRunner {
     affinityKey: string,
     url: string,
     step: string,
+    jobId?: string,
   ): RenderProfileContext {
-    return { affinityKey, label: `${url} ${step}` };
+    // `card`/`step` mirror what `label` concatenates but stay structured so
+    // the artifact sink can key on them; `jobId` is threaded only by the
+    // visit path (on-demand screenshot/module/command renders carry none).
+    return { affinityKey, label: `${url} ${step}`, card: url, step, jobId };
   }
 
   #authKeys(auth: string): string[] | null {
@@ -891,7 +895,7 @@ export class RenderRunner {
             return await captureFileExtract(page, captureOptions);
           },
           opts?.timeoutMs,
-          this.#profileContext(affinityKey, url, 'file-extract'),
+          this.#profileContext(affinityKey, url, 'file-extract', jobId),
         );
         let extractResponse: FileExtractResponse;
         if (isRenderError(capture)) {
@@ -1060,7 +1064,7 @@ export class RenderRunner {
               page,
               fn,
               opts?.timeoutMs,
-              this.#profileContext(affinityKey, url, step),
+              this.#profileContext(affinityKey, url, step, jobId),
             ),
           );
           if (stepResult.ok) {
@@ -1085,7 +1089,7 @@ export class RenderRunner {
             return await renderHTML(page, 'isolated', 0, captureOptions);
           },
           opts?.timeoutMs,
-          this.#profileContext(affinityKey, url, 'card isolated/0'),
+          this.#profileContext(affinityKey, url, 'card isolated/0', jobId),
         );
         if (isRenderError(isolatedResult)) {
           cardShortCircuit = true;
@@ -1348,7 +1352,7 @@ export class RenderRunner {
               return await captureResult(page, 'innerHTML', captureOptions);
             },
             opts?.timeoutMs,
-            this.#profileContext(affinityKey, url, 'file isolated/0'),
+            this.#profileContext(affinityKey, url, 'file isolated/0', jobId),
           );
           if (isRenderError(isolatedResult)) {
             let renderError = isolatedResult as RenderError;
@@ -1384,7 +1388,7 @@ export class RenderRunner {
                   page,
                   () => renderHTML(page, 'head', 0, captureOptions),
                   opts?.timeoutMs,
-                  this.#profileContext(affinityKey, url, 'file head/0'),
+                  this.#profileContext(affinityKey, url, 'file head/0', jobId),
                 ),
             );
             if (headHTMLResult.ok) {
@@ -1463,7 +1467,7 @@ export class RenderRunner {
                   page,
                   step.cb,
                   opts?.timeoutMs,
-                  this.#profileContext(affinityKey, url, step.name),
+                  this.#profileContext(affinityKey, url, step.name, jobId),
                 ),
               );
               if (res.ok) {

--- a/packages/realm-server/prerender/trace-capture.ts
+++ b/packages/realm-server/prerender/trace-capture.ts
@@ -184,8 +184,10 @@ export async function captureTraceStream(
   }
 }
 
-// Resolves with the `tracingComplete` event (carrying the `IO` stream
-// handle), or rejects if the session errors first. Bounded by the caller.
+// Resolves with the `tracingComplete` event, which carries the `IO`
+// stream handle. Never rejects: if the session dies before the event
+// fires it simply never resolves, and the caller's `withTimeout` supplies
+// the fallback at the bound.
 function waitForTracingComplete(
   client: CDPSession,
 ): Promise<TracingCompleteEvent> {

--- a/packages/realm-server/prerender/trace-capture.ts
+++ b/packages/realm-server/prerender/trace-capture.ts
@@ -1,0 +1,318 @@
+// Streaming CDP `Tracing` capture for prerender pages.
+//
+// Why a trace stream, when we already have the CPU profiler:
+//
+//   The CDP `Profiler` only delivers its samples at `Profiler.stop`, and a
+//   fully-wedged renderer defeats that stop the same way it defeats
+//   `Performance.getMetrics` — the call needs the renderer's own thread to
+//   serialize the profile, and that thread is pegged. So the CPU profiler
+//   captures heavy-but-completing renders but structurally cannot capture
+//   the hard wedge.
+//
+//   `Tracing` with `transferMode: ReturnAsStream` fixes exactly that. The
+//   trace agent and the V8 sampler buffer trace events on their own
+//   browser-process threads as the render runs, so the samples leading into
+//   (and during) a wedge are already collected out-of-band before the
+//   renderer's thread locks. `Tracing.end` and the `IO.read` drain are
+//   browser-process operations too, so they return even while the page's
+//   main thread is fully pegged — no main-thread `stop` has to succeed.
+//
+//   Tracing also separates the work by category (JS execution / V8 GC /
+//   compile / layout / paint), so it can tell a JS spin apart from GC
+//   thrash — something a JS-only CPU profile can't.
+//
+// Caveat (inherent to any sampler): a hot frame only appears if the wedge
+// is actually CPU-spinning. A non-CPU block (a thread idle-waiting on
+// something) traces as idle — which is itself the answer, pivoting the
+// investigation to "what is it blocked on".
+//
+// Single-flight: browser-level tracing is a process-wide singleton — only
+// one `Tracing.start` can be active per browser, and every prerender page
+// shares one browser. This module enforces that with an in-process guard;
+// concurrent renders that would collide simply skip their trace (the
+// affinity trigger targets one realm, so collisions are rare and a skipped
+// trace is not a failure). The guard is released as soon as `Tracing.end`
+// completes — the draining of the finished stream runs on its own session
+// and does not block the next render's trace.
+
+import type { CDPSession, Page } from 'puppeteer';
+import { Readable } from 'stream';
+import { logger } from '@cardstack/runtime-common';
+
+const log = logger('prerenderer');
+
+// Trace categories chosen to separate the things a wedge investigation
+// needs to tell apart: JS execution + the in-trace CPU sampler, V8 GC, V8
+// compile, and the DevTools timeline (layout / paint / frames). `toplevel`
+// gives task boundaries; `blink.user_timing` surfaces the host's own
+// render-phase marks.
+const TRACE_CATEGORIES = [
+  'toplevel',
+  'devtools.timeline',
+  'disabled-by-default-devtools.timeline',
+  'disabled-by-default-devtools.timeline.frame',
+  'v8',
+  'v8.execute',
+  'disabled-by-default-v8.cpu_profiler',
+  'disabled-by-default-v8.gc',
+  'disabled-by-default-v8.compile',
+  'blink.user_timing',
+  'latencyInfo',
+];
+
+// Ring-buffer recording: keep capturing into a long wedge, retaining the
+// most recent events (the hot loop itself) rather than stopping when an
+// early-filled buffer would otherwise drop the wedge.
+const RECORD_MODE = 'recordContinuously';
+
+// Bytes per `IO.read` round trip while draining the finished trace.
+const IO_READ_CHUNK_BYTES = 1 << 20; // 1 MiB
+// Hard ceilings so a wedged or dead session can never stall the pool: the
+// trace finalize and the wait for its stream handle are each time-boxed,
+// mirroring the CPU profiler's `Profiler.stop` guard.
+const TRACING_END_TIMEOUT_MS = 5000;
+const TRACING_COMPLETE_TIMEOUT_MS = 5000;
+
+export interface TraceCaptureOptions {
+  // Work to trace across. The trace starts, this is awaited (or `maxRunMs`
+  // elapses, whichever is first), then the trace ends. `run` must not
+  // reject in a way that escapes — pass a never-rejecting observer; the
+  // caller retains ownership of the render's own result/rejection.
+  run: () => Promise<void>;
+  // Upper bound on the trace window. A render can hang past its timeout
+  // (the case this targets); without the bound the trace would run until
+  // the tab is torn down. When it fires, the trace ends with whatever was
+  // buffered. Omitted means "wait for `run`".
+  maxRunMs?: number;
+}
+
+// Local subset of the CDP shapes used here. As in `cpu-profiler.ts` we
+// avoid importing `devtools-protocol` (a transitive, not direct, dep of
+// puppeteer) and declare only the fields read.
+//   https://chromedevtools.github.io/devtools-protocol/tot/Tracing/
+//   https://chromedevtools.github.io/devtools-protocol/tot/IO/
+interface TracingCompleteEvent {
+  stream?: string;
+}
+interface IoReadResult {
+  data: string;
+  eof: boolean;
+  base64Encoded?: boolean;
+}
+
+// Process-wide guard: at most one active browser trace at a time.
+let tracingActive = false;
+let tracingBusyLogged = false;
+
+// Starts a browser trace across the window defined by `run` (or `maxRunMs`),
+// ends it, and returns a `Readable` that drains the finished trace from the
+// CDP `IO` stream — ready to hand straight to the artifact sink's streaming
+// upload. Returns `null` (never throws) when a trace is already active, or
+// on any CDP error / timeout. The returned stream owns its CDP session and
+// closes the `IO` handle + detaches when fully drained or destroyed.
+export async function captureTraceStream(
+  page: Page,
+  options: TraceCaptureOptions,
+): Promise<Readable | null> {
+  if (tracingActive) {
+    if (!tracingBusyLogged) {
+      tracingBusyLogged = true;
+      log.debug(
+        'trace capture skipped: a browser trace is already active ' +
+          '(browser-wide tracing is single-flight)',
+      );
+    }
+    return null;
+  }
+  tracingActive = true;
+
+  let client: CDPSession | undefined;
+  let released = false;
+  // Release the single-flight guard exactly once. Called after
+  // `Tracing.end` so the next render can trace while this trace's stream
+  // drains independently, and on every failure path so a guard is never
+  // leaked.
+  let releaseTracing = () => {
+    if (!released) {
+      released = true;
+      tracingActive = false;
+      tracingBusyLogged = false;
+    }
+  };
+
+  try {
+    client = await page.createCDPSession();
+    // Register the completion listener before ending: `Tracing.end` only
+    // signals that finalization started; the stream handle arrives on the
+    // `tracingComplete` event.
+    let completed = waitForTracingComplete(client);
+    await client.send('Tracing.start', {
+      transferMode: 'ReturnAsStream',
+      traceConfig: {
+        recordMode: RECORD_MODE,
+        includedCategories: TRACE_CATEGORIES,
+      },
+    });
+
+    await waitForRunOrBound(options.run(), options.maxRunMs);
+
+    await withTimeout(
+      client.send('Tracing.end'),
+      TRACING_END_TIMEOUT_MS,
+      undefined,
+    );
+    let event = await withTimeout(
+      completed,
+      TRACING_COMPLETE_TIMEOUT_MS,
+      null as TracingCompleteEvent | null,
+    );
+    // The browser trace is finalized — free the guard so the next render's
+    // trace can start while this one's bytes stream out below.
+    releaseTracing();
+
+    let handle = event?.stream;
+    if (!handle) {
+      await detachQuietly(client);
+      return null;
+    }
+    return drainTraceStream(client, handle);
+  } catch (e) {
+    log.debug('trace capture failed:', e);
+    await detachQuietly(client);
+    releaseTracing();
+    return null;
+  }
+}
+
+// Resolves with the `tracingComplete` event (carrying the `IO` stream
+// handle), or rejects if the session errors first. Bounded by the caller.
+function waitForTracingComplete(
+  client: CDPSession,
+): Promise<TracingCompleteEvent> {
+  return new Promise<TracingCompleteEvent>((resolve) => {
+    client.once('Tracing.tracingComplete', (event: unknown) =>
+      resolve((event ?? {}) as TracingCompleteEvent),
+    );
+  });
+}
+
+// Wraps the finished trace's `IO` stream as a `Readable`, pulling one
+// `IO.read` chunk per `_read` so backpressure from a slow S3 upload
+// naturally throttles the drain. Closes the handle and detaches the session
+// on EOF, error, or destroy.
+function drainTraceStream(client: CDPSession, handle: string): Readable {
+  let reading = false;
+  let cleanedUp = false;
+  let cleanup = async () => {
+    if (cleanedUp) {
+      return;
+    }
+    cleanedUp = true;
+    try {
+      await client.send('IO.close', { handle });
+    } catch {
+      // Handle may already be gone with the session; ignore.
+    }
+    await detachQuietly(client);
+  };
+
+  return new Readable({
+    read() {
+      if (reading) {
+        return;
+      }
+      reading = true;
+      void (async () => {
+        try {
+          let result = (await client.send('IO.read', {
+            handle,
+            size: IO_READ_CHUNK_BYTES,
+          })) as IoReadResult;
+          if (result.data) {
+            this.push(
+              Buffer.from(
+                result.data,
+                result.base64Encoded ? 'base64' : 'utf8',
+              ),
+            );
+          }
+          if (result.eof) {
+            this.push(null);
+            await cleanup();
+          }
+        } catch (e) {
+          await cleanup();
+          this.destroy(e as Error);
+        } finally {
+          reading = false;
+        }
+      })();
+    },
+    destroy(err, callback) {
+      void cleanup().finally(() => callback(err));
+    },
+  });
+}
+
+// Resolves when `run` settles or `maxRunMs` elapses, whichever is first;
+// reflects `run` so its rejection resolves (not throws) here — the caller
+// owns that rejection. Mirrors the CPU profiler's window wait.
+async function waitForRunOrBound(
+  run: Promise<void>,
+  maxRunMs: number | undefined,
+): Promise<void> {
+  let reflected = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  if (typeof maxRunMs !== 'number' || maxRunMs <= 0) {
+    await reflected;
+    return;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      reflected,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, maxRunMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Races a CDP command against a hard timeout, resolving to `fallback` if it
+// doesn't return in time. Never throws — a wedged or dead session can't
+// stall the pool here.
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  fallback: T,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.catch(() => fallback),
+      new Promise<T>((resolve) => {
+        timer = setTimeout(() => resolve(fallback), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function detachQuietly(client: CDPSession | undefined): Promise<void> {
+  try {
+    await client?.detach();
+  } catch {
+    // Session may already be gone with the page; ignore.
+  }
+}
+
+// Test-only: clear the single-flight guard between cases.
+export function __resetTraceCaptureForTests(): void {
+  tracingActive = false;
+  tracingBusyLogged = false;
+}

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -15,6 +15,20 @@ import {
   getAffinityProfileTargets,
   shouldProfileAffinity,
 } from './cpu-profiler.ts';
+import { fromAffinityKey } from './affinity.ts';
+import { captureTraceStream } from './trace-capture.ts';
+import {
+  ensureHeapSampling,
+  captureHeapSamplingProfile,
+} from './heap-sampler.ts';
+import {
+  artifactSinkEnabled,
+  shouldCaptureCpuProfile,
+  shouldCaptureTrace,
+  shouldCaptureHeap,
+  uploadArtifact,
+  type ArtifactKeyParts,
+} from './artifact-sink.ts';
 
 import type { CDPSession, Page } from 'puppeteer';
 
@@ -1413,20 +1427,57 @@ export interface RenderProfileContext {
   // e.g. `<card-url> isolated/0` — identifies which render produced the
   // profile in the per-render affinity-trigger log line.
   label?: string;
+  // Structured identifiers for keying the heavyweight artifacts in the S3
+  // sink (`env/realm/jobId/card/step/...`). `card` and `step` mirror what
+  // `label` concatenates; `jobId` is the indexing job and is set only for
+  // visits. The realm is recovered from `affinityKey`, so it isn't carried
+  // here. All optional — the sink falls back to `no-<field>` segments.
+  card?: string;
+  step?: string;
+  jobId?: string;
 }
 
-// Runs `fn` under a CDP CPU profile and logs the top self-time frames,
-// keyed by the render's label and wall-duration. Used only by the
-// affinity-scoped trigger, for renders whose affinity exactly matches
-// the configured target.
+// Derives the S3 artifact-key fields from a render's profile context. The
+// realm is recovered from the affinity key (which encodes it); card / step
+// / jobId pass through. Used only for keying the heavyweight artifacts.
+function artifactKeyPartsFor(
+  profileContext: RenderProfileContext | undefined,
+): Omit<ArtifactKeyParts, 'kind'> {
+  let realm: string | undefined;
+  if (profileContext?.affinityKey) {
+    realm = fromAffinityKey(profileContext.affinityKey)?.affinityValue;
+  }
+  return {
+    realm,
+    jobId: profileContext?.jobId,
+    card: profileContext?.card,
+    step: profileContext?.step,
+  };
+}
+
+// Runs `fn` under the affinity-scoped CPU profile (always: logs the top
+// self-time frames, keyed by the render's label and wall-duration) and,
+// when the artifact sink is configured and the matching per-mode flag is
+// on, also persists the heavyweight blobs that don't fit a log line:
 //
-// The render promise drives the return value directly — this resolves
-// or rejects exactly as `fn` does, so the caller's error/timeout
-// handling is unchanged and a render that hangs leaves this awaiting (the
-// outer `withTimeout` race owns the timeout). The profile runs alongside
-// as a detached best-effort task, bounded by `timeoutMs`: if the render
-// hangs past its own timeout, the profiler still stops and detaches at
-// the bound rather than holding a CDP session open on the wedged page.
+//   * full `.cpuprofile` — the raw of the same profile the summary comes
+//     from, so it adds a flush, not a second CPU profiler;
+//   * a streaming CDP trace — the one capture that survives a fully-wedged
+//     renderer (browser-process drain, no main-thread `stop`);
+//   * the cumulative heap allocation-sampling profile, read after the
+//     render window so its per-render series shows what kept allocating.
+//
+// Used only by the affinity-scoped trigger, for renders whose affinity
+// exactly matches the configured target.
+//
+// The render promise drives the return value directly — this resolves or
+// rejects exactly as `fn` does, so the caller's error/timeout handling is
+// unchanged and a render that hangs leaves this awaiting (the outer
+// `withTimeout` race owns the timeout). Every capture runs alongside as a
+// detached best-effort task bounded by `timeoutMs`: a render that hangs
+// past its own timeout still stops the profiler / ends the trace at the
+// bound rather than holding a CDP session open on the wedged page, and any
+// capture or upload failure is swallowed so it never perturbs the render.
 function runWithAffinityProfile<T>(
   page: Page,
   fn: () => Promise<T>,
@@ -1434,20 +1485,64 @@ function runWithAffinityProfile<T>(
   profileContext: RenderProfileContext | undefined,
 ): Promise<T> {
   let render = fn();
+  let observe = () =>
+    render.then(
+      () => undefined,
+      () => undefined,
+    );
+
+  // The heavyweight captures only matter when the sink is configured AND
+  // the operator has flipped the matching flag — every gate short-circuits
+  // on a cheap env read otherwise, so the default affinity behaviour
+  // (summary log only) issues no extra CDP calls and pays nothing.
+  let sinkOn = artifactSinkEnabled();
+  let wantCpuProfile = sinkOn && shouldCaptureCpuProfile();
+  let wantTrace = sinkOn && shouldCaptureTrace();
+  let wantHeap = sinkOn && shouldCaptureHeap();
+  let keyParts = artifactKeyPartsFor(profileContext);
+
+  // Heap sampling is cumulative across the tab, so start it before the
+  // render so this render's allocations are sampled; the cumulative read
+  // happens after the window closes (below).
+  if (wantHeap) {
+    void ensureHeapSampling(page);
+  }
+
+  // The streaming trace starts as early as possible and ends at
+  // render-settle / `timeoutMs`. Drained straight into the sink's managed
+  // upload so memory stays bounded even for a large trace.
+  if (wantTrace) {
+    void captureTraceStream(page, { run: observe, maxRunMs: timeoutMs })
+      .then((stream) => {
+        if (stream) {
+          return uploadArtifact({ ...keyParts, kind: 'trace', body: stream });
+        }
+        return undefined;
+      })
+      .catch(() => {
+        // Best-effort: a missing trace is a missing diagnostic.
+      });
+  }
+
   // Detached: the profile's log line is diagnostic and must not gate the
   // render's return. `profileWindow` observes `render` only for timing
   // (it never consumes the result/rejection) and stops on whichever of
-  // render-settles / `timeoutMs` comes first.
+  // render-settles / `timeoutMs` comes first. When the cpuprofile flag is
+  // on, the same run's raw profile is flushed to the sink.
   void profileWindow(page, {
     samplingIntervalUs: AFFINITY_PROFILE_SAMPLING_INTERVAL_US,
     maxRunMs: timeoutMs,
-    run: () =>
-      render.then(
-        () => undefined,
-        () => undefined,
-      ),
+    run: observe,
+    onRawProfile: wantCpuProfile
+      ? (rawProfile) =>
+          uploadArtifact({
+            ...keyParts,
+            kind: 'cpuprofile',
+            body: Buffer.from(JSON.stringify(rawProfile), 'utf8'),
+          })
+      : undefined,
   })
-    .then((summary) => {
+    .then(async (summary) => {
       let top = formatTopFrames(summary);
       if (top && summary) {
         log.warn(
@@ -1456,6 +1551,19 @@ function runWithAffinityProfile<T>(
             ` samples=${summary.totalSamples}` +
             ` topFrames: ${top}`,
         );
+      }
+      // The profiler window has closed (render settled or bound elapsed),
+      // so the cumulative heap profile now reflects this render. Read and
+      // flush it — each upload is a point in the per-render growth series.
+      if (wantHeap) {
+        let heapProfile = await captureHeapSamplingProfile(page);
+        if (heapProfile) {
+          await uploadArtifact({
+            ...keyParts,
+            kind: 'heap',
+            body: heapProfile,
+          });
+        }
       }
     })
     .catch(() => {

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -1478,19 +1478,12 @@ function artifactKeyPartsFor(
 // past its own timeout still stops the profiler / ends the trace at the
 // bound rather than holding a CDP session open on the wedged page, and any
 // capture or upload failure is swallowed so it never perturbs the render.
-function runWithAffinityProfile<T>(
+async function runWithAffinityProfile<T>(
   page: Page,
   fn: () => Promise<T>,
   timeoutMs: number,
   profileContext: RenderProfileContext | undefined,
 ): Promise<T> {
-  let render = fn();
-  let observe = () =>
-    render.then(
-      () => undefined,
-      () => undefined,
-    );
-
   // The heavyweight captures only matter when the sink is configured AND
   // the operator has flipped the matching flag — every gate short-circuits
   // on a cheap env read otherwise, so the default affinity behaviour
@@ -1501,12 +1494,23 @@ function runWithAffinityProfile<T>(
   let wantHeap = sinkOn && shouldCaptureHeap();
   let keyParts = artifactKeyPartsFor(profileContext);
 
-  // Heap sampling is cumulative across the tab, so start it before the
-  // render so this render's allocations are sampled; the cumulative read
-  // happens after the window closes (below).
+  // Heap sampling is cumulative across the tab and must be running BEFORE
+  // the render starts: otherwise the first targeted render's early (route
+  // transition / module load) allocations land before the sampler attaches,
+  // and that early growth is exactly what this mode is meant to diagnose.
+  // `ensureHeapSampling` is idempotent per tab and never throws, so this
+  // awaits a one-time setup on the first profiled render and is a no-op
+  // thereafter.
   if (wantHeap) {
-    void ensureHeapSampling(page);
+    await ensureHeapSampling(page);
   }
+
+  let render = fn();
+  let observe = () =>
+    render.then(
+      () => undefined,
+      () => undefined,
+    );
 
   // The streaming trace starts as early as possible and ends at
   // render-settle / `timeoutMs`. Drained straight into the sink's managed

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -190,6 +190,7 @@ const ALL_TEST_FILES: string[] = [
   './prerendering-test',
   './prerender-server-test',
   './prerender-manager-test',
+  './prerender-artifact-sink-test',
   './prerender-affinity-activity-test',
   './prerender-batch-ownership-test',
   './prerender-cancellation-test',

--- a/packages/realm-server/tests/prerender-artifact-sink-test.ts
+++ b/packages/realm-server/tests/prerender-artifact-sink-test.ts
@@ -1,0 +1,200 @@
+import { module, test } from 'qunit';
+import {
+  buildArtifactKey,
+  getMaxSessionBytes,
+  artifactSinkEnabled,
+  anyArtifactCaptureEnabled,
+  shouldCaptureCpuProfile,
+  shouldCaptureTrace,
+  shouldCaptureHeap,
+} from '../prerender/artifact-sink.ts';
+
+// The heavyweight artifact sink is gated by env (a configured bucket plus
+// per-mode flags) and keys every blob by render identity. These tests pin
+// the dependency-free pieces — key construction, the flag gates, and the
+// per-session byte budget — without touching S3 or Chrome. The env vars
+// are read at call time, so each case sets exactly what it needs and the
+// hooks restore the process environment afterwards.
+
+const ENV_KEYS = [
+  'PRERENDER_ARTIFACTS_BUCKET',
+  'PRERENDER_ARTIFACTS_ENV',
+  'PRERENDER_PROFILE_CPUPROFILE',
+  'PRERENDER_PROFILE_TRACE',
+  'PRERENDER_PROFILE_HEAP',
+  'PRERENDER_PROFILE_MAX_SESSION_BYTES',
+];
+
+function snapshotEnv(): Record<string, string | undefined> {
+  let snapshot: Record<string, string | undefined> = {};
+  for (let key of ENV_KEYS) {
+    snapshot[key] = process.env[key];
+  }
+  return snapshot;
+}
+
+function restoreEnv(snapshot: Record<string, string | undefined>): void {
+  for (let key of ENV_KEYS) {
+    if (snapshot[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = snapshot[key];
+    }
+  }
+}
+
+module('prerender artifact-sink key', function (hooks) {
+  let saved: Record<string, string | undefined>;
+  hooks.beforeEach(function () {
+    saved = snapshotEnv();
+    for (let key of ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+  hooks.afterEach(function () {
+    restoreEnv(saved);
+  });
+
+  let now = new Date('2026-06-10T14:30:00.000Z');
+
+  test('a fully-populated key sanitizes every segment and orders them env/realm/jobId/card/step/file', function (assert) {
+    process.env.PRERENDER_ARTIFACTS_ENV = 'staging';
+    let key = buildArtifactKey(
+      {
+        realm: 'https://realms.example/team/realm-a/',
+        jobId: 'job-123',
+        card: 'https://realms.example/team/realm-a/Card/1',
+        step: 'card isolated/0',
+        kind: 'cpuprofile',
+      },
+      now,
+      0,
+    );
+    assert.strictEqual(
+      key,
+      'staging/realms.example-team-realm-a/job-123/' +
+        'realms.example-team-realm-a-Card-1/card-isolated-0/' +
+        '2026-06-10T14-30-00-000Z-0.cpuprofile',
+    );
+  });
+
+  test('missing fields fall back to no-<field> segments and env to "unknown"', function (assert) {
+    let key = buildArtifactKey({ kind: 'trace' }, now, 7);
+    assert.strictEqual(
+      key,
+      'unknown/no-realm/no-job/no-card/no-step/' +
+        '2026-06-10T14-30-00-000Z-7.trace.json',
+    );
+  });
+
+  test('each artifact kind maps to its conventional file suffix', function (assert) {
+    let suffix = (kind: 'cpuprofile' | 'trace' | 'heap') =>
+      buildArtifactKey({ kind }, now, 0).split('.').slice(1).join('.');
+    assert.strictEqual(suffix('cpuprofile'), 'cpuprofile');
+    assert.strictEqual(suffix('trace'), 'trace.json');
+    assert.strictEqual(suffix('heap'), 'heapprofile');
+  });
+
+  test('the seq disambiguates artifacts that share a millisecond', function (assert) {
+    let a = buildArtifactKey({ kind: 'cpuprofile' }, now, 0);
+    let b = buildArtifactKey({ kind: 'cpuprofile' }, now, 1);
+    assert.notStrictEqual(a, b, 'distinct seq → distinct key');
+    assert.true(a.endsWith('-0.cpuprofile'));
+    assert.true(b.endsWith('-1.cpuprofile'));
+  });
+});
+
+module('prerender artifact-sink gates', function (hooks) {
+  let saved: Record<string, string | undefined>;
+  hooks.beforeEach(function () {
+    saved = snapshotEnv();
+    for (let key of ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+  hooks.afterEach(function () {
+    restoreEnv(saved);
+  });
+
+  test('the sink is enabled only when a non-empty bucket is configured', function (assert) {
+    assert.false(artifactSinkEnabled(), 'unset → disabled');
+    process.env.PRERENDER_ARTIFACTS_BUCKET = '   ';
+    assert.false(artifactSinkEnabled(), 'whitespace → disabled');
+    process.env.PRERENDER_ARTIFACTS_BUCKET =
+      'boxel-prerender-artifacts-staging';
+    assert.true(artifactSinkEnabled(), 'set → enabled');
+  });
+
+  test('each per-mode flag is on only for the exact string "true"', function (assert) {
+    for (let [flag, read] of [
+      ['PRERENDER_PROFILE_CPUPROFILE', shouldCaptureCpuProfile],
+      ['PRERENDER_PROFILE_TRACE', shouldCaptureTrace],
+      ['PRERENDER_PROFILE_HEAP', shouldCaptureHeap],
+    ] as const) {
+      delete process.env[flag];
+      assert.false(read(), `${flag} unset → off`);
+      process.env[flag] = 'false';
+      assert.false(read(), `${flag}=false → off`);
+      process.env[flag] = '1';
+      assert.false(read(), `${flag}=1 → off`);
+      process.env[flag] = 'TRUE';
+      assert.false(read(), `${flag}=TRUE → off (exact match only)`);
+      process.env[flag] = '  true  ';
+      assert.true(read(), `${flag} trims to "true" → on`);
+    }
+  });
+
+  test('anyArtifactCaptureEnabled requires the sink AND at least one mode', function (assert) {
+    process.env.PRERENDER_PROFILE_TRACE = 'true';
+    assert.false(
+      anyArtifactCaptureEnabled(),
+      'a flag without a bucket captures nothing',
+    );
+    process.env.PRERENDER_ARTIFACTS_BUCKET =
+      'boxel-prerender-artifacts-staging';
+    assert.true(anyArtifactCaptureEnabled(), 'bucket + a flag → enabled');
+    delete process.env.PRERENDER_PROFILE_TRACE;
+    assert.false(
+      anyArtifactCaptureEnabled(),
+      'a bucket with every mode off → nothing to capture',
+    );
+  });
+});
+
+module('prerender artifact-sink session budget', function (hooks) {
+  let saved: Record<string, string | undefined>;
+  hooks.beforeEach(function () {
+    saved = snapshotEnv();
+    for (let key of ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+  hooks.afterEach(function () {
+    restoreEnv(saved);
+  });
+
+  let defaultBytes = 5 * 1024 * 1024 * 1024;
+
+  test('unset / non-positive / unparseable falls back to the built-in default', function (assert) {
+    assert.strictEqual(getMaxSessionBytes(), defaultBytes, 'unset → default');
+    process.env.PRERENDER_PROFILE_MAX_SESSION_BYTES = '0';
+    assert.strictEqual(getMaxSessionBytes(), defaultBytes, '0 → default');
+    process.env.PRERENDER_PROFILE_MAX_SESSION_BYTES = '-5';
+    assert.strictEqual(
+      getMaxSessionBytes(),
+      defaultBytes,
+      'negative → default',
+    );
+    process.env.PRERENDER_PROFILE_MAX_SESSION_BYTES = 'lots';
+    assert.strictEqual(
+      getMaxSessionBytes(),
+      defaultBytes,
+      'unparseable → default',
+    );
+  });
+
+  test('a positive integer is honored', function (assert) {
+    process.env.PRERENDER_PROFILE_MAX_SESSION_BYTES = '1048576';
+    assert.strictEqual(getMaxSessionBytes(), 1048576);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2563,6 +2563,12 @@ importers:
 
   packages/realm-server:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1065.0
+        version: 3.1065.0
+      '@aws-sdk/lib-storage':
+        specifier: ^3.1065.0
+        version: 3.1065.0(@aws-sdk/client-s3@3.1065.0)
       morphdom:
         specifier: ^2.7.8
         version: 2.7.8
@@ -3441,16 +3447,118 @@ packages:
   '@atlaskit/pragmatic-drag-and-drop@1.8.1':
     resolution: {integrity: sha512-uXWNPpL8n4OmTVbduH7nq8pk8htqGo/prR5cYEE8sVCPJGAUMWn6lzvWTfI+4VCeQvHiDRODVz4YzH06OVAxhw==}
 
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
   '@aws-crypto/sha256-js@5.2.0':
     resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
     engines: {node: '>=16.0.0'}
 
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/checksums@3.1000.4':
+    resolution: {integrity: sha512-Pt1JEVLu02jTWzpcUzUHciiWScyZg3JpHCTB1h9DtDPWY3dBufBnFJAevVHali/bAkmMdMhYUD8tH/VvPuBkUg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1065.0':
+    resolution: {integrity: sha512-KtCpg2vihUjhUpqpsZIcB6Dm1hv9lRn5hWwU6hXtYfSQionFD/dB/gTwgyn9AHX6eGiCFqHfjIZwETz5Cz4RWA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.20':
+    resolution: {integrity: sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.46':
+    resolution: {integrity: sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.48':
+    resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.52':
+    resolution: {integrity: sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.51':
+    resolution: {integrity: sha512-csHFsH+/VjnI40oqm1l1OqMY4B4kza36DbfcbHcgcbobgjebasqUbTU34xvwUkvtoNGGizbfyMSlMzJWUPv3dQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.54':
+    resolution: {integrity: sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.46':
+    resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.51':
+    resolution: {integrity: sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.51':
+    resolution: {integrity: sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/lib-storage@3.1065.0':
+    resolution: {integrity: sha512-0eEVoAWuvob9BkiKc/jtFPaOQYR7hbW6xioTe3b1U1WpwyVLKO6KROdm1zpMC7k5EOpVDhdFXkqZvFSCJuc4Uw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.1065.0
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.29':
+    resolution: {integrity: sha512-ALTHDXk6YWVDfAWIHzXyaTZ82QFoMWhHENXlO61lv4ZqSMl3cvh2s0ZVOS89qbtw9LRJhIDoZaaC9FYo/Z4KLQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.50':
+    resolution: {integrity: sha512-yOXn9mmJQQODpbmwQB224IX1PLLneyqInX2Fv2nEmSHWpJj54nrzdrUT1TGQk/s8mr+XPssDQy1at/8GS4EFVQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.19':
+    resolution: {integrity: sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.33':
+    resolution: {integrity: sha512-Hn0RThJEbyOZWV2PV9Z4YD3nitGPxybmyU17dSe9b61WOBcKnqS0WTtM3c1zyZq9WnGiyrfi/i+UBPUk7cM8Ug==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1065.0':
+    resolution: {integrity: sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.12':
+    resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.8':
     resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
     engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.7':
+    resolution: {integrity: sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.29':
+    resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@azu/format-text@1.0.2':
     resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
@@ -5427,6 +5535,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -6410,12 +6521,36 @@ packages:
   '@sinonjs/samsam@8.0.3':
     resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
 
+  '@smithy/core@3.24.6':
+    resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.8':
+    resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.6':
+    resolution: {integrity: sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
+  '@smithy/node-http-handler@4.7.7':
+    resolution: {integrity: sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.6':
+    resolution: {integrity: sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.3':
+    resolution: {integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
@@ -7388,6 +7523,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.0:
+    resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
+
   aproba@2.1.0:
     resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
 
@@ -7832,6 +7970,9 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -8063,6 +8204,9 @@ packages:
 
   buffer@4.9.2:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
+
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -10365,6 +10509,13 @@ packages:
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -13005,6 +13156,10 @@ packages:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -14373,6 +14528,9 @@ packages:
     resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
     engines: {node: '>=12.*'}
 
+  strnum@2.4.0:
+    resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
+
   structured-source@4.0.0:
     resolution: {integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==}
 
@@ -15546,6 +15704,10 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
     engines: {node: '>=4.0.0'}
@@ -15766,10 +15928,45 @@ snapshots:
       bind-event-listener: 3.0.0
       raf-schd: 4.0.3
 
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.7
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.7
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
       tslib: 2.8.1
 
   '@aws-crypto/util@5.2.0':
@@ -15778,10 +15975,203 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/checksums@3.1000.4':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1065.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/credential-provider-node': 3.972.54
+      '@aws-sdk/middleware-flexible-checksums': 3.974.29
+      '@aws-sdk/middleware-sdk-s3': 3.972.50
+      '@aws-sdk/signature-v4-multi-region': 3.996.33
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.20':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/xml-builder': 3.972.29
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.6
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.46':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.48':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/credential-provider-env': 3.972.46
+      '@aws-sdk/credential-provider-http': 3.972.48
+      '@aws-sdk/credential-provider-login': 3.972.51
+      '@aws-sdk/credential-provider-process': 3.972.46
+      '@aws-sdk/credential-provider-sso': 3.972.51
+      '@aws-sdk/credential-provider-web-identity': 3.972.51
+      '@aws-sdk/nested-clients': 3.997.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.54':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.46
+      '@aws-sdk/credential-provider-http': 3.972.48
+      '@aws-sdk/credential-provider-ini': 3.972.52
+      '@aws-sdk/credential-provider-process': 3.972.46
+      '@aws-sdk/credential-provider-sso': 3.972.51
+      '@aws-sdk/credential-provider-web-identity': 3.972.51
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.46':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.19
+      '@aws-sdk/token-providers': 3.1065.0
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/lib-storage@3.1065.0(@aws-sdk/client-s3@3.1065.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1065.0
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.29':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.4
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.50':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/signature-v4-multi-region': 3.996.33
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.19':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/signature-v4-multi-region': 3.996.33
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.33':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1065.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.19
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.12':
+    dependencies:
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.8':
     dependencies:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.29':
+    dependencies:
+      '@smithy/types': 4.14.3
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@azu/format-text@1.0.2': {}
 
@@ -18182,6 +18572,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@nodable/entities@2.1.1': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -19287,11 +19679,45 @@ snapshots:
       '@sinonjs/commons': 3.0.1
       type-detect: 4.1.0
 
+  '@smithy/core@3.24.6':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.8':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.6':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.7':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.6':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.3':
     dependencies:
       tslib: 2.8.1
 
@@ -20451,6 +20877,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  anynum@1.0.0: {}
+
   aproba@2.1.0: {}
 
   archiver-utils@5.0.2:
@@ -20966,6 +21394,8 @@ snapshots:
   boolean@3.2.0: {}
 
   boundary@2.0.0: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.14:
     dependencies:
@@ -21507,6 +21937,11 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.1.13
       isarray: 1.0.0
+
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buffer@5.7.1:
     dependencies:
@@ -24932,6 +25367,18 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.1
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -27898,6 +28345,8 @@ snapshots:
 
   path-exists@5.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@2.0.1: {}
@@ -29538,6 +29987,10 @@ snapshots:
       '@types/node': 25.7.0
       qs: 6.15.1
 
+  strnum@2.4.0:
+    dependencies:
+      anynum: 1.0.0
+
   structured-source@4.0.0:
     dependencies:
       boundary: 2.0.0
@@ -30923,6 +31376,8 @@ snapshots:
   xml-name-validator@4.0.0: {}
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xml2js@0.5.0:
     dependencies:


### PR DESCRIPTION
## What

The affinity-scoped prerender CPU profiler logs a top-N self-time summary — enough to *name* a hot or looping function, but it can't carry the full artifacts needed for deeper analysis. This adds an opt-in, prerender-owned S3 sink that persists the heavyweight captures **per render**:

- **Full `.cpuprofile`** (`PRERENDER_PROFILE_CPUPROFILE`) — the complete V8 call tree behind the summary, for Chrome DevTools / speedscope.
- **Streaming CDP trace** (`PRERENDER_PROFILE_TRACE`) — `Tracing` with `transferMode: ReturnAsStream`, drained out-of-band via `IO.read`. This is the one capture that survives a **fully-wedged** renderer (no main-thread `Profiler.stop` has to succeed), and it separates JS / GC / compile / layout / paint so a JS spin can be told apart from GC thrash.
- **Heap allocation sampling** (`PRERENDER_PROFILE_HEAP`) — sampling started once per affinity tab; the cumulative profile is flushed per render, so consecutive uploads diff into an allocation-growth story.

## How it's gated and bounded

Each capture requires **both** the affinity target (`PRERENDER_PROFILE_AFFINITY`, the existing summary trigger) **and** its own per-mode flag, so a realm can be summarised in logs without also paying to persist a blob. With no bucket configured or no flag set, the path short-circuits on a cheap env read and issues no extra CDP calls.

Artifacts are keyed `env/realm/jobId/card/step/<timestamp>` and bounded by a per-session byte budget (`PRERENDER_PROFILE_MAX_SESSION_BYTES`, default 5 GiB) on top of the bucket's lifecycle expiry. Every capture and upload is best-effort — a failure is a missing diagnostic, never a perturbed render. Browser-wide tracing is single-flight, so concurrent targeted renders skip their trace rather than collide.

## Shape

- New `prerender/artifact-sink.ts`, `trace-capture.ts`, `heap-sampler.ts`; a raw-profile hook on `cpu-profiler.ts`; the `runWithAffinityProfile` orchestrator in `prerender/utils.ts` drives the three captures.
- `indexing-diagnostics` skill gains "Mode H": the two-tier capture model, the SSM knob table, how to run a capture session, and how to pull + read each artifact.
- Unit tests cover key construction, the flag gates, and the byte budget.

## Pairs with

The bucket, the task-role write grant, the `boxel-claude-readonly` read grant, and the SSM wiring are provisioned in the infra repo. This code no-ops until the bucket env var is set, so it's inert wherever capture isn't deliberately enabled.

> Draft: the `@aws-sdk/client-s3` / `@aws-sdk/lib-storage` release pinned in the lockfile clears the repo's `minimumReleaseAge` window shortly; held as a draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)