### PR TITLE
Unified search: default render type to native (drop filter.on default + native escape valve)

### DIFF
--- a/packages/host/app/lib/unified-search-results.ts
+++ b/packages/host/app/lib/unified-search-results.ts
@@ -18,10 +18,13 @@ import { htmlComponent, type HTMLComponent } from './html-component.ts';
 // its Store-resident card live (under `renderType`).
 export interface RenderableSearchItem {
   id: string;
-  // An explicit ancestor render-type override (the collection's
-  // `meta.renderType`), so a live/fallback row renders as the same ancestor
-  // type as its HTML siblings. Absent by default — each row renders in its own
-  // (native) type.
+  // An explicit ancestor render-type override carried from the collection's
+  // `meta.renderType`, so a live/fallback row renders as the same ancestor type
+  // as its HTML siblings. Absent on the default (native) path: there is no
+  // collection-level override, so the consumer renders each row in its own
+  // type — `CardRenderer` with no `@codeRef` does exactly this — rather than a
+  // forced ancestor. (It does not happen automatically here; this field only
+  // carries the override, leaving the per-row native fallback to the consumer.)
   renderType: CodeRef | undefined;
   // The inert prerendered component, present only for HTML-backed rows.
   component: HTMLComponent | undefined;

--- a/packages/host/app/lib/unified-search-results.ts
+++ b/packages/host/app/lib/unified-search-results.ts
@@ -18,8 +18,10 @@ import { htmlComponent, type HTMLComponent } from './html-component.ts';
 // its Store-resident card live (under `renderType`).
 export interface RenderableSearchItem {
   id: string;
-  // The collection's resolved render type, so a live/fallback row renders as
-  // the same ancestor type as its HTML siblings.
+  // An explicit ancestor render-type override (the collection's
+  // `meta.renderType`), so a live/fallback row renders as the same ancestor
+  // type as its HTML siblings. Absent by default — each row renders in its own
+  // (native) type.
   renderType: CodeRef | undefined;
   // The inert prerendered component, present only for HTML-backed rows.
   component: HTMLComponent | undefined;

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -101,10 +101,10 @@ export default function handleSearch(opts: {
     let cardsQuery = parsed.cardsQuery;
 
     // Resolve the prefer-HTML spec when the caller explicitly asked to render.
-    // `render.renderType` resolves to one ancestor type — an explicit CodeRef,
-    // `"native"` (each result's own most-derived type), or the query's
-    // `filter.on` when omitted — which selects the HTML column and is echoed in
-    // the response. `format` is the HTML column to read.
+    // `render.renderType` is an optional explicit ancestor-type override (a
+    // CodeRef) that selects the HTML column and is echoed in the response;
+    // omitted, each result renders in its own actual (native) type. `format`
+    // is the HTML column to read.
     let renderSpec:
       | { format: PrerenderedHtmlFormat; renderType?: CodeRef }
       | undefined;
@@ -123,10 +123,8 @@ export default function handleSearch(opts: {
         return;
       }
       let format = parsed.render.format;
-      let filterOn = (cardsQuery.filter as { on?: CodeRef } | undefined)?.on;
       let renderType = resolveRenderType({
         renderType: parsed.render.renderType,
-        filterOn,
       });
       renderSpec = { format, ...(renderType ? { renderType } : {}) };
     }

--- a/packages/realm-server/tests/render-type-resolution-test.ts
+++ b/packages/realm-server/tests/render-type-resolution-test.ts
@@ -28,43 +28,24 @@ module(basename(__filename), function () {
       assert.deepEqual(
         resolveRenderType({
           renderType: explicitRef,
-          filterOn: baseRef,
           types: [subRef, baseRef],
         }),
         explicitRef,
-        'the explicit CodeRef is used regardless of filterOn / types',
+        'the explicit ancestor override is used regardless of the result types',
       );
     });
 
-    test('"native" resolves to the most-derived type (types[0])', function (assert) {
+    test('an omitted renderType resolves to the result’s own actual type (types[0])', function (assert) {
       assert.deepEqual(
         resolveRenderType({
-          renderType: 'native',
-          filterOn: baseRef,
           types: [subRef, baseRef],
         }),
         subRef,
-        'native renders each result in its own actual type',
+        'the default renders each result in its own most-derived (native) type — not the searched-against ancestor',
       );
     });
 
-    test('an omitted renderType resolves to filter.on', function (assert) {
-      assert.deepEqual(
-        resolveRenderType({
-          filterOn: baseRef,
-          types: [subRef, baseRef],
-        }),
-        baseRef,
-        'the default is the common ancestor searched on',
-      );
-    });
-
-    test('an omitted renderType with no filter.on falls back to the most-derived type', function (assert) {
-      assert.deepEqual(
-        resolveRenderType({ types: [subRef, baseRef] }),
-        subRef,
-        'with no filter.on, render as the actual type',
-      );
+    test('an omitted renderType with no types resolves to undefined', function (assert) {
       assert.strictEqual(
         resolveRenderType({}),
         undefined,

--- a/packages/realm-server/tests/server-endpoints/search-test.ts
+++ b/packages/realm-server/tests/server-endpoints/search-test.ts
@@ -81,6 +81,48 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
           },
         },
       },
+      // A two-link adoption chain (SubThing → BaseThing → CardDef) with a
+      // distinct fitted template per type, so a render against the SubThing
+      // instance is identifiable as native (SubThing) vs the BaseThing ancestor
+      // override. Each `.gts` exercises the per-ancestor HTML the indexer keys
+      // by type, which the render-type default/override paths select between.
+      'base-thing.gts': `
+        import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+        import StringField from "https://cardstack.com/base/string";
+
+        export class BaseThing extends CardDef {
+          static displayName = 'BaseThing';
+          @field label = contains(StringField);
+          static fitted = class Fitted extends Component<typeof this> {
+            <template>BaseThing fitted: <@fields.label/></template>
+          }
+        }
+      `,
+      'sub-thing.gts': `
+        import { Component } from "https://cardstack.com/base/card-api";
+        import { BaseThing } from './base-thing';
+
+        export class SubThing extends BaseThing {
+          static displayName = 'SubThing';
+          static fitted = class Fitted extends Component<typeof this> {
+            <template>SubThing fitted: <@fields.label/></template>
+          }
+        }
+      `,
+      'sub-instance.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            label: 'render-type probe',
+          },
+          meta: {
+            adoptsFrom: {
+              module: rri('./sub-thing'),
+              name: 'SubThing',
+            },
+          },
+        },
+      },
     };
 
     async function startSearchRealmServer({
@@ -598,6 +640,151 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
       assert.notOk(
         included.find((r) => r.type === 'rendered-html' && r.id === liveUrl),
         'no rendered-html is emitted for the live fallback row',
+      );
+    });
+
+    // Native-default render type: with no `render.renderType`, each result
+    // renders in its OWN actual (most-derived) type — even when the query is
+    // `on:` a common ancestor. A SubThing instance matched by an `on: BaseThing`
+    // query renders/echoes SubThing, never the BaseThing ancestor, and the
+    // response carries no collection-level render type (each row echoes its own).
+    test('QUERY /_federated-search default render type is native — a SubThing matched by on: BaseThing renders/echoes SubThing, not the ancestor', async function (assert) {
+      let realmServerToken = createRealmServerJWT(
+        { user: ownerUserId, sessionRoom: 'session-room-test' },
+        realmSecretSeed,
+      );
+      let subId = `${testRealm.url}sub-instance`;
+      let baseThingRef = {
+        module: rri(`${testRealm.url}base-thing`),
+        name: 'BaseThing',
+      };
+
+      let searchURL = new URL('/_federated-search', testRealm.url);
+      let response = await request
+        .post(`${searchURL.pathname}${searchURL.search}`)
+        .set('Accept', 'application/vnd.card+json')
+        .set('Content-Type', 'application/json')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Authorization', `Bearer ${realmServerToken}`)
+        // `on: BaseThing` matches the SubThing instance (it adopts BaseThing);
+        // no `render.renderType` → the native default.
+        .send({
+          // An `on: BaseThing` query (the ancestor) with a predicate — the
+          // case the old default rendered as the `filter.on` ancestor.
+          filter: { on: baseThingRef, eq: { label: 'render-type probe' } },
+          realms: [testRealm.url],
+          render: { format: 'fitted' },
+        });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200');
+      let data = response.body.data as any[];
+      let included = (response.body.included ?? []) as any[];
+
+      // The native default carries NO collection-level render type — each row
+      // varies by its own type and echoes it on its rendered-html.
+      assert.notOk(
+        response.body.meta?.renderType,
+        'no collection-level renderType on the native default path',
+      );
+
+      let card = data.find((r) => r.id === subId);
+      assert.ok(card, 'the SubThing instance is in data');
+      assert.strictEqual(
+        card.meta?.adoptsFrom?.name,
+        'SubThing',
+        'adoptsFrom is the actual (SubThing) type',
+      );
+      assert.strictEqual(
+        card.meta?.renderType?.name,
+        'SubThing',
+        'the identity-only card echoes its own (native) render type',
+      );
+
+      let rendered = included.find(
+        (r) => r.type === 'rendered-html' && r.id === subId,
+      );
+      assert.ok(rendered, 'a rendered-html for the SubThing rides in included');
+      assert.strictEqual(
+        rendered.meta?.renderType?.name,
+        'SubThing',
+        'rendered-html echoes the SubThing (native) render type, not the BaseThing ancestor',
+      );
+      assert.true(
+        rendered.attributes.html
+          .replace(/\s+/g, ' ')
+          .includes('SubThing fitted'),
+        'the SubThing fitted template rendered (native), not the BaseThing template',
+      );
+    });
+
+    // The explicit ancestor override — the only remaining non-default. An
+    // explicit `render.renderType` CodeRef renders/echoes that ancestor: the
+    // SubThing instance is rendered AS BaseThing (collection-level echo + the
+    // BaseThing template), while its actual type still rides in `adoptsFrom`.
+    test('QUERY /_federated-search explicit render.renderType renders/echoes the ancestor (override still works)', async function (assert) {
+      let realmServerToken = createRealmServerJWT(
+        { user: ownerUserId, sessionRoom: 'session-room-test' },
+        realmSecretSeed,
+      );
+      let subId = `${testRealm.url}sub-instance`;
+      let baseThingRef = {
+        module: rri(`${testRealm.url}base-thing`),
+        name: 'BaseThing',
+      };
+
+      let searchURL = new URL('/_federated-search', testRealm.url);
+      let response = await request
+        .post(`${searchURL.pathname}${searchURL.search}`)
+        .set('Accept', 'application/vnd.card+json')
+        .set('Content-Type', 'application/json')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Authorization', `Bearer ${realmServerToken}`)
+        .send({
+          filter: { on: baseThingRef, eq: { label: 'render-type probe' } },
+          realms: [testRealm.url],
+          // Explicit ancestor override → render every match AS BaseThing.
+          render: { format: 'fitted', renderType: baseThingRef },
+        });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200');
+      let data = response.body.data as any[];
+      let included = (response.body.included ?? []) as any[];
+
+      // An explicit override is one resolved type for the whole search, so it's
+      // echoed collection-level.
+      assert.strictEqual(
+        response.body.meta?.renderType?.name,
+        'BaseThing',
+        'the explicit ancestor override is echoed collection-level',
+      );
+
+      let card = data.find((r) => r.id === subId);
+      assert.ok(card, 'the SubThing instance is in data');
+      assert.strictEqual(
+        card.meta?.adoptsFrom?.name,
+        'SubThing',
+        'adoptsFrom is still the actual (SubThing) type, even under an override',
+      );
+      assert.strictEqual(
+        card.meta?.renderType?.name,
+        'BaseThing',
+        'the card echoes the requested ancestor render type',
+      );
+
+      let rendered = included.find(
+        (r) => r.type === 'rendered-html' && r.id === subId,
+      );
+      assert.ok(rendered, 'a rendered-html for the SubThing rides in included');
+      assert.strictEqual(
+        rendered.meta?.renderType?.name,
+        'BaseThing',
+        'rendered-html echoes the requested ancestor',
+      );
+      assert.true(
+        rendered.attributes.html
+          .replace(/\s+/g, ' ')
+          .includes('BaseThing fitted'),
+        'the BaseThing (ancestor) fitted template rendered',
       );
     });
 

--- a/packages/realm-server/tests/unified-search-contracts-test.ts
+++ b/packages/realm-server/tests/unified-search-contracts-test.ts
@@ -240,12 +240,18 @@ module(basename(__filename), function () {
       assert.deepEqual(render?.renderType, authorRef);
     });
 
-    test('parse: render.renderType accepts the "native" escape valve', function (assert) {
-      let { render } = parseUnifiedSearchRequestFromPayload({
-        realms: [realmURL],
-        render: { renderType: 'native' },
-      });
-      assert.strictEqual(render?.renderType, 'native');
+    test('parse: render.renderType no longer accepts the removed "native" literal', function (assert) {
+      // Native is now the default (omitted renderType), so the "native" escape
+      // valve is gone — a bare string is rejected like any non-CodeRef.
+      assert.throws(
+        () =>
+          parseUnifiedSearchRequestFromPayload({
+            realms: [realmURL],
+            render: { renderType: 'native' },
+          }),
+        /render.renderType must be a CodeRef/,
+        'the "native" literal is rejected',
+      );
     });
 
     test('parse: render.renderType omitted leaves renderType unset', function (assert) {

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -563,9 +563,9 @@ export class RealmIndexQueryEngine {
     if (included.length > 0) {
       doc.included = included;
     }
-    // Echo the collection-level render type when it's a single resolved type
-    // (an explicit `renderType`); the `"native"` / per-row cases vary by row
-    // and are echoed on each `rendered-html` instead.
+    // Echo the collection-level render type only for an explicit `renderType`
+    // override; on the default (native) path each row varies by its own type
+    // and is echoed on each `rendered-html` instead.
     if (opts.render.renderType) {
       doc.meta.renderType = opts.render.renderType;
     }
@@ -592,12 +592,12 @@ export class RealmIndexQueryEngine {
     //
     // A file renders natively: its prerendered HTML is keyed by the file's own
     // most-derived type, never by an ancestor a caller asked *cards* to render
-    // as. So the card-side render type — which `resolveRenderType` may default
-    // to `filter.on` — is deliberately dropped here rather than threaded into
-    // the file lookup. `fileEntryToPrerenderedCard` then selects each file's
-    // own `types[0]`, and that is the type `buildIdentityOnlyFileMeta` stamps
-    // as `adoptsFrom`; letting an ancestor type leak in would mismatch a
-    // FileDef subclass's HTML against its identity.
+    // as. So an explicit card-side `renderType` ancestor override is
+    // deliberately dropped here rather than threaded into the file lookup.
+    // `fileEntryToPrerenderedCard` then selects each file's own `types[0]`, and
+    // that is the type `buildIdentityOnlyFileMeta` stamps as `adoptsFrom`;
+    // letting an ancestor type leak in would mismatch a FileDef subclass's HTML
+    // against its identity.
     let {
       includeErrors: _includeErrors,
       renderType: _renderType,

--- a/packages/runtime-common/search-utils.ts
+++ b/packages/runtime-common/search-utils.ts
@@ -402,11 +402,12 @@ export function parseUnifiedSearchRequestFromPayload(
   };
 }
 
-// The single render-type resolution rule, shared by the server (selects the
-// HTML column, echoes `meta.renderType`) and the host (drives the live
-// `CardRenderer @codeRef`) so both pick the same type. Governs only the
-// prefer-HTML path; `dataOnly` results are the actual types (nothing renders),
-// so the caller does not invoke this for them.
+// The single render-type resolution rule. The server applies it (it selects the
+// HTML column and echoes the result in `meta.renderType`); the host then
+// consumes that `meta.renderType` to drive the live `CardRenderer @codeRef`, so
+// both pick the same type. Governs only the prefer-HTML path; `dataOnly`
+// results are the actual types (nothing renders), so the caller does not invoke
+// this for them.
 //
 //   - an explicit `renderType` CodeRef → render every result as that ancestor
 //   - omitted                          → the result's own actual (most-derived,

--- a/packages/runtime-common/search-utils.ts
+++ b/packages/runtime-common/search-utils.ts
@@ -269,16 +269,12 @@ export function parsePrerenderedSearchRequestFromPayload(payload: unknown): {
 // read as data-only; `dataOnly: true` is the only way to get live-only.
 // ---------------------------------------------------------------------------
 
-// `render.renderType`: an explicit CodeRef to render every result as, or the
-// literal "native" escape valve (each result in its own most-derived type).
-// Omitted → the searched `filter.on` common-ancestor type (resolved by the
-// server).
-export type SearchRenderType = CodeRef | 'native';
-
 export interface SearchRenderSpec {
   // The format to render; defaults to "fitted" when the caller omits it.
   format: Format;
-  renderType?: SearchRenderType;
+  // An explicit CodeRef to render every result as that ancestor type. Omitted
+  // → each result renders in its own actual (most-derived, "native") type.
+  renderType?: CodeRef;
 }
 
 export interface UnifiedSearchOpts {
@@ -317,14 +313,12 @@ function normalizeRenderSpec(value: unknown): SearchRenderSpec {
     spec.format = format;
   }
   if (renderType !== undefined) {
-    if (renderType === 'native') {
-      spec.renderType = 'native';
-    } else if (isCodeRef(renderType)) {
+    if (isCodeRef(renderType)) {
       spec.renderType = renderType;
     } else {
       throw new SearchRequestError(
         'invalid-render',
-        'render.renderType must be a CodeRef or "native"',
+        'render.renderType must be a CodeRef',
       );
     }
   }
@@ -414,26 +408,16 @@ export function parseUnifiedSearchRequestFromPayload(
 // prefer-HTML path; `dataOnly` results are the actual types (nothing renders),
 // so the caller does not invoke this for them.
 //
-//   - an explicit `renderType` CodeRef  → use it
-//   - the `"native"` escape valve       → the result's own most-derived type (types[0])
-//   - omitted                           → the query's `filter.on` (the common
-//                                          ancestor searched on); when the
-//                                          query has no `filter.on`, fall back
-//                                          to the most-derived type
+//   - an explicit `renderType` CodeRef → render every result as that ancestor
+//   - omitted                          → the result's own actual (most-derived,
+//                                         "native") type (types[0])
 export function resolveRenderType(input: {
-  renderType?: SearchRenderType;
-  filterOn?: CodeRef;
+  renderType?: CodeRef;
   // The result's adoption chain, most-derived first (types[0] is the actual type).
   types?: CodeRef[];
 }): CodeRef | undefined {
-  let { renderType, filterOn, types } = input;
-  if (renderType && renderType !== 'native') {
-    return renderType;
-  }
-  if (renderType === 'native') {
-    return types?.[0];
-  }
-  return filterOn ?? types?.[0];
+  let { renderType, types } = input;
+  return renderType ?? types?.[0];
 }
 
 // The unified federated merge: concatenate `data` in realm order, sum
@@ -465,8 +449,9 @@ export function combineSearchResults(
     // Carry the collection-level render type the per-realm docs echo. The
     // resolved render type is consistent across one search (every realm
     // resolves the same one), so the first non-null value is authoritative;
-    // a host consumer renders live/fallback card rows under it. Absent for
-    // "native"/per-row searches, where each resource echoes its own type.
+    // a host consumer renders live/fallback card rows under it. Present only
+    // for an explicit ancestor override; absent on the default (native) path,
+    // where each result renders in its own type and echoes that per row.
     if (combined.meta.renderType == null && doc.meta?.renderType != null) {
       combined.meta.renderType = doc.meta.renderType;
     }
@@ -553,11 +538,11 @@ export type SearchOpts = {
   // elapsed time. Callers never supply this directly.
   timings?: RequestTimings;
   // The prefer-HTML rendering spec, resolved by the handler: `format` is the
-  // HTML column to select and `renderType` is the already-resolved ancestor
-  // type (the `"native"` / `filter.on` defaulting has been applied upstream, so
-  // this is a concrete `CodeRef` or absent). When present, `Realm.search`
-  // resolves each result to prerendered HTML where indexed and falls back to
-  // the full live card otherwise. Absent → the live-card document.
+  // HTML column to select and `renderType` is an explicit ancestor-type
+  // override (a concrete `CodeRef`); when absent, each result renders in its
+  // own actual (native) type. When `render` is present, `Realm.search` resolves
+  // each result to prerendered HTML where indexed and falls back to the full
+  // live card otherwise. Absent → the live-card document.
   render?: { format: PrerenderedHtmlFormat; renderType?: CodeRef };
   // Opt-in live-cards-only mode. Mutually exclusive with `render`; both absent
   // is also live-only. Carried so the federated path is explicit about the


### PR DESCRIPTION
Defaults the unified-search render type to **native** — each result renders in its own actual (most-derived) type. An explicit `render.renderType` CodeRef still overrides, rendering every result as that ancestor type; that override is the only non-default option, and the `"native"` literal is gone (native is simply the default).

### What changed

- **`resolveRenderType`** (runtime-common): an omitted `renderType` resolves to `types[0]` (the result's own native type). The `"native"` branch and the `filter.on` fallback are removed.
- **Request type / parsing**: `render.renderType` is a `CodeRef`; the `"native"` string is no longer accepted.
- **Handler** (`handle-search.ts`): no longer reads `filter.on`. An omitted `renderType` produces no ancestor override, so the query engine selects each row's own type and echoes it per `rendered-html`; an explicit override is still echoed collection-level in `meta.renderType`.

The native default matches the pre-unification silent `types[0]` SQL default, so the default path is observably unchanged for callers and the prerendered compat shim needs no render-type special-casing.

### Tests

- `resolveRenderType`: omitted → `types[0]`; explicit CodeRef wins; the `"native"` literal is rejected at parse time.
- `/_federated-search` integration (new `BaseThing → SubThing` fixture): a `SubThing` matched by an `on: BaseThing` query renders and echoes **SubThing** (native) by default — not the `BaseThing` ancestor — and the response carries no collection-level render type. An explicit `render.renderType: BaseThing` renders/echoes the **BaseThing** ancestor while the actual type still rides in `adoptsFrom`.

Linear: CS-11483
