### PR TITLE
Point CardsGrid nav disclosure arrows right when collapsed, down when expanded

### DIFF
--- a/packages/boxel-ui/addon/src/components/filter-list/index.gts
+++ b/packages/boxel-ui/addon/src/components/filter-list/index.gts
@@ -184,9 +184,12 @@ export class ListItem extends Component<ListItemSignature> {
           --boxel-icon-button-width: 2rem;
           --boxel-icon-button-height: 2rem;
           flex-shrink: 0;
+          /* Collapsed: the down-arrow icon points right. */
+          transform: rotate(-90deg);
         }
         .is-expanded > .dropdown-toggle {
-          transform: rotate(180deg);
+          /* Expanded: arrow points down. */
+          transform: rotate(0deg);
         }
         .filter-list__button {
           flex-grow: 1;


### PR DESCRIPTION
## What & why

In the CardsGrid left-nav, the collapsible group headers ("All Cards" / "All Files") showed a **down** arrow when collapsed and an **up** arrow when expanded. This switches them to the conventional disclosure-triangle behavior:

| State | Before | After |
|-------|--------|-------|
| Collapsed | down ⌄ | **right ›** |
| Expanded | up ⌃ | **down ⌄** |

## How

The arrow is the `dropdown-arrow-down` icon in `FilterList` (`packages/boxel-ui/addon/src/components/filter-list/index.gts`), rotated via CSS. Swapped the rotations: collapsed `.dropdown-toggle` now `rotate(-90deg)` (right), expanded `.is-expanded > .dropdown-toggle` now `rotate(0deg)` (down).

The arrow only renders on group headers (`{{#if this.hasNestedItems}}`), so leaf filter items are unaffected. `FilterList` is used only by CardsGrid, so the change is scoped to that nav.

Before

<img width="375" height="992" alt="image" src="https://github.com/user-attachments/assets/dd4e8717-e012-4805-bd5b-87a1935ec4c4" />

After

<img width="375" height="489" alt="image" src="https://github.com/user-attachments/assets/e81ffff3-e7f3-4466-964c-47fbb94f0dc0" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)