### PR TITLE
Fix CardsGrid scrollbar hover reflow

### DIFF
--- a/packages/base/components/cards-grid-layout.gts
+++ b/packages/base/components/cards-grid-layout.gts
@@ -243,11 +243,33 @@ export default class CardsGridLayout extends Component<Signature> {
         color: var(--foreground, var(--boxel-dark));
       }
       .scroll-container {
-        overflow: hidden;
+        /* Keep the scrollbar gutter reserved and the scrollbar a fixed width in
+           every state, so revealing it on hover never steals layout width and
+           reflows the card grid. Only the thumb color is toggled on hover/focus;
+           toggling overflow or the scrollbar width would shift the layout. */
+        overflow-y: auto;
+        scrollbar-gutter: stable;
+        scrollbar-width: thin;
+        scrollbar-color: transparent transparent;
       }
       .scroll-container:hover,
       .scroll-container:focus {
-        overflow-y: auto;
+        scrollbar-color: rgba(0 0 0 / 25%) transparent;
+      }
+      .scroll-container::-webkit-scrollbar {
+        width: 0.5rem;
+        height: 0.5rem;
+      }
+      .scroll-container::-webkit-scrollbar-track {
+        background: transparent;
+      }
+      .scroll-container::-webkit-scrollbar-thumb {
+        background: transparent;
+        border-radius: var(--boxel-border-radius-xs);
+      }
+      .scroll-container:hover::-webkit-scrollbar-thumb,
+      .scroll-container:focus::-webkit-scrollbar-thumb {
+        background: rgba(0 0 0 / 25%);
       }
       .sidebar {
         --accent: var(--sidebar-accent);


### PR DESCRIPTION
## Problem

At certain window widths, hovering over a card in `CardsGrid` made a vertical scrollbar appear, which stole layout width and forced the card grid to drop a column — a janky, jumpy reflow on hover.

## Root cause

The scroll container in `cards-grid-layout.gts` revealed its scrollbar on hover by toggling `overflow`:

```css
.scroll-container { overflow: hidden; }
.scroll-container:hover,
.scroll-container:focus { overflow-y: auto; }
```

The grid lays columns out with a fixed item width + `auto-fill`, so column count is `floor(contentWidth / (170px + gap))`. On hover, a classic (space-consuming) scrollbar appears and eats ~15px of content width; at a width sitting right at a column boundary that tips the grid from N to N−1 columns (5 → 4 in the reported case), re-flowing the rows. It only reproduces near a column boundary, and not with overlay scrollbars — which is why it looked setting/width-dependent.

## Fix

Keep `overflow-y: auto` with a fixed-width scrollbar and a reserved `scrollbar-gutter: stable` in **every** state, so the content width never changes. Only the thumb color is toggled `transparent → rgba(0 0 0 / 25%)` on hover/focus, preserving the hidden-until-hover look without the layout shift. Mirrors the existing `.boxel-dark-scrollbar` convention in `boxel-ui` global.css.

Note: an earlier approach toggling the scrollbar *width* to zero didn't work — `scrollbar-gutter: stable` only reserves as much space as the scrollbar's width, so zeroing it collapsed the gutter and the width still changed between states. Keeping the width constant is what eliminates the reflow.

Resolves CS-11491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)