### PR TITLE
Workspace chooser keyboard navigation

### DIFF
--- a/packages/host/app/components/operator-mode/workspace-chooser/add-workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/add-workspace.gts
@@ -32,6 +32,7 @@ import {
 
 import ModalContainer from '../../modal-container';
 
+import focusWhenSelected from './focus-when-selected';
 import ItemContainer from './item-container';
 
 interface AddWorkspaceModalSignature {
@@ -179,6 +180,10 @@ class AddWorkspaceModal extends Component<AddWorkspaceModalSignature> {
 
 interface Signature {
   Element: HTMLButtonElement;
+  Args: {
+    isSelected?: boolean;
+    navIndex?: number;
+  };
 }
 
 export default class AddWorkspace extends Component<Signature> {
@@ -230,9 +235,12 @@ export default class AddWorkspace extends Component<Signature> {
   <template>
     <ItemContainer
       {{on 'click' (fn this.setIsModalOpen true)}}
-      class='container'
+      {{focusWhenSelected @isSelected}}
+      class='container {{if @isSelected "is-selected"}}'
       title='Create a New Workspace'
+      data-nav-index={{@navIndex}}
       data-test-add-workspace
+      data-test-add-workspace-selected={{if @isSelected 'selected'}}
     >
       <div class='content'>
         <IconPlus width='32px' height='32px' role='presentation' class='icon' />

--- a/packages/host/app/components/operator-mode/workspace-chooser/focus-when-selected.ts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/focus-when-selected.ts
@@ -1,11 +1,21 @@
 import { modifier } from 'ember-modifier';
 
+// Per-element record of the last-seen selection state, so we only act on the
+// unselected -> selected transition. Without this, the modifier would re-run
+// whenever the tile re-renders while still selected and could yank focus back
+// to the tile from a control the user just focused (a card's favorite/options
+// button), since those controls live outside the tile element.
+const wasSelected = new WeakMap<HTMLElement, boolean>();
+
 // When a workspace-chooser tile becomes the keyboard-selected item, move DOM
 // focus to it and scroll it into view, so the selection is visible and the
 // tile is reachable as arrow-key navigation walks the list.
 export default modifier(
   (element: HTMLElement, [isSelected]: [boolean | undefined]) => {
-    if (isSelected && document.activeElement !== element) {
+    let selected = !!isSelected;
+    let justSelected = selected && !wasSelected.get(element);
+    wasSelected.set(element, selected);
+    if (justSelected && document.activeElement !== element) {
       element.focus();
       element.scrollIntoView({ block: 'nearest' });
     }

--- a/packages/host/app/components/operator-mode/workspace-chooser/focus-when-selected.ts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/focus-when-selected.ts
@@ -1,0 +1,13 @@
+import { modifier } from 'ember-modifier';
+
+// When a workspace-chooser tile becomes the keyboard-selected item, move DOM
+// focus to it and scroll it into view, so the selection is visible and the
+// tile is reachable as arrow-key navigation walks the list.
+export default modifier(
+  (element: HTMLElement, [isSelected]: [boolean | undefined]) => {
+    if (isSelected && document.activeElement !== element) {
+      element.focus();
+      element.scrollIntoView({ block: 'nearest' });
+    }
+  },
+);

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -16,7 +16,6 @@ import { ri } from '@cardstack/runtime-common';
 
 import config from '@cardstack/host/config/environment';
 import type MatrixService from '@cardstack/host/services/matrix-service';
-import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 
@@ -41,7 +40,6 @@ export default class WorkspaceChooser extends Component<Signature> {
   @service declare matrixService: MatrixService;
   @service declare realmServer: RealmServerService;
   @service declare realm: RealmService;
-  @service declare private operatorModeStateService: OperatorModeStateService;
 
   private sortOptions: SortOption[] = [
     { label: 'View All', icon: Shapes, value: 'default' },
@@ -139,62 +137,145 @@ export default class WorkspaceChooser extends Component<Signature> {
     return null;
   }
 
-  // Tracks the keyboard-selected workspace as an index into the flat,
-  // DOM-ordered list of all workspace items across the three sections.
+  // The keyboard-selected tile, identified by its position in the flat,
+  // DOM-ordered sequence of selectable tiles. The sequence spans, in render
+  // order: Favorites, Your Workspaces, the "New Workspace" tile, then Catalogs.
   @tracked private selectedIndex = 0;
 
-  // Flat list of every selectable workspace, in the same order they render:
-  // Favorites, then Your Workspaces, then Catalogs. The "New Workspace" tile
-  // and the loading placeholder are intentionally excluded.
-  private get orderedRealmIdentifiers() {
-    return [
-      ...this.favoriteRealmIdentifiers,
-      ...this.filteredUserRealmIdentifiers,
-      ...this.filteredCatalogRealmIdentifiers,
-    ];
-  }
-
-  // Section offsets used to map a per-section loop index onto its position in
-  // orderedRealmIdentifiers, so each Workspace can tell if it's selected.
-  private get userWorkspacesOffset() {
+  private get favoritesCount() {
     return this.favoriteRealmIdentifiers.length;
   }
 
-  private get catalogOffset() {
-    return (
-      this.favoriteRealmIdentifiers.length +
-      this.filteredUserRealmIdentifiers.length
-    );
+  private get userWorkspacesCount() {
+    return this.filteredUserRealmIdentifiers.length;
+  }
+
+  // The "New Workspace" tile is hidden only when the hosted-only filter empties
+  // the Your Workspaces section.
+  private get isAddWorkspaceShown() {
+    return !this.userWorkspacesEmptyMessage;
+  }
+
+  private get renderedCatalogCount() {
+    if (!this.displayCatalogWorkspaces || this.catalogEmptyMessage) {
+      return 0;
+    }
+    return this.filteredCatalogRealmIdentifiers.length;
+  }
+
+  // navIndex of the first tile in each section. The "New Workspace" tile sits
+  // between Your Workspaces and Catalogs.
+  private get userWorkspacesNavBase() {
+    return this.favoritesCount;
+  }
+
+  private get addWorkspaceNavIndex() {
+    return this.favoritesCount + this.userWorkspacesCount;
+  }
+
+  private get catalogNavBase() {
+    return this.addWorkspaceNavIndex + (this.isAddWorkspaceShown ? 1 : 0);
+  }
+
+  private get selectableCount() {
+    return this.catalogNavBase + this.renderedCatalogCount;
+  }
+
+  // Keep the selection in sync with focus, so tabbing onto a tile selects it.
+  @action private onFocusIn(event: Event) {
+    let tile = (event.target as HTMLElement).closest('[data-nav-index]');
+    if (!tile) {
+      return;
+    }
+    let index = Number((tile as HTMLElement).dataset.navIndex);
+    if (!Number.isNaN(index) && index !== this.selectedIndex) {
+      this.selectedIndex = index;
+    }
   }
 
   @action private onKeydown(event: Event) {
     let kbEvent = event as KeyboardEvent;
-    let count = this.orderedRealmIdentifiers.length;
+    let container = kbEvent.currentTarget as HTMLElement;
+    let count = this.selectableCount;
     if (count === 0) {
       return;
     }
     switch (kbEvent.key) {
-      case 'ArrowDown':
+      // Left/Right step linearly through the sequence.
       case 'ArrowRight':
         event.preventDefault();
         this.selectedIndex = Math.min(this.selectedIndex + 1, count - 1);
         break;
-      case 'ArrowUp':
       case 'ArrowLeft':
         event.preventDefault();
         this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
         break;
+      // Up/Down move by visual row in the wrapped flex layout.
+      case 'ArrowDown':
+        event.preventDefault();
+        this.moveVertically(container, 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.moveVertically(container, -1);
+        break;
       case 'Enter': {
-        let selected = this.orderedRealmIdentifiers[this.selectedIndex];
-        if (selected) {
-          // preventDefault suppresses the focused workspace button's native
-          // Enter-to-click so the workspace only opens once.
-          event.preventDefault();
-          this.operatorModeStateService.openWorkspace(selected);
+        event.preventDefault();
+        let selected = container.querySelector(
+          `[data-nav-index='${this.selectedIndex}']`,
+        );
+        if (selected instanceof HTMLElement) {
+          // Activates the focused tile — opening the workspace, or the
+          // "New Workspace" modal. preventDefault above suppresses the focused
+          // button's native Enter-to-click so it fires only once.
+          selected.click();
         }
         break;
       }
     }
+  }
+
+  // From the selected tile, find the nearest row in the given direction and
+  // pick the tile whose horizontal center is closest to the current one.
+  private moveVertically(container: HTMLElement, direction: 1 | -1) {
+    let tiles = [...container.querySelectorAll('[data-nav-index]')].map(
+      (element) => ({
+        index: Number((element as HTMLElement).dataset.navIndex),
+        rect: element.getBoundingClientRect(),
+      }),
+    );
+    let current = tiles.find((tile) => tile.index === this.selectedIndex);
+    if (!current) {
+      return;
+    }
+    let currentCenterX = current.rect.left + current.rect.width / 2;
+    let candidates = tiles.filter((tile) =>
+      direction === 1
+        ? tile.rect.top > current.rect.top + 1
+        : tile.rect.top < current.rect.top - 1,
+    );
+    if (candidates.length === 0) {
+      return;
+    }
+    // The nearest row is the one whose top is closest to the current tile in
+    // the travel direction; tiles in that row share (near-)identical tops.
+    let targetRowTop =
+      direction === 1
+        ? Math.min(...candidates.map((tile) => tile.rect.top))
+        : Math.max(...candidates.map((tile) => tile.rect.top));
+    let rowTiles = candidates.filter(
+      (tile) => Math.abs(tile.rect.top - targetRowTop) <= 1,
+    );
+    let nearest = rowTiles.reduce((closest, tile) => {
+      let closestDx = Math.abs(
+        closest.rect.left + closest.rect.width / 2 - currentCenterX,
+      );
+      let tileDx = Math.abs(
+        tile.rect.left + tile.rect.width / 2 - currentCenterX,
+      );
+      return tileDx < closestDx ? tile : closest;
+    });
+    this.selectedIndex = nearest.index;
   }
 
   <template>
@@ -203,6 +284,7 @@ export default class WorkspaceChooser extends Component<Signature> {
       class='workspace-chooser'
       data-test-workspace-chooser
       {{on 'keydown' this.onKeydown}}
+      {{on 'focusin' this.onFocusIn}}
     >
       {{#if @topBarCenterElement}}
         {{#in-element @topBarCenterElement}}
@@ -240,6 +322,7 @@ export default class WorkspaceChooser extends Component<Signature> {
                 {{#each this.favoriteRealmIdentifiers as |realmIdentifier i|}}
                   <Workspace
                     @realmIdentifier={{realmIdentifier}}
+                    @navIndex={{i}}
                     @isSelected={{eq this.selectedIndex i}}
                   />
                 {{/each}}
@@ -262,19 +345,25 @@ export default class WorkspaceChooser extends Component<Signature> {
                   this.filteredUserRealmIdentifiers
                   as |realmIdentifier i|
                 }}
-                  <Workspace
-                    @realmIdentifier={{realmIdentifier}}
-                    @showMenu={{true}}
-                    @isSelected={{eq
-                      this.selectedIndex
-                      (add this.userWorkspacesOffset i)
-                    }}
-                  />
+                  {{#let (add this.userWorkspacesNavBase i) as |navIndex|}}
+                    <Workspace
+                      @realmIdentifier={{realmIdentifier}}
+                      @showMenu={{true}}
+                      @navIndex={{navIndex}}
+                      @isSelected={{eq this.selectedIndex navIndex}}
+                    />
+                  {{/let}}
                 {{/each}}
                 {{#if this.matrixService.isInitializingNewUser}}
                   <WorkspaceLoadingIndicator />
                 {{/if}}
-                <AddWorkspace />
+                <AddWorkspace
+                  @navIndex={{this.addWorkspaceNavIndex}}
+                  @isSelected={{eq
+                    this.selectedIndex
+                    this.addWorkspaceNavIndex
+                  }}
+                />
               </div>
             {{/if}}
           </div>
@@ -295,13 +384,13 @@ export default class WorkspaceChooser extends Component<Signature> {
                     this.filteredCatalogRealmIdentifiers
                     as |realmIdentifier i|
                   }}
-                    <Workspace
-                      @realmIdentifier={{realmIdentifier}}
-                      @isSelected={{eq
-                        this.selectedIndex
-                        (add this.catalogOffset i)
-                      }}
-                    />
+                    {{#let (add this.catalogNavBase i) as |navIndex|}}
+                      <Workspace
+                        @realmIdentifier={{realmIdentifier}}
+                        @navIndex={{navIndex}}
+                        @isSelected={{eq this.selectedIndex navIndex}}
+                      />
+                    {{/let}}
                   {{/each}}
                 </div>
               {{/if}}

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -181,6 +181,19 @@ export default class WorkspaceChooser extends Component<Signature> {
     return this.catalogNavBase + this.renderedCatalogCount;
   }
 
+  // `selectedIndex` can fall out of range when the selectable set shrinks
+  // without a keypress (e.g. switching to the Hosted Only filter hides the
+  // user section and "New Workspace" tile). Clamping on read keeps a tile
+  // selected so focus/Enter/arrow navigation keep working. Used everywhere the
+  // selection is consumed — rendering, lookups, and as the base for movement.
+  private get currentIndex() {
+    let count = this.selectableCount;
+    if (count === 0) {
+      return 0;
+    }
+    return Math.min(Math.max(this.selectedIndex, 0), count - 1);
+  }
+
   // Keep the selection in sync with focus, so tabbing onto a tile selects it.
   @action private onFocusIn(event: Event) {
     let tile = (event.target as HTMLElement).closest('[data-nav-index]');
@@ -200,15 +213,21 @@ export default class WorkspaceChooser extends Component<Signature> {
     if (count === 0) {
       return;
     }
+    // Only handle keys that originate from a selectable tile. Other controls
+    // inside the chooser (a card's favorite/options/host buttons) handle their
+    // own keys, so we must not intercept (and preventDefault) their events.
+    if (!(kbEvent.target as HTMLElement).closest('[data-nav-index]')) {
+      return;
+    }
     switch (kbEvent.key) {
       // Left/Right step linearly through the sequence.
       case 'ArrowRight':
         event.preventDefault();
-        this.selectedIndex = Math.min(this.selectedIndex + 1, count - 1);
+        this.selectedIndex = Math.min(this.currentIndex + 1, count - 1);
         break;
       case 'ArrowLeft':
         event.preventDefault();
-        this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
+        this.selectedIndex = Math.max(this.currentIndex - 1, 0);
         break;
       // Up/Down move by visual row in the wrapped flex layout.
       case 'ArrowDown':
@@ -222,7 +241,7 @@ export default class WorkspaceChooser extends Component<Signature> {
       case 'Enter': {
         event.preventDefault();
         let selected = container.querySelector(
-          `[data-nav-index='${this.selectedIndex}']`,
+          `[data-nav-index='${this.currentIndex}']`,
         );
         if (selected instanceof HTMLElement) {
           // Activates the focused tile — opening the workspace, or the
@@ -244,7 +263,7 @@ export default class WorkspaceChooser extends Component<Signature> {
         rect: element.getBoundingClientRect(),
       }),
     );
-    let current = tiles.find((tile) => tile.index === this.selectedIndex);
+    let current = tiles.find((tile) => tile.index === this.currentIndex);
     if (!current) {
       return;
     }
@@ -323,7 +342,7 @@ export default class WorkspaceChooser extends Component<Signature> {
                   <Workspace
                     @realmIdentifier={{realmIdentifier}}
                     @navIndex={{i}}
-                    @isSelected={{eq this.selectedIndex i}}
+                    @isSelected={{eq this.currentIndex i}}
                   />
                 {{/each}}
               </div>
@@ -350,7 +369,7 @@ export default class WorkspaceChooser extends Component<Signature> {
                       @realmIdentifier={{realmIdentifier}}
                       @showMenu={{true}}
                       @navIndex={{navIndex}}
-                      @isSelected={{eq this.selectedIndex navIndex}}
+                      @isSelected={{eq this.currentIndex navIndex}}
                     />
                   {{/let}}
                 {{/each}}
@@ -359,10 +378,7 @@ export default class WorkspaceChooser extends Component<Signature> {
                 {{/if}}
                 <AddWorkspace
                   @navIndex={{this.addWorkspaceNavIndex}}
-                  @isSelected={{eq
-                    this.selectedIndex
-                    this.addWorkspaceNavIndex
-                  }}
+                  @isSelected={{eq this.currentIndex this.addWorkspaceNavIndex}}
                 />
               </div>
             {{/if}}
@@ -388,7 +404,7 @@ export default class WorkspaceChooser extends Component<Signature> {
                       <Workspace
                         @realmIdentifier={{realmIdentifier}}
                         @navIndex={{navIndex}}
-                        @isSelected={{eq this.selectedIndex navIndex}}
+                        @isSelected={{eq this.currentIndex navIndex}}
                       />
                     {{/let}}
                   {{/each}}

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -240,6 +240,12 @@ export default class WorkspaceChooser extends Component<Signature> {
         break;
       case 'Enter': {
         event.preventDefault();
+        // Stop this keystroke from reaching ember-keyboard's document-level
+        // listener. Activating the "New Workspace" tile mounts a modal whose
+        // Create button has a global `{{on-key 'Enter'}}`; without this, the
+        // same Enter would bubble on to that listener and submit the form the
+        // instant it opens.
+        event.stopPropagation();
         let selected = container.querySelector(
           `[data-nav-index='${this.currentIndex}']`,
         );

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -1,3 +1,4 @@
+import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -7,6 +8,7 @@ import Home from '@cardstack/boxel-icons/home';
 import Shapes from '@cardstack/boxel-icons/shapes';
 
 import { BoxelSelect } from '@cardstack/boxel-ui/components';
+import { add, eq } from '@cardstack/boxel-ui/helpers';
 import { IconGlobe, Lock, StarFilled } from '@cardstack/boxel-ui/icons';
 import type { Icon } from '@cardstack/boxel-ui/icons';
 
@@ -14,6 +16,7 @@ import { ri } from '@cardstack/runtime-common';
 
 import config from '@cardstack/host/config/environment';
 import type MatrixService from '@cardstack/host/services/matrix-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 
@@ -38,6 +41,7 @@ export default class WorkspaceChooser extends Component<Signature> {
   @service declare matrixService: MatrixService;
   @service declare realmServer: RealmServerService;
   @service declare realm: RealmService;
+  @service declare private operatorModeStateService: OperatorModeStateService;
 
   private sortOptions: SortOption[] = [
     { label: 'View All', icon: Shapes, value: 'default' },
@@ -135,8 +139,71 @@ export default class WorkspaceChooser extends Component<Signature> {
     return null;
   }
 
+  // Tracks the keyboard-selected workspace as an index into the flat,
+  // DOM-ordered list of all workspace items across the three sections.
+  @tracked private selectedIndex = 0;
+
+  // Flat list of every selectable workspace, in the same order they render:
+  // Favorites, then Your Workspaces, then Catalogs. The "New Workspace" tile
+  // and the loading placeholder are intentionally excluded.
+  private get orderedRealmIdentifiers() {
+    return [
+      ...this.favoriteRealmIdentifiers,
+      ...this.filteredUserRealmIdentifiers,
+      ...this.filteredCatalogRealmIdentifiers,
+    ];
+  }
+
+  // Section offsets used to map a per-section loop index onto its position in
+  // orderedRealmIdentifiers, so each Workspace can tell if it's selected.
+  private get userWorkspacesOffset() {
+    return this.favoriteRealmIdentifiers.length;
+  }
+
+  private get catalogOffset() {
+    return (
+      this.favoriteRealmIdentifiers.length +
+      this.filteredUserRealmIdentifiers.length
+    );
+  }
+
+  @action private onKeydown(event: Event) {
+    let kbEvent = event as KeyboardEvent;
+    let count = this.orderedRealmIdentifiers.length;
+    if (count === 0) {
+      return;
+    }
+    switch (kbEvent.key) {
+      case 'ArrowDown':
+      case 'ArrowRight':
+        event.preventDefault();
+        this.selectedIndex = Math.min(this.selectedIndex + 1, count - 1);
+        break;
+      case 'ArrowUp':
+      case 'ArrowLeft':
+        event.preventDefault();
+        this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
+        break;
+      case 'Enter': {
+        let selected = this.orderedRealmIdentifiers[this.selectedIndex];
+        if (selected) {
+          // preventDefault suppresses the focused workspace button's native
+          // Enter-to-click so the workspace only opens once.
+          event.preventDefault();
+          this.operatorModeStateService.openWorkspace(selected);
+        }
+        break;
+      }
+    }
+  }
+
   <template>
-    <div class='workspace-chooser' data-test-workspace-chooser>
+    {{! template-lint-disable no-invalid-interactive }}
+    <div
+      class='workspace-chooser'
+      data-test-workspace-chooser
+      {{on 'keydown' this.onKeydown}}
+    >
       {{#if @topBarCenterElement}}
         {{#in-element @topBarCenterElement}}
           <div class='sort-controls'>
@@ -170,8 +237,11 @@ export default class WorkspaceChooser extends Component<Signature> {
               >{{this.favoritesEmptyMessage}}</span>
             {{else}}
               <div class='workspace-list' data-test-favorites-list>
-                {{#each this.favoriteRealmIdentifiers as |realmIdentifier|}}
-                  <Workspace @realmIdentifier={{realmIdentifier}} />
+                {{#each this.favoriteRealmIdentifiers as |realmIdentifier i|}}
+                  <Workspace
+                    @realmIdentifier={{realmIdentifier}}
+                    @isSelected={{eq this.selectedIndex i}}
+                  />
                 {{/each}}
               </div>
             {{/if}}
@@ -188,10 +258,17 @@ export default class WorkspaceChooser extends Component<Signature> {
               >{{this.userWorkspacesEmptyMessage}}</span>
             {{else}}
               <div class='workspace-list' data-test-workspace-list>
-                {{#each this.filteredUserRealmIdentifiers as |realmIdentifier|}}
+                {{#each
+                  this.filteredUserRealmIdentifiers
+                  as |realmIdentifier i|
+                }}
                   <Workspace
                     @realmIdentifier={{realmIdentifier}}
                     @showMenu={{true}}
+                    @isSelected={{eq
+                      this.selectedIndex
+                      (add this.userWorkspacesOffset i)
+                    }}
                   />
                 {{/each}}
                 {{#if this.matrixService.isInitializingNewUser}}
@@ -216,9 +293,15 @@ export default class WorkspaceChooser extends Component<Signature> {
                 <div class='workspace-list' data-test-catalog-list>
                   {{#each
                     this.filteredCatalogRealmIdentifiers
-                    as |realmIdentifier|
+                    as |realmIdentifier i|
                   }}
-                    <Workspace @realmIdentifier={{realmIdentifier}} />
+                    <Workspace
+                      @realmIdentifier={{realmIdentifier}}
+                      @isSelected={{eq
+                        this.selectedIndex
+                        (add this.catalogOffset i)
+                      }}
+                    />
                   {{/each}}
                 </div>
               {{/if}}

--- a/packages/host/app/components/operator-mode/workspace-chooser/item-container.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/item-container.gts
@@ -44,6 +44,10 @@ const WorkspaceChooserItemContainer: TemplateOnlyComponent<Signature> =
       .workspace:focus-visible {
         outline-offset: -1px;
       }
+      .workspace.is-selected::after {
+        border-color: var(--boxel-teal);
+        box-shadow: 0 0 0 1px var(--boxel-teal);
+      }
     </style>
   </template>;
 

--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -341,8 +341,6 @@ export default class Workspace extends Component<Signature> {
         right: 0.5rem;
         z-index: 3;
         color: var(--boxel-light);
-        opacity: 0;
-        transition: opacity 0.15s ease;
         border-radius: var(--boxel-border-radius-sm);
         width: var(--boxel-button-xs);
         height: var(--boxel-button-xs);
@@ -353,13 +351,13 @@ export default class Workspace extends Component<Signature> {
         --boxel-icon-button-width: var(--boxel-button-xs);
         --boxel-icon-button-height: var(--boxel-button-xs);
       }
-      .workspace-card:hover .tile-menu-btn,
-      .tile-menu-btn:focus-within {
-        opacity: 1;
-      }
       .tile-menu-btn:hover {
         background: rgba(0 0 0 / 40%);
         backdrop-filter: blur(6px);
+      }
+      .tile-menu-btn:focus-within {
+        background: var(--boxel-highlight);
+        color: var(--boxel-highlight-foreground);
       }
       .tile-icon {
         background-color: var(--boxel-500);

--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -10,6 +10,7 @@ import FileSettingsIcon from '@cardstack/boxel-icons/file-settings';
 import Home from '@cardstack/boxel-icons/home';
 import { dropTask, task } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
+import { modifier } from 'ember-modifier';
 import pluralize from 'pluralize';
 
 import {
@@ -54,8 +55,21 @@ interface Signature {
   Args: {
     realmIdentifier: RealmIdentifier;
     showMenu?: boolean;
+    isSelected?: boolean;
   };
 }
+
+// When the workspace becomes the keyboard-selected item, move DOM focus to its
+// button and scroll it into view, so the selection is visible and reachable as
+// arrow-key navigation walks through the list.
+const focusWhenSelected = modifier(
+  (element: HTMLElement, [isSelected]: [boolean | undefined]) => {
+    if (isSelected && document.activeElement !== element) {
+      element.focus();
+      element.scrollIntoView({ block: 'nearest' });
+    }
+  },
+);
 
 export default class Workspace extends Component<Signature> {
   <template>
@@ -63,14 +77,18 @@ export default class Workspace extends Component<Signature> {
       <WorkspaceLoadingIndicator />
     {{else}}
       <div
-        class='workspace-card {{if this.isHostDropdownOpen "is-open"}}'
+        class='workspace-card
+          {{if this.isHostDropdownOpen "is-open"}}
+          {{if @isSelected "is-selected"}}'
         data-test-workspace={{this.name}}
+        data-test-workspace-selected={{if @isSelected this.name}}
         {{on 'mouseleave' this.closeHostDropdown}}
         ...attributes
       >
         <ItemContainer
           data-test-workspace-button={{this.name}}
           {{on 'click' this.openWorkspace}}
+          {{focusWhenSelected @isSelected}}
         >
           <div
             class='tile-icon'
@@ -299,6 +317,10 @@ export default class Workspace extends Component<Signature> {
       }
       .workspace-card:hover::after {
         border-color: rgba(255 255 255 / 50%);
+      }
+      .workspace-card.is-selected::after {
+        border-color: var(--boxel-teal);
+        box-shadow: 0 0 0 1px var(--boxel-teal);
       }
       .tile-favorite-btn {
         position: absolute;

--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -10,7 +10,6 @@ import FileSettingsIcon from '@cardstack/boxel-icons/file-settings';
 import Home from '@cardstack/boxel-icons/home';
 import { dropTask, task } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
-import { modifier } from 'ember-modifier';
 import pluralize from 'pluralize';
 
 import {
@@ -47,6 +46,7 @@ import type RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 
+import focusWhenSelected from './focus-when-selected';
 import ItemContainer from './item-container';
 import WorkspaceLoadingIndicator from './workspace-loading-indicator';
 
@@ -56,20 +56,9 @@ interface Signature {
     realmIdentifier: RealmIdentifier;
     showMenu?: boolean;
     isSelected?: boolean;
+    navIndex?: number;
   };
 }
-
-// When the workspace becomes the keyboard-selected item, move DOM focus to its
-// button and scroll it into view, so the selection is visible and reachable as
-// arrow-key navigation walks through the list.
-const focusWhenSelected = modifier(
-  (element: HTMLElement, [isSelected]: [boolean | undefined]) => {
-    if (isSelected && document.activeElement !== element) {
-      element.focus();
-      element.scrollIntoView({ block: 'nearest' });
-    }
-  },
-);
 
 export default class Workspace extends Component<Signature> {
   <template>
@@ -87,6 +76,7 @@ export default class Workspace extends Component<Signature> {
       >
         <ItemContainer
           data-test-workspace-button={{this.name}}
+          data-nav-index={{@navIndex}}
           {{on 'click' this.openWorkspace}}
           {{focusWhenSelected @isSelected}}
         >

--- a/packages/host/tests/acceptance/workspace-chooser-test.gts
+++ b/packages/host/tests/acceptance/workspace-chooser-test.gts
@@ -410,9 +410,12 @@ module('Acceptance | workspace-chooser', function (hooks) {
       ].map((el) => el.getAttribute('data-test-workspace') ?? '');
     }
 
-    async function arrow(key: string) {
+    // Keyboard navigation is driven from the focused tile, and the chooser's
+    // keydown handler intentionally ignores keys that don't originate from a
+    // tile. Fire on the active element so tests exercise the real path.
+    async function pressKey(key: string) {
       await triggerKeyEvent(
-        '[data-test-workspace-chooser]',
+        document.activeElement as Element,
         'keydown',
         key as any,
       );
@@ -440,13 +443,13 @@ module('Acceptance | workspace-chooser', function (hooks) {
 
       let [first, second] = orderedWorkspaceNames();
 
-      await arrow('ArrowRight');
+      await pressKey('ArrowRight');
       assert
         .dom(`[data-test-workspace-selected="${second}"]`)
         .exists('ArrowRight selects the next workspace');
       assert.dom('[data-test-workspace-selected]').exists({ count: 1 });
 
-      await arrow('ArrowRight');
+      await pressKey('ArrowRight');
       assert
         .dom('[data-test-add-workspace-selected]')
         .exists('ArrowRight reaches the New Workspace tile');
@@ -454,17 +457,17 @@ module('Acceptance | workspace-chooser', function (hooks) {
         .dom('[data-test-workspace-selected]')
         .doesNotExist('no workspace card is selected while New Workspace is');
 
-      await arrow('ArrowLeft');
+      await pressKey('ArrowLeft');
       assert
         .dom(`[data-test-workspace-selected="${second}"]`)
         .exists('ArrowLeft leaves the New Workspace tile');
 
-      await arrow('ArrowLeft');
+      await pressKey('ArrowLeft');
       assert
         .dom(`[data-test-workspace-selected="${first}"]`)
         .exists('ArrowLeft returns to the first workspace');
 
-      await arrow('ArrowLeft');
+      await pressKey('ArrowLeft');
       assert
         .dom(`[data-test-workspace-selected="${first}"]`)
         .exists('ArrowLeft at the start stays on the first workspace');
@@ -491,7 +494,7 @@ module('Acceptance | workspace-chooser', function (hooks) {
       // ArrowDown leaves the Favorites row and lands somewhere in the row
       // below (Your Workspaces). The exact tile depends on column alignment,
       // so assert the row, not a specific tile.
-      await arrow('ArrowDown');
+      await pressKey('ArrowDown');
       assert
         .dom('[data-test-favorites-list] [data-test-workspace-selected]')
         .doesNotExist('ArrowDown moves the selection out of the Favorites row');
@@ -501,7 +504,7 @@ module('Acceptance | workspace-chooser', function (hooks) {
         )
         .exists('ArrowDown moves the selection into the Your Workspaces row');
 
-      await arrow('ArrowUp');
+      await pressKey('ArrowUp');
       assert
         .dom(
           '[data-test-favorites-list] [data-test-workspace-selected="Workspace A"]',
@@ -532,11 +535,7 @@ module('Acceptance | workspace-chooser', function (hooks) {
       let [first] = orderedWorkspaceNames();
       let firstURL = urlByName[first];
 
-      await triggerKeyEvent(
-        '[data-test-workspace-chooser]',
-        'keydown',
-        'Enter',
-      );
+      await pressKey('Enter');
 
       await waitFor(`[data-test-stack-card="${firstURL}index"]`);
       assert
@@ -552,22 +551,71 @@ module('Acceptance | workspace-chooser', function (hooks) {
       await waitFor('[data-test-workspace-selected]');
 
       // Step right past the two user workspaces to the New Workspace tile.
-      await arrow('ArrowRight');
-      await arrow('ArrowRight');
+      await pressKey('ArrowRight');
+      await pressKey('ArrowRight');
       assert
         .dom('[data-test-add-workspace-selected]')
         .exists('the New Workspace tile is selected');
 
-      await triggerKeyEvent(
-        '[data-test-workspace-chooser]',
-        'keydown',
-        'Enter',
-      );
+      await pressKey('Enter');
 
       await waitFor('[data-test-create-workspace-modal]');
       assert
         .dom('[data-test-create-workspace-modal]')
         .exists('Enter opens the create-workspace modal');
+    });
+
+    test('right arrow advances past the New Workspace tile into the catalog section', async function (assert) {
+      await visitOperatorMode({ workspaceChooserOpened: true });
+      await waitFor('[data-test-workspace-selected]');
+
+      // This configuration shows catalog workspaces, so the New Workspace tile
+      // is not the last selectable item.
+      assert
+        .dom('[data-test-catalog-list]')
+        .exists('catalogs are shown in this configuration');
+
+      await pressKey('ArrowRight'); // second user workspace
+      await pressKey('ArrowRight'); // New Workspace tile
+      assert
+        .dom('[data-test-add-workspace-selected]')
+        .exists('reached the New Workspace tile');
+
+      await pressKey('ArrowRight'); // into the catalog section
+      assert
+        .dom('[data-test-add-workspace-selected]')
+        .doesNotExist(
+          'ArrowRight advances past the New Workspace tile into the catalogs',
+        );
+    });
+
+    test('keys originating from a non-tile control are ignored', async function (assert) {
+      await visitOperatorMode({ workspaceChooserOpened: true });
+      await waitFor('[data-test-workspace-selected]');
+
+      let [first] = orderedWorkspaceNames();
+      let firstURL = urlByName[first];
+
+      // Focus a control inside the chooser that isn't a navigable tile.
+      let favoriteBtn = `[data-test-workspace-favorite-btn="${firstURL}"]`;
+      await focus(favoriteBtn);
+
+      // Arrow keys here must not drive tile navigation...
+      await triggerKeyEvent(favoriteBtn, 'keydown', 'ArrowRight');
+      assert
+        .dom(`[data-test-workspace-selected="${first}"]`)
+        .exists(
+          'ArrowRight from a non-tile control does not move the selection',
+        );
+
+      // ...and Enter must not open the selected workspace.
+      await triggerKeyEvent(favoriteBtn, 'keydown', 'Enter');
+      assert
+        .dom('[data-test-workspace-chooser]')
+        .exists('Enter from a non-tile control does not open a workspace');
+      assert
+        .dom(`[data-test-stack-card="${firstURL}index"]`)
+        .doesNotExist('no workspace was opened');
     });
   });
 

--- a/packages/host/tests/acceptance/workspace-chooser-test.gts
+++ b/packages/host/tests/acceptance/workspace-chooser-test.gts
@@ -1,5 +1,6 @@
 import {
   click,
+  focus,
   settled,
   triggerKeyEvent,
   waitFor,
@@ -400,7 +401,7 @@ module('Acceptance | workspace-chooser', function (hooks) {
       'Workspace B': realmBURL,
     };
 
-    // Workspace names rendered as selectable items, in DOM (selection) order.
+    // Workspace names rendered as cards, in DOM (selection) order.
     function orderedWorkspaceNames(): string[] {
       return [
         ...document.querySelectorAll(
@@ -417,7 +418,7 @@ module('Acceptance | workspace-chooser', function (hooks) {
       );
     }
 
-    test('the first workspace is selected when the chooser opens', async function (assert) {
+    test('the first workspace is selected and focused when the chooser opens', async function (assert) {
       await visitOperatorMode({ workspaceChooserOpened: true });
       await waitFor('[data-test-workspace-selected]');
 
@@ -433,53 +434,103 @@ module('Acceptance | workspace-chooser', function (hooks) {
         .isFocused('the selected workspace button receives focus');
     });
 
-    test('arrow keys move the selection and clamp at the ends', async function (assert) {
+    test('left/right arrows step through the sequence, including the New Workspace tile', async function (assert) {
       await visitOperatorMode({ workspaceChooserOpened: true });
       await waitFor('[data-test-workspace-selected]');
 
       let [first, second] = orderedWorkspaceNames();
 
-      await arrow('ArrowDown');
-      assert
-        .dom(`[data-test-workspace-selected="${second}"]`)
-        .exists('ArrowDown selects the next workspace');
-      assert.dom('[data-test-workspace-selected]').exists({ count: 1 });
-
-      await arrow('ArrowDown');
-      assert
-        .dom(`[data-test-workspace-selected="${second}"]`)
-        .exists('ArrowDown at the end keeps the last workspace selected');
-
-      await arrow('ArrowUp');
-      assert
-        .dom(`[data-test-workspace-selected="${first}"]`)
-        .exists('ArrowUp selects the previous workspace');
-
-      await arrow('ArrowUp');
-      assert
-        .dom(`[data-test-workspace-selected="${first}"]`)
-        .exists('ArrowUp at the start keeps the first workspace selected');
-
-      // Left/Right behave the same as Up/Down.
       await arrow('ArrowRight');
       assert
         .dom(`[data-test-workspace-selected="${second}"]`)
         .exists('ArrowRight selects the next workspace');
+      assert.dom('[data-test-workspace-selected]').exists({ count: 1 });
+
+      await arrow('ArrowRight');
+      assert
+        .dom('[data-test-add-workspace-selected]')
+        .exists('ArrowRight reaches the New Workspace tile');
+      assert
+        .dom('[data-test-workspace-selected]')
+        .doesNotExist('no workspace card is selected while New Workspace is');
+
+      await arrow('ArrowRight');
+      assert
+        .dom('[data-test-add-workspace-selected]')
+        .exists('ArrowRight at the end stays on the New Workspace tile');
+
+      await arrow('ArrowLeft');
+      assert
+        .dom(`[data-test-workspace-selected="${second}"]`)
+        .exists('ArrowLeft leaves the New Workspace tile');
+
       await arrow('ArrowLeft');
       assert
         .dom(`[data-test-workspace-selected="${first}"]`)
-        .exists('ArrowLeft selects the previous workspace');
+        .exists('ArrowLeft returns to the first workspace');
+
+      await arrow('ArrowLeft');
+      assert
+        .dom(`[data-test-workspace-selected="${first}"]`)
+        .exists('ArrowLeft at the start stays on the first workspace');
+    });
+
+    test('up/down arrows move vertically between rows', async function (assert) {
+      await visitOperatorMode({ workspaceChooserOpened: true });
+
+      // Favoriting a workspace puts a Favorites row directly above the
+      // Your Workspaces row, so up/down can cross between them.
+      let matrixService = getService('matrix-service') as MatrixService;
+      matrixService.workspaceFavorites = [realmAURL];
+      await settled();
+      await waitFor(
+        '[data-test-favorites-list] [data-test-workspace-selected]',
+      );
+
+      assert
+        .dom(
+          '[data-test-favorites-list] [data-test-workspace-selected="Workspace A"]',
+        )
+        .exists('the favorited workspace (top row) starts selected');
+
+      await arrow('ArrowDown');
+      assert
+        .dom(
+          '[data-test-workspace-list] [data-test-workspace-selected="Workspace A"]',
+        )
+        .exists('ArrowDown moves down into the Your Workspaces row');
+      assert.dom('[data-test-workspace-selected]').exists({ count: 1 });
+
+      await arrow('ArrowUp');
+      assert
+        .dom(
+          '[data-test-favorites-list] [data-test-workspace-selected="Workspace A"]',
+        )
+        .exists('ArrowUp moves back up into the Favorites row');
+    });
+
+    test('focusing a workspace selects it', async function (assert) {
+      await visitOperatorMode({ workspaceChooserOpened: true });
+      await waitFor('[data-test-workspace-selected]');
+
+      let [first, second] = orderedWorkspaceNames();
+      assert
+        .dom(`[data-test-workspace-selected="${first}"]`)
+        .exists('first workspace selected initially');
+
+      await focus(`[data-test-workspace-button="${second}"]`);
+      assert
+        .dom(`[data-test-workspace-selected="${second}"]`)
+        .exists('focusing the second workspace selects it');
+      assert.dom('[data-test-workspace-selected]').exists({ count: 1 });
     });
 
     test('Enter opens the selected workspace', async function (assert) {
       await visitOperatorMode({ workspaceChooserOpened: true });
       await waitFor('[data-test-workspace-selected]');
 
-      let [, second] = orderedWorkspaceNames();
-      let secondURL = urlByName[second];
-
-      await arrow('ArrowDown');
-      assert.dom(`[data-test-workspace-selected="${second}"]`).exists();
+      let [first] = orderedWorkspaceNames();
+      let firstURL = urlByName[first];
 
       await triggerKeyEvent(
         '[data-test-workspace-chooser]',
@@ -487,13 +538,36 @@ module('Acceptance | workspace-chooser', function (hooks) {
         'Enter',
       );
 
-      await waitFor(`[data-test-stack-card="${secondURL}index"]`);
+      await waitFor(`[data-test-stack-card="${firstURL}index"]`);
       assert
         .dom('[data-test-workspace-chooser]')
         .doesNotExist('chooser is dismissed after opening a workspace');
       assert
-        .dom(`[data-test-stack-card="${secondURL}index"]`)
+        .dom(`[data-test-stack-card="${firstURL}index"]`)
         .exists('the selected workspace is opened on the stack');
+    });
+
+    test('Enter on the New Workspace tile opens the create-workspace modal', async function (assert) {
+      await visitOperatorMode({ workspaceChooserOpened: true });
+      await waitFor('[data-test-workspace-selected]');
+
+      // Step right past the two user workspaces to the New Workspace tile.
+      await arrow('ArrowRight');
+      await arrow('ArrowRight');
+      assert
+        .dom('[data-test-add-workspace-selected]')
+        .exists('the New Workspace tile is selected');
+
+      await triggerKeyEvent(
+        '[data-test-workspace-chooser]',
+        'keydown',
+        'Enter',
+      );
+
+      await waitFor('[data-test-create-workspace-modal]');
+      assert
+        .dom('[data-test-create-workspace-modal]')
+        .exists('Enter opens the create-workspace modal');
     });
   });
 

--- a/packages/host/tests/acceptance/workspace-chooser-test.gts
+++ b/packages/host/tests/acceptance/workspace-chooser-test.gts
@@ -454,11 +454,6 @@ module('Acceptance | workspace-chooser', function (hooks) {
         .dom('[data-test-workspace-selected]')
         .doesNotExist('no workspace card is selected while New Workspace is');
 
-      await arrow('ArrowRight');
-      assert
-        .dom('[data-test-add-workspace-selected]')
-        .exists('ArrowRight at the end stays on the New Workspace tile');
-
       await arrow('ArrowLeft');
       assert
         .dom(`[data-test-workspace-selected="${second}"]`)
@@ -493,20 +488,25 @@ module('Acceptance | workspace-chooser', function (hooks) {
         )
         .exists('the favorited workspace (top row) starts selected');
 
+      // ArrowDown leaves the Favorites row and lands somewhere in the row
+      // below (Your Workspaces). The exact tile depends on column alignment,
+      // so assert the row, not a specific tile.
       await arrow('ArrowDown');
       assert
+        .dom('[data-test-favorites-list] [data-test-workspace-selected]')
+        .doesNotExist('ArrowDown moves the selection out of the Favorites row');
+      assert
         .dom(
-          '[data-test-workspace-list] [data-test-workspace-selected="Workspace A"]',
+          '[data-test-workspace-list] [data-test-workspace-selected], [data-test-workspace-list] [data-test-add-workspace-selected]',
         )
-        .exists('ArrowDown moves down into the Your Workspaces row');
-      assert.dom('[data-test-workspace-selected]').exists({ count: 1 });
+        .exists('ArrowDown moves the selection into the Your Workspaces row');
 
       await arrow('ArrowUp');
       assert
         .dom(
           '[data-test-favorites-list] [data-test-workspace-selected="Workspace A"]',
         )
-        .exists('ArrowUp moves back up into the Favorites row');
+        .exists('ArrowUp moves the selection back up into the Favorites row');
     });
 
     test('focusing a workspace selects it', async function (assert) {

--- a/packages/host/tests/acceptance/workspace-chooser-test.gts
+++ b/packages/host/tests/acceptance/workspace-chooser-test.gts
@@ -1,4 +1,10 @@
-import { click, settled, waitFor, waitUntil } from '@ember/test-helpers';
+import {
+  click,
+  settled,
+  triggerKeyEvent,
+  waitFor,
+  waitUntil,
+} from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 
@@ -385,6 +391,109 @@ module('Acceptance | workspace-chooser', function (hooks) {
       } finally {
         restoreA();
       }
+    });
+  });
+
+  module('keyboard navigation', function () {
+    const urlByName: Record<string, string> = {
+      'Workspace A': realmAURL,
+      'Workspace B': realmBURL,
+    };
+
+    // Workspace names rendered as selectable items, in DOM (selection) order.
+    function orderedWorkspaceNames(): string[] {
+      return [
+        ...document.querySelectorAll(
+          '[data-test-workspace-chooser] [data-test-workspace]',
+        ),
+      ].map((el) => el.getAttribute('data-test-workspace') ?? '');
+    }
+
+    async function arrow(key: string) {
+      await triggerKeyEvent(
+        '[data-test-workspace-chooser]',
+        'keydown',
+        key as any,
+      );
+    }
+
+    test('the first workspace is selected when the chooser opens', async function (assert) {
+      await visitOperatorMode({ workspaceChooserOpened: true });
+      await waitFor('[data-test-workspace-selected]');
+
+      let [first] = orderedWorkspaceNames();
+      assert
+        .dom('[data-test-workspace-selected]')
+        .exists({ count: 1 }, 'exactly one workspace is selected');
+      assert
+        .dom(`[data-test-workspace-selected="${first}"]`)
+        .exists('the first workspace is the selected one');
+      assert
+        .dom(`[data-test-workspace-button="${first}"]`)
+        .isFocused('the selected workspace button receives focus');
+    });
+
+    test('arrow keys move the selection and clamp at the ends', async function (assert) {
+      await visitOperatorMode({ workspaceChooserOpened: true });
+      await waitFor('[data-test-workspace-selected]');
+
+      let [first, second] = orderedWorkspaceNames();
+
+      await arrow('ArrowDown');
+      assert
+        .dom(`[data-test-workspace-selected="${second}"]`)
+        .exists('ArrowDown selects the next workspace');
+      assert.dom('[data-test-workspace-selected]').exists({ count: 1 });
+
+      await arrow('ArrowDown');
+      assert
+        .dom(`[data-test-workspace-selected="${second}"]`)
+        .exists('ArrowDown at the end keeps the last workspace selected');
+
+      await arrow('ArrowUp');
+      assert
+        .dom(`[data-test-workspace-selected="${first}"]`)
+        .exists('ArrowUp selects the previous workspace');
+
+      await arrow('ArrowUp');
+      assert
+        .dom(`[data-test-workspace-selected="${first}"]`)
+        .exists('ArrowUp at the start keeps the first workspace selected');
+
+      // Left/Right behave the same as Up/Down.
+      await arrow('ArrowRight');
+      assert
+        .dom(`[data-test-workspace-selected="${second}"]`)
+        .exists('ArrowRight selects the next workspace');
+      await arrow('ArrowLeft');
+      assert
+        .dom(`[data-test-workspace-selected="${first}"]`)
+        .exists('ArrowLeft selects the previous workspace');
+    });
+
+    test('Enter opens the selected workspace', async function (assert) {
+      await visitOperatorMode({ workspaceChooserOpened: true });
+      await waitFor('[data-test-workspace-selected]');
+
+      let [, second] = orderedWorkspaceNames();
+      let secondURL = urlByName[second];
+
+      await arrow('ArrowDown');
+      assert.dom(`[data-test-workspace-selected="${second}"]`).exists();
+
+      await triggerKeyEvent(
+        '[data-test-workspace-chooser]',
+        'keydown',
+        'Enter',
+      );
+
+      await waitFor(`[data-test-stack-card="${secondURL}index"]`);
+      assert
+        .dom('[data-test-workspace-chooser]')
+        .doesNotExist('chooser is dismissed after opening a workspace');
+      assert
+        .dom(`[data-test-stack-card="${secondURL}index"]`)
+        .exists('the selected workspace is opened on the stack');
     });
   });
 

--- a/packages/host/tests/acceptance/workspace-chooser-test.gts
+++ b/packages/host/tests/acceptance/workspace-chooser-test.gts
@@ -563,6 +563,11 @@ module('Acceptance | workspace-chooser', function (hooks) {
       assert
         .dom('[data-test-create-workspace-modal]')
         .exists('Enter opens the create-workspace modal');
+      // The same Enter must not also submit the form: the modal stays on its
+      // input fields rather than flipping to the "Creating workspace..." state.
+      assert
+        .dom('[data-test-display-name-field]')
+        .exists('the modal shows its form rather than submitting on open');
     });
 
     test('right arrow advances past the New Workspace tile into the catalog section', async function (assert) {


### PR DESCRIPTION
Makes the workspace chooser keyboard navigable.

## Behavior
- When the chooser opens, the first tile is selected and focused.
- **Left/Right** step linearly through the full sequence: Favorites → Your Workspaces → the **New Workspace** tile → Catalogs, clamped at the ends.
- **Up/Down** move by visual row in the wrapped flex layout — from the selected tile, the nearest row in that direction is found and the tile whose horizontal center is closest is selected. This crosses section boundaries.
- **Tab** (or any focus landing on a tile) syncs the selection to that tile.
- **Enter** activates the selected tile: opening the workspace, or opening the New Workspace modal.

## Implementation notes
- The chooser owns a `selectedIndex` into the flat, DOM-ordered sequence of tiles. Each tile carries its index as `data-nav-index` and reports selection via `@isSelected`.
- Up/Down navigation reads the rendered tiles' rects, so it follows the actual layout rather than the linear index.
- Enter `.click()`s the selected tile, so workspaces and the New Workspace tile activate through the same path; `preventDefault` stops the focused button's native Enter-to-click so it fires once.
- A shared `focus-when-selected` modifier moves DOM focus to the selected tile and scrolls it into view; a `focusin` listener keeps selection and focus in sync.

## Tests
Added a `keyboard navigation` acceptance module covering: initial selection + focus, Left/Right stepping through the New Workspace tile with clamping, Up/Down crossing rows, focus-to-select, Enter opening a workspace, and Enter opening the New Workspace modal.

Tracking: [CS-11496](https://linear.app/cardstack/issue/CS-11496/workspace-chooser-keyboard-navigation-arrow-keys-enter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)