### PR TITLE
Software factory: runbook + interactive-skill docs for the adjust-existing-card flow

### DIFF
--- a/packages/software-factory/.agents/skills/software-factory-bootstrap/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-bootstrap/SKILL.md
@@ -141,11 +141,11 @@ of** creating `feature` Issues per entry-point card.
    boxel realm ingest-card "<source-card-url>" .
    ```
 
-   It copies, preserving realm-relative paths: the source card's
-   module, every same-realm module it imports transitively
-   (**including type-only imports**, which a runtime dep graph would
-   miss but `boxel parse` needs), its sample instances, and its
-   **card-level** Catalog Spec. Cross-realm imports
+It copies, preserving realm-relative paths, into the local workspace: the source card's
+module, every same-realm module it imports transitively
+(**including type-only imports**, which a runtime dep graph would
+miss but `boxel parse` needs), its sample instances, and its
+**card/app** Catalog Spec. Cross-realm imports
    (`https://cardstack.com/base/...`) and component/function Specs
    are left out on purpose. Pass `--realm <url>` only if the source
    realm can't be auto-detected.

--- a/packages/software-factory/.agents/skills/software-factory-bootstrap/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-bootstrap/SKILL.md
@@ -9,8 +9,29 @@ Use this skill when the Issue you just picked up has
 `attributes.issueType: "bootstrap"`. Your job is to read the brief,
 make sure the target realm exists, and seed the project artifacts
 that drive the rest of the run: a Project card, an IssueTracker
-board, Knowledge Article cards with the brief context, and one
-implementation Issue per entry-point card the brief describes.
+board, Knowledge Article cards with the brief context, and the
+implementation Issues.
+
+## Two modes: greenfield vs adjust
+
+The brief tells you which mode you're in. Read the brief card's JSON
+(`boxel file read "<brief-path>.json" --realm <source-realm-url>`)
+and check `data.attributes.sourceCardUrl`:
+
+- **Greenfield** (`sourceCardUrl` absent or empty) — build new cards
+  from scratch. Create Project / IssueTracker / Knowledge Articles,
+  then one `feature` Issue per entry-point card. This is the
+  default; the rest of this skill describes it.
+- **Adjust** (`sourceCardUrl` set) — seed the target realm with a
+  working copy of the existing card it points at, confirm the copy
+  is green, then create `adjustment` Issues that describe deltas to
+  it. See **"Adjust flow"** below.
+
+Everything from the implementation loop onward (scheduling, the
+validators, status transitions, project completion) is identical for
+both modes — adjust is a superset, not a fork. The only differences
+are the seed-from-source sub-phase below and that adjust emits
+`adjustment` Issues instead of `feature` Issues.
 
 ## When you reach this skill
 
@@ -105,6 +126,85 @@ A freshly-created realm is empty, so the pull is a no-op except to
 establish the local-dir ↔ realm mapping. All subsequent writes
 happen in the workspace and propagate via
 `boxel realm push <local-dir> <realm-url>` when you sync.
+
+## Adjust flow (when the brief sets `sourceCardUrl`)
+
+Do this **in addition to** the standard Project / IssueTracker /
+Knowledge Article artifacts (those steps still apply), and **instead
+of** creating `feature` Issues per entry-point card.
+
+1. **Seed the source card + its same-realm dependency graph.** From
+   inside the workspace dir, run the dedicated ingestion command
+   (read-only from the source realm — it doesn't write to it):
+
+   ```bash
+   boxel realm ingest-card "<source-card-url>" .
+   ```
+
+   It copies, preserving realm-relative paths: the source card's
+   module, every same-realm module it imports transitively
+   (**including type-only imports**, which a runtime dep graph would
+   miss but `boxel parse` needs), its sample instances, and its
+   **card-level** Catalog Spec. Cross-realm imports
+   (`https://cardstack.com/base/...`) and component/function Specs
+   are left out on purpose. Pass `--realm <url>` only if the source
+   realm can't be auto-detected.
+   - **If the source card has no co-located test** — common for
+     catalog cards, which rarely ship `.test.gts` — write
+     **characterization tests** that capture its current behavior:
+     field defaults, computed-field outputs, and the key rendered
+     output of its formats. These establish the green baseline; they
+     are what the adjustment must not regress. Without them there is
+     nothing to protect and a zero-test `boxel test` run can never
+     count as green.
+
+2. **Confirm a green baseline.** Push the seeded workspace, then run
+   the standard validators (per the "Validators" section of
+   `software-factory-operations`: `boxel parse`, `boxel lint`,
+   evaluate-module, instantiate-card, `boxel test`) against the
+   seeded copy. They must **all pass before you create any
+   adjustment Issue**. Two traps:
+   - A validator reporting `filesChecked: 0` (or zero tests) is
+     **not** a pass — it usually means the push hasn't landed yet.
+     Re-sync and re-run.
+   - A red parse/eval/instantiate baseline usually means the copy is
+     incomplete (a missed same-realm dependency) — copy the missing
+     file and re-run. If you cannot get the baseline green, **stop
+     and report to the user** rather than proceeding; adjustment
+     Issues against a red baseline are meaningless.
+
+3. **Write a source-provenance Knowledge Article**
+   (`Knowledge Articles/<slug>-source-provenance.json`,
+   `articleType` per the schema): the `sourceCardUrl`, the list of
+   files copied, and the baseline validator results. This is what
+   later Issues read to understand what the seed was.
+
+4. **Create `adjustment` Issues** — one per coherent delta the brief
+   describes (not one-per-entry-point-card; that's the greenfield
+   rule). Use `issueType: "adjustment"` (confirm the enum via
+   `get-card-type-schema`). Each adjustment Issue's `description`
+   (immutable after creation) must name:
+   - the **workspace-relative target file(s)** to edit — the seeded
+     card and any support files the delta touches (they already
+     exist in the workspace);
+   - the **delta** — what changes, phrased as a diff against the
+     seeded baseline, not a from-scratch card spec;
+   - **acceptance** — the new expected behavior and its test
+     assertions, plus the standing requirement that the
+     **pre-existing baseline tests keep passing** (the delta must
+     not regress the green baseline).
+
+   Adjustment Issues direct edits at the **seeded artifacts** —
+   module, tests, sample instances, Spec. Don't write an Issue that
+   asks for a new module, instance, or Spec alongside the seeded
+   ones unless the brief explicitly asks for a new card.
+
+   Wire `project` / `relatedKnowledge` (include the provenance
+   article) / `blockedBy` exactly as for `feature` Issues.
+
+The agent that later picks up an `adjustment` Issue **edits** the
+seeded files rather than creating cards from scratch — see the
+"Adjustment issues" section of `software-factory-operations`.
 
 ## Discover the tracker module URL
 

--- a/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-operations/SKILL.md
@@ -518,6 +518,48 @@ If you cannot make progress at any step, set the Issue's `status`
 to `"blocked"`, append a comment explaining what's stuck, push, and
 report back to the user. See `software-factory-scheduling`.
 
+## Adjustment issues (adjust flow)
+
+When the Issue you picked up has `issueType: "adjustment"`, you are
+**editing an existing, already-seeded card** — not creating one from
+scratch. The bootstrap step seeded the source card and its
+same-realm dependency graph into the workspace and confirmed a green
+baseline before this Issue existed, so the files named in the
+Issue's description are **already present** (see the "Adjust flow"
+section of `software-factory-bootstrap`).
+
+How adjustment work differs from a greenfield `feature` Issue:
+
+- **Read the seeded files first.** The Issue description names the
+  target file(s). `Read` each one (and `Grep` for siblings) before
+  touching anything — you are modifying working code, not authoring
+  a blank slate. The source-provenance Knowledge Article (linked via
+  `relatedKnowledge`) records where the seed came from and its
+  baseline results.
+- **Apply only the delta.** Use `Edit` for surgical changes to the
+  seeded `.gts` / `.json`. Don't rewrite the card; change exactly
+  what the delta calls for.
+- **Guard the baseline.** The pre-existing tests are part of the
+  contract. Extend `.test.gts` with assertions for the new behavior,
+  but the **existing tests must still pass** — `boxel test` covers
+  both. A delta that breaks a baseline test is not done; fix it, or
+  bail out per "Bailing out" above.
+- **Operate on the seeded artifacts — never create parallel ones.**
+  The delta is applied by editing the existing seeded files: the
+  card module, its tests, its sample instances, and its Spec. If the
+  delta adds or renames a field, update the **existing** sample
+  instances to reflect it (so they demonstrate the new behavior) and
+  keep the Spec's `linkedExamples` pointing at them —
+  instantiate-card and `boxel parse` must stay green. Do **not** add
+  a new instance, module, or Spec to showcase a change; a new card
+  (or instance) is created only when the Issue explicitly calls for
+  one.
+- **Then the standard loop applies unchanged** — the "Required flow
+  per Issue" steps with "write" read as "edit": local `boxel parse`
+  pre-flight, push, run the five validators, write the
+  `Validations/` artifact cards, fix on failure, mark `done` only
+  when everything passes. Same validators, same bail-out limits.
+
 ## Target realm artifact structure
 
 ```

--- a/packages/software-factory/.agents/skills/software-factory-scheduling/SKILL.md
+++ b/packages/software-factory/.agents/skills/software-factory-scheduling/SKILL.md
@@ -226,4 +226,6 @@ that to the user — don't silently proceed with partial context.
   Issues).
 - `software-factory-operations` — what to do **inside** a regular
   implementation Issue (write `.gts` / `.test.gts` / instances /
-  Spec, run validators, fix failures, sync).
+  Spec, run validators, fix failures, sync). Covers both `feature`
+  Issues (build from scratch) and `adjustment` Issues (edit the
+  seeded card — see its "Adjustment issues" section).

--- a/packages/software-factory/docs/runbook.md
+++ b/packages/software-factory/docs/runbook.md
@@ -174,11 +174,11 @@ absolute URL of the card to adjust.
 Adjust is a superset of greenfield: one extra sub-phase inside
 bootstrap, then the standard Issue loop. During bootstrap the agent:
 
-1. **Seeds the target realm** with a working copy of the source card
+1. **Seeds the workspace (then the target realm on push)** with a working copy of the source card
    and its same-realm dependency graph —
    `boxel realm ingest-card "<source-card-url>" .` copies the card's
    module, the same-realm modules it imports (including type-only
-   imports), its sample instances, and its card-level Catalog Spec.
+   imports), its sample instances, and its card/app Catalog Spec.
    If the source card ships no co-located test (common for catalog
    cards), the agent writes **characterization tests** capturing its
    current behavior.

--- a/packages/software-factory/docs/runbook.md
+++ b/packages/software-factory/docs/runbook.md
@@ -80,9 +80,13 @@ Follow docs/runbook.md end-to-end:
 2. Create the target realm at the URL above and pull it into the
    workspace.
 3. Read the brief and follow software-factory-bootstrap to write
-   the Project, IssueTracker, Knowledge Articles, one Issue per
-   entry-point card the brief describes, plus the bootstrap-seed
-   Issue. Push the workspace.
+   the Project, IssueTracker, Knowledge Articles, and the
+   implementation Issues, plus the bootstrap-seed Issue. The brief
+   selects the flow: no `sourceCardUrl` → greenfield (one `feature`
+   Issue per entry-point card); `sourceCardUrl` set → adjust (seed
+   the source card, confirm a green baseline, then one `adjustment`
+   Issue per delta — see the skill's "Adjust flow" section). Push
+   the workspace.
 4. Hand off to software-factory-scheduling: pick the next
    unblocked Issue, follow software-factory-operations to
    implement it (.gts + .test.gts + sample instances + Catalog
@@ -125,6 +129,92 @@ session.
 > because the recipe brief proved it works end-to-end without
 > intervention.
 
+## Adjusting an existing card
+
+The factory can also **adjust an existing card** instead of building
+new ones from scratch. The run contract is identical — the same two
+inputs (brief URL + target realm URL) and the same prompt above. What
+selects the adjust flow is the **brief**, not the prompt: a brief that
+carries a `sourceCardUrl` attribute runs as an adjust; one without it
+runs greenfield. (Full contract:
+[adjust-existing-card-flow.md](./adjust-existing-card-flow.md).)
+
+### Authoring an adjust brief
+
+The brief is a `Wiki` card, exactly as for greenfield, with one extra
+requirement: set the optional `sourceCardUrl` attribute to the
+absolute URL of the card to adjust.
+
+```jsonc
+// the brief's JSON:API document
+{
+  "data": {
+    "attributes": {
+      "content": "…the adjustments, phrased as deltas to the source card…",
+      "sourceCardUrl": "http://localhost:4201/catalog/mortgage-calculator",
+    },
+  },
+}
+```
+
+- **`sourceCardUrl` is required for an adjust run.** Without it the
+  factory runs greenfield and builds the brief's cards from scratch.
+- **The source card must live on the same realm server** as the
+  target realm, reachable with the active profile. A missing,
+  malformed, or cross-server URL fails loudly at seed time (the
+  ingest step can't fetch it) — it does not silently fall back to
+  greenfield.
+- **Write the brief content as deltas**, not as a full card spec:
+  what changes about the source card (add field X, change behavior
+  Y, restyle the fitted view), one coherent delta per adjustment you
+  want. Bootstrap turns each delta into one `adjustment` Issue.
+
+### What the run does differently
+
+Adjust is a superset of greenfield: one extra sub-phase inside
+bootstrap, then the standard Issue loop. During bootstrap the agent:
+
+1. **Seeds the target realm** with a working copy of the source card
+   and its same-realm dependency graph —
+   `boxel realm ingest-card "<source-card-url>" .` copies the card's
+   module, the same-realm modules it imports (including type-only
+   imports), its sample instances, and its card-level Catalog Spec.
+   If the source card ships no co-located test (common for catalog
+   cards), the agent writes **characterization tests** capturing its
+   current behavior.
+2. **Confirms a green baseline** — the standard validators must all
+   pass on the seeded copy before any adjustment Issue is created. A
+   zero-test run does not count as green.
+3. **Writes a source-provenance Knowledge Article**
+   (`Knowledge Articles/<slug>-source-provenance.json`): the
+   `sourceCardUrl`, the files copied, and the baseline results.
+4. **Creates `adjustment` Issues** — one per coherent delta the brief
+   describes (instead of greenfield's one `feature` Issue per
+   entry-point card). Each names the seeded file(s) to edit, the
+   delta, and acceptance criteria that include "the baseline tests
+   keep passing."
+
+From there scheduling, the validator loop, the
+`Validations/` audit-trail cards, the bail-out limits, and project
+completion are identical to greenfield. The implementation agent
+**edits the seeded artifacts in place** (module, tests, instances,
+Spec) rather than creating parallel ones — see the "Adjustment
+issues" section of `software-factory-operations`.
+
+### Expected output (adjust run)
+
+Same shape as the greenfield list below, with these differences:
+
+- The card module, tests, sample instances, and `Spec/` card are the
+  **seeded copies of the source card**, with the brief's deltas
+  applied (plus characterization tests if the source had none).
+- `Knowledge Articles/<slug>-source-provenance.json` — where the
+  seed came from and the baseline validator results.
+- `Issues/<slug>-<delta>.json` — one Issue per delta, with
+  `issueType: "adjustment"`. The baseline validator results live in
+  the provenance article, not in `Validations/` (those cards are
+  per-Issue).
+
 ## What the agent calls (and from where)
 
 | Capability              | How the agent invokes it                                                                                                                                                                                         |
@@ -154,11 +244,8 @@ A few rough edges remain — not blocking, but worth tracking:
 - **`/factory-run` slash command** — wrap the single prompt above
   as a slash command (or a `boxel factory run` CLI that spawns
   `claude` with the prompt baked in) so the user doesn't paste
-  prose every time.
-- **Self-contained `boxel test`** — track [CS-11164](https://linear.app/cardstack/issue/CS-11164).
-  Today `boxel test` still needs the monorepo (host `dist/` +
-  Playwright). The plan is to bundle a QUnit harness into the CLI the
-  same way CS-11165 bundled the type-check toolchain.
+  prose every time. One wrapper covers both flows, since the brief
+  (not the prompt) selects greenfield vs adjust.
 - **Orchestrator retirement** — once this runbook has shipped and
   run in production for long enough, delete the SDK orchestrator
   code (`issue-loop.ts`, `factory-agent/`, etc.).


### PR DESCRIPTION
Allows us to run the software factory for existing cards, in interact mode from within an agent (as opposed to the other way of running the factory - using the node app). 

Example:

```
Run the software factory per docs/runbook.md:                           
Brief URL: http://localhost:4201/software-factory/Wiki/adjust-mortgage-calculator        
Target realm: http://localhost:4201/user/adjust-mortgage-calculator-test-123/
```

Documents the adjust-existing-card flow for users ([CS-11405](https://linear.app/cardstack/issue/CS-11405/runbook-prompt-for-the-improve-flow)), building on the flow shipped in #5145.

## Runbook (`docs/runbook.md`)

- New **"Adjusting an existing card"** section: the run contract stays 2-input (brief URL + target realm URL) and the prompt is unchanged — the **brief** selects the flow. Covers the brief-authoring requirement (`sourceCardUrl` on the Wiki brief, source card on the same realm server, fails loud at seed time), what the run does differently (seed via `boxel realm ingest-card`, characterization tests for test-less source cards, green-baseline gate, source-provenance Knowledge Article, one `adjustment` Issue per delta), and the expected-output deltas.
- The kickoff prompt's bootstrap step is reworded to be flow-neutral (greenfield vs adjust shape, selected by the brief).
- The optional `/factory-improve` wrapper from the ticket is folded into the existing `/factory-run` follow-up bullet — one wrapper covers both flows since the brief selects the flow.
- Drops the stale follow-up bullet saying `boxel test` still needs the monorepo (contradicted by the prerequisites section of the same doc).

## Interactive skills (one step beyond the ticket's literal scope)

#5145 added the adjust guidance to the **orchestrator** skills only. The runbook's prompt runs through the **interactive** skills, which had no adjust coverage — so documenting the prompt without them would describe a run the agent can't execute. This PR ports that guidance, translated to the CLI surface the interactive flow uses (`boxel realm ingest-card`, `boxel parse/lint/test`, run-command validators, blocked-status reporting instead of `request_clarification`):

- `software-factory-bootstrap`: the greenfield/adjust mode fork (detected from the brief's `sourceCardUrl`) and the seed → green baseline → provenance article → adjustment-Issues sub-phase. Includes the two baseline traps from the first real runs: zero-files-checked is not a pass, and a red baseline usually means an incomplete copy.
- `software-factory-operations`: the "Adjustment issues" section — read the seeded files first, apply only the delta, guard the baseline tests, edit the seeded artifacts in place rather than creating parallel ones.
- `software-factory-scheduling`: a see-also pointer to the issueType dispatch.

If the interactive-skill port should be its own ticket instead, happy to split it out — the runbook section stands on its own minus the prompt claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)