### PR TITLE
fix: ship @glimmer/component + @glimmer/tracking types with boxel parse

### DIFF
--- a/packages/boxel-cli/package.json
+++ b/packages/boxel-cli/package.json
@@ -32,6 +32,8 @@
   "author": "Cardstack",
   "dependencies": {
     "@aws-crypto/sha256-js": "catalog:",
+    "@glimmer/component": "catalog:",
+    "@glimmer/tracking": "^1.1.2",
     "@glint/ember-tsc": "catalog:",
     "@playwright/test": "catalog:",
     "@types/qunit": "catalog:",

--- a/packages/boxel-cli/src/commands/parse.ts
+++ b/packages/boxel-cli/src/commands/parse.ts
@@ -108,11 +108,14 @@ const SHIMS_PATH = BUNDLED_TYPES_DIR
 
 // Node modules: in-monorepo, host has every transitive dep glint needs
 // already installed. In a published install we don't ship host's
-// node_modules, so we fall back to boxel-cli's own node_modules — which
-// has `@glint/ember-tsc`, `typescript`, and `content-tag` as runtime
-// dependencies (CS-11165). Diagnostics from third-party imports that
-// exist only in host/node_modules but not in boxel-cli's will surface as
-// "Cannot find module …"; we filter those out in `runGlintCheck` below.
+// node_modules, so we fall back to boxel-cli's own node_modules. That
+// means a third-party import in card code only type-checks if the
+// package is a runtime dependency of boxel-cli: `@glint/ember-tsc`,
+// `typescript`, and `content-tag` (CS-11165), plus the packages card
+// code itself commonly imports — `@glimmer/component` and
+// `@glimmer/tracking` (CS-11509). Imports outside that set surface as
+// "Cannot find module …" parse errors; the fix is adding the package
+// as a boxel-cli dependency, not shimming it.
 const NODE_MODULES_PATH = BUNDLED_TYPES_DIR
   ? join(BOXEL_CLI_PATH, 'node_modules')
   : join(PACKAGES_PATH, 'host', 'node_modules');

--- a/packages/boxel-cli/tests/commands/parse-glimmer-types.test.ts
+++ b/packages/boxel-cli/tests/commands/parse-glimmer-types.test.ts
@@ -1,0 +1,73 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import { join, resolve } from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { parseRealm } from '../../src/commands/parse.ts';
+
+// `boxel parse` resolves third-party imports in card code against
+// boxel-cli's own node_modules when running from the published layout
+// (bundled-types present). Cards that define plain Glimmer components
+// import `@glimmer/component` / `@glimmer/tracking`, so those packages
+// must be runtime dependencies of boxel-cli (CS-11509).
+//
+// This exercises the published-layout resolution path: CI runs
+// `pnpm build` (which produces `bundled-types/`) before the unit
+// tests. Without that build, parse falls back to the monorepo layout
+// and resolves against host's node_modules — which would mask a
+// missing boxel-cli dependency — so the test skips instead.
+const bundledTypesPresent = fs.existsSync(
+  resolve(__dirname, '../../bundled-types/base'),
+);
+
+describe.skipIf(!bundledTypesPresent)(
+  'boxel parse — @glimmer imports in card code',
+  () => {
+    let workspace: string;
+
+    beforeAll(() => {
+      workspace = fs.mkdtempSync(join(os.tmpdir(), 'boxel-parse-glimmer-'));
+      fs.writeFileSync(
+        join(workspace, 'counter.gts'),
+        `import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import {
+  CardDef,
+  Component as CardComponent,
+  field,
+  contains,
+} from 'https://cardstack.com/base/card-api';
+import NumberField from 'https://cardstack.com/base/number';
+
+class CounterWidget extends Component<{ Args: { start?: number } }> {
+  @tracked count = this.args.start ?? 0;
+  <template><span>{{this.count}}</span></template>
+}
+
+export class Counter extends CardDef {
+  static displayName = 'Counter';
+  @field start = contains(NumberField);
+  static isolated = class Isolated extends CardComponent<typeof Counter> {
+    <template><CounterWidget @start={{@model.start}} /></template>
+  };
+}
+`,
+      );
+    });
+
+    afterAll(() => {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    });
+
+    it(
+      'type-checks a card defining a plain Glimmer component',
+      async () => {
+        let result = await parseRealm(undefined, { workspace });
+        expect(result.errors).toEqual([]);
+        expect(result.status).toBe('passed');
+        expect(result.filesChecked).toBeGreaterThanOrEqual(1);
+      },
+      { timeout: 180_000 },
+    );
+  },
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1022,6 +1022,12 @@ importers:
       '@aws-crypto/sha256-js':
         specifier: 'catalog:'
         version: 5.2.0
+      '@glimmer/component':
+        specifier: ^2.0.0
+        version: 2.1.1
+      '@glimmer/tracking':
+        specifier: ^1.1.2
+        version: 1.1.2
       '@glint/ember-tsc':
         specifier: 'catalog:'
         version: 1.5.0(typescript@5.9.3)
@@ -1504,10 +1510,10 @@ importers:
         version: 1.16.13(@glint/template@1.7.7)
       '@embroider/test-setup':
         specifier: ^4.0.0
-        version: 4.0.0(@embroider/compat@3.9.4(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.10(@glint/template@1.7.7))(@glint/template@1.7.7))(@embroider/core@3.5.10(@glint/template@1.7.7))(@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2))
+        version: 4.0.0(@embroider/compat@3.9.4(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.10(@glint/template@1.7.7))(@glint/template@1.7.7))(@embroider/core@3.5.10(@glint/template@1.7.7))(@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14)))
       '@embroider/webpack':
         specifier: ^4.0.4
-        version: 4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2)
+        version: 4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14))
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.1.1
@@ -1558,7 +1564,7 @@ importers:
         version: 8.0.1(@babel/core@7.29.0)(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/test-waiters@4.1.1(@glint/template@1.7.7))(axe-core@4.11.4)(qunit@2.25.0)
       ember-auto-import:
         specifier: ^2.7.2
-        version: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
+        version: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
       ember-cli:
         specifier: ^5.4.1
         version: 5.12.0(@babel/core@7.29.0)(@types/node@24.12.4)
@@ -1609,7 +1615,7 @@ importers:
         version: 1.0.0(patch_hash=0e5253a008cc7bf02424d786e7a8fb2397bc48962f3cd1443f2c0fdd8200c96d)
       ember-freestyle:
         specifier: ^0.22.0
-        version: 0.22.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2)
+        version: 0.22.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2(postcss@8.5.14))
       ember-load-initializers:
         specifier: ^3.0.0
         version: 3.0.1(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
@@ -1687,7 +1693,7 @@ importers:
         version: 5.9.3
       webpack:
         specifier: 'catalog:'
-        version: 5.106.2
+        version: 5.106.2(postcss@8.5.14)
 
   packages/catalog:
     dependencies:
@@ -2073,7 +2079,7 @@ importers:
         version: 1.31.13(typescript@5.9.3)
       '@percy/ember':
         specifier: 'catalog:'
-        version: 5.0.1(@babel/core@7.29.0)(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
+        version: 5.0.1(@babel/core@7.29.0)(@glint/template@1.7.7)(webpack@5.106.2)
       '@rollup/plugin-babel':
         specifier: ^6.0.4
         version: 6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.3)
@@ -2181,7 +2187,7 @@ importers:
         version: 1.0.3(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
       ember-auto-import:
         specifier: ^2.7.2
-        version: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
+        version: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
       ember-basic-dropdown:
         specifier: 8.0.4
         version: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
@@ -2232,13 +2238,13 @@ importers:
         version: 2.0.0(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
       ember-exam:
         specifier: ^10.1.0
-        version: 10.1.0(@glint/template@1.7.7)(ember-qunit@9.0.4(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.106.2(postcss@8.5.14))
+        version: 10.1.0(@glint/template@1.7.7)(ember-qunit@9.0.4(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.106.2)
       ember-focus-trap:
         specifier: ^1.0.1
         version: 1.2.0(@babel/core@7.29.0)
       ember-freestyle:
         specifier: ^0.20.0
-        version: 0.20.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2(postcss@8.5.14))
+        version: 0.20.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2)
       ember-keyboard:
         specifier: ^8.2.1
         version: 8.2.1(@babel/core@7.29.0)(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))
@@ -17347,11 +17353,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/babel-loader-9@3.1.3(@embroider/core@3.5.10(@glint/template@1.7.7))(supports-color@8.1.1)(webpack@5.106.2)':
+  '@embroider/babel-loader-9@3.1.3(@embroider/core@3.5.10(@glint/template@1.7.7))(supports-color@8.1.1)(webpack@5.106.2(postcss@8.5.14))':
     dependencies:
       '@babel/core': 7.29.0(supports-color@8.1.1)
       '@embroider/core': 3.5.10(@glint/template@1.7.7)
-      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.2)
+      babel-loader: 9.2.1(@babel/core@7.29.0)(webpack@5.106.2(postcss@8.5.14))
     transitivePeerDependencies:
       - supports-color
       - webpack
@@ -17534,10 +17540,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/hbs-loader@3.0.5(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2)':
+  '@embroider/hbs-loader@3.0.5(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14))':
     dependencies:
       '@embroider/core': 3.5.10(@glint/template@1.7.7)
-      webpack: 5.106.2
+      webpack: 5.106.2(postcss@8.5.14)
 
   '@embroider/legacy-inspector-support@0.1.3':
     dependencies:
@@ -17633,14 +17639,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/test-setup@4.0.0(@embroider/compat@3.9.4(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.10(@glint/template@1.7.7))(@glint/template@1.7.7))(@embroider/core@3.5.10(@glint/template@1.7.7))(@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2))':
+  '@embroider/test-setup@4.0.0(@embroider/compat@3.9.4(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.10(@glint/template@1.7.7))(@glint/template@1.7.7))(@embroider/core@3.5.10(@glint/template@1.7.7))(@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14)))':
     dependencies:
       lodash: 4.18.1
       resolve: 1.22.12
     optionalDependencies:
       '@embroider/compat': 3.9.4(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.10(@glint/template@1.7.7))(@glint/template@1.7.7)
       '@embroider/core': 3.5.10(@glint/template@1.7.7)
-      '@embroider/webpack': 4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2)
+      '@embroider/webpack': 4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14))
 
   '@embroider/util@1.13.1(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))':
     dependencies:
@@ -17679,32 +17685,32 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2)':
+  '@embroider/webpack@4.1.2(patch_hash=3575bbdd1074ff74a26adde4a25140c197c845679f6ad0941e00494f73c79eff)(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14))':
     dependencies:
       '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/preset-env': 7.29.5(@babel/core@7.29.0)(supports-color@8.1.1)
-      '@embroider/babel-loader-9': 3.1.3(@embroider/core@3.5.10(@glint/template@1.7.7))(supports-color@8.1.1)(webpack@5.106.2)
+      '@embroider/babel-loader-9': 3.1.3(@embroider/core@3.5.10(@glint/template@1.7.7))(supports-color@8.1.1)(webpack@5.106.2(postcss@8.5.14))
       '@embroider/core': 3.5.10(@glint/template@1.7.7)
-      '@embroider/hbs-loader': 3.0.5(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2)
+      '@embroider/hbs-loader': 3.0.5(@embroider/core@3.5.10(@glint/template@1.7.7))(webpack@5.106.2(postcss@8.5.14))
       '@embroider/shared-internals': 2.9.2(supports-color@8.1.1)
       '@types/supports-color': 8.1.3
       assert-never: 1.4.0
-      babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.106.2)
-      css-loader: 5.2.7(webpack@5.106.2)
+      babel-loader: 8.4.1(@babel/core@7.29.0)(webpack@5.106.2(postcss@8.5.14))
+      css-loader: 5.2.7(webpack@5.106.2(postcss@8.5.14))
       csso: 4.2.0
       debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       fs-extra: 9.1.0
       jsdom: 25.0.1(supports-color@8.1.1)
       lodash: 4.18.1
-      mini-css-extract-plugin: 2.10.2(webpack@5.106.2)
+      mini-css-extract-plugin: 2.10.2(webpack@5.106.2(postcss@8.5.14))
       semver: 7.8.0
       source-map-url: 0.4.1
-      style-loader: 2.0.0(patch_hash=579dd92e6adabd45669f9a99a01c6c28c97488c7bf4ee0d6c1c622a14592e4c8)(webpack@5.106.2)
+      style-loader: 2.0.0(patch_hash=579dd92e6adabd45669f9a99a01c6c28c97488c7bf4ee0d6c1c622a14592e4c8)(webpack@5.106.2(postcss@8.5.14))
       supports-color: 8.1.1
       terser: 5.47.1
-      thread-loader: 3.0.4(webpack@5.106.2)
-      webpack: 5.106.2
+      thread-loader: 3.0.4(webpack@5.106.2(postcss@8.5.14))
+      webpack: 5.106.2(postcss@8.5.14)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -19111,10 +19117,7 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli-command@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -19131,10 +19134,7 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli-doctor@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -19170,10 +19170,7 @@ snapshots:
       '@percy/cli-command': 1.31.13(typescript@5.9.3)
       yaml: 2.9.0
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli-upload@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -19181,10 +19178,7 @@ snapshots:
       fast-glob: 3.3.3
       image-size: 1.2.1
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
       - typescript
-      - utf-8-validate
 
   '@percy/cli@1.31.13(typescript@5.9.3)':
     dependencies:
@@ -19253,10 +19247,10 @@ snapshots:
 
   '@percy/dom@1.31.13': {}
 
-  '@percy/ember@5.0.1(@babel/core@7.29.0)(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))':
+  '@percy/ember@5.0.1(@babel/core@7.29.0)(@glint/template@1.7.7)(webpack@5.106.2)':
     dependencies:
       '@percy/sdk-utils': 1.31.13
-      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
+      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
       ember-cli-babel: 8.3.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -21146,12 +21140,12 @@ snapshots:
       schema-utils: 2.7.1
       webpack: 5.106.2
 
-  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.2):
+  babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.106.2(postcss@8.5.14)):
     dependencies:
       '@babel/core': 7.29.0(supports-color@8.1.1)
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.106.2
+      webpack: 5.106.2(postcss@8.5.14)
 
   babel-plugin-debug-macros@0.2.0(@babel/core@7.29.0):
     dependencies:
@@ -24000,13 +23994,13 @@ snapshots:
       content-tag: 4.2.0
       oxc-parser: 0.130.0
 
-  ember-exam@10.1.0(@glint/template@1.7.7)(ember-qunit@9.0.4(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.106.2(postcss@8.5.14)):
+  ember-exam@10.1.0(@glint/template@1.7.7)(ember-qunit@9.0.4(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.106.2):
     dependencies:
       '@babel/core': 7.29.0(supports-color@8.1.1)
       chalk: 5.6.2
       cli-table3: 0.6.5
       debug: 4.4.3(supports-color@8.1.1)
-      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
+      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
       ember-cli-babel: 8.3.1(@babel/core@7.29.0)
       ember-qunit: 9.0.4(@ember/test-helpers@5.4.2(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0)
       ember-source: 6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5)
@@ -24031,31 +24025,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-
-  ember-freestyle@0.20.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2(postcss@8.5.14)):
-    dependencies:
-      '@ember/render-modifiers': 2.1.0(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
-      '@ember/string': 4.0.1
-      '@glimmer/component': 2.1.1
-      '@glimmer/tracking': 1.1.2
-      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 6.3.0
-      ember-cli-typescript: 5.3.0
-      ember-focus-trap: 1.2.0(@babel/core@7.29.0)
-      ember-modifier: 4.3.0(@babel/core@7.29.0)
-      ember-named-blocks-polyfill: 0.2.5
-      ember-truth-helpers: 4.0.3(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
-      json-formatter-js: 2.5.23
-      macro-decorators: 0.1.2
-      strip-indent: 3.0.0
-      tracked-built-ins: 4.1.2(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - ember-source
-      - supports-color
-      - webpack
 
   ember-freestyle@0.20.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2):
     dependencies:
@@ -24082,12 +24051,12 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-freestyle@0.22.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2):
+  ember-freestyle@0.22.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2(postcss@8.5.14)):
     dependencies:
       '@ember/string': 4.0.1
       '@glimmer/component': 2.1.1
       '@glimmer/tracking': 1.1.2
-      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
+      ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2(postcss@8.5.14))
       ember-cli-babel: 8.3.1(@babel/core@7.29.0)
       ember-cli-htmlbars: 6.3.0
       ember-cli-typescript: 5.3.0
@@ -30343,14 +30312,14 @@ snapshots:
     dependencies:
       editions: 6.22.0
 
-  thread-loader@3.0.4(webpack@5.106.2):
+  thread-loader@3.0.4(webpack@5.106.2(postcss@8.5.14)):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.2
       loader-utils: 2.0.4
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      webpack: 5.106.2
+      webpack: 5.106.2(postcss@8.5.14)
 
   through2@3.0.2:
     dependencies:


### PR DESCRIPTION
Fixes [CS-11509](https://linear.app/cardstack/issue/CS-11509/boxel-parse-published-cli-fails-on-cards-importing-glimmercomponent). Found during the first interactive adjust-flow run: the seeded catalog mortgage-calculator failed `boxel parse` with 32 `Cannot find module '@glimmer/component'` errors on a published install, costing the agent ~10 minutes of CLI forensics plus a hand-written ambient-shim workaround. Any card defining a plain Glimmer component hits this.

## Why

A published boxel-cli resolves third-party imports in card code against **its own** `node_modules` (`parse.ts` symlinks it into the type-check workspace), so a package type-checks only if it's a boxel-cli runtime dependency. `@glimmer/component` / `@glimmer/tracking` weren't — and monorepo dev masks the gap because it resolves against host's `node_modules` instead. The code comment claiming such diagnostics are filtered in `runGlintCheck` described a filter that was never implemented.

## What

- `@glimmer/component` (`catalog:` → `^2.0.0`, matching host) and `@glimmer/tracking` (`^1.1.2`, matching host) added as runtime dependencies. A few KB; type-only at parse time (no peer deps); the bundled test-harness runtime already serves these fine.
- The stale node-modules comment now states the real contract: a third-party import in card code type-checks iff the package is a boxel-cli dependency.
- Regression test: `parseRealm` over a fixture card that imports `@glimmer/component` + `@glimmer/tracking`, exercised against the **published layout** (`bundled-types/` present → published-mode resolution). Skips when bundled-types isn't built; CI's `pnpm build` step produces it before unit tests run.

## Verification

- New test passes locally against a freshly built `bundled-types/` (5.5s).
- `tsc --noEmit`, eslint, prettier clean.
- The failure mode itself was reproduced on a real published install (`0.4.0-unstable.0`) before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)