### PR TITLE
Fix realm-server shard flake: prerender env leak + poisoned template snapshots

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -592,7 +592,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
-          name: realm-server-test-report-${{ matrix.shardIndex }}
+          # Attempt-scoped (same convention as host-test-report-*): artifacts
+          # from earlier attempts stay attached to the run, so an unscoped
+          # name accumulates one copy per rerun and the merge job aggregates
+          # failures from attempts that have since gone green.
+          name: realm-server-test-report-${{ github.run_attempt }}-${{ matrix.shardIndex }}
           path: junit/realm-server-${{ matrix.shardIndex }}.xml
           retention-days: 30
       - name: Print realm server logs
@@ -686,7 +690,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: all-realm-server-reports
-          pattern: realm-server-test-report-*
+          # Only this attempt's reports. On a partial rerun (rerun --failed)
+          # the aggregate check covers just the rerun shards — the per-shard
+          # jobs remain the real gates — instead of staying red forever on
+          # stale failures from dead attempts. Also must not match the
+          # merged artifact below, or rerun merges ingest their own prior
+          # output recursively.
+          pattern: realm-server-test-report-${{ github.run_attempt }}-*
           merge-multiple: true
       - name: Merge reports
         run: npx junit-report-merger realm-server.xml "./all-realm-server-reports/*.xml"

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -828,6 +828,40 @@ export async function logRealmIndexDiagnostics(
   }
 }
 
+/**
+ * Refuse to snapshot a template whose from-scratch index never completed.
+ * `waitForQueueIdle` only proves the queue drained — a failed
+ * `from-scratch-index` job (e.g. a timed-out prerender visit) leaves the
+ * realm at `current_version` 0 with no `realm_meta` row, and snapshotting
+ * that database poisons every test module that clones the template. An
+ * intentionally-empty realm still indexes to version >= 1 with a
+ * `realm_meta` row (`instances: 0`), so this check holds for blank
+ * fixtures too.
+ */
+async function assertRealmIndexBuilt(
+  dbAdapter: PgAdapter,
+  realmURL: string,
+): Promise<void> {
+  let [versionRow] = await dbAdapter.execute(
+    `SELECT current_version FROM realm_versions WHERE realm_url = $1`,
+    { bind: [realmURL] },
+  );
+  let currentVersion = Number(versionRow?.current_version ?? 0);
+  let [metaRow] = await dbAdapter.execute(
+    `SELECT realm_version FROM realm_meta WHERE realm_url = $1 AND realm_version = $2`,
+    { bind: [realmURL, currentVersion] },
+  );
+  if (currentVersion < 1 || !metaRow) {
+    throw new Error(
+      `template build for ${realmURL} finished with an unindexed realm ` +
+        `(current_version=${currentVersion}, realm_meta ${
+          metaRow ? 'present' : 'missing'
+        }) — refusing to snapshot. The from-scratch-index job likely ` +
+        `failed; see the [realm-index-diag template-build] output above.`,
+    );
+  }
+}
+
 interface CachedPermissionedRealmTemplateEntry {
   ready: Promise<void>;
 }
@@ -2257,6 +2291,10 @@ async function buildPermissionedRealmTemplate(
       (options.realmURL ?? testRealmURL).href,
       'template-build',
     );
+    await assertRealmIndexBuilt(
+      dbAdapter,
+      (options.realmURL ?? testRealmURL).href,
+    );
     await teardownPermissionedRealmFixture(fixture.testRealmServer);
     fixture = undefined;
 
@@ -2428,6 +2466,7 @@ async function buildPermissionedRealmsTemplate(
         fixtureRealm.realm.url,
         'template-build',
       );
+      await assertRealmIndexBuilt(dbAdapter, fixtureRealm.realm.url);
     }
     await teardownPermissionedRealmsFixture(fixture.realms);
     fixture = undefined;

--- a/packages/realm-server/tests/remote-prerenderer-test.ts
+++ b/packages/realm-server/tests/remote-prerenderer-test.ts
@@ -449,7 +449,18 @@ module(basename(__filename), function (hooks) {
   });
 });
 
-module(basename(__filename), function () {
+module(basename(__filename), function (hooks) {
+  // These env vars are read at createRemotePrerenderer() call time, so a
+  // leaked value poisons every prerenderer created later in this shard
+  // process — e.g. a 20ms request timeout (clamped to the 1s floor) made
+  // the next test file's cached-template index build fail intermittently.
+  hooks.afterEach(function () {
+    delete process.env.PRERENDER_MANAGER_RETRY_ATTEMPTS;
+    delete process.env.PRERENDER_MANAGER_RETRY_DELAY_MS;
+    delete process.env.PRERENDER_MANAGER_REQUEST_TIMEOUT_MS;
+    delete process.env.PRERENDER_MANAGER_MAX_DELAY_MS;
+  });
+
   module('remote prerenderer timeouts', function () {
     test('does not retry when the client aborts from request timeout', async function (assert) {
       process.env.PRERENDER_MANAGER_RETRY_ATTEMPTS = '3';


### PR DESCRIPTION
Fixes [CS-11511](https://linear.app/cardstack/issue/CS-11511/realm-server-shard-flake-remote-prerenderer-test-leaks-1s-prerender). This is the flake that failed `skip-query-backed-expansion-test.ts` on ~half of today's main runs and 4 consecutive attempts on #5197.

## Mechanism

1. `tests/remote-prerenderer-test.ts` declares two top-level modules. The first cleans up its `PRERENDER_MANAGER_*` env mutations in `hooks.afterEach`; the second took **no hooks** and left `REQUEST_TIMEOUT_MS='20'` (clamped to the 1000ms floor), `RETRY_ATTEMPTS='3'`, `RETRY_DELAY_MS='1'` set for the rest of the shard process.
2. `createRemotePrerenderer()` reads those at call time, and a request-timeout abort is deliberately non-retryable — so the next test file to build a realm fixture (`skip-query-backed-expansion-test.ts`, the alphabetical neighbor) ran its from-scratch index with a 1s hard timeout. Cold prerender pages routinely exceed that; warm ones don't — hence the coin-flip.
3. `buildPermissionedRealmTemplate` waits for queue idle but never checks the index *succeeded*: it logged `current_version=0 realm_meta=[(none)]` and snapshotted the empty database anyway, so one timed-out render became five failing tests with `cardDocument === undefined`.

## What

- The second module now scopes its env mutations with the same `hooks.afterEach` cleanup as the first.
- Both cached template builders (`buildPermissionedRealmTemplate` / `buildPermissionedRealmsTemplate`) assert the realm indexed — `current_version >= 1` with a matching `realm_meta` row — before snapshotting, and throw with a pointer to the `realm-index-diag` output otherwise. Intentionally-empty realms still pass (blank fixtures index to v1 with `instances: 0`).

**Reporting fallout (third fix).** Report artifacts from failed attempts stay attached to the workflow run, and the merge job's wildcard (`realm-server-test-report-*`) swept them all up — including its own previous merged outputs, whose name matched the same wildcard — so the published "Realm Server Test Results" check kept re-reporting failures from attempts that had since gone green (observed on #5197: five copies of the shard-4 report, one per attempt). Shard report names and the download pattern are now scoped to `github.run_attempt`, the convention `host-test-report-*` already uses.

## Verification

- `remote-prerenderer-test.ts` 14/14 green locally; `ember-tsc`, eslint, prettier clean.
- The snapshot guard's failure mode is exercised by the very flake it closes: with the env leak also fixed the guard should never fire, but if a from-scratch index fails for any other reason, the template build now errors loudly instead of poisoning the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
