### PR TITLE
Picker: toggle off by id when options rebuild across renders

### DIFF
--- a/packages/boxel-ui/addon/src/components/picker/index.gts
+++ b/packages/boxel-ui/addon/src/components/picker/index.gts
@@ -274,6 +274,35 @@ export default class Picker extends Component<PickerSignature> {
       return;
     }
 
+    // ember-power-select's multi-select toggle uses object identity to decide
+    // add-vs-remove. Consumers that rebuild PickerOption objects across renders
+    // (e.g. RealmPicker) never satisfy that identity check, so a click on an
+    // already-selected option arrives here as a duplicate id instead of a
+    // removal. Normalize by id: a duplicate id means "toggle off"; otherwise
+    // dedupe defensively so identity drift can't pile up extra entries.
+    const idCounts = new Map<string, number>();
+    for (const opt of selected) {
+      idCounts.set(opt.id, (idCounts.get(opt.id) ?? 0) + 1);
+    }
+    const toggleOffIds = new Set<string>();
+    for (const [id, count] of idCounts) {
+      if (count > 1) {
+        toggleOffIds.add(id);
+      }
+    }
+    if (toggleOffIds.size > 0) {
+      selected = selected.filter((opt) => !toggleOffIds.has(opt.id));
+    } else {
+      const seenIds = new Set<string>();
+      selected = selected.filter((opt) => {
+        if (seenIds.has(opt.id)) {
+          return false;
+        }
+        seenIds.add(opt.id);
+        return true;
+      });
+    }
+
     const selectAllOptions = selected.filter((option) => {
       return option.type === 'select-all';
     });

--- a/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
@@ -254,11 +254,11 @@ module('Integration | Component | picker', function (hooks) {
       .doesNotExist('Option 1 checkbox is unchecked after deselecting');
   });
 
-  // Regression: CS-11321. Consumers like RealmPicker rebuild PickerOption
-  // objects on every render rather than maintaining stable references.
-  // Power-select's identity-based toggle then fails to recognize an
-  // already-selected option, so a second click used to append a duplicate
-  // instead of unselecting. Picker.onChange normalizes by id to fix this.
+  // When a consumer reconstructs PickerOption objects on every render
+  // rather than keeping object references stable, power-select's
+  // identity-based multi-select toggle can't match the clicked option
+  // against @selected and emits a duplicate-id selection. Picker
+  // normalizes by id so a duplicate signals a toggle-off.
   test('picker toggles selection by id when consumer rebuilds option objects each render', async function (assert) {
     class SelectionController {
       @tracked selectedIds: string[] = [];

--- a/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
@@ -254,6 +254,80 @@ module('Integration | Component | picker', function (hooks) {
       .doesNotExist('Option 1 checkbox is unchecked after deselecting');
   });
 
+  // Regression: CS-11321. Consumers like RealmPicker rebuild PickerOption
+  // objects on every render rather than maintaining stable references.
+  // Power-select's identity-based toggle then fails to recognize an
+  // already-selected option, so a second click used to append a duplicate
+  // instead of unselecting. Picker.onChange normalizes by id to fix this.
+  test('picker toggles selection by id when consumer rebuilds option objects each render', async function (assert) {
+    class SelectionController {
+      @tracked selectedIds: string[] = [];
+
+      get options(): PickerOption[] {
+        return [
+          { id: 'select-all', label: 'All', type: 'select-all' },
+          { id: '1', label: 'Option 1' },
+          { id: '2', label: 'Option 2' },
+        ];
+      }
+
+      get selected(): PickerOption[] {
+        if (this.selectedIds.length === 0) {
+          return this.options.filter((o) => o.type === 'select-all');
+        }
+        return this.selectedIds.map((id) => ({ id, label: `Option ${id}` }));
+      }
+    }
+
+    const controller = new SelectionController();
+
+    const onChange = (newSelected: PickerOption[]) => {
+      controller.selectedIds = newSelected
+        .filter((o) => o.type !== 'select-all')
+        .map((o) => o.id);
+    };
+
+    await render(
+      <template>
+        <Picker
+          @options={{controller.options}}
+          @selected={{controller.selected}}
+          @onChange={{onChange}}
+          @label='Test'
+        />
+      </template>,
+    );
+
+    await click('[data-test-boxel-picker-trigger]');
+    await waitFor('[data-test-boxel-picker-option-row]');
+
+    const optionOne = () =>
+      document
+        .querySelector(
+          '.ember-power-select-options [data-test-boxel-picker-option-row="1"]',
+        )!
+        .closest('.ember-power-select-option') as HTMLElement;
+
+    await click(optionOne());
+    assert.deepEqual(
+      controller.selectedIds,
+      ['1'],
+      'first click selects option 1',
+    );
+
+    await click(optionOne());
+    assert.deepEqual(
+      controller.selectedIds,
+      [],
+      'second click on the same option unselects it (no duplicate)',
+    );
+    assert
+      .dom(
+        '[data-test-boxel-picker-option-row="1"] .picker-option-row__checkbox--selected',
+      )
+      .doesNotExist('checkbox is unchecked after toggle off');
+  });
+
   test('picker shows search input when searchEnabled is true', async function (assert) {
     class SelectionController {
       @tracked selected: PickerOption[] = [];


### PR DESCRIPTION
## Background and Goal

In the Realm filter pill on the card search bar, clicking an already-selected realm was adding a duplicate of that realm to the trigger instead of unselecting it. Same bug latent for any other consumer of `Picker` that doesn't keep `PickerOption` object references stable across renders.

Root cause: `Picker` wraps `BoxelMultiSelectBasic` → `PowerSelect`, whose multi-select toggle uses object identity (`indexOf`) to decide add-vs-remove. `RealmPicker` builds fresh `PickerOption` objects in both `realmOptions` and `pickerSelected` on every render, so the clicked option never matches the entry already in `@selected` by identity, and power-select always treats the click as a fresh add.

The fix lives in `Picker.onChange`: normalize the incoming `selected` array by id. A duplicate id signals "toggle off" — strip it. Otherwise dedupe defensively. Keeps the contract id-based and lets consumers reconstruct option objects freely.

## Where to start

- `packages/boxel-ui/addon/src/components/picker/index.gts` — the normalization block sits ahead of the existing select-all branching so the rest of `onChange` operates on a deduped array.
- `packages/boxel-ui/test-app/tests/integration/components/picker-test.gts` — new regression test that mirrors the RealmPicker pattern (consumer stores selection by id, rebuilds options each render). Without the fix the second click stacks a duplicate; with the fix it toggles off.