### PR TITLE
fix: keep republish recovery progress off stdout in boxel realm publish

### DIFF
--- a/packages/boxel-cli/src/commands/realm/publish.ts
+++ b/packages/boxel-cli/src/commands/realm/publish.ts
@@ -93,7 +93,9 @@ export async function publishRealm(
       (err.status === 400 || err.status === 409) &&
       options.republish !== false
     ) {
-      console.log(
+      // Progress, not payload: route to stderr via cliLog.info so it never
+      // corrupts stdout when the caller passed --json (stdout is JSON-only).
+      cliLog.info(
         `Publish returned ${err.status} (${(err.body ?? '').slice(0, 200)}). Unpublishing and retrying.`,
       );
       let unpublishResult = await unpublishRealm(normalizedPublished, {

--- a/packages/boxel-cli/tests/commands/realm-publish-recovery-output.test.ts
+++ b/packages/boxel-cli/tests/commands/realm-publish-recovery-output.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// The republish recovery path (unpublish-then-retry on 400/409) emits a
+// progress line. Under `--json` the command treats stdout as JSON-only, so
+// that progress must land on stderr — never stdout — or it corrupts the
+// caller's parse. Reproducing a real 400/409 from the server is timing- and
+// state-dependent, so we mock the shared realm operations to throw a 409 on
+// the first publish and succeed on the retry, exercising the recovery path
+// deterministically and asserting where its progress lands.
+
+let publishCallCount = 0;
+
+vi.mock('@cardstack/runtime-common/realm-operations', async (importActual) => {
+  let actual =
+    await importActual<
+      typeof import('@cardstack/runtime-common/realm-operations')
+    >();
+  return {
+    ...actual,
+    fetchPublishabilityReport: vi.fn(async () => ({
+      publishable: true,
+      violations: [],
+    })),
+    waitForReady: vi.fn(async () => undefined),
+    // publish.ts imports this export as `publishRealmOperation`; the real
+    // export name here is `publishRealm`.
+    publishRealm: vi.fn(async (_client, input) => {
+      publishCallCount += 1;
+      if (publishCallCount === 1) {
+        throw new actual.RealmOperationError('conflict', {
+          status: 409,
+          body: 'already published',
+        });
+      }
+      return {
+        sourceRealmURL: input.sourceRealmURL,
+        publishedRealmURL: input.publishedRealmURL,
+        publishedRealmId: 'pub-id',
+        lastPublishedAt: '2026-01-01T00:00:00.000Z',
+        status: 'pending',
+      };
+    }),
+  };
+});
+
+vi.mock('../../src/commands/realm/unpublish.ts', () => ({
+  unpublishRealm: vi.fn(async (publishedRealmURL: string) => ({
+    publishedRealmURL,
+    unpublished: true,
+  })),
+}));
+
+import { publishRealm } from '../../src/commands/realm/publish.ts';
+import type { ProfileManager } from '../../src/lib/profile-manager.ts';
+
+// Minimal ProfileManager — buildCliRealmClient only reads the active profile's
+// realmServerUrl; every network call is routed through the mocked operations.
+const fakeProfileManager = {
+  getActiveProfile: () => ({
+    name: 'test',
+    profile: { realmServerUrl: 'http://localhost:4201/' },
+  }),
+} as unknown as ProfileManager;
+
+describe('publishRealm republish-recovery output routing', () => {
+  beforeEach(() => {
+    publishCallCount = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('routes the 409 recovery progress to stderr, keeping stdout clean', async () => {
+    let stdout: string[] = [];
+    let stderr: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+    let result = await publishRealm(
+      'http://localhost:4201/source/',
+      'http://published.localhost:4201/',
+      { profileManager: fakeProfileManager, waitForReady: false },
+    );
+
+    // The retry after unpublish succeeds.
+    expect(result.publishedRealmURL).toBe('http://published.localhost:4201/');
+
+    // The progress line is emitted (recovery path was taken) — on stderr only.
+    expect(stderr.join('')).toContain('Unpublishing and retrying');
+    expect(stdout.join('')).not.toContain('Unpublishing and retrying');
+  });
+});


### PR DESCRIPTION
## What

Follow-up to a review comment on #5191 ([discussion_r3391712808](https://github.com/cardstack/boxel/pull/5191#discussion_r3391712808)) that was unaddressed before merge.

When `--json` is set, `boxel realm publish` treats stdout as JSON-only. But `publishRealm`'s republish recovery path (unpublish-then-retry on a 400/409 conflict) wrote its progress line to **stdout** via `console.log`, which would corrupt the JSON output a caller parses.

## Fix

Route that progress line through `cliLog.info`, which writes to **stderr** and is silenced under `--quiet` — matching the logger's documented contract for progress-not-payload output (`packages/boxel-cli/src/lib/cli-log.ts`). The result payload (the `--json` branch) continues to own stdout.

## Test

Added a unit test that mocks the shared realm operation to throw a `409` on the first publish and succeed on the retry, deterministically exercising the recovery path, then asserts the progress line lands on stderr and never on stdout. (A server-driven integration test was rejected: re-publishing the same URL in the test harness succeeds idempotently rather than returning 400/409, so the conflict can't be triggered reliably from the outside.)

Verified the test fails against the pre-fix `console.log` and passes with `cliLog.info`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)