### PR TITLE
Unified search v2 engine foundation: search-entry model, item. query + htmlQuery, projection engine

### DIFF
--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -282,6 +282,8 @@ const ALL_TEST_FILES: string[] = [
   './eq-containment-integration-test',
   './search-in-flight-key-test',
   './unified-search-contracts-test',
+  './search-entry-test',
+  './search-entries-engine-test',
   './render-type-resolution-test',
   './coerce-error-message-test',
   './realm-operations-test',

--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -335,6 +335,23 @@ module(basename(__filename), function () {
       assert.strictEqual(pinnedJane.relationships.item, undefined);
     });
 
+    test('an error row with nothing renderable keeps membership with an empty html array', async function (assert) {
+      // a first indexing attempt that failed: error flagged, no last-known-good
+      // renderings, no serialization to fall back to
+      await dbAdapter.execute(
+        `UPDATE boxel_index SET has_error = TRUE, pristine_doc = NULL, fitted_html = NULL, embedded_html = NULL, atom_html = NULL, head_html = NULL WHERE url = '${janeId}.json'`,
+      );
+      let doc =
+        await testRealm.realmIndexQueryEngine.searchEntries(personQuery());
+      let jane = entryFor(doc, janeId)!;
+      assert.deepEqual(
+        jane.relationships.html,
+        { data: [] },
+        'membership stays visible through the empty html array',
+      );
+      assert.strictEqual(jane.relationships.item, undefined);
+    });
+
     test('file results flow through the same fieldset semantics', async function (assert) {
       let fileUrl = `${realmHref}hello.md`;
       let query = parseSearchEntryQueryFromPayload({

--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -55,6 +55,10 @@ function entryFor(
   return doc.data.find((entry) => entry.id === id);
 }
 
+function htmlIdsOf(entry: SearchEntryResource): string[] | undefined {
+  return entry.relationships.html?.data.map((member) => member.id);
+}
+
 module(basename(__filename), function () {
   module('searchEntries projection engine', function (hooks) {
     let testRealm: Realm;
@@ -133,15 +137,18 @@ module(basename(__filename), function () {
       });
     }
 
-    test('default fieldset: html-backed entries with native render type', async function (assert) {
+    test('default fieldset: html-backed entries with the default htmlQuery (fitted × native)', async function (assert) {
       let doc =
         await testRealm.realmIndexQueryEngine.searchEntries(personQuery());
       assert.strictEqual(doc.meta.page.total, 2);
+      assert.deepEqual(
+        doc.meta.htmlQuery,
+        { eq: { format: 'fitted' } },
+        'the applied default htmlQuery is echoed once at the document level',
+      );
       let htmlId = `${johnId}#fitted#${personKey}`;
       let entry = entryFor(doc, johnId)!;
-      assert.deepEqual(entry.relationships.html, {
-        data: { type: 'html', id: htmlId },
-      });
+      assert.deepEqual(htmlIdsOf(entry), [htmlId]);
       assert.strictEqual(
         entry.relationships.item,
         undefined,
@@ -157,14 +164,15 @@ module(basename(__filename), function () {
       assert.strictEqual(html.attributes.cardType, 'Person');
     });
 
-    test('html.format selects the rendering format', async function (assert) {
+    test('an explicit htmlQuery selects the rendering format', async function (assert) {
       let doc = await testRealm.realmIndexQueryEngine.searchEntries(
-        personQuery({ filterEq: { 'html.format': 'embedded' } }),
+        personQuery({
+          filterEq: { htmlQuery: { eq: { format: 'embedded' } } },
+        }),
       );
+      assert.deepEqual(doc.meta.htmlQuery, { eq: { format: 'embedded' } });
       let htmlId = `${johnId}#embedded#${personKey}`;
-      assert.deepEqual(entryFor(doc, johnId)!.relationships.html, {
-        data: { type: 'html', id: htmlId },
-      });
+      assert.deepEqual(htmlIdsOf(entryFor(doc, johnId)!), [htmlId]);
       assert.true(
         normalizedHtml(htmlIn(doc, htmlId)!).includes(
           'Embedded Card Person: John',
@@ -172,15 +180,68 @@ module(basename(__filename), function () {
       );
     });
 
-    test('fields[search-entry]=item: full serializations, no html', async function (assert) {
+    test('a disjunctive htmlQuery selects several renderings per entry', async function (assert) {
       let doc = await testRealm.realmIndexQueryEngine.searchEntries(
-        personQuery({ fields: { 'search-entry': ['item'] } }),
+        personQuery({
+          filterEq: {
+            htmlQuery: {
+              any: [
+                { eq: { format: 'fitted' } },
+                { eq: { format: 'embedded' } },
+              ],
+            },
+          },
+        }),
+      );
+      let fittedId = `${johnId}#fitted#${personKey}`;
+      let embeddedId = `${johnId}#embedded#${personKey}`;
+      let ids = htmlIdsOf(entryFor(doc, johnId)!)!;
+      assert.deepEqual([...ids].sort(), [embeddedId, fittedId].sort());
+      assert.true(
+        normalizedHtml(htmlIn(doc, fittedId)!).includes(
+          'Fitted Card Person: John',
+        ),
+      );
+      assert.true(
+        normalizedHtml(htmlIn(doc, embeddedId)!).includes(
+          'Embedded Card Person: John',
+        ),
+      );
+    });
+
+    test('involution at the engine: not(not(q)) selects the same renderings as q', async function (assert) {
+      let q = { eq: { format: 'embedded' } };
+      let direct = await testRealm.realmIndexQueryEngine.searchEntries(
+        personQuery({ filterEq: { htmlQuery: q } }),
+      );
+      let doubled = await testRealm.realmIndexQueryEngine.searchEntries(
+        personQuery({ filterEq: { htmlQuery: { not: { not: q } } } }),
+      );
+      assert.deepEqual(
+        doubled.data.map((entry) => htmlIdsOf(entry)),
+        direct.data.map((entry) => htmlIdsOf(entry)),
+      );
+    });
+
+    test('fields[search-entry]=item: full serializations, no html, htmlQuery inert', async function (assert) {
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        personQuery({
+          // an htmlQuery alongside an item-only fieldset is inert, not an
+          // error
+          filterEq: { htmlQuery: { eq: { format: 'embedded' } } },
+          fields: { 'search-entry': ['item'] },
+        }),
       );
       let entry = entryFor(doc, johnId)!;
       assert.strictEqual(entry.relationships.html, undefined);
       assert.deepEqual(entry.relationships.item, {
         data: { type: 'card', id: johnId },
       });
+      assert.strictEqual(
+        doc.meta.htmlQuery,
+        undefined,
+        'no echo when the html branch is not in play',
+      );
       let item = itemIn(doc, johnId)!;
       assert.strictEqual(item.attributes?.firstName, 'John');
       assert.strictEqual(
@@ -215,9 +276,7 @@ module(basename(__filename), function () {
       );
       let entry = entryFor(doc, johnId)!;
       let htmlId = `${johnId}#fitted#${personKey}`;
-      assert.deepEqual(entry.relationships.html, {
-        data: { type: 'html', id: htmlId },
-      });
+      assert.deepEqual(htmlIdsOf(entry), [htmlId]);
       assert.deepEqual(entry.relationships.item, {
         data: { type: 'card', id: johnId },
       });
@@ -239,23 +298,41 @@ module(basename(__filename), function () {
       );
     });
 
-    test('mixed index: a row with no html falls back to a full item', async function (assert) {
+    test('mixed index: a row with no matching rendering falls back per the fieldset', async function (assert) {
       await dbAdapter.execute(
         `UPDATE boxel_index SET fitted_html = NULL WHERE url = '${janeId}.json'`,
       );
+      // default mode: the fallback row carries item and omits the html
+      // relationship entirely
       let doc =
         await testRealm.realmIndexQueryEngine.searchEntries(personQuery());
       let john = entryFor(doc, johnId)!;
-      assert.true(Boolean(john.relationships.html), 'john is html-backed');
+      assert.deepEqual(htmlIdsOf(john), [`${johnId}#fitted#${personKey}`]);
       assert.strictEqual(john.relationships.item, undefined);
       let jane = entryFor(doc, janeId)!;
-      assert.strictEqual(jane.relationships.html, undefined);
+      assert.strictEqual(
+        jane.relationships.html,
+        undefined,
+        'a default-mode fallback row omits the html relationship',
+      );
       assert.deepEqual(jane.relationships.item, {
         data: { type: 'card', id: janeId },
       });
       let item = itemIn(doc, janeId)!;
       assert.strictEqual(item.attributes?.firstName, 'Jane');
       assert.strictEqual(item.meta.sparseFields, undefined);
+
+      // a pinned html branch keeps membership visible with an empty array
+      let pinned = await testRealm.realmIndexQueryEngine.searchEntries(
+        personQuery({ fields: { 'search-entry': ['html'] } }),
+      );
+      let pinnedJane = entryFor(pinned, janeId)!;
+      assert.deepEqual(
+        pinnedJane.relationships.html,
+        { data: [] },
+        'matched, no rendering yet',
+      );
+      assert.strictEqual(pinnedJane.relationships.item, undefined);
     });
 
     test('file results flow through the same fieldset semantics', async function (assert) {
@@ -276,7 +353,7 @@ module(basename(__filename), function () {
       assert.strictEqual(item.type, 'file-meta');
       assert.strictEqual(item.attributes?.name, 'hello.md');
 
-      // default fieldset: the file's rendering is its own (no renderType in
+      // default fieldset: a file's rendering is its own (no renderType in
       // the composite id — files render natively)
       let defaultDoc = await testRealm.realmIndexQueryEngine.searchEntries(
         parseSearchEntryQueryFromPayload({
@@ -286,11 +363,14 @@ module(basename(__filename), function () {
           },
         }),
       );
+      assert.deepEqual(defaultDoc.meta.htmlQuery, {
+        eq: { format: 'fitted' },
+      });
       let defaultEntry = entryFor(defaultDoc, fileUrl)!;
-      let htmlRel = defaultEntry.relationships.html;
-      if (htmlRel) {
-        assert.strictEqual(htmlRel.data.id, `${fileUrl}#fitted`);
-        let html = htmlIn(defaultDoc, htmlRel.data.id)!;
+      let ids = htmlIdsOf(defaultEntry);
+      if (ids) {
+        assert.deepEqual(ids, [`${fileUrl}#fitted`]);
+        let html = htmlIn(defaultDoc, ids[0])!;
         assert.strictEqual(html.attributes.renderType, undefined);
         assert.strictEqual(html.attributes.format, 'fitted');
       } else {
@@ -387,12 +467,24 @@ module(basename(__filename), function () {
       onRealmSetup,
     });
 
+    function fancyQuery(htmlQuery: unknown) {
+      return parseSearchEntryQueryFromPayload({
+        filter: {
+          'item.on': {
+            module: `${realmHref}fancy-person`,
+            name: 'FancyPerson',
+          },
+          eq: { htmlQuery },
+        },
+      });
+    }
+
     test('identical css dedupes to one resource shared across renderings', async function (assert) {
       let doc = await testRealm.realmIndexQueryEngine.searchEntries(
         parseSearchEntryQueryFromPayload({
           filter: {
             'item.on': { module: `${realmHref}person`, name: 'Person' },
-            eq: { 'html.format': 'embedded' },
+            eq: { htmlQuery: { eq: { format: 'embedded' } } },
           },
         }),
       );
@@ -426,29 +518,22 @@ module(basename(__filename), function () {
       }
     });
 
-    test('explicit html.renderType renders a subclass as its ancestor', async function (assert) {
+    test('a renderType predicate renders a subclass as its ancestor', async function (assert) {
       let janeId = `${realmHref}jane`;
       let doc = await testRealm.realmIndexQueryEngine.searchEntries(
-        parseSearchEntryQueryFromPayload({
-          filter: {
-            'item.on': {
-              module: `${realmHref}fancy-person`,
-              name: 'FancyPerson',
-            },
-            eq: {
-              'html.format': 'embedded',
-              'html.renderType': {
-                module: `${realmHref}person`,
-                name: 'Person',
+        fancyQuery({
+          every: [
+            { eq: { format: 'embedded' } },
+            {
+              eq: {
+                renderType: { module: `${realmHref}person`, name: 'Person' },
               },
             },
-          },
+          ],
         }),
       );
       let htmlId = `${janeId}#embedded#${realmHref}person/Person`;
-      assert.deepEqual(entryFor(doc, janeId)!.relationships.html, {
-        data: { type: 'html', id: htmlId },
-      });
+      assert.deepEqual(htmlIdsOf(entryFor(doc, janeId)!), [htmlId]);
       let html = htmlIn(doc, htmlId)!;
       assert.deepEqual(html.attributes.renderType, {
         module: `${realmHref}person`,
@@ -457,27 +542,50 @@ module(basename(__filename), function () {
       assert.true(normalizedHtml(html).includes('Embedded Card Person: Jane'));
     });
 
-    test('omitted html.renderType renders each result as its own native type', async function (assert) {
+    test('no renderType predicate → only the native rendering is in play', async function (assert) {
       let janeId = `${realmHref}jane`;
       let doc = await testRealm.realmIndexQueryEngine.searchEntries(
-        parseSearchEntryQueryFromPayload({
-          filter: {
-            'item.on': {
-              module: `${realmHref}fancy-person`,
-              name: 'FancyPerson',
-            },
-            eq: { 'html.format': 'embedded' },
-          },
-        }),
+        fancyQuery({ eq: { format: 'embedded' } }),
       );
-      let htmlId = `${janeId}#embedded#${realmHref}fancy-person/FancyPerson`;
-      let html = htmlIn(doc, htmlId)!;
+      let nativeId = `${janeId}#embedded#${realmHref}fancy-person/FancyPerson`;
+      assert.deepEqual(htmlIdsOf(entryFor(doc, janeId)!), [nativeId]);
+      let html = htmlIn(doc, nativeId)!;
       assert.deepEqual(html.attributes.renderType, {
         module: `${realmHref}fancy-person`,
         name: 'FancyPerson',
       });
       assert.true(
         normalizedHtml(html).includes('Embedded Card FancyPerson: Jane'),
+      );
+    });
+
+    test('a negated renderType predicate opens the chain and excludes the negated type', async function (assert) {
+      let janeId = `${realmHref}jane`;
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        fancyQuery({
+          every: [
+            { eq: { format: 'embedded' } },
+            {
+              not: {
+                eq: {
+                  renderType: {
+                    module: `${realmHref}person`,
+                    name: 'Person',
+                  },
+                },
+              },
+            },
+          ],
+        }),
+      );
+      let ids = htmlIdsOf(entryFor(doc, janeId)!)!;
+      assert.true(
+        ids.includes(`${janeId}#embedded#${realmHref}fancy-person/FancyPerson`),
+        'the native rendering matches',
+      );
+      assert.false(
+        ids.includes(`${janeId}#embedded#${realmHref}person/Person`),
+        'the negated ancestor rendering is excluded',
       );
     });
   });

--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -1,0 +1,479 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import {
+  baseRRI,
+  parseSearchEntryQueryFromPayload,
+  rri,
+  type CardResource,
+  type CssResource,
+  type FileMetaResource,
+  type HtmlResource,
+  type Realm,
+  type SearchEntryCollectionDocument,
+  type SearchEntryResource,
+} from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
+import { setupPermissionedRealmCached } from './helpers/index.ts';
+
+function htmlIn(
+  doc: SearchEntryCollectionDocument,
+  id: string,
+): HtmlResource | undefined {
+  return doc.included?.find(
+    (resource): resource is HtmlResource =>
+      resource.type === 'html' && resource.id === id,
+  );
+}
+
+// Prerendered markup splits text across newlines/indentation, so content
+// assertions match against a whitespace-collapsed form.
+function normalizedHtml(resource: HtmlResource): string {
+  return (resource.attributes.html ?? '').replace(/\s+/g, ' ');
+}
+
+function itemIn(
+  doc: SearchEntryCollectionDocument,
+  id: string,
+): CardResource | FileMetaResource | undefined {
+  return doc.included?.find(
+    (resource): resource is CardResource | FileMetaResource =>
+      (resource.type === 'card' || resource.type === 'file-meta') &&
+      resource.id === id,
+  );
+}
+
+function cssIn(doc: SearchEntryCollectionDocument): CssResource[] {
+  return (doc.included ?? []).filter(
+    (resource): resource is CssResource => resource.type === 'css',
+  );
+}
+
+function entryFor(
+  doc: SearchEntryCollectionDocument,
+  id: string,
+): SearchEntryResource | undefined {
+  return doc.data.find((entry) => entry.id === id);
+}
+
+module(basename(__filename), function () {
+  module('searchEntries projection engine', function (hooks) {
+    let testRealm: Realm;
+    let dbAdapter: PgAdapter;
+    let realmHref: string;
+    let personKey: string;
+    let johnId: string;
+    let janeId: string;
+
+    function onRealmSetup(args: { testRealm: Realm; dbAdapter: PgAdapter }) {
+      testRealm = args.testRealm;
+      dbAdapter = args.dbAdapter;
+      realmHref = new URL(testRealm.url).href;
+      personKey = `${realmHref}person/Person`;
+      johnId = `${realmHref}john`;
+      janeId = `${realmHref}jane`;
+    }
+
+    setupPermissionedRealmCached(hooks, {
+      realmURL: new URL('http://127.0.0.1:4444/test/'),
+      permissions: { '*': ['read'] },
+      fileSystem: {
+        'person.gts': `
+          import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+          import StringField from "https://cardstack.com/base/string";
+
+          export class Person extends CardDef {
+            @field firstName = contains(StringField);
+            static isolated = class Isolated extends Component<typeof this> {
+              <template>
+                <h1><@fields.firstName/></h1>
+              </template>
+            }
+            static embedded = class Embedded extends Component<typeof this> {
+              <template>
+                Embedded Card Person: <@fields.firstName/>
+              </template>
+            }
+            static fitted = class Fitted extends Component<typeof this> {
+              <template>
+                Fitted Card Person: <@fields.firstName/>
+              </template>
+            }
+          }
+        `,
+        'john.json': {
+          data: {
+            attributes: { firstName: 'John' },
+            meta: {
+              adoptsFrom: { module: rri('./person'), name: 'Person' },
+            },
+          },
+        },
+        'jane.json': {
+          data: {
+            attributes: { firstName: 'Jane' },
+            meta: {
+              adoptsFrom: { module: rri('./person'), name: 'Person' },
+            },
+          },
+        },
+        'hello.md': '# Hello from FileDef content',
+      },
+      onRealmSetup,
+    });
+
+    function personQuery(extra: Record<string, unknown> = {}) {
+      return parseSearchEntryQueryFromPayload({
+        filter: {
+          'item.on': { module: `${realmHref}person`, name: 'Person' },
+          ...(extra.filterEq ? { eq: extra.filterEq } : {}),
+        },
+        ...(extra.fields ? { fields: extra.fields } : {}),
+        ...(extra.sort ? { sort: extra.sort } : {}),
+        ...(extra.page ? { page: extra.page } : {}),
+      });
+    }
+
+    test('default fieldset: html-backed entries with native render type', async function (assert) {
+      let doc =
+        await testRealm.realmIndexQueryEngine.searchEntries(personQuery());
+      assert.strictEqual(doc.meta.page.total, 2);
+      let htmlId = `${johnId}#fitted#${personKey}`;
+      let entry = entryFor(doc, johnId)!;
+      assert.deepEqual(entry.relationships.html, {
+        data: { type: 'html', id: htmlId },
+      });
+      assert.strictEqual(
+        entry.relationships.item,
+        undefined,
+        'no item branch on an html-backed row',
+      );
+      let html = htmlIn(doc, htmlId)!;
+      assert.strictEqual(html.attributes.format, 'fitted');
+      assert.deepEqual(html.attributes.renderType, {
+        module: `${realmHref}person`,
+        name: 'Person',
+      });
+      assert.true(normalizedHtml(html).includes('Fitted Card Person: John'));
+      assert.strictEqual(html.attributes.cardType, 'Person');
+    });
+
+    test('html.format selects the rendering format', async function (assert) {
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        personQuery({ filterEq: { 'html.format': 'embedded' } }),
+      );
+      let htmlId = `${johnId}#embedded#${personKey}`;
+      assert.deepEqual(entryFor(doc, johnId)!.relationships.html, {
+        data: { type: 'html', id: htmlId },
+      });
+      assert.true(
+        normalizedHtml(htmlIn(doc, htmlId)!).includes(
+          'Embedded Card Person: John',
+        ),
+      );
+    });
+
+    test('fields[search-entry]=item: full serializations, no html', async function (assert) {
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        personQuery({ fields: { 'search-entry': ['item'] } }),
+      );
+      let entry = entryFor(doc, johnId)!;
+      assert.strictEqual(entry.relationships.html, undefined);
+      assert.deepEqual(entry.relationships.item, {
+        data: { type: 'card', id: johnId },
+      });
+      let item = itemIn(doc, johnId)!;
+      assert.strictEqual(item.attributes?.firstName, 'John');
+      assert.strictEqual(
+        item.meta.sparseFields,
+        undefined,
+        'a full item carries no sparse marker',
+      );
+      assert.strictEqual(item.links?.self, johnId);
+      assert.strictEqual(
+        (doc.included ?? []).filter((r) => r.type === 'html').length,
+        0,
+      );
+    });
+
+    test('fields[search-entry]=item.<field>: sparse items carry meta.sparseFields', async function (assert) {
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        personQuery({ fields: { 'search-entry': ['item.firstName'] } }),
+      );
+      let item = itemIn(doc, johnId)!;
+      assert.deepEqual(item.attributes, { firstName: 'John' });
+      assert.deepEqual(item.meta.sparseFields, ['firstName']);
+    });
+
+    test('fields[search-entry]=html,item: both branches on every entry', async function (assert) {
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        personQuery({ fields: { 'search-entry': ['html', 'item'] } }),
+      );
+      let entry = entryFor(doc, johnId)!;
+      let htmlId = `${johnId}#fitted#${personKey}`;
+      assert.deepEqual(entry.relationships.html, {
+        data: { type: 'html', id: htmlId },
+      });
+      assert.deepEqual(entry.relationships.item, {
+        data: { type: 'card', id: johnId },
+      });
+      assert.true(Boolean(htmlIn(doc, htmlId)));
+      assert.strictEqual(itemIn(doc, johnId)!.attributes?.firstName, 'John');
+    });
+
+    test('sort and page ride the item query', async function (assert) {
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        personQuery({
+          sort: [{ by: 'item.firstName', direction: 'asc' }],
+          page: { size: 1 },
+        }),
+      );
+      assert.strictEqual(doc.meta.page.total, 2);
+      assert.deepEqual(
+        doc.data.map((entry) => entry.id),
+        [janeId],
+      );
+    });
+
+    test('mixed index: a row with no html falls back to a full item', async function (assert) {
+      await dbAdapter.execute(
+        `UPDATE boxel_index SET fitted_html = NULL WHERE url = '${janeId}.json'`,
+      );
+      let doc =
+        await testRealm.realmIndexQueryEngine.searchEntries(personQuery());
+      let john = entryFor(doc, johnId)!;
+      assert.true(Boolean(john.relationships.html), 'john is html-backed');
+      assert.strictEqual(john.relationships.item, undefined);
+      let jane = entryFor(doc, janeId)!;
+      assert.strictEqual(jane.relationships.html, undefined);
+      assert.deepEqual(jane.relationships.item, {
+        data: { type: 'card', id: janeId },
+      });
+      let item = itemIn(doc, janeId)!;
+      assert.strictEqual(item.attributes?.firstName, 'Jane');
+      assert.strictEqual(item.meta.sparseFields, undefined);
+    });
+
+    test('file results flow through the same fieldset semantics', async function (assert) {
+      let fileUrl = `${realmHref}hello.md`;
+      let query = parseSearchEntryQueryFromPayload({
+        filter: {
+          'item.on': { module: baseRRI('card-api'), name: 'FileDef' },
+          eq: { 'item.url': fileUrl },
+        },
+        fields: { 'search-entry': ['item'] },
+      });
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(query);
+      let entry = entryFor(doc, fileUrl)!;
+      assert.deepEqual(entry.relationships.item, {
+        data: { type: 'file-meta', id: fileUrl },
+      });
+      let item = itemIn(doc, fileUrl)!;
+      assert.strictEqual(item.type, 'file-meta');
+      assert.strictEqual(item.attributes?.name, 'hello.md');
+
+      // default fieldset: the file's rendering is its own (no renderType in
+      // the composite id — files render natively)
+      let defaultDoc = await testRealm.realmIndexQueryEngine.searchEntries(
+        parseSearchEntryQueryFromPayload({
+          filter: {
+            'item.on': { module: baseRRI('card-api'), name: 'FileDef' },
+            eq: { 'item.url': fileUrl },
+          },
+        }),
+      );
+      let defaultEntry = entryFor(defaultDoc, fileUrl)!;
+      let htmlRel = defaultEntry.relationships.html;
+      if (htmlRel) {
+        assert.strictEqual(htmlRel.data.id, `${fileUrl}#fitted`);
+        let html = htmlIn(defaultDoc, htmlRel.data.id)!;
+        assert.strictEqual(html.attributes.renderType, undefined);
+        assert.strictEqual(html.attributes.format, 'fitted');
+      } else {
+        assert.deepEqual(
+          defaultEntry.relationships.item,
+          { data: { type: 'file-meta', id: fileUrl } },
+          'a file with no fitted rendering falls back to its item',
+        );
+      }
+    });
+  });
+
+  module('searchEntries css + render-type', function (hooks) {
+    let testRealm: Realm;
+    let realmHref: string;
+
+    function onRealmSetup(args: { testRealm: Realm }) {
+      testRealm = args.testRealm;
+      realmHref = new URL(testRealm.url).href;
+    }
+
+    setupPermissionedRealmCached(hooks, {
+      realmURL: new URL('http://127.0.0.1:4444/test/'),
+      permissions: { '*': ['read'] },
+      fileSystem: {
+        'person.gts': `
+          import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+          import StringField from "https://cardstack.com/base/string";
+
+          export class Person extends CardDef {
+            @field firstName = contains(StringField);
+            static embedded = class Embedded extends Component<typeof this> {
+              <template>
+                Embedded Card Person: <@fields.firstName/>
+
+                <style scoped>
+                  .border {
+                    border: 1px solid red;
+                  }
+                </style>
+              </template>
+            }
+          }
+        `,
+        'fancy-person.gts': `
+          import { Person } from './person';
+          import { contains, field, Component } from "https://cardstack.com/base/card-api";
+          import StringField from "https://cardstack.com/base/string";
+
+          export class FancyPerson extends Person {
+            @field favoriteColor = contains(StringField);
+
+            static embedded = class Embedded extends Component<typeof this> {
+              <template>
+                Embedded Card FancyPerson: <@fields.firstName/>
+
+                <style scoped>
+                  .fancy-border {
+                    border: 1px solid pink;
+                  }
+                </style>
+              </template>
+            }
+          }
+        `,
+        'aaron.json': {
+          data: {
+            attributes: { firstName: 'Aaron' },
+            meta: {
+              adoptsFrom: { module: rri('./person'), name: 'Person' },
+            },
+          },
+        },
+        'craig.json': {
+          data: {
+            attributes: { firstName: 'Craig' },
+            meta: {
+              adoptsFrom: { module: rri('./person'), name: 'Person' },
+            },
+          },
+        },
+        'jane.json': {
+          data: {
+            attributes: { firstName: 'Jane', favoriteColor: 'pink' },
+            meta: {
+              adoptsFrom: {
+                module: rri('./fancy-person'),
+                name: 'FancyPerson',
+              },
+            },
+          },
+        },
+      },
+      onRealmSetup,
+    });
+
+    test('identical css dedupes to one resource shared across renderings', async function (assert) {
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        parseSearchEntryQueryFromPayload({
+          filter: {
+            'item.on': { module: `${realmHref}person`, name: 'Person' },
+            eq: { 'html.format': 'embedded' },
+          },
+        }),
+      );
+      assert.strictEqual(doc.meta.page.total, 3);
+      let aaronHtml = htmlIn(
+        doc,
+        `${realmHref}aaron#embedded#${realmHref}person/Person`,
+      )!;
+      let craigHtml = htmlIn(
+        doc,
+        `${realmHref}craig#embedded#${realmHref}person/Person`,
+      )!;
+      assert.deepEqual(
+        aaronHtml.relationships.styles.data,
+        craigHtml.relationships.styles.data,
+        'two instances of the same type reference the same stylesheets',
+      );
+      assert.true(aaronHtml.relationships.styles.data.length > 0);
+      let css = cssIn(doc);
+      let ids = css.map((resource) => resource.id);
+      assert.deepEqual(
+        ids,
+        [...new Set(ids)],
+        'each stylesheet travels exactly once',
+      );
+      for (let { id } of aaronHtml.relationships.styles.data) {
+        assert.true(
+          ids.includes(id),
+          `referenced stylesheet ${id} is in included`,
+        );
+      }
+    });
+
+    test('explicit html.renderType renders a subclass as its ancestor', async function (assert) {
+      let janeId = `${realmHref}jane`;
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        parseSearchEntryQueryFromPayload({
+          filter: {
+            'item.on': {
+              module: `${realmHref}fancy-person`,
+              name: 'FancyPerson',
+            },
+            eq: {
+              'html.format': 'embedded',
+              'html.renderType': {
+                module: `${realmHref}person`,
+                name: 'Person',
+              },
+            },
+          },
+        }),
+      );
+      let htmlId = `${janeId}#embedded#${realmHref}person/Person`;
+      assert.deepEqual(entryFor(doc, janeId)!.relationships.html, {
+        data: { type: 'html', id: htmlId },
+      });
+      let html = htmlIn(doc, htmlId)!;
+      assert.deepEqual(html.attributes.renderType, {
+        module: `${realmHref}person`,
+        name: 'Person',
+      });
+      assert.true(normalizedHtml(html).includes('Embedded Card Person: Jane'));
+    });
+
+    test('omitted html.renderType renders each result as its own native type', async function (assert) {
+      let janeId = `${realmHref}jane`;
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        parseSearchEntryQueryFromPayload({
+          filter: {
+            'item.on': {
+              module: `${realmHref}fancy-person`,
+              name: 'FancyPerson',
+            },
+            eq: { 'html.format': 'embedded' },
+          },
+        }),
+      );
+      let htmlId = `${janeId}#embedded#${realmHref}fancy-person/FancyPerson`;
+      let html = htmlIn(doc, htmlId)!;
+      assert.deepEqual(html.attributes.renderType, {
+        module: `${realmHref}fancy-person`,
+        name: 'FancyPerson',
+      });
+      assert.true(
+        normalizedHtml(html).includes('Embedded Card FancyPerson: Jane'),
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -190,6 +190,11 @@ module(basename(__filename), function () {
       );
       assert.strictEqual(item.links?.self, johnId);
       assert.strictEqual(
+        item.meta.realmInfo?.name,
+        'Unnamed Workspace',
+        'an item carries meta.realmInfo exactly as the live search path serializes it',
+      );
+      assert.strictEqual(
         (doc.included ?? []).filter((r) => r.type === 'html').length,
         0,
       );

--- a/packages/realm-server/tests/search-entry-test.ts
+++ b/packages/realm-server/tests/search-entry-test.ts
@@ -6,13 +6,19 @@ import {
   buildSparseItemResource,
   htmlResourceId,
   cssResourceId,
+  htmlQueryHasRenderTypePredicate,
+  htmlQueryMatches,
   isHtmlResource,
   isSearchEntryResource,
   isSparseItemResource,
   parseSearchEntryQueryFromPayload,
+  resolveHtmlQuery,
   SearchRequestError,
+  DEFAULT_HTML_QUERY,
   rri,
   type CardResource,
+  type HtmlQuery,
+  type RenderingCandidate,
   type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
 
@@ -40,16 +46,50 @@ function parseError(payload: unknown): SearchRequestError {
   throw new Error('expected parseSearchEntryQueryFromPayload to throw');
 }
 
+// Evaluate an htmlQuery against a rendering universe, returning the selected
+// candidates (in universe order).
+function select(
+  query: HtmlQuery,
+  universe: RenderingCandidate[],
+): RenderingCandidate[] {
+  let resolved = resolveHtmlQuery(
+    query,
+    (ref) =>
+      `${(ref as ResolvedCodeRef).module}/${(ref as ResolvedCodeRef).name}`,
+  );
+  return universe.filter((candidate) => htmlQueryMatches(resolved, candidate));
+}
+
+const authorKey = `${authorRef.module}/${authorRef.name}`;
+const baseKey = `${baseRef.module}/${baseRef.name}`;
+
+// A representative rendering universe: two render types across two keyed
+// formats, a scalar-format rendering, and a file-style candidate that
+// carries no renderType.
+const universe: RenderingCandidate[] = [
+  { format: 'fitted', renderTypeKey: authorKey },
+  { format: 'fitted', renderTypeKey: baseKey },
+  { format: 'embedded', renderTypeKey: authorKey },
+  { format: 'embedded', renderTypeKey: baseKey },
+  { format: 'atom', renderTypeKey: authorKey },
+  { format: 'head' },
+];
+
 module(basename(__filename), function () {
   module('search-entry query parser', function () {
     test('translates the canonical search-entry query', function (assert) {
+      let htmlQuery: HtmlQuery = {
+        every: [
+          { eq: { format: 'embedded' } },
+          { eq: { renderType: baseRef } },
+        ],
+      };
       let parsed = parseSearchEntryQueryFromPayload({
         filter: {
           'item.on': authorRef,
           eq: {
             'item.status': 'ready',
-            'html.format': 'embedded',
-            'html.renderType': baseRef,
+            htmlQuery,
           },
         },
         sort: [{ by: 'item.title', direction: 'asc' }],
@@ -63,10 +103,7 @@ module(basename(__filename), function () {
         sort: [{ by: 'title', direction: 'asc', on: authorRef }],
         page: { size: 20 },
       } as any);
-      assert.deepEqual(parsed.render, {
-        format: 'embedded',
-        renderType: baseRef,
-      });
+      assert.deepEqual(parsed.htmlQuery, htmlQuery);
       assert.deepEqual(parsed.fieldset, {
         html: true,
         item: { kind: 'none' },
@@ -75,10 +112,11 @@ module(basename(__filename), function () {
       assert.deepEqual(parsed.realms, ['http://localhost:4201/test/']);
     });
 
-    test('defaults: no filter → fitted/native; no fields → html with item fallback', function (assert) {
+    test('defaults: no htmlQuery → fitted; no fields → html with item fallback', function (assert) {
       let parsed = parseSearchEntryQueryFromPayload({});
       assert.deepEqual(parsed.itemQuery, {} as any);
-      assert.deepEqual(parsed.render, { format: 'fitted' });
+      assert.deepEqual(parsed.htmlQuery, DEFAULT_HTML_QUERY);
+      assert.deepEqual(parsed.htmlQuery, { eq: { format: 'fitted' } });
       assert.deepEqual(parsed.fieldset, {
         html: true,
         item: { kind: 'none' },
@@ -95,12 +133,12 @@ module(basename(__filename), function () {
       } as any);
     });
 
-    test('a filter that carried only rendering config dissolves', function (assert) {
+    test('an eq that carried only the htmlQuery binding dissolves', function (assert) {
       let parsed = parseSearchEntryQueryFromPayload({
-        filter: { eq: { 'html.format': 'atom' } },
+        filter: { eq: { htmlQuery: { eq: { format: 'atom' } } } },
       });
       assert.deepEqual(parsed.itemQuery, {} as any);
-      assert.strictEqual(parsed.render.format, 'atom');
+      assert.deepEqual(parsed.htmlQuery, { eq: { format: 'atom' } });
     });
 
     test('translates item. paths through nested connectives', function (assert) {
@@ -122,21 +160,80 @@ module(basename(__filename), function () {
       } as any);
     });
 
-    test('html.* under a non-eq operator (or a nested eq) is ignored', function (assert) {
-      let parsed = parseSearchEntryQueryFromPayload({
-        filter: {
-          'item.on': authorRef,
-          range: { 'item.age': { gt: 21 }, 'html.format': { gt: 'a' } },
-          every: [{ eq: { 'item.x': 1, 'html.format': 'atom' } }],
-        },
-      });
-      // the ignored html.* entries leave no residue and do not set the format
-      assert.deepEqual(parsed.itemQuery.filter, {
-        on: authorRef,
-        range: { age: { gt: 21 } },
-        every: [{ eq: { x: 1 } }],
-      } as any);
-      assert.strictEqual(parsed.render.format, 'fitted');
+    test('htmlQuery binds exactly once, in the top-level eq', function (assert) {
+      assert.strictEqual(
+        parseError({
+          filter: {
+            any: [{ eq: { htmlQuery: { eq: { format: 'atom' } } } }],
+          },
+        }).code,
+        'invalid-render',
+        'binding in a nested node is rejected',
+      );
+      assert.strictEqual(
+        parseError({
+          filter: {
+            not: { eq: { htmlQuery: { eq: { format: 'atom' } } } },
+          },
+        }).code,
+        'invalid-render',
+        'binding under not is rejected',
+      );
+      assert.strictEqual(
+        parseError({
+          filter: {
+            contains: { htmlQuery: { eq: { format: 'atom' } } },
+          },
+        }).code,
+        'invalid-render',
+        'binding through another operator is rejected',
+      );
+      assert.strictEqual(
+        parseError({
+          filter: { htmlQuery: { eq: { format: 'atom' } } },
+        }).code,
+        'invalid-render',
+        'htmlQuery is a field — it binds with eq, not as a filter member',
+      );
+    });
+
+    test('rejects malformed htmlQuery values', function (assert) {
+      assert.strictEqual(
+        parseError({ filter: { eq: { htmlQuery: {} } } }).code,
+        'invalid-render',
+        'a node must have exactly one of eq/every/any/not',
+      );
+      assert.strictEqual(
+        parseError({ filter: { eq: { htmlQuery: { eq: {} } } } }).code,
+        'invalid-render',
+        'an unconstrained leaf is unsupported',
+      );
+      assert.strictEqual(
+        parseError({ filter: { eq: { htmlQuery: { every: [] } } } }).code,
+        'invalid-render',
+        'an empty connective is unsupported',
+      );
+      assert.strictEqual(
+        parseError({
+          filter: { eq: { htmlQuery: { eq: { format: 'bogus' } } } },
+        }).code,
+        'invalid-render',
+        'invalid format value',
+      );
+      assert.strictEqual(
+        parseError({
+          filter: { eq: { htmlQuery: { eq: { renderType: 'Author' } } } },
+        }).code,
+        'invalid-render',
+        'renderType must be a CodeRef',
+      );
+      assert.strictEqual(
+        parseError({
+          filter: { eq: { htmlQuery: { eq: { color: 'red' } } } },
+        }).code,
+        'invalid-render',
+        'unknown rendering dimension',
+      );
     });
 
     test('sort entries may carry their own item.on anchor', function (assert) {
@@ -185,21 +282,6 @@ module(basename(__filename), function () {
         'bare field path',
       );
       assert.strictEqual(
-        parseError({ filter: { 'html.format': 'embedded' } }).code,
-        'invalid-query',
-        'field-keyed html.* at the filter level',
-      );
-      assert.strictEqual(
-        parseError({ filter: { eq: { 'html.format': 'bogus' } } }).code,
-        'invalid-render',
-        'invalid html.format value',
-      );
-      assert.strictEqual(
-        parseError({ filter: { eq: { 'html.renderType': 'Author' } } }).code,
-        'invalid-render',
-        'html.renderType must be a CodeRef',
-      );
-      assert.strictEqual(
         parseError({ fields: { 'search-entry': ['item', 'item.title'] } }).code,
         'invalid-query',
         'full item cannot combine with item.<field>',
@@ -237,6 +319,127 @@ module(basename(__filename), function () {
     });
   });
 
+  module('htmlQuery evaluation', function () {
+    test('eq selects by format and renderType, conjoined within a leaf', function (assert) {
+      assert.deepEqual(select({ eq: { format: 'fitted' } }, universe), [
+        { format: 'fitted', renderTypeKey: authorKey },
+        { format: 'fitted', renderTypeKey: baseKey },
+      ]);
+      assert.deepEqual(select({ eq: { renderType: baseRef } }, universe), [
+        { format: 'fitted', renderTypeKey: baseKey },
+        { format: 'embedded', renderTypeKey: baseKey },
+      ]);
+      assert.deepEqual(
+        select({ eq: { format: 'embedded', renderType: authorRef } }, universe),
+        [{ format: 'embedded', renderTypeKey: authorKey }],
+      );
+    });
+
+    test('every and any compose', function (assert) {
+      assert.deepEqual(
+        select(
+          {
+            every: [
+              { eq: { format: 'embedded' } },
+              { eq: { renderType: baseRef } },
+            ],
+          },
+          universe,
+        ),
+        [{ format: 'embedded', renderTypeKey: baseKey }],
+      );
+      assert.deepEqual(
+        select(
+          {
+            any: [{ eq: { format: 'atom' } }, { eq: { format: 'head' } }],
+          },
+          universe,
+        ),
+        [{ format: 'atom', renderTypeKey: authorKey }, { format: 'head' }],
+      );
+    });
+
+    test('a renderType predicate never matches a rendering with no renderType', function (assert) {
+      // the file-style candidate (no renderTypeKey) is unmatchable by a
+      // positive renderType predicate...
+      assert.false(
+        select({ eq: { renderType: authorRef } }, universe).some(
+          (candidate) => candidate.renderTypeKey === undefined,
+        ),
+      );
+      // ...and IS matched by its negation (the complement)
+      assert.true(
+        select({ not: { eq: { renderType: authorRef } } }, universe).some(
+          (candidate) => candidate.renderTypeKey === undefined,
+        ),
+      );
+    });
+
+    test('involution: not(not(q)) selects exactly what q selects', function (assert) {
+      let queries: HtmlQuery[] = [
+        { eq: { format: 'fitted' } },
+        { eq: { renderType: authorRef } },
+        { eq: { format: 'embedded', renderType: baseRef } },
+        {
+          any: [{ eq: { format: 'atom' } }, { eq: { renderType: baseRef } }],
+        },
+        {
+          every: [
+            { eq: { format: 'embedded' } },
+            { not: { eq: { renderType: authorRef } } },
+          ],
+        },
+      ];
+      for (let q of queries) {
+        assert.deepEqual(
+          select({ not: { not: q } }, universe),
+          select(q, universe),
+          `not(not(q)) ≡ q for ${JSON.stringify(q)}`,
+        );
+      }
+    });
+
+    test('complement: not(q) selects exactly the universe minus q', function (assert) {
+      let q: HtmlQuery = { eq: { format: 'fitted' } };
+      let selected = select(q, universe);
+      let complement = select({ not: q }, universe);
+      assert.deepEqual(
+        [...selected, ...complement].length,
+        universe.length,
+        'q and not(q) partition the universe',
+      );
+      for (let candidate of universe) {
+        assert.strictEqual(
+          complement.includes(candidate),
+          !selected.includes(candidate),
+          `candidate ${JSON.stringify(candidate)} is in exactly one side`,
+        );
+      }
+    });
+
+    test('htmlQueryHasRenderTypePredicate sees through connectives and negation', function (assert) {
+      assert.false(
+        htmlQueryHasRenderTypePredicate({ eq: { format: 'fitted' } }),
+      );
+      assert.true(
+        htmlQueryHasRenderTypePredicate({ eq: { renderType: authorRef } }),
+      );
+      assert.true(
+        htmlQueryHasRenderTypePredicate({
+          not: { eq: { renderType: authorRef } },
+        }),
+      );
+      assert.true(
+        htmlQueryHasRenderTypePredicate({
+          any: [
+            { eq: { format: 'fitted' } },
+            { every: [{ eq: { renderType: baseRef } }] },
+          ],
+        }),
+      );
+    });
+  });
+
   module('html composite id', function () {
     test('encodes (url, format, renderType) with # at both joints', function (assert) {
       assert.strictEqual(
@@ -266,22 +469,31 @@ module(basename(__filename), function () {
       });
       let both = buildSearchEntryResource({
         url: cardUrl,
-        htmlId,
+        htmlIds: [htmlId],
         itemType: 'card',
       });
       assert.deepEqual(both, {
         type: 'search-entry',
         id: cardUrl,
         relationships: {
-          html: { data: { type: 'html', id: htmlId } },
+          html: { data: [{ type: 'html', id: htmlId }] },
           item: { data: { type: 'card', id: cardUrl } },
         },
       });
       assert.true(isSearchEntryResource(both));
 
-      let htmlOnly = buildSearchEntryResource({ url: cardUrl, htmlId });
-      assert.deepEqual(Object.keys(htmlOnly.relationships), ['html']);
-      assert.true(isSearchEntryResource(htmlOnly));
+      // a pinned html branch with no matching rendering: empty array
+      let empty = buildSearchEntryResource({ url: cardUrl, htmlIds: [] });
+      assert.deepEqual(empty.relationships.html, { data: [] });
+      assert.true(isSearchEntryResource(empty));
+
+      // the default mode's fallback rows omit the relationship entirely
+      let itemOnly = buildSearchEntryResource({
+        url: cardUrl,
+        itemType: 'card',
+      });
+      assert.deepEqual(Object.keys(itemOnly.relationships), ['item']);
+      assert.true(isSearchEntryResource(itemOnly));
     });
 
     test('buildHtmlResource carries the rendering attributes and styles', function (assert) {

--- a/packages/realm-server/tests/search-entry-test.ts
+++ b/packages/realm-server/tests/search-entry-test.ts
@@ -1,0 +1,364 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import {
+  buildHtmlResource,
+  buildSearchEntryResource,
+  buildSparseItemResource,
+  htmlResourceId,
+  cssResourceId,
+  isHtmlResource,
+  isSearchEntryResource,
+  isSparseItemResource,
+  parseSearchEntryQueryFromPayload,
+  SearchRequestError,
+  rri,
+  type CardResource,
+  type ResolvedCodeRef,
+} from '@cardstack/runtime-common';
+
+const realmURL = 'http://localhost:4201/test/';
+const cardUrl = rri(`${realmURL}Author/1`);
+
+const authorRef: ResolvedCodeRef = {
+  module: rri(`${realmURL}author`),
+  name: 'Author',
+};
+const baseRef: ResolvedCodeRef = {
+  module: rri(`${realmURL}base-card`),
+  name: 'BaseCard',
+};
+
+function parseError(payload: unknown): SearchRequestError {
+  try {
+    parseSearchEntryQueryFromPayload(payload);
+  } catch (e) {
+    if (e instanceof SearchRequestError) {
+      return e;
+    }
+    throw e;
+  }
+  throw new Error('expected parseSearchEntryQueryFromPayload to throw');
+}
+
+module(basename(__filename), function () {
+  module('search-entry query parser', function () {
+    test('translates the canonical search-entry query', function (assert) {
+      let parsed = parseSearchEntryQueryFromPayload({
+        filter: {
+          'item.on': authorRef,
+          eq: {
+            'item.status': 'ready',
+            'html.format': 'embedded',
+            'html.renderType': baseRef,
+          },
+        },
+        sort: [{ by: 'item.title', direction: 'asc' }],
+        page: { size: 20 },
+        realms: ['http://localhost:4201/test'],
+        fields: { 'search-entry': ['html'] },
+      });
+      assert.deepEqual(parsed.itemQuery, {
+        filter: { on: authorRef, eq: { status: 'ready' } },
+        // a card-field sort without its own anchor inherits the filter's
+        sort: [{ by: 'title', direction: 'asc', on: authorRef }],
+        page: { size: 20 },
+      } as any);
+      assert.deepEqual(parsed.render, {
+        format: 'embedded',
+        renderType: baseRef,
+      });
+      assert.deepEqual(parsed.fieldset, {
+        html: true,
+        item: { kind: 'none' },
+        itemAsFallback: false,
+      });
+      assert.deepEqual(parsed.realms, ['http://localhost:4201/test/']);
+    });
+
+    test('defaults: no filter → fitted/native; no fields → html with item fallback', function (assert) {
+      let parsed = parseSearchEntryQueryFromPayload({});
+      assert.deepEqual(parsed.itemQuery, {} as any);
+      assert.deepEqual(parsed.render, { format: 'fitted' });
+      assert.deepEqual(parsed.fieldset, {
+        html: true,
+        item: { kind: 'none' },
+        itemAsFallback: true,
+      });
+    });
+
+    test('a filter carrying only the item.on anchor is a pure card-type filter', function (assert) {
+      let parsed = parseSearchEntryQueryFromPayload({
+        filter: { 'item.on': authorRef },
+      });
+      assert.deepEqual(parsed.itemQuery, {
+        filter: { type: authorRef },
+      } as any);
+    });
+
+    test('a filter that carried only rendering config dissolves', function (assert) {
+      let parsed = parseSearchEntryQueryFromPayload({
+        filter: { eq: { 'html.format': 'atom' } },
+      });
+      assert.deepEqual(parsed.itemQuery, {} as any);
+      assert.strictEqual(parsed.render.format, 'atom');
+    });
+
+    test('translates item. paths through nested connectives', function (assert) {
+      let parsed = parseSearchEntryQueryFromPayload({
+        filter: {
+          'item.on': authorRef,
+          any: [
+            { contains: { 'item.title': 'draft' } },
+            { not: { eq: { 'item.archived': true } } },
+          ],
+        },
+      });
+      assert.deepEqual(parsed.itemQuery.filter, {
+        on: authorRef,
+        any: [
+          { contains: { title: 'draft' } },
+          { not: { eq: { archived: true } } },
+        ],
+      } as any);
+    });
+
+    test('html.* under a non-eq operator (or a nested eq) is ignored', function (assert) {
+      let parsed = parseSearchEntryQueryFromPayload({
+        filter: {
+          'item.on': authorRef,
+          range: { 'item.age': { gt: 21 }, 'html.format': { gt: 'a' } },
+          every: [{ eq: { 'item.x': 1, 'html.format': 'atom' } }],
+        },
+      });
+      // the ignored html.* entries leave no residue and do not set the format
+      assert.deepEqual(parsed.itemQuery.filter, {
+        on: authorRef,
+        range: { age: { gt: 21 } },
+        every: [{ eq: { x: 1 } }],
+      } as any);
+      assert.strictEqual(parsed.render.format, 'fitted');
+    });
+
+    test('sort entries may carry their own item.on anchor', function (assert) {
+      let parsed = parseSearchEntryQueryFromPayload({
+        sort: [
+          { by: 'item.title', 'item.on': authorRef, direction: 'desc' },
+          { by: 'item.lastModified' },
+        ],
+      });
+      assert.deepEqual(parsed.itemQuery.sort, [
+        { by: 'title', on: authorRef, direction: 'desc' },
+        // a general sort field needs no anchor
+        { by: 'lastModified' },
+      ] as any);
+    });
+
+    test('sparse fieldsets parse to the item selection', function (assert) {
+      assert.deepEqual(
+        parseSearchEntryQueryFromPayload({
+          fields: { 'search-entry': ['item'] },
+        }).fieldset,
+        { html: false, item: { kind: 'full' }, itemAsFallback: false },
+      );
+      assert.deepEqual(
+        parseSearchEntryQueryFromPayload({
+          fields: { 'search-entry': ['item.title', 'item.status'] },
+        }).fieldset,
+        {
+          html: false,
+          item: { kind: 'sparse', fields: ['title', 'status'] },
+          itemAsFallback: false,
+        },
+      );
+      assert.deepEqual(
+        parseSearchEntryQueryFromPayload({
+          fields: { 'search-entry': ['html', 'item'] },
+        }).fieldset,
+        { html: true, item: { kind: 'full' }, itemAsFallback: false },
+      );
+    });
+
+    test('rejects malformed queries', function (assert) {
+      assert.strictEqual(
+        parseError({ filter: { eq: { status: 'ready' } } }).code,
+        'invalid-query',
+        'bare field path',
+      );
+      assert.strictEqual(
+        parseError({ filter: { 'html.format': 'embedded' } }).code,
+        'invalid-query',
+        'field-keyed html.* at the filter level',
+      );
+      assert.strictEqual(
+        parseError({ filter: { eq: { 'html.format': 'bogus' } } }).code,
+        'invalid-render',
+        'invalid html.format value',
+      );
+      assert.strictEqual(
+        parseError({ filter: { eq: { 'html.renderType': 'Author' } } }).code,
+        'invalid-render',
+        'html.renderType must be a CodeRef',
+      );
+      assert.strictEqual(
+        parseError({ fields: { 'search-entry': ['item', 'item.title'] } }).code,
+        'invalid-query',
+        'full item cannot combine with item.<field>',
+      );
+      assert.strictEqual(
+        parseError({ fields: { 'search-entry': ['html.cardType'] } }).code,
+        'invalid-query',
+        'html does not dot deeper in a fieldset',
+      );
+      assert.strictEqual(
+        parseError({ fields: { card: ['title'] } }).code,
+        'invalid-query',
+        'only the search-entry type is selectable',
+      );
+      assert.strictEqual(
+        parseError({ fields: { 'search-entry': [] } }).code,
+        'invalid-query',
+        'empty fieldset',
+      );
+      assert.strictEqual(
+        parseError({ render: {} }).code,
+        'invalid-query',
+        'unknown top-level member',
+      );
+      assert.strictEqual(
+        parseError({ sort: [{ by: 'title' }] }).code,
+        'invalid-query',
+        'sort by must be item.-addressed',
+      );
+      assert.strictEqual(
+        parseError({ sort: [{ by: 'item.title', on: authorRef }] }).code,
+        'invalid-query',
+        'sort anchor is addressed as item.on',
+      );
+    });
+  });
+
+  module('html composite id', function () {
+    test('encodes (url, format, renderType) with # at both joints', function (assert) {
+      assert.strictEqual(
+        htmlResourceId({
+          url: cardUrl,
+          format: 'fitted',
+          renderType: authorRef,
+        }),
+        `${cardUrl}#fitted#${authorRef.module}/${authorRef.name}`,
+      );
+    });
+
+    test('a rendering with no renderType (a file) is url#format', function (assert) {
+      assert.strictEqual(
+        htmlResourceId({ url: `${realmURL}notes.txt`, format: 'embedded' }),
+        `${realmURL}notes.txt#embedded`,
+      );
+    });
+  });
+
+  module('search-entry builders', function () {
+    test('buildSearchEntryResource links the requested branches', function (assert) {
+      let htmlId = htmlResourceId({
+        url: cardUrl,
+        format: 'fitted',
+        renderType: authorRef,
+      });
+      let both = buildSearchEntryResource({
+        url: cardUrl,
+        htmlId,
+        itemType: 'card',
+      });
+      assert.deepEqual(both, {
+        type: 'search-entry',
+        id: cardUrl,
+        relationships: {
+          html: { data: { type: 'html', id: htmlId } },
+          item: { data: { type: 'card', id: cardUrl } },
+        },
+      });
+      assert.true(isSearchEntryResource(both));
+
+      let htmlOnly = buildSearchEntryResource({ url: cardUrl, htmlId });
+      assert.deepEqual(Object.keys(htmlOnly.relationships), ['html']);
+      assert.true(isSearchEntryResource(htmlOnly));
+    });
+
+    test('buildHtmlResource carries the rendering attributes and styles', function (assert) {
+      let cssId = cssResourceId('https://x/scoped.glimmer-scoped.css');
+      let resource = buildHtmlResource({
+        url: cardUrl,
+        format: 'fitted',
+        renderType: authorRef,
+        html: '<div>hi</div>',
+        cardType: 'Author',
+        iconHtml: '<svg/>',
+        cssIds: [cssId],
+      });
+      assert.deepEqual(resource, {
+        type: 'html',
+        id: `${cardUrl}#fitted#${authorRef.module}/${authorRef.name}`,
+        attributes: {
+          html: '<div>hi</div>',
+          cardType: 'Author',
+          iconHtml: '<svg/>',
+          format: 'fitted',
+          renderType: authorRef,
+        },
+        relationships: { styles: { data: [{ type: 'css', id: cssId }] } },
+      });
+      assert.true(isHtmlResource(resource));
+    });
+
+    test('an error rendering may omit html', function (assert) {
+      let resource = buildHtmlResource({
+        url: cardUrl,
+        format: 'fitted',
+        renderType: authorRef,
+        cardType: 'Author',
+        isError: true,
+        cssIds: [],
+      });
+      assert.false('html' in resource.attributes);
+      assert.true(resource.attributes.isError);
+      assert.true(isHtmlResource(resource));
+    });
+
+    test('buildSparseItemResource projects the requested fields and stamps the marker', function (assert) {
+      let full: CardResource = {
+        type: 'card',
+        id: cardUrl,
+        attributes: {
+          title: 'T',
+          status: 'ready',
+          bio: { city: 'X', zip: 1 },
+        },
+        relationships: {
+          'friends.0': { links: { self: './F/1' } },
+          pet: { links: { self: './P/1' } },
+        },
+        meta: { adoptsFrom: authorRef, fields: {}, lastModified: 5 },
+        links: { self: cardUrl },
+      };
+      let sparse = buildSparseItemResource(full, [
+        'title',
+        'bio.city',
+        'friends',
+      ]);
+      assert.deepEqual(sparse.attributes, {
+        title: 'T',
+        bio: { city: 'X' },
+      });
+      assert.deepEqual(Object.keys(sparse.relationships!), ['friends.0']);
+      assert.deepEqual(sparse.meta.sparseFields, [
+        'title',
+        'bio.city',
+        'friends',
+      ]);
+      assert.false('fields' in sparse.meta, 'per-field meta is dropped');
+      assert.strictEqual(sparse.meta.lastModified, 5);
+      assert.true(isSparseItemResource(sparse));
+      assert.false(isSparseItemResource(full));
+    });
+  });
+});

--- a/packages/runtime-common/card-document-shape.ts
+++ b/packages/runtime-common/card-document-shape.ts
@@ -351,11 +351,13 @@ export function isSearchEntryResource(
   }
   let { html, item } = relationships;
   if (html !== undefined) {
-    if (
-      html?.data?.type !== HtmlResourceType ||
-      typeof html.data.id !== 'string'
-    ) {
+    if (!Array.isArray(html?.data)) {
       return false;
+    }
+    for (let member of html.data) {
+      if (member?.type !== HtmlResourceType || typeof member?.id !== 'string') {
+        return false;
+      }
     }
   }
   if (item !== undefined) {

--- a/packages/runtime-common/card-document-shape.ts
+++ b/packages/runtime-common/card-document-shape.ts
@@ -26,10 +26,12 @@ import type {
   CardResource,
   CssResource,
   FileMetaResource,
+  HtmlResource,
   Meta,
   Relationship,
   RenderedHtmlResource,
   Saved,
+  SearchEntryResource,
 } from './resource-types.ts';
 import type {
   CardCollectionDocument,
@@ -46,6 +48,8 @@ const CardResourceType: CardResource['type'] = 'card';
 const FileMetaResourceType: FileMetaResource['type'] = 'file-meta';
 const RenderedHtmlResourceType: RenderedHtmlResource['type'] = 'rendered-html';
 const CssResourceType: CssResource['type'] = 'css';
+const SearchEntryResourceType: SearchEntryResource['type'] = 'search-entry';
+const HtmlResourceType: HtmlResource['type'] = 'html';
 
 // ---------------------------------------------------------------------------
 // Code refs
@@ -327,6 +331,89 @@ export function isCssResource(resource: any): resource is CssResource {
     return false;
   }
   return typeof resource.attributes.href === 'string';
+}
+
+export function isSearchEntryResource(
+  resource: any,
+): resource is SearchEntryResource {
+  if (typeof resource !== 'object' || resource == null) {
+    return false;
+  }
+  if (resource.type !== SearchEntryResourceType) {
+    return false;
+  }
+  if (typeof resource.id !== 'string') {
+    return false;
+  }
+  let { relationships } = resource;
+  if (typeof relationships !== 'object' || relationships == null) {
+    return false;
+  }
+  let { html, item } = relationships;
+  if (html !== undefined) {
+    if (
+      html?.data?.type !== HtmlResourceType ||
+      typeof html.data.id !== 'string'
+    ) {
+      return false;
+    }
+  }
+  if (item !== undefined) {
+    if (
+      (item?.data?.type !== CardResourceType &&
+        item?.data?.type !== FileMetaResourceType) ||
+      typeof item.data.id !== 'string'
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function isHtmlResource(resource: any): resource is HtmlResource {
+  if (typeof resource !== 'object' || resource == null) {
+    return false;
+  }
+  if (resource.type !== HtmlResourceType) {
+    return false;
+  }
+  if (typeof resource.id !== 'string') {
+    return false;
+  }
+  let { attributes } = resource;
+  if (typeof attributes !== 'object' || attributes == null) {
+    return false;
+  }
+  if (
+    typeof attributes.cardType !== 'string' ||
+    typeof attributes.format !== 'string'
+  ) {
+    return false;
+  }
+  // `html` is absent only on an error rendering with no last-known-good HTML.
+  if (attributes.html === undefined && attributes.isError !== true) {
+    return false;
+  }
+  if (attributes.html !== undefined && typeof attributes.html !== 'string') {
+    return false;
+  }
+  // The has-many `styles` relationship is part of the type, so a sound guard
+  // must confirm it before a consumer reads the stylesheet links.
+  let styles = resource.relationships?.styles;
+  return Boolean(styles && Array.isArray(styles.data));
+}
+
+// A field-limited (`meta.sparseFields`-carrying) `card`/`file-meta`
+// serialization — the `item` shape a sparse fieldset produces. Presence of
+// the marker is the authoritative sparse signal (not which fields happen to
+// be present); a sparse item must never enter the Store.
+export function isSparseItemResource(
+  resource: any,
+): resource is CardResource | FileMetaResource {
+  if (!isCardResource(resource) && !isFileMetaResource(resource)) {
+    return false;
+  }
+  return Array.isArray(resource.meta?.sparseFields);
 }
 
 // An "identity-only" card: the server's representation for an HTML-backed

--- a/packages/runtime-common/document-types.ts
+++ b/packages/runtime-common/document-types.ts
@@ -9,6 +9,7 @@ import {
   type CardResource,
   type CssResource,
   type FileMetaResource,
+  type HtmlQuery,
   type HtmlResource,
   type PrerenderedCardResource,
   type RenderedHtmlResource,
@@ -78,7 +79,12 @@ export type SearchEntryIncludedResource =
 export interface SearchEntryCollectionDocument {
   data: SearchEntryResource[];
   included?: SearchEntryIncludedResource[];
-  meta: QueryResultsMeta;
+  meta: QueryResultsMeta & {
+    // The applied (bound or defaulted) htmlQuery, echoed once at the document
+    // level — it cannot vary across entries, so it is never repeated per
+    // entry. Present whenever the fieldset puts the html branch in play.
+    htmlQuery?: HtmlQuery;
+  };
 }
 
 export interface SingleFileMetaDocument {

--- a/packages/runtime-common/document-types.ts
+++ b/packages/runtime-common/document-types.ts
@@ -9,9 +9,11 @@ import {
   type CardResource,
   type CssResource,
   type FileMetaResource,
+  type HtmlResource,
   type PrerenderedCardResource,
   type RenderedHtmlResource,
   type Saved,
+  type SearchEntryResource,
   type Unsaved,
   isCardResource,
   isFileMetaResource,
@@ -60,6 +62,23 @@ export interface UnifiedSearchCollectionDocument<
     // siblings.
     renderType?: CodeRef;
   };
+}
+
+// The v2 search response: heterogeneous `search-entry` resources in `data`,
+// with everything they compose — `html` renderings (plus their deduped `css`
+// stylesheets) and/or `card`/`file-meta` `item` serializations — riding in
+// `included`. Which branches appear per entry is governed by the query's
+// sparse fieldset (default: prefer `html`, fall back to `item`).
+export type SearchEntryIncludedResource =
+  | HtmlResource
+  | CssResource
+  | CardResource<Saved>
+  | FileMetaResource;
+
+export interface SearchEntryCollectionDocument {
+  data: SearchEntryResource[];
+  included?: SearchEntryIncludedResource[];
+  meta: QueryResultsMeta;
 }
 
 export interface SingleFileMetaDocument {

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -153,10 +153,12 @@ interface PrerenderedCardOptions {
 }
 
 // Selects which columns the unified `search()` projects. `dataOnly` projects
-// the live serialization only (pristine_doc / error_doc); `render` projects the
-// format-specific HTML column plus the live serialization carried only on
-// no-HTML fallback rows; `renderAndData` projects the HTML column plus the
-// live serialization on every row (for responses that pin both branches).
+// the live serialization only (pristine_doc / error_doc); `render` projects
+// one format-specific HTML value plus the live serialization carried only on
+// no-HTML fallback rows; `renderSet` projects each row's full rendering set
+// (every per-format HTML column, JSONB maps whole) plus the live
+// serialization on every row — the caller selects renderings from the set
+// (the v2 htmlQuery evaluation).
 export type SearchProjection =
   | { kind: 'dataOnly' }
   | {
@@ -164,11 +166,7 @@ export type SearchProjection =
       htmlFormat: PrerenderedHtmlFormat;
       renderType?: ResolvedCodeRef;
     }
-  | {
-      kind: 'renderAndData';
-      htmlFormat: PrerenderedHtmlFormat;
-      renderType?: ResolvedCodeRef;
-    };
+  | { kind: 'renderSet' };
 
 export interface WIPOptions {
   useWorkInProgressIndex?: boolean;
@@ -728,6 +726,14 @@ export class IndexQueryEngine {
       selectClauseExpression = [
         'SELECT url, ANY_VALUE(i.type) as type, ANY_VALUE(i.has_error) as has_error, ANY_VALUE(pristine_doc) as pristine_doc, ANY_VALUE(error_doc) as error_doc',
       ];
+    } else if (projection.kind === 'renderSet') {
+      // The full rendering set: every per-format HTML column whole (the
+      // fitted/embedded JSONB maps keyed by render type, the scalar
+      // atom/head columns), plus the live serialization on every row. The
+      // caller enumerates candidate renderings and selects from the set.
+      selectClauseExpression = [
+        'SELECT url, ANY_VALUE(i.type) as type, ANY_VALUE(i.has_error) as has_error, ANY_VALUE(file_alias) as file_alias, ANY_VALUE(fitted_html) as fitted_html, ANY_VALUE(embedded_html) as embedded_html, ANY_VALUE(atom_html) as atom_html, ANY_VALUE(head_html) as head_html, ANY_VALUE(types) as types, ANY_VALUE(deps) as deps, ANY_VALUE(display_names) as display_names, ANY_VALUE(icon_html) as icon_html, ANY_VALUE(error_doc) as error_doc, ANY_VALUE(pristine_doc) as pristine_doc',
+      ];
     } else {
       let htmlColumnExpression = this.buildHtmlColumnExpression({
         htmlFormat: projection.htmlFormat,
@@ -752,18 +758,12 @@ export class IndexQueryEngine {
         'ANY_VALUE(display_names) as display_names,',
         'ANY_VALUE(icon_html) as icon_html,',
         'ANY_VALUE(error_doc) as error_doc,',
-        ...(projection.kind === 'renderAndData'
-          ? // Both branches pinned: the live serialization rides on every row,
-            // alongside the HTML column.
-            ['ANY_VALUE(pristine_doc) as pristine_doc']
-          : [
-              // Carry the live serialization as a raw column. `_search` wraps
-              // this projection so the final `pristine_doc` keeps it only on
-              // rows whose `html` is NULL — the HTML expression is evaluated
-              // once (as `html`) and the NULL test references that computed
-              // column rather than recomputing the COALESCE/JSONB expression.
-              'ANY_VALUE(pristine_doc) as pristine_doc_fallback',
-            ]),
+        // Carry the live serialization as a raw column. `_search` wraps this
+        // projection so the final `pristine_doc` keeps it only on rows whose
+        // `html` is NULL — the HTML expression is evaluated once (as `html`)
+        // and the NULL test references that computed column rather than
+        // recomputing the COALESCE/JSONB expression.
+        'ANY_VALUE(pristine_doc) as pristine_doc_fallback',
       ];
     }
 

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -155,11 +155,17 @@ interface PrerenderedCardOptions {
 // Selects which columns the unified `search()` projects. `dataOnly` projects
 // the live serialization only (pristine_doc / error_doc); `render` projects the
 // format-specific HTML column plus the live serialization carried only on
-// no-HTML fallback rows.
+// no-HTML fallback rows; `renderAndData` projects the HTML column plus the
+// live serialization on every row (for responses that pin both branches).
 export type SearchProjection =
   | { kind: 'dataOnly' }
   | {
       kind: 'render';
+      htmlFormat: PrerenderedHtmlFormat;
+      renderType?: ResolvedCodeRef;
+    }
+  | {
+      kind: 'renderAndData';
       htmlFormat: PrerenderedHtmlFormat;
       renderType?: ResolvedCodeRef;
     };
@@ -746,12 +752,18 @@ export class IndexQueryEngine {
         'ANY_VALUE(display_names) as display_names,',
         'ANY_VALUE(icon_html) as icon_html,',
         'ANY_VALUE(error_doc) as error_doc,',
-        // Carry the live serialization as a raw column. `_search` wraps this
-        // projection so the final `pristine_doc` keeps it only on rows whose
-        // `html` is NULL — the HTML expression is evaluated once (as `html`)
-        // and the NULL test references that computed column rather than
-        // recomputing the COALESCE/JSONB expression.
-        'ANY_VALUE(pristine_doc) as pristine_doc_fallback',
+        ...(projection.kind === 'renderAndData'
+          ? // Both branches pinned: the live serialization rides on every row,
+            // alongside the HTML column.
+            ['ANY_VALUE(pristine_doc) as pristine_doc']
+          : [
+              // Carry the live serialization as a raw column. `_search` wraps
+              // this projection so the final `pristine_doc` keeps it only on
+              // rows whose `html` is NULL — the HTML expression is evaluated
+              // once (as `html`) and the NULL test references that computed
+              // column rather than recomputing the COALESCE/JSONB expression.
+              'ANY_VALUE(pristine_doc) as pristine_doc_fallback',
+            ]),
       ];
     }
 

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -738,6 +738,7 @@ export * from './query.ts';
 export * from './instance-filter-matcher.ts';
 export * from './search-utils.ts';
 export * from './unified-search.ts';
+export * from './search-entry.ts';
 export * from './request-timings.ts';
 export * from './prerendered-html-format.ts';
 export * from './query-field-utils.ts';
@@ -828,6 +829,8 @@ export type {
   LinkableCollectionDocument,
   UnifiedSearchCollectionDocument,
   UnifiedSearchIncludedResource,
+  SearchEntryCollectionDocument,
+  SearchEntryIncludedResource,
 } from './document-types.ts';
 export type {
   CardResource,

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -20,6 +20,7 @@ import {
   type IndexedFile,
   type DefinitionLookup,
   type ResolvedCodeRef,
+  type SearchProjection,
   internalKeyFor,
   visitInstanceURLs,
   maybeRelativeReference,
@@ -53,6 +54,8 @@ import {
   isSingleFileMetaDocument,
   type SingleCardDocument,
   type LinkableCollectionDocument,
+  type SearchEntryCollectionDocument,
+  type SearchEntryIncludedResource,
   type UnifiedSearchCollectionDocument,
   type UnifiedSearchIncludedResource,
   isLinkableCollectionDocument,
@@ -64,6 +67,7 @@ import type {
   FileMetaResource,
   QueryFieldMeta,
   Saved,
+  SearchEntryResource,
 } from './resource-types.ts';
 import type { PrerenderedHtmlFormat } from './prerendered-html-format.ts';
 import {
@@ -74,6 +78,12 @@ import {
   parseUsedRenderType,
   scopedCssHrefsFromDeps,
 } from './unified-search.ts';
+import {
+  buildHtmlResource,
+  buildSearchEntryResource,
+  buildSparseItemResource,
+  type SearchEntryQuery,
+} from './search-entry.ts';
 import { getImmediateFieldDef, type FieldDefinition } from './definitions.ts';
 import {
   normalizeQueryDefinition,
@@ -699,6 +709,277 @@ export class RealmIndexQueryEngine {
       doc.included = included;
     }
     await this.attachRealmInfo(doc);
+    return doc;
+  }
+
+  // The v2 search-entry engine. Runs the parsed search-entry query (the
+  // `item.` query against the SQL core, the `html.` render spec selecting the
+  // projection) and assembles a heterogeneous `search-entry` document: one
+  // entry per result, with `html` (+ deduped `css`) and/or `item` resources in
+  // `included` per the sparse fieldset.
+  //
+  // Branch emission per entry:
+  //   - `fieldset.html` → an `html` resource when the row has a rendering (or
+  //     is an error row, flagged `isError`); its composite id keys (card URL,
+  //     format, renderType).
+  //   - a pinned `item` (`fieldset.item` full/sparse) rides on every row; the
+  //     default mode (`itemAsFallback`) emits it only where no `html` was
+  //     emitted. Sparse items carry `meta.sparseFields` and skip the link
+  //     expansion; full items go through `loadLinks` (same gating as the live
+  //     search path).
+  async searchEntries(
+    searchEntryQuery: SearchEntryQuery,
+    opts?: Options,
+  ): Promise<SearchEntryCollectionDocument> {
+    let { itemQuery: query, render, fieldset, cardUrls } = searchEntryQuery;
+    let engineOpts: Options = {
+      ...opts,
+      ...(cardUrls && cardUrls.length > 0 ? { cardUrls } : {}),
+    };
+    if (await this.queryTargetsFileMeta(query.filter, engineOpts)) {
+      return await this.searchEntriesFileMeta(searchEntryQuery, engineOpts);
+    }
+
+    let itemOnEveryRow = fieldset.item.kind !== 'none';
+    let projection: SearchProjection = fieldset.html
+      ? {
+          kind: itemOnEveryRow ? 'renderAndData' : 'render',
+          htmlFormat: render.format,
+          // `internalKeyFor` (used by the HTML-column expression) resolves a
+          // relative module, so a plain `CodeRef` is accepted here; a render
+          // type is always a concrete `{module,name}`, never an
+          // ancestorOf/fieldOf ref.
+          renderType: render.renderType as ResolvedCodeRef | undefined,
+        }
+      : { kind: 'dataOnly' };
+    // Error rows surface only through the `html` branch (`isError`); the
+    // item-only projection matches the live search path, which excludes them.
+    let sqlOpts: QueryOptions = fieldset.html
+      ? { ...engineOpts, includeErrors: true }
+      : engineOpts;
+    let runSql = () =>
+      this.#indexQueryEngine.search(
+        new URL(this.#realm.url),
+        query,
+        sqlOpts,
+        projection,
+      );
+    let { results, meta } = opts?.timings
+      ? await opts.timings.time('sql', runSql)
+      : await runSql();
+
+    let data: SearchEntryResource[] = [];
+    let htmlResources: SearchEntryIncludedResource[] = [];
+    let itemResources: (CardResource<Saved> | FileMetaResource)[] = [];
+    let cssById = new Map<string, CssResource>();
+    let fullItemRoots: (CardResource<Saved> | FileMetaResource)[] = [];
+
+    for (let row of results) {
+      let fileUrl = row.url;
+      if (!fileUrl) {
+        continue;
+      }
+      // The index `url` column is the instance's file URL; a result's identity
+      // (shared by the `search-entry` and its `item`) drops the `.json`
+      // extension.
+      let cardUrl = fileUrl.endsWith('.json') ? fileUrl.slice(0, -5) : fileUrl;
+      let hasError = Boolean(row.has_error);
+      let html = (row.html as string | null) ?? null;
+
+      let htmlId: string | undefined;
+      if (fieldset.html && (html != null || hasError)) {
+        let cssIds: string[] = [];
+        for (let href of scopedCssHrefsFromDeps(row.deps as string[] | null)) {
+          let css = buildCssResource(href);
+          if (!cssById.has(css.id)) {
+            cssById.set(css.id, css);
+          }
+          cssIds.push(css.id);
+        }
+        let htmlResource = buildHtmlResource({
+          url: cardUrl,
+          format: render.format,
+          renderType: parseUsedRenderType(
+            row.used_render_type as string | null,
+          ) as ResolvedCodeRef | undefined,
+          html: html ?? undefined,
+          cardType: (row.display_names as string[] | null)?.[0] ?? '',
+          iconHtml: (row.icon_html as string | null) ?? undefined,
+          isError: hasError || undefined,
+          cssIds,
+        });
+        htmlResources.push(htmlResource);
+        htmlId = htmlResource.id;
+      }
+
+      let itemType: typeof CardResourceType | undefined;
+      let emitItem =
+        itemOnEveryRow || (fieldset.itemAsFallback && htmlId === undefined);
+      let pristine = row.pristine_doc as CardResource<Saved> | null;
+      if (emitItem && pristine) {
+        let item: CardResource<Saved> = {
+          ...pristine,
+          links: { self: pristine.id },
+        };
+        if (fieldset.item.kind === 'sparse') {
+          item = buildSparseItemResource(item, fieldset.item.fields);
+        } else {
+          fullItemRoots.push(item);
+        }
+        itemResources.push(item);
+        itemType = CardResourceType;
+      }
+
+      data.push(buildSearchEntryResource({ url: cardUrl, htmlId, itemType }));
+    }
+
+    return await this.assembleSearchEntryDoc(
+      { data, meta },
+      { htmlResources, cssById, itemResources, fullItemRoots },
+      opts,
+    );
+  }
+
+  // The file-meta counterpart of `searchEntries`. Files are indexed as
+  // `type: 'file'` rows, which the instance-only projections skip, so they
+  // resolve through `searchFiles` (per-format HTML + the full `file-meta`
+  // resource), with the same fieldset semantics. A file renders natively —
+  // there is no ancestor coercion — so an explicit `html.renderType` is
+  // deliberately dropped here, its `html` resource carries no renderType, and
+  // its composite id is just `<fileURL>#<format>`.
+  private async searchEntriesFileMeta(
+    searchEntryQuery: SearchEntryQuery,
+    opts?: Options,
+  ): Promise<SearchEntryCollectionDocument> {
+    let { itemQuery: query, render, fieldset } = searchEntryQuery;
+    let {
+      includeErrors: _includeErrors,
+      renderType: _renderType,
+      ...rest
+    } = opts ?? {};
+    let fileOpts = {
+      ...rest,
+      htmlFormat: render.format,
+    };
+    let runSql = () =>
+      this.#indexQueryEngine.searchFiles(
+        new URL(this.#realm.url),
+        query,
+        fileOpts,
+      );
+    let { files, meta } = opts?.timings
+      ? await opts.timings.time('sql', runSql)
+      : await runSql();
+
+    let itemOnEveryRow = fieldset.item.kind !== 'none';
+    let data: SearchEntryResource[] = [];
+    let htmlResources: SearchEntryIncludedResource[] = [];
+    let itemResources: (CardResource<Saved> | FileMetaResource)[] = [];
+    let cssById = new Map<string, CssResource>();
+    let fullItemRoots: (CardResource<Saved> | FileMetaResource)[] = [];
+
+    for (let file of files) {
+      let { url, html, cardType, iconHtml } = this.fileEntryToPrerenderedCard(
+        file,
+        fileOpts,
+      );
+      if (!url) {
+        continue;
+      }
+
+      let htmlId: string | undefined;
+      if (fieldset.html && html != null) {
+        let cssIds: string[] = [];
+        for (let href of scopedCssHrefsFromDeps(file.deps)) {
+          let css = buildCssResource(href);
+          if (!cssById.has(css.id)) {
+            cssById.set(css.id, css);
+          }
+          cssIds.push(css.id);
+        }
+        let htmlResource = buildHtmlResource({
+          url,
+          format: render.format,
+          html,
+          cardType: cardType ?? '',
+          iconHtml,
+          cssIds,
+        });
+        htmlResources.push(htmlResource);
+        htmlId = htmlResource.id;
+      }
+
+      let emitItem =
+        itemOnEveryRow || (fieldset.itemAsFallback && htmlId === undefined);
+      let itemEmitted = false;
+      if (emitItem && file.resource?.id) {
+        let item: FileMetaResource = {
+          ...file.resource,
+          links: { self: file.resource.id },
+        };
+        if (fieldset.item.kind === 'sparse') {
+          item = buildSparseItemResource(item, fieldset.item.fields);
+        } else {
+          fullItemRoots.push(item);
+        }
+        itemResources.push(item);
+        itemEmitted = true;
+      }
+
+      data.push(
+        buildSearchEntryResource({
+          url,
+          htmlId,
+          itemType: itemEmitted ? FileMetaResourceType : undefined,
+        }),
+      );
+    }
+
+    return await this.assembleSearchEntryDoc(
+      { data, meta },
+      { htmlResources, cssById, itemResources, fullItemRoots },
+      opts,
+    );
+  }
+
+  // Shared tail of the two searchEntries paths: stitch `included` together
+  // (html renderings first, then the deduped css, then the items), expand
+  // links for the full items only (sparse items are field-limited data reads
+  // and identity-only entries have nothing to expand), same gating as the
+  // live search path.
+  private async assembleSearchEntryDoc(
+    doc: SearchEntryCollectionDocument,
+    resources: {
+      htmlResources: SearchEntryIncludedResource[];
+      cssById: Map<string, CssResource>;
+      itemResources: (CardResource<Saved> | FileMetaResource)[];
+      fullItemRoots: (CardResource<Saved> | FileMetaResource)[];
+    },
+    opts?: Options,
+  ): Promise<SearchEntryCollectionDocument> {
+    let { htmlResources, cssById, itemResources, fullItemRoots } = resources;
+    let included: SearchEntryIncludedResource[] = [
+      ...htmlResources,
+      ...cssById.values(),
+      ...itemResources,
+    ];
+
+    if (fullItemRoots.length > 0 && opts?.loadLinks && !opts?.omitIncluded) {
+      let omit = itemResources.map((r) => r.id).filter(Boolean) as string[];
+      let runLoadLinks = () =>
+        this.loadLinks(
+          { realmURL: this.realmURL, rootResources: fullItemRoots, omit },
+          opts,
+        );
+      let linked = opts?.timings
+        ? await opts.timings.time('loadLinks', runLoadLinks)
+        : await runLoadLinks();
+      included.push(...linked);
+    }
+
+    if (included.length > 0) {
+      doc.included = included;
+    }
     return doc;
   }
 

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -82,6 +82,10 @@ import {
   buildHtmlResource,
   buildSearchEntryResource,
   buildSparseItemResource,
+  htmlQueryHasRenderTypePredicate,
+  htmlQueryMatches,
+  resolveHtmlQuery,
+  type RenderingCandidate,
   type SearchEntryQuery,
 } from './search-entry.ts';
 import { getImmediateFieldDef, type FieldDefinition } from './definitions.ts';
@@ -712,26 +716,34 @@ export class RealmIndexQueryEngine {
     return doc;
   }
 
-  // The v2 search-entry engine. Runs the parsed search-entry query (the
-  // `item.` query against the SQL core, the `html.` render spec selecting the
-  // projection) and assembles a heterogeneous `search-entry` document: one
-  // entry per result, with `html` (+ deduped `css`) and/or `item` resources in
+  // The v2 search-entry engine. Runs the parsed search-entry query — the
+  // `item.` membership query against the SQL core, then the htmlQuery
+  // evaluated per candidate rendering in this mapper — and assembles a
+  // heterogeneous `search-entry` document: one entry per result, with the
+  // selected `html` renderings (+ deduped `css`) and/or `item` resources in
   // `included` per the sparse fieldset.
   //
   // Branch emission per entry:
-  //   - `fieldset.html` → an `html` resource when the row has a rendering (or
-  //     is an error row, flagged `isError`); its composite id keys (card URL,
-  //     format, renderType).
+  //   - `fieldset.html` → one `html` resource per rendering the htmlQuery
+  //     selects from the row's rendering set (formats × ancestor render
+  //     types; error rows flag their renderings `isError`). A pinned html
+  //     branch emits an empty `data: []` when nothing matches; the default
+  //     mode omits the relationship on fallback rows instead.
   //   - a pinned `item` (`fieldset.item` full/sparse) rides on every row; the
-  //     default mode (`itemAsFallback`) emits it only where no `html` was
-  //     emitted. Sparse items carry `meta.sparseFields` and skip the link
+  //     default mode (`itemAsFallback`) emits it only where no rendering
+  //     matched. Sparse items carry `meta.sparseFields` and skip the link
   //     expansion; full items go through `loadLinks` (same gating as the live
   //     search path).
+  //
+  // When no renderType predicate appears anywhere in the htmlQuery, only each
+  // result's own native type (`types[0]`) is in play; an explicit predicate
+  // opens the full adoption-chain universe. The applied htmlQuery is echoed
+  // once as `meta.htmlQuery` whenever the html branch is in play.
   async searchEntries(
     searchEntryQuery: SearchEntryQuery,
     opts?: Options,
   ): Promise<SearchEntryCollectionDocument> {
-    let { itemQuery: query, render, fieldset, cardUrls } = searchEntryQuery;
+    let { itemQuery: query, htmlQuery, fieldset, cardUrls } = searchEntryQuery;
     let engineOpts: Options = {
       ...opts,
       ...(cardUrls && cardUrls.length > 0 ? { cardUrls } : {}),
@@ -742,18 +754,11 @@ export class RealmIndexQueryEngine {
 
     let itemOnEveryRow = fieldset.item.kind !== 'none';
     let projection: SearchProjection = fieldset.html
-      ? {
-          kind: itemOnEveryRow ? 'renderAndData' : 'render',
-          htmlFormat: render.format,
-          // `internalKeyFor` (used by the HTML-column expression) resolves a
-          // relative module, so a plain `CodeRef` is accepted here; a render
-          // type is always a concrete `{module,name}`, never an
-          // ancestorOf/fieldOf ref.
-          renderType: render.renderType as ResolvedCodeRef | undefined,
-        }
+      ? { kind: 'renderSet' }
       : { kind: 'dataOnly' };
-    // Error rows surface only through the `html` branch (`isError`); the
-    // item-only projection matches the live search path, which excludes them.
+    // Error rows surface only through the `html` branch (their renderings
+    // carry `isError`); the item-only projection matches the live search
+    // path, which excludes them.
     let sqlOpts: QueryOptions = fieldset.html
       ? { ...engineOpts, includeErrors: true }
       : engineOpts;
@@ -767,6 +772,13 @@ export class RealmIndexQueryEngine {
     let { results, meta } = opts?.timings
       ? await opts.timings.time('sql', runSql)
       : await runSql();
+
+    // Resolve the htmlQuery's renderType CodeRefs to their `<module>/<name>`
+    // keys once; the pure evaluator then runs per candidate rendering.
+    let resolvedHtmlQuery = resolveHtmlQuery(htmlQuery, (ref) =>
+      internalKeyFor(ref, undefined, this.#realm.virtualNetwork),
+    );
+    let nativeOnly = !htmlQueryHasRenderTypePredicate(htmlQuery);
 
     let data: SearchEntryResource[] = [];
     let htmlResources: SearchEntryIncludedResource[] = [];
@@ -784,37 +796,57 @@ export class RealmIndexQueryEngine {
       // extension.
       let cardUrl = fileUrl.endsWith('.json') ? fileUrl.slice(0, -5) : fileUrl;
       let hasError = Boolean(row.has_error);
-      let html = (row.html as string | null) ?? null;
 
-      let htmlId: string | undefined;
-      if (fieldset.html && (html != null || hasError)) {
-        let cssIds: string[] = [];
-        for (let href of scopedCssHrefsFromDeps(row.deps as string[] | null)) {
-          let css = buildCssResource(href);
-          if (!cssById.has(css.id)) {
-            cssById.set(css.id, css);
-          }
-          cssIds.push(css.id);
+      let htmlIds: string[] | undefined;
+      if (fieldset.html) {
+        let nativeKey = (row.types as string[] | null)?.[0];
+        let candidates = enumerateRowRenderings(row);
+        if (nativeOnly) {
+          candidates = candidates.filter(
+            (candidate) =>
+              nativeKey != null && candidate.renderTypeKey === nativeKey,
+          );
         }
-        let htmlResource = buildHtmlResource({
-          url: cardUrl,
-          format: render.format,
-          renderType: parseUsedRenderType(
-            row.used_render_type as string | null,
-          ) as ResolvedCodeRef | undefined,
-          html: html ?? undefined,
-          cardType: (row.display_names as string[] | null)?.[0] ?? '',
-          iconHtml: (row.icon_html as string | null) ?? undefined,
-          isError: hasError || undefined,
-          cssIds,
-        });
-        htmlResources.push(htmlResource);
-        htmlId = htmlResource.id;
+        let matched = candidates.filter((candidate) =>
+          htmlQueryMatches(resolvedHtmlQuery, candidate),
+        );
+        let cssIds: string[] = [];
+        if (matched.length > 0) {
+          for (let href of scopedCssHrefsFromDeps(
+            row.deps as string[] | null,
+          )) {
+            let css = buildCssResource(href);
+            if (!cssById.has(css.id)) {
+              cssById.set(css.id, css);
+            }
+            cssIds.push(css.id);
+          }
+        }
+        let ids: string[] = [];
+        for (let candidate of matched) {
+          let htmlResource = buildHtmlResource({
+            url: cardUrl,
+            format: candidate.format,
+            renderType: parseUsedRenderType(candidate.renderTypeKey) as
+              | ResolvedCodeRef
+              | undefined,
+            html: candidate.html,
+            cardType: (row.display_names as string[] | null)?.[0] ?? '',
+            iconHtml: (row.icon_html as string | null) ?? undefined,
+            isError: hasError || undefined,
+            cssIds,
+          });
+          htmlResources.push(htmlResource);
+          ids.push(htmlResource.id);
+        }
+        // A pinned html branch always carries the (possibly empty) array;
+        // the default mode omits the relationship on fallback rows.
+        htmlIds = fieldset.itemAsFallback && ids.length === 0 ? undefined : ids;
       }
 
       let itemType: typeof CardResourceType | undefined;
       let emitItem =
-        itemOnEveryRow || (fieldset.itemAsFallback && htmlId === undefined);
+        itemOnEveryRow || (fieldset.itemAsFallback && htmlIds === undefined);
       let pristine = row.pristine_doc as CardResource<Saved> | null;
       if (emitItem && pristine) {
         let item: CardResource<Saved> = {
@@ -830,11 +862,14 @@ export class RealmIndexQueryEngine {
         itemType = CardResourceType;
       }
 
-      data.push(buildSearchEntryResource({ url: cardUrl, htmlId, itemType }));
+      data.push(buildSearchEntryResource({ url: cardUrl, htmlIds, itemType }));
     }
 
+    let metaWithEcho: SearchEntryCollectionDocument['meta'] = fieldset.html
+      ? { ...meta, htmlQuery }
+      : meta;
     return await this.assembleSearchEntryDoc(
-      { data, meta },
+      { data, meta: metaWithEcho },
       { htmlResources, cssById, itemResources, fullItemRoots },
       opts,
     );
@@ -844,23 +879,19 @@ export class RealmIndexQueryEngine {
   // `type: 'file'` rows, which the instance-only projections skip, so they
   // resolve through `searchFiles` (per-format HTML + the full `file-meta`
   // resource), with the same fieldset semantics. A file renders natively —
-  // there is no ancestor coercion — so an explicit `html.renderType` is
-  // deliberately dropped here, its `html` resource carries no renderType, and
-  // its composite id is just `<fileURL>#<format>`.
+  // there is no ancestor coercion — so a file rendering carries no
+  // renderType, its composite id is just `<fileURL>#<format>`, and a
+  // renderType predicate in the htmlQuery never matches a file rendering.
   private async searchEntriesFileMeta(
     searchEntryQuery: SearchEntryQuery,
     opts?: Options,
   ): Promise<SearchEntryCollectionDocument> {
-    let { itemQuery: query, render, fieldset } = searchEntryQuery;
+    let { itemQuery: query, htmlQuery, fieldset } = searchEntryQuery;
     let {
       includeErrors: _includeErrors,
       renderType: _renderType,
-      ...rest
+      ...fileOpts
     } = opts ?? {};
-    let fileOpts = {
-      ...rest,
-      htmlFormat: render.format,
-    };
     let runSql = () =>
       this.#indexQueryEngine.searchFiles(
         new URL(this.#realm.url),
@@ -871,6 +902,10 @@ export class RealmIndexQueryEngine {
       ? await opts.timings.time('sql', runSql)
       : await runSql();
 
+    let resolvedHtmlQuery = resolveHtmlQuery(htmlQuery, (ref) =>
+      internalKeyFor(ref, undefined, this.#realm.virtualNetwork),
+    );
+
     let itemOnEveryRow = fieldset.item.kind !== 'none';
     let data: SearchEntryResource[] = [];
     let htmlResources: SearchEntryIncludedResource[] = [];
@@ -879,38 +914,44 @@ export class RealmIndexQueryEngine {
     let fullItemRoots: (CardResource<Saved> | FileMetaResource)[] = [];
 
     for (let file of files) {
-      let { url, html, cardType, iconHtml } = this.fileEntryToPrerenderedCard(
-        file,
-        fileOpts,
-      );
+      let url = file.canonicalURL;
       if (!url) {
         continue;
       }
 
-      let htmlId: string | undefined;
-      if (fieldset.html && html != null) {
+      let htmlIds: string[] | undefined;
+      if (fieldset.html) {
+        let matched = enumerateFileRenderings(file).filter((candidate) =>
+          htmlQueryMatches(resolvedHtmlQuery, candidate),
+        );
         let cssIds: string[] = [];
-        for (let href of scopedCssHrefsFromDeps(file.deps)) {
-          let css = buildCssResource(href);
-          if (!cssById.has(css.id)) {
-            cssById.set(css.id, css);
+        if (matched.length > 0) {
+          for (let href of scopedCssHrefsFromDeps(file.deps)) {
+            let css = buildCssResource(href);
+            if (!cssById.has(css.id)) {
+              cssById.set(css.id, css);
+            }
+            cssIds.push(css.id);
           }
-          cssIds.push(css.id);
         }
-        let htmlResource = buildHtmlResource({
-          url,
-          format: render.format,
-          html,
-          cardType: cardType ?? '',
-          iconHtml,
-          cssIds,
-        });
-        htmlResources.push(htmlResource);
-        htmlId = htmlResource.id;
+        let ids: string[] = [];
+        for (let candidate of matched) {
+          let htmlResource = buildHtmlResource({
+            url,
+            format: candidate.format,
+            html: candidate.html,
+            cardType: file.displayNames?.[0] ?? '',
+            iconHtml: file.iconHtml ?? undefined,
+            cssIds,
+          });
+          htmlResources.push(htmlResource);
+          ids.push(htmlResource.id);
+        }
+        htmlIds = fieldset.itemAsFallback && ids.length === 0 ? undefined : ids;
       }
 
       let emitItem =
-        itemOnEveryRow || (fieldset.itemAsFallback && htmlId === undefined);
+        itemOnEveryRow || (fieldset.itemAsFallback && htmlIds === undefined);
       let itemEmitted = false;
       if (emitItem && file.resource?.id) {
         let item: FileMetaResource = {
@@ -929,14 +970,17 @@ export class RealmIndexQueryEngine {
       data.push(
         buildSearchEntryResource({
           url,
-          htmlId,
+          htmlIds,
           itemType: itemEmitted ? FileMetaResourceType : undefined,
         }),
       );
     }
 
+    let metaWithEcho: SearchEntryCollectionDocument['meta'] = fieldset.html
+      ? { ...meta, htmlQuery }
+      : meta;
     return await this.assembleSearchEntryDoc(
-      { data, meta },
+      { data, meta: metaWithEcho },
       { htmlResources, cssById, itemResources, fullItemRoots },
       opts,
     );
@@ -2391,6 +2435,74 @@ function relativizeResource(
       ) as RealmResourceIdentifier,
     );
   });
+}
+
+// One candidate rendering of a row, with its markup: a (format, renderType)
+// point in the rendering set the renderSet projection selects. The
+// fitted/embedded JSONB maps contribute one candidate per render-type key;
+// the scalar atom/head columns contribute one candidate at the row's own
+// native type.
+type RowRendering = RenderingCandidate & { html: string };
+
+function enumerateRowRenderings(row: {
+  fitted_html?: Record<string, string> | null;
+  embedded_html?: Record<string, string> | null;
+  atom_html?: string | null;
+  head_html?: string | null;
+  types?: string[] | null;
+}): RowRendering[] {
+  let candidates: RowRendering[] = [];
+  for (let [format, byType] of [
+    ['fitted', row.fitted_html],
+    ['embedded', row.embedded_html],
+  ] as const) {
+    for (let [renderTypeKey, html] of Object.entries(byType ?? {})) {
+      if (html != null) {
+        candidates.push({ format, renderTypeKey, html });
+      }
+    }
+  }
+  let nativeKey = row.types?.[0];
+  if (row.atom_html != null) {
+    candidates.push({
+      format: 'atom',
+      ...(nativeKey ? { renderTypeKey: nativeKey } : {}),
+      html: row.atom_html,
+    });
+  }
+  if (row.head_html != null) {
+    candidates.push({
+      format: 'head',
+      ...(nativeKey ? { renderTypeKey: nativeKey } : {}),
+      html: row.head_html,
+    });
+  }
+  return candidates;
+}
+
+// The file counterpart: a file renders natively, so its fitted/embedded
+// candidates come from its own type's entry and no candidate carries a
+// renderTypeKey (a renderType predicate in the htmlQuery never matches a
+// file rendering).
+function enumerateFileRenderings(file: IndexedFile): RowRendering[] {
+  let candidates: RowRendering[] = [];
+  let nativeKey = file.types?.[0];
+  for (let [format, byType] of [
+    ['fitted', file.fittedHtml],
+    ['embedded', file.embeddedHtml],
+  ] as const) {
+    let html = nativeKey != null ? byType?.[nativeKey] : undefined;
+    if (html != null) {
+      candidates.push({ format, html });
+    }
+  }
+  if (file.atomHtml != null) {
+    candidates.push({ format: 'atom', html: file.atomHtml });
+  }
+  if (file.headHtml != null) {
+    candidates.push({ format: 'head', html: file.headHtml });
+  }
+  return candidates;
 }
 
 function applySparseFieldset<T extends CardResource<Saved> | FileMetaResource>(

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -946,7 +946,8 @@ export class RealmIndexQueryEngine {
   // (html renderings first, then the deduped css, then the items), expand
   // links for the full items only (sparse items are field-limited data reads
   // and identity-only entries have nothing to expand), same gating as the
-  // live search path.
+  // live search path. Items carry `meta.realmInfo` exactly as the live
+  // search path serializes them.
   private async assembleSearchEntryDoc(
     doc: SearchEntryCollectionDocument,
     resources: {
@@ -980,6 +981,7 @@ export class RealmIndexQueryEngine {
     if (included.length > 0) {
       doc.included = included;
     }
+    await this.attachRealmInfo(doc);
     return doc;
   }
 
@@ -1711,7 +1713,8 @@ export class RealmIndexQueryEngine {
     doc:
       | SingleCardDocument
       | LinkableCollectionDocument
-      | UnifiedSearchCollectionDocument,
+      | UnifiedSearchCollectionDocument
+      | SearchEntryCollectionDocument,
   ): Promise<void> {
     let realmInfo = await this.#realm.getRealmInfo();
     let resources = Array.isArray(doc.data) ? doc.data : [doc.data];

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -848,6 +848,14 @@ export class RealmIndexQueryEngine {
       let emitItem =
         itemOnEveryRow || (fieldset.itemAsFallback && htmlIds === undefined);
       let pristine = row.pristine_doc as CardResource<Saved> | null;
+      // A row can have nothing renderable AND no serialization — an error row
+      // whose first indexing attempt failed (no last-known-good renderings,
+      // no pristine doc). Keep its membership visible through the empty html
+      // array rather than emitting an entry with neither branch.
+      if (fieldset.html && htmlIds === undefined && !pristine) {
+        htmlIds = [];
+        emitItem = false;
+      }
       if (emitItem && pristine) {
         let item: CardResource<Saved> = {
           ...pristine,
@@ -952,6 +960,13 @@ export class RealmIndexQueryEngine {
 
       let emitItem =
         itemOnEveryRow || (fieldset.itemAsFallback && htmlIds === undefined);
+      // Same neither-branch guard as the card path: keep membership visible
+      // through the empty html array when there is no serialization to fall
+      // back to.
+      if (fieldset.html && htmlIds === undefined && !file.resource?.id) {
+        htmlIds = [];
+        emitItem = false;
+      }
       let itemEmitted = false;
       if (emitItem && file.resource?.id) {
         let item: FileMetaResource = {

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -1,6 +1,7 @@
 import { md5 } from 'super-fast-md5';
 import type { RealmInfo } from './realm.ts';
-import { type CodeRef, moduleFrom } from './code-ref.ts';
+import { type CodeRef, type ResolvedCodeRef, moduleFrom } from './code-ref.ts';
+import type { PrerenderedHtmlFormat } from './prerendered-html-format.ts';
 import type {
   RealmResourceIdentifier,
   RealmIdentifier,
@@ -22,13 +23,17 @@ export const CardResourceType = 'card';
 export const FileMetaResourceType = 'file-meta';
 export const RenderedHtmlResourceType = 'rendered-html';
 export const CssResourceType = 'css';
+export const SearchEntryResourceType = 'search-entry';
+export const HtmlResourceType = 'html';
 // resource
 export type Resource =
   | ModuleResource
   | CardResource
   | PrerenderedCardResource
   | RenderedHtmlResource
-  | CssResource;
+  | CssResource
+  | SearchEntryResource
+  | HtmlResource;
 export type ResourceMeta = ModuleMeta | Meta;
 export type LinkableResource = CardResource | FileMetaResource;
 
@@ -94,6 +99,13 @@ export type CardResourceMeta = Meta & {
   // (it ships the standard live wireformat); it rides only on identity-only
   // results.
   renderType?: CodeRef;
+  // Set on a field-limited serialization: the names of the fields it carries.
+  // Presence marks the resource sparse — distinguishing "only these fields
+  // were loaded" from "a full card whose other fields happen to be empty" —
+  // and a sparse resource must never enter the Store (it would misrepresent
+  // the instance and could clobber a correctly-loaded full one). Absence
+  // marks the serialization full.
+  sparseFields?: string[];
 };
 
 export type FileMetaResourceResourceMeta = Meta & {
@@ -103,6 +115,9 @@ export type FileMetaResourceResourceMeta = Meta & {
   // See CardResourceMeta.identityOnly — a file-meta result can likewise be
   // HTML-backed and identity-only.
   identityOnly?: boolean;
+  // See CardResourceMeta.sparseFields — a file-meta serialization can likewise
+  // be field-limited.
+  sparseFields?: string[];
 };
 
 export interface CardResource<Identity extends Unsaved = Saved> {
@@ -178,6 +193,56 @@ export interface CssResource {
   };
 }
 
+// One v2 search result. A platform resource — never a userland card — so its
+// relationships cannot collide with user `@field` names. Its `id` is the bare
+// card/file URL, shared with its `item` (`card`/`file-meta`) serialization;
+// `type` is the discriminator. The two branches are composition: `html` points
+// at the result's prerendered rendering, `item` at its live serialization.
+// Which branches appear is governed by the query's sparse fieldset (default:
+// prefer `html`, fall back to `item` when no HTML exists).
+export interface SearchEntryResource {
+  id: string;
+  type: typeof SearchEntryResourceType;
+  relationships: {
+    html?: {
+      data: { type: typeof HtmlResourceType; id: string };
+    };
+    item?: {
+      data: {
+        type: typeof CardResourceType | typeof FileMetaResourceType;
+        id: string;
+      };
+    };
+  };
+}
+
+// One prerendered rendering of a card/file: a v2 resource whose `id` is the
+// (card URL, format, renderType) composite (see `htmlResourceId`), so each
+// rendering of a card — per format × render type — is an independently
+// cacheable/dedupable resource. The scoped CSS it needs travels as
+// first-class `css` resources linked through `styles`.
+export interface HtmlResource {
+  id: string;
+  type: typeof HtmlResourceType;
+  attributes: {
+    // Absent only on an error rendering with no last-known-good HTML.
+    html?: string;
+    cardType: string;
+    iconHtml?: string;
+    isError?: boolean;
+    format: PrerenderedHtmlFormat;
+    // The type this rendering was rendered as — the result's own native type
+    // unless the query asked for an ancestor. A file rendering carries no
+    // renderType (files render natively; there is no ancestor coercion).
+    renderType?: ResolvedCodeRef;
+  };
+  relationships: {
+    styles: {
+      data: { type: typeof CssResourceType; id: string }[];
+    };
+  };
+}
+
 export type LooseLinkableResource<T extends LinkableResource> = Omit<
   T,
   'id' | 'type'
@@ -232,6 +297,9 @@ export {
   isCssResource,
   isIdentityOnlyCardResource,
   isIdentityOnlyFileMetaResource,
+  isSearchEntryResource,
+  isHtmlResource,
+  isSparseItemResource,
 } from './card-document-shape.ts';
 
 // The `css` resource id: a content hash of the (base64-embedding) scoped-CSS
@@ -240,6 +308,25 @@ export {
 // standing convention for non-security fingerprints (see `transpile.ts`).
 export function cssResourceId(href: string): string {
   return md5(href);
+}
+
+// The `html` resource id: the (card URL, format, renderType) composite that
+// makes each rendering an independently cacheable resource. Consumers treat
+// it as an opaque cache key — the readable format/renderType live in the
+// resource's attributes. `#` is the composite delimiter at both joints
+// (neither card URLs nor module URLs contain one); the `/` inside the
+// renderType segment is just the renderType key's own `<module>/<name>`
+// encoding (the same string the `used_render_type` SQL column carries). A
+// file rendering has no renderType, so its id is just `<fileURL>#<format>`.
+export function htmlResourceId(args: {
+  url: string;
+  format: PrerenderedHtmlFormat;
+  renderType?: ResolvedCodeRef;
+}): string {
+  let { url, format, renderType } = args;
+  return `${url}#${format}${
+    renderType ? `#${renderType.module}/${renderType.name}` : ''
+  }`;
 }
 
 export function extractRelationshipIds(

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -193,19 +193,41 @@ export interface CssResource {
   };
 }
 
+// The synthesized rendering-selection query bound on a `search-entry` (the
+// "htmlQuery"): a boolean sub-query over the rendering dimensions — `eq`
+// leaves composed with `every`/`any`/`not`, with real boolean semantics
+// (`not(not(q))` selects exactly what `q` selects). It selects which of an
+// entry's indexed renderings (formats × ancestor render types) populate the
+// `html` has-many; it never affects entry membership.
+export type HtmlQuery =
+  | { eq: HtmlQueryLeaf }
+  | { every: HtmlQuery[] }
+  | { any: HtmlQuery[] }
+  | { not: HtmlQuery };
+
+// An `eq` leaf over the rendering dimensions; several keys in one leaf are
+// conjoined, and at least one must be present (an unconstrained leaf is
+// unsupported).
+export interface HtmlQueryLeaf {
+  format?: PrerenderedHtmlFormat;
+  renderType?: CodeRef;
+}
+
 // One v2 search result. A platform resource — never a userland card — so its
 // relationships cannot collide with user `@field` names. Its `id` is the bare
 // card/file URL, shared with its `item` (`card`/`file-meta`) serialization;
-// `type` is the discriminator. The two branches are composition: `html` points
-// at the result's prerendered rendering, `item` at its live serialization.
-// Which branches appear is governed by the query's sparse fieldset (default:
-// prefer `html`, fall back to `item` when no HTML exists).
+// `type` is the discriminator. The branches are composition: the `html`
+// has-many carries the renderings selected by the query's htmlQuery (an empty
+// array = the entry matched but no rendering satisfies the htmlQuery yet);
+// `item` points at the live serialization. Which branches appear is governed
+// by the query's sparse fieldset (default: the selected renderings, falling
+// back to `item` — with the `html` relationship omitted — where none match).
 export interface SearchEntryResource {
   id: string;
   type: typeof SearchEntryResourceType;
   relationships: {
     html?: {
-      data: { type: typeof HtmlResourceType; id: string };
+      data: { type: typeof HtmlResourceType; id: string }[];
     };
     item?: {
       data: {

--- a/packages/runtime-common/search-entry.ts
+++ b/packages/runtime-common/search-entry.ts
@@ -1,0 +1,611 @@
+import { assertQuery, InvalidQueryError, type Query } from './query.ts';
+import { SearchRequestError } from './search-utils.ts';
+import type {
+  CardResourceType,
+  FileMetaResourceType,
+} from './resource-types.ts';
+import {
+  CssResourceType,
+  HtmlResourceType,
+  SearchEntryResourceType,
+  htmlResourceId,
+  type CardResource,
+  type FileMetaResource,
+  type HtmlResource,
+  type Relationship,
+  type Saved,
+  type SearchEntryResource,
+} from './resource-types.ts';
+import type { ResolvedCodeRef } from './code-ref.ts';
+import {
+  isValidPrerenderedHtmlFormat,
+  PRERENDERED_HTML_FORMATS,
+  type PrerenderedHtmlFormat,
+} from './prerendered-html-format.ts';
+import type { CodeRef } from './code-ref.ts';
+import { isCodeRef } from './card-document-shape.ts';
+import { generalSortFields } from './index-query-engine.ts';
+import { ensureTrailingSlash } from './paths.ts';
+import { logger } from './log.ts';
+
+// ---------------------------------------------------------------------------
+// The v2 search-entry query.
+//
+// A v2 request is one query rooted on `search-entry`, addressed through two
+// branches: `item.` (the card/file serialization) and `html.` (the
+// rendering). The filter grammar is the standard operator-keyed grammar
+// (`eq` / `contains` / `in` / `range` / `any` / `every` / `not` / `matches`)
+// — only the addressing changes:
+//
+//   - the type anchor is `item.on` (a node carrying only the anchor is the
+//     pure card-type filter),
+//   - field paths inside the operators are reached through `item.`
+//     (`eq: { "item.status": "ready" }`),
+//   - `html.renderType` / `html.format` are rendering config spelled as `eq`
+//     predicates at the top level of `filter`. The index stores a set of
+//     renderings per entry (formats × ancestor render types), so these
+//     genuinely narrow — but they narrow which rendering satisfies the `html`
+//     branch, not entry membership: a result with no matching rendering still
+//     returns, falling back to `item`. Equality is the only meaningful
+//     predicate over a rendering dimension, so an `html.*` path under any
+//     other operator (or outside the top-level `eq`) is ignored with a logged
+//     warning,
+//   - sort keys are `item.` paths, with `item.on` as a sort entry's own
+//     anchor (a card-field sort without one inherits the filter's anchor).
+//
+// `fields[search-entry]` is the sparse fieldset selecting which branches the
+// response carries: `html`, `item` (the full serialization), or
+// `item.<field>` entries (a field-limited serialization that ships
+// `meta.sparseFields` and never enters the Store). No fieldset means the
+// default resolution policy: prefer `html`, fall back to `item` where a
+// result has no HTML.
+//
+// The parser translates the wire query into the legacy `Query` the SQL core
+// consumes (`item.` prefixes stripped) plus the lifted render spec and the
+// parsed fieldset.
+// ---------------------------------------------------------------------------
+
+const ITEM_PREFIX = 'item.';
+const ITEM_ANCHOR = 'item.on';
+const HTML_RENDER_TYPE = 'html.renderType';
+const HTML_FORMAT = 'html.format';
+
+export const DEFAULT_SEARCH_ENTRY_FORMAT: PrerenderedHtmlFormat = 'fitted';
+
+const SEARCH_ENTRY_QUERY_MEMBERS = [
+  'filter',
+  'sort',
+  'page',
+  'realms',
+  'fields',
+  'cardUrls',
+];
+
+// The operator members whose value is an object keyed by field paths.
+const FIELD_KEYED_OPERATORS = ['eq', 'contains', 'in', 'range'];
+
+export interface SearchEntryRenderSpec {
+  // The format of the `html` branch; `html.format`, defaulting to fitted.
+  format: PrerenderedHtmlFormat;
+  // `html.renderType`: render every result as this ancestor type. Omitted →
+  // each result renders in its own actual (native) type.
+  renderType?: CodeRef;
+}
+
+// Which form of the `item` serialization the fieldset selects.
+export type SearchEntryItemSelection =
+  | { kind: 'none' }
+  | { kind: 'full' }
+  | { kind: 'sparse'; fields: string[] };
+
+export interface SearchEntryFieldset {
+  html: boolean;
+  item: SearchEntryItemSelection;
+  // True only in the default (no `fields` member) mode: the `item` branch
+  // appears per result, only where the result has no HTML. An explicit
+  // fieldset always pins the branches instead.
+  itemAsFallback: boolean;
+}
+
+// The parsed form of a v2 request: the legacy `Query` for the SQL core (the
+// `item.` addressing stripped), the lifted `html.` render config, and the
+// parsed sparse fieldset. The compat layer constructs this directly from a
+// legacy request — it does not round-trip through the wire grammar.
+export interface SearchEntryQuery {
+  itemQuery: Query;
+  render: SearchEntryRenderSpec;
+  fieldset: SearchEntryFieldset;
+  realms?: string[];
+  cardUrls?: string[];
+}
+
+function invalidQuery(message: string): SearchRequestError {
+  return new SearchRequestError('invalid-query', `Invalid query: ${message}`);
+}
+
+// Lazy: a module-load `logger()` call races the circular import that installs
+// the logger factory. First emission happens well after boot.
+let searchEntryLog: ReturnType<typeof logger> | undefined;
+function warn(message: string): void {
+  (searchEntryLog ??= logger('search-entry-query')).warn(message);
+}
+
+// The `html.*` rendering config captured out of the filter's top-level `eq`.
+// Values are validated by `parseRenderSpec` after the walk.
+interface RenderConfigCapture {
+  renderType?: unknown;
+  format?: unknown;
+}
+
+function stripItemPrefix(fieldPath: string, pointer: string): string {
+  if (
+    !fieldPath.startsWith(ITEM_PREFIX) ||
+    fieldPath.length <= ITEM_PREFIX.length
+  ) {
+    throw invalidQuery(
+      `${pointer}: field paths must be addressed through item. (got "${fieldPath}")`,
+    );
+  }
+  return fieldPath.slice(ITEM_PREFIX.length);
+}
+
+// The `html.` rendering config — top-level members of the query.
+function parseRenderSpec(
+  renderType: unknown,
+  format: unknown,
+): SearchEntryRenderSpec {
+  let render: SearchEntryRenderSpec = { format: DEFAULT_SEARCH_ENTRY_FORMAT };
+  if (format !== undefined) {
+    if (typeof format !== 'string' || !isValidPrerenderedHtmlFormat(format)) {
+      throw new SearchRequestError(
+        'invalid-render',
+        `${HTML_FORMAT} must be one of ${PRERENDERED_HTML_FORMATS.join(', ')}`,
+      );
+    }
+    render.format = format;
+  }
+  if (renderType !== undefined) {
+    if (!isCodeRef(renderType)) {
+      throw new SearchRequestError(
+        'invalid-render',
+        `${HTML_RENDER_TYPE} must be a CodeRef`,
+      );
+    }
+    render.renderType = renderType;
+  }
+  return render;
+}
+
+// Translate one filter node from `item.` addressing to the legacy grammar:
+// `item.on` → `on`, field paths inside the operators stripped of their
+// `item.` prefix, connectives recursed. The structure (which operators nest
+// where) is untouched — `assertQuery` validates the translated result.
+//
+// `capture` is present only on the root node: `html.*` paths in the root
+// node's `eq` are lifted into it. Anywhere else — another operator, or any
+// nested node — an `html.*` path is ignored with a logged warning (equality
+// at the top level is the only meaningful spelling for rendering config).
+function translateFilterNode(
+  node: unknown,
+  pointer: string,
+  capture?: RenderConfigCapture,
+): Record<string, unknown> {
+  if (typeof node !== 'object' || node == null || Array.isArray(node)) {
+    throw invalidQuery(`${pointer}: filter must be an object`);
+  }
+  let out: Record<string, unknown> = {};
+  for (let [key, value] of Object.entries(node)) {
+    if (key === ITEM_ANCHOR) {
+      out.on = value;
+    } else if (key === 'any' || key === 'every') {
+      if (!Array.isArray(value)) {
+        throw invalidQuery(`${pointer}/${key}: ${key} must be an array`);
+      }
+      out[key] = value.map((entry, i) =>
+        translateFilterNode(entry, `${pointer}/${key}[${i}]`),
+      );
+    } else if (key === 'not') {
+      out.not = translateFilterNode(value, `${pointer}/not`);
+    } else if (FIELD_KEYED_OPERATORS.includes(key)) {
+      let translated = translateFieldKeys(
+        value,
+        `${pointer}/${key}`,
+        key === 'eq' ? capture : undefined,
+      );
+      // An operator that carried only html.* entries (lifted or ignored)
+      // vanishes with them; a user-authored empty operator is preserved for
+      // assertQuery to reject.
+      if (
+        Object.keys(translated).length === 0 &&
+        Object.keys(value as object).length > 0
+      ) {
+        continue;
+      }
+      out[key] = translated;
+    } else if (key === 'matches') {
+      // Full-text match over the whole document — no field path to address.
+      out.matches = value;
+    } else if (key === HTML_RENDER_TYPE || key === HTML_FORMAT) {
+      throw invalidQuery(
+        `${pointer}/${key}: ${key} is an eq predicate — spell it eq: { "${key}": … }`,
+      );
+    } else {
+      throw invalidQuery(
+        `${pointer}: unknown filter member "${key}" — the type anchor is item.on and field paths are addressed through item. inside the filter operators (${FIELD_KEYED_OPERATORS.join(
+          '/',
+        )})`,
+      );
+    }
+  }
+  // A node carrying only the type anchor is the v2 spelling of a pure
+  // card-type filter.
+  let keys = Object.keys(out);
+  if (keys.length === 1 && keys[0] === 'on') {
+    return { type: out.on };
+  }
+  return out;
+}
+
+function translateFieldKeys(
+  value: unknown,
+  pointer: string,
+  capture: RenderConfigCapture | undefined,
+): Record<string, unknown> {
+  if (typeof value !== 'object' || value == null || Array.isArray(value)) {
+    throw invalidQuery(
+      `${pointer}: must be an object keyed by item. field paths`,
+    );
+  }
+  let out: Record<string, unknown> = {};
+  for (let [fieldPath, fieldValue] of Object.entries(value)) {
+    if (fieldPath === HTML_RENDER_TYPE || fieldPath === HTML_FORMAT) {
+      if (capture) {
+        if (fieldPath === HTML_RENDER_TYPE) {
+          capture.renderType = fieldValue;
+        } else {
+          capture.format = fieldValue;
+        }
+      } else {
+        warn(
+          `${pointer}/${fieldPath}: ${fieldPath} is rendering config and supports only the eq operator at the top level of filter — ignoring`,
+        );
+      }
+      continue;
+    }
+    out[stripItemPrefix(fieldPath, `${pointer}/${fieldPath}`)] = fieldValue;
+  }
+  return out;
+}
+
+function translateSort(value: unknown, rootAnchor: unknown): unknown[] {
+  if (!Array.isArray(value)) {
+    throw invalidQuery(`sort: sort must be an array`);
+  }
+  return value.map((entry, i) => {
+    let pointer = `sort[${i}]`;
+    if (typeof entry !== 'object' || entry == null) {
+      throw invalidQuery(`${pointer}: missing sort object`);
+    }
+    let out: Record<string, unknown> = {};
+    for (let [key, v] of Object.entries(entry)) {
+      if (key === 'by') {
+        if (typeof v !== 'string') {
+          throw invalidQuery(`${pointer}/by: by must be a string`);
+        }
+        out.by = stripItemPrefix(v, `${pointer}/by`);
+      } else if (key === ITEM_ANCHOR) {
+        out.on = v;
+      } else if (key === 'direction') {
+        out.direction = v;
+      } else if (key === 'on') {
+        throw invalidQuery(
+          `${pointer}: the sort type anchor is addressed as item.on`,
+        );
+      } else {
+        throw invalidQuery(`${pointer}: unknown sort member "${key}"`);
+      }
+    }
+    // A card-field sort entry without its own anchor inherits the filter's —
+    // the sort resolves against the same type the query is anchored on.
+    // General (non-card-field) sort keys need no anchor.
+    if (
+      out.on === undefined &&
+      typeof out.by === 'string' &&
+      !(out.by in generalSortFields) &&
+      rootAnchor !== undefined
+    ) {
+      out.on = rootAnchor;
+    }
+    return out;
+  });
+}
+
+function parseFieldset(fields: unknown): SearchEntryFieldset {
+  if (fields === undefined) {
+    // No fieldset → the default resolution policy: prefer html, fall back to
+    // the item serialization where a result has no HTML.
+    return { html: true, item: { kind: 'none' }, itemAsFallback: true };
+  }
+  if (typeof fields !== 'object' || fields == null || Array.isArray(fields)) {
+    throw invalidQuery(`fields must be an object`);
+  }
+  let keys = Object.keys(fields);
+  if (keys.length !== 1 || keys[0] !== 'search-entry') {
+    throw invalidQuery(`fields supports only the "search-entry" type`);
+  }
+  let entries = (fields as Record<string, unknown>)['search-entry'];
+  if (
+    !Array.isArray(entries) ||
+    entries.length === 0 ||
+    !entries.every((entry) => typeof entry === 'string')
+  ) {
+    throw invalidQuery(
+      `fields[search-entry] must be a non-empty array of strings`,
+    );
+  }
+  let html = false;
+  let itemFull = false;
+  let sparseFields: string[] = [];
+  for (let entry of entries) {
+    if (entry === 'html') {
+      html = true;
+    } else if (entry === 'item') {
+      itemFull = true;
+    } else if (
+      entry.startsWith(ITEM_PREFIX) &&
+      entry.length > ITEM_PREFIX.length
+    ) {
+      sparseFields.push(entry.slice(ITEM_PREFIX.length));
+    } else {
+      throw invalidQuery(
+        `each fields[search-entry] entry must be "html", "item", or "item.<field>" (got "${entry}")`,
+      );
+    }
+  }
+  if (itemFull && sparseFields.length > 0) {
+    throw invalidQuery(
+      `fields[search-entry] cannot combine "item" (the full serialization) with item.<field> entries`,
+    );
+  }
+  let item: SearchEntryItemSelection = itemFull
+    ? { kind: 'full' }
+    : sparseFields.length > 0
+      ? { kind: 'sparse', fields: [...new Set(sparseFields)] }
+      : { kind: 'none' };
+  return { html, item, itemAsFallback: false };
+}
+
+export function parseSearchEntryQueryFromPayload(
+  payload: unknown,
+): SearchEntryQuery {
+  if (
+    payload == null ||
+    typeof payload !== 'object' ||
+    Array.isArray(payload)
+  ) {
+    throw invalidQuery(`request body must be a JSON object`);
+  }
+  let record = payload as Record<string, unknown>;
+  for (let key of Object.keys(record)) {
+    if (!SEARCH_ENTRY_QUERY_MEMBERS.includes(key)) {
+      throw invalidQuery(`unknown member "${key}" in search-entry query`);
+    }
+  }
+
+  let realms: string[] | undefined;
+  if (record.realms !== undefined) {
+    if (
+      !Array.isArray(record.realms) ||
+      !record.realms.every((realm) => typeof realm === 'string')
+    ) {
+      throw new SearchRequestError(
+        'missing-realms',
+        'realms must be an array of strings',
+      );
+    }
+    realms = record.realms
+      .map((realm) => realm.trim())
+      .filter(Boolean)
+      .map((realm) => ensureTrailingSlash(realm));
+  }
+
+  let cardUrls: string[] | undefined;
+  if (record.cardUrls !== undefined) {
+    if (typeof record.cardUrls === 'string') {
+      cardUrls = [record.cardUrls];
+    } else if (
+      Array.isArray(record.cardUrls) &&
+      record.cardUrls.every((url) => typeof url === 'string')
+    ) {
+      cardUrls = record.cardUrls;
+    } else {
+      throw invalidQuery(`cardUrls must be a string or array of strings`);
+    }
+  }
+
+  let renderCapture: RenderConfigCapture = {};
+  let filter: Record<string, unknown> | undefined;
+  if (record.filter !== undefined) {
+    filter = translateFilterNode(record.filter, 'filter', renderCapture);
+    // A filter that carried only rendering config dissolves with the lift —
+    // the residual query matches everything.
+    if (Object.keys(filter).length === 0) {
+      filter = undefined;
+    }
+  }
+  let render = parseRenderSpec(renderCapture.renderType, renderCapture.format);
+
+  let rootAnchor = filter?.on ?? filter?.type;
+  let sort =
+    record.sort !== undefined
+      ? translateSort(record.sort, rootAnchor)
+      : undefined;
+
+  let itemQuery: Record<string, unknown> = {};
+  if (filter) {
+    itemQuery.filter = filter;
+  }
+  if (sort) {
+    itemQuery.sort = sort;
+  }
+  if (record.page !== undefined) {
+    itemQuery.page = record.page;
+  }
+  try {
+    assertQuery(itemQuery);
+  } catch (e) {
+    if (e instanceof InvalidQueryError) {
+      throw invalidQuery(e.message);
+    }
+    throw e;
+  }
+
+  let fieldset = parseFieldset(record.fields);
+
+  return {
+    itemQuery: itemQuery as Query,
+    render,
+    fieldset,
+    realms,
+    cardUrls,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Builders for the v2 resources. The projection engine runs these per row
+// when assembling a `search-entry` document; keeping them pure (no SQL, no
+// realm state) lets the shapes be unit-tested directly. The `css` resource
+// builder is shared with the pre-existing search paths (`buildCssResource`).
+// ---------------------------------------------------------------------------
+
+// One `search-entry` — the top-level `data` resource for a result. Which
+// branches it carries is the resolution policy / sparse fieldset's call; this
+// just assembles the linkage. The `item` shares the entry's URL as its id;
+// the `html` branch points at a specific rendering by its composite id.
+export function buildSearchEntryResource(args: {
+  url: string;
+  htmlId?: string;
+  itemType?: typeof CardResourceType | typeof FileMetaResourceType;
+}): SearchEntryResource {
+  let { url, htmlId, itemType } = args;
+  let resource: SearchEntryResource = {
+    type: SearchEntryResourceType,
+    id: url,
+    relationships: {},
+  };
+  if (htmlId !== undefined) {
+    resource.relationships.html = {
+      data: { type: HtmlResourceType, id: htmlId },
+    };
+  }
+  if (itemType !== undefined) {
+    resource.relationships.item = { data: { type: itemType, id: url } };
+  }
+  return resource;
+}
+
+// One `html` rendering. Its id is the (card URL, format, renderType)
+// composite — pass the same args the id derives from; `format`/`renderType`
+// are also carried as attributes (the readable form; the id is an opaque
+// cache key). `html` is absent only on an error rendering with no
+// last-known-good markup. `styles` references the rendering's `css`
+// resources by their content-hash ids.
+export function buildHtmlResource(args: {
+  url: string;
+  format: PrerenderedHtmlFormat;
+  renderType?: ResolvedCodeRef;
+  html?: string;
+  cardType: string;
+  iconHtml?: string;
+  isError?: boolean;
+  cssIds: string[];
+}): HtmlResource {
+  let { url, format, renderType, html, cardType, iconHtml, isError, cssIds } =
+    args;
+  return {
+    type: HtmlResourceType,
+    id: htmlResourceId({ url, format, renderType }),
+    attributes: {
+      ...(html !== undefined ? { html } : {}),
+      cardType,
+      ...(iconHtml ? { iconHtml } : {}),
+      ...(isError ? { isError: true } : {}),
+      format,
+      ...(renderType ? { renderType } : {}),
+    },
+    relationships: {
+      styles: {
+        data: cssIds.map((id) => ({ type: CssResourceType, id })),
+      },
+    },
+  };
+}
+
+// A field-limited (`meta.sparseFields`) projection of a full serialization:
+// only the requested fields' attributes (and the relationships rooted at a
+// requested field) ride along, and the marker records exactly what was
+// requested — so a consumer can tell "sparse" from "full but empty" and the
+// Store can refuse it. id / type / links / meta are preserved per JSON:API;
+// `meta.fields` is dropped since it describes per-field metadata for fields
+// that may not be present.
+export function buildSparseItemResource<
+  T extends CardResource<Saved> | FileMetaResource,
+>(resource: T, sparseFields: string[]): T {
+  let attributes: Record<string, any> = {};
+  for (let field of sparseFields) {
+    let path = field.split('.');
+    let value = pickAttributePath(resource.attributes, path);
+    if (value !== undefined) {
+      setAttributePath(attributes, path, value);
+    }
+  }
+  // A requested field may be a relationship (linksTo / linksToMany — plural
+  // entries serialize as `field.N` keys), keyed by its root segment.
+  let requestedRoots = new Set(sparseFields.map((f) => f.split('.')[0]));
+  let relationships: Record<string, Relationship | Relationship[]> = {};
+  for (let [key, relationship] of Object.entries(
+    resource.relationships ?? {},
+  )) {
+    if (requestedRoots.has(key.split('.')[0])) {
+      relationships[key] = relationship;
+    }
+  }
+  let { fields: _perFieldMeta, ...meta } = resource.meta;
+  let sparse = {
+    ...resource,
+    attributes,
+    meta: { ...meta, sparseFields: [...sparseFields] },
+  };
+  if (Object.keys(relationships).length > 0) {
+    sparse.relationships = relationships;
+  } else {
+    delete sparse.relationships;
+  }
+  return sparse;
+}
+
+function pickAttributePath(
+  source: Record<string, any> | undefined,
+  path: string[],
+): any {
+  let value: any = source;
+  for (let segment of path) {
+    if (value == null || typeof value !== 'object') {
+      return undefined;
+    }
+    value = value[segment];
+  }
+  return value;
+}
+
+function setAttributePath(
+  target: Record<string, any>,
+  path: string[],
+  value: any,
+): void {
+  let cursor = target;
+  for (let segment of path.slice(0, -1)) {
+    cursor = cursor[segment] ??= {};
+  }
+  cursor[path[path.length - 1]] = value;
+}

--- a/packages/runtime-common/search-entry.ts
+++ b/packages/runtime-common/search-entry.ts
@@ -1,76 +1,79 @@
 import { assertQuery, InvalidQueryError, type Query } from './query.ts';
 import { SearchRequestError } from './search-utils.ts';
-import type {
-  CardResourceType,
-  FileMetaResourceType,
-} from './resource-types.ts';
 import {
   CssResourceType,
   HtmlResourceType,
   SearchEntryResourceType,
   htmlResourceId,
   type CardResource,
+  type CardResourceType,
   type FileMetaResource,
+  type FileMetaResourceType,
+  type HtmlQuery,
   type HtmlResource,
   type Relationship,
   type Saved,
   type SearchEntryResource,
 } from './resource-types.ts';
-import type { ResolvedCodeRef } from './code-ref.ts';
+import type { CodeRef, ResolvedCodeRef } from './code-ref.ts';
 import {
   isValidPrerenderedHtmlFormat,
   PRERENDERED_HTML_FORMATS,
   type PrerenderedHtmlFormat,
 } from './prerendered-html-format.ts';
-import type { CodeRef } from './code-ref.ts';
 import { isCodeRef } from './card-document-shape.ts';
 import { generalSortFields } from './index-query-engine.ts';
 import { ensureTrailingSlash } from './paths.ts';
-import { logger } from './log.ts';
 
 // ---------------------------------------------------------------------------
 // The v2 search-entry query.
 //
-// A v2 request is one query rooted on `search-entry`, addressed through two
-// branches: `item.` (the card/file serialization) and `html.` (the
-// rendering). The filter grammar is the standard operator-keyed grammar
-// (`eq` / `contains` / `in` / `range` / `any` / `every` / `not` / `matches`)
-// — only the addressing changes:
+// A v2 request is one query rooted on `search-entry`. Entry MEMBERSHIP is
+// addressed through `item.` (the card/file serialization) with the standard
+// operator-keyed filter grammar (`eq` / `contains` / `in` / `range` / `any` /
+// `every` / `not` / `matches`) — only the addressing changes:
 //
 //   - the type anchor is `item.on` (a node carrying only the anchor is the
 //     pure card-type filter),
 //   - field paths inside the operators are reached through `item.`
 //     (`eq: { "item.status": "ready" }`),
-//   - `html.renderType` / `html.format` are rendering config spelled as `eq`
-//     predicates at the top level of `filter`. The index stores a set of
-//     renderings per entry (formats × ancestor render types), so these
-//     genuinely narrow — but they narrow which rendering satisfies the `html`
-//     branch, not entry membership: a result with no matching rendering still
-//     returns, falling back to `item`. Equality is the only meaningful
-//     predicate over a rendering dimension, so an `html.*` path under any
-//     other operator (or outside the top-level `eq`) is ignored with a logged
-//     warning,
 //   - sort keys are `item.` paths, with `item.on` as a sort entry's own
 //     anchor (a card-field sort without one inherits the filter's anchor).
+//
+// RENDERING SELECTION is bound through `htmlQuery` — a synthesized,
+// single-valued field of `search-entry` (the `html` has-many is computed from
+// it). It is bound with an ordinary `eq` in the filter's top-level node, and
+// being single-valued it can be bound exactly once: binding it in a nested
+// node, under `not`, or through any other operator is an unsatisfiable
+// binding and is rejected. Its value is a boolean sub-query over the bare
+// rendering dimensions (`format` / `renderType`): `eq` leaves composed with
+// `every` / `any` / `not`, with real boolean semantics — `not(not(q))`
+// selects exactly what `q` selects. It selects which renderings populate the
+// `html` has-many; it never affects entry membership. Omitted, the default
+// `{ eq: { format: "fitted" } }` applies; an unconstrained htmlQuery ("give
+// me everything") is unsupported and rejected. When no `renderType` predicate
+// appears anywhere in the htmlQuery, only each result's own native type
+// (`types[0]`) is in play — an explicit predicate opens the full
+// adoption-chain universe.
 //
 // `fields[search-entry]` is the sparse fieldset selecting which branches the
 // response carries: `html`, `item` (the full serialization), or
 // `item.<field>` entries (a field-limited serialization that ships
 // `meta.sparseFields` and never enters the Store). No fieldset means the
-// default resolution policy: prefer `html`, fall back to `item` where a
-// result has no HTML.
+// default resolution policy: the selected renderings, falling back to `item`
+// where none match. A fieldset that excludes `html` makes the htmlQuery
+// inert.
 //
 // The parser translates the wire query into the legacy `Query` the SQL core
-// consumes (`item.` prefixes stripped) plus the lifted render spec and the
+// consumes (`item.` prefixes stripped) plus the captured htmlQuery and the
 // parsed fieldset.
 // ---------------------------------------------------------------------------
 
 const ITEM_PREFIX = 'item.';
 const ITEM_ANCHOR = 'item.on';
-const HTML_RENDER_TYPE = 'html.renderType';
-const HTML_FORMAT = 'html.format';
+const HTML_QUERY = 'htmlQuery';
 
-export const DEFAULT_SEARCH_ENTRY_FORMAT: PrerenderedHtmlFormat = 'fitted';
+export const DEFAULT_HTML_QUERY: HtmlQuery = { eq: { format: 'fitted' } };
 
 const SEARCH_ENTRY_QUERY_MEMBERS = [
   'filter',
@@ -84,14 +87,6 @@ const SEARCH_ENTRY_QUERY_MEMBERS = [
 // The operator members whose value is an object keyed by field paths.
 const FIELD_KEYED_OPERATORS = ['eq', 'contains', 'in', 'range'];
 
-export interface SearchEntryRenderSpec {
-  // The format of the `html` branch; `html.format`, defaulting to fitted.
-  format: PrerenderedHtmlFormat;
-  // `html.renderType`: render every result as this ancestor type. Omitted →
-  // each result renders in its own actual (native) type.
-  renderType?: CodeRef;
-}
-
 // Which form of the `item` serialization the fieldset selects.
 export type SearchEntryItemSelection =
   | { kind: 'none' }
@@ -102,18 +97,19 @@ export interface SearchEntryFieldset {
   html: boolean;
   item: SearchEntryItemSelection;
   // True only in the default (no `fields` member) mode: the `item` branch
-  // appears per result, only where the result has no HTML. An explicit
-  // fieldset always pins the branches instead.
+  // appears per result, only where no rendering matched (and the empty `html`
+  // relationship is omitted). An explicit fieldset always pins the branches
+  // instead.
   itemAsFallback: boolean;
 }
 
 // The parsed form of a v2 request: the legacy `Query` for the SQL core (the
-// `item.` addressing stripped), the lifted `html.` render config, and the
-// parsed sparse fieldset. The compat layer constructs this directly from a
-// legacy request — it does not round-trip through the wire grammar.
+// `item.` addressing stripped), the applied (bound or defaulted) htmlQuery,
+// and the parsed sparse fieldset. The compat layer constructs this directly
+// from a legacy request — it does not round-trip through the wire grammar.
 export interface SearchEntryQuery {
   itemQuery: Query;
-  render: SearchEntryRenderSpec;
+  htmlQuery: HtmlQuery;
   fieldset: SearchEntryFieldset;
   realms?: string[];
   cardUrls?: string[];
@@ -123,18 +119,14 @@ function invalidQuery(message: string): SearchRequestError {
   return new SearchRequestError('invalid-query', `Invalid query: ${message}`);
 }
 
-// Lazy: a module-load `logger()` call races the circular import that installs
-// the logger factory. First emission happens well after boot.
-let searchEntryLog: ReturnType<typeof logger> | undefined;
-function warn(message: string): void {
-  (searchEntryLog ??= logger('search-entry-query')).warn(message);
+function invalidHtmlQuery(message: string): SearchRequestError {
+  return new SearchRequestError('invalid-render', message);
 }
 
-// The `html.*` rendering config captured out of the filter's top-level `eq`.
-// Values are validated by `parseRenderSpec` after the walk.
-interface RenderConfigCapture {
-  renderType?: unknown;
-  format?: unknown;
+// The htmlQuery binding captured out of the filter's top-level `eq`. The
+// value is validated by `assertHtmlQuery` after the walk.
+interface HtmlQueryCapture {
+  htmlQuery?: unknown;
 }
 
 function stripItemPrefix(fieldPath: string, pointer: string): string {
@@ -149,46 +141,193 @@ function stripItemPrefix(fieldPath: string, pointer: string): string {
   return fieldPath.slice(ITEM_PREFIX.length);
 }
 
-// The `html.` rendering config — top-level members of the query.
-function parseRenderSpec(
-  renderType: unknown,
-  format: unknown,
-): SearchEntryRenderSpec {
-  let render: SearchEntryRenderSpec = { format: DEFAULT_SEARCH_ENTRY_FORMAT };
-  if (format !== undefined) {
-    if (typeof format !== 'string' || !isValidPrerenderedHtmlFormat(format)) {
-      throw new SearchRequestError(
-        'invalid-render',
-        `${HTML_FORMAT} must be one of ${PRERENDERED_HTML_FORMATS.join(', ')}`,
-      );
-    }
-    render.format = format;
+// Validates a bound htmlQuery value: one connective or `eq` leaf per node,
+// leaves constrain at least one rendering dimension. An unconstrained query
+// (an empty leaf or an empty connective) is unsupported — there is no "give
+// me everything" spelling.
+export function assertHtmlQuery(
+  value: unknown,
+  pointer = HTML_QUERY,
+): asserts value is HtmlQuery {
+  if (typeof value !== 'object' || value == null || Array.isArray(value)) {
+    throw invalidHtmlQuery(`${pointer}: htmlQuery must be an object`);
   }
-  if (renderType !== undefined) {
-    if (!isCodeRef(renderType)) {
-      throw new SearchRequestError(
-        'invalid-render',
-        `${HTML_RENDER_TYPE} must be a CodeRef`,
-      );
-    }
-    render.renderType = renderType;
+  let keys = Object.keys(value);
+  if (keys.length !== 1) {
+    throw invalidHtmlQuery(
+      `${pointer}: an htmlQuery node must have exactly one of eq, every, any, not`,
+    );
   }
-  return render;
+  let [key] = keys;
+  let inner = (value as Record<string, unknown>)[key];
+  switch (key) {
+    case 'eq': {
+      if (typeof inner !== 'object' || inner == null || Array.isArray(inner)) {
+        throw invalidHtmlQuery(`${pointer}/eq: eq must be an object`);
+      }
+      let leaf = inner as Record<string, unknown>;
+      let leafKeys = Object.keys(leaf);
+      if (leafKeys.length === 0) {
+        throw invalidHtmlQuery(
+          `${pointer}/eq: an unconstrained htmlQuery is unsupported — constrain format and/or renderType`,
+        );
+      }
+      for (let leafKey of leafKeys) {
+        if (leafKey === 'format') {
+          if (
+            typeof leaf.format !== 'string' ||
+            !isValidPrerenderedHtmlFormat(leaf.format)
+          ) {
+            throw invalidHtmlQuery(
+              `${pointer}/eq/format: format must be one of ${PRERENDERED_HTML_FORMATS.join(', ')}`,
+            );
+          }
+        } else if (leafKey === 'renderType') {
+          if (!isCodeRef(leaf.renderType)) {
+            throw invalidHtmlQuery(
+              `${pointer}/eq/renderType: renderType must be a CodeRef`,
+            );
+          }
+        } else {
+          throw invalidHtmlQuery(
+            `${pointer}/eq: unknown rendering dimension "${leafKey}" — the dimensions are format and renderType`,
+          );
+        }
+      }
+      return;
+    }
+    case 'every':
+    case 'any': {
+      if (!Array.isArray(inner) || inner.length === 0) {
+        throw invalidHtmlQuery(
+          `${pointer}/${key}: ${key} must be a non-empty array`,
+        );
+      }
+      inner.forEach((entry, i) =>
+        assertHtmlQuery(entry, `${pointer}/${key}[${i}]`),
+      );
+      return;
+    }
+    case 'not': {
+      assertHtmlQuery(inner, `${pointer}/not`);
+      return;
+    }
+    default:
+      throw invalidHtmlQuery(
+        `${pointer}: unknown htmlQuery member "${key}" — an htmlQuery node has exactly one of eq, every, any, not`,
+      );
+  }
 }
+
+// Whether any renderType predicate appears in the htmlQuery (negated ones
+// count). When none does, only each result's own native type is in play; an
+// explicit predicate opens the full adoption-chain universe.
+export function htmlQueryHasRenderTypePredicate(query: HtmlQuery): boolean {
+  if ('eq' in query) {
+    return query.eq.renderType !== undefined;
+  }
+  if ('every' in query) {
+    return query.every.some(htmlQueryHasRenderTypePredicate);
+  }
+  if ('any' in query) {
+    return query.any.some(htmlQueryHasRenderTypePredicate);
+  }
+  return htmlQueryHasRenderTypePredicate(query.not);
+}
+
+// ---------------------------------------------------------------------------
+// htmlQuery evaluation. The engine enumerates each row's candidate renderings
+// and evaluates the htmlQuery per candidate — proper boolean semantics over
+// the rendering universe, so negation composes (involution holds). The
+// renderType CodeRefs in the query are resolved to their `<module>/<name>`
+// keys once (`resolveHtmlQuery`), then the pure evaluator runs per candidate.
+// ---------------------------------------------------------------------------
+
+// One candidate rendering of a row: a (format, renderType) point in the
+// row's rendering set. A file rendering carries no renderTypeKey (files
+// render natively), so a renderType predicate never matches it — positively
+// or under an even number of negations.
+export interface RenderingCandidate {
+  format: PrerenderedHtmlFormat;
+  renderTypeKey?: string;
+}
+
+export type ResolvedHtmlQuery =
+  | { eq: { format?: PrerenderedHtmlFormat; renderTypeKey?: string } }
+  | { every: ResolvedHtmlQuery[] }
+  | { any: ResolvedHtmlQuery[] }
+  | { not: ResolvedHtmlQuery };
+
+export function resolveHtmlQuery(
+  query: HtmlQuery,
+  resolveRenderTypeKey: (ref: CodeRef) => string,
+): ResolvedHtmlQuery {
+  if ('eq' in query) {
+    let { format, renderType } = query.eq;
+    return {
+      eq: {
+        ...(format !== undefined ? { format } : {}),
+        ...(renderType !== undefined
+          ? { renderTypeKey: resolveRenderTypeKey(renderType) }
+          : {}),
+      },
+    };
+  }
+  if ('every' in query) {
+    return {
+      every: query.every.map((q) => resolveHtmlQuery(q, resolveRenderTypeKey)),
+    };
+  }
+  if ('any' in query) {
+    return {
+      any: query.any.map((q) => resolveHtmlQuery(q, resolveRenderTypeKey)),
+    };
+  }
+  return { not: resolveHtmlQuery(query.not, resolveRenderTypeKey) };
+}
+
+export function htmlQueryMatches(
+  query: ResolvedHtmlQuery,
+  candidate: RenderingCandidate,
+): boolean {
+  if ('eq' in query) {
+    let { format, renderTypeKey } = query.eq;
+    if (format !== undefined && candidate.format !== format) {
+      return false;
+    }
+    if (
+      renderTypeKey !== undefined &&
+      candidate.renderTypeKey !== renderTypeKey
+    ) {
+      return false;
+    }
+    return true;
+  }
+  if ('every' in query) {
+    return query.every.every((q) => htmlQueryMatches(q, candidate));
+  }
+  if ('any' in query) {
+    return query.any.some((q) => htmlQueryMatches(q, candidate));
+  }
+  return !htmlQueryMatches(query.not, candidate);
+}
+
+// ---------------------------------------------------------------------------
+// Request parsing.
+// ---------------------------------------------------------------------------
 
 // Translate one filter node from `item.` addressing to the legacy grammar:
 // `item.on` → `on`, field paths inside the operators stripped of their
 // `item.` prefix, connectives recursed. The structure (which operators nest
 // where) is untouched — `assertQuery` validates the translated result.
 //
-// `capture` is present only on the root node: `html.*` paths in the root
-// node's `eq` are lifted into it. Anywhere else — another operator, or any
-// nested node — an `html.*` path is ignored with a logged warning (equality
-// at the top level is the only meaningful spelling for rendering config).
+// `capture` is present only on the root node: an `htmlQuery` binding in the
+// root node's `eq` is lifted into it. Anywhere else the binding is
+// unsatisfiable (a single-valued field binds once) and rejected.
 function translateFilterNode(
   node: unknown,
   pointer: string,
-  capture?: RenderConfigCapture,
+  capture?: HtmlQueryCapture,
 ): Record<string, unknown> {
   if (typeof node !== 'object' || node == null || Array.isArray(node)) {
     throw invalidQuery(`${pointer}: filter must be an object`);
@@ -212,9 +351,9 @@ function translateFilterNode(
         `${pointer}/${key}`,
         key === 'eq' ? capture : undefined,
       );
-      // An operator that carried only html.* entries (lifted or ignored)
-      // vanishes with them; a user-authored empty operator is preserved for
-      // assertQuery to reject.
+      // An eq that carried only the htmlQuery binding vanishes with the lift;
+      // a user-authored empty operator is preserved for assertQuery to
+      // reject.
       if (
         Object.keys(translated).length === 0 &&
         Object.keys(value as object).length > 0
@@ -225,9 +364,9 @@ function translateFilterNode(
     } else if (key === 'matches') {
       // Full-text match over the whole document — no field path to address.
       out.matches = value;
-    } else if (key === HTML_RENDER_TYPE || key === HTML_FORMAT) {
-      throw invalidQuery(
-        `${pointer}/${key}: ${key} is an eq predicate — spell it eq: { "${key}": … }`,
+    } else if (key === HTML_QUERY) {
+      throw invalidHtmlQuery(
+        `${pointer}/${HTML_QUERY}: ${HTML_QUERY} is a field — bind it with eq: { "${HTML_QUERY}": … }`,
       );
     } else {
       throw invalidQuery(
@@ -249,7 +388,7 @@ function translateFilterNode(
 function translateFieldKeys(
   value: unknown,
   pointer: string,
-  capture: RenderConfigCapture | undefined,
+  capture: HtmlQueryCapture | undefined,
 ): Record<string, unknown> {
   if (typeof value !== 'object' || value == null || Array.isArray(value)) {
     throw invalidQuery(
@@ -258,16 +397,12 @@ function translateFieldKeys(
   }
   let out: Record<string, unknown> = {};
   for (let [fieldPath, fieldValue] of Object.entries(value)) {
-    if (fieldPath === HTML_RENDER_TYPE || fieldPath === HTML_FORMAT) {
+    if (fieldPath === HTML_QUERY) {
       if (capture) {
-        if (fieldPath === HTML_RENDER_TYPE) {
-          capture.renderType = fieldValue;
-        } else {
-          capture.format = fieldValue;
-        }
+        capture.htmlQuery = fieldValue;
       } else {
-        warn(
-          `${pointer}/${fieldPath}: ${fieldPath} is rendering config and supports only the eq operator at the top level of filter — ignoring`,
+        throw invalidHtmlQuery(
+          `${pointer}/${HTML_QUERY}: ${HTML_QUERY} is a single-valued synthesized field — bind it once, in the filter's top-level eq`,
         );
       }
       continue;
@@ -322,8 +457,8 @@ function translateSort(value: unknown, rootAnchor: unknown): unknown[] {
 
 function parseFieldset(fields: unknown): SearchEntryFieldset {
   if (fields === undefined) {
-    // No fieldset → the default resolution policy: prefer html, fall back to
-    // the item serialization where a result has no HTML.
+    // No fieldset → the default resolution policy: the selected renderings,
+    // falling back to the item serialization where none match.
     return { html: true, item: { kind: 'none' }, itemAsFallback: true };
   }
   if (typeof fields !== 'object' || fields == null || Array.isArray(fields)) {
@@ -423,17 +558,23 @@ export function parseSearchEntryQueryFromPayload(
     }
   }
 
-  let renderCapture: RenderConfigCapture = {};
+  let capture: HtmlQueryCapture = {};
   let filter: Record<string, unknown> | undefined;
   if (record.filter !== undefined) {
-    filter = translateFilterNode(record.filter, 'filter', renderCapture);
-    // A filter that carried only rendering config dissolves with the lift —
-    // the residual query matches everything.
+    filter = translateFilterNode(record.filter, 'filter', capture);
+    // A filter that carried only the htmlQuery binding dissolves with the
+    // lift — the residual query matches everything.
     if (Object.keys(filter).length === 0) {
       filter = undefined;
     }
   }
-  let render = parseRenderSpec(renderCapture.renderType, renderCapture.format);
+  let htmlQuery: HtmlQuery;
+  if (capture.htmlQuery !== undefined) {
+    assertHtmlQuery(capture.htmlQuery);
+    htmlQuery = capture.htmlQuery;
+  } else {
+    htmlQuery = DEFAULT_HTML_QUERY;
+  }
 
   let rootAnchor = filter?.on ?? filter?.type;
   let sort =
@@ -464,7 +605,7 @@ export function parseSearchEntryQueryFromPayload(
 
   return {
     itemQuery: itemQuery as Query,
-    render,
+    htmlQuery,
     fieldset,
     realms,
     cardUrls,
@@ -481,21 +622,24 @@ export function parseSearchEntryQueryFromPayload(
 // One `search-entry` — the top-level `data` resource for a result. Which
 // branches it carries is the resolution policy / sparse fieldset's call; this
 // just assembles the linkage. The `item` shares the entry's URL as its id;
-// the `html` branch points at a specific rendering by its composite id.
+// each `html` member points at one specific rendering by its composite id.
+// `htmlIds` undefined omits the relationship (the default mode's fallback
+// rows); an empty array emits `data: []` (a pinned html branch with no
+// matching rendering yet).
 export function buildSearchEntryResource(args: {
   url: string;
-  htmlId?: string;
+  htmlIds?: string[];
   itemType?: typeof CardResourceType | typeof FileMetaResourceType;
 }): SearchEntryResource {
-  let { url, htmlId, itemType } = args;
+  let { url, htmlIds, itemType } = args;
   let resource: SearchEntryResource = {
     type: SearchEntryResourceType,
     id: url,
     relationships: {},
   };
-  if (htmlId !== undefined) {
+  if (htmlIds !== undefined) {
     resource.relationships.html = {
-      data: { type: HtmlResourceType, id: htmlId },
+      data: htmlIds.map((id) => ({ type: HtmlResourceType, id })),
     };
   }
   if (itemType !== undefined) {


### PR DESCRIPTION
One underlying search engine for the unified-search v2 model ([CS-11492](https://linear.app/cardstack/issue/CS-11492/unified-search-v2-search-engine-search-entry-model-item-query)). This is an **internal library only** — no endpoint wiring; nothing reachable changes until the v2 endpoints and compat layer land on top of it.

## The wire model

A v2 result is a `search-entry` (id = card/file URL). Conceptually:

```
SearchEntry
  attributes: htmlQuery   // synthesized, single-valued — bound by the request
  hasOne:  item           // the card/file-meta serialization
  hasMany: html           // the renderings selected by htmlQuery
```

- `html` (**has-many**) → the prerendered renderings the htmlQuery selects from the entry's indexed rendering set (formats × ancestor render types). Each member's id is the cacheable composite `<cardURL>#<format>#<module>/<name>`; `format`/`renderType` also ride as attributes; `styles` references first-class `css` resources deduped by content hash. An **empty array** means the entry matched but no rendering satisfies the htmlQuery yet — membership stays visible and a later refresh fills it in.
- `item` → the live `card`/`file-meta` serialization, full or field-limited. A field-limited item carries `meta.sparseFields` (the authoritative sparse marker — it must never enter the host Store).

A default (no fieldset) response with one html-backed result and one result whose rendering hasn't been indexed yet (it falls back to its `item`, omitting the `html` relationship):

```jsonc
{
  "data": [
    { "type": "search-entry", "id": "https://realm/john",
      "relationships": {
        "html": { "data": [{ "type": "html", "id": "https://realm/john#fitted#https://realm/person/Person" }] }
      } },
    { "type": "search-entry", "id": "https://realm/jane",
      "relationships": {
        "item": { "data": { "type": "card", "id": "https://realm/jane" } }
      } }
  ],
  "included": [
    { "type": "html", "id": "https://realm/john#fitted#https://realm/person/Person",
      "attributes": {
        "html": "<div …>Fitted Card Person: John</div>",
        "cardType": "Person",
        "iconHtml": "<svg …>",
        "format": "fitted",
        "renderType": { "module": "https://realm/person", "name": "Person" }
      },
      "relationships": { "styles": { "data": [{ "type": "css", "id": "b1946ac92492" }] } } },
    { "type": "css", "id": "b1946ac92492",
      "attributes": { "href": "https://realm/person.gts.<base64-css>.glimmer-scoped.css" } },
    { "type": "card", "id": "https://realm/jane",
      "attributes": { "firstName": "Jane" },
      "meta": { "adoptsFrom": { "module": "https://realm/person", "name": "Person" },
                "realmInfo": { "name": "…", … } },
      "links": { "self": "https://realm/jane" } }
  ],
  "meta": {
    "page": { "total": 2 },
    "htmlQuery": { "eq": { "format": "fitted" } }   // the applied (here: default) htmlQuery, echoed once
  }
}
```

When the fieldset explicitly pins `html` (`fields[search-entry]=html`), a matched-but-unrendered entry instead carries an empty has-many: `"html": { "data": [] }`. With `fields[search-entry]=item.firstName` the `item` ships only the requested attributes plus the marker: `"attributes": { "firstName": "Jane" }, "meta": { …, "sparseFields": ["firstName"] }`.

## The query

One query rooted on `search-entry`. Entry **membership** uses the standard operator-keyed filter grammar with `item.` addressing; **rendering selection** is bound through the `htmlQuery` synthesized field, with an ordinary `eq` in the filter's top-level node:

```jsonc
{
  "filter": {
    "item.on": { "module": "…/person", "name": "Person" },   // type anchor
    "eq": {
      "item.status": "ready",            // fields addressed through item.
      "htmlQuery": {                     // binds the rendering selection
        "every": [
          { "eq": { "format": "embedded" } },
          { "eq": { "renderType": { "module": "…", "name": "…" } } }
        ]
      }
    }
  },
  "sort": [{ "by": "item.title", "direction": "asc" }],
  "fields": { "search-entry": ["html"] }  // html | item | item.<field>
}
```

The htmlQuery's value is a **boolean sub-query over the rendering dimensions** (bare `format`/`renderType`): `eq` leaves composed with `every`/`any`/`not`, with real boolean semantics — `not(not(q))` selects exactly what `q` selects (proven by test), and a disjunction like "embedded or fitted" puts several `html` members on one entry. It selects which renderings populate the has-many, **never entry membership**.

The rules around it:

- **Bind-once** — a single-valued field binds exactly once, in the top-level `eq`; binding it nested, under `not`, or through another operator is an unsatisfiable binding and rejected.
- **Default** — omitted → `{ "eq": { "format": "fitted" } }` with the native render type. The **native rule**: no `renderType` predicate anywhere (including negated) → only each result's own type (`types[0]`) is in play; an explicit predicate opens the full adoption-chain universe.
- **No "everything" spelling** — an unconstrained htmlQuery is rejected (unimplemented until a consumer could use it).
- **Echo** — the applied value is echoed once as `meta.htmlQuery` (it cannot vary across entries).
- **Fields interplay** — a fieldset that excludes `html` makes the htmlQuery inert (no error, no echo).

## The engine

`RealmIndexQueryEngine.searchEntries()` drives the shared `_search()` SQL core with a projection per fieldset — `dataOnly` (item only) or the new `renderSet`, which selects each row's **full rendering set** (the per-format HTML columns, JSONB maps whole) plus the live serialization. The mapper enumerates candidate `(format, renderType, html)` renderings per row, evaluates the htmlQuery per candidate, and assembles `search-entry` + `html[]` (+ deduped `css`) + `item` resources per the fieldset, expanding links for full items only and stamping `meta.realmInfo` on items exactly as the live search path does. File-meta queries route through the per-format file path — a file renders natively, so its renderings carry no renderType (id `<fileURL>#<format>`) and a renderType predicate never matches them.

## Tests

- `search-entry-test.ts` — pure parser/evaluator/builder coverage: canonical query translation, the htmlQuery capture, bind-once rejections, value validation, **involution and complement property tests** against a rendering universe, native-rule detection through connectives and negation, sparse fieldsets, composite-id encoding, sparse-item projection.
- `search-entries-engine-test.ts` — the engine over indexed realms: default fieldset with the echoed default htmlQuery, explicit format selection, **disjunctive htmlQuery → several renderings per entry**, engine-level involution, htmlQuery-inert item fieldsets, sparse items, sort/page passthrough, mixed-index fallback (default mode omits `html`; a pinned fieldset yields the empty array), native rule + explicit-ancestor + **negated renderType** selection, css dedup across instances, and file results through the same semantics.
