### PR TITLE
Collapse repeated module-graph walks in dependency tracking

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -85,6 +85,7 @@ import {
   CardResource,
   LooseLinkableResource,
   LooseSingleResourceDocument,
+  shouldTrackRuntimeModuleGraph,
   trackRuntimeFileDependency,
   trackRuntimeInstanceDependency,
   trackRuntimeModuleDependency,
@@ -3845,6 +3846,23 @@ function trackRuntimeRelationshipModuleDependencies(
     return;
   }
 
+  // This walk repeats once per element of a linksToMany (and again on every
+  // getter re-read), but records the identical node set every time, so it only
+  // needs to run once per (context, type module) per tracking session. The
+  // probe collapses each repeat to a single Set lookup — without it, a
+  // linksToMany of N same-typed cards re-tracks the type's entire module graph
+  // N times per read, and that per-call tracking overhead dominates aggregate
+  // renders.
+  if (
+    !shouldTrackRuntimeModuleGraph(
+      'relationship',
+      identity.module,
+      dependencyTrackingContext,
+    )
+  ) {
+    return;
+  }
+
   trackRuntimeModuleDependency(identity.module, dependencyTrackingContext);
 
   let loader = Loader.getLoaderFor(ctor);
@@ -3852,10 +3870,6 @@ function trackRuntimeRelationshipModuleDependencies(
     return;
   }
 
-  // getKnownConsumedModules is fast now: the Loader caches the dependency
-  // graph traversal result in collectKnownModuleDependencies, and
-  // trimModuleIdentifier uses string ops + a cache instead of URL
-  // construction. No need for a caller-side skip cache here.
   for (let dep of loader.getKnownConsumedModules(identity.module)) {
     trackRuntimeModuleDependency(dep, dependencyTrackingContext);
   }

--- a/packages/realm-server/tests/runtime-dependency-tracker-test.ts
+++ b/packages/realm-server/tests/runtime-dependency-tracker-test.ts
@@ -5,6 +5,7 @@ import {
   beginRuntimeDependencyTrackingSession,
   endRuntimeDependencyTrackingSession,
   resetRuntimeDependencyTracker,
+  shouldTrackRuntimeModuleGraph,
   snapshotRuntimeDependencies,
   trackRuntimeFileDependency,
   trackRuntimeInstanceDependency,
@@ -484,6 +485,200 @@ module(basename(__filename), function (hooks) {
     assert.notOk(
       snapshot.deps.includes('https://example.com/hidden-link.json'),
       'non-rendered relationship target is not captured',
+    );
+  });
+
+  test('module-graph probe permits a walk exactly once per context per session', function (assert) {
+    let moduleURL = 'https://example.com/cards/aggregate.gts';
+    let queryContext = {
+      mode: 'query' as const,
+      queryField: 'members',
+      source: 'test:graph-probe',
+      consumer: 'https://example.com/root.json',
+      consumerKind: 'instance' as const,
+    };
+
+    assert.false(
+      shouldTrackRuntimeModuleGraph('relationship', moduleURL, queryContext),
+      'inactive tracker permits no walk (nothing would record)',
+    );
+
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: 'graph-probe',
+      rootURL: 'https://example.com/root.json',
+      rootKind: 'instance',
+    });
+
+    assert.true(
+      shouldTrackRuntimeModuleGraph('relationship', moduleURL, queryContext),
+      'first probe under an active session permits the walk',
+    );
+    assert.false(
+      shouldTrackRuntimeModuleGraph('relationship', moduleURL, queryContext),
+      'repeat probe with an equivalent context is collapsed',
+    );
+    assert.false(
+      shouldTrackRuntimeModuleGraph('relationship', moduleURL, {
+        ...queryContext,
+      }),
+      'equivalence is by value, not object identity',
+    );
+
+    assert.true(
+      shouldTrackRuntimeModuleGraph('import', moduleURL, queryContext),
+      'a different scope walks again (sites record different node sets)',
+    );
+    assert.true(
+      shouldTrackRuntimeModuleGraph('relationship', moduleURL, {
+        ...queryContext,
+        mode: 'non-query',
+      }),
+      'a different mode walks again (query-only classification must not stick)',
+    );
+    assert.true(
+      shouldTrackRuntimeModuleGraph('relationship', moduleURL, {
+        ...queryContext,
+        consumer: 'https://example.com/other-consumer.json',
+      }),
+      'a different consumer walks again',
+    );
+    assert.true(
+      shouldTrackRuntimeModuleGraph(
+        'relationship',
+        'https://example.com/cards/other-type.gts',
+        queryContext,
+      ),
+      'a different root module walks again',
+    );
+
+    resetRuntimeDependencyTracker();
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: 'graph-probe',
+      rootURL: 'https://example.com/root.json',
+      rootKind: 'instance',
+    });
+    assert.true(
+      shouldTrackRuntimeModuleGraph('relationship', moduleURL, queryContext),
+      'reset clears walk markers so a fresh session re-walks',
+    );
+  });
+
+  test('module-graph probe with no explicit context dedups via the active context', async function (assert) {
+    let moduleURL = 'https://example.com/cards/aggregate.gts';
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: 'graph-probe-stack-context',
+      rootURL: 'https://example.com/root.json',
+      rootKind: 'instance',
+    });
+
+    await withRuntimeDependencyTrackingContext(
+      {
+        mode: 'non-query',
+        source: 'test:stack-context',
+        consumer: 'https://example.com/root.json',
+        consumerKind: 'instance',
+      },
+      async () => {
+        assert.true(
+          shouldTrackRuntimeModuleGraph('relationship', moduleURL),
+          'first probe inside a context scope permits the walk',
+        );
+        assert.false(
+          shouldTrackRuntimeModuleGraph('relationship', moduleURL),
+          'repeat probe inside the same scope is collapsed',
+        );
+      },
+    );
+    // A fresh withContext scope builds a new context object, but its
+    // recording-relevant fields are identical — the walk must stay collapsed
+    // (this is the repeat-getter-invocation case object-identity dedup misses).
+    await withRuntimeDependencyTrackingContext(
+      {
+        mode: 'non-query',
+        source: 'test:stack-context',
+        consumer: 'https://example.com/root.json',
+        consumerKind: 'instance',
+      },
+      async () => {
+        assert.false(
+          shouldTrackRuntimeModuleGraph('relationship', moduleURL),
+          'an equivalent later scope is still collapsed (value equivalence)',
+        );
+      },
+    );
+  });
+
+  test('imports under query then non-query contexts leave module deps non-query', async function (assert) {
+    // The import-time module-graph walk is skipped on repeats; mode is part of
+    // the walk identity, so a graph first walked under a query context must
+    // still re-walk under a later non-query context — otherwise its modules
+    // would be misclassified query-only and excluded from deps.
+    let loader = new Loader(
+      async () => new Response('export const value = 1;', { status: 200 }),
+    );
+    let moduleURL = 'https://example.com/cards/query-then-non-query.gts';
+
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: 'import-mode-transition',
+      rootURL: 'https://example.com/root.json',
+      rootKind: 'instance',
+    });
+    let queryContext = {
+      mode: 'query' as const,
+      queryField: 'matches',
+      source: 'test:import-query',
+      consumer: 'https://example.com/root.json',
+      consumerKind: 'instance' as const,
+    };
+    let nonQueryContext = {
+      mode: 'non-query' as const,
+      source: 'test:import-non-query',
+      consumer: 'https://example.com/root.json',
+      consumerKind: 'instance' as const,
+    };
+    await loader.import(moduleURL, queryContext);
+    await loader.import(moduleURL, nonQueryContext);
+
+    let snapshot = snapshotRuntimeDependencies({ excludeQueryOnly: true });
+    assert.true(
+      snapshot.deps.includes('https://example.com/cards/query-then-non-query'),
+      'module imported under both modes is retained in deps',
+    );
+    assert.notOk(
+      snapshot.excludedQueryOnlyDeps.includes(
+        'https://example.com/cards/query-then-non-query',
+      ),
+      'module is not misclassified as query-only',
+    );
+  });
+
+  test('repeat imports in one session still record module deps', async function (assert) {
+    let loader = new Loader(
+      async () => new Response('export const value = 1;', { status: 200 }),
+    );
+    let moduleURL = 'https://example.com/cards/repeat-import.gts';
+
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: 'repeat-import',
+      rootURL: 'https://example.com/root.json',
+      rootKind: 'instance',
+    });
+    let context = {
+      mode: 'non-query' as const,
+      source: 'test:repeat-import',
+      consumer: 'https://example.com/root.json',
+      consumerKind: 'instance' as const,
+    };
+    // Models deserializing many cards of one type: each deserialization
+    // imports the same module. The collapsed repeats must not lose the dep.
+    for (let i = 0; i < 3; i++) {
+      await loader.import(moduleURL, context);
+    }
+
+    let snapshot = snapshotRuntimeDependencies({ excludeQueryOnly: true });
+    assert.true(
+      snapshot.deps.includes('https://example.com/cards/repeat-import'),
+      'module dep is recorded once across repeated imports',
     );
   });
 });

--- a/packages/realm-server/tests/runtime-dependency-tracker-test.ts
+++ b/packages/realm-server/tests/runtime-dependency-tracker-test.ts
@@ -523,6 +523,13 @@ module(basename(__filename), function (hooks) {
       }),
       'equivalence is by value, not object identity',
     );
+    assert.false(
+      shouldTrackRuntimeModuleGraph('relationship', moduleURL, {
+        ...queryContext,
+        consumerKind: undefined,
+      }),
+      "an omitted consumerKind dedups against the recorded default ('instance')",
+    );
 
     assert.true(
       shouldTrackRuntimeModuleGraph('import', moduleURL, queryContext),

--- a/packages/runtime-common/dependency-tracker.ts
+++ b/packages/runtime-common/dependency-tracker.ts
@@ -239,11 +239,18 @@ export class RuntimeDependencyTracker {
       return false;
     }
     let context = explicitContext ?? this.#currentContext();
+    // consumerKind only influences recording when a consumer is present, and
+    // then it defaults to 'instance' (mirroring #normalizeConsumer) — fold the
+    // same resolution into the key so an omitted consumerKind dedups against
+    // an explicit 'instance'.
+    let consumerKind = context.consumer
+      ? (context.consumerKind ?? 'instance')
+      : '';
     let key = [
       scope,
       contextLabel(context),
       context.consumer ?? '',
-      context.consumerKind ?? '',
+      consumerKind,
       rootModule,
     ].join(CACHE_KEY_SEPARATOR);
     if (this.#trackedModuleGraphs.has(key)) {

--- a/packages/runtime-common/dependency-tracker.ts
+++ b/packages/runtime-common/dependency-tracker.ts
@@ -171,6 +171,15 @@ export class RuntimeDependencyTracker {
     Set<string>
   >();
 
+  // Walk-level dedup for module-graph traversals (see shouldTrackModuleGraph).
+  // Keyed by value — every context dimension that affects how a node is
+  // recorded — so it collapses repeats that the identity-keyed
+  // #trackedByContext cannot: explicit contexts (exempt from identity dedup)
+  // and fresh merged contexts built by each withContext scope. Cleared in
+  // reset() alongside #nodes so a cleared node map never inherits a stale
+  // "already walked" marker that would drop real dependencies.
+  #trackedModuleGraphs = new Set<string>();
+
   startSession({
     sessionKey,
     rootURL,
@@ -198,6 +207,50 @@ export class RuntimeDependencyTracker {
     this.#contextStack = [];
     this.#normalizeCache.clear();
     this.#trackedByContext = new WeakMap();
+    this.#trackedModuleGraphs.clear();
+  }
+
+  // A module-graph walk (tracking a module plus its transitive consumed
+  // modules) records an identical node set every time it repeats under an
+  // equivalent context, so the walk only needs to run once per session — but
+  // the walks repeat heavily: every linksTo/linksToMany getter invocation
+  // re-walks the linked type's graph once PER ELEMENT, multiplying render cost
+  // by the graph size. Deduping inside #track can't help; by then the
+  // composite-key build + hash (the actual cost) is already paid. This probe
+  // lets callers skip the whole walk for the price of one Set lookup.
+  //
+  // Returns true exactly once per (scope, root module, recording-relevant
+  // context) per session; the caller must then perform the full walk. The key
+  // folds in contextLabel, consumer, and consumerKind — everything #track
+  // derives from a context when recording — so a skipped repeat is a provable
+  // no-op. `scope` namespaces call sites whose walks record different node
+  // sets (e.g. one excludes shimmed modules), keeping a probe at one site from
+  // suppressing a non-identical walk at another.
+  //
+  // Returns false while inactive: nothing records when inactive, so the walk
+  // would be pure waste, and nothing is marked so the walk still runs in a
+  // later active session.
+  shouldTrackModuleGraph(
+    scope: string,
+    rootModule: string,
+    explicitContext?: RuntimeDependencyTrackingContext,
+  ): boolean {
+    if (!this.#isActive) {
+      return false;
+    }
+    let context = explicitContext ?? this.#currentContext();
+    let key = [
+      scope,
+      contextLabel(context),
+      context.consumer ?? '',
+      context.consumerKind ?? '',
+      rootModule,
+    ].join(CACHE_KEY_SEPARATOR);
+    if (this.#trackedModuleGraphs.has(key)) {
+      return false;
+    }
+    this.#trackedModuleGraphs.add(key);
+    return true;
   }
 
   withContext<T>(context: RuntimeDependencyTrackingContext, cb: () => T): T {
@@ -464,6 +517,14 @@ export function trackRuntimeModuleDependency(
   context?: RuntimeDependencyTrackingContext,
 ): void {
   getTracker().trackModule(url, context);
+}
+
+export function shouldTrackRuntimeModuleGraph(
+  scope: string,
+  rootModule: string,
+  context?: RuntimeDependencyTrackingContext,
+): boolean {
+  return getTracker().shouldTrackModuleGraph(scope, rootModule, context);
 }
 
 export function trackRuntimeInstanceDependency(

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -6,6 +6,7 @@ import { executableExtensions, logger } from './index.ts';
 import { CardError, iconNotFoundMessage } from './error.ts';
 import flatMap from 'lodash/flatMap';
 import {
+  shouldTrackRuntimeModuleGraph,
   trackRuntimeModuleDependency,
   type RuntimeDependencyTrackingContext,
 } from './dependency-tracker.ts';
@@ -447,6 +448,20 @@ export class Loader {
     rootModuleIdentifier: string,
     dependencyTrackingContext?: RuntimeDependencyTrackingContext,
   ): void {
+    // This walk repeats on every import() of the same module (e.g. when
+    // deserializing many cards of one type) yet records the identical node set
+    // each time; the probe collapses repeats to one Set lookup. Scoped apart
+    // from the relationship walk because this one excludes shimmed modules, so
+    // the two record slightly different node sets.
+    if (
+      !shouldTrackRuntimeModuleGraph(
+        'import',
+        rootModuleIdentifier,
+        dependencyTrackingContext,
+      )
+    ) {
+      return;
+    }
     for (let moduleIdentifier of this.collectKnownModuleDependencies(
       rootModuleIdentifier,
     )) {


### PR DESCRIPTION
Aggregate cards with many linked same-typed members spend most of their prerender time in runtime dependency tracking. A CPU profile of the slowest such render (29.6s, from a staging from-scratch index) attributes 77% of the render to tracking calls — and 0.00% to the URL canonicalization those calls feed, which is already memoized. The cost is purely the *number* of track calls, each paying a composite-key build and hash on a ~100-char string.

The calls multiply three ways: every `linksTo`/`linksToMany` getter invocation re-tracks; `trackRuntimeRelationshipDependencies` loops every element; and `trackRuntimeRelationshipModuleDependencies` walks the element type's entire module graph once per element. `loader.import()` repeats the same full-graph walk per call (e.g. once per deserialized card of a type). The existing dedups can't catch this: explicit contexts (which query-backed fields always pass) are deliberately exempt from the identity-keyed dedup, non-explicit scopes build a fresh merged context object each time so identity never matches, and both dedups sit inside `#track` — below the loop — so even a hit pays the key build + hash.

This adds a session-scoped once-probe, `shouldTrackModuleGraph`, keyed by value on every context dimension that affects how a node is recorded (context label, consumer, consumerKind) plus a per-site scope, and guards both walk sites with it. A repeat walk now costs one `Set` lookup instead of one tracking call per module in the graph — O(I·N·M) → O(I·N + M). The probe returns `false` while the tracker is inactive, so live-app field reads no longer iterate module graphs just to no-op inside each track call.

Skipping repeats is sound because the loader's `knownDepsCache` freezes a root module's dep set on first traversal: a repeat walk always replays an identical list, so a skip can never drop a dep the walk would have recorded. Mode is part of the walk identity, so a graph first walked under a query context still re-walks under a later non-query context rather than leaving its modules stuck in query-only classification (which would wrongly exclude them from `deps`). The two guarded sites use distinct scopes because their walks record slightly different node sets (the loader's excludes shimmed modules).

Verified with new unit tests for the probe (once-per-context semantics, value-equivalence across fresh context objects, mode-transition re-walk, reset clearing, import-repeat dedup) plus the full `indexing-test.ts` module (61/61) against the real prerender stack, including the deep-relationship deps parity test.
