### PR TITLE
Don't steal focus from text entry when placing the Monaco cursor

### DIFF
--- a/packages/host/app/resources/url-bar.ts
+++ b/packages/host/app/resources/url-bar.ts
@@ -53,14 +53,19 @@ export default class URLBarResource extends Resource<Args> {
     if (event.key !== 'Enter' || !this.lastEditedValue) {
       return;
     }
-    let submitted = await this.setURL(this.lastEditedValue);
-    // Submitting the URL commits the navigation, so the bar is done with
-    // focus; releasing it here lets the editor take focus when it places
-    // the cursor in the newly opened file (the editor declines to grab
-    // focus away from a text-entry element that still holds it).
-    if (submitted && event.target instanceof HTMLElement) {
+    if (!this.validate(this.lastEditedValue)) {
+      return;
+    }
+    // Submitting a valid URL commits the navigation, so the bar is done with
+    // focus. Release it before navigating: the editor places its cursor in
+    // the newly opened file at an unpredictable point during the load, and
+    // it declines to grab focus away from a text-entry element that still
+    // holds it. Blurring first guarantees the editor sees the bar as
+    // relinquished no matter when that cursor placement fires.
+    if (event.target instanceof HTMLElement) {
       event.target.blur();
     }
+    await this.setURL(this.lastEditedValue);
   }
 
   onInput(newURL: string) {
@@ -96,16 +101,14 @@ export default class URLBarResource extends Resource<Args> {
     }
   }
 
-  async setURL(newURL: string): Promise<boolean> {
-    if (!this.validate(this.lastEditedValue)) {
-      return false;
+  async setURL(newURL: string) {
+    if (this.validate(this.lastEditedValue)) {
+      if (this.setValue) {
+        await this.setValue(newURL);
+      }
+      this.value = newURL;
+      this.isEditing = false;
     }
-    if (this.setValue) {
-      await this.setValue(newURL);
-    }
-    this.value = newURL;
-    this.isEditing = false;
-    return true;
   }
 }
 

--- a/packages/host/app/resources/url-bar.ts
+++ b/packages/host/app/resources/url-bar.ts
@@ -53,7 +53,14 @@ export default class URLBarResource extends Resource<Args> {
     if (event.key !== 'Enter' || !this.lastEditedValue) {
       return;
     }
-    await this.setURL(this.lastEditedValue);
+    let submitted = await this.setURL(this.lastEditedValue);
+    // Submitting the URL commits the navigation, so the bar is done with
+    // focus; releasing it here lets the editor take focus when it places
+    // the cursor in the newly opened file (the editor declines to grab
+    // focus away from a text-entry element that still holds it).
+    if (submitted && event.target instanceof HTMLElement) {
+      event.target.blur();
+    }
   }
 
   onInput(newURL: string) {
@@ -89,14 +96,16 @@ export default class URLBarResource extends Resource<Args> {
     }
   }
 
-  async setURL(newURL: string) {
-    if (this.validate(this.lastEditedValue)) {
-      if (this.setValue) {
-        await this.setValue(newURL);
-      }
-      this.value = newURL;
-      this.isEditing = false;
+  async setURL(newURL: string): Promise<boolean> {
+    if (!this.validate(this.lastEditedValue)) {
+      return false;
     }
+    if (this.setValue) {
+      await this.setValue(newURL);
+    }
+    this.value = newURL;
+    this.isEditing = false;
+    return true;
   }
 }
 

--- a/packages/host/app/services/monaco-service.ts
+++ b/packages/host/app/services/monaco-service.ts
@@ -24,7 +24,7 @@ import HTMLWorkerUrl from 'monaco-editor/esm/vs/language/html/html.worker.js?wor
 import JSONWorkerUrl from 'monaco-editor/esm/vs/language/json/json.worker.js?worker&url';
 import TSWorkerUrl from 'monaco-editor/esm/vs/language/typescript/ts.worker.js?worker&url';
 
-import type { SingleCardDocument } from '@cardstack/runtime-common';
+import { logger, type SingleCardDocument } from '@cardstack/runtime-common';
 
 import config from '@cardstack/host/config/environment';
 import type CardService from '@cardstack/host/services/card-service';
@@ -43,6 +43,8 @@ export type MonacoSDK = typeof _MonacoSDK;
 export type IStandaloneCodeEditor = _MonacoSDK.editor.IStandaloneCodeEditor;
 
 const { serverEchoDebounceMs } = config;
+
+const log = logger('service:monaco');
 
 // `new Worker(url)` rejects cross-origin URLs, but importScripts inside a
 // worker is allowed to fetch them. When the worker URL is on a different
@@ -335,7 +337,30 @@ export default class MonacoService extends Service {
     if (!this.editor) {
       return;
     }
-    this.editor.focus();
+    // Cursor placement runs on debounced timers (e.g. restoring a position
+    // after a file opens or a definition is selected), so by the time it
+    // fires the user may already be typing in another text-entry element,
+    // like the AI assistant chat box. Grabbing focus then would redirect
+    // their keystrokes into the editor, where auto-save would persist the
+    // stray characters into the open file. Take focus only when it won't
+    // interrupt text entry happening elsewhere.
+    let active = document.activeElement;
+    let editorDom = this.editor.getDomNode();
+    let activeElementAcceptsText =
+      active instanceof HTMLElement &&
+      !(editorDom?.contains(active) ?? false) &&
+      (active.tagName === 'INPUT' ||
+        active.tagName === 'TEXTAREA' ||
+        active.isContentEditable);
+    if (activeElementAcceptsText) {
+      log.warn(
+        `monaco cursor update: leaving focus on ${active!.tagName.toLowerCase()} ${JSON.stringify(
+          (active as HTMLElement).dataset,
+        )} instead of taking it for the editor`,
+      );
+    } else {
+      this.editor.focus();
+    }
     this.editor.setPosition(cursorPosition);
     this.editor.revealLineNearTop(cursorPosition.lineNumber);
   }

--- a/packages/host/app/services/monaco-service.ts
+++ b/packages/host/app/services/monaco-service.ts
@@ -348,7 +348,7 @@ export default class MonacoService extends Service {
     let editorDom = this.editor.getDomNode();
     let activeElementAcceptsText =
       active instanceof HTMLElement &&
-      !(editorDom?.contains(active) ?? false) &&
+      !editorDom?.contains(active) &&
       (active.tagName === 'INPUT' ||
         active.tagName === 'TEXTAREA' ||
         active.isContentEditable);

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -1,4 +1,11 @@
-import { click, waitFor, fillIn, find, settled } from '@ember/test-helpers';
+import {
+  click,
+  waitFor,
+  waitUntil,
+  fillIn,
+  find,
+  settled,
+} from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 
@@ -360,6 +367,79 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     assert.false(
       monacoService?.editor?.getOption(MonacoSDK.editor.EditorOption.readOnly),
       'editor should not be read-only for a .txt file in a writable realm',
+    );
+  });
+
+  test('updating the cursor position does not steal focus from a text-entry element', async function (assert) {
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}pet.gts`,
+    });
+    await waitFor('[data-test-editor]');
+    await waitUntil(() => monacoService.editor);
+
+    let textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    try {
+      textarea.focus();
+      assert.strictEqual(
+        document.activeElement,
+        textarea,
+        'textarea has focus before the cursor update',
+      );
+
+      monacoService.updateCursorPosition(new MonacoSDK.Position(3, 1));
+
+      assert.strictEqual(
+        document.activeElement,
+        textarea,
+        'textarea keeps focus after the cursor update',
+      );
+      let cursorPosition = monacoService.getCursorPosition();
+      assert.strictEqual(
+        cursorPosition?.lineNumber,
+        3,
+        'editor cursor line is updated',
+      );
+      assert.strictEqual(
+        cursorPosition?.column,
+        1,
+        'editor cursor column is updated',
+      );
+    } finally {
+      textarea.remove();
+    }
+  });
+
+  test('updating the cursor position focuses the editor when no text-entry element has focus', async function (assert) {
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}pet.gts`,
+    });
+    await waitFor('[data-test-editor]');
+    await waitUntil(() => monacoService.editor);
+
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+    assert.notStrictEqual(
+      document.activeElement,
+      null,
+      'something (e.g. the body) is the active element before the cursor update',
+    );
+
+    monacoService.updateCursorPosition(new MonacoSDK.Position(3, 1));
+
+    let editorDom = monacoService.editor!.getDomNode();
+    assert.true(
+      editorDom!.contains(document.activeElement),
+      'editor receives focus when no text-entry element had it',
+    );
+    let cursorPosition = monacoService.getCursorPosition();
+    assert.strictEqual(
+      cursorPosition?.lineNumber,
+      3,
+      'editor cursor line is updated',
     );
   });
 


### PR DESCRIPTION
In code submode, cursor placement runs on debounced timers: the monaco modifier restores a cursor position some time after a file opens or a definition is selected, and `MonacoService.updateCursorPosition()` unconditionally called `editor.focus()` when it finally fired. If the user had meanwhile started typing somewhere else — most commonly the AI assistant chat box — that delayed `focus()` yanked their keystrokes into the code editor, and the editor's auto-save then persisted the stray text into the open file, silently corrupting a source module.

This is also the mechanism behind a flaky cascade in the matrix Playwright suite ([example run](https://github.com/cardstack/boxel/actions/runs/27372997674/job/80890520131)). In `messages.spec.ts`, "currently viewed file is auto-attached" clicks a definition (which schedules a cursor placement at the class body of `person.gts`, line 17) and then fills the chat input. Playwright's `fill()` focuses the textarea in-page and then inserts the text via a separate CDP call into whatever element is focused *at that moment*. When the debounced cursor update fired inside that window, the chat sentence "Are there any computed fields in person.gts?" was inserted into the monaco buffer at line 17 col 36, auto-saved to the realm (`Parse Error at person.gts:17:40: 17:45` — "there" lands at columns 40–45), and every Person instance in the shared test realm went into an error state — failing 17 downstream tests for the rest of the shard.

The fix: `updateCursorPosition()` still places and reveals the cursor unconditionally, but only takes focus when doing so won't interrupt text entry elsewhere. If the active element is an input, textarea, or contenteditable outside the editor's DOM, focus is left alone and a `service:monaco` warning is logged — a diagnostic breadcrumb so any future trace shows whether this path fired.

The card URL bar is the one text-entry element that *hands off* focus to the editor: submitting a valid URL with Enter commits the navigation, so the bar blurs itself before the navigation starts. By the time the editor's cursor placement fires — at whatever point during the file load — the bar has already relinquished focus and the editor takes it as before.

Two acceptance tests cover the guard: a cursor update leaves focus on an external textarea while still moving the editor cursor, and still focuses the editor when no text-entry element has focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)