### PR TITLE
feat(ui): Extract fitted component from homepage to boxel-ui with improvements

### DIFF
--- a/packages/boxel-cli/plugin/skills/boxel-ui-guidelines/SKILL.md
+++ b/packages/boxel-cli/plugin/skills/boxel-ui-guidelines/SKILL.md
@@ -348,6 +348,145 @@ Fitted cards are rendered at many different container sizes — from small badge
 - Use `text-overflow: ellipsis` with `white-space: nowrap` for single-line labels, or clamp multi-line text with `-webkit-line-clamp`
 - Override inherited font sizes to fit the smaller space — but keep text legible. Depending on the font, you can go as small as 0.5rem, but ideally no smaller
 
+Optionally, you can use the `FittedCard` component from `@cardstack/boxel-ui/components` for fitted card layouts. It handles all responsive container-query breakpoints, image column sizing, text clamping, and overflow — you only supply named content blocks.
+
+```gts
+import { FittedCard, Pill } from '@cardstack/boxel-ui/components';
+import BookOpen from '@cardstack/boxel-icons/book-open';
+import Calendar from '@cardstack/boxel-icons/calendar';
+
+static fitted = class Fitted extends Component<typeof this> {
+  <template>
+    <FittedCard
+      @imageUrl={{@model.cardThumbnailURL}}
+      @imageAlt={{@model.cardTitle}}
+      class='my-fitted'
+    >
+      <:placeholder><BookOpen width='24' height='24' /></:placeholder>
+      <:badgeLeft><Pill>New</Pill></:badgeLeft>
+      <:badgeRight><Pill>4.8 ★</Pill></:badgeRight>
+      <:eyebrow>{{@model.category}}</:eyebrow>
+      <:title><@fields.cardTitle /></:title>
+      <:subtitle><@fields.cardDescription /></:subtitle>
+      <:meta><Calendar width='14' height='14' /><@fields.date /></:meta>
+      <:footer><strong>{{@model.author.name}}</strong></:footer>
+    </FittedCard>
+    <style scoped>
+      .my-fitted {
+        --fc-content-gap: var(--boxel-sp-xs);
+      }
+    </style>
+  </template>
+};
+```
+
+#### Named blocks
+
+| Block         | Description                                                                                                                              | Required |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `title`       | Primary heading                                                                                                                          | Yes      |
+| `placeholder` | Icon/content in the image column when `@imageUrl` is absent. Yielding empty content removes the column entirely.                         | No       |
+| `image`       | Custom image block (alternative to `@imageUrl`)                                                                                          | No       |
+| `background`  | Absolutely-positioned background graphics layer                                                                                          | No       |
+| `badgeLeft`   | Absolutely-positioned group at top-left (over the image when present)                                                                    | No       |
+| `badgeRight`  | Absolutely-positioned group at top-right                                                                                                 | No       |
+| `badgeRow`    | Inline flex row of badges/pills above the header inside the text column; controlled by `--fc-badge-row-justify` and `--fc-badge-row-gap` | No       |
+| `badge`       | Alias for `badgeLeft` (legacy — prefer `badgeLeft`)                                                                                      | No       |
+| `eyebrow`     | Tiny uppercase overline above the title                                                                                                  | No       |
+| `subtitle`    | Secondary line below the title                                                                                                           | No       |
+| `meta`        | Additional content between header and footer                                                                                             | No       |
+| `footer`      | Bottom row: date, location, price, stats, etc.                                                                                           | No       |
+
+#### Args
+
+| Arg             | Type     | Description                                                                                                                                                                    |
+| --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@imageUrl`     | `string` | Cover image URL; triggers the image column layout                                                                                                                              |
+| `@imageAlt`     | `string` | Alt text for the cover image (defaults to `""`)                                                                                                                                |
+| `@imageLoading` | `string` | `'lazy'` or `'eager'`; omit to use the browser default                                                                                                                         |
+| `@titleTag`     | `string` | HTML heading element for the title: `'h1'` (default), `'h2'`, `'h3'`, etc. Pass `'h2'` or `'h3'` when cards appear in a list to preserve heading hierarchy for screen readers. |
+
+#### CSS custom properties
+
+Override these on the FittedCard root element. Breakpoints adjust many automatically; only set them when you need to deviate.
+
+```css
+.my-fitted {
+  /* ── Layout ── */
+  --fc-content-padding: var(--boxel-sp-xs); /* padding inside text column */
+  --fc-content-gap: var(
+    --boxel-sp-3xs
+  ); /* gap between header / meta / footer */
+  --fc-content-gap-no-image: var(
+    --boxel-sp-xs
+  ); /* gap when there is no image column */
+  --fc-header-gap: var(
+    --boxel-sp-6xs
+  ); /* gap within header (eyebrow / title / subtitle) */
+
+  /* ── Image column ── */
+  --fc-image-width: 40cqh; /* horizontal layouts */
+  --fc-image-min-width: 3.75rem;
+  --fc-image-max-width: 12.5rem;
+  --fc-image-height: auto; /* vertical tiles override with a cqmin value */
+  --fc-image-object-fit: cover; /* object-fit for the cover image */
+  --fc-image-background: linear-gradient(
+    180deg,
+    var(--muted) 0%,
+    var(--accent) 100%
+  ); /* column bg when no image fills it */
+  --fc-image-fade-color: var(
+    --card
+  ); /* base color for expanded-card image fade; match your card background */
+
+  /* ── Typography ── */
+  --fc-eyebrow-font-size: 0.625rem;
+  --fc-eyebrow-line-height: 1.1;
+  --fc-title-font-size: var(--boxel-font-size-sm);
+  --fc-title-line-height: 1.2;
+  --fc-title-line-clamp: 2;
+  --fc-subtitle-font-size: var(--boxel-font-size-xs);
+  --fc-subtitle-line-height: 1.1;
+  --fc-subtitle-line-clamp: 2;
+  --fc-meta-font-size: var(--boxel-caption-font-size);
+  --fc-meta-line-height: 1.1;
+  --fc-footer-font-size: var(--boxel-caption-font-size);
+
+  /* ── Badges ── */
+  --fc-badge-offset: var(
+    --boxel-sp-2xs
+  ); /* inset from card edges for badgeLeft / badgeRight */
+
+  /* ── Badge row ── */
+  --fc-badge-row-justify: space-between;
+  --fc-badge-row-gap: var(--boxel-sp-2xs);
+
+  /* ── Meta & footer flex row ── */
+  --fc-meta-justify: flex-start; /* justify-content */
+  --fc-meta-gap: var(--boxel-sp-2xs);
+  --fc-meta-align-items: center; /* align-items */
+  --fc-meta-flex-wrap: wrap;
+  --fc-footer-justify: flex-start; /* justify-content */
+  --fc-footer-align-items: center; /* align-items */
+  --fc-footer-flex-wrap: nowrap; /* flex-wrap */
+  --fc-footer-gap: var(--boxel-sp-2xs);
+}
+```
+
+#### Customising caller-owned content per breakpoint
+
+`FittedCard` handles its own layout at every size. For caller-owned content that needs show/hide per breakpoint, add `@container fitted-card` rules in your own `<style scoped>`:
+
+```css
+@container fitted-card (width < 250px) {
+  .my-detail-row {
+    display: none;
+  }
+}
+```
+
+Use `:deep(.fc-eyebrow)` etc. to reach into `FittedCard` internals only for layout overrides (e.g. making the eyebrow a flex row for an icon + label).
+
 ### All 16 fitted formats (from `fitted-formats.ts`)
 
 The runtime defines 16 named formats. Sizes are exact spec values (width × height in px):
@@ -371,48 +510,35 @@ The runtime defines 16 named formats. Sizes are exact spec values (width × heig
 | full-card         | 400   | 275    |
 | expanded-card     | 400   | 445    |
 
-```gts
-static fitted = class Fitted extends Component<typeof this> {
-  <template>
-    <article class='my-fitted'>
-      <header class='content-header'>
-        <h1 class='title boxel-ellipsize'><@fields.cardTitle /></h1>
-        <p class='subtitle'><@fields.cardDescription /></p>
-      </header>
-     <div class='body-content'>
-        <p>Content here...</p>
-     </div>
-    <footer>
-       <p>Footer content here...</p>
-    </footer>
-    </article>
-    <style scoped>
-      .my-fitted {
-        display: grid;
-        grid-template-rows: auto 1fr auto;
-        padding: var(--boxel-sp-xs);
-        background-color: var(--card);
-        color: var(--card-foreground);
-      }
-      .content {
-        display: grid;
-        gap: var(--boxel-sp-xs);
-      }
-      .title {
-        font-weight: 500;
-      }
-      .subtitle {
-        font-size: var(--boxel-font-size-xs);
-        color: var(--muted-foreground);
-        overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        -webkit-box-orient: vertical;
-      }
-    </style>
-  </template>
-};
-```
+#### What `FittedCard` does at each breakpoint
+
+**Badges** (`aspect-ratio > 1.0`, `width < 250px`) — 1-col, no image column:
+
+- Small Badge (150×40): 1-line title only; hides image, both badges, subtitle, meta, footer
+- Medium Badge (150×65): 1-line title + subtitle; hides image, both badges, meta, footer
+- Large Badge (150×105): hides image, both badges, meta
+
+**Strips** (`aspect-ratio > 1.0`, `width ≥ 250px`, `height < 170px`):
+
+- Single Strip (250×40): compact padding, 1-line title; hides both badges, subtitle, meta, footer
+- Double Strip (250×65): 1-line title + subtitle; hides both badges, meta, footer
+- Triple Strip (250×105): hides both badges, meta
+- Double Wide Strip (400×65): image `width: 40cqw`; 1-line title + subtitle; hides both badges and badge-row, meta, footer — restores `badgeLeft` when image is present
+- Triple Wide Strip (400×105): image `width: 40cqw`; hides both badges and badge-row, meta — restores `badgeLeft` when image is present
+
+**Vertical / Square tiles** (`aspect-ratio ≤ 1.0`) — 1-col, image stacks above content:
+
+- All: image `height: 45cqmin`; taller than 250px → `55cqmin`
+- Small Tile (150×170): smaller title font; hides badge-row, meta; hides both badges when no image
+- Shorter than 150px height: hides meta + footer; 1-line subtitle
+- Narrower than 140px: hides both badges
+- Regular Tile (250×170), CardsGrid Tile, Tall Tile, Large Tile: hides both badges when no image
+
+**Horizontal cards** (`aspect-ratio > 1.0`, `width ≥ 400px`, `height ≥ 170px`) — image `width: 40cqw`:
+
+- Compact Card (400×170): increased padding + gap; hides both badges when no image
+- Full Card (400×275): larger font sizes; `line-clamp: 3`; hides both badges when no image
+- Expanded Card (400×445): full padding, image `height: 50cqh` with bottom scrim fade; hides both badges when no image
 
 ### Form fields
 

--- a/packages/boxel-cli/plugin/skills/boxel-ui-guidelines/SKILL.md
+++ b/packages/boxel-cli/plugin/skills/boxel-ui-guidelines/SKILL.md
@@ -352,6 +352,7 @@ Optionally, you can use the `FittedCard` component from `@cardstack/boxel-ui/com
 
 ```gts
 import { FittedCard, Pill } from '@cardstack/boxel-ui/components';
+import type { FittedCardLayout, FittedCardTitleTag } from '@cardstack/boxel-ui/components';
 import BookOpen from '@cardstack/boxel-icons/book-open';
 import Calendar from '@cardstack/boxel-icons/calendar';
 
@@ -399,12 +400,15 @@ static fitted = class Fitted extends Component<typeof this> {
 
 #### Args
 
-| Arg             | Type     | Description                                                                                                                                                                    |
-| --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `@imageUrl`     | `string` | Cover image URL; triggers the image column layout                                                                                                                              |
-| `@imageAlt`     | `string` | Alt text for the cover image (defaults to `""`)                                                                                                                                |
-| `@imageLoading` | `string` | `'lazy'` or `'eager'`; omit to use the browser default                                                                                                                         |
-| `@titleTag`     | `string` | HTML heading element for the title: `'h1'` (default), `'h2'`, `'h3'`, etc. Pass `'h2'` or `'h3'` when cards appear in a list to preserve heading hierarchy for screen readers. |
+| Arg             | Type                 | Description                                                                                                                                                                                                                                               |
+| --------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@imageUrl`     | `string`             | Cover image URL; triggers the image column layout                                                                                                                                                                                                         |
+| `@imageAlt`     | `string`             | Alt text for the cover image (defaults to `""`)                                                                                                                                                                                                           |
+| `@imageLoading` | `string`             | `'lazy'` or `'eager'`; omit to use the browser default                                                                                                                                                                                                    |
+| `@titleTag`     | `FittedCardTitleTag` | HTML heading element for the title: `'h1'` (default), `'h2'`, `'h3'`, etc. Pass `'h2'` or `'h3'` when cards appear in a list to preserve heading hierarchy for screen readers.                                                                            |
+| `@layout`       | `FittedCardLayout`   | Force a layout direction regardless of container size: `'vertical'` — image always stacks on top; `'horizontal'` — image always sits to the left; `'auto'` (default) — direction is chosen by container-query breakpoints based on aspect-ratio and size. |
+
+`FittedCardLayout` and `FittedCardTitleTag` are exported named types from `@cardstack/boxel-ui/components`. When you need the allowed values as an array (e.g. for a dropdown), use the exported constants `FITTED_CARD_LAYOUT_OPTIONS` and `FITTED_CARD_TITLE_TAG_OPTIONS`.
 
 #### CSS custom properties
 
@@ -539,6 +543,21 @@ The runtime defines 16 named formats. Sizes are exact spec values (width × heig
 - Compact Card (400×170): increased padding + gap; hides both badges when no image
 - Full Card (400×275): larger font sizes; `line-clamp: 3`; hides both badges when no image
 - Expanded Card (400×445): full padding, image `height: 50cqh` with bottom scrim fade; hides both badges when no image
+
+#### `@layout` forced-mode overrides
+
+When `@layout` is `'vertical'` or `'horizontal'`, the image column direction is locked regardless of container size. Container-query breakpoints still apply for font sizes, padding, and section visibility — only the grid direction and image sizing are overridden.
+
+**`@layout='vertical'`** — image stacks above content (`width: 100%`, `height: 45cqmin`):
+
+- Strip sizes (`aspect-ratio > 1.0`, `height < 170px`) and compact card (`width ≥ 400px`, `170px ≤ height < 275px`): image is **hidden** — not enough vertical space to stack it usefully.
+
+**`@layout='horizontal'`** — image sits to the left (`width: 40cqh`):
+
+- Portrait/square tiles with `height ≥ 200px` and `width < 400px` (CardsGrid, Tall Tile, Large Tile): image width reduced to `30cqh` — avoids eating too much of a narrow card.
+- Expanded Card (`width ≥ 400px`, `height ≥ 445px`): image width reduced to `25cqh` — `40cqh` of a 445px+ card is ~180px, which is too wide.
+
+All image-sizing values are still overridable per-card with `--fc-image-width`.
 
 ### Form fields
 

--- a/packages/boxel-ui/addon/src/components.ts
+++ b/packages/boxel-ui/addon/src/components.ts
@@ -26,6 +26,7 @@ import EntityDisplayWithIcon from './components/entity-icon-display/index.gts';
 import EntityDisplayWithThumbnail from './components/entity-thumbnail-display/index.gts';
 import FieldContainer from './components/field-container/index.gts';
 import FilterList, { type Filter } from './components/filter-list/index.gts';
+import { FittedCard } from './components/fitted-card/index.gts';
 import FittedCardContainer from './components/fitted-card-container/index.gts';
 import GridContainer from './components/grid-container/index.gts';
 import BoxelHeader from './components/header/index.gts';
@@ -137,6 +138,7 @@ export {
   FieldContainer,
   FilterList,
   findInsertionFromPointer,
+  FittedCard,
   FittedCardContainer,
   GridContainer,
   Header,

--- a/packages/boxel-ui/addon/src/components.ts
+++ b/packages/boxel-ui/addon/src/components.ts
@@ -26,7 +26,12 @@ import EntityDisplayWithIcon from './components/entity-icon-display/index.gts';
 import EntityDisplayWithThumbnail from './components/entity-thumbnail-display/index.gts';
 import FieldContainer from './components/field-container/index.gts';
 import FilterList, { type Filter } from './components/filter-list/index.gts';
-import { FittedCard } from './components/fitted-card/index.gts';
+import FittedCard, {
+  type FittedCardLayout,
+  type FittedCardTitleTag,
+  FITTED_CARD_LAYOUT_OPTIONS,
+  FITTED_CARD_TITLE_TAG_OPTIONS,
+} from './components/fitted-card/index.gts';
 import FittedCardContainer from './components/fitted-card-container/index.gts';
 import GridContainer from './components/grid-container/index.gts';
 import BoxelHeader from './components/header/index.gts';
@@ -91,6 +96,8 @@ import ViewSelector, {
 
 export {
   type Filter,
+  type FittedCardLayout,
+  type FittedCardTitleTag,
   type InsertionPoint,
   type KanbanColumnConfig,
   type KanbanPlacement,
@@ -138,6 +145,8 @@ export {
   FieldContainer,
   FilterList,
   findInsertionFromPointer,
+  FITTED_CARD_LAYOUT_OPTIONS,
+  FITTED_CARD_TITLE_TAG_OPTIONS,
   FittedCard,
   FittedCardContainer,
   GridContainer,

--- a/packages/boxel-ui/addon/src/components/accordion/item/index.gts
+++ b/packages/boxel-ui/addon/src/components/accordion/item/index.gts
@@ -50,6 +50,7 @@ const AccordionItem: TemplateOnlyComponent<AccordionItemSignature> = <template>
       role='region'
       aria-labelledby={{@id}}
       aria-hidden={{if @isOpen 'false' 'true'}}
+      inert={{unless @isOpen true}}
     >
       <div class='boxel-accordion-item-content-inner'>
         {{yield to='content'}}

--- a/packages/boxel-ui/addon/src/components/basic-fitted/usage.gts
+++ b/packages/boxel-ui/addon/src/components/basic-fitted/usage.gts
@@ -1,22 +1,17 @@
 import Captions from '@cardstack/boxel-icons/captions';
-import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { fn } from '@ember/helper';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
-import {
-  type FittedFormatSpec,
-  cn,
-  FITTED_FORMATS,
-  gt,
-  gte,
-} from '../../helpers.ts';
+import { FITTED_FORMATS } from '../../helpers.ts';
 import type { Icon } from '../../icons.ts';
 import CardContainer from '../card-container/index.gts';
+import {
+  type Spec,
+  FittedUsagePreview,
+} from '../fitted-card/usage-preview.gts';
 import BasicFitted from './index.gts';
-
-type Spec = Partial<FittedFormatSpec> & { height: number; width: number };
 
 const OTHER_SIZES: Spec[] = [
   { width: 226, height: 226 },
@@ -34,107 +29,6 @@ const OTHER_SIZES: Spec[] = [
   { width: 226, height: 58 },
   { width: 300, height: 115 },
 ];
-
-const calcRatio = ({ width, height }: Spec) => (width / height).toFixed(2);
-
-interface FittedItemContainerSignature {
-  Args: { spec: Spec };
-  Blocks: { default: [] };
-}
-
-const FittedItemContainer: TemplateOnlyComponent<FittedItemContainerSignature> =
-  <template>
-    <div
-      class={{cn
-        'item'
-        wide=(gt @spec.width 300)
-        full-width=(gte @spec.width 400)
-      }}
-    >
-      <div class='desc'>
-        <h4>{{@spec.title}} {{@spec.width}}px &times; {{@spec.height}}px</h4>
-        Aspect Ratio
-        {{calcRatio @spec}}
-      </div>
-
-      {{yield}}
-    </div>
-    <style scoped>
-      .card {
-        container-name: fitted-card;
-        container-type: size;
-        overflow: hidden;
-      }
-      .wide {
-        grid-column: span 2;
-      }
-      .full-width {
-        grid-column: -1 / 1;
-      }
-      .item {
-        position: relative;
-        padding-top: 50px;
-        padding-inline: var(--boxel-sp);
-        padding-bottom: var(--boxel-sp);
-        background-color: color-mix(
-          in oklab,
-          var(--background, var(--boxel-light)) 90%,
-          var(--foreground, var(--boxel-dark))
-        );
-      }
-      .desc {
-        position: absolute;
-        top: 0;
-        right: 0;
-        padding: var(--boxel-sp-4xs);
-        background-color: var(--boxel-light);
-        border-left: var(--boxel-border-card);
-        border-right: var(--boxel-border-card);
-        border-bottom: var(--boxel-border-card);
-        color: var(--muted-foreground, var(--boxel-450));
-        font: var(--boxel-font-xs);
-      }
-      h4 {
-        margin: 0;
-        font-weight: 500;
-      }
-    </style>
-  </template>;
-
-interface PreviewTemplateSignature {
-  Args: { specs: { items: Spec[]; title: string }[] };
-  Blocks: { default: [spec: Spec] };
-}
-
-const FittedUsagePreview: TemplateOnlyComponent<PreviewTemplateSignature> =
-  <template>
-    <div class='scroller' tabindex='0'>
-      <h3>Standard Fitted Sizes</h3>
-      {{#each @specs as |specGroup|}}
-        <h3>{{specGroup.title}}</h3>
-        {{#each specGroup.items as |spec|}}
-          <FittedItemContainer @spec={{spec}}>
-            {{yield spec}}
-          </FittedItemContainer>
-        {{/each}}
-      {{/each}}
-    </div>
-    <style scoped>
-      .scroller {
-        max-height: 40vh;
-        overflow-y: scroll;
-        border: 1px solid var(--border, var(--boxel-200));
-        padding: 10px;
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-        gap: var(--boxel-sp-xs);
-      }
-      h3 {
-        grid-column: -1 / 1;
-        font-weight: 500;
-      }
-    </style>
-  </template>;
 
 export default class BasicFittedUsage extends Component {
   @tracked primary: string =

--- a/packages/boxel-ui/addon/src/components/field-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/field-container/index.gts
@@ -113,9 +113,6 @@ const FieldContainer: TemplateOnlyComponent<Signature> = <template>
         ); /* necessary for our various overlays utilizing box-shadow */
         word-break: break-word;
       }
-      .content:not(:has(input)) {
-        text-box-trim: trim-both;
-      }
 
       .horizontal {
         grid-template-columns:

--- a/packages/boxel-ui/addon/src/components/fitted-card/index.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card/index.gts
@@ -28,6 +28,11 @@ import { element } from '../../helpers.ts';
  *   @titleTag      – HTML element tag for the title heading (default: 'h1').
  *                    Pass 'h2' or 'h3' when cards appear in a list to preserve
  *                    correct heading hierarchy for screen readers.
+ *   @layout        – force a layout direction regardless of container size:
+ *                    'vertical'   — image always stacks on top of content
+ *                    'horizontal' — image always sits to the left of content
+ *                    'auto'       — default; layout is chosen by container-query
+ *                                  breakpoints based on aspect-ratio and size
  *
  * CSS custom properties (set on the host element or a wrapper):
  *   --fc-content-padding      padding inside the text column
@@ -110,12 +115,30 @@ import { element } from '../../helpers.ts';
  * footer content is in the caller's scope, not this component's.
  */
 
+export type FittedCardLayout = 'auto' | 'horizontal' | 'vertical';
+export type FittedCardTitleTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+export const FITTED_CARD_LAYOUT_OPTIONS: FittedCardLayout[] = [
+  'auto',
+  'vertical',
+  'horizontal',
+];
+export const FITTED_CARD_TITLE_TAG_OPTIONS: FittedCardTitleTag[] = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+];
+
 interface FittedCardSignature {
   Args: {
     imageAlt?: string;
     imageLoading?: 'lazy' | 'eager';
     imageUrl?: string | null;
-    titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+    layout?: FittedCardLayout;
+    titleTag?: FittedCardTitleTag;
   };
   Blocks: {
     background: [];
@@ -135,7 +158,11 @@ interface FittedCardSignature {
 }
 
 export const FittedCard: TemplateOnlyComponent<FittedCardSignature> = <template>
-  <article class='fitted-card' ...attributes>
+  <article
+    class='fitted-card'
+    data-layout={{if @layout @layout 'auto'}}
+    ...attributes
+  >
 
     {{#if (has-block 'background')}}
       <div class='fc-background'>{{yield to='background'}}</div>
@@ -268,6 +295,13 @@ export const FittedCard: TemplateOnlyComponent<FittedCardSignature> = <template>
       }
       .fitted-card:has(.fc-image) {
         grid-template-columns: auto 1fr;
+      }
+      /* When <:placeholder> yields empty content, collapse the image column */
+      .fitted-card:has(.fc-placeholder:empty) {
+        grid-template-columns: 1fr;
+      }
+      .fc-image:has(> .fc-placeholder:empty) {
+        display: none;
       }
 
       .fc-background {
@@ -405,14 +439,6 @@ export const FittedCard: TemplateOnlyComponent<FittedCardSignature> = <template>
       .fc-footer:empty,
       .fc-badge:not(:has(*)),
       .fc-badge-row:empty {
-        display: none;
-      }
-
-      /* When <:placeholder> yields empty content, collapse the image column */
-      .fitted-card:has(.fc-placeholder:empty) {
-        grid-template-columns: 1fr;
-      }
-      .fc-image:has(> .fc-placeholder:empty) {
         display: none;
       }
 
@@ -598,7 +624,7 @@ export const FittedCard: TemplateOnlyComponent<FittedCardSignature> = <template>
           --fc-badge-row-display: none;
           --fc-meta-display: none;
         }
-        :not(:has(.fc-image)) {
+        .fitted-card:not(:has(.fc-image)) {
           --fc-badge-right-display: none;
           --fc-badge-left-display: none;
         }
@@ -738,6 +764,66 @@ export const FittedCard: TemplateOnlyComponent<FittedCardSignature> = <template>
         }
         .fc-footer {
           gap: var(--boxel-sp-sm);
+        }
+      }
+
+      /* ── Forced layout overrides ────────────────────────────────────
+         [data-layout] adds an attribute selector (0,2,0 specificity) which
+         beats plain class selectors inside container queries (0,1,0), so
+         these rules always win regardless of container dimensions.
+         ──────────────────────────────────────────────────────────────── */
+      .fitted-card[data-layout='vertical'] {
+        --fc-image-width: 100%;
+        --fc-image-max-width: 100%;
+        --fc-image-height: 45cqmin;
+        grid-template-columns: 1fr;
+      }
+      .fitted-card[data-layout='vertical']:has(.fc-image) {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto 1fr;
+      }
+
+      .fitted-card[data-layout='horizontal'] {
+        --fc-image-width: 40cqh;
+        --fc-image-min-width: 3.75rem;
+        --fc-image-max-width: 12.5rem;
+        --fc-image-height: auto;
+        grid-template-columns: 1fr;
+      }
+      .fitted-card[data-layout='horizontal']:has(.fc-image) {
+        grid-template-columns: auto 1fr;
+        grid-template-rows: unset;
+      }
+
+      /* Vertical layout: hide image at strip sizes (landscape, height < 170px).
+         Strips are too short for a stacked image — collapse the image row. */
+      @container fitted-card (1.0 < aspect-ratio) and (height < 170px) {
+        .fitted-card[data-layout='vertical']:has(.fc-image) {
+          --fc-image-display: none;
+          grid-template-rows: unset;
+        }
+      }
+
+      /* Vertical layout: hide image at compact card (400+wide, 170–275px tall).
+         Not enough height to stack image above content usefully. */
+      @container fitted-card (1.0 < aspect-ratio) and (width >= 400px) and (170px <= height < 275px) {
+        .fitted-card[data-layout='vertical']:has(.fc-image) {
+          --fc-image-display: none;
+          grid-template-rows: unset;
+        }
+      }
+
+      /* Horizontal layout: portrait/square tiles are narrow, so 40cqh image width
+         eats too much of the card — reduce to leave room for content. */
+      @container fitted-card (aspect-ratio <= 1.0) and (height >= 200px) and (width < 400px) {
+        .fitted-card[data-layout='horizontal'] {
+          --fc-image-width: 30cqh;
+        }
+      }
+      /* Expanded card is very tall; 40cqh of 445px+ would be ~180px — cap it smaller. */
+      @container fitted-card (aspect-ratio <= 1.0) and (width >= 400px) and (height >= 445px) {
+        .fitted-card[data-layout='horizontal'] {
+          --fc-image-width: 25cqh;
         }
       }
     }

--- a/packages/boxel-ui/addon/src/components/fitted-card/index.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card/index.gts
@@ -1,0 +1,747 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+
+import { element } from '../../helpers.ts';
+
+/**
+ * FittedCard — generic responsive card layout for the fitted format.
+ *
+ * Named blocks:
+ *   placeholder  – icon/content shown in the image column when no @imageUrl
+ *   background   - block for additional background graphics
+ *   badgeLeft    – absolutely-positioned badge anchored to the top-left corner
+ *   badgeRight   – absolutely-positioned badge anchored to the top-right corner
+ *   badge        – alias for badgeLeft (legacy; prefer badgeLeft/badgeRight)
+ *   badgeRow     – inline flex row of badges/pills rendered above the header
+ *   eyebrow      – tiny uppercase overline above the title
+ *   image        – custom image block (caller owns accessibility; provide alt text
+ *                  on the img element inside this block)
+ *   title        – primary heading (required)
+ *   subtitle     – secondary line below the title
+ *   meta         – meta section for additional content between header and footer
+ *   footer       – bottom row: date, location, price, stats, etc.
+ *
+ * Args:
+ *   @imageUrl      – cover image URL (optional)
+ *   @imageAlt      – alt text for the cover image (optional, defaults to "")
+ *   @imageLoading  – loading attribute for the cover image: 'lazy' | 'eager'
+ *                    (optional; omit to use the browser default)
+ *   @titleTag      – HTML element tag for the title heading (default: 'h1').
+ *                    Pass 'h2' or 'h3' when cards appear in a list to preserve
+ *                    correct heading hierarchy for screen readers.
+ *
+ * CSS custom properties (set on the host element or a wrapper):
+ *   --fc-content-padding      padding inside the text column
+ *   --fc-content-gap          gap between content sections (with image)
+ *   --fc-content-gap-no-image gap between content sections (no image)
+ *   --fc-content-justify      justify-content for the text column (default: flex-start; no-image: space-between)
+ *   --fc-header-gap           gap between eyebrow / title / subtitle
+ *   --fc-eyebrow-font-size
+ *   --fc-eyebrow-line-height
+ *   --fc-title-font-size
+ *   --fc-title-line-height
+ *   --fc-title-line-clamp     -webkit-line-clamp value
+ *   --fc-subtitle-font-size
+ *   --fc-subtitle-line-height
+ *   --fc-subtitle-line-clamp
+ *   --fc-title-text-overflow
+ *   --fc-title-white-space
+ *   --fc-subtitle-text-overflow
+ *   --fc-subtitle-white-space
+ *   --fc-image-width          image column width (default 40cqh)
+ *   --fc-image-min-width      image column min-width (default 3.75rem)
+ *   --fc-image-max-width      image column max-width (default 12.5rem)
+ *   --fc-image-height         image column height (default auto)
+ *   --fc-image-object-fit     object-fit for the cover image (default: cover)
+ *   --fc-image-background     image column background when no <img> fills it
+ *                             (default: linear-gradient(180deg, var(--muted), var(--accent)))
+ *   --fc-image-fade-color     base color for the expanded-card image fade gradient
+ *                             (default: var(--card)); set to match a custom card background
+ *   --fc-badge-offset         inset from card edges for absolutely-positioned badges
+ *                             (default: var(--boxel-sp-2xs))
+ *   --fc-badge-row-gap        gap inside the badge row
+ *   --fc-badge-row-justify    justify-content for the badge row
+ *   --fc-meta-font-size
+ *   --fc-meta-line-height
+ *   --fc-meta-flex-wrap
+ *   --fc-meta-gap
+ *   --fc-meta-justify
+ *   --fc-meta-align-items     align-items for the meta row (default: center)
+ *   --fc-footer-font-size
+ *   --fc-footer-gap
+ *   --fc-footer-justify       justify-content for the footer row
+ *   --fc-footer-align-items   align-items for the footer row (default: center)
+ *   --fc-footer-flex-wrap     flex-wrap for the footer row (default: nowrap)
+ *
+ * Section visibility (override to force-show or force-hide a section regardless of breakpoint):
+ *   Note: badgeLeft/Right are always position:absolute relative to the card —
+ *   set --fc-badge-right/left-display: none to hide them; block to force-show.
+ *   --fc-image-display           display value for the image column (default: flex)
+ *   --fc-badge-left-display      display value for absolute left badge (default: block)
+ *   --fc-badge-right-display     display value for absolute right badge (default: block)
+ *   --fc-badge-row-display       display value for the badge row (default: flex)
+ *   --fc-subtitle-display        display value for the subtitle (default: -webkit-box)
+ *   --fc-meta-display            display value for the meta row (default: flex)
+ *   --fc-footer-display          display value for the footer row (default: flex)
+ *
+ *   Set to `none` to hide, or to the default value above to force-show at any size.
+ *   Example — always show the footer:
+ *     .my-card { --fc-footer-display: flex; }
+ *   Example — hide meta at a custom breakpoint:
+ *     @container fitted-card (width < 300px) { .my-card { --fc-meta-display: none; } }
+ *
+ * Usage example:
+ *
+ *   <FittedCard @imageUrl={{@model.imageUrl}} @imageAlt={{@model.title}}>
+ *     <:background><div class='test-bg'></div></:background>
+ *     <:placeholder><BookOpen width='24' height='24' /></:placeholder>
+ *     <:badgeLeft><Pill @size='extra-small'>New</Pill></:badgeLeft>
+ *     <:badgeRight><Pill @size='extra-small'>Draft</Pill></:badgeRight>
+ *     <:eyebrow>Non-fiction</:eyebrow>
+ *     <:title><@fields.cardTitle /></:title>
+ *     <:subtitle><@fields.cardDescription /></:subtitle>
+ *     <:meta><span>150 mins</span><span>Difficulty 5</span></:meta>
+ *     <:footer>
+ *       <span>320 pages</span>
+ *       <span>2024</span>
+ *     </:footer>
+ *   </FittedCard>
+ *
+ * Footer dividers: style separators from the calling card's own scoped CSS since
+ * footer content is in the caller's scope, not this component's.
+ */
+
+interface FittedCardSignature {
+  Args: {
+    imageAlt?: string;
+    imageLoading?: 'lazy' | 'eager';
+    imageUrl?: string | null;
+    titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  };
+  Blocks: {
+    background: [];
+    badge: [];
+    badgeLeft: [];
+    badgeRight: [];
+    badgeRow: [];
+    eyebrow: [];
+    footer: [];
+    image: [];
+    meta: [];
+    placeholder: [];
+    subtitle: [];
+    title: [];
+  };
+  Element: HTMLElement;
+}
+
+export const FittedCard: TemplateOnlyComponent<FittedCardSignature> = <template>
+  <article class='fitted-card' ...attributes>
+
+    {{#if (has-block 'background')}}
+      <div class='fc-background'>{{yield to='background'}}</div>
+    {{/if}}
+
+    {{! ── Thumbnail ──────────────────────────────────────────────── }}
+    {{#if @imageUrl}}
+      <div class='fc-image'>
+        <img
+          src={{@imageUrl}}
+          alt={{if @imageAlt @imageAlt ''}}
+          loading={{@imageLoading}}
+        />
+      </div>
+    {{else if (has-block 'image')}}
+      <div class='fc-image'>
+        {{yield to='image'}}
+      </div>
+    {{else if (has-block 'placeholder')}}
+      <div class='fc-image'>
+        <div class='fc-placeholder'>{{yield to='placeholder'}}</div>
+      </div>
+    {{/if}}
+
+    {{! ── Absolute badges (always positioned relative to .fitted-card) ── }}
+    {{#if (has-block 'badgeLeft')}}
+      <div class='fc-badge fc-badge-left'>{{yield to='badgeLeft'}}</div>
+    {{else if (has-block 'badge')}}
+      <div class='fc-badge fc-badge-left'>{{yield to='badge'}}</div>
+    {{/if}}
+
+    {{#if (has-block 'badgeRight')}}
+      <div class='fc-badge fc-badge-right'>{{yield to='badgeRight'}}</div>
+    {{/if}}
+
+    {{! ── Text content ──────────────────────────────────────────────────  }}
+    <div class='fc-content'>
+      {{#if (has-block 'badgeRow')}}
+        <div class='fc-badge-row'>{{yield to='badgeRow'}}</div>
+      {{/if}}
+
+      <header class='fc-header'>
+        {{#if (has-block 'eyebrow')}}
+          <p class='fc-eyebrow boxel-ellipsize'>{{yield to='eyebrow'}}</p>
+        {{/if}}
+        {{#if @titleTag}}
+          {{#let (element @titleTag) as |TitleTag|}}
+            <TitleTag class='fc-title'>{{yield to='title'}}</TitleTag>
+          {{/let}}
+        {{else}}
+          <h1 class='fc-title'>{{yield to='title'}}</h1>
+        {{/if}}
+        {{#if (has-block 'subtitle')}}
+          <p class='fc-subtitle'>{{yield to='subtitle'}}</p>
+        {{/if}}
+      </header>
+
+      {{#if (has-block 'meta')}}
+        <div class='fc-meta'>{{yield to='meta'}}</div>
+      {{/if}}
+
+      {{#if (has-block 'footer')}}
+        <footer class='fc-footer'>{{yield to='footer'}}</footer>
+      {{/if}}
+    </div>
+
+  </article>
+
+  <style scoped>
+    @layer boxelComponentL1 {
+      /* ── Base layout ── */
+      .fitted-card {
+        --fc-content-padding: var(--boxel-sp-xs);
+        --fc-content-gap: var(--boxel-sp-3xs);
+        --fc-header-gap: var(--boxel-sp-6xs);
+        --fc-eyebrow-font-size: 0.625rem;
+        --fc-eyebrow-line-height: 1.1;
+        --fc-title-font-size: var(--boxel-font-size-sm);
+        --fc-title-line-height: 1.2;
+        --fc-title-line-clamp: 2;
+        --fc-subtitle-font-size: var(--boxel-font-size-xs);
+        --fc-subtitle-line-height: 1.1;
+        --fc-subtitle-line-clamp: 2;
+        --fc-image-width: 40cqh;
+        --fc-image-min-width: 3.75rem;
+        --fc-image-max-width: 12.5rem;
+        --fc-image-height: auto;
+        --fc-image-object-fit: cover;
+        --fc-image-background: linear-gradient(
+          180deg,
+          var(--muted) 0%,
+          var(--accent) 100%
+        );
+        --fc-image-fade-color: var(--card);
+        --fc-badge-offset: var(--boxel-sp-2xs);
+        --fc-content-gap-no-image: var(--boxel-sp-xs);
+        --fc-badge-row-gap: var(--boxel-sp-2xs);
+        --fc-badge-row-justify: space-between;
+        --fc-meta-font-size: var(--boxel-caption-font-size);
+        --fc-meta-line-height: 1.1;
+        --fc-meta-flex-wrap: nowrap;
+        --fc-meta-gap: var(--boxel-sp-2xs);
+        --fc-meta-justify: flex-start;
+        --fc-meta-align-items: center;
+        --fc-footer-font-size: var(--boxel-caption-font-size);
+        --fc-footer-gap: var(--boxel-sp-2xs);
+        --fc-footer-justify: flex-start;
+        --fc-footer-align-items: center;
+        --fc-footer-flex-wrap: nowrap;
+        --fc-content-justify: flex-start;
+        --fc-title-text-overflow: clip;
+        --fc-title-white-space: normal;
+        --fc-subtitle-text-overflow: clip;
+        --fc-subtitle-white-space: normal;
+        --fc-image-display: flex;
+        --fc-badge-right-display: block;
+        --fc-badge-left-display: block;
+        --fc-badge-row-display: flex;
+        --fc-subtitle-display: -webkit-box;
+        --fc-meta-display: flex;
+        --fc-footer-display: flex;
+
+        position: relative;
+        display: grid;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: var(--card);
+        color: var(--card-foreground);
+      }
+      .fitted-card:has(.fc-image) {
+        grid-template-columns: auto 1fr;
+      }
+
+      .fc-background {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        overflow: hidden;
+      }
+
+      /* ── Image column ── */
+      .fc-image {
+        position: relative;
+        width: var(--fc-image-width);
+        min-width: var(--fc-image-min-width);
+        max-width: var(--fc-image-max-width);
+        height: var(--fc-image-height);
+        overflow: hidden;
+        background: var(--fc-image-background);
+        display: var(--fc-image-display, flex);
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+      }
+      .fc-image img {
+        width: 100%;
+        height: 100%;
+        object-fit: var(--fc-image-object-fit);
+        display: block;
+      }
+      .fc-placeholder {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+      }
+
+      /* ── Text Content ── */
+      .fc-content {
+        display: flex;
+        flex-direction: column;
+        padding: var(--fc-content-padding);
+        gap: var(--fc-content-gap);
+        justify-content: var(--fc-content-justify);
+        overflow: hidden;
+        max-width: 100%;
+        min-width: 0;
+      }
+      .fitted-card:not(:has(.fc-image)) .fc-content {
+        gap: var(--fc-content-gap-no-image, var(--boxel-sp-xs));
+      }
+
+      /* ── Header ── */
+      .fc-header {
+        display: flex;
+        flex-direction: column;
+        gap: var(--fc-header-gap);
+        overflow: hidden;
+        max-width: 100%;
+        min-width: 0;
+        flex-shrink: 0;
+      }
+      .fc-eyebrow {
+        font-size: var(--fc-eyebrow-font-size);
+        font-weight: var(--boxel-caption-font-weight);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--muted-foreground);
+        margin: 0;
+        line-height: var(--fc-eyebrow-line-height);
+      }
+      .fc-title {
+        font-size: var(--fc-title-font-size);
+        font-weight: var(--boxel-heading-font-weight);
+        line-height: var(--fc-title-line-height);
+        margin: 0;
+        display: -webkit-box;
+        -webkit-line-clamp: var(--fc-title-line-clamp);
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: var(--fc-title-text-overflow);
+        white-space: var(--fc-title-white-space);
+        text-wrap: pretty;
+      }
+      .fc-subtitle {
+        font-size: var(--fc-subtitle-font-size);
+        color: var(--muted-foreground);
+        line-height: var(--fc-subtitle-line-height);
+        margin: 0;
+        display: var(--fc-subtitle-display, -webkit-box);
+        -webkit-line-clamp: var(--fc-subtitle-line-clamp);
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: var(--fc-subtitle-text-overflow);
+        white-space: var(--fc-subtitle-white-space);
+        text-wrap: pretty;
+      }
+
+      /* ── Meta ── */
+      .fc-meta {
+        display: var(--fc-meta-display, flex);
+        flex-wrap: var(--fc-meta-flex-wrap);
+        align-items: var(--fc-meta-align-items);
+        justify-content: var(--fc-meta-justify);
+        gap: var(--fc-meta-gap);
+        margin: 0;
+        font-size: var(--fc-meta-font-size);
+        line-height: var(--fc-meta-line-height);
+        overflow: hidden;
+      }
+
+      /* ── Footer ── */
+      .fc-footer {
+        display: var(--fc-footer-display, flex);
+        flex-wrap: var(--fc-footer-flex-wrap);
+        align-items: var(--fc-footer-align-items);
+        justify-content: var(--fc-footer-justify);
+        gap: var(--fc-footer-gap);
+        overflow: hidden;
+        font-size: var(--fc-footer-font-size);
+        margin-top: auto;
+        max-width: 100%;
+        min-width: 0;
+        flex-shrink: 0;
+      }
+
+      /* Hide block containers when yielded content is empty.
+         .fc-badge uses :not(:has(*)) rather than :empty because Glimmer emits
+         whitespace text nodes around block helpers in named slots, which prevents
+         :empty from matching even when no real content is rendered. */
+      .fc-eyebrow:empty,
+      .fc-background:empty,
+      .fc-subtitle:empty,
+      .fc-meta:empty,
+      .fc-footer:empty,
+      .fc-badge:not(:has(*)),
+      .fc-badge-row:empty {
+        display: none;
+      }
+
+      /* When <:placeholder> yields empty content, collapse the image column */
+      .fitted-card:has(.fc-placeholder:empty) {
+        grid-template-columns: 1fr;
+      }
+      .fc-image:has(> .fc-placeholder:empty) {
+        display: none;
+      }
+
+      /* ── Badges (always absolutely positioned relative to .fitted-card) ── */
+      .fc-badge {
+        position: absolute;
+        z-index: 1;
+        top: var(--fc-badge-offset);
+      }
+      .fc-badge-left {
+        left: var(--fc-badge-offset);
+        display: var(--fc-badge-left-display);
+      }
+      .fc-badge-right {
+        right: var(--fc-badge-offset);
+        display: var(--fc-badge-right-display);
+      }
+
+      /* ── Badge Row (flex positioning, inside content flow) ── */
+      .fc-badge-row {
+        display: var(--fc-badge-row-display, flex);
+        justify-content: var(--fc-badge-row-justify);
+        gap: var(--fc-badge-row-gap);
+      }
+
+      /* ────────────────────────────────────────────────────────────────
+           Container query breakpoints
+           (runtime provides the "fitted-card" container)
+           ──────────────────────────────────────────────────────────────── */
+
+      /* Small Badge 150x40 */
+      @container fitted-card (1.0 < aspect-ratio) and (width < 250px) and (height < 65px) {
+        .fitted-card {
+          --fc-content-padding: var(--boxel-sp-4xs);
+          --fc-title-line-clamp: 1;
+          --fc-image-display: none;
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+          --fc-badge-row-display: none;
+          --fc-subtitle-display: none;
+          --fc-meta-display: none;
+          --fc-footer-display: none;
+          --fc-content-justify: center;
+          --fc-title-text-overflow: ellipsis;
+          --fc-title-white-space: nowrap;
+          grid-template-columns: 1fr;
+        }
+      }
+      /* Medium Badge 150x65 */
+      @container fitted-card (1.0 < aspect-ratio) and (width < 250px) and (65px <= height < 105px) {
+        .fitted-card {
+          --fc-title-line-clamp: 1;
+          --fc-subtitle-line-clamp: 1;
+          --fc-image-display: none;
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+          --fc-badge-row-display: none;
+          --fc-meta-display: none;
+          --fc-footer-display: none;
+          --fc-content-justify: center;
+          --fc-title-text-overflow: ellipsis;
+          --fc-title-white-space: nowrap;
+          --fc-subtitle-text-overflow: ellipsis;
+          --fc-subtitle-white-space: nowrap;
+          grid-template-columns: 1fr;
+        }
+      }
+      /* Large Badge 150x105 */
+      @container fitted-card (1.0 < aspect-ratio) and (width < 250px) and (height >= 105px) {
+        .fitted-card {
+          --fc-image-display: none;
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+          --fc-badge-row-display: none;
+          --fc-meta-display: none;
+          --fc-content-justify: center;
+          grid-template-columns: 1fr;
+        }
+      }
+
+      /* Single Strip 250x40 */
+      @container fitted-card (1.0 < aspect-ratio) and (250px <= width) and (height < 65px) {
+        .fitted-card {
+          --fc-content-padding: var(--boxel-sp-4xs);
+          --fc-title-line-clamp: 1;
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+          --fc-badge-row-display: none;
+          --fc-subtitle-display: none;
+          --fc-meta-display: none;
+          --fc-footer-display: none;
+          --fc-content-justify: center;
+          --fc-title-text-overflow: ellipsis;
+          --fc-title-white-space: nowrap;
+        }
+      }
+      /* Double Strip 250x65 */
+      @container fitted-card (1.0 < aspect-ratio) and (250px <= width < 400px) and (65px <= height < 105px) {
+        .fitted-card {
+          --fc-title-line-clamp: 1;
+          --fc-subtitle-line-clamp: 1;
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+          --fc-badge-row-display: none;
+          --fc-meta-display: none;
+          --fc-footer-display: none;
+          --fc-content-justify: center;
+          --fc-title-text-overflow: ellipsis;
+          --fc-title-white-space: nowrap;
+          --fc-subtitle-text-overflow: ellipsis;
+          --fc-subtitle-white-space: nowrap;
+        }
+      }
+      /* Triple Strip 250x105 */
+      @container fitted-card (1.0 < aspect-ratio) and (250px <= width < 400px) and (105px <= height < 170px) {
+        .fitted-card {
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+          --fc-badge-row-display: none;
+          --fc-meta-display: none;
+          --fc-footer-display: none;
+        }
+      }
+      /* Double Wide Strip 400x65 */
+      @container fitted-card (1.0 < aspect-ratio) and (400px <= width) and (65px <= height < 105px) {
+        .fitted-card {
+          --fc-image-width: 40cqw;
+          --fc-title-line-clamp: 1;
+          --fc-subtitle-line-clamp: 1;
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+          --fc-badge-row-display: none;
+          --fc-meta-display: none;
+          --fc-footer-display: none;
+          --fc-content-justify: center;
+          --fc-title-text-overflow: ellipsis;
+          --fc-title-white-space: nowrap;
+          --fc-subtitle-text-overflow: ellipsis;
+          --fc-subtitle-white-space: nowrap;
+        }
+        :has(.fc-image) {
+          --fc-badge-left-display: block;
+        }
+      }
+      /* Triple Wide Strip 400x105 */
+      @container fitted-card (1.0 < aspect-ratio) and (400px <= width) and (105px <= height < 170px) {
+        .fitted-card {
+          --fc-image-width: 40cqw;
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+          --fc-badge-row-display: none;
+          --fc-meta-display: none;
+          --fc-footer-display: none;
+        }
+        :has(.fc-image) {
+          --fc-badge-left-display: block;
+        }
+      }
+
+      /* ── Vertical & square tiles ── */
+      @container fitted-card (aspect-ratio <= 1.0) {
+        .fitted-card {
+          --fc-image-width: 100%;
+          --fc-image-max-width: 100%;
+          --fc-image-height: 45cqmin;
+          grid-template-columns: 1fr;
+        }
+        .fitted-card:has(.fc-image) {
+          grid-template-columns: 1fr;
+          grid-template-rows: auto 1fr;
+        }
+      }
+      /* Vertical & square, taller than 250px */
+      @container fitted-card (aspect-ratio <= 1.0) and (250px <= height) {
+        .fitted-card {
+          --fc-image-height: 55cqmin;
+        }
+      }
+      /* Small Tile and smaller (150x170) */
+      @container fitted-card (aspect-ratio <= 1.0) and (width <= 150px) and (height <= 170px) {
+        .fitted-card {
+          --fc-title-font-size: var(--boxel-font-size-xs);
+          --fc-badge-row-display: none;
+          --fc-meta-display: none;
+        }
+        :not(:has(.fc-image)) {
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+        }
+      }
+      /* Vertical, shorter than small-tile */
+      @container fitted-card (aspect-ratio <= 1.0) and (height < 170px) {
+        .fitted-card {
+          --fc-subtitle-line-clamp: 1;
+          --fc-meta-display: none;
+          --fc-footer-display: none;
+          --fc-subtitle-text-overflow: ellipsis;
+          --fc-subtitle-white-space: nowrap;
+        }
+      }
+      /* Vertical, narrower than 140px; hide badge */
+      @container fitted-card (aspect-ratio <= 1.0) and (width < 140px) {
+        .fitted-card {
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+        }
+      }
+      /* Regular Tile 250x170 */
+      @container fitted-card (1.0 < aspect-ratio) and (250px <= width < 400px) and (170px <= height) {
+        .fitted-card:not(:has(.fc-image)) {
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+        }
+      }
+      /* CardsGrid Tile ~170x250 */
+      @container fitted-card (aspect-ratio <= 1.0) and (155px <= width <= 185px) and (height >= 200px) {
+        .fitted-card {
+          --fc-meta-display: none;
+        }
+        .fitted-card:not(:has(.fc-image)) {
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+        }
+      }
+      /* Tall Tile ~150x275 */
+      @container fitted-card (aspect-ratio <= 1.0) and (150px <= width < 250px) and (height >= 250px) {
+        .fitted-card:not(:has(.fc-image)) {
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+        }
+      }
+      /* Large Tile ~250x275 */
+      @container fitted-card (aspect-ratio <= 1.0) and (250px <= width < 400px) and (height >= 250px) {
+        .fitted-card:not(:has(.fc-image)) {
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+        }
+      }
+
+      /* Compact Card (400x170) */
+      @container fitted-card (1.0 < aspect-ratio) and (width >= 400px) and (170px <= height < 275px) {
+        .fitted-card {
+          --fc-content-padding: var(--boxel-sp-xs);
+          --fc-content-gap: var(--boxel-sp-2xs);
+          --fc-header-gap: var(--boxel-sp-3xs);
+          --fc-image-width: 40cqw;
+          --fc-content-justify: space-between;
+        }
+        .fitted-card:not(:has(.fc-image)) {
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+        }
+      }
+      /* Full Card (400x275) */
+      @container fitted-card (1.0 < aspect-ratio) and (width >= 400px) and (275px <= height < 445px) {
+        .fitted-card {
+          --fc-content-padding: var(--boxel-sp-xs);
+          --fc-content-gap: var(--boxel-sp-xs);
+          --fc-header-gap: var(--boxel-sp-2xs);
+          --fc-image-width: 40cqw;
+          --fc-title-font-size: var(--boxel-font-size);
+          --fc-title-line-clamp: 3;
+          --fc-subtitle-font-size: var(--boxel-font-size-sm);
+          --fc-subtitle-line-clamp: 3;
+          --fc-content-justify: space-between;
+        }
+        .fitted-card:not(:has(.fc-image)) {
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+        }
+      }
+      /* No-image layout: extra padding increase beyond what card breakpoints set */
+      @container fitted-card (width >= 400px) and (170px <= height < 275px) {
+        .fitted-card:not(:has(.fc-image)) {
+          --fc-content-padding: var(--boxel-sp-sm);
+        }
+      }
+      @container fitted-card (width >= 400px) and (height >= 275px) {
+        .fitted-card:not(:has(.fc-image)) {
+          --fc-content-padding: var(--boxel-sp);
+        }
+      }
+      @container fitted-card (aspect-ratio <= 1.0) and (height >= 250px) {
+        .fitted-card:not(:has(.fc-image)) {
+          --fc-header-gap: var(--boxel-sp-3xs);
+          --fc-content-padding: var(--boxel-sp-sm);
+          --fc-content-justify: space-between;
+        }
+      }
+
+      /* Expanded Card (400x445) */
+      @container fitted-card (aspect-ratio <= 1.0) and (width >= 400px) and (445px <= height) {
+        .fitted-card {
+          --fc-content-padding: var(--boxel-sp);
+          --fc-content-gap: var(--boxel-sp);
+          --fc-image-height: 50cqh;
+          --fc-eyebrow-line-height: 1.2;
+          --fc-title-font-size: var(--boxel-font-size);
+          --fc-title-line-height: 1.3;
+          --fc-title-line-clamp: 3;
+          --fc-subtitle-font-size: var(--boxel-font-size-sm);
+          --fc-subtitle-line-clamp: 3;
+        }
+        .fitted-card:not(:has(.fc-image)) {
+          --fc-badge-right-display: none;
+          --fc-badge-left-display: none;
+        }
+        .fc-image {
+          position: relative;
+        }
+        /* Fade image into card background */
+        .fc-image::after {
+          content: '';
+          position: absolute;
+          inset: auto 0 0;
+          height: 35%;
+          background: linear-gradient(
+            to bottom,
+            transparent,
+            var(--fc-image-fade-color)
+          );
+          pointer-events: none;
+        }
+        .fc-footer {
+          gap: var(--boxel-sp-sm);
+        }
+      }
+    }
+  </style>
+</template>;
+
+export default FittedCard;

--- a/packages/boxel-ui/addon/src/components/fitted-card/index.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card/index.gts
@@ -579,7 +579,7 @@ export const FittedCard: TemplateOnlyComponent<FittedCardSignature> = <template>
           --fc-subtitle-text-overflow: ellipsis;
           --fc-subtitle-white-space: nowrap;
         }
-        :has(.fc-image) {
+        .fitted-card:has(.fc-image) {
           --fc-badge-left-display: block;
         }
       }
@@ -593,7 +593,7 @@ export const FittedCard: TemplateOnlyComponent<FittedCardSignature> = <template>
           --fc-meta-display: none;
           --fc-footer-display: none;
         }
-        :has(.fc-image) {
+        .fitted-card:has(.fc-image) {
           --fc-badge-left-display: block;
         }
       }

--- a/packages/boxel-ui/addon/src/components/fitted-card/usage-preview.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card/usage-preview.gts
@@ -103,6 +103,9 @@ export const FittedItemContainer: TemplateOnlyComponent<FittedItemContainerSigna
         position: absolute;
         top: 0;
         right: 0;
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp-4xs);
         padding: var(--boxel-sp-4xs);
         background-color: var(--boxel-light);
         border-left: var(--boxel-border-card);
@@ -114,11 +117,6 @@ export const FittedItemContainer: TemplateOnlyComponent<FittedItemContainerSigna
       h4 {
         margin: 0;
         font-weight: 500;
-      }
-      .desc {
-        display: flex;
-        align-items: center;
-        gap: var(--boxel-sp-4xs);
       }
       .copy-btn {
         margin-left: auto;

--- a/packages/boxel-ui/addon/src/components/fitted-card/usage-preview.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card/usage-preview.gts
@@ -1,0 +1,162 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+
+import { type FittedFormatSpec, cn, gt, gte } from '../../helpers.ts';
+import CopyButton from '../copy-button/index.gts';
+
+export type Spec = Partial<FittedFormatSpec> & {
+  height: number;
+  width: number;
+};
+
+export const calcRatio = ({ width, height }: Spec) =>
+  (width / height).toFixed(2);
+
+const QUERIES: Record<string, string> = {
+  'small-badge': '(1.0 < aspect-ratio) and (width < 250px) and (height < 65px)',
+  'medium-badge':
+    '(1.0 < aspect-ratio) and (width < 250px) and (65px <= height < 105px)',
+  'large-badge':
+    '(1.0 < aspect-ratio) and (width < 250px) and (height >= 105px)',
+  'single-strip':
+    '(1.0 < aspect-ratio) and (250px <= width) and (height < 65px)',
+  'double-strip':
+    '(1.0 < aspect-ratio) and (250px <= width < 400px) and (65px <= height < 105px)',
+  'triple-strip':
+    '(1.0 < aspect-ratio) and (250px <= width < 400px) and (105px <= height < 170px)',
+  'double-wide-strip':
+    '(1.0 < aspect-ratio) and (400px <= width) and (65px <= height < 105px)',
+  'triple-wide-strip':
+    '(1.0 < aspect-ratio) and (400px <= width) and (105px <= height < 170px)',
+  'small-tile':
+    '(aspect-ratio <= 1.0) and (width <= 150px) and (height <= 170px)',
+  'regular-tile':
+    '(1.0 < aspect-ratio) and (250px <= width < 400px) and (170px <= height)',
+  'cardsgrid-tile':
+    '(aspect-ratio <= 1.0) and (155px <= width <= 185px) and (height >= 200px)',
+  'tall-tile':
+    '(aspect-ratio <= 1.0) and (150px <= width < 250px) and (250px <= height)',
+  'large-tile':
+    '(aspect-ratio <= 1.0) and (250px <= width < 400px) and (250px <= height)',
+  'compact-card':
+    '(1.0 < aspect-ratio) and (width >= 400px) and (170px <= height < 275px)',
+  'full-card':
+    '(1.0 < aspect-ratio) and (width >= 400px) and (275px <= height < 445px)',
+  'expanded-card':
+    '(aspect-ratio <= 1.0) and (width >= 400px) and (445px <= height)',
+};
+
+const containerQuery = (spec: Spec) => {
+  const conditions =
+    spec.id && QUERIES[spec.id]
+      ? QUERIES[spec.id]
+      : `(${spec.width}px <= width) and (${spec.height}px <= height)`;
+  return `@container fitted-card ${conditions} { }`;
+};
+
+interface FittedItemContainerSignature {
+  Args: { spec: Spec };
+  Blocks: { default: [] };
+}
+
+export const FittedItemContainer: TemplateOnlyComponent<FittedItemContainerSignature> =
+  <template>
+    <div
+      class={{cn
+        'item'
+        wide=(gt @spec.width 300)
+        full-width=(gte @spec.width 400)
+      }}
+    >
+      <div class='desc'>
+        <h4>{{@spec.title}} {{@spec.width}}px &times; {{@spec.height}}px</h4>
+        Aspect Ratio
+        {{calcRatio @spec}}
+        <CopyButton
+          @textToCopy={{containerQuery @spec}}
+          @tooltipText='Copy @container query'
+          @size='extra-small'
+          @variant='secondary'
+          class='copy-btn'
+        />
+      </div>
+      {{yield}}
+    </div>
+    <style scoped>
+      .item {
+        position: relative;
+        padding-top: 50px;
+        padding-inline: var(--boxel-sp);
+        padding-bottom: var(--boxel-sp);
+        background-color: color-mix(
+          in oklab,
+          var(--background, var(--boxel-light)) 90%,
+          var(--foreground, var(--boxel-dark))
+        );
+      }
+      .wide {
+        grid-column: span 2;
+      }
+      .full-width {
+        grid-column: -1 / 1;
+      }
+      .desc {
+        position: absolute;
+        top: 0;
+        right: 0;
+        padding: var(--boxel-sp-4xs);
+        background-color: var(--boxel-light);
+        border-left: var(--boxel-border-card);
+        border-right: var(--boxel-border-card);
+        border-bottom: var(--boxel-border-card);
+        color: var(--muted-foreground, var(--boxel-450));
+        font: var(--boxel-font-xs);
+      }
+      h4 {
+        margin: 0;
+        font-weight: 500;
+      }
+      .desc {
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp-4xs);
+      }
+      .copy-btn {
+        margin-left: auto;
+        flex-shrink: 0;
+      }
+    </style>
+  </template>;
+
+interface FittedUsagePreviewSignature {
+  Args: { specs: { items: Spec[]; title: string }[] };
+  Blocks: { default: [spec: Spec] };
+}
+
+export const FittedUsagePreview: TemplateOnlyComponent<FittedUsagePreviewSignature> =
+  <template>
+    <div class='scroller' tabindex='0'>
+      {{#each @specs as |specGroup|}}
+        <h3>{{specGroup.title}}</h3>
+        {{#each specGroup.items as |spec|}}
+          <FittedItemContainer @spec={{spec}}>
+            {{yield spec}}
+          </FittedItemContainer>
+        {{/each}}
+      {{/each}}
+    </div>
+    <style scoped>
+      .scroller {
+        max-height: 40vh;
+        overflow-y: scroll;
+        border: 1px solid var(--border, var(--boxel-200));
+        padding: 10px;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        gap: var(--boxel-sp-xs);
+      }
+      h3 {
+        grid-column: -1 / 1;
+        font-weight: 500;
+      }
+    </style>
+  </template>;

--- a/packages/boxel-ui/addon/src/components/fitted-card/usage.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card/usage.gts
@@ -1,0 +1,667 @@
+import BookOpen from '@cardstack/boxel-icons/book-open';
+import Calendar from '@cardstack/boxel-icons/calendar';
+import { fn, hash } from '@ember/helper';
+import { htmlSafe } from '@ember/template';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+
+import { FITTED_FORMATS } from '../../helpers.ts';
+import CardContainer from '../card-container/index.gts';
+import FittedCardContainer from '../fitted-card-container/index.gts';
+import BoxelInput from '../input/index.gts';
+import Pill from '../pill/index.gts';
+import { FittedCard } from './index.gts';
+import { FittedUsagePreview } from './usage-preview.gts';
+
+type BoolField =
+  | 'showImage'
+  | 'showPlaceholder'
+  | 'showEyebrow'
+  | 'showSubtitle'
+  | 'showMeta'
+  | 'showFooter'
+  | 'showBadgeLeft'
+  | 'showBadgeRight'
+  | 'showBadgeRow';
+
+interface FittedCardDemoState {
+  showBadgeLeft: boolean;
+  showBadgeRight: boolean;
+  showBadgeRow: boolean;
+  showEyebrow: boolean;
+  showFooter: boolean;
+  showImage: boolean;
+  showMeta: boolean;
+  showPlaceholder: boolean;
+  showSubtitle: boolean;
+}
+
+interface FittedCardDemoSignature {
+  Blocks: {
+    default: [FittedCardDemoState];
+  };
+}
+
+class FittedCardDemo extends Component<FittedCardDemoSignature> {
+  @tracked showImage = true;
+  @tracked showPlaceholder = true;
+  @tracked showEyebrow = true;
+  @tracked showSubtitle = true;
+  @tracked showMeta = true;
+  @tracked showFooter = true;
+  @tracked showBadgeLeft = false;
+  @tracked showBadgeRight = false;
+  @tracked showBadgeRow = false;
+
+  specs = [
+    ...FITTED_FORMATS.flatMap((format) => ({
+      title: format.name,
+      items: format.specs,
+    })),
+  ];
+
+  setCheck = (field: BoolField, event: Event) => {
+    this[field] = (event.target as HTMLInputElement).checked;
+  };
+
+  <template>
+    {{! template-lint-disable no-inline-styles style-concatenation }}
+    <div class='demo'>
+      <div class='demo-controls'>
+        <label class='demo-toggle'>
+          <BoxelInput
+            @type='checkbox'
+            @value={{this.showImage}}
+            @onChange={{fn this.setCheck 'showImage'}}
+          />
+          Image
+        </label>
+        <label class='demo-toggle'>
+          <BoxelInput
+            @type='checkbox'
+            @value={{this.showPlaceholder}}
+            @onChange={{fn this.setCheck 'showPlaceholder'}}
+          />
+          Placeholder
+        </label>
+        <label class='demo-toggle'>
+          <BoxelInput
+            @type='checkbox'
+            @value={{this.showEyebrow}}
+            @onChange={{fn this.setCheck 'showEyebrow'}}
+          />
+          Eyebrow
+        </label>
+        <label class='demo-toggle'>
+          <BoxelInput
+            @type='checkbox'
+            @value={{this.showSubtitle}}
+            @onChange={{fn this.setCheck 'showSubtitle'}}
+          />
+          Subtitle
+        </label>
+        <label class='demo-toggle'>
+          <BoxelInput
+            @type='checkbox'
+            @value={{this.showMeta}}
+            @onChange={{fn this.setCheck 'showMeta'}}
+          />
+          Meta
+        </label>
+        <label class='demo-toggle'>
+          <BoxelInput
+            @type='checkbox'
+            @value={{this.showFooter}}
+            @onChange={{fn this.setCheck 'showFooter'}}
+          />
+          Footer
+        </label>
+        <label class='demo-toggle'>
+          <BoxelInput
+            @type='checkbox'
+            @value={{this.showBadgeLeft}}
+            @onChange={{fn this.setCheck 'showBadgeLeft'}}
+          />
+          Badge Left
+        </label>
+        <label class='demo-toggle'>
+          <BoxelInput
+            @type='checkbox'
+            @value={{this.showBadgeRight}}
+            @onChange={{fn this.setCheck 'showBadgeRight'}}
+          />
+          Badge Right
+        </label>
+        <label class='demo-toggle'>
+          <BoxelInput
+            @type='checkbox'
+            @value={{this.showBadgeRow}}
+            @onChange={{fn this.setCheck 'showBadgeRow'}}
+          />
+          Badge Row
+        </label>
+      </div>
+      <FittedUsagePreview @specs={{this.specs}} as |spec|>
+        <FittedCardContainer @size={{spec.id}}>
+          <CardContainer
+            @displayBoundaries={{true}}
+            style={{htmlSafe
+              'container-name: fitted-card; container-type: size; width: 100%; height: 100%'
+            }}
+          >
+            {{yield
+              (hash
+                showImage=this.showImage
+                showPlaceholder=this.showPlaceholder
+                showEyebrow=this.showEyebrow
+                showSubtitle=this.showSubtitle
+                showMeta=this.showMeta
+                showFooter=this.showFooter
+                showBadgeLeft=this.showBadgeLeft
+                showBadgeRight=this.showBadgeRight
+                showBadgeRow=this.showBadgeRow
+              )
+            }}
+          </CardContainer>
+        </FittedCardContainer>
+      </FittedUsagePreview>
+    </div>
+    <style scoped>
+      .demo {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-xs);
+      }
+      .demo-controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp-xs);
+        background-color: var(--background, var(--boxel-light));
+        border: 1px solid var(--border, var(--boxel-200));
+        border-radius: var(--boxel-border-radius-sm);
+      }
+      .demo-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--boxel-sp-4xs);
+        font: var(--boxel-font-xs);
+        cursor: pointer;
+      }
+    </style>
+  </template>
+}
+
+export default class FittedCardUsage extends Component {
+  @tracked imageUrl: string =
+    'https://boxel-images.boxel.ai/app-assets/blog-posts/space-movie-thumb.jpeg';
+  @tracked imageAlt: string = 'A sci-fi movie still';
+
+  <template>
+    <FreestyleUsage @name='FittedCard'>
+      <:description>
+        Responsive fitted-format card layout. Adapts automatically across all 16
+        fitted sizes — from small badges to expanded cards — via CSS container
+        queries on a named container provided by the runtime. All content is
+        supplied via named blocks; only
+        <code>title</code>
+        is required.
+        <pre>
+          .sample-container-class {
+            /* customize css vars here */
+            container-name: fitted-card;
+            container-type: size;
+            width: /* ... */;
+            height: /* ... */;
+          }
+        </pre>
+        <strong>CSS custom properties</strong>
+        — set on a custom class name on the card root element to override
+        defaults:
+        <br /><br />
+        <table>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Default</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td colspan='3'><em>Layout</em></td>
+            </tr>
+            <tr>
+              <td><code>--fc-content-padding</code></td>
+              <td><code>--boxel-sp-xs</code></td>
+              <td>Padding inside the text column</td>
+            </tr>
+            <tr>
+              <td><code>--fc-content-gap</code></td>
+              <td><code>--boxel-sp-3xs</code></td>
+              <td>Gap between header, meta, and footer</td>
+            </tr>
+            <tr>
+              <td><code>--fc-content-gap-no-image</code></td>
+              <td><code>--boxel-sp-xs</code></td>
+              <td>Gap override applied when there is no image column</td>
+            </tr>
+            <tr>
+              <td><code>--fc-header-gap</code></td>
+              <td><code>--boxel-sp-6xs</code></td>
+              <td>Gap between eyebrow, title, and subtitle</td>
+            </tr>
+            <tr>
+              <td colspan='3'><em>Image column</em></td>
+            </tr>
+            <tr>
+              <td><code>--fc-image-width</code></td>
+              <td><code>40cqh</code></td>
+              <td>Width of the image column in horizontal layouts</td>
+            </tr>
+            <tr>
+              <td><code>--fc-image-min-width</code></td>
+              <td><code>3.75rem</code></td>
+              <td>Minimum width of the image column</td>
+            </tr>
+            <tr>
+              <td><code>--fc-image-max-width</code></td>
+              <td><code>12.5rem</code></td>
+              <td>Maximum width cap for the image column</td>
+            </tr>
+            <tr>
+              <td><code>--fc-image-height</code></td>
+              <td><code>auto</code></td>
+              <td>
+                Height of the image area in vertical/tile layouts; breakpoints
+                override this with a
+                <code>cqmin</code>
+                value
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-image-background</code></td>
+              <td><code>linear-gradient(var(--muted), var(--accent))</code></td>
+              <td>
+                Background of the image column when no image fills it
+                (placeholder or empty)
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-image-fade-color</code></td>
+              <td><code>var(--card)</code></td>
+              <td>
+                Base color for the expanded-card image-to-content fade gradient;
+                set to match a custom card background
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-image-object-fit</code></td>
+              <td><code>cover</code></td>
+              <td>
+                <code>object-fit</code>
+                for the cover image
+              </td>
+            </tr>
+            <tr>
+              <td colspan='3'><em>Absolute badges</em></td>
+            </tr>
+            <tr>
+              <td><code>--fc-badge-offset</code></td>
+              <td><code>--boxel-sp-2xs</code></td>
+              <td>
+                Inset from card edges for absolutely-positioned
+                <code>badgeLeft</code>
+                /
+                <code>badgeRight</code>
+                badges
+              </td>
+            </tr>
+            <tr>
+              <td colspan='3'><em>Badge row</em></td>
+            </tr>
+            <tr>
+              <td><code>--fc-badge-row-justify</code></td>
+              <td><code>space-between</code></td>
+              <td>
+                <code>justify-content</code>
+                for the badge row
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-badge-row-gap</code></td>
+              <td><code>--boxel-sp-2xs</code></td>
+              <td>Gap between badge row items</td>
+            </tr>
+            <tr>
+              <td colspan='3'><em>Typography</em></td>
+            </tr>
+            <tr>
+              <td><code>--fc-eyebrow-font-size</code></td>
+              <td><code>0.625rem</code></td>
+              <td rowspan='2'>Eyebrow text size and line height</td>
+            </tr>
+            <tr>
+              <td><code>--fc-eyebrow-line-height</code></td>
+              <td><code>1.1</code></td>
+            </tr>
+            <tr>
+              <td><code>--fc-title-font-size</code></td>
+              <td><code>--boxel-font-size-sm</code></td>
+              <td rowspan='3'>Title text size, line height, and max lines before
+                truncation</td>
+            </tr>
+            <tr>
+              <td><code>--fc-title-line-height</code></td>
+              <td><code>1.2</code></td>
+            </tr>
+            <tr>
+              <td><code>--fc-title-line-clamp</code></td>
+              <td><code>2</code></td>
+            </tr>
+            <tr>
+              <td><code>--fc-subtitle-font-size</code></td>
+              <td><code>--boxel-font-size-xs</code></td>
+              <td rowspan='3'>Subtitle text size, line height, and max lines
+                before truncation</td>
+            </tr>
+            <tr>
+              <td><code>--fc-subtitle-line-height</code></td>
+              <td><code>1.1</code></td>
+            </tr>
+            <tr>
+              <td><code>--fc-subtitle-line-clamp</code></td>
+              <td><code>2</code></td>
+            </tr>
+            <tr>
+              <td><code>--fc-meta-font-size</code></td>
+              <td><code>--boxel-caption-font-size</code></td>
+              <td rowspan='2'>Meta row text size and line height</td>
+            </tr>
+            <tr>
+              <td><code>--fc-meta-line-height</code></td>
+              <td><code>1.1</code></td>
+            </tr>
+            <tr>
+              <td><code>--fc-footer-font-size</code></td>
+              <td><code>--boxel-caption-font-size</code></td>
+              <td>Footer row text size</td>
+            </tr>
+            <tr>
+              <td colspan='3'><em>Meta &amp; footer flex row</em></td>
+            </tr>
+            <tr>
+              <td><code>--fc-meta-justify</code></td>
+              <td><code>flex-start</code></td>
+              <td>
+                <code>justify-content</code>
+                for the meta row
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-meta-align-items</code></td>
+              <td><code>center</code></td>
+              <td>
+                <code>align-items</code>
+                for the meta row
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-meta-gap</code></td>
+              <td><code>--boxel-sp-2xs</code></td>
+              <td>Gap between meta items</td>
+            </tr>
+            <tr>
+              <td><code>--fc-meta-flex-wrap</code></td>
+              <td><code>nowrap</code></td>
+              <td>
+                <code>flex-wrap</code>
+                for the meta row
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-footer-justify</code></td>
+              <td><code>flex-start</code></td>
+              <td>
+                <code>justify-content</code>
+                for the footer row
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-footer-align-items</code></td>
+              <td><code>center</code></td>
+              <td>
+                <code>align-items</code>
+                for the footer row
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-footer-gap</code></td>
+              <td><code>--boxel-sp-2xs</code></td>
+              <td>Gap between footer items</td>
+            </tr>
+            <tr>
+              <td><code>--fc-footer-flex-wrap</code></td>
+              <td><code>nowrap</code></td>
+              <td>
+                <code>flex-wrap</code>
+                for the footer row
+              </td>
+            </tr>
+            <tr>
+              <td colspan='3'><em>Section visibility</em></td>
+            </tr>
+            <tr>
+              <td><code>--fc-image-display</code></td>
+              <td><code>flex</code></td>
+              <td>
+                <code>display</code>
+                for the image column; set to
+                <code>none</code>
+                to hide,
+                <code>flex</code>
+                to force-show
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-badge-left-display</code></td>
+              <td><code>block</code></td>
+              <td>
+                <code>display</code>
+                for the absolute left badge; set to
+                <code>none</code>
+                to hide,
+                <code>block</code>
+                to force-show
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-badge-right-display</code></td>
+              <td><code>block</code></td>
+              <td>
+                <code>display</code>
+                for the absolute right badge; set to
+                <code>none</code>
+                to hide,
+                <code>block</code>
+                to force-show
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-badge-row-display</code></td>
+              <td><code>flex</code></td>
+              <td>
+                <code>display</code>
+                for the badge row; set to
+                <code>none</code>
+                to hide,
+                <code>flex</code>
+                to force-show
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-subtitle-display</code></td>
+              <td><code>-webkit-box</code></td>
+              <td>
+                <code>display</code>
+                for the subtitle; set to
+                <code>none</code>
+                to hide
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-meta-display</code></td>
+              <td><code>flex</code></td>
+              <td>
+                <code>display</code>
+                for the meta row; set to
+                <code>none</code>
+                to hide,
+                <code>flex</code>
+                to force-show
+              </td>
+            </tr>
+            <tr>
+              <td><code>--fc-footer-display</code></td>
+              <td><code>flex</code></td>
+              <td>
+                <code>display</code>
+                for the footer row; set to
+                <code>none</code>
+                to hide,
+                <code>flex</code>
+                to force-show
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </:description>
+      <:example>
+        <FittedCardDemo as |demo|>
+          <FittedCard
+            class='my-fitted-card-class'
+            @imageUrl={{if demo.showImage this.imageUrl}}
+            @imageAlt={{this.imageAlt}}
+            @titleTag='h5'
+          >
+            <:placeholder>{{#if demo.showPlaceholder}}<BookOpen
+                  width='24'
+                  height='24'
+                />{{/if}}</:placeholder>
+            <:eyebrow>{{#if demo.showEyebrow}}Movie Review{{/if}}</:eyebrow>
+            <:title>Singularity&rsquo;s Echo &ndash; A Mind-Bending Sci-Fi
+              Masterpiece</:title>
+            <:subtitle>{{#if demo.showSubtitle}}In an era hungry for
+                originality, "Singularity's Echo" emerges as a luminous beacon
+                in the cosmic darkness—an audacious journey that redefines what
+                viewers can expect from the genre. Directed by the elusive
+                auteur Oruni Kilrain, this film harnesses the raw power of
+                interstellar wonder and transforms it into a multilayered
+                narrative tapestry. Blending heart-stirring drama with
+                disorienting visuals, "Singularity's Echo" reminds us that true
+                cinematic frontiers remain ripe for exploration, stretching
+                beyond the gravitational pull of safe storytelling.{{/if}}</:subtitle>
+            <:meta>{{#if demo.showMeta}}<Calendar width='14' height='14' />
+                Oct 17, 2024{{/if}}</:meta>
+            <:footer>{{#if demo.showFooter}}<strong>Robert Fields</strong>{{/if}}</:footer>
+            <:badgeLeft>
+              {{#if demo.showBadgeLeft}}
+                <Pill @variant='primary'>New</Pill>
+              {{/if}}
+            </:badgeLeft>
+            <:badgeRight>
+              {{#if demo.showBadgeRight}}
+                <Pill @variant='muted'>4.8 ★</Pill>
+              {{/if}}
+            </:badgeRight>
+            <:badgeRow>{{#if demo.showBadgeRow}}<Pill
+                  @variant='accent'
+                >Sci-Fi</Pill><Pill @variant='secondary'>4.8 ★</Pill>{{/if}}</:badgeRow>
+          </FittedCard>
+        </FittedCardDemo>
+      </:example>
+      <:api as |Args|>
+        <Args.String
+          @name='imageUrl'
+          @description='Cover image URL. When present the image column is shown; omit to show the placeholder block instead.'
+          @value={{this.imageUrl}}
+          @onInput={{fn (mut this.imageUrl)}}
+        />
+        <Args.String
+          @name='imageAlt'
+          @description='Alt text for the cover image.'
+          @value={{this.imageAlt}}
+          @onInput={{fn (mut this.imageAlt)}}
+        />
+        <Args.String
+          @name='imageLoading'
+          @description="Loading behaviour for the cover image: 'lazy' or 'eager'. Omit to use the browser default."
+        />
+        <Args.String
+          @name='titleTag'
+          @description="HTML heading element for the title: 'h1' (default), 'h2', 'h3', etc. Pass 'h2' or 'h3' when cards appear in a list to preserve heading hierarchy."
+        />
+        <Args.Yield
+          @name='title'
+          @description='Primary heading.'
+          @required={{true}}
+        />
+        <Args.Yield
+          @name='placeholder'
+          @description='Icon or content shown in the image column when @imageUrl is absent. Omitting this block removes the image column entirely.'
+        />
+        <Args.Yield
+          @name='image'
+          @description='Custom image block, rendered directly inside the image column. Alternative to @imageUrl for when you need markup rather than a bare URL.'
+        />
+        <Args.Yield
+          @name='background'
+          @description='Absolutely-positioned layer behind all content. Use for decorative background graphics or patterns.'
+        />
+        <Args.Yield
+          @name='eyebrow'
+          @description='Tiny uppercase overline rendered above the title. Styled with muted-foreground color and letter-spacing.'
+        />
+        <Args.Yield
+          @name='subtitle'
+          @description='Secondary line rendered below the title. Hidden at small sizes; line-clamped at larger ones.'
+        />
+        <Args.Yield
+          @name='meta'
+          @description='Additional content between the header and footer. Use for stats, tags, or secondary metadata. Hidden at strip and badge sizes.'
+        />
+        <Args.Yield
+          @name='footer'
+          @description='Bottom row for date, location, price, stats, etc. Anchored to the bottom of the content column. Hidden at badge and strip sizes.'
+        />
+        <Args.Yield
+          @name='badgeLeft'
+          @description='Absolutely-positioned group at the top-left corner of the card (over the image when present). Use for status pills or labels.'
+        />
+        <Args.Yield
+          @name='badgeRight'
+          @description='Absolutely-positioned group at the top-right corner of the card.'
+        />
+        <Args.Yield
+          @name='badgeRow'
+          @description='Inline flex row of badges or pills rendered above the header, inside the text column. Use for tags or category chips. Controlled by --fc-badge-row-justify (default space-between) and --fc-badge-row-gap.'
+        />
+      </:api>
+    </FreestyleUsage>
+    <style scoped>
+      table {
+        font-size: 0.8rem;
+      }
+      table td:first-child code {
+        white-space: nowrap;
+      }
+      em {
+        font-weight: 600;
+      }
+      strong {
+        font-weight: 500;
+      }
+    </style>
+  </template>
+}

--- a/packages/boxel-ui/addon/src/components/fitted-card/usage.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card/usage.gts
@@ -11,7 +11,13 @@ import CardContainer from '../card-container/index.gts';
 import FittedCardContainer from '../fitted-card-container/index.gts';
 import BoxelInput from '../input/index.gts';
 import Pill from '../pill/index.gts';
-import { FittedCard } from './index.gts';
+import {
+  type FittedCardLayout,
+  type FittedCardTitleTag,
+  FITTED_CARD_LAYOUT_OPTIONS,
+  FITTED_CARD_TITLE_TAG_OPTIONS,
+  FittedCard,
+} from './index.gts';
 import { FittedUsagePreview } from './usage-preview.gts';
 
 type BoolField =
@@ -197,6 +203,12 @@ export default class FittedCardUsage extends Component {
   @tracked imageUrl: string =
     'https://boxel-images.boxel.ai/app-assets/blog-posts/space-movie-thumb.jpeg';
   @tracked imageAlt: string = 'A sci-fi movie still';
+  @tracked imageLoading: 'eager' | 'lazy' | undefined = undefined;
+  @tracked layout: FittedCardLayout = 'auto';
+  @tracked titleTag: FittedCardTitleTag = 'h5';
+  imageLoadingOptions = ['lazy', 'eager'];
+  layoutOptions = FITTED_CARD_LAYOUT_OPTIONS;
+  titleTagOptions = FITTED_CARD_TITLE_TAG_OPTIONS;
 
   <template>
     <FreestyleUsage @name='FittedCard'>
@@ -543,7 +555,9 @@ export default class FittedCardUsage extends Component {
             class='my-fitted-card-class'
             @imageUrl={{if demo.showImage this.imageUrl}}
             @imageAlt={{this.imageAlt}}
-            @titleTag='h5'
+            @imageLoading={{this.imageLoading}}
+            @layout={{this.layout}}
+            @titleTag={{this.titleTag}}
           >
             <:placeholder>{{#if demo.showPlaceholder}}<BookOpen
                   width='24'
@@ -597,10 +611,23 @@ export default class FittedCardUsage extends Component {
         <Args.String
           @name='imageLoading'
           @description="Loading behaviour for the cover image: 'lazy' or 'eager'. Omit to use the browser default."
+          @options={{this.imageLoadingOptions}}
+          @value={{this.imageLoading}}
+          @onInput={{fn (mut this.imageLoading)}}
         />
         <Args.String
           @name='titleTag'
           @description="HTML heading element for the title: 'h1' (default), 'h2', 'h3', etc. Pass 'h2' or 'h3' when cards appear in a list to preserve heading hierarchy."
+          @options={{this.titleTagOptions}}
+          @value={{this.titleTag}}
+          @onInput={{fn (mut this.titleTag)}}
+        />
+        <Args.String
+          @name='layout'
+          @description="Force a layout direction regardless of container size: 'vertical' — image stacks on top; 'horizontal' — image sits to the left; 'auto' (default) — direction is chosen by container-query breakpoints based on aspect-ratio and size."
+          @options={{this.layoutOptions}}
+          @value={{this.layout}}
+          @onInput={{fn (mut this.layout)}}
         />
         <Args.Yield
           @name='title'

--- a/packages/boxel-ui/addon/src/usage.ts
+++ b/packages/boxel-ui/addon/src/usage.ts
@@ -25,6 +25,7 @@ import EntityThumbnailDisplayUsage from './components/entity-thumbnail-display/u
 import FieldContainerUsage from './components/field-container/usage.gts';
 import FilterListUsage from './components/filter-list/usage.gts';
 import FittedCardContainerUsage from './components/fitted-card-container/usage.gts';
+import FittedCardUsage from './components/fitted-card/usage.gts';
 import GridContainerUsage from './components/grid-container/usage.gts';
 import HeaderUsage from './components/header/usage.gts';
 import IconButtonUsage from './components/icon-button/usage.gts';
@@ -81,6 +82,7 @@ export const ALL_USAGE_COMPONENTS = [
   ['FieldContainer', FieldContainerUsage],
   ['FilterList', FilterListUsage],
   ['FittedCardContainer', FittedCardContainerUsage],
+  ['FittedCard', FittedCardUsage],
   ['GridContainer', GridContainerUsage],
   ['Header', HeaderUsage],
   ['IconButton', IconButtonUsage],

--- a/packages/boxel-ui/test-app/tests/integration/components/fitted-card-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/fitted-card-test.gts
@@ -1,0 +1,181 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { FittedCard } from '@cardstack/boxel-ui/components';
+
+module('Integration | Component | fitted-card', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // ── Named blocks ─────────────────────────────────────────────────────────
+
+  test('named blocks: all sections render when provided', async function (assert) {
+    await render(
+      <template>
+        <FittedCard @imageUrl='https://example.com/photo.jpg'>
+          <:background><div class='test-bg'></div></:background>
+          <:badgeLeft><span class='test-badge-left'>New</span></:badgeLeft>
+          <:badgeRight><span class='test-badge-right'>Draft</span></:badgeRight>
+          <:badgeRow><span class='test-badge-row'>Pill</span></:badgeRow>
+          <:placeholder><span class='test-placeholder'>*</span></:placeholder>
+          <:eyebrow>Category</:eyebrow>
+          <:title>My Title</:title>
+          <:subtitle>Sub</:subtitle>
+          <:meta><span class='test-meta'>5 min</span></:meta>
+          <:footer><span class='test-footer'>2024</span></:footer>
+        </FittedCard>
+      </template>,
+    );
+
+    assert.dom('.fc-title').hasText('My Title');
+    assert.dom('.fc-eyebrow').hasText('Category');
+    assert.dom('.fc-subtitle').hasText('Sub');
+    assert.dom('.test-meta').exists();
+    assert.dom('.test-footer').exists();
+    assert.dom('.fc-badge-left .test-badge-left').exists();
+    assert.dom('.fc-badge-right .test-badge-right').exists();
+    assert.dom('.fc-badge-row .test-badge-row').exists();
+    assert.dom('.fc-background .test-bg').exists();
+  });
+
+  test('named blocks: omitted sections leave no DOM nodes', async function (assert) {
+    await render(
+      <template>
+        <FittedCard><:title>T</:title></FittedCard>
+      </template>,
+    );
+
+    assert.dom('.fc-eyebrow').doesNotExist();
+    assert.dom('.fc-subtitle').doesNotExist();
+    assert.dom('.fc-meta').doesNotExist();
+    assert.dom('.fc-footer').doesNotExist();
+    assert.dom('.fc-badge-left').doesNotExist();
+    assert.dom('.fc-badge-right').doesNotExist();
+    assert.dom('.fc-badge-row').doesNotExist();
+    assert.dom('.fc-background').doesNotExist();
+    assert.dom('.fc-image').doesNotExist();
+  });
+
+  // ── Image rendering ───────────────────────────────────────────────────────
+
+  module('image rendering', function () {
+    test('@imageUrl renders img with correct src and alt', async function (assert) {
+      await render(
+        <template>
+          <FittedCard
+            @imageUrl='https://example.com/photo.jpg'
+            @imageAlt='A photo'
+          >
+            <:title>T</:title>
+          </FittedCard>
+        </template>,
+      );
+      assert.dom('.fc-image img').exists();
+      assert
+        .dom('.fc-image img')
+        .hasAttribute('src', 'https://example.com/photo.jpg');
+      assert.dom('.fc-image img').hasAttribute('alt', 'A photo');
+    });
+
+    test('@imageLoading passes through to loading attribute', async function (assert) {
+      await render(
+        <template>
+          <FittedCard
+            @imageUrl='https://example.com/photo.jpg'
+            @imageLoading='lazy'
+          >
+            <:title>T</:title>
+          </FittedCard>
+        </template>,
+      );
+      assert.dom('.fc-image img').hasAttribute('loading', 'lazy');
+    });
+
+    test('omitting @imageUrl hides image column', async function (assert) {
+      await render(
+        <template>
+          <FittedCard><:title>T</:title></FittedCard>
+        </template>,
+      );
+      assert.dom('.fc-image img').doesNotExist();
+      assert.dom('.fc-image').doesNotExist();
+    });
+
+    test('image block takes priority over placeholder when @imageUrl is absent', async function (assert) {
+      await render(
+        <template>
+          <FittedCard>
+            <:title>T</:title>
+            <:image><img src='custom.jpg' alt='custom' /></:image>
+            <:placeholder><span class='placeholder-icon'>?</span></:placeholder>
+          </FittedCard>
+        </template>,
+      );
+      assert.dom('.fc-image img[src="custom.jpg"]').exists();
+      assert.dom('.fc-placeholder').doesNotExist();
+    });
+  });
+
+  // ── CSS custom property overrides ─────────────────────────────────────────
+
+  module('CSS custom property overrides smoke test', function () {
+    test('--fc-content-gap is applied to .fc-content', async function (assert) {
+      // --fc-content-gap-no-image overrides gap when there is no image column,
+      // so we provide @imageUrl to keep the base gap: var(--fc-content-gap) rule active.
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <FittedCard
+            @imageUrl='https://example.com/photo.jpg'
+            style='--fc-content-gap: 99px'
+          >
+            <:title>T</:title>
+          </FittedCard>
+        </template>,
+      );
+      const content = document.querySelector('.fc-content') as HTMLElement;
+      assert.ok(content, '.fc-content exists');
+      assert.strictEqual(
+        getComputedStyle(content).gap,
+        '99px',
+        '--fc-content-gap is applied',
+      );
+    });
+
+    test('--fc-title-font-size is applied to .fc-title', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <FittedCard style='--fc-title-font-size: 42px'>
+            <:title>T</:title>
+          </FittedCard>
+        </template>,
+      );
+      const title = document.querySelector('.fc-title') as HTMLElement;
+      assert.ok(title, '.fc-title exists');
+      assert.strictEqual(
+        getComputedStyle(title).fontSize,
+        '42px',
+        '--fc-title-font-size is applied',
+      );
+    });
+
+    test('--fc-footer-gap is applied to .fc-footer', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <FittedCard style='--fc-footer-gap: 20px'>
+            <:title>T</:title>
+            <:footer><span>A</span><span>B</span></:footer>
+          </FittedCard>
+        </template>,
+      );
+      const footer = document.querySelector('.fc-footer') as HTMLElement;
+      assert.ok(footer, '.fc-footer exists');
+      assert.strictEqual(
+        getComputedStyle(footer).gap,
+        '20px',
+        '--fc-footer-gap is applied',
+      );
+    });
+  });
+});

--- a/packages/boxel-ui/test-app/tests/integration/components/fitted-card-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/fitted-card-test.gts
@@ -115,6 +115,37 @@ module('Integration | Component | fitted-card', function (hooks) {
     });
   });
 
+  // ── @layout ───────────────────────────────────────────────────────────────
+
+  module('@layout', function () {
+    test('defaults to data-layout="auto" when @layout is omitted', async function (assert) {
+      await render(
+        <template>
+          <FittedCard><:title>T</:title></FittedCard>
+        </template>,
+      );
+      assert.dom('article').hasAttribute('data-layout', 'auto');
+    });
+
+    test('@layout="vertical" sets data-layout="vertical"', async function (assert) {
+      await render(
+        <template>
+          <FittedCard @layout='vertical'><:title>T</:title></FittedCard>
+        </template>,
+      );
+      assert.dom('article').hasAttribute('data-layout', 'vertical');
+    });
+
+    test('@layout="horizontal" sets data-layout="horizontal"', async function (assert) {
+      await render(
+        <template>
+          <FittedCard @layout='horizontal'><:title>T</:title></FittedCard>
+        </template>,
+      );
+      assert.dom('article').hasAttribute('data-layout', 'horizontal');
+    });
+  });
+
   // ── CSS custom property overrides ─────────────────────────────────────────
 
   module('CSS custom property overrides smoke test', function () {


### PR DESCRIPTION
This `FittedCard` boxel-ui component is an alternative to `BasicFitted`. It is a much richer version for more complex fitted layout handling without having to write a fitted layout from scratch.

<img width="1204" height="635" alt="fitted-card-component" src="https://github.com/user-attachments/assets/0b437ac2-604d-4802-a501-e03fe943ea9e" />
<img width="1177" height="903" alt="fitted-card-api" src="https://github.com/user-attachments/assets/56677451-7864-4901-9c58-bee0932e718a" />

<img width="749" height="125" alt="layout-arg" src="https://github.com/user-attachments/assets/0a27e3e9-e251-4537-8189-74f1a8decf59" />
