### PR TITLE
Fix flaky multipart request-forward test — find the upload call by URL

### DIFF
--- a/packages/realm-server/tests/request-forward-test.ts
+++ b/packages/realm-server/tests/request-forward-test.ts
@@ -821,10 +821,8 @@ module(basename(__filename), function () {
       const originalFetch = global.fetch;
       const mockFetch = sinon.stub(global, 'fetch');
 
-      let capturedInit: RequestInit | undefined;
       mockFetch.callsFake(
-        async (_input: string | URL | Request, init?: RequestInit) => {
-          capturedInit = init;
+        async (_input: string | URL | Request, _init?: RequestInit) => {
           return new Response(JSON.stringify({ ok: true }), {
             status: 200,
             headers: { 'content-type': 'application/json' },
@@ -865,7 +863,26 @@ module(basename(__filename), function () {
           'Should pass along API response',
         );
 
-        assert.ok(capturedInit, 'fetch init should be captured');
+        // Find the forwarded upload call by URL rather than capturing the most
+        // recent stubbed call — background timers in the shared test prerender
+        // server (heartbeat to prerender-manager, periodic queue snapshots,
+        // etc.) also use `global.fetch` and can fire inside this test's stub
+        // window, so the last call through the stub is not necessarily ours.
+        const uploadCall = mockFetch.getCalls().find((call) => {
+          let raw = call.args[0];
+          let s = typeof raw === 'string' ? raw : raw.toString();
+          return s.includes('api.example.com/upload');
+        });
+        if (!uploadCall) {
+          // Diagnostic for the next failure: show what traffic the stub saw so
+          // the racing fetch can be identified from CI output alone.
+          console.error(
+            'multipart forward call not found; stubbed fetch saw:',
+            mockFetch.getCalls().map((c) => String(c.args[0])),
+          );
+        }
+        assert.ok(uploadCall, 'fetch was invoked against the upload URL');
+        const capturedInit = uploadCall?.args[1];
 
         const headersRecord =
           capturedInit?.headers instanceof Headers


### PR DESCRIPTION
The multipart request-forward test stubbed `global.fetch` with sinon and captured the request init inside `callsFake`, so the captured value belonged to whichever fetch went through the stub last. Background timers in the shared test prerender server (heartbeat to prerender-manager, periodic queue snapshots, etc.) also use `global.fetch` and can fire inside the test's stub window, overwriting the capture with an unrelated request's init. When that happened in CI, all eight assertions about the forwarded request failed (Content-Type not multipart, body missing boundary markers) while the response assertions passed.

The fix locates the forwarded upload call by URL (`api.example.com/upload`) via `mockFetch.getCalls()` and derives the init from that call — the same pattern the Google and Cloudflare forward tests in this file already use. If no matching call is found, the test logs every URL the stub saw before failing, so a future CI failure identifies the racing fetch from the log alone.

Verified locally: `TEST_MODULE="request-forward-test.ts" pnpm test-module` — all request-forward tests pass. `eslint` and `ember-tsc --noEmit` are clean on the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
