### PR TITLE
Add minDate/maxDate support to DateRangeField edit calendar

### DIFF
--- a/packages/base/date-range-field.gts
+++ b/packages/base/date-range-field.gts
@@ -18,7 +18,21 @@ import { formatDateRangeForMarkdown } from './markdown-helpers';
 import { BusinessDays } from './components/business-days';
 
 interface DateRangeFieldConfiguration {
+  minDate?: 'today' | Date;
+  maxDate?: 'today' | Date;
   presentation?: 'standard' | 'businessDays';
+}
+
+function resolveConfiguredDate(
+  value: 'today' | Date | undefined,
+): Date | undefined {
+  if (!value) return undefined;
+  if (value === 'today') {
+    let today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return today;
+  }
+  return value;
 }
 
 const Format = new Intl.DateTimeFormat('en-US', {
@@ -40,6 +54,18 @@ class Edit extends Component<typeof DateRangeField> {
 
   get formatted() {
     return getFormattedDate(this.range);
+  }
+
+  get config(): DateRangeFieldConfiguration | undefined {
+    return this.args.configuration as DateRangeFieldConfiguration | undefined;
+  }
+
+  get minDate(): Date | undefined {
+    return resolveConfiguredDate(this.config?.minDate);
+  }
+
+  get maxDate(): Date | undefined {
+    return resolveConfiguredDate(this.config?.maxDate);
   }
 
   @action onSelect(selected: any) {
@@ -93,6 +119,8 @@ class Edit extends Component<typeof DateRangeField> {
               @end={{this.range.end}}
               @onSelect={{this.onSelect}}
               @selected={{this.range}}
+              @minDate={{this.minDate}}
+              @maxDate={{this.maxDate}}
             />
           </div>
           <div class='dropdown-actions'>

--- a/packages/boxel-ui/addon/src/components/date-range-picker/index.gts
+++ b/packages/boxel-ui/addon/src/components/date-range-picker/index.gts
@@ -22,6 +22,8 @@ interface Signature {
   Args: {
     disabled?: boolean;
     end?: Date | null;
+    maxDate?: Date;
+    minDate?: Date;
     onSelect: TPowerCalendarRangeOnSelect;
     selected?: SelectedPowerCalendarRange;
     start?: Date | null;
@@ -132,6 +134,8 @@ export default class DateRangePicker extends Component<Signature> {
           <calendar.Days
             @weekdayFormat={{weekdayFormat}}
             @center={{this.leftCenter}}
+            @minDate={{@minDate}}
+            @maxDate={{@maxDate}}
           />
         </div>
 
@@ -160,6 +164,8 @@ export default class DateRangePicker extends Component<Signature> {
           <calendar.Days
             @weekdayFormat={{weekdayFormat}}
             @center={{this.rightCenter}}
+            @minDate={{@minDate}}
+            @maxDate={{@maxDate}}
           />
         </div>
       </div>

--- a/packages/boxel-ui/addon/src/components/date-range-picker/usage.gts
+++ b/packages/boxel-ui/addon/src/components/date-range-picker/usage.gts
@@ -1,3 +1,5 @@
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -14,10 +16,26 @@ export default class DateRangePickerUsage extends Component {
     start: new Date(2024, 10, 1),
     end: new Date(2024, 10, 15),
   };
+  @tracked disabled = false;
+  @tracked disablePastDates = false;
 
   @action
   onSelect1(selected: NormalizeRangeActionValue) {
     this.range1 = selected.date;
+  }
+
+  @action
+  toggleDisablePastDates() {
+    this.disablePastDates = !this.disablePastDates;
+  }
+
+  get minDate(): Date | undefined {
+    if (!this.disablePastDates) {
+      return undefined;
+    }
+    let today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return today;
   }
 
   parseDate(date: Date | null | undefined) {
@@ -45,11 +63,71 @@ export default class DateRangePickerUsage extends Component {
     >
       <:example>
         {{this.range1String}}
+        <label class='date-range-picker-usage-toggle'>
+          <input
+            type='checkbox'
+            checked={{this.disablePastDates}}
+            {{on 'change' this.toggleDisablePastDates}}
+          />
+          Disable past dates (sets
+          <code>@minDate</code>
+          to today, booking-calendar style)
+        </label>
         <DateRangePicker
           @selected={{this.range1}}
           @onSelect={{this.onSelect1}}
+          @minDate={{this.minDate}}
+          @disabled={{this.disabled}}
         />
       </:example>
+      <:api as |Args|>
+        <Args.Object
+          @name='selected'
+          @description='The currently selected range ({ start, end }) — drives which days render highlighted'
+          @value={{this.range1}}
+          @required={{true}}
+        />
+        <Args.Action
+          @name='onSelect'
+          @description='Called with the normalized selection when the user picks days; receives { date: { start, end } }'
+          @required={{true}}
+        />
+        <Args.Object
+          @name='start'
+          @description='Selected range start date — only used to decide which month the left calendar initially centers on'
+          @value={{this.range1.start}}
+        />
+        <Args.Object
+          @name='end'
+          @description='Selected range end date — only used to decide which month the right calendar initially centers on'
+          @value={{this.range1.end}}
+        />
+        <Args.Object
+          @name='minDate'
+          @description='Earliest selectable day; days before it render disabled. Pass today for an Airbnb-style no-past-dates calendar (toggle in the example above)'
+          @value={{this.minDate}}
+        />
+        <Args.Object
+          @name='maxDate'
+          @description='Latest selectable day; days after it render disabled (e.g. a booking horizon)'
+        />
+        <Args.Bool
+          @name='disabled'
+          @description='Disables interaction with the whole control'
+          @defaultValue={{false}}
+          @value={{this.disabled}}
+          @onInput={{fn (mut this.disabled)}}
+        />
+      </:api>
     </FreestyleUsage>
+    <style scoped>
+      .date-range-picker-usage-toggle {
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp-xxs);
+        margin-block: var(--boxel-sp-sm);
+        font: var(--boxel-font-sm);
+      }
+    </style>
   </template>
 }

--- a/packages/host/tests/integration/date-time-fields-test.gts
+++ b/packages/host/tests/integration/date-time-fields-test.gts
@@ -479,6 +479,68 @@ module('Integration | date-time fields', function (hooks) {
     assert.dom('[data-test-relative-time-embedded]').hasText('In 30 minutes');
   });
 
+  test('date range edit calendar disables days outside configured minDate/maxDate', async function (assert) {
+    let pad = (n: number) => String(n).padStart(2, '0');
+    let toDataDate = (d: Date) =>
+      `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+    // Anchor on mid-month days so all asserted cells are guaranteed to be
+    // rendered in the calendar pane that centers on the current month.
+    let now = new Date();
+    let day14 = new Date(now.getFullYear(), now.getMonth(), 14);
+    let day15 = new Date(now.getFullYear(), now.getMonth(), 15);
+    let day16 = new Date(now.getFullYear(), now.getMonth(), 16);
+
+    await renderConfiguredField(
+      DateRangeField,
+      buildField(DateRangeField, {}),
+      { minDate: day15 },
+      'edit',
+    );
+    await click('[data-test-field-container] button');
+    assert
+      .dom(`.ember-power-calendar-day[data-date="${toDataDate(day14)}"]`)
+      .isDisabled('day before minDate is not selectable');
+    assert
+      .dom(`.ember-power-calendar-day[data-date="${toDataDate(day15)}"]`)
+      .isNotDisabled('minDate itself is selectable');
+    assert
+      .dom(`.ember-power-calendar-day[data-date="${toDataDate(day16)}"]`)
+      .isNotDisabled('day after minDate is selectable');
+
+    await renderConfiguredField(
+      DateRangeField,
+      buildField(DateRangeField, {}),
+      { maxDate: day15 },
+      'edit',
+    );
+    await click('[data-test-field-container] button');
+    assert
+      .dom(`.ember-power-calendar-day[data-date="${toDataDate(day16)}"]`)
+      .isDisabled('day after maxDate is not selectable');
+    assert
+      .dom(`.ember-power-calendar-day[data-date="${toDataDate(day14)}"]`)
+      .isNotDisabled('day before maxDate is selectable');
+
+    await renderConfiguredField(
+      DateRangeField,
+      buildField(DateRangeField, {}),
+      { minDate: 'today' },
+      'edit',
+    );
+    await click('[data-test-field-container] button');
+    assert
+      .dom(`.ember-power-calendar-day[data-date="${toDataDate(now)}"]`)
+      .isNotDisabled("'today' sentinel keeps today selectable");
+    if (now.getDate() > 1) {
+      let firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+      assert
+        .dom(
+          `.ember-power-calendar-day[data-date="${toDataDate(firstOfMonth)}"]`,
+        )
+        .isDisabled("'today' sentinel disables earlier days this month");
+    }
+  });
+
   test('edit mode for partial calendar fields renders correctly', async function (assert) {
     await renderField(
       YearField,


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-11523/add-mindatemaxdate-support-to-daterangefield-edit-calendar

The DateRangeField edit calendar allowed selecting any date, including
dates in the past. Booking-style flows (travel planning, reservations)
need a calendar where out-of-window days are disabled, the way
Airbnb/airline date pickers behave.

## What changes:
- boxel-ui <DateRangePicker> accepts optional @minDate / @maxDate args,
  forwarded to ember-power-calendar's Days components in both month
  panes. Days outside the window render disabled and cannot be selected.
  Both args are optional; when omitted, behavior is unchanged. 
  @minDate/@maxDate are the levers that constrain selectability.
- DateRangeField (base) supports new configuration keys
  minDate?: 'today' | Date and maxDate?: 'today' | Date. The 'today'
  sentinel resolves to local midnight when the editor opens; resolved
  dates are passed to the picker by the edit template. The keys are flat
  top-level configuration, following the date-family convention
  (preset/format on DateField).
- The DateRangePicker usage page now documents the full component API
  (selected, onSelect, start, end, minDate, maxDate, disabled) — it
  previously had no <:api> block — and includes a live "disable past
  dates" toggle in the example.
  
  ## Test added:
- New host integration test covers the edit calendar: days before
  minDate and after maxDate are disabled, in-window days remain
  selectable, and the 'today' sentinel keeps today selectable while
  disabling earlier days. Assertions anchor on mid-month dates so they
  are deterministic regardless of the current date.
