### PR TITLE
Software factory: the instantiate check skips Specs that are not cards

### DIFF
--- a/packages/software-factory/src/instantiate-execution.ts
+++ b/packages/software-factory/src/instantiate-execution.ts
@@ -78,13 +78,24 @@ export type InstantiateCardFn = (
   instanceData?: string,
 ) => Promise<InstantiateModuleResult>;
 
+export interface SearchSpecsResult {
+  specs: SpecInfo[];
+  error?: string;
+  /**
+   * Raw Spec-card count from the realm search, before the card/app
+   * filter. Lets discovery distinguish "the index hasn't caught up yet"
+   * (zero raw hits — worth polling) from "Spec cards exist but none are
+   * instantiable" (final — return immediately instead of polling to the
+   * deadline).
+   */
+  totalSpecCards?: number;
+}
+
 export interface DiscoverRealmSpecsOptions {
   targetRealm: string;
   client: BoxelCLIClient;
   /** Injected for testing — defaults to a client.search over Spec cards. */
-  searchSpecsFn?: (
-    realmUrl: string,
-  ) => Promise<{ specs: SpecInfo[]; error?: string }>;
+  searchSpecsFn?: (realmUrl: string) => Promise<SearchSpecsResult>;
 }
 
 export interface InstantiateRealmSpecsOptions {
@@ -179,7 +190,7 @@ export interface RunInstantiateResult {
  */
 export async function discoverRealmSpecs(
   options: DiscoverRealmSpecsOptions,
-): Promise<{ specs: SpecInfo[]; error?: string }> {
+): Promise<SearchSpecsResult> {
   let searchSpecsFn =
     options.searchSpecsFn ??
     ((realmUrl: string) => defaultSearchSpecs(options.client, realmUrl));
@@ -187,10 +198,13 @@ export async function discoverRealmSpecs(
   // Realm-side source POST indexing is async, so a newly-uploaded Spec
   // card may not be in the search index by the time we get here. Bounded-
   // poll until even one spec shows up so an agent or test that just
-  // pushed Spec files isn't penalized for indexing latency.
+  // pushed Spec files isn't penalized for indexing latency. When the
+  // search DID return Spec cards but the card/app filter dropped them
+  // all, the index is up to date and polling can't change the answer —
+  // return immediately.
   return retryWithPoll(
     () => searchSpecsFn(options.targetRealm),
-    (r) => !r.error && r.specs.length === 0,
+    (r) => !r.error && r.specs.length === 0 && (r.totalSpecCards ?? 0) === 0,
   );
 }
 
@@ -655,7 +669,7 @@ function emptyErrorResult(errorMessage: string): RunInstantiateResult {
 async function defaultSearchSpecs(
   client: BoxelCLIClient,
   realmUrl: string,
-): Promise<{ specs: SpecInfo[]; error?: string }> {
+): Promise<SearchSpecsResult> {
   let searchResult = await client.search(realmUrl, {
     filter: { type: specRef },
   });
@@ -664,6 +678,7 @@ async function defaultSearchSpecs(
     return { specs: [], error: searchResult.error };
   }
 
+  let totalSpecCards = (searchResult.data ?? []).length;
   let specs: SpecInfo[] = [];
   for (let card of searchResult.data ?? []) {
     let specId = (card as Record<string, unknown>).id as string | undefined;
@@ -738,7 +753,7 @@ async function defaultSearchSpecs(
     });
   }
 
-  return { specs };
+  return { specs, totalSpecCards };
 }
 
 /**

--- a/packages/software-factory/src/instantiate-execution.ts
+++ b/packages/software-factory/src/instantiate-execution.ts
@@ -172,10 +172,10 @@ export interface RunInstantiateResult {
 
 /**
  * Search the realm for Spec cards and return the ref + linkedExamples for
- * each card/app spec. Field specs are skipped (they don't produce
- * instantiable cards). linkedExample URLs that resolve outside the target
- * realm are dropped to prevent leaking the realm auth token to external
- * origins.
+ * each card/app spec. Specs of any other specType (field, component,
+ * command) are skipped — they don't reference instantiable cards.
+ * linkedExample URLs that resolve outside the target realm are dropped to
+ * prevent leaking the realm auth token to external origins.
  */
 export async function discoverRealmSpecs(
   options: DiscoverRealmSpecsOptions,
@@ -678,10 +678,16 @@ async function defaultSearchSpecs(
       continue;
     }
 
-    // Field specs don't produce instantiable instances — skip.
+    // Only card/app specs reference instantiable CardDefs. Field,
+    // component, and command specs point at exports the prerenderer
+    // cannot instantiate — catalog cards commonly ship them alongside
+    // the card spec — so they are skipped rather than failing the run.
+    // Same allowlist `boxel realm ingest-card` applies at seed time.
     let specType = attributes.specType as string | undefined;
-    if (specType === 'field') {
-      log.info(`Spec ${specId} is a field spec — skipping`);
+    if (specType !== 'card' && specType !== 'app') {
+      log.info(
+        `Spec ${specId} has specType ${specType ?? '(none)'} — not instantiable, skipping`,
+      );
       continue;
     }
 

--- a/packages/software-factory/src/instantiate-execution.ts
+++ b/packages/software-factory/src/instantiate-execution.ts
@@ -86,7 +86,10 @@ export interface SearchSpecsResult {
    * filter. Lets discovery distinguish "the index hasn't caught up yet"
    * (zero raw hits — worth polling) from "Spec cards exist but none are
    * instantiable" (final — return immediately instead of polling to the
-   * deadline).
+   * deadline). Optional because injected `searchSpecsFn` test doubles
+   * predate it: `undefined` means "no raw-count signal" and is treated
+   * as final, so an injected empty result returns immediately instead
+   * of polling for 30s.
    */
   totalSpecCards?: number;
 }
@@ -198,13 +201,15 @@ export async function discoverRealmSpecs(
   // Realm-side source POST indexing is async, so a newly-uploaded Spec
   // card may not be in the search index by the time we get here. Bounded-
   // poll until even one spec shows up so an agent or test that just
-  // pushed Spec files isn't penalized for indexing latency. When the
-  // search DID return Spec cards but the card/app filter dropped them
-  // all, the index is up to date and polling can't change the answer —
-  // return immediately.
+  // pushed Spec files isn't penalized for indexing latency. Poll ONLY on
+  // affirmative evidence of that race — the search itself returned zero
+  // Spec cards (`totalSpecCards === 0`). When Spec cards were found but
+  // the card/app filter dropped them all, or an injected searchSpecsFn
+  // reports no raw count at all, the result is final — polling can't
+  // change the answer.
   return retryWithPoll(
     () => searchSpecsFn(options.targetRealm),
-    (r) => !r.error && r.specs.length === 0 && (r.totalSpecCards ?? 0) === 0,
+    (r) => !r.error && r.specs.length === 0 && r.totalSpecCards === 0,
   );
 }
 

--- a/packages/software-factory/src/parse-execution.ts
+++ b/packages/software-factory/src/parse-execution.ts
@@ -99,9 +99,19 @@ export interface DiscoverFilesOptions {
     realmUrl: string,
   ) => Promise<{ filenames: string[]; error?: string }>;
   /** Injected for testing — defaults to client.search-based spec discovery. */
-  searchSpecsFn?: (
-    realmUrl: string,
-  ) => Promise<{ specs: SpecExampleInfo[]; error?: string }>;
+  searchSpecsFn?: (realmUrl: string) => Promise<SearchSpecExamplesResult>;
+}
+
+export interface SearchSpecExamplesResult {
+  specs: SpecExampleInfo[];
+  error?: string;
+  /**
+   * Raw Spec-card count from the realm search. `undefined` (injected
+   * test doubles) and non-zero counts are final results; only an
+   * affirmative zero indicates the index may not have caught up yet
+   * and is worth polling.
+   */
+  totalSpecCards?: number;
 }
 
 export interface ParseRealmFilesOptions {
@@ -242,10 +252,12 @@ export async function discoverJsonExampleFiles(
   // Realm-side source POST indexing is async, so a newly-uploaded Spec
   // card may not be in the search index by the time we get here. Bounded-
   // poll until even one spec shows up so an agent or test that just
-  // pushed Spec files isn't penalized for indexing latency.
+  // pushed Spec files isn't penalized for indexing latency. Poll ONLY on
+  // affirmative evidence of that race — the search itself returned zero
+  // Spec cards. An injected searchSpecsFn without a raw count is final.
   let result = await retryWithPoll(
     () => searchSpecsFn(options.targetRealm),
-    (r) => !r.error && r.specs.length === 0,
+    (r) => !r.error && r.specs.length === 0 && r.totalSpecCards === 0,
   );
   if (result.error) {
     log.warn(`Failed to discover specs for JSON validation: ${result.error}`);
@@ -858,7 +870,7 @@ export function validateCardDocumentStructure(
 async function defaultSearchSpecs(
   client: BoxelCLIClient,
   realmUrl: string,
-): Promise<{ specs: SpecExampleInfo[]; error?: string }> {
+): Promise<SearchSpecExamplesResult> {
   let searchResult = await client.search(realmUrl, {
     filter: {
       type: specRef,
@@ -869,6 +881,7 @@ async function defaultSearchSpecs(
     return { specs: [], error: searchResult.error };
   }
 
+  let totalSpecCards = (searchResult.data ?? []).length;
   let specs: SpecExampleInfo[] = [];
   for (let card of searchResult.data ?? []) {
     let specId = (card as Record<string, unknown>).id as string | undefined;
@@ -905,7 +918,7 @@ async function defaultSearchSpecs(
     specs.push({ specId, exampleUrls });
   }
 
-  return { specs };
+  return { specs, totalSpecCards };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/software-factory/src/validators/instantiate-step.ts
+++ b/packages/software-factory/src/validators/instantiate-step.ts
@@ -21,6 +21,7 @@ import {
   instantiateRealmSpecs,
   type InstantiateCardFn,
   type InstanceInstantiationRecord,
+  type SearchSpecsResult,
   type SpecInfo,
 } from '../instantiate-execution.ts';
 import {
@@ -64,9 +65,7 @@ export interface InstantiateValidationStepConfig {
     realmUrl: string,
   ) => Promise<{ filenames: string[]; error?: string }>;
   /** Injected for testing — defaults to a spec search via the shared engine. */
-  searchSpecsFn?: (
-    realmUrl: string,
-  ) => Promise<{ specs: SpecInfo[]; error?: string }>;
+  searchSpecsFn?: (realmUrl: string) => Promise<SearchSpecsResult>;
   /** Injected for testing — defaults to the shared engine's instantiate-card caller. */
   instantiateCardFn?: InstantiateCardFn;
   /** Injected for testing — defaults to getNextValidationSequenceNumber. */

--- a/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
+++ b/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
@@ -289,6 +289,89 @@ export async function seedValidCardWithSpec(
 }
 
 /**
+ * A support module shaped like the ones catalog cards ship: a plain
+ * Glimmer component plus a helper function — neither is a CardDef.
+ */
+export const CHART_COMPONENT_MODULE_GTS = `import GlimmerComponent from '@glimmer/component';
+
+export class ChartComponent extends GlimmerComponent {
+  <template>
+    <div>chart</div>
+  </template>
+}
+
+export function formatChartLabel(value: number): string {
+  return String(value);
+}
+`;
+
+/** A component Spec — references a Glimmer component, not a CardDef. */
+export function componentSpecJson(): string {
+  return JSON.stringify(
+    {
+      data: {
+        type: 'card',
+        attributes: {
+          specType: 'component',
+          ref: { module: '../chart-component', name: 'ChartComponent' },
+        },
+        meta: {
+          adoptsFrom: {
+            module: 'https://cardstack.com/base/spec',
+            name: 'Spec',
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+/** A command Spec — references a plain function export, not a CardDef. */
+export function commandSpecJson(): string {
+  return JSON.stringify(
+    {
+      data: {
+        type: 'card',
+        attributes: {
+          specType: 'command',
+          ref: { module: '../chart-component', name: 'formatChartLabel' },
+        },
+        meta: {
+          adoptsFrom: {
+            module: 'https://cardstack.com/base/spec',
+            name: 'Spec',
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * Seed the valid card + example + card Spec alongside a component
+ * module with component and command Specs — the mix a catalog card
+ * seeded by `boxel realm pull` (rather than `ingest-card`) presents to
+ * the instantiate validator.
+ */
+export async function seedValidCardWithMixedSpecs(
+  client: BoxelCLIClient,
+  realmUrl: string,
+): Promise<void> {
+  await seedFilesAndWaitForIndex(client, realmUrl, [
+    { path: 'instantiate-test-card.gts', content: VALID_MODULE_GTS },
+    { path: 'ValidCard/example-1.json', content: validExampleJson() },
+    { path: 'Spec/valid-card-spec.json', content: validCardSpecJson() },
+    { path: 'chart-component.gts', content: CHART_COMPONENT_MODULE_GTS },
+    { path: 'Spec/chart-component-spec.json', content: componentSpecJson() },
+    { path: 'Spec/format-chart-label-spec.json', content: commandSpecJson() },
+  ]);
+}
+
+/**
  * Seed `tags-card.gts`, a well-formed `TagsCard/bad-example.json`, and
  * a Spec linking to that file. The realm-side example is intentionally
  * the WELL-FORMED placeholder (`validTagsExampleJson`) — the test

--- a/packages/software-factory/tests/index.ts
+++ b/packages/software-factory/tests/index.ts
@@ -21,6 +21,7 @@ import './test-step.test.ts';
 import './lint-step.test.ts';
 import './eval-step.test.ts';
 import './eval-execution.test.ts';
+import './instantiate-discovery.test.ts';
 import './instantiate-step.test.ts';
 import './parse-step.test.ts';
 import './port-allocator.test.ts';

--- a/packages/software-factory/tests/instantiate-discovery.test.ts
+++ b/packages/software-factory/tests/instantiate-discovery.test.ts
@@ -74,4 +74,26 @@ module('discoverRealmSpecs', function () {
       'Spec cards were found and filtered — the index is current, so no poll',
     );
   });
+
+  test('an injected empty result without a raw count is final — no polling', async function (assert) {
+    let searchCalls = 0;
+    let { specs, error } = await discoverRealmSpecs({
+      targetRealm: REALM,
+      client: clientReturning([]),
+      // The legacy injected shape used by test doubles that mean
+      // "nothing to validate" — no totalSpecCards signal.
+      searchSpecsFn: async () => {
+        searchCalls++;
+        return { specs: [] };
+      },
+    });
+
+    assert.strictEqual(error, undefined);
+    assert.deepEqual(specs, []);
+    assert.strictEqual(
+      searchCalls,
+      1,
+      'no raw-count signal means the result is final, not an index race',
+    );
+  });
 });

--- a/packages/software-factory/tests/instantiate-discovery.test.ts
+++ b/packages/software-factory/tests/instantiate-discovery.test.ts
@@ -44,4 +44,34 @@ module('discoverRealmSpecs', function () {
     assert.strictEqual(error, undefined);
     assert.deepEqual(specs.map((s) => s.cardName).sort(), ['MyApp', 'MyCard']);
   });
+
+  test('a realm with only non-instantiable Specs returns immediately instead of polling', async function (assert) {
+    let searchCalls = 0;
+    let client = {
+      search: async () => {
+        searchCalls++;
+        return {
+          ok: true,
+          data: [
+            specCard('component-spec', 'component', 'ChartComponent'),
+            specCard('command-spec', 'command', 'formatChartLabel'),
+          ],
+        };
+      },
+    } as unknown as BoxelCLIClient;
+
+    let { specs, error, totalSpecCards } = await discoverRealmSpecs({
+      targetRealm: REALM,
+      client,
+    });
+
+    assert.strictEqual(error, undefined);
+    assert.deepEqual(specs, []);
+    assert.strictEqual(totalSpecCards, 2);
+    assert.strictEqual(
+      searchCalls,
+      1,
+      'Spec cards were found and filtered — the index is current, so no poll',
+    );
+  });
 });

--- a/packages/software-factory/tests/instantiate-discovery.test.ts
+++ b/packages/software-factory/tests/instantiate-discovery.test.ts
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+
+import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
+
+import { discoverRealmSpecs } from '../src/instantiate-execution.ts';
+
+const REALM = 'https://realms.example.test/user/target/';
+
+function specCard(
+  id: string,
+  specType: string | undefined,
+  refName: string,
+): Record<string, unknown> {
+  return {
+    id: `${REALM}Spec/${id}`,
+    attributes: {
+      ...(specType ? { specType } : {}),
+      ref: { module: '../my-module', name: refName },
+    },
+    relationships: {},
+  };
+}
+
+function clientReturning(cards: Record<string, unknown>[]): BoxelCLIClient {
+  return {
+    search: async () => ({ ok: true, data: cards }),
+  } as unknown as BoxelCLIClient;
+}
+
+module('discoverRealmSpecs', function () {
+  test('only card and app specs survive discovery; other specTypes are skipped', async function (assert) {
+    let { specs, error } = await discoverRealmSpecs({
+      targetRealm: REALM,
+      client: clientReturning([
+        specCard('card-spec', 'card', 'MyCard'),
+        specCard('app-spec', 'app', 'MyApp'),
+        specCard('field-spec', 'field', 'MyField'),
+        specCard('component-spec', 'component', 'ChartComponent'),
+        specCard('command-spec', 'command', 'formatChartLabel'),
+        specCard('typeless-spec', undefined, 'Mystery'),
+      ]),
+    });
+
+    assert.strictEqual(error, undefined);
+    assert.deepEqual(specs.map((s) => s.cardName).sort(), ['MyApp', 'MyCard']);
+  });
+});

--- a/packages/software-factory/tests/run-instantiate-in-memory.spec.ts
+++ b/packages/software-factory/tests/run-instantiate-in-memory.spec.ts
@@ -7,6 +7,7 @@ import { expect, test } from './fixtures.ts';
 import { runInstantiateInMemory } from '../src/instantiate-execution.ts';
 import {
   seedTagsCardWithBrokenExampleAndSpec,
+  seedValidCardWithMixedSpecs,
   seedValidCardWithSpec,
   overwriteTagsExampleWithBadShape,
 } from './helpers/instantiate-test-fixtures.ts';
@@ -64,6 +65,46 @@ test.describe('runInstantiateInMemory e2e', () => {
         f.startsWith('Validations/instantiate_'),
       );
       expect(validationArtifacts).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('component and command Specs are skipped, not failed', async ({
+    realm,
+  }) => {
+    let realmUrl = realm.realmURL.href;
+    let realmServerUrl = realm.realmServerURL.href;
+    let authorization = realm.authorizationHeaders()['Authorization'];
+    let serverToken = `Bearer ${realm.serverToken}`;
+
+    let { client, cleanup } = buildTestClient({
+      realmUrl,
+      realmToken: authorization,
+      realmServerUrl,
+      realmServerToken: serverToken,
+    });
+
+    try {
+      await seedValidCardWithMixedSpecs(client, realmUrl);
+
+      let workspace = createTestWorkspace();
+      await client.pull(realmUrl, workspace.dir);
+
+      let result = await runInstantiateInMemory({
+        targetRealm: realmUrl,
+        realmServerUrl,
+        client,
+        workspaceDir: workspace.dir,
+      });
+
+      // The card Spec's example instantiates; the component and command
+      // Specs are not instantiable and must be skipped rather than
+      // failing the run (the catalog mortgage-calculator shape).
+      expect(result.failures).toEqual([]);
+      expect(result.status).toBe('passed');
+      expect(result.instancesChecked).toBe(1);
+      expect(result.instanceFiles).toEqual(['ValidCard/example-1.json']);
     } finally {
       cleanup();
     }


### PR DESCRIPTION
Fixes [CS-11425](https://linear.app/cardstack/issue/CS-11425/improve-flow-dont-let-componentfunction-specs-fail-the-seed-baseline).

## The problem

The adjust flow copies an existing card and proves the copy works before changing anything. One of those proofs is the instantiate check: "try to create an instance of every card here."

Catalog cards ship Spec descriptor files not just for the card itself, but also for its internal building blocks — chart components, helper functions. Those building blocks aren't cards, so "create an instance" of them is meaningless. The check didn't know the difference and tried anyway.

Real example from the first adjust run: copying the catalog mortgage-calculator, the check made 8 attempts and failed 7 — every failure a building-block Spec (`LineChart`, `DonutChart`, `formatCurrency`, …), none of them an actual problem. The agent's only way to a green baseline was **deleting those 7 Specs from the copy** — damaging what it had just copied before the real work started.

## The fix

The check now looks at each Spec's type first: `card` and `app` Specs get instantiated, everything else (`field`, `component`, `command`) is skipped with a log line. This is the same rule `boxel realm ingest-card` already applies when copying a card, applied now on the validation side too — so the baseline goes green without touching any source Spec, even when the workspace was seeded some other way (whole-realm pull, agent-written Specs).

One safety interaction worth knowing: if skipping ever leaves *nothing* to check, the zero-coverage guard from #5199 reports that as an error instead of a hollow pass.

## Tests

- **Unit**: discovery over every Spec type (plus one with no type at all) — only `card` and `app` survive.
- **End-to-end**: seeds the exact mortgage-calculator shape — a working card with its Spec, plus a Glimmer-component module with component and command Specs — and asserts the check passes with 1 instance checked, zero failures, and no Spec deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
