### PR TITLE
Tear down wedged HTTP/2 sessions so hung fetches reject and retry

### DIFF
--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -50,6 +50,47 @@ const TLS_KEY_FILE_ENV = 'REALM_SERVER_TLS_KEY_FILE';
 // production mechanism.
 const HTTP2_DIAGNOSTICS_ENV = 'REALM_SERVER_HTTP2_DIAGNOSTICS';
 
+// HTTP/2 PING keepalive tuning. The h2 transport between Chrome and this
+// server can wedge: the session stops carrying frames entirely — the server's
+// PINGs go unanswered (PONG is handled by the peer's network stack, not JS,
+// so a missing pong means no frames are flowing at all) while the browser
+// still has a fetch awaiting its response. That fetch never rejects, so the
+// client-side retry in runtime-common's virtual-network (which only retries
+// rejections) never fires and a host test hangs until its 60s timeout. The
+// keepalive turns the silent wedge into a recoverable error: every session is
+// pinged on an interval, and one that misses enough consecutive pongs is torn
+// down, RSTing its streams so the hung fetch rejects and retries on a fresh
+// session.
+//
+// Budget: worst-case detection is maxMissedPings × (interval + pongTimeout) +
+// grace = 3 × 10s + 3s = 33s, leaving the released fetch room to retry and
+// complete inside a 60s host-test timeout. Three consecutive misses (~30s of
+// silence) cannot be produced by a transient event-loop stall — a single
+// delayed pong scores at most one miss before the next successful ping resets
+// the counter — while a genuinely wedged session never pongs again, so the
+// discrimination is clean. A false teardown would only cost the peer a
+// reconnect, never a wrong result.
+const HTTP2_KEEPALIVE_INTERVAL_MS = 5000;
+const HTTP2_KEEPALIVE_PONG_TIMEOUT_MS = 5000;
+const HTTP2_KEEPALIVE_MAX_MISSED_PINGS = 3;
+// After a graceful close (GOAWAY) a wedged transport won't deliver anything,
+// so force the session down to actually RST the browser's hung fetch.
+const HTTP2_KEEPALIVE_GRACE_MS = 3000;
+const HTTP2_KEEPALIVE_TCP_INITIAL_DELAY_MS = 15000;
+
+// Per-session liveness recorded by the PING keepalive and read by the h2
+// diagnostics, so diagnostic dumps can say whether the underlying session was
+// still answering pings (transport alive, stream wedged) or had gone silent
+// (whole session wedged). The id correlates [h2-keepalive] lines with the
+// [h2-diag] session #N lines.
+interface SessionLiveness {
+  id: number;
+  lastPingAt: number | undefined;
+  lastPongAt: number | undefined;
+  lastRttMs: number | undefined;
+  consecutiveMisses: number;
+}
+
 export type RealmHttpServer =
   | http.Server
   | http2.Http2SecureServer
@@ -254,10 +295,208 @@ function buildHttp2SecureServer(
       `Unable to construct HTTPS/h2 server (malformed cert?): ${(e as Error).message}`,
     );
   }
+  // Always on (the fix, not a diagnostic): tear down wedged h2 sessions so a
+  // hung browser fetch rejects (and retries) instead of hanging until a test
+  // timeout. Returns the shared liveness map the diagnostics read.
+  let liveness = installHttp2Keepalive(tlsServer, log);
   if (process.env[HTTP2_DIAGNOSTICS_ENV]) {
-    installHttp2Diagnostics(tlsServer, log);
+    installHttp2Diagnostics(tlsServer, log, liveness);
   }
   return tlsServer;
+}
+
+// Wire the HTTP/2 PING keepalive onto every session the secure server
+// accepts — see the HTTP2_KEEPALIVE_* constants for the rationale. Returns
+// the liveness map so the diagnostics can report each session's ping health.
+function installHttp2Keepalive(
+  tlsServer: http2.Http2SecureServer,
+  log: ReturnType<typeof logger>,
+): WeakMap<http2.Http2Session, SessionLiveness> {
+  let liveness = new WeakMap<http2.Http2Session, SessionLiveness>();
+  let nextSessionId = 0;
+  tlsServer.on('session', (session) => {
+    liveness.set(session, {
+      id: nextSessionId++,
+      lastPingAt: undefined,
+      lastPongAt: undefined,
+      lastRttMs: undefined,
+      consecutiveMisses: 0,
+    });
+    // Belt-and-suspenders: TCP keepalive surfaces a dead peer at the socket
+    // layer even if the h2 PING path is somehow starved. Best-effort.
+    try {
+      session.socket?.setKeepAlive?.(
+        true,
+        HTTP2_KEEPALIVE_TCP_INITIAL_DELAY_MS,
+      );
+    } catch {
+      // some socket states reject setKeepAlive; ignore
+    }
+    startSessionKeepalive(session, log, {}, liveness);
+  });
+  return liveness;
+}
+
+interface KeepaliveOptions {
+  intervalMs?: number;
+  pongTimeoutMs?: number;
+  maxMissedPings?: number;
+  graceMsBeforeDestroy?: number;
+}
+
+// Ping a single h2 session on an interval; if it misses `maxMissedPings`
+// consecutive pings (no PONG within `pongTimeoutMs`, or the PING frame can't
+// even be queued), the session is wedged — close it (GOAWAY) and force it
+// down after a grace period so its streams RST and the browser's pending
+// fetch rejects. Returns a stop() for teardown/testing. Exported for unit
+// tests, which drive it with a fake session and short timers.
+export function startSessionKeepalive(
+  session: http2.Http2Session,
+  log: ReturnType<typeof logger>,
+  options: KeepaliveOptions = {},
+  liveness?: WeakMap<http2.Http2Session, SessionLiveness>,
+): () => void {
+  let intervalMs = options.intervalMs ?? HTTP2_KEEPALIVE_INTERVAL_MS;
+  let pongTimeoutMs = options.pongTimeoutMs ?? HTTP2_KEEPALIVE_PONG_TIMEOUT_MS;
+  let maxMissedPings =
+    options.maxMissedPings ?? HTTP2_KEEPALIVE_MAX_MISSED_PINGS;
+  let graceMsBeforeDestroy =
+    options.graceMsBeforeDestroy ?? HTTP2_KEEPALIVE_GRACE_MS;
+
+  let stopped = false;
+  let misses = 0;
+  let nextTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function record(patch: Partial<SessionLiveness>) {
+    if (!liveness) {
+      return;
+    }
+    let prev = liveness.get(session) ?? {
+      id: -1,
+      lastPingAt: undefined,
+      lastPongAt: undefined,
+      lastRttMs: undefined,
+      consecutiveMisses: 0,
+    };
+    liveness.set(session, { ...prev, ...patch });
+  }
+
+  function sessionLabel() {
+    let id = liveness?.get(session)?.id;
+    return id != null && id >= 0 ? `#${id}` : '<untracked>';
+  }
+
+  function stop() {
+    stopped = true;
+    if (nextTimer) {
+      clearTimeout(nextTimer);
+      nextTimer = undefined;
+    }
+  }
+
+  function scheduleNext() {
+    if (stopped) {
+      return;
+    }
+    nextTimer = setTimeout(sendPing, intervalMs);
+    nextTimer.unref?.();
+  }
+
+  function onMiss(reason: string) {
+    misses++;
+    record({ consecutiveMisses: misses });
+    if (misses < maxMissedPings) {
+      scheduleNext();
+      return;
+    }
+    let lastPongAt = liveness?.get(session)?.lastPongAt;
+    let pongAge = lastPongAt != null ? `${Date.now() - lastPongAt}ms` : 'never';
+    log.warn(
+      `[h2-keepalive] session ${sessionLabel()} unresponsive ` +
+        `(${misses} missed pings, ${reason}, last pong ${pongAge} ago) — ` +
+        `closing to release wedged streams`,
+    );
+    stop();
+    try {
+      session.close();
+    } catch {
+      // already closing/closed
+    }
+    let hard = setTimeout(() => {
+      try {
+        if (!session.destroyed) {
+          log.warn(
+            `[h2-keepalive] session ${sessionLabel()} still up after ` +
+              `${graceMsBeforeDestroy}ms grace — force-destroying`,
+          );
+          session.destroy();
+        }
+      } catch {
+        // already destroyed
+      }
+    }, graceMsBeforeDestroy);
+    hard.unref?.();
+  }
+
+  function sendPing() {
+    if (stopped || session.destroyed || session.closed) {
+      stop();
+      return;
+    }
+    let settled = false;
+    let pongTimer: ReturnType<typeof setTimeout> | undefined;
+    function finish(then: () => void) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (pongTimer) {
+        clearTimeout(pongTimer);
+      }
+      then();
+    }
+
+    record({ lastPingAt: Date.now() });
+    let queued: boolean;
+    try {
+      // ping() returns false when the frame couldn't be queued; the callback
+      // fires on PONG (or with an error if the session dies first).
+      queued =
+        session.ping((err: Error | null, duration: number) => {
+          finish(() => {
+            if (err) {
+              onMiss(`ping errored: ${err.message}`);
+              return;
+            }
+            misses = 0;
+            record({
+              lastPongAt: Date.now(),
+              lastRttMs: Math.round(duration),
+              consecutiveMisses: 0,
+            });
+            scheduleNext();
+          });
+        }) !== false;
+    } catch (e) {
+      finish(() => onMiss(`ping threw: ${(e as Error).message}`));
+      return;
+    }
+
+    if (!queued) {
+      finish(() => onMiss('ping frame could not be queued'));
+      return;
+    }
+
+    pongTimer = setTimeout(() => {
+      finish(() => onMiss(`no pong within ${pongTimeoutMs}ms`));
+    }, pongTimeoutMs);
+    pongTimer.unref?.();
+  }
+
+  session.once('close', stop);
+  session.once('error', stop);
+  scheduleNext();
+  return stop;
 }
 
 // Node's http2 secure server — like net/tls servers, and unlike
@@ -324,11 +563,15 @@ function withForcedConnectionClose(
 //     queueing requests it never sends? (live/peak vs maxConcurrentStreams)
 //   - is the connection flow-control-deadlocked? (session windows + outbound
 //     queue, sampled continuously rather than only per stalled stream)
-//   - is the transport even alive during the hang? (a passive PING round-trip
-//     per session — observe only, never tear anything down)
+//   - is the transport even alive during the hang? (each session's PING
+//     liveness, read from the keepalive's shared map — a recent pong means
+//     the transport is alive and only a stream is stuck; a stale/never pong
+//     with rising misses means the whole session went silent and the
+//     keepalive is about to tear it down)
 function installHttp2Diagnostics(
   tlsServer: http2.Http2SecureServer,
   log: ReturnType<typeof logger>,
+  liveness: WeakMap<http2.Http2Session, SessionLiveness>,
 ) {
   const STALL_THRESHOLD_MS = 8000;
   const SWEEP_INTERVAL_MS = 5000;
@@ -346,10 +589,6 @@ function installHttp2Diagnostics(
   interface SessionRec {
     id: number;
     peakStreams: number;
-    lastPingAt?: number;
-    lastPongAt?: number;
-    lastRttMs?: number;
-    pingInFlight: boolean;
   }
 
   let nextId = 0;
@@ -359,15 +598,16 @@ function installHttp2Diagnostics(
 
   tlsServer.on('session', (session) => {
     let srec: SessionRec = {
-      id: nextSessionId++,
+      // The keepalive's session listener is registered first, so its liveness
+      // record already exists — reuse its id so [h2-diag] and [h2-keepalive]
+      // lines correlate.
+      id: liveness.get(session)?.id ?? nextSessionId++,
       peakStreams: 0,
-      pingInFlight: false,
     };
     sessions.set(session, srec);
     log.info(
       `[h2-diag] session #${srec.id} opened (live sessions=${sessions.size})`,
     );
-    probeSession(session, srec);
     session.on('close', () => {
       sessions.delete(session);
       log.info(
@@ -454,37 +694,6 @@ function installHttp2Diagnostics(
     rec.res = res;
   });
 
-  // Passive liveness probe — send one PING and record its round-trip. Observe
-  // only; never tears the session down (that distinguishes this from a
-  // keepalive). Run once on session open so the first sweep already has a
-  // reading, then again each sweep.
-  function probeSession(
-    session: http2.ServerHttp2Session,
-    srec: SessionRec,
-  ): void {
-    if (srec.pingInFlight || session.destroyed || session.closed) {
-      return;
-    }
-    srec.pingInFlight = true;
-    srec.lastPingAt = Date.now();
-    let sent = false;
-    try {
-      sent =
-        session.ping((err: Error | null, duration: number) => {
-          srec.pingInFlight = false;
-          if (!err) {
-            srec.lastPongAt = Date.now();
-            srec.lastRttMs = Math.round(duration);
-          }
-        }) !== false;
-    } catch {
-      srec.pingInFlight = false;
-    }
-    if (!sent) {
-      srec.pingInFlight = false;
-    }
-  }
-
   let timer = setInterval(() => {
     let now = Date.now();
     for (let [stream, rec] of open) {
@@ -509,6 +718,13 @@ function installHttp2Diagnostics(
           }
         }
       }
+      // PING liveness disambiguates the wedge: a recent pong (low pongAge,
+      // missedPings=0) means the transport is alive and only this stream is
+      // stuck; a stale/never pongAge with rising missedPings means the whole
+      // session has gone silent and the keepalive is about to tear it down.
+      let live = session ? liveness.get(session) : undefined;
+      let stalledPongAge =
+        live?.lastPongAt != null ? `${now - live.lastPongAt}ms` : 'never';
       log.warn(
         `[h2-diag] STALLED stream #${rec.id} ${rec.method} ${rec.path} age=${age}ms ` +
           `sawRequest=${rec.sawRequest} ` +
@@ -524,6 +740,8 @@ function installHttp2Diagnostics(
           `effectiveRecvData=${ss?.effectiveRecvDataLength} ` +
           `remoteWindow=${ss?.remoteWindowSize} ` +
           `liveStreamsThisSession=${liveThisSession} liveStreamsTotal=${open.size}) ` +
+          `keepalive(pingRtt=${live?.lastRttMs ?? 'n/a'}ms pongAge=${stalledPongAge} ` +
+          `missedPings=${live?.consecutiveMisses ?? 0}) ` +
           `maxConcurrentStreams(local=${session?.localSettings?.maxConcurrentStreams} ` +
           `remote=${session?.remoteSettings?.maxConcurrentStreams})`,
       );
@@ -543,14 +761,19 @@ function installHttp2Diagnostics(
       if (inFlight.length > srec.peakStreams) {
         srec.peakStreams = inFlight.length;
       }
-      let pongAge = srec.lastPongAt != null ? now - srec.lastPongAt : undefined;
-      let pongHealthy = pongAge != null && pongAge < SWEEP_INTERVAL_MS * 2;
+      let live = liveness.get(session);
+      let pongAge =
+        live?.lastPongAt != null ? now - live.lastPongAt : undefined;
+      // The keepalive pings every HTTP2_KEEPALIVE_INTERVAL_MS, so a healthy
+      // session's last pong is at most one interval (plus rtt) old.
+      let pongHealthy =
+        pongAge != null && pongAge < HTTP2_KEEPALIVE_INTERVAL_MS * 2;
       if (pongHealthy) {
         healthyPongs++;
       }
       // Log a per-session line only when it's doing work or its last ping went
       // unanswered; idle, healthy sessions are covered by the roll-up below.
-      let pongOverdue = srec.lastPingAt != null && !pongHealthy;
+      let pongOverdue = live?.lastPingAt != null && !pongHealthy;
       if (inFlight.length > 0 || pongOverdue) {
         let ss = session.state;
         let shown = inFlight.slice(0, 12);
@@ -570,12 +793,12 @@ function installHttp2Diagnostics(
             `remote=${ss?.remoteWindowSize} ` +
             `recvData=${ss?.effectiveRecvDataLength} ` +
             `outQ=${ss?.outboundQueueSize}) ` +
-            `ping(rtt=${srec.lastRttMs ?? 'n/a'}ms ` +
-            `pongAge=${pongAge != null ? `${pongAge}ms` : 'never'}) ` +
+            `ping(rtt=${live?.lastRttMs ?? 'n/a'}ms ` +
+            `pongAge=${pongAge != null ? `${pongAge}ms` : 'never'} ` +
+            `missed=${live?.consecutiveMisses ?? 0}) ` +
             `inFlight=[${list}${more}]`,
         );
       }
-      probeSession(session, srec);
     }
     // Greppable roll-up: a client hang showing `openStreams=0 pingHealthy=N/N`
     // means the request never reached the server (it's wedged client-side or in

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -446,7 +446,10 @@ export function startSessionKeepalive(
     let settled = false;
     let pongTimer: ReturnType<typeof setTimeout> | undefined;
     function finish(then: () => void) {
-      if (settled) {
+      // `stopped` covers a ping still in flight when the session closes or
+      // errors: its late pong callback / pong timeout must not record a miss
+      // or tear down a session that already ended normally.
+      if (settled || stopped) {
         return;
       }
       settled = true;

--- a/packages/realm-server/tests/http2-keepalive-test.ts
+++ b/packages/realm-server/tests/http2-keepalive-test.ts
@@ -188,6 +188,36 @@ module(basename(__filename), function () {
     );
   });
 
+  test('a ping in flight when the session closes does not trigger teardown', async function (assert) {
+    let fake = new FakeSession();
+    // Never pong, so the first ping scores a miss and the second is one
+    // pong-timeout away from the 2-miss teardown threshold when the session
+    // closes out from under it.
+    fake.pingImpl = () => true;
+    let stopKeepalive = startSessionKeepalive(asSession(fake), log, FAST);
+    try {
+      // FAST timeline: ping1 @20ms, miss1 @35ms, ping2 @55ms, and ping2's
+      // pong timeout would fire @70ms — close the session while ping2 is in
+      // flight and wait past that timeout.
+      await wait(60);
+      assert.strictEqual(fake.pingCount, 2, 'second ping is in flight');
+      fake.emit('close');
+      await wait(60);
+      assert.strictEqual(
+        fake.closeCount,
+        0,
+        'late pong timeout after session close does not tear down',
+      );
+      assert.strictEqual(
+        fake.destroyCount,
+        0,
+        'no force-destroy after session close',
+      );
+    } finally {
+      stopKeepalive();
+    }
+  });
+
   test('a session close event halts pinging without tearing down', async function (assert) {
     let fake = new FakeSession();
     fake.pingImpl = () => true; // would otherwise wedge and get closed

--- a/packages/realm-server/tests/http2-keepalive-test.ts
+++ b/packages/realm-server/tests/http2-keepalive-test.ts
@@ -1,0 +1,207 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { EventEmitter } from 'events';
+import type http2 from 'http2';
+import { logger } from '@cardstack/runtime-common';
+
+import { startSessionKeepalive } from '../server';
+
+// Unit coverage for the HTTP/2 PING keepalive that tears down wedged sessions
+// so a hung browser fetch rejects (and retries) instead of hanging until a
+// host-test timeout. Driven against a fake session whose ping behaviour we
+// control and with short timers so the whole cycle runs in milliseconds.
+
+type PingCallback = (
+  err: Error | null,
+  duration: number,
+  payload?: Buffer,
+) => void;
+
+// Minimal stand-in for an Http2Session: only the surface startSessionKeepalive
+// touches (ping/close/destroy + the close/error events + closed/destroyed).
+class FakeSession extends EventEmitter {
+  closed = false;
+  destroyed = false;
+  closeCount = 0;
+  destroyCount = 0;
+  pingCount = 0;
+  // Default: a healthy peer that pongs immediately.
+  pingImpl: (cb: PingCallback) => boolean = (cb) => {
+    setTimeout(() => cb(null, 1), 0);
+    return true;
+  };
+
+  ping(cb: PingCallback): boolean {
+    this.pingCount++;
+    return this.pingImpl(cb);
+  }
+
+  close() {
+    this.closeCount++;
+    this.closed = true;
+  }
+
+  destroy() {
+    this.destroyCount++;
+    this.destroyed = true;
+  }
+}
+
+function asSession(fake: FakeSession): http2.Http2Session {
+  return fake as unknown as http2.Http2Session;
+}
+
+const log = logger('test:h2-keepalive');
+
+// Fast tuning so a 2-miss teardown completes well under the QUnit timeout.
+const FAST = {
+  intervalMs: 20,
+  pongTimeoutMs: 15,
+  maxMissedPings: 2,
+  graceMsBeforeDestroy: 10,
+};
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+module(basename(__filename), function () {
+  test('a responsive session is pinged and never torn down', async function (assert) {
+    let fake = new FakeSession();
+    let stopKeepalive = startSessionKeepalive(asSession(fake), log, FAST);
+    try {
+      await wait(120);
+      assert.ok(
+        fake.pingCount >= 2,
+        `session was pinged repeatedly (${fake.pingCount})`,
+      );
+      assert.strictEqual(
+        fake.closeCount,
+        0,
+        'responsive session is not closed',
+      );
+      assert.strictEqual(
+        fake.destroyCount,
+        0,
+        'responsive session is not destroyed',
+      );
+    } finally {
+      stopKeepalive();
+    }
+  });
+
+  test('a session that never pongs is closed then force-destroyed', async function (assert) {
+    let fake = new FakeSession();
+    // PING frame is sent but no PONG ever arrives — the wedge signature.
+    fake.pingImpl = () => true;
+    let stopKeepalive = startSessionKeepalive(asSession(fake), log, FAST);
+    try {
+      await wait(200);
+      assert.strictEqual(fake.closeCount, 1, 'wedged session is closed once');
+      assert.ok(
+        fake.destroyCount >= 1,
+        'wedged session is force-destroyed after the grace period',
+      );
+    } finally {
+      stopKeepalive();
+    }
+  });
+
+  test('a session that cannot queue a PING frame is torn down', async function (assert) {
+    let fake = new FakeSession();
+    // ping() returning false means the outbound path is backed up.
+    fake.pingImpl = () => false;
+    let stopKeepalive = startSessionKeepalive(asSession(fake), log, FAST);
+    try {
+      await wait(120);
+      assert.strictEqual(
+        fake.closeCount,
+        1,
+        'session with unqueueable pings is closed',
+      );
+    } finally {
+      stopKeepalive();
+    }
+  });
+
+  test('one missed pong does not tear down a session that then recovers', async function (assert) {
+    let fake = new FakeSession();
+    let pings = 0;
+    // First ping never pongs (one miss); subsequent pings pong normally.
+    fake.pingImpl = (cb) => {
+      pings++;
+      if (pings > 1) {
+        setTimeout(() => cb(null, 1), 0);
+      }
+      return true;
+    };
+    let stopKeepalive = startSessionKeepalive(asSession(fake), log, FAST);
+    try {
+      await wait(160);
+      assert.strictEqual(
+        fake.closeCount,
+        0,
+        'a single transient miss does not close the session',
+      );
+    } finally {
+      stopKeepalive();
+    }
+  });
+
+  test('a successful pong resets the miss counter', async function (assert) {
+    let fake = new FakeSession();
+    let pings = 0;
+    // Alternate miss / pong forever: consecutive misses never accumulate to
+    // the teardown threshold even though total misses do.
+    fake.pingImpl = (cb) => {
+      pings++;
+      if (pings % 2 === 0) {
+        setTimeout(() => cb(null, 1), 0);
+      }
+      return true;
+    };
+    let stopKeepalive = startSessionKeepalive(asSession(fake), log, FAST);
+    try {
+      await wait(300);
+      assert.ok(pings >= 4, `alternating pattern exercised (${pings} pings)`);
+      assert.strictEqual(
+        fake.closeCount,
+        0,
+        'non-consecutive misses never trigger teardown',
+      );
+    } finally {
+      stopKeepalive();
+    }
+  });
+
+  test('stop() halts pinging', async function (assert) {
+    let fake = new FakeSession();
+    let stopKeepalive = startSessionKeepalive(asSession(fake), log, FAST);
+    await wait(50);
+    let countAtStop = fake.pingCount;
+    stopKeepalive();
+    await wait(80);
+    assert.strictEqual(
+      fake.pingCount,
+      countAtStop,
+      'no further pings are sent after stop()',
+    );
+  });
+
+  test('a session close event halts pinging without tearing down', async function (assert) {
+    let fake = new FakeSession();
+    fake.pingImpl = () => true; // would otherwise wedge and get closed
+    let stopKeepalive = startSessionKeepalive(asSession(fake), log, FAST);
+    try {
+      fake.emit('close');
+      await wait(120);
+      assert.strictEqual(
+        fake.closeCount,
+        0,
+        'keepalive does not re-close an already-closed session',
+      );
+    } finally {
+      stopKeepalive();
+    }
+  });
+});

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -180,6 +180,7 @@ const ALL_TEST_FILES: string[] = [
   './file-watcher-events-test',
   './full-index-on-startup-test',
   './full-reindex-test',
+  './http2-keepalive-test',
   './indexing-test',
   './lazy-mount-test',
   './listener-dispatcher-test',

--- a/packages/realm-server/tests/listener-dispatcher-test.ts
+++ b/packages/realm-server/tests/listener-dispatcher-test.ts
@@ -516,12 +516,13 @@ module(basename(__filename), function (hooks) {
     );
   });
 
-  test('h2 diagnostics (passive ping + session snapshot) do not disrupt serving', async function (assert) {
-    // With REALM_SERVER_HTTP2_DIAGNOSTICS on, every accepted session is swept
-    // every 5s — a passive PING + a state snapshot. Hold one h2 connection open
-    // across a sweep and confirm the session still serves afterwards, i.e. the
-    // observer-only diagnostics neither throw in the interval nor perturb the
-    // session they watch.
+  test('h2 keepalive + diagnostics do not disrupt serving', async function (assert) {
+    // Every accepted session gets the PING keepalive, and with
+    // REALM_SERVER_HTTP2_DIAGNOSTICS on it is also swept every 5s for a state
+    // snapshot. Hold one h2 connection open across a keepalive ping and a
+    // diagnostics sweep and confirm the session still serves afterwards: a
+    // healthy peer pongs, so the keepalive must never tear it down, and the
+    // observer-only diagnostics must neither throw nor perturb the session.
     let prior = process.env.REALM_SERVER_HTTP2_DIAGNOSTICS;
     process.env.REALM_SERVER_HTTP2_DIAGNOSTICS = '1';
     let restoreEnv = () => {
@@ -551,13 +552,13 @@ module(basename(__filename), function (hooks) {
     try {
       assert.true(isHttp2, 'listener advertises h2 mode');
       assert.strictEqual(await request('/_alive'), 200, 'first request OK');
-      // Cross at least one 5s sweep so the passive ping + snapshot run against
-      // the live session.
+      // Cross at least one 5s keepalive ping and one diagnostics sweep so
+      // both run against the live session.
       await new Promise((r) => setTimeout(r, 5500));
       assert.strictEqual(
         await request('/_alive'),
         200,
-        'request after a diagnostics sweep still OK — ping did not disrupt the session',
+        'request after a keepalive ping + diagnostics sweep still OK',
       );
     } finally {
       client.close();


### PR DESCRIPTION
## Background and Goal

Host acceptance tests intermittently time out with no assertion failure. The client-side timeout dump shows a single in-flight base-realm fetch (e.g. `QUERY https://localhost:4201/base/_info` outstanding for 119s) holding the `fetcher` test waiter open, while the app is otherwise idle. The server-side session diagnostics for the same window show the wedge's signature: the session that carried the burst of base-module requests reports `streams=0` while its `pongAge` climbs monotonically past 100s — the server's PINGs go unanswered.

PONG is handled by the peer's network stack, not JS, so a missing pong means no frames are flowing on that connection at all: the transport is wedged. The browser never receives a response or an error, the fetch never rejects, and the test-env fetch retry in `virtual-network.ts` (which only retries rejections) never fires — the test hangs until its 60s timeout. Example failure: [Host Tests (9, 20)](https://github.com/cardstack/boxel/actions/runs/27410488678/job/81010718675).

## The fix

Every h2 session the realm server accepts now gets an always-on PING keepalive. A session that misses 3 consecutive pongs (~30s of silence) is closed (GOAWAY) and force-destroyed after a short grace, RSTing its streams so the browser's hung fetch rejects and the existing retry path reissues it on a fresh session. h2 itself is untouched.

Tuning: worst-case detection is `maxMissedPings × (interval + pongTimeout) + grace = 3 × 10s + 3s ≈ 33s`, leaving the released fetch room to retry and complete inside a 60s host-test timeout. The discrimination is clean: a transient event-loop hiccup scores at most one miss before the next successful pong resets the counter, while a wedged session never pongs again. A false teardown costs the peer a reconnect, never a wrong result. This path only runs where the realm server speaks h2 (local dev and CI); hosted staging/prod serve plain HTTP/1.1 behind the load balancer and are untouched.

## Where to start

- `packages/realm-server/server.ts` — `installHttp2Keepalive` (wires the keepalive onto every accepted session, owns the shared liveness map) and `startSessionKeepalive` (the per-session PING loop + teardown), both called from `buildHttp2SecureServer`.
- The env-gated h2 diagnostics now read ping liveness (`pongAge`, `missedPings`) from the keepalive's map instead of running their own passive probe, and share session ids with the keepalive's log lines so `[h2-keepalive]` and `[h2-diag]` output correlates.
- `packages/realm-server/tests/http2-keepalive-test.ts` — unit coverage of the PING loop against a fake session (teardown on sustained silence, no teardown on transient misses, miss-counter reset, stop/close semantics).
- `tests/listener-dispatcher-test.ts` — the live-listener test now crosses a real keepalive ping and asserts a healthy session keeps serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
