### PR TITLE
Add handling for missing card in routing map

### DIFF
--- a/packages/base/realm-config.gts
+++ b/packages/base/realm-config.gts
@@ -5,6 +5,7 @@ import {
   field,
   contains,
   containsMany,
+  getRelationshipMembershipState,
   linksTo,
   realmURL,
 } from './card-api';
@@ -285,6 +286,30 @@ class RealmConfigEdit extends Component<typeof RealmConfig> {
     return findDuplicateRoutingPaths(this.args.model.hostRoutingRules);
   }
 
+  // Routing rules whose linked target card no longer exists. The
+  // `instance` linksTo resolves to a terminal broken-link state once the
+  // editor has tried to load it ('not-found' for a 404, 'error' for an
+  // upstream failure). Surfacing these lets the owner repair the rule
+  // before publishing — a dangling target otherwise degrades that routed
+  // path to a 404 placeholder on the published site.
+  get danglingRoutingRulePaths(): string[] {
+    let rules = this.args.model.hostRoutingRules ?? [];
+    let paths: string[] = [];
+    for (let rule of rules) {
+      if (!rule) {
+        continue;
+      }
+      let slot = getRelationshipMembershipState(
+        rule as unknown as CardDef,
+        'instance',
+      ).membership?.[0];
+      if (slot?.kind === 'not-found' || slot?.kind === 'error') {
+        paths.push(rule.path ?? '(no path)');
+      }
+    }
+    return paths;
+  }
+
   // CardInfoTemplates.edit insists on a strict `CardDef` for `@model`;
   // the template arg here is `PartialFields<RealmConfig>` (every field
   // optional, including `id`), so cast to the looser shape it actually
@@ -310,6 +335,18 @@ class RealmConfigEdit extends Component<typeof RealmConfig> {
                 >
                   Duplicate paths:
                   {{#each this.duplicatePaths as |p i|}}
+                    {{#if i}}, {{/if}}<code>{{p}}</code>
+                  {{/each}}
+                </div>
+              {{/if}}
+              {{#if this.danglingRoutingRulePaths.length}}
+                <div
+                  class='warning'
+                  role='status'
+                  data-test-dangling-routing-warning
+                >
+                  These paths point to a card that no longer exists:
+                  {{#each this.danglingRoutingRulePaths as |p i|}}
                     {{#if i}}, {{/if}}<code>{{p}}</code>
                   {{/each}}
                 </div>

--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -40,11 +40,13 @@ export default class HostModeCard extends Component<Signature> {
     return this.cardResource?.cardError;
   }
 
-  get cardErrorMessage() {
-    if (this.cardError?.status === 404) {
-      return 'Card not found.';
-    }
-    return undefined;
+  // A routing rule pointing at a card that no longer exists, or a direct
+  // visit to a missing card, resolves to a 404. Rather than surfacing the
+  // raw card-error/debug treatment on a public page, render a friendly
+  // not-found placeholder so one dangling reference degrades gracefully
+  // instead of taking the page down.
+  get isNotFound() {
+    return this.cardError?.status === 404;
   }
 
   get isLoading() {
@@ -120,12 +122,13 @@ export default class HostModeCard extends Component<Signature> {
       data-test-host-mode-card-loaded={{bool this.card}}
       ...attributes
     >
-      {{#if this.cardError}}
-        <CardError
-          @error={{this.cardError}}
-          @hideHeader={{true}}
-          @message={{this.cardErrorMessage}}
-        />
+      {{#if this.isNotFound}}
+        <div class='not-found' data-test-host-mode-404>
+          <p class='not-found-code'>404</p>
+          <p class='not-found-message'>This page could not be found.</p>
+        </div>
+      {{else if this.cardError}}
+        <CardError @error={{this.cardError}} @hideHeader={{true}} />
       {{else if this.card}}
         <CardRenderer
           class='card'
@@ -172,6 +175,29 @@ export default class HostModeCard extends Component<Signature> {
         min-height: 16rem;
         text-align: center;
         gap: var(--boxel-sp);
+      }
+
+      .not-found {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: 16rem;
+        height: 100%;
+        text-align: center;
+        gap: var(--boxel-sp-xs);
+      }
+
+      .not-found-code {
+        margin: 0;
+        font: 700 var(--boxel-font-xl);
+        line-height: 1;
+      }
+
+      .not-found-message {
+        margin: 0;
+        color: var(--boxel-450);
+        font: var(--boxel-font);
       }
 
       .non-publishable-message {

--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -10,6 +10,7 @@ import { bool, cn } from '@cardstack/boxel-ui/helpers';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
 import CardError from '@cardstack/host/components/operator-mode/card-error';
+import CardErrorDetail from '@cardstack/host/components/operator-mode/card-error-detail';
 import { getCard } from '@cardstack/host/resources/card-resource';
 
 interface Signature {
@@ -122,13 +123,19 @@ export default class HostModeCard extends Component<Signature> {
       data-test-host-mode-card-loaded={{bool this.card}}
       ...attributes
     >
-      {{#if this.isNotFound}}
-        <div class='not-found' data-test-host-mode-404>
-          <p class='not-found-code'>404</p>
-          <p class='not-found-message'>This page could not be found.</p>
-        </div>
-      {{else if this.cardError}}
-        <CardError @error={{this.cardError}} @hideHeader={{true}} />
+      {{#if this.cardError}}
+        {{#if this.isNotFound}}
+          {{! A 404 (e.g. a routing rule pointing at a deleted card) gets a
+              friendly centered placeholder, while the collapsible technical
+              detail stays available below for the realm owner debugging it. }}
+          <div class='not-found' data-test-host-mode-404>
+            <p class='not-found-code'>404</p>
+            <p class='not-found-message'>This page could not be found.</p>
+          </div>
+          <CardErrorDetail @error={{this.cardError}} class='not-found-detail' />
+        {{else}}
+          <CardError @error={{this.cardError}} @hideHeader={{true}} />
+        {{/if}}
       {{else if this.card}}
         <CardRenderer
           class='card'
@@ -198,6 +205,19 @@ export default class HostModeCard extends Component<Signature> {
         margin: 0;
         color: var(--boxel-450);
         font: var(--boxel-font);
+      }
+
+      /* Anchor the technical-detail box to the bottom of the card, the same
+         way CardError positions its own detail, so the centered 404 message
+         sits above it. */
+      .not-found-detail {
+        position: absolute;
+        bottom: var(--boxel-sp);
+        left: var(--boxel-sp);
+        right: var(--boxel-sp);
+        max-height: calc(100% - calc(var(--boxel-sp) * 2));
+        z-index: 10;
+        margin: 0;
       }
 
       .non-publishable-message {

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -27,6 +27,8 @@ import { IconX, Warning as WarningIcon } from '@cardstack/boxel-ui/icons';
 import {
   deriveRealmName,
   ensureTrailingSlash,
+  isCardErrorJSONAPI,
+  isCardInstance,
   resolvePublishedRealmUrl,
 } from '@cardstack/runtime-common';
 import { getPublishedRealmDomainOverrides } from '@cardstack/runtime-common/constants';
@@ -40,8 +42,10 @@ import config from '@cardstack/host/config/environment';
 
 import type CommandService from '@cardstack/host/services/command-service';
 import type HostModeService from '@cardstack/host/services/host-mode-service';
+import type LoaderService from '@cardstack/host/services/loader-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import type RealmService from '@cardstack/host/services/realm';
+
 import type {
   PrivateDependencyViolation,
   ErrorDocumentViolation,
@@ -51,6 +55,9 @@ import type {
   ClaimedDomain,
   SubdomainAvailabilityResult,
 } from '@cardstack/host/services/realm-server';
+import type StoreService from '@cardstack/host/services/store';
+
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
 type CustomSubdomainSelection = {
   url: string;
@@ -74,10 +81,14 @@ interface Signature {
 
 export default class PublishRealmModal extends Component<Signature> {
   @service declare private hostModeService: HostModeService;
+  @service declare private loaderService: LoaderService;
   @service declare private matrixService: MatrixService;
   @service declare private realm: RealmService;
   @service declare private realmServer: RealmServerService;
   @service declare private commandService: CommandService;
+  @service declare private store: StoreService;
+
+  #cardAPI?: typeof CardAPI;
 
   @tracked selectedPublishedRealmURLs: string[] = [];
   @tracked private customSubdomainSelection: CustomSubdomainSelection | null =
@@ -98,6 +109,9 @@ export default class PublishRealmModal extends Component<Signature> {
   @tracked private errorDocumentViolations: ErrorDocumentViolation[] | null =
     null;
   @tracked private warningTypes: string[] | null = null;
+  @tracked private danglingRoutingRules:
+    | { path: string; reference: string }[]
+    | null = null;
 
   @tracked private initialSelectionsSet = false;
 
@@ -106,6 +120,16 @@ export default class PublishRealmModal extends Component<Signature> {
     this.ensureInitialSelectionsTask.perform();
     this.fetchBoxelClaimedDomain.perform();
     this.checkPrivateDependenciesTask.perform();
+    this.checkDanglingRoutingRulesTask.perform();
+  }
+
+  private async loadCardAPI() {
+    if (!this.#cardAPI) {
+      this.#cardAPI = await this.loaderService.loader.import<typeof CardAPI>(
+        'https://cardstack.com/base/card-api',
+      );
+    }
+    return this.#cardAPI;
   }
 
   get isSubdirectoryRealmPublished() {
@@ -138,6 +162,13 @@ export default class PublishRealmModal extends Component<Signature> {
 
   get isCheckingPrivateDependencies() {
     return this.checkPrivateDependenciesTask.isRunning;
+  }
+
+  get shouldShowDanglingRoutingWarning() {
+    return (
+      Array.isArray(this.danglingRoutingRules) &&
+      this.danglingRoutingRules.length > 0
+    );
   }
 
   private privateRealmURLsForViolation = (
@@ -444,6 +475,56 @@ export default class PublishRealmModal extends Component<Signature> {
       this.privateDependencyViolations = null;
       this.errorDocumentViolations = null;
       this.warningTypes = null;
+    }
+  });
+
+  // Pre-publish check for host routing rules whose target card no longer
+  // exists. Publishing copies the realm config verbatim, including such a
+  // rule, and the published site then degrades the matched path to a 404
+  // placeholder — so warn the owner before they publish. Reads each rule's
+  // `instance` reference (preserved even when the link is broken) and
+  // confirms the target 404s.
+  private checkDanglingRoutingRulesTask = restartableTask(async () => {
+    this.danglingRoutingRules = null;
+    let realmURL = this.currentRealmURL;
+    if (!realmURL) {
+      return;
+    }
+    try {
+      let realmConfigId = `${ensureTrailingSlash(String(realmURL))}realm`;
+      let configCard = await this.store.get(realmConfigId);
+      if (!isCardInstance(configCard)) {
+        this.danglingRoutingRules = [];
+        return;
+      }
+      let api = await this.loadCardAPI();
+      let rules =
+        (configCard as unknown as { hostRoutingRules?: any[] })
+          .hostRoutingRules ?? [];
+      let dangling: { path: string; reference: string }[] = [];
+      for (let rule of rules) {
+        if (!rule) {
+          continue;
+        }
+        let slot = api.getRelationshipMembershipState(rule, 'instance')
+          .membership?.[0];
+        let reference = slot?.reference;
+        if (!reference) {
+          continue;
+        }
+        let targetId = new URL(reference, realmConfigId).href;
+        let target = await this.store.get(targetId);
+        if (isCardErrorJSONAPI(target) && target.status === 404) {
+          dangling.push({ path: rule.path ?? '/', reference: targetId });
+        }
+      }
+      this.danglingRoutingRules = dangling;
+    } catch (error) {
+      console.error(
+        'Failed to check for dangling routing rules before publishing',
+        error,
+      );
+      this.danglingRoutingRules = null;
     }
   });
 
@@ -819,6 +900,36 @@ export default class PublishRealmModal extends Component<Signature> {
               </div>
             </div>
           {{/if}}
+        {{/if}}
+
+        {{#if this.shouldShowDanglingRoutingWarning}}
+          <div
+            class='publish-warning warning'
+            data-test-dangling-routing-warning
+          >
+            <WarningIcon
+              class='publish-warning-icon'
+              width='20'
+              height='20'
+              role='presentation'
+            />
+            <div class='publish-warning-body'>
+              <div>
+                Some host routing rules point to a card that no longer exists.
+                Visitors to these paths will see a "page not found" error after
+                publishing.
+              </div>
+              <ul class='violation-list'>
+                {{#each this.danglingRoutingRules as |rule|}}
+                  <li>
+                    <code>{{rule.path}}</code>
+                    →
+                    {{rule.reference}}
+                  </li>
+                {{/each}}
+              </ul>
+            </div>
+          </div>
         {{/if}}
 
         <div class='domain-options'>

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -420,9 +420,12 @@ module('Acceptance | host mode tests', function (hooks) {
     gate.fulfill();
 
     await visitPromise;
-    await waitFor('[data-test-card-error]');
-    assert.dom('[data-test-card-error]').exists();
-    assert.dom('[data-test-card-error]').containsText('Card not found');
+    await waitFor('[data-test-host-mode-404]');
+    assert
+      .dom('[data-test-host-mode-404]')
+      .containsText('This page could not be found.');
+    // The collapsible technical detail stays available below the placeholder.
+    assert.dom('[data-test-error-display]').exists();
     assert.strictEqual(
       getPageTitle(),
       `Card not found: ${testHostModeRealmURL}Pet/non-existent`,

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -595,8 +595,10 @@ module('Acceptance | host submode', function (hooks) {
         trail: [`${testRealmURL}nonexistent.json`],
       });
 
-      await waitFor('[data-test-card-error]');
-      assert.dom('[data-test-card-error]').exists();
+      await waitFor('[data-test-host-mode-404]');
+      assert.dom('[data-test-host-mode-404]').exists();
+      // The collapsible technical detail stays available below the placeholder.
+      assert.dom('[data-test-error-display]').exists();
     });
 
     test('ai assistant is not displayed in host submode', async function (assert) {

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -193,6 +193,65 @@ module('Acceptance | host submode', function (hooks) {
     };
   });
 
+  module('with a dangling host routing rule', function (hooks) {
+    hooks.beforeEach(async function () {
+      let dbAdapter = await getDbAdapter();
+      await query(dbAdapter, [
+        `INSERT INTO realm_metadata (url, publishable) VALUES (`,
+        param(testRealmURL),
+        `,`,
+        param(true),
+        `) ON CONFLICT (url) DO UPDATE SET publishable = true`,
+      ]);
+      // A `/` routing rule whose target card was never created, so the
+      // `instance` link dangles.
+      realmContents['realm.json'] = {
+        data: {
+          type: 'card',
+          attributes: {
+            cardInfo: { name: 'Test Workspace B' },
+            hostRoutingRules: [{ path: '/' }],
+          },
+          relationships: {
+            'hostRoutingRules.0.instance': {
+              links: { self: './does-not-exist' },
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/realm-config',
+              name: 'RealmConfig',
+            },
+          },
+        },
+      };
+      await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        contents: realmContents,
+      });
+    });
+
+    test('publish modal warns that a routing rule points to a missing card', async function (assert) {
+      await visitOperatorMode({
+        submode: 'host',
+        trail: [`${testRealmURL}Person/1.json`],
+      });
+
+      await click('[data-test-publish-realm-button]');
+      await waitFor('[data-test-publish-realm-modal]');
+      await waitFor('[data-test-dangling-routing-warning]');
+      assert
+        .dom('[data-test-dangling-routing-warning]')
+        .exists('the dangling-routing warning shows in the publish modal');
+      assert
+        .dom('[data-test-dangling-routing-warning]')
+        .containsText(
+          'does-not-exist',
+          'the warning names the missing routing target',
+        );
+    });
+  });
+
   module('with a realm that is not publishable', function (hooks) {
     hooks.beforeEach(async function () {
       await setupAcceptanceTestRealm({

--- a/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
+++ b/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
@@ -42,6 +42,7 @@ module(
 
     async function renderRealmConfigEdit(
       hostRoutingRules: Array<Record<string, unknown>>,
+      relationships?: Record<string, unknown>,
     ) {
       let loader = getService('loader-service').loader;
       let cardApi: typeof import('https://cardstack.com/base/card-api') =
@@ -74,6 +75,7 @@ module(
             data: {
               type: 'card',
               attributes: { hostRoutingRules },
+              ...(relationships ? { relationships } : {}),
               meta: {
                 adoptsFrom: {
                   module: 'https://cardstack.com/base/realm-config',
@@ -204,6 +206,29 @@ module(
       assert
         .dom('[data-test-duplicate-path-warning]')
         .containsText('/docs', 'the duplicate banner names the repeated path');
+    });
+
+    test('warns when a routing rule points to a card that no longer exists', async function (assert) {
+      // The rule links to a card that was never created in the realm, so
+      // its `instance` linksTo resolves to a 404 (not-found) once the
+      // editor tries to load it. The aggregate warning names the path so
+      // the owner can repair or remove the rule before publishing.
+      await renderRealmConfigEdit([{ path: '/gone' }], {
+        'hostRoutingRules.0.instance': {
+          links: { self: './does-not-exist' },
+        },
+      });
+
+      await waitFor('[data-test-dangling-routing-warning]');
+      assert
+        .dom('[data-test-dangling-routing-warning]')
+        .exists('the dangling-routing banner is shown');
+      assert
+        .dom('[data-test-dangling-routing-warning]')
+        .containsText(
+          '/gone',
+          'the banner names the path with the dead target',
+        );
     });
 
     test('rules with unset paths warn as duplicates of explicit "/" rules', async function (assert) {

--- a/packages/matrix/tests/host-mode.spec.ts
+++ b/packages/matrix/tests/host-mode.spec.ts
@@ -73,9 +73,13 @@ async function publishRealm(
 // `_publish-realm` POST is the heaviest, contention-prone step in the suite,
 // so collapsing two publishes into one is what keeps the routing tests from
 // timing out on a first-attempt publish under shard load.
+//
+// `options.routingRuleTarget` overrides the rule's `instance` link (default
+// `./white-paper`). Point it at a card that is never created to exercise a
+// dangling routing target.
 async function createAndPublishHostModeRealm(
   page: Page,
-  options: { routingRulePath?: string } = {},
+  options: { routingRulePath?: string; routingRuleTarget?: string } = {},
 ): Promise<PublishedHostModeRealm> {
   const serverIndexUrl = new URL(appURL).origin;
   const { username, password } = await createSubscribedUserAndLogin(
@@ -256,7 +260,7 @@ async function createAndPublishHostModeRealm(
           },
           relationships: {
             'hostRoutingRules.0.instance': {
-              links: { self: './white-paper' },
+              links: { self: options.routingRuleTarget ?? './white-paper' },
             },
           },
           meta: {
@@ -557,5 +561,42 @@ test.describe('Host mode routing rules', () => {
     await expect(
       page.locator(`[data-test-host-mode-card="${expectedRoutedCardId}"]`),
     ).toBeVisible();
+  });
+
+  // A routing rule whose target card no longer exists must degrade
+  // gracefully: the realm config keeps the rule (the read path only filters
+  // cross-realm targets, not missing ones), so serve-index rewrites the root
+  // to the dead card and the SPA's first store fetch for it 404s. Rather than
+  // taking the whole published site down with a raw card error, the host
+  // renders a friendly 404 placeholder for that path.
+  test('dangling `/` routing rule target renders a 404 placeholder', async ({
+    page,
+  }) => {
+    let realm = await createAndPublishHostModeRealm(page, {
+      routingRulePath: '/',
+      // Never created in the helper, so the rule dangles.
+      routingRuleTarget: './dangling-target',
+    });
+
+    // The usual card-marker gate can't be used here: the target 404s, so
+    // no isolated HTML is ever served at the root. Gate instead on the
+    // dead target's id appearing in serve-index's injected hostRoutingMap
+    // — that confirms the RealmConfig card is indexed and the rewrite is
+    // live (the base config ships an empty hostRoutingMap, so the slug
+    // only shows up once the rule is active).
+    await waitForPublishedMarker(
+      page,
+      realm.publishedRealmURL,
+      'dangling-target',
+    );
+
+    await page.goto(realm.publishedRealmURL, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await expect(page.locator('[data-test-host-mode-404]')).toBeVisible();
+
+    // It's a clean placeholder, not the raw card-error/debug treatment.
+    await expect(page.locator('[data-test-card-error]')).toHaveCount(0);
   });
 });

--- a/packages/matrix/tests/host-mode.spec.ts
+++ b/packages/matrix/tests/host-mode.spec.ts
@@ -596,7 +596,11 @@ test.describe('Host mode routing rules', () => {
 
     await expect(page.locator('[data-test-host-mode-404]')).toBeVisible();
 
-    // It's a clean placeholder, not the raw card-error/debug treatment.
-    await expect(page.locator('[data-test-card-error]')).toHaveCount(0);
+    // The collapsible technical detail stays available below the placeholder
+    // for the realm owner debugging the dead reference.
+    await expect(page.locator('[data-test-error-display]')).toBeVisible();
+    await expect(page.locator('[data-test-toggle-details]')).toContainText(
+      'Show Details',
+    );
   });
 });


### PR DESCRIPTION
If a routing map points to a nonexistent card you see this in the published realm:

<img width="2794" height="1884" alt="s 2026-06-12 at 14 53 16@2x" src="https://github.com/user-attachments/assets/a721a595-a7c3-4bd3-909b-e0bfe3afc4cb" />

This makes a more prominent 404 to make clear what’s happening:

<img width="2446" height="1574" alt="s 2026-06-15 at 13 21 25@2x" src="https://github.com/user-attachments/assets/1f651915-997d-4edd-aa57-0dd875385ecb" />

The realm config editor warns about this:

<img width="2446" height="1574" alt="s 2026-06-15 at 14 23 48@2x" src="https://github.com/user-attachments/assets/2ce4fb3d-bc78-449f-b888-70cee64da05c" />

Publishing also warns this will happen:

<img width="2446" height="1574" alt="s 2026-06-15 at 13 35 56@2x" src="https://github.com/user-attachments/assets/696fc53f-5053-4ef1-89a8-aa8660fc9617" />

While looking at this I realised host submode doesn’t even look at routing, so that’s filed as 11537:

<img width="2446" height="1574" alt="s 2026-06-15 at 14 20 35@2x" src="https://github.com/user-attachments/assets/bc11daba-4814-4ff5-88ee-7d51490e76f8" />
