### PR TITLE
Unified search v2 host live-search resource (getSearchEntriesResource)

### DIFF
--- a/packages/host/app/lib/search-error-entry.ts
+++ b/packages/host/app/lib/search-error-entry.ts
@@ -1,0 +1,52 @@
+import {
+  isCardError,
+  type ErrorEntry,
+  type SerializedError,
+} from '@cardstack/runtime-common';
+
+// Serialize a failed search request into the `ErrorEntry` shape the search
+// resources expose to their consumers.
+export function searchErrorEntry(err: unknown): ErrorEntry {
+  let status =
+    typeof (err as { status?: unknown })?.status === 'number'
+      ? ((err as { status: number }).status as number)
+      : 500;
+  let message =
+    typeof (err as { message?: unknown })?.message === 'string'
+      ? ((err as { message: string }).message as string)
+      : String(err);
+  let stack =
+    typeof (err as { stack?: unknown })?.stack === 'string'
+      ? ((err as { stack: string }).stack as string)
+      : undefined;
+  let title = status === 404 ? 'Link Not Found' : 'Search Error';
+  let serialized: SerializedError = {
+    title,
+    status,
+    message,
+    stack,
+    additionalErrors: null,
+  };
+  if (isCardError(err)) {
+    if (err.additionalErrors?.length) {
+      serialized.additionalErrors = err.additionalErrors.map(
+        (additionalError) => {
+          let normalized = additionalError as Partial<SerializedError>;
+          return {
+            title: normalized.title,
+            status: normalized.status,
+            message: normalized.message,
+            stack: normalized.stack,
+          };
+        },
+      );
+    }
+    if (err.deps?.length) {
+      serialized.deps = [...err.deps];
+    }
+  }
+  return {
+    type: 'instance-error',
+    error: serialized,
+  };
+}

--- a/packages/host/app/resources/search-entries.ts
+++ b/packages/host/app/resources/search-entries.ts
@@ -1,4 +1,4 @@
-import { registerDestructor } from '@ember/destroyable';
+import { isDestroyed, registerDestructor } from '@ember/destroyable';
 import { service } from '@ember/service';
 import { buildWaiter } from '@ember/test-waiters';
 import { tracked } from '@glimmer/tracking';
@@ -16,6 +16,9 @@ import {
   isFileMetaResource,
   isHtmlResource,
   logger as runtimeLogger,
+  resourceIdentity,
+  rri,
+  RealmPaths,
   type CardResource,
   type ErrorEntry,
   type FileMetaResource,
@@ -29,7 +32,7 @@ import {
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 
-import { normalizeRealms, resolveCardRealmUrl } from '../lib/realm-utils';
+import { normalizeRealms } from '../lib/realm-utils';
 import { searchErrorEntry } from '../lib/search-error-entry';
 
 import type LoaderService from '../services/loader-service';
@@ -110,6 +113,7 @@ export class SearchEntriesResource extends Resource<Args> {
 
   #previousQuery: SearchEntryWireQuery | undefined;
   #previousRealms: string[] | undefined;
+  #idleClearScheduled = false;
   #log = runtimeLogger('search-entries-resource');
   // Kept private for tests/internal load bookkeeping.
   // @ts-ignore read only via the test cast.
@@ -132,6 +136,12 @@ export class SearchEntriesResource extends Resource<Args> {
 
     if (query === undefined) {
       // Clear stale state so live subscriptions don't re-fire the old query.
+      // The untracked bookkeeping clears synchronously; the tracked result
+      // state must not — modify() runs inside a tracked computation (a
+      // property access on the resource proxy, typically mid-render), so a
+      // synchronous read-then-write of `_entries` would trip Glimmer's
+      // mutation-after-consumption assertion and self-invalidate this
+      // resource's cache on every access.
       this.#previousQuery = undefined;
       this.#previousRealms = undefined;
       this.realmsNeedingRefresh.clear();
@@ -141,9 +151,26 @@ export class SearchEntriesResource extends Resource<Args> {
         subscription.unsubscribe();
       }
       this.subscriptions = [];
-      this._entries.splice(0, this._entries.length);
-      this._meta = { page: { total: 0 } };
-      this._errors = undefined;
+      if (!this.#idleClearScheduled) {
+        this.#idleClearScheduled = true;
+        void Promise.resolve().then(() => {
+          this.#idleClearScheduled = false;
+          // Apply only if still idle and alive — a query may have arrived
+          // (or the resource been torn down) between schedule and flush.
+          if (this.#previousQuery !== undefined || isDestroyed(this)) {
+            return;
+          }
+          if (this._entries.length > 0) {
+            this._entries.splice(0, this._entries.length);
+          }
+          if (this._meta.page.total !== 0 || this._meta.htmlQuery) {
+            this._meta = { page: { total: 0 } };
+          }
+          if (this._errors !== undefined) {
+            this._errors = undefined;
+          }
+        });
+      }
       return;
     }
 
@@ -187,16 +214,9 @@ export class SearchEntriesResource extends Resource<Args> {
       return;
     }
 
-    if (realmsChanged && this.#previousRealms !== undefined) {
-      // Drop rows from realms no longer searched; the run below replaces the
-      // rest.
-      let kept = this._entries.filter((entry) =>
-        realms.includes(entry.realmUrl),
-      );
-      this._entries.splice(0, this._entries.length, ...kept);
-    }
-
-    this.#previousQuery = query;
+    // Snapshot, don't alias: a caller that mutates a long-lived query object
+    // in place would otherwise be compared against itself and never re-run.
+    this.#previousQuery = structuredClone(query);
     this.#previousRealms = realms;
     // A query/realm change owns the whole result set again.
     this.realmsNeedingRefresh.clear();
@@ -244,13 +264,27 @@ export class SearchEntriesResource extends Resource<Args> {
         let fresh = this.buildEntries(doc);
 
         if (isPartialRefresh) {
-          // Replace only the fetched realms' rows; rows from other realms
-          // keep their identity (realm A's refresh leaves realm B's entries
-          // untouched).
-          let kept = this._entries.filter(
-            (entry) => !realmsToFetch.includes(entry.realmUrl),
-          );
-          this._entries.splice(0, this._entries.length, ...kept, ...fresh);
+          // Merge in place: rows from unfetched realms keep their position
+          // and identity; a refreshed row that survives keeps its position
+          // (and its identity when nothing about it changed); vanished rows
+          // drop out; new rows append. Live updates must not reshuffle the
+          // visible list, and unchanged rows must stay render-stable.
+          let refreshedRealms = new Set(realmsToFetch);
+          let freshById = new Map(fresh.map((entry) => [entry.id, entry]));
+          let merged: SearchEntry[] = [];
+          for (let entry of this._entries) {
+            if (!refreshedRealms.has(entry.realmUrl)) {
+              merged.push(entry);
+              continue;
+            }
+            let replacement = freshById.get(entry.id);
+            if (replacement !== undefined) {
+              merged.push(isEqual(entry, replacement) ? entry : replacement);
+              freshById.delete(entry.id);
+            }
+          }
+          merged.push(...freshById.values());
+          this._entries.splice(0, this._entries.length, ...merged);
           // Unpaginated (a partial refresh precondition), so the standing
           // entry count is the exact whole-set total; the response's total
           // only speaks for the fetched realm subset.
@@ -259,7 +293,19 @@ export class SearchEntriesResource extends Resource<Args> {
             page: { total: this._entries.length },
           };
         } else {
-          this._entries.splice(0, this._entries.length, ...fresh);
+          // Server order is authoritative on a full run, but an unchanged
+          // row keeps its object identity so live re-runs don't force every
+          // row to re-render.
+          let previousById = new Map(
+            this._entries.map((entry) => [entry.id, entry]),
+          );
+          let next = fresh.map((entry) => {
+            let previous = previousById.get(entry.id);
+            return previous !== undefined && isEqual(previous, entry)
+              ? previous
+              : entry;
+          });
+          this._entries.splice(0, this._entries.length, ...next);
           this._meta = doc.meta;
           this.hasCompletedFullRun = true;
         }
@@ -310,9 +356,26 @@ export class SearchEntriesResource extends Resource<Args> {
       } else if (isCssResource(resource)) {
         cssHrefById.set(resource.id, resource.attributes.href);
       } else if (isCardResource(resource) || isFileMetaResource(resource)) {
-        itemsByIdentity.set(`${resource.type} ${resource.id}`, resource);
+        itemsByIdentity.set(
+          resourceIdentity(resource.type, resource.id),
+          resource,
+        );
       }
     }
+
+    // One RealmPaths per searched realm per build — not per entry.
+    let realmPaths = this.realmsToSearch.map(
+      (realm) => new RealmPaths(new URL(realm)),
+    );
+    let realmUrlFor = (id: string): string => {
+      let idRRI = rri(id);
+      for (let paths of realmPaths) {
+        if (paths.inRealm(idRRI)) {
+          return paths.url;
+        }
+      }
+      return new RealmPaths(this.network.virtualNetwork.toURL(id)).url;
+    };
 
     return doc.data.map((entry) => {
       let renderings = (entry.relationships.html?.data ?? [])
@@ -321,15 +384,11 @@ export class SearchEntriesResource extends Resource<Args> {
         .map((html) => buildRendering(html!, cssHrefById));
       let itemRef = entry.relationships.item?.data;
       let item = itemRef
-        ? itemsByIdentity.get(`${itemRef.type} ${itemRef.id}`)
+        ? itemsByIdentity.get(resourceIdentity(itemRef.type, itemRef.id))
         : undefined;
       return {
         id: entry.id,
-        realmUrl: resolveCardRealmUrl(
-          entry.id,
-          this.realmsToSearch,
-          this.network.virtualNetwork,
-        ),
+        realmUrl: realmUrlFor(entry.id),
         html: renderings,
         ...(item ? { item } : {}),
       };
@@ -361,6 +420,13 @@ function buildRendering(
 // and re-runs on incremental index events with a per-realm partial refresh.
 // Realms ride in the query's `realms` member; omitted, every available realm
 // is searched.
+//
+// Create exactly once per owner — a class field or a one-time assignment,
+// never inside a getter or during render. Every call builds an independent
+// resource with its own realm subscriptions and fetches; per-render calls
+// pile up live instances on the parent until the parent is destroyed. Vary
+// the search through the `getQuery` thunk (it is re-read reactively), not by
+// constructing new resources.
 export function getSearchEntriesResource(
   parent: object,
   getQuery: () => SearchEntryWireQuery | undefined,

--- a/packages/host/app/resources/search-entries.ts
+++ b/packages/host/app/resources/search-entries.ts
@@ -1,0 +1,368 @@
+import { registerDestructor } from '@ember/destroyable';
+import { service } from '@ember/service';
+import { buildWaiter } from '@ember/test-waiters';
+import { tracked } from '@glimmer/tracking';
+
+import { didCancel, restartableTask } from 'ember-concurrency';
+import { Resource } from 'ember-modify-based-class-resource';
+
+import isEqual from 'lodash/isEqual';
+import { TrackedArray } from 'tracked-built-ins';
+
+import {
+  subscribeToRealm,
+  isCardResource,
+  isCssResource,
+  isFileMetaResource,
+  isHtmlResource,
+  logger as runtimeLogger,
+  type CardResource,
+  type ErrorEntry,
+  type FileMetaResource,
+  type HtmlResource,
+  type PrerenderedHtmlFormat,
+  type ResolvedCodeRef,
+  type Saved,
+  type SearchEntryCollectionDocument,
+  type SearchEntryWireQuery,
+} from '@cardstack/runtime-common';
+
+import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
+
+import { normalizeRealms, resolveCardRealmUrl } from '../lib/realm-utils';
+import { searchErrorEntry } from '../lib/search-error-entry';
+
+import type LoaderService from '../services/loader-service';
+import type NetworkService from '../services/network';
+import type RealmServerService from '../services/realm-server';
+import type StoreService from '../services/store';
+
+const waiter = buildWaiter('search-entries-resource:search-waiter');
+
+// One rendering of an entry: the wire's `html` resource flattened, with its
+// `styles` references resolved to the stylesheets' hrefs (the stylesheets
+// themselves are already imported through the loader by the time entries are
+// exposed). `id` is the (card URL, format, renderType) composite — an opaque
+// cache key; the readable rendering dimensions are the `format`/`renderType`
+// fields.
+export interface SearchEntryRendering {
+  id: string;
+  // Absent only on an error rendering with no last-known-good HTML.
+  html?: string;
+  cardType: string;
+  iconHtml?: string;
+  isError: boolean;
+  format: PrerenderedHtmlFormat;
+  // The type this rendering was rendered as. A file rendering carries none
+  // (files render natively).
+  renderType?: ResolvedCodeRef;
+  cssUrls: string[];
+}
+
+// One v2 search result, joined from the wire document: the `search-entry`
+// resource plus the `html` renderings and/or `item` serialization it
+// references in `included`. An empty `html` array means the entry matched but
+// no rendering satisfies the query's htmlQuery yet — the invalidation re-run
+// refreshes it when the rendering lands. The `item` is the raw wire
+// serialization (sparse when it carries `meta.sparseFields`), never a store
+// instance: entries live outside the store and are owned by the re-run; a
+// row a consumer has hydrated is owned by the store's reactive reload
+// instead.
+export interface SearchEntry {
+  id: string;
+  realmUrl: string;
+  html: SearchEntryRendering[];
+  item?: CardResource<Saved> | FileMetaResource;
+}
+
+interface Args {
+  named: {
+    query: SearchEntryWireQuery | undefined;
+  };
+}
+
+export class SearchEntriesResource extends Resource<Args> {
+  @service declare private loaderService: LoaderService;
+  @service declare private network: NetworkService;
+  @service declare private realmServer: RealmServerService;
+  @service declare private store: StoreService;
+
+  private realmsToSearch: string[] = [];
+  private subscriptions: { realm: string; unsubscribe: () => void }[] = [];
+  private _entries = new TrackedArray<SearchEntry>();
+  @tracked private _meta: SearchEntryCollectionDocument['meta'] = {
+    page: { total: 0 },
+  };
+  @tracked private _errors: ErrorEntry[] | undefined;
+
+  // Realms whose index moved since the last fetch. A non-empty set scopes the
+  // next run to just those realms (the per-realm partial refresh); rows from
+  // other realms keep their identity. Only the subscription callback writes
+  // it and only the search task reads it, so a plain Set suffices — modify()
+  // never consumes it, which is what would create a tracking hazard.
+  private realmsNeedingRefresh = new Set<string>();
+
+  // A partial refresh splices fetched-realm rows into the standing result
+  // set, so it is only sound once a full run has populated that set. Until
+  // then every run fetches all realms (an event arriving during the initial
+  // fetch must not narrow it).
+  private hasCompletedFullRun = false;
+
+  #previousQuery: SearchEntryWireQuery | undefined;
+  #previousRealms: string[] | undefined;
+  #log = runtimeLogger('search-entries-resource');
+  // Kept private for tests/internal load bookkeeping.
+  // @ts-ignore read only via the test cast.
+  private loaded: Promise<void> | undefined;
+
+  constructor(owner: object) {
+    super(owner);
+    registerDestructor(this, () => {
+      this.search.cancelAll();
+      for (let subscription of this.subscriptions) {
+        subscription.unsubscribe();
+      }
+      this.subscriptions = [];
+      this.realmsNeedingRefresh.clear();
+    });
+  }
+
+  modify(_positional: never[], named: Args['named']) {
+    let { query } = named;
+
+    if (query === undefined) {
+      // Clear stale state so live subscriptions don't re-fire the old query.
+      this.#previousQuery = undefined;
+      this.#previousRealms = undefined;
+      this.realmsNeedingRefresh.clear();
+      this.hasCompletedFullRun = false;
+      this.search.cancelAll();
+      for (let subscription of this.subscriptions) {
+        subscription.unsubscribe();
+      }
+      this.subscriptions = [];
+      this._entries.splice(0, this._entries.length);
+      this._meta = { page: { total: 0 } };
+      this._errors = undefined;
+      return;
+    }
+
+    let realms = normalizeRealms(
+      query.realms && query.realms.length > 0
+        ? query.realms
+        : this.realmServer.availableRealmIdentifiers,
+    );
+    this.realmsToSearch = realms;
+
+    let realmsChanged = !isEqual(realms, this.#previousRealms);
+    if (this.subscriptions.length === 0 || realmsChanged) {
+      for (let subscription of this.subscriptions) {
+        subscription.unsubscribe();
+      }
+      this.subscriptions = realms.map((realm) => ({
+        realm,
+        unsubscribe: subscribeToRealm(realm, (event: RealmEventContent) => {
+          if (this.#previousQuery === undefined) {
+            return;
+          }
+          // Only incremental index events re-run the search — the coarse
+          // "anything moved in a subscribed realm" trigger.
+          if (
+            event.eventName !== 'index' ||
+            ('indexType' in event && event.indexType !== 'incremental')
+          ) {
+            return;
+          }
+          this.#log.info(
+            `incremental index event on ${realm}; scheduling partial refresh`,
+          );
+          this.realmsNeedingRefresh.add(realm);
+          this.search.perform();
+        }),
+      }));
+    }
+
+    let queryChanged = !isEqual(query, this.#previousQuery);
+    if (!queryChanged && !realmsChanged) {
+      return;
+    }
+
+    if (realmsChanged && this.#previousRealms !== undefined) {
+      // Drop rows from realms no longer searched; the run below replaces the
+      // rest.
+      let kept = this._entries.filter((entry) =>
+        realms.includes(entry.realmUrl),
+      );
+      this._entries.splice(0, this._entries.length, ...kept);
+    }
+
+    this.#previousQuery = query;
+    this.#previousRealms = realms;
+    // A query/realm change owns the whole result set again.
+    this.realmsNeedingRefresh.clear();
+    this.hasCompletedFullRun = false;
+    this.loaded = this.search.perform();
+  }
+
+  get isLoading() {
+    return this.search.isRunning;
+  }
+
+  get entries(): SearchEntry[] {
+    return this._entries;
+  }
+
+  get meta() {
+    return this._meta;
+  }
+
+  get errors() {
+    return this._errors;
+  }
+
+  private search = restartableTask(async () => {
+    let query = this.#previousQuery;
+    if (query === undefined) {
+      return;
+    }
+    let token = waiter.beginAsync();
+    try {
+      let isPartialRefresh =
+        this.hasCompletedFullRun && this.realmsNeedingRefresh.size > 0;
+      let realmsToFetch = isPartialRefresh
+        ? [...this.realmsNeedingRefresh]
+        : this.realmsToSearch;
+
+      try {
+        let doc = await this.store.searchEntries(query, realmsToFetch);
+        await this.loadStylesheets(doc);
+        let fresh = this.buildEntries(doc);
+
+        if (isPartialRefresh) {
+          // Replace only the fetched realms' rows; rows from other realms
+          // keep their identity (realm A's refresh leaves realm B's entries
+          // untouched).
+          let kept = this._entries.filter(
+            (entry) => !realmsToFetch.includes(entry.realmUrl),
+          );
+          this._entries.splice(0, this._entries.length, ...kept, ...fresh);
+          // The fetch covered a realm subset, so the response's total only
+          // speaks for that subset; the standing entry count is the best
+          // whole-set figure available.
+          this._meta = {
+            ...this._meta,
+            page: { total: this._entries.length },
+          };
+        } else {
+          this._entries.splice(0, this._entries.length, ...fresh);
+          this._meta = doc.meta;
+          this.hasCompletedFullRun = true;
+        }
+
+        this.realmsNeedingRefresh.clear();
+        this._errors = undefined;
+      } catch (err) {
+        if (didCancel(err)) {
+          throw err;
+        }
+        this.#log.error(`search-entries fetch failed`, err);
+        this._errors = [searchErrorEntry(err)];
+        if (!isPartialRefresh) {
+          this._entries.splice(0, this._entries.length);
+          this._meta = { page: { total: 0 } };
+        }
+        // On a failed partial refresh the stale rows stay (with the error
+        // surfaced) and the realms stay marked, so the next event retries
+        // them.
+      }
+    } finally {
+      waiter.endAsync(token);
+    }
+  });
+
+  // The `css` resources base64-embed their whole stylesheet in the href; the
+  // loader import is what registers each scoped stylesheet with the document,
+  // so entries are paint-ready when exposed.
+  private async loadStylesheets(doc: SearchEntryCollectionDocument) {
+    let hrefs = (doc.included ?? [])
+      .filter(isCssResource)
+      .map((resource) => resource.attributes.href);
+    await Promise.all(
+      hrefs.map((href) => this.loaderService.loader.import(href)),
+    );
+  }
+
+  private buildEntries(doc: SearchEntryCollectionDocument): SearchEntry[] {
+    let htmlById = new Map<string, HtmlResource>();
+    let cssHrefById = new Map<string, string>();
+    let itemsByIdentity = new Map<
+      string,
+      CardResource<Saved> | FileMetaResource
+    >();
+    for (let resource of doc.included ?? []) {
+      if (isHtmlResource(resource)) {
+        htmlById.set(resource.id, resource);
+      } else if (isCssResource(resource)) {
+        cssHrefById.set(resource.id, resource.attributes.href);
+      } else if (isCardResource(resource) || isFileMetaResource(resource)) {
+        itemsByIdentity.set(`${resource.type} ${resource.id}`, resource);
+      }
+    }
+
+    return doc.data.map((entry) => {
+      let renderings = (entry.relationships.html?.data ?? [])
+        .map((ref) => htmlById.get(ref.id))
+        .filter(Boolean)
+        .map((html) => buildRendering(html!, cssHrefById));
+      let itemRef = entry.relationships.item?.data;
+      let item = itemRef
+        ? itemsByIdentity.get(`${itemRef.type} ${itemRef.id}`)
+        : undefined;
+      return {
+        id: entry.id,
+        realmUrl: resolveCardRealmUrl(
+          entry.id,
+          this.realmsToSearch,
+          this.network.virtualNetwork,
+        ),
+        html: renderings,
+        ...(item ? { item } : {}),
+      };
+    });
+  }
+}
+
+function buildRendering(
+  html: HtmlResource,
+  cssHrefById: Map<string, string>,
+): SearchEntryRendering {
+  let { attributes, relationships } = html;
+  return {
+    id: html.id,
+    ...(attributes.html !== undefined ? { html: attributes.html } : {}),
+    cardType: attributes.cardType,
+    ...(attributes.iconHtml ? { iconHtml: attributes.iconHtml } : {}),
+    isError: Boolean(attributes.isError),
+    format: attributes.format,
+    ...(attributes.renderType ? { renderType: attributes.renderType } : {}),
+    cssUrls: relationships.styles.data
+      .map(({ id }) => cssHrefById.get(id))
+      .filter((href): href is string => Boolean(href)),
+  };
+}
+
+// The one v2 host live-search resource: issues the `search-entry` wire query
+// through `StoreService.searchEntries`, subscribes to each searched realm,
+// and re-runs on incremental index events with a per-realm partial refresh.
+// Realms ride in the query's `realms` member; omitted, every available realm
+// is searched.
+export function getSearchEntriesResource(
+  parent: object,
+  getQuery: () => SearchEntryWireQuery | undefined,
+) {
+  return SearchEntriesResource.from(parent, () => ({
+    named: {
+      query: getQuery(),
+    },
+  })) as SearchEntriesResource;
+}

--- a/packages/host/app/resources/search-entries.ts
+++ b/packages/host/app/resources/search-entries.ts
@@ -227,8 +227,13 @@ export class SearchEntriesResource extends Resource<Args> {
     }
     let token = waiter.beginAsync();
     try {
+      // A paginated query never takes the realm-scoped path: with the held
+      // rows page-limited, no whole-set total can be reconstituted from a
+      // realm-subset fetch — the full re-run keeps `meta` server-accurate.
       let isPartialRefresh =
-        this.hasCompletedFullRun && this.realmsNeedingRefresh.size > 0;
+        this.hasCompletedFullRun &&
+        this.realmsNeedingRefresh.size > 0 &&
+        query.page === undefined;
       let realmsToFetch = isPartialRefresh
         ? [...this.realmsNeedingRefresh]
         : this.realmsToSearch;
@@ -246,9 +251,9 @@ export class SearchEntriesResource extends Resource<Args> {
             (entry) => !realmsToFetch.includes(entry.realmUrl),
           );
           this._entries.splice(0, this._entries.length, ...kept, ...fresh);
-          // The fetch covered a realm subset, so the response's total only
-          // speaks for that subset; the standing entry count is the best
-          // whole-set figure available.
+          // Unpaginated (a partial refresh precondition), so the standing
+          // entry count is the exact whole-set total; the response's total
+          // only speaks for the fetched realm subset.
           this._meta = {
             ...this._meta,
             page: { total: this._entries.length },

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -17,10 +17,8 @@ import type {
   ErrorEntry,
   RealmIdentifier,
   RuntimeDependencyTrackingContext,
-  SerializedError,
 } from '@cardstack/runtime-common';
 import {
-  isCardError,
   subscribeToRealm,
   isFileDefInstance,
   logger as runtimeLogger,
@@ -36,6 +34,8 @@ import type { Query } from '@cardstack/runtime-common/query';
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
+
+import { searchErrorEntry } from '../lib/search-error-entry';
 
 import type RealmServerService from '../services/realm-server';
 import type StoreService from '../services/store';
@@ -524,51 +524,6 @@ export class SearchResource<
       waiter.endAsync(token);
     }
   });
-}
-
-function searchErrorEntry(err: unknown): ErrorEntry {
-  let status =
-    typeof (err as { status?: unknown })?.status === 'number'
-      ? ((err as { status: number }).status as number)
-      : 500;
-  let message =
-    typeof (err as { message?: unknown })?.message === 'string'
-      ? ((err as { message: string }).message as string)
-      : String(err);
-  let stack =
-    typeof (err as { stack?: unknown })?.stack === 'string'
-      ? ((err as { stack: string }).stack as string)
-      : undefined;
-  let title = status === 404 ? 'Link Not Found' : 'Search Error';
-  let serialized: SerializedError = {
-    title,
-    status,
-    message,
-    stack,
-    additionalErrors: null,
-  };
-  if (isCardError(err)) {
-    if (err.additionalErrors?.length) {
-      serialized.additionalErrors = err.additionalErrors.map(
-        (additionalError) => {
-          let normalized = additionalError as Partial<SerializedError>;
-          return {
-            title: normalized.title,
-            status: normalized.status,
-            message: normalized.message,
-            stack: normalized.stack,
-          };
-        },
-      );
-    }
-    if (err.deps?.length) {
-      serialized.deps = [...err.deps];
-    }
-  }
-  return {
-    type: 'instance-error',
-    error: serialized,
-  };
 }
 
 // WARNING! please don't import this directly into your component's module.

--- a/packages/host/tests/integration/resources/search-entries-test.gts
+++ b/packages/host/tests/integration/resources/search-entries-test.gts
@@ -1,7 +1,9 @@
 import { destroy } from '@ember/destroyable';
 import { setOwner } from '@ember/owner';
 import type { RenderingTestContext } from '@ember/test-helpers';
-import { settled, waitUntil } from '@ember/test-helpers';
+import { render, settled, waitUntil } from '@ember/test-helpers';
+import GlimmerComponent from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -17,7 +19,10 @@ import {
   type SearchEntryWireQuery,
 } from '@cardstack/runtime-common';
 
-import { SearchEntriesResource } from '@cardstack/host/resources/search-entries';
+import {
+  getSearchEntriesResource,
+  SearchEntriesResource,
+} from '@cardstack/host/resources/search-entries';
 
 import type LoaderService from '@cardstack/host/services/loader-service';
 import type StoreService from '@cardstack/host/services/store';
@@ -343,7 +348,9 @@ module('Integration | search-entries resource', function (hooks) {
         3,
         'both realms contribute entries',
       );
-      let realm2EntryBefore = search.entries.find(
+      let entriesBefore = [...search.entries];
+      let orderBefore = entriesBefore.map((entry) => entry.id);
+      let realm2EntryBefore = entriesBefore.find(
         (entry) => entry.realmUrl === testRealm2URL,
       );
       assert.ok(realm2EntryBefore, 'realm 2 contributed an entry');
@@ -356,6 +363,11 @@ module('Integration | search-entries resource', function (hooks) {
         [testRealmURL],
         'the refresh fetch is scoped to the realm whose index moved',
       );
+      assert.deepEqual(
+        search.entries.map((entry) => entry.id),
+        [...orderBefore, `${testRealmURL}books/3`],
+        'surviving rows keep their positions; the new row appends',
+      );
       let realm2EntryAfter = search.entries.find(
         (entry) => entry.realmUrl === testRealm2URL,
       );
@@ -364,12 +376,15 @@ module('Integration | search-entries resource', function (hooks) {
         realm2EntryBefore,
         "realm 2's entry keeps its identity through realm 1's refresh",
       );
-      assert.strictEqual(
-        search.entries.filter((entry) => entry.realmUrl === testRealmURL)
-          .length,
-        3,
-        "realm 1's rows are refreshed",
-      );
+      for (let entryBefore of entriesBefore.filter(
+        (entry) => entry.realmUrl === testRealmURL,
+      )) {
+        assert.strictEqual(
+          search.entries.find((entry) => entry.id === entryBefore.id),
+          entryBefore,
+          `unchanged refreshed row ${entryBefore.id} keeps its identity`,
+        );
+      }
       assert.strictEqual(search.meta.page.total, 4);
     } finally {
       storeService.searchEntries = originalSearchEntries;
@@ -589,5 +604,79 @@ module('Integration | search-entries resource', function (hooks) {
     } finally {
       storeService.searchEntries = originalSearchEntries;
     }
+  });
+
+  // modify() runs inside a tracked computation (property access on the
+  // resource proxy during render), so these tests exercise the resource the
+  // way a real component consumes it — any tracked read-then-write inside
+  // modify() throws Glimmer's mutation-after-consumption assertion here,
+  // which plain-JS consumption can never surface.
+  module('rendered consumption', function () {
+    class QueryState {
+      @tracked query: SearchEntryWireQuery | undefined;
+    }
+
+    class Harness extends GlimmerComponent<{
+      Args: { state: QueryState };
+    }> {
+      search = getSearchEntriesResource(this, () => this.args.state.query);
+      <template>
+        <div data-test-entry-count>{{this.search.entries.length}}</div>
+      </template>
+    }
+
+    test('a rendered consumer activates from an idle query and clears back to idle', async function (assert) {
+      let state = new QueryState();
+
+      await render(<template><Harness @state={{state}} /></template>);
+      assert
+        .dom('[data-test-entry-count]')
+        .hasText('0', 'an idle (undefined) query renders empty');
+
+      state.query = {
+        filter: { 'item.on': bookRef },
+        realms: [testRealmURL],
+      };
+      await settled();
+      assert
+        .dom('[data-test-entry-count]')
+        .hasText('2', 'setting the query activates the search');
+
+      state.query = undefined;
+      await settled();
+      assert
+        .dom('[data-test-entry-count]')
+        .hasText('0', 'returning to idle clears the standing entries');
+
+      state.query = {
+        filter: { 'item.on': bookRef, eq: { 'item.status': 'ready' } },
+        realms: [testRealmURL],
+      };
+      await settled();
+      assert
+        .dom('[data-test-entry-count]')
+        .hasText('1', 'a fresh query after idle re-activates');
+    });
+
+    test('changing realms while entries are standing re-runs cleanly', async function (assert) {
+      let state = new QueryState();
+      state.query = {
+        filter: { 'item.on': bookRef },
+        realms: [testRealmURL],
+      };
+
+      await render(<template><Harness @state={{state}} /></template>);
+
+      assert.dom('[data-test-entry-count]').hasText('2');
+
+      state.query = {
+        filter: { 'item.on': bookRef },
+        realms: [testRealm2URL],
+      };
+      await settled();
+      assert
+        .dom('[data-test-entry-count]')
+        .hasText('1', "only the new realm's entries remain after the re-run");
+    });
   });
 });

--- a/packages/host/tests/integration/resources/search-entries-test.ts
+++ b/packages/host/tests/integration/resources/search-entries-test.ts
@@ -376,6 +376,58 @@ module('Integration | search-entries resource', function (hooks) {
     }
   });
 
+  test('a paginated query takes a full re-run on an incremental event, keeping the server total', async function (assert) {
+    let fetchedRealms: string[][] = [];
+    let originalSearchEntries = storeService.searchEntries.bind(storeService);
+    storeService.searchEntries = async (query, realms) => {
+      fetchedRealms.push(realms ?? []);
+      return await originalSearchEntries(query, realms);
+    };
+
+    try {
+      let search = getResourceForTest(storeService, () => ({
+        named: {
+          query: {
+            filter: { 'item.on': bookRef },
+            page: { size: 2 },
+            realms: [testRealmURL, testRealm2URL],
+          },
+        },
+      }));
+      await search.loaded;
+
+      // federated pagination applies per realm: realm 1 contributes a full
+      // page (2 of its 2 books), realm 2 its single book
+      assert.strictEqual(search.entries.length, 3);
+      assert.strictEqual(
+        search.meta.page.total,
+        3,
+        'the server total spans all pages',
+      );
+
+      await realm.write('books/3.json', bookDoc('Paper'));
+      await waitUntil(() => search.meta.page.total === 4, { timeout: 10_000 });
+
+      assert.deepEqual(
+        fetchedRealms[fetchedRealms.length - 1],
+        [testRealmURL, testRealm2URL],
+        'a paginated query re-fetches all realms — no realm-scoped splice',
+      );
+      assert.strictEqual(
+        search.entries.length,
+        3,
+        "realm 1's contribution stays page-limited",
+      );
+      assert.strictEqual(
+        search.meta.page.total,
+        4,
+        'the total stays server-accurate after the live update',
+      );
+    } finally {
+      storeService.searchEntries = originalSearchEntries;
+    }
+  });
+
   test("an event in realm 2 refreshes realm 2's rows", async function (assert) {
     let search = getResourceForTest(storeService, () => ({
       named: {

--- a/packages/host/tests/integration/resources/search-entries-test.ts
+++ b/packages/host/tests/integration/resources/search-entries-test.ts
@@ -1,0 +1,541 @@
+import { destroy } from '@ember/destroyable';
+import { setOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { settled, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  htmlResourceId,
+  CssResourceType,
+  HtmlResourceType,
+  SearchEntryResourceType,
+  type Loader,
+  type Realm,
+  type SearchEntryResults,
+  type SearchEntryWireQuery,
+} from '@cardstack/runtime-common';
+
+import { SearchEntriesResource } from '@cardstack/host/resources/search-entries';
+
+import type LoaderService from '@cardstack/host/services/loader-service';
+import type StoreService from '@cardstack/host/services/store';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+  testRRI,
+} from '../../helpers';
+import {
+  CardDef,
+  contains,
+  field,
+  StringField,
+  setupBaseRealm,
+} from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+const testRealm2URL = 'http://test-realm/test2/';
+
+function getResourceForTest(
+  parent: object,
+  args: () => { named: { query: SearchEntryWireQuery | undefined } },
+) {
+  return SearchEntriesResource.from(parent, args) as unknown as Omit<
+    SearchEntriesResource,
+    'loaded'
+  > & {
+    // we expose the private loaded promise just for our tests
+    loaded: Promise<void>;
+    modify: (
+      positional: never[],
+      named: { query: SearchEntryWireQuery | undefined },
+    ) => void;
+  };
+}
+
+module('Integration | search-entries resource', function (hooks) {
+  let loader: Loader;
+  let loaderService: LoaderService;
+  let storeService: StoreService;
+  let realm: Realm;
+  let realm2: Realm;
+
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL, testRealm2URL],
+    autostart: true,
+  });
+
+  let bookRef = { module: testRRI('book'), name: 'Book' };
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    loaderService = getService('loader-service');
+    loader = loaderService.loader;
+    storeService = getService('store');
+
+    class Book extends CardDef {
+      static displayName = 'Book';
+      @field title = contains(StringField);
+      @field status = contains(StringField);
+    }
+
+    ({ realm } = await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      realmURL: testRealmURL,
+      contents: {
+        'book.gts': { Book },
+        'books/1.json': new Book({ title: 'Mango', status: 'ready' }),
+        'books/2.json': new Book({ title: 'Van Gogh', status: 'draft' }),
+      },
+    }));
+    ({ realm: realm2 } = await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      realmURL: testRealm2URL,
+      contents: {
+        'books/other.json': {
+          data: {
+            type: 'card',
+            attributes: { title: 'Paper', status: 'ready' },
+            meta: {
+              adoptsFrom: {
+                module: testRRI('book'),
+                name: 'Book',
+              },
+            },
+          },
+        },
+      },
+    }));
+  });
+
+  function bookDoc(title: string) {
+    return JSON.stringify({
+      data: {
+        type: 'card',
+        attributes: { title, status: 'ready' },
+        meta: {
+          adoptsFrom: {
+            module: testRRI('book'),
+            name: 'Book',
+          },
+        },
+      },
+    });
+  }
+
+  test('exposes entries joined from the wire document (default fieldset: html renderings)', async function (assert) {
+    let search = getResourceForTest(storeService, () => ({
+      named: {
+        query: {
+          filter: { 'item.on': bookRef },
+          realms: [testRealmURL],
+        },
+      },
+    }));
+    await search.loaded;
+
+    assert.strictEqual(search.entries.length, 2, 'both books are returned');
+    assert.strictEqual(search.meta.page.total, 2);
+    assert.strictEqual(search.errors, undefined);
+    for (let entry of search.entries) {
+      assert.strictEqual(entry.realmUrl, testRealmURL);
+      assert.strictEqual(
+        entry.html.length,
+        1,
+        'the default htmlQuery selects the fitted rendering',
+      );
+      let [rendering] = entry.html;
+      assert.strictEqual(rendering.format, 'fitted');
+      assert.strictEqual(rendering.cardType, 'Book');
+      assert.false(rendering.isError);
+      assert.ok(rendering.html, 'the rendering carries markup');
+      assert.strictEqual(
+        entry.item,
+        undefined,
+        'an html-bearing entry has no item fallback',
+      );
+    }
+  });
+
+  test('exposes raw item serializations per the fieldset, without touching the store', async function (assert) {
+    let search = getResourceForTest(storeService, () => ({
+      named: {
+        query: {
+          filter: { 'item.on': bookRef },
+          fields: { 'search-entry': ['item'] },
+          realms: [testRealmURL],
+        },
+      },
+    }));
+    await search.loaded;
+
+    assert.strictEqual(search.entries.length, 2);
+    for (let entry of search.entries) {
+      assert.deepEqual(
+        entry.html,
+        [],
+        'an item-only fieldset pins an empty html branch',
+      );
+      assert.ok(entry.item, 'the raw serialization rides on the entry');
+      assert.strictEqual(entry.item!.type, 'card');
+      assert.strictEqual(
+        storeService.peek(entry.id),
+        undefined,
+        'nothing is hydrated into the store',
+      );
+    }
+    assert.deepEqual(
+      search.entries.map((entry) => entry.item!.attributes?.title).sort(),
+      ['Mango', 'Van Gogh'],
+    );
+  });
+
+  test('re-runs the search on an incremental index event', async function (assert) {
+    let search = getResourceForTest(storeService, () => ({
+      named: {
+        query: {
+          filter: { 'item.on': bookRef },
+          realms: [testRealmURL],
+        },
+      },
+    }));
+    await search.loaded;
+    assert.strictEqual(search.entries.length, 2);
+
+    await realm.write('books/3.json', bookDoc('Paper'));
+    await waitUntil(() => search.entries.length === 3, { timeout: 10_000 });
+
+    assert.ok(
+      search.entries.find((entry) => entry.id === `${testRealmURL}books/3`),
+      'the new book appears after the incremental index event',
+    );
+  });
+
+  test('an entry with an empty html array upgrades when its rendering lands on a later event', async function (assert) {
+    let entryURL = `${testRealmURL}books/1`;
+    let renderingId = htmlResourceId({
+      url: entryURL,
+      format: 'fitted',
+      renderType: bookRef,
+    });
+    let cssHref = `${testRealmURL}book.gts.abc123.glimmer-scoped.css`;
+
+    // The matched-but-not-yet-rendered shape: the html branch is pinned but
+    // no rendering satisfies the htmlQuery yet.
+    let unrenderedDoc: SearchEntryResults = {
+      data: [
+        {
+          type: SearchEntryResourceType,
+          id: entryURL,
+          relationships: { html: { data: [] } },
+        },
+      ],
+      meta: { page: { total: 1 } },
+    };
+    let renderedDoc: SearchEntryResults = {
+      data: [
+        {
+          type: SearchEntryResourceType,
+          id: entryURL,
+          relationships: {
+            html: { data: [{ type: HtmlResourceType, id: renderingId }] },
+          },
+        },
+      ],
+      included: [
+        {
+          type: HtmlResourceType,
+          id: renderingId,
+          attributes: {
+            html: '<div>Mango</div>',
+            cardType: 'Book',
+            format: 'fitted',
+            renderType: bookRef,
+          },
+          relationships: {
+            styles: { data: [{ type: CssResourceType, id: 'deadbeef' }] },
+          },
+        },
+        {
+          type: CssResourceType,
+          id: 'deadbeef',
+          attributes: { href: cssHref },
+        },
+      ],
+      meta: { page: { total: 1 } },
+    };
+
+    let docs = [unrenderedDoc, renderedDoc, renderedDoc];
+    let originalSearchEntries = storeService.searchEntries.bind(storeService);
+    storeService.searchEntries = async () => docs.shift() ?? renderedDoc;
+    let originalImport = loader.import.bind(loader);
+    loader.import = (async (url: string) =>
+      url === cssHref ? {} : originalImport(url)) as Loader['import'];
+
+    try {
+      let search = getResourceForTest(storeService, () => ({
+        named: {
+          query: {
+            filter: { 'item.on': bookRef },
+            realms: [testRealmURL],
+          },
+        },
+      }));
+      await search.loaded;
+
+      assert.strictEqual(search.entries.length, 1);
+      assert.deepEqual(
+        search.entries[0].html,
+        [],
+        'the entry matched but carries no rendering yet',
+      );
+
+      // Any incremental event in the realm triggers the re-run that picks up
+      // the landed rendering.
+      await realm.write('books/9.json', bookDoc('Trigger'));
+      await waitUntil(() => search.entries[0]?.html.length === 1, {
+        timeout: 10_000,
+      });
+
+      let [rendering] = search.entries[0].html;
+      assert.strictEqual(rendering.id, renderingId);
+      assert.strictEqual(rendering.html, '<div>Mango</div>');
+      assert.deepEqual(
+        rendering.cssUrls,
+        [cssHref],
+        'the styles references resolve to the stylesheet hrefs',
+      );
+    } finally {
+      storeService.searchEntries = originalSearchEntries;
+      loader.import = originalImport;
+    }
+  });
+
+  test('an incremental event refreshes only its own realm, leaving other realms untouched', async function (assert) {
+    let fetchedRealms: string[][] = [];
+    let originalSearchEntries = storeService.searchEntries.bind(storeService);
+    storeService.searchEntries = async (query, realms) => {
+      fetchedRealms.push(realms ?? []);
+      return await originalSearchEntries(query, realms);
+    };
+
+    try {
+      let search = getResourceForTest(storeService, () => ({
+        named: {
+          query: {
+            filter: { 'item.on': bookRef },
+            realms: [testRealmURL, testRealm2URL],
+          },
+        },
+      }));
+      await search.loaded;
+
+      assert.strictEqual(
+        search.entries.length,
+        3,
+        'both realms contribute entries',
+      );
+      let realm2EntryBefore = search.entries.find(
+        (entry) => entry.realmUrl === testRealm2URL,
+      );
+      assert.ok(realm2EntryBefore, 'realm 2 contributed an entry');
+
+      await realm.write('books/3.json', bookDoc('Paper'));
+      await waitUntil(() => search.entries.length === 4, { timeout: 10_000 });
+
+      assert.deepEqual(
+        fetchedRealms[fetchedRealms.length - 1],
+        [testRealmURL],
+        'the refresh fetch is scoped to the realm whose index moved',
+      );
+      let realm2EntryAfter = search.entries.find(
+        (entry) => entry.realmUrl === testRealm2URL,
+      );
+      assert.strictEqual(
+        realm2EntryAfter,
+        realm2EntryBefore,
+        "realm 2's entry keeps its identity through realm 1's refresh",
+      );
+      assert.strictEqual(
+        search.entries.filter((entry) => entry.realmUrl === testRealmURL)
+          .length,
+        3,
+        "realm 1's rows are refreshed",
+      );
+      assert.strictEqual(search.meta.page.total, 4);
+    } finally {
+      storeService.searchEntries = originalSearchEntries;
+    }
+  });
+
+  test("an event in realm 2 refreshes realm 2's rows", async function (assert) {
+    let search = getResourceForTest(storeService, () => ({
+      named: {
+        query: {
+          filter: { 'item.on': bookRef },
+          realms: [testRealmURL, testRealm2URL],
+        },
+      },
+    }));
+    await search.loaded;
+    assert.strictEqual(search.entries.length, 3);
+
+    await realm2.write(
+      'books/another.json',
+      JSON.stringify({
+        data: {
+          type: 'card',
+          attributes: { title: 'Hassan', status: 'ready' },
+          meta: {
+            adoptsFrom: {
+              module: testRRI('book'),
+              name: 'Book',
+            },
+          },
+        },
+      }),
+    );
+    await waitUntil(() => search.entries.length === 4, { timeout: 10_000 });
+
+    assert.ok(
+      search.entries.find(
+        (entry) => entry.id === `${testRealm2URL}books/another`,
+      ),
+      "realm 2's new book appears",
+    );
+  });
+
+  test('does not re-fetch when the query is structurally unchanged', async function (assert) {
+    let fetchCount = 0;
+    let originalSearchEntries = storeService.searchEntries.bind(storeService);
+    storeService.searchEntries = async (query, realms) => {
+      fetchCount++;
+      return await originalSearchEntries(query, realms);
+    };
+
+    try {
+      let query: SearchEntryWireQuery = {
+        filter: { 'item.on': bookRef },
+        realms: [testRealmURL],
+      };
+      let search = getResourceForTest(storeService, () => ({
+        named: { query },
+      }));
+      await search.loaded;
+      assert.strictEqual(fetchCount, 1, 'initial search performed once');
+
+      // a structurally-equal but referentially-new query must not re-run
+      search.modify([], { query: JSON.parse(JSON.stringify(query)) });
+      await settled();
+
+      assert.strictEqual(fetchCount, 1, 'no re-fetch for a deep-equal query');
+
+      search.modify([], {
+        query: {
+          filter: { 'item.on': bookRef, eq: { 'item.status': 'ready' } },
+          realms: [testRealmURL],
+        },
+      });
+      await settled();
+
+      assert.strictEqual(fetchCount, 2, 'a changed query re-runs the search');
+      assert.strictEqual(
+        search.entries.length,
+        1,
+        'the new query narrows the result set',
+      );
+    } finally {
+      storeService.searchEntries = originalSearchEntries;
+    }
+  });
+
+  test('destroying the resource tears down its realm subscriptions', async function (this: RenderingTestContext, assert) {
+    let fetchCount = 0;
+    let originalSearchEntries = storeService.searchEntries.bind(storeService);
+    storeService.searchEntries = async (query, realms) => {
+      fetchCount++;
+      return await originalSearchEntries(query, realms);
+    };
+
+    try {
+      // The resource's lifetime is linked to its parent; destroying the
+      // parent is what tears the resource down (`Resource.from` hands back a
+      // lazy proxy, not the destroyable instance itself).
+      let parent = {};
+      setOwner(parent, this.owner);
+      let search = getResourceForTest(parent, () => ({
+        named: {
+          query: {
+            filter: { 'item.on': bookRef },
+            realms: [testRealmURL],
+          },
+        },
+      }));
+      await search.loaded;
+      assert.strictEqual(fetchCount, 1);
+
+      destroy(parent);
+      await settled();
+
+      await realm.write('books/3.json', bookDoc('Paper'));
+      await settled();
+
+      assert.strictEqual(
+        fetchCount,
+        1,
+        'no fetch fires for a realm event after the resource is destroyed',
+      );
+    } finally {
+      storeService.searchEntries = originalSearchEntries;
+    }
+  });
+
+  test('a failed fetch surfaces errors; a later successful run clears them', async function (assert) {
+    let failNext = true;
+    let originalSearchEntries = storeService.searchEntries.bind(storeService);
+    storeService.searchEntries = async (query, realms) => {
+      if (failNext) {
+        failNext = false;
+        let err = new Error('search exploded') as Error & { status: number };
+        err.status = 500;
+        throw err;
+      }
+      return await originalSearchEntries(query, realms);
+    };
+
+    try {
+      let search = getResourceForTest(storeService, () => ({
+        named: {
+          query: {
+            filter: { 'item.on': bookRef },
+            realms: [testRealmURL],
+          },
+        },
+      }));
+      await search.loaded;
+
+      assert.strictEqual(search.entries.length, 0);
+      assert.strictEqual(search.errors?.length, 1);
+      assert.strictEqual(search.errors?.[0].type, 'instance-error');
+
+      await realm.write('books/3.json', bookDoc('Paper'));
+      await waitUntil(() => search.entries.length === 3, { timeout: 10_000 });
+
+      assert.strictEqual(
+        search.errors,
+        undefined,
+        'a successful re-run clears the errors',
+      );
+    } finally {
+      storeService.searchEntries = originalSearchEntries;
+    }
+  });
+});

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -324,6 +324,15 @@ export {
   isSparseItemResource,
 } from './card-document-shape.ts';
 
+// The map/set key for a JSON:API `(type, id)` identity pair. NUL-separated so
+// one pair can't alias another by concatenation — no resource type or id
+// contains a NUL byte.
+// `id` may be absent on an unsaved resource; the literal "undefined" segment
+// it produces is still a stable, non-aliasing key.
+export function resourceIdentity(type: string, id: string | undefined): string {
+  return `${type}\u0000${id}`;
+}
+
 // The `css` resource id: a content hash of the (base64-embedding) scoped-CSS
 // URL. Server and host compute it through this one helper so identical
 // stylesheets dedupe to the same `(type, id)` in `included`. md5 is our

--- a/packages/runtime-common/search-compat.ts
+++ b/packages/runtime-common/search-compat.ts
@@ -1,13 +1,14 @@
 import type { Query, SparseFieldsets } from './query.ts';
 import { DEFAULT_HTML_QUERY, type SearchEntryQuery } from './search-entry.ts';
-import type {
-  CardResource,
-  FileMetaResource,
-  HtmlQuery,
-  HtmlResource,
-  PrerenderedCardResource,
-  Saved,
-  SearchEntryResource,
+import {
+  resourceIdentity,
+  type CardResource,
+  type FileMetaResource,
+  type HtmlQuery,
+  type HtmlResource,
+  type PrerenderedCardResource,
+  type Saved,
+  type SearchEntryResource,
 } from './resource-types.ts';
 import type {
   LinkableCollectionDocument,
@@ -107,7 +108,7 @@ function itemFor(
   if (!ref) {
     return undefined;
   }
-  return byIdentity.get(`${ref.type}\u0000${ref.id}`);
+  return byIdentity.get(resourceIdentity(ref.type, ref.id));
 }
 
 // Coalesce a search-entry document into the legacy live-search shape: the
@@ -125,7 +126,7 @@ export function searchEntryDocToLinkableDoc(
       (resource.type === 'card' || resource.type === 'file-meta') &&
       resource.id
     ) {
-      byIdentity.set(`${resource.type}\u0000${resource.id}`, resource);
+      byIdentity.set(resourceIdentity(resource.type, resource.id), resource);
     }
   }
 
@@ -138,13 +139,13 @@ export function searchEntryDocToLinkableDoc(
     }
     let fields = opts?.fields?.[item.type === 'card' ? 'card' : 'file-meta'];
     data.push(fields !== undefined ? applySparseFieldset(item, fields) : item);
-    dataIdentities.add(`${item.type}\u0000${item.id}`);
+    dataIdentities.add(resourceIdentity(item.type, item.id));
   }
 
   let included = (doc.included ?? []).filter(
     (resource): resource is CardResource<Saved> | FileMetaResource =>
       (resource.type === 'card' || resource.type === 'file-meta') &&
-      !dataIdentities.has(`${resource.type}\u0000${resource.id}`),
+      !dataIdentities.has(resourceIdentity(resource.type, resource.id)),
   );
 
   let result: LinkableCollectionDocument = {
@@ -216,7 +217,7 @@ export function searchEntryDocToPrerenderedDoc(
       (resource.type === 'card' || resource.type === 'file-meta') &&
       resource.id
     ) {
-      byIdentity.set(`${resource.type}\u0000${resource.id}`, resource);
+      byIdentity.set(resourceIdentity(resource.type, resource.id), resource);
     }
   }
 

--- a/packages/runtime-common/search-entry.ts
+++ b/packages/runtime-common/search-entry.ts
@@ -21,6 +21,7 @@ import {
   HtmlResourceType,
   SearchEntryResourceType,
   htmlResourceId,
+  resourceIdentity,
   type CardResource,
   type CardResourceType,
   type FileMetaResource,
@@ -788,7 +789,7 @@ export function combineSearchEntryResults(
       if (resource.id) {
         // NUL-separated so a `(type, id)` pair can't alias another by
         // concatenation (no resource type or id contains a NUL byte).
-        let identity = `${resource.type}\u0000${resource.id}`;
+        let identity = resourceIdentity(resource.type, resource.id);
         if (includedByIdentity.has(identity)) {
           continue;
         }

--- a/packages/runtime-common/search-utils.ts
+++ b/packages/runtime-common/search-utils.ts
@@ -1,5 +1,6 @@
 import type { RealmResourceIdentifier } from './realm-identifiers.ts';
 import { logger } from './log.ts';
+import { resourceIdentity } from './resource-types.ts';
 import { ensureTrailingSlash } from './paths.ts';
 import { assertQuery, InvalidQueryError, type Query } from './query.ts';
 import { RequestTimings } from './request-timings.ts';
@@ -461,7 +462,7 @@ export function combineSearchResults(
         if (resource.id) {
           // NUL-separated so a `(type, id)` pair can't alias another by
           // concatenation (no resource type or id contains a NUL byte).
-          let identity = `${resource.type}\u0000${resource.id}`;
+          let identity = resourceIdentity(resource.type, resource.id);
           if (includedByIdentity.has(identity)) {
             continue;
           }


### PR DESCRIPTION
The one v2 host live-search resource: `getSearchEntriesResource(parent, () => query)` issues a `search-entry` wire query through `StoreService.searchEntries`, subscribes to each searched realm, and re-runs on incremental index events. It exposes `{ entries, isLoading, meta, errors }`, where each entry is a flattened join of the wire document: `entry.html[]` (the renderings the query's htmlQuery selected, with `styles` references resolved to stylesheet hrefs and the stylesheets already imported through the loader) and `entry.item?` (the raw `card`/`file-meta` serialization). An empty `html` array means the entry matched but no rendering satisfies the htmlQuery yet — the invalidation re-run upgrades it when the rendering lands.

Realms ride in the query's `realms` member (omitted → every available realm). An incremental event marks just its own realm, and the re-run fetches only the marked realms, splicing only their rows — entries from other realms keep their object identity. A partial refresh is only taken once a full run has completed, so an event arriving during the initial fetch can't narrow it. Nothing the resource holds enters the store: entries are owned by the re-run; a row a consumer hydrates is owned by the store's reactive reload.

`searchErrorEntry` moves out of `resources/search.ts` into `lib/search-error-entry.ts` so both resources share one copy.

This is additive — the pre-v2 fetcher resources stay until their call sites migrate. `<SearchResults>` (the component consumer) builds on this resource in a follow-up.

Integration tests cover the joined entry shape (html renderings from the real local index, and raw item serializations that never touch the store), the re-run on invalidation, the empty-`html[]` upgrade, the per-realm partial refresh (realm A's event leaves realm B's entries untouched, fetch scoped to realm A), no re-fetch on a structurally-unchanged query, subscription teardown on destroy, and error surface/clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
