### PR TITLE
Eliminate per-instance URL construction on hot render paths

### DIFF
--- a/packages/host/app/resources/live-prerendered-search.ts
+++ b/packages/host/app/resources/live-prerendered-search.ts
@@ -66,6 +66,10 @@ export class LivePrerenderedSearchResource extends Resource<Args> {
   private _instances = new TrackedArray<PrerenderedCard>();
   @tracked private _meta: QueryResultsMeta = { page: { total: 0 } };
   #loadedScopedCssModules = new Set<string>();
+  #scopedCssModulesByLoader = new WeakMap<
+    Loader,
+    Map<string, Promise<string[]>>
+  >();
   #previousSignature: string | undefined;
 
   constructor(owner: object) {
@@ -163,11 +167,20 @@ export class LivePrerenderedSearchResource extends Resource<Args> {
   }
 
   private isScopedCssModule(url: string): boolean {
-    try {
-      return isScopedCSSRequest(new URL(url).pathname);
-    } catch {
-      return false;
+    // Suffix check on the path portion only — scoped-css URLs carry the
+    // encoded CSS in the filename, never in a query string or hash, so
+    // trimming those is enough. String ops instead of `new URL()`: this runs
+    // per dependency per type and the URL constructor dominates otherwise.
+    let end = url.length;
+    let queryIdx = url.indexOf('?');
+    if (queryIdx !== -1) {
+      end = queryIdx;
     }
+    let hashIdx = url.indexOf('#');
+    if (hashIdx !== -1 && hashIdx < end) {
+      end = hashIdx;
+    }
+    return isScopedCSSRequest(end === url.length ? url : url.slice(0, end));
   }
 
   private async loadScopedCssForInstance(instance: SearchInstance) {
@@ -175,11 +188,25 @@ export class LivePrerenderedSearchResource extends Resource<Args> {
     if (!identity?.module) {
       return;
     }
-    let deps = await this.loaderService.loader.getConsumedModules(
-      identity.module,
-    );
-    let scopedCssModules = deps.filter((dep) => this.isScopedCssModule(dep));
-    let modulesToLoad = scopedCssModules.filter(
+    let loader = this.loaderService.loader;
+    // A result set holds many instances of few types, but the dependency
+    // walk costs the same for each instance of a type — so compute the
+    // scoped-css module list once per (loader, type module). Keyed by loader
+    // because a loader reset re-transpiles modules and the content-addressed
+    // scoped-css URLs change with the CSS.
+    let byModule = this.#scopedCssModulesByLoader.get(loader);
+    if (!byModule) {
+      byModule = new Map();
+      this.#scopedCssModulesByLoader.set(loader, byModule);
+    }
+    let scopedCssModules = byModule.get(identity.module);
+    if (!scopedCssModules) {
+      scopedCssModules = loader
+        .getConsumedModules(identity.module)
+        .then((deps) => deps.filter((dep) => this.isScopedCssModule(dep)));
+      byModule.set(identity.module, scopedCssModules);
+    }
+    let modulesToLoad = (await scopedCssModules).filter(
       (moduleURL) => !this.#loadedScopedCssModules.has(moduleURL),
     );
     if (modulesToLoad.length === 0) {
@@ -187,7 +214,7 @@ export class LivePrerenderedSearchResource extends Resource<Args> {
     }
     await Promise.all(
       modulesToLoad.map(async (moduleURL) => {
-        await this.loaderService.loader.import(moduleURL);
+        await loader.import(moduleURL);
         this.#loadedScopedCssModules.add(moduleURL);
       }),
     );

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -970,8 +970,13 @@ export default class RealmService extends Service {
   realmOf(input: RealmResourceIdentifier | URL): RealmIdentifier | undefined {
     let id = input instanceof URL ? rri(input.href) : input;
     let cached = this.realmOfCache.get(id);
-    if (cached !== undefined && this.realms.has(cached)) {
-      return ri(cached);
+    if (cached !== undefined) {
+      if (this.realms.has(cached)) {
+        return ri(cached);
+      }
+      // The answer pointed at a realm that is no longer known — evict so a
+      // stale id doesn't pay validation + full scan on every call.
+      this.realmOfCache.delete(id);
     }
     for (const realm of this.realms.keys()) {
       let paths = this.realmPathsCache.get(realm);

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -720,6 +720,14 @@ export default class RealmService extends Service {
   private currentKnownRealms = new TrackedSet<string>();
   private reauthentications = new Map<string, Promise<string | undefined>>();
   private bulkInfoPromise: Promise<void> | undefined;
+  // realmOf runs once per instance added to the store, so its per-call costs
+  // multiply by instance count during large renders. RealmPaths is a pure
+  // function of the realm URL string (cache entries never go stale), and a
+  // resolved id→realm answer stays valid as long as that realm is still
+  // known — validated against `realms` on every hit, so realm removal and
+  // resetState can't serve a stale answer.
+  private realmPathsCache = new Map<string, RealmPaths>();
+  private realmOfCache = new Map<string, string>();
 
   @tracked private identifyRealmTracker = 0;
 
@@ -739,6 +747,8 @@ export default class RealmService extends Service {
     this.reauthentications.clear();
     this.bulkInfoPromise = undefined;
     this.identifyRealmTracker++;
+    this.realmPathsCache.clear();
+    this.realmOfCache.clear();
   }
 
   async waitForBulkInfoIfNeeded(): Promise<void> {
@@ -959,11 +969,22 @@ export default class RealmService extends Service {
 
   realmOf(input: RealmResourceIdentifier | URL): RealmIdentifier | undefined {
     let id = input instanceof URL ? rri(input.href) : input;
+    let cached = this.realmOfCache.get(id);
+    if (cached !== undefined && this.realms.has(cached)) {
+      return ri(cached);
+    }
     for (const realm of this.realms.keys()) {
-      if (new RealmPaths(new URL(realm)).inRealm(id)) {
+      let paths = this.realmPathsCache.get(realm);
+      if (!paths) {
+        paths = new RealmPaths(new URL(realm));
+        this.realmPathsCache.set(realm, paths);
+      }
+      if (paths.inRealm(id)) {
+        this.realmOfCache.set(id, realm);
         return ri(realm);
       }
     }
+    // Misses are not cached: a realm learned later may claim this id.
     return undefined;
   }
 

--- a/packages/realm-server/tests/virtual-network-test.ts
+++ b/packages/realm-server/tests/virtual-network-test.ts
@@ -87,6 +87,40 @@ module(basename(__filename), function () {
       );
     });
 
+    test('toURLHref resolves like toURL and tracks mapping changes', function (assert) {
+      let virtualNetwork = new VirtualNetwork();
+      virtualNetwork.addRealmMapping(
+        '@cardstack/skills/',
+        'https://localhost:4201/skills/',
+      );
+      assert.strictEqual(
+        virtualNetwork.toURLHref('@cardstack/skills/Skill/foo'),
+        virtualNetwork.toURL('@cardstack/skills/Skill/foo').href,
+        'prefix-form resolves identically to toURL().href',
+      );
+      assert.strictEqual(
+        virtualNetwork.toURLHref('https://example.com/a?b=c#d'),
+        'https://example.com/a?b=c#d',
+        'URL-form normalizes identically to toURL().href',
+      );
+      // Cached entries must not outlive the mappings they were derived from.
+      virtualNetwork.removeRealmMapping('@cardstack/skills/');
+      assert.throws(
+        () => virtualNetwork.toURLHref('@cardstack/skills/Skill/foo'),
+        'a cached resolution is dropped when its mapping is removed',
+      );
+      // A failed resolution must not be negatively cached.
+      virtualNetwork.addRealmMapping(
+        '@cardstack/skills/',
+        'https://localhost:4201/skills/',
+      );
+      assert.strictEqual(
+        virtualNetwork.toURLHref('@cardstack/skills/Skill/foo'),
+        'https://localhost:4201/skills/Skill/foo',
+        'resolution recovers after the mapping is re-registered',
+      );
+    });
+
     test('resolveURL: root-relative ref joins against the mapped URL of a prefix-form base', function (assert) {
       let virtualNetwork = new VirtualNetwork();
       virtualNetwork.addRealmMapping(

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -310,52 +310,48 @@ export class Loader {
     });
   }
 
-  async getConsumedModules(
-    moduleIdentifier: string,
-    consumed: string[] = [],
-    initialIdentifier = moduleIdentifier,
-  ): Promise<string[]> {
+  async getConsumedModules(moduleIdentifier: string): Promise<string[]> {
     // Normalize to resolved URL href so that prefix-form identifiers
     // (e.g. @cardstack/catalog/...) and their resolved URL equivalents
     // are treated as the same module for cycle detection and self-exclusion.
-    let resolvedHref = this.virtualNetwork
-      ? this.virtualNetwork.toURL(moduleIdentifier).href
-      : new URL(moduleIdentifier).href;
-    let resolvedInitial = this.virtualNetwork
-      ? this.virtualNetwork.toURL(initialIdentifier).href
-      : new URL(initialIdentifier).href;
+    // The walk is Set-based and resolves each identifier once: this runs per
+    // module across large dependency graphs, so an array-scan accumulator or
+    // a per-identifier URL construction multiplies into real render time.
+    let resolveHref = (id: string) =>
+      this.virtualNetwork
+        ? this.virtualNetwork.toURLHref(id)
+        : new URL(id).href;
+    let visited = new Set<string>();
+    let walk = async (id: string, href: string): Promise<void> => {
+      if (visited.has(href)) {
+        return;
+      }
+      visited.add(href);
 
-    if (consumed.includes(resolvedHref)) {
-      return [];
-    }
+      let module = this.getModule(href);
+      if (!module || module.state === 'fetching') {
+        // we haven't yet tried importing the module or we are still in the
+        // process of importing the module
+        try {
+          await this.import<Record<string, any>>(id);
+        } catch (err: any) {
+          this.log.warn(
+            `encountered an error trying to load the module ${id}. The consumedModule result includes all the known consumed modules including the module that caused the error: ${err.message}`,
+          );
+        }
+        module = this.getModule(href);
+      }
+      if (module?.state === 'evaluated' || module?.state === 'broken') {
+        for (let consumedModule of module.consumedModules) {
+          await walk(consumedModule, resolveHref(consumedModule));
+        }
+      }
+    };
+    let initialHref = resolveHref(moduleIdentifier);
+    await walk(moduleIdentifier, initialHref);
     // you can't consume yourself
-    if (resolvedHref !== resolvedInitial) {
-      consumed.push(resolvedHref);
-    }
-
-    let module = this.getModule(resolvedHref);
-
-    if (!module || module.state === 'fetching') {
-      // we haven't yet tried importing the module or we are still in the process of importing the module
-      try {
-        await this.import<Record<string, any>>(moduleIdentifier);
-      } catch (err: any) {
-        this.log.warn(
-          `encountered an error trying to load the module ${moduleIdentifier}. The consumedModule result includes all the known consumed modules including the module that caused the error: ${err.message}`,
-        );
-      }
-    }
-    if (module?.state === 'evaluated' || module?.state === 'broken') {
-      for (let consumedModule of module?.consumedModules ?? []) {
-        await this.getConsumedModules(
-          consumedModule,
-          consumed,
-          initialIdentifier,
-        );
-      }
-      return [...new Set(consumed)]; // Get rid of duplicates
-    }
-    return [];
+    visited.delete(initialHref);
+    return [...visited];
   }
 
   static identify(

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -13,6 +13,7 @@ interface LocalOptions {
 // that only need URL-handling, like @cardstack/boxel-cli).
 interface RealmPathsVirtualNetwork {
   toURL(rri: string): URL;
+  toURLHref(rri: string): string;
 }
 
 export class RealmPaths {
@@ -128,8 +129,8 @@ export class RealmPaths {
     let realmURL: string;
     let inputURL: string;
     try {
-      realmURL = this.virtualNetwork.toURL(this.url).href;
-      inputURL = this.virtualNetwork.toURL(inputStr).href;
+      realmURL = this.virtualNetwork.toURLHref(this.url);
+      inputURL = this.virtualNetwork.toURLHref(inputStr);
     } catch {
       return false;
     }

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -25,6 +25,15 @@ export class VirtualNetwork {
   private urlMappings: [string, string][] = [];
   private importMap: Map<string, (rest: string) => string> = new Map();
   private realmMappings = new Map<string, string>();
+  // Memo for toURLHref. Hot paths (module-graph walks, per-instance realm
+  // membership checks) resolve the same identifiers over and over and only
+  // ever need the href STRING, yet toURL pays a native `new URL()` per call —
+  // in large renders that constructor shows up as a top self-time frame, and
+  // the discarded URL objects feed GC pressure. Caching the resolved href
+  // turns every repeat into a Map lookup with zero allocation. Resolution is
+  // a pure function of the realm mappings, so entries stay valid until a
+  // mapping is added or removed (both clear the cache).
+  private toURLHrefCache = new Map<string, string>();
 
   constructor(nativeFetch = createEnvironmentAwareFetch()) {
     this.nativeFetch = nativeFetch;
@@ -84,6 +93,7 @@ export class VirtualNetwork {
     let normalizedId = ensureTrailingSlash(realmIdentifier);
     let normalizedTarget = ensureTrailingSlash(targetURL);
     this.realmMappings.set(normalizedId, normalizedTarget);
+    this.toURLHrefCache.clear();
     this.addImportMap(
       normalizedId,
       (rest) => new URL(rest, normalizedTarget).href,
@@ -100,6 +110,7 @@ export class VirtualNetwork {
     let normalizedId = ensureTrailingSlash(realmIdentifier);
     this.realmMappings.delete(normalizedId);
     this.importMap.delete(normalizedId);
+    this.toURLHrefCache.clear();
   }
 
   knownRealms(): RealmIdentifier[] {
@@ -184,6 +195,24 @@ export class VirtualNetwork {
     }
     // Not a registered prefix; parse as a plain URL.
     return new URL(rri);
+  }
+
+  /**
+   * `toURL().href` without constructing a URL object on repeats. Same
+   * resolution and same throw-on-unresolvable behavior as `toURL`, but
+   * memoized — for callers that only need the href string this turns the
+   * per-call native URL construction into a Map lookup. Failures are not
+   * cached, so an identifier that becomes resolvable after a mapping is
+   * registered resolves normally.
+   */
+  toURLHref(rri: string): string {
+    let cached = this.toURLHrefCache.get(rri);
+    if (cached !== undefined) {
+      return cached;
+    }
+    let href = this.toURL(rri).href;
+    this.toURLHrefCache.set(rri, href);
+    return href;
   }
 
   /**


### PR DESCRIPTION
Large renders resolve the same URL-shaped identifiers over and over, and profiles of the slowest aggregate cards show the native `URL` constructor as a top self-time frame (13–15% on staging) plus `RealmPaths`/`inRealm` and GC churn from the discarded objects. The hot consumers never need a `URL` object — they compare or key on the href string — so the construction is pure overhead.

The change adds `VirtualNetwork.toURLHref`: identical resolution and throw behavior to `toURL`, but memoized and string-returning, so a repeat costs a Map lookup with zero allocation. Entries stay valid until a realm mapping is added or removed (both clear the cache), and failed resolutions are never cached, so an identifier that becomes resolvable later resolves normally.

The measured hot paths consume it:

- **`Loader.getConsumedModules`** now walks with a Set-based visited collection keyed by memoized hrefs. The previous accumulator did a linear array scan per visit (quadratic in graph size), built a `new URL()` per identifier per visit, and allocated a dedup spread at every recursion level. The walk also re-reads module state after a cold import, so a never-loaded module now reports its dependency graph instead of returning `[]` (previously the post-import state check consulted a stale binding).
- **`RealmPaths.inRealm`** cross-form comparison resolves both sides via `toURLHref`.
- **The realm service's `realmOf`** caches a `RealmPaths` per known realm (pure of the realm URL string) and memoizes positive id→realm answers, validated against the live realm set on every hit so realm removal and `resetState` can't serve a stale answer. `realmOf` runs once per instance added to the store and scans every known realm per call, so its per-call construction multiplied by instance count × realm count — the realm-count dimension is why aggregate renders degrade much harder in deployed environments (many known realms) than locally.
- **`live-prerendered-search`** computes the scoped-css module list once per (loader, type module) instead of re-walking the dependency graph for every instance of a type — keyed by loader so a loader reset (which changes the content-addressed scoped-css URLs) invalidates naturally — and tests the scoped-css suffix with string ops instead of constructing a URL per dependency.

Measured on an aggregate-heavy test realm (897 files / 885 instances), same-machine fresh-stack A/B against the merge base: the targeted frames vanish from the slowest dashboard card's profile (`toURL` 8.3%, `getConsumedModules` 4.5%, `isScopedCssModule` 3.0% → all absent from the top 20 post-change) and total CPU samples for that render drop 35%; the three slowest dashboard cards' combined render time drops 80s → 56s with identical index output (entry counts and zero errors on both sides).

Verified with a new `toURLHref` unit test (resolution parity with `toURL`, cache invalidation on mapping removal, no negative caching), the existing loader `getConsumedModules` tests (cycles, prefix-form identifiers), the prerendered-card-search integration tests, and the full `indexing-test.ts` module (61/61) against the real prerender stack.
