### PR TITLE
Fix realm picker search icon overlapping placeholder text

### DIFF
--- a/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
+++ b/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
@@ -280,12 +280,11 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
       .picker-before-options__search {
         --boxel-input-search-color: var(--boxel-dark);
         --boxel-input-search-background-color: transparent;
-        --icon-full-length: var(--boxel-icon-xs);
         padding: 0 calc(2 * var(--boxel-sp-2xs));
       }
 
       .picker-before-options__search :deep(.input-container) {
-        --icon-full-length: var(--boxel-icon-xs);
+        --boxel-input-icon-size: var(--boxel-icon-xs);
       }
 
       .picker-before-options__search :deep(.search-icon) {
@@ -295,7 +294,7 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
       }
 
       .picker-before-options__search :deep(.search) {
-        padding-left: calc(var(--boxel-icon-xs) + var(--boxel-sp-2xs));
+        padding-left: calc(var(--boxel-icon-xs) + var(--boxel-sp-xs));
       }
 
       .picker-before-options__search-input {


### PR DESCRIPTION
Fixes [CS-11534](https://linear.app/cardstack/issue/CS-11534/realm-picker-search-icon-overlaps-placeholder-text-in-dropdown).

## Summary

The Realm filter dropdown's search input rendered its placeholder underneath the leading search icon.

`BoxelInput` lays the search variant out as a 3-column grid (`pre-icon | input | post-icon`), with the pre-icon column width controlled by the custom property `--boxel-input-icon-size` (default ≈ 38px). The picker's `before-options-with-search.gts` tried to shrink that column with `--icon-full-length: var(--boxel-icon-xs)` — but that property name is not the one BoxelInput reads, so the override was a no-op and the icon column stayed at its default width. The picker's input `padding-left` was only ≈ 23px, so the placeholder rendered inside the icon column.

This PR:

- Replaces the no-op `--icon-full-length` override with `--boxel-input-icon-size: var(--boxel-icon-xs)` so the icon column actually matches the smaller xs icon.
- Widens the input's `padding-left` to `--boxel-icon-xs + --boxel-sp-xs` so the placeholder clears the column with a small buffer.

Pure CSS; no behavior change.


### Before

<img width="268" height="115" alt="Screenshot 2026-06-15 at 10 11 23" src="https://github.com/user-attachments/assets/d8651376-b8c6-4fb7-8237-5babf8406667" />


### After
<img width="259" height="99" alt="Screenshot 2026-06-15 at 10 10 10" src="https://github.com/user-attachments/assets/6e71ac1d-a8bf-4d48-b4ad-ef966a53f139" />


## Test plan

- [x] Open the Realm filter dropdown — the search icon and "Search for a realm" placeholder no longer overlap.
- [x] Spot-check other `Picker` consumers (e.g. type filter) — placeholder text still clears the icon.