### PR TITLE
fix: re-enable erasable-syntax guards in catalog contents, lifting only Decorator (CS-11461)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,39 +1,8 @@
 'use strict';
 
-// Selectors for TypeScript syntax that Node cannot run via
-// `--experimental-strip-types`, which only handles "erasable" TS —
-// syntax that vanishes once type annotations are stripped. New code
-// must avoid these so it can run under Node natively, without ts-node.
-const NO_COMPILATION_REQUIRED_TS_SELECTORS = [
-  {
-    selector: 'TSEnumDeclaration',
-    message:
-      'TypeScript `enum` is not erasable and requires compilation. Use a `const` object with `as const` (or a union of string literals) instead.',
-  },
-  {
-    selector: 'TSImportEqualsDeclaration',
-    message:
-      '`import =` syntax requires TypeScript compilation. Use standard ES module `import` instead.',
-  },
-  {
-    selector: 'TSExportAssignment',
-    message:
-      '`export =` syntax requires TypeScript compilation. Use a standard ES module `export default` (or named exports) instead.',
-  },
-  {
-    selector: 'Decorator',
-    message:
-      "Decorators are not erasable and require compilation, so they break under Node's native `--experimental-strip-types`. Avoid decorators here (e.g. replace `@Memoize()` with a manual cache).",
-  },
-  {
-    // Non-ambient `namespace`/`module` blocks emit runtime code. Ambient
-    // declarations (`declare module`, `declare global`, `declare namespace`)
-    // are type-only and erasable, so they are exempt via `:not([declare=true])`.
-    selector: 'TSModuleDeclaration:not([declare=true])',
-    message:
-      'TypeScript `namespace`/`module` blocks emit runtime code and are not erasable. Use standard ES modules instead.',
-  },
-];
+const {
+  NO_COMPILATION_REQUIRED_TS_SELECTORS,
+} = require('./eslint/erasable-syntax-selectors.cjs');
 
 const DATA_TEST_SELECTORS = [
   {
@@ -93,6 +62,20 @@ module.exports = {
     'no-restricted-syntax': ['error', ...NO_COMPILATION_REQUIRED_TS_SELECTORS],
   },
   overrides: [
+    {
+      // Scoped to the root file only (`./`), so it does not cascade to
+      // package-level configs.
+      files: ['./.eslintrc.js'],
+      parserOptions: {
+        sourceType: 'script',
+      },
+      env: {
+        node: true,
+      },
+      rules: {
+        '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
     {
       // Disallow data-test-* CSS selectors in app code across all packages.
       // ember-test-selectors strips these attributes in production, so selectors

--- a/eslint/erasable-syntax-selectors.cjs
+++ b/eslint/erasable-syntax-selectors.cjs
@@ -1,0 +1,42 @@
+'use strict';
+
+// Selectors for TypeScript syntax that Node cannot run via
+// `--experimental-strip-types`, which only handles "erasable" TS —
+// syntax that vanishes once type annotations are stripped. New code
+// must avoid these so it can run under Node natively, without ts-node.
+//
+// Shared by the root `.eslintrc.js`, `packages/ai-bot/.eslintrc.js`
+// (which is `root: true`), and `packages/catalog/.eslintrc.cjs` (which
+// lifts only the `Decorator` selector for realm-compiled contents).
+const NO_COMPILATION_REQUIRED_TS_SELECTORS = [
+  {
+    selector: 'TSEnumDeclaration',
+    message:
+      'TypeScript `enum` is not erasable and requires compilation. Use a `const` object with `as const` (or a union of string literals) instead.',
+  },
+  {
+    selector: 'TSImportEqualsDeclaration',
+    message:
+      '`import =` syntax requires TypeScript compilation. Use standard ES module `import` instead.',
+  },
+  {
+    selector: 'TSExportAssignment',
+    message:
+      '`export =` syntax requires TypeScript compilation. Use a standard ES module `export default` (or named exports) instead.',
+  },
+  {
+    selector: 'Decorator',
+    message:
+      "Decorators are not erasable and require compilation, so they break under Node's native `--experimental-strip-types`. Avoid decorators here (e.g. replace `@Memoize()` with a manual cache).",
+  },
+  {
+    // Non-ambient `namespace`/`module` blocks emit runtime code. Ambient
+    // declarations (`declare module`, `declare global`, `declare namespace`)
+    // are type-only and erasable, so they are exempt via `:not([declare=true])`.
+    selector: 'TSModuleDeclaration:not([declare=true])',
+    message:
+      'TypeScript `namespace`/`module` blocks emit runtime code and are not erasable. Use standard ES modules instead.',
+  },
+];
+
+module.exports = { NO_COMPILATION_REQUIRED_TS_SELECTORS };

--- a/packages/ai-bot/.eslintrc.js
+++ b/packages/ai-bot/.eslintrc.js
@@ -1,39 +1,10 @@
 'use strict';
 
-// See the root `.eslintrc.js` — these selectors guard against TypeScript
-// syntax that requires compilation (so it would not work under Node's
-// native `--experimental-strip-types`). This package has `root: true`,
-// so the root config does not apply here.
-const NO_COMPILATION_REQUIRED_TS_SELECTORS = [
-  {
-    selector: 'TSEnumDeclaration',
-    message:
-      'TypeScript `enum` is not erasable and requires compilation. Use a `const` object with `as const` (or a union of string literals) instead.',
-  },
-  {
-    selector: 'TSImportEqualsDeclaration',
-    message:
-      '`import =` syntax requires TypeScript compilation. Use standard ES module `import` instead.',
-  },
-  {
-    selector: 'TSExportAssignment',
-    message:
-      '`export =` syntax requires TypeScript compilation. Use a standard ES module `export default` (or named exports) instead.',
-  },
-  {
-    selector: 'Decorator',
-    message:
-      "Decorators are not erasable and require compilation, so they break under Node's native `--experimental-strip-types`. Avoid decorators here (e.g. replace `@Memoize()` with a manual cache).",
-  },
-  {
-    // Non-ambient `namespace`/`module` blocks emit runtime code. Ambient
-    // declarations (`declare module`, `declare global`, `declare namespace`)
-    // are type-only and erasable, so they are exempt via `:not([declare=true])`.
-    selector: 'TSModuleDeclaration:not([declare=true])',
-    message:
-      'TypeScript `namespace`/`module` blocks emit runtime code and are not erasable. Use standard ES modules instead.',
-  },
-];
+// `root: true` here, so the root config does not apply and the
+// erasable-syntax rule must be re-declared from the shared list.
+const {
+  NO_COMPILATION_REQUIRED_TS_SELECTORS,
+} = require('../../eslint/erasable-syntax-selectors.cjs');
 
 module.exports = {
   root: true,
@@ -80,4 +51,15 @@ module.exports = {
     ],
     'no-restricted-syntax': ['error', ...NO_COMPILATION_REQUIRED_TS_SELECTORS],
   },
+  overrides: [
+    {
+      files: ['./.eslintrc.js'],
+      parserOptions: {
+        sourceType: 'script',
+      },
+      rules: {
+        '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
+  ],
 };

--- a/packages/catalog/.eslintrc.cjs
+++ b/packages/catalog/.eslintrc.cjs
@@ -1,13 +1,28 @@
 'use strict';
 
+const {
+  NO_COMPILATION_REQUIRED_TS_SELECTORS,
+} = require('../../eslint/erasable-syntax-selectors.cjs');
+
+// contents/ files (both .ts card/command modules and .gts Glimmer components)
+// always go through the realm/Ember compilation pipeline, so decorators like
+// @field, @tracked, and @action are valid here — only the `Decorator` selector
+// is lifted. The remaining erasable-syntax guards (enum, `import =`,
+// `export =`, runtime namespaces) still apply, for consistency with the rest
+// of the repo.
+const CONTENTS_RESTRICTED_SYNTAX = [
+  'error',
+  ...NO_COMPILATION_REQUIRED_TS_SELECTORS.filter(
+    (s) => s.selector !== 'Decorator',
+  ),
+];
+
 module.exports = {
   overrides: [
     {
-      // contents/ .ts files are Boxel card/command modules that go through the
-      // realm compilation pipeline — decorators are valid here.
       files: ['contents/**/*.ts'],
       rules: {
-        'no-restricted-syntax': 'off',
+        'no-restricted-syntax': CONTENTS_RESTRICTED_SYNTAX,
       },
     },
     {
@@ -35,10 +50,7 @@ module.exports = {
         'plugin:prettier/recommended',
       ],
       rules: {
-        // .gts files always go through the Ember build pipeline, so decorators
-        // like @tracked and @action are valid here — the no-erasable-syntax
-        // restriction only applies to Node-native strip-types contexts.
-        'no-restricted-syntax': 'off',
+        'no-restricted-syntax': CONTENTS_RESTRICTED_SYNTAX,
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-unused-vars': [
           'error',


### PR DESCRIPTION
Follow-up to #5164.

## Background
#5164 hot-fixed a catalog CI lint failure: boxel's `no-restricted-syntax` ban gained a `Decorator` selector (commit `3af153c3ab`, the erasable-syntax guard for the ts-node → native Node migration / CS-11449), and it fired on every `@field`/`@tracked`/`@action` in catalog `contents/`. The fix set `'no-restricted-syntax': 'off'` for all of `contents/**`.

That also silently un-banned the other four non-erasable constructs — `enum`, `import =`, `export =`, and runtime `namespace`/`module` blocks — which have no more reason to be allowed in card modules than anywhere else.

## What this does
Narrows the catalog override to lift **only** the `Decorator` selector. Decorators are permanently valid in `contents/` (everything there goes through the realm/Ember compilation pipeline; `@field` is the card API), so this is the correct end state — not a grandfather. The remaining four guards now apply to contents too, matching the rest of the repo.

No file-by-file exception list is needed: catalog contents have **zero** violations of the four remaining selectors today (verified by layering the selectors back via `--rule` against freshly synced contents).

The `NO_COMPILATION_REQUIRED_TS_SELECTORS` list was duplicated verbatim in the root and `ai-bot` configs; the catalog override needs to filter it, so it's extracted to `eslint/erasable-syntax-selectors.cjs` rather than adding a third copy. The `require()` in the root and `ai-bot` `.js` configs needs the standard self-override (cf. `packages/postgres/.eslintrc.js`) to satisfy `no-var-requires`.

## Verification
- `pnpm lint:js` in `packages/catalog` (against synced `contents/`) — clean.
- Negative test: a scratch `enum` in a `contents/*.ts` file errors with the enum message; `@field` decorators stay clean.
- `eslint` on the root and `ai-bot` configs — clean (exit 0); selector lists resolve identically to before (root/ai-bot keep all 5, catalog drops only `Decorator`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)