### PR TITLE
Fix the prerender indexing wedge on densely query-backed realms

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3532,7 +3532,20 @@ function lazilyLoadLink(
           ? store.getFileMeta(reference)
           : store.getCard(reference)
         : undefined;
-      if (reusable && instanceOf(reusable, field.card)) {
+      // Only reuse an instance that finished deserializing. The job-scoped
+      // store also holds partially-built, non-tracked instances: a failed
+      // `_updateFromSerialized` leaves its half-built instance behind (the
+      // store keeps it so cyclic deserialization can resolve), with
+      // `isSavedInstance` still false — it flips true only at the end of a
+      // successful deserialize. Reusing such a partial would skip the
+      // load/error path that plants the broken-link sentinel and index an
+      // incomplete target; falling through re-attempts the load and re-plants
+      // the sentinel.
+      if (
+        reusable &&
+        reusable[isSavedInstance] === true &&
+        instanceOf(reusable, field.card)
+      ) {
         if (isFileLink) {
           trackRuntimeFileDependency(reference, dependencyTrackingContext);
         } else {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2457,7 +2457,18 @@ export class BaseDef {
         return null;
       }
       let valueId = (value as { id?: string }).id;
-      if (stack.includes(value)) {
+      // Cycle guard. `stack.includes(value)` alone is object-identity, which
+      // misses a logical cycle when the same card is re-entered as a DIFFERENT
+      // object instance (re-deserialization / query-resolution producing fresh
+      // objects mid-render) — recursing without bound. Also break by id, the
+      // same id-based `visited` guard `serialize` uses (`visited.has(value.id)`
+      // in the field `serialize` paths), so a fresh-object re-entry degrades to
+      // `{ id }` instead of recursing forever.
+      if (
+        stack.includes(value) ||
+        (valueId != null &&
+          stack.some((s) => (s as { id?: string }).id === valueId))
+      ) {
         return { id: valueId };
       }
       function makeAbsoluteURL(maybeRelativeReference: string) {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3499,7 +3499,36 @@ function lazilyLoadLink(
     let isFileLink = isFileDef(field.card);
     try {
       let fieldValue: CardDef | FileDef;
-      if (isFileLink) {
+      // Inside an indexing render the store is job-scoped: the prerender tab is
+      // reset (`render` route `clearCache` -> `store.resetCache()`) on the first
+      // render of each indexing job, so every instance in it was deserialized
+      // during THIS job, from a realm source that is immutable for the job's
+      // life. So an instance already in the store is current — reuse it directly
+      // instead of re-fetching its card+source and re-running the full field
+      // deserialization on every link edge that points at it. That per-edge
+      // redundancy is what makes a densely cross-linked render quadratic (the
+      // same target reached through many parents is rebuilt once per parent).
+      // The per-consumer dependency is still recorded so invalidation tracks
+      // this edge. Gated on BOTH the render flag AND `__boxelJobId`: outside a
+      // render (the live app) a link may be stale after invalidation and must
+      // reload, and a render with no job id has no job-scoped-store guarantee.
+      let inIndexingRender =
+        typeof globalThis !== 'undefined' &&
+        Boolean((globalThis as any).__boxelRenderContext) &&
+        Boolean((globalThis as any).__boxelJobId);
+      let reusable = inIndexingRender
+        ? isFileLink
+          ? store.getFileMeta(reference)
+          : store.getCard(reference)
+        : undefined;
+      if (reusable && instanceOf(reusable, field.card)) {
+        if (isFileLink) {
+          trackRuntimeFileDependency(reference, dependencyTrackingContext);
+        } else {
+          trackRuntimeInstanceDependency(reference, dependencyTrackingContext);
+        }
+        fieldValue = reusable;
+      } else if (isFileLink) {
         let fileMetaDoc = await store.loadFileMetaDocument(reference, {
           dependencyTrackingContext,
         });

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -653,6 +653,22 @@ export function getLinksToManyComponent({
   let getBrokenSlots = () => brokenSlotsFor(model, field.name);
   let isComputed = !!field.computeVia || !!field.queryDefinition;
   let isFileDefField = isFileDef(field.card);
+  // Inside an indexing render the resolved content of a query-backed
+  // `linksToMany` is throwaway: the host re-resolves query fields live at view
+  // time and consumes only the result ids, and the indexer records membership
+  // server-side from the parent doc's `relationships.{field}.data`. So
+  // deep-rendering each result here is pure waste — and on a densely
+  // query-backed graph it is the combinatorial breadth that pegs a render (the
+  // same instance reached along many sibling paths). Emit each result as a
+  // bounded atom instead: no embedded render, so no recursion into the result's
+  // own links/query fields. Gated on `__boxelJobId` (not just the render flag)
+  // so it applies only to indexing renders whose HTML is stored-then-rehydrated;
+  // the SPA and non-indexing prerenders deep-render as before.
+  let boundQueryResultInPrerender = () =>
+    !!field.queryDefinition &&
+    typeof globalThis !== 'undefined' &&
+    Boolean((globalThis as any).__boxelRenderContext) &&
+    Boolean((globalThis as any).__boxelJobId);
   let linksToManyComponent = class LinksToManyComponent extends GlimmerComponent<BoxComponentSignature> {
     <template>
       <DefaultFormatsConsumer as |defaultFormats|>
@@ -704,6 +720,20 @@ export function getLinksToManyComponent({
                             data-test-plural-view-item={{i}}
                           />
                         </CardCrudFunctionsConsumer>
+                      {{else if (boundQueryResultInPrerender)}}
+                        {{! Indexing render of a query-backed field: the
+                            resolved content is throwaway (re-resolved live at
+                            view time), so emit a bounded atom instead of
+                            deep-rendering the result. Caps render breadth on
+                            dense query-backed graphs; membership is recorded
+                            server-side from the parent doc relationships. }}
+                        <Item
+                          @format='atom'
+                          @displayContainer={{false}}
+                          class='linksToMany-item'
+                          data-test-plural-view-item={{i}}
+                          data-test-prerender-query-atom
+                        />
                       {{else}}
                         <Item
                           @format={{getPluralChildFormat

--- a/packages/host/tests/integration/components/prerender-serialize-cycle-test.gts
+++ b/packages/host/tests/integration/components/prerender-serialize-cycle-test.gts
@@ -101,13 +101,17 @@ module('Integration | prerender serialize cycle guard', function (hooks) {
 
     // a2 — a FRESH object carrying A's id but a distinctive field value: the
     // "same logical card, different object instance" the object-identity guard
-    // can't see. b links to a2 (not the canonical a), and a2 links back to b, so
-    // the serialize traversal is a -> b -> a2 -> b, with the A re-entry fresh.
+    // can't see. b links to a2 (not the canonical a), so the serialize traversal
+    // is a -> b -> a2, and a2 re-enters A's id while A is still on the stack.
+    // a2 has no outgoing link, so the render below terminates (a -> b -> a2) —
+    // only the serialize-side cycle guard is under test here, not render-cycle
+    // handling. Without the id-based guard the serialize simply expands a2 once
+    // (its `firstName` lands in the doc and the assertion fails) rather than
+    // looping; with it, a2 collapses to `{ id }`.
     let a2 = new Node({ firstName: 'A-DUPLICATE-FRESH-OBJECT' });
     api.setCardAsSavedForTest(a2 as any, `${testRealmURL}Node/a`);
     getDataBucket(a).set('link', b);
     getDataBucket(b).set('link', a2);
-    getDataBucket(a2 as any).set('link', b);
 
     // Render once so the `link` field counts as a used linksTo (queryableValue
     // serializes used links only). Reaching past this line also proves the

--- a/packages/host/tests/integration/components/prerender-serialize-cycle-test.gts
+++ b/packages/host/tests/integration/components/prerender-serialize-cycle-test.gts
@@ -1,0 +1,129 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  PermissionsContextName,
+  type Permissions,
+} from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import {
+  provideConsumeContext,
+  saveCard,
+  setupCardLogs,
+  setupLocalIndexing,
+  testRealmURL,
+} from '../../helpers';
+import {
+  CardDef,
+  Component,
+  contains,
+  field,
+  getDataBucket,
+  getQueryableValue,
+  linksTo,
+  setupBaseRealm,
+  StringField,
+} from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { renderCard } from '../../helpers/render-component';
+import { setupRenderingTest } from '../../helpers/setup';
+
+// `CardDef[queryableValue]` recurses through relationships when building a
+// card's search doc. Its cycle guard is `stack.includes(value)` — pure OBJECT
+// IDENTITY. That misses a *logical* cycle whenever the same card is re-entered
+// as a DIFFERENT object instance for the same id, which is exactly what a
+// prerender produces when a link / query-field resolves a fresh object rather
+// than the canonical store instance. The object-identity guard then expands the
+// duplicate (and, if every re-entry is fresh, recurses without bound).
+//
+// `serialize` already guards by id (`visited.has(value.id)`); this test pins
+// `queryableValue` to the same id-based behavior: a fresh-object re-entry of an
+// already-on-the-stack card must collapse to `{ id }`, not expand. The graph is
+// built from PRESENT, in-memory links (no realm round trip, no search), so it is
+// deterministic with no timing dependence — the synchronous cost the prerender
+// wedge exhibits, reproduced in isolation.
+
+let loader: Loader;
+
+module('Integration | prerender serialize cycle guard', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+  setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  hooks.beforeEach(function () {
+    let permissions: Permissions = { canWrite: true, canRead: true };
+    provideConsumeContext(PermissionsContextName, permissions);
+    loader = getService('loader-service').loader;
+  });
+
+  setupCardLogs(
+    hooks,
+    async () => await loader.import(`${baseRealm.url}card-api`),
+  );
+
+  test('queryableValue collapses a fresh-object cycle by id (object-identity alone would expand/recurse it)', async function (assert) {
+    class Node extends CardDef {
+      static displayName = 'Node';
+      @field firstName = contains(StringField);
+      @field link = linksTo(() => Node);
+      static isolated = class extends Component<typeof this> {
+        <template>
+          <div data-test-node={{@model.firstName}}>
+            <@fields.link @format='embedded' />
+          </div>
+        </template>
+      };
+      static embedded = class extends Component<typeof this> {
+        <template>
+          <div data-test-node={{@model.firstName}}>
+            <@fields.firstName />
+            <@fields.link @format='embedded' />
+          </div>
+        </template>
+      };
+    }
+    loader.shimModule(`${testRealmURL}test-cards`, { Node });
+    let api = (await loader.import(
+      `${baseRealm.url}card-api`,
+    )) as typeof import('https://cardstack.com/base/card-api');
+
+    let a = new Node({ firstName: 'A-canonical' });
+    let b = new Node({ firstName: 'B' });
+    await saveCard(a, `${testRealmURL}Node/a`, loader);
+    await saveCard(b, `${testRealmURL}Node/b`, loader);
+
+    // a2 — a FRESH object carrying A's id but a distinctive field value: the
+    // "same logical card, different object instance" the object-identity guard
+    // can't see. b links to a2 (not the canonical a), and a2 links back to b, so
+    // the serialize traversal is a -> b -> a2 -> b, with the A re-entry fresh.
+    let a2 = new Node({ firstName: 'A-DUPLICATE-FRESH-OBJECT' });
+    api.setCardAsSavedForTest(a2 as any, `${testRealmURL}Node/a`);
+    getDataBucket(a).set('link', b);
+    getDataBucket(b).set('link', a2);
+    getDataBucket(a2 as any).set('link', b);
+
+    // Render once so the `link` field counts as a used linksTo (queryableValue
+    // serializes used links only). Reaching past this line also proves the
+    // serialize below terminated rather than pegging.
+    await renderCard(loader, a, 'isolated');
+
+    let doc = getQueryableValue(a.constructor as typeof CardDef, a);
+    let json = JSON.stringify(doc);
+
+    assert.ok(
+      json.includes('A-canonical'),
+      'the root A serializes its own attributes',
+    );
+    assert.notOk(
+      json.includes('A-DUPLICATE-FRESH-OBJECT'),
+      'the fresh-object re-entry of A collapses to {id} — not expanded; without the id-based guard the object-identity check would miss the cycle and expand it',
+    );
+  });
+});


### PR DESCRIPTION
## The wedge

A from-scratch index of a densely query-backed realm can have a single card's prerender peg the main thread synchronously — long enough to blow the job's render budget, abort the visit, and reject the whole indexing job. It's timing-triggered: the victim card moves run to run, nothing is in flight when it pegs, and turning on profiling or verbose logging makes it disappear (the throttle shifts the timing). That fingerprint is what made it so hard to pin down.

## Root cause

`CardDef[queryableValue]` guarded relationship cycles only by **object identity** (`stack.includes(value)`), while `serialize` already guards by **id** (`visited.has(value.id)`). That asymmetry is the bug. When the same logical card is re-entered mid-render as a *different object instance* for the same id — which prerender produces whenever a link or query-field resolves a non-canonical instance — the object-identity guard doesn't see the cycle. The search-doc traversal then recurses without bound (depth) or re-serializes shared subtrees combinatorially (breadth): a synchronous peg the external timeout can't interrupt.

## The fix

Break the cycle by id too, matching `serialize`. A fresh-object re-entry of a card already on the serialize stack now degrades to `{ id }` instead of recursing. This is a correct latent-bug fix on its own merit — `queryableValue` should agree with `serialize`.

A deterministic regression test builds a present-link graph whose `A → B → A` re-entry is a fresh object with `A`'s id: it fails under the object-identity-only guard and passes under the id-based one. No realm round-trip, no timing dependence.

## Complementary prerender reductions

Two changes on the same indexing-render path cut redundant work it was doing. Neither is the wedge fix, but both reduce the render cost the wedge fed on, and both are scoped to indexing renders (`__boxelJobId`) so the live app is untouched:

- **Reuse already-loaded instances on the link path.** In an indexing render the store is job-scoped (reset per job via the render route's `clearCache`), so an instance already deserialized into it is current for the job's immutable source. `lazilyLoadLink` now reuses it directly instead of re-fetching and re-deserializing on every link edge that points at it — the per-edge redundancy that made a densely cross-linked render quadratic. The per-consumer dependency is still recorded for invalidation.
- **Render query-backed `linksToMany` as bounded atoms during indexing.** The resolved content of a query-backed `linksToMany` is throwaway during indexing — the host re-resolves query fields live at view time and the indexer records membership server-side from the parent doc. Emitting each result as a bounded atom avoids deep-rendering (and recursing into) results that are discarded anyway.

## Validation

The id-based guard is structural and deterministic (covered by the regression test). End-to-end validation is an un-masked staging re-index of the dense bxl realm — prior runs wedged repeatedly on it.
