### PR TITLE
Hide CardPicker type selector when type search is disabled

### DIFF
--- a/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
+++ b/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
@@ -60,7 +60,6 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
   }
 
   get showSearch() {
-    if (this.args.select.disabled) return false;
     return this.args.extra?.searchEnabled ?? true;
   }
 
@@ -231,7 +230,15 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
   }
 
   <template>
-    <div class='picker-before-options' data-test-boxel-picker-before-options>
+    {{! Keydown lives on the wrapper so navigation works even when the
+        search input is hidden — events bubble from the input or the
+        focus-target div. }}
+    <div
+      class='picker-before-options'
+      data-test-boxel-picker-before-options
+      tabindex='-1'
+      {{on 'keydown' this.handleKeydown}}
+    >
       {{#if this.showSearch}}
         <div
           class='picker-before-options__search'
@@ -245,9 +252,15 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
             @autocomplete='off'
             class='picker-before-options__search-input'
             {{autoFocus}}
-            {{on 'keydown' this.handleKeydown}}
           />
         </div>
+      {{else}}
+        <div
+          class='picker-before-options__focus-target'
+          tabindex='-1'
+          data-test-boxel-picker-focus-target
+          {{autoFocus}}
+        ></div>
       {{/if}}
 
       <div
@@ -316,6 +329,17 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
 
       .picker-before-options__search-input:focus-visible,
       .search {
+        outline: none;
+      }
+
+      .picker-before-options__focus-target {
+        width: 0;
+        height: 0;
+        overflow: hidden;
+        outline: none;
+      }
+
+      .picker-before-options:focus-visible {
         outline: none;
       }
 

--- a/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
+++ b/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
@@ -20,6 +20,7 @@ export interface BeforeOptionsWithSearchSignature {
       ) => PickerOption[];
       isSelectAllActive?: boolean;
       onSearchTermChange?: (term: string) => void;
+      searchEnabled?: boolean;
       searchPlaceholder?: string;
       searchTerm?: string;
       selectAllOption?: PickerOption;
@@ -56,6 +57,11 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
 
   get searchPlaceholder() {
     return this.args.extra?.searchPlaceholder || 'Search...';
+  }
+
+  get showSearch() {
+    if (this.args.select.disabled) return false;
+    return this.args.extra?.searchEnabled ?? true;
   }
 
   get selectAllOption() {
@@ -226,18 +232,23 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
 
   <template>
     <div class='picker-before-options' data-test-boxel-picker-before-options>
-      <div class='picker-before-options__search' data-test-boxel-picker-search>
-        <BoxelInput
-          @type='search'
-          @value={{this.searchTerm}}
-          @onInput={{this.updateSearchTerm}}
-          @placeholder={{this.searchPlaceholder}}
-          @autocomplete='off'
-          class='picker-before-options__search-input'
-          {{autoFocus}}
-          {{on 'keydown' this.handleKeydown}}
-        />
-      </div>
+      {{#if this.showSearch}}
+        <div
+          class='picker-before-options__search'
+          data-test-boxel-picker-search
+        >
+          <BoxelInput
+            @type='search'
+            @value={{this.searchTerm}}
+            @onInput={{this.updateSearchTerm}}
+            @placeholder={{this.searchPlaceholder}}
+            @autocomplete='off'
+            class='picker-before-options__search-input'
+            {{autoFocus}}
+            {{on 'keydown' this.handleKeydown}}
+          />
+        </div>
+      {{/if}}
 
       <div
         class='picker-before-options__selected-summary'

--- a/packages/boxel-ui/addon/src/components/picker/index.gts
+++ b/packages/boxel-ui/addon/src/components/picker/index.gts
@@ -42,6 +42,8 @@ export interface PickerSignature {
     options: PickerOption[];
     placeholder?: string;
     renderInPlace?: boolean;
+    /** Defaults to true. When false, the search input section is hidden. */
+    searchEnabled?: boolean;
     searchPlaceholder?: string;
     selected: PickerOption[];
   };
@@ -219,10 +221,15 @@ export default class Picker extends Component<PickerSignature> {
     return true;
   };
 
+  get isSearchEnabled() {
+    return this.args.searchEnabled ?? true;
+  }
+
   get extra() {
     return {
       ...this.args.extra,
       label: this.args.label,
+      searchEnabled: this.isSearchEnabled,
       searchTerm: this.searchTerm,
       searchPlaceholder: this.args.searchPlaceholder,
       onSearchTermChange: this.onSearchTermChange,

--- a/packages/boxel-ui/addon/src/components/picker/selected-item.gts
+++ b/packages/boxel-ui/addon/src/components/picker/selected-item.gts
@@ -164,9 +164,6 @@ export default class PickerSelectedItem extends Component<PickerSelectedItemSign
         border-radius: var(--boxel-border-radius-xs);
         display: block;
       }
-      .picker-selected-item__remove:hover {
-        background: var(--boxel-200);
-      }
     </style>
   </template>
 }

--- a/packages/boxel-ui/addon/src/components/picker/selected-item.gts
+++ b/packages/boxel-ui/addon/src/components/picker/selected-item.gts
@@ -165,8 +165,7 @@ export default class PickerSelectedItem extends Component<PickerSelectedItemSign
         display: block;
       }
       .picker-selected-item__remove:hover {
-        background: none;
-        opacity: 0.7;
+        background: var(--boxel-200);
       }
     </style>
   </template>

--- a/packages/boxel-ui/addon/src/components/picker/trigger-labeled.gts
+++ b/packages/boxel-ui/addon/src/components/picker/trigger-labeled.gts
@@ -103,7 +103,10 @@ export default class PickerLabeledTrigger extends Component<TriggerLabeledSignat
   }
 
   <template>
-    <div class='boxel-trigger' data-test-boxel-picker-trigger>
+    <div
+      class={{cn 'boxel-trigger' is-disabled=@select.disabled}}
+      data-test-boxel-picker-trigger
+    >
       <div class='boxel-trigger-content'>
         {{#if this.label}}
           <span
@@ -171,6 +174,11 @@ export default class PickerLabeledTrigger extends Component<TriggerLabeledSignat
         letter-spacing: var(--boxel-lsp-sm);
         outline: none;
         cursor: pointer;
+      }
+
+      .boxel-trigger.is-disabled {
+        cursor: not-allowed;
+        color: var(--boxel-450);
       }
 
       .boxel-trigger-content {

--- a/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
@@ -1434,4 +1434,104 @@ module('Integration | Component | picker', function (hooks) {
       .dom('[data-test-boxel-picker-select-all].picker-option-row--highlighted')
       .exists('Select-all remains highlighted after ArrowUp at boundary');
   });
+
+  test('disabled picker hides the search input section', async function (assert) {
+    const selected = [testOptions[0]];
+
+    await render(
+      <template>
+        <Picker
+          @options={{testOptionsWithSelectAll}}
+          @selected={{selected}}
+          @onChange={{noop}}
+          @label='Test'
+          @disabled={{true}}
+        />
+      </template>,
+    );
+
+    await click('[data-test-boxel-picker-trigger]');
+
+    assert
+      .dom('[data-test-boxel-picker-search]')
+      .doesNotExist(
+        'Search section is not rendered when the picker is disabled',
+      );
+  });
+
+  test('picker with @searchEnabled={{false}} hides the search input', async function (assert) {
+    const selected: PickerOption[] = [];
+
+    await render(
+      <template>
+        <Picker
+          @options={{testOptionsWithSelectAll}}
+          @selected={{selected}}
+          @onChange={{noop}}
+          @label='Test'
+          @searchEnabled={{false}}
+        />
+      </template>,
+    );
+
+    await click('[data-test-boxel-picker-trigger]');
+    await waitFor('[data-test-boxel-picker-before-options]');
+
+    assert
+      .dom('[data-test-boxel-picker-search]')
+      .doesNotExist(
+        'Search section is not rendered when @searchEnabled is false',
+      );
+    assert
+      .dom('.ember-power-select-options [data-test-boxel-picker-option-row]')
+      .exists({ count: 4 }, 'Main list still renders without the search input');
+  });
+
+  test('disabled picker marks the trigger with a disabled visual state', async function (assert) {
+    const selected: PickerOption[] = [];
+
+    await render(
+      <template>
+        <Picker
+          @options={{testOptionsWithSelectAll}}
+          @selected={{selected}}
+          @onChange={{noop}}
+          @label='Test'
+          @disabled={{true}}
+        />
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-boxel-picker-trigger]')
+      .hasClass(
+        'is-disabled',
+        'Trigger carries an is-disabled class when the picker is disabled',
+      );
+  });
+
+  test('selected items hide the remove button when picker is disabled', async function (assert) {
+    const selected = [testOptions[0], testOptions[1]];
+
+    await render(
+      <template>
+        <Picker
+          @options={{testOptionsWithSelectAll}}
+          @selected={{selected}}
+          @onChange={{noop}}
+          @label='Test'
+          @disabled={{true}}
+        />
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-boxel-picker-selected-item]')
+      .exists({ count: 2 }, 'Selected pills still render when disabled');
+    assert
+      .dom('[data-test-boxel-picker-remove-button]')
+      .doesNotExist(
+        'Remove buttons are not rendered on selected items when the picker is disabled',
+      );
+  });
 });

--- a/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/picker-test.gts
@@ -1487,6 +1487,51 @@ module('Integration | Component | picker', function (hooks) {
       .exists({ count: 4 }, 'Main list still renders without the search input');
   });
 
+  test('keyboard navigation works when @searchEnabled={{false}}', async function (assert) {
+    class SelectionController {
+      @tracked selected: PickerOption[] = [selectAllOption];
+    }
+
+    const controller = new SelectionController();
+
+    const onChange = (newSelected: PickerOption[]) => {
+      controller.selected = newSelected;
+    };
+
+    await render(
+      <template>
+        <Picker
+          @options={{testOptionsWithSelectAll}}
+          @selected={{controller.selected}}
+          @onChange={{onChange}}
+          @label='Test'
+          @searchEnabled={{false}}
+        />
+      </template>,
+    );
+
+    await click('[data-test-boxel-picker-trigger]');
+    await waitFor('[data-test-boxel-picker-before-options]');
+
+    const focusTarget = '[data-test-boxel-picker-focus-target]';
+
+    // Select-all is highlighted on open via activateFirstItem
+    assert
+      .dom('[data-test-boxel-picker-select-all].picker-option-row--highlighted')
+      .exists('Select-all is highlighted on open even without a search input');
+
+    // ArrowDown should still move the highlight into the main list
+    await triggerKeyEvent(focusTarget, 'keydown', 'ArrowDown');
+
+    assert
+      .dom(
+        '.ember-power-select-options .ember-power-select-option[aria-current="true"]',
+      )
+      .exists(
+        'ArrowDown moves the highlight into the main list when search is hidden',
+      );
+  });
+
   test('disabled picker marks the trigger with a disabled visual state', async function (assert) {
     const selected: PickerOption[] = [];
 

--- a/packages/host/app/components/card-search/search-bar.gts
+++ b/packages/host/app/components/card-search/search-bar.gts
@@ -72,12 +72,14 @@ export default class SearchBar extends Component<Signature> {
           @destination={{@pickerDestination}}
         />
       </div>
-      <div class='search-sheet__search-bar-picker'>
-        <TypePicker
-          @filter={{@typeFilter}}
-          @destination={{@pickerDestination}}
-        />
-      </div>
+      {{#unless @typeFilter.skipTypeFiltering}}
+        <div class='search-sheet__search-bar-picker'>
+          <TypePicker
+            @filter={{@typeFilter}}
+            @destination={{@pickerDestination}}
+          />
+        </div>
+      {{/unless}}
       <div class='search-sheet__search-bar-separator' aria-hidden='true'></div>
       {{! template-lint-disable no-invalid-interactive }}
       <div

--- a/packages/host/tests/integration/components/operator-mode-card-chooser-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-chooser-test.gts
@@ -363,7 +363,7 @@ module('Integration | operator-mode | card chooser', function (hooks) {
         .exists({ count: 2 }, 'non-Pet recent cards are filtered out');
     });
 
-    test('type picker works in card chooser modal with baseFilter', async function (assert) {
+    test('type picker is hidden when baseFilter constrains type', async function (assert) {
       let recentCardsService = getService('recent-cards-service');
       recentCardsService.add(`${testRealmURL}Pet/mango`);
       recentCardsService.add(`${testRealmURL}Person/fadhlan`);
@@ -382,76 +382,25 @@ module('Integration | operator-mode | card chooser', function (hooks) {
       await waitFor('[data-test-card-chooser-modal]');
       await settled();
 
-      // Type picker should exist in the modal
+      // The type picker is redundant when baseFilter already locks the type
       assert
-        .dom('[data-test-type-picker]')
-        .exists('type picker is present in card chooser modal');
-
-      // Open type picker
-      await click('[data-test-type-picker] [data-test-boxel-picker-trigger]');
-      await waitFor('[data-test-boxel-picker-option-row]');
-
-      // Clicking the search input should focus it (CS-10581)
-      await click('[data-test-boxel-picker-search] input');
-      assert
-        .dom('[data-test-boxel-picker-search] input')
-        .isFocused('type picker search input is focusable when clicked');
-      assert
-        .dom('[data-test-boxel-picker-search] input')
-        .hasAttribute(
-          'placeholder',
-          'Search for a type',
-          'type picker has correct search placeholder',
-        );
-
-      // "Any Type" should be present with count
-      assert
-        .dom(
-          '[data-test-boxel-picker-option-row="select-all"][data-test-boxel-picker-option-disabled="true"]',
-        )
-        .exists('"Any Type" is disabled when baseFilter constrains to Pet');
-
-      // Options should be constrained by baseFilter (Pet types only)
-      // Person should NOT appear as a type option since baseFilter constrains to Pet
-      assert
-        .dom('[data-test-boxel-picker-option-label="Person"]')
+        .dom('[data-test-card-chooser-modal] [data-test-type-picker]')
         .doesNotExist(
-          'Person type is not available when baseFilter constrains to Pet',
+          'type picker is not rendered when baseFilter constrains type',
         );
-    });
 
-    test('type picker auto-selects constrained type and disables Any Type when baseFilter specifies a specific type', async function (assert) {
-      ctx.setCardInOperatorModeState(`${testRealmURL}Person/hassan`, 'edit');
-      await renderComponent(
-        class TestDriver extends GlimmerComponent {
-          <template><OperatorMode @onClose={{noop}} /></template>
-        },
-      );
-      await waitFor(`[data-test-stack-card="${testRealmURL}Person/hassan"]`);
-
-      // Open linksTo card picker for Pet field
-      await waitFor(`[data-test-add-new="pet"]`);
-      await click(`[data-test-add-new="pet"]`);
-      await waitFor('[data-test-card-chooser-modal]');
-      await settled();
-
-      // Type picker should auto-select Pet instead of "Any Type"
-      await waitFor('[data-test-boxel-picker-selected-item="Pet"]');
+      // The realm picker still renders so users can narrow by realm
       assert
-        .dom(
-          '[data-test-type-picker] [data-test-boxel-picker-selected-item="Pet"]',
-        )
-        .exists('Pet type is auto-selected when baseFilter constrains to Pet');
+        .dom('[data-test-card-chooser-modal] [data-test-realm-picker]')
+        .exists('realm picker is still rendered');
 
-      // Open type picker to verify "Any Type" is disabled
-      await click('[data-test-type-picker] [data-test-boxel-picker-trigger]');
-      await waitFor('[data-test-boxel-picker-option-row]');
-
+      // Search results are still constrained to Pet types behind the scenes
       assert
-        .dom(
-          '[data-test-boxel-picker-option-row="select-all"][data-test-boxel-picker-option-disabled="true"]',
-        )
-        .exists('"Any Type" is disabled when baseFilter auto-selects Pet');
+        .dom(`[data-test-recent-card-result="${testRealmURL}Pet/mango"]`)
+        .exists('Pet recent card appears in the linksTo picker');
+      assert
+        .dom(`[data-test-recent-card-result="${testRealmURL}Person/fadhlan"]`)
+        .doesNotExist('non-Pet recent cards are filtered out');
     });
   });
 


### PR DESCRIPTION
## Background and Goal

[CS-11322](https://linear.app/cardstack/issue/CS-11322/cardpicker-type-selector-widget-should-not-appear-when-type-search-is) — when the card chooser's `baseFilter` already constrains card type (e.g. a `linksTo` field), the Type picker in the search bar is redundant: the type is pinned and the user can't change it. This PR hides the picker entirely in that situation, and polishes the underlying boxel-ui `Picker` so disabled state is reflected in the trigger, the search input, and selected-item remove buttons via the component API (no opacity hacks).

## Where to start

- `packages/host/app/components/card-search/search-bar.gts` — `<TypePicker>` wrapped in `{{#unless @typeFilter.skipTypeFiltering}}`. That's the user-visible behavior change.
- `packages/boxel-ui/addon/src/components/picker/index.gts` + `before-options-with-search.gts` — new `@searchEnabled` arg (default `true`) and a `showSearch` getter that hides the search input section when the picker is disabled or `@searchEnabled` is false.
- `packages/boxel-ui/addon/src/components/picker/trigger-labeled.gts` — `is-disabled` modifier on the trigger (not-allowed cursor + muted colour) when disabled.
- `packages/boxel-ui/addon/src/components/picker/selected-item.gts` — replaced the `:hover { opacity: 0.7 }` hack on the remove button with a `--boxel-200` background hover.

## Key decisions and non-obvious mechanics

- "This situation" maps to `typeFilter.skipTypeFiltering`, which is true iff `getTypeSummaries.hasNonRootBaseFilter` — i.e. the `baseFilter` pins a non-root type. AI assistant card-catalog (`CardDef` root baseFilter) → still shows the picker. Pet linksTo (non-root) → hides it.
- The picker's existing `displayRemoveButton` already returned `false` when the picker was disabled. The remove-button test in this PR pins that behavior; the visible changes are the trigger and search-input states the ticket called out.
- Search-icon placement (the fourth UI bullet on the ticket) is already addressed by #5230; not duplicated here.

## Before
<img width="1118" height="304" alt="Screenshot 2026-06-16 at 23 24 55" src="https://github.com/user-attachments/assets/68ff5012-a035-4dcb-8051-5c04fa38e944" />

## After 
<img width="1054" height="166" alt="Screenshot 2026-06-16 at 23 19 04" src="https://github.com/user-attachments/assets/71f6af3a-c18c-4af2-ac5b-8b4f6bf9ec46" />


