### PR TITLE
Fix AI credit overspend and uncharged generations in ai-bot

### DIFF
--- a/packages/ai-bot/lib/credit-tracking.ts
+++ b/packages/ai-bot/lib/credit-tracking.ts
@@ -1,13 +1,19 @@
-import { logger, delay } from '@cardstack/runtime-common';
+import { logger, delay, type DBAdapter } from '@cardstack/runtime-common';
+import {
+  spendUsageCost,
+  fetchGenerationCostWithBackoff,
+} from '@cardstack/billing/ai-billing';
 
 let log = logger('ai-bot');
 
 const CREDIT_TRACKING_TIMEOUT_MS = 5_000;
 
 /**
- * Waits for any pending credit tracking to complete before starting
- * a new generation. This prevents generating responses when the previous
- * generation's cost hasn't been recorded yet.
+ * Waits for any pending fallback credit tracking to complete before starting
+ * a new generation. The primary serialization is now the per-user
+ * `withUserCostLock` barrier around generate → debit (see main.ts); this
+ * remains a secondary net for the rare fallback path below, whose debit lands
+ * outside the lock.
  *
  * Uses a timeout to avoid blocking indefinitely when
  * fetchGenerationCostWithBackoff is retrying with exponential backoff
@@ -32,4 +38,52 @@ export async function waitForPendingCreditTracking(
     }
   }
   return {};
+}
+
+/**
+ * Fire-and-forget fallback for the rare case where the stream reported no
+ * inline cost. `fetchGenerationCostWithBackoff` can retry for up to 10
+ * minutes, so this must NOT be awaited inside `withUserCostLock` — we cannot
+ * pin a DB connection that long. The debit therefore lands outside the
+ * per-user lock; `waitForPendingCreditTracking` is the best-effort net that
+ * makes the next same-user request wait (bounded) for it.
+ *
+ * Each scheduled fallback always performs its own debit — unlike the old
+ * per-process barrier it never early-returns when another debit is pending,
+ * so concurrent costs are not coalesced away.
+ */
+export function scheduleFallbackCostTracking(opts: {
+  dbAdapter: DBAdapter;
+  matrixUserId: string;
+  generationId: string;
+  openRouterApiKey: string;
+  trackAiUsageCostPromises: Map<string, Promise<void>>;
+}): void {
+  let {
+    dbAdapter,
+    matrixUserId,
+    generationId,
+    openRouterApiKey,
+    trackAiUsageCostPromises,
+  } = opts;
+
+  let work = (async () => {
+    log.info(
+      `No inline cost for user ${matrixUserId}, falling back to generation cost API (generationId: ${generationId})`,
+    );
+    let fetchedCost = await fetchGenerationCostWithBackoff(
+      generationId,
+      openRouterApiKey,
+    );
+    if (fetchedCost !== null) {
+      await spendUsageCost(dbAdapter, matrixUserId, fetchedCost);
+    } else {
+      log.warn(
+        `Failed to fetch generation cost for user ${matrixUserId} (generationId: ${generationId}), credit deduction skipped`,
+      );
+    }
+  })().finally(() => {
+    trackAiUsageCostPromises.delete(matrixUserId);
+  });
+  trackAiUsageCostPromises.set(matrixUserId, work);
 }

--- a/packages/ai-bot/lib/credit-tracking.ts
+++ b/packages/ai-bot/lib/credit-tracking.ts
@@ -51,6 +51,12 @@ export async function waitForPendingCreditTracking(
  * Each scheduled fallback always performs its own debit — unlike the old
  * per-process barrier it never early-returns when another debit is pending,
  * so concurrent costs are not coalesced away.
+ *
+ * The map entry is the chain of ALL pending fallback debits for the user
+ * (the new work joined to whatever was already pending), so
+ * waitForPendingCreditTracking waits for every still-in-flight debit. The
+ * entry is removed only while it still points at this chain, so an earlier
+ * debit settling can't unlink a newer fallback that overwrote it.
  */
 export function scheduleFallbackCostTracking(opts: {
   dbAdapter: DBAdapter;
@@ -82,8 +88,15 @@ export function scheduleFallbackCostTracking(opts: {
         `Failed to fetch generation cost for user ${matrixUserId} (generationId: ${generationId}), credit deduction skipped`,
       );
     }
-  })().finally(() => {
-    trackAiUsageCostPromises.delete(matrixUserId);
+  })();
+
+  let prior = trackAiUsageCostPromises.get(matrixUserId);
+  let tracked: Promise<void> = (
+    prior ? Promise.allSettled([prior, work]).then(() => undefined) : work
+  ).finally(() => {
+    if (trackAiUsageCostPromises.get(matrixUserId) === tracked) {
+      trackAiUsageCostPromises.delete(matrixUserId);
+    }
   });
-  trackAiUsageCostPromises.set(matrixUserId, work);
+  trackAiUsageCostPromises.set(matrixUserId, tracked);
 }

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -558,35 +558,49 @@ Common issues are:
                 // Debit the inline cost INSIDE the lock so the next same-user
                 // request observes it before validating. This path has the
                 // best data (both costInUsd from inline chunks and
-                // generationId).
-                if (
-                  typeof costInUsd === 'number' &&
-                  Number.isFinite(costInUsd) &&
-                  costInUsd > 0
-                ) {
-                  await spendUsageCost(
-                    assistant.pgAdapter,
-                    senderMatrixUserId,
-                    costInUsd,
-                  );
-                } else if (generationId) {
-                  // No inline cost: fall back to the slow generation-cost API.
-                  // Register it in the tracking map here (inside the lock) so
-                  // the next same-user request's waitForPendingCreditTracking
-                  // observes it, but let the fetch + debit run detached — its
-                  // backoff can take up to 10 minutes and must not pin the
-                  // lock's connection that long.
-                  scheduleFallbackCostTracking({
-                    dbAdapter: assistant.pgAdapter,
-                    matrixUserId: senderMatrixUserId,
-                    generationId,
-                    openRouterApiKey: process.env.OPENROUTER_API_KEY!,
-                    trackAiUsageCostPromises,
+                // generationId). The user-facing response is already
+                // finalized, so a billing-write failure here must not skip the
+                // activeGenerations cleanup below (a stale entry would make a
+                // later message abort an already-finished run); swallow and log
+                // it, and let the next request surface any billing error via
+                // validateAICredits / waitForPendingCreditTracking.
+                try {
+                  if (
+                    typeof costInUsd === 'number' &&
+                    Number.isFinite(costInUsd) &&
+                    costInUsd > 0
+                  ) {
+                    await spendUsageCost(
+                      assistant.pgAdapter,
+                      senderMatrixUserId,
+                      costInUsd,
+                    );
+                  } else if (generationId) {
+                    // No inline cost: fall back to the slow generation-cost
+                    // API. Register it in the tracking map here (inside the
+                    // lock) so the next same-user request's
+                    // waitForPendingCreditTracking observes it, but let the
+                    // fetch + debit run detached — its backoff can take up to
+                    // 10 minutes and must not pin the lock's connection that
+                    // long.
+                    scheduleFallbackCostTracking({
+                      dbAdapter: assistant.pgAdapter,
+                      matrixUserId: senderMatrixUserId,
+                      generationId,
+                      openRouterApiKey: process.env.OPENROUTER_API_KEY!,
+                      trackAiUsageCostPromises,
+                    });
+                  } else {
+                    log.warn(
+                      `No usage cost and no generation ID for user ${senderMatrixUserId}, skipping credit deduction`,
+                    );
+                  }
+                } catch (costError) {
+                  log.error(`[${eventId}] Failed to record AI usage cost`);
+                  log.error(costError);
+                  Sentry.captureException(costError, {
+                    extra: { roomId: room.roomId, eventId },
                   });
-                } else {
-                  log.warn(
-                    `No usage cost and no generation ID for user ${senderMatrixUserId}, skipping credit deduction`,
-                  );
                 }
                 activeGenerations.delete(room.roomId);
               }

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -40,10 +40,7 @@ import {
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/matrix-event';
 import * as Sentry from '@sentry/node';
 
-import {
-  spendUsageCost,
-  fetchGenerationCostWithBackoff,
-} from '@cardstack/billing/ai-billing';
+import { spendUsageCost } from '@cardstack/billing/ai-billing';
 import { PgAdapter } from '@cardstack/postgres';
 import type { ChatCompletionMessageParam } from 'openai/resources';
 import { APIUserAbortError } from 'openai/error';
@@ -57,7 +54,10 @@ import type { MatrixClient } from 'matrix-js-sdk';
 import { debug } from 'debug';
 import { profEnabled, profTime, profNote } from './lib/profiler.ts';
 import { publishCodePatchCorrectnessMessage } from './lib/code-patch-correctness.ts';
-import { waitForPendingCreditTracking } from './lib/credit-tracking.ts';
+import {
+  waitForPendingCreditTracking,
+  scheduleFallbackCostTracking,
+} from './lib/credit-tracking.ts';
 
 let log = logger('ai-bot');
 
@@ -90,47 +90,6 @@ class Assistant {
     this.client = client;
     this.pgAdapter = new PgAdapter();
     this.aiBotInstanceId = aiBotInstanceId;
-  }
-
-  async trackAiUsageCost(
-    matrixUserId: string,
-    opts: { costInUsd?: number; generationId?: string },
-  ) {
-    if (trackAiUsageCostPromises.has(matrixUserId)) {
-      return;
-    }
-    const promise = (async () => {
-      let { costInUsd, generationId } = opts;
-      if (
-        typeof costInUsd === 'number' &&
-        Number.isFinite(costInUsd) &&
-        costInUsd > 0
-      ) {
-        await spendUsageCost(this.pgAdapter, matrixUserId, costInUsd);
-      } else if (generationId) {
-        log.info(
-          `No inline cost for user ${matrixUserId}, falling back to generation cost API (generationId: ${generationId})`,
-        );
-        const fetchedCost = await fetchGenerationCostWithBackoff(
-          generationId,
-          process.env.OPENROUTER_API_KEY!,
-        );
-        if (fetchedCost !== null) {
-          await spendUsageCost(this.pgAdapter, matrixUserId, fetchedCost);
-        } else {
-          log.warn(
-            `Failed to fetch generation cost for user ${matrixUserId} (generationId: ${generationId}), credit deduction skipped`,
-          );
-        }
-      } else {
-        log.warn(
-          `No usage cost and no generation ID for user ${matrixUserId}, skipping credit deduction`,
-        );
-      }
-    })().finally(() => {
-      trackAiUsageCostPromises.delete(matrixUserId);
-    });
-    trackAiUsageCostPromises.set(matrixUserId, promise);
   }
 
   getResponse(prompt: PromptParts, senderMatrixUserId?: string) {
@@ -456,136 +415,190 @@ Common issues are:
             return;
           }
 
-          // Do not generate new responses if previous ones' cost is still being reported
-          let { error: creditTrackingError } =
-            await waitForPendingCreditTracking(
-              trackAiUsageCostPromises,
-              senderMatrixUserId!,
-            );
-          if (creditTrackingError) {
-            return responder.onError(
-              'There was an error saving your Boxel credits usage. Try again or contact support if the problem persists.',
-            );
-          }
-
-          const creditValidation = await profTime(
-            eventId,
-            'billing:validateCredits',
-            async () =>
-              validateAICredits(assistant.pgAdapter, senderMatrixUserId),
-          );
-
-          if (!creditValidation.hasEnoughCredits) {
-            // Careful when changing this message, it's used in the UI as a detection of whether to show the "Buy credits" button.
-            return responder.onError(
-              `You need a minimum of ${MINIMUM_AI_CREDITS_TO_CONTINUE} credits to continue using the AI bot. Please upgrade to a larger plan, or top up your account.`,
-              { reloadBillingData: true },
-            );
-          }
-
+          // Declarations that must outlive the per-user cost lock — read
+          // after it releases to decide whether the fallback debit is needed.
           let chunkHandlingError: string | undefined;
           let generationId: string | undefined;
           let costInUsd: number | undefined;
-          log.info(
-            `[${eventId}] Starting generation with model %s`,
-            promptParts.model,
-          );
-          const requestStart = Date.now();
-          let firstChunkAt: number | undefined;
-          if (profEnabled()) {
-            profNote(eventId, 'llm:request:start', {
-              model: promptParts.model,
-            });
-          }
-          const runner = assistant
-            .getResponse(promptParts, senderMatrixUserId)
-            .on('chunk', async (chunk, snapshot) => {
-              log.info(`[${eventId}] Received chunk %s`, chunk.id);
-              if (profEnabled() && firstChunkAt == null) {
-                firstChunkAt = Date.now();
-                profNote(eventId, 'llm:ttft', {
-                  ms: firstChunkAt - requestStart,
+          let generationCompleted = false;
+
+          // Serialize this user's credit gate → generate → debit across all
+          // rooms and replicas with the per-user cost lock (CS-11128),
+          // mirroring the realm-server proxy paths. The room lock only
+          // serializes per room, so without this a user firing concurrent
+          // requests in N rooms passes the balance gate N times against the
+          // same stale balance and overspends (CS-11504). The inline-cost
+          // debit is awaited inside the lock so the next same-user request
+          // cannot validate against a pre-deduction balance.
+          await assistant.pgAdapter.withUserCostLock(
+            senderMatrixUserId,
+            async () => {
+              // Do not generate new responses if previous ones' cost is still being reported
+              let { error: creditTrackingError } =
+                await waitForPendingCreditTracking(
+                  trackAiUsageCostPromises,
+                  senderMatrixUserId,
+                );
+              if (creditTrackingError) {
+                await responder.onError(
+                  'There was an error saving your Boxel credits usage. Try again or contact support if the problem persists.',
+                );
+                return;
+              }
+
+              const creditValidation = await profTime(
+                eventId,
+                'billing:validateCredits',
+                async () =>
+                  validateAICredits(assistant.pgAdapter, senderMatrixUserId),
+              );
+
+              if (!creditValidation.hasEnoughCredits) {
+                // Careful when changing this message, it's used in the UI as a detection of whether to show the "Buy credits" button.
+                await responder.onError(
+                  `You need a minimum of ${MINIMUM_AI_CREDITS_TO_CONTINUE} credits to continue using the AI bot. Please upgrade to a larger plan, or top up your account.`,
+                  { reloadBillingData: true },
+                );
+                return;
+              }
+
+              log.info(
+                `[${eventId}] Starting generation with model %s`,
+                promptParts.model,
+              );
+              const requestStart = Date.now();
+              let firstChunkAt: number | undefined;
+              if (profEnabled()) {
+                profNote(eventId, 'llm:request:start', {
                   model: promptParts.model,
                 });
               }
-              generationId = chunk.id;
-              if (chunk.usage && (chunk.usage as any).cost != null) {
-                costInUsd = (chunk.usage as any).cost;
+              const runner = assistant
+                .getResponse(promptParts, senderMatrixUserId)
+                .on('chunk', async (chunk, snapshot) => {
+                  log.info(`[${eventId}] Received chunk %s`, chunk.id);
+                  if (profEnabled() && firstChunkAt == null) {
+                    firstChunkAt = Date.now();
+                    profNote(eventId, 'llm:ttft', {
+                      ms: firstChunkAt - requestStart,
+                      model: promptParts.model,
+                    });
+                  }
+                  generationId = chunk.id;
+                  if (chunk.usage && (chunk.usage as any).cost != null) {
+                    costInUsd = (chunk.usage as any).cost;
+                  }
+                  let activeGeneration = activeGenerations.get(room.roomId);
+                  if (activeGeneration) {
+                    activeGeneration.lastGeneratedChunkId = generationId;
+                  }
+
+                  let chunkProcessingResult = await profTime(
+                    eventId,
+                    'llm:chunk:onChunk',
+                    async () => responder.onChunk(chunk, snapshot),
+                  );
+                  let chunkProcessingResultError = chunkProcessingResult.find(
+                    (promiseResult) =>
+                      promiseResult &&
+                      'errorMessage' in promiseResult &&
+                      promiseResult.errorMessage != null,
+                  ) as { errorMessage: string } | undefined;
+
+                  if (chunkProcessingResultError) {
+                    chunkHandlingError =
+                      chunkProcessingResultError.errorMessage;
+
+                    // If there was an error processing the chunk, e.g. matrix sending error (e.g. event too large),
+                    // then we want to stop accepting more chunks by aborting the runner. This will throw an error
+                    // where the await responder.finalize() is called (the catch block below will handle this)
+                    runner.abort();
+                  }
+                })
+                .on('error', async (error) => {
+                  await responder.onError(error);
+                });
+
+              activeGenerations.set(room.roomId, {
+                responder,
+                runner,
+                lastGeneratedChunkId: generationId,
+                completionPromise: generationCompletionPromise,
+              });
+
+              try {
+                await profTime(eventId, 'llm:finalChatCompletion', async () =>
+                  runner.finalChatCompletion(),
+                );
+                log.info(`[${eventId}] Generation complete`);
+                await profTime(eventId, 'response:finalize', async () =>
+                  responder.finalize(),
+                );
+                log.info(`[${eventId}] Response finalized`);
+              } catch (error) {
+                // When the cancel handler aborts the runner,
+                // finalChatCompletion() throws APIUserAbortError.
+                // Finalize the responder with the canceled flag and let
+                // the finally block handle credit tracking.
+                if (error instanceof APIUserAbortError) {
+                  log.info(`[${eventId}] Generation was canceled by user`);
+                  await responder.finalize({ isCanceled: true });
+                } else {
+                  log.error(
+                    `[${eventId}] Error during generation or finalization`,
+                  );
+                  log.error(error);
+                  if (chunkHandlingError) {
+                    await responder.onError(chunkHandlingError); // E.g. MatrixError: [413] event too large
+                  } else {
+                    await responder.onError(error as OpenAIError);
+                  }
+                }
+              } finally {
+                // Debit the inline cost INSIDE the lock so the next same-user
+                // request observes it before validating. This path has the
+                // best data (both costInUsd from inline chunks and
+                // generationId).
+                if (
+                  typeof costInUsd === 'number' &&
+                  Number.isFinite(costInUsd) &&
+                  costInUsd > 0
+                ) {
+                  await spendUsageCost(
+                    assistant.pgAdapter,
+                    senderMatrixUserId,
+                    costInUsd,
+                  );
+                } else if (generationId) {
+                  // No inline cost: fall back to the slow generation-cost API.
+                  // Register it in the tracking map here (inside the lock) so
+                  // the next same-user request's waitForPendingCreditTracking
+                  // observes it, but let the fetch + debit run detached — its
+                  // backoff can take up to 10 minutes and must not pin the
+                  // lock's connection that long.
+                  scheduleFallbackCostTracking({
+                    dbAdapter: assistant.pgAdapter,
+                    matrixUserId: senderMatrixUserId,
+                    generationId,
+                    openRouterApiKey: process.env.OPENROUTER_API_KEY!,
+                    trackAiUsageCostPromises,
+                  });
+                } else {
+                  log.warn(
+                    `No usage cost and no generation ID for user ${senderMatrixUserId}, skipping credit deduction`,
+                  );
+                }
+                activeGenerations.delete(room.roomId);
               }
-              let activeGeneration = activeGenerations.get(room.roomId);
-              if (activeGeneration) {
-                activeGeneration.lastGeneratedChunkId = generationId;
-              }
 
-              let chunkProcessingResult = await profTime(
-                eventId,
-                'llm:chunk:onChunk',
-                async () => responder.onChunk(chunk, snapshot),
-              );
-              let chunkProcessingResultError = chunkProcessingResult.find(
-                (promiseResult) =>
-                  promiseResult &&
-                  'errorMessage' in promiseResult &&
-                  promiseResult.errorMessage != null,
-              ) as { errorMessage: string } | undefined;
+              generationCompleted = true;
+            },
+          );
 
-              if (chunkProcessingResultError) {
-                chunkHandlingError = chunkProcessingResultError.errorMessage;
-
-                // If there was an error processing the chunk, e.g. matrix sending error (e.g. event too large),
-                // then we want to stop accepting more chunks by aborting the runner. This will throw an error
-                // where the await responder.finalize() is called (the catch block below will handle this)
-                runner.abort();
-              }
-            })
-            .on('error', async (error) => {
-              await responder.onError(error);
-            });
-
-          activeGenerations.set(room.roomId, {
-            responder,
-            runner,
-            lastGeneratedChunkId: generationId,
-            completionPromise: generationCompletionPromise,
-          });
-
-          try {
-            await profTime(eventId, 'llm:finalChatCompletion', async () =>
-              runner.finalChatCompletion(),
-            );
-            log.info(`[${eventId}] Generation complete`);
-            await profTime(eventId, 'response:finalize', async () =>
-              responder.finalize(),
-            );
-            log.info(`[${eventId}] Response finalized`);
-          } catch (error) {
-            // When the cancel handler aborts the runner,
-            // finalChatCompletion() throws APIUserAbortError.
-            // Finalize the responder with the canceled flag and let
-            // the finally block handle credit tracking.
-            if (error instanceof APIUserAbortError) {
-              log.info(`[${eventId}] Generation was canceled by user`);
-              await responder.finalize({ isCanceled: true });
-            } else {
-              log.error(`[${eventId}] Error during generation or finalization`);
-              log.error(error);
-              if (chunkHandlingError) {
-                await responder.onError(chunkHandlingError); // E.g. MatrixError: [413] event too large
-              } else {
-                await responder.onError(error as OpenAIError);
-              }
-            }
-          } finally {
-            // Always track cost here — this path has the best data
-            // (both costInUsd from inline chunks and generationId).
-            assistant.trackAiUsageCost(senderMatrixUserId, {
-              costInUsd,
-              generationId,
-            });
-            activeGenerations.delete(room.roomId);
-          }
-
-          if (shouldSetRoomTitle(eventList, aiBotUserId, event)) {
+          if (
+            generationCompleted &&
+            shouldSetRoomTitle(eventList, aiBotUserId, event)
+          ) {
             // Intentionally do not await setTitle - let it run async so that
             // the room lock gets released asap after finalizing the response.
             // This is important because tool call results may arrive

--- a/packages/ai-bot/tests/credit-tracking-test.ts
+++ b/packages/ai-bot/tests/credit-tracking-test.ts
@@ -1,6 +1,54 @@
 import { module, test } from 'qunit';
 import FakeTimers from '@sinonjs/fake-timers';
-import { waitForPendingCreditTracking } from '../lib/credit-tracking.ts';
+import type { DBAdapter } from '@cardstack/runtime-common';
+import {
+  waitForPendingCreditTracking,
+  scheduleFallbackCostTracking,
+} from '../lib/credit-tracking.ts';
+
+// Minimal in-memory DBAdapter that answers just the queries the billing
+// spend path issues for a free-plan user with ample daily credits, and
+// records every credits_ledger INSERT so tests can assert the debit.
+function makeFakeAdapter() {
+  let inserts: { sql: string; bind: unknown[] }[] = [];
+  let adapter = {
+    kind: 'pg' as const,
+    isClosed: false,
+    async execute(sql: string, opts?: { bind?: unknown[] }) {
+      let bind = opts?.bind ?? [];
+      if (sql.includes('INSERT INTO credits_ledger')) {
+        inserts.push({ sql, bind });
+        return [];
+      }
+      if (sql.includes('FROM users')) {
+        return [
+          {
+            id: 'user-1',
+            matrix_user_id: bind[0] ?? '@user:localhost',
+            stripe_customer_id: null,
+            stripe_customer_email: null,
+            matrix_registration_token: null,
+            session_room_id: null,
+          },
+        ];
+      }
+      if (sql.includes('FROM subscriptions')) {
+        return []; // no active subscription => free plan
+      }
+      if (sql.includes('SUM(credit_amount)')) {
+        return [{ sum: '1000' }]; // plenty of daily/extra credits
+      }
+      return [];
+    },
+    close: async () => {},
+    getColumnNames: async () => [],
+    notify: async () => {},
+    withWriteLock: async (_realmUrl: string, fn: (q: undefined) => unknown) =>
+      fn(undefined),
+    withUserCostLock: async (_userId: string, fn: () => unknown) => fn(),
+  };
+  return { adapter: adapter as unknown as DBAdapter, inserts };
+}
 
 module('Credit Tracking', () => {
   test('waitForPendingCreditTracking does not block indefinitely on slow credit tracking', async (assert) => {
@@ -82,5 +130,88 @@ module('Credit Tracking', () => {
     let result = await waitForPendingCreditTracking(map, '@user:localhost');
 
     assert.strictEqual(result.error, undefined, 'Should resolve with no error');
+  });
+
+  test('scheduleFallbackCostTracking registers, debits, then clears the map entry', async (assert) => {
+    let { adapter, inserts } = makeFakeAdapter();
+    let originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { total_cost: 0.005 } }),
+    });
+    try {
+      let map = new Map<string, Promise<void>>();
+      scheduleFallbackCostTracking({
+        dbAdapter: adapter,
+        matrixUserId: '@user:localhost',
+        generationId: 'gen-1',
+        openRouterApiKey: 'test-key',
+        trackAiUsageCostPromises: map,
+      });
+
+      assert.ok(
+        map.has('@user:localhost'),
+        'fallback promise is registered synchronously so waitForPendingCreditTracking can observe it',
+      );
+
+      await map.get('@user:localhost');
+
+      assert.strictEqual(
+        inserts.length,
+        1,
+        'the fetched generation cost is debited',
+      );
+      assert.true(
+        inserts[0].bind.includes(-5),
+        'debit is 5 credits (0.005 USD * 1000)',
+      );
+      assert.false(
+        map.has('@user:localhost'),
+        'map entry is removed once the debit settles',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('scheduleFallbackCostTracking debits every scheduled fallback — no coalescing', async (assert) => {
+    let { adapter, inserts } = makeFakeAdapter();
+    let originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { total_cost: 0.005 } }),
+    });
+    try {
+      let map = new Map<string, Promise<void>>();
+
+      scheduleFallbackCostTracking({
+        dbAdapter: adapter,
+        matrixUserId: '@user:localhost',
+        generationId: 'gen-1',
+        openRouterApiKey: 'test-key',
+        trackAiUsageCostPromises: map,
+      });
+      let first = map.get('@user:localhost');
+      scheduleFallbackCostTracking({
+        dbAdapter: adapter,
+        matrixUserId: '@user:localhost',
+        generationId: 'gen-2',
+        openRouterApiKey: 'test-key',
+        trackAiUsageCostPromises: map,
+      });
+      let second = map.get('@user:localhost');
+
+      await Promise.all([first, second]);
+
+      assert.strictEqual(
+        inserts.length,
+        2,
+        'both same-user fallbacks are debited — the old in-memory barrier early-returned and silently dropped the second',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/ai-bot/tests/credit-tracking-test.ts
+++ b/packages/ai-bot/tests/credit-tracking-test.ts
@@ -214,4 +214,65 @@ module('Credit Tracking', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test('an earlier fallback settling does not unlink a newer same-user entry', async (assert) => {
+    let { adapter } = makeFakeAdapter();
+    let resolvers: Record<string, () => void> = {};
+    let originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = (url: string) => {
+      let id = new URL(url).searchParams.get('id')!;
+      return new Promise((resolve) => {
+        resolvers[id] = () =>
+          resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ data: { total_cost: 0.001 } }),
+          });
+      });
+    };
+    try {
+      let map = new Map<string, Promise<void>>();
+      scheduleFallbackCostTracking({
+        dbAdapter: adapter,
+        matrixUserId: '@u:localhost',
+        generationId: 'gen-1',
+        openRouterApiKey: 'k',
+        trackAiUsageCostPromises: map,
+      });
+      let first = map.get('@u:localhost');
+      scheduleFallbackCostTracking({
+        dbAdapter: adapter,
+        matrixUserId: '@u:localhost',
+        generationId: 'gen-2',
+        openRouterApiKey: 'k',
+        trackAiUsageCostPromises: map,
+      });
+      let second = map.get('@u:localhost');
+      assert.notStrictEqual(
+        first,
+        second,
+        'the second fallback chained a new map entry',
+      );
+
+      // Settle the EARLIER fallback first — it must not delete the chained
+      // entry that now also represents the still-pending second fallback.
+      resolvers['gen-1']();
+      await first;
+      assert.strictEqual(
+        map.get('@u:localhost'),
+        second,
+        'the newer chained entry survives the earlier debit settling',
+      );
+
+      // Settling the second drains the chain and clears the entry.
+      resolvers['gen-2']();
+      await second;
+      assert.false(
+        map.has('@u:localhost'),
+        'the entry is removed once all chained debits settle',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });


### PR DESCRIPTION
_(Written by Claude on Matic's behalf.)_

Fixes **CS-11504** and **CS-11505** — both HIGH severity.

## What was broken

The ai-bot locked credit checking **per room**, not per user, and recorded costs *after* generating.

- **Overspend (CS-11504):** one user firing requests across N rooms passed the balance check N times against the same stale balance → balance goes arbitrarily negative.
- **Uncharged usage (CS-11505):** cost tracking dropped the charge if a prior one was still in flight (`if (trackAiUsageCostPromises.has(user)) return`) → a steady stream of messages = free generations.

## The fix

Wrap **check credits → generate → charge** in the per-user `withUserCostLock` that the realm-server proxy paths already use. The charge is awaited *inside* the lock, so a concurrent same-user request blocks until the prior charge lands and then validates against the real balance. Every generation's cost is recorded (no more drop-if-busy).

## Where to look

| File | Change |
|------|--------|
| `ai-bot/main.ts` | wrap the credit/generate/charge block in `withUserCostLock` (most of the diff is just re-indentation from nesting) |
| `ai-bot/lib/credit-tracking.ts` | fallback cost helper for the rare no-inline-cost case (never coalesces) |
| `ai-bot/tests/credit-tracking-test.ts` | tests for no-dropped-charges + fallback bookkeeping |

🤖 Generated with [Claude Code](https://claude.com/claude-code)