### PR TITLE
Unified search: the v2 <SearchResults> component + host consumer

### DIFF
--- a/packages/host/app/components/card-search/hydratable-card.gts
+++ b/packages/host/app/components/card-search/hydratable-card.gts
@@ -9,6 +9,7 @@ import { consume } from 'ember-provide-consume-context';
 import {
   CardContextName,
   GetCardContextName,
+  type Format,
   type ResolvedCodeRef,
   type StoreReadType,
   type getCard,
@@ -84,6 +85,9 @@ interface Signature {
     isError?: boolean;
     // The hydration gesture (defaults to `none`).
     mode?: HydrationMode;
+    // The format the live/hydrated card renders as, so it matches the
+    // prerendered HTML the query selected (defaults to `fitted`).
+    format?: Format;
   };
 }
 
@@ -134,6 +138,10 @@ export default class HydratableCard extends Component<Signature> {
       return 'none';
     }
     return this.args.mode ?? 'none';
+  }
+
+  private get format(): Format {
+    return this.args.format ?? 'fitted';
   }
 
   // The resolved live instance — a `CardDef` or a `FileDef`. Short-circuits
@@ -191,7 +199,7 @@ export default class HydratableCard extends Component<Signature> {
           needed. }}
       <CardRenderer
         @card={{this.liveCard}}
-        @format='fitted'
+        @format={{this.format}}
         @codeRef={{@renderType}}
         @displayContainer={{false}}
         data-hydration={{this.hydrationState}}

--- a/packages/host/app/components/card-search/search-results.gts
+++ b/packages/host/app/components/card-search/search-results.gts
@@ -5,10 +5,14 @@ import { modifier } from 'ember-modifier';
 
 import {
   isResolvedCodeRef,
+  isValidPrerenderedHtmlFormat,
+  logger as runtimeLogger,
   type CardResource,
   type ErrorEntry,
   type FileMetaResource,
+  type Format,
   type HtmlQuery,
+  type PrerenderedHtmlFormat,
   type ResolvedCodeRef,
   type Saved,
   type SearchEntryCollectionDocument,
@@ -67,6 +71,19 @@ function renderTypeFromHtmlQuery(
   return undefined;
 }
 
+// The query's requested format, echoed once at the document level. Used so an
+// item-only (live) fallback renders at the same format the HTML rows the query
+// selected would have. A composite html query (no single `eq` leaf) and the
+// default both fall back to `fitted`.
+function formatFromHtmlQuery(
+  query: HtmlQuery | undefined,
+): PrerenderedHtmlFormat {
+  if (query && 'eq' in query && isValidPrerenderedHtmlFormat(query.eq.format)) {
+    return query.eq.format;
+  }
+  return 'fitted';
+}
+
 // One v2 search result as a renderable view-model. Wraps the resource's raw
 // `SearchEntry`, exposing the chosen `html` rendering, the raw `item`
 // serialization, and a ready-to-render `component` that renders HTML inert (and
@@ -76,6 +93,7 @@ class RenderableSearchEntry {
   constructor(
     private raw: SearchEntry,
     private fallbackRenderType: ResolvedCodeRef | undefined,
+    private fallbackFormat: PrerenderedHtmlFormat,
     private mode: HydrationMode,
   ) {}
 
@@ -119,6 +137,13 @@ class RenderableSearchEntry {
     return this.html ? this.html.renderType : this.fallbackRenderType;
   }
 
+  // The format the live/hydrated card renders as: the rendering's own format for
+  // an HTML-backed row, the query's requested format for an item-only fallback
+  // (so it matches its HTML siblings).
+  get format(): Format {
+    return this.html ? this.html.format : this.fallbackFormat;
+  }
+
   // Built once, lazily: an inert row never reaches here, and an unchanged row
   // keeps the same component object across live re-runs (its view-model is
   // memoized by raw-entry identity), so the rendered list stays render-stable.
@@ -135,6 +160,7 @@ class RenderableSearchEntry {
         component: inert,
         renderType: this.renderType,
         type: this.type,
+        format: this.format,
         isError: this.isError,
         mode: this.mode,
       });
@@ -190,6 +216,12 @@ export default class SearchResults extends Component<Signature> {
   // object identity across live re-runs when nothing about it changed, so the
   // same render-stable view-model (and its built component) is reused.
   #renderables = new WeakMap<SearchEntry, RenderableSearchEntry>();
+  // The render inputs a view-model captures at construction (gesture mode + the
+  // document-level fallback render type/format). They are not part of a row's
+  // raw identity, so when any of them changes the memoized view-models are
+  // stale and the cache is dropped.
+  #renderInputsKey: string | undefined;
+  #log = runtimeLogger('search-results');
 
   private get mode(): HydrationMode {
     return this.args.mode ?? 'hover';
@@ -199,15 +231,35 @@ export default class SearchResults extends Component<Signature> {
     return renderTypeFromHtmlQuery(this.searchEntries.meta.htmlQuery);
   }
 
+  private get fallbackFormat(): PrerenderedHtmlFormat {
+    return formatFromHtmlQuery(this.searchEntries.meta.htmlQuery);
+  }
+
   private get entries(): RenderableSearchEntry[] {
-    let fallback = this.fallbackRenderType;
+    let fallbackRenderType = this.fallbackRenderType;
+    let fallbackFormat = this.fallbackFormat;
     let mode = this.mode;
+    let inputsKey = JSON.stringify([mode, fallbackRenderType, fallbackFormat]);
+    if (inputsKey !== this.#renderInputsKey) {
+      // Pure memoization bookkeeping — see the per-row note below. Dropping the
+      // cache when the captured inputs change rebuilds view-models with the new
+      // mode/render type/format instead of reusing stale ones.
+      // eslint-disable-next-line ember/no-side-effects
+      this.#renderInputsKey = inputsKey;
+      // eslint-disable-next-line ember/no-side-effects
+      this.#renderables = new WeakMap();
+    }
     return this.searchEntries.entries.map((raw) => {
       let existing = this.#renderables.get(raw);
       if (existing) {
         return existing;
       }
-      let renderable = new RenderableSearchEntry(raw, fallback, mode);
+      let renderable = new RenderableSearchEntry(
+        raw,
+        fallbackRenderType,
+        fallbackFormat,
+        mode,
+      );
       // Pure memoization keyed on the resource's stable entry identity — it
       // dirties no tracked state, and keeping unchanged rows' view-models (and
       // their built components) prevents a live re-run from re-mounting every
@@ -236,7 +288,17 @@ export default class SearchResults extends Component<Signature> {
     (_element: Element, [entries]: [RenderableSearchEntry[]]) => {
       for (let entry of entries) {
         if (entry.item) {
-          void this.store.inflateSearchEntryItem(entry.item);
+          // Fire-and-forget; a deposit failure (e.g. a malformed resource)
+          // must not reject unhandled mid-render — the row still renders
+          // (resolving its instance on demand) and the next re-run retries.
+          this.store
+            .inflateSearchEntryItem(entry.item)
+            .catch((err: unknown) => {
+              this.#log.error(
+                `failed to inflate search-entry item ${entry.id}`,
+                err,
+              );
+            });
         }
       }
     },

--- a/packages/host/app/components/card-search/search-results.gts
+++ b/packages/host/app/components/card-search/search-results.gts
@@ -1,0 +1,266 @@
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import { modifier } from 'ember-modifier';
+
+import {
+  isResolvedCodeRef,
+  type CardResource,
+  type ErrorEntry,
+  type FileMetaResource,
+  type HtmlQuery,
+  type ResolvedCodeRef,
+  type Saved,
+  type SearchEntryCollectionDocument,
+  type SearchEntryWireQuery,
+  type StoreReadType,
+} from '@cardstack/runtime-common';
+
+import { htmlComponent } from '../../lib/html-component';
+import {
+  hydratableEntryComponent,
+  type EntryComponent,
+} from '../../lib/hydratable-entry-component';
+import {
+  getSearchEntriesResource,
+  type SearchEntry,
+  type SearchEntryRendering,
+} from '../../resources/search-entries';
+
+import type { HydrationMode } from './hydratable-card';
+
+import type StoreService from '../../services/store';
+
+// The diagnostic/labeling attributes the prerendered HTML carries so consumers
+// (e.g. the operator-mode overlay) can label and icon a card before its
+// instance loads — mirrors what the legacy prerendered path stamped.
+function extraAttributesFor(
+  rendering: SearchEntryRendering,
+): Record<string, string> {
+  let attrs: Record<string, string> = {};
+  if (rendering.isError) {
+    attrs['data-is-error'] = 'true';
+  }
+  if (rendering.cardType) {
+    attrs['data-card-type-display-name'] = rendering.cardType;
+  }
+  if (rendering.iconHtml) {
+    attrs['data-card-type-icon-html'] = rendering.iconHtml;
+  }
+  return attrs;
+}
+
+// The query's requested render type, echoed once at the document level. Used
+// to render an item-only (live) fallback as the same ancestor its HTML
+// siblings would have rendered as. Only a single `eq` leaf names one type; a
+// composite html query has no single render type, so the fallback renders
+// natively.
+function renderTypeFromHtmlQuery(
+  query: HtmlQuery | undefined,
+): ResolvedCodeRef | undefined {
+  if (query && 'eq' in query) {
+    let renderType = query.eq.renderType;
+    if (renderType && isResolvedCodeRef(renderType)) {
+      return renderType;
+    }
+  }
+  return undefined;
+}
+
+// One v2 search result as a renderable view-model. Wraps the resource's raw
+// `SearchEntry`, exposing the chosen `html` rendering, the raw `item`
+// serialization, and a ready-to-render `component` that renders HTML inert (and
+// hydrates it lazily) or resolves a full live row — so a consumer renders
+// `<entry.component />` without branching on prerendered-vs-live.
+class RenderableSearchEntry {
+  constructor(
+    private raw: SearchEntry,
+    private fallbackRenderType: ResolvedCodeRef | undefined,
+    private mode: HydrationMode,
+  ) {}
+
+  get id(): string {
+    return this.raw.id;
+  }
+
+  // The chosen prerendered rendering. The query's htmlQuery selects one
+  // format × render type, so the resource's `html` array holds at most the one
+  // matching rendering. Absent → an item-only (live) row.
+  get html(): SearchEntryRendering | undefined {
+    return this.raw.html[0];
+  }
+
+  // The raw live serialization branch (full or sparse), when present.
+  get item(): CardResource<Saved> | FileMetaResource | undefined {
+    return this.raw.item;
+  }
+
+  get isError(): boolean {
+    return this.html?.isError ?? false;
+  }
+
+  // `card` vs `file-meta`: the serialization carries its own type; an HTML-only
+  // row is a file when its rendering carries no render type (files render
+  // natively; a card rendering always names one).
+  get type(): StoreReadType {
+    if (this.item) {
+      return this.item.type === 'file-meta' ? 'file-meta' : 'card';
+    }
+    if (this.html && !this.html.renderType) {
+      return 'file-meta';
+    }
+    return 'card';
+  }
+
+  // The type the live/hydrated card renders as: the rendering's own resolved
+  // type for an HTML-backed row, the query's requested ancestor for an
+  // item-only fallback (so it matches its HTML siblings), else native.
+  get renderType(): ResolvedCodeRef | undefined {
+    return this.html ? this.html.renderType : this.fallbackRenderType;
+  }
+
+  // Built once, lazily: an inert row never reaches here, and an unchanged row
+  // keeps the same component object across live re-runs (its view-model is
+  // memoized by raw-entry identity), so the rendered list stays render-stable.
+  #component: EntryComponent | undefined;
+  get component(): EntryComponent {
+    if (this.#component === undefined) {
+      let { html } = this;
+      let inert =
+        html && html.html != null
+          ? htmlComponent(html.html, extraAttributesFor(html))
+          : undefined;
+      this.#component = hydratableEntryComponent({
+        cardId: this.id,
+        component: inert,
+        renderType: this.renderType,
+        type: this.type,
+        isError: this.isError,
+        mode: this.mode,
+      });
+    }
+    return this.#component;
+  }
+}
+
+// The block argument: the heterogeneous result stream plus its loading/meta/
+// error state. Mirrors the documented public API (`results.entries` /
+// `.isLoading` / `.meta` / `.errors`).
+export interface SearchResultsYield {
+  entries: RenderableSearchEntry[];
+  isLoading: boolean;
+  meta: SearchEntryCollectionDocument['meta'];
+  errors: ErrorEntry[] | undefined;
+}
+
+interface Signature {
+  Element: HTMLElement;
+  Args: {
+    // The `search-entry`-rooted v2 query. Re-issued live on invalidation;
+    // changing it re-runs the search. Undefined → idle (no results).
+    query: SearchEntryWireQuery | undefined;
+    // The hydration gesture for HTML-backed rows — a host-UX choice, never on
+    // the wire. A full live row ignores it. Defaults to `hover` (the fitted
+    // fast path); pass `none` to keep rows inert, `click`/`touch` to gate on
+    // those gestures.
+    mode?: HydrationMode;
+  };
+  Blocks: {
+    default: [SearchResultsYield];
+  };
+}
+
+// The one v2 search component family. Consumes the heterogeneous `search-entry`
+// stream from `getSearchEntriesResource` and renders it transparently —
+// prerendered HTML inert (the fast path, hydrated lazily on interaction) or the
+// live serialization. Used with a block it yields a `results` object
+// (`entries` / `isLoading` / `meta` / `errors`); used without one it renders
+// the default stream of `entry.component`s itself. Additive: it supersedes the
+// `prerendered-card-search` component and the live `SearchContent` tree as call
+// sites migrate.
+export default class SearchResults extends Component<Signature> {
+  @service declare private store: StoreService;
+
+  // Created once per component (the resource owns its own realm subscriptions
+  // and re-runs); the query varies through the reactive thunk, never by
+  // rebuilding the resource.
+  private searchEntries = getSearchEntriesResource(this, () => this.args.query);
+
+  // View-models memoized by raw-entry identity: the resource preserves a row's
+  // object identity across live re-runs when nothing about it changed, so the
+  // same render-stable view-model (and its built component) is reused.
+  #renderables = new WeakMap<SearchEntry, RenderableSearchEntry>();
+
+  private get mode(): HydrationMode {
+    return this.args.mode ?? 'hover';
+  }
+
+  private get fallbackRenderType(): ResolvedCodeRef | undefined {
+    return renderTypeFromHtmlQuery(this.searchEntries.meta.htmlQuery);
+  }
+
+  private get entries(): RenderableSearchEntry[] {
+    let fallback = this.fallbackRenderType;
+    let mode = this.mode;
+    return this.searchEntries.entries.map((raw) => {
+      let existing = this.#renderables.get(raw);
+      if (existing) {
+        return existing;
+      }
+      let renderable = new RenderableSearchEntry(raw, fallback, mode);
+      // Pure memoization keyed on the resource's stable entry identity — it
+      // dirties no tracked state, and keeping unchanged rows' view-models (and
+      // their built components) prevents a live re-run from re-mounting every
+      // HydratableCard.
+      // eslint-disable-next-line ember/no-side-effects
+      this.#renderables.set(raw, renderable);
+      return renderable;
+    });
+  }
+
+  private get results(): SearchResultsYield {
+    return {
+      entries: this.entries,
+      isLoading: this.searchEntries.isLoading,
+      meta: this.searchEntries.meta,
+      errors: this.searchEntries.errors,
+    };
+  }
+
+  // Selective Store inflate: deposit only full `item` serializations so a
+  // by-URL read (or the hydration GET) resolves without a round-trip. Sparse
+  // items and `search-entry`s are never deposited (the store method no-ops on a
+  // sparse item). A render-side effect keyed on the live entry set, so it
+  // deposits an item-bearing row whenever one lands on a re-run.
+  private inflateFullItems = modifier(
+    (_element: Element, [entries]: [RenderableSearchEntry[]]) => {
+      for (let entry of entries) {
+        if (entry.item) {
+          void this.store.inflateSearchEntryItem(entry.item);
+        }
+      }
+    },
+  );
+
+  <template>
+    <div
+      class='search-results'
+      {{this.inflateFullItems this.entries}}
+      data-test-search-results
+      ...attributes
+    >
+      {{#if (has-block)}}
+        {{yield this.results}}
+      {{else}}
+        {{#each this.results.entries key='id' as |entry|}}
+          <entry.component data-test-search-result={{entry.id}} />
+        {{/each}}
+      {{/if}}
+    </div>
+    <style scoped>
+      .search-results {
+        display: contents;
+      }
+    </style>
+  </template>
+}

--- a/packages/host/app/lib/hydratable-entry-component.ts
+++ b/packages/host/app/lib/hydratable-entry-component.ts
@@ -1,0 +1,107 @@
+import {
+  capabilities,
+  setComponentManager,
+  setComponentTemplate,
+} from '@ember/component';
+import { precompileTemplate } from '@ember/template-compilation';
+
+import type { ResolvedCodeRef, StoreReadType } from '@cardstack/runtime-common';
+
+import HydratableCard, {
+  type HydrationMode,
+} from '../components/card-search/hydratable-card';
+
+import type { HTMLComponent } from './html-component';
+import type { ComponentLike } from '@glint/template';
+
+// A `<SearchResults>` entry's ready-to-render component, curried in JS so each
+// entry can carry its own `.component` and consumers invoke `<entry.component
+// />` without branching on prerendered-vs-live. It wraps `HydratableCard`,
+// which renders the inert HTML for an HTML-backed row and swaps in a live
+// `<CardRenderer>` on the hydration gesture, or resolves a full live row
+// immediately. Currying through a custom component manager (the same shape
+// `html-component.ts` uses) compiles the wrapping template once and varies the
+// `HydratableCard` args per entry — context still propagates to the nested
+// `HydratableCard` because the glimmer VM tracks provide/consume context per
+// component instance regardless of manager.
+export interface HydratableEntryArgs {
+  // The card/file identity URL — also the hydration GET target.
+  cardId: string;
+  // The inert prerendered HTML for an HTML-backed row; absent for a full live
+  // row, which resolves to its live instance with nothing to stay inert as.
+  component?: HTMLComponent;
+  // The ancestor type the live/hydrated card renders as, so it matches its
+  // prerendered-HTML siblings. Files render natively (undefined).
+  renderType?: ResolvedCodeRef;
+  // `card` (default) or `file-meta` — the resource type the row resolves to.
+  type?: StoreReadType;
+  // An error rendering never hydrates.
+  isError: boolean;
+  // The hydration gesture for an HTML-backed row.
+  mode: HydrationMode;
+}
+
+class _HydratableEntryComponent {
+  constructor(
+    readonly cardId: string,
+    readonly component: HTMLComponent | undefined,
+    readonly renderType: ResolvedCodeRef | undefined,
+    readonly type: StoreReadType | undefined,
+    readonly isError: boolean,
+    readonly mode: HydrationMode,
+  ) {}
+}
+
+setComponentTemplate(
+  precompileTemplate(
+    `<HydratableCard
+      @cardId={{this.cardId}}
+      @component={{this.component}}
+      @renderType={{this.renderType}}
+      @type={{this.type}}
+      @isError={{this.isError}}
+      @mode={{this.mode}}
+      ...attributes
+    />`,
+    {
+      strictMode: true,
+      scope: () => ({ HydratableCard }),
+    },
+  ),
+  _HydratableEntryComponent.prototype,
+);
+
+type ComponentManager = ReturnType<Parameters<typeof setComponentManager>[0]>;
+
+class HydratableEntryComponentManager implements ComponentManager {
+  capabilities = capabilities('3.13', {});
+  static create(_owner: unknown) {
+    return new HydratableEntryComponentManager();
+  }
+  createComponent(entryComponent: _HydratableEntryComponent, _args: unknown) {
+    return entryComponent;
+  }
+  getContext(entryComponent: _HydratableEntryComponent) {
+    return entryComponent;
+  }
+}
+
+setComponentManager(
+  (owner) => HydratableEntryComponentManager.create(owner),
+  _HydratableEntryComponent.prototype,
+);
+
+export type EntryComponent = ComponentLike<{ Element: Element; Args: {} }>;
+
+export function hydratableEntryComponent(
+  args: HydratableEntryArgs,
+): EntryComponent {
+  return new _HydratableEntryComponent(
+    args.cardId,
+    args.component,
+    args.renderType,
+    args.type,
+    args.isError,
+    args.mode,
+  ) as unknown as EntryComponent;
+}

--- a/packages/host/app/lib/hydratable-entry-component.ts
+++ b/packages/host/app/lib/hydratable-entry-component.ts
@@ -5,7 +5,11 @@ import {
 } from '@ember/component';
 import { precompileTemplate } from '@ember/template-compilation';
 
-import type { ResolvedCodeRef, StoreReadType } from '@cardstack/runtime-common';
+import type {
+  Format,
+  ResolvedCodeRef,
+  StoreReadType,
+} from '@cardstack/runtime-common';
 
 import HydratableCard, {
   type HydrationMode,
@@ -35,6 +39,9 @@ export interface HydratableEntryArgs {
   renderType?: ResolvedCodeRef;
   // `card` (default) or `file-meta` — the resource type the row resolves to.
   type?: StoreReadType;
+  // The format the live/hydrated card renders as, so it matches the
+  // prerendered HTML the query selected.
+  format: Format;
   // An error rendering never hydrates.
   isError: boolean;
   // The hydration gesture for an HTML-backed row.
@@ -47,6 +54,7 @@ class _HydratableEntryComponent {
     readonly component: HTMLComponent | undefined,
     readonly renderType: ResolvedCodeRef | undefined,
     readonly type: StoreReadType | undefined,
+    readonly format: Format,
     readonly isError: boolean,
     readonly mode: HydrationMode,
   ) {}
@@ -59,6 +67,7 @@ setComponentTemplate(
       @component={{this.component}}
       @renderType={{this.renderType}}
       @type={{this.type}}
+      @format={{this.format}}
       @isError={{this.isError}}
       @mode={{this.mode}}
       ...attributes
@@ -101,6 +110,7 @@ export function hydratableEntryComponent(
     args.component,
     args.renderType,
     args.type,
+    args.format,
     args.isError,
     args.mode,
   ) as unknown as EntryComponent;

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -30,6 +30,7 @@ import {
   isSingleCardDocument,
   isSingleFileMetaDocument,
   isSearchEntryCollectionDocument,
+  isSparseItemResource,
   resolveFileDefCodeRef,
   searchEntryDocToLinkableDoc,
   searchEntryWireQueryFromQuery,
@@ -1033,6 +1034,22 @@ export default class StoreService extends Service implements StoreInterface {
       return { data: [], meta: { page: { total: 0 } } };
     }
     return await this.fetchSearchEntryDoc(query, searchRealms);
+  }
+
+  // Selective inflate for a `<SearchResults>` consumer of `searchEntries`:
+  // deposit one full `item` serialization into the store so a by-URL read (or
+  // the hydration GET) resolves it without a round-trip. A sparse `item` (one
+  // carrying `meta.sparseFields`) is never deposited — it would misrepresent
+  // the instance and could clobber a correctly-loaded full one — so the call
+  // is a no-op for it; `search-entry`s carry no serialization to deposit.
+  // Idempotent: an already-resident instance is returned as-is.
+  async inflateSearchEntryItem(
+    resource: CardResource<Saved> | FileMetaResource,
+  ): Promise<void> {
+    if (isSparseItemResource(resource)) {
+      return;
+    }
+    await this.addResourceFromSearchData(resource);
   }
 
   private normalizeSearchRealms(realms: string[] | undefined): string[] {

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1042,7 +1042,7 @@ export default class StoreService extends Service implements StoreInterface {
   // carrying `meta.sparseFields`) is never deposited — it would misrepresent
   // the instance and could clobber a correctly-loaded full one — so the call
   // is a no-op for it; `search-entry`s carry no serialization to deposit.
-  // Idempotent: an already-resident instance is returned as-is.
+  // Idempotent: depositing is skipped when the instance is already resident.
   async inflateSearchEntryItem(
     resource: CardResource<Saved> | FileMetaResource,
   ): Promise<void> {

--- a/packages/host/tests/integration/components/search-results-test.gts
+++ b/packages/host/tests/integration/components/search-results-test.gts
@@ -1,0 +1,463 @@
+import {
+  type RenderingTestContext,
+  render,
+  triggerEvent,
+  waitUntil,
+} from '@ember/test-helpers';
+
+import GlimmerComponent from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import { getService } from '@universal-ember/test-support';
+import { provide } from 'ember-provide-consume-context';
+
+import { module, test } from 'qunit';
+
+import {
+  htmlResourceId,
+  isCardInstance,
+  CardContextName,
+  CssResourceType,
+  GetCardContextName,
+  HtmlResourceType,
+  SearchEntryResourceType,
+  type CardResource,
+  type Loader,
+  type Saved,
+  type SearchEntryIncludedResource,
+  type SearchEntryResults,
+  type SearchEntryWireQuery,
+} from '@cardstack/runtime-common';
+
+import SearchResults from '@cardstack/host/components/card-search/search-results';
+import { getCard } from '@cardstack/host/resources/card-resource';
+import type StoreService from '@cardstack/host/services/store';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+  testRRI,
+} from '../../helpers';
+import {
+  CardDef,
+  Component,
+  contains,
+  field,
+  StringField,
+  setupBaseRealm,
+} from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+type SearchEntryWireResource = SearchEntryResults['data'][number];
+
+// Provides the context `<SearchResults>`'s rendered `HydratableCard`s consume:
+// `getCard` (always, the way the route does). No operator-mode overlay is
+// provided — host mode / published views render without one.
+class TestContext extends GlimmerComponent<{ Blocks: { default: [] } }> {
+  @provide(GetCardContextName)
+  get getCardFn() {
+    return getCard;
+  }
+  @provide(CardContextName)
+  get cardContext() {
+    return undefined;
+  }
+
+  <template>
+    {{! template-lint-disable no-yield-only }}
+    {{yield}}
+  </template>
+}
+
+class QueryState {
+  @tracked query: SearchEntryWireQuery | undefined = undefined;
+}
+
+const bookRef = { module: testRRI('book'), name: 'Book' };
+const BOOK_1 = `${testRealmURL}books/1`;
+const BOOK_2 = `${testRealmURL}books/2`;
+const CSS_HREF = `${testRealmURL}book.gts.abc123.glimmer-scoped.css`;
+
+function renderingIdFor(url: string): string {
+  return htmlResourceId({ url, format: 'fitted', renderType: bookRef });
+}
+
+// The `search-entry` resource pointing at a prerendered rendering.
+function htmlEntryResource(url: string): SearchEntryWireResource {
+  return {
+    type: SearchEntryResourceType,
+    id: url,
+    relationships: {
+      html: { data: [{ type: HtmlResourceType, id: renderingIdFor(url) }] },
+    },
+  };
+}
+
+// The `html` rendering (plus its scoped stylesheet) for an html-backed entry.
+function htmlIncluded(
+  url: string,
+  html: string,
+  isError = false,
+): SearchEntryIncludedResource[] {
+  return [
+    {
+      type: HtmlResourceType,
+      id: renderingIdFor(url),
+      attributes: {
+        html,
+        cardType: 'Book',
+        isError,
+        format: 'fitted',
+        renderType: bookRef,
+      },
+      relationships: {
+        styles: { data: [{ type: CssResourceType, id: 'deadbeef' }] },
+      },
+    },
+    {
+      type: CssResourceType,
+      id: 'deadbeef',
+      attributes: { href: CSS_HREF },
+    },
+  ];
+}
+
+// The `search-entry` resource pointing at an `item` serialization.
+function itemEntryResource(url: string): SearchEntryWireResource {
+  return {
+    type: SearchEntryResourceType,
+    id: url,
+    relationships: { item: { data: { type: 'card', id: url } } },
+  };
+}
+
+// A full live serialization for one of the seeded books, optionally marked
+// sparse. Built to be valid enough for the store to instantiate.
+function bookItem(
+  url: string,
+  title: string,
+  opts?: { sparseFields?: string[] },
+): CardResource<Saved> {
+  return {
+    type: 'card',
+    id: url,
+    attributes: { title, status: 'ready' },
+    relationships: {},
+    meta: {
+      adoptsFrom: { module: testRRI('book'), name: 'Book' },
+      ...(opts?.sparseFields ? { sparseFields: opts.sparseFields } : {}),
+    },
+    links: { self: url },
+  } as unknown as CardResource<Saved>;
+}
+
+module('Integration | Component | search-results', function (hooks) {
+  let loader: Loader;
+  let storeService: StoreService;
+
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    loader = getService('loader-service').loader;
+    storeService = getService('store');
+
+    class Book extends CardDef {
+      static displayName = 'Book';
+      @field title = contains(StringField);
+      @field status = contains(StringField);
+      static fitted = class Fitted extends Component<typeof this> {
+        <template>
+          <div class='live-book' data-test-live-book>
+            Live:
+            <@fields.title />
+          </div>
+        </template>
+      };
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      realmURL: testRealmURL,
+      contents: {
+        'book.gts': { Book },
+        'books/1.json': new Book({ title: 'Mango', status: 'ready' }),
+        'books/2.json': new Book({ title: 'Van Gogh', status: 'ready' }),
+      },
+    });
+    await getService('realm').login(testRealmURL);
+  });
+
+  // Stub the v2 fetch with a manufactured document and short-circuit the
+  // stylesheet import for its fake css href. Returns the restore thunk.
+  function stubSearchEntries(doc: SearchEntryResults): () => void {
+    let originalSearchEntries = storeService.searchEntries.bind(storeService);
+    storeService.searchEntries = async () => doc;
+    let originalImport = loader.import.bind(loader);
+    loader.import = (async (url: string) =>
+      url === CSS_HREF ? {} : originalImport(url)) as Loader['import'];
+    return () => {
+      storeService.searchEntries = originalSearchEntries;
+      loader.import = originalImport;
+    };
+  }
+
+  test('renders prerendered HTML inert and hydrates it lazily on hover', async function (assert) {
+    let query: SearchEntryWireQuery = {
+      filter: { 'item.on': bookRef },
+      realms: [testRealmURL],
+    };
+    await render(
+      <template>
+        <TestContext>
+          <SearchResults @query={{query}} @mode='hover' />
+        </TestContext>
+      </template>,
+    );
+    await waitUntil(() =>
+      Boolean(document.querySelector('[data-test-search-result]')),
+    );
+
+    assert
+      .dom(`[data-test-search-result="${BOOK_1}"]`)
+      .exists('the first book result rendered');
+    assert
+      .dom(`[data-test-search-result="${BOOK_2}"]`)
+      .exists('the second book result rendered');
+    assert
+      .dom(`[data-test-hydratable-card="${BOOK_1}"][data-hydration="hover"]`)
+      .exists(
+        'an html-backed result starts inert with the hover gesture wired',
+      );
+    assert.notOk(
+      isCardInstance(storeService.peek(BOOK_1)),
+      'an html-only result is not deposited into the store',
+    );
+
+    await triggerEvent(`[data-test-hydratable-card="${BOOK_1}"]`, 'mouseenter');
+
+    assert
+      .dom(`[data-test-hydratable-card="${BOOK_1}"][data-hydration="hydrated"]`)
+      .exists('hovering hydrates the result into a live card');
+    assert.ok(
+      isCardInstance(storeService.peek(BOOK_1)),
+      'the hydration GET deposited the card into the store',
+    );
+  });
+
+  test('renders a heterogeneous stream: an html row inert, an item-only row live', async function (assert) {
+    let restore = stubSearchEntries({
+      data: [htmlEntryResource(BOOK_1), itemEntryResource(BOOK_2)],
+      included: [
+        ...htmlIncluded(BOOK_1, `<div data-test-inert-book>Mango</div>`),
+        bookItem(BOOK_2, 'Van Gogh'),
+      ],
+      meta: {
+        page: { total: 2 },
+        htmlQuery: { eq: { format: 'fitted', renderType: bookRef } },
+      },
+    });
+    try {
+      let query: SearchEntryWireQuery = {
+        filter: { 'item.on': bookRef },
+        realms: [testRealmURL],
+      };
+      await render(
+        <template>
+          <TestContext>
+            <SearchResults @query={{query}} @mode='hover' />
+          </TestContext>
+        </template>,
+      );
+      await waitUntil(() =>
+        Boolean(document.querySelector('[data-test-live-book]')),
+      );
+
+      // The html-backed row stays inert (its prerendered markup) with the
+      // gesture wired.
+      assert
+        .dom(`[data-test-hydratable-card="${BOOK_1}"][data-hydration="hover"]`)
+        .exists('the html row is inert');
+      assert
+        .dom('[data-test-inert-book]')
+        .exists('it shows its prerendered markup');
+
+      // The item-only row resolves live immediately (no gesture), as a full
+      // live card, and is deposited by the selective inflate.
+      assert
+        .dom(
+          `[data-test-hydratable-card="${BOOK_2}"][data-hydration="hydrated"]`,
+        )
+        .exists('the item-only row renders live without a gesture');
+      assert.dom('[data-test-live-book]').hasText('Live: Van Gogh');
+      assert.ok(
+        isCardInstance(storeService.peek(BOOK_2)),
+        'the full item was inflated into the store',
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test('selective Store inflate: a full item is deposited, a sparse item never is', async function (assert) {
+    // The store-level rule, independent of rendering: a full serialization
+    // deposits; a sparse one (carrying meta.sparseFields) is a no-op.
+    await storeService.inflateSearchEntryItem(bookItem(BOOK_1, 'Mango'));
+    assert.ok(
+      isCardInstance(storeService.peek(BOOK_1)),
+      'a full item is deposited into the store',
+    );
+
+    await storeService.inflateSearchEntryItem(
+      bookItem(BOOK_2, 'Van Gogh', { sparseFields: ['title'] }),
+    );
+    assert.notOk(
+      isCardInstance(storeService.peek(BOOK_2)),
+      'a sparse item is never deposited',
+    );
+  });
+
+  test('the component inflates a full item row into the store', async function (assert) {
+    let restore = stubSearchEntries({
+      data: [itemEntryResource(BOOK_1)],
+      included: [bookItem(BOOK_1, 'Mango')],
+      meta: { page: { total: 1 } },
+    });
+    try {
+      let query: SearchEntryWireQuery = {
+        filter: { 'item.on': bookRef },
+        fields: { 'search-entry': ['item'] },
+        realms: [testRealmURL],
+      };
+      await render(
+        <template>
+          <TestContext>
+            <SearchResults @query={{query}} />
+          </TestContext>
+        </template>,
+      );
+      await waitUntil(() => isCardInstance(storeService.peek(BOOK_1)));
+
+      assert.ok(
+        isCardInstance(storeService.peek(BOOK_1)),
+        'the full item row was deposited by the selective inflate',
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test('an error rendering never hydrates', async function (assert) {
+    let errorHtml = `<div data-test-inert-book data-is-error='true'>Last known good</div>`;
+    let restore = stubSearchEntries({
+      data: [htmlEntryResource(BOOK_1)],
+      included: htmlIncluded(BOOK_1, errorHtml, true),
+      meta: {
+        page: { total: 1 },
+        htmlQuery: { eq: { format: 'fitted', renderType: bookRef } },
+      },
+    });
+    try {
+      let query: SearchEntryWireQuery = {
+        filter: { 'item.on': bookRef },
+        realms: [testRealmURL],
+      };
+      await render(
+        <template>
+          <TestContext>
+            <SearchResults @query={{query}} @mode='hover' />
+          </TestContext>
+        </template>,
+      );
+      await waitUntil(() =>
+        Boolean(document.querySelector('[data-test-inert-book]')),
+      );
+
+      assert
+        .dom(`[data-test-hydratable-card="${BOOK_1}"][data-hydration="none"]`)
+        .exists('an error row is forced to none regardless of @mode');
+
+      await triggerEvent(
+        `[data-test-hydratable-card="${BOOK_1}"]`,
+        'mouseenter',
+      );
+
+      assert
+        .dom('[data-test-inert-book]')
+        .exists('the error rendering stays inert after hover');
+      assert.notOk(
+        isCardInstance(storeService.peek(BOOK_1)),
+        'no hydration GET fired for an error row',
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test('yields a results object to a block consumer', async function (assert) {
+    let query: SearchEntryWireQuery = {
+      filter: { 'item.on': bookRef },
+      realms: [testRealmURL],
+    };
+    await render(
+      <template>
+        <TestContext>
+          <SearchResults @query={{query}} as |results|>
+            <div data-test-total>{{results.meta.page.total}}</div>
+            <div data-test-count>{{results.entries.length}}</div>
+            {{#each results.entries key='id' as |entry|}}
+              <div class='custom' data-test-custom={{entry.id}}>
+                <entry.component />
+              </div>
+            {{/each}}
+          </SearchResults>
+        </TestContext>
+      </template>,
+    );
+    await waitUntil(() =>
+      Boolean(document.querySelector('[data-test-custom]')),
+    );
+
+    assert.dom('[data-test-total]').hasText('2', 'the page total is yielded');
+    assert.dom('[data-test-count]').hasText('2', 'both entries are yielded');
+    assert
+      .dom(`[data-test-custom="${BOOK_1}"] [data-test-hydratable-card]`)
+      .exists('the consumer renders each entry.component');
+  });
+
+  test('an undefined query renders nothing, then activates when set', async function (assert) {
+    let state = new QueryState();
+    await render(
+      <template>
+        <TestContext>
+          <SearchResults @query={{state.query}} />
+        </TestContext>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-search-result]')
+      .doesNotExist('an idle query renders no results');
+
+    state.query = { filter: { 'item.on': bookRef }, realms: [testRealmURL] };
+    await waitUntil(() =>
+      Boolean(document.querySelector('[data-test-search-result]')),
+    );
+    assert
+      .dom('[data-test-search-result]')
+      .exists({ count: 2 }, 'setting the query activates the search');
+  });
+
+  hooks.afterEach(function () {
+    getService('network').virtualNetwork.removeRealmMapping('@test-prefix/');
+  });
+});

--- a/packages/host/tests/integration/components/search-results-test.gts
+++ b/packages/host/tests/integration/components/search-results-test.gts
@@ -183,6 +183,14 @@ module('Integration | Component | search-results', function (hooks) {
           </div>
         </template>
       };
+      static embedded = class Embedded extends Component<typeof this> {
+        <template>
+          <div class='embedded-book' data-test-embedded-book>
+            Embedded:
+            <@fields.title />
+          </div>
+        </template>
+      };
     }
 
     await setupIntegrationTestRealm({
@@ -303,6 +311,45 @@ module('Integration | Component | search-results', function (hooks) {
         isCardInstance(storeService.peek(BOOK_2)),
         'the full item was inflated into the store',
       );
+    } finally {
+      restore();
+    }
+  });
+
+  test('a live fallback renders at the format the query selected', async function (assert) {
+    // An item-only row for an `embedded` search renders the live card at
+    // `embedded`, not the hardcoded `fitted`, so it matches the HTML rows the
+    // query would have produced.
+    let restore = stubSearchEntries({
+      data: [itemEntryResource(BOOK_1)],
+      included: [bookItem(BOOK_1, 'Mango')],
+      meta: {
+        page: { total: 1 },
+        htmlQuery: { eq: { format: 'embedded', renderType: bookRef } },
+      },
+    });
+    try {
+      let query: SearchEntryWireQuery = {
+        filter: { 'item.on': bookRef },
+        realms: [testRealmURL],
+      };
+      await render(
+        <template>
+          <TestContext>
+            <SearchResults @query={{query}} />
+          </TestContext>
+        </template>,
+      );
+      await waitUntil(() =>
+        Boolean(document.querySelector('[data-test-embedded-book]')),
+      );
+
+      assert
+        .dom('[data-test-embedded-book]')
+        .hasText('Embedded: Mango', 'the live fallback rendered at embedded');
+      assert
+        .dom('[data-test-live-book]')
+        .doesNotExist('it did not fall back to the fitted format');
     } finally {
       restore();
     }


### PR DESCRIPTION
The one v2 search component family, `<SearchResults @query=… />`, plus the host-side pieces it needs. Phase 1 of the [unified-search project](https://linear.app/cardstack/project/unify-prerendered-card-search-and-card-search-concepts-b6db4a4835ad). Additive — it sits alongside the existing `prerendered-card-search` component and the live `SearchContent` tree; **no call site is migrated in this PR** (each surface migrates as its own shippable step).

### What it does

`<SearchResults>` consumes the heterogeneous `search-entry` stream from `getSearchEntriesResource` and renders it transparently:

- a prerendered `html` rendering shows **inert** (the fast path) and **hydrates lazily** on interaction (`hover`/`click`/`touch`, or `none`),
- an `item`-only row renders as a **live card**.

Each result is a `RenderableSearchEntry` exposing `id` / `isError` / `html` / `item` / `component`. The `component` wraps the merged `HydratableCard` mechanism, so a consumer renders `<entry.component />` without ever branching on prerendered-vs-live — that's what makes the split transparent. It's curried in JS via the same custom-manager pattern `html-component.ts` already uses to yield a renderable `.component`; provide/consume context still reaches the nested `HydratableCard` because the glimmer VM tracks context per component instance regardless of manager.

Used **with a block** it yields a `results` object (`entries` / `isLoading` / `meta` / `errors`); used **without one** it renders the default stream of `entry.component`s itself.

```hbs
<SearchResults @query={{this.query}} as |results|>
  {{#each results.entries key='id' as |entry|}}
    <entry.component />
  {{/each}}
</SearchResults>
```

### Selective Store inflate

`StoreService.inflateSearchEntryItem` deposits **only full `item` serializations** (so a by-URL read or the hydration GET resolves without a round-trip). A **sparse `item`** (one carrying `meta.sparseFields`) and the `search-entry` itself are **never** deposited — a sparse item would misrepresent the instance and could clobber a correctly-loaded full one. `<SearchResults>` runs this as a render-side effect over the live entry set, so an item-bearing row deposits whenever one lands on a re-run.

### Render type

An html row hydrates/renders as the type its rendering carries; an item-only fallback renders as the query's requested ancestor (echoed once in the document `meta`) so it matches its HTML siblings; files render natively. View-models are memoized by the resource's stable entry identity, so a live re-run never re-mounts an unchanged row's component.

### Tests

`tests/integration/components/search-results-test.gts` (7 tests, all green against the realm stack):

- prerendered HTML renders inert and hydrates into a live card on hover;
- a heterogeneous stream renders the html row inert and the item-only row live;
- selective inflate — a full item is deposited, a sparse item never is;
- the component inflates a full-item row into the store;
- an error rendering never hydrates;
- the block-yield shape (`results.entries` / `meta` / each `entry.component`);
- an idle query renders nothing, then activates when set.
