### PR TITLE
Unified search: error / last-known-good rendering affordances

### DIFF
--- a/packages/host/app/components/card-search/hydratable-card.gts
+++ b/packages/host/app/components/card-search/hydratable-card.gts
@@ -9,6 +9,7 @@ import { consume } from 'ember-provide-consume-context';
 import {
   CardContextName,
   GetCardContextName,
+  type ErrorEntry,
   type Format,
   type ResolvedCodeRef,
   type StoreReadType,
@@ -20,6 +21,8 @@ import type { HTMLComponent } from '@cardstack/host/lib/html-component';
 import type { BaseDef, CardContext } from 'https://cardstack.com/base/card-api';
 
 import CardRenderer from '../card-renderer';
+
+import SearchResultError from './search-result-error';
 
 // How an HTML-backed search result becomes a live, running card. `none` stays
 // inert; `hover` / `click` / `touch` fetch the card on the matching gesture and
@@ -81,8 +84,13 @@ interface Signature {
     // The resource type to resolve — `card` (default) or `file-meta`, so a
     // full live file-meta row renders its `FileDef` instead of nothing.
     type?: StoreReadType;
-    // An error rendering never hydrates.
+    // An error rendering never hydrates. When set and there's no inert HTML to
+    // show (no last-known-good rendering), the row resolves to the host error
+    // component (`SearchResultError`) — the terminal rung of the chain.
     isError?: boolean;
+    // The error doc surfaced by the host error component when this row falls
+    // through to it. Absent => the component shows a generic message.
+    errorDoc?: ErrorEntry;
     // The hydration gesture (defaults to `none`).
     mode?: HydrationMode;
     // The format the live/hydrated card renders as, so it matches the
@@ -217,6 +225,15 @@ export default class HydratableCard extends Component<Signature> {
         }}
         data-hydration={{this.hydrationState}}
         data-test-hydratable-card={{@cardId}}
+        ...attributes
+      />
+    {{else if @isError}}
+      {{! The terminal rung: an error result with no good html, no
+          last-known-good html, and no renderable live item. Inert and
+          non-hydratable — no gesture, no GET. }}
+      <SearchResultError
+        @cardId={{@cardId}}
+        @error={{@errorDoc}}
         ...attributes
       />
     {{/if}}

--- a/packages/host/app/components/card-search/search-result-error.gts
+++ b/packages/host/app/components/card-search/search-result-error.gts
@@ -1,0 +1,77 @@
+import Component from '@glimmer/component';
+
+import { ExclamationCircle } from '@cardstack/boxel-ui/icons';
+
+import type { ErrorEntry } from '@cardstack/runtime-common';
+
+interface Signature {
+  Element: HTMLElement;
+  Args: {
+    // The result's identity URL — the diagnostic / test hook for the row.
+    cardId: string;
+    // The result's error doc, when one rode along on the wire (the `item`'s
+    // `meta.error`). Absent for an error rendering that carried no last-known-
+    // good HTML and no item — the tile then shows a generic message.
+    error?: ErrorEntry;
+  };
+}
+
+// The terminal rung of the `<SearchResults>` resolution chain: prefer good
+// `html` → last-known-good `html` (inert) → live `item` → THIS. Rendered when a
+// result is in an error state with nothing renderable left. It is inert and
+// non-hydratable — no gesture is wired and no card GET ever fires from here, so
+// an error result can never become live.
+export default class SearchResultError extends Component<Signature> {
+  private get title(): string {
+    return this.args.error?.error.title ?? 'Card Error';
+  }
+
+  private get message(): string {
+    return this.args.error?.error.message ?? 'This card could not be rendered.';
+  }
+
+  <template>
+    <div
+      class='search-result-error'
+      data-test-search-result-error={{@cardId}}
+      data-hydration='none'
+      ...attributes
+    >
+      <ExclamationCircle class='icon' role='presentation' />
+      <div class='content'>
+        <div class='title'>{{this.title}}</div>
+        <div class='message' title={{this.message}}>{{this.message}}</div>
+      </div>
+    </div>
+    <style scoped>
+      .search-result-error {
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp-xs);
+        height: 100%;
+        color: var(--boxel-error-300);
+        overflow: hidden;
+      }
+      .icon {
+        flex-shrink: 0;
+        width: var(--boxel-icon-sm);
+        height: var(--boxel-icon-sm);
+      }
+      .content {
+        min-width: 0;
+      }
+      .title {
+        font: 600 var(--boxel-font-sm);
+        line-height: 1.2;
+      }
+      .message {
+        font: var(--boxel-font-xs);
+        line-height: 1.2;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    </style>
+  </template>
+}

--- a/packages/host/app/components/card-search/search-results.gts
+++ b/packages/host/app/components/card-search/search-results.gts
@@ -113,8 +113,26 @@ class RenderableSearchEntry {
     return this.raw.item;
   }
 
+  // The error doc carried on the `item` serialization's `meta`. Present => the
+  // live item cannot render, so the row falls through to the host error
+  // component and the item is never deposited into the Store.
+  get itemErrorDoc(): ErrorEntry | undefined {
+    return this.item?.meta.error;
+  }
+
+  // The row is in an error state when its chosen rendering is an error
+  // rendering (a last-known-good or bare error placeholder, both
+  // non-hydratable) or its `item` serialization carries an error doc. Drives
+  // both "never hydrate" and the fall-through to the host error component.
   get isError(): boolean {
-    return this.html?.isError ?? false;
+    return (this.html?.isError ?? false) || this.itemErrorDoc != null;
+  }
+
+  // The error doc the host error component surfaces (rung 4). It comes from the
+  // `item`'s `meta`; an error rendering with no last-known-good HTML and no
+  // item carries no doc, so the component shows a generic message.
+  get errorDoc(): ErrorEntry | undefined {
+    return this.itemErrorDoc;
   }
 
   // `card` vs `file-meta`: the serialization carries its own type; an HTML-only
@@ -162,6 +180,7 @@ class RenderableSearchEntry {
         type: this.type,
         format: this.format,
         isError: this.isError,
+        errorDoc: this.errorDoc,
         mode: this.mode,
       });
     }
@@ -282,12 +301,14 @@ export default class SearchResults extends Component<Signature> {
   // Selective Store inflate: deposit only full `item` serializations so a
   // by-URL read (or the hydration GET) resolves without a round-trip. Sparse
   // items and `search-entry`s are never deposited (the store method no-ops on a
-  // sparse item). A render-side effect keyed on the live entry set, so it
-  // deposits an item-bearing row whenever one lands on a re-run.
+  // sparse item); an item carrying an error doc is skipped here too — it stands
+  // in for a card that failed to render and must not enter the Store. A
+  // render-side effect keyed on the live entry set, so it deposits an
+  // item-bearing row whenever one lands on a re-run.
   private inflateFullItems = modifier(
     (_element: Element, [entries]: [RenderableSearchEntry[]]) => {
       for (let entry of entries) {
-        if (entry.item) {
+        if (entry.item && !entry.itemErrorDoc) {
           // Fire-and-forget; a deposit failure (e.g. a malformed resource)
           // must not reject unhandled mid-render — the row still renders
           // (resolving its instance on demand) and the next re-run retries.

--- a/packages/host/app/lib/hydratable-entry-component.ts
+++ b/packages/host/app/lib/hydratable-entry-component.ts
@@ -6,6 +6,7 @@ import {
 import { precompileTemplate } from '@ember/template-compilation';
 
 import type {
+  ErrorEntry,
   Format,
   ResolvedCodeRef,
   StoreReadType,
@@ -42,8 +43,12 @@ export interface HydratableEntryArgs {
   // The format the live/hydrated card renders as, so it matches the
   // prerendered HTML the query selected.
   format: Format;
-  // An error rendering never hydrates.
+  // An error rendering never hydrates; with no inert HTML it falls through to
+  // the host error component.
   isError: boolean;
+  // The error doc the host error component surfaces when this row falls through
+  // to it.
+  errorDoc?: ErrorEntry;
   // The hydration gesture for an HTML-backed row.
   mode: HydrationMode;
 }
@@ -56,6 +61,7 @@ class _HydratableEntryComponent {
     readonly type: StoreReadType | undefined,
     readonly format: Format,
     readonly isError: boolean,
+    readonly errorDoc: ErrorEntry | undefined,
     readonly mode: HydrationMode,
   ) {}
 }
@@ -69,6 +75,7 @@ setComponentTemplate(
       @type={{this.type}}
       @format={{this.format}}
       @isError={{this.isError}}
+      @errorDoc={{this.errorDoc}}
       @mode={{this.mode}}
       ...attributes
     />`,
@@ -112,6 +119,7 @@ export function hydratableEntryComponent(
     args.type,
     args.format,
     args.isError,
+    args.errorDoc,
     args.mode,
   ) as unknown as EntryComponent;
 }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1041,12 +1041,17 @@ export default class StoreService extends Service implements StoreInterface {
   // the hydration GET) resolves it without a round-trip. A sparse `item` (one
   // carrying `meta.sparseFields`) is never deposited — it would misrepresent
   // the instance and could clobber a correctly-loaded full one — so the call
-  // is a no-op for it; `search-entry`s carry no serialization to deposit.
-  // Idempotent: depositing is skipped when the instance is already resident.
+  // is a no-op for it; likewise an item carrying an error doc (`meta.error`),
+  // which stands in for a card that failed to render and is not a real
+  // instance. `search-entry`s carry no serialization to deposit. Idempotent:
+  // depositing is skipped when the instance is already resident.
   async inflateSearchEntryItem(
     resource: CardResource<Saved> | FileMetaResource,
   ): Promise<void> {
-    if (isSparseItemResource(resource)) {
+    // Read `meta.error` before the guard: `isSparseItemResource`'s negative
+    // narrowing would otherwise reduce `resource` to `never` in the second
+    // operand.
+    if (resource.meta.error != null || isSparseItemResource(resource)) {
       return;
     }
     await this.addResourceFromSearchData(resource);

--- a/packages/host/tests/integration/components/search-results-test.gts
+++ b/packages/host/tests/integration/components/search-results-test.gts
@@ -153,6 +153,51 @@ function bookItem(
   } as unknown as CardResource<Saved>;
 }
 
+// An `item` serialization standing in for a card that failed to render: it
+// carries the error doc in `meta.error` and no usable attributes. Drives the
+// terminal rung — the host error component.
+function errorItem(url: string, message: string): CardResource<Saved> {
+  return {
+    type: 'card',
+    id: url,
+    meta: {
+      adoptsFrom: { module: testRRI('book'), name: 'Book' },
+      error: {
+        type: 'instance-error',
+        error: {
+          title: 'Card Error',
+          status: 500,
+          message,
+          additionalErrors: null,
+        },
+      },
+    },
+    links: { self: url },
+  } as unknown as CardResource<Saved>;
+}
+
+// An error rendering carrying no last-known-good HTML: `isError` with the
+// `html` string absent. With no item alongside it, the row has nothing to
+// render but its error state — the host error component, with a generic
+// message (no error doc rode along).
+function htmlIncludedNoLastKnownGood(
+  url: string,
+): SearchEntryIncludedResource[] {
+  return [
+    {
+      type: HtmlResourceType,
+      id: renderingIdFor(url),
+      attributes: {
+        cardType: 'Book',
+        isError: true,
+        format: 'fitted',
+        renderType: bookRef,
+      },
+      relationships: { styles: { data: [] } },
+    },
+  ];
+}
+
 module('Integration | Component | search-results', function (hooks) {
   let loader: Loader;
   let storeService: StoreService;
@@ -444,6 +489,105 @@ module('Integration | Component | search-results', function (hooks) {
       assert.notOk(
         isCardInstance(storeService.peek(BOOK_1)),
         'no hydration GET fired for an error row',
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test('an error item with no html falls through to the host error component', async function (assert) {
+    // No good html, no last-known-good html, and the live item carries an
+    // error doc — the terminal rung. The host error component surfaces the
+    // doc's message and the row never enters the store or fires a GET.
+    let restore = stubSearchEntries({
+      data: [itemEntryResource(BOOK_1)],
+      included: [errorItem(BOOK_1, 'Boom: failed to render')],
+      meta: { page: { total: 1 } },
+    });
+    try {
+      let query: SearchEntryWireQuery = {
+        filter: { 'item.on': bookRef },
+        realms: [testRealmURL],
+      };
+      await render(
+        <template>
+          <TestContext>
+            <SearchResults @query={{query}} @mode='hover' />
+          </TestContext>
+        </template>,
+      );
+      await waitUntil(() =>
+        Boolean(document.querySelector('[data-test-search-result-error]')),
+      );
+
+      assert
+        .dom(`[data-test-search-result-error="${BOOK_1}"]`)
+        .exists('the host error component renders for an error item')
+        .containsText(
+          'Boom: failed to render',
+          'it surfaces the error doc message',
+        );
+      assert
+        .dom(`[data-test-hydratable-card="${BOOK_1}"]`)
+        .doesNotExist('an error item is not a hydratable card');
+      assert.notOk(
+        isCardInstance(storeService.peek(BOOK_1)),
+        'an error item is never deposited into the store',
+      );
+
+      await triggerEvent(
+        `[data-test-search-result-error="${BOOK_1}"]`,
+        'mouseenter',
+      );
+      assert.notOk(
+        isCardInstance(storeService.peek(BOOK_1)),
+        'hovering the host error component fires no hydration GET',
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test('an error rendering with no last-known-good html falls through to the host error component', async function (assert) {
+    // The html rendering is an error rendering carrying no html string, and no
+    // item rode along — nothing renders but the error state, so the host error
+    // component shows its generic message.
+    let restore = stubSearchEntries({
+      data: [htmlEntryResource(BOOK_1)],
+      included: htmlIncludedNoLastKnownGood(BOOK_1),
+      meta: {
+        page: { total: 1 },
+        htmlQuery: { eq: { format: 'fitted', renderType: bookRef } },
+      },
+    });
+    try {
+      let query: SearchEntryWireQuery = {
+        filter: { 'item.on': bookRef },
+        realms: [testRealmURL],
+      };
+      await render(
+        <template>
+          <TestContext>
+            <SearchResults @query={{query}} @mode='hover' />
+          </TestContext>
+        </template>,
+      );
+      await waitUntil(() =>
+        Boolean(document.querySelector('[data-test-search-result-error]')),
+      );
+
+      assert
+        .dom(`[data-test-search-result-error="${BOOK_1}"]`)
+        .exists(
+          'the host error component renders when there is nothing to show',
+        )
+        .containsText(
+          'could not be rendered',
+          'it shows the generic message when no error doc rode along',
+        );
+      assert.notOk(
+        isCardInstance(storeService.peek(BOOK_1)),
+        'a bare error rendering never enters the store',
       );
     } finally {
       restore();

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -36,6 +36,18 @@ export interface SerializedError {
   diagnostics?: Record<string, unknown>;
 }
 
+// A persisted error document: the `SerializedError` plus the index metadata
+// that rode with the row that failed. Stored in the `error_doc` column and
+// carried on the wire by anything that stands in for a card/module/file that
+// failed to render or index.
+export interface ErrorEntry {
+  type: 'instance-error' | 'module-error' | 'file-error';
+  error: SerializedError;
+  types?: string[];
+  searchData?: Record<string, any>;
+  cardType?: string;
+}
+
 // Postgres `jsonb` containers store child offsets in 28 bits, so a
 // single jsonb array's elements must total < 256 MiB — a format-level
 // constraint baked into jsonb, not a column setting we can raise.

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -9,7 +9,7 @@ import type { CodeRef, ResolvedCodeRef } from './code-ref.ts';
 import type { VirtualNetwork } from './virtual-network.ts';
 import type { RenderRouteOptions } from './render-route-options.ts';
 import type { Definition } from './definitions.ts';
-import type { SerializedError } from './error.ts';
+import type { ErrorEntry } from './error.ts';
 import { rri, type RealmResourceIdentifier } from './realm-identifiers.ts';
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
@@ -124,13 +124,9 @@ export interface RenderResponse extends PrerenderMeta {
   error?: RenderError;
 }
 
-export interface ErrorEntry {
-  type: 'instance-error' | 'module-error' | 'file-error';
-  error: SerializedError;
-  types?: string[];
-  searchData?: Record<string, any>;
-  cardType?: string;
-}
+// `ErrorEntry` lives in `./error.ts` alongside the `SerializedError` it wraps;
+// re-exported here so barrel consumers reach it unchanged.
+export type { ErrorEntry } from './error.ts';
 
 // CS-10872: attached to timeout-class RenderErrors so the persisted
 // error document tells operators *where* the time went. All fields

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -1,5 +1,5 @@
 import { md5 } from 'super-fast-md5';
-import type { ErrorEntry } from './index.ts';
+import type { ErrorEntry } from './error.ts';
 import type { RealmInfo } from './realm.ts';
 import { type CodeRef, type ResolvedCodeRef, moduleFrom } from './code-ref.ts';
 import type { PrerenderedHtmlFormat } from './prerendered-html-format.ts';

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -1,4 +1,5 @@
 import { md5 } from 'super-fast-md5';
+import type { ErrorEntry } from './index.ts';
 import type { RealmInfo } from './realm.ts';
 import { type CodeRef, type ResolvedCodeRef, moduleFrom } from './code-ref.ts';
 import type { PrerenderedHtmlFormat } from './prerendered-html-format.ts';
@@ -106,6 +107,11 @@ export type CardResourceMeta = Meta & {
   // the instance and could clobber a correctly-loaded full one). Absence
   // marks the serialization full.
   sparseFields?: string[];
+  // The result's error doc, when this serialization stands in for a card that
+  // failed to render/index. Present => the live `item` cannot render, so a
+  // consumer falls through to the host error component (the terminal rung of
+  // the resolution chain) and never deposits the resource into the Store.
+  error?: ErrorEntry;
 };
 
 export type FileMetaResourceResourceMeta = Meta & {
@@ -118,6 +124,9 @@ export type FileMetaResourceResourceMeta = Meta & {
   // See CardResourceMeta.sparseFields — a file-meta serialization can likewise
   // be field-limited.
   sparseFields?: string[];
+  // See CardResourceMeta.error — a file-meta serialization can likewise carry
+  // the result's error doc when it failed to render.
+  error?: ErrorEntry;
 };
 
 export interface CardResource<Identity extends Unsaved = Saved> {


### PR DESCRIPTION
Extends the v2 `<SearchResults>` consumer with the error rung of the per-result resolution chain. Phase 1 of the [unified-search project](https://linear.app/cardstack/project/unify-prerendered-card-search-and-card-search-concepts-b6db4a4835ad). Additive — it adds a terminal rendering branch and changes no existing behavior. Stacked on #5237.

### The resolution chain

Each `search-entry` resolves, in order:

1. **good `html`** — render inert, hydrate lazily on interaction (unchanged);
2. **last-known-good `html`** — an error rendering (`html.attributes.isError`) that still carries HTML; render it inert and **non-hydratable** (unchanged);
3. **live `item`** — no usable HTML; render the live serialization (unchanged);
4. **host error component** — *new*: nothing renderable is left, so render `SearchResultError`, an inert, non-hydratable tile that surfaces the error doc.

Rung 4 fires in two cases: an `item` serialization carrying an error doc in `meta.error` (the live item can't render), or an error rendering with no last-known-good HTML and no item. The component shows the error doc's title/message, or a generic message when no doc rode along.

### What changed

- `CardResourceMeta` / `FileMetaResourceResourceMeta` gain `error?: ErrorEntry` — the wire field an `item` carries when it stands in for a card that failed to render.
- `SearchResultError` — the compact, non-hydratable host error component.
- `HydratableCard` takes `@errorDoc` and renders `SearchResultError` as the terminal `{{else}}` branch; `hydratable-entry-component` threads it through the curry.
- `RenderableSearchEntry.isError` now also covers an item with an error doc, and exposes `errorDoc`. An error item is never deposited into the Store (the render-side inflate skips it, and `StoreService.inflateSearchEntryItem` also no-ops on `meta.error`).

### Tests

`search-results-test.gts` gains coverage for each rung — good html (existing), last-known-good inert + non-hydratable (existing), live-item fallback (existing), and the host error component (new): an error item renders the tile, surfaces its message, never hydrates, and never enters the Store; a bare error rendering with no last-known-good HTML shows the generic message.
