### PR TITLE
Trust mkcert CA in realm-server qunit runner

### DIFF
--- a/packages/realm-server/tests/scripts/run-qunit-with-test-pg.sh
+++ b/packages/realm-server/tests/scripts/run-qunit-with-test-pg.sh
@@ -19,6 +19,20 @@ if [ -n "${JUNIT_OUTPUT_FILE-}" ]; then
   JUNIT_REPORTER_ARGS=(--require "${SCRIPT_DIR}/../../scripts/junit-reporter.js")
 fi
 
+# Trust mkcert's local CA so test fetches to the dev stack on HTTPS
+# (mkcert leaf) validate without requiring `mkcert -install` into the
+# system trust store. Mirrors the env-vars.sh logic so behavior stays
+# consistent between the dev stack and the test runner.
+if command -v mkcert >/dev/null 2>&1; then
+  _MKCERT_CAROOT="$(mkcert -CAROOT 2>/dev/null || true)"
+  if [ -n "$_MKCERT_CAROOT" ] && [ -f "$_MKCERT_CAROOT/rootCA.pem" ]; then
+    if [ -z "${NODE_EXTRA_CA_CERTS:-}" ]; then
+      export NODE_EXTRA_CA_CERTS="$_MKCERT_CAROOT/rootCA.pem"
+    fi
+  fi
+  unset _MKCERT_CAROOT
+fi
+
 # Disable Node's V8 compile cache (Node 22+). When enabled, it caches
 # transpiled JS of test files at /tmp/node-compile-cache and
 # /tmp/v8-compile-cache-1000, and when a test file changes on disk the


### PR DESCRIPTION
## Summary

- `packages/realm-server/tests/scripts/run-qunit-with-test-pg.sh` now probes `mkcert -CAROOT` and points `NODE_EXTRA_CA_CERTS` at `rootCA.pem` when it's unset.
- Mirrors the existing logic in `mise-tasks/lib/env-vars.sh` so the test runner trusts the mkcert leaf the dev stack serves on HTTPS, without requiring `mkcert -install` into the system trust store.
- If `mkcert` isn't installed, or `NODE_EXTRA_CA_CERTS` is already set, the script leaves things alone.

Closes [CS-11584](https://linear.app/cardstack/issue/CS-11584).

## Test plan

- [ ] With dev stack running on HTTPS and no `mkcert -install`, run `pnpm -C packages/realm-server test` — tests reach the realm-server without self-signed-cert TLS errors.
- [ ] With `NODE_EXTRA_CA_CERTS` pre-set in the shell, run the same — script leaves the existing value in place.
- [ ] Without `mkcert` installed, run the same — script is a no-op and tests still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)