### PR TITLE
Cut wasted per-instance work from prerender/indexing renders

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -965,6 +965,8 @@ Arm it:
 3. Re-run the index. On a wedge, grep the prerender-server log for `v8ProfLog: uploaded` — and pull the artifact (next section).
 4. Set it back to `false` + restart when done — it samples **every** render while on.
 
+> **Expect a multi-minute lag between the job rejecting and the `.v8log` landing in S3.** The worker rejects the indexing job at the shorter **request-abort** timeout (`client-aborted after 120000ms` in the manager log), but the `v8log` only uploads when the prerender-server's longer **render-level** timeout (`RENDER_TIMEOUT_MS`) fires — the renderer keeps pegging after the worker gives up — plus the S3 PUT. Observed gap on staging: job rejected at `20:02:33`, `v8ProfLog: uploaded` + artifact in S3 at `20:07:52` (~5 min later). So don't read "job rejected, no artifact yet" as a failed capture — poll the bucket (`symbolize-prerender-wedge.sh … --list`, or `s3api list-objects-v2`) for a few minutes before concluding the capture didn't happen.
+
 **Symbolize offline.** With an aws-access session for the env (`boxel-claude-readonly` has `s3:GetObject`/`ListBucket` on `boxel-prerender-artifacts-*`), the helper fetches the newest matching `.v8log` and runs `node --prof-process` for you:
 
 ```sh

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -87,6 +87,7 @@ import {
   LooseLinkableResource,
   LooseSingleResourceDocument,
   shouldTrackRuntimeModuleGraph,
+  shouldTrackRuntimeRelationship,
   trackRuntimeFileDependency,
   trackRuntimeInstanceDependency,
   trackRuntimeModuleDependency,
@@ -1252,15 +1253,6 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
       // structured read.
       let bucketEntry = deserialized.get(this.name);
       if (isLinkError(bucketEntry) || isLinkNotFound(bucketEntry)) {
-        // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes.
-        console.error(
-          '[CS-11221 DIAG] linksTo getter returning undefined (bucket sentinel)',
-          {
-            fieldName: this.name,
-            ownerType: instance?.constructor?.name,
-            sentinelType: (bucketEntry as { type?: string })?.type,
-          },
-        );
         return undefined;
       }
       let records = (searchResource as any)?.instances ?? ([] as any[]);
@@ -3865,6 +3857,14 @@ function trackRuntimeRelationshipDependency(
   }
   let id = (value as { id?: unknown }).id;
   if (typeof id !== 'string') {
+    return;
+  }
+  if (!shouldTrackRuntimeRelationship(id, dependencyTrackingContext)) {
+    // Already tracked this relationship target this session. A linksTo /
+    // linksToMany getter runs this on every read, and a dense graph re-reads
+    // the same targets combinatorially; a repeat would re-derive the identical
+    // instance/file + module-graph node set, so skipping it — and the
+    // prototype/identity lookups below — is a pure no-op.
     return;
   }
   if (isFileDef(declaredCard)) {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2491,7 +2491,15 @@ export class BaseDef {
             includeComputeds: true,
             usedLinksToFieldsOnly: true,
           }),
-        ).map(([fieldName, field]) => {
+        )
+          // A query-backed field is resolved live from a query; the index has no
+          // way to invalidate it when matching cards change, so its value in the
+          // search doc would always be stale. Skip it entirely rather than
+          // traverse (and deep-resolve) the query closure into the doc — the
+          // host re-resolves these fields at view time, and the indexer records
+          // membership from `relationships.{field}.data` separately.
+          .filter(([, field]) => !field?.queryDefinition)
+          .map(([fieldName, field]) => {
           let rawValue = peekAtField(value, fieldName);
           if (field?.fieldType === 'linksToMany') {
             return [

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -346,6 +346,46 @@ export function getFieldOverrides<T extends BaseDef>(
   return overrides;
 }
 
+// A render/indexing pass reads the same instances' field maps over and over —
+// per serialize, per searchDoc, per getDeps/findInstances recursion — and
+// `computeFields` walks the prototype chain and resolves every field on each
+// call. The result is determined by the prototype chain plus, for an instance,
+// its polymorphic field overrides (and, with `usedLinksToFieldsOnly`, its
+// populated field set). A read-only render only ever GROWS those, so their
+// sizes are a sound validity token: an unchanged token means an identical
+// result. Gated to the render context so the live app — where instances mutate
+// freely (same-size override swaps, field clears) — is never served a memoized
+// map. Keyed on the instance/class via a WeakMap so entries fall away with
+// their subjects; the token guards reuse across passes.
+const renderFieldsCache = new WeakMap<
+  object,
+  Map<
+    string,
+    {
+      token: string;
+      fields: { [fieldName: string]: Field<BaseDefConstructor> };
+    }
+  >
+>();
+
+function renderFieldsCacheToken(
+  subject: object,
+  isInstance: boolean,
+  usedLinksToFieldsOnly: boolean,
+): string {
+  if (!isInstance) {
+    // A class's field map is static; a module reload yields a new class object,
+    // which is a fresh WeakMap key, so no token is needed.
+    return '';
+  }
+  let overrideSize = fieldOverrides.get(subject as BaseDef)?.size ?? 0;
+  if (!usedLinksToFieldsOnly) {
+    return `o${overrideSize}`;
+  }
+  let usedSize = deserializedData.get(subject as BaseDef)?.size ?? 0;
+  return `o${overrideSize}:u${usedSize}`;
+}
+
 export function getFields(
   card: typeof BaseDef,
   opts?: { usedLinksToFieldsOnly?: boolean; includeComputeds?: boolean },
@@ -355,6 +395,39 @@ export function getFields<T extends BaseDef>(
   opts?: { usedLinksToFieldsOnly?: boolean; includeComputeds?: boolean },
 ): { [P in keyof T]?: Field<BaseDefConstructor> };
 export function getFields(
+  cardInstanceOrClass: BaseDef | typeof BaseDef,
+  opts?: { usedLinksToFieldsOnly?: boolean; includeComputeds?: boolean },
+): { [fieldName: string]: Field<BaseDefConstructor> } {
+  if (!(globalThis as any).__boxelRenderContext) {
+    return computeFields(cardInstanceOrClass, opts);
+  }
+  // `cardInstanceOrClass` is a valid WeakMap key whether it's an instance or a
+  // class; an instance keys per-instance so polymorphic overrides aren't shared
+  // across instances of the same class.
+  let subject: object = cardInstanceOrClass;
+  let isInstance = isCardOrField(cardInstanceOrClass);
+  let usedLinksToFieldsOnly = opts?.usedLinksToFieldsOnly ?? false;
+  let optsKey = `${usedLinksToFieldsOnly ? 1 : 0}${opts?.includeComputeds ? 1 : 0}`;
+  let token = renderFieldsCacheToken(
+    subject,
+    isInstance,
+    usedLinksToFieldsOnly,
+  );
+  let perSubject = renderFieldsCache.get(subject);
+  let entry = perSubject?.get(optsKey);
+  if (entry && entry.token === token) {
+    return entry.fields;
+  }
+  let fields = computeFields(cardInstanceOrClass, opts);
+  if (!perSubject) {
+    perSubject = new Map();
+    renderFieldsCache.set(subject, perSubject);
+  }
+  perSubject.set(optsKey, { token, fields });
+  return fields;
+}
+
+function computeFields(
   cardInstanceOrClass: BaseDef | typeof BaseDef,
   opts?: { usedLinksToFieldsOnly?: boolean; includeComputeds?: boolean },
 ): { [fieldName: string]: Field<BaseDefConstructor> } {
@@ -412,7 +485,9 @@ export function getFields(
 }
 
 function getUsedFields(instance: BaseDef): string[] {
-  return [...getDataBucket(instance)?.keys()];
+  // getDataBucket always returns a Map (it creates one if absent), so the spread
+  // is safe without optional chaining.
+  return [...getDataBucket(instance).keys()];
 }
 
 export function isArrayOfCardOrField(

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -95,6 +95,13 @@ export default class RenderMetaRoute extends Route<Model> {
       let vn = this.network.virtualNetwork;
       serialized = api.serializeCard(instance, {
         includeComputeds: true,
+        // A query-backed field is resolved live and the index can't invalidate
+        // it, so its serialized value would always be stale — and deep-
+        // serializing the query closure into `included[]` is what wedges a
+        // densely cross-linked realm. Membership comes from the file's own
+        // relationships, so omit query fields here (the relationship data is
+        // stripped below regardless).
+        omitQueryFields: true,
         virtualNetwork: vn,
         maybeRelativeReference: (reference: string) =>
           maybeRelativeReference(

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -728,6 +728,12 @@ export default class RealmService extends Service {
   // resetState can't serve a stale answer.
   private realmPathsCache = new Map<string, RealmPaths>();
   private realmOfCache = new Map<string, string>();
+  // The authorization middleware reads `token()` on every fetch, and a single
+  // render can issue hundreds — each one landing in `restoreSessionsFromStorage`
+  // for any realm it hasn't resolved yet. We memoize on the raw storage string
+  // so an unchanged blob is never re-parsed or re-walked; a later write (a newly
+  // seeded realm session) changes the string and re-runs the walk.
+  private lastRestoredSessionsString: string | undefined = undefined;
 
   @tracked private identifyRealmTracker = 0;
 
@@ -749,6 +755,7 @@ export default class RealmService extends Service {
     this.identifyRealmTracker++;
     this.realmPathsCache.clear();
     this.realmOfCache.clear();
+    this.lastRestoredSessionsString = undefined;
   }
 
   async waitForBulkInfoIfNeeded(): Promise<void> {
@@ -828,10 +835,15 @@ export default class RealmService extends Service {
   }
 
   restoreSessionsFromStorage(): void {
-    let tokens = SessionStorage.getAll();
-    if (!tokens) {
+    let sessionsString = window.localStorage.getItem(SessionLocalStorageKey);
+    if (sessionsString === this.lastRestoredSessionsString) {
       return;
     }
+    this.lastRestoredSessionsString = sessionsString;
+    if (!sessionsString) {
+      return;
+    }
+    let tokens = JSON.parse(sessionsString) as Record<string, string>;
     for (let [realmURL, token] of Object.entries(tokens)) {
       let resource = this.getOrCreateRealmResource(realmURL, token);
       if (token && resource.token !== token) {

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -733,7 +733,7 @@ export default class RealmService extends Service {
   // for any realm it hasn't resolved yet. We memoize on the raw storage string
   // so an unchanged blob is never re-parsed or re-walked; a later write (a newly
   // seeded realm session) changes the string and re-runs the walk.
-  private lastRestoredSessionsString: string | undefined = undefined;
+  private lastRestoredSessionsString: string | null = null;
 
   @tracked private identifyRealmTracker = 0;
 
@@ -755,7 +755,7 @@ export default class RealmService extends Service {
     this.identifyRealmTracker++;
     this.realmPathsCache.clear();
     this.realmOfCache.clear();
-    this.lastRestoredSessionsString = undefined;
+    this.lastRestoredSessionsString = null;
   }
 
   async waitForBulkInfoIfNeeded(): Promise<void> {

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -839,11 +839,14 @@ export default class RealmService extends Service {
     if (sessionsString === this.lastRestoredSessionsString) {
       return;
     }
-    this.lastRestoredSessionsString = sessionsString;
     if (!sessionsString) {
+      this.lastRestoredSessionsString = sessionsString;
       return;
     }
     let tokens = JSON.parse(sessionsString) as Record<string, string>;
+    // Record the memo only after a successful parse, so a malformed blob can't
+    // poison it and suppress a later retry.
+    this.lastRestoredSessionsString = sessionsString;
     for (let [realmURL, token] of Object.entries(tokens)) {
       let resource = this.getOrCreateRealmResource(realmURL, token);
       if (token && resource.token !== token) {

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1850,6 +1850,14 @@ export default class StoreService extends Service implements StoreInterface {
     if (!isCardInstance(instanceOrError)) {
       return;
     }
+    if (this.renderContextBlocksPersistence()) {
+      // Persistence is blocked in this context, so the change subscription that
+      // drives autosave can never produce a save. Skipping it avoids the
+      // per-instance subscribe/unsubscribe churn — and the `getFields`
+      // dependency-graph walk each one triggers — for every instance a render
+      // loads.
+      return;
+    }
     let instance = instanceOrError;
     // module updates will break the cached api. so don't hang on to this longer
     // than necessary

--- a/packages/host/tests/integration/components/prerender-serialize-cycle-test.gts
+++ b/packages/host/tests/integration/components/prerender-serialize-cycle-test.gts
@@ -23,6 +23,7 @@ import {
   getDataBucket,
   getQueryableValue,
   linksTo,
+  linksToMany,
   setupBaseRealm,
   StringField,
 } from '../../helpers/base-realm';
@@ -128,6 +129,56 @@ module('Integration | prerender serialize cycle guard', function (hooks) {
     assert.notOk(
       json.includes('A-DUPLICATE-FRESH-OBJECT'),
       'the fresh-object re-entry of A collapses to {id} — not expanded; without the id-based guard the object-identity check would miss the cycle and expand it',
+    );
+  });
+
+  // A query-backed field is resolved live from a query and the index has no way
+  // to invalidate it when matching cards change, so its value in the search doc
+  // would always be stale — and traversing the query closure to build it is what
+  // wedges a dense realm. The search-doc builder must skip query-backed fields
+  // entirely, while keeping ordinary contains / linksTo(Many) fields.
+  test('a query-backed field is omitted from the search doc; ordinary fields are kept', async function (assert) {
+    class Member extends CardDef {
+      static displayName = 'Member';
+      @field firstName = contains(StringField);
+    }
+    class Team extends CardDef {
+      static displayName = 'Team';
+      @field teamName = contains(StringField);
+      @field roster = linksToMany(() => Member);
+      @field matchingMembers = linksToMany(() => Member, {
+        query: { filter: { eq: { firstName: 'anything' } } },
+      });
+    }
+    loader.shimModule(`${testRealmURL}team-cards`, { Member, Team });
+
+    let member = new Member({ firstName: 'Mango' });
+    let team = new Team({ teamName: 'Engineering' });
+    await saveCard(member, `${testRealmURL}Member/mango`, loader);
+    await saveCard(team, `${testRealmURL}Team/eng`, loader);
+
+    // Mark both relationship fields as used (populate the bucket) so each would
+    // be a search-doc candidate were it not for the query-backed filter.
+    getDataBucket(team).set('roster', [member]);
+    getDataBucket(team).set('matchingMembers', [member]);
+
+    let doc = getQueryableValue(
+      team.constructor as typeof CardDef,
+      team,
+    ) as Record<string, any>;
+
+    assert.notOk(
+      'matchingMembers' in doc,
+      'the query-backed field is absent from the search doc',
+    );
+    assert.strictEqual(
+      doc.teamName,
+      'Engineering',
+      'an ordinary contains field is still present',
+    );
+    assert.ok(
+      'roster' in doc,
+      'an ordinary (non-query) linksToMany field is still present',
     );
   });
 });

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -622,6 +622,51 @@ module('Integration | Store', function (hooks) {
     }
   });
 
+  test('getFields is memoized per instance in the render context and invalidates as the instance grows', function (assert) {
+    let person = new PersonDef({ name: 'Mango' });
+    try {
+      (globalThis as any).__boxelRenderContext = true;
+
+      let first = api.getFields(person, { usedLinksToFieldsOnly: true });
+      let second = api.getFields(person, { usedLinksToFieldsOnly: true });
+      assert.strictEqual(
+        first,
+        second,
+        'a repeat call in the render context returns the memoized field map',
+      );
+      assert.notOk(
+        'bestFriend' in first,
+        'an unused linksTo field is absent before it is populated',
+      );
+
+      // Populating a linksTo field grows the data bucket, so the memo token no
+      // longer matches and the next call recomputes.
+      (person as any).bestFriend = new PersonDef({ name: 'Van Gogh' });
+      let third = api.getFields(person, { usedLinksToFieldsOnly: true });
+      assert.notStrictEqual(
+        third,
+        first,
+        'growing the instance invalidates the memo',
+      );
+      assert.ok(
+        'bestFriend' in third,
+        'the now-used linksTo field appears after the bucket grows',
+      );
+
+      // Outside the render context the result is never memoized.
+      delete (globalThis as any).__boxelRenderContext;
+      let live1 = api.getFields(person, { usedLinksToFieldsOnly: true });
+      let live2 = api.getFields(person, { usedLinksToFieldsOnly: true });
+      assert.notStrictEqual(
+        live1,
+        live2,
+        'the live app always gets a fresh field map',
+      );
+    } finally {
+      delete (globalThis as any).__boxelRenderContext;
+    }
+  });
+
   test('can drop reference to a card url', async function (assert) {
     storeService.addReference(`${testRealmURL}Person/hassan`);
     await storeService.flush();

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -524,6 +524,104 @@ module('Integration | Store', function (hooks) {
     );
   });
 
+  test('a render-context load does not set up the autosave change subscription', async function (assert) {
+    // The card-api module's exports are read-only, so we count `subscribeToChanges`
+    // by interposing on `cardService.getAPI()` — which the store re-reads each time
+    // it sets up autosave — and handing back a proxy that tallies the call.
+    let cardService = getService('card-service');
+    let originalGetAPI = cardService.getAPI.bind(cardService);
+    let realApi = await originalGetAPI();
+    let trueSubscribe = realApi.subscribeToChanges;
+    let subscribeCount = 0;
+    (cardService as any).getAPI = async () =>
+      new Proxy(realApi, {
+        get(target, prop, receiver) {
+          if (prop === 'subscribeToChanges') {
+            return (...args: unknown[]) => {
+              subscribeCount++;
+              return (trueSubscribe as any)(...args);
+            };
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+
+    try {
+      // The live store wires up the change subscription that drives autosave.
+      await storeService.add(new PersonDef({ name: 'Mango' }), {
+        doNotPersist: true,
+      });
+      assert.true(
+        subscribeCount > 0,
+        'the live store subscribes a loaded instance for autosave',
+      );
+
+      // A render store blocks persistence, so autosave can never fire — it must
+      // not pay for the per-instance subscribe/unsubscribe churn that drives it.
+      subscribeCount = 0;
+      (globalThis as any).__boxelRenderContext = true;
+      let renderStore = getService('render-store');
+      await renderStore.add(new PersonDef({ name: 'Van Gogh' }), {
+        doNotPersist: true,
+      });
+      assert.strictEqual(
+        subscribeCount,
+        0,
+        'the render store does not subscribe a loaded instance for autosave',
+      );
+    } finally {
+      (cardService as any).getAPI = originalGetAPI;
+      delete (globalThis as any).__boxelRenderContext;
+    }
+  });
+
+  test('restoring sessions from storage skips the re-walk when the session blob is unchanged', function (assert) {
+    // `restoreSessionsFromStorage` is synchronous, so the walk-count delta
+    // measured immediately around each call is exactly that call's work — other
+    // realm activity can only run at async boundaries, never mid-call. The realms
+    // already in storage (from login) are resolved with their own tokens, so the
+    // walk has no token-setter side effects.
+    let walks = 0;
+    let originalGetOrCreate = (
+      realmService as any
+    ).getOrCreateRealmResource.bind(realmService);
+    (realmService as any).getOrCreateRealmResource = (...args: unknown[]) => {
+      walks++;
+      return originalGetOrCreate(...args);
+    };
+
+    try {
+      (realmService as any).lastRestoredSessionsString = undefined;
+
+      let before = walks;
+      realmService.restoreSessionsFromStorage();
+      assert.true(
+        walks - before > 0,
+        'the first restore walks the stored sessions',
+      );
+
+      before = walks;
+      realmService.restoreSessionsFromStorage();
+      assert.strictEqual(
+        walks - before,
+        0,
+        'a restore with an unchanged blob does not re-walk',
+      );
+
+      // When a newly seeded realm session changes the stored blob, the memo no
+      // longer matches it, so the next restore re-reads and re-walks.
+      (realmService as any).lastRestoredSessionsString = 'stale-sentinel';
+      before = walks;
+      realmService.restoreSessionsFromStorage();
+      assert.true(
+        walks - before > 0,
+        'a restore re-walks once the stored blob no longer matches the memo',
+      );
+    } finally {
+      (realmService as any).getOrCreateRealmResource = originalGetOrCreate;
+    }
+  });
+
   test('can drop reference to a card url', async function (assert) {
     storeService.addReference(`${testRealmURL}Person/hassan`);
     await storeService.flush();

--- a/packages/realm-server/tests/runtime-dependency-tracker-test.ts
+++ b/packages/realm-server/tests/runtime-dependency-tracker-test.ts
@@ -6,6 +6,7 @@ import {
   endRuntimeDependencyTrackingSession,
   resetRuntimeDependencyTracker,
   shouldTrackRuntimeModuleGraph,
+  shouldTrackRuntimeRelationship,
   snapshotRuntimeDependencies,
   trackRuntimeFileDependency,
   trackRuntimeInstanceDependency,
@@ -567,6 +568,81 @@ module(basename(__filename), function (hooks) {
     assert.true(
       shouldTrackRuntimeModuleGraph('relationship', moduleURL, queryContext),
       'reset clears walk markers so a fresh session re-walks',
+    );
+  });
+
+  test('relationship probe permits the walk exactly once per (context, id) per session', function (assert) {
+    let id = 'https://example.com/cards/member-1.json';
+    let queryContext = {
+      mode: 'query' as const,
+      queryField: 'members',
+      source: 'test:rel-probe',
+      consumer: 'https://example.com/root.json',
+      consumerKind: 'instance' as const,
+    };
+
+    assert.false(
+      shouldTrackRuntimeRelationship(id, queryContext),
+      'inactive tracker permits no walk (nothing would record)',
+    );
+
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: 'rel-probe',
+      rootURL: 'https://example.com/root.json',
+      rootKind: 'instance',
+    });
+
+    assert.true(
+      shouldTrackRuntimeRelationship(id, queryContext),
+      'first probe under an active session permits the walk',
+    );
+    assert.false(
+      shouldTrackRuntimeRelationship(id, queryContext),
+      'repeat read of the same target is collapsed',
+    );
+    assert.false(
+      shouldTrackRuntimeRelationship(id, { ...queryContext }),
+      'equivalence is by value, not object identity (the explicit-context combinatorial path)',
+    );
+    assert.false(
+      shouldTrackRuntimeRelationship(id, {
+        ...queryContext,
+        consumerKind: undefined,
+      }),
+      "an omitted consumerKind dedups against the recorded default ('instance')",
+    );
+
+    assert.true(
+      shouldTrackRuntimeRelationship(
+        'https://example.com/cards/member-2.json',
+        queryContext,
+      ),
+      'a different target walks again',
+    );
+    assert.true(
+      shouldTrackRuntimeRelationship(id, {
+        ...queryContext,
+        mode: 'non-query',
+      }),
+      'a different mode walks again (query-only classification must not stick)',
+    );
+    assert.true(
+      shouldTrackRuntimeRelationship(id, {
+        ...queryContext,
+        consumer: 'https://example.com/other-consumer.json',
+      }),
+      'a different consumer walks again',
+    );
+
+    resetRuntimeDependencyTracker();
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: 'rel-probe',
+      rootURL: 'https://example.com/root.json',
+      rootKind: 'instance',
+    });
+    assert.true(
+      shouldTrackRuntimeRelationship(id, queryContext),
+      'reset clears markers so a fresh session re-walks',
     );
   });
 

--- a/packages/runtime-common/dependency-tracker.ts
+++ b/packages/runtime-common/dependency-tracker.ts
@@ -180,6 +180,19 @@ export class RuntimeDependencyTracker {
   // "already walked" marker that would drop real dependencies.
   #trackedModuleGraphs = new Set<string>();
 
+  // Per-relationship-target dedup. A linksTo/linksToMany getter calls the
+  // relationship-dependency walk (instance/file dep + the linked type's module
+  // graph) on EVERY read, and a dense graph re-reads the same targets
+  // combinatorially — so the per-call guard work (prototype/identity lookups
+  // ahead of #trackedModuleGraphs, and the explicit-context branch of #track,
+  // which is exempt from identity dedup and re-records every time) dominates
+  // aggregate renders. This probe collapses every repeat to one Set lookup.
+  // Keyed by value (everything #track/#recordNode derive from a context, plus
+  // the target id) so a skipped repeat is a provable no-op, the same as
+  // #trackedModuleGraphs. Cleared in reset() alongside #nodes so a cleared node
+  // map never inherits a stale marker that would drop a real dependency.
+  #trackedRelationships = new Set<string>();
+
   startSession({
     sessionKey,
     rootURL,
@@ -208,6 +221,7 @@ export class RuntimeDependencyTracker {
     this.#normalizeCache.clear();
     this.#trackedByContext = new WeakMap();
     this.#trackedModuleGraphs.clear();
+    this.#trackedRelationships.clear();
   }
 
   // A module-graph walk (tracking a module plus its transitive consumed
@@ -257,6 +271,37 @@ export class RuntimeDependencyTracker {
       return false;
     }
     this.#trackedModuleGraphs.add(key);
+    return true;
+  }
+
+  // Sibling of shouldTrackModuleGraph for the whole relationship-dependency walk
+  // (instance/file dep + module graph) keyed on the target id. Returns true
+  // exactly once per (recording-relevant context, id) per session; the caller
+  // then performs the walk. A given id resolves to one resource, so its kind
+  // (instance vs file) is fixed and need not be in the key. Returns false while
+  // inactive — nothing records, so the walk would be pure waste and nothing is
+  // marked, so it still runs in a later active session.
+  shouldTrackRelationship(
+    id: string,
+    explicitContext?: RuntimeDependencyTrackingContext,
+  ): boolean {
+    if (!this.#isActive) {
+      return false;
+    }
+    let context = explicitContext ?? this.#currentContext();
+    let consumerKind = context.consumer
+      ? (context.consumerKind ?? 'instance')
+      : '';
+    let key = [
+      contextLabel(context),
+      context.consumer ?? '',
+      consumerKind,
+      id,
+    ].join(CACHE_KEY_SEPARATOR);
+    if (this.#trackedRelationships.has(key)) {
+      return false;
+    }
+    this.#trackedRelationships.add(key);
     return true;
   }
 
@@ -532,6 +577,13 @@ export function shouldTrackRuntimeModuleGraph(
   context?: RuntimeDependencyTrackingContext,
 ): boolean {
   return getTracker().shouldTrackModuleGraph(scope, rootModule, context);
+}
+
+export function shouldTrackRuntimeRelationship(
+  id: string,
+  context?: RuntimeDependencyTrackingContext,
+): boolean {
+  return getTracker().shouldTrackRelationship(id, context);
 }
 
 export function trackRuntimeInstanceDependency(


### PR DESCRIPTION
A prerender/indexing render blocks persistence and discards the live query
results it computes, yet several pieces of per-instance work still ran on the
hot path — once per loaded instance, once per fetch, once per relationship read,
once per field-map lookup, and across the whole query-backed closure when
building the search doc — and compounded badly on a densely cross-linked graph.
Each change below removes work whose result the indexing render cannot use, or
that it had already computed.

## Skip the autosave subscription in the render context

`StoreService.startAutoSaving` subscribes every loaded instance to change
notifications so edits can be autosaved. In a render, persistence is blocked, so
that subscription can never produce a save — but wiring it up (and tearing the
prior one down) walks the instance's fields via `getFields` → `getDeps` →
`makeDependencyGraph` on every load. It now returns early when
`renderContextBlocksPersistence()`.

## Memoize the session-token restore

The authorization middleware reads `realm.token(url)` on every fetch. For any
realm it hasn't resolved into a `RealmResource` yet (e.g. token-less public
realms), the render-context branch re-parsed the entire localStorage session
blob — `getItem` + `JSON.parse` + a walk over every token — on each call.
`restoreSessionsFromStorage` now memoizes on the raw stored string: an unchanged
blob is parsed and walked once, and a newly seeded realm session changes the
string and re-runs the walk. The memo is cleared in `resetState`.

## Dedup the relationship-dependency walk

A `linksTo` / `linksToMany` getter runs the runtime relationship-dependency walk
(instance/file dep + the linked type's module graph) on every read, and a dense
graph re-reads the same targets combinatorially. A new per-(recording-relevant
context, target id) probe in the dependency tracker — a sibling of the existing
module-graph probe — short-circuits the whole walk on a repeat. A repeat
re-derives the identical node set, so skipping it (and the prototype/identity
lookups ahead of it) is a pure no-op; the key is by value so it collapses the
explicit-context path too, and it's cleared on tracker reset.

## Memoize the field map during a render

`getFields` walks the prototype chain and resolves every field on each call, and
a render calls it repeatedly for the same instances — once per serialize, per
searchDoc, and per `getDeps`/`findInstances` recursion. `getFields` now caches
per subject (instance or class) in the render context, keyed by a WeakMap, with
a validity token (override-map + data-bucket sizes — a read-only render only
grows those) guarding reuse. Gated on the render context so the live app, where
instances mutate freely, is never served a memoized map.

## Don't index query-backed fields

A query-backed field is resolved live from a query, and the index has no way to
invalidate it when matching cards change — so its value would always be stale in
the indexed doc. Building that value also means traversing and deep-resolving
the query closure, which is what pegs the `render.meta` pass past the render
budget on a dense realm. So `render.meta` no longer touches query-backed fields:

- The search-doc builder (`card-api` card-level `[queryableValue]`) skips fields
  with a `queryDefinition`.
- `render.meta`'s `serializeCard` passes `omitQueryFields: true`, so the
  serialized doc doesn't deep-serialize the query closure into `included[]` (the
  relationship data is stripped right after regardless, and membership comes
  from the file's own relationships).

## Also

- Drop a leftover diagnostic `console.error` from the `linksTo` getter, and a
  needless optional-chain in `getUsedFields`.
- Note in the indexing-diagnostics skill that the V8 `--prof` artifact lands in
  S3 only on the render-level timeout, minutes after the worker rejects the job
  on the shorter request-abort timeout.

## Tests

- `Integration | Store`: a render-context load sets up no autosave subscription
  (a live store still does); an unchanged session blob is not re-walked, a
  changed one is; `getFields` is memoized per instance in the render context and
  invalidates as the instance grows (live app always gets a fresh map).
- `runtime-dependency-tracker-test`: the relationship probe permits the walk
  exactly once per (context, id) per session, dedups by value, and resets per
  session.
- `prerender serialize cycle`: a query-backed field is omitted from the search
  doc while ordinary contains / linksTo(Many) fields are kept.
