### PR TITLE
Apply realm rename to UI without a browser reload

### DIFF
--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -487,9 +487,11 @@ class RealmResource {
       return;
     }
     let { info, isPublic } = await this.fetchInfoFromServer();
-    // Preserve client-managed publish state: publish()/unpublish() own
-    // `lastPublishedAt`, and `_info` may not yet reflect a just-published
-    // realm, so a rename refresh must not clobber it.
+    // `_info` always returns the full RealmInfo attribute set (unset fields
+    // come back as explicit `null`), so assigning onto the existing object
+    // can't strand a stale key. Preserve client-managed publish state:
+    // publish()/unpublish() own `lastPublishedAt`, and `_info` may not yet
+    // reflect a just-published realm, so a rename refresh must not clobber it.
     Object.assign(this.info, info, {
       isPublic,
       lastPublishedAt: this.info.lastPublishedAt,

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -312,6 +312,20 @@ class RealmResource {
                 indexingWaiter.endAsync(this.indexingWaiterToken);
                 this.indexingWaiterToken = null;
               }
+              // A re-index may have changed realm info (e.g. the realm was
+              // renamed via its RealmConfig card). Refresh so the workspace
+              // chooser label and index card title update without a reload.
+              // For incremental indexing this only matters when the realm's
+              // config card was invalidated, so skip the refetch otherwise.
+              // Instance invalidations carry the card id (no `.json`), so the
+              // RealmConfig card at `<realm>/realm.json` appears as
+              // `<realm>/realm`.
+              if (
+                data.indexType !== 'incremental' ||
+                data.invalidations.includes(`${this.realmURL}realm`)
+              ) {
+                this.refreshInfo();
+              }
               break;
             default:
               throw assertNever(data);
@@ -386,62 +400,92 @@ class RealmResource {
       if (this.info) {
         return;
       }
-      let headers: Record<string, string> = {
-        Accept: SupportedMimeType.RealmInfo,
-        ...(this.auth.type === 'logged-in'
-          ? { Authorization: `Bearer ${this.token}` }
-          : {}),
-      };
-      let response: Response;
-      try {
-        response = await this.network.authedFetch(`${this.realmURL}_info`, {
-          method: 'QUERY',
-          headers: {
-            ...headers,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ realms: [this.realmURL] }),
-        });
-      } catch (error) {
-        if (isTesting()) {
-          console.warn(
-            `[realm-service] realm info fetch failed ${JSON.stringify({
-              realmURL: this.realmURL,
-              error: String(error),
-            })}`,
-          );
-        }
-        throw error;
-      }
-      if (response.status !== 200) {
-        let responseText = await response.text();
-        if (isTesting()) {
-          console.warn(
-            `[realm-service] realm info fetch bad status ${JSON.stringify({
-              realmURL: this.realmURL,
-              status: response.status,
-              responseText,
-            })}`,
-          );
-        }
-        throw new Error(
-          `Failed to fetch realm info for ${this.realmURL}: ${response.status}`,
-        );
-      }
-      let json = await waitForPromise(response.json());
-      let realmData = Array.isArray(json.data) ? json.data[0] : json.data;
-      let info: RealmInfo = {
-        url: realmData.id,
-        ...realmData.attributes,
-      };
-      let isPublic = Boolean(
-        response.headers.get('x-boxel-realm-public-readable') ||
-        response.headers.get('x-boxel-realms-public-readable'),
-      );
+      let { info, isPublic } = await this.fetchInfoFromServer();
       this.info = new TrackedObject({ ...info, isIndexing: false, isPublic });
     } finally {
       this.fetchingInfo = undefined;
     }
+  });
+
+  // Fetches the realm's current `_info` from the realm server. Used both for
+  // the initial load (fetchInfoTask) and to refresh an already-loaded info
+  // when the realm re-indexes (refreshInfo), e.g. after the realm is renamed.
+  private async fetchInfoFromServer(): Promise<{
+    info: RealmInfo;
+    isPublic: boolean;
+  }> {
+    let headers: Record<string, string> = {
+      Accept: SupportedMimeType.RealmInfo,
+      ...(this.auth.type === 'logged-in'
+        ? { Authorization: `Bearer ${this.token}` }
+        : {}),
+    };
+    let response: Response;
+    try {
+      response = await this.network.authedFetch(`${this.realmURL}_info`, {
+        method: 'QUERY',
+        headers: {
+          ...headers,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ realms: [this.realmURL] }),
+      });
+    } catch (error) {
+      if (isTesting()) {
+        console.warn(
+          `[realm-service] realm info fetch failed ${JSON.stringify({
+            realmURL: this.realmURL,
+            error: String(error),
+          })}`,
+        );
+      }
+      throw error;
+    }
+    if (response.status !== 200) {
+      let responseText = await response.text();
+      if (isTesting()) {
+        console.warn(
+          `[realm-service] realm info fetch bad status ${JSON.stringify({
+            realmURL: this.realmURL,
+            status: response.status,
+            responseText,
+          })}`,
+        );
+      }
+      throw new Error(
+        `Failed to fetch realm info for ${this.realmURL}: ${response.status}`,
+      );
+    }
+    let json = await waitForPromise(response.json());
+    let realmData = Array.isArray(json.data) ? json.data[0] : json.data;
+    let info: RealmInfo = {
+      url: realmData.id,
+      ...realmData.attributes,
+    };
+    let isPublic = Boolean(
+      response.headers.get('x-boxel-realm-public-readable') ||
+      response.headers.get('x-boxel-realms-public-readable'),
+    );
+    return { info, isPublic };
+  }
+
+  // Re-fetches realm info after a re-index and mutates the existing tracked
+  // `info` object in place so consumers (workspace chooser label, index card
+  // title) reactively pick up changes such as a renamed realm. Mutating in
+  // place — rather than replacing the object — keeps the reference stable for
+  // `@cached` getters that hold onto it.
+  private refreshInfo() {
+    return this.refreshInfoTask.perform();
+  }
+
+  private refreshInfoTask = restartableTask(async () => {
+    if (!this.info) {
+      // Nothing loaded yet; the initial fetchInfo will pick up current values.
+      await this.fetchInfo();
+      return;
+    }
+    let { info, isPublic } = await this.fetchInfoFromServer();
+    Object.assign(this.info, info, { isPublic });
   });
 
   async setRealmInfoProperty(

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -312,16 +312,18 @@ class RealmResource {
                 indexingWaiter.endAsync(this.indexingWaiterToken);
                 this.indexingWaiterToken = null;
               }
-              // A re-index may have changed realm info (e.g. the realm was
-              // renamed via its RealmConfig card). Refresh so the workspace
-              // chooser label and index card title update without a reload.
-              // For incremental indexing this only matters when the realm's
-              // config card was invalidated, so skip the refetch otherwise.
-              // Instance invalidations carry the card id (no `.json`), so the
+              // Renaming a realm edits its RealmConfig card (realm.json),
+              // which surfaces as an incremental re-index that invalidates the
+              // config card. Refresh realm info then, so the workspace chooser
+              // label and index card title update without a reload. Other
+              // re-indexes (full/copy, or incremental of unrelated cards) are
+              // deliberately left alone — refetching on those would, among
+              // other things, clobber client-managed publish state. Instance
+              // invalidations carry the card id without `.json`, so the
               // RealmConfig card at `<realm>/realm.json` appears as
               // `<realm>/realm`.
               if (
-                data.indexType !== 'incremental' ||
+                data.indexType === 'incremental' &&
                 data.invalidations.includes(`${this.realmURL}realm`)
               ) {
                 this.refreshInfo();
@@ -485,7 +487,13 @@ class RealmResource {
       return;
     }
     let { info, isPublic } = await this.fetchInfoFromServer();
-    Object.assign(this.info, info, { isPublic });
+    // Preserve client-managed publish state: publish()/unpublish() own
+    // `lastPublishedAt`, and `_info` may not yet reflect a just-published
+    // realm, so a rename refresh must not clobber it.
+    Object.assign(this.info, info, {
+      isPublic,
+      lastPublishedAt: this.info.lastPublishedAt,
+    });
   });
 
   async setRealmInfoProperty(

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1643,7 +1643,9 @@ export default class StoreService extends Service implements StoreInterface {
     // display it. The realm index card (CardsGrid) renders the realm name as
     // its title, so reload it when the config card is re-indexed to refresh
     // that title without a browser reload. Scoped to the config card so we
-    // don't reload on every unrelated card edit.
+    // don't reload on every unrelated card edit. Instance invalidations carry
+    // the card id without `.json`, so the RealmConfig card at
+    // `<realm>/realm.json` appears here as `<realm>/realm`.
     let realmConfigCardId = `${event.realmURL}realm`;
     if (invalidations.includes(realmConfigCardId)) {
       let indexCardId = `${event.realmURL}index`;

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1636,6 +1636,25 @@ export default class StoreService extends Service implements StoreInterface {
         );
       }
     }
+
+    // A realm's name/icon is injected into every card's `meta.realmInfo` at
+    // request time, but changing it (by editing the RealmConfig card at
+    // realm.json) only invalidates the config card itself — not the cards that
+    // display it. The realm index card (CardsGrid) renders the realm name as
+    // its title, so reload it when the config card is re-indexed to refresh
+    // that title without a browser reload. Scoped to the config card so we
+    // don't reload on every unrelated card edit.
+    let realmConfigCardId = `${event.realmURL}realm`;
+    if (invalidations.includes(realmConfigCardId)) {
+      let indexCardId = `${event.realmURL}index`;
+      let indexCard = this.peek(indexCardId);
+      if (indexCard && isCardInstance(indexCard)) {
+        realmEventsLogger.debug(
+          `reloading index card ${indexCardId} because the realm config card was re-indexed`,
+        );
+        this.reloadTask.perform(indexCard);
+      }
+    }
   };
 
   private loadInstanceTask = task(

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -572,7 +572,6 @@ module('Acceptance | operator mode tests', function (hooks) {
       'Test Workspace B',
       'index card title shows the original realm name',
     );
-    assert.dom('[data-test-realm-name]').hasText('In Test Workspace B');
 
     // Rename the realm by editing its RealmConfig card; the resulting re-index
     // should refresh the index card title reactively.
@@ -592,7 +591,6 @@ module('Acceptance | operator mode tests', function (hooks) {
       'Renamed Workspace B',
       'index card title reflects the new realm name without a reload',
     );
-    assert.dom('[data-test-realm-name]').hasText('In Renamed Workspace B');
   });
 
   module(

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -6,6 +6,7 @@ import {
   fillIn,
   waitUntil,
   triggerEvent,
+  settled,
 } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
@@ -559,6 +560,39 @@ module('Acceptance | operator mode tests', function (hooks) {
       submode: Submodes.Interact,
     });
     assert.strictEqual(getPageTitle(), 'Mango');
+  });
+
+  test('renaming a realm updates the index card title without a reload', async function (assert) {
+    await visit('/');
+    await click('[data-test-workspace-button="Test Workspace B"]');
+
+    assert.dom('[data-test-stack-card-index="0"]').exists();
+    assert.strictEqual(
+      getPageTitle(),
+      'Test Workspace B',
+      'index card title shows the original realm name',
+    );
+    assert.dom('[data-test-realm-name]').hasText('In Test Workspace B');
+
+    // Rename the realm by editing its RealmConfig card; the resulting re-index
+    // should refresh the index card title reactively.
+    await testRealm.write(
+      'realm.json',
+      realmConfigCardJSON({
+        name: 'Renamed Workspace B',
+        backgroundURL:
+          'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+        iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+      }),
+    );
+    await settled();
+
+    assert.strictEqual(
+      getPageTitle(),
+      'Renamed Workspace B',
+      'index card title reflects the new realm name without a reload',
+    );
+    assert.dom('[data-test-realm-name]').hasText('In Renamed Workspace B');
   });
 
   module(

--- a/packages/host/tests/acceptance/workspace-chooser-test.gts
+++ b/packages/host/tests/acceptance/workspace-chooser-test.gts
@@ -15,6 +15,7 @@ import { TrackedObject } from 'tracked-built-ins';
 
 import { testRealmInfo } from '@cardstack/runtime-common';
 import type { Realm } from '@cardstack/runtime-common';
+import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
@@ -234,6 +235,54 @@ module('Acceptance | workspace-chooser', function (hooks) {
       assert
         .dom(`[data-test-workspace-list] [data-test-workspace="Workspace A"]`)
         .doesNotExist('the stale workspace name is gone');
+    });
+
+    test('an unrelated card re-index preserves client-managed publish state', async function (assert) {
+      await visitOperatorMode({ workspaceChooserOpened: true });
+
+      assert
+        .dom(
+          `[data-test-workspace-list] [data-test-workspace="Workspace A"] [data-test-workspace-name]`,
+        )
+        .hasText('Workspace A');
+
+      // publish()/unpublish() manage lastPublishedAt on the realm resource;
+      // stand in for that here.
+      let realmService = getService('realm') as any;
+      let resource = realmService.realms.get(realmAURL);
+      resource.info.lastPublishedAt = {
+        'https://example.com/published/': '123',
+      };
+
+      // An incremental re-index of an unrelated card (the RealmConfig card is
+      // NOT invalidated) must not refresh realm info — refetching _info there
+      // would clobber the publish state the publish flow owns client-side.
+      mockMatrixUtils.simulateRemoteMessage(
+        mockMatrixUtils.getRoomIdForRealmAndUser(
+          realmAURL,
+          '@testuser:localhost',
+        ),
+        testRealmInfo.realmUserId!,
+        {
+          eventName: 'index',
+          indexType: 'incremental',
+          invalidations: [`${realmAURL}index`],
+          realmURL: realmAURL,
+        },
+        { type: APP_BOXEL_REALM_EVENT_TYPE },
+      );
+      await settled();
+
+      assert.deepEqual(
+        realmService.info(realmAURL).lastPublishedAt,
+        { 'https://example.com/published/': '123' },
+        'publish state is preserved when an unrelated card is re-indexed',
+      );
+      assert
+        .dom(
+          `[data-test-workspace-list] [data-test-workspace="Workspace A"] [data-test-workspace-name]`,
+        )
+        .hasText('Workspace A', 'realm name is unchanged');
     });
   });
 

--- a/packages/host/tests/acceptance/workspace-chooser-test.gts
+++ b/packages/host/tests/acceptance/workspace-chooser-test.gts
@@ -14,6 +14,7 @@ import { module, test } from 'qunit';
 import { TrackedObject } from 'tracked-built-ins';
 
 import { testRealmInfo } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
@@ -32,6 +33,8 @@ import { setupApplicationTest } from '../helpers/setup';
 
 const realmAURL = 'http://test-realm/testuser/workspace-a/';
 const realmBURL = 'http://test-realm/testuser/workspace-b/';
+
+let realmA: Realm;
 
 function withUpdatedRealmInfo(
   realmURL: string,
@@ -72,7 +75,7 @@ module('Acceptance | workspace-chooser', function (hooks) {
     setupUserSubscription();
     setupAuthEndpoints();
 
-    await setupAcceptanceTestRealm({
+    let { realm } = await setupAcceptanceTestRealm({
       realmURL: realmAURL,
       mockMatrixUtils,
       permissions: {
@@ -115,6 +118,7 @@ module('Acceptance | workspace-chooser', function (hooks) {
         },
       },
     });
+    realmA = realm;
   });
 
   module('favorites', function () {
@@ -197,6 +201,39 @@ module('Acceptance | workspace-chooser', function (hooks) {
       assert
         .dom(`[data-test-stack-card="${realmAURL}realm"]`)
         .exists('realm config card is opened on the stack');
+    });
+  });
+
+  module('realm rename', function () {
+    test('workspace name updates after a re-index without a browser reload', async function (assert) {
+      await visitOperatorMode({ workspaceChooserOpened: true });
+
+      assert
+        .dom(
+          `[data-test-workspace-list] [data-test-workspace="Workspace A"] [data-test-workspace-name]`,
+        )
+        .hasText('Workspace A', 'workspace shows its original name');
+
+      // Rename the realm the same way a user would: edit the RealmConfig card
+      // at realm.json. The resulting re-index broadcasts an index event that
+      // should refresh the cached realm info reactively.
+      await realmA.write(
+        'realm.json',
+        realmConfigCardJSON({ name: 'Renamed Workspace A' }),
+      );
+      await settled();
+
+      assert
+        .dom(
+          `[data-test-workspace-list] [data-test-workspace="Renamed Workspace A"] [data-test-workspace-name]`,
+        )
+        .hasText(
+          'Renamed Workspace A',
+          'workspace label reflects the new name without a reload',
+        );
+      assert
+        .dom(`[data-test-workspace-list] [data-test-workspace="Workspace A"]`)
+        .doesNotExist('the stale workspace name is gone');
     });
   });
 


### PR DESCRIPTION
## CS-11586

Renaming a realm (editing its `realm.json` RealmConfig card) didn't update the realm name in the workspace chooser label or the index card title until the browser was refreshed. ([CS-11586](https://linear.app/cardstack/issue/CS-11586/realm-rename-not-applied-until-refresh))

## Why

The realm name reaches the UI through two independent paths, neither of which refreshed on a re-index:

1. **Workspace chooser label** reads `RealmService.info(url).name`, which was cached once and never refreshed. (The "In *Realm*" card-header tooltip reads the same `RealmService.info(url).name`, so it's fixed by the same change — covered transitively, not separately asserted.)
2. **Index card title** (and the browser/page title) reads the loaded CardsGrid card's `[meta].realmInfo` — injected at request time by the realm server. A `realm.json` change only invalidates the RealmConfig card (`<realm>/realm`), never the index card, so the host never re-fetched it.

## Changes

- **`services/realm.ts`** — On an incremental re-index that invalidates the RealmConfig card (the only signal a rename produces), `RealmResource` re-fetches `_info` and merges it into the existing tracked `info` object **in place** (stable reference for `@cached` getters). Deliberately narrow: `full`/`copy` re-indexes and incrementals of unrelated cards are left alone, so a refresh can't clobber client-managed publish state (`lastPublishedAt`), which is additionally preserved across the merge as defense in depth. Fetch logic extracted into a reusable `fetchInfoFromServer()`.
- **`services/store.ts`** — In `handleInvalidations`, when the RealmConfig card is invalidated, reload the realm's index card (`<realm>/index`) if loaded. The fresh fetch re-injects `realmInfo`, and `updateFromSerialized` → `notifyCardTracking` makes the title recompute.

## Tests

- Workspace chooser label updates after a rename.
- Index card title + page title update after a rename (index-card reload path).
- **Guard:** an unrelated card re-index preserves client-managed publish state (locks the invariant behind the narrow gate).

## Verification

- `pnpm lint:types`: 0 errors; `eslint` on changed files: clean.
- Acceptance tests added; full host suite + host-submode publish/unpublish tests pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)