### PR TITLE
Order queue dequeue by (created_at, id) to fix flaky serial-order test

### DIFF
--- a/packages/postgres/pg-queue.ts
+++ b/packages/postgres/pg-queue.ts
@@ -585,6 +585,11 @@ export class PgQueueRunner implements QueueRunner {
 
           let jobs = (await query([
             // find the queue with the oldest job that isn't running and lock it.
+            // Break created_at ties on the monotonic id so the job enqueued
+            // first always wins — two jobs in the same concurrency group can
+            // share a created_at (current_timestamp is the transaction start
+            // time), and without the tiebreaker the worker could claim them
+            // out of enqueue order.
             `WITH
               pending_jobs AS (
                 SELECT * FROM jobs WHERE status='unfulfilled' and priority >=`,
@@ -603,7 +608,7 @@ export class PgQueueRunner implements QueueRunner {
               AND j.concurrency_group NOT IN (
                 SELECT concurrency_group FROM active_concurrency_groups
               )
-              ORDER BY j.created_at
+              ORDER BY j.created_at, j.id
               LIMIT 1`,
           ])) as unknown as JobsTable[];
           if (jobs.length === 0) {

--- a/packages/realm-server/tests/queue-test.ts
+++ b/packages/realm-server/tests/queue-test.ts
@@ -1431,7 +1431,10 @@ module(basename(__filename), function () {
         runner.register('logJob', logJob);
         runner2.register('logJob', logJob);
 
-        let promiseForJob1 = publisher.publish({
+        // Await job1's publish so it is durably enqueued (and picked up by a
+        // worker during the sleep below) before job2 is published — the
+        // assertion below depends on job1 starting first.
+        let job1 = await publisher.publish({
           jobType: 'logJob',
           concurrencyGroup: 'log-group',
           timeout: 5000,
@@ -1439,21 +1442,20 @@ module(basename(__filename), function () {
         });
         // start the 2nd job before the first job finishes
         await new Promise((r) => setTimeout(r, 100));
-        let promiseForJob2 = publisher.publish({
+        let job2 = await publisher.publish({
           jobType: 'logJob',
           concurrencyGroup: 'other-group',
           timeout: 5000,
           args: 2,
         });
-        let [job1, job2] = await Promise.all([promiseForJob1, promiseForJob2]);
 
         await Promise.all([job1.done, job2.done]);
-        assert.deepEqual(events, [
-          'job1 start',
-          'job2 start',
-          'job1 finish',
-          'job2 finish',
-        ]);
+        assert.deepEqual(
+          events,
+          ['job1 start', 'job2 start', 'job1 finish', 'job2 finish'],
+          `different-group jobs overlap; job1=${job1.id} job2=${job2.id}; ` +
+            `events=${JSON.stringify(events)}`,
+        );
       });
 
       test('jobs are processed serially within a particular queue across different queue clients', async function (assert) {
@@ -1468,7 +1470,12 @@ module(basename(__filename), function () {
         runner.register('logJob', logJob);
         runner2.register('logJob', logJob);
 
-        let promiseForJob1 = publisher.publish({
+        // Await each publish so job1 is durably enqueued (its created_at
+        // fixed) before job2 is published. Workers dequeue by (created_at,
+        // id); leaving the publishes unawaited let job1's INSERT race job2's
+        // under load, so the two could share a created_at and run out of
+        // enqueue order.
+        let job1 = await publisher.publish({
           jobType: 'logJob',
           concurrencyGroup: 'log-group',
           timeout: 5000,
@@ -1476,21 +1483,26 @@ module(basename(__filename), function () {
         });
         // start the 2nd job before the first job finishes
         await new Promise((r) => setTimeout(r, 100));
-        let promiseForJob2 = publisher.publish({
+        let job2 = await publisher.publish({
           jobType: 'logJob',
           concurrencyGroup: 'log-group',
           timeout: 5000,
           args: 2,
         });
-        let [job1, job2] = await Promise.all([promiseForJob1, promiseForJob2]);
 
         await Promise.all([job1.done, job2.done]);
-        assert.deepEqual(events, [
-          'job1 start',
-          'job1 finish',
-          'job2 start',
-          'job2 finish',
-        ]);
+        let enqueueOrder = await adapter.execute(
+          `SELECT id, args, created_at FROM jobs WHERE id IN ($1, $2) ORDER BY created_at, id`,
+          { bind: [job1.id, job2.id] },
+        );
+        assert.deepEqual(
+          events,
+          ['job1 start', 'job1 finish', 'job2 start', 'job2 finish'],
+          `same-group jobs run in enqueue order; job1=${job1.id} job2=${job2.id}; ` +
+            `persisted order=${JSON.stringify(enqueueOrder)}; events=${JSON.stringify(
+              events,
+            )}`,
+        );
       });
 
       test('job can timeout; timed out job is picked up by another worker', async function (assert) {


### PR DESCRIPTION
## Flaky test

`queue-test.ts > queue > multiple queue clients > jobs are processed serially within a particular queue across different queue clients` intermittently fails: the two same-concurrency-group jobs run in reverse order (`job2` fully before `job1`). Serialization itself holds — only the order flips.

```
actual  : ["job2 start", "job2 finish", "job1 start", "job1 finish"]
expected: ["job1 start", "job1 finish", "job2 start", "job2 finish"]
```

## Why it happens

Two independent gaps let the run order flip:

- **Dequeue tiebreaker (production).** The worker selects the next job with `ORDER BY j.created_at` and no tiebreaker, while the coalesce candidate query already orders by `(created_at, id)`. `created_at` defaults to `current_timestamp` (the transaction start time), so two jobs in the same concurrency group can share a `created_at`; on a tie the worker claims an arbitrary one.
- **Unawaited publish (test).** The test published `job1` without awaiting it, slept 100ms, then published `job2`. With the publish unawaited, `job1`'s INSERT can race `job2`'s under load and land at the same — or a later — `created_at`, so the queue (correctly, by its own rules) runs `job2` first.

## Fix

- `pg-queue.ts`: dequeue by `ORDER BY j.created_at, j.id` so the job enqueued first always wins, matching the coalesce query and the FIFO contract.
- `queue-test.ts`: await each publish so `job1` is durably enqueued before `job2`, giving it a strictly earlier `created_at`. Applied to the sibling "different concurrency groups can run in parallel" test, which shared the same fragile idiom.
- Diagnostics: the serial test now dumps the persisted `(created_at, id)` order and both job ids in the assertion message, so any future regression shows whether the queue mis-ordered a correctly-enqueued pair (a real serialization bug) or the publishes raced.

Ran the `multiple queue clients` module 15× locally — all green.
