### PR TITLE
Wire command-definition upload to read commands from skill markdown files

### DIFF
--- a/packages/host/app/commands/update-room-skills.ts
+++ b/packages/host/app/commands/update-room-skills.ts
@@ -1,17 +1,24 @@
 import { service } from '@ember/service';
 
-import { isCardErrorJSONAPI, isCardInstance } from '@cardstack/runtime-common';
 import { APP_BOXEL_ROOM_SKILLS_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
-import type { SerializedFile } from 'https://cardstack.com/base/file-api';
+import type {
+  FileDef,
+  SerializedFile,
+} from 'https://cardstack.com/base/file-api';
 
 import type * as SkillModule from 'https://cardstack.com/base/skill';
 
 import { isSkillCard } from '../lib/file-def-manager';
 
 import HostBaseCommand from '../lib/host-base-command';
+import {
+  getSkillSourceCommands,
+  loadSkillSource,
+  type SkillSource,
+} from '../lib/skill-commands';
 
 import type MatrixService from '../services/matrix-service';
 import type StoreService from '../services/store';
@@ -71,8 +78,12 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
           }
         }
 
-        let skillCardCache = new Map<string, SkillModule.Skill>();
-        let skillsNeedingUpload: SkillModule.Skill[] = [];
+        let skillSourceCache = new Map<string, SkillSource>();
+        // Skill cards re-upload their serialized card content; skill markdown
+        // files re-upload their file content. Both produce the FileDef stored
+        // in the room's enabled-skills config.
+        let skillCardsNeedingUpload: SkillModule.Skill[] = [];
+        let markdownSkillsNeedingUpload: FileDef[] = [];
         let skillIdsToActivate = new Set(skillCardIdsToActivate);
 
         for (let skillId of skillIdsToActivate) {
@@ -87,18 +98,17 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
           }
 
           try {
-            let maybeSkillCard =
-              await this.store.get<SkillModule.Skill>(skillId);
-            if (
-              isCardInstance(maybeSkillCard) &&
-              Object.prototype.hasOwnProperty.call(maybeSkillCard, isSkillCard)
-            ) {
-              let skillCard = maybeSkillCard as SkillModule.Skill;
-              skillCardCache.set(skillId, skillCard);
-              skillsNeedingUpload.push(skillCard);
+            let source = await loadSkillSource(this.store, skillId);
+            if (source) {
+              skillSourceCache.set(skillId, source);
+              if (isSkillCard in source) {
+                skillCardsNeedingUpload.push(source as SkillModule.Skill);
+              } else {
+                markdownSkillsNeedingUpload.push(source as FileDef);
+              }
             } else {
               console.warn(
-                `[UpdateRoomSkillsCommand] skipping activation of "${skillId}": ${describeStoreResult(maybeSkillCard)}`,
+                `[UpdateRoomSkillsCommand] skipping activation of "${skillId}": not a skill card or skill markdown file`,
               );
             }
           } catch (err) {
@@ -108,16 +118,24 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
           }
         }
 
-        if (skillsNeedingUpload.length > 0) {
-          let uploadedSkillFileDefs = await this.matrixService.uploadCards(
-            skillsNeedingUpload as CardDef[],
+        let uploadedSkillFileDefs: FileDef[] = [];
+        if (skillCardsNeedingUpload.length > 0) {
+          uploadedSkillFileDefs = uploadedSkillFileDefs.concat(
+            await this.matrixService.uploadCards(
+              skillCardsNeedingUpload as CardDef[],
+            ),
           );
-          for (let uploaded of uploadedSkillFileDefs) {
-            let serialized = uploaded.serialize();
-            if (serialized.sourceUrl) {
-              enabledSkillCardMap.set(serialized.sourceUrl, serialized);
-              disabledSkillCardMap.delete(serialized.sourceUrl);
-            }
+        }
+        if (markdownSkillsNeedingUpload.length > 0) {
+          uploadedSkillFileDefs = uploadedSkillFileDefs.concat(
+            await this.matrixService.uploadFiles(markdownSkillsNeedingUpload),
+          );
+        }
+        for (let uploaded of uploadedSkillFileDefs) {
+          let serialized = uploaded.serialize();
+          if (serialized.sourceUrl) {
+            enabledSkillCardMap.set(serialized.sourceUrl, serialized);
+            disabledSkillCardMap.delete(serialized.sourceUrl);
           }
         }
 
@@ -129,25 +147,17 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
         let enabledSkillIds = Array.from(enabledSkillCardMap.keys());
         let loadedEnabledSkills = await Promise.all(
           enabledSkillIds.map(async (skillId) => {
-            if (skillCardCache.has(skillId)) {
-              return skillCardCache.get(skillId)!;
+            if (skillSourceCache.has(skillId)) {
+              return skillSourceCache.get(skillId)!;
             }
             try {
-              let maybeSkillCard =
-                await this.store.get<SkillModule.Skill>(skillId);
-              if (
-                isCardInstance(maybeSkillCard) &&
-                Object.prototype.hasOwnProperty.call(
-                  maybeSkillCard,
-                  isSkillCard,
-                )
-              ) {
-                let skillCard = maybeSkillCard as SkillModule.Skill;
-                skillCardCache.set(skillId, skillCard);
-                return skillCard;
+              let source = await loadSkillSource(this.store, skillId);
+              if (source) {
+                skillSourceCache.set(skillId, source);
+                return source;
               }
               console.warn(
-                `[UpdateRoomSkillsCommand] cannot rehydrate enabled skill "${skillId}": ${describeStoreResult(maybeSkillCard)}`,
+                `[UpdateRoomSkillsCommand] cannot rehydrate enabled skill "${skillId}": not a skill card or skill markdown file`,
               );
             } catch (err) {
               console.warn(
@@ -159,7 +169,7 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
         );
 
         let validEnabledSkills = loadedEnabledSkills.filter(
-          (skill): skill is SkillModule.Skill => Boolean(skill),
+          (skill): skill is SkillSource => Boolean(skill),
         );
 
         let previousCommandDefinitions =
@@ -169,8 +179,8 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
         ];
 
         if (validEnabledSkills.length > 0) {
-          let allCommandDefinitions = validEnabledSkills.flatMap(
-            (skill) => skill.commands ?? [],
+          let allCommandDefinitions = validEnabledSkills.flatMap((skill) =>
+            getSkillSourceCommands(skill),
           );
 
           if (allCommandDefinitions.length > 0) {
@@ -201,26 +211,6 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
       },
     );
   }
-}
-
-// Stable, redaction-safe one-line summary of whatever `store.get` produced for
-// a skill. Avoids dumping the full instance / error payload (which can be
-// large and may carry user content) while still naming the failure mode.
-function describeStoreResult(result: unknown): string {
-  if (result == null) {
-    return `store.get returned ${result === null ? 'null' : 'undefined'}`;
-  }
-  if (isCardErrorJSONAPI(result)) {
-    let status = (result as { status?: number }).status;
-    let title = (result as { title?: string }).title;
-    return `store.get returned a CardErrorJSONAPI (status=${status ?? 'n/a'}, title=${JSON.stringify(title ?? '')})`;
-  }
-  if (isCardInstance(result)) {
-    return `store.get returned a card instance that is not a Skill (id=${
-      (result as { id?: string }).id ?? '<no id>'
-    })`;
-  }
-  return `store.get returned an unrecognized value of type ${typeof result}`;
 }
 
 function errorSummary(err: unknown): string {

--- a/packages/host/app/lib/skill-commands.ts
+++ b/packages/host/app/lib/skill-commands.ts
@@ -1,0 +1,98 @@
+import { isCardInstance } from '@cardstack/runtime-common';
+
+import type { MarkdownDef } from 'https://cardstack.com/base/markdown-file-def';
+import type * as SkillModule from 'https://cardstack.com/base/skill';
+
+import { isSkillCard } from './file-def-manager';
+
+import type StoreService from '../services/store';
+
+// A skill is either a `Skill` card (commands on `Skill.commands`) or a
+// markdown file whose `boxel.kind: skill` frontmatter rehydrates as a
+// `SkillFrontmatterField` (commands on `MarkdownDef.frontmatter.commands`).
+// Both `commands` fields are `containsMany(CommandField)`, so once gathered the
+// `CommandField` instances feed the command-definition upload flow identically.
+export type SkillSource = SkillModule.Skill | MarkdownDef;
+
+const MARKDOWN_EXTENSION = /\.(md|markdown)$/i;
+
+// A markdown skill carries its kind on the indexed `MarkdownDef.kind` field.
+export const SKILL_MARKDOWN_KIND = 'skill';
+
+function isSkillCardInstance(instance: unknown): instance is SkillModule.Skill {
+  return (
+    typeof instance === 'object' && instance !== null && isSkillCard in instance
+  );
+}
+
+function isSkillMarkdown(instance: unknown): instance is MarkdownDef {
+  return (
+    typeof instance === 'object' &&
+    instance !== null &&
+    (instance as MarkdownDef).kind === SKILL_MARKDOWN_KIND
+  );
+}
+
+export function isSkillSource(instance: unknown): instance is SkillSource {
+  return isSkillCardInstance(instance) || isSkillMarkdown(instance);
+}
+
+// Returns the `CommandField` instances a skill source contributes, regardless
+// of whether the source is a `Skill` card or a skill-bearing markdown file.
+export function getSkillSourceCommands(
+  instance: SkillSource | null | undefined,
+): SkillModule.CommandField[] {
+  if (isSkillCardInstance(instance)) {
+    return instance.commands ?? [];
+  }
+  if (isSkillMarkdown(instance)) {
+    // For `boxel.kind: skill`, `frontmatter` is a `SkillFrontmatterField` whose
+    // `commands` is the same `containsMany(CommandField)` as `Skill.commands`.
+    let frontmatter = instance.frontmatter as {
+      commands?: SkillModule.CommandField[];
+    } | null;
+    return frontmatter?.commands ?? [];
+  }
+  return [];
+}
+
+// True for ids that name a markdown file (skills live in `*.md` / `*.markdown`
+// files). Such ids load through the `file-meta` read type rather than as cards.
+export function isMarkdownSkillId(id: string): boolean {
+  let pathname: string;
+  try {
+    pathname = new URL(id).pathname;
+  } catch {
+    pathname = id;
+  }
+  return MARKDOWN_EXTENSION.test(pathname);
+}
+
+// Loads a skill by id, dispatching markdown files to the `file-meta` read type
+// and everything else to the card read type. Returns the instance only when it
+// is actually a skill source; otherwise `undefined`.
+export async function loadSkillSource(
+  store: StoreService,
+  id: string,
+): Promise<SkillSource | undefined> {
+  if (isMarkdownSkillId(id)) {
+    let fileMeta = await store.get<MarkdownDef>(id, { type: 'file-meta' });
+    return isSkillMarkdown(fileMeta) ? fileMeta : undefined;
+  }
+  let card = await store.get<SkillModule.Skill>(id);
+  return isCardInstance(card) && isSkillCardInstance(card) ? card : undefined;
+}
+
+// Synchronous, cache-only variant for code paths that already require loaded
+// instances (e.g. computing the room's usable commands).
+export function peekSkillSource(
+  store: StoreService,
+  id: string,
+): SkillSource | undefined {
+  if (isMarkdownSkillId(id)) {
+    let fileMeta = store.peek<MarkdownDef>(id, { type: 'file-meta' });
+    return isSkillMarkdown(fileMeta) ? fileMeta : undefined;
+  }
+  let card = store.peek<SkillModule.Skill>(id);
+  return isCardInstance(card) && isSkillCardInstance(card) ? card : undefined;
+}

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -56,6 +56,8 @@ import {
 
 import MessageBuilder from '../lib/matrix-classes/message-builder';
 
+import { getSkillSourceCommands, peekSkillSource } from '../lib/skill-commands';
+
 import type { Message } from '../lib/matrix-classes/message';
 
 import type Room from '../lib/matrix-classes/room';
@@ -333,12 +335,16 @@ export class RoomResource extends Resource<Args> {
   }
 
   get commands() {
-    // Usable commands are all commands on *active* skills
+    // Usable commands are all commands on *active* skills, whether the skill is
+    // a Skill card or a skill-bearing markdown file.
     let commands = [];
     for (let skill of this.skills) {
-      let skillCard = this.store.peek<Skill>(skill.cardId);
-      if (skillCard && isCardInstance(skillCard) && skill.isActive) {
-        commands.push(...skillCard.commands);
+      if (!skill.isActive) {
+        continue;
+      }
+      let skillSource = peekSkillSource(this.store, skill.cardId);
+      if (skillSource) {
+        commands.push(...getSkillSourceCommands(skillSource));
       }
     }
     return commands;

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -117,6 +117,7 @@ import UpdateRoomSkillsCommand from '../commands/update-room-skills';
 import { addPatchTools } from '../commands/utils';
 import { getUniqueValidCommandDefinitions } from '../lib/command-definitions';
 import { isSkillCard } from '../lib/file-def-manager';
+import { getSkillSourceCommands, loadSkillSource } from '../lib/skill-commands';
 import { skillCardURL, devSkillId, envSkillId } from '../lib/utils';
 import { importResource } from '../resources/import';
 
@@ -1026,24 +1027,32 @@ export default class MatrixService extends Service {
           (currentSkillsConfig?.enabledSkillCards ??
             []) as FileAPI.SerializedFile[];
         let enabledCommandDefinitions: SkillModule.CommandField[] = [];
-        let enabledSkillCards = (
-          await Promise.all(
-            enabledSkillCardFileDefs.map(async (fileDef) => {
-              const card = await this.store.get<SkillModule.Skill>(
-                fileDef.sourceUrl,
-              );
-              if (isSkillCard in card) {
-                enabledCommandDefinitions = enabledCommandDefinitions.concat(
-                  (card as SkillModule.Skill).commands ?? [],
-                );
-              }
-              return card;
-            }),
-          )
-        ).filter((card) => isSkillCard in card) as SkillModule.Skill[];
-        let enabledSkillFileDefs = await this.uploadCards(
-          enabledSkillCards as CardDef[],
+        // Skill cards re-upload their serialized card content; skill markdown
+        // files re-upload their file content. Both contribute commands.
+        let skillCardsToReupload: SkillModule.Skill[] = [];
+        let markdownSkillFileDefs: FileDef[] = [];
+        await Promise.all(
+          enabledSkillCardFileDefs.map(async (fileDef) => {
+            let source = await loadSkillSource(this.store, fileDef.sourceUrl);
+            if (!source) {
+              return;
+            }
+            enabledCommandDefinitions = enabledCommandDefinitions.concat(
+              getSkillSourceCommands(source),
+            );
+            if (isSkillCard in source) {
+              skillCardsToReupload.push(source as SkillModule.Skill);
+            } else {
+              markdownSkillFileDefs.push(this.fileAPI.createFileDef(fileDef));
+            }
+          }),
         );
+        let enabledSkillFileDefs = await this.uploadCards(
+          skillCardsToReupload as CardDef[],
+        );
+        let enabledMarkdownSkillFileDefs = markdownSkillFileDefs.length
+          ? await this.uploadFiles(markdownSkillFileDefs)
+          : [];
         // get the unique subset of enabledCommandDefinitions by functionName
         enabledCommandDefinitions = this.getUniqueCommandDefinitions(
           enabledCommandDefinitions,
@@ -1052,9 +1061,10 @@ export default class MatrixService extends Service {
           enabledCommandDefinitions,
         );
         return {
-          enabledSkillCards: enabledSkillFileDefs.map((fileDef) =>
-            fileDef.serialize(),
-          ),
+          enabledSkillCards: [
+            ...enabledSkillFileDefs,
+            ...enabledMarkdownSkillFileDefs,
+          ].map((fileDef) => fileDef.serialize()),
           disabledSkillCards: currentSkillsConfig?.disabledSkillCards ?? [],
           commandDefinitions: enabledCommandDefFileDefs.map((fileDef) =>
             fileDef.serialize(),

--- a/packages/host/tests/integration/commands/update-room-skills-test.gts
+++ b/packages/host/tests/integration/commands/update-room-skills-test.gts
@@ -175,6 +175,23 @@ export class DoThing extends Command {
                 }),
               ],
             }),
+            // A skill expressed as a markdown file: `boxel.kind: skill`
+            // frontmatter carries the same command shape as a Skill card.
+            'skills/markdown-skill/SKILL.md': `---
+name: Markdown Skill
+description: A skill expressed as a markdown file
+boxel:
+  kind: skill
+  commands:
+    - codeRef:
+        module: '${testRealmURL}test-command.gts'
+        name: DoThing
+      requiresApproval: false
+---
+# Markdown Skill
+
+Instructions live in the markdown body.
+`,
           },
         }),
       );
@@ -352,6 +369,73 @@ export class DoThing extends Command {
         commandDefJson.codeRef.name,
         'DoThing',
         'only valid command definition is uploaded',
+      );
+    });
+
+    test('activates a skill markdown file and uploads its command definitions', async function (assert) {
+      let command = new UpdateRoomSkillsCommand(
+        getService('command-service').commandContext,
+      );
+      let skillId = `${testRealmURL}skills/markdown-skill/SKILL.md`;
+      await command.execute({
+        roomId: matrixRoomId,
+        skillCardIdsToActivate: [skillId],
+        skillCardIdsToDeactivate: [],
+      });
+
+      let skillsRoomState = mockMatrixUtils.getRoomState(
+        matrixRoomId,
+        APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
+      );
+      assert.deepEqual(
+        skillsRoomState.enabledSkillCards.map((card: any) => card.sourceUrl),
+        [skillId],
+        'skill markdown file added to enabled list (not dropped as a non-card)',
+      );
+      assert.strictEqual(
+        skillsRoomState.disabledSkillCards.length,
+        0,
+        'no skills are disabled',
+      );
+
+      let commandDefSourceUrls = skillsRoomState.commandDefinitions.map(
+        (def: any) => def.sourceUrl,
+      );
+      assert.deepEqual(
+        commandDefSourceUrls,
+        [`${testRealmURL}test-command.gts/DoThing`],
+        "the markdown skill's frontmatter command is uploaded as a command definition",
+      );
+    });
+
+    test('gathers commands from both a skill card and a skill markdown file', async function (assert) {
+      let command = new UpdateRoomSkillsCommand(
+        getService('command-service').commandContext,
+      );
+      let cardSkillId = `${testRealmURL}Skill/boxel-environment`;
+      let markdownSkillId = `${testRealmURL}skills/markdown-skill/SKILL.md`;
+      await command.execute({
+        roomId: matrixRoomId,
+        skillCardIdsToActivate: [cardSkillId, markdownSkillId],
+        skillCardIdsToDeactivate: [],
+      });
+
+      let skillsRoomState = mockMatrixUtils.getRoomState(
+        matrixRoomId,
+        APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
+      );
+      assert.deepEqual(
+        skillsRoomState.enabledSkillCards
+          .map((card: any) => card.sourceUrl)
+          .sort(),
+        [cardSkillId, markdownSkillId].sort(),
+        'both the skill card and the skill markdown file are enabled',
+      );
+      // Both skills point at the same command; deduped by functionName to one.
+      assert.deepEqual(
+        skillsRoomState.commandDefinitions.map((def: any) => def.sourceUrl),
+        [`${testRealmURL}test-command.gts/DoThing`],
+        'the shared command is uploaded once across both skill sources',
       );
     });
   });


### PR DESCRIPTION
Stacked on #5244 (skill-as-markdown platform work).

The host's command-definition upload flow read commands only from `Skill` cards (`Skill.commands`). A skill is now also expressible as a markdown file whose `boxel.kind: skill` frontmatter rehydrates as a `SkillFrontmatterField`, exposing the same `containsMany(CommandField)` at `MarkdownDef.frontmatter.commands`. Because both are the same `CommandField`, the schemas feed the existing upload path unchanged — this is plumbing the markdown source in, not new schema logic.

## Changes
- **`lib/skill-commands`** (new): `isSkillSource` / `getSkillSourceCommands` extract `CommandField` instances uniformly from either a `Skill` card or a skill-bearing `MarkdownDef`; `loadSkillSource` / `peekSkillSource` load a skill by id, dispatching `*.md` ids to the `file-meta` read type.
- **`MatrixService.updateSkillsAndCommandsIfNeeded`**: re-uploads markdown skill content via `uploadFiles` and preserves those file defs (previously non-card skills were dropped), while concatenating their commands.
- **`UpdateRoomSkillsCommand`**: activates skill markdown files — uploading their content and gathering their commands alongside skill cards.
- **`RoomResource.get commands()`**: reads usable commands from either skill source.

## Tests
`update-room-skills-test`: activating a skill markdown file uploads its frontmatter command as a command definition, and a command shared between a skill card and a skill markdown file is uploaded once. Verified green in-browser.

## Not in scope (follow-ups)
- The skill-attach UI (`chooseCard` filtered to skill-card type) still surfaces only `Skill` cards, and `RoomResource.loadSkills` doesn't yet load markdown skills into the peek cache — so markdown skills aren't user-reachable via the menu yet; this is the enabling/upload layer.
- `CreateAiAssistantRoomCommand` is unchanged (its input is a typed `Skill[]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)