### PR TITLE
Mark software-factory project completed (query canonical issue-tracker type)

### DIFF
--- a/packages/software-factory/src/issue-scheduler.ts
+++ b/packages/software-factory/src/issue-scheduler.ts
@@ -199,22 +199,16 @@ export interface RealmIssueStoreConfig {
 
 export class RealmIssueStore implements IssueStore {
   private realmUrl: string;
-  private darkfactoryModuleUrl: string;
   private issueTrackerModuleUrl: string;
   private client: BoxelCLIClient;
   private workspaceDir: string;
 
   constructor(config: RealmIssueStoreConfig) {
     this.realmUrl = config.realmUrl;
-    this.darkfactoryModuleUrl = config.darkfactoryModuleUrl;
-    // The Issue class lives in `issue-tracker` and is re-exported by
-    // `darkfactory`. Factory-written issues adopt the darkfactory re-export;
-    // issues a human adds through the IssueTracker board adopt the canonical
-    // `issue-tracker` module instead. A type filter is module-URL-specific,
-    // so the scheduler must match either — otherwise UI-added issues are
-    // silently invisible to the loop.
-    // Swap the final path segment (`darkfactory` → `issue-tracker`),
-    // tolerating a trailing slash or other equivalent canonicalization.
+    // Tracker types (Issue/Project/IssueTracker) are defined in the
+    // `issue-tracker` module and re-exported by `darkfactory`. Derive the
+    // canonical `issue-tracker` URL from the darkfactory URL by swapping the
+    // final path segment, tolerating a trailing slash.
     this.issueTrackerModuleUrl = config.darkfactoryModuleUrl
       .replace(/\/+$/, '')
       .replace(/[^/]+$/, 'issue-tracker');
@@ -222,23 +216,9 @@ export class RealmIssueStore implements IssueStore {
     this.workspaceDir = config.workspaceDir;
   }
 
-  /**
-   * Match `Issue` cards regardless of which module they adopt — the
-   * `darkfactory` re-export (factory-written) or the canonical
-   * `issue-tracker` module (added via the board UI).
-   */
-  private issueTypeFilter() {
-    return {
-      any: [
-        { type: { module: this.darkfactoryModuleUrl, name: 'Issue' } },
-        { type: { module: this.issueTrackerModuleUrl, name: 'Issue' } },
-      ],
-    };
-  }
-
   async listIssues(): Promise<SchedulableIssue[]> {
     let result = await this.client.search(this.realmUrl, {
-      filter: this.issueTypeFilter(),
+      filter: { type: { module: this.issueTrackerModuleUrl, name: 'Issue' } },
     });
 
     if (!result.ok) {
@@ -254,7 +234,10 @@ export class RealmIssueStore implements IssueStore {
   async refreshIssue(issueId: string): Promise<SchedulableIssue> {
     let result = await this.client.search(this.realmUrl, {
       filter: {
-        every: [this.issueTypeFilter(), { eq: { id: issueId } }],
+        every: [
+          { type: { module: this.issueTrackerModuleUrl, name: 'Issue' } },
+          { eq: { id: issueId } },
+        ],
       },
     });
 
@@ -331,11 +314,12 @@ export class RealmIssueStore implements IssueStore {
   }
 
   async updateProjectStatus(projectStatus: string): Promise<void> {
-    // We expect exactly one Project card per target realm. The search
-    // index stays on the realm — card mutations happen locally.
+    // We expect exactly one Project card per target realm. The search index
+    // stays on the realm — card mutations happen locally. Match by the
+    // canonical `issue-tracker` module (see the constructor).
     let result = await this.client.search(this.realmUrl, {
       filter: {
-        type: { module: this.darkfactoryModuleUrl, name: 'Project' },
+        type: { module: this.issueTrackerModuleUrl, name: 'Project' },
       },
       sort: [{ by: 'lastModified', direction: 'desc' as const }],
     });

--- a/packages/software-factory/tests/issue-scheduler.test.ts
+++ b/packages/software-factory/tests/issue-scheduler.test.ts
@@ -474,17 +474,16 @@ module('issue-scheduler > RealmIssueStore blockedBy resolution', function () {
 // ---------------------------------------------------------------------------
 
 module('issue-scheduler > RealmIssueStore issue-type filter', function () {
-  // The `Issue` class is defined in `issue-tracker` and re-exported by
-  // `darkfactory`. Factory-written issues adopt darkfactory#Issue; an issue a
-  // human adds via the IssueTracker board adopts issue-tracker#Issue. A type
-  // filter is module-URL-specific, so listIssues must match BOTH — otherwise
-  // UI-added issues are invisible to the loop (observed in factory:go: a
-  // backlog issue added in the host UI was never picked).
-  test('listIssues matches both darkfactory#Issue and issue-tracker#Issue', async function (assert) {
+  // `Issue` is defined in `issue-tracker` and re-exported by `darkfactory`
+  // (same class). A Boxel `type` filter resolves to the canonical definition
+  // module, so listIssues queries `issue-tracker#Issue` — which matches the
+  // card regardless of which module it was authored adopting.
+  test('listIssues queries the canonical issue-tracker#Issue type', async function (assert) {
     let realmUrl = 'http://localhost:4201/user/my-test-realm/';
     let darkfactoryModuleUrl =
       'http://localhost:4201/software-factory/darkfactory';
-    let captured: { filter?: { any?: { type?: { module?: string } }[] } } = {};
+    let captured: { filter?: { type?: { module?: string; name?: string } } } =
+      {};
 
     let mockClient = {
       async search(_realm: string, query: typeof captured) {
@@ -502,14 +501,9 @@ module('issue-scheduler > RealmIssueStore issue-type filter', function () {
 
     await store.listIssues();
 
-    let modules = (captured.filter?.any ?? []).map((c) => c.type?.module);
-    assert.ok(
-      modules.includes(darkfactoryModuleUrl),
-      'matches factory-written darkfactory#Issue cards',
-    );
-    assert.ok(
-      modules.includes('http://localhost:4201/software-factory/issue-tracker'),
-      'matches UI-added issue-tracker#Issue cards',
-    );
+    assert.deepEqual(captured.filter?.type, {
+      module: 'http://localhost:4201/software-factory/issue-tracker',
+      name: 'Issue',
+    });
   });
 });


### PR DESCRIPTION
_(Written by Claude on Matic's behalf.)_

## Problem
Every run logged `No project found to update status: no results` and never marked the Project `completed`.

## Cause
`updateProjectStatus` (and the Issue queries) searched `type: darkfactory/Project`, which returns nothing. `Issue`/`Project`/`IssueTracker` are **defined** in `issue-tracker` and only **re-exported** by `darkfactory` (same class — see `darkfactory.gts`), and a Boxel `type` filter resolves to the **canonical definition module**. Querying the re-export barrel matches zero cards.

## Fix
Query the canonical `issue-tracker` module directly. The store derives `issueTrackerModuleUrl` once in the constructor (swap the final path segment of the darkfactory URL) and the three query sites (`listIssues`, `refreshIssue`, `updateProjectStatus`) each use a single inlined `type` filter against it. The canonical type matches the card regardless of which module it was authored adopting, so one filter is correct and there is no need to OR across modules.

Verified live against a fresh `factory:go` run: the project is now marked `completed` at end of loop (`Updated project "Projects/sticky-note" status to "completed"`).

## Testing
- `tests/issue-scheduler.test.ts` — updated to assert the canonical single-type filter; passing.
- `pnpm lint` clean; `pnpm test:node` 452/453 (the one failure is the pre-existing `port-allocator` dual-stack environmental case, also red on base).

Supersedes the earlier "index staleness" diagnosis on CS-11577.

Ticket: CS-11577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
