### PR TITLE
Unified search: deduped icon resource on the v2 search-entry

### DIFF
--- a/packages/host/app/components/card-search/search-results.gts
+++ b/packages/host/app/components/card-search/search-results.gts
@@ -40,6 +40,7 @@ import type StoreService from '../../services/store';
 // instance loads — mirrors what the legacy prerendered path stamped.
 function extraAttributesFor(
   rendering: SearchEntryRendering,
+  iconHtml: string | undefined,
 ): Record<string, string> {
   let attrs: Record<string, string> = {};
   if (rendering.isError) {
@@ -48,8 +49,10 @@ function extraAttributesFor(
   if (rendering.cardType) {
     attrs['data-card-type-display-name'] = rendering.cardType;
   }
-  if (rendering.iconHtml) {
-    attrs['data-card-type-icon-html'] = rendering.iconHtml;
+  // The type icon rides as a deduped `icon` resource on the entry, not the
+  // rendering — see `SearchEntry.iconHtml`.
+  if (iconHtml) {
+    attrs['data-card-type-icon-html'] = iconHtml;
   }
   return attrs;
 }
@@ -113,6 +116,13 @@ class RenderableSearchEntry {
     return this.raw.item;
   }
 
+  // The result's card-type icon HTML, resolved from the deduped `icon`
+  // resource — exposed so a consumer can render a type icon for an item-only
+  // row without loading the live instance.
+  get iconHtml(): string | undefined {
+    return this.raw.iconHtml;
+  }
+
   // The error doc carried on the `item` serialization's `meta`. Present => the
   // live item cannot render, so the row falls through to the host error
   // component and the item is never deposited into the Store.
@@ -171,7 +181,7 @@ class RenderableSearchEntry {
       let { html } = this;
       let inert =
         html && html.html != null
-          ? htmlComponent(html.html, extraAttributesFor(html))
+          ? htmlComponent(html.html, extraAttributesFor(html, this.iconHtml))
           : undefined;
       this.#component = hydratableEntryComponent({
         cardId: this.id,

--- a/packages/host/app/components/card-search/search-results.gts
+++ b/packages/host/app/components/card-search/search-results.gts
@@ -116,11 +116,19 @@ class RenderableSearchEntry {
     return this.raw.item;
   }
 
-  // The result's card-type icon HTML, resolved from the deduped `icon`
-  // resource — exposed so a consumer can render a type icon for an item-only
-  // row without loading the live instance.
+  // The result's card-type descriptor, resolved from the deduped `icon`
+  // resource — exposed so a consumer can render a type icon / name (and render
+  // as the right type) for an item-only row without loading the live instance.
   get iconHtml(): string | undefined {
     return this.raw.iconHtml;
+  }
+
+  get displayName(): string | undefined {
+    return this.raw.displayName;
+  }
+
+  get codeRef(): ResolvedCodeRef | undefined {
+    return this.raw.codeRef;
   }
 
   // The error doc carried on the `item` serialization's `meta`. Present => the

--- a/packages/host/app/resources/search-entries.ts
+++ b/packages/host/app/resources/search-entries.ts
@@ -25,6 +25,8 @@ import {
   type ErrorEntry,
   type FileMetaResource,
   type HtmlResource,
+  type IconResource,
+  type ResolvedCodeRef,
   type Saved,
   type SearchEntryCollectionDocument,
   type SearchEntryRendering,
@@ -62,10 +64,13 @@ export interface SearchEntry {
   realmUrl: string;
   html: SearchEntryRendering[];
   item?: CardResource<Saved> | FileMetaResource;
-  // The result's card-type icon HTML, resolved from the deduped `icon`
+  // The result's card-type descriptor, resolved from the deduped `icon`
   // resource (absent when the row's native type carries none). Lives on the
-  // entry, not the rendering, so a no-HTML row still exposes it.
+  // entry, not the rendering, so a no-HTML row still exposes it: the type's
+  // icon HTML, display name, and code ref.
   iconHtml?: string;
+  displayName?: string;
+  codeRef?: ResolvedCodeRef;
 }
 
 interface Args {
@@ -375,7 +380,7 @@ export class SearchEntriesResource extends Resource<Args> {
   private buildEntries(doc: SearchEntryCollectionDocument): SearchEntry[] {
     let htmlById = new Map<string, HtmlResource>();
     let cssHrefById = new Map<string, string>();
-    let iconHtmlById = new Map<string, string>();
+    let iconById = new Map<string, IconResource['attributes']>();
     let itemsByIdentity = new Map<
       string,
       CardResource<Saved> | FileMetaResource
@@ -386,7 +391,7 @@ export class SearchEntriesResource extends Resource<Args> {
       } else if (isCssResource(resource)) {
         cssHrefById.set(resource.id, resource.attributes.href);
       } else if (isIconResource(resource)) {
-        iconHtmlById.set(resource.id, resource.attributes.iconHtml);
+        iconById.set(resource.id, resource.attributes);
       } else if (isCardResource(resource) || isFileMetaResource(resource)) {
         itemsByIdentity.set(
           resourceIdentity(resource.type, resource.id),
@@ -419,13 +424,19 @@ export class SearchEntriesResource extends Resource<Args> {
         ? itemsByIdentity.get(resourceIdentity(itemRef.type, itemRef.id))
         : undefined;
       let iconRef = entry.relationships.icon?.data;
-      let iconHtml = iconRef ? iconHtmlById.get(iconRef.id) : undefined;
+      let icon = iconRef ? iconById.get(iconRef.id) : undefined;
       return {
         id: entry.id,
         realmUrl: realmUrlFor(entry.id),
         html: renderings,
         ...(item ? { item } : {}),
-        ...(iconHtml ? { iconHtml } : {}),
+        ...(icon
+          ? {
+              iconHtml: icon.iconHtml,
+              displayName: icon.displayName,
+              codeRef: icon.codeRef,
+            }
+          : {}),
       };
     });
   }

--- a/packages/host/app/resources/search-entries.ts
+++ b/packages/host/app/resources/search-entries.ts
@@ -16,6 +16,7 @@ import {
   isCssResource,
   isFileMetaResource,
   isHtmlResource,
+  isIconResource,
   logger as runtimeLogger,
   resourceIdentity,
   rri,
@@ -61,6 +62,10 @@ export interface SearchEntry {
   realmUrl: string;
   html: SearchEntryRendering[];
   item?: CardResource<Saved> | FileMetaResource;
+  // The result's card-type icon HTML, resolved from the deduped `icon`
+  // resource (absent when the row's native type carries none). Lives on the
+  // entry, not the rendering, so a no-HTML row still exposes it.
+  iconHtml?: string;
 }
 
 interface Args {
@@ -370,6 +375,7 @@ export class SearchEntriesResource extends Resource<Args> {
   private buildEntries(doc: SearchEntryCollectionDocument): SearchEntry[] {
     let htmlById = new Map<string, HtmlResource>();
     let cssHrefById = new Map<string, string>();
+    let iconHtmlById = new Map<string, string>();
     let itemsByIdentity = new Map<
       string,
       CardResource<Saved> | FileMetaResource
@@ -379,6 +385,8 @@ export class SearchEntriesResource extends Resource<Args> {
         htmlById.set(resource.id, resource);
       } else if (isCssResource(resource)) {
         cssHrefById.set(resource.id, resource.attributes.href);
+      } else if (isIconResource(resource)) {
+        iconHtmlById.set(resource.id, resource.attributes.iconHtml);
       } else if (isCardResource(resource) || isFileMetaResource(resource)) {
         itemsByIdentity.set(
           resourceIdentity(resource.type, resource.id),
@@ -410,11 +418,14 @@ export class SearchEntriesResource extends Resource<Args> {
       let item = itemRef
         ? itemsByIdentity.get(resourceIdentity(itemRef.type, itemRef.id))
         : undefined;
+      let iconRef = entry.relationships.icon?.data;
+      let iconHtml = iconRef ? iconHtmlById.get(iconRef.id) : undefined;
       return {
         id: entry.id,
         realmUrl: realmUrlFor(entry.id),
         html: renderings,
         ...(item ? { item } : {}),
+        ...(iconHtml ? { iconHtml } : {}),
       };
     });
   }
@@ -429,7 +440,6 @@ function buildRendering(
     id: html.id,
     ...(attributes.html !== undefined ? { html: attributes.html } : {}),
     cardType: attributes.cardType,
-    ...(attributes.iconHtml ? { iconHtml: attributes.iconHtml } : {}),
     isError: Boolean(attributes.isError),
     format: attributes.format,
     ...(attributes.renderType ? { renderType: attributes.renderType } : {}),

--- a/packages/host/tests/integration/components/search-results-test.gts
+++ b/packages/host/tests/integration/components/search-results-test.gts
@@ -387,7 +387,11 @@ module('Integration | Component | search-results', function (hooks) {
         {
           type: IconResourceType,
           id: BOOK_ICON_ID,
-          attributes: { iconHtml: BOOK_ICON_HTML },
+          attributes: {
+            iconHtml: BOOK_ICON_HTML,
+            displayName: 'Book',
+            codeRef: bookRef,
+          },
         },
       ],
       meta: {

--- a/packages/host/tests/integration/components/search-results-test.gts
+++ b/packages/host/tests/integration/components/search-results-test.gts
@@ -20,6 +20,7 @@ import {
   CssResourceType,
   GetCardContextName,
   HtmlResourceType,
+  IconResourceType,
   SearchEntryResourceType,
   type CardResource,
   type Loader,
@@ -79,6 +80,9 @@ const bookRef = { module: testRRI('book'), name: 'Book' };
 const BOOK_1 = `${testRealmURL}books/1`;
 const BOOK_2 = `${testRealmURL}books/2`;
 const CSS_HREF = `${testRealmURL}book.gts.abc123.glimmer-scoped.css`;
+// The deduped `icon` resource's id — the type's internal key (`<module>/<name>`).
+const BOOK_ICON_ID = `${bookRef.module}/Book`;
+const BOOK_ICON_HTML = '<svg data-test-book-type-icon></svg>';
 
 function renderingIdFor(url: string): string {
   return htmlResourceId({ url, format: 'fitted', renderType: bookRef });
@@ -356,6 +360,66 @@ module('Integration | Component | search-results', function (hooks) {
         isCardInstance(storeService.peek(BOOK_2)),
         'the full item was inflated into the store',
       );
+    } finally {
+      restore();
+    }
+  });
+
+  test('stamps the type icon from the deduped icon resource, shared across rows', async function (assert) {
+    // Two same-type rows reference one `icon` resource via the entry's `icon`
+    // relationship (deduped). The host resolves it to `entry.iconHtml` and
+    // stamps `data-card-type-icon-html` on each inert row — the attribute the
+    // operator-mode overlay / adorn tab reads, sourced without loading the
+    // instance.
+    let withIcon = (url: string): SearchEntryWireResource => ({
+      type: SearchEntryResourceType,
+      id: url,
+      relationships: {
+        html: { data: [{ type: HtmlResourceType, id: renderingIdFor(url) }] },
+        icon: { data: { type: IconResourceType, id: BOOK_ICON_ID } },
+      },
+    });
+    let restore = stubSearchEntries({
+      data: [withIcon(BOOK_1), withIcon(BOOK_2)],
+      included: [
+        ...htmlIncluded(BOOK_1, `<div data-test-inert-book>Mango</div>`),
+        ...htmlIncluded(BOOK_2, `<div data-test-inert-book>Van Gogh</div>`),
+        {
+          type: IconResourceType,
+          id: BOOK_ICON_ID,
+          attributes: { iconHtml: BOOK_ICON_HTML },
+        },
+      ],
+      meta: {
+        page: { total: 2 },
+        htmlQuery: { eq: { format: 'fitted', renderType: bookRef } },
+      },
+    });
+    try {
+      let query: SearchEntryWireQuery = {
+        filter: { 'item.on': bookRef },
+        realms: [testRealmURL],
+      };
+      await render(
+        <template>
+          <TestContext>
+            <SearchResults @query={{query}} @mode='none' />
+          </TestContext>
+        </template>,
+      );
+      await waitUntil(() =>
+        Boolean(document.querySelector('[data-test-search-result]')),
+      );
+
+      for (let url of [BOOK_1, BOOK_2]) {
+        assert
+          .dom(`[data-test-hydratable-card="${url}"]`)
+          .hasAttribute(
+            'data-card-type-icon-html',
+            BOOK_ICON_HTML,
+            `${url} carries the deduped type icon as a data attribute`,
+          );
+      }
     } finally {
       restore();
     }

--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -8,6 +8,7 @@ import {
   type CssResource,
   type FileMetaResource,
   type HtmlResource,
+  type IconResource,
   type Realm,
   type SearchEntryCollectionDocument,
   type SearchEntryResource,
@@ -46,6 +47,16 @@ function cssIn(doc: SearchEntryCollectionDocument): CssResource[] {
   return (doc.included ?? []).filter(
     (resource): resource is CssResource => resource.type === 'css',
   );
+}
+
+function iconsIn(doc: SearchEntryCollectionDocument): IconResource[] {
+  return (doc.included ?? []).filter(
+    (resource): resource is IconResource => resource.type === 'icon',
+  );
+}
+
+function iconIdOf(entry: SearchEntryResource): string | undefined {
+  return entry.relationships.icon?.data.id;
 }
 
 function entryFor(
@@ -162,6 +173,32 @@ module(basename(__filename), function () {
       });
       assert.true(normalizedHtml(html).includes('Fitted Card Person: John'));
       assert.strictEqual(html.attributes.cardType, 'Person');
+    });
+
+    test('the type icon rides as a deduped icon resource on the entry', async function (assert) {
+      let doc =
+        await testRealm.realmIndexQueryEngine.searchEntries(personQuery());
+      // both same-type results point at the one shared icon resource, keyed
+      // by the native-type internal key
+      assert.strictEqual(iconIdOf(entryFor(doc, johnId)!), personKey);
+      assert.strictEqual(iconIdOf(entryFor(doc, janeId)!), personKey);
+      let icons = iconsIn(doc);
+      assert.strictEqual(
+        icons.length,
+        1,
+        'the shared type icon is included exactly once',
+      );
+      assert.strictEqual(icons[0].id, personKey);
+      assert.ok(
+        icons[0].attributes.iconHtml.length > 0,
+        'the icon resource carries the icon markup',
+      );
+      // the icon no longer rides on each html rendering
+      let html = htmlIn(doc, `${johnId}#fitted#${personKey}`)!;
+      assert.false(
+        'iconHtml' in html.attributes,
+        'the icon moved off the html resource',
+      );
     });
 
     test('an explicit htmlQuery selects the rendering format', async function (assert) {
@@ -318,6 +355,18 @@ module(basename(__filename), function () {
       assert.deepEqual(jane.relationships.item, {
         data: { type: 'card', id: janeId },
       });
+      // The motivating case: a no-HTML fallback row still resolves its type
+      // icon (entry-level, deduped) — a consumer can paint a placeholder icon
+      // without loading the live instance.
+      assert.strictEqual(
+        iconIdOf(jane),
+        personKey,
+        'a fallback row carries the icon relationship',
+      );
+      assert.ok(
+        iconsIn(doc).some((icon) => icon.id === personKey),
+        'the icon resource is included for the fallback row',
+      );
       let item = itemIn(doc, janeId)!;
       assert.strictEqual(item.attributes?.firstName, 'Jane');
       assert.strictEqual(item.meta.sparseFields, undefined);

--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -193,6 +193,17 @@ module(basename(__filename), function () {
         icons[0].attributes.iconHtml.length > 0,
         'the icon resource carries the icon markup',
       );
+      // the deduped resource carries the full type descriptor
+      assert.strictEqual(
+        icons[0].attributes.displayName,
+        'Person',
+        'the type descriptor carries the card def display name',
+      );
+      assert.deepEqual(
+        icons[0].attributes.codeRef,
+        { module: `${realmHref}person`, name: 'Person' },
+        'the type descriptor carries the card def code ref',
+      );
       // the icon no longer rides on each html rendering
       let html = htmlIn(doc, `${johnId}#fitted#${personKey}`)!;
       assert.false(

--- a/packages/realm-server/tests/search-entry-test.ts
+++ b/packages/realm-server/tests/search-entry-test.ts
@@ -699,21 +699,31 @@ module(basename(__filename), function () {
       assert.true(isHtmlResource(resource));
     });
 
-    test('buildIconResource keys on the type internal key and is an icon resource', function (assert) {
+    test('buildIconResource keys on the type internal key and carries the type descriptor', function (assert) {
       let internalKey = `${authorRef.module}/${authorRef.name}`;
       let resource = buildIconResource({
         internalKey,
         iconHtml: '<svg>author</svg>',
+        displayName: 'Author',
+        codeRef: authorRef,
       });
       assert.deepEqual(resource, {
         type: 'icon',
         id: internalKey,
-        attributes: { iconHtml: '<svg>author</svg>' },
+        attributes: {
+          iconHtml: '<svg>author</svg>',
+          displayName: 'Author',
+          codeRef: authorRef,
+        },
       });
       assert.true(isIconResource(resource));
       assert.false(
-        isIconResource({ type: 'icon', id: internalKey, attributes: {} }),
-        'an icon resource without iconHtml is rejected',
+        isIconResource({
+          type: 'icon',
+          id: internalKey,
+          attributes: { iconHtml: '<svg/>' },
+        }),
+        'an icon resource missing displayName / codeRef is rejected',
       );
     });
 

--- a/packages/realm-server/tests/search-entry-test.ts
+++ b/packages/realm-server/tests/search-entry-test.ts
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { basename } from 'path';
 import {
   buildHtmlResource,
+  buildIconResource,
   buildSearchEntryResource,
   buildSparseItemResource,
   htmlResourceId,
@@ -9,6 +10,7 @@ import {
   htmlQueryHasRenderTypePredicate,
   htmlQueryMatches,
   isHtmlResource,
+  isIconResource,
   isSearchEntryCollectionDocument,
   isSearchEntryResource,
   isSparseItemResource,
@@ -641,6 +643,7 @@ module(basename(__filename), function () {
         url: cardUrl,
         htmlIds: [htmlId],
         itemType: 'card',
+        iconId: `${authorRef.module}/${authorRef.name}`,
       });
       assert.deepEqual(both, {
         type: 'search-entry',
@@ -648,6 +651,12 @@ module(basename(__filename), function () {
         relationships: {
           html: { data: [{ type: 'html', id: htmlId }] },
           item: { data: { type: 'card', id: cardUrl } },
+          icon: {
+            data: {
+              type: 'icon',
+              id: `${authorRef.module}/${authorRef.name}`,
+            },
+          },
         },
       });
       assert.true(isSearchEntryResource(both));
@@ -674,7 +683,6 @@ module(basename(__filename), function () {
         renderType: authorRef,
         html: '<div>hi</div>',
         cardType: 'Author',
-        iconHtml: '<svg/>',
         cssIds: [cssId],
       });
       assert.deepEqual(resource, {
@@ -683,13 +691,30 @@ module(basename(__filename), function () {
         attributes: {
           html: '<div>hi</div>',
           cardType: 'Author',
-          iconHtml: '<svg/>',
           format: 'fitted',
           renderType: authorRef,
         },
         relationships: { styles: { data: [{ type: 'css', id: cssId }] } },
       });
       assert.true(isHtmlResource(resource));
+    });
+
+    test('buildIconResource keys on the type internal key and is an icon resource', function (assert) {
+      let internalKey = `${authorRef.module}/${authorRef.name}`;
+      let resource = buildIconResource({
+        internalKey,
+        iconHtml: '<svg>author</svg>',
+      });
+      assert.deepEqual(resource, {
+        type: 'icon',
+        id: internalKey,
+        attributes: { iconHtml: '<svg>author</svg>' },
+      });
+      assert.true(isIconResource(resource));
+      assert.false(
+        isIconResource({ type: 'icon', id: internalKey, attributes: {} }),
+        'an icon resource without iconHtml is rejected',
+      );
     });
 
     test('an error rendering may omit html', function (assert) {

--- a/packages/runtime-common/card-document-shape.ts
+++ b/packages/runtime-common/card-document-shape.ts
@@ -345,10 +345,15 @@ export function isIconResource(resource: any): resource is IconResource {
   if (typeof resource.id !== 'string') {
     return false;
   }
-  if (typeof resource.attributes !== 'object' || resource.attributes == null) {
+  let { attributes } = resource;
+  if (typeof attributes !== 'object' || attributes == null) {
     return false;
   }
-  return typeof resource.attributes.iconHtml === 'string';
+  return (
+    typeof attributes.iconHtml === 'string' &&
+    typeof attributes.displayName === 'string' &&
+    isResolvedCodeRef(attributes.codeRef)
+  );
 }
 
 export function isSearchEntryResource(

--- a/packages/runtime-common/card-document-shape.ts
+++ b/packages/runtime-common/card-document-shape.ts
@@ -27,6 +27,7 @@ import type {
   CssResource,
   FileMetaResource,
   HtmlResource,
+  IconResource,
   Meta,
   Relationship,
   RenderedHtmlResource,
@@ -50,6 +51,7 @@ const RenderedHtmlResourceType: RenderedHtmlResource['type'] = 'rendered-html';
 const CssResourceType: CssResource['type'] = 'css';
 const SearchEntryResourceType: SearchEntryResource['type'] = 'search-entry';
 const HtmlResourceType: HtmlResource['type'] = 'html';
+const IconResourceType: IconResource['type'] = 'icon';
 
 // ---------------------------------------------------------------------------
 // Code refs
@@ -333,6 +335,22 @@ export function isCssResource(resource: any): resource is CssResource {
   return typeof resource.attributes.href === 'string';
 }
 
+export function isIconResource(resource: any): resource is IconResource {
+  if (typeof resource !== 'object' || resource == null) {
+    return false;
+  }
+  if (resource.type !== IconResourceType) {
+    return false;
+  }
+  if (typeof resource.id !== 'string') {
+    return false;
+  }
+  if (typeof resource.attributes !== 'object' || resource.attributes == null) {
+    return false;
+  }
+  return typeof resource.attributes.iconHtml === 'string';
+}
+
 export function isSearchEntryResource(
   resource: any,
 ): resource is SearchEntryResource {
@@ -349,7 +367,7 @@ export function isSearchEntryResource(
   if (typeof relationships !== 'object' || relationships == null) {
     return false;
   }
-  let { html, item } = relationships;
+  let { html, item, icon } = relationships;
   if (html !== undefined) {
     if (!Array.isArray(html?.data)) {
       return false;
@@ -365,6 +383,14 @@ export function isSearchEntryResource(
       (item?.data?.type !== CardResourceType &&
         item?.data?.type !== FileMetaResourceType) ||
       typeof item.data.id !== 'string'
+    ) {
+      return false;
+    }
+  }
+  if (icon !== undefined) {
+    if (
+      icon?.data?.type !== IconResourceType ||
+      typeof icon.data.id !== 'string'
     ) {
       return false;
     }

--- a/packages/runtime-common/document-types.ts
+++ b/packages/runtime-common/document-types.ts
@@ -11,6 +11,7 @@ import {
   type FileMetaResource,
   type HtmlQuery,
   type HtmlResource,
+  type IconResource,
   type PrerenderedCardResource,
   type RenderedHtmlResource,
   type Saved,
@@ -74,6 +75,7 @@ export interface UnifiedSearchCollectionDocument<
 export type SearchEntryIncludedResource =
   | HtmlResource
   | CssResource
+  | IconResource
   | CardResource<Saved>
   | FileMetaResource;
 

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -751,6 +751,7 @@ export class RealmIndexQueryEngine {
         fieldset.html
           ? ((row.icon_html as string | null) ?? undefined)
           : undefined,
+        (row.display_names as string[] | null)?.[0] ?? '',
         iconById,
       );
       if (fieldset.html) {
@@ -910,6 +911,7 @@ export class RealmIndexQueryEngine {
       let iconId = collectIconId(
         fieldset.html ? file.types?.[0] : undefined,
         fieldset.html ? (file.iconHtml ?? undefined) : undefined,
+        file.displayNames?.[0] ?? '',
         iconById,
       );
       if (fieldset.html) {
@@ -2432,23 +2434,34 @@ function relativizeResource(
   });
 }
 
-// Resolve a row's `icon` resource id (its native-type internal key) and
-// register the deduped resource. Returns the id to hang the `search-entry` →
-// `icon` relationship on, or undefined when the row has no native type or no
-// `icon_html`. The same internal key collapses every result of that type to
-// one resource in `included`.
+// Resolve a row's `icon` (type-descriptor) resource id — its native-type
+// internal key — and register the deduped resource carrying the type's icon,
+// display name, and code ref. Returns the id to hang the `search-entry` →
+// `icon` relationship on, or undefined when the row has no native type, no
+// `icon_html`, or an unparseable internal key. The same internal key collapses
+// every result of that type to one resource in `included`.
 function collectIconId(
   nativeKey: string | undefined,
   iconHtml: string | undefined,
+  displayName: string,
   iconById: Map<string, IconResource>,
 ): string | undefined {
   if (!nativeKey || !iconHtml) {
     return undefined;
   }
+  let codeRef = codeRefFromInternalKey(nativeKey);
+  if (!codeRef) {
+    return undefined;
+  }
   if (!iconById.has(nativeKey)) {
     iconById.set(
       nativeKey,
-      buildIconResource({ internalKey: nativeKey, iconHtml }),
+      buildIconResource({
+        internalKey: nativeKey,
+        iconHtml,
+        displayName,
+        codeRef,
+      }),
     );
   }
   return nativeKey;

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -65,6 +65,7 @@ import type {
   CardResource,
   CssResource,
   FileMetaResource,
+  IconResource,
   QueryFieldMeta,
   Saved,
   SearchEntryResource,
@@ -80,6 +81,7 @@ import {
 } from './unified-search.ts';
 import {
   buildHtmlResource,
+  buildIconResource,
   buildSearchEntryResource,
   buildSparseItemResource,
   htmlQueryFormats,
@@ -725,6 +727,7 @@ export class RealmIndexQueryEngine {
     let htmlResources: SearchEntryIncludedResource[] = [];
     let itemResources: (CardResource<Saved> | FileMetaResource)[] = [];
     let cssById = new Map<string, CssResource>();
+    let iconById = new Map<string, IconResource>();
     let fullItemRoots: (CardResource<Saved> | FileMetaResource)[] = [];
 
     for (let row of results) {
@@ -739,6 +742,17 @@ export class RealmIndexQueryEngine {
       let hasError = Boolean(row.has_error);
 
       let htmlIds: string[] | undefined;
+      // The result's type icon, deduped by native-type internal key. Resolved
+      // alongside the html branch (a consumer that asks for renderings is the
+      // one that paints icons), but emitted on the `search-entry` itself so a
+      // fallback row with no matching rendering still carries it.
+      let iconId = collectIconId(
+        fieldset.html ? (row.types as string[] | null)?.[0] : undefined,
+        fieldset.html
+          ? ((row.icon_html as string | null) ?? undefined)
+          : undefined,
+        iconById,
+      );
       if (fieldset.html) {
         let nativeKey = (row.types as string[] | null)?.[0];
         let candidates = enumerateRowRenderings(row);
@@ -773,7 +787,6 @@ export class RealmIndexQueryEngine {
               | undefined,
             html: candidate.html,
             cardType: (row.display_names as string[] | null)?.[0] ?? '',
-            iconHtml: (row.icon_html as string | null) ?? undefined,
             isError: hasError || undefined,
             cssIds,
           });
@@ -792,7 +805,6 @@ export class RealmIndexQueryEngine {
                 | ResolvedCodeRef
                 | undefined,
               cardType: (row.display_names as string[] | null)?.[0] ?? '',
-              iconHtml: (row.icon_html as string | null) ?? undefined,
               isError: true,
               cssIds: [],
             });
@@ -831,7 +843,9 @@ export class RealmIndexQueryEngine {
         itemType = CardResourceType;
       }
 
-      data.push(buildSearchEntryResource({ url: cardUrl, htmlIds, itemType }));
+      data.push(
+        buildSearchEntryResource({ url: cardUrl, htmlIds, itemType, iconId }),
+      );
     }
 
     let metaWithEcho: SearchEntryCollectionDocument['meta'] = fieldset.html
@@ -839,7 +853,7 @@ export class RealmIndexQueryEngine {
       : meta;
     return await this.assembleSearchEntryDoc(
       { data, meta: metaWithEcho },
-      { htmlResources, cssById, itemResources, fullItemRoots },
+      { htmlResources, cssById, iconById, itemResources, fullItemRoots },
       opts,
     );
   }
@@ -880,6 +894,7 @@ export class RealmIndexQueryEngine {
     let htmlResources: SearchEntryIncludedResource[] = [];
     let itemResources: (CardResource<Saved> | FileMetaResource)[] = [];
     let cssById = new Map<string, CssResource>();
+    let iconById = new Map<string, IconResource>();
     let fullItemRoots: (CardResource<Saved> | FileMetaResource)[] = [];
 
     for (let file of files) {
@@ -889,6 +904,14 @@ export class RealmIndexQueryEngine {
       }
 
       let htmlIds: string[] | undefined;
+      // A file's type icon, deduped by its native-type internal key — carried
+      // on the `search-entry` so a no-HTML file row (e.g. a `.gts`/`.ts`
+      // FileDef with no fitted rendering) still resolves its icon.
+      let iconId = collectIconId(
+        fieldset.html ? file.types?.[0] : undefined,
+        fieldset.html ? (file.iconHtml ?? undefined) : undefined,
+        iconById,
+      );
       if (fieldset.html) {
         let matched = enumerateFileRenderings(file).filter((candidate) =>
           htmlQueryMatches(resolvedHtmlQuery, candidate),
@@ -910,7 +933,6 @@ export class RealmIndexQueryEngine {
             format: candidate.format,
             html: candidate.html,
             cardType: file.displayNames?.[0] ?? '',
-            iconHtml: file.iconHtml ?? undefined,
             cssIds,
           });
           htmlResources.push(htmlResource);
@@ -941,6 +963,7 @@ export class RealmIndexQueryEngine {
           url,
           htmlIds,
           itemType: itemEmitted ? FileMetaResourceType : undefined,
+          iconId,
         }),
       );
     }
@@ -950,7 +973,7 @@ export class RealmIndexQueryEngine {
       : meta;
     return await this.assembleSearchEntryDoc(
       { data, meta: metaWithEcho },
-      { htmlResources, cssById, itemResources, fullItemRoots },
+      { htmlResources, cssById, iconById, itemResources, fullItemRoots },
       opts,
     );
   }
@@ -966,15 +989,18 @@ export class RealmIndexQueryEngine {
     resources: {
       htmlResources: SearchEntryIncludedResource[];
       cssById: Map<string, CssResource>;
+      iconById: Map<string, IconResource>;
       itemResources: (CardResource<Saved> | FileMetaResource)[];
       fullItemRoots: (CardResource<Saved> | FileMetaResource)[];
     },
     opts?: Options,
   ): Promise<SearchEntryCollectionDocument> {
-    let { htmlResources, cssById, itemResources, fullItemRoots } = resources;
+    let { htmlResources, cssById, iconById, itemResources, fullItemRoots } =
+      resources;
     let included: SearchEntryIncludedResource[] = [
       ...htmlResources,
       ...cssById.values(),
+      ...iconById.values(),
       ...itemResources,
     ];
 
@@ -2404,6 +2430,28 @@ function relativizeResource(
       ) as RealmResourceIdentifier,
     );
   });
+}
+
+// Resolve a row's `icon` resource id (its native-type internal key) and
+// register the deduped resource. Returns the id to hang the `search-entry` →
+// `icon` relationship on, or undefined when the row has no native type or no
+// `icon_html`. The same internal key collapses every result of that type to
+// one resource in `included`.
+function collectIconId(
+  nativeKey: string | undefined,
+  iconHtml: string | undefined,
+  iconById: Map<string, IconResource>,
+): string | undefined {
+  if (!nativeKey || !iconHtml) {
+    return undefined;
+  }
+  if (!iconById.has(nativeKey)) {
+    iconById.set(
+      nativeKey,
+      buildIconResource({ internalKey: nativeKey, iconHtml }),
+    );
+  }
+  return nativeKey;
 }
 
 // One candidate rendering of a row, with its markup: a (format, renderType)

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -26,6 +26,7 @@ export const RenderedHtmlResourceType = 'rendered-html';
 export const CssResourceType = 'css';
 export const SearchEntryResourceType = 'search-entry';
 export const HtmlResourceType = 'html';
+export const IconResourceType = 'icon';
 // resource
 export type Resource =
   | ModuleResource
@@ -34,7 +35,8 @@ export type Resource =
   | RenderedHtmlResource
   | CssResource
   | SearchEntryResource
-  | HtmlResource;
+  | HtmlResource
+  | IconResource;
 export type ResourceMeta = ModuleMeta | Meta;
 export type LinkableResource = CardResource | FileMetaResource;
 
@@ -202,6 +204,20 @@ export interface CssResource {
   };
 }
 
+// One card-type icon. A type's `iconHtml` is identical across every result of
+// that type, so it rides as its own deduped resource rather than repeated on
+// each rendering. Its `id` is the type's internal key (the `<module>/<name>`
+// form already carried as a row's `types[0]`), so identical types collapse to
+// one `(type, id)` in `included`. Reached from the `search-entry` (not the
+// `html`) so item-only / no-HTML rows resolve their icon too.
+export interface IconResource {
+  id: string;
+  type: typeof IconResourceType;
+  attributes: {
+    iconHtml: string;
+  };
+}
+
 // The synthesized rendering-selection query bound on a `search-entry` (the
 // "htmlQuery"): a boolean sub-query over the rendering dimensions — `eq`
 // leaves composed with `every`/`any`/`not`, with real boolean semantics
@@ -244,6 +260,12 @@ export interface SearchEntryResource {
         id: string;
       };
     };
+    // The result's card-type icon, deduped across entries of the same type.
+    // Present whenever the row carries an `icon_html`; reached here (not on
+    // `html`) so item-only / no-HTML rows resolve it too.
+    icon?: {
+      data: { type: typeof IconResourceType; id: string };
+    };
   };
 }
 
@@ -259,7 +281,6 @@ export interface HtmlResource {
     // Absent only on an error rendering with no last-known-good HTML.
     html?: string;
     cardType: string;
-    iconHtml?: string;
     isError?: boolean;
     format: PrerenderedHtmlFormat;
     // The type this rendering was rendered as — the result's own native type
@@ -326,6 +347,7 @@ export {
   isRelationship,
   isRenderedHtmlResource,
   isCssResource,
+  isIconResource,
   isIdentityOnlyCardResource,
   isIdentityOnlyFileMetaResource,
   isSearchEntryResource,

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -204,17 +204,23 @@ export interface CssResource {
   };
 }
 
-// One card-type icon. A type's `iconHtml` is identical across every result of
-// that type, so it rides as its own deduped resource rather than repeated on
-// each rendering. Its `id` is the type's internal key (the `<module>/<name>`
-// form already carried as a row's `types[0]`), so identical types collapse to
-// one `(type, id)` in `included`. Reached from the `search-entry` (not the
-// `html`) so item-only / no-HTML rows resolve their icon too.
+// A card type's presentation descriptor — the per-type data that is identical
+// across every result of that type (its icon, display name, and code ref), so
+// it rides as its own deduped resource rather than repeated on each rendering.
+// Its `id` is the type's internal key (the `<module>/<name>` form already
+// carried as a row's `types[0]`), so identical types collapse to one
+// `(type, id)` in `included`. Reached from the `search-entry` (not the `html`)
+// so item-only / no-HTML rows resolve their type descriptor too.
 export interface IconResource {
   id: string;
   type: typeof IconResourceType;
   attributes: {
     iconHtml: string;
+    // The card def's display name (e.g. "Author").
+    displayName: string;
+    // The card def's resolved code ref — the structured form of the
+    // `<module>/<name>` the `id` encodes, so consumers needn't re-parse it.
+    codeRef: ResolvedCodeRef;
   };
 }
 

--- a/packages/runtime-common/search-compat.ts
+++ b/packages/runtime-common/search-compat.ts
@@ -206,6 +206,7 @@ export function searchEntryDocToPrerenderedDoc(
   },
 ): PrerenderedCardCollectionDocument {
   let htmlById = new Map<string, HtmlResource>();
+  let iconHtmlById = new Map<string, string>();
   let scopedCssUrls: string[] = [];
   let byIdentity = new Map<string, CardResource<Saved> | FileMetaResource>();
   for (let resource of doc.included ?? []) {
@@ -213,6 +214,8 @@ export function searchEntryDocToPrerenderedDoc(
       htmlById.set(resource.id, resource);
     } else if (resource.type === 'css') {
       scopedCssUrls.push(resource.attributes.href);
+    } else if (resource.type === 'icon') {
+      iconHtmlById.set(resource.id, resource.attributes.iconHtml);
     } else if (
       (resource.type === 'card' || resource.type === 'file-meta') &&
       resource.id
@@ -249,6 +252,13 @@ export function searchEntryDocToPrerenderedDoc(
           sameRef(member.attributes.renderType, nativeRef),
         ))
       : members[0];
+    // The type icon now rides as a deduped `icon` resource rather than on each
+    // rendering; resolve it through the entry's `icon` relationship. Gated on
+    // `picked` to match the legacy shape (a rendered row carries its icon; an
+    // unrendered fallback row carries none).
+    let iconHtml = entry.relationships.icon?.data.id
+      ? iconHtmlById.get(entry.relationships.icon.data.id)
+      : undefined;
 
     let resource: PrerenderedCardResource = {
       type: 'prerendered-card',
@@ -261,9 +271,7 @@ export function searchEntryDocToPrerenderedDoc(
         ...(picked?.attributes.cardType
           ? { cardType: picked.attributes.cardType }
           : {}),
-        ...(picked?.attributes.iconHtml
-          ? { iconHtml: picked.attributes.iconHtml }
-          : {}),
+        ...(picked && iconHtml ? { iconHtml } : {}),
         ...(picked?.attributes.isError ? { isError: true } : {}),
       },
       relationships: {

--- a/packages/runtime-common/search-entry.ts
+++ b/packages/runtime-common/search-entry.ts
@@ -930,19 +930,26 @@ export function buildHtmlResource(args: {
   };
 }
 
-// One card-type `icon` resource (see `IconResource`). Its `id` is the type's
-// internal key — the `<module>/<name>` form a row already carries as
-// `types[0]` — so the same type collapses to one resource in `included`. The
-// `search-entry` → `icon` relationship points here, reachable for item-only
-// rows that carry no `html` rendering.
+// One card-type `icon` resource (see `IconResource`): the per-type descriptor
+// (icon, display name, code ref). Its `id` is the type's internal key — the
+// `<module>/<name>` form a row already carries as `types[0]` — so the same type
+// collapses to one resource in `included`. The `search-entry` → `icon`
+// relationship points here, reachable for item-only rows that carry no `html`
+// rendering.
 export function buildIconResource(args: {
   internalKey: string;
   iconHtml: string;
+  displayName: string;
+  codeRef: ResolvedCodeRef;
 }): IconResource {
   return {
     type: IconResourceType,
     id: args.internalKey,
-    attributes: { iconHtml: args.iconHtml },
+    attributes: {
+      iconHtml: args.iconHtml,
+      displayName: args.displayName,
+      codeRef: args.codeRef,
+    },
   };
 }
 

--- a/packages/runtime-common/search-entry.ts
+++ b/packages/runtime-common/search-entry.ts
@@ -19,6 +19,7 @@ import type {
 import {
   CssResourceType,
   HtmlResourceType,
+  IconResourceType,
   SearchEntryResourceType,
   htmlResourceId,
   resourceIdentity,
@@ -28,6 +29,7 @@ import {
   type FileMetaResourceType,
   type HtmlQuery,
   type HtmlResource,
+  type IconResource,
   type Relationship,
   type Saved,
   type SearchEntryResource,
@@ -868,8 +870,11 @@ export function buildSearchEntryResource(args: {
   url: string;
   htmlIds?: string[];
   itemType?: typeof CardResourceType | typeof FileMetaResourceType;
+  // The id of the result's `icon` resource (its native-type internal key) —
+  // omitted when the row carries no `icon_html`.
+  iconId?: string;
 }): SearchEntryResource {
-  let { url, htmlIds, itemType } = args;
+  let { url, htmlIds, itemType, iconId } = args;
   let resource: SearchEntryResource = {
     type: SearchEntryResourceType,
     id: url,
@@ -882,6 +887,11 @@ export function buildSearchEntryResource(args: {
   }
   if (itemType !== undefined) {
     resource.relationships.item = { data: { type: itemType, id: url } };
+  }
+  if (iconId !== undefined) {
+    resource.relationships.icon = {
+      data: { type: IconResourceType, id: iconId },
+    };
   }
   return resource;
 }
@@ -898,19 +908,16 @@ export function buildHtmlResource(args: {
   renderType?: ResolvedCodeRef;
   html?: string;
   cardType: string;
-  iconHtml?: string;
   isError?: boolean;
   cssIds: string[];
 }): HtmlResource {
-  let { url, format, renderType, html, cardType, iconHtml, isError, cssIds } =
-    args;
+  let { url, format, renderType, html, cardType, isError, cssIds } = args;
   return {
     type: HtmlResourceType,
     id: htmlResourceId({ url, format, renderType }),
     attributes: {
       ...(html !== undefined ? { html } : {}),
       cardType,
-      ...(iconHtml ? { iconHtml } : {}),
       ...(isError ? { isError: true } : {}),
       format,
       ...(renderType ? { renderType } : {}),
@@ -920,6 +927,22 @@ export function buildHtmlResource(args: {
         data: cssIds.map((id) => ({ type: CssResourceType, id })),
       },
     },
+  };
+}
+
+// One card-type `icon` resource (see `IconResource`). Its `id` is the type's
+// internal key — the `<module>/<name>` form a row already carries as
+// `types[0]` — so the same type collapses to one resource in `included`. The
+// `search-entry` → `icon` relationship points here, reachable for item-only
+// rows that carry no `html` rendering.
+export function buildIconResource(args: {
+  internalKey: string;
+  iconHtml: string;
+}): IconResource {
+  return {
+    type: IconResourceType,
+    id: args.internalKey,
+    attributes: { iconHtml: args.iconHtml },
   };
 }
 

--- a/packages/runtime-common/search-results-component.ts
+++ b/packages/runtime-common/search-results-component.ts
@@ -43,10 +43,13 @@ export interface RenderableSearchEntryLike {
   // The card/file identity URL.
   id: string;
   isError: boolean;
-  // The result's card-type icon HTML, resolved from the deduped `icon`
+  // The result's card-type descriptor, resolved from the deduped `icon`
   // resource — present whenever the row's native type has one. Carried on the
-  // entry (not the rendering) so an item-only / no-HTML row exposes it too.
+  // entry (not the rendering) so an item-only / no-HTML row exposes it too:
+  // the type's icon HTML, display name, and code ref.
   iconHtml?: string;
+  displayName?: string;
+  codeRef?: ResolvedCodeRef;
   // The chosen prerendered rendering, when the result carries one.
   html?: SearchEntryRendering;
   // The raw live serialization branch (full or sparse), when present.

--- a/packages/runtime-common/search-results-component.ts
+++ b/packages/runtime-common/search-results-component.ts
@@ -26,7 +26,6 @@ export interface SearchEntryRendering {
   // Absent only on an error rendering with no last-known-good HTML.
   html?: string;
   cardType: string;
-  iconHtml?: string;
   isError: boolean;
   format: PrerenderedHtmlFormat;
   // The type this rendering was rendered as. A file rendering carries none
@@ -44,6 +43,10 @@ export interface RenderableSearchEntryLike {
   // The card/file identity URL.
   id: string;
   isError: boolean;
+  // The result's card-type icon HTML, resolved from the deduped `icon`
+  // resource — present whenever the row's native type has one. Carried on the
+  // entry (not the rendering) so an item-only / no-HTML row exposes it too.
+  iconHtml?: string;
   // The chosen prerendered rendering, when the result carries one.
   html?: SearchEntryRendering;
   // The raw live serialization branch (full or sparse), when present.


### PR DESCRIPTION
The card-type icon (`icon_html`) is identical across every search result of the same type, but on the v2 `search-entry` wire it rode only on the per-result `html` resource: repeated on each rendering, and absent entirely from results that have no matching rendering — e.g. `.gts`/`.ts` `FileDef` rows that fall back to an `item`-only `search-entry`. A consumer that needs the type icon for those fallback rows (the card-list / CardsGrid file fallback, and the operator-mode overlay / adorn type-label) could only get it by loading the live instance — exactly what those placeholders exist to avoid.

This models the icon as a first-class, deduped resource, mirroring `css`:

- **`icon` resource** — `{ type: 'icon', id: <internalKey>, attributes: { iconHtml } }`. The `id` is the result's native-type internal key (the `<module>/<name>` form already stored as a row's `types[0]`), so identical types collapse to one resource in `included`.
- **`search-entry` → `icon` (to-one) relationship** — carried on the entry, not the `html` resource, so item-only / no-HTML rows resolve their icon too. `iconHtml` is removed from the `html` resource's attributes.
- **Engine** (`realm-index-query-engine.ts`) builds the deduped icon in both the instance and file projection paths and stitches it into `included`.
- **Compat layer** (`search-compat.ts`) resolves the icon from the new resource so the legacy `/_prerendered-search` contract (which carries `iconHtml` on the prerendered card) is preserved unchanged.
- **Host** (`resources/search-entries.ts`, `<SearchResults>`) parses the icon resource, exposes `entry.iconHtml`, and stamps `data-card-type-icon-html` from it — the attribute the overlay / adorn tab reads.

Additive: the v2 endpoints emit the new resource natively; existing consumers read `entry.iconHtml`. Part of the unify-search project — the deduped icon unblocks the card-list / CardsGrid file-fallback hand-migration, which needs the per-type icon for no-HTML file rows without loading the instance.

### Tests
- `runtime-common` and `host` type-check clean.
- `search-entry-test` (builders incl. `buildIconResource`), `search-entries-engine-test` (icon dedup across same-type rows + a no-HTML fallback row still resolving its icon), and `unified-search-contracts-test` (the prerendered golden, unchanged) pass.
- Host `search-results` and `search-entries` resource suites pass, including a new assertion that the deduped icon surfaces as `data-card-type-icon-html` on each rendered row.
