### PR TITLE
host: Remove error details from 404 page

### DIFF
--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -10,7 +10,6 @@ import { bool, cn } from '@cardstack/boxel-ui/helpers';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
 import CardError from '@cardstack/host/components/operator-mode/card-error';
-import CardErrorDetail from '@cardstack/host/components/operator-mode/card-error-detail';
 import { getCard } from '@cardstack/host/resources/card-resource';
 
 interface Signature {
@@ -132,7 +131,6 @@ export default class HostModeCard extends Component<Signature> {
             <p class='not-found-code'>404</p>
             <p class='not-found-message'>This page could not be found.</p>
           </div>
-          <CardErrorDetail @error={{this.cardError}} class='not-found-detail' />
         {{else}}
           <CardError @error={{this.cardError}} @hideHeader={{true}} />
         {{/if}}

--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -202,19 +202,6 @@ export default class HostModeCard extends Component<Signature> {
         font: var(--boxel-font);
       }
 
-      /* Anchor the technical-detail box to the bottom of the card, the same
-         way CardError positions its own detail, so the centered 404 message
-         sits above it. */
-      .not-found-detail {
-        position: absolute;
-        bottom: var(--boxel-sp);
-        left: var(--boxel-sp);
-        right: var(--boxel-sp);
-        max-height: calc(100% - calc(var(--boxel-sp) * 2));
-        z-index: 10;
-        margin: 0;
-      }
-
       .non-publishable-message {
         display: flex;
         flex-direction: column;

--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -44,7 +44,10 @@ export default class HostModeCard extends Component<Signature> {
   // visit to a missing card, resolves to a 404. Rather than surfacing the
   // raw card-error/debug treatment on a public page, render a friendly
   // not-found placeholder so one dangling reference degrades gracefully
-  // instead of taking the page down.
+  // instead of taking the page down. A card that exists but is in an error
+  // state — e.g. because one of its dependencies is missing — does not get
+  // this treatment: the store reports it with its real (non-404) status, so
+  // its error is surfaced instead of a bare 404.
   get isNotFound() {
     return this.cardError?.status === 404;
   }

--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -124,9 +124,6 @@ export default class HostModeCard extends Component<Signature> {
     >
       {{#if this.cardError}}
         {{#if this.isNotFound}}
-          {{! A 404 (e.g. a routing rule pointing at a deleted card) gets a
-              friendly centered placeholder, while the collapsible technical
-              detail stays available below for the realm owner debugging it. }}
           <div class='not-found' data-test-host-mode-404>
             <p class='not-found-code'>404</p>
             <p class='not-found-message'>This page could not be found.</p>

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -2643,22 +2643,38 @@ function processCardError(
   url: string | undefined,
   error: any,
 ): CardErrorsJSONAPI {
+  let httpStatus = typeof error?.status === 'number' ? error.status : undefined;
+  let errorResponse: CardErrorsJSONAPI;
   try {
-    let errorResponse = JSON.parse(error.responseText);
-    return formattedError(url, error, errorResponse.errors?.[0]);
+    let parsed = JSON.parse(error.responseText);
+    errorResponse = formattedError(url, error, parsed.errors?.[0]);
   } catch (parseError) {
     switch (error.status) {
       // tailor HTTP responses as necessary for better user feedback
       case 404:
-        return formattedError(url, error, {
+        errorResponse = formattedError(url, error, {
           status: 404,
           title: 'Card Not Found',
           message: `The card ${url} does not exist`,
         });
+        break;
       default:
-        return formattedError(url, error, undefined);
+        errorResponse = formattedError(url, error, undefined);
     }
   }
+  // The realm server responds with an HTTP 404 only when the card document
+  // itself is missing. A card that exists but can't be served — e.g. because a
+  // module it imports is missing — comes back as a 5xx whose JSON:API body
+  // still carries the dependency's propagated 404. Trust the HTTP status as
+  // the authoritative not-found signal so a broken dependency surfaces as the
+  // error it is rather than masquerading as a missing card.
+  if (httpStatus != null && httpStatus !== 404) {
+    let cardError = errorResponse.errors[0];
+    if (cardError?.status === 404) {
+      cardError.status = httpStatus;
+    }
+  }
+  return errorResponse;
 }
 
 function needsServerStateMerge(

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -424,8 +424,6 @@ module('Acceptance | host mode tests', function (hooks) {
     assert
       .dom('[data-test-host-mode-404]')
       .containsText('This page could not be found.');
-    // The collapsible technical detail stays available below the placeholder.
-    assert.dom('[data-test-error-display]').exists();
     assert.strictEqual(
       getPageTitle(),
       `Card not found: ${testHostModeRealmURL}Pet/non-existent`,

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -356,6 +356,30 @@ module('Acceptance | host mode tests', function (hooks) {
             },
           },
         },
+        // A valid card definition whose module imports a dependency that does
+        // not exist, so resolving the import 404s. The card itself is found;
+        // it just can't load because a dependency is missing — a legitimate
+        // error state, distinct from the card not being found.
+        'missing-dep-card.gts': `
+          import { Component, CardDef } from 'https://cardstack.com/base/card-api';
+          import { MissingThing } from './missing-dependency';
+          export class MissingDepCard extends CardDef {
+            static displayName = 'MissingDepCard';
+            static isolated = class Isolated extends Component<typeof this> {
+              <template><div>{{MissingThing}}</div></template>
+            };
+          }
+        `,
+        'MissingDepCard/instance.json': {
+          data: {
+            meta: {
+              adoptsFrom: {
+                module: `${testHostModeRealmURL}missing-dep-card`,
+                name: 'MissingDepCard',
+              },
+            },
+          },
+        },
         'realm.json': realmConfigCardJSON({
           name: 'Test Workspace B',
           backgroundURL:
@@ -431,6 +455,25 @@ module('Acceptance | host mode tests', function (hooks) {
     assert.dom('[data-test-host-loading]').doesNotExist();
 
     store.get = originalGet;
+  });
+
+  test('visiting a card whose dependency is missing surfaces the error rather than a 404', async function (assert) {
+    await visit('/test/MissingDepCard/instance.json');
+
+    await waitFor('[data-test-card-error]');
+    // The card itself exists; one of its dependencies 404s. That is a
+    // legitimate error state, not a missing card, so the error is surfaced
+    // instead of the bare 404 placeholder.
+    assert
+      .dom('[data-test-host-mode-404]')
+      .doesNotExist('a missing dependency is not a missing card');
+    assert
+      .dom('[data-test-card-error]')
+      .containsText('This card contains an error');
+    assert.strictEqual(
+      getPageTitle(),
+      `Error rendering ${testHostModeRealmURL}MissingDepCard/instance`,
+    );
   });
 
   test('visiting a card with a rendering error shows an error', async function (assert) {

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -609,8 +609,6 @@ module('Acceptance | host submode', function (hooks) {
 
       await waitFor('[data-test-host-mode-404]');
       assert.dom('[data-test-host-mode-404]').exists();
-      // The collapsible technical detail stays available below the placeholder.
-      assert.dom('[data-test-error-display]').exists();
     });
 
     test('ai assistant is not displayed in host submode', async function (assert) {

--- a/packages/matrix/tests/host-mode.spec.ts
+++ b/packages/matrix/tests/host-mode.spec.ts
@@ -595,12 +595,5 @@ test.describe('Host mode routing rules', () => {
     });
 
     await expect(page.locator('[data-test-host-mode-404]')).toBeVisible();
-
-    // The collapsible technical detail stays available below the placeholder
-    // for the realm owner debugging the dead reference.
-    await expect(page.locator('[data-test-error-display]')).toBeVisible();
-    await expect(page.locator('[data-test-toggle-details]')).toContainText(
-      'Show Details',
-    );
   });
 });


### PR DESCRIPTION
The new 404 page had an error container to show details:

<img width="1223" height="787" alt="image" src="https://github.com/user-attachments/assets/f85d262c-2a4f-48b8-b65a-622b80951b4a" />

This removes it, since the error doesn’t really say much more than 404:

<img width="2624" height="1956" alt="s 2026-06-17 at 13 38 46@2x" src="https://github.com/user-attachments/assets/ac8e57ec-2ccf-42a4-bccd-1d437e4da2ab" />
