### PR TITLE
Render CardsGrid results through the v2 <SearchResults> surface

### DIFF
--- a/packages/base/components/card-list.gts
+++ b/packages/base/components/card-list.gts
@@ -7,7 +7,7 @@ import Component from '@glimmer/component';
 import { consume } from 'ember-provide-consume-context';
 import { modifier } from 'ember-modifier';
 
-import { LoadingIndicator } from '@cardstack/boxel-ui/components';
+import { CardContainer, LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 import FileIcon from '@cardstack/boxel-icons/file';
 import TriangleAlert from '@cardstack/boxel-icons/triangle-alert';
@@ -210,18 +210,21 @@ export default class CardList extends Component<Signature> {
                     overlay can still select/label it. Routing these through
                     `<entry.component />` would render the compact
                     `SearchResultError` row, which doesn't fill a grid cell. }}
-                <div class='card-error' data-test-card-error>
-                  <div class='card-error__thumbnail'>
-                    <TriangleAlert
-                      class='card-error__icon'
-                      role='presentation'
-                    />
+                <CardContainer
+                  class='error-tile'
+                  @displayBoundaries={{true}}
+                  data-test-card-error
+                >
+                  <div class='error'>
+                    <div class='thumbnail'>
+                      <TriangleAlert />
+                    </div>
+                    <div
+                      class='name'
+                      data-test-instance-error-name
+                    >{{entry.name}}</div>
                   </div>
-                  <div
-                    class='card-error__name'
-                    data-test-instance-error-name
-                  >{{entry.name}}</div>
-                </div>
+                </CardContainer>
               {{else if (this.shouldRenderFallback entry)}}
                 {{! A file row with no prerendered HTML (currently `.gts`/`.ts`
                     FileDef rows) — render the type icon + name so the row is
@@ -363,54 +366,40 @@ export default class CardList extends Component<Signature> {
         width: 1.5rem;
         height: 1.5rem;
       }
-      .card-error {
+      /* The default error tile, matching the v1 prerendered error component:
+         a bounded card with a centered alert icon + the result's realm-local
+         name. Identical markup + styles, so it renders the same. */
+      .error-tile {
+        width: 100%;
+        height: 100%;
+      }
+      .error {
         display: flex;
         align-content: flex-start;
         justify-content: center;
+        padding: var(--boxel-sp-xs);
         flex-wrap: wrap;
         width: 100%;
         height: 100%;
-        padding: var(--boxel-sp-xs);
         overflow: hidden;
       }
-      .card-error__thumbnail {
+      .thumbnail {
         display: flex;
-        align-items: center;
         justify-content: center;
+        align-items: center;
         height: calc(100% - 64.35px);
       }
-      .card-error__icon {
-        width: 50px;
-        height: 50px;
-        color: var(--boxel-error-300);
-      }
-      .card-error__name {
+      .name {
         width: 100%;
         text-align: center;
         font: 500 var(--boxel-font-sm);
         line-height: 1.23;
         letter-spacing: 0.13px;
         text-overflow: ellipsis;
-        overflow: hidden;
       }
-      .strip-view .card-error {
-        flex-direction: row;
-        flex-wrap: nowrap;
-        align-content: center;
-        align-items: center;
-        justify-content: flex-start;
-        gap: var(--boxel-sp-xs);
-      }
-      .strip-view .card-error__thumbnail {
-        height: auto;
-      }
-      .strip-view .card-error__icon {
-        width: 1.5rem;
-        height: 1.5rem;
-      }
-      .strip-view .card-error__name {
-        width: auto;
-        text-align: left;
+      .error svg {
+        width: 50px;
+        height: 50px;
       }
       .instance-error {
         position: relative;

--- a/packages/base/components/card-list.gts
+++ b/packages/base/components/card-list.gts
@@ -10,6 +10,7 @@ import { modifier } from 'ember-modifier';
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 import FileIcon from '@cardstack/boxel-icons/file';
+import TriangleAlert from '@cardstack/boxel-icons/triangle-alert';
 
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
 
@@ -94,14 +95,15 @@ export default class CardList extends Component<Signature> {
     return this.cardContext?.cardComponentModifier ?? noopCardModifier;
   }
 
-  // Only fallback rows are tracked on the <li> (their visible card is the
-  // <li> itself). HTML / live rows render through `<entry.component />`
-  // (`HydratableCard`), which tracks its own element with the overlay, so
-  // tracking the <li> too would double-register them — hence the no-op there.
+  // Fallback rows and error tiles are tracked on the <li> (their visible card
+  // is the <li> itself — they don't render `<entry.component />`). HTML / live
+  // rows render through `<entry.component />` (`HydratableCard`), which tracks
+  // its own element with the overlay, so tracking the <li> too would
+  // double-register them — hence the no-op there.
   private trackerFor = (
     entry: RenderableSearchEntryLike,
   ): CardComponentModifier =>
-    this.shouldRenderFallback(entry)
+    this.shouldRenderFallback(entry) || this.shouldRenderErrorTile(entry)
       ? this.cardComponentModifier
       : noopCardModifier;
 
@@ -139,6 +141,17 @@ export default class CardList extends Component<Signature> {
     return (
       !entry.html && entry.item?.type === 'file-meta' && !entry.isError
     );
+  }
+
+  // Render the full-cell error tile for an error row with no renderable HTML —
+  // no good rendering, no last-known-good rendering, and no live item to fall
+  // back to. `<entry.component />` would route these to `SearchResultError`,
+  // whose compact row layout doesn't fill a grid cell; the grid wants the
+  // centered icon + name tile instead. An error row that still carries
+  // last-known-good HTML (`entry.html.html` present) is excluded — it renders
+  // that HTML inert through `<entry.component />`.
+  shouldRenderErrorTile(entry: RenderableSearchEntryLike): boolean {
+    return entry.isError && !entry.html?.html;
   }
 
   <template>
@@ -187,7 +200,29 @@ export default class CardList extends Component<Signature> {
                 fieldName=undefined
               }}
             >
-              {{#if (this.shouldRenderFallback entry)}}
+              {{#if (this.shouldRenderErrorTile entry)}}
+                {{! An error row with no renderable HTML (no good rendering, no
+                    last-known-good rendering, no live item). Render the
+                    full-cell error tile — centered alert icon + the result's
+                    realm-local name — so the grid cell reads as a card-shaped
+                    error, matching the rest of the grid. The <li> carries the
+                    tracking modifier (see trackerFor) so the operator-mode
+                    overlay can still select/label it. Routing these through
+                    `<entry.component />` would render the compact
+                    `SearchResultError` row, which doesn't fill a grid cell. }}
+                <div class='card-error' data-test-card-error>
+                  <div class='card-error__thumbnail'>
+                    <TriangleAlert
+                      class='card-error__icon'
+                      role='presentation'
+                    />
+                  </div>
+                  <div
+                    class='card-error__name'
+                    data-test-instance-error-name
+                  >{{entry.name}}</div>
+                </div>
+              {{else if (this.shouldRenderFallback entry)}}
                 {{! A file row with no prerendered HTML (currently `.gts`/`.ts`
                     FileDef rows) — render the type icon + name so the row is
                     visible and the click handler on this `<li>` can still route
@@ -196,8 +231,8 @@ export default class CardList extends Component<Signature> {
                     the entry's deduped `icon` resource. The <li> carries the
                     tracking modifier + type attributes (see trackerFor) so the
                     overlay labels and acts on these rows, aligned to the card.
-                    Error rows and no-HTML card rows are excluded — they render
-                    through `<entry.component />`. }}
+                    Error-no-HTML rows render the tile above; no-HTML card rows
+                    render live (self-healing) through `<entry.component />`. }}
                 <div class='card-fallback' data-test-card-fallback>
                   {{#if entry.iconHtml}}
                     <span
@@ -327,6 +362,55 @@ export default class CardList extends Component<Signature> {
       .strip-view .card-fallback__icon {
         width: 1.5rem;
         height: 1.5rem;
+      }
+      .card-error {
+        display: flex;
+        align-content: flex-start;
+        justify-content: center;
+        flex-wrap: wrap;
+        width: 100%;
+        height: 100%;
+        padding: var(--boxel-sp-xs);
+        overflow: hidden;
+      }
+      .card-error__thumbnail {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: calc(100% - 64.35px);
+      }
+      .card-error__icon {
+        width: 50px;
+        height: 50px;
+        color: var(--boxel-error-300);
+      }
+      .card-error__name {
+        width: 100%;
+        text-align: center;
+        font: 500 var(--boxel-font-sm);
+        line-height: 1.23;
+        letter-spacing: 0.13px;
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
+      .strip-view .card-error {
+        flex-direction: row;
+        flex-wrap: nowrap;
+        align-content: center;
+        align-items: center;
+        justify-content: flex-start;
+        gap: var(--boxel-sp-xs);
+      }
+      .strip-view .card-error__thumbnail {
+        height: auto;
+      }
+      .strip-view .card-error__icon {
+        width: 1.5rem;
+        height: 1.5rem;
+      }
+      .strip-view .card-error__name {
+        width: auto;
+        text-align: left;
       }
       .instance-error {
         position: relative;

--- a/packages/base/components/card-list.gts
+++ b/packages/base/components/card-list.gts
@@ -14,6 +14,7 @@ import FileIcon from '@cardstack/boxel-icons/file';
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
 
 import {
+  isValidPrerenderedHtmlFormat,
   removeFileExtension,
   rri,
   searchEntryWireQueryFromQuery,
@@ -64,11 +65,25 @@ export default class CardList extends Component<Signature> {
   // The default fieldset (no `fields` member) resolves to "html, falling back
   // to the `item` serialization where no rendering matched" — exactly what the
   // grid wants (prerendered HTML for cards; an `item`/`icon` fallback for file
-  // rows). Only read under `{{#if @query}}`.
+  // rows). `@format` binds the prerendered format through the query's
+  // `htmlQuery` (the v2 way to select it); CardsGrid passes `fitted`, which
+  // matches the default, so this is behavior-preserving there while keeping a
+  // non-`fitted` caller working. Only read under `{{#if @query}}`.
   private get searchResultsQuery(): SearchEntryWireQuery {
+    let query = searchEntryWireQueryFromQuery(this.args.query!);
+    if (!isValidPrerenderedHtmlFormat(this.args.format)) {
+      return { ...query, realms: this.args.realms };
+    }
     return {
-      ...searchEntryWireQueryFromQuery(this.args.query!),
+      ...query,
       realms: this.args.realms,
+      filter: {
+        ...query.filter,
+        eq: {
+          ...query.filter?.eq,
+          htmlQuery: { eq: { format: this.args.format } },
+        },
+      },
     };
   }
 

--- a/packages/base/components/card-list.gts
+++ b/packages/base/components/card-list.gts
@@ -16,9 +16,12 @@ import { cn, eq } from '@cardstack/boxel-ui/helpers';
 import {
   removeFileExtension,
   rri,
+  searchEntryWireQueryFromQuery,
   CardCrudFunctionsContextName,
   CardContextName,
   type Query,
+  type RenderableSearchEntryLike,
+  type SearchEntryWireQuery,
 } from '@cardstack/runtime-common';
 
 import type {
@@ -57,8 +60,19 @@ export default class CardList extends Component<Signature> {
   @consume(CardContextName)
   declare cardContext: CardContext | undefined;
 
-  // Tracks the fallback row with the overlay system the same way
-  // PrerenderedCard does for rows that produced HTML. Falls back to a no-op
+  // The v2 `search-entry`-rooted query, adapted from the incoming v1 `Query`.
+  // The default fieldset (no `fields` member) resolves to "html, falling back
+  // to the `item` serialization where no rendering matched" — exactly what the
+  // grid wants (prerendered HTML for cards; an `item`/`icon` fallback for file
+  // rows). Only read under `{{#if @query}}`.
+  private get searchResultsQuery(): SearchEntryWireQuery {
+    return {
+      ...searchEntryWireQueryFromQuery(this.args.query!),
+      realms: this.args.realms,
+    };
+  }
+
+  // Tracks the fallback row with the overlay system. Falls back to a no-op
   // when no context provides one (e.g. CardList used outside operator mode),
   // so applying the modifier is always safe.
   private get cardComponentModifier(): CardComponentModifier {
@@ -66,14 +80,13 @@ export default class CardList extends Component<Signature> {
   }
 
   // Only fallback rows are tracked on the <li> (their visible card is the
-  // <li> itself). HTML rows are tracked by PrerenderedCard on their own
-  // component root, so tracking the <li> too would double-register them and
-  // misplace the overlay — hence the no-op for those.
-  private trackerFor = (card: {
-    hasHtml?: boolean;
-    isError?: boolean;
-  }): CardComponentModifier =>
-    this.shouldRenderFallback(card)
+  // <li> itself). HTML / live rows render through `<entry.component />`
+  // (`HydratableCard`), which tracks its own element with the overlay, so
+  // tracking the <li> too would double-register them — hence the no-op there.
+  private trackerFor = (
+    entry: RenderableSearchEntryLike,
+  ): CardComponentModifier =>
+    this.shouldRenderFallback(entry)
       ? this.cardComponentModifier
       : noopCardModifier;
 
@@ -85,10 +98,10 @@ export default class CardList extends Component<Signature> {
     }
   }
 
-  // Last URL segment, used as a visible label when the prerender pipeline
-  // didn't produce HTML for a file row (CS-11171 — `.gts`/`.ts` FileDef rows
-  // currently skip the FileRender pass, so their `fitted_html` is null and
-  // `<card.component />` renders nothing).
+  // Last URL segment, used as a visible label for a file row the prerender
+  // pipeline produced no HTML for (`.gts`/`.ts` FileDef rows skip the
+  // FileRender pass, so they carry no `html` rendering and fall back to a
+  // `file-meta` `item`).
   fileNameFromUrl(url: string): string {
     try {
       let pathname = new URL(url).pathname;
@@ -100,16 +113,17 @@ export default class CardList extends Component<Signature> {
     }
   }
 
-  // Render the filename fallback only when the prerender pipeline produced
-  // no HTML AND the row is not an error. Error rows have their own
-  // dedicated error component built by PrerenderedCard's constructor, which
-  // also has empty `html`; treating them like file fallbacks would swap a
-  // helpful "rendering error" affordance for a bare filename.
-  shouldRenderFallback(card: {
-    hasHtml?: boolean;
-    isError?: boolean;
-  }): boolean {
-    return card.hasHtml === false && !card.isError;
+  // Render the cheap icon + filename placeholder for a file row that has no
+  // prerendered HTML — it fell back to a `file-meta` `item`. Rendering
+  // `<entry.component />` for such a row would eagerly load the live `FileDef`
+  // instance; the placeholder shows the type icon + name (resolved from the
+  // deduped `icon` resource on the entry) without that load. Error rows and
+  // no-HTML *card* rows are excluded: the former render their error affordance,
+  // the latter resolve live (self-healing) through `<entry.component />`.
+  shouldRenderFallback(entry: RenderableSearchEntryLike): boolean {
+    return (
+      !entry.html && entry.item?.type === 'file-meta' && !entry.isError
+    );
   }
 
   <template>
@@ -123,83 +137,78 @@ export default class CardList extends Component<Signature> {
       ...attributes
     >
       {{#if @query}}
-        <@context.prerenderedCardSearchComponent
-          @query={{@query}}
-          @format={{@format}}
-          @realms={{@realms}}
-          @isLive={{@isLive}}
+        <@context.searchResultsComponent
+          @query={{this.searchResultsQuery}}
+          @mode='none'
+          as |results|
         >
-          <:loading>
-            <div class='loading-container'>
-              <LoadingIndicator />
-            </div>
-          </:loading>
-          <:response as |cards|>
-            {{#each cards key='url' as |card|}}
-              <li
-                class={{cn
-                  'boxel-card-list-item'
-                  instance-error=card.isError
-                  clickable=(if this.cardCrudFunctions.viewCard true false)
-                  fallback=(this.shouldRenderFallback card)
-                }}
-                data-test-instance-error={{card.isError}}
-                data-test-cards-grid-item={{removeFileExtension card.url}}
-                {{! In order to support scrolling cards into view we use a selector that is not pruned out in production builds }}
-                data-cards-grid-item={{removeFileExtension card.url}}
-                data-card-type-display-name={{if
-                  (this.shouldRenderFallback card)
-                  card.cardType
-                }}
-                data-card-type-icon-html={{if
-                  (this.shouldRenderFallback card)
-                  card.iconHtml
-                }}
-                role={{if this.cardCrudFunctions.viewCard 'button'}}
-                tabindex={{if this.cardCrudFunctions.viewCard '0'}}
-                {{on 'click' (fn this.handleCardClick card.url)}}
-                {{(this.trackerFor card)
-                  cardId=card.url
-                  format='data'
-                  fieldType=undefined
-                  fieldName=undefined
-                }}
-              >
-                {{#if (this.shouldRenderFallback card)}}
-                  {{! CS-11171: file rows whose prerender produced no HTML
-                      (currently `.gts`/`.ts` FileDef rows) — render a name
-                      so the row is at least visible and the click handler on
-                      this `<li>` can still route the user into interact-mode
-                      (and from there into Code Mode via the kebab menu).
-                      Error rows are excluded so PrerenderedCard's dedicated
-                      error component still gets rendered for them.
-                      The <li> carries the tracking modifier + type attributes
-                      (see trackerFor) so the overlay system labels and acts on
-                      these rows too, aligned to the visible card. }}
-                  <div class='card-fallback' data-test-card-fallback>
-                    {{#if card.iconHtml}}
-                      <span
-                        class='card-fallback__icon card-fallback__icon--svg'
-                      >{{htmlSafe card.iconHtml}}</span>
-                    {{else}}
-                      <FileIcon
-                        class='card-fallback__icon'
-                        role='presentation'
-                      />
-                    {{/if}}
-                    <div class='card-fallback__name'>
-                      {{this.fileNameFromUrl card.url}}
-                    </div>
+          {{#each results.entries key='id' as |entry|}}
+            <li
+              class={{cn
+                'boxel-card-list-item'
+                instance-error=entry.isError
+                clickable=(if this.cardCrudFunctions.viewCard true false)
+                fallback=(this.shouldRenderFallback entry)
+              }}
+              data-test-instance-error={{entry.isError}}
+              data-test-cards-grid-item={{removeFileExtension entry.id}}
+              {{! In order to support scrolling cards into view we use a selector that is not pruned out in production builds }}
+              data-cards-grid-item={{removeFileExtension entry.id}}
+              data-card-type-display-name={{if
+                (this.shouldRenderFallback entry)
+                entry.displayName
+              }}
+              data-card-type-icon-html={{if
+                (this.shouldRenderFallback entry)
+                entry.iconHtml
+              }}
+              role={{if this.cardCrudFunctions.viewCard 'button'}}
+              tabindex={{if this.cardCrudFunctions.viewCard '0'}}
+              {{on 'click' (fn this.handleCardClick entry.id)}}
+              {{(this.trackerFor entry)
+                cardId=entry.id
+                format='data'
+                fieldType=undefined
+                fieldName=undefined
+              }}
+            >
+              {{#if (this.shouldRenderFallback entry)}}
+                {{! A file row with no prerendered HTML (currently `.gts`/`.ts`
+                    FileDef rows) — render the type icon + name so the row is
+                    visible and the click handler on this `<li>` can still route
+                    into interact-mode (and from there into Code Mode), without
+                    eagerly loading the live FileDef. The icon + name come from
+                    the entry's deduped `icon` resource. The <li> carries the
+                    tracking modifier + type attributes (see trackerFor) so the
+                    overlay labels and acts on these rows, aligned to the card.
+                    Error rows and no-HTML card rows are excluded — they render
+                    through `<entry.component />`. }}
+                <div class='card-fallback' data-test-card-fallback>
+                  {{#if entry.iconHtml}}
+                    <span
+                      class='card-fallback__icon card-fallback__icon--svg'
+                    >{{htmlSafe entry.iconHtml}}</span>
+                  {{else}}
+                    <FileIcon class='card-fallback__icon' role='presentation' />
+                  {{/if}}
+                  <div class='card-fallback__name'>
+                    {{this.fileNameFromUrl entry.id}}
                   </div>
-                {{else}}
-                  <card.component />
-                {{/if}}
-              </li>
+                </div>
+              {{else}}
+                <entry.component />
+              {{/if}}
+            </li>
+          {{else}}
+            {{#if results.isLoading}}
+              <div class='loading-container'>
+                <LoadingIndicator />
+              </div>
             {{else}}
               <p>No results were found</p>
-            {{/each}}
-          </:response>
-        </@context.prerenderedCardSearchComponent>
+            {{/if}}
+          {{/each}}
+        </@context.searchResultsComponent>
       {{else if @cards}}
         {{#each @cards key='id' as |Card|}}
           <li class='boxel-card-list-item'>

--- a/packages/host/app/components/card-search/hydratable-card.gts
+++ b/packages/host/app/components/card-search/hydratable-card.gts
@@ -75,6 +75,9 @@ interface Signature {
   Args: {
     // The card/file identity URL, which is also its `links.self` GET target.
     cardId: string;
+    // The result's display name (realm-local path), surfaced by the host error
+    // component so an error tile identifies which result failed.
+    name?: string;
     // The inert prerendered HTML for an HTML-backed row. Absent for a full
     // live row, which carries no HTML and resolves to its live instance.
     component?: HTMLComponent;
@@ -233,6 +236,7 @@ export default class HydratableCard extends Component<Signature> {
           non-hydratable — no gesture, no GET. }}
       <SearchResultError
         @cardId={{@cardId}}
+        @name={{@name}}
         @error={{@errorDoc}}
         ...attributes
       />

--- a/packages/host/app/components/card-search/search-result-error.gts
+++ b/packages/host/app/components/card-search/search-result-error.gts
@@ -9,6 +9,9 @@ interface Signature {
   Args: {
     // The result's identity URL — the diagnostic / test hook for the row.
     cardId: string;
+    // The result's display name (its realm-local path, e.g. `Person/error`),
+    // shown so the tile identifies which result failed. Absent → no name line.
+    name?: string;
     // The result's error doc, when one rode along on the wire (the `item`'s
     // `meta.error`). Absent for an error rendering that carried no last-known-
     // good HTML and no item — the tile then shows a generic message.
@@ -40,6 +43,11 @@ export default class SearchResultError extends Component<Signature> {
       <ExclamationCircle class='icon' role='presentation' />
       <div class='content'>
         <div class='title'>{{this.title}}</div>
+        {{#if @name}}
+          <div class='name' data-test-instance-error-name title={{@name}}>
+            {{@name}}
+          </div>
+        {{/if}}
         <div class='message' title={{this.message}}>{{this.message}}</div>
       </div>
     </div>
@@ -64,6 +72,13 @@ export default class SearchResultError extends Component<Signature> {
       .title {
         font: 600 var(--boxel-font-sm);
         line-height: 1.2;
+      }
+      .name {
+        font: 500 var(--boxel-font-xs);
+        line-height: 1.2;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       .message {
         font: var(--boxel-font-xs);

--- a/packages/host/app/components/card-search/search-results.gts
+++ b/packages/host/app/components/card-search/search-results.gts
@@ -7,6 +7,7 @@ import {
   isResolvedCodeRef,
   isValidPrerenderedHtmlFormat,
   logger as runtimeLogger,
+  RealmPaths,
   type CardResource,
   type ErrorEntry,
   type FileMetaResource,
@@ -104,6 +105,19 @@ class RenderableSearchEntry {
     return this.raw.id;
   }
 
+  // The result's realm-local path (e.g. `Person/error`), shown by the host
+  // error tile to identify which result failed. Falls back to the bare id when
+  // the id isn't under the entry's realm.
+  get name(): string {
+    try {
+      return new RealmPaths(new URL(this.raw.realmUrl)).local(
+        new URL(this.raw.id),
+      );
+    } catch {
+      return this.raw.id;
+    }
+  }
+
   // The chosen prerendered rendering. The query's htmlQuery selects one
   // format × render type, so the resource's `html` array holds at most the one
   // matching rendering. Absent → an item-only (live) row.
@@ -193,6 +207,7 @@ class RenderableSearchEntry {
           : undefined;
       this.#component = hydratableEntryComponent({
         cardId: this.id,
+        name: this.name,
         component: inert,
         renderType: this.renderType,
         type: this.type,

--- a/packages/host/app/lib/hydratable-entry-component.ts
+++ b/packages/host/app/lib/hydratable-entry-component.ts
@@ -32,6 +32,9 @@ import type { ComponentLike } from '@glint/template';
 export interface HydratableEntryArgs {
   // The card/file identity URL — also the hydration GET target.
   cardId: string;
+  // The result's display name (realm-local path), surfaced by the host error
+  // tile to identify which result failed.
+  name?: string;
   // The inert prerendered HTML for an HTML-backed row; absent for a full live
   // row, which resolves to its live instance with nothing to stay inert as.
   component?: HTMLComponent;
@@ -56,6 +59,7 @@ export interface HydratableEntryArgs {
 class _HydratableEntryComponent {
   constructor(
     readonly cardId: string,
+    readonly name: string | undefined,
     readonly component: HTMLComponent | undefined,
     readonly renderType: ResolvedCodeRef | undefined,
     readonly type: StoreReadType | undefined,
@@ -70,6 +74,7 @@ setComponentTemplate(
   precompileTemplate(
     `<HydratableCard
       @cardId={{this.cardId}}
+      @name={{this.name}}
       @component={{this.component}}
       @renderType={{this.renderType}}
       @type={{this.type}}
@@ -114,6 +119,7 @@ export function hydratableEntryComponent(
 ): EntryComponent {
   return new _HydratableEntryComponent(
     args.cardId,
+    args.name,
     args.component,
     args.renderType,
     args.type,

--- a/packages/host/app/resources/search-entries.ts
+++ b/packages/host/app/resources/search-entries.ts
@@ -35,6 +35,7 @@ import {
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 
+import { knownFileMetaUrls } from '../lib/known-file-meta-urls';
 import { normalizeRealms } from '../lib/realm-utils';
 import { searchErrorEntry } from '../lib/search-error-entry';
 
@@ -425,6 +426,20 @@ export class SearchEntriesResource extends Resource<Args> {
         : undefined;
       let iconRef = entry.relationships.icon?.data;
       let icon = iconRef ? iconById.get(iconRef.id) : undefined;
+      // Remember which result URLs are files. A file row's `file-meta`
+      // serialization is HTML-only / never stored, so the operator-mode
+      // click + overlay path (`lib/stack-item.ts`,
+      // `operator-mode-overlays.gts`) can't classify it as a file from the
+      // Store — it consults this registry instead. A file is an `item` of
+      // type `file-meta`, or an html-backed row whose rendering carries no
+      // render type (files render natively; card renderings always name one).
+      // Mirrors what the v1 `PrerenderedCard` wrapper registered.
+      let isFile =
+        itemRef?.type === 'file-meta' ||
+        (renderings.length > 0 && !renderings[0].renderType);
+      if (isFile) {
+        knownFileMetaUrls.add(entry.id);
+      }
       return {
         id: entry.id,
         realmUrl: realmUrlFor(entry.id),

--- a/packages/host/tests/integration/resources/search-entries-test.gts
+++ b/packages/host/tests/integration/resources/search-entries-test.gts
@@ -20,6 +20,10 @@ import {
 } from '@cardstack/runtime-common';
 
 import {
+  knownFileMetaUrls,
+  clearKnownFileMetaUrls,
+} from '@cardstack/host/lib/known-file-meta-urls';
+import {
   getSearchEntriesResource,
   SearchEntriesResource,
 } from '@cardstack/host/resources/search-entries';
@@ -167,6 +171,78 @@ module('Integration | search-entries resource', function (hooks) {
         undefined,
         'an html-bearing entry has no item fallback',
       );
+    }
+  });
+
+  test('registers file result URLs so clicks/overlay classify them as files', async function (assert) {
+    // A file row's `file-meta` serialization is HTML-only / never stored, so
+    // the operator-mode click + overlay path consults `knownFileMetaUrls` to
+    // classify a clicked URL as a file. The resource must register both an
+    // item-only file row and an html-backed file row (whose rendering carries
+    // no render type — files render natively).
+    let itemFileUrl = `${testRealmURL}notes.txt`;
+    let htmlFileUrl = `${testRealmURL}readme.md`;
+    let renderingId = htmlResourceId({ url: htmlFileUrl, format: 'fitted' });
+    let doc: SearchEntryResults = {
+      data: [
+        {
+          type: SearchEntryResourceType,
+          id: itemFileUrl,
+          relationships: {
+            item: { data: { type: 'file-meta', id: itemFileUrl } },
+          },
+        },
+        {
+          type: SearchEntryResourceType,
+          id: htmlFileUrl,
+          relationships: {
+            html: { data: [{ type: HtmlResourceType, id: renderingId }] },
+          },
+        },
+      ],
+      // The item-only file row registers off its `item` relationship's
+      // `file-meta` type — the resolved serialization need not ride in
+      // `included`. The html-backed file row needs its rendering (no render
+      // type → a file rendering).
+      included: [
+        {
+          type: HtmlResourceType,
+          id: renderingId,
+          attributes: {
+            html: '<div>readme</div>',
+            cardType: '',
+            format: 'fitted',
+          },
+          relationships: { styles: { data: [] } },
+        },
+      ],
+      meta: { page: { total: 2 } },
+    };
+    let originalSearchEntries = storeService.searchEntries.bind(storeService);
+    storeService.searchEntries = async () => doc;
+    clearKnownFileMetaUrls();
+    try {
+      let search = getResourceForTest(storeService, () => ({
+        named: {
+          query: {
+            filter: { 'item.on': bookRef },
+            realms: [testRealmURL],
+          },
+        },
+      }));
+      await search.loaded;
+
+      assert.true(
+        knownFileMetaUrls.has(itemFileUrl),
+        'the item-only file row is registered',
+      );
+      assert.true(
+        knownFileMetaUrls.has(htmlFileUrl),
+        'the html-backed file row (no render type) is registered',
+      );
+    } finally {
+      storeService.searchEntries = originalSearchEntries;
+      clearKnownFileMetaUrls();
     }
   });
 

--- a/packages/runtime-common/search-results-component.ts
+++ b/packages/runtime-common/search-results-component.ts
@@ -42,6 +42,10 @@ export interface SearchEntryRendering {
 export interface RenderableSearchEntryLike {
   // The card/file identity URL.
   id: string;
+  // The result's realm-local path (e.g. `Person/error`) — a readable label a
+  // consumer shows on an error tile to identify which result failed. Falls back
+  // to the bare id when the id isn't under the entry's realm.
+  name: string;
   isError: boolean;
   // The result's card-type descriptor, resolved from the deduped `icon`
   // resource — present whenever the row's native type has one. Carried on the


### PR DESCRIPTION
Migrates the card-catalog grid (`CardsGrid` → `CardList`) off the deprecated `@context.prerenderedCardSearchComponent` and onto the v2 `@context.searchResultsComponent`.

- Each result renders through `<entry.component />`, which paints prerendered HTML inert (`mode='none'` — the grid is a prerendered-HTML surface) or resolves a live row, so the grid no longer branches on prerendered-vs-live.
- The incoming v1 `Query` adapts to the `search-entry`-rooted wire query via `searchEntryWireQueryFromQuery` (default fieldset → html, falling back to the `item` serialization).
- The file-row placeholder (a `.gts`/`.ts` FileDef with no prerendered HTML) is preserved by hand and now sources its type icon + name from the entry's deduped `icon` resource — so it shows the per-type icon and filename without eagerly loading the live `FileDef`. No-HTML *card* rows resolve live through `<entry.component />` (self-healing).
- Error instances with no last-known-good HTML render the default error tile by hand, through the same `CardContainer` + centered alert icon + scoped styles as the legacy prerendered error component — so the tile (bounded rounded card, `--boxel-error-100` icon + label) is visually identical.
- The grid `<li>` chrome (classes, `data-test-cards-grid-item`, click → `viewCard`, overlay tracking on fallback rows via `cardComponentModifier`) and the `@cards` (BoxComponent) path are unchanged.

**Minor behavioral difference:** the default error tile labels a no-last-known-good instance with the result's realm-local **id** (e.g. `Person/error`), whereas the legacy tile labeled it with the index row's **file URL** (`Person/error.json`). The practical difference is that the `.json` extension no longer appears in the tile — the v2 `search-entry` identity strips it, and there is no separate file-URL field to surface for card rows.

Part of the unified-search first-party call-site migration. The file-row placeholder needs the deduped `icon` resource, so this **stacks on #5260** — retarget the base to `main` before merge.

### Verification
- `ember-template-lint` clean (base `.gts` is linted via ember-template-lint; the eslint `<template>` parse "error" is a known tooling artifact, not a CI failure).
- Verified live in the running app: the Experiments CardsGrid renders all rows through the v2 surface — card rows (prerendered HTML inert), file rows that render their content, the icon + filename fallback for no-HTML files, and the default error tile — with the grid layout, sort/view controls, and click-through intact.
