### PR TITLE
Time out wedged test fetches so a stuck h2 stream retries instead of hanging

### DIFF
--- a/packages/host/tests/unit/fetcher-test.ts
+++ b/packages/host/tests/unit/fetcher-test.ts
@@ -140,3 +140,61 @@ module('Unit | fetcher', function () {
     assert.strictEqual(await response.text(), 'OK', 'body text is correct');
   });
 });
+
+module('Unit | VirtualNetwork fetch retries', function (hooks) {
+  let priorEnvironment: unknown;
+  let priorTimeout: unknown;
+
+  hooks.beforeEach(function () {
+    // The per-attempt timeout is armed only in the test environment; pin it
+    // and shrink the deadline so the retry path runs in milliseconds.
+    priorEnvironment = (globalThis as any).__environment;
+    priorTimeout = (globalThis as any).__fetchAttemptTimeoutMs;
+    (globalThis as any).__environment = 'test';
+    (globalThis as any).__fetchAttemptTimeoutMs = 50;
+  });
+
+  hooks.afterEach(function () {
+    (globalThis as any).__environment = priorEnvironment;
+    if (priorTimeout === undefined) {
+      delete (globalThis as any).__fetchAttemptTimeoutMs;
+    } else {
+      (globalThis as any).__fetchAttemptTimeoutMs = priorTimeout;
+    }
+  });
+
+  test('a wedged (never-settling) attempt to a retryable host times out and retries on a fresh stream', async function (assert) {
+    assert.expect(3);
+    let attempts = 0;
+    // Mirror a wedged HTTP/2 stream: the first attempt never resolves on its
+    // own and only settles when its abort signal fires; the retry succeeds.
+    let vn = new VirtualNetwork(async function (input) {
+      attempts++;
+      let request = input as Request;
+      if (attempts === 1) {
+        return await new Promise<Response>((_resolve, reject) => {
+          request.signal.addEventListener('abort', () =>
+            reject(
+              new DOMException('The operation was aborted.', 'AbortError'),
+            ),
+          );
+        });
+      }
+      return new Response('OK', { status: 200 });
+    });
+
+    // localhost is a retryable host, so withRetries arms the timeout.
+    let response = await vn.fetch('http://localhost:4201/base/_info');
+    assert.strictEqual(
+      attempts,
+      2,
+      'first attempt was aborted by the timeout and the request was retried',
+    );
+    assert.strictEqual(response.status, 200, 'retry resolved successfully');
+    assert.strictEqual(
+      await response.text(),
+      'OK',
+      'body comes from the retry',
+    );
+  });
+});

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -408,9 +408,19 @@ export class VirtualNetwork {
       return next(await this.mapRequest(request, 'virtual-to-real'));
     });
 
-    return withRetries(new URL(request.url), () =>
-      fetcher(this.nativeFetch, handlers, this)(request, init),
-    );
+    return withRetries(new URL(request.url), (signal) => {
+      // `signal` is supplied only on the per-attempt timeout path (test env);
+      // attach it to a fresh clone so aborting one attempt cancels its
+      // underlying fetch without disturbing the template request the next
+      // attempt re-clones. Combine with any caller-supplied signal so an
+      // explicit cancellation still propagates.
+      let attemptRequest = signal
+        ? new Request(request.clone(), {
+            signal: combineAbortSignals(request.signal, signal),
+          })
+        : request;
+      return fetcher(this.nativeFetch, handlers, this)(attemptRequest, init);
+    });
   }
 
   // This method is used to handle the boundary between the real and virtual network,
@@ -497,6 +507,45 @@ const maxAttempts = 10;
 const backOffMs = 100;
 const retryableLocalHosts = new Set(['localhost', '127.0.0.1']);
 
+// Per-attempt deadline for retryable fetches in the host/Node test
+// environment. An HTTP/2 *stream* can wedge while its session stays healthy:
+// the session keeps answering the realm server's keepalive PINGs (so the
+// server-side wedged-session teardown never fires) yet one request's response
+// never arrives. That fetch never settles, so withRetries' catch never runs,
+// the `fetcher` test-waiter stays open, and the test hangs until its 60s QUnit
+// timeout. A deadline turns the silent stream wedge into an AbortError the
+// retry loop can act on: it frees the waiter and reissues the request on a
+// fresh stream (or, once a fully-silent session is torn down, a fresh
+// session), comfortably inside the 60s budget. 15s sits well above a healthy
+// base-realm fetch (sub-second even on a loaded CI runner) so a merely slow
+// response is never aborted, while still leaving room for several retries.
+const DEFAULT_ATTEMPT_TIMEOUT_MS = 15_000;
+
+// Read the per-attempt deadline, honoring a test-only override so the retry
+// path can be exercised deterministically without waiting out the real 15s.
+function attemptTimeoutMs(): number {
+  let override = (globalThis as any).__fetchAttemptTimeoutMs;
+  return typeof override === 'number' && override > 0
+    ? override
+    : DEFAULT_ATTEMPT_TIMEOUT_MS;
+}
+
+// Merge a request's own signal with our per-attempt timeout signal so either
+// one aborts the underlying fetch. Defined defensively, but AbortSignal.any is
+// available in every environment this test-only path runs in (Chrome + Node).
+function combineAbortSignals(
+  requestSignal: AbortSignal | undefined,
+  timeoutSignal: AbortSignal,
+): AbortSignal {
+  if (!requestSignal) {
+    return timeoutSignal;
+  }
+  if (typeof (AbortSignal as any).any === 'function') {
+    return (AbortSignal as any).any([requestSignal, timeoutSignal]);
+  }
+  return requestSignal.aborted ? requestSignal : timeoutSignal;
+}
+
 function shouldRetryFetch(url: URL) {
   // Env-mode services live at `<service>.<slug>.localhost` and are
   // reached through a local Traefik. The realm-server worker fetches
@@ -535,15 +584,27 @@ function shouldRetryFetch(url: URL) {
 
 async function withRetries(
   url: URL,
-  fetchFn: () => ReturnType<typeof globalThis.fetch>,
+  fetchFn: (signal?: AbortSignal) => ReturnType<typeof globalThis.fetch>,
 ) {
+  let retryable = shouldRetryFetch(url);
+  // Only arm the per-attempt timeout in the host/Node *test* environment, not
+  // on shouldRetryFetch's production env-mode worker-boot branch above, which
+  // must keep its existing no-deadline behavior.
+  let armTimeout = retryable && (globalThis as any).__environment === 'test';
   let attempt = 0;
   for (;;) {
+    let timeoutController: AbortController | undefined;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    let timeoutMs = attemptTimeoutMs();
+    if (armTimeout) {
+      timeoutController = new AbortController();
+      timeoutTimer = setTimeout(() => timeoutController!.abort(), timeoutMs);
+    }
     try {
-      return await fetchFn();
+      return await fetchFn(timeoutController?.signal);
     } catch (err: any) {
-      if (!shouldRetryFetch(url) || ++attempt > maxAttempts) {
-        if (shouldRetryFetch(url) && attempt > maxAttempts) {
+      if (!retryable || ++attempt > maxAttempts) {
+        if (retryable && attempt > maxAttempts) {
           // Final-exhaustion log: distinct from the per-attempt warning so
           // CI output can be grepped for the actual cap being hit.
           console.error(
@@ -554,12 +615,22 @@ async function withRetries(
         }
         throw err;
       }
+      // A timed-out attempt is logged distinctly from a rejected one so a
+      // future CI failure shows the deadline firing (and on which URL) rather
+      // than blending into the transient "fetch failed" noise.
+      let timedOut = timeoutController?.signal.aborted ?? false;
       console.error(
-        `Encountered fetch failed for ${
-          url.href
-        } retry attempt #${attempt} in ${attempt * backOffMs}ms`,
+        `Encountered fetch ${
+          timedOut ? `timeout (>${timeoutMs}ms)` : 'failed'
+        } for ${url.href} retry attempt #${attempt} in ${
+          attempt * backOffMs
+        }ms`,
       );
       await new Promise((r) => setTimeout(r, attempt * backOffMs));
+    } finally {
+      if (timeoutTimer) {
+        clearTimeout(timeoutTimer);
+      }
     }
   }
 }


### PR DESCRIPTION
## What

A host acceptance test (`code-submode | card playground > multiple realms: edit format is enabled for writable instances of read-only card definitions`) intermittently times out at 60s. The timeout diagnostics already in the suite pinned the cause precisely:

```
[test-timeout] ... ran for 126135ms
in-flight fetches at rejection time (1):
  QUERY https://localhost:4201/base/_info (outstanding 119777ms)
```

One fetch to the base realm hung for ~120s and never settled. The same run shows other base-realm fetches on the session (`css-value`, `color`) failing and recovering — so the HTTP/2 session itself was alive, but that single `_info` stream was individually wedged.

## Why the existing safeguards don't catch it

- **`withRetries`** (the test-env fetch retry) only reacts to *rejections*. A fetch that never settles is never retried — and because the `fetcher` test-waiter stays open around it, `settled()` / `waitFor` never resolve and the test waits out its 60s budget.
- **The realm server's HTTP/2 keepalive** tears down a session only when it goes *fully silent* (misses consecutive pongs). A session that keeps answering pings while one of its streams is stuck is healthy from the keepalive's point of view, so it's never torn down. This is the "transport alive, stream wedged" mode the keepalive's own diagnostics distinguish — and it's exactly what happened here.

## The fix

Give each retryable fetch attempt in the test environment a deadline. When an attempt doesn't settle in time, it's aborted; that rejects the underlying fetch (freeing the `fetcher` waiter) and lets the existing retry loop reissue the request on a fresh stream. The deadline (15s) sits well above a healthy base-realm fetch, so a merely slow response is never aborted, and it leaves room for several retries inside the 60s test timeout.

A timed-out attempt is logged distinctly from a rejected one (`Encountered fetch timeout (>…ms) for <url>`), so if a future failure slips through, CI output shows the deadline firing and on which URL rather than blending into the transient "fetch failed" noise.

Scope is limited to the test-env retry path. Production fetch behavior — including the env-mode worker-boot `.localhost` retry, which intentionally has no deadline — is unchanged, and any caller-supplied `AbortSignal` is preserved (merged with the timeout signal).

## Test

`Unit | VirtualNetwork fetch retries` drives a stub whose first attempt mirrors a wedged stream (never resolves; only settles when aborted) and asserts the request is aborted and retried to success. A test-only `__fetchAttemptTimeoutMs` knob shrinks the deadline so the path runs in milliseconds.
