### PR TITLE
Record whether an h2 keepalive force-destroy actually releases a wedged session

### DIFF
--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -77,6 +77,12 @@ const HTTP2_KEEPALIVE_MAX_MISSED_PINGS = 3;
 // so force the session down to actually RST the browser's hung fetch.
 const HTTP2_KEEPALIVE_GRACE_MS = 3000;
 const HTTP2_KEEPALIVE_TCP_INITIAL_DELAY_MS = 15000;
+// How long after the force-destroy to check whether the session actually
+// emitted 'close'. A transport-wedged session can swallow `session.destroy()`
+// — no 'close' fires, the session lingers, and its streams never RST — so this
+// confirm window records whether the forced teardown reached the peer or the
+// wedge is unreachable from the server.
+const HTTP2_KEEPALIVE_POST_DESTROY_CONFIRM_MS = 2000;
 
 // Per-session liveness recorded by the PING keepalive and read by the h2
 // diagnostics, so diagnostic dumps can say whether the underlying session was
@@ -342,6 +348,7 @@ interface KeepaliveOptions {
   pongTimeoutMs?: number;
   maxMissedPings?: number;
   graceMsBeforeDestroy?: number;
+  postDestroyConfirmMs?: number;
 }
 
 // Ping a single h2 session on an interval; if it misses `maxMissedPings`
@@ -362,6 +369,8 @@ export function startSessionKeepalive(
     options.maxMissedPings ?? HTTP2_KEEPALIVE_MAX_MISSED_PINGS;
   let graceMsBeforeDestroy =
     options.graceMsBeforeDestroy ?? HTTP2_KEEPALIVE_GRACE_MS;
+  let postDestroyConfirmMs =
+    options.postDestroyConfirmMs ?? HTTP2_KEEPALIVE_POST_DESTROY_CONFIRM_MS;
 
   let stopped = false;
   let misses = 0;
@@ -423,17 +432,55 @@ export function startSessionKeepalive(
       // already closing/closed
     }
     let hard = setTimeout(() => {
+      if (session.destroyed) {
+        return;
+      }
+      // Record the socket-level state that characterizes the wedge. Reads go
+      // through the guarded Http2Session.socket proxy, which permits property
+      // gets but throws ERR_HTTP2_NO_SOCKET_MANIPULATION on mutators — so this
+      // can observe the socket but cannot tear it down directly; session
+      // teardown is `session.destroy()`'s job (it targets the socket itself).
+      let socket = session.socket as net.Socket | undefined;
+      let socketState = socket
+        ? `socket(destroyed=${socket.destroyed} writable=${socket.writable} ` +
+          `writableLength=${socket.writableLength} ` +
+          `bytesRead=${socket.bytesRead} bytesWritten=${socket.bytesWritten})`
+        : 'socket=<none>';
+      log.warn(
+        `[h2-keepalive] session ${sessionLabel()} still up after ` +
+          `${graceMsBeforeDestroy}ms grace — force-destroying; ${socketState}`,
+      );
+      let destroyAt = Date.now();
+      let closeFired = false;
+      session.once('close', () => {
+        closeFired = true;
+        log.warn(
+          `[h2-keepalive] session ${sessionLabel()} closed ` +
+            `${Date.now() - destroyAt}ms after force-destroy`,
+        );
+      });
       try {
-        if (!session.destroyed) {
-          log.warn(
-            `[h2-keepalive] session ${sessionLabel()} still up after ` +
-              `${graceMsBeforeDestroy}ms grace — force-destroying`,
-          );
-          session.destroy();
-        }
+        session.destroy();
       } catch {
         // already destroyed
       }
+      // Whether destroy() actually releases the peer is the open question. If
+      // 'close' never fires, the streams never RST and the browser's fetch
+      // never rejects — no server-side teardown reached the wedged transport,
+      // which is the signal that distinguishes a fixable server-side issue
+      // from a hang only the client can recover from.
+      let confirm = setTimeout(() => {
+        if (!closeFired) {
+          log.warn(
+            `[h2-keepalive] session ${sessionLabel()} STILL not closed ` +
+              `${postDestroyConfirmMs}ms after force-destroy ` +
+              `(destroyed=${session.destroyed} ` +
+              `socketDestroyed=${session.socket?.destroyed ?? '<none>'}) — ` +
+              `transport-level wedge unreachable from the server`,
+          );
+        }
+      }, postDestroyConfirmMs);
+      confirm.unref?.();
     }, graceMsBeforeDestroy);
     hard.unref?.();
   }
@@ -755,6 +802,19 @@ function installHttp2Diagnostics(
     // server stream exists, connection-level flow-control stall, dead transport).
     let healthyPongs = 0;
     for (let [session, srec] of sessions) {
+      // A force-destroyed session that never emitted 'close' (the keepalive
+      // logs this transport-wedge case) is only ever removed on the 'close'
+      // event — so without this it would linger here for minutes, inflating
+      // liveSessions and re-reporting a dead connection every sweep. Once we
+      // can see it's destroyed, drop it so the counts reflect reality.
+      if (session.destroyed) {
+        sessions.delete(session);
+        log.warn(
+          `[h2-diag] session #${srec.id} destroyed without 'close' — ` +
+            `dropping from live set (live sessions=${sessions.size})`,
+        );
+        continue;
+      }
       let inFlight: { rec: TrackedStream; age: number }[] = [];
       for (let [stream, rec] of open) {
         if (stream.session === session) {

--- a/packages/realm-server/tests/http2-keepalive-test.ts
+++ b/packages/realm-server/tests/http2-keepalive-test.ts
@@ -17,14 +17,29 @@ type PingCallback = (
   payload?: Buffer,
 ) => void;
 
+// Minimal stand-in for the Http2Session.socket proxy: the teardown only reads
+// these fields for its diagnostics (the real proxy forbids mutators).
+class FakeSocket {
+  destroyed = false;
+  writable = true;
+  writableLength = 0;
+  bytesRead = 0;
+  bytesWritten = 0;
+}
+
 // Minimal stand-in for an Http2Session: only the surface startSessionKeepalive
-// touches (ping/close/destroy + the close/error events + closed/destroyed).
+// touches (ping/close/destroy + socket + the close/error events +
+// closed/destroyed).
 class FakeSession extends EventEmitter {
   closed = false;
   destroyed = false;
   closeCount = 0;
   destroyCount = 0;
   pingCount = 0;
+  socket = new FakeSocket();
+  // When true, destroy() releases the peer cleanly by emitting 'close' on the
+  // next tick — the success path the confirm window should observe.
+  emitCloseOnDestroy = false;
   // Default: a healthy peer that pongs immediately.
   pingImpl: (cb: PingCallback) => boolean = (cb) => {
     setTimeout(() => cb(null, 1), 0);
@@ -44,6 +59,9 @@ class FakeSession extends EventEmitter {
   destroy() {
     this.destroyCount++;
     this.destroyed = true;
+    if (this.emitCloseOnDestroy) {
+      setTimeout(() => this.emit('close'), 0);
+    }
   }
 }
 
@@ -53,12 +71,32 @@ function asSession(fake: FakeSession): http2.Http2Session {
 
 const log = logger('test:h2-keepalive');
 
+// A logger that records its warnings so a test can assert which teardown
+// branch fired. startSessionKeepalive only emits via warn().
+function recordingLog(): {
+  log: ReturnType<typeof logger>;
+  warnings: string[];
+} {
+  let warnings: string[] = [];
+  let noop = () => {};
+  let log = {
+    warn: (...args: unknown[]) => warnings.push(args.join(' ')),
+    info: noop,
+    error: noop,
+    debug: noop,
+    trace: noop,
+    setLevel: noop,
+  } as unknown as ReturnType<typeof logger>;
+  return { log, warnings };
+}
+
 // Fast tuning so a 2-miss teardown completes well under the QUnit timeout.
 const FAST = {
   intervalMs: 20,
   pongTimeoutMs: 15,
   maxMissedPings: 2,
   graceMsBeforeDestroy: 10,
+  postDestroyConfirmMs: 20,
 };
 
 function wait(ms: number) {
@@ -101,6 +139,57 @@ module(basename(__filename), function () {
       assert.ok(
         fake.destroyCount >= 1,
         'wedged session is force-destroyed after the grace period',
+      );
+    } finally {
+      stopKeepalive();
+    }
+  });
+
+  // The unreachable warning ("STILL not closed …") and the success line
+  // ("closed Nms after force-destroy") both end in "after force-destroy", so
+  // match the success path by that suffix while excluding the unreachable one.
+  let isUnreachable = (w: string) => w.includes('STILL not closed');
+  let isCloseSuccess = (w: string) =>
+    w.includes('after force-destroy') && !isUnreachable(w);
+
+  test('a wedged session that never emits close is reported as unreachable', async function (assert) {
+    let fake = new FakeSession();
+    // Never pong, and never emit 'close' from destroy() — the transport-wedge
+    // signature where session.destroy() leaves a zombie.
+    fake.pingImpl = () => true;
+    let { log: recLog, warnings } = recordingLog();
+    let stopKeepalive = startSessionKeepalive(asSession(fake), recLog, FAST);
+    try {
+      await wait(200);
+      assert.ok(fake.destroyCount >= 1, 'wedged session is force-destroyed');
+      assert.ok(
+        warnings.some(isUnreachable),
+        'logs that the teardown did not reach the peer',
+      );
+      assert.notOk(
+        warnings.some(isCloseSuccess),
+        'does not log the success path',
+      );
+    } finally {
+      stopKeepalive();
+    }
+  });
+
+  test('a session that closes after force-destroy logs the success path', async function (assert) {
+    let fake = new FakeSession();
+    fake.pingImpl = () => true; // wedge → triggers teardown
+    fake.emitCloseOnDestroy = true; // but destroy() releases the peer
+    let { log: recLog, warnings } = recordingLog();
+    let stopKeepalive = startSessionKeepalive(asSession(fake), recLog, FAST);
+    try {
+      await wait(200);
+      assert.ok(
+        warnings.some(isCloseSuccess),
+        'logs that the session closed after force-destroy',
+      );
+      assert.notOk(
+        warnings.some(isUnreachable),
+        'does not log the transport-wedge-unreachable warning',
       );
     } finally {
       stopKeepalive();


### PR DESCRIPTION
## What

A host acceptance test (`code-submode | card playground > multiple realms: edit format ...`) intermittently times out at 60s on a single base-realm fetch (`QUERY /base/_info`) that hangs ~120s and never settles.

The shard-9 realm-server log for the failing run shows the existing PING keepalive working as designed up to a point: exactly one h2 session went frame-silent, the keepalive detected it (3 missed pings), and it logged `closing to release wedged streams` → `force-destroying`. **But the force-destroy didn't release the connection.** That session:

- never emitted a `close` event,
- kept being reported by the diagnostics for **185s** after "force-destroying" (`win=undefined`, so destroyed server-side), and
- left the client's `_info` fetch hung the whole time (`_info` never appears as a server-side stream — it was queued client-side on the wedged session and the frames never flowed).

So `session.destroy()` on a transport-wedged session can leave it in a zombie state: the streams never RST, so the browser's pending fetch never rejects.

## Why this is diagnostics-only

There's no stronger server-side teardown lever to reach for: the guarded `Http2Session.socket` proxy throws `ERR_HTTP2_NO_SOCKET_MANIPULATION` on mutators, so the underlying socket can't be destroyed directly, and `session.destroy()` already targets it. Rather than add an ineffective teardown, this records what the existing one actually does.

## Change

- **Record the teardown outcome.** At force-destroy time, log the socket-level state (`destroyed`/`writable`/`writableLength`/`bytesRead`/`bytesWritten` — reads are permitted through the proxy) and whether `close` fires within a short confirm window:
  - `session #N closed Xms after force-destroy` → the teardown reached the peer; look upstream.
  - `STILL not closed … transport-level wedge unreachable from the server` → no server-side teardown can reach this peer; the recovery has to move off the server.
- **Stop counting zombies.** The diagnostics only drop a session from the live set on `close`; a destroyed-but-never-closed session would otherwise inflate `liveSessions` and re-report a dead connection every sweep. Drop it once it's observably destroyed.

No h2 behavior changes — `close()` + `destroy()` on a wedged session is exactly as before; this only adds logging and the zombie cleanup.

## Test

`packages/realm-server/tests/http2-keepalive-test.ts` adds a fake socket to the session stub and a case asserting a session that stays wedged (never emits `close`) is still force-destroyed and runs the new diagnostics without throwing. All 9 keepalive unit tests pass standalone.
