### PR TITLE
Migrate the create-listing modal examples to the v2 <SearchResults> surface

### DIFF
--- a/packages/host/app/components/operator-mode/create-listing-modal.gts
+++ b/packages/host/app/components/operator-mode/create-listing-modal.gts
@@ -1,4 +1,4 @@
-import { fn, hash } from '@ember/helper';
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -25,11 +25,12 @@ import {
   rri,
   type CommandContext,
   type ResolvedCodeRef,
+  type SearchEntryWireQuery,
 } from '@cardstack/runtime-common';
 
+import SearchResults from '@cardstack/host/components/card-search/search-results';
 import ModalContainer from '@cardstack/host/components/modal-container';
 import { SelectedTypePill } from '@cardstack/host/components/operator-mode/create-file-modal';
-import PrerenderedCardSearch from '@cardstack/host/components/prerendered-card-search';
 import { Submodes } from '@cardstack/host/components/submode-switcher';
 
 import type CommandService from '@cardstack/host/services/command-service';
@@ -106,6 +107,20 @@ export default class CreateListingModal extends Component<Signature> {
       }
     });
     return [...new Set(realms)];
+  }
+
+  // The v2 `search-entry` query for the selected example cards: scoped to the
+  // chosen card URLs (matched by index file URL, hence the `.json`-suffixed
+  // `selectedExampleCardUrls`) and their realms, with the `atom` rendering
+  // bound through the filter's `htmlQuery` (the v2 way to select a prerendered
+  // format). The eq carries only that binding, which the engine lifts out,
+  // leaving the result set scoped purely by `cardUrls`.
+  private get exampleSearchQuery(): SearchEntryWireQuery {
+    return {
+      cardUrls: this.selectedExampleCardUrls,
+      realms: this.selectedExampleRealms,
+      filter: { eq: { htmlQuery: { eq: { format: 'atom' } } } },
+    };
   }
 
   private chooseExamples = task(async () => {
@@ -263,26 +278,23 @@ export default class CreateListingModal extends Component<Signature> {
                     class='selected-examples-list'
                     data-test-selected-examples
                   >
-                    <PrerenderedCardSearch
-                      @query={{hash}}
-                      @cardUrls={{this.selectedExampleCardUrls}}
-                      @format='atom'
-                      @realms={{this.selectedExampleRealms}}
-                      @isLive={{false}}
+                    <SearchResults
+                      @query={{this.exampleSearchQuery}}
+                      @mode='none'
+                      as |results|
                     >
-                      <:loading>
+                      {{#if results.isLoading}}
                         <div class='selected-example-loading'>
                           <LoadingIndicator />
                         </div>
-                      </:loading>
-                      <:response as |cards|>
-                        {{#each cards key='url' as |card|}}
+                      {{else}}
+                        {{#each results.entries key='id' as |entry|}}
                           <div
                             class='selected-example-atom'
-                            data-test-selected-example={{card.url}}
+                            data-test-selected-example={{entry.id}}
                             data-test-card-format='atom'
                           >
-                            <card.component />
+                            <entry.component />
                             <IconButton
                               class='selected-example-remove-button'
                               @icon={{IconX}}
@@ -291,14 +303,14 @@ export default class CreateListingModal extends Component<Signature> {
                               aria-label='Remove example'
                               {{on
                                 'click'
-                                (fn this.removeSelectedExample card.url)
+                                (fn this.removeSelectedExample entry.id)
                               }}
-                              data-test-selected-example-remove={{card.url}}
+                              data-test-selected-example-remove={{entry.id}}
                             />
                           </div>
                         {{/each}}
-                      </:response>
-                    </PrerenderedCardSearch>
+                      {{/if}}
+                    </SearchResults>
                   </div>
                 {{else}}
                   <span class='no-examples-message'>No examples selected</span>

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -2862,12 +2862,10 @@ export class ExportedCard extends ExportedCardParent {
       .dom('[data-test-create-listing-modal]')
       .exists('confirmation modal appears after clicking Create Listing');
 
-    await waitFor(
-      `[data-test-selected-example="${testRealmURL}Pet/mango.json"]`,
-    );
+    await waitFor(`[data-test-selected-example="${testRealmURL}Pet/mango"]`);
 
     assert
-      .dom(`[data-test-selected-example="${testRealmURL}Pet/mango.json"]`)
+      .dom(`[data-test-selected-example="${testRealmURL}Pet/mango"]`)
       .exists('the opened instance is pre-selected');
     assert
       .dom('[data-test-selected-examples] [data-test-card-format="atom"]')

--- a/packages/host/tests/integration/components/create-listing-modal-test.gts
+++ b/packages/host/tests/integration/components/create-listing-modal-test.gts
@@ -126,20 +126,16 @@ module('Integration | components | create-listing-modal', function (hooks) {
     });
 
     await waitFor('[data-test-create-listing-modal]');
-    await waitFor(
-      `[data-test-selected-example="${testRealmURL}Pet/mango.json"]`,
-    );
+    await waitFor(`[data-test-selected-example="${testRealmURL}Pet/mango"]`);
 
     assert
-      .dom(`[data-test-selected-example="${testRealmURL}Pet/mango.json"]`)
+      .dom(`[data-test-selected-example="${testRealmURL}Pet/mango"]`)
       .exists();
     assert
       .dom('[data-test-selected-examples] [data-test-card-format="atom"]')
       .exists({ count: 1 });
     assert
-      .dom(
-        `[data-test-selected-example-remove="${testRealmURL}Pet/mango.json"]`,
-      )
+      .dom(`[data-test-selected-example-remove="${testRealmURL}Pet/mango"]`)
       .exists();
     assert.dom('[data-test-choose-examples-button]').hasText('Add Examples');
   });
@@ -163,15 +159,15 @@ module('Integration | components | create-listing-modal', function (hooks) {
 
     await waitFor('[data-test-create-listing-modal]');
     await waitFor(
-      `[data-test-selected-example-remove="${testRealmURL}Pet/mango.json"]`,
+      `[data-test-selected-example-remove="${testRealmURL}Pet/mango"]`,
     );
 
     await click(
-      `[data-test-selected-example-remove="${testRealmURL}Pet/mango.json"]`,
+      `[data-test-selected-example-remove="${testRealmURL}Pet/mango"]`,
     );
 
     assert
-      .dom(`[data-test-selected-example="${testRealmURL}Pet/mango.json"]`)
+      .dom(`[data-test-selected-example="${testRealmURL}Pet/mango"]`)
       .doesNotExist();
     assert.dom('[data-test-choose-examples-button]').hasText('Add Examples');
   });


### PR DESCRIPTION
Migrates the create-listing modal's selected-examples row off the deprecated `<PrerenderedCardSearch>` and onto the v2 `<SearchResults>` surface.

- The selected example cards render through `<SearchResults @mode='none'>` (the examples row is a prerendered-HTML surface, `atom` format). The query scopes to the chosen card URLs (matched on the index file URL, hence the `.json`-suffixed `selectedExampleCardUrls`) and their realms, and binds the `atom` rendering through the filter's `htmlQuery`; the engine lifts that binding out, leaving the result set scoped purely by `cardUrls`.
- Each row renders `<entry.component />` plus its remove button.
- `removeSelectedExample` is unchanged — it strips the file extension before comparing, so it matches whether handed the bare id or a `.json` URL.

The example test hooks (`data-test-selected-example` / `-remove`) now carry the entry's id — the v2 identity, which has no `.json` extension where the legacy prerendered model used the file URL (`Pet/mango` vs `Pet/mango.json`). The two tests asserting the old form are updated to match.

Part of the unified-search first-party call-site migration (CS-11536); independent of the other surfaces, based on `main`.

### Verification
- The `Integration | components | create-listing-modal` suite (7 tests) passes locally against the running stack — including the selected-example atom render and the remove-icon flow.
