### PR TITLE
Migrate the playground instance chooser to the v2 <SearchResults> surface

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
@@ -12,7 +12,7 @@ import {
   cardTypeDisplayName,
   isFileDefInstance,
   type Format,
-  type PrerenderedCardLike,
+  type RenderableSearchEntryLike,
 } from '@cardstack/runtime-common';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
@@ -135,14 +135,14 @@ interface Signature {
   Args: {
     isFieldDef: boolean;
     isFileDef?: boolean;
-    cardOptions: PrerenderedCardLike[] | undefined;
+    cardOptions: RenderableSearchEntryLike[] | undefined;
     fieldOptions?: FieldOption[];
     fileMetaOptions?: FileDef[];
     findSelectedCard: (
-      cards?: PrerenderedCardLike[],
-    ) => PrerenderedCardLike | SelectedInstance | undefined;
+      cards?: RenderableSearchEntryLike[],
+    ) => RenderableSearchEntryLike | SelectedInstance | undefined;
     selection: SelectedInstance | undefined;
-    onSelect: (item: PrerenderedCardLike | FieldOption | FileDef) => void;
+    onSelect: (item: RenderableSearchEntryLike | FieldOption | FileDef) => void;
     moduleId: string;
     persistSelections?: (cardId: string, format: Format) => void;
     recentCardIds: string[];
@@ -154,10 +154,18 @@ interface OptionsDropdownSignature {
   Args: {
     isField?: boolean;
     isFileMeta?: boolean;
-    options: PrerenderedCardLike[] | FieldOption[] | FileDef[] | undefined;
-    selected?: PrerenderedCardLike | FieldOption | SelectedInstance | FileDef;
+    options:
+      | RenderableSearchEntryLike[]
+      | FieldOption[]
+      | FileDef[]
+      | undefined;
+    selected?:
+      | RenderableSearchEntryLike
+      | FieldOption
+      | SelectedInstance
+      | FileDef;
     selection: SelectedInstance | undefined;
-    onSelect: (item: PrerenderedCardLike | FieldOption | FileDef) => void;
+    onSelect: (item: RenderableSearchEntryLike | FieldOption | FileDef) => void;
     afterMenuOptions: MenuItem[];
     beforeOptionsLabel?: string;
     selectedItemLabel?: string;

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -965,7 +965,7 @@ export default class PlaygroundPanel extends Component<Signature> {
     return card;
   };
 
-  // sort prerendered-search card results by most recently viewed
+  // sort the instance-chooser card results by most recently viewed
   private getSortedCards = (entries: RenderableSearchEntryLike[]) => {
     if (!this.recentCardIds?.length) {
       return;
@@ -990,7 +990,7 @@ export default class PlaygroundPanel extends Component<Signature> {
 
   private firstResult = (results?: RenderableSearchEntryLike[]) => {
     let card = results?.[0];
-    return [card].filter(Boolean) as RenderableSearchEntryLike[];
+    return card ? [card] : [];
   };
 
   private createNewWhenNoCards = (results?: RenderableSearchEntryLike[]) => {

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -50,10 +50,12 @@ import {
   trimJsonExtension,
   uuidv4,
   realmURL,
+  searchEntryWireQueryFromQuery,
   type LooseSingleCardDocument,
   type Query,
   type CardErrorJSONAPI,
-  type PrerenderedCardLike,
+  type RenderableSearchEntryLike,
+  type SearchEntryWireQuery,
 } from '@cardstack/runtime-common';
 
 import Overlays from '@cardstack/host/components/operator-mode/overlays';
@@ -88,7 +90,7 @@ import type {
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 import type { Spec } from 'https://cardstack.com/base/spec';
 
-import PrerenderedCardSearch from '../../../prerendered-card-search';
+import SearchResults from '../../../card-search/search-results';
 import CardError from '../../card-error';
 import FormatChooser from '../format-chooser';
 
@@ -142,7 +144,7 @@ export default class PlaygroundPanel extends Component<Signature> {
   @tracked private fieldChooserIsOpen = false;
   @tracked private newCardNonce = 0;
 
-  @tracked private cardOptions: PrerenderedCardLike[] = [];
+  @tracked private cardOptions: RenderableSearchEntryLike[] = [];
   @tracked private selectedFileMetaId: string | undefined;
   @use private moduleChangeTracker = resource(() => {
     let moduleId = internalKeyFor(
@@ -565,6 +567,29 @@ export default class PlaygroundPanel extends Component<Signature> {
     };
   }
 
+  // The v2 `search-entry` queries for the instance chooser, adapted from the
+  // legacy `Query` getters above. The default fieldset resolves to fitted HTML
+  // (the format these searches used), so no `htmlQuery` override is needed.
+  private get searchResultsQuery(): SearchEntryWireQuery | undefined {
+    if (!this.query) {
+      return undefined;
+    }
+    return {
+      ...searchEntryWireQueryFromQuery(this.query),
+      realms: this.recentRealms,
+    };
+  }
+
+  private get expandedSearchResultsQuery(): SearchEntryWireQuery | undefined {
+    if (!this.expandedQuery) {
+      return undefined;
+    }
+    return {
+      ...searchEntryWireQueryFromQuery(this.expandedQuery),
+      realms: this.realmServer.availableRealmIdentifiers,
+    };
+  }
+
   private get fieldInstances(): FieldOption[] | undefined {
     if (!this.args.isFieldDef || !this.specCard) {
       return undefined;
@@ -620,7 +645,9 @@ export default class PlaygroundPanel extends Component<Signature> {
     };
   }
 
-  @action private onSelect(item: PrerenderedCardLike | FieldOption | FileDef) {
+  @action private onSelect(
+    item: RenderableSearchEntryLike | FieldOption | FileDef,
+  ) {
     if (this.args.isFileDef) {
       let fileId = (item as FileDef).id!;
       this.selectedFileMetaId = fileId;
@@ -632,7 +659,7 @@ export default class PlaygroundPanel extends Component<Signature> {
         (item as FieldOption).index,
       );
     } else {
-      this.persistSelections((item as PrerenderedCardLike).url);
+      this.persistSelections((item as RenderableSearchEntryLike).id);
     }
   }
 
@@ -894,23 +921,23 @@ export default class PlaygroundPanel extends Component<Signature> {
     });
   }
 
-  private processSearchResults = (prerenderedCards?: PrerenderedCardLike[]) => {
-    this.cardOptions = prerenderedCards ?? [];
-    this.findSelectedCard(prerenderedCards);
+  private processSearchResults = (entries?: RenderableSearchEntryLike[]) => {
+    this.cardOptions = entries ?? [];
+    this.findSelectedCard(entries);
   };
 
-  private showResults = (cards: PrerenderedCardLike[] | undefined) => {
+  private showResults = (entries: RenderableSearchEntryLike[] | undefined) => {
     return (
       !this.args.isFieldDef &&
-      (cards?.length ||
+      (entries?.length ||
         this.persistedCardId ||
         this.createNewIsRunning ||
         this.isBaseCardModule) // means we do not conduct the expanded search for baseCardModule
     );
   };
 
-  private findSelectedCard = (prerenderedCards?: PrerenderedCardLike[]) => {
-    if (!prerenderedCards?.length) {
+  private findSelectedCard = (entries?: RenderableSearchEntryLike[]) => {
+    if (!entries?.length) {
       // it is possible that there's a persisted cardId in playground-selections local storage
       // but that the card is no longer in recent-files local storage
       // if that is the case, the card title will appear in dropdown menu but
@@ -925,27 +952,27 @@ export default class PlaygroundPanel extends Component<Signature> {
         // not displaying card preview for base card module unless user selects it specifically
         return;
       }
-      let recentCard = prerenderedCards[0];
+      let recentCard = entries[0];
       // if there's no selected card, choose the most recent card as selected
-      this.persistSelections(recentCard.url, 'isolated');
+      this.persistSelections(recentCard.id, 'isolated');
       return recentCard;
     }
 
     let selectedCardId = this.dropdownSelection.card.id;
-    let card = prerenderedCards.find(
-      (c) => trimJsonExtension(c.url) === selectedCardId,
-    );
+    // `entry.id` is the bare card URL already (the v2 identity strips the
+    // `.json` the dropdown selection also omits), so they compare directly.
+    let card = entries.find((c) => c.id === selectedCardId);
     return card;
   };
 
   // sort prerendered-search card results by most recently viewed
-  private getSortedCards = (cards: PrerenderedCardLike[]) => {
+  private getSortedCards = (entries: RenderableSearchEntryLike[]) => {
     if (!this.recentCardIds?.length) {
       return;
     }
-    let sortedCards: PrerenderedCardLike[] = [];
+    let sortedCards: RenderableSearchEntryLike[] = [];
     for (let id of this.recentCardIds) {
-      let card = cards.find((c) => trimJsonExtension(c.url) === id);
+      let card = entries.find((c) => c.id === id);
       if (card) {
         sortedCards.push(card);
       }
@@ -961,12 +988,12 @@ export default class PlaygroundPanel extends Component<Signature> {
     return this.moduleId === `${baseCardRef.module}/${baseCardRef.name}`;
   }
 
-  private firstResult = (results?: PrerenderedCardLike[]) => {
+  private firstResult = (results?: RenderableSearchEntryLike[]) => {
     let card = results?.[0];
-    return [card].filter(Boolean) as PrerenderedCardLike[];
+    return [card].filter(Boolean) as RenderableSearchEntryLike[];
   };
 
-  private createNewWhenNoCards = (results?: PrerenderedCardLike[]) => {
+  private createNewWhenNoCards = (results?: RenderableSearchEntryLike[]) => {
     if (!results?.length) {
       if (
         this.#creationError ||
@@ -988,35 +1015,34 @@ export default class PlaygroundPanel extends Component<Signature> {
     {{consumeContext this.makeCardResource}}
     {{consumeContext this.searchFileMeta}}
 
-    {{#if this.query}}
-      <PrerenderedCardSearch
-        @query={{this.query}}
-        @format='fitted'
-        @realms={{this.recentRealms}}
-        @isLive={{true}}
+    {{#if this.searchResultsQuery}}
+      <SearchResults
+        @query={{this.searchResultsQuery}}
+        @mode='none'
+        as |results|
       >
-        <:response as |cards|>
-          {{#if (this.showResults cards)}}
-            {{#let (this.getSortedCards cards) as |sortedCards|}}
+        {{#unless results.isLoading}}
+          {{#if (this.showResults results.entries)}}
+            {{#let (this.getSortedCards results.entries) as |sortedCards|}}
               {{afterRender (fn this.processSearchResults sortedCards)}}
             {{/let}}
-          {{else if this.expandedQuery}}
-            <PrerenderedCardSearch
-              @query={{this.expandedQuery}}
-              @format='fitted'
-              @realms={{this.realmServer.availableRealmIdentifiers}}
+          {{else if this.expandedSearchResultsQuery}}
+            <SearchResults
+              @query={{this.expandedSearchResultsQuery}}
+              @mode='none'
+              as |expandedResults|
             >
-              <:response as |maybeCards|>
+              {{#unless expandedResults.isLoading}}
                 {{! TODO: remove side-effects for instance chooser in CS-8746 }}
-                {{this.createNewWhenNoCards maybeCards}}
-                {{#let (this.firstResult maybeCards) as |cards|}}
+                {{this.createNewWhenNoCards expandedResults.entries}}
+                {{#let (this.firstResult expandedResults.entries) as |cards|}}
                   {{afterRender (fn this.processSearchResults cards)}}
                 {{/let}}
-              </:response>
-            </PrerenderedCardSearch>
+              {{/unless}}
+            </SearchResults>
           {{/if}}
-        </:response>
-      </PrerenderedCardSearch>
+        {{/unless}}
+      </SearchResults>
     {{/if}}
 
     {{#if this.fieldChooserIsOpen}}


### PR DESCRIPTION
Migrates the code-mode playground's card-instance chooser off the deprecated `<PrerenderedCardSearch>` and onto the v2 `<SearchResults>` surface.

- The two nested searches — the recent-realms search, the expanded all-realms fallback when no recents match, and the auto-create-when-empty path — render through `<SearchResults @mode='none'>` (the chooser is a prerendered-HTML / `fitted` surface). The `afterRender(processSearchResults)` plumbing and the `showResults` → `getSortedCards` / `firstResult` → `createNewWhenNoCards` flow are preserved.
- The `cardOptions` model and the methods that consume it (`processSearchResults` / `showResults` / `findSelectedCard` / `getSortedCards` / `firstResult` / `createNewWhenNoCards` / `onSelect`), plus the `InstanceSelectDropdown` signature, move from `PrerenderedCardLike` to `RenderableSearchEntryLike`. `entry.id` is the bare card URL the selection logic already normalized to (every consumer called `trimJsonExtension(card.url)`), so the swap is direct and the dropdown template (`<item.component />`) is unchanged.
- **Untouched:** the live `getCards` file-meta search, `SpecSearch`, and the preview / error panels — they don't render prerendered card HTML.

Part of the unified-search first-party call-site migration (CS-11536); independent of the other surfaces, based on `main`.

### Verification
- The full `Acceptance | code-submode | card playground` suite (40 tests) passes locally against the running stack — instance chooser, recent/expanded search, selection persistence, auto-create, error states, and formats. No test changes were needed (the playground already keyed selections on the bare card id).
