### PR TITLE
Fix flaky matrix truncated-timeline test by landing sends before logout

### DIFF
--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -572,12 +572,17 @@ export async function sendMessage(
   await expect(
     page.locator(`[data-test-message-field="${roomId}"]`),
   ).toHaveValue('');
-  await expect(
-    page.locator('[data-test-ai-assistant-message-pending="true"]'),
-  ).toHaveCount(0);
+  // The new message bubble is rendered optimistically a moment after the draft
+  // clears. Wait for it to appear before asserting that nothing is pending:
+  // checking for no-pending first can pass in the window before the bubble
+  // exists, returning from this helper while the send is still in flight rather
+  // than after the server has acknowledged it.
   await expect(page.locator('[data-test-message-idx]')).toHaveCount(
     messageCountBeforeSend + 1,
   );
+  await expect(
+    page.locator('[data-test-ai-assistant-message-pending="true"]'),
+  ).toHaveCount(0);
   await page.waitForSelector(`[data-test-room-settled]`);
 }
 

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -118,6 +118,22 @@ test.describe('Room messages', () => {
     for (let i = 1; i <= totalMessageCount; i++) {
       await sendMessage(page, room1, `message ${i}`);
     }
+
+    // Every message must be persisted on the server before logging out;
+    // otherwise the re-login below rebuilds a timeline that is missing whatever
+    // send had not yet landed. Verify the server side directly so a regression
+    // surfaces here rather than as a short count after pagination.
+    await expect
+      .poll(async () => {
+        let events = await getRoomEvents(username, password, room1);
+        return events.filter(
+          (e) =>
+            e.type === 'm.room.message' &&
+            e.content?.msgtype === APP_BOXEL_MESSAGE_MSGTYPE,
+        ).length;
+      })
+      .toBe(totalMessageCount);
+
     await logout(page);
 
     await login(page, username, password, { url: appURL });


### PR DESCRIPTION
The matrix test "it can load all events back to beginning of timeline for timelines that truncated" sends 20 messages, logs out, logs back in, and asserts all 20 reload via back-pagination. It intermittently saw 19.

The `sendMessage` test helper asserted that no message bubble was pending before it asserted the message count had incremented. The optimistic bubble renders a moment after the message draft clears, so the no-pending check could pass in the window before the new `sending` bubble existed — letting the helper return while the message's `PUT /send` was still in flight. Within the send loop the next iteration absorbed that gap, but the final message is immediately followed by `logout`, which discarded the still-unsent send. The server then held only 19 messages, so back-pagination correctly loaded 19 and the count assertion failed.

This reorders the helper's two assertions so the count assertion (the bubble has rendered) runs before the no-pending assertion, which makes the no-pending check wait for the real server acknowledgement rather than passing in the pre-render gap.

The test also now verifies, against the homeserver, that all 20 messages are persisted before logging out, so any future send-side regression surfaces at that point rather than as a short count after pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
