### PR TITLE
software-factory: warn when a brief reads like an adjust task but sourceCardUrl is unset

### DIFF
--- a/packages/software-factory/src/factory-seed.ts
+++ b/packages/software-factory/src/factory-seed.ts
@@ -24,6 +24,39 @@ export function inferDarkfactoryModuleUrl(targetRealm: string): string {
 
 let log = logger('factory-seed');
 
+// Phrases that read like "modify a card that already exists" rather than
+// "build a new one". Kept deliberately narrow — these don't naturally appear
+// in a greenfield "build a new X" brief, so a match on one of them while
+// `sourceCardUrl` is unset is a strong signal the brief author meant to set it.
+const ADJUST_PROSE_SIGNALS = [
+  'adjust the existing',
+  'adjust an existing',
+  'adjusting the existing',
+  'existing card',
+  'rather than rebuild',
+  'rather than build',
+  'instead of rebuilding',
+  'ingest-card',
+  'source card',
+];
+
+function briefProseLooksLikeAdjust(brief: FactoryBrief): boolean {
+  let text = `${brief.title}\n${brief.content}`.toLowerCase();
+  return ADJUST_PROSE_SIGNALS.some((signal) => text.includes(signal));
+}
+
+/**
+ * The factory's adjust-existing-card flow is triggered by the brief's
+ * structured `sourceCardUrl` attribute, NOT by its prose. A brief that
+ * describes adjusting an existing card only in prose but leaves `sourceCardUrl`
+ * unset silently falls through to the greenfield path — the agent never
+ * ingests the source and rebuilds from scratch. Return true when that mismatch
+ * is detected so the caller can warn the operator. Exported for unit testing.
+ */
+export function shouldWarnMissingSourceCardUrl(brief: FactoryBrief): boolean {
+  return !brief.sourceCardUrl && briefProseLooksLikeAdjust(brief);
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -112,6 +145,16 @@ function buildSeedIssueDocument(
 ) {
   let now = new Date().toISOString();
   let adjust = Boolean(brief.sourceCardUrl);
+
+  if (shouldWarnMissingSourceCardUrl(brief)) {
+    log.warn(
+      `Brief "${brief.title}" reads like an "adjust existing card" task but its ` +
+        `\`sourceCardUrl\` attribute is unset — the factory will treat this as a ` +
+        `greenfield build and the agent will NOT ingest a source card. Set the ` +
+        `brief's \`sourceCardUrl\` to the absolute source card URL to trigger the ` +
+        `adjust flow.`,
+    );
+  }
 
   let briefHeader = [
     `## Brief`,

--- a/packages/software-factory/tests/factory-seed.test.ts
+++ b/packages/software-factory/tests/factory-seed.test.ts
@@ -1,0 +1,42 @@
+import { module, test } from 'qunit';
+
+import type { FactoryBrief } from '../src/factory-brief.ts';
+import { shouldWarnMissingSourceCardUrl } from '../src/factory-seed.ts';
+
+function makeBrief(overrides: Partial<FactoryBrief> = {}): FactoryBrief {
+  return {
+    title: 'Sticky Note',
+    sourceUrl: 'http://localhost:4201/software-factory/Wiki/sticky-note',
+    content: 'Build a colorful short-form note card for spatial boards.',
+    contentSummary: 'A colorful sticky note card.',
+    tags: [],
+    ...overrides,
+  };
+}
+
+module('factory-seed > shouldWarnMissingSourceCardUrl', function () {
+  test('warns when adjust-intent prose has no sourceCardUrl', function (assert) {
+    let brief = makeBrief({
+      title: 'Wine Cellar — User Rating',
+      content:
+        'This adjusts an existing card that already lives in the catalog realm. ' +
+        'Bring the source card in and adjust it rather than rebuild from scratch.',
+    });
+    assert.true(shouldWarnMissingSourceCardUrl(brief));
+  });
+
+  test('does not warn for a normal greenfield brief', function (assert) {
+    let brief = makeBrief();
+    assert.false(shouldWarnMissingSourceCardUrl(brief));
+  });
+
+  test('does not warn when sourceCardUrl is set (adjust flow already triggered)', function (assert) {
+    let brief = makeBrief({
+      title: 'Wine Cellar — User Rating',
+      content: 'This adjusts an existing card. Bring the source card in.',
+      sourceCardUrl:
+        'https://localhost:4201/catalog/4b6602-wine-cellar-card-definition/WineCellar/c7b6f051',
+    });
+    assert.false(shouldWarnMissingSourceCardUrl(brief));
+  });
+});

--- a/packages/software-factory/tests/index.ts
+++ b/packages/software-factory/tests/index.ts
@@ -1,4 +1,5 @@
 import './factory-brief.test.ts';
+import './factory-seed.test.ts';
 import './validation-run-cache.test.ts';
 import './factory-prompt-loader.test.ts';
 import './factory-entrypoint.test.ts';


### PR DESCRIPTION
_(Written by Claude on Matic's behalf.)_

## Why
The factory's **adjust-existing-card** flow is triggered by the brief's structured `sourceCardUrl` attribute (`realm/wiki.gts`) — *not* by its prose. When `sourceCardUrl` is set, `factory-seed.ts` emits the seed instruction `boxel realm ingest-card "<sourceCardUrl>" .` (which auto-resolves the source realm).

If a brief *describes* adjusting an existing card only in prose but never sets `sourceCardUrl`, the factory silently takes the **greenfield** path: the agent never ingests the source and rebuilds from scratch (or, as seen in the wine-cellar test runs, flails trying to guess the source realm). The failure is silent — nothing tells the operator the brief shape was wrong.

## What
At seed time, if `sourceCardUrl` is unset but the brief's title/content reads like an adjust task, emit a non-fatal `log.warn` pointing the operator at the fix:

```
Brief "<title>" reads like an "adjust existing card" task but its `sourceCardUrl`
attribute is unset — the factory will treat this as a greenfield build and the
agent will NOT ingest a source card. Set the brief's `sourceCardUrl` to the
absolute source card URL to trigger the adjust flow.
```

- The decision is an exported pure predicate, `shouldWarnMissingSourceCardUrl(brief)` = `!brief.sourceCardUrl && briefProseLooksLikeAdjust(brief)`, so it's unit-testable without capturing logs.
- The prose heuristic is a narrow keyword set ("adjust the existing", "existing card", "rather than rebuild", "source card", "ingest-card", …) — phrases that don't naturally appear in a greenfield "build a new X" brief, to avoid nagging.

This is a guardrail only; it changes no control flow.

## Testing
- New `tests/factory-seed.test.ts` (registered in `tests/index.ts`): warns on adjust-prose-without-url; silent on greenfield; silent when `sourceCardUrl` is set. All pass.
- `pnpm lint` clean (eslint / prettier / ember-tsc); `pnpm test:node` 455 pass (the one failure is the pre-existing `port-allocator` dual-stack env test).

Ticket: CS-11650. (Supersedes CS-11649, closed as a false premise — the ingest/adjust machinery already exists and is correct.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
