### PR TITLE
Mark legacy search surfaces deprecated; add unified-search skill

### DIFF
--- a/.claude/skills/unified-search/SKILL.md
+++ b/.claude/skills/unified-search/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: unified-search
+description: The supported search surface across the platform is the v2 `search-entry` API — realm endpoints `/_search-v2` + `/_federated-search-v2`, the host resource `getSearchEntriesResource`, the `<SearchResults>` component (provided to cards as `@context.searchResultsComponent`), and the `RenderableSearchEntryLike` row view-model. The four legacy endpoints (`/_search`, `/_federated-search`, `/_search-prerendered`, `/_federated-search-prerendered`) plus `<PrerenderedCardSearch>` / `getPrerenderedSearch` / `@context.prerenderedCardSearchComponent` / the `SearchContent`→`SearchResultSection`→`ItemButton` tree / `PrerenderedCardLike` are deprecated compat kept working over the same engine. Use whenever adding a new search/query call site, choosing which search API to call, reviewing or refactoring search code, or writing a card that lists/queries other cards — reach for v2, never the deprecated surfaces.
+---
+
+# Unified search — the v2 `search-entry` API
+
+The platform once ran two parallel search stacks — a live-card one (`/_search`,
+`/_federated-search`) and a prerendered-HTML one (`/_search-prerendered`,
+`/_federated-search-prerendered`) — each with its own endpoint, wire shape, host
+resource, and component. They are now **one engine** exposed as the **v2
+`search-entry` API**. A `search-entry` is a heterogeneous result: the engine
+prefers prerendered HTML (the fast path) and falls back to a live serialization
+per row. **The governing invariant: a consumer never assumes whether a result
+came back as prerendered HTML or a live card — it renders the entry transparently.**
+
+The four legacy endpoints and the host/card surfaces that fed them still work,
+but only as a **compat layer over the same engine**. They are `@deprecated` and
+removed once every consumer is on v2. **Always reach for v2 below; never
+introduce a new call site on a deprecated surface.**
+
+## Reach for v2 — quick map
+
+| When you need to… | Use (v2) | Do NOT use (deprecated) |
+| --- | --- | --- |
+| Search from the realm / over HTTP | `/_search-v2`, `/_federated-search-v2` | `/_search`, `/_federated-search`, `/_search-prerendered`, `/_federated-search-prerendered` |
+| Fetch results in a host resource | `getSearchEntriesResource` (`host/app/resources/search-entries`) | `getPrerenderedSearch` (`resources/prerendered-search`) |
+| Render a result list in host UI | `<SearchResults>` (`host/app/components/card-search/search-results`) | `<PrerenderedCardSearch>`; the `SearchContent` → `SearchResultSection` → `ItemButton` tree |
+| Render a result list from a **card** | `@context.searchResultsComponent` | `@context.prerenderedCardSearchComponent` |
+| Type a single result row | `RenderableSearchEntryLike` (`runtime-common/search-results-component`) | `PrerenderedCardLike` / `PrerenderedCardData` (`runtime-common/prerendered-card-search`) |
+| Get instances programmatically | `StoreService.search(query, realms?)` → `CardDef[]` | — |
+| Get raw wire data (host only) | `StoreService.searchEntries(query, realms?)` | — |
+
+## Realm server / API
+
+- v2 lives on `/_search-v2` (single realm — `Realm.searchEntriesResponse`) and
+  `/_federated-search-v2` (realm-server — `handleSearchV2`). They emit the
+  `search-entry` document natively (heterogeneous `html` / `item` results).
+- The four legacy endpoints are thin adapters over the same engine, frozen at
+  their original contracts. Treat them as read-only history; route new work and
+  new tests through v2.
+
+## Host
+
+- **Resource:** `getSearchEntriesResource(parent, () => query)` → a reactive
+  `{ entries, isLoading, meta, errors }`; subscribes per realm and re-issues on
+  invalidation. It supersedes `getPrerenderedSearch` (and the live
+  `SearchContent` tree's hand-rolled fetching).
+- **Component:** `<SearchResults @query=… as |results| />` renders the
+  heterogeneous stream — prerendered HTML inert (lazily hydrated) or a live card.
+  Used block-less it renders the default stream itself. It supersedes both
+  `<PrerenderedCardSearch>` and the `SearchContent` → `SearchResultSection` →
+  `ItemButton` rendering tree.
+- **Programmatic split (`StoreService`):** `search` returns **instances only**
+  (hydrates full serializations into the Store); `searchEntries` returns the
+  **raw wire format** (host-only — the cards-facing `Store` interface omits it).
+  Commands (`SearchCardsByQueryCommand`, `SearchAndChooseCommand`, …) ride
+  `search` → instances.
+
+## Cards — using search via `@context`
+
+A card that lists or queries other cards renders results through the v2
+component the host provides on `@context`: **`@context.searchResultsComponent`**
+(not the deprecated `@context.prerenderedCardSearchComponent`). The card never
+branches on prerendered-vs-live — `entry.component` resolves that.
+
+```gts
+import {
+  searchEntryWireQueryFromQuery,
+  type SearchEntryWireQuery,
+} from '@cardstack/runtime-common';
+
+// `@query` is a `search-entry`-rooted v2 query (`SearchEntryWireQuery`).
+// Build one from an ordinary v1 `Query` with `searchEntryWireQueryFromQuery`,
+// then add `realms` / `page` / a `fields[search-entry]` fieldset as needed.
+get query(): SearchEntryWireQuery {
+  return {
+    ...searchEntryWireQueryFromQuery({
+      filter: { on: this.authorRef, eq: { status: 'ready' } },
+      sort: [{ by: 'title', direction: 'asc' }],
+    }),
+    realms: this.realms,
+  };
+}
+```
+
+```hbs
+<@context.searchResultsComponent @query={{this.query}} @mode='none' as |results|>
+  {{#each results.entries key='id' as |entry|}}
+    <entry.component />   {{!-- html inert | live card; the consumer never branches --}}
+  {{else}}
+    {{#if results.isLoading}}<LoadingIndicator />{{else}}<p>No results</p>{{/if}}
+  {{/each}}
+</@context.searchResultsComponent>
+```
+
+Yielded `results`:
+
+- `results.entries` — `RenderableSearchEntryLike[]`. Each `entry` exposes
+  `entry.component` (the ready-to-render component — inert HTML or live card,
+  owns lazy hydration), `entry.id` (the card/file URL), `entry.isError`,
+  `entry.displayName` / `entry.iconHtml` / `entry.name` (the deduped type
+  descriptor, resolvable without loading the instance), and the raw
+  `entry.html?` / `entry.item?` branches for custom rendering.
+- `results.isLoading`, `results.meta` (`{ page: { total } }`), `results.errors`.
+
+`@mode` is the hydration gesture for HTML-backed rows — `none` (stay inert),
+`hover` (default), `click`, `touch`. It is host UX only, never on the wire; a
+fully-live row ignores it. Hydration is always lazy-on-interaction — never eager.
+
+For raw HTML strings / field-limited data / the page doc, a **host** consumer
+reaches past the component to `StoreService.searchEntries`; a **card** cannot
+(the boundary is codified at the type level — cards get instances or rendered
+HTML, never the raw wire format).
+
+## Why it's shaped this way
+
+One engine, one query vocabulary, one heterogeneous result. Prerendered HTML is
+the preferred fast path (orders of magnitude cheaper than a live card); a result
+lacks HTML only transiently (the prerender channel briefly lags the search-doc
+index, plus render errors), so the live-serialization fallback self-heals as
+HTML lands. `<SearchResults>` / `entry.component` hide the split so no consumer —
+host UI or card author — ever forks on prerendered-vs-live.

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -138,6 +138,12 @@ function isNewCardArgs(item: ItemType): item is NewCardArgs {
   return typeof item === 'object' && 'realmURL' in item;
 }
 
+/**
+ * @deprecated Leaf of the legacy `SearchContent` → `SearchResultSection` →
+ * `ItemButton` search-results tree (renders a single result, prerendered or
+ * live). Favor the v2 `<SearchResults>` component, whose entries render
+ * prerendered-vs-live transparently. Removed once every consumer is on v2.
+ */
 export default class ItemButton extends Component<Signature> {
   @service declare realm: RealmService;
 

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -153,6 +153,13 @@ interface Signature {
 const OWNER_DESTROYED_ERROR =
   "Cannot call `.lookup('renderer:-dom')` after the owner has been destroyed";
 
+/**
+ * @deprecated Root of the legacy live search-results tree (`SearchContent` →
+ * `SearchResultSection` → `ItemButton`). Favor the v2 `<SearchResults>`
+ * component, which renders the heterogeneous `search-entry` stream (prerendered
+ * HTML inert or live card) for a `search-entry`-rooted query. Removed once every
+ * consumer is on v2.
+ */
 export default class SearchContent extends Component<Signature> {
   @service declare network: NetworkService;
   @service declare realm: RealmService;

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -99,6 +99,11 @@ interface Signature {
   Blocks: {};
 }
 
+/**
+ * @deprecated Mid-tier of the legacy `SearchContent` → `SearchResultSection` →
+ * `ItemButton` search-results tree. Favor the v2 `<SearchResults>` component.
+ * Removed once every consumer is on v2.
+ */
 export default class SearchResultSection extends Component<Signature> {
   @service declare realm: RealmService;
 

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -42,6 +42,11 @@ export { knownFileMetaUrls, clearKnownFileMetaUrls };
 const OWNER_DESTROYED_ERROR =
   "Cannot call `.lookup('renderer:-dom')` after the owner has been destroyed";
 
+/**
+ * @deprecated Legacy per-row view-model produced by the prerendered-search
+ * resource. The v2 `search-entry` path renders each result via
+ * `RenderableSearchEntryLike` instead. Removed once every consumer is on v2.
+ */
 export class PrerenderedCard implements PrerenderedCardLike {
   component: HTMLComponent;
   constructor(
@@ -196,6 +201,14 @@ function wrapWithModifier(
   return DecoratedPrerenderedCard as unknown as HTMLComponent;
 }
 
+/**
+ * @deprecated The legacy prerendered-card search component. Favor the v2
+ * `<SearchResults>` component — host: `components/card-search/search-results`;
+ * card `@context`: `@context.searchResultsComponent` — which consumes the
+ * heterogeneous `search-entry` stream and renders prerendered-HTML / live rows
+ * transparently. Still provided during the migration window; removed once every
+ * consumer is on v2.
+ */
 export default class PrerenderedCardSearch extends Component<PrerenderedCardComponentSignature> {
   @consume(CardContextName) declare private cardContext?: CardContext;
 

--- a/packages/host/app/resources/prerendered-search.ts
+++ b/packages/host/app/resources/prerendered-search.ts
@@ -54,6 +54,14 @@ export interface Args {
   };
 }
 
+/**
+ * @deprecated The resource backing the legacy `<PrerenderedCardSearch>`
+ * component; fetches the prerendered-card document from
+ * `/_federated-search-prerendered`. Favor the v2 search-entry resource
+ * `SearchEntriesResource` / `getSearchEntriesResource`
+ * (`resources/search-entries`), which fetches `search-entry`s from `/_search-v2`
+ * and backs `<SearchResults>`. Removed once every consumer is on v2.
+ */
 export class PrerenderedSearchResource extends Resource<Args> {
   @service declare private loaderService: LoaderService;
   @service declare private network: NetworkService;
@@ -430,6 +438,10 @@ export class PrerenderedSearchResource extends Resource<Args> {
 /**
  * Creates a PrerenderedSearchResource that fetches prerendered card HTML
  * from the realm server and manages live updates.
+ *
+ * @deprecated Favor the v2 search-entry resource `getSearchEntriesResource`
+ * (`resources/search-entries`), which fetches `search-entry`s from `/_search-v2`
+ * and backs `<SearchResults>`. Removed once every consumer is on v2.
  *
  * @param parent - The component or object that owns this resource
  * @param owner - The Ember owner for dependency injection

--- a/packages/realm-server/handlers/handle-search-prerendered.ts
+++ b/packages/realm-server/handlers/handle-search-prerendered.ts
@@ -32,6 +32,13 @@ import { respondWithJobScopedSearchCache } from './handle-search.ts';
 // with `_federated-search` through `respondWithJobScopedSearchCache`. Its
 // `htmlFormat` / `cardUrls` / `renderType` are the inner-key opts, so its cache
 // entries segregate from the live endpoint's.
+/**
+ * @deprecated Backs the legacy `/_federated-search-prerendered` endpoint. Prefer
+ * the v2 `search-entry` handler `handleSearchV2` (`/_federated-search-v2`), which
+ * carries prerendered HTML and the live serialization in one heterogeneous
+ * result rather than a dedicated prerendered shape. Retained as a compat layer
+ * over the shared search engine; removed once every consumer is on v2.
+ */
 export default function handleSearchPrerendered(opts: {
   reconciler: RealmRegistryReconciler;
   searchCache?: JobScopedSearchCache;

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -35,6 +35,13 @@ import {
   sanitizePrerenderJobId,
 } from '../prerender/prerender-constants.ts';
 
+/**
+ * @deprecated Backs the legacy `/_federated-search` endpoint. Prefer the v2
+ * `search-entry` handler `handleSearchV2` (`/_federated-search-v2`), which
+ * returns one heterogeneous result stream — prerendered HTML or live
+ * serialization. Retained as a compat layer over the shared search engine;
+ * removed once every consumer is on v2.
+ */
 export default function handleSearch(opts: {
   reconciler: RealmRegistryReconciler;
   searchCache?: JobScopedSearchCache;

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -191,6 +191,11 @@ export function createRoutes(args: CreateRoutesArgs) {
       dbAdapter: args.dbAdapter,
     }),
   );
+  // @deprecated Legacy federated live-card search. Prefer the v2 `search-entry`
+  // endpoint `/_federated-search-v2` (`handleSearchV2`), which returns one
+  // heterogeneous result stream — prerendered HTML or live serialization. Kept
+  // as a compat layer over the shared search engine; removed once every
+  // consumer is on v2.
   router.all(
     '/_federated-search',
     multiRealmAuthorization(args),
@@ -217,6 +222,11 @@ export function createRoutes(args: CreateRoutesArgs) {
       reconciler: args.reconciler,
     }),
   );
+  // @deprecated Legacy federated prerendered-HTML search. Prefer the v2
+  // `search-entry` endpoint `/_federated-search-v2` (`handleSearchV2`), which
+  // carries prerendered HTML and the live serialization in one heterogeneous
+  // result rather than a dedicated prerendered shape. Kept as a compat layer
+  // over the shared search engine; removed once every consumer is on v2.
   router.all(
     '/_federated-search-prerendered',
     multiRealmAuthorization(args),

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -191,7 +191,8 @@ export function createRoutes(args: CreateRoutesArgs) {
       dbAdapter: args.dbAdapter,
     }),
   );
-  // @deprecated Legacy federated live-card search. Prefer the v2 `search-entry`
+  // Deprecated: legacy federated live-card search (the bound `handleSearch`
+  // carries the `@deprecated` tag). Prefer the v2 `search-entry`
   // endpoint `/_federated-search-v2` (`handleSearchV2`), which returns one
   // heterogeneous result stream — prerendered HTML or live serialization. Kept
   // as a compat layer over the shared search engine; removed once every
@@ -222,7 +223,8 @@ export function createRoutes(args: CreateRoutesArgs) {
       reconciler: args.reconciler,
     }),
   );
-  // @deprecated Legacy federated prerendered-HTML search. Prefer the v2
+  // Deprecated: legacy federated prerendered-HTML search (the bound
+  // `handleSearchPrerendered` carries the `@deprecated` tag). Prefer the v2
   // `search-entry` endpoint `/_federated-search-v2` (`handleSearchV2`), which
   // carries prerendered HTML and the live serialization in one heterogeneous
   // result rather than a dedicated prerendered shape. Kept as a compat layer

--- a/packages/runtime-common/prerendered-card-search.ts
+++ b/packages/runtime-common/prerendered-card-search.ts
@@ -4,6 +4,11 @@ import type { Format } from './formats.ts';
 import type { QueryResultsMeta } from './index-query-engine.ts';
 import type { ResolvedCodeRef } from './code-ref.ts';
 
+/**
+ * @deprecated Backing data for the legacy prerendered-card view-model. The v2
+ * `search-entry` model supersedes this shape — favor `RenderableSearchEntryLike`.
+ * Removed once every consumer is on v2.
+ */
 export interface PrerenderedCardData {
   url: string;
   realmUrl: string;
@@ -15,6 +20,12 @@ export interface PrerenderedCardData {
   isFileMeta?: boolean;
 }
 
+/**
+ * @deprecated Legacy per-row view-model consumed by `<PrerenderedCardSearch>`.
+ * Favor the v2 `search-entry` shape `RenderableSearchEntryLike`, which a row
+ * renders transparently (prerendered HTML inert or the live card). Removed once
+ * every consumer is on v2.
+ */
 export interface PrerenderedCardLike {
   url: string;
   isError: boolean;
@@ -31,6 +42,12 @@ export interface PrerenderedCardLike {
   hasHtml?: boolean;
 }
 
+/**
+ * @deprecated Glimmer signature of the legacy `<PrerenderedCardSearch>`
+ * component. Favor the v2 `SearchResultsComponentSignature` (the
+ * `@context.searchResultsComponent` / `<SearchResults>` contract). Removed once
+ * every consumer is on v2.
+ */
 export interface PrerenderedCardComponentSignature {
   Element: undefined;
   Args: {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -958,7 +958,8 @@ export class Realm {
       )
       .query('/_lint', SupportedMimeType.JSON, this.lint.bind(this))
       .get('/_mtimes', SupportedMimeType.Mtimes, this.realmMtimes.bind(this))
-      // @deprecated Legacy single-realm live-card search. Prefer the v2
+      // Deprecated: legacy single-realm live-card search (the bound
+      // `searchResponse` carries the `@deprecated` tag). Prefer the v2
       // `search-entry` endpoint `/_search-v2` (`searchEntriesResponse`), which
       // returns one heterogeneous result stream — prerendered HTML or live
       // serialization, the engine decides per row. Kept as a compat layer over
@@ -983,7 +984,8 @@ export class Realm {
         SupportedMimeType.CardJson,
         this.searchEntriesResponse.bind(this),
       )
-      // @deprecated Legacy single-realm prerendered-HTML search. Prefer the v2
+      // Deprecated: legacy single-realm prerendered-HTML search (the bound
+      // `searchPrerenderedResponse` carries the `@deprecated` tag). Prefer the v2
       // `search-entry` endpoint `/_search-v2` (`searchEntriesResponse`), which
       // carries the prerendered HTML and the live serialization in one
       // heterogeneous result rather than a dedicated prerendered shape. Kept as

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -958,6 +958,11 @@ export class Realm {
       )
       .query('/_lint', SupportedMimeType.JSON, this.lint.bind(this))
       .get('/_mtimes', SupportedMimeType.Mtimes, this.realmMtimes.bind(this))
+      // @deprecated Legacy single-realm live-card search. Prefer the v2
+      // `search-entry` endpoint `/_search-v2` (`searchEntriesResponse`), which
+      // returns one heterogeneous result stream — prerendered HTML or live
+      // serialization, the engine decides per row. Kept as a compat layer over
+      // the shared search engine; removed once every consumer is on v2.
       .get(
         '/_search',
         SupportedMimeType.CardJson,
@@ -978,6 +983,12 @@ export class Realm {
         SupportedMimeType.CardJson,
         this.searchEntriesResponse.bind(this),
       )
+      // @deprecated Legacy single-realm prerendered-HTML search. Prefer the v2
+      // `search-entry` endpoint `/_search-v2` (`searchEntriesResponse`), which
+      // carries the prerendered HTML and the live serialization in one
+      // heterogeneous result rather than a dedicated prerendered shape. Kept as
+      // a compat layer over the shared search engine; removed once every
+      // consumer is on v2.
       .get(
         '/_search-prerendered',
         SupportedMimeType.CardJson,
@@ -5317,6 +5328,13 @@ export class Realm {
     return await this.#realmIndexQueryEngine.searchCards(query, engineOpts);
   }
 
+  /**
+   * @deprecated Backs the legacy `/_search` endpoint. Prefer the v2
+   * `search-entry` path — {@link Realm.searchEntriesResponse} / `/_search-v2` —
+   * which returns one heterogeneous result stream (prerendered HTML or live
+   * serialization). Retained as a compat layer over the shared search engine;
+   * removed once every consumer is on v2.
+   */
   private async searchResponse(
     request: Request,
     requestContext: RequestContext,
@@ -5563,6 +5581,13 @@ export class Realm {
     });
   }
 
+  /**
+   * @deprecated Backs the legacy `/_search-prerendered` endpoint. Prefer the v2
+   * `search-entry` path — {@link Realm.searchEntriesResponse} / `/_search-v2` —
+   * which carries prerendered HTML and the live serialization in one
+   * heterogeneous result. Retained as a compat layer over the shared search
+   * engine; removed once every consumer is on v2.
+   */
   private async searchPrerenderedResponse(
     request: Request,
     requestContext: RequestContext,


### PR DESCRIPTION
Marks the still-in-use legacy search surfaces as `@deprecated`, each pointing at its v2 `search-entry` replacement, and adds a platform-dev skill that steers future work to the v2 API. Everything keeps working — the legacy endpoints stay as a compat layer over the shared search engine; this only annotates them and documents the preferred surface. Removing the legacy endpoints + compat layer is out of scope.

### Deprecation annotations

**Realm server / API** — the route registrations plus the methods/handlers behind them:
- `/_search`, `/_search-prerendered` (`searchResponse` / `searchPrerenderedResponse`) → `/_search-v2` (`searchEntriesResponse`).
- `/_federated-search`, `/_federated-search-prerendered` (`handleSearch` / `handleSearchPrerendered`) → `/_federated-search-v2` (`handleSearchV2`).

**Host / runtime-common**
- `<PrerenderedCardSearch>` + `PrerenderedCard`, and the `getPrerenderedSearch` resource → `<SearchResults>` / `getSearchEntriesResource`.
- The `SearchContent` → `SearchResultSection` → `ItemButton` live rendering tree → `<SearchResults>`.
- `PrerenderedCardLike` / `PrerenderedCardData` / `PrerenderedCardComponentSignature` → `RenderableSearchEntryLike` / `SearchResultsComponentSignature`.

`@context.prerenderedCardSearchComponent` already carried its `@deprecated` tag, so it's left as-is.

These are comment/JSDoc-only changes — no runtime or type behavior changes. There's no `@deprecated` lint rule active, so the existing call sites stay green.

### `.claude/skills/unified-search`

A new platform-dev skill so future work reaches for the v2 API rather than the deprecated surfaces — the `/_search-v2` / `/_federated-search-v2` endpoints, the `<SearchResults>` component and `getSearchEntriesResource`, and the `@context.searchResultsComponent` surface a card uses to render search results (with a worked example). A companion PR updates the card-authoring search guidance in the boxel-skills source repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
