### PR TITLE
Fix computed linksToMany layout in edit template

### DIFF
--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -756,10 +756,11 @@ export function getLinksToManyComponent({
       </DefaultFormatsConsumer>
       <style scoped>
         @layer {
-          .linksToMany-field.fitted-effectiveFormat
-            > .linksToMany-itemContainer
-            + .linksToMany-itemContainer,
-          .linksToMany-field.embedded-effectiveFormat
+          .linksToMany-field:is(
+              .fitted-effectiveFormat,
+              .embedded-effectiveFormat,
+              .edit-effectiveFormat
+            )
             > .linksToMany-itemContainer
             + .linksToMany-itemContainer {
             margin-top: var(--boxel-sp);


### PR DESCRIPTION
Added missing edit format css. This is for the computed (non-editable / view-only) linksToMany component in a card's edit view.

<img width="381" height="354" alt="computed-links-to-many-edit" src="https://github.com/user-attachments/assets/a6732ece-a751-4b89-a802-b27a1ec1f584" />
