### PR TITLE
Fix misaligned card chooser item

### DIFF
--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -394,6 +394,7 @@ export default class ItemButton extends Component<Signature> {
 
         box-sizing: content-box;
         text-align: start;
+        display: block;
       }
       .item-button :deep(*) {
         box-sizing: border-box;


### PR DESCRIPTION
Before:
<img width="836" height="171" alt="misaligned-1" src="https://github.com/user-attachments/assets/bd0bf4a0-e68b-4bd1-9fb0-1e128e9871c5" />
After:
<img width="1323" height="144" alt="after" src="https://github.com/user-attachments/assets/944baff9-1d4c-49b6-93ce-cf469de394ba" />

Before:
<img width="824" height="373" alt="misaligned-2" src="https://github.com/user-attachments/assets/af23acb2-9b7f-4240-ab59-8390a5220ac4" />
After:
<img width="1311" height="572" alt="after-2" src="https://github.com/user-attachments/assets/7f182d75-598a-4644-a127-c744ff3522c0" />
