### PR TITLE
Migrate experiments-realm card source to the v2 search surface

### DIFF
--- a/packages/experiments-realm/app-card.gts
+++ b/packages/experiments-realm/app-card.gts
@@ -177,11 +177,14 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
             @query={{this.searchResultsQuery}}
             as |results|
           >
-            {{#if results.isLoading}}Loading...{{/if}}
-            {{#if @activeTab.isTable}}
-              <TableView @cards={{results.entries}} @context={{@context}} />
-            {{else}}
-              <CardsGrid @cards={{results.entries}} @context={{@context}} />
+            {{#if results.entries.length}}
+              {{#if @activeTab.isTable}}
+                <TableView @cards={{results.entries}} @context={{@context}} />
+              {{else}}
+                <CardsGrid @cards={{results.entries}} @context={{@context}} />
+              {{/if}}
+            {{else if results.isLoading}}
+              Loading...
             {{/if}}
           </@context.searchResultsComponent>
         {{/if}}

--- a/packages/experiments-realm/app-card.gts
+++ b/packages/experiments-realm/app-card.gts
@@ -20,7 +20,9 @@ import { and, bool, cn } from '@cardstack/boxel-ui/helpers';
 import {
   type Query,
   baseRealm,
-  type PrerenderedCardLike,
+  type RenderableSearchEntryLike,
+  type SearchEntryWireQuery,
+  searchEntryWireQueryFromQuery,
 } from '@cardstack/runtime-common';
 import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
@@ -64,7 +66,7 @@ export class Tab extends FieldDef {
 }
 
 class TableView extends GlimmerComponent<{
-  Args: { cards: PrerenderedCardLike[]; context?: CardContext };
+  Args: { cards: RenderableSearchEntryLike[]; context?: CardContext };
 }> {
   <template>
     {{#if this.isLoaded}}
@@ -127,7 +129,7 @@ class TableView extends GlimmerComponent<{
   // a possibility it might be initialized as undefined
   @tracked private cardCollection = this.args.context?.getCardCollection(
     this,
-    () => this.args.cards.map((c) => c.url),
+    () => this.args.cards.map((c) => c.id),
   );
 
   private get isLoaded() {
@@ -170,22 +172,18 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
   <template>
     <div class='app-card-content'>
       {{#if this.activeTabRef}}
-        {{#if this.query}}
-          <@context.prerenderedCardSearchComponent
-            @query={{this.query}}
-            @format='fitted'
-            @realms={{@realms}}
-            @isLive={{true}}
+        {{#if this.searchResultsQuery}}
+          <@context.searchResultsComponent
+            @query={{this.searchResultsQuery}}
+            as |results|
           >
-            <:loading>Loading...</:loading>
-            <:response as |cards|>
-              {{#if @activeTab.isTable}}
-                <TableView @cards={{cards}} @context={{@context}} />
-              {{else}}
-                <CardsGrid @cards={{cards}} @context={{@context}} />
-              {{/if}}
-            </:response>
-          </@context.prerenderedCardSearchComponent>
+            {{#if results.isLoading}}Loading...{{/if}}
+            {{#if @activeTab.isTable}}
+              <TableView @cards={{results.entries}} @context={{@context}} />
+            {{else}}
+              <CardsGrid @cards={{results.entries}} @context={{@context}} />
+            {{/if}}
+          </@context.searchResultsComponent>
         {{/if}}
       {{else}}
         <p>No cards available</p>
@@ -328,6 +326,19 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
         },
       ],
     } as Query;
+  }
+
+  // The v2 `search-entry`-rooted query, adapted from the v1 `query` above.
+  // `fitted` is the default rendering, so no `htmlQuery` binding is needed.
+  // Undefined (no active tab ref) leaves the search component idle.
+  get searchResultsQuery(): SearchEntryWireQuery | undefined {
+    if (!this.query) {
+      return undefined;
+    }
+    return {
+      ...searchEntryWireQueryFromQuery(this.query),
+      realms: this.args.realms,
+    };
   }
 
   @action createNew(value: unknown) {
@@ -492,7 +503,7 @@ export class AppCard extends CardDef {
 
 export class CardsGrid extends GlimmerComponent<{
   Args: {
-    cards: PrerenderedCardLike[];
+    cards: RenderableSearchEntryLike[];
     context?: CardContext;
     isListFormat?: boolean;
   };
@@ -505,14 +516,14 @@ export class CardsGrid extends GlimmerComponent<{
           <li
             class='cards-grid-item'
             {{@context.cardComponentModifier
-              cardId=card.url
+              cardId=card.id
               format='data'
               fieldType=undefined
               fieldName=undefined
             }}
-            data-test-cards-grid-item={{removeFileExtension card.url}}
+            data-test-cards-grid-item={{removeFileExtension card.id}}
             {{! In order to support scrolling cards into view we use a selector that is not pruned out in production builds }}
-            data-cards-grid-item={{removeFileExtension card.url}}
+            data-cards-grid-item={{removeFileExtension card.id}}
           >
             <CardContainer class='card' @displayBoundaries={{true}}>
               {{card.component}}

--- a/packages/experiments-realm/blog-app.gts
+++ b/packages/experiments-realm/blog-app.gts
@@ -234,7 +234,7 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
               <:meta as |card|>
                 {{#if this.showAdminData}}
                   <BlogAdminData
-                    @cardId={{card.url}}
+                    @cardId={{card.id}}
                     @context={{this.context}}
                   />
                 {{/if}}
@@ -307,10 +307,10 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
       displayName === 'Blog Posts'
         ? 'blog-posts-grid'
         : displayName === 'Author Bios'
-        ? 'author-bios-grid'
-        : displayName === 'Categories'
-        ? 'categories-grid'
-        : '';
+          ? 'author-bios-grid'
+          : displayName === 'Categories'
+            ? 'categories-grid'
+            : '';
     return gridName ? `bordered-items ${gridName}` : '';
   }
 

--- a/packages/experiments-realm/components/card-list.gts
+++ b/packages/experiments-realm/components/card-list.gts
@@ -4,7 +4,9 @@ import { type CardContext } from 'https://cardstack.com/base/card-api';
 
 import {
   type Query,
-  type PrerenderedCardLike,
+  type RenderableSearchEntryLike,
+  type SearchEntryWireQuery,
+  searchEntryWireQueryFromQuery,
 } from '@cardstack/runtime-common';
 
 interface CardListSignature {
@@ -14,36 +16,44 @@ interface CardListSignature {
     context?: CardContext;
   };
   Blocks: {
-    meta: [card: PrerenderedCardLike];
+    meta: [card: RenderableSearchEntryLike];
   };
   Element: HTMLElement;
 }
 export class CardList extends GlimmerComponent<CardListSignature> {
+  // The v2 `search-entry`-rooted query, adapted from the incoming v1 `Query`.
+  // `embedded` is bound through the query's `htmlQuery` field (the v2 way to
+  // select a prerendered format); a bare `eq.format` would be read as an
+  // `item.` field path and rejected.
+  get searchResultsQuery(): SearchEntryWireQuery {
+    let query = searchEntryWireQueryFromQuery(this.args.query);
+    return {
+      ...query,
+      realms: this.args.realms,
+      filter: {
+        ...query.filter,
+        eq: { ...query.filter?.eq, htmlQuery: { eq: { format: 'embedded' } } },
+      },
+    };
+  }
   <template>
     <ul class='card-list' ...attributes>
       {{#let
-        (component @context.prerenderedCardSearchComponent)
+        (component @context.searchResultsComponent)
         as |PrerenderedCardSearch|
       }}
-        <PrerenderedCardSearch
-          @query={{@query}}
-          @format='embedded'
-          @realms={{@realms}}
-          @isLive={{true}}
-        >
-          <:loading>
+        <PrerenderedCardSearch @query={{this.searchResultsQuery}} as |results|>
+          {{#if results.isLoading}}
             Loading...
-          </:loading>
-          <:response as |cards|>
-            {{#each cards key='url' as |card|}}
-              <li class='card-list-item'>
-                <card.component class='card' />
-                {{#if (has-block 'meta')}}
-                  {{yield card to='meta'}}
-                {{/if}}
-              </li>
-            {{/each}}
-          </:response>
+          {{/if}}
+          {{#each results.entries key='id' as |card|}}
+            <li class='card-list-item'>
+              <card.component class='card' />
+              {{#if (has-block 'meta')}}
+                {{yield card to='meta'}}
+              {{/if}}
+            </li>
+          {{/each}}
         </PrerenderedCardSearch>
       {{/let}}
     </ul>

--- a/packages/experiments-realm/components/card-list.gts
+++ b/packages/experiments-realm/components/card-list.gts
@@ -40,9 +40,9 @@ export class CardList extends GlimmerComponent<CardListSignature> {
     <ul class='card-list' ...attributes>
       {{#let
         (component @context.searchResultsComponent)
-        as |PrerenderedCardSearch|
+        as |SearchResults|
       }}
-        <PrerenderedCardSearch @query={{this.searchResultsQuery}} as |results|>
+        <SearchResults @query={{this.searchResultsQuery}} as |results|>
           {{#if results.isLoading}}
             Loading...
           {{/if}}
@@ -54,7 +54,7 @@ export class CardList extends GlimmerComponent<CardListSignature> {
               {{/if}}
             </li>
           {{/each}}
-        </PrerenderedCardSearch>
+        </SearchResults>
       {{/let}}
     </ul>
     <style scoped>

--- a/packages/experiments-realm/components/grid.gts
+++ b/packages/experiments-realm/components/grid.gts
@@ -2,7 +2,11 @@ import GlimmerComponent from '@glimmer/component';
 
 import { type CardContext } from 'https://cardstack.com/base/card-api';
 
-import { type Query } from '@cardstack/runtime-common';
+import {
+  type Query,
+  searchEntryWireQueryFromQuery,
+  type SearchEntryWireQuery,
+} from '@cardstack/runtime-common';
 
 interface CardsGridSignature {
   Args: {
@@ -14,6 +18,12 @@ interface CardsGridSignature {
   Element: HTMLElement;
 }
 export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
+  get searchResultsQuery(): SearchEntryWireQuery {
+    return {
+      ...searchEntryWireQueryFromQuery(this.args.query),
+      realms: this.args.realms,
+    };
+  }
   <template>
     <ul
       class='cards {{@selectedView}}-view'
@@ -21,25 +31,18 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
       ...attributes
     >
       {{#let
-        (component @context.prerenderedCardSearchComponent)
+        (component @context.searchResultsComponent)
         as |PrerenderedCardSearch|
       }}
-        <PrerenderedCardSearch
-          @query={{@query}}
-          @format='fitted'
-          @realms={{@realms}}
-          @isLive={{true}}
-        >
-          <:loading>
+        <PrerenderedCardSearch @query={{this.searchResultsQuery}} as |results|>
+          {{#if results.isLoading}}
             Loading...
-          </:loading>
-          <:response as |cards|>
-            {{#each cards key='url' as |card|}}
-              <li class='{{@selectedView}}-view-container'>
-                <card.component class='card' />
-              </li>
-            {{/each}}
-          </:response>
+          {{/if}}
+          {{#each results.entries key='id' as |card|}}
+            <li class='{{@selectedView}}-view-container'>
+              <card.component class='card' />
+            </li>
+          {{/each}}
         </PrerenderedCardSearch>
       {{/let}}
     </ul>

--- a/packages/experiments-realm/components/grid.gts
+++ b/packages/experiments-realm/components/grid.gts
@@ -32,9 +32,9 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
     >
       {{#let
         (component @context.searchResultsComponent)
-        as |PrerenderedCardSearch|
+        as |SearchResults|
       }}
-        <PrerenderedCardSearch @query={{this.searchResultsQuery}} as |results|>
+        <SearchResults @query={{this.searchResultsQuery}} as |results|>
           {{#if results.isLoading}}
             Loading...
           {{/if}}
@@ -43,7 +43,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
               <card.component class='card' />
             </li>
           {{/each}}
-        </PrerenderedCardSearch>
+        </SearchResults>
       {{/let}}
     </ul>
     <style scoped>


### PR DESCRIPTION
Runs the `@context` search codemod across the first-party realms (base, experiments, catalog, skills) and hand-fixes the usages it can't transform mechanically, moving experiments-realm card source off the deprecated `@context.prerenderedCardSearchComponent` and onto the v2 `@context.searchResultsComponent` (`<SearchResults>`) surface.

Only **experiments-realm** carries prerendered-card-search usages. `base` declares the (deprecated) `@context` member itself — left in place for the later cleanup — and `catalog` / `skills-realm` have none.

### Codemod-migrated
- `components/grid.gts` — the v1 query is adapted through `searchEntryWireQueryFromQuery`, `<:response>` becomes `{{#each results.entries}}`, and rows are addressed by `id`.

### Hand-migrated (shapes the codemod can't transform mechanically)
- `components/card-list.gts` — its loop yields each row to a `:meta` block instead of a direct `{{#each}}`. The block now yields a `RenderableSearchEntryLike`; the `embedded` format is bound through the query's `htmlQuery` field.
- `app-card.gts` — the result list is handed to the local `TableView` / `CardsGrid` components instead of being iterated directly. Both now take `RenderableSearchEntryLike[]` and address rows by `id`.
- `blog-app.gts` — its `CardList` `:meta` consumer reads the yielded row's `id`.

Hydration mode is left at the codemod default (`hover`): rows paint inert prerendered HTML at rest — identical to the prior behavior — and hydrate to a live card on hover.

### Verification
- Every changed `.gts` transpiles through the realm's own `gjsToPlaceholderJS` + babel lowering — the path that indexes and serves card source.
- `ember-template-lint` passes.
- The codemod is idempotent: a second run is a no-op.
- The migrated surface matches the v2 pattern already shipped in `base/components/card-list.gts`.
