### PR TITLE
Fix host browser-bundle Node-builtin polyfills broken by ESM migration

### DIFF
--- a/packages/host/index.html
+++ b/packages/host/index.html
@@ -56,6 +56,13 @@
     <script>
       globalThis.process = {
         env: {},
+        browser: true,
+        version: '',
+        versions: {},
+        platform: 'browser',
+        nextTick(fn, ...args) {
+          Promise.resolve().then(() => fn(...args));
+        },
         cwd() {
           return '';
         },

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -186,6 +186,7 @@
     "tracked-built-ins": "catalog:",
     "turndown": "^7.2.4",
     "typescript": "catalog:",
+    "util": "catalog:",
     "uuid": "catalog:",
     "vite": "^8.0.8",
     "wait-for-localhost-cli": "catalog:",

--- a/packages/host/tests/index.html
+++ b/packages/host/tests/index.html
@@ -28,16 +28,13 @@
     <script>
       globalThis.process = {
         env: {},
+        browser: true,
         version: '',
-        cwd() {
-          return '/';
+        versions: {},
+        platform: 'browser',
+        nextTick(fn, ...args) {
+          Promise.resolve().then(() => fn(...args));
         },
-      };
-    </script>
-
-    <script>
-      globalThis.process = {
-        env: {},
         cwd() {
           return '';
         },

--- a/packages/host/vite.config.mjs
+++ b/packages/host/vite.config.mjs
@@ -268,14 +268,14 @@ export default defineConfig(({ mode }) => ({
     },
   },
   resolve: {
-    alias: {
-      path: require.resolve('path-browserify'),
-      crypto: require.resolve('crypto-browserify'),
-      stream: require.resolve('stream-browserify'),
-      util: require.resolve('util/'),
+    alias: [
+      { find: 'path', replacement: require.resolve('path-browserify') },
+      { find: 'crypto', replacement: require.resolve('crypto-browserify') },
+      { find: 'stream', replacement: require.resolve('stream-browserify') },
+      { find: /^util$/, replacement: require.resolve('util/') },
       // recast's main.js eagerly requires 'fs'; we stub it for the browser.
-      fs: require.resolve('./lib/empty-fs.js'),
-    },
+      { find: 'fs', replacement: require.resolve('./lib/empty-fs.js') },
+    ],
   },
   plugins: [
     scopedCSS(),

--- a/packages/host/vite.config.mjs
+++ b/packages/host/vite.config.mjs
@@ -84,12 +84,7 @@ const emptyFsPath = require.resolve('./lib/empty-fs.js');
 const nodeBuiltinStubResolver = {
   name: 'node-builtin-stub-resolver',
   resolveId(id) {
-    if (
-      id === 'fs' ||
-      id === 'node:fs' ||
-      id === 'url' ||
-      id === 'node:url'
-    ) {
+    if (id === 'fs' || id === 'node:fs' || id === 'url' || id === 'node:url') {
       return emptyFsPath;
     }
     return null;
@@ -277,6 +272,7 @@ export default defineConfig(({ mode }) => ({
       path: require.resolve('path-browserify'),
       crypto: require.resolve('crypto-browserify'),
       stream: require.resolve('stream-browserify'),
+      util: require.resolve('util/'),
       // recast's main.js eagerly requires 'fs'; we stub it for the browser.
       fs: require.resolve('./lib/empty-fs.js'),
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,6 +660,9 @@ catalogs:
     undici:
       specifier: ^7.22.0
       version: 7.25.0
+    util:
+      specifier: ^0.12.5
+      version: 0.12.5
     uuid:
       specifier: ^9.0.1
       version: 9.0.1
@@ -2422,6 +2425,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      util:
+        specifier: 'catalog:'
+        version: 0.12.5
       uuid:
         specifier: 'catalog:'
         version: 9.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -243,6 +243,7 @@ catalog:
   tracked-built-ins: ^4.0.0
   typescript: ~5.9.3
   undici: ^7.22.0
+  util: ^0.12.5
   uuid: ^9.0.1
   validate-peer-dependencies: ^1.1.0
   vite: ^6.3.2


### PR DESCRIPTION
## Problem

`dev-all` loops forever on `[wait-for-host-standby]` because the host's `/_standby` page crashes during Ember boot, so the `#standby-ready` marker never renders and the prerender's standby probe times out on every attempt.

<img width="1019" height="535" alt="Screenshot 2026-06-22 at 11 32 35 AM" src="https://github.com/user-attachments/assets/8fba4c36-5c19-4652-b954-fce105ce1597" />



The Vite 8 / rolldown migration dropped the automatic Node-builtin polyfilling that the previous esbuild-based optimizer provided. The host's `crypto`/`stream` CJS dependency chains now blow up in the browser one Node global at a time:

1. `stream-browserify` → `readable-stream` calls `require('util')`. With no `util` browser alias, rolldown emits a runtime `__require('util')` that throws: *"Calling `require` for 'util' in an environment that doesn't expose the `require` function."*
2. With `util` fixed, the next crash: `crypto-browserify` → `create-hash` → `ripemd160` → `readable-stream` reads `process.version.slice(...)` / `process.browser` at module-eval time. The inline `process` stub in `index.html` only defined `{ env, cwd }`, so this threw *"Cannot read properties of undefined (reading 'slice')."*

## Fix

- Add a browser polyfill alias for `util` (`util: require.resolve('util/')` in `vite.config.mjs`), declare `util` as a host dependency, and add it to the workspace catalog.
- Flesh out the inline `process` global in `index.html` with `browser`, `version`, `versions`, `platform`, and `nextTick` so the readable-stream module-eval checks pass.

## Verification

With both changes, the standby probe boots cleanly:

```
[wait-for-host-standby] browser-ready after 33s (attempt 2)
```

The `require('util')` and `reading 'slice'` page errors no longer appear in the host log, and `wait-for-host-standby` / `dev-all` no longer loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)