### PR TITLE
Restore lodash VirtualNetwork shim alongside lodash-es

### DIFF
--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -180,6 +180,7 @@ export function shimExternals(virtualNetwork: VirtualNetwork) {
   });
   virtualNetwork.shimModule('flat', flat);
   virtualNetwork.shimModule('@floating-ui/dom', floatingUiDom);
+  virtualNetwork.shimModule('lodash', lodash);
   virtualNetwork.shimModule('lodash-es', lodash);
   virtualNetwork.shimModule('matrix-js-sdk', matrixJsSDK);
   virtualNetwork.shimModule('rsvp', rsvp);


### PR DESCRIPTION


## Problem

After the ESM migration, opening/indexing a card that imports the conventional `lodash` specifier fails at runtime:

<img width="823" height="694" alt="Screenshot 2026-06-22 at 2 00 20 PM" src="https://github.com/user-attachments/assets/60dc07a2-e4f5-4e4d-b43d-36313b36ed9a" />


```
unable to fetch https://packages/lodash: fetch failed for https://packages/lodash: Failed to fetch
```

The migration moved the host code to `lodash-es` and, with it, **moved** the VirtualNetwork shim id from `lodash` to `lodash-es` (so the host's own imports resolve). But card content — including catalog cards (e.g. `catalog-app/catalog.gts`, `fields/geo-search-point/...`) — commonly imports the conventional `lodash` name. With only `lodash-es` shimmed, those imports find no shim and fall through to a network fetch of `https://packages/lodash`, which has no backing and fails. The card then can't load.

## Fix

Register the shim under **both** ids, pointing at the same module:

```js
virtualNetwork.shimModule('lodash', lodash);
virtualNetwork.shimModule('lodash-es', lodash);
```

This restores backward compatibility for the many cards in realms that import `lodash` (named imports resolve through the same `lodash-es`-backed module the host already uses) without disturbing host code that imports `lodash-es`.

## Design note for reviewers

The alternative is to migrate the offending catalog cards to import `lodash-es`. That fixes those specific cards but silently breaks any other realm/card content importing `lodash`, so shimming both ids is the lower-risk platform-level fix. Happy to switch approaches if we'd rather treat `lodash` as unsupported going forward.

## Verification

After loading this shim (host + prerender restart) and reindexing the affected realm, the `https://packages/lodash` runtime error no longer appears and the card renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)