### PR TITLE
fix: boxel-cli __dirname under ESM breaks build-plugin / publish

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,6 +94,9 @@ module.exports = {
       // Ban the CommonJS-only `__dirname`/`__filename` globals in TS source under
       // `src/` and `scripts/` — the surface that runs or gets imported as native
       // ESM, where they are `undefined`. Bundle-only modules opt out per-line.
+      // Packages with their own `root: true` ESLint config don't inherit this and
+      // must re-declare it; among the native-ESM (`type: module`) packages only
+      // `ai-bot` is `root: true`, and it does (see its `.eslintrc.cjs`).
       files: ['**/src/**/*.{ts,mts}', '**/scripts/**/*.{ts,mts}'],
       rules: {
         'no-restricted-globals': ['error', ...CJS_GLOBALS_IN_ESM],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@
 
 const {
   NO_COMPILATION_REQUIRED_TS_SELECTORS,
+  CJS_GLOBALS_IN_ESM,
 } = require('./eslint/erasable-syntax-selectors.cjs');
 
 const DATA_TEST_SELECTORS = [
@@ -87,6 +88,15 @@ module.exports = {
           ...NO_COMPILATION_REQUIRED_TS_SELECTORS,
           ...DATA_TEST_SELECTORS,
         ],
+      },
+    },
+    {
+      // Ban the CommonJS-only `__dirname`/`__filename` globals in TS source under
+      // `src/` and `scripts/` — the surface that runs or gets imported as native
+      // ESM, where they are `undefined`. Bundle-only modules opt out per-line.
+      files: ['**/src/**/*.{ts,mts}', '**/scripts/**/*.{ts,mts}'],
+      rules: {
+        'no-restricted-globals': ['error', ...CJS_GLOBALS_IN_ESM],
       },
     },
   ],

--- a/eslint/erasable-syntax-selectors.cjs
+++ b/eslint/erasable-syntax-selectors.cjs
@@ -39,4 +39,28 @@ const NO_COMPILATION_REQUIRED_TS_SELECTORS = [
   },
 ];
 
-module.exports = { NO_COMPILATION_REQUIRED_TS_SELECTORS };
+// CommonJS-only globals that are `undefined` when a module is loaded as native
+// ESM (`type: module`, or imported as ESM by another tool). `import.meta.dirname`
+// / `import.meta.url` are the ESM equivalents. Used with `no-restricted-globals`,
+// which flags only true global references — not comments, local bindings, or
+// `import.meta.dirname` member access.
+//
+// Scoped (in the configs that consume this) to `src/` and `scripts/` TS source,
+// the surface that runs/imports as ESM. Modules that ONLY ever execute as an
+// esbuild CJS bundle (where `__dirname` is real and `import.meta` is a TS1470
+// error) are the legitimate exception — opt out per-line with an
+// `// eslint-disable-next-line no-restricted-globals` and a reason.
+const CJS_GLOBALS_IN_ESM = [
+  {
+    name: '__dirname',
+    message:
+      '`__dirname` is undefined when this module is loaded as native ESM. Use `import.meta.dirname` instead. If this module only ever runs as a CJS bundle, opt out with an `eslint-disable-next-line no-restricted-globals` and a reason.',
+  },
+  {
+    name: '__filename',
+    message:
+      '`__filename` is undefined when this module is loaded as native ESM. Use `import.meta.filename` (or `fileURLToPath(import.meta.url)`) instead. If this module only ever runs as a CJS bundle, opt out with an `eslint-disable-next-line no-restricted-globals` and a reason.',
+  },
+];
+
+module.exports = { NO_COMPILATION_REQUIRED_TS_SELECTORS, CJS_GLOBALS_IN_ESM };

--- a/packages/ai-bot/.eslintrc.cjs
+++ b/packages/ai-bot/.eslintrc.cjs
@@ -4,6 +4,7 @@
 // erasable-syntax rule must be re-declared from the shared list.
 const {
   NO_COMPILATION_REQUIRED_TS_SELECTORS,
+  CJS_GLOBALS_IN_ESM,
 } = require('../../eslint/erasable-syntax-selectors.cjs');
 
 module.exports = {
@@ -59,6 +60,14 @@ module.exports = {
       },
       rules: {
         '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
+    {
+      // See the root `.eslintrc.js`: ban CommonJS-only `__dirname`/`__filename`
+      // in ESM-loaded TS source. Re-declared here because this config is `root`.
+      files: ['**/src/**/*.{ts,mts}', '**/scripts/**/*.{ts,mts}'],
+      rules: {
+        'no-restricted-globals': ['error', ...CJS_GLOBALS_IN_ESM],
       },
     },
   ],

--- a/packages/boxel-cli/scripts/build.ts
+++ b/packages/boxel-cli/scripts/build.ts
@@ -31,6 +31,12 @@ const commonConfig = {
   treeShaking: true,
   define: {
     'process.env.NODE_ENV': '"production"',
+    // Source uses `import.meta.dirname` so it runs as native ESM (e.g. `node
+    // scripts/build-plugin.ts` imports the command modules directly). esbuild
+    // does NOT fill `import.meta.dirname` in CJS output — it resolves to
+    // `undefined` at runtime — so map it to `__dirname`, which the CJS bundle
+    // (this single `dist/*.js` file) provides natively as the `dist/` dir.
+    'import.meta.dirname': '__dirname',
   },
   mainFields: ['module', 'main'],
   conditions: ['import', 'require'],

--- a/packages/boxel-cli/src/commands/parse.ts
+++ b/packages/boxel-cli/src/commands/parse.ts
@@ -66,7 +66,7 @@ const SPEC_TYPE = {
 const PARSEABLE_GTS_EXTENSIONS = ['.gts', '.gjs', '.ts'] as const;
 const PARSEABLE_JSON_EXTENSION = '.json';
 
-const BOXEL_CLI_PATH = findBoxelCliRoot(__dirname);
+const BOXEL_CLI_PATH = findBoxelCliRoot(import.meta.dirname);
 const PACKAGES_PATH = resolve(BOXEL_CLI_PATH, '..');
 
 // CS-11165: a published `@cardstack/boxel-cli` install vendors the type

--- a/packages/boxel-cli/src/index.ts
+++ b/packages/boxel-cli/src/index.ts
@@ -5,7 +5,7 @@ import { buildBoxelProgram } from './build-program.ts';
 import { setQuiet } from './lib/cli-log.ts';
 
 const pkg = JSON.parse(
-  readFileSync(resolve(__dirname, '../package.json'), 'utf-8'),
+  readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf-8'),
 );
 
 // `--quiet` is implemented by intercepting `console.log/info/debug`.

--- a/packages/boxel-cli/src/lib/find-package-root.ts
+++ b/packages/boxel-cli/src/lib/find-package-root.ts
@@ -2,11 +2,11 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 /**
- * Walk up from `__dirname` until we find the `@cardstack/boxel-cli`
- * package.json. The single-file esbuild bundle places `__dirname` at
- * `boxel-cli/dist`; running from source (e.g. under vitest) places it
- * inside `src/...`. Anchoring to the package.json keeps every downstream
- * path stable regardless of which entry mode is active.
+ * Walk up from the caller's directory (`import.meta.dirname`) until we find
+ * the `@cardstack/boxel-cli` package.json. The single-file esbuild bundle
+ * places it at `boxel-cli/dist`; running from source (e.g. under vitest or
+ * `node scripts/build-plugin.ts`) places it inside `src/...`. Anchoring to the
+ * package.json keeps every downstream path stable regardless of entry mode.
  */
 export function findBoxelCliRoot(startDir: string): string {
   let dir = startDir;

--- a/packages/boxel-cli/src/lib/test-engine.ts
+++ b/packages/boxel-cli/src/lib/test-engine.ts
@@ -372,7 +372,12 @@ function resolveBundledRealms(override: string | undefined): {
       skillsDir: join(override, 'skills'),
     };
   }
-  let cliRoot = findBoxelCliRoot(import.meta.dirname);
+  // Use `__dirname` (not `import.meta.dirname`) here: this module is re-exported
+  // through `@cardstack/boxel-cli/api` and type-checked by CommonJS consumers
+  // (e.g. the software factory), where `import.meta` is a TS1470 error. esbuild
+  // provides `__dirname` in the CJS bundle (the `dist/` dir); these calls run
+  // inside functions, never at import time, so ESM-source importers are fine.
+  let cliRoot = findBoxelCliRoot(__dirname);
   let bundled = join(cliRoot, 'bundled-realms');
   if (dirExists(join(bundled, 'base'))) {
     return {
@@ -1048,7 +1053,7 @@ function resolveHostDistDir(): string {
       'dist',
     );
   }
-  let cliRoot = findBoxelCliRoot(import.meta.dirname);
+  let cliRoot = findBoxelCliRoot(__dirname);
   let bundled = join(cliRoot, 'bundled-test-harness');
   if (fileExists(join(bundled, 'tests', 'index.html'))) {
     return bundled;
@@ -1064,7 +1069,7 @@ function resolveHostDistDir(): string {
 }
 
 function findHostDistPackageDir(): string | undefined {
-  let packageRoot = findBoxelCliRoot(import.meta.dirname);
+  let packageRoot = findBoxelCliRoot(__dirname);
   let packagesDir = resolve(packageRoot, '..');
   let workspaceRoot = resolve(packagesDir, '..');
   let hostDir = join(packagesDir, 'host');

--- a/packages/boxel-cli/src/lib/test-engine.ts
+++ b/packages/boxel-cli/src/lib/test-engine.ts
@@ -377,6 +377,7 @@ function resolveBundledRealms(override: string | undefined): {
   // (e.g. the software factory), where `import.meta` is a TS1470 error. esbuild
   // provides `__dirname` in the CJS bundle (the `dist/` dir); these calls run
   // inside functions, never at import time, so ESM-source importers are fine.
+  // eslint-disable-next-line no-restricted-globals -- bundle-only; see comment above
   let cliRoot = findBoxelCliRoot(__dirname);
   let bundled = join(cliRoot, 'bundled-realms');
   if (dirExists(join(bundled, 'base'))) {
@@ -1053,6 +1054,7 @@ function resolveHostDistDir(): string {
       'dist',
     );
   }
+  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `bundledRealmDirs` above
   let cliRoot = findBoxelCliRoot(__dirname);
   let bundled = join(cliRoot, 'bundled-test-harness');
   if (fileExists(join(bundled, 'tests', 'index.html'))) {
@@ -1069,6 +1071,7 @@ function resolveHostDistDir(): string {
 }
 
 function findHostDistPackageDir(): string | undefined {
+  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `bundledRealmDirs` above
   let packageRoot = findBoxelCliRoot(__dirname);
   let packagesDir = resolve(packageRoot, '..');
   let workspaceRoot = resolve(packagesDir, '..');

--- a/packages/boxel-cli/src/lib/test-engine.ts
+++ b/packages/boxel-cli/src/lib/test-engine.ts
@@ -1054,7 +1054,7 @@ function resolveHostDistDir(): string {
       'dist',
     );
   }
-  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `bundledRealmDirs` above
+  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `resolveBundledRealms` above
   let cliRoot = findBoxelCliRoot(__dirname);
   let bundled = join(cliRoot, 'bundled-test-harness');
   if (fileExists(join(bundled, 'tests', 'index.html'))) {
@@ -1071,7 +1071,7 @@ function resolveHostDistDir(): string {
 }
 
 function findHostDistPackageDir(): string | undefined {
-  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `bundledRealmDirs` above
+  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `resolveBundledRealms` above
   let packageRoot = findBoxelCliRoot(__dirname);
   let packagesDir = resolve(packageRoot, '..');
   let workspaceRoot = resolve(packagesDir, '..');

--- a/packages/boxel-cli/src/lib/test-engine.ts
+++ b/packages/boxel-cli/src/lib/test-engine.ts
@@ -372,7 +372,7 @@ function resolveBundledRealms(override: string | undefined): {
       skillsDir: join(override, 'skills'),
     };
   }
-  let cliRoot = findBoxelCliRoot(__dirname);
+  let cliRoot = findBoxelCliRoot(import.meta.dirname);
   let bundled = join(cliRoot, 'bundled-realms');
   if (dirExists(join(bundled, 'base'))) {
     return {
@@ -1048,7 +1048,7 @@ function resolveHostDistDir(): string {
       'dist',
     );
   }
-  let cliRoot = findBoxelCliRoot(__dirname);
+  let cliRoot = findBoxelCliRoot(import.meta.dirname);
   let bundled = join(cliRoot, 'bundled-test-harness');
   if (fileExists(join(bundled, 'tests', 'index.html'))) {
     return bundled;
@@ -1064,7 +1064,7 @@ function resolveHostDistDir(): string {
 }
 
 function findHostDistPackageDir(): string | undefined {
-  let packageRoot = findBoxelCliRoot(__dirname);
+  let packageRoot = findBoxelCliRoot(import.meta.dirname);
   let packagesDir = resolve(packageRoot, '..');
   let workspaceRoot = resolve(packagesDir, '..');
   let hostDir = join(packagesDir, 'host');


### PR DESCRIPTION
## What broke
The **boxel-cli publish** workflow on `main` is failing at the "Regenerate plugin synopsis and skills" step:

```
ReferenceError: __dirname is not defined in ES module scope
    at packages/boxel-cli/src/commands/parse.ts:69
```

## Why
The recent ESM migration switched scripts from `ts-node` (CommonJS, `__dirname` defined) to native `node` ESM (`__dirname` undefined). `build-plugin.ts` imports the command tree as ES modules, and `parse.ts` runs `findBoxelCliRoot(__dirname)` at the top level — so just importing it throws.

The migration codemod missed these boxel-cli files because they normally run as the esbuild **CJS bundle**, where `__dirname` exists. The shipped `boxel` CLI was fine; only loading the raw source as ESM (what `build-plugin` does) trips it.

## Fix
- Source now uses **`import.meta.dirname`** (native ESM) in the five spots that used `__dirname` (`parse.ts`, `test-engine.ts` ×3, `index.ts`).
- esbuild's CJS bundle doesn't fill `import.meta.dirname` (it resolves to `undefined`), so `build.ts` adds an esbuild `define` mapping `import.meta.dirname` → `__dirname` — which the single-file CJS bundle provides natively as the `dist/` dir.

So it works in both modes: native ESM source uses the real `import.meta.dirname`; the bundle rewrites it to `__dirname`.

## Verified
- `node scripts/build-plugin.ts` runs clean (the failing CI step).
- Bundled `boxel parse --help` and `boxel --help` resolve paths correctly (the top-level call that was throwing).
- `tsc` + `eslint` clean; boxel-cli unit tests pass.

CS-11688.
