### PR TITLE
Add MarkdownEmbedPreview component + preview pane (CS-11673, CS-11674)

### DIFF
--- a/packages/base/markdown-helpers.ts
+++ b/packages/base/markdown-helpers.ts
@@ -3,7 +3,7 @@
 // construction, and so future adjustments happen in one place.
 
 import { markdownEscape } from '@cardstack/boxel-ui/helpers';
-import { isValidDate } from '@cardstack/runtime-common';
+import { isValidDate, serializeBfmRef } from '@cardstack/runtime-common';
 
 // Date formatting shared by DateField, DateTimeField, and DateRangeField so
 // their markdown output is consistent. Matches the existing `en-US` `{year:
@@ -158,22 +158,25 @@ interface MarkdownEmbedOptions {
   size?: string;
 }
 
+// Returns a BFM reference directive (`:card`/`::card`, `:file`/`::file`, …)
+// for a single reference by keyword + id. Returns `''` for a missing id.
+// Thin wrapper over the shared `serializeBfmRef` builder so base-realm and
+// host code emit identical BFM syntax.
+export function markdownEmbedForRef(
+  refType: string,
+  id: string | null | undefined,
+  options?: MarkdownEmbedOptions,
+): string {
+  return serializeBfmRef(refType, id, options);
+}
+
 // Returns a BFM card-reference directive for a single card.
 // Returns `''` for null/undefined cards.
 export function markdownEmbedForCard(
   card: CardLike | null | undefined,
   options?: MarkdownEmbedOptions,
 ): string {
-  if (!card?.id) {
-    return '';
-  }
-  let kind = options?.kind ?? 'block';
-  let size = options?.size;
-  let prefix = kind === 'inline' ? ':card' : '::card';
-  if (size) {
-    return `${prefix}[${card.id} | ${size}]`;
-  }
-  return `${prefix}[${card.id}]`;
+  return serializeBfmRef('card', card?.id, options);
 }
 
 interface MarkdownEmbedsOptions extends MarkdownEmbedOptions {

--- a/packages/host/app/components/markdown-embed-chooser/pane-usage.gts
+++ b/packages/host/app/components/markdown-embed-chooser/pane-usage.gts
@@ -1,0 +1,112 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+
+import { isCardErrorJSONAPI } from '@cardstack/runtime-common';
+
+import MiniCardChooser from '@cardstack/host/components/card-chooser/mini';
+
+import type StoreService from '@cardstack/host/services/store';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+
+import MarkdownEmbedPreviewPane from './pane';
+
+export default class MarkdownEmbedPreviewPaneUsage extends Component {
+  @service declare private store: StoreService;
+
+  @tracked private target: CardDef | undefined;
+  @tracked private inserted: string | undefined;
+
+  @action private async onSelect(url: string) {
+    let result = await this.store.get(url);
+    if (!isCardErrorJSONAPI(result)) {
+      this.target = result as CardDef;
+    }
+  }
+
+  @action private onInsert(bfm: string) {
+    this.inserted = bfm;
+  }
+
+  <template>
+    <FreestyleUsage @name='MarkdownEmbedChooser::Pane'>
+      <:description>
+        The right-hand companion to the mini choosers: a live preview plus a
+        format dropdown, always-on W×H inputs for Fitted (with smart variant
+        matching), an Inline/Block toggle (Block is disabled while Atom is
+        selected, since atom has no block form), and a dynamic "Insert as …"
+        CTA. The CTA fires
+        <code>onInsert</code>
+        with the serialized BFM — the host owns cursor insertion.
+      </:description>
+      <:example>
+        <div class='side-by-side'>
+          <div class='panel'>
+            <MiniCardChooser @onSelect={{this.onSelect}} />
+          </div>
+          <div class='panel'>
+            {{#if this.target}}
+              <MarkdownEmbedPreviewPane
+                @target={{this.target}}
+                @refType='card'
+                @onInsert={{this.onInsert}}
+              />
+            {{else}}
+              <p class='hint'>Pick a card to configure its embed.</p>
+            {{/if}}
+          </div>
+        </div>
+        {{#if this.inserted}}
+          <p class='readout' data-test-pane-usage-readout>
+            Inserted:
+            <code>{{this.inserted}}</code>
+          </p>
+        {{/if}}
+      </:example>
+      <:api as |Args|>
+        <Args.Object
+          @name='target'
+          @description='Resolved CardDef or FileDef being previewed; its id is the BFM ref URL.'
+          @required={{true}}
+        />
+        <Args.String
+          @name='refType'
+          @description="'card' or 'file' — which BFM keyword to emit."
+          @required={{true}}
+        />
+        <Args.Action
+          @name='onInsert'
+          @description='Called with the serialized BFM directive when the CTA is clicked.'
+          @required={{true}}
+        />
+      </:api>
+    </FreestyleUsage>
+    <style scoped>
+      .side-by-side {
+        display: flex;
+        gap: var(--boxel-sp);
+        height: 480px;
+      }
+      .panel {
+        flex: 1 1 0;
+        min-width: 0;
+        border: 1px solid var(--boxel-border-color, var(--boxel-300));
+        border-radius: var(--boxel-border-radius);
+        overflow: hidden;
+      }
+      .hint {
+        padding: var(--boxel-sp);
+        font: var(--boxel-font-sm);
+        color: var(--boxel-450);
+      }
+      .readout {
+        margin-top: var(--boxel-sp-xs);
+        font: var(--boxel-font-sm);
+      }
+    </style>
+  </template>
+}

--- a/packages/host/app/components/markdown-embed-chooser/pane-usage.gts
+++ b/packages/host/app/components/markdown-embed-chooser/pane-usage.gts
@@ -20,6 +20,7 @@ export default class MarkdownEmbedPreviewPaneUsage extends Component {
 
   @tracked private target: CardDef | undefined;
   @tracked private inserted: string | undefined;
+  @tracked private refType: 'card' | 'file' = 'card';
 
   @action private async onSelect(url: string) {
     let result = await this.store.get(url);
@@ -32,14 +33,18 @@ export default class MarkdownEmbedPreviewPaneUsage extends Component {
     this.inserted = bfm;
   }
 
+  @action private setRefType(value: string) {
+    this.refType = value === 'file' ? 'file' : 'card';
+  }
+
   <template>
     <FreestyleUsage @name='MarkdownEmbedChooser::Pane'>
       <:description>
         The right-hand companion to the mini choosers: a live preview plus a
         format dropdown, always-on W×H inputs for Fitted (with smart variant
-        matching), an Inline/Block toggle (Block is disabled while Atom is
-        selected, since atom has no block form), and a dynamic "Insert as …"
-        CTA. The CTA fires
+        matching), an independent Inline/Block placement toggle (every format
+        works in both placements), and a dynamic "Insert as …" CTA. The CTA
+        fires
         <code>onInsert</code>
         with the serialized BFM — the host owns cursor insertion.
       </:description>
@@ -52,7 +57,7 @@ export default class MarkdownEmbedPreviewPaneUsage extends Component {
             {{#if this.target}}
               <MarkdownEmbedPreviewPane
                 @target={{this.target}}
-                @refType='card'
+                @refType={{this.refType}}
                 @onInsert={{this.onInsert}}
               />
             {{else}}
@@ -72,16 +77,21 @@ export default class MarkdownEmbedPreviewPaneUsage extends Component {
           @name='target'
           @description='Resolved CardDef or FileDef being previewed; its id is the BFM ref URL.'
           @required={{true}}
+          @value={{this.target}}
         />
         <Args.String
           @name='refType'
           @description="'card' or 'file' — which BFM keyword to emit."
           @required={{true}}
+          @value={{this.refType}}
+          @onInput={{this.setRefType}}
+          @options={{this.refTypeOptions}}
         />
         <Args.Action
           @name='onInsert'
-          @description='Called with the serialized BFM directive when the CTA is clicked.'
+          @description='Called with the serialized BFM directive when the CTA is clicked. Watch the "Inserted:" readout above.'
           @required={{true}}
+          @value={{this.onInsert}}
         />
       </:api>
     </FreestyleUsage>
@@ -109,4 +119,6 @@ export default class MarkdownEmbedPreviewPaneUsage extends Component {
       }
     </style>
   </template>
+
+  private refTypeOptions = ['card', 'file'];
 }

--- a/packages/host/app/components/markdown-embed-chooser/pane.gts
+++ b/packages/host/app/components/markdown-embed-chooser/pane.gts
@@ -406,6 +406,7 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         justify-content: center;
         padding: var(--boxel-sp);
         overflow: auto;
+        background-color: var(--boxel-100);
       }
       .markdown-embed-preview-pane__format-select {
         flex: 1 1 auto;

--- a/packages/host/app/components/markdown-embed-chooser/pane.gts
+++ b/packages/host/app/components/markdown-embed-chooser/pane.gts
@@ -104,16 +104,12 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
     return this.selectedOption.category;
   }
 
-  // Atom has no `::card[... | atom]` block form, so block is disallowed while
-  // Atom is selected — the toggle is forced/locked to inline.
-  private get blockDisabled(): boolean {
-    return this.category === 'atom';
-  }
-
   private get showSizeInputs(): boolean {
     return this.category === 'fitted' || this.category === 'custom';
   }
 
+  // The preview renders the selected format in the chosen placement; format and
+  // inline/block are independent (every format works in both modes).
   private get previewFormat(): EmbedFormat {
     switch (this.category) {
       case 'atom':
@@ -163,10 +159,13 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
     return `Insert as ${this.categoryLabel}`;
   }
 
-  // Block size specifier: the variant id for a named Fitted variant, `embedded`
-  // for Embedded, and `w:<w> h:<h>` for Custom dimensions (per CS-11674).
-  private get blockSizeSpecifier(): string | undefined {
+  // Size specifier for the chosen format, independent of placement: `atom` /
+  // `embedded` keywords, the variant id for a named Fitted variant, and
+  // `w:<w> h:<h>` for Custom dimensions (per CS-11674).
+  private get sizeSpecifier(): string | undefined {
     switch (this.category) {
+      case 'atom':
+        return 'atom';
       case 'embedded':
         return 'embedded';
       case 'fitted':
@@ -184,25 +183,24 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
 
   private get bfmString(): string {
     let url = this.args.target.id;
-    if (this.kind === 'inline') {
-      return serializeBfmRef(this.args.refType, url, { kind: 'inline' });
-    }
+    // Declare intent uniformly (kind + size); the BFM serializer in
+    // runtime-common owns whether a given kind carries the size. Today it drops
+    // the size for inline (so inline emits `:card[url]`); the BFM "all formats
+    // in both modes" ticket makes inline honor it, after which this chooser
+    // emits `:card[url | spec]` with no change here.
     return serializeBfmRef(this.args.refType, url, {
-      kind: 'block',
-      size: this.blockSizeSpecifier,
+      kind: this.kind,
+      size: this.sizeSpecifier,
     });
   }
 
   @action
   private selectFormat(option: FormatOption) {
     this.selectedValue = option.value;
-    if (option.category === 'atom') {
-      this.kind = 'inline';
-    } else {
-      // A sized embed is meaningful as a block; the user can still toggle back
-      // to inline afterward.
-      this.kind = 'block';
-    }
+    // Pick a sensible default placement for the format — atom reads as inline,
+    // sized formats as block — but the toggle stays free, so the user can flip
+    // either way afterward.
+    this.kind = option.category === 'atom' ? 'inline' : 'block';
     if (option.category === 'fitted') {
       let spec = fittedFormatById.get(option.value as FittedFormatId);
       if (spec) {
@@ -241,9 +239,6 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
 
   @action
   private setKind(kind: 'inline' | 'block') {
-    if (kind === 'block' && this.blockDisabled) {
-      return;
-    }
     this.kind = kind;
   }
 
@@ -258,16 +253,7 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
       data-test-markdown-embed-preview-pane
       ...attributes
     >
-      <div class='markdown-embed-preview-pane__viewport'>
-        <MarkdownEmbedPreview
-          @target={{@target}}
-          @format={{this.previewFormat}}
-          @sizeSpec={{this.sizeSpec}}
-          @kind={{this.kind}}
-        />
-      </div>
-
-      <div class='markdown-embed-preview-pane__controls'>
+      <div class='markdown-embed-preview-pane__header'>
         <BoxelSelect
           class='markdown-embed-preview-pane__format-select'
           @options={{this.formatOptions}}
@@ -280,6 +266,45 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         >
           <span data-test-format-option={{option.value}}>{{option.label}}</span>
         </BoxelSelect>
+      </div>
+
+      <div class='markdown-embed-preview-pane__viewport'>
+        <MarkdownEmbedPreview
+          @target={{@target}}
+          @format={{this.previewFormat}}
+          @sizeSpec={{this.sizeSpec}}
+          @kind={{this.kind}}
+          @showSurroundingText={{true}}
+        />
+      </div>
+
+      <footer class='markdown-embed-preview-pane__footer'>
+        <div
+          class='markdown-embed-preview-pane__toggle'
+          role='group'
+          aria-label='Embed placement'
+        >
+          <button
+            type='button'
+            class='markdown-embed-preview-pane__toggle-option
+              {{if (eq this.kind "inline") "is-active"}}'
+            aria-pressed='{{if (eq this.kind "inline") "true" "false"}}'
+            data-test-markdown-embed-preview-inline
+            {{on 'click' (fn this.setKind 'inline')}}
+          >
+            Inline
+          </button>
+          <button
+            type='button'
+            class='markdown-embed-preview-pane__toggle-option
+              {{if (eq this.kind "block") "is-active"}}'
+            aria-pressed='{{if (eq this.kind "block") "true" "false"}}'
+            data-test-markdown-embed-preview-block
+            {{on 'click' (fn this.setKind 'block')}}
+          >
+            Block
+          </button>
+        </div>
 
         {{#if this.showSizeInputs}}
           <div
@@ -306,36 +331,6 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
             />
           </div>
         {{/if}}
-      </div>
-
-      <footer class='markdown-embed-preview-pane__footer'>
-        <div
-          class='markdown-embed-preview-pane__toggle'
-          role='group'
-          aria-label='Embed placement'
-        >
-          <button
-            type='button'
-            class='markdown-embed-preview-pane__toggle-option
-              {{if (eq this.kind "inline") "is-active"}}'
-            aria-pressed='{{if (eq this.kind "inline") "true" "false"}}'
-            data-test-markdown-embed-preview-inline
-            {{on 'click' (fn this.setKind 'inline')}}
-          >
-            Inline
-          </button>
-          <button
-            type='button'
-            class='markdown-embed-preview-pane__toggle-option
-              {{if (eq this.kind "block") "is-active"}}'
-            aria-pressed='{{if (eq this.kind "block") "true" "false"}}'
-            disabled={{this.blockDisabled}}
-            data-test-markdown-embed-preview-block
-            {{on 'click' (fn this.setKind 'block')}}
-          >
-            Block
-          </button>
-        </div>
 
         <Button
           @kind='primary'
@@ -355,6 +350,12 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         min-height: 0;
         background-color: var(--boxel-light);
       }
+      .markdown-embed-preview-pane__header {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        padding: var(--boxel-sp) var(--boxel-sp) var(--boxel-sp-xs);
+      }
       .markdown-embed-preview-pane__viewport {
         flex: 1 1 auto;
         min-height: 0;
@@ -363,13 +364,6 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         justify-content: center;
         padding: var(--boxel-sp);
         overflow: auto;
-      }
-      .markdown-embed-preview-pane__controls {
-        flex: 0 0 auto;
-        display: flex;
-        align-items: center;
-        gap: var(--boxel-sp-xs);
-        padding: 0 var(--boxel-sp) var(--boxel-sp-xs);
       }
       .markdown-embed-preview-pane__format-select {
         flex: 1 1 auto;
@@ -417,10 +411,6 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         background-color: var(--boxel-light);
         color: var(--boxel-dark);
         box-shadow: var(--boxel-box-shadow);
-      }
-      .markdown-embed-preview-pane__toggle-option:disabled {
-        cursor: not-allowed;
-        opacity: 0.5;
       }
     </style>
   </template>

--- a/packages/host/app/components/markdown-embed-chooser/pane.gts
+++ b/packages/host/app/components/markdown-embed-chooser/pane.gts
@@ -159,13 +159,14 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
     return `Insert as ${this.categoryLabel}`;
   }
 
-  // Size specifier for the chosen format, independent of placement: `atom` /
-  // `embedded` keywords, the variant id for a named Fitted variant, and
-  // `w:<w> h:<h>` for Custom dimensions (per CS-11674).
+  // Size specifier for the chosen format. Atom is the default for inline
+  // placement, so an inline atom embed emits the size-less `:card[url]`;
+  // every other combination carries an explicit specifier so the rendered
+  // format matches the user's choice unambiguously.
   private get sizeSpecifier(): string | undefined {
     switch (this.category) {
       case 'atom':
-        return 'atom';
+        return this.kind === 'inline' ? undefined : 'atom';
       case 'embedded':
         return 'embedded';
       case 'fitted':
@@ -183,15 +184,26 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
 
   private get bfmString(): string {
     let url = this.args.target.id;
-    // Declare intent uniformly (kind + size); the BFM serializer in
-    // runtime-common owns whether a given kind carries the size. Today it drops
-    // the size for inline (so inline emits `:card[url]`); the BFM "all formats
-    // in both modes" ticket makes inline honor it, after which this chooser
-    // emits `:card[url | spec]` with no change here.
     return serializeBfmRef(this.args.refType, url, {
       kind: this.kind,
       size: this.sizeSpecifier,
     });
+  }
+
+  // An inline span carrying an embedded card has no intrinsic size to flow
+  // with the surrounding text, so the preview collapses. Surface a hint so
+  // the user understands why the preview is empty and how to recover.
+  private get placementWarning(): string | undefined {
+    if (this.kind !== 'inline') {
+      return undefined;
+    }
+    if (this.category === 'embedded') {
+      return 'Inline Embedded has no intrinsic width — pick a Fitted variant (or set custom W×H) to embed within a paragraph.';
+    }
+    if (this.category === 'custom' && !(this.width && this.height)) {
+      return 'Set both width and height to render this inline embed.';
+    }
+    return undefined;
   }
 
   @action
@@ -277,6 +289,16 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
           @showSurroundingText={{true}}
         />
       </div>
+
+      {{#if this.placementWarning}}
+        <p
+          class='markdown-embed-preview-pane__warning'
+          role='status'
+          data-test-markdown-embed-preview-warning
+        >
+          {{this.placementWarning}}
+        </p>
+      {{/if}}
 
       <footer class='markdown-embed-preview-pane__footer'>
         <div
@@ -364,6 +386,15 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         justify-content: center;
         padding: var(--boxel-sp);
         overflow: auto;
+      }
+      .markdown-embed-preview-pane__warning {
+        flex: 0 0 auto;
+        margin: 0 var(--boxel-sp) var(--boxel-sp-xxs);
+        padding: var(--boxel-sp-xxs) var(--boxel-sp-xs);
+        border-radius: var(--boxel-border-radius-sm);
+        background-color: var(--boxel-warning-100, var(--boxel-100));
+        color: var(--boxel-warning-700, var(--boxel-600));
+        font: var(--boxel-font-xs);
       }
       .markdown-embed-preview-pane__format-select {
         flex: 1 1 auto;

--- a/packages/host/app/components/markdown-embed-chooser/pane.gts
+++ b/packages/host/app/components/markdown-embed-chooser/pane.gts
@@ -1,0 +1,427 @@
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import {
+  BoxelInput,
+  BoxelSelect,
+  Button,
+} from '@cardstack/boxel-ui/components';
+import {
+  eq,
+  type FittedFormatId,
+  type FittedFormatSpec,
+  FITTED_FORMAT_SIZES,
+  fittedFormatById,
+} from '@cardstack/boxel-ui/helpers';
+
+import {
+  serializeBfmRef,
+  serializeBfmSizeSpec,
+  type BfmSizeSpec,
+} from '@cardstack/runtime-common/bfm-card-references';
+
+import type { CardDef, FileDef } from 'https://cardstack.com/base/card-api';
+
+import MarkdownEmbedPreview from './preview';
+
+type EmbedFormat = 'atom' | 'embedded' | 'fitted' | 'isolated';
+type FormatCategory = 'atom' | 'embedded' | 'fitted' | 'custom';
+type OptionValue = 'atom' | 'embedded' | FittedFormatId | 'custom';
+
+interface FormatOption {
+  value: OptionValue;
+  label: string;
+  category: FormatCategory;
+}
+
+// Flat dropdown list (no group headers): Atom, Embedded, every Fitted variant,
+// then Custom — matching the designer's dropdown. `Custom` is labelled
+// `Fitted - Custom size` for grouping but is its own CTA category.
+function buildFormatOptions(): FormatOption[] {
+  let options: FormatOption[] = [
+    { value: 'atom', label: 'Atom - Variable size', category: 'atom' },
+    {
+      value: 'embedded',
+      label: 'Embedded - Variable size',
+      category: 'embedded',
+    },
+  ];
+  for (let spec of FITTED_FORMAT_SIZES) {
+    options.push({
+      value: spec.id,
+      label: `Fitted - ${spec.title} - ${spec.width}x${spec.height}`,
+      category: 'fitted',
+    });
+  }
+  options.push({
+    value: 'custom',
+    label: 'Fitted - Custom size',
+    category: 'custom',
+  });
+  return options;
+}
+
+interface Signature {
+  Element: HTMLElement;
+  Args: {
+    // Resolved instance being previewed. Its `id` is the BFM ref URL.
+    target: CardDef | FileDef;
+    // Which BFM keyword to emit: `:card[...]` vs `:file[...]`.
+    refType: 'card' | 'file';
+    // Receives the serialized BFM directive when the CTA is clicked. The host
+    // owns actual cursor insertion (a later ticket).
+    onInsert: (bfm: string) => void;
+  };
+}
+
+// Right-hand companion to the mini choosers: a live preview plus the controls
+// that decide how a card/file embeds — format dropdown, always-on W×H inputs
+// for Fitted (with smart variant matching), an Inline/Block toggle, and a
+// dynamic "Insert as …" CTA.
+export default class MarkdownEmbedPreviewPane extends Component<Signature> {
+  private formatOptions: FormatOption[] = buildFormatOptions();
+
+  // Atom is the default on first selection; atom is inline-only (see below).
+  @tracked private selectedValue: OptionValue = 'atom';
+  @tracked private kind: 'inline' | 'block' = 'inline';
+  // Raw input strings so a partially-typed value (e.g. while clearing) doesn't
+  // throw away the user's keystrokes. `%` widths are preserved verbatim.
+  @tracked private widthInput = '';
+  @tracked private heightInput = '';
+
+  private get selectedOption(): FormatOption {
+    return (
+      this.formatOptions.find((o) => o.value === this.selectedValue) ??
+      this.formatOptions[0]
+    );
+  }
+
+  private get category(): FormatCategory {
+    return this.selectedOption.category;
+  }
+
+  // Atom has no `::card[... | atom]` block form, so block is disallowed while
+  // Atom is selected — the toggle is forced/locked to inline.
+  private get blockDisabled(): boolean {
+    return this.category === 'atom';
+  }
+
+  private get showSizeInputs(): boolean {
+    return this.category === 'fitted' || this.category === 'custom';
+  }
+
+  private get previewFormat(): EmbedFormat {
+    switch (this.category) {
+      case 'atom':
+        return 'atom';
+      case 'embedded':
+        return 'embedded';
+      default:
+        return 'fitted';
+    }
+  }
+
+  // px number, `%` string, or undefined for an unparseable/empty input.
+  private get width(): number | string | undefined {
+    let v = this.widthInput.trim();
+    if (/^\d+%$/.test(v)) return v;
+    if (/^\d+$/.test(v)) return parseInt(v, 10);
+    return undefined;
+  }
+
+  private get height(): number | undefined {
+    let v = this.heightInput.trim();
+    return /^\d+$/.test(v) ? parseInt(v, 10) : undefined;
+  }
+
+  private get sizeSpec(): BfmSizeSpec | undefined {
+    if (!this.showSizeInputs) {
+      return undefined;
+    }
+    return { format: 'fitted', width: this.width, height: this.height };
+  }
+
+  private get categoryLabel(): string {
+    switch (this.category) {
+      case 'atom':
+        return 'Atom';
+      case 'embedded':
+        return 'Embedded';
+      case 'custom':
+        return 'Custom';
+      case 'fitted':
+      default:
+        return 'Fitted';
+    }
+  }
+
+  private get ctaLabel(): string {
+    return `Insert as ${this.categoryLabel}`;
+  }
+
+  // Block size specifier: the variant id for a named Fitted variant, `embedded`
+  // for Embedded, and `w:<w> h:<h>` for Custom dimensions (per CS-11674).
+  private get blockSizeSpecifier(): string | undefined {
+    switch (this.category) {
+      case 'embedded':
+        return 'embedded';
+      case 'fitted':
+        return this.selectedValue;
+      case 'custom':
+        return serializeBfmSizeSpec({
+          format: 'fitted',
+          width: this.width,
+          height: this.height,
+        });
+      default:
+        return undefined;
+    }
+  }
+
+  private get bfmString(): string {
+    let url = this.args.target.id;
+    if (this.kind === 'inline') {
+      return serializeBfmRef(this.args.refType, url, { kind: 'inline' });
+    }
+    return serializeBfmRef(this.args.refType, url, {
+      kind: 'block',
+      size: this.blockSizeSpecifier,
+    });
+  }
+
+  @action
+  private selectFormat(option: FormatOption) {
+    this.selectedValue = option.value;
+    if (option.category === 'atom') {
+      this.kind = 'inline';
+    } else {
+      // A sized embed is meaningful as a block; the user can still toggle back
+      // to inline afterward.
+      this.kind = 'block';
+    }
+    if (option.category === 'fitted') {
+      let spec = fittedFormatById.get(option.value as FittedFormatId);
+      if (spec) {
+        this.widthInput = String(spec.width);
+        this.heightInput = String(spec.height);
+      }
+    }
+  }
+
+  // Bidirectional sync: editing either dimension re-points the dropdown to the
+  // matching named variant, or to Custom when nothing matches exactly.
+  private syncVariantFromSize() {
+    let w = this.width;
+    let h = this.height;
+    if (typeof w === 'number' && typeof h === 'number') {
+      let match = FITTED_FORMAT_SIZES.find(
+        (s: FittedFormatSpec) => s.width === w && s.height === h,
+      );
+      this.selectedValue = match ? match.id : 'custom';
+    } else {
+      this.selectedValue = 'custom';
+    }
+  }
+
+  @action
+  private setWidth(value: string) {
+    this.widthInput = value;
+    this.syncVariantFromSize();
+  }
+
+  @action
+  private setHeight(value: string) {
+    this.heightInput = value;
+    this.syncVariantFromSize();
+  }
+
+  @action
+  private setKind(kind: 'inline' | 'block') {
+    if (kind === 'block' && this.blockDisabled) {
+      return;
+    }
+    this.kind = kind;
+  }
+
+  @action
+  private insert() {
+    this.args.onInsert(this.bfmString);
+  }
+
+  <template>
+    <section
+      class='markdown-embed-preview-pane'
+      data-test-markdown-embed-preview-pane
+      ...attributes
+    >
+      <div class='markdown-embed-preview-pane__viewport'>
+        <MarkdownEmbedPreview
+          @target={{@target}}
+          @format={{this.previewFormat}}
+          @sizeSpec={{this.sizeSpec}}
+          @kind={{this.kind}}
+        />
+      </div>
+
+      <div class='markdown-embed-preview-pane__controls'>
+        <BoxelSelect
+          class='markdown-embed-preview-pane__format-select'
+          @options={{this.formatOptions}}
+          @selected={{this.selectedOption}}
+          @onChange={{this.selectFormat}}
+          @searchEnabled={{false}}
+          @matchTriggerWidth={{true}}
+          data-test-markdown-embed-preview-format-select
+          as |option|
+        >
+          <span data-test-format-option={{option.value}}>{{option.label}}</span>
+        </BoxelSelect>
+
+        {{#if this.showSizeInputs}}
+          <div
+            class='markdown-embed-preview-pane__size'
+            data-test-markdown-embed-preview-size
+          >
+            <BoxelInput
+              class='markdown-embed-preview-pane__size-input'
+              @value={{this.widthInput}}
+              @onInput={{this.setWidth}}
+              aria-label='Width'
+              data-test-markdown-embed-preview-width
+            />
+            <span
+              class='markdown-embed-preview-pane__size-x'
+              aria-hidden='true'
+            >×</span>
+            <BoxelInput
+              class='markdown-embed-preview-pane__size-input'
+              @value={{this.heightInput}}
+              @onInput={{this.setHeight}}
+              aria-label='Height'
+              data-test-markdown-embed-preview-height
+            />
+          </div>
+        {{/if}}
+      </div>
+
+      <footer class='markdown-embed-preview-pane__footer'>
+        <div
+          class='markdown-embed-preview-pane__toggle'
+          role='group'
+          aria-label='Embed placement'
+        >
+          <button
+            type='button'
+            class='markdown-embed-preview-pane__toggle-option
+              {{if (eq this.kind "inline") "is-active"}}'
+            aria-pressed='{{if (eq this.kind "inline") "true" "false"}}'
+            data-test-markdown-embed-preview-inline
+            {{on 'click' (fn this.setKind 'inline')}}
+          >
+            Inline
+          </button>
+          <button
+            type='button'
+            class='markdown-embed-preview-pane__toggle-option
+              {{if (eq this.kind "block") "is-active"}}'
+            aria-pressed='{{if (eq this.kind "block") "true" "false"}}'
+            disabled={{this.blockDisabled}}
+            data-test-markdown-embed-preview-block
+            {{on 'click' (fn this.setKind 'block')}}
+          >
+            Block
+          </button>
+        </div>
+
+        <Button
+          @kind='primary'
+          data-test-markdown-embed-preview-cta
+          {{on 'click' this.insert}}
+        >
+          {{this.ctaLabel}}
+        </Button>
+      </footer>
+    </section>
+    <style scoped>
+      .markdown-embed-preview-pane {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        background-color: var(--boxel-light);
+      }
+      .markdown-embed-preview-pane__viewport {
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: var(--boxel-sp);
+        overflow: auto;
+      }
+      .markdown-embed-preview-pane__controls {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp-xs);
+        padding: 0 var(--boxel-sp) var(--boxel-sp-xs);
+      }
+      .markdown-embed-preview-pane__format-select {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .markdown-embed-preview-pane__size {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp-5xs);
+      }
+      .markdown-embed-preview-pane__size-input {
+        width: 4rem;
+        text-align: center;
+      }
+      .markdown-embed-preview-pane__size-x {
+        color: var(--boxel-450);
+      }
+      .markdown-embed-preview-pane__footer {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp-xs) var(--boxel-sp) var(--boxel-sp);
+      }
+      .markdown-embed-preview-pane__toggle {
+        display: inline-flex;
+        padding: 2px;
+        border-radius: 999px;
+        background-color: var(--boxel-light-200);
+      }
+      .markdown-embed-preview-pane__toggle-option {
+        appearance: none;
+        border: none;
+        background: transparent;
+        padding: var(--boxel-sp-5xs) var(--boxel-sp-sm);
+        border-radius: 999px;
+        font: var(--boxel-font-sm);
+        font-weight: 600;
+        color: var(--boxel-450);
+        cursor: pointer;
+      }
+      .markdown-embed-preview-pane__toggle-option.is-active {
+        background-color: var(--boxel-light);
+        color: var(--boxel-dark);
+        box-shadow: var(--boxel-box-shadow);
+      }
+      .markdown-embed-preview-pane__toggle-option:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+      }
+    </style>
+  </template>
+}

--- a/packages/host/app/components/markdown-embed-chooser/pane.gts
+++ b/packages/host/app/components/markdown-embed-chooser/pane.gts
@@ -1,4 +1,3 @@
-import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 
@@ -11,12 +10,12 @@ import {
   Button,
 } from '@cardstack/boxel-ui/components';
 import {
-  eq,
   type FittedFormatId,
   type FittedFormatSpec,
   FITTED_FORMAT_SIZES,
   fittedFormatById,
 } from '@cardstack/boxel-ui/helpers';
+import { IconX } from '@cardstack/boxel-ui/icons';
 
 import {
   serializeBfmRef,
@@ -26,40 +25,61 @@ import {
 
 import type { CardDef, FileDef } from 'https://cardstack.com/base/card-api';
 
+import PlacementToggle from './placement-toggle';
 import MarkdownEmbedPreview from './preview';
 
 type EmbedFormat = 'atom' | 'embedded' | 'fitted' | 'isolated';
-type FormatCategory = 'atom' | 'embedded' | 'fitted' | 'custom';
-type OptionValue = 'atom' | 'embedded' | FittedFormatId | 'custom';
+type FormatCategory = 'atom' | 'embedded' | 'fitted' | 'isolated' | 'custom';
+type OptionValue = 'atom' | 'embedded' | 'isolated' | FittedFormatId | 'custom';
 
 interface FormatOption {
   value: OptionValue;
-  label: string;
+  formatLabel: string;
+  sizeLabel: string;
   category: FormatCategory;
+  dividerAfter?: boolean;
 }
 
-// Flat dropdown list (no group headers): Atom, Embedded, every Fitted variant,
-// then Custom — matching the designer's dropdown. `Custom` is labelled
-// `Fitted - Custom size` for grouping but is its own CTA category.
+// Flat dropdown list (no group headers): Atom, Embedded, Isolated, every
+// Fitted variant, then Custom — matching the designer's dropdown. `Custom`
+// is labelled `Fitted - Custom size` for grouping but is its own CTA
+// category. Every option works in both inline and block placement.
 function buildFormatOptions(): FormatOption[] {
   let options: FormatOption[] = [
-    { value: 'atom', label: 'Atom - Variable size', category: 'atom' },
+    {
+      value: 'atom',
+      formatLabel: 'Atom',
+      sizeLabel: 'Variable size',
+      category: 'atom',
+      dividerAfter: true,
+    },
     {
       value: 'embedded',
-      label: 'Embedded - Variable size',
+      formatLabel: 'Embedded',
+      sizeLabel: 'Variable size',
       category: 'embedded',
+      dividerAfter: true,
+    },
+    {
+      value: 'isolated',
+      formatLabel: 'Isolated',
+      sizeLabel: 'Variable size',
+      category: 'isolated',
+      dividerAfter: true,
     },
   ];
   for (let spec of FITTED_FORMAT_SIZES) {
     options.push({
       value: spec.id,
-      label: `Fitted - ${spec.title} - ${spec.width}x${spec.height}`,
+      formatLabel: 'Fitted',
+      sizeLabel: `${spec.title} (${spec.width}x${spec.height})`,
       category: 'fitted',
     });
   }
   options.push({
     value: 'custom',
-    label: 'Fitted - Custom size',
+    formatLabel: 'Fitted',
+    sizeLabel: 'Custom size',
     category: 'custom',
   });
   return options;
@@ -116,6 +136,8 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         return 'atom';
       case 'embedded':
         return 'embedded';
+      case 'isolated':
+        return 'isolated';
       default:
         return 'fitted';
     }
@@ -147,6 +169,8 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         return 'Atom';
       case 'embedded':
         return 'Embedded';
+      case 'isolated':
+        return 'Isolated';
       case 'custom':
         return 'Custom';
       case 'fitted':
@@ -169,6 +193,8 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         return this.kind === 'inline' ? undefined : 'atom';
       case 'embedded':
         return 'embedded';
+      case 'isolated':
+        return 'isolated';
       case 'fitted':
         return this.selectedValue;
       case 'custom':
@@ -188,22 +214,6 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
       kind: this.kind,
       size: this.sizeSpecifier,
     });
-  }
-
-  // An inline span carrying an embedded card has no intrinsic size to flow
-  // with the surrounding text, so the preview collapses. Surface a hint so
-  // the user understands why the preview is empty and how to recover.
-  private get placementWarning(): string | undefined {
-    if (this.kind !== 'inline') {
-      return undefined;
-    }
-    if (this.category === 'embedded') {
-      return 'Inline Embedded has no intrinsic width — pick a Fitted variant (or set custom W×H) to embed within a paragraph.';
-    }
-    if (this.category === 'custom' && !(this.width && this.height)) {
-      return 'Set both width and height to render this inline embed.';
-    }
-    return undefined;
   }
 
   @action
@@ -268,6 +278,7 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
       <div class='markdown-embed-preview-pane__header'>
         <BoxelSelect
           class='markdown-embed-preview-pane__format-select'
+          @dropdownClass='markdown-embed-preview-pane__format-dropdown'
           @options={{this.formatOptions}}
           @selected={{this.selectedOption}}
           @onChange={{this.selectFormat}}
@@ -276,7 +287,17 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
           data-test-markdown-embed-preview-format-select
           as |option|
         >
-          <span data-test-format-option={{option.value}}>{{option.label}}</span>
+          <span
+            class='markdown-embed-preview-pane__format-option
+              {{if option.dividerAfter "has-divider"}}'
+            data-test-format-option={{option.value}}
+          >
+            <span
+              class='markdown-embed-preview-pane__format-option-name'
+            >{{option.formatLabel}}</span>
+            -
+            <span>{{option.sizeLabel}}</span>
+          </span>
         </BoxelSelect>
       </div>
 
@@ -290,43 +311,8 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         />
       </div>
 
-      {{#if this.placementWarning}}
-        <p
-          class='markdown-embed-preview-pane__warning'
-          role='status'
-          data-test-markdown-embed-preview-warning
-        >
-          {{this.placementWarning}}
-        </p>
-      {{/if}}
-
       <footer class='markdown-embed-preview-pane__footer'>
-        <div
-          class='markdown-embed-preview-pane__toggle'
-          role='group'
-          aria-label='Embed placement'
-        >
-          <button
-            type='button'
-            class='markdown-embed-preview-pane__toggle-option
-              {{if (eq this.kind "inline") "is-active"}}'
-            aria-pressed='{{if (eq this.kind "inline") "true" "false"}}'
-            data-test-markdown-embed-preview-inline
-            {{on 'click' (fn this.setKind 'inline')}}
-          >
-            Inline
-          </button>
-          <button
-            type='button'
-            class='markdown-embed-preview-pane__toggle-option
-              {{if (eq this.kind "block") "is-active"}}'
-            aria-pressed='{{if (eq this.kind "block") "true" "false"}}'
-            data-test-markdown-embed-preview-block
-            {{on 'click' (fn this.setKind 'block')}}
-          >
-            Block
-          </button>
-        </div>
+        <PlacementToggle @selected={{this.kind}} @onChange={{this.setKind}} />
 
         {{#if this.showSizeInputs}}
           <div
@@ -340,10 +326,10 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
               aria-label='Width'
               data-test-markdown-embed-preview-width
             />
-            <span
+            <IconX
               class='markdown-embed-preview-pane__size-x'
               aria-hidden='true'
-            >×</span>
+            />
             <BoxelInput
               class='markdown-embed-preview-pane__size-input'
               @value={{this.heightInput}}
@@ -356,6 +342,8 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
 
         <Button
           @kind='primary'
+          @size='small'
+          class='markdown-embed-preview-pane__cta'
           data-test-markdown-embed-preview-cta
           {{on 'click' this.insert}}
         >
@@ -363,6 +351,37 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         </Button>
       </footer>
     </section>
+    {{! template-lint-disable require-scoped-style }}
+    <style>
+      /* The divider sits in the gap *between* options so the row's hover /
+         selected background (painted inside the <li>'s border-box) can't
+         engulf it. The dropdown is rendered in the basic-dropdown wormhole,
+         so :deep() — which requires a scoped ancestor — can't reach it;
+         :global() with this component's unique class names is the correct
+         escape hatch. The trigger has no .ember-power-select-option
+         ancestor, so the divider is automatically suppressed there. */
+      .markdown-embed-preview-pane__format-dropdown
+        .ember-power-select-option:has(
+          .markdown-embed-preview-pane__format-option.has-divider
+        ) {
+        position: relative;
+        margin-bottom: var(--boxel-sp-xs);
+      }
+
+      .markdown-embed-preview-pane__format-dropdown
+        .ember-power-select-option:has(
+          .markdown-embed-preview-pane__format-option.has-divider
+        )::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: calc(-1 * var(--boxel-sp-xs) / 2 - 0.5px);
+        height: 1px;
+        background-color: var(--boxel-border-color);
+        pointer-events: none;
+      }
+    </style>
     <style scoped>
       .markdown-embed-preview-pane {
         display: flex;
@@ -376,7 +395,8 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         flex: 0 0 auto;
         display: flex;
         align-items: center;
-        padding: var(--boxel-sp) var(--boxel-sp) var(--boxel-sp-xs);
+        justify-content: center;
+        padding: var(--boxel-sp-sm) var(--boxel-sp) var(--boxel-sp-xs);
       }
       .markdown-embed-preview-pane__viewport {
         flex: 1 1 auto;
@@ -387,31 +407,38 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         padding: var(--boxel-sp);
         overflow: auto;
       }
-      .markdown-embed-preview-pane__warning {
-        flex: 0 0 auto;
-        margin: 0 var(--boxel-sp) var(--boxel-sp-xxs);
-        padding: var(--boxel-sp-xxs) var(--boxel-sp-xs);
-        border-radius: var(--boxel-border-radius-sm);
-        background-color: var(--boxel-warning-100, var(--boxel-100));
-        color: var(--boxel-warning-700, var(--boxel-600));
-        font: var(--boxel-font-xs);
-      }
       .markdown-embed-preview-pane__format-select {
         flex: 1 1 auto;
         min-width: 0;
+        max-width: 330px;
+        --boxel-select-trigger-padding: var(--boxel-sp-2xs);
+      }
+      .markdown-embed-preview-pane__format-option-name {
+        font-weight: 500;
       }
       .markdown-embed-preview-pane__size {
         flex: 0 0 auto;
         display: flex;
         align-items: center;
-        gap: var(--boxel-sp-5xs);
+        gap: var(--boxel-sp-3xs);
+        --boxel-input-icon-size: fit-content;
       }
       .markdown-embed-preview-pane__size-input {
-        width: 4rem;
+        --boxel-input-height: 30px;
+        --boxel-input-width: 46px;
+        padding: var(--boxel-sp-4xs);
         text-align: center;
       }
+      .markdown-embed-preview-pane__size-input :deep(.boxel-input) {
+        padding: 0;
+        text-align: center;
+        font: 600 var(--boxel-font-sm);
+      }
       .markdown-embed-preview-pane__size-x {
-        color: var(--boxel-450);
+        width: 0.5rem;
+        height: 0.5rem;
+        flex: 0 0 auto;
+        --icon-color: var(--boxel-dark);
       }
       .markdown-embed-preview-pane__footer {
         flex: 0 0 auto;
@@ -421,27 +448,9 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
         gap: var(--boxel-sp-xs);
         padding: var(--boxel-sp-xs) var(--boxel-sp) var(--boxel-sp);
       }
-      .markdown-embed-preview-pane__toggle {
-        display: inline-flex;
-        padding: 2px;
-        border-radius: 999px;
-        background-color: var(--boxel-light-200);
-      }
-      .markdown-embed-preview-pane__toggle-option {
-        appearance: none;
-        border: none;
-        background: transparent;
-        padding: var(--boxel-sp-5xs) var(--boxel-sp-sm);
-        border-radius: 999px;
-        font: var(--boxel-font-sm);
+      .markdown-embed-preview-pane__cta {
+        --boxel-button-padding: var(--boxel-sp-2xs) var(--boxel-sp-sm);
         font-weight: 600;
-        color: var(--boxel-450);
-        cursor: pointer;
-      }
-      .markdown-embed-preview-pane__toggle-option.is-active {
-        background-color: var(--boxel-light);
-        color: var(--boxel-dark);
-        box-shadow: var(--boxel-box-shadow);
       }
     </style>
   </template>

--- a/packages/host/app/components/markdown-embed-chooser/placement-toggle.gts
+++ b/packages/host/app/components/markdown-embed-chooser/placement-toggle.gts
@@ -1,0 +1,84 @@
+import type { TOC } from '@ember/component/template-only';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+
+import { eq } from '@cardstack/boxel-ui/helpers';
+
+interface Signature {
+  Element: HTMLDivElement;
+  Args: {
+    selected: 'inline' | 'block';
+    onChange: (kind: 'inline' | 'block') => void;
+    disabled?: boolean;
+  };
+}
+
+// Two-option segmented pill for choosing inline vs block placement. A white
+// pill-shaped track with a hairline border holds two equal segments; the
+// selected one is filled grey and clips to the rounded edge (the track's
+// `overflow: hidden` rounds the fill). Used by the embed chooser's preview
+// pane footer.
+const PlacementToggle: TOC<Signature> = <template>
+  <div
+    class='placement-toggle'
+    role='group'
+    aria-label='Embed placement'
+    ...attributes
+  >
+    <button
+      type='button'
+      class='placement-toggle__option
+        {{if (eq @selected "inline") "is-active"}}'
+      aria-pressed='{{if (eq @selected "inline") "true" "false"}}'
+      disabled={{@disabled}}
+      data-test-markdown-embed-preview-inline
+      {{on 'click' (fn @onChange 'inline')}}
+    >
+      Inline
+    </button>
+    <button
+      type='button'
+      class='placement-toggle__option {{if (eq @selected "block") "is-active"}}'
+      aria-pressed='{{if (eq @selected "block") "true" "false"}}'
+      disabled={{@disabled}}
+      data-test-markdown-embed-preview-block
+      {{on 'click' (fn @onChange 'block')}}
+    >
+      Block
+    </button>
+  </div>
+  <style scoped>
+    .placement-toggle {
+      display: inline-flex;
+      border: 1px solid var(--boxel-border-color);
+      border-radius: 999px;
+      background-color: var(--boxel-light);
+      overflow: hidden;
+    }
+    .placement-toggle__option {
+      appearance: none;
+      border: none;
+      background: transparent;
+      padding: var(--boxel-sp-5xs) var(--boxel-sp);
+      font: 600 var(--boxel-font-sm);
+      color: var(--boxel-dark);
+      cursor: pointer;
+      line-height: 1.2;
+      min-width: 3.5rem;
+      flex: 1;
+    }
+    .placement-toggle__option.is-active {
+      background-color: var(--boxel-200);
+    }
+    .placement-toggle__option:focus-visible {
+      outline: 2px solid var(--boxel-highlight);
+      outline-offset: -2px;
+    }
+    .placement-toggle__option:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+  </style>
+</template>;
+
+export default PlacementToggle;

--- a/packages/host/app/components/markdown-embed-chooser/preview/index.gts
+++ b/packages/host/app/components/markdown-embed-chooser/preview/index.gts
@@ -1,3 +1,4 @@
+import type { TOC } from '@ember/component/template-only';
 import { htmlSafe } from '@ember/template';
 
 import Component from '@glimmer/component';
@@ -19,6 +20,68 @@ import type {
 
 type EmbedFormat = 'atom' | 'embedded' | 'fitted' | 'isolated';
 
+interface EmbedSignature {
+  Element: HTMLElement;
+  Args: {
+    target: CardDef | FileDef;
+    format: Format;
+    kind: 'inline' | 'block';
+    sizeStyle?: ReturnType<typeof htmlSafe>;
+  };
+}
+
+// The embed itself: inline placement flows within text (`<span>`), block gives
+// it its own line (`<div>`). Both render through the same CardRenderer.
+const Embed: TOC<EmbedSignature> = <template>
+  {{#if (eq @kind 'inline')}}
+    <span
+      class='markdown-embed-preview markdown-embed-preview--inline
+        {{if @sizeStyle "markdown-embed-preview--fitted"}}'
+      style={{@sizeStyle}}
+      data-test-markdown-embed-preview
+      data-test-markdown-embed-preview-format={{@format}}
+      ...attributes
+    >
+      <CardRenderer
+        @card={{@target}}
+        @format={{@format}}
+        @displayContainer={{false}}
+      />
+    </span>
+  {{else}}
+    <div
+      class='markdown-embed-preview markdown-embed-preview--block
+        {{if @sizeStyle "markdown-embed-preview--fitted"}}'
+      style={{@sizeStyle}}
+      data-test-markdown-embed-preview
+      data-test-markdown-embed-preview-format={{@format}}
+      ...attributes
+    >
+      <CardRenderer
+        @card={{@target}}
+        @format={{@format}}
+        @displayContainer={{false}}
+      />
+    </div>
+  {{/if}}
+  <style scoped>
+    .markdown-embed-preview {
+      max-width: 100%;
+    }
+    .markdown-embed-preview--inline {
+      display: inline-flex;
+      vertical-align: middle;
+    }
+    .markdown-embed-preview--block {
+      display: block;
+    }
+    .markdown-embed-preview--fitted {
+      border-radius: var(--boxel-border-radius);
+      overflow: hidden;
+    }
+  </style>
+</template>;
+
 interface Signature {
   Element: HTMLElement;
   Args: {
@@ -37,13 +100,18 @@ interface Signature {
     // gives it its own line (`<div>`). Does NOT change the render format.
     // Default: 'block'.
     kind?: 'inline' | 'block';
+    // When true, the embed is shown inside placeholder document text so the
+    // viewer sees how it sits in a real markdown doc: an inline embed flows
+    // within the paragraph, a block embed breaks onto its own line. Off by
+    // default so format galleries / overlays can render the bare embed.
+    showSurroundingText?: boolean;
   };
 }
 
 // Renders a resolved card/file in the requested format + size, matching how
-// `rendered-markdown.gts` paints the eventual document slot. The chooser's
-// preview pane wraps this with format/size controls; later tickets reuse it in
-// the Edit modal and inline overlay.
+// `rendered-markdown.gts` paints the eventual document slot. With
+// `@showSurroundingText` it wraps the embed in skeleton document text to
+// preview placement in context; the chooser's preview pane turns this on.
 export default class MarkdownEmbedPreview extends Component<Signature> {
   private get kind(): 'inline' | 'block' {
     return this.args.kind ?? 'block';
@@ -72,51 +140,93 @@ export default class MarkdownEmbedPreview extends Component<Signature> {
   }
 
   <template>
-    {{#if (eq this.kind 'inline')}}
-      <span
-        class='markdown-embed-preview markdown-embed-preview--inline
-          {{if this.sizeStyle "markdown-embed-preview--fitted"}}'
-        style={{this.sizeStyle}}
-        data-test-markdown-embed-preview
-        data-test-markdown-embed-preview-format={{this.renderFormat}}
-        ...attributes
-      >
-        <CardRenderer
-          @card={{@target}}
-          @format={{this.renderFormat}}
-          @displayContainer={{false}}
-        />
-      </span>
-    {{else}}
-      <div
-        class='markdown-embed-preview markdown-embed-preview--block
-          {{if this.sizeStyle "markdown-embed-preview--fitted"}}'
-        style={{this.sizeStyle}}
-        data-test-markdown-embed-preview
-        data-test-markdown-embed-preview-format={{this.renderFormat}}
-        ...attributes
-      >
-        <CardRenderer
-          @card={{@target}}
-          @format={{this.renderFormat}}
-          @displayContainer={{false}}
-        />
+    {{#if @showSurroundingText}}
+      <div class='markdown-embed-preview-doc' ...attributes>
+        <span
+          class='markdown-embed-preview-doc__line'
+          aria-hidden='true'
+        ></span>
+        <span
+          class='markdown-embed-preview-doc__line'
+          aria-hidden='true'
+        ></span>
+        <p class='markdown-embed-preview-doc__para'>
+          <span
+            class='markdown-embed-preview-doc__word'
+            aria-hidden='true'
+          ></span>
+          <span
+            class='markdown-embed-preview-doc__word is-sm'
+            aria-hidden='true'
+          ></span>
+          <Embed
+            @target={{@target}}
+            @format={{this.renderFormat}}
+            @kind={{this.kind}}
+            @sizeStyle={{this.sizeStyle}}
+          />
+          <span
+            class='markdown-embed-preview-doc__word is-lg'
+            aria-hidden='true'
+          ></span>
+          <span
+            class='markdown-embed-preview-doc__word'
+            aria-hidden='true'
+          ></span>
+        </p>
+        <span
+          class='markdown-embed-preview-doc__line'
+          aria-hidden='true'
+        ></span>
+        <span
+          class='markdown-embed-preview-doc__line is-short'
+          aria-hidden='true'
+        ></span>
       </div>
+    {{else}}
+      <Embed
+        @target={{@target}}
+        @format={{this.renderFormat}}
+        @kind={{this.kind}}
+        @sizeStyle={{this.sizeStyle}}
+        ...attributes
+      />
     {{/if}}
     <style scoped>
-      .markdown-embed-preview {
-        max-width: 100%;
+      .markdown-embed-preview-doc {
+        width: 100%;
+        max-width: 32rem;
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-sm);
       }
-      .markdown-embed-preview--inline {
-        display: inline-flex;
+      .markdown-embed-preview-doc__line {
+        display: block;
+        height: 0.75rem;
+        border-radius: var(--boxel-border-radius-sm);
+        background-color: var(--boxel-200);
+      }
+      .markdown-embed-preview-doc__line.is-short {
+        width: 60%;
+      }
+      .markdown-embed-preview-doc__para {
+        margin: 0;
+        line-height: 2.2;
+      }
+      .markdown-embed-preview-doc__word {
+        display: inline-block;
+        width: 5rem;
+        height: 0.75rem;
+        margin: 0 var(--boxel-sp-5xs);
+        border-radius: var(--boxel-border-radius-sm);
+        background-color: var(--boxel-200);
         vertical-align: middle;
       }
-      .markdown-embed-preview--block {
-        display: block;
+      .markdown-embed-preview-doc__word.is-sm {
+        width: 3rem;
       }
-      .markdown-embed-preview--fitted {
-        border-radius: var(--boxel-border-radius);
-        overflow: hidden;
+      .markdown-embed-preview-doc__word.is-lg {
+        width: 7rem;
       }
     </style>
   </template>

--- a/packages/host/app/components/markdown-embed-chooser/preview/index.gts
+++ b/packages/host/app/components/markdown-embed-chooser/preview/index.gts
@@ -3,7 +3,7 @@ import { htmlSafe } from '@ember/template';
 
 import Component from '@glimmer/component';
 
-import { eq } from '@cardstack/boxel-ui/helpers';
+import { eq, not } from '@cardstack/boxel-ui/helpers';
 
 import {
   bfmRefFormatAndSize,
@@ -44,7 +44,8 @@ const Embed: TOC<EmbedSignature> = <template>
           "markdown-embed-preview--inline"
           "markdown-embed-preview--inline-embed"
         }}
-        {{if @sizeStyle "markdown-embed-preview--fitted"}}'
+        {{if @sizeStyle "markdown-embed-preview--fitted"}}
+        {{if (not (eq @format "atom")) "markdown-embed-preview--card-frame"}}'
       style={{@sizeStyle}}
       data-test-markdown-embed-preview
       data-test-markdown-embed-preview-format={{@format}}
@@ -59,7 +60,8 @@ const Embed: TOC<EmbedSignature> = <template>
   {{else}}
     <div
       class='markdown-embed-preview markdown-embed-preview--block
-        {{if @sizeStyle "markdown-embed-preview--fitted"}}'
+        {{if @sizeStyle "markdown-embed-preview--fitted"}}
+        {{if (not (eq @format "atom")) "markdown-embed-preview--card-frame"}}'
       style={{@sizeStyle}}
       data-test-markdown-embed-preview
       data-test-markdown-embed-preview-format={{@format}}
@@ -89,6 +91,15 @@ const Embed: TOC<EmbedSignature> = <template>
     }
     .markdown-embed-preview--fitted {
       border-radius: var(--boxel-border-radius);
+      overflow: hidden;
+    }
+    /* Frame the embed so reviewers can see where the card body sits against
+       the pane background — applied for embedded/isolated/fitted, never atom
+       (which is its own pill shape). */
+    .markdown-embed-preview--card-frame {
+      border: 1px solid var(--boxel-300);
+      border-radius: var(--boxel-border-radius);
+      background-color: var(--boxel-light);
       overflow: hidden;
     }
   </style>

--- a/packages/host/app/components/markdown-embed-chooser/preview/index.gts
+++ b/packages/host/app/components/markdown-embed-chooser/preview/index.gts
@@ -6,7 +6,7 @@ import Component from '@glimmer/component';
 import { eq } from '@cardstack/boxel-ui/helpers';
 
 import {
-  bfmBlockFormatAndSize,
+  bfmRefFormatAndSize,
   type BfmSizeSpec,
 } from '@cardstack/runtime-common/bfm-card-references';
 
@@ -129,7 +129,7 @@ export default class MarkdownEmbedPreview extends Component<Signature> {
       return undefined;
     }
     let { width, height } = this.args.sizeSpec ?? { format: 'fitted' };
-    let { sizeStyle } = bfmBlockFormatAndSize(
+    let { sizeStyle } = bfmRefFormatAndSize(
       'fitted',
       width === undefined ? undefined : String(width),
       height === undefined ? undefined : String(height),

--- a/packages/host/app/components/markdown-embed-chooser/preview/index.gts
+++ b/packages/host/app/components/markdown-embed-chooser/preview/index.gts
@@ -1,0 +1,123 @@
+import { htmlSafe } from '@ember/template';
+
+import Component from '@glimmer/component';
+
+import { eq } from '@cardstack/boxel-ui/helpers';
+
+import {
+  bfmBlockFormatAndSize,
+  type BfmSizeSpec,
+} from '@cardstack/runtime-common/bfm-card-references';
+
+import CardRenderer from '@cardstack/host/components/card-renderer';
+
+import type {
+  CardDef,
+  FileDef,
+  Format,
+} from 'https://cardstack.com/base/card-api';
+
+type EmbedFormat = 'atom' | 'embedded' | 'fitted' | 'isolated';
+
+interface Signature {
+  Element: HTMLElement;
+  Args: {
+    // Already-resolved instance to preview. Both card refs (`:card[...]`) and
+    // file refs (`:file[...]`) render through the same CardRenderer, so the
+    // caller resolves the URL and hands us the instance — this component loads
+    // nothing.
+    target: CardDef | FileDef;
+    // Render format. `fitted` consults `@sizeSpec` for its width/height;
+    // atom/embedded/isolated ignore it.
+    format: EmbedFormat;
+    // Width/height for fitted renders. Width may be a px number or a `%`
+    // string; height is a px number. Ignored unless `@format` is 'fitted'.
+    sizeSpec?: BfmSizeSpec;
+    // Placement only: inline flows the preview within text (`<span>`); block
+    // gives it its own line (`<div>`). Does NOT change the render format.
+    // Default: 'block'.
+    kind?: 'inline' | 'block';
+  };
+}
+
+// Renders a resolved card/file in the requested format + size, matching how
+// `rendered-markdown.gts` paints the eventual document slot. The chooser's
+// preview pane wraps this with format/size controls; later tickets reuse it in
+// the Edit modal and inline overlay.
+export default class MarkdownEmbedPreview extends Component<Signature> {
+  private get kind(): 'inline' | 'block' {
+    return this.args.kind ?? 'block';
+  }
+
+  private get renderFormat(): Format {
+    return this.args.format;
+  }
+
+  // Fitted slots carry an inline width/height plus `overflow: hidden` so the
+  // instance occupies the requested footprint — derived through the same helper
+  // the live markdown renderer uses (`rendered-markdown.gts`).
+  private get sizeStyle(): ReturnType<typeof htmlSafe> | undefined {
+    if (this.args.format !== 'fitted') {
+      return undefined;
+    }
+    let { width, height } = this.args.sizeSpec ?? { format: 'fitted' };
+    let { sizeStyle } = bfmBlockFormatAndSize(
+      'fitted',
+      width === undefined ? undefined : String(width),
+      height === undefined ? undefined : String(height),
+    );
+    return htmlSafe(
+      sizeStyle ? `${sizeStyle}; overflow: hidden` : 'overflow: hidden',
+    );
+  }
+
+  <template>
+    {{#if (eq this.kind 'inline')}}
+      <span
+        class='markdown-embed-preview markdown-embed-preview--inline
+          {{if this.sizeStyle "markdown-embed-preview--fitted"}}'
+        style={{this.sizeStyle}}
+        data-test-markdown-embed-preview
+        data-test-markdown-embed-preview-format={{this.renderFormat}}
+        ...attributes
+      >
+        <CardRenderer
+          @card={{@target}}
+          @format={{this.renderFormat}}
+          @displayContainer={{false}}
+        />
+      </span>
+    {{else}}
+      <div
+        class='markdown-embed-preview markdown-embed-preview--block
+          {{if this.sizeStyle "markdown-embed-preview--fitted"}}'
+        style={{this.sizeStyle}}
+        data-test-markdown-embed-preview
+        data-test-markdown-embed-preview-format={{this.renderFormat}}
+        ...attributes
+      >
+        <CardRenderer
+          @card={{@target}}
+          @format={{this.renderFormat}}
+          @displayContainer={{false}}
+        />
+      </div>
+    {{/if}}
+    <style scoped>
+      .markdown-embed-preview {
+        max-width: 100%;
+      }
+      .markdown-embed-preview--inline {
+        display: inline-flex;
+        vertical-align: middle;
+      }
+      .markdown-embed-preview--block {
+        display: block;
+      }
+      .markdown-embed-preview--fitted {
+        border-radius: var(--boxel-border-radius);
+        overflow: hidden;
+      }
+    </style>
+  </template>
+}

--- a/packages/host/app/components/markdown-embed-chooser/preview/index.gts
+++ b/packages/host/app/components/markdown-embed-chooser/preview/index.gts
@@ -31,11 +31,19 @@ interface EmbedSignature {
 }
 
 // The embed itself: inline placement flows within text (`<span>`), block gives
-// it its own line (`<div>`). Both render through the same CardRenderer.
+// it its own line (`<div>`). Both render through the same CardRenderer. Inline
+// atom uses `inline-flex` to align with text baseline; every other inline
+// format uses `inline-block` so the card occupies its intrinsic (or fitted)
+// width — mirrors the live markdown renderer's `--inline-embed` slot.
 const Embed: TOC<EmbedSignature> = <template>
   {{#if (eq @kind 'inline')}}
     <span
-      class='markdown-embed-preview markdown-embed-preview--inline
+      class='markdown-embed-preview
+        {{if
+          (eq @format "atom")
+          "markdown-embed-preview--inline"
+          "markdown-embed-preview--inline-embed"
+        }}
         {{if @sizeStyle "markdown-embed-preview--fitted"}}'
       style={{@sizeStyle}}
       data-test-markdown-embed-preview
@@ -70,6 +78,10 @@ const Embed: TOC<EmbedSignature> = <template>
     }
     .markdown-embed-preview--inline {
       display: inline-flex;
+      vertical-align: middle;
+    }
+    .markdown-embed-preview--inline-embed {
+      display: inline-block;
       vertical-align: middle;
     }
     .markdown-embed-preview--block {
@@ -123,20 +135,36 @@ export default class MarkdownEmbedPreview extends Component<Signature> {
 
   // Fitted slots carry an inline width/height plus `overflow: hidden` so the
   // instance occupies the requested footprint — derived through the same helper
-  // the live markdown renderer uses (`rendered-markdown.gts`).
+  // the live markdown renderer uses (`rendered-markdown.gts`). Inline embedded
+  // and isolated have no intrinsic inline width: the default template's
+  // `width/height: 100%` resolves against the inline-block wrapper, which is
+  // itself shrink-wrapping, and the box collapses. Give the wrapper a definite
+  // footprint that matches the live renderer's loading placeholders so the
+  // preview shows a real card body.
   private get sizeStyle(): ReturnType<typeof htmlSafe> | undefined {
-    if (this.args.format !== 'fitted') {
-      return undefined;
+    let { format } = this.args;
+    if (format === 'fitted') {
+      let { width, height } = this.args.sizeSpec ?? { format: 'fitted' };
+      let { sizeStyle } = bfmRefFormatAndSize(
+        'fitted',
+        width === undefined ? undefined : String(width),
+        height === undefined ? undefined : String(height),
+      );
+      return htmlSafe(
+        sizeStyle ? `${sizeStyle}; overflow: hidden` : 'overflow: hidden',
+      );
     }
-    let { width, height } = this.args.sizeSpec ?? { format: 'fitted' };
-    let { sizeStyle } = bfmRefFormatAndSize(
-      'fitted',
-      width === undefined ? undefined : String(width),
-      height === undefined ? undefined : String(height),
-    );
-    return htmlSafe(
-      sizeStyle ? `${sizeStyle}; overflow: hidden` : 'overflow: hidden',
-    );
+    if (
+      this.kind === 'inline' &&
+      (format === 'embedded' || format === 'isolated')
+    ) {
+      let footprint =
+        format === 'isolated'
+          ? 'width: 24rem; height: 18.75rem'
+          : 'width: 16rem; height: 9.375rem';
+      return htmlSafe(`${footprint}; overflow: hidden`);
+    }
+    return undefined;
   }
 
   <template>

--- a/packages/host/app/components/markdown-embed-chooser/preview/usage.gts
+++ b/packages/host/app/components/markdown-embed-chooser/preview/usage.gts
@@ -1,3 +1,4 @@
+import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -6,6 +7,7 @@ import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
 import { isCardErrorJSONAPI } from '@cardstack/runtime-common';
+import type { BfmSizeSpec } from '@cardstack/runtime-common/bfm-card-references';
 
 import MiniCardChooser from '@cardstack/host/components/card-chooser/mini';
 
@@ -15,10 +17,28 @@ import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import MarkdownEmbedPreview from './index';
 
+type EmbedFormat = 'atom' | 'embedded' | 'fitted' | 'isolated';
+
 export default class MarkdownEmbedPreviewUsage extends Component {
   @service declare private store: StoreService;
 
   @tracked private target: CardDef | undefined;
+
+  // Args panel state — bound to <:api> so the freestyle UI drives the live
+  // example below.
+  @tracked private format: EmbedFormat = 'embedded';
+  @tracked private kind: 'inline' | 'block' = 'block';
+  @tracked private showSurroundingText = false;
+  @tracked private fittedWidth = 150;
+  @tracked private fittedHeight = 275;
+
+  private get sizeSpec(): BfmSizeSpec {
+    return {
+      format: 'fitted',
+      width: this.fittedWidth,
+      height: this.fittedHeight,
+    };
+  }
 
   @action private async onSelect(url: string) {
     let result = await this.store.get(url);
@@ -43,53 +63,47 @@ export default class MarkdownEmbedPreviewUsage extends Component {
           <MiniCardChooser @onSelect={{this.onSelect}} />
         </div>
         {{#if this.target}}
-          <div class='gallery'>
-            <figure>
-              <figcaption>atom</figcaption>
-              <MarkdownEmbedPreview @target={{this.target}} @format='atom' />
-            </figure>
-            <figure>
-              <figcaption>embedded</figcaption>
-              <MarkdownEmbedPreview
-                @target={{this.target}}
-                @format='embedded'
-              />
-            </figure>
-            <figure>
-              <figcaption>fitted — tall-tile (150×275)</figcaption>
-              <MarkdownEmbedPreview
-                @target={{this.target}}
-                @format='fitted'
-                @sizeSpec={{this.tallTile}}
-              />
-            </figure>
-            <figure>
-              <figcaption>fitted — custom 300×200</figcaption>
-              <MarkdownEmbedPreview
-                @target={{this.target}}
-                @format='fitted'
-                @sizeSpec={{this.custom}}
-              />
-            </figure>
-            <figure>
-              <figcaption>atom — within surrounding text (inline)</figcaption>
-              <MarkdownEmbedPreview
-                @target={{this.target}}
-                @format='atom'
-                @kind='inline'
-                @showSurroundingText={{true}}
-              />
-            </figure>
-            <figure>
-              <figcaption>embedded — within surrounding text (block)</figcaption>
-              <MarkdownEmbedPreview
-                @target={{this.target}}
-                @format='embedded'
-                @kind='block'
-                @showSurroundingText={{true}}
-              />
-            </figure>
+          <div class='live'>
+            <MarkdownEmbedPreview
+              @target={{this.target}}
+              @format={{this.format}}
+              @kind={{this.kind}}
+              @sizeSpec={{this.sizeSpec}}
+              @showSurroundingText={{this.showSurroundingText}}
+            />
           </div>
+          <details class='gallery-toggle'>
+            <summary>All formats at a glance</summary>
+            <div class='gallery'>
+              <figure>
+                <figcaption>atom</figcaption>
+                <MarkdownEmbedPreview @target={{this.target}} @format='atom' />
+              </figure>
+              <figure>
+                <figcaption>embedded</figcaption>
+                <MarkdownEmbedPreview
+                  @target={{this.target}}
+                  @format='embedded'
+                />
+              </figure>
+              <figure>
+                <figcaption>fitted — tall-tile (150×275)</figcaption>
+                <MarkdownEmbedPreview
+                  @target={{this.target}}
+                  @format='fitted'
+                  @sizeSpec={{this.tallTile}}
+                />
+              </figure>
+              <figure>
+                <figcaption>fitted — custom 300×200</figcaption>
+                <MarkdownEmbedPreview
+                  @target={{this.target}}
+                  @format='fitted'
+                  @sizeSpec={{this.custom}}
+                />
+              </figure>
+            </div>
+          </details>
         {{else}}
           <p class='hint'>Pick a card above to preview it.</p>
         {{/if}}
@@ -99,23 +113,45 @@ export default class MarkdownEmbedPreviewUsage extends Component {
           @name='target'
           @description='Resolved CardDef or FileDef to render. The caller loads it; this component renders only.'
           @required={{true}}
+          @value={{this.target}}
         />
         <Args.String
           @name='format'
           @description="One of 'atom' | 'embedded' | 'fitted' | 'isolated'."
           @required={{true}}
+          @value={{this.format}}
+          @onInput={{fn (mut this.format)}}
+          @options={{this.formatOptions}}
         />
         <Args.Object
           @name='sizeSpec'
-          @description='BfmSizeSpec supplying width/height for fitted renders.'
+          @description='BfmSizeSpec supplying width/height for fitted renders. Drive width/height with the inputs below.'
+          @value={{this.sizeSpec}}
+        />
+        <Args.Number
+          @name='sizeSpec.width'
+          @description='Width in px when @format is fitted.'
+          @value={{this.fittedWidth}}
+          @onInput={{fn (mut this.fittedWidth)}}
+        />
+        <Args.Number
+          @name='sizeSpec.height'
+          @description='Height in px when @format is fitted.'
+          @value={{this.fittedHeight}}
+          @onInput={{fn (mut this.fittedHeight)}}
         />
         <Args.String
           @name='kind'
           @description="Placement: 'inline' (<span>) or 'block' (<div>). Default 'block'."
+          @value={{this.kind}}
+          @onInput={{fn (mut this.kind)}}
+          @options={{this.kindOptions}}
         />
         <Args.Bool
           @name='showSurroundingText'
           @description='When true, wraps the embed in skeleton document text to preview how it sits in a real markdown doc. Default false.'
+          @value={{this.showSurroundingText}}
+          @onInput={{fn (mut this.showSurroundingText)}}
         />
       </:api>
     </FreestyleUsage>
@@ -127,11 +163,25 @@ export default class MarkdownEmbedPreviewUsage extends Component {
         border-radius: var(--boxel-border-radius);
         overflow: hidden;
       }
+      .live {
+        margin-top: var(--boxel-sp);
+        padding: var(--boxel-sp);
+        border: 1px dashed var(--boxel-300);
+        border-radius: var(--boxel-border-radius);
+      }
+      .gallery-toggle {
+        margin-top: var(--boxel-sp);
+      }
+      .gallery-toggle summary {
+        cursor: pointer;
+        font: var(--boxel-font-sm);
+        color: var(--boxel-450);
+        margin-bottom: var(--boxel-sp-xs);
+      }
       .gallery {
         display: flex;
         flex-wrap: wrap;
         gap: var(--boxel-sp);
-        margin-top: var(--boxel-sp);
       }
       .gallery figcaption {
         margin-bottom: var(--boxel-sp-xxs);
@@ -148,4 +198,6 @@ export default class MarkdownEmbedPreviewUsage extends Component {
 
   private tallTile = { format: 'fitted', width: 150, height: 275 } as const;
   private custom = { format: 'fitted', width: 300, height: 200 } as const;
+  private formatOptions = ['atom', 'embedded', 'fitted', 'isolated'];
+  private kindOptions = ['inline', 'block'];
 }

--- a/packages/host/app/components/markdown-embed-chooser/preview/usage.gts
+++ b/packages/host/app/components/markdown-embed-chooser/preview/usage.gts
@@ -71,6 +71,24 @@ export default class MarkdownEmbedPreviewUsage extends Component {
                 @sizeSpec={{this.custom}}
               />
             </figure>
+            <figure>
+              <figcaption>atom — within surrounding text (inline)</figcaption>
+              <MarkdownEmbedPreview
+                @target={{this.target}}
+                @format='atom'
+                @kind='inline'
+                @showSurroundingText={{true}}
+              />
+            </figure>
+            <figure>
+              <figcaption>embedded — within surrounding text (block)</figcaption>
+              <MarkdownEmbedPreview
+                @target={{this.target}}
+                @format='embedded'
+                @kind='block'
+                @showSurroundingText={{true}}
+              />
+            </figure>
           </div>
         {{else}}
           <p class='hint'>Pick a card above to preview it.</p>
@@ -94,6 +112,10 @@ export default class MarkdownEmbedPreviewUsage extends Component {
         <Args.String
           @name='kind'
           @description="Placement: 'inline' (<span>) or 'block' (<div>). Default 'block'."
+        />
+        <Args.Bool
+          @name='showSurroundingText'
+          @description='When true, wraps the embed in skeleton document text to preview how it sits in a real markdown doc. Default false.'
         />
       </:api>
     </FreestyleUsage>

--- a/packages/host/app/components/markdown-embed-chooser/preview/usage.gts
+++ b/packages/host/app/components/markdown-embed-chooser/preview/usage.gts
@@ -1,0 +1,129 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+
+import { isCardErrorJSONAPI } from '@cardstack/runtime-common';
+
+import MiniCardChooser from '@cardstack/host/components/card-chooser/mini';
+
+import type StoreService from '@cardstack/host/services/store';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+
+import MarkdownEmbedPreview from './index';
+
+export default class MarkdownEmbedPreviewUsage extends Component {
+  @service declare private store: StoreService;
+
+  @tracked private target: CardDef | undefined;
+
+  @action private async onSelect(url: string) {
+    let result = await this.store.get(url);
+    if (!isCardErrorJSONAPI(result)) {
+      this.target = result as CardDef;
+    }
+  }
+
+  <template>
+    <FreestyleUsage @name='MarkdownEmbedChooser::Preview'>
+      <:description>
+        Pure render component for a markdown embed: given a resolved card/file,
+        a format, and (for Fitted) a size, it renders the instance exactly as
+        the live markdown renderer would. Cards and files share the same
+        <code>CardRenderer</code>
+        path.
+        <code>@kind</code>
+        only controls placement (inline-flow vs. block), not the render format.
+      </:description>
+      <:example>
+        <div class='picker'>
+          <MiniCardChooser @onSelect={{this.onSelect}} />
+        </div>
+        {{#if this.target}}
+          <div class='gallery'>
+            <figure>
+              <figcaption>atom</figcaption>
+              <MarkdownEmbedPreview @target={{this.target}} @format='atom' />
+            </figure>
+            <figure>
+              <figcaption>embedded</figcaption>
+              <MarkdownEmbedPreview
+                @target={{this.target}}
+                @format='embedded'
+              />
+            </figure>
+            <figure>
+              <figcaption>fitted — tall-tile (150×275)</figcaption>
+              <MarkdownEmbedPreview
+                @target={{this.target}}
+                @format='fitted'
+                @sizeSpec={{this.tallTile}}
+              />
+            </figure>
+            <figure>
+              <figcaption>fitted — custom 300×200</figcaption>
+              <MarkdownEmbedPreview
+                @target={{this.target}}
+                @format='fitted'
+                @sizeSpec={{this.custom}}
+              />
+            </figure>
+          </div>
+        {{else}}
+          <p class='hint'>Pick a card above to preview it.</p>
+        {{/if}}
+      </:example>
+      <:api as |Args|>
+        <Args.Object
+          @name='target'
+          @description='Resolved CardDef or FileDef to render. The caller loads it; this component renders only.'
+          @required={{true}}
+        />
+        <Args.String
+          @name='format'
+          @description="One of 'atom' | 'embedded' | 'fitted' | 'isolated'."
+          @required={{true}}
+        />
+        <Args.Object
+          @name='sizeSpec'
+          @description='BfmSizeSpec supplying width/height for fitted renders.'
+        />
+        <Args.String
+          @name='kind'
+          @description="Placement: 'inline' (<span>) or 'block' (<div>). Default 'block'."
+        />
+      </:api>
+    </FreestyleUsage>
+    <style scoped>
+      .picker {
+        width: 360px;
+        height: 360px;
+        border: 1px solid var(--boxel-border-color, var(--boxel-300));
+        border-radius: var(--boxel-border-radius);
+        overflow: hidden;
+      }
+      .gallery {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--boxel-sp);
+        margin-top: var(--boxel-sp);
+      }
+      .gallery figcaption {
+        margin-bottom: var(--boxel-sp-xxs);
+        font: var(--boxel-font-xs);
+        color: var(--boxel-450);
+      }
+      .hint {
+        margin-top: var(--boxel-sp-xs);
+        font: var(--boxel-font-sm);
+        color: var(--boxel-450);
+      }
+    </style>
+  </template>
+
+  private tallTile = { format: 'fitted', width: 150, height: 275 } as const;
+  private custom = { format: 'fitted', width: 300, height: 200 } as const;
+}

--- a/packages/host/app/templates/host-freestyle.gts
+++ b/packages/host/app/templates/host-freestyle.gts
@@ -25,6 +25,8 @@ import AiAssistantSkillMenuUsage from '@cardstack/host/components/ai-assistant/s
 import MiniCardChooserUsage from '@cardstack/host/components/card-chooser/mini/usage';
 import CardChooserModal from '@cardstack/host/components/card-chooser/modal';
 import MiniFileChooserUsage from '@cardstack/host/components/file-chooser/mini/usage';
+import MarkdownEmbedPreviewPaneUsage from '@cardstack/host/components/markdown-embed-chooser/pane-usage';
+import MarkdownEmbedPreviewUsage from '@cardstack/host/components/markdown-embed-chooser/preview/usage';
 import PillMenuUsage from '@cardstack/host/components/pill-menu/usage';
 import SearchSheetUsage from '@cardstack/host/components/search-sheet/usage';
 
@@ -78,6 +80,8 @@ class HostFreestyleComponent extends Component<HostFreestyleSignature> {
       ['AiAssistant::SkillMenu', AiAssistantSkillMenuUsage],
       ['MiniCardChooser', MiniCardChooserUsage],
       ['MiniFileChooser', MiniFileChooserUsage],
+      ['MarkdownEmbedChooser::Preview', MarkdownEmbedPreviewUsage],
+      ['MarkdownEmbedChooser::Pane', MarkdownEmbedPreviewPaneUsage],
       ['SearchSheet', SearchSheetUsage],
     ].map(([name, c]) => {
       return {

--- a/packages/host/app/templates/host-freestyle.gts
+++ b/packages/host/app/templates/host-freestyle.gts
@@ -15,6 +15,7 @@ import {
   GetCardContextName,
   GetCardsContextName,
   GetCardCollectionContextName,
+  type getCard as GetCardType,
 } from '@cardstack/runtime-common';
 
 import AiAssistantApplyButtonUsage from '@cardstack/host/components/ai-assistant/apply-button/usage';
@@ -60,8 +61,8 @@ class HostFreestyleComponent extends Component<HostFreestyleSignature> {
 
   @provide(GetCardContextName)
   // @ts-ignore "getCard" is declared but not used
-  private get getCard() {
-    return getCard;
+  private get getCard(): GetCardType {
+    return getCard as unknown as GetCardType;
   }
 
   @provide(GetCardsContextName)
@@ -82,7 +83,7 @@ class HostFreestyleComponent extends Component<HostFreestyleSignature> {
   // @ts-ignore "cardContext" is declared but not used
   private get cardContext(): CardContext {
     return {
-      getCard,
+      getCard: this.getCard,
       getCards: this.store.getSearchResource.bind(this.store),
       getCardCollection,
       store: this.store,

--- a/packages/host/app/templates/host-freestyle.gts
+++ b/packages/host/app/templates/host-freestyle.gts
@@ -11,6 +11,7 @@ import { provide } from 'ember-provide-consume-context';
 import RouteTemplate from 'ember-route-template';
 
 import {
+  CardContextName,
   GetCardContextName,
   GetCardsContextName,
   GetCardCollectionContextName,
@@ -24,17 +25,22 @@ import AiAssistantMessageUsage from '@cardstack/host/components/ai-assistant/mes
 import AiAssistantSkillMenuUsage from '@cardstack/host/components/ai-assistant/skill-menu/usage';
 import MiniCardChooserUsage from '@cardstack/host/components/card-chooser/mini/usage';
 import CardChooserModal from '@cardstack/host/components/card-chooser/modal';
+import SearchResults from '@cardstack/host/components/card-search/search-results';
 import MiniFileChooserUsage from '@cardstack/host/components/file-chooser/mini/usage';
 import MarkdownEmbedPreviewPaneUsage from '@cardstack/host/components/markdown-embed-chooser/pane-usage';
 import MarkdownEmbedPreviewUsage from '@cardstack/host/components/markdown-embed-chooser/preview/usage';
 import PillMenuUsage from '@cardstack/host/components/pill-menu/usage';
+import PrerenderedCardSearch from '@cardstack/host/components/prerendered-card-search';
 import SearchSheetUsage from '@cardstack/host/components/search-sheet/usage';
 
 import { getCardCollection } from '@cardstack/host/resources/card-collection';
 import { getCard } from '@cardstack/host/resources/card-resource';
 
+import type { CardContext } from 'https://cardstack.com/base/card-api';
+
 import formatComponentName from '../helpers/format-component-name';
 
+import type CommandService from '../services/command-service';
 import type StoreService from '../services/store';
 import type { ComponentLike } from '@glint/template';
 
@@ -49,6 +55,7 @@ interface HostFreestyleSignature {
 
 class HostFreestyleComponent extends Component<HostFreestyleSignature> {
   @service declare private store: StoreService;
+  @service declare private commandService: CommandService;
   formatComponentName = formatComponentName;
 
   @provide(GetCardContextName)
@@ -67,6 +74,22 @@ class HostFreestyleComponent extends Component<HostFreestyleSignature> {
   // @ts-ignore "getCardCollection" is declared but not used
   private get getCardCollection() {
     return getCardCollection;
+  }
+
+  // CardRenderer (used by the markdown-embed preview usages) consumes the full
+  // CardContext; provide it here so previewed cards/files actually render.
+  @provide(CardContextName)
+  // @ts-ignore "cardContext" is declared but not used
+  private get cardContext(): CardContext {
+    return {
+      getCard,
+      getCards: this.store.getSearchResource.bind(this.store),
+      getCardCollection,
+      store: this.store,
+      commandContext: this.commandService.commandContext,
+      prerenderedCardSearchComponent: PrerenderedCardSearch,
+      searchResultsComponent: SearchResults,
+    };
   }
 
   get usageComponents() {

--- a/packages/host/tests/integration/components/markdown-embed-preview-pane-test.gts
+++ b/packages/host/tests/integration/components/markdown-embed-preview-pane-test.gts
@@ -252,7 +252,7 @@ module('Integration | markdown-embed-preview-pane', function (hooks) {
       );
   });
 
-  test('fitted variant prefills W/H, emits the variant id, and inline drops the size', async function (assert) {
+  test('fitted variant prefills W/H and emits the variant id in both placements', async function (assert) {
     let card = await loadCard();
     let harness = new InsertHarness();
     await render(
@@ -287,16 +287,14 @@ module('Integration | markdown-embed-preview-pane', function (hooks) {
       'block emits the named variant id',
     );
 
-    // The chooser passes the size for inline too, but the BFM serializer
-    // (runtime-common) currently drops it for inline, so the emitted directive
-    // is the size-less `:card[url]`. The BFM "all formats in both modes" ticket
-    // flips this to `:card[url | tall-tile]` and updates this assertion.
+    // Inline carries the size too, so the emitted directive keeps the named
+    // variant — `:card[url | tall-tile]`.
     await click('[data-test-markdown-embed-preview-inline]');
     await click('[data-test-markdown-embed-preview-cta]');
     assert.strictEqual(
       harness.last,
-      `:card[${card.id}]`,
-      'inline emission drops the size today (BFM-owned, pending the grammar ticket)',
+      `:card[${card.id} | tall-tile]`,
+      'inline carries the same size specifier as block',
     );
   });
 
@@ -364,6 +362,49 @@ module('Integration | markdown-embed-preview-pane', function (hooks) {
       `::card[${card.id} | regular-tile]`,
       'the dropdown follows the dimensions to the matching variant',
     );
+  });
+
+  test('inline + embedded surfaces a sizing hint (no intrinsic inline width)', async function (assert) {
+    let card = await loadCard();
+    let harness = new InsertHarness();
+    await render(
+      <template>
+        <PaneBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreviewPane
+              @target={{card}}
+              @refType='card'
+              @onInsert={{harness.onInsert}}
+            />
+          </HostContextProvider>
+        </PaneBox>
+      </template>,
+    );
+
+    // No hint while atom (the default for inline) is selected.
+    assert
+      .dom('[data-test-markdown-embed-preview-warning]')
+      .doesNotExist('no hint when inline + atom is selected');
+
+    await chooseFormat('embedded');
+    // Default placement for embedded is block, so still no hint yet.
+    assert
+      .dom('[data-test-markdown-embed-preview-warning]')
+      .doesNotExist('no hint when embedded + block is selected');
+
+    await click('[data-test-markdown-embed-preview-inline]');
+    assert
+      .dom('[data-test-markdown-embed-preview-warning]')
+      .exists('hint appears when embedded is paired with inline');
+    assert
+      .dom('[data-test-markdown-embed-preview-warning]')
+      .hasText(/no intrinsic width/i);
+
+    // Switching to a sized Fitted variant removes the hint.
+    await chooseFormat('tall-tile');
+    assert
+      .dom('[data-test-markdown-embed-preview-warning]')
+      .doesNotExist('Fitted with explicit dims clears the hint');
   });
 
   test('refType drives the keyword (file)', async function (assert) {

--- a/packages/host/tests/integration/components/markdown-embed-preview-pane-test.gts
+++ b/packages/host/tests/integration/components/markdown-embed-preview-pane-test.gts
@@ -1,0 +1,344 @@
+import type { TOC } from '@ember/component/template-only';
+import {
+  type RenderingTestContext,
+  click,
+  fillIn,
+  render,
+  waitFor,
+} from '@ember/test-helpers';
+
+import GlimmerComponent from '@glimmer/component';
+
+import { getService } from '@universal-ember/test-support';
+import { provide } from 'ember-provide-consume-context';
+
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  CardContextName,
+  GetCardContextName,
+  GetCardCollectionContextName,
+  GetCardsContextName,
+} from '@cardstack/runtime-common';
+
+import MarkdownEmbedPreviewPane from '@cardstack/host/components/markdown-embed-chooser/pane';
+import { getCardCollection } from '@cardstack/host/resources/card-collection';
+import { getCard } from '@cardstack/host/resources/card-resource';
+import type StoreService from '@cardstack/host/services/store';
+
+// The base-realm helper below exports `CardDef` as a value (for defining test
+// card classes); import the instance *type* separately for annotations.
+import type { CardDef as CardDefInstance } from 'https://cardstack.com/base/card-api';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+} from '../../helpers';
+import {
+  CardDef,
+  StringField,
+  contains,
+  field,
+  setupBaseRealm,
+} from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+const PaneBox: TOC<{ Blocks: { default: [] } }> = <template>
+  <div class='pane-box'>
+    {{yield}}
+  </div>
+  <style scoped>
+    .pane-box {
+      width: 420px;
+      height: 480px;
+      display: flex;
+      flex-direction: column;
+      border: 1px solid var(--boxel-border-color, var(--boxel-300));
+    }
+  </style>
+</template>;
+
+class HostContextProvider extends GlimmerComponent<{
+  Blocks: { default: [] };
+}> {
+  @provide(GetCardContextName)
+  get getCardFn() {
+    return getCard;
+  }
+  @provide(GetCardsContextName)
+  get getCardsFn() {
+    let store = getService('store') as StoreService;
+    return store.getSearchResource.bind(store);
+  }
+  @provide(GetCardCollectionContextName)
+  get getCardCollectionFn() {
+    return getCardCollection;
+  }
+  @provide(CardContextName)
+  get cardContext() {
+    return {};
+  }
+  <template>
+    {{! template-lint-disable no-yield-only }}
+    {{yield}}
+  </template>
+}
+
+class InsertHarness {
+  inserts: string[] = [];
+  onInsert = (bfm: string) => {
+    this.inserts.push(bfm);
+  };
+  get last() {
+    return this.inserts[this.inserts.length - 1];
+  }
+}
+
+async function chooseFormat(value: string) {
+  await click(
+    '[data-test-markdown-embed-preview-format-select] .ember-power-select-trigger',
+  );
+  await waitFor('.ember-power-select-option', { timeout: 3000 });
+  await click(`[data-test-format-option="${value}"]`);
+}
+
+module('Integration | markdown-embed-preview-pane', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [baseRealm.url, testRealmURL],
+    autostart: true,
+  });
+
+  const mango = `${testRealmURL}books/mango`;
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    class Book extends CardDef {
+      static displayName = 'Book';
+      @field title = contains(StringField);
+    }
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      realmURL: testRealmURL,
+      contents: {
+        'book.gts': { Book },
+        'books/mango.json': new Book({ title: 'Mango' }),
+      },
+    });
+    await getService('realm').login(testRealmURL);
+  });
+
+  async function loadCard(): Promise<CardDefInstance> {
+    let store = getService('store') as StoreService;
+    return (await store.get(mango)) as CardDefInstance;
+  }
+
+  test('atom is the default; block is disabled and inline emits :card[url]', async function (assert) {
+    let card = await loadCard();
+    let harness = new InsertHarness();
+    await render(
+      <template>
+        <PaneBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreviewPane
+              @target={{card}}
+              @refType='card'
+              @onInsert={{harness.onInsert}}
+            />
+          </HostContextProvider>
+        </PaneBox>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-markdown-embed-preview-cta]')
+      .hasText('Insert as Atom', 'CTA reflects the default Atom category');
+    assert
+      .dom('[data-test-markdown-embed-preview-block]')
+      .isDisabled('Block toggle is disabled while Atom is selected');
+    assert
+      .dom('[data-test-markdown-embed-preview-size]')
+      .doesNotExist('no W/H inputs for Atom');
+
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(
+      harness.last,
+      `:card[${card.id}]`,
+      'atom inserts the inline atom directive',
+    );
+  });
+
+  test('embedded emits a block directive with the embedded keyword', async function (assert) {
+    let card = await loadCard();
+    let harness = new InsertHarness();
+    await render(
+      <template>
+        <PaneBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreviewPane
+              @target={{card}}
+              @refType='card'
+              @onInsert={{harness.onInsert}}
+            />
+          </HostContextProvider>
+        </PaneBox>
+      </template>,
+    );
+
+    await chooseFormat('embedded');
+    assert
+      .dom('[data-test-markdown-embed-preview-cta]')
+      .hasText('Insert as Embedded');
+    assert
+      .dom('[data-test-markdown-embed-preview-block]')
+      .isNotDisabled('Block re-enables for non-atom formats');
+
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(harness.last, `::card[${card.id} | embedded]`);
+  });
+
+  test('fitted variant prefills W/H, emits the variant id, and inline drops the size', async function (assert) {
+    let card = await loadCard();
+    let harness = new InsertHarness();
+    await render(
+      <template>
+        <PaneBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreviewPane
+              @target={{card}}
+              @refType='card'
+              @onInsert={{harness.onInsert}}
+            />
+          </HostContextProvider>
+        </PaneBox>
+      </template>,
+    );
+
+    await chooseFormat('tall-tile');
+    assert
+      .dom('[data-test-markdown-embed-preview-cta]')
+      .hasText('Insert as Fitted');
+    assert
+      .dom('[data-test-markdown-embed-preview-width]')
+      .hasValue('150', 'width prefilled from the variant');
+    assert
+      .dom('[data-test-markdown-embed-preview-height]')
+      .hasValue('275', 'height prefilled from the variant');
+
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(
+      harness.last,
+      `::card[${card.id} | tall-tile]`,
+      'block emits the named variant id',
+    );
+
+    await click('[data-test-markdown-embed-preview-inline]');
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(
+      harness.last,
+      `:card[${card.id}]`,
+      'inline drops the size and emits the atom directive',
+    );
+  });
+
+  test('editing W/H to unknown dims switches to Custom and emits w:/h:', async function (assert) {
+    let card = await loadCard();
+    let harness = new InsertHarness();
+    await render(
+      <template>
+        <PaneBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreviewPane
+              @target={{card}}
+              @refType='card'
+              @onInsert={{harness.onInsert}}
+            />
+          </HostContextProvider>
+        </PaneBox>
+      </template>,
+    );
+
+    await chooseFormat('tall-tile');
+    await fillIn('[data-test-markdown-embed-preview-width]', '300');
+    await fillIn('[data-test-markdown-embed-preview-height]', '200');
+
+    assert
+      .dom('[data-test-markdown-embed-preview-cta]')
+      .hasText('Insert as Custom', 'unknown dims fall back to Custom');
+
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(harness.last, `::card[${card.id} | w:300 h:200]`);
+  });
+
+  test('editing W/H to a known variant follows the dropdown to that variant', async function (assert) {
+    let card = await loadCard();
+    let harness = new InsertHarness();
+    await render(
+      <template>
+        <PaneBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreviewPane
+              @target={{card}}
+              @refType='card'
+              @onInsert={{harness.onInsert}}
+            />
+          </HostContextProvider>
+        </PaneBox>
+      </template>,
+    );
+
+    await chooseFormat('tall-tile');
+    // regular-tile = 250x170
+    await fillIn('[data-test-markdown-embed-preview-width]', '250');
+    await fillIn('[data-test-markdown-embed-preview-height]', '170');
+
+    assert
+      .dom('[data-test-markdown-embed-preview-cta]')
+      .hasText(
+        'Insert as Fitted',
+        'an exact match stays in the Fitted category',
+      );
+
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(
+      harness.last,
+      `::card[${card.id} | regular-tile]`,
+      'the dropdown follows the dimensions to the matching variant',
+    );
+  });
+
+  test('refType drives the keyword (file)', async function (assert) {
+    let card = await loadCard();
+    let harness = new InsertHarness();
+    await render(
+      <template>
+        <PaneBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreviewPane
+              @target={{card}}
+              @refType='file'
+              @onInsert={{harness.onInsert}}
+            />
+          </HostContextProvider>
+        </PaneBox>
+      </template>,
+    );
+
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(
+      harness.last,
+      `:file[${card.id}]`,
+      'atom inline file ref',
+    );
+
+    await chooseFormat('embedded');
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(harness.last, `::file[${card.id} | embedded]`);
+  });
+});

--- a/packages/host/tests/integration/components/markdown-embed-preview-pane-test.gts
+++ b/packages/host/tests/integration/components/markdown-embed-preview-pane-test.gts
@@ -52,7 +52,7 @@ const PaneBox: TOC<{ Blocks: { default: [] } }> = <template>
   </div>
   <style scoped>
     .pane-box {
-      width: 420px;
+      width: 553px;
       height: 480px;
       display: flex;
       flex-direction: column;
@@ -98,9 +98,10 @@ class InsertHarness {
 }
 
 async function chooseFormat(value: string) {
-  await click(
-    '[data-test-markdown-embed-preview-format-select] .ember-power-select-trigger',
-  );
+  // BoxelSelect spreads attributes onto the PowerSelect trigger itself, so the
+  // data-test attribute lands directly on the `.ember-power-select-trigger`
+  // element (not a wrapper) — click it directly to open the dropdown.
+  await click('[data-test-markdown-embed-preview-format-select]');
   await waitFor('.ember-power-select-option', { timeout: 3000 });
   await click(`[data-test-format-option="${value}"]`);
 }
@@ -139,7 +140,7 @@ module('Integration | markdown-embed-preview-pane', function (hooks) {
     return (await store.get(mango)) as CardDefInstance;
   }
 
-  test('atom is the default; block is disabled and inline emits :card[url]', async function (assert) {
+  test('atom is the default; both placements are available', async function (assert) {
     let card = await loadCard();
     let harness = new InsertHarness();
     await render(
@@ -161,7 +162,7 @@ module('Integration | markdown-embed-preview-pane', function (hooks) {
       .hasText('Insert as Atom', 'CTA reflects the default Atom category');
     assert
       .dom('[data-test-markdown-embed-preview-block]')
-      .isDisabled('Block toggle is disabled while Atom is selected');
+      .isNotDisabled('Block toggle is available for every format');
     assert
       .dom('[data-test-markdown-embed-preview-size]')
       .doesNotExist('no W/H inputs for Atom');
@@ -170,7 +171,17 @@ module('Integration | markdown-embed-preview-pane', function (hooks) {
     assert.strictEqual(
       harness.last,
       `:card[${card.id}]`,
-      'atom inserts the inline atom directive',
+      'inline atom inserts the size-less inline directive',
+    );
+
+    // Atom is available in block placement too (`::card[url | atom]`); the BFM
+    // grammar ticket makes the renderer honor it.
+    await click('[data-test-markdown-embed-preview-block]');
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(
+      harness.last,
+      `::card[${card.id} | atom]`,
+      'block atom emits the atom specifier',
     );
   });
 
@@ -201,6 +212,44 @@ module('Integration | markdown-embed-preview-pane', function (hooks) {
 
     await click('[data-test-markdown-embed-preview-cta]');
     assert.strictEqual(harness.last, `::card[${card.id} | embedded]`);
+  });
+
+  test('the preview tracks the selected format in either placement', async function (assert) {
+    let card = await loadCard();
+    let harness = new InsertHarness();
+    await render(
+      <template>
+        <PaneBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreviewPane
+              @target={{card}}
+              @refType='card'
+              @onInsert={{harness.onInsert}}
+            />
+          </HostContextProvider>
+        </PaneBox>
+      </template>,
+    );
+
+    await chooseFormat('embedded');
+    assert
+      .dom('[data-test-markdown-embed-preview]')
+      .hasAttribute(
+        'data-test-markdown-embed-preview-format',
+        'embedded',
+        'block embedded previews in embedded format',
+      );
+
+    // Format and placement are independent: toggling to inline keeps the
+    // embedded render rather than collapsing to atom.
+    await click('[data-test-markdown-embed-preview-inline]');
+    assert
+      .dom('[data-test-markdown-embed-preview]')
+      .hasAttribute(
+        'data-test-markdown-embed-preview-format',
+        'embedded',
+        'inline still previews the selected embedded format',
+      );
   });
 
   test('fitted variant prefills W/H, emits the variant id, and inline drops the size', async function (assert) {
@@ -238,12 +287,16 @@ module('Integration | markdown-embed-preview-pane', function (hooks) {
       'block emits the named variant id',
     );
 
+    // The chooser passes the size for inline too, but the BFM serializer
+    // (runtime-common) currently drops it for inline, so the emitted directive
+    // is the size-less `:card[url]`. The BFM "all formats in both modes" ticket
+    // flips this to `:card[url | tall-tile]` and updates this assertion.
     await click('[data-test-markdown-embed-preview-inline]');
     await click('[data-test-markdown-embed-preview-cta]');
     assert.strictEqual(
       harness.last,
       `:card[${card.id}]`,
-      'inline drops the size and emits the atom directive',
+      'inline emission drops the size today (BFM-owned, pending the grammar ticket)',
     );
   });
 

--- a/packages/host/tests/integration/components/markdown-embed-preview-pane-test.gts
+++ b/packages/host/tests/integration/components/markdown-embed-preview-pane-test.gts
@@ -364,7 +364,7 @@ module('Integration | markdown-embed-preview-pane', function (hooks) {
     );
   });
 
-  test('inline + embedded surfaces a sizing hint (no intrinsic inline width)', async function (assert) {
+  test('isolated emits in both placements', async function (assert) {
     let card = await loadCard();
     let harness = new InsertHarness();
     await render(
@@ -381,30 +381,88 @@ module('Integration | markdown-embed-preview-pane', function (hooks) {
       </template>,
     );
 
-    // No hint while atom (the default for inline) is selected.
+    await chooseFormat('isolated');
     assert
-      .dom('[data-test-markdown-embed-preview-warning]')
-      .doesNotExist('no hint when inline + atom is selected');
+      .dom('[data-test-markdown-embed-preview-cta]')
+      .hasText('Insert as Isolated');
+    assert
+      .dom('[data-test-markdown-embed-preview]')
+      .hasAttribute(
+        'data-test-markdown-embed-preview-format',
+        'isolated',
+        'preview switches to isolated',
+      );
 
-    await chooseFormat('embedded');
-    // Default placement for embedded is block, so still no hint yet.
-    assert
-      .dom('[data-test-markdown-embed-preview-warning]')
-      .doesNotExist('no hint when embedded + block is selected');
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(
+      harness.last,
+      `::card[${card.id} | isolated]`,
+      'block isolated emits the isolated specifier',
+    );
 
     await click('[data-test-markdown-embed-preview-inline]');
-    assert
-      .dom('[data-test-markdown-embed-preview-warning]')
-      .exists('hint appears when embedded is paired with inline');
-    assert
-      .dom('[data-test-markdown-embed-preview-warning]')
-      .hasText(/no intrinsic width/i);
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(
+      harness.last,
+      `:card[${card.id} | isolated]`,
+      'inline isolated also carries the isolated specifier',
+    );
+  });
 
-    // Switching to a sized Fitted variant removes the hint.
+  test('inline + embedded emits the explicit specifier on CTA', async function (assert) {
+    let card = await loadCard();
+    let harness = new InsertHarness();
+    await render(
+      <template>
+        <PaneBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreviewPane
+              @target={{card}}
+              @refType='card'
+              @onInsert={{harness.onInsert}}
+            />
+          </HostContextProvider>
+        </PaneBox>
+      </template>,
+    );
+
+    await chooseFormat('embedded');
+    await click('[data-test-markdown-embed-preview-inline]');
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(
+      harness.last,
+      `:card[${card.id} | embedded]`,
+      'inline embedded carries the embedded specifier',
+    );
+  });
+
+  test('inline + custom dimensions emit w:/h: in the inline directive', async function (assert) {
+    let card = await loadCard();
+    let harness = new InsertHarness();
+    await render(
+      <template>
+        <PaneBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreviewPane
+              @target={{card}}
+              @refType='card'
+              @onInsert={{harness.onInsert}}
+            />
+          </HostContextProvider>
+        </PaneBox>
+      </template>,
+    );
+
     await chooseFormat('tall-tile');
-    assert
-      .dom('[data-test-markdown-embed-preview-warning]')
-      .doesNotExist('Fitted with explicit dims clears the hint');
+    await fillIn('[data-test-markdown-embed-preview-width]', '321');
+    await fillIn('[data-test-markdown-embed-preview-height]', '210');
+    await click('[data-test-markdown-embed-preview-inline]');
+    await click('[data-test-markdown-embed-preview-cta]');
+    assert.strictEqual(
+      harness.last,
+      `:card[${card.id} | w:321 h:210]`,
+      'inline custom carries w:/h:',
+    );
   });
 
   test('refType drives the keyword (file)', async function (assert) {
@@ -434,5 +492,43 @@ module('Integration | markdown-embed-preview-pane', function (hooks) {
     await chooseFormat('embedded');
     await click('[data-test-markdown-embed-preview-cta]');
     assert.strictEqual(harness.last, `::file[${card.id} | embedded]`);
+  });
+
+  test('atom, embedded, isolated carry the has-divider modifier; fitted/custom do not', async function (assert) {
+    let card = await loadCard();
+    let harness = new InsertHarness();
+    await render(
+      <template>
+        <PaneBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreviewPane
+              @target={{card}}
+              @refType='card'
+              @onInsert={{harness.onInsert}}
+            />
+          </HostContextProvider>
+        </PaneBox>
+      </template>,
+    );
+
+    await click('[data-test-markdown-embed-preview-format-select]');
+    await waitFor('.ember-power-select-option', { timeout: 3000 });
+
+    for (let value of ['atom', 'embedded', 'isolated']) {
+      assert
+        .dom(`[data-test-format-option="${value}"]`)
+        .hasClass(
+          'has-divider',
+          `${value} wrapper carries has-divider so the dropdown can paint a gap below it`,
+        );
+    }
+    for (let value of ['tall-tile', 'custom']) {
+      assert
+        .dom(`[data-test-format-option="${value}"]`)
+        .doesNotHaveClass(
+          'has-divider',
+          `${value} wrapper has no divider — only the non-fitted heads do`,
+        );
+    }
   });
 });

--- a/packages/host/tests/integration/components/markdown-embed-preview-test.gts
+++ b/packages/host/tests/integration/components/markdown-embed-preview-test.gts
@@ -1,0 +1,234 @@
+import type { TOC } from '@ember/component/template-only';
+import { type RenderingTestContext, render } from '@ember/test-helpers';
+
+import GlimmerComponent from '@glimmer/component';
+
+import { getService } from '@universal-ember/test-support';
+import { provide } from 'ember-provide-consume-context';
+
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  CardContextName,
+  GetCardContextName,
+  GetCardCollectionContextName,
+  GetCardsContextName,
+  type BfmSizeSpec,
+} from '@cardstack/runtime-common';
+
+import MarkdownEmbedPreview from '@cardstack/host/components/markdown-embed-chooser/preview';
+import { getCardCollection } from '@cardstack/host/resources/card-collection';
+import { getCard } from '@cardstack/host/resources/card-resource';
+import type StoreService from '@cardstack/host/services/store';
+
+// The base-realm helper below exports `CardDef` as a value (for defining test
+// card classes); import the instance *type* separately for annotations.
+import type { CardDef as CardDefInstance } from 'https://cardstack.com/base/card-api';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+} from '../../helpers';
+import {
+  CardDef,
+  StringField,
+  contains,
+  field,
+  setupBaseRealm,
+} from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+const PreviewBox: TOC<{ Blocks: { default: [] } }> = <template>
+  <div class='preview-box'>
+    {{yield}}
+  </div>
+  <style scoped>
+    .preview-box {
+      width: 360px;
+      min-height: 320px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+    }
+  </style>
+</template>;
+
+// Provides the contexts CardRenderer reads via @consume so the preview can
+// render outside OperatorMode.
+class HostContextProvider extends GlimmerComponent<{
+  Blocks: { default: [] };
+}> {
+  @provide(GetCardContextName)
+  get getCardFn() {
+    return getCard;
+  }
+  @provide(GetCardsContextName)
+  get getCardsFn() {
+    let store = getService('store') as StoreService;
+    return store.getSearchResource.bind(store);
+  }
+  @provide(GetCardCollectionContextName)
+  get getCardCollectionFn() {
+    return getCardCollection;
+  }
+  @provide(CardContextName)
+  get cardContext() {
+    return {};
+  }
+  <template>
+    {{! template-lint-disable no-yield-only }}
+    {{yield}}
+  </template>
+}
+
+function styleOf(): string {
+  return (
+    document
+      .querySelector('[data-test-markdown-embed-preview]')
+      ?.getAttribute('style') ?? ''
+  );
+}
+
+module('Integration | markdown-embed-preview', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [baseRealm.url, testRealmURL],
+    autostart: true,
+  });
+
+  const mango = `${testRealmURL}books/mango`;
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    class Book extends CardDef {
+      static displayName = 'Book';
+      @field title = contains(StringField);
+    }
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      realmURL: testRealmURL,
+      contents: {
+        'book.gts': { Book },
+        'books/mango.json': new Book({ title: 'Mango' }),
+      },
+    });
+    await getService('realm').login(testRealmURL);
+  });
+
+  async function loadCard(): Promise<CardDefInstance> {
+    let store = getService('store') as StoreService;
+    return (await store.get(mango)) as CardDefInstance;
+  }
+
+  test('renders atom format with no fitted sizing', async function (assert) {
+    let card = await loadCard();
+    await render(
+      <template>
+        <PreviewBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreview @target={{card}} @format='atom' />
+          </HostContextProvider>
+        </PreviewBox>
+      </template>,
+    );
+    assert
+      .dom('[data-test-markdown-embed-preview]')
+      .hasAttribute('data-test-markdown-embed-preview-format', 'atom');
+    assert
+      .dom('[data-test-markdown-embed-preview].markdown-embed-preview--fitted')
+      .doesNotExist('atom carries no fitted sizing');
+  });
+
+  test('renders embedded format', async function (assert) {
+    let card = await loadCard();
+    await render(
+      <template>
+        <PreviewBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreview @target={{card}} @format='embedded' />
+          </HostContextProvider>
+        </PreviewBox>
+      </template>,
+    );
+    assert
+      .dom('[data-test-markdown-embed-preview]')
+      .hasAttribute('data-test-markdown-embed-preview-format', 'embedded');
+  });
+
+  test('renders a named fitted variant at its exact footprint', async function (assert) {
+    let card = await loadCard();
+    // tall-tile = 150x275
+    let tallTile: BfmSizeSpec = { format: 'fitted', width: 150, height: 275 };
+    await render(
+      <template>
+        <PreviewBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreview
+              @target={{card}}
+              @format='fitted'
+              @sizeSpec={{tallTile}}
+            />
+          </HostContextProvider>
+        </PreviewBox>
+      </template>,
+    );
+    assert
+      .dom('[data-test-markdown-embed-preview]')
+      .hasAttribute('data-test-markdown-embed-preview-format', 'fitted');
+    let style = styleOf();
+    assert.ok(style.includes('width: 150px'), `width applied (${style})`);
+    assert.ok(style.includes('height: 275px'), `height applied (${style})`);
+    assert.ok(style.includes('overflow: hidden'), 'fitted clips overflow');
+  });
+
+  test('renders an arbitrary custom W×H', async function (assert) {
+    let card = await loadCard();
+    let custom: BfmSizeSpec = { format: 'fitted', width: 300, height: 200 };
+    await render(
+      <template>
+        <PreviewBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreview
+              @target={{card}}
+              @format='fitted'
+              @sizeSpec={{custom}}
+            />
+          </HostContextProvider>
+        </PreviewBox>
+      </template>,
+    );
+    let style = styleOf();
+    assert.ok(style.includes('width: 300px'), `custom width (${style})`);
+    assert.ok(style.includes('height: 200px'), `custom height (${style})`);
+  });
+
+  test('kind controls placement: inline renders a span, block renders a div', async function (assert) {
+    let card = await loadCard();
+    await render(
+      <template>
+        <PreviewBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreview
+              @target={{card}}
+              @format='embedded'
+              @kind='inline'
+            />
+          </HostContextProvider>
+        </PreviewBox>
+      </template>,
+    );
+    assert
+      .dom('span[data-test-markdown-embed-preview]')
+      .exists('inline kind renders a span');
+    assert
+      .dom('div[data-test-markdown-embed-preview]')
+      .doesNotExist('no block wrapper for inline kind');
+  });
+});

--- a/packages/host/tests/integration/components/markdown-embed-preview-test.gts
+++ b/packages/host/tests/integration/components/markdown-embed-preview-test.gts
@@ -231,4 +231,55 @@ module('Integration | markdown-embed-preview', function (hooks) {
       .dom('div[data-test-markdown-embed-preview]')
       .doesNotExist('no block wrapper for inline kind');
   });
+
+  test('showSurroundingText wraps the embed in skeleton document text', async function (assert) {
+    let card = await loadCard();
+    await render(
+      <template>
+        <PreviewBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreview
+              @target={{card}}
+              @format='atom'
+              @kind='inline'
+              @showSurroundingText={{true}}
+            />
+          </HostContextProvider>
+        </PreviewBox>
+      </template>,
+    );
+    // The real embed still renders…
+    assert
+      .dom('[data-test-markdown-embed-preview]')
+      .hasAttribute('data-test-markdown-embed-preview-format', 'atom');
+    // …flowing inside decorative skeleton document text (2 lines above + 2
+    // below the paragraph that carries the inline embed).
+    assert.dom('.markdown-embed-preview-doc__line').exists({ count: 4 });
+    assert
+      .dom(
+        '.markdown-embed-preview-doc__para span[data-test-markdown-embed-preview]',
+      )
+      .exists('inline embed flows within the skeleton paragraph');
+  });
+
+  test('bare preview (no surrounding text) renders no skeleton document', async function (assert) {
+    let card = await loadCard();
+    await render(
+      <template>
+        <PreviewBox>
+          <HostContextProvider>
+            <MarkdownEmbedPreview @target={{card}} @format='atom' />
+          </HostContextProvider>
+        </PreviewBox>
+      </template>,
+    );
+    assert
+      .dom('[data-test-markdown-embed-preview]')
+      .exists('the embed renders');
+    assert
+      .dom('.markdown-embed-preview-doc')
+      .doesNotExist(
+        'no skeleton document wrapper without @showSurroundingText',
+      );
+  });
 });

--- a/packages/host/tests/unit/bfm-card-references-test.ts
+++ b/packages/host/tests/unit/bfm-card-references-test.ts
@@ -1129,7 +1129,8 @@ module('Unit | bfm-card-references', function () {
   });
 
   module('serializeBfmSizeSpec', function () {
-    test('isolated / embedded round-trip to their keyword', function (assert) {
+    test('atom / isolated / embedded round-trip to their keyword', function (assert) {
+      assert.strictEqual(serializeBfmSizeSpec({ format: 'atom' }), 'atom');
       assert.strictEqual(
         serializeBfmSizeSpec({ format: 'isolated' }),
         'isolated',
@@ -1165,8 +1166,9 @@ module('Unit | bfm-card-references', function () {
       );
     });
 
-    test('round-trips through parseBfmSizeSpec for isolated, embedded, dims, and %', function (assert) {
+    test('round-trips through parseBfmSizeSpec for atom, isolated, embedded, dims, and %', function (assert) {
       let specs: BfmSizeSpec[] = [
+        { format: 'atom' },
         { format: 'isolated' },
         { format: 'embedded' },
         { format: 'fitted', width: 300, height: 200 },
@@ -1199,10 +1201,17 @@ module('Unit | bfm-card-references', function () {
   module('serializeBfmRef', function () {
     let url = 'https://example.com/Author/jane';
 
-    test('inline drops the size and emits the single-colon form', function (assert) {
+    test('inline with no size emits the bare single-colon form', function (assert) {
+      assert.strictEqual(
+        serializeBfmRef('card', url, { kind: 'inline' }),
+        `:card[${url}]`,
+      );
+    });
+
+    test('inline with a size appends the specifier', function (assert) {
       assert.strictEqual(
         serializeBfmRef('card', url, { kind: 'inline', size: 'tall-tile' }),
-        `:card[${url}]`,
+        `:card[${url} | tall-tile]`,
       );
     });
 

--- a/packages/host/tests/unit/bfm-card-references-test.ts
+++ b/packages/host/tests/unit/bfm-card-references-test.ts
@@ -1,5 +1,7 @@
 import { module, test } from 'qunit';
 
+import { fittedFormatIds } from '@cardstack/boxel-ui/helpers';
+
 import {
   extractCardReferenceUrls,
   extractFileReferenceUrls,
@@ -8,6 +10,9 @@ import {
   bfmCardReferenceExtensions,
   bfmExtensionsForKeyword,
   parseBfmSizeSpec,
+  serializeBfmSizeSpec,
+  serializeBfmRef,
+  type BfmSizeSpec,
 } from '@cardstack/runtime-common/bfm-card-references';
 import { markdownToHtml } from '@cardstack/runtime-common/marked-sync';
 import { VirtualNetwork } from '@cardstack/runtime-common/virtual-network';
@@ -1120,6 +1125,123 @@ module('Unit | bfm-card-references', function () {
         format: 'fitted',
         sizeStyle: 'width: 400px',
       });
+    });
+  });
+
+  module('serializeBfmSizeSpec', function () {
+    test('isolated / embedded round-trip to their keyword', function (assert) {
+      assert.strictEqual(
+        serializeBfmSizeSpec({ format: 'isolated' }),
+        'isolated',
+      );
+      assert.strictEqual(
+        serializeBfmSizeSpec({ format: 'embedded' }),
+        'embedded',
+      );
+    });
+
+    test('bare fitted with no dimensions serializes to `fitted`', function (assert) {
+      assert.strictEqual(serializeBfmSizeSpec({ format: 'fitted' }), 'fitted');
+    });
+
+    test('fitted dimensions serialize to the explicit-key form', function (assert) {
+      assert.strictEqual(
+        serializeBfmSizeSpec({ format: 'fitted', width: 300, height: 200 }),
+        'w:300 h:200',
+      );
+    });
+
+    test('percentage width is preserved', function (assert) {
+      assert.strictEqual(
+        serializeBfmSizeSpec({ format: 'fitted', width: '50%', height: 200 }),
+        'w:50% h:200',
+      );
+    });
+
+    test('a single dimension serializes on its own', function (assert) {
+      assert.strictEqual(
+        serializeBfmSizeSpec({ format: 'fitted', height: 300 }),
+        'h:300',
+      );
+    });
+
+    test('round-trips through parseBfmSizeSpec for isolated, embedded, dims, and %', function (assert) {
+      let specs: BfmSizeSpec[] = [
+        { format: 'isolated' },
+        { format: 'embedded' },
+        { format: 'fitted', width: 300, height: 200 },
+        { format: 'fitted', width: '50%', height: 120 },
+        { format: 'fitted', height: 300 },
+      ];
+      for (let spec of specs) {
+        assert.deepEqual(
+          parseBfmSizeSpec(serializeBfmSizeSpec(spec)),
+          spec,
+          `round-trips ${JSON.stringify(spec)}`,
+        );
+      }
+    });
+
+    test('every named fitted id round-trips dimensionally', function (assert) {
+      for (let id of fittedFormatIds) {
+        let parsed = parseBfmSizeSpec(id)!;
+        // The serializer emits `w:N h:N`, which re-parses to the same spec —
+        // the named identity is intentionally not reconstructed.
+        assert.deepEqual(
+          parseBfmSizeSpec(serializeBfmSizeSpec(parsed)),
+          parsed,
+          `${id} round-trips dimensionally`,
+        );
+      }
+    });
+  });
+
+  module('serializeBfmRef', function () {
+    let url = 'https://example.com/Author/jane';
+
+    test('inline drops the size and emits the single-colon form', function (assert) {
+      assert.strictEqual(
+        serializeBfmRef('card', url, { kind: 'inline', size: 'tall-tile' }),
+        `:card[${url}]`,
+      );
+    });
+
+    test('block with no size emits the bare double-colon form', function (assert) {
+      assert.strictEqual(
+        serializeBfmRef('card', url, { kind: 'block' }),
+        `::card[${url}]`,
+      );
+    });
+
+    test('block with a size appends the specifier', function (assert) {
+      assert.strictEqual(
+        serializeBfmRef('card', url, { kind: 'block', size: 'tall-tile' }),
+        `::card[${url} | tall-tile]`,
+      );
+      assert.strictEqual(
+        serializeBfmRef('card', url, { kind: 'block', size: 'w:300 h:200' }),
+        `::card[${url} | w:300 h:200]`,
+      );
+    });
+
+    test('defaults to block', function (assert) {
+      assert.strictEqual(serializeBfmRef('card', url), `::card[${url}]`);
+    });
+
+    test('honors the refType keyword (file)', function (assert) {
+      assert.strictEqual(
+        serializeBfmRef('file', url, { kind: 'inline' }),
+        `:file[${url}]`,
+      );
+      assert.strictEqual(
+        serializeBfmRef('file', url, { kind: 'block', size: 'embedded' }),
+        `::file[${url} | embedded]`,
+      );
+    });
+
+    test('returns empty string for a missing url', function (assert) {
+      assert.strictEqual(serializeBfmRef('card', undefined), '');
+      assert.strictEqual(serializeBfmRef('card', ''), '');
     });
   });
 });

--- a/packages/runtime-common/bfm-card-references.ts
+++ b/packages/runtime-common/bfm-card-references.ts
@@ -115,6 +115,70 @@ export function parseBfmSizeSpec(specifier: string): BfmSizeSpec | null {
   return null;
 }
 
+/**
+ * Serializes a `BfmSizeSpec` back into the specifier string that goes after
+ * `|` in `::card[url | spec]` — the inverse of `parseBfmSizeSpec`.
+ *
+ * `atom` / `isolated` / `embedded` round-trip to their keyword. Fitted specs
+ * serialize to the explicit-key form (`w:<w> h:<h>`, `w:50%`, `h:200`, or bare
+ * `fitted` when no dimensions are present). Named variants are intentionally
+ * NOT reconstructed here: a `BfmSizeSpec` only carries dimensions, not the
+ * named identity, so callers that want the friendlier `tall-tile` form must
+ * emit it themselves (the chooser pane does this off the user's explicit
+ * selection). The `w:`/`h:` output still parses back to a dimensionally-
+ * identical spec.
+ */
+export function serializeBfmSizeSpec(spec: BfmSizeSpec): string {
+  if (
+    spec.format === 'atom' ||
+    spec.format === 'isolated' ||
+    spec.format === 'embedded'
+  ) {
+    return spec.format;
+  }
+  let parts: string[] = [];
+  if (spec.width !== undefined) {
+    parts.push(`w:${spec.width}`);
+  }
+  if (spec.height !== undefined) {
+    parts.push(`h:${spec.height}`);
+  }
+  return parts.length ? parts.join(' ') : 'fitted';
+}
+
+export interface BfmRefOptions {
+  // 'inline' produces `:<refType>[url]` (or `:<refType>[url | size]`),
+  // 'block' produces `::<refType>[url]` (or `::<refType>[url | size]`).
+  // Default: 'block'.
+  kind?: 'inline' | 'block';
+  // Size specifier appended after `|` (e.g. 'fitted', 'tall-tile',
+  // 'w:300 h:200'). Supported in both inline and block placements.
+  size?: string;
+}
+
+/**
+ * Builds a BFM reference directive (`:card[url]`, `::file[url | size]`, …) for
+ * a single reference by keyword + url. Returns `''` for a missing url. This is
+ * the single source of truth for BFM directive syntax, shared by the base-realm
+ * markdown helpers and host-side serializers (the `extract*`/`parse*` functions
+ * above are the matching readers).
+ */
+export function serializeBfmRef(
+  refType: string,
+  url: string | null | undefined,
+  options?: BfmRefOptions,
+): string {
+  if (!url) {
+    return '';
+  }
+  let kind = options?.kind ?? 'block';
+  let prefix = kind === 'inline' ? ':' : '::';
+  let size = options?.size;
+  return size
+    ? `${prefix}${refType}[${url} | ${size}]`
+    : `${prefix}${refType}[${url}]`;
+}
+
 export type BfmRefFormat = 'atom' | 'embedded' | 'fitted' | 'isolated';
 
 /**


### PR DESCRIPTION
## Summary

Builds the reusable markdown-embed preview and its right-hand **preview pane** — the companion the combined chooser modal (CS-11675) will compose later. Per discussion, **CS-11674** (always-on W×H inputs with smart variant matching) is combined into this branch.

Cards/files embed in markdown via BFM directives (`:card[URL]` inline / `::card[URL | size]` block). This lets a user pick a target, choose how it renders, toggle inline vs block, and get the correctly-serialized BFM.

## What's here

- **`MarkdownEmbedPreview`** (`markdown-embed-chooser/preview/index.gts`) — pure render component. Given a resolved `CardDef`/`FileDef`, a `@format`, and (for fitted) a `@sizeSpec`, it renders via `CardRenderer`. Fitted sizing reuses `bfmBlockFormatAndSize`, so the preview footprint matches the live markdown renderer byte-for-byte. `@kind` controls inline/block **placement**, not the render format. With `@showSurroundingText` it renders the embed inside skeleton document text so you can see how it sits in a real doc — an inline embed flows within the paragraph, a block embed breaks to its own line. A shared inner `Embed` component keeps the bare and in-context paths from duplicating the inline/block markup.
- **`MarkdownEmbedPreviewPane`** (`markdown-embed-chooser/pane.gts`) — format dropdown at the top (Atom / Embedded / each Fitted variant / Custom), a live preview, and a footer with the Inline/Block toggle, the W×H inputs (for Fitted/Custom, placed right after the toggle), and a dynamic "Insert as …" CTA that fires `@onInsert(bfm)`. **Format and placement are independent** — every format is selectable in both inline and block, and the preview tracks the true format × placement.
- **`runtime-common/bfm-card-references.ts`** — `serializeBfmSizeSpec` (inverse of `parseBfmSizeSpec`) and `serializeBfmRef`, the single source of truth for BFM directive syntax. `base/markdown-helpers.ts` delegates to it so file refs (`:file[…]`) serialize too. The pane declares its intent uniformly (`{ kind, size }`) and lets this serializer decide what each placement carries.
- **`templates/host-freestyle.gts`** — provides the full `CardContext` so the Freestyle preview usages actually render cards/files (`CardRenderer` consumes it via `@consume`).
- Freestyle demos for both components (registered as `MarkdownEmbedChooser::Preview` / `::Pane`), plus unit + integration tests.

## Serialization

Today `serializeBfmRef` drops the size for inline (inline is atom-only in the current BFM grammar):

| Choice | Inline (today) | Block |
|---|---|---|
| Atom | `:card[URL]` | `::card[URL \| atom]` |
| Embedded | `:card[URL]` | `::card[URL \| embedded]` |
| Fitted variant | `:card[URL]` | `::card[URL \| tall-tile]` |
| Custom W×H | `:card[URL]` | `::card[URL \| w:300 h:200]` |

Files use the `file` keyword. The preview already shows the selected format in **both** placements; the inline column collapses to a size-less `:card[URL]` only because BFM's serializer/grammar doesn't yet carry a spec for inline.

## Follow-up: CS-11704

Making inline carry a format/size is a BFM-grammar change tracked in **CS-11704** ("BFM: support all formats in both inline and block reference directives"). When it lands, the inline column above becomes `:card[URL | <spec>]` with **no** change to this chooser — it already passes the size through `serializeBfmRef`.

## Notes for reviewers

- **Scope:** standalone pane + Freestyle only — real chooser composition is deferred to the combined modal (CS-11675). The CTA only *emits* the BFM via `@onInsert`; cursor insertion is a later ticket.
- **Deviation:** uses the inline-style fitted path (shared with production `rendered-markdown`) instead of `FittedCardContainer`, because it covers custom W×H + `%` widths uniformly and guarantees parity with the live renderer.
- **Verification:** `eslint`, `ember-template-lint`, and `ember-tsc` are clean for the touched files; the `markdown-embed` integration suite passes locally against the dev stack (14 tests, 37 assertions).

## Screen Recording

https://github.com/user-attachments/assets/7f6cc9fa-5902-4ca7-af05-b0de3fcd090e




🤖 Generated with [Claude Code](https://claude.com/claude-code)
