### PR TITLE
Add `overlays` opt-out to search results so rows can render without operator-mode overlays

### DIFF
--- a/packages/host/app/components/card-search/hydratable-card.gts
+++ b/packages/host/app/components/card-search/hydratable-card.gts
@@ -4,7 +4,7 @@ import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
 
 import { modifier } from 'ember-modifier';
-import { consume } from 'ember-provide-consume-context';
+import { consume, provide } from 'ember-provide-consume-context';
 
 import {
   CardContextName,
@@ -96,6 +96,11 @@ interface Signature {
     errorDoc?: ErrorEntry;
     // The hydration gesture (defaults to `none`).
     mode?: HydrationMode;
+    // Whether this row registers with the operator-mode overlay (defaults to
+    // `true`). `false` applies the no-op tracker, so the row is never tracked
+    // and no overlay (chip / options menu / selection toggle) ever anchors to
+    // it — for a consumer that lays results out in its own UI.
+    overlays?: boolean;
     // The format the live/hydrated card renders as, so it matches the
     // prerendered HTML the query selected (defaults to `fitted`).
     format?: Format;
@@ -181,6 +186,11 @@ export default class HydratableCard extends Component<Signature> {
   // element with no extra wiring here. Guarded so reading the context while
   // this component is being destroyed can't throw.
   private get trackElement(): CardComponentModifier {
+    // Opted out of overlays — never register with the tracker, so no overlay
+    // can anchor to this row regardless of the surrounding context.
+    if (this.args.overlays === false) {
+      return noopCardModifier;
+    }
     if (isDestroying(this) || isDestroyed(this)) {
       return noopCardModifier;
     }
@@ -192,6 +202,20 @@ export default class HydratableCard extends Component<Signature> {
       }
       throw e;
     }
+  }
+
+  // Re-provide the card context to the rendered subtree. Normally a pass-through
+  // of the consumed context, but when `overlays` is opted out it blanks
+  // `cardComponentModifier` to the no-op — the live `CardRenderer` registers
+  // itself through this context (not through `trackElement`, which only governs
+  // the inert element), so the opt-out must reach it here too, else a hydrated
+  // row would re-acquire an overlay.
+  @provide(CardContextName)
+  private get providedCardContext(): CardContext | undefined {
+    if (this.args.overlays === false && this.cardContext) {
+      return { ...this.cardContext, cardComponentModifier: noopCardModifier };
+    }
+    return this.cardContext;
   }
 
   @action private hydrate() {

--- a/packages/host/app/components/card-search/hydratable-card.gts
+++ b/packages/host/app/components/card-search/hydratable-card.gts
@@ -185,23 +185,30 @@ export default class HydratableCard extends Component<Signature> {
   // any delegate-rendered card does), so the overlay re-anchors to the new
   // element with no extra wiring here. Guarded so reading the context while
   // this component is being destroyed can't throw.
+  // Reads the consumed card context, tolerating the owner-destroyed error that a
+  // teardown (realm refresh / unmount) can raise mid-render — returns undefined
+  // then, the same safe no-overlay fallback both consumers below want.
+  private get safeCardContext(): CardContext | undefined {
+    if (isDestroying(this) || isDestroyed(this)) {
+      return undefined;
+    }
+    try {
+      return this.cardContext;
+    } catch (e) {
+      if (e instanceof Error && e.message.includes(OWNER_DESTROYED_ERROR)) {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
   private get trackElement(): CardComponentModifier {
     // Opted out of overlays — never register with the tracker, so no overlay
     // can anchor to this row regardless of the surrounding context.
     if (this.args.overlays === false) {
       return noopCardModifier;
     }
-    if (isDestroying(this) || isDestroyed(this)) {
-      return noopCardModifier;
-    }
-    try {
-      return this.cardContext?.cardComponentModifier ?? noopCardModifier;
-    } catch (e) {
-      if (e instanceof Error && e.message.includes(OWNER_DESTROYED_ERROR)) {
-        return noopCardModifier;
-      }
-      throw e;
-    }
+    return this.safeCardContext?.cardComponentModifier ?? noopCardModifier;
   }
 
   // Re-provide the card context to the rendered subtree. Normally a pass-through
@@ -211,11 +218,13 @@ export default class HydratableCard extends Component<Signature> {
   // the inert element), so the opt-out must reach it here too, else a hydrated
   // row would re-acquire an overlay.
   @provide(CardContextName)
+  // @ts-ignore "providedCardContext" is declared but not used
   private get providedCardContext(): CardContext | undefined {
-    if (this.args.overlays === false && this.cardContext) {
-      return { ...this.cardContext, cardComponentModifier: noopCardModifier };
+    let cardContext = this.safeCardContext;
+    if (this.args.overlays === false && cardContext) {
+      return { ...cardContext, cardComponentModifier: noopCardModifier };
     }
-    return this.cardContext;
+    return cardContext;
   }
 
   @action private hydrate() {

--- a/packages/host/app/components/card-search/search-results.gts
+++ b/packages/host/app/components/card-search/search-results.gts
@@ -34,6 +34,10 @@ export default class SearchResults extends Component<SearchResultsComponentSigna
     return this.args.mode ?? 'hover';
   }
 
+  private get overlays(): boolean {
+    return this.args.overlays ?? true;
+  }
+
   // Created once per component: the underlying search resource owns its realm
   // subscriptions and re-runs through the reactive query thunk, while the
   // view-model layer memoizes render-stable entries on top. The query varies
@@ -42,6 +46,7 @@ export default class SearchResults extends Component<SearchResultsComponentSigna
     this,
     () => this.args.query,
     () => this.mode,
+    () => this.overlays,
   );
 
   private get results(): SearchResultsYield {

--- a/packages/host/app/lib/hydratable-entry-component.ts
+++ b/packages/host/app/lib/hydratable-entry-component.ts
@@ -54,6 +54,9 @@ export interface HydratableEntryArgs {
   errorDoc?: ErrorEntry;
   // The hydration gesture for an HTML-backed row.
   mode: HydrationMode;
+  // Whether the row registers with the operator-mode overlay; `false` renders
+  // it plainly (no chip / options menu / selection toggle).
+  overlays: boolean;
 }
 
 class _HydratableEntryComponent {
@@ -67,6 +70,7 @@ class _HydratableEntryComponent {
     readonly isError: boolean,
     readonly errorDoc: ErrorEntry | undefined,
     readonly mode: HydrationMode,
+    readonly overlays: boolean,
   ) {}
 }
 
@@ -82,6 +86,7 @@ setComponentTemplate(
       @isError={{this.isError}}
       @errorDoc={{this.errorDoc}}
       @mode={{this.mode}}
+      @overlays={{this.overlays}}
       ...attributes
     />`,
     {
@@ -127,5 +132,6 @@ export function hydratableEntryComponent(
     args.isError,
     args.errorDoc,
     args.mode,
+    args.overlays,
   ) as unknown as EntryComponent;
 }

--- a/packages/host/app/resources/renderable-search-entries.ts
+++ b/packages/host/app/resources/renderable-search-entries.ts
@@ -91,6 +91,7 @@ export class RenderableSearchEntry {
     private fallbackRenderType: ResolvedCodeRef | undefined,
     private fallbackFormat: PrerenderedHtmlFormat,
     private mode: HydrationMode,
+    private overlays: boolean,
   ) {}
 
   get id(): string {
@@ -212,6 +213,7 @@ export class RenderableSearchEntry {
         isError: this.isError,
         errorDoc: this.errorDoc,
         mode: this.mode,
+        overlays: this.overlays,
       });
     }
     return this.#component;
@@ -239,6 +241,7 @@ export class RenderableSearchEntries {
   constructor(
     private resource: ReturnType<typeof getSearchEntriesResource>,
     private getMode: () => HydrationMode,
+    private getOverlays: () => boolean,
   ) {}
 
   private get fallbackRenderType(): ResolvedCodeRef | undefined {
@@ -253,7 +256,13 @@ export class RenderableSearchEntries {
     let fallbackRenderType = this.fallbackRenderType;
     let fallbackFormat = this.fallbackFormat;
     let mode = this.getMode();
-    let inputsKey = JSON.stringify([mode, fallbackRenderType, fallbackFormat]);
+    let overlays = this.getOverlays();
+    let inputsKey = JSON.stringify([
+      mode,
+      overlays,
+      fallbackRenderType,
+      fallbackFormat,
+    ]);
     if (inputsKey !== this.#renderInputsKey) {
       // Pure memoization bookkeeping — see the per-row note below. Dropping the
       // cache when the captured inputs change rebuilds view-models with the new
@@ -272,6 +281,7 @@ export class RenderableSearchEntries {
         fallbackRenderType,
         fallbackFormat,
         mode,
+        overlays,
       );
       // Pure memoization keyed on the resource's stable entry identity — it
       // dirties no tracked state, and keeping unchanged rows' view-models (and
@@ -300,14 +310,17 @@ export class RenderableSearchEntries {
 // one `getSearchEntriesResource` parented to `owner`, and per-render calls would
 // pile up live resources. Vary the search through the `getQuery` thunk (re-read
 // reactively) and the hydration gesture through `getMode`; the resource is never
-// rebuilt.
+// rebuilt. `getOverlays` (defaults to `true` at the call site) similarly re-reads
+// whether rendered rows register with the operator-mode overlay.
 export function getRenderableSearchEntries(
   owner: object,
   getQuery: () => SearchEntryWireQuery | undefined,
   getMode: () => HydrationMode,
+  getOverlays: () => boolean = () => true,
 ): RenderableSearchEntries {
   return new RenderableSearchEntries(
     getSearchEntriesResource(owner, getQuery),
     getMode,
+    getOverlays,
   );
 }

--- a/packages/host/tests/integration/components/hydratable-card-test.gts
+++ b/packages/host/tests/integration/components/hydratable-card-test.gts
@@ -275,6 +275,47 @@ module('Integration | Component | hydratable-card', function (hooks) {
     );
   });
 
+  // (d) `@overlays={{false}}`: even with the operator-mode tracker present, the
+  // row opts out of the overlay — it never registers, so no chip / options menu
+  // / selection toggle can anchor to it. Hydration is unaffected: the inert HTML
+  // still swaps to a live card, the swap just never registers either element.
+  test('overlays=false — never registers with the tracker, even in operator mode', async function (assert) {
+    let tracker = new ElementTracker();
+    let inert = htmlComponent(INERT_HTML);
+    await render(
+      <template>
+        <TestContext @tracker={{tracker}}>
+          <HydratableCard
+            @cardId={{HASSAN}}
+            @component={{inert}}
+            @mode='hover'
+            @overlays={{false}}
+          />
+        </TestContext>
+      </template>,
+    );
+
+    assert.strictEqual(
+      tracker.elements.length,
+      0,
+      'the inert element opts out of the overlay tracker',
+    );
+
+    await triggerEvent('[data-test-hydratable-card]', 'mouseenter');
+
+    assert
+      .dom('[data-test-live-card]')
+      .hasText(
+        'Live: Hassan',
+        'still hydrates — overlays opt-out is independent',
+      );
+    assert.strictEqual(
+      tracker.elements.length,
+      0,
+      'the live element stays out of the tracker too',
+    );
+  });
+
   // `none` stays inert with the diagnostic attribute and never fetches.
   test('none — stays inert, marks data-hydration=none, and never fetches', async function (assert) {
     let inert = htmlComponent(INERT_HTML);

--- a/packages/runtime-common/search-results-component.ts
+++ b/packages/runtime-common/search-results-component.ts
@@ -92,6 +92,11 @@ export interface SearchResultsComponentSignature {
     // the wire. A full live row ignores it. Defaults to `hover`; pass `none` to
     // keep rows inert, `click` / `touch` to gate on those gestures.
     mode?: HydrationMode;
+    // Whether rendered results register with the operator-mode overlay (the
+    // card-type chip / options menu / selection toggle). Defaults to `true`;
+    // pass `false` for a card that lays results out in its own UI and wants
+    // them rendered plainly, with no overlay even inside operator mode.
+    overlays?: boolean;
   };
   Blocks: {
     default: [SearchResultsYield];


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-11689/add-overlays-opt-out-to-search-results-so-rows-can-render-without


Adds an `overlays` flag (default `true`) to the v2 `<SearchResults>` surface,
because a consumer may not want results to carry the operator-mode overlay (the
card-type chip / options menu / selection toggle) — which lets the user trigger
it and click through to open the card. With `overlays={{false}}` rows render
plainly, while still being live cards.

`HydratableCard` blocks both overlay-registration paths when opted out: the
inert HTML's `trackElement` returns the no-op modifier, and the card context
re-provided to the live `CardRenderer` subtree has `cardComponentModifier`
blanked, so a hydrated row can't re-acquire an overlay either.

## Adds an integration test:
with the tracker present, an `overlays={{false}}` row never registers (inert or live) while still hydrating on hover.
