### PR TITLE
refactor: migrate boxel-cli ingest-card search to per-realm _search-v2 (data-only)

### DIFF
--- a/packages/boxel-cli/src/commands/realm/ingest-card.ts
+++ b/packages/boxel-cli/src/commands/realm/ingest-card.ts
@@ -17,6 +17,7 @@ import {
   type ProfileManager,
 } from '../../lib/profile-manager.ts';
 import type { RealmAuthenticator } from '../../lib/realm-authenticator.ts';
+import { searchEntryRequestBody, itemsFromSearchEntryDoc } from '../search.ts';
 
 const CARD_JSON = 'application/vnd.card+json';
 const MODULE_EXTENSIONS = ['.gts', '.gjs', '.ts', '.js'];
@@ -432,21 +433,25 @@ class RealmCardIngester extends RealmSyncBase {
   private async searchCards(
     query: Record<string, unknown>,
   ): Promise<CardResource[]> {
-    // Query the SOURCE realm's own `_search` directly rather than the
-    // profile-scoped `_federated-search`. A shared/published source realm
-    // (e.g. the catalog) isn't in the active profile's federated set, so
-    // federated search returns nothing for it — which is why instances and
-    // Specs went uncopied (the module crawl survives because it uses direct
-    // file fetches). The realm's own `_search` sees its full index.
+    // Query the SOURCE realm's own `_search-v2` directly rather than the
+    // profile-scoped federated search. A shared/published source realm (e.g.
+    // the catalog) isn't in the active profile's federated set, so federated
+    // search returns nothing for it — which is why instances and Specs went
+    // uncopied (the module crawl survives because it uses direct file fetches).
+    // The realm's own endpoint sees its full index. The request is data-only
+    // (`fields[search-entry]=item`); the response is a search-entry document
+    // whose matched `item` serializations resolve out of `included` uniformly
+    // for normal and published realms (the v1 `data`-vs-`included` split
+    // disappears — every match is an entry that references its item).
     let res = await this.authenticator.authedRealmFetch(
-      `${this.realmRoot}_search`,
+      `${this.realmRoot}_search-v2`,
       {
         method: 'QUERY',
         headers: {
           Accept: CARD_JSON,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(query),
+        body: JSON.stringify(searchEntryRequestBody(query)),
       },
     );
     if (!res.ok) {
@@ -460,8 +465,10 @@ class RealmCardIngester extends RealmSyncBase {
       );
       return [];
     }
-    let json = (await res.json()) as SearchResponse;
-    return selectSearchResults(json);
+    let json = (await res.json()) as Parameters<
+      typeof itemsFromSearchEntryDoc
+    >[0];
+    return itemsFromSearchEntryDoc(json) as unknown as CardResource[];
   }
 
   private cardIdToInstanceRel(id: string | undefined): string | null {
@@ -527,23 +534,6 @@ class RealmCardIngester extends RealmSyncBase {
 interface CardResource {
   id?: string;
   attributes?: { specType?: string; ref?: unknown; [k: string]: unknown };
-}
-
-interface SearchResponse {
-  data?: CardResource[];
-  included?: CardResource[];
-}
-
-/**
- * Pick the matched cards out of a realm `_search` response. A normal realm
- * returns matches in `data`; a published realm (e.g. the catalog) returns them
- * in `included` with an empty `data`. Prefer `data`, fall back to `included` —
- * never merge, so a normal realm's `included` (linked deps of the matches) is
- * not mistaken for matches. Exported for unit testing.
- */
-export function selectSearchResults(json: SearchResponse): CardResource[] {
-  let data = json.data ?? [];
-  return data.length > 0 ? data : (json.included ?? []);
 }
 
 function tryParseCardDoc(

--- a/packages/boxel-cli/src/commands/search.ts
+++ b/packages/boxel-cli/src/commands/search.ts
@@ -99,7 +99,7 @@ function toItemSort(entry: Record<string, unknown>): Record<string, unknown> {
 }
 
 interface SearchEntryRequestBody {
-  realms: string[];
+  realms?: string[];
   // boxel-cli never renders HTML, so it requests the data-only fieldset: each
   // entry carries only its full `item` serialization (no prerendered `html`).
   fields: { 'search-entry': ['item'] };
@@ -110,18 +110,21 @@ interface SearchEntryRequestBody {
 }
 
 /**
- * Build the `_federated-search-v2` request body from a card-rooted query: the
- * `item.`-addressed filter/sort, the realms to federate across, and the
- * data-only fieldset.
+ * Build a v2 search-entry request body from a card-rooted query: the
+ * `item.`-addressed filter/sort plus the data-only fieldset. Pass `realms` for
+ * the federated `_federated-search-v2`; omit it to query a single realm's own
+ * `_search-v2`.
  */
 export function searchEntryRequestBody(
   query: Record<string, unknown>,
-  realms: string[],
+  realms?: string[],
 ): SearchEntryRequestBody {
   let body: SearchEntryRequestBody = {
-    realms,
     fields: { 'search-entry': ['item'] },
   };
+  if (realms !== undefined) {
+    body.realms = realms;
+  }
   if (query.filter !== undefined) {
     if (
       typeof query.filter !== 'object' ||

--- a/packages/boxel-cli/tests/commands/ingest-card-graph.test.ts
+++ b/packages/boxel-cli/tests/commands/ingest-card-graph.test.ts
@@ -140,13 +140,14 @@ function makeFakeAuthenticator(fetchedUrls: string[]): RealmAuthenticator {
         );
       }
       // The ingester discovers instances + Specs via the source realm's own
-      // `_search` endpoint (a QUERY request), not the profile-scoped
-      // federated search — so a shared/published source realm is reachable.
-      if (url === `${ROOT}_search`) {
-        return new Response(
-          JSON.stringify({ data: fakeSearchData(String(init?.body ?? '{}')) }),
-          { status: 200 },
-        );
+      // `_search-v2` endpoint (a data-only QUERY request), not the
+      // profile-scoped federated search — so a shared/published source realm
+      // is reachable.
+      if (url === `${ROOT}_search-v2`) {
+        let cards = fakeSearchData(String(init?.body ?? '{}'));
+        return new Response(JSON.stringify(searchEntryDoc(cards)), {
+          status: 200,
+        });
       }
       let rel = url.startsWith(ROOT) ? url.slice(ROOT.length) : null;
       if (rel != null && REALM_FILES[rel] != null) {
@@ -157,15 +158,19 @@ function makeFakeAuthenticator(fetchedUrls: string[]): RealmAuthenticator {
   };
 }
 
-// The data the source realm's `_search` returns for the two shapes the
-// ingester issues: instances of the entry card's exported classes, and all
-// base-realm Spec cards (filtered by specType + ref in the ingester itself).
-function fakeSearchData(bodyStr: string): unknown[] {
+// The cards the source realm matches for the two shapes the ingester issues:
+// instances of the entry card's exported classes, and all base-realm Spec
+// cards (filtered by specType + ref in the ingester itself). The type anchor
+// arrives `item.`-addressed (`filter['item.on']`) — the search-entry grammar
+// `_search-v2` speaks.
+function fakeSearchData(
+  bodyStr: string,
+): { id: string; attributes?: unknown }[] {
   let body = JSON.parse(bodyStr) as {
-    filter?: { type?: { module?: string; name?: string } };
+    filter?: { 'item.on'?: { module?: string; name?: string } };
   };
-  let type = body.filter?.type;
-  if (type?.module === 'https://cardstack.com/base/spec') {
+  let on = body.filter?.['item.on'];
+  if (on?.module === 'https://cardstack.com/base/spec') {
     return [
       {
         id: `${ROOT}Spec/gadget`,
@@ -193,10 +198,25 @@ function fakeSearchData(bodyStr: string): unknown[] {
       },
     ];
   }
-  if (type?.module === GADGET_MODULE_ABS && type?.name === 'Gadget') {
+  if (on?.module === GADGET_MODULE_ABS && on?.name === 'Gadget') {
     return [{ id: `${ROOT}Gadget/g1` }];
   }
   return [];
+}
+
+// Wrap matched cards as a data-only search-entry document — one entry per card
+// linking its `item`, with the card resources themselves in `included` (the
+// shape `_search-v2` returns; a published realm carries its matches the same
+// way, so the ingester needs no published-vs-normal special-casing).
+function searchEntryDoc(cards: { id: string; attributes?: unknown }[]) {
+  return {
+    data: cards.map((card) => ({
+      id: card.id,
+      relationships: { item: { data: { type: 'card', id: card.id } } },
+    })),
+    included: cards.map((card) => ({ type: 'card', ...card })),
+    meta: { page: { total: cards.length } },
+  };
 }
 
 // Auth is supplied directly via `authenticator`, so the profile manager is

--- a/packages/boxel-cli/tests/commands/ingest-card.test.ts
+++ b/packages/boxel-cli/tests/commands/ingest-card.test.ts
@@ -4,34 +4,9 @@ import {
   extractExportedClassNames,
   extractRelationshipLinks,
   resolveSameRealmFile,
-  selectSearchResults,
 } from '../../src/commands/realm/ingest-card.js';
 
 describe('ingest-card helpers', () => {
-  describe('selectSearchResults', () => {
-    it('uses `data` when present (normal realm)', () => {
-      let json = {
-        data: [{ id: 'a' }, { id: 'b' }],
-        included: [{ id: 'dep' }],
-      };
-      expect(selectSearchResults(json)).toEqual([{ id: 'a' }, { id: 'b' }]);
-    });
-
-    it('falls back to `included` when `data` is empty (published realm)', () => {
-      // The catalog returns matches in `included` with `data: []`.
-      let json = { data: [], included: [{ id: 'spec-1' }, { id: 'spec-2' }] };
-      expect(selectSearchResults(json)).toEqual([
-        { id: 'spec-1' },
-        { id: 'spec-2' },
-      ]);
-    });
-
-    it('returns [] when both are empty/absent', () => {
-      expect(selectSearchResults({})).toEqual([]);
-      expect(selectSearchResults({ data: [], included: [] })).toEqual([]);
-    });
-  });
-
   describe('extractRelationshipLinks', () => {
     it('collects linksToMany (field.N) + linksTo self URLs, skipping nulls', () => {
       let src = JSON.stringify({


### PR DESCRIPTION
`ingest-card` discovers a card's instances and Specs by querying the **source realm's own** search endpoint (not the profile-scoped federated search, so a shared/published source realm like the catalog is reachable). This moves that query from the legacy v1 `_search` to the per-realm **`_search-v2`** with the data-only fieldset (`fields[search-entry]=item`), reading the matched `item` serializations out of the search-entry document's `included` via the shared `itemsFromSearchEntryDoc`.

The v1 path needed `selectSearchResults` to paper over a quirk: a normal realm returns matches in `data`, but a **published realm returns them in `included` with empty `data`**. The v2 entry model removes that ambiguity — every match is a `search-entry` in `data` that references its `item` in `included` — so normal and published realms read identically, and `selectSearchResults` (plus its fallback) is deleted. `searchEntryRequestBody`'s `realms` argument is now optional so the per-realm body omits it; the federated callers still pass it.

Verified directly against the live catalog: where v1 `_search` returns the matches in `included` with an empty `data`, `_search-v2` returns each match as a `search-entry` in `data` referencing its card in `included`.

After this, boxel-cli has no remaining v1 `_search` consumer.

## Tests

- The `ingest-card-graph` fake realm now serves `_search-v2`, returning a data-only search-entry document; `ingest-card`'s `selectSearchResults` unit tests are removed with the function. The boxel-cli unit suite is green (the `smoke` test exercises a built `dist/` and isn't run in this branch's check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
