### PR TITLE
chore: lint-guard CommonJS `__dirname`/`__filename` in ESM TS source

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,6 +94,9 @@ module.exports = {
       // Ban the CommonJS-only `__dirname`/`__filename` globals in TS source under
       // `src/` and `scripts/` — the surface that runs or gets imported as native
       // ESM, where they are `undefined`. Bundle-only modules opt out per-line.
+      // Packages with their own `root: true` ESLint config don't inherit this and
+      // must re-declare it; among the native-ESM (`type: module`) packages only
+      // `ai-bot` is `root: true`, and it does (see its `.eslintrc.cjs`).
       files: ['**/src/**/*.{ts,mts}', '**/scripts/**/*.{ts,mts}'],
       rules: {
         'no-restricted-globals': ['error', ...CJS_GLOBALS_IN_ESM],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@
 
 const {
   NO_COMPILATION_REQUIRED_TS_SELECTORS,
+  CJS_GLOBALS_IN_ESM,
 } = require('./eslint/erasable-syntax-selectors.cjs');
 
 const DATA_TEST_SELECTORS = [
@@ -87,6 +88,15 @@ module.exports = {
           ...NO_COMPILATION_REQUIRED_TS_SELECTORS,
           ...DATA_TEST_SELECTORS,
         ],
+      },
+    },
+    {
+      // Ban the CommonJS-only `__dirname`/`__filename` globals in TS source under
+      // `src/` and `scripts/` — the surface that runs or gets imported as native
+      // ESM, where they are `undefined`. Bundle-only modules opt out per-line.
+      files: ['**/src/**/*.{ts,mts}', '**/scripts/**/*.{ts,mts}'],
+      rules: {
+        'no-restricted-globals': ['error', ...CJS_GLOBALS_IN_ESM],
       },
     },
   ],

--- a/eslint/erasable-syntax-selectors.cjs
+++ b/eslint/erasable-syntax-selectors.cjs
@@ -39,4 +39,28 @@ const NO_COMPILATION_REQUIRED_TS_SELECTORS = [
   },
 ];
 
-module.exports = { NO_COMPILATION_REQUIRED_TS_SELECTORS };
+// CommonJS-only globals that are `undefined` when a module is loaded as native
+// ESM (`type: module`, or imported as ESM by another tool). `import.meta.dirname`
+// / `import.meta.url` are the ESM equivalents. Used with `no-restricted-globals`,
+// which flags only true global references — not comments, local bindings, or
+// `import.meta.dirname` member access.
+//
+// Scoped (in the configs that consume this) to `src/` and `scripts/` TS source,
+// the surface that runs/imports as ESM. Modules that ONLY ever execute as an
+// esbuild CJS bundle (where `__dirname` is real and `import.meta` is a TS1470
+// error) are the legitimate exception — opt out per-line with an
+// `// eslint-disable-next-line no-restricted-globals` and a reason.
+const CJS_GLOBALS_IN_ESM = [
+  {
+    name: '__dirname',
+    message:
+      '`__dirname` is undefined when this module is loaded as native ESM. Use `import.meta.dirname` instead. If this module only ever runs as a CJS bundle, opt out with an `eslint-disable-next-line no-restricted-globals` and a reason.',
+  },
+  {
+    name: '__filename',
+    message:
+      '`__filename` is undefined when this module is loaded as native ESM. Use `import.meta.filename` (or `fileURLToPath(import.meta.url)`) instead. If this module only ever runs as a CJS bundle, opt out with an `eslint-disable-next-line no-restricted-globals` and a reason.',
+  },
+];
+
+module.exports = { NO_COMPILATION_REQUIRED_TS_SELECTORS, CJS_GLOBALS_IN_ESM };

--- a/packages/ai-bot/.eslintrc.cjs
+++ b/packages/ai-bot/.eslintrc.cjs
@@ -4,6 +4,7 @@
 // erasable-syntax rule must be re-declared from the shared list.
 const {
   NO_COMPILATION_REQUIRED_TS_SELECTORS,
+  CJS_GLOBALS_IN_ESM,
 } = require('../../eslint/erasable-syntax-selectors.cjs');
 
 module.exports = {
@@ -59,6 +60,14 @@ module.exports = {
       },
       rules: {
         '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
+    {
+      // See the root `.eslintrc.js`: ban CommonJS-only `__dirname`/`__filename`
+      // in ESM-loaded TS source. Re-declared here because this config is `root`.
+      files: ['**/src/**/*.{ts,mts}', '**/scripts/**/*.{ts,mts}'],
+      rules: {
+        'no-restricted-globals': ['error', ...CJS_GLOBALS_IN_ESM],
       },
     },
   ],

--- a/packages/boxel-cli/src/lib/test-engine.ts
+++ b/packages/boxel-cli/src/lib/test-engine.ts
@@ -377,6 +377,7 @@ function resolveBundledRealms(override: string | undefined): {
   // (e.g. the software factory), where `import.meta` is a TS1470 error. esbuild
   // provides `__dirname` in the CJS bundle (the `dist/` dir); these calls run
   // inside functions, never at import time, so ESM-source importers are fine.
+  // eslint-disable-next-line no-restricted-globals -- bundle-only; see comment above
   let cliRoot = findBoxelCliRoot(__dirname);
   let bundled = join(cliRoot, 'bundled-realms');
   if (dirExists(join(bundled, 'base'))) {
@@ -1053,6 +1054,7 @@ function resolveHostDistDir(): string {
       'dist',
     );
   }
+  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `bundledRealmDirs` above
   let cliRoot = findBoxelCliRoot(__dirname);
   let bundled = join(cliRoot, 'bundled-test-harness');
   if (fileExists(join(bundled, 'tests', 'index.html'))) {
@@ -1069,6 +1071,7 @@ function resolveHostDistDir(): string {
 }
 
 function findHostDistPackageDir(): string | undefined {
+  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `bundledRealmDirs` above
   let packageRoot = findBoxelCliRoot(__dirname);
   let packagesDir = resolve(packageRoot, '..');
   let workspaceRoot = resolve(packagesDir, '..');

--- a/packages/boxel-cli/src/lib/test-engine.ts
+++ b/packages/boxel-cli/src/lib/test-engine.ts
@@ -1054,7 +1054,7 @@ function resolveHostDistDir(): string {
       'dist',
     );
   }
-  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `bundledRealmDirs` above
+  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `resolveBundledRealms` above
   let cliRoot = findBoxelCliRoot(__dirname);
   let bundled = join(cliRoot, 'bundled-test-harness');
   if (fileExists(join(bundled, 'tests', 'index.html'))) {
@@ -1071,7 +1071,7 @@ function resolveHostDistDir(): string {
 }
 
 function findHostDistPackageDir(): string | undefined {
-  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `bundledRealmDirs` above
+  // eslint-disable-next-line no-restricted-globals -- bundle-only `__dirname`; see `resolveBundledRealms` above
   let packageRoot = findBoxelCliRoot(__dirname);
   let packagesDir = resolve(packageRoot, '..');
   let workspaceRoot = resolve(packagesDir, '..');


### PR DESCRIPTION
Follow-up to #5302, addressing @habdelra's question there: *"maybe we should audit the mono repo for more uses of `__dirname`?"*

## The audit
I swept the repo. After #5302, **boxel-cli was the only exposure** — there are zero `__dirname`/`__filename` references in non-`.cjs` source of the nine `type: module` packages (ai-bot, billing, bot-runner, matrix, postgres, realm-server, realm-test-harness, runtime-common, software-factory). The CS-11449 codemod already moved those off Node globals; boxel-cli was missed only because it isn't `type: module` — its `.ts` source gets loaded as ESM by `build-plugin.ts`.

So a one-time audit comes back clean. The point of this PR is the **durable guard** — because the bug is invisible at runtime.

## Why a lint rule, not just an audit
The breakage only shows up on the path that imports the *raw source* as ESM (`build-plugin`). On the normal path the file runs as the esbuild **CJS bundle**, where `__dirname` is real — so the shipped CLI worked and tests passed. Running things wouldn't have caught it; only static inspection does. That's exactly what a lint rule is for.

## The nuance (why this isn't a blanket ban)
`#5302` itself shows the catch: `test-engine.ts` *deliberately* keeps `__dirname`, because it's re-exported into a CommonJS-typed consumer (the software factory) where `import.meta` is a TS1470 error, and it only ever runs as the CJS bundle. So "any `__dirname` in `.ts`" is the wrong rule — the real hazard is "`__dirname` in a module loaded as raw ESM," which **isn't statically distinguishable**.

This rule therefore makes CJS globals an **opt-in, documented exception** rather than an accident:
- `no-restricted-globals` bans `__dirname`/`__filename` in TS source under `src/`/`scripts/` (the ESM-loaded/-imported surface). It flags only true global references — not comments, local bindings, or `import.meta.dirname`.
- Bundle-only modules opt out per line with `// eslint-disable-next-line no-restricted-globals -- <reason>`. The intentional `test-engine.ts` uses are annotated this way.
- Scope deliberately excludes `.cjs`, host app `.js`, the eslint plugins, and test files (vitest polyfills the globals), so there are no false positives.

## Verified
- Rule fires on a planted `__dirname`/`__filename` with the guidance message.
- All current source lints clean (including the `find-package-root.ts` doc-comment mention, which is correctly ignored).
- Configs load without error.

Stacked on #5302 (depends on its fixes to lint clean). Draft to gather input on scope before finalizing.

CS-11694.