### PR TITLE
Migrate host-mode head prefetch to the unified search API

### DIFF
--- a/packages/host/app/services/host-mode-service.ts
+++ b/packages/host/app/services/host-mode-service.ts
@@ -314,6 +314,7 @@ export default class HostModeService extends Service {
       method: 'QUERY',
       headers: {
         Accept: 'application/vnd.card+json',
+        'Content-Type': 'application/json',
       },
       credentials: 'include',
       body: JSON.stringify({

--- a/packages/host/app/services/host-mode-service.ts
+++ b/packages/host/app/services/host-mode-service.ts
@@ -304,8 +304,12 @@ export default class HostModeService extends Service {
     ) {
       realmServerURL = hostModeOrigin;
     }
-    let searchURL = new URL('_federated-search-prerendered', realmServerURL);
+    let searchURL = new URL('_federated-search-v2', realmServerURL);
     let cardJsonURL = cardURL.endsWith('.json') ? cardURL : `${cardURL}.json`;
+    // The head markup is the `head` rendering of the card's `search-entry`:
+    // an html-only query at `html.format: head`, scoped to the single card.
+    // The head HTML rides on the resolved `html` resource in `included`,
+    // reached through the entry's `html` relationship.
     let response = await fetch(searchURL.toString(), {
       method: 'QUERY',
       headers: {
@@ -314,8 +318,9 @@ export default class HostModeService extends Service {
       credentials: 'include',
       body: JSON.stringify({
         realms: [realmRoot],
-        prerenderedHtmlFormat: 'head',
         cardUrls: [cardJsonURL],
+        filter: { eq: { htmlQuery: { eq: { format: 'head' } } } },
+        fields: { 'search-entry': ['html'] },
       }),
     });
 
@@ -329,7 +334,15 @@ export default class HostModeService extends Service {
     } catch (_error) {
       return undefined;
     }
-    let headHTML: unknown = json?.data?.[0]?.attributes?.html;
+    let htmlRef = json?.data?.[0]?.relationships?.html?.data?.[0];
+    let headHTML: unknown;
+    if (htmlRef?.id) {
+      let htmlResource = (json?.included ?? []).find(
+        (resource: { type?: string; id?: string }) =>
+          resource?.type === 'html' && resource?.id === htmlRef.id,
+      );
+      headHTML = htmlResource?.attributes?.html;
+    }
     return typeof headHTML === 'string' ? headHTML : null;
   }
 

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -421,6 +421,115 @@ module('Acceptance | host mode tests', function (hooks) {
     await percySnapshot(assert);
   });
 
+  test('host mode fetches the card head from the search API and injects it', async function (assert) {
+    // The published page talks to its realm server directly (cookie creds), so
+    // the head prefetch goes through the global fetch rather than the virtual
+    // network. Intercept the head query, assert its shape, and answer with a
+    // search-entry doc whose `html` resource carries the head markup so the
+    // injection path is exercised end-to-end.
+    let cardUrl = `${testHostModeRealmURL}Pet/mango`;
+    let htmlId = `${cardUrl}#head#${testHostModeRealmURL}pet/Pet`;
+    let capturedHeadQuery: any;
+    let realFetch = globalThis.fetch;
+    globalThis.fetch = async (input: any, init?: any) => {
+      let url = typeof input === 'string' ? input : (input?.url ?? '');
+      if (url.includes('_federated-search-v2') && init?.body) {
+        let body = JSON.parse(init.body);
+        if (body?.filter?.eq?.htmlQuery) {
+          capturedHeadQuery = body;
+          return new Response(
+            JSON.stringify({
+              data: [
+                {
+                  type: 'search-entry',
+                  id: cardUrl,
+                  relationships: {
+                    html: { data: [{ type: 'html', id: htmlId }] },
+                  },
+                },
+              ],
+              included: [
+                {
+                  type: 'html',
+                  id: htmlId,
+                  attributes: {
+                    format: 'head',
+                    html: '<title data-test-card-head-title>Mango</title>\n<meta property="og:title" content="Mango" />',
+                  },
+                },
+              ],
+              meta: { page: { total: 1 } },
+            }),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/vnd.card+json' },
+            },
+          );
+        }
+      }
+      return realFetch(input, init);
+    };
+
+    // The realm server serves index.html with these boundary markers, between
+    // which the host injects the card's prerendered <head>. The test harness
+    // index.html has none, so stand them in to observe the injection.
+    let headStart = document.createElement('meta');
+    headStart.setAttribute('data-boxel-head-start', '');
+    let headEnd = document.createElement('meta');
+    headEnd.setAttribute('data-boxel-head-end', '');
+    document.head.append(headStart, headEnd);
+
+    try {
+      await visit('/test/Pet/mango.json');
+
+      // The request is the v2 head query: html-only fieldset, the `head`
+      // htmlQuery, scoped to the visited card.
+      assert.deepEqual(
+        capturedHeadQuery?.fields,
+        { 'search-entry': ['html'] },
+        'requests only the html branch',
+      );
+      assert.strictEqual(
+        capturedHeadQuery?.filter?.eq?.htmlQuery?.eq?.format,
+        'head',
+        'selects the head rendering',
+      );
+      assert.deepEqual(
+        capturedHeadQuery?.cardUrls,
+        [`${cardUrl}.json`],
+        'scoped to the visited card',
+      );
+
+      // og:title is emitted only by the prerendered card <head> (ember-page-title
+      // never does), so it uniquely marks the injected markup.
+      let ogTitle = document.head.querySelector('meta[property="og:title"]');
+      assert.ok(
+        ogTitle,
+        'the head markup from the search response is injected',
+      );
+      assert.strictEqual(
+        ogTitle?.getAttribute('content'),
+        'Mango',
+        'the injected head markup is the visited card head',
+      );
+
+      let hostModeService = getService('host-mode-service') as HostModeService;
+      assert.true(
+        hostModeService.headTemplateContainsTitle,
+        'the fetched head markup carries a title',
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+      for (let node = headStart.nextSibling; node && node !== headEnd; ) {
+        let next = node.nextSibling;
+        node.remove();
+        node = next;
+      }
+      headStart.remove();
+      headEnd.remove();
+    }
+  });
+
   test('visiting a non-existent card shows an error', async function (assert) {
     let store = getService('store') as StoreService;
     let originalGet = store.get.bind(store);

--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -229,6 +229,57 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('html.format: head selects the document head rendering', async function (assert) {
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        personQuery({
+          filterEq: { htmlQuery: { eq: { format: 'head' } } },
+          fields: { 'search-entry': ['html'] },
+        }),
+      );
+      assert.deepEqual(doc.meta.htmlQuery, { eq: { format: 'head' } });
+      // `head` is a scalar column rendered at the row's own native type, so its
+      // composite id carries the native key like the keyed formats do.
+      let htmlId = `${johnId}#head#${personKey}`;
+      assert.deepEqual(htmlIdsOf(entryFor(doc, johnId)!), [htmlId]);
+      let html = htmlIn(doc, htmlId)!;
+      assert.strictEqual(html.attributes.format, 'head');
+      assert.true(
+        normalizedHtml(html).includes('data-test-card-head-title'),
+        `head rendering carries the card head <title>: ${html.attributes.html}`,
+      );
+    });
+
+    test('html.format: head scoped to a single card URL returns only that card head markup', async function (assert) {
+      // Mirrors the host-mode published-view head prefetch: an html-only query
+      // at html.format: head, scoped to the single card by cardUrls.
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        parseSearchEntryQueryFromPayload({
+          cardUrls: [`${johnId}.json`],
+          filter: { eq: { htmlQuery: { eq: { format: 'head' } } } },
+          fields: { 'search-entry': ['html'] },
+        }),
+      );
+      assert.strictEqual(
+        doc.data.length,
+        1,
+        'only the scoped card is returned',
+      );
+      let entry = entryFor(doc, johnId)!;
+      let htmlId = `${johnId}#head#${personKey}`;
+      assert.deepEqual(htmlIdsOf(entry), [htmlId]);
+      assert.strictEqual(
+        entry.relationships.item,
+        undefined,
+        'the html-only fieldset carries no item branch',
+      );
+      let html = htmlIn(doc, htmlId)!;
+      assert.strictEqual(html.attributes.format, 'head');
+      assert.true(
+        normalizedHtml(html).includes('data-test-card-head-title'),
+        `head rendering carries the card head <title>: ${html.attributes.html}`,
+      );
+    });
+
     test('a disjunctive htmlQuery selects several renderings per entry', async function (assert) {
       let doc = await testRealm.realmIndexQueryEngine.searchEntries(
         personQuery({


### PR DESCRIPTION
Moves the host-mode published-view head prefetch off the legacy `/_federated-search-prerendered` endpoint and onto the unified search API.

`host-mode-service`'s `fetchPrerenderedHead` now issues a `search-entry`-rooted query against `/_federated-search-v2`: an html-only fieldset (`fields[search-entry]=['html']`) selecting `html.format: head`, scoped to the single card via `cardUrls`. It reads the head markup off the resolved `html` resource in `included` (reached through the entry's `html` relationship) instead of the legacy top-level `data[0].attributes.html`. The `<head>` injection — single-title handling, the boundary-marker replacement, and the undefined/null/string return contract — is unchanged.

No server change was needed: `head` is already projected on the v2 card path (`renderSet` selects `head_html`, and the engine enumerates a `head` candidate at the row's native type). This was the only consumer still calling one of the four legacy endpoints.

## Tests
- Engine: `html.format: head` returns the card head rendering, including the `cardUrls`-scoped form the host issues (head was previously exercised only against a synthetic rendering universe).
- Host: the head prefetch issues the head query in the expected shape and injects the returned `<head>` markup on the published view.
