### PR TITLE
Remove Puppeteer Chrome download in browserless deploy images

### DIFF
--- a/packages/ai-bot/Dockerfile
+++ b/packages/ai-bot/Dockerfile
@@ -6,6 +6,9 @@ ARG PNPM_VERSION
 RUN apt-get update && apt-get install -y python3 build-essential
 RUN npm install -g pnpm@${PNPM_VERSION}
 WORKDIR /boxel
+# This image never launches a browser, so skip Puppeteer's Chrome download. Its
+# extractor needs a native tar/unzip binary that node:slim doesn't ship.
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 COPY . .
 RUN pnpm install --frozen-lockfile
 

--- a/packages/bot-runner/Dockerfile
+++ b/packages/bot-runner/Dockerfile
@@ -6,6 +6,9 @@ ARG PNPM_VERSION
 RUN apt-get update && apt-get install -y python3 build-essential
 RUN npm install -g pnpm@${PNPM_VERSION}
 WORKDIR /boxel
+# This image never launches a browser, so skip Puppeteer's Chrome download. Its
+# extractor needs a native tar/unzip binary that node:slim doesn't ship.
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 COPY . .
 RUN pnpm install --frozen-lockfile
 

--- a/packages/postgres/Dockerfile
+++ b/packages/postgres/Dockerfile
@@ -6,6 +6,9 @@ ARG PNPM_VERSION
 RUN apt-get update && apt-get install -y postgresql
 RUN npm install -g pnpm@${PNPM_VERSION}
 WORKDIR /boxel
+# This image never launches a browser, so skip Puppeteer's Chrome download. Its
+# extractor needs a native tar/unzip binary that node:slim doesn't ship.
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 
 # Cache-friendly dependency fetch: this layer only re-runs when the lockfile
 # (or patches it references) changes, not on every source edit. `pnpm fetch`


### PR DESCRIPTION
This has been resulting in silent deployment failures.