### PR TITLE
Add filter for migrations

### DIFF
--- a/packages/postgres/Dockerfile
+++ b/packages/postgres/Dockerfile
@@ -20,4 +20,11 @@ RUN CI=1 pnpm install -r --offline
 
 WORKDIR /boxel/packages/postgres
 
-CMD node ./scripts/fix-migration-names.ts && ./node_modules/.bin/node-pg-migrate --check-order false --migrations-table migrations up && sleep infinity
+# --ignore-pattern keeps node-pg-migrate from treating non-migration files in
+# the migrations directory (the `{ "type": "commonjs" }` package.json that
+# pins migrations to CommonJS, plus .eslintrc.js) as migrations. Without it,
+# package.json is loaded as a migration, has no `up` export, and the whole `up`
+# run errors and rolls back — so no migrations apply. Mirrors the `migrate`
+# script in package.json. (.eslintrc.js is a dotfile and ignored by default;
+# package.json is not, so it must be listed explicitly.)
+CMD node ./scripts/fix-migration-names.ts && ./node_modules/.bin/node-pg-migrate --check-order false --migrations-table migrations --ignore-pattern '.*\.eslintrc\.js|package\.json' up && sleep infinity


### PR DESCRIPTION
Migrations haven’t been running since #5265 added a `package.json` in the migrations
directory, which was causing `node-pg-migrate` to choke.