### PR TITLE
Sync Synapse custom modules to staging/prod

### DIFF
--- a/.github/workflows/sync-synapse-assets.yml
+++ b/.github/workflows/sync-synapse-assets.yml
@@ -1,10 +1,11 @@
-name: Sync Matrix Synapse Email Templates
+name: Sync Matrix Synapse Assets
 
 on:
   push:
     branches: [main]
     paths:
       - "packages/matrix/support/synapse/templates/**"
+      - "packages/matrix/support/synapse/modules/**"
   workflow_dispatch:
     inputs:
       environment:
@@ -20,7 +21,7 @@ jobs:
   sync:
     name: sync
     runs-on: ubuntu-latest
-    concurrency: sync-synapse-templates-${{ inputs.environment || 'staging' }}
+    concurrency: sync-synapse-assets-${{ inputs.environment || 'staging' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -62,9 +63,13 @@ jobs:
         run: |
           sed -i "s/d12nxmpmo97fii.cloudfront.net\/boxel-icon.png/${{ env.BOXEL_ICON_DOMAIN_AND_PATH }}/" packages/matrix/support/synapse/templates/_base.html
 
-      - name: S3 Sync
+      - name: S3 Sync templates
         run: |
           aws s3 sync packages/matrix/support/synapse/templates s3://${{ env.AWS_S3_BUCKET }}/templates
+
+      - name: S3 Sync modules
+        run: |
+          aws s3 sync packages/matrix/support/synapse/modules s3://${{ env.AWS_S3_BUCKET }}/modules --exclude "test_*"
 
       - name: Restart Synapse ECS Service
         run: |


### PR DESCRIPTION
## What

Extends the Synapse asset-sync workflow to ship the custom Python modules under `packages/matrix/support/synapse/modules` (the OIDC `user_mapping_provider` added in #5300) to staging/prod Synapse, alongside the existing email-template sync.

- Renames `sync-synapse-templates.yml` → `sync-synapse-assets.yml` — the workflow is no longer template-only.
- Triggers on `modules/**` in addition to `templates/**`.
- Adds a second `aws s3 sync` step pushing `modules` → `s3://$BUCKET/modules`, excluding test files (`--exclude "test_*"`).
- The existing `aws ecs update-service --force-new-deployment` step already restarts Synapse and picks up both synced directories.

## Why

Part of provisioning Google sign-in on staging. The dev mapping provider currently only runs locally; this carries it to the deployed Synapse. The matching `cardstack/infra` PR mounts `s3://$BUCKET/modules` into the container at `/data/modules` and sets `PYTHONPATH` so Synapse can import it.

## Sequencing

This is one of three PRs. It is safe to merge independently — it only makes the module available in S3. The host feature-flag flip (a separate PR) lands last, after the infra OIDC config is deployed and verified.

## Testing

After merge, the `Sync Matrix Synapse Assets` workflow run should push `boxel_oidc_mapping_provider.py` to `s3://cardstack-matrix-synapse-staging/modules` and restart `synapse-staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)