### PR TITLE
Migrate cross-realm query-backed field resolution to /_search-v2

### DIFF
--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -4382,7 +4382,7 @@ module('Integration | serialization', function (hooks) {
     let favoriteSearchURL = new URL(favoriteSearchLink!);
     assert.strictEqual(
       favoriteSearchURL.href.split('?')[0],
-      new URL('_search', testRealmURL).href,
+      new URL('_search-v2', testRealmURL).href,
       'favorite search link points to canonical search endpoint',
     );
     let favoriteQueryParams = parseQueryString(
@@ -4411,7 +4411,7 @@ module('Integration | serialization', function (hooks) {
     let matchesSearchURL = new URL(matchesSearchLink!);
     assert.strictEqual(
       matchesSearchURL.href.split('?')[0],
-      new URL('_search', testRealmURL).href,
+      new URL('_search-v2', testRealmURL).href,
       'matches search link points to canonical search endpoint',
     );
     let matchesQueryParams = parseQueryString(
@@ -4454,7 +4454,7 @@ module('Integration | serialization', function (hooks) {
     let emptyMatchesSearchURL = new URL(emptyMatchesSearchLink!);
     assert.strictEqual(
       emptyMatchesSearchURL.href.split('?')[0],
-      new URL('_search', testRealmURL).href,
+      new URL('_search-v2', testRealmURL).href,
       'emptyMatches search link points to canonical search endpoint',
     );
 

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -4614,7 +4614,7 @@ module(basename(import.meta.filename), function () {
       let favoriteSearchURL = new URL(favoriteSearchLink);
       assert.strictEqual(
         favoriteSearchURL.href.split('?')[0],
-        new URL('_search', consumerRealmURL).href,
+        new URL('_search-v2', consumerRealmURL).href,
         'favorite relationship search link targets consumer realm',
       );
       let favoriteQueryParams = parseSearchQuery(favoriteSearchURL);
@@ -4696,7 +4696,7 @@ module(basename(import.meta.filename), function () {
       );
       assert.strictEqual(
         matchesSearchURL.href.split('?')[0],
-        new URL('_search', providerRealmURL).href,
+        new URL('_search-v2', providerRealmURL).href,
         'matches relationship search link targets provider realm',
       );
       let matchesQueryParams = parseSearchQuery(matchesSearchURL);
@@ -4749,7 +4749,7 @@ module(basename(import.meta.filename), function () {
       );
       assert.strictEqual(
         failingSearchURL.href.split('?')[0],
-        new URL('_search', UNREACHABLE_REALM_URL).href,
+        new URL('_search-v2', UNREACHABLE_REALM_URL).href,
         'failingMatches search link targets unreachable realm',
       );
       let failingQueryParams = parseSearchQuery(failingSearchURL);

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -296,6 +296,7 @@ const ALL_TEST_FILES: string[] = [
   './package-shim-handler-test',
   './command-parsing-utils-test',
   './query-matches-filter-test',
+  './parse-search-url-test',
   './matches-filter-integration-test',
   './eq-containment-integration-test',
   './search-in-flight-key-test',

--- a/packages/realm-server/tests/parse-search-url-test.ts
+++ b/packages/realm-server/tests/parse-search-url-test.ts
@@ -1,0 +1,55 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import { buildQuerySearchURL, parseSearchURL } from '@cardstack/runtime-common';
+import type { Query } from '@cardstack/runtime-common';
+
+module(basename(import.meta.filename), function () {
+  module('parseSearchURL realm recovery', function () {
+    const realm = 'http://example.test/my-realm/';
+    const query: Query = {
+      filter: { type: { module: `${realm}person`, name: 'Person' } },
+    };
+
+    test('recovers the realm from a built v2 search URL', async function (assert) {
+      let { realm: recovered, query: recoveredQuery } = parseSearchURL(
+        buildQuerySearchURL(realm, query),
+      );
+      assert.strictEqual(recovered.href, realm, 'realm round-trips');
+      assert.deepEqual(
+        recoveredQuery.filter,
+        query.filter,
+        'query round-trips',
+      );
+    });
+
+    test('strips the _search-v2 segment without leaving a double slash', async function (assert) {
+      let { realm: recovered } = parseSearchURL(
+        new URL('_search-v2', realm).href,
+      );
+      assert.strictEqual(recovered.href, realm);
+    });
+
+    test('strips a trailing-slash _search-v2 segment without leaving a double slash', async function (assert) {
+      let { realm: recovered } = parseSearchURL(`${realm}_search-v2/`);
+      assert.strictEqual(recovered.href, realm);
+    });
+
+    test('strips the legacy _search segment', async function (assert) {
+      let { realm: recovered } = parseSearchURL(new URL('_search', realm).href);
+      assert.strictEqual(recovered.href, realm);
+    });
+
+    test('strips a trailing-slash legacy _search segment', async function (assert) {
+      let { realm: recovered } = parseSearchURL(`${realm}_search/`);
+      assert.strictEqual(recovered.href, realm);
+    });
+
+    test('recovers a root realm', async function (assert) {
+      let { realm: recovered } = parseSearchURL(
+        'http://example.test/_search-v2',
+      );
+      assert.strictEqual(recovered.href, 'http://example.test/');
+    });
+  });
+});

--- a/packages/realm-server/tests/parse-search-url-test.ts
+++ b/packages/realm-server/tests/parse-search-url-test.ts
@@ -1,14 +1,18 @@
 import QUnit from 'qunit';
 const { module, test } = QUnit;
 import { basename } from 'path';
-import { buildQuerySearchURL, parseSearchURL } from '@cardstack/runtime-common';
+import {
+  buildQuerySearchURL,
+  parseSearchURL,
+  rri,
+} from '@cardstack/runtime-common';
 import type { Query } from '@cardstack/runtime-common';
 
 module(basename(import.meta.filename), function () {
   module('parseSearchURL realm recovery', function () {
     const realm = 'http://example.test/my-realm/';
     const query: Query = {
-      filter: { type: { module: `${realm}person`, name: 'Person' } },
+      filter: { type: { module: rri(`${realm}person`), name: 'Person' } },
     };
 
     test('recovers the realm from a built v2 search URL', async function (assert) {

--- a/packages/runtime-common/query-field-utils.ts
+++ b/packages/runtime-common/query-field-utils.ts
@@ -319,8 +319,12 @@ export function getValueForResourcePath(
 
 export function buildQuerySearchURL(realmHref: string, query: Query): string {
   let baseHref = realmHref.endsWith('/') ? realmHref : `${realmHref}/`;
-  let searchURL = new URL('./_search', baseHref);
+  let searchURL = new URL('./_search-v2', baseHref);
   searchURL.searchParams.set('realms', baseHref);
+  // A query-backed field resolves to linked instances, so it asks the
+  // search-entry engine for a data-only projection: each entry carries its
+  // full `item` (`card`/`file-meta`) serialization, no prerendered HTML.
+  searchURL.searchParams.set('fields[search-entry]', 'item');
   let normalizedQuery = normalizeQueryForSignature(query);
   searchURL.searchParams.set('query', buildQueryParamValue(normalizedQuery));
   return searchURL.href;

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -726,12 +726,11 @@ export function parseSearchURL(searchURL: string | URL): {
     ? parseQuery(queryParam)
     : parseQuery(url.search.slice(1));
 
-  // strip the trailing "_search" path segment to recover the realm URL
-  if (url.pathname.endsWith('_search')) {
-    url.pathname = url.pathname.replace(/_search$/, '');
-  } else if (url.pathname.endsWith('_search/')) {
-    url.pathname = url.pathname.replace(/_search\/$/, '/');
-  }
+  // Strip the trailing search path segment — the v2 `_search-v2` or the
+  // legacy `_search` — to recover the realm URL.
+  url.pathname = url.pathname.replace(/_search(?:-v2)?\/?$/, (segment) =>
+    segment.endsWith('/') ? '/' : '',
+  );
   url.search = '';
 
   return { query, realm: url };

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -727,10 +727,11 @@ export function parseSearchURL(searchURL: string | URL): {
     : parseQuery(url.search.slice(1));
 
   // Strip the trailing search path segment — the v2 `_search-v2` or the
-  // legacy `_search` — to recover the realm URL.
-  url.pathname = url.pathname.replace(/_search(?:-v2)?\/?$/, (segment) =>
-    segment.endsWith('/') ? '/' : '',
-  );
+  // legacy `_search`, with or without a trailing slash — to recover the
+  // realm URL. Matching the segment's leading slash and substituting a
+  // single `/` leaves exactly one separator (a trailing-slash input like
+  // `/realm/_search-v2/` must not collapse to `/realm//`).
+  url.pathname = url.pathname.replace(/\/_search(?:-v2)?\/?$/, '/');
   url.search = '';
 
   return { query, realm: url };

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -56,8 +56,9 @@ import {
   type LinkableCollectionDocument,
   type SearchEntryCollectionDocument,
   type SearchEntryIncludedResource,
-  isLinkableCollectionDocument,
+  isSearchEntryCollectionDocument,
 } from './document-types.ts';
+import { resourceIdentity } from './resource-identity.ts';
 import { relationshipEntries } from './relationship-utils.ts';
 import type {
   CardResource,
@@ -82,6 +83,7 @@ import {
   htmlQueryHasRenderTypePredicate,
   htmlQueryMatches,
   resolveHtmlQuery,
+  searchEntryWireQueryFromQuery,
   type RenderingCandidate,
   type SearchEntryQuery,
 } from './search-entry.ts';
@@ -1408,12 +1410,22 @@ export class RealmIndexQueryEngine {
         realms?: string[];
       };
       let realmList = realms ?? (realm ? [realm] : [realmHref]);
+      // Resolve the cross-realm query-backed field against the peer realm's
+      // v2 `/_search-v2` endpoint, data-only: the legacy card-rooted query
+      // translates to the search-entry wire grammar, and the `item` fieldset
+      // makes every entry carry its full `card`/`file-meta` serialization.
+      let wireQuery = searchEntryWireQueryFromQuery(
+        queryWithoutRealm as Query,
+        {
+          fields: ['item'],
+        },
+      );
       let response = await this.#fetch(searchURL, {
         method: 'QUERY',
         headers: {
           Accept: SupportedMimeType.CardJson,
         },
-        body: JSON.stringify({ ...queryWithoutRealm, realms: realmList }),
+        body: JSON.stringify({ ...wireQuery, realms: realmList }),
       });
       if (!response.ok) {
         let type: QueryFieldErrorType =
@@ -1434,7 +1446,7 @@ export class RealmIndexQueryEngine {
         };
       }
       let json = await response.json();
-      if (!isLinkableCollectionDocument(json)) {
+      if (!isSearchEntryCollectionDocument(json)) {
         return {
           cards: [],
           error: {
@@ -1444,7 +1456,38 @@ export class RealmIndexQueryEngine {
           },
         };
       }
-      return { cards: json.data };
+      // The matched instances ride in `included` as `card`/`file-meta`
+      // resources, reached through each entry's `item` relationship; recover
+      // them in entry (sorted) order — the linked resources this field
+      // resolves to.
+      let itemsByIdentity = new Map<
+        string,
+        CardResource<Saved> | FileMetaResource
+      >();
+      for (let resource of json.included ?? []) {
+        if (
+          (resource.type === CardResourceType ||
+            resource.type === FileMetaResourceType) &&
+          resource.id
+        ) {
+          itemsByIdentity.set(
+            resourceIdentity(resource.type, resource.id),
+            resource,
+          );
+        }
+      }
+      let cards: (CardResource<Saved> | FileMetaResource)[] = [];
+      for (let entry of json.data) {
+        let ref = entry.relationships.item?.data;
+        if (!ref) {
+          continue;
+        }
+        let item = itemsByIdentity.get(resourceIdentity(ref.type, ref.id));
+        if (item) {
+          cards.push(item);
+        }
+      }
+      return { cards };
     } catch (err: unknown) {
       let message =
         err instanceof Error ? err.message : String(err ?? 'unknown error');


### PR DESCRIPTION
The realm-server still resolved **cross-realm** query-backed fields against a peer realm's legacy `/_search`: when a query-backed field (e.g. `linksToMany(X, { query })`) targets a *different* realm, `RealmIndexQueryEngine.fetchRemoteQueryResults` issued `QUERY <peerRealm>/_search` and read the linked resources off the response's top-level `data` array (`LinkableCollectionDocument`). This was the last server-side consumer of `/_search` + `LinkableCollectionDocument`.

This moves that resolution onto the unified search API (`/_search-v2`), with no change to which instances a field resolves to. Same-realm resolution is untouched — it already runs against the local index.

## What changed

- **`buildQuerySearchURL`** targets `/_search-v2` with a data-only projection (`fields[search-entry]=item`), so every entry carries its full `item` (`card`/`file-meta`) serialization and no prerendered HTML. The `query`/`realms` params are kept so the seed search link (`relationships.{field}.links.search`) still round-trips through `parseSearchURL`.
- **`fetchRemoteQueryResults`** translates the normalized card-rooted query into the `search-entry` wire grammar and recovers each entry's `item` serialization from `included` (in entry/sort order) instead of reading a top-level `data` array of cards.
- **`parseSearchURL`** strips a trailing `_search-v2` (as well as the legacy `_search`) when recovering the realm URL from a seed search link.

The data-only projection always carries the matched `item` resources in `included` regardless of `omitIncluded` (that flag only gates the transitive `loadLinks` expansion), so the indexing/prerender path resolves the same way.

## Testing

- `pnpm lint` (types + eslint) clean for `runtime-common`.
- The cross-realm query-backed resolver suite (`card-endpoints-test.ts` → "Query-backed relationships runtime resolver") passes through the v2 path: a `linksToMany` field targeting a peer realm resolves the same linked instance, and a query against an unreachable realm still records the error and exposes the seed link. Its seed-link assertions (and the same-realm ones in `serialization-test.gts`) now expect the `_search-v2` path; the resolved-data assertions are unchanged.

Gates the legacy-endpoint retirement (CS-11594).

[CS-11705](https://linear.app/cardstack/issue/CS-11705)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
