### PR TITLE
Fix broken software-factory/realm types

### DIFF
--- a/packages/software-factory/realm/darkfactory.gts
+++ b/packages/software-factory/realm/darkfactory.gts
@@ -10,11 +10,11 @@ import MarkdownField from 'https://cardstack.com/base/markdown';
 
 // Re-export (not subclass) so `darkfactory#Issue` stays identical to
 // `issue-tracker#Issue` — subclassing forks the type identity.
-import { Issue, Project, IssueTracker } from './issue-tracker';
+import { Issue, Project, IssueTracker } from './issue-tracker.gts';
 export { Issue, Project, IssueTracker };
-export { AgentProfile } from './agent-profile';
-export { Comment } from './comment';
-export { KnowledgeArticle } from './knowledge-article';
+export { AgentProfile } from './agent-profile.gts';
+export { Comment } from './comment.gts';
+export { KnowledgeArticle } from './knowledge-article.gts';
 
 export class DarkFactory extends CardDef {
   static displayName = 'Dark Factory';

--- a/packages/software-factory/realm/document.gts
+++ b/packages/software-factory/realm/document.gts
@@ -473,7 +473,7 @@ export class Document extends CardDef {
   static isolated = class Isolated extends Component<typeof this> {
     // ¹⁷ Isolated format matching SkillPlus layout
 
-    handleTocClick = (event: MouseEvent) => {
+    handleTocClick = (event: Event) => {
       const target = event.target as HTMLElement | null;
       const anchor = target?.closest?.('a') as HTMLAnchorElement | null;
       if (!anchor) return;

--- a/packages/software-factory/realm/eval-result.gts
+++ b/packages/software-factory/realm/eval-result.gts
@@ -11,7 +11,7 @@ import StringField from 'https://cardstack.com/base/string';
 import NumberField from 'https://cardstack.com/base/number';
 import DateTimeField from 'https://cardstack.com/base/datetime';
 import enumField from 'https://cardstack.com/base/enum';
-import { Project, Issue } from './darkfactory';
+import { Project, Issue } from './darkfactory.gts';
 
 export const EvalResultStatusField = enumField(StringField, {
   options: [

--- a/packages/software-factory/realm/instantiate-result.gts
+++ b/packages/software-factory/realm/instantiate-result.gts
@@ -14,7 +14,7 @@ import DateTimeField from 'https://cardstack.com/base/datetime';
 import CodeRefField from 'https://cardstack.com/base/code-ref';
 import enumField from 'https://cardstack.com/base/enum';
 import { RealmPaths } from '@cardstack/runtime-common';
-import { Project, Issue } from './darkfactory';
+import { Project, Issue } from './darkfactory.gts';
 
 export const InstantiateResultStatusField = enumField(StringField, {
   options: [

--- a/packages/software-factory/realm/issue-option.gts
+++ b/packages/software-factory/realm/issue-option.gts
@@ -8,7 +8,7 @@ import ColorField from 'https://cardstack.com/base/color';
 import StringField from 'https://cardstack.com/base/string';
 
 import { FieldContainer } from '@cardstack/boxel-ui/components';
-import { StatusPill } from './status-pill';
+import { StatusPill } from './status-pill.gts';
 
 export class IssueOptionField extends FieldDef {
   @field value = contains(StringField);

--- a/packages/software-factory/realm/issue-tracker.gts
+++ b/packages/software-factory/realm/issue-tracker.gts
@@ -50,9 +50,9 @@ import SquareKanban from '@cardstack/boxel-icons/square-kanban';
 
 import { realmURL, type ResolvedCodeRef } from '@cardstack/runtime-common';
 
-import { KanbanBoard } from './kanban-board';
-import { KanbanColumnField } from './kanban-column';
-import { KanbanBoardPlacement } from './kanban-board-placement';
+import { KanbanBoard } from './kanban-board.gts';
+import { KanbanColumnField } from './kanban-column.gts';
+import { KanbanBoardPlacement } from './kanban-board-placement.gts';
 import {
   issueStatusOptions,
   issuePriorityOptions,
@@ -71,11 +71,11 @@ import {
   ProjectStatusField,
   GroupByField,
   type Column,
-} from './kanban-config';
-import { Comment } from './comment';
-import { KnowledgeArticle } from './knowledge-article';
-import { StatusPill } from './status-pill';
-import { IssueOptionField } from './issue-option';
+} from './kanban-config.gts';
+import { Comment } from './comment.gts';
+import { KnowledgeArticle } from './knowledge-article.gts';
+import { StatusPill } from './status-pill.gts';
+import { IssueOptionField } from './issue-option.gts';
 
 const issueCodeRef: ResolvedCodeRef = {
   // @ts-expect-error this is not a CJS file, import.meta is allowed

--- a/packages/software-factory/realm/kanban-board.gts
+++ b/packages/software-factory/realm/kanban-board.gts
@@ -30,8 +30,8 @@ import { cn, eq } from '@cardstack/boxel-ui/helpers';
 import Settings from '@cardstack/boxel-icons/settings';
 import SquareKanban from '@cardstack/boxel-icons/square-kanban';
 
-import { KanbanColumnField } from './kanban-column';
-import { KanbanBoardPlacement } from './kanban-board-placement';
+import { KanbanColumnField } from './kanban-column.gts';
+import { KanbanBoardPlacement } from './kanban-board-placement.gts';
 
 class KanbanBoardIsolated extends Component<typeof KanbanBoard> {
   @tracked isSidebarOpen = false;

--- a/packages/software-factory/realm/kanban-config.gts
+++ b/packages/software-factory/realm/kanban-config.gts
@@ -1,7 +1,7 @@
 import StringField from 'https://cardstack.com/base/string';
 import enumField from 'https://cardstack.com/base/enum';
 
-import { IssueOptionField } from './issue-option';
+import { IssueOptionField } from './issue-option.gts';
 
 export interface Option {
   value: string;

--- a/packages/software-factory/realm/knowledge-article.gts
+++ b/packages/software-factory/realm/knowledge-article.gts
@@ -22,7 +22,7 @@ import { eq } from '@cardstack/boxel-ui/helpers';
 
 import BookOpen from '@cardstack/boxel-icons/book-open';
 
-import { AgentProfile } from './agent-profile';
+import { AgentProfile } from './agent-profile.gts';
 
 export const KnowledgeTypeField = enumField(StringField, {
   options: [

--- a/packages/software-factory/realm/lint-result.gts
+++ b/packages/software-factory/realm/lint-result.gts
@@ -11,7 +11,7 @@ import StringField from 'https://cardstack.com/base/string';
 import NumberField from 'https://cardstack.com/base/number';
 import DateTimeField from 'https://cardstack.com/base/datetime';
 import enumField from 'https://cardstack.com/base/enum';
-import { Project, Issue } from './darkfactory';
+import { Project, Issue } from './darkfactory.gts';
 
 export const LintResultStatusField = enumField(StringField, {
   options: [

--- a/packages/software-factory/realm/parse-result.gts
+++ b/packages/software-factory/realm/parse-result.gts
@@ -11,7 +11,7 @@ import StringField from 'https://cardstack.com/base/string';
 import NumberField from 'https://cardstack.com/base/number';
 import DateTimeField from 'https://cardstack.com/base/datetime';
 import enumField from 'https://cardstack.com/base/enum';
-import { Project, Issue } from './darkfactory';
+import { Project, Issue } from './darkfactory.gts';
 
 export const ParseResultStatusField = enumField(StringField, {
   options: [

--- a/packages/software-factory/realm/test-results.gts
+++ b/packages/software-factory/realm/test-results.gts
@@ -12,7 +12,7 @@ import NumberField from 'https://cardstack.com/base/number';
 import DateTimeField from 'https://cardstack.com/base/datetime';
 import CodeRefField from 'https://cardstack.com/base/code-ref';
 import enumField from 'https://cardstack.com/base/enum';
-import { Project, Issue } from './darkfactory';
+import { Project, Issue } from './darkfactory.gts';
 
 export const TestRunStatusField = enumField(StringField, {
   options: [

--- a/packages/software-factory/realm/tsconfig.json
+++ b/packages/software-factory/realm/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "allowJs": true,
+    "allowImportingTsExtensions": true,
     "moduleResolution": "node16",
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
@@ -22,11 +23,21 @@
     "strict": true,
     "experimentalDecorators": true,
     "paths": {
-      "https://cardstack.com/base/*": ["../../base/*"],
-      "@cardstack/boxel-ui": ["../../boxel-ui/addon"],
-      "@cardstack/boxel-ui/*": ["../../boxel-ui/addon/*"],
+      "https://cardstack.com/base/*": [
+        "../../base/*.gts",
+        "../../base/*.ts",
+        "../../base/*.d.ts",
+        "../../base/*"
+      ],
+      "@cardstack/boxel-ui": ["../../boxel-ui/addon/declarations"],
+      "@cardstack/boxel-ui/*": ["../../boxel-ui/addon/declarations/*"],
       "@cardstack/host/*": ["../../host/app/*"],
-      "@cardstack/host/tests/*": ["../../host/tests/*"],
+      "@cardstack/host/tests/*": [
+        "../../host/tests/*",
+        "../../host/tests/*.ts",
+        "../../host/tests/*.gts",
+        "../../host/tests/*/index.gts"
+      ],
       "*": ["../../host/types/*"]
     },
     "types": ["@cardstack/local-types", "qunit", "qunit-dom"]

--- a/packages/software-factory/realm/wiki.gts
+++ b/packages/software-factory/realm/wiki.gts
@@ -642,7 +642,7 @@ export class Wiki extends CardDef {
   static isolated = class Isolated extends Component<typeof this> {
     // Handle clicks on wiki links inside rendered markdown content
     // Resolves [[Name]] links by matching against relatedPages, falls back to URL
-    handleContentClick = (event: MouseEvent) => {
+    handleContentClick = (event: Event) => {
       const target = event.target as HTMLElement | null;
       const wikiLink = target?.closest?.('.wiki-link') as HTMLElement | null;
       if (!wikiLink) return;
@@ -687,7 +687,7 @@ export class Wiki extends CardDef {
       }
     };
 
-    handleTocClick = (event: MouseEvent) => {
+    handleTocClick = (event: Event) => {
       const target = event.target as HTMLElement | null;
       const anchor = target?.closest?.('a') as HTMLAnchorElement | null;
       if (!anchor) return;

--- a/packages/software-factory/tsconfig.json
+++ b/packages/software-factory/tsconfig.json
@@ -40,9 +40,10 @@
     "./scripts/**/*.ts",
     "./src/**/*",
     "./tests/**/*",
+    "./realm/**/*",
     "./playwright.config.ts",
     "./playwright.global-setup.ts",
     "./playwright.global-teardown.ts"
   ],
-  "exclude": ["./test-fixtures/**", "./realm/**/*"]
+  "exclude": ["./test-fixtures/**", "./realm/*.test.gts"]
 }


### PR DESCRIPTION
- fix missing types
- include most `software-factory/realm/` files in pnpm lint (previously excluded)