### PR TITLE
Migrate sync-openrouter-models command search to /_search-v2

### DIFF
--- a/packages/host/app/commands/sync-openrouter-models.ts
+++ b/packages/host/app/commands/sync-openrouter-models.ts
@@ -381,6 +381,13 @@ export default class SyncOpenRouterModelsCommand extends HostBaseCommand<
               slugs.add(slug);
             }
           }
+        } else {
+          // A 200 that isn't a search-entry document is unexpected for
+          // /_search-v2; surface it rather than silently treating every model
+          // as new (same best-effort fallback as the catch below).
+          console.warn(
+            'Unexpected /_search-v2 response shape, treating all models as new',
+          );
         }
       }
     } catch (e) {

--- a/packages/host/app/commands/sync-openrouter-models.ts
+++ b/packages/host/app/commands/sync-openrouter-models.ts
@@ -1,6 +1,11 @@
 import { service } from '@ember/service';
 
-import { SupportedMimeType, rri } from '@cardstack/runtime-common';
+import {
+  SupportedMimeType,
+  isSearchEntryCollectionDocument,
+  rri,
+  searchEntryWireQueryFromQuery,
+} from '@cardstack/runtime-common';
 import type { AtomicOperation } from '@cardstack/runtime-common/atomic-document';
 
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
@@ -333,35 +338,48 @@ export default class SyncOpenRouterModelsCommand extends HostBaseCommand<
   private async fetchExistingSlugs(realmURL: string): Promise<Set<string>> {
     let slugs = new Set<string>();
     try {
-      let response = await this.network.authedFetch(`${realmURL}_search`, {
-        method: 'QUERY',
-        headers: {
-          Accept: SupportedMimeType.CardJson,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      // Listing existing cards only needs each one's id, so ask the
+      // search-entry engine for a data-only projection
+      // (`fields[search-entry]=item`): every entry carries its `item`
+      // serialization, no prerendered HTML.
+      let wireQuery = searchEntryWireQueryFromQuery(
+        {
           filter: {
             type: {
-              module: new URL('openrouter-model', realmURL).href,
+              module: rri(new URL('openrouter-model', realmURL).href),
               name: 'OpenRouterModel',
             },
           },
-        }),
-      });
+        },
+        { fields: ['item'] },
+      );
+      let response = await this.network.authedFetch(
+        new URL('_search-v2', realmURL).href,
+        {
+          method: 'QUERY',
+          headers: {
+            Accept: SupportedMimeType.CardJson,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(wireQuery),
+        },
+      );
 
       if (response.ok) {
         let result = await response.json();
-        let cards = result?.data ?? [];
-        for (let card of cards) {
-          let id: string = card.id ?? '';
-          // Extract slug from URL: .../OpenRouterModel/slug-name or .../OpenRouterModel/slug-name.json
-          let match = id.match(/OpenRouterModel\/([^/]+)$/);
-          if (match) {
-            let slug = match[1];
-            if (slug.endsWith('.json')) {
-              slug = slug.slice(0, -5);
+        if (isSearchEntryCollectionDocument(result)) {
+          for (let entry of result.data) {
+            // A `search-entry` resource's id is the card URL.
+            let id = entry.id ?? '';
+            // Extract slug from URL: .../OpenRouterModel/slug-name or .../OpenRouterModel/slug-name.json
+            let match = id.match(/OpenRouterModel\/([^/]+)$/);
+            if (match) {
+              let slug = match[1];
+              if (slug.endsWith('.json')) {
+                slug = slug.slice(0, -5);
+              }
+              slugs.add(slug);
             }
-            slugs.add(slug);
           }
         }
       }

--- a/packages/host/tests/integration/commands/sync-openrouter-models-test.gts
+++ b/packages/host/tests/integration/commands/sync-openrouter-models-test.gts
@@ -1,0 +1,183 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm } from '@cardstack/runtime-common';
+import type { AtomicOperation } from '@cardstack/runtime-common/atomic-document';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import SyncOpenRouterModelsCommand from '@cardstack/host/commands/sync-openrouter-models';
+import CardService from '@cardstack/host/services/card-service';
+
+import {
+  testRealmURL,
+  setupCardLogs,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+  realmConfigCardJSON,
+} from '../../helpers';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
+
+// The models the stubbed OpenRouter HTTP API returns for the test.
+let apiModels: { id: string }[];
+// The atomic operations the sync command derives, captured instead of written.
+let capturedOperations: AtomicOperation[];
+
+// Capture the operations the command derives so the test can assert which
+// existing cards it discovered, without exercising the realm write path.
+class CapturingCardService extends CardService {
+  override async executeAtomicOperations(
+    operations: AtomicOperation[],
+    _realmUrl: URL,
+  ): Promise<any> {
+    capturedOperations.push(...operations);
+    return {};
+  }
+}
+
+module('Integration | commands | sync-openrouter-models', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let loader: Loader;
+  let originalFetch: typeof globalThis.fetch;
+
+  // Register the capturing card-service first — before any later hook resolves
+  // the store, which would instantiate the real card-service and shadow this.
+  hooks.beforeEach(function (this: RenderingTestContext) {
+    capturedOperations = [];
+    getOwner(this)!.register('service:card-service', CapturingCardService);
+    loader = getService('loader-service').loader;
+
+    // The command lists models from the OpenRouter HTTP API via the global
+    // fetch; stub just that URL and pass everything else (including the realm
+    // search) through untouched.
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input: any, init?: any) => {
+      let url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      if (url === OPENROUTER_MODELS_URL) {
+        return new Response(JSON.stringify({ data: apiModels }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return originalFetch(input, init);
+    };
+  });
+
+  hooks.afterEach(function () {
+    globalThis.fetch = originalFetch;
+  });
+
+  setupLocalIndexing(hooks);
+  setupRealmCacheTeardown(hooks);
+  setupCardLogs(
+    hooks,
+    async () => await loader.import(`${baseRealm.url}card-api`),
+  );
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  hooks.beforeEach(async function () {
+    loader = getService('loader-service').loader;
+    let cardApi: typeof import('https://cardstack.com/base/card-api');
+    let string: typeof import('https://cardstack.com/base/string');
+    cardApi = await loader.import(`${baseRealm.url}card-api`);
+    string = await loader.import(`${baseRealm.url}string`);
+    let { field, contains, CardDef } = cardApi;
+    let { default: StringField } = string;
+
+    // A minimal stand-in for the real OpenRouterModel card: the sync command
+    // matches existing instances by this module path + name.
+    class OpenRouterModel extends CardDef {
+      static displayName = 'OpenRouterModel';
+      @field modelId = contains(StringField);
+    }
+
+    await withCachedRealmSetup(async () => {
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'openrouter-model.gts': { OpenRouterModel },
+          'OpenRouterModel/openai-gpt-4.json': new OpenRouterModel({
+            modelId: 'openai/gpt-4',
+          }),
+          'OpenRouterModel/legacy-model.json': new OpenRouterModel({
+            modelId: 'legacy/model',
+          }),
+          'realm.json': realmConfigCardJSON({
+            name: 'OpenRouter Models',
+          }),
+        },
+      });
+    });
+  });
+
+  function runSync() {
+    let commandService = getService('command-service');
+    let command = new SyncOpenRouterModelsCommand(
+      commandService.commandContext,
+    );
+    return command.execute({ realmIdentifier: testRealmURL });
+  }
+
+  function opFor(href: string) {
+    return capturedOperations.find((op) => op.href === href);
+  }
+
+  test('discovers existing OpenRouterModel slugs through /_search-v2', async function (assert) {
+    // The API still lists gpt-4 (slug openai-gpt-4) and introduces a new model
+    // (slug google-gemini-pro); the pre-existing legacy-model is absent.
+    apiModels = [{ id: 'openai/gpt-4' }, { id: 'google/gemini-pro' }];
+
+    let result = await runSync();
+
+    // The existing, still-listed model is discovered via v2, so it is updated
+    // in place rather than re-added.
+    assert.strictEqual(
+      opFor('OpenRouterModel/openai-gpt-4.json')?.op,
+      'update',
+      'existing listed model resolves to an update',
+    );
+
+    // The model not previously in the realm is added.
+    assert.strictEqual(
+      opFor('OpenRouterModel/google-gemini-pro.json')?.op,
+      'add',
+      'previously unknown model resolves to an add',
+    );
+
+    // The existing model the API no longer lists is discovered via v2 and
+    // marked deprecated — this op only exists because v2 surfaced its slug.
+    let legacyOp = opFor('OpenRouterModel/legacy-model.json');
+    assert.strictEqual(
+      legacyOp?.op,
+      'update',
+      'existing-but-delisted model resolves to an update',
+    );
+    assert.true(
+      (legacyOp?.data as any)?.attributes?.deprecated,
+      'existing model absent from the API is marked deprecated',
+    );
+
+    assert.ok(
+      result.status.includes('1 deprecated'),
+      'status reports the one deprecated model discovered via v2',
+    );
+  });
+});


### PR DESCRIPTION
Migrates the last host-side consumer of the legacy `/_search` endpoint — the `SyncOpenRouterModels` command — onto the v2 `search-entry` API.

`fetchExistingSlugs` listed existing `OpenRouterModel` cards by issuing a `QUERY` against `<realm>/_search` and reading their ids off the top-level `data` array. It now issues the same type-filtered `QUERY` against `<realm>/_search-v2` with a data-only projection (`fields[search-entry]=item`, so the engine returns each row's serialization and skips prerendered HTML), recognizes the response with `isSearchEntryCollectionDocument`, and reads each card's URL off its `search-entry` resource id (a `search-entry`'s id is the card URL).

The type filter, slug parsing, and the downstream add / update / deprecate logic are untouched — the same existing slugs are discovered.

A new integration test runs the real command against an in-process realm seeded with two `OpenRouterModel` cards, stubs only the external OpenRouter HTTP API, and asserts the v2 round-trip recovers them: a still-listed model resolves to an `update`, a previously unknown model to an `add`, and an existing model the API no longer lists is marked deprecated.

Gates retiring the four legacy search endpoints ([CS-11594](https://linear.app/cardstack/issue/CS-11594), which stacks on this PR).

[CS-11706](https://linear.app/cardstack/issue/CS-11706)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgpY6ANFr4zszXPFm2HvSP
