### PR TITLE
feat: support all BFM formats in both inline and block reference directives

### DIFF
--- a/packages/base/default-templates/markdown.gts
+++ b/packages/base/default-templates/markdown.gts
@@ -9,7 +9,7 @@ import { eq } from '@cardstack/boxel-ui/helpers';
 import LinkOffIcon from '@cardstack/boxel-icons/link-off';
 
 import {
-  bfmBlockFormatAndSize,
+  bfmRefFormatAndSize,
   buildWaiter,
   cardTypeName,
   fileNameFromUrl,
@@ -255,23 +255,19 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           if (!rawUrl) continue;
           let kind: 'inline' | 'block' = isInline ? 'inline' : 'block';
 
-          // Inline refs render in atom format. Block refs (card and file
-          // alike) derive their format and any fitted sizing from the BFM size
-          // attributes, so `::file[./photo.jpg | 400x300]` is honored the same
-          // way `::card[... | 400x300]` is.
-          let format: CardSlotFormat;
-          let sizeStyle: string | undefined;
-          if (isInline) {
-            format = 'atom';
-          } else {
-            let derived = bfmBlockFormatAndSize(
-              el.dataset.boxelBfmFormat,
-              el.dataset.boxelBfmWidth,
-              el.dataset.boxelBfmHeight,
-            );
-            format = derived.format;
-            sizeStyle = derived.sizeStyle;
-          }
+          // Both inline and block refs derive their format and any fitted
+          // sizing from the BFM size attributes, so `:card[url | embedded]` and
+          // `::card[url | 400x300]` are honored alike. Only the default differs:
+          // an inline ref with no specifier falls back to atom, a block ref to
+          // embedded.
+          let derived = bfmRefFormatAndSize(
+            el.dataset.boxelBfmFormat,
+            el.dataset.boxelBfmWidth,
+            el.dataset.boxelBfmHeight,
+            isInline ? 'atom' : 'embedded',
+          );
+          let format: CardSlotFormat = derived.format;
+          let sizeStyle: string | undefined = derived.sizeStyle;
 
           // Fitted slots carry an inline width/height plus `overflow: hidden`
           // so the resolved instance occupies the requested footprint.
@@ -507,7 +503,14 @@ export default class MarkDownTemplate extends GlimmerComponent<{
             {{#let (this.getCardComponent slot.instance) as |RefComponent|}}
               {{#if (eq slot.kind 'inline')}}
                 <span
-                  class='markdown-bfm-card-slot markdown-bfm-card-slot--inline'
+                  class='markdown-bfm-card-slot
+                    {{if
+                      (eq slot.format "atom")
+                      "markdown-bfm-card-slot--inline"
+                      "markdown-bfm-card-slot--inline-embed"
+                    }}
+                    {{if slot.style "markdown-bfm-card-slot--fitted"}}'
+                  style={{slot.style}}
                   data-test-markdown-bfm-inline-file={{if
                     (eq slot.refType 'file')
                     ''
@@ -558,11 +561,21 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           </CardContextConsumer>
         {{else if (eq slot.state 'loading')}}
           {{#if (eq slot.kind 'inline')}}
-            <span
-              class='markdown-bfm-loading markdown-bfm-loading--inline'
-              aria-hidden='true'
-              data-test-markdown-bfm-loading-inline
-            />
+            {{#if (eq slot.format 'atom')}}
+              <span
+                class='markdown-bfm-loading markdown-bfm-loading--inline'
+                aria-hidden='true'
+                data-test-markdown-bfm-loading-inline
+              />
+            {{else}}
+              <span
+                class='markdown-bfm-loading markdown-bfm-loading--inline-embed
+                  markdown-bfm-loading--{{slot.format}}'
+                style={{slot.style}}
+                aria-hidden='true'
+                data-test-markdown-bfm-loading-inline
+              />
+            {{/if}}
           {{else}}
             <div
               class='markdown-bfm-loading markdown-bfm-loading--block markdown-bfm-loading--{{slot.format}}'
@@ -573,16 +586,31 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           {{/if}}
         {{else}}
           {{#if (eq slot.kind 'inline')}}
-            <span
-              class='markdown-bfm-broken markdown-bfm-broken--inline'
-              title={{slot.url}}
-              data-test-markdown-bfm-unresolved-inline
-            >
-              <span class='markdown-bfm-broken-label'>
-                <LinkOffIcon width='12' height='12' />
-                {{slot.typeName}}
+            {{#if (eq slot.format 'atom')}}
+              <span
+                class='markdown-bfm-broken markdown-bfm-broken--inline'
+                title={{slot.url}}
+                data-test-markdown-bfm-unresolved-inline
+              >
+                <span class='markdown-bfm-broken-label'>
+                  <LinkOffIcon width='12' height='12' />
+                  {{slot.typeName}}
+                </span>
               </span>
-            </span>
+            {{else}}
+              <span
+                class='markdown-bfm-broken markdown-bfm-broken--inline-embed
+                  markdown-bfm-broken--{{slot.format}}'
+                style={{slot.style}}
+                title={{slot.url}}
+                data-test-markdown-bfm-unresolved-inline
+              >
+                <span class='markdown-bfm-broken-label'>
+                  <LinkOffIcon width='14' height='14' />
+                  {{slot.typeName}}
+                </span>
+              </span>
+            {{/if}}
           {{else}}
             <div
               class='markdown-bfm-broken markdown-bfm-broken--block markdown-bfm-broken--{{slot.format}}'
@@ -925,6 +953,14 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           vertical-align: middle;
         }
 
+        /* Inline embeds with an explicit non-atom format flow inline-block so a
+           sized card sits in the text run without the flex shrink behavior the
+           atom pill relies on. */
+        .markdown-bfm-card-slot--inline-embed {
+          display: inline-block;
+          vertical-align: middle;
+        }
+
         .markdown-bfm-card-slot--block {
           display: block;
         }
@@ -967,6 +1003,13 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           height: 1.2em;
           vertical-align: middle;
           border-radius: var(--boxel-border-radius-sm);
+        }
+        /* Inline embeds with an explicit non-atom format share the block
+           footprint classes but flow inline. */
+        .markdown-bfm-loading--inline-embed {
+          display: inline-block;
+          max-width: 100%;
+          vertical-align: middle;
         }
         .markdown-bfm-loading--block {
           display: block;
@@ -1026,6 +1069,12 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           padding: 0 var(--boxel-sp-5xs);
           vertical-align: middle;
           border-radius: var(--boxel-border-radius-sm);
+        }
+        /* Inline embeds with an explicit non-atom format share the block
+           footprint classes but flow inline. */
+        .markdown-bfm-broken--inline-embed {
+          display: inline-flex;
+          vertical-align: middle;
         }
         .markdown-bfm-broken--block {
           display: flex;

--- a/packages/base/markdown-helpers.ts
+++ b/packages/base/markdown-helpers.ts
@@ -153,8 +153,8 @@ interface MarkdownEmbedOptions {
   // 'inline' produces `:card[URL]`, 'block' produces `::card[URL]`.
   // Default: 'block'.
   kind?: 'inline' | 'block';
-  // Size specifier appended after `|` in block embeds (e.g. 'fitted 250x40',
-  // 'isolated', 'strip'). Ignored for inline embeds.
+  // Size specifier appended after `|` (e.g. 'fitted 250x40', 'isolated',
+  // 'embedded', 'atom', 'strip'). Honored for both inline and block embeds.
   size?: string;
 }
 
@@ -168,14 +168,12 @@ export function markdownEmbedForCard(
     return '';
   }
   let kind = options?.kind ?? 'block';
-  if (kind === 'inline') {
-    return `:card[${card.id}]`;
-  }
   let size = options?.size;
+  let prefix = kind === 'inline' ? ':card' : '::card';
   if (size) {
-    return `::card[${card.id} | ${size}]`;
+    return `${prefix}[${card.id} | ${size}]`;
   }
-  return `::card[${card.id}]`;
+  return `${prefix}[${card.id}]`;
 }
 
 interface MarkdownEmbedsOptions extends MarkdownEmbedOptions {

--- a/packages/boxel-cli/plugin/skills/dev-bfm-syntax/SKILL.md
+++ b/packages/boxel-cli/plugin/skills/dev-bfm-syntax/SKILL.md
@@ -122,15 +122,17 @@ Fenced code blocks with a language tag (e.g. ` `ts ```) are highlighted via the 
 
 Two forms reference a card by its full URL:
 
-### Inline: `:card[URL]`
+### Inline: `:card[URL]` or `:card[URL | spec]`
 
-Renders the target card in **atom** format, inline with surrounding text.
+Renders the target card inline with surrounding text. Default format is **atom**.
 
 ```md
 Written by :card[https://my.realm/Author/jane] for the team.
 ```
 
-Use inline form when the card should flow with the sentence.
+Use inline form when the card should flow with the sentence. The optional
+`| spec` accepts every format the block form does (see the grammar below), so
+`:card[URL | embedded]` flows an embedded card inline.
 
 ### Block: `::card[URL]` or `::card[URL | spec]`
 
@@ -142,11 +144,14 @@ See the latest post:
 ::card[https://my.realm/BlogPost/first-look]
 ```
 
-The optional `| spec` after the URL controls size/format. The grammar:
+The optional `| spec` after the URL controls size/format, and works in both the
+inline and block forms — only the default differs (inline → atom, block →
+embedded). The grammar:
 
 | Spec                            | Meaning                                                            |
 | ------------------------------- | ------------------------------------------------------------------ |
-| _(no spec)_                     | Default — embedded                                                 |
+| _(no spec)_                     | Default — atom inline, embedded block                              |
+| `atom`                          | Atom format (explicit)                                            |
 | `embedded`                      | Embedded format (explicit)                                         |
 | `isolated`                      | Isolated format (full detailed view)                               |
 | `fitted`                        | Fitted format at its container's natural size                      |
@@ -174,7 +179,7 @@ Featured authors:
 ::card[https://my.realm/Essay/manifesto | isolated]
 ```
 
-If a spec fails to parse, the renderer emits the directive with no format override, so the card falls back to embedded with no error — validate specs before shipping.
+If a spec fails to parse, the renderer emits the directive with no format override, so the card falls back to its placement default (embedded for block, atom for inline) with no error — validate specs before shipping.
 
 ### Unresolved references
 

--- a/packages/boxel-cli/plugin/skills/dev-markdown-format/SKILL.md
+++ b/packages/boxel-cli/plugin/skills/dev-markdown-format/SKILL.md
@@ -91,7 +91,7 @@ All helpers return pre-escaped strings — safe to interpolate directly.
 | `fencedCodeBlock(content, language?)`        | Auto-widens the fence past any backtick run in `content`                           |
 | `markdownLinkForCard(card, text?)`           | `[title](card.id)` — empty for null card                                           |
 | `markdownLinksForCards(cards, { style })`    | `style: 'list'` (default, `- [A](id)` per line) or `'inline'` (`[A](id), [B](id)`) |
-| `markdownEmbedForCard(card, { kind, size })` | `:card[id]` (inline) or `::card[id]` / `::card[id \| size]` (block, default)       |
+| `markdownEmbedForCard(card, { kind, size })` | `:card[id]` / `:card[id \| size]` (inline) or `::card[id]` / `::card[id \| size]` (block, default) |
 | `markdownEmbedsForCards(cards, options)`     | Multiple embeds joined by `separator` (default `\n\n` block, `' '` inline)         |
 
 The last four emit BFM card directives — see the `dev-bfm-syntax` skill.

--- a/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
+++ b/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
@@ -22,7 +22,7 @@ import { consume } from 'ember-provide-consume-context';
 import { eq } from '@cardstack/boxel-ui/helpers';
 
 import {
-  bfmBlockFormatAndSize,
+  bfmRefFormatAndSize,
   CardContextName,
   cardTypeName,
   extractCardReferenceUrls,
@@ -254,23 +254,19 @@ export default class RenderedMarkdown extends Component<Signature> {
           if (!rawUrl) continue;
           let kind: 'inline' | 'block' = isInline ? 'inline' : 'block';
 
-          // Inline refs render in atom format. Block refs (card and file alike)
-          // derive their format and any fitted sizing from the BFM size
-          // attributes, so `::file[./photo.jpg | 400x300]` is honored the same
-          // way `::card[... | 400x300]` is.
-          let format: CardSlotFormat;
-          let sizeStyle: string | undefined;
-          if (isInline) {
-            format = 'atom';
-          } else {
-            let derived = bfmBlockFormatAndSize(
-              el.dataset.boxelBfmFormat,
-              el.dataset.boxelBfmWidth,
-              el.dataset.boxelBfmHeight,
-            );
-            format = derived.format;
-            sizeStyle = derived.sizeStyle;
-          }
+          // Both inline and block refs derive their format and any fitted
+          // sizing from the BFM size attributes, so `:card[url | embedded]` and
+          // `::card[url | 400x300]` are honored alike. Only the default differs:
+          // an inline ref with no specifier falls back to atom, a block ref to
+          // embedded.
+          let derived = bfmRefFormatAndSize(
+            el.dataset.boxelBfmFormat,
+            el.dataset.boxelBfmWidth,
+            el.dataset.boxelBfmHeight,
+            isInline ? 'atom' : 'embedded',
+          );
+          let format: CardSlotFormat = derived.format;
+          let sizeStyle: string | undefined = derived.sizeStyle;
 
           // Fitted slots carry an inline width/height plus `overflow: hidden`
           // so the resolved instance occupies the requested footprint.
@@ -406,7 +402,14 @@ export default class RenderedMarkdown extends Component<Signature> {
           {{#if (eq slot.refType 'file')}}
             {{#if (eq slot.kind 'inline')}}
               <span
-                class='markdown-bfm-card-slot markdown-bfm-card-slot--inline'
+                class='markdown-bfm-card-slot
+                  {{if
+                    (eq slot.format "atom")
+                    "markdown-bfm-card-slot--inline"
+                    "markdown-bfm-card-slot--inline-embed"
+                  }}
+                  {{if slot.style "markdown-bfm-card-slot--fitted"}}'
+                style={{slot.style}}
                 data-test-markdown-bfm-inline-file
                 {{this.cardContext.cardComponentModifier
                   cardId=slot.file.id
@@ -443,7 +446,14 @@ export default class RenderedMarkdown extends Component<Signature> {
             {{/if}}
           {{else if (eq slot.kind 'inline')}}
             <span
-              class='markdown-bfm-card-slot markdown-bfm-card-slot--inline'
+              class='markdown-bfm-card-slot
+                {{if
+                  (eq slot.format "atom")
+                  "markdown-bfm-card-slot--inline"
+                  "markdown-bfm-card-slot--inline-embed"
+                }}
+                {{if slot.style "markdown-bfm-card-slot--fitted"}}'
+              style={{slot.style}}
               data-test-markdown-bfm-inline-card
               {{this.cardContext.cardComponentModifier
                 card=slot.card
@@ -480,11 +490,20 @@ export default class RenderedMarkdown extends Component<Signature> {
           {{/if}}
         {{else if (eq slot.state 'loading')}}
           {{#if (eq slot.kind 'inline')}}
-            <span
-              class='markdown-bfm-loading markdown-bfm-loading--inline'
-              aria-hidden='true'
-              data-test-markdown-bfm-loading-inline
-            />
+            {{#if (eq slot.format 'atom')}}
+              <span
+                class='markdown-bfm-loading markdown-bfm-loading--inline'
+                aria-hidden='true'
+                data-test-markdown-bfm-loading-inline
+              />
+            {{else}}
+              <span
+                class='markdown-bfm-loading markdown-bfm-loading--inline-embed markdown-bfm-loading--{{slot.format}}'
+                style={{slot.style}}
+                aria-hidden='true'
+                data-test-markdown-bfm-loading-inline
+              />
+            {{/if}}
           {{else}}
             <div
               class='markdown-bfm-loading markdown-bfm-loading--block markdown-bfm-loading--{{slot.format}}'
@@ -495,16 +514,30 @@ export default class RenderedMarkdown extends Component<Signature> {
           {{/if}}
         {{else}}
           {{#if (eq slot.kind 'inline')}}
-            <span
-              class='markdown-bfm-broken markdown-bfm-broken--inline'
-              title={{slot.url}}
-              data-test-markdown-bfm-unresolved-inline
-            >
-              <span class='markdown-bfm-broken-label'>
-                <LinkOffIcon width='12' height='12' />
-                {{slot.typeName}}
+            {{#if (eq slot.format 'atom')}}
+              <span
+                class='markdown-bfm-broken markdown-bfm-broken--inline'
+                title={{slot.url}}
+                data-test-markdown-bfm-unresolved-inline
+              >
+                <span class='markdown-bfm-broken-label'>
+                  <LinkOffIcon width='12' height='12' />
+                  {{slot.typeName}}
+                </span>
               </span>
-            </span>
+            {{else}}
+              <span
+                class='markdown-bfm-broken markdown-bfm-broken--inline-embed markdown-bfm-broken--{{slot.format}}'
+                style={{slot.style}}
+                title={{slot.url}}
+                data-test-markdown-bfm-unresolved-inline
+              >
+                <span class='markdown-bfm-broken-label'>
+                  <LinkOffIcon width='14' height='14' />
+                  {{slot.typeName}}
+                </span>
+              </span>
+            {{/if}}
           {{else}}
             <div
               class='markdown-bfm-broken markdown-bfm-broken--block markdown-bfm-broken--{{slot.format}}'
@@ -806,6 +839,13 @@ export default class RenderedMarkdown extends Component<Signature> {
           display: inline-flex;
           vertical-align: middle;
         }
+        /* Inline embeds with an explicit non-atom format flow inline-block so a
+           sized card sits in the text run without the flex shrink behavior the
+           atom pill relies on. */
+        .markdown-bfm-card-slot--inline-embed {
+          display: inline-block;
+          vertical-align: middle;
+        }
         .markdown-bfm-card-slot--block {
           display: block;
         }
@@ -847,6 +887,13 @@ export default class RenderedMarkdown extends Component<Signature> {
           height: 1.2em;
           vertical-align: middle;
           border-radius: var(--boxel-border-radius-sm);
+        }
+        /* Inline embeds with an explicit non-atom format share the block
+           footprint classes but flow inline. */
+        .markdown-bfm-loading--inline-embed {
+          display: inline-block;
+          max-width: 100%;
+          vertical-align: middle;
         }
         .markdown-bfm-loading--block {
           display: block;
@@ -906,6 +953,12 @@ export default class RenderedMarkdown extends Component<Signature> {
           padding: 0 var(--boxel-sp-5xs);
           vertical-align: middle;
           border-radius: var(--boxel-border-radius-sm);
+        }
+        /* Inline embeds with an explicit non-atom format share the block
+           footprint classes but flow inline. */
+        .markdown-bfm-broken--inline-embed {
+          display: inline-flex;
+          vertical-align: middle;
         }
         .markdown-bfm-broken--block {
           display: flex;

--- a/packages/host/tests/integration/components/rendered-markdown-test.gts
+++ b/packages/host/tests/integration/components/rendered-markdown-test.gts
@@ -592,4 +592,151 @@ module('Integration | rendered-markdown', function (hooks) {
       `loading block inline style includes height: 200px (got "${capturedLoadingStyle}")`,
     );
   });
+
+  test('inline card reference with size spec sets data attributes', async function (assert) {
+    let cardUrl = 'http://example.com/Card/inline-sized';
+    let content = `See :card[${cardUrl} | 400x200] here.`;
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><RenderedMarkdown @content={{content}} /></template>
+      },
+    );
+    await settled();
+
+    let el = document.querySelector(
+      `.markdown-content [data-boxel-bfm-inline-ref="${cardUrl}"]`,
+    );
+    assert.ok(el, 'inline placeholder exists');
+    assert.strictEqual(
+      el?.getAttribute('data-boxel-bfm-format'),
+      'fitted',
+      'format is set to fitted',
+    );
+    assert.strictEqual(el?.getAttribute('data-boxel-bfm-width'), '400');
+    assert.strictEqual(el?.getAttribute('data-boxel-bfm-height'), '200');
+  });
+
+  test('inline card reference with embedded format sets the format attribute', async function (assert) {
+    let cardUrl = 'http://example.com/Card/inline-embedded';
+    let content = `See :card[${cardUrl} | embedded] here.`;
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><RenderedMarkdown @content={{content}} /></template>
+      },
+    );
+    await settled();
+
+    let el = document.querySelector(
+      `.markdown-content [data-boxel-bfm-inline-ref="${cardUrl}"]`,
+    );
+    assert.ok(el, 'inline placeholder exists');
+    assert.strictEqual(
+      el?.getAttribute('data-boxel-bfm-format'),
+      'embedded',
+      'inline ref carries the embedded format',
+    );
+  });
+
+  test('unresolved embedded inline ref renders with the embedded footprint class', async function (assert) {
+    let cardUrl = 'http://nonexistent.example.com/Article/missing-inline-embed';
+    let content = `See :card[${cardUrl} | embedded] here.`;
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><RenderedMarkdown @content={{content}} /></template>
+      },
+    );
+
+    await waitUntil(
+      () =>
+        document.querySelector('[data-test-markdown-bfm-unresolved-inline]') !==
+        null,
+      { timeout: 5000, timeoutMessage: 'unresolved inline did not appear' },
+    );
+
+    assert
+      .dom('[data-test-markdown-bfm-unresolved-inline]')
+      .hasClass(
+        'markdown-bfm-broken--embedded',
+        'embedded inline ref carries the embedded footprint class',
+      );
+    assert
+      .dom('[data-test-markdown-bfm-unresolved-inline]')
+      .hasClass(
+        'markdown-bfm-broken--inline-embed',
+        'embedded inline ref flows inline',
+      );
+  });
+
+  test('unresolved fitted inline ref carries inline width/height matching the footprint', async function (assert) {
+    let cardUrl =
+      'http://nonexistent.example.com/Article/missing-inline-fitted';
+    let content = `See :card[${cardUrl} | 400x200] here.`;
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><RenderedMarkdown @content={{content}} /></template>
+      },
+    );
+
+    await waitUntil(
+      () =>
+        document.querySelector('[data-test-markdown-bfm-unresolved-inline]') !==
+        null,
+      { timeout: 5000, timeoutMessage: 'unresolved inline did not appear' },
+    );
+
+    let brokenInline = document.querySelector(
+      '[data-test-markdown-bfm-unresolved-inline]',
+    ) as HTMLElement | null;
+    assert.ok(brokenInline, 'broken-link inline exists');
+    assert
+      .dom(brokenInline)
+      .hasClass(
+        'markdown-bfm-broken--fitted',
+        'fitted inline ref carries the fitted footprint class',
+      );
+    let style = brokenInline?.getAttribute('style') ?? '';
+    assert.true(
+      /width:\s*400px/.test(style),
+      `broken-link inline style includes width: 400px (got "${style}")`,
+    );
+    assert.true(
+      /height:\s*200px/.test(style),
+      `broken-link inline style includes height: 200px (got "${style}")`,
+    );
+  });
+
+  test('plain inline ref (no spec) keeps the atom pill fallback', async function (assert) {
+    let cardUrl = 'http://nonexistent.example.com/Pet/plain-inline';
+    let content = `See :card[${cardUrl}] here.`;
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><RenderedMarkdown @content={{content}} /></template>
+      },
+    );
+
+    await waitUntil(
+      () =>
+        document.querySelector('[data-test-markdown-bfm-unresolved-inline]') !==
+        null,
+      { timeout: 5000, timeoutMessage: 'unresolved inline did not appear' },
+    );
+
+    assert
+      .dom('[data-test-markdown-bfm-unresolved-inline]')
+      .hasClass(
+        'markdown-bfm-broken--inline',
+        'a plain inline ref defaults to the atom pill',
+      );
+    assert
+      .dom('[data-test-markdown-bfm-unresolved-inline]')
+      .doesNotHaveClass(
+        'markdown-bfm-broken--embedded',
+        'a plain inline ref is not given a non-atom footprint',
+      );
+  });
 });

--- a/packages/host/tests/integration/components/rich-markdown-field-test.gts
+++ b/packages/host/tests/integration/components/rich-markdown-field-test.gts
@@ -426,6 +426,108 @@ module('Integration | RichMarkdownField', function (hooks) {
       .doesNotExist('no unresolved Pill remains after card resolves (block)');
   });
 
+  test('inline card reference with a non-atom format resolves to an inline-block slot', async function (assert) {
+    class Pet extends CardDef {
+      static displayName = 'Pet';
+      @field name = contains(StringField);
+      @field cardTitle = contains(StringField, {
+        computeVia: function (this: Pet) {
+          return this.name;
+        },
+      });
+      static embedded = class Embedded extends Component<typeof this> {
+        <template>
+          <div data-test-pet-embedded><@fields.name /></div>
+        </template>
+      };
+      static atom = class Atom extends Component<typeof this> {
+        <template>
+          <span data-test-pet-atom>{{@model.name}}</span>
+        </template>
+      };
+    }
+
+    class ArticleCard extends CardDef {
+      @field body = contains(RichMarkdownField);
+      static isolated = class Isolated extends Component<typeof this> {
+        <template><@fields.body /></template>
+      };
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'pet.gts': { Pet },
+        'article.gts': { ArticleCard },
+        'Pet/mango.json': {
+          data: {
+            attributes: { name: 'Mango', cardTitle: 'Mango' },
+            meta: {
+              adoptsFrom: { module: '../pet', name: 'Pet' },
+            },
+          },
+        },
+        'article-1.json': {
+          data: {
+            attributes: {
+              body: {
+                content: `Embedded inline: :card[${testRealmURL}Pet/mango | embedded]\n\nAtom inline: :card[${testRealmURL}Pet/mango | atom]\n`,
+              },
+            },
+            meta: {
+              adoptsFrom: { module: './article', name: 'ArticleCard' },
+            },
+          },
+        },
+      },
+    });
+
+    let store = getService('store');
+    let article = (await store.get(`${testRealmURL}article-1`)) as BaseDef;
+    await store.loaded();
+
+    await renderCard(loader, article, 'isolated');
+
+    // Both inline refs target the same card; the embedded one renders the
+    // embedded format and the atom one renders atom.
+    await waitFor('[data-test-pet-embedded]', { timeout: 10_000 });
+    await waitFor('[data-test-pet-atom]', { timeout: 10_000 });
+
+    let embeddedSlot = document
+      .querySelector('[data-test-pet-embedded]')!
+      .closest('[data-test-markdown-bfm-inline-card]');
+    assert.ok(
+      embeddedSlot,
+      'the embedded inline ref renders inside an inline card slot',
+    );
+    assert
+      .dom(embeddedSlot)
+      .hasClass(
+        'markdown-bfm-card-slot--inline-embed',
+        'a non-atom inline embed flows as an inline-block slot',
+      );
+    assert
+      .dom(embeddedSlot)
+      .doesNotHaveClass(
+        'markdown-bfm-card-slot--inline',
+        'a non-atom inline embed does not use the atom pill flow class',
+      );
+
+    let atomSlot = document
+      .querySelector('[data-test-pet-atom]')!
+      .closest('[data-test-markdown-bfm-inline-card]');
+    assert.ok(
+      atomSlot,
+      'the atom inline ref renders inside an inline card slot',
+    );
+    assert
+      .dom(atomSlot)
+      .hasClass(
+        'markdown-bfm-card-slot--inline',
+        'a plain (atom) inline ref keeps the atom pill flow class',
+      );
+  });
+
   test('card references show loading shimmer before linkedCards resolves, not broken Pills', async function (assert) {
     class Pet extends CardDef {
       static displayName = 'Pet';

--- a/packages/host/tests/unit/bfm-card-references-test.ts
+++ b/packages/host/tests/unit/bfm-card-references-test.ts
@@ -4,7 +4,7 @@ import {
   extractCardReferenceUrls,
   extractFileReferenceUrls,
   extractBfmReferences,
-  bfmBlockFormatAndSize,
+  bfmRefFormatAndSize,
   bfmCardReferenceExtensions,
   bfmExtensionsForKeyword,
   parseBfmSizeSpec,
@@ -51,6 +51,21 @@ module('Unit | bfm-card-references', function () {
         'https://example.com/cards/1',
         'https://example.com/cards/2',
       ]);
+    });
+
+    test('extracts the URL from an inline ref with a size spec', function (assert) {
+      let markdown =
+        'See :card[https://example.com/cards/1 | embedded] for details.';
+      let urls = extractCardReferenceUrls(
+        markdown,
+        'https://base.com/',
+        virtualNetwork,
+      );
+      assert.deepEqual(
+        urls,
+        ['https://example.com/cards/1'],
+        'the specifier is stripped from the extracted URL',
+      );
     });
 
     test('resolves relative URLs against base', function (assert) {
@@ -685,12 +700,99 @@ module('Unit | bfm-card-references', function () {
         'no format for unrecognized specifier',
       );
     });
+
+    test('block ref with atom format emits an atom format attribute', function (assert) {
+      let markdown = '::card[https://example.com/cards/1 | atom]\n';
+      let html = markdownToHtml(markdown);
+      assert.true(
+        html.includes('data-boxel-bfm-block-ref="https://example.com/cards/1"'),
+        'URL excludes the pipe and specifier',
+      );
+      assert.true(
+        html.includes('data-boxel-bfm-format="atom"'),
+        'has atom format attribute',
+      );
+      assert.false(
+        html.includes('data-boxel-bfm-width'),
+        'atom carries no width',
+      );
+    });
+
+    test('inline ref with a size spec emits format and dimension attributes', function (assert) {
+      let markdown = 'See :card[https://example.com/cards/1 | 400x200] here.';
+      let html = markdownToHtml(markdown);
+      assert.true(
+        html.includes(
+          'data-boxel-bfm-inline-ref="https://example.com/cards/1"',
+        ),
+        'URL excludes the pipe and specifier',
+      );
+      assert.true(
+        html.includes('data-boxel-bfm-format="fitted"'),
+        'has fitted format attribute',
+      );
+      assert.true(html.includes('data-boxel-bfm-width="400"'), 'width=400');
+      assert.true(html.includes('data-boxel-bfm-height="200"'), 'height=200');
+    });
+
+    test('inline ref with embedded format emits the format attribute', function (assert) {
+      let markdown = 'See :card[https://example.com/cards/1 | embedded] here.';
+      let html = markdownToHtml(markdown);
+      assert.true(
+        html.includes('data-boxel-bfm-format="embedded"'),
+        'has embedded format attribute',
+      );
+      assert.false(
+        html.includes('data-boxel-bfm-width'),
+        'embedded carries no width',
+      );
+    });
+
+    test('inline ref without pipe has no format/size attributes', function (assert) {
+      let markdown = 'See :card[https://example.com/cards/1] here.';
+      let html = markdownToHtml(markdown);
+      assert.true(
+        html.includes(
+          'data-boxel-bfm-inline-ref="https://example.com/cards/1"',
+        ),
+        'inline placeholder still has the ref attribute',
+      );
+      assert.false(
+        html.includes('data-boxel-bfm-format'),
+        'no format attribute for plain inline ref',
+      );
+    });
+
+    test('inline ref with unrecognized specifier emits no format attributes', function (assert) {
+      let markdown = 'See :card[https://example.com/cards/1 | nonsense] here.';
+      let html = markdownToHtml(markdown);
+      assert.true(
+        html.includes(
+          'data-boxel-bfm-inline-ref="https://example.com/cards/1"',
+        ),
+        'URL excludes the pipe and specifier',
+      );
+      assert.false(
+        html.includes('data-boxel-bfm-format'),
+        'no format for unrecognized specifier',
+      );
+    });
   });
 
   module('parseBfmSizeSpec', function () {
     test('returns null for unrecognized specifiers', function (assert) {
       assert.strictEqual(parseBfmSizeSpec('nonsense'), null);
       assert.strictEqual(parseBfmSizeSpec(''), null);
+    });
+
+    test('parses atom keyword', function (assert) {
+      let result = parseBfmSizeSpec('atom');
+      assert.deepEqual(result, { format: 'atom' });
+    });
+
+    test('parses atom keyword case-insensitively', function (assert) {
+      let result = parseBfmSizeSpec('Atom');
+      assert.deepEqual(result, { format: 'atom' });
     });
 
     test('parses isolated keyword', function (assert) {
@@ -929,55 +1031,77 @@ module('Unit | bfm-card-references', function () {
     });
   });
 
-  module('bfmBlockFormatAndSize', function () {
+  module('bfmRefFormatAndSize', function () {
     test('defaults to embedded with no sizeStyle when format attr is missing', function (assert) {
-      assert.deepEqual(bfmBlockFormatAndSize(undefined, undefined, undefined), {
+      assert.deepEqual(bfmRefFormatAndSize(undefined, undefined, undefined), {
         format: 'embedded',
       });
     });
 
+    test('honors an explicit defaultFormat when the format attr is missing', function (assert) {
+      assert.deepEqual(
+        bfmRefFormatAndSize(undefined, undefined, undefined, 'atom'),
+        { format: 'atom' },
+      );
+    });
+
     test('defaults to embedded when format attr is unrecognized', function (assert) {
-      assert.deepEqual(bfmBlockFormatAndSize('something', '400', '200'), {
+      assert.deepEqual(bfmRefFormatAndSize('something', '400', '200'), {
         format: 'embedded',
+      });
+    });
+
+    test('falls back to the supplied defaultFormat when format attr is unrecognized', function (assert) {
+      assert.deepEqual(
+        bfmRefFormatAndSize('something', undefined, undefined, 'atom'),
+        {
+          format: 'atom',
+        },
+      );
+    });
+
+    test('passes atom through and ignores width/height', function (assert) {
+      assert.deepEqual(bfmRefFormatAndSize('atom', '400', '200'), {
+        format: 'atom',
       });
     });
 
     test('passes isolated through and ignores width/height', function (assert) {
-      assert.deepEqual(bfmBlockFormatAndSize('isolated', '400', '200'), {
+      assert.deepEqual(bfmRefFormatAndSize('isolated', '400', '200'), {
         format: 'isolated',
       });
     });
 
     test('fitted with no width/height returns undefined sizeStyle', function (assert) {
-      assert.deepEqual(bfmBlockFormatAndSize('fitted', undefined, undefined), {
+      assert.deepEqual(bfmRefFormatAndSize('fitted', undefined, undefined), {
         format: 'fitted',
         sizeStyle: undefined,
       });
     });
 
     test('fitted converts integer width attr to a px value', function (assert) {
-      assert.deepEqual(bfmBlockFormatAndSize('fitted', '400', undefined), {
+      assert.deepEqual(bfmRefFormatAndSize('fitted', '400', undefined), {
         format: 'fitted',
         sizeStyle: 'width: 400px',
       });
     });
 
     test('fitted passes percentage width attr through unchanged', function (assert) {
-      assert.deepEqual(bfmBlockFormatAndSize('fitted', '50%', undefined), {
+      assert.deepEqual(bfmRefFormatAndSize('fitted', '50%', undefined), {
         format: 'fitted',
         sizeStyle: 'width: 50%',
       });
     });
 
     test('fitted converts integer height attr to a px value', function (assert) {
-      assert.deepEqual(bfmBlockFormatAndSize('fitted', undefined, '200'), {
+      assert.deepEqual(bfmRefFormatAndSize('fitted', undefined, '200'), {
         format: 'fitted',
         sizeStyle: 'height: 200px',
       });
     });
 
     test('fitted combines width + height into one sizeStyle string', function (assert) {
-      assert.deepEqual(bfmBlockFormatAndSize('fitted', '400', '200'), {
+      assert.deepEqual(bfmRefFormatAndSize('fitted', '400', '200'), {
         format: 'fitted',
         sizeStyle: 'width: 400px; height: 200px',
       });
@@ -985,14 +1109,14 @@ module('Unit | bfm-card-references', function () {
 
     test('fitted ignores width with unsupported units', function (assert) {
       // Only `\d+` (px implied) and `\d+%` are accepted; anything else is dropped.
-      assert.deepEqual(bfmBlockFormatAndSize('fitted', '100em', '200'), {
+      assert.deepEqual(bfmRefFormatAndSize('fitted', '100em', '200'), {
         format: 'fitted',
         sizeStyle: 'height: 200px',
       });
     });
 
     test('fitted ignores height with unsupported units', function (assert) {
-      assert.deepEqual(bfmBlockFormatAndSize('fitted', '400', '50%'), {
+      assert.deepEqual(bfmRefFormatAndSize('fitted', '400', '50%'), {
         format: 'fitted',
         sizeStyle: 'width: 400px',
       });

--- a/packages/host/tests/unit/markdown-helpers-test.ts
+++ b/packages/host/tests/unit/markdown-helpers-test.ts
@@ -184,11 +184,19 @@ module('Unit | markdown-helpers | card link helpers', function (hooks) {
     );
   });
 
-  test('size specifier is ignored for inline embeds', function (assert) {
+  test('size specifier is honored for inline embeds', function (assert) {
     let card = { id: 'https://example.com/Post/1' };
     assert.strictEqual(
       markdownEmbedForCard(card, { kind: 'inline', size: 'strip' }),
-      ':card[https://example.com/Post/1]',
+      ':card[https://example.com/Post/1 | strip]',
+    );
+  });
+
+  test('inline embed with embedded size', function (assert) {
+    let card = { id: 'https://example.com/Post/1' };
+    assert.strictEqual(
+      markdownEmbedForCard(card, { kind: 'inline', size: 'embedded' }),
+      ':card[https://example.com/Post/1 | embedded]',
     );
   });
 

--- a/packages/runtime-common/bfm-card-references.ts
+++ b/packages/runtime-common/bfm-card-references.ts
@@ -26,7 +26,7 @@ function resolveUrl(
 // ── BFM size spec parsing ──
 
 export interface BfmSizeSpec {
-  format: 'fitted' | 'isolated' | 'embedded';
+  format: 'atom' | 'fitted' | 'isolated' | 'embedded';
   width?: number | string; // number = px, string = e.g. "50%"
   height?: number;
 }
@@ -47,6 +47,7 @@ SIZE_CONSTANTS.set('grid-tile', SIZE_CONSTANTS.get('cardsgrid-tile')!);
  * Parses a BFM size specifier (the part after `|` in `::card[url | spec]`).
  *
  * Supported forms:
+ *  - `atom`                              — atom format
  *  - `isolated`                          — isolated format
  *  - `embedded`                          — embedded format (explicit)
  *  - `fitted`                            — fitted at the container's natural size
@@ -58,6 +59,10 @@ SIZE_CONSTANTS.set('grid-tile', SIZE_CONSTANTS.get('cardsgrid-tile')!);
  */
 export function parseBfmSizeSpec(specifier: string): BfmSizeSpec | null {
   let trimmed = specifier.trim().toLowerCase();
+
+  if (trimmed === 'atom') {
+    return { format: 'atom' };
+  }
 
   if (trimmed === 'isolated') {
     return { format: 'isolated' };
@@ -110,23 +115,29 @@ export function parseBfmSizeSpec(specifier: string): BfmSizeSpec | null {
   return null;
 }
 
-export type BfmBlockFormat = 'embedded' | 'fitted' | 'isolated';
+export type BfmRefFormat = 'atom' | 'embedded' | 'fitted' | 'isolated';
 
 /**
- * Derives the block-level render format and an optional inline sizing style
- * (`width`/`height`) from a BFM block-ref element's `data-boxel-bfm-*`
- * attributes. Shared so that resolved cards, the loading shimmer, and the
- * broken-link placeholder all occupy the same footprint as the eventual card.
+ * Derives the render format and an optional inline sizing style
+ * (`width`/`height`) from a BFM ref element's `data-boxel-bfm-*` attributes.
+ * Works for both inline and block refs — only `defaultFormat` differs by
+ * placement (block embeds default to `embedded`, inline embeds to `atom`).
+ * Shared so that resolved cards, the loading shimmer, and the broken-link
+ * placeholder all occupy the same footprint as the eventual card.
  */
-export function bfmBlockFormatAndSize(
+export function bfmRefFormatAndSize(
   formatAttr: string | undefined,
   widthAttr: string | undefined,
   heightAttr: string | undefined,
-): { format: BfmBlockFormat; sizeStyle?: string } {
-  let format: BfmBlockFormat =
-    formatAttr === 'fitted' || formatAttr === 'isolated'
+  defaultFormat: BfmRefFormat = 'embedded',
+): { format: BfmRefFormat; sizeStyle?: string } {
+  let format: BfmRefFormat =
+    formatAttr === 'atom' ||
+    formatAttr === 'embedded' ||
+    formatAttr === 'fitted' ||
+    formatAttr === 'isolated'
       ? formatAttr
-      : 'embedded';
+      : defaultFormat;
   if (format !== 'fitted') {
     return { format };
   }
@@ -140,6 +151,30 @@ export function bfmBlockFormatAndSize(
     parts.push(`height: ${heightAttr}px`);
   }
   return { format, sizeStyle: parts.length ? parts.join('; ') : undefined };
+}
+
+/**
+ * Builds the `data-boxel-bfm-format` / `-width` / `-height` attribute string
+ * for a BFM size specifier (the part after `|`). Returns `''` when there is no
+ * specifier or it doesn't parse. Shared by the inline and block renderers so
+ * both placements emit identical size attributes.
+ */
+function bfmSizeAttrs(specifier: string | undefined): string {
+  if (!specifier) {
+    return '';
+  }
+  let sizeSpec = parseBfmSizeSpec(specifier);
+  if (!sizeSpec) {
+    return '';
+  }
+  let attrs = ` data-boxel-bfm-format="${sizeSpec.format}"`;
+  if (sizeSpec.width !== undefined) {
+    attrs += ` data-boxel-bfm-width="${sizeSpec.width}"`;
+  }
+  if (sizeSpec.height !== undefined) {
+    attrs += ` data-boxel-bfm-height="${sizeSpec.height}"`;
+  }
+  return attrs;
 }
 
 /**
@@ -202,7 +237,8 @@ export function extractBfmReferences(
       }
     }
     for (let match of stripped.matchAll(inlineRe)) {
-      let resolved = resolveUrl(match[1], baseUrl, virtualNetwork);
+      let { url: rawUrl } = splitBfmContent(match[1]);
+      let resolved = resolveUrl(rawUrl, baseUrl, virtualNetwork);
       if (resolved) {
         matches.push({
           index: match.index!,
@@ -303,21 +339,9 @@ export function bfmExtensionsForKeyword(
       renderer(token) {
         let url = escapeHtml((token as any).url);
         let specifier: string | undefined = (token as any).specifier;
-        let attrs = `data-boxel-bfm-block-ref="${url}" data-boxel-bfm-type="${keyword}"`;
-
-        if (specifier) {
-          let sizeSpec = parseBfmSizeSpec(specifier);
-          if (sizeSpec) {
-            attrs += ` data-boxel-bfm-format="${sizeSpec.format}"`;
-            if (sizeSpec.width !== undefined) {
-              attrs += ` data-boxel-bfm-width="${sizeSpec.width}"`;
-            }
-            if (sizeSpec.height !== undefined) {
-              attrs += ` data-boxel-bfm-height="${sizeSpec.height}"`;
-            }
-          }
-        }
-
+        let attrs =
+          `data-boxel-bfm-block-ref="${url}" data-boxel-bfm-type="${keyword}"` +
+          bfmSizeAttrs(specifier);
         return `<div ${attrs}>${url}</div>\n`;
       },
     },
@@ -342,17 +366,23 @@ export function bfmExtensionsForKeyword(
         let re = new RegExp(`^:${escapeRegExp(keyword)}\\[([^\\]]+)\\]`);
         let match = src.match(re);
         if (match) {
+          let { url, specifier } = splitBfmContent(match[1]);
           return {
             type: inlineType,
             raw: match[0],
-            url: match[1],
+            url,
+            specifier,
           };
         }
         return undefined;
       },
       renderer(token) {
         let url = escapeHtml((token as any).url);
-        return `<span data-boxel-bfm-inline-ref="${url}" data-boxel-bfm-type="${keyword}">${url}</span>`;
+        let specifier: string | undefined = (token as any).specifier;
+        let attrs =
+          `data-boxel-bfm-inline-ref="${url}" data-boxel-bfm-type="${keyword}"` +
+          bfmSizeAttrs(specifier);
+        return `<span ${attrs}>${url}</span>`;
       },
     },
   ];


### PR DESCRIPTION
Resolves [CS-11704](https://linear.app/cardstack/issue/CS-11704/bfm-support-all-formats-in-both-inline-and-block-reference-directives).

## Why

BFM previously coupled render format to placement: the **inline** directive `:card[url]` had no size/format slot, so it was hardcoded to **atom**; only the **block** directive `::card[url | spec]` could express embedded / fitted / isolated / dimensions. This decouples format from placement so every format works in both modes — the grammar ("dictionary") side of the Markdown Editing UI design.

## What changed

**Grammar — `packages/runtime-common/bfm-card-references.ts`**
- `parseBfmSizeSpec` accepts `atom` (and confirms `embedded`/`isolated`); `BfmSizeSpec.format` gains `'atom'`.
- Inline tokenizer splits the bracket on `|` and captures the specifier; inline renderer emits `data-boxel-bfm-format` / `-width` / `-height` via a new shared `bfmSizeAttrs` helper used by both the inline and block renderers.
- `extractBfmReferences` strips the specifier from inline URLs (so `:card[url | spec]` extracts just the URL).
- `bfmBlockFormatAndSize` → **`bfmRefFormatAndSize`** (`BfmBlockFormat` → `BfmRefFormat`, now includes `atom`) with a `defaultFormat` param — block defaults to `embedded`, inline to `atom`.

**Writer — `packages/base/markdown-helpers.ts`**
- `markdownEmbedForCard` honors the `size` option for inline embeds (`:card[id | embedded]`).

**Renderers — `packages/host/.../rendered-markdown.gts` + `packages/base/default-templates/markdown.gts` (kept in parallel)**
- Inline refs derive format/size from the data attributes instead of forcing atom. Resolved non-atom inline slots flow as `display: inline-block` (new `--inline-embed` class); loading/broken inline placeholders adopt the derived footprint. Plain (atom) inline refs are unchanged.

**Docs** — updated the `dev-bfm-syntax` and `dev-markdown-format` skill grammar tables to document inline specs and the `atom` spec.

## Acceptance criteria
- `:card[url | embedded]`, `:card[url | 400x200]`, and `::card[url | atom]` all parse, extract, and render in the correct format and placement. ✅

## Scope note (read/grammar side only)

This is the **partial-on-`main`** slice agreed for CS-11704. The literal `serializeBfmRef` function and the `markdown-embed-preview-pane` test referenced in the ticket live only on the open PR #5303 (`cs-11673`) branch, not on `main`, so they're deferred. On `main` the writer is `markdownEmbedForCard` (which #5303 turns into a `serializeBfmRef` delegate); the inline-size logic added here moves into `serializeBfmRef` as a straightforward conflict resolution when #5303 lands, after which the chooser emits/previews inline-formatted embeds with no further change.

## Tests
- Unit (`bfm-card-references-test`, `markdown-helpers-test`): inline pipe-extraction, inline renderer emits format/size attrs, `parseBfmSizeSpec('atom')`, `bfmRefFormatAndSize` atom + `defaultFormat`, block `| atom`, "ignored for inline" flipped to "honored for inline".
- Integration (`rendered-markdown-test`): inline embedded/fitted/atom data-attr + broken-footprint cases.
- Integration (`rich-markdown-field-test`): real-card resolved inline embed asserts the `--inline-embed` (inline-block) slot class; atom ref keeps `--inline`.

Verified locally with `ember-tsc` (host + runtime-common), eslint, and ember-template-lint. The host QUnit suite runs on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)