### PR TITLE
Skip and report unparseable files in the @context search codemod

### DIFF
--- a/packages/realm-server/scripts/codemod/context-search/run.ts
+++ b/packages/realm-server/scripts/codemod/context-search/run.ts
@@ -1,7 +1,9 @@
 // CLI for the `@context` search codemod. Dry-run by default; pass `--write` to
 // apply. Walks the given files/directories for `.gts` card source, migrates the
 // usages it can transform mechanically, and reports the ones it can't so they
-// can be migrated by hand.
+// can be migrated by hand. A file whose template can't be parsed is skipped and
+// reported (left untouched) rather than aborting the whole sweep — such a module
+// already fails to compile, so it's out of scope here.
 //
 //   node scripts/codemod/context-search/run.ts <path…> [--write]
 
@@ -62,10 +64,20 @@ async function main(): Promise<void> {
   let files = collectGtsFiles(paths);
   let transformed: string[] = [];
   let reported: { file: string; reasons: string[] }[] = [];
+  let unparseable: { file: string; error: string }[] = [];
 
   for (let file of files) {
     let source = readFileSync(file, 'utf8');
-    let result = transformContextSearch(source, { filename: file });
+    let result;
+    try {
+      result = transformContextSearch(source, { filename: file });
+    } catch (err) {
+      // The transformer threw while parsing this module's template, so it can't
+      // be migrated mechanically (and would not compile as-is either). Record it
+      // and keep going so a single bad module doesn't mask every file after it.
+      unparseable.push({ file, error: (err as Error).message.split('\n')[0] });
+      continue;
+    }
     if (result.status === 'transformed') {
       transformed.push(file);
       if (write && result.output !== source) {
@@ -94,6 +106,16 @@ async function main(): Promise<void> {
       for (let reason of reasons) {
         console.log(`      - ${reason}`);
       }
+    }
+  }
+
+  if (unparseable.length > 0) {
+    console.log(
+      `\nSkipped ${unparseable.length} unparseable file(s) (left untouched):`,
+    );
+    for (let { file, error } of unparseable) {
+      console.log(`  ⚠ ${file}`);
+      console.log(`      - ${error}`);
     }
   }
 

--- a/packages/realm-server/scripts/codemod/context-search/run.ts
+++ b/packages/realm-server/scripts/codemod/context-search/run.ts
@@ -12,7 +12,7 @@ import { join, resolve } from 'path';
 
 import * as prettier from 'prettier';
 
-import { transformContextSearch } from './transform.ts';
+import { transformContextSearch, type TransformResult } from './transform.ts';
 
 // Format the migrated source through the repo's prettier config (with
 // prettier-plugin-ember-template-tag for `.gts`) so the structural edits land as
@@ -68,14 +68,15 @@ async function main(): Promise<void> {
 
   for (let file of files) {
     let source = readFileSync(file, 'utf8');
-    let result;
+    let result: TransformResult;
     try {
       result = transformContextSearch(source, { filename: file });
     } catch (err) {
       // The transformer threw while parsing this module's template, so it can't
       // be migrated mechanically (and would not compile as-is either). Record it
       // and keep going so a single bad module doesn't mask every file after it.
-      unparseable.push({ file, error: (err as Error).message.split('\n')[0] });
+      let message = err instanceof Error ? err.message : String(err);
+      unparseable.push({ file, error: message.split('\n')[0] });
       continue;
     }
     if (result.status === 'transformed') {


### PR DESCRIPTION
The `@context` search codemod (`packages/realm-server/scripts/codemod/context-search`) called `transformContextSearch` per file with no error handling. A single module whose `<template>` the parser rejects threw out of the loop and aborted the entire run, masking every file after it — which is exactly what bites when sweeping a large body of card source.

This wraps the per-file transform in `try/catch`: on a parse throw the file is recorded in a new `unparseable` bucket and the sweep continues. Such modules can't be migrated mechanically (and don't compile as-is), so they're left untouched and surfaced in a new "Skipped unparseable file(s)" section alongside the existing migrated / hand-migration reports.

Verified on a two-file fixture (one clean card + one with a malformed template): the codemod migrates the clean file, reports the malformed one as skipped, and exits 0 instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4n4P6G1vFdSvSZaKkFK5f
