### PR TITLE
fix(CS-11713): fully replace array attributes in store.patch

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -96,6 +96,7 @@ import {
   rri,
   type RealmResourceIdentifier,
   type VirtualNetwork,
+  isDirectIndexedFieldKey,
 } from '@cardstack/runtime-common';
 import {
   captureQueryFieldSeedData,
@@ -4238,15 +4239,6 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
   ): Partial<Meta>[] | undefined {
     let entry = fieldsMeta?.[key];
     return Array.isArray(entry) ? entry : undefined;
-  }
-  function isDirectIndexedFieldKey(key: string, fieldName: string): boolean {
-    let prefix = `${fieldName}.`;
-    if (!key.startsWith(prefix)) {
-      return false;
-    }
-    let suffix = key.slice(prefix.length);
-    let index = Number(suffix);
-    return Number.isInteger(index) && index >= 0 && String(index) === suffix;
   }
   function clearIndexedFieldOverrides(fieldName: string): void {
     for (let key of existingOverrides.keys()) {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2491,37 +2491,37 @@ export class BaseDef {
           // membership from `relationships.{field}.data` separately.
           .filter(([, field]) => !field?.queryDefinition)
           .map(([fieldName, field]) => {
-          let rawValue = peekAtField(value, fieldName);
-          if (field?.fieldType === 'linksToMany') {
+            let rawValue = peekAtField(value, fieldName);
+            if (field?.fieldType === 'linksToMany') {
+              return [
+                fieldName,
+                field
+                  .queryableValue(rawValue, [value, ...stack])
+                  ?.map((v: any) => {
+                    return { ...v, id: makeAbsoluteURL(v.id) };
+                  }) ?? null,
+              ];
+            }
+            if (isNonPresentLink(rawValue)) {
+              let normalizedId = rawValue.reference;
+              if (value[relativeTo]) {
+                normalizedId = resolveRef(
+                  getStore(value).virtualNetwork,
+                  normalizedId,
+                  value[relativeTo],
+                );
+              }
+              return [fieldName, { id: makeAbsoluteURL(rawValue.reference) }];
+            }
+            // Reuse the value we already peeked above instead of re-reading
+            // through the descriptor — for computed fields the descriptor
+            // get path re-invokes `computeVia`, doubling the work for every
+            // contains/contains-many/links-to field in the search doc.
             return [
               fieldName,
-              field
-                .queryableValue(rawValue, [value, ...stack])
-                ?.map((v: any) => {
-                  return { ...v, id: makeAbsoluteURL(v.id) };
-                }) ?? null,
+              getQueryableValue(field!, rawValue, [value, ...stack]),
             ];
-          }
-          if (isNonPresentLink(rawValue)) {
-            let normalizedId = rawValue.reference;
-            if (value[relativeTo]) {
-              normalizedId = resolveRef(
-                getStore(value).virtualNetwork,
-                normalizedId,
-                value[relativeTo],
-              );
-            }
-            return [fieldName, { id: makeAbsoluteURL(rawValue.reference) }];
-          }
-          // Reuse the value we already peeked above instead of re-reading
-          // through the descriptor — for computed fields the descriptor
-          // get path re-invokes `computeVia`, doubling the work for every
-          // contains/contains-many/links-to field in the search doc.
-          return [
-            fieldName,
-            getQueryableValue(field!, rawValue, [value, ...stack]),
-          ];
-        }),
+          }),
       );
     }
   }
@@ -4239,6 +4239,22 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
     let entry = fieldsMeta?.[key];
     return Array.isArray(entry) ? entry : undefined;
   }
+  function isDirectIndexedFieldKey(key: string, fieldName: string): boolean {
+    let prefix = `${fieldName}.`;
+    if (!key.startsWith(prefix)) {
+      return false;
+    }
+    let suffix = key.slice(prefix.length);
+    let index = Number(suffix);
+    return Number.isInteger(index) && index >= 0 && String(index) === suffix;
+  }
+  function clearIndexedFieldOverrides(fieldName: string): void {
+    for (let key of existingOverrides.keys()) {
+      if (isDirectIndexedFieldKey(key, fieldName)) {
+        existingOverrides.delete(key);
+      }
+    }
+  }
   function isAssignableToField(
     overrideCard: typeof BaseDef,
     fieldCard: typeof BaseDef,
@@ -4350,6 +4366,7 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
       let resourceMetaFields = resource.meta?.fields;
       let overrideApplied = false;
       if (field.fieldType === 'containsMany') {
+        clearIndexedFieldOverrides(fieldName);
         if (primitive in field.card) {
           if (Array.isArray(value)) {
             for (let [index] of value.entries()) {
@@ -4838,10 +4855,7 @@ function resolveRef(
   if (relativeTo instanceof URL) {
     base = relativeTo;
   } else if (typeof relativeTo === 'string') {
-    if (
-      relativeTo.startsWith('http://') ||
-      relativeTo.startsWith('https://')
-    ) {
+    if (relativeTo.startsWith('http://') || relativeTo.startsWith('https://')) {
       base = relativeTo;
     }
   }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -15,7 +15,7 @@ import { task } from 'ember-concurrency';
 
 import { cloneDeep } from 'lodash-es';
 import { isEqual } from 'lodash-es';
-import { merge } from 'lodash-es';
+import { merge, mergeWith } from 'lodash-es';
 
 import { TrackedObject, TrackedMap } from 'tracked-built-ins';
 
@@ -974,7 +974,11 @@ export default class StoreService extends Service implements StoreInterface {
       omitQueryFields: true,
     });
     if (patch.attributes) {
-      doc.data.attributes = merge(doc.data.attributes, patch.attributes);
+      doc.data.attributes = mergeWith(
+        doc.data.attributes,
+        patch.attributes,
+        (_dest, src) => (Array.isArray(src) ? src : undefined),
+      );
     }
     if (patch.relationships) {
       let mergedRel = mergeRelationships(

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -51,6 +51,7 @@ import {
   SupportedMimeType,
   RealmPaths,
   type CardAPIForMatching,
+  clearReplacedArrayFieldMeta,
   type Store as StoreInterface,
   type AddOptions,
   type CreateOptions,
@@ -979,6 +980,7 @@ export default class StoreService extends Service implements StoreInterface {
         patch.attributes,
         (_dest, src) => (Array.isArray(src) ? src : undefined),
       );
+      clearReplacedArrayFieldMeta(doc.data.meta, patch.attributes);
     }
     if (patch.relationships) {
       let mergedRel = mergeRelationships(

--- a/packages/host/tests/integration/commands/patch-instance-test.gts
+++ b/packages/host/tests/integration/commands/patch-instance-test.gts
@@ -3,7 +3,11 @@ import { waitUntil } from '@ember/test-helpers';
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { localId, type SingleCardDocument } from '@cardstack/runtime-common';
+import {
+  fields,
+  localId,
+  type SingleCardDocument,
+} from '@cardstack/runtime-common';
 import type { RealmIndexQueryEngine } from '@cardstack/runtime-common/realm-index-query-engine';
 
 import PatchCardInstanceCommand from '@cardstack/host/commands/patch-card-instance';
@@ -52,6 +56,8 @@ module('Integration | commands | patch-instance', function (hooks) {
 
   hooks.beforeEach(async function () {
     commandService = getService('command-service');
+    class SpecialStringA extends StringField {}
+    class SpecialStringB extends StringField {}
     class Person extends CardDef {
       @field name = contains(StringField);
       @field nickNames = containsMany(StringField);
@@ -64,8 +70,16 @@ module('Integration | commands | patch-instance', function (hooks) {
       setupIntegrationTestRealm({
         mockMatrixUtils,
         contents: {
-          'person.gts': { Person },
+          'person.gts': { Person, SpecialStringA, SpecialStringB },
           'Person/hassan.json': new Person({ name: 'Hassan' }),
+          'Person/polymorphic-nicknames.json': new Person({
+            name: 'Polymorphic Nicknames',
+            nickNames: ['Alpha', 'Beta'],
+            [fields]: {
+              'nickNames.0': SpecialStringA,
+              'nickNames.1': SpecialStringB,
+            },
+          }),
           'Person/jade.json': new Person({ name: 'Jade' }),
           'Person/queenzy.json': new Person({ name: 'Queenzy' }),
           'Person/germaine.json': new Person({ name: 'Germaine' }),
@@ -260,6 +274,70 @@ module('Integration | commands | patch-instance', function (hooks) {
       instance.attributes?.nickNames,
       ['Paper'],
       'the containsMany array was fully replaced, not index-merged',
+    );
+  });
+
+  test<TestContextWithSave>('patching a polymorphic containsMany field clears stale field metadata', async function (assert) {
+    let patchInstanceCommand = new PatchCardInstanceCommand(
+      commandService.commandContext,
+      {
+        cardType: PersonDef,
+      },
+    );
+    let cardId = `${testRealmURL}Person/polymorphic-nicknames`;
+    let saves = 0;
+    let savedDoc: SingleCardDocument | undefined;
+    this.onSave((saveURL, doc) => {
+      if (saveURL.href === cardId && typeof doc !== 'string') {
+        saves++;
+        savedDoc = doc as SingleCardDocument;
+      }
+    });
+
+    await patchInstanceCommand.execute({
+      cardId,
+      patch: { attributes: { nickNames: ['Beta'] } },
+    });
+    await waitUntil(() => saves > 0, {
+      timeout: saveWaitTimeoutMs,
+      timeoutMessage: 'timed out waiting for the first save',
+    });
+
+    assert.deepEqual(
+      savedDoc?.data.attributes?.nickNames,
+      ['Beta'],
+      'the shorter array was persisted',
+    );
+    assert.strictEqual(
+      savedDoc?.data.meta.fields?.['nickNames.0'],
+      undefined,
+      'first index metadata was cleared on replacement',
+    );
+    assert.strictEqual(
+      savedDoc?.data.meta.fields?.['nickNames.1'],
+      undefined,
+      'second index metadata was cleared on replacement',
+    );
+
+    let savesAfterShrink = saves;
+    await patchInstanceCommand.execute({
+      cardId,
+      patch: { attributes: { nickNames: ['Beta', 'Gamma'] } },
+    });
+    await waitUntil(() => saves > savesAfterShrink, {
+      timeout: saveWaitTimeoutMs,
+      timeoutMessage: 'timed out waiting for the second save',
+    });
+
+    assert.deepEqual(
+      savedDoc?.data.attributes?.nickNames,
+      ['Beta', 'Gamma'],
+      'the expanded array was persisted without a reload',
+    );
+    assert.strictEqual(
+      savedDoc?.data.meta.fields?.['nickNames.1'],
+      undefined,
+      'old second index metadata did not come back after expanding',
     );
   });
 

--- a/packages/host/tests/integration/commands/patch-instance-test.gts
+++ b/packages/host/tests/integration/commands/patch-instance-test.gts
@@ -215,6 +215,54 @@ module('Integration | commands | patch-instance', function (hooks) {
     );
   });
 
+  test<TestContextWithSave>('patching a containsMany field with a shorter array fully replaces it (no stale trailing items)', async function (assert) {
+    let patchInstanceCommand = new PatchCardInstanceCommand(
+      commandService.commandContext,
+      {
+        cardType: PersonDef,
+      },
+    );
+    let url = new URL(`${testRealmURL}Person/hassan`);
+    let saves = 0;
+    this.onSave((saveURL) => {
+      if (saveURL.href === url.href) {
+        saves++;
+      }
+    });
+
+    await patchInstanceCommand.execute({
+      cardId: `${testRealmURL}Person/hassan`,
+      patch: { attributes: { nickNames: ['Paper', 'Pinky', 'Pix'] } },
+    });
+    await waitUntil(() => saves > 0, {
+      timeout: saveWaitTimeoutMs,
+      timeoutMessage: 'timed out waiting for the first save',
+    });
+
+    let savesAfterGrow = saves;
+    await patchInstanceCommand.execute({
+      cardId: `${testRealmURL}Person/hassan`,
+      patch: { attributes: { nickNames: ['Paper'] } },
+    });
+    await waitUntil(() => saves > savesAfterGrow, {
+      timeout: saveWaitTimeoutMs,
+      timeoutMessage: 'timed out waiting for the second save',
+    });
+
+    let result = await indexQuery.instance(url);
+    let instance =
+      result && result.type === 'instance' ? result.instance : undefined;
+    assert.ok(instance, 'instance payload is present');
+    if (!instance) {
+      throw new Error('expected instance payload');
+    }
+    assert.deepEqual(
+      instance.attributes?.nickNames,
+      ['Paper'],
+      'the containsMany array was fully replaced, not index-merged',
+    );
+  });
+
   test<TestContextWithSave>('can patch a linksTo field', async function (assert) {
     let patchInstanceCommand = new PatchCardInstanceCommand(
       commandService.commandContext,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -29,6 +29,7 @@ import {
   type PrerenderedCardCollectionDocument,
 } from './document-types.ts';
 import type { CardResource, Relationship } from './resource-types.ts';
+import { clearReplacedArrayFieldMeta } from './resource-types.ts';
 import { normalizeRelationships } from './relationship-utils.ts';
 import type { LocalPath } from './paths.ts';
 import { RealmPaths, ensureTrailingSlash, join } from './paths.ts';
@@ -4631,6 +4632,16 @@ export class Realm {
         included,
         realmURL: new URL(this.url),
       });
+
+      // When a patch fully replaces an array attribute, its per-index field
+      // metadata (e.g. the polymorphic type recorded at `meta.fields['items.1']`,
+      // or the array-valued `meta.fields['items']` for a composite containsMany)
+      // is stale. `mergeWith` overwrites arrays in attributes but deep-merges the
+      // `meta.fields` object, so without clearing these first the removed
+      // element's metadata survives and can be re-applied to a new entry when the
+      // array grows again. Drop the matching entries from the original before the
+      // merge so the patch's own metadata (if any) wins cleanly.
+      clearReplacedArrayFieldMeta(originalClone.meta, patch.attributes);
 
       let primaryResource = mergeWith(
         originalClone,

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -404,7 +404,10 @@ export function isPrerenderedCardResource(
 // True when `key` is `fieldName` followed by a plain array index (e.g.
 // `items.1`), the shape `meta.fields` uses for a primitive polymorphic
 // containsMany. Excludes deeper paths like `items.1.nested`.
-function isDirectIndexedFieldKey(key: string, fieldName: string): boolean {
+export function isDirectIndexedFieldKey(
+  key: string,
+  fieldName: string,
+): boolean {
   let prefix = `${fieldName}.`;
   if (!key.startsWith(prefix)) {
     return false;

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -401,6 +401,50 @@ export function isPrerenderedCardResource(
   return true;
 }
 
+// True when `key` is `fieldName` followed by a plain array index (e.g.
+// `items.1`), the shape `meta.fields` uses for a primitive polymorphic
+// containsMany. Excludes deeper paths like `items.1.nested`.
+function isDirectIndexedFieldKey(key: string, fieldName: string): boolean {
+  let prefix = `${fieldName}.`;
+  if (!key.startsWith(prefix)) {
+    return false;
+  }
+  let suffix = key.slice(prefix.length);
+  let index = Number(suffix);
+  return Number.isInteger(index) && index >= 0 && String(index) === suffix;
+}
+
+// Remove the field metadata describing an array attribute that a patch fully
+// replaces. A merge that overwrites arrays in `attributes` still deep-merges the
+// `meta.fields` object, so without this the removed elements' per-index metadata
+// survives and can be re-applied to a new entry when the array grows again.
+// Covers both serialization shapes: the array-valued `meta.fields[fieldName]` of
+// a composite containsMany and the per-index `meta.fields['fieldName.0']` keys of
+// a primitive polymorphic containsMany.
+export function clearReplacedArrayFieldMeta(
+  meta: Partial<Meta> | undefined,
+  attributes: Record<string, unknown> | undefined,
+): void {
+  if (!meta?.fields || !attributes) {
+    return;
+  }
+  let fields = meta.fields;
+  for (let [fieldName, value] of Object.entries(attributes)) {
+    if (!Array.isArray(value)) {
+      continue;
+    }
+    delete fields[fieldName];
+    for (let metaKey of Object.keys(fields)) {
+      if (isDirectIndexedFieldKey(metaKey, fieldName)) {
+        delete fields[metaKey];
+      }
+    }
+  }
+  if (Object.keys(fields).length === 0) {
+    delete meta.fields;
+  }
+}
+
 export function modulesConsumedInMeta(meta: Partial<Meta>): string[] {
   let modules: string[] = [];
   if (meta.adoptsFrom) {


### PR DESCRIPTION
linear: https://github.com/cardstack/boxel/pulls

Motivation: I have created a travel planner app tjat  lets the AI assistant plan and able tomutate a "containsMany" of itinerary stops. Asking it to reduce the stops got stuck — the assistant replies that the stops have been reduced (e.g. "Day 2 trimmed to a relaxed 4-stop flow"), but the containsMany field is never actually patched (or only the first day shrank while later days kept stale stops). After switching the merge logic to mergeWith, the same prompts now mutate the stops correctly.

---------

Root cause: StoreService.patch merged patch.attributes with lodash `merge`, which merges arrays by index and never shortens the destination array. A containsMany (or any array attribute) could grow or change in place via a patch but never shrink — a shorter array left the old trailing items behind. Because stops is one flat array (each carries a `day`), reducing every day reliably trimmed the low indices (Day 1) but left the high-index tail (Day 2+) untouched.

This only bit patch-based writes: the AI patchCardInstance tool and any PatchCardInstanceCommand caller. A component-side `model.field = [...]` assignment was never affected, because it replaces the whole field value.

Fix: merge attributes with mergeWith and a customizer that returns the source array, so a patched array fully replaces the existing one — matching PatchCardInstanceCommand's documented contract ("attributes specified will be fully replaced; display the full array in the patch code"). Non-array values still deep-merge (nested patches like `cardInfo: { name }` keep their siblings); the relationships and meta merge paths are unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Before: 
<img width="1446" height="756" alt="Screenshot 2026-06-24 at 8 08 54 PM" src="https://github.com/user-attachments/assets/4749534c-5664-4148-9f57-e0732ebeacd8" />


After:
<img width="1439" height="744" alt="Screenshot 2026-06-24 at 8 10 52 PM" src="https://github.com/user-attachments/assets/c7a71e85-3e31-4e45-950f-9184a1cd9dd6" />
