### PR TITLE
Guard queue Job result promise against unhandled-rejection crash

### DIFF
--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -52,16 +52,24 @@ QUnit.config.autostart = false;
   process.exitCode = data.testCounts.failed > 0 ? 1 : 0;
 });
 
+// Track the running test through QUnit's public callback API so the
+// unhandled-rejection handler below can attribute a leak without reaching
+// into QUnit internals.
+let currentTestName = '<no test running>';
+QUnit.testStart(({ module, name }) => {
+  currentTestName = module ? `${module} > ${name}` : name;
+});
+QUnit.testDone(() => {
+  currentTestName = '<no test running>';
+});
+
 // Native Node aborts the whole suite on the first unhandled rejection, and
 // its default dump names neither the test that leaked the promise nor a
 // usable stack. Attribute it to the running test before re-raising so the
 // failure stays fatal but becomes diagnosable instead of an opaque object
 // printed by node:internal/process/promises.
 process.on('unhandledRejection', (reason: unknown) => {
-  let current = (QUnit.config as any).current;
-  let testName = current
-    ? `${current.module?.name ?? ''} > ${current.testName}`
-    : '<no test running>';
+  let testName = currentTestName;
   let detail =
     reason instanceof Error
       ? (reason.stack ?? reason.message)

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -52,6 +52,32 @@ QUnit.config.autostart = false;
   process.exitCode = data.testCounts.failed > 0 ? 1 : 0;
 });
 
+// Native Node aborts the whole suite on the first unhandled rejection, and
+// its default dump names neither the test that leaked the promise nor a
+// usable stack. Attribute it to the running test before re-raising so the
+// failure stays fatal but becomes diagnosable instead of an opaque object
+// printed by node:internal/process/promises.
+process.on('unhandledRejection', (reason: unknown) => {
+  let current = (QUnit.config as any).current;
+  let testName = current
+    ? `${current.module?.name ?? ''} > ${current.testName}`
+    : '<no test running>';
+  let detail =
+    reason instanceof Error
+      ? (reason.stack ?? reason.message)
+      : (() => {
+          try {
+            return JSON.stringify(reason);
+          } catch {
+            return String(reason);
+          }
+        })();
+  console.error(
+    `Unhandled promise rejection during test [${testName}]:\n${detail}`,
+  );
+  throw reason;
+});
+
 QUnit.config.testTimeout = 60000;
 const testModules = process.env.TEST_MODULES?.trim();
 

--- a/packages/runtime-common/queue.ts
+++ b/packages/runtime-common/queue.ts
@@ -144,12 +144,13 @@ export class Job<T> {
     // The result promise is live from the moment the job is published,
     // before any caller reads `.done` and attaches a handler. A job that
     // settles to a rejection in that window — or whose result is never
-    // awaited at all — would otherwise surface as an unhandled rejection
-    // and abort the process. The runner is the source of truth for job
-    // failures (it logs and reports them), so a dropped `.done` rejection
-    // loses no signal. This no-op keeps the promise permanently handled;
-    // callers that do read `.done` still receive the rejection, because a
-    // promise delivers to every attached handler.
+    // awaited at all — would otherwise surface as an unhandled rejection,
+    // which under native Node aborts the whole process. Awaiting `.done`
+    // is opt-in: a caller that cares about the outcome reads it and
+    // handles the rejection there, and still receives it even though this
+    // no-op ran first, because a promise delivers to every attached
+    // handler. This guard only suppresses the unhandled-rejection signal
+    // for an outcome nobody is awaiting.
     this.notifier.promise.catch(() => {});
   }
   get done(): Promise<T> {

--- a/packages/runtime-common/queue.ts
+++ b/packages/runtime-common/queue.ts
@@ -141,6 +141,16 @@ export class Job<T> {
   constructor(id: number, notifier: Deferred<T>) {
     this.id = id;
     this.notifier = notifier;
+    // The result promise is live from the moment the job is published,
+    // before any caller reads `.done` and attaches a handler. A job that
+    // settles to a rejection in that window — or whose result is never
+    // awaited at all — would otherwise surface as an unhandled rejection
+    // and abort the process. The runner is the source of truth for job
+    // failures (it logs and reports them), so a dropped `.done` rejection
+    // loses no signal. This no-op keeps the promise permanently handled;
+    // callers that do read `.done` still receive the rejection, because a
+    // promise delivers to every attached handler.
+    this.notifier.promise.catch(() => {});
   }
   get done(): Promise<T> {
     return this.notifier.promise;


### PR DESCRIPTION
## What

The realm-server `queue-test.ts` shard intermittently aborts with a bare crash from `node:internal/process/promises` — `triggerUncaughtException(err, true /* fromPromise */)` printing `{ stack, message: 'boom!' }`. It surfaced after the node-cluster suites moved to native `node tests/index.ts`, where an unhandled rejection aborts the process (the qunit/ts-node CLI runner didn't).

A published `Job`'s result promise is live the instant `publish()` returns, before any caller reads `.done` and attaches a handler. In `'a job can throw an exception'` both jobs are published via `Promise.all` and handlers are only attached (via `allSettled`) after **both** publishes resolve. If the sibling publish lags, the worker runs the fast-failing `boom` job and the notification rejects its `Deferred` first — with no handler attached yet — so the rejection goes unhandled and kills the shard. The rejection value is `serializableError(err)` = `{ stack, message }`, which matches the crash dump exactly.

## Change

- **`packages/runtime-common/queue.ts`** — attach a permanent no-op `.catch` to the `Job`'s result promise in the constructor. The promise is now always handled, so an unawaited result (or one that rejects before `.done` is read) can't abort the process. Real `.done` consumers still receive the rejection, because a promise delivers to every attached handler; the worker remains the source of truth for job failures (it logs and reports them), so a dropped result loses no signal.
- **`packages/realm-server/tests/index.ts`** — register an `unhandledRejection` handler that attributes the rejection to the running QUnit test and prints a usable detail, then re-raises. A future leak stays fatal but is diagnosable instead of an opaque object dump.

## Validation

Reproduced the exact CI crash with the real `Job`/`Deferred` classes under native Node (`triggerUncaughtException … { stack, message: 'boom!' }`, exit 1). With the guard: no crash, and an end-to-end simulation of the `Promise.all` → delayed sibling publish → `allSettled` flow still hands the `boom!` rejection to the awaiter. Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
