### PR TITLE
Remove the `click` and `touch` hydration modes

### DIFF
--- a/packages/host/app/components/card-search/hydratable-card.gts
+++ b/packages/host/app/components/card-search/hydratable-card.gts
@@ -57,16 +57,11 @@ const hydrationTrigger = modifier(
     if (mode === 'none') {
       return;
     }
-    // Hover mode treats pointer-hover and keyboard-focus synonymously, so a
-    // card hydrates the same way for both. `focusin` (which bubbles, unlike
-    // `focus`) also fires when focus lands on a descendant during keyboard
-    // navigation into the card.
-    let events =
-      mode === 'hover'
-        ? ['mouseenter', 'focusin']
-        : mode === 'touch'
-          ? ['touchstart']
-          : ['click'];
+    // `hover` treats pointer-hover and keyboard-focus synonymously, so a card
+    // hydrates the same way for both. `focusin` (which bubbles, unlike `focus`)
+    // also fires when focus lands on a descendant during keyboard navigation
+    // into the card.
+    let events = ['mouseenter', 'focusin'];
     let handler = () => onTrigger();
     events.forEach((event) => element.addEventListener(event, handler));
     return () =>

--- a/packages/host/tests/integration/components/hydratable-card-test.gts
+++ b/packages/host/tests/integration/components/hydratable-card-test.gts
@@ -3,7 +3,6 @@ import {
   render,
   settled,
   triggerEvent,
-  click,
 } from '@ember/test-helpers';
 
 import GlimmerComponent from '@glimmer/component';
@@ -197,36 +196,7 @@ module('Integration | Component | hydratable-card', function (hooks) {
     );
   });
 
-  // (b) Published view (no overlay): the click gesture hydrates the same way,
-  // with no operator-mode machinery present.
-  test('published view — click hydrates the inert HTML into a live card', async function (assert) {
-    let inert = htmlComponent(INERT_HTML);
-    await render(
-      <template>
-        <TestContext>
-          <HydratableCard
-            @cardId={{HASSAN}}
-            @component={{inert}}
-            @mode='click'
-          />
-        </TestContext>
-      </template>,
-    );
-
-    assert.dom('[data-hydration="click"]').exists('carries the click gesture');
-    assert.dom('[data-test-live-card]').doesNotExist('no live card yet');
-
-    await click('[data-test-hydratable-card]');
-
-    assert.dom('[data-test-live-card]').hasText('Live: Hassan', 'now live');
-    assert.dom('[data-test-inert-card]').doesNotExist('inert HTML is gone');
-    assert.ok(
-      isCardInstance(storeService.peek(HASSAN)),
-      'the card entered the Store',
-    );
-  });
-
-  // (c) Operator mode (overlay present): hydration and the overlay coexist —
+  // (b) Operator mode (overlay present): hydration and the overlay coexist —
   // the inert HTML registers with the ElementTracker, and the inert→live swap
   // re-registers the new element so the overlay re-anchors to the live card.
   test('operator mode — the swap re-registers the new element with the ElementTracker', async function (assert) {
@@ -283,7 +253,7 @@ module('Integration | Component | hydratable-card', function (hooks) {
     );
   });
 
-  // (d) `@overlays={{false}}`: even with the operator-mode tracker present, the
+  // (c) `@overlays={{false}}`: even with the operator-mode tracker present, the
   // row opts out of the overlay — it never registers, so no chip / options menu
   // / selection toggle can anchor to it. Hydration is unaffected: the inert HTML
   // still swaps to a live card, the swap just never registers either element.

--- a/packages/runtime-common/search-results-component.ts
+++ b/packages/runtime-common/search-results-component.ts
@@ -12,10 +12,10 @@ import type {
 import type { SearchEntryWireQuery } from './search-entry.ts';
 
 // How an HTML-backed search result becomes a live, running card. `none` stays
-// inert; `hover` / `click` / `touch` fetch the card on the matching gesture and
-// swap the inert HTML for a live render. A host-side UX choice — it never
-// travels on the wire.
-export type HydrationMode = 'none' | 'hover' | 'click' | 'touch';
+// inert; `hover` fetches the card on pointer-hover / keyboard-focus and swaps
+// the inert HTML for a live render. A host-side UX choice — it never travels on
+// the wire.
+export type HydrationMode = 'none' | 'hover';
 
 // One rendering of a search result: the wire's `html` resource flattened, with
 // its `styles` references resolved to the stylesheets' hrefs. `id` is the
@@ -90,7 +90,7 @@ export interface SearchResultsComponentSignature {
     query: SearchEntryWireQuery | undefined;
     // The hydration gesture for HTML-backed rows — a host-UX choice, never on
     // the wire. A full live row ignores it. Defaults to `hover`; pass `none` to
-    // keep rows inert, `click` / `touch` to gate on those gestures.
+    // keep rows inert.
     mode?: HydrationMode;
     // Whether rendered results register with the operator-mode overlay (the
     // card-type chip / options menu / selection toggle). Defaults to `true`;


### PR DESCRIPTION
Hydration mode is a per-surface host-UX choice for how an HTML-backed search result becomes a live, running card — it never travels on the wire. `HydrationMode` defined four modes; this reduces it to the two we actually want:

```ts
export type HydrationMode = 'none' | 'hover';
```

`click` and `touch` hydrated on the **same gesture a user makes to select / navigate to a result**, so the hydration gesture collided with the result's primary interaction — a tap meant to open a result got consumed to hydrate it instead. Lazy `hover` hydration (pointer-hover + keyboard `focusin`) already makes a result live ahead of the interaction that opens it, so `click` / `touch` were a footgun with no upside.

## Changes

- **`runtime-common/search-results-component.ts`** — drop `'click'` / `'touch'` from the `HydrationMode` union and update the explanatory comments.
- **`host/app/components/card-search/hydratable-card.gts`** — remove the `click` / `touch` branches from the `hydrationTrigger` modifier: `hover` keeps its `mouseenter` + `focusin` listeners, `none` keeps the early return.
- **`host/tests/integration/components/hydratable-card-test.gts`** — drop the `@mode='click'` case (with `click` removed it is mechanically the existing no-overlay `hover` case) and the now-unused `click` import; `none` / `hover` coverage is unchanged.

Defaults are unaffected: `<SearchResults>` defaults to `hover` and `HydratableCard` falls back to `none`.

The project's Decision #9 ("Hydration mode") has been reconciled to `none` / `hover`.

## Testing

- `ember test --path dist --filter 'hydratable-card'` — **13/13 pass**.
- `ember-tsc` (glint) type-check clean across `host` and `runtime-common`; eslint + ember-template-lint clean.
