### PR TITLE
Retry base-realm fetches addressed at the real CI host

### DIFF
--- a/packages/host/tests/unit/virtual-network-retry-test.ts
+++ b/packages/host/tests/unit/virtual-network-retry-test.ts
@@ -1,0 +1,103 @@
+import { module, test } from 'qunit';
+
+import { shouldRetryFetch } from '@cardstack/runtime-common/virtual-network';
+
+// `shouldRetryFetch` is the pure predicate that gates the in-app fetch-retry
+// safety net (see virtual-network.ts). The net papers over a transient CI
+// failure mode where base-realm artifact fetches occasionally vanish with
+// `TypeError: Failed to fetch`. These tests pin exactly which URLs the net
+// covers — and, just as importantly, which it deliberately does not.
+
+function withEnvironment(value: string | undefined, fn: () => void) {
+  let g = globalThis as { __environment?: string };
+  let had = '__environment' in g;
+  let prev = g.__environment;
+  if (value === undefined) {
+    delete g.__environment;
+  } else {
+    g.__environment = value;
+  }
+  try {
+    fn();
+  } finally {
+    if (had) {
+      g.__environment = prev;
+    } else {
+      delete g.__environment;
+    }
+  }
+}
+
+module('Unit | virtual-network shouldRetryFetch', function () {
+  test('retries base-realm fetches addressed at the virtual cardstack.com host', function (assert) {
+    withEnvironment('test', () => {
+      assert.true(
+        shouldRetryFetch(new URL('https://cardstack.com/base/style-reference')),
+        'virtual base-realm URL is retryable',
+      );
+    });
+  });
+
+  test('retries base-realm fetches addressed at the real CI *.localhost host', function (assert) {
+    withEnvironment('test', () => {
+      // The exact shape that escaped as an uncaught `TypeError: Failed to
+      // fetch` before the net covered it: a base-realm artifact requested at
+      // the Traefik-fronted host rather than the virtual cardstack.com URL.
+      assert.true(
+        shouldRetryFetch(
+          new URL('https://realm-server.ci.localhost/base/style-reference'),
+        ),
+        'base artifact at realm-server.ci.localhost is retryable',
+      );
+      assert.true(
+        shouldRetryFetch(
+          new URL('https://realm-server.ci.localhost/base/card-api'),
+        ),
+        'base module at the real host is retryable',
+      );
+    });
+  });
+
+  test('retries base-realm fetches on a bare localhost host', function (assert) {
+    withEnvironment('test', () => {
+      assert.true(
+        shouldRetryFetch(
+          new URL('https://localhost:4201/base/style-reference'),
+        ),
+        'base artifact on localhost is retryable',
+      );
+    });
+  });
+
+  test('does not retry non-base realms that share the real CI host', function (assert) {
+    withEnvironment('test', () => {
+      assert.false(
+        shouldRetryFetch(
+          new URL(
+            'https://realm-server.ci.localhost/testuser/personal/Author/1',
+          ),
+        ),
+        'a user realm on the same host keeps its no-retry behavior',
+      );
+      assert.false(
+        shouldRetryFetch(new URL('http://test-realm/test/SystemCard/default')),
+        'the in-browser test realm host is not retried',
+      );
+    });
+  });
+
+  test('does not retry anything outside the test environment', function (assert) {
+    withEnvironment(undefined, () => {
+      assert.false(
+        shouldRetryFetch(new URL('https://cardstack.com/base/style-reference')),
+        'production fetch flow is unaffected for the virtual URL',
+      );
+      assert.false(
+        shouldRetryFetch(
+          new URL('https://localhost:4201/base/style-reference'),
+        ),
+        'production fetch flow is unaffected for the localhost URL',
+      );
+    });
+  });
+});

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -556,7 +556,7 @@ const maxAttempts = 10;
 const backOffMs = 100;
 const retryableLocalHosts = new Set(['localhost', '127.0.0.1']);
 
-export function shouldRetryFetch(url: URL) {
+export function shouldRetryFetch(url: URL): boolean {
   // Env-mode services live at `<service>.<slug>.localhost` and are
   // reached through a local Traefik. The realm-server worker fetches
   // its own realm's `_mtimes` via this hostname on boot, and if Traefik

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -556,7 +556,7 @@ const maxAttempts = 10;
 const backOffMs = 100;
 const retryableLocalHosts = new Set(['localhost', '127.0.0.1']);
 
-function shouldRetryFetch(url: URL) {
+export function shouldRetryFetch(url: URL) {
   // Env-mode services live at `<service>.<slug>.localhost` and are
   // reached through a local Traefik. The realm-server worker fetches
   // its own realm's `_mtimes` via this hostname on boot, and if Traefik
@@ -586,6 +586,20 @@ function shouldRetryFetch(url: URL) {
   }
 
   if (retryableLocalHosts.has(url.hostname)) {
+    return true;
+  }
+
+  // CI serves the base realm from a Traefik-fronted `*.localhost` host
+  // (e.g. https://realm-server.ci.localhost/base/...) instead of the virtual
+  // https://cardstack.com/base/ URL that `baseRealm.inRealm` recognizes above.
+  // A base-realm GET that reaches here already addressed at that host is the
+  // same artifact and just as exposed to the transient fetch-vanishing, so
+  // retry it too. Scoped to the `/base/` path so sibling realms on the same
+  // host (e.g. /testuser/personal/) keep their no-retry behavior.
+  if (
+    url.hostname.endsWith('.localhost') &&
+    (url.pathname === '/base' || url.pathname.startsWith('/base/'))
+  ) {
     return true;
   }
 

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -589,13 +589,15 @@ export function shouldRetryFetch(url: URL) {
     return true;
   }
 
-  // CI serves the base realm from a Traefik-fronted `*.localhost` host
-  // (e.g. https://realm-server.ci.localhost/base/...) instead of the virtual
-  // https://cardstack.com/base/ URL that `baseRealm.inRealm` recognizes above.
-  // A base-realm GET that reaches here already addressed at that host is the
-  // same artifact and just as exposed to the transient fetch-vanishing, so
-  // retry it too. Scoped to the `/base/` path so sibling realms on the same
-  // host (e.g. /testuser/personal/) keep their no-retry behavior.
+  // The env-mode service stack (including env-mode CI) serves the base realm
+  // at a `*.localhost` host (e.g. https://realm-server.ci.localhost/base/...)
+  // rather than the virtual https://cardstack.com/base/ URL that
+  // `baseRealm.inRealm` recognizes above. The env-mode `.localhost` branch at
+  // the top of this function only fires in node/worker processes — it reads
+  // `process.env.BOXEL_ENVIRONMENT`, which a browser host test can't see — so
+  // without this clause a transient base-realm fetch-vanish in the browser
+  // escapes unretried. Match base artifacts by their `/base/` path so sibling
+  // realms on the same host (e.g. /testuser/personal/) keep no-retry behavior.
   if (
     url.hostname.endsWith('.localhost') &&
     (url.pathname === '/base' || url.pathname.startsWith('/base/'))


### PR DESCRIPTION
## Symptom

The host acceptance test `Acceptance | code-submode | card playground > multiple realms: edit format is enabled for writable instances of read-only card definitions` intermittently fails in CI with an uncaught global `TypeError: Failed to fetch`. The vanished fetch is a base-realm artifact at the real CI host, e.g. `https://realm-server.ci.localhost/base/style-reference`. The same commit passes on a parallel run, and the failure is a transport-level fetch vanish rather than a logic error.

## Root cause

`virtual-network.ts` carries a test-only fetch-retry safety net (`withRetries` / `shouldRetryFetch`) for a known CI quirk where base-realm artifact fetches occasionally vanish mid-flight with `TypeError: Failed to fetch`. In the browser, `shouldRetryFetch` recognizes base-realm fetches only in their virtual `https://cardstack.com/base/...` form (via `baseRealm.inRealm`) or on a bare `localhost` / `127.0.0.1` host. The env-mode service stack that the host-test CI job runs against serves the base realm at a `*.localhost` host such as `https://realm-server.ci.localhost/base/...`. The function's existing env-mode `.localhost` branch is gated on `process.env.BOXEL_ENVIRONMENT`, which is only set in node/worker processes — a browser host test can't see it — so a base fetch addressed at that host falls through to the test-mode branches, is not treated as retryable, throws on the first attempt, and the unhandled rejection fails whichever test QUnit is currently executing.

## Change

`shouldRetryFetch` now also treats a base-realm artifact addressed at a `*.localhost` host as retryable, matched by the `/base/` path so sibling realms on the same host (e.g. `/testuser/personal/`) keep their no-retry behavior. The predicate stays gated on `__environment === 'test'`, so production fetch behavior is unchanged. `fetch()` only rejects on transport errors (HTTP 4xx/5xx return a Response and are not retried), so this cannot mask a genuine 404.

If a base-realm fetch ever exhausts the full retry window, the existing `Exhausted N fetch retries for <url>` log names the exact URL, keeping any residual failure attributable.

A unit test (`packages/host/tests/unit/virtual-network-retry-test.ts`) pins the retry scope: virtual, real-host, and localhost base URLs retry; non-base realms on the same host and the test-realm host do not; and nothing retries outside the test environment.

Reference failing run: https://github.com/cardstack/boxel/actions/runs/28176122110/job/83454453815
