### PR TITLE
Make client-side filter type gate tolerant of module-ref spellings

### DIFF
--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -527,7 +527,10 @@ export class SearchResource<
     // still need the file-meta pool to surface a locally hydrated FileDef. Fall
     // back to the row when the query carries no top-level type ref.
     let filterRef = filter as { on?: CodeRef; type?: CodeRef } | undefined;
-    let isFileSearch = isFileDefCodeRef(filterRef?.on ?? filterRef?.type)
+    let isFileSearch = isFileDefCodeRef(
+      filterRef?.on ?? filterRef?.type,
+      api.virtualNetwork,
+    )
       ? true
       : serverResults.length > 0 && isFileDefInstance(serverResults[0]);
     let candidatePool: (CardDef | FileDef)[] = isFileSearch

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -799,6 +799,7 @@ export default class StoreService extends Service implements StoreInterface {
       isNonPresentLink: api.isNonPresentLink,
       getCardMeta: api.getCardMeta as CardAPIForMatching['getCardMeta'],
       primitive: api.primitive,
+      virtualNetwork: this.network.virtualNetwork,
     };
   }
 

--- a/packages/host/tests/unit/file-def-code-ref-test.ts
+++ b/packages/host/tests/unit/file-def-code-ref-test.ts
@@ -1,53 +1,94 @@
 import { module, test } from 'qunit';
 
-import { baseRRI, isFileDefCodeRef } from '@cardstack/runtime-common';
+import {
+  VirtualNetwork,
+  baseRealm,
+  baseRRI,
+  isFileDefCodeRef,
+} from '@cardstack/runtime-common';
 import type { RealmResourceIdentifier } from '@cardstack/runtime-common';
+
+import ENV from '@cardstack/host/config/environment';
+
+let { resolvedBaseRealmURL } = ENV;
 
 // `isFileDefCodeRef` lets the client-side search filter dispatch its candidate
 // pool (cards vs. file-meta) from the query's target type, so a file-meta
 // search that is complete with zero server rows still reconciles locally
 // hydrated FileDefs — rather than sniffing the kind off the first returned row,
 // which is unavailable when the result set is empty.
-module('Unit | isFileDefCodeRef', function () {
+//
+// Refs reach it in prefix form (`@cardstack/base/…`) while the internal subtype
+// map is built in full-URL form, so the comparison canonicalizes module
+// spellings through the VirtualNetwork. The VN here registers the base realm
+// the same way the host boot does — both the `addURLMapping` alias and the
+// `@cardstack/base/` prefix mapping — so the two spellings collapse to one key.
+module('Unit | isFileDefCodeRef', function (hooks) {
+  let virtualNetwork: VirtualNetwork;
+
+  hooks.beforeEach(function () {
+    virtualNetwork = new VirtualNetwork();
+    virtualNetwork.addURLMapping(
+      new URL(baseRealm.url),
+      new URL(resolvedBaseRealmURL),
+    );
+    virtualNetwork.addRealmMapping('@cardstack/base/', resolvedBaseRealmURL);
+  });
+
   test('recognizes the base FileDef ref', function (assert) {
     assert.true(
-      isFileDefCodeRef({ module: baseRRI('card-api'), name: 'FileDef' }),
+      isFileDefCodeRef(
+        { module: baseRRI('card-api'), name: 'FileDef' },
+        virtualNetwork,
+      ),
     );
   });
 
   test('recognizes a known extension subtype ref', function (assert) {
     assert.true(
-      isFileDefCodeRef({
-        module: baseRRI('markdown-file-def'),
-        name: 'MarkdownDef',
-      }),
+      isFileDefCodeRef(
+        { module: baseRRI('markdown-file-def'), name: 'MarkdownDef' },
+        virtualNetwork,
+      ),
       'MarkdownDef',
     );
     assert.true(
-      isFileDefCodeRef({ module: baseRRI('png-image-def'), name: 'PngDef' }),
+      isFileDefCodeRef(
+        { module: baseRRI('png-image-def'), name: 'PngDef' },
+        virtualNetwork,
+      ),
       'PngDef',
     );
   });
 
   test('rejects a non-FileDef card ref', function (assert) {
     assert.false(
-      isFileDefCodeRef({ module: baseRRI('card-api'), name: 'CardDef' }),
+      isFileDefCodeRef(
+        { module: baseRRI('card-api'), name: 'CardDef' },
+        virtualNetwork,
+      ),
     );
     assert.false(
-      isFileDefCodeRef({
-        module: 'http://test-realm/test/book' as RealmResourceIdentifier,
-        name: 'Book',
-      }),
+      isFileDefCodeRef(
+        {
+          module: 'http://test-realm/test/book' as RealmResourceIdentifier,
+          name: 'Book',
+        },
+        virtualNetwork,
+      ),
     );
   });
 
   test('rejects undefined and non-resolved refs', function (assert) {
-    assert.false(isFileDefCodeRef(undefined));
+    assert.false(isFileDefCodeRef(undefined, virtualNetwork));
     assert.false(
-      isFileDefCodeRef({
-        type: 'ancestorOf',
-        card: { module: baseRRI('card-api'), name: 'FileDef' },
-      }),
+      isFileDefCodeRef(
+        {
+          type: 'ancestorOf',
+          card: { module: baseRRI('card-api'), name: 'FileDef' },
+        },
+        virtualNetwork,
+      ),
       'a structured (non-module/name) ref is not treated as a FileDef ref',
     );
   });

--- a/packages/host/tests/unit/instance-filter-matcher-test.ts
+++ b/packages/host/tests/unit/instance-filter-matcher-test.ts
@@ -69,6 +69,7 @@ module('Unit | instance-filter-matcher', function (hooks) {
       isNonPresentLink: cardApi.isNonPresentLink,
       getCardMeta: cardApi.getCardMeta as CardAPIForMatching['getCardMeta'],
       primitive: cardApi.primitive,
+      virtualNetwork,
     };
 
     let {
@@ -363,6 +364,33 @@ module('Unit | instance-filter-matcher', function (hooks) {
     assert.strictEqual(match(mango, { type: fancyPersonRef }), 'match');
     assert.strictEqual(match(paper, { type: personRef }), 'no-match');
     assert.strictEqual(match(paper, { type: catRef }), 'match');
+  });
+
+  test('a type gate tolerates equivalent module spellings', function (assert) {
+    let { mango } = cards;
+    // The instance's class is identified under the realm's real URL. Express
+    // the filter's type ref under an equivalent virtual-alias spelling: an
+    // exact-string comparison misses it, so the gate would wrongly reject a
+    // server-returned card. The server tolerates this via `internalKeyFor`;
+    // the client matcher must resolve both spellings before comparing.
+    api.virtualNetwork.addURLMapping(
+      new URL('https://virtual-alias.example/test/'),
+      new URL(testRealmURL),
+    );
+    let aliasedPersonRef: CodeRef = {
+      module: rri('https://virtual-alias.example/test/person'),
+      name: 'Person',
+    };
+    assert.strictEqual(
+      match(mango, { type: aliasedPersonRef }),
+      'match',
+      'pure type filter matches across spellings',
+    );
+    assert.strictEqual(
+      match(mango, { on: aliasedPersonRef, eq: { name: 'Mango' } }),
+      'match',
+      'on-gate matches across spellings',
+    );
   });
 
   test('an on-scoped predicate gates by type', function (assert) {

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -392,6 +392,46 @@ export function moduleFrom(ref: CodeRef): string {
   }
 }
 
+// Reduce a module reference to a single canonical key, collapsing every
+// equivalent spelling the VirtualNetwork knows about — a prefix-form RRI
+// (`@cardstack/base/foo`), the real URL it maps to, and any virtual-URL alias
+// registered via `addURLMapping` (e.g. `https://cardstack.com/base/foo`) — so
+// two refs that point at the same module compare equal regardless of how they
+// were written. The client-side counterpart to the server's `internalKeyFor`,
+// extended to also fold `addURLMapping` aliases (which `resolveURL` alone
+// leaves untouched). Used wherever a code ref carried in a query is compared
+// against a ref derived from a loaded module.
+export function canonicalModuleKey(
+  module: string,
+  virtualNetwork: VirtualNetwork,
+): string {
+  let href: string;
+  try {
+    // Resolves a prefix-form RRI to its mapped URL; an absolute URL is parsed
+    // and returned unchanged. Memoized, so this stays cheap on hot paths.
+    href = virtualNetwork.toURLHref(module);
+  } catch {
+    // Unresolvable reference (e.g. a scoped prefix with no mapping): fall back
+    // to the raw form. Exact-string equality already covers the only way two
+    // such refs can be equal.
+    return module;
+  }
+  // `toURLHref` leaves an absolute URL untouched, so a virtual spelling and its
+  // real target (registered via `addURLMapping`) stay distinct without this.
+  // Collapse virtual onto real; real and unmapped URLs pass through.
+  try {
+    let real = virtualNetwork.mapURL(href, 'virtual-to-real');
+    if (real) {
+      href = real.href;
+    }
+  } catch {
+    // `href` wasn't a parseable absolute URL — leave it as resolved.
+  }
+  // Collapse the real URL onto its portable prefix form when a registered realm
+  // prefix matches, so `@scope/…` and the real URL also land on one key.
+  return virtualNetwork.unresolveURL(href);
+}
+
 function exportFrom(ref: CodeRef): string {
   if (!('type' in ref)) {
     return ref.name;

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -1,4 +1,5 @@
 import { baseRealm, baseFileRef } from './constants.ts';
+import { canonicalModuleKey } from './code-ref.ts';
 import type { CodeRef, ResolvedCodeRef } from './code-ref.ts';
 import type { RealmResourceIdentifier } from './realm-identifiers.ts';
 import type { VirtualNetwork } from './virtual-network.ts';
@@ -44,7 +45,16 @@ const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
 // the file-meta candidate pool from the query alone — without depending on the
 // server having returned a row to sniff — so an empty-but-complete file-meta
 // search still reconciles locally hydrated FileDefs.
-export function isFileDefCodeRef(ref: CodeRef | undefined): boolean {
+//
+// The query carries refs in prefix form (e.g. `@cardstack/base/markdown-file-def`)
+// while `FILEDEF_CODE_REF_BY_EXTENSION` is built in full-URL form, so the module
+// strings are compared by their canonical key rather than verbatim — otherwise
+// a subtype ref (`MarkdownDef`, `PngDef`, …) would miss and the file-meta search
+// would skip local reconciliation.
+export function isFileDefCodeRef(
+  ref: CodeRef | undefined,
+  virtualNetwork: VirtualNetwork,
+): boolean {
   if (
     !ref ||
     !('module' in ref) ||
@@ -53,11 +63,14 @@ export function isFileDefCodeRef(ref: CodeRef | undefined): boolean {
   ) {
     return false;
   }
-  if (ref.module === baseFileRef.module && ref.name === baseFileRef.name) {
+  let refKey = canonicalModuleKey(ref.module, virtualNetwork);
+  let matchesModule = (candidate: string) =>
+    refKey === canonicalModuleKey(candidate, virtualNetwork);
+  if (matchesModule(baseFileRef.module) && ref.name === baseFileRef.name) {
     return true;
   }
   for (let subtype of Object.values(FILEDEF_CODE_REF_BY_EXTENSION)) {
-    if (ref.module === subtype.module && ref.name === subtype.name) {
+    if (matchesModule(subtype.module) && ref.name === subtype.name) {
       return true;
     }
   }

--- a/packages/runtime-common/instance-filter-matcher.ts
+++ b/packages/runtime-common/instance-filter-matcher.ts
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash-es';
 
-import { getField, identifyCard } from './code-ref.ts';
+import { canonicalModuleKey, getField, identifyCard } from './code-ref.ts';
 import {
   isAnyFilter,
   isCardTypeFilter,
@@ -473,41 +473,6 @@ function codeRefEquals(
     );
   }
   return isEqual(a, b);
-}
-
-// Reduce a module reference to a single canonical key, collapsing every
-// equivalent spelling the VirtualNetwork knows about so two refs that point at
-// the same module compare equal regardless of how they were written.
-function canonicalModuleKey(
-  module: string,
-  virtualNetwork: VirtualNetwork,
-): string {
-  let href: string;
-  try {
-    // Resolves a prefix-form RRI (e.g. `@cardstack/base/card-api`) to its
-    // mapped URL; an absolute URL is returned unchanged.
-    href = virtualNetwork.resolveURL(module, undefined).href;
-  } catch {
-    // Unresolvable reference (e.g. a scoped prefix with no mapping): fall back
-    // to the raw form. The `a.module === b.module` fast path already covered
-    // the only way two such refs can be equal.
-    return module;
-  }
-  // `resolveURL` leaves an absolute URL untouched, so a virtual spelling and
-  // its real target (registered via `addURLMapping`, e.g.
-  // `https://cardstack.com/base/…` ↔ the deployed realm URL) stay distinct.
-  // Collapse virtual onto real here; real and unmapped URLs pass through.
-  try {
-    let real = virtualNetwork.mapURL(href, 'virtual-to-real');
-    if (real) {
-      href = real.href;
-    }
-  } catch {
-    // `href` wasn't a parseable absolute URL — leave it as resolved.
-  }
-  // Collapse the real URL onto its portable prefix form when a registered realm
-  // prefix matches, so `@scope/…` and the real URL also land on one key.
-  return virtualNetwork.unresolveURL(href);
 }
 
 // -- sort comparator ---------------------------------------------------------

--- a/packages/runtime-common/instance-filter-matcher.ts
+++ b/packages/runtime-common/instance-filter-matcher.ts
@@ -463,30 +463,51 @@ function codeRefEquals(
       return true;
     }
     // The class is identified under the module spelling it was loaded from,
-    // while the filter ref can carry an equivalent spelling (RRI / real-URL /
-    // virtual-alias). Resolve both through the VirtualNetwork before comparing
-    // so the type gate doesn't drop an instance over a cosmetic URL difference
-    // — the same tolerance the server applies in `internalKeyFor`.
+    // while the filter ref can carry an equivalent spelling (prefix RRI /
+    // real-URL / virtual-alias). Reduce both to a single canonical key before
+    // comparing so the type gate doesn't drop an instance over a cosmetic URL
+    // difference — the tolerance the server applies in `internalKeyFor`.
     return (
-      resolveModuleURL(a.module, virtualNetwork) ===
-      resolveModuleURL(b.module, virtualNetwork)
+      canonicalModuleKey(a.module, virtualNetwork) ===
+      canonicalModuleKey(b.module, virtualNetwork)
     );
   }
   return isEqual(a, b);
 }
 
-function resolveModuleURL(
+// Reduce a module reference to a single canonical key, collapsing every
+// equivalent spelling the VirtualNetwork knows about so two refs that point at
+// the same module compare equal regardless of how they were written.
+function canonicalModuleKey(
   module: string,
   virtualNetwork: VirtualNetwork,
 ): string {
+  let href: string;
   try {
-    return virtualNetwork.resolveURL(module, undefined).href;
+    // Resolves a prefix-form RRI (e.g. `@cardstack/base/card-api`) to its
+    // mapped URL; an absolute URL is returned unchanged.
+    href = virtualNetwork.resolveURL(module, undefined).href;
   } catch {
-    // A reference the VirtualNetwork can't resolve (e.g. a scoped prefix it has
-    // no mapping for) falls back to its raw form; the `a.module === b.module`
-    // fast path above already covered the only way two such refs can match.
+    // Unresolvable reference (e.g. a scoped prefix with no mapping): fall back
+    // to the raw form. The `a.module === b.module` fast path already covered
+    // the only way two such refs can be equal.
     return module;
   }
+  // `resolveURL` leaves an absolute URL untouched, so a virtual spelling and
+  // its real target (registered via `addURLMapping`, e.g.
+  // `https://cardstack.com/base/…` ↔ the deployed realm URL) stay distinct.
+  // Collapse virtual onto real here; real and unmapped URLs pass through.
+  try {
+    let real = virtualNetwork.mapURL(href, 'virtual-to-real');
+    if (real) {
+      href = real.href;
+    }
+  } catch {
+    // `href` wasn't a parseable absolute URL — leave it as resolved.
+  }
+  // Collapse the real URL onto its portable prefix form when a registered realm
+  // prefix matches, so `@scope/…` and the real URL also land on one key.
+  return virtualNetwork.unresolveURL(href);
 }
 
 // -- sort comparator ---------------------------------------------------------

--- a/packages/runtime-common/instance-filter-matcher.ts
+++ b/packages/runtime-common/instance-filter-matcher.ts
@@ -16,6 +16,7 @@ import {
 } from './query.ts';
 
 import type { CodeRef } from './code-ref.ts';
+import type { VirtualNetwork } from './virtual-network.ts';
 import type {
   BaseDef,
   CardDef,
@@ -47,6 +48,13 @@ export interface CardAPIForMatching {
     metaKey: 'lastModified' | 'resourceCreatedAt',
   ): any;
   primitive: symbol;
+  // Resolves a module reference's URL aliases so a type gate compares refs by
+  // their resolved identity rather than raw spelling. The server tolerates
+  // equivalent spellings (RRI / real-URL / virtual-alias) via `internalKeyFor`
+  // in index-query-engine.ts; this is the client-side counterpart, and without
+  // it a type-gated filter drops a server-returned instance whose class was
+  // identified under a different-but-equivalent module spelling.
+  virtualNetwork: VirtualNetwork;
 }
 
 // Three-valued result, deliberately not a boolean. The integration layer needs
@@ -103,12 +111,12 @@ export function matchInstanceAgainstFilter(
   // carries `type` *and* an operator (e.g. `{ type, eq }`) is not pure; there
   // `type` only gates, exactly as the server treats it.
   if (typeRef && Object.keys(filter).length === 1) {
-    return instanceIsType(instance, typeRef) ? 'match' : 'no-match';
+    return instanceIsType(instance, typeRef, api) ? 'match' : 'no-match';
   }
 
   // Any other node with an `on`/`type` is gated: if the instance isn't of that
   // type the whole node is a no-match before we look at fields.
-  if (typeGate && !instanceIsType(instance, typeGate)) {
+  if (typeGate && !instanceIsType(instance, typeGate, api)) {
     return 'no-match';
   }
 
@@ -425,12 +433,16 @@ function negate(result: MatchResult): MatchResult {
   return 'unresolvable';
 }
 
-function instanceIsType(instance: BaseDef, ref: CodeRef): boolean {
+function instanceIsType(
+  instance: BaseDef,
+  ref: CodeRef,
+  api: CardAPIForMatching,
+): boolean {
   let klass: typeof BaseDef | null =
     (instance.constructor as typeof BaseDef) ?? null;
   while (klass) {
     let codeRef = identifyCard(klass);
-    if (codeRef && codeRefEquals(codeRef, ref)) {
+    if (codeRef && codeRefEquals(codeRef, ref, api.virtualNetwork)) {
       return true;
     }
     klass = Object.getPrototypeOf(klass) as typeof BaseDef | null;
@@ -438,11 +450,43 @@ function instanceIsType(instance: BaseDef, ref: CodeRef): boolean {
   return false;
 }
 
-function codeRefEquals(a: CodeRef, b: CodeRef): boolean {
+function codeRefEquals(
+  a: CodeRef,
+  b: CodeRef,
+  virtualNetwork: VirtualNetwork,
+): boolean {
   if (a && b && 'module' in a && 'name' in a && 'module' in b && 'name' in b) {
-    return a.module === b.module && a.name === b.name;
+    if (a.name !== b.name) {
+      return false;
+    }
+    if (a.module === b.module) {
+      return true;
+    }
+    // The class is identified under the module spelling it was loaded from,
+    // while the filter ref can carry an equivalent spelling (RRI / real-URL /
+    // virtual-alias). Resolve both through the VirtualNetwork before comparing
+    // so the type gate doesn't drop an instance over a cosmetic URL difference
+    // — the same tolerance the server applies in `internalKeyFor`.
+    return (
+      resolveModuleURL(a.module, virtualNetwork) ===
+      resolveModuleURL(b.module, virtualNetwork)
+    );
   }
   return isEqual(a, b);
+}
+
+function resolveModuleURL(
+  module: string,
+  virtualNetwork: VirtualNetwork,
+): string {
+  try {
+    return virtualNetwork.resolveURL(module, undefined).href;
+  } catch {
+    // A reference the VirtualNetwork can't resolve (e.g. a scoped prefix it has
+    // no mapping for) falls back to its raw form; the `a.module === b.module`
+    // fast path above already covered the only way two such refs can match.
+    return module;
+  }
 }
 
 // -- sort comparator ---------------------------------------------------------


### PR DESCRIPTION
## Problem

`main`'s host test suite is red — `markdown BFM card references` (acceptance) and `RichMarkdownField: linkedCards …` (integration) fail because query-backed fields render nothing.

This is a latent interaction between two PRs that were each green in isolation:

- **#5327** (cs-11416) added the client-side search filtering step (`SearchResource.displayedInstances`), which reconciles an eligible live search's server result against in-memory Store state. Its CI ran at 03:57 UTC.
- **#5148** ("Change cross-resource references to prefix form") canonicalized refs and landed at 13:58 UTC — *after* #5327's CI, so the two were never tested together until #5327 merged.

## Root cause

The filtering step gates each candidate by the query's `on`/`type` ref via `instanceIsType`, which compared the instance class's identified ref against the filter ref with **exact string equality** (`a.module === b.module`).

After #5148, a class identified under one module spelling (e.g. the realm's real URL `https://realm-server.ci.localhost/base/card-api`) no longer string-matched a filter ref carrying an equivalent spelling (RRI / virtual alias). The gate returned `no-match`, so reconciliation dropped a server-returned instance the **server had correctly matched** (the server tolerates equivalent spellings via `internalKeyFor` / `internalKeysFor`).

Concretely, the `linkedCards` query is `{ in: { id: [...] }, on: { module: <card-api>, name: 'CardDef' } }`. The server returns the linked card; the client's exact-string type gate drops it; nothing renders.

## Fix

Resolve both module refs through the `VirtualNetwork` before comparing in `codeRefEquals`, mirroring the tolerance the server already applies in `internalKeyFor`. `CardAPIForMatching` gains a `virtualNetwork` member (supplied by `store.getMatchAPI()`).

Added a unit-test case asserting the type gate matches across equivalent module spellings.

## Verification

- `runtime-common` and `host` type-check clean; eslint clean on changed files.
- The failing markdown acceptance + `RichMarkdownField` integration tests are the regression coverage (they exercise the exact `on`-gated query path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)