### PR TITLE
Render errors as message+stack in fetch/card-loading logs

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -38,6 +38,7 @@ import {
   REPLACE_MARKER,
   SEPARATOR_MARKER,
   isCardErrorJSONAPI,
+  stringifyErrorForLog,
 } from '@cardstack/runtime-common';
 
 import { getPromptParts } from '@cardstack/runtime-common/ai';
@@ -2572,7 +2573,9 @@ export default class MatrixService extends Service {
     if (userChoiceId) {
       let result = await this.store.get<SystemCard>(userChoiceId);
       if (isCardErrorJSONAPI(result)) {
-        console.error('Error loading user-chosen system card:', result);
+        console.error(
+          `Error loading user-chosen system card: ${stringifyErrorForLog(result)}`,
+        );
         userChoiceFailed = true;
       } else {
         loadedCard = result;
@@ -2586,7 +2589,9 @@ export default class MatrixService extends Service {
       } else {
         let result = await this.store.get<SystemCard>(envDefaultId);
         if (isCardErrorJSONAPI(result)) {
-          console.error('Error loading env default system card:', result);
+          console.error(
+            `Error loading env default system card: ${stringifyErrorForLog(result)}`,
+          );
           envDefaultFailed = true;
         } else {
           loadedCard = result;

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -46,6 +46,7 @@ import {
   rri,
   logger,
   formattedError,
+  stringifyErrorForLog,
   isJsonContentType,
   SupportedMimeType,
   RealmPaths,
@@ -2142,11 +2143,11 @@ export default class StoreService extends Service implements StoreInterface {
         status === 404 &&
         isSystemCardDefault
       );
-      let message = `error getting instance ${JSON.stringify(idOrDoc, null, 2)}: ${JSON.stringify(error, null, 2)}`;
+      let message = `error getting instance ${JSON.stringify(idOrDoc, null, 2)}: ${stringifyErrorForLog(error)}`;
       if (shouldLogAsError) {
-        storeLogger.error(message, error);
+        storeLogger.error(message);
       } else {
-        storeLogger.debug(message, error);
+        storeLogger.debug(message);
       }
       return cardError;
     } finally {

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -639,6 +639,30 @@ export function coerceErrorMessage(err: unknown, placeholder: string): string {
   return placeholder;
 }
 
+// Render an unknown error as a single log-safe string. Passing an Error (or any
+// object) as a console argument serializes to "[object Object]" in
+// text-captured console output (e.g. CI test logs), and `JSON.stringify` of an
+// Error yields "{}" because its `message`/`stack` are non-enumerable — both
+// drop the stack, which is the detail that localizes a transient failure.
+// Prefer the stack for Errors, a JSON dump for plain / JSON:API error objects,
+// and fall back to `coerceErrorMessage` for everything else.
+export function stringifyErrorForLog(err: unknown): string {
+  if (err instanceof Error) {
+    return err.stack ?? `${err.name}: ${err.message}`;
+  }
+  if (err != null && typeof err === 'object') {
+    try {
+      let json = JSON.stringify(err);
+      if (json && json !== '{}') {
+        return json;
+      }
+    } catch {
+      // not serializable (e.g. circular references) — fall through
+    }
+  }
+  return coerceErrorMessage(err, '(no error detail available)');
+}
+
 export function responseWithError(
   error: CardError,
   requestContext: RequestContext,

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -676,6 +676,7 @@ export {
   isCardErrorJSONAPI,
   clampSerializedError,
   coerceErrorMessage,
+  stringifyErrorForLog,
   sanitizeForJsonb,
   ERROR_DOC_MAX_BYTES,
   ERROR_DOC_MAX_ADDITIONAL_ERRORS,

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -3,7 +3,11 @@ import { Deferred } from './deferred.ts';
 import { cachedFetch, type MaybeCachedResponse } from './cached-fetch.ts';
 import { executableExtensions, logger } from './index.ts';
 
-import { CardError, iconNotFoundMessage } from './error.ts';
+import {
+  CardError,
+  iconNotFoundMessage,
+  stringifyErrorForLog,
+} from './error.ts';
 import { flatMap } from 'lodash-es';
 import {
   shouldTrackRuntimeModuleGraph,
@@ -757,7 +761,10 @@ export class Loader {
       let detail = err?.code
         ? `${err.message} (${err.code})`
         : (err?.message ?? String(err));
-      this.log.error(`fetch failed for ${url}: ${detail}`, err);
+      this.log.error(
+        `fetch failed for ${url}: ${detail}`,
+        stringifyErrorForLog(err),
+      );
 
       let synthetic = new Response(`fetch failed for ${url}: ${detail}`, {
         status: 500,
@@ -1134,7 +1141,9 @@ export class Loader {
         },
       });
     } catch (err) {
-      this.log.error(`fetch failed for ${moduleURL}`, err); // to aid in debugging, since this exception doesn't include the URL that failed
+      this.log.error(
+        `fetch failed for ${moduleURL}: ${stringifyErrorForLog(err)}`,
+      ); // to aid in debugging, since this exception doesn't include the URL that failed
       // this particular exception might not be worth caching the module in a
       // "broken" state, since the server hosting the module is likely down. it
       // might be a good idea to be able to try again in this case...

--- a/packages/runtime-common/tests/coerce-error-message-test.ts
+++ b/packages/runtime-common/tests/coerce-error-message-test.ts
@@ -135,7 +135,13 @@ const tests = Object.freeze({
   'stringifyErrorForLog falls back to name+message when an Error has no stack':
     async (assert) => {
       let err = new Error('no stack here');
-      delete (err as { stack?: unknown }).stack;
+      // Force `stack` to undefined via an own data property so the test
+      // doesn't depend on whether the engine exposes `stack` as an own
+      // property (deletable) or a prototype accessor.
+      Object.defineProperty(err, 'stack', {
+        value: undefined,
+        configurable: true,
+      });
       assert.strictEqual(stringifyErrorForLog(err), 'Error: no stack here');
     },
 

--- a/packages/runtime-common/tests/coerce-error-message-test.ts
+++ b/packages/runtime-common/tests/coerce-error-message-test.ts
@@ -1,4 +1,8 @@
-import { CardError, coerceErrorMessage } from '../error.ts';
+import {
+  CardError,
+  coerceErrorMessage,
+  stringifyErrorForLog,
+} from '../error.ts';
 import type { SharedTests } from '../helpers/index.ts';
 
 const PLACEHOLDER = 'placeholder fallback message';
@@ -119,6 +123,42 @@ const tests = Object.freeze({
     assert.strictEqual(coerceErrorMessage({}, PLACEHOLDER), PLACEHOLDER);
     let tagged = { [Symbol.toStringTag]: 'TaggedError' };
     assert.strictEqual(coerceErrorMessage(tagged, PLACEHOLDER), PLACEHOLDER);
+  },
+
+  'stringifyErrorForLog returns the stack for an Error': async (assert) => {
+    let err = new Error('boom');
+    let out = stringifyErrorForLog(err);
+    assert.true(out.includes('boom'), 'includes the message');
+    assert.true(out.includes('Error'), 'includes the error name');
+  },
+
+  'stringifyErrorForLog falls back to name+message when an Error has no stack':
+    async (assert) => {
+      let err = new Error('no stack here');
+      delete (err as { stack?: unknown }).stack;
+      assert.strictEqual(stringifyErrorForLog(err), 'Error: no stack here');
+    },
+
+  'stringifyErrorForLog JSON-dumps a plain / JSON:API error object': async (
+    assert,
+  ) => {
+    assert.strictEqual(
+      stringifyErrorForLog({ status: 500, title: 'Internal Server Error' }),
+      '{"status":500,"title":"Internal Server Error"}',
+    );
+  },
+
+  'stringifyErrorForLog returns a string error unchanged': async (assert) => {
+    assert.strictEqual(stringifyErrorForLog('plain message'), 'plain message');
+  },
+
+  'stringifyErrorForLog falls back to a placeholder for null': async (
+    assert,
+  ) => {
+    assert.strictEqual(
+      stringifyErrorForLog(null),
+      '(no error detail available)',
+    );
   },
 } as SharedTests<{}>);
 


### PR DESCRIPTION
## Problem

Several error logs in the fetch and card-loading paths pass an `Error` (or error object) straight to `console.error` as an argument, or run it through `JSON.stringify`. Loggers forward extra arguments to `console.error`, and text-captured console output (CI test logs) renders an object argument as `[object Object]`; `JSON.stringify` of an `Error` yields `{}` because `message` and `stack` are non-enumerable. Either way the stack — the detail that localizes a transient failure — is lost.

## Change

Add `stringifyErrorForLog(err)` to `runtime-common/error.ts`: it returns the stack for `Error` instances, a JSON dump for plain / JSON:API error objects, and falls back to the existing `coerceErrorMessage` otherwise. Route the affected logs through it:

- `loader.ts` — the two `fetch failed for …` logs.
- `store.ts` — `error getting instance …` (was `JSON.stringify(error)` → `{}`).
- `matrix-service.ts` — the user-chosen and env-default system-card load errors.

Unit tests for the helper sit alongside the existing `coerceErrorMessage` tests.
