### PR TITLE
Fix flaky definition-lookup invalidate-race test

### DIFF
--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -1740,19 +1740,33 @@ module(basename(import.meta.filename), function () {
         2,
         'invalidate dropped the in-flight entry so caller B triggered its own prerender',
       );
-      // CS-10948: A's pre-invalidation result is dropped at persist time
-      // rather than served back. lookupDefinition therefore rejects (the
-      // post-skip readFromDatabaseCache misses because invalidate also
-      // deleted the row). Only B — which started after the bump and ran a
-      // fresh prerender — returns a Definition.
-      assert.strictEqual(
-        resultA.status,
-        'rejected',
-        'A is rejected — its pre-invalidation prerender result is discarded',
-      );
+      // A's pre-invalidation prerender result (v1) is discarded at persist
+      // time rather than served back. After discarding it, A falls back to
+      // readFromDatabaseCache, and which row that finds races caller B's
+      // fresh persist: releaseGate() unparks both callers at once, so A's
+      // fallback SELECT and B's INSERT of v2 settle in nondeterministic
+      // order —
+      //   - B's v2 not yet persisted when A reads -> A misses -> A rejects.
+      //   - B's v2 already persisted              -> A returns v2.
+      // Either way the invariant holds: A never serves its own stale v1.
+      // (Asserting strictly 'rejected' picks one race winner and flakes when
+      // B's INSERT lands before A's SELECT.)
       assert.strictEqual(resultB.status, 'fulfilled');
       if (resultB.status === 'fulfilled') {
         assert.strictEqual(resultB.value?.displayName, 'CoalesceInvalidate v2');
+      }
+      if (resultA.status === 'fulfilled') {
+        assert.strictEqual(
+          resultA.value?.displayName,
+          'CoalesceInvalidate v2',
+          'A discarded its stale v1 and fell back to B’s freshly-persisted v2 (benign race: B persisted before A read)',
+        );
+      } else {
+        assert.strictEqual(
+          resultA.status,
+          'rejected',
+          'A discarded its stale v1 and its DB fallback missed (benign race: A read before B persisted)',
+        );
       }
     });
 

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -1742,8 +1742,9 @@ module(basename(import.meta.filename), function () {
       );
       // A's pre-invalidation prerender result (v1) is discarded at persist
       // time rather than served back. After discarding it, A falls back to
-      // readFromDatabaseCache, and which row that finds races caller B's
-      // fresh persist: releaseGate() unparks both callers at once, so A's
+      // readFromDatabaseCache, and the row that read finds depends on a race
+      // with caller B's fresh persist: releaseGate() unparks both callers at
+      // once, so A's
       // fallback SELECT and B's INSERT of v2 settle in nondeterministic
       // order —
       //   - B's v2 not yet persisted when A reads -> A misses -> A rejects.
@@ -1759,7 +1760,7 @@ module(basename(import.meta.filename), function () {
         assert.strictEqual(
           resultA.value?.displayName,
           'CoalesceInvalidate v2',
-          'A discarded its stale v1 and fell back to B’s freshly-persisted v2 (benign race: B persisted before A read)',
+          "A discarded its stale v1 and fell back to B's freshly-persisted v2 (benign race: B persisted before A read)",
         );
       } else {
         assert.strictEqual(


### PR DESCRIPTION
The realm-server test `DefinitionLookup > invalidate drops in-flight entries so post-invalidation lookups do not join the stale promise` flakes: it asserts caller A's lookup strictly `rejects`, but A can legitimately resolve instead.

The test gates one prerender behind two callers. Caller A starts a prerender (v1) and parks; `invalidate()` then bumps the module generation and deletes the row; caller B starts a fresh prerender (v2) and parks at the same gate. A single `releaseGate()` unparks both, then `Promise.allSettled([pA, pB])`.

After the gate, A's generation guard fires (its snapshot predates the bump), so A discards its own v1 and falls back to `readFromDatabaseCache`. That fallback SELECT races B's INSERT of v2:

- B's v2 not yet persisted when A reads → A misses → A rejects.
- B's v2 already persisted → A reads it → A resolves with v2.

Both outcomes uphold the invariant the test exists to protect: **A never serves its own stale v1.** The old assertion hard-coded `rejected`, picking one race winner, so it flaked whenever B's INSERT landed before A's SELECT (the more likely ordering under CI load).

This change asserts the invariant rather than the race winner: a fulfilled A must equal v2, never v1; otherwise A must reject. A regression that reintroduced "serve own stale result" still fails loudly because a fulfilled A is required to be v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
