### PR TITLE
Update RRI migration script for JSON files

### DIFF
--- a/packages/realm-server/scripts/migrate-realm-references.sh
+++ b/packages/realm-server/scripts/migrate-realm-references.sh
@@ -176,9 +176,19 @@ fi
 # Directories to skip (matched by name at any depth), e.g. --exclude
 # decommissioned to leave moved-aside / backup trees untouched.
 EXCLUDE_ARGS=()
-for d in ${EXCLUDE_DIRS[@]+"${EXCLUDE_DIRS[@]}"}; do
-  EXCLUDE_ARGS+=("--exclude-dir=$d")
-done
+if [ ${#EXCLUDE_DIRS[@]} -gt 0 ]; then
+  for d in "${EXCLUDE_DIRS[@]}"; do
+    EXCLUDE_ARGS+=("--exclude-dir=$d")
+  done
+fi
+
+# File-type + exclude args for grep, assembled once. INCLUDE_ARGS is always
+# non-empty, so this array is always safe to expand even when no excludes
+# were given.
+GREP_ARGS=("${INCLUDE_ARGS[@]}")
+if [ ${#EXCLUDE_ARGS[@]} -gt 0 ]; then
+  GREP_ARGS+=("${EXCLUDE_ARGS[@]}")
+fi
 
 # If <find> is a URL, extract the path portion for matching path-only references.
 # e.g., https://realms-staging.stack.cards/catalog/ -> /catalog/
@@ -214,9 +224,9 @@ for search_dir in "$@"; do
     [ -n "$file" ] && matching_files+=("$file")
   done < <(
     if [ "$IS_URL" = true ]; then
-      grep -rlE "${FIND_STR}|[\"']${REALM_PATH}" "$search_dir" "${INCLUDE_ARGS[@]}" ${EXCLUDE_ARGS[@]+"${EXCLUDE_ARGS[@]}"} 2>/dev/null || true
+      grep -rlE "${FIND_STR}|[\"']${REALM_PATH}" "$search_dir" "${GREP_ARGS[@]}" 2>/dev/null || true
     else
-      grep -rl "${FIND_STR}" "$search_dir" "${INCLUDE_ARGS[@]}" ${EXCLUDE_ARGS[@]+"${EXCLUDE_ARGS[@]}"} 2>/dev/null || true
+      grep -rl "${FIND_STR}" "$search_dir" "${GREP_ARGS[@]}" 2>/dev/null || true
     fi
   )
 

--- a/packages/realm-server/scripts/migrate-realm-references.sh
+++ b/packages/realm-server/scripts/migrate-realm-references.sh
@@ -135,8 +135,8 @@ elif [ $# -ge 2 ]; then
   REPLACEMENT="$1"
   shift
 else
-  echo "Usage: $0 [--dry-run] [--json-only] <find> <replace> <directory> [<directory> ...]"
-  echo "       $0 [--dry-run] [--json-only] -e <environment> -r <realm> <directory> [<directory> ...]"
+  echo "Usage: $0 [--dry-run] [--json-only] [--exclude <dir>]... <find> <replace> <directory> [<directory> ...]"
+  echo "       $0 [--dry-run] [--json-only] [--exclude <dir>]... -e <environment> -r <realm> <directory> [<directory> ...]"
   echo ""
   echo "  <find>           The string to find (URL or prefix)"
   echo "  <replace>        The replacement string"

--- a/packages/realm-server/scripts/migrate-realm-references.sh
+++ b/packages/realm-server/scripts/migrate-realm-references.sh
@@ -13,12 +13,15 @@
 # so changes can be rolled back with: patch -R -p0 < <name>.patch
 #
 # Usage:
-#   ./migrate-realm-references.sh [--dry-run] [--json-only] <find> <replace> <directory> [<directory> ...]
-#   ./migrate-realm-references.sh [--dry-run] [--json-only] -e <environment> -r <realm> <directory> [<directory> ...]
+#   ./migrate-realm-references.sh [--dry-run] [--json-only] [--exclude <dir>]... <find> <replace> <directory> [<directory> ...]
+#   ./migrate-realm-references.sh [--dry-run] [--json-only] [--exclude <dir>]... -e <environment> -r <realm> <directory> [<directory> ...]
 #
 # Flags:
 #   --dry-run           Preview changes without modifying files
 #   --json-only         Only scan card JSON (skip .gts modules)
+#   --exclude <dir>     Skip directories matching <dir> (by name, any depth).
+#                       Repeatable. e.g. --exclude decommissioned to leave
+#                       moved-aside or backup trees untouched.
 #
 # Shortcut flags:
 #   -e, --environment   development | staging | production
@@ -35,8 +38,9 @@
 # replacement left valid JSON; a parse failure is reported and exits non-zero.
 #
 # Examples:
-#   # Convert the base virtual-alias references to RRI prefix form in card JSON.
-#   ./migrate-realm-references.sh --json-only https://cardstack.com/base/ @cardstack/base/ /persistent
+#   # Convert the base virtual-alias references to RRI prefix form in card JSON,
+#   # skipping moved-aside / backup trees.
+#   ./migrate-realm-references.sh --json-only --exclude decommissioned https://cardstack.com/base/ @cardstack/base/ /persistent
 #
 #   # Shortcut form (deployment-URL references)
 #   ./migrate-realm-references.sh --dry-run -e staging -r catalog /persistent/catalog /persistent/experiments
@@ -64,6 +68,7 @@ ENV=""
 REALM=""
 ERRORS=()
 CHANGED_JSON=()
+EXCLUDE_DIRS=()
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -74,6 +79,10 @@ while [ $# -gt 0 ]; do
     --json-only)
       JSON_ONLY=true
       shift
+      ;;
+    --exclude)
+      EXCLUDE_DIRS+=("$2")
+      shift 2
       ;;
     -e|--environment)
       ENV="$2"
@@ -137,6 +146,7 @@ else
   echo "  -r, --realm        catalog | base | skills | openrouter"
   echo "  --dry-run          Preview changes without modifying files"
   echo "  --json-only        Only scan card JSON (skip .gts modules)"
+  echo "  --exclude <dir>    Skip directories matching <dir> (repeatable)"
   echo ""
   echo "  Environment URL mappings:"
   echo "    development  -> http://localhost:4201/"
@@ -162,6 +172,13 @@ if [ "$JSON_ONLY" = true ]; then
 else
   INCLUDE_ARGS=(--include='*.json' --include='*.gts')
 fi
+
+# Directories to skip (matched by name at any depth), e.g. --exclude
+# decommissioned to leave moved-aside / backup trees untouched.
+EXCLUDE_ARGS=()
+for d in ${EXCLUDE_DIRS[@]+"${EXCLUDE_DIRS[@]}"}; do
+  EXCLUDE_ARGS+=("--exclude-dir=$d")
+done
 
 # If <find> is a URL, extract the path portion for matching path-only references.
 # e.g., https://realms-staging.stack.cards/catalog/ -> /catalog/
@@ -197,9 +214,9 @@ for search_dir in "$@"; do
     [ -n "$file" ] && matching_files+=("$file")
   done < <(
     if [ "$IS_URL" = true ]; then
-      grep -rlE "${FIND_STR}|[\"']${REALM_PATH}" "$search_dir" "${INCLUDE_ARGS[@]}" 2>/dev/null || true
+      grep -rlE "${FIND_STR}|[\"']${REALM_PATH}" "$search_dir" "${INCLUDE_ARGS[@]}" ${EXCLUDE_ARGS[@]+"${EXCLUDE_ARGS[@]}"} 2>/dev/null || true
     else
-      grep -rl "${FIND_STR}" "$search_dir" "${INCLUDE_ARGS[@]}" 2>/dev/null || true
+      grep -rl "${FIND_STR}" "$search_dir" "${INCLUDE_ARGS[@]}" ${EXCLUDE_ARGS[@]+"${EXCLUDE_ARGS[@]}"} 2>/dev/null || true
     fi
   )
 

--- a/packages/realm-server/scripts/migrate-realm-references.sh
+++ b/packages/realm-server/scripts/migrate-realm-references.sh
@@ -13,12 +13,16 @@
 # so changes can be rolled back with: patch -R -p0 < <name>.patch
 #
 # Usage:
-#   ./migrate-realm-references.sh [--dry-run] <find> <replace> <directory> [<directory> ...]
-#   ./migrate-realm-references.sh [--dry-run] -e <environment> -r <realm> <directory> [<directory> ...]
+#   ./migrate-realm-references.sh [--dry-run] [--json-only] <find> <replace> <directory> [<directory> ...]
+#   ./migrate-realm-references.sh [--dry-run] [--json-only] -e <environment> -r <realm> <directory> [<directory> ...]
+#
+# Flags:
+#   --dry-run           Preview changes without modifying files
+#   --json-only         Only scan card JSON (skip .gts modules)
 #
 # Shortcut flags:
 #   -e, --environment   development | staging | production
-#   -r, --realm         catalog | base | skills
+#   -r, --realm         catalog | base | skills | openrouter
 #
 #   Environment URL mappings:
 #     development  -> http://localhost:4201/
@@ -27,8 +31,14 @@
 #
 #   The replacement is auto-derived as @cardstack/<realm>/
 #
+# After a non-dry-run, every changed .json file is re-parsed to confirm the
+# replacement left valid JSON; a parse failure is reported and exits non-zero.
+#
 # Examples:
-#   # Shortcut form
+#   # Convert the base virtual-alias references to RRI prefix form in card JSON.
+#   ./migrate-realm-references.sh --json-only https://cardstack.com/base/ @cardstack/base/ /persistent
+#
+#   # Shortcut form (deployment-URL references)
 #   ./migrate-realm-references.sh --dry-run -e staging -r catalog /persistent/catalog /persistent/experiments
 #
 #   # Equivalent explicit form
@@ -49,14 +59,20 @@ set -uo pipefail
 # --- Parse flags ---
 
 DRY_RUN=false
+JSON_ONLY=false
 ENV=""
 REALM=""
 ERRORS=()
+CHANGED_JSON=()
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run)
       DRY_RUN=true
+      shift
+      ;;
+    --json-only)
+      JSON_ONLY=true
       shift
       ;;
     -e|--environment)
@@ -92,9 +108,9 @@ if [ -n "$ENV" ] || [ -n "$REALM" ]; then
   esac
 
   case "$REALM" in
-    catalog|base|skills) ;;
+    catalog|base|skills|openrouter) ;;
     *)
-      echo "Error: unknown realm '$REALM' (expected: catalog, base, skills)"
+      echo "Error: unknown realm '$REALM' (expected: catalog, base, skills, openrouter)"
       exit 1
       ;;
   esac
@@ -110,16 +126,17 @@ elif [ $# -ge 2 ]; then
   REPLACEMENT="$1"
   shift
 else
-  echo "Usage: $0 [--dry-run] <find> <replace> <directory> [<directory> ...]"
-  echo "       $0 [--dry-run] -e <environment> -r <realm> <directory> [<directory> ...]"
+  echo "Usage: $0 [--dry-run] [--json-only] <find> <replace> <directory> [<directory> ...]"
+  echo "       $0 [--dry-run] [--json-only] -e <environment> -r <realm> <directory> [<directory> ...]"
   echo ""
   echo "  <find>           The string to find (URL or prefix)"
   echo "  <replace>        The replacement string"
   echo "  <directory>      One or more realm directories to process"
   echo ""
   echo "  -e, --environment  development | staging | production"
-  echo "  -r, --realm        catalog | base | skills"
+  echo "  -r, --realm        catalog | base | skills | openrouter"
   echo "  --dry-run          Preview changes without modifying files"
+  echo "  --json-only        Only scan card JSON (skip .gts modules)"
   echo ""
   echo "  Environment URL mappings:"
   echo "    development  -> http://localhost:4201/"
@@ -136,6 +153,15 @@ fi
 # Ensure trailing slashes
 FIND_STR="${FIND_STR%/}/"
 REPLACEMENT="${REPLACEMENT%/}/"
+
+# Which file types to scan. Default covers both card JSON and in-realm .gts
+# modules; --json-only restricts to card documents (e.g. when .gts import
+# rewriting is handled separately).
+if [ "$JSON_ONLY" = true ]; then
+  INCLUDE_ARGS=(--include='*.json')
+else
+  INCLUDE_ARGS=(--include='*.json' --include='*.gts')
+fi
 
 # If <find> is a URL, extract the path portion for matching path-only references.
 # e.g., https://realms-staging.stack.cards/catalog/ -> /catalog/
@@ -171,9 +197,9 @@ for search_dir in "$@"; do
     [ -n "$file" ] && matching_files+=("$file")
   done < <(
     if [ "$IS_URL" = true ]; then
-      grep -rlE "${FIND_STR}|[\"']${REALM_PATH}" "$search_dir" --include='*.json' --include='*.gts' 2>/dev/null || true
+      grep -rlE "${FIND_STR}|[\"']${REALM_PATH}" "$search_dir" "${INCLUDE_ARGS[@]}" 2>/dev/null || true
     else
-      grep -rl "${FIND_STR}" "$search_dir" --include='*.json' --include='*.gts' 2>/dev/null || true
+      grep -rl "${FIND_STR}" "$search_dir" "${INCLUDE_ARGS[@]}" 2>/dev/null || true
     fi
   )
 
@@ -222,6 +248,9 @@ for search_dir in "$@"; do
       fi
       rm -f /tmp/migrate-err.$$
       echo "  Updated: $file"
+      case "$file" in
+        *.json) CHANGED_JSON+=("$file") ;;
+      esac
     fi
     total_files=$((total_files + 1))
   done
@@ -236,6 +265,31 @@ else
   echo "Done. $total_files file(s) updated."
   echo "Rollback patch saved to: $PATCH_FILE"
   echo "  To undo: patch -R -p0 < $PATCH_FILE"
+fi
+
+# Verify every changed JSON file still parses, so a bad replacement can't
+# silently corrupt a card document. Failures are reported and force a
+# non-zero exit; roll back with the patch above.
+if [ "$DRY_RUN" = false ] && [ ${#CHANGED_JSON[@]} -gt 0 ]; then
+  echo ""
+  echo "Verifying ${#CHANGED_JSON[@]} changed JSON file(s) still parse ..."
+  if ! node -e '
+    const fs = require("fs");
+    let bad = 0;
+    for (const f of process.argv.slice(1)) {
+      try {
+        JSON.parse(fs.readFileSync(f, "utf8"));
+      } catch (e) {
+        console.error("  Invalid JSON after migration: " + f + ": " + e.message);
+        bad++;
+      }
+    }
+    process.exit(bad > 0 ? 1 : 0);
+  ' "${CHANGED_JSON[@]}"; then
+    ERRORS+=("JSON validation failed for one or more migrated files (see above). Roll back with: patch -R -p0 < $PATCH_FILE")
+  else
+    echo "  All migrated JSON files parse cleanly."
+  fi
 fi
 
 if [ ${#ERRORS[@]} -gt 0 ]; then

--- a/packages/realm-server/scripts/migrate-realms-to-rri.sh
+++ b/packages/realm-server/scripts/migrate-realms-to-rri.sh
@@ -10,18 +10,18 @@
 # conversion. If a realm regains a virtual alias, add a mapping to MAPPINGS
 # below and it is picked up automatically.
 #
-# Pass-through flags (--dry-run, --json-only) are forwarded to each underlying
-# run; each run writes its own rollback .patch.
+# Pass-through flags (--dry-run, --json-only, --exclude <dir>) are forwarded to
+# each underlying run; each run writes its own rollback .patch.
 #
 # Usage:
-#   ./migrate-realms-to-rri.sh [--dry-run] [--json-only] <directory> [<directory> ...]
+#   ./migrate-realms-to-rri.sh [--dry-run] [--json-only] [--exclude <dir>]... <directory> [<directory> ...]
 #
 # Examples:
-#   # Preview the conversion across a realm data tree (no writes)
-#   ./migrate-realms-to-rri.sh --dry-run --json-only /persistent
+#   # Preview the conversion across /persistent, skipping moved-aside trees
+#   ./migrate-realms-to-rri.sh --dry-run --json-only --exclude decommissioned /persistent
 #
 #   # Apply it
-#   ./migrate-realms-to-rri.sh --json-only /persistent
+#   ./migrate-realms-to-rri.sh --json-only --exclude decommissioned /persistent
 
 set -uo pipefail
 
@@ -41,6 +41,10 @@ while [ $# -gt 0 ]; do
       FLAGS+=("$1")
       shift
       ;;
+    --exclude)
+      FLAGS+=("$1" "$2")
+      shift 2
+      ;;
     -*)
       echo "Unknown flag: $1" >&2
       exit 1
@@ -53,7 +57,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ ${#DIRS[@]} -lt 1 ]; then
-  echo "Usage: $0 [--dry-run] [--json-only] <directory> [<directory> ...]" >&2
+  echo "Usage: $0 [--dry-run] [--json-only] [--exclude <dir>]... <directory> [<directory> ...]" >&2
   exit 1
 fi
 

--- a/packages/realm-server/scripts/migrate-realms-to-rri.sh
+++ b/packages/realm-server/scripts/migrate-realms-to-rri.sh
@@ -13,15 +13,26 @@
 # Pass-through flags (--dry-run, --json-only, --exclude <dir>) are forwarded to
 # each underlying run; each run writes its own rollback .patch.
 #
+# --persistent <root> targets exactly the realm directories the server mounts
+# (the REALM_DIRS list below, joined to <root>) instead of taking explicit
+# directory arguments. This is the safest option: it converts only live realm
+# trees and never descends into backups, decommissioned data, or other
+# non-realm content sitting alongside them. Missing dirs under <root> are
+# skipped with a warning.
+#
 # Usage:
 #   ./migrate-realms-to-rri.sh [--dry-run] [--json-only] [--exclude <dir>]... <directory> [<directory> ...]
+#   ./migrate-realms-to-rri.sh [--dry-run] [--json-only] --persistent <root>
 #
 # Examples:
-#   # Preview the conversion across /persistent, skipping moved-aside trees
-#   ./migrate-realms-to-rri.sh --dry-run --json-only --exclude decommissioned /persistent
+#   # Preview against every live realm tree under /persistent (recommended)
+#   ./migrate-realms-to-rri.sh --dry-run --json-only --persistent /persistent
 #
 #   # Apply it
-#   ./migrate-realms-to-rri.sh --json-only --exclude decommissioned /persistent
+#   ./migrate-realms-to-rri.sh --json-only --persistent /persistent
+#
+#   # Or target explicit directories
+#   ./migrate-realms-to-rri.sh --json-only /persistent/base /persistent/realms
 
 set -uo pipefail
 
@@ -33,8 +44,24 @@ MAPPINGS=(
   "https://cardstack.com/base/|@cardstack/base/"
 )
 
+# Realm directory names the server mounts — mirrors the --path / --realmsRootPath
+# entries in start-staging.sh / start-production.sh. KEEP IN SYNC with those.
+# Used by --persistent to target exactly the live realm trees under a root.
+REALM_DIRS=(
+  base
+  catalog
+  submissions
+  skills
+  boxel-homepage
+  experiments
+  openrouter
+  software-factory
+  realms
+)
+
 FLAGS=()
 DIRS=()
+PERSISTENT_ROOT=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run|--json-only)
@@ -43,6 +70,10 @@ while [ $# -gt 0 ]; do
       ;;
     --exclude)
       FLAGS+=("$1" "$2")
+      shift 2
+      ;;
+    --persistent)
+      PERSISTENT_ROOT="$2"
       shift 2
       ;;
     -*)
@@ -56,8 +87,20 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ -n "$PERSISTENT_ROOT" ]; then
+  if [ ${#DIRS[@]} -gt 0 ]; then
+    echo "Note: --persistent given; ignoring explicit directory arguments" >&2
+  fi
+  DIRS=()
+  root="${PERSISTENT_ROOT%/}"
+  for name in "${REALM_DIRS[@]}"; do
+    DIRS+=("$root/$name")
+  done
+fi
+
 if [ ${#DIRS[@]} -lt 1 ]; then
   echo "Usage: $0 [--dry-run] [--json-only] [--exclude <dir>]... <directory> [<directory> ...]" >&2
+  echo "       $0 [--dry-run] [--json-only] --persistent <root>" >&2
   exit 1
 fi
 

--- a/packages/realm-server/scripts/migrate-realms-to-rri.sh
+++ b/packages/realm-server/scripts/migrate-realms-to-rri.sh
@@ -109,7 +109,15 @@ for mapping in "${MAPPINGS[@]}"; do
   find_str="${mapping%%|*}"
   replace_str="${mapping#*|}"
   echo "=== $find_str -> $replace_str ==="
-  if ! bash "$MIGRATE" ${FLAGS[@]+"${FLAGS[@]}"} "$find_str" "$replace_str" "${DIRS[@]}"; then
+  # Assemble the underlying invocation. DIRS is always non-empty (checked
+  # above), so this array is always safe to expand, with or without flags.
+  run_args=()
+  if [ ${#FLAGS[@]} -gt 0 ]; then
+    run_args+=("${FLAGS[@]}")
+  fi
+  run_args+=("$find_str" "$replace_str")
+  run_args+=("${DIRS[@]}")
+  if ! bash "$MIGRATE" "${run_args[@]}"; then
     status=1
   fi
   echo ""

--- a/packages/realm-server/scripts/migrate-realms-to-rri.sh
+++ b/packages/realm-server/scripts/migrate-realms-to-rri.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# One-command wrapper around migrate-realm-references.sh that converts the
+# on-disk virtual-alias realm references to RRI prefix form across the given
+# directories.
+#
+# Only the base realm is addressed by a virtual alias
+# (https://cardstack.com/base/); catalog, skills, and openrouter are authored
+# directly in scoped @cardstack/<realm>/ form on disk, so they need no
+# conversion. If a realm regains a virtual alias, add a mapping to MAPPINGS
+# below and it is picked up automatically.
+#
+# Pass-through flags (--dry-run, --json-only) are forwarded to each underlying
+# run; each run writes its own rollback .patch.
+#
+# Usage:
+#   ./migrate-realms-to-rri.sh [--dry-run] [--json-only] <directory> [<directory> ...]
+#
+# Examples:
+#   # Preview the conversion across a realm data tree (no writes)
+#   ./migrate-realms-to-rri.sh --dry-run --json-only /persistent
+#
+#   # Apply it
+#   ./migrate-realms-to-rri.sh --json-only /persistent
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATE="$SCRIPT_DIR/migrate-realm-references.sh"
+
+# <find>|<replace> pairs, one per virtual-alias realm.
+MAPPINGS=(
+  "https://cardstack.com/base/|@cardstack/base/"
+)
+
+FLAGS=()
+DIRS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run|--json-only)
+      FLAGS+=("$1")
+      shift
+      ;;
+    -*)
+      echo "Unknown flag: $1" >&2
+      exit 1
+      ;;
+    *)
+      DIRS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ ${#DIRS[@]} -lt 1 ]; then
+  echo "Usage: $0 [--dry-run] [--json-only] <directory> [<directory> ...]" >&2
+  exit 1
+fi
+
+status=0
+for mapping in "${MAPPINGS[@]}"; do
+  find_str="${mapping%%|*}"
+  replace_str="${mapping#*|}"
+  echo "=== $find_str -> $replace_str ==="
+  if ! bash "$MIGRATE" ${FLAGS[@]+"${FLAGS[@]}"} "$find_str" "$replace_str" "${DIRS[@]}"; then
+    status=1
+  fi
+  echo ""
+done
+
+exit $status


### PR DESCRIPTION
This extends the existing migration script with:
* `--json-only` as future issues track non-JSON files
* `--exclude` to ignore `.git` and `node_modules`
* `--persistent` to specifically choose the relevant directories, as the EFS has a lot of cruft

I ran this on a staging realm and reindexed, all seems well. My plan is to refine this for `.json` (this PR) and then `.gts` in a followup PR, and then run it on staging, because it requires reindexing each realm afterward.