### PR TITLE
Add archived_at to realm_metadata + archive query helpers

### DIFF
--- a/packages/host/config/schema/1782417591926_schema.sql
+++ b/packages/host/config/schema/1782417591926_schema.sql
@@ -137,6 +137,7 @@
    publishable BOOLEAN,
    created_at DEFAULT CURRENT_TIMESTAMP NOT NULL,
    updated_at DEFAULT CURRENT_TIMESTAMP NOT NULL,
+   archived_at,
    PRIMARY KEY ( url ) 
 );
 
@@ -167,6 +168,16 @@
    realm_url TEXT NOT NULL,
    current_version INTEGER NOT NULL,
    PRIMARY KEY ( realm_url ) 
+);
+
+ CREATE TABLE IF NOT EXISTS unlisted_realm_paths (
+   id DEFAULT (hex(randomblob(16))) NOT NULL,
+   source_realm_url TEXT NOT NULL,
+   slug TEXT NOT NULL,
+   owner_user_id TEXT NOT NULL,
+   created_at DEFAULT CURRENT_TIMESTAMP NOT NULL,
+   updated_at DEFAULT CURRENT_TIMESTAMP NOT NULL,
+   PRIMARY KEY ( id ) 
 );
 
  CREATE TABLE IF NOT EXISTS webhook_commands (

--- a/packages/postgres/migrations/1782417591926_add-archived-at-to-realm-metadata.js
+++ b/packages/postgres/migrations/1782417591926_add-archived-at-to-realm-metadata.js
@@ -1,0 +1,20 @@
+// Storage for the owner-controlled realm archive flag. Archiving is a
+// global, per-realm state (not per-user), so it lives on realm_metadata,
+// the purpose-built mutable per-realm flags table.
+//
+// archived_at IS NULL  -> realm is active
+// archived_at NOT NULL -> realm is archived (timestamp it was archived)
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.addColumn('realm_metadata', {
+    archived_at: {
+      type: 'timestamptz',
+      notNull: false,
+    },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumn('realm_metadata', 'archived_at');
+};

--- a/packages/postgres/scripts/convert-to-sqlite.ts
+++ b/packages/postgres/scripts/convert-to-sqlite.ts
@@ -291,8 +291,12 @@ function prepareDump(sql: string): string {
 
 function getSchemaFilename(): string {
   let files = readdirSync(migrationsDir);
+  // Only timestamped migration files — ignores non-migration entries in the
+  // dir such as `package.json` (pins the dir to type:commonjs) and
+  // `.eslintrc.js`. Must stay in sync with getLatestSchemaFile in
+  // packages/host/config/environment.js, which validates the schema file name.
   let lastFile = files
-    .filter((f) => f !== '.eslintrc.js')
+    .filter((f) => /^\d+_/.test(f))
     .sort()
     .pop()!;
   return `${lastFile.replace(/_.*/, '')}_schema.sql`;

--- a/packages/realm-server/tests/queries-test.ts
+++ b/packages/realm-server/tests/queries-test.ts
@@ -5,9 +5,13 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type { PgAdapter } from '@cardstack/postgres';
 import {
+  archiveRealm,
   fetchAllRealmsWithOwners,
+  fetchArchivedRealmsForOwner,
   fetchUserPermissions,
   insertPermissions,
+  isRealmArchived,
+  unarchiveRealm,
 } from '@cardstack/runtime-common';
 
 import { upsertPublishedRealmInRegistry } from '../lib/realm-registry-writes.ts';
@@ -218,6 +222,96 @@ module(basename(import.meta.filename), function () {
         ownerByRealm.get(publishedRealmURL),
         'realm/published-only',
         'uses published realm owner when source owner is missing',
+      );
+    });
+  });
+
+  module('realm archive helpers', function (hooks) {
+    let dbAdapter: PgAdapter;
+
+    setupDB(hooks, {
+      beforeEach: async (
+        _dbAdapter: PgAdapter,
+        _publisher,
+        _runner,
+      ): Promise<void> => {
+        dbAdapter = _dbAdapter;
+      },
+    });
+
+    test('archiveRealm marks a realm archived and isRealmArchived reflects it', async function (assert) {
+      const realmURL = new URL('http://example.com/archive-me/');
+
+      assert.false(
+        await isRealmArchived(dbAdapter, realmURL),
+        'a realm with no metadata row is not archived',
+      );
+
+      await archiveRealm(dbAdapter, realmURL);
+
+      assert.true(
+        await isRealmArchived(dbAdapter, realmURL),
+        'realm is archived after archiveRealm',
+      );
+    });
+
+    test('unarchiveRealm clears the flag and returns the realm to active', async function (assert) {
+      const realmURL = new URL('http://example.com/restore-me/');
+
+      await archiveRealm(dbAdapter, realmURL);
+      assert.true(await isRealmArchived(dbAdapter, realmURL));
+
+      await unarchiveRealm(dbAdapter, realmURL);
+      assert.false(
+        await isRealmArchived(dbAdapter, realmURL),
+        'realm is active after unarchiveRealm',
+      );
+    });
+
+    test('unarchiveRealm is idempotent when no metadata row exists', async function (assert) {
+      const realmURL = new URL('http://example.com/never-archived/');
+
+      await unarchiveRealm(dbAdapter, realmURL);
+      assert.false(
+        await isRealmArchived(dbAdapter, realmURL),
+        'realm remains active',
+      );
+    });
+
+    test('fetchArchivedRealmsForOwner returns only the owner’s archived realms', async function (assert) {
+      const owner = '@owner:localhost';
+      const otherOwner = '@other:localhost';
+
+      const archivedOwned = 'http://example.com/owned-archived/';
+      const activeOwned = 'http://example.com/owned-active/';
+      const archivedOtherOwner = 'http://example.com/other-archived/';
+      const archivedReadOnly = 'http://example.com/read-only-archived/';
+
+      await insertPermissions(dbAdapter, new URL(archivedOwned), {
+        [owner]: ['read', 'write', 'realm-owner'],
+      });
+      await insertPermissions(dbAdapter, new URL(activeOwned), {
+        [owner]: ['read', 'write', 'realm-owner'],
+      });
+      await insertPermissions(dbAdapter, new URL(archivedOtherOwner), {
+        [otherOwner]: ['read', 'write', 'realm-owner'],
+      });
+      // owner can read this realm but is not its owner
+      await insertPermissions(dbAdapter, new URL(archivedReadOnly), {
+        [owner]: ['read'],
+        [otherOwner]: ['read', 'write', 'realm-owner'],
+      });
+
+      await archiveRealm(dbAdapter, new URL(archivedOwned));
+      await archiveRealm(dbAdapter, new URL(archivedOtherOwner));
+      await archiveRealm(dbAdapter, new URL(archivedReadOnly));
+
+      let archived = await fetchArchivedRealmsForOwner(dbAdapter, owner);
+
+      assert.deepEqual(
+        archived,
+        [archivedOwned],
+        'returns only realms that are both archived and owned by the user',
       );
     });
   });

--- a/packages/realm-server/tests/queries-test.ts
+++ b/packages/realm-server/tests/queries-test.ts
@@ -314,5 +314,38 @@ module(basename(import.meta.filename), function () {
         'returns only realms that are both archived and owned by the user',
       );
     });
+
+    test('fetchArchivedRealmsForOwner excludes archived published snapshots', async function (assert) {
+      const owner = '@owner:localhost';
+      const sourceRealmURL = 'http://example.com/source/';
+      const publishedRealmURL = 'http://example.com/published/';
+
+      await insertPermissions(dbAdapter, new URL(sourceRealmURL), {
+        [owner]: ['read', 'write', 'realm-owner'],
+      });
+      // Publishing grants the owner realm-owner on the published URL too.
+      await upsertPublishedRealmInRegistry(dbAdapter, {
+        publishedRealmURL,
+        publishedRealmId: uuidv4(),
+        ownerUsername: owner,
+        sourceRealmURL,
+        lastPublishedAt: Date.now(),
+      });
+      await insertPermissions(dbAdapter, new URL(publishedRealmURL), {
+        [owner]: ['read', 'realm-owner'],
+        '*': ['read'],
+      });
+
+      await archiveRealm(dbAdapter, new URL(sourceRealmURL));
+      await archiveRealm(dbAdapter, new URL(publishedRealmURL));
+
+      let archived = await fetchArchivedRealmsForOwner(dbAdapter, owner);
+
+      assert.deepEqual(
+        archived,
+        [sourceRealmURL],
+        'published snapshots are omitted even when archived and owned',
+      );
+    });
   });
 });

--- a/packages/runtime-common/db-queries/realm-metadata-queries.ts
+++ b/packages/runtime-common/db-queries/realm-metadata-queries.ts
@@ -2,7 +2,12 @@
 // on realm_metadata.archived_at (NULL = active, non-null = archived at
 // that timestamp).
 import type { DBAdapter } from '../db.ts';
-import { param, query } from '../expression.ts';
+import { dbExpression, param, query } from '../expression.ts';
+
+// `now()` is Postgres-only; SQLite spells it `CURRENT_TIMESTAMP`. These
+// helpers are a shared runtime-common API, so render the timestamp
+// per-adapter rather than baking in a single dialect.
+const now = dbExpression({ pg: 'now()', sqlite: 'CURRENT_TIMESTAMP' });
 
 // Mark a realm archived. Upserts the realm_metadata row so a realm that
 // never had a metadata row (no other flags ever set) can still be
@@ -12,7 +17,12 @@ export async function archiveRealm(dbAdapter: DBAdapter, realmURL: URL) {
   await query(dbAdapter, [
     `INSERT INTO realm_metadata (url, archived_at) VALUES (`,
     param(realmURL.href),
-    `, now()) ON CONFLICT (url) DO UPDATE SET archived_at = now(), updated_at = now()`,
+    `,`,
+    now,
+    `) ON CONFLICT (url) DO UPDATE SET archived_at =`,
+    now,
+    `, updated_at =`,
+    now,
   ]);
 }
 
@@ -22,7 +32,8 @@ export async function unarchiveRealm(dbAdapter: DBAdapter, realmURL: URL) {
   await query(dbAdapter, [
     `INSERT INTO realm_metadata (url, archived_at) VALUES (`,
     param(realmURL.href),
-    `, NULL) ON CONFLICT (url) DO UPDATE SET archived_at = NULL, updated_at = now()`,
+    `, NULL) ON CONFLICT (url) DO UPDATE SET archived_at = NULL, updated_at =`,
+    now,
   ]);
 }
 
@@ -39,7 +50,10 @@ export async function isRealmArchived(
 
 // List the URLs of archived realms owned by a user. Joins archived
 // realm_metadata rows to realm_user_permissions where the user holds the
-// realm-owner permission.
+// realm-owner permission. Published snapshots are excluded: publishing
+// grants the owner realm-owner on the published URL too, so without this
+// filter an archived snapshot would surface as one of the user's
+// workspaces.
 export async function fetchArchivedRealmsForOwner(
   dbAdapter: DBAdapter,
   username: string,
@@ -50,6 +64,7 @@ export async function fetchArchivedRealmsForOwner(
      INNER JOIN realm_user_permissions rup ON rup.realm_url = rm.url
      WHERE rm.archived_at IS NOT NULL
        AND rup.realm_owner = true
+       AND rm.url NOT IN (SELECT url FROM realm_registry WHERE kind = 'published')
        AND rup.username =`,
     param(username),
     `ORDER BY rm.archived_at DESC`,

--- a/packages/runtime-common/db-queries/realm-metadata-queries.ts
+++ b/packages/runtime-common/db-queries/realm-metadata-queries.ts
@@ -1,0 +1,58 @@
+// Read/write helpers for the owner-controlled realm archive flag stored
+// on realm_metadata.archived_at (NULL = active, non-null = archived at
+// that timestamp).
+import type { DBAdapter } from '../db.ts';
+import { param, query } from '../expression.ts';
+
+// Mark a realm archived. Upserts the realm_metadata row so a realm that
+// never had a metadata row (no other flags ever set) can still be
+// archived. Re-archiving an already-archived realm refreshes the
+// timestamp.
+export async function archiveRealm(dbAdapter: DBAdapter, realmURL: URL) {
+  await query(dbAdapter, [
+    `INSERT INTO realm_metadata (url, archived_at) VALUES (`,
+    param(realmURL.href),
+    `, now()) ON CONFLICT (url) DO UPDATE SET archived_at = now(), updated_at = now()`,
+  ]);
+}
+
+// Clear the archive flag, returning a realm to active. Upserts so the
+// call is idempotent even when no metadata row exists yet.
+export async function unarchiveRealm(dbAdapter: DBAdapter, realmURL: URL) {
+  await query(dbAdapter, [
+    `INSERT INTO realm_metadata (url, archived_at) VALUES (`,
+    param(realmURL.href),
+    `, NULL) ON CONFLICT (url) DO UPDATE SET archived_at = NULL, updated_at = now()`,
+  ]);
+}
+
+export async function isRealmArchived(
+  dbAdapter: DBAdapter,
+  realmURL: URL,
+): Promise<boolean> {
+  let results = (await query(dbAdapter, [
+    `SELECT archived_at FROM realm_metadata WHERE url =`,
+    param(realmURL.href),
+  ])) as { archived_at: string | null }[];
+  return results.length > 0 && results[0].archived_at != null;
+}
+
+// List the URLs of archived realms owned by a user. Joins archived
+// realm_metadata rows to realm_user_permissions where the user holds the
+// realm-owner permission.
+export async function fetchArchivedRealmsForOwner(
+  dbAdapter: DBAdapter,
+  username: string,
+): Promise<string[]> {
+  let results = (await query(dbAdapter, [
+    `SELECT rm.url
+     FROM realm_metadata rm
+     INNER JOIN realm_user_permissions rup ON rup.realm_url = rm.url
+     WHERE rm.archived_at IS NOT NULL
+       AND rup.realm_owner = true
+       AND rup.username =`,
+    param(username),
+    `ORDER BY rm.archived_at DESC`,
+  ])) as { url: string }[];
+  return results.map((r) => r.url);
+}

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -824,6 +824,7 @@ export const cardExtensions = ['.gts', '.gjs'];
 export { createResponse } from './create-response.ts';
 
 export * from './db-queries/db-types.ts';
+export * from './db-queries/realm-metadata-queries.ts';
 export * from './db-queries/realm-permission-queries.ts';
 export * from './db-queries/session-room-queries.ts';
 export * from './db-queries/user-queries.ts';


### PR DESCRIPTION
## What

Adds the storage and query layer for the owner-controlled realm archive flag.

## Changes

- **Migration** (`packages/postgres/migrations/1782417591926_add-archived-at-to-realm-metadata.js`): adds a nullable `archived_at timestamptz` column to `realm_metadata`. `NULL` = active; non-null = the time the realm was archived. Existing and new rows default to `NULL`.
- **Query helpers** (`packages/runtime-common/db-queries/realm-metadata-queries.ts`, exported via `runtime-common/index.ts`):
  - `archiveRealm(dbAdapter, realmURL)` — upserts `archived_at = now()`, so a realm with no metadata row yet can still be archived.
  - `unarchiveRealm(dbAdapter, realmURL)` — upserts `archived_at = NULL`; idempotent when no row exists.
  - `isRealmArchived(dbAdapter, realmURL)` — boolean.
  - `fetchArchivedRealmsForOwner(dbAdapter, username)` — joins archived `realm_metadata` rows to `realm_user_permissions` where the user holds `realm-owner`, returning the owner's archived realm URLs (newest first).

## Why this shape

Archiving is a global, per-realm state rather than per-user, so it belongs on `realm_metadata` — the mutable per-realm flags table — not on a permissions or per-user table. A nullable timestamp captures both the active/archived boolean and when the transition happened in one column.

## Testing

- Migration applies up, rolls back down, and re-applies cleanly; the column is confirmed nullable with no default.
- New `realm archive helpers` module in `packages/realm-server/tests/queries-test.ts` covers set → archived, clear → active, idempotent clear, and the owner-scoped archived list (excludes other owners' realms and realms where the user only has read). The file passes 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)