### PR TITLE
Add validation resilience and parallelisation to RRI migration script

### DIFF
--- a/packages/realm-server/scripts/migrate-realm-references.sh
+++ b/packages/realm-server/scripts/migrate-realm-references.sh
@@ -268,10 +268,12 @@ VALID_BEFORE_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-valid-before.$$")
 
 # --- Parallel processing scratch ---
 # Files are processed concurrently (xargs -P) because the per-file work is
-# I/O-latency-bound on networked filesystems (EFS). Each worker writes its own
-# patch fragment (concurrent appends to one shared patch file would interleave
-# and corrupt it) and appends results to shared list files; everything is
-# aggregated after the directory loop.
+# I/O-latency-bound on networked filesystems (EFS). Each worker writes ONLY to
+# its own per-PID fragment files under FRAGMENTS_DIR (one stream each for the
+# patch, processed-file list, errors, and changed-JSON list) and never to a
+# shared file — so there are no cross-process appends to serialize (append
+# atomicity is not guaranteed on NFS/EFS). The fragments are concatenated into
+# the aggregate files below after the directory loop.
 FRAGMENTS_DIR=$(mktemp -d 2>/dev/null || echo "/tmp/migrate-frags.$$")
 mkdir -p "$FRAGMENTS_DIR"
 CHANGED_JSON_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-changed-json.$$")
@@ -287,9 +289,13 @@ JSON_CANDIDATES_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-json-candidates.
 
 # Worker: process a batch of files passed as positional args. Reconstructs the
 # sed program from exported scalars (arrays can't be exported across xargs).
-# Runs in its own `bash -c`, so results go to the shared files above.
+# Runs in its own `bash -c`; all output goes to this worker's own per-PID
+# fragment files (never to a shared file), aggregated after the loop.
 process_files() {
-  local frag="$FRAGMENTS_DIR/frag.$$"
+  local patch="$FRAGMENTS_DIR/patch.$$"
+  local processed="$FRAGMENTS_DIR/processed.$$"
+  local errors="$FRAGMENTS_DIR/errors.$$"
+  local changed="$FRAGMENTS_DIR/changed.$$"
   local file tmp
   for file in "$@"; do
     tmp="$file.tmp.$$"
@@ -298,34 +304,33 @@ process_files() {
                -e "s|\"${REALM_PATH}|\"${REPLACEMENT}|g" \
                -e "s|'${REALM_PATH}|'${REPLACEMENT}|g" \
                "$file" > "$tmp" 2>/dev/null; then
-        printf '%s\n' "Error processing $file" >> "$WORKER_ERRORS_FILE"
+        printf '%s\n' "Error processing $file" >> "$errors"
         rm -f "$tmp"
         continue
       fi
     else
       if ! sed -e "s|${FIND_STR}|${REPLACEMENT}|g" "$file" > "$tmp" 2>/dev/null; then
-        printf '%s\n' "Error processing $file" >> "$WORKER_ERRORS_FILE"
+        printf '%s\n' "Error processing $file" >> "$errors"
         rm -f "$tmp"
         continue
       fi
     fi
-    diff -u --label "$file" --label "$file" "$file" "$tmp" >> "$frag" 2>/dev/null || true
-    printf '%s\n' "$file" >> "$PROCESSED_FILE"
+    diff -u --label "$file" --label "$file" "$file" "$tmp" >> "$patch" 2>/dev/null || true
+    printf '%s\n' "$file" >> "$processed"
     if [ "$DRY_RUN" = true ]; then
       rm -f "$tmp"
     elif mv "$tmp" "$file" 2>/dev/null; then
       case "$file" in
-        *.json) printf '%s\n' "$file" >> "$CHANGED_JSON_FILE" ;;
+        *.json) printf '%s\n' "$file" >> "$changed" ;;
       esac
     else
-      printf '%s\n' "Error replacing $file" >> "$WORKER_ERRORS_FILE"
+      printf '%s\n' "Error replacing $file" >> "$errors"
       rm -f "$tmp"
     fi
   done
 }
 export -f process_files
-export FIND_STR REPLACEMENT IS_URL REALM_PATH DRY_RUN
-export FRAGMENTS_DIR CHANGED_JSON_FILE PROCESSED_FILE WORKER_ERRORS_FILE
+export FIND_STR REPLACEMENT IS_URL REALM_PATH DRY_RUN FRAGMENTS_DIR
 
 for search_dir in "$@"; do
   if [ ! -d "$search_dir" ]; then
@@ -399,9 +404,20 @@ for search_dir in "$@"; do
     | xargs -0 -P "$JOBS" -n 50 bash -c 'process_files "$@"' _
 done
 
-# --- Aggregate parallel results ---
-if ls "$FRAGMENTS_DIR"/frag.* >/dev/null 2>&1; then
-  cat "$FRAGMENTS_DIR"/frag.* >> "$PATCH_FILE"
+# --- Aggregate per-worker fragments ---
+# Each worker wrote its own per-PID files, so concatenation order is the only
+# thing left to decide here; every stream is line-oriented and order-insensitive.
+if ls "$FRAGMENTS_DIR"/patch.* >/dev/null 2>&1; then
+  cat "$FRAGMENTS_DIR"/patch.* >> "$PATCH_FILE"
+fi
+if ls "$FRAGMENTS_DIR"/processed.* >/dev/null 2>&1; then
+  cat "$FRAGMENTS_DIR"/processed.* > "$PROCESSED_FILE"
+fi
+if ls "$FRAGMENTS_DIR"/errors.* >/dev/null 2>&1; then
+  cat "$FRAGMENTS_DIR"/errors.* > "$WORKER_ERRORS_FILE"
+fi
+if ls "$FRAGMENTS_DIR"/changed.* >/dev/null 2>&1; then
+  cat "$FRAGMENTS_DIR"/changed.* > "$CHANGED_JSON_FILE"
 fi
 total_files=$(wc -l < "$PROCESSED_FILE" 2>/dev/null | tr -d '[:space:]')
 [ -z "$total_files" ] && total_files=0

--- a/packages/realm-server/scripts/migrate-realm-references.sh
+++ b/packages/realm-server/scripts/migrate-realm-references.sh
@@ -263,6 +263,10 @@ mkdir -p "$FRAGMENTS_DIR"
 CHANGED_JSON_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-changed-json.$$")
 PROCESSED_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-processed.$$")
 WORKER_ERRORS_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-werr.$$")
+# Per-directory scratch holding the .json paths fed to the pre-edit validator,
+# one per line. Streamed via a file (not argv) so a directory with enough
+# matching files never exceeds ARG_MAX. Rebuilt each directory iteration.
+JSON_CANDIDATES_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-json-candidates.$$")
 > "$CHANGED_JSON_FILE"
 > "$PROCESSED_FILE"
 > "$WORKER_ERRORS_FILE"
@@ -338,18 +342,24 @@ for search_dir in "$@"; do
 
   # Record which matching .json files parse cleanly BEFORE editing, so the
   # post-run verification can distinguish "the replacement broke this" from
-  # "this was already non-strict". One batched node pass per directory.
+  # "this was already non-strict". The candidate list is streamed through a
+  # file (not node argv) so a directory with thousands of matches can't exceed
+  # ARG_MAX, and the validator's exit status is checked: if pre-validation
+  # fails we skip editing this directory rather than proceed with an
+  # incomplete valid-before set (which would let a real corruption pass the
+  # after-check unflagged).
   if [ "$DRY_RUN" = false ]; then
-    json_candidates=()
+    > "$JSON_CANDIDATES_FILE"
     for f in "${matching_files[@]}"; do
       case "$f" in
-        *.json) json_candidates+=("$f") ;;
+        *.json) printf '%s\n' "$f" >> "$JSON_CANDIDATES_FILE" ;;
       esac
     done
-    if [ ${#json_candidates[@]} -gt 0 ]; then
-      node -e '
+    if [ -s "$JSON_CANDIDATES_FILE" ]; then
+      if ! node -e '
         const fs = require("fs");
-        for (const f of process.argv.slice(1)) {
+        const files = fs.readFileSync(process.argv[1], "utf8").split("\n").filter(Boolean);
+        for (const f of files) {
           try {
             JSON.parse(fs.readFileSync(f, "utf8"));
             console.log(f);
@@ -357,7 +367,12 @@ for search_dir in "$@"; do
             /* already non-strict; omit so it is not held to the after-check */
           }
         }
-      ' "${json_candidates[@]}" >> "$VALID_BEFORE_FILE"
+      ' "$JSON_CANDIDATES_FILE" >> "$VALID_BEFORE_FILE"; then
+        err="Pre-migration JSON validation failed for $search_dir; skipping its edits to avoid masking corruption"
+        echo "  $err" >&2
+        ERRORS+=("$err")
+        continue
+      fi
     fi
   fi
 
@@ -436,7 +451,7 @@ if [ "$DRY_RUN" = false ] && [ "$changed_json_count" -gt 0 ]; then
   fi
 fi
 
-rm -f "$VALID_BEFORE_FILE" "$CHANGED_JSON_FILE" "$PROCESSED_FILE" "$WORKER_ERRORS_FILE"
+rm -f "$VALID_BEFORE_FILE" "$CHANGED_JSON_FILE" "$PROCESSED_FILE" "$WORKER_ERRORS_FILE" "$JSON_CANDIDATES_FILE"
 rm -rf "$FRAGMENTS_DIR"
 
 if [ ${#ERRORS[@]} -gt 0 ]; then

--- a/packages/realm-server/scripts/migrate-realm-references.sh
+++ b/packages/realm-server/scripts/migrate-realm-references.sh
@@ -237,6 +237,14 @@ PATCH_FILE="${PATCH_NAME}.patch"
 total_files=0
 > "$PATCH_FILE"
 
+# Paths of .json files that were valid JSON *before* editing. The post-run
+# verification only flags a file if it was valid before and is invalid after
+# (i.e. the replacement broke it) — files that were already non-strict (e.g.
+# trailing commas, unescaped embedded source) are tolerated by the realm
+# server's parser and must not fail the migration.
+VALID_BEFORE_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-valid-before.$$")
+> "$VALID_BEFORE_FILE"
+
 for search_dir in "$@"; do
   if [ ! -d "$search_dir" ]; then
     echo "Warning: directory '$search_dir' does not exist, skipping."
@@ -262,6 +270,31 @@ for search_dir in "$@"; do
   if [ ${#matching_files[@]} -eq 0 ]; then
     echo "  No matching references found"
     continue
+  fi
+
+  # Record which matching .json files parse cleanly BEFORE editing, so the
+  # post-run verification can distinguish "the replacement broke this" from
+  # "this was already non-strict". One batched node pass per directory.
+  if [ "$DRY_RUN" = false ]; then
+    json_candidates=()
+    for f in "${matching_files[@]}"; do
+      case "$f" in
+        *.json) json_candidates+=("$f") ;;
+      esac
+    done
+    if [ ${#json_candidates[@]} -gt 0 ]; then
+      node -e '
+        const fs = require("fs");
+        for (const f of process.argv.slice(1)) {
+          try {
+            JSON.parse(fs.readFileSync(f, "utf8"));
+            console.log(f);
+          } catch (e) {
+            /* already non-strict; omit so it is not held to the after-check */
+          }
+        }
+      ' "${json_candidates[@]}" >> "$VALID_BEFORE_FILE"
+    fi
   fi
 
   # Build sed args once. For URLs, also handle path-only preceded by " or '
@@ -323,30 +356,48 @@ else
   echo "  To undo: patch -R -p0 < $PATCH_FILE"
 fi
 
-# Verify every changed JSON file still parses, so a bad replacement can't
-# silently corrupt a card document. Failures are reported and force a
-# non-zero exit; roll back with the patch above.
+# Verify the replacement didn't turn any *previously valid* JSON invalid.
+# Files that were already non-strict before editing (captured in
+# VALID_BEFORE_FILE) are tolerated by the realm server's lenient parser, so
+# they're reported as a note but don't fail the run — only a genuine
+# valid -> invalid regression forces a non-zero exit.
 if [ "$DRY_RUN" = false ] && [ ${#CHANGED_JSON[@]} -gt 0 ]; then
   echo ""
-  echo "Verifying ${#CHANGED_JSON[@]} changed JSON file(s) still parse ..."
+  echo "Verifying ${#CHANGED_JSON[@]} changed JSON file(s) ..."
   if ! node -e '
     const fs = require("fs");
-    let bad = 0;
-    for (const f of process.argv.slice(1)) {
+    const validBefore = new Set(
+      fs.readFileSync(process.argv[1], "utf8").split("\n").filter(Boolean)
+    );
+    let broke = 0;
+    let preexisting = 0;
+    for (const f of process.argv.slice(2)) {
       try {
         JSON.parse(fs.readFileSync(f, "utf8"));
       } catch (e) {
-        console.error("  Invalid JSON after migration: " + f + ": " + e.message);
-        bad++;
+        if (validBefore.has(f)) {
+          console.error("  Migration broke valid JSON: " + f + ": " + e.message);
+          broke++;
+        } else {
+          preexisting++;
+        }
       }
     }
-    process.exit(bad > 0 ? 1 : 0);
-  ' "${CHANGED_JSON[@]}"; then
-    ERRORS+=("JSON validation failed for one or more migrated files (see above). Roll back with: patch -R -p0 < $PATCH_FILE")
+    if (preexisting > 0) {
+      console.error(
+        "  Note: " + preexisting +
+        " changed file(s) were already non-strict JSON before the migration (not flagged)."
+      );
+    }
+    process.exit(broke > 0 ? 1 : 0);
+  ' "$VALID_BEFORE_FILE" "${CHANGED_JSON[@]}"; then
+    ERRORS+=("Migration turned previously-valid JSON invalid in one or more files (see above). Roll back with: patch -R -p0 < $PATCH_FILE")
   else
-    echo "  All migrated JSON files parse cleanly."
+    echo "  No previously-valid JSON was broken."
   fi
 fi
+
+rm -f "$VALID_BEFORE_FILE"
 
 if [ ${#ERRORS[@]} -gt 0 ]; then
   echo ""

--- a/packages/realm-server/scripts/migrate-realm-references.sh
+++ b/packages/realm-server/scripts/migrate-realm-references.sh
@@ -89,6 +89,20 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     -j|--jobs)
+      if [ $# -lt 2 ]; then
+        echo "Error: $1 requires a value (a positive integer)" >&2
+        exit 1
+      fi
+      case "$2" in
+        ''|*[!0-9]*)
+          echo "Error: $1 must be a positive integer (got '$2')" >&2
+          exit 1
+          ;;
+      esac
+      if [ "$2" -lt 1 ]; then
+        echo "Error: $1 must be at least 1 (got '$2')" >&2
+        exit 1
+      fi
       JOBS="$2"
       shift 2
       ;;

--- a/packages/realm-server/scripts/migrate-realm-references.sh
+++ b/packages/realm-server/scripts/migrate-realm-references.sh
@@ -182,6 +182,7 @@ else
   echo "  --json-only        Only scan card JSON (skip .gts/.ts modules)"
   echo "  --modules-only     Only scan .gts/.ts modules (skip card JSON)"
   echo "  --exclude <dir>    Skip directories matching <dir> (repeatable)"
+  echo "  -j, --jobs <n>     Number of parallel workers (default 16)"
   echo ""
   echo "  Environment URL mappings:"
   echo "    development  -> http://localhost:4201/"

--- a/packages/realm-server/scripts/migrate-realm-references.sh
+++ b/packages/realm-server/scripts/migrate-realm-references.sh
@@ -25,6 +25,9 @@
 #   --exclude <dir>     Skip directories matching <dir> (by name, any depth).
 #                       Repeatable. e.g. --exclude decommissioned to leave
 #                       moved-aside or backup trees untouched.
+#   -j, --jobs <n>      Number of parallel workers (default 16). Files are
+#                       edited concurrently to hide per-file I/O latency on
+#                       networked filesystems (e.g. EFS).
 #
 # Shortcut flags:
 #   -e, --environment   development | staging | production
@@ -73,10 +76,10 @@ set -uo pipefail
 DRY_RUN=false
 JSON_ONLY=false
 MODULES_ONLY=false
+JOBS=16
 ENV=""
 REALM=""
 ERRORS=()
-CHANGED_JSON=()
 EXCLUDE_DIRS=()
 
 while [ $# -gt 0 ]; do
@@ -84,6 +87,10 @@ while [ $# -gt 0 ]; do
     --dry-run)
       DRY_RUN=true
       shift
+      ;;
+    -j|--jobs)
+      JOBS="$2"
+      shift 2
       ;;
     --json-only)
       JSON_ONLY=true
@@ -245,6 +252,63 @@ total_files=0
 VALID_BEFORE_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-valid-before.$$")
 > "$VALID_BEFORE_FILE"
 
+# --- Parallel processing scratch ---
+# Files are processed concurrently (xargs -P) because the per-file work is
+# I/O-latency-bound on networked filesystems (EFS). Each worker writes its own
+# patch fragment (concurrent appends to one shared patch file would interleave
+# and corrupt it) and appends results to shared list files; everything is
+# aggregated after the directory loop.
+FRAGMENTS_DIR=$(mktemp -d 2>/dev/null || echo "/tmp/migrate-frags.$$")
+mkdir -p "$FRAGMENTS_DIR"
+CHANGED_JSON_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-changed-json.$$")
+PROCESSED_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-processed.$$")
+WORKER_ERRORS_FILE=$(mktemp 2>/dev/null || echo "/tmp/migrate-werr.$$")
+> "$CHANGED_JSON_FILE"
+> "$PROCESSED_FILE"
+> "$WORKER_ERRORS_FILE"
+
+# Worker: process a batch of files passed as positional args. Reconstructs the
+# sed program from exported scalars (arrays can't be exported across xargs).
+# Runs in its own `bash -c`, so results go to the shared files above.
+process_files() {
+  local frag="$FRAGMENTS_DIR/frag.$$"
+  local file tmp
+  for file in "$@"; do
+    tmp="$file.tmp.$$"
+    if [ "$IS_URL" = true ]; then
+      if ! sed -e "s|${FIND_STR}|${REPLACEMENT}|g" \
+               -e "s|\"${REALM_PATH}|\"${REPLACEMENT}|g" \
+               -e "s|'${REALM_PATH}|'${REPLACEMENT}|g" \
+               "$file" > "$tmp" 2>/dev/null; then
+        printf '%s\n' "Error processing $file" >> "$WORKER_ERRORS_FILE"
+        rm -f "$tmp"
+        continue
+      fi
+    else
+      if ! sed -e "s|${FIND_STR}|${REPLACEMENT}|g" "$file" > "$tmp" 2>/dev/null; then
+        printf '%s\n' "Error processing $file" >> "$WORKER_ERRORS_FILE"
+        rm -f "$tmp"
+        continue
+      fi
+    fi
+    diff -u --label "$file" --label "$file" "$file" "$tmp" >> "$frag" 2>/dev/null || true
+    printf '%s\n' "$file" >> "$PROCESSED_FILE"
+    if [ "$DRY_RUN" = true ]; then
+      rm -f "$tmp"
+    elif mv "$tmp" "$file" 2>/dev/null; then
+      case "$file" in
+        *.json) printf '%s\n' "$file" >> "$CHANGED_JSON_FILE" ;;
+      esac
+    else
+      printf '%s\n' "Error replacing $file" >> "$WORKER_ERRORS_FILE"
+      rm -f "$tmp"
+    fi
+  done
+}
+export -f process_files
+export FIND_STR REPLACEMENT IS_URL REALM_PATH DRY_RUN
+export FRAGMENTS_DIR CHANGED_JSON_FILE PROCESSED_FILE WORKER_ERRORS_FILE
+
 for search_dir in "$@"; do
   if [ ! -d "$search_dir" ]; then
     echo "Warning: directory '$search_dir' does not exist, skipping."
@@ -297,53 +361,24 @@ for search_dir in "$@"; do
     fi
   fi
 
-  # Build sed args once. For URLs, also handle path-only preceded by " or '
-  DQ='"'
-  if [ "$IS_URL" = true ]; then
-    SED_ARGS=(-e "s|${FIND_STR}|${REPLACEMENT}|g"
-              -e "s|${DQ}${REALM_PATH}|${DQ}${REPLACEMENT}|g"
-              -e "s|'${REALM_PATH}|'${REPLACEMENT}|g")
-  else
-    SED_ARGS=(-e "s|${FIND_STR}|${REPLACEMENT}|g")
-  fi
+  echo "  ${#matching_files[@]} file(s) to process (jobs=$JOBS) ..."
 
-  for file in "${matching_files[@]}"; do
-    if ! sed "${SED_ARGS[@]}" "$file" > "$file.tmp" 2>/tmp/migrate-err.$$; then
-      err="Error processing $file: $(cat /tmp/migrate-err.$$)"
-      echo "  $err"
-      ERRORS+=("$err")
-      rm -f "$file.tmp" /tmp/migrate-err.$$
-      continue
-    fi
-    rm -f /tmp/migrate-err.$$
-
-    # Append unified diff to the patch file (use --label so both sides show the real path)
-    { diff -u --label "$file" --label "$file" "$file" "$file.tmp" || true; } >> "$PATCH_FILE"
-
-    if [ "$DRY_RUN" = true ]; then
-      echo ""
-      echo "  Would update: $file"
-      { diff --unified=0 "$file" "$file.tmp" || true; } | tail -n +3 | grep '^[+-]' | while IFS= read -r line; do
-        echo "    $line"
-      done
-      rm -f "$file.tmp"
-    else
-      if ! mv "$file.tmp" "$file" 2>/tmp/migrate-err.$$; then
-        err="Error replacing $file: $(cat /tmp/migrate-err.$$)"
-        echo "  $err"
-        ERRORS+=("$err")
-        rm -f "$file.tmp" /tmp/migrate-err.$$
-        continue
-      fi
-      rm -f /tmp/migrate-err.$$
-      echo "  Updated: $file"
-      case "$file" in
-        *.json) CHANGED_JSON+=("$file") ;;
-      esac
-    fi
-    total_files=$((total_files + 1))
-  done
+  # Process this directory's matching files concurrently. NUL-delimited so any
+  # path (spaces/newlines) is safe; -n batches files per worker to amortize the
+  # bash fork; -P runs JOBS workers at once to hide per-file EFS latency.
+  printf '%s\0' "${matching_files[@]}" \
+    | xargs -0 -P "$JOBS" -n 50 bash -c 'process_files "$@"' _
 done
+
+# --- Aggregate parallel results ---
+if ls "$FRAGMENTS_DIR"/frag.* >/dev/null 2>&1; then
+  cat "$FRAGMENTS_DIR"/frag.* >> "$PATCH_FILE"
+fi
+total_files=$(wc -l < "$PROCESSED_FILE" 2>/dev/null | tr -d '[:space:]')
+[ -z "$total_files" ] && total_files=0
+while IFS= read -r werr; do
+  [ -n "$werr" ] && ERRORS+=("$werr")
+done < "$WORKER_ERRORS_FILE"
 
 echo ""
 if [ "$DRY_RUN" = true ]; then
@@ -361,17 +396,21 @@ fi
 # VALID_BEFORE_FILE) are tolerated by the realm server's lenient parser, so
 # they're reported as a note but don't fail the run — only a genuine
 # valid -> invalid regression forces a non-zero exit.
-if [ "$DRY_RUN" = false ] && [ ${#CHANGED_JSON[@]} -gt 0 ]; then
+changed_json_count=$(wc -l < "$CHANGED_JSON_FILE" 2>/dev/null | tr -d '[:space:]')
+[ -z "$changed_json_count" ] && changed_json_count=0
+if [ "$DRY_RUN" = false ] && [ "$changed_json_count" -gt 0 ]; then
   echo ""
-  echo "Verifying ${#CHANGED_JSON[@]} changed JSON file(s) ..."
+  echo "Verifying $changed_json_count changed JSON file(s) ..."
+  # Both path lists are read from files (not argv) so this scales past ARG_MAX.
   if ! node -e '
     const fs = require("fs");
     const validBefore = new Set(
       fs.readFileSync(process.argv[1], "utf8").split("\n").filter(Boolean)
     );
+    const changed = fs.readFileSync(process.argv[2], "utf8").split("\n").filter(Boolean);
     let broke = 0;
     let preexisting = 0;
-    for (const f of process.argv.slice(2)) {
+    for (const f of changed) {
       try {
         JSON.parse(fs.readFileSync(f, "utf8"));
       } catch (e) {
@@ -390,14 +429,15 @@ if [ "$DRY_RUN" = false ] && [ ${#CHANGED_JSON[@]} -gt 0 ]; then
       );
     }
     process.exit(broke > 0 ? 1 : 0);
-  ' "$VALID_BEFORE_FILE" "${CHANGED_JSON[@]}"; then
+  ' "$VALID_BEFORE_FILE" "$CHANGED_JSON_FILE"; then
     ERRORS+=("Migration turned previously-valid JSON invalid in one or more files (see above). Roll back with: patch -R -p0 < $PATCH_FILE")
   else
     echo "  No previously-valid JSON was broken."
   fi
 fi
 
-rm -f "$VALID_BEFORE_FILE"
+rm -f "$VALID_BEFORE_FILE" "$CHANGED_JSON_FILE" "$PROCESSED_FILE" "$WORKER_ERRORS_FILE"
+rm -rf "$FRAGMENTS_DIR"
 
 if [ ${#ERRORS[@]} -gt 0 ]; then
   echo ""


### PR DESCRIPTION
When running it in staging, I got a warning about some files not being valid JSON after migration. But the files already were invalid JSON! This parses before and after to make sure nothing _became_ invalid.

This also adds a `--jobs` flag to migrate more than one file at once, since it took quite a while to run, and the above new step will slow it down further.