### PR TITLE
Add `searchable` field option: API + FieldDefinition cache + definition-build validation

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -317,12 +317,15 @@ export type ByteStream = ReadableStream<Uint8Array> | Uint8Array;
 
 // Declares which links a field makes searchable — i.e. which linked cards are
 // pulled into the search doc rather than left as a bare `{ id }` reference.
-// Contained fields are always included regardless, so `searchable` never
-// applies to them. `true` makes the immediate ("self") link searchable; a
-// dotted path makes a deeper (n+1) link searchable, routed from this field's
-// target through its own links (intermediate contained fields named as
-// segments); an array combines multiple routes. Omitted leaves the link as
-// `{ id }` only.
+// `searchable` only ever governs links: a contained value is always included
+// once its owner is in the doc, so `searchable` never decides whether a
+// contained field appears. `true` makes the immediate ("self") link
+// searchable; a dotted path makes a deeper (n+1) link searchable, routed from
+// this field's target through its links — naming intermediate contained
+// fields as segments to reach a link beneath them; an array combines routes.
+// Omitted leaves the link as `{ id }` only. On a `contains`/`containsMany`
+// field (whose value is always present) a path is therefore only meaningful to
+// make a link reached *through* that contained value searchable.
 export type Searchable = true | string | string[];
 
 interface Options {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -315,6 +315,16 @@ export type SerializedFile<Extra extends object = {}> = {
 
 export type ByteStream = ReadableStream<Uint8Array> | Uint8Array;
 
+// Declares which links a field makes searchable — i.e. which linked cards are
+// pulled into the search doc rather than left as a bare `{ id }` reference.
+// Contained fields are always included regardless, so `searchable` never
+// applies to them. `true` makes the immediate ("self") link searchable; a
+// dotted path makes a deeper (n+1) link searchable, routed from this field's
+// target through its own links (intermediate contained fields named as
+// segments); an array combines multiple routes. Omitted leaves the link as
+// `{ id }` only.
+export type Searchable = true | string | string[];
+
 interface Options {
   computeVia?: () => unknown;
   description?: string;
@@ -324,6 +334,8 @@ interface Options {
   // in which case we need to tell the runtime that a card is
   // explicitly being used.
   isUsed?: true;
+  // Names which links this field makes searchable. See `Searchable`.
+  searchable?: Searchable;
   // Optional: per-usage configuration provider merged with FieldDef-level configuration
   configuration?: ConfigurationInput<any>;
 }
@@ -365,6 +377,7 @@ export interface FieldConstructor<T> {
   declaredCardThunk?: () => T;
   isUsed?: true;
   isPolymorphic?: true;
+  searchable?: Searchable;
   name: string;
   queryDefinition?: QueryWithInterpolations;
 }
@@ -566,6 +579,11 @@ export interface Field<
   // explicitly being used.
   isUsed?: true;
   isPolymorphic?: true;
+  // The links this field makes searchable. This descriptor is the source of
+  // truth; `getFieldDefinitions` mirrors it (raw) into the cached
+  // `FieldDefinition` for the loaderless query compiler and definition-build
+  // validation. See `Searchable`.
+  searchable?: Searchable;
   serialize(
     value: any,
     doc: JSONAPISingleResourceDocument,
@@ -639,6 +657,7 @@ class ContainsMany<FieldT extends FieldDefConstructor> implements Field<
   readonly description: string | undefined;
   readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
+  readonly searchable: Searchable | undefined;
   configuration: ConfigurationInput<any> | undefined;
   constructor({
     cardThunk,
@@ -646,12 +665,14 @@ class ContainsMany<FieldT extends FieldDefConstructor> implements Field<
     name,
     isUsed,
     isPolymorphic,
+    searchable,
   }: FieldConstructor<FieldT>) {
     this.cardThunk = cardThunk;
     this.computeVia = computeVia;
     this.name = name;
     this.isUsed = isUsed;
     this.isPolymorphic = isPolymorphic;
+    this.searchable = searchable;
   }
 
   get card(): FieldT {
@@ -966,6 +987,7 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
   readonly description: string | undefined;
   readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
+  readonly searchable: Searchable | undefined;
   configuration: ConfigurationInput<any> | undefined;
   constructor({
     cardThunk,
@@ -973,12 +995,14 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
     name,
     isUsed,
     isPolymorphic,
+    searchable,
   }: FieldConstructor<CardT>) {
     this.cardThunk = cardThunk;
     this.computeVia = computeVia;
     this.name = name;
     this.isUsed = isUsed;
     this.isPolymorphic = isPolymorphic;
+    this.searchable = searchable;
   }
 
   get card(): CardT {
@@ -1194,6 +1218,7 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
   readonly description: string | undefined;
   readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
+  readonly searchable: Searchable | undefined;
   readonly configuration?: ConfigurationInput<any>;
   readonly queryDefinition?: QueryWithInterpolations;
   constructor({
@@ -1203,6 +1228,7 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
     name,
     isUsed,
     isPolymorphic,
+    searchable,
     queryDefinition,
   }: FieldConstructor<CardT>) {
     this.cardThunk = cardThunk;
@@ -1211,6 +1237,7 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
     this.name = name;
     this.isUsed = isUsed;
     this.isPolymorphic = isPolymorphic;
+    this.searchable = searchable;
     this.queryDefinition = queryDefinition;
   }
 
@@ -1630,6 +1657,7 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
   readonly name: string;
   readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
+  readonly searchable: Searchable | undefined;
   readonly configuration?: ConfigurationInput<any>;
   readonly queryDefinition?: QueryWithInterpolations;
   constructor({
@@ -1639,6 +1667,7 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
     name,
     isUsed,
     isPolymorphic,
+    searchable,
     queryDefinition,
   }: FieldConstructor<FieldT>) {
     this.cardThunk = cardThunk;
@@ -1647,6 +1676,7 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
     this.name = name;
     this.isUsed = isUsed;
     this.isPolymorphic = isPolymorphic;
+    this.searchable = searchable;
     this.queryDefinition = queryDefinition;
   }
 
@@ -2292,12 +2322,13 @@ export function containsMany<FieldT extends FieldDefConstructor>(
 ): BaseInstanceType<FieldT>[] {
   return {
     setupField(fieldName: string, _ownerPrototype: BaseDef) {
-      let { computeVia, isUsed } = options ?? {};
+      let { computeVia, isUsed, searchable } = options ?? {};
       let instance = new ContainsMany({
         cardThunk: cardThunk(field),
         computeVia,
         name: fieldName,
         isUsed,
+        searchable,
       });
       (instance as any).configuration = options?.configuration;
       return makeDescriptor(instance);
@@ -2312,12 +2343,13 @@ export function contains<FieldT extends FieldDefConstructor>(
 ): BaseInstanceType<FieldT> {
   return {
     setupField(fieldName: string, _ownerPrototype: BaseDef) {
-      let { computeVia, isUsed } = options ?? {};
+      let { computeVia, isUsed, searchable } = options ?? {};
       let instance = new Contains({
         cardThunk: cardThunk(field),
         computeVia,
         name: fieldName,
         isUsed,
+        searchable,
       });
       (instance as any).configuration = options?.configuration;
       return makeDescriptor(instance);
@@ -2332,7 +2364,7 @@ export function linksTo<CardT extends LinkableDefConstructor>(
 ): BaseInstanceType<CardT> {
   return {
     setupField(fieldName: string, ownerPrototype: BaseDef) {
-      let { computeVia, isUsed, query } = options ?? {};
+      let { computeVia, isUsed, searchable, query } = options ?? {};
       let fieldCardThunk = cardThunk(cardOrThunk);
       if (query) {
         validateRelationshipQuery(ownerPrototype, fieldName, query);
@@ -2343,6 +2375,7 @@ export function linksTo<CardT extends LinkableDefConstructor>(
         computeVia,
         name: fieldName,
         isUsed,
+        searchable,
         queryDefinition: query,
       });
       (instance as any).configuration = options?.configuration;
@@ -2358,7 +2391,7 @@ export function linksToMany<CardT extends LinkableDefConstructor>(
 ): BaseInstanceType<CardT>[] {
   return {
     setupField(fieldName: string, ownerPrototype: BaseDef) {
-      let { computeVia, isUsed, query } = options ?? {};
+      let { computeVia, isUsed, searchable, query } = options ?? {};
       let fieldCardThunk = cardThunk(cardOrThunk);
       if (query) {
         validateRelationshipQuery(ownerPrototype, fieldName, query);
@@ -2369,6 +2402,7 @@ export function linksToMany<CardT extends LinkableDefConstructor>(
         computeVia,
         name: fieldName,
         isUsed,
+        searchable,
         queryDefinition: query,
       });
       (instance as any).configuration = options?.configuration;

--- a/packages/host/app/routes/module.ts
+++ b/packages/host/app/routes/module.ts
@@ -16,6 +16,8 @@ import {
   type ResolvedCodeRef,
   type ErrorEntry,
   type ModuleDefinitionResult,
+  type PrerenderResponseMeta,
+  type SearchablePathDiagnostic,
   isBaseDef,
   baseCardRef,
   baseRealm,
@@ -30,6 +32,7 @@ import {
   parseRenderRouteOptions,
   SupportedMimeType,
   getFieldDefinitions,
+  validateSearchablePaths,
   CardError,
   unixTime,
   type RealmResourceIdentifier,
@@ -69,6 +72,11 @@ export type Model = {
     [name: string]: ModuleDefinitionResult | ErrorEntry;
   };
   error?: ErrorEntry;
+  // Definition-build diagnostics (currently the `searchable`-path validation
+  // findings) ride here so they JSON-round-trip into the `ModuleRenderResponse`
+  // and persist to `modules.diagnostics` via `flattenPrerenderMeta`. Absent
+  // when there's nothing to report.
+  meta?: PrerenderResponseMeta;
 };
 
 interface CardType {
@@ -331,6 +339,11 @@ export async function buildModuleModel(
         }
       }
 
+      let searchablePathIssues = await validateModuleSearchablePaths(
+        definitions,
+        context,
+      );
+
       return {
         id,
         nonce,
@@ -340,6 +353,9 @@ export async function buildModuleModel(
         createdAt,
         isShimmed,
         definitions,
+        ...(searchablePathIssues.length > 0
+          ? { meta: { diagnostics: { searchablePathIssues } } }
+          : {}),
       };
     });
   } catch (err: any) {
@@ -354,6 +370,65 @@ export async function buildModuleModel(
     }
     throw err;
   }
+}
+
+// Validate the `searchable` annotations on every definition this module built,
+// resolving each dotted path against the definition graph. Findings are
+// recorded (never thrown) onto `meta.diagnostics` so an un-routable path
+// surfaces in `modules.diagnostics` rather than silently making nothing
+// searchable. Inert until a field actually declares `searchable`: with none
+// present `validateSearchablePaths` walks the fields, finds nothing to resolve,
+// and never touches the loader. The whole pass is best-effort — any failure is
+// logged and yields no findings rather than breaking the definition build.
+async function validateModuleSearchablePaths(
+  definitions: { [name: string]: ModuleDefinitionResult | ErrorEntry },
+  context: ModuleModelContext,
+): Promise<SearchablePathDiagnostic[]> {
+  let issues: SearchablePathDiagnostic[] = [];
+  try {
+    let loader = context.loaderService.loader;
+    let api = await loader.import<typeof CardAPI>(`${baseRealm.url}card-api`);
+    let lookupDefinition = async (
+      codeRef: CodeRef,
+    ): Promise<Definition | undefined> => {
+      try {
+        let card = await loadCardDef(codeRef, { loader });
+        let { fields, fieldDefs } = getFieldDefinitions(api, card);
+        return {
+          codeRef,
+          fields,
+          fieldDefs,
+          type: isCardDef(card) ? 'card-def' : 'field-def',
+          displayName: isCardDef(card) ? card.displayName : null,
+        };
+      } catch (err: any) {
+        console.warn(
+          `searchable validation: could not resolve definition ${JSON.stringify(
+            codeRef,
+          )}: ${err.message}`,
+        );
+        return undefined;
+      }
+    };
+    for (let [codeRef, entry] of Object.entries(definitions)) {
+      if (entry.type !== 'definition') {
+        continue;
+      }
+      let found = await validateSearchablePaths(
+        entry.definition,
+        lookupDefinition,
+      );
+      for (let { fieldName, path } of found) {
+        console.warn(
+          `searchable validation: unresolvable path "${path}" on field "${fieldName}" of ${codeRef}`,
+        );
+        issues.push({ codeRef, fieldName, path });
+      }
+    }
+  } catch (err: any) {
+    console.warn(`searchable validation: unexpected failure: ${err.message}`);
+  }
+  return issues;
 }
 
 async function makeDefinition(

--- a/packages/host/app/routes/module.ts
+++ b/packages/host/app/routes/module.ts
@@ -376,15 +376,25 @@ export async function buildModuleModel(
 // resolving each dotted path against the definition graph. Findings are
 // recorded (never thrown) onto `meta.diagnostics` so an un-routable path
 // surfaces in `modules.diagnostics` rather than silently making nothing
-// searchable. Inert until a field actually declares `searchable`: with none
-// present `validateSearchablePaths` walks the fields, finds nothing to resolve,
-// and never touches the loader. The whole pass is best-effort — any failure is
-// logged and yields no findings rather than breaking the definition build.
+// searchable. Inert until a field actually declares `searchable`: when no
+// built definition carries one we return before importing card-api or touching
+// the loader at all. The whole pass is best-effort — any failure is logged and
+// yields no findings rather than breaking the definition build.
 async function validateModuleSearchablePaths(
   definitions: { [name: string]: ModuleDefinitionResult | ErrorEntry },
   context: ModuleModelContext,
 ): Promise<SearchablePathDiagnostic[]> {
   let issues: SearchablePathDiagnostic[] = [];
+  let hasAnnotation = Object.values(definitions).some(
+    (entry) =>
+      entry.type === 'definition' &&
+      Object.values(entry.definition.fieldDefs).some(
+        (fieldDef) => fieldDef.searchable != null,
+      ),
+  );
+  if (!hasAnnotation) {
+    return issues;
+  }
   try {
     let loader = context.loaderService.loader;
     let api = await loader.import<typeof CardAPI>(`${baseRealm.url}card-api`);

--- a/packages/host/tests/acceptance/prerender-module-test.gts
+++ b/packages/host/tests/acceptance/prerender-module-test.gts
@@ -76,6 +76,24 @@ module('Acceptance | prerender | module', function (hooks) {
     }
   `;
   const BROKEN_MODULE = `export const Broken = ;`;
+  // One resolvable `searchable` path (author → name) and one unresolvable one
+  // (reviewer → bogus). Definition-build validation records only the bad path
+  // on `meta.diagnostics.searchablePathIssues`, tagged with its owning def.
+  const SEARCHABLE_MODULE = `
+    import { CardDef, field, contains, linksTo, StringField } from 'https://cardstack.com/base/card-api';
+
+    export class SearchAuthor extends CardDef {
+      static displayName = 'SearchAuthor';
+      @field name = contains(StringField);
+    }
+
+    export class SearchArticle extends CardDef {
+      static displayName = 'SearchArticle';
+      @field title = contains(StringField);
+      @field author = linksTo(() => SearchAuthor, { searchable: 'name' });
+      @field reviewer = linksTo(() => SearchAuthor, { searchable: 'bogus' });
+    }
+  `;
 
   hooks.beforeEach(async function () {
     ({ adapter, realm } = await withCachedRealmSetup(async () =>
@@ -87,6 +105,7 @@ module('Acceptance | prerender | module', function (hooks) {
           'parent.gts': PARENT_MODULE,
           'child.gts': CHILD_MODULE,
           'broken.gts': BROKEN_MODULE,
+          'searchable-card.gts': SEARCHABLE_MODULE,
         },
       }),
     ));
@@ -358,6 +377,33 @@ module('Acceptance | prerender | module', function (hooks) {
         : undefined,
       'Updated Person',
       'updated display name observed after clearCache flag',
+    );
+  });
+
+  test('records unresolvable searchable paths on meta.diagnostics, tagged with the owning def', async function (assert) {
+    let moduleURL = `${testRealmURL}searchable-card.gts`;
+
+    await visit(modulePath(moduleURL));
+    let { status, model } = captureModuleResult();
+    assert.strictEqual(status, 'ready', 'module loads');
+
+    let articleKey = `${trimExecutableExtension(rri(moduleURL))}/SearchArticle`;
+    assert.deepEqual(
+      model.meta?.diagnostics?.searchablePathIssues,
+      [{ codeRef: articleKey, fieldName: 'reviewer', path: 'bogus' }],
+      'only the unresolvable path is recorded, tagged with its owning def — the resolvable author→name path is not',
+    );
+  });
+
+  test('a module with no searchable annotations produces no diagnostics meta (inert)', async function (assert) {
+    let moduleURL = `${testRealmURL}person.gts`;
+
+    await visit(modulePath(moduleURL));
+    let { model } = captureModuleResult();
+    assert.strictEqual(
+      model.meta?.diagnostics?.searchablePathIssues,
+      undefined,
+      'no searchablePathIssues meta when nothing is annotated',
     );
   });
 });

--- a/packages/host/tests/unit/searchable-option-test.ts
+++ b/packages/host/tests/unit/searchable-option-test.ts
@@ -9,6 +9,7 @@ import {
   internalKeyFor,
   identifyCard,
   getFieldDefinitions,
+  getFieldDef,
   validateSearchablePaths,
   type CodeRef,
   type Definition,
@@ -38,6 +39,8 @@ module('Unit | searchable option', function (hooks) {
     Author: typeof CardDef;
     Address: typeof CardDef;
     Employer: typeof CardDef;
+    Citation: typeof CardDef;
+    Journal: typeof CardDef;
     Country: typeof CardDef;
   };
   let virtualNetwork: VirtualNetwork;
@@ -118,6 +121,26 @@ module('Unit | searchable option', function (hooks) {
         searchable: ['address.city', 'nope'],
       });
     }
+    // A FieldDef that itself declares a link, so a `searchable` path can route
+    // *through* a contained value to reach a deeper link (the §4 citations
+    // case). FieldDefs may declare linksTo — see e.g. base/skill-reference.
+    class Citation extends FieldDef {
+      @field label = contains(StringField);
+      @field article = linksTo(() => Author);
+    }
+    // Exercises contains/containsMany routing through a contained FieldDef's
+    // link. `Journal` yields exactly one issue (badCitations) so the count is
+    // an assertable signal.
+    class Journal extends CardDef {
+      @field title = contains(StringField);
+      @field citations = containsMany(Citation, {
+        searchable: 'article.name',
+      });
+      @field lead = contains(Citation, { searchable: 'article' });
+      @field badCitations = containsMany(Citation, {
+        searchable: 'article.bogus',
+      });
+    }
     // Used for option-plumbing + projection coverage across all four field
     // kinds; never validated, so the annotation values are arbitrary.
     class Sample extends CardDef {
@@ -137,6 +160,8 @@ module('Unit | searchable option', function (hooks) {
     loader.shimModule(`${testRealmURL}address`, { Address });
     loader.shimModule(`${testRealmURL}author`, { Author });
     loader.shimModule(`${testRealmURL}article`, { Article });
+    loader.shimModule(`${testRealmURL}citation`, { Citation });
+    loader.shimModule(`${testRealmURL}journal`, { Journal });
     loader.shimModule(`${testRealmURL}sample`, { Sample });
 
     cards = {
@@ -145,6 +170,8 @@ module('Unit | searchable option', function (hooks) {
       Author: Author as unknown as typeof CardDef,
       Address: Address as unknown as typeof CardDef,
       Employer: Employer as unknown as typeof CardDef,
+      Citation: Citation as unknown as typeof CardDef,
+      Journal: Journal as unknown as typeof CardDef,
       Country,
     };
   });
@@ -249,6 +276,79 @@ module('Unit | searchable option', function (hooks) {
     assert.notOk(
       issues.some((i) => i.fieldName === 'combo'),
       'combo (both legs resolvable) produced no issue',
+    );
+
+    // Positively confirm, for a path that exists, both that the raw annotation
+    // is stored on the owning field's definition item and that the path
+    // actually resolves through the graph — not merely "no issue".
+    let articleDef = buildDefinition(cards.Article);
+    let reviewerDef = articleDef.fieldDefs[articleDef.fields['reviewer']];
+    assert.strictEqual(
+      reviewerDef.searchable,
+      'address',
+      'reviewer field def carries the raw searchable annotation',
+    );
+    let reviewerTarget = await lookup(reviewerDef.fieldOrCard);
+    let resolvedAddress = await getFieldDef(reviewerTarget!, 'address', lookup);
+    assert.strictEqual(
+      resolvedAddress?.type,
+      'contains',
+      "reviewer's 'address' resolves to Author.address against the graph",
+    );
+    let publisherDef = articleDef.fieldDefs[articleDef.fields['publisher']];
+    let publisherTarget = await lookup(publisherDef.fieldOrCard);
+    let resolvedHq = await getFieldDef(
+      publisherTarget!,
+      'employer.headquarters',
+      lookup,
+    );
+    assert.strictEqual(
+      resolvedHq?.type,
+      'linksTo',
+      "publisher's 'employer.headquarters' resolves across two link hops",
+    );
+  });
+
+  test('searchable paths route through a contained FieldDef to a deeper link', async function (assert) {
+    let lookup = makeLookup();
+    let issues = await validateSearchablePaths(
+      buildDefinition(cards.Journal),
+      lookup,
+    );
+    assert.notOk(
+      issues.some((i) => i.fieldName === 'citations'),
+      "'article.name' routes through the contained Citation's link and resolves",
+    );
+    assert.notOk(
+      issues.some((i) => i.fieldName === 'lead'),
+      "'article' resolves to the contained FieldDef's own link",
+    );
+    assert.deepEqual(
+      issues.map((i) => `${i.fieldName}:${i.path}`),
+      ['badCitations:article.bogus'],
+      'only the path with a nonexistent segment beyond the link is recorded',
+    );
+  });
+
+  test('skips searchable: true and omitted, and flags every dotted path when the target is unresolvable', async function (assert) {
+    // A lookup that resolves nothing: `true` (self link) and omitted fields are
+    // still skipped without a lookup, while every dotted path is flagged
+    // because its target type can't be resolved.
+    let issues = await validateSearchablePaths(
+      buildDefinition(cards.Article),
+      async () => undefined,
+    );
+    assert.notOk(
+      issues.some((i) => i.fieldName === 'author'),
+      'searchable: true carries no path and is never flagged',
+    );
+    assert.notOk(
+      issues.some((i) => i.fieldName === 'title'),
+      'an unannotated field is skipped',
+    );
+    assert.ok(
+      issues.some((i) => i.fieldName === 'reviewer' && i.path === 'address'),
+      'a dotted path whose target cannot be resolved is flagged',
     );
   });
 

--- a/packages/host/tests/unit/searchable-option-test.ts
+++ b/packages/host/tests/unit/searchable-option-test.ts
@@ -1,0 +1,288 @@
+import { module, test } from 'qunit';
+
+import {
+  Loader,
+  VirtualNetwork,
+  baseRealm,
+  fetcher,
+  maybeHandleScopedCSSRequest,
+  internalKeyFor,
+  identifyCard,
+  getFieldDefinitions,
+  validateSearchablePaths,
+  type CodeRef,
+  type Definition,
+} from '@cardstack/runtime-common';
+
+import ENV from '@cardstack/host/config/environment';
+import { shimExternals } from '@cardstack/host/lib/externals';
+
+import type { CardDef, Field } from 'https://cardstack.com/base/card-api';
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
+
+import { testRealmURL } from '../helpers';
+
+let { resolvedBaseRealmURL } = ENV;
+
+// Scaffolding-only coverage for the `searchable` field option (additive, inert
+// — nothing consumes it for search-doc depth yet): it plumbs onto the field
+// descriptor, mirrors into the cached `FieldDefinition`, and its annotation
+// paths validate against the definition graph.
+module('Unit | searchable option', function (hooks) {
+  let loader: Loader;
+  let api: typeof CardAPI;
+  // Card classes captured from the per-test setup so assertions can reach them.
+  let cards: {
+    Article: typeof CardDef;
+    Sample: typeof CardDef;
+    Author: typeof CardDef;
+    Address: typeof CardDef;
+    Employer: typeof CardDef;
+    Country: typeof CardDef;
+  };
+  let virtualNetwork: VirtualNetwork;
+
+  hooks.beforeEach(async function () {
+    virtualNetwork = new VirtualNetwork();
+    virtualNetwork.addURLMapping(
+      new URL(baseRealm.url),
+      new URL(resolvedBaseRealmURL),
+    );
+    virtualNetwork.addRealmMapping('@cardstack/base/', resolvedBaseRealmURL);
+    virtualNetwork.addImportMap('@cardstack/boxel-icons/', (rest) => {
+      return `${ENV.iconsURL}/@cardstack/boxel-icons/v1/icons/${rest}.js`;
+    });
+    shimExternals(virtualNetwork);
+    let fetch = fetcher(virtualNetwork.fetch, [
+      async (req, next) => {
+        return (await maybeHandleScopedCSSRequest(req)) || next(req);
+      },
+    ]);
+    loader = new Loader(fetch, virtualNetwork.resolveImport, {
+      virtualNetwork,
+    });
+
+    api = await loader.import<typeof CardAPI>(`${baseRealm.url}card-api`);
+    let string = await loader.import<
+      typeof import('https://cardstack.com/base/string')
+    >(`${baseRealm.url}string`);
+
+    let {
+      field,
+      contains,
+      containsMany,
+      linksTo,
+      linksToMany,
+      CardDef,
+      FieldDef,
+    } = api;
+    let { default: StringField } = string;
+
+    class Country extends CardDef {
+      @field name = contains(StringField);
+    }
+    class Employer extends CardDef {
+      @field name = contains(StringField);
+      @field headquarters = linksTo(() => Country);
+    }
+    class Address extends FieldDef {
+      @field street = contains(StringField);
+      @field city = contains(StringField);
+    }
+    class Author extends CardDef {
+      @field name = contains(StringField);
+      @field address = contains(Address);
+      @field employer = linksTo(() => Employer);
+    }
+    // Used for validation good/bad coverage — every annotated field is a link
+    // so the path root is unambiguous (the field's target type).
+    class Article extends CardDef {
+      @field title = contains(StringField);
+      @field author = linksTo(() => Author, { searchable: true });
+      @field reviewer = linksTo(() => Author, { searchable: 'address' });
+      @field editor = linksTo(() => Author, { searchable: 'address.city' });
+      @field publisher = linksTo(() => Author, {
+        searchable: 'employer.headquarters',
+      });
+      @field combo = linksTo(() => Author, {
+        searchable: ['address', 'employer.headquarters'],
+      });
+      @field typo = linksTo(() => Author, { searchable: 'addresss' });
+      @field deepTypo = linksTo(() => Author, {
+        searchable: 'address.zipcode',
+      });
+      @field primitiveRoute = linksTo(() => Author, {
+        searchable: 'name.first',
+      });
+      @field comboBad = linksTo(() => Author, {
+        searchable: ['address.city', 'nope'],
+      });
+    }
+    // Used for option-plumbing + projection coverage across all four field
+    // kinds; never validated, so the annotation values are arbitrary.
+    class Sample extends CardDef {
+      @field plainContains = contains(StringField);
+      @field searchContains = contains(Address, { searchable: 'city' });
+      @field searchContainsMany = containsMany(StringField, {
+        searchable: true,
+      });
+      @field searchLinksTo = linksTo(() => Author, { searchable: 'address' });
+      @field searchLinksToMany = linksToMany(() => Author, {
+        searchable: ['address', 'employer.headquarters'],
+      });
+    }
+
+    loader.shimModule(`${testRealmURL}country`, { Country });
+    loader.shimModule(`${testRealmURL}employer`, { Employer });
+    loader.shimModule(`${testRealmURL}address`, { Address });
+    loader.shimModule(`${testRealmURL}author`, { Author });
+    loader.shimModule(`${testRealmURL}article`, { Article });
+    loader.shimModule(`${testRealmURL}sample`, { Sample });
+
+    cards = {
+      Article: Article as unknown as typeof CardDef,
+      Sample: Sample as unknown as typeof CardDef,
+      Author: Author as unknown as typeof CardDef,
+      Address: Address as unknown as typeof CardDef,
+      Employer: Employer as unknown as typeof CardDef,
+      Country,
+    };
+  });
+
+  function buildDefinition(cardDef: typeof CardDef): Definition {
+    let { fields, fieldDefs } = getFieldDefinitions(api, cardDef);
+    return {
+      codeRef: identifyCard(cardDef)!,
+      displayName: cardDef.displayName,
+      fields,
+      fieldDefs,
+      type: 'card-def',
+    };
+  }
+
+  // Resolve any CodeRef among the cards registered above to its definition,
+  // mirroring what `CachingDefinitionLookup` does loaderlessly in production.
+  function makeLookup() {
+    let byKey = new Map<string, typeof CardDef>();
+    for (let cardDef of Object.values(cards)) {
+      byKey.set(
+        internalKeyFor(identifyCard(cardDef)!, undefined, virtualNetwork),
+        cardDef,
+      );
+    }
+    return async (codeRef: CodeRef): Promise<Definition | undefined> => {
+      let cardDef = byKey.get(
+        internalKeyFor(codeRef, undefined, virtualNetwork),
+      );
+      return cardDef ? buildDefinition(cardDef) : undefined;
+    };
+  }
+
+  test('searchable plumbs onto the field descriptor for every field kind', function (assert) {
+    let fields = api.getFields(cards.Sample) as Record<string, Field>;
+    assert.strictEqual(
+      fields.plainContains.searchable,
+      undefined,
+      'an unannotated field has no searchable',
+    );
+    assert.strictEqual(
+      fields.searchContains.searchable,
+      'city',
+      'contains carries a dotted-path searchable',
+    );
+    let containsManyIsSelfSearchable =
+      fields.searchContainsMany.searchable === true;
+    assert.true(
+      containsManyIsSelfSearchable,
+      'containsMany carries searchable: true',
+    );
+    assert.strictEqual(
+      fields.searchLinksTo.searchable,
+      'address',
+      'linksTo carries a dotted-path searchable',
+    );
+    assert.deepEqual(
+      fields.searchLinksToMany.searchable,
+      ['address', 'employer.headquarters'],
+      'linksToMany carries an array searchable',
+    );
+  });
+
+  test('getFieldDefinitions mirrors searchable into the cached FieldDefinition', function (assert) {
+    let { fields, fieldDefs } = getFieldDefinitions(api, cards.Sample);
+    let searchableOf = (fieldName: string) =>
+      fieldDefs[fields[fieldName]].searchable;
+
+    assert.strictEqual(
+      searchableOf('plainContains'),
+      undefined,
+      'unannotated field def has no searchable',
+    );
+    assert.strictEqual(searchableOf('searchContains'), 'city');
+    let containsManyMirrorsSelf = searchableOf('searchContainsMany') === true;
+    assert.true(
+      containsManyMirrorsSelf,
+      'containsMany def mirrors searchable: true',
+    );
+    assert.strictEqual(searchableOf('searchLinksTo'), 'address');
+    assert.deepEqual(searchableOf('searchLinksToMany'), [
+      'address',
+      'employer.headquarters',
+    ]);
+  });
+
+  test('searchable: true and resolvable paths produce no validation issues', async function (assert) {
+    let lookup = makeLookup();
+    let issues = await validateSearchablePaths(
+      buildDefinition(cards.Article),
+      lookup,
+    );
+    let goodFields = ['author', 'reviewer', 'editor', 'publisher'];
+    for (let fieldName of goodFields) {
+      assert.notOk(
+        issues.some((i) => i.fieldName === fieldName),
+        `${fieldName} (a resolvable annotation) produced no issue`,
+      );
+    }
+    // The good leg of `combo` (`address`) resolves; only its bad leg, if any,
+    // would surface — and combo has none, so combo is absent from issues.
+    assert.notOk(
+      issues.some((i) => i.fieldName === 'combo'),
+      'combo (both legs resolvable) produced no issue',
+    );
+  });
+
+  test('unresolvable searchable paths are recorded as issues (never thrown)', async function (assert) {
+    let lookup = makeLookup();
+    let issues = await validateSearchablePaths(
+      buildDefinition(cards.Article),
+      lookup,
+    );
+
+    let issueFor = (fieldName: string, path: string) =>
+      issues.find((i) => i.fieldName === fieldName && i.path === path);
+
+    assert.ok(issueFor('typo', 'addresss'), 'typo path is recorded');
+    assert.ok(
+      issueFor('deepTypo', 'address.zipcode'),
+      'a path with a nonexistent deep segment is recorded',
+    );
+    assert.ok(
+      issueFor('primitiveRoute', 'name.first'),
+      'a path routing deeper through a primitive is recorded',
+    );
+    assert.ok(
+      issueFor('comboBad', 'nope'),
+      'the unresolvable leg of an array annotation is recorded',
+    );
+    assert.notOk(
+      issueFor('comboBad', 'address.city'),
+      'the resolvable leg of the same array annotation is not recorded',
+    );
+    assert.strictEqual(
+      issues.length,
+      4,
+      'exactly the four unresolvable paths are recorded',
+    );
+  });
+});

--- a/packages/realm-server/prerender/render-settlement.ts
+++ b/packages/realm-server/prerender/render-settlement.ts
@@ -244,8 +244,16 @@ export function decorateRenderErrorsWithTimings(
     ...(tabReused !== undefined ? { tabReused } : {}),
   };
   let existingMeta = (r.meta as PrerenderResponseMeta | undefined) ?? {};
+  // Merge onto any diagnostics the response already carries rather than
+  // replacing them: the module-prerender route records definition-build
+  // findings (`searchablePathIssues`) on `meta.diagnostics`, and those must
+  // survive to `flattenPrerenderMeta` / `modules.diagnostics`. Timing fields
+  // are spread last so they win on the (disjoint) keys they own.
   r.meta = {
     ...existingMeta,
-    diagnostics,
+    diagnostics: {
+      ...existingMeta.diagnostics,
+      ...diagnostics,
+    },
   };
 }

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -2262,6 +2262,12 @@ module(basename(import.meta.filename), function () {
     let nextPrerenderMeta:
       | import('@cardstack/runtime-common').PrerenderResponseMeta
       | undefined;
+    // Override the field map/defs the mock returns for the Person definition,
+    // so a test can drive a `searchable`-bearing FieldDefinition through the
+    // persistence path and read it back out of `modules.definitions`.
+    let nextPersonDefinitionParts:
+      | { fields: Record<string, string>; fieldDefs: Record<string, any> }
+      | undefined;
 
     hooks.beforeEach(async function () {
       prepareTestDB();
@@ -2287,8 +2293,8 @@ module(basename(import.meta.filename), function () {
                   type: 'card-def',
                   codeRef: { module: rri(moduleURL.href), name: 'Person' },
                   displayName: 'Person',
-                  fields: {},
-                  fieldDefs: {},
+                  fields: nextPersonDefinitionParts?.fields ?? {},
+                  fieldDefs: nextPersonDefinitionParts?.fieldDefs ?? {},
                 },
                 types: [],
               },
@@ -2331,6 +2337,7 @@ module(basename(import.meta.filename), function () {
     hooks.afterEach(async function () {
       await adapter.close();
       nextPrerenderMeta = undefined;
+      nextPersonDefinitionParts = undefined;
     });
 
     test('persists diagnostics from prerender meta on module rows', async function (assert) {
@@ -2382,6 +2389,84 @@ module(basename(import.meta.filename), function () {
         rows[0].diagnostics,
         null,
         'diagnostics is null when meta is absent',
+      );
+    });
+
+    test('persists searchablePathIssues from prerender meta on module rows', async function (assert) {
+      // The module-prerender route's definition-build validation records
+      // unresolvable `searchable` paths on meta.diagnostics; this is the
+      // channel that lands them in `modules.diagnostics` for authors to see.
+      let searchablePathIssues = [
+        {
+          codeRef: `${realmURL}person/Person`,
+          fieldName: 'reviewer',
+          path: 'addresss',
+        },
+      ];
+      nextPrerenderMeta = { diagnostics: { searchablePathIssues } };
+      await definitionLookup.lookupDefinition({
+        module: rri(`${realmURL}person.gts`),
+        name: 'Person',
+      });
+
+      let rows = (await adapter.execute(
+        `SELECT diagnostics FROM modules WHERE url = $1`,
+        { bind: [`${realmURL}person.gts`] },
+      )) as { diagnostics: unknown }[];
+      assert.strictEqual(rows.length, 1, 'one modules row was written');
+      let raw = rows[0].diagnostics;
+      let persisted =
+        typeof raw === 'string'
+          ? (JSON.parse(raw) as Record<string, any>)
+          : (raw as Record<string, any>);
+      assert.deepEqual(
+        persisted?.searchablePathIssues,
+        searchablePathIssues,
+        'searchablePathIssues persisted to modules.diagnostics',
+      );
+    });
+
+    test("persists a field's searchable annotation into modules.definitions", async function (assert) {
+      // getFieldDefinitions mirrors `searchable` onto the cached
+      // FieldDefinition; confirm the raw value survives the persistence path
+      // into the `modules.definitions` JSON the loaderless query compiler reads.
+      nextPersonDefinitionParts = {
+        fields: { reviewer: 'f0' },
+        fieldDefs: {
+          f0: {
+            type: 'linksTo',
+            isPrimitive: false,
+            isComputed: false,
+            fieldOrCard: {
+              module: rri(`${realmURL}author.gts`),
+              name: 'Author',
+            },
+            searchable: 'address',
+          },
+        },
+      };
+      await definitionLookup.lookupDefinition({
+        module: rri(`${realmURL}person.gts`),
+        name: 'Person',
+      });
+
+      let rows = (await adapter.execute(
+        `SELECT definitions FROM modules WHERE url = $1`,
+        { bind: [`${realmURL}person.gts`] },
+      )) as { definitions: unknown }[];
+      assert.strictEqual(rows.length, 1, 'one modules row was written');
+      let raw = rows[0].definitions;
+      let persisted =
+        typeof raw === 'string'
+          ? (JSON.parse(raw) as Record<string, any>)
+          : (raw as Record<string, any>);
+      let personEntry = persisted[Object.keys(persisted)[0]];
+      let definition = personEntry.definition;
+      let reviewerDefId = definition.fields.reviewer;
+      assert.strictEqual(
+        definition.fieldDefs[reviewerDefId].searchable,
+        'address',
+        'searchable survives into the persisted modules.definitions JSON',
       );
     });
   });

--- a/packages/realm-server/tests/prerender-diagnostics-persistence-test.ts
+++ b/packages/realm-server/tests/prerender-diagnostics-persistence-test.ts
@@ -244,6 +244,46 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('module-prerender searchablePathIssues on response.meta.diagnostics survive the timing stamp', function (assert) {
+      // The module-prerender route records definition-build findings on
+      // meta.diagnostics before the Prerenderer stamps timings. The timing
+      // stamp must MERGE onto the existing diagnostics, not replace them —
+      // otherwise the findings are dropped on the prerender path and never
+      // reach `modules.diagnostics` via `flattenPrerenderMeta`.
+      let searchablePathIssues = [
+        {
+          codeRef: 'http://realm.example/article/Article',
+          fieldName: 'typo',
+          path: 'addresss',
+        },
+      ];
+      let response: FakeVisitResponse = {
+        meta: { diagnostics: { searchablePathIssues } },
+      };
+      Prerenderer.decorateRenderErrorsWithTimings(
+        response,
+        { launchMs: 4, renderMs: 8, waits: {} },
+        12,
+      );
+
+      let diagnostics = response.meta?.diagnostics;
+      assert.deepEqual(
+        diagnostics?.searchablePathIssues,
+        searchablePathIssues,
+        'searchablePathIssues preserved through the timing stamp',
+      );
+      assert.strictEqual(
+        diagnostics?.launchMs,
+        4,
+        'server timing merged alongside the preserved findings',
+      );
+      assert.strictEqual(
+        diagnostics?.totalElapsedMs,
+        12,
+        'totalElapsedMs merged alongside',
+      );
+    });
+
     test('both decorators stack: host-lifted diagnostics + server timings + requestId coexist on response.meta', function (assert) {
       let response = buildFakeVisitResponseWithTimeoutError();
       Prerenderer.decorateRenderErrorsWithTimings(

--- a/packages/runtime-common/definitions.ts
+++ b/packages/runtime-common/definitions.ts
@@ -6,7 +6,10 @@ import {
   type CodeRef,
 } from './index.ts';
 import type { SerializerName } from './serializers/index.ts';
-import type { FieldType } from 'https://cardstack.com/base/card-api';
+import type {
+  FieldType,
+  Searchable,
+} from 'https://cardstack.com/base/card-api';
 import type { BaseDef } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type { Query } from './query.ts';
@@ -18,6 +21,11 @@ export interface FieldDefinition {
   fieldOrCard: CodeRef;
   serializerName?: SerializerName;
   query?: Query;
+  // Raw `searchable` annotation mirrored from the field descriptor (the source
+  // of truth in `card-api.gts`). Carried here for the loaderless query compiler
+  // and definition-build validation — not a pre-resolved plan. Persisted as
+  // plain JSON in `modules.definitions`; omitted when the field declares none.
+  searchable?: Searchable;
 }
 
 // `Definition.fields` only carries the **immediate** field map. Dotted
@@ -92,6 +100,7 @@ export function getFieldDefinitions(
           ? (field.card[fieldSerializer] as SerializerName)
           : undefined,
       query: queryDefinition,
+      searchable: field.searchable,
     };
     fields[fieldName] = intern(def);
   }
@@ -149,4 +158,62 @@ export async function getFieldDef(
     current = next;
   }
   return undefined;
+}
+
+// A `searchable` annotation path that didn't resolve against the definition
+// graph during definition build. Recorded (never thrown) into
+// `modules.diagnostics` so a typo / removed field / un-routable segment
+// surfaces where authors can see it instead of silently making nothing
+// searchable. Carries no owning-codeRef — the caller tags each finding with
+// the definition it came from when aggregating across a module.
+export interface SearchablePathIssue {
+  // The immediate field (on the validated definition) carrying the annotation.
+  fieldName: string;
+  // The dotted `searchable` path that failed to resolve.
+  path: string;
+}
+
+// Validate every field's `searchable` annotation on `definition` against the
+// definition graph. A path is rooted at the annotated field's TARGET type
+// (`fieldOrCard`), matching the search-doc semantics: `searchable: 'address'`
+// on `author = linksTo(Author)` names Author's `address` link, so the path
+// resolves against Author — not against the card declaring `author`. The
+// `true` form (the immediate "self" link) carries no path and is always valid;
+// an omitted annotation is skipped. Returns one issue per path that
+// `getFieldDef` can't resolve and never throws — definition build is decoupled
+// in time from the edit that introduced a bad path, so a throw would surface at
+// a confusing moment, and the query-time check is the loud backstop if the
+// intended path is ever actually queried. `lookupDefinition` resolves a CodeRef
+// to its `Definition`; returning undefined for an unloadable ref makes every
+// path under it unresolvable (recorded), which is the intended behavior.
+export async function validateSearchablePaths(
+  definition: Pick<Definition, 'fields' | 'fieldDefs'>,
+  lookupDefinition: (codeRef: CodeRef) => Promise<Definition | undefined>,
+): Promise<SearchablePathIssue[]> {
+  let issues: SearchablePathIssue[] = [];
+  for (let [fieldName, defId] of Object.entries(definition.fields)) {
+    let fieldDef = definition.fieldDefs[defId];
+    let searchable = fieldDef?.searchable;
+    if (searchable == null || searchable === true) {
+      continue;
+    }
+    let paths = typeof searchable === 'string' ? [searchable] : searchable;
+    if (paths.length === 0) {
+      continue;
+    }
+    // A path is rooted at this field's target type. If we can't even identify
+    // that target, none of the paths can be followed.
+    let targetDef = isResolvedCodeRef(fieldDef.fieldOrCard)
+      ? await lookupDefinition(fieldDef.fieldOrCard)
+      : undefined;
+    for (let path of paths) {
+      let resolved = targetDef
+        ? await getFieldDef(targetDef, path, lookupDefinition)
+        : undefined;
+      if (!resolved) {
+        issues.push({ fieldName, path });
+      }
+    }
+  }
+  return issues;
 }

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -57,6 +57,24 @@ export interface BrokenLinkSummary {
   kind: 'error' | 'not-found';
 }
 
+// A `searchable` annotation path that didn't resolve against the definition
+// graph when the module's definitions were built. Recorded on the module
+// render's `meta.diagnostics` and persisted to `modules.diagnostics` so a typo
+// / removed field / un-routable segment is visible to authors instead of
+// silently making nothing searchable. Definition build is decoupled in time
+// from the edit, so these are logged, never thrown; the path is simply not
+// followed. Omitted entirely when every annotation in the module resolves.
+export interface SearchablePathDiagnostic {
+  // The card/field def whose field carried the annotation, as the
+  // `internalKeyFor` CodeRef string (a module exports several defs, so the
+  // owning def is named to pinpoint the source).
+  codeRef: string;
+  // The immediate field holding the `searchable` annotation.
+  fieldName: string;
+  // The dotted `searchable` path that failed to resolve.
+  path: string;
+}
+
 // A failure to parse a markdown file's leading YAML frontmatter block,
 // recorded as a finding on the (still successful) index entry. The file
 // indexes fine — `extractAttributes` falls back to treating the whole file
@@ -111,6 +129,11 @@ export interface PrerenderMetaDiagnostics {
   // cards-with-broken-links are cheaply enumerable. Omitted entirely
   // when the card has no broken links.
   brokenLinks?: BrokenLinkSummary[];
+  // Unresolvable `searchable` annotation paths found while building the
+  // module's definitions, persisted to `modules.diagnostics`. Populated by the
+  // module-prerender route's definition-build validation, not a card render.
+  // Omitted entirely when every annotation in the module resolves.
+  searchablePathIssues?: SearchablePathDiagnostic[];
 }
 
 // Shared type produced by the host app when visiting the render.meta route and


### PR DESCRIPTION
Adds the `searchable` field option end-to-end as additive, inert scaffolding. Nothing consumes it for search-doc depth yet, so this lands with zero behavior change — the store-driven generation stays authoritative and `searchable` is read by nothing on the depth path.

### What's here

- **`searchable` option on the field descriptor (source of truth)** — `packages/base/card-api.gts`
  - `export type Searchable = true | string | string[]`.
  - `searchable?` on `Options`/`RelationshipOptions`, stored on the `Contains`/`ContainsMany`/`LinksTo`/`LinksToMany` field instances at setup, and surfaced on the `Field` interface. Flows exactly like `isUsed`.

- **Mirror into the cached `FieldDefinition`** — `packages/runtime-common/definitions.ts`
  - `searchable?` on `FieldDefinition`; `getFieldDefinitions` copies the raw value in (interned like the other field metadata, persisted as plain JSON in `modules.definitions`). This copy is for the loaderless query compiler and definition-build validation, not for generation. `undefined` is dropped by `JSON.stringify`, so the persisted shape for unannotated fields is unchanged — no spurious cache invalidation.

- **Definition-build validation** — `definitions.ts` + module-prerender route
  - `validateSearchablePaths` resolves each annotation against the definition graph via `getFieldDef`, rooting a path at the annotated field's **target** type (so `searchable: 'address'` on `author = linksTo(Author)` validates `address` against `Author`). `true` is always valid; an omitted annotation is skipped. Returns the unresolvable paths and **never throws**.
  - The module-prerender route (`packages/host/app/routes/module.ts`) runs the validation per built definition with a loader-backed lookup and records findings on `meta.diagnostics.searchablePathIssues`, which persists to `modules.diagnostics` through the existing `flattenPrerenderMeta` path. Best-effort (any failure logs and yields no findings rather than breaking the build) and inert until a field actually declares `searchable`.

### Semantics

`searchable` decides which links are pulled into the search doc; contained fields are always included and `searchable` never applies to them. `true` makes the immediate ("self") link searchable; a dotted path makes a deeper link searchable, routed from the field's target through its links (intermediate contained fields named as segments); an array combines routes. Unresolvable paths are logged + recorded, never thrown — definition build is decoupled from edit time, and the query-time check (a later change) is the loud backstop if a bad path is actually queried.

### Tests

`packages/host/tests/unit/searchable-option-test.ts` covers option plumbing across all four field kinds, the `FieldDefinition` projection, and validation diagnostics for resolvable (`true`, dotted, array) and unresolvable (typo, deep-typo, primitive-routing, array bad-leg) paths.

Verified: glint + `tsc` clean across base/runtime-common/host, eslint clean, and the test suite green on a live `test-services:host` stack (4/4 pass).

This unblocks the searchable-driven generation + parity-harness work and the migration codemod, which both build on this.
