### PR TITLE
Add owner-only GET /_archived-realms endpoint

### DIFF
--- a/packages/realm-server/handlers/handle-archived-realms.ts
+++ b/packages/realm-server/handlers/handle-archived-realms.ts
@@ -117,10 +117,19 @@ export default function handleArchivedRealms({
           typeof cardInfo.name === 'string' && cardInfo.name.length > 0
             ? cardInfo.name
             : fallbackName(url);
-        let iconURL =
-          typeof attrs.iconURL === 'string'
-            ? attrs.iconURL
-            : (iconURLFor(name) ?? null);
+        let iconURL: string | null;
+        if (typeof attrs.iconURL === 'string') {
+          iconURL = attrs.iconURL;
+        } else if (config && 'iconURL' in attrs) {
+          // The icon was explicitly cleared on an indexed realm. Preserve the
+          // null rather than synthesizing one, matching how RealmConfig
+          // parsing treats an explicit null (see Realm#parseRealmInfo).
+          iconURL = null;
+        } else {
+          // No indexed config (or no iconURL field) — fall back to a letter
+          // icon so the chooser still has something to show.
+          iconURL = iconURLFor(name) ?? null;
+        }
         let backgroundURL =
           typeof attrs.backgroundURL === 'string' ? attrs.backgroundURL : null;
         let attributes: ArchivedRealmAttributes = {

--- a/packages/realm-server/handlers/handle-archived-realms.ts
+++ b/packages/realm-server/handlers/handle-archived-realms.ts
@@ -1,0 +1,147 @@
+import type Koa from 'koa';
+import {
+  any,
+  every,
+  fetchArchivedRealmsForOwner,
+  logger,
+  param,
+  query,
+  separatedByCommas,
+  SupportedMimeType,
+  type CardResource,
+  type Expression,
+} from '@cardstack/runtime-common';
+import { iconURLFor } from '@cardstack/runtime-common/realm-display-defaults';
+import * as Sentry from '@sentry/node';
+import {
+  sendResponseForSystemError,
+  setContextResponse,
+} from '../middleware/index.ts';
+import type { CreateRoutesArgs } from '../routes.ts';
+import type { RealmServerTokenClaim } from '../utils/jwt.ts';
+
+const log = logger('handle-archived-realms');
+
+// The RealmConfig card lives at `<realmURL>realm.json`; the indexer stores
+// it under the `.json`-stripped URL `<realmURL>realm` (matching
+// Realm#parseRealmInfo's index read).
+function realmConfigCardURL(realmURL: string): string {
+  return `${realmURL}realm`;
+}
+
+// Best-effort name for a realm that has no indexed RealmConfig card yet
+// (e.g. never finished its first index). Falls back to the last path
+// segment of the URL so the chooser still has something to show.
+function fallbackName(realmURL: string): string {
+  try {
+    let segments = new URL(realmURL).pathname.split('/').filter(Boolean);
+    let last = segments[segments.length - 1];
+    return last ?? 'Unnamed Workspace';
+  } catch {
+    return 'Unnamed Workspace';
+  }
+}
+
+interface ArchivedRealmAttributes {
+  archivedAt: string;
+  name: string;
+  iconURL: string | null;
+  backgroundURL: string | null;
+}
+
+// GET /_archived-realms — returns the archived realms the authenticated
+// caller owns, with the display metadata the workspace chooser's archived
+// section needs (URL, name, icon, archived_at). Ownership and the
+// archived/published filtering live in fetchArchivedRealmsForOwner; this
+// handler layers on the per-realm display info.
+//
+// Name/icon are read straight from the indexed RealmConfig card rather than
+// by mounting each realm: archived realms are meant to stay dormant, and
+// their index rows persist while archived, so a direct read avoids waking
+// them up.
+export default function handleArchivedRealms({
+  dbAdapter,
+}: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
+  return async function (ctxt: Koa.Context, _next: Koa.Next) {
+    let token = ctxt.state.token as RealmServerTokenClaim;
+    if (!token) {
+      await sendResponseForSystemError(
+        ctxt,
+        'token is required to list archived realms',
+      );
+      return;
+    }
+
+    try {
+      let { user: username } = token;
+      let archivedRealms = await fetchArchivedRealmsForOwner(
+        dbAdapter,
+        username,
+      );
+
+      let configByRealmURL = new Map<string, CardResource>();
+      if (archivedRealms.length > 0) {
+        let configURLToRealmURL = new Map<string, string>();
+        for (let { url } of archivedRealms) {
+          configURLToRealmURL.set(realmConfigCardURL(url), url);
+        }
+        let configURLs = [...configURLToRealmURL.keys()];
+        let rows = (await query(dbAdapter, [
+          `SELECT url, pristine_doc FROM boxel_index WHERE`,
+          ...every([
+            [
+              `url IN (`,
+              ...separatedByCommas(configURLs.map((u) => [param(u)])),
+              `)`,
+            ],
+            [`type =`, param('instance')],
+            any([[`is_deleted = FALSE`], [`is_deleted IS NULL`]]),
+          ]),
+        ] as Expression)) as {
+          url: string;
+          pristine_doc: CardResource | null;
+        }[];
+        for (let { url, pristine_doc } of rows) {
+          let realmURL = configURLToRealmURL.get(url);
+          if (realmURL && pristine_doc) {
+            configByRealmURL.set(realmURL, pristine_doc);
+          }
+        }
+      }
+
+      let data = archivedRealms.map(({ url, archivedAt }) => {
+        let config = configByRealmURL.get(url);
+        let attrs = (config?.attributes ?? {}) as Record<string, unknown>;
+        let cardInfo = (attrs.cardInfo ?? {}) as Record<string, unknown>;
+        let name =
+          typeof cardInfo.name === 'string' && cardInfo.name.length > 0
+            ? cardInfo.name
+            : fallbackName(url);
+        let iconURL =
+          typeof attrs.iconURL === 'string'
+            ? attrs.iconURL
+            : (iconURLFor(name) ?? null);
+        let backgroundURL =
+          typeof attrs.backgroundURL === 'string' ? attrs.backgroundURL : null;
+        let attributes: ArchivedRealmAttributes = {
+          archivedAt,
+          name,
+          iconURL,
+          backgroundURL,
+        };
+        return { type: 'realm', id: url, attributes };
+      });
+
+      await setContextResponse(
+        ctxt,
+        new Response(JSON.stringify({ data }, null, 2), {
+          headers: { 'content-type': SupportedMimeType.JSONAPI },
+        }),
+      );
+    } catch (error: any) {
+      log.error(`Error listing archived realms:`, error);
+      Sentry.captureException(error);
+      await sendResponseForSystemError(ctxt, error.message);
+    }
+  };
+}

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -21,6 +21,7 @@ import handlePublishRealm from './handlers/handle-publish-realm.ts';
 import handleUnpublishRealm from './handlers/handle-unpublish-realm.ts';
 import handleArchiveRealm from './handlers/handle-archive-realm.ts';
 import handleUnarchiveRealm from './handlers/handle-unarchive-realm.ts';
+import handleArchivedRealms from './handlers/handle-archived-realms.ts';
 import {
   healthCheck,
   jwtMiddleware,
@@ -277,6 +278,11 @@ export function createRoutes(args: CreateRoutesArgs) {
     '/_unarchive-realm',
     jwtMiddleware(args.realmSecretSeed),
     handleUnarchiveRealm(args),
+  );
+  router.get(
+    '/_archived-realms',
+    jwtMiddleware(args.realmSecretSeed),
+    handleArchivedRealms(args),
   );
 
   // Grafana operator-action endpoints. All POST-only with

--- a/packages/realm-server/tests/queries-test.ts
+++ b/packages/realm-server/tests/queries-test.ts
@@ -309,9 +309,13 @@ module(basename(import.meta.filename), function () {
       let archived = await fetchArchivedRealmsForOwner(dbAdapter, owner);
 
       assert.deepEqual(
-        archived,
+        archived.map((r) => r.url),
         [archivedOwned],
         'returns only realms that are both archived and owned by the user',
+      );
+      assert.ok(
+        archived[0]?.archivedAt,
+        'each archived realm carries its archived_at timestamp',
       );
     });
 
@@ -342,7 +346,7 @@ module(basename(import.meta.filename), function () {
       let archived = await fetchArchivedRealmsForOwner(dbAdapter, owner);
 
       assert.deepEqual(
-        archived,
+        archived.map((r) => r.url),
         [sourceRealmURL],
         'published snapshots are omitted even when archived and owned',
       );

--- a/packages/realm-server/tests/server-endpoints/archive-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/archive-realm-test.ts
@@ -401,6 +401,31 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       );
     });
 
+    test('preserves an explicitly cleared (null) icon rather than synthesizing one', async function (assert) {
+      const owner = '@archive-owner:localhost';
+      const realmURL = makeRealmURL();
+      await seedArchivedRealm(realmURL, owner);
+      // An indexed RealmConfig whose icon was cleared to null.
+      await seedRealmConfigInIndex(realmURL, {
+        name: 'Cleared Icon Workspace',
+        iconURL: null,
+      });
+
+      let response = await context.request
+        .get('/_archived-realms')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Authorization', authHeader(owner));
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let entry = findEntry(response.body, realmURL);
+      assert.ok(entry, 'the archived realm is present');
+      assert.strictEqual(
+        entry.attributes.iconURL,
+        null,
+        'an explicitly cleared icon stays null and is not synthesized',
+      );
+    });
+
     test('falls back to a URL-derived name when no RealmConfig is indexed', async function (assert) {
       const owner = '@archive-owner:localhost';
       const realmURL = `${testRealmURL.origin}/no-config-realm/`;

--- a/packages/realm-server/tests/server-endpoints/archive-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/archive-realm-test.ts
@@ -3,8 +3,11 @@ const { module, test } = QUnit;
 import { basename } from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import {
+  archiveRealm,
   insertPermissions,
   isRealmArchived,
+  param,
+  query,
   type RealmPermissions,
 } from '@cardstack/runtime-common';
 import { realmSecretSeed } from '../helpers/index.ts';
@@ -219,6 +222,215 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
         await isRealmArchived(context.dbAdapter, new URL(publishedRealmURL)),
         'published realm is not archived',
       );
+    });
+  });
+
+  module('GET /_archived-realms', function (hooks) {
+    let context = setupServerEndpointsTest(hooks);
+
+    function makeRealmURL() {
+      return `${testRealmURL.origin}/archived-${uuidv4()}/`;
+    }
+
+    // Seed an archived realm owned by `owner`: a realm_registry row, its
+    // permissions, and the archive flag.
+    async function seedArchivedRealm(
+      realmURL: string,
+      owner: string,
+      extraPermissions: RealmPermissions = {},
+    ) {
+      await insertSourceRealmInRegistry(context.dbAdapter, {
+        url: realmURL,
+        diskId: uuidv4(),
+        ownerUsername: owner,
+      });
+      await insertPermissions(context.dbAdapter, new URL(realmURL), {
+        [owner]: ['read', 'write', 'realm-owner'],
+        ...extraPermissions,
+      });
+      await archiveRealm(context.dbAdapter, new URL(realmURL));
+    }
+
+    // Insert an indexed RealmConfig card (at `<realmURL>realm`) so the
+    // endpoint can read display metadata the way it does for a real realm.
+    async function seedRealmConfigInIndex(
+      realmURL: string,
+      attributes: {
+        name?: string;
+        iconURL?: string | null;
+        backgroundURL?: string | null;
+      },
+    ) {
+      let configURL = `${realmURL}realm`;
+      let pristineDoc = {
+        id: configURL,
+        type: 'card',
+        attributes: {
+          cardInfo: attributes.name ? { name: attributes.name } : {},
+          ...(attributes.iconURL !== undefined
+            ? { iconURL: attributes.iconURL }
+            : {}),
+          ...(attributes.backgroundURL !== undefined
+            ? { backgroundURL: attributes.backgroundURL }
+            : {}),
+        },
+      };
+      await query(context.dbAdapter, [
+        `INSERT INTO boxel_index (url, file_alias, realm_url, realm_version, type, pristine_doc, search_doc, deps, types, is_deleted, has_error, indexed_at) VALUES (`,
+        param(configURL),
+        `,`,
+        param(configURL),
+        `,`,
+        param(realmURL),
+        `,`,
+        param(1),
+        `,`,
+        param('instance'),
+        `,`,
+        param(JSON.stringify(pristineDoc)),
+        `::jsonb,`,
+        param(JSON.stringify({})),
+        `::jsonb,`,
+        `'[]'::jsonb,`,
+        `'[]'::jsonb,`,
+        param(false),
+        `,`,
+        param(false),
+        `,`,
+        param(Date.now()),
+        `)`,
+      ]);
+    }
+
+    function findEntry(body: any, realmURL: string) {
+      return (body.data as any[]).find((d) => d.id === realmURL);
+    }
+
+    test("returns the caller's archived realms with display metadata", async function (assert) {
+      const owner = '@archive-owner:localhost';
+      const realmURL = makeRealmURL();
+      await seedArchivedRealm(realmURL, owner);
+      await seedRealmConfigInIndex(realmURL, {
+        name: 'My Archived Workspace',
+        iconURL: 'https://example.com/icon.png',
+        backgroundURL: 'https://example.com/bg.jpg',
+      });
+
+      let response = await context.request
+        .get('/_archived-realms')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Authorization', authHeader(owner));
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let entry = findEntry(response.body, realmURL);
+      assert.ok(entry, 'the archived realm is present');
+      assert.strictEqual(entry.type, 'realm');
+      assert.strictEqual(
+        entry.attributes.name,
+        'My Archived Workspace',
+        'name comes from the indexed RealmConfig',
+      );
+      assert.strictEqual(
+        entry.attributes.iconURL,
+        'https://example.com/icon.png',
+        'iconURL comes from the indexed RealmConfig',
+      );
+      assert.strictEqual(
+        entry.attributes.backgroundURL,
+        'https://example.com/bg.jpg',
+        'backgroundURL comes from the indexed RealmConfig',
+      );
+      assert.ok(
+        entry.attributes.archivedAt,
+        'archivedAt timestamp is included',
+      );
+    });
+
+    test('does not leak archived realms the caller does not own', async function (assert) {
+      const owner = '@archive-owner:localhost';
+      const otherOwner = '@other-owner:localhost';
+      const ownedURL = makeRealmURL();
+      const otherURL = makeRealmURL();
+      await seedArchivedRealm(ownedURL, owner);
+      // owner can read otherURL but is not its owner
+      await seedArchivedRealm(otherURL, otherOwner, {
+        [owner]: ['read'],
+      });
+
+      let response = await context.request
+        .get('/_archived-realms')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Authorization', authHeader(owner));
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.ok(findEntry(response.body, ownedURL), 'owned realm is present');
+      assert.notOk(
+        findEntry(response.body, otherURL),
+        "another owner's archived realm is not leaked",
+      );
+    });
+
+    test("excludes the caller's non-archived realms", async function (assert) {
+      const owner = '@archive-owner:localhost';
+      const archivedURL = makeRealmURL();
+      const activeURL = makeRealmURL();
+      await seedArchivedRealm(archivedURL, owner);
+      // An owned but never-archived realm.
+      await insertSourceRealmInRegistry(context.dbAdapter, {
+        url: activeURL,
+        diskId: uuidv4(),
+        ownerUsername: owner,
+      });
+      await insertPermissions(context.dbAdapter, new URL(activeURL), {
+        [owner]: ['read', 'write', 'realm-owner'],
+      });
+
+      let response = await context.request
+        .get('/_archived-realms')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Authorization', authHeader(owner));
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.ok(
+        findEntry(response.body, archivedURL),
+        'archived realm is present',
+      );
+      assert.notOk(
+        findEntry(response.body, activeURL),
+        'active (non-archived) realm is excluded',
+      );
+    });
+
+    test('falls back to a URL-derived name when no RealmConfig is indexed', async function (assert) {
+      const owner = '@archive-owner:localhost';
+      const realmURL = `${testRealmURL.origin}/no-config-realm/`;
+      await seedArchivedRealm(realmURL, owner);
+
+      let response = await context.request
+        .get('/_archived-realms')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Authorization', authHeader(owner));
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let entry = findEntry(response.body, realmURL);
+      assert.ok(entry, 'the archived realm is present');
+      assert.strictEqual(
+        entry.attributes.name,
+        'no-config-realm',
+        'name falls back to the last URL path segment',
+      );
+    });
+
+    test('returns an empty list when the caller has no archived realms', async function (assert) {
+      const owner = '@no-archives-owner:localhost';
+
+      let response = await context.request
+        .get('/_archived-realms')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Authorization', authHeader(owner));
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.deepEqual(response.body.data, [], 'data is an empty array');
     });
   });
 });

--- a/packages/runtime-common/db-queries/realm-metadata-queries.ts
+++ b/packages/runtime-common/db-queries/realm-metadata-queries.ts
@@ -48,18 +48,24 @@ export async function isRealmArchived(
   return results.length > 0 && results[0].archived_at != null;
 }
 
-// List the URLs of archived realms owned by a user. Joins archived
-// realm_metadata rows to realm_user_permissions where the user holds the
-// realm-owner permission. Published snapshots are excluded: publishing
-// grants the owner realm-owner on the published URL too, so without this
-// filter an archived snapshot would surface as one of the user's
-// workspaces.
+export interface ArchivedRealm {
+  url: string;
+  // The archived_at timestamp as the adapter returns it (ISO-ish string).
+  archivedAt: string;
+}
+
+// List the archived realms owned by a user, most-recently-archived first.
+// Joins archived realm_metadata rows to realm_user_permissions where the
+// user holds the realm-owner permission. Published snapshots are excluded:
+// publishing grants the owner realm-owner on the published URL too, so
+// without this filter an archived snapshot would surface as one of the
+// user's workspaces.
 export async function fetchArchivedRealmsForOwner(
   dbAdapter: DBAdapter,
   username: string,
-): Promise<string[]> {
+): Promise<ArchivedRealm[]> {
   let results = (await query(dbAdapter, [
-    `SELECT rm.url
+    `SELECT rm.url, rm.archived_at
      FROM realm_metadata rm
      INNER JOIN realm_user_permissions rup ON rup.realm_url = rm.url
      WHERE rm.archived_at IS NOT NULL
@@ -70,6 +76,6 @@ export async function fetchArchivedRealmsForOwner(
     // Secondary sort on url keeps ordering deterministic when several realms
     // share an archived_at second (SQLite's CURRENT_TIMESTAMP is 1s-resolution).
     `ORDER BY rm.archived_at DESC, rm.url ASC`,
-  ])) as { url: string }[];
-  return results.map((r) => r.url);
+  ])) as { url: string; archived_at: string }[];
+  return results.map((r) => ({ url: r.url, archivedAt: r.archived_at }));
 }


### PR DESCRIPTION
## What

Adds `GET /_archived-realms`, authenticated as the current user. It returns the archived realms the caller **owns**, with the display metadata the workspace chooser's archived section needs:

```json
{ "data": [
  { "type": "realm", "id": "<realmURL>",
    "attributes": { "archivedAt": "...", "name": "...", "iconURL": "...", "backgroundURL": "..." } }
] }
```

## How

- `fetchArchivedRealmsForOwner` now returns `ArchivedRealm[]` (`{ url, archivedAt }`) instead of bare URLs. It already joins archived `realm_metadata` to `realm_user_permissions` on `realm_owner = true` and excludes published snapshots — so ownership and archived/published filtering live there.
- New handler `handle-archived-realms.ts` reads each realm's name/icon straight from the indexed `RealmConfig` card (`boxel_index` row at `<realmURL>realm`) rather than mounting the realm — archived realms are meant to stay dormant and their index rows persist while archived. Falls back to a URL-derived name + letter icon when a realm has no indexed config.
- Route registered behind `jwtMiddleware`, beside the archive/unarchive POSTs.

## Acceptance criteria

- [x] Returns only archived realms the caller owns.
- [x] Does not leak archived realms the caller doesn't own.
- [x] Includes the metadata needed to render the chooser's archived section.

## Testing

- `ember-tsc` type-check + eslint clean (realm-server, runtime-common).
- `queries-test.ts` — helper change, real Postgres: 9/9.
- `server-endpoints/archive-realm-test.ts` — new `GET /_archived-realms` module against the full dev stack: 11/11 (metadata from indexed config, non-owner not leaked, non-archived excluded, URL-derived name fallback, empty list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)