### PR TITLE
Fix cta regression

### DIFF
--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -200,7 +200,8 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
               {{on 'click' this.toggleThumbnailEditor}}
               data-test-toggle-thumbnail-editor
             >
-              Change Thumbnail
+              Change
+              {{#unless @hideThemeChooser}}Theme & {{/unless}}Thumbnail
             </Button>
           </div>
         </:label>
@@ -240,10 +241,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
             @icon={{ImageIcon}}
             data-test-field='cardInfo-thumbnailURL'
           >
-            <div
-              class='thumbnail-picker'
-              data-thumbnail-picker-controls
-            >
+            <div class='thumbnail-picker' data-thumbnail-picker-controls>
               <div class='thumbnail-picker-inputs'>
                 <span
                   class='thumbnail-picker-input-slot'

--- a/packages/host/tests/integration/components/card-info-thumbnail-picker-test.gts
+++ b/packages/host/tests/integration/components/card-info-thumbnail-picker-test.gts
@@ -61,7 +61,7 @@ module('Integration | card-info | thumbnail picker edit', function (hooks) {
     };
   }
 
-  test('toggle button reads "Change Thumbnail" and discloses the picker', async function (this: RenderingTestContext, assert) {
+  test('toggle button discloses the picker', async function (this: RenderingTestContext, assert) {
     class Thing extends CardDef {
       static displayName = 'Thing';
     }
@@ -70,13 +70,32 @@ module('Integration | card-info | thumbnail picker edit', function (hooks) {
 
     assert
       .dom('[data-test-toggle-thumbnail-editor]')
-      .hasText('Change Thumbnail');
+      .hasText('Change Theme & Thumbnail');
     assert
       .dom('[data-test-field="cardInfo-thumbnailURL"]')
       .doesNotExist('picker is hidden by default');
 
     await click('[data-test-toggle-thumbnail-editor]');
     assert.dom('[data-test-field="cardInfo-thumbnailURL"]').exists();
+  });
+
+  test('toggle button omits "Theme &" and hides the theme field when the theme chooser is hidden', async function (this: RenderingTestContext, assert) {
+    class Thing extends CardDef {
+      static displayName = 'Thing';
+      @field cssVariables = contains(StringField);
+    }
+    let instance = new Thing({ cardInfo: new CardInfoField({ name: 'x' }) });
+    await renderCard(loader, instance, 'edit');
+
+    assert
+      .dom('[data-test-toggle-thumbnail-editor]')
+      .hasText('Change Thumbnail');
+
+    await click('[data-test-toggle-thumbnail-editor]');
+    assert.dom('[data-test-field="cardInfo-thumbnailURL"]').exists();
+    assert
+      .dom('[data-test-field="cardInfo-theme"]')
+      .doesNotExist('theme field is hidden when the theme chooser is hidden');
   });
 
   test('renders url input and Select Image button when no value is set', async function (this: RenderingTestContext, assert) {


### PR DESCRIPTION
The card info thumbnail CTA should read "Change Theme & Thumbnail" unless it's a theme card (then it will read "Change Thumbnail").