### PR TITLE
Eagerly bundle yaml into the host test build so a dropped chunk fetch can't wedge rendering

### DIFF
--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -12,12 +12,27 @@ import {
 } from 'ember-qunit';
 import window from 'ember-window-mock';
 import { setupWindowMock } from 'ember-window-mock/test-support';
+import * as yaml from 'yaml';
 
 import { clearHtmlComponentCache } from '@cardstack/host/lib/html-component';
 import type ResetService from '@cardstack/host/services/reset';
 import { AiAssistantOpen } from '@cardstack/host/utils/local-storage-keys';
 
 import { cleanupMonacoEditorModels } from './index';
+
+// Pin `yaml` into the eager test bundle. `markdown-file-def` parses frontmatter
+// with it, but the app shims `yaml` lazily (see `externals.ts`) so web users
+// who never render markdown frontmatter don't download it. Under test that lazy
+// `import('yaml')` is a per-render chunk fetch, and a single transient failure
+// is cached by the engine as a permanent module rejection (only a page reload
+// clears it), wedging every later render in the page. Importing it eagerly here
+// — `setup.ts` loads at test-bundle boot — means the chunk is already resolved,
+// so the app's lazy `import('yaml')` returns it without a fetch in tests; the
+// app's lazy shim is untouched. The `parse` reference keeps the bundler from
+// tree-shaking this import away (and asserts the module actually bundled).
+if (typeof yaml.parse !== 'function') {
+  throw new Error('expected `yaml` to be bundled into the host test build');
+}
 
 // Map of fetch calls currently in flight, keyed by a globally-unique per-call
 // id so overlapping identical requests each occupy their own slot, and so a

--- a/packages/realm-server/tests/package-shim-handler-test.ts
+++ b/packages/realm-server/tests/package-shim-handler-test.ts
@@ -99,5 +99,14 @@ module(basename(import.meta.filename), function () {
     test('shimAsyncModule returns null from handle() when the resolver throws permanently', async function (assert) {
       await runSharedTest(packageShimHandlerTests, assert, {});
     });
+    test('describeShimError surfaces the transient signature from an Error message', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('describeShimError appends a Node socket error code when present', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
+    test('describeShimError handles non-Error values without throwing', async function (assert) {
+      await runSharedTest(packageShimHandlerTests, assert, {});
+    });
   });
 });

--- a/packages/runtime-common/package-shim-handler.ts
+++ b/packages/runtime-common/package-shim-handler.ts
@@ -298,6 +298,36 @@ export interface ShimRetryDeps {
 const defaultDelay = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+// Render an unknown thrown value as one readable line for logs. Shim
+// resolvers compile to runtime `import()` calls whose chunk-fetch
+// failures carry the diagnostic signature ("Failed to fetch dynamically
+// imported module", a Chrome `ERR_*` string, an HTTP 50x) in the Error
+// `message`. Captured browser logs render a raw Error passed as a
+// trailing console argument as "[object Object]" and drop that signature,
+// so the message is interpolated into the log string here instead.
+export function describeShimError(err: unknown): string {
+  if (err instanceof Error) {
+    let code = (err as { code?: unknown }).code;
+    let codeSuffix =
+      typeof code === 'string' || typeof code === 'number'
+        ? ` (code ${code})`
+        : '';
+    return `${err.name}: ${err.message}${codeSuffix}`;
+  }
+  if (typeof err === 'string') {
+    return err;
+  }
+  // `JSON.stringify` returns `undefined` (not a string) for `undefined`,
+  // functions, and symbols, and throws on a bigint or a circular object.
+  // Fall back to `String(err)` in both cases so this always returns a
+  // string, honoring the declared return type for any thrown value.
+  try {
+    return JSON.stringify(err) ?? String(err);
+  } catch {
+    return String(err);
+  }
+}
+
 // Minimal logging surface used by `withResolveRetry`. Narrower than
 // `ReturnType<typeof logger>` so tests can pass a no-op stub without
 // having to construct a full `loglevel` instance — the production
@@ -339,15 +369,13 @@ export function withResolveRetry<TArgs extends unknown[], TResult>(
           // error or a missing module wastes the budget and delays
           // the error surfacing to the operator.
           log.debug(
-            `shim resolver for ${label} failed with non-retryable error; not retrying`,
-            err,
+            `shim resolver for ${label} failed with non-retryable error; not retrying: ${describeShimError(err)}`,
           );
           break;
         }
         let waitMs = delaysMs[attempt];
         log.warn(
-          `shim resolver for ${label} failed on attempt ${attempt + 1}/${totalAttempts}; retrying in ${waitMs}ms`,
-          err,
+          `shim resolver for ${label} failed on attempt ${attempt + 1}/${totalAttempts}; retrying in ${waitMs}ms: ${describeShimError(err)}`,
         );
         await delay(waitMs);
       }
@@ -403,7 +431,7 @@ export class PackageShimHandler {
         return null;
       } catch (err: any) {
         this.log.error(
-          `PackageShimHandler#handle threw an error handling ${request.url}`,
+          `PackageShimHandler#handle threw an error handling ${request.url}: ${describeShimError(err)}`,
           err,
         );
         return null;

--- a/packages/runtime-common/tests/package-shim-handler-test.ts
+++ b/packages/runtime-common/tests/package-shim-handler-test.ts
@@ -6,6 +6,7 @@ import {
   wrapWithStrictNamespace,
   isRetryableShimResolveError,
   withResolveRetry,
+  describeShimError,
   type ShimRetryLogger,
 } from '../package-shim-handler.ts';
 
@@ -657,6 +658,68 @@ const tests: SharedTests<Record<string, never>> = Object.freeze({
         'handler returns null after all retries failed (existing contract preserved)',
       );
     },
+
+  'describeShimError surfaces the transient signature from an Error message':
+    async (assert) => {
+      let described = describeShimError(
+        new TypeError(
+          'Failed to fetch dynamically imported module: https://packages/yaml',
+        ),
+      );
+      assert.true(
+        described.includes('Failed to fetch dynamically imported module'),
+        'the chunk-fetch signature is interpolated into the string (not hidden as "[object Object]")',
+      );
+      assert.true(
+        described.includes('TypeError'),
+        'the error name is included',
+      );
+    },
+
+  'describeShimError appends a Node socket error code when present': async (
+    assert,
+  ) => {
+    let err = Object.assign(new Error('connect failed'), {
+      code: 'ECONNRESET',
+    });
+    assert.strictEqual(
+      describeShimError(err),
+      'Error: connect failed (code ECONNRESET)',
+      'err.code is appended so socket/DNS failures are identifiable',
+    );
+  },
+
+  'describeShimError handles non-Error values without throwing': async (
+    assert,
+  ) => {
+    assert.strictEqual(
+      describeShimError('plain string failure'),
+      'plain string failure',
+      'a thrown string is returned verbatim',
+    );
+    assert.strictEqual(
+      describeShimError({ status: 503 }),
+      '{"status":503}',
+      'a plain object is JSON-serialized',
+    );
+    // Values where `JSON.stringify` returns `undefined` (or throws) must
+    // still produce a string, since the return type is `string`.
+    assert.strictEqual(
+      typeof describeShimError(undefined),
+      'string',
+      'a thrown `undefined` still yields a string, not `undefined`',
+    );
+    assert.strictEqual(
+      typeof describeShimError(() => {}),
+      'string',
+      'a thrown function still yields a string',
+    );
+    assert.strictEqual(
+      typeof describeShimError(10n),
+      'string',
+      'a bigint (which JSON.stringify throws on) still yields a string',
+    );
+  },
 });
 
 export default tests;


### PR DESCRIPTION
The `Integration | field markdown domain` host tests can fail as a whole group with `unable to fetch https://packages/yaml: fetch failed`. The same failure can wedge any test that renders a skill or a `.md` file.

## Root cause

`markdown-file-def` parses frontmatter with `yaml` (`markdown-file-def → frontmatter-parse → import { parse } from 'yaml'`), so `yaml` loads whenever a markdown file or skill is rendered. The app shims `yaml` **lazily** (`externals.ts`) on purpose — most web users never touch markdown frontmatter, so they shouldn't download it — which means that lazy `import('yaml')` is a runtime chunk fetch.

When that chunk fetch hits a transient error (we see Chrome `ERR_NETWORK_CHANGED` on a sibling dynamic chunk in the same CI run), the JS engine **caches the rejected module promise**: native dynamic imports never re-fetch after a failure, and a page reload is the only recovery. So a single dropped fetch is sticky — the first `import('yaml')` fails and every subsequent render in the page fails the same way. That is how one transient blip becomes a whole shard of red. (The in-process resolver retry can't help, because re-calling `import('yaml')` just returns the cached rejection.)

## Fix

This only bites under test, so **keep `yaml` lazy in the app** and statically import it from the shared test setup (`setup.ts`, which loads at test-bundle boot). By ESM module-singleton semantics the module is already evaluated by the time the app's lazy `import('yaml')` runs, so it resolves from the module map with no fetch. Production has no static import of `yaml`, so it stays a lazy chunk — web users who never render markdown frontmatter still don't pay for it.

This is pure bundling: it touches no services and adds no per-test hook, so it can't perturb the service-instantiation order that test-specific stubs depend on.

## Also: make shim-resolver failures diagnosable

`PackageShimHandler` logged thrown resolver errors as a trailing console argument, which captured browser logs render as `[object Object]` — hiding both the cause and the chunk-fetch signature. `describeShimError` interpolates the real message (name, message, and any `err.code`) into the log line, so future failures are diagnosable and the remaining async shims' (`ethers`/`uuid`/`marked-sync`) transient failures are recognizable in logs.

## Tests

- New `describeShimError` cases in the shared `package-shim-handler` suite (Error-with-signature, `err.code` append, and non-Error inputs incl. `undefined`/function/bigint, which must still return a string).
