### PR TITLE
Stop best-effort realm-info background loads from leaking unhandled rejections

### DIFF
--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -943,7 +943,11 @@ export default class RealmService extends Service {
       return;
     }
     log.warn(`background realm-info ${op} failed for ${url}: ${error}`);
-    if (isTesting()) {
+    // The `fetchInfo` path already surfaces a test-time `[realm-service] realm
+    // info fetch …` warning from fetchInfoFromServer(); only the identify HEAD
+    // has no such diagnostic, so scope the extra test-time warning to it rather
+    // than logging the `fetchInfo` failure twice.
+    if (isTesting() && op === 'identify') {
       console.warn(
         `[realm-service] background realm-info load failed ${JSON.stringify({
           realmURL: url,

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -881,7 +881,11 @@ export default class RealmService extends Service {
     }
     let resource = this.knownRealm(url, { tracked: false });
     if (!resource) {
-      this.identifyRealm.perform(url);
+      this.identifyRealm
+        .perform(url)
+        .catch((error: unknown) =>
+          this.swallowBackgroundInfoError(url, 'identify', error),
+        );
 
       this.identifyRealmTracker;
 
@@ -899,7 +903,11 @@ export default class RealmService extends Service {
     }
 
     if (!resource.info) {
-      resource.fetchInfo();
+      resource
+        .fetchInfo()
+        .catch((error: unknown) =>
+          this.swallowBackgroundInfoError(url, 'fetchInfo', error),
+        );
       return {
         name: UNKNOWN_REALM_NAME,
         backgroundURL: null,
@@ -915,6 +923,36 @@ export default class RealmService extends Service {
       return resource.info;
     }
   };
+
+  // `info()` returns a placeholder synchronously and kicks off a background
+  // load — a realm-identifying HEAD, or an `_info` fetch — to fill in the real
+  // values on a later render. Those loads are best-effort: they can reject when
+  // the realm isn't reachable (a transient network failure, or — in tests — an
+  // in-process realm whose VirtualNetwork handler isn't mounted yet, so the
+  // request escapes to the network and rejects with `TypeError: Failed to
+  // fetch`). Since nothing awaits them, an unhandled rejection would surface as
+  // a global error and fail whatever happens to be running, so it is swallowed
+  // here; the placeholder stays and a later render retries. Cancellations
+  // (component unmount / teardown) are expected and stay silent.
+  private swallowBackgroundInfoError(
+    url: string,
+    op: 'identify' | 'fetchInfo',
+    error: unknown,
+  ) {
+    if (didCancel(error)) {
+      return;
+    }
+    log.warn(`background realm-info ${op} failed for ${url}: ${error}`);
+    if (isTesting()) {
+      console.warn(
+        `[realm-service] background realm-info load failed ${JSON.stringify({
+          realmURL: url,
+          op,
+          error: String(error),
+        })}`,
+      );
+    }
+  }
 
   async allUsersPermissions(url: string) {
     if (this.network.virtualNetwork.isRegisteredPrefix(url)) {

--- a/packages/host/tests/integration/services/realm-service-info-test.gts
+++ b/packages/host/tests/integration/services/realm-service-info-test.gts
@@ -1,0 +1,65 @@
+import { settled } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import { baseRealm } from '@cardstack/runtime-common';
+
+import { UNKNOWN_REALM_NAME } from '@cardstack/host/services/realm';
+import type RealmService from '@cardstack/host/services/realm';
+
+import { setupLocalIndexing, testRealmURL } from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+module('Integration | services | realm-service info()', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+  setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [baseRealm.url, testRealmURL],
+    autostart: true,
+  });
+
+  test('a failed background load is swallowed, not leaked as an unhandled rejection', async function (assert) {
+    let leaked: unknown[] = [];
+    let onRejection = (event: PromiseRejectionEvent) => {
+      leaked.push(event.reason);
+      // Keep the harness's own unhandledrejection guard from failing the test
+      // on the very rejection we are asserting is handled; the captured list is
+      // the real assertion.
+      event.preventDefault();
+    };
+    window.addEventListener('unhandledrejection', onRejection);
+    try {
+      let realm = getService('realm') as RealmService;
+
+      // A realm under the mocked realm-server origin (http://test-realm) that
+      // was never registered as an in-process realm: every request for it
+      // misses the VirtualNetwork handlers and escapes to the real network,
+      // where nothing listens, so info()'s background realm-identifying HEAD
+      // rejects with `TypeError: Failed to fetch`. info() must return the
+      // placeholder synchronously and absorb that rejection — a leak here would
+      // surface as a global error and red whatever test happens to be running.
+      let info = realm.info('http://test-realm/never-registered/');
+      assert.strictEqual(
+        info.name,
+        UNKNOWN_REALM_NAME,
+        'info() returns the placeholder synchronously while the load runs',
+      );
+
+      await settled();
+    } finally {
+      window.removeEventListener('unhandledrejection', onRejection);
+    }
+
+    assert.deepEqual(
+      leaked,
+      [],
+      'the failed background realm-info load did not escape as an unhandled rejection',
+    );
+  });
+});


### PR DESCRIPTION
## What

`RealmService.info()` is a synchronous accessor used during render: it returns a placeholder (`Unknown Workspace`) immediately and kicks off a background load — a realm-identifying `HEAD` (`identifyRealm`) or an `_info` fetch (`fetchInfo`) — to fill in the real values on a later render.

Both background loads were fired without `await` and without a `catch`, so a rejected load surfaced as an **unhandled rejection** and failed whatever happened to be running. In CI this lands as a `Global error: Uncaught TypeError: Failed to fetch` attributed to an unrelated test that simply happened to be executing at the time.

This change attaches a `catch` at both call sites. A failure is swallowed (the placeholder stays and a later render retries) and cancellations stay silent — mirroring the `didCancel` handling already in `fetchInfo()`. The handler logs which realm and which operation failed: via the service logger normally, and as a `console.warn` under test so the next occurrence is diagnosable.

## Why it shows up in host tests

`info()` is reached for a realm that isn't known yet. In host integration tests that realm is the in-process test realm (`http://test-realm/test/`), served by a `VirtualNetwork` handler that is mounted during per-test setup. When `info()` runs before that handler is mounted, the `HEAD`/`_info` request misses every handler and escapes to the real network, where `http://test-realm` has no listener and the fetch rejects with `TypeError: Failed to fetch`. The placeholder path is the same one the existing `result-section: rendering with placeholder realm name … realm.info() returned "Unknown Workspace"` diagnostic warns about.

This complements the earlier change that kept the realm-server *mock's* own resolvers from fetching in-process realm URLs; that left the *app's* fire-and-forget `info()` loads as the remaining way the same URL could escape.

## Verification

- `ember-tsc` type-check, ESLint, and Prettier all pass on the change.
- The fix is additive — it only converts a previously-uncaught rejection into a swallowed-and-logged one — so it cannot alter any passing test's success path. The triggering race is load-dependent and does not reproduce reliably on a single machine; the added `console.warn` is the insurance that pins it if it recurs.

Reported flaky job: https://github.com/cardstack/boxel/actions/runs/28456884448/job/84334947516 (shard 18, `Integration | mini-card-chooser: typing in the search input renders matching results from the realm`).
