### PR TITLE
Cut over indexing to searchable-driven search-doc generation

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -4520,15 +4520,6 @@ export function setCardAsSavedForTest(instance: CardDef, id?: string): void {
   instance[isSavedInstance] = true;
 }
 
-export function searchDoc<CardT extends BaseDefConstructor>(
-  instance: InstanceType<CardT>,
-): Record<string, any> {
-  return getQueryableValue(instance.constructor, instance) as Record<
-    string,
-    any
-  >;
-}
-
 function makeDescriptor<
   CardT extends BaseDefConstructor,
   FieldT extends BaseDefConstructor,

--- a/packages/base/searchable.ts
+++ b/packages/base/searchable.ts
@@ -43,6 +43,12 @@ import {
 // non-queryable polymorphic-subtype bloat.
 export async function searchDocFromFields(
   instance: CardDef,
+  // Collects the URLs of the link targets pulled into the doc. The indexer
+  // unions these into the card's tracked dependencies: an expanded target's
+  // data lives in the search doc, so editing that target must reindex the
+  // owner — whether or not the render happened to load it (a `{ id }`-only link
+  // contributes none, since its target's data is not in the doc).
+  dependencies: Set<string> = new Set(),
 ): Promise<Record<string, any>> {
   let routes = seedSearchableRoutes(
     instance.constructor as unknown as typeof BaseDef,
@@ -53,6 +59,7 @@ export async function searchDocFromFields(
     routes,
     [],
     getStore(instance),
+    dependencies,
   )) as Record<string, any>;
 }
 
@@ -160,6 +167,7 @@ async function searchableQueryableValue(
   // contained FieldDef value may not be store-associated, but its nested links
   // must still load against the owner's store.
   store: CardStore,
+  dependencies: Set<string>,
 ): Promise<any> {
   if (primitive in fieldCard) {
     // Delegate to the field's own queryableValue. The default handles
@@ -223,6 +231,7 @@ async function searchableQueryableValue(
             tails,
             nextStack,
             store,
+            dependencies,
           ),
         ]);
         break;
@@ -246,6 +255,7 @@ async function searchableQueryableValue(
             tails,
             nextStack,
             store,
+            dependencies,
           );
           if (v != null) {
             items.push(v);
@@ -265,6 +275,7 @@ async function searchableQueryableValue(
             nextStack,
             store,
             makeAbsoluteURL,
+            dependencies,
           ),
         ]);
         break;
@@ -280,6 +291,7 @@ async function searchableQueryableValue(
             nextStack,
             store,
             makeAbsoluteURL,
+            dependencies,
           ),
         ]);
         break;
@@ -300,6 +312,7 @@ async function searchableLink(
   stack: BaseDef[],
   store: CardStore,
   makeAbsoluteURL: (reference: string) => string,
+  dependencies: Set<string>,
 ): Promise<any> {
   if (rawValue == null) {
     return null;
@@ -330,12 +343,18 @@ async function searchableLink(
     }
     target = loaded;
   }
+  // The expanded target's data is now in the doc, so it is a dependency of the
+  // indexed card.
+  if (target.id != null) {
+    dependencies.add(makeAbsoluteURL(target.id));
+  }
   return await searchableQueryableValue(
     field.card,
     target,
     tails,
     stack,
     store,
+    dependencies,
   );
 }
 
@@ -349,6 +368,7 @@ async function searchableLinksToMany(
   stack: BaseDef[],
   store: CardStore,
   makeAbsoluteURL: (reference: string) => string,
+  dependencies: Set<string>,
 ): Promise<any[] | null> {
   // A whole-field sentinel (errored/unresolved plural) is not iterable; treat
   // as empty, same as `LinksToMany.queryableValue`.
@@ -383,12 +403,18 @@ async function searchableLinksToMany(
       }
       target = loaded;
     }
+    // The expanded target's data is now in the doc, so it is a dependency of
+    // the indexed card.
+    if (target.id != null) {
+      dependencies.add(makeAbsoluteURL(target.id));
+    }
     let expanded = await searchableQueryableValue(
       field.card,
       target,
       tails,
       stack,
       store,
+      dependencies,
     );
     if (expanded != null) {
       out.push(

--- a/packages/base/searchable.ts
+++ b/packages/base/searchable.ts
@@ -1,14 +1,8 @@
 import { rawArrayValues } from './watched-array';
 import { isSavedInstance } from './-private';
+import { isCardError, primitive, relativeTo } from '@cardstack/runtime-common';
 import {
-  assertIsSerializerName,
-  fieldSerializer,
-  getSerializer,
-  isCardError,
-  primitive,
-  relativeTo,
-} from '@cardstack/runtime-common';
-import {
+  getDataBucket,
   getFields,
   isLinkError,
   isLinkNotFound,
@@ -19,6 +13,7 @@ import {
 import {
   createFromSerialized,
   getStore,
+  queryableValue,
   resolveRef,
   type BaseDef,
   type BaseDefConstructor,
@@ -167,14 +162,15 @@ async function searchableQueryableValue(
   store: CardStore,
 ): Promise<any> {
   if (primitive in fieldCard) {
-    if (fieldSerializer in fieldCard) {
-      assertIsSerializerName((fieldCard as any)[fieldSerializer]);
-      return getSerializer((fieldCard as any)[fieldSerializer]).queryableValue(
-        value,
-        stack,
-      );
-    }
-    return value;
+    // Delegate to the field's own queryableValue. The default handles
+    // serializer-backed primitives; a primitive FieldDef may override it to
+    // shape its indexed form — e.g. JsonField returns null to stay out of the
+    // search index. Reimplementing only the default here would drop that.
+    return (
+      fieldCard as unknown as {
+        [queryableValue](value: any, stack: BaseDef[]): any;
+      }
+    )[queryableValue](value, stack);
   }
   if (value == null) {
     return null;
@@ -202,7 +198,21 @@ async function searchableQueryableValue(
       continue;
     }
     let { matched, tails } = matchSearchableRoutes(routes, fieldName);
-    let rawValue = peekAtField(value, fieldName);
+    // Search-doc generation is a pure read: reading a declared relationship
+    // through the getter writes `emptyValue` into the data bucket, which marks
+    // an otherwise-unset link "used" and pulls it into the owner card's
+    // serialized relationships. So peek a declared link only when it is already
+    // materialized; an unmaterialized link holds no target and contributes
+    // `null` either way. Contained values and computed fields read normally —
+    // the getter's empty-value write is harmless for the former and absent for
+    // the latter.
+    let isDeclaredLink =
+      (field!.fieldType === 'linksTo' || field!.fieldType === 'linksToMany') &&
+      !field!.computeVia;
+    let rawValue =
+      isDeclaredLink && !getDataBucket(value).has(fieldName)
+        ? null
+        : peekAtField(value, fieldName);
     switch (field!.fieldType) {
       case 'contains': {
         entries.push([

--- a/packages/base/searchable.ts
+++ b/packages/base/searchable.ts
@@ -23,13 +23,12 @@ import {
 } from './card-api';
 
 // ============================================================================
-// Searchable-driven search-doc generation — NON-AUTHORITATIVE.
+// Searchable-driven search-doc generation.
 //
-// Parallel to `searchDoc` (in card-api), which stays in charge of production
-// indexing. This path derives link depth from the explicit `field.searchable`
-// annotation instead of from what the render happened to load into the store,
-// and loads the named link targets itself (targeted loading) rather than
-// relying on render-driven store residency.
+// The authoritative search-doc generator: it derives link depth from the
+// explicit `field.searchable` annotation rather than from what the render
+// happened to load into the store, and loads the named link targets itself
+// (targeted loading) rather than relying on render-driven store residency.
 //
 // Routes are dotted paths rooted at the CURRENT card's link fields. Depth is
 // governed ENTIRELY by the `searchable` annotations on the card being indexed
@@ -37,10 +36,9 @@ import {
 // re-consult its own `searchable` — only the explicit route continues into it.
 // `true` => the immediate ("self") link; `'a.b'` => the n+1 route a→b; an array
 // combines routes. Cycle clipping, `{ id }` for unfollowed / broken / not-found
-// links, and `linksToMany` id normalization are preserved from
-// `BaseDef[queryableValue]`. The declared field type is enumerated for both
-// links and contained values (not the runtime subtype), which drops the
-// non-queryable polymorphic-subtype bloat.
+// links, and `linksToMany` id normalization match `BaseDef[queryableValue]`. The
+// declared field type is enumerated for both links and contained values (not the
+// runtime subtype), which drops non-queryable polymorphic-subtype bloat.
 export async function searchDocFromFields(
   instance: CardDef,
   // Collects the URLs of the link targets pulled into the doc. The indexer
@@ -125,8 +123,9 @@ function matchSearchableRoutes(
 
 // Targeted load of a link target by reference: reuse a fully-deserialized
 // resident instance when present, else load + deserialize the document (the
-// same load path the lazy link getter uses, sans dependency tracking — this
-// generator is non-authoritative). Returns undefined if the target errors.
+// same load path the lazy link getter uses). The store load is not itself
+// dependency-tracked; callers record each expanded target in the `dependencies`
+// set instead. Returns undefined if the target errors.
 async function loadSearchableTarget(
   store: CardStore,
   reference: string,
@@ -200,8 +199,8 @@ async function searchableQueryableValue(
   for (let [fieldName, field] of Object.entries(
     getFields(fieldCard, { includeComputeds: true }),
   )) {
-    // Query-backed relationships can't be invalidated, so they're never in the
-    // doc — same skip as the store-driven path.
+    // Query-backed relationships can't be invalidated, so their value would
+    // always be stale; they are omitted from the doc, matching `queryableValue`.
     if (field?.queryDefinition) {
       continue;
     }
@@ -358,8 +357,8 @@ async function searchableLink(
   );
 }
 
-// A `linksToMany` value: per-slot `{ id }` / expansion, with the same
-// absolute-URL id normalization the store-driven path applies.
+// A `linksToMany` value: per-slot `{ id }` / expansion, with the absolute-URL
+// id normalization `LinksToMany.queryableValue` applies.
 async function searchableLinksToMany(
   field: Field<BaseDefConstructor>,
   rawValue: any,

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -63,32 +63,36 @@ export default class RenderMetaRoute extends Route<Model> {
       renderModel?.capturedDeps ??
       snapshotRuntimeDependencies({ excludeQueryOnly: true }).deps;
 
-    // Open a synchronous compute-memo pass that spans both
-    // serializeCard and searchDoc. Computed fields invoked through the
-    // descriptor or through peekAtField hit the per-instance memo
-    // instead of re-running `computeVia` — one compute per distinct
-    // (instance, fieldName) for the whole traversal. The pass MUST
-    // close before any await so it doesn't leak across reactive cycles.
+    // The search doc comes from the searchable-driven generator, which lives in
+    // its own base module (off card-api, so it stays out of every card's
+    // dependency closure). It derives link depth from the explicit `searchable`
+    // annotations rather than from what the render happened to load.
+    let searchable = await this.cardService.getSearchable();
+
+    // Open a synchronous compute-memo pass over serializeCard. Computed fields
+    // invoked through the descriptor or through peekAtField hit the per-instance
+    // memo instead of re-running `computeVia` — one compute per distinct
+    // (instance, fieldName). The pass MUST close before any await so it doesn't
+    // leak across reactive cycles; searchable-driven generation does targeted
+    // link loading (async), so it runs after the pass closes — see below.
     //
     // Guarded by typeof checks: during a cold dev boot the host can briefly
     // load a base/card-api build that predates these exports (vite is still
     // bundling, or a stale realm-transpile is in flight). In that window we
     // skip the pass — `getter` falls through its `passComputeMemo === null`
-    // fast path and the render still produces a correct serialized + search
-    // doc, just without the per-row diagnostics fields.
+    // fast path and the render still produces a correct serialized doc, just
+    // without the per-row diagnostics fields.
     //
-    // Pass close is in a `finally` so a throw inside serializeCard /
-    // searchDoc still closes the pass — otherwise the module-global
-    // memo in field-support.ts stays set and later off-pass `getter`
-    // calls would read stale memoized values across reactive cycles.
+    // Pass close is in a `finally` so a throw inside serializeCard still closes
+    // the pass — otherwise the module-global memo in field-support.ts stays set
+    // and later off-pass `getter` calls would read stale memoized values across
+    // reactive cycles.
     let passOpen = typeof api.beginComputePass === 'function';
     if (passOpen) {
       api.beginComputePass();
     }
     let serialized: SingleCardDocument;
     let serializeMs: number;
-    let searchDoc: Record<string, any>;
-    let searchDocMs: number;
     let passSnapshot: ComputePassSnapshot | undefined;
     try {
       let serializeStart = performance.now();
@@ -116,15 +120,18 @@ export default class RenderMetaRoute extends Route<Model> {
         // we want to emulate the file serialization here
         delete relationship.data;
       }
-
-      let searchDocStart = performance.now();
-      searchDoc = api.searchDoc(instance);
-      searchDocMs = performance.now() - searchDocStart;
     } finally {
       if (passOpen && typeof api.endComputePass === 'function') {
         passSnapshot = api.endComputePass();
       }
     }
+
+    // Run searchable-driven generation after the compute-memo pass closes: it
+    // awaits targeted link loads, and the pass cannot span an await.
+    let searchDocStart = performance.now();
+    let searchDoc: Record<string, any> =
+      await searchable.searchDocFromFields(instance);
+    let searchDocMs = performance.now() - searchDocStart;
 
     let Klass = getClass(instance);
 

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -127,11 +127,21 @@ export default class RenderMetaRoute extends Route<Model> {
     }
 
     // Run searchable-driven generation after the compute-memo pass closes: it
-    // awaits targeted link loads, and the pass cannot span an await.
+    // awaits targeted link loads, and the pass cannot span an await. The
+    // generator collects the URLs of the link targets it pulls into the doc;
+    // those are dependencies of this card (unioned into `deps` below), so
+    // editing a searchable target reindexes the owner even when the render did
+    // not itself load that target.
     let searchDocStart = performance.now();
-    let searchDoc: Record<string, any> =
-      await searchable.searchDocFromFields(instance);
+    let searchableDeps = new Set<string>();
+    let searchDoc: Record<string, any> = await searchable.searchDocFromFields(
+      instance,
+      searchableDeps,
+    );
     let searchDocMs = performance.now() - searchDocStart;
+    if (searchableDeps.size > 0) {
+      deps = [...new Set([...deps, ...searchableDeps])];
+    }
 
     let Klass = getClass(instance);
 

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -26,6 +26,7 @@ import type {
   SerializeOpts,
 } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
+import type * as Searchable from 'https://cardstack.com/base/searchable';
 
 import LimitedSet from '../lib/limited-set';
 
@@ -73,6 +74,13 @@ export default class CardService extends Service {
     Loader,
     Promise<typeof CardAPI>
   >;
+  // The searchable-driven search-doc generator lives in its own base module so
+  // it stays out of every card's dependency closure; cache it per-loader the
+  // same way the card-api module is cached.
+  declare private loaderToSearchableLoadingCache: WeakMap<
+    Loader,
+    Promise<typeof Searchable>
+  >;
   declare clientRequestIds: LimitedSet<string>;
 
   constructor(owner: Owner) {
@@ -93,10 +101,23 @@ export default class CardService extends Service {
     return this.loaderToCardAPILoadingCache.get(loader)!;
   }
 
+  async getSearchable(): Promise<typeof Searchable> {
+    let loader = this.loaderService.loader;
+    if (!this.loaderToSearchableLoadingCache.has(loader)) {
+      let searchablePromise = loader.import<typeof Searchable>(
+        'https://cardstack.com/base/searchable',
+      );
+      this.loaderToSearchableLoadingCache.set(loader, searchablePromise);
+      return searchablePromise;
+    }
+    return this.loaderToSearchableLoadingCache.get(loader)!;
+  }
+
   resetState() {
     this.subscriber = undefined;
     this.clientRequestIds = new LimitedSet(250);
     this.loaderToCardAPILoadingCache = new WeakMap();
+    this.loaderToSearchableLoadingCache = new WeakMap();
     this.sizeLimitError.clear();
   }
 

--- a/packages/host/tests/acceptance/prerender-meta-test.gts
+++ b/packages/host/tests/acceptance/prerender-meta-test.gts
@@ -7,6 +7,7 @@ import { module, test } from 'qunit';
 import {
   baseRealm,
   baseRealmRRI,
+  diffDoc,
   type PrerenderMeta,
   type RenderRouteOptions,
   rri,
@@ -23,6 +24,24 @@ import {
 } from '../helpers';
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupApplicationTest } from '../helpers/setup';
+
+// The prerender meta route generates the search doc via the searchable-driven
+// generator. It is at parity with the store-driven baseline each assertion
+// captured, up to the intended omit-vs-keep-`{ id }` difference for unloaded
+// base-card links (e.g. `cardInfo.theme` / `cardInfo.cardThumbnail`);
+// `diffDoc(..., true)` ignores that at any depth while flagging real data deltas.
+function expectMetaSearchDoc(
+  assert: Assert,
+  actual: Record<string, any> | null | undefined,
+  storeDrivenBaseline: Record<string, any>,
+  message?: string,
+) {
+  assert.deepEqual(
+    diffDoc(storeDrivenBaseline, actual ?? {}, true),
+    [],
+    message ?? 'search doc is at parity with store-driven',
+  );
+}
 
 module('Acceptance | prerender | meta', function (hooks) {
   setupApplicationTest(hooks);
@@ -84,14 +103,16 @@ module('Acceptance | prerender | meta', function (hooks) {
     class Cat extends Pet {
       static displayName = 'Cat';
       @field aliases = containsMany(StringField);
-      @field emergencyContacts = containsMany(EmergencyContact);
+      @field emergencyContacts = containsMany(EmergencyContact, {
+        searchable: 'contact',
+      });
     }
 
     class Person extends CardDef {
       static displayName = 'Person';
       @field name = contains(StringField);
-      @field pets = linksToMany(() => Pet);
-      @field friend = linksTo(() => Person);
+      @field pets = linksToMany(() => Pet, { searchable: true });
+      @field friend = linksTo(() => Person, { searchable: true });
       @field cardTitle = contains(StringField, {
         computeVia(this: Person) {
           return this.name;
@@ -344,7 +365,8 @@ module('Acceptance | prerender | meta', function (hooks) {
     await visit(renderPath(url, '/meta'));
     let { value } = await capturePrerenderResult('textContent');
     let meta: PrerenderMeta = JSON.parse(value);
-    assert.deepEqual(
+    expectMetaSearchDoc(
+      assert,
       meta.searchDoc,
       {
         id: `${testRealmURL}Pet/mango`,
@@ -362,7 +384,8 @@ module('Acceptance | prerender | meta', function (hooks) {
     await visit(renderPath(url, '/meta'));
     let { value } = await capturePrerenderResult('textContent');
     let meta: PrerenderMeta = JSON.parse(value);
-    assert.deepEqual(
+    expectMetaSearchDoc(
+      assert,
       meta.searchDoc,
       {
         id: `${testRealmURL}Pet/paper`,
@@ -384,7 +407,8 @@ module('Acceptance | prerender | meta', function (hooks) {
     await visit(renderPath(url, '/meta'));
     let { value } = await capturePrerenderResult('textContent');
     let meta: PrerenderMeta = JSON.parse(value);
-    assert.deepEqual(
+    expectMetaSearchDoc(
+      assert,
       meta.searchDoc,
       {
         id: `${testRealmURL}Person/jade`,
@@ -427,7 +451,8 @@ module('Acceptance | prerender | meta', function (hooks) {
     await visit(renderPath(url, '/meta'));
     let { value } = await capturePrerenderResult('textContent');
     let meta: PrerenderMeta = JSON.parse(value);
-    assert.deepEqual(
+    expectMetaSearchDoc(
+      assert,
       meta.searchDoc,
       {
         id: `${testRealmURL}Person/hassan`,
@@ -478,7 +503,8 @@ module('Acceptance | prerender | meta', function (hooks) {
     await visit(renderPath(url, '/meta'));
     let { value } = await capturePrerenderResult('textContent');
     let meta: PrerenderMeta = JSON.parse(value);
-    assert.deepEqual(
+    expectMetaSearchDoc(
+      assert,
       meta.searchDoc,
       {
         _cardType: 'Cat',

--- a/packages/host/tests/acceptance/prerender-meta-test.gts
+++ b/packages/host/tests/acceptance/prerender-meta-test.gts
@@ -26,20 +26,21 @@ import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupApplicationTest } from '../helpers/setup';
 
 // The prerender meta route generates the search doc via the searchable-driven
-// generator. It is at parity with the store-driven baseline each assertion
-// captured, up to the intended omit-vs-keep-`{ id }` difference for unloaded
-// base-card links (e.g. `cardInfo.theme` / `cardInfo.cardThumbnail`);
-// `diffDoc(..., true)` ignores that at any depth while flagging real data deltas.
+// generator: every relationship is present (an unset link is `null`, a set one
+// expands per its `searchable` annotation), and every card carries its base-card
+// fields (`cardTheme`, `cardInfo.cardThumbnail`). The expected doc is the exact
+// generator output; `diffDoc(..., false)` reports any deviation as a readable
+// path-level diff.
 function expectMetaSearchDoc(
   assert: Assert,
   actual: Record<string, any> | null | undefined,
-  storeDrivenBaseline: Record<string, any>,
+  expected: Record<string, any>,
   message?: string,
 ) {
   assert.deepEqual(
-    diffDoc(storeDrivenBaseline, actual ?? {}, true),
+    diffDoc(expected, actual ?? {}, false),
     [],
-    message ?? 'search doc is at parity with store-driven',
+    message ?? 'search doc is correct',
   );
 }
 
@@ -371,7 +372,8 @@ module('Acceptance | prerender | meta', function (hooks) {
       {
         id: `${testRealmURL}Pet/mango`,
         _cardType: 'Pet',
-        cardInfo: {},
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
         name: 'Mango',
         cardTitle: 'Mango',
       },
@@ -390,7 +392,8 @@ module('Acceptance | prerender | meta', function (hooks) {
       {
         id: `${testRealmURL}Pet/paper`,
         _cardType: 'Cat',
-        cardInfo: {},
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
         name: 'Paper',
         cardTitle: 'Paper',
         aliases: ['Satan', "Satan's Mistress"],
@@ -413,21 +416,20 @@ module('Acceptance | prerender | meta', function (hooks) {
       {
         id: `${testRealmURL}Person/jade`,
         _cardType: 'Person',
-        cardInfo: {
-          theme: null,
-        },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
         name: 'Jade',
         cardTitle: 'Jade',
         pets: null,
         numOfPets: '0',
         friend: {
           id: `${testRealmURL}Person/hassan`,
-          cardInfo: {
-            theme: null,
-          },
+          cardTheme: null,
+          cardInfo: { cardThumbnail: null, theme: null },
           name: 'Hassan',
           cardTitle: 'Hassan',
           numOfPets: '3',
+          friend: null,
           pets: [
             {
               id: `${testRealmURL}Pet/mango`,
@@ -457,9 +459,8 @@ module('Acceptance | prerender | meta', function (hooks) {
       {
         id: `${testRealmURL}Person/hassan`,
         _cardType: 'Person',
-        cardInfo: {
-          theme: null,
-        },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
         name: 'Hassan',
         cardTitle: 'Hassan',
         friend: null,
@@ -469,27 +470,22 @@ module('Acceptance | prerender | meta', function (hooks) {
             id: `${testRealmURL}Pet/mango`,
             name: 'Mango',
             cardTitle: 'Mango',
-            cardInfo: {
-              theme: null,
-            },
+            cardTheme: null,
+            cardInfo: { cardThumbnail: null, theme: null },
           },
           {
             id: `${testRealmURL}Pet/vangogh`,
             name: 'Van Gogh',
             cardTitle: 'Van Gogh',
-            cardInfo: {
-              theme: null,
-            },
+            cardTheme: null,
+            cardInfo: { cardThumbnail: null, theme: null },
           },
           {
             id: `${testRealmURL}Pet/paper`,
             name: 'Paper',
             cardTitle: 'Paper',
-            aliases: ['Satan', "Satan's Mistress"],
-            emergencyContacts: null,
-            cardInfo: {
-              theme: null,
-            },
+            cardTheme: null,
+            cardInfo: { cardThumbnail: null, theme: null },
           },
         ],
       },
@@ -509,9 +505,8 @@ module('Acceptance | prerender | meta', function (hooks) {
       {
         _cardType: 'Cat',
         aliases: null,
-        cardInfo: {
-          theme: null,
-        },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
         emergencyContacts: [
           {
             phone: '01234',
@@ -521,9 +516,8 @@ module('Acceptance | prerender | meta', function (hooks) {
               cardTitle: 'Jade',
               numOfPets: '0',
               pets: null,
-              cardInfo: {
-                theme: null,
-              },
+              cardTheme: null,
+              cardInfo: { cardThumbnail: null, theme: null },
               friend: {
                 id: `${testRealmURL}Person/hassan`,
               },
@@ -535,10 +529,10 @@ module('Acceptance | prerender | meta', function (hooks) {
               id: `${testRealmURL}Person/hassan`,
               name: 'Hassan',
               cardTitle: 'Hassan',
-              cardInfo: {
-                theme: null,
-              },
+              cardTheme: null,
+              cardInfo: { cardThumbnail: null, theme: null },
               numOfPets: '3',
+              friend: null,
               pets: [
                 {
                   id: `${testRealmURL}Pet/mango`,

--- a/packages/host/tests/helpers/base-realm.ts
+++ b/packages/host/tests/helpers/base-realm.ts
@@ -160,7 +160,6 @@ let createFromSerialized: (typeof CardAPIModule)['createFromSerialized'];
 let updateFromSerialized: (typeof CardAPIModule)['updateFromSerialized'];
 let rawSerializeCard: (typeof CardAPIModule)['serializeCard'];
 let rawSerializeFileDef: (typeof CardAPIModule)['serializeFileDef'];
-let searchDoc: (typeof CardAPIModule)['searchDoc'];
 let searchDocFromFields: (typeof SearchableModule)['searchDocFromFields'];
 
 // Test-side wrappers around the raw card-api serialize functions that
@@ -390,7 +389,6 @@ async function initialize() {
     getBrokenLinks,
     getDataBucket,
     getQueryableValue,
-    searchDoc,
     subscribeToChanges,
     unsubscribeFromChanges,
     flushLogs,
@@ -480,7 +478,6 @@ export {
   getBrokenLinks,
   getDataBucket,
   getQueryableValue,
-  searchDoc,
   searchDocFromFields,
   subscribeToChanges,
   unsubscribeFromChanges,

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -18,6 +18,7 @@ import {
   type LooseSingleCardDocument,
   type IndexedInstance,
   type Realm,
+  diffDoc,
 } from '@cardstack/runtime-common';
 import stripScopedCSSAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-attributes';
 import type { Loader } from '@cardstack/runtime-common/loader';
@@ -82,6 +83,26 @@ function assertInnerHtmlMatches(
   );
   let cleanedExpected = cleanWhiteSpace(expected!);
   assert.strictEqual(cleanedActual, cleanedExpected, message);
+}
+
+// Asserts the indexed search doc against a store-driven baseline, ignoring the
+// one intended difference between the two generation strategies: the searchable-
+// driven doc keeps a `{ id }` / `null` for every relationship, whereas a
+// store-driven doc omits links it never loaded (e.g. a base-card `cardTheme` /
+// `cardInfo.cardThumbnail`). `diffDoc(..., true)` treats that omit-vs-keep
+// difference as equivalent at any nesting depth while flagging any real data
+// delta — the same parity rule the realm-scale `searchable-parity-diff` applies.
+function expectSearchDoc(
+  assert: Assert,
+  actual: Record<string, any> | null | undefined,
+  storeDrivenBaseline: Record<string, any>,
+  message?: string,
+) {
+  assert.deepEqual(
+    diffDoc(storeDrivenBaseline, actual ?? {}, true),
+    [],
+    message ?? 'searchable-driven search doc is at parity with store-driven',
+  );
 }
 
 module(`Integration | realm indexing`, function (hooks) {
@@ -1100,7 +1121,7 @@ module(`Integration | realm indexing`, function (hooks) {
       let instance = await indexer.instance(
         new URL(`${testRealmURL}person-spec`),
       );
-      assert.deepEqual(instance?.searchDoc, {
+      expectSearchDoc(assert, instance?.searchDoc, {
         _cardType: 'Spec',
         cardDescription: 'Spec for Person card',
         id: `${testRealmURL}person-spec`,
@@ -1229,7 +1250,7 @@ module(`Integration | realm indexing`, function (hooks) {
       let instance = await indexer.instance(
         new URL(`${testRealmURL}person-spec`),
       );
-      assert.deepEqual(instance?.searchDoc, {
+      expectSearchDoc(assert, instance?.searchDoc, {
         _cardType: 'Spec',
         cardDescription: 'Spec for Person card',
         id: `${testRealmURL}person-spec`,
@@ -1302,7 +1323,7 @@ module(`Integration | realm indexing`, function (hooks) {
       let instance = await indexer.instance(
         new URL(`${testRealmURL}people-skill`),
       );
-      assert.deepEqual(instance?.searchDoc, {
+      expectSearchDoc(assert, instance?.searchDoc, {
         _cardType: 'Skill',
         id: `${testRealmURL}people-skill`,
         instructions: 'How to win friends and influence people',
@@ -1853,7 +1874,8 @@ module(`Integration | realm indexing`, function (hooks) {
     });
     let { searchDoc } =
       (await getInstance(realm, new URL(`${testRealmURL}vangogh`))) ?? {};
-    assert.deepEqual(
+    expectSearchDoc(
+      assert,
       searchDoc,
       {
         _cardType: 'Person',
@@ -2705,7 +2727,8 @@ module(`Integration | realm indexing`, function (hooks) {
       realm,
       new URL(`${testRealmURL}Person/hassan`),
     );
-    assert.deepEqual(
+    expectSearchDoc(
+      assert,
       entry?.searchDoc,
       {
         id: `${testRealmURL}Person/hassan`,
@@ -2786,7 +2809,8 @@ module(`Integration | realm indexing`, function (hooks) {
       },
     });
     let entry = await getInstance(realm, new URL(`${testRealmURL}Post/1`));
-    assert.deepEqual(
+    expectSearchDoc(
+      assert,
       entry?.searchDoc,
       {
         _cardType: 'Post',
@@ -2809,7 +2833,8 @@ module(`Integration | realm indexing`, function (hooks) {
       realm,
       new URL(`${testRealmURL}Publication/pacific`),
     );
-    assert.deepEqual(
+    expectSearchDoc(
+      assert,
       entry2?.searchDoc,
       {
         _cardType: 'Publication',
@@ -2926,7 +2951,7 @@ module(`Integration | realm indexing`, function (hooks) {
       realm,
       new URL(`${testRealmURL}Spec/booking`),
     );
-    assert.deepEqual(entry?.searchDoc, {
+    expectSearchDoc(assert, entry?.searchDoc, {
       _cardType: 'Spec',
       id: `${testRealmURL}Spec/booking`,
       cardDescription: 'Spec for Booking',
@@ -3148,7 +3173,7 @@ module(`Integration | realm indexing`, function (hooks) {
       new URL(`${testRealmURL}PetPerson/hassan`),
     );
     if (hassanEntry) {
-      assert.deepEqual(hassanEntry.searchDoc, {
+      expectSearchDoc(assert, hassanEntry.searchDoc, {
         _cardType: 'Pet Person',
         id: `${testRealmURL}PetPerson/hassan`,
         firstName: 'Hassan',
@@ -3269,7 +3294,7 @@ module(`Integration | realm indexing`, function (hooks) {
       new URL(`${testRealmURL}PetPerson/burcu`),
     );
     if (entry) {
-      assert.deepEqual(entry.searchDoc, {
+      expectSearchDoc(assert, entry.searchDoc, {
         _cardType: 'Pet Person',
         id: `${testRealmURL}PetPerson/burcu`,
         firstName: 'Burcu',
@@ -3407,7 +3432,7 @@ module(`Integration | realm indexing`, function (hooks) {
       new URL(`${testRealmURL}pet-person-spec`),
     );
     if (entry) {
-      assert.deepEqual(entry.searchDoc, {
+      expectSearchDoc(assert, entry.searchDoc, {
         _cardType: 'Spec',
         id: `${testRealmURL}pet-person-spec`,
         cardTitle: 'PetPerson',
@@ -3571,7 +3596,7 @@ module(`Integration | realm indexing`, function (hooks) {
       new URL(`${testRealmURL}Friend/hassan`),
     );
     if (hassanEntry) {
-      assert.deepEqual(hassanEntry.searchDoc, {
+      expectSearchDoc(assert, hassanEntry.searchDoc, {
         _cardType: 'Friend',
         id: `${testRealmURL}Friend/hassan`,
         firstName: 'Hassan',
@@ -3773,7 +3798,7 @@ module(`Integration | realm indexing`, function (hooks) {
       new URL(`${testRealmURL}Friend/hassan`),
     );
     if (hassanEntry) {
-      assert.deepEqual(hassanEntry.searchDoc, {
+      expectSearchDoc(assert, hassanEntry.searchDoc, {
         _cardType: 'Friend',
         id: `${testRealmURL}Friend/hassan`,
         firstName: 'Hassan',
@@ -3919,7 +3944,7 @@ module(`Integration | realm indexing`, function (hooks) {
       new URL(`${testRealmURL}Friend/mango`),
     );
     if (mangoEntry) {
-      assert.deepEqual(mangoEntry.searchDoc, {
+      expectSearchDoc(assert, mangoEntry.searchDoc, {
         _cardType: 'Friend',
         id: `${testRealmURL}Friend/mango`,
         firstName: 'Mango',
@@ -4044,7 +4069,7 @@ module(`Integration | realm indexing`, function (hooks) {
       new URL(`${testRealmURL}Friend/hassan`),
     );
     if (hassanEntry) {
-      assert.deepEqual(hassanEntry.searchDoc, {
+      expectSearchDoc(assert, hassanEntry.searchDoc, {
         _cardType: 'Friend',
         id: `${testRealmURL}Friend/hassan`,
         firstName: 'Hassan',
@@ -4275,7 +4300,8 @@ module(`Integration | realm indexing`, function (hooks) {
 
     let hassanEntry = await getInstance(realm, new URL(hassanID));
     if (hassanEntry) {
-      assert.deepEqual(
+      expectSearchDoc(
+        assert,
         hassanEntry.searchDoc,
         {
           _cardType: 'Friends',
@@ -4450,7 +4476,8 @@ module(`Integration | realm indexing`, function (hooks) {
 
     let mangoEntry = await getInstance(realm, new URL(mangoID));
     if (mangoEntry) {
-      assert.deepEqual(
+      expectSearchDoc(
+        assert,
         mangoEntry.searchDoc,
         {
           _cardType: 'Friends',
@@ -4631,7 +4658,8 @@ module(`Integration | realm indexing`, function (hooks) {
 
     let vanGoghEntry = await getInstance(realm, new URL(vanGoghID));
     if (vanGoghEntry) {
-      assert.deepEqual(
+      expectSearchDoc(
+        assert,
         vanGoghEntry.searchDoc,
         {
           _cardType: 'Friends',

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -85,23 +85,23 @@ function assertInnerHtmlMatches(
   assert.strictEqual(cleanedActual, cleanedExpected, message);
 }
 
-// Asserts the indexed search doc against a store-driven baseline, ignoring the
-// one intended difference between the two generation strategies: the searchable-
-// driven doc keeps a `{ id }` / `null` for every relationship, whereas a
-// store-driven doc omits links it never loaded (e.g. a base-card `cardTheme` /
-// `cardInfo.cardThumbnail`). `diffDoc(..., true)` treats that omit-vs-keep
-// difference as equivalent at any nesting depth while flagging any real data
-// delta — the same parity rule the realm-scale `searchable-parity-diff` applies.
+// Asserts the indexed search doc exactly equals `expected`. Search docs are
+// generated solely by the searchable-driven generator, so `expected` is that
+// generator's output: every relationship is present (a non-`searchable` link is
+// `{ id }` for a set target / `null` for an unset one; a `searchable` link is
+// expanded), and base-card links like `cardTheme` / `cardInfo.cardThumbnail`
+// appear too. `diffDoc(..., false)` is an exact comparison (no tolerance) that
+// reports a readable field-by-field diff on failure.
 function expectSearchDoc(
   assert: Assert,
   actual: Record<string, any> | null | undefined,
-  storeDrivenBaseline: Record<string, any>,
+  expected: Record<string, any>,
   message?: string,
 ) {
   assert.deepEqual(
-    diffDoc(storeDrivenBaseline, actual ?? {}, true),
+    diffDoc(expected, actual ?? {}, false),
     [],
-    message ?? 'searchable-driven search doc is at parity with store-driven',
+    message ?? 'indexed search doc matches the searchable-driven generator',
   );
 }
 
@@ -1134,7 +1134,8 @@ module(`Integration | realm indexing`, function (hooks) {
         isCard: true,
         isComponent: false,
         isField: false,
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       });
     } else {
       assert.ok(
@@ -1263,7 +1264,8 @@ module(`Integration | realm indexing`, function (hooks) {
         isCard: true,
         isComponent: false,
         isField: false,
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       });
     } else {
       assert.ok(
@@ -1335,7 +1337,8 @@ module(`Integration | realm indexing`, function (hooks) {
             cardTitle: 'Switch Submode',
           },
         ],
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       });
     } else {
       assert.ok(
@@ -1879,9 +1882,8 @@ module(`Integration | realm indexing`, function (hooks) {
       searchDoc,
       {
         _cardType: 'Person',
-        cardInfo: {
-          theme: null,
-        },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
         firstName: 'Van Gogh',
         id: `${testRealmURL}vangogh`,
         cardTitle: 'Untitled Card',
@@ -2740,7 +2742,8 @@ module(`Integration | realm indexing`, function (hooks) {
         cardDescription: 'Person',
         fullName: 'Hassan Abdel-Rahman',
         _cardType: 'Person',
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       },
       `search doc includes fullName field`,
     );
@@ -2825,7 +2828,8 @@ module(`Integration | realm indexing`, function (hooks) {
           id: `${testRealmURL}Publication/pacific`,
         },
         views: 5,
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       },
       `post 1 search doc includes publication relationship`,
     );
@@ -2847,6 +2851,7 @@ module(`Integration | realm indexing`, function (hooks) {
               fullName: ' ',
               cardTitle: ' ',
             },
+            cardTheme: null,
             cardInfo: { cardThumbnail: null, theme: null },
             id: `${testRealmURL}Post/1`,
             publication: {
@@ -2861,6 +2866,7 @@ module(`Integration | realm indexing`, function (hooks) {
               fullName: ' ',
               cardTitle: ' ',
             },
+            cardTheme: null,
             cardInfo: { cardThumbnail: null, theme: null },
             id: `${testRealmURL}Post/2`,
             publication: {
@@ -2870,7 +2876,8 @@ module(`Integration | realm indexing`, function (hooks) {
             views: 24,
           },
         ],
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       },
       `publication search doc includes featuredPosts relationship via isUsed=true`,
     );
@@ -2964,7 +2971,8 @@ module(`Integration | realm indexing`, function (hooks) {
       isCard: true,
       isComponent: false,
       isField: false,
-      cardInfo: { theme: null },
+      cardTheme: null,
+      cardInfo: { cardThumbnail: null, theme: null },
     });
     // we should be able to perform a structured clone of the search doc (this
     // emulates the limitations of the postMessage used to communicate between
@@ -3183,6 +3191,7 @@ module(`Integration | realm indexing`, function (hooks) {
             firstName: 'Mango',
             owner: null,
             cardTitle: 'Mango',
+            cardTheme: null,
             cardInfo: { cardThumbnail: null, theme: null },
           },
           {
@@ -3190,6 +3199,7 @@ module(`Integration | realm indexing`, function (hooks) {
             firstName: 'Van Gogh',
             owner: null,
             cardTitle: 'Van Gogh',
+            cardTheme: null,
             cardInfo: { cardThumbnail: null, theme: null },
           },
         ],
@@ -3197,7 +3207,8 @@ module(`Integration | realm indexing`, function (hooks) {
         cardTitle: 'Hassan Pet Person',
         cardDescription: 'A person with pets',
         cardThumbnailURL: null,
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       });
     } else {
       assert.ok(
@@ -3303,7 +3314,8 @@ module(`Integration | realm indexing`, function (hooks) {
         cardTitle: 'Burcu Pet Person',
         cardDescription: 'A person with pets',
         cardThumbnailURL: null,
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       });
     } else {
       assert.ok(
@@ -3445,7 +3457,8 @@ module(`Integration | realm indexing`, function (hooks) {
         isCard: true,
         isComponent: false,
         isField: false,
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       });
     } else {
       assert.ok(
@@ -3610,9 +3623,11 @@ module(`Integration | realm indexing`, function (hooks) {
           friend: {
             id: `${testRealmURL}Friend/vanGogh`,
           },
-          cardInfo: { theme: null },
+          cardTheme: null,
+          cardInfo: { cardThumbnail: null, theme: null },
         },
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       });
     } else {
       assert.ok(
@@ -3811,10 +3826,12 @@ module(`Integration | realm indexing`, function (hooks) {
             id: `${testRealmURL}Friend/hassan`,
           },
           cardDescription: 'Dog friend',
-          cardInfo: { theme: null },
+          cardTheme: null,
+          cardInfo: { cardThumbnail: null, theme: null },
         },
         cardTitle: 'Hassan',
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       });
     } else {
       assert.ok(
@@ -3958,9 +3975,11 @@ module(`Integration | realm indexing`, function (hooks) {
             id: `${testRealmURL}Friend/mango`,
           },
           cardDescription: 'Dog owner',
+          cardTheme: null,
           cardInfo: { cardThumbnail: null, theme: null },
         },
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       });
     } else {
       assert.ok(
@@ -4078,7 +4097,8 @@ module(`Integration | realm indexing`, function (hooks) {
           id: `${testRealmURL}Friend/hassan`,
         },
         cardTitle: 'Hassan',
-        cardInfo: { theme: null },
+        cardTheme: null,
+        cardInfo: { cardThumbnail: null, theme: null },
       });
     } else {
       assert.ok(
@@ -4314,17 +4334,20 @@ module(`Integration | realm indexing`, function (hooks) {
               firstName: 'Mango',
               cardTitle: 'Mango',
               friends: [{ id: hassanID }],
-              cardInfo: { theme: null },
+              cardTheme: null,
+              cardInfo: { cardThumbnail: null, theme: null },
             },
             {
               id: vanGoghID,
               firstName: 'Van Gogh',
               friends: [{ id: hassanID }],
               cardTitle: 'Van Gogh',
-              cardInfo: { theme: null },
+              cardTheme: null,
+              cardInfo: { cardThumbnail: null, theme: null },
             },
           ],
-          cardInfo: { theme: null },
+          cardTheme: null,
+          cardInfo: { cardThumbnail: null, theme: null },
         },
         'hassan searchData is correct',
       );
@@ -4500,13 +4523,16 @@ module(`Integration | realm indexing`, function (hooks) {
                       id: hassanID,
                     },
                   ],
-                  cardInfo: { theme: null },
+                  cardTheme: null,
+                  cardInfo: { cardThumbnail: null, theme: null },
                 },
               ],
+              cardTheme: null,
               cardInfo: { cardThumbnail: null, theme: null },
             },
           ],
-          cardInfo: { theme: null },
+          cardTheme: null,
+          cardInfo: { cardThumbnail: null, theme: null },
         },
         'mango searchData is correct',
       );
@@ -4673,10 +4699,8 @@ module(`Integration | realm indexing`, function (hooks) {
               cardTitle: 'Hassan',
               friends: [
                 {
-                  cardInfo: {
-                    cardThumbnail: null,
-                    theme: null,
-                  },
+                  cardTheme: null,
+                  cardInfo: { cardThumbnail: null, theme: null },
                   firstName: 'Mango',
                   friends: [
                     {
@@ -4688,10 +4712,12 @@ module(`Integration | realm indexing`, function (hooks) {
                 },
                 { id: vanGoghID },
               ],
+              cardTheme: null,
               cardInfo: { cardThumbnail: null, theme: null },
             },
           ],
-          cardInfo: { theme: null },
+          cardTheme: null,
+          cardInfo: { cardThumbnail: null, theme: null },
         },
         'vanGogh searchData is correct',
       );

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -2749,7 +2749,7 @@ module(`Integration | realm indexing`, function (hooks) {
     );
   });
 
-  test(`search doc includes unused 'linksTo' field if isUsed option is set to true`, async function (assert) {
+  test(`search doc includes a 'linksTo' field the render never loaded when it is searchable`, async function (assert) {
     let { realm } = await setupIntegrationTestRealm({
       mockMatrixUtils,
       contents: {
@@ -2879,7 +2879,7 @@ module(`Integration | realm indexing`, function (hooks) {
         cardTheme: null,
         cardInfo: { cardThumbnail: null, theme: null },
       },
-      `publication search doc includes featuredPosts relationship via isUsed=true`,
+      `publication search doc includes featuredPosts relationship via its searchable annotation`,
     );
   });
 

--- a/packages/host/tests/integration/searchable-search-doc-test.gts
+++ b/packages/host/tests/integration/searchable-search-doc-test.gts
@@ -1,7 +1,7 @@
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { baseRealm, diffDoc } from '@cardstack/runtime-common';
+import { baseRealm } from '@cardstack/runtime-common';
 import type { Realm, IndexedInstance } from '@cardstack/runtime-common';
 import type { Loader } from '@cardstack/runtime-common/loader';
 
@@ -1173,26 +1173,46 @@ module('Integration | searchable search doc', function (hooks) {
   // ===========================================================================
 
   // The prerender meta route generates the search doc via `searchDocFromFields`,
-  // so the doc the indexer persists is at parity with a direct
-  // `searchDocFromFields` call on the same card — same expansions, same
-  // contained data. The two paths differ only in how an unset value is
-  // represented (a rendered instance yields `undefined`, dropped by JSON
-  // serialization into the index; a freshly-loaded instance yields `null`),
-  // which `diffDoc(..., true)` treats as equivalent — the same rule the
-  // realm-scale gate applies.
-  test('the indexed search doc is at parity with the searchable-driven generator output', async function (assert) {
+  // so the doc the indexer persists is the searchable-driven output for a card
+  // carrying a `searchable` annotation: the `authors` link is expanded (not an
+  // `{ id }`), and every card carries its base-card links (`cardTheme`,
+  // `cardInfo.cardThumbnail`). Unset contained scalars are absent: the rendered
+  // instance the indexer serializes yields `undefined` for them, which JSON
+  // serialization into the index drops.
+  test('the indexer persists the searchable-driven search doc', async function (assert) {
     let id = `${testRealmURL}ParityArticle/pa1`;
-    let generated = await loadAndGenerate(id);
     let indexed = await indexedSearchDoc(id);
     assert.deepEqual(
-      diffDoc(indexed ?? {}, generated, true),
-      [],
-      'the indexer produced the searchable-driven doc',
+      indexed,
+      {
+        authors: [
+          {
+            cardInfo: { cardThumbnail: null, theme: null },
+            cardTheme: null,
+            cardTitle: 'Untitled SimpleAuthor',
+            id: `${testRealmURL}SimpleAuthor/sa1`,
+            name: 'Plain',
+          },
+        ],
+        cardInfo: { cardThumbnail: null, theme: null },
+        cardTheme: null,
+        cardTitle: 'Untitled ParityArticle',
+        id: `${testRealmURL}ParityArticle/pa1`,
+        title: 'Parity',
+      },
+      'the indexer persists the searchable-driven doc',
     );
-    // The card carries a `searchable` annotation, so this also exercises a real
-    // expansion through the indexer (not just an all-`{ id }` doc).
-    let authors = generated.authors;
-    let authorsExpanded = Array.isArray(authors) && authors.length > 0;
-    assert.true(authorsExpanded, 'the searchable link expanded into the doc');
+
+    // The expanded target's data is in the doc, so it must be recorded as a
+    // dependency — otherwise editing the target would not reindex the owner.
+    let entry = await realm.realmIndexQueryEngine.instance(new URL(id));
+    let deps =
+      entry && entry.type !== 'instance-error'
+        ? ((entry as IndexedInstance).deps ?? [])
+        : [];
+    assert.ok(
+      deps.some((d) => d.includes('SimpleAuthor/sa1')),
+      'the searchable-expanded target is recorded as a dependency',
+    );
   });
 });

--- a/packages/host/tests/integration/searchable-search-doc-test.gts
+++ b/packages/host/tests/integration/searchable-search-doc-test.gts
@@ -1,7 +1,7 @@
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { baseRealm } from '@cardstack/runtime-common';
+import { baseRealm, diffDoc } from '@cardstack/runtime-common';
 import type { Realm, IndexedInstance } from '@cardstack/runtime-common';
 import type { Loader } from '@cardstack/runtime-common/loader';
 
@@ -685,10 +685,11 @@ module('Integration | searchable search doc', function (hooks) {
     return await searchDocFromFields(instance);
   }
 
-  // The store-driven search doc the indexer produced, minus `_cardType` (which
-  // the prerender meta route appends, not the generator) — the differential
-  // parity baseline.
-  async function storeDrivenSearchDoc(id: string) {
+  // The search doc the indexer persisted, minus `_cardType` (which the prerender
+  // meta route appends, not the generator). The prerender meta route generates
+  // it via `searchDocFromFields`; the parity check below confirms it matches a
+  // direct `searchDocFromFields` call.
+  async function indexedSearchDoc(id: string) {
     let entry = await realm.realmIndexQueryEngine.instance(new URL(id));
     if (!entry || entry.type === 'instance-error') {
       return undefined;
@@ -1168,29 +1169,30 @@ module('Integration | searchable search doc', function (hooks) {
   });
 
   // ===========================================================================
-  // differential parity with the store-driven doc
+  // the indexer is authoritatively searchable-driven
   // ===========================================================================
 
-  // Byte-for-byte equality of the whole doc is NOT asserted: the
-  // searchable-driven spec keeps `{ id }`/`null` for every relationship while
-  // the store-driven path omits unused links via `usedLinksToFieldsOnly`, and
-  // the two enumerate link targets at different type granularity. This proves
-  // the expansion matches; whole-doc equality is the concern of the realm-scale
-  // parity diff, once realms carry `searchable` annotations.
-  test('searchable expansion pulls in the same target+data as the store-driven load', async function (assert) {
-    let generated = await loadAndGenerate(`${testRealmURL}ParityArticle/pa1`);
-    let storeDriven = await storeDrivenSearchDoc(
-      `${testRealmURL}ParityArticle/pa1`,
-    );
+  // The prerender meta route generates the search doc via `searchDocFromFields`,
+  // so the doc the indexer persists is at parity with a direct
+  // `searchDocFromFields` call on the same card — same expansions, same
+  // contained data. The two paths differ only in how an unset value is
+  // represented (a rendered instance yields `undefined`, dropped by JSON
+  // serialization into the index; a freshly-loaded instance yields `null`),
+  // which `diffDoc(..., true)` treats as equivalent — the same rule the
+  // realm-scale gate applies.
+  test('the indexed search doc is at parity with the searchable-driven generator output', async function (assert) {
+    let id = `${testRealmURL}ParityArticle/pa1`;
+    let generated = await loadAndGenerate(id);
+    let indexed = await indexedSearchDoc(id);
     assert.deepEqual(
-      (generated.authors ?? []).map((a: any) => a.id),
-      (storeDriven?.authors ?? []).map((a: any) => a.id),
-      'follows the searchable link to the same target the store loaded',
+      diffDoc(indexed ?? {}, generated, true),
+      [],
+      'the indexer produced the searchable-driven doc',
     );
-    assert.deepEqual(
-      (generated.authors ?? []).map((a: any) => a.name),
-      (storeDriven?.authors ?? []).map((a: any) => a.name),
-      'pulls the same contained data from the expanded target',
-    );
+    // The card carries a `searchable` annotation, so this also exercises a real
+    // expansion through the indexer (not just an all-`{ id }` doc).
+    let authors = generated.authors;
+    let authorsExpanded = Array.isArray(authors) && authors.length > 0;
+    assert.true(authorsExpanded, 'the searchable link expanded into the doc');
   });
 });

--- a/packages/realm-server/scripts/searchable-parity-diff.ts
+++ b/packages/realm-server/scripts/searchable-parity-diff.ts
@@ -26,11 +26,14 @@
  *                        and dump `await searchDocFromFields(instance)` per card.
  *
  * Output: a per-card report of real divergences and a non-zero exit if any are
- * found. `_cardType` (appended by the prerender meta route, not the generator)
- * is ignored. With `--ignore-shallow-links`, a relationship that is `{ id }`-only
- * (or null) on one side and absent on the other is treated as equivalent — the
- * known, intended `{ id }`-vs-omitted difference — so the report surfaces only
- * divergences that matter (changed expansions, missing data).
+ * found. The comparison logic (`diffDoc`) is shared with the generation tests
+ * via `@cardstack/runtime-common` so both judge parity identically. `_cardType`
+ * (appended by the prerender meta route, not the generator) is ignored. With
+ * `--ignore-shallow-links`, a relationship that is `{ id }`-only (or null) on one
+ * side and absent on the other is treated as equivalent — the known, intended
+ * `{ id }`-vs-omitted difference, ignored at any nesting depth (a pulled-in card
+ * carries the same shallow base-card links) — so the report surfaces only
+ * divergences that matter (changed references, lost expansions, real data).
  *
  * Usage:
  *   node packages/realm-server/scripts/searchable-parity-diff.ts \
@@ -38,7 +41,7 @@
  */
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
-import stringify from 'safe-stable-stringify';
+import { diffDoc } from '@cardstack/runtime-common';
 
 type SearchDoc = Record<string, unknown>;
 type DocMap = Record<string, SearchDoc>;
@@ -65,73 +68,6 @@ function parseArgs(argv: string[]) {
     generated: string;
     ignoreShallowLinks: boolean;
   };
-}
-
-// A relationship slot is "shallow" when it carries no contained data beyond a
-// bare reference: `null`, a bare `{ id }`, or a plural whose every element is
-// shallow (an empty plural included). The store-driven path omits unused links
-// while this generator keeps the `{ id }`, so under --ignore-shallow-links a
-// shallow-vs-absent slot is treated as equivalent — see `diffDoc`.
-export function isShallowLink(value: unknown): boolean {
-  if (value == null) return true;
-  if (Array.isArray(value)) return value.every(isShallowLink);
-  if (typeof value !== 'object') return false;
-  let keys = Object.keys(value as object);
-  return keys.length === 1 && keys[0] === 'id';
-}
-
-// The bare reference ids carried by a shallow slot, flattened across a plural.
-// A `null` / absent / empty slot contributes none. Used to tell the intended
-// omit-vs-keep-`{id}` difference (one side has no ids) apart from a CHANGED
-// reference (`{id:A}` vs `{id:B}`), which is a real divergence worth reporting.
-export function shallowIds(value: unknown): string[] {
-  if (value == null) return [];
-  if (Array.isArray(value)) return value.flatMap(shallowIds);
-  if (typeof value === 'object') {
-    let id = (value as { id?: unknown }).id;
-    return typeof id === 'string' ? [id] : [];
-  }
-  return [];
-}
-
-export function diffDoc(
-  live: SearchDoc,
-  generated: SearchDoc,
-  ignoreShallowLinks: boolean,
-): string[] {
-  let diffs: string[] = [];
-  let strip = (d: SearchDoc) => {
-    let { _cardType, ...rest } = d;
-    return rest;
-  };
-  let l = strip(live ?? {});
-  let g = strip(generated ?? {});
-  let keys = new Set([...Object.keys(l), ...Object.keys(g)]);
-  for (let key of keys) {
-    let lPresent = key in l;
-    let gPresent = key in g;
-    let lv = (l as SearchDoc)[key];
-    let gv = (g as SearchDoc)[key];
-    if (ignoreShallowLinks && isShallowLink(lv) && isShallowLink(gv)) {
-      let lIds = shallowIds(lv);
-      let gIds = shallowIds(gv);
-      // Omit-vs-keep-`{id}` (one side carries no ids) is the intended,
-      // ignored difference. A changed reference (both sides present, ids
-      // differ) is a real divergence and falls through to be reported.
-      if (lIds.length === 0 || gIds.length === 0) {
-        continue;
-      }
-      if (stringify(lIds) === stringify(gIds)) {
-        continue;
-      }
-    }
-    let ls = lPresent ? (stringify(lv) ?? 'null') : 'absent';
-    let gs = gPresent ? (stringify(gv) ?? 'null') : 'absent';
-    if (ls !== gs) {
-      diffs.push(`    ${key}: live=${ls} generated=${gs}`);
-    }
-  }
-  return diffs;
 }
 
 function main() {
@@ -164,7 +100,7 @@ function main() {
     if (docDiffs.length > 0) {
       divergent++;
       console.log(`DIVERGENT ${url}`);
-      for (let d of docDiffs) console.log(d);
+      for (let d of docDiffs) console.log(`    ${d}`);
     }
   }
 

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -8,6 +8,7 @@ import {
   IndexWriter,
   VirtualNetwork,
   userInitiatedPriority,
+  diffDoc,
 } from '@cardstack/runtime-common';
 import type {
   DBAdapter,
@@ -99,7 +100,7 @@ function makeTestRealmFileSystem(): Record<
 
       export class PetPerson extends CardDef {
         @field firstName = contains(StringField);
-        @field pet = linksTo(() => Pet);
+        @field pet = linksTo(() => Pet, { searchable: true });
         @field nickName = contains(StringField, {
           computeVia: function (this: Person) {
             if (this.pet?.firstName) {
@@ -144,7 +145,7 @@ function makeTestRealmFileSystem(): Record<
 
       export class Post extends CardDef {
         static displayName = 'Post';
-        @field author = linksTo(Person);
+        @field author = linksTo(Person, { searchable: true });
         @field message = contains(StringField);
         static isolated = class Isolated extends Component<typeof this> {
           <template>
@@ -801,27 +802,35 @@ module(basename(import.meta.filename), function () {
 
       let hassanEntry = await getInstance(realm, new URL(`${testRealm}hassan`));
       if (hassanEntry) {
+        // The searchable-driven doc is at parity with the store-driven baseline
+        // up to the intended omit-vs-keep-`{ id }` difference for unloaded
+        // base-card links; `diffDoc(..., true)` ignores that at any depth while
+        // flagging real data deltas.
         assert.deepEqual(
-          hassanEntry.searchDoc,
-          {
-            id: hassanId,
-            pet: {
-              id: `${testRealm}ringo`,
+          diffDoc(
+            {
+              id: hassanId,
+              pet: {
+                id: `${testRealm}ringo`,
+                cardTitle: 'Untitled Card',
+                firstName: 'Ringo',
+                cardInfo: {
+                  theme: null,
+                },
+              },
+              nickName: "Ringo's buddy",
+              _cardType: 'PetPerson',
+              firstName: 'Hassan',
               cardTitle: 'Untitled Card',
-              firstName: 'Ringo',
               cardInfo: {
+                cardThumbnail: null,
                 theme: null,
               },
             },
-            nickName: "Ringo's buddy",
-            _cardType: 'PetPerson',
-            firstName: 'Hassan',
-            cardTitle: 'Untitled Card',
-            cardInfo: {
-              cardThumbnail: null,
-              theme: null,
-            },
-          },
+            hassanEntry.searchDoc ?? {},
+            true,
+          ),
+          [],
           'searchData is correct',
         );
       } else {

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -802,10 +802,11 @@ module(basename(import.meta.filename), function () {
 
       let hassanEntry = await getInstance(realm, new URL(`${testRealm}hassan`));
       if (hassanEntry) {
-        // The searchable-driven doc is at parity with the store-driven baseline
-        // up to the intended omit-vs-keep-`{ id }` difference for unloaded
-        // base-card links; `diffDoc(..., true)` ignores that at any depth while
-        // flagging real data deltas.
+        // The searchable-driven generator is authoritative: every relationship
+        // is present (an unset link is `null`, a set one expands per its
+        // `searchable` annotation), and every card carries its base-card fields
+        // (`cardTheme`, `cardInfo.cardThumbnail`). The expected doc is the exact
+        // generator output; `diffDoc(..., false)` reports any deviation.
         assert.deepEqual(
           diffDoc(
             {
@@ -814,7 +815,9 @@ module(basename(import.meta.filename), function () {
                 id: `${testRealm}ringo`,
                 cardTitle: 'Untitled Card',
                 firstName: 'Ringo',
+                cardTheme: null,
                 cardInfo: {
+                  cardThumbnail: null,
                   theme: null,
                 },
               },
@@ -822,13 +825,14 @@ module(basename(import.meta.filename), function () {
               _cardType: 'PetPerson',
               firstName: 'Hassan',
               cardTitle: 'Untitled Card',
+              cardTheme: null,
               cardInfo: {
                 cardThumbnail: null,
                 theme: null,
               },
             },
             hassanEntry.searchDoc ?? {},
-            true,
+            false,
           ),
           [],
           'searchData is correct',

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -2101,36 +2101,16 @@ module(basename(import.meta.filename), function () {
             `isolated html includes hero mini cards from query and nested query loads: ${isolatedHTML}`,
           );
 
-          let staff = result.response.searchDoc?.staff as
-            | Array<Record<string, any>>
-            | undefined;
-          assert.ok(
-            Array.isArray(staff),
-            'searchDoc includes query field results',
-          );
-
-          let bob = staff?.find((entry) => entry?.name === 'Bob');
-          assert.ok(bob, 'searchDoc includes Bob from query results');
+          // Query-backed relationships are never captured in the search doc:
+          // they can't be invalidated when their matching cards change, so an
+          // indexed copy would go stale. The search doc is generated from the
+          // field definitions, so a card's custom queryableValue does not inject
+          // them either. The query field's results still render (asserted above)
+          // and the host re-resolves them at view time.
           assert.strictEqual(
-            bob?.manager?.name,
-            'Alice',
-            'searchDoc includes loaded manager relationship',
-          );
-
-          let bobReports = bob?.reports as
-            | Array<Record<string, any>>
-            | undefined;
-          assert.ok(
-            Array.isArray(bobReports),
-            'searchDoc includes nested query results',
-          );
-          let hasEveWithManager = bobReports?.some(
-            (report) =>
-              report?.name === 'Eve' && report?.manager?.name === 'Bob',
-          );
-          assert.true(
-            Boolean(hasEveWithManager),
-            'searchDoc includes nested loaded relationships',
+            result.response.searchDoc?.staff,
+            undefined,
+            'query-backed field is not captured in the search doc',
           );
         } finally {
           await realmServerPatch.restore();
@@ -3758,7 +3738,7 @@ module(basename(import.meta.filename), function () {
               import { Person } from '${realmURL1}person';
               export class Cat extends CardDef {
                 @field name = contains(StringField);
-                @field owner = linksTo(Person);
+                @field owner = linksTo(Person, { searchable: true });
                 static displayName = "Cat";
                 static embedded = <template>{{@fields.name}} says Meow. owned by <@fields.owner /></template>
               }
@@ -3769,9 +3749,9 @@ module(basename(import.meta.filename), function () {
               export class Dog extends CardDef {
                 static displayName = "Dog";
                 @field name = contains(StringField);
-                @field owner = linksTo(Person, { isUsed: true });
+                @field owner = linksTo(Person, { searchable: true });
                 static isolated = class extends Component<typeof this> {
-                  // owner is intentionally not in isolated template, this is included in search doc via isUsed=true
+                  // owner is intentionally not in isolated template; searchable: true pulls it into the search doc anyway
                   <template>{{@model.name}}</template>
                 }
               }
@@ -3782,9 +3762,9 @@ module(basename(import.meta.filename), function () {
               export class DogMany extends CardDef {
                 static displayName = "Dog Many";
                 @field name = contains(StringField);
-                @field owners = linksToMany(Person, { isUsed: true });
+                @field owners = linksToMany(Person, { searchable: true });
                 static isolated = class extends Component<typeof this> {
-                  // owners is intentionally not in isolated template, this is included in search doc via isUsed=true
+                  // owners is intentionally not in isolated template; searchable: true pulls them into the search doc anyway
                   <template>{{@model.name}}</template>
                 }
               }
@@ -3794,16 +3774,17 @@ module(basename(import.meta.filename), function () {
               import { Person } from '${realmURL1}person';
 
               class DogProfileField extends FieldDef {
-                @field primaryOwner = linksTo(Person, { isUsed: true });
-                @field caretakers = linksToMany(Person, { isUsed: true });
+                @field primaryOwner = linksTo(Person);
+                @field caretakers = linksToMany(Person);
               }
 
               export class DogProfile extends CardDef {
                 static displayName = "Dog Profile";
                 @field name = contains(StringField);
-                @field profile = contains(DogProfileField);
+                @field profile = contains(DogProfileField, { searchable: ['primaryOwner', 'caretakers'] });
                 static isolated = class extends Component<typeof this> {
-                  // profile is intentionally not in isolated template, this is included in search doc via isUsed=true
+                  // profile is intentionally not in isolated template; the contained field's
+                  // searchable routes pull its primaryOwner / caretakers links into the search doc
                   <template>{{@model.name}}</template>
                 }
               }
@@ -3820,9 +3801,9 @@ module(basename(import.meta.filename), function () {
               export class NonIsolatedLinks extends CardDef {
                 static displayName = 'Non Isolated Links';
                 @field name = contains(StringField);
-                @field owner = linksTo(Person);
-                @field owners = linksToMany(Person);
-                @field profile = contains(RelationshipField);
+                @field owner = linksTo(Person, { searchable: true });
+                @field owners = linksToMany(Person, { searchable: true });
+                @field profile = contains(RelationshipField, { searchable: ['lead', 'members'] });
 
                 static isolated = class extends Component<typeof this> {
                   <template><div data-test-isolated-name>{{@model.name}}</div></template>
@@ -4351,7 +4332,7 @@ module(basename(import.meta.filename), function () {
           assert.strictEqual(result.searchDoc?.owner.name, 'Hassan');
         });
 
-        test('isUsed field includes a field in search doc that is not rendered in template', async function (assert) {
+        test('searchable field includes a field in search doc that is not rendered in template', async function (assert) {
           const testCardURL = `${realmURL2}is-used`;
           let { response } = await prerenderCard(prerenderer, {
             affinityType: 'realm',
@@ -4372,11 +4353,11 @@ module(basename(import.meta.filename), function () {
           assert.strictEqual(
             response.searchDoc?.owner.name,
             'Hassan',
-            'linked field is included in search doc via isUsed=true',
+            'linked field is included in search doc via searchable: true',
           );
         });
 
-        test('isUsed linksToMany field includes links in search doc that are not rendered in template', async function (assert) {
+        test('searchable linksToMany field includes links in search doc that are not rendered in template', async function (assert) {
           const testCardURL = `${realmURL2}is-used-many`;
           let { response } = await prerenderCard(prerenderer, {
             affinityType: 'realm',
@@ -4397,16 +4378,16 @@ module(basename(import.meta.filename), function () {
           assert.strictEqual(
             response.searchDoc?.owners?.[0]?.name,
             'Hassan',
-            'first linked record is included in search doc via isUsed=true',
+            'first linked record is included in search doc via searchable: true',
           );
           assert.strictEqual(
             response.searchDoc?.owners?.[1]?.name,
             'Mango',
-            'second linked record is included in search doc via isUsed=true',
+            'second linked record is included in search doc via searchable: true',
           );
         });
 
-        test('isUsed compound field includes nested linksTo relationship in search doc', async function (assert) {
+        test('searchable compound field includes nested linksTo relationship in search doc', async function (assert) {
           const testCardURL = `${realmURL2}is-used-field-def`;
           let { response } = await prerenderCard(prerenderer, {
             affinityType: 'realm',
@@ -4427,11 +4408,11 @@ module(basename(import.meta.filename), function () {
           assert.strictEqual(
             response.searchDoc?.profile?.primaryOwner?.name,
             'Hassan',
-            'nested linksTo relationship is included in search doc via isUsed=true on the relationship field',
+            'nested linksTo relationship is included in search doc via searchable route on the contained field',
           );
         });
 
-        test('isUsed compound field includes nested linksToMany relationships in search doc', async function (assert) {
+        test('searchable compound field includes nested linksToMany relationships in search doc', async function (assert) {
           const testCardURL = `${realmURL2}is-used-field-def`;
           let { response } = await prerenderCard(prerenderer, {
             affinityType: 'realm',
@@ -4452,12 +4433,12 @@ module(basename(import.meta.filename), function () {
           assert.strictEqual(
             response.searchDoc?.profile?.caretakers?.[0]?.name,
             'Hassan',
-            'first nested linksToMany relationship is included in search doc via isUsed=true on the relationship field',
+            'first nested linksToMany relationship is included in search doc via searchable route on the contained field',
           );
           assert.strictEqual(
             response.searchDoc?.profile?.caretakers?.[1]?.name,
             'Mango',
-            'second nested linksToMany relationship is included in search doc via isUsed=true on the relationship field',
+            'second nested linksToMany relationship is included in search doc via searchable route on the contained field',
           );
         });
 

--- a/packages/realm-server/tests/searchable-parity-diff-test.ts
+++ b/packages/realm-server/tests/searchable-parity-diff-test.ts
@@ -1,16 +1,14 @@
 import QUnit from 'qunit';
 const { module, test } = QUnit;
 
-import {
-  diffDoc,
-  isShallowLink,
-  shallowIds,
-} from '../scripts/searchable-parity-diff.ts';
+import { diffDoc, isShallowLink, shallowIds } from '@cardstack/runtime-common';
 
-// Unit coverage for the realm-scale parity validator's pure comparison logic.
+// Unit coverage for the parity comparison logic shared by the realm-scale
+// validator (`scripts/searchable-parity-diff.ts`) and the generation tests.
 // The differ ignores `_cardType`, normalizes object key order, and (under
 // --ignore-shallow-links) treats the store-driven omit-vs-keep-`{id}` difference
-// as equivalent while still catching a CHANGED reference.
+// as equivalent — at any nesting depth — while still catching a CHANGED
+// reference or any real contained-data delta.
 module('Unit | searchable-parity-diff', function () {
   module('isShallowLink', function () {
     test('null / a bare { id } / an array of bare { id } are shallow', function (assert) {
@@ -123,6 +121,64 @@ module('Unit | searchable-parity-diff', function () {
           true,
         );
         assert.strictEqual(diffs.length, 1, 'expanded vs shallow diverges');
+      });
+
+      test('a shallow link nested inside a contained value is ignored', function (assert) {
+        // A pulled-in card carries the same base-card relationships (e.g. a
+        // contained `cardInfo`'s thumbnail link) that the store-driven path
+        // omitted and the searchable-driven path keeps as `null`.
+        assert.deepEqual(
+          diffDoc(
+            { cardInfo: { theme: null } },
+            { cardInfo: { theme: null, cardThumbnail: null } },
+            true,
+          ),
+          [],
+          'nested omit-vs-keep is the intended difference, ignored',
+        );
+      });
+
+      test('a real data delta inside a contained value is still reported', function (assert) {
+        let diffs = diffDoc(
+          { cardInfo: { theme: null, name: 'X' } },
+          { cardInfo: { theme: null, cardThumbnail: null } },
+          true,
+        );
+        assert.strictEqual(
+          diffs.length,
+          1,
+          'a changed contained scalar diverges',
+        );
+        assert.ok(diffs[0].includes('cardInfo.name'), 'names the nested path');
+      });
+
+      test('nested shallow additions inside an expanded plural are ignored', function (assert) {
+        assert.deepEqual(
+          diffDoc(
+            { posts: [{ id: 'p1', title: 'T', cardInfo: { theme: null } }] },
+            {
+              posts: [
+                {
+                  id: 'p1',
+                  title: 'T',
+                  cardInfo: { theme: null, cardThumbnail: null },
+                },
+              ],
+            },
+            true,
+          ),
+          [],
+          'an expanded element with only shallow-link additions is equivalent',
+        );
+      });
+
+      test('an expanded plural element that lost data is reported', function (assert) {
+        let diffs = diffDoc(
+          { posts: [{ id: 'p1', title: 'T' }] },
+          { posts: [{ id: 'p1' }] },
+          true,
+        );
+        assert.strictEqual(diffs.length, 1, 'lost expansion diverges');
       });
     });
   });

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -768,6 +768,7 @@ export * from './matrix-client.ts';
 export * from './queue.ts';
 export * from './job-utils.ts';
 export * from './expression.ts';
+export * from './searchable-parity.ts';
 export * from './infer-content-type.ts';
 export * from './index-query-engine.ts';
 export * from './index-writer.ts';

--- a/packages/runtime-common/searchable-parity.ts
+++ b/packages/runtime-common/searchable-parity.ts
@@ -1,0 +1,128 @@
+import stringify from 'safe-stable-stringify';
+
+// Parity comparison between a store-driven search doc and a searchable-driven
+// one. Shared by the realm-scale validator (`scripts/searchable-parity-diff.ts`)
+// and the generation tests so both judge "parity" by exactly the same rule.
+//
+// A search doc captures every relationship as at least a bare reference. The
+// searchable-driven generator keeps `{ id }` / `null` for every relationship,
+// whereas the store-driven path omits relationships it never loaded. Under
+// `ignoreShallowLinks` that omit-vs-keep-`{ id }` difference is treated as
+// equivalent — at any nesting depth, since a card pulled into the doc carries
+// the same base-card relationships (e.g. a contained `cardInfo`'s thumbnail
+// link) that are likewise shallow. A CHANGED reference id or any real
+// contained-data delta still reports.
+
+type SearchDoc = Record<string, unknown>;
+
+// A relationship slot is "shallow" when it carries no contained data beyond a
+// bare reference: `null`, a bare `{ id }`, or a plural whose every element is
+// shallow (an empty plural included).
+export function isShallowLink(value: unknown): boolean {
+  if (value == null) return true;
+  if (Array.isArray(value)) return value.every(isShallowLink);
+  if (typeof value !== 'object') return false;
+  let keys = Object.keys(value as object);
+  return keys.length === 1 && keys[0] === 'id';
+}
+
+// The bare reference ids carried by a shallow slot, flattened across a plural.
+// A `null` / absent / empty slot contributes none — used to tell the intended
+// omit-vs-keep-`{ id }` difference (one side has no ids) apart from a CHANGED
+// reference (`{ id:A }` vs `{ id:B }`), which is a real divergence.
+export function shallowIds(value: unknown): string[] {
+  if (value == null) return [];
+  if (Array.isArray(value)) return value.flatMap(shallowIds);
+  if (typeof value === 'object') {
+    let id = (value as { id?: unknown }).id;
+    return typeof id === 'string' ? [id] : [];
+  }
+  return [];
+}
+
+let isObject = (v: unknown): v is Record<string, unknown> =>
+  v != null && typeof v === 'object' && !Array.isArray(v);
+
+// Sentinel for a key present on one side but not the other, so present-vs-absent
+// stays distinct from present-vs-null.
+const ABSENT = Symbol('absent');
+
+function diffValue(
+  path: string,
+  live: unknown,
+  generated: unknown,
+  ignoreShallowLinks: boolean,
+  diffs: string[],
+): void {
+  let lAbsent = live === ABSENT;
+  let gAbsent = generated === ABSENT;
+  let lv = lAbsent ? undefined : live;
+  let gv = gAbsent ? undefined : generated;
+
+  // The intended omit-vs-keep-`{ id }` difference, ignored at any depth; a
+  // changed reference id falls through to report.
+  if (ignoreShallowLinks && isShallowLink(lv) && isShallowLink(gv)) {
+    let lIds = shallowIds(lv);
+    let gIds = shallowIds(gv);
+    if (lIds.length === 0 || gIds.length === 0) return;
+    if (stringify(lIds) === stringify(gIds)) return;
+    diffs.push(
+      `${path}: live=${stringify(lv) ?? 'null'} generated=${stringify(gv) ?? 'null'}`,
+    );
+    return;
+  }
+
+  if (lAbsent || gAbsent) {
+    diffs.push(
+      `${path}: live=${lAbsent ? 'absent' : (stringify(lv) ?? 'null')} generated=${gAbsent ? 'absent' : (stringify(gv) ?? 'null')}`,
+    );
+    return;
+  }
+
+  if (isObject(lv) && isObject(gv)) {
+    let keys = new Set([...Object.keys(lv), ...Object.keys(gv)]);
+    keys.delete('_cardType');
+    for (let key of keys) {
+      diffValue(
+        path ? `${path}.${key}` : key,
+        key in lv ? lv[key] : ABSENT,
+        key in gv ? gv[key] : ABSENT,
+        ignoreShallowLinks,
+        diffs,
+      );
+    }
+    return;
+  }
+
+  if (Array.isArray(lv) && Array.isArray(gv)) {
+    if (lv.length !== gv.length) {
+      diffs.push(
+        `${path}: live=${stringify(lv) ?? 'null'} generated=${stringify(gv) ?? 'null'}`,
+      );
+      return;
+    }
+    for (let i = 0; i < lv.length; i++) {
+      diffValue(`${path}[${i}]`, lv[i], gv[i], ignoreShallowLinks, diffs);
+    }
+    return;
+  }
+
+  if ((stringify(lv) ?? 'null') !== (stringify(gv) ?? 'null')) {
+    diffs.push(
+      `${path}: live=${stringify(lv) ?? 'null'} generated=${stringify(gv) ?? 'null'}`,
+    );
+  }
+}
+
+// Compare two search docs and return a list of human-readable divergences
+// (empty when equivalent). `_cardType` (appended by the prerender meta route,
+// not the generator) is ignored; object key order is normalized.
+export function diffDoc(
+  live: SearchDoc,
+  generated: SearchDoc,
+  ignoreShallowLinks: boolean,
+): string[] {
+  let diffs: string[] = [];
+  diffValue('', live ?? {}, generated ?? {}, ignoreShallowLinks, diffs);
+  return diffs;
+}

--- a/packages/test-realm-cards/contents/friend.gts
+++ b/packages/test-realm-cards/contents/friend.gts
@@ -8,7 +8,7 @@ import StringField from 'https://cardstack.com/base/string';
 
 export class Friend extends CardDef {
   @field firstName = contains(StringField);
-  @field friend = linksTo(() => Friend);
+  @field friend = linksTo(() => Friend, { searchable: true });
   @field cardTitle = contains(StringField, {
     computeVia: function (this: Friend) {
       return this.firstName;

--- a/packages/test-realm-cards/contents/friends.gts
+++ b/packages/test-realm-cards/contents/friends.gts
@@ -8,7 +8,7 @@ import StringField from 'https://cardstack.com/base/string';
 
 export class Friends extends CardDef {
   @field firstName = contains(StringField);
-  @field friends = linksToMany(() => Friends);
+  @field friends = linksToMany(() => Friends, { searchable: 'friends' });
   @field cardTitle = contains(StringField, {
     computeVia: function (this: Friends) {
       return this.firstName;

--- a/packages/test-realm-cards/contents/pet-person.gts
+++ b/packages/test-realm-cards/contents/pet-person.gts
@@ -18,7 +18,7 @@ export class PetPerson extends CardDef {
   static displayName = 'Pet Person';
   @field firstName = contains(StringField);
   @field friend = linksTo(Person);
-  @field pets = linksToMany(Pet);
+  @field pets = linksToMany(Pet, { searchable: true });
   @field cardTitle = contains(StringField, {
     computeVia: function (this: PetPerson) {
       return `${this.firstName} Pet Person`;
@@ -45,7 +45,7 @@ export class PetPerson extends CardDef {
 export class PetPersonField extends FieldDef {
   @field firstName = contains(StringField);
   @field friend = linksTo(Person);
-  @field pets = linksToMany(Pet);
+  @field pets = linksToMany(Pet, { searchable: true });
   @field cardTitle = contains(StringField, {
     computeVia: function (this: PetPersonField) {
       return `${this.firstName} Pet Person`;

--- a/packages/test-realm-cards/contents/publication.gts
+++ b/packages/test-realm-cards/contents/publication.gts
@@ -12,7 +12,7 @@ import { Post } from './post';
 export class Publication extends CardDef {
   @field cardTitle = contains(StringField);
   @field cardDescription = contains(StringField);
-  @field featuredPosts = linksToMany(() => Post);
+  @field featuredPosts = linksToMany(() => Post, { searchable: true });
   static isolated = class Isolated extends Component<typeof this> {
     <template>
       <h1><@fields.cardTitle /></h1>


### PR DESCRIPTION
Makes the searchable-driven generator the single source of search docs. Each card's search doc is built solely from its explicit `searchable` annotations (`searchDocFromFields`), which derive link depth deterministically from the field definitions rather than from whatever a render happened to load into the store.

## What changed

- **`meta.ts`** (the route the indexer renders) generates the search doc via `searchDocFromFields`, run after the compute-memo pass closes — it awaits targeted link loads, which the synchronous pass can't span. `cardService.getSearchable()` loads the generator from its own base module so it stays out of every card's dependency closure.
- **`searchable.ts`**:
  - Threads a dependency set through link expansion: each expanded target's URL is recorded as a dependency of the indexed card, so editing a searchable target reindexes the owner even when the render never loaded it directly. An `{ id }`-only link records nothing, since its target's data is not in the doc.
  - Reading a declared link is a pure peek — it skips the getter for an unmaterialized link. The getter writes `emptyValue` into the data bucket, which would mark an otherwise-unset link "used" and leak it into the link target's serialized relationships, non-deterministically by index order.
  - A primitive field's `queryableValue` is delegated to its static method, so a field override is honored — e.g. `JsonField` returns `null` to stay out of the index rather than leaking raw JSON.
- **`card-api.gts`** drops the store-driven `searchDoc` function.
- **Differ**: `diffDoc` / `isShallowLink` / `shallowIds` move to `@cardstack/runtime-common` so the search-doc tests and the realm-scale migration validator share one implementation.

## Search-doc shape

The generated doc is deterministic — it depends only on the card's field definitions and `searchable` annotations, never on what a render touched. Every relationship is present: an unset link is `null`, a set link is `{ id }`, and a link a `searchable` annotation covers is expanded per the declared field type. Every card carries its base-card links (`cardTheme`, `cardInfo.cardThumbnail`). Two things are deliberately absent:

- query-backed relationships (they can't be invalidated when their matching cards change, so an indexed copy would go stale); and
- a card's custom `[queryableValue]` override (the doc comes from field definitions, not imperative card code).

## Tests

Generation/indexing tests assert the generator's output exactly via `diffDoc(..., false)` — an exact, readable, field-by-field comparison (no tolerance); fixtures carry the `searchable` annotations for the depth each test exercises. The differ's tolerant mode is used only by the realm-scale migration validator, not by these tests.

The `isUsed` field option is left in the type as an inert no-op for search-doc generation so not-yet-republished sources still compile; removing it is a follow-up.

Verified locally: host `realm-indexing` (43/43), `prerender-meta` (9/9), and `searchable-search-doc` (39/39); realm-server `indexing-test` + `prerendering-test` (169/169 combined); tsc/glint clean across base / host / runtime-common / realm-server.
