### PR TITLE
Strip isUsed from realm card sources (CS-11737)

### DIFF
--- a/packages/base/rich-markdown.gts
+++ b/packages/base/rich-markdown.gts
@@ -83,7 +83,6 @@ export class RichMarkdownField extends FieldDef {
 
   /** Cards referenced in the markdown, loaded via query. */
   @field linkedCards = linksToMany(CardDef, {
-    isUsed: true,
     query: {
       filter: {
         in: { id: '$this.cardReferenceUrls' },
@@ -111,7 +110,6 @@ export class RichMarkdownField extends FieldDef {
    * (unlike CardDef instances), so `in: { id }` never matches.
    */
   @field linkedFiles = linksToMany(FileDef, {
-    isUsed: true,
     query: {
       filter: {
         in: { url: '$this.fileReferenceUrls' },

--- a/packages/base/spec.gts
+++ b/packages/base/spec.gts
@@ -954,7 +954,7 @@ export class Spec extends CardDef {
     },
   });
   @field linkedExamples = linksToMany(CardDef);
-  @field containedExamples = containsMany(FieldDef, { isUsed: true });
+  @field containedExamples = containsMany(FieldDef);
   @field cardTitle = contains(SpecTitleField);
   @field cardDescription = contains(SpecDescriptionField);
 

--- a/packages/experiments-realm/author.gts
+++ b/packages/experiments-realm/author.gts
@@ -70,7 +70,6 @@ export class Author extends CardDef {
   @field email = contains(EmailField);
   @field featuredImage = contains(FeaturedImageField);
   @field blog = linksTo(BlogApp, {
-    isUsed: true,
     searchable: true,
   });
 

--- a/packages/experiments-realm/blog-category.gts
+++ b/packages/experiments-realm/blog-category.gts
@@ -82,7 +82,6 @@ export class BlogCategory extends CardDef {
   @field pillColor = contains(ColorField);
   @field cardDescription = contains(StringField);
   @field blog = linksTo(BlogAppCard, {
-    isUsed: true,
     searchable: true,
   });
 

--- a/packages/experiments-realm/blog-post.gts
+++ b/packages/experiments-realm/blog-post.gts
@@ -643,7 +643,6 @@ export class BlogPost extends CardDef {
     },
   });
   @field blog = linksTo(BlogAppCard, {
-    isUsed: true,
     searchable: true,
   });
   @field featuredImage = contains(FeaturedImageField);

--- a/packages/experiments-realm/crm/account.gts
+++ b/packages/experiments-realm/crm/account.gts
@@ -1242,11 +1242,9 @@ export class Account extends CardDef {
   static icon = AccountIcon;
   @field crmApp = linksTo(() => CrmApp, { searchable: true });
   @field company = linksTo(() => Company, {
-    isUsed: true,
     searchable: 'crmApp',
   });
   @field primaryContact = linksTo(() => Contact, {
-    isUsed: true,
     searchable: ['company', 'company.crmApp', 'crmApp'],
   });
   @field contacts = linksToMany(() => Contact);

--- a/packages/experiments-realm/crm/deal.gts
+++ b/packages/experiments-realm/crm/deal.gts
@@ -1611,7 +1611,6 @@ export class Deal extends CardDef {
         this.status.label !== 'Closed Lost'
       );
     },
-    isUsed: true,
   });
   //TODO: Fix after CS-7670. Maybe no fix needed
   @field headquartersAddress = contains(AddressField, {

--- a/packages/experiments-realm/sprint-task.gts
+++ b/packages/experiments-realm/sprint-task.gts
@@ -504,7 +504,6 @@ export class SprintTask extends Task {
   static icon = CheckboxIcon;
   @field project = linksTo(() => Project, { searchable: true });
   @field team = linksTo(() => Team, {
-    isUsed: true,
     searchable: true,
   });
   @field subtasks = linksToMany(() => SprintTask, { searchable: ['assignee', 'tags', 'team'] });

--- a/packages/realm-server/scripts/codemod/searchable/apply-deployed.ts
+++ b/packages/realm-server/scripts/codemod/searchable/apply-deployed.ts
@@ -20,8 +20,9 @@
 // `/realms/_published/`) are skipped here — they pick up the strip when their
 // source realm is republished, not by a direct write.
 //
-// The seed is read from ~/.config/boxel/realm-secret-seed-<staging|production>
-// and handed to boxel-cli via BOXEL_REALM_SECRET_SEED in the child's env, so it
+// The seed is read from ~/.config/boxel/realm-secret-seed-staging (for --env
+// staging) or ~/.config/boxel/realm-secret-seed-production (for --env prod) and
+// handed to boxel-cli via BOXEL_REALM_SECRET_SEED in the child's env, so it
 // never lands in this process's argv or the logs.
 
 import {
@@ -49,6 +50,12 @@ const ORIGIN: Record<string, string> = {
   staging: 'https://realms-staging.stack.cards',
   prod: 'https://app.boxel.ai',
 };
+
+// Matches the `isUsed:` field OPTION (an object-literal property) — not a field
+// or getter named `isUsed` (`@field isUsed = …`, `get isUsed()`), nor a
+// `this.isUsed` / `@model.isUsed` reference. Used to tell a real leftover
+// annotation from a coincidental identifier when deciding clean vs. not.
+const ISUSED_OPTION = /(?<![.\w])isUsed\s*:/;
 const SEED_FILE: Record<string, string> = {
   staging: 'realm-secret-seed-staging',
   prod: 'realm-secret-seed-production',
@@ -89,6 +96,12 @@ function parseArgs(argv: string[]): Args {
       'usage: --env <staging|prod> --efs-base <url> --hits <scan.json> --out <report.jsonl> [--write] [--concurrency N] [--limit N] [--realm url]',
     );
   }
+  if (!Number.isFinite(a.concurrency) || a.concurrency < 1) {
+    throw new Error('--concurrency must be a positive number');
+  }
+  if (a.limit !== undefined && (!Number.isFinite(a.limit) || a.limit < 1)) {
+    throw new Error('--limit must be a positive number');
+  }
   return a;
 }
 
@@ -102,12 +115,7 @@ function readSeed(env: string): string {
 
 // Run a boxel-cli subcommand with the seed supplied via the child's env only —
 // never on argv, never logged.
-function boxel(
-  env: string,
-  seed: string,
-  args: string[],
-  timeoutMs = 240000,
-): string {
+function boxel(seed: string, args: string[], timeoutMs = 240000): string {
   return execFileSync('node', [BOXEL, ...args], {
     encoding: 'utf8',
     timeout: timeoutMs,
@@ -118,7 +126,6 @@ function boxel(
 
 // Write one module via boxel-cli `file write` (content through a temp file).
 function writeRealmFile(
-  env: string,
   seed: string,
   realmUrl: string,
   relPath: string,
@@ -128,7 +135,7 @@ function writeRealmFile(
   let tmp = join(dir, 'content');
   try {
     writeFileSync(tmp, content);
-    boxel(env, seed, [
+    boxel(seed, [
       'file',
       'write',
       relPath,
@@ -146,12 +153,11 @@ function writeRealmFile(
 // Read one module back via boxel-cli `file read --json`. Returns the content,
 // or null if the file isn't there.
 function readRealmFile(
-  env: string,
   seed: string,
   realmUrl: string,
   relPath: string,
 ): string | null {
-  let out = boxel(env, seed, [
+  let out = boxel(seed, [
     'file',
     'read',
     relPath,
@@ -231,6 +237,7 @@ async function main(): Promise<void> {
   let changedRealms = 0;
   let strippedModules = 0;
   let noopModules = 0;
+  let unstrippedModules = 0;
   let failed = 0;
   let done = 0;
 
@@ -240,6 +247,12 @@ async function main(): Promise<void> {
       let targets = byRealm.get(realmUrl) ?? [];
       let stripped: string[] = [];
       let noop: string[] = [];
+      // `isUsed` survived the transform: it sits in non-literal field options
+      // (`const o = { isUsed: true }; linksTo(X, o)`) or another form the codemod
+      // can't statically rewrite (these land in `result.skipped`). This is NOT a
+      // no-op — the annotation is still there, so it's surfaced for manual
+      // handling and the file is left untouched rather than half-written.
+      let unstripped: string[] = [];
       let errors: string[] = [];
       for (let { efsPath, relPath } of targets) {
         try {
@@ -249,16 +262,27 @@ async function main(): Promise<void> {
             policyForClass: () => undefined, // strip-only: never add searchable
             stripIsUsed: true,
           });
-          if (result.status !== 'transformed' || result.output === before) {
-            // Stale hit or nothing to strip (e.g. already stripped) — no write.
+          let changed =
+            result.status === 'transformed' && result.output !== before;
+          let after = changed ? result.output : before;
+          if (ISUSED_OPTION.test(after)) {
+            let where = result.skipped.length
+              ? ` (${result.skipped.map((s) => `${s.className ?? '?'}.${s.fieldName}`).join(', ')})`
+              : '';
+            unstripped.push(relPath + where);
+            unstrippedModules++;
+            continue;
+          }
+          if (!changed) {
+            // No `isUsed` present — genuinely clean (already stripped / stale hit).
             noop.push(relPath);
             noopModules++;
             continue;
           }
           if (args.write) {
-            writeRealmFile(args.env, seed, realmUrl, relPath, result.output);
-            let after = readRealmFile(args.env, seed, realmUrl, relPath);
-            if (after !== result.output) {
+            writeRealmFile(seed, realmUrl, relPath, result.output);
+            let readBack = readRealmFile(seed, realmUrl, relPath);
+            if (readBack !== result.output) {
               throw new Error(`verify ${relPath}: write did not round-trip`);
             }
           }
@@ -274,12 +298,13 @@ async function main(): Promise<void> {
         realm: realmUrl,
         stripped,
         noop,
+        unstripped: unstripped.length ? unstripped : undefined,
         errors: errors.length ? errors : undefined,
         written: args.write ? stripped : undefined,
       });
-      if (stripped.length > 0 || errors.length > 0) {
+      if (stripped.length > 0 || errors.length > 0 || unstripped.length > 0) {
         process.stderr.write(
-          `  ${errors.length ? '✗' : '✓'} ${realmUrl} — ${stripped.length} module(s)${args.write ? ' WRITTEN' : ' would strip'}${errors.length ? `, ${errors.length} error(s)` : ''}\n`,
+          `  ${errors.length || unstripped.length ? '✗' : '✓'} ${realmUrl} — ${stripped.length} module(s)${args.write ? ' WRITTEN' : ' would strip'}${unstripped.length ? `, ${unstripped.length} STILL has isUsed` : ''}${errors.length ? `, ${errors.length} error(s)` : ''}\n`,
         );
       }
       done++;
@@ -292,9 +317,11 @@ async function main(): Promise<void> {
   );
 
   process.stderr.write(
-    `\nDone. ${realms.length} realms, ${changedRealms} ${args.write ? 'changed' : 'would change'}, ${strippedModules} module(s) ${args.write ? 'stripped' : 'to strip'}, ${noopModules} no-op, ${failed} failed. Report: ${args.out}\n`,
+    `\nDone. ${realms.length} realms, ${changedRealms} ${args.write ? 'changed' : 'would change'}, ${strippedModules} module(s) ${args.write ? 'stripped' : 'to strip'}, ${noopModules} no-op, ${unstrippedModules} still-has-isUsed, ${failed} failed. Report: ${args.out}\n`,
   );
-  if (failed > 0) process.exitCode = 1;
+  // A leftover `isUsed` (unstripped) means the realm isn't clean yet, so it
+  // fails the run just like a hard error.
+  if (failed > 0 || unstrippedModules > 0) process.exitCode = 1;
 }
 
 main().catch((err) => {

--- a/packages/realm-server/scripts/codemod/searchable/apply-deployed.ts
+++ b/packages/realm-server/scripts/codemod/searchable/apply-deployed.ts
@@ -1,19 +1,28 @@
-// Deployed-realm crawl for the `searchable` migration. For each SOURCE realm
-// that has >=1 annotated def, pull its source, run the same apply logic as
-// apply-local on the pulled copy, and (dry-run) report the modules that would
-// change, or (--write) `boxel file write` only those modules. Published realms
-// are handled by updating their source realm + republishing (republish is a
-// slow full reindex, so it's a separate phase, --republish).
+// Deployed-realm crawl that strips the `isUsed` field option from every hosted
+// realm whose source carries it. Source is read from the read-only EFS mount
+// (the aws-access fs-explorer SSM tunnel — a Caddy file-server), each affected
+// module is rewritten in-process with the searchable codemod's strip-only
+// transform, and the changed modules are written back with boxel-cli
+// `file write` (which mints its own realm JWT from the secret seed) and then
+// read back to confirm the write round-tripped.
 //
 //   node apply-deployed.ts --env staging \
-//     --derivation staging.full.derivation.json --registry staging-registry.json \
-//     --out report.json [--concurrency 6] [--limit N] [--realm <url>] [--write]
+//     --efs-base http://localhost:58080 \
+//     --hits staging-userland-isused.json \
+//     --out report.jsonl [--write] [--concurrency 6] [--limit N] [--realm <url>]
 //
-// DRY-RUN by default — no realm is modified. The DB read that produced the
-// derivation already happened (read-only). This script only pulls (read) +
-// reports; it writes nothing unless --write is given. boxel-cli reads BOXEL_REALM_SECRET_SEED from
-// the environment; source ~/.boxel-secrets/<env>.env before running so the seed
-// stays out of argv/logs.
+// DRY-RUN by default — no realm is modified; it reads from EFS, runs the strip,
+// and reports the modules that would change. Pass --write to write them back.
+//
+// `--hits` is the scan report from `scan-deployed-isused.mjs` listing the EFS
+// paths that contain `isUsed` (objects with a `path` like
+// `/realms/<user>/<realm>/<module>`). Published copies (paths under
+// `/realms/_published/`) are skipped here — they pick up the strip when their
+// source realm is republished, not by a direct write.
+//
+// The seed is read from ~/.config/boxel/realm-secret-seed-<staging|production>
+// and handed to boxel-cli via BOXEL_REALM_SECRET_SEED in the child's env, so it
+// never lands in this process's argv or the logs.
 
 import {
   mkdtempSync,
@@ -23,20 +32,32 @@ import {
   appendFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { tmpdir, homedir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
 
+import { transformSearchable } from './transform.ts';
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = join(HERE, '..', '..', '..', '..', '..'); // packages/realm-server/scripts/codemod/searchable -> repo root
 const BOXEL = join(REPO, 'packages', 'boxel-cli', 'bin', 'boxel.js');
-const APPLY_LOCAL = join(HERE, 'apply-local.ts');
+
+// Realm-server origin per environment. A user realm at EFS
+// `/realms/<user>/<realm>/` is served at `<origin>/<user>/<realm>/`.
+const ORIGIN: Record<string, string> = {
+  staging: 'https://realms-staging.stack.cards',
+  prod: 'https://app.boxel.ai',
+};
+const SEED_FILE: Record<string, string> = {
+  staging: 'realm-secret-seed-staging',
+  prod: 'realm-secret-seed-production',
+};
 
 interface Args {
-  env: string;
-  derivations: string[];
-  registry: string;
+  env: 'staging' | 'prod';
+  efsBase: string;
+  hits: string;
   out: string;
   concurrency: number;
   limit?: number;
@@ -45,13 +66,13 @@ interface Args {
 }
 
 function parseArgs(argv: string[]): Args {
-  let a: any = { derivations: [], concurrency: 6, write: false };
+  let a: any = { concurrency: 6, write: false };
   for (let i = 0; i < argv.length; i++) {
     let f = argv[i];
     if (f === '--write') a.write = true;
     else if (f === '--env') a.env = argv[++i];
-    else if (f === '--derivation') a.derivations.push(argv[++i]);
-    else if (f === '--registry') a.registry = argv[++i];
+    else if (f === '--efs-base') a.efsBase = argv[++i];
+    else if (f === '--hits') a.hits = argv[++i];
     else if (f === '--out') a.out = argv[++i];
     else if (f === '--concurrency') a.concurrency = Number(argv[++i]);
     else if (f === '--limit') a.limit = Number(argv[++i]);
@@ -59,240 +80,206 @@ function parseArgs(argv: string[]): Args {
     else throw new Error(`unknown arg: ${f}`);
   }
   if (a.env !== 'staging' && a.env !== 'prod') {
-    // Restricted to a fixed set — `env` is interpolated into the bash command
-    // that sources the seed file, so it must never carry arbitrary text.
     throw new Error(
       `--env must be 'staging' or 'prod' (got ${JSON.stringify(a.env)})`,
     );
   }
-  if (a.derivations.length === 0 || !a.registry || !a.out) {
+  if (!a.efsBase || !a.hits || !a.out) {
     throw new Error(
-      'usage: --env <staging|prod> --derivation <json>… --registry <json> --out <report> [--concurrency N] [--limit N] [--realm url] [--write]',
+      'usage: --env <staging|prod> --efs-base <url> --hits <scan.json> --out <report.jsonl> [--write] [--concurrency N] [--limit N] [--realm url]',
     );
   }
   return a;
 }
 
-// run a boxel-cli subcommand with the env-file seed sourced inside a bash -c so
-// the seed never lands in this process's argv/env/logs.
-function boxel(env: string, args: string[], timeoutMs = 240000): string {
-  let quoted = args.map((x) => `'${x.replace(/'/g, `'\\''`)}'`).join(' ');
-  let cmd = `set -a; . "$HOME/.boxel-secrets/${env}.env"; set +a; exec node ${JSON.stringify(BOXEL)} ${quoted}`;
-  return execFileSync('bash', ['-c', cmd], {
+// Read the env's realm secret seed once. boxel-cli reads it from
+// BOXEL_REALM_SECRET_SEED (and mints the JWT itself); we strip a trailing
+// newline so an editor-saved seed file still authenticates.
+function readSeed(env: string): string {
+  let p = join(homedir(), '.config', 'boxel', SEED_FILE[env]);
+  return readFileSync(p, 'utf8').replace(/\r?\n$/, '');
+}
+
+// Run a boxel-cli subcommand with the seed supplied via the child's env only —
+// never on argv, never logged.
+function boxel(
+  env: string,
+  seed: string,
+  args: string[],
+  timeoutMs = 240000,
+): string {
+  return execFileSync('node', [BOXEL, ...args], {
     encoding: 'utf8',
     timeout: timeoutMs,
     maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, BOXEL_REALM_SECRET_SEED: seed },
   });
 }
 
-// Write one module via boxel-cli `file write` (content passed through a temp
-// file). boxel-cli mints the realm JWT from the seed itself — no sync, just the
-// one changed module.
+// Write one module via boxel-cli `file write` (content through a temp file).
 function writeRealmFile(
   env: string,
+  seed: string,
   realmUrl: string,
   relPath: string,
   content: string,
 ): void {
-  let tmp = join(mkdtempSync(join(tmpdir(), 'searchable-write-')), 'content');
+  let dir = mkdtempSync(join(tmpdir(), 'isused-write-'));
+  let tmp = join(dir, 'content');
   try {
     writeFileSync(tmp, content);
-    boxel(env, ['file', 'write', relPath, '--realm', realmUrl, '--file', tmp]);
+    boxel(env, seed, [
+      'file',
+      'write',
+      relPath,
+      '--realm',
+      realmUrl,
+      '--file',
+      tmp,
+      '--realm-secret-seed',
+    ]);
   } finally {
-    rmSync(tmp, { recursive: true, force: true });
+    rmSync(dir, { recursive: true, force: true });
   }
 }
 
-// Read one module back via boxel-cli `file read --json`. Returns the content, or
-// null if the file isn't there.
+// Read one module back via boxel-cli `file read --json`. Returns the content,
+// or null if the file isn't there.
 function readRealmFile(
   env: string,
+  seed: string,
   realmUrl: string,
   relPath: string,
 ): string | null {
-  let out = boxel(env, [
+  let out = boxel(env, seed, [
     'file',
     'read',
     relPath,
     '--realm',
     realmUrl,
     '--json',
+    '--realm-secret-seed',
   ]);
   let parsed = JSON.parse(out);
   return parsed.ok ? (parsed.content ?? null) : null;
 }
 
-// Which source realms have >=1 annotated def? Match annotated defKeys (https)
-// to the source realm whose URL is a prefix. @cardstack/<realm> keys are
-// repo-handled, skipped.
-function realmsWithChanges(
-  derivations: string[],
-  sourceUrls: string[],
-): Map<string, number> {
-  let sorted = [...sourceUrls].sort((a, b) => b.length - a.length); // longest-prefix-first
-  let counts = new Map<string, number>();
-  for (let path of derivations) {
-    let { defs } = JSON.parse(readFileSync(path, 'utf8')) as { defs: any[] };
-    for (let d of defs) {
-      if (!d.fields || Object.keys(d.fields).length === 0) continue;
-      if (typeof d.defKey !== 'string' || !d.defKey.startsWith('http'))
-        continue;
-      let realm = sorted.find((u) => d.defKey.startsWith(u));
-      if (realm) counts.set(realm, (counts.get(realm) ?? 0) + 1);
+// Read a module's source straight off the read-only EFS mount (Caddy file
+// server over the SSM tunnel). Retries a few times so a transient tunnel hiccup
+// doesn't drop a realm.
+async function efsRead(efsBase: string, efsPath: string): Promise<string> {
+  let last: unknown;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      let res = await fetch(efsBase + efsPath);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return await res.text();
+    } catch (e) {
+      last = e;
+      await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
     }
   }
-  return counts;
+  throw new Error(`EFS read ${efsPath} failed: ${(last as Error)?.message}`);
 }
 
-// Pull realm source, snapshot via git, run apply-local --write on the copy,
-// return the list of changed module paths (realm-relative).
-function changedModulesForRealm(
-  env: string,
-  realmUrl: string,
-  derivations: string[],
-): { path: string; content: string }[] {
-  let dir = mkdtempSync(join(tmpdir(), 'searchable-realm-'));
-  try {
-    boxel(env, ['realm', 'pull', realmUrl, dir]);
-    // `realm pull` leaves a `.boxel-history` checkpoint dir that is itself a git
-    // repo — drop it so our snapshot doesn't treat it as a submodule. (apply-local
-    // already ignores dot-dirs, so it never participates in the rewrite.)
-    rmSync(join(dir, '.boxel-history'), { recursive: true, force: true });
-    execFileSync('git', ['init', '-q'], { cwd: dir });
-    execFileSync('git', ['add', '-A'], { cwd: dir });
-    execFileSync(
-      'git',
-      [
-        '-c',
-        'user.email=x@x',
-        '-c',
-        'user.name=x',
-        'commit',
-        '-qm',
-        'snap',
-        '--allow-empty',
-      ],
-      { cwd: dir },
-    );
-    let derivArgs: string[] = [];
-    for (let d of derivations) derivArgs.push('--derivation', d);
-    execFileSync(
-      'node',
-      [
-        APPLY_LOCAL,
-        '--realm-root',
-        dir,
-        '--realm-url',
-        realmUrl,
-        ...derivArgs,
-        '--write',
-      ],
-      {
-        encoding: 'utf8',
-        env: { ...process.env, NODE_NO_WARNINGS: '1' },
-        maxBuffer: 64 * 1024 * 1024,
-      },
-    );
-    let out = execFileSync('git', ['diff', '--name-only'], {
-      cwd: dir,
-      encoding: 'utf8',
-    });
-    return out
-      .split('\n')
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .map((path) => ({
-        path,
-        content: readFileSync(join(dir, path), 'utf8'),
-      }));
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
+interface FileTarget {
+  efsPath: string;
+  relPath: string;
+}
+
+// Group the scan's hit paths into the realms they belong to, skipping published
+// copies (republished, not directly written).
+function realmsFromHits(
+  hitsPath: string,
+  origin: string,
+): Map<string, FileTarget[]> {
+  let payload = JSON.parse(readFileSync(hitsPath, 'utf8')) as {
+    hits?: { path: string }[];
+  };
+  let byRealm = new Map<string, FileTarget[]>();
+  for (let { path } of payload.hits ?? []) {
+    let segs = path.split('/').filter(Boolean); // realms / <user> / <realm> / <rel...>
+    if (segs[0] !== 'realms' || segs.length < 4) continue;
+    if (segs[1] === '_published') continue; // republished separately
+    let [, user, realm, ...rest] = segs;
+    let realmUrl = `${origin}/${user}/${realm}/`;
+    let relPath = rest.join('/');
+    let list = byRealm.get(realmUrl);
+    if (!list) byRealm.set(realmUrl, (list = []));
+    list.push({ efsPath: path, relPath });
   }
+  return byRealm;
 }
 
 async function main(): Promise<void> {
   let args = parseArgs(process.argv.slice(2));
-  let registry = JSON.parse(readFileSync(args.registry, 'utf8')) as {
-    url: string;
-    kind: string;
-    source_url: string | null;
-  }[];
-  let sourceUrls = registry
-    .filter((r) => r.kind === 'source')
-    .map((r) => r.url);
-  // source realm -> its published copies (for republish planning)
-  let publishedBySource = new Map<string, string[]>();
-  for (let r of registry) {
-    if (r.kind === 'published' && r.source_url) {
-      let list = publishedBySource.get(r.source_url) ?? [];
-      list.push(r.url);
-      publishedBySource.set(r.source_url, list);
-    }
-  }
+  // Seed only needed to write; a dry-run reads from EFS and never authenticates.
+  let seed = args.write ? readSeed(args.env) : '';
+  let origin = ORIGIN[args.env];
 
-  let counts = realmsWithChanges(args.derivations, sourceUrls);
-  let realms = args.realm
-    ? [args.realm]
-    : [...counts.keys()].sort((a, b) => counts.get(b)! - counts.get(a)!);
+  let byRealm = realmsFromHits(args.hits, origin);
+  let realms = args.realm ? [args.realm] : [...byRealm.keys()].sort();
   if (args.limit) realms = realms.slice(0, args.limit);
 
   writeFileSync(args.out, '');
   let log = (obj: any) => appendFileSync(args.out, JSON.stringify(obj) + '\n');
   process.stderr.write(
-    `Crawling ${realms.length} realm(s), concurrency ${args.concurrency}, write=${args.write}\n`,
+    `${args.env}: ${realms.length} realm(s) with isUsed, concurrency ${args.concurrency}, write=${args.write}\n`,
   );
 
   let idx = 0;
   let changedRealms = 0;
-  let wroteModules = 0;
+  let strippedModules = 0;
+  let noopModules = 0;
   let failed = 0;
   let done = 0;
+
   async function worker() {
     while (idx < realms.length) {
       let realmUrl = realms[idx++];
-      try {
-        let changed = changedModulesForRealm(
-          args.env,
-          realmUrl,
-          args.derivations,
-        );
-        let published = publishedBySource.get(realmUrl) ?? [];
-        if (changed.length > 0) changedRealms++;
-        let written: string[] = [];
-        if (args.write) {
-          for (let { path, content } of changed) {
-            writeRealmFile(args.env, realmUrl, path, content);
-            // Read back to confirm the write landed with our content.
-            let after = readRealmFile(args.env, realmUrl, path);
-            if (after !== content) {
-              throw new Error(
-                `verify ${path}: written content did not round-trip`,
-              );
-            }
-            written.push(path);
-            wroteModules++;
+      let targets = byRealm.get(realmUrl) ?? [];
+      let stripped: string[] = [];
+      let noop: string[] = [];
+      let errors: string[] = [];
+      for (let { efsPath, relPath } of targets) {
+        try {
+          let before = await efsRead(args.efsBase, efsPath);
+          let result = transformSearchable(before, {
+            filename: relPath,
+            policyForClass: () => undefined, // strip-only: never add searchable
+            stripIsUsed: true,
+          });
+          if (result.status !== 'transformed' || result.output === before) {
+            // Stale hit or nothing to strip (e.g. already stripped) — no write.
+            noop.push(relPath);
+            noopModules++;
+            continue;
           }
+          if (args.write) {
+            writeRealmFile(args.env, seed, realmUrl, relPath, result.output);
+            let after = readRealmFile(args.env, seed, realmUrl, relPath);
+            if (after !== result.output) {
+              throw new Error(`verify ${relPath}: write did not round-trip`);
+            }
+          }
+          stripped.push(relPath);
+          strippedModules++;
+        } catch (err) {
+          errors.push(`${relPath}: ${(err as Error).message.split('\n')[0]}`);
+          failed++;
         }
-        log({
-          realm: realmUrl,
-          annotatedDefs: counts.get(realmUrl) ?? null,
-          changedModules: changed.map((c) => c.path),
-          written: args.write ? written : undefined,
-          publishedCopies: published,
-        });
-        if (changed.length > 0) {
-          process.stderr.write(
-            `  ✓ ${realmUrl} — ${changed.length} module(s)${args.write ? ' WRITTEN' : ''}${published.length ? ` (+${published.length} published)` : ''}\n`,
-          );
-        }
-      } catch (err) {
-        failed++;
-        log({
-          realm: realmUrl,
-          error: (err as Error).message.split('\n').slice(0, 3).join(' | '),
-        });
+      }
+      if (stripped.length > 0) changedRealms++;
+      log({
+        realm: realmUrl,
+        stripped,
+        noop,
+        errors: errors.length ? errors : undefined,
+        written: args.write ? stripped : undefined,
+      });
+      if (stripped.length > 0 || errors.length > 0) {
         process.stderr.write(
-          `  ✗ ${realmUrl} — ${(err as Error).message.split('\n')[0]}\n`,
+          `  ${errors.length ? '✗' : '✓'} ${realmUrl} — ${stripped.length} module(s)${args.write ? ' WRITTEN' : ' would strip'}${errors.length ? `, ${errors.length} error(s)` : ''}\n`,
         );
       }
       done++;
@@ -305,8 +292,9 @@ async function main(): Promise<void> {
   );
 
   process.stderr.write(
-    `\nDone. ${realms.length} realms scanned, ${changedRealms} ${args.write ? 'changed' : 'would change'}, ${args.write ? `${wroteModules} modules written, ` : ''}${failed} failed. Report: ${args.out}\n`,
+    `\nDone. ${realms.length} realms, ${changedRealms} ${args.write ? 'changed' : 'would change'}, ${strippedModules} module(s) ${args.write ? 'stripped' : 'to strip'}, ${noopModules} no-op, ${failed} failed. Report: ${args.out}\n`,
   );
+  if (failed > 0) process.exitCode = 1;
 }
 
 main().catch((err) => {

--- a/packages/realm-server/scripts/codemod/searchable/apply-local.ts
+++ b/packages/realm-server/scripts/codemod/searchable/apply-local.ts
@@ -75,10 +75,23 @@ function parseArgs(argv: string[]): Args {
     else if (a === '--derivation') derivations.push(argv[++i]);
     else throw new Error(`unknown arg: ${a}`);
   }
-  if (!realmRoot || realmUrls.length === 0 || derivations.length === 0) {
+  if (!realmRoot) {
     throw new Error(
-      'usage: --realm-root <dir> --realm-url <url>… --derivation <json>… [--write] [--strip-isused]',
+      'usage: --realm-root <dir> [--realm-url <url>… --derivation <json>…] [--write] [--strip-isused]',
     );
+  }
+  // Strip-only mode: `--strip-isused` with no derivation removes every `isUsed`
+  // option and adds no `searchable` (so a realm that already carries its
+  // `searchable` annotations is edited only to drop the now-inert `isUsed` —
+  // provably behavior-neutral). A derivation, when given, adds `searchable` and
+  // needs the realm URL(s) it maps to so defs match by prefix.
+  if (derivations.length === 0 && !stripIsUsed) {
+    throw new Error(
+      'nothing to do: pass --derivation <json>… (add searchable) and/or --strip-isused (remove isUsed)',
+    );
+  }
+  if (derivations.length > 0 && realmUrls.length === 0) {
+    throw new Error('--derivation requires at least one --realm-url');
   }
   return { realmRoot, realmUrls, derivations, write, stripIsUsed };
 }
@@ -174,73 +187,23 @@ async function main(): Promise<void> {
   let args = parseArgs(process.argv.slice(2));
   let root = resolve(args.realmRoot);
 
-  // 1) Parse the realm's source into a class graph.
+  // 1) Read the realm's source files.
   let files = collectSourceFiles(root);
   let modules: SourceModule[] = files.map((file) => ({
     filename: file,
     modPath: relModulePath(root, file),
     source: readFileSync(file, 'utf8'),
   }));
-  let graph = buildClassGraph(modules);
 
-  // 2) Raw observed routes per leaf def, then HOIST to the declaring class.
-  let { routesByRelKey: raw, instanceRelKeys } = buildRawRoutes(
-    args.derivations,
-    args.realmUrls,
-  );
-  let finalRoutes = new Map<string, Set<string>>();
+  // `searchable` planning. EMPTY in strip-only mode (no --derivation): there is
+  // nothing to plan, and we skip parsing the whole realm into a class graph
+  // just to strip `isUsed`. Populated below only when a derivation is given.
+  let graph: ReturnType<typeof buildClassGraph> | undefined;
+  let prunedRoutes = new Map<string, Set<string>>();
+  let instanceRelKeys = new Set<string>();
   let noLocalClass: { relKey: string; fields: Record<string, unknown> }[] = [];
   let platformInherited: { leaf: string; route: string; base: string }[] = [];
   let unresolved: { leaf: string; route: string }[] = [];
-
-  for (let [leafRelKey, routes] of raw) {
-    if (!graph.has(leafRelKey)) {
-      // No local source file — a hosted-only card (handled by the deployed
-      // crawl) or a moved/renamed def. Don't apply here.
-      noLocalClass.push({
-        relKey: leafRelKey,
-        fields: routesToFieldSearchable(routes),
-      });
-      continue;
-    }
-    for (let route of routes) {
-      let head = route.includes('.')
-        ? route.slice(0, route.indexOf('.'))
-        : route;
-      let decl = findDeclaringClass(graph, leafRelKey, head);
-      if (
-        decl.kind === 'local' &&
-        PLATFORM_ROOT_CLASSES.has(graph.get(decl.relKey)!.className)
-      ) {
-        // The head field is declared by a platform-root type (CardDef's
-        // `cardInfo`, etc.). Annotating it deepens EVERY card's search doc — a
-        // platform-wide blast radius we deliberately leave shallow (deepen later
-        // via a base edit + reindex if ever wanted). Holds even when processing
-        // base itself, where CardDef is a local class.
-        platformInherited.push({
-          leaf: leafRelKey,
-          route,
-          base: graph.get(decl.relKey)!.className,
-        });
-      } else if (decl.kind === 'local') {
-        let set = finalRoutes.get(decl.relKey);
-        if (!set) finalRoutes.set(decl.relKey, (set = new Set()));
-        set.add(route);
-      } else if (decl.kind === 'external') {
-        platformInherited.push({
-          leaf: leafRelKey,
-          route,
-          base: decl.externalName,
-        });
-      } else {
-        unresolved.push({ leaf: leafRelKey, route });
-      }
-    }
-  }
-
-  // 2b) PRUNE each hoisted route against declared types: drop segments that
-  //     cross a polymorphic field (unsearchable cruft) or aren't declared.
-  let prunedRoutes = new Map<string, Set<string>>();
   let droppedPolymorphic: {
     relKey: string;
     route: string;
@@ -253,19 +216,78 @@ async function main(): Promise<void> {
   }[] = [];
   let unvalidated: { relKey: string; route: string; kept: string | null }[] =
     [];
-  for (let [relKey, routes] of finalRoutes) {
-    for (let route of routes) {
-      let { kept, reason } = pruneRoute(graph, relKey, route);
-      if (reason === 'polymorphic')
-        droppedPolymorphic.push({ relKey, route, kept });
-      else if (reason === 'unresolved')
-        droppedUnresolved.push({ relKey, route, kept });
-      else if (reason === 'unvalidated')
-        unvalidated.push({ relKey, route, kept });
-      if (kept) {
-        let set = prunedRoutes.get(relKey);
-        if (!set) prunedRoutes.set(relKey, (set = new Set()));
-        set.add(kept);
+
+  if (args.derivations.length > 0) {
+    // Parse the realm's source into a class graph.
+    graph = buildClassGraph(modules);
+
+    // 2) Raw observed routes per leaf def, then HOIST to the declaring class.
+    let built = buildRawRoutes(args.derivations, args.realmUrls);
+    instanceRelKeys = built.instanceRelKeys;
+    let raw = built.routesByRelKey;
+    let finalRoutes = new Map<string, Set<string>>();
+
+    for (let [leafRelKey, routes] of raw) {
+      if (!graph.has(leafRelKey)) {
+        // No local source file — a hosted-only card (handled by the deployed
+        // crawl) or a moved/renamed def. Don't apply here.
+        noLocalClass.push({
+          relKey: leafRelKey,
+          fields: routesToFieldSearchable(routes),
+        });
+        continue;
+      }
+      for (let route of routes) {
+        let head = route.includes('.')
+          ? route.slice(0, route.indexOf('.'))
+          : route;
+        let decl = findDeclaringClass(graph, leafRelKey, head);
+        if (
+          decl.kind === 'local' &&
+          PLATFORM_ROOT_CLASSES.has(graph.get(decl.relKey)!.className)
+        ) {
+          // The head field is declared by a platform-root type (CardDef's
+          // `cardInfo`, etc.). Annotating it deepens EVERY card's search doc — a
+          // platform-wide blast radius we deliberately leave shallow (deepen later
+          // via a base edit + reindex if ever wanted). Holds even when processing
+          // base itself, where CardDef is a local class.
+          platformInherited.push({
+            leaf: leafRelKey,
+            route,
+            base: graph.get(decl.relKey)!.className,
+          });
+        } else if (decl.kind === 'local') {
+          let set = finalRoutes.get(decl.relKey);
+          if (!set) finalRoutes.set(decl.relKey, (set = new Set()));
+          set.add(route);
+        } else if (decl.kind === 'external') {
+          platformInherited.push({
+            leaf: leafRelKey,
+            route,
+            base: decl.externalName,
+          });
+        } else {
+          unresolved.push({ leaf: leafRelKey, route });
+        }
+      }
+    }
+
+    // 2b) PRUNE each hoisted route against declared types: drop segments that
+    //     cross a polymorphic field (unsearchable cruft) or aren't declared.
+    for (let [relKey, routes] of finalRoutes) {
+      for (let route of routes) {
+        let { kept, reason } = pruneRoute(graph, relKey, route);
+        if (reason === 'polymorphic')
+          droppedPolymorphic.push({ relKey, route, kept });
+        else if (reason === 'unresolved')
+          droppedUnresolved.push({ relKey, route, kept });
+        else if (reason === 'unvalidated')
+          unvalidated.push({ relKey, route, kept });
+        if (kept) {
+          let set = prunedRoutes.get(relKey);
+          if (!set) prunedRoutes.set(relKey, (set = new Set()));
+          set.add(kept);
+        }
       }
     }
   }
@@ -280,6 +302,10 @@ async function main(): Promise<void> {
     let policyForClass = (
       exportName: string | null,
     ): ClassPolicy | undefined => {
+      // Strip-only mode (no derivation): never apply a `searchable` policy —
+      // not the observed routes and not the zero-instance depth-1 default — so
+      // the only edit is the `isUsed` strip below.
+      if (args.derivations.length === 0) return undefined;
       if (!exportName) return undefined;
       let relKey = `${mod.modPath}/${exportName}`;
       let routes = prunedRoutes.get(relKey);
@@ -291,7 +317,7 @@ async function main(): Promise<void> {
       // were genuinely shallow — leave them. If it had ZERO instances (absent
       // from the derivation) and is an instantiable card def, default its
       // relationships to depth-1 (`searchable: true`) for resilience.
-      if (!instanceRelKeys.has(relKey) && isCardDef(graph, relKey)) {
+      if (!instanceRelKeys.has(relKey) && isCardDef(graph!, relKey)) {
         appliedRelKeys.add(relKey);
         return { defaultRelationshipsToTrue: true };
       }

--- a/packages/realm-server/scripts/codemod/searchable/republish.mjs
+++ b/packages/realm-server/scripts/codemod/searchable/republish.mjs
@@ -1,12 +1,12 @@
 // Republish each (source -> published) pair so the published snapshot picks up
-// the searchable annotations now in its source realm, then ASSERT the annotation
-// landed: `realm publish` waits for the published realm to be ready (fully
-// indexed), after which we read a known-changed module back from the published
-// realm and confirm it carries `searchable`.
+// the now-stripped source realm, then ASSERT the strip landed: `realm publish`
+// waits for the published realm to be ready (fully indexed), after which we read
+// a known-changed module back from the published realm and confirm the `isUsed`
+// option is gone.
 //
 //   node republish.mjs <pairs.json> <staging|prod> <out.jsonl> [--limit N]
-// You do not need to source the seed before running: each boxel-cli call sources
-// ~/.boxel-secrets/<env>.env itself, so the seed never enters this process.
+// The secret seed is read from ~/.config/boxel/realm-secret-seed-<staging|production>
+// and handed to boxel-cli via BOXEL_REALM_SECRET_SEED, so it never enters argv.
 import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync, appendFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';

--- a/packages/realm-server/scripts/codemod/searchable/republish.mjs
+++ b/packages/realm-server/scripts/codemod/searchable/republish.mjs
@@ -11,13 +11,12 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync, appendFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
 
 let [pairsPath, env, out] = process.argv.slice(2);
 let limitIdx = process.argv.indexOf('--limit');
 let limit = limitIdx > -1 ? Number(process.argv[limitIdx + 1]) : Infinity;
 if (env !== 'staging' && env !== 'prod') {
-  // env is interpolated into the bash command that sources the seed file, so it
-  // must never carry arbitrary text.
   throw new Error(
     `env must be 'staging' or 'prod' (got ${JSON.stringify(env)})`,
   );
@@ -27,13 +26,31 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = join(HERE, '..', '..', '..', '..', '..');
 let BOXEL = join(REPO, 'packages', 'boxel-cli', 'bin', 'boxel.js');
 
+// The `isUsed:` field OPTION — not a field/getter named `isUsed` or a
+// `this.isUsed` / `@model.isUsed` reference.
+const ISUSED_OPTION = /(?<![.\w])isUsed\s*:/;
+
+// Seed read once from ~/.config/boxel/realm-secret-seed-<staging|production>
+// and handed to boxel-cli via BOXEL_REALM_SECRET_SEED in the child's env, so it
+// never lands in argv or the logs. boxel-cli mints the realm JWT itself.
+let SEED = readFileSync(
+  join(
+    homedir(),
+    '.config',
+    'boxel',
+    env === 'prod'
+      ? 'realm-secret-seed-production'
+      : 'realm-secret-seed-staging',
+  ),
+  'utf8',
+).replace(/\r?\n$/, '');
+
 function boxel(args, timeout = 660000) {
-  let q = args.map((x) => `'${x.replace(/'/g, `'\\''`)}'`).join(' ');
-  let cmd = `set -a; . "$HOME/.boxel-secrets/${env}.env"; set +a; exec node ${JSON.stringify(BOXEL)} ${q}`;
-  return execFileSync('bash', ['-c', cmd], {
+  return execFileSync('node', [BOXEL, ...args], {
     encoding: 'utf8',
     timeout,
     maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, BOXEL_REALM_SECRET_SEED: SEED },
   });
 }
 
@@ -59,20 +76,29 @@ for (let [i, p] of pairs.entries()) {
       '--timeout',
       '600000',
     ]);
-    // Assert: the annotation is present in the published realm's source.
+    // Assert: the `isUsed` option is gone from the republished snapshot — i.e.
+    // the strip propagated from the (already-stripped) source realm.
     let r = JSON.parse(
-      boxel(['file', 'read', p.sampleModule, '--realm', p.published, '--json']),
+      boxel([
+        'file',
+        'read',
+        p.sampleModule,
+        '--realm',
+        p.published,
+        '--json',
+        '--realm-secret-seed',
+      ]),
     );
-    let present = Boolean(r.ok && (r.content || '').includes('searchable'));
-    if (!present) assertFail++;
+    let isUsedGone = Boolean(r.ok && !ISUSED_OPTION.test(r.content || ''));
+    if (!isUsedGone) assertFail++;
     log({
       published: p.published,
       source: p.source,
       sampleModule: p.sampleModule,
-      searchablePresent: present,
+      isUsedAbsent: isUsedGone,
     });
     process.stderr.write(
-      `  ${present ? '✓' : '⚠'} ${p.published} (searchable in ${p.sampleModule}: ${present})\n`,
+      `  ${isUsedGone ? '✓' : '⚠'} ${p.published} (isUsed gone from ${p.sampleModule}: ${isUsedGone})\n`,
     );
     ok++;
   } catch (e) {
@@ -96,7 +122,7 @@ for (let [i, p] of pairs.entries()) {
   process.stderr.write(`  …${i + 1}/${pairs.length}\n`);
 }
 process.stderr.write(
-  `\nDone. ${ok} republished, ${assertFail} missing-searchable, ${skipped} skipped (not publishable), ${fail} failed.\n`,
+  `\nDone. ${ok} republished, ${assertFail} still-has-isUsed, ${skipped} skipped (not publishable), ${fail} failed.\n`,
 );
 // Surface real failures to callers/CI; expected "not publishable" skips do not
 // fail the run.

--- a/packages/realm-server/scripts/codemod/searchable/scan-deployed-isused.mjs
+++ b/packages/realm-server/scripts/codemod/searchable/scan-deployed-isused.mjs
@@ -22,6 +22,14 @@ if (!efsBase || !root || !out) {
     'usage: node scan-deployed-isused.mjs <efs-base> <root> <out.json> [--concurrency N]',
   );
 }
+if (!Number.isFinite(CONCURRENCY) || CONCURRENCY < 1) {
+  throw new Error('--concurrency must be a positive number');
+}
+
+// Matches the `isUsed:` field OPTION (an object-literal property), so a field
+// or getter named `isUsed` (`@field isUsed = …`, `get isUsed()`) or a
+// `this.isUsed` / `@model.isUsed` reference doesn't count as a hit.
+const ISUSED_OPTION = /(?<![.\w])isUsed\s*:/g;
 
 async function get(path, asJson) {
   let last;
@@ -79,9 +87,9 @@ async function worker() {
     let path = files[i++];
     try {
       let body = await get(path, false);
-      if (body.includes('isUsed')) {
-        let count = body.split('isUsed').length - 1;
-        hits.push({ path, count });
+      let m = body.match(ISUSED_OPTION);
+      if (m) {
+        hits.push({ path, count: m.length });
       }
     } catch {
       // leave unrecorded; a transient miss is re-found on a re-run

--- a/packages/realm-server/scripts/codemod/searchable/scan-deployed-isused.mjs
+++ b/packages/realm-server/scripts/codemod/searchable/scan-deployed-isused.mjs
@@ -1,0 +1,129 @@
+// Scan deployed realm source on the read-only EFS mount (the aws-access
+// fs-explorer SSM tunnel — a Caddy file server with JSON directory listings)
+// for modules that still carry the `isUsed` field option, and write the hit
+// list that apply-deployed.ts consumes (`--hits`).
+//
+//   node scan-deployed-isused.mjs <efs-base> <root> <out.json> [--concurrency N]
+//     efs-base : local tunnel base, e.g. http://localhost:58080
+//     root     : EFS path to crawl, e.g. /realms/ (user realms) or / (all)
+//
+// Reads only — no auth, no writes. Output: { root, files_scanned, hit_files,
+// by_realm, hits: [{ path, count }] }. Published copies live under
+// /realms/_published/ and are republished (not directly stripped), so the
+// caller decides whether to act on them.
+
+import { writeFileSync } from 'node:fs';
+
+let [efsBase, root, out] = process.argv.slice(2);
+let ci = process.argv.indexOf('--concurrency');
+let CONCURRENCY = ci > -1 ? Number(process.argv[ci + 1]) : 24;
+if (!efsBase || !root || !out) {
+  throw new Error(
+    'usage: node scan-deployed-isused.mjs <efs-base> <root> <out.json> [--concurrency N]',
+  );
+}
+
+async function get(path, asJson) {
+  let last;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      let res = await fetch(efsBase + path, {
+        headers: asJson ? { Accept: 'application/json' } : {},
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return asJson ? await res.json() : await res.text();
+    } catch (e) {
+      last = e;
+      await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
+    }
+  }
+  throw last;
+}
+
+async function listdir(path) {
+  try {
+    let data = await get(path, true);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+// Walk directories depth-first, collecting .gts/.ts file paths.
+let files = [];
+let dirs = 0;
+async function walk(path) {
+  dirs++;
+  if (dirs % 200 === 0)
+    process.stderr.write(`  …walked ${dirs} dirs, ${files.length} files\n`);
+  for (let entry of await listdir(path)) {
+    let name = entry.name ?? '';
+    if (entry.is_dir) {
+      if (name === '.boxel-history' || name.startsWith('.git')) continue;
+      await walk(path + name + '/');
+    } else if (name.endsWith('.gts') || name.endsWith('.ts')) {
+      files.push(path + name);
+    }
+  }
+}
+process.stderr.write(`Walking ${root} …\n`);
+await walk(root);
+process.stderr.write(`Walk done: ${dirs} dirs, ${files.length} files\n`);
+
+// Fetch each file and record the ones containing `isUsed`. Bounded concurrency.
+let hits = [];
+let checked = 0;
+let i = 0;
+async function worker() {
+  while (i < files.length) {
+    let path = files[i++];
+    try {
+      let body = await get(path, false);
+      if (body.includes('isUsed')) {
+        let count = body.split('isUsed').length - 1;
+        hits.push({ path, count });
+      }
+    } catch {
+      // leave unrecorded; a transient miss is re-found on a re-run
+    }
+    if (++checked % 500 === 0)
+      process.stderr.write(
+        `  …checked ${checked}/${files.length}, ${hits.length} hits\n`,
+      );
+  }
+}
+await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
+
+// Group hits by realm: /realms/<user>/<realm>/ or a /<system>/ root.
+let byRealm = {};
+for (let h of hits) {
+  let parts = h.path.split('/').filter(Boolean);
+  let realm =
+    parts[0] === 'realms' && parts.length >= 3
+      ? `/${parts.slice(0, 3).join('/')}/`
+      : `/${parts[0]}/`;
+  (byRealm[realm] ??= []).push(h.path);
+}
+
+hits.sort((a, b) => a.path.localeCompare(b.path));
+writeFileSync(
+  out,
+  JSON.stringify(
+    {
+      root,
+      files_scanned: files.length,
+      hit_files: hits.length,
+      by_realm: Object.fromEntries(
+        Object.entries(byRealm)
+          .map(([k, v]) => [k, v.sort()])
+          .sort(),
+      ),
+      hits,
+    },
+    null,
+    2,
+  ),
+);
+process.stderr.write(
+  `\n${hits.length} file(s) with isUsed across ${Object.keys(byRealm).length} realm(s). Wrote ${out}\n`,
+);


### PR DESCRIPTION
After the searchable-driven cutover, the `isUsed` field option no longer affects search-doc generation — `searchable` carries link depth and `isUsed` is inert. This sweeps `isUsed` out of realm card source so the option can later be removed from the card API without a leftover annotation breaking compilation. Because `searchable` already carries the depth, removing `isUsed` is behavior-neutral.

### Repo realms
- `packages/base` (`spec.gts`, `rich-markdown.gts`) and `packages/experiments-realm` (6 card defs): `isUsed` removed, `searchable` untouched. The diff is `isUsed`-only.

### Codemod tooling (`packages/realm-server/scripts/codemod/searchable/`)
- **`apply-local`**: `--strip-isused` with no `--derivation` now runs strip-only — it removes every `isUsed` and adds no `searchable` (skipping class-graph/route planning), so a realm that already carries its `searchable` annotations is edited only to drop the inert `isUsed`.
- **`apply-deployed`**: source acquisition reads the read-only EFS mount instead of `realm pull`; each affected module is stripped in-process and written back with boxel-cli `file write` (which mints its own realm JWT from the secret seed), then read back to confirm the write round-tripped. Dry-run by default; fault-isolated per file.
- **`scan-deployed-isused.mjs`**: walks the EFS mount and produces the hit list `apply-deployed` consumes.

Deployed user realms were swept with this tooling (staging then prod), each module read-back verified; a few pre-existing unparseable source files were reported and left untouched.
