### PR TITLE
Remove isUsed / usedLinksToFieldsOnly from the card API (CS-11725)

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -332,12 +332,6 @@ export type Searchable = true | string | string[];
 interface Options {
   computeVia?: () => unknown;
   description?: string;
-  // there exists cards that we only ever run in the host without
-  // the isolated renderer (RoomField), which means that we cannot
-  // use the rendering mechanism to tell if a card is used or not,
-  // in which case we need to tell the runtime that a card is
-  // explicitly being used.
-  isUsed?: true;
   // Names which links this field makes searchable. See `Searchable`.
   searchable?: Searchable;
   // Optional: per-usage configuration provider merged with FieldDef-level configuration
@@ -379,7 +373,6 @@ export interface FieldConstructor<T> {
   cardThunk: () => T;
   computeVia: undefined | (() => unknown);
   declaredCardThunk?: () => T;
-  isUsed?: true;
   isPolymorphic?: true;
   searchable?: Searchable;
   name: string;
@@ -576,12 +569,6 @@ export interface Field<
     value: any,
     resource: LooseCardResource,
   ): void;
-  // there exists cards that we only ever run in the host without
-  // the isolated renderer (RoomField), which means that we cannot
-  // use the rendering mechanism to tell if a card is used or not,
-  // in which case we need to tell the runtime that a card is
-  // explicitly being used.
-  isUsed?: true;
   isPolymorphic?: true;
   // The links this field makes searchable. This descriptor is the source of
   // truth; `getFieldDefinitions` mirrors it (raw) into the cached
@@ -659,7 +646,6 @@ class ContainsMany<FieldT extends FieldDefConstructor> implements Field<
   readonly computeVia: undefined | (() => unknown);
   readonly name: string;
   readonly description: string | undefined;
-  readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
   readonly searchable: Searchable | undefined;
   configuration: ConfigurationInput<any> | undefined;
@@ -667,14 +653,12 @@ class ContainsMany<FieldT extends FieldDefConstructor> implements Field<
     cardThunk,
     computeVia,
     name,
-    isUsed,
     isPolymorphic,
     searchable,
   }: FieldConstructor<FieldT>) {
     this.cardThunk = cardThunk;
     this.computeVia = computeVia;
     this.name = name;
-    this.isUsed = isUsed;
     this.isPolymorphic = isPolymorphic;
     this.searchable = searchable;
   }
@@ -989,7 +973,6 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
   readonly computeVia: undefined | (() => unknown);
   readonly name: string;
   readonly description: string | undefined;
-  readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
   readonly searchable: Searchable | undefined;
   configuration: ConfigurationInput<any> | undefined;
@@ -997,14 +980,12 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
     cardThunk,
     computeVia,
     name,
-    isUsed,
     isPolymorphic,
     searchable,
   }: FieldConstructor<CardT>) {
     this.cardThunk = cardThunk;
     this.computeVia = computeVia;
     this.name = name;
-    this.isUsed = isUsed;
     this.isPolymorphic = isPolymorphic;
     this.searchable = searchable;
   }
@@ -1220,7 +1201,6 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
   readonly computeVia: undefined | (() => unknown);
   readonly name: string;
   readonly description: string | undefined;
-  readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
   readonly searchable: Searchable | undefined;
   readonly configuration?: ConfigurationInput<any>;
@@ -1230,7 +1210,6 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
     declaredCardThunk,
     computeVia,
     name,
-    isUsed,
     isPolymorphic,
     searchable,
     queryDefinition,
@@ -1239,7 +1218,6 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
     this.declaredCardThunk = declaredCardThunk ?? cardThunk;
     this.computeVia = computeVia;
     this.name = name;
-    this.isUsed = isUsed;
     this.isPolymorphic = isPolymorphic;
     this.searchable = searchable;
     this.queryDefinition = queryDefinition;
@@ -1659,7 +1637,6 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
   private declaredCardCache: FieldT | undefined;
   readonly computeVia: undefined | (() => unknown);
   readonly name: string;
-  readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
   readonly searchable: Searchable | undefined;
   readonly configuration?: ConfigurationInput<any>;
@@ -1669,7 +1646,6 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
     declaredCardThunk,
     computeVia,
     name,
-    isUsed,
     isPolymorphic,
     searchable,
     queryDefinition,
@@ -1678,7 +1654,6 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
     this.declaredCardThunk = declaredCardThunk ?? cardThunk;
     this.computeVia = computeVia;
     this.name = name;
-    this.isUsed = isUsed;
     this.isPolymorphic = isPolymorphic;
     this.searchable = searchable;
     this.queryDefinition = queryDefinition;
@@ -2322,12 +2297,11 @@ export function containsMany<FieldT extends FieldDefConstructor>(
 ): BaseInstanceType<FieldT>[] {
   return {
     setupField(fieldName: string, _ownerPrototype: BaseDef) {
-      let { computeVia, isUsed, searchable } = options ?? {};
+      let { computeVia, searchable } = options ?? {};
       let instance = new ContainsMany({
         cardThunk: cardThunk(field),
         computeVia,
         name: fieldName,
-        isUsed,
         searchable,
       });
       (instance as any).configuration = options?.configuration;
@@ -2343,12 +2317,11 @@ export function contains<FieldT extends FieldDefConstructor>(
 ): BaseInstanceType<FieldT> {
   return {
     setupField(fieldName: string, _ownerPrototype: BaseDef) {
-      let { computeVia, isUsed, searchable } = options ?? {};
+      let { computeVia, searchable } = options ?? {};
       let instance = new Contains({
         cardThunk: cardThunk(field),
         computeVia,
         name: fieldName,
-        isUsed,
         searchable,
       });
       (instance as any).configuration = options?.configuration;
@@ -2364,7 +2337,7 @@ export function linksTo<CardT extends LinkableDefConstructor>(
 ): BaseInstanceType<CardT> {
   return {
     setupField(fieldName: string, ownerPrototype: BaseDef) {
-      let { computeVia, isUsed, searchable, query } = options ?? {};
+      let { computeVia, searchable, query } = options ?? {};
       let fieldCardThunk = cardThunk(cardOrThunk);
       if (query) {
         validateRelationshipQuery(ownerPrototype, fieldName, query);
@@ -2374,7 +2347,6 @@ export function linksTo<CardT extends LinkableDefConstructor>(
         declaredCardThunk: fieldCardThunk,
         computeVia,
         name: fieldName,
-        isUsed,
         searchable,
         queryDefinition: query,
       });
@@ -2391,7 +2363,7 @@ export function linksToMany<CardT extends LinkableDefConstructor>(
 ): BaseInstanceType<CardT>[] {
   return {
     setupField(fieldName: string, ownerPrototype: BaseDef) {
-      let { computeVia, isUsed, searchable, query } = options ?? {};
+      let { computeVia, searchable, query } = options ?? {};
       let fieldCardThunk = cardThunk(cardOrThunk);
       if (query) {
         validateRelationshipQuery(ownerPrototype, fieldName, query);
@@ -2401,7 +2373,6 @@ export function linksToMany<CardT extends LinkableDefConstructor>(
         declaredCardThunk: fieldCardThunk,
         computeVia,
         name: fieldName,
-        isUsed,
         searchable,
         queryDefinition: query,
       });

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -463,7 +463,6 @@ function computeFields(
         if (
           opts?.usedLinksToFieldsOnly &&
           !usedFields.includes(maybeFieldName) &&
-          !maybeField.isUsed &&
           !['contains', 'containsMany'].includes(maybeField.fieldType)
         ) {
           return [];

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
     "lint:hbs": "ember-template-lint .",
-    "lint:hbs:fix": "ember-template-lint . --fix"
+    "lint:hbs:fix": "ember-template-lint . --fix",
+    "lint:no-isused-option": "node scripts/check-no-isused-option.mjs"
   }
 }

--- a/packages/base/scripts/check-no-isused-option.mjs
+++ b/packages/base/scripts/check-no-isused-option.mjs
@@ -1,0 +1,48 @@
+// Enforces that the `isUsed` field option is not used in the base card API.
+// Which links a search doc follows is expressed through the `searchable` field
+// option; there is no per-field flag that forces a link into the doc.
+//
+// The type system rejects the option in typed code elsewhere, so this check
+// covers the base package where the option would be declared — a hit here is the
+// earliest signal it has crept in.
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const baseDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'declarations', '__boxel']);
+const SOURCE_EXT = /\.(gts|ts|js)$/;
+
+// Matched only in its field-option shape (`isUsed:` as an object-literal key),
+// never a `.isUsed` property access or a field named `isUsed`.
+const ISUSED_OPTION = /(?<![.\w])isUsed\s*:/;
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (!SKIP_DIRS.has(entry)) yield* walk(full);
+    } else if (SOURCE_EXT.test(entry)) {
+      yield full;
+    }
+  }
+}
+
+const violations = [];
+for (const file of walk(baseDir)) {
+  const lines = readFileSync(file, 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    if (ISUSED_OPTION.test(line)) {
+      violations.push(`${relative(baseDir, file)}:${i + 1}: ${line.trim()}`);
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error(
+    'Disallowed `isUsed` field option found — use the `searchable` field option instead:\n' +
+      violations.map((v) => `  ${v}`).join('\n'),
+  );
+  process.exit(1);
+}
+console.log('ok: no isUsed field option in base');

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -17,11 +17,9 @@ import {
   beginRuntimeDependencyTrackingSession,
   endRuntimeDependencyTrackingSession,
   formattedError,
-  baseRealm,
   snapshotRuntimeDependencies,
   SupportedMimeType,
   isCardError,
-  isBaseDefInstance,
   rri,
   type CardErrorsJSONAPI,
   type LooseSingleCardDocument,
@@ -38,7 +36,6 @@ import {
 } from '@cardstack/runtime-common/error';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
-import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
 import {
   windowErrorHandler,
@@ -532,12 +529,6 @@ export default class RenderRoute extends Route<Model> {
             realm: realmURL,
             doNotPersist: true,
           });
-          if (hydratedInstance) {
-            (globalThis as any).__boxelSetRenderStage?.(
-              'buildModel:touching-used-fields',
-            );
-            await this.#touchIsUsedFields(hydratedInstance);
-          }
           (globalThis as any).__boxelSetRenderStage?.(
             'buildModel:store-settle',
           );
@@ -569,137 +560,6 @@ export default class RenderRoute extends Route<Model> {
     (globalThis as any).__renderModel = model;
     this.currentTransition = undefined;
     return model;
-  }
-
-  async #touchIsUsedFields(instance: CardDef): Promise<void> {
-    let cardApi = await this.loaderService.loader.import<typeof CardAPI>(
-      `${baseRealm.url}card-api`,
-    );
-    this.#touchIsUsedRelationships(
-      cardApi,
-      instance,
-      new WeakSet<object>(),
-      new WeakMap<object, boolean>(),
-    );
-  }
-
-  #touchFieldSafely(container: any, fieldName: string): unknown {
-    try {
-      // accessing the field triggers lazy loading for links
-      return container?.[fieldName];
-    } catch (error) {
-      console.warn(
-        `Failed to touch field '${fieldName}' on ${container?.constructor?.name ?? 'Unknown'} for isUsed=true:`,
-        error,
-      );
-      return undefined;
-    }
-  }
-
-  #touchIsUsedRelationships(
-    cardApi: typeof CardAPI,
-    value: unknown,
-    visited: WeakSet<object>,
-    typeHasUsedRelationshipCache: WeakMap<object, boolean>,
-  ): void {
-    if (Array.isArray(value)) {
-      for (let item of value) {
-        this.#touchIsUsedRelationships(
-          cardApi,
-          item,
-          visited,
-          typeHasUsedRelationshipCache,
-        );
-      }
-      return;
-    }
-    if (!isBaseDefInstance(value)) {
-      return;
-    }
-    if (visited.has(value)) {
-      return;
-    }
-    visited.add(value);
-
-    let fields = cardApi.getFields(value, { includeComputeds: true });
-    for (let [fieldName, field] of Object.entries(fields)) {
-      if (!field) {
-        continue;
-      }
-      if (field.fieldType === 'linksTo' || field.fieldType === 'linksToMany') {
-        if (field.isUsed) {
-          this.#touchFieldSafely(value, fieldName);
-        }
-        continue;
-      }
-      if (
-        field.fieldType === 'contains' ||
-        field.fieldType === 'containsMany'
-      ) {
-        if (
-          !this.#typeHasIsUsedRelationship(
-            cardApi,
-            field.card as CardAPI.BaseDefConstructor,
-            new WeakSet<object>(),
-            typeHasUsedRelationshipCache,
-          )
-        ) {
-          continue;
-        }
-        let nested = this.#touchFieldSafely(value, fieldName);
-        this.#touchIsUsedRelationships(
-          cardApi,
-          nested,
-          visited,
-          typeHasUsedRelationshipCache,
-        );
-      }
-    }
-  }
-
-  #typeHasIsUsedRelationship(
-    cardApi: typeof CardAPI,
-    type: CardAPI.BaseDefConstructor,
-    visitedTypes: WeakSet<object>,
-    cache: WeakMap<object, boolean>,
-  ): boolean {
-    if (cache.has(type)) {
-      return cache.get(type)!;
-    }
-    if (visitedTypes.has(type)) {
-      return false;
-    }
-    visitedTypes.add(type);
-
-    let fields = cardApi.getFields(type, { includeComputeds: true });
-    for (let field of Object.values(fields)) {
-      if (!field) {
-        continue;
-      }
-      if (
-        (field.fieldType === 'linksTo' || field.fieldType === 'linksToMany') &&
-        field.isUsed
-      ) {
-        cache.set(type, true);
-        return true;
-      }
-      if (
-        (field.fieldType === 'contains' ||
-          field.fieldType === 'containsMany') &&
-        this.#typeHasIsUsedRelationship(
-          cardApi,
-          field.card as CardAPI.BaseDefConstructor,
-          visitedTypes,
-          cache,
-        )
-      ) {
-        cache.set(type, true);
-        return true;
-      }
-    }
-
-    cache.set(type, false);
-    return false;
   }
 
   setupController(controller: Controller, model: Model) {

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -1161,14 +1161,7 @@ export class RenderRunner {
         // First pass is the lightweight /types route — just the type
         // chain the ancestor renders below need. The full render.meta
         // (serialized + searchDoc + deps + displayNames) runs once
-        // afterwards, because the fitted/embedded ancestor renders are
-        // what mark linksTo / linksToMany fields as "used"; the final
-        // renderMeta's queryableValue then includes those linked fields
-        // in the search doc. Running render.meta before the ancestor
-        // renders breaks the isUsed-via-non-isolated-render contract
-        // that
-        // `non-isolated formats render linked fields and those links appear in search doc`
-        // covers.
+        // afterwards.
         if (!cardShortCircuit) {
           let typesResult = await runTimedStep<PrerenderTypes>(
             'visit card render.types',

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -3542,7 +3542,7 @@ module(basename(import.meta.filename), function () {
           }
         });
 
-        test('creates card instances when it encounters "lid" in the request for requests that has "isUsed: true" links', async function (assert) {
+        test('creates card instances when it encounters "lid" in the request for requests that have linksTo relationships', async function (assert) {
           let response = await request
             .patch('/hassan-x')
             .send({

--- a/packages/realm-server/tests/fixtures/realistic/friend-with-used-link.gts
+++ b/packages/realm-server/tests/fixtures/realistic/friend-with-used-link.gts
@@ -10,7 +10,7 @@ import StringField from 'https://cardstack.com/base/string';
 
 export class FriendWithUsedLink extends CardDef {
   @field firstName = contains(StringField);
-  @field friend = linksTo(() => FriendWithUsedLink, { isUsed: true }); // using isUsed: true will throw when ensureLinksLoaded encounters broken links
+  @field friend = linksTo(() => FriendWithUsedLink);
   @field friends = linksToMany(() => FriendWithUsedLink);
   @field cardTitle = contains(StringField, {
     computeVia: function (this: FriendWithUsedLink) {

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -331,7 +331,7 @@ export function getField<T extends BaseDef>(
       }
       if (fieldOverride) {
         let cardThunk = fieldOverride;
-        let { computeVia, name, isUsed, queryDefinition } = result;
+        let { computeVia, name, queryDefinition } = result;
         let originalField = result;
         let declaredCardThunk =
           (originalField as any).declaredCardResolver ??
@@ -343,7 +343,6 @@ export function getField<T extends BaseDef>(
           declaredCardThunk,
           computeVia,
           name,
-          isUsed,
           isPolymorphic: true,
           queryDefinition,
         }) as Field;


### PR DESCRIPTION
The `isUsed` field option is a per-field escape hatch that forced a link into a card's search doc. Search-doc link depth is expressed through the `searchable` field option, and no realm source sets `isUsed`, so the option is dead. This removes it from the card API.

## Removed

- `isUsed` from `Options` / `RelationshipOptions`, the `Field` interface, the four field classes (Contains / ContainsMany / LinksTo / LinksToMany), the field factories, and the polymorphic-field rebuild in `runtime-common/code-ref`.
- The `isUsed` term from the `computeFields` link filter (nothing sets the option, so dropping it is a no-op).
- The prerender render route's `#touchIsUsed*` pass, which force-loaded `isUsed` links during render — unnecessary now that search-doc generation does its own targeted link loading.

## Kept

`usedLinksToFieldsOnly` stays. It is the serialization mechanism that keeps un-materialized links out of a card's indexed `data.relationships` — independent of the `isUsed` escape hatch, and load-bearing for indexing.

## Guard

`packages/base/scripts/check-no-isused-option.mjs` (wired into `pnpm lint`) fails if the `isUsed` field option reappears in the base API.

## Safety

Behavior-neutral: no realm source (in-repo or deployed) sets `isUsed`, so the option and its now-dead code paths carry no effect. Type-check and eslint clean.

Stacked on the branch that strips `isUsed` from realm sources; base retargets to `main` before merge. The `searchable` authoring skill and `dev-*` doc updates ship from the boxel-skills repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
