### PR TITLE
Fix flaky delete-realm test: wait for the published realm index to settle before deleting

### DIFF
--- a/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
@@ -703,6 +703,37 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (hooks) {
     let publishedRealmId = publishResponse.body.data.id as string;
     // Phase 3: drive reconcile so the published realm shows up in realms[].
     await context.testRealmServer.testingOnlyReconcile();
+
+    // _publish-realm returns 202 before the published realm's from-scratch
+    // index finishes; the background mount keeps writing its boxel_index /
+    // realm_versions rows. The DELETE below removes those same rows via
+    // removeRealmDatabaseArtifacts, so issuing it while that index is still in
+    // flight races the indexer's writes against the delete's and intermittently
+    // fails the transaction with a 500. Wait for the index to commit —
+    // realm_versions.current_version >= 1 lands atomically with the rest of the
+    // from-scratch pass — and for no indexing job to remain queued, before
+    // tearing the realm down.
+    await waitUntil(
+      async () => {
+        let versionRows = await context.dbAdapter.execute(
+          `SELECT current_version FROM realm_versions WHERE realm_url = '${publishedRealmURL}' AND current_version >= 1 LIMIT 1`,
+        );
+        if (versionRows.length === 0) {
+          return undefined;
+        }
+        let pendingJobs = await context.dbAdapter.execute(
+          `SELECT id FROM jobs WHERE concurrency_group = 'indexing:${publishedRealmURL}' AND status = 'unfulfilled'`,
+        );
+        return pendingJobs.length === 0 ? versionRows : undefined;
+      },
+      {
+        timeout: 30_000,
+        interval: 100,
+        timeoutMessage:
+          'published realm from-scratch index did not settle before delete',
+      },
+    );
+
     let publishedRealmPath = join(
       context.dir.name,
       'realm_server_1',
@@ -755,7 +786,17 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (hooks) {
         }),
       );
 
-    assert.strictEqual(deleteResponse.status, 204, 'realm deleted');
+    assert.strictEqual(
+      deleteResponse.status,
+      204,
+      `realm deleted${
+        deleteResponse.status === 204
+          ? ''
+          : ` (got ${deleteResponse.status}: ${JSON.stringify(
+              deleteResponse.body,
+            )})`
+      }`,
+    );
     // Phase 3: unmount is reconciler-driven.
     await context.testRealmServer.testingOnlyReconcile();
     assert.false(


### PR DESCRIPTION
The `DELETE /_delete-realm still deletes a realm when a published copy is no longer mounted` test intermittently failed in CI with the DELETE returning 500 instead of 204.

`_publish-realm` returns 202 before the published realm's from-scratch index finishes — the background mount keeps writing its `boxel_index` / `realm_versions` / related rows. The test then unmounted the published copy and immediately issued `DELETE /_delete-realm`, whose `removeRealmDatabaseArtifacts` tears down those same rows. Firing the delete while that index was still in flight raced the indexer's writes against the delete's and intermittently failed the transaction with a 500.

The test now waits for the published realm's from-scratch index to commit (`realm_versions.current_version >= 1`, which lands atomically with the rest of the pass, plus no indexing job left queued) before unmounting and deleting. The delete assertion now includes the response body on failure so any future 500 is diagnosable from the CI log alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
