### PR TITLE
Gate the test-realm SW so it stops intercepting when unclaimed

### DIFF
--- a/packages/host/public/test-realm-sw.js
+++ b/packages/host/public/test-realm-sw.js
@@ -29,6 +29,12 @@ self.addEventListener('message', (event) => {
   let port = event.ports && event.ports[0];
   if (port) {
     port.postMessage({ ok: true, active });
+    // Release the transferred ack port promptly, as relayViaClient does.
+    try {
+      port.close();
+    } catch {
+      // Ignore errors when closing an already-closed port.
+    }
   }
 });
 

--- a/packages/host/public/test-realm-sw.js
+++ b/packages/host/public/test-realm-sw.js
@@ -6,7 +6,36 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(self.clients.claim());
 });
 
+// Interception is opt-in per module. `unregister()` does not evict an already
+// active worker from a still-loaded page, so once a module registers this SW it
+// keeps controlling the QUnit runner into later modules. If it kept intercepting
+// there, those modules (which never installed a `test-realm-fetch` responder)
+// would get a 503 for every test-realm fetch and cascade. Gating on `active`
+// lets a module turn interception on for its own tests and off on teardown, so a
+// lingering worker passes requests straight through — behaving exactly as if no
+// SW were installed, which is the state non-intercepting modules expect.
+//
+// Default off so a cold-started/terminated-and-restarted worker (which loses
+// this in-memory flag) fails safe toward passthrough rather than resurrecting
+// the leak; the owning module re-asserts `active` in its beforeEach.
+let active = false;
+
+self.addEventListener('message', (event) => {
+  let data = event.data;
+  if (!data || data.type !== 'test-realm-sw-set-active') {
+    return;
+  }
+  active = Boolean(data.active);
+  let port = event.ports && event.ports[0];
+  if (port) {
+    port.postMessage({ ok: true, active });
+  }
+});
+
 self.addEventListener('fetch', (event) => {
+  if (!active) {
+    return;
+  }
   if (!event.request.url.startsWith('http://test-realm/')) {
     return;
   }

--- a/packages/host/tests/helpers/test-realm-service-worker.ts
+++ b/packages/host/tests/helpers/test-realm-service-worker.ts
@@ -56,6 +56,13 @@ async function setSwActive(active: boolean): Promise<void> {
       settled = true;
       clearTimeout(timeout);
       channel.port1.onmessage = null;
+      // Release this side's port (port2 was transferred to the SW, which
+      // closes it after acking). Mirrors relayViaClient's port cleanup.
+      try {
+        channel.port1.close();
+      } catch {
+        // Ignore errors when closing an already-closed port.
+      }
       resolve();
     };
     let timeout = setTimeout(finish, 500);

--- a/packages/host/tests/helpers/test-realm-service-worker.ts
+++ b/packages/host/tests/helpers/test-realm-service-worker.ts
@@ -36,6 +36,36 @@ async function ensureRegistered(): Promise<void> {
   return swReady;
 }
 
+// Toggle the SW's interception. The worker defaults to passthrough and only
+// intercepts test-realm fetches while a module has turned it on, so a worker
+// that lingers past `unregister()` stops intercepting for later modules. Awaits
+// an ack (bounded, so a missing controller/ack never hangs a hook) to guarantee
+// the flag is applied before the module's tests issue their fetches.
+async function setSwActive(active: boolean): Promise<void> {
+  let controller = navigator.serviceWorker.controller;
+  if (!controller) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    let channel = new MessageChannel();
+    let settled = false;
+    let finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      channel.port1.onmessage = null;
+      resolve();
+    };
+    let timeout = setTimeout(finish, 500);
+    channel.port1.onmessage = finish;
+    controller.postMessage({ type: 'test-realm-sw-set-active', active }, [
+      channel.port2,
+    ]);
+  });
+}
+
 // Sets up a service worker that intercepts <img> requests to http://test-realm/
 // and relays them to the VirtualNetwork so that browser-native resource loads
 // (which bypass VirtualNetwork) can reach the test realm's files.
@@ -70,6 +100,8 @@ export function setupTestRealmServiceWorker(hooks: NestedHooks) {
       }
     };
     navigator.serviceWorker.addEventListener('message', handler);
+    // Only intercept once the responder above is listening.
+    await setSwActive(true);
   });
 
   hooks.afterEach(function () {
@@ -83,6 +115,12 @@ export function setupTestRealmServiceWorker(hooks: NestedHooks) {
   // doesn't persist and replace the auth service worker (which would break
   // the app if the user navigates from /tests back to / during ember serve).
   hooks.after(async function () {
+    // Stop intercepting before we let go of the registration: the worker keeps
+    // controlling the loaded page after unregister(), and later modules must
+    // see it as passthrough rather than a 503 source.
+    if ('serviceWorker' in navigator) {
+      await setSwActive(false);
+    }
     if (swRegistration) {
       await swRegistration.unregister();
       swRegistration = undefined;


### PR DESCRIPTION
## Problem

Host test shards fail intermittently with whole modules failing at setup (`Promise rejected before … [object Object]`) or hanging to a 60s timeout, with the app stuck on the **login form**. Recent examples on #5373 hit `theme-card-test`, `fallback-models`, `show-card`, `workspace-chooser-delete`, and `workspace-chooser archive`.

## Root cause: the test-realm service worker leaks across modules

`packages/host/public/test-realm-sw.js` intercepts every browser-level fetch to `http://test-realm/…` and relays it to the window via `postMessage`, returning `503 "No responsive client available"` if nothing replies within its **1500ms** relay timeout.

The client-side responder (the `test-realm-fetch` handler in `tests/helpers/test-realm-service-worker.ts`, via `setupTestRealmServiceWorker`) is installed **only** by the ~13 `image-def/*` and `audio-def/*` acceptance modules.

`unregister()` (called in that helper's `hooks.after`) does **not** evict an already-active worker from a still-loaded page — the active worker keeps controlling the QUnit runner until the page unloads. So once an image/audio module registers the SW, it lingers into later modules. A later module that does a `http://test-realm/` browser fetch but never installed a responder — e.g. boot-time `MatrixService.start → setSystemCard → store.get(http://test-realm/test/SystemCard/default)` — gets a **503**. Because a 503 (unlike the expected **404** for a missing SystemCard) is fatal to boot, the app renders the login form, and the module cascades or times out (60s waiting for operator-mode DOM that never appears).

Confirmed from the failing logs:
- The 503 body `No responsive client available` is emitted only at `test-realm-sw.js:~29`.
- Timeout diagnostics show the app fully settled and stuck on the login form; the boot failure is the SystemCard 503 during `IndexRootRoute.model`.
- Module order in a failing shard: `Acceptance | image def | opening an image URL in a new tab` (registers SW) → `Acceptance | workspace-chooser-delete` (victim), i.e. the exact leaked-SW adjacency.
- The `relation "jobs" does not exist` / `worker-fatal` lines that also appear are **shutdown-time noise** (timestamped after tests finish); not causal.

**Why it's flaky / shard-composition-sensitive:** it only bites when an image/audio module lands immediately before a non-SW module that fetches `test-realm/` URLs in the same shard/browser session. Adding tests reshuffles shard boundaries, so a PR that adds tests (or a stale branch) can trigger it while `main` doesn't.

## Fix

Gate interception on an `active` flag in the SW:
- Defaults to **passthrough** (off).
- The owning module turns it **on** in `beforeEach` (after the responder is listening) and **off** in `hooks.after` (before `unregister`), each via a small ack'd `postMessage`.
- A lingering worker then passes `test-realm/` requests straight through — behaving exactly as if no SW were installed, which is the state non-intercepting modules already expect and pass under. No responder is invoked for them, so there is no hanging-fetch failure mode.
- The flag defaults off so a terminated-and-restarted worker (which loses the in-memory flag) fails safe toward passthrough rather than resurrecting the leak; the owning module re-asserts it every `beforeEach`.

## Rejected alternative

An earlier attempt (on #5373, since reverted) made the responder **always-on** — installed globally and resolving the network at message time. That backfired: it called `virtualNetwork.fetch()` for every leaked request, and for slow/not-found/torn-down fetches the promise never resolved, holding a test waiter so `settled()` never completed — turning fast cascades into 243s timeouts and spreading failures from one shard to three. This PR takes the opposite tack (stop intercepting) rather than (always respond).

## Validation

Host tests can't be run locally (the `ember test --path dist` harness aborts at boot), so this is validated by CI on this branch. Lint + type-check pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
