### PR TITLE
Fix catalog typecheck: alias lodash to lodash-es

### DIFF
--- a/packages/catalog/tsconfig.json
+++ b/packages/catalog/tsconfig.json
@@ -25,6 +25,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "paths": {
+      "lodash": ["node_modules/@types/lodash-es"],
       "https://cardstack.com/base/*": [
         "../base/*.gts",
         "../base/*.ts",


### PR DESCRIPTION
## Summary
- Catalog card sources commonly import from `'lodash'`, which isn't an installed dependency anywhere in the monorepo (only `lodash-es` is) — `lint:types` fails with TS2307/TS7016 on any such import.
- The realm's virtual module loader already shims `'lodash'` to the `lodash-es` implementation at runtime (`packages/host/app/lib/externals.ts`), so cards run fine; `tsc` just had no equivalent mapping.
- Adds a `paths` alias in `packages/catalog/tsconfig.json` pointing `lodash` at `lodash-es`'s type declarations, mirroring the runtime shim so `tsc` and the loader agree.

## Test plan
- [x] `pnpm lint:types` in `packages/catalog` no longer reports lodash-related errors for cards importing from `'lodash'`
- [x] Verify boxel-catalog's `ci-lint.yaml` (which checks out this monorepo) goes green against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)