### PR TITLE
Fix markdown embed toolbar not swapping to Edit pencil for later refs

### DIFF
--- a/packages/host/tests/integration/components/codemirror-embed-toolbar-test.gts
+++ b/packages/host/tests/integration/components/codemirror-embed-toolbar-test.gts
@@ -297,6 +297,76 @@ module('Integration | codemirror embed toolbar', function (hooks) {
     );
   });
 
+  test('caret inside a directive after a lone backtick still swaps to Edit', async function (assert) {
+    // A stray lone backtick (here in `Mod-\``) must not pair — across a blank
+    // line — with the backtick fence below: that would form a spurious
+    // inline-code region hiding every directive in between, leaving their
+    // toolbar stuck on "+". The caret in each embed must show the Edit pencil.
+    let harness = new ContentHarness();
+    let content = [
+      '- Keyboard shortcuts (Mod-`)',
+      '',
+      `Inline card reference: :card[${mango}]`,
+      '',
+      `::card[${mango}]`,
+      '',
+      '```typescript',
+      'let greeting = "hi";',
+      '```',
+    ].join('\n');
+    harness.content = content;
+    await renderEditorAndModal({ CodeMirrorEditor, harness });
+
+    await waitFor('[data-test-codemirror-editor] .cm-content', {
+      timeout: 5000,
+    });
+
+    let editor = document.querySelector(
+      '[data-test-codemirror-editor] .cm-editor',
+    ) as HTMLElement | null;
+    let view = editor ? cmContext.EditorView.findFromDOM(editor) : null;
+    view?.focus();
+
+    let inlineStart = content.indexOf(`:card[${mango}]`);
+    let blockStart = content.indexOf(`::card[${mango}]`);
+
+    let placeCaret = async (head: number) => {
+      view?.dispatch({ selection: { anchor: head, head } });
+      await settled();
+    };
+
+    // Start of the inline directive.
+    await placeCaret(inlineStart);
+    await waitFor('[data-test-toolbar="edit-embed"]', { timeout: 5000 });
+    assert
+      .dom('[data-test-toolbar="edit-embed"]')
+      .exists('Edit pencil at the start of the 2nd (inline) embed');
+    assert.dom('[data-test-toolbar="add-embed"]').doesNotExist();
+
+    // Mid-URL of the inline directive.
+    await placeCaret(inlineStart + ':card['.length + 5);
+    await waitFor('[data-test-toolbar="edit-embed"]', { timeout: 5000 });
+    assert
+      .dom('[data-test-toolbar="edit-embed"]')
+      .exists('Edit pencil mid-URL of the 2nd (inline) embed');
+
+    // Mid-URL of the block directive.
+    await placeCaret(blockStart + '::card['.length + 5);
+    await waitFor('[data-test-toolbar="edit-embed"]', { timeout: 5000 });
+    assert
+      .dom('[data-test-toolbar="edit-embed"]')
+      .exists('Edit pencil mid-URL of the 3rd (block) embed');
+    assert.dom('[data-test-toolbar="add-embed"]').doesNotExist();
+
+    // Caret in prose between embeds falls back to the Add popover.
+    await placeCaret(content.indexOf('Inline card reference') + 3);
+    await waitFor('[data-test-toolbar="add-embed"]', { timeout: 5000 });
+    assert
+      .dom('[data-test-toolbar="add-embed"]')
+      .exists('caret in prose shows the Add button, not the pencil');
+    assert.dom('[data-test-toolbar="edit-embed"]').doesNotExist();
+  });
+
   test('Remove saves exactly once (no duplicate debounced save)', async function (assert) {
     let harness = new ContentHarness();
     harness.content = `:card[${mango}]`;

--- a/packages/host/tests/integration/components/codemirror-embed-toolbar-test.gts
+++ b/packages/host/tests/integration/components/codemirror-embed-toolbar-test.gts
@@ -297,11 +297,11 @@ module('Integration | codemirror embed toolbar', function (hooks) {
     );
   });
 
+  // A stray lone backtick (here in `Mod-\``) must not pair — across a blank
+  // line — with the backtick fence below: that would form a spurious
+  // inline-code region hiding every directive in between, leaving their
+  // toolbar stuck on "+". The caret in each embed must show the Edit pencil.
   test('caret inside a directive after a lone backtick still swaps to Edit', async function (assert) {
-    // A stray lone backtick (here in `Mod-\``) must not pair — across a blank
-    // line — with the backtick fence below: that would form a spurious
-    // inline-code region hiding every directive in between, leaving their
-    // toolbar stuck on "+". The caret in each embed must show the Edit pencil.
     let harness = new ContentHarness();
     let content = [
       '- Keyboard shortcuts (Mod-`)',

--- a/packages/host/tests/unit/bfm-card-references-test.ts
+++ b/packages/host/tests/unit/bfm-card-references-test.ts
@@ -1302,6 +1302,31 @@ module('Unit | bfm-card-references', function () {
       assert.strictEqual(ranges[0].url, './real');
     });
 
+    test('a lone backtick does not swallow later directives across a blank line', function (assert) {
+      // A stray lone backtick (here in `Mod-\``) must not pair — across a blank
+      // line — with a backtick in a later fence, which would form a spurious
+      // inline-code region hiding every directive in between. Inline code
+      // content ends at a paragraph break, so both real refs still surface and
+      // only the ref genuinely inside the fence is skipped.
+      let markdown = [
+        '- Keyboard shortcuts (Mod-`)',
+        '',
+        'Inline card reference: :card[./friend-1]',
+        '',
+        '::card[./jane-doe]',
+        '',
+        '```typescript',
+        ':card[./inside-fence]',
+        '```',
+      ].join('\n');
+      let ranges = extractBfmRefRanges(markdown);
+      assert.deepEqual(
+        ranges.map((r) => r.url),
+        ['./friend-1', './jane-doe'],
+        'inline and block refs after the lone backtick both surface; the fenced ref stays skipped',
+      );
+    });
+
     test('emits one range per site (no deduplication)', function (assert) {
       let markdown = ':card[./mango] then :card[./mango]';
       let ranges = extractBfmRefRanges(markdown);

--- a/packages/host/tests/unit/bfm-card-references-test.ts
+++ b/packages/host/tests/unit/bfm-card-references-test.ts
@@ -1327,6 +1327,30 @@ module('Unit | bfm-card-references', function () {
       );
     });
 
+    test('the lone-backtick guard also holds for CRLF line endings', function (assert) {
+      // Same scenario as above but with Windows CRLF (`\r\n`) breaks. The
+      // paragraph-break guard must recognize `\r\n\r\n` as a blank line, or the
+      // lone backtick pairs across it with the later fence and swallows the
+      // intervening directives.
+      let markdown = [
+        '- Keyboard shortcuts (Mod-`)',
+        '',
+        'Inline card reference: :card[./friend-1]',
+        '',
+        '::card[./jane-doe]',
+        '',
+        '```typescript',
+        ':card[./inside-fence]',
+        '```',
+      ].join('\r\n');
+      let ranges = extractBfmRefRanges(markdown);
+      assert.deepEqual(
+        ranges.map((r) => r.url),
+        ['./friend-1', './jane-doe'],
+        'CRLF blank lines end the code span just like LF; both real refs surface',
+      );
+    });
+
     test('emits one range per site (no deduplication)', function (assert) {
       let markdown = ':card[./mango] then :card[./mango]';
       let ranges = extractBfmRefRanges(markdown);

--- a/packages/runtime-common/bfm-card-references.ts
+++ b/packages/runtime-common/bfm-card-references.ts
@@ -8,8 +8,15 @@ import type { TokenizerAndRendererExtension } from './marked.mts';
 // These avoid backtick-in-regex issues that break content-tag in .gts files.
 const FENCED_CODE_RE = /```[\s\S]*?```/g;
 // Match code spans with any number of consecutive backticks as delimiter
-// (e.g. `code`, ``code``, ```code```).
-const INLINE_CODE_RE = new RegExp('(`+)([\\s\\S]*?)\\1', 'g');
+// (e.g. `code`, ``code``, ```code```). Content may span soft line breaks but
+// not a blank line: a paragraph break ends the span (per CommonMark). Without
+// the blank-line guard a stray lone backtick pairs lazily across blank lines
+// with a later fence, producing a spurious code region that swallows real
+// directives.
+const INLINE_CODE_RE = new RegExp(
+  '(`+)((?:(?!\\n[ \\t]*\\n)[\\s\\S])*?)\\1',
+  'g',
+);
 
 function resolveUrl(
   ref: string,

--- a/packages/runtime-common/bfm-card-references.ts
+++ b/packages/runtime-common/bfm-card-references.ts
@@ -12,9 +12,10 @@ const FENCED_CODE_RE = /```[\s\S]*?```/g;
 // not a blank line: a paragraph break ends the span (per CommonMark). Without
 // the blank-line guard a stray lone backtick pairs lazily across blank lines
 // with a later fence, producing a spurious code region that swallows real
-// directives.
+// directives. The `\r?` on each newline makes the paragraph-break guard fire
+// on CRLF line endings too, not just LF.
 const INLINE_CODE_RE = new RegExp(
-  '(`+)((?:(?!\\n[ \\t]*\\n)[\\s\\S])*?)\\1',
+  '(`+)((?:(?!\\r?\\n[ \\t]*\\r?\\n)[\\s\\S])*?)\\1',
   'g',
 );
 


### PR DESCRIPTION
## Summary

The markdown editor toolbar swaps its `+` ("Add embed") button for a pencil ("Edit embed") when the caret sits inside a `:card[…]` / `::card[…]` (or `:file` / `::file`) reference. In a document with several embeds, the first embed worked but the caret inside later embeds kept showing `+`.

## Root cause

`extractBfmRefRanges()` skips any directive that falls inside a code region, and code regions came from `INLINE_CODE_RE`. That regex allowed an inline code span's content to cross a blank line, so a stray lone backtick — e.g. in a bullet like `Keyboard shortcuts (Mod-\`)` — paired lazily, across the blank line and intervening prose, with the first backtick of a later ```` ``` ```` fenced block. The result was a spurious "inline code" region spanning everything in between, so every `:card` / `::card` directive it covered was treated as code and never got a range. No range → `_currentBfmRef` stayed null → the toolbar never swapped to the pencil. The first embed (before the stray backtick) was unaffected.

## Fix

Constrain inline code spans so their content cannot contain a blank line — a paragraph break ends the span, matching CommonMark and the render-side tokenizer. This is a strict tightening: single-line and soft-wrapped inline code still match; only cross-blank-line pairing is removed. The same regex is shared by `extractBfmReferences()`, so both call sites are corrected consistently.

## Screenshot

### Before
<img width="620" height="527" alt="Screenshot 2026-07-01 at 21 55 02" src="https://github.com/user-attachments/assets/c558a096-5cac-4996-93cb-77260b3ae68e" />


### After
<img width="595" height="469" alt="Screenshot 2026-07-02 at 16 42 02" src="https://github.com/user-attachments/assets/e41cb965-1b25-4e1e-87fd-defce62664ce" />




## Testing

- Unit: new `extractBfmRefRanges` regression asserting an inline and a block ref after a lone backtick both surface while a ref genuinely inside a fence stays skipped. Existing inline/fenced-code tests stay green.
- Integration (`codemirror embed toolbar`): new case placing the caret in the 2nd (inline) and 3rd (block) embeds after a lone backtick, asserting the Edit pencil appears and Add does not, plus a prose position that still shows Add.
- Verified locally: unit module 132/132 pass; the integration module passes against the running dev stack.

https://linear.app/cardstack/issue/CS-11753

🤖 Generated with [Claude Code](https://claude.com/claude-code)