### PR TITLE
Close race window in StoreService.patch() between snapshot and write-back

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -967,6 +967,28 @@ export default class StoreService extends Service implements StoreInterface {
     if (opts?.doNotPersist) {
       await this.stopAutoSaving(instance);
     }
+    // Resolve any linked-card relationships first. This can require a
+    // network fetch, and a sibling task elsewhere may mutate other fields on
+    // this same live instance while we wait. Snapshotting the instance below
+    // (for the merge + write-back further down) only after this resolves
+    // keeps that snapshot from going stale and reverting the sibling's write.
+    let linkedCards = await this.loadPatchedInstances(patch, instance.id);
+    for (let [field, value] of Object.entries(linkedCards)) {
+      if (field.includes('.')) {
+        let parts = field.split('.');
+        let leaf = parts.pop();
+        if (!leaf) {
+          throw new Error(`bug: error in field name "${field}"`);
+        }
+        let inner = instance;
+        for (let part of parts) {
+          inner = (inner as any)[part];
+        }
+        (inner as any)[leaf.match(/^\d+$/) ? Number(leaf) : leaf] = value;
+      } else {
+        (instance as any)[field] = value;
+      }
+    }
     let doc = await this.cardService.serializeCard(instance, {
       omitQueryFields: true,
     });
@@ -989,23 +1011,6 @@ export default class StoreService extends Service implements StoreInterface {
     }
     if (patch.meta) {
       doc.data.meta = merge(doc.data.meta, patch.meta);
-    }
-    let linkedCards = await this.loadPatchedInstances(patch, instance.id);
-    for (let [field, value] of Object.entries(linkedCards)) {
-      if (field.includes('.')) {
-        let parts = field.split('.');
-        let leaf = parts.pop();
-        if (!leaf) {
-          throw new Error(`bug: error in field name "${field}"`);
-        }
-        let inner = instance;
-        for (let part of parts) {
-          inner = (inner as any)[part];
-        }
-        (inner as any)[leaf.match(/^\d+$/) ? Number(leaf) : leaf] = value;
-      } else {
-        (instance as any)[field] = value;
-      }
     }
     let api = await this.cardService.getAPI();
     await api.updateFromSerialized(instance, doc, this.store);

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -1596,15 +1596,19 @@ module('Integration | Store', function (hooks) {
     let instance = (await storeService.get(targetId)) as any;
 
     let gate = new Deferred<void>();
-    let originalLoadPatchedInstances = (
-      storeService as any
-    ).loadPatchedInstances.bind(storeService);
-    (storeService as any).loadPatchedInstances = async (...args: any[]) => {
-      let result = await originalLoadPatchedInstances(...args);
+    let enteredGate = new Deferred<void>();
+    let originalLoadPatchedInstances = (storeService as any)
+      .loadPatchedInstances;
+    (storeService as any).loadPatchedInstances = async function (
+      this: unknown,
+      ...args: any[]
+    ) {
+      let result = await originalLoadPatchedInstances.apply(this, args);
       // simulate a slow relationship load (e.g. fetching a not-yet-cached
       // linked card) so a concurrent field write on the same live instance
-      // can land in the window between the patch's initial snapshot and its
+      // can land in the window between the patch's snapshot and its
       // eventual write-back
+      enteredGate.fulfill();
       await gate.promise;
       return result;
     };
@@ -1617,6 +1621,11 @@ module('Integration | Store', function (hooks) {
           },
         },
       });
+
+      // wait until the patch has actually reached the gated relationship
+      // load before mutating a sibling field, so the write lands squarely in
+      // the window the patch's snapshot needs to still be sensitive to
+      await enteredGate.promise;
 
       // a sibling background task (e.g. an unrelated auto-linking step, as in
       // the catalog listing-create flow) mutates a different field on the

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -1591,6 +1591,56 @@ module('Integration | Store', function (hooks) {
     );
   });
 
+  test('a concurrent field write during store.patch is not clobbered by the patch’s stale snapshot', async function (assert) {
+    let targetId = `${testRealmURL}Person/hassan`;
+    let instance = (await storeService.get(targetId)) as any;
+
+    let gate = new Deferred<void>();
+    let originalLoadPatchedInstances = (
+      storeService as any
+    ).loadPatchedInstances.bind(storeService);
+    (storeService as any).loadPatchedInstances = async (...args: any[]) => {
+      let result = await originalLoadPatchedInstances(...args);
+      // simulate a slow relationship load (e.g. fetching a not-yet-cached
+      // linked card) so a concurrent field write on the same live instance
+      // can land in the window between the patch's initial snapshot and its
+      // eventual write-back
+      await gate.promise;
+      return result;
+    };
+
+    try {
+      let patchPromise = storeService.patch(targetId, {
+        relationships: {
+          bestFriend: {
+            links: { self: `${testRealmURL}Person/jade` },
+          },
+        },
+      });
+
+      // a sibling background task (e.g. an unrelated auto-linking step, as in
+      // the catalog listing-create flow) mutates a different field on the
+      // same live instance while the patch above is still in flight
+      instance.name = 'Race Winner';
+
+      gate.fulfill();
+      await patchPromise;
+    } finally {
+      (storeService as any).loadPatchedInstances = originalLoadPatchedInstances;
+    }
+
+    assert.strictEqual(
+      instance.name,
+      'Race Winner',
+      "the concurrent field write is not clobbered by the patch's stale snapshot",
+    );
+    assert.strictEqual(
+      instance.bestFriend?.id,
+      `${testRealmURL}Person/jade`,
+      'the patch itself was still applied',
+    );
+  });
+
   test('loads FileDef links from included resources', async function (assert) {
     await testRealm.writeMany(
       new Map<string, string>([


### PR DESCRIPTION
## Summary

There's a catalog listing-create command that creates a listing card, then kicks off about nine background tasks concurrently against that same card to auto-populate it — name, summary, tags, categories, license, examples, and specs get set directly, while a screenshot and thumbnail get attached via `PatchCardInstanceCommand` → `store.patch()`. Fields were silently disappearing after listing creation — a tag or category set by one task would vanish once another task's patch landed later.

The cause is in `StoreService.patch()`: it snapshots the instance, resolves the patch's relationship target (a network fetch), then reapplies the snapshot wholesale — so whatever another task wrote to the same instance during that fetch gets reverted when the stale snapshot writes back.

This reorders the method to resolve the relationship before taking the snapshot instead of after, so the snapshot can't go stale. No behavior change for the non-concurrent case.

## Why `patch()` resolves relationships at all

This isn't required to persist the patch — the server only needs the pointer, not the target's content. It's there because `LinksTo.deserialize()`'s lazy fallback (cache → `included[]` → `not-loaded` sentinel) assumes a live UI template that re-renders once the real value arrives, but most `patch()` callers are Commands — plain code with no equivalent "wait for it." Without the eager load, a patched relationship would come back as an unresolved placeholder for any caller whose target isn't already cached, with no automatic recovery.

This PR is intentionally scoped to the concurrency bug rather than also removing that eager load — `patch()`'s relationships path has other callers (the AI chat edit tools, code-mode field editing, submission-retry logic) that haven't been audited for whether they assume synchronous hydration.

## Test plan

- Added an integration test that gates the relationship-resolution step on a controlled `Deferred`, mutates an unrelated field on the same live instance while `patch()` is in flight, and asserts that field survives.
- Verified both directions locally: reverting just the reorder in `store.ts` fails the test (`actual: "Hassan"`, `expected: "Race Winner"`); with the reorder in place, it passes.