### PR TITLE
Room state: skill entry points as SkillDef refs by realm URL (CS-11556)

### DIFF
--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_FALLBACK_MODEL_ID,
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 
 import type {
@@ -40,6 +41,7 @@ import {
   buildPromptForModel,
   getPromptParts,
   getRelevantCards,
+  getSkillEntryPoints,
   getTools,
   SKILL_INSTRUCTIONS_MESSAGE,
 } from '@cardstack/runtime-common/ai';
@@ -7199,5 +7201,94 @@ module('fill missing capability fields from fallback constant', (hooks) => {
       true,
       'no-event branch fills toolsSupported from the default row',
     );
+  });
+});
+
+module('getSkillEntryPoints', () => {
+  function skillsConfigEvent(
+    content: Record<string, unknown>,
+    { origin_server_ts = 1000 }: { origin_server_ts?: number } = {},
+  ): DiscreteMatrixEvent {
+    return {
+      type: APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
+      event_id: `skills-${origin_server_ts}`,
+      origin_server_ts,
+      state_key: '',
+      content: {
+        enabledSkillCards: [],
+        disabledSkillCards: [],
+        commandDefinitions: [],
+        ...content,
+      },
+      sender: '@user:localhost',
+      room_id: 'room1',
+      unsigned: { age: 1000 },
+      status: EventStatus.SENT,
+    } as unknown as DiscreteMatrixEvent;
+  }
+
+  test('returns [] when there is no skills-config event', (assert) => {
+    assert.deepEqual(getSkillEntryPoints([]), []);
+  });
+
+  test('returns [] for a legacy skills-config event with no entry points', (assert) => {
+    let eventList = [
+      skillsConfigEvent({
+        enabledSkillCards: [{ sourceUrl: 'https://realm/u/jane/Skill/foo' }],
+      }),
+    ];
+    assert.deepEqual(getSkillEntryPoints(eventList), []);
+  });
+
+  test('reads the enabled entry points from the skills-config event', (assert) => {
+    let entryPoints = [
+      {
+        realm: 'https://realm/u/jane/',
+        url: 'https://realm/u/jane/skills/a/SKILL.md',
+      },
+      {
+        realm: 'https://realm/u/jane/',
+        url: 'https://realm/u/jane/skills/b/SKILL.md',
+      },
+    ];
+    let eventList = [
+      skillsConfigEvent({
+        enabledSkillEntryPoints: entryPoints,
+        disabledSkillEntryPoints: [
+          {
+            realm: 'https://realm/u/jane/',
+            url: 'https://realm/u/jane/skills/c/SKILL.md',
+          },
+        ],
+      }),
+    ];
+    assert.deepEqual(getSkillEntryPoints(eventList), entryPoints);
+  });
+
+  test('uses the latest skills-config event', (assert) => {
+    let latest = [
+      {
+        realm: 'https://realm/u/jane/',
+        url: 'https://realm/u/jane/skills/new/SKILL.md',
+      },
+    ];
+    let eventList = [
+      skillsConfigEvent(
+        {
+          enabledSkillEntryPoints: [
+            {
+              realm: 'https://realm/u/jane/',
+              url: 'https://realm/u/jane/skills/old/SKILL.md',
+            },
+          ],
+        },
+        { origin_server_ts: 1000 },
+      ),
+      skillsConfigEvent(
+        { enabledSkillEntryPoints: latest },
+        { origin_server_ts: 2000 },
+      ),
+    ];
+    assert.deepEqual(getSkillEntryPoints(eventList), latest);
   });
 });

--- a/packages/base/matrix-event.gts
+++ b/packages/base/matrix-event.gts
@@ -4,7 +4,7 @@ import type {
   ToolChoice,
 } from '@cardstack/runtime-common/helpers/ai';
 import type { CommandRequest } from '@cardstack/runtime-common/commands';
-import {
+import type {
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
   APP_BOXEL_CODE_PATCH_RESULT_MSGTYPE,
@@ -26,10 +26,12 @@ import {
   APP_BOXEL_STOP_GENERATING_EVENT_TYPE,
   CodeRef,
   APP_BOXEL_LLM_MODE,
-  type LLMMode,
-  type RealmResourceIdentifier,
 } from '@cardstack/runtime-common';
-import { type SerializedFile } from './file-api';
+import type {
+  LLMMode,
+  RealmResourceIdentifier,
+} from '@cardstack/runtime-common';
+import type { SerializedFile } from './file-api';
 
 interface BaseMatrixEvent {
   sender: string;
@@ -260,12 +262,28 @@ export interface CardMessageContent {
   };
 }
 
+// A pull-model skill entry point: a room's advertised reference to a skill,
+// held by realm URL rather than uploaded into Matrix. The bot resolves the
+// SKILL.md live over HTTP at tool-call time (see the `readRealmFile` tool),
+// so edits to the skill are always reflected without re-enabling it. Carries
+// both the realm root (what a delegated read token is scoped to) and the full
+// file URL, the pair the read tool needs.
+export interface SkillEntryPoint {
+  realm: string;
+  url: string;
+}
+
 export interface SkillsConfigEvent extends RoomStateEvent {
   type: typeof APP_BOXEL_ROOM_SKILLS_EVENT_TYPE;
   content: {
     enabledSkillCards: SerializedFile[];
     disabledSkillCards: SerializedFile[];
     commandDefinitions?: SerializedFile[];
+    // Pull-model skill entry points, referenced by realm URL. Optional so
+    // legacy events (push-only, pre-pull-model) parse unchanged; the two lists
+    // mirror the enabled/disabled split of the legacy skill cards above.
+    enabledSkillEntryPoints?: SkillEntryPoint[];
+    disabledSkillEntryPoints?: SkillEntryPoint[];
   };
 }
 

--- a/packages/host/app/lib/matrix-classes/room.ts
+++ b/packages/host/app/lib/matrix-classes/room.ts
@@ -13,6 +13,7 @@ import type { SerializedFile } from 'https://cardstack.com/base/file-api';
 import type {
   ActiveLLMEvent,
   MatrixEvent as DiscreteMatrixEvent,
+  SkillEntryPoint,
 } from 'https://cardstack.com/base/matrix-event';
 
 import Mutex from '../mutex';
@@ -30,6 +31,8 @@ export type SkillsConfig = {
   enabledSkillCards: SerializedFile[];
   disabledSkillCards: SerializedFile[];
   commandDefinitions: SerializedFile[];
+  enabledSkillEntryPoints: SkillEntryPoint[];
+  disabledSkillEntryPoints: SkillEntryPoint[];
 };
 
 export default class Room {
@@ -79,7 +82,7 @@ export default class Room {
     return this._roomState !== undefined;
   }
 
-  get skillsConfig() {
+  get skillsConfig(): SkillsConfig {
     const content = this._roomState?.events
       .get(APP_BOXEL_ROOM_SKILLS_EVENT_TYPE)
       ?.get('')?.event.content ?? {
@@ -96,10 +99,8 @@ export default class Room {
         ? content.disabledSkillCards
         : [],
       commandDefinitions: content.commandDefinitions ?? [],
-    } as {
-      enabledSkillCards: SerializedFile[];
-      disabledSkillCards: SerializedFile[];
-      commandDefinitions: SerializedFile[];
+      enabledSkillEntryPoints: content.enabledSkillEntryPoints ?? [],
+      disabledSkillEntryPoints: content.disabledSkillEntryPoints ?? [],
     };
   }
 

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -35,6 +35,7 @@ import type {
   MatrixEvent as DiscreteMatrixEvent,
   EncodedCommandRequest,
   MatrixEventWithBoxelContext,
+  SkillEntryPoint,
   SkillsConfigEvent,
   Tool,
 } from 'https://cardstack.com/base/matrix-event';
@@ -457,6 +458,21 @@ export async function getDisabledSkillIds(
   return skillsConfigEvent.content.disabledSkillCards.map(
     (serializedFile) => serializedFile.sourceUrl,
   );
+}
+
+// A room's advertised pull-model skill entry points (SkillDef refs by realm
+// URL), read from the latest skills-config state event. These are the skills
+// the bot lists in the tier-1 prompt and resolves on demand via `readRealmFile`
+// — distinct from the legacy pushed `enabledSkillCards`. Returns [] for legacy
+// rooms that predate the pull model.
+export function getSkillEntryPoints(
+  eventList: DiscreteMatrixEvent[],
+): SkillEntryPoint[] {
+  let skillsConfigEvent = findLast(
+    eventList,
+    (event) => event.type === APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
+  ) as SkillsConfigEvent;
+  return skillsConfigEvent?.content.enabledSkillEntryPoints ?? [];
 }
 
 function setRelevantCards(


### PR DESCRIPTION
## What

Extends the skills-config room state event so a room can advertise **skill entry points** — references to skills by realm URL — alongside the legacy pushed skill cards.

An entry point is a pure reference:

```ts
interface SkillEntryPoint {
  realm: string; // realm root a delegated read token is scoped to
  url: string;   // full URL of the SKILL.md within that realm
}
```

No content is uploaded into Matrix. The bot resolves the SKILL.md live over HTTP via the `readRealmFile` tool, so edits to a skill are always reflected without re-enabling it. The `{ realm, url }` pair is exactly what that tool needs.

## Why

This is the room-state foundation for the pull model in the AI Assistant. It's the data the bot lists in the tier-1 prompt and resolves on demand — distinct from the legacy `enabledSkillCards`, which are pushed into context in full.

## Shape notes

- The two new lists (`enabledSkillEntryPoints` / `disabledSkillEntryPoints`) are **optional** and mirror the enabled/disabled split of the legacy skill cards, so events written before the pull model parse unchanged and both mechanisms can coexist during the migration window.
- `update-room-skills` preserves entry points across writes (it spreads the existing config), so this change is additive and non-destructive.

## Scope

This PR is the contract + read accessors only:

- `SkillEntryPoint` type and the enabled/disabled lists on the event contract.
- The host room's `skillsConfig` accessor threads them through (defaulting to `[]`).
- `getSkillEntryPoints()` read helper for the bot's tier-1 prompt and `loadSkill` paths.

Tier-1 prompt assembly and the host UI for managing entry points are follow-ups.

## Testing

- New unit tests for `getSkillEntryPoints` (no event, legacy event, reads enabled entry points, uses the latest event).
- `ember-tsc` clean for host and ai-bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
