### PR TITLE
Fix catalog/base/skills/openrouter search returning zero results

### DIFF
--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -479,6 +479,44 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('fields[entry]=item: the included item id matches the entry even when pristine_doc was stored under a registered-prefix alias', async function (assert) {
+      // Realms with a registered alias prefix (catalog, base, skills,
+      // openrouter) store `pristine_doc.id` in that alias form for storage
+      // portability (`unresolveResourceInstanceURLs` at index time), while
+      // every other identifier this engine emits — the entry itself,
+      // its `item` relationship, `links.self` — uses the row's resolved URL.
+      // Simulate that storage shape directly (no need to stand up a fully
+      // aliased realm) and confirm the served item's identity still matches
+      // the relationship that points at it, not the stored alias.
+      await dbAdapter.execute(
+        `UPDATE boxel_index
+         SET pristine_doc = jsonb_set(pristine_doc, '{id}', '"@fake-alias/john"'::jsonb)
+         WHERE url = '${johnId}.json' AND type = 'instance'`,
+      );
+      try {
+        let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+          personQuery({ fields: { entry: ['item'] } }),
+        );
+        let entry = entryFor(doc, johnId)!;
+        assert.deepEqual(entry.relationships.item, {
+          data: { type: 'card', id: johnId },
+        });
+        let item = itemIn(doc, johnId);
+        assert.ok(
+          item,
+          'the included item is keyed by the resolved id the relationship points at, not the stored alias',
+        );
+        assert.strictEqual(item!.id, johnId);
+        assert.strictEqual(item!.links?.self, johnId);
+      } finally {
+        await dbAdapter.execute(
+          `UPDATE boxel_index
+           SET pristine_doc = jsonb_set(pristine_doc, '{id}', '"${johnId}"'::jsonb)
+           WHERE url = '${johnId}.json' AND type = 'instance'`,
+        );
+      }
+    });
+
     test('fields[entry]=item.<field>: sparse items carry meta.sparseFields', async function (assert) {
       let doc = await testRealm.realmIndexQueryEngine.searchEntries(
         personQuery({ fields: { entry: ['item.firstName'] } }),

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -1413,8 +1413,16 @@ export class RealmIndexQueryEngine {
     let invocationId = `${Date.now().toString(36)}-${Math.random()
       .toString(36)
       .slice(2, 8)}`;
-    let realmPath = new RealmPaths(realmURL, this.#realm.virtualNetwork);
-    let omitSet = new Set(omit);
+    let vnForIdentity = this.#realm.virtualNetwork;
+    let realmPath = new RealmPaths(realmURL, vnForIdentity);
+    // `omit`/root ids may arrive in either resolved-URL or registered-alias
+    // form (the search-entry item resource's id is always resolved, while a
+    // fetched linked resource's own pristine_doc-derived id — and the
+    // relationship pointing at it, `relationshipIdStr` below — stays in
+    // alias form for storage portability). Index both spellings under one
+    // key so a root recognized via one form still matches when the same
+    // card is reached again via the other.
+    let omitSet = new Set(omit.flatMap((id) => vnForIdentity.equivalentURLForms(id)));
     let visited = new Set<string>();
 
     type LayerItem = {
@@ -1434,7 +1442,9 @@ export class RealmIndexQueryEngine {
         if (visited.has(resource.id)) {
           continue;
         }
-        visited.add(resource.id);
+        for (let form of vnForIdentity.equivalentURLForms(resource.id)) {
+          visited.add(form);
+        }
       }
       layer.push({
         resource,

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -1416,13 +1416,18 @@ export class RealmIndexQueryEngine {
     let vnForIdentity = this.#realm.virtualNetwork;
     let realmPath = new RealmPaths(realmURL, vnForIdentity);
     // `omit`/root ids may arrive in either resolved-URL or registered-alias
-    // form (the search-entry item resource's id is always resolved, while a
+    // form (the entry's item resource id is always resolved, while a
     // fetched linked resource's own pristine_doc-derived id — and the
     // relationship pointing at it, `relationshipIdStr` below — stays in
-    // alias form for storage portability). Index both spellings under one
-    // key so a root recognized via one form still matches when the same
-    // card is reached again via the other.
-    let omitSet = new Set(omit.flatMap((id) => vnForIdentity.equivalentURLForms(id)));
+    // alias form for storage portability). `equivalentURLForms` only
+    // enumerates spellings of a *resolved* URL, so an alias-form input needs
+    // `toURLHref` first to reach the resolved form it can expand from;
+    // `toURLHref` is a no-op on an input that's already a resolved URL.
+    // Index every spelling under one key so a root recognized via one form
+    // still matches when the same card is reached again via another.
+    let allIdForms = (id: string) =>
+      vnForIdentity.equivalentURLForms(vnForIdentity.toURLHref(id));
+    let omitSet = new Set(omit.flatMap((id) => allIdForms(id)));
     let visited = new Set<string>();
 
     type LayerItem = {
@@ -1442,7 +1447,7 @@ export class RealmIndexQueryEngine {
         if (visited.has(resource.id)) {
           continue;
         }
-        for (let form of vnForIdentity.equivalentURLForms(resource.id)) {
+        for (let form of allIdForms(resource.id)) {
           visited.add(form);
         }
       }

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -427,9 +427,17 @@ export class RealmIndexQueryEngine {
         emitItem = false;
       }
       if (emitItem && pristine) {
+        // `pristine_doc` is stored with its id unresolved to the realm's
+        // registered alias prefix (e.g. `@cardstack/catalog/...`) for
+        // storage portability. The search-entry's `item` relationship
+        // always points at `cardUrl` (the row's resolved absolute URL,
+        // shared with the entry's own id) — the included resource's id
+        // must match that exactly or a JSON:API consumer's relationship
+        // lookup silently finds nothing.
         let item: CardResource<Saved> = {
           ...pristine,
-          links: { self: pristine.id },
+          id: cardUrl as RealmResourceIdentifier,
+          links: { self: cardUrl },
         };
         if (fieldset.item.kind === 'sparse') {
           item = buildSparseItemResource(item, fieldset.item.fields);


### PR DESCRIPTION
## Origin
Found while debugging the Virtual Piano App in the public catalog: its in-card song search (a `context.getCards` query for MusicSheet cards in the card's own realm) showed "No Music Sheets found" when the app ran from the catalog realm, yet the identical search worked after remixing the app into a personal realm. The backend returned all five MusicSheet results correctly — the host silently dropped every one of them at hydration because of the id mismatch below. Personal realms were immune only by coincidence: they have no registered alias prefix, so the stored id and the resolved URL happen to be the same string. (Same investigation also surfaced a realm-indexing failure mode, fixed separately in #5389.)

## Summary
- A search-entry response's `item` resource inherited its id straight from the stored `pristine_doc`, which realms with a registered alias prefix (catalog, base, skills, openrouter) store in unresolved alias form (e.g. `@cardstack/catalog/...`) for storage portability across environments.
- The item's own entry relationship always points at the row's resolved absolute URL instead, so the two ids never matched. A consumer doing a strict JSON:API `(type, id)` lookup on `included` (e.g. the host's search hydration) silently found nothing, so any search requesting `fields[entry]=item` against these realms returned zero hydrated results despite the backend having correct, fully-indexed data.
- Confirmed this is not just a local edge case — spot-checked staging's `boxel_index` and found the same id mismatch present across a majority of instance rows in the catalog/base/skills/openrouter realms there.
- Fix: set the item's `id`/`links.self` to the same resolved URL its relationship already uses, instead of trusting whatever form happened to be in storage.
- Follow-ups from review: `loadLinks`'s `visited`/`omitSet` now index every equivalent spelling of each root id (resolved first via `toURLHref`, then expanded via `equivalentURLForms`) so the resolved-form item id and alias-form linked-resource ids can't be treated as different cards.

## Test plan
- [x] Added a regression test that stores a card under a simulated alias-form `pristine_doc.id` and asserts the served item's id still matches its relationship
- [x] Red/green verified: with the fix reverted the regression test fails (included item not found under the resolved id — the exact reported symptom); with the fix it passes
- [x] Full `search-entries-engine-test.ts` module run: 22/22 pass on the rebased branch
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)