### PR TITLE
Isolate per-file indexing failures instead of aborting the whole realm

### DIFF
--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -5293,6 +5293,56 @@ module(basename(import.meta.filename), function () {
           'the recovered card is searchable with its new content',
         );
       });
+
+      test('a failed visit for a brand-new card records an instance error via the source-parse fallback', async function (assert) {
+        // A brand-new file has no prior index row, so the batch's
+        // tombstoned-types oracle can't identify it as a card — this is
+        // the path where the source re-parse fallback must decide.
+        failVisitsFor = 'pistachio.json';
+        await realm.write(
+          'pistachio.json',
+          JSON.stringify({
+            data: {
+              attributes: { firstName: 'Pistachio' },
+              meta: {
+                adoptsFrom: {
+                  module: rri('./person'),
+                  name: 'Person',
+                },
+              },
+            },
+          } as LooseSingleCardDocument),
+        );
+
+        let rows = (await testDbAdapter.execute(
+          `SELECT type, has_error, is_deleted,
+                  error_doc->>'message' as error_message
+           FROM boxel_index
+           WHERE url = '${testRealm}pistachio.json'
+           ORDER BY type`,
+        )) as {
+          type: string;
+          has_error: boolean;
+          is_deleted: boolean | null;
+          error_message: string | null;
+        }[];
+        assert.deepEqual(
+          rows.map((row) => row.type).sort(),
+          ['file', 'instance'],
+          'both file and instance error rows are recorded for the new card',
+        );
+        for (let row of rows) {
+          assert.true(
+            row.has_error,
+            `the ${row.type} row carries the failure as an error`,
+          );
+          assert.notOk(row.is_deleted, `the ${row.type} row is not deleted`);
+          assert.ok(
+            row.error_message?.includes('simulated transport failure'),
+            `the ${row.type} row's error_doc carries the underlying failure text`,
+          );
+        }
+      });
     });
   });
 });

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -14,6 +14,7 @@ import type {
   DBAdapter,
   DefinitionLookup,
   LooseSingleCardDocument,
+  Prerenderer,
   Realm,
   RealmPermissions,
   RealmAdapter,
@@ -28,6 +29,7 @@ import {
   cleanWhiteSpace,
   waitUntil,
   cardInfo,
+  getTestPrerenderer,
   setupPermissionedRealmCached,
   setupPermissionedRealmsCached,
   searchCardsForTest,
@@ -5131,6 +5133,164 @@ module(basename(import.meta.filename), function () {
           deletedFile,
           undefined,
           'deleted file is not retrievable',
+        );
+      });
+    });
+
+    module('per-file failure isolation', function (hooks) {
+      let realm: Realm;
+      let testDbAdapter: PgAdapter;
+      // URL substring the wrapper fails prerender visits for; unset =
+      // pass everything through to the real test prerenderer.
+      let failVisitsFor: string | undefined;
+
+      let delegatePromise: Promise<Prerenderer> | undefined;
+      let delegate = () => (delegatePromise ??= getTestPrerenderer());
+      // A transport-level failure (the prerender request aborting before a
+      // response exists) can only be simulated at the Prerenderer seam —
+      // the in-band error paths all require a response document.
+      let interceptingPrerenderer: Prerenderer = {
+        async prerenderModule(args) {
+          return (await delegate()).prerenderModule(args);
+        },
+        async prerenderVisit(args) {
+          if (failVisitsFor && args.url.includes(failVisitsFor)) {
+            throw new Error(
+              'Prerender request to /prerender-visit aborted after 120000ms (simulated transport failure)',
+            );
+          }
+          return (await delegate()).prerenderVisit(args);
+        },
+        async runCommand(args) {
+          return (await delegate()).runCommand(args);
+        },
+        async releaseBatch(args) {
+          await (await delegate()).releaseBatch?.(args);
+        },
+      };
+
+      hooks.beforeEach(function () {
+        failVisitsFor = undefined;
+      });
+
+      setupPermissionedRealmCached(hooks, {
+        mode: 'beforeEach',
+        realmURL: testRealm,
+        permissions: {
+          '*': ['read'],
+        },
+        fileSystem: makeTestRealmFileSystem(),
+        prerenderer: interceptingPrerenderer,
+        onRealmSetup({ dbAdapter, testRealm: r }) {
+          testDbAdapter = dbAdapter;
+          realm = r;
+        },
+      });
+
+      function mangoDoc(firstName: string): LooseSingleCardDocument {
+        return {
+          data: {
+            attributes: { firstName },
+            meta: {
+              adoptsFrom: {
+                module: rri('./person'),
+                name: 'Person',
+              },
+            },
+          },
+        };
+      }
+
+      async function mangoIndexRows() {
+        return (await testDbAdapter.execute(
+          `SELECT type, has_error, is_deleted,
+                  (pristine_doc IS NOT NULL) as has_pristine_doc,
+                  error_doc->>'message' as error_message
+           FROM boxel_index
+           WHERE url = '${testRealm}mango.json'
+           ORDER BY type`,
+        )) as {
+          type: string;
+          has_error: boolean;
+          is_deleted: boolean | null;
+          has_pristine_doc: boolean;
+          error_message: string | null;
+        }[];
+      }
+
+      test('a transport-level visit failure isolates to its file: the batch still commits and the card keeps last-known-good state under an error row', async function (assert) {
+        failVisitsFor = 'mango.json';
+        await realm.write('mango.json', JSON.stringify(mangoDoc('Mang-Mang')));
+
+        let rows = await mangoIndexRows();
+        assert.deepEqual(
+          rows.map((row) => row.type).sort(),
+          ['file', 'instance'],
+          'both the file and instance rows exist for the failed card',
+        );
+        for (let row of rows) {
+          assert.true(
+            row.has_error,
+            `the ${row.type} row carries the failure as an error`,
+          );
+          assert.notOk(
+            row.is_deleted,
+            `the ${row.type} row is not tombstoned by the transient failure`,
+          );
+          assert.ok(
+            row.error_message?.includes('simulated transport failure'),
+            `the ${row.type} row's error_doc carries the underlying failure text`,
+          );
+        }
+        let instanceRow = rows.find((row) => row.type === 'instance')!;
+        assert.true(
+          instanceRow.has_pristine_doc,
+          'the instance row preserves the last-known-good serialization',
+        );
+
+        // The failure was isolated: the same job's other work still
+        // committed. A sibling card written in the same realm version
+        // remains searchable, proving batch.done() ran.
+        let { data: others } = await searchCardsForTest(
+          realm.realmIndexQueryEngine,
+          {
+            filter: {
+              on: { module: rri(`${testRealm}person`), name: 'Person' },
+              eq: { firstName: 'Van Gogh' },
+            },
+          },
+        );
+        assert.strictEqual(
+          others.length,
+          1,
+          'sibling cards are still searchable after the failed visit',
+        );
+
+        // Recovery: once the transport failure clears, a rewrite indexes
+        // normally and the error state washes out.
+        failVisitsFor = undefined;
+        await realm.write(
+          'mango.json',
+          JSON.stringify(mangoDoc('Mango Recovered')),
+        );
+        rows = await mangoIndexRows();
+        assert.true(
+          rows.every((row) => !row.has_error),
+          'the error state clears once the visit succeeds',
+        );
+        let { data: recovered } = await searchCardsForTest(
+          realm.realmIndexQueryEngine,
+          {
+            filter: {
+              on: { module: rri(`${testRealm}person`), name: 'Person' },
+              eq: { firstName: 'Mango Recovered' },
+            },
+          },
+        );
+        assert.strictEqual(
+          recovered.length,
+          1,
+          'the recovered card is searchable with its new content',
         );
       });
     });

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -8,6 +8,7 @@ import {
   logger,
   hasCardExtension,
   hasExecutableExtension,
+  isCardResource,
   SupportedMimeType,
   jobIdentity,
   Deferred,
@@ -691,13 +692,43 @@ export class IndexRunner {
             }),
           );
       error.message = message;
-      let entry: FileErrorIndexEntry = {
+      let fileEntry: FileErrorIndexEntry = {
         type: 'file-error',
         error,
       };
-      await this.batch.updateEntry(url, entry);
+      await this.batch.updateEntry(url, fileEntry);
       this.#dependencyResolver.invalidateRelationshipDependencyRowCache(url);
       this.stats.fileErrors++;
+      // `Batch.invalidate()` already tombstoned every type this URL
+      // previously had in the index — for an existing card that's both
+      // `instance` and `file`. Overwriting only the `file` tombstone
+      // above would let batch.done() promote the untouched `instance`
+      // tombstone, silently removing a previously-good card from search
+      // over a transient error. Re-parse the file ourselves (the throw
+      // above lost visitFileForIndexingFused's internal determination)
+      // and write a matching instance-error row when it's a card, so
+      // the last-known-good instance survives the same as the in-band
+      // render-error path.
+      if (url.href.endsWith('.json')) {
+        try {
+          let fileRef = await this.#reader.readFile(url);
+          let resource = fileRef?.content
+            ? (JSON.parse(fileRef.content)?.data as unknown)
+            : undefined;
+          if (resource && isCardResource(resource)) {
+            let instanceEntry: InstanceErrorIndexEntry = {
+              type: 'instance-error',
+              error,
+            };
+            await this.batch.updateEntry(url, instanceEntry);
+            this.stats.instanceErrors++;
+          }
+        } catch (parseErr) {
+          this.#log.warn(
+            `${jobIdentity(this.#jobInfo)} could not determine whether ${url.href} is a card instance after its visit failed: ${(parseErr as Error)?.message}`,
+          );
+        }
+      }
     }
   }
 

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -18,6 +18,7 @@ import {
   type LooseCardResource,
   type InstanceEntry,
   type InstanceErrorIndexEntry,
+  type FileErrorIndexEntry,
   type RealmInfo,
   type FromScratchResult,
   type IncrementalResult,
@@ -35,7 +36,12 @@ import { moduleFrom } from './code-ref.ts';
 import type { RealmResourceIdentifier } from './realm-identifiers.ts';
 import type { CacheScope, DefinitionLookup } from './definition-lookup.ts';
 import type { VirtualNetwork } from './virtual-network.ts';
-import { isCardError } from './error.ts';
+import {
+  CardError,
+  coerceErrorMessage,
+  isCardError,
+  serializableError,
+} from './error.ts';
 import type { IndexingProgressEvent } from './worker.ts';
 import { canonicalURL } from './index-runner/dependency-url.ts';
 import { IndexRunnerDependencyManager } from './index-runner/dependency-resolver.ts';
@@ -658,9 +664,40 @@ export class IndexRunner {
         this.#log.info(
           `${jobIdentity(this.#jobInfo)} tried to visit file ${url.href}, but it no longer exists`,
         );
-      } else {
-        throw err;
+        return;
       }
+      // A transport-level failure (prerender timeout/abort, network error)
+      // never reaches performCardIndexing/performFileIndexing's own
+      // error-entry construction — visitFileForIndexingFused rethrows
+      // before calling indexCardWithResult/indexFileWithResults. Left
+      // uncaught here, one file's failure propagates out of the
+      // fromScratch/incremental visit loop, skips batch.done(), and
+      // discards every other successfully-visited file's rows for the
+      // whole job. Persist a file-error row instead so the failure is
+      // isolated to this URL, matching the error_doc pattern used for
+      // in-band render errors.
+      let message = coerceErrorMessage(
+        err,
+        `Indexing failed for ${url.href} with no error message (${jobIdentity(this.#jobInfo)})`,
+      );
+      this.#log.warn(
+        `${jobIdentity(this.#jobInfo)} failed to index ${url.href}, recording file-error: ${message}`,
+      );
+      let error = isCardError(err)
+        ? serializableError(err)
+        : serializableError(
+            Object.assign(new CardError(message, { status: 500 }), {
+              stack: (err as Error)?.stack,
+            }),
+          );
+      error.message = message;
+      let entry: FileErrorIndexEntry = {
+        type: 'file-error',
+        error,
+      };
+      await this.batch.updateEntry(url, entry);
+      this.#dependencyResolver.invalidateRelationshipDependencyRowCache(url);
+      this.stats.fileErrors++;
     }
   }
 

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -667,16 +667,18 @@ export class IndexRunner {
         );
         return;
       }
-      // A transport-level failure (prerender timeout/abort, network error)
-      // never reaches performCardIndexing/performFileIndexing's own
-      // error-entry construction — visitFileForIndexing rethrows
-      // before calling indexCardWithResult/indexFileWithResults. Left
-      // uncaught here, one file's failure propagates out of the
-      // fromScratch/incremental visit loop, skips batch.done(), and
-      // discards every other successfully-visited file's rows for the
-      // whole job. Persist a file-error row instead so the failure is
-      // isolated to this URL, matching the error_doc pattern used for
-      // in-band render errors.
+      // A transport-level failure of the index visit — its
+      // prerender-server request timing out/aborting, or a reader/network
+      // error — never reaches performCardIndexing/performFileIndexing's
+      // own error-entry construction: visitFileForIndexing rethrows
+      // before calling indexCardWithResult/indexFileWithResults. (HTML
+      // prerendering is a separate job; the request here is the index
+      // pass's own visit.) Left uncaught, one file's failure propagates
+      // out of the fromScratch/incremental visit loop, skips
+      // batch.done(), and discards every other successfully-visited
+      // file's rows for the whole job. Persist a file-error row instead
+      // so the failure is isolated to this URL, matching the error_doc
+      // pattern used for in-band render errors.
       let message = coerceErrorMessage(
         err,
         `Indexing failed for ${url.href} with no error message (${jobIdentity(this.#jobInfo)})`,
@@ -704,30 +706,35 @@ export class IndexRunner {
       // `instance` and `file`. Overwriting only the `file` tombstone
       // above would let batch.done() promote the untouched `instance`
       // tombstone, silently removing a previously-good card from search
-      // over a transient error. Re-parse the file ourselves (the throw
-      // above lost visitFileForIndexing's internal determination)
-      // and write a matching instance-error row when it's a card, so
-      // the last-known-good instance survives the same as the in-band
-      // render-error path.
-      if (url.href.endsWith('.json')) {
+      // over a transient error. The index is the oracle for "was this a
+      // card?": the batch records which live row types it tombstoned, so
+      // an existing card is protected even when the file can't be read —
+      // which may be exactly how the visit failed. Re-parsing the source
+      // is only the fallback for a brand-new file, which has no prior
+      // row to protect but should still surface its failure as an
+      // instance error when it's a card.
+      let isCardInstance =
+        this.batch.tombstonedLiveTypes(url.href)?.includes('instance') ?? false;
+      if (!isCardInstance && url.href.endsWith('.json')) {
         try {
           let fileRef = await this.#reader.readFile(url);
           let resource = fileRef?.content
             ? (JSON.parse(fileRef.content)?.data as unknown)
             : undefined;
-          if (resource && isCardResource(resource)) {
-            let instanceEntry: InstanceErrorIndexEntry = {
-              type: 'instance-error',
-              error,
-            };
-            await this.batch.updateEntry(url, instanceEntry);
-            this.stats.instanceErrors++;
-          }
+          isCardInstance = Boolean(resource && isCardResource(resource));
         } catch (parseErr) {
           this.#log.warn(
             `${jobIdentity(this.#jobInfo)} could not determine whether ${url.href} is a card instance after its visit failed: ${(parseErr as Error)?.message}`,
           );
         }
+      }
+      if (isCardInstance) {
+        let instanceEntry: InstanceErrorIndexEntry = {
+          type: 'instance-error',
+          error,
+        };
+        await this.batch.updateEntry(url, instanceEntry);
+        this.stats.instanceErrors++;
       }
     }
   }

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -669,7 +669,7 @@ export class IndexRunner {
       }
       // A transport-level failure (prerender timeout/abort, network error)
       // never reaches performCardIndexing/performFileIndexing's own
-      // error-entry construction — visitFileForIndexingFused rethrows
+      // error-entry construction — visitFileForIndexing rethrows
       // before calling indexCardWithResult/indexFileWithResults. Left
       // uncaught here, one file's failure propagates out of the
       // fromScratch/incremental visit loop, skips batch.done(), and
@@ -705,7 +705,7 @@ export class IndexRunner {
       // above would let batch.done() promote the untouched `instance`
       // tombstone, silently removing a previously-good card from search
       // over a transient error. Re-parse the file ourselves (the throw
-      // above lost visitFileForIndexingFused's internal determination)
+      // above lost visitFileForIndexing's internal determination)
       // and write a matching instance-error row when it's a card, so
       // the last-known-good instance survives the same as the in-band
       // render-error path.

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -265,6 +265,7 @@ export class Batch {
   // changed mid-attempt is re-visited rather than silently resumed
   // with stale content.
   #resumedRows = new Map<string, number | null>();
+  #tombstonedLiveTypes = new Map<string, BoxelIndexTable['type'][]>();
   // Correlation ID minted once per Batch and stamped into every row's
   // `diagnostics` via `updateEntry`, so operators can
   // `SELECT ... WHERE diagnostics->>'invalidationId' = '...'`
@@ -491,6 +492,18 @@ export class Batch {
    */
   get resumedRows(): ReadonlyMap<string, number | null> {
     return this.#resumedRows;
+  }
+
+  /**
+   * Row types `tombstoneEntries` overwrote with tombstones this pass,
+   * restricted to rows that were live (not already deleted) in the
+   * production index. IndexRunner's per-file failure isolation consults
+   * this to decide whether a failed URL had a card instance to protect —
+   * the index is a more reliable oracle than re-reading the file, since
+   * the read path may be exactly what failed.
+   */
+  tombstonedLiveTypes(url: string): BoxelIndexTable['type'][] | undefined {
+    return this.#tombstonedLiveTypes.get(url);
   }
 
   /**
@@ -1526,6 +1539,14 @@ export class Batch {
       return;
     }
     let existingTypes = await this.existingIndexTypes(toTombstone);
+    for (let [url, entries] of existingTypes) {
+      let liveTypes = entries
+        .filter((entry) => !entry.isDeleted)
+        .map((entry) => entry.type);
+      if (liveTypes.length > 0) {
+        this.#tombstonedLiveTypes.set(url, liveTypes);
+      }
+    }
     // `has_error` and `error_doc` are listed (with explicit false / null
     // values per row) so the upsert's ON CONFLICT SET clause clears them.
     // The primary key is `(url, realm_url, type)` — no `generation` —
@@ -1563,7 +1584,7 @@ export class Batch {
       if (!types || types.length === 0) {
         return [];
       }
-      return types.map((type) =>
+      return types.map(({ type }) =>
         [
           id,
           // The same file_alias form `updateEntry` writes, so a tombstone
@@ -1667,13 +1688,17 @@ export class Batch {
 
   private async existingIndexTypes(
     invalidations: string[],
-  ): Promise<Map<string, BoxelIndexTable['type'][]>> {
+  ): Promise<
+    Map<string, { type: BoxelIndexTable['type']; isDeleted: boolean }[]>
+  > {
     if (invalidations.length === 0) {
       return new Map();
     }
     let uniqueInvalidations = [...new Set(invalidations)];
+    // One row per (url, type) — the table's primary key is
+    // (url, realm_url, type) and the realm is pinned below.
     let rows = (await this.#query([
-      'SELECT DISTINCT url, type FROM boxel_index WHERE',
+      'SELECT url, type, is_deleted FROM boxel_index WHERE',
       ...every([
         ['realm_url =', param(this.realmURL.href)],
         [
@@ -1683,14 +1708,18 @@ export class Batch {
           ),
         ],
       ]),
-    ] as Expression)) as Pick<BoxelIndexTable, 'url' | 'type'>[];
-    let typesByUrl = new Map<string, BoxelIndexTable['type'][]>();
+    ] as Expression)) as Pick<BoxelIndexTable, 'url' | 'type' | 'is_deleted'>[];
+    let typesByUrl = new Map<
+      string,
+      { type: BoxelIndexTable['type']; isDeleted: boolean }[]
+    >();
     for (let row of rows) {
+      let entry = { type: row.type, isDeleted: Boolean(row.is_deleted) };
       let existing = typesByUrl.get(row.url);
       if (existing) {
-        existing.push(row.type);
+        existing.push(entry);
       } else {
-        typesByUrl.set(row.url, [row.type]);
+        typesByUrl.set(row.url, [entry]);
       }
     }
     return typesByUrl;


### PR DESCRIPTION
## Origin
Found while debugging the Virtual Piano App in the public catalog: its in-card song search showed "No Music Sheets found" when the app ran from the catalog realm, yet worked after remixing into a personal realm. First root cause: the local catalog realm's `boxel_index` was completely empty — its from-scratch reindex had gotten through 652 of 1166 files, hit one stuck prerender-visit request (a 120s abort on a listing-thumbnail PNG), and the whole job died, discarding all the already-indexed rows. The realm still mounted "successfully," so every search against it silently returned nothing. This PR fixes that all-or-nothing failure mode. (The same investigation surfaced a second, independent bug in how search results are hydrated for alias-prefixed realms, fixed in #5388.)

## Summary
- `IndexRunner.tryToVisit` rethrew any non-404 error from a file's visit — e.g. a transport-level failure of the index visit's own prerender-server request (timeout/abort), or a reader error — which unwound the entire `fromScratch`/`incremental` visit loop and skipped `batch.done()`. (HTML prerendering runs in a separate job; the request at issue is the index pass's own visit.)
- Since `batch.done()` is what promotes the working table into the live `boxel_index`, a single file's transport-level failure discarded every other already-successfully-indexed file in the same job — leaving the realm mounted but with an empty or stale search index, and no error surfaced anywhere.
- The indexer already isolates per-file failures for in-band render errors (an `error_doc` row for just that card), but a transport-level failure — where no response ever arrives — bypassed that model entirely and became all-or-nothing for the whole realm.
- Fix: catch non-404 failures per file and record a `file-error` entry for that URL, mirroring the existing `error_doc` pattern, so the rest of the realm still indexes and commits.
- Follow-up from review (Codex + @habdelra): `Batch.invalidate()` pre-tombstones every existing row type at a URL, so the file-error write alone would let an existing card's untouched `instance` tombstone be promoted — silently deleting a previously-good card from search over a transient error. And deciding "was this a card?" by re-reading the file was itself fragile: if the visit failed on the read path, the re-read fails the same way. The batch now records which live row types `tombstoneEntries` overwrote per URL (`Batch.tombstonedLiveTypes`), and `tryToVisit` writes the companion `instance-error` based on that index-derived answer — the source re-parse remains only as the fallback for brand-new files, which have no prior row to lose.

## Test plan
- [x] Regression test (`indexing-test.ts` › per-file failure isolation): a wrapping `Prerenderer` throws an abort-style transport error for one armed URL; asserts the incremental job still commits (sibling card stays searchable), both the `file` and `instance` rows carry the error without being tombstoned, the instance keeps its last-known-good `pristine_doc`, and a later successful rewrite clears the error state
- [x] Second regression test for the brand-new-card fallback: a new card whose first visit fails still gets both error rows via the source-parse fallback (no prior index row for the oracle to consult)
- [x] Red/green verified: with the fix reverted to main's version, the isolation test fails — the whole incremental-index job rejects with the injected transport error
- [x] Full `indexing-test.ts` run: 63/63 pass
- [x] `tsc --noEmit` clean on changed files
- [x] Branch rebased onto latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)