### PR TITLE
Change prefix-form RRI realms to serve RRI ids

### DIFF
--- a/packages/host/tests/integration/realm-test.gts
+++ b/packages/host/tests/integration/realm-test.gts
@@ -141,6 +141,64 @@ module('Integration | realm', function (hooks) {
     assert.ok(json.data.meta.lastModified, 'lastModified is populated');
   });
 
+  test('realm serves instance ids in canonical RRI form for a prefix-mapped realm', async function (assert) {
+    let { realm } = await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'dir/empty.json': {
+          data: {
+            meta: {
+              adoptsFrom: {
+                module: '@cardstack/base/card-api',
+                name: 'CardDef',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Without a realm-prefix mapping, instance ids are served in URL form.
+    let urlResponse = await handle(
+      realm,
+      new Request(`${testRealmURL}dir/empty`, {
+        headers: { Accept: 'application/vnd.card+json' },
+      }),
+    );
+    let urlDoc = await urlResponse.json();
+    assert.strictEqual(
+      urlDoc.data.id,
+      `${testRealmURL}dir/empty`,
+      'an unmapped realm serves the instance id in URL form',
+    );
+
+    // Registering a realm-prefix mapping makes the same GET serve the id (and
+    // links.self) in canonical RRI (prefix) form. The unresolve happens at
+    // serve time in getCard, so the mapping need not be present at index time.
+    getService('network').virtualNetwork.addRealmMapping(
+      '@test-prefix/',
+      testRealmURL,
+    );
+
+    let rriResponse = await handle(
+      realm,
+      new Request(`${testRealmURL}dir/empty`, {
+        headers: { Accept: 'application/vnd.card+json' },
+      }),
+    );
+    let rriDoc = await rriResponse.json();
+    assert.strictEqual(
+      rriDoc.data.id,
+      '@test-prefix/dir/empty',
+      'a prefix-mapped realm serves the instance id in canonical RRI form',
+    );
+    assert.strictEqual(
+      rriDoc.data.links.self,
+      '@test-prefix/dir/empty',
+      'links.self is served in canonical RRI form too',
+    );
+  });
+
   test('realm can serve GET card requests with linksTo relationships', async function (assert) {
     let { realm, adapter } = await setupIntegrationTestRealm({
       mockMatrixUtils,

--- a/packages/host/tests/integration/realm-test.gts
+++ b/packages/host/tests/integration/realm-test.gts
@@ -175,28 +175,31 @@ module('Integration | realm', function (hooks) {
     // Registering a realm-prefix mapping makes the same GET serve the id (and
     // links.self) in canonical RRI (prefix) form. The unresolve happens at
     // serve time in getCard, so the mapping need not be present at index time.
-    getService('network').virtualNetwork.addRealmMapping(
-      '@test-prefix/',
-      testRealmURL,
-    );
-
-    let rriResponse = await handle(
-      realm,
-      new Request(`${testRealmURL}dir/empty`, {
-        headers: { Accept: 'application/vnd.card+json' },
-      }),
-    );
-    let rriDoc = await rriResponse.json();
-    assert.strictEqual(
-      rriDoc.data.id,
-      '@test-prefix/dir/empty',
-      'a prefix-mapped realm serves the instance id in canonical RRI form',
-    );
-    assert.strictEqual(
-      rriDoc.data.links.self,
-      '@test-prefix/dir/empty',
-      'links.self is served in canonical RRI form too',
-    );
+    // The network service's VirtualNetwork is shared across tests, so remove
+    // the mapping afterward to avoid leaking it into later tests.
+    let virtualNetwork = getService('network').virtualNetwork;
+    virtualNetwork.addRealmMapping('@test-prefix/', testRealmURL);
+    try {
+      let rriResponse = await handle(
+        realm,
+        new Request(`${testRealmURL}dir/empty`, {
+          headers: { Accept: 'application/vnd.card+json' },
+        }),
+      );
+      let rriDoc = await rriResponse.json();
+      assert.strictEqual(
+        rriDoc.data.id,
+        '@test-prefix/dir/empty',
+        'a prefix-mapped realm serves the instance id in canonical RRI form',
+      );
+      assert.strictEqual(
+        rriDoc.data.links.self,
+        '@test-prefix/dir/empty',
+        'links.self is served in canonical RRI form too',
+      );
+    } finally {
+      virtualNetwork.removeRealmMapping('@test-prefix/');
+    }
   });
 
   test('realm can serve GET card requests with linksTo relationships', async function (assert) {

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -856,8 +856,8 @@ module(basename(import.meta.filename), function () {
           let etag = response.get('etag') ?? '';
           assert.ok(etag, 'response carries an ETag');
           assert.true(
-            /^"\d+(?:-[0-9a-f]+)?:card"$/.test(etag),
-            `ETag matches "<indexed_at>(-<realmInfoHash>)?:card" pattern (got ${etag})`,
+            /^"\d+(?:-[0-9a-f]+)?:card-rri"$/.test(etag),
+            `ETag matches "<indexed_at>(-<realmInfoHash>)?:card-rri" pattern (got ${etag})`,
           );
           assert.strictEqual(
             response.get('cache-control'),
@@ -2629,8 +2629,8 @@ module(basename(import.meta.filename), function () {
           let patchEtag = patchResponse.get('etag') ?? '';
           assert.ok(patchEtag, 'PATCH response carries an ETag');
           assert.true(
-            /^"\d+(?:-[0-9a-f]+)?:card"$/.test(patchEtag),
-            `PATCH ETag matches "<indexed_at>(-<realmInfoHash>)?:card" pattern (got ${patchEtag})`,
+            /^"\d+(?:-[0-9a-f]+)?:card-rri"$/.test(patchEtag),
+            `PATCH ETag matches "<indexed_at>(-<realmInfoHash>)?:card-rri" pattern (got ${patchEtag})`,
           );
           assert.notStrictEqual(
             patchEtag,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2110,6 +2110,16 @@ export class Realm {
     return statuses.length > 0 ? Math.min(...statuses) : 400;
   }
 
+  // Atomic operation hrefs may arrive in canonical RRI (prefix) form, since
+  // that is the form this realm now serves instance ids in. Resolve those to a
+  // real URL before doing path math; plain URL / relative hrefs pass through
+  // unchanged (they are not registered prefixes).
+  #resolveAtomicHref(href: string): string {
+    return this.#virtualNetwork.isRegisteredPrefix(href)
+      ? this.#virtualNetwork.toURL(href).href
+      : href;
+  }
+
   private async checkBeforeAtomicWrite(
     operations: AtomicOperation[],
   ): Promise<AtomicPayloadValidationError[]> {
@@ -2125,7 +2135,9 @@ export class Realm {
 
         let localPath: LocalPath;
         try {
-          localPath = this.paths.local(new URL(operation.href, this.paths.url));
+          localPath = this.paths.local(
+            new URL(this.#resolveAtomicHref(operation.href), this.paths.url),
+          );
         } catch (error: any) {
           errors.push({
             title: 'Invalid atomic:operations format',
@@ -2270,7 +2282,9 @@ export class Realm {
       for (let operation of operations) {
         let resource = operation.data;
         let href = operation.href;
-        let localPath = this.paths.local(new URL(href, this.paths.url));
+        let localPath = this.paths.local(
+          new URL(this.#resolveAtomicHref(href), this.paths.url),
+        );
         let exists = await this.#adapter.exists(localPath);
         if (operation.op === 'add' && exists) {
           return createResponse({

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -278,7 +278,14 @@ const SOURCE_ETAG_VARIANT = 'source';
 // `buildCardJsonEtag()` constructs the value; cards with foreign-
 // realm instance deps suppress emission entirely because cross-realm
 // invalidation doesn't cascade `indexed_at` today.
-const CARD_JSON_ETAG_VARIANT = 'card';
+//
+// Bump this variant whenever the served card-JSON representation changes so
+// caches revalidate instead of 304'ing a client to a stale body: neither
+// `indexed_at` nor the realm-info hash moves on a serialization change, so the
+// variant is the only signal that invalidates already-cached bodies. Bumped to
+// `card-rri` when the server began serving instance ids (`id`/`links.self`/
+// relationship ids) in canonical prefix (RRI) form for mapped realms.
+const CARD_JSON_ETAG_VARIANT = 'card-rri';
 
 // Postgres NOTIFY channel for cross-instance invalidation of #sourceCache /
 // #transpiledModuleCache entries on file writes. Two payload shapes:

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -94,7 +94,10 @@ import {
   userIdFromUsername,
   isCardDocumentString,
   isBrowserTestEnv,
+  unresolveResourceInstanceURLs,
   type IndexedFile,
+  type LooseCardResource,
+  type FileMetaResource,
 } from './index.ts';
 import type { FromScratchResult } from './tasks/indexer.ts';
 import { isCodeRef, visitModuleDeps } from './code-ref.ts';
@@ -2379,7 +2382,11 @@ export class Realm {
       let results: AtomicOperationResult[] = writeResults.map(
         ({ path, created }) => ({
           data: {
-            id: this.paths.fileURL(path).href,
+            // Serve the created instance id in canonical RRI (prefix) form, to
+            // match getCard / create / patch (no-op for unmapped realms).
+            id: this.#virtualNetwork.unresolveURL(
+              this.paths.fileURL(path).href,
+            ),
           },
           meta: {
             created,
@@ -4268,6 +4275,7 @@ export class Realm {
         links: { self: fileURL },
       },
     };
+    this.#serveInstanceIdsAsRRI(doc);
     return createResponse({
       body: JSON.stringify(doc, null, 2),
       init: {
@@ -4363,6 +4371,7 @@ export class Realm {
         links: { self: fileURL },
       },
     };
+    this.#serveInstanceIdsAsRRI(doc);
     return createResponse({
       body: JSON.stringify(doc, null, 2),
       init: {
@@ -4539,6 +4548,7 @@ export class Realm {
         meta: { lastModified },
       },
     });
+    this.#serveInstanceIdsAsRRI(doc);
     return createResponse({
       body: JSON.stringify(doc, null, 2),
       init: {
@@ -4716,6 +4726,7 @@ export class Realm {
           let etag = foreignDeps
             ? undefined
             : buildCardJsonEtag(entry.indexedAt, this.getCachedRealmInfoHash());
+          this.#serveInstanceIdsAsRRI(existingDoc);
           return createResponse({
             body: JSON.stringify(existingDoc, null, 2),
             init: {
@@ -4856,6 +4867,7 @@ export class Realm {
         entry && entry.type !== 'error' && !foreignDeps
           ? buildCardJsonEtag(entry.indexedAt, this.getCachedRealmInfoHash())
           : undefined;
+      this.#serveInstanceIdsAsRRI(doc);
       return createResponse({
         body: JSON.stringify(doc, null, 2),
         init: {
@@ -4941,6 +4953,22 @@ export class Realm {
       ? 'public'
       : 'private';
     return `${cacheVisibility}, max-age=0, must-revalidate`;
+  }
+
+  // Serve instance ids in canonical RRI (prefix) form. Unresolves the primary
+  // resource's `id` / `links.self` / relationship ids and every loaded link
+  // from URL to registered-prefix form. Unmapped realms have no prefix
+  // mapping, so this is a no-op there (ids stay URL). The write handlers derive
+  // the on-disk path from the request path / `lid` (not `data.id`), so accepting
+  // a prefix-form id needs no change — only the responses are canonicalized.
+  #serveInstanceIdsAsRRI(doc: {
+    data: LooseCardResource | FileMetaResource;
+    included?: (LooseCardResource | FileMetaResource)[];
+  }): void {
+    unresolveResourceInstanceURLs(doc.data, this.#virtualNetwork);
+    for (let resource of doc.included ?? []) {
+      unresolveResourceInstanceURLs(resource, this.#virtualNetwork);
+    }
   }
 
   private async getCard(
@@ -5116,6 +5144,7 @@ export class Realm {
       }
       let { doc: card } = maybeError;
       card.data.links = { self: url.href };
+      this.#serveInstanceIdsAsRRI(card);
 
       // The 302 redirect for the `.json` form is now done up-front
       // (see top of method). Here we only need to redirect for the


### PR DESCRIPTION
As seen here:

<img width="1492" height="804" alt="s 2026-07-03 at 17 14 17@2x" src="https://github.com/user-attachments/assets/47bd7d99-78bb-4e7f-9e30-7c65a34b00b5" />

One thing I’m unsure about: does [this](https://github.com/cardstack/boxel/pull/5390/changes#diff-b6059baf94cff52ea5df0ab5f23724bc3c52a3685ea3a844fc1d9c9c84192bddR288) ETag-related change make sense, for cache-breaking?