### PR TITLE
test: rename realm version to generation across the index schema

### DIFF
--- a/packages/boxel-cli/tests/integration/realm-indexing-errors.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-indexing-errors.test.ts
@@ -76,7 +76,7 @@ describe('realm indexing-errors (integration)', () => {
     // is needed since the /_indexing-errors endpoint reads it directly.
     await dbAdapter!.execute(
       `INSERT INTO boxel_index
-         (url, file_alias, type, realm_version, realm_url,
+         (url, file_alias, type, generation, realm_url,
           has_error, error_doc, diagnostics, is_deleted)
        VALUES ($1, $2, 'instance', 1, $3,
                TRUE, $4::jsonb, $5::jsonb, FALSE)`,
@@ -125,7 +125,7 @@ describe('realm indexing-errors (integration)', () => {
     ] as const) {
       await dbAdapter!.execute(
         `INSERT INTO boxel_index
-           (url, file_alias, type, realm_version, realm_url,
+           (url, file_alias, type, generation, realm_url,
             has_error, error_doc, is_deleted)
          VALUES ($1, $2, $3, 1, $4, TRUE, $5::jsonb, FALSE)`,
         {
@@ -174,7 +174,7 @@ describe('realm indexing-errors (integration)', () => {
 
     await dbAdapter!.execute(
       `INSERT INTO boxel_index
-         (url, file_alias, type, realm_version, realm_url,
+         (url, file_alias, type, generation, realm_url,
           has_error, error_doc, diagnostics, is_deleted)
        VALUES ($1, $2, 'instance', 1, $3,
                FALSE, NULL, $4::jsonb, FALSE)`,
@@ -207,7 +207,7 @@ describe('realm indexing-errors (integration)', () => {
 
     await dbAdapter!.execute(
       `INSERT INTO boxel_index
-         (url, file_alias, type, realm_version, realm_url,
+         (url, file_alias, type, generation, realm_url,
           has_error, error_doc, diagnostics, is_deleted)
        VALUES ($1, $2, 'file', 1, $3,
                FALSE, NULL, $4::jsonb, FALSE)`,
@@ -249,7 +249,7 @@ describe('realm indexing-errors (integration)', () => {
 
     await dbAdapter!.execute(
       `INSERT INTO boxel_index
-         (url, file_alias, type, realm_version, realm_url,
+         (url, file_alias, type, generation, realm_url,
           has_error, error_doc, diagnostics, is_deleted)
        VALUES ($1, $2, 'file', 1, $3,
                FALSE, NULL, $4::jsonb, FALSE)`,

--- a/packages/host/config/schema/1783004110683_schema.sql
+++ b/packages/host/config/schema/1783004110683_schema.sql
@@ -21,7 +21,7 @@
    url TEXT NOT NULL,
    file_alias TEXT NOT NULL,
    type TEXT NOT NULL,
-   realm_version INTEGER NOT NULL,
+   generation INTEGER NOT NULL,
    realm_url TEXT NOT NULL,
    pristine_doc BLOB,
    search_doc BLOB,
@@ -50,7 +50,7 @@
    url TEXT NOT NULL,
    file_alias TEXT NOT NULL,
    type TEXT NOT NULL,
-   realm_version INTEGER NOT NULL,
+   generation INTEGER NOT NULL,
    realm_url TEXT NOT NULL,
    pristine_doc BLOB,
    search_doc BLOB,
@@ -123,12 +123,18 @@
    PRIMARY KEY ( realm_url, file_path ) 
 );
 
+ CREATE TABLE IF NOT EXISTS realm_generations (
+   realm_url TEXT NOT NULL,
+   current_generation INTEGER NOT NULL,
+   PRIMARY KEY ( realm_url ) 
+);
+
  CREATE TABLE IF NOT EXISTS realm_meta (
    realm_url TEXT NOT NULL,
-   realm_version INTEGER NOT NULL,
+   generation INTEGER NOT NULL,
    value BLOB NOT NULL,
    indexed_at,
-   PRIMARY KEY ( realm_url, realm_version ) 
+   PRIMARY KEY ( realm_url, generation ) 
 );
 
  CREATE TABLE IF NOT EXISTS realm_metadata (
@@ -162,12 +168,6 @@
    write BOOLEAN NOT NULL,
    realm_owner BOOLEAN DEFAULT false NOT NULL,
    PRIMARY KEY ( realm_url, username ) 
-);
-
- CREATE TABLE IF NOT EXISTS realm_versions (
-   realm_url TEXT NOT NULL,
-   current_version INTEGER NOT NULL,
-   PRIMARY KEY ( realm_url ) 
 );
 
  CREATE TABLE IF NOT EXISTS unlisted_realm_paths (

--- a/packages/host/tests/helpers/indexer.ts
+++ b/packages/host/tests/helpers/indexer.ts
@@ -104,8 +104,8 @@ export type TestIndexRow =
 //    row in the boxel_index table, as well as any additional fields that you
 //    wish to set from the `data` object.
 //
-// the realm version table will default to version 1 of the testRealmURL if no
-// value is supplied
+// the realm generations table will default to generation 1 of the testRealmURL
+// if no value is supplied
 export async function setupIndex(client: DBAdapter): Promise<void>;
 export async function setupIndex(
   client: DBAdapter,

--- a/packages/host/tests/helpers/indexer.ts
+++ b/packages/host/tests/helpers/indexer.ts
@@ -16,7 +16,7 @@ import {
   type CardResource,
   type Expression,
   type BoxelIndexTable,
-  type RealmVersionsTable,
+  type RealmGenerationsTable,
   trimExecutableExtension,
   query,
   coerceTypes,
@@ -28,7 +28,7 @@ import type { CardDef } from 'https://cardstack.com/base/card-api';
 import { testRealmURL } from './index';
 
 const defaultIndexEntry = {
-  realm_version: 1,
+  generation: 1,
   realm_url: testRealmURL,
   has_error: false,
 };
@@ -113,30 +113,30 @@ export async function setupIndex(
 ): Promise<void>;
 export async function setupIndex(
   client: DBAdapter,
-  versionRows: RealmVersionsTable[],
+  versionRows: RealmGenerationsTable[],
   indexRows: { working: TestIndexRow[]; production: TestIndexRow[] },
 ): Promise<void>;
 export async function setupIndex(
   client: DBAdapter,
-  versionRows: RealmVersionsTable[],
+  versionRows: RealmGenerationsTable[],
   indexRows: TestIndexRow[],
 ): Promise<void>;
 export async function setupIndex(
   client: DBAdapter,
-  maybeVersionRows: RealmVersionsTable[] | TestIndexRow[] = [],
+  maybeVersionRows: RealmGenerationsTable[] | TestIndexRow[] = [],
   maybeWorkingProductionRows?:
     | TestIndexRow[]
     | { working: TestIndexRow[]; production: TestIndexRow[] },
 ): Promise<void> {
-  let versionRows: RealmVersionsTable[];
+  let versionRows: RealmGenerationsTable[];
   let workingRows: TestIndexRow[] = [];
   let productionRows: TestIndexRow[] = [];
   if (!maybeWorkingProductionRows) {
-    versionRows = [{ realm_url: testRealmURL, current_version: 1 }];
+    versionRows = [{ realm_url: testRealmURL, current_generation: 1 }];
     workingRows = maybeVersionRows as TestIndexRow[];
     productionRows = maybeVersionRows as TestIndexRow[];
   } else {
-    versionRows = maybeVersionRows as RealmVersionsTable[];
+    versionRows = maybeVersionRows as RealmGenerationsTable[];
     if (Array.isArray(maybeWorkingProductionRows)) {
       workingRows = maybeWorkingProductionRows as TestIndexRow[];
       productionRows = maybeWorkingProductionRows as TestIndexRow[];
@@ -203,7 +203,7 @@ export async function setupIndex(
     await query(
       client,
       [
-        `INSERT INTO realm_versions`,
+        `INSERT INTO realm_generations`,
         ...addExplicitParens(
           separatedByCommas(versionExpressions[0].nameExpressions),
         ),

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -338,7 +338,7 @@ module('Unit | query', function (hooks) {
         url: `${testRealmURL}1.json`,
         type: 'instance',
         has_error: true,
-        realm_version: 1,
+        generation: 1,
         realm_url: testRealmURL,
         pristine_doc: undefined,
         types: [],
@@ -351,7 +351,7 @@ module('Unit | query', function (hooks) {
       {
         url: `${testRealmURL}mango.json`,
         type: 'instance',
-        realm_version: 1,
+        generation: 1,
         realm_url: testRealmURL,
         pristine_doc: await serializeCard(mango),
         types: await getTypes(mango),
@@ -360,7 +360,7 @@ module('Unit | query', function (hooks) {
       {
         url: `${testRealmURL}vangogh.json`,
         type: 'instance',
-        realm_version: 1,
+        generation: 1,
         realm_url: testRealmURL,
         pristine_doc: await serializeCard(vangogh),
         types: await getTypes(vangogh),
@@ -1870,34 +1870,34 @@ module('Unit | query', function (hooks) {
     let { mango, vangogh, ringo } = testCards;
     await setupIndex(
       dbAdapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       {
         working: [
           {
             card: mango,
-            data: { realm_version: 1, search_doc: { name: 'Mango' } },
+            data: { generation: 1, search_doc: { name: 'Mango' } },
           },
           {
             card: vangogh,
-            data: { realm_version: 2, search_doc: { name: 'Mango' } },
+            data: { generation: 2, search_doc: { name: 'Mango' } },
           },
           {
             card: ringo,
-            data: { realm_version: 2, search_doc: { name: 'Ringo' } },
+            data: { generation: 2, search_doc: { name: 'Ringo' } },
           },
         ],
         production: [
           {
             card: mango,
-            data: { realm_version: 1, search_doc: { name: 'Mango' } },
+            data: { generation: 1, search_doc: { name: 'Mango' } },
           },
           {
             card: vangogh,
-            data: { realm_version: 1, search_doc: { name: 'Van Gogh' } },
+            data: { generation: 1, search_doc: { name: 'Van Gogh' } },
           },
           {
             card: ringo,
-            data: { realm_version: 1, search_doc: { name: 'Mango' } },
+            data: { generation: 1, search_doc: { name: 'Mango' } },
           },
         ],
       },
@@ -1927,34 +1927,34 @@ module('Unit | query', function (hooks) {
     let { mango, vangogh, ringo } = testCards;
     await setupIndex(
       dbAdapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       {
         working: [
           {
             card: mango,
-            data: { realm_version: 1, search_doc: { name: 'Mango' } },
+            data: { generation: 1, search_doc: { name: 'Mango' } },
           },
           {
             card: vangogh,
-            data: { realm_version: 2, search_doc: { name: 'Mango' } },
+            data: { generation: 2, search_doc: { name: 'Mango' } },
           },
           {
             card: ringo,
-            data: { realm_version: 1, search_doc: { name: 'Ringo' } },
+            data: { generation: 1, search_doc: { name: 'Ringo' } },
           },
         ],
         production: [
           {
             card: mango,
-            data: { realm_version: 1, search_doc: { name: 'Mango' } },
+            data: { generation: 1, search_doc: { name: 'Mango' } },
           },
           {
             card: vangogh,
-            data: { realm_version: 1, search_doc: { name: 'Van Gogh' } },
+            data: { generation: 1, search_doc: { name: 'Van Gogh' } },
           },
           {
             card: ringo,
-            data: { realm_version: 1, search_doc: { name: 'Ringo' } },
+            data: { generation: 1, search_doc: { name: 'Ringo' } },
           },
         ],
       },
@@ -3328,7 +3328,7 @@ module('Unit | query', function (hooks) {
         url: `${testRealmURL}vangogh.json`,
         file_alias: `${testRealmURL}vangogh`,
         type: 'instance',
-        realm_version: 1,
+        generation: 1,
         realm_url: testRealmURL,
         deps: [],
         types: [
@@ -3342,7 +3342,7 @@ module('Unit | query', function (hooks) {
         url: `${testRealmURL}jimmy.json`,
         file_alias: `${testRealmURL}jimmy`,
         type: 'instance',
-        realm_version: 1,
+        generation: 1,
         realm_url: testRealmURL,
         deps: [],
         types: [
@@ -3356,7 +3356,7 @@ module('Unit | query', function (hooks) {
         url: `${testRealmURL}donald.json`,
         file_alias: `${testRealmURL}donald`,
         type: 'instance',
-        realm_version: 1,
+        generation: 1,
         realm_url: testRealmURL,
         deps: [],
         types: [

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -143,43 +143,43 @@ module('Unit | index-writer', function (hooks) {
     await setupIndex(
       adapter,
       [
-        { realm_url: testRealmURL, current_version: 1 },
-        { realm_url: testRealmURL2, current_version: 5 },
+        { realm_url: testRealmURL, current_generation: 1 },
+        { realm_url: testRealmURL2, current_generation: 5 },
       ],
       [
         {
           url: `${testRealmURL}1.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           deps: [`${testRealmURL}2.json`],
         },
         {
           url: `${testRealmURL}2.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           deps: [`${testRealmURL}4.json`],
         },
         {
           url: `${testRealmURL}3.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           deps: [`${testRealmURL}2.json`],
         },
         {
           url: `${testRealmURL}4.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           deps: [],
         },
         {
           url: `${testRealmURL}5.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           deps: [],
         },
         {
           url: `${testRealmURL2}A.json`,
-          realm_version: 5,
+          generation: 5,
           realm_url: testRealmURL2,
           deps: [],
         },
@@ -201,7 +201,7 @@ module('Unit | index-writer', function (hooks) {
     ]);
 
     let invalidatedEntries = await adapter.execute(
-      'SELECT url, realm_url, is_deleted FROM boxel_index_working WHERE realm_version = 2 ORDER BY url COLLATE "POSIX"',
+      'SELECT url, realm_url, is_deleted FROM boxel_index_working WHERE generation = 2 ORDER BY url COLLATE "POSIX"',
       { coerceTypes: { is_deleted: 'BOOLEAN' } },
     );
     assert.deepEqual(
@@ -214,7 +214,7 @@ module('Unit | index-writer', function (hooks) {
       'the "work-in-progress" version of the index entries have been marked as deleted',
     );
     let otherRealms = await adapter.execute(
-      `SELECT url, realm_url, realm_version, is_deleted FROM boxel_index_working WHERE realm_url != '${testRealmURL}'`,
+      `SELECT url, realm_url, generation, is_deleted FROM boxel_index_working WHERE realm_url != '${testRealmURL}'`,
       { coerceTypes: { is_deleted: 'BOOLEAN' } },
     );
     assert.deepEqual(
@@ -223,25 +223,25 @@ module('Unit | index-writer', function (hooks) {
         {
           url: `${testRealmURL2}A.json`,
           realm_url: testRealmURL2,
-          realm_version: 5,
+          generation: 5,
           is_deleted: null,
         },
       ],
       'the index entries from other realms are unchanged',
     );
-    let realmVersions = await adapter.execute(
-      'select * from realm_versions ORDER BY realm_url COLLATE "POSIX"',
+    let generations = await adapter.execute(
+      'select * from realm_generations ORDER BY realm_url COLLATE "POSIX"',
     );
     assert.deepEqual(
-      realmVersions,
+      generations,
       [
         {
           realm_url: `${testRealmURL}`,
-          current_version: 1,
+          current_generation: 1,
         },
         {
           realm_url: `${testRealmURL2}`,
-          current_version: 5,
+          current_generation: 5,
         },
       ],
       'the "production" realm versions are correct',
@@ -252,15 +252,15 @@ module('Unit | index-writer', function (hooks) {
     await setupIndex(
       adapter,
       [
-        { realm_url: testRealmURL, current_version: 1 },
-        { realm_url: testRealmURL2, current_version: 5 },
+        { realm_url: testRealmURL, current_generation: 1 },
+        { realm_url: testRealmURL2, current_generation: 5 },
       ],
       [
         {
           url: `${testRealmURL}1.json`,
           file_alias: `${testRealmURL}1.json`,
           type: 'instance',
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           deps: [`${testRealmURL}employee`, `${testRealmURL}person`],
         },
@@ -268,7 +268,7 @@ module('Unit | index-writer', function (hooks) {
           url: `${testRealmURL}2.json`,
           file_alias: `${testRealmURL}2.json`,
           type: 'instance',
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           deps: [`${testRealmURL}1.json`],
         },
@@ -276,7 +276,7 @@ module('Unit | index-writer', function (hooks) {
           url: `${testRealmURL}3.json`,
           file_alias: `${testRealmURL}3.json`,
           type: 'instance',
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           deps: [],
         },
@@ -301,15 +301,15 @@ module('Unit | index-writer', function (hooks) {
     await setupIndex(
       adapter,
       [
-        { realm_url: testRealmURL, current_version: 1 },
-        { realm_url: testRealmURL2, current_version: 5 },
+        { realm_url: testRealmURL, current_generation: 1 },
+        { realm_url: testRealmURL2, current_generation: 5 },
       ],
       [
         {
           url: `${testRealmURL2}luke.json`,
           file_alias: `${testRealmURL2}luke.json`,
           type: 'instance',
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL2,
           deps: [`${testRealmURL}person`],
         },
@@ -330,11 +330,11 @@ module('Unit | index-writer', function (hooks) {
   test('can update an index entry', async function (assert) {
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [
         {
           url: `${testRealmURL}1.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           pristine_doc: {
             id: `${testRealmURL}1.json`,
@@ -395,7 +395,7 @@ module('Unit | index-writer', function (hooks) {
     });
 
     let [liveVersion] = await adapter.execute(
-      `SELECT realm_version, pristine_doc, search_doc, deps, types FROM boxel_index WHERE url = $1`,
+      `SELECT generation, pristine_doc, search_doc, deps, types FROM boxel_index WHERE url = $1`,
       {
         bind: [`${testRealmURL}1.json`],
         coerceTypes: {
@@ -410,7 +410,7 @@ module('Unit | index-writer', function (hooks) {
     assert.deepEqual(
       liveVersion,
       {
-        realm_version: 1,
+        generation: 1,
         pristine_doc: {
           id: `${testRealmURL}1.json`,
           type: 'card',
@@ -434,7 +434,7 @@ module('Unit | index-writer', function (hooks) {
     );
 
     let [wipVersion] = await adapter.execute(
-      `SELECT realm_version, pristine_doc, search_doc, deps, types FROM boxel_index_working WHERE url = $1`,
+      `SELECT generation, pristine_doc, search_doc, deps, types FROM boxel_index_working WHERE url = $1`,
       {
         bind: [`${testRealmURL}1.json`],
         coerceTypes: {
@@ -448,7 +448,7 @@ module('Unit | index-writer', function (hooks) {
     assert.deepEqual(
       wipVersion,
       {
-        realm_version: 2,
+        generation: 2,
         pristine_doc: {
           id: `${testRealmURL}1.json`,
           type: 'card',
@@ -479,7 +479,7 @@ module('Unit | index-writer', function (hooks) {
     await batch.done();
 
     let [finalVersion] = await adapter.execute(
-      `SELECT realm_version, pristine_doc, search_doc, deps, types FROM boxel_index WHERE url = $1`,
+      `SELECT generation, pristine_doc, search_doc, deps, types FROM boxel_index WHERE url = $1`,
       {
         bind: [`${testRealmURL}1.json`],
         coerceTypes: {
@@ -493,7 +493,7 @@ module('Unit | index-writer', function (hooks) {
     assert.deepEqual(
       finalVersion,
       {
-        realm_version: 2,
+        generation: 2,
         pristine_doc: {
           id: `${testRealmURL}1.json`,
           type: 'card',
@@ -547,13 +547,13 @@ module('Unit | index-writer', function (hooks) {
     await setupIndex(
       adapter,
       [
-        { realm_url: testRealmURL, current_version: 1 },
-        { realm_url: testRealmURL2, current_version: 1 },
+        { realm_url: testRealmURL, current_generation: 1 },
+        { realm_url: testRealmURL2, current_generation: 1 },
       ],
       [
         {
           url: `${testRealmURL}1.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           type: 'instance',
           pristine_doc: resource,
@@ -621,7 +621,7 @@ module('Unit | index-writer', function (hooks) {
       {
         url: `${testRealmURL2}1.json`,
         file_alias: `${testRealmURL2}1`,
-        realm_version: 2,
+        generation: 2,
         realm_url: testRealmURL2,
         type: 'instance',
         has_error: false,
@@ -681,7 +681,7 @@ module('Unit | index-writer', function (hooks) {
 
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL2, current_version: 1 }],
+      [{ realm_url: testRealmURL2, current_generation: 1 }],
       [],
     );
     let batch = await indexWriter.createBatch(
@@ -720,11 +720,11 @@ module('Unit | index-writer', function (hooks) {
     };
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [
         {
           url: `${testRealmURL}1.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           pristine_doc: resource,
           search_doc: { name: 'Mango' },
@@ -768,7 +768,7 @@ module('Unit | index-writer', function (hooks) {
     await batch.done();
 
     let [rawErrorEntry] = (await adapter.execute(
-      'SELECT * FROM boxel_index WHERE realm_version = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
+      'SELECT * FROM boxel_index WHERE generation = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
       { coerceTypes },
     )) as unknown as BoxelIndexTable[];
     // Strip non-deterministic write-time stamps from both the row and
@@ -790,7 +790,7 @@ module('Unit | index-writer', function (hooks) {
       {
         url: `${testRealmURL}1.json`,
         file_alias: `${testRealmURL}1`,
-        realm_version: 2,
+        generation: 2,
         realm_url: testRealmURL,
         type: 'instance',
         has_error: true,
@@ -845,7 +845,7 @@ module('Unit | index-writer', function (hooks) {
   test('strips jsonb-illegal code points from error_doc and diagnostics on write', async function (assert) {
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [],
     );
     let batch = await indexWriter.createBatch(
@@ -874,7 +874,7 @@ module('Unit | index-writer', function (hooks) {
     await batch.done();
 
     let [row] = (await adapter.execute(
-      'SELECT * FROM boxel_index WHERE has_error = TRUE AND realm_version = 2',
+      'SELECT * FROM boxel_index WHERE has_error = TRUE AND generation = 2',
       { coerceTypes },
     )) as unknown as BoxelIndexTable[];
     assert.ok(row?.error_doc, 'error row persisted despite binary in message');
@@ -909,7 +909,7 @@ module('Unit | index-writer', function (hooks) {
   test('error entry does not include last known good state when not available', async function (assert) {
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [],
     );
     let batch = await indexWriter.createBatch(
@@ -927,7 +927,7 @@ module('Unit | index-writer', function (hooks) {
     await batch.done();
 
     let [rawErrorEntry] = (await adapter.execute(
-      'SELECT * FROM boxel_index WHERE realm_version = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
+      'SELECT * FROM boxel_index WHERE generation = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
       { coerceTypes },
     )) as unknown as BoxelIndexTable[];
     let { indexed_at: _remove, diagnostics, ...errorEntry } = rawErrorEntry;
@@ -945,7 +945,7 @@ module('Unit | index-writer', function (hooks) {
       {
         url: `${testRealmURL}1.json`,
         file_alias: `${testRealmURL}1`,
-        realm_version: 2,
+        generation: 2,
         realm_url: testRealmURL,
         type: 'instance',
         has_error: true,
@@ -990,7 +990,7 @@ module('Unit | index-writer', function (hooks) {
   test('normalizes error doc id and deps', async function (assert) {
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [],
     );
     let batch = await indexWriter.createBatch(
@@ -1010,7 +1010,7 @@ module('Unit | index-writer', function (hooks) {
     await batch.done();
 
     let [{ error_doc: errorDoc, deps }] = (await adapter.execute(
-      'SELECT error_doc, deps FROM boxel_index WHERE realm_version = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
+      'SELECT error_doc, deps FROM boxel_index WHERE generation = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
       { coerceTypes },
     )) as Pick<BoxelIndexTable, 'error_doc' | 'deps'>[];
 
@@ -1035,7 +1035,7 @@ module('Unit | index-writer', function (hooks) {
   test('error_doc within budget is persisted unchanged', async function (assert) {
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [],
     );
     let inputError = {
@@ -1109,7 +1109,7 @@ module('Unit | index-writer', function (hooks) {
   test('oversized error_doc is shed progressively until it fits', async function (assert) {
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [],
     );
     // Deliberately pathological: 50 entries × ~1 MiB stacks (≈50 MiB)
@@ -1181,7 +1181,7 @@ module('Unit | index-writer', function (hooks) {
     await setupIndex(adapter, [
       {
         url: `${testRealmURL}1.json`,
-        realm_version: 1,
+        generation: 1,
         realm_url: testRealmURL,
         type: 'instance',
         has_error: true,
@@ -1206,7 +1206,7 @@ module('Unit | index-writer', function (hooks) {
           additionalErrors: [],
         },
         canonicalURL: `${testRealmURL}1.json`,
-        realmVersion: 1,
+        generation: 1,
         realmURL: testRealmURL,
         instance: null,
         lastModified: null,
@@ -1291,11 +1291,11 @@ module('Unit | index-writer', function (hooks) {
     };
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [
         {
           url: `${testRealmURL}1.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           pristine_doc: originalResource,
           last_modified: String(originalModified),
@@ -1337,7 +1337,7 @@ module('Unit | index-writer', function (hooks) {
     if (entry?.type === 'instance') {
       assert.deepEqual(entry, {
         type: 'instance',
-        realmVersion: 1,
+        generation: 1,
         realmURL: testRealmURL,
         canonicalURL: `${testRealmURL}1.json`,
         instance: {
@@ -1374,11 +1374,11 @@ module('Unit | index-writer', function (hooks) {
   test('can get work in progress card', async function (assert) {
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [
         {
           url: `${testRealmURL}1.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           pristine_doc: {
             attributes: {
@@ -1436,7 +1436,7 @@ module('Unit | index-writer', function (hooks) {
       delete (entry as Partial<IndexedInstance>)?.indexedAt;
       assert.deepEqual(entry as Omit<IndexedInstance, 'indexedAt'>, {
         type: 'instance',
-        realmVersion: 2,
+        generation: 2,
         realmURL: testRealmURL,
         canonicalURL: `${testRealmURL}1.json`,
         instance: {
@@ -1472,7 +1472,7 @@ module('Unit | index-writer', function (hooks) {
   test('persists and reads back markdown for an instance entry', async function (assert) {
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [],
     );
     let resource: CardResource = {
@@ -1526,11 +1526,11 @@ module('Unit | index-writer', function (hooks) {
   test('returns undefined when getting a deleted card', async function (assert) {
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [
         {
           url: `${testRealmURL}1.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           is_deleted: true,
         },
@@ -1547,7 +1547,7 @@ module('Unit | index-writer', function (hooks) {
     for (let i = 1; i <= 1002; i++) {
       indexRows.push({
         url: `${testRealmURL}${i}.json`,
-        realm_version: 1,
+        generation: 1,
         realm_url: testRealmURL,
         deps: [...(i <= 1 ? [] : [`${testRealmURL}1.json`])],
       });
@@ -1555,7 +1555,7 @@ module('Unit | index-writer', function (hooks) {
     indexRows.sort((a, b) => a.url.localeCompare(b.url));
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       indexRows,
     );
 
@@ -1573,7 +1573,7 @@ module('Unit | index-writer', function (hooks) {
     );
 
     let invalidatedEntries = (await adapter.execute(
-      'SELECT url, realm_url, is_deleted FROM boxel_index_working WHERE realm_version = 2 ORDER BY url COLLATE "POSIX"',
+      'SELECT url, realm_url, is_deleted FROM boxel_index_working WHERE generation = 2 ORDER BY url COLLATE "POSIX"',
       { coerceTypes: { is_deleted: 'BOOLEAN' } },
     )) as Pick<BoxelIndexTable, 'url' | 'realm_url' | 'is_deleted'>[];
     assert.deepEqual(
@@ -1585,15 +1585,15 @@ module('Unit | index-writer', function (hooks) {
       })) as Pick<BoxelIndexTable, 'url' | 'realm_url' | 'is_deleted'>[],
       'the "work-in-progress" version of the index entries have been marked as deleted',
     );
-    let realmVersions = await adapter.execute(
-      'select * from realm_versions ORDER BY realm_url COLLATE "POSIX"',
+    let generations = await adapter.execute(
+      'select * from realm_generations ORDER BY realm_url COLLATE "POSIX"',
     );
     assert.deepEqual(
-      realmVersions,
+      generations,
       [
         {
           realm_url: `${testRealmURL}`,
-          current_version: 1,
+          current_generation: 1,
         },
       ],
       'the "production" realm versions are correct',
@@ -1624,11 +1624,11 @@ module('Unit | index-writer', function (hooks) {
     );
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [
         {
           url: `${testRealmURL}1.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           pristine_doc: {
             id: `${testRealmURL}1`,
@@ -1809,12 +1809,12 @@ module('Unit | index-writer', function (hooks) {
 
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [
         // Plain instance row — should land in `instances`.
         {
           url: `${testRealmURL}1.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           type: 'instance',
           pristine_doc: makeCardResource('1', 'Mango', {
@@ -1835,7 +1835,7 @@ module('Unit | index-writer', function (hooks) {
         // summary row with total: 2.
         {
           url: `${testRealmURL}notes/a.md`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           type: 'file',
           search_doc: { name: 'a.md', url: `${testRealmURL}notes/a.md` },
@@ -1845,7 +1845,7 @@ module('Unit | index-writer', function (hooks) {
         },
         {
           url: `${testRealmURL}notes/b.md`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           type: 'file',
           search_doc: { name: 'b.md', url: `${testRealmURL}notes/b.md` },
@@ -1856,7 +1856,7 @@ module('Unit | index-writer', function (hooks) {
         // A bare-FileDef file — base type used when the extension isn't mapped.
         {
           url: `${testRealmURL}misc/raw.bin`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           type: 'file',
           search_doc: { name: 'raw.bin', url: `${testRealmURL}misc/raw.bin` },
@@ -1932,14 +1932,14 @@ module('Unit | index-writer', function (hooks) {
 
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [
         // Two markdown files with the same code_ref but different
         // display_names — simulates the rolling-deploy state where the
         // new extractor populated names for one file but not the other.
         {
           url: `${testRealmURL}notes/new.md`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           type: 'file',
           search_doc: { name: 'new.md', url: `${testRealmURL}notes/new.md` },
@@ -1949,7 +1949,7 @@ module('Unit | index-writer', function (hooks) {
         },
         {
           url: `${testRealmURL}notes/old.md`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           type: 'file',
           search_doc: { name: 'old.md', url: `${testRealmURL}notes/old.md` },
@@ -1981,9 +1981,9 @@ module('Unit | index-writer', function (hooks) {
     );
   });
 
-  test('fetchCardTypeSummary returns the realm_meta row at realm_versions.current_version', async function (assert) {
+  test('fetchCardTypeSummary returns the realm_meta row at realm_generations.current_generation', async function (assert) {
     // Regression: the read path JOINs realm_meta against
-    // realm_versions.current_version so it always picks the row that
+    // realm_generations.current_generation so it always picks the row that
     // matches the realm's authoritative current version. Without the JOIN,
     // a naive SELECT returns an arbitrary realm_meta row when stale rows
     // linger (e.g., after a from-scratch reindex resets the version) and
@@ -2001,11 +2001,11 @@ module('Unit | index-writer', function (hooks) {
     // (new partitioned shape) for v1.
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [
         {
           url: `${testRealmURL}1.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           type: 'instance',
           pristine_doc: makeCardResource('1', 'Mango', {
@@ -2031,11 +2031,11 @@ module('Unit | index-writer', function (hooks) {
 
     // Now plant a *stale* legacy-shape row at a HIGHER version number. This
     // is exactly the layout you get after a from-scratch reindex: the prune
-    // predicate `realm_version < current` doesn't reach v999, so it lingers.
+    // predicate `generation < current` doesn't reach v999, so it lingers.
     // The naive `SELECT … WHERE realm_url=…` (no ORDER BY) would happily
     // return this row first.
     await adapter.execute(
-      `INSERT INTO realm_meta (realm_url, realm_version, value, indexed_at)
+      `INSERT INTO realm_meta (realm_url, generation, value, indexed_at)
        VALUES ($1, $2, $3, $4)`,
       {
         bind: [
@@ -2060,7 +2060,7 @@ module('Unit | index-writer', function (hooks) {
     assert.deepEqual(
       summary.instances.map((s) => s.code_ref),
       [`${testRealmURL}person/Person`],
-      'fetchCardTypeSummary returns the row at realm_versions.current_version even when a higher-numbered stale row is present',
+      'fetchCardTypeSummary returns the row at realm_generations.current_generation even when a higher-numbered stale row is present',
     );
     assert.notOk(
       summary.instances.find((s) => s.display_name === 'Stale'),
@@ -2070,15 +2070,15 @@ module('Unit | index-writer', function (hooks) {
 
   test('done() prunes realm_meta rows at any version, including ones higher than the current', async function (assert) {
     // Regression: pruneObsoleteEntries uses != instead of < so a
-    // from-scratch reindex (which resets the realm_version to a low
+    // from-scratch reindex (which resets the generation to a low
     // number) doesn't leave older high-version rows orphaned in
     // realm_meta forever.
     let iconHTML = '<svg>icon</svg>';
 
-    // realm_versions starts at 0, so the next batch will write at v1.
+    // realm_generations starts at 0, so the next batch will write at v1.
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 0 }],
+      [{ realm_url: testRealmURL, current_generation: 0 }],
       [],
     );
 
@@ -2087,7 +2087,7 @@ module('Unit | index-writer', function (hooks) {
     // from-scratch reindex.
     for (let version of [50, 100, 200, 999]) {
       await adapter.execute(
-        `INSERT INTO realm_meta (realm_url, realm_version, value, indexed_at)
+        `INSERT INTO realm_meta (realm_url, generation, value, indexed_at)
          VALUES ($1, $2, $3, $4)`,
         {
           bind: [
@@ -2108,11 +2108,11 @@ module('Unit | index-writer', function (hooks) {
     }
 
     let rowsBefore = await adapter.execute(
-      `SELECT realm_version FROM realm_meta WHERE realm_url = $1 ORDER BY realm_version`,
+      `SELECT generation FROM realm_meta WHERE realm_url = $1 ORDER BY generation`,
       { bind: [testRealmURL] },
     );
     assert.deepEqual(
-      rowsBefore.map((r) => r.realm_version),
+      rowsBefore.map((r) => r.generation),
       [50, 100, 200, 999],
       'stale rows are seeded before the batch runs',
     );
@@ -2124,11 +2124,11 @@ module('Unit | index-writer', function (hooks) {
     await batch.done();
 
     let rowsAfter = await adapter.execute(
-      `SELECT realm_version FROM realm_meta WHERE realm_url = $1 ORDER BY realm_version`,
+      `SELECT generation FROM realm_meta WHERE realm_url = $1 ORDER BY generation`,
       { bind: [testRealmURL] },
     );
     assert.deepEqual(
-      rowsAfter.map((r) => r.realm_version),
+      rowsAfter.map((r) => r.generation),
       [1],
       'pruneObsoleteEntries deletes every row that is not the current version, including higher-numbered stale ones',
     );
@@ -2148,11 +2148,11 @@ module('Unit | index-writer', function (hooks) {
 
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       [
         {
           url: `${testRealmURL}1.json`,
-          realm_version: 1,
+          generation: 1,
           realm_url: testRealmURL,
           pristine_doc: personResource as LooseCardResource,
           search_doc: { name: 'Mango' },
@@ -2204,12 +2204,12 @@ module('Unit | index-writer', function (hooks) {
     let lastModified = 1700000000;
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       {
         working: [
           {
             url,
-            realm_version: 1,
+            generation: 1,
             realm_url: testRealmURL,
             type: 'instance',
             job_id: 42,
@@ -2253,12 +2253,12 @@ module('Unit | index-writer', function (hooks) {
     let url = `${testRealmURL}errored.json`;
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       {
         working: [
           {
             url,
-            realm_version: 1,
+            generation: 1,
             realm_url: testRealmURL,
             type: 'instance',
             job_id: 42,
@@ -2302,12 +2302,12 @@ module('Unit | index-writer', function (hooks) {
   test('does not resume rows from a different job', async function (assert) {
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       {
         working: [
           {
             url: `${testRealmURL}from-other-job.json`,
-            realm_version: 1,
+            generation: 1,
             realm_url: testRealmURL,
             type: 'instance',
             job_id: 99,
@@ -2347,12 +2347,12 @@ module('Unit | index-writer', function (hooks) {
     let otherUrl = `${testRealmURL}other-job-row.json`;
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       {
         working: [
           {
             url: otherUrl,
-            realm_version: 1,
+            generation: 1,
             realm_url: testRealmURL,
             type: 'instance',
             job_id: 99,
@@ -2395,12 +2395,12 @@ module('Unit | index-writer', function (hooks) {
     let url = `${testRealmURL}1.json`;
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       {
         working: [
           {
             url,
-            realm_version: 1,
+            generation: 1,
             realm_url: testRealmURL,
             type: 'instance',
             job_id: 42,
@@ -2449,12 +2449,12 @@ module('Unit | index-writer', function (hooks) {
     };
     await setupIndex(
       adapter,
-      [{ realm_url: testRealmURL, current_version: 1 }],
+      [{ realm_url: testRealmURL, current_generation: 1 }],
       {
         working: [
           {
             url,
-            realm_version: 1,
+            generation: 1,
             realm_url: testRealmURL,
             type: 'instance',
             job_id: 42,
@@ -2509,13 +2509,13 @@ module('Unit | index-writer', function (hooks) {
       let depUrl = `${testRealmURL}prod-only-dep.json`;
       await setupIndex(
         adapter,
-        [{ realm_url: testRealmURL, current_version: 1 }],
+        [{ realm_url: testRealmURL, current_generation: 1 }],
         {
           working: [],
           production: [
             {
               url,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               deps: [depUrl],
@@ -2542,12 +2542,12 @@ module('Unit | index-writer', function (hooks) {
       let depUrl = `${testRealmURL}working-only-dep.json`;
       await setupIndex(
         adapter,
-        [{ realm_url: testRealmURL, current_version: 1 }],
+        [{ realm_url: testRealmURL, current_generation: 1 }],
         {
           working: [
             {
               url,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               is_deleted: false,
@@ -2577,12 +2577,12 @@ module('Unit | index-writer', function (hooks) {
       let productionDep = `${testRealmURL}production-dep.json`;
       await setupIndex(
         adapter,
-        [{ realm_url: testRealmURL, current_version: 1 }],
+        [{ realm_url: testRealmURL, current_generation: 1 }],
         {
           working: [
             {
               url,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               is_deleted: false,
@@ -2593,7 +2593,7 @@ module('Unit | index-writer', function (hooks) {
           production: [
             {
               url,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               deps: [productionDep],
@@ -2621,12 +2621,12 @@ module('Unit | index-writer', function (hooks) {
       let productionDep = `${testRealmURL}production-dep.json`;
       await setupIndex(
         adapter,
-        [{ realm_url: testRealmURL, current_version: 1 }],
+        [{ realm_url: testRealmURL, current_generation: 1 }],
         {
           working: [
             {
               url,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               is_deleted: true,
@@ -2637,7 +2637,7 @@ module('Unit | index-writer', function (hooks) {
           production: [
             {
               url,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               deps: [productionDep],
@@ -2664,12 +2664,12 @@ module('Unit | index-writer', function (hooks) {
       let depUrl = `${testRealmURL}deleted-only-dep.json`;
       await setupIndex(
         adapter,
-        [{ realm_url: testRealmURL, current_version: 1 }],
+        [{ realm_url: testRealmURL, current_generation: 1 }],
         {
           working: [
             {
               url,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               is_deleted: true,
@@ -2703,12 +2703,12 @@ module('Unit | index-writer', function (hooks) {
       let bothProductionDep = `${testRealmURL}mixed-both-production-dep.json`;
       await setupIndex(
         adapter,
-        [{ realm_url: testRealmURL, current_version: 1 }],
+        [{ realm_url: testRealmURL, current_generation: 1 }],
         {
           working: [
             {
               url: workingOnlyUrl,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               is_deleted: false,
@@ -2717,7 +2717,7 @@ module('Unit | index-writer', function (hooks) {
             },
             {
               url: bothUrl,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               is_deleted: false,
@@ -2728,7 +2728,7 @@ module('Unit | index-writer', function (hooks) {
           production: [
             {
               url: productionOnlyUrl,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               deps: [productionOnlyDep],
@@ -2736,7 +2736,7 @@ module('Unit | index-writer', function (hooks) {
             },
             {
               url: bothUrl,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               deps: [bothProductionDep],
@@ -2782,12 +2782,12 @@ module('Unit | index-writer', function (hooks) {
       let url = `${testRealmURL}projection.json`;
       await setupIndex(
         adapter,
-        [{ realm_url: testRealmURL, current_version: 1 }],
+        [{ realm_url: testRealmURL, current_generation: 1 }],
         {
           working: [
             {
               url,
-              realm_version: 1,
+              generation: 1,
               realm_url: testRealmURL,
               type: 'instance',
               is_deleted: false,

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -244,7 +244,7 @@ module('Unit | index-writer', function (hooks) {
           current_generation: 5,
         },
       ],
-      'the "production" realm versions are correct',
+      'the "production" realm generations are correct',
     );
   });
 
@@ -1596,7 +1596,7 @@ module('Unit | index-writer', function (hooks) {
           current_generation: 1,
         },
       ],
-      'the "production" realm versions are correct',
+      'the "production" realm generations are correct',
     );
   });
 

--- a/packages/postgres/migrations/1783004110683_rename-realm-version-to-generation.js
+++ b/packages/postgres/migrations/1783004110683_rename-realm-version-to-generation.js
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 // Renames the per-realm "realm version" concept to "generation" throughout the
 // index schema. The stamp column `realm_version` (the generation each row was
 // written at) becomes `generation` on boxel_index, boxel_index_working, and

--- a/packages/postgres/migrations/1783004110683_rename-realm-version-to-generation.js
+++ b/packages/postgres/migrations/1783004110683_rename-realm-version-to-generation.js
@@ -1,0 +1,77 @@
+/* eslint-disable camelcase */
+
+// Renames the per-realm "realm version" concept to "generation" throughout the
+// index schema. The stamp column `realm_version` (the generation each row was
+// written at) becomes `generation` on boxel_index, boxel_index_working, and
+// realm_meta. The allocator `realm_versions` table (the per-realm current
+// counter) becomes `realm_generations`, with `current_version` → current_generation.
+// Column values, indexes, and constraints are preserved — only names change — so
+// existing readers behave identically under the new names.
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  // Stamp column on the index tables + realm_meta.
+  pgm.renameColumn('boxel_index', 'realm_version', 'generation');
+  pgm.renameColumn('boxel_index_working', 'realm_version', 'generation');
+  pgm.renameColumn('realm_meta', 'realm_version', 'generation');
+
+  // The indexes over the stamp column keep pointing at the renamed column, but
+  // their names would still read `realm_version`; rename them to match.
+  pgm.sql(
+    'ALTER INDEX boxel_index_realm_version_index RENAME TO boxel_index_generation_index',
+  );
+  pgm.sql(
+    'ALTER INDEX boxel_index_url_realm_version_index RENAME TO boxel_index_url_generation_index',
+  );
+  pgm.sql(
+    'ALTER INDEX boxel_index_working_realm_version_index RENAME TO boxel_index_working_generation_index',
+  );
+  pgm.sql(
+    'ALTER INDEX boxel_index_working_url_realm_version_index RENAME TO boxel_index_working_url_generation_index',
+  );
+
+  // The allocator table.
+  pgm.renameTable('realm_versions', 'realm_generations');
+  pgm.renameColumn('realm_generations', 'current_version', 'current_generation');
+  // RENAME CONSTRAINT renames the backing unique index in lockstep, so the
+  // ON CONFLICT ON CONSTRAINT upsert can key on `realm_generations_pkey`.
+  pgm.renameConstraint(
+    'realm_generations',
+    'realm_versions_pkey',
+    'realm_generations_pkey',
+  );
+  pgm.sql(
+    'ALTER INDEX realm_versions_current_version_index RENAME TO realm_generations_current_generation_index',
+  );
+};
+
+exports.down = (pgm) => {
+  pgm.sql(
+    'ALTER INDEX realm_generations_current_generation_index RENAME TO realm_versions_current_version_index',
+  );
+  pgm.renameConstraint(
+    'realm_generations',
+    'realm_generations_pkey',
+    'realm_versions_pkey',
+  );
+  pgm.renameColumn('realm_generations', 'current_generation', 'current_version');
+  pgm.renameTable('realm_generations', 'realm_versions');
+
+  pgm.sql(
+    'ALTER INDEX boxel_index_working_url_generation_index RENAME TO boxel_index_working_url_realm_version_index',
+  );
+  pgm.sql(
+    'ALTER INDEX boxel_index_working_generation_index RENAME TO boxel_index_working_realm_version_index',
+  );
+  pgm.sql(
+    'ALTER INDEX boxel_index_url_generation_index RENAME TO boxel_index_url_realm_version_index',
+  );
+  pgm.sql(
+    'ALTER INDEX boxel_index_generation_index RENAME TO boxel_index_realm_version_index',
+  );
+
+  pgm.renameColumn('realm_meta', 'generation', 'realm_version');
+  pgm.renameColumn('boxel_index_working', 'generation', 'realm_version');
+  pgm.renameColumn('boxel_index', 'generation', 'realm_version');
+};

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -120,7 +120,7 @@ export default function handleUnpublishRealm({
       // job whose execution runs on a worker connection of its own, so it
       // is not transactional with the lock-holder's DB cleanup either way.
       // Doing it before the tx keeps the tombstones (which mark every
-      // boxel_index entry as deleted + bump realm_version) in place if
+      // boxel_index entry as deleted + bump generation) in place if
       // the registry/permissions DELETEs fail — a retry of the same
       // unpublish will succeed without re-tombstoning the same content.
       if (publishedRealm) {

--- a/packages/realm-server/handlers/realm-destruction-utils.ts
+++ b/packages/realm-server/handlers/realm-destruction-utils.ts
@@ -108,7 +108,7 @@ export async function removeRealmDatabaseArtifacts(args: {
   ]);
   await q([`DELETE FROM boxel_index WHERE realm_url =`, param(realmURL)]);
   await q([`DELETE FROM realm_meta WHERE realm_url =`, param(realmURL)]);
-  await q([`DELETE FROM realm_versions WHERE realm_url =`, param(realmURL)]);
+  await q([`DELETE FROM realm_generations WHERE realm_url =`, param(realmURL)]);
   await q([`DELETE FROM realm_file_meta WHERE realm_url =`, param(realmURL)]);
   await q([`DELETE FROM realm_metadata WHERE url =`, param(realmURL)]);
 }

--- a/packages/realm-server/lib/index-html-injection.ts
+++ b/packages/realm-server/lib/index-html-injection.ts
@@ -29,7 +29,7 @@ export async function retrieveHeadHTML({
 
   let rows = await query(dbAdapter, [
     `
-      SELECT head_html, realm_version
+      SELECT head_html, generation
       FROM boxel_index
       WHERE type = 'instance'
        AND head_html IS NOT NULL
@@ -38,7 +38,7 @@ export async function retrieveHeadHTML({
     `,
     ...indexCandidateExpressions(candidates),
     `
-      ORDER BY realm_version DESC
+      ORDER BY generation DESC
       LIMIT 1
     `,
   ]);
@@ -46,12 +46,12 @@ export async function retrieveHeadHTML({
   log?.debug('Head query result for %s', cardURL.href, rows);
 
   let headRow = rows[0] as
-    | { head_html?: string | null; realm_version?: string | number }
+    | { head_html?: string | null; generation?: string | number }
     | undefined;
 
   if (headRow?.head_html != null) {
     log?.debug(
-      `Using head HTML from realm version ${headRow.realm_version} for ${cardURL.href}`,
+      `Using head HTML from generation ${headRow.generation} for ${cardURL.href}`,
     );
   } else {
     log?.debug(`No head HTML returned from database for ${cardURL.href}`);
@@ -83,7 +83,7 @@ export async function retrieveIsolatedHTML({
 
   let rows = await query(dbAdapter, [
     `
-      SELECT isolated_html, realm_version
+      SELECT isolated_html, generation
       FROM boxel_index
       WHERE isolated_html IS NOT NULL
         AND type = 'instance'
@@ -92,7 +92,7 @@ export async function retrieveIsolatedHTML({
       `,
     ...indexCandidateExpressions(candidates),
     `
-      ORDER BY realm_version DESC
+      ORDER BY generation DESC
       LIMIT 1
     `,
   ]);
@@ -100,12 +100,12 @@ export async function retrieveIsolatedHTML({
   log?.debug('Isolated query result for %s', cardURL.href, rows);
 
   let isolatedRow = rows[0] as
-    | { isolated_html?: string | null; realm_version?: string | number }
+    | { isolated_html?: string | null; generation?: string | number }
     | undefined;
 
   if (isolatedRow?.isolated_html != null) {
     log?.debug(
-      `Using isolated HTML from realm version ${isolatedRow.realm_version} for ${cardURL.href}`,
+      `Using isolated HTML from generation ${isolatedRow.generation} for ${cardURL.href}`,
     );
   } else {
     log?.debug(`No isolated HTML returned from database for ${cardURL.href}`);

--- a/packages/realm-server/lib/retrieve-scoped-css.ts
+++ b/packages/realm-server/lib/retrieve-scoped-css.ts
@@ -28,7 +28,7 @@ export async function retrieveScopedCSS({
 
   let scopedCSSQuery: Expression = [
     `
-      SELECT deps, last_known_good_deps, realm_version
+      SELECT deps, last_known_good_deps, generation
       FROM boxel_index
       WHERE type = 'instance'
         AND is_deleted IS NOT TRUE
@@ -37,7 +37,7 @@ export async function retrieveScopedCSS({
     `,
     ...indexCandidateExpressions(candidates),
     `
-      ORDER BY realm_version DESC
+      ORDER BY generation DESC
       LIMIT 1
     `,
   ];
@@ -60,7 +60,7 @@ export async function retrieveScopedCSS({
     | {
         deps?: string[] | string | null;
         last_known_good_deps?: string[] | string | null;
-        realm_version?: string | number;
+        generation?: string | number;
       }
     | undefined;
 

--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -56,7 +56,7 @@ function formatDiskSnapshot(snapshot: DiskSnapshot): string {
 }
 
 // Read the raw rows for a URL from boxel_index + boxel_index_working,
-// plus realm_versions, so we can tell whether a stale GET is the index
+// plus realm_generations, so we can tell whether a stale GET is the index
 // being out of date or the GET path picking up the wrong row.
 async function readIndexSnapshot(
   dbAdapter: PgAdapter,
@@ -64,17 +64,17 @@ async function readIndexSnapshot(
   cardURL: string,
   fileURL: string,
 ): Promise<{
-  realmVersion: unknown;
+  generation: unknown;
   stable: unknown[];
   working: unknown[];
 }> {
   let [versionRow] = (await dbAdapter.execute(
-    `SELECT current_version FROM realm_versions WHERE realm_url = $1`,
+    `SELECT current_generation FROM realm_generations WHERE realm_url = $1`,
     { bind: [realmHref] },
-  )) as { current_version: number }[];
+  )) as { current_generation: number }[];
 
   let stable = (await dbAdapter.execute(
-    `SELECT url, file_alias, type, realm_version, is_deleted,
+    `SELECT url, file_alias, type, generation, is_deleted,
             pristine_doc, last_modified
        FROM boxel_index
       WHERE realm_url = $1 AND (url = $2 OR url = $3 OR file_alias = $2 OR file_alias = $3)`,
@@ -82,7 +82,7 @@ async function readIndexSnapshot(
   )) as unknown[];
 
   let working = (await dbAdapter.execute(
-    `SELECT url, file_alias, type, realm_version, is_deleted,
+    `SELECT url, file_alias, type, generation, is_deleted,
             pristine_doc, last_modified
        FROM boxel_index_working
       WHERE realm_url = $1 AND (url = $2 OR url = $3 OR file_alias = $2 OR file_alias = $3)`,
@@ -90,7 +90,7 @@ async function readIndexSnapshot(
   )) as unknown[];
 
   return {
-    realmVersion: versionRow?.current_version ?? null,
+    generation: versionRow?.current_generation ?? null,
     stable,
     working,
   };

--- a/packages/realm-server/tests/eq-containment-integration-test.ts
+++ b/packages/realm-server/tests/eq-containment-integration-test.ts
@@ -268,7 +268,7 @@ async function seedPolicy(
 ) {
   let typeKey = internalKeyFor(policyRef, undefined, vn);
   await query(dbAdapter, [
-    `INSERT INTO boxel_index (url, file_alias, realm_url, realm_version, type, pristine_doc, search_doc, deps, types, is_deleted, has_error, indexed_at) VALUES (`,
+    `INSERT INTO boxel_index (url, file_alias, realm_url, generation, type, pristine_doc, search_doc, deps, types, is_deleted, has_error, indexed_at) VALUES (`,
     param(url),
     `,`,
     param(url),

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -805,7 +805,7 @@ async function waitForQueueIdle(
 
 // Pure diagnostics — never changes behavior. `_types` (and any reader of the
 // precomputed `realm_meta`) returns instances from the `realm_meta` row whose
-// `realm_version` equals `realm_versions.current_version`. An empty result has
+// `generation` equals `realm_generations.current_generation`. An empty result has
 // three distinguishable causes, and this dump tells them apart in the CI log
 // without needing another iteration:
 //   1. The from-scratch index produced no instance rows at all
@@ -813,7 +813,7 @@ async function waitForQueueIdle(
 //   2. Instances were indexed but their `types` couldn't be resolved (a render
 //      or module fetch failed) — `#fetchTypeSummary` requires `types->>0`, so
 //      those rows silently drop out of `realm_meta` (null_types > 0).
-//   3. No `realm_meta` row matches `current_version` (a version mismatch —
+//   3. No `realm_meta` row matches `current_generation` (a version mismatch —
 //      e.g. a from-scratch reset left only orphan rows), so the JOIN is empty
 //      even though instances exist (matched = NONE while instances > 0).
 // Logged unconditionally as a one-liner; degraded/error instance rows are
@@ -826,16 +826,16 @@ export async function logRealmIndexDiagnostics(
 ): Promise<void> {
   try {
     let [versionRow] = await dbAdapter.execute(
-      `SELECT current_version FROM realm_versions WHERE realm_url = $1`,
+      `SELECT current_generation FROM realm_generations WHERE realm_url = $1`,
       { bind: [realmURL] },
     );
-    let currentVersion = versionRow?.current_version ?? null;
+    let currentVersion = versionRow?.current_generation ?? null;
 
     let metaRows = await dbAdapter.execute(
-      `SELECT realm_version,
+      `SELECT generation,
               COALESCE(jsonb_array_length(value->'instances'), -1) AS instances,
               COALESCE(jsonb_array_length(value->'files'), -1) AS files
-       FROM realm_meta WHERE realm_url = $1 ORDER BY realm_version`,
+       FROM realm_meta WHERE realm_url = $1 ORDER BY generation`,
       { bind: [realmURL] },
     );
 
@@ -851,16 +851,15 @@ export async function logRealmIndexDiagnostics(
     let metaSummary =
       metaRows
         .map(
-          (r) =>
-            `v${r.realm_version}{instances:${r.instances},files:${r.files}}`,
+          (r) => `v${r.generation}{instances:${r.instances},files:${r.files}}`,
         )
         .join(', ') || '(none)';
-    let matched = metaRows.find((r) => r.realm_version === currentVersion);
+    let matched = metaRows.find((r) => r.generation === currentVersion);
     let nullTypes = Number(counts?.null_types ?? 0);
     let errored = Number(counts?.errored ?? 0);
 
     console.log(
-      `[realm-index-diag ${label}] realm=${realmURL} current_version=${currentVersion} ` +
+      `[realm-index-diag ${label}] realm=${realmURL} current_generation=${currentVersion} ` +
         `realm_meta=[${metaSummary}] ` +
         `matched=${matched ? `instances:${matched.instances}` : 'NONE(version-mismatch)'} ` +
         `boxel_index.instances=${counts?.instances ?? '?'} null_types=${nullTypes} errored=${errored}`,

--- a/packages/realm-server/tests/helpers/indexing.ts
+++ b/packages/realm-server/tests/helpers/indexing.ts
@@ -166,7 +166,7 @@ export async function depsForIndexEntry(
       ['url =', param(url)],
       ['type =', param(type)],
     ]),
-    `ORDER BY realm_version DESC LIMIT 1`,
+    `ORDER BY generation DESC LIMIT 1`,
   ] as Expression)) as { deps: string[] | string | null }[];
   let rawDeps = rows[0]?.deps ?? [];
   if (Array.isArray(rawDeps)) {
@@ -189,7 +189,7 @@ export async function indexedAtForIndexEntry(
       ['url =', param(url)],
       ['type =', param(type)],
     ]),
-    `ORDER BY realm_version DESC LIMIT 1`,
+    `ORDER BY generation DESC LIMIT 1`,
   ] as Expression)) as { indexed_at: string | number | null }[];
   let value = rows[0]?.indexed_at ?? null;
   if (value == null) {
@@ -205,7 +205,7 @@ export async function typeForIndexEntry(
   let rows = (await query(dbAdapter, [
     `SELECT type FROM boxel_index WHERE`,
     ...every([['url =', param(url)]]),
-    `ORDER BY realm_version DESC LIMIT 1`,
+    `ORDER BY generation DESC LIMIT 1`,
   ] as Expression)) as { type: string }[];
   return rows[0]?.type ?? null;
 }
@@ -221,7 +221,7 @@ export async function errorDocForIndexEntry(
       ['url =', param(url)],
       ['type =', param(type)],
     ]),
-    `ORDER BY realm_version DESC LIMIT 1`,
+    `ORDER BY generation DESC LIMIT 1`,
   ] as Expression)) as {
     has_error: boolean | null;
     error_doc: unknown | string | null;

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1509,7 +1509,7 @@ module(basename(import.meta.filename), function () {
       });
 
       test('batch invalidation clears has_error and error_doc when tombstoning a previously-errored row', async function (assert) {
-        // The primary key is `(url, realm_url, type)` — no `realm_version` —
+        // The primary key is `(url, realm_url, type)` — no `generation` —
         // so a tombstone upsert always collides with the prior row for the
         // same URL. Any column NOT in the tombstone upsert's SET list keeps
         // its previous value. Before this guard, `has_error` and `error_doc`

--- a/packages/realm-server/tests/job-scoped-search-cache-test.ts
+++ b/packages/realm-server/tests/job-scoped-search-cache-test.ts
@@ -24,7 +24,7 @@ function makeDoc(label: string): string {
   return JSON.stringify(
     {
       data: [{ type: 'card', id: `${realmA}${label}` }],
-      meta: { page: { total: 1, realmVersion: 1 } },
+      meta: { page: { total: 1, generation: 1 } },
     },
     null,
     2,

--- a/packages/realm-server/tests/matches-filter-integration-test.ts
+++ b/packages/realm-server/tests/matches-filter-integration-test.ts
@@ -49,7 +49,7 @@ async function seedRow(
   { url, markdown }: { url: string; markdown: string | null },
 ) {
   await query(dbAdapter, [
-    `INSERT INTO boxel_index (url, file_alias, realm_url, realm_version, type, pristine_doc, search_doc, deps, types, is_deleted, has_error, indexed_at, markdown)`,
+    `INSERT INTO boxel_index (url, file_alias, realm_url, generation, type, pristine_doc, search_doc, deps, types, is_deleted, has_error, indexed_at, markdown)`,
     `VALUES (`,
     param(url),
     `,`,

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -1457,9 +1457,9 @@ module(basename(import.meta.filename), function () {
 
         let versionBeforeUnpublish = (
           await dbAdapter.execute(
-            `SELECT current_version FROM realm_versions WHERE realm_url = '${publishedRealmURL}'`,
+            `SELECT current_generation FROM realm_generations WHERE realm_url = '${publishedRealmURL}'`,
           )
-        )[0]?.current_version as number | undefined;
+        )[0]?.current_generation as number | undefined;
 
         // Now unpublish the realm
         let unpublishResponse = await request
@@ -1518,24 +1518,24 @@ module(basename(import.meta.filename), function () {
           'published realm directory should be removed',
         );
 
-        let realmVersion = (
+        let generation = (
           await dbAdapter.execute(
-            `SELECT current_version FROM realm_versions WHERE realm_url = '${publishedRealmURL}'`,
+            `SELECT current_generation FROM realm_generations WHERE realm_url = '${publishedRealmURL}'`,
           )
-        )[0] as { current_version: number };
+        )[0] as { current_generation: number };
         assert.notStrictEqual(
           versionBeforeUnpublish,
           undefined,
           'realm version of published realm is set before unpublish',
         );
         assert.ok(
-          realmVersion.current_version > (versionBeforeUnpublish ?? 0),
+          generation.current_generation > (versionBeforeUnpublish ?? 0),
           'realm version of published realm is increased',
         );
 
         // Verify that boxel_index entries are tombstoned (marked as deleted) for the unpublished realm
         let indexResultsAfter = await dbAdapter.execute(
-          `SELECT * FROM boxel_index WHERE realm_url = '${publishedRealmURL}' AND realm_version = '${realmVersion.current_version}'`,
+          `SELECT * FROM boxel_index WHERE realm_url = '${publishedRealmURL}' AND generation = '${generation.current_generation}'`,
         );
         assert.ok(
           indexResultsAfter.length > 0,

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -1526,11 +1526,11 @@ module(basename(import.meta.filename), function () {
         assert.notStrictEqual(
           versionBeforeUnpublish,
           undefined,
-          'realm version of published realm is set before unpublish',
+          'realm generation of published realm is set before unpublish',
         );
         assert.ok(
           generation.current_generation > (versionBeforeUnpublish ?? 0),
-          'realm version of published realm is increased',
+          'realm generation of published realm is increased',
         );
 
         // Verify that boxel_index entries are tombstoned (marked as deleted) for the unpublished realm

--- a/packages/realm-server/tests/realm-endpoints/indexing-errors-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/indexing-errors-test.ts
@@ -208,7 +208,7 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
       // the .json was treated as instance-only). Upsert the (url, file) row.
       await dbAdapter.execute(
         `INSERT INTO boxel_index
-           (url, file_alias, type, realm_version, realm_url,
+           (url, file_alias, type, generation, realm_url,
             has_error, error_doc, is_deleted)
          VALUES ($1, $2, 'file', 1, $3, TRUE, $4::jsonb, FALSE)
          ON CONFLICT (url, realm_url, type) DO UPDATE
@@ -419,7 +419,7 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
       // the cached realm.
       await dbAdapter.execute(
         `INSERT INTO boxel_index
-           (url, file_alias, type, realm_version, realm_url,
+           (url, file_alias, type, generation, realm_url,
             has_error, error_doc, diagnostics, is_deleted)
          VALUES ($1, $2, 'file', 1, $3, FALSE, NULL, $4::jsonb, FALSE)
          ON CONFLICT (url, realm_url, type) DO UPDATE
@@ -508,7 +508,7 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
       // findings at once. Neither should mask the other.
       await dbAdapter.execute(
         `INSERT INTO boxel_index
-           (url, file_alias, type, realm_version, realm_url,
+           (url, file_alias, type, generation, realm_url,
             has_error, error_doc, diagnostics, is_deleted)
          VALUES ($1, $2, 'file', 1, $3, FALSE, NULL, $4::jsonb, FALSE)
          ON CONFLICT (url, realm_url, type) DO UPDATE

--- a/packages/realm-server/tests/realm-endpoints/invalidate-urls-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/invalidate-urls-test.ts
@@ -163,9 +163,9 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
 
     test('returns 400 and does not process when any url is out of realm', async function (assert) {
       let initialVersionRows = (await dbAdapter.execute(
-        `SELECT current_version FROM realm_versions WHERE realm_url = $1`,
+        `SELECT current_generation FROM realm_generations WHERE realm_url = $1`,
         { bind: [testRealm.url] },
-      )) as { current_version: number }[];
+      )) as { current_generation: number }[];
 
       let response = await request
         .post('/_invalidate')
@@ -190,12 +190,12 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
       assert.strictEqual(response.status, 400, 'HTTP 400 status');
 
       let currentVersionRows = (await dbAdapter.execute(
-        `SELECT current_version FROM realm_versions WHERE realm_url = $1`,
+        `SELECT current_generation FROM realm_generations WHERE realm_url = $1`,
         { bind: [testRealm.url] },
-      )) as { current_version: number }[];
+      )) as { current_generation: number }[];
       assert.strictEqual(
-        currentVersionRows[0]?.current_version,
-        initialVersionRows[0]?.current_version,
+        currentVersionRows[0]?.current_generation,
+        initialVersionRows[0]?.current_generation,
         'failed validation does not commit a new index version',
       );
     });
@@ -222,15 +222,15 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
       assert.strictEqual(response.status, 204, 'HTTP 204 status');
 
       let rows = (await dbAdapter.execute(
-        `SELECT type, realm_version
+        `SELECT type, generation
          FROM boxel_index
          WHERE realm_url = $1
            AND url = $2`,
         { bind: [testRealm.url, indexedURL] },
-      )) as { type: 'instance' | 'file'; realm_version: number }[];
+      )) as { type: 'instance' | 'file'; generation: number }[];
       assert.true(rows.length > 0, 'target url still has indexed rows');
       assert.true(
-        rows.every((row) => row.realm_version === 2),
+        rows.every((row) => row.generation === 2),
         'target url rows were updated to the new index version by invalidation',
       );
     });
@@ -257,24 +257,24 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
       assert.strictEqual(response.status, 204, 'HTTP 204 status');
 
       let targetRows = (await dbAdapter.execute(
-        `SELECT realm_version
+        `SELECT generation
          FROM boxel_index
          WHERE realm_url = $1
            AND url = $2`,
         { bind: [testRealm.url, indexedURL] },
-      )) as { realm_version: number }[];
+      )) as { generation: number }[];
       assert.true(targetRows.length > 0, 'target url still has indexed rows');
       assert.true(
-        targetRows.every((row) => row.realm_version === 2),
+        targetRows.every((row) => row.generation === 2),
         'deduped request still invalidates the target url',
       );
 
       let versionRows = (await dbAdapter.execute(
-        `SELECT current_version FROM realm_versions WHERE realm_url = $1`,
+        `SELECT current_generation FROM realm_generations WHERE realm_url = $1`,
         { bind: [testRealm.url] },
-      )) as { current_version: number }[];
+      )) as { current_generation: number }[];
       assert.strictEqual(
-        versionRows[0]?.current_version,
+        versionRows[0]?.current_generation,
         2,
         'deduped request advances index version once',
       );

--- a/packages/realm-server/tests/server-endpoints/archive-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/archive-realm-test.ts
@@ -316,7 +316,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
         },
       };
       await query(context.dbAdapter, [
-        `INSERT INTO boxel_index (url, file_alias, realm_url, realm_version, type, pristine_doc, search_doc, deps, types, is_deleted, has_error, indexed_at) VALUES (`,
+        `INSERT INTO boxel_index (url, file_alias, realm_url, generation, type, pristine_doc, search_doc, deps, types, is_deleted, has_error, indexed_at) VALUES (`,
         param(configURL),
         `,`,
         param(configURL),

--- a/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/delete-realm-test.ts
@@ -69,7 +69,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (hooks) {
       url: args.url,
       file_alias: args.url,
       type: 'instance',
-      realm_version: 1,
+      generation: 1,
       realm_url: args.realmURL,
     });
     await query(
@@ -150,13 +150,13 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (hooks) {
     await context.testRealmServer.testingOnlyReconcile();
 
     // Publish returns 202 before indexing finishes, and the mount kicks the
-    // published realm's index in the background — its realm_versions rows are
+    // published realm's index in the background — its realm_generations rows are
     // written when that index completes. Wait for them before asserting they
     // exist below.
     await waitUntil(
       async () => {
         let rows = await context.dbAdapter.execute(
-          `SELECT 1 FROM realm_versions WHERE realm_url = '${publishedRealmURL}' LIMIT 1`,
+          `SELECT 1 FROM realm_generations WHERE realm_url = '${publishedRealmURL}' LIMIT 1`,
         );
         return rows.length > 0 ? rows : undefined;
       },
@@ -164,7 +164,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (hooks) {
         timeout: 30_000,
         interval: 100,
         timeoutMessage:
-          'published realm_versions rows did not appear after publish',
+          'published realm_generations rows did not appear after publish',
       },
     );
 
@@ -221,33 +221,33 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (hooks) {
     await insertRealmFileMeta(unrelatedRealmURL, unrelatedFileMetaPath);
 
     let existingSourceRealmVersionRows = await context.dbAdapter.execute(
-      `SELECT * FROM realm_versions WHERE realm_url = '${realmURL}'`,
+      `SELECT * FROM realm_generations WHERE realm_url = '${realmURL}'`,
     );
     let existingPublishedRealmVersionRows = await context.dbAdapter.execute(
-      `SELECT * FROM realm_versions WHERE realm_url = '${publishedRealmURL}'`,
+      `SELECT * FROM realm_generations WHERE realm_url = '${publishedRealmURL}'`,
     );
     assert.ok(
       existingSourceRealmVersionRows.length > 0,
-      'source realm rows exist in realm_versions before deletion',
+      'source realm rows exist in realm_generations before deletion',
     );
     assert.ok(
       existingPublishedRealmVersionRows.length > 0,
-      'published realm rows exist in realm_versions before deletion',
+      'published realm rows exist in realm_generations before deletion',
     );
 
     let {
-      nameExpressions: realmVersionNames,
-      valueExpressions: realmVersionValues,
+      nameExpressions: generationNames,
+      valueExpressions: generationValues,
     } = asExpressions({
       realm_url: unrelatedRealmURL,
-      current_version: 77,
+      current_generation: 77,
     });
     await query(
       context.dbAdapter,
-      insert('realm_versions', realmVersionNames, realmVersionValues),
+      insert('realm_generations', generationNames, generationValues),
     );
 
-    for (let [cleanupRealmURL, realmVersion] of [
+    for (let [cleanupRealmURL, generation] of [
       [realmURL, 91],
       [publishedRealmURL, 92],
       [unrelatedRealmURL, 93],
@@ -255,7 +255,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (hooks) {
       let { nameExpressions, valueExpressions } = asExpressions(
         {
           realm_url: cleanupRealmURL,
-          realm_version: realmVersion,
+          generation: generation,
           value: {
             scopedCssLinks: [],
             types: {},
@@ -470,28 +470,28 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (hooks) {
     );
 
     let remainingSourceRealmVersionRows = await context.dbAdapter.execute(
-      `SELECT * FROM realm_versions WHERE realm_url = '${realmURL}'`,
+      `SELECT * FROM realm_generations WHERE realm_url = '${realmURL}'`,
     );
     let remainingPublishedRealmVersionRows = await context.dbAdapter.execute(
-      `SELECT * FROM realm_versions WHERE realm_url = '${publishedRealmURL}'`,
+      `SELECT * FROM realm_generations WHERE realm_url = '${publishedRealmURL}'`,
     );
     let remainingUnrelatedRealmVersionRows = await context.dbAdapter.execute(
-      `SELECT * FROM realm_versions WHERE realm_url = '${unrelatedRealmURL}'`,
+      `SELECT * FROM realm_generations WHERE realm_url = '${unrelatedRealmURL}'`,
     );
     assert.strictEqual(
       remainingSourceRealmVersionRows.length,
       0,
-      'source realm rows are removed from realm_versions',
+      'source realm rows are removed from realm_generations',
     );
     assert.strictEqual(
       remainingPublishedRealmVersionRows.length,
       0,
-      'published realm rows are removed from realm_versions',
+      'published realm rows are removed from realm_generations',
     );
     assert.strictEqual(
       remainingUnrelatedRealmVersionRows.length,
       1,
-      'unrelated realm rows remain in realm_versions',
+      'unrelated realm rows remain in realm_generations',
     );
 
     let sourceRealmMetaRows = await context.dbAdapter.execute(
@@ -706,17 +706,17 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (hooks) {
 
     // _publish-realm returns 202 before the published realm's from-scratch
     // index finishes; the background mount keeps writing its boxel_index /
-    // realm_versions rows. The DELETE below removes those same rows via
+    // realm_generations rows. The DELETE below removes those same rows via
     // removeRealmDatabaseArtifacts, so issuing it while that index is still in
     // flight races the indexer's writes against the delete's and intermittently
     // fails the transaction with a 500. Wait for the index to commit —
-    // realm_versions.current_version >= 1 lands atomically with the rest of the
+    // realm_generations.current_generation >= 1 lands atomically with the rest of the
     // from-scratch pass — and for no indexing job to remain queued, before
     // tearing the realm down.
     await waitUntil(
       async () => {
         let versionRows = await context.dbAdapter.execute(
-          `SELECT current_version FROM realm_versions WHERE realm_url = '${publishedRealmURL}' AND current_version >= 1 LIMIT 1`,
+          `SELECT current_generation FROM realm_generations WHERE realm_url = '${publishedRealmURL}' AND current_generation >= 1 LIMIT 1`,
         );
         if (versionRows.length === 0) {
           return undefined;

--- a/packages/realm-server/tests/server-endpoints/webhook-receiver-test.ts
+++ b/packages/realm-server/tests/server-endpoints/webhook-receiver-test.ts
@@ -838,7 +838,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       let prCardId = uuidv4();
       let prCardUrl = `https://app.boxel.ai/submissions/PrCard/${prCardId}`;
       await query(context.dbAdapter, [
-        `INSERT INTO boxel_index (url, file_alias, realm_url, realm_version, type, pristine_doc, search_doc, deps, is_deleted, indexed_at)`,
+        `INSERT INTO boxel_index (url, file_alias, realm_url, generation, type, pristine_doc, search_doc, deps, is_deleted, indexed_at)`,
         `VALUES (`,
         param(prCardUrl),
         `,`,
@@ -952,7 +952,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       let prCardId = uuidv4();
       let prCardUrl = `https://realms-staging.stack.cards/submissions/PrCard/${prCardId}`;
       await query(context.dbAdapter, [
-        `INSERT INTO boxel_index (url, file_alias, realm_url, realm_version, type, pristine_doc, search_doc, deps, is_deleted, indexed_at)`,
+        `INSERT INTO boxel_index (url, file_alias, realm_url, generation, type, pristine_doc, search_doc, deps, is_deleted, indexed_at)`,
         `VALUES (`,
         param(prCardUrl),
         `,`,

--- a/packages/realm-test-harness/src/database.ts
+++ b/packages/realm-test-harness/src/database.ts
@@ -272,9 +272,10 @@ export async function resetRealmState(
           `DELETE FROM boxel_index_working WHERE realm_url = $1`,
           [realmURL.href],
         );
-        await client.query(`DELETE FROM realm_versions WHERE realm_url = $1`, [
-          realmURL.href,
-        ]);
+        await client.query(
+          `DELETE FROM realm_generations WHERE realm_url = $1`,
+          [realmURL.href],
+        );
         await client.query(`DELETE FROM realm_file_meta WHERE realm_url = $1`, [
           realmURL.href,
         ]);
@@ -394,7 +395,7 @@ export async function rewriteClonedRealmServerUrls(
         );
 
         await client.query(
-          `UPDATE realm_versions
+          `UPDATE realm_generations
            SET realm_url = replace(realm_url, $1, $2)`,
           [fromURL, toURL],
         );
@@ -467,7 +468,7 @@ export async function rebuildWorkingIndexFromIndex(
              url,
              file_alias,
              type,
-             realm_version,
+             generation,
              realm_url,
              pristine_doc,
              search_doc,
@@ -492,7 +493,7 @@ export async function rebuildWorkingIndexFromIndex(
              url,
              file_alias,
              type,
-             realm_version,
+             generation,
              realm_url,
              pristine_doc,
              search_doc,

--- a/packages/runtime-common/helpers/ai.ts
+++ b/packages/runtime-common/helpers/ai.ts
@@ -291,10 +291,10 @@ export async function basicMappings(loader: Loader) {
         properties: {
           number: { type: 'integer', description: '0-based page number.' },
           size: { type: 'integer', description: 'Number of items per page.' },
-          realmVersion: {
+          generation: {
             type: 'integer',
             description:
-              'Optional. Specifies the realm version for consistent pagination if data can change.',
+              'Optional. Specifies the realm generation for consistent pagination if data can change.',
           },
         },
         required: ['number', 'size'],

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -160,7 +160,7 @@ export interface IndexedFile {
   atomHtml: string | null;
   iconHtml: string | null;
   markdown: string | null;
-  realmVersion: number;
+  generation: number;
   realmURL: string;
   indexedAt: number | null;
 }
@@ -180,7 +180,7 @@ export interface IndexedInstance {
   searchDoc: Record<string, any> | null;
   types: string[] | null;
   deps: string[] | null;
-  realmVersion: number;
+  generation: number;
   realmURL: string;
   indexedAt: number | null;
 }
@@ -189,7 +189,7 @@ interface InstanceError extends Partial<
   Omit<
     IndexedInstance,
     | 'type'
-    | 'realmVersion'
+    | 'generation'
     | 'realmURL'
     | 'instance'
     | 'lastModified'
@@ -198,7 +198,7 @@ interface InstanceError extends Partial<
 > {
   type: 'instance-error';
   error: SerializedError;
-  realmVersion: number;
+  generation: number;
   realmURL: string;
   instance: CardResource | null;
   lastModified: number | null;
@@ -386,7 +386,7 @@ export class IndexQueryEngine {
       fitted_html: fittedHtml,
       markdown,
       search_doc: searchDoc,
-      realm_version: realmVersion,
+      generation,
       realm_url: realmURL,
       indexed_at: indexedAt,
       last_modified: lastModified,
@@ -411,7 +411,7 @@ export class IndexQueryEngine {
       lastModified: lastModified != null ? parseInt(lastModified) : null,
       resourceCreatedAt:
         resourceCreatedAt != null ? parseInt(resourceCreatedAt) : null,
-      realmVersion,
+      generation,
     };
 
     if (maybeResult.has_error) {
@@ -535,7 +535,7 @@ export class IndexQueryEngine {
       atom_html: atomHtml,
       icon_html: iconHtml,
       markdown,
-      realm_version: realmVersion,
+      generation,
       realm_url: realmURL,
       indexed_at: indexedAt,
       last_modified: lastModified,
@@ -544,10 +544,8 @@ export class IndexQueryEngine {
       types,
       display_names: displayNames,
     } = maybeResult;
-    realmVersion =
-      typeof realmVersion === 'string'
-        ? parseInt(realmVersion)
-        : (realmVersion ?? 0);
+    generation =
+      typeof generation === 'string' ? parseInt(generation) : (generation ?? 0);
     return {
       type: 'file',
       canonicalURL,
@@ -566,7 +564,7 @@ export class IndexQueryEngine {
       lastModified: lastModified != null ? parseInt(lastModified) : null,
       resourceCreatedAt:
         resourceCreatedAt != null ? parseInt(resourceCreatedAt) : null,
-      realmVersion,
+      generation,
       realmURL,
       indexedAt: indexedAt != null ? parseInt(indexedAt) : null,
     };
@@ -839,7 +837,7 @@ export class IndexQueryEngine {
       { filter, sort, page },
       opts,
       [
-        'SELECT url, ANY_VALUE(pristine_doc) AS pristine_doc, ANY_VALUE(search_doc) AS search_doc, ANY_VALUE(types) AS types, ANY_VALUE(display_names) AS display_names, ANY_VALUE(deps) AS deps, ANY_VALUE(last_modified) AS last_modified, ANY_VALUE(resource_created_at) AS resource_created_at, ANY_VALUE(isolated_html) AS isolated_html, ANY_VALUE(head_html) AS head_html, ANY_VALUE(embedded_html) AS embedded_html, ANY_VALUE(fitted_html) AS fitted_html, ANY_VALUE(atom_html) AS atom_html, ANY_VALUE(icon_html) AS icon_html, ANY_VALUE(markdown) AS markdown, ANY_VALUE(realm_version) AS realm_version, ANY_VALUE(realm_url) AS realm_url, ANY_VALUE(indexed_at) AS indexed_at',
+        'SELECT url, ANY_VALUE(pristine_doc) AS pristine_doc, ANY_VALUE(search_doc) AS search_doc, ANY_VALUE(types) AS types, ANY_VALUE(display_names) AS display_names, ANY_VALUE(deps) AS deps, ANY_VALUE(last_modified) AS last_modified, ANY_VALUE(resource_created_at) AS resource_created_at, ANY_VALUE(isolated_html) AS isolated_html, ANY_VALUE(head_html) AS head_html, ANY_VALUE(embedded_html) AS embedded_html, ANY_VALUE(fitted_html) AS fitted_html, ANY_VALUE(atom_html) AS atom_html, ANY_VALUE(icon_html) AS icon_html, ANY_VALUE(markdown) AS markdown, ANY_VALUE(generation) AS generation, ANY_VALUE(realm_url) AS realm_url, ANY_VALUE(indexed_at) AS indexed_at',
       ],
       'file',
     );
@@ -884,7 +882,7 @@ export class IndexQueryEngine {
       markdown: result.markdown ?? null,
       lastModified,
       resourceCreatedAt,
-      realmVersion: result.realm_version ?? 0,
+      generation: result.generation ?? 0,
       realmURL: result.realm_url ?? '',
       indexedAt,
     };
@@ -960,22 +958,22 @@ export class IndexQueryEngine {
   }
 
   async fetchCardTypeSummary(realmURL: URL): Promise<RealmMetaValue> {
-    // JOIN against realm_versions.current_version so we always pick the
+    // JOIN against realm_generations.current_generation so we always pick the
     // realm_meta row that matches the realm's authoritative current
-    // version. Naive `SELECT … WHERE realm_url=…` returns an arbitrary
+    // generation. Naive `SELECT … WHERE realm_url=…` returns an arbitrary
     // row when stale rows linger (e.g., a from-scratch reindex resets
-    // the version to a low number, leaving older high-version rows that
-    // the legacy prune predicate `realm_version < <new>` never reaches).
-    // Ordering by `realm_version DESC` would actually pick the *wrong*
-    // row after a from-scratch — the highest version is the oldest.
-    // realm_versions is the system source of truth for "which version
+    // the generation to a low number, leaving older high-generation rows that
+    // the legacy prune predicate `generation < <new>` never reaches).
+    // Ordering by `generation DESC` would actually pick the *wrong*
+    // row after a from-scratch — the highest generation is the oldest.
+    // realm_generations is the system source of truth for "which generation
     // is current," so anchoring the read there is the robust fix.
     let results = (await this.#query([
       `SELECT rm.value
        FROM realm_meta rm
-       JOIN realm_versions rv
-         ON rv.realm_url = rm.realm_url
-        AND rv.current_version = rm.realm_version
+       JOIN realm_generations rg
+         ON rg.realm_url = rm.realm_url
+        AND rg.current_generation = rm.generation
        WHERE`,
       ...every([['rm.realm_url =', param(realmURL.href)]]),
       `LIMIT 1`,

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -5,7 +5,7 @@ import type { PgPrimitive } from './expression.ts';
 export interface BoxelIndexTable {
   url: string;
   file_alias: string;
-  realm_version: number;
+  generation: number;
   realm_url: string;
   type: 'instance' | 'file';
   has_error: boolean | null;
@@ -50,9 +50,9 @@ export interface BoxelIndexTable {
   job_id?: number | null;
 }
 
-export interface RealmVersionsTable {
+export interface RealmGenerationsTable {
   realm_url: string;
-  current_version: number;
+  current_generation: number;
 }
 
 export interface CardTypeSummary {
@@ -78,7 +78,7 @@ export interface RealmMetaValue {
 }
 
 export interface RealmMetaTable {
-  realm_version: number;
+  generation: number;
   realm_url: string;
   value: RealmMetaValue;
   indexed_at: string | null;

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -47,7 +47,7 @@ import {
   coerceTypes,
   type BoxelIndexTable,
   type CardTypeSummary,
-  type RealmVersionsTable,
+  type RealmGenerationsTable,
 } from './index-structure.ts';
 import { v4 as uuidv4 } from '@lukeed/uuid';
 
@@ -73,9 +73,9 @@ export class IndexWriter {
 
   async isNewIndex(realm: URL): Promise<boolean> {
     let [row] = (await this.#query([
-      'SELECT current_version FROM realm_versions WHERE realm_url =',
+      'SELECT current_generation FROM realm_generations WHERE realm_url =',
       param(realm.href),
-    ])) as Pick<RealmVersionsTable, 'current_version'>[];
+    ])) as Pick<RealmGenerationsTable, 'current_generation'>[];
     return !row;
   }
 }
@@ -193,7 +193,7 @@ export class Batch {
   #currentInvalidationId: string;
   #dbAdapter: DBAdapter;
   #perfLog = logger('index-perf');
-  declare private realmVersion: number;
+  declare private generation: number;
   private realmURL: URL; // this assumes that we only index cards in our own realm...
   private virtualNetwork: VirtualNetwork;
   private jobInfo?: JobInfo;
@@ -221,7 +221,7 @@ export class Batch {
   }
 
   private async setupBatch(): Promise<void> {
-    await this.setNextRealmVersion();
+    await this.setNextGeneration();
     await this.loadResumedRows();
   }
 
@@ -368,7 +368,7 @@ export class Batch {
       this.#invalidations.add(destURL);
       entry.url = destURL;
       entry.realm_url = this.realmURL.href;
-      entry.realm_version = this.realmVersion;
+      entry.generation = this.generation;
       entry.job_id = this.jobInfo?.jobId ?? null;
       entry.file_alias = copyURL(entry.file_alias);
       entry.types = entry.types ? entry.types.map(copyURL) : entry.types;
@@ -573,7 +573,7 @@ export class Batch {
     let preparedEntry = {
       url: href,
       file_alias: trimExecutableExtension(rri(url.href)).replace(/\.json$/, ''),
-      realm_version: this.realmVersion,
+      generation: this.generation,
       realm_url: this.realmURL.href,
       is_deleted: false,
       indexed_at: Date.now(),
@@ -671,7 +671,7 @@ export class Batch {
       indexed_at: _remove1,
       last_modified: _remove2,
       resource_created_at: _remove3,
-      realm_version: _remove4,
+      generation: _remove4,
       job_id: _remove5,
       ...productionVersion
     } = entry;
@@ -725,7 +725,7 @@ export class Batch {
     let { nameExpressions, valueExpressions } = asExpressions(
       {
         realm_url: this.realmURL.href,
-        realm_version: this.realmVersion,
+        generation: this.generation,
         value,
         indexed_at: unixTime(new Date().getTime()),
       } as Omit<RealmMetaTable, 'indexed_at'> & {
@@ -789,12 +789,12 @@ export class Batch {
   private async applyBatchUpdates() {
     let { nameExpressions, valueExpressions } = asExpressions({
       realm_url: this.realmURL.href,
-      current_version: this.realmVersion,
-    } as RealmVersionsTable);
+      current_generation: this.generation,
+    } as RealmGenerationsTable);
     await this.#query([
       ...upsert(
-        'realm_versions',
-        'realm_versions_pkey',
+        'realm_generations',
+        'realm_generations_pkey',
         nameExpressions,
         valueExpressions,
       ),
@@ -831,46 +831,46 @@ export class Batch {
 
   private async pruneObsoleteEntries() {
     // Delete every realm_meta row for this realm except the one we just
-    // wrote. The previous predicate (`realm_version < this.realmVersion`)
-    // only swept rows from incremental indexing where versions march
-    // forward. A from-scratch reindex resets the version to a low number,
-    // leaving older high-version rows orphaned forever — those legacy rows
+    // wrote. The previous predicate (`generation < this.generation`)
+    // only swept rows from incremental indexing where generations march
+    // forward. A from-scratch reindex resets the generation to a low number,
+    // leaving older high-generation rows orphaned forever — those legacy rows
     // then poisoned `_types` reads when the SELECT picked the wrong one.
     // Cleaning by `!=` covers both directions safely; the unique key on
-    // (realm_url, realm_version) guarantees we never accidentally keep
+    // (realm_url, generation) guarantees we never accidentally keep
     // two current rows.
     await this.#query([
       `DELETE FROM realm_meta`,
       'WHERE',
       ...every([
-        ['realm_version !=', param(this.realmVersion)],
+        ['generation !=', param(this.generation)],
         ['realm_url =', param(this.realmURL.href)],
       ]),
     ] as Expression);
   }
 
-  private async setNextRealmVersion() {
+  private async setNextGeneration() {
     let [row] = (await this.#query([
-      'SELECT current_version FROM realm_versions WHERE realm_url =',
+      'SELECT current_generation FROM realm_generations WHERE realm_url =',
       param(this.realmURL.href),
-    ])) as Pick<RealmVersionsTable, 'current_version'>[];
+    ])) as Pick<RealmGenerationsTable, 'current_generation'>[];
     if (!row) {
       let { nameExpressions, valueExpressions } = asExpressions({
         realm_url: this.realmURL.href,
-        current_version: 0,
-      } as RealmVersionsTable);
+        current_generation: 0,
+      } as RealmGenerationsTable);
       // Make the batch updates live
       await this.#query([
         ...upsert(
-          'realm_versions',
-          'realm_versions_pkey',
+          'realm_generations',
+          'realm_generations_pkey',
           nameExpressions,
           valueExpressions,
         ),
       ]);
-      this.realmVersion = 1;
+      this.generation = 1;
     } else {
-      this.realmVersion = row.current_version + 1;
+      this.generation = row.current_generation + 1;
     }
   }
 
@@ -895,7 +895,7 @@ export class Batch {
     let existingTypes = await this.existingIndexTypes(toTombstone);
     // `has_error` and `error_doc` are listed (with explicit false / null
     // values per row) so the upsert's ON CONFLICT SET clause clears them.
-    // The primary key is `(url, realm_url, type)` — no `realm_version` —
+    // The primary key is `(url, realm_url, type)` — no `generation` —
     // so a tombstone always collides with the prior row, and any column
     // NOT in this list keeps its previous value. Without these two,
     // a row that ever held `has_error = true` would carry that flag
@@ -906,7 +906,7 @@ export class Batch {
       'url',
       'file_alias',
       'type',
-      'realm_version',
+      'generation',
       'realm_url',
       'is_deleted',
       'has_error',
@@ -935,7 +935,7 @@ export class Batch {
           id,
           trimExecutableExtension(rri(id)),
           type,
-          this.realmVersion,
+          this.generation,
           this.realmURL.href,
           true, // is_deleted
           false, // has_error — explicit clear so stale error state from
@@ -999,7 +999,7 @@ export class Batch {
       `SELECT DISTINCT url FROM boxel_index_working WHERE`,
       ...every([
         ['realm_url =', param(this.realmURL.href)],
-        ['realm_version =', param(this.realmVersion)],
+        ['generation =', param(this.generation)],
         any([
           ['url =', param(seedURL.href)],
           ['file_alias =', param(seedURL.href)],

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -26,7 +26,7 @@ interface QueryCommon {
   page?: {
     number?: number; // page.number is 0-based
     size: number;
-    realmVersion?: number;
+    generation?: number;
   };
 }
 
@@ -49,7 +49,7 @@ interface QueryWithInterpolationsBase {
   page?: {
     number?: number; // page.number is 0-based
     size: number | string;
-    realmVersion?: number;
+    generation?: number;
   };
 }
 

--- a/packages/runtime-common/search-entry.ts
+++ b/packages/runtime-common/search-entry.ts
@@ -697,7 +697,7 @@ export type SearchEntryWireFilter = {
 export interface SearchEntryWireQuery {
   filter?: SearchEntryWireFilter;
   sort?: SearchEntryWireSortExpression[];
-  page?: { number?: number; size: number; realmVersion?: number };
+  page?: { number?: number; size: number; generation?: number };
   fields?: { 'search-entry': string[] };
   cardUrls?: string[];
   realms?: string[];


### PR DESCRIPTION
Renames the per-realm "realm version" concept to **generation** throughout the index layer. This is the first data-layer step of the [prerender split](https://linear.app/cardstack/issue/CS-11756/prerender-split-rename-realm-version-generation-advance-and-stamp-per): the generation is the monotonic per-realm counter that later lets a consumer tell whether a card's prerendered HTML is fresh for the index data it was built from.

### Schema

A reversible migration renames columns in place — values, indexes, and constraints are preserved, only names change:

- `realm_version` → `generation` on `boxel_index`, `boxel_index_working`, and `realm_meta`
- allocator table `realm_versions` → `realm_generations`; `current_version` → `current_generation`
- the PK constraint (`realm_versions_pkey` → `realm_generations_pkey`, so the `ON CONFLICT ON CONSTRAINT` upsert still keys correctly) and the five indexes over the renamed columns are renamed to match

The SQLite schema snapshot the host test suite builds from is regenerated from the migrated schema.

### Code

Types, SQL, and log terminology are updated in lockstep: `BoxelIndexTable` / `RealmMetaTable` / `RealmGenerationsTable`, `IndexWriter` (allocator + row stamp + `setNextGeneration`), `IndexQueryEngine` (projections and the `realm_generations` join in `fetchCardTypeSummary`), the HTML-serving lookups, realm destruction/unpublish, and the realm test harness.

### Behavior

Every indexing job — from-scratch and incremental — already advances the realm's counter to a new value and stamps it on every row it writes (from-scratch stamps every row; incremental stamps the rows it revisits). This PR is a rename that preserves that behavior exactly. Nothing reads the stamped value yet, so the change is inert to every consumer.

### Scope note

The ticket's schema bullet names only the three `realm_version` columns, but the project doc calls for renaming the concept "throughout the codebase," so the allocator table and its column are renamed too rather than leaving a `versions`/`generation` split.

### Verification

- Typecheck clean across runtime-common, realm-server, host, realm-test-harness, boxel-cli, and postgres
- Migration applies and reverts cleanly against Postgres
- `Unit | index-writer` (38) and `Unit | query` (76) pass against the renamed schema — covering the counter advance, the row stamp, invalidation, tombstones, `realm_meta`, and the `fetchCardTypeSummary` join

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNqd83PwtQVEEGcvM11JJC
