### PR TITLE
Remove VirtualNetwork from other Markdown pill rendering

### DIFF
--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -103,9 +103,9 @@ function resolveUrl(raw: string, baseUrl: string | null | undefined): string {
   // Resolve in RRI space (no VirtualNetwork), matching the MarkDownTemplate
   // display path. Instance ids are canonical (prefix form for mapped realms,
   // URL for unmapped), so a prefix-form base resolves relative refs to RRI and
-  // a URL-form base to URL — either way the `in:{ id }` reference query below
-  // matches the indexed card (prefix ids are expanded to their URL forms
-  // index-side).
+  // a URL-form base to URL. Either form matches the indexed card because the
+  // search tolerates a reference's equivalent spellings (RRI / real-URL /
+  // virtual-alias) rather than requiring one canonical form.
   try {
     return trimJsonExtension(
       resolveRRIReference(raw, baseUrl ? rri(baseUrl) : undefined),

--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -11,7 +11,8 @@ import {
   baseRealm,
   trimJsonExtension,
   maybeRelativeReference,
-  type VirtualNetwork,
+  resolveRRIReference,
+  rri,
 } from '@cardstack/runtime-common';
 import {
   type BfmRefRange,
@@ -98,24 +99,17 @@ function isInline(kind: string): boolean {
   return kind === 'inline';
 }
 
-function resolveUrl(
-  raw: string,
-  baseUrl: string | null | undefined,
-  virtualNetwork: VirtualNetwork | undefined,
-): string {
-  // With a VN, resolve through it so prefix-form bases and registered
-  // prefix-form refs round-trip correctly. Without a VN, plain
-  // `new URL(raw, baseUrl)` still handles the common case — URL-form
-  // refs (with or without a base) and relative refs against a URL-form
-  // base. Prefix-form bases need a VN; `new URL()` throws on those and
-  // we fall back to the raw ref.
+function resolveUrl(raw: string, baseUrl: string | null | undefined): string {
+  // Resolve in RRI space (no VirtualNetwork), matching the MarkDownTemplate
+  // display path. Instance ids are canonical (prefix form for mapped realms,
+  // URL for unmapped), so a prefix-form base resolves relative refs to RRI and
+  // a URL-form base to URL — either way the `in:{ id }` reference query below
+  // matches the indexed card (prefix ids are expanded to their URL forms
+  // index-side).
   try {
-    if (virtualNetwork) {
-      return trimJsonExtension(
-        virtualNetwork.resolveURL(raw, baseUrl || undefined).href,
-      );
-    }
-    return trimJsonExtension(new URL(raw, baseUrl || undefined).href);
+    return trimJsonExtension(
+      resolveRRIReference(raw, baseUrl ? rri(baseUrl) : undefined),
+    );
   } catch {
     return trimJsonExtension(raw);
   }
@@ -163,7 +157,6 @@ interface CodeMirrorEditorSignature {
     linkedCards?: CardDef[] | null;
     linkedFiles?: FileDef[] | null;
     cardReferenceBaseUrl?: string | null;
-    cardReferenceVirtualNetwork?: VirtualNetwork;
     /** When false, all syntax markers are visible (source mode). Default true. */
     livePreview?: boolean;
     getCards?: (
@@ -854,11 +847,10 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
 
   private resolvedUrlsForRefType(refType: 'card' | 'file'): string[] {
     let baseUrl = this.args.cardReferenceBaseUrl;
-    let vn = this.args.cardReferenceVirtualNetwork;
     let urls = new Set<string>();
     for (let target of this._widgetTargets) {
       if (target.refType === refType) {
-        urls.add(resolveUrl(target.cardId, baseUrl, vn));
+        urls.add(resolveUrl(target.cardId, baseUrl));
       }
     }
     return [...urls];
@@ -911,7 +903,6 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
   get cardRenderTargets(): CardRenderTarget[] {
     let targets = this._widgetTargets;
     let baseUrl = this.args.cardReferenceBaseUrl;
-    let vn = this.args.cardReferenceVirtualNetwork;
 
     // Resolve cards and files by URL from every available source. linkedCards /
     // linkedFiles work when a store is present; the getCards resources resolve
@@ -936,7 +927,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
     addInstances(this.resolvedFiles);
 
     return targets.map((target) => {
-      let resolvedUrl = resolveUrl(target.cardId, baseUrl, vn);
+      let resolvedUrl = resolveUrl(target.cardId, baseUrl);
       return {
         ...target,
         instance: instancesByUrl.get(resolvedUrl) ?? null,
@@ -1123,7 +1114,10 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
                 {{on 'click' this._toggleEmbedPopover}}
               ><PlusIcon width='16' height='16' /></button>
               {{#if this._embedPopoverOpen}}
-                <div class='toolbar-embed-popover' data-test-toolbar-embed-popover>
+                <div
+                  class='toolbar-embed-popover'
+                  data-test-toolbar-embed-popover
+                >
                   <button
                     type='button'
                     class='toolbar-embed-popover__item'

--- a/packages/base/default-templates/markdown.gts
+++ b/packages/base/default-templates/markdown.gts
@@ -16,8 +16,9 @@ import {
   extractMermaidBlocks,
   processKatexPlaceholders,
   replaceMermaidSvgs,
+  resolveRRIReference,
+  rri,
   trimJsonExtension,
-  type VirtualNetwork,
 } from '@cardstack/runtime-common';
 import {
   hasCodeBlocks,
@@ -79,24 +80,16 @@ interface RenderSlot {
   typeName?: string; // present when state === 'unresolved'
 }
 
-function resolveUrl(
-  raw: string,
-  baseUrl: string | null | undefined,
-  virtualNetwork: VirtualNetwork | undefined,
-): string {
-  // With a VN, resolve through it so prefix-form bases and registered
-  // prefix-form refs round-trip correctly. Without a VN, plain
-  // `new URL(raw, baseUrl)` still handles the common case — URL-form
-  // refs (with or without a base) and relative refs against a URL-form
-  // base. Prefix-form bases need a VN; `new URL()` throws on those and
-  // we fall back to the raw ref.
+function resolveUrl(raw: string, baseUrl: string | null | undefined): string {
+  // Resolve in RRI space (no VirtualNetwork), the same way the reference
+  // extractors resolve the refs behind `linkedCards`/`linkedFiles`. Instance
+  // ids are canonical (the realm serves prefix form for mapped realms, URL for
+  // unmapped), so this produces the same form as a loaded card's `id` — the
+  // slot key (`card.id` / `file.id`) matches without a VirtualNetwork.
   try {
-    if (virtualNetwork) {
-      return trimJsonExtension(
-        virtualNetwork.resolveURL(raw, baseUrl || undefined).href,
-      );
-    }
-    return trimJsonExtension(new URL(raw, baseUrl || undefined).href);
+    return trimJsonExtension(
+      resolveRRIReference(raw, baseUrl ? rri(baseUrl) : undefined),
+    );
   } catch {
     return trimJsonExtension(raw);
   }
@@ -108,7 +101,6 @@ export default class MarkDownTemplate extends GlimmerComponent<{
     linkedCards?: CardDef[] | null;
     linkedFiles?: FileDef[] | null;
     cardReferenceBaseUrl?: string | null;
-    cardReferenceVirtualNetwork?: VirtualNetwork;
   };
 }> {
   @tracked monacoContextInternal: any = undefined;
@@ -208,7 +200,6 @@ export default class MarkDownTemplate extends GlimmerComponent<{
       let linkedCards = this.args.linkedCards;
       let linkedFiles = this.args.linkedFiles;
       let baseUrl = this.args.cardReferenceBaseUrl;
-      let virtualNetwork = this.args.cardReferenceVirtualNetwork;
       let pendingUpdate = false;
       let pendingToken: unknown = undefined;
       // On the very first modifier run the linked instances are likely still
@@ -278,7 +269,7 @@ export default class MarkDownTemplate extends GlimmerComponent<{
             );
           }
 
-          let resolvedUrl = resolveUrl(rawUrl, baseUrl, virtualNetwork);
+          let resolvedUrl = resolveUrl(rawUrl, baseUrl);
 
           let instance =
             refType === 'file'
@@ -569,8 +560,7 @@ export default class MarkDownTemplate extends GlimmerComponent<{
               />
             {{else}}
               <span
-                class='markdown-bfm-loading markdown-bfm-loading--inline-embed
-                  markdown-bfm-loading--{{slot.format}}'
+                class='markdown-bfm-loading markdown-bfm-loading--inline-embed markdown-bfm-loading--{{slot.format}}'
                 style={{slot.style}}
                 aria-hidden='true'
                 data-test-markdown-bfm-loading-inline
@@ -599,8 +589,7 @@ export default class MarkDownTemplate extends GlimmerComponent<{
               </span>
             {{else}}
               <span
-                class='markdown-bfm-broken markdown-bfm-broken--inline-embed
-                  markdown-bfm-broken--{{slot.format}}'
+                class='markdown-bfm-broken markdown-bfm-broken--inline-embed markdown-bfm-broken--{{slot.format}}'
                 style={{slot.style}}
                 title={{slot.url}}
                 data-test-markdown-bfm-unresolved-inline

--- a/packages/base/rich-markdown.gts
+++ b/packages/base/rich-markdown.gts
@@ -18,7 +18,6 @@ import {
   containsMany,
   field,
   linksToMany,
-  virtualNetworkFor,
 } from './card-api';
 import MarkdownTemplate from './default-templates/markdown';
 import CodeMirrorEditor from './codemirror-editor';
@@ -112,18 +111,15 @@ export class RichMarkdownField extends FieldDef {
     get content() {
       return this.args.model?.content ?? null;
     }
-    get virtualNetwork() {
-      return this.args.model ? virtualNetworkFor(this.args.model) : undefined;
-    }
     get baseUrl(): string | null {
       let model = this.args.model;
       let rel = model?.[relativeTo];
       if (!model || !rel) {
         return null;
       }
-      return typeof rel === 'string'
-        ? (virtualNetworkFor(model)?.toURL(rel).href ?? rel)
-        : rel.href;
+      // Instance ids are canonical (prefix form for mapped realms, URL for
+      // unmapped), so the reference base is the id as-is — no VirtualNetwork.
+      return typeof rel === 'string' ? rel : rel.href;
     }
     <template>
       <MarkdownTemplate
@@ -131,7 +127,6 @@ export class RichMarkdownField extends FieldDef {
         @linkedCards={{@model.linkedCards}}
         @linkedFiles={{@model.linkedFiles}}
         @cardReferenceBaseUrl={{this.baseUrl}}
-        @cardReferenceVirtualNetwork={{this.virtualNetwork}}
       />
     </template>
   };
@@ -140,18 +135,15 @@ export class RichMarkdownField extends FieldDef {
     get content() {
       return this.args.model?.content ?? null;
     }
-    get virtualNetwork() {
-      return this.args.model ? virtualNetworkFor(this.args.model) : undefined;
-    }
     get baseUrl(): string | null {
       let model = this.args.model;
       let rel = model?.[relativeTo];
       if (!model || !rel) {
         return null;
       }
-      return typeof rel === 'string'
-        ? (virtualNetworkFor(model)?.toURL(rel).href ?? rel)
-        : rel.href;
+      // Instance ids are canonical (prefix form for mapped realms, URL for
+      // unmapped), so the reference base is the id as-is — no VirtualNetwork.
+      return typeof rel === 'string' ? rel : rel.href;
     }
     <template>
       <MarkdownTemplate
@@ -159,7 +151,6 @@ export class RichMarkdownField extends FieldDef {
         @linkedCards={{@model.linkedCards}}
         @linkedFiles={{@model.linkedFiles}}
         @cardReferenceBaseUrl={{this.baseUrl}}
-        @cardReferenceVirtualNetwork={{this.virtualNetwork}}
       />
     </template>
   };
@@ -186,18 +177,15 @@ export class RichMarkdownField extends FieldDef {
     updateContent = (markdown: string) => {
       this.args.model.content = markdown;
     };
-    get virtualNetwork() {
-      return this.args.model ? virtualNetworkFor(this.args.model) : undefined;
-    }
     get baseUrl(): string | null {
       let model = this.args.model;
       let rel = model?.[relativeTo];
       if (!model || !rel) {
         return null;
       }
-      return typeof rel === 'string'
-        ? (virtualNetworkFor(model)?.toURL(rel).href ?? rel)
-        : rel.href;
+      // Instance ids are canonical (prefix form for mapped realms, URL for
+      // unmapped), so the reference base is the id as-is — no VirtualNetwork.
+      return typeof rel === 'string' ? rel : rel.href;
     }
     get linkedCards(): CardDef[] | null {
       try {
@@ -235,7 +223,6 @@ export class RichMarkdownField extends FieldDef {
               @linkedCards={{@model.linkedCards}}
               @linkedFiles={{@model.linkedFiles}}
               @cardReferenceBaseUrl={{this.baseUrl}}
-              @cardReferenceVirtualNetwork={{this.virtualNetwork}}
             />
           </div>
         {{else}}
@@ -246,7 +233,6 @@ export class RichMarkdownField extends FieldDef {
               @linkedCards={{this.linkedCards}}
               @linkedFiles={{this.linkedFiles}}
               @cardReferenceBaseUrl={{this.baseUrl}}
-              @cardReferenceVirtualNetwork={{this.virtualNetwork}}
               @livePreview={{eq this._mode 'compose'}}
               @getCards={{context.getCards}}
             >

--- a/packages/host/tests/integration/components/rich-markdown-field-test.gts
+++ b/packages/host/tests/integration/components/rich-markdown-field-test.gts
@@ -1,5 +1,6 @@
+import { precompileTemplate } from '@ember/template-compilation';
 import type { RenderingTestContext } from '@ember/test-helpers';
-import { click, waitFor, waitUntil } from '@ember/test-helpers';
+import { click, render, waitFor, waitUntil } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -424,6 +425,102 @@ module('Integration | RichMarkdownField', function (hooks) {
     assert
       .dom('[data-test-markdown-bfm-unresolved-block]')
       .doesNotExist('no unresolved Pill remains after card resolves (block)');
+  });
+
+  test('compose preview resolves a relative card ref against a prefix-form base', async function (assert) {
+    // Regression guard for the compose/edit path: when the realm is
+    // prefix-mapped the editor's reference base is a prefix-form RRI, and a
+    // relative embed (`:card[./Pet/mango]`) must resolve against it without a
+    // VirtualNetwork. Before the fix, CodeMirrorEditor's resolveUrl did
+    // `new URL(raw, base)`, which throws on a prefix base and falls back to the
+    // raw ref — so the widget never matched the loaded card and stayed a
+    // fallback. We render CodeMirrorEditor directly with the referenced card
+    // supplied via `linkedCards`, isolating the ref-resolution from the
+    // query-backed-field machinery.
+    class Pet extends CardDef {
+      static displayName = 'Pet';
+      @field name = contains(StringField);
+      @field cardTitle = contains(StringField, {
+        computeVia: function (this: Pet) {
+          return this.name;
+        },
+      });
+      static atom = class Atom extends Component<typeof this> {
+        <template>
+          <span data-test-pet-atom>{{@model.name}}</span>
+        </template>
+      };
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'pet.gts': { Pet },
+        'Pet/mango.json': {
+          data: {
+            attributes: { name: 'Mango', cardTitle: 'Mango' },
+            meta: {
+              adoptsFrom: { module: '../pet', name: 'Pet' },
+            },
+          },
+        },
+      },
+    });
+
+    // Two-segment realm prefix (`@scope/name/`), matching how real realm
+    // prefixes are namespaced (e.g. `@cardstack/base/`). Remove it afterward:
+    // the network service's VirtualNetwork is shared across tests.
+    let virtualNetwork = getService('network').virtualNetwork;
+    virtualNetwork.addRealmMapping('@test/cards/', testRealmURL);
+    try {
+      let store = getService('store');
+      // Served in canonical RRI form because the realm is prefix-mapped.
+      let pet = (await store.get('@test/cards/Pet/mango')) as BaseDef;
+      await store.loaded();
+      assert.strictEqual(
+        (pet as any).id,
+        '@test/cards/Pet/mango',
+        'precondition: the referenced card loads with a canonical RRI id',
+      );
+
+      let CodeMirrorEditor = (
+        (await loader.import(`${baseRealm.url}codemirror-editor`)) as {
+          default: unknown;
+        }
+      ).default;
+      let harness = {
+        content: 'Inline: :card[./Pet/mango]',
+        linkedCards: [pet],
+        onUpdate: () => {},
+      };
+
+      await render(
+        precompileTemplate(
+          `<CodeMirrorEditor
+             @content={{harness.content}}
+             @onUpdate={{harness.onUpdate}}
+             @linkedCards={{harness.linkedCards}}
+             @cardReferenceBaseUrl="@test/cards/article-1"
+             @livePreview={{true}}
+           />`,
+          {
+            strictMode: true,
+            scope: () => ({ CodeMirrorEditor, harness }),
+          },
+        ),
+      );
+
+      // With the fix, `./Pet/mango` resolves against the prefix base to
+      // `@test/cards/Pet/mango`, matching the supplied card's id, so the
+      // compose preview renders it. Before the fix it stayed an unresolved
+      // fallback and this selector never appears.
+      await waitFor('[data-test-pet-atom]', { timeout: 10_000 });
+      assert
+        .dom('[data-test-pet-atom]')
+        .hasText('Mango', 'relative ref resolves and renders in the preview');
+    } finally {
+      virtualNetwork.removeRealmMapping('@test/cards/');
+    }
   });
 
   test('inline card reference with a non-atom format resolves to an inline-block slot', async function (assert) {


### PR DESCRIPTION
This lets BFM `:card`/`:file` references use RRIs without needing a virtual network.