### PR TITLE
Stamp _isCardInstance and cardTitle into file search docs during indexing

### DIFF
--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -211,6 +211,11 @@ export default class RenderMetaRoute extends Route<Model> {
     // "_" prefix to make a decent attempt to not pollute the userland
     // namespace for cards
     searchDoc._cardType = friendlyCardType(Klass);
+    // `_title` is the neutral, cross-type display-title key that file docs also
+    // carry (see file-indexer), so a mixed cards+files query can substring-match
+    // and A-Z sort both row types on a single key. For a card it mirrors the
+    // `cardTitle` computed already present in the search doc.
+    searchDoc._title = searchDoc.cardTitle;
 
     let diagnostics: PrerenderMetaDiagnostics = {
       ...(passSnapshot

--- a/packages/host/tests/integration/searchable-search-doc-test.gts
+++ b/packages/host/tests/integration/searchable-search-doc-test.gts
@@ -685,16 +685,17 @@ module('Integration | searchable search doc', function (hooks) {
     return await searchDocFromFields(instance);
   }
 
-  // The search doc the indexer persisted, minus `_cardType` (which the prerender
-  // meta route appends, not the generator). The prerender meta route generates
-  // it via `searchDocFromFields`; the parity check below confirms it matches a
-  // direct `searchDocFromFields` call.
+  // The search doc the indexer persisted, minus the synthetic keys `_cardType`
+  // and `_title` (which the prerender meta route appends, not the generator).
+  // The prerender meta route generates the rest via `searchDocFromFields`; the
+  // parity check below confirms it matches a direct `searchDocFromFields` call.
   async function indexedSearchDoc(id: string) {
     let entry = await realm.realmIndexQueryEngine.instance(new URL(id));
     if (!entry || entry.type === 'instance-error') {
       return undefined;
     }
-    let { _cardType, ...rest } = (entry as IndexedInstance).searchDoc ?? {};
+    let { _cardType, _title, ...rest } =
+      (entry as IndexedInstance).searchDoc ?? {};
     return rest;
   }
 

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -1562,6 +1562,56 @@ module('Unit | index-writer', function (hooks) {
     );
   });
 
+  test('error entry keeps freshly-stamped synthetic search keys over the last-known-good doc', async function (assert) {
+    // Rollout case: a `file` row indexed before `_isCardInstance` / `_title`
+    // existed, then hit by a dependency-error reindex. The fresh searchData
+    // carries the synthetic keys and must survive rather than being clobbered
+    // by the production doc, while last-known-good fields (here `extra`) still
+    // carry forward.
+    let timestamp = Date.now();
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_generation: 1 }],
+      [
+        {
+          url: `${testRealmURL}1.json`,
+          generation: 1,
+          realm_url: testRealmURL,
+          type: 'file',
+          search_doc: { name: '1.json', extra: 'keep-me' },
+          last_modified: String(timestamp),
+          resource_created_at: String(timestamp),
+        },
+      ],
+    );
+
+    let batch = await indexWriter.createBatch(
+      new URL(testRealmURL),
+      virtualNetwork,
+    );
+    await batch.updateEntry(new URL(`${testRealmURL}1.json`), {
+      type: 'file-error',
+      error: { message: 'dep in error', status: 500, additionalErrors: [] },
+      searchData: { name: '1.json', _isCardInstance: true, _title: '1.json' },
+    });
+    await batch.done();
+
+    let [row] = (await adapter.execute(
+      "SELECT search_doc FROM boxel_index WHERE generation = 2 AND type = 'file' AND has_error = TRUE",
+      { coerceTypes },
+    )) as unknown as BoxelIndexTable[];
+    assert.deepEqual(
+      row.search_doc,
+      {
+        name: '1.json',
+        extra: 'keep-me',
+        _isCardInstance: true,
+        _title: '1.json',
+      },
+      'error row merges freshly-stamped synthetic keys onto the last-known-good doc',
+    );
+  });
+
   test('strips jsonb-illegal code points from error_doc and diagnostics on write', async function (assert) {
     await setupIndex(
       adapter,

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1060,9 +1060,9 @@ module(basename(import.meta.filename), function () {
         'file entry for a card instance json is marked _isCardInstance',
       );
       assert.strictEqual(
-        entry?.searchDoc?.cardTitle,
+        entry?.searchDoc?._title,
         'mango.json',
-        'file entry cardTitle is the file name',
+        'file entry _title is the file name',
       );
     });
 
@@ -1112,9 +1112,9 @@ module(basename(import.meta.filename), function () {
         'search_doc includes contentSize',
       );
       assert.strictEqual(
-        searchDoc.cardTitle,
+        searchDoc._title,
         'random-file.txt',
-        'search_doc cardTitle is the file name',
+        'search_doc _title is the file name',
       );
       assert.false(
         '_isCardInstance' in searchDoc,

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1055,6 +1055,15 @@ module(basename(import.meta.filename), function () {
         'number',
         'file entry includes contentSize',
       );
+      assert.true(
+        entry?.searchDoc?._isCardInstance,
+        'file entry for a card instance json is marked _isCardInstance',
+      );
+      assert.strictEqual(
+        entry?.searchDoc?.cardTitle,
+        'mango.json',
+        'file entry cardTitle is the file name',
+      );
     });
 
     test('keeps instance entries when indexing card json files as file entries', async function (assert) {
@@ -1101,6 +1110,15 @@ module(basename(import.meta.filename), function () {
         typeof searchDoc.contentSize,
         'number',
         'search_doc includes contentSize',
+      );
+      assert.strictEqual(
+        searchDoc.cardTitle,
+        'random-file.txt',
+        'search_doc cardTitle is the file name',
+      );
+      assert.false(
+        '_isCardInstance' in searchDoc,
+        'non-card file search_doc does not carry _isCardInstance',
       );
     });
 

--- a/packages/realm-server/tests/searchable-parity-diff-test.ts
+++ b/packages/realm-server/tests/searchable-parity-diff-test.ts
@@ -5,7 +5,8 @@ import { diffDoc, isShallowLink, shallowIds } from '@cardstack/runtime-common';
 
 // Unit coverage for the parity comparison logic shared by the realm-scale
 // validator (`scripts/searchable-parity-diff.ts`) and the generation tests.
-// The differ ignores `_cardType`, normalizes object key order, and (under
+// The differ ignores synthetic keys (`_cardType`, `_title`, `_isCardInstance`),
+// normalizes object key order, and (under
 // --ignore-shallow-links) treats the store-driven omit-vs-keep-`{id}` difference
 // as equivalent — at any nesting depth — while still catching a CHANGED
 // reference or any real contained-data delta.
@@ -49,6 +50,27 @@ module('Unit | searchable-parity-diff', function () {
         ),
         [],
         'same data, differing _cardType → equal',
+      );
+    });
+
+    test('synthetic _title / _isCardInstance keys are ignored', function (assert) {
+      assert.deepEqual(
+        diffDoc(
+          { title: 'A' },
+          { title: 'A', _title: 'A', _isCardInstance: true },
+          false,
+        ),
+        [],
+        'synthetic keys present on only one side → equal',
+      );
+      assert.deepEqual(
+        diffDoc(
+          { title: 'A', _title: 'X' },
+          { title: 'A', _title: 'Y' },
+          false,
+        ),
+        [],
+        'differing _title → equal',
       );
     });
 

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -1912,11 +1912,16 @@ async function getField(
     return await definitionLookup.lookupDefinition(codeRef);
   });
   if (!field) {
-    if (currentField(pathTraveled) === '_cardType') {
-      // this is a little awkward--we have the need to treat '_cardType' as a
-      // type of string field that we can query against from the index (e.g. the
-      // cards grid sorts by the card's display name). index-runner is injecting
-      // this into the searchDoc during index time.
+    if (
+      currentField(pathTraveled) === '_cardType' ||
+      currentField(pathTraveled) === '_title'
+    ) {
+      // this is a little awkward--we have the need to treat '_cardType' and
+      // '_title' as string fields that we can query against from the index
+      // (e.g. the cards grid sorts by the card's display name; a mixed
+      // cards+files search sorts/filters both row types on '_title'). the
+      // index-runner / prerender meta route inject these into the searchDoc
+      // during index time.
       return {
         type: 'contains',
         isPrimitive: true,

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -1014,6 +1014,7 @@ export class IndexRunner {
     lastModified,
     resourceCreatedAt,
     hasModulePrerender,
+    isCardInstance,
     extractResult,
     renderResult,
     diagnostics,
@@ -1022,6 +1023,7 @@ export class IndexRunner {
     lastModified: number;
     resourceCreatedAt: number;
     hasModulePrerender?: boolean;
+    isCardInstance?: boolean;
     // Extract result from the index visit and merged render result from the
     // index + prerender-html visits. Either may be undefined if the visits
     // short-circuited before producing it.
@@ -1040,6 +1042,7 @@ export class IndexRunner {
       lastModified,
       resourceCreatedAt,
       hasModulePrerender,
+      isCardInstance,
       realmURL: this.#realmURL,
       auth: this.#auth,
       jobInfo: this.#jobInfo,

--- a/packages/runtime-common/index-runner/file-indexer.ts
+++ b/packages/runtime-common/index-runner/file-indexer.ts
@@ -176,11 +176,11 @@ export async function performFileIndexing({
   //   appears via its `instance` row). It rides on the dependency-error entry
   //   too, so a card .json whose card is in an error state stays out of file
   //   search. Stamped only when true; plain file docs don't carry the key.
-  // - `cardTitle` on a file doc is NOT a claim that the file is a card: it is
-  //   the file's display title (its name) aliased under the key card docs use
-  //   (CardDef's title field is named `cardTitle`), so one mixed query can
-  //   substring-match (`contains: {cardTitle}`) and A-Z sort
-  //   (`search_doc->>'cardTitle'`, NULLS LAST) cards and files uniformly.
+  // - `_title` is the row's display title (a file's is its name) under a
+  //   neutral key that card docs also carry (stamped alongside `_cardType`
+  //   during card render), so one mixed query can substring-match
+  //   (`contains: {_title}`) and A-Z sort (`search_doc->>'_title'`, NULLS
+  //   LAST) cards and files uniformly.
   let searchData = {
     url: fileURL,
     sourceUrl: fileURL,
@@ -188,7 +188,7 @@ export async function performFileIndexing({
     contentType,
     ...(extractResult.searchDoc ?? {}),
     ...(isCardInstance ? { _isCardInstance: true } : {}),
-    cardTitle: name,
+    _title: name,
   };
 
   // Runtime deps are the source of truth. Use index-backed lookup only to

--- a/packages/runtime-common/index-runner/file-indexer.ts
+++ b/packages/runtime-common/index-runner/file-indexer.ts
@@ -32,6 +32,9 @@ export interface FileIndexerOptions {
   lastModified: number;
   resourceCreatedAt: number;
   hasModulePrerender?: boolean;
+  // True when this file is a card-instance .json — the fused visit dual-
+  // indexes those (an `instance` row plus this `file` row).
+  isCardInstance?: boolean;
   realmURL: URL;
   auth: string;
   jobInfo: JobInfo;
@@ -59,6 +62,7 @@ export async function performFileIndexing({
   lastModified,
   resourceCreatedAt,
   hasModulePrerender,
+  isCardInstance,
   realmURL: _realmURL,
   auth: _auth,
   jobInfo,
@@ -164,6 +168,29 @@ export async function performFileIndexing({
   let fileTypes = extractResult.types ?? fallbackTypes;
   let deps = new Set(extractResult.deps ?? []);
 
+  // Shared by the success entry and the dependency-error entry below, so the
+  // two rows carry the same search keys. Two of them are synthetic (stamped
+  // after the extractor's searchDoc so they win deterministically):
+  // - `_isCardInstance` marks the `file` row of a dual-indexed card-instance
+  //   .json so mixed cards+files search can exclude it (the card already
+  //   appears via its `instance` row). It rides on the dependency-error entry
+  //   too, so a card .json whose card is in an error state stays out of file
+  //   search. Stamped only when true; plain file docs don't carry the key.
+  // - `cardTitle` on a file doc is NOT a claim that the file is a card: it is
+  //   the file's display title (its name) aliased under the key card docs use
+  //   (CardDef's title field is named `cardTitle`), so one mixed query can
+  //   substring-match (`contains: {cardTitle}`) and A-Z sort
+  //   (`search_doc->>'cardTitle'`, NULLS LAST) cards and files uniformly.
+  let searchData = {
+    url: fileURL,
+    sourceUrl: fileURL,
+    name,
+    contentType,
+    ...(extractResult.searchDoc ?? {}),
+    ...(isCardInstance ? { _isCardInstance: true } : {}),
+    cardTitle: name,
+  };
+
   // Runtime deps are the source of truth. Use index-backed lookup only to
   // detect whether any dependency currently has an errored row.
   let dependencyError =
@@ -179,13 +206,7 @@ export async function performFileIndexing({
     await updateEntry(entryURL, {
       type: 'file-error',
       error: normalizedDependencyError,
-      searchData: {
-        url: fileURL,
-        sourceUrl: fileURL,
-        name,
-        contentType,
-        ...(extractResult.searchDoc ?? {}),
-      },
+      searchData,
       types: fileTypes,
       diagnostics,
     });
@@ -223,13 +244,7 @@ export async function performFileIndexing({
     resourceCreatedAt,
     deps,
     resource: extractResult.resource ?? null,
-    searchData: {
-      url: fileURL,
-      sourceUrl: fileURL,
-      name,
-      contentType,
-      ...(extractResult.searchDoc ?? {}),
-    },
+    searchData,
     types: fileTypes,
     displayNames: extractResult.displayNames ?? [],
     isolatedHtml: renderResult?.isolatedHTML ?? undefined,

--- a/packages/runtime-common/index-runner/visit-file.ts
+++ b/packages/runtime-common/index-runner/visit-file.ts
@@ -66,6 +66,9 @@ interface VisitFileOptions {
     lastModified: number;
     resourceCreatedAt: number;
     hasModulePrerender?: boolean;
+    // True when this file is a card-instance .json (the same fact that
+    // triggers the additional `instance` row in this fused visit).
+    isCardInstance?: boolean;
     extractResult?: RenderVisitResponse['fileExtract'];
     renderResult?: RenderVisitResponse['fileRender'];
     diagnostics?: Diagnostics;
@@ -330,6 +333,7 @@ export async function visitFileForIndexing({
     lastModified,
     resourceCreatedAt,
     hasModulePrerender: isModule,
+    isCardInstance: Boolean(parsedCardResource),
     extractResult: indexResponse.fileExtract,
     renderResult: fileRenderResult,
     diagnostics,

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -649,15 +649,23 @@ export class Batch {
         };
         break;
       case 'instance-error':
-      case 'file-error':
+      case 'file-error': {
+        let production: Record<string, any> =
+          (await this.getProductionVersion(url, baseTypeFromError(entry))) ??
+          {};
         entryPayload = {
           types: entry.types,
-          search_doc: entry.searchData,
           // favor the last known good types over the types derived from the error state
-          ...((await this.getProductionVersion(
-            url,
-            baseTypeFromError(entry),
-          )) ?? {}),
+          ...production,
+          // Assign search_doc AFTER the production spread so the freshly-stamped
+          // synthetic keys (`_title`, `_isCardInstance`, `_cardType`) survive
+          // rather than being clobbered by the last-known-good doc. Overlaying
+          // the current searchData onto that doc keeps an instance's rich fields
+          // when it degrades to a sparse error searchData, while a file /
+          // dependency-error row (full searchData) wins outright.
+          search_doc: entry.searchData
+            ? { ...(production.search_doc ?? {}), ...entry.searchData }
+            : (production.search_doc ?? null),
           // preserve last_known_good_deps through error cycles (may have been cleared
           // by getProductionVersion if it returned undefined, so we explicitly preserve it)
           last_known_good_deps: await this.getLastKnownGoodDeps(
@@ -670,6 +678,7 @@ export class Batch {
           diagnostics: diagnostics,
         };
         break;
+      }
       default:
         throw new Error(
           `Unsupported index entry type: ${(entry as { type: string }).type}`,

--- a/packages/runtime-common/searchable-parity.ts
+++ b/packages/runtime-common/searchable-parity.ts
@@ -82,6 +82,7 @@ function diffValue(
   if (isObject(lv) && isObject(gv)) {
     let keys = new Set([...Object.keys(lv), ...Object.keys(gv)]);
     keys.delete('_cardType');
+    keys.delete('_isCardInstance');
     for (let key of keys) {
       diffValue(
         path ? `${path}.${key}` : key,

--- a/packages/runtime-common/searchable-parity.ts
+++ b/packages/runtime-common/searchable-parity.ts
@@ -83,6 +83,7 @@ function diffValue(
     let keys = new Set([...Object.keys(lv), ...Object.keys(gv)]);
     keys.delete('_cardType');
     keys.delete('_isCardInstance');
+    keys.delete('_title');
     for (let key of keys) {
       diffValue(
         path ? `${path}.${key}` : key,
@@ -116,8 +117,9 @@ function diffValue(
 }
 
 // Compare two search docs and return a list of human-readable divergences
-// (empty when equivalent). `_cardType` (appended by the prerender meta route,
-// not the generator) is ignored; object key order is normalized.
+// (empty when equivalent). Synthetic keys stamped after generation
+// (`_cardType`, `_title`, `_isCardInstance`) are ignored; object key order is
+// normalized.
 export function diffDoc(
   live: SearchDoc,
   generated: SearchDoc,


### PR DESCRIPTION
## What

Every realm file gets a `type='file'` index row, and a card-instance `.json` is dual-indexed (an `instance` row plus a `file` row). The fused visit computes "is this a card instance" at index time (`parsedCardResource`) but the file indexer never learned it. This PR threads that fact through to `performFileIndexing` and stamps two synthetic keys into the file row's `search_doc`:

- **`_isCardInstance: true`** — marks the `file` row of a dual-indexed card-instance `.json` so a mixed cards+files search can exclude it (the card already appears via its `instance` row). Stamped on the dependency-error entry too, so a card `.json` whose card is in an error state stays out of file search. Only stamped when true; plain file docs don't carry the key. Added to the searchable-parity ignore set alongside `_cardType`.
- **`cardTitle`** — the file's name aliased under the key card docs use (CardDef's title field is named `cardTitle`). The search sheet's term filter substring-matches via `contains: {cardTitle}` (full-text `matches` only matches whole words) and A-Z sort compiles to `search_doc->>'cardTitle'` with NULLS LAST, so without the alias files never prefix-match and always sink below every card in a mixed result set. It is not a claim that the file is a card.

Both keys are stamped generically in `file-indexer.ts`; no `packages/base` or query-engine changes.

## Rollout caveat

Pre-existing index rows lack both keys until their realm reindexes — until then, card-instance `.json` files will linger in file search and files will sort/match degraded, per realm. Forced reindex vs. natural cadence is a ship-time decision for the downstream mixed-search work.

## Testing

Extended `packages/realm-server/tests/indexing-test.ts`:
- the file entry for a card-instance `.json` fixture carries `_isCardInstance: true` and `cardTitle` = file name
- a plain text file's search doc carries `cardTitle` = file name and no `_isCardInstance` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)