### PR TITLE
Harden ai-assistant scrolling tests against a scroll-settle race

### DIFF
--- a/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
@@ -1,4 +1,4 @@
-import { waitFor, click, triggerEvent } from '@ember/test-helpers';
+import { waitFor, waitUntil, click, triggerEvent } from '@ember/test-helpers';
 import { settled } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
@@ -194,6 +194,50 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
     return conversationElement.scrollTop < 20;
   }
 
+  function describeScrollPosition() {
+    let conversationElement = document.querySelector(
+      '[data-test-ai-assistant-conversation]',
+    );
+    if (!conversationElement) {
+      return 'no [data-test-ai-assistant-conversation] element';
+    }
+    let { scrollHeight, clientHeight, scrollTop } = conversationElement;
+    let distanceFromBottom = Math.abs(scrollHeight - clientHeight - scrollTop);
+    return `scrollHeight=${scrollHeight} clientHeight=${clientHeight} scrollTop=${scrollTop} distanceFromBottom=${distanceFromBottom} bottomThreshold=${BOTTOM_THRESHOLD}`;
+  }
+
+  // The auto-scroll that keeps the newest message in view fires when the last
+  // message registers its scroller and again whenever that message's subtree
+  // mutates. Avatars, card pills, and markdown can finish rendering (and shift
+  // layout) after the test runloop has otherwise settled, which moves the
+  // scroll position before the component re-scrolls to correct it. A single
+  // synchronous read races that correction, so poll until the conversation
+  // settles at the target position. On timeout, report the exact geometry so a
+  // future failure is diagnosable instead of a bare `expected true`.
+  async function assertScrolledToBottom(
+    assert: Assert,
+    message = 'AI assistant is scrolled to bottom',
+  ) {
+    try {
+      await waitUntil(() => isAiAssistantScrolledToBottom(), { timeout: 2000 });
+      assert.ok(true, message);
+    } catch {
+      assert.ok(false, `${message} — ${describeScrollPosition()}`);
+    }
+  }
+
+  async function assertScrolledToTop(
+    assert: Assert,
+    message = 'AI assistant is scrolled to top',
+  ) {
+    try {
+      await waitUntil(() => isAiAssistantScrolledToTop(), { timeout: 2000 });
+      assert.ok(true, message);
+    } catch {
+      assert.ok(false, `${message} — ${describeScrollPosition()}`);
+    }
+  }
+
   function fillRoomWithReadMessages(
     roomId: string,
     messagesHaveBeenRead = true,
@@ -265,11 +309,8 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
     });
     await waitFor('[data-test-message-idx="40"]');
     await click('[data-test-unread-messages-button]');
-    await new Promise((r) => setTimeout(r, 2000)); // wait for animated scroll to complete
-    assert.ok(
-      isAiAssistantScrolledToBottom(),
-      'AI assistant is scrolled to bottom',
-    );
+    // poll until the animated scroll completes and settles at the bottom
+    await assertScrolledToBottom(assert);
   });
 
   test('it does not show unread message indicator when new message received and scrolled to bottom', async function (assert) {
@@ -307,8 +348,8 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
     await settled();
     await click('[data-test-open-ai-assistant]');
     await waitFor('[data-test-message-idx="39"]');
-    assert.ok(
-      isAiAssistantScrolledToTop(),
+    await assertScrolledToTop(
+      assert,
       'AI assistant is scrolled to top (where the first unread message is)',
     );
   });
@@ -329,10 +370,7 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
     await settled();
     await click('[data-test-open-ai-assistant]');
     await waitFor('[data-test-message-idx="39"]');
-    assert.ok(
-      isAiAssistantScrolledToBottom(),
-      'AI assistant is scrolled to bottom',
-    );
+    await assertScrolledToBottom(assert);
   });
 
   test('scrolling stays at the bottom if a message is streaming in', async function (assert) {
@@ -351,10 +389,7 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
     await settled();
     await click('[data-test-open-ai-assistant]');
     await waitFor('[data-test-message-idx="39"]');
-    assert.ok(
-      isAiAssistantScrolledToBottom(),
-      'AI assistant is scrolled to bottom',
-    );
+    await assertScrolledToBottom(assert);
 
     let eventId = simulateRemoteMessage(roomId, '@aibot:localhost', {
       body: `thinking...`,

--- a/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
@@ -202,7 +202,11 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
       return 'no [data-test-ai-assistant-conversation] element';
     }
     let { scrollHeight, clientHeight, scrollTop } = conversationElement;
-    let distanceFromBottom = Math.abs(scrollHeight - clientHeight - scrollTop);
+    // Signed: positive means content still sits below the fold (not scrolled
+    // far enough down), negative means scrolled past the bottom. The
+    // scrolled-to-bottom check compares the absolute value against the
+    // threshold, so the sign is diagnostic-only.
+    let distanceFromBottom = scrollHeight - clientHeight - scrollTop;
     return `scrollHeight=${scrollHeight} clientHeight=${clientHeight} scrollTop=${scrollTop} distanceFromBottom=${distanceFromBottom} bottomThreshold=${BOTTOM_THRESHOLD}`;
   }
 
@@ -221,8 +225,9 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
     try {
       await waitUntil(() => isAiAssistantScrolledToBottom(), { timeout: 2000 });
       assert.ok(true, message);
-    } catch {
-      assert.ok(false, `${message} — ${describeScrollPosition()}`);
+    } catch (e) {
+      let reason = e instanceof Error ? e.message : String(e);
+      assert.ok(false, `${message} — ${describeScrollPosition()} (${reason})`);
     }
   }
 
@@ -233,8 +238,9 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
     try {
       await waitUntil(() => isAiAssistantScrolledToTop(), { timeout: 2000 });
       assert.ok(true, message);
-    } catch {
-      assert.ok(false, `${message} — ${describeScrollPosition()}`);
+    } catch (e) {
+      let reason = e instanceof Error ? e.message : String(e);
+      assert.ok(false, `${message} — ${describeScrollPosition()} (${reason})`);
     }
   }
 


### PR DESCRIPTION
The `Integration | ai-assistant-panel | scrolling` suite intermittently fails on `scrolling stays at the bottom if a message is streaming in` with `AI assistant is scrolled to bottom` expected `true`, got `false` ([failing CI job](https://github.com/cardstack/boxel/actions/runs/28691856694/job/85094687875)).

## Root cause

The "open a room" assertions read the conversation's scroll position **synchronously**, immediately after the room renders. The panel auto-scrolls to the newest message when the last message registers its scroller, and re-scrolls whenever that message's subtree mutates (see the per-message `MutationObserver` in `ai-assistant/message`). Avatars, card pills, and markdown that finish rendering *after* the test runloop has otherwise settled shift the layout and briefly move the scroll position before the component re-scrolls to correct it. A single synchronous read races that correction and occasionally samples a position past the bottom threshold. The failing run shows this directly — the avatar `set-background-image` helper module 404s and retries at +100ms, i.e. late layout work landing after `settled()`.

Only the first assertion in the test can fail this way: `simulateRemoteMessage` delivers events via `setTimeout(0)` and Glimmer batches renders, so the two assertions that follow a `simulateRemoteMessage` with no `await` read stale DOM (still at the bottom) and pass trivially.

## Fix

Replace the point-in-time scroll reads in the "open a room" assertions with a `waitUntil` poll that tolerates the late re-scroll. The predicate is unchanged, so an already-settled panel resolves immediately; only the racing case now waits for the component's own correction to land. On timeout the helper reports the exact geometry (`scrollHeight` / `clientHeight` / `scrollTop` / `distanceFromBottom` / `bottomThreshold`) so a future failure is diagnosable instead of a bare `expected true`.

The same race exists in the sibling "open a room" checks (scroll-to-last, scroll-to-first-unread, and the unread-indicator click, which previously used a fixed 2s sleep), so they move to the same helper. The two checks that verify enqueuing a streaming event doesn't *synchronously* jank the scroll stay synchronous by design.

## Verification

Test-only change; `eslint` and `ember-tsc` are clean for the file. The underlying flake is timing- and CI-load-dependent and doesn't reproduce reliably locally, so the diagnostics are included as insurance: if the poll ever times out, the next failure will print the exact scroll geometry.
