### PR TITLE
fix: preserve an authored-empty linksToMany distinctly from a never-set one

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1981,23 +1981,21 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
         );
       }
       if (!Array.isArray(values.data)) {
-        // An authored-empty plural relationship (`{ links: { self: null } }` or
-        // `{ data: null }` in the source). Tag the empty result as authored so
-        // serialization keeps it as `{ self: null }` rather than dropping it
-        // like a never-set link. A computed field's emptiness is derived, never
-        // authored, so it is never tagged.
-        let empty: (BaseInstanceType<FieldT> | NotLoadedValue)[] = [];
-        if (!this.computeVia) {
-          markAuthoredEmptyLink(empty);
-        }
-        return empty;
+        // A `{ links: { self: null } }` relationship (no `data` array) is an
+        // authored empty — no members. Fall through with an empty relationship
+        // list so the shared WatchedArray path below wraps (and tags) it the
+        // same as an empty `{ data: [] }`: a mutable, reactive backing array,
+        // not a bare `[]` (which would hand a later push/splice a plain array
+        // and skip the WatchedArray subscriber).
+        relationships = [];
+      } else {
+        relationships = values.data.map((entry) => ({
+          links: {
+            self: entry && 'id' in entry ? (entry.id ?? null) : null,
+          },
+          data: entry,
+        }));
       }
-      relationships = values.data.map((entry) => ({
-        links: {
-          self: entry && 'id' in entry ? (entry.id ?? null) : null,
-        },
-        data: entry,
-      }));
     }
 
     let resources: Promise<BaseInstanceType<FieldT> | NotLoadedValue>[] =
@@ -2089,10 +2087,11 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       resolved,
       { hideSlot: isNonPresentLink },
     );
-    // An authored-empty plural relationship spelled `{ data: [] }` in the source
-    // deserializes to an empty array — tag it authored so serialization keeps it
-    // as `{ self: null }`. (`{ links: { self: null } }` sources return early
-    // above.) A computed field's emptiness is derived, never authored.
+    // An authored-empty plural relationship (`{ data: [] }` or
+    // `{ links: { self: null } }` in the source) deserializes to an empty
+    // array — tag it authored so serialization keeps it as `{ self: null }`
+    // rather than dropping it like a never-set link. A computed field's
+    // emptiness is derived, never authored, so it is never tagged.
     if (resolved.length === 0 && !this.computeVia) {
       markAuthoredEmptyLink(watched);
     }

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -182,6 +182,7 @@ import {
   isLinkNotFound,
   isNonPresentLink,
   isNotLoadedValue,
+  markAuthoredEmptyLink,
   notifyCardTracking,
   peekAtField,
   propagateRealmContext,
@@ -1980,7 +1981,16 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
         );
       }
       if (!Array.isArray(values.data)) {
-        return [];
+        // An authored-empty plural relationship (`{ links: { self: null } }` or
+        // `{ data: null }` in the source). Tag the empty result as authored so
+        // serialization keeps it as `{ self: null }` rather than dropping it
+        // like a never-set link. A computed field's emptiness is derived, never
+        // authored, so it is never tagged.
+        let empty: (BaseInstanceType<FieldT> | NotLoadedValue)[] = [];
+        if (!this.computeVia) {
+          markAuthoredEmptyLink(empty);
+        }
+        return empty;
       }
       relationships = values.data.map((entry) => ({
         links: {
@@ -2063,7 +2073,8 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
         return deserialized;
       });
 
-    return new WatchedArray(
+    let resolved = await Promise.all(resources);
+    let watched = new WatchedArray(
       (oldValue, value) =>
         instancePromise.then((instance) => {
           applySubscribersToInstanceValue(
@@ -2075,9 +2086,17 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
           notifySubscribers(instance, this.name, value);
           notifyCardTracking(instance);
         }),
-      await Promise.all(resources),
+      resolved,
       { hideSlot: isNonPresentLink },
     );
+    // An authored-empty plural relationship spelled `{ data: [] }` in the source
+    // deserializes to an empty array — tag it authored so serialization keeps it
+    // as `{ self: null }`. (`{ links: { self: null } }` sources return early
+    // above.) A computed field's emptiness is derived, never authored.
+    if (resolved.length === 0 && !this.computeVia) {
+      markAuthoredEmptyLink(watched);
+    }
+    return watched;
   }
 
   emptyValue(instance: BaseDef) {

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -516,7 +516,7 @@ const authoredEmptyLinks = new WeakSet<object>();
 // treats it as a relationship the card has (`isFieldUsed`). No-op for a
 // non-empty array (already "had" by length) or a non-array value.
 export function markAuthoredEmptyLink(value: unknown): void {
-  if (Array.isArray(value)) {
+  if (Array.isArray(value) && value.length === 0) {
     authoredEmptyLinks.add(value);
   }
 }

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -504,16 +504,41 @@ function computeFields(
   return fields;
 }
 
+// Empty `linksToMany` backing arrays that came from an authored-empty
+// relationship (`{ self: null }` / `{ data: [] }` in the source), tagged by
+// `LinksToMany.deserialize`. An empty array in the data bucket is ambiguous —
+// it may be an authored empty or one a mere render fabricated (the plural
+// getter persists a backing array on read, unlike `linksTo`) — so this tag is
+// what lets serialization keep the authored empty and drop the fabricated one.
+const authoredEmptyLinks = new WeakSet<object>();
+
+// Tag an empty `linksToMany` backing array as an authored empty so serialization
+// treats it as a relationship the card has (`isFieldUsed`). No-op for a
+// non-empty array (already "had" by length) or a non-array value.
+export function markAuthoredEmptyLink(value: unknown): void {
+  if (Array.isArray(value)) {
+    authoredEmptyLinks.add(value);
+  }
+}
+
 // Whether a link field is "used" for `usedLinksToFieldsOnly` serialization: the
 // card actually has the relationship. A link enters the data bucket only when
 // it was authored (deserialized from the source — a set target, or an empty
 // `{ self: null }` that lands as a `null` entry) or set on the instance; a
 // never-authored `linksTo` has no bucket entry, because the getter skips
 // persisting its nullish empty value, so a mere render can't mark it "used".
+//
 // A `linksToMany` getter must persist its (mutable) backing array even when
-// empty, so an empty array is NOT a "had" relationship — reading an unset
-// plural link would otherwise fabricate one. This is pure card data,
-// independent of searchability. Contained fields never reach here (always kept).
+// empty, so a never-set plural link merely read fabricates an empty array in
+// the bucket. An empty array is therefore ambiguous: authored empty vs.
+// render-fabricated. `LinksToMany.deserialize` disambiguates by tagging the
+// arrays it produces from an authored-empty relationship
+// (`markAuthoredEmptyLink`); an untagged empty array is treated as never-set
+// and omitted. So an authored empty plural link round-trips as `{ self: null }`
+// while a never-set one stays off the wire — matching the `linksTo` fidelity.
+//
+// This is pure card data, independent of searchability. Contained fields never
+// reach here (always kept).
 function isFieldUsed(
   instance: BaseDef | undefined,
   fieldName: string,
@@ -526,11 +551,12 @@ function isFieldUsed(
     return false;
   }
   let value = bucket.get(fieldName);
-  // An empty backing array is a `linksToMany` the card doesn't actually have
-  // (never authored, or materialized empty on read); `null` is an authored
-  // empty `linksTo` and is kept.
+  // A non-empty array is a set plural link. An empty array is "had" only when
+  // `deserialize` tagged it as an authored empty; a render-fabricated empty
+  // (an unset plural link merely read) is untagged and dropped. `null` is an
+  // authored empty `linksTo` and is kept.
   if (Array.isArray(value)) {
-    return value.length > 0;
+    return value.length > 0 || authoredEmptyLinks.has(value);
   }
   return true;
 }

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -58,6 +58,9 @@ import {
   field,
   NumberField,
   isSaved,
+  subscribeToChanges,
+  unsubscribeFromChanges,
+  flushLogs,
   Base64ImageField,
   updateFromSerialized,
   CodeRefField,
@@ -7077,6 +7080,72 @@ module('Integration | serialization', function (hooks) {
       assert.ok(hassan instanceof Person, `${hassan.id} is a Person`);
       assert.ok(isSaved(hassan), `${hassan.id} is saved`);
       assert.strictEqual(hassan.firstName, 'Hassan');
+    });
+
+    test('an authored-empty linksToMany deserializes to a reactive backing array (in-place mutation notifies subscribers)', async function (assert) {
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field friends = linksToMany(() => Person);
+      }
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'test-cards.gts': { Person },
+        },
+      });
+
+      // Author `friends` explicitly empty (`{ self: null }`) rather than
+      // leaving it absent, then deserialize.
+      let doc = {
+        data: {
+          type: 'card',
+          id: `${testRealmURL}Person/hassan`,
+          attributes: { firstName: 'Hassan' },
+          relationships: { friends: { links: { self: null } } },
+          meta: {
+            adoptsFrom: { module: testRRI('test-cards'), name: 'Person' },
+          },
+        },
+      };
+      let hassan = await createFromSerialized<typeof Person>(
+        doc.data,
+        doc,
+        new URL(`${testRealmURL}Person/hassan`),
+      );
+      assert.strictEqual(hassan.friends.length, 0, 'friends starts empty');
+
+      // The getter must hand back the reactive backing array, not a bare `[]`:
+      // an in-place push runs the WatchedArray subscriber, which notifies
+      // change listeners. A plain array would mutate silently.
+      let events: { fieldName: string; value: unknown }[] = [];
+      let subscriber = (
+        _instance: unknown,
+        fieldName: string,
+        value: unknown,
+      ) => events.push({ fieldName, value });
+      subscribeToChanges(hassan, subscriber);
+      try {
+        let mango = new Person({ firstName: 'Mango' });
+        hassan.friends.push(mango);
+        await flushLogs();
+        assert.strictEqual(
+          events.length,
+          1,
+          'pushing onto the authored-empty relationship notifies subscribers',
+        );
+        assert.strictEqual(
+          events[0]?.fieldName,
+          'friends',
+          'the change event names the mutated field',
+        );
+        assert.strictEqual(
+          hassan.friends[0],
+          mango,
+          'the pushed card is read back from the same backing array',
+        );
+      } finally {
+        unsubscribeFromChanges(hassan, subscriber);
+      }
     });
   });
 

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -7096,7 +7096,7 @@ module('Integration | serialization', function (hooks) {
 
       // Author `friends` explicitly empty (`{ self: null }`) rather than
       // leaving it absent, then deserialize.
-      let doc = {
+      let doc: LooseSingleCardDocument = {
         data: {
           type: 'card',
           id: `${testRealmURL}Person/hassan`,

--- a/packages/host/tests/integration/realm-test.gts
+++ b/packages/host/tests/integration/realm-test.gts
@@ -1785,6 +1785,13 @@ module('Integration | realm', function (hooks) {
         cardThumbnailURL: null,
         cardInfo,
       },
+      // Emptying `pets` authors it empty — a relationship the card has, spelled
+      // `{ self: null }` on the wire — as distinct from a never-set link, which
+      // is omitted. So the served card+json keeps the emptied `pets` and omits
+      // the never-authored `friend`.
+      relationships: {
+        pets: { links: { self: null } },
+      },
       meta: {
         adoptsFrom: {
           module: `${testModuleRealm}pet-person`,

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -1433,6 +1433,103 @@ module(basename(import.meta.filename), function () {
           );
         });
 
+        test('an authored-empty linksToMany is preserved distinctly from a never-set one, in both the source and the served card+json', async function (assert) {
+          let realmEventTimestampStart = Date.now();
+
+          // Mirror of the `linksTo` case above for the plural link. Author
+          // `friends` (linksToMany) explicitly empty and leave `friend`
+          // (linksTo) absent. An empty plural link is authored — a relationship
+          // the card has, spelled `{ self: null }` on the wire — vs. a never-set
+          // one, which is omitted. This holds even though the plural getter
+          // materializes a backing array on read: a mere render doesn't author a
+          // link, so the never-set `friend` stays omitted while the authored
+          // empty `friends` round-trips.
+          let response = await request
+            .post('/')
+            .send({
+              data: {
+                type: 'card',
+                attributes: {
+                  firstName: 'Hassan',
+                },
+                relationships: {
+                  friends: {
+                    links: {
+                      self: null,
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: rri('https://localhost:4202/node-test/friend'),
+                    name: 'Friend',
+                  },
+                },
+              },
+            } as LooseSingleCardDocument)
+            .set('Accept', 'application/vnd.card+json');
+
+          let incrementalEventContent = await expectIncrementalIndexEvent(
+            testRealmHref,
+            realmEventTimestampStart,
+            {
+              assert,
+              getMessagesSince,
+              realm: testRealmHref,
+              type: 'Friend',
+              timeout: 5000,
+            },
+          );
+          let id = incrementalEventContent.invalidations[0].split('/').pop()!;
+
+          assert.strictEqual(
+            response.status,
+            201,
+            `HTTP 201 status: ${response.text}`,
+          );
+
+          // The written source persists the card's relationships as authored:
+          // the explicitly-empty `friends` survives as `{ self: null }` while the
+          // never-authored `friend` is absent.
+          let cardFile = join(
+            dir.name,
+            'realm_server_1',
+            'test',
+            'Friend',
+            `${id}.json`,
+          );
+          assert.ok(existsSync(cardFile), `card json ${cardFile} exists`);
+          let source = readJSONSync(cardFile) as LooseSingleCardDocument;
+          assert.deepEqual(
+            source.data.relationships,
+            { friends: { links: { self: null } } },
+            'source keeps the explicitly-empty friends link and omits the absent friend link',
+          );
+
+          // The served card+json (the indexed pristine doc) keeps the same
+          // distinction: `friends` was authored empty, so it round-trips as
+          // `{ self: null }`; `friend` was never set, so it is omitted.
+          let getResponse = await request
+            .get(`/Friend/${id}`)
+            .set('Accept', 'application/vnd.card+json');
+          assert.strictEqual(
+            getResponse.status,
+            200,
+            `HTTP 200 status: ${getResponse.text}`,
+          );
+          let served = getResponse.body as SingleCardDocument;
+          assert.deepEqual(
+            served.data.relationships?.friends,
+            { links: { self: null } },
+            'served card+json preserves the explicitly-empty friends link',
+          );
+          assert.strictEqual(
+            served.data.relationships?.friend,
+            undefined,
+            'served card+json omits the absent friend link',
+          );
+        });
+
         test('creates card instances when it encounters "lid" in the request', async function (assert) {
           let response = await request
             .post('/')


### PR DESCRIPTION
Stacked on #5399.

## What

A `linksToMany` field has two distinct authored states a card+json consumer could not tell apart:

- **never set** — the author never specified the plural link.
- **explicitly empty** — the author set it to nothing (`{ links: { self: null } }` / `{ data: [] }`), a deliberate "this points to nothing."

The written source already preserves that distinction; the served card+json (the index pristine doc and the re-serialization a POST/PATCH returns) did not — both an authored empty and a never-set plural link collapsed to "not had" and were omitted. #5399 resolved this for `linksTo`; this change does the same for `linksToMany`, so the two states round-trip with the same fidelity, independent of searchability.

## Why it needed a marker

`linksTo` can key the distinction on bucket state alone: its getter no longer persists a nullish empty on read, so key-absent = never set and `null` = authored empty. `linksToMany` can't — its getter must persist a (mutable) backing array on read for reactivity, so a never-set plural link merely rendered fabricates an empty array in the data bucket. An empty array is therefore ambiguous.

`LinksToMany.deserialize` disambiguates by tagging the empty arrays it produces from an authored-empty relationship (`markAuthoredEmptyLink`). `isFieldUsed` then keeps a tagged empty and drops an untagged (render-fabricated) one. An untagged empty stays omitted, which keeps the safe default: never-set links stay off the wire. The tag is re-established at every deserialize, so it survives each serialize→wire→deserialize hop (indexing, prerender).

## Tests

- `card-endpoints-test`: a new case authors `friends` (linksToMany) empty and leaves `friend` (linksTo) absent, asserting the empty round-trips as `{ self: null }` in both the written source and the served card+json while the never-set link is omitted — the plural mirror of the existing `linksTo` case.
- `realm-test`: the "remove all items from a linksToMany via PATCH" case now expects the emptied `pets` preserved as `{ self: null }` rather than omitted.

Validated locally against the full realm-server + prerender + index stack: `card-endpoints-test` (57 pass) plus `indexing-test` / `realm-endpoints-test` / `card-source-endpoints-test` (138 pass).

Resolves [CS-11779](https://linear.app/cardstack/issue/CS-11779/preserve-an-authored-empty-null-link-distinctly-from-a-never-set-link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
