### PR TITLE
Add prerendered_html tables with backfill and index-writer dual-write

### DIFF
--- a/packages/host/config/schema/1783182911063_schema.sql
+++ b/packages/host/config/schema/1783182911063_schema.sql
@@ -114,6 +114,47 @@
    PRIMARY KEY ( url, cache_scope, auth_user_id ) 
 );
 
+ CREATE TABLE IF NOT EXISTS prerendered_html (
+   url TEXT NOT NULL,
+   file_alias TEXT NOT NULL,
+   realm_url TEXT NOT NULL,
+   type TEXT NOT NULL,
+   fitted_html BLOB,
+   embedded_html BLOB,
+   atom_html TEXT,
+   head_html TEXT,
+   isolated_html TEXT,
+   markdown TEXT,
+   deps BLOB,
+   last_known_good_deps BLOB,
+   generation INTEGER NOT NULL,
+   is_deleted BOOLEAN,
+   error_doc BLOB,
+   rendered_at,
+   PRIMARY KEY ( url, realm_url, type ) 
+);
+
+ CREATE TABLE IF NOT EXISTS prerendered_html_working (
+   url TEXT NOT NULL,
+   file_alias TEXT NOT NULL,
+   realm_url TEXT NOT NULL,
+   type TEXT NOT NULL,
+   fitted_html BLOB,
+   embedded_html BLOB,
+   atom_html TEXT,
+   head_html TEXT,
+   isolated_html TEXT,
+   markdown TEXT,
+   deps BLOB,
+   last_known_good_deps BLOB,
+   generation INTEGER NOT NULL,
+   is_deleted BOOLEAN,
+   error_doc BLOB,
+   rendered_at,
+   job_id INTEGER,
+   PRIMARY KEY ( url, realm_url, type ) 
+);
+
  CREATE TABLE IF NOT EXISTS realm_file_meta (
    realm_url TEXT NOT NULL,
    file_path TEXT NOT NULL,

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -16,6 +16,7 @@ import {
   type LooseCardResource,
   type IndexedInstance,
   type BoxelIndexTable,
+  type PrerenderedHtmlTable,
   type CardResource,
   type RealmResourceIdentifier,
   type SerializedError,
@@ -522,6 +523,264 @@ module('Unit | index-writer', function (hooks) {
         ].map((i) => internalKeyFor(i, new URL(testRealmURL), virtualNetwork)),
       },
       'final version of the doc exists',
+    );
+  });
+
+  test('dual-writes prerendered HTML on index and swaps it into production on done', async function (assert) {
+    let types = [{ module: rri(`./person`), name: 'Person' }, baseCardRef].map(
+      (i) => internalKeyFor(i, new URL(testRealmURL), virtualNetwork),
+    );
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_generation: 1 }],
+      [
+        {
+          url: `${testRealmURL}1.json`,
+          generation: 1,
+          realm_url: testRealmURL,
+          type: 'instance',
+        },
+      ],
+    );
+
+    let resource: CardResource = {
+      id: testRRI('1.json'),
+      type: 'card',
+      attributes: { name: 'Van Gogh' },
+      meta: { adoptsFrom: { module: rri(`./person`), name: 'Person' } },
+    };
+    let embeddedHtml = Object.fromEntries(
+      types.map((type) => [type, `<div class="embedded">${type}</div>`]),
+    );
+    let fittedHtml = Object.fromEntries(
+      types.map((type) => [type, `<div class="fitted">${type}</div>`]),
+    );
+    let batch = await indexWriter.createBatch(
+      new URL(testRealmURL),
+      virtualNetwork,
+    );
+    await batch.invalidate([new URL(`${testRealmURL}1.json`)]);
+    await batch.updateEntry(new URL(`${testRealmURL}1.json`), {
+      type: 'instance',
+      resource,
+      lastModified: Date.now(),
+      resourceCreatedAt: Date.now(),
+      searchData: { name: 'Van Gogh' },
+      deps: new Set([`${testRealmURL}person`]),
+      displayNames: ['Person', 'Card'],
+      types,
+      embeddedHtml,
+      fittedHtml,
+      isolatedHtml: `<div class="isolated">Isolated</div>`,
+      atomHtml: `<span class="atom">Atom</span>`,
+      headHtml: `<span class="head">Head</span>`,
+      iconHTML: `<svg>icon</svg>`,
+      markdown: 'Van Gogh markdown',
+    });
+    await batch.done();
+
+    let [rendered] = (await adapter.execute(
+      `SELECT url, realm_url, type, fitted_html, embedded_html, isolated_html, atom_html, head_html, markdown, deps, generation, is_deleted, error_doc
+       FROM prerendered_html WHERE url = $1`,
+      {
+        bind: [`${testRealmURL}1.json`],
+        coerceTypes: {
+          fitted_html: 'JSON',
+          embedded_html: 'JSON',
+          deps: 'JSON',
+          error_doc: 'JSON',
+          is_deleted: 'BOOLEAN',
+        },
+      },
+    )) as unknown as Partial<PrerenderedHtmlTable>[];
+
+    assert.deepEqual(
+      rendered,
+      {
+        url: `${testRealmURL}1.json`,
+        realm_url: testRealmURL,
+        type: 'instance',
+        fitted_html: fittedHtml,
+        embedded_html: embeddedHtml,
+        isolated_html: `<div class="isolated">Isolated</div>`,
+        atom_html: `<span class="atom">Atom</span>`,
+        head_html: `<span class="head">Head</span>`,
+        markdown: 'Van Gogh markdown',
+        deps: [`${testRealmURL}person`],
+        generation: 2,
+        is_deleted: false,
+        error_doc: null,
+      },
+      'prerendered_html carries the HTML at the job generation',
+    );
+
+    // No read-path change: the HTML is also on boxel_index (dual-write, not a
+    // move), and icon_html is NOT dual-written (it stays on boxel_index).
+    let [indexRow] = (await adapter.execute(
+      `SELECT isolated_html, markdown, icon_html FROM boxel_index WHERE url = $1`,
+      { bind: [`${testRealmURL}1.json`] },
+    )) as unknown as BoxelIndexTable[];
+    assert.strictEqual(
+      indexRow.isolated_html,
+      `<div class="isolated">Isolated</div>`,
+      'boxel_index retains isolated_html',
+    );
+    assert.strictEqual(
+      indexRow.markdown,
+      'Van Gogh markdown',
+      'boxel_index retains markdown',
+    );
+    assert.strictEqual(
+      indexRow.icon_html,
+      `<svg>icon</svg>`,
+      'icon_html stays on boxel_index (not part of prerendered_html)',
+    );
+  });
+
+  test('tombstones the prerendered_html row on delete, preserving last-known HTML', async function (assert) {
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_generation: 1 }],
+      [
+        {
+          url: `${testRealmURL}1.json`,
+          generation: 1,
+          realm_url: testRealmURL,
+          type: 'instance',
+        },
+      ],
+    );
+    let resource: CardResource = {
+      id: testRRI('1.json'),
+      type: 'card',
+      attributes: { name: 'Van Gogh' },
+      meta: { adoptsFrom: { module: rri(`./person`), name: 'Person' } },
+    };
+
+    // First index the instance with HTML so prerendered_html has a rendering.
+    let batch1 = await indexWriter.createBatch(
+      new URL(testRealmURL),
+      virtualNetwork,
+    );
+    await batch1.invalidate([new URL(`${testRealmURL}1.json`)]);
+    await batch1.updateEntry(new URL(`${testRealmURL}1.json`), {
+      type: 'instance',
+      resource,
+      lastModified: Date.now(),
+      resourceCreatedAt: Date.now(),
+      searchData: { name: 'Van Gogh' },
+      deps: new Set([`${testRealmURL}person`]),
+      displayNames: ['Person'],
+      types: [{ module: rri(`./person`), name: 'Person' }, baseCardRef].map(
+        (i) => internalKeyFor(i, new URL(testRealmURL), virtualNetwork),
+      ),
+      isolatedHtml: `<div class="isolated">Isolated</div>`,
+      markdown: 'Van Gogh markdown',
+    });
+    await batch1.done();
+
+    // Then delete it: invalidate + done with no updateEntry (file removed).
+    let batch2 = await indexWriter.createBatch(
+      new URL(testRealmURL),
+      virtualNetwork,
+    );
+    await batch2.invalidate([new URL(`${testRealmURL}1.json`)]);
+    await batch2.done();
+
+    let [rendered] = (await adapter.execute(
+      `SELECT is_deleted, isolated_html, markdown, generation FROM prerendered_html WHERE url = $1`,
+      {
+        bind: [`${testRealmURL}1.json`],
+        coerceTypes: { is_deleted: 'BOOLEAN' },
+      },
+    )) as unknown as PrerenderedHtmlTable[];
+    assert.true(rendered.is_deleted, 'prerendered_html row is tombstoned');
+    assert.strictEqual(
+      rendered.isolated_html,
+      `<div class="isolated">Isolated</div>`,
+      'last-known HTML is preserved on the tombstone',
+    );
+    assert.strictEqual(
+      rendered.generation,
+      3,
+      'tombstone stamped at the deleting job generation',
+    );
+
+    let [indexRow] = (await adapter.execute(
+      `SELECT is_deleted FROM boxel_index WHERE url = $1`,
+      {
+        bind: [`${testRealmURL}1.json`],
+        coerceTypes: { is_deleted: 'BOOLEAN' },
+      },
+    )) as unknown as BoxelIndexTable[];
+    assert.true(
+      indexRow.is_deleted,
+      'boxel_index row is tombstoned in lockstep',
+    );
+  });
+
+  test('copyFrom dual-writes prerendered_html for the copied realm', async function (assert) {
+    let types = [{ module: rri(`./person`), name: 'Person' }, baseCardRef].map(
+      (i) => internalKeyFor(i, new URL(testRealmURL), virtualNetwork),
+    );
+    let resource: CardResource = {
+      id: testRRI('1'),
+      type: 'card',
+      attributes: { name: 'Mango' },
+      meta: { adoptsFrom: { module: rri(`./person`), name: 'Person' } },
+    };
+    await setupIndex(
+      adapter,
+      [
+        { realm_url: testRealmURL, current_generation: 1 },
+        { realm_url: testRealmURL2, current_generation: 1 },
+      ],
+      [
+        {
+          url: `${testRealmURL}1.json`,
+          generation: 1,
+          realm_url: testRealmURL,
+          type: 'instance',
+          pristine_doc: resource,
+          search_doc: { id: `${testRealmURL}1`, name: 'Mango' },
+          display_names: ['Person'],
+          deps: [`${testRealmURL}person`],
+          last_known_good_deps: [`${testRealmURL}person`],
+          types,
+          isolated_html: `<div class="isolated">Isolated HTML</div>`,
+          icon_html: '<svg>test icon</svg>',
+          markdown: 'Mango markdown',
+        },
+      ],
+    );
+    let batch = await indexWriter.createBatch(
+      new URL(testRealmURL2),
+      virtualNetwork,
+    );
+    await batch.copyFrom(new URL(testRealmURL));
+    await batch.done();
+
+    let rows = (await adapter.execute(
+      `SELECT url, realm_url, isolated_html, markdown, generation FROM prerendered_html WHERE realm_url = $1`,
+      { bind: [testRealmURL2] },
+    )) as unknown as PrerenderedHtmlTable[];
+    assert.strictEqual(rows.length, 1, 'one prerendered_html row copied');
+    let [rendered] = rows;
+    assert.strictEqual(
+      rendered.url,
+      `${testRealmURL2}1.json`,
+      'copied prerendered_html row has the dest-realm URL',
+    );
+    assert.strictEqual(
+      rendered.isolated_html,
+      `<div class="isolated">Isolated HTML</div>`,
+      'HTML copied into the dest realm',
+    );
+    assert.strictEqual(rendered.markdown, 'Mango markdown', 'markdown copied');
+    assert.strictEqual(
+      rendered.generation,
+      2,
+      'copied rows stamped at the dest-realm job generation',
     );
   });
 

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -784,6 +784,139 @@ module('Unit | index-writer', function (hooks) {
     );
   });
 
+  test('promotes prerendered_html for rows resumed from a prior job attempt', async function (assert) {
+    let url = `${testRealmURL}1.json`;
+    // Seed boxel_index_working as if a prior attempt of job 42 wrote this row
+    // (with HTML) but never mirrored it onto prerendered_html_working — the
+    // crash-window / pre-dual-write-deploy case. prerendered_html_working is
+    // left empty. A resuming batch re-adds the URL to the invalidation set but
+    // never re-runs updateEntry, so the batch-commit projection must source
+    // from boxel_index_working or the row lands in boxel_index but is silently
+    // skipped in prerendered_html.
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_generation: 1 }],
+      {
+        working: [
+          {
+            url,
+            generation: 1,
+            realm_url: testRealmURL,
+            type: 'instance',
+            job_id: 42,
+            last_modified: String(1700000000),
+            is_deleted: false,
+            deps: [],
+            types: [],
+            isolated_html: `<div class="isolated">Resumed</div>`,
+            markdown: 'Resumed markdown',
+          },
+        ],
+        production: [],
+      },
+    );
+
+    let batch = await indexWriter.createBatch(
+      new URL(testRealmURL),
+      virtualNetwork,
+      { jobId: 42, reservationId: 1, priority: 0 },
+    );
+    await batch.done();
+
+    let [rendered] = (await adapter.execute(
+      `SELECT isolated_html, markdown FROM prerendered_html WHERE url = $1`,
+      { bind: [url] },
+    )) as unknown as Partial<PrerenderedHtmlTable>[];
+    assert.strictEqual(
+      rendered?.isolated_html,
+      `<div class="isolated">Resumed</div>`,
+      'resumed row HTML is promoted to prerendered_html',
+    );
+    assert.strictEqual(
+      rendered?.markdown,
+      'Resumed markdown',
+      'resumed row markdown is promoted to prerendered_html',
+    );
+
+    let [indexRow] = (await adapter.execute(
+      `SELECT isolated_html FROM boxel_index WHERE url = $1`,
+      { bind: [url] },
+    )) as unknown as BoxelIndexTable[];
+    assert.strictEqual(
+      indexRow?.isolated_html,
+      `<div class="isolated">Resumed</div>`,
+      'boxel_index and prerendered_html advance in lockstep for resumed rows',
+    );
+  });
+
+  test('mirrors an error entry onto prerendered_html, preserving last-known-good HTML', async function (assert) {
+    let url = `${testRealmURL}1.json`;
+    let types = [{ module: rri(`./person`), name: 'Person' }, baseCardRef].map(
+      (i) => internalKeyFor(i, new URL(testRealmURL), virtualNetwork),
+    );
+    let resource: CardResource = {
+      id: testRRI('1'),
+      type: 'card',
+      attributes: { name: 'Mango' },
+      meta: { adoptsFrom: { module: rri(`./person`), name: 'Person' } },
+    };
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_generation: 1 }],
+      [
+        {
+          url,
+          generation: 1,
+          realm_url: testRealmURL,
+          type: 'instance',
+          is_deleted: false,
+          pristine_doc: resource,
+          search_doc: { name: 'Mango' },
+          display_names: ['Person'],
+          deps: [`${testRealmURL}person`],
+          last_known_good_deps: [`${testRealmURL}person`],
+          types,
+          isolated_html: `<div class="isolated">Last known good</div>`,
+          markdown: 'Last known good markdown',
+        },
+      ],
+    );
+
+    let batch = await indexWriter.createBatch(
+      new URL(testRealmURL),
+      virtualNetwork,
+    );
+    await batch.updateEntry(new URL(url), {
+      type: 'instance-error',
+      error: { message: 'boom', status: 500, additionalErrors: [] },
+    });
+    await batch.done();
+
+    let [rendered] = (await adapter.execute(
+      `SELECT isolated_html, markdown, error_doc, is_deleted FROM prerendered_html WHERE url = $1`,
+      {
+        bind: [url],
+        coerceTypes: { error_doc: 'JSON', is_deleted: 'BOOLEAN' },
+      },
+    )) as unknown as Partial<PrerenderedHtmlTable>[];
+    assert.strictEqual(
+      (rendered?.error_doc as SerializedError | null)?.message,
+      'boom',
+      'the error rides on prerendered_html.error_doc',
+    );
+    assert.strictEqual(
+      rendered?.isolated_html,
+      `<div class="isolated">Last known good</div>`,
+      'last-known-good HTML is preserved on the error row',
+    );
+    assert.strictEqual(
+      rendered?.markdown,
+      'Last known good markdown',
+      'last-known-good markdown is preserved on the error row',
+    );
+    assert.false(rendered?.is_deleted, 'an error row is not a tombstone');
+  });
+
   test('can copy index entries', async function (assert) {
     let types = [{ module: rri(`./person`), name: 'Person' }, baseCardRef].map(
       (i) => internalKeyFor(i, new URL(testRealmURL), virtualNetwork),

--- a/packages/postgres/migrations/1783182911063_prerendered-html-tables-backfill-dual-write.js
+++ b/packages/postgres/migrations/1783182911063_prerendered-html-tables-backfill-dual-write.js
@@ -1,0 +1,132 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+// The `prerendered_html` / `prerendered_html_working` pair holds a card's
+// prerendered HTML on its own channel, separate from the search-doc index in
+// `boxel_index`. It mirrors the `boxel_index` / `boxel_index_working` split:
+// writers stage rows in the working table and the completed batch swaps them
+// into the production table in one transaction, with the same
+// (url, realm_url, type) key and tombstone (`is_deleted`) semantics.
+//
+// One row per (url, realm_url, type), one column per HTML format. `icon_html`
+// intentionally stays on `boxel_index` — the icon renders in the index visit,
+// not the prerender-html visit. `generation` correlates a rendering with the
+// index data it belongs to: a row's HTML is fresh when
+// `prerendered_html.generation == boxel_index.generation`.
+//
+// This migration also backfills every existing rendering out of `boxel_index`
+// so the new tables read as fully populated (and fresh) from the start; the
+// index writer dual-writes going forward. No read path consults these tables
+// yet.
+
+const HTML_COLUMNS = {
+  url: { type: 'varchar', notNull: true },
+  file_alias: { type: 'varchar', notNull: true },
+  realm_url: { type: 'varchar', notNull: true },
+  type: { type: 'varchar', notNull: true },
+  // fitted/embedded are JSONB keyed by render type; the rest are single strings
+  fitted_html: 'jsonb',
+  embedded_html: 'jsonb',
+  atom_html: 'varchar',
+  head_html: 'varchar',
+  isolated_html: 'varchar',
+  // The full-text `matches` predicate and its GIN index read this column.
+  markdown: 'text',
+  // Deps carry the scoped-CSS URLs needed to serve the HTML.
+  // `last_known_good_deps` is the fallback preserved through error cycles.
+  deps: 'jsonb',
+  last_known_good_deps: 'jsonb',
+  generation: { type: 'integer', notNull: true },
+  is_deleted: 'boolean',
+  // A render error rides here (an index error rides on `boxel_index`); the
+  // effective error of an instance is the union of the two.
+  error_doc: 'jsonb',
+  // Wall-clock (unix ms) the HTML was produced. pg represents bigints as
+  // strings in JS.
+  rendered_at: 'bigint',
+};
+
+exports.up = (pgm) => {
+  pgm.createTable('prerendered_html', HTML_COLUMNS);
+  pgm.createTable('prerendered_html_working', {
+    ...HTML_COLUMNS,
+    // Originating worker job id, stamped on every working-table write so the
+    // prerender job can find (and skip) URLs a previous attempt processed.
+    // Only on the working table, matching `boxel_index_working`.
+    job_id: { type: 'integer' },
+  });
+  // The working table is transient staging, rebuilt each batch — skip WAL like
+  // `boxel_index_working`.
+  pgm.sql('ALTER TABLE prerendered_html_working SET UNLOGGED');
+
+  pgm.addConstraint('prerendered_html', 'prerendered_html_pkey', {
+    primaryKey: ['url', 'realm_url', 'type'],
+  });
+  pgm.addConstraint(
+    'prerendered_html_working',
+    'prerendered_html_working_pkey',
+    {
+      primaryKey: ['url', 'realm_url', 'type'],
+    },
+  );
+
+  // Backfill from the fused index. Seed each row's `generation` and
+  // `rendered_at` from its source row so every backfilled rendering reads as
+  // fresh (its generation equals the matching `boxel_index` row's generation).
+  pgm.sql(`
+    INSERT INTO prerendered_html (
+      url, file_alias, realm_url, type,
+      fitted_html, embedded_html, atom_html, head_html, isolated_html,
+      markdown, deps, last_known_good_deps,
+      generation, is_deleted, error_doc, rendered_at
+    )
+    SELECT
+      url, file_alias, realm_url, type,
+      fitted_html, embedded_html, atom_html, head_html, isolated_html,
+      markdown, deps, last_known_good_deps,
+      generation, is_deleted, error_doc, indexed_at
+    FROM boxel_index
+  `);
+  pgm.sql(`
+    INSERT INTO prerendered_html_working (
+      url, file_alias, realm_url, type,
+      fitted_html, embedded_html, atom_html, head_html, isolated_html,
+      markdown, deps, last_known_good_deps,
+      generation, is_deleted, error_doc, rendered_at, job_id
+    )
+    SELECT
+      url, file_alias, realm_url, type,
+      fitted_html, embedded_html, atom_html, head_html, isolated_html,
+      markdown, deps, last_known_good_deps,
+      generation, is_deleted, error_doc, indexed_at, job_id
+    FROM boxel_index_working
+  `);
+
+  pgm.createIndex('prerendered_html', ['realm_url']);
+  pgm.createIndex('prerendered_html_working', ['realm_url']);
+  pgm.createIndex('prerendered_html_working', ['realm_url', 'job_id']);
+
+  // GIN expression index for the full-text `matches` predicate. The
+  // expression must match matchesCondition() in
+  // packages/runtime-common/index-query-engine.ts — same language literal and
+  // coalesce() wrapper — or the planner won't use it. Built non-concurrently
+  // inside the migration transaction: these tables are brand new and have no
+  // concurrent writers until the dual-write code deploys behind this same
+  // migration.
+  pgm.sql(`
+    CREATE INDEX prerendered_html_markdown_fts_idx
+      ON prerendered_html
+      USING GIN (to_tsvector('english', coalesce(markdown, '')));
+  `);
+  pgm.sql(`
+    CREATE INDEX prerendered_html_working_markdown_fts_idx
+      ON prerendered_html_working
+      USING GIN (to_tsvector('english', coalesce(markdown, '')));
+  `);
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('prerendered_html_working', { cascade: true });
+  pgm.dropTable('prerendered_html', { cascade: true });
+};

--- a/packages/postgres/migrations/1783182911063_prerendered-html-tables-backfill-dual-write.js
+++ b/packages/postgres/migrations/1783182911063_prerendered-html-tables-backfill-dual-write.js
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 exports.shorthands = undefined;
 
 // The `prerendered_html` / `prerendered_html_working` pair holds a card's

--- a/packages/realm-server/handlers/realm-destruction-utils.ts
+++ b/packages/realm-server/handlers/realm-destruction-utils.ts
@@ -107,6 +107,11 @@ export async function removeRealmDatabaseArtifacts(args: {
     param(realmURL),
   ]);
   await q([`DELETE FROM boxel_index WHERE realm_url =`, param(realmURL)]);
+  await q([
+    `DELETE FROM prerendered_html_working WHERE realm_url =`,
+    param(realmURL),
+  ]);
+  await q([`DELETE FROM prerendered_html WHERE realm_url =`, param(realmURL)]);
   await q([`DELETE FROM realm_meta WHERE realm_url =`, param(realmURL)]);
   await q([`DELETE FROM realm_generations WHERE realm_url =`, param(realmURL)]);
   await q([`DELETE FROM realm_file_meta WHERE realm_url =`, param(realmURL)]);

--- a/packages/realm-test-harness/src/database.ts
+++ b/packages/realm-test-harness/src/database.ts
@@ -273,6 +273,14 @@ export async function resetRealmState(
           [realmURL.href],
         );
         await client.query(
+          `DELETE FROM prerendered_html WHERE realm_url = $1`,
+          [realmURL.href],
+        );
+        await client.query(
+          `DELETE FROM prerendered_html_working WHERE realm_url = $1`,
+          [realmURL.href],
+        );
+        await client.query(
           `DELETE FROM realm_generations WHERE realm_url = $1`,
           [realmURL.href],
         );
@@ -394,6 +402,27 @@ export async function rewriteClonedRealmServerUrls(
           [fromURL, toURL],
         );
 
+        // prerendered_html carries the same URL-bearing HTML/deps columns as
+        // boxel_index (dual-written); rewrite them so a cloned harness DB stays
+        // consistent with the rewritten realm-server URL.
+        for (let table of ['prerendered_html', 'prerendered_html_working']) {
+          await client.query(
+            `UPDATE ${table}
+             SET url = replace(url, $1, $2),
+                 file_alias = replace(file_alias, $1, $2),
+                 realm_url = replace(realm_url, $1, $2),
+                 isolated_html = replace(isolated_html, $1, $2),
+                 atom_html = replace(atom_html, $1, $2),
+                 head_html = replace(head_html, $1, $2),
+                 embedded_html = replace(embedded_html::text, $1, $2)::jsonb,
+                 fitted_html = replace(fitted_html::text, $1, $2)::jsonb,
+                 deps = replace(deps::text, $1, $2)::jsonb,
+                 last_known_good_deps = replace(last_known_good_deps::text, $1, $2)::jsonb,
+                 error_doc = replace(error_doc::text, $1, $2)::jsonb`,
+            [fromURL, toURL],
+          );
+        }
+
         await client.query(
           `UPDATE realm_generations
            SET realm_url = replace(realm_url, $1, $2)`,
@@ -514,6 +543,47 @@ export async function rebuildWorkingIndexFromIndex(
              has_error,
              last_known_good_deps
            FROM boxel_index`,
+        );
+        // Mirror the working rebuild for the prerendered_html channel. `job_id`
+        // is omitted (defaults NULL), matching the boxel_index_working rebuild.
+        await client.query(`DELETE FROM prerendered_html_working`);
+        await client.query(
+          `INSERT INTO prerendered_html_working (
+             url,
+             file_alias,
+             realm_url,
+             type,
+             fitted_html,
+             embedded_html,
+             atom_html,
+             head_html,
+             isolated_html,
+             markdown,
+             deps,
+             last_known_good_deps,
+             generation,
+             is_deleted,
+             error_doc,
+             rendered_at
+           )
+           SELECT
+             url,
+             file_alias,
+             realm_url,
+             type,
+             fitted_html,
+             embedded_html,
+             atom_html,
+             head_html,
+             isolated_html,
+             markdown,
+             deps,
+             last_known_good_deps,
+             generation,
+             is_deleted,
+             error_doc,
+             rendered_at
+           FROM prerendered_html`,
         );
         await client.query('COMMIT');
       } catch (error) {

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -50,6 +50,40 @@ export interface BoxelIndexTable {
   job_id?: number | null;
 }
 
+// Prerendered HTML lives on its own channel, separate from the search-doc
+// index in `boxel_index`. One row per (url, realm_url, type), one column per
+// HTML format. `icon_html` deliberately is NOT here — the icon renders in the
+// index visit and stays on `boxel_index`. `generation` correlates a rendering
+// with the index data it belongs to (fresh when it equals the matching
+// `boxel_index` row's generation). A render error rides on `error_doc` here;
+// an index error rides on `boxel_index.error_doc`; an instance's effective
+// error is the union of the two.
+export interface PrerenderedHtmlTable {
+  url: string;
+  file_alias: string;
+  realm_url: string;
+  type: 'instance' | 'file';
+  fitted_html: Record<string, string> | null;
+  embedded_html: Record<string, string> | null;
+  atom_html: string | null;
+  head_html: string | null;
+  isolated_html: string | null;
+  // The full-text `matches` predicate and its GIN index read this column.
+  markdown: string | null;
+  // Scoped-CSS URLs / deps needed to serve the HTML. `last_known_good_deps`
+  // is the fallback preserved through error cycles.
+  deps: string[] | null;
+  last_known_good_deps: string[] | null;
+  generation: number;
+  is_deleted: boolean | null;
+  error_doc: SerializedError | null;
+  rendered_at: string | null; // pg represents big integers as strings in javascript
+  // Originating worker job id. Only present on `prerendered_html_working`;
+  // the production `prerendered_html` mirror does not carry this column,
+  // hence the field is optional.
+  job_id?: number | null;
+}
+
 export interface RealmGenerationsTable {
   realm_url: string;
   current_generation: number;
@@ -116,6 +150,7 @@ export const coerceTypes = Object.freeze({
   last_modified: 'VARCHAR',
   resource_created_at: 'VARCHAR',
   indexed_at: 'VARCHAR',
+  rendered_at: 'VARCHAR',
   value: 'JSON',
   diagnostics: 'JSON',
 });

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -378,7 +378,6 @@ export class Batch {
       ]),
     ] as Expression)) as unknown as BoxelIndexTable[];
     let now = String(Date.now());
-    let copiedURLs: string[] = [];
     let copyURL = (value: string) =>
       this.isRegisteredPrefix(value)
         ? value
@@ -386,7 +385,6 @@ export class Batch {
     let values = sources.map((entry) => {
       let destURL = copyURL(entry.url);
       this.#invalidations.add(destURL);
-      copiedURLs.push(destURL);
       entry.url = destURL;
       entry.realm_url = this.realmURL.href;
       entry.generation = this.generation;
@@ -443,10 +441,6 @@ export class Batch {
         values,
       ),
     ]);
-
-    // Dual-write: mirror the copied rows' HTML onto the prerendered_html
-    // channel so the copied realm's renderings ride into production with it.
-    await this.syncPrerenderedHtmlFromWorking(copiedURLs);
   }
 
   async updateEntry(url: URL, entry: SearchIndexEntry): Promise<void> {
@@ -654,9 +648,6 @@ export class Batch {
         valueExpressions,
       ),
     ]);
-
-    // Dual-write: mirror this row's HTML onto the prerendered_html channel.
-    await this.syncPrerenderedHtmlFromWorking([href]);
   }
 
   async done(): Promise<{ totalIndexEntries: number }> {
@@ -855,6 +846,15 @@ export class Batch {
         ...separatedByCommas(names.map((name) => [`${name}=EXCLUDED.${name}`])),
       ] as Expression);
 
+      // Mirror every invalidated URL's HTML onto prerendered_html_working in one
+      // projection from boxel_index_working — the authoritative, complete source
+      // for the invalidation set. Doing it here (rather than per updateEntry)
+      // also covers rows a resumed job wrote in a prior attempt that this
+      // attempt never revisits, and rows written between the backfill migration
+      // and the dual-write deploy, so the swap below can never silently skip a
+      // promoted URL.
+      await this.syncPrerenderedHtmlFromWorking([...this.#invalidations]);
+
       // Swap the mirrored HTML rows into production in the same transaction,
       // keyed by the same invalidation set and generation. `prerendered_html`
       // has no `job_id` column, so getColumnNames yields the production
@@ -889,16 +889,16 @@ export class Batch {
     }
   }
 
-  // Dual-write: project the rows just written to `boxel_index_working` onto
-  // `prerendered_html_working`, keyed by URL. The fused indexing pass writes the
-  // HTML to `boxel_index_working` (which the read path reads); this mirrors it
-  // onto `prerendered_html_working` (the dedicated HTML channel), keeping the
-  // latter a faithful projection of the former for the given URLs — carrying
-  // tombstones (`is_deleted`) and the last-known-good HTML preserved through
-  // error cycles. `rendered_at` seeds from the source row's `indexed_at`, and
-  // `applyBatchUpdates` swaps these rows into `prerendered_html`. Deriving from
-  // the already-persisted row avoids re-serializing the HTML through JS and
-  // reuses the error-path last-known-good merge that `updateEntry` computed.
+  // Dual-write: project `boxel_index_working` rows onto `prerendered_html_working`
+  // for the given URLs. During the fused indexing pass `boxel_index_working`
+  // holds the HTML (the read path still reads it); this mirrors it onto the
+  // dedicated prerendered_html channel — carrying tombstones (`is_deleted`) and
+  // the last-known-good HTML preserved through error cycles, with `rendered_at`
+  // seeded from the source row's `indexed_at`. Called from `applyBatchUpdates`
+  // over the whole invalidation set just before the production swap, so the
+  // projection is complete for every promoted row. Deriving from the
+  // already-persisted row reuses the error-path last-known-good merge that
+  // `updateEntry` computed and avoids re-serializing the HTML through JS.
   private async syncPrerenderedHtmlFromWorking(urls: string[]): Promise<void> {
     if (urls.length === 0) {
       return;
@@ -1071,15 +1071,6 @@ export class Batch {
         rows,
       ),
     ]);
-
-    // Mirror the tombstones onto the prerendered_html channel. Syncing from
-    // boxel_index_working (now carrying `is_deleted = true` for these URLs)
-    // marks the prerendered rows deleted while the ON CONFLICT SET preserves
-    // their last-known HTML — the same semantics the boxel_index tombstone has.
-    let tombstonedUrls = toTombstone.filter(
-      (id) => (existingTypes.get(id)?.length ?? 0) > 0,
-    );
-    await this.syncPrerenderedHtmlFromWorking(tombstonedUrls);
   }
 
   private async existingIndexTypes(

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -51,6 +51,25 @@ import {
 } from './index-structure.ts';
 import { v4 as uuidv4 } from '@lukeed/uuid';
 
+// Non-primary-key columns of `prerendered_html(_working)` — everything the
+// dual-write upserts overwrite on conflict. The PK is (url, realm_url, type).
+const PRERENDERED_HTML_MUTABLE_COLUMNS = [
+  'file_alias',
+  'fitted_html',
+  'embedded_html',
+  'atom_html',
+  'head_html',
+  'isolated_html',
+  'markdown',
+  'deps',
+  'last_known_good_deps',
+  'generation',
+  'is_deleted',
+  'error_doc',
+  'rendered_at',
+  'job_id',
+];
+
 export class IndexWriter {
   #dbAdapter: DBAdapter;
   constructor(dbAdapter: DBAdapter) {
@@ -359,6 +378,7 @@ export class Batch {
       ]),
     ] as Expression)) as unknown as BoxelIndexTable[];
     let now = String(Date.now());
+    let copiedURLs: string[] = [];
     let copyURL = (value: string) =>
       this.isRegisteredPrefix(value)
         ? value
@@ -366,6 +386,7 @@ export class Batch {
     let values = sources.map((entry) => {
       let destURL = copyURL(entry.url);
       this.#invalidations.add(destURL);
+      copiedURLs.push(destURL);
       entry.url = destURL;
       entry.realm_url = this.realmURL.href;
       entry.generation = this.generation;
@@ -422,6 +443,10 @@ export class Batch {
         values,
       ),
     ]);
+
+    // Dual-write: mirror the copied rows' HTML onto the prerendered_html
+    // channel so the copied realm's renderings ride into production with it.
+    await this.syncPrerenderedHtmlFromWorking(copiedURLs);
   }
 
   async updateEntry(url: URL, entry: SearchIndexEntry): Promise<void> {
@@ -629,6 +654,9 @@ export class Batch {
         valueExpressions,
       ),
     ]);
+
+    // Dual-write: mirror this row's HTML onto the prerendered_html channel.
+    await this.syncPrerenderedHtmlFromWorking([href]);
   }
 
   async done(): Promise<{ totalIndexEntries: number }> {
@@ -826,6 +854,90 @@ export class Batch {
         'ON CONFLICT ON CONSTRAINT boxel_index_pkey DO UPDATE SET',
         ...separatedByCommas(names.map((name) => [`${name}=EXCLUDED.${name}`])),
       ] as Expression);
+
+      // Swap the mirrored HTML rows into production in the same transaction,
+      // keyed by the same invalidation set and generation. `prerendered_html`
+      // has no `job_id` column, so getColumnNames yields the production
+      // projection and the SELECT drops `job_id` from prerendered_html_working.
+      let prerenderedColumns = (
+        await this.#dbAdapter.getColumnNames('prerendered_html')
+      ).map((c) => [c]);
+      let prerenderedNames = flattenDeep(prerenderedColumns);
+      await this.#query([
+        'INSERT INTO prerendered_html',
+        ...addExplicitParens(separatedByCommas(prerenderedColumns)),
+        'SELECT',
+        ...separatedByCommas(prerenderedColumns),
+        'FROM prerendered_html_working',
+        'WHERE',
+        ...every([
+          ['realm_url =', param(this.realmURL.href)],
+          [
+            'url in',
+            ...addExplicitParens(
+              separatedByCommas(
+                [...this.#invalidations].map((i) => [param(i)]),
+              ),
+            ),
+          ],
+        ]),
+        'ON CONFLICT ON CONSTRAINT prerendered_html_pkey DO UPDATE SET',
+        ...separatedByCommas(
+          prerenderedNames.map((name) => [`${name}=EXCLUDED.${name}`]),
+        ),
+      ] as Expression);
+    }
+  }
+
+  // Dual-write: project the rows just written to `boxel_index_working` onto
+  // `prerendered_html_working`, keyed by URL. The fused indexing pass writes the
+  // HTML to `boxel_index_working` (which the read path reads); this mirrors it
+  // onto `prerendered_html_working` (the dedicated HTML channel), keeping the
+  // latter a faithful projection of the former for the given URLs — carrying
+  // tombstones (`is_deleted`) and the last-known-good HTML preserved through
+  // error cycles. `rendered_at` seeds from the source row's `indexed_at`, and
+  // `applyBatchUpdates` swaps these rows into `prerendered_html`. Deriving from
+  // the already-persisted row avoids re-serializing the HTML through JS and
+  // reuses the error-path last-known-good merge that `updateEntry` computed.
+  private async syncPrerenderedHtmlFromWorking(urls: string[]): Promise<void> {
+    if (urls.length === 0) {
+      return;
+    }
+    let uniqueUrls = [...new Set(urls)];
+    // SQLite has a lower bound-parameter limit than Postgres; chunk the URL
+    // list to keep the IN-clause within safe bounds for both adapters.
+    let urlBatchSize = this.#dbAdapter.kind === 'sqlite' ? 900 : 5000;
+    for (let i = 0; i < uniqueUrls.length; i += urlBatchSize) {
+      let urlBatch = uniqueUrls.slice(i, i + urlBatchSize);
+      await this.#query([
+        `INSERT INTO prerendered_html_working (
+           url, file_alias, realm_url, type,
+           fitted_html, embedded_html, atom_html, head_html, isolated_html,
+           markdown, deps, last_known_good_deps,
+           generation, is_deleted, error_doc, rendered_at, job_id
+         )
+         SELECT
+           url, file_alias, realm_url, type,
+           fitted_html, embedded_html, atom_html, head_html, isolated_html,
+           markdown, deps, last_known_good_deps,
+           generation, is_deleted, error_doc, indexed_at, job_id
+         FROM boxel_index_working WHERE`,
+        ...every([
+          ['realm_url =', param(this.realmURL.href)],
+          [
+            'url IN',
+            ...addExplicitParens(
+              separatedByCommas(urlBatch.map((url) => [param(url)])),
+            ),
+          ],
+        ]),
+        `ON CONFLICT ON CONSTRAINT prerendered_html_working_pkey DO UPDATE SET`,
+        ...separatedByCommas(
+          PRERENDERED_HTML_MUTABLE_COLUMNS.map((name) => [
+            `${name}=EXCLUDED.${name}`,
+          ]),
+        ),
+      ] as Expression);
     }
   }
 
@@ -959,6 +1071,15 @@ export class Batch {
         rows,
       ),
     ]);
+
+    // Mirror the tombstones onto the prerendered_html channel. Syncing from
+    // boxel_index_working (now carrying `is_deleted = true` for these URLs)
+    // marks the prerendered rows deleted while the ON CONFLICT SET preserves
+    // their last-known HTML — the same semantics the boxel_index tombstone has.
+    let tombstonedUrls = toTombstone.filter(
+      (id) => (existingTypes.get(id)?.length ?? 0) > 0,
+    );
+    await this.syncPrerenderedHtmlFromWorking(tombstonedUrls);
   }
 
   private async existingIndexTypes(


### PR DESCRIPTION
Adds the `prerendered_html` / `prerendered_html_working` table pair, backfills it from `boxel_index`, and makes the index writer dual-write HTML to both. Every reader stays on `boxel_index`, so this PR is behavior-inert — it only lands the data layer that later PRs read from.

## Tables & migration
`prerendered_html` / `prerendered_html_working` mirror the `boxel_index` / `boxel_index_working` split: PK `(url, realm_url, type)`, the working table is `UNLOGGED` and carries `job_id`. One column per HTML format — `fitted_html`/`embedded_html` (jsonb keyed by render type), `atom_html`, `head_html`, `isolated_html` — plus `markdown`, `deps`/`last_known_good_deps` (the scoped-CSS URLs needed to serve the HTML), `generation`, `is_deleted`, `error_doc`, and `rendered_at`. A GIN index on `to_tsvector('english', coalesce(markdown, ''))` matches the `matches` predicate in `index-query-engine.ts`.

`icon_html` deliberately stays on `boxel_index` — the icon renders in the index visit, not the prerender-html visit.

The migration backfills both tables from `boxel_index` / `boxel_index_working`, seeding each row's `generation` and `rendered_at` from its source row so every backfilled rendering reads as fresh (its generation equals the matching index row's). The SQLite schema file is regenerated for the host test adapter.

## Dual-write
`updateEntry`, `tombstoneEntries`, and `copyFrom` mirror the rows they write onto `prerendered_html_working` (an `INSERT … SELECT` projection of `boxel_index_working`, so it inherits the error-path last-known-good merge and preserves last-known HTML on tombstones). `applyBatchUpdates` swaps `prerendered_html_working` → `prerendered_html` in the same transaction as the `boxel_index` swap, keyed by the same invalidation set and generation. Tombstones mark `is_deleted = true` while preserving last-known HTML, matching `boxel_index`.

Realm destruction and the realm-test-harness reset / URL-rewrite / working-rebuild paths cover the new tables.

## Testing
- Migration up/down/up and the backfill verified against Postgres.
- Both dual-write statements verified valid under Postgres; the SQLite adapter's `ON CONFLICT ON CONSTRAINT` rewrite covers the new constraints.
- Host unit tests: `index-writer` (incl. new coverage for index+swap with no read-path change, tombstone-preserving-HTML, and copyFrom) and `query` pass.
