### PR TITLE
Serve HTML and full-text search from prerendered_html (dual-read)

### DIFF
--- a/packages/host/tests/unit/prerendered-html-dual-read-test.ts
+++ b/packages/host/tests/unit/prerendered-html-dual-read-test.ts
@@ -351,6 +351,31 @@ module('Unit | prerendered-html dual-read', function (hooks) {
     );
   });
 
+  test('a present prerendered_html row is authoritative for a null column (no boxel_index fallback)', async function (assert) {
+    await mirrorPrerenderedHtml(adapter, testRealmURL);
+    // Null the prerendered rendering while boxel_index still carries a value.
+    // A present prerendered_html row is authoritative, so the read reports the
+    // absence rather than leaking the stale boxel_index column — otherwise a row
+    // could drop out of full-text search yet still serve stale markdown/HTML.
+    await adapter.execute(
+      `UPDATE prerendered_html SET markdown = NULL, isolated_html = NULL WHERE url = $1`,
+      { bind: [`${testRealmURL}1.json`] },
+    );
+    let entry = (await indexQueryEngine.getInstance(
+      new URL(`${testRealmURL}1`),
+    )) as IndexedInstance;
+    assert.strictEqual(
+      entry.markdown,
+      null,
+      'a present-but-null prerendered markdown reads as absent, not the boxel_index value',
+    );
+    assert.strictEqual(
+      entry.isolatedHtml,
+      null,
+      'a present-but-null prerendered isolated_html reads as absent',
+    );
+  });
+
   test('FTS matches reads prerendered_html.markdown with a boxel_index fallback', async function (assert) {
     await mirrorPrerenderedHtml(adapter, testRealmURL);
 

--- a/packages/host/tests/unit/prerendered-html-dual-read-test.ts
+++ b/packages/host/tests/unit/prerendered-html-dual-read-test.ts
@@ -1,0 +1,419 @@
+import { type TestContext, getContext } from '@ember/test-helpers';
+
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import {
+  IndexQueryEngine,
+  internalKeyFor,
+  baseCardRef,
+  rri,
+  type CardResource,
+  type IndexedInstance,
+  type InstanceOrError,
+  type RealmResourceIdentifier,
+} from '@cardstack/runtime-common';
+import { CachingDefinitionLookup } from '@cardstack/runtime-common/definition-lookup';
+import { VirtualNetwork } from '@cardstack/runtime-common/virtual-network';
+
+import type SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
+import type LocalIndexer from '@cardstack/host/services/local-indexer';
+
+import {
+  getDbAdapter,
+  testRealmURL,
+  testRRI,
+  setupIndex,
+  makeRenderer,
+  createPrerenderAuth,
+} from '../helpers';
+
+const testRealmURLObject = new URL(testRealmURL);
+
+// Copy every boxel_index row for the realm into prerendered_html exactly as the
+// backfill migration does (rendered_at seeded from indexed_at), so a mirrored
+// row reads identically whether the dual-read serves it from prerendered_html
+// or from the boxel_index fallback.
+async function mirrorPrerenderedHtml(adapter: SQLiteAdapter, realmURL: string) {
+  await adapter.execute(
+    `INSERT INTO prerendered_html (
+       url, file_alias, realm_url, type,
+       fitted_html, embedded_html, atom_html, head_html, isolated_html,
+       markdown, deps, last_known_good_deps,
+       generation, is_deleted, error_doc, rendered_at
+     )
+     SELECT
+       url, file_alias, realm_url, type,
+       fitted_html, embedded_html, atom_html, head_html, isolated_html,
+       markdown, deps, last_known_good_deps,
+       generation, is_deleted, error_doc, indexed_at
+     FROM boxel_index WHERE realm_url = $1`,
+    { bind: [realmURL] },
+  );
+}
+
+const makeCardResource = (
+  id: string,
+  name: string,
+  adoptsFrom: { module: RealmResourceIdentifier; name: string },
+): CardResource => ({
+  id: testRRI(id),
+  type: 'card',
+  attributes: { name },
+  meta: { adoptsFrom },
+});
+
+module('Unit | prerendered-html dual-read', function (hooks) {
+  let adapter: SQLiteAdapter;
+  let indexQueryEngine: IndexQueryEngine;
+  let virtualNetwork: VirtualNetwork;
+  let personTypes: string[];
+  setupTest(hooks);
+
+  hooks.before(async function () {
+    adapter = await getDbAdapter();
+  });
+
+  hooks.beforeEach(async function () {
+    await adapter.reset();
+    let owner = (getContext() as TestContext).owner;
+    await makeRenderer();
+    let localIndexer = owner.lookup('service:local-indexer') as LocalIndexer;
+    virtualNetwork = new VirtualNetwork();
+
+    let definitionLookup = new CachingDefinitionLookup(
+      adapter,
+      localIndexer.prerenderer,
+      virtualNetwork,
+      createPrerenderAuth,
+    );
+    definitionLookup.registerRealm({
+      url: testRealmURL,
+      async getRealmOwnerUserId() {
+        return '@user1:localhost';
+      },
+      async visibility() {
+        return 'private';
+      },
+    });
+
+    indexQueryEngine = new IndexQueryEngine(
+      adapter,
+      definitionLookup,
+      virtualNetwork,
+    );
+
+    personTypes = [
+      { module: rri(`./person`), name: 'Person' },
+      baseCardRef,
+    ].map((t) => internalKeyFor(t, testRealmURLObject, virtualNetwork));
+
+    // Two instances + one file, each carrying every HTML format, markdown, and
+    // the scoped-CSS deps. A fourth instance carries no HTML at all — the row
+    // whose renderings never existed.
+    let fittedFor = (label: string) =>
+      Object.fromEntries(
+        personTypes.map((t) => [t, `<div class="fitted">${label} ${t}</div>`]),
+      );
+    let embeddedFor = (label: string) =>
+      Object.fromEntries(
+        personTypes.map((t) => [
+          t,
+          `<div class="embedded">${label} ${t}</div>`,
+        ]),
+      );
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_generation: 1 }],
+      [
+        {
+          url: `${testRealmURL}1.json`,
+          type: 'instance',
+          generation: 1,
+          realm_url: testRealmURL,
+          pristine_doc: makeCardResource('1', 'Van Gogh', {
+            module: rri(`./person`),
+            name: 'Person',
+          }),
+          search_doc: { name: 'Van Gogh' },
+          resource_created_at: String(1700000000000),
+          display_names: ['Person', 'Card'],
+          types: personTypes,
+          deps: [
+            `${testRealmURL}person`,
+            `${testRealmURL}Person.gts.abc.glimmer-scoped.css`,
+          ],
+          fitted_html: fittedFor('Van Gogh'),
+          embedded_html: embeddedFor('Van Gogh'),
+          atom_html: `<span class="atom">Van Gogh</span>`,
+          head_html: `<meta name="og:title" content="Van Gogh" />`,
+          isolated_html: `<div class="isolated">Van Gogh</div>`,
+          icon_html: `<svg>vg-icon</svg>`,
+          markdown: 'Van Gogh painted sunflowers',
+        },
+        {
+          url: `${testRealmURL}2.json`,
+          type: 'instance',
+          generation: 1,
+          realm_url: testRealmURL,
+          pristine_doc: makeCardResource('2', 'Mango', {
+            module: rri(`./person`),
+            name: 'Person',
+          }),
+          search_doc: { name: 'Mango' },
+          resource_created_at: String(1700000000000),
+          display_names: ['Person', 'Card'],
+          types: personTypes,
+          deps: [`${testRealmURL}person`],
+          fitted_html: fittedFor('Mango'),
+          embedded_html: embeddedFor('Mango'),
+          atom_html: `<span class="atom">Mango</span>`,
+          head_html: `<meta name="og:title" content="Mango" />`,
+          isolated_html: `<div class="isolated">Mango</div>`,
+          icon_html: `<svg>mango-icon</svg>`,
+          markdown: 'Mango is a sweet fruit',
+        },
+        {
+          // No HTML/markdown at all — a row whose renderings never existed.
+          url: `${testRealmURL}3.json`,
+          type: 'instance',
+          generation: 1,
+          realm_url: testRealmURL,
+          pristine_doc: makeCardResource('3', 'Empty', {
+            module: rri(`./person`),
+            name: 'Person',
+          }),
+          search_doc: { name: 'Empty' },
+          resource_created_at: String(1700000000000),
+          display_names: ['Person', 'Card'],
+          types: personTypes,
+          deps: [`${testRealmURL}person`],
+        },
+        {
+          url: `${testRealmURL}readme.md`,
+          type: 'file',
+          generation: 1,
+          realm_url: testRealmURL,
+          search_doc: { name: 'readme.md' },
+          display_names: ['File'],
+          types: personTypes,
+          deps: [`${testRealmURL}Readme.gts.def.glimmer-scoped.css`],
+          fitted_html: { [personTypes[0]]: `<div class="fitted">Readme</div>` },
+          embedded_html: {
+            [personTypes[0]]: `<div class="embedded">Readme</div>`,
+          },
+          atom_html: `<span class="atom">Readme</span>`,
+          head_html: `<meta name="og:title" content="Readme" />`,
+          isolated_html: `<div class="isolated">Readme</div>`,
+          icon_html: `<svg>file-icon</svg>`,
+          markdown: 'Readme markdown body',
+        },
+      ],
+    );
+  });
+
+  // A normalized, order-stable snapshot of every HTML/markdown read path, so
+  // the same battery can be compared across dual-read scenarios.
+  async function snapshot() {
+    let instanceUrls = [1, 2, 3].map((n) => new URL(`${testRealmURL}${n}`));
+    let single: (InstanceOrError | undefined)[] = [];
+    for (let url of instanceUrls) {
+      single.push(await indexQueryEngine.getInstance(url));
+    }
+    let batched = await indexQueryEngine.getInstances(instanceUrls);
+    let batchedEntries = [...batched.entries()].sort(([a], [b]) =>
+      a < b ? -1 : a > b ? 1 : 0,
+    );
+
+    let file = await indexQueryEngine.getFile(
+      new URL(`${testRealmURL}readme.md`),
+    );
+
+    let renderSet = await indexQueryEngine.search(
+      testRealmURLObject,
+      {},
+      { includeErrors: true },
+      { kind: 'renderSet' },
+    );
+    let files = await indexQueryEngine.searchFiles(testRealmURLObject, {}, {});
+    let matched = await indexQueryEngine.searchCards(
+      testRealmURLObject,
+      { filter: { matches: 'sunflowers' } },
+      {},
+    );
+
+    return {
+      single,
+      batchedEntries,
+      file,
+      renderSet,
+      files: files.files,
+      matchedUrls: matched.cards.map((c) => c.id as string).sort(),
+    };
+  }
+
+  test('golden parity: prerendered_html mirror and boxel_index fallback return identical results', async function (assert) {
+    // Fallback path: no prerendered_html rows exist yet, so every read falls
+    // back to the boxel_index columns.
+    let fallback = await snapshot();
+
+    // Sanity: HTML actually flowed through the fallback (guards against a
+    // snapshot that is trivially empty and would pass any comparison).
+    let vg = fallback.single[0] as IndexedInstance;
+    assert.strictEqual(
+      vg.isolatedHtml,
+      `<div class="isolated">Van Gogh</div>`,
+      'fallback path serves boxel_index HTML',
+    );
+    assert.strictEqual(
+      vg.markdown,
+      'Van Gogh painted sunflowers',
+      'fallback path serves boxel_index markdown',
+    );
+    assert.deepEqual(
+      fallback.matchedUrls,
+      [`${testRealmURL}1`],
+      'fallback FTS matches over boxel_index.markdown',
+    );
+
+    // Prerendered path: mirror every row into prerendered_html; reads now come
+    // from prerendered_html and must be byte-for-byte identical.
+    await mirrorPrerenderedHtml(adapter, testRealmURL);
+    let prerendered = await snapshot();
+    assert.deepEqual(
+      prerendered,
+      fallback,
+      'prerendered_html mirror returns identical results to the boxel_index fallback',
+    );
+
+    // A row deliberately missing from prerendered_html still resolves — via the
+    // boxel_index fallback — while its neighbors are served from prerendered_html.
+    await adapter.execute(`DELETE FROM prerendered_html WHERE url = $1`, {
+      bind: [`${testRealmURL}2.json`],
+    });
+    let mixed = await snapshot();
+    assert.deepEqual(
+      mixed,
+      fallback,
+      'a row missing from prerendered_html is served identically from the fallback',
+    );
+  });
+
+  test('reads prefer prerendered_html over boxel_index when a row exists', async function (assert) {
+    await mirrorPrerenderedHtml(adapter, testRealmURL);
+    // Diverge the prerendered_html rendering from the boxel_index column with a
+    // sentinel. A correct dual-read serves the sentinel; only a stale read that
+    // ignored prerendered_html would return the boxel_index value.
+    await adapter.execute(
+      `UPDATE prerendered_html
+       SET isolated_html = $1, atom_html = $2, markdown = $3
+       WHERE url = $4`,
+      {
+        bind: [
+          `<div class="isolated">PRERENDERED</div>`,
+          `<span class="atom">PRERENDERED</span>`,
+          'prerendered markdown sentinel',
+          `${testRealmURL}1.json`,
+        ],
+      },
+    );
+
+    let entry = (await indexQueryEngine.getInstance(
+      new URL(`${testRealmURL}1`),
+    )) as IndexedInstance;
+    assert.strictEqual(
+      entry.isolatedHtml,
+      `<div class="isolated">PRERENDERED</div>`,
+      'getInstance serves isolated_html from prerendered_html',
+    );
+    assert.strictEqual(
+      entry.atomHtml,
+      `<span class="atom">PRERENDERED</span>`,
+      'getInstance serves atom_html from prerendered_html',
+    );
+    assert.strictEqual(
+      entry.markdown,
+      'prerendered markdown sentinel',
+      'getInstance serves markdown from prerendered_html',
+    );
+
+    // A row with no prerendered_html row keeps serving the boxel_index column.
+    await adapter.execute(`DELETE FROM prerendered_html WHERE url = $1`, {
+      bind: [`${testRealmURL}2.json`],
+    });
+    let fallbackEntry = (await indexQueryEngine.getInstance(
+      new URL(`${testRealmURL}2`),
+    )) as IndexedInstance;
+    assert.strictEqual(
+      fallbackEntry.isolatedHtml,
+      `<div class="isolated">Mango</div>`,
+      'a row absent from prerendered_html falls back to boxel_index HTML',
+    );
+  });
+
+  test('FTS matches reads prerendered_html.markdown with a boxel_index fallback', async function (assert) {
+    await mirrorPrerenderedHtml(adapter, testRealmURL);
+
+    // Membership tracks prerendered_html.markdown: rewrite row 2's markdown to
+    // include a new term and confirm the matches query now finds it.
+    await adapter.execute(
+      `UPDATE prerendered_html SET markdown = $1 WHERE url = $2`,
+      { bind: ['Mango and sunflowers together', `${testRealmURL}2.json`] },
+    );
+    // Confirm the mirror created row 2 and the update landed, so the membership
+    // assertion below exercises the prerendered_html.markdown read (not a no-op).
+    let [row2] = (await adapter.execute(
+      `SELECT markdown FROM prerendered_html WHERE url = $1`,
+      { bind: [`${testRealmURL}2.json`] },
+    )) as { markdown: string | null }[];
+    assert.strictEqual(
+      row2?.markdown,
+      'Mango and sunflowers together',
+      'prerendered_html row 2 markdown was mirrored and updated',
+    );
+    let bothMatch = await indexQueryEngine.searchCards(
+      testRealmURLObject,
+      { filter: { matches: 'sunflowers' } },
+      {},
+    );
+    assert.deepEqual(
+      bothMatch.cards.map((c) => c.id as string).sort(),
+      [`${testRealmURL}1`, `${testRealmURL}2`],
+      'matches membership follows prerendered_html.markdown',
+    );
+
+    // Blanking a prerendered_html markdown drops the row from FTS even though
+    // boxel_index still carries the old text (the ph row exists, so the guarded
+    // boxel_index fallback does not re-add it).
+    await adapter.execute(
+      `UPDATE prerendered_html SET markdown = NULL WHERE url = $1`,
+      { bind: [`${testRealmURL}1.json`] },
+    );
+    let afterBlank = await indexQueryEngine.searchCards(
+      testRealmURLObject,
+      { filter: { matches: 'sunflowers' } },
+      {},
+    );
+    assert.deepEqual(
+      afterBlank.cards.map((c) => c.id as string).sort(),
+      [`${testRealmURL}2`],
+      'a present-but-empty prerendered_html markdown is not re-matched via boxel_index',
+    );
+
+    // With no prerendered_html row at all, the guarded fallback reads
+    // boxel_index.markdown so the row stays full-text findable.
+    await adapter.execute(`DELETE FROM prerendered_html WHERE url = $1`, {
+      bind: [`${testRealmURL}1.json`],
+    });
+    let afterDelete = await indexQueryEngine.searchCards(
+      testRealmURLObject,
+      { filter: { matches: 'sunflowers' } },
+      {},
+    );
+    assert.deepEqual(
+      afterDelete.cards.map((c) => c.id as string).sort(),
+      [`${testRealmURL}1`, `${testRealmURL}2`],
+      'a row missing from prerendered_html falls back to boxel_index.markdown for FTS',
+    );
+  });
+});

--- a/packages/host/tests/unit/prerendered-html-dual-read-test.ts
+++ b/packages/host/tests/unit/prerendered-html-dual-read-test.ts
@@ -30,10 +30,9 @@ import {
 
 const testRealmURLObject = new URL(testRealmURL);
 
-// Copy every boxel_index row for the realm into prerendered_html exactly as the
-// backfill migration does (rendered_at seeded from indexed_at), so a mirrored
-// row reads identically whether the dual-read serves it from prerendered_html
-// or from the boxel_index fallback.
+// Copy every boxel_index row for the realm into prerendered_html, seeding
+// rendered_at from indexed_at, so a mirrored row reads identically whether the
+// dual-read serves it from prerendered_html or from the boxel_index fallback.
 async function mirrorPrerenderedHtml(adapter: SQLiteAdapter, realmURL: string) {
   await adapter.execute(
     `INSERT INTO prerendered_html (
@@ -253,8 +252,8 @@ module('Unit | prerendered-html dual-read', function (hooks) {
   }
 
   test('golden parity: prerendered_html mirror and boxel_index fallback return identical results', async function (assert) {
-    // Fallback path: no prerendered_html rows exist yet, so every read falls
-    // back to the boxel_index columns.
+    // Fallback path: with no prerendered_html rows, every read falls back to
+    // the boxel_index columns.
     let fallback = await snapshot();
 
     // Sanity: HTML actually flowed through the fallback (guards against a
@@ -286,8 +285,8 @@ module('Unit | prerendered-html dual-read', function (hooks) {
       'prerendered_html mirror returns identical results to the boxel_index fallback',
     );
 
-    // A row deliberately missing from prerendered_html still resolves — via the
-    // boxel_index fallback — while its neighbors are served from prerendered_html.
+    // A row deliberately missing from prerendered_html resolves via the
+    // boxel_index fallback, while its neighbors are served from prerendered_html.
     await adapter.execute(`DELETE FROM prerendered_html WHERE url = $1`, {
       bind: [`${testRealmURL}2.json`],
     });
@@ -353,10 +352,10 @@ module('Unit | prerendered-html dual-read', function (hooks) {
 
   test('a present prerendered_html row is authoritative for a null column (no boxel_index fallback)', async function (assert) {
     await mirrorPrerenderedHtml(adapter, testRealmURL);
-    // Null the prerendered rendering while boxel_index still carries a value.
-    // A present prerendered_html row is authoritative, so the read reports the
-    // absence rather than leaking the stale boxel_index column — otherwise a row
-    // could drop out of full-text search yet still serve stale markdown/HTML.
+    // Null the prerendered rendering while boxel_index retains a value. A
+    // present prerendered_html row is authoritative, so the read reports the
+    // absence rather than leaking the boxel_index column — otherwise a row
+    // absent from full-text search could serve stale markdown/HTML.
     await adapter.execute(
       `UPDATE prerendered_html SET markdown = NULL, isolated_html = NULL WHERE url = $1`,
       { bind: [`${testRealmURL}1.json`] },
@@ -408,7 +407,7 @@ module('Unit | prerendered-html dual-read', function (hooks) {
     );
 
     // Blanking a prerendered_html markdown drops the row from FTS even though
-    // boxel_index still carries the old text (the ph row exists, so the guarded
+    // boxel_index retains its markdown (the ph row exists, so the guarded
     // boxel_index fallback does not re-add it).
     await adapter.execute(
       `UPDATE prerendered_html SET markdown = NULL WHERE url = $1`,

--- a/packages/realm-server/lib/index-html-injection.ts
+++ b/packages/realm-server/lib/index-html-injection.ts
@@ -27,18 +27,22 @@ export async function retrieveHeadHTML({
     return null;
   }
 
+  // Dual-read: serve the head HTML from prerendered_html, falling back to the
+  // boxel_index column when no prerendered_html row exists.
   let rows = await query(dbAdapter, [
     `
-      SELECT head_html, generation
-      FROM boxel_index
-      WHERE type = 'instance'
-       AND head_html IS NOT NULL
-       AND is_deleted IS NOT TRUE
+      SELECT coalesce(ph.head_html, i.head_html) AS head_html, i.generation
+      FROM boxel_index AS i
+      LEFT JOIN prerendered_html AS ph
+        ON ph.url = i.url AND ph.realm_url = i.realm_url AND ph.type = i.type
+      WHERE i.type = 'instance'
+       AND coalesce(ph.head_html, i.head_html) IS NOT NULL
+       AND i.is_deleted IS NOT TRUE
        AND
     `,
-    ...indexCandidateExpressions(candidates),
+    ...indexCandidateExpressions(candidates, 'i'),
     `
-      ORDER BY generation DESC
+      ORDER BY i.generation DESC
       LIMIT 1
     `,
   ]);
@@ -81,18 +85,22 @@ export async function retrieveIsolatedHTML({
     return null;
   }
 
+  // Dual-read: serve the isolated HTML from prerendered_html, falling back to
+  // the boxel_index column when no prerendered_html row exists.
   let rows = await query(dbAdapter, [
     `
-      SELECT isolated_html, generation
-      FROM boxel_index
-      WHERE isolated_html IS NOT NULL
-        AND type = 'instance'
-        AND is_deleted IS NOT TRUE
+      SELECT coalesce(ph.isolated_html, i.isolated_html) AS isolated_html, i.generation
+      FROM boxel_index AS i
+      LEFT JOIN prerendered_html AS ph
+        ON ph.url = i.url AND ph.realm_url = i.realm_url AND ph.type = i.type
+      WHERE coalesce(ph.isolated_html, i.isolated_html) IS NOT NULL
+        AND i.type = 'instance'
+        AND i.is_deleted IS NOT TRUE
         AND
       `,
-    ...indexCandidateExpressions(candidates),
+    ...indexCandidateExpressions(candidates, 'i'),
     `
-      ORDER BY generation DESC
+      ORDER BY i.generation DESC
       LIMIT 1
     `,
   ]);

--- a/packages/realm-server/lib/index-html-injection.ts
+++ b/packages/realm-server/lib/index-html-injection.ts
@@ -28,15 +28,16 @@ export async function retrieveHeadHTML({
   }
 
   // Dual-read: serve the head HTML from prerendered_html, falling back to the
-  // boxel_index column when no prerendered_html row exists.
+  // boxel_index column only when no prerendered_html row exists (a present row
+  // is authoritative, matching the query engine's `ph.url IS NULL` guard).
   let rows = await query(dbAdapter, [
     `
-      SELECT coalesce(ph.head_html, i.head_html) AS head_html, i.generation
+      SELECT CASE WHEN ph.url IS NULL THEN i.head_html ELSE ph.head_html END AS head_html, i.generation
       FROM boxel_index AS i
       LEFT JOIN prerendered_html AS ph
         ON ph.url = i.url AND ph.realm_url = i.realm_url AND ph.type = i.type
       WHERE i.type = 'instance'
-       AND coalesce(ph.head_html, i.head_html) IS NOT NULL
+       AND (CASE WHEN ph.url IS NULL THEN i.head_html ELSE ph.head_html END) IS NOT NULL
        AND i.is_deleted IS NOT TRUE
        AND
     `,
@@ -86,14 +87,15 @@ export async function retrieveIsolatedHTML({
   }
 
   // Dual-read: serve the isolated HTML from prerendered_html, falling back to
-  // the boxel_index column when no prerendered_html row exists.
+  // the boxel_index column only when no prerendered_html row exists (a present
+  // row is authoritative, matching the query engine's `ph.url IS NULL` guard).
   let rows = await query(dbAdapter, [
     `
-      SELECT coalesce(ph.isolated_html, i.isolated_html) AS isolated_html, i.generation
+      SELECT CASE WHEN ph.url IS NULL THEN i.isolated_html ELSE ph.isolated_html END AS isolated_html, i.generation
       FROM boxel_index AS i
       LEFT JOIN prerendered_html AS ph
         ON ph.url = i.url AND ph.realm_url = i.realm_url AND ph.type = i.type
-      WHERE coalesce(ph.isolated_html, i.isolated_html) IS NOT NULL
+      WHERE (CASE WHEN ph.url IS NULL THEN i.isolated_html ELSE ph.isolated_html END) IS NOT NULL
         AND i.type = 'instance'
         AND i.is_deleted IS NOT TRUE
         AND

--- a/packages/realm-server/lib/index-url-utils.ts
+++ b/packages/realm-server/lib/index-url-utils.ts
@@ -23,17 +23,24 @@ export function indexURLCandidates(cardURL: URL): string[] {
   return [...new Set(candidates)];
 }
 
-export function indexCandidateExpressions(candidates: string[]): Expression {
+export function indexCandidateExpressions(
+  candidates: string[],
+  // Table alias to qualify `url` / `file_alias` with. Required when the query
+  // joins another table that also carries these columns (e.g. the dual-read
+  // join to `prerendered_html`), so the references are unambiguous.
+  alias?: string,
+): Expression {
+  let prefix = alias ? `${alias}.` : '';
   // Proxying means the apparent request URL will be http but in the database it's https
   return addExplicitParens(
     any(
       candidates.flatMap((candidate) => [
         [
-          "regexp_replace(url, '^https?://', '') =",
+          `regexp_replace(${prefix}url, '^https?://', '') =`,
           param(stripProtocol(candidate)),
         ],
         [
-          "regexp_replace(file_alias, '^https?://', '') =",
+          `regexp_replace(${prefix}file_alias, '^https?://', '') =`,
           param(stripProtocol(candidate)),
         ],
       ]),

--- a/packages/realm-server/lib/retrieve-scoped-css.ts
+++ b/packages/realm-server/lib/retrieve-scoped-css.ts
@@ -28,19 +28,20 @@ export async function retrieveScopedCSS({
 
   // Dual-read: the scoped-CSS URLs needed to serve a card's HTML ride on the
   // prerendered_html `deps` / `last_known_good_deps`, falling back to the
-  // boxel_index columns when no prerendered_html row exists.
+  // boxel_index columns only when no prerendered_html row exists (a present row
+  // is authoritative, matching the query engine's `ph.url IS NULL` guard).
   let scopedCSSQuery: Expression = [
     `
-      SELECT coalesce(ph.deps, i.deps) AS deps,
-             coalesce(ph.last_known_good_deps, i.last_known_good_deps) AS last_known_good_deps,
+      SELECT CASE WHEN ph.url IS NULL THEN i.deps ELSE ph.deps END AS deps,
+             CASE WHEN ph.url IS NULL THEN i.last_known_good_deps ELSE ph.last_known_good_deps END AS last_known_good_deps,
              i.generation
       FROM boxel_index AS i
       LEFT JOIN prerendered_html AS ph
         ON ph.url = i.url AND ph.realm_url = i.realm_url AND ph.type = i.type
       WHERE i.type = 'instance'
         AND i.is_deleted IS NOT TRUE
-        AND (coalesce(ph.deps, i.deps) IS NOT NULL
-             OR coalesce(ph.last_known_good_deps, i.last_known_good_deps) IS NOT NULL)
+        AND ((CASE WHEN ph.url IS NULL THEN i.deps ELSE ph.deps END) IS NOT NULL
+             OR (CASE WHEN ph.url IS NULL THEN i.last_known_good_deps ELSE ph.last_known_good_deps END) IS NOT NULL)
         AND
     `,
     ...indexCandidateExpressions(candidates, 'i'),

--- a/packages/realm-server/lib/retrieve-scoped-css.ts
+++ b/packages/realm-server/lib/retrieve-scoped-css.ts
@@ -26,18 +26,26 @@ export async function retrieveScopedCSS({
     return null;
   }
 
+  // Dual-read: the scoped-CSS URLs needed to serve a card's HTML ride on the
+  // prerendered_html `deps` / `last_known_good_deps`, falling back to the
+  // boxel_index columns when no prerendered_html row exists.
   let scopedCSSQuery: Expression = [
     `
-      SELECT deps, last_known_good_deps, generation
-      FROM boxel_index
-      WHERE type = 'instance'
-        AND is_deleted IS NOT TRUE
-        AND (deps IS NOT NULL OR last_known_good_deps IS NOT NULL)
+      SELECT coalesce(ph.deps, i.deps) AS deps,
+             coalesce(ph.last_known_good_deps, i.last_known_good_deps) AS last_known_good_deps,
+             i.generation
+      FROM boxel_index AS i
+      LEFT JOIN prerendered_html AS ph
+        ON ph.url = i.url AND ph.realm_url = i.realm_url AND ph.type = i.type
+      WHERE i.type = 'instance'
+        AND i.is_deleted IS NOT TRUE
+        AND (coalesce(ph.deps, i.deps) IS NOT NULL
+             OR coalesce(ph.last_known_good_deps, i.last_known_good_deps) IS NOT NULL)
         AND
     `,
-    ...indexCandidateExpressions(candidates),
+    ...indexCandidateExpressions(candidates, 'i'),
     `
-      ORDER BY generation DESC
+      ORDER BY i.generation DESC
       LIMIT 1
     `,
   ];

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -2622,8 +2622,14 @@ module(basename(import.meta.filename), function () {
         let alternate = url.endsWith('.json')
           ? url.replace(/\.json$/, '')
           : `${url}.json`;
+        // The isolated-HTML injection dual-reads from prerendered_html (falling
+        // back to boxel_index), so override both channels for the row.
         await dbAdapter.execute(
           `UPDATE boxel_index SET isolated_html = $1 WHERE url = $2 OR url = $3`,
+          { bind: [html, url, alternate] },
+        );
+        await dbAdapter.execute(
+          `UPDATE prerendered_html SET isolated_html = $1 WHERE url = $2 OR url = $3`,
           { bind: [html, url, alternate] },
         );
       }

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -219,8 +219,14 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
     });
 
     test('mixed index: fallback per the fieldset', async function (assert) {
+      // Clear the rendering from both channels: the engine dual-reads HTML from
+      // prerendered_html, falling back to boxel_index, so a rendering is absent
+      // only when neither carries it.
       await dbAdapter.execute(
         `UPDATE boxel_index SET fitted_html = NULL WHERE url = '${janeId}.json'`,
+      );
+      await dbAdapter.execute(
+        `UPDATE prerendered_html SET fitted_html = NULL WHERE url = '${janeId}.json'`,
       );
       // default mode: the fallback row carries item and omits html
       let response = await postSearch({ filter: personFilter() });

--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -487,8 +487,14 @@ module(basename(import.meta.filename), function () {
     });
 
     test('mixed index: a row with no matching rendering falls back per the fieldset', async function (assert) {
+      // Clear the rendering from both channels: the engine dual-reads HTML from
+      // prerendered_html, falling back to boxel_index, so a rendering is absent
+      // only when neither carries it.
       await dbAdapter.execute(
         `UPDATE boxel_index SET fitted_html = NULL WHERE url = '${janeId}.json'`,
+      );
+      await dbAdapter.execute(
+        `UPDATE prerendered_html SET fitted_html = NULL WHERE url = '${janeId}.json'`,
       );
       // default mode: the fallback row carries item and omits the html
       // relationship entirely
@@ -542,6 +548,11 @@ module(basename(import.meta.filename), function () {
       // html — at the format the htmlQuery names and the row's own type.
       await dbAdapter.execute(
         `UPDATE boxel_index SET has_error = TRUE, pristine_doc = NULL, fitted_html = NULL, embedded_html = NULL, atom_html = NULL, head_html = NULL WHERE url = '${janeId}.json'`,
+      );
+      // The renderings the engine reads live on prerendered_html; clear them
+      // there too so nothing renderable remains for the error row.
+      await dbAdapter.execute(
+        `UPDATE prerendered_html SET fitted_html = NULL, embedded_html = NULL, atom_html = NULL, head_html = NULL WHERE url = '${janeId}.json'`,
       );
       let doc =
         await testRealm.realmIndexQueryEngine.searchEntries(personQuery());

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -731,11 +731,21 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       });
 
       test('missing apple-touch-icon is filled with default when only favicon is present in head HTML', async function (assert) {
-        // Directly set head_html to contain only a favicon link (no apple-touch-icon)
+        // Directly set head_html to contain only a favicon link (no apple-touch-icon).
+        // The head-HTML injection dual-reads from prerendered_html (falling back
+        // to boxel_index), so set the head on both channels for the row.
         let cardURL = `${testRealmURL.href}isolated-test.json`;
+        let faviconHead = `'<title>Test</title><link rel="icon" href="https://example.com/custom-icon.png" type="image/png">'`;
         await dbAdapter.execute(
           `UPDATE boxel_index
-           SET head_html = '<title>Test</title><link rel="icon" href="https://example.com/custom-icon.png" type="image/png">'
+           SET head_html = ${faviconHead}
+           WHERE url = '${cardURL}'
+             AND type = 'instance'
+             AND is_deleted IS NOT TRUE`,
+        );
+        await dbAdapter.execute(
+          `UPDATE prerendered_html
+           SET head_html = ${faviconHead}
            WHERE url = '${cardURL}'
              AND type = 'instance'
              AND is_deleted IS NOT TRUE`,
@@ -784,10 +794,20 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       });
 
       test('missing favicon is filled with default when only apple-touch-icon is present in head HTML', async function (assert) {
+        // The head-HTML injection dual-reads from prerendered_html (falling back
+        // to boxel_index), so set the head on both channels for the row.
         let cardURL = `${testRealmURL.href}isolated-test.json`;
+        let touchIconHead = `'<title>Test</title><link rel="apple-touch-icon" href="https://example.com/custom-touch.png">'`;
         await dbAdapter.execute(
           `UPDATE boxel_index
-           SET head_html = '<title>Test</title><link rel="apple-touch-icon" href="https://example.com/custom-touch.png">'
+           SET head_html = ${touchIconHead}
+           WHERE url = '${cardURL}'
+             AND type = 'instance'
+             AND is_deleted IS NOT TRUE`,
+        );
+        await dbAdapter.execute(
+          `UPDATE prerendered_html
+           SET head_html = ${touchIconHead}
            WHERE url = '${cardURL}'
              AND type = 'instance'
              AND is_deleted IS NOT TRUE`,

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -801,7 +801,17 @@ export class IndexQueryEngine {
       // atom/head columns), plus the live serialization on every row. The
       // caller enumerates candidate renderings and selects from the set.
       selectClauseExpression = [
-        'SELECT i.url AS url, ANY_VALUE(i.type) as type, ANY_VALUE(i.has_error) as has_error, ANY_VALUE(i.file_alias) as file_alias, ANY_VALUE(coalesce(ph.fitted_html, i.fitted_html)) as fitted_html, ANY_VALUE(coalesce(ph.embedded_html, i.embedded_html)) as embedded_html, ANY_VALUE(coalesce(ph.atom_html, i.atom_html)) as atom_html, ANY_VALUE(coalesce(ph.head_html, i.head_html)) as head_html, ANY_VALUE(i.types) as types, ANY_VALUE(coalesce(ph.deps, i.deps)) as deps, ANY_VALUE(i.display_names) as display_names, ANY_VALUE(i.icon_html) as icon_html, ANY_VALUE(i.error_doc) as error_doc, ANY_VALUE(i.pristine_doc) as pristine_doc',
+        `SELECT i.url AS url, ANY_VALUE(i.type) as type, ANY_VALUE(i.has_error) as has_error, ANY_VALUE(i.file_alias) as file_alias, ANY_VALUE(${dualReadColumn(
+          'fitted_html',
+        )}) as fitted_html, ANY_VALUE(${dualReadColumn(
+          'embedded_html',
+        )}) as embedded_html, ANY_VALUE(${dualReadColumn(
+          'atom_html',
+        )}) as atom_html, ANY_VALUE(${dualReadColumn(
+          'head_html',
+        )}) as head_html, ANY_VALUE(i.types) as types, ANY_VALUE(${dualReadColumn(
+          'deps',
+        )}) as deps, ANY_VALUE(i.display_names) as display_names, ANY_VALUE(i.icon_html) as icon_html, ANY_VALUE(i.error_doc) as error_doc, ANY_VALUE(i.pristine_doc) as pristine_doc`,
       ];
     }
 
@@ -851,7 +861,21 @@ export class IndexQueryEngine {
       { filter, sort, page },
       opts,
       [
-        'SELECT i.url AS url, ANY_VALUE(i.pristine_doc) AS pristine_doc, ANY_VALUE(i.search_doc) AS search_doc, ANY_VALUE(i.types) AS types, ANY_VALUE(i.display_names) AS display_names, ANY_VALUE(coalesce(ph.deps, i.deps)) AS deps, ANY_VALUE(i.last_modified) AS last_modified, ANY_VALUE(i.resource_created_at) AS resource_created_at, ANY_VALUE(coalesce(ph.isolated_html, i.isolated_html)) AS isolated_html, ANY_VALUE(coalesce(ph.head_html, i.head_html)) AS head_html, ANY_VALUE(coalesce(ph.embedded_html, i.embedded_html)) AS embedded_html, ANY_VALUE(coalesce(ph.fitted_html, i.fitted_html)) AS fitted_html, ANY_VALUE(coalesce(ph.atom_html, i.atom_html)) AS atom_html, ANY_VALUE(i.icon_html) AS icon_html, ANY_VALUE(coalesce(ph.markdown, i.markdown)) AS markdown, ANY_VALUE(i.generation) AS generation, ANY_VALUE(i.realm_url) AS realm_url, ANY_VALUE(i.indexed_at) AS indexed_at',
+        `SELECT i.url AS url, ANY_VALUE(i.pristine_doc) AS pristine_doc, ANY_VALUE(i.search_doc) AS search_doc, ANY_VALUE(i.types) AS types, ANY_VALUE(i.display_names) AS display_names, ANY_VALUE(${dualReadColumn(
+          'deps',
+        )}) AS deps, ANY_VALUE(i.last_modified) AS last_modified, ANY_VALUE(i.resource_created_at) AS resource_created_at, ANY_VALUE(${dualReadColumn(
+          'isolated_html',
+        )}) AS isolated_html, ANY_VALUE(${dualReadColumn(
+          'head_html',
+        )}) AS head_html, ANY_VALUE(${dualReadColumn(
+          'embedded_html',
+        )}) AS embedded_html, ANY_VALUE(${dualReadColumn(
+          'fitted_html',
+        )}) AS fitted_html, ANY_VALUE(${dualReadColumn(
+          'atom_html',
+        )}) AS atom_html, ANY_VALUE(i.icon_html) AS icon_html, ANY_VALUE(${dualReadColumn(
+          'markdown',
+        )}) AS markdown, ANY_VALUE(i.generation) AS generation, ANY_VALUE(i.realm_url) AS realm_url, ANY_VALUE(i.indexed_at) AS indexed_at`,
       ],
       'file',
     );
@@ -1941,18 +1965,32 @@ function prerenderedJoin(opts: WIPOptions | undefined) {
   )} AS ph ON ph.url = i.url AND ph.realm_url = i.realm_url AND ph.type = i.type`;
 }
 
-// Coalesced HTML/markdown reads, appended after a `SELECT i.*` so these win over
+// A single dual-read column. A present prerendered_html row is authoritative for
+// the column — its value wins even when NULL — and boxel_index is consulted only
+// when no prerendered_html row exists (`ph.url IS NULL`, the primary key so never
+// null on a matched row). This matches matchesCondition's `ph.url IS NULL` guard,
+// so a present-but-null prerendered rendering reads as an absence consistently:
+// the column and full-text membership never disagree (a plain
+// `coalesce(ph.col, i.col)` would leak the stale boxel_index value for a row the
+// FTS path already treats as unrendered).
+function dualReadColumn(col: string): string {
+  return `CASE WHEN ph.url IS NULL THEN i.${col} ELSE ph.${col} END`;
+}
+
+// Dual-read HTML/markdown reads, appended after a `SELECT i.*` so these win over
 // the same-named boxel_index columns (duplicate result columns resolve to the
-// last one in both the pg and sqlite adapters). Each prefers the prerendered_html
-// value and falls back to boxel_index when the prerendered row is absent.
-// `icon_html` is intentionally excluded — it stays on boxel_index.
-const DUAL_READ_HTML_OVERRIDES =
-  `coalesce(ph.isolated_html, i.isolated_html) AS isolated_html, ` +
-  `coalesce(ph.head_html, i.head_html) AS head_html, ` +
-  `coalesce(ph.atom_html, i.atom_html) AS atom_html, ` +
-  `coalesce(ph.embedded_html, i.embedded_html) AS embedded_html, ` +
-  `coalesce(ph.fitted_html, i.fitted_html) AS fitted_html, ` +
-  `coalesce(ph.markdown, i.markdown) AS markdown`;
+// last one in both the pg and sqlite adapters). `icon_html` is intentionally
+// excluded — it stays on boxel_index.
+const DUAL_READ_HTML_OVERRIDES = [
+  'isolated_html',
+  'head_html',
+  'atom_html',
+  'embedded_html',
+  'fitted_html',
+  'markdown',
+]
+  .map((col) => `${dualReadColumn(col)} AS ${col}`)
+  .join(', ');
 
 // SQLite LIKE treats `%` and `_` as wildcards. With `ESCAPE '\'` we can
 // neutralize user-supplied wildcards by prefixing them (and the escape

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -738,13 +738,14 @@ export class IndexQueryEngine {
           ...limitClause,
         ];
       }
-      // The count query keeps its own base table (`boxel_index`) but joins the
-      // production prerendered_html so a `matches` predicate — shared with the
-      // data query through `everyCondition` — can reference `ph.markdown`.
+      // Count over the same tables as the data query (via `opts`) so `total`
+      // stays consistent with the result set — including in WIP mode and for a
+      // `matches` predicate, which is shared with the data query through
+      // `everyCondition` and references `ph.markdown`.
       let queryCount = [
         'SELECT COUNT(DISTINCT i.url) AS total',
-        `FROM boxel_index AS i ${prerenderedJoin(
-          undefined,
+        `FROM ${tableFromOpts(opts)} AS i ${prerenderedJoin(
+          opts,
         )} ${tableValuedFunctionsPlaceholder}`,
         'WHERE',
         ...everyCondition,
@@ -1953,12 +1954,11 @@ function prerenderedTableFromOpts(opts: WIPOptions | undefined) {
 
 // Dual-read LEFT JOIN: attaches the prerendered_html row (aliased `ph`) for each
 // boxel_index row (aliased `i`) on their shared (url, realm_url, type) primary
-// key. HTML and markdown reads prefer `ph` and fall back to the boxel_index
-// column when no prerendered row exists — rows written between the backfill
-// migration and the dual-write deploy, or a row deliberately absent from
-// prerendered_html. Being keyed on the primary key the join is 1:1, so it never
-// fans out a `GROUP BY url` grouping. `icon_html` is not dual-read: the icon
-// renders in the index visit and stays on boxel_index.
+// key. A boxel_index row without a matching prerendered_html row leaves `ph`'s
+// columns NULL (`ph.url IS NULL`), which the reads treat as the fallback to the
+// boxel_index column. Being keyed on the primary key the join is 1:1, so it
+// never fans out a `GROUP BY url` grouping. `icon_html` is not dual-read: the
+// icon renders in the index visit and stays on boxel_index.
 function prerenderedJoin(opts: WIPOptions | undefined) {
   return `LEFT JOIN ${prerenderedTableFromOpts(
     opts,
@@ -1979,8 +1979,12 @@ function dualReadColumn(col: string): string {
 
 // Dual-read HTML/markdown reads, appended after a `SELECT i.*` so these win over
 // the same-named boxel_index columns (duplicate result columns resolve to the
-// last one in both the pg and sqlite adapters). `icon_html` is intentionally
-// excluded — it stays on boxel_index.
+// last one in both the pg and sqlite adapters). `icon_html` is excluded — the
+// icon renders in the index visit and stays on boxel_index. `deps` is excluded
+// too: `getInstance`/`getFile` expose `deps` for the dependency graph
+// (`getCardDependencies`), which is boxel_index's; the scoped-CSS URLs needed to
+// serve HTML are dual-read where HTML is served — the search selects, searchFiles,
+// and retrieve-scoped-css.
 const DUAL_READ_HTML_OVERRIDES = [
   'isolated_html',
   'head_html',

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -235,10 +235,15 @@ export interface QueryResultsMeta {
 }
 
 // A mapper for fields that can be sorted on but are not an attribute of a card
+// SQL fragments consumed by `_search`'s ORDER BY, which runs with the
+// boxel_index alias `i` in scope (and, since dual-read, a joined prerendered
+// `ph`). `cardURL` sorts on the primary-key `url`, which now exists in both
+// joined tables — qualify it to `i` so it is unambiguous. Callers outside the
+// query engine (query.ts, search-entry.ts) use only the keys of this map.
 export const generalSortFields: Record<string, string> = {
-  lastModified: 'last_modified',
-  createdAt: 'resource_created_at',
-  cardURL: 'url COLLATE "POSIX"',
+  lastModified: 'i.last_modified',
+  createdAt: 'i.resource_created_at',
+  cardURL: 'i.url COLLATE "POSIX"',
 };
 
 export { isValidPrerenderedHtmlFormat };
@@ -293,8 +298,8 @@ export class IndexQueryEngine {
     opts?: GetEntryOptions,
   ): Promise<InstanceOrError | undefined> {
     let result = (await this.#query([
-      `SELECT i.*, embedded_html, fitted_html`,
-      `FROM ${tableFromOpts(opts)} as i
+      `SELECT i.*, ${DUAL_READ_HTML_OVERRIDES}`,
+      `FROM ${tableFromOpts(opts)} as i ${prerenderedJoin(opts)}
        WHERE`,
       ...every([
         any([
@@ -330,8 +335,8 @@ export class IndexQueryEngine {
       let chunkSet = new Set(chunk);
       let chunkParams = chunk.map((href) => [param(href)]);
       let rows = (await this.#query([
-        `SELECT i.*, embedded_html, fitted_html`,
-        `FROM ${tableFromOpts(opts)} as i
+        `SELECT i.*, ${DUAL_READ_HTML_OVERRIDES}`,
+        `FROM ${tableFromOpts(opts)} as i ${prerenderedJoin(opts)}
          WHERE`,
         ...every([
           any([
@@ -448,8 +453,8 @@ export class IndexQueryEngine {
     opts?: GetEntryOptions,
   ): Promise<IndexedFile | undefined> {
     let result = (await this.#query([
-      `SELECT i.*`,
-      `FROM ${tableFromOpts(opts)} as i
+      `SELECT i.*, ${DUAL_READ_HTML_OVERRIDES}`,
+      `FROM ${tableFromOpts(opts)} as i ${prerenderedJoin(opts)}
        WHERE`,
       ...every([
         any([
@@ -483,8 +488,8 @@ export class IndexQueryEngine {
       let chunkSet = new Set(chunk);
       let chunkParams = chunk.map((href) => [param(href)]);
       let rows = (await this.#query([
-        `SELECT i.*`,
-        `FROM ${tableFromOpts(opts)} as i
+        `SELECT i.*, ${DUAL_READ_HTML_OVERRIDES}`,
+        `FROM ${tableFromOpts(opts)} as i ${prerenderedJoin(opts)}
          WHERE`,
         ...every([
           any([
@@ -660,7 +665,7 @@ export class IndexQueryEngine {
     try {
       let conditions: CardExpression[] = [
         ['i.realm_url = ', param(realmURL.href)],
-        ['is_deleted = FALSE OR is_deleted IS NULL'],
+        ['i.is_deleted = FALSE OR i.is_deleted IS NULL'],
       ];
 
       if (opts.includeErrors) {
@@ -710,10 +715,12 @@ export class IndexQueryEngine {
           'FROM (',
           ...selectClauseExpression,
           ...innerSortColumns,
-          `FROM ${tableFromOpts(opts)} AS i ${tableValuedFunctionsPlaceholder}`,
+          `FROM ${tableFromOpts(opts)} AS i ${prerenderedJoin(
+            opts,
+          )} ${tableValuedFunctionsPlaceholder}`,
           'WHERE',
           ...everyCondition,
-          'GROUP BY url',
+          'GROUP BY i.url',
           ') AS sub',
           ...outerOrderBy,
           ...limitClause,
@@ -721,17 +728,24 @@ export class IndexQueryEngine {
       } else {
         query = [
           ...selectClauseExpression,
-          `FROM ${tableFromOpts(opts)} AS i ${tableValuedFunctionsPlaceholder}`,
+          `FROM ${tableFromOpts(opts)} AS i ${prerenderedJoin(
+            opts,
+          )} ${tableValuedFunctionsPlaceholder}`,
           'WHERE',
           ...everyCondition,
-          'GROUP BY url',
+          'GROUP BY i.url',
           ...this.orderExpression(sort),
           ...limitClause,
         ];
       }
+      // The count query keeps its own base table (`boxel_index`) but joins the
+      // production prerendered_html so a `matches` predicate — shared with the
+      // data query through `everyCondition` — can reference `ph.markdown`.
       let queryCount = [
-        'SELECT COUNT(DISTINCT url) AS total',
-        `FROM boxel_index AS i ${tableValuedFunctionsPlaceholder}`,
+        'SELECT COUNT(DISTINCT i.url) AS total',
+        `FROM boxel_index AS i ${prerenderedJoin(
+          undefined,
+        )} ${tableValuedFunctionsPlaceholder}`,
         'WHERE',
         ...everyCondition,
       ];
@@ -779,7 +793,7 @@ export class IndexQueryEngine {
     let selectClauseExpression: CardExpression;
     if (projection.kind === 'dataOnly') {
       selectClauseExpression = [
-        'SELECT url, ANY_VALUE(i.type) as type, ANY_VALUE(i.has_error) as has_error, ANY_VALUE(pristine_doc) as pristine_doc, ANY_VALUE(error_doc) as error_doc',
+        'SELECT i.url AS url, ANY_VALUE(i.type) as type, ANY_VALUE(i.has_error) as has_error, ANY_VALUE(i.pristine_doc) as pristine_doc, ANY_VALUE(i.error_doc) as error_doc',
       ];
     } else {
       // The full rendering set: every per-format HTML column whole (the
@@ -787,7 +801,7 @@ export class IndexQueryEngine {
       // atom/head columns), plus the live serialization on every row. The
       // caller enumerates candidate renderings and selects from the set.
       selectClauseExpression = [
-        'SELECT url, ANY_VALUE(i.type) as type, ANY_VALUE(i.has_error) as has_error, ANY_VALUE(file_alias) as file_alias, ANY_VALUE(fitted_html) as fitted_html, ANY_VALUE(embedded_html) as embedded_html, ANY_VALUE(atom_html) as atom_html, ANY_VALUE(head_html) as head_html, ANY_VALUE(types) as types, ANY_VALUE(deps) as deps, ANY_VALUE(display_names) as display_names, ANY_VALUE(icon_html) as icon_html, ANY_VALUE(error_doc) as error_doc, ANY_VALUE(pristine_doc) as pristine_doc',
+        'SELECT i.url AS url, ANY_VALUE(i.type) as type, ANY_VALUE(i.has_error) as has_error, ANY_VALUE(i.file_alias) as file_alias, ANY_VALUE(coalesce(ph.fitted_html, i.fitted_html)) as fitted_html, ANY_VALUE(coalesce(ph.embedded_html, i.embedded_html)) as embedded_html, ANY_VALUE(coalesce(ph.atom_html, i.atom_html)) as atom_html, ANY_VALUE(coalesce(ph.head_html, i.head_html)) as head_html, ANY_VALUE(i.types) as types, ANY_VALUE(coalesce(ph.deps, i.deps)) as deps, ANY_VALUE(i.display_names) as display_names, ANY_VALUE(i.icon_html) as icon_html, ANY_VALUE(i.error_doc) as error_doc, ANY_VALUE(i.pristine_doc) as pristine_doc',
       ];
     }
 
@@ -837,7 +851,7 @@ export class IndexQueryEngine {
       { filter, sort, page },
       opts,
       [
-        'SELECT url, ANY_VALUE(pristine_doc) AS pristine_doc, ANY_VALUE(search_doc) AS search_doc, ANY_VALUE(types) AS types, ANY_VALUE(display_names) AS display_names, ANY_VALUE(deps) AS deps, ANY_VALUE(last_modified) AS last_modified, ANY_VALUE(resource_created_at) AS resource_created_at, ANY_VALUE(isolated_html) AS isolated_html, ANY_VALUE(head_html) AS head_html, ANY_VALUE(embedded_html) AS embedded_html, ANY_VALUE(fitted_html) AS fitted_html, ANY_VALUE(atom_html) AS atom_html, ANY_VALUE(icon_html) AS icon_html, ANY_VALUE(markdown) AS markdown, ANY_VALUE(generation) AS generation, ANY_VALUE(realm_url) AS realm_url, ANY_VALUE(indexed_at) AS indexed_at',
+        'SELECT i.url AS url, ANY_VALUE(i.pristine_doc) AS pristine_doc, ANY_VALUE(i.search_doc) AS search_doc, ANY_VALUE(i.types) AS types, ANY_VALUE(i.display_names) AS display_names, ANY_VALUE(coalesce(ph.deps, i.deps)) AS deps, ANY_VALUE(i.last_modified) AS last_modified, ANY_VALUE(i.resource_created_at) AS resource_created_at, ANY_VALUE(coalesce(ph.isolated_html, i.isolated_html)) AS isolated_html, ANY_VALUE(coalesce(ph.head_html, i.head_html)) AS head_html, ANY_VALUE(coalesce(ph.embedded_html, i.embedded_html)) AS embedded_html, ANY_VALUE(coalesce(ph.fitted_html, i.fitted_html)) AS fitted_html, ANY_VALUE(coalesce(ph.atom_html, i.atom_html)) AS atom_html, ANY_VALUE(i.icon_html) AS icon_html, ANY_VALUE(coalesce(ph.markdown, i.markdown)) AS markdown, ANY_VALUE(i.generation) AS generation, ANY_VALUE(i.realm_url) AS realm_url, ANY_VALUE(i.indexed_at) AS indexed_at',
       ],
       'file',
     );
@@ -899,7 +913,7 @@ export class IndexQueryEngine {
 
   private orderExpression(sort: Sort | undefined): CardExpression {
     if (!sort) {
-      return ['ORDER BY url COLLATE "POSIX"'];
+      return ['ORDER BY i.url COLLATE "POSIX"'];
     }
     return [
       'ORDER BY',
@@ -916,7 +930,7 @@ export class IndexQueryEngine {
           'NULLS LAST',
         ]),
         // we include 'url' as the final sort key for deterministic results
-        ['url COLLATE "POSIX"'],
+        ['i.url COLLATE "POSIX"'],
       ]),
     ];
   }
@@ -1184,6 +1198,17 @@ export class IndexQueryEngine {
   // empty/whitespace-only query short-circuits to FALSE so SQLite doesn't
   // match every non-null row (PG's websearch_to_tsquery already yields an
   // empty tsquery that matches nothing — we match that behavior here).
+  //
+  // Dual-read: markdown lives on `prerendered_html.markdown` (behind the
+  // prerendered_html GIN index) with a fallback to `boxel_index.markdown` for
+  // rows with no prerendered_html row. The fallback is guarded by
+  // `ph.url IS NULL` so a row whose prerendered_html markdown is intentionally
+  // absent never re-matches through the boxel_index column, and so a mirrored
+  // row is evaluated against exactly one channel. Both branches are expression
+  // matches against a GIN-indexed `to_tsvector('english', coalesce(<col>,''))`,
+  // so the planner can serve them with a bitmap-OR of the two indexes; in
+  // practice the fallback branch reaches ~no rows (dual-write mirrors every
+  // row), so the prerendered_html index carries the load.
   private matchesCondition(
     filter: MatchesFilter,
     _on: CodeRef,
@@ -1196,16 +1221,18 @@ export class IndexQueryEngine {
         : [
             dbExpression({
               pg: [
-                `to_tsvector('english', coalesce(i.markdown, ''))`,
-                '@@',
-                `websearch_to_tsquery('english',`,
+                `(to_tsvector('english', coalesce(ph.markdown, '')) @@ websearch_to_tsquery('english',`,
                 param(filter.matches),
-                `)`,
+                `)) OR (ph.url IS NULL AND to_tsvector('english', coalesce(i.markdown, '')) @@ websearch_to_tsquery('english',`,
+                param(filter.matches),
+                `))`,
               ],
               sqlite: [
-                `LOWER(i.markdown) LIKE LOWER(`,
+                `(LOWER(coalesce(ph.markdown, '')) LIKE LOWER(`,
                 param(`%${escapeSqliteLikePattern(filter.matches)}%`),
-                `) ESCAPE '\\'`,
+                `) ESCAPE '\\') OR (ph.url IS NULL AND LOWER(coalesce(i.markdown, '')) LIKE LOWER(`,
+                param(`%${escapeSqliteLikePattern(filter.matches)}%`),
+                `) ESCAPE '\\')`,
               ],
             }),
           ];
@@ -1890,6 +1917,42 @@ function assertIndexEntry<T>(obj: T): Omit<
 function tableFromOpts(opts: WIPOptions | undefined) {
   return opts?.useWorkInProgressIndex ? 'boxel_index_working' : 'boxel_index';
 }
+
+// The prerendered_html table paired with the boxel_index table `tableFromOpts`
+// selects: the working table mirrors boxel_index_working during an in-progress
+// pass, the production table mirrors boxel_index.
+function prerenderedTableFromOpts(opts: WIPOptions | undefined) {
+  return opts?.useWorkInProgressIndex
+    ? 'prerendered_html_working'
+    : 'prerendered_html';
+}
+
+// Dual-read LEFT JOIN: attaches the prerendered_html row (aliased `ph`) for each
+// boxel_index row (aliased `i`) on their shared (url, realm_url, type) primary
+// key. HTML and markdown reads prefer `ph` and fall back to the boxel_index
+// column when no prerendered row exists — rows written between the backfill
+// migration and the dual-write deploy, or a row deliberately absent from
+// prerendered_html. Being keyed on the primary key the join is 1:1, so it never
+// fans out a `GROUP BY url` grouping. `icon_html` is not dual-read: the icon
+// renders in the index visit and stays on boxel_index.
+function prerenderedJoin(opts: WIPOptions | undefined) {
+  return `LEFT JOIN ${prerenderedTableFromOpts(
+    opts,
+  )} AS ph ON ph.url = i.url AND ph.realm_url = i.realm_url AND ph.type = i.type`;
+}
+
+// Coalesced HTML/markdown reads, appended after a `SELECT i.*` so these win over
+// the same-named boxel_index columns (duplicate result columns resolve to the
+// last one in both the pg and sqlite adapters). Each prefers the prerendered_html
+// value and falls back to boxel_index when the prerendered row is absent.
+// `icon_html` is intentionally excluded — it stays on boxel_index.
+const DUAL_READ_HTML_OVERRIDES =
+  `coalesce(ph.isolated_html, i.isolated_html) AS isolated_html, ` +
+  `coalesce(ph.head_html, i.head_html) AS head_html, ` +
+  `coalesce(ph.atom_html, i.atom_html) AS atom_html, ` +
+  `coalesce(ph.embedded_html, i.embedded_html) AS embedded_html, ` +
+  `coalesce(ph.fitted_html, i.fitted_html) AS fitted_html, ` +
+  `coalesce(ph.markdown, i.markdown) AS markdown`;
 
 // SQLite LIKE treats `%` and `_` as wildcards. With `ESCAPE '\'` we can
 // neutralize user-supplied wildcards by prefixing them (and the escape


### PR DESCRIPTION
Moves every HTML and markdown reader onto the `prerendered_html` channel, with a fallback to the `boxel_index` columns so the transition can't lose data.

## Read path
- **Query engine** (`index-query-engine.ts`): `getInstance` / `getInstances` / `getFile` / `getFiles` / `search` / `searchFiles` LEFT JOIN `prerendered_html` (or `prerendered_html_working`) on the shared `(url, realm_url, type)` key and read each HTML/markdown/deps column as `coalesce(ph.<col>, i.<col>)` — the prerendered rendering wins, the `boxel_index` column is the fallback when no prerendered row exists. `icon_html` stays on `boxel_index` (the icon renders in the index visit).
- **Full-text search**: the `matches` predicate reads `prerendered_html.markdown` behind its GIN index, with the `boxel_index.markdown` fallback guarded by `ph.url IS NULL`. The LEFT JOIN never drops a structured-query row that has no prerendered row, and the count query joins the same way so `matches` totals stay correct.
- **Other readers**: the SSR head / isolated-HTML injection (`index-html-injection.ts`) and the scoped-CSS deps reader (`retrieve-scoped-css.ts`) dual-read the same way.

Staleness is metadata, never a serving gate — the newest rendering that exists is served regardless of its generation.

## Tests
Golden parity tests (`prerendered-html-dual-read-test.ts`) assert the dual-read returns identical results whether a row is served from `prerendered_html` or the `boxel_index` fallback — including `matches` queries and rows deliberately missing from `prerendered_html` — that the read prefers `prerendered_html` when a row exists, and that `matches` membership follows `prerendered_html.markdown`. The realm-server search/prerendering tests that simulated an absent rendering by clearing `boxel_index` now clear the authoritative `prerendered_html` too.

Stacked on the branch that adds the `prerendered_html` tables and index-writer dual-write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnTHph5rM6No4kQzeFezT1
