### PR TITLE
ai-bot: offer command tools contributed by markdown skills 

### DIFF
--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -7303,6 +7303,25 @@ module('markdown skill commands', (hooks) => {
     assert.false(commands[0].requiresApproval);
   });
 
+  test('a command without requiresApproval defaults to approval required', (assert) => {
+    let md = [
+      '---',
+      'name: "My Skill"',
+      'boxel:',
+      '  kind: skill',
+      '  commands:',
+      '    - codeRef:',
+      '        module: "@cardstack/boxel-host/commands/switch-submode"',
+      '        name: "default"',
+      '---',
+      'body',
+    ].join('\n');
+    let { commands } = parseMarkdownSkill(md, {
+      sourceUrl: 'https://realm/skills/my-skill/SKILL.md',
+    } as any);
+    assert.true(commands[0].requiresApproval);
+  });
+
   test('parseMarkdownSkill resolves relative command modules against the skill URL', (assert) => {
     let md = [
       '---',

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_FALLBACK_MODEL_ID,
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 
 import type {
@@ -7246,5 +7247,154 @@ module('markdown skills', () => {
     } as any);
     assert.strictEqual(title, 'SKILL.md');
     assert.strictEqual(body, 'Just instructions.');
+  });
+});
+
+module('markdown skill commands', (hooks) => {
+  let fakeMatrixClient: FakeMatrixClient;
+  let mockResponses: Map<string, { ok: boolean; text: string }>;
+  let originalFetch: any;
+
+  hooks.beforeEach(() => {
+    fakeMatrixClient = new FakeMatrixClient();
+    mockResponses = new Map();
+    originalFetch = (globalThis as any).fetch;
+    (globalThis as any).fetch = async (url: string) => {
+      const response = mockResponses.get(url);
+      if (response) {
+        return {
+          ok: response.ok,
+          status: response.ok ? 200 : 500,
+          text: async () => response.text,
+        };
+      }
+      throw new Error(`No mock response for ${url}`);
+    };
+  });
+
+  hooks.afterEach(() => {
+    (globalThis as any).fetch = originalFetch;
+  });
+
+  const SKILL_MD = [
+    '---',
+    'name: "Boxel Environment"',
+    'description: "env"',
+    'boxel:',
+    '  kind: skill',
+    '  commands:',
+    '    - codeRef:',
+    '        module: "@cardstack/boxel-host/commands/switch-submode"',
+    '        name: "default"',
+    '      requiresApproval: false',
+    '---',
+    '',
+    'Use switch-submode to change modes.',
+  ].join('\n');
+
+  test('parseMarkdownSkill computes the same functionName the host derives', (assert) => {
+    let { commands } = parseMarkdownSkill(SKILL_MD, {
+      sourceUrl: 'https://realm/skills/boxel-environment/SKILL.md',
+    } as any);
+    assert.strictEqual(commands.length, 1);
+    // switch-submode_dd88 is the name the host's buildCommandFunctionName
+    // produces for this code ref (registered prefixes resolve verbatim).
+    assert.strictEqual(commands[0].functionName, 'switch-submode_dd88');
+    assert.false(commands[0].requiresApproval);
+  });
+
+  test('parseMarkdownSkill resolves relative command modules against the skill URL', (assert) => {
+    let md = [
+      '---',
+      'name: "My Skill"',
+      'boxel:',
+      '  kind: skill',
+      '  commands:',
+      '    - codeRef:',
+      '        module: "../../commands/my-command"',
+      '        name: "default"',
+      '---',
+      'body',
+    ].join('\n');
+    let { commands } = parseMarkdownSkill(md, {
+      sourceUrl: 'https://realm/skills/my-skill/SKILL.md',
+    } as any);
+    assert.strictEqual(
+      commands[0].codeRef.module,
+      'https://realm/commands/my-command',
+    );
+  });
+
+  test('getTools offers a command definition matched by a markdown skill', async () => {
+    mockResponses.set('mxc://mock-server/switch-submode-def', {
+      ok: true,
+      text: JSON.stringify({
+        codeRef: {
+          module: '@cardstack/boxel-host/commands/switch-submode',
+          name: 'default',
+        },
+        tool: {
+          type: 'function',
+          function: {
+            name: 'switch-submode_dd88',
+            description: 'Switch between interact and code submodes',
+            parameters: { type: 'object', properties: {} },
+          },
+        },
+      }),
+    });
+
+    const eventList = [
+      {
+        type: APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
+        event_id: 'skills-1',
+        origin_server_ts: 1000,
+        state_key: '',
+        content: {
+          enabledSkillCards: [
+            {
+              sourceUrl: 'https://realm/skills/boxel-environment/SKILL.md',
+              url: 'mxc://mock-server/env-skill',
+              name: 'SKILL.md',
+              contentType: 'text/plain',
+            },
+          ],
+          disabledSkillCards: [],
+          commandDefinitions: [
+            {
+              sourceUrl: 'https://realm/commands/switch-submode',
+              url: 'mxc://mock-server/switch-submode-def',
+              name: 'switch-submode_dd88',
+              contentType: 'text/plain',
+            },
+          ],
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000 },
+        status: EventStatus.SENT,
+      },
+    ] as unknown as DiscreteMatrixEvent[];
+
+    // The card-shaped skill getEnabledSkills produces for this SKILL.md.
+    let { title, body, commands } = parseMarkdownSkill(SKILL_MD, {
+      sourceUrl: 'https://realm/skills/boxel-environment/SKILL.md',
+    } as any);
+    const enabledSkills = [
+      {
+        id: 'https://realm/skills/boxel-environment/SKILL.md',
+        type: 'card',
+        attributes: { title, instructions: body, commands },
+      } as unknown as LooseCardResource,
+    ];
+
+    const tools = await getTools(
+      eventList,
+      enabledSkills,
+      '@aibot:localhost',
+      fakeMatrixClient,
+    );
+    assert.strictEqual(tools.length, 1);
+    assert.strictEqual(tools[0].function.name, 'switch-submode_dd88');
   });
 });

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -7325,6 +7325,28 @@ module('markdown skill commands', (hooks) => {
     );
   });
 
+  test('parseMarkdownSkill resolves root-relative command modules against the skill URL', (assert) => {
+    let md = [
+      '---',
+      'name: "My Skill"',
+      'boxel:',
+      '  kind: skill',
+      '  commands:',
+      '    - codeRef:',
+      '        module: "/commands/my-command"',
+      '        name: "default"',
+      '---',
+      'body',
+    ].join('\n');
+    let { commands } = parseMarkdownSkill(md, {
+      sourceUrl: 'https://realm/skills/my-skill/SKILL.md',
+    } as any);
+    assert.strictEqual(
+      commands[0].codeRef.module,
+      'https://realm/commands/my-command',
+    );
+  });
+
   test('getTools offers a command definition matched by a markdown skill', async () => {
     mockResponses.set('mxc://mock-server/switch-submode-def', {
       ok: true,

--- a/packages/host/app/lib/matrix-classes/message-builder.ts
+++ b/packages/host/app/lib/matrix-classes/message-builder.ts
@@ -6,11 +6,7 @@ import { service } from '@ember/service';
 
 import { TrackedArray } from 'tracked-built-ins';
 
-import {
-  type ResolvedCodeRef,
-  getClass,
-  isCardInstance,
-} from '@cardstack/runtime-common';
+import { type ResolvedCodeRef, getClass } from '@cardstack/runtime-common';
 
 import type { CommandRequest } from '@cardstack/runtime-common/commands';
 import {
@@ -34,6 +30,10 @@ import {
   APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 
+import {
+  getSkillSourceCommands,
+  loadSkillSource,
+} from '@cardstack/host/lib/skill-commands';
 import type { RoomSkill } from '@cardstack/host/resources/room';
 
 import type CommandService from '@cardstack/host/services/command-service';
@@ -52,7 +52,6 @@ import type {
   MatrixEvent as DiscreteMatrixEvent,
   MessageEvent,
 } from 'https://cardstack.com/base/matrix-event';
-import type { Skill } from 'https://cardstack.com/base/skill';
 
 import { Message } from './message';
 import MessageCodePatchResult from './message-code-patch-result';
@@ -362,16 +361,17 @@ export default class MessageBuilder {
       );
     }
 
-    // Find command in skills
+    // Find command in skills. loadSkillSource handles both legacy Skill
+    // cards and markdown skills (commands in boxel.commands frontmatter).
     let skillCommand:
       | { codeRef: ResolvedCodeRef; requiresApproval: boolean }
       | undefined;
     findCommand: for (let skill of this.builderContext.skills) {
-      let skillCard = await this.store.get<Skill>(skill.cardId);
-      if (!skillCard || !isCardInstance(skillCard)) {
+      let source = await loadSkillSource(this.store, skill.cardId);
+      if (!source) {
         continue;
       }
-      for (let candidateSkillCommand of skillCard.commands) {
+      for (let candidateSkillCommand of getSkillSourceCommands(source)) {
         if (commandRequest.name === candidateSkillCommand.functionName) {
           skillCommand = candidateSkillCommand;
           break findCommand;

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -2240,6 +2240,13 @@ export default class StoreService extends Service implements StoreInterface {
         },
       );
       this.setIdentityContext(fileInstance as unknown as FileDef, 'file-meta');
+      // The realm may serve the doc id in canonical prefix form (e.g.
+      // `@cardstack/skills/...`) while the caller asked by URL. Register the
+      // requested id as an alias — mirroring the card path — so later lookups
+      // by either form find this instance instead of silently missing.
+      if (fileMetaDoc.data.id && fileMetaDoc.data.id !== id) {
+        this.store.setFileMeta(id, fileInstance as unknown as FileDef);
+      }
       deferred.fulfill(fileInstance as T);
       return fileInstance as T;
     } catch (error: any) {

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -55,7 +55,10 @@ import {
   DEFAULT_FALLBACK_MODELS,
   DEFAULT_FALLBACK_MODEL_ID,
 } from '../matrix-constants.ts';
-import { decodeCommandRequest } from '../commands.ts';
+import {
+  buildCommandFunctionNameFromResolvedRef,
+  decodeCommandRequest,
+} from '../commands.ts';
 import type { CommandRequest } from '../commands.ts';
 import type { ReasoningEffort } from 'openai/resources/shared';
 import type {
@@ -450,7 +453,7 @@ async function getEnabledSkills(
           // choke on non-JSON. The JSON.parse fallthrough is the legacy
           // pushed-card path; it is removed when the push model is retired.
           if (isMarkdownSkillFile(cardFileDef)) {
-            let { title, body, kind } = parseMarkdownSkill(
+            let { title, body, kind, commands } = parseMarkdownSkill(
               content,
               cardFileDef,
             );
@@ -459,7 +462,7 @@ async function getEnabledSkills(
             }
             return {
               id: cardFileDef.sourceUrl,
-              attributes: { title, instructions: body },
+              attributes: { title, instructions: body, commands },
             };
           }
           return (JSON.parse(content) as LooseSingleCardDocument)?.data;
@@ -488,8 +491,17 @@ export function isMarkdownSkillFile(fileDef: SerializedFileDef): boolean {
   return /\.(md|markdown)$/i.test(fileDef.sourceUrl ?? fileDef.name ?? '');
 }
 
-// Splits a markdown skill into its instruction body, a title, and its
-// declared boxel.kind. The body is everything after the leading
+// A command a markdown skill contributes via its `boxel.commands`
+// frontmatter, with the functionName the host derives for the same code ref —
+// so getTools can match it against the room's uploaded command definitions.
+export interface MarkdownSkillCommand {
+  codeRef: { module: string; name: string };
+  functionName: string;
+  requiresApproval?: boolean;
+}
+
+// Splits a markdown skill into its instruction body, a title, its declared
+// boxel.kind, and its frontmatter commands. The body is everything after the
 // `--- frontmatter ---` block (the frontmatter is metadata, not
 // instructions); the title is the frontmatter `name`, falling back to the
 // file name. Invalid frontmatter YAML degrades to the raw content as body —
@@ -497,10 +509,16 @@ export function isMarkdownSkillFile(fileDef: SerializedFileDef): boolean {
 export function parseMarkdownSkill(
   content: string,
   fileDef: SerializedFileDef,
-): { title: string; body: string; kind?: string } {
+): {
+  title: string;
+  body: string;
+  kind?: string;
+  commands: MarkdownSkillCommand[];
+} {
   let body = content;
   let title: string | undefined;
   let kind: string | undefined;
+  let commands: MarkdownSkillCommand[] = [];
   try {
     let { data, body: parsedBody } = parseFrontmatter(content);
     body = parsedBody;
@@ -514,6 +532,7 @@ export function parseMarkdownSkill(
     if (typeof boxel?.kind === 'string') {
       kind = boxel.kind;
     }
+    commands = markdownSkillCommands(data, fileDef.sourceUrl);
   } catch {
     // Malformed frontmatter: keep the full content as the body.
   }
@@ -521,7 +540,55 @@ export function parseMarkdownSkill(
     let path = fileDef.sourceUrl ?? fileDef.name ?? '';
     title = path.split('/').filter(Boolean).pop() ?? 'Skill';
   }
-  return { title, body: body.trim(), kind };
+  return { title, body: body.trim(), kind, commands };
+}
+
+// Extracts `boxel.commands` from parsed frontmatter and computes each
+// command's functionName the way the host does when it uploads the room's
+// command definitions. Package specifiers (e.g. @cardstack/boxel-host/...)
+// resolve verbatim on the host, so hashing the literal module gives the same
+// name; relative modules resolve against the skill's own URL.
+function markdownSkillCommands(
+  frontmatter: Record<string, unknown>,
+  skillUrl: string | undefined,
+): MarkdownSkillCommand[] {
+  let boxel =
+    frontmatter.boxel &&
+    typeof frontmatter.boxel === 'object' &&
+    !Array.isArray(frontmatter.boxel)
+      ? (frontmatter.boxel as Record<string, unknown>)
+      : undefined;
+  if (!Array.isArray(boxel?.commands)) {
+    return [];
+  }
+  let commands: MarkdownSkillCommand[] = [];
+  for (let entry of boxel.commands) {
+    let codeRef = (entry as { codeRef?: { module?: string; name?: string } })
+      ?.codeRef;
+    if (
+      typeof codeRef?.module !== 'string' ||
+      typeof codeRef?.name !== 'string'
+    ) {
+      continue;
+    }
+    let module = codeRef.module;
+    if (module.startsWith('.') && skillUrl) {
+      try {
+        module = new URL(module, skillUrl).href;
+      } catch {
+        // keep the module as authored; a bad relative ref simply won't match
+      }
+    }
+    let resolvedRef = { module, name: codeRef.name };
+    commands.push({
+      codeRef: resolvedRef,
+      functionName: buildCommandFunctionNameFromResolvedRef(resolvedRef),
+      requiresApproval: Boolean(
+        (entry as { requiresApproval?: unknown }).requiresApproval,
+      ),
+    });
+  }
+  return commands;
 }
 
 export async function getDisabledSkillIds(

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -572,7 +572,9 @@ function markdownSkillCommands(
       continue;
     }
     let module = codeRef.module;
-    if (module.startsWith('.') && skillUrl) {
+    // Match the host's isUrlLike semantics: both `.`- and `/`-prefixed
+    // modules resolve against the skill's own URL.
+    if ((module.startsWith('.') || module.startsWith('/')) && skillUrl) {
       try {
         module = new URL(module, skillUrl).href;
       } catch {

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -497,7 +497,7 @@ export function isMarkdownSkillFile(fileDef: SerializedFileDef): boolean {
 export interface MarkdownSkillCommand {
   codeRef: { module: string; name: string };
   functionName: string;
-  requiresApproval?: boolean;
+  requiresApproval: boolean;
 }
 
 // Splits a markdown skill into its instruction body, a title, its declared
@@ -573,7 +573,12 @@ function markdownSkillCommands(
     }
     let module = codeRef.module;
     // Match the host's isUrlLike semantics: both `.`- and `/`-prefixed
-    // modules resolve against the skill's own URL.
+    // modules resolve against the skill's own URL. Known limitation: the
+    // host hashes relative refs against the skill's canonical document id,
+    // which in a prefix-form realm differs from the room-state sourceUrl we
+    // resolve against — so relative command modules in prefix-form realms
+    // may not match. Package specifiers and absolute URLs (all current
+    // skills) hash identically on both sides.
     if ((module.startsWith('.') || module.startsWith('/')) && skillUrl) {
       try {
         module = new URL(module, skillUrl).href;
@@ -585,9 +590,10 @@ function markdownSkillCommands(
     commands.push({
       codeRef: resolvedRef,
       functionName: buildCommandFunctionNameFromResolvedRef(resolvedRef),
-      requiresApproval: Boolean(
-        (entry as { requiresApproval?: unknown }).requiresApproval,
-      ),
+      // Missing means approval required, matching how the host treats an
+      // absent requiresApproval on a skill command.
+      requiresApproval:
+        (entry as { requiresApproval?: unknown }).requiresApproval !== false,
     });
   }
   return commands;

--- a/packages/runtime-common/commands.ts
+++ b/packages/runtime-common/commands.ts
@@ -149,13 +149,22 @@ export function buildCommandFunctionName(
     virtualNetwork,
   ) as ResolvedCodeRef;
 
-  const hashed = simpleHash(
-    `${absoluteCodeRef.module}#${absoluteCodeRef.name}`,
-  );
-  let name =
-    absoluteCodeRef.name === 'default'
-      ? friendlyModuleName(absoluteCodeRef.module)
-      : absoluteCodeRef.name;
+  return buildCommandFunctionNameFromResolvedRef(absoluteCodeRef);
+}
+
+// The name-construction half of buildCommandFunctionName, for callers that
+// already hold an absolute code ref (registered package prefixes resolve
+// verbatim, so e.g. ai-bot can produce identical names without a
+// VirtualNetwork).
+export function buildCommandFunctionNameFromResolvedRef(ref: {
+  module: string;
+  name: string;
+}): string {
+  if (!ref?.module || !ref?.name) {
+    return '';
+  }
+  const hashed = simpleHash(`${ref.module}#${ref.name}`);
+  let name = ref.name === 'default' ? friendlyModuleName(ref.module) : ref.name;
   return `${name}_${hashed.slice(0, 4)}`;
 }
 


### PR DESCRIPTION
Markdown skills can declare commands in frontmatter (`boxel.commands`), but they didn't work — the bot and the host both only understood commands on card skills. This blocks converting skills like Boxel Environment (21 commands) to markdown.

Three fixes:

- **Bot offers the tools.** `getTools` now reads command claims from markdown-skill frontmatter, computing each command's hashed name (`switch-submode_dd88`) the same way the host does — pinned by test.
- **Host executes them.** The tool-call → command-class lookup now uses the helpers that handle both skill kinds, instead of loading every skill as a card (which failed for markdown and errored with "No command for the name … was found").
- **Panel shows the skill.** Since #5390 the realm returns ids like `@cardstack/skills/...` while rooms store URLs; the file-meta loader only registered the returned id, so enabled markdown skills vanished from the skills panel. It now also registers the requested id, like the card loader does.

Verified end to end with a test markdown skill: tool offered, auto-executed, result returned.
