### PR TITLE
Match id/url filters in canonical RRI form client-side

### DIFF
--- a/packages/host/tests/unit/instance-filter-matcher-test.ts
+++ b/packages/host/tests/unit/instance-filter-matcher-test.ts
@@ -288,6 +288,40 @@ module('Unit | instance-filter-matcher', function (hooks) {
     );
   });
 
+  // -- reference (id/url) canonical-RRI tolerance -----------------------------
+
+  test('id filter matches a URL-form instance against a prefix-form value', function (assert) {
+    let { mango, ringo } = cards;
+    // The cards' ids are URL form (`http://test-realm/test/mango`). Register a
+    // realm-prefix mapping so the same realm also has a canonical RRI spelling.
+    api.virtualNetwork.addRealmMapping('@test/cards/', testRealmURL);
+
+    // A filter value in prefix-RRI form must match the URL-form instance id —
+    // the client counterpart of the server's index-side tolerance (CS-11733).
+    assert.strictEqual(
+      match(mango, { on: personRef, in: { id: ['@test/cards/mango'] } }),
+      'match',
+      'prefix-form `in` value matches the URL-form id',
+    );
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { id: '@test/cards/mango' } }),
+      'match',
+      'prefix-form `eq` value matches the URL-form id',
+    );
+    // A different card's prefix-form id must not match.
+    assert.strictEqual(
+      match(ringo, { on: personRef, in: { id: ['@test/cards/mango'] } }),
+      'no-match',
+      'a non-matching prefix-form id is still rejected',
+    );
+    // The URL form continues to match (no regression).
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { id: `${testRealmURL}mango` } }),
+      'match',
+      'URL-form value still matches the URL-form id',
+    );
+  });
+
   // -- contains ---------------------------------------------------------------
 
   test('contains is a case-insensitive substring match', function (assert) {

--- a/packages/host/tests/unit/instance-filter-matcher-test.ts
+++ b/packages/host/tests/unit/instance-filter-matcher-test.ts
@@ -296,8 +296,8 @@ module('Unit | instance-filter-matcher', function (hooks) {
     // realm-prefix mapping so the same realm also has a canonical RRI spelling.
     api.virtualNetwork.addRealmMapping('@test/cards/', testRealmURL);
 
-    // A prefix-RRI `in` value must match the URL-form instance id — the client
-    // counterpart of the server's index-side `in` tolerance (CS-11733).
+    // A prefix-RRI `in` value must match the URL-form instance id — the
+    // client-side counterpart of the index query engine's `in` tolerance.
     assert.strictEqual(
       match(mango, { on: personRef, in: { id: ['@test/cards/mango'] } }),
       'match',

--- a/packages/host/tests/unit/instance-filter-matcher-test.ts
+++ b/packages/host/tests/unit/instance-filter-matcher-test.ts
@@ -290,23 +290,18 @@ module('Unit | instance-filter-matcher', function (hooks) {
 
   // -- reference (id/url) canonical-RRI tolerance -----------------------------
 
-  test('id filter matches a URL-form instance against a prefix-form value', function (assert) {
+  test('in filter matches a URL-form instance against a prefix-form value', function (assert) {
     let { mango, ringo } = cards;
     // The cards' ids are URL form (`http://test-realm/test/mango`). Register a
     // realm-prefix mapping so the same realm also has a canonical RRI spelling.
     api.virtualNetwork.addRealmMapping('@test/cards/', testRealmURL);
 
-    // A filter value in prefix-RRI form must match the URL-form instance id —
-    // the client counterpart of the server's index-side tolerance (CS-11733).
+    // A prefix-RRI `in` value must match the URL-form instance id — the client
+    // counterpart of the server's index-side `in` tolerance (CS-11733).
     assert.strictEqual(
       match(mango, { on: personRef, in: { id: ['@test/cards/mango'] } }),
       'match',
       'prefix-form `in` value matches the URL-form id',
-    );
-    assert.strictEqual(
-      match(mango, { on: personRef, eq: { id: '@test/cards/mango' } }),
-      'match',
-      'prefix-form `eq` value matches the URL-form id',
     );
     // A different card's prefix-form id must not match.
     assert.strictEqual(
@@ -316,9 +311,23 @@ module('Unit | instance-filter-matcher', function (hooks) {
     );
     // The URL form continues to match (no regression).
     assert.strictEqual(
+      match(mango, { on: personRef, in: { id: [`${testRealmURL}mango`] } }),
+      'match',
+      'URL-form `in` value still matches the URL-form id',
+    );
+    // `eq` on a reference field keeps EXACT semantics, mirroring the server's
+    // `fieldEqFilter` (tolerance is applied to `in` only). A prefix-form `eq`
+    // value therefore does NOT match a URL-form id — matching a tolerant `eq`
+    // here would diverge from the authoritative search response.
+    assert.strictEqual(
+      match(mango, { on: personRef, eq: { id: '@test/cards/mango' } }),
+      'no-match',
+      'prefix-form `eq` value does not match (eq stays exact)',
+    );
+    assert.strictEqual(
       match(mango, { on: personRef, eq: { id: `${testRealmURL}mango` } }),
       'match',
-      'URL-form value still matches the URL-form id',
+      'exact URL-form `eq` value matches',
     );
   });
 

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -48,6 +48,7 @@ import {
   type RangeFilter,
   RANGE_OPERATORS,
   isCardTypeFilter,
+  isReferenceFilterField,
 } from './query.ts';
 import type { SerializedError } from './error.ts';
 import type { DBAdapter } from './db.ts';
@@ -1123,16 +1124,11 @@ export class IndexQueryEngine {
   // strings or URLs and whose `in` filter is an exact string comparison —
   // those are matched exactly as given, gaining no extra normalized spellings,
   // so exact semantics are preserved for non-reference fields.
-  private isReferenceFilterField(key: string): boolean {
-    let leaf = key.split('.').pop();
-    return leaf === 'id' || leaf === 'url';
-  }
-
   private expandReferenceFilterValues(
     key: string,
     values: JSONTypes.Value[],
   ): JSONTypes.Value[] {
-    if (!this.isReferenceFilterField(key)) {
+    if (!isReferenceFilterField(key)) {
       return values;
     }
     let expanded: JSONTypes.Value[] = [];

--- a/packages/runtime-common/instance-filter-matcher.ts
+++ b/packages/runtime-common/instance-filter-matcher.ts
@@ -301,8 +301,8 @@ function referenceForms(
 
 // Compare a resolved leaf value against a formatted filter value. For reference
 // leaves (`id` / `url`) the comparison is spelling-tolerant: a card whose id is
-// stored in URL form matches a filter value in canonical RRI (prefix) form, and
-// vice versa. Non-reference leaves use exact equality, as before.
+// in URL form matches a filter value in canonical RRI (prefix) form, and vice
+// versa. Non-reference leaves use exact equality.
 function leafMatches(
   leafValue: unknown,
   filterValue: unknown,

--- a/packages/runtime-common/instance-filter-matcher.ts
+++ b/packages/runtime-common/instance-filter-matcher.ts
@@ -9,6 +9,7 @@ import {
   isMatchesFilter,
   isNotFilter,
   isRangeFilter,
+  isReferenceFilterField,
   type Filter,
   type RangeFilterValue,
   type RangeOperator,
@@ -269,15 +270,6 @@ function resolvePath(
   return { values, leafField, sawUnresolvable };
 }
 
-// A filter path whose leaf is a card/file reference (`id` / `url`). Values on
-// these paths are compared with canonical-RRI tolerance below, mirroring the
-// server's `expandReferenceFilterValues` (index-query-engine.ts) which matches
-// a reference filter value against every equivalent spelling.
-function isReferenceLeaf(path: string): boolean {
-  let leaf = path.split('.').pop();
-  return leaf === 'id' || leaf === 'url';
-}
-
 // All equivalent spellings (RRI-prefix / real-URL / virtual-alias) of a
 // reference value. A registered-prefix RRI is first resolved to its real URL so
 // `equivalentURLForms` can enumerate the set; anything else is expanded as-is.
@@ -316,7 +308,7 @@ function leafMatches(
     return true;
   }
   if (
-    isReferenceLeaf(path) &&
+    isReferenceFilterField(path) &&
     typeof leafValue === 'string' &&
     typeof filterValue === 'string'
   ) {

--- a/packages/runtime-common/instance-filter-matcher.ts
+++ b/packages/runtime-common/instance-filter-matcher.ts
@@ -270,9 +270,13 @@ function resolvePath(
   return { values, leafField, sawUnresolvable };
 }
 
-// All equivalent spellings (RRI-prefix / real-URL / virtual-alias) of a
-// reference value. A registered-prefix RRI is first resolved to its real URL so
-// `equivalentURLForms` can enumerate the set; anything else is expanded as-is.
+// Equivalent spellings of a reference value, mirroring the index engine's
+// `expandReferenceFilterValues` exactly: match the value as given by default,
+// and expand to the full RRI / real-URL / virtual-alias set ONLY for a
+// registered-prefix RRI. URL-form values (and ordinary strings on an `id`/`url`
+// path) stay exact — expanding them would let client reconciliation match a
+// virtual/RRI spelling the server, which only expands prefixes, would not
+// return.
 function referenceForms(
   value: unknown,
   virtualNetwork: VirtualNetwork,
@@ -281,15 +285,16 @@ function referenceForms(
     return [];
   }
   let forms = new Set<string>([value]);
-  try {
-    let url = virtualNetwork.isRegisteredPrefix(value)
-      ? virtualNetwork.toURL(value).href
-      : value;
-    for (let form of virtualNetwork.equivalentURLForms(url)) {
-      forms.add(form);
+  if (virtualNetwork.isRegisteredPrefix(value)) {
+    try {
+      for (let form of virtualNetwork.equivalentURLForms(
+        virtualNetwork.toURL(value).href,
+      )) {
+        forms.add(form);
+      }
+    } catch {
+      // Unresolvable prefix — match the value as given.
     }
-  } catch {
-    // Unresolvable (e.g. a bare local id or an unmapped prefix) — compare as-is.
   }
   return [...forms];
 }
@@ -335,8 +340,13 @@ function matchEq(
     return existential(values, sawUnresolvable, (lv) => lv == null);
   }
   let formatted = formatValue(leafField, value, api);
+  // Exact match, including for reference (`id`/`url`) leaves: the server's
+  // `fieldEqFilter` deliberately keeps `eq` exact (so a singular `.id` eq is
+  // served by the `@>` GIN path) and applies canonical-RRI tolerance to `in`
+  // filters only. Mirror that here — tolerant `eq` would diverge from the
+  // authoritative search response during client reconciliation.
   return existential(values, sawUnresolvable, (leafValue) =>
-    leafMatches(leafValue, formatted, path, api.virtualNetwork),
+    isEqual(leafValue, formatted),
   );
 }
 

--- a/packages/runtime-common/instance-filter-matcher.ts
+++ b/packages/runtime-common/instance-filter-matcher.ts
@@ -269,6 +269,65 @@ function resolvePath(
   return { values, leafField, sawUnresolvable };
 }
 
+// A filter path whose leaf is a card/file reference (`id` / `url`). Values on
+// these paths are compared with canonical-RRI tolerance below, mirroring the
+// server's `expandReferenceFilterValues` (index-query-engine.ts) which matches
+// a reference filter value against every equivalent spelling.
+function isReferenceLeaf(path: string): boolean {
+  let leaf = path.split('.').pop();
+  return leaf === 'id' || leaf === 'url';
+}
+
+// All equivalent spellings (RRI-prefix / real-URL / virtual-alias) of a
+// reference value. A registered-prefix RRI is first resolved to its real URL so
+// `equivalentURLForms` can enumerate the set; anything else is expanded as-is.
+function referenceForms(
+  value: unknown,
+  virtualNetwork: VirtualNetwork,
+): string[] {
+  if (typeof value !== 'string') {
+    return [];
+  }
+  let forms = new Set<string>([value]);
+  try {
+    let url = virtualNetwork.isRegisteredPrefix(value)
+      ? virtualNetwork.toURL(value).href
+      : value;
+    for (let form of virtualNetwork.equivalentURLForms(url)) {
+      forms.add(form);
+    }
+  } catch {
+    // Unresolvable (e.g. a bare local id or an unmapped prefix) — compare as-is.
+  }
+  return [...forms];
+}
+
+// Compare a resolved leaf value against a formatted filter value. For reference
+// leaves (`id` / `url`) the comparison is spelling-tolerant: a card whose id is
+// stored in URL form matches a filter value in canonical RRI (prefix) form, and
+// vice versa. Non-reference leaves use exact equality, as before.
+function leafMatches(
+  leafValue: unknown,
+  filterValue: unknown,
+  path: string,
+  virtualNetwork: VirtualNetwork,
+): boolean {
+  if (isEqual(leafValue, filterValue)) {
+    return true;
+  }
+  if (
+    isReferenceLeaf(path) &&
+    typeof leafValue === 'string' &&
+    typeof filterValue === 'string'
+  ) {
+    let leafForms = new Set(referenceForms(leafValue, virtualNetwork));
+    return referenceForms(filterValue, virtualNetwork).some((form) =>
+      leafForms.has(form),
+    );
+  }
+  return false;
+}
+
 // -- per-operator predicates -------------------------------------------------
 
 function matchEq(
@@ -285,7 +344,7 @@ function matchEq(
   }
   let formatted = formatValue(leafField, value, api);
   return existential(values, sawUnresolvable, (leafValue) =>
-    isEqual(leafValue, formatted),
+    leafMatches(leafValue, formatted, path, api.virtualNetwork),
   );
 }
 
@@ -309,7 +368,9 @@ function matchIn(
     sawUnresolvable,
     (leafValue) =>
       (hasNull && leafValue == null) ||
-      formatted.some((fv) => isEqual(leafValue, fv)),
+      formatted.some((fv) =>
+        leafMatches(leafValue, fv, path, api.virtualNetwork),
+      ),
   );
 }
 

--- a/packages/runtime-common/instance-filter-matcher.ts
+++ b/packages/runtime-common/instance-filter-matcher.ts
@@ -315,7 +315,13 @@ function leafMatches(
   if (
     isReferenceFilterField(path) &&
     typeof leafValue === 'string' &&
-    typeof filterValue === 'string'
+    typeof filterValue === 'string' &&
+    // Only a registered-prefix RRI expands to alternate spellings; when neither
+    // side is one, `referenceForms` returns each value unchanged and the sets
+    // can only intersect on an exact match, which `isEqual` above already ruled
+    // out. Skip the allocation in that (common) case.
+    (virtualNetwork.isRegisteredPrefix(leafValue) ||
+      virtualNetwork.isRegisteredPrefix(filterValue))
   ) {
     let leafForms = new Set(referenceForms(leafValue, virtualNetwork));
     return referenceForms(filterValue, virtualNetwork).some((form) =>

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -187,6 +187,16 @@ export function isMatchesFilter(filter: Filter): filter is MatchesFilter {
   return (filter as MatchesFilter).matches !== undefined;
 }
 
+// A filter path whose leaf is a card/file reference (`id` / `url`). Values on
+// these paths are compared with canonical-RRI tolerance (a reference matches
+// any of its equivalent RRI / real-URL / virtual-alias spellings) rather than
+// by exact string equality — applied both index-side (the query engine's
+// `expandReferenceFilterValues`) and client-side (the instance-filter matcher).
+export function isReferenceFilterField(path: string): boolean {
+  let leaf = path.split('.').pop();
+  return leaf === 'id' || leaf === 'url';
+}
+
 export function buildQueryParamValue(query: Query): string {
   return qs.stringify(query, { strictNullHandling: true, encode: false });
 }

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -187,11 +187,12 @@ export function isMatchesFilter(filter: Filter): filter is MatchesFilter {
   return (filter as MatchesFilter).matches !== undefined;
 }
 
-// A filter path whose leaf is a card/file reference (`id` / `url`). Values on
-// these paths are compared with canonical-RRI tolerance (a reference matches
-// any of its equivalent RRI / real-URL / virtual-alias spellings) rather than
-// by exact string equality — applied both index-side (the query engine's
-// `expandReferenceFilterValues`) and client-side (the instance-filter matcher).
+// True when a filter path's leaf is a card/file reference (`id` / `url`). Such
+// leaves get canonical-RRI tolerance in `in` filters — a registered-prefix
+// value also matches its equivalent real-URL / virtual-alias spellings — while
+// `eq` and other operators stay exact. Both the index query engine and the
+// client-side instance-filter matcher key that tolerance off this predicate so
+// they agree on which paths it covers.
 export function isReferenceFilterField(path: string): boolean {
   let leaf = path.split('.').pop();
   return leaf === 'id' || leaf === 'url';


### PR DESCRIPTION
This is the client-side version of #5356. It’s a step toward card/file-reference pills resolution without a virtual network.