### PR TITLE
Single-instance card+html GET with a composite generation ETag

### DIFF
--- a/packages/realm-server/tests/card-html-endpoints-test.ts
+++ b/packages/realm-server/tests/card-html-endpoints-test.ts
@@ -1,0 +1,305 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import type { Test, SuperTest } from 'supertest';
+import {
+  DEFAULT_HTML_QUERY,
+  fieldsetFromParam,
+  rri,
+  type HtmlResource,
+  type Realm,
+} from '@cardstack/runtime-common';
+import {
+  setupPermissionedRealmCached,
+  withRealmPath,
+  type RealmRequest,
+} from './helpers/index.ts';
+
+// The single-instance card+html / file-meta+html GET (the single-instance
+// counterpart to `_search`): one `entry` sourced by URL, carrying the selected
+// rendering (`html`) + the `item` serialization, guarded by a composite ETag
+// that encodes both the index-data generation and the rendering's
+// generation-or-absence.
+module(basename(import.meta.filename), function () {
+  module('Realm-specific Endpoints | card+html GET', function (hooks) {
+    let realmURL = new URL('http://127.0.0.1:4444/test/');
+    let testRealm: Realm;
+    let realmHref: string;
+    let request: RealmRequest;
+
+    function onRealmSetup(args: {
+      testRealm: Realm;
+      request: SuperTest<Test>;
+    }) {
+      testRealm = args.testRealm;
+      realmHref = new URL(testRealm.url).href;
+      request = withRealmPath(args.request, realmURL);
+    }
+
+    setupPermissionedRealmCached(hooks, {
+      realmURL,
+      permissions: { '*': ['read'] },
+      fileSystem: {
+        'person.gts': `
+          import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+          import StringField from "https://cardstack.com/base/string";
+
+          export class Person extends CardDef {
+            @field firstName = contains(StringField);
+            static embedded = class Embedded extends Component<typeof this> {
+              <template>
+                Embedded Card Person: <@fields.firstName/>
+              </template>
+            }
+            static fitted = class Fitted extends Component<typeof this> {
+              <template>
+                Fitted Card Person: <@fields.firstName/>
+
+                <style scoped>
+                  .border { border: 1px solid red; }
+                </style>
+              </template>
+            }
+          }
+        `,
+        'john.json': {
+          data: {
+            attributes: { firstName: 'John' },
+            meta: {
+              adoptsFrom: { module: rri('./person'), name: 'Person' },
+            },
+          },
+        },
+        'hello.md': '# Hello from FileDef content',
+      },
+      onRealmSetup,
+    });
+
+    function cardHtml(path: string) {
+      return request.get(path).set('Accept', 'application/vnd.card+html');
+    }
+    function fileMetaHtml(path: string) {
+      return request
+        .get(path)
+        .set('Accept', 'application/vnd.card.file-meta+html');
+    }
+    function htmlResourceIn(body: any, id: string): HtmlResource | undefined {
+      return body.included?.find(
+        (resource: any) => resource.type === 'html' && resource.id === id,
+      );
+    }
+    // The response is a JSON:API document served under the negotiated
+    // `+html` media type, so superagent (which only auto-parses `+json`)
+    // leaves `response.body` empty — parse the raw text ourselves.
+    function bodyOf(response: { text: string }): any {
+      return JSON.parse(response.text);
+    }
+
+    // ---- engine: searchEntry (the reshaped single-instance projection) ----
+
+    test('searchEntry returns one entry unwrapped to a single-resource document', async function (assert) {
+      let doc = await testRealm.realmIndexQueryEngine.searchEntry(
+        new URL(`${realmHref}john.json`),
+        {
+          htmlQuery: DEFAULT_HTML_QUERY,
+          fieldset: fieldsetFromParam(undefined),
+          kind: 'instance',
+        },
+      );
+      assert.ok(doc, 'the entry resolves');
+      assert.false(Array.isArray(doc!.data), 'data is a single resource');
+      assert.strictEqual(doc!.data.id, `${realmHref}john`);
+      assert.strictEqual(
+        typeof doc!.data.meta?.generation,
+        'number',
+        'the entry carries its index-data generation',
+      );
+      assert.strictEqual(
+        doc!.data.relationships.html?.data.length,
+        1,
+        'the default fitted rendering is linked',
+      );
+    });
+
+    test('searchEntry returns undefined for a URL with no index row', async function (assert) {
+      let doc = await testRealm.realmIndexQueryEngine.searchEntry(
+        new URL(`${realmHref}does-not-exist.json`),
+        {
+          htmlQuery: DEFAULT_HTML_QUERY,
+          fieldset: fieldsetFromParam(undefined),
+          kind: 'instance',
+        },
+      );
+      assert.strictEqual(doc, undefined);
+    });
+
+    // ---- HTTP: the content-negotiated GET ----
+
+    test('serves one entry with its fitted rendering + a composite ETag', async function (assert) {
+      let response = await cardHtml('/john');
+      assert.strictEqual(response.status, 200, `HTTP 200: ${response.text}`);
+      assert.strictEqual(
+        (response.get('content-type') ?? '').split(';')[0],
+        'application/vnd.card+html',
+      );
+      let { data, included } = bodyOf(response);
+      assert.strictEqual(
+        data.id,
+        `${realmHref}john`,
+        'entry id is the card URL',
+      );
+      assert.strictEqual(data.type, 'entry');
+      assert.strictEqual(
+        data.relationships.html.data.length,
+        1,
+        'the fitted rendering is linked',
+      );
+      let html = htmlResourceIn(
+        bodyOf(response),
+        data.relationships.html.data[0].id,
+      );
+      assert.ok(html, 'the html rendering rides in included');
+      assert.true(
+        (html!.attributes.html ?? '')
+          .replace(/\s+/g, ' ')
+          .includes('Fitted Card Person: John'),
+        'the fitted markup is the requested rendering',
+      );
+      assert.ok(
+        included.some((r: any) => r.type === 'css'),
+        'the rendering ships its scoped css',
+      );
+      assert.ok(
+        included.some((r: any) => r.type === 'icon'),
+        'the card-type icon rides in included',
+      );
+
+      // The composite ETag: <indexGeneration>:<htmlGeneration>. Both channels
+      // are fresh in a from-scratch index, so both are present (never `none`).
+      let etag = response.get('etag') ?? '';
+      assert.true(
+        /^"\d+:\d+"$/.test(etag),
+        `ETag encodes both generations, got ${etag}`,
+      );
+      assert.strictEqual(
+        etag,
+        `"${data.meta.generation}:${html!.meta!.generation}"`,
+        'the ETag pairs the entry generation with its rendering generation',
+      );
+    });
+
+    test('If-None-Match matching the composite state → 304', async function (assert) {
+      let first = await cardHtml('/john');
+      let etag = first.get('etag') ?? '';
+      assert.true(Boolean(etag), 'a validator is emitted');
+
+      let revalidated = await cardHtml('/john').set('If-None-Match', etag);
+      assert.strictEqual(
+        revalidated.status,
+        304,
+        '304 on a matching validator',
+      );
+      assert.strictEqual(
+        revalidated.get('etag'),
+        etag,
+        'the 304 echoes the validator',
+      );
+
+      let stale = await cardHtml('/john').set('If-None-Match', '"0:0"');
+      assert.strictEqual(
+        stale.status,
+        200,
+        'a non-matching validator falls through to a fresh 200',
+      );
+    });
+
+    test('?format= selects the rendering', async function (assert) {
+      let response = await cardHtml('/john?format=embedded');
+      assert.strictEqual(response.status, 200);
+      let { data } = bodyOf(response);
+      let html = htmlResourceIn(
+        bodyOf(response),
+        data.relationships.html.data[0].id,
+      );
+      assert.strictEqual(html!.attributes.format, 'embedded');
+      assert.true(
+        (html!.attributes.html ?? '')
+          .replace(/\s+/g, ' ')
+          .includes('Embedded Card Person: John'),
+        'the embedded markup is served',
+      );
+    });
+
+    test('?fields=item serves the item alone with a rendering-less ETag', async function (assert) {
+      let response = await cardHtml('/john?fields=item');
+      assert.strictEqual(response.status, 200);
+      let { data, included } = bodyOf(response);
+      assert.strictEqual(
+        data.relationships.html,
+        undefined,
+        'no html branch when only item is requested',
+      );
+      assert.deepEqual(data.relationships.item, {
+        data: { type: 'card', id: `${realmHref}john` },
+      });
+      assert.ok(
+        included.some(
+          (r: any) => r.type === 'card' && r.id === `${realmHref}john`,
+        ),
+        'the card item rides in included',
+      );
+      let etag = response.get('etag') ?? '';
+      assert.true(
+        /^"\d+:none"$/.test(etag),
+        `an item-only response depends only on the index channel, got ${etag}`,
+      );
+    });
+
+    test('?fields=html,item pins both branches', async function (assert) {
+      let response = await cardHtml('/john?fields=html,item');
+      assert.strictEqual(response.status, 200);
+      let { data } = bodyOf(response);
+      assert.strictEqual(data.relationships.html.data.length, 1);
+      assert.deepEqual(data.relationships.item, {
+        data: { type: 'card', id: `${realmHref}john` },
+      });
+    });
+
+    test('an invalid ?format= is a 400 invalid-render, not a 500', async function (assert) {
+      let response = await cardHtml('/john?format=nonsense');
+      assert.strictEqual(response.status, 400);
+      assert.ok(
+        String(response.body?.errors?.[0] ?? response.text).length > 0,
+        'the response carries an error message',
+      );
+    });
+
+    test('a URL with no index row → 404', async function (assert) {
+      let response = await cardHtml('/does-not-exist');
+      assert.strictEqual(response.status, 404);
+    });
+
+    test('the file counterpart serves a file entry by URL', async function (assert) {
+      let response = await fileMetaHtml('/hello.md');
+      assert.strictEqual(response.status, 200, `HTTP 200: ${response.text}`);
+      assert.strictEqual(
+        (response.get('content-type') ?? '').split(';')[0],
+        'application/vnd.card.file-meta+html',
+      );
+      let { data } = bodyOf(response);
+      assert.strictEqual(
+        data.id,
+        `${realmHref}hello.md`,
+        'entry id is the file URL',
+      );
+      assert.strictEqual(data.type, 'entry');
+      // A file renders natively; whichever branch it resolves, the ETag pairs
+      // the two channels (a rendering → `<gen>:<gen>`, else `<gen>:none`).
+      let etag = response.get('etag') ?? '';
+      assert.true(
+        /^"\d+:(\d+|none)"$/.test(etag),
+        `the file entry carries a composite ETag, got ${etag}`,
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/card-html-endpoints-test.ts
+++ b/packages/realm-server/tests/card-html-endpoints-test.ts
@@ -248,10 +248,13 @@ module(basename(import.meta.filename), function () {
         ),
         'the card item rides in included',
       );
+      // An item carries `meta.realmInfo` (which can change without a reindex),
+      // so an item-bearing response folds the realm-info hash in as a third
+      // segment on top of the `<index>:none` composite.
       let etag = response.get('etag') ?? '';
       assert.true(
-        /^"\d+:none"$/.test(etag),
-        `an item-only response depends only on the index channel, got ${etag}`,
+        /^"\d+:none:[^:"]+"$/.test(etag),
+        `an item response has no rendering channel + a realm-info segment, got ${etag}`,
       );
     });
 
@@ -294,10 +297,11 @@ module(basename(import.meta.filename), function () {
       );
       assert.strictEqual(data.type, 'entry');
       // A file renders natively; whichever branch it resolves, the ETag pairs
-      // the two channels (a rendering → `<gen>:<gen>`, else `<gen>:none`).
+      // the two channels (a rendering → `<gen>:<gen>`, else `<gen>:none`), plus
+      // a realm-info segment when it falls back to its item.
       let etag = response.get('etag') ?? '';
       assert.true(
-        /^"\d+:(\d+|none)"$/.test(etag),
+        /^"\d+:(\d+|none)(:[^:"]+)?"$/.test(etag),
         `the file entry carries a composite ETag, got ${etag}`,
       );
     });

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -220,6 +220,7 @@ const ALL_TEST_FILES: string[] = [
   './billing-test',
   './card-dependencies-endpoint-test',
   './card-endpoints-test',
+  './card-html-endpoints-test',
   './card-source-endpoints-test',
   './cpu-profiler-affinity-gate-test',
   './definition-lookup-test',

--- a/packages/realm-server/tests/search-entry-test.ts
+++ b/packages/realm-server/tests/search-entry-test.ts
@@ -347,6 +347,26 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('empty params mean unspecified, consistent with an omitted fields param', function (assert) {
+      // An empty `?format=` / `?renderType=` is "unspecified" (like an omitted
+      // param), not malformed — the universal query-string convention, and the
+      // same way an empty `?fields=` resolves to the default.
+      assert.deepEqual(htmlQueryFromParams({ format: '' }), {
+        eq: { format: 'fitted' },
+      });
+      assert.deepEqual(
+        htmlQueryFromParams({ format: 'atom', renderType: '' }),
+        {
+          eq: { format: 'atom' },
+        },
+      );
+      assert.deepEqual(fieldsetFromParam(''), {
+        html: true,
+        item: { kind: 'none' },
+        itemAsFallback: true,
+      });
+    });
+
     test('an invalid format is rejected as an invalid-render request', function (assert) {
       assert.throws(
         () => htmlQueryFromParams({ format: 'nonsense' }),

--- a/packages/realm-server/tests/search-entry-test.ts
+++ b/packages/realm-server/tests/search-entry-test.ts
@@ -6,6 +6,8 @@ import {
   buildIconResource,
   buildEntryResource,
   buildSparseItemResource,
+  fieldsetFromParam,
+  htmlQueryFromParams,
   htmlResourceId,
   cssResourceId,
   htmlQueryHasRenderTypePredicate,
@@ -320,6 +322,80 @@ module(basename(import.meta.filename), function () {
         parseError({ sort: [{ by: 'item.title', on: authorRef }] }).code,
         'invalid-query',
         'sort anchor is addressed as item.on',
+      );
+    });
+  });
+
+  // The single-instance GET's query-string surface: `?format=` / `?renderType=`
+  // → an htmlQuery, `?fields=` → a fieldset. The same HtmlQuery /
+  // SearchEntryFieldset the wire body produces, sourced from the URL.
+  module('single-instance query params', function () {
+    test('format defaults to fitted; an explicit format is honored', function (assert) {
+      assert.deepEqual(htmlQueryFromParams({}), { eq: { format: 'fitted' } });
+      assert.deepEqual(htmlQueryFromParams({ format: 'embedded' }), {
+        eq: { format: 'embedded' },
+      });
+    });
+
+    test('a renderType param is parsed into the eq leaf alongside the format', function (assert) {
+      assert.deepEqual(
+        htmlQueryFromParams({
+          format: 'fitted',
+          renderType: `${realmURL}author/Author`,
+        }),
+        { eq: { format: 'fitted', renderType: authorRef } },
+      );
+    });
+
+    test('an invalid format is rejected as an invalid-render request', function (assert) {
+      assert.throws(
+        () => htmlQueryFromParams({ format: 'nonsense' }),
+        (e: any) =>
+          e instanceof SearchRequestError && e.code === 'invalid-render',
+      );
+    });
+
+    test('a renderType with no <module>/<name> separator is rejected', function (assert) {
+      assert.throws(
+        () => htmlQueryFromParams({ renderType: 'noseparator' }),
+        (e: any) =>
+          e instanceof SearchRequestError && e.code === 'invalid-render',
+      );
+    });
+
+    test('an absent fields param is the default resolution policy', function (assert) {
+      for (let fields of [undefined, null, '']) {
+        assert.deepEqual(
+          fieldsetFromParam(fields),
+          { html: true, item: { kind: 'none' }, itemAsFallback: true },
+          `fields=${JSON.stringify(fields)} → default`,
+        );
+      }
+    });
+
+    test('fields=html / item / html,item pin the branches (no fallback)', function (assert) {
+      assert.deepEqual(fieldsetFromParam('html'), {
+        html: true,
+        item: { kind: 'none' },
+        itemAsFallback: false,
+      });
+      assert.deepEqual(fieldsetFromParam('item'), {
+        html: false,
+        item: { kind: 'full' },
+        itemAsFallback: false,
+      });
+      assert.deepEqual(fieldsetFromParam('html,item'), {
+        html: true,
+        item: { kind: 'full' },
+        itemAsFallback: false,
+      });
+    });
+
+    test('an unknown fields entry is rejected as an invalid query', function (assert) {
+      assert.throws(
+        () => fieldsetFromParam('html,bogus'),
+        (e: any) =>
+          e instanceof SearchRequestError && e.code === 'invalid-query',
       );
     });
   });

--- a/packages/runtime-common/document-types.ts
+++ b/packages/runtime-common/document-types.ts
@@ -48,6 +48,16 @@ export interface EntryCollectionDocument {
   };
 }
 
+// The single-instance entry response (the card+html / file-meta+html GET): one
+// `entry` sourced by URL rather than by a query, with everything it composes
+// riding in `included`. The collection's document-level `meta` (page total,
+// htmlQuery echo) drops away — the single `entry` carries its own
+// `meta.generation`, and the caller named the format/renderType in the request.
+export interface EntrySingleDocument {
+  data: EntryResource;
+  included?: EntryIncludedResource[];
+}
+
 // The public-API name for the raw entry wire format a programmatic
 // `searchEntries` caller receives.
 export type SearchEntryResults = EntryCollectionDocument;

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -216,7 +216,8 @@ export type InstanceOrError = IndexedInstance | InstanceError;
 type GetEntryOptions = WIPOptions;
 export type QueryOptions = WIPOptions & {
   includeErrors?: true;
-  // Restrict the result set to this subset of card URLs (SQL `i.url IN (...)`).
+  // Restrict the result set to this subset of URLs (SQL `i.url IN (...)`) —
+  // instance rows by their `.json` file URL, file rows by their canonical URL.
   cardUrls?: string[];
   timings?: RequestTimings;
 };
@@ -685,11 +686,11 @@ export class IndexQueryEngine {
         );
       }
 
-      if (
-        entryType === 'instance' &&
-        opts.cardUrls &&
-        opts.cardUrls.length > 0
-      ) {
+      if (opts.cardUrls && opts.cardUrls.length > 0) {
+        // Restrict to this URL subset. Instance rows key on their `.json` file
+        // URL; file rows on their canonical file URL — the same `i.url` column,
+        // so the filter applies to both projections (the single-instance
+        // card+html / file-meta+html GET sources one entry this way).
         conditions.push([
           'i.url IN',
           ...addExplicitParens(

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -916,6 +916,7 @@ export type {
   CardCollectionDocument,
   FileMetaCollectionDocument,
   EntryCollectionDocument,
+  EntrySingleDocument,
   EntryIncludedResource,
   SearchEntryResults,
 } from './document-types.ts';

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -49,6 +49,7 @@ import {
   isSingleFileMetaDocument,
   type SingleCardDocument,
   type EntryCollectionDocument,
+  type EntrySingleDocument,
   type EntryIncludedResource,
   isEntryCollectionDocument,
 } from './document-types.ts';
@@ -58,6 +59,7 @@ import type {
   CardResource,
   CssResource,
   FileMetaResource,
+  HtmlQuery,
   IconResource,
   QueryFieldMeta,
   Saved,
@@ -79,6 +81,7 @@ import {
   resolveHtmlQuery,
   searchEntryWireQueryFromQuery,
   type RenderingCandidate,
+  type SearchEntryFieldset,
   type SearchEntryQuery,
 } from './search-entry.ts';
 import { getImmediateFieldDef, type FieldDefinition } from './definitions.ts';
@@ -455,6 +458,54 @@ export class RealmIndexQueryEngine {
       { htmlResources, cssById, iconById, itemResources, fullItemRoots },
       opts,
     );
+  }
+
+  // The single-instance counterpart of `searchEntries`: one entry sourced by
+  // URL rather than by a membership query. `kind` selects the instance vs file
+  // projection — the caller's accept header is the discriminator (card+html →
+  // instance, file-meta+html → file), mirroring the card+json vs
+  // file-meta+json GET split. Reuses the collection path with a one-URL
+  // `cardUrls` filter (so all the rendering enumeration / htmlQuery matching /
+  // css + icon dedup / item serialization + loadLinks assembly is shared),
+  // then unwraps to a single-resource document. Returns undefined when no row
+  // matches the URL (the handler 404s).
+  async searchEntry(
+    url: URL,
+    args: {
+      htmlQuery: HtmlQuery;
+      fieldset: SearchEntryFieldset;
+      kind: 'instance' | 'file';
+    },
+    opts?: Options,
+  ): Promise<EntrySingleDocument | undefined> {
+    let { htmlQuery, fieldset, kind } = args;
+    let searchEntryQuery: SearchEntryQuery = {
+      itemQuery: {},
+      htmlQuery,
+      fieldset,
+      cardUrls: [url.href],
+    };
+    let collection =
+      kind === 'file'
+        ? // The file path is reached only through this explicit `kind` — an
+          // empty membership query never routes to file-meta on its own (see
+          // `queryTargetsFileMeta`), so a file's entry must be requested by
+          // accept header. `cardUrls` rides in `opts` for the file path (it's
+          // read there, not off the SearchEntryQuery).
+          await this.searchEntriesFileMeta(searchEntryQuery, {
+            ...opts,
+            cardUrls: [url.href],
+          })
+        : await this.searchEntries(searchEntryQuery, opts);
+    let [entry] = collection.data;
+    if (!entry) {
+      return undefined;
+    }
+    let doc: EntrySingleDocument = { data: entry };
+    if (collection.included && collection.included.length > 0) {
+      doc.included = collection.included;
+    }
+    return doc;
   }
 
   // The file-meta counterpart of `searchEntries`. Files are indexed as

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3,7 +3,10 @@ import type { RealmVisibility } from './realm-visibility.ts';
 import type { SearchOpts } from './search-utils.ts';
 import { buildSearchErrorBody, SearchRequestError } from './search-utils.ts';
 import {
+  fieldsetFromParam,
+  htmlQueryFromParams,
   parseSearchEntryQueryFromPayload,
+  type SearchEntryFieldset,
   type SearchEntryQuery,
 } from './search-entry.ts';
 import {
@@ -21,9 +24,18 @@ import {
   type SingleCardDocument,
   type SingleFileMetaDocument,
   type EntryCollectionDocument,
+  type EntrySingleDocument,
 } from './document-types.ts';
-import type { CardResource, Relationship } from './resource-types.ts';
-import { clearReplacedArrayFieldMeta } from './resource-types.ts';
+import type {
+  CardResource,
+  HtmlQuery,
+  HtmlResource,
+  Relationship,
+} from './resource-types.ts';
+import {
+  clearReplacedArrayFieldMeta,
+  HtmlResourceType,
+} from './resource-types.ts';
 import { normalizeRelationships } from './relationship-utils.ts';
 import type { LocalPath } from './paths.ts';
 import { RealmPaths, ensureTrailingSlash, join } from './paths.ts';
@@ -476,6 +488,31 @@ function buildCardJsonEtag(
   }
   let base = realmInfoHash ? `${indexedAt}-${realmInfoHash}` : `${indexedAt}`;
   return `"${base}:${CARD_JSON_ETAG_VARIANT}"`;
+}
+
+// The card+html / file-meta+html GET's composite validator. It encodes both
+// channels the response draws from: the entry's index-data generation and the
+// rendering's generation — or `none` when no rendering is present — so the
+// validator changes when EITHER advances. An ETag of the rendering generation
+// alone breaks the refresh flow: a client that cached the no-rendering response
+// at index generation 42 would send a validator that still matches after HTML
+// lands at 42 and would 304 forever. The rendering generation is read off the
+// entry's own `html` linkage; all of one card's renderings share a generation
+// (it's a per-row value), so the first referenced `html` resource stands for
+// the channel.
+function buildEntryHtmlEtag(doc: EntrySingleDocument): string {
+  let indexGeneration = doc.data.meta?.generation ?? 0;
+  let htmlIds = doc.data.relationships.html?.data ?? [];
+  let htmlGeneration: number | undefined;
+  if (htmlIds.length > 0) {
+    let firstId = htmlIds[0].id;
+    let htmlResource = doc.included?.find(
+      (resource): resource is HtmlResource =>
+        resource.type === HtmlResourceType && resource.id === firstId,
+    );
+    htmlGeneration = htmlResource?.meta?.generation;
+  }
+  return `"${indexGeneration}:${htmlGeneration ?? 'none'}"`;
 }
 
 // RFC 9110 §13.1.2: `If-None-Match` may be `*`, a comma-separated
@@ -1037,6 +1074,12 @@ export class Realm {
       )
       .post('(/|/.+/)', SupportedMimeType.CardJson, this.createCard.bind(this))
       .get('/.*', SupportedMimeType.CardJson, this.getCard.bind(this))
+      .get('/.*', SupportedMimeType.CardHtml, this.getCardHtml.bind(this))
+      .get(
+        '/.*',
+        SupportedMimeType.FileMetaHtml,
+        this.getFileMetaHtml.bind(this),
+      )
       .get('/.*', SupportedMimeType.Markdown, this.getCardMarkdown.bind(this))
       .patch(
         '/.+(?<!.json)',
@@ -5225,6 +5268,118 @@ export class Realm {
     } finally {
       this.#logRequestPerformance(request, start);
     }
+  }
+
+  // The single-instance card+html GET: one `entry` sourced by URL, carrying
+  // the card's selected rendering (`html`) plus its `item` serialization — the
+  // single-instance counterpart to `_search` and the primitive the host's
+  // selective refresh uses to update one member's HTML without re-running a
+  // whole query.
+  private async getCardHtml(
+    request: Request,
+    requestContext: RequestContext,
+  ): Promise<Response> {
+    return this.#entryHtmlResponse(request, requestContext, 'instance');
+  }
+
+  // The file counterpart of `getCardHtml`: one file's `entry` (a native
+  // rendering + its `file-meta` serialization).
+  private async getFileMetaHtml(
+    request: Request,
+    requestContext: RequestContext,
+  ): Promise<Response> {
+    return this.#entryHtmlResponse(request, requestContext, 'file');
+  }
+
+  async #entryHtmlResponse(
+    request: Request,
+    requestContext: RequestContext,
+    kind: 'instance' | 'file',
+  ): Promise<Response> {
+    let mimeType =
+      kind === 'file'
+        ? SupportedMimeType.FileMetaHtml
+        : SupportedMimeType.CardHtml;
+
+    // Read endpoints serve the realm's canonical indexed view — drain any
+    // in-flight incremental indexing first, exactly as `getCard` does.
+    let pending = this.incrementalIndexing();
+    if (pending) {
+      await pending;
+    }
+
+    let htmlQuery: HtmlQuery;
+    let fieldset: SearchEntryFieldset;
+    try {
+      let { searchParams } = new URL(request.url);
+      // `?format=` (default fitted) + optional `?renderType=<module>/<name>`
+      // select the rendering; `?fields=` (html | item | html,item) is the
+      // sparse fieldset. Both mirror the html. branch, sourced from the query
+      // string rather than a request body.
+      htmlQuery = htmlQueryFromParams({
+        format: searchParams.get('format'),
+        renderType: searchParams.get('renderType'),
+      });
+      fieldset = fieldsetFromParam(searchParams.get('fields'));
+    } catch (e) {
+      if (e instanceof SearchRequestError) {
+        return createResponse({
+          body: JSON.stringify(buildSearchErrorBody(e.message)),
+          init: {
+            status: 400,
+            headers: { 'content-type': mimeType },
+          },
+          requestContext,
+        });
+      }
+      throw e;
+    }
+
+    let localPath = this.paths.local(new URL(request.url));
+    if (localPath === '') {
+      localPath = 'index';
+    }
+    // Instance rows key on their `.json` file URL; file rows on the bare path.
+    let dbUrl =
+      kind === 'file'
+        ? this.paths.fileURL(localPath)
+        : this.paths.fileURL(
+            `${localPath.replace(/\.json$/, '') || 'index'}.json`,
+          );
+
+    let doc = await this.#realmIndexQueryEngine.searchEntry(
+      dbUrl,
+      { htmlQuery, fieldset, kind },
+      {
+        loadLinks: true,
+        ...(isDuringPrerenderRequest(request)
+          ? { cacheOnlyDefinitions: true }
+          : {}),
+      },
+    );
+    if (!doc) {
+      return notFound(request, requestContext);
+    }
+
+    let etag = buildEntryHtmlEtag(doc);
+    let ifNoneMatch = request.headers.get('if-none-match');
+    if (ifNoneMatch && ifNoneMatchMatches(ifNoneMatch, etag)) {
+      return createResponse({
+        requestContext,
+        body: null,
+        init: {
+          status: 304,
+          headers: { etag, 'content-type': mimeType },
+        },
+      });
+    }
+    return createResponse({
+      body: JSON.stringify(doc, null, 2),
+      init: {
+        headers: { 'content-type': mimeType, etag },
+      },
+      requestContext,
+    });
   }
 
   private async getCardMarkdown(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -500,7 +500,18 @@ function buildCardJsonEtag(
 // entry's own `html` linkage; all of one card's renderings share a generation
 // (it's a per-row value), so the first referenced `html` resource stands for
 // the channel.
-function buildEntryHtmlEtag(doc: EntrySingleDocument): string {
+//
+// When the response carries an `item`, its serialization also rides
+// `meta.realmInfo` — which can change without reindexing the card (realm
+// rename / icon / publish) and so advances neither generation. So fold the
+// realm-info hash in for item-bearing responses, exactly as the card+json GET
+// does, or a validator would pin the stale realmInfo across such a change. A
+// pure-html response carries no realmInfo, so its validator stays the clean
+// index:html composite.
+function buildEntryHtmlEtag(
+  doc: EntrySingleDocument,
+  realmInfoHash: string | undefined,
+): string {
   let indexGeneration = doc.data.meta?.generation ?? 0;
   let htmlIds = doc.data.relationships.html?.data ?? [];
   let htmlGeneration: number | undefined;
@@ -512,7 +523,11 @@ function buildEntryHtmlEtag(doc: EntrySingleDocument): string {
     );
     htmlGeneration = htmlResource?.meta?.generation;
   }
-  return `"${indexGeneration}:${htmlGeneration ?? 'none'}"`;
+  let base = `${indexGeneration}:${htmlGeneration ?? 'none'}`;
+  if (doc.data.relationships.item && realmInfoHash) {
+    base = `${base}:${realmInfoHash}`;
+  }
+  return `"${base}"`;
 }
 
 // RFC 9110 §13.1.2: `If-None-Match` may be `*`, a comma-separated
@@ -5361,7 +5376,10 @@ export class Realm {
       return notFound(request, requestContext);
     }
 
-    let etag = buildEntryHtmlEtag(doc);
+    // `searchEntry` ran `attachRealmInfo`, which (re)populated the realm-info
+    // cache, so the hash we fold into an item-bearing response's ETag reflects
+    // the realm info the item was just serialized with.
+    let etag = buildEntryHtmlEtag(doc, this.getCachedRealmInfoHash());
     let ifNoneMatch = request.headers.get('if-none-match');
     if (ifNoneMatch && ifNoneMatchMatches(ifNoneMatch, etag)) {
       return createResponse({

--- a/packages/runtime-common/search-entry.ts
+++ b/packages/runtime-common/search-entry.ts
@@ -43,6 +43,7 @@ import {
 import { isCodeRef } from './card-document-shape.ts';
 import { generalSortFields } from './index-query-engine.ts';
 import { ensureTrailingSlash } from './paths.ts';
+import { parseUsedRenderType } from './search-resource-helpers.ts';
 
 // ---------------------------------------------------------------------------
 // The entry query.
@@ -654,6 +655,80 @@ export function parseSearchEntryQueryFromPayload(
     fieldset,
     realms,
     cardUrls,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The single-instance GET's query-string surface. The card+html /
+// file-meta+html GET sources one entry by URL, so it needs no membership
+// query — only the rendering selection (`?format=` / `?renderType=`) and the
+// sparse fieldset (`?fields=`), the query-string spelling of the html. branch's
+// `htmlQuery` + `fields[entry]`. The two helpers translate those params into
+// the same `HtmlQuery` / `SearchEntryFieldset` the engine consumes, reusing
+// the wire grammar's validation.
+// ---------------------------------------------------------------------------
+
+// `?format=` (default `fitted`) + optional `?renderType=<module>/<name>` → the
+// htmlQuery selecting the rendering. An absent `renderType` leaves only the
+// card's native type in play (no renderType predicate), exactly like an
+// htmlQuery that constrains format alone.
+export function htmlQueryFromParams(params: {
+  format?: string | null;
+  renderType?: string | null;
+}): HtmlQuery {
+  let format = params.format ?? DEFAULT_HTML_QUERY.eq.format;
+  let renderType: unknown;
+  if (params.renderType) {
+    renderType = parseUsedRenderType(params.renderType);
+    if (renderType === undefined) {
+      throw invalidHtmlQuery(
+        `renderType must be a <module>/<name> key (got "${params.renderType}")`,
+      );
+    }
+  }
+  let htmlQuery = {
+    eq: {
+      format,
+      ...(renderType !== undefined ? { renderType } : {}),
+    },
+  };
+  // Validates the format is a known rendering format and the renderType is a
+  // CodeRef — the same checks the wire grammar applies to a bound htmlQuery.
+  assertHtmlQuery(htmlQuery);
+  return htmlQuery;
+}
+
+// `?fields=` → the sparse fieldset. The single GET serves the three
+// combinations `html`, `item`, and `html,item`; the wire grammar's sparse
+// `item.<field>` selectors have no query-string spelling here. Omitted → the
+// default resolution policy (the selected rendering, falling back to the item
+// where none matched).
+export function fieldsetFromParam(
+  fields: string | null | undefined,
+): SearchEntryFieldset {
+  if (fields == null || fields.trim() === '') {
+    return { html: true, item: { kind: 'none' }, itemAsFallback: true };
+  }
+  let html = false;
+  let item = false;
+  for (let part of fields.split(',').map((f) => f.trim())) {
+    if (part === 'html') {
+      html = true;
+    } else if (part === 'item') {
+      item = true;
+    } else if (part !== '') {
+      throw invalidQuery(
+        `each fields entry must be "html" or "item" (got "${part}")`,
+      );
+    }
+  }
+  if (!html && !item) {
+    throw invalidQuery(`fields must name at least one of "html" or "item"`);
+  }
+  return {
+    html,
+    item: item ? { kind: 'full' } : { kind: 'none' },
+    itemAsFallback: false,
   };
 }
 

--- a/packages/runtime-common/search-entry.ts
+++ b/packages/runtime-common/search-entry.ts
@@ -676,7 +676,13 @@ export function htmlQueryFromParams(params: {
   format?: string | null;
   renderType?: string | null;
 }): HtmlQuery {
-  let format = params.format ?? DEFAULT_HTML_QUERY.eq.format;
+  // Empty or absent means "unspecified" for both dimensions, consistent with
+  // an omitted `?fields=` — the universal query-string convention. So an empty
+  // `?format=` falls back to fitted, and an empty `?renderType=` leaves only
+  // the native type in play (no predicate). A genuinely malformed value still
+  // fails: a bad format is rejected by `assertHtmlQuery` below, and a
+  // renderType that isn't a `<module>/<name>` key throws here.
+  let format = params.format || DEFAULT_HTML_QUERY.eq.format;
   let renderType: unknown;
   if (params.renderType) {
     renderType = parseUsedRenderType(params.renderType);

--- a/packages/runtime-common/supported-mime-type.ts
+++ b/packages/runtime-common/supported-mime-type.ts
@@ -5,6 +5,12 @@
 // the same wire value intentionally (the `application/vnd.api+json` group).
 export const SupportedMimeType = {
   CardJson: 'application/vnd.card+json',
+  // The single-instance card+html GET: one `entry` sourced by URL (the
+  // single-instance counterpart to `_search`), carrying the card's selected
+  // rendering (`html`) plus its `item` serialization. `.file-meta` is the file
+  // counterpart — a file rendering + its `file-meta` serialization.
+  CardHtml: 'application/vnd.card+html',
+  FileMetaHtml: 'application/vnd.card.file-meta+html',
   CardSource: 'application/vnd.card+source',
   FileMeta: 'application/vnd.card.file-meta+json',
   DirectoryListing: 'application/vnd.api+json',


### PR DESCRIPTION
Adds the single-instance counterpart to `_search`: `GET <card-url>` with `Accept: application/vnd.card+html` returns a JSON:API document whose `data` is one `entry` — the card's selected rendering (`html`) plus its `item` serialization — sourced by URL instead of by a query. Files use `Accept: application/vnd.card.file-meta+html`. This is the primitive the host's selective refresh uses to update one member's HTML without re-running a whole query.

Stacked on #5406 (per-entry generation in `meta`), which this reuses.

### The endpoint

- Content-negotiated on the realm's existing `GET /.*` route, alongside `card+json` / `file-meta+json` / markdown. New mime types in `supported-mime-type.ts`.
- Query params mirror the html. branch, sourced from the query string: `?format=` (default `fitted`), `?renderType=<module>/<name>` (default native), `?fields=` (`html` | `item` | `html,item`). Omitting `?fields` is the default resolution policy — the selected rendering, falling back to the `item` where none matched.
- Reuses the entry projection wholesale: the handler builds a one-URL `entry` query and runs it through `RealmIndexQueryEngine.searchEntry`, which threads the existing collection path (rendering enumeration, htmlQuery matching, css/icon dedup, item serialization + `loadLinks`) with a single-URL filter and unwraps the result to a single-resource document.

### Composite ETag

The validator encodes both channels the response draws from — the entry's index-data generation and the rendering's generation-or-absence, e.g. `"42:40"` or `"42:none"` — so it changes when either advances. An ETag of the rendering generation alone would break the refresh flow: a client that cached the no-rendering response at index generation 42 would send a validator that still matches after HTML lands at 42 and would 304 forever.

Outcomes:
- `304` when `If-None-Match` matches the current composite state.
- `200` with a populated `html` relationship (+ `styles`/`css` + `icon` in `included`) when a rendering exists.
- `200` with no `html` relationship and an `item` fallback when no rendering exists — the server serves the newest rendering it has regardless of generation; staleness rides in `meta` for the client to judge.
- `404` for a URL with no index row; `400` for a malformed `?format=` / `?renderType=` / `?fields=`.

Purely additive — a new accept header; no existing route changes shape. The `_search` `i.url IN (...)` narrowing (`cardUrls`) now applies to file rows too, so a file's `entry` can be sourced by URL the same way.

### Tests

- `search-entry-test`: the query-param → `htmlQuery` / fieldset translation and its validation.
- `card-html-endpoints-test`: the engine `searchEntry` reshape, and the GET end-to-end — the populated-rendering response + composite ETag, `304` on a matching validator, `?format=`, `?fields=item` / `html,item`, the file counterpart, `404`, and the `400` on a bad param.
