### PR TITLE
Replace inline theme styles with scoped theme stylesheet

### DIFF
--- a/packages/base/brand-guide.gts
+++ b/packages/base/brand-guide.gts
@@ -74,7 +74,7 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
   <template>
     <ThemeDashboard
       class='brand-guide'
-      style={{if this.isDarkMode @model.darkModeStyles}}
+      @themeCss={{@model.cssVariables}}
       @sections={{this.sectionsWithContent}}
       @isDarkMode={{this.isDarkMode}}
     >

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -3,6 +3,7 @@ import GlimmerComponent from '@glimmer/component';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
 import { modifier } from 'ember-modifier';
 
 import Moon from '@cardstack/boxel-icons/moon';
@@ -17,7 +18,7 @@ import {
   FieldContainer,
   BoxelInput,
 } from '@cardstack/boxel-ui/components';
-import { bool, cn } from '@cardstack/boxel-ui/helpers';
+import { bool, cn, themeScopedCss } from '@cardstack/boxel-ui/helpers';
 
 import { DEFAULT_THEME_SCALE } from '../structured-theme-variables';
 
@@ -1070,51 +1071,76 @@ export class ThemeDashboard extends GlimmerComponent<{
     headerLabel?: string;
     version?: string;
     isDarkMode?: boolean;
+    themeCss?: string | null;
   };
   Blocks: { default: []; header: []; navBar: [] };
   Element: HTMLElement;
 }> {
+  private themeScopeId = guidFor(this);
+
+  // The data-theme wrapper drives the preview's light/dark toggle through the
+  // ambient `--boxel-color-scheme` signal, flipping the semantic tokens to the
+  // boxel dark defaults for this subtree. The theme's own variables must be
+  // re-scoped inside the wrapper (via `data-boxel-theme-scope` + the style
+  // tag) because the card-level scope sits above it and resolves against the
+  // app chrome's scheme, not this toggle.
   <template>
-    <article
-      id='top'
-      class={{cn 'detailed-style-reference' dsr--dark=@isDarkMode}}
-      ...attributes
+    <div
+      class='theme-dashboard-scheme'
+      data-theme={{if @isDarkMode 'dark' 'light'}}
     >
-      {{#if (has-block 'header')}}
-        {{yield to='header'}}
-      {{else}}
-        <ThemeDashboardHeader
-          class='dsr-header'
-          @title={{@title}}
-          @description={{@description}}
-          @isDarkMode={{@isDarkMode}}
-          @metaLabel={{@headerLabel}}
-          @version={{@version}}
-        />
-      {{/if}}
+      <article
+        id='top'
+        class={{cn 'detailed-style-reference' dsr--dark=@isDarkMode}}
+        data-boxel-theme-scope={{if @themeCss this.themeScopeId}}
+        ...attributes
+      >
+        {{#if @themeCss}}
+          {{! template-lint-disable require-scoped-style }}
+          <style>
+            {{themeScopedCss this.themeScopeId @themeCss}}
+          </style>
+          {{! template-lint-enable require-scoped-style }}
+        {{/if}}
+        {{#if (has-block 'header')}}
+          {{yield to='header'}}
+        {{else}}
+          <ThemeDashboardHeader
+            class='dsr-header'
+            @title={{@title}}
+            @description={{@description}}
+            @isDarkMode={{@isDarkMode}}
+            @metaLabel={{@headerLabel}}
+            @version={{@version}}
+          />
+        {{/if}}
 
-      {{#if (has-block 'navBar')}}
-        {{yield to='navBar'}}
-      {{else if @sections.length}}
-        <NavBar @sections={{@sections}} />
-      {{/if}}
+        {{#if (has-block 'navBar')}}
+          {{yield to='navBar'}}
+        {{else if @sections.length}}
+          <NavBar @sections={{@sections}} />
+        {{/if}}
 
-      <div class='dsr-content'>
-        {{yield}}
-      </div>
-
-      <footer class='dsr-footer'>
-        <div class='footer-content'>
-          <p class='footer-text'>
-            This style guide is a living document. Design systems evolve with
-            thoughtful iteration and disciplined execution.
-          </p>
+        <div class='dsr-content'>
+          {{yield}}
         </div>
-      </footer>
-    </article>
+
+        <footer class='dsr-footer'>
+          <div class='footer-content'>
+            <p class='footer-text'>
+              This style guide is a living document. Design systems evolve with
+              thoughtful iteration and disciplined execution.
+            </p>
+          </div>
+        </footer>
+      </article>
+    </div>
 
     <style scoped>
       @layer baseComponent {
+        .theme-dashboard-scheme {
+          height: 100%;
+        }
         .detailed-style-reference {
           --dsr-bg: var(--background, var(--boxel-light));
           --dsr-fg: var(--foreground, var(--boxel-700));

--- a/packages/base/detailed-style-reference.gts
+++ b/packages/base/detailed-style-reference.gts
@@ -142,7 +142,7 @@ class Isolated extends Component<typeof DetailedStyleReference> {
 
   <template>
     <ThemeDashboard
-      style={{if this.isDarkMode @model.darkModeStyles}}
+      @themeCss={{@model.cssVariables}}
       @title={{@model.cardTitle}}
       @description={{@model.cardDescription}}
       @sections={{this.sectionsWithContent}}

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -293,7 +293,16 @@ export function getBoxComponent(
   }
 
   let component = class FieldComponent extends Component<BoxComponentSignature> {
-    private themeScopeId = guidFor(this);
+    // Scopes this card's theme stylesheet. Derived from the card id so the
+    // scope stays stable in persisted prerendered HTML — a per-process guid
+    // can repeat across prerender jobs, and since the scoped style rules are
+    // page-global, two cached cards with the same scope would capture each
+    // other's theme variables. The guid fallback only covers unsaved cards,
+    // which are never persisted.
+    private get themeScopeId() {
+      let value = model.value;
+      return (isCard(value) && value.id) || guidFor(this);
+    }
 
     // Compute merged configuration for this field based on the owning instance.
     // We intentionally do not expose the instance itself to templates.

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -28,11 +28,7 @@ import {
 } from '@cardstack/runtime-common';
 import type { ComponentLike } from '@glint/template';
 import { CardContainer } from '@cardstack/boxel-ui/components';
-import {
-  coalesce,
-  extractCssVariables,
-  sanitizeHtmlSafe,
-} from '@cardstack/boxel-ui/helpers';
+import { coalesce } from '@cardstack/boxel-ui/helpers';
 import Modifier from 'ember-modifier';
 import { isEqual, flatMap } from 'lodash-es';
 import { initSharedState } from './shared-state';
@@ -40,7 +36,7 @@ import { and, cn, eq, not } from '@cardstack/boxel-ui/helpers';
 import { consume, provide } from 'ember-provide-consume-context';
 import Component from '@glimmer/component';
 import { concat } from '@ember/helper';
-import { htmlSafe } from '@ember/template';
+import { guidFor } from '@ember/object/internals';
 import { resolveFieldConfiguration } from './field-support';
 
 export interface BoxComponentSignature {
@@ -271,14 +267,10 @@ export function getBoxComponent(
     return false;
   }
 
-  function getThemeStyles(cardDef?: CardDef) {
-    if (!extractCssVariables) {
-      return htmlSafe('');
-    }
-    let css = isThemeCard(cardDef)
+  function themeCss(cardDef?: CardDef) {
+    return isThemeCard(cardDef)
       ? cardDef.cssVariables
       : cardDef?.cardTheme?.cssVariables;
-    return sanitizeHtmlSafe(extractCssVariables(css));
   }
 
   function hasTheme(cardDef?: CardDef) {
@@ -301,6 +293,8 @@ export function getBoxComponent(
   }
 
   let component = class FieldComponent extends Component<BoxComponentSignature> {
+    private themeScopeId = guidFor(this);
+
     // Compute merged configuration for this field based on the owning instance.
     // We intentionally do not expose the instance itself to templates.
     get resolvedConfiguration() {
@@ -349,6 +343,8 @@ export function getBoxComponent(
                           @displayBoundaries={{displayContainer}}
                           @isThemed={{hasTheme card}}
                           @cssImports={{getCssImports card}}
+                          @themeCss={{themeCss card}}
+                          @themeScope={{this.themeScopeId}}
                           class={{cn
                             'field-component-card'
                             (concat effectiveFormats.cardDef '-format')
@@ -360,7 +356,6 @@ export function getBoxComponent(
                             fieldType=field.fieldType
                             fieldName=field.name
                           }}
-                          style={{getThemeStyles card}}
                           data-boxel-card-id={{card.id}}
                           data-boxel-card-format={{effectiveFormats.cardDef}}
                           data-test-card={{card.id}}

--- a/packages/base/structured-theme.gts
+++ b/packages/base/structured-theme.gts
@@ -11,9 +11,7 @@ import {
   buildCssGroups,
   generateCssVariables,
   parseCssGroups,
-  extractCssVariables,
   markdownEscape,
-  sanitizeHtmlSafe,
   type CssRuleMap,
 } from '@cardstack/boxel-ui/helpers';
 
@@ -148,7 +146,7 @@ class Isolated extends Component<typeof StructuredTheme> {
   <template>
     <ThemeDashboard
       class='structured-theme-card'
-      style={{if this.isDarkMode @model.darkModeStyles}}
+      @themeCss={{@model.cssVariables}}
       @title={{@model.cardTitle}}
       @description={{@model.cardDescription}}
       @isDarkMode={{this.isDarkMode}}
@@ -286,10 +284,6 @@ export default class StructuredTheme extends Theme {
   });
 
   guideSections: SectionSignature[] = GUIDE_SECTIONS;
-
-  get darkModeStyles() {
-    return sanitizeHtmlSafe(extractCssVariables(this.cssVariables, '.dark'));
-  }
 
   setCss = (content: string) => {
     if (!content || !parseCssGroups) {

--- a/packages/base/style-reference.gts
+++ b/packages/base/style-reference.gts
@@ -31,7 +31,7 @@ class Isolated extends Component<typeof StyleReference> {
   <template>
     <ThemeDashboard
       class='style-reference'
-      style={{if this.isDarkMode @model.darkModeStyles}}
+      @themeCss={{@model.cssVariables}}
       @isDarkMode={{this.isDarkMode}}
     >
       <:header>

--- a/packages/boxel-ui/addon/src/components/card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/index.gts
@@ -3,6 +3,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import cn from '../../helpers/cn.ts';
 import element from '../../helpers/element.ts';
 import { sanitizeHtml } from '../../helpers/sanitize-html.ts';
+import { themeScopedCss } from '../../helpers/theme-scoped-css.ts';
 
 interface Signature {
   Args: {
@@ -10,6 +11,14 @@ interface Signature {
     displayBoundaries?: boolean;
     isThemed?: boolean;
     tag?: keyof HTMLElementTagNameMap;
+    // Raw theme CSS variable definitions (`:root` + optional `.dark`). Scoped to
+    // this container via `themeScope` so light/dark switches with the ambient
+    // `--boxel-color-scheme` signal — no inline styles, no JS. The scope
+    // attribute is only stamped when theme CSS is present: it also triggers the
+    // theme.css boundary reset that stops ambient/outer-theme token values from
+    // inheriting in, which unthemed cards rely on to follow the chrome scheme.
+    themeCss?: string | null;
+    themeScope?: string;
   };
   Blocks: {
     default: [];
@@ -26,6 +35,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
         boxel-card-container--themed=@isThemed
       }}
       data-boxel-card-container
+      data-boxel-theme-scope={{if @themeCss @themeScope}}
       data-test-boxel-card-container
       ...attributes
     >
@@ -36,6 +46,13 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
           {{#each @cssImports as |url|}}
             @import url('{{sanitizeHtml url}}');
           {{/each}}
+        </style>
+        {{! template-lint-enable require-scoped-style  }}
+      {{/if}}
+      {{#if @themeCss}}
+        {{! template-lint-disable require-scoped-style  }}
+        <style>
+          {{themeScopedCss @themeScope @themeCss}}
         </style>
         {{! template-lint-enable require-scoped-style  }}
       {{/if}}
@@ -217,42 +234,40 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       line-height: var(--boxel-body-line-height);
     }
 
+    /* Element reset + typography roles, contained to card content: bare
+       :global(h1) etc. would restyle the entire document once a single card
+       renders. Still :global (with an ancestor guard) for the cached-HTML
+       safety described above. */
     @layer reset {
-      :global(h1),
-      :global(h2),
-      :global(h3),
-      :global(h4),
-      :global(h5),
-      :global(h6),
-      :global(p) {
+      :global(.boxel-card-container :is(h1, h2, h3, h4, h5, h6, p)) {
         margin-inline-start: 0;
         margin-inline-end: 0;
         margin-block-start: 0;
         margin-block-end: 0;
       }
 
-      :global(h1) {
+      :global(.boxel-card-container h1) {
         font-family: var(--boxel-heading-font-family);
         font-size: var(--boxel-heading-font-size);
         font-weight: var(--boxel-heading-font-weight);
         line-height: var(--boxel-heading-line-height);
       }
-      :global(h2) {
+      :global(.boxel-card-container h2) {
         font-family: var(--boxel-section-heading-font-family);
         font-size: var(--boxel-section-heading-font-size);
         font-weight: var(--boxel-section-heading-font-weight);
         line-height: var(--boxel-section-heading-line-height);
       }
-      :global(h3) {
+      :global(.boxel-card-container h3) {
         font-family: var(--boxel-subheading-font-family);
         font-size: var(--boxel-subheading-font-size);
         font-weight: var(--boxel-subheading-font-weight);
         line-height: var(--boxel-subheading-line-height);
       }
-      :global(h4, h5, h6) {
+      :global(.boxel-card-container :is(h4, h5, h6)) {
         font-size: inherit;
       }
-      :global(small) {
+      :global(.boxel-card-container small) {
         font-size: var(--boxel-caption-font-size);
         line-height: var(--boxel-caption-line-height);
       }

--- a/packages/boxel-ui/addon/src/components/kanban/plane.gts
+++ b/packages/boxel-ui/addon/src/components/kanban/plane.gts
@@ -116,28 +116,16 @@ export class KanbanPlane extends Component<{
       .kanban-plane {
         --_kanban-bg: var(
           --boxel-kanban-bg,
-          var(--background, var(--boxel-100))
+          color-mix(in oklch, var(--foreground) 1%, transparent)
         );
-        --_kanban-fg: var(
-          --boxel-kanban-fg,
-          var(--foreground, var(--boxel-700))
-        );
-        --_kanban-card-bg: var(
-          --boxel-kanban-card-bg,
-          var(--card, var(--boxel-light))
-        );
-        --_kanban-card-fg: var(
-          --boxel-kanban-card-fg,
-          var(--card-foreground, var(--boxel-dark))
-        );
+        --_kanban-fg: var(--boxel-kanban-fg, var(--foreground));
+        --_kanban-card-bg: var(--boxel-kanban-card-bg, var(--card));
+        --_kanban-card-fg: var(--boxel-kanban-card-fg, var(--card-foreground));
         --_kanban-col-bg: var(
           --boxel-kanban-col-bg,
-          var(--sidebar, var(--boxel-200))
+          color-mix(in oklch, var(--foreground) 7%, transparent)
         );
-        --_kanban-col-fg: var(
-          --boxel-kanban-col-fg,
-          var(--sidebar-foreground, var(--boxel-dark))
-        );
+        --_kanban-col-fg: var(--boxel-kanban-col-fg, var(--foreground));
         --_kanban-ring: var(
           --boxel-kanban-ring,
           var(--ring, var(--boxel-highlight))

--- a/packages/boxel-ui/addon/src/helpers.ts
+++ b/packages/boxel-ui/addon/src/helpers.ts
@@ -48,6 +48,7 @@ import {
   entriesToCssRuleMap,
   normalizeCssRuleMap,
 } from './helpers/theme-css.ts';
+import { themeScopedCss } from './helpers/theme-scoped-css.ts';
 import {
   and,
   bool,
@@ -121,6 +122,7 @@ export {
   sanitizeHtmlSafe,
   substring,
   subtract,
+  themeScopedCss,
   toMenuItems,
 };
 

--- a/packages/boxel-ui/addon/src/helpers/extract-css-variables.ts
+++ b/packages/boxel-ui/addon/src/helpers/extract-css-variables.ts
@@ -8,6 +8,7 @@ import {
 const COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
 const BLOCK_PATTERN = /(.*?)\{([\s\S]*?)\}/g;
 const PROPERTY_PATTERN = /^[a-z\d-]+$/i;
+const CUSTOM_PROPERTY_PATTERN = /^--[a-z\d_-]+$/i;
 
 // Turns a CSS declaration block into a property-value map.
 const parseCssDeclarations = (rules?: string): CssRuleMap | undefined => {
@@ -36,7 +37,9 @@ const parseCssDeclarations = (rules?: string): CssRuleMap | undefined => {
     const value = declaration.slice(colonIndex + 1).trim();
     if (
       !property ||
-      (!property.startsWith('--') && !PROPERTY_PATTERN.test(property))
+      (property.startsWith('--')
+        ? !CUSTOM_PROPERTY_PATTERN.test(property)
+        : !PROPERTY_PATTERN.test(property))
     ) {
       console.warn(
         'parseCssDeclarations: skipping invalid property "%s"',

--- a/packages/boxel-ui/addon/src/helpers/theme-css.ts
+++ b/packages/boxel-ui/addon/src/helpers/theme-css.ts
@@ -55,6 +55,9 @@ export function buildCssVariableName(
 }
 
 // Standardizes rule values by trimming and removing trailing semicolons.
+// Rejects values containing CSS block delimiters: these values are serialized
+// into <style> declaration blocks, where an embedded `}` would close the
+// scoped block and let the remainder inject page-wide rules.
 export const normalizeCssValue = (
   value?: string | null,
 ): string | undefined => {
@@ -62,7 +65,10 @@ export const normalizeCssValue = (
     return;
   }
   const normalized = `${value}`.trim().replace(/[;\s]+$/, '');
-  return normalized ? normalized : undefined;
+  if (!normalized || /[{}]/.test(normalized)) {
+    return;
+  }
+  return normalized;
 };
 
 // Collapses selector aliases (like `root`) into their canonical form.

--- a/packages/boxel-ui/addon/src/helpers/theme-scoped-css.ts
+++ b/packages/boxel-ui/addon/src/helpers/theme-scoped-css.ts
@@ -11,6 +11,14 @@ import { sanitizeHtml } from './sanitize-html.ts';
 // to the *nearest* ancestor's color scheme, so per-subtree overrides (dark
 // pages, light islands, nested) all work with no JS and no !important. A theme
 // with no `.dark` block simply keeps its light values.
+// Declarations are emitted inside a <style> block: sanitizeHtml strips markup
+// (e.g. a `</style>` breakout) but knows nothing about CSS, so also drop block
+// delimiters — an embedded `}` would close the scoped block and turn the rest
+// of the value into page-wide rules.
+function sanitizeDeclarations(declarations: string): string {
+  return sanitizeHtml(declarations).replace(/[{}]/g, '');
+}
+
 export function themeScopedCss(
   scope?: string,
   cssVariables?: string | null,
@@ -20,13 +28,16 @@ export function themeScopedCss(
   }
   let light = extractCssVariables(cssVariables, ':root');
   let dark = extractCssVariables(cssVariables, '.dark');
-  let selector = `[data-boxel-theme-scope="${scope}"]`;
+  // Scopes are arbitrary strings (typically card URLs); escape the characters
+  // that could break out of the double-quoted attribute selector. The escaped
+  // selector still matches the literal attribute value.
+  let selector = `[data-boxel-theme-scope="${scope.replace(/[\\"]/g, '\\$&')}"]`;
   let css = '';
   if (light) {
-    css += `${selector}{${sanitizeHtml(light)}}`;
+    css += `${selector}{${sanitizeDeclarations(light)}}`;
   }
   if (dark) {
-    css += `@container style(--boxel-color-scheme: dark){${selector}{${sanitizeHtml(dark)}}}`;
+    css += `@container style(--boxel-color-scheme: dark){${selector}{${sanitizeDeclarations(dark)}}}`;
   }
   return htmlSafe(css);
 }

--- a/packages/boxel-ui/addon/src/helpers/theme-scoped-css.ts
+++ b/packages/boxel-ui/addon/src/helpers/theme-scoped-css.ts
@@ -1,0 +1,32 @@
+import { type SafeString, htmlSafe } from '@ember/template';
+
+import { extractCssVariables } from './extract-css-variables.ts';
+import { sanitizeHtml } from './sanitize-html.ts';
+
+// Builds a card's theme stylesheet, scoped to `scope` (a per-card
+// `data-boxel-theme-scope` value). The theme's `:root` variables apply by
+// default; its `.dark` variables take over via a CSS style container query on
+// `--boxel-color-scheme` — an inherited signal the theme (theme.css) sets on
+// each `[data-theme]` element. Because that signal inherits, the query resolves
+// to the *nearest* ancestor's color scheme, so per-subtree overrides (dark
+// pages, light islands, nested) all work with no JS and no !important. A theme
+// with no `.dark` block simply keeps its light values.
+export function themeScopedCss(
+  scope?: string,
+  cssVariables?: string | null,
+): SafeString {
+  if (!extractCssVariables || !scope || !cssVariables) {
+    return htmlSafe('');
+  }
+  let light = extractCssVariables(cssVariables, ':root');
+  let dark = extractCssVariables(cssVariables, '.dark');
+  let selector = `[data-boxel-theme-scope="${scope}"]`;
+  let css = '';
+  if (light) {
+    css += `${selector}{${sanitizeHtml(light)}}`;
+  }
+  if (dark) {
+    css += `@container style(--boxel-color-scheme: dark){${selector}{${sanitizeHtml(dark)}}}`;
+  }
+  return htmlSafe(css);
+}

--- a/packages/boxel-ui/addon/src/helpers/theme-scoped-css.ts
+++ b/packages/boxel-ui/addon/src/helpers/theme-scoped-css.ts
@@ -29,9 +29,18 @@ export function themeScopedCss(
   let light = extractCssVariables(cssVariables, ':root');
   let dark = extractCssVariables(cssVariables, '.dark');
   // Scopes are arbitrary strings (typically card URLs); escape the characters
-  // that could break out of the double-quoted attribute selector. The escaped
-  // selector still matches the literal attribute value.
-  let selector = `[data-boxel-theme-scope="${scope.replace(/[\\"]/g, '\\$&')}"]`;
+  // that could break out of the double-quoted attribute selector (`\`, `"`),
+  // terminate the surrounding <style> element once this markup is serialized
+  // and re-parsed (`<`, as in `</style`), or are invalid in a CSS string
+  // (control characters). CSS hex escapes keep the selector matching the
+  // literal attribute value.
+  // eslint-disable-next-line no-control-regex
+  let escapedScope = scope.replace(/[\\"<\u0000-\u001f]/g, (char) =>
+    char === '\\' || char === '"'
+      ? `\\${char}`
+      : `\\${char.codePointAt(0)!.toString(16)} `,
+  );
+  let selector = `[data-boxel-theme-scope="${escapedScope}"]`;
   let css = '';
   if (light) {
     css += `${selector}{${sanitizeDeclarations(light)}}`;

--- a/packages/boxel-ui/addon/src/styles/theme.css
+++ b/packages/boxel-ui/addon/src/styles/theme.css
@@ -16,13 +16,28 @@
    is layered on separately, below.
 */
 
-/* Light — the default theme, and the explicit `data-theme="light"` scope used
-   to force light back on inside a dark subtree. Both resolve to the same
-   values. */
+/* The inherited light/dark signal that scoped theme stylesheets key off (via a
+   style container query). Kept out of the token block below on purpose: it must
+   inherit *through* themed-card boundaries so a card's own `.dark` variables
+   can follow the ambient scheme, while the token values themselves must not. */
 :root,
 [data-theme='light'] {
   --boxel-color-scheme: light;
+}
 
+/* Light — the default theme, and the explicit `data-theme="light"` scope used
+   to force light back on inside a dark subtree. Both resolve to the same
+   values.
+
+   `:where([data-boxel-theme-scope])` re-declares the full contract at every
+   themed-card boundary so token values can't inherit into a themed card from
+   the chrome or an outer theme card — a theme only overrides the tokens it
+   defines, and the rest reset to these defaults instead of leaking through.
+   `:where()` keeps the reset at zero specificity, so the card's own scoped
+   theme stylesheet always wins. */
+:root,
+[data-theme='light'],
+:where([data-boxel-theme-scope]) {
   /* surfaces */
   --background: var(--boxel-light);
   --foreground: var(--boxel-dark);
@@ -99,16 +114,48 @@
   --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
 }
 
+/* Themed-card boundary reset for the --theme-* knobs (typography roles, base
+   font size, typescale) that theme cards may define and CardContainer consumes
+   through var() fallbacks. They have no defaults here, so `initial` (the
+   guaranteed-invalid value for a custom property) stops an outer theme card's
+   values from inheriting into a nested one and lets those fallbacks apply. A
+   card's own theme stylesheet overrides this — `:where()` keeps it at zero
+   specificity. (--theme-spacing is excluded: CardContainer derives it from
+   --spacing, which the token reset above already covers.) */
+:where([data-boxel-theme-scope]) {
+  --theme-font-size: initial;
+  --theme-scale: initial;
+  --theme-heading-font-family: initial;
+  --theme-heading-font-size: initial;
+  --theme-heading-font-weight: initial;
+  --theme-heading-line-height: initial;
+  --theme-section-heading-font-family: initial;
+  --theme-section-heading-font-size: initial;
+  --theme-section-heading-font-weight: initial;
+  --theme-section-heading-line-height: initial;
+  --theme-subheading-font-family: initial;
+  --theme-subheading-font-size: initial;
+  --theme-subheading-font-weight: initial;
+  --theme-subheading-line-height: initial;
+  --theme-body-font-family: initial;
+  --theme-body-font-size: initial;
+  --theme-body-font-weight: initial;
+  --theme-body-line-height: initial;
+  --theme-caption-font-family: initial;
+  --theme-caption-font-size: initial;
+  --theme-caption-font-weight: initial;
+  --theme-caption-line-height: initial;
+}
+
 /* ── Dark mode ──────────────────────────────────────────────────────────────
    Opt-in and explicit: add class `dark` or `data-theme="dark"` to <html>, or to
    any subtree you want themed dark. Force light back on inside a dark subtree
    with `data-theme="light"` (see the light block above).
 
-   OS-driven dark (`prefers-color-scheme` / a `data-theme="system"` mode) is
-   intentionally NOT wired up yet — it needs to resolve in both directions
-   (falling back to light when the OS is light, including inside a dark subtree),
-   so it is deferred until that feature is implemented.
-*/
+   OS-driven dark ('system' preference) has no token set of its own: consumers
+   (e.g. the host theme service) resolve `prefers-color-scheme` to a concrete
+   `data-theme="light"|"dark"` so these two blocks stay the single source of
+   truth in both directions. */
 .dark,
 [data-theme='dark'] {
   --boxel-color-scheme: dark;

--- a/packages/boxel-ui/test-app/tests/integration/components/card-container-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/card-container-test.gts
@@ -1,0 +1,164 @@
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+
+import { CardContainer } from '@cardstack/boxel-ui/components';
+
+const OUTER_THEME = `:root {
+  --primary: #112233;
+  --theme-body-font-size: 18px;
+}
+.dark {
+  --primary: #445566;
+}`;
+
+// Defines --accent only; --primary and --theme-body-font-size must come from
+// the boundary reset, not from an enclosing theme.
+const INNER_THEME = `:root { --accent: #aabbcc; } .dark { --accent: #ddeeff; }`;
+
+function propertyOf(selector: string, property: string): string {
+  let el = document.querySelector(selector);
+  if (!el) {
+    throw new Error(`expected to find element: ${selector}`);
+  }
+  return window.getComputedStyle(el).getPropertyValue(property).trim();
+}
+
+module('Integration | Component | card-container', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('stamps the theme scope only when theme css is present', async function (assert) {
+    await render(
+      <template>
+        <CardContainer data-test-unthemed>unthemed</CardContainer>
+        <CardContainer
+          @themeCss={{OUTER_THEME}}
+          @themeScope='scope-a'
+          data-test-themed
+        >themed</CardContainer>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-unthemed]')
+      .doesNotHaveAttribute('data-boxel-theme-scope');
+    assert
+      .dom('[data-test-themed]')
+      .hasAttribute('data-boxel-theme-scope', 'scope-a');
+  });
+
+  test('applies root variables under the ambient light scheme', async function (assert) {
+    await render(
+      <template>
+        <CardContainer
+          @themeCss={{OUTER_THEME}}
+          @themeScope='scope-a'
+          data-test-themed
+        >themed</CardContainer>
+      </template>,
+    );
+
+    assert.strictEqual(
+      propertyOf('[data-test-themed]', '--primary'),
+      '#112233',
+    );
+  });
+
+  test('applies dark variables inside a dark subtree and switches back inside a light island', async function (assert) {
+    await render(
+      <template>
+        <div data-theme='dark'>
+          <CardContainer
+            @themeCss={{OUTER_THEME}}
+            @themeScope='scope-a'
+            data-test-dark
+          >dark</CardContainer>
+          <div data-theme='light'>
+            <CardContainer
+              @themeCss={{OUTER_THEME}}
+              @themeScope='scope-b'
+              data-test-light-island
+            >light island</CardContainer>
+          </div>
+        </div>
+      </template>,
+    );
+
+    assert.strictEqual(
+      propertyOf('[data-test-dark]', '--primary'),
+      '#445566',
+      'dark variables apply inside a dark subtree',
+    );
+    assert.strictEqual(
+      propertyOf('[data-test-light-island]', '--primary'),
+      '#112233',
+      'root variables apply again inside a nested light island',
+    );
+  });
+
+  test('an outer theme does not leak into a nested themed card', async function (assert) {
+    await render(
+      <template>
+        <CardContainer data-test-reference>reference</CardContainer>
+        <CardContainer
+          @themeCss={{OUTER_THEME}}
+          @themeScope='scope-outer'
+          data-test-outer
+        >
+          <CardContainer
+            @themeCss={{INNER_THEME}}
+            @themeScope='scope-inner'
+            data-test-inner
+          >inner</CardContainer>
+        </CardContainer>
+      </template>,
+    );
+
+    assert.strictEqual(
+      propertyOf('[data-test-inner]', '--accent'),
+      '#aabbcc',
+      'inner theme applies its own variables',
+    );
+    assert.strictEqual(
+      propertyOf('[data-test-inner]', '--primary'),
+      propertyOf('[data-test-reference]', '--primary'),
+      'inner card resets --primary to the default instead of inheriting the outer theme',
+    );
+    assert.strictEqual(
+      propertyOf('[data-test-inner]', '--theme-body-font-size'),
+      '',
+      'inner card resets --theme-* knobs to initial instead of inheriting the outer theme',
+    );
+  });
+
+  test('the ambient color scheme inherits through a themed-card boundary', async function (assert) {
+    await render(
+      <template>
+        <div data-theme='dark'>
+          <CardContainer
+            @themeCss={{OUTER_THEME}}
+            @themeScope='scope-outer'
+            data-test-outer
+          >
+            <CardContainer
+              @themeCss={{INNER_THEME}}
+              @themeScope='scope-inner'
+              data-test-inner
+            >inner</CardContainer>
+          </CardContainer>
+        </div>
+      </template>,
+    );
+
+    assert.strictEqual(
+      propertyOf('[data-test-outer]', '--primary'),
+      '#445566',
+      'outer themed card follows the ambient dark scheme',
+    );
+    assert.strictEqual(
+      propertyOf('[data-test-inner]', '--accent'),
+      '#ddeeff',
+      'nested themed card still sees the ambient dark scheme',
+    );
+  });
+});

--- a/packages/boxel-ui/test-app/tests/unit/theme-scoped-css-test.ts
+++ b/packages/boxel-ui/test-app/tests/unit/theme-scoped-css-test.ts
@@ -52,6 +52,37 @@ module('Unit | theme-scoped-css', function () {
     assert.strictEqual(themeScopedCss(SCOPE, '').toString(), '');
   });
 
+  test('a bare-declaration value cannot break out of the scoped block', function (assert) {
+    let css = themeScopedCss(
+      SCOPE,
+      '--primary: red} body{background:url(https://evil.example/x)',
+    ).toString();
+    assert.false(
+      css.includes('body{'),
+      'no rule escapes the scoped selector block',
+    );
+    let openBraces = css.split('{').length - 1;
+    let closeBraces = css.split('}').length - 1;
+    assert.strictEqual(openBraces, closeBraces, 'braces stay balanced');
+  });
+
+  test('drops declarations whose value contains block delimiters', function (assert) {
+    let css = themeScopedCss(
+      SCOPE,
+      ':root { --safe: blue; --evil: red{orange; }',
+    ).toString();
+    assert.true(css.includes('--safe: blue'), 'safe declaration is kept');
+    assert.false(
+      css.includes('--evil'),
+      'declaration with a block delimiter in its value is dropped',
+    );
+  });
+
+  test('drops declarations whose property name contains block delimiters', function (assert) {
+    let css = themeScopedCss(SCOPE, '--safe: blue; --x} body: red').toString();
+    assert.strictEqual(css, `${SELECTOR}{--safe: blue}`);
+  });
+
   test('sanitizes markup out of variable values', function (assert) {
     let css = themeScopedCss(
       SCOPE,

--- a/packages/boxel-ui/test-app/tests/unit/theme-scoped-css-test.ts
+++ b/packages/boxel-ui/test-app/tests/unit/theme-scoped-css-test.ts
@@ -92,4 +92,25 @@ module('Unit | theme-scoped-css', function () {
     assert.false(css.includes('<script>'), 'script tag is stripped');
     assert.notOk((window as any).hacked, 'script does not execute');
   });
+
+  test('a scope cannot terminate the surrounding style element', function (assert) {
+    let css = themeScopedCss(
+      'x"]</style><script>window.hacked = true</script>',
+      ':root { --primary: blue; }',
+    ).toString();
+    assert.false(css.includes('<'), 'markup delimiters are CSS-escaped');
+    assert.true(
+      css.includes('[data-boxel-theme-scope="x\\"]\\3c /style>'),
+      'quote and < are escaped but the selector still targets the literal scope',
+    );
+  });
+
+  test('an escaped scope selector still matches its element', function (assert) {
+    let scope = 'https://example.test/card"</style>';
+    let css = themeScopedCss(scope, ':root { --primary: blue; }').toString();
+    let selector = css.slice(0, css.indexOf('{'));
+    let el = document.createElement('div');
+    el.setAttribute('data-boxel-theme-scope', scope);
+    assert.true(el.matches(selector), 'escaped selector matches the element');
+  });
 });

--- a/packages/boxel-ui/test-app/tests/unit/theme-scoped-css-test.ts
+++ b/packages/boxel-ui/test-app/tests/unit/theme-scoped-css-test.ts
@@ -1,0 +1,64 @@
+import { module, test } from 'qunit';
+
+import { themeScopedCss } from '@cardstack/boxel-ui/helpers';
+
+const SCOPE = 'ember123';
+const SELECTOR = `[data-boxel-theme-scope="${SCOPE}"]`;
+
+module('Unit | theme-scoped-css', function () {
+  test('scopes root variables to the theme-scope selector', function (assert) {
+    let css = themeScopedCss(
+      SCOPE,
+      ':root { --background: #fff; --primary: #112233; }',
+    ).toString();
+    assert.strictEqual(
+      css,
+      `${SELECTOR}{--background: #fff; --primary: #112233}`,
+    );
+  });
+
+  test('wraps dark variables in a color-scheme style container query', function (assert) {
+    let css = themeScopedCss(
+      SCOPE,
+      ':root { --primary: #112233; } .dark { --primary: #445566; }',
+    ).toString();
+    assert.strictEqual(
+      css,
+      `${SELECTOR}{--primary: #112233}` +
+        `@container style(--boxel-color-scheme: dark){${SELECTOR}{--primary: #445566}}`,
+    );
+  });
+
+  test('a dark-only theme emits only the container query block', function (assert) {
+    let css = themeScopedCss(SCOPE, '.dark { --primary: #445566; }').toString();
+    assert.strictEqual(
+      css,
+      `@container style(--boxel-color-scheme: dark){${SELECTOR}{--primary: #445566}}`,
+    );
+  });
+
+  test('bare declarations without a selector are treated as root variables', function (assert) {
+    let css = themeScopedCss(SCOPE, '--primary: #112233;').toString();
+    assert.strictEqual(css, `${SELECTOR}{--primary: #112233}`);
+  });
+
+  test('returns empty string without a scope or css', function (assert) {
+    assert.strictEqual(
+      themeScopedCss(undefined, ':root { --primary: red; }').toString(),
+      '',
+    );
+    assert.strictEqual(themeScopedCss(SCOPE, undefined).toString(), '');
+    assert.strictEqual(themeScopedCss(SCOPE, null).toString(), '');
+    assert.strictEqual(themeScopedCss(SCOPE, '').toString(), '');
+  });
+
+  test('sanitizes markup out of variable values', function (assert) {
+    let css = themeScopedCss(
+      SCOPE,
+      ':root { --primary: red</style><script>window.hacked = true</script>; }',
+    ).toString();
+    assert.false(css.includes('</style>'), 'closing style tag is stripped');
+    assert.false(css.includes('<script>'), 'script tag is stripped');
+    assert.notOk((window as any).hacked, 'script does not execute');
+  });
+});

--- a/packages/host/tests/acceptance/theme-card-test.gts
+++ b/packages/host/tests/acceptance/theme-card-test.gts
@@ -6,7 +6,6 @@ import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 
 import { BoxelInput } from '@cardstack/boxel-ui/components';
-import { dasherize } from '@cardstack/boxel-ui/helpers';
 
 import { baseRealm, Deferred } from '@cardstack/runtime-common';
 
@@ -92,11 +91,6 @@ const DARK_MODE_VARS = {
   trackingNormal: '0.01em',
 };
 
-const ROOT_STYLE_ATTRS = Object.entries(ROOT_CSS_VARS)
-  .sort()
-  .map(([key, val]) => [`--${dasherize(key)}`, val].join(': '))
-  .join('; ');
-
 const DARK_GOLD_THEME_VARS = {
   primary: '#ffd700',
   primaryForeground: '#0a0f23',
@@ -120,6 +114,14 @@ const FOREST_GREEN_THEME_VARS = {
   background: '#E8F5E9',
   spacing: '0.25rem',
 };
+
+function computedProperty(selector: string, property: string): string {
+  let el = document.querySelector(selector);
+  if (!el) {
+    throw new Error(`expected to find element: ${selector}`);
+  }
+  return window.getComputedStyle(el).getPropertyValue(property).trim();
+}
 
 function hexToRgb(hex: string): string {
   const r = parseInt(hex.slice(1, 3), 16);
@@ -472,27 +474,25 @@ module('Acceptance | theme-card-test', function (hooks) {
   });
 
   module('style-reference-card', () => {
-    test('renders with inline css variables', async function (assert) {
+    test('renders with scoped theme css variables', async function (assert) {
       await visitOperatorMode({
         stacks: [[{ id: styleRefCardId, format: 'isolated' }]],
       });
-      assert
-        .dom(`[data-test-card="${styleRefCardId}"] h1`)
-        .hasText('Starry Night');
-      assert
-        .dom(`[data-test-card="${styleRefCardId}"]`)
-        .hasClass('boxel-card-container--themed');
-      assert
-        .dom(`[data-test-card="${styleRefCardId}"]`)
-        .hasAttribute('style', ROOT_STYLE_ATTRS);
-
-      let container = document.querySelector<HTMLElement>(
-        `[data-test-card="${styleRefCardId}"]`,
+      let cardSelector = `[data-test-card="${styleRefCardId}"]`;
+      assert.dom(`${cardSelector} h1`).hasText('Starry Night');
+      assert.dom(cardSelector).hasClass('boxel-card-container--themed');
+      assert.dom(cardSelector).hasAttribute('data-boxel-theme-scope');
+      assert.strictEqual(
+        computedProperty(cardSelector, '--background'),
+        ROOT_CSS_VARS.background,
+        'computed --background matches the theme root variable',
       );
-      assert.ok(container, 'theme card container is present');
-      let computedFontFamily = window
-        .getComputedStyle(container!)
-        .getPropertyValue('font-family');
+      assert.strictEqual(
+        computedProperty(cardSelector, '--primary'),
+        ROOT_CSS_VARS.primary,
+        'computed --primary matches the theme root variable',
+      );
+      let computedFontFamily = computedProperty(cardSelector, 'font-family');
       assert.ok(
         computedFontFamily.includes('Libre Baskerville'),
         `computed font-family includes themed value`,
@@ -501,45 +501,32 @@ module('Acceptance | theme-card-test', function (hooks) {
   });
 
   module('structured-theme-card', () => {
-    test('renders with inline css variables', async function (assert) {
+    test('renders with scoped theme css variables', async function (assert) {
       await visitOperatorMode({
         stacks: [[{ id: themeCardId, format: 'isolated' }]],
       });
-      assert
-        .dom(`[data-test-card="${themeCardId}"] h1`)
-        .hasText('Starry Night');
+      let cardSelector = `[data-test-card="${themeCardId}"]`;
+      assert.dom(`${cardSelector} h1`).hasText('Starry Night');
       assert.dom('[data-test-css-field]').containsText('--radius: 0.75rem;');
-      assert
-        .dom(`[data-test-card="${themeCardId}"]`)
-        .hasClass('boxel-card-container--themed');
-      assert
-        .dom(`[data-test-card="${themeCardId}"]`)
-        .hasAttribute('style', ROOT_STYLE_ATTRS);
+      assert.dom(cardSelector).hasClass('boxel-card-container--themed');
+      assert.dom(cardSelector).hasAttribute('data-boxel-theme-scope');
 
-      let container = document.querySelector<HTMLElement>(
-        `[data-test-card="${themeCardId}"]`,
+      assert.strictEqual(
+        computedProperty(cardSelector, '--background'),
+        '#0a0f23',
+        'computed --background matches the root variable',
       );
-      assert.ok(container, 'theme card container is present');
-      let styleAttr = container?.getAttribute('style') ?? '';
-      assert.ok(
-        styleAttr.includes('--background: #0a0f23'),
-        'inline style includes root background variable',
+      assert.strictEqual(
+        computedProperty(cardSelector, '--chart-1'),
+        '#ffb347',
+        'computed --chart-1 matches the root variable',
       );
-      assert.ok(
-        styleAttr.includes('--chart-1: #ffb347'),
-        'inline style includes root chart-1 variable',
+      assert.strictEqual(
+        computedProperty(cardSelector, '--shadow-2xl'),
+        '0 6px 12px rgba(255, 215, 0, 0.5)',
+        'computed --shadow-2xl matches the root variable',
       );
-      assert.ok(
-        styleAttr.includes('--shadow-2xl: 0 6px 12px rgba(255, 215, 0, 0.5)'),
-        'inline style includes root shadow-2xl variable',
-      );
-      assert.false(
-        styleAttr.includes('--background: #050813'),
-        'dark mode value is not applied inline',
-      );
-      let computedFontFamily = window
-        .getComputedStyle(container!)
-        .getPropertyValue('font-family');
+      let computedFontFamily = computedProperty(cardSelector, 'font-family');
       assert.ok(
         computedFontFamily.includes('Libre Baskerville'),
         `computed font-family includes themed value`,
@@ -550,15 +537,80 @@ module('Acceptance | theme-card-test', function (hooks) {
         codePath: themeCardId,
         submode: 'code',
       });
-      assert
-        .dom(`[data-test-card="${themeCardId}"] h1`)
-        .hasText('Starry Night');
+      assert.dom(`${cardSelector} h1`).hasText('Starry Night');
       assert.dom('[data-test-css-field]').containsText('--radius: 0.75rem;');
-      assert
-        .dom(`[data-test-card="${themeCardId}"]`)
-        .hasAttribute('style', ROOT_STYLE_ATTRS);
+      assert.dom(cardSelector).hasAttribute('data-boxel-theme-scope');
+      assert.strictEqual(
+        computedProperty(cardSelector, '--background'),
+        '#0a0f23',
+        'computed --background matches the root variable in code submode',
+      );
 
       await percySnapshot(assert);
+    });
+
+    test('dark mode preview toggle applies dark theme variables to the dashboard', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: themeCardId, format: 'isolated' }]],
+      });
+      let dashboardSelector = `[data-test-card="${themeCardId}"] .detailed-style-reference`;
+      assert.strictEqual(
+        computedProperty(dashboardSelector, '--background'),
+        ROOT_CSS_VARS.background,
+        'dashboard shows root variables before toggling',
+      );
+
+      await click('[data-test-mode="toggle-dark"]');
+      assert.strictEqual(
+        computedProperty(dashboardSelector, '--background'),
+        DARK_MODE_VARS.background,
+        'dashboard shows dark mode variables after toggling dark',
+      );
+      assert.strictEqual(
+        computedProperty(dashboardSelector, '--primary'),
+        DARK_MODE_VARS.primary,
+        'dashboard --primary flips to the dark value',
+      );
+
+      await click('[data-test-mode="toggle-light"]');
+      assert.strictEqual(
+        computedProperty(dashboardSelector, '--background'),
+        ROOT_CSS_VARS.background,
+        'dashboard shows root variables again after toggling light',
+      );
+    });
+
+    test('dark mode variables apply when the ambient scheme is dark', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: themeCardId, format: 'isolated' }]],
+      });
+      let cardSelector = `[data-test-card="${themeCardId}"]`;
+      assert.strictEqual(
+        computedProperty(cardSelector, '--background'),
+        ROOT_CSS_VARS.background,
+        'root variables apply under the default light scheme',
+      );
+
+      document.documentElement.setAttribute('data-theme', 'dark');
+      try {
+        assert.strictEqual(
+          computedProperty(cardSelector, '--background'),
+          DARK_MODE_VARS.background,
+          'dark mode variables apply when the ambient scheme is dark',
+        );
+        assert.strictEqual(
+          computedProperty(cardSelector, '--primary'),
+          DARK_MODE_VARS.primary,
+          'dark mode --primary applies when the ambient scheme is dark',
+        );
+      } finally {
+        document.documentElement.removeAttribute('data-theme');
+      }
+      assert.strictEqual(
+        computedProperty(cardSelector, '--background'),
+        ROOT_CSS_VARS.background,
+        'root variables apply again when the ambient scheme returns to light',
+      );
     });
 
     test<TestContextWithSave>('applies pasted custom CSS variables', async function (assert) {
@@ -801,22 +853,31 @@ module('Acceptance | theme-card-test', function (hooks) {
       );
       assert.ok(container, 'themed card container is present');
 
-      let styleAttr = container?.getAttribute('style') ?? '';
-      assert.ok(
-        styleAttr.includes('--primary: #ffd700'),
-        'inline style includes --primary',
+      assert
+        .dom(`[data-test-card="${cardId}"]`)
+        .hasAttribute('data-boxel-theme-scope');
+      assert.strictEqual(
+        computedProperty(`[data-test-card="${cardId}"]`, '--primary'),
+        '#ffd700',
+        'computed --primary matches the theme',
       );
-      assert.ok(
-        styleAttr.includes('--border: #3a4073'),
-        'inline style includes --border',
+      assert.strictEqual(
+        computedProperty(`[data-test-card="${cardId}"]`, '--border'),
+        '#3a4073',
+        'computed --border matches the theme',
       );
-      assert.ok(
-        styleAttr.includes('--background: #1a1f3a'),
-        'inline style includes --background',
+      assert.strictEqual(
+        computedProperty(`[data-test-card="${cardId}"]`, '--background'),
+        '#1a1f3a',
+        'computed --background matches the theme',
       );
-      assert.ok(
-        styleAttr.includes('--theme-body-font-size: 18px'),
-        'inline style includes --theme-body-font-size',
+      assert.strictEqual(
+        computedProperty(
+          `[data-test-card="${cardId}"]`,
+          '--theme-body-font-size',
+        ),
+        '18px',
+        'computed --theme-body-font-size matches the theme',
       );
 
       assert
@@ -874,22 +935,31 @@ module('Acceptance | theme-card-test', function (hooks) {
       );
       assert.ok(container, 'themed card container is present');
 
-      let styleAttr = container?.getAttribute('style') ?? '';
-      assert.ok(
-        styleAttr.includes('--primary: #0058A3'),
-        'inline style includes --primary',
+      assert
+        .dom(`[data-test-card="${cardId}"]`)
+        .hasAttribute('data-boxel-theme-scope');
+      assert.strictEqual(
+        computedProperty(`[data-test-card="${cardId}"]`, '--primary'),
+        '#0058A3',
+        'computed --primary matches the theme',
       );
-      assert.ok(
-        styleAttr.includes('--border: #003B6F'),
-        'inline style includes --border',
+      assert.strictEqual(
+        computedProperty(`[data-test-card="${cardId}"]`, '--border'),
+        '#003B6F',
+        'computed --border matches the theme',
       );
-      assert.ok(
-        styleAttr.includes('--background: #E3F2FD'),
-        'inline style includes --background',
+      assert.strictEqual(
+        computedProperty(`[data-test-card="${cardId}"]`, '--background'),
+        '#E3F2FD',
+        'computed --background matches the theme',
       );
-      assert.ok(
-        styleAttr.includes('--theme-body-font-size: 14px'),
-        'inline style includes --theme-body-font-size',
+      assert.strictEqual(
+        computedProperty(
+          `[data-test-card="${cardId}"]`,
+          '--theme-body-font-size',
+        ),
+        '14px',
+        'computed --theme-body-font-size matches the theme',
       );
 
       assert
@@ -947,22 +1017,31 @@ module('Acceptance | theme-card-test', function (hooks) {
       );
       assert.ok(container, 'themed card container is present');
 
-      let styleAttr = container?.getAttribute('style') ?? '';
-      assert.ok(
-        styleAttr.includes('--primary: #2e7d32'),
-        'inline style includes --primary',
+      assert
+        .dom(`[data-test-card="${cardId}"]`)
+        .hasAttribute('data-boxel-theme-scope');
+      assert.strictEqual(
+        computedProperty(`[data-test-card="${cardId}"]`, '--primary'),
+        '#2e7d32',
+        'computed --primary matches the theme',
       );
-      assert.ok(
-        styleAttr.includes('--border: #1b5e20'),
-        'inline style includes --border',
+      assert.strictEqual(
+        computedProperty(`[data-test-card="${cardId}"]`, '--border'),
+        '#1b5e20',
+        'computed --border matches the theme',
       );
-      assert.ok(
-        styleAttr.includes('--background: #E8F5E9'),
-        'inline style includes --background',
+      assert.strictEqual(
+        computedProperty(`[data-test-card="${cardId}"]`, '--background'),
+        '#E8F5E9',
+        'computed --background matches the theme',
       );
-      assert.ok(
-        styleAttr.includes('--theme-body-font-size: 16px'),
-        'inline style includes --theme-body-font-size',
+      assert.strictEqual(
+        computedProperty(
+          `[data-test-card="${cardId}"]`,
+          '--theme-body-font-size',
+        ),
+        '16px',
+        'computed --theme-body-font-size matches the theme',
       );
 
       assert

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -2017,7 +2017,6 @@ module(`Integration | realm indexing`, function (hooks) {
           class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
           data-boxel-card-container
           data-test-boxel-card-container
-          style
           data-boxel-card-id="http://test-realm/test/germaine"
           data-boxel-card-format="embedded"
           data-test-card="http://test-realm/test/germaine"
@@ -2054,7 +2053,6 @@ module(`Integration | realm indexing`, function (hooks) {
         class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
         data-boxel-card-container
         data-test-boxel-card-container
-        style
         data-boxel-card-id="http://test-realm/test/germaine"
         data-boxel-card-format="embedded"
         data-test-card="http://test-realm/test/germaine"
@@ -2073,7 +2071,6 @@ module(`Integration | realm indexing`, function (hooks) {
         class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
         data-boxel-card-container
         data-test-boxel-card-container
-        style
         data-boxel-card-id="http://test-realm/test/germaine"
         data-boxel-card-format="embedded"
         data-test-card="http://test-realm/test/germaine"
@@ -2170,7 +2167,6 @@ module(`Integration | realm indexing`, function (hooks) {
           class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card fitted-format display-container-true"
           data-boxel-card-container
           data-test-boxel-card-container
-          style
           data-boxel-card-id="http://test-realm/test/germaine"
           data-boxel-card-format="fitted"
           data-test-card="http://test-realm/test/germaine"
@@ -2205,7 +2201,6 @@ module(`Integration | realm indexing`, function (hooks) {
       class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card fitted-format display-container-true"
       data-boxel-card-container
       data-test-boxel-card-container
-      style
       data-boxel-card-id="http://test-realm/test/germaine"
       data-boxel-card-format="fitted"
       data-test-card="http://test-realm/test/germaine"
@@ -2224,7 +2219,6 @@ module(`Integration | realm indexing`, function (hooks) {
       class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
       data-boxel-card-container
       data-test-boxel-card-container
-      style
       data-boxel-card-id="http://test-realm/test/germaine"
       data-boxel-card-format="embedded"
       data-test-card="http://test-realm/test/germaine"

--- a/packages/software-factory/realm/issue-tracker.gts
+++ b/packages/software-factory/realm/issue-tracker.gts
@@ -3215,13 +3215,13 @@ class IssueTrackerIsolated extends Component<typeof IssueTracker> {
     </div>
     <style scoped>
       .kanban-board-isolated {
-        --board-bg: var(--background, var(--boxel-100));
-        --board-fg: var(--foreground, var(--boxel-700));
-        --board-card-bg: var(--card, var(--boxel-light));
-        --board-card-fg: var(--foreground, var(--boxel-dark));
-        --board-muted-bg: var(--muted, var(--boxel-100));
-        --board-muted-fg: var(--muted-foreground, var(--boxel-500));
-        --board-border: var(--border, var(--boxel-border-color));
+        --board-bg: color-mix(in oklch, var(--foreground) 1%, transparent);
+        --board-fg: var(--foreground);
+        --board-card-bg: var(--card);
+        --board-card-fg: var(--card-foreground);
+        --board-muted-bg: var(--muted);
+        --board-muted-fg: var(--muted-foreground);
+        --board-border: var(--border);
 
         /* setting boxel-ui component variables */
         --boxel-kanban-bg: var(--board-bg);


### PR DESCRIPTION
## Summary

Card theme CSS is applied as a stylesheet scoped to the card's container, rather than as an inline `style` attribute of resolved variable values.

- `CardContainer` takes `@themeCss` (raw `:root` + optional `.dark` variable blocks) and `@themeScope`, stamps `data-boxel-theme-scope` on the container, and emits a `<style>` element built by the new `themeScopedCss` helper.
- **Dark mode with no JS:** the theme's `:root` variables apply by default; its `.dark` variables take over via a CSS style container query on `--boxel-color-scheme` — an inherited signal `theme.css` sets on each `[data-theme]` element. Because the signal inherits, a themed card follows its *nearest* ancestor's scheme, so dark pages, light islands, and nested overrides all work without inline styles or `!important`.
- **Stable scope for prerendered HTML:** the scope id derives from the card id, so persisted prerendered HTML keeps matching its stylesheet across builds and prerender processes. A guid fallback covers unsaved cards, which are never persisted.
- **Theme boundary reset:** `theme.css` re-declares the full semantic-token contract at zero specificity via `:where([data-boxel-theme-scope])`, so a themed card only inherits the tokens its own theme defines — chrome or outer-theme values can't leak in. The `--theme-*` typography/scale knobs reset to `initial` at the same boundary.
- **Contained typographic reset:** `CardContainer`'s element reset and heading roles are guarded by `.boxel-card-container` instead of bare global `h1`/`h2`/`p` selectors, so rendering one card no longer restyles the whole document.
- **Injection hardening:** the scope value is escaped for use in the attribute selector, and declaration values containing `{`/`}` are rejected so theme data can't close the scoped block and inject page-wide rules.
- `ThemeDashboard`'s preview re-scopes the theme's variables inside its own `data-theme` wrapper, so its light/dark toggle drives the preview subtree independently of the app chrome's scheme.

## Testing

- New unit tests for `themeScopedCss` (selector escaping, light/dark emission, declaration sanitization).
- New `CardContainer` integration tests covering the scoped theme stylesheet.
- Theme-card acceptance tests updated for the scoped-stylesheet rendering.
- Realm-indexing snapshots updated: card containers no longer carry a `style` attribute.