### PR TITLE
fix: atomic upload result mapping breaks when the realm returns resource-identifier ids

### DIFF
--- a/packages/boxel-cli/src/commands/realm/push.ts
+++ b/packages/boxel-cli/src/commands/realm/push.ts
@@ -205,11 +205,16 @@ class RealmPusher extends RealmSyncBase {
       // binary POST fails — dropping the manifest update in that
       // case would force a re-add on the next push (409 cascade).
       if (result.succeeded.length > 0) {
+        // Guard the map lookup: `succeeded` should only carry paths from
+        // `filesToUpload`, but a server response in an unexpected shape must
+        // degrade to a manifest gap (re-upload next push), not a crash.
         const uploaded = await Promise.all(
-          result.succeeded.map(async (rel) => ({
-            rel,
-            hash: await computeFileHash(filesToUpload.get(rel)!),
-          })),
+          result.succeeded
+            .filter((rel) => filesToUpload.has(rel))
+            .map(async (rel) => ({
+              rel,
+              hash: await computeFileHash(filesToUpload.get(rel)!),
+            })),
         );
         for (const { rel, hash } of uploaded) {
           newManifest.files[rel] = hash;

--- a/packages/boxel-cli/src/lib/realm-sync-base.ts
+++ b/packages/boxel-cli/src/lib/realm-sync-base.ts
@@ -680,16 +680,25 @@ export abstract class RealmSyncBase {
       const body = (await response.json()) as {
         'atomic:results'?: Array<{ data?: { id?: string } }>;
       };
-      // The realm normalizes hrefs: a path with a space goes out as
-      // `Knowledge Articles/...` but comes back URL-encoded as
-      // `Knowledge%20Articles/...`. Decode the response id before the
-      // map lookup so we resolve back to the original relative path
-      // instead of falling through to the raw encoded URL.
-      const atomicSucceeded = (body['atomic:results'] ?? [])
-        .map((r) => r.data?.id)
-        .filter((id): id is string => typeof id === 'string')
-        .map((id) => decodeAtomicResultId(id))
-        .map((id) => hrefToRelative.get(id) ?? id);
+      const results = body['atomic:results'] ?? [];
+      // atomic:results are positional: result[i] answers operations[i]. Map
+      // back to relative paths by index rather than by matching the returned
+      // id string — the server may express ids in forms this side cannot
+      // reconstruct (URL-encoded hrefs, or resource identifiers like
+      // `@cardstack/skills/...`), and a missed match used to leak raw ids
+      // into `succeeded`, crashing the manifest hashing downstream.
+      let atomicSucceeded: string[];
+      if (results.length === textEntries.length) {
+        atomicSucceeded = textEntries.map(([rel]) => rel);
+      } else {
+        // Unexpected shape; fall back to id matching (decoding the
+        // URL-encoded href form) and drop anything unmatched.
+        atomicSucceeded = results
+          .map((r) => r.data?.id)
+          .filter((id): id is string => typeof id === 'string')
+          .map((id) => hrefToRelative.get(decodeAtomicResultId(id)))
+          .filter((rel): rel is string => rel !== undefined);
+      }
       for (const rel of atomicSucceeded) {
         console.log(`  Uploaded: ${rel}`);
       }

--- a/packages/boxel-cli/tests/helpers/integration.ts
+++ b/packages/boxel-cli/tests/helpers/integration.ts
@@ -87,6 +87,14 @@ export interface StartTestRealmServerOptions {
    * realm-server JWT via `setupJwtTestProfile`).
    */
   registerMatrixUser?: boolean;
+  /**
+   * Realm-prefix mappings (prefix → realm URL, e.g.
+   * `'@cli-test/prefixed/': '${TEST_REALM_SERVER_URL}/test/'`) registered on
+   * the server's virtual network before boot. A mapped realm serves its
+   * document ids in prefix (RRI) form, matching production prefix-form
+   * realms like `@cardstack/skills/`.
+   */
+  realmPrefixes?: Record<string, string>;
 }
 
 export async function startTestRealmServer(
@@ -123,6 +131,9 @@ export async function startTestRealmServer(
   });
 
   let virtualNetwork = createVirtualNetwork();
+  for (let [prefix, target] of Object.entries(options.realmPrefixes ?? {})) {
+    virtualNetwork.addRealmMapping(prefix, target);
+  }
   realmsRootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-cli-realms-'));
 
   let realms: RealmConfig[] = options.realms ?? [

--- a/packages/boxel-cli/tests/integration/realm-push-rri.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-push-rri.test.ts
@@ -1,0 +1,128 @@
+import '../helpers/setup-realm-server.ts';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { pushCommand } from '../../src/commands/realm/push.ts';
+import {
+  startTestRealmServer,
+  stopTestRealmServer,
+  createTestProfileDir,
+  setupTestProfile,
+  TEST_REALM_SERVER_URL,
+} from '../helpers/integration.ts';
+import type { ProfileManager } from '../../src/lib/profile-manager.ts';
+
+// A realm with a registered prefix mapping serves its document ids in RRI
+// form (`@cli-test/prefixed/...`) rather than as URLs — the shape that made
+// `realm push` crash after uploading (raw ids leaked into the succeeded list
+// and were treated as local file paths). This suite pushes against such a
+// realm end to end.
+
+const REALM_PREFIX = '@cli-test/prefixed/';
+
+let profileManager: ProfileManager;
+let cleanupProfile: () => void;
+let realmUrl: string;
+let localDirs: string[] = [];
+
+function makeLocalDir(): string {
+  let dir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-push-rri-int-'));
+  localDirs.push(dir);
+  return dir;
+}
+
+function writeLocalFile(localDir: string, relPath: string, content: string) {
+  let fullPath = path.join(localDir, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content);
+}
+
+interface SyncManifest {
+  realmUrl: string;
+  files: Record<string, string>;
+}
+
+function readManifest(localDir: string): SyncManifest {
+  return JSON.parse(
+    fs.readFileSync(path.join(localDir, '.boxel-sync.json'), 'utf8'),
+  );
+}
+
+beforeAll(async () => {
+  realmUrl = `${TEST_REALM_SERVER_URL}/test/`;
+  await startTestRealmServer({
+    fileSystem: {
+      'seed.txt': 'seeded\n',
+    },
+    realmPrefixes: { [REALM_PREFIX]: realmUrl },
+  });
+
+  let testProfile = createTestProfileDir();
+  profileManager = testProfile.profileManager;
+  cleanupProfile = testProfile.cleanup;
+  await setupTestProfile(profileManager);
+});
+
+afterAll(async () => {
+  for (let dir of localDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  cleanupProfile?.();
+  await stopTestRealmServer();
+});
+
+describe('realm push against a prefix-form RRI realm (integration)', () => {
+  it('the realm serves atomic result ids in prefix form', async () => {
+    // Pins the precondition the regression test below relies on: if the
+    // server stops answering in RRI form, this fails rather than the suite
+    // silently testing the URL-form path.
+    let response = await profileManager.authedRealmFetch(`${realmUrl}_atomic`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/vnd.api+json',
+        Accept: 'application/vnd.api+json',
+      },
+      body: JSON.stringify({
+        'atomic:operations': [
+          {
+            op: 'add',
+            href: `${realmUrl}precondition-check.txt`,
+            data: {
+              type: 'source',
+              attributes: { content: 'x\n' },
+              meta: {},
+            },
+          },
+        ],
+      }),
+    });
+    expect(response.status).toBe(201);
+    let body = (await response.json()) as {
+      'atomic:results': Array<{ data?: { id?: string } }>;
+    };
+    expect(body['atomic:results'][0]?.data?.id).toMatch(
+      new RegExp(`^${REALM_PREFIX.replace(/[@/]/g, '\\$&')}`),
+    );
+  });
+
+  it('pushes files and records the manifest by relative path', async () => {
+    let localDir = makeLocalDir();
+    writeLocalFile(localDir, 'hello.txt', 'hello\n');
+    writeLocalFile(localDir, 'nested/card.gts', 'export const x = 1;\n');
+
+    await pushCommand(localDir, realmUrl, { profileManager });
+
+    let manifest = readManifest(localDir);
+    expect(manifest.realmUrl).toBe(realmUrl);
+    expect(Object.keys(manifest.files).sort()).toEqual([
+      'hello.txt',
+      'nested/card.gts',
+    ]);
+    // Hashes only get recorded when the succeeded list maps back to real
+    // local paths — the exact step that crashed on RRI-form ids.
+    for (let hash of Object.values(manifest.files)) {
+      expect(hash).toMatch(/^[0-9a-f]{32}$/);
+    }
+  });
+});


### PR DESCRIPTION
Yesterday #5390 changed RRI-prefix realms (like the skills realm) to return ids as `@cardstack/skills/...` instead of full URLs. That broke `boxel realm push` against those realms — it only surfaced today with the first real boxel-skills → staging sync (run 28848681319), because PR builds are dry-runs and never hit this code path.

The reason: after uploading, the CLI matches the server's returned ids against the URLs it built, to update its sync manifest. The new id form matches nothing, the raw id falls through as a "file path", and `readFile` crashes the push — after all files already uploaded fine.

The fix: map results back by position (result 3 answers upload 3), which works for any id format. String matching stays only as a mismatch fallback, and unmatched entries are dropped instead of passed along.
