### PR TITLE
Add tooltips with shortcut hints to the markdown editor toolbar

### DIFF
--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -1702,7 +1702,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           padding: 0 var(--boxel-sp-5xs);
           border-radius: var(--boxel-border-radius-xs, 4px);
           background: rgb(0 0 0 / 35%);
-          color: #939393;
+          color: var(--boxel-450, #939393);
           font-family: inherit;
           font-size: 0.9em;
           line-height: 1.5;

--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -5,6 +5,7 @@ import { modifier } from 'ember-modifier';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { scheduleOnce } from '@ember/runloop';
+import { Tooltip } from '@cardstack/boxel-ui/components';
 import { eq, not } from '@cardstack/boxel-ui/helpers';
 
 import {
@@ -95,6 +96,14 @@ interface CodeMirrorContext {
 
 const SAVE_DEBOUNCE_MS = 500;
 
+// The symbol CodeMirror's `Mod-` binding resolves to per platform: ⌘ on macOS,
+// Ctrl elsewhere. Kept local to this file — the toolbar tooltips are its only
+// consumer.
+const modKey =
+  typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform)
+    ? '⌘'
+    : 'Ctrl';
+
 function isInline(kind: string): boolean {
   return kind === 'inline';
 }
@@ -179,6 +188,10 @@ interface ToolbarItem {
   action?: () => void;
   active?: boolean;
   ariaPressed?: 'true' | 'false';
+  // Key-command hint shown as a badge in the tooltip. Set only for items with a
+  // binding in the CodeMirror keymap (bold/italic/code); absent items render a
+  // label-only tooltip.
+  shortcut?: string;
 }
 
 const EMPTY_FORMATS: SelectionFormats = Object.freeze({
@@ -450,6 +463,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         action: this._wrapBold,
         active: f.bold,
         ariaPressed: pressed(f.bold),
+        shortcut: `${modKey}B`,
       },
       {
         testId: 'italic',
@@ -458,6 +472,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         action: this._wrapItalic,
         active: f.italic,
         ariaPressed: pressed(f.italic),
+        shortcut: `${modKey}I`,
       },
       {
         testId: 'strikethrough',
@@ -474,6 +489,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         action: this._wrapCode,
         active: f.code,
         ariaPressed: pressed(f.code),
+        shortcut: `${modKey}\``,
       },
       {
         testId: 'link',
@@ -1091,28 +1107,44 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           {{/if}}
 
           {{#if this._currentBfmRef}}
-            <button
-              class='toolbar-btn'
-              data-test-toolbar='edit-embed'
-              type='button'
-              title='Edit embed'
-              aria-label='Edit embed'
-              {{on 'mousedown' this._preventFocusLoss}}
-              {{on 'click' this._openEditEmbed}}
-            ><PencilIcon width='16' height='16' /></button>
+            <Tooltip @placement='top' data-test-toolbar-tooltip='edit-embed'>
+              <:trigger>
+                <button
+                  class='toolbar-btn'
+                  data-test-toolbar='edit-embed'
+                  type='button'
+                  aria-label='Edit embed'
+                  {{on 'mousedown' this._preventFocusLoss}}
+                  {{on 'click' this._openEditEmbed}}
+                ><PencilIcon width='16' height='16' /></button>
+              </:trigger>
+              <:content>
+                <span class='toolbar-tooltip'>
+                  <span class='toolbar-tooltip__label'>Edit embed</span>
+                </span>
+              </:content>
+            </Tooltip>
           {{else}}
             <div class='toolbar-embed-trigger'>
-              <button
-                class='toolbar-btn
-                  {{if this._embedPopoverOpen "toolbar-btn--active"}}'
-                data-test-toolbar='add-embed'
-                type='button'
-                title='Add embed'
-                aria-label='Add embed'
-                aria-expanded={{if this._embedPopoverOpen 'true' 'false'}}
-                {{on 'mousedown' this._preventFocusLoss}}
-                {{on 'click' this._toggleEmbedPopover}}
-              ><PlusIcon width='16' height='16' /></button>
+              <Tooltip @placement='top' data-test-toolbar-tooltip='add-embed'>
+                <:trigger>
+                  <button
+                    class='toolbar-btn
+                      {{if this._embedPopoverOpen "toolbar-btn--active"}}'
+                    data-test-toolbar='add-embed'
+                    type='button'
+                    aria-label='Add embed'
+                    aria-expanded={{if this._embedPopoverOpen 'true' 'false'}}
+                    {{on 'mousedown' this._preventFocusLoss}}
+                    {{on 'click' this._toggleEmbedPopover}}
+                  ><PlusIcon width='16' height='16' /></button>
+                </:trigger>
+                <:content>
+                  <span class='toolbar-tooltip'>
+                    <span class='toolbar-tooltip__label'>Add embed</span>
+                  </span>
+                </:content>
+              </Tooltip>
               {{#if this._embedPopoverOpen}}
                 <div
                   class='toolbar-embed-popover'
@@ -1142,20 +1174,38 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
             {{#if btn.divider}}
               <span class='toolbar-divider'></span>
             {{else}}
-              <button
-                class='toolbar-btn {{if btn.active "toolbar-btn--active"}}'
-                data-test-toolbar={{btn.testId}}
-                type='button'
-                title={{btn.label}}
-                aria-label={{btn.label}}
-                aria-pressed={{btn.ariaPressed}}
-                disabled={{not this.toolbarEnabled}}
-                {{on 'mousedown' this._preventFocusLoss}}
-                {{on 'click' btn.action}}
-              >{{#let btn.icon as |Icon|}}<Icon
-                    width='16'
-                    height='16'
-                  />{{/let}}</button>
+              {{! Every item gets a styled tooltip — the label, plus a shortcut
+                  key badge when the item has a CodeMirror binding. The tooltip
+                  is suppressed while the control is disabled. }}
+              <Tooltip
+                @placement='top'
+                @disabled={{not this.toolbarEnabled}}
+                data-test-toolbar-tooltip={{btn.testId}}
+              >
+                <:trigger>
+                  <button
+                    class='toolbar-btn {{if btn.active "toolbar-btn--active"}}'
+                    data-test-toolbar={{btn.testId}}
+                    type='button'
+                    aria-label={{btn.label}}
+                    aria-pressed={{btn.ariaPressed}}
+                    disabled={{not this.toolbarEnabled}}
+                    {{on 'mousedown' this._preventFocusLoss}}
+                    {{on 'click' btn.action}}
+                  >{{#let btn.icon as |Icon|}}<Icon
+                        width='16'
+                        height='16'
+                      />{{/let}}</button>
+                </:trigger>
+                <:content>
+                  <span class='toolbar-tooltip'>
+                    <span class='toolbar-tooltip__label'>{{btn.label}}</span>
+                    {{#if btn.shortcut}}
+                      <kbd class='shortcut-key'>{{btn.shortcut}}</kbd>
+                    {{/if}}
+                  </span>
+                </:content>
+              </Tooltip>
             {{/if}}
           {{/each}}
         </div>
@@ -1632,6 +1682,30 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         .toolbar-btn:disabled {
           color: var(--muted-foreground, var(--boxel-300));
           cursor: not-allowed;
+        }
+
+        /* Tooltip content: label at left, shortcut in a darker key badge at
+           right. Rendered into the shared #tooltip-overlay, but these rules
+           still apply — scoped CSS keys off the element's class, not its
+           position in the DOM tree. */
+        .toolbar-tooltip {
+          display: inline-flex;
+          align-items: center;
+          gap: var(--boxel-sp-xxs);
+        }
+
+        .shortcut-key {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          min-width: 1.4em;
+          padding: 0 var(--boxel-sp-5xs);
+          border-radius: var(--boxel-border-radius-xs, 4px);
+          background: rgb(0 0 0 / 35%);
+          color: #939393;
+          font-family: inherit;
+          font-size: 0.9em;
+          line-height: 1.5;
         }
 
         .toolbar-divider {

--- a/packages/boxel-ui/addon/src/components/tooltip/index.gts
+++ b/packages/boxel-ui/addon/src/components/tooltip/index.gts
@@ -24,6 +24,9 @@ export type TooltipThemeVariant = (typeof TOOLTIP_VARIANTS)[number];
 
 interface Signature {
   Args: {
+    // When true, hovering the trigger does not reveal the tooltip content.
+    // Useful for wrapping a disabled control whose hint would otherwise show.
+    disabled?: boolean;
     offset?: number;
     placement?: MiddlewareState['placement'];
     variant?: TooltipThemeVariant;
@@ -47,6 +50,10 @@ export default class Tooltip extends Component<Signature> {
 
   get triggerEl(): HTMLElement {
     return this.triggerElement as HTMLElement;
+  }
+
+  get showContent(): boolean {
+    return this.isHoverOnTrigger && !this.args.disabled;
   }
 
   get appRootEl(): HTMLElement {
@@ -177,7 +184,7 @@ export default class Tooltip extends Component<Signature> {
       >
         {{yield to='trigger'}}
       </div>
-      {{#if this.isHoverOnTrigger}}
+      {{#if this.showContent}}
         {{#in-element this.tooltipOverlay}}
           {{! @glint-ignore velcro.loop }}
           <div

--- a/packages/host/app/components/markdown-embed-chooser/modal.gts
+++ b/packages/host/app/components/markdown-embed-chooser/modal.gts
@@ -116,6 +116,11 @@ export default class MarkdownEmbedChooserModal extends Component<Signature> {
   @action
   private handleKeydown(event: Event) {
     if ((event as KeyboardEvent).key === 'Escape') {
+      // Own the Escape here: stop it before it reaches the document-level
+      // operator-mode handler, which would otherwise flip the card out of edit
+      // format once closing this modal has cleared the `has-modal` guard.
+      event.preventDefault();
+      event.stopPropagation();
       this.handleClose();
     }
   }
@@ -138,6 +143,8 @@ export default class MarkdownEmbedChooserModal extends Component<Signature> {
         class='markdown-embed-chooser-modal'
         @title=''
         @onClose={{this.handleClose}}
+        @closeButtonLabel='close'
+        @closeButtonShortcut='ESC'
         @size='large'
         @centered={{true}}
         @cardContainerClass='markdown-embed-chooser-modal__container'

--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -6,6 +6,7 @@ import {
   Header,
   IconButton,
   Modal,
+  Tooltip,
 } from '@cardstack/boxel-ui/components';
 
 import { IconX } from '@cardstack/boxel-ui/icons';
@@ -21,6 +22,11 @@ interface Signature {
     isOpen?: boolean;
     isCloseDisabled?: boolean;
     layer?: 'urgent';
+    // When a shortcut is supplied, the close button gets a styled tooltip
+    // (label + key badge). Opt-in, so the many modals that don't wire a close
+    // shortcut render the plain close button unchanged.
+    closeButtonLabel?: string;
+    closeButtonShortcut?: string;
   };
   Blocks: {
     content: [];
@@ -36,6 +42,9 @@ export default class ModalContainer extends Component<Signature> {
   }
   get isOpen() {
     return this.args.isOpen ?? true;
+  }
+  get closeButtonLabel() {
+    return this.args.closeButtonLabel ?? 'Close';
   }
 
   <template>
@@ -61,16 +70,45 @@ export default class ModalContainer extends Component<Signature> {
           </aside>
         {{/if}}
         <Header @size='large' @title={{@title}} class='dialog-box__header'>
-          <IconButton
-            @icon={{IconX}}
-            @width='12'
-            @height='12'
-            {{on 'click' @onClose}}
-            class='dialog-box__close'
-            aria-label='close modal'
-            disabled={{@isCloseDisabled}}
-            data-test-close-modal
-          />
+          {{#if @closeButtonShortcut}}
+            <Tooltip
+              @placement='bottom'
+              @disabled={{@isCloseDisabled}}
+              class='dialog-box__close-tooltip'
+            >
+              <:trigger>
+                <IconButton
+                  @icon={{IconX}}
+                  @width='12'
+                  @height='12'
+                  {{on 'click' @onClose}}
+                  class='dialog-box__close dialog-box__close--in-tooltip'
+                  aria-label='close modal'
+                  disabled={{@isCloseDisabled}}
+                  data-test-close-modal
+                />
+              </:trigger>
+              <:content>
+                <span class='close-tooltip'>
+                  <span
+                    class='close-tooltip__label'
+                  >{{this.closeButtonLabel}}</span>
+                  <kbd class='shortcut-key'>{{@closeButtonShortcut}}</kbd>
+                </span>
+              </:content>
+            </Tooltip>
+          {{else}}
+            <IconButton
+              @icon={{IconX}}
+              @width='12'
+              @height='12'
+              {{on 'click' @onClose}}
+              class='dialog-box__close'
+              aria-label='close modal'
+              disabled={{@isCloseDisabled}}
+              data-test-close-modal
+            />
+          {{/if}}
           {{yield to='header'}}
         </Header>
         <div class='dialog-box__content'>
@@ -153,6 +191,42 @@ export default class ModalContainer extends Component<Signature> {
       .dialog-box__close:disabled {
         --icon-color: var(--boxel-300);
         cursor: default;
+      }
+
+      /* When the close button carries a tooltip, the Tooltip's trigger wrapper
+         takes over the absolute placement so it (and the anchored overlay) hug
+         the top-right corner; the button itself sits statically inside it. */
+      .dialog-box__close-tooltip {
+        position: absolute;
+        top: 1px;
+        right: 1px;
+        z-index: 1;
+      }
+
+      .dialog-box__close--in-tooltip {
+        position: static;
+      }
+
+      /* Tooltip content: label at left, key badge at right. Lives in the shared
+         #tooltip-overlay, but scoped CSS keys off the class, not DOM position. */
+      .close-tooltip {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--boxel-sp-xxs);
+      }
+
+      .shortcut-key {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 1.4em;
+        padding: 0 var(--boxel-sp-5xs);
+        border-radius: var(--boxel-border-radius-xs, 4px);
+        background: rgb(0 0 0 / 35%);
+        color: #939393;
+        font-family: inherit;
+        font-size: 0.9em;
+        line-height: 1.5;
       }
 
       .dialog-box__footer {

--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -223,7 +223,7 @@ export default class ModalContainer extends Component<Signature> {
         padding: 0 var(--boxel-sp-5xs);
         border-radius: var(--boxel-border-radius-xs, 4px);
         background: rgb(0 0 0 / 35%);
-        color: #939393;
+        color: var(--boxel-450, #939393);
         font-family: inherit;
         font-size: 0.9em;
         line-height: 1.5;

--- a/packages/host/tests/integration/components/codemirror-embed-toolbar-test.gts
+++ b/packages/host/tests/integration/components/codemirror-embed-toolbar-test.gts
@@ -5,6 +5,7 @@ import {
   fillIn,
   render,
   settled,
+  triggerEvent,
   waitFor,
   waitUntil,
 } from '@ember/test-helpers';
@@ -202,6 +203,19 @@ module('Integration | codemirror embed toolbar', function (hooks) {
     assert
       .dom('[data-test-toolbar="add-embed"]')
       .exists('Add embed lives in the toolbar when no directive is focused');
+    // Add-embed has no key command → a label-only tooltip (no shortcut badge).
+    assert
+      .dom('[data-test-toolbar-tooltip="add-embed"]')
+      .exists('Add embed is wrapped in a tooltip trigger');
+    await triggerEvent('[data-test-toolbar-tooltip="add-embed"]', 'mouseenter');
+    await waitFor('[data-test-tooltip-content]');
+    assert
+      .dom('[data-test-tooltip-content]')
+      .hasText('Add embed', 'tooltip shows the Add embed label');
+    assert
+      .dom('[data-test-tooltip-content] .shortcut-key')
+      .doesNotExist('shortcut-less item has no shortcut badge');
+    await triggerEvent('[data-test-toolbar-tooltip="add-embed"]', 'mouseleave');
     assert
       .dom('[data-test-toolbar-embed-popover]')
       .doesNotExist('popover is closed by default');
@@ -278,6 +292,22 @@ module('Integration | codemirror embed toolbar', function (hooks) {
       .exists(
         'Edit pencil replaces the Add popover when the cursor is inside a directive',
       );
+    // Edit-embed has no key command → a label-only tooltip (no shortcut badge).
+    assert
+      .dom('[data-test-toolbar-tooltip="edit-embed"]')
+      .exists('Edit embed is wrapped in a tooltip trigger');
+    await triggerEvent(
+      '[data-test-toolbar-tooltip="edit-embed"]',
+      'mouseenter',
+    );
+    await waitFor('[data-test-tooltip-content]');
+    assert
+      .dom('[data-test-tooltip-content]')
+      .hasText('Edit embed', 'tooltip shows the Edit embed label');
+    await triggerEvent(
+      '[data-test-toolbar-tooltip="edit-embed"]',
+      'mouseleave',
+    );
 
     await click('[data-test-toolbar="edit-embed"]');
     await waitFor('[data-test-markdown-embed-chooser-modal]');

--- a/packages/host/tests/integration/components/markdown-embed-chooser-modal-test.gts
+++ b/packages/host/tests/integration/components/markdown-embed-chooser-modal-test.gts
@@ -3,6 +3,8 @@ import {
   click,
   fillIn,
   render,
+  triggerEvent,
+  triggerKeyEvent,
   waitFor,
   waitUntil,
 } from '@ember/test-helpers';
@@ -208,6 +210,69 @@ module('Integration | markdown-embed-chooser-modal', function (hooks) {
     await click('[data-test-close-modal]');
     let result = await pending;
     assert.strictEqual(result, undefined, 'cancelling resolves with undefined');
+    await waitUntil(
+      () => !document.querySelector('[data-test-markdown-embed-chooser-modal]'),
+    );
+  });
+
+  test('the close button shows an ESC tooltip and Escape closes the modal', async function (assert) {
+    await render(
+      <template>
+        <HostContextProvider>
+          <MarkdownEmbedChooserModal />
+        </HostContextProvider>
+      </template>,
+    );
+
+    let svc = getService(
+      'markdown-embed-chooser',
+    ) as MarkdownEmbedChooserService;
+    let pending = svc.chooseCardOrFile();
+    await waitFor('[data-test-markdown-embed-chooser-modal]');
+
+    // Hovering the close button reveals a styled tooltip: label + ESC badge.
+    let trigger = document
+      .querySelector('[data-test-close-modal]')
+      ?.closest('[data-tooltip-trigger]');
+    assert.ok(trigger, 'close button is wrapped in a tooltip trigger');
+    await triggerEvent(trigger as Element, 'mouseenter');
+    await waitFor('[data-test-tooltip-content]');
+    assert
+      .dom('[data-test-tooltip-content]')
+      .includesText('close', 'tooltip shows the close label');
+    assert
+      .dom('[data-test-tooltip-content] .shortcut-key')
+      .hasText('ESC', 'tooltip shows the ESC key badge');
+    await triggerEvent(trigger as Element, 'mouseleave');
+
+    // The modal owns Escape: it must not bubble to the document-level
+    // operator-mode handler (which would flip the card out of edit format).
+    let escapeReachedDocument = false;
+    let docListener = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') escapeReachedDocument = true;
+    };
+    document.addEventListener('keydown', docListener);
+
+    // Pressing Escape closes the modal and resolves the deferred with undefined.
+    try {
+      await triggerKeyEvent(
+        '[data-test-markdown-embed-chooser-modal]',
+        'keydown',
+        'Escape',
+      );
+    } finally {
+      document.removeEventListener('keydown', docListener);
+    }
+    assert.false(
+      escapeReachedDocument,
+      'Escape is stopped at the modal and does not reach the document',
+    );
+    let result = await pending;
+    assert.strictEqual(
+      result,
+      undefined,
+      'pressing Escape resolves with undefined',
+    );
     await waitUntil(
       () => !document.querySelector('[data-test-markdown-embed-chooser-modal]'),
     );

--- a/packages/host/tests/integration/components/rich-markdown-field-test.gts
+++ b/packages/host/tests/integration/components/rich-markdown-field-test.gts
@@ -1,6 +1,12 @@
 import { precompileTemplate } from '@ember/template-compilation';
 import type { RenderingTestContext } from '@ember/test-helpers';
-import { click, render, waitFor, waitUntil } from '@ember/test-helpers';
+import {
+  click,
+  render,
+  triggerEvent,
+  waitFor,
+  waitUntil,
+} from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -1118,6 +1124,52 @@ module('Integration | RichMarkdownField', function (hooks) {
       .dom('[data-test-markdown-mode-option="source"]')
       .exists('view selector opens without editor focus');
     await click('[data-test-markdown-mode-option="compose"]');
+  });
+
+  test('toolbar items are wrapped in tooltips whose hint is suppressed while the control is disabled', async function (assert) {
+    // The enabled-on-focus transition depends on document.hasFocus(), which is
+    // false in headless CI (see the "formatting controls start disabled" test),
+    // so the format buttons are disabled here. That makes this the reliable
+    // side to assert: every item is a tooltip trigger, and hovering a disabled
+    // control reveals no tooltip. The always-enabled add/edit-embed tooltips
+    // (label + hover reveal) are covered in the codemirror embed toolbar test.
+    class TestCard extends CardDef {
+      @field body = contains(RichMarkdownField);
+      static edit = class Edit extends Component<typeof this> {
+        <template><@fields.body /></template>
+      };
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'test-card.gts': { TestCard },
+      },
+    });
+
+    let card = new TestCard({
+      body: new RichMarkdownField({ content: 'Hello world' }),
+    });
+    await renderCard(loader, card, 'edit');
+
+    await waitFor('[data-test-toolbar="bold"]');
+
+    // Bold (a shortcut item) and Strikethrough (shortcut-less) are both wrapped
+    // in a tooltip trigger.
+    assert
+      .dom('[data-test-toolbar-tooltip="bold"]')
+      .exists('Bold is wrapped in a tooltip trigger');
+    assert
+      .dom('[data-test-toolbar-tooltip="strikethrough"]')
+      .exists('Strikethrough is wrapped in a tooltip trigger');
+
+    // Disabled before the editor gains focus → hovering reveals no tooltip.
+    assert.dom('[data-test-toolbar="bold"]').isDisabled();
+    await triggerEvent('[data-test-toolbar-tooltip="bold"]', 'mouseenter');
+    assert
+      .dom('[data-test-tooltip-content]')
+      .doesNotExist('no tooltip is shown while the control is disabled');
+    await triggerEvent('[data-test-toolbar-tooltip="bold"]', 'mouseleave');
   });
 
   test('selecting Preview shows rendered markdown and hides editor', async function (assert) {


### PR DESCRIPTION
## What & why

The rich-markdown editor toolbar showed plain browser `title` attributes on hover, which can't render a styled "label + key-command badge". This gives every toolbar item a proper styled tooltip, surfacing the keyboard shortcut where one exists.

## Changes

- **`packages/base/codemirror-editor.gts`** — Every toolbar item renders a styled boxel-ui `<Tooltip>`: the item label, plus a shortcut key badge for items that have a CodeMirror binding — Bold (`⌘/Ctrl+B`), Italic (`⌘/Ctrl+I`), Code (`` ⌘/Ctrl+` ``). A local `modKey` helper picks `⌘` on macOS / `Ctrl` elsewhere, mirroring CodeMirror's `Mod-`. Shortcut-less items (strikethrough, link, headings, lists, blockquote) and the add-embed / edit-embed buttons get label-only tooltips. The format-button tooltips are suppressed while the control is disabled, so no hint shows until the editor holds focus.
- **`packages/boxel-ui/addon/src/components/tooltip/index.gts`** — Adds an opt-in `@disabled` arg to `Tooltip`: when true, hovering the trigger reveals no content. Defaults to the previous always-show behavior, so existing call sites are unchanged.
- **`packages/host/app/components/modal-container.gts`** — Adds opt-in `@closeButtonLabel` / `@closeButtonShortcut` args. When a shortcut is supplied, the close button renders the same styled tooltip (suppressed while the close button is disabled, via the new `@disabled`); the absolute positioning moves to the tooltip trigger wrapper so the overlay anchors to the button. Modals that don't pass a shortcut are unchanged.
- **`packages/host/app/components/markdown-embed-chooser/modal.gts`** — Passes `@closeButtonLabel='close'` `@closeButtonShortcut='ESC'`, surfacing the already-wired Escape-to-close binding as a tooltip. The chooser now stops the Escape keydown at the modal so it no longer bubbles to the document-level operator-mode handler — previously, closing via Escape (but not via the × button) flipped the underlying card out of edit format, because the modal cleared the `has-modal` guard before the same event reached that handler.

No new formatting keymap entries are added — only the three shortcuts that already exist in the CodeMirror keymap get badges. Further bindings are a follow-up pending design confirmation.

## Testing

- `rich-markdown-field-test` — every toolbar item is wrapped in a tooltip trigger; hovering a disabled control (format buttons are disabled until the editor is OS-focused, which headless CI can't grant) reveals no tooltip. ✅
- `codemirror-embed-toolbar-test` — the always-enabled Add / Edit embed buttons reveal a label-only tooltip on hover (no shortcut badge). ✅
- `markdown-embed-chooser-modal-test` — the close button shows a `close ESC` tooltip on hover; pressing Escape closes the modal and is stopped at the modal (does not reach the document). ✅
- `eslint` and `ember-template-lint` pass clean across the changed base + host + boxel-ui files.

All affected test modules were also run in the browser against the live dev server and pass.

## Note for review

The modal close button's absolute positioning was moved onto the `<Tooltip>` trigger wrapper (the button itself becomes `position: static` inside it) so the overlay anchors correctly. Worth a quick visual check that the × still sits flush in the top-right corner.

## Screen Recording

https://github.com/user-attachments/assets/679bdfc9-5ed0-4ea5-9deb-1cbb0a15b887

Ref: CS-11679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
