### PR TITLE
Load relative-URL embeds in the markdown embed chooser preview

### DIFF
--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -681,7 +681,13 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
     try {
       result = await editMarkdownEmbed({
         refType: ref.refType as 'card' | 'file',
-        url: ref.url,
+        // Resolve the directive's raw ref (which may be relative to the field's
+        // base URL) to an absolute URL. The chooser loads the preview via
+        // `store.get`, which can't resolve a relative specifier on its own.
+        url: resolveUrl(
+          ref.url,
+          this.args.cardReferenceBaseUrl,
+        ),
         sizeSpec: ref.sizeSpec,
         kind: ref.kind,
       });

--- a/packages/host/tests/acceptance/markdown-embed-chooser-test.gts
+++ b/packages/host/tests/acceptance/markdown-embed-chooser-test.gts
@@ -251,6 +251,52 @@ module('Acceptance | markdown embed chooser modal', function (hooks) {
     );
   });
 
+  test('editing an embed with a relative URL loads the preview pane', async function (assert) {
+    // A directive can carry a ref relative to the field's base URL
+    // (`../Pet/mango` from `Note/welcome`). The chooser loads its preview via
+    // `store.get`, which can't resolve a relative specifier — so the editor
+    // must resolve the ref to an absolute URL before opening the chooser. The
+    // preview pane only mounts once the target instance resolves, so its
+    // presence proves the relative ref was resolved and loaded.
+    await visitOperatorMode({
+      stacks: [[{ id: noteId, format: 'isolated' }]],
+    });
+    await click(`[data-test-operator-mode-stack="0"] [data-test-edit-button]`);
+    await waitFor(
+      `[data-test-stack-card="${noteId}"] [data-test-codemirror-editor]`,
+      { timeout: 5000 },
+    );
+
+    let editorEl = document.querySelector(
+      `[data-test-stack-card="${noteId}"] [data-test-codemirror-editor] .cm-editor`,
+    ) as HTMLElement | null;
+    let view = editorEl ? cmContext.EditorView.findFromDOM(editorEl) : null;
+    assert.ok(view, 'codemirror view is reachable');
+    view!.focus();
+
+    // `../Pet/mango` is relative to the `Note/welcome` field's base URL and
+    // resolves to `${testRealmURL}Pet/mango` (the fixture's `mangoId`).
+    view!.dispatch({ changes: { from: 0, insert: `:card[../Pet/mango]` } });
+    view!.dispatch({ selection: { anchor: 3, head: 3 } });
+
+    await waitFor('[data-test-toolbar="edit-embed"]', { timeout: 5000 });
+    await click('[data-test-toolbar="edit-embed"]');
+    await waitFor('[data-test-markdown-embed-chooser-modal]');
+
+    await waitFor('[data-test-markdown-embed-preview-pane]', { timeout: 5000 });
+    assert
+      .dom('[data-test-markdown-embed-preview-pane]')
+      .exists('preview pane mounts once the relative ref resolves and loads');
+    assert
+      .dom('[data-test-markdown-embed-preview-pane]')
+      .containsText('Mango', 'the resolved Pet card previews in the pane');
+
+    await click('[data-test-close-modal]');
+    await waitUntil(
+      () => !document.querySelector('[data-test-markdown-embed-chooser-modal]'),
+    );
+  });
+
   test('cursor at the end of a block directive line keeps the Edit pencil', async function (assert) {
     // A block directive is the only content on its line, so the caret at the
     // line end (`head == to`, reached via End / clicking the block widget) must


### PR DESCRIPTION
## Problem

CS-11805. When editing an existing card/file embed whose directive URL is **relative** (e.g. `:card[../Pet/mango]`), the combined chooser's right-hand preview pane stays on its empty placeholder — the target never loads. Absolute URLs preview fine.

The editor passed the directive's raw ref straight to the chooser, which loads the preview via `store.get`. `store.get` can't resolve a relative specifier without a base URL, so the instance never resolved and the pane (which only mounts once a target resolves) never rendered.

## Fix

Resolve the ref to an absolute URL at the call site in `_openEditEmbed`, reusing the editor's existing `resolveUrl` helper together with the base URL / virtual network already in scope (the same context `cardRenderTargets` uses for card-widget URLs). This keeps the base↔host chooser bridge payload a plain absolute-URL string and mirrors the add-embed path, where the mini choosers already return absolute URLs.

`resolveUrl` returns already-absolute URLs unchanged and falls back to the raw ref when there's no base URL, so the absolute-URL edit path and the "card running outside the host" path are unaffected.

## Testing

Added an acceptance test (`editing an embed with a relative URL loads the preview pane`) that preloads a relative `:card[../Pet/mango]` directive, opens the Edit pencil, and asserts the preview pane mounts and renders the resolved card. Ran the full `markdown embed chooser modal` module locally — **4 tests / 12 assertions pass, 0 failed**, including the existing edit-pencil and add-embed cases (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)