### PR TITLE
Fix index cache for `realm_generations`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,8 +162,7 @@ jobs:
   test-web-assets:
     name: Build test web assets
     needs: change-check
-    # TEMP(index-cache-fix-cs-11814): last term forces the build on this branch so cache-index has its artifact. Revert before merge.
-    if: needs.change-check.outputs.boxel == 'true' || needs.change-check.outputs.boxel-ui == 'true' || needs.change-check.outputs.matrix == 'true' || needs.change-check.outputs.realm-server == 'true' || needs.change-check.outputs.vscode-boxel-tools == 'true' || needs.change-check.outputs.boxel-cli == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true' || github.head_ref == 'index-cache-fix-cs-11814'
+    if: needs.change-check.outputs.boxel == 'true' || needs.change-check.outputs.boxel-ui == 'true' || needs.change-check.outputs.matrix == 'true' || needs.change-check.outputs.realm-server == 'true' || needs.change-check.outputs.vscode-boxel-tools == 'true' || needs.change-check.outputs.boxel-cli == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     uses: ./.github/workflows/test-web-assets.yaml
     with:
       caller: ci
@@ -1009,8 +1008,7 @@ jobs:
   cache-index:
     name: Cache realm index
     needs: [change-check, test-web-assets]
-    # TEMP(index-cache-fix-cs-11814): also run on this branch to demo the guard. Revert before merge.
-    if: github.ref == 'refs/heads/main' || github.head_ref == 'index-cache-fix-cs-11814'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     concurrency:
       group: cache-index-${{ github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1029,8 +1029,8 @@ jobs:
           shopt -s dotglob
           cp -a .test-web-assets-artifact/. ./
       - name: Index all realms and dump tables
-        # pipefail so a nonzero exit from mise (e.g. the dump guard) fails the
-        # step instead of being masked by tee's exit code.
+        # pipefail so a nonzero exit from the index/dump task fails the step
+        # instead of being masked by tee's exit code.
         run: |
           set -o pipefail
           mise run ci:cache-index 2>&1 | tee /tmp/cache-index.log
@@ -1042,6 +1042,11 @@ jobs:
           name: cache-index-log
           path: /tmp/cache-index.log
           retention-days: 7
+      # Separate step so an incomplete cache (a table dropped out of the dump)
+      # surfaces as its own short, clearly-labeled failure with an error
+      # annotation, rather than an exit code buried in the dump log above.
+      - name: Verify index cache is complete
+        run: scripts/verify-index-cache.sh /tmp/boxel-index-cache.sql.gz
       - name: Upload index cache
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,8 @@ jobs:
   test-web-assets:
     name: Build test web assets
     needs: change-check
-    if: needs.change-check.outputs.boxel == 'true' || needs.change-check.outputs.boxel-ui == 'true' || needs.change-check.outputs.matrix == 'true' || needs.change-check.outputs.realm-server == 'true' || needs.change-check.outputs.vscode-boxel-tools == 'true' || needs.change-check.outputs.boxel-cli == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
+    # TEMP(index-cache-fix-cs-11814): last term forces the build on this branch so cache-index has its artifact. Revert before merge.
+    if: needs.change-check.outputs.boxel == 'true' || needs.change-check.outputs.boxel-ui == 'true' || needs.change-check.outputs.matrix == 'true' || needs.change-check.outputs.realm-server == 'true' || needs.change-check.outputs.vscode-boxel-tools == 'true' || needs.change-check.outputs.boxel-cli == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true' || github.head_ref == 'index-cache-fix-cs-11814'
     uses: ./.github/workflows/test-web-assets.yaml
     with:
       caller: ci
@@ -1008,7 +1009,8 @@ jobs:
   cache-index:
     name: Cache realm index
     needs: [change-check, test-web-assets]
-    if: github.ref == 'refs/heads/main'
+    # TEMP(index-cache-fix-cs-11814): also run on this branch to demo the guard. Revert before merge.
+    if: github.ref == 'refs/heads/main' || github.head_ref == 'index-cache-fix-cs-11814'
     runs-on: ubuntu-latest
     concurrency:
       group: cache-index-${{ github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1029,7 +1029,11 @@ jobs:
           shopt -s dotglob
           cp -a .test-web-assets-artifact/. ./
       - name: Index all realms and dump tables
-        run: mise run ci:cache-index 2>&1 | tee /tmp/cache-index.log
+        # pipefail so a nonzero exit from mise (e.g. the dump guard) fails the
+        # step instead of being masked by tee's exit code.
+        run: |
+          set -o pipefail
+          mise run ci:cache-index 2>&1 | tee /tmp/cache-index.log
         timeout-minutes: 45
       - name: Upload service logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -69,13 +69,14 @@ done
 wait "$WAIT_ON_PID"
 
 echo "All realms ready. Dumping index tables..."
-# Tables that make up the cache. Keep in sync with the TRUNCATE list in
-# scripts/import-cached-index.sh. pg_dump only *warns* (exit 0) when a -t
-# pattern matches no table, so a renamed/removed table would silently drop
-# out of the cache — the guard below turns that into a hard failure.
-CACHE_TABLES=(boxel_index realm_generations realm_meta)
+# Tables that make up the cache. This is the single source of truth: the same
+# list drives pg_dump's -t args and the completeness check in the separate
+# "Verify index cache" CI step (via the sidecar written below). Keep the
+# TRUNCATE list in scripts/import-cached-index.sh in sync. The *_working
+# tables are deliberately excluded — they are transient UNLOGGED scratch space.
+CACHE_TABLES=(boxel_index prerendered_html realm_generations realm_meta)
 # TEMP(index-cache-fix-cs-11814): sentinel table that does not exist, to prove
-# the guard below fails the job when a table drops out of the dump. Revert before merge.
+# the verify step fails the job when a table drops out of the dump. Revert before merge.
 CACHE_TABLES+=(__guard_demo_missing_table)
 
 DUMP_ARGS=()
@@ -87,16 +88,8 @@ docker exec boxel-pg pg_dump -U postgres --data-only \
   "${DUMP_ARGS[@]}" \
   boxel > /tmp/boxel-index-cache.sql
 
-# Every expected table must have produced a COPY block. A missing block means
-# pg_dump matched no such table (typically a rename), so the cache would be
-# incomplete but the job would otherwise "succeed" — fail instead.
-for t in "${CACHE_TABLES[@]}"; do
-  if ! grep -q "^COPY public\.${t} " /tmp/boxel-index-cache.sql; then
-    echo "ERROR: no COPY block for table '${t}' in the dump — did it get renamed?"
-    echo "Update CACHE_TABLES here and the TRUNCATE list in scripts/import-cached-index.sh."
-    exit 1
-  fi
-done
+# Record exactly which tables we dumped so the verify step checks the same set.
+printf '%s\n' "${CACHE_TABLES[@]}" > /tmp/boxel-index-cache.tables
 
 gzip /tmp/boxel-index-cache.sql
 

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -75,9 +75,6 @@ echo "All realms ready. Dumping index tables..."
 # TRUNCATE list in scripts/import-cached-index.sh in sync. The *_working
 # tables are deliberately excluded — they are transient UNLOGGED scratch space.
 CACHE_TABLES=(boxel_index prerendered_html realm_generations realm_meta)
-# TEMP(index-cache-fix-cs-11814): sentinel table that does not exist, to prove
-# the verify step fails the job when a table drops out of the dump. Revert before merge.
-CACHE_TABLES+=(__guard_demo_missing_table)
 
 DUMP_ARGS=()
 for t in "${CACHE_TABLES[@]}"; do

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -69,9 +69,31 @@ done
 wait "$WAIT_ON_PID"
 
 echo "All realms ready. Dumping index tables..."
+# Tables that make up the cache. Keep in sync with the TRUNCATE list in
+# scripts/import-cached-index.sh. pg_dump only *warns* (exit 0) when a -t
+# pattern matches no table, so a renamed/removed table would silently drop
+# out of the cache — the guard below turns that into a hard failure.
+CACHE_TABLES=(boxel_index realm_generations realm_meta)
+
+DUMP_ARGS=()
+for t in "${CACHE_TABLES[@]}"; do
+  DUMP_ARGS+=(-t "$t")
+done
+
 docker exec boxel-pg pg_dump -U postgres --data-only \
-  -t boxel_index -t realm_versions -t realm_meta \
+  "${DUMP_ARGS[@]}" \
   boxel > /tmp/boxel-index-cache.sql
+
+# Every expected table must have produced a COPY block. A missing block means
+# pg_dump matched no such table (typically a rename), so the cache would be
+# incomplete but the job would otherwise "succeed" — fail instead.
+for t in "${CACHE_TABLES[@]}"; do
+  if ! grep -q "^COPY public\.${t} " /tmp/boxel-index-cache.sql; then
+    echo "ERROR: no COPY block for table '${t}' in the dump — did it get renamed?"
+    echo "Update CACHE_TABLES here and the TRUNCATE list in scripts/import-cached-index.sh."
+    exit 1
+  fi
+done
 
 gzip /tmp/boxel-index-cache.sql
 

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -74,6 +74,9 @@ echo "All realms ready. Dumping index tables..."
 # pattern matches no table, so a renamed/removed table would silently drop
 # out of the cache — the guard below turns that into a hard failure.
 CACHE_TABLES=(boxel_index realm_generations realm_meta)
+# TEMP(index-cache-fix-cs-11814): sentinel table that does not exist, to prove
+# the guard below fails the job when a table drops out of the dump. Revert before merge.
+CACHE_TABLES+=(__guard_demo_missing_table)
 
 DUMP_ARGS=()
 for t in "${CACHE_TABLES[@]}"; do

--- a/scripts/import-cached-index.sh
+++ b/scripts/import-cached-index.sh
@@ -21,9 +21,9 @@ trap cleanup EXIT
 
 # Check if the database already has index data — if so, skip.
 ROW_COUNT=$(docker exec boxel-pg psql -U postgres -d "$DB_NAME" -tAc \
-  "SELECT COUNT(*) FROM realm_versions" 2>/dev/null) || ROW_COUNT=""
+  "SELECT COUNT(*) FROM realm_generations" 2>/dev/null) || ROW_COUNT=""
 if [ -n "$ROW_COUNT" ] && [ "$ROW_COUNT" -gt 0 ] 2>/dev/null; then
-  echo "Database already has index data ($ROW_COUNT realm versions), skipping cache import."
+  echo "Database already has index data ($ROW_COUNT realm generations), skipping cache import."
   exit 0
 fi
 
@@ -58,7 +58,7 @@ fi
 # Clear any partial data before importing.
 echo "Truncating index tables..."
 docker exec boxel-pg psql -U postgres -d "$DB_NAME" --quiet --no-psqlrc -c \
-  "TRUNCATE boxel_index, realm_versions, realm_meta"
+  "TRUNCATE boxel_index, realm_generations, realm_meta"
 
 # Import the cache into the local database.
 # In BOXEL_ENVIRONMENT mode, remap URLs from CI standard mode (localhost:4201)

--- a/scripts/import-cached-index.sh
+++ b/scripts/import-cached-index.sh
@@ -58,7 +58,7 @@ fi
 # Clear any partial data before importing.
 echo "Truncating index tables..."
 docker exec boxel-pg psql -U postgres -d "$DB_NAME" --quiet --no-psqlrc -c \
-  "TRUNCATE boxel_index, realm_generations, realm_meta"
+  "TRUNCATE boxel_index, prerendered_html, realm_generations, realm_meta"
 
 # Import the cache into the local database.
 # In BOXEL_ENVIRONMENT mode, remap URLs from CI standard mode (localhost:4201)

--- a/scripts/verify-index-cache.sh
+++ b/scripts/verify-index-cache.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Verifies that an index-cache dump actually contains a COPY block for every
+# table it was supposed to include.
+#
+# pg_dump only *warns* (and still exits 0) when a -t pattern matches no table,
+# so a table renamed or removed by a migration silently drops out of the cache
+# while the dump job otherwise "succeeds". Running this as its own CI step —
+# separate from the long, noisy index/dump step — turns that into a short,
+# clearly labeled failure with a GitHub error annotation, instead of an
+# `exit 1` buried tens of thousands of lines deep in the dump log.
+#
+# Usage: verify-index-cache.sh <dump.sql[.gz]> [tables-file]
+#   tables-file defaults to <dump-dir>/boxel-index-cache.tables and lists one
+#   expected table per line. mise-tasks/ci/cache-index writes it from the same
+#   list it feeds to pg_dump, so the two never drift.
+
+set -euo pipefail
+
+DUMP="${1:?usage: verify-index-cache.sh <dump.sql[.gz]> [tables-file]}"
+TABLES_FILE="${2:-$(dirname "$DUMP")/boxel-index-cache.tables}"
+
+if [ ! -f "$DUMP" ]; then
+  echo "::error title=Index cache missing::dump file not found: ${DUMP}"
+  exit 1
+fi
+if [ ! -f "$TABLES_FILE" ]; then
+  echo "::error title=Index cache verification::expected-tables file not found: ${TABLES_FILE}"
+  exit 1
+fi
+
+# Read the dump's COPY-block headers once (transparently handle gzip or plain).
+case "$DUMP" in
+  *.gz) copy_headers=$(gunzip -c "$DUMP" | grep '^COPY public\.' || true) ;;
+  *)    copy_headers=$(grep '^COPY public\.' "$DUMP" || true) ;;
+esac
+
+missing=()
+present=()
+while IFS= read -r table; do
+  [ -z "$table" ] && continue
+  # The trailing space matches the column list that always follows the table
+  # name ("COPY public.foo (col, ...) FROM stdin;"), so a table name that is a
+  # prefix of another (prerendered_html vs prerendered_html_working) can't
+  # match by accident.
+  if printf '%s\n' "$copy_headers" | grep -q "^COPY public\.${table} "; then
+    present+=("$table")
+  else
+    missing+=("$table")
+  fi
+done < "$TABLES_FILE"
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  for table in "${missing[@]}"; do
+    echo "::error title=Index cache incomplete::pg_dump produced no COPY block for table '${table}'. It was likely renamed or removed by a migration. Update CACHE_TABLES in mise-tasks/ci/cache-index and the TRUNCATE list in scripts/import-cached-index.sh."
+  done
+  echo "Index cache verification FAILED: ${#missing[@]} of $(( ${#present[@]} + ${#missing[@]} )) expected tables missing: ${missing[*]}"
+  exit 1
+fi
+
+echo "Index cache verified: ${#present[@]} tables present (${present[*]})."

--- a/scripts/verify-index-cache.sh
+++ b/scripts/verify-index-cache.sh
@@ -38,11 +38,13 @@ missing=()
 present=()
 while IFS= read -r table; do
   [ -z "$table" ] && continue
+  # Fixed-string match (-F) so a table name is never interpreted as a regex.
   # The trailing space matches the column list that always follows the table
   # name ("COPY public.foo (col, ...) FROM stdin;"), so a table name that is a
   # prefix of another (prerendered_html vs prerendered_html_working) can't
-  # match by accident.
-  if printf '%s\n' "$copy_headers" | grep -q "^COPY public\.${table} "; then
+  # match by accident. No ^ anchor is needed: every line in copy_headers
+  # already begins with "COPY public.".
+  if printf '%s\n' "$copy_headers" | grep -qF "COPY public.${table} "; then
     present+=("$table")
   else
     missing+=("$table")


### PR DESCRIPTION
This was silently broken, so this includes a change to fail the job in CI if the cache needs tending. Here it is failing when triggered deliberately by adding a spurious table:

<img width="2840" height="1082" alt="s 2026-07-07 at 19 31 52@2x" src="https://github.com/user-attachments/assets/1afb4724-218d-478b-8c11-801543bfc9e3" />

This also adds `prerendered_html` to the cache as recommended [by @habdelra](https://github.com/cardstack/boxel/pull/5419#issuecomment-4910135434).