### PR TITLE
Populate prerendered_html in direct-construction test index setup

### DIFF
--- a/packages/host/tests/helpers/indexer.ts
+++ b/packages/host/tests/helpers/indexer.ts
@@ -121,6 +121,7 @@ export async function setupIndex(client: DBAdapter): Promise<void>;
 export async function setupIndex(
   client: DBAdapter,
   indexRows: TestIndexRow[],
+  options?: SetupIndexOptions,
 ): Promise<void>;
 export async function setupIndex(
   client: DBAdapter,
@@ -137,11 +138,36 @@ export async function setupIndex(
 export async function setupIndex(
   client: DBAdapter,
   maybeVersionRows: RealmGenerationsTable[] | TestIndexRow[] = [],
-  maybeWorkingProductionRows?:
+  maybeRowsOrOptions?:
     | TestIndexRow[]
-    | { working: TestIndexRow[]; production: TestIndexRow[] },
-  options: SetupIndexOptions = {},
+    | { working: TestIndexRow[]; production: TestIndexRow[] }
+    | SetupIndexOptions,
+  maybeOptions: SetupIndexOptions = {},
 ): Promise<void> {
+  // The two-arg form `setupIndex(client, indexRows, options?)` passes options in
+  // the third position; the versionRows forms pass rows there and options
+  // fourth. Options are the only third-arg shape that is neither an array nor a
+  // `{ working, production }` object, so disambiguate on that.
+  let maybeWorkingProductionRows:
+    | TestIndexRow[]
+    | { working: TestIndexRow[]; production: TestIndexRow[] }
+    | undefined;
+  let options: SetupIndexOptions;
+  if (
+    maybeRowsOrOptions != null &&
+    !Array.isArray(maybeRowsOrOptions) &&
+    !('working' in maybeRowsOrOptions)
+  ) {
+    maybeWorkingProductionRows = undefined;
+    options = maybeRowsOrOptions;
+  } else {
+    maybeWorkingProductionRows = maybeRowsOrOptions as
+      | TestIndexRow[]
+      | { working: TestIndexRow[]; production: TestIndexRow[] }
+      | undefined;
+    options = maybeOptions;
+  }
+
   let versionRows: RealmGenerationsTable[];
   let workingRows: TestIndexRow[] = [];
   let productionRows: TestIndexRow[] = [];
@@ -242,14 +268,15 @@ export async function setupIndex(
   }
 }
 
-// Project the HTML/markdown columns (and generation) of the just-seeded
-// `boxel_index(_working)` rows onto `prerendered_html(_working)`, matching the
-// production backfill + dual-write (`IndexWriter.syncPrerenderedHtmlFromWorking`):
-// same column mapping, `indexed_at` seeds `rendered_at`, and `icon_html` stays
-// on `boxel_index`. The upsert keeps the projection idempotent. This lets tests
-// read HTML/markdown through the real `prerendered_html` path — the path that
-// remains once the `boxel_index` HTML columns and the dual-read fallback are
-// dropped.
+// Project the HTML/markdown columns (and generation) of the `boxel_index(_working)`
+// rows onto `prerendered_html(_working)`, matching the production backfill +
+// dual-write (`IndexWriter.syncPrerenderedHtmlFromWorking`): same column mapping,
+// `indexed_at` seeds `rendered_at`, and `icon_html` stays on `boxel_index`. The
+// SELECT covers every row in the source table — in a freshly-seeded test DB
+// those are exactly the rows `setupIndex` just wrote — and the upsert keeps the
+// projection idempotent. This lets tests read HTML/markdown through the real
+// `prerendered_html` path — the path that remains once the `boxel_index` HTML
+// columns and the dual-read fallback are dropped.
 async function projectPrerenderedHtml(
   client: DBAdapter,
   table: 'working' | 'production',

--- a/packages/host/tests/helpers/indexer.ts
+++ b/packages/host/tests/helpers/indexer.ts
@@ -97,6 +97,17 @@ export type TestIndexRow =
       >;
     };
 
+export interface SetupIndexOptions {
+  // When `false`, `setupIndex` seeds only `boxel_index(_working)` and leaves
+  // `prerendered_html(_working)` empty. The default projects the HTML/markdown
+  // columns and generation onto `prerendered_html(_working)` — mirroring the
+  // production backfill + dual-write — so tests read HTML/markdown through the
+  // real `prerendered_html` path rather than the transitional `boxel_index`
+  // fallback. Only a test that manages `prerendered_html` rows itself (to
+  // exercise the fallback vs the mirror) needs to opt out.
+  prerenderedHtml?: boolean;
+}
+
 // There are 3 ways to setup an index:
 // 1. provide the raw data for each row in the boxel_index table
 // 2. provide a card instance for each row in the boxel_index table
@@ -115,11 +126,13 @@ export async function setupIndex(
   client: DBAdapter,
   versionRows: RealmGenerationsTable[],
   indexRows: { working: TestIndexRow[]; production: TestIndexRow[] },
+  options?: SetupIndexOptions,
 ): Promise<void>;
 export async function setupIndex(
   client: DBAdapter,
   versionRows: RealmGenerationsTable[],
   indexRows: TestIndexRow[],
+  options?: SetupIndexOptions,
 ): Promise<void>;
 export async function setupIndex(
   client: DBAdapter,
@@ -127,6 +140,7 @@ export async function setupIndex(
   maybeWorkingProductionRows?:
     | TestIndexRow[]
     | { working: TestIndexRow[]; production: TestIndexRow[] },
+  options: SetupIndexOptions = {},
 ): Promise<void> {
   let versionRows: RealmGenerationsTable[];
   let workingRows: TestIndexRow[] = [];
@@ -217,6 +231,71 @@ export async function setupIndex(
       coerceTypes,
     );
   }
+
+  if (options.prerenderedHtml !== false) {
+    if (workingIndexedCardsExpressions.length > 0) {
+      await projectPrerenderedHtml(client, 'working');
+    }
+    if (productionIndexedCardsExpressions.length > 0) {
+      await projectPrerenderedHtml(client, 'production');
+    }
+  }
+}
+
+// Project the HTML/markdown columns (and generation) of the just-seeded
+// `boxel_index(_working)` rows onto `prerendered_html(_working)`, matching the
+// production backfill + dual-write (`IndexWriter.syncPrerenderedHtmlFromWorking`):
+// same column mapping, `indexed_at` seeds `rendered_at`, and `icon_html` stays
+// on `boxel_index`. The upsert keeps the projection idempotent. This lets tests
+// read HTML/markdown through the real `prerendered_html` path — the path that
+// remains once the `boxel_index` HTML columns and the dual-read fallback are
+// dropped.
+async function projectPrerenderedHtml(
+  client: DBAdapter,
+  table: 'working' | 'production',
+) {
+  let source = table === 'working' ? 'boxel_index_working' : 'boxel_index';
+  let target =
+    table === 'working' ? 'prerendered_html_working' : 'prerendered_html';
+  // `job_id` exists only on the working tables.
+  let jobIdColumn = table === 'working' ? ', job_id' : '';
+  let mutableColumns = [
+    'file_alias',
+    'fitted_html',
+    'embedded_html',
+    'atom_html',
+    'head_html',
+    'isolated_html',
+    'markdown',
+    'deps',
+    'last_known_good_deps',
+    'generation',
+    'is_deleted',
+    'error_doc',
+    'rendered_at',
+    ...(table === 'working' ? ['job_id'] : []),
+  ];
+  await query(
+    client,
+    [
+      `INSERT INTO ${target} (
+         url, file_alias, realm_url, type,
+         fitted_html, embedded_html, atom_html, head_html, isolated_html,
+         markdown, deps, last_known_good_deps,
+         generation, is_deleted, error_doc, rendered_at${jobIdColumn}
+       )
+       SELECT
+         url, file_alias, realm_url, type,
+         fitted_html, embedded_html, atom_html, head_html, isolated_html,
+         markdown, deps, last_known_good_deps,
+         generation, is_deleted, error_doc, indexed_at${jobIdColumn}
+       FROM ${source}
+       WHERE 1=1
+       ON CONFLICT ON CONSTRAINT ${target}_pkey DO UPDATE SET ` +
+        mutableColumns.map((name) => `${name}=EXCLUDED.${name}`).join(', '),
+    ] as Expression,
+    coerceTypes,
+  );
 }
 
 async function indexedCardsExpressions({

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -100,31 +100,6 @@ const fetchRealmMeta = async (adapter: SQLiteAdapter) => {
   };
 };
 
-// Seed a realm's `prerendered_html` rows from its `boxel_index` rows, matching
-// the backfill + dual-write that populate `prerendered_html` in production.
-// `setupIndex` only writes `boxel_index`, so a copy — which sources the
-// destination's HTML from the source realm's `prerendered_html` — needs the
-// source's `prerendered_html` seeded to have anything to copy.
-const mirrorPrerenderedHtml = async (
-  adapter: SQLiteAdapter,
-  realmURL: string,
-) =>
-  adapter.execute(
-    `INSERT INTO prerendered_html (
-       url, file_alias, realm_url, type,
-       fitted_html, embedded_html, atom_html, head_html, isolated_html,
-       markdown, deps, last_known_good_deps,
-       generation, is_deleted, error_doc, rendered_at
-     )
-     SELECT
-       url, file_alias, realm_url, type,
-       fitted_html, embedded_html, atom_html, head_html, isolated_html,
-       markdown, deps, last_known_good_deps,
-       generation, is_deleted, error_doc, indexed_at
-     FROM boxel_index WHERE realm_url = $1`,
-    { bind: [realmURL] },
-  );
-
 module('Unit | index-writer', function (hooks) {
   let adapter: SQLiteAdapter;
   let indexWriter: IndexWriter;
@@ -778,10 +753,8 @@ module('Unit | index-writer', function (hooks) {
         },
       ],
     );
-    // The copy sources the destination's HTML from the source realm's
-    // prerendered_html channel, so seed it (as backfill + dual-write do in
-    // production).
-    await mirrorPrerenderedHtml(adapter, testRealmURL);
+    // setupIndex seeds the source realm's prerendered_html (as the backfill +
+    // dual-write do in production), so the copy has a rendering to source.
     let batch = await indexWriter.createBatch(
       new URL(testRealmURL2),
       virtualNetwork,
@@ -859,10 +832,10 @@ module('Unit | index-writer', function (hooks) {
         },
       ],
     );
-    // Seed the source realm's prerendered_html (backfill + dual-write do this in
-    // production), then diverge its rendering from the boxel_index column with a
-    // sentinel a boxel_index-sourced copy could never produce.
-    await mirrorPrerenderedHtml(adapter, testRealmURL);
+    // setupIndex seeds the source realm's prerendered_html (backfill +
+    // dual-write do this in production); diverge its rendering from the
+    // boxel_index column with a sentinel a boxel_index-sourced copy could never
+    // produce.
     await adapter.execute(
       `UPDATE prerendered_html SET isolated_html = $1, markdown = $2 WHERE url = $3 AND realm_url = $4`,
       {
@@ -977,9 +950,13 @@ module('Unit | index-writer', function (hooks) {
         },
       ],
     );
-    // Deliberately do NOT seed the source's prerendered_html — this row is a
-    // gap the copy fills from boxel_index. Pre-seed a stale destination
+    // Drop the source's prerendered_html row that setupIndex seeded so this row
+    // is a gap the copy must fill from boxel_index. Pre-seed a stale destination
     // prerendered_html row for the URL the copy will write.
+    await adapter.execute(
+      `DELETE FROM prerendered_html WHERE url = $1 AND realm_url = $2`,
+      { bind: [`${testRealmURL}1.json`, testRealmURL] },
+    );
     await adapter.execute(
       `INSERT INTO prerendered_html (url, file_alias, realm_url, type, isolated_html, markdown, generation, is_deleted, rendered_at)
        VALUES ($1, $2, $3, 'instance', $4, $5, 1, false, $6)`,
@@ -1062,9 +1039,9 @@ module('Unit | index-writer', function (hooks) {
         },
       ],
     );
-    // Source prerendered_html covers only the instance row: mirror both, drop
-    // the file row, and diverge the instance rendering with a sentinel.
-    await mirrorPrerenderedHtml(adapter, testRealmURL);
+    // setupIndex seeds prerendered_html for both types; drop the file row so the
+    // source covers only the instance, then diverge the instance rendering with
+    // a sentinel.
     await adapter.execute(
       `DELETE FROM prerendered_html WHERE url = $1 AND realm_url = $2 AND type = 'file'`,
       { bind: [`${testRealmURL}1.json`, testRealmURL] },

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -1091,10 +1091,12 @@ module('Unit | index-writer', function (hooks) {
     // Seed boxel_index_working as if a prior attempt of job 42 wrote this row
     // (with HTML) but never mirrored it onto prerendered_html_working — the
     // crash-window / pre-dual-write-deploy case. prerendered_html_working is
-    // left empty. A resuming batch re-adds the URL to the invalidation set but
-    // never re-runs updateEntry, so the batch-commit projection must source
-    // from boxel_index_working or the row lands in boxel_index but is silently
-    // skipped in prerendered_html.
+    // left empty (prerenderedHtml: false), so the batch-commit projection is the
+    // only thing that can promote the row: a resuming batch re-adds the URL to
+    // the invalidation set but never re-runs updateEntry, so the projection must
+    // source from boxel_index_working or the row lands in boxel_index but is
+    // silently skipped in prerendered_html. Auto-seeding prerendered_html_working
+    // here would mask a regression in that projection.
     await setupIndex(
       adapter,
       [{ realm_url: testRealmURL, current_generation: 1 }],
@@ -1116,6 +1118,7 @@ module('Unit | index-writer', function (hooks) {
         ],
         production: [],
       },
+      { prerenderedHtml: false },
     );
 
     let batch = await indexWriter.createBatch(

--- a/packages/host/tests/unit/prerendered-html-dual-read-test.ts
+++ b/packages/host/tests/unit/prerendered-html-dual-read-test.ts
@@ -208,6 +208,11 @@ module('Unit | prerendered-html dual-read', function (hooks) {
           markdown: 'Readme markdown body',
         },
       ],
+      // This suite exercises the dual-read itself — the boxel_index fallback,
+      // the prerendered_html mirror, and the mix — so it seeds prerendered_html
+      // by hand (the local mirrorPrerenderedHtml helper) rather than via
+      // setupIndex.
+      { prerenderedHtml: false },
     );
   });
 

--- a/packages/realm-server/tests/matches-filter-integration-test.ts
+++ b/packages/realm-server/tests/matches-filter-integration-test.ts
@@ -78,6 +78,19 @@ async function seedRow(
     param(markdown),
     `)`,
   ]);
+  // The full-text `matches` predicate reads `prerendered_html.markdown` (the
+  // `boxel_index.markdown` fallback disappears once the dual paths are dropped).
+  // Project the just-seeded row's markdown onto `prerendered_html` — mirroring
+  // the production backfill + dual-write — so these tests exercise the real
+  // read path. `indexed_at` seeds `rendered_at`.
+  await query(dbAdapter, [
+    `INSERT INTO prerendered_html (url, file_alias, realm_url, type, markdown, deps, last_known_good_deps, generation, is_deleted, error_doc, rendered_at)`,
+    `SELECT url, file_alias, realm_url, type, markdown, deps, last_known_good_deps, generation, is_deleted, error_doc, indexed_at`,
+    `FROM boxel_index WHERE url =`,
+    param(url),
+    `AND realm_url =`,
+    param(testRealmURL),
+  ]);
 }
 
 async function countBoxelIndexRows(dbAdapter: PgAdapter): Promise<number> {


### PR DESCRIPTION
Several test suites build a `boxel_index` template with raw `INSERT`s rather than the real indexer, so they never populate `prerendered_html`. Those HTML/markdown reads resolve today only through the dual-read `boxel_index` fallback — which disappears once the `boxel_index` HTML/markdown columns and the dual paths are dropped. This seeds `prerendered_html` in the direct-construction paths that read it, so those tests exercise the real `prerendered_html` read path now and keep passing after the fallback goes away.

## host `setupIndex`

`setupIndex` now projects the HTML/markdown columns (and `generation`) of every seeded `boxel_index(_working)` row onto `prerendered_html(_working)`, mirroring the production backfill + dual-write (`indexed_at` seeds `rendered_at`; `icon_html` stays on `boxel_index`). The projection is a transparent mirror, so query-engine and index-writer unit tests read identical values whether served from `prerendered_html` or the fallback — but now they go through the real channel.

- A `prerenderedHtml: false` option opts out. Only the dual-read parity suite uses it, because that suite manages `prerendered_html` rows by hand to exercise the fallback-vs-mirror behavior directly.
- With `setupIndex` seeding `prerendered_html`, the per-test `mirrorPrerenderedHtml` helper in the index-writer suite is redundant and is removed. Its copy-gap tests now drop the auto-seeded rows to recreate the "source has no rendering" / "source covers one type only" gaps they assert on.

## realm-server `matches-filter`

The full-text `matches` predicate reads `prerendered_html.markdown`. The integration test's `seedRow` now mirrors each seeded row's markdown onto `prerendered_html`, so the `matches` tests exercise that read path.

## Audited, no change needed

The remaining direct-construction paths read only `boxel_index` columns that survive the column drop, so they need no `prerendered_html` rows:

- `eq-containment-integration-test` — structured `search_doc` predicates only.
- `server-endpoints/webhook-receiver-test` — `search_doc` DB lookup.
- `server-endpoints/archive-realm-test` — `pristine_doc` display metadata.
- `realm-endpoints/indexing-errors-test` — real `fullIndex()` (already dual-writes) plus an error row read via `boxel_index.error_doc`.
- boxel-cli `realm-indexing-errors.test` — error-doc-focused; reads `error_doc` from `boxel_index`.
- realm-test-harness `rebuildWorkingIndexFromIndex` — already mirrors `prerendered_html → prerendered_html_working`.

## Tests

- host: `Unit | index-writer` 50/50, `Unit | prerendered-html dual-read` 4/4, `Unit | query` 76/76.
- realm-server: `matches-filter-integration-test` 15/15 (including the base64 and index-planner cases).
- `eslint` and `ember-tsc --noEmit` clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y63cPJn9WLpHmc4GBv2JoQ
