### PR TITLE
Sanitize jsonb-illegal code points across all index content columns

### DIFF
--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -551,6 +551,105 @@ module('Unit | index-writer', function (hooks) {
     );
   });
 
+  test('sanitizes jsonb-illegal code points in content columns before write', async function (assert) {
+    // Postgres rejects the NUL character and unpaired UTF-16 surrogate halves
+    // inside a jsonb value's text (22P05), which aborts the whole upsert batch
+    // — a single bad card strands an entire realm's from-scratch index. These
+    // code points reach the writer inside rendered card content: a stray NUL
+    // folded in from an upstream resolver, or a valid astral-plane emoji whose
+    // surrogate pair was split by an upstream truncation. updateEntry must
+    // strip them from every content column while leaving valid content intact.
+    const NUL = '\u0000';
+    const LONE_HIGH = '\uD83E'; // high surrogate with no trailing low
+    const LONE_LOW = '\uDDE9'; // low surrogate with no leading high
+    const VALID_EMOJI = '🧩'; // 🧩 — a well-formed surrogate pair
+    const REPLACEMENT = '\uFFFD';
+
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_generation: 1 }],
+      [],
+    );
+
+    let resource: CardResource = {
+      id: testRRI('1.json'),
+      type: 'card',
+      attributes: {
+        name: `Van${NUL}Gogh`,
+        bio: `high:${LONE_HIGH} emoji:${VALID_EMOJI} low:${LONE_LOW}`,
+      },
+      meta: {
+        adoptsFrom: {
+          module: rri(`./person`),
+          name: 'Person',
+        },
+      },
+    };
+    let batch = await indexWriter.createBatch(
+      new URL(testRealmURL),
+      virtualNetwork,
+    );
+    await batch.invalidate([new URL(`${testRealmURL}1.json`)]);
+    await batch.updateEntry(new URL(`${testRealmURL}1.json`), {
+      type: 'instance',
+      resource,
+      lastModified: Date.now(),
+      resourceCreatedAt: Date.now(),
+      searchData: {
+        name: `Van${NUL}Gogh`,
+        bio: `high:${LONE_HIGH} emoji:${VALID_EMOJI} low:${LONE_LOW}`,
+      },
+      markdown: `# Title${NUL} ${LONE_HIGH} keep ${VALID_EMOJI}`,
+      deps: new Set([`${testRealmURL}person`]),
+      displayNames: [`Person${NUL}`],
+      types: [{ module: rri(`./person`), name: 'Person' }, baseCardRef].map(
+        (i) => internalKeyFor(i, new URL(testRealmURL), virtualNetwork),
+      ),
+    });
+
+    let [row] = await adapter.execute(
+      `SELECT pristine_doc, search_doc, display_names, markdown FROM boxel_index_working WHERE url = $1`,
+      {
+        bind: [`${testRealmURL}1.json`],
+        coerceTypes: {
+          pristine_doc: 'JSON',
+          search_doc: 'JSON',
+          display_names: 'JSON',
+        },
+      },
+    );
+
+    let pristine = row.pristine_doc as LooseCardResource;
+    let search = row.search_doc as Record<string, string>;
+    let displayNames = row.display_names as string[];
+
+    assert.strictEqual(
+      pristine.attributes?.name,
+      `Van${REPLACEMENT}Gogh`,
+      'NUL in pristine_doc string is replaced',
+    );
+    assert.strictEqual(
+      search.name,
+      `Van${REPLACEMENT}Gogh`,
+      'NUL in search_doc string is replaced',
+    );
+    assert.strictEqual(
+      search.bio,
+      `high:${REPLACEMENT} emoji:${VALID_EMOJI} low:${REPLACEMENT}`,
+      'lone surrogates are replaced while the valid emoji pair is preserved',
+    );
+    assert.strictEqual(
+      row.markdown,
+      `# Title${REPLACEMENT} ${REPLACEMENT} keep ${VALID_EMOJI}`,
+      'markdown column is sanitized and keeps the valid emoji',
+    );
+    assert.deepEqual(
+      displayNames,
+      [`Person${REPLACEMENT}`],
+      'display_names entries are sanitized',
+    );
+  });
+
   test('dual-writes prerendered HTML on index and swaps it into production on done', async function (assert) {
     let types = [{ module: rri(`./person`), name: 'Person' }, baseCardRef].map(
       (i) => internalKeyFor(i, new URL(testRealmURL), virtualNetwork),

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -619,9 +619,9 @@ module('Unit | index-writer', function (hooks) {
       },
     );
 
-    let pristine = row.pristine_doc as LooseCardResource;
-    let search = row.search_doc as Record<string, string>;
-    let displayNames = row.display_names as string[];
+    let pristine = row.pristine_doc as unknown as LooseCardResource;
+    let search = row.search_doc as unknown as Record<string, string>;
+    let displayNames = row.display_names as unknown as string[];
 
     assert.strictEqual(
       pristine.attributes?.name,

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -575,12 +575,14 @@ export class Batch {
     // diagnostics via `formattedError`) keeps working unchanged —
     // no schema rename needed. The column remains source of truth;
     // the error-doc copy is derived.
-    // Sanitize so jsonb-illegal bytes can't abort the batch on write.
-    let diagnostics: Diagnostics = sanitizeForJsonb({
+    // jsonb-illegal bytes are stripped once at the write boundary below
+    // (see the sanitizeForJsonb call before asExpressions), so this and every
+    // other content column is covered in one place.
+    let diagnostics: Diagnostics = {
       ...(entry.diagnostics ?? {}),
       invalidationId: this.#currentInvalidationId,
       indexedAt: Date.now(),
-    });
+    };
     let errorEntry = isErrorEntry(entry)
       ? {
           ...entry,
@@ -665,7 +667,7 @@ export class Batch {
             baseTypeFromError(entry),
           ),
           type: baseTypeFromError(entry),
-          error_doc: sanitizeForJsonb(errorEntry?.error ?? entry.error),
+          error_doc: errorEntry?.error ?? entry.error,
           has_error: true,
           diagnostics: diagnostics,
         };
@@ -720,11 +722,24 @@ export class Batch {
       );
     }
 
-    let { nameExpressions, valueExpressions } = asExpressions(preparedEntry, {
-      jsonFields: [...Object.entries(coerceTypes)]
-        .filter(([_, type]) => type === 'JSON')
-        .map(([column]) => column),
-    });
+    // Strip jsonb-illegal code points from the entire row before persisting.
+    // Postgres rejects the NUL character and unpaired UTF-16 surrogate halves
+    // inside a jsonb value's text (22P05); a single such code point anywhere in
+    // the row aborts the whole upsert batch and, during a from-scratch index,
+    // strands every other card in the realm behind it. Sanitizing the prepared
+    // row here — rather than per-field — covers every content column
+    // (pristine_doc, search_doc, markdown, the *_html columns, deps,
+    // display_names, diagnostics, error_doc) in one place, including rendered
+    // card content that can carry a split emoji surrogate or a stray NUL folded
+    // in from an upstream resolver.
+    let { nameExpressions, valueExpressions } = asExpressions(
+      sanitizeForJsonb(preparedEntry),
+      {
+        jsonFields: [...Object.entries(coerceTypes)]
+          .filter(([_, type]) => type === 'JSON')
+          .map(([column]) => column),
+      },
+    );
 
     await this.#query([
       ...upsert(


### PR DESCRIPTION
## Problem

Postgres rejects the NUL character and unpaired UTF-16 surrogate halves inside a `jsonb` value's text (error `22P05: unsupported Unicode escape sequence`). The index writer already guards against this with `sanitizeForJsonb`, but it was only applied to the `diagnostics` and `error_doc` columns. The primary content columns — `pristine_doc`, `search_doc`, `markdown`, the `*_html` columns, `deps`, `display_names` — were written raw.

So a single card whose **rendered** content carried an illegal code point took down the whole upsert batch:

- a stray NUL folded in from an upstream resolver, or
- a valid astral-plane emoji (e.g. the puzzle-piece emoji) whose surrogate pair was split by an upstream truncation, leaving a lone surrogate.

Because indexing writes a realm as one batch, one bad card aborts it entirely. During a from-scratch index that leaves **every** card in the realm unindexed until the offending card is tracked down by hand.

## Fix

Move sanitization to the write boundary: sanitize the whole prepared row once, immediately before `asExpressions`, so every content column is covered in one place. The two per-field `sanitizeForJsonb` calls (`diagnostics`, `error_doc`) are now redundant and removed. Valid content — including well-formed emoji — is untouched; only illegal code points are replaced with `U+FFFD`, matching the existing `sanitizeForJsonb` behavior.

## Test coverage

Adds a unit test (`packages/host/tests/unit/index-writer-test.ts`) that pushes a NUL, a lone high surrogate, and a lone low surrogate through `updateEntry` alongside a valid emoji, then asserts the stored `pristine_doc`, `search_doc`, `markdown`, and `display_names` have the illegal code points replaced while the emoji is preserved.

Note: the host unit suite runs on SQLite, which tolerates these code points, so the test asserts the sanitization happened (content is cleaned before write) rather than reproducing the Postgres rejection. That is the correct invariant regardless of backend — the row never leaves the writer with jsonb-illegal content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
