### PR TITLE
Change client-side query field searches to use RRIs

### DIFF
--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -13,13 +13,13 @@ import type {
   QueryWithInterpolations,
   RuntimeDependencyTrackingContext,
   SerializedError,
-  VirtualNetwork,
 } from '@cardstack/runtime-common';
 import {
   getField,
   getSingularRelationship,
   identifyCard,
   isCardInstance,
+  rri,
   THIS_INTERPOLATION_PREFIX,
   THIS_REALM_TOKEN,
   realmURL as realmURLSymbol,
@@ -147,13 +147,7 @@ export function ensureQueryFieldSearchResource(
   let seedRecords = fieldState?.seedRecords;
   let seedSearchURL = fieldState?.seedSearchURL;
   let args = () => {
-    let vn = store.virtualNetwork;
-    if (!vn) {
-      throw new Error(
-        `query-field-support requires the CardStore to have a VirtualNetwork`,
-      );
-    }
-    return resolveQueryAndRealm(instance, field, fieldDefinition, vn);
+    return resolveQueryAndRealm(instance, field, fieldDefinition);
   };
 
   // Inside a prerender the parent doc's `relationships.{field}.data` is
@@ -574,7 +568,6 @@ function resolveQueryAndRealm(
   instance: BaseDef,
   field: Field,
   fieldDefinition: FieldDefinition,
-  virtualNetwork: VirtualNetwork,
 ): { realmHref: string; searchURL: string; query: Query } | undefined {
   let realmURL: URL | undefined = (instance as any)[realmURLSymbol];
   if (!realmURL) {
@@ -585,6 +578,10 @@ function resolveQueryAndRealm(
     ? field.name.slice(0, field.name.lastIndexOf('.'))
     : undefined;
 
+  // Resolve in RRI space (no VirtualNetwork): the instance's id is canonical
+  // (prefix form for mapped realms, URL otherwise) and is a valid base for
+  // relative code-ref resolution. The index and the client-side filter matcher
+  // both tolerate either spelling in the resulting query.
   let normalized = normalizeQueryDefinition({
     fieldDefinition,
     queryDefinition: field.queryDefinition ?? {},
@@ -593,9 +590,8 @@ function resolveQueryAndRealm(
     fieldPath,
     resolvePathValue: (path) => resolveInstancePathValue(instance, path),
     relativeTo: (instance as CardDef).id
-      ? virtualNetwork.toURL((instance as CardDef).id)
+      ? rri((instance as CardDef).id)
       : realmURL,
-    virtualNetwork,
   });
 
   if (!normalized) {

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -30,8 +30,7 @@ import {
   matchInstanceAgainstFilter,
   makeInstanceComparator,
   logger as runtimeLogger,
-  normalizeQueryForSignature,
-  buildQueryParamValue,
+  canonicalQuerySignature,
   parseSearchURL,
   ri,
   RealmPaths,
@@ -49,6 +48,7 @@ import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event'
 
 import { searchErrorEntry } from '../lib/search-error-entry';
 
+import type NetworkService from '../services/network';
 import type RealmServerService from '../services/realm-server';
 import type StoreService from '../services/store';
 
@@ -153,6 +153,7 @@ export interface Args<T extends CardDef | FileDef = CardDef> {
 export class SearchResource<
   T extends CardDef | FileDef = CardDef,
 > extends Resource<Args<T>> {
+  @service declare private network: NetworkService;
   @service declare private realmServer: RealmServerService;
   @service declare private store: StoreService;
   #storeServiceOverride: StoreService | undefined;
@@ -356,9 +357,7 @@ export class SearchResource<
       let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
       if (seed.searchURL && !hasQueryErrors) {
         let { query: seedQuery } = parseSearchURL(seed.searchURL);
-        this.#previousQueryString = buildQueryParamValue(
-          normalizeQueryForSignature(seedQuery),
-        );
+        this.#previousQueryString = this.querySignature(seedQuery);
       }
       this.#previousQuery = query;
       if (seed.realms) {
@@ -396,9 +395,7 @@ export class SearchResource<
         // the recomputed query doesn't sneak a fetch back in.
         this.#previousRealms = realms;
         this.#previousQuery = query;
-        this.#previousQueryString = buildQueryParamValue(
-          normalizeQueryForSignature(query),
-        );
+        this.#previousQueryString = this.querySignature(query);
         return;
       }
     }
@@ -442,7 +439,7 @@ export class SearchResource<
       });
     }
 
-    let queryString = buildQueryParamValue(normalizeQueryForSignature(query));
+    let queryString = this.querySignature(query);
     if (
       isEqual(queryString, this.#previousQueryString) &&
       isEqual(realms, this.#previousRealms)
@@ -462,6 +459,14 @@ export class SearchResource<
     this.#previousQueryString = queryString;
     this.trackStoreLoad(this.search.perform(query), 'search');
   }
+
+  // Spelling-tolerant query identity, so a server-produced seed query
+  // (URL-form refs) and the client's RRI-space rebuild of the same query
+  // compare equal and the seed can satisfy the initial search.
+  private querySignature(query: Query): string {
+    return canonicalQuerySignature(query, this.network.virtualNetwork);
+  }
+
   get isLoading() {
     return this.search.isRunning;
   }

--- a/packages/host/tests/unit/query-field-normalization-test.ts
+++ b/packages/host/tests/unit/query-field-normalization-test.ts
@@ -66,6 +66,65 @@ module('normalizeQueryDefinition', function () {
     assert.strictEqual(normalized?.realm, 'https://other.realm/');
   });
 
+  test('resolves in RRI space when no VirtualNetwork is supplied', function (assert) {
+    let realmURL = new URL('https://realm.example/');
+    let resource: LooseCardResource = {
+      // A prefix-mapped realm's canonical instance id.
+      id: '@scope/realm/cards/1',
+      meta: {
+        adoptsFrom: {
+          module: rri('@scope/realm/base'),
+          name: 'BaseCard',
+        },
+      },
+      attributes: {},
+    };
+
+    let normalized = normalizeQueryDefinition({
+      fieldDefinition: {
+        ...fieldDefinition,
+        fieldOrCard: {
+          // Relative module: must resolve against the prefix-form id.
+          module: rri('../test-defs'),
+          name: 'Test',
+        },
+      },
+      queryDefinition: {},
+      realmURL,
+      fieldName: 'queryField',
+      resource,
+      resolvePathValue: () => undefined,
+    });
+
+    assert.ok(normalized, 'normalization succeeded without a VirtualNetwork');
+    assert.deepEqual(
+      normalized?.query.filter,
+      {
+        type: { module: rri('@scope/realm/test-defs'), name: 'Test' },
+      },
+      'relative module resolved against the prefix-form id, staying in RRI space',
+    );
+
+    // An already-absolute prefix module passes through unchanged.
+    let absolute = normalizeQueryDefinition({
+      fieldDefinition: {
+        ...fieldDefinition,
+        fieldOrCard: {
+          module: rri('@other/realm/defs'),
+          name: 'Test',
+        },
+      },
+      queryDefinition: {},
+      realmURL,
+      fieldName: 'queryField',
+      resource,
+      resolvePathValue: () => undefined,
+    });
+    assert.deepEqual(absolute?.query.filter, {
+      type: { module: rri('@other/realm/defs'), name: 'Test' },
+    });
+  });
+
   test('injects on into leaf filter inside not', function (assert) {
     let realmURL = new URL('https://realm.example/');
     let relativeTo = new URL('https://realm.example/cards/1');

--- a/packages/host/tests/unit/query-signature-test.ts
+++ b/packages/host/tests/unit/query-signature-test.ts
@@ -1,0 +1,111 @@
+import { module, test } from 'qunit';
+
+import {
+  canonicalQuerySignature,
+  VirtualNetwork,
+  rri,
+  type Query,
+} from '@cardstack/runtime-common';
+
+module('Unit | canonicalQuerySignature', function (hooks) {
+  let virtualNetwork: VirtualNetwork;
+
+  hooks.beforeEach(function () {
+    virtualNetwork = new VirtualNetwork();
+    virtualNetwork.addRealmMapping('@scope/realm/', 'https://realm.example/');
+  });
+
+  function sig(query: Query) {
+    return canonicalQuerySignature(query, virtualNetwork);
+  }
+
+  test('prefix and URL spellings of the same query produce the same signature', function (assert) {
+    let urlForm: Query = {
+      filter: {
+        on: { module: rri('https://realm.example/defs'), name: 'Pet' },
+        in: { id: ['https://realm.example/Pet/mango'] },
+      },
+      sort: [
+        {
+          by: 'name',
+          on: { module: rri('https://realm.example/defs'), name: 'Pet' },
+        },
+      ],
+    };
+    let prefixForm: Query = {
+      filter: {
+        on: { module: rri('@scope/realm/defs'), name: 'Pet' },
+        in: { id: ['@scope/realm/Pet/mango'] },
+      },
+      sort: [
+        {
+          by: 'name',
+          on: { module: rri('@scope/realm/defs'), name: 'Pet' },
+        },
+      ],
+    };
+    assert.strictEqual(
+      sig(urlForm),
+      sig(prefixForm),
+      'equivalent spellings collapse to one signature',
+    );
+  });
+
+  test('genuinely different queries keep different signatures', function (assert) {
+    let base: Query = {
+      filter: {
+        on: { module: rri('@scope/realm/defs'), name: 'Pet' },
+        in: { id: ['@scope/realm/Pet/mango'] },
+      },
+    };
+    let differentName: Query = {
+      filter: {
+        on: { module: rri('@scope/realm/defs'), name: 'Person' },
+        in: { id: ['@scope/realm/Pet/mango'] },
+      },
+    };
+    let differentId: Query = {
+      filter: {
+        on: { module: rri('@scope/realm/defs'), name: 'Pet' },
+        in: { id: ['@scope/realm/Pet/paper'] },
+      },
+    };
+    assert.notStrictEqual(sig(base), sig(differentName));
+    assert.notStrictEqual(sig(base), sig(differentId));
+  });
+
+  test('non-reference filter values are not collapsed', function (assert) {
+    // `title` is not a reference leaf, so a prefix-looking string value and
+    // its resolved URL remain distinct queries.
+    let a: Query = {
+      filter: {
+        on: { module: rri('@scope/realm/defs'), name: 'Pet' },
+        eq: { cardTitle: '@scope/realm/Pet/mango' },
+      },
+    };
+    let b: Query = {
+      filter: {
+        on: { module: rri('@scope/realm/defs'), name: 'Pet' },
+        eq: { cardTitle: 'https://realm.example/Pet/mango' },
+      },
+    };
+    assert.notStrictEqual(sig(a), sig(b));
+  });
+
+  test('unmapped references pass through unchanged', function (assert) {
+    let a: Query = {
+      filter: {
+        on: { module: rri('https://other.example/defs'), name: 'Pet' },
+        in: { id: ['https://other.example/Pet/mango'] },
+      },
+    };
+    assert.strictEqual(sig(a), sig(a), 'deterministic');
+    let b: Query = {
+      filter: {
+        on: { module: rri('https://other.example/defs'), name: 'Pet' },
+        in: { id: ['https://other.example/Pet/paper'] },
+      },
+    };
+    assert.notStrictEqual(sig(a), sig(b));
+  });
+});

--- a/packages/host/tests/unit/query-signature-test.ts
+++ b/packages/host/tests/unit/query-signature-test.ts
@@ -74,6 +74,25 @@ module('Unit | canonicalQuerySignature', function (hooks) {
     assert.notStrictEqual(sig(base), sig(differentId));
   });
 
+  test('eq on a reference field stays exact (engine applies tolerance to `in` only)', function (assert) {
+    // `eq:{id}` compiles to an exact match server-side, so URL-form and
+    // prefix-form eq values are genuinely different queries with different
+    // result sets — their signatures must not collapse.
+    let urlForm: Query = {
+      filter: {
+        on: { module: rri('@scope/realm/defs'), name: 'Pet' },
+        eq: { id: 'https://realm.example/Pet/mango' },
+      },
+    };
+    let prefixForm: Query = {
+      filter: {
+        on: { module: rri('@scope/realm/defs'), name: 'Pet' },
+        eq: { id: '@scope/realm/Pet/mango' },
+      },
+    };
+    assert.notStrictEqual(sig(urlForm), sig(prefixForm));
+  });
+
   test('non-reference filter values are not collapsed', function (assert) {
     // `title` is not a reference leaf, so a prefix-looking string value and
     // its resolved URL remain distinct queries.

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -824,6 +824,7 @@ export * from './authorization-middleware.ts';
 export * from './resource-types.ts';
 export * from './prerender-headers.ts';
 export * from './query.ts';
+export * from './query-signature.ts';
 export * from './instance-filter-matcher.ts';
 export * from './search-utils.ts';
 export * from './search-resource-helpers.ts';

--- a/packages/runtime-common/query-field-utils.ts
+++ b/packages/runtime-common/query-field-utils.ts
@@ -1,4 +1,5 @@
 import { codeRefWithAbsoluteIdentifier, type CodeRef } from './code-ref.ts';
+import { rri, type RealmResourceIdentifier } from './realm-identifiers.ts';
 import type { VirtualNetwork } from './virtual-network.ts';
 import type { FieldDefinition } from './definitions.ts';
 import type {
@@ -39,8 +40,13 @@ export interface NormalizeQueryDefinitionParams {
   fieldPath?: string;
   resolvePathValue: (path: string) => any;
   resource?: LooseCardResource | FileMetaResource;
-  relativeTo?: URL;
-  virtualNetwork: VirtualNetwork;
+  relativeTo?: RealmResourceIdentifier | URL;
+  // Optional: when supplied, the target code ref and the reference base are
+  // resolved through the VirtualNetwork to real URLs (legacy callers). When
+  // omitted, resolution happens in RRI space — identifiers pass through in
+  // their canonical form (prefix for mapped realms, URL otherwise), which the
+  // search index and the client-side filter matcher both tolerate.
+  virtualNetwork?: VirtualNetwork;
 }
 
 export interface NormalizedQueryDefinitionResult {
@@ -233,11 +239,16 @@ export function normalizeQueryDefinition({
 
   let resolvedRealm = resolveRealm(specifiedRealm);
 
-  let relativeToURL =
-    relativeTo ?? (resource?.id ? virtualNetwork.toURL(resource.id) : realmURL);
+  let relativeToBase: RealmResourceIdentifier | URL =
+    relativeTo ??
+    (resource?.id
+      ? virtualNetwork
+        ? virtualNetwork.toURL(resource.id)
+        : rri(resource.id)
+      : realmURL);
   let targetRef = codeRefWithAbsoluteIdentifier(
     fieldDefinition.fieldOrCard,
-    relativeToURL,
+    relativeToBase,
     undefined,
     virtualNetwork,
   );

--- a/packages/runtime-common/query-signature.ts
+++ b/packages/runtime-common/query-signature.ts
@@ -1,0 +1,98 @@
+import { canonicalModuleKey } from './code-ref.ts';
+import {
+  buildQueryParamValue,
+  isReferenceFilterField,
+  normalizeQueryForSignature,
+  type Query,
+} from './query.ts';
+import type { VirtualNetwork } from './virtual-network.ts';
+
+// A spelling-tolerant identity signature for a query. Two queries that differ
+// only in how they spell module references (`on`/`type` code refs, sort `on`
+// refs) or reference-field filter values (`id`/`url` under `eq`/`in`) — RRI
+// prefix vs real URL vs virtual alias — produce the same signature.
+//
+// The consumer is seed/live query reconciliation: a server-produced seed
+// query (built through the server's VirtualNetwork, URL-form refs) must be
+// recognized as "the same query" as the client's rebuild of it (RRI-space,
+// prefix-form refs for mapped realms), otherwise every server-seeded query
+// field re-fetches results the seed already answered.
+//
+// Correctness note: this is a comparison key, not a semantic transform — both
+// sides of a comparison pass through the same canonicalization, so the only
+// requirement is that the mapping is deterministic and collapses exactly the
+// equivalent spellings (`canonicalModuleKey` guarantees that: prefix and
+// virtual spellings fold onto the real URL; unmapped values pass through).
+export function canonicalQuerySignature(
+  query: Query,
+  virtualNetwork: VirtualNetwork,
+): string {
+  return buildQueryParamValue(
+    canonicalizeNode(
+      normalizeQueryForSignature(query),
+      virtualNetwork,
+    ) as Query,
+  );
+}
+
+function canonicalizeNode(
+  node: unknown,
+  virtualNetwork: VirtualNetwork,
+): unknown {
+  if (Array.isArray(node)) {
+    return node.map((entry) => canonicalizeNode(entry, virtualNetwork));
+  }
+  if (node && typeof node === 'object') {
+    let out: Record<string, unknown> = {};
+    for (let [key, value] of Object.entries(node)) {
+      if (
+        (key === 'eq' || key === 'in') &&
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value)
+      ) {
+        out[key] = canonicalizeFieldValues(
+          value as Record<string, unknown>,
+          virtualNetwork,
+        );
+      } else {
+        out[key] = canonicalizeNode(value, virtualNetwork);
+      }
+    }
+    // A code-ref-shaped node ({ module, name }) — `on`/`type` gates and sort
+    // entries — compares by its resolved module identity.
+    if (typeof out.module === 'string' && typeof out.name === 'string') {
+      out.module = canonicalModuleKey(out.module, virtualNetwork);
+    }
+    return out;
+  }
+  return node;
+}
+
+function canonicalizeFieldValues(
+  fields: Record<string, unknown>,
+  virtualNetwork: VirtualNetwork,
+): Record<string, unknown> {
+  let out: Record<string, unknown> = {};
+  for (let [path, value] of Object.entries(fields)) {
+    out[path] = isReferenceFilterField(path)
+      ? canonicalizeReferenceValue(value, virtualNetwork)
+      : canonicalizeNode(value, virtualNetwork);
+  }
+  return out;
+}
+
+function canonicalizeReferenceValue(
+  value: unknown,
+  virtualNetwork: VirtualNetwork,
+): unknown {
+  if (typeof value === 'string') {
+    return canonicalModuleKey(value, virtualNetwork);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) =>
+      canonicalizeReferenceValue(entry, virtualNetwork),
+    );
+  }
+  return value;
+}

--- a/packages/runtime-common/query-signature.ts
+++ b/packages/runtime-common/query-signature.ts
@@ -9,8 +9,12 @@ import type { VirtualNetwork } from './virtual-network.ts';
 
 // A spelling-tolerant identity signature for a query. Two queries that differ
 // only in how they spell module references (`on`/`type` code refs, sort `on`
-// refs) or reference-field filter values (`id`/`url` under `eq`/`in`) — RRI
-// prefix vs real URL vs virtual alias — produce the same signature.
+// refs) or reference-field filter values (`id`/`url` under `in`) — RRI prefix
+// vs real URL vs virtual alias — produce the same signature. The tolerance
+// mirrors the query engine's exactly: `in` on a reference field matches
+// equivalent spellings, while `eq` stays exact — so two `eq` queries that
+// differ in spelling are genuinely different queries (different result sets)
+// and keep different signatures.
 //
 // The consumer is seed/live query reconciliation: a server-produced seed
 // query (built through the server's VirtualNetwork, URL-form refs) must be
@@ -46,7 +50,7 @@ function canonicalizeNode(
     let out: Record<string, unknown> = {};
     for (let [key, value] of Object.entries(node)) {
       if (
-        (key === 'eq' || key === 'in') &&
+        key === 'in' &&
         value &&
         typeof value === 'object' &&
         !Array.isArray(value)
@@ -55,6 +59,15 @@ function canonicalizeNode(
           value as Record<string, unknown>,
           virtualNetwork,
         );
+      } else if (
+        (key === 'eq' || key === 'contains' || key === 'range') &&
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value)
+      ) {
+        // Exact-match predicates: the engine compares these values verbatim,
+        // so the signature must too — no folding anywhere in the subtree.
+        out[key] = value;
       } else {
         out[key] = canonicalizeNode(value, virtualNetwork);
       }
@@ -75,9 +88,11 @@ function canonicalizeFieldValues(
 ): Record<string, unknown> {
   let out: Record<string, unknown> = {};
   for (let [path, value] of Object.entries(fields)) {
+    // Only reference leaves get the equivalent-spelling fold — the engine
+    // compares every other `in` value verbatim.
     out[path] = isReferenceFilterField(path)
       ? canonicalizeReferenceValue(value, virtualNetwork)
-      : canonicalizeNode(value, virtualNetwork);
+      : value;
   }
   return out;
 }


### PR DESCRIPTION
This allows `normalizeQueryDefinition`’s virtual network to become optional.

The server side still passes one; addressing that is for CS-11773, as it’s a bigger change that involves persisted output.