### PR TITLE
Close workspace chooser when going to current system card

### DIFF
--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -1163,6 +1163,9 @@ export default class Room extends Component<Signature> {
   private goToSystemCard() {
     let systemCardId = this.systemCardId;
     if (systemCardId) {
+      if (this.operatorModeStateService.workspaceChooserOpened) {
+        this.operatorModeStateService.closeWorkspaceChooser();
+      }
       let stackIndex = Math.min(
         this.operatorModeStateService.numberOfStacks(),
         1,

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1005,6 +1005,39 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await click('[data-test-close-ai-assistant]');
   });
 
+  test('"Go to current system card" closes the workspace chooser', async function (assert) {
+    await visitOperatorMode({
+      workspaceChooserOpened: true,
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}index`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+
+    assert
+      .dom('[data-test-workspace-chooser]')
+      .exists('workspace chooser is open');
+
+    await click('[data-test-open-ai-assistant]');
+    await waitFor('[data-room-settled]');
+    await click('[data-test-llm-select-selected]');
+    await click('[data-test-go-to-system-card]');
+
+    assert
+      .dom('[data-test-workspace-chooser]')
+      .doesNotExist('workspace chooser is closed after going to system card');
+    assert
+      .dom(`[data-test-stack-card="${testRealmURL}SystemCard/default"]`)
+      .exists('the system card is shown on the stack');
+
+    await click('[data-test-pill-menu-button]');
+    await click('[data-test-close-ai-assistant]');
+  });
+
   test('LLM select footer shows "Restore default" when non-default system card is active', async function (assert) {
     await visitOperatorMode({
       stacks: [


### PR DESCRIPTION
## Problem

Clicking **"Go to current system card"** (in the AI assistant's LLM select footer) while the workspace chooser is open added the system card to a stack, but left the chooser open. Because the chooser fully overlays the stacks, the click appeared to have no effect.

## Fix

`goToSystemCard()` in `packages/host/app/components/matrix/room.gts` now closes the workspace chooser before navigating — mirroring the existing behavior of `ShowCardCommand`, `ShowFileCommand`, and `SwitchSubmodeCommand`.

## Test coverage

Added an acceptance test in `packages/host/tests/acceptance/ai-assistant-test.gts` that opens operator mode with the workspace chooser open, triggers "Go to current system card", and asserts the chooser closes and the system card lands on the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)