### PR TITLE
Enable source-code-editing directly in code mode

### DIFF
--- a/packages/host/app/lib/utils.ts
+++ b/packages/host/app/lib/utils.ts
@@ -99,8 +99,6 @@ export function skillFileURL(skillName: string): string {
 export const devSkillId = `@cardstack/skills/${devSkillLocalPath}`;
 export const envSkillId = `@cardstack/skills/${envSkillLocalPath}`;
 
-// Every room enables this entry-point skill at creation instead of pushing
-// full skill bodies: its short body lists the code skills
-// (source-code-editing, ...) by SKILL.md path and the bot loads each on
-// demand via readRealmFile.
-export const codeModeEntryPointSkillUrl = `${skillsRealmURL}skills/code-mode/SKILL.md`;
+// The markdown-first source-code-editing skill, enabled directly in code
+// mode alongside the card defaults.
+export const sourceCodeEditingSkillUrl = `${skillsRealmURL}skills/source-code-editing/SKILL.md`;

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -126,7 +126,7 @@ import { getUniqueValidCommandDefinitions } from '../lib/command-definitions';
 import { isSkillCard } from '../lib/file-def-manager';
 import { getSkillSourceCommands, loadSkillSource } from '../lib/skill-commands';
 import {
-  codeModeEntryPointSkillUrl,
+  sourceCodeEditingSkillUrl,
   devSkillId,
   envSkillId,
 } from '../lib/utils';
@@ -2808,11 +2808,10 @@ export default class MatrixService extends Service {
     let defaultSkillIds = await this.loadDefaultSkills('code');
     await updateRoomSkillsCommand.execute({
       roomId: this.currentRoomId,
-      // Dual-path window: the legacy card skills (pushed in full) activate
-      // alongside the code-mode entry-point skill, whose linked skills the
-      // bot loads on demand. As the card skills convert to markdown the
-      // pushed set shrinks.
-      skillCardIdsToActivate: [...defaultSkillIds, codeModeEntryPointSkillUrl],
+      // Dual-path window: the legacy card skills activate alongside the
+      // markdown source-code-editing skill. All are pushed for now; the
+      // on-demand entry point returns as a catalog listing.
+      skillCardIdsToActivate: [...defaultSkillIds, sourceCodeEditingSkillUrl],
     });
   }
 


### PR DESCRIPTION
The markdown-first skills import (cardstack/boxel-skills#88) deletes `skills/code-mode/SKILL.md`, the entry-point skill that code mode currently enables. Once that merges and syncs, the activation would silently skip and code-mode rooms would carry no source-code-editing at all (it's no longer in the pushed card defaults either).

Fix: enable the markdown `skills/source-code-editing/SKILL.md` directly in code mode — that file survives the import. Its body is pushed like the other defaults for now; the on-demand entry point returns later as a catalog listing.

Effectively a one-line URL change plus renames.
