### PR TITLE
ai-bot: resolve relative skill links and infer realm on readRealmFile

### DIFF
--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -3,7 +3,7 @@ import type { CommandRequest } from '@cardstack/runtime-common/commands';
 import { AI_BOT_EXECUTOR } from '@cardstack/runtime-common/commands';
 import {
   READ_REALM_FILE_TOOL_NAME,
-  fileLabelFromUrl,
+  readFilesLabel,
 } from '../read-realm-file.ts';
 import { thinkingMessage } from '../../constants.ts';
 import type ResponseState from '../response-state.ts';
@@ -46,18 +46,9 @@ function toCommandRequest(
   // arguments carry no description of their own.
   if (result.name === READ_REALM_FILE_TOOL_NAME) {
     result.executedBy = AI_BOT_EXECUTOR;
-    let urls: unknown = result.arguments?.urls;
-    let labels = (Array.isArray(urls) ? urls : [])
-      .map((url) => (typeof url === 'string' ? fileLabelFromUrl(url) : url))
-      .filter(Boolean);
     result.arguments = {
       ...(result.arguments ?? {}),
-      description:
-        labels.length === 0
-          ? 'Read files'
-          : labels.length === 1
-            ? `Read file: ${labels[0]}`
-            : `Read files: ${labels.join(', ')}`,
+      description: readFilesLabel(result.arguments?.urls),
     };
   }
   return result;

--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -42,14 +42,22 @@ function toCommandRequest(
   }
   // readRealmFile is a tool ai-bot fulfills itself: tag it so the host records
   // it in the timeline but never runs it, and give it a human label the
-  // timeline indicator can show ("Read file: <name>") since the raw arguments
-  // carry no description of their own.
+  // timeline indicator can show ("Read files: <names>") since the raw
+  // arguments carry no description of their own.
   if (result.name === READ_REALM_FILE_TOOL_NAME) {
     result.executedBy = AI_BOT_EXECUTOR;
-    let label = fileLabelFromUrl(result.arguments?.url);
+    let urls: unknown = result.arguments?.urls;
+    let labels = (Array.isArray(urls) ? urls : [])
+      .map((url) => (typeof url === 'string' ? fileLabelFromUrl(url) : url))
+      .filter(Boolean);
     result.arguments = {
       ...(result.arguments ?? {}),
-      description: label ? `Read file: ${label}` : 'Read file',
+      description:
+        labels.length === 0
+          ? 'Read files'
+          : labels.length === 1
+            ? `Read file: ${labels[0]}`
+            : `Read files: ${labels.join(', ')}`,
     };
   }
   return result;

--- a/packages/ai-bot/lib/read-realm-file-fulfillment.ts
+++ b/packages/ai-bot/lib/read-realm-file-fulfillment.ts
@@ -51,6 +51,9 @@ export interface ReadRealmFileFulfillmentDeps {
 
 export interface ReadRealmFileFulfillmentOutcome {
   commandRequestId: string;
+  // True only when every requested file was read and attached; a partial read
+  // reports ok: false with `error` naming the files that failed, even though
+  // the successful ones were still attached.
   ok: boolean;
   error?: string;
 }
@@ -87,12 +90,16 @@ async function uploadTextToMatrix(
 // Runs each readRealmFile tool call ai-bot owns and publishes its outcome as a
 // command-result event — the same shape a host command result takes, so the
 // existing prompt reconstruction pairs it with the request and feeds it back on
-// the next turn. On success the fetched file is uploaded to Matrix and attached
-// to the result event (data.attachedFiles); the model receives its content via
-// the same attachment-download path host-read files use. On failure the result
-// event carries the reason and resolves the request as invalid, so a failed
-// read reads as failed rather than as a clean read. Returns one outcome per
-// call; never throws (a publish failure is logged so the turn still settles).
+// the next turn. A call names any number of files; they are fetched
+// concurrently (as are the calls themselves) and every file that was read is
+// uploaded to Matrix and attached to the call's single result event
+// (data.attachedFiles); the model receives their content via the same
+// attachment-download path host-read files use. Files that could not be read
+// are named in the result's failureReason: the result stays `applied` while at
+// least one file came back (so the successful content isn't thrown away), and
+// resolves as invalid only when nothing did — either way a partial or failed
+// read never reads as a clean one. Returns one outcome per call; never throws
+// (a publish failure is logged so the turn still settles).
 export async function fulfillReadRealmFileCalls(
   botToolCalls: ChatCompletionMessageToolCall[],
   deps: ReadRealmFileFulfillmentDeps,
@@ -101,14 +108,52 @@ export async function fulfillReadRealmFileCalls(
     deps.uploadText ??
     ((content: string, contentType: string) =>
       uploadTextToMatrix(deps.client, content, contentType));
-  let outcomes: ReadRealmFileFulfillmentOutcome[] = [];
-  for (let call of botToolCalls) {
-    if (call.type !== 'function') {
-      continue;
-    }
-    outcomes.push(await fulfillOne(call, deps, upload));
+  return Promise.all(
+    botToolCalls
+      .filter(
+        (call): call is ChatCompletionMessageToolCall & { type: 'function' } =>
+          call.type === 'function',
+      )
+      .map((call) => fulfillOne(call, deps, upload)),
+  );
+}
+
+type FileRead =
+  | { url: string; attachment: Record<string, unknown> }
+  | { url: string; error: string };
+
+// Reads and uploads a single file of a call. An upload failure is folded into
+// the same shape as a read failure so the caller reports both alike.
+async function readAndUpload(
+  url: string,
+  deps: ReadRealmFileFulfillmentDeps,
+  upload: (content: string, contentType: string) => Promise<string>,
+): Promise<FileRead> {
+  let result = await executeReadRealmFile(url, {
+    onBehalfOf: deps.onBehalfOf,
+    delegatedUserRealmSessions: deps.delegatedUserRealmSessions,
+    fetch: deps.fetch,
+  });
+  if (!result.ok) {
+    return { url, error: result.error };
   }
-  return outcomes;
+  let fileUrl: string;
+  try {
+    fileUrl = await upload(result.content, READ_FILE_CONTENT_TYPE);
+  } catch (e: any) {
+    log.error(`readRealmFile: upload failed for ${url}: ${e?.message ?? e}`);
+    return { url, error: `could not store ${url} for reading` };
+  }
+  return {
+    url,
+    attachment: {
+      sourceUrl: url,
+      url: fileUrl,
+      name: fileLabelFromUrl(url) ?? url,
+      contentType: READ_FILE_CONTENT_TYPE,
+      contentSize: Buffer.byteLength(result.content),
+    },
+  };
 }
 
 async function fulfillOne(
@@ -122,32 +167,48 @@ async function fulfillOne(
   } catch {
     args = undefined;
   }
-  if (!args || !args.url) {
-    return await publishFailure(call.id, 'readRealmFile needs a url.', deps);
-  }
-
-  let result = await executeReadRealmFile(args, {
-    onBehalfOf: deps.onBehalfOf,
-    delegatedUserRealmSessions: deps.delegatedUserRealmSessions,
-    fetch: deps.fetch,
-  });
-  if (!result.ok) {
-    return await publishFailure(call.id, result.error, deps);
-  }
-
-  let label = fileLabelFromUrl(args.url) ?? args.url;
-  let fileUrl: string;
-  try {
-    fileUrl = await upload(result.content, READ_FILE_CONTENT_TYPE);
-  } catch (e: any) {
-    log.error(
-      `readRealmFile: upload failed for ${args.url}: ${e?.message ?? e}`,
-    );
+  // Dedupe within the call so a repeated URL doesn't attach (and inline into
+  // every later prompt) twice.
+  let urls = [
+    ...new Set(
+      (Array.isArray(args?.urls) ? args.urls : []).filter(
+        (url): url is string => typeof url === 'string' && url.length > 0,
+      ),
+    ),
+  ];
+  if (urls.length === 0) {
     return await publishFailure(
       call.id,
-      `could not store ${args.url} for reading`,
+      'readRealmFile needs a non-empty list of urls.',
       deps,
     );
+  }
+
+  let reads = await Promise.all(
+    urls.map((url) => readAndUpload(url, deps, upload)),
+  );
+  let attachedFiles = reads
+    .filter(
+      (read): read is Extract<FileRead, { attachment: object }> =>
+        'attachment' in read,
+    )
+    .map((read) => read.attachment);
+  let failureReason =
+    reads
+      .filter(
+        (read): read is Extract<FileRead, { error: string }> => 'error' in read,
+      )
+      // Most read errors already name the file; prefix the ones (e.g. realm
+      // access errors) that don't, so the model knows which URL to retry.
+      .map((read) =>
+        read.error.includes(read.url)
+          ? read.error
+          : `${read.url}: ${read.error}`,
+      )
+      .join('\n') || undefined;
+
+  if (attachedFiles.length === 0) {
+    return await publishFailure(call.id, failureReason!, deps);
   }
 
   await publish(deps, {
@@ -158,20 +219,17 @@ async function fulfillOne(
       key: 'applied',
       event_id: deps.requestEventId,
     },
+    ...(failureReason ? { failureReason } : {}),
     data: {
       context: { agentId: deps.agentId },
-      attachedFiles: [
-        {
-          sourceUrl: args.url,
-          url: fileUrl,
-          name: label,
-          contentType: READ_FILE_CONTENT_TYPE,
-          contentSize: Buffer.byteLength(result.content),
-        },
-      ],
+      attachedFiles,
     },
   });
-  return { commandRequestId: call.id, ok: true };
+  return {
+    commandRequestId: call.id,
+    ok: !failureReason,
+    ...(failureReason ? { error: failureReason } : {}),
+  };
 }
 
 async function publishFailure(

--- a/packages/ai-bot/lib/read-realm-file-fulfillment.ts
+++ b/packages/ai-bot/lib/read-realm-file-fulfillment.ts
@@ -122,12 +122,8 @@ async function fulfillOne(
   } catch {
     args = undefined;
   }
-  if (!args || !args.realm || !args.url) {
-    return await publishFailure(
-      call.id,
-      'readRealmFile needs a realm and a url.',
-      deps,
-    );
+  if (!args || !args.url) {
+    return await publishFailure(call.id, 'readRealmFile needs a url.', deps);
   }
 
   let result = await executeReadRealmFile(args, {

--- a/packages/ai-bot/lib/read-realm-file.ts
+++ b/packages/ai-bot/lib/read-realm-file.ts
@@ -12,41 +12,49 @@ let log = logger('ai-bot:read-realm-file');
 
 export const READ_REALM_FILE_TOOL_NAME = 'readRealmFile';
 
-// On-demand file reading. The model calls `readRealmFile` to pull a file's
-// contents only when it needs them — most often a skill's SKILL.md or a file it
-// references, but it works for any file in the realm. ai-bot executes it
-// in-process: it mints a delegated, user-scoped realm token and fetches the
-// file over HTTP, so the bot can only read what the requesting human can
-// already read, and the content is always live (no Matrix snapshots, no host
-// round-trip).
+// On-demand file reading. The model calls `readRealmFile` to pull files'
+// contents only when it needs them — most often a skill's SKILL.md or the
+// references it lists, but it works for any file in the realm. One call reads
+// any number of files: each model turn that requests reads costs a full
+// round-trip (fulfillment + a fresh generation), so the tool takes a list and
+// the description pushes the model to batch everything it already knows it
+// needs. ai-bot executes it in-process: it mints a delegated, user-scoped
+// realm token and fetches each file over HTTP, so the bot can only read what
+// the requesting human can already read, and the content is always live (no
+// Matrix snapshots, no host round-trip).
 export const readRealmFileTool: Tool = {
   type: 'function',
   function: {
     name: READ_REALM_FILE_TOOL_NAME,
     description:
-      "Read a file from a realm on demand — e.g. a skill's SKILL.md, or a " +
-      "file it references. Use this to get a skill's full instructions, or a " +
-      'reference it cites, when you only have it listed.',
+      "Read files from a realm on demand — e.g. a skill's SKILL.md, or the " +
+      'reference files it lists. Reads all the given URLs at once, so when ' +
+      'you already know several files you need (a skill’s reference ' +
+      'list usually tells you), request them all in a single call rather ' +
+      'than a few at a time — every extra round of reads delays your answer.',
     parameters: {
       type: 'object',
       properties: {
-        url: {
-          type: 'string',
+        urls: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string' },
           description:
-            'Full URL of the file to read, exactly as it appears in the ' +
-            "skill (a link there is already absolute — don't shorten or " +
-            'rewrite it). The realm it lives in is worked out for you.',
+            'Full URLs of the files to read, each exactly as it appears in ' +
+            "the skill (a link there is already absolute — don't shorten " +
+            'or rewrite it). The realm each file lives in is worked out ' +
+            'for you.',
         },
       },
-      required: ['url'],
+      required: ['urls'],
     },
   },
 };
 
 export interface ReadRealmFileArgs {
-  // Full URL of the file to read. The realm it belongs to is discovered from
-  // the realm server's response, so the caller supplies only the URL.
-  url: string;
+  // Full URLs of the files to read. The realm each belongs to is discovered
+  // from the realm server's response, so the caller supplies only URLs.
+  urls: string[];
 }
 
 // Realm servers echo the owning realm's root on every response — success or
@@ -59,16 +67,16 @@ export type ReadRealmFileResult =
   | { ok: true; url: string; content: string }
   | { ok: false; error: string };
 
-// Executes a readRealmFile tool call inside the bot process: GETs the file as
-// raw source, discovering the owning realm from the response so a delegated,
-// read-only token can be minted for `onBehalfOf` only when the realm actually
-// gates the file. A public file (e.g. anything in the skills realm) is returned
-// from the first unauthenticated fetch with no token at all. Never throws —
-// returns a result the caller hands back to the model as the tool result, so a
-// missing file or a permission failure becomes information the model can act on
-// rather than a crashed turn.
+// Reads one of a readRealmFile call's files inside the bot process: GETs the
+// file as raw source, discovering the owning realm from the response so a
+// delegated, read-only token can be minted for `onBehalfOf` only when the
+// realm actually gates the file. A public file (e.g. anything in the skills
+// realm) is returned from the first unauthenticated fetch with no token at
+// all. Never throws — returns a result the caller hands back to the model as
+// part of the tool result, so a missing file or a permission failure becomes
+// information the model can act on rather than a crashed turn.
 export async function executeReadRealmFile(
-  args: ReadRealmFileArgs,
+  url: string,
   {
     onBehalfOf,
     delegatedUserRealmSessions,
@@ -82,8 +90,6 @@ export async function executeReadRealmFile(
     fetch?: typeof globalThis.fetch;
   },
 ): Promise<ReadRealmFileResult> {
-  let url = args.url;
-
   // `redirect: 'manual'` keeps a stray redirect from being silently followed
   // (it surfaces as a non-2xx instead). No Authorization on the first try:
   // public files (the skills realm) come back 200, and a gated file comes back

--- a/packages/ai-bot/lib/read-realm-file.ts
+++ b/packages/ai-bot/lib/read-realm-file.ts
@@ -128,6 +128,19 @@ export async function executeReadRealmFile(
   }
   let realm = ensureTrailingSlash(realmHeader);
 
+  // The header is only trustworthy as a claim about the responding host
+  // itself: the token minted below is sent with the retry to `url`, and the
+  // mint handshake goes to the realm's origin. Requiring the file to live
+  // inside the realm that claimed it keeps both on the origin that issued the
+  // challenge — otherwise a hostile host could name someone else's realm in
+  // the header and receive that realm's delegated token on the retry.
+  if (!url.startsWith(realm)) {
+    return {
+      ok: false,
+      error: `could not load ${url}: it does not belong to the realm that claimed it (${realm})`,
+    };
+  }
+
   let authorized = async (): Promise<{
     response?: Response;
     error?: string;

--- a/packages/ai-bot/lib/read-realm-file.ts
+++ b/packages/ai-bot/lib/read-realm-file.ts
@@ -30,40 +30,43 @@ export const readRealmFileTool: Tool = {
     parameters: {
       type: 'object',
       properties: {
-        realm: {
-          type: 'string',
-          description:
-            'Realm URL the file lives in, e.g. https://app.boxel.ai/user/jane/. ' +
-            'Scopes the read to that realm; the file must be inside it.',
-        },
         url: {
           type: 'string',
           description:
-            'Full URL of the file to read. The realm and these URLs are given ' +
-            'to you together.',
+            'Full URL of the file to read, exactly as it appears in the ' +
+            "skill (a link there is already absolute — don't shorten or " +
+            'rewrite it). The realm it lives in is worked out for you.',
         },
       },
-      required: ['realm', 'url'],
+      required: ['url'],
     },
   },
 };
 
 export interface ReadRealmFileArgs {
-  // Realm root the read is scoped to (what the delegated token is minted for).
-  realm: string;
-  // Full URL of the file to read; must be inside `realm`.
+  // Full URL of the file to read. The realm it belongs to is discovered from
+  // the realm server's response, so the caller supplies only the URL.
   url: string;
 }
+
+// Realm servers echo the owning realm's root on every response — success or
+// auth failure — via this header. Reading it lets us discover the realm from
+// the file URL alone, so a delegated token is minted for the right realm
+// without the model having to name it (and get it wrong).
+const REALM_URL_HEADER = 'x-boxel-realm-url';
 
 export type ReadRealmFileResult =
   | { ok: true; url: string; content: string }
   | { ok: false; error: string };
 
-// Executes a readRealmFile tool call inside the bot process: mints a delegated,
-// read-only token for `onBehalfOf` scoped to `realm`, then GETs the file as raw
-// source. Never throws — returns a result the caller hands back to the model as
-// the tool result, so a missing file or a permission failure becomes
-// information the model can act on rather than a crashed turn.
+// Executes a readRealmFile tool call inside the bot process: GETs the file as
+// raw source, discovering the owning realm from the response so a delegated,
+// read-only token can be minted for `onBehalfOf` only when the realm actually
+// gates the file. A public file (e.g. anything in the skills realm) is returned
+// from the first unauthenticated fetch with no token at all. Never throws —
+// returns a result the caller hands back to the model as the tool result, so a
+// missing file or a permission failure becomes information the model can act on
+// rather than a crashed turn.
 export async function executeReadRealmFile(
   args: ReadRealmFileArgs,
   {
@@ -81,21 +84,57 @@ export async function executeReadRealmFile(
 ): Promise<ReadRealmFileResult> {
   let url = args.url;
 
-  // The delegated token is scoped to `realm`; a file outside it would be
-  // rejected by the realm server anyway, so fail clearly up front.
-  if (!url.startsWith(ensureTrailingSlash(args.realm))) {
-    return { ok: false, error: `${url} is not inside realm ${args.realm}` };
+  // `redirect: 'manual'` keeps a stray redirect from being silently followed
+  // (it surfaces as a non-2xx instead). No Authorization on the first try:
+  // public files (the skills realm) come back 200, and a gated file comes back
+  // 401/403 while still telling us its realm via the response header.
+  let get = async (token?: string): Promise<Response> =>
+    fetch(url, {
+      redirect: 'manual',
+      headers: {
+        Accept: SupportedMimeType.CardSource,
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+
+  let response: Response;
+  try {
+    response = await get();
+  } catch (e: any) {
+    log.error(`readRealmFile: fetch failed for ${url}: ${e?.message ?? e}`);
+    return { ok: false, error: `could not fetch ${url}` };
   }
 
-  // One mint+fetch attempt. `redirect: 'manual'` keeps a stray redirect from
-  // being silently followed (it surfaces as a non-2xx instead).
-  let attempt = async (): Promise<{ response?: Response; error?: string }> => {
+  // Public read (or an already-authorized cache/CDN hit): done, no token.
+  if (response.ok) {
+    return { ok: true, url, content: await response.text() };
+  }
+
+  // Anything other than an auth challenge is a real failure (404, 302, …).
+  if (response.status !== 401 && response.status !== 403) {
+    return {
+      ok: false,
+      error: `could not load ${url} (HTTP ${response.status})`,
+    };
+  }
+
+  // Gated file: the realm server named the owning realm even on the 401/403.
+  let realmHeader = response.headers.get(REALM_URL_HEADER);
+  if (!realmHeader) {
+    return {
+      ok: false,
+      error: `could not determine which realm ${url} belongs to`,
+    };
+  }
+  let realm = ensureTrailingSlash(realmHeader);
+
+  let authorized = async (): Promise<{
+    response?: Response;
+    error?: string;
+  }> => {
     let token: string;
     try {
-      token = await delegatedUserRealmSessions.getToken({
-        onBehalfOf,
-        realm: args.realm,
-      });
+      token = await delegatedUserRealmSessions.getToken({ onBehalfOf, realm });
     } catch (e: any) {
       if (e instanceof DelegatedUserRealmSessionError) {
         if (e.kind === 'disabled') {
@@ -105,54 +144,46 @@ export async function executeReadRealmFile(
           };
         }
         if (e.kind === 'forbidden') {
-          return { error: `no read access to ${args.realm}` };
+          return { error: `no read access to ${realm}` };
         }
       }
       log.error(
-        `readRealmFile: could not obtain a delegated token for ${args.realm}: ${
+        `readRealmFile: could not obtain a delegated token for ${realm}: ${
           e?.message ?? e
         }`,
       );
-      return { error: `could not obtain realm access for ${args.realm}` };
+      return { error: `could not obtain realm access for ${realm}` };
     }
     try {
-      return {
-        response: await fetch(url, {
-          redirect: 'manual',
-          headers: {
-            Accept: SupportedMimeType.CardSource,
-            Authorization: `Bearer ${token}`,
-          },
-        }),
-      };
+      return { response: await get(token) };
     } catch (e: any) {
       log.error(`readRealmFile: fetch failed for ${url}: ${e?.message ?? e}`);
       return { error: `could not fetch ${url}` };
     }
   };
 
-  let { response, error } = await attempt();
+  let { response: authed, error } = await authorized();
   if (error) {
     return { ok: false, error };
   }
   // A cached token whose access was revoked inside its staleness window gets a
   // 401/403. Drop it and try once with a freshly minted token before failing.
-  if (response && (response.status === 401 || response.status === 403)) {
-    delegatedUserRealmSessions.invalidate({ onBehalfOf, realm: args.realm });
-    ({ response, error } = await attempt());
+  if (authed && (authed.status === 401 || authed.status === 403)) {
+    delegatedUserRealmSessions.invalidate({ onBehalfOf, realm });
+    ({ response: authed, error } = await authorized());
     if (error) {
       return { ok: false, error };
     }
   }
 
-  if (!response || !response.ok) {
+  if (!authed || !authed.ok) {
     return {
       ok: false,
-      error: `could not load ${url} (HTTP ${response?.status ?? 'unknown'})`,
+      error: `could not load ${url} (HTTP ${authed?.status ?? 'unknown'})`,
     };
   }
 
-  return { ok: true, url, content: await response.text() };
+  return { ok: true, url, content: await authed.text() };
 }
 
 export interface ClassifiedToolCalls {

--- a/packages/ai-bot/lib/read-realm-file.ts
+++ b/packages/ai-bot/lib/read-realm-file.ts
@@ -253,3 +253,28 @@ export function fileLabelFromUrl(url: string | undefined): string | undefined {
     return url;
   }
 }
+
+// A readRealmFile call can batch many urls; cap how many we name in the
+// timeline label so the description (and the event payload it rides in) stays
+// bounded no matter how many files the model requests at once.
+const READ_FILES_LABEL_MAX = 5;
+
+// Build the human-readable timeline label ("Read file: <name>" /
+// "Read files: <names>") from a readRealmFile call's `urls` argument. Non-string
+// entries are dropped so a malformed argument never leaks into the label.
+export function readFilesLabel(urls: unknown): string {
+  let labels = (Array.isArray(urls) ? urls : [])
+    .filter((url): url is string => typeof url === 'string')
+    .map((url) => fileLabelFromUrl(url))
+    .filter((label): label is string => Boolean(label));
+  if (labels.length === 0) {
+    return 'Read files';
+  }
+  if (labels.length === 1) {
+    return `Read file: ${labels[0]}`;
+  }
+  let shown = labels.slice(0, READ_FILES_LABEL_MAX);
+  let remaining = labels.length - shown.length;
+  let suffix = remaining > 0 ? `, and ${remaining} more` : '';
+  return `Read files: ${shown.join(', ')}${suffix}`;
+}

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -38,12 +38,14 @@ import {
   rri,
 } from '@cardstack/runtime-common';
 import {
+  absolutizeSkillLinks,
   buildPromptForModel,
   getPromptParts,
   getRelevantCards,
   getTools,
   isMarkdownSkillFile,
   parseMarkdownSkill,
+  skillCardsToMessages,
   SKILL_INSTRUCTIONS_MESSAGE,
 } from '@cardstack/runtime-common/ai';
 import type { TextContent } from '@cardstack/runtime-common/ai/types';
@@ -7437,5 +7439,69 @@ module('markdown skill commands', (hooks) => {
     );
     assert.strictEqual(tools.length, 1);
     assert.strictEqual(tools[0].function.name, 'switch-submode_dd88');
+  });
+});
+
+module('absolutizeSkillLinks', () => {
+  const INDEX = 'https://localhost:4201/skills/index.md';
+
+  test('resolves a document-relative link against the skill url', () => {
+    // The skills realm is itself named `skills`, so a link relative to the
+    // index (which lives at the realm root) doubles the segment — the exact
+    // shape the ai-bot used to flatten to a 404.
+    assert.strictEqual(
+      absolutizeSkillLinks('See [boxel](skills/boxel/SKILL.md).', INDEX),
+      'See [boxel](https://localhost:4201/skills/skills/boxel/SKILL.md).',
+    );
+  });
+
+  test('resolves against the skill url, not a shorter prefix', () => {
+    assert.strictEqual(
+      absolutizeSkillLinks('[g](skills/glossary.md)', INDEX),
+      '[g](https://localhost:4201/skills/skills/glossary.md)',
+    );
+  });
+
+  test('leaves absolute urls, anchors, and non-navigational schemes alone', () => {
+    let body =
+      '[abs](https://example.com/x) [anchor](#section) [mail](mailto:a@b.c) [root](/top)';
+    assert.strictEqual(absolutizeSkillLinks(body, INDEX), body);
+  });
+
+  test('preserves a link title', () => {
+    assert.strictEqual(
+      absolutizeSkillLinks(
+        '[c](commands/boxel-create-card.md "Create")',
+        INDEX,
+      ),
+      '[c](https://localhost:4201/skills/commands/boxel-create-card.md "Create")',
+    );
+  });
+
+  test('leaves the body untouched when the id is not an absolute url', () => {
+    let body = '[boxel](skills/boxel/SKILL.md)';
+    assert.strictEqual(
+      absolutizeSkillLinks(body, '@cardstack/skills/index.md'),
+      body,
+    );
+    assert.strictEqual(absolutizeSkillLinks(body, undefined), body);
+  });
+
+  test('skillCardsToMessages absolutizes links in the emitted instructions', () => {
+    let [message] = skillCardsToMessages([
+      {
+        id: INDEX,
+        attributes: {
+          title: 'Index',
+          instructions: 'Read [boxel](skills/boxel/SKILL.md).',
+        },
+      },
+    ]);
+    assert.true(
+      message.includes(
+        '[boxel](https://localhost:4201/skills/skills/boxel/SKILL.md)',
+      ),
+      'the prompt carries a copy-ready absolute url',
+    );
   });
 });

--- a/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
@@ -13,7 +13,6 @@ const ON_BEHALF_OF = '@user:localhost';
 const AGENT_ID = 'agent-1';
 const ROOM_ID = '!room:localhost';
 const REQUEST_EVENT_ID = '$request:localhost';
-const REALM = 'https://localhost:4201/user/jane/';
 const FILE_URL =
   'https://localhost:4201/user/jane/skills/trip-planner/SKILL.md';
 
@@ -85,7 +84,7 @@ module('fulfillReadRealmFileCalls', () => {
       })) as unknown as typeof globalThis.fetch;
 
     let outcomes = await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c1', { realm: REALM, url: FILE_URL })],
+      [readRealmFileCall('c1', { url: FILE_URL })],
       baseDeps(client, {
         fetch,
         // Inject the uploader so this case doesn't touch the dedup cache.
@@ -127,7 +126,7 @@ module('fulfillReadRealmFileCalls', () => {
       })) as unknown as typeof globalThis.fetch;
 
     let outcomes = await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c1', { realm: REALM, url: FILE_URL })],
+      [readRealmFileCall('c1', { url: FILE_URL })],
       baseDeps(client, { fetch }),
     );
 
@@ -185,11 +184,11 @@ module('fulfillReadRealmFileCalls', () => {
       })) as unknown as typeof globalThis.fetch;
 
     await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c1', { realm: REALM, url: FILE_URL })],
+      [readRealmFileCall('c1', { url: FILE_URL })],
       baseDeps(client, { fetch }),
     );
     await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c2', { realm: REALM, url: FILE_URL })],
+      [readRealmFileCall('c2', { url: FILE_URL })],
       baseDeps(client, { fetch }),
     );
 

--- a/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
@@ -84,7 +84,7 @@ module('fulfillReadRealmFileCalls', () => {
       })) as unknown as typeof globalThis.fetch;
 
     let outcomes = await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c1', { url: FILE_URL })],
+      [readRealmFileCall('c1', { urls: [FILE_URL] })],
       baseDeps(client, {
         fetch,
         // Inject the uploader so this case doesn't touch the dedup cache.
@@ -118,6 +118,89 @@ module('fulfillReadRealmFileCalls', () => {
     assert.strictEqual(data.context.agentId, AGENT_ID);
   });
 
+  test('one call with many urls reads them all into a single result event', async () => {
+    let { client, sent } = fakeClient();
+    let otherUrl = 'https://localhost:4201/user/jane/notes.md';
+    let fetch = (async (input: any) => {
+      let url = typeof input === 'string' ? input : input.url;
+      return new Response(`content of ${url}`, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    let outcomes = await fulfillReadRealmFileCalls(
+      // The same url twice: within-call dedup keeps it from attaching twice.
+      [readRealmFileCall('c1', { urls: [FILE_URL, otherUrl, FILE_URL] })],
+      baseDeps(client, {
+        fetch,
+        uploadText: async (content: string) =>
+          `https://localhost/media/${content.length}`,
+      }),
+    );
+
+    assert.deepEqual(outcomes, [{ commandRequestId: 'c1', ok: true }]);
+    assert.strictEqual(sent.length, 1, 'all files ride one result event');
+    let { content } = sent[0];
+    assert.strictEqual(
+      content.msgtype,
+      APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+    );
+    assert.strictEqual(content['m.relates_to'].key, 'applied');
+    assert.notOk(content.failureReason, 'a clean read carries no failure note');
+    let data = dataOf(sent[0]);
+    assert.deepEqual(
+      data.attachedFiles.map((f: any) => f.sourceUrl),
+      [FILE_URL, otherUrl],
+      'one attachment per distinct url',
+    );
+  });
+
+  test('a partial read attaches what succeeded and names what failed', async () => {
+    let { client, sent } = fakeClient();
+    let missingUrl = 'https://localhost:4201/user/jane/missing.md';
+    let fetch = (async (input: any) => {
+      let url = typeof input === 'string' ? input : input.url;
+      return url === missingUrl
+        ? new Response('nope', { status: 404 })
+        : new Response('# Trip Planner', { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    let outcomes = await fulfillReadRealmFileCalls(
+      [readRealmFileCall('c1', { urls: [FILE_URL, missingUrl] })],
+      baseDeps(client, {
+        fetch,
+        uploadText: async () => 'https://localhost/media/trip-planner',
+      }),
+    );
+
+    assert.false(outcomes[0].ok, 'a partial read is not reported as clean');
+    assert.true(
+      outcomes[0].error!.includes(missingUrl),
+      'the outcome names the failed file',
+    );
+    assert.strictEqual(sent.length, 1);
+    let { content } = sent[0];
+    assert.strictEqual(
+      content.msgtype,
+      APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+      'the successful file still comes back with output',
+    );
+    assert.strictEqual(
+      content['m.relates_to'].key,
+      'applied',
+      'partial results resolve the request so the turn can continue',
+    );
+    assert.true(
+      content.failureReason.includes(missingUrl) &&
+        content.failureReason.includes('404'),
+      'the failure note names the file and why it failed',
+    );
+    let data = dataOf(sent[0]);
+    assert.deepEqual(
+      data.attachedFiles.map((f: any) => f.sourceUrl),
+      [FILE_URL],
+      'only the readable file is attached',
+    );
+  });
+
   test('a failed read posts an invalid result carrying the reason, no attachment', async () => {
     let { client, sent } = fakeClient();
     let fetch = (async () =>
@@ -126,7 +209,7 @@ module('fulfillReadRealmFileCalls', () => {
       })) as unknown as typeof globalThis.fetch;
 
     let outcomes = await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c1', { url: FILE_URL })],
+      [readRealmFileCall('c1', { urls: [FILE_URL] })],
       baseDeps(client, { fetch }),
     );
 
@@ -172,6 +255,25 @@ module('fulfillReadRealmFileCalls', () => {
     assert.strictEqual(sent[0].content['m.relates_to'].key, 'invalid');
   });
 
+  test('an empty urls list fails without fetching', async () => {
+    let { client, sent } = fakeClient();
+    let fetched = false;
+    let fetch = (async () => {
+      fetched = true;
+      return new Response('x', { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    let outcomes = await fulfillReadRealmFileCalls(
+      [readRealmFileCall('c1', { urls: [] })],
+      baseDeps(client, { fetch }),
+    );
+
+    assert.false(outcomes[0].ok);
+    assert.false(fetched, 'never fetched for an empty list');
+    assert.strictEqual(sent[0].content['m.relates_to'].key, 'invalid');
+    assert.true(sent[0].content.failureReason.includes('urls'));
+  });
+
   test('identical content is uploaded once and re-referenced (dedup)', async () => {
     let { client, sent, uploads } = fakeClient();
     // Content unique to this test so the module-level hash cache is exercised
@@ -184,11 +286,11 @@ module('fulfillReadRealmFileCalls', () => {
       })) as unknown as typeof globalThis.fetch;
 
     await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c1', { url: FILE_URL })],
+      [readRealmFileCall('c1', { urls: [FILE_URL] })],
       baseDeps(client, { fetch }),
     );
     await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c2', { url: FILE_URL })],
+      [readRealmFileCall('c2', { urls: [FILE_URL] })],
       baseDeps(client, { fetch }),
     );
 

--- a/packages/ai-bot/tests/read-realm-file-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-test.ts
@@ -8,6 +8,7 @@ import {
   readRealmFileTool,
   classifyToolCalls,
   fileLabelFromUrl,
+  readFilesLabel,
   READ_REALM_FILE_TOOL_NAME,
 } from '../lib/read-realm-file.ts';
 
@@ -340,5 +341,52 @@ module('fileLabelFromUrl', () => {
 
   test('undefined url → undefined label', () => {
     assert.strictEqual(fileLabelFromUrl(undefined), undefined);
+  });
+});
+
+module('readFilesLabel', () => {
+  test('no urls → generic label', () => {
+    assert.strictEqual(readFilesLabel(undefined), 'Read files');
+    assert.strictEqual(readFilesLabel([]), 'Read files');
+  });
+
+  test('one url → singular label', () => {
+    assert.strictEqual(
+      readFilesLabel([FILE_URL]),
+      'Read file: trip-planner/SKILL.md',
+    );
+  });
+
+  test('several urls → names joined', () => {
+    assert.strictEqual(
+      readFilesLabel([
+        'https://localhost:4201/user/jane/a.md',
+        'https://localhost:4201/user/jane/b.md',
+      ]),
+      'Read files: a.md, b.md',
+    );
+  });
+
+  test('caps the number of names and counts the rest', () => {
+    let urls = Array.from(
+      { length: 8 },
+      (_, i) => `https://localhost:4201/user/jane/f${i}.md`,
+    );
+    assert.strictEqual(
+      readFilesLabel(urls),
+      'Read files: f0.md, f1.md, f2.md, f3.md, f4.md, and 3 more',
+    );
+  });
+
+  test('drops non-string entries', () => {
+    assert.strictEqual(
+      readFilesLabel([
+        'https://localhost:4201/user/jane/a.md',
+        42,
+        null,
+        { url: 'x' },
+      ]),
+      'Read file: a.md',
+    );
   });
 });

--- a/packages/ai-bot/tests/read-realm-file-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-test.ts
@@ -76,9 +76,14 @@ module('readRealmFile tool definition', () => {
     assert.strictEqual(readRealmFileTool.type, 'function');
     let required = (readRealmFileTool.function.parameters as any)
       .required as string[];
-    assert.deepEqual(required, ['url'], 'only url is required');
+    assert.deepEqual(required, ['urls'], 'only urls is required');
     let properties = (readRealmFileTool.function.parameters as any)
-      .properties as Record<string, unknown>;
+      .properties as Record<string, any>;
+    assert.strictEqual(
+      properties['urls']?.type,
+      'array',
+      'many files read in one call — a per-turn trickle of single reads is the latency we are avoiding',
+    );
     assert.notOk(
       properties['realm'],
       'realm is discovered, not asked of the model',
@@ -93,10 +98,11 @@ module('executeReadRealmFile', () => {
       () => new Response('# Trip Planner\n\ninstructions', { status: 200 }),
     );
 
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
 
     assert.strictEqual(sessions.calls.length, 0, 'no token minted');
     assert.strictEqual(calls.length, 1, 'a single fetch');
@@ -121,10 +127,11 @@ module('executeReadRealmFile', () => {
         : new Response('# Gated\n\ninstructions', { status: 200 });
     });
 
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
 
     assert.deepEqual(
       sessions.calls,
@@ -152,10 +159,11 @@ module('executeReadRealmFile', () => {
     let { fetch } = recordingFetch(
       () => new Response('unauthorized', { status: 401 }),
     );
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
     assert.false(result.ok);
     assert.true(
       (result as { ok: false; error: string }).error.includes('which realm'),
@@ -175,10 +183,11 @@ module('executeReadRealmFile', () => {
           headers: { 'x-boxel-realm-url': 'https://other.example/user/mary/' },
         }),
     );
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
     assert.false(result.ok, 'result not ok');
     assert.true(
       (result as { ok: false; error: string }).error.includes(
@@ -195,10 +204,11 @@ module('executeReadRealmFile', () => {
     let { fetch } = recordingFetch(
       () => new Response('not found', { status: 404 }),
     );
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
     assert.false(result.ok, 'result not ok');
     assert.true(
       (result as { ok: false; error: string }).error.includes('404'),
@@ -212,10 +222,11 @@ module('executeReadRealmFile', () => {
       throws: new DelegatedUserRealmSessionError('disabled', 'off'),
     });
     let { fetch } = recordingFetch(() => gated());
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
     assert.false(result.ok);
     assert.true(
       (result as { ok: false; error: string }).error.includes('unavailable'),
@@ -228,10 +239,11 @@ module('executeReadRealmFile', () => {
       throws: new DelegatedUserRealmSessionError('forbidden', 'nope', 403),
     });
     let { fetch } = recordingFetch(() => gated(403));
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
     assert.false(result.ok);
     assert.true(
       (result as { ok: false; error: string }).error.includes('no read access'),
@@ -253,10 +265,11 @@ module('executeReadRealmFile', () => {
       return n === 2 ? gated() : new Response('# Fresh', { status: 200 });
     });
 
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
 
     assert.true(result.ok, 'succeeds on the retry');
     assert.strictEqual(calls.length, 3, 'probe, stale authed, fresh authed');
@@ -285,7 +298,7 @@ module('classifyToolCalls', () => {
   test('splits readRealmFile (bot) from everything else (host)', () => {
     let { botToolCalls, hostToolCalls } = classifyToolCalls(
       assistantMessage([
-        fnCall('c1', READ_REALM_FILE_TOOL_NAME, { url: FILE_URL }),
+        fnCall('c1', READ_REALM_FILE_TOOL_NAME, { urls: [FILE_URL] }),
         fnCall('c2', 'SomeHostCommand'),
       ]),
     );

--- a/packages/ai-bot/tests/read-realm-file-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-test.ts
@@ -16,6 +16,15 @@ const REALM = 'https://localhost:4201/user/jane/';
 const FILE_URL =
   'https://localhost:4201/user/jane/skills/trip-planner/SKILL.md';
 
+// A gated file's response: the realm server names the owning realm even on the
+// auth challenge, which is how executeReadRealmFile discovers the realm.
+function gated(status: 401 | 403 = 401): Response {
+  return new Response('unauthorized', {
+    status,
+    headers: { 'x-boxel-realm-url': REALM },
+  });
+}
+
 // A fake fetch that records each call and returns a scripted Response.
 function recordingFetch(
   handler: (url: string, init: RequestInit) => Response,
@@ -67,29 +76,33 @@ module('readRealmFile tool definition', () => {
     assert.strictEqual(readRealmFileTool.type, 'function');
     let required = (readRealmFileTool.function.parameters as any)
       .required as string[];
-    assert.true(required.includes('realm'), 'realm is required');
-    assert.true(required.includes('url'), 'url is required');
+    assert.deepEqual(required, ['url'], 'only url is required');
+    let properties = (readRealmFileTool.function.parameters as any)
+      .properties as Record<string, unknown>;
+    assert.notOk(
+      properties['realm'],
+      'realm is discovered, not asked of the model',
+    );
   });
 });
 
 module('executeReadRealmFile', () => {
-  test('mints a token for the realm and returns the file source', async () => {
-    let sessions = stubSessions({ token: 'tok-123' });
+  test('reads a public file from the first fetch with no token', async () => {
+    let sessions = stubSessions({ token: 'unused' });
     let { fetch, calls } = recordingFetch(
       () => new Response('# Trip Planner\n\ninstructions', { status: 200 }),
     );
 
     let result = await executeReadRealmFile(
-      { realm: REALM, url: FILE_URL },
+      { url: FILE_URL },
       { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
     );
 
-    assert.deepEqual(sessions.calls, [
-      { onBehalfOf: ON_BEHALF_OF, realm: REALM },
-    ]);
+    assert.strictEqual(sessions.calls.length, 0, 'no token minted');
+    assert.strictEqual(calls.length, 1, 'a single fetch');
     assert.strictEqual(calls[0].url, FILE_URL, 'fetches the given url');
     let headers = calls[0].init.headers as Record<string, string>;
-    assert.strictEqual(headers['Authorization'], 'Bearer tok-123');
+    assert.notOk(headers['Authorization'], 'no Authorization on a public read');
     assert.strictEqual(headers['Accept'], SupportedMimeType.CardSource);
     assert.true(result.ok, 'result ok');
     assert.strictEqual(
@@ -98,26 +111,57 @@ module('executeReadRealmFile', () => {
     );
   });
 
-  test('rejects a url outside the realm without minting or fetching', async () => {
+  test('discovers the realm from the challenge, then mints a token', async () => {
+    let sessions = stubSessions({ token: 'tok-123' });
+    let n = 0;
+    let { fetch, calls } = recordingFetch(() => {
+      n += 1;
+      return n === 1
+        ? gated()
+        : new Response('# Gated\n\ninstructions', { status: 200 });
+    });
+
+    let result = await executeReadRealmFile(
+      { url: FILE_URL },
+      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
+    );
+
+    assert.deepEqual(
+      sessions.calls,
+      [{ onBehalfOf: ON_BEHALF_OF, realm: REALM }],
+      'minted for the realm named in the response header',
+    );
+    assert.strictEqual(calls.length, 2, 'unauthenticated probe, then authed');
+    assert.notOk(
+      (calls[0].init.headers as Record<string, string>)['Authorization'],
+      'first fetch carries no token',
+    );
+    assert.strictEqual(
+      (calls[1].init.headers as Record<string, string>)['Authorization'],
+      'Bearer tok-123',
+    );
+    assert.true(result.ok, 'result ok');
+    assert.strictEqual(
+      (result as { ok: true; content: string }).content,
+      '# Gated\n\ninstructions',
+    );
+  });
+
+  test('errors when a gated file names no realm to mint against', async () => {
     let sessions = stubSessions({ token: 'tok' });
-    let { fetch, calls } = recordingFetch(
-      () => new Response('x', { status: 200 }),
+    let { fetch } = recordingFetch(
+      () => new Response('unauthorized', { status: 401 }),
     );
     let result = await executeReadRealmFile(
-      {
-        realm: REALM,
-        url: 'https://localhost:4201/user/someone-else/skills/x/SKILL.md',
-      },
+      { url: FILE_URL },
       { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
     );
     assert.false(result.ok);
     assert.true(
-      (result as { ok: false; error: string }).error.includes(
-        'not inside realm',
-      ),
+      (result as { ok: false; error: string }).error.includes('which realm'),
+      'error explains the realm could not be determined',
     );
     assert.strictEqual(sessions.calls.length, 0, 'no token minted');
-    assert.strictEqual(calls.length, 0, 'no fetch attempted');
   });
 
   test('returns an error result when the file is missing (404)', async () => {
@@ -126,7 +170,7 @@ module('executeReadRealmFile', () => {
       () => new Response('not found', { status: 404 }),
     );
     let result = await executeReadRealmFile(
-      { realm: REALM, url: FILE_URL },
+      { url: FILE_URL },
       { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
     );
     assert.false(result.ok, 'result not ok');
@@ -134,17 +178,16 @@ module('executeReadRealmFile', () => {
       (result as { ok: false; error: string }).error.includes('404'),
       'error mentions the status',
     );
+    assert.strictEqual(sessions.calls.length, 0, 'a 404 never mints a token');
   });
 
   test('reports a clear message when delegation is disabled', async () => {
     let sessions = stubSessions({
       throws: new DelegatedUserRealmSessionError('disabled', 'off'),
     });
-    let { fetch, calls } = recordingFetch(
-      () => new Response('', { status: 200 }),
-    );
+    let { fetch } = recordingFetch(() => gated());
     let result = await executeReadRealmFile(
-      { realm: REALM, url: FILE_URL },
+      { url: FILE_URL },
       { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
     );
     assert.false(result.ok);
@@ -152,16 +195,15 @@ module('executeReadRealmFile', () => {
       (result as { ok: false; error: string }).error.includes('unavailable'),
       'error explains the feature is off',
     );
-    assert.strictEqual(calls.length, 0, 'never fetched without a token');
   });
 
   test('reports no-access when the user lacks read on the realm', async () => {
     let sessions = stubSessions({
       throws: new DelegatedUserRealmSessionError('forbidden', 'nope', 403),
     });
-    let { fetch } = recordingFetch(() => new Response('', { status: 200 }));
+    let { fetch } = recordingFetch(() => gated(403));
     let result = await executeReadRealmFile(
-      { realm: REALM, url: FILE_URL },
+      { url: FILE_URL },
       { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
     );
     assert.false(result.ok);
@@ -176,18 +218,22 @@ module('executeReadRealmFile', () => {
     let n = 0;
     let { fetch, calls } = recordingFetch(() => {
       n += 1;
-      return n === 1
-        ? new Response('stale', { status: 401 })
-        : new Response('# Fresh', { status: 200 });
+      // 1: unauthenticated probe → challenge (names the realm)
+      // 2: authed with a stale cached token → still rejected
+      // 3: authed with a freshly minted token → served
+      if (n === 1) {
+        return gated();
+      }
+      return n === 2 ? gated() : new Response('# Fresh', { status: 200 });
     });
 
     let result = await executeReadRealmFile(
-      { realm: REALM, url: FILE_URL },
+      { url: FILE_URL },
       { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
     );
 
     assert.true(result.ok, 'succeeds on the retry');
-    assert.strictEqual(calls.length, 2, 'fetched twice');
+    assert.strictEqual(calls.length, 3, 'probe, stale authed, fresh authed');
     assert.deepEqual(
       sessions.invalidated,
       [{ onBehalfOf: ON_BEHALF_OF, realm: REALM }],
@@ -213,10 +259,7 @@ module('classifyToolCalls', () => {
   test('splits readRealmFile (bot) from everything else (host)', () => {
     let { botToolCalls, hostToolCalls } = classifyToolCalls(
       assistantMessage([
-        fnCall('c1', READ_REALM_FILE_TOOL_NAME, {
-          realm: REALM,
-          url: FILE_URL,
-        }),
+        fnCall('c1', READ_REALM_FILE_TOOL_NAME, { url: FILE_URL }),
         fnCall('c2', 'SomeHostCommand'),
       ]),
     );

--- a/packages/ai-bot/tests/read-realm-file-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-test.ts
@@ -164,6 +164,32 @@ module('executeReadRealmFile', () => {
     assert.strictEqual(sessions.calls.length, 0, 'no token minted');
   });
 
+  test('refuses to mint when the claimed realm does not contain the file', async () => {
+    let sessions = stubSessions({ token: 'tok' });
+    // A host answering for FILE_URL claims a realm on a different origin; the
+    // delegated token for that realm must not be minted or sent back to it.
+    let { fetch, calls } = recordingFetch(
+      () =>
+        new Response('unauthorized', {
+          status: 401,
+          headers: { 'x-boxel-realm-url': 'https://other.example/user/mary/' },
+        }),
+    );
+    let result = await executeReadRealmFile(
+      { url: FILE_URL },
+      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
+    );
+    assert.false(result.ok, 'result not ok');
+    assert.true(
+      (result as { ok: false; error: string }).error.includes(
+        'does not belong to the realm',
+      ),
+      'error explains the mismatch',
+    );
+    assert.strictEqual(sessions.calls.length, 0, 'no token minted');
+    assert.strictEqual(calls.length, 1, 'no authenticated retry');
+  });
+
   test('returns an error result when the file is missing (404)', async () => {
     let sessions = stubSessions({ token: 'tok' });
     let { fetch } = recordingFetch(

--- a/packages/base/matrix-event.gts
+++ b/packages/base/matrix-event.gts
@@ -4,7 +4,7 @@ import type {
   ToolChoice,
 } from '@cardstack/runtime-common/helpers/ai';
 import type { CommandRequest } from '@cardstack/runtime-common/commands';
-import {
+import type {
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
   APP_BOXEL_CODE_PATCH_RESULT_MSGTYPE,
@@ -26,10 +26,12 @@ import {
   APP_BOXEL_STOP_GENERATING_EVENT_TYPE,
   CodeRef,
   APP_BOXEL_LLM_MODE,
-  type LLMMode,
-  type RealmResourceIdentifier,
 } from '@cardstack/runtime-common';
-import { type SerializedFile } from './file-api';
+import type {
+  LLMMode,
+  RealmResourceIdentifier,
+} from '@cardstack/runtime-common';
+import type { SerializedFile } from './file-api';
 
 interface BaseMatrixEvent {
   sender: string;
@@ -339,7 +341,10 @@ export interface CommandResultWithOutputContent {
     event_id: string;
   };
   commandRequestId: string;
-  failureReason?: string; // only present if status is 'failed' or 'invalid'
+  // Present if status is 'failed' or 'invalid', or on an 'applied' result
+  // where part of the work failed (e.g. a multi-file read that fetched only
+  // some of its files).
+  failureReason?: string;
   data: {
     // we retrieve the content on the server side by downloading the file
     card?: SerializedFile & { content?: string; error?: string };

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1106,6 +1106,14 @@ async function toResultMessages(
         } else {
           content = `Tool call ${status == 'applied' ? 'executed' : status}.\n`;
         }
+        // Surface the failure reason to the model — without it a failed (or
+        // partially fulfilled, e.g. a multi-file read where one file 404ed)
+        // tool call reads as a bare status with nothing to act on.
+        // Check-correctness results fold their reason in above.
+        let failureReason = commandResult.content.failureReason;
+        if (!isCheckCorrectnessRequest && failureReason) {
+          content = `${content}${failureReason}\n`;
+        }
         let attachmentResult = await buildAttachmentsMessagePart(
           client,
           commandResult,

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -2353,6 +2353,68 @@ export const attachedCardsToMessage = (
   return a + b;
 };
 
+// Skill bodies (a SKILL.md, the skills index) are authored with links relative
+// to the file's own location, so the same source resolves on the coding
+// harness's filesystem. The ai-bot has no filesystem: it reads a referenced
+// file over HTTP via `readRealmFile`, and can't resolve a relative path itself
+// — it has repeatedly flattened `skills/skills/…` to `skills/…` (404) or
+// guessed the wrong realm. Resolving every relative markdown link against the
+// skill's own URL up front hands the model a copy-ready absolute URL, so one
+// relative-authored document works for both agents.
+export function absolutizeSkillLinks(
+  markdown: string,
+  baseUrl: string | undefined,
+): string {
+  if (!baseUrl) {
+    return markdown;
+  }
+  let base: URL;
+  try {
+    base = new URL(baseUrl);
+  } catch {
+    // A non-absolute id (e.g. an unresolved `@cardstack/skills/…` ref) can't
+    // anchor resolution; leave the body untouched.
+    return markdown;
+  }
+  return markdown.replace(
+    /\[([^\]]*)\]\(([^)]+)\)/g,
+    (whole, text, destination) => {
+      let trimmed = destination.trim();
+      let spaceIndex = trimmed.search(/\s/);
+      let target = spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex);
+      let title = spaceIndex === -1 ? '' : trimmed.slice(spaceIndex);
+      let bare = target.replace(/^<|>$/g, '');
+      if (!isRelativeLink(bare)) {
+        return whole;
+      }
+      let resolved: string;
+      try {
+        resolved = new URL(bare, base).href;
+      } catch {
+        return whole;
+      }
+      return `[${text}](${resolved}${title})`;
+    },
+  );
+}
+
+// A markdown link destination we resolve — document-relative paths only.
+// Absolute URLs, protocol- and root-relative refs, bare fragments, and
+// non-navigational schemes (mailto:, etc.) are left as authored.
+function isRelativeLink(target: string): boolean {
+  if (!target) {
+    return false;
+  }
+  if (/^[a-z][a-z0-9+.-]*:/i.test(target)) {
+    return false; // has a scheme
+  }
+  return !(
+    target.startsWith('//') ||
+    target.startsWith('/') ||
+    target.startsWith('#')
+  );
+}
+
 export const skillCardsToMessages = (cards: EnabledSkill[]) => {
   return cards.map((card) => {
     let headerParts = [`id: ${card.id}`];
@@ -2364,7 +2426,7 @@ export const skillCardsToMessages = (cards: EnabledSkill[]) => {
     let instructions =
       card.attributes?.instructions?.trim() ?? 'No instructions provided.';
 
-    return `${header}\n${instructions}`;
+    return `${header}\n${absolutizeSkillLinks(instructions, card.id)}`;
   });
 };
 

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -2355,12 +2355,12 @@ export const attachedCardsToMessage = (
 
 // Skill bodies (a SKILL.md, the skills index) are authored with links relative
 // to the file's own location, so the same source resolves on the coding
-// harness's filesystem. The ai-bot has no filesystem: it reads a referenced
-// file over HTTP via `readRealmFile`, and can't resolve a relative path itself
-// — it has repeatedly flattened `skills/skills/…` to `skills/…` (404) or
-// guessed the wrong realm. Resolving every relative markdown link against the
-// skill's own URL up front hands the model a copy-ready absolute URL, so one
-// relative-authored document works for both agents.
+// harness's filesystem. The ai-bot has no filesystem: it reads referenced
+// files over HTTP via `readRealmFile`, which needs a full URL — a relative
+// path gives the model nothing reliable to resolve it against. Resolving
+// every relative markdown link against the skill's own URL up front hands the
+// model a copy-ready absolute URL, so one relative-authored document works
+// for both agents.
 export function absolutizeSkillLinks(
   markdown: string,
   baseUrl: string | undefined,


### PR DESCRIPTION
## Problem

When the ai-bot is pointed at a markdown skill (a `SKILL.md`, or the skills `index.md` catalog), it repeatedly fails to open the files that skill references. The skills index and each `SKILL.md` are authored with links **relative to the file's own location**, so the same source resolves on the coding harness's filesystem. The ai-bot has no filesystem — it reads referenced files over HTTP via `readRealmFile` — and it can't resolve a relative path itself:

- It flattened realm-relative paths (e.g. dropping a repeated path segment) → HTTP 404.
- It supplied the wrong `realm` argument (the room's realm rather than the file's) → "not inside realm".

The net effect: the bot burns its turns on failed reads and never gets to the work the skill was describing.

## Changes

**Resolve relative skill links at prompt-assembly time.** `skillCardsToMessages` now runs each skill body through `absolutizeSkillLinks`, resolving every relative markdown link against the skill's own URL. The model receives copy-ready absolute URLs instead of relative paths it has to (mis)interpret. Only the in-memory prompt is rewritten — the stored content stays relative, so the coding harness and realm cloning are unaffected.

**Discover the realm instead of asking the model for it.** `readRealmFile` drops its `realm` argument. It fetches the URL, reads the owning realm from the `x-boxel-realm-url` response header (returned even on an auth challenge), and mints a delegated token only when the file is actually gated. Public reads (the skills realm) now succeed with no token at all, and the "not inside realm" failure mode is gone — there's no realm arg left to get wrong.

## Tests

- Rewrote `read-realm-file-test.ts` around the url-only, realm-from-header flow (public read needs no token; gated read discovers the realm then mints; retries once on a stale token).
- Added `absolutizeSkillLinks` unit tests covering the double-segment realm-relative case, title preservation, and pass-through of absolute/anchor/scheme links.
- All affected ai-bot tests pass; type-check and lint clean. (The 2 unrelated "AI Bot Locking" tests need a DB and fail on `main` too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)