### PR TITLE
Show final streamed content in ai-bot debug:eventlist dumps

### DIFF
--- a/packages/ai-bot/README.md
+++ b/packages/ai-bot/README.md
@@ -60,6 +60,12 @@ It will be able to see any cards shared in the chat and can respond using GPT4 i
 
 ### Debugging
 
+Send `debug:help` in a room the bot has joined to list the available debug commands.
+
+`debug:eventlist` attaches a JSON dump of the room's events. Streamed messages show their final content: `m.replace` edits are applied and continuation-split messages are joined, so each message body matches what the model sees when the prompt is constructed. Use `debug:eventlist:raw` for the unaggregated timeline, where streamed messages appear as their original placeholder events with edits nested under `unsigned["m.relations"]["m.replace"]`.
+
+`debug:prompt` attaches the prompt that would be sent to the AI for the last user message. Append a number, e.g. `debug:prompt:3`, to drop that many trailing events first.
+
 You can deliberately trigger a specific patch by sending a message that starts `debug:patch:` and has the JSON patch you want returned. For example:
 
 ```

--- a/packages/ai-bot/lib/debug.ts
+++ b/packages/ai-bot/lib/debug.ts
@@ -102,7 +102,12 @@ To patch a card:\n
     );
   } else if (eventBody.startsWith('debug:eventlist')) {
     try {
-      let aggregatedEventList = await constructHistory(eventList, client);
+      // constructHistory mutates the events it is given; aggregate a clone so
+      // the fallback below still dumps the untouched raw timeline
+      let aggregatedEventList = await constructHistory(
+        structuredClone(eventList),
+        client,
+      );
       await sendEventListAsDebugMessage(
         client,
         roomId,

--- a/packages/ai-bot/lib/debug.ts
+++ b/packages/ai-bot/lib/debug.ts
@@ -4,6 +4,7 @@ import type OpenAI from 'openai';
 import { errorReporter } from './sentry.ts';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/matrix-event';
 import {
+  constructHistory,
   getPromptParts,
   isRecognisedDebugCommand,
   sendErrorEvent,
@@ -31,8 +32,10 @@ To get the prompt sent to the AI with the last user message:\n
   debug:prompt\n
 To get the prompt but with some events removed:\n
   debug:prompt:(number of events to remove)\n
-To get the raw event list:\n
+To get the event list with streaming edits applied (what the model sees):\n
   debug:eventlist\n
+To get the raw event list, without streaming edits applied:\n
+  debug:eventlist:raw\n
 To set the room name:\n
   debug:title:set:\n
 To throw an error:\n
@@ -90,8 +93,37 @@ To patch a card:\n
     }
   }
 
-  if (eventBody.startsWith('debug:eventlist')) {
-    await sendEventListAsDebugMessage(client, roomId, eventList);
+  if (eventBody.startsWith('debug:eventlist:raw')) {
+    await sendEventListAsDebugMessage(
+      client,
+      roomId,
+      eventList,
+      'This is the raw timeline: streamed messages show their original placeholder content, not their final edits.',
+    );
+  } else if (eventBody.startsWith('debug:eventlist')) {
+    try {
+      let aggregatedEventList = await constructHistory(eventList, client);
+      await sendEventListAsDebugMessage(
+        client,
+        roomId,
+        aggregatedEventList,
+        'Each message shows its final content, with streaming edits applied and continuations joined. Use debug:eventlist:raw for the unaggregated timeline.',
+      );
+    } catch (error) {
+      errorReporter.captureException(error, {
+        extra: {
+          roomId: roomId,
+          userId: userId,
+          eventBody: eventBody,
+        },
+      });
+      await sendEventListAsDebugMessage(
+        client,
+        roomId,
+        eventList,
+        `Failed to apply streaming edits (${error}); this is the raw timeline instead.`,
+      );
+    }
   }
   // Explicitly set the room name
   if (eventBody.startsWith('debug:title:set:')) {

--- a/packages/ai-bot/tests/debug-test.ts
+++ b/packages/ai-bot/tests/debug-test.ts
@@ -12,7 +12,7 @@ module('handleDebugCommands - debug:eventlist', (hooks) => {
   hooks.beforeEach(() => {
     fakeMatrixClient = new FakeMatrixClient();
     uploadedContents = [];
-    fakeMatrixClient.uploadContent = async (content: any) => {
+    fakeMatrixClient.uploadContent = async (content: string) => {
       uploadedContents.push(content);
       return { content_uri: 'mxc://example.com/debug-dump' };
     };
@@ -102,6 +102,26 @@ module('handleDebugCommands - debug:eventlist', (hooks) => {
     assert.true(
       event.content.isStreamingFinished,
       'isStreamingFinished reflects the final edit',
+    );
+  });
+
+  test('debug:eventlist leaves the input event list unmutated', async (assert) => {
+    let input = [streamedBotMessage()];
+    let pristine = structuredClone(input);
+
+    await handleDebugCommands(
+      {} as any,
+      'debug:eventlist',
+      fakeMatrixClient,
+      'room1',
+      '@aibot:localhost',
+      input,
+    );
+
+    assert.deepEqual(
+      input,
+      pristine,
+      'aggregation operates on a clone, so a fallback raw dump stays raw',
     );
   });
 

--- a/packages/ai-bot/tests/debug-test.ts
+++ b/packages/ai-bot/tests/debug-test.ts
@@ -1,0 +1,124 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { APP_BOXEL_MESSAGE_MSGTYPE } from '@cardstack/runtime-common';
+import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/matrix-event';
+import { handleDebugCommands } from '../lib/debug.ts';
+import { FakeMatrixClient } from './helpers/fake-matrix-client.ts';
+
+module('handleDebugCommands - debug:eventlist', (hooks) => {
+  let fakeMatrixClient: FakeMatrixClient;
+  let uploadedContents: string[];
+
+  hooks.beforeEach(() => {
+    fakeMatrixClient = new FakeMatrixClient();
+    uploadedContents = [];
+    fakeMatrixClient.uploadContent = async (content: any) => {
+      uploadedContents.push(content);
+      return { content_uri: 'mxc://example.com/debug-dump' };
+    };
+  });
+
+  hooks.afterEach(() => {
+    fakeMatrixClient.resetSentEvents();
+  });
+
+  // A streamed bot message as returned by the /messages API: the original
+  // event holds the empty streaming placeholder, and the server aggregates
+  // the final edit under unsigned['m.relations']['m.replace'].
+  function streamedBotMessage(): DiscreteMatrixEvent {
+    return {
+      type: 'm.room.message',
+      event_id: 'streamed-event-1',
+      origin_server_ts: 1000,
+      room_id: 'room1',
+      sender: '@aibot:localhost',
+      content: {
+        msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+        format: 'org.matrix.custom.html',
+        body: '',
+        isStreamingFinished: false,
+      },
+      unsigned: {
+        age: 1000,
+        'm.relations': {
+          'm.replace': {
+            type: 'm.room.message',
+            event_id: 'streamed-event-1-final-edit',
+            origin_server_ts: 2000,
+            room_id: 'room1',
+            sender: '@aibot:localhost',
+            content: {
+              msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+              format: 'org.matrix.custom.html',
+              body: 'The complete streamed answer',
+              isStreamingFinished: true,
+              'm.relates_to': {
+                rel_type: 'm.replace',
+                event_id: 'streamed-event-1',
+              },
+            },
+            unsigned: {
+              age: 500,
+            },
+          },
+        },
+      },
+      status: null,
+    } as unknown as DiscreteMatrixEvent;
+  }
+
+  async function dumpedEventList(eventBody: string): Promise<any[]> {
+    await handleDebugCommands(
+      {} as any, // openai is only used by debug:title:create
+      eventBody,
+      fakeMatrixClient,
+      'room1',
+      '@aibot:localhost',
+      [streamedBotMessage()],
+    );
+    QUnit.assert.strictEqual(
+      uploadedContents.length,
+      1,
+      'one event list dump was uploaded',
+    );
+    return JSON.parse(uploadedContents[0]);
+  }
+
+  test('debug:eventlist dumps the final streamed content, not the placeholder', async (assert) => {
+    let events = await dumpedEventList('debug:eventlist');
+
+    assert.strictEqual(events.length, 1, 'dump contains the message event');
+    let [event] = events;
+    assert.strictEqual(
+      event.event_id,
+      'streamed-event-1',
+      'the original event id is kept',
+    );
+    assert.strictEqual(
+      event.content.body,
+      'The complete streamed answer',
+      'body is the final streamed content',
+    );
+    assert.true(
+      event.content.isStreamingFinished,
+      'isStreamingFinished reflects the final edit',
+    );
+  });
+
+  test('debug:eventlist:raw dumps the unaggregated timeline', async (assert) => {
+    let events = await dumpedEventList('debug:eventlist:raw');
+
+    assert.strictEqual(events.length, 1, 'dump contains the message event');
+    let [event] = events;
+    assert.strictEqual(event.content.body, '', 'body is the raw placeholder');
+    assert.false(
+      event.content.isStreamingFinished,
+      'isStreamingFinished is the raw value',
+    );
+    assert.strictEqual(
+      event.unsigned['m.relations']['m.replace'].content.body,
+      'The complete streamed answer',
+      'the final edit is still available under unsigned',
+    );
+  });
+});

--- a/packages/ai-bot/tests/index.ts
+++ b/packages/ai-bot/tests/index.ts
@@ -8,6 +8,7 @@ import './code-patch-correctness-test.ts';
 import './chat-titling-test.ts';
 import './responding-test.ts';
 import './matrix-util-test.ts';
+import './debug-test.ts';
 import './modality-test.ts';
 import './locking-test.ts';
 import './interrupt-test.ts';

--- a/packages/runtime-common/ai/matrix-utils.ts
+++ b/packages/runtime-common/ai/matrix-utils.ts
@@ -133,7 +133,7 @@ export async function sendEventListAsDebugMessage(
   await sendDebugMessage(
     client,
     roomId,
-    'Debug: attached the raw event list.\n\n' + customMessage,
+    'Debug: attached the event list.\n\n' + customMessage,
     {
       attachedFiles: [
         {


### PR DESCRIPTION
## What

`debug:eventlist` attaches a JSON dump of a room's events for debugging an AI session. The dump serialized the raw timeline, where every streamed bot message appears as its original placeholder (`body: ""`, `isStreamingFinished: false`, reasoning stuck at "Thinking...") with the real final content nested under `unsigned["m.relations"]["m.replace"]` — making the dump nearly useless for seeing what actually happened in a session.

## How

- `debug:eventlist` now runs the events through `constructHistory` — the same aggregation used for prompt construction — before dumping. Each message shows its final content with `m.replace` edits applied and continuation-split messages joined, in chronological order, matching what the model sees.
- `debug:eventlist:raw` dumps the unaggregated timeline for when the raw truth is needed.
- If aggregation fails (e.g. malformed `content.data` JSON), the error is reported and the command falls back to the raw dump with a note, rather than producing nothing.
- `debug:help` output and the ai-bot README document both variants.

## Testing

- New unit tests in `packages/ai-bot/tests/debug-test.ts`: an event whose final body lives only under `unsigned["m.relations"]["m.replace"]` serializes with that final body and `isStreamingFinished: true` via `debug:eventlist`, and as the raw placeholder via `debug:eventlist:raw`.
- Full ai-bot suite passes locally aside from the two Postgres-dependent locking tests, which require the test database and are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)