### PR TITLE
Strip a stray separator from code-patch replace content

### DIFF
--- a/packages/host/app/commands/apply-search-replace-block.ts
+++ b/packages/host/app/commands/apply-search-replace-block.ts
@@ -7,6 +7,7 @@ import {
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
+import { stripTrailingSeparatorMarker } from '../lib/search-replace-block-parsing';
 
 let standardErrorMessage =
   'Unable to process the code patch due to invalid code coming from AI';
@@ -114,10 +115,15 @@ export default class ApplySearchReplaceBlockCommand extends HostBaseCommand<
       /^[\n\r]*/,
       '',
     );
+    // A malformed block can carry a stray extra separator line right before the
+    // REPLACE marker; without this it would be written into the file verbatim.
+    const replacePatternWithoutStraySeparator = stripTrailingSeparatorMarker(
+      replacePatternWithoutLeadingNewline,
+    );
 
     return {
       searchPattern,
-      replacePattern: replacePatternWithoutLeadingNewline.replace(/\n$/, ''),
+      replacePattern: replacePatternWithoutStraySeparator.replace(/\n$/, ''),
     };
   }
 

--- a/packages/host/app/lib/search-replace-block-parsing.ts
+++ b/packages/host/app/lib/search-replace-block-parsing.ts
@@ -9,6 +9,18 @@ interface SearchReplaceResult {
   replaceContent: string | null;
 }
 
+// A well-formed block carries a single SEPARATOR_MARKER between its search and
+// replace halves. A model occasionally emits a stray extra separator right
+// before the REPLACE marker; left in, it lands in the replace content and gets
+// written into the file as a line of box-drawing characters. Drop any trailing
+// separator (with surrounding whitespace) so the slip self-heals into the
+// intended content. The marker is distinctive enough that real code/JSON never
+// legitimately ends with it.
+export function stripTrailingSeparatorMarker(content: string): string {
+  let escaped = SEPARATOR_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return content.replace(new RegExp(`(?:\\s*${escaped})+\\s*$`), '');
+}
+
 /**
  * Parses a string containing search and replace content in a specific format.
  * It tries to detect the search and replace content even if the markers are missing or incomplete.
@@ -78,7 +90,7 @@ export function parseSearchReplace(input: string): SearchReplaceResult {
         content = content.substring(1);
       }
 
-      content = content.trimEnd();
+      content = stripTrailingSeparatorMarker(content).trimEnd();
 
       result.replaceContent = content;
     } else {

--- a/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
+++ b/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
@@ -776,4 +776,34 @@ ${REPLACE_MARKER}`;
       );
     }
   });
+
+  test('does not write a stray extra separator into the file', async function (assert) {
+    // Regression: a model emitted a duplicated separator right before the
+    // REPLACE marker, which was applied verbatim as a trailing line of
+    // box-drawing characters in the resulting file.
+    let commandService = getService('command-service');
+    let applyCommand = new ApplySearchReplaceBlockCommand(
+      commandService.commandContext,
+    );
+
+    const fileContent = `{ "old": true }`;
+    const codeBlock = `${SEARCH_MARKER}
+{ "old": true }
+${SEPARATOR_MARKER}
+{ "new": true }
+${SEPARATOR_MARKER}
+${REPLACE_MARKER}`;
+
+    let result = await applyCommand.execute({ fileContent, codeBlock });
+
+    assert.strictEqual(
+      result.resultContent,
+      `{ "new": true }`,
+      'the applied file has no trailing separator artifact',
+    );
+    assert.notOk(
+      result.resultContent.includes(SEPARATOR_MARKER),
+      'no separator marker leaks into the file',
+    );
+  });
 });

--- a/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
+++ b/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
@@ -778,9 +778,9 @@ ${REPLACE_MARKER}`;
   });
 
   test('does not write a stray extra separator into the file', async function (assert) {
-    // Regression: a model emitted a duplicated separator right before the
-    // REPLACE marker, which was applied verbatim as a trailing line of
-    // box-drawing characters in the resulting file.
+    // Models sometimes duplicate the separator right before the REPLACE
+    // marker; applying the block must strip it rather than write it into the
+    // file as a trailing line of box-drawing characters.
     let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,

--- a/packages/host/tests/unit/code-patching-test.ts
+++ b/packages/host/tests/unit/code-patching-test.ts
@@ -148,9 +148,9 @@ ${REPLACE_MARKER}`;
     });
 
     test('strips a stray extra separator the model emits before the REPLACE marker', async function (assert) {
-      // Regression: a duplicated separator right before REPLACE_MARKER used to
-      // land in replaceContent and get written into the file as a line of
-      // box-drawing characters.
+      // Models sometimes duplicate the separator right before REPLACE_MARKER;
+      // parsing must drop it rather than include it in replaceContent, where
+      // it would reach the file as a line of box-drawing characters.
       let block = `game-1.json
 ${SEARCH_MARKER}
 { "old": true }

--- a/packages/host/tests/unit/code-patching-test.ts
+++ b/packages/host/tests/unit/code-patching-test.ts
@@ -146,5 +146,25 @@ ${REPLACE_MARKER}`;
           <div class='rsvp-section'>`,
       );
     });
+
+    test('strips a stray extra separator the model emits before the REPLACE marker', async function (assert) {
+      // Regression: a duplicated separator right before REPLACE_MARKER used to
+      // land in replaceContent and get written into the file as a line of
+      // box-drawing characters.
+      let block = `game-1.json
+${SEARCH_MARKER}
+{ "old": true }
+${SEPARATOR_MARKER}
+{ "new": true }
+${SEPARATOR_MARKER}
+${REPLACE_MARKER}`;
+      let result = parseSearchReplace(block);
+      assert.strictEqual(result.searchContent, `{ "old": true }`);
+      assert.strictEqual(
+        result.replaceContent,
+        `{ "new": true }`,
+        'the stray separator is not part of the replacement',
+      );
+    });
   },
 );


### PR DESCRIPTION
## Problem

A search/replace code patch is delimited by box-drawing markers:

```
╔═══ SEARCH ════╗
<search>
╠═══════════════╣     ← separator
<replace>
╚═══ REPLACE ═══╝
```

When the model emits a **duplicate separator** line right before the REPLACE marker, both parse paths take everything between the *first* separator and the REPLACE marker as the replacement. The stray separator rides along and gets written into the file as a trailing line of box-drawing characters:

```json
{
  "data": { ... }
}
╠═══════════════╣          ← ends up in the saved file
```

This was observed on a real card-instance write: a follow-up edit to a `.json` instance produced a valid file with a trailing `╠═══════════════╣` line.

## Fix

Add `stripTrailingSeparatorMarker`, which removes any trailing separator marker (with surrounding whitespace) from the replace content, and apply it in both parse paths:

- `parseSearchReplace` (`packages/host/app/lib/search-replace-block-parsing.ts`)
- `parseCodeBlock` in `ApplySearchReplaceBlockCommand` (`packages/host/app/commands/apply-search-replace-block.ts`) — the actual apply path

A malformed block now self-heals into the intended content instead of corrupting the file. A separator that appears elsewhere in the content (not trailing) is left untouched.

## Tests

- Unit: `parseSearchReplace` strips a stray trailing separator from `replaceContent`.
- Integration: `ApplySearchReplaceBlockCommand` produces a clean file (no separator marker) for a full-file replace whose block carries a duplicate separator.

Lint + type-check clean. (Host test suite runs in CI; the parser logic was also validated directly against the real marker constants.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)