### PR TITLE
Fix local use of `INDEX_CACHE` on macOS

### DIFF
--- a/scripts/import-cached-index.sh
+++ b/scripts/import-cached-index.sh
@@ -70,11 +70,17 @@ if [ -n "${BOXEL_ENVIRONMENT:-}" ]; then
   # Match both http and https canonicals — local dev now stores
   # https://localhost:4201/... in the index (CS-11114), but older
   # cached snapshots still have http://. Either prefix in the snapshot
-  # gets remapped to the env-mode Traefik hostname.
+  # gets remapped to the env-mode Traefik hostname. Use `sed -E` (POSIX
+  # ERE) so the optional-`s` quantifier works under BSD sed too — the
+  # basic-regex `\?` form is a GNU extension that macOS sed treats as a
+  # literal, silently skipping the remap. The destinations are https:
+  # the env-mode realm server and icons host register their realms and
+  # URLs under https://<service>.<slug>.localhost, so http-form rows
+  # would never match a served realm and the cache would be ignored.
   gunzip -c "$CACHE_FILE" \
-    | sed \
-      -e "s|https\\?://localhost:4201|http://realm-server.${SLUG}.localhost|g" \
-      -e "s|http://localhost:4206|http://icons.${SLUG}.localhost|g" \
+    | sed -E \
+      -e "s|https?://localhost:4201|https://realm-server.${SLUG}.localhost|g" \
+      -e "s|https?://localhost:4206|https://icons.${SLUG}.localhost|g" \
     | docker exec -i boxel-pg psql $PSQL_OPTS
 else
   gunzip -c "$CACHE_FILE" \


### PR DESCRIPTION
The `\?` isn’t interpreted properly by macOS built-in `sed`.

You can see it working here locally; on the left I had to wait for all the realms to index, on the right the cache worked so only one realm was indexed:

<img width="2516" height="2026" alt="s 2026-07-08 at 17 05 43@2x" src="https://github.com/user-attachments/assets/493b8c3a-395f-484d-b3ab-aa13450f760d" />
