### PR TITLE
ai-bot: read many realm files in one readRealmFile call

### DIFF
--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -3,7 +3,7 @@ import type { CommandRequest } from '@cardstack/runtime-common/commands';
 import { AI_BOT_EXECUTOR } from '@cardstack/runtime-common/commands';
 import {
   READ_REALM_FILE_TOOL_NAME,
-  fileLabelFromUrl,
+  readFilesLabel,
 } from '../read-realm-file.ts';
 import { thinkingMessage } from '../../constants.ts';
 import type ResponseState from '../response-state.ts';
@@ -46,18 +46,9 @@ function toCommandRequest(
   // arguments carry no description of their own.
   if (result.name === READ_REALM_FILE_TOOL_NAME) {
     result.executedBy = AI_BOT_EXECUTOR;
-    let urls: unknown = result.arguments?.urls;
-    let labels = (Array.isArray(urls) ? urls : [])
-      .map((url) => (typeof url === 'string' ? fileLabelFromUrl(url) : url))
-      .filter(Boolean);
     result.arguments = {
       ...(result.arguments ?? {}),
-      description:
-        labels.length === 0
-          ? 'Read files'
-          : labels.length === 1
-            ? `Read file: ${labels[0]}`
-            : `Read files: ${labels.join(', ')}`,
+      description: readFilesLabel(result.arguments?.urls),
     };
   }
   return result;

--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -42,14 +42,22 @@ function toCommandRequest(
   }
   // readRealmFile is a tool ai-bot fulfills itself: tag it so the host records
   // it in the timeline but never runs it, and give it a human label the
-  // timeline indicator can show ("Read file: <name>") since the raw arguments
-  // carry no description of their own.
+  // timeline indicator can show ("Read files: <names>") since the raw
+  // arguments carry no description of their own.
   if (result.name === READ_REALM_FILE_TOOL_NAME) {
     result.executedBy = AI_BOT_EXECUTOR;
-    let label = fileLabelFromUrl(result.arguments?.url);
+    let urls: unknown = result.arguments?.urls;
+    let labels = (Array.isArray(urls) ? urls : [])
+      .map((url) => (typeof url === 'string' ? fileLabelFromUrl(url) : url))
+      .filter(Boolean);
     result.arguments = {
       ...(result.arguments ?? {}),
-      description: label ? `Read file: ${label}` : 'Read file',
+      description:
+        labels.length === 0
+          ? 'Read files'
+          : labels.length === 1
+            ? `Read file: ${labels[0]}`
+            : `Read files: ${labels.join(', ')}`,
     };
   }
   return result;

--- a/packages/ai-bot/lib/read-realm-file-fulfillment.ts
+++ b/packages/ai-bot/lib/read-realm-file-fulfillment.ts
@@ -51,6 +51,9 @@ export interface ReadRealmFileFulfillmentDeps {
 
 export interface ReadRealmFileFulfillmentOutcome {
   commandRequestId: string;
+  // True only when every requested file was read and attached; a partial read
+  // reports ok: false with `error` naming the files that failed, even though
+  // the successful ones were still attached.
   ok: boolean;
   error?: string;
 }
@@ -87,12 +90,16 @@ async function uploadTextToMatrix(
 // Runs each readRealmFile tool call ai-bot owns and publishes its outcome as a
 // command-result event — the same shape a host command result takes, so the
 // existing prompt reconstruction pairs it with the request and feeds it back on
-// the next turn. On success the fetched file is uploaded to Matrix and attached
-// to the result event (data.attachedFiles); the model receives its content via
-// the same attachment-download path host-read files use. On failure the result
-// event carries the reason and resolves the request as invalid, so a failed
-// read reads as failed rather than as a clean read. Returns one outcome per
-// call; never throws (a publish failure is logged so the turn still settles).
+// the next turn. A call names any number of files; they are fetched
+// concurrently (as are the calls themselves) and every file that was read is
+// uploaded to Matrix and attached to the call's single result event
+// (data.attachedFiles); the model receives their content via the same
+// attachment-download path host-read files use. Files that could not be read
+// are named in the result's failureReason: the result stays `applied` while at
+// least one file came back (so the successful content isn't thrown away), and
+// resolves as invalid only when nothing did — either way a partial or failed
+// read never reads as a clean one. Returns one outcome per call; never throws
+// (a publish failure is logged so the turn still settles).
 export async function fulfillReadRealmFileCalls(
   botToolCalls: ChatCompletionMessageToolCall[],
   deps: ReadRealmFileFulfillmentDeps,
@@ -101,14 +108,52 @@ export async function fulfillReadRealmFileCalls(
     deps.uploadText ??
     ((content: string, contentType: string) =>
       uploadTextToMatrix(deps.client, content, contentType));
-  let outcomes: ReadRealmFileFulfillmentOutcome[] = [];
-  for (let call of botToolCalls) {
-    if (call.type !== 'function') {
-      continue;
-    }
-    outcomes.push(await fulfillOne(call, deps, upload));
+  return Promise.all(
+    botToolCalls
+      .filter(
+        (call): call is ChatCompletionMessageToolCall & { type: 'function' } =>
+          call.type === 'function',
+      )
+      .map((call) => fulfillOne(call, deps, upload)),
+  );
+}
+
+type FileRead =
+  | { url: string; attachment: Record<string, unknown> }
+  | { url: string; error: string };
+
+// Reads and uploads a single file of a call. An upload failure is folded into
+// the same shape as a read failure so the caller reports both alike.
+async function readAndUpload(
+  url: string,
+  deps: ReadRealmFileFulfillmentDeps,
+  upload: (content: string, contentType: string) => Promise<string>,
+): Promise<FileRead> {
+  let result = await executeReadRealmFile(url, {
+    onBehalfOf: deps.onBehalfOf,
+    delegatedUserRealmSessions: deps.delegatedUserRealmSessions,
+    fetch: deps.fetch,
+  });
+  if (!result.ok) {
+    return { url, error: result.error };
   }
-  return outcomes;
+  let fileUrl: string;
+  try {
+    fileUrl = await upload(result.content, READ_FILE_CONTENT_TYPE);
+  } catch (e: any) {
+    log.error(`readRealmFile: upload failed for ${url}: ${e?.message ?? e}`);
+    return { url, error: `could not store ${url} for reading` };
+  }
+  return {
+    url,
+    attachment: {
+      sourceUrl: url,
+      url: fileUrl,
+      name: fileLabelFromUrl(url) ?? url,
+      contentType: READ_FILE_CONTENT_TYPE,
+      contentSize: Buffer.byteLength(result.content),
+    },
+  };
 }
 
 async function fulfillOne(
@@ -122,32 +167,48 @@ async function fulfillOne(
   } catch {
     args = undefined;
   }
-  if (!args || !args.url) {
-    return await publishFailure(call.id, 'readRealmFile needs a url.', deps);
-  }
-
-  let result = await executeReadRealmFile(args, {
-    onBehalfOf: deps.onBehalfOf,
-    delegatedUserRealmSessions: deps.delegatedUserRealmSessions,
-    fetch: deps.fetch,
-  });
-  if (!result.ok) {
-    return await publishFailure(call.id, result.error, deps);
-  }
-
-  let label = fileLabelFromUrl(args.url) ?? args.url;
-  let fileUrl: string;
-  try {
-    fileUrl = await upload(result.content, READ_FILE_CONTENT_TYPE);
-  } catch (e: any) {
-    log.error(
-      `readRealmFile: upload failed for ${args.url}: ${e?.message ?? e}`,
-    );
+  // Dedupe within the call so a repeated URL doesn't attach (and inline into
+  // every later prompt) twice.
+  let urls = [
+    ...new Set(
+      (Array.isArray(args?.urls) ? args.urls : []).filter(
+        (url): url is string => typeof url === 'string' && url.length > 0,
+      ),
+    ),
+  ];
+  if (urls.length === 0) {
     return await publishFailure(
       call.id,
-      `could not store ${args.url} for reading`,
+      'readRealmFile needs a non-empty list of urls.',
       deps,
     );
+  }
+
+  let reads = await Promise.all(
+    urls.map((url) => readAndUpload(url, deps, upload)),
+  );
+  let attachedFiles = reads
+    .filter(
+      (read): read is Extract<FileRead, { attachment: object }> =>
+        'attachment' in read,
+    )
+    .map((read) => read.attachment);
+  let failureReason =
+    reads
+      .filter(
+        (read): read is Extract<FileRead, { error: string }> => 'error' in read,
+      )
+      // Most read errors already name the file; prefix the ones (e.g. realm
+      // access errors) that don't, so the model knows which URL to retry.
+      .map((read) =>
+        read.error.includes(read.url)
+          ? read.error
+          : `${read.url}: ${read.error}`,
+      )
+      .join('\n') || undefined;
+
+  if (attachedFiles.length === 0) {
+    return await publishFailure(call.id, failureReason!, deps);
   }
 
   await publish(deps, {
@@ -158,20 +219,17 @@ async function fulfillOne(
       key: 'applied',
       event_id: deps.requestEventId,
     },
+    ...(failureReason ? { failureReason } : {}),
     data: {
       context: { agentId: deps.agentId },
-      attachedFiles: [
-        {
-          sourceUrl: args.url,
-          url: fileUrl,
-          name: label,
-          contentType: READ_FILE_CONTENT_TYPE,
-          contentSize: Buffer.byteLength(result.content),
-        },
-      ],
+      attachedFiles,
     },
   });
-  return { commandRequestId: call.id, ok: true };
+  return {
+    commandRequestId: call.id,
+    ok: !failureReason,
+    ...(failureReason ? { error: failureReason } : {}),
+  };
 }
 
 async function publishFailure(

--- a/packages/ai-bot/lib/read-realm-file.ts
+++ b/packages/ai-bot/lib/read-realm-file.ts
@@ -12,41 +12,49 @@ let log = logger('ai-bot:read-realm-file');
 
 export const READ_REALM_FILE_TOOL_NAME = 'readRealmFile';
 
-// On-demand file reading. The model calls `readRealmFile` to pull a file's
-// contents only when it needs them — most often a skill's SKILL.md or a file it
-// references, but it works for any file in the realm. ai-bot executes it
-// in-process: it mints a delegated, user-scoped realm token and fetches the
-// file over HTTP, so the bot can only read what the requesting human can
-// already read, and the content is always live (no Matrix snapshots, no host
-// round-trip).
+// On-demand file reading. The model calls `readRealmFile` to pull files'
+// contents only when it needs them — most often a skill's SKILL.md or the
+// references it lists, but it works for any file in the realm. One call reads
+// any number of files: each model turn that requests reads costs a full
+// round-trip (fulfillment + a fresh generation), so the tool takes a list and
+// the description pushes the model to batch everything it already knows it
+// needs. ai-bot executes it in-process: it mints a delegated, user-scoped
+// realm token and fetches each file over HTTP, so the bot can only read what
+// the requesting human can already read, and the content is always live (no
+// Matrix snapshots, no host round-trip).
 export const readRealmFileTool: Tool = {
   type: 'function',
   function: {
     name: READ_REALM_FILE_TOOL_NAME,
     description:
-      "Read a file from a realm on demand — e.g. a skill's SKILL.md, or a " +
-      "file it references. Use this to get a skill's full instructions, or a " +
-      'reference it cites, when you only have it listed.',
+      "Read files from a realm on demand — e.g. a skill's SKILL.md, or the " +
+      'reference files it lists. Reads all the given URLs at once, so when ' +
+      'you already know several files you need (a skill’s reference ' +
+      'list usually tells you), request them all in a single call rather ' +
+      'than a few at a time — every extra round of reads delays your answer.',
     parameters: {
       type: 'object',
       properties: {
-        url: {
-          type: 'string',
+        urls: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string' },
           description:
-            'Full URL of the file to read, exactly as it appears in the ' +
-            "skill (a link there is already absolute — don't shorten or " +
-            'rewrite it). The realm it lives in is worked out for you.',
+            'Full URLs of the files to read, each exactly as it appears in ' +
+            "the skill (a link there is already absolute — don't shorten " +
+            'or rewrite it). The realm each file lives in is worked out ' +
+            'for you.',
         },
       },
-      required: ['url'],
+      required: ['urls'],
     },
   },
 };
 
 export interface ReadRealmFileArgs {
-  // Full URL of the file to read. The realm it belongs to is discovered from
-  // the realm server's response, so the caller supplies only the URL.
-  url: string;
+  // Full URLs of the files to read. The realm each belongs to is discovered
+  // from the realm server's response, so the caller supplies only URLs.
+  urls: string[];
 }
 
 // Realm servers echo the owning realm's root on every response — success or
@@ -59,16 +67,16 @@ export type ReadRealmFileResult =
   | { ok: true; url: string; content: string }
   | { ok: false; error: string };
 
-// Executes a readRealmFile tool call inside the bot process: GETs the file as
-// raw source, discovering the owning realm from the response so a delegated,
-// read-only token can be minted for `onBehalfOf` only when the realm actually
-// gates the file. A public file (e.g. anything in the skills realm) is returned
-// from the first unauthenticated fetch with no token at all. Never throws —
-// returns a result the caller hands back to the model as the tool result, so a
-// missing file or a permission failure becomes information the model can act on
-// rather than a crashed turn.
+// Reads one of a readRealmFile call's files inside the bot process: GETs the
+// file as raw source, discovering the owning realm from the response so a
+// delegated, read-only token can be minted for `onBehalfOf` only when the
+// realm actually gates the file. A public file (e.g. anything in the skills
+// realm) is returned from the first unauthenticated fetch with no token at
+// all. Never throws — returns a result the caller hands back to the model as
+// part of the tool result, so a missing file or a permission failure becomes
+// information the model can act on rather than a crashed turn.
 export async function executeReadRealmFile(
-  args: ReadRealmFileArgs,
+  url: string,
   {
     onBehalfOf,
     delegatedUserRealmSessions,
@@ -82,8 +90,6 @@ export async function executeReadRealmFile(
     fetch?: typeof globalThis.fetch;
   },
 ): Promise<ReadRealmFileResult> {
-  let url = args.url;
-
   // `redirect: 'manual'` keeps a stray redirect from being silently followed
   // (it surfaces as a non-2xx instead). No Authorization on the first try:
   // public files (the skills realm) come back 200, and a gated file comes back

--- a/packages/ai-bot/lib/read-realm-file.ts
+++ b/packages/ai-bot/lib/read-realm-file.ts
@@ -253,3 +253,28 @@ export function fileLabelFromUrl(url: string | undefined): string | undefined {
     return url;
   }
 }
+
+// A readRealmFile call can batch many urls; cap how many we name in the
+// timeline label so the description (and the event payload it rides in) stays
+// bounded no matter how many files the model requests at once.
+const READ_FILES_LABEL_MAX = 5;
+
+// Build the human-readable timeline label ("Read file: <name>" /
+// "Read files: <names>") from a readRealmFile call's `urls` argument. Non-string
+// entries are dropped so a malformed argument never leaks into the label.
+export function readFilesLabel(urls: unknown): string {
+  let labels = (Array.isArray(urls) ? urls : [])
+    .filter((url): url is string => typeof url === 'string')
+    .map((url) => fileLabelFromUrl(url))
+    .filter((label): label is string => Boolean(label));
+  if (labels.length === 0) {
+    return 'Read files';
+  }
+  if (labels.length === 1) {
+    return `Read file: ${labels[0]}`;
+  }
+  let shown = labels.slice(0, READ_FILES_LABEL_MAX);
+  let remaining = labels.length - shown.length;
+  let suffix = remaining > 0 ? `, and ${remaining} more` : '';
+  return `Read files: ${shown.join(', ')}${suffix}`;
+}

--- a/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
@@ -84,7 +84,7 @@ module('fulfillReadRealmFileCalls', () => {
       })) as unknown as typeof globalThis.fetch;
 
     let outcomes = await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c1', { url: FILE_URL })],
+      [readRealmFileCall('c1', { urls: [FILE_URL] })],
       baseDeps(client, {
         fetch,
         // Inject the uploader so this case doesn't touch the dedup cache.
@@ -118,6 +118,89 @@ module('fulfillReadRealmFileCalls', () => {
     assert.strictEqual(data.context.agentId, AGENT_ID);
   });
 
+  test('one call with many urls reads them all into a single result event', async () => {
+    let { client, sent } = fakeClient();
+    let otherUrl = 'https://localhost:4201/user/jane/notes.md';
+    let fetch = (async (input: any) => {
+      let url = typeof input === 'string' ? input : input.url;
+      return new Response(`content of ${url}`, { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    let outcomes = await fulfillReadRealmFileCalls(
+      // The same url twice: within-call dedup keeps it from attaching twice.
+      [readRealmFileCall('c1', { urls: [FILE_URL, otherUrl, FILE_URL] })],
+      baseDeps(client, {
+        fetch,
+        uploadText: async (content: string) =>
+          `https://localhost/media/${content.length}`,
+      }),
+    );
+
+    assert.deepEqual(outcomes, [{ commandRequestId: 'c1', ok: true }]);
+    assert.strictEqual(sent.length, 1, 'all files ride one result event');
+    let { content } = sent[0];
+    assert.strictEqual(
+      content.msgtype,
+      APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+    );
+    assert.strictEqual(content['m.relates_to'].key, 'applied');
+    assert.notOk(content.failureReason, 'a clean read carries no failure note');
+    let data = dataOf(sent[0]);
+    assert.deepEqual(
+      data.attachedFiles.map((f: any) => f.sourceUrl),
+      [FILE_URL, otherUrl],
+      'one attachment per distinct url',
+    );
+  });
+
+  test('a partial read attaches what succeeded and names what failed', async () => {
+    let { client, sent } = fakeClient();
+    let missingUrl = 'https://localhost:4201/user/jane/missing.md';
+    let fetch = (async (input: any) => {
+      let url = typeof input === 'string' ? input : input.url;
+      return url === missingUrl
+        ? new Response('nope', { status: 404 })
+        : new Response('# Trip Planner', { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    let outcomes = await fulfillReadRealmFileCalls(
+      [readRealmFileCall('c1', { urls: [FILE_URL, missingUrl] })],
+      baseDeps(client, {
+        fetch,
+        uploadText: async () => 'https://localhost/media/trip-planner',
+      }),
+    );
+
+    assert.false(outcomes[0].ok, 'a partial read is not reported as clean');
+    assert.true(
+      outcomes[0].error!.includes(missingUrl),
+      'the outcome names the failed file',
+    );
+    assert.strictEqual(sent.length, 1);
+    let { content } = sent[0];
+    assert.strictEqual(
+      content.msgtype,
+      APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+      'the successful file still comes back with output',
+    );
+    assert.strictEqual(
+      content['m.relates_to'].key,
+      'applied',
+      'partial results resolve the request so the turn can continue',
+    );
+    assert.true(
+      content.failureReason.includes(missingUrl) &&
+        content.failureReason.includes('404'),
+      'the failure note names the file and why it failed',
+    );
+    let data = dataOf(sent[0]);
+    assert.deepEqual(
+      data.attachedFiles.map((f: any) => f.sourceUrl),
+      [FILE_URL],
+      'only the readable file is attached',
+    );
+  });
+
   test('a failed read posts an invalid result carrying the reason, no attachment', async () => {
     let { client, sent } = fakeClient();
     let fetch = (async () =>
@@ -126,7 +209,7 @@ module('fulfillReadRealmFileCalls', () => {
       })) as unknown as typeof globalThis.fetch;
 
     let outcomes = await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c1', { url: FILE_URL })],
+      [readRealmFileCall('c1', { urls: [FILE_URL] })],
       baseDeps(client, { fetch }),
     );
 
@@ -172,6 +255,25 @@ module('fulfillReadRealmFileCalls', () => {
     assert.strictEqual(sent[0].content['m.relates_to'].key, 'invalid');
   });
 
+  test('an empty urls list fails without fetching', async () => {
+    let { client, sent } = fakeClient();
+    let fetched = false;
+    let fetch = (async () => {
+      fetched = true;
+      return new Response('x', { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    let outcomes = await fulfillReadRealmFileCalls(
+      [readRealmFileCall('c1', { urls: [] })],
+      baseDeps(client, { fetch }),
+    );
+
+    assert.false(outcomes[0].ok);
+    assert.false(fetched, 'never fetched for an empty list');
+    assert.strictEqual(sent[0].content['m.relates_to'].key, 'invalid');
+    assert.true(sent[0].content.failureReason.includes('urls'));
+  });
+
   test('identical content is uploaded once and re-referenced (dedup)', async () => {
     let { client, sent, uploads } = fakeClient();
     // Content unique to this test so the module-level hash cache is exercised
@@ -184,11 +286,11 @@ module('fulfillReadRealmFileCalls', () => {
       })) as unknown as typeof globalThis.fetch;
 
     await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c1', { url: FILE_URL })],
+      [readRealmFileCall('c1', { urls: [FILE_URL] })],
       baseDeps(client, { fetch }),
     );
     await fulfillReadRealmFileCalls(
-      [readRealmFileCall('c2', { url: FILE_URL })],
+      [readRealmFileCall('c2', { urls: [FILE_URL] })],
       baseDeps(client, { fetch }),
     );
 

--- a/packages/ai-bot/tests/read-realm-file-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-test.ts
@@ -8,6 +8,7 @@ import {
   readRealmFileTool,
   classifyToolCalls,
   fileLabelFromUrl,
+  readFilesLabel,
   READ_REALM_FILE_TOOL_NAME,
 } from '../lib/read-realm-file.ts';
 
@@ -340,5 +341,52 @@ module('fileLabelFromUrl', () => {
 
   test('undefined url → undefined label', () => {
     assert.strictEqual(fileLabelFromUrl(undefined), undefined);
+  });
+});
+
+module('readFilesLabel', () => {
+  test('no urls → generic label', () => {
+    assert.strictEqual(readFilesLabel(undefined), 'Read files');
+    assert.strictEqual(readFilesLabel([]), 'Read files');
+  });
+
+  test('one url → singular label', () => {
+    assert.strictEqual(
+      readFilesLabel([FILE_URL]),
+      'Read file: trip-planner/SKILL.md',
+    );
+  });
+
+  test('several urls → names joined', () => {
+    assert.strictEqual(
+      readFilesLabel([
+        'https://localhost:4201/user/jane/a.md',
+        'https://localhost:4201/user/jane/b.md',
+      ]),
+      'Read files: a.md, b.md',
+    );
+  });
+
+  test('caps the number of names and counts the rest', () => {
+    let urls = Array.from(
+      { length: 8 },
+      (_, i) => `https://localhost:4201/user/jane/f${i}.md`,
+    );
+    assert.strictEqual(
+      readFilesLabel(urls),
+      'Read files: f0.md, f1.md, f2.md, f3.md, f4.md, and 3 more',
+    );
+  });
+
+  test('drops non-string entries', () => {
+    assert.strictEqual(
+      readFilesLabel([
+        'https://localhost:4201/user/jane/a.md',
+        42,
+        null,
+        { url: 'x' },
+      ]),
+      'Read file: a.md',
+    );
   });
 });

--- a/packages/ai-bot/tests/read-realm-file-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-test.ts
@@ -76,9 +76,14 @@ module('readRealmFile tool definition', () => {
     assert.strictEqual(readRealmFileTool.type, 'function');
     let required = (readRealmFileTool.function.parameters as any)
       .required as string[];
-    assert.deepEqual(required, ['url'], 'only url is required');
+    assert.deepEqual(required, ['urls'], 'only urls is required');
     let properties = (readRealmFileTool.function.parameters as any)
-      .properties as Record<string, unknown>;
+      .properties as Record<string, any>;
+    assert.strictEqual(
+      properties['urls']?.type,
+      'array',
+      'many files read in one call — a per-turn trickle of single reads is the latency we are avoiding',
+    );
     assert.notOk(
       properties['realm'],
       'realm is discovered, not asked of the model',
@@ -93,10 +98,11 @@ module('executeReadRealmFile', () => {
       () => new Response('# Trip Planner\n\ninstructions', { status: 200 }),
     );
 
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
 
     assert.strictEqual(sessions.calls.length, 0, 'no token minted');
     assert.strictEqual(calls.length, 1, 'a single fetch');
@@ -121,10 +127,11 @@ module('executeReadRealmFile', () => {
         : new Response('# Gated\n\ninstructions', { status: 200 });
     });
 
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
 
     assert.deepEqual(
       sessions.calls,
@@ -152,10 +159,11 @@ module('executeReadRealmFile', () => {
     let { fetch } = recordingFetch(
       () => new Response('unauthorized', { status: 401 }),
     );
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
     assert.false(result.ok);
     assert.true(
       (result as { ok: false; error: string }).error.includes('which realm'),
@@ -175,10 +183,11 @@ module('executeReadRealmFile', () => {
           headers: { 'x-boxel-realm-url': 'https://other.example/user/mary/' },
         }),
     );
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
     assert.false(result.ok, 'result not ok');
     assert.true(
       (result as { ok: false; error: string }).error.includes(
@@ -195,10 +204,11 @@ module('executeReadRealmFile', () => {
     let { fetch } = recordingFetch(
       () => new Response('not found', { status: 404 }),
     );
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
     assert.false(result.ok, 'result not ok');
     assert.true(
       (result as { ok: false; error: string }).error.includes('404'),
@@ -212,10 +222,11 @@ module('executeReadRealmFile', () => {
       throws: new DelegatedUserRealmSessionError('disabled', 'off'),
     });
     let { fetch } = recordingFetch(() => gated());
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
     assert.false(result.ok);
     assert.true(
       (result as { ok: false; error: string }).error.includes('unavailable'),
@@ -228,10 +239,11 @@ module('executeReadRealmFile', () => {
       throws: new DelegatedUserRealmSessionError('forbidden', 'nope', 403),
     });
     let { fetch } = recordingFetch(() => gated(403));
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
     assert.false(result.ok);
     assert.true(
       (result as { ok: false; error: string }).error.includes('no read access'),
@@ -253,10 +265,11 @@ module('executeReadRealmFile', () => {
       return n === 2 ? gated() : new Response('# Fresh', { status: 200 });
     });
 
-    let result = await executeReadRealmFile(
-      { url: FILE_URL },
-      { onBehalfOf: ON_BEHALF_OF, delegatedUserRealmSessions: sessions, fetch },
-    );
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
 
     assert.true(result.ok, 'succeeds on the retry');
     assert.strictEqual(calls.length, 3, 'probe, stale authed, fresh authed');
@@ -285,7 +298,7 @@ module('classifyToolCalls', () => {
   test('splits readRealmFile (bot) from everything else (host)', () => {
     let { botToolCalls, hostToolCalls } = classifyToolCalls(
       assistantMessage([
-        fnCall('c1', READ_REALM_FILE_TOOL_NAME, { url: FILE_URL }),
+        fnCall('c1', READ_REALM_FILE_TOOL_NAME, { urls: [FILE_URL] }),
         fnCall('c2', 'SomeHostCommand'),
       ]),
     );

--- a/packages/base/matrix-event.gts
+++ b/packages/base/matrix-event.gts
@@ -4,7 +4,7 @@ import type {
   ToolChoice,
 } from '@cardstack/runtime-common/helpers/ai';
 import type { CommandRequest } from '@cardstack/runtime-common/commands';
-import {
+import type {
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
   APP_BOXEL_CODE_PATCH_RESULT_MSGTYPE,
@@ -26,10 +26,12 @@ import {
   APP_BOXEL_STOP_GENERATING_EVENT_TYPE,
   CodeRef,
   APP_BOXEL_LLM_MODE,
-  type LLMMode,
-  type RealmResourceIdentifier,
 } from '@cardstack/runtime-common';
-import { type SerializedFile } from './file-api';
+import type {
+  LLMMode,
+  RealmResourceIdentifier,
+} from '@cardstack/runtime-common';
+import type { SerializedFile } from './file-api';
 
 interface BaseMatrixEvent {
   sender: string;
@@ -339,7 +341,10 @@ export interface CommandResultWithOutputContent {
     event_id: string;
   };
   commandRequestId: string;
-  failureReason?: string; // only present if status is 'failed' or 'invalid'
+  // Present if status is 'failed' or 'invalid', or on an 'applied' result
+  // where part of the work failed (e.g. a multi-file read that fetched only
+  // some of its files).
+  failureReason?: string;
   data: {
     // we retrieve the content on the server side by downloading the file
     card?: SerializedFile & { content?: string; error?: string };

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1106,6 +1106,14 @@ async function toResultMessages(
         } else {
           content = `Tool call ${status == 'applied' ? 'executed' : status}.\n`;
         }
+        // Surface the failure reason to the model — without it a failed (or
+        // partially fulfilled, e.g. a multi-file read where one file 404ed)
+        // tool call reads as a bare status with nothing to act on.
+        // Check-correctness results fold their reason in above.
+        let failureReason = commandResult.content.failureReason;
+        if (!isCheckCorrectnessRequest && failureReason) {
+          content = `${content}${failureReason}\n`;
+        }
         let attachmentResult = await buildAttachmentsMessagePart(
           client,
           commandResult,


### PR DESCRIPTION
**Note:** stacked on #5427 

## What

`readRealmFile` accepts a `urls` array and reads every listed file in a single tool call, so a skill's reference set arrives in one round-trip instead of trickling in.

## Why

Each model turn that requests reads costs a full cycle — fulfillment posts result events, the bot re-triggers, and a fresh generation runs over a prompt that re-inlines everything read so far. With one url per call, models emit only a couple of parallel calls per turn, so reading a skill's references took ~5 such cycles (~40s in an observed boxel-skill session) before any code generation began. Making one call carry the whole batch removes the mechanical reason for the trickle while keeping the read-on-demand design: the model still chooses which files to read, so context grows only with files actually needed.

## How

- **Tool schema** (`read-realm-file.ts`): `urls: string[]` (min 1), with a description that tells the model to request every file it already knows it needs in one call. Realm discovery, delegated-token minting, and the retry-on-stale-token path are unchanged and apply per URL.
- **Fulfillment** (`read-realm-file-fulfillment.ts`): a call's urls are deduped and fetched/uploaded concurrently, and calls themselves run concurrently. All readable files attach to the call's single command-result event (`data.attachedFiles`), preserving the content-hash upload dedup. Files that fail are named in `failureReason`; the result stays `applied` when at least one file came back (so successful content isn't discarded) and resolves `invalid` only when none did.
- **Prompt reconstruction** (`runtime-common/ai/prompt.ts`): a command result's `failureReason` is appended to the tool message, so the model sees which files failed and why — a partial or failed read never reads as a clean one.
- **Timeline label** (`response-publisher.ts`): `Read file: core-concept.md` for one file, `Read files: a.md, b.md, …` for several.

## Testing

- `packages/ai-bot`: full suite passes (218 tests), including new coverage for multi-url batching with within-call dedup, partial failure (attach successes + name failures), and empty-url rejection.
- Type-check and eslint clean on `ai-bot` and `runtime-common`.
- End-to-end validation plan: export the debug event list from a boxel-skill card-building session and count assistant turns containing readRealmFile requests (target ≤3, from 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)