### PR TITLE
Write software-factory test-harness metadata atomically

### DIFF
--- a/packages/realm-test-harness/src/runtime-metadata.ts
+++ b/packages/realm-test-harness/src/runtime-metadata.ts
@@ -6,7 +6,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 export const sharedRuntimeDir = join(tmpdir(), 'software-factory-runtime');
 export const templateMetadataDir = join(
@@ -101,27 +101,36 @@ export function readPreparedTemplateMetadata(
   }
 }
 
-export function writePreparedTemplateMetadata(
-  payload: PreparedTemplateMetadata,
+// Write JSON to a sibling temp file and rename it into place. A reader
+// polling for the file with existsSync + readFileSync would otherwise be
+// able to observe the target mid-write — created but not yet fully
+// written — and parse a truncated prefix (`Unexpected end of JSON
+// input`). A rename within a directory is atomic on the same filesystem,
+// so the reader sees either no file or the complete payload, never a
+// partial one. The pid+timestamp suffix keeps concurrent writers from
+// colliding on the temp path.
+export function writeMetadataFileAtomically(
+  metadataFile: string,
+  payload: unknown,
 ): void {
-  mkdirSync(templateMetadataDir, { recursive: true });
-  let metadataFile = getTemplateMetadataFile(payload.templateDatabaseName);
+  mkdirSync(dirname(metadataFile), { recursive: true });
   let tempFile = join(
     dirname(metadataFile),
-    `.template.${process.pid}.${Date.now()}.tmp`,
+    `.${basename(metadataFile)}.${process.pid}.${Date.now()}.tmp`,
   );
   writeFileSync(tempFile, JSON.stringify(payload, null, 2));
   renameSync(tempFile, metadataFile);
 }
 
-export function writeSupportMetadata(payload: unknown): void {
-  let metadataFile = getSupportMetadataFile();
-  mkdirSync(dirname(metadataFile), { recursive: true });
-  let tempFile = join(
-    dirname(metadataFile),
-    `.support.${process.pid}.${Date.now()}.tmp`,
+export function writePreparedTemplateMetadata(
+  payload: PreparedTemplateMetadata,
+): void {
+  writeMetadataFileAtomically(
+    getTemplateMetadataFile(payload.templateDatabaseName),
+    payload,
   );
+}
 
-  writeFileSync(tempFile, JSON.stringify(payload, null, 2));
-  renameSync(tempFile, metadataFile);
+export function writeSupportMetadata(payload: unknown): void {
+  writeMetadataFileAtomically(getSupportMetadataFile(), payload);
 }

--- a/packages/software-factory/src/cli/cache-realm.ts
+++ b/packages/software-factory/src/cli/cache-realm.ts
@@ -1,13 +1,13 @@
 // This should be first
 import '../setup-logger.ts';
 
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { basename, dirname, resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 
 import {
   ensureCombinedFactoryRealmTemplate,
   isFactorySupportContext,
   readSupportContext,
+  writeMetadataFileAtomically,
 } from '@cardstack/realm-test-harness';
 import { logger } from '../logger.ts';
 
@@ -162,12 +162,9 @@ async function main(): Promise<void> {
   };
 
   if (process.env.TEST_HARNESS_METADATA_FILE) {
-    mkdirSync(dirname(process.env.TEST_HARNESS_METADATA_FILE), {
-      recursive: true,
-    });
-    writeFileSync(
+    writeMetadataFileAtomically(
       process.env.TEST_HARNESS_METADATA_FILE,
-      JSON.stringify(payload, null, 2),
+      payload,
     );
   }
 

--- a/packages/software-factory/src/cli/serve-realm.ts
+++ b/packages/software-factory/src/cli/serve-realm.ts
@@ -4,10 +4,10 @@ import '../setup-logger.ts';
 import {
   readSupportContext,
   startFactoryRealmServer,
+  writeMetadataFileAtomically,
   type RealmConfig,
 } from '@cardstack/realm-test-harness';
 import { logger } from '../logger.ts';
-import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import type { RealmPermissions } from '@cardstack/runtime-common';
@@ -185,9 +185,9 @@ async function main(): Promise<void> {
   };
 
   if (process.env.TEST_HARNESS_METADATA_FILE) {
-    writeFileSync(
+    writeMetadataFileAtomically(
       process.env.TEST_HARNESS_METADATA_FILE,
-      JSON.stringify(payload, null, 2),
+      payload,
     );
   }
 

--- a/packages/software-factory/tests/fixtures.ts
+++ b/packages/software-factory/tests/fixtures.ts
@@ -184,10 +184,24 @@ async function waitForMetadataFile<T>(
 ): Promise<T> {
   let startedAt = Date.now();
   let nextHeartbeat = startedAt + METADATA_FILE_HEARTBEAT_MS;
+  let lastParseError: string | undefined;
 
   while (Date.now() - startedAt < timeoutMs) {
     if (existsSync(metadataFile)) {
-      return JSON.parse(readFileSync(metadataFile, 'utf8')) as T;
+      let raw = readFileSync(metadataFile, 'utf8');
+      try {
+        return JSON.parse(raw) as T;
+      } catch (error) {
+        // The writer renames an atomically-written temp file into place,
+        // so a partial payload shouldn't be observable here — but
+        // tolerate a truncated read and keep polling rather than aborting
+        // the run on it. Record what we saw so a genuinely malformed
+        // payload surfaces in the timeout error below instead of hiding
+        // behind a bare timeout.
+        lastParseError = `failed to parse ${metadataFile} (${raw.length} chars): ${
+          error instanceof Error ? error.message : String(error)
+        }`;
+      }
     }
 
     if (child.exitCode !== null) {
@@ -211,7 +225,9 @@ async function waitForMetadataFile<T>(
 
   throw new Error(
     `timed out waiting for software-factory metadata file ${metadataFile} ` +
-      `after ${Math.round((Date.now() - startedAt) / 1000)}s\n${getLogs()}`,
+      `after ${Math.round((Date.now() - startedAt) / 1000)}s` +
+      (lastParseError ? `\nlast parse attempt: ${lastParseError}` : '') +
+      `\n${getLogs()}`,
   );
 }
 


### PR DESCRIPTION
## What

The software-factory Playwright harness starts a realm child process that writes a JSON metadata file, and the test process polls for that file and parses it (`waitForMetadataFile`). The writers truncated the destination and then filled it in place, so a poll that landed between the truncate and the final write read an empty or half-written file and threw `SyntaxError: Unexpected end of JSON input` — taking down whichever test happened to be setting up its realm at that moment. That is the intermittent failure in `run-lint-in-memory.spec.ts › no lintable files produces a vacuous pass` and its siblings.

## Change

- `serve-realm` and `cache-realm` write metadata through a shared `writeMetadataFileAtomically` helper in `realm-test-harness`: it writes a sibling temp file and renames it into place. A rename within a directory is atomic on the same filesystem, so a polling reader observes either no file or the complete payload — never a truncated prefix. The support-metadata and prepared-template writers, which already used this temp-then-rename pattern inline, now share the helper.
- The `fixtures.ts` reader also tolerates a transient partial read and keeps polling, and surfaces the last parse failure in its timeout error, so a genuinely malformed payload is diagnosable instead of hiding behind a bare timeout.

## Test plan

- `pnpm lint` passes in both `realm-test-harness` and `software-factory` (types, eslint, prettier, template-lint).
- A two-process reproduction — one process writing the metadata in a loop, another polling exactly like `waitForMetadataFile` — produces partial-parse reads with the non-atomic write and zero with the atomic helper, and leaves no `.tmp` files behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
