### PR TITLE
Per-file progress reporting for prerender_html jobs

### DIFF
--- a/packages/realm-server/tests/indexing-event-sink-test.ts
+++ b/packages/realm-server/tests/indexing-event-sink-test.ts
@@ -326,6 +326,93 @@ module(basename(import.meta.filename), function () {
       }
     });
 
+    test('a prerender_html job feeds the shared sink: side-by-side snapshot state plus its own job_progress row', async function (assert) {
+      let { adapter, executes } = makeRecordingAdapter();
+      let sink = new IndexingEventSink({ flushIntervalMs: 1000 });
+      sink.setAdapter(adapter);
+      try {
+        sink.handleEvent({
+          type: 'indexing-started',
+          realmURL: 'http://example.com/realm/',
+          jobId: 300,
+          jobType: 'incremental',
+          totalFiles: 4,
+          files: [],
+        });
+        sink.handleEvent({
+          type: 'indexing-started',
+          realmURL: 'http://example.com/realm/',
+          jobId: 301,
+          jobType: 'prerender_html',
+          totalFiles: 2,
+          files: [],
+        });
+
+        let { active } = sink.getSnapshot();
+        assert.deepEqual(
+          active.map((a) => [a.jobId, a.jobType]),
+          [
+            [300, 'incremental'],
+            [301, 'prerender_html'],
+          ],
+          'index and prerender jobs are tracked side by side, distinguished by jobType',
+        );
+
+        sink.handleEvent({
+          type: 'file-visited',
+          realmURL: 'http://example.com/realm/',
+          jobId: 301,
+          url: 'http://example.com/realm/1.json',
+          filesCompleted: 1,
+          totalFiles: 2,
+        });
+        sink.handleEvent({
+          type: 'file-visited',
+          realmURL: 'http://example.com/realm/',
+          jobId: 301,
+          url: 'http://example.com/realm/2.json',
+          filesCompleted: 2,
+          totalFiles: 2,
+        });
+        sink.handleEvent({
+          type: 'indexing-finished',
+          realmURL: 'http://example.com/realm/',
+          jobId: 301,
+          stats: {
+            instancesIndexed: 2,
+            filesIndexed: 0,
+            instanceErrors: 0,
+            fileErrors: 0,
+            totalIndexEntries: 2,
+          },
+        });
+        await sleep(10);
+
+        let prerenderWrites = executes.filter((e) => e.bind[0] === 301);
+        assert.deepEqual(
+          prerenderWrites[0].bind,
+          [301, 2, 0],
+          'started upserted the prerender job into its own row with the real total',
+        );
+        assert.deepEqual(
+          prerenderWrites[prerenderWrites.length - 1].bind,
+          [301, 2, 2],
+          'finished wrote the terminal counts',
+        );
+
+        let { active: activeAfter, history } = sink.getSnapshot();
+        assert.deepEqual(
+          activeAfter.map((a) => a.jobId),
+          [300],
+          'the indexing job is untouched by the prerender stream',
+        );
+        assert.strictEqual(history[0].jobType, 'prerender_html');
+        assert.strictEqual(history[0].filesCompleted, 2);
+      } finally {
+        sink.dispose();
+      }
+    });
+
     test('dispose() stops the flush timer; no writes after dispose', async function (assert) {
       let { adapter, executes } = makeRecordingAdapter();
       let sink = new IndexingEventSink({ flushIntervalMs: 20 });

--- a/packages/realm-server/tests/prerender-html-split-test.ts
+++ b/packages/realm-server/tests/prerender-html-split-test.ts
@@ -6,10 +6,14 @@ import {
   IndexWriter,
   VirtualNetwork,
   getQueueJobCoalesceHandler,
+  type IndexingProgressEvent,
+  type Prerenderer,
   type QueueCoalesceCandidate,
   type QueueCoalesceContext,
   type QueueJobSpec,
+  type Reader,
 } from '@cardstack/runtime-common';
+import { runPrerenderHtmlPass } from '@cardstack/runtime-common/index-runner/prerender-html-visit';
 // Registers the `prerender_html` coalesce handler at load time.
 import '@cardstack/runtime-common/tasks/prerender-html';
 import type { PrerenderHtmlArgs } from '@cardstack/runtime-common/tasks/prerender-html';
@@ -764,6 +768,155 @@ module(basename(import.meta.filename), function () {
         }),
         /requires an explicit generation/,
       );
+    });
+
+    module('progress reporting', function () {
+      function stubReader(contents: Map<string, string>): Reader {
+        return {
+          async readFile(url: URL) {
+            let content = contents.get(url.href);
+            if (content === undefined) {
+              return undefined;
+            }
+            return { content, lastModified: 0, path: url.href };
+          },
+          async readStream() {
+            return undefined;
+          },
+          async mtimes() {
+            return {};
+          },
+        };
+      }
+
+      function stubPrerenderer(
+        visit: (url: string) => void = () => {},
+      ): Prerenderer {
+        return {
+          async prerenderVisit(args) {
+            visit(args.url);
+            return {
+              fileRender: {
+                isolatedHTML: '<pre>rendered</pre>',
+                headHTML: null,
+                atomHTML: null,
+                embeddedHTML: null,
+                fittedHTML: null,
+                iconHTML: null,
+                markdown: null,
+              },
+            };
+          },
+          async prerenderModule() {
+            throw new Error('not used by the prerender-html pass');
+          },
+          async runCommand() {
+            throw new Error('not used by the prerender-html pass');
+          },
+        };
+      }
+
+      test('the pass reports started / file-visited / finished with the real totals', async function (assert) {
+        let events: IndexingProgressEvent[] = [];
+        let visited: string[] = [];
+        let info = jobInfo();
+        await runPrerenderHtmlPass({
+          realmURL: new URL(testRealm),
+          changes: [
+            { url: `${testRealm}a.txt`, operation: 'update' },
+            // Duplicate of the first URL — deduped out of the total.
+            { url: `${testRealm}a.txt`, operation: 'update' },
+            { url: `${testRealm}b.txt`, operation: 'update' },
+            // File missing on disk — never reaches the prerenderer, but
+            // still advances the counter.
+            { url: `${testRealm}missing.txt`, operation: 'update' },
+            // Deletion — never visited, still advances the counter.
+            { url: `${testRealm}gone.txt`, operation: 'delete' },
+          ],
+          generation: 1,
+          loaderEpoch: 'epoch-a',
+          indexWriter,
+          virtualNetwork,
+          reader: stubReader(
+            new Map([
+              [`${testRealm}a.txt`, 'alpha'],
+              [`${testRealm}b.txt`, 'beta'],
+            ]),
+          ),
+          prerenderer: stubPrerenderer((url) => visited.push(url)),
+          auth: 'test-auth',
+          jobInfo: info,
+          onProgress: (event) => events.push(event),
+        });
+
+        assert.deepEqual(
+          visited,
+          [`${testRealm}a.txt`, `${testRealm}b.txt`],
+          'only readable update URLs reach the prerenderer',
+        );
+
+        let [started, ...rest] = events;
+        let finished = rest.pop();
+        assert.deepEqual(
+          started,
+          {
+            type: 'indexing-started',
+            realmURL: testRealm,
+            jobId: info.jobId,
+            jobType: 'prerender_html',
+            totalFiles: 4,
+            files: [],
+          },
+          'started carries the deduped total and the queue job-type label',
+        );
+        assert.deepEqual(
+          rest.map((e) => [e.type, e.url, e.filesCompleted, e.totalFiles]),
+          [
+            ['file-visited', `${testRealm}a.txt`, 1, 4],
+            ['file-visited', `${testRealm}b.txt`, 2, 4],
+            ['file-visited', `${testRealm}missing.txt`, 3, 4],
+            ['file-visited', `${testRealm}gone.txt`, 4, 4],
+          ],
+          'every URL in the set advances the counter — rendered, missing, and deleted alike',
+        );
+        assert.strictEqual(finished?.type, 'indexing-finished');
+        assert.strictEqual(
+          finished?.stats?.filesIndexed,
+          2,
+          'finished carries the pass stats',
+        );
+      });
+
+      test('a visit failure still emits indexing-finished so consumers clear the job', async function (assert) {
+        let events: IndexingProgressEvent[] = [];
+        let prerenderer: Prerenderer = {
+          ...stubPrerenderer(),
+          async prerenderVisit() {
+            throw new Error('renderer died');
+          },
+        };
+        await assert.rejects(
+          runPrerenderHtmlPass({
+            realmURL: new URL(testRealm),
+            changes: [{ url: `${testRealm}a.txt`, operation: 'update' }],
+            generation: 1,
+            loaderEpoch: 'epoch-a',
+            indexWriter,
+            virtualNetwork,
+            reader: stubReader(new Map([[`${testRealm}a.txt`, 'alpha']])),
+            prerenderer,
+            auth: 'test-auth',
+            jobInfo: jobInfo(),
+            onProgress: (event) => events.push(event),
+          }),
+          /renderer died/,
+        );
+        assert.deepEqual(
+          events.map((e) => e.type),
+          ['indexing-started', 'indexing-finished'],
+          'the stream terminates even when the pass dies mid-visit',
+        );
+      });
     });
   });
 });

--- a/packages/runtime-common/index-runner/prerender-html-visit.ts
+++ b/packages/runtime-common/index-runner/prerender-html-visit.ts
@@ -96,20 +96,6 @@ export async function runPrerenderHtmlPass({
     `${jobTag} starting prerender-html pass for ${changes.length} changes`,
   );
 
-  let batch = await indexWriter.createBatch(realmURL, virtualNetwork, jobInfo, {
-    prerenderHtmlOnly: true,
-    generation,
-  });
-
-  onProgress?.({
-    type: 'indexing-started',
-    realmURL: realmURL.href,
-    jobId: jobInfo.jobId,
-    jobType: 'prerender-html',
-    totalFiles: 0,
-    files: [],
-  });
-
   // Delete-sticky dedupe, mirroring the incremental index loop: coalesced
   // publishes are already merged this way, but a single publish may still
   // carry duplicates.
@@ -121,12 +107,30 @@ export async function runPrerenderHtmlPass({
       operations.set(url, 'update');
     }
   }
+  let totalFiles = operations.size;
+
+  let batch = await indexWriter.createBatch(realmURL, virtualNetwork, jobInfo, {
+    prerenderHtmlOnly: true,
+    generation,
+  });
+
+  // Unlike the index runner — which announces a zero total and lets the
+  // first `file-visited` fill it in once invalidation discovery runs — this
+  // job's URL set arrives fully computed in its args, so the progress row
+  // carries the real denominator from the start. The jobType matches the
+  // queue's `jobs.job_type` value so both spell the job the same way.
+  onProgress?.({
+    type: 'indexing-started',
+    realmURL: realmURL.href,
+    jobId: jobInfo.jobId,
+    jobType: 'prerender_html',
+    totalFiles,
+    files: [],
+  });
 
   await batch.seedPrerenderedHtmlInvalidations(
     [...operations].map(([url, operation]) => ({ url, operation })),
   );
-
-  let totalFiles = operations.size;
   let filesCompleted = 0;
   let resumedRows = batch.resumedRows;
   let resumedSkipped = 0;


### PR DESCRIPTION
# Per-file progress for `prerender_html` jobs

`prerender_html` jobs stream the same live "N of M files" progress that indexing jobs do. The job's visit loop reports started / file-visited / finished events through the worker's progress callback; those ride the worker→manager IPC into the shared indexing event sink, which keeps in-memory per-job state and coalesces the per-file events into one `job_progress` UPDATE per tick. `job_progress` is keyed by job id, so each prerender job writes its own row — the row the Prerender HTML dashboard's live progress bars read.

Most of that pipeline is shared machinery and needed no changes. What this PR fixes is the emission side:

- **The `started` event announces the real file total.** The index runner has to announce a zero total and let the first `file-visited` fill it in, because its invalidation discovery hasn't run yet at kickoff. The prerender job has no such constraint — its URL set arrives fully computed in its args (the spawning index pass's invalidation set) — so it now announces the true denominator immediately instead of showing 0/0 until the first file lands.
- **The event's job-type label is `prerender_html`**, matching the queue's `jobs.job_type` value, so the sink's in-memory state, the `[indexing-progress]` log lines, and a `job_progress`→`jobs` join all spell the job the same way.

The sink itself is untouched — it was already job-type agnostic — and the indexing progress path is unchanged.

## Tests

- The pass's progress stream: `started` carries the deduped URL total and the `prerender_html` label; every URL in the set advances the counter — rendered, missing-on-disk, and deleted alike; `finished` carries the pass stats and still fires when a render dies mid-visit, so consumers always clear the job.
- The shared sink tracks an indexing job and a prerender job side by side, distinguished by job type, each with its own `job_progress` row; the prerender stream leaves the indexing job's state untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)