### PR TITLE
fix: add import attribute to release-prefixes.json import

### DIFF
--- a/packages/boxel-cli/scripts/compute-release.ts
+++ b/packages/boxel-cli/scripts/compute-release.ts
@@ -15,7 +15,7 @@ import { resolve } from 'path';
 
 import semver from 'semver';
 
-import bumpByPrefixJson from './release-prefixes.json';
+import bumpByPrefixJson from './release-prefixes.json' with { type: 'json' };
 import { lastStableTag } from './lib/tags.ts';
 
 export type BumpLevel = 'major' | 'minor' | 'patch' | 'none';


### PR DESCRIPTION
## Problem

The `boxel-cli publish` workflow has failed on every push to main since ~Jun 26 at its "Compute release" step:

```
TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]: Module ".../scripts/release-prefixes.json" needs an import attribute of "type: json"
```

CI runs Node 24, which rejects bare JSON module imports. Because the publish pipeline is broken, no new versions of `@cardstack/boxel-cli` have shipped to npm since Jun 19 — including the atomic-upload positional-mapping fix (#5413) that the boxel-skills "Sync to Workspace" action needs.

## Fix

Add the required import attribute to the one bare JSON import in `packages/boxel-cli/scripts/`:

```ts
import bumpByPrefixJson from './release-prefixes.json' with { type: 'json' };
```

## Verification

- Reproduced the crash locally on Node 24.17.0 (same version as CI) with the unfixed script; the fixed script runs cleanly and emits its release JSON.
- `pnpm exec vitest run tests/scripts/compute-release.test.ts` — 30/30 pass.
- eslint + prettier clean.

Note: `scripts/compute-release.ts` is not part of the npm or plugin bump surfaces, so this PR itself computes a no-op release; its purpose is to unbreak the workflow for subsequent merges and the promote path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)