### PR TITLE
Stop flaky atomic instance batch depending on unindexed modules

### DIFF
--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -554,8 +554,19 @@ module(basename(import.meta.filename), function () {
               },
             ],
           };
+          // This module batch is setup for the instance batch below, which
+          // adopts from Place/Country. /_atomic returns as soon as writes are
+          // durable — not indexed — and a subsequent /_atomic write does not
+          // wait for a prior write's indexing to settle. Without waitForIndex
+          // the modules can still be indexing when the instance batch's
+          // fileSerialization looks up the Place definition; that lookup then
+          // races the in-flight module index (generation bump discards the
+          // on-demand prerender result) and the batch fails with
+          // FilterRefersToNonexistentTypeError. waitForIndex makes the modules
+          // indexed before we move on, which is what a caller writing modules
+          // then dependent instances across separate batches must do.
           let response = await request
-            .post('/_atomic')
+            .post('/_atomic?waitForIndex=true')
             .set('Accept', SupportedMimeType.JSONAPI)
             .set(
               'Authorization',
@@ -637,7 +648,13 @@ module(basename(import.meta.filename), function () {
               `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`,
             )
             .send(JSON.stringify(instanceDoc));
-          assert.strictEqual(instanceResponse.status, 201);
+          assert.strictEqual(
+            instanceResponse.status,
+            201,
+            `expected 201, got ${instanceResponse.status}: ${JSON.stringify(
+              instanceResponse.body,
+            )}`,
+          );
           assert.strictEqual(instanceResponse.body['atomic:results'].length, 2);
         });
         test('can write new instance with new module', async function (assert) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2462,9 +2462,21 @@ export class Realm {
           // Log the underlying exception before returning 500 —
           // otherwise callers only see "Write Error" and the original
           // stack trace is lost, making atomic-batch failures
-          // effectively undebuggable.
+          // effectively undebuggable. Include e.cause explicitly: errors
+          // like FilterRefersToNonexistentTypeError carry the actionable
+          // detail (which module/definition was missing, or that a
+          // concurrent invalidation discarded the lookup) in their cause,
+          // not their message, so without this the real reason is swallowed.
+          let cause =
+            e?.cause instanceof Error
+              ? `${e.cause.message}\n${e.cause.stack ?? '(no stack)'}`
+              : e?.cause != null
+                ? String(e.cause)
+                : undefined;
           this.#log.error(
-            `Atomic write failed: ${e.message}\n${e.stack ?? '(no stack)'}`,
+            `Atomic write failed: ${e.message}${
+              cause ? `\ncause: ${cause}` : ''
+            }\n${e.stack ?? '(no stack)'}`,
           );
           return createResponse({
             body: JSON.stringify({


### PR DESCRIPTION
## What was flaky

`atomic-endpoints-test.ts > ... > writes > can write multiple instances that depend on each other` intermittently fails in CI with a 500 and `FilterRefersToNonexistentTypeError` for the `Place` type ([failing run](https://github.com/cardstack/boxel/actions/runs/29020085236/job/86128073638)).

## Root cause

The test does two separate `/_atomic` writes: first `place.gts` + `country.gts` (modules), then `Country`/`Place` instances that adopt from them.

`/_atomic` returns once writes are **durable, not indexed**, and `_batchWriteUnlocked` run with `waitForIndex: false` deliberately skips waiting for a prior write's pending index (so consecutive atomic writes stay responsive). So the second batch's `fileSerialization` can look up the `Place` definition while the first batch's modules are still indexing. That on-demand definition lookup then races the in-flight module index: the generation bump discards the prerender result and the lookup returns `undefined`, so the whole batch rolls back with a 500. Under CI load the module index lags into that window; locally it usually wins, so it only flakes in CI.

The existing module-before-instance ordering handles modules and instances **within a single batch**. This test splits them across two batches, so that path never applies.

## Fix

The first batch is setup for the second, so it posts with `?waitForIndex=true`. The modules are indexed before the instance batch runs, which removes the race. This is the documented way for a caller writing modules and then dependent instances across separate batches to stay correct.

## Diagnostics kept alongside the fix

So a recurrence is debuggable without a rerun:
- The atomic 500 handler now logs `e.cause`. `FilterRefersToNonexistentTypeError` carries the actionable detail (which module/definition was missing, or that a concurrent invalidation discarded the lookup) in its `cause`, not its message.
- The instance-batch assertion prints the response body on a non-201.
