### PR TITLE
feat: accept prefix RRIs in CLI

### DIFF
--- a/packages/boxel-cli/src/commands/file/delete.ts
+++ b/packages/boxel-cli/src/commands/file/delete.ts
@@ -9,6 +9,7 @@ import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_RED, DIM, RESET } from '../../lib/colors.ts';
 import { cliLog } from '../../lib/cli-log.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 
 export interface DeleteResult {
   ok: boolean;
@@ -50,6 +51,12 @@ export async function deleteFile(
       error: `Cannot delete protected file: ${path}`,
     };
   }
+
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, { profileManager: pm });
+  if (!resolvedRealm.ok) {
+    return { ok: false, error: resolvedRealm.error };
+  }
+  realmUrl = resolvedRealm.url;
 
   let url = new URL(path, ensureTrailingSlash(realmUrl)).href;
 

--- a/packages/boxel-cli/src/commands/file/lint.ts
+++ b/packages/boxel-cli/src/commands/file/lint.ts
@@ -9,6 +9,7 @@ import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_GREEN, FG_RED, FG_YELLOW, DIM, RESET } from '../../lib/colors.ts';
 import { cliLog } from '../../lib/cli-log.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 import { write } from './write.ts';
 
 export interface LintMessage {
@@ -56,6 +57,12 @@ export async function lint(
       error: NO_ACTIVE_PROFILE_ERROR,
     };
   }
+
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, { profileManager: pm });
+  if (!resolvedRealm.ok) {
+    return { ok: false, error: resolvedRealm.error };
+  }
+  realmUrl = resolvedRealm.url;
 
   let lintUrl = `${ensureTrailingSlash(realmUrl)}_lint`;
 

--- a/packages/boxel-cli/src/commands/file/list.ts
+++ b/packages/boxel-cli/src/commands/file/list.ts
@@ -8,6 +8,7 @@ import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_RED, DIM, RESET } from '../../lib/colors.ts';
 import { cliLog } from '../../lib/cli-log.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 
 export interface ListFilesResult {
   filenames: string[];
@@ -39,6 +40,12 @@ export async function listFiles(
       error: NO_ACTIVE_PROFILE_ERROR,
     };
   }
+
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, { profileManager: pm });
+  if (!resolvedRealm.ok) {
+    return { filenames: [], error: resolvedRealm.error };
+  }
+  realmUrl = resolvedRealm.url;
 
   let normalizedRealmUrl = ensureTrailingSlash(realmUrl);
   let mtimesUrl = `${normalizedRealmUrl}_mtimes`;

--- a/packages/boxel-cli/src/commands/file/read.ts
+++ b/packages/boxel-cli/src/commands/file/read.ts
@@ -1,6 +1,10 @@
 import type { Command } from 'commander';
 import type { ProfileManager } from '../../lib/profile-manager.ts';
 import { resolveRealmAuthenticator } from '../../lib/auth-resolver.ts';
+import {
+  resolveRealmIdentifier,
+  splitRealmResourceIdentifier,
+} from '../../lib/resolve-realm-identifier.ts';
 import { resolveRealmSecretSeed } from '../../lib/prompt.ts';
 import type { RealmAuthenticator } from '../../lib/realm-authenticator.ts';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
@@ -32,7 +36,7 @@ export interface ReadCommandOptions {
 }
 
 interface ReadCliOptions {
-  realm: string;
+  realm?: string;
   json?: boolean;
   realmSecretSeed?: boolean;
 }
@@ -52,6 +56,13 @@ export async function read(
   path: string,
   options?: ReadCommandOptions,
 ): Promise<ReadResult> {
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, {
+    profileManager: options?.profileManager,
+  });
+  if (!resolvedRealm.ok) {
+    return { ok: false, error: resolvedRealm.error };
+  }
+  realmUrl = resolvedRealm.url;
   let resolution = resolveRealmAuthenticator({
     realmUrl,
     realmSecretSeed: options?.realmSecretSeed,
@@ -102,15 +113,35 @@ export function registerReadCommand(parent: Command): void {
     .description('Read a file from a realm')
     .argument(
       '<path>',
-      'Realm-relative file path (e.g., hello-world.json, Cards/my-card.gts)',
+      'Realm-relative file path (e.g., hello-world.json, Cards/my-card.gts), or a full @cardstack/ identifier (e.g., @cardstack/catalog/hello.gts) in which case --realm is omitted',
     )
-    .requiredOption('--realm <realm-url>', 'The realm URL to read from')
+    .option(
+      '--realm <realm-url>',
+      'The realm URL or @cardstack/<realm>/ identifier to read from (required unless <path> is a full @cardstack/ identifier)',
+    )
     .option(
       '--realm-secret-seed',
       'Administrative auth: prompt for a realm secret seed and mint a JWT locally instead of using a Matrix profile (env: BOXEL_REALM_SECRET_SEED)',
     )
     .option('--json', 'Output raw JSON response')
     .action(async (filePath: string, opts: ReadCliOptions) => {
+      let realm = opts.realm;
+      let split = splitRealmResourceIdentifier(filePath);
+      if (split) {
+        if (realm) {
+          console.error(
+            `${FG_RED}Error:${RESET} Pass either a full @cardstack/ identifier as <path> or --realm with a realm-relative path, not both`,
+          );
+          process.exit(1);
+        }
+        ({ realm, path: filePath } = split);
+      } else if (!realm) {
+        console.error(
+          `${FG_RED}Error:${RESET} --realm is required unless <path> is a full @cardstack/ identifier`,
+        );
+        process.exit(1);
+      }
+
       let result: ReadResult;
       try {
         // Inside the try so a seed-resolution throw (e.g. --realm-secret-seed
@@ -118,7 +149,7 @@ export function registerReadCommand(parent: Command): void {
         let realmSecretSeed = await resolveRealmSecretSeed(
           opts.realmSecretSeed === true,
         );
-        result = await read(opts.realm, filePath, { realmSecretSeed });
+        result = await read(realm, filePath, { realmSecretSeed });
       } catch (err) {
         console.error(
           `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/boxel-cli/src/commands/file/read.ts
+++ b/packages/boxel-cli/src/commands/file/read.ts
@@ -41,6 +41,40 @@ interface ReadCliOptions {
   realmSecretSeed?: boolean;
 }
 
+export type ReadTarget =
+  | { ok: true; realm: string; path: string }
+  | { ok: false; error: string };
+
+/**
+ * Derive the realm identifier and realm-relative path for `file read` from
+ * its CLI inputs: a full @cardstack/ identifier as <path> carries its own
+ * realm; otherwise --realm is required.
+ */
+export function resolveReadTarget(
+  path: string,
+  realm: string | undefined,
+): ReadTarget {
+  let split = splitRealmResourceIdentifier(path);
+  if (split) {
+    if (realm) {
+      return {
+        ok: false,
+        error:
+          'Pass either a full @cardstack/ identifier as <path> or --realm with a realm-relative path, not both',
+      };
+    }
+    return { ok: true, ...split };
+  }
+  if (!realm) {
+    return {
+      ok: false,
+      error:
+        '--realm is required unless <path> is a full @cardstack/ identifier',
+    };
+  }
+  return { ok: true, realm, path };
+}
+
 /**
  * Read a file from a realm. Returns raw text in `content` for text files;
  * returns raw bytes in `bytes` for binary files (PNG / PDF / font / etc.,
@@ -125,20 +159,9 @@ export function registerReadCommand(parent: Command): void {
     )
     .option('--json', 'Output raw JSON response')
     .action(async (filePath: string, opts: ReadCliOptions) => {
-      let realm = opts.realm;
-      let split = splitRealmResourceIdentifier(filePath);
-      if (split) {
-        if (realm) {
-          console.error(
-            `${FG_RED}Error:${RESET} Pass either a full @cardstack/ identifier as <path> or --realm with a realm-relative path, not both`,
-          );
-          process.exit(1);
-        }
-        ({ realm, path: filePath } = split);
-      } else if (!realm) {
-        console.error(
-          `${FG_RED}Error:${RESET} --realm is required unless <path> is a full @cardstack/ identifier`,
-        );
+      let target = resolveReadTarget(filePath, opts.realm);
+      if (!target.ok) {
+        console.error(`${FG_RED}Error:${RESET} ${target.error}`);
         process.exit(1);
       }
 
@@ -149,7 +172,7 @@ export function registerReadCommand(parent: Command): void {
         let realmSecretSeed = await resolveRealmSecretSeed(
           opts.realmSecretSeed === true,
         );
-        result = await read(realm, filePath, { realmSecretSeed });
+        result = await read(target.realm, target.path, { realmSecretSeed });
       } catch (err) {
         console.error(
           `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/boxel-cli/src/commands/file/touch.ts
+++ b/packages/boxel-cli/src/commands/file/touch.ts
@@ -9,6 +9,7 @@ import { listFiles } from './list.ts';
 import { read } from './read.ts';
 import { write } from './write.ts';
 import { FG_GREEN, FG_RED, DIM, RESET } from '../../lib/colors.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 
 export interface TouchResult {
   ok: boolean;
@@ -57,6 +58,17 @@ export async function touchFiles(
       error: NO_ACTIVE_PROFILE_ERROR,
     };
   }
+
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, { profileManager: pm });
+  if (!resolvedRealm.ok) {
+    return {
+      ok: false,
+      touched: [],
+      skipped: [],
+      error: resolvedRealm.error,
+    };
+  }
+  realmUrl = resolvedRealm.url;
 
   let targets: string[];
 

--- a/packages/boxel-cli/src/commands/file/write.ts
+++ b/packages/boxel-cli/src/commands/file/write.ts
@@ -2,6 +2,7 @@ import type { Command } from 'commander';
 import { readFileSync } from 'fs';
 import type { ProfileManager } from '../../lib/profile-manager.ts';
 import { resolveRealmAuthenticator } from '../../lib/auth-resolver.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 import { resolveRealmSecretSeed } from '../../lib/prompt.ts';
 import type { RealmAuthenticator } from '../../lib/realm-authenticator.ts';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
@@ -48,6 +49,13 @@ export async function write(
   content: string | Uint8Array,
   options?: WriteCommandOptions,
 ): Promise<WriteResult> {
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, {
+    profileManager: options?.profileManager,
+  });
+  if (!resolvedRealm.ok) {
+    return { ok: false, error: resolvedRealm.error };
+  }
+  realmUrl = resolvedRealm.url;
   let resolution = resolveRealmAuthenticator({
     realmUrl,
     realmSecretSeed: options?.realmSecretSeed,

--- a/packages/boxel-cli/src/commands/lint.ts
+++ b/packages/boxel-cli/src/commands/lint.ts
@@ -11,6 +11,7 @@ import { cliLog } from '../lib/cli-log.ts';
 import { validateRealmRelativePath } from '../lib/realm-relative-path.ts';
 import { lint as lintSingleFile, type LintMessage } from './file/lint.ts';
 import { listFiles } from './file/list.ts';
+import { resolveRealmIdentifier } from '../lib/resolve-realm-identifier.ts';
 
 const LINTABLE_EXTENSIONS = ['.gts', '.gjs', '.ts', '.js'] as const;
 
@@ -56,6 +57,12 @@ export async function lintRealm(
   if (!active) {
     return emptyErrorResult(NO_ACTIVE_PROFILE_ERROR);
   }
+
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, { profileManager: pm });
+  if (!resolvedRealm.ok) {
+    return emptyErrorResult(resolvedRealm.error);
+  }
+  realmUrl = resolvedRealm.url;
 
   let normalizedRealmUrl = ensureTrailingSlash(realmUrl);
   let startedAt = Date.now();

--- a/packages/boxel-cli/src/commands/parse.ts
+++ b/packages/boxel-cli/src/commands/parse.ts
@@ -22,6 +22,7 @@ import {
   NO_ACTIVE_PROFILE_ERROR,
   type ProfileManager,
 } from '../lib/profile-manager.ts';
+import { resolveRealmIdentifier } from '../lib/resolve-realm-identifier.ts';
 import { FG_RED, DIM, RESET } from '../lib/colors.ts';
 import { cliLog } from '../lib/cli-log.ts';
 import { findBoxelCliRoot } from '../lib/find-package-root.ts';
@@ -215,6 +216,16 @@ export async function parseRealm(
     if (!active) {
       return emptyErrorResult(NO_ACTIVE_PROFILE_ERROR);
     }
+  }
+
+  if (realmUrl) {
+    let resolvedRealm = resolveRealmIdentifier(realmUrl, {
+      profileManager: pm,
+    });
+    if (!resolvedRealm.ok) {
+      return emptyErrorResult(resolvedRealm.error);
+    }
+    realmUrl = resolvedRealm.url;
   }
 
   let normalizedRealmUrl = realmUrl ? ensureTrailingSlash(realmUrl) : '';

--- a/packages/boxel-cli/src/commands/read-transpiled.ts
+++ b/packages/boxel-cli/src/commands/read-transpiled.ts
@@ -6,6 +6,7 @@ import {
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { FG_RED, DIM, RESET } from '../lib/colors.ts';
 import { cliLog } from '../lib/cli-log.ts';
+import { resolveRealmIdentifier } from '../lib/resolve-realm-identifier.ts';
 
 export interface ReadTranspiledResult {
   ok: boolean;
@@ -47,6 +48,12 @@ export async function readTranspiledModule(
       'No active profile. Run `boxel profile add` to create one.',
     );
   }
+
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, { profileManager: pm });
+  if (!resolvedRealm.ok) {
+    return { ok: false, error: resolvedRealm.error };
+  }
+  realmUrl = resolvedRealm.url;
 
   let url = new URL(modulePath, ensureTrailingSlash(realmUrl)).href;
 

--- a/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
+++ b/packages/boxel-cli/src/commands/realm/cancel-indexing.ts
@@ -7,6 +7,7 @@ import {
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { FG_GREEN, FG_RED, RESET } from '../../lib/colors.ts';
 import { cliLog } from '../../lib/cli-log.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 
 export interface CancelIndexingCommandOptions {
   profileManager?: ProfileManager;
@@ -44,6 +45,12 @@ export async function cancelIndexing(
       error: NO_ACTIVE_PROFILE_ERROR,
     };
   }
+
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, { profileManager: pm });
+  if (!resolvedRealm.ok) {
+    return { ok: false, error: resolvedRealm.error };
+  }
+  realmUrl = resolvedRealm.url;
 
   let cancelPending = options?.cancelPending ?? false;
   let cancelUrl = `${ensureTrailingSlash(realmUrl)}_cancel-indexing-job`;

--- a/packages/boxel-cli/src/commands/realm/indexing-errors.ts
+++ b/packages/boxel-cli/src/commands/realm/indexing-errors.ts
@@ -8,6 +8,7 @@ import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_GREEN, FG_RED, RESET } from '../../lib/colors.ts';
 import { cliLog } from '../../lib/cli-log.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 
 export interface IndexingErrorsCommandOptions {
   profileManager?: ProfileManager;
@@ -111,6 +112,12 @@ export async function indexingErrors(
   if (!active) {
     return { ok: false, error: NO_ACTIVE_PROFILE_ERROR };
   }
+
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, { profileManager: pm });
+  if (!resolvedRealm.ok) {
+    return { ok: false, error: resolvedRealm.error };
+  }
+  realmUrl = resolvedRealm.url;
 
   let endpoint = `${ensureTrailingSlash(realmUrl)}_indexing-errors`;
 

--- a/packages/boxel-cli/src/commands/realm/ingest-card.ts
+++ b/packages/boxel-cli/src/commands/realm/ingest-card.ts
@@ -11,6 +11,7 @@ import {
   type CheckpointChange,
 } from '../../lib/checkpoint-manager.ts';
 import { resolveRealmAuthenticator } from '../../lib/auth-resolver.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 import { resolveRealmSecretSeed } from '../../lib/prompt.ts';
 import {
   getProfileManager,
@@ -569,6 +570,20 @@ export async function ingestCard(
   // card path rather than the realm) and realm auto-detection below.
   cardUrl = cardUrl.replace(/\/$/, '');
   let pm = options.profileManager ?? getProfileManager();
+  let resolvedCard = resolveRealmIdentifier(cardUrl, { profileManager: pm });
+  if (!resolvedCard.ok) {
+    return { files: [], error: resolvedCard.error };
+  }
+  cardUrl = resolvedCard.url;
+  if (options.realm) {
+    let resolvedRealm = resolveRealmIdentifier(options.realm, {
+      profileManager: pm,
+    });
+    if (!resolvedRealm.ok) {
+      return { files: [], error: resolvedRealm.error };
+    }
+    options = { ...options, realm: resolvedRealm.url };
+  }
   let resolution = resolveRealmAuthenticator({
     realmUrl: options.realm ?? cardUrl,
     realmSecretSeed: options.realmSecretSeed,

--- a/packages/boxel-cli/src/commands/realm/pull.ts
+++ b/packages/boxel-cli/src/commands/realm/pull.ts
@@ -7,6 +7,7 @@ import {
 import type { ProfileManager } from '../../lib/profile-manager.ts';
 import type { RealmAuthenticator } from '../../lib/realm-authenticator.ts';
 import { resolveRealmAuthenticator } from '../../lib/auth-resolver.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 import { resolveRealmSecretSeed } from '../../lib/prompt.ts';
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -232,6 +233,13 @@ export async function pull(
   localDir: string,
   options: PullCommandOptions,
 ): Promise<{ files: string[]; error?: string }> {
+  const resolvedRealm = resolveRealmIdentifier(realmUrl, {
+    profileManager: options.profileManager,
+  });
+  if (!resolvedRealm.ok) {
+    return { files: [], error: resolvedRealm.error };
+  }
+  realmUrl = resolvedRealm.url;
   const resolution = resolveRealmAuthenticator({
     realmUrl,
     realmSecretSeed: options.realmSecretSeed,

--- a/packages/boxel-cli/src/commands/realm/push.ts
+++ b/packages/boxel-cli/src/commands/realm/push.ts
@@ -11,6 +11,7 @@ import {
 import type { ProfileManager } from '../../lib/profile-manager.ts';
 import type { RealmAuthenticator } from '../../lib/realm-authenticator.ts';
 import { resolveRealmAuthenticator } from '../../lib/auth-resolver.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 import { resolveRealmSecretSeed } from '../../lib/prompt.ts';
 import {
   type SyncManifest,
@@ -398,6 +399,14 @@ export async function pushCommand(
   realmUrl: string,
   options: PushCommandOptions,
 ): Promise<void> {
+  const resolvedRealm = resolveRealmIdentifier(realmUrl, {
+    profileManager: options.profileManager,
+  });
+  if (!resolvedRealm.ok) {
+    console.error(`Error: ${resolvedRealm.error}`);
+    process.exit(1);
+  }
+  realmUrl = resolvedRealm.url;
   const resolution = resolveRealmAuthenticator({
     realmUrl,
     realmSecretSeed: options.realmSecretSeed,

--- a/packages/boxel-cli/src/commands/realm/sync.ts
+++ b/packages/boxel-cli/src/commands/realm/sync.ts
@@ -11,6 +11,7 @@ import {
 import type { ProfileManager } from '../../lib/profile-manager.ts';
 import type { RealmAuthenticator } from '../../lib/realm-authenticator.ts';
 import { resolveRealmAuthenticator } from '../../lib/auth-resolver.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 import { resolveRealmSecretSeed } from '../../lib/prompt.ts';
 import {
   type SyncManifest,
@@ -619,6 +620,13 @@ export async function sync(
   realmUrl: string,
   options: SyncCommandOptions,
 ): Promise<SyncResult> {
+  const resolvedRealm = resolveRealmIdentifier(realmUrl, {
+    profileManager: options.profileManager,
+  });
+  if (!resolvedRealm.ok) {
+    return emptyResult({ error: resolvedRealm.error });
+  }
+  realmUrl = resolvedRealm.url;
   const resolution = resolveRealmAuthenticator({
     realmUrl,
     realmSecretSeed: options.realmSecretSeed,

--- a/packages/boxel-cli/src/commands/realm/wait-for-ready.ts
+++ b/packages/boxel-cli/src/commands/realm/wait-for-ready.ts
@@ -7,6 +7,7 @@ import {
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
 import { FG_GREEN, FG_RED, RESET } from '../../lib/colors.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
 
 export interface WaitForReadyResult {
   ready: boolean;
@@ -58,6 +59,12 @@ export async function waitForReady(
       error: NO_ACTIVE_PROFILE_ERROR,
     };
   }
+
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, { profileManager: pm });
+  if (!resolvedRealm.ok) {
+    return { ready: false, error: resolvedRealm.error };
+  }
+  realmUrl = resolvedRealm.url;
 
   let readinessUrl = `${ensureTrailingSlash(realmUrl)}_readiness-check`;
   let startedAt = Date.now();

--- a/packages/boxel-cli/src/commands/run-command.ts
+++ b/packages/boxel-cli/src/commands/run-command.ts
@@ -5,6 +5,7 @@ import {
 } from '../lib/profile-manager.ts';
 import { FG_GREEN, FG_RED, FG_CYAN, DIM, RESET } from '../lib/colors.ts';
 import { cliLog } from '../lib/cli-log.ts';
+import { resolveRealmIdentifier } from '../lib/resolve-realm-identifier.ts';
 
 export interface RunCommandResult {
   status: 'ready' | 'error' | 'unusable';
@@ -36,6 +37,12 @@ export async function runCommand(
       'No active profile. Run `boxel profile add` to create one.',
     );
   }
+
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, { profileManager: pm });
+  if (!resolvedRealm.ok) {
+    return { status: 'error', error: resolvedRealm.error };
+  }
+  realmUrl = resolvedRealm.url;
 
   let realmServerUrl = active.profile.realmServerUrl.replace(/\/$/, '');
   let url = `${realmServerUrl}/_run-command`;

--- a/packages/boxel-cli/src/commands/search.ts
+++ b/packages/boxel-cli/src/commands/search.ts
@@ -5,6 +5,7 @@ import {
   type ProfileManager,
 } from '../lib/profile-manager.ts';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+import { resolveRealmIdentifier } from '../lib/resolve-realm-identifier.ts';
 import { resourceIdentity } from '@cardstack/runtime-common/resource-identity';
 import { FG_RED, DIM, RESET } from '../lib/colors.ts';
 import { cliLog } from '../lib/cli-log.ts';
@@ -226,9 +227,14 @@ export async function search(
   let realmServerUrl = active.profile.realmServerUrl.replace(/\/$/, '');
   let searchUrl = `${realmServerUrl}/_federated-search`;
 
-  let realms = (Array.isArray(realmUrls) ? realmUrls : [realmUrls]).map(
-    ensureTrailingSlash,
-  );
+  let realms: string[] = [];
+  for (let realm of Array.isArray(realmUrls) ? realmUrls : [realmUrls]) {
+    let resolved = resolveRealmIdentifier(realm, { profileManager: pm });
+    if (!resolved.ok) {
+      return { ok: false, error: resolved.error };
+    }
+    realms.push(ensureTrailingSlash(resolved.url));
+  }
 
   let body: SearchEntryRequestBody;
   try {

--- a/packages/boxel-cli/src/lib/profile-manager.ts
+++ b/packages/boxel-cli/src/lib/profile-manager.ts
@@ -53,6 +53,18 @@ function isJwtNearExpiry(
 export const NO_ACTIVE_PROFILE_ERROR =
   'No active profile. Run `boxel profile add` to create one.';
 
+/**
+ * Bootstrap realms (the base realm) are registered — and tokened by
+ * `_realm-auth` — under a `https://cardstack.com/<name>/` alias, but are
+ * served over HTTP at `<realm-server>/<name>/`. Returns the `<name>` for
+ * an aliased realm URL so token lookup can mirror the realm server's own
+ * aliasing; undefined for every other realm URL.
+ */
+function aliasedRealmName(realmUrl: string): string | undefined {
+  let match = realmUrl.match(/^https:\/\/cardstack\.com\/([^/]+)\/$/);
+  return match?.[1];
+}
+
 export interface Profile {
   displayName: string;
   matrixUrl: string;
@@ -539,12 +551,19 @@ export class ProfileManager implements RealmAuthenticator {
 
   private findRealmTokenForUrl(url: string): string | undefined {
     let active = this.getActiveProfile();
-    let realmTokens = active?.profile.realmTokens;
-    if (!realmTokens) {
+    if (!active?.profile.realmTokens) {
       return undefined;
     }
-    for (let [realmUrl, token] of Object.entries(realmTokens)) {
-      if (url.startsWith(realmUrl) && token) {
+    let serverUrl = active.profile.realmServerUrl.replace(/\/+$/, '') + '/';
+    for (let [realmUrl, token] of Object.entries(active.profile.realmTokens)) {
+      if (!token) {
+        continue;
+      }
+      if (url.startsWith(realmUrl)) {
+        return token;
+      }
+      let aliasedName = aliasedRealmName(realmUrl);
+      if (aliasedName && url.startsWith(`${serverUrl}${aliasedName}/`)) {
         return token;
       }
     }

--- a/packages/boxel-cli/src/lib/resolve-realm-identifier.ts
+++ b/packages/boxel-cli/src/lib/resolve-realm-identifier.ts
@@ -1,0 +1,110 @@
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+import { getProfileManager, type ProfileManager } from './profile-manager.ts';
+
+/**
+ * Realm resource identifiers (RRIs) in the cardstack scope follow the
+ * convention `@cardstack/<realm>/…` → `<realm-server>/<realm>/…` in every
+ * environment — the same prefix→URL pairs the realm server registers at boot
+ * (`@cardstack/base/`, `@cardstack/catalog/`, `@cardstack/skills/`, …).
+ */
+const CARDSTACK_SCOPE = '@cardstack/';
+
+export interface ResolveRealmIdentifierOptions {
+  /** Override the ProfileManager used to look up the realm-server URL (tests). */
+  profileManager?: ProfileManager;
+  /**
+   * Explicit realm-server base URL to resolve against. Takes precedence over
+   * the active profile and the REALM_SERVER_URL environment variable.
+   */
+  realmServerUrl?: string;
+}
+
+export type RealmIdentifierResolution =
+  | { ok: true; url: string }
+  | { ok: false; error: string };
+
+/** Whether the input is a non-URL realm resource identifier (`@cardstack/…`). */
+export function isRealmResourceIdentifier(input: string): boolean {
+  return input.startsWith('@');
+}
+
+/**
+ * Resolve a realm identifier argument to a URL. Plain URLs pass through
+ * unchanged; `@cardstack/<realm>/…` identifiers resolve against the
+ * realm-server base URL from (in order) `options.realmServerUrl`, the active
+ * profile, or the REALM_SERVER_URL environment variable.
+ */
+export function resolveRealmIdentifier(
+  input: string,
+  options?: ResolveRealmIdentifierOptions,
+): RealmIdentifierResolution {
+  if (!isRealmResourceIdentifier(input)) {
+    return { ok: true, url: input };
+  }
+  if (!input.startsWith(CARDSTACK_SCOPE)) {
+    return {
+      ok: false,
+      error: `Unsupported realm identifier "${input}": only @cardstack/<realm>/ identifiers are supported`,
+    };
+  }
+  let remainder = input.slice(CARDSTACK_SCOPE.length);
+  if (!remainder.split('/')[0]) {
+    return {
+      ok: false,
+      error: `Malformed realm identifier "${input}": expected @cardstack/<realm>/…`,
+    };
+  }
+  let server = resolveRealmServerUrl(options);
+  if (!server.ok) {
+    return server;
+  }
+  return {
+    ok: true,
+    url: new URL(remainder, ensureTrailingSlash(server.url)).href,
+  };
+}
+
+/**
+ * Split a full-RRI file identifier into its realm identifier and
+ * realm-relative path: `@cardstack/catalog/foo/bar.gts` →
+ * `{ realm: '@cardstack/catalog/', path: 'foo/bar.gts' }`. Returns undefined
+ * when the input isn't an RRI or has no path component after the realm.
+ */
+export function splitRealmResourceIdentifier(
+  input: string,
+): { realm: string; path: string } | undefined {
+  if (!input.startsWith(CARDSTACK_SCOPE)) {
+    return undefined;
+  }
+  let remainder = input.slice(CARDSTACK_SCOPE.length);
+  let slash = remainder.indexOf('/');
+  if (slash === -1 || slash === remainder.length - 1) {
+    return undefined;
+  }
+  return {
+    realm: `${CARDSTACK_SCOPE}${remainder.slice(0, slash)}/`,
+    path: remainder.slice(slash + 1),
+  };
+}
+
+function resolveRealmServerUrl(
+  options?: ResolveRealmIdentifierOptions,
+): RealmIdentifierResolution {
+  if (options?.realmServerUrl) {
+    return { ok: true, url: options.realmServerUrl };
+  }
+  let active = (
+    options?.profileManager ?? getProfileManager()
+  ).getActiveProfile();
+  if (active) {
+    return { ok: true, url: active.profile.realmServerUrl };
+  }
+  if (process.env.REALM_SERVER_URL) {
+    return { ok: true, url: process.env.REALM_SERVER_URL };
+  }
+  return {
+    ok: false,
+    error:
+      'Cannot resolve a @cardstack/ realm identifier without a realm-server URL. Run `boxel profile add` to create a profile, or set REALM_SERVER_URL.',
+  };
+}

--- a/packages/boxel-cli/src/lib/test-engine.ts
+++ b/packages/boxel-cli/src/lib/test-engine.ts
@@ -10,6 +10,7 @@ import {
   NO_ACTIVE_PROFILE_ERROR,
   type ProfileManager,
 } from './profile-manager.ts';
+import { resolveRealmIdentifier } from './resolve-realm-identifier.ts';
 import { findBoxelCliRoot } from './find-package-root.ts';
 import { listFiles } from '../commands/file/list.ts';
 import { readdirSync } from 'node:fs';
@@ -194,6 +195,12 @@ export async function runTestsForRealm(
   if (!active) {
     return emptyErrorResult(NO_ACTIVE_PROFILE_ERROR);
   }
+
+  let resolvedRealm = resolveRealmIdentifier(realmUrl, { profileManager: pm });
+  if (!resolvedRealm.ok) {
+    return emptyErrorResult(resolvedRealm.error);
+  }
+  realmUrl = resolvedRealm.url;
 
   let normalizedRealmUrl = ensureTrailingSlash(realmUrl);
   let hostAppUrl = ensureTrailingSlash(

--- a/packages/boxel-cli/tests/commands/file-read-cli.test.ts
+++ b/packages/boxel-cli/tests/commands/file-read-cli.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import {
+  registerReadCommand,
+  resolveReadTarget,
+} from '../../src/commands/file/read.ts';
+
+describe('resolveReadTarget', () => {
+  it('derives realm and path from a full @cardstack/ identifier', () => {
+    expect(
+      resolveReadTarget('@cardstack/catalog/nested/card.gts', undefined),
+    ).toEqual({
+      ok: true,
+      realm: '@cardstack/catalog/',
+      path: 'nested/card.gts',
+    });
+  });
+
+  it('passes --realm and a relative path through unchanged', () => {
+    expect(
+      resolveReadTarget('hello.json', 'http://localhost:4201/user/realm/'),
+    ).toEqual({
+      ok: true,
+      realm: 'http://localhost:4201/user/realm/',
+      path: 'hello.json',
+    });
+  });
+
+  it('accepts an @cardstack/ identifier as --realm with a relative path', () => {
+    expect(resolveReadTarget('hello.json', '@cardstack/catalog/')).toEqual({
+      ok: true,
+      realm: '@cardstack/catalog/',
+      path: 'hello.json',
+    });
+  });
+
+  it('rejects a full identifier combined with --realm', () => {
+    let target = resolveReadTarget(
+      '@cardstack/catalog/hello.json',
+      'http://localhost:4201/catalog/',
+    );
+    expect(target.ok).toBe(false);
+    if (!target.ok) {
+      expect(target.error).toContain('not both');
+    }
+  });
+
+  it('rejects a relative path without --realm', () => {
+    let target = resolveReadTarget('hello.json', undefined);
+    expect(target.ok).toBe(false);
+    if (!target.ok) {
+      expect(target.error).toContain('--realm is required');
+    }
+  });
+
+  it('rejects a bare realm identifier with no file path', () => {
+    // No path component after the realm, so it isn't a full file
+    // identifier — and there's no --realm to pair it with.
+    let target = resolveReadTarget('@cardstack/catalog/', undefined);
+    expect(target.ok).toBe(false);
+    if (!target.ok) {
+      expect(target.error).toContain('--realm is required');
+    }
+  });
+});
+
+describe('boxel file read CLI parsing', () => {
+  function parseRead(args: string[]): {
+    capturedPath: string | null;
+    capturedOpts: Record<string, unknown> | null;
+  } {
+    let capturedPath: string | null = null;
+    let capturedOpts: Record<string, unknown> | null = null;
+
+    const program = new Command().exitOverride();
+    const file = program.command('file');
+    registerReadCommand(file);
+    const readCmd = file.commands.find((c) => c.name() === 'read');
+    if (!readCmd) {
+      throw new Error('read subcommand not registered');
+    }
+
+    // Replace the action so we capture parsed inputs without executing
+    // read() (which would need a real realm-server).
+    readCmd.action((filePath: string, opts: object) => {
+      capturedPath = filePath;
+      capturedOpts = { ...opts } as Record<string, unknown>;
+    });
+
+    program.parse(['file', 'read', ...args], { from: 'user' });
+    return { capturedPath, capturedOpts };
+  }
+
+  it('parses a full @cardstack/ identifier without --realm', () => {
+    // --realm was previously a requiredOption; commander must not reject
+    // its absence now that a full identifier can carry the realm.
+    let { capturedPath, capturedOpts } = parseRead([
+      '@cardstack/catalog/hello.gts',
+    ]);
+    expect(capturedPath).toBe('@cardstack/catalog/hello.gts');
+    expect(capturedOpts!.realm).toBeUndefined();
+  });
+
+  it('parses --realm alongside a relative path', () => {
+    let { capturedPath, capturedOpts } = parseRead([
+      'hello.gts',
+      '--realm',
+      '@cardstack/catalog/',
+    ]);
+    expect(capturedPath).toBe('hello.gts');
+    expect(capturedOpts!.realm).toBe('@cardstack/catalog/');
+  });
+});

--- a/packages/boxel-cli/tests/integration/file-read.test.ts
+++ b/packages/boxel-cli/tests/integration/file-read.test.ts
@@ -93,6 +93,27 @@ describe('file read (integration)', () => {
     expect(result.content!.length).toBeGreaterThan(0);
   });
 
+  it('reads a file via a non-URL @cardstack/ realm identifier', async () => {
+    // `@cardstack/<realm>/` resolves against the active profile's
+    // realm-server URL, so `@cardstack/test/` names the test realm.
+    let result = await read('@cardstack/test/', 'test-card.json', {
+      profileManager,
+    });
+
+    expect(result.ok, `read failed: ${JSON.stringify(result)}`).toBe(true);
+    expect(result.status).toBe(200);
+    let parsed = JSON.parse(result.content!);
+    expect(parsed).toHaveProperty('data');
+  });
+
+  it('returns a not-ok result for an unsupported realm identifier scope', async () => {
+    let result = await read('@unknown-scope/test/', 'test-card.json', {
+      profileManager,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('only @cardstack/<realm>/');
+  });
+
   it('returns a not-ok result with 404 status for a nonexistent file', async () => {
     let result = await read(realmUrl, 'does-not-exist.json', {
       profileManager,

--- a/packages/boxel-cli/tests/integration/realm-ingest-card.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-ingest-card.test.ts
@@ -202,6 +202,30 @@ describe('realm ingest-card (integration)', () => {
     }
   });
 
+  it('ingests via non-URL @cardstack/ identifiers for both the card and --realm', async () => {
+    // `@cardstack/<realm>/` resolves against the profile's realm-server
+    // URL, so these identifiers name the same realm as realmHref. The card
+    // identifier and the realm option resolve independently in ingestCard.
+    let rriDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-ingest-rri-'));
+    try {
+      let rriResult = await ingestCard(
+        '@cardstack/test/widgets/gadget/gadget',
+        rriDir,
+        {
+          realm: '@cardstack/test/',
+          profileManager,
+        },
+      );
+      expect(
+        rriResult.error,
+        `ingest failed: ${rriResult.error}`,
+      ).toBeUndefined();
+      expect(rriResult.files).toEqual(EXPECTED_INGESTED);
+    } finally {
+      fs.rmSync(rriDir, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it('does not copy base-realm modules the card imports', () => {
     // The copied source still imports the base realm by absolute URL; no
     // base-realm file is materialized locally.

--- a/packages/boxel-cli/tests/integration/search.test.ts
+++ b/packages/boxel-cli/tests/integration/search.test.ts
@@ -142,6 +142,21 @@ describe('federated search (integration)', () => {
     expect(Array.isArray(result.data)).toBe(true);
   });
 
+  it('accepts a non-URL @cardstack/ realm identifier in the realm list', async () => {
+    // `@cardstack/<realm>/` resolves against the profile's realm-server
+    // URL, so `@cardstack/test/` names the same realm as realmHref.
+    let result = await search(['@cardstack/test/'], {}, { profileManager });
+    expect(result.ok, `search failed: ${result.error}`).toBe(true);
+    let titles = (result.data ?? []).map(
+      (entry) =>
+        (entry as { attributes?: { cardTitle?: string } }).attributes
+          ?.cardTitle,
+    );
+    expect(titles).toEqual(
+      expect.arrayContaining(['Shared Card', 'Other Card']),
+    );
+  });
+
   it('returns ok: false for search on unknown realm URL', async () => {
     let unknownRealm = new URL('nonexistent/', new URL(realmHref)).href;
     let result = await search(unknownRealm, {}, { profileManager });

--- a/packages/boxel-cli/tests/lib/realm-token-alias.test.ts
+++ b/packages/boxel-cli/tests/lib/realm-token-alias.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ProfileManager } from '../../src/lib/profile-manager.ts';
+
+// The base realm is registered — and tokened by `_realm-auth` — under its
+// `https://cardstack.com/base/` alias, but served over HTTP at
+// `<realm-server>/base/`. Token lookup must bridge that aliasing or every
+// profile-auth request to the serving URL fails with "No realm token
+// available" despite _realm-auth having issued one.
+
+const SERVER_URL = 'https://realms.example.test/';
+
+let pm: ProfileManager;
+let configDir: string;
+
+beforeEach(async () => {
+  configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-token-alias-'));
+  pm = new ProfileManager(configDir);
+  await pm.addProfileWithAuth(
+    '@cli-test:example.test',
+    {
+      accessToken: 'test-access-token',
+      userId: '@cli-test:example.test',
+      deviceId: 'CLI_TEST_DEVICE',
+      matrixUrl: 'https://matrix.example.test/',
+    },
+    'CLI Test User',
+    SERVER_URL,
+  );
+  pm.setRealmToken('https://cardstack.com/base/', 'Bearer base-token');
+  pm.setRealmToken(`${SERVER_URL}catalog/`, 'Bearer catalog-token');
+});
+
+afterEach(() => {
+  fs.rmSync(configDir, { recursive: true, force: true });
+});
+
+describe('realm token lookup across the cardstack.com alias', () => {
+  it('matches a cardstack.com-aliased token for a serving-host URL', async () => {
+    let token = await pm.getRealmTokenForUrl(`${SERVER_URL}base/card-api.gts`);
+    expect(token).toBe('Bearer base-token');
+  });
+
+  it('still matches tokens keyed by their serving URL directly', async () => {
+    let token = await pm.getRealmTokenForUrl(`${SERVER_URL}catalog/foo.json`);
+    expect(token).toBe('Bearer catalog-token');
+  });
+
+  it('matches the canonical alias URL itself unchanged', async () => {
+    let token = await pm.getRealmTokenForUrl(
+      'https://cardstack.com/base/card-api.gts',
+    );
+    expect(token).toBe('Bearer base-token');
+  });
+
+  it('does not surface the aliased token under a different realm path', async () => {
+    // The exact-key getter shows the alias key is the only base entry;
+    // the catalog URL must resolve to its own token, not base's.
+    expect(pm.getRealmToken(`${SERVER_URL}base/`)).toBeUndefined();
+    let token = await pm.getRealmTokenForUrl(`${SERVER_URL}catalog/bar.gts`);
+    expect(token).toBe('Bearer catalog-token');
+  });
+});

--- a/packages/boxel-cli/tests/lib/resolve-realm-identifier.test.ts
+++ b/packages/boxel-cli/tests/lib/resolve-realm-identifier.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  isRealmResourceIdentifier,
+  resolveRealmIdentifier,
+  splitRealmResourceIdentifier,
+} from '../../src/lib/resolve-realm-identifier.ts';
+import { ProfileManager } from '../../src/lib/profile-manager.ts';
+
+function emptyProfileManager(): {
+  profileManager: ProfileManager;
+  cleanup: () => void;
+} {
+  let dir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-rri-test-'));
+  return {
+    profileManager: new ProfileManager(dir),
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe('isRealmResourceIdentifier', () => {
+  it('is true for @-prefixed identifiers and false for URLs', () => {
+    expect(isRealmResourceIdentifier('@cardstack/catalog/')).toBe(true);
+    expect(isRealmResourceIdentifier('http://localhost:4201/catalog/')).toBe(
+      false,
+    );
+    expect(isRealmResourceIdentifier('catalog/')).toBe(false);
+  });
+});
+
+describe('resolveRealmIdentifier', () => {
+  const server = 'https://realms.example.test/';
+
+  it('passes plain URLs through unchanged', () => {
+    let result = resolveRealmIdentifier('http://localhost:4201/user/realm/', {
+      realmServerUrl: server,
+    });
+    expect(result).toEqual({
+      ok: true,
+      url: 'http://localhost:4201/user/realm/',
+    });
+  });
+
+  it('resolves @cardstack/catalog/ against the realm-server URL', () => {
+    let result = resolveRealmIdentifier('@cardstack/catalog/', {
+      realmServerUrl: server,
+    });
+    expect(result).toEqual({
+      ok: true,
+      url: 'https://realms.example.test/catalog/',
+    });
+  });
+
+  it('resolves @cardstack/base/ against the realm-server URL', () => {
+    let result = resolveRealmIdentifier('@cardstack/base/', {
+      realmServerUrl: server,
+    });
+    expect(result).toEqual({
+      ok: true,
+      url: 'https://realms.example.test/base/',
+    });
+  });
+
+  it('resolves a full file identifier, preserving the path', () => {
+    let result = resolveRealmIdentifier('@cardstack/catalog/nested/card.gts', {
+      realmServerUrl: server,
+    });
+    expect(result).toEqual({
+      ok: true,
+      url: 'https://realms.example.test/catalog/nested/card.gts',
+    });
+  });
+
+  it('tolerates a realm-server URL without a trailing slash', () => {
+    let result = resolveRealmIdentifier('@cardstack/skills/', {
+      realmServerUrl: 'https://realms.example.test',
+    });
+    expect(result).toEqual({
+      ok: true,
+      url: 'https://realms.example.test/skills/',
+    });
+  });
+
+  it('rejects non-cardstack scopes', () => {
+    let result = resolveRealmIdentifier('@other/realm/', {
+      realmServerUrl: server,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('only @cardstack/<realm>/');
+    }
+  });
+
+  it('rejects a scope with no realm name', () => {
+    let result = resolveRealmIdentifier('@cardstack/', {
+      realmServerUrl: server,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('Malformed realm identifier');
+    }
+  });
+
+  describe('realm-server URL sources', () => {
+    let savedEnv = process.env.REALM_SERVER_URL;
+    afterEach(() => {
+      if (savedEnv === undefined) {
+        delete process.env.REALM_SERVER_URL;
+      } else {
+        process.env.REALM_SERVER_URL = savedEnv;
+      }
+    });
+
+    it('falls back to REALM_SERVER_URL when there is no active profile', () => {
+      process.env.REALM_SERVER_URL = 'https://env.example.test/';
+      let { profileManager, cleanup } = emptyProfileManager();
+      let result = resolveRealmIdentifier('@cardstack/catalog/', {
+        profileManager,
+      });
+      cleanup();
+      expect(result).toEqual({
+        ok: true,
+        url: 'https://env.example.test/catalog/',
+      });
+    });
+
+    it('errors when no realm-server URL source is available', () => {
+      delete process.env.REALM_SERVER_URL;
+      let { profileManager, cleanup } = emptyProfileManager();
+      let result = resolveRealmIdentifier('@cardstack/catalog/', {
+        profileManager,
+      });
+      cleanup();
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('boxel profile add');
+      }
+    });
+  });
+});
+
+describe('splitRealmResourceIdentifier', () => {
+  it('splits a full file identifier into realm and path', () => {
+    expect(
+      splitRealmResourceIdentifier('@cardstack/catalog/nested/card.gts'),
+    ).toEqual({
+      realm: '@cardstack/catalog/',
+      path: 'nested/card.gts',
+    });
+  });
+
+  it('returns undefined for a bare realm identifier', () => {
+    expect(splitRealmResourceIdentifier('@cardstack/catalog/')).toBeUndefined();
+    expect(splitRealmResourceIdentifier('@cardstack/catalog')).toBeUndefined();
+  });
+
+  it('returns undefined for URLs and non-cardstack scopes', () => {
+    expect(
+      splitRealmResourceIdentifier('http://localhost:4201/catalog/card.gts'),
+    ).toBeUndefined();
+    expect(
+      splitRealmResourceIdentifier('@other/realm/card.gts'),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Exercising this locally:

```
❯ node src/index.ts file list --realm '@cardstack/catalog/'
.boxelignore
.github/workflows/ci-lint.yaml
.github/workflows/ci-test.yaml
.github/workflows/sync-to-workspace.yml
.gitignore
04868f-mortgage-calculator/CardListing/998bee54-a47c-4301-86e6-181780af5ad8.json
04868f-mortgage-calculator/ListingThumbnails/mortgagecalculator-ceb7d712.png
…
```

```
❯ node src/index.ts file read '@cardstack/catalog/.boxelignore'
package.json
package-lock.json
.boxelignore
…
```