### PR TITLE
Rename skill frontmatter key boxel.commands to boxel.tools with dual-read (CS-12037)

### DIFF
--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -7284,7 +7284,7 @@ module('markdown skill commands', (hooks) => {
     'description: "env"',
     'boxel:',
     '  kind: skill',
-    '  commands:',
+    '  tools:',
     '    - codeRef:',
     '        module: "@cardstack/boxel-host/commands/switch-submode"',
     '        name: "default"',
@@ -7305,13 +7305,24 @@ module('markdown skill commands', (hooks) => {
     assert.false(commands[0].requiresApproval);
   });
 
+  test('parseMarkdownSkill reads the pre-rename boxel.commands key', (assert) => {
+    let { commands } = parseMarkdownSkill(
+      SKILL_MD.replace('  tools:', '  commands:'),
+      {
+        sourceUrl: 'https://realm/skills/boxel-environment/SKILL.md',
+      } as any,
+    );
+    assert.strictEqual(commands.length, 1);
+    assert.strictEqual(commands[0].functionName, 'switch-submode_dd88');
+  });
+
   test('a command without requiresApproval defaults to approval required', (assert) => {
     let md = [
       '---',
       'name: "My Skill"',
       'boxel:',
       '  kind: skill',
-      '  commands:',
+      '  tools:',
       '    - codeRef:',
       '        module: "@cardstack/boxel-host/commands/switch-submode"',
       '        name: "default"',
@@ -7330,7 +7341,7 @@ module('markdown skill commands', (hooks) => {
       'name: "My Skill"',
       'boxel:',
       '  kind: skill',
-      '  commands:',
+      '  tools:',
       '    - codeRef:',
       '        module: "../../commands/my-command"',
       '        name: "default"',
@@ -7352,7 +7363,7 @@ module('markdown skill commands', (hooks) => {
       'name: "My Skill"',
       'boxel:',
       '  kind: skill',
-      '  commands:',
+      '  tools:',
       '    - codeRef:',
       '        module: "/commands/my-command"',
       '        name: "default"',

--- a/packages/base/skill-frontmatter-field.gts
+++ b/packages/base/skill-frontmatter-field.gts
@@ -12,7 +12,7 @@ import { CommandField } from './command-field';
 // A skill markdown file's frontmatter (`boxel.kind: skill`). Adds typed fields
 // on top of the base `FrontmatterField` (which holds the raw frontmatter in
 // `rawContent`). Mirrors the field shape of the legacy `Skill` card so the
-// host's command-definition upload flow reads `markdownDef.frontmatter.commands`
+// host's tool-definition upload flow reads `markdownDef.frontmatter.tools`
 // exactly as it reads `Skill.commands`. `name`/`description` are sourced from the
 // shared top-level frontmatter keys (see `MarkdownDef.extractAttributes`).
 export class SkillFrontmatterField extends FrontmatterField {
@@ -20,11 +20,18 @@ export class SkillFrontmatterField extends FrontmatterField {
 
   @field name = contains(StringField);
   @field description = contains(StringField);
+  @field tools = containsMany(CommandField);
+  // Legacy spelling of `tools`. Index rows extracted before the
+  // command -> tool rename persist the value under a `commands` attribute;
+  // this field lets those rows rehydrate without a reindex. Consumers read
+  // `tools` and fall back to this (see the host's `getSkillSourceCommands`).
+  // Remove once all realms have reindexed post-rename.
   @field commands = containsMany(CommandField);
 
   // `name`/`description` come from the shared top-level frontmatter keys;
-  // `commands` from the `boxel:` namespace. Only this subclass knows that
-  // mapping.
+  // `tools` from the `boxel:` namespace (`boxel.tools`, with the pre-rename
+  // `boxel.commands` key still accepted; `tools` wins when both are present).
+  // Only this subclass knows that mapping.
   static fromFrontmatter(
     frontmatter: Record<string, unknown>,
   ): Record<string, unknown> {
@@ -38,7 +45,7 @@ export class SkillFrontmatterField extends FrontmatterField {
       ...super.fromFrontmatter(frontmatter),
       name: frontmatter.name,
       description: frontmatter.description,
-      commands: boxel?.commands,
+      tools: boxel?.tools ?? boxel?.commands,
     };
   }
 

--- a/packages/host/app/commands/migrate-skill.ts
+++ b/packages/host/app/commands/migrate-skill.ts
@@ -14,8 +14,8 @@ import type RealmService from '../services/realm';
 import type StoreService from '../services/store';
 
 // A single command in the migrated frontmatter — the same shape
-// `SkillFrontmatterField.commands` (a `containsMany(CommandField)`) parses back
-// out of `boxel.commands`.
+// `SkillFrontmatterField.tools` (a `containsMany(CommandField)`) parses back
+// out of `boxel.tools`.
 interface FrontmatterCommand {
   codeRef: { module: string; name: string };
   // Always emitted explicitly. The host auto-executes a command only when
@@ -152,7 +152,7 @@ files with boxel.kind: skill frontmatter.`;
   }
 
   private buildSkillMarkdown(skill: Skill, body: string): string {
-    let commands = (skill.commands ?? []).reduce<FrontmatterCommand[]>(
+    let tools = (skill.commands ?? []).reduce<FrontmatterCommand[]>(
       (acc, command) => {
         let module = command.codeRef?.module;
         let name = command.codeRef?.name;
@@ -168,13 +168,13 @@ files with boxel.kind: skill frontmatter.`;
     );
 
     // Shared top-level keys (read byte-for-byte by Claude Code) first, then the
-    // Boxel-only `boxel:` namespace that carries `kind` and `commands`.
+    // Boxel-only `boxel:` namespace that carries `kind` and `tools`.
     let frontmatter: Record<string, unknown> = {
       name: skill.cardTitle ?? '',
       description: skill.cardDescription ?? '',
       boxel: {
         kind: 'skill',
-        ...(commands.length > 0 ? { commands } : {}),
+        ...(tools.length > 0 ? { tools } : {}),
       },
     };
 

--- a/packages/host/app/lib/matrix-classes/message-builder.ts
+++ b/packages/host/app/lib/matrix-classes/message-builder.ts
@@ -362,7 +362,7 @@ export default class MessageBuilder {
     }
 
     // Find command in skills. loadSkillSource handles both legacy Skill
-    // cards and markdown skills (commands in boxel.commands frontmatter).
+    // cards and markdown skills (tools in boxel.tools frontmatter).
     let skillCommand:
       | { codeRef: ResolvedCodeRef; requiresApproval: boolean }
       | undefined;

--- a/packages/host/app/lib/skill-commands.ts
+++ b/packages/host/app/lib/skill-commands.ts
@@ -9,8 +9,8 @@ import type StoreService from '../services/store';
 
 // A skill is either a `Skill` card (commands on `Skill.commands`) or a
 // markdown file whose `boxel.kind: skill` frontmatter rehydrates as a
-// `SkillFrontmatterField` (commands on `MarkdownDef.frontmatter.commands`).
-// Both `commands` fields are `containsMany(CommandField)`, so once gathered the
+// `SkillFrontmatterField` (tools on `MarkdownDef.frontmatter.tools`).
+// Both fields are `containsMany(CommandField)`, so once gathered the
 // `CommandField` instances feed the command-definition upload flow identically.
 export type SkillSource = SkillModule.Skill | MarkdownDef;
 
@@ -47,11 +47,18 @@ export function getSkillSourceCommands(
   }
   if (isSkillMarkdown(instance)) {
     // For `boxel.kind: skill`, `frontmatter` is a `SkillFrontmatterField` whose
-    // `commands` is the same `containsMany(CommandField)` as `Skill.commands`.
+    // `tools` is the same `containsMany(CommandField)` as `Skill.commands`.
+    // Index rows extracted before the command → tool rename carry the value
+    // under the legacy `commands` field instead; fall back until all realms
+    // have reindexed.
     let frontmatter = instance.frontmatter as {
+      tools?: SkillModule.CommandField[];
       commands?: SkillModule.CommandField[];
     } | null;
-    return frontmatter?.commands ?? [];
+    // `tools` is a containsMany, so a rehydrated pre-rename row yields [] (not
+    // undefined) — an empty-check, not `??`, is what routes to the fallback.
+    let tools = frontmatter?.tools;
+    return tools?.length ? tools : (frontmatter?.commands ?? []);
   }
   return [];
 }

--- a/packages/host/tests/integration/commands/migrate-skill-test.gts
+++ b/packages/host/tests/integration/commands/migrate-skill-test.gts
@@ -164,7 +164,7 @@ export class DoThingQuietly extends Command {
     );
     assert.strictEqual(data.boxel.kind, 'skill', 'boxel.kind is skill');
     assert.deepEqual(
-      data.boxel.commands,
+      data.boxel.tools,
       [
         {
           codeRef: { module: COMMAND_MODULE, name: 'DoThing' },
@@ -175,7 +175,7 @@ export class DoThingQuietly extends Command {
           requiresApproval: false,
         },
       ],
-      'commands round-trip into boxel.commands, preserving an explicit requiresApproval: false',
+      'commands round-trip into boxel.tools, preserving an explicit requiresApproval: false',
     );
     assert.strictEqual(
       body.trim(),
@@ -184,7 +184,7 @@ export class DoThingQuietly extends Command {
     );
   });
 
-  test('omits boxel.commands when the skill has none', async function (assert) {
+  test('omits boxel.tools when the skill has none', async function (assert) {
     let commandContext = getService('command-service').commandContext;
     let cardService = getService('card-service');
     let command = new MigrateSkillCommand(commandContext);
@@ -199,10 +199,7 @@ export class DoThingQuietly extends Command {
       ).content,
     );
     assert.strictEqual(data.boxel.kind, 'skill', 'boxel.kind is skill');
-    assert.notOk(
-      'commands' in data.boxel,
-      'no commands key when the skill has none',
-    );
+    assert.notOk('tools' in data.boxel, 'no tools key when the skill has none');
   });
 
   test('reports skills with no instructions instead of writing an empty file', async function (assert) {

--- a/packages/host/tests/integration/components/markdown-skill-frontmatter-test.gts
+++ b/packages/host/tests/integration/components/markdown-skill-frontmatter-test.gts
@@ -9,7 +9,7 @@
 //      (SkillFrontmatterField) via the file-field-meta symbol.
 //   3. The write→read round-trip (extractor lift → buildFileResource →
 //      createFromSerialized) rehydrates `frontmatter` as a SkillFrontmatterField
-//      with its commands intact.
+//      with its tools intact.
 //   4. Plain markdown (no frontmatter) is unaffected.
 
 import { getService } from '@universal-ember/test-support';
@@ -43,7 +43,7 @@ name: Realm Sync
 description: Sync workspace files
 boxel:
   kind: skill
-  commands:
+  tools:
     - codeRef:
         module: '@cardstack/boxel-host/commands/realm-sync'
         name: SyncCommand
@@ -53,6 +53,10 @@ boxel:
 
 Body paragraph.
 `;
+
+// The pre-rename spelling of the tools key. Files authored before the
+// command → tool rename keep working via the fromFrontmatter fallback.
+const LEGACY_SKILL_MD = SKILL_MD.replace('  tools:', '  commands:');
 
 module('Integration | markdown skill frontmatter', function (hooks) {
   setupRenderingTest(hooks);
@@ -91,9 +95,9 @@ module('Integration | markdown skill frontmatter', function (hooks) {
     assert.strictEqual(data.name, 'Realm Sync', 'top-level name parsed');
     assert.strictEqual((data.boxel as any).kind, 'skill', 'boxel.kind parsed');
     assert.strictEqual(
-      (data.boxel as any).commands[0].codeRef.name,
+      (data.boxel as any).tools[0].codeRef.name,
       'SyncCommand',
-      'nested boxel.commands codeRef parsed',
+      'nested boxel.tools codeRef parsed',
     );
     assert.true(
       body.startsWith('# Realm Sync'),
@@ -143,8 +147,8 @@ module('Integration | markdown skill frontmatter', function (hooks) {
       'typed name sourced from shared top-level name',
     );
     assert.true(
-      attrs.frontmatter.commands[0].requiresApproval,
-      'typed commands sourced from the boxel namespace',
+      attrs.frontmatter.tools[0].requiresApproval,
+      'typed tools sourced from the boxel namespace',
     );
 
     let routed = (attrs as Record<PropertyKey, any>)[FILE_FIELD_META];
@@ -155,7 +159,30 @@ module('Integration | markdown skill frontmatter', function (hooks) {
     );
   });
 
-  test('write -> read round-trip rehydrates frontmatter as SkillFrontmatterField with commands', async function (assert) {
+  test('the legacy boxel.commands key still parses into typed tools', async function (assert) {
+    let { MarkdownDef, SkillFrontmatterField } = await loadBase();
+    let url = `${testRealmURL}skills/realm-sync/SKILL.md`;
+    let attrs = await MarkdownDef.extractAttributes(
+      url,
+      streamOf(LEGACY_SKILL_MD),
+      {},
+    );
+
+    assert.strictEqual(attrs.kind, 'skill', 'kind still extracted');
+    assert.strictEqual(
+      attrs.frontmatter.tools[0].codeRef.name,
+      'SyncCommand',
+      'legacy boxel.commands entries land on the tools field',
+    );
+    let routed = (attrs as Record<PropertyKey, any>)[FILE_FIELD_META];
+    assert.deepEqual(
+      routed?.frontmatter?.adoptsFrom,
+      identifyCard(SkillFrontmatterField),
+      'legacy key still routes the SkillFrontmatterField marker',
+    );
+  });
+
+  test('write -> read round-trip rehydrates frontmatter as SkillFrontmatterField with tools', async function (assert) {
     let { MarkdownDef, SkillFrontmatterField } = await loadBase();
     let url = `${testRealmURL}skills/realm-sync/SKILL.md`;
     let attrs = await MarkdownDef.extractAttributes(
@@ -204,14 +231,61 @@ module('Integration | markdown skill frontmatter', function (hooks) {
       'rawContent survives round-trip',
     );
     assert.strictEqual(
-      instance.frontmatter.commands.length,
+      instance.frontmatter.tools.length,
       1,
-      'commands survive round-trip',
+      'tools survive round-trip',
+    );
+    assert.strictEqual(
+      instance.frontmatter.tools[0].codeRef.name,
+      'SyncCommand',
+      'tool codeRef survives round-trip',
+    );
+  });
+
+  test('a pre-rename index row (frontmatter.commands attribute) rehydrates via the legacy field', async function (assert) {
+    let { MarkdownDef, SkillFrontmatterField } = await loadBase();
+    let url = `${testRealmURL}skills/realm-sync/SKILL.md`;
+    let attrs = await MarkdownDef.extractAttributes(
+      url,
+      streamOf(SKILL_MD),
+      {},
+    );
+
+    let cleaned: Record<string, any> = { ...attrs };
+    let cleanedBag = cleaned as Record<PropertyKey, any>;
+    let fieldsMeta = cleanedBag[FILE_FIELD_META];
+    delete cleanedBag[FILE_FIELD_META];
+    // Rows extracted before the command → tool rename persisted the value
+    // under a `commands` attribute; simulate one by moving the key.
+    cleaned.frontmatter = { ...cleaned.frontmatter };
+    cleaned.frontmatter.commands = cleaned.frontmatter.tools;
+    delete cleaned.frontmatter.tools;
+
+    let resource = buildFileResource(
+      url,
+      cleaned,
+      identifyCard(MarkdownDef)!,
+      undefined,
+      fieldsMeta,
+    );
+    let instance: any = await createFromSerialized(
+      resource as any,
+      { data: resource } as any,
+      undefined,
+    );
+    assert.true(
+      instance.frontmatter instanceof SkillFrontmatterField,
+      'frontmatter still rehydrates as SkillFrontmatterField',
+    );
+    assert.strictEqual(
+      instance.frontmatter.tools.length,
+      0,
+      'the tools field is empty on a pre-rename row',
     );
     assert.strictEqual(
       instance.frontmatter.commands[0].codeRef.name,
       'SyncCommand',
-      'command codeRef survives round-trip',
+      'the legacy commands field carries the value until the realm reindexes',
     );
   });
 
@@ -221,7 +295,7 @@ module('Integration | markdown skill frontmatter', function (hooks) {
     // Unterminated flow mapping — valid `---` fences, invalid YAML inside.
     let badMarkdown = `---
 name: Bad Skill
-boxel: { kind: skill, commands: [
+boxel: { kind: skill, tools: [
 ---
 # Bad Skill
 

--- a/packages/host/tests/integration/markdown-skill-search-test.gts
+++ b/packages/host/tests/integration/markdown-skill-search-test.gts
@@ -28,7 +28,7 @@ name: Realm Sync
 description: Sync workspace files
 boxel:
   kind: skill
-  commands:
+  tools:
     - codeRef:
         module: '@cardstack/boxel-host/commands/realm-sync'
         name: SyncCommand
@@ -137,14 +137,14 @@ module('Integration | markdown skill search', function (hooks) {
       'frontmatter rehydrated as SkillFrontmatterField, not the base FrontmatterField',
     );
     assert.strictEqual(
-      instance.frontmatter.commands.length,
+      instance.frontmatter.tools.length,
       1,
-      'typed commands survive the realm file-meta read',
+      'typed tools survive the realm file-meta read',
     );
     assert.strictEqual(
-      instance.frontmatter.commands[0].codeRef.name,
+      instance.frontmatter.tools[0].codeRef.name,
       'SyncCommand',
-      'command codeRef survives the realm file-meta read',
+      'tool codeRef survives the realm file-meta read',
     );
   });
 });

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -491,9 +491,10 @@ export function isMarkdownSkillFile(fileDef: SerializedFileDef): boolean {
   return /\.(md|markdown)$/i.test(fileDef.sourceUrl ?? fileDef.name ?? '');
 }
 
-// A command a markdown skill contributes via its `boxel.commands`
-// frontmatter, with the functionName the host derives for the same code ref —
-// so getTools can match it against the room's uploaded command definitions.
+// A command a markdown skill contributes via its `boxel.tools` frontmatter
+// (or the pre-rename `boxel.commands` key), with the functionName the host
+// derives for the same code ref — so getTools can match it against the room's
+// uploaded command definitions.
 export interface MarkdownSkillCommand {
   codeRef: { module: string; name: string };
   functionName: string;
@@ -543,11 +544,13 @@ export function parseMarkdownSkill(
   return { title, body: body.trim(), kind, commands };
 }
 
-// Extracts `boxel.commands` from parsed frontmatter and computes each
-// command's functionName the way the host does when it uploads the room's
-// command definitions. Package specifiers (e.g. @cardstack/boxel-host/...)
-// resolve verbatim on the host, so hashing the literal module gives the same
-// name; relative modules resolve against the skill's own URL.
+// Extracts `boxel.tools` (falling back to the pre-rename `boxel.commands`
+// key; `tools` wins when both are present) from parsed frontmatter and
+// computes each command's functionName the way the host does when it uploads
+// the room's command definitions. Package specifiers (e.g.
+// @cardstack/boxel-host/...) resolve verbatim on the host, so hashing the
+// literal module gives the same name; relative modules resolve against the
+// skill's own URL.
 function markdownSkillCommands(
   frontmatter: Record<string, unknown>,
   skillUrl: string | undefined,
@@ -558,11 +561,16 @@ function markdownSkillCommands(
     !Array.isArray(frontmatter.boxel)
       ? (frontmatter.boxel as Record<string, unknown>)
       : undefined;
-  if (!Array.isArray(boxel?.commands)) {
+  let entries = Array.isArray(boxel?.tools)
+    ? boxel.tools
+    : Array.isArray(boxel?.commands)
+      ? boxel.commands
+      : undefined;
+  if (!entries) {
     return [];
   }
   let commands: MarkdownSkillCommand[] = [];
-  for (let entry of boxel.commands) {
+  for (let entry of entries) {
     let codeRef = (entry as { codeRef?: { module?: string; name?: string } })
       ?.codeRef;
     if (


### PR DESCRIPTION
## What

First slice of the platform-wide command → tool rename (CS-11788): the authored frontmatter key for skill-attached tools becomes `boxel.tools`, and `SkillFrontmatterField`'s typed field renames to `tools`. This is the persisted-content seam, so it ships with dual-read on every path that can encounter the old spelling.

## Dual-read, on both paths

- **YAML parsing** — `SkillFrontmatterField.fromFrontmatter` and ai-bot's `markdownSkillCommands` accept `boxel.tools` and the pre-rename `boxel.commands` (`tools` wins when both are present). Files authored before the rename keep working unmodified; the content-side flip across boxel-workspaces / boxel-skills lands separately.
- **Index-row rehydration** — rows extracted before the rename persist the value under a `frontmatter.commands` attribute and don't re-extract until their realm reindexes. A legacy `commands` field remains on `SkillFrontmatterField` so those rows hydrate, and `getSkillSourceCommands` falls back to it. The fallback is an empty-check rather than `??` because `containsMany` hydrates to `[]`, not `undefined`, when the attribute is absent.

`migrate-skill` now emits `boxel.tools`.

## Tests

- New: legacy-YAML-key parse (host integration + ai-bot), and a simulated pre-rename index row rehydrating through the legacy field.
- Updated fixtures/assertions in the markdown-skill frontmatter, search, and migrate-skill suites to the new key.
- ai-bot suite passes locally (the two `locking-test` failures are a local Postgres-role environment issue, present before this change); host type-check, runtime-common/ai-bot type-checks, and per-package lints are clean.

## Notes for deploy

The legacy field and fallbacks stay until realms are reindexed post-rename and the deprecation window closes (tracked on CS-11788). No reindex is *required* by this PR — old rows keep working through the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)