### PR TITLE
Rename Matrix wire keys command to tool with permanent dual-read (CS-12039)

### DIFF
--- a/packages/ai-bot/lib/code-patch-correctness.ts
+++ b/packages/ai-bot/lib/code-patch-correctness.ts
@@ -4,7 +4,7 @@ import type { RoomMessageEventContent } from 'matrix-js-sdk/lib/@types/events.js
 import { uuidv4 } from '@cardstack/runtime-common';
 import type { PendingCodePatchCorrectnessCheck } from '@cardstack/runtime-common/ai/types';
 import {
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_REL_TYPE,
 } from '@cardstack/runtime-common/matrix-constants';
@@ -47,7 +47,7 @@ export async function publishCodePatchCorrectnessMessage(
     content.data = data;
   }
   if (commandRequests.length) {
-    content[APP_BOXEL_COMMAND_REQUESTS_KEY] =
+    content[APP_BOXEL_TOOL_REQUESTS_KEY] =
       encodeCommandRequests(commandRequests);
   }
   await client.sendEvent(summary.roomId, 'm.room.message', content);

--- a/packages/ai-bot/lib/read-realm-file-fulfillment.ts
+++ b/packages/ai-bot/lib/read-realm-file-fulfillment.ts
@@ -2,10 +2,10 @@ import { createHash } from 'crypto';
 import { logger } from '@cardstack/runtime-common';
 import { sendMatrixEvent } from '@cardstack/runtime-common/ai';
 import {
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
+  APP_BOXEL_TOOL_RESULT_REL_TYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 import type { MatrixClient } from 'matrix-js-sdk';
 import type { ChatCompletionMessageToolCall } from 'openai/resources';
@@ -212,10 +212,10 @@ async function fulfillOne(
   }
 
   await publish(deps, {
-    msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+    msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
     commandRequestId: call.id,
     'm.relates_to': {
-      rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+      rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
       key: 'applied',
       event_id: deps.requestEventId,
     },
@@ -238,11 +238,11 @@ async function publishFailure(
   deps: ReadRealmFileFulfillmentDeps,
 ): Promise<ReadRealmFileFulfillmentOutcome> {
   await publish(deps, {
-    msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+    msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
     commandRequestId,
     failureReason: error,
     'm.relates_to': {
-      rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+      rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
       key: 'invalid',
       event_id: deps.requestEventId,
     },
@@ -262,7 +262,7 @@ async function publish(
     await sendMatrixEvent(
       deps.client,
       deps.roomId,
-      APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+      APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
       content,
       undefined,
     );

--- a/packages/ai-bot/lib/set-title.ts
+++ b/packages/ai-bot/lib/set-title.ts
@@ -17,7 +17,7 @@ import {
   attachedCardsToMessage,
   getRelevantCards,
 } from '@cardstack/runtime-common/ai';
-import { APP_BOXEL_COMMAND_REQUESTS_KEY } from '@cardstack/runtime-common/matrix-constants';
+import { getToolRequests } from '@cardstack/runtime-common/matrix-constants';
 
 const SET_TITLE_SYSTEM_MESSAGE = `You are a chat titling system, you must read the conversation and return a suggested title of no more than six words.
 Do NOT say talk or discussion or discussing or chat or chatting, this is implied by the context.
@@ -127,9 +127,9 @@ export const getLatestResultMessage = (
       | CommandResultWithNoOutputContent
   ).commandRequestId;
   if (commandRequestId) {
-    let commandRequests = (resultSourceEvent.content as CardMessageContent)[
-      APP_BOXEL_COMMAND_REQUESTS_KEY
-    ];
+    let commandRequests = getToolRequests<Partial<EncodedCommandRequest>>(
+      resultSourceEvent.content as CardMessageContent,
+    );
     if (commandRequests) {
       let commandRequest = commandRequests.find(
         (cr: Partial<EncodedCommandRequest>) => {

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -31,7 +31,7 @@ import {
   INITIAL_SLIDING_SYNC_LIST_TIMELINE_LIMIT,
   SLIDING_SYNC_TIMEOUT,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+  isToolResultEventType,
 } from '@cardstack/runtime-common/matrix-constants';
 
 import { handleDebugCommands } from './lib/debug.ts';
@@ -304,7 +304,7 @@ Common issues are:
         // answer.
         if (
           senderMatrixUserId === aiBotUserId &&
-          event.getType() === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+          isToolResultEventType(event.getType()) &&
           humanRoomMemberCount === 1
         ) {
           senderMatrixUserId = humanRoomMembers[0].userId;
@@ -435,11 +435,11 @@ Common issues are:
           let triggerCommandRequestId = (event.getContent() as any)
             ?.commandRequestId;
           if (
-            event.getType() === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+            isToolResultEventType(event.getType()) &&
             triggerCommandRequestId &&
             !eventList.some(
               (e: any) =>
-                e.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+                isToolResultEventType(e.type) &&
                 e.content?.commandRequestId === triggerCommandRequestId,
             )
           ) {

--- a/packages/ai-bot/tests/chat-titling-test.ts
+++ b/packages/ai-bot/tests/chat-titling-test.ts
@@ -10,11 +10,11 @@ import {
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
   APP_BOXEL_CODE_PATCH_RESULT_MSGTYPE,
   APP_BOXEL_CODE_PATCH_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
+  APP_BOXEL_TOOL_RESULT_REL_TYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
   APP_BOXEL_MESSAGE_MSGTYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 import type { IEvent, IRoomEvent, IStateEvent } from 'matrix-js-sdk';
@@ -383,7 +383,7 @@ module('shouldSetRoomTitle', () => {
           msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
           format: 'org.matrix.custom.html',
           body: 'patching card',
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               name: 'patchCardInstance',
               id: 'patchCardInstance-1',
@@ -405,14 +405,14 @@ module('shouldSetRoomTitle', () => {
 
   test('Set a title if the user applied a command', () => {
     let patchCommandResultEvent: Partial<IEvent> = {
-      type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+      type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
       content: {
         'm.relates_to': {
           event_id: '1',
           key: 'applied',
-          rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
         },
-        msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+        msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
       },
     };
     const eventLog: IRoomEvent[] = [
@@ -440,7 +440,7 @@ module('shouldSetRoomTitle', () => {
           msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
           format: 'org.matrix.custom.html',
           body: 'patching card',
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               name: 'patchCardInstance',
               id: 'patchCardInstance-1',
@@ -557,7 +557,7 @@ module('getLatestResultMessage', (hooks) => {
               functions: [],
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: commandRequestId,
               name: 'testCommand',
@@ -588,10 +588,10 @@ module('getLatestResultMessage', (hooks) => {
       getContent: () => ({
         'm.relates_to': {
           event_id: testEventId,
-          rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           key: 'applied',
         },
-        msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+        msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
         commandRequestId: commandRequestId,
       }),
     } as unknown as MatrixEvent;
@@ -631,7 +631,7 @@ module('getLatestResultMessage', (hooks) => {
               functions: [],
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'non-matching-id',
               name: 'testCommand',
@@ -653,10 +653,10 @@ module('getLatestResultMessage', (hooks) => {
       getContent: () => ({
         'm.relates_to': {
           event_id: 'test-event-id',
-          rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           key: 'applied',
         },
-        msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+        msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
         commandRequestId: 'missing-id', // ID that doesn't exist in the command requests
       }),
     } as unknown as MatrixEvent;
@@ -696,7 +696,7 @@ module('getLatestResultMessage', (hooks) => {
               functions: [],
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'first-command',
               name: 'firstCommand',
@@ -728,10 +728,10 @@ module('getLatestResultMessage', (hooks) => {
       getContent: () => ({
         'm.relates_to': {
           event_id: testEventId,
-          rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           key: 'applied',
         },
-        msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+        msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
         commandRequestId: commandRequestId,
       }),
     } as unknown as MatrixEvent;
@@ -801,7 +801,7 @@ module('setTitle', () => {
               functions: [],
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: commandRequestId,
               name: 'patchCardInstance',
@@ -851,10 +851,10 @@ module('setTitle', () => {
       getContent: () => ({
         'm.relates_to': {
           event_id: testEventId,
-          rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           key: 'applied',
         },
-        msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+        msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
         commandRequestId: commandRequestId,
       }),
     } as unknown as MatrixEvent;

--- a/packages/ai-bot/tests/code-patch-correctness-test.ts
+++ b/packages/ai-bot/tests/code-patch-correctness-test.ts
@@ -7,7 +7,7 @@ import type { PendingCodePatchCorrectnessCheck } from '@cardstack/runtime-common
 import {
   APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_REL_TYPE,
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
 } from '@cardstack/runtime-common/matrix-constants';
 import {
   decodeCommandRequest,
@@ -71,7 +71,7 @@ module('code patch correctness helpers', () => {
       'Should forward the context with the message',
     );
 
-    let encodedRequests = content[APP_BOXEL_COMMAND_REQUESTS_KEY];
+    let encodedRequests = content[APP_BOXEL_TOOL_REQUESTS_KEY];
     assert.true(
       Array.isArray(encodedRequests),
       'Command requests should be present',
@@ -150,7 +150,7 @@ module('code patch correctness helpers', () => {
     await publishCodePatchCorrectnessMessage(summary, client);
 
     let [event] = client.getSentEvents();
-    let encodedRequests = event.content[APP_BOXEL_COMMAND_REQUESTS_KEY];
+    let encodedRequests = event.content[APP_BOXEL_TOOL_REQUESTS_KEY];
     let decodedRequests = encodedRequests.map((request: any) =>
       decodeCommandRequest(request),
     );
@@ -207,7 +207,7 @@ module('code patch correctness helpers', () => {
     await publishCodePatchCorrectnessMessage(summary, client);
 
     let [event] = client.getSentEvents();
-    let encodedRequests = event.content[APP_BOXEL_COMMAND_REQUESTS_KEY];
+    let encodedRequests = event.content[APP_BOXEL_TOOL_REQUESTS_KEY];
     assert.notOk(
       encodedRequests,
       'Targets beyond the attempt limit should not emit correctness requests',

--- a/packages/ai-bot/tests/history-construction-test.ts
+++ b/packages/ai-bot/tests/history-construction-test.ts
@@ -1,9 +1,9 @@
 import QUnit from 'qunit';
 const { module, test, assert } = QUnit;
 import {
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
+  APP_BOXEL_TOOL_RESULT_REL_TYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
   APP_BOXEL_MESSAGE_MSGTYPE,
 } from '@cardstack/runtime-common';
 import {
@@ -507,16 +507,16 @@ module('constructHistory', (hooks) => {
 
     const eventlist: IRoomEvent[] = [
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         room_id: 'room-id-1',
         sender: '@tintinthong:localhost',
         content: {
           'm.relates_to': {
             event_id: 'command-event-id-1',
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
             key: 'applied',
           },
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
           commandRequestId: 'tool-call-id-1',
           data: JSON.stringify({
             card: {
@@ -539,16 +539,16 @@ module('constructHistory', (hooks) => {
     const result = await constructHistory(eventlist, fakeMatrixClient);
     assert.deepEqual(result, [
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         room_id: 'room-id-1',
         sender: '@tintinthong:localhost',
         content: {
           'm.relates_to': {
             event_id: 'command-event-id-1',
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
             key: 'applied',
           },
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
           commandRequestId: 'tool-call-id-1',
           data: {
             card: {

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -4,10 +4,10 @@ import { getPatchTool } from '@cardstack/runtime-common/helpers/ai';
 import type { ChatCompletionMessageFunctionToolCall } from 'openai/resources/chat/completions';
 import {
   APP_BOXEL_MESSAGE_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_REL_TYPE,
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
   APP_BOXEL_CODE_PATCH_RESULT_MSGTYPE,
   APP_BOXEL_CODE_PATCH_RESULT_REL_TYPE,
@@ -16,8 +16,12 @@ import {
   DEFAULT_FALLBACK_MODELS,
   DEFAULT_FALLBACK_MODEL_ID,
   APP_BOXEL_ACTIVE_LLM,
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
+  LEGACY_APP_BOXEL_COMMAND_REQUESTS_KEY,
+  LEGACY_APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+  LEGACY_APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+  LEGACY_APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 
 import type {
@@ -2608,7 +2612,7 @@ Attached Files (files with newer versions don't show their content):
               functions: [],
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'tool-call-id-1',
               name: 'searchCardsByTypeAndTitle',
@@ -2633,16 +2637,16 @@ Attached Files (files with newer versions don't show their content):
         status: EventStatus.SENT,
       },
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         room_id: 'room-id-1',
         sender: '@tintinthong:localhost',
         content: {
           'm.relates_to': {
             event_id: 'command-event-id-1',
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
             key: 'applied',
           },
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
           commandRequestId: 'tool-call-id-1',
           data: {
             card: {
@@ -2721,6 +2725,93 @@ Attached Files (files with newer versions don't show their content):
     const expected = `Tool call executed, with result card: {"data":{"type":"card","attributes":{"title":"Search Results","description":"Here are the search results","results":[{"data":{"type":"card","id":"http://localhost:4201/drafts/Author/1","attributes":{"firstName":"Alice","lastName":"Enwunder","photo":null,"body":"Alice is a software engineer at Google.","description":null,"thumbnailURL":null},"meta":{"adoptsFrom":{"module":"../author","name":"Author"}}}}]},"meta":{"adoptsFrom":{"module":"@cardstack/base/search-results","name":"SearchResults"}}}}.`;
 
     assert.equal((result[5].content as string).trim(), expected.trim());
+  });
+
+  test('pairs a pre-rename request/result (legacy wire keys) with the same tool_call_id', async () => {
+    // A room whose history predates the command → tool rename replays events
+    // with the legacy spellings forever; prompt assembly must pair them
+    // exactly as it pairs new-keyed events.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        room_id: 'room-id-1',
+        sender: '@user:localhost',
+        content: {
+          body: 'set the title',
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          data: { context: { tools: [], functions: [] } },
+        },
+        origin_server_ts: 1722242847000,
+        unsigned: { age: 1000, transaction_id: 't0' },
+        event_id: 'user-event-id-1',
+        status: EventStatus.SENT,
+      },
+      {
+        type: 'm.room.message',
+        room_id: 'room-id-1',
+        sender: '@aibot:localhost',
+        content: {
+          body: 'Setting the title',
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          data: { context: { functions: [] } },
+          [LEGACY_APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+            {
+              id: 'legacy-tool-call-id-1',
+              name: 'patchCardInstance',
+              arguments: JSON.stringify({
+                attributes: { description: 'Set the title' },
+              }),
+            },
+          ],
+        },
+        origin_server_ts: 1722242849000,
+        unsigned: { age: 900, transaction_id: 't1' },
+        event_id: 'legacy-command-event-id-1',
+        status: EventStatus.SENT,
+      },
+      {
+        type: LEGACY_APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        room_id: 'room-id-1',
+        sender: '@user:localhost',
+        content: {
+          'm.relates_to': {
+            event_id: 'legacy-command-event-id-1',
+            rel_type: LEGACY_APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            key: 'applied',
+          },
+          msgtype: LEGACY_APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+          commandRequestId: 'legacy-tool-call-id-1',
+          data: { context: { tools: [], functions: [] } },
+        },
+        origin_server_ts: 1722242853000,
+        unsigned: { age: 800, transaction_id: 't2' },
+        event_id: 'legacy-command-result-id-1',
+        status: EventStatus.SENT,
+      },
+    ];
+    const result = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      [],
+      [],
+      [],
+      fakeMatrixClient,
+    );
+    let assistantMessage = result.find((m) => m.role === 'assistant');
+    assert.ok(
+      assistantMessage?.tool_calls?.some(
+        (tc) => tc.id === 'legacy-tool-call-id-1',
+      ),
+      'the legacy-keyed request surfaces as a tool call',
+    );
+    let toolMessage = result.find((m) => m.role === 'tool');
+    assert.equal(
+      (toolMessage as { tool_call_id?: string })?.tool_call_id,
+      'legacy-tool-call-id-1',
+      'the legacy-typed result pairs with the same tool_call_id',
+    );
   });
 
   test('Tools remain available in prompt parts even when not in last message', async () => {
@@ -4107,7 +4198,7 @@ new content
               functions: [],
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'patch-card',
               name: 'patchCardInstance',
@@ -4163,17 +4254,17 @@ new content
         status: EventStatus.SENT,
       },
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         event_id: 'command-result',
         origin_server_ts: 4,
         room_id: roomId,
         sender: '@admin:localhost',
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
           'm.relates_to': {
             event_id: aiMessageId,
             key: 'applied',
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           },
           commandRequestId: 'patch-card',
           data: {
@@ -4261,7 +4352,7 @@ new content
               functions: [],
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'cancelled-patch',
               name: 'patchFields',
@@ -4330,7 +4421,7 @@ new content
               functions: [],
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'patch-card',
               name: 'patchCardInstance',
@@ -4386,17 +4477,17 @@ new content
         status: EventStatus.SENT,
       },
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         event_id: 'command-result',
         origin_server_ts: 4,
         room_id: roomId,
         sender: '@admin:localhost',
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
           'm.relates_to': {
             event_id: aiMessageId,
             key: 'applied',
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           },
           commandRequestId: 'patch-card',
           data: {
@@ -4486,7 +4577,7 @@ new content
               functions: [],
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'stale-command',
               name: 'patchFields',
@@ -4624,7 +4715,7 @@ new content
               functions: [],
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: `check-${requestId}`,
               name: 'checkCorrectness',
@@ -4655,18 +4746,18 @@ new content
       errorText: string,
     ): DiscreteMatrixEvent {
       return {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         event_id: `command-result-${index}`,
         room_id: roomId,
         sender: '@command:localhost',
         origin_server_ts: index * 10 + 3,
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
           commandRequestId: requestId,
           'm.relates_to': {
             event_id: relatesToId,
             key: 'applied',
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           },
           data: {
             card: {
@@ -4790,7 +4881,7 @@ new content
           body: 'First patch',
           format: 'org.matrix.custom.html',
           isStreamingFinished: true,
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'check-first',
               name: 'checkCorrectness',
@@ -4817,18 +4908,18 @@ new content
         status: EventStatus.SENT,
       },
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         event_id: 'command-result-1',
         room_id: roomId,
         sender: '@command:localhost',
         origin_server_ts: 2,
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
           commandRequestId: 'check-first',
           'm.relates_to': {
             event_id: firstEventId,
             key: 'applied',
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           },
           data: {
             card: {
@@ -4862,7 +4953,7 @@ new content
           body: 'Second patch',
           format: 'org.matrix.custom.html',
           isStreamingFinished: true,
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'check-second',
               name: 'checkCorrectness',
@@ -4889,18 +4980,18 @@ new content
         status: EventStatus.SENT,
       },
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         event_id: 'command-result-2',
         room_id: roomId,
         sender: '@command:localhost',
         origin_server_ts: 4,
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
           commandRequestId: 'check-second',
           'm.relates_to': {
             event_id: secondEventId,
             key: 'applied',
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           },
           data: {
             card: {
@@ -4998,7 +5089,7 @@ new
               functions: [],
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'check-1',
               name: 'checkCorrectness',
@@ -5049,18 +5140,18 @@ new
         status: EventStatus.SENT,
       },
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         event_id: '$command-result',
         room_id: roomId,
         sender: '@command:localhost',
         origin_server_ts: 4,
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
           commandRequestId: 'check-1',
           'm.relates_to': {
             event_id: aiMessageId,
             key: 'applied',
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           },
           data: {
             context: {
@@ -5336,7 +5427,7 @@ new
           msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
           format: 'org.matrix.custom.html',
           isStreamingFinished: true,
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'call_1',
               name: 'patchCardInstance',
@@ -5357,14 +5448,14 @@ new
         status: EventStatus.SENT,
       },
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         event_id: '3',
         origin_server_ts: 3,
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
           commandRequestId: 'call_1',
           'm.relates_to': {
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
             event_id: '2',
             key: 'applied',
           },
@@ -6479,7 +6570,7 @@ new
           format: 'org.matrix.custom.html',
           isStreamingFinished: true,
           data: {},
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: 'call_1',
               name: 'read-file-for-ai-assistant_a831',
@@ -6500,14 +6591,14 @@ new
         status: EventStatus.SENT,
       },
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         event_id: '3',
         origin_server_ts: 3,
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
           commandRequestId: 'call_1',
           'm.relates_to': {
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
             event_id: '2',
             key: 'applied',
           },
@@ -6650,7 +6741,7 @@ module('set model in prompt', (hooks) => {
           format: 'org.matrix.custom.html',
           isStreamingFinished: true,
           data: { context: {} },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: TOOL_CALL_ID,
               name: 'switch-submode_dd88',
@@ -6667,15 +6758,15 @@ module('set model in prompt', (hooks) => {
         status: EventStatus.SENT,
       } as DiscreteMatrixEvent,
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         room_id: 'room-id-1',
         sender: '@user:localhost',
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
           commandRequestId: TOOL_CALL_ID,
           'm.relates_to': {
             event_id: OLD_EVENT_ID,
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
             key: 'applied',
           },
           data: { context: {} },
@@ -6752,7 +6843,7 @@ module('set model in prompt', (hooks) => {
           format: 'org.matrix.custom.html',
           isStreamingFinished: true,
           data: { context: {} },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: TOOL_CALL_ID,
               name: 'switch-submode_dd88',
@@ -6769,15 +6860,15 @@ module('set model in prompt', (hooks) => {
         status: EventStatus.SENT,
       } as DiscreteMatrixEvent,
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         room_id: 'room-id-1',
         sender: '@user:localhost',
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
           commandRequestId: TOOL_CALL_ID,
           'm.relates_to': {
             event_id: BOT_EVENT_ID,
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
             key: 'applied',
           },
           data: { context: {} },
@@ -6857,7 +6948,7 @@ module('set model in prompt', (hooks) => {
           format: 'org.matrix.custom.html',
           isStreamingFinished: true,
           data: { context: {} },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: TOOL_CALL_SWITCH_SUBMODE,
               name: 'switch-submode_dd88',
@@ -6874,15 +6965,15 @@ module('set model in prompt', (hooks) => {
         status: EventStatus.SENT,
       } as DiscreteMatrixEvent,
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         room_id: 'room-id-1',
         sender: '@user:localhost',
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
           commandRequestId: TOOL_CALL_SWITCH_SUBMODE,
           'm.relates_to': {
             event_id: BOT1_EVENT_ID,
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
             key: 'applied',
           },
           data: { context: {} },
@@ -6905,7 +6996,7 @@ module('set model in prompt', (hooks) => {
           format: 'org.matrix.custom.html',
           isStreamingFinished: true,
           data: { context: {} },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: TOOL_CALL_WRITE_TEXT_FILE,
               name: 'write-text-file_e5a1',
@@ -6926,15 +7017,15 @@ module('set model in prompt', (hooks) => {
         status: EventStatus.SENT,
       } as DiscreteMatrixEvent,
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         room_id: 'room-id-1',
         sender: '@user:localhost',
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
           commandRequestId: TOOL_CALL_WRITE_TEXT_FILE,
           'm.relates_to': {
             event_id: BOT2_DRIFTED_EVENT_ID,
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
             key: 'applied',
           },
           data: { context: {} },
@@ -6960,7 +7051,7 @@ module('set model in prompt', (hooks) => {
             event_id: BOT2_EVENT_ID,
           },
           data: { context: {} },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: [
             {
               id: TOOL_CALL_CHECK_CORRECTNESS,
               name: 'checkCorrectness',
@@ -6984,15 +7075,15 @@ module('set model in prompt', (hooks) => {
         status: EventStatus.SENT,
       } as DiscreteMatrixEvent,
       {
-        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         room_id: 'room-id-1',
         sender: '@user:localhost',
         content: {
-          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+          msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
           commandRequestId: TOOL_CALL_CHECK_CORRECTNESS,
           'm.relates_to': {
             event_id: BOT3_EVENT_ID,
-            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+            rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
             key: 'applied',
           },
           data: { context: {} },
@@ -7379,7 +7470,11 @@ module('markdown skill commands', (hooks) => {
     );
   });
 
-  test('getTools offers a command definition matched by a markdown skill', async () => {
+  // Builds the room-skills state event + enabled skill for the getTools
+  // tests; `definitionsKey` selects which spelling the state event uses for
+  // its uploaded definitions ('toolDefinitions', or the pre-rename
+  // 'commandDefinitions' that old rooms replay).
+  function skillsRoomFixture(definitionsKey: string) {
     mockResponses.set('mxc://mock-server/switch-submode-def', {
       ok: true,
       text: JSON.stringify({
@@ -7414,7 +7509,7 @@ module('markdown skill commands', (hooks) => {
             },
           ],
           disabledSkillCards: [],
-          commandDefinitions: [
+          [definitionsKey]: [
             {
               sourceUrl: 'https://realm/commands/switch-submode',
               url: 'mxc://mock-server/switch-submode-def',
@@ -7441,7 +7536,24 @@ module('markdown skill commands', (hooks) => {
         attributes: { title, instructions: body, commands },
       } as unknown as LooseCardResource,
     ];
+    return { eventList, enabledSkills };
+  }
 
+  test('getTools offers a command definition matched by a markdown skill', async () => {
+    const { eventList, enabledSkills } = skillsRoomFixture('toolDefinitions');
+    const tools = await getTools(
+      eventList,
+      enabledSkills,
+      '@aibot:localhost',
+      fakeMatrixClient,
+    );
+    assert.strictEqual(tools.length, 1);
+    assert.strictEqual(tools[0].function.name, 'switch-submode_dd88');
+  });
+
+  test('getTools reads definitions from the pre-rename commandDefinitions state key', async () => {
+    const { eventList, enabledSkills } =
+      skillsRoomFixture('commandDefinitions');
     const tools = await getTools(
       eventList,
       enabledSkills,

--- a/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
@@ -4,9 +4,9 @@ const { module, test, assert } = QUnit;
 import { fulfillReadRealmFileCalls } from '../lib/read-realm-file-fulfillment.ts';
 import { READ_REALM_FILE_TOOL_NAME } from '../lib/read-realm-file.ts';
 import {
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 
 const ON_BEHALF_OF = '@user:localhost';
@@ -95,10 +95,10 @@ module('fulfillReadRealmFileCalls', () => {
     assert.deepEqual(outcomes, [{ commandRequestId: 'c1', ok: true }]);
     assert.strictEqual(sent.length, 1, 'one command-result event posted');
     let { eventType, content } = sent[0];
-    assert.strictEqual(eventType, APP_BOXEL_COMMAND_RESULT_EVENT_TYPE);
+    assert.strictEqual(eventType, APP_BOXEL_TOOL_RESULT_EVENT_TYPE);
     assert.strictEqual(
       content.msgtype,
-      APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+      APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
     );
     assert.strictEqual(content.commandRequestId, 'c1');
     assert.strictEqual(content['m.relates_to'].key, 'applied');
@@ -141,7 +141,7 @@ module('fulfillReadRealmFileCalls', () => {
     let { content } = sent[0];
     assert.strictEqual(
       content.msgtype,
-      APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+      APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
     );
     assert.strictEqual(content['m.relates_to'].key, 'applied');
     assert.notOk(content.failureReason, 'a clean read carries no failure note');
@@ -180,7 +180,7 @@ module('fulfillReadRealmFileCalls', () => {
     let { content } = sent[0];
     assert.strictEqual(
       content.msgtype,
-      APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+      APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
       'the successful file still comes back with output',
     );
     assert.strictEqual(
@@ -218,7 +218,7 @@ module('fulfillReadRealmFileCalls', () => {
     let { content } = sent[0];
     assert.strictEqual(
       content.msgtype,
-      APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+      APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
     );
     assert.strictEqual(content['m.relates_to'].key, 'invalid');
     assert.true(

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -8,7 +8,7 @@ import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
 import type { CommandRequest } from '@cardstack/runtime-common/commands';
 import {
   APP_BOXEL_REASONING_CONTENT_KEY,
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
 } from '@cardstack/runtime-common/matrix-constants';
@@ -305,7 +305,7 @@ module('Responding', (hooks) => {
       'Initial body should be empty',
     );
     assert.deepEqual(
-      sentEvents[1].content[APP_BOXEL_COMMAND_REQUESTS_KEY],
+      sentEvents[1].content[APP_BOXEL_TOOL_REQUESTS_KEY],
       [
         {
           id: 'some-tool-call-id',
@@ -391,7 +391,7 @@ module('Responding', (hooks) => {
       'Initial body should be empty',
     );
     assert.deepEqual(
-      sentEvents[2].content[APP_BOXEL_COMMAND_REQUESTS_KEY],
+      sentEvents[2].content[APP_BOXEL_TOOL_REQUESTS_KEY],
       [
         {
           name: 'patchCardInstance',
@@ -401,7 +401,7 @@ module('Responding', (hooks) => {
       'Partial tool call event should be sent with correct content',
     );
     assert.deepEqual(
-      sentEvents[3].content[APP_BOXEL_COMMAND_REQUESTS_KEY],
+      sentEvents[3].content[APP_BOXEL_TOOL_REQUESTS_KEY],
       [
         {
           id: 'some-tool-call-id',
@@ -523,7 +523,7 @@ module('Responding', (hooks) => {
       'Initial body should be empty',
     );
     assert.deepEqual(
-      sentEvents[2].content[APP_BOXEL_COMMAND_REQUESTS_KEY],
+      sentEvents[2].content[APP_BOXEL_TOOL_REQUESTS_KEY],
       [
         {
           id: 'tool-call-1-id',
@@ -610,7 +610,7 @@ module('Responding', (hooks) => {
       'Thinking message, and event with content, and event with one tool call should be sent',
     );
     assert.deepEqual(
-      sentEvents[2].content[APP_BOXEL_COMMAND_REQUESTS_KEY],
+      sentEvents[2].content[APP_BOXEL_TOOL_REQUESTS_KEY],
       [
         {
           id: 'tool-call-1-id',

--- a/packages/base/matrix-event.gts
+++ b/packages/base/matrix-event.gts
@@ -10,11 +10,12 @@ import type {
   APP_BOXEL_CODE_PATCH_RESULT_MSGTYPE,
   APP_BOXEL_CODE_PATCH_RESULT_REL_TYPE,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE,
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
+  LEGACY_APP_BOXEL_COMMAND_REQUESTS_KEY,
+  ToolResultEventType,
+  ToolResultRelType,
+  ToolResultWithNoOutputMsgtype,
+  ToolResultWithOutputMsgtype,
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
@@ -249,7 +250,10 @@ export interface CardMessageContent {
   [APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY]?: boolean;
   [APP_BOXEL_CONTINUATION_OF_CONTENT_KEY]?: string; // event_id of the message we are continuing
   [APP_BOXEL_REASONING_CONTENT_KEY]?: string;
-  [APP_BOXEL_COMMAND_REQUESTS_KEY]?: Partial<EncodedCommandRequest>[];
+  [APP_BOXEL_TOOL_REQUESTS_KEY]?: Partial<EncodedCommandRequest>[];
+  // Replay-only: messages written before the command → tool rename carry
+  // their requests under this key. Read via `getToolRequests`; never write.
+  [LEGACY_APP_BOXEL_COMMAND_REQUESTS_KEY]?: Partial<EncodedCommandRequest>[];
   errorMessage?: string;
   // ID from the client and can be used by client
   // to verify whether the message is already sent or not.
@@ -267,6 +271,9 @@ export interface SkillsConfigEvent extends RoomStateEvent {
   content: {
     enabledSkillCards: SerializedFile[];
     disabledSkillCards: SerializedFile[];
+    toolDefinitions?: SerializedFile[];
+    // Replay-only: state written before the command → tool rename. Read via
+    // `getToolDefinitions`; never write.
     commandDefinitions?: SerializedFile[];
   };
 }
@@ -289,7 +296,7 @@ export interface LLMModeEvent extends RoomStateEvent {
 }
 
 export interface CommandResultEvent extends BaseMatrixEvent {
-  type: typeof APP_BOXEL_COMMAND_RESULT_EVENT_TYPE;
+  type: ToolResultEventType;
   content: CommandResultWithOutputContent | CommandResultWithNoOutputContent;
   unsigned: {
     age: number;
@@ -336,7 +343,7 @@ export type CommandResultStatus = 'applied' | 'failed' | 'invalid';
 
 export interface CommandResultWithOutputContent {
   'm.relates_to': {
-    rel_type: typeof APP_BOXEL_COMMAND_RESULT_REL_TYPE;
+    rel_type: ToolResultRelType;
     key: CommandResultStatus;
     event_id: string;
   };
@@ -352,16 +359,16 @@ export interface CommandResultWithOutputContent {
     attachedFiles?: (SerializedFile & { content?: string; error?: string })[];
     attachedCards?: (SerializedFile & { content?: string; error?: string })[];
   };
-  msgtype: typeof APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE;
+  msgtype: ToolResultWithOutputMsgtype;
 }
 
 export interface CommandResultWithNoOutputContent {
   'm.relates_to': {
-    rel_type: typeof APP_BOXEL_COMMAND_RESULT_REL_TYPE;
+    rel_type: ToolResultRelType;
     key: CommandResultStatus;
     event_id: string;
   };
-  msgtype: typeof APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE;
+  msgtype: ToolResultWithNoOutputMsgtype;
   commandRequestId: string;
   failureReason?: string; // only present if status is 'failed' or 'invalid'
   data: {

--- a/packages/host/app/commands/create-ai-assistant-room.ts
+++ b/packages/host/app/commands/create-ai-assistant-room.ts
@@ -205,7 +205,7 @@ export default class CreateAiAssistantRoomCommand extends HostBaseCommand<
               disabledSkillCards: disabled.fileDefs.map((fileDef) =>
                 fileDef.serialize(),
               ),
-              commandDefinitions: commandFileDefs.map((commandFileDef) =>
+              toolDefinitions: commandFileDefs.map((commandFileDef) =>
                 commandFileDef.serialize(),
               ),
             },

--- a/packages/host/app/commands/update-room-skills.ts
+++ b/packages/host/app/commands/update-room-skills.ts
@@ -1,6 +1,9 @@
 import { service } from '@ember/service';
 
-import { APP_BOXEL_ROOM_SKILLS_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
+import {
+  APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
+  getToolDefinitions,
+} from '@cardstack/runtime-common/matrix-constants';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
@@ -172,8 +175,9 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
           (skill): skill is SkillSource => Boolean(skill),
         );
 
-        let previousCommandDefinitions =
-          (currentSkillsConfig.commandDefinitions ?? []) as SerializedFile[];
+        let previousCommandDefinitions = (getToolDefinitions(
+          currentSkillsConfig,
+        ) ?? []) as SerializedFile[];
         let serializedCommandDefinitions: SerializedFile[] = [
           ...previousCommandDefinitions,
         ];
@@ -202,11 +206,16 @@ export default class UpdateRoomSkillsCommand extends HostBaseCommand<
           serializedCommandDefinitions = [];
         }
 
+        // Write only the tool-named key; a pre-rename room's state may carry
+        // `commandDefinitions`, which must not survive the rewrite or it would
+        // shadow nothing but confuse readers of raw state.
+        let { commandDefinitions: _legacyDefinitions, ...restOfSkillsConfig } =
+          currentSkillsConfig;
         return {
-          ...currentSkillsConfig,
+          ...restOfSkillsConfig,
           enabledSkillCards: Array.from(enabledSkillCardMap.values()),
           disabledSkillCards: Array.from(disabledSkillCardMap.values()),
-          commandDefinitions: serializedCommandDefinitions,
+          toolDefinitions: serializedCommandDefinitions,
         };
       },
     );

--- a/packages/host/app/commands/utils.ts
+++ b/packages/host/app/commands/utils.ts
@@ -1,9 +1,9 @@
 import { getOwner } from '@ember/owner';
 
 import {
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+  getToolRequests,
+  isToolResultEventType,
+  isToolResultRelType,
   decodeCommandRequest,
   type CommandContext,
   type CommandRequest,
@@ -20,6 +20,7 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type {
   CardMessageEvent,
   CommandResultEvent,
+  EncodedCommandRequest,
   MatrixEvent,
   RealmEventContent,
   Tool,
@@ -81,10 +82,11 @@ export async function waitForCompletedCommandRequest(
         : matrixEvents;
       let commandResultEvents = events.filter(
         (e) =>
-          e.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
-          e.content['m.relates_to']?.rel_type ===
-            APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
-          e.content['m.relates_to']?.key === 'applied',
+          isToolResultEventType(e.type) &&
+          isToolResultRelType(
+            (e as CommandResultEvent).content['m.relates_to']?.rel_type,
+          ) &&
+          (e as CommandResultEvent).content['m.relates_to']?.key === 'applied',
       ) as CommandResultEvent[];
       return commandResultEvents.some((commandResultEvent) => {
         let eventWithRequest = events.find(
@@ -95,7 +97,9 @@ export async function waitForCompletedCommandRequest(
           return false;
         }
         let commandRequests =
-          eventWithRequest.content[APP_BOXEL_COMMAND_REQUESTS_KEY] ?? [];
+          getToolRequests<Partial<EncodedCommandRequest>>(
+            eventWithRequest.content,
+          ) ?? [];
         let commandRequest = commandRequests.find(
           (commandRequest) =>
             commandRequest.id === commandResultEvent.content.commandRequestId,

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -11,6 +11,7 @@ import {
   baseRealm,
   codeRefWithAbsoluteIdentifier,
   getClass,
+  getToolDefinitions,
   inferContentType,
   SupportedMimeType,
   relativeTo,
@@ -696,7 +697,7 @@ export default class FileDefManagerImpl
       const skillsAndCommands = [
         ...(skillsContent.enabledSkillCards || []),
         ...(skillsContent.disabledSkillCards || []),
-        ...(skillsContent.commandDefinitions || []),
+        ...(getToolDefinitions<SerializedFile>(skillsContent) || []),
       ];
 
       for (const skillOrCommand of skillsAndCommands) {

--- a/packages/host/app/lib/matrix-classes/message-builder.ts
+++ b/packages/host/app/lib/matrix-classes/message-builder.ts
@@ -14,11 +14,12 @@ import {
   decodeCommandRequest,
 } from '@cardstack/runtime-common/commands';
 import {
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+  getToolRequests,
+  isToolResultEventType,
+  isToolResultRelType,
+  isToolResultWithNoOutputMsgtype,
+  isToolResultWithOutputContent,
+  isToolResultWithOutputMsgtype,
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
@@ -49,6 +50,7 @@ import type {
   CodePatchResultEvent,
   DebugMessageEvent,
   CommandResultEvent,
+  EncodedCommandRequest,
   MatrixEvent as DiscreteMatrixEvent,
   MessageEvent,
 } from 'https://cardstack.com/base/matrix-event';
@@ -183,7 +185,7 @@ export default class MessageBuilder {
       message.reloadBillingData = shouldReloadBillingData(event.content);
       message.attachedCardIds = this.attachedCardIds;
       message.attachedCardsAsFiles = this.attachedCardsAsFiles;
-      if (event.content[APP_BOXEL_COMMAND_REQUESTS_KEY]) {
+      if (getToolRequests(event.content)) {
         message.setCommands(await this.buildMessageCommands(message));
       }
       message.codePatchResults = this.buildMessageCodePatchResults(message);
@@ -244,9 +246,9 @@ export default class MessageBuilder {
     }
 
     let encodedCommandRequests =
-      (this.event.content as CardMessageContent)[
-        APP_BOXEL_COMMAND_REQUESTS_KEY
-      ] ?? [];
+      getToolRequests<Partial<EncodedCommandRequest>>(
+        this.event.content as CardMessageContent,
+      ) ?? [];
     for (let encodedCommandRequest of encodedCommandRequests) {
       let command = message.commands.find(
         (c) => c.commandRequest.id === encodedCommandRequest.id,
@@ -272,10 +274,8 @@ export default class MessageBuilder {
     if (this.builderContext.commandResultEvent && message.commands.length > 0) {
       let event = this.builderContext.commandResultEvent;
       if (
-        event.content.msgtype ===
-          APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE ||
-        event.content.msgtype ===
-          APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE
+        isToolResultWithOutputMsgtype(event.content.msgtype) ||
+        isToolResultWithNoOutputMsgtype(event.content.msgtype)
       ) {
         let commandRequestId = event.content.commandRequestId;
         let messageCommand = message.commands.find(
@@ -284,11 +284,11 @@ export default class MessageBuilder {
         if (messageCommand) {
           messageCommand.commandStatus = event.content['m.relates_to']
             .key as CommandStatus;
-          messageCommand.commandResultFileDef =
-            event.content.msgtype ===
-            APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE
-              ? event.content.data.card
-              : undefined;
+          messageCommand.commandResultFileDef = isToolResultWithOutputContent(
+            event.content,
+          )
+            ? event.content.data.card
+            : undefined;
           messageCommand.failureReason = event.content.failureReason;
         }
       }
@@ -301,7 +301,8 @@ export default class MessageBuilder {
 
   private async buildMessageCommands(message: Message) {
     let eventContent = this.event.content as CardMessageContent;
-    let commandRequests = eventContent[APP_BOXEL_COMMAND_REQUESTS_KEY];
+    let commandRequests =
+      getToolRequests<Partial<EncodedCommandRequest>>(eventContent);
     if (!commandRequests) {
       return new TrackedArray<MessageCommand>();
     }
@@ -332,8 +333,8 @@ export default class MessageBuilder {
         // across edits and present on every one, so it resolves the command on
         // both the live and reload paths.
         return (
-          e.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
-          r?.rel_type === APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
+          isToolResultEventType(e.type) &&
+          isToolResultRelType(r?.rel_type) &&
           e.content.commandRequestId === commandRequest.id
         );
       }) as CommandResultEvent | undefined);
@@ -404,8 +405,8 @@ export default class MessageBuilder {
       requiresApproval,
       actionVerb,
       commandStatus,
-      commandResultEvent?.content.msgtype ===
-        APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE
+      commandResultEvent &&
+        isToolResultWithOutputContent(commandResultEvent.content)
         ? commandResultEvent.content.data.card
         : undefined,
       getOwner(this)!,

--- a/packages/host/app/lib/matrix-classes/room.ts
+++ b/packages/host/app/lib/matrix-classes/room.ts
@@ -6,6 +6,7 @@ import {
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
   APP_BOXEL_LLM_MODE,
+  getToolDefinitions,
   type LLMMode,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -95,7 +96,7 @@ export default class Room {
       disabledSkillCards: content.disabledSkillCards
         ? content.disabledSkillCards
         : [],
-      commandDefinitions: content.commandDefinitions ?? [],
+      commandDefinitions: getToolDefinitions<SerializedFile>(content) ?? [],
     } as {
       enabledSkillCards: SerializedFile[];
       disabledSkillCards: SerializedFile[];

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -20,9 +20,10 @@ import type { CommandRequest } from '@cardstack/runtime-common/commands';
 import {
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
+  LEGACY_APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+  getToolRequests,
+  isToolResultRelType,
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
   APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE,
   APP_BOXEL_LLM_MODE,
@@ -200,7 +201,8 @@ export class RoomResource extends Resource<Args> {
           case APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE:
             await this.loadRoomMessage({ roomId, event, index });
             break;
-          case APP_BOXEL_COMMAND_RESULT_EVENT_TYPE:
+          case APP_BOXEL_TOOL_RESULT_EVENT_TYPE:
+          case LEGACY_APP_BOXEL_COMMAND_RESULT_EVENT_TYPE:
             await this.updateMessageCommandResult({ roomId, event, index });
             break;
           case APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE:
@@ -734,7 +736,7 @@ export class RoomResource extends Resource<Args> {
     let messageEventWithCommand = this.events.find(
       (e: any) =>
         e.type === 'm.room.message' &&
-        e.content[APP_BOXEL_COMMAND_REQUESTS_KEY]?.some(
+        getToolRequests(e.content)?.some(
           (cr: any) => cr.id === event.content.commandRequestId,
         ),
     ) as CardMessageEvent | undefined;
@@ -820,8 +822,7 @@ export class RoomResource extends Resource<Args> {
     }
 
     return event.content['m.relates_to']?.rel_type === 'm.replace' ||
-      event.content['m.relates_to']?.rel_type ===
-        APP_BOXEL_COMMAND_RESULT_REL_TYPE
+      isToolResultRelType(event.content['m.relates_to']?.rel_type)
       ? event.content['m.relates_to'].event_id
       : event.event_id;
   }

--- a/packages/host/app/services/ai-assistant-panel-service.ts
+++ b/packages/host/app/services/ai-assistant-panel-service.ts
@@ -498,7 +498,7 @@ export default class AiAssistantPanelService extends Service {
           content: {
             enabledSkillCards: [],
             disabledSkillCards: [],
-            commandDefinitions: [],
+            toolDefinitions: [],
           },
         },
       ],

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -26,7 +26,7 @@ import {
 
 import { AI_BOT_EXECUTOR } from '@cardstack/runtime-common/commands';
 import { basicMappings } from '@cardstack/runtime-common/helpers/ai';
-import { APP_BOXEL_COMMAND_REQUESTS_KEY } from '@cardstack/runtime-common/matrix-constants';
+import { getToolRequests } from '@cardstack/runtime-common/matrix-constants';
 
 import CheckCorrectnessCommand from '@cardstack/host/commands/check-correctness';
 import PatchCodeCommand from '@cardstack/host/commands/patch-code';
@@ -660,7 +660,7 @@ export default class CommandService extends Service {
       if (e?.type !== 'm.room.message') {
         continue;
       }
-      let requests = e.content?.[APP_BOXEL_COMMAND_REQUESTS_KEY];
+      let requests = getToolRequests(e.content);
       if (
         Array.isArray(requests) &&
         requests.some((r: any) => r?.id === commandRequestId)

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -53,10 +53,10 @@ import {
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
   APP_BOXEL_CODE_PATCH_RESULT_MSGTYPE,
   APP_BOXEL_CODE_PATCH_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
+  APP_BOXEL_TOOL_RESULT_REL_TYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
   APP_BOXEL_MESSAGE_MSGTYPE,
   APP_BOXEL_REALM_EVENT_TYPE,
   APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE,
@@ -76,7 +76,7 @@ import {
   SLIDING_SYNC_LIST_RANGE_END,
   SLIDING_SYNC_TIMEOUT,
   type LLMMode,
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  getToolRequests,
   APP_BOXEL_SYSTEM_CARD_EVENT_TYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -1393,7 +1393,7 @@ export default class MatrixService extends Service {
             ...enabledMarkdownSkillFileDefs,
           ].map((fileDef) => fileDef.serialize()),
           disabledSkillCards: currentSkillsConfig?.disabledSkillCards ?? [],
-          commandDefinitions: enabledCommandDefFileDefs.map((fileDef) =>
+          toolDefinitions: enabledCommandDefFileDefs.map((fileDef) =>
             fileDef.serialize(),
           ),
         };
@@ -1485,23 +1485,23 @@ export default class MatrixService extends Service {
       | CommandResultWithOutputContent;
     if (resultCardFileDef === undefined) {
       content = {
-        msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+        msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
         commandRequestId: params.toolCallId,
         failureReason: params.failureReason,
         'm.relates_to': {
           event_id: params.invokedToolFromEventId,
           key: params.status,
-          rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
         },
         data: contentData,
       };
     } else {
       content = {
-        msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+        msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
         'm.relates_to': {
           event_id: params.invokedToolFromEventId,
           key: params.status,
-          rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
         },
         commandRequestId: params.toolCallId,
         failureReason: params.failureReason,
@@ -1514,7 +1514,7 @@ export default class MatrixService extends Service {
     try {
       return await this.sendEvent(
         params.roomId,
-        APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
         content,
       );
     } catch (e) {
@@ -2745,7 +2745,7 @@ export default class MatrixService extends Service {
 
     if (
       event.type === 'm.room.message' &&
-      event.content?.[APP_BOXEL_COMMAND_REQUESTS_KEY]?.length &&
+      getToolRequests(event.content)?.length &&
       event.content?.isStreamingFinished
     ) {
       this.commandService.queueEventForCommandProcessing(event);

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -24,7 +24,7 @@ import {
   APP_BOXEL_CODE_PATCH_RESULT_MSGTYPE,
   APP_BOXEL_MESSAGE_MSGTYPE,
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_LLM_MODE,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -399,7 +399,7 @@ ${REPLACE_MARKER}
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'abc123',
           name: 'show-card_566f',
@@ -653,7 +653,7 @@ ${REPLACE_MARKER}
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'abc123',
           name: 'show-card_566f',

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -25,12 +25,12 @@ import {
 } from '@cardstack/runtime-common';
 
 import {
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
+  APP_BOXEL_TOOL_RESULT_REL_TYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
   APP_BOXEL_LLM_MODE,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -610,7 +610,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           name: 'patchCardInstance',
           id: '794c52f1-b444-47bd-8b2c-5d03ba7ef042',
@@ -714,7 +714,7 @@ module('Acceptance | Commands tests', function (hooks) {
         stateKey: (e as any).state_key,
         msgtype: (e.content as any)?.msgtype,
         hasCommandRequests: Array.isArray(
-          (e.content as any)?.[APP_BOXEL_COMMAND_REQUESTS_KEY],
+          (e.content as any)?.[APP_BOXEL_TOOL_REQUESTS_KEY],
         ),
       }));
       console.error(
@@ -779,7 +779,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'abc123',
           name: 'switch-submode_dd88',
@@ -814,8 +814,7 @@ module('Acceptance | Commands tests', function (hooks) {
         getRoomIds().length > 0 &&
         getRoomEvents(roomId).find(
           (m) =>
-            m.content.msgtype ===
-            APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+            m.content.msgtype === APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
         ),
       {
         timeout: 5000,
@@ -823,16 +822,15 @@ module('Acceptance | Commands tests', function (hooks) {
       },
     );
     let message = getRoomEvents(roomId).find(
-      (m) =>
-        m.content.msgtype === APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+      (m) => m.content.msgtype === APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
     )!;
     assert.strictEqual(
       message.content.msgtype,
-      APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+      APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
     );
     assert.strictEqual(
       message.content['m.relates_to']?.rel_type,
-      APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+      APP_BOXEL_TOOL_RESULT_REL_TYPE,
     );
     assert.strictEqual(message.content['m.relates_to']?.key, 'applied');
     assert.strictEqual(message.content.commandRequestId, 'abc123');
@@ -859,7 +857,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '29e8addb-197b-4d6d-b0a9-547959bf7c96',
           name: buildCommandFunctionName(
@@ -899,11 +897,11 @@ module('Acceptance | Commands tests', function (hooks) {
     let message = getRoomEvents(roomId).pop()!;
     assert.strictEqual(
       message.content.msgtype,
-      APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+      APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
     );
     assert.strictEqual(
       message.content['m.relates_to']?.rel_type,
-      APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+      APP_BOXEL_TOOL_RESULT_REL_TYPE,
     );
     assert.strictEqual(message.content['m.relates_to']?.key, 'applied');
     assert.strictEqual(
@@ -933,7 +931,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '29e8addb-197b-4d6d-b0a9-547959bf7c96',
           name: buildCommandFunctionName(
@@ -982,7 +980,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: false,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'preparing-command-id',
           name: 'switch-submode_dd88',
@@ -1042,7 +1040,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '1554f297-e9f2-43fe-8b95-55b29251444d',
           name: 'show-card_566f',
@@ -1124,11 +1122,11 @@ module('Acceptance | Commands tests', function (hooks) {
     let message = getRoomEvents(roomId).pop()!;
     assert.strictEqual(
       message.content.msgtype,
-      APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+      APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
     );
     assert.strictEqual(
       message.content['m.relates_to']?.rel_type,
-      APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+      APP_BOXEL_TOOL_RESULT_REL_TYPE,
     );
     assert.strictEqual(message.content['m.relates_to']?.key, 'applied');
     assert.strictEqual(
@@ -1171,7 +1169,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '1554f297-e9f2-43fe-8b95-55b29251444d',
           name: 'show-card_566f',
@@ -1215,7 +1213,7 @@ module('Acceptance | Commands tests', function (hooks) {
       body: 'Checking the current UI state and searching for cards',
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'a4237eca-b73e-4256-bf3a-45849fa07d02',
           name: 'switch-submode_dd88',
@@ -1269,7 +1267,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: commandId,
           name: 'switch-submode_dd88',
@@ -1308,7 +1306,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: commandId2,
           name: 'switch-submode_dd88',
@@ -1345,7 +1343,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: commandId3,
           name: 'switch-submode_dd88',
@@ -1393,7 +1391,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: commandId4,
           name: 'switch-submode_dd88',
@@ -1447,7 +1445,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '1554f297-e9f2-43fe-8b95-55b29251444d',
           name: 'no-such-command',
@@ -1482,11 +1480,11 @@ module('Acceptance | Commands tests', function (hooks) {
     let message = getRoomEvents(roomId).pop()!;
     assert.strictEqual(
       message.content.msgtype,
-      APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+      APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
     );
     assert.strictEqual(
       message.content['m.relates_to']?.rel_type,
-      APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+      APP_BOXEL_TOOL_RESULT_REL_TYPE,
     );
     assert.strictEqual(message.content['m.relates_to']?.key, 'invalid');
     assert.strictEqual(
@@ -1532,7 +1530,7 @@ module('Acceptance | Commands tests', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '1554f297-e9f2-43fe-8b95-55b29251444d',
           name: 'show-card_566f',
@@ -1597,11 +1595,11 @@ module('Acceptance | Commands tests', function (hooks) {
     let message = getRoomEvents(roomId).pop()!;
     assert.strictEqual(
       message.content.msgtype,
-      APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+      APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
     );
     assert.strictEqual(
       message.content['m.relates_to']?.rel_type,
-      APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+      APP_BOXEL_TOOL_RESULT_REL_TYPE,
     );
     assert.strictEqual(message.content['m.relates_to']?.key, 'invalid');
     assert.strictEqual(
@@ -1640,7 +1638,7 @@ module('Acceptance | Commands tests', function (hooks) {
         msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
         format: 'org.matrix.custom.html',
         isStreamingFinished: true,
-        [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+        [APP_BOXEL_TOOL_REQUESTS_KEY]: [
           {
             id: '2dd27b90-b473-403c-a5ae-399a29af7d62',
             name: 'maybe-boom-command_4b30',
@@ -1659,7 +1657,7 @@ module('Acceptance | Commands tests', function (hooks) {
 
       await settled();
       let commandResultEvents = await getRoomEvents(roomId).filter(
-        (event) => event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        (event) => event.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
       );
       assert.strictEqual(
         commandResultEvents.length,
@@ -1669,7 +1667,7 @@ module('Acceptance | Commands tests', function (hooks) {
       maybeBoomShouldBoom = false;
       await click('[data-test-alert-action-button="Retry"]');
       commandResultEvents = await getRoomEvents(roomId).filter(
-        (event) => event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        (event) => event.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
       );
       assert.strictEqual(
         commandResultEvents.length,

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -14,7 +14,7 @@ import { BOT_TRIGGER_EVENT_TYPE } from '@cardstack/runtime-common';
 import { canonicalizeMatrixMediaKey } from '@cardstack/runtime-common/ai/matrix-utils';
 import {
   APP_BOXEL_ACTIVE_LLM,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
   APP_BOXEL_REALMS_EVENT_TYPE,
   APP_BOXEL_REALM_SERVERS_EVENT_TYPE,
@@ -682,7 +682,7 @@ export class MockClient implements ExtendedClient {
         return this.sdk.ClientEvent.AccountData;
       case APP_BOXEL_ROOM_SKILLS_EVENT_TYPE:
       case APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE:
-      case APP_BOXEL_COMMAND_RESULT_EVENT_TYPE:
+      case APP_BOXEL_TOOL_RESULT_EVENT_TYPE:
       case APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE:
       case APP_BOXEL_ACTIVE_LLM:
       case APP_BOXEL_REALM_EVENT_TYPE:

--- a/packages/host/tests/integration/commands/update-room-skills-test.gts
+++ b/packages/host/tests/integration/commands/update-room-skills-test.gts
@@ -228,7 +228,7 @@ Instructions live in the markdown body.
         'no skills are disabled',
       );
       assert.ok(
-        skillsRoomState.commandDefinitions.length > 0,
+        skillsRoomState.toolDefinitions.length > 0,
         'command definitions populated',
       );
       let uploadedContents = mockMatrixUtils.getUploadedContents();
@@ -281,7 +281,7 @@ Instructions live in the markdown body.
         'skill added to disabled list',
       );
       assert.strictEqual(
-        skillsRoomState.commandDefinitions.length,
+        skillsRoomState.toolDefinitions.length,
         0,
         'command definitions cleared when no skills enabled',
       );
@@ -334,7 +334,7 @@ Instructions live in the markdown body.
         'skill removed from disabled list',
       );
       assert.ok(
-        skillsRoomState.commandDefinitions.length > 0,
+        skillsRoomState.toolDefinitions.length > 0,
         'command definitions restored for reactivated skill',
       );
       let uploadedContents = mockMatrixUtils.getUploadedContents();
@@ -398,7 +398,7 @@ Instructions live in the markdown body.
         'no skills are disabled',
       );
 
-      let commandDefSourceUrls = skillsRoomState.commandDefinitions.map(
+      let commandDefSourceUrls = skillsRoomState.toolDefinitions.map(
         (def: any) => def.sourceUrl,
       );
       assert.deepEqual(
@@ -433,7 +433,7 @@ Instructions live in the markdown body.
       );
       // Both skills point at the same command; deduped by functionName to one.
       assert.deepEqual(
-        skillsRoomState.commandDefinitions.map((def: any) => def.sourceUrl),
+        skillsRoomState.toolDefinitions.map((def: any) => def.sourceUrl),
         [`${testRealmURL}test-command.gts/DoThing`],
         'the shared command is uploaded once across both skill sources',
       );

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -10,10 +10,10 @@ import { baseRealm, skillCardRef } from '@cardstack/runtime-common';
 import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
+  APP_BOXEL_TOOL_RESULT_REL_TYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
@@ -364,7 +364,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           name: 'patchCardInstance',
           arguments: JSON.stringify({
@@ -418,7 +418,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Changing first name to Evie',
       format: 'org.matrix.custom.html',
       isStreamingFinished: false,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '6545dc5a-01a1-47d6-b2f7-493d2ff5a0c2',
           name: 'patchCardInstance',
@@ -449,7 +449,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'fb8fef81-2142-4861-a902-d5614b0aea52',
           name: 'patchCardInstance',
@@ -496,7 +496,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       body: 'Changing first names',
       format: 'org.matrix.custom.html',
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '6545dc5a-01a1-47d6-b2f7-493d2ff5a0c2',
           name: 'patchCardInstance',
@@ -523,7 +523,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       body: 'Changing first names',
       format: 'org.matrix.custom.html',
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '6545dc5a-01a1-47d6-b2f7-493d2ff5a0c2',
           name: 'patchCardInstance',
@@ -565,7 +565,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       body: 'Changing first names',
       format: 'org.matrix.custom.html',
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '6545dc5a-01a1-47d6-b2f7-493d2ff5a0c2',
           name: 'patchCardInstance',
@@ -624,7 +624,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Changing first name to Evie',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           name: 'patchCardInstance',
           arguments: JSON.stringify({
@@ -640,9 +640,9 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     });
     let commandResultEvents = getRoomEvents(roomId).filter(
       (event) =>
-        event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+        event.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE &&
         event.content['m.relates_to']?.rel_type ===
-          APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
+          APP_BOXEL_TOOL_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
     assert.strictEqual(
@@ -665,9 +665,9 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
 
     commandResultEvents = getRoomEvents(roomId).filter(
       (event) =>
-        event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+        event.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE &&
         event.content['m.relates_to']?.rel_type ===
-          APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
+          APP_BOXEL_TOOL_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
     assert.strictEqual(
@@ -709,7 +709,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           name: 'patchCardInstance',
           arguments: JSON.stringify({
@@ -724,7 +724,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       ],
     });
     let commandResultEvents = getRoomEvents(roomId).filter(
-      (event) => event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+      (event) => event.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
     );
     assert.strictEqual(
       commandResultEvents.length,
@@ -743,7 +743,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       .exists();
 
     commandResultEvents = getRoomEvents(roomId).filter(
-      (event) => event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+      (event) => event.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
     );
     assert.strictEqual(
       commandResultEvents.length,
@@ -776,7 +776,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Search for the following card',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'search1',
           name: 'SearchCardsByTypeAndTitleCommand_a959',
@@ -824,7 +824,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Search for the following card',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'search1',
           name: 'SearchCardsByTypeAndTitleCommand_a959',
@@ -865,7 +865,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Search for the following card',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '721c8c78-d8c1-4cc1-a7e9-51d2d3143e4d',
           name: 'SearchCardsByTypeAndTitleCommand_a959',
@@ -930,7 +930,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Search for the following card',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'fd4515fb-ed4d-4005-9782-4e844d7d4d9c',
           name: 'SearchCardsByTypeAndTitleCommand_a959',
@@ -1002,7 +1002,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Search for the following card',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '9a5b7422-87de-4a93-9f07-9b7c40b75b1e',
           name: 'SearchCardsByTypeAndTitleCommand_a959',
@@ -1041,7 +1041,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Search for the following card',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '6c6e2d73-8e09-4b44-a0d9-688f36b73be8',
           name: 'SearchCardsByTypeAndTitleCommand_a959',
@@ -1084,7 +1084,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Search for the following card',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'ffd1a3d0-0bd4-491a-a907-b96ec9d8902c',
           name: 'SearchCardsByTypeAndTitleCommand_a959',
@@ -1165,7 +1165,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Changing first name to Evie',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           name: 'patchCardInstance',
           arguments: JSON.stringify({
@@ -1242,7 +1242,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
         body: 'Changing first names',
         format: 'org.matrix.custom.html',
         [APP_BOXEL_CONTINUATION_OF_CONTENT_KEY]: initialEventId,
-        [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+        [APP_BOXEL_TOOL_REQUESTS_KEY]: [
           {
             id: '6545dc5a-01a1-47d6-b2f7-493d2ff5a0c2',
             name: 'patchCard',
@@ -1267,7 +1267,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Changing first names',
       format: 'org.matrix.custom.html',
       [APP_BOXEL_CONTINUATION_OF_CONTENT_KEY]: initialEventId,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '6545dc5a-01a1-47d6-b2f7-493d2ff5a0c2',
           name: 'patchCard',
@@ -1310,7 +1310,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Changing first names',
       format: 'org.matrix.custom.html',
       [APP_BOXEL_CONTINUATION_OF_CONTENT_KEY]: initialEventId,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '6545dc5a-01a1-47d6-b2f7-493d2ff5a0c2',
           name: 'patchCard',
@@ -1378,7 +1378,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Reading hello file',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '0ce51dc1-c819-4d6d-9f4f-77fbf60e9a0a',
           name: 'read-file-for-ai-assistant_a831',
@@ -1392,9 +1392,9 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     });
     let commandResultEvents = getRoomEvents(roomId).filter(
       (event) =>
-        event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+        event.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE &&
         event.content['m.relates_to']?.rel_type ===
-          APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
+          APP_BOXEL_TOOL_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
     assert.strictEqual(
@@ -1415,9 +1415,9 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
 
     commandResultEvents = getRoomEvents(roomId).filter(
       (event) =>
-        event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+        event.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE &&
         event.content['m.relates_to']?.rel_type ===
-          APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
+          APP_BOXEL_TOOL_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
     assert.strictEqual(
@@ -1469,7 +1469,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Reading card',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '1ef9a66a-2201-4874-a156-9705acb1ac13',
           name: 'read-card-for-ai-assistant_dd38',
@@ -1483,9 +1483,9 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     });
     let commandResultEvents = getRoomEvents(roomId).filter(
       (event) =>
-        event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+        event.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE &&
         event.content['m.relates_to']?.rel_type ===
-          APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
+          APP_BOXEL_TOOL_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
     assert.strictEqual(
@@ -1506,9 +1506,9 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
 
     commandResultEvents = getRoomEvents(roomId).filter(
       (event) =>
-        event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+        event.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE &&
         event.content['m.relates_to']?.rel_type ===
-          APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
+          APP_BOXEL_TOOL_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
     assert.strictEqual(
@@ -1578,7 +1578,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Changing first name to Evie',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: commandRequestId,
           name: 'patchCardInstance',
@@ -1619,9 +1619,9 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
 
     let commandResultEvents = getRoomEvents(roomId).filter(
       (event) =>
-        event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+        event.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE &&
         event.content['m.relates_to']?.rel_type ===
-          APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          APP_BOXEL_TOOL_RESULT_REL_TYPE,
     );
 
     assert.strictEqual(
@@ -1673,7 +1673,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Changing first name to Evie',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: commandRequestId,
           name: 'patchCardInstance',
@@ -1693,16 +1693,16 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       roomId,
       '@aibot:localhost',
       {
-        msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+        msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
         commandRequestId,
         'm.relates_to': {
-          rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           key: 'applied',
           event_id: strippedEditEventId,
         },
         data: {},
       },
-      { type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE },
+      { type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE },
     );
 
     await settled();
@@ -1744,7 +1744,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Changing first name to Evie',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: firstCommandRequestId,
           name: 'patchCardInstance',
@@ -1764,7 +1764,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Changing first name to Mango',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: secondCommandRequestId,
           name: 'patchCardInstance',
@@ -1784,16 +1784,16 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       roomId,
       '@aibot:localhost',
       {
-        msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+        msgtype: APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
         commandRequestId: secondCommandRequestId,
         'm.relates_to': {
-          rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
           key: 'applied',
           event_id: strippedEditEventId,
         },
         data: {},
       },
-      { type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE },
+      { type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE },
     );
 
     await settled();
@@ -1834,7 +1834,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'cs-11647-check-correctness',
           name: 'checkCorrectness',
@@ -1896,7 +1896,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       body: 'Reading hello file',
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'cs-11647-no-approval',
           name: 'read-file-for-ai-assistant_a831',
@@ -1933,7 +1933,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'cs-11647-apply-button',
           name: 'checkCorrectness',
@@ -1995,7 +1995,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'cs-11647-stuck-auto',
           name: 'checkCorrectness',
@@ -2072,7 +2072,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'cs-11647-patch',
           name: 'patchCardInstance',

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -19,7 +19,7 @@ import { baseRealm } from '@cardstack/runtime-common';
 import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
@@ -428,7 +428,7 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
         rel_type: 'm.replace',
       },
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           name: 'patchCardInstance',
           arguments: {

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -17,7 +17,7 @@ import {
 import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
   APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
 } from '@cardstack/runtime-common/matrix-constants';
@@ -380,10 +380,8 @@ Instructions live in the markdown body.
       'disabled skill cards have not changed',
     );
     assert.deepEqual(
-      finalRoomStateSkillsJson.commandDefinitions.map((c: any) => c.sourceUrl),
-      initialRoomStateSkillsJson.commandDefinitions.map(
-        (c: any) => c.sourceUrl,
-      ),
+      finalRoomStateSkillsJson.toolDefinitions.map((c: any) => c.sourceUrl),
+      initialRoomStateSkillsJson.toolDefinitions.map((c: any) => c.sourceUrl),
       'command definitions have not changed',
     );
   });
@@ -453,7 +451,7 @@ Instructions live in the markdown body.
 
     let skillsState = getRoomState(roomId, APP_BOXEL_ROOM_SKILLS_EVENT_TYPE);
     assert.ok(
-      skillsState.commandDefinitions?.some((c: any) =>
+      skillsState.toolDefinitions?.some((c: any) =>
         c.sourceUrl?.includes('placeholder-command'),
       ),
       "the markdown skill's frontmatter command is uploaded as a command definition",
@@ -649,18 +647,18 @@ Instructions live in the markdown body.
 
     // Verify both rooms have command definitions
     assert.ok(
-      room1StateSkillsJson.commandDefinitions?.length > 0,
+      room1StateSkillsJson.toolDefinitions?.length > 0,
       'first room has command definitions',
     );
     assert.ok(
-      room2StateSkillsJson.commandDefinitions?.length > 0,
+      room2StateSkillsJson.toolDefinitions?.length > 0,
       'second room has command definitions',
     );
 
     // Verify the command definitions are the same between rooms when content hasn't changed
     assert.deepEqual(
-      room1StateSkillsJson.commandDefinitions,
-      room2StateSkillsJson.commandDefinitions,
+      room1StateSkillsJson.toolDefinitions,
+      room2StateSkillsJson.toolDefinitions,
       "command definitions are the same between rooms when content hasn't changed",
     );
 
@@ -706,28 +704,28 @@ Instructions live in the markdown body.
 
     // Verify the command definitions are different after content change
     assert.notDeepEqual(
-      room2StateSkillsJson.commandDefinitions,
-      room3StateSkillsJson.commandDefinitions,
+      room2StateSkillsJson.toolDefinitions,
+      room3StateSkillsJson.toolDefinitions,
       'command definitions are different after content change',
     );
 
     // Verify the command definitions have different URLs after content change
-    const room2CommandUrls = room2StateSkillsJson.commandDefinitions.map(
+    const room2CommandUrls = room2StateSkillsJson.toolDefinitions.map(
       (cmd: any) => cmd.url,
     );
-    const room3CommandUrls = room3StateSkillsJson.commandDefinitions.map(
+    const room3CommandUrls = room3StateSkillsJson.toolDefinitions.map(
       (cmd: any) => cmd.url,
     );
-    const room2CommandSourceUrls = room2StateSkillsJson.commandDefinitions.map(
+    const room2CommandSourceUrls = room2StateSkillsJson.toolDefinitions.map(
       (cmd: any) => cmd.sourceUrl,
     );
-    const room3CommandSourceUrls = room3StateSkillsJson.commandDefinitions.map(
+    const room3CommandSourceUrls = room3StateSkillsJson.toolDefinitions.map(
       (cmd: any) => cmd.sourceUrl,
     );
-    const room2CommandHashes = room2StateSkillsJson.commandDefinitions.map(
+    const room2CommandHashes = room2StateSkillsJson.toolDefinitions.map(
       (cmd: any) => cmd.contentHash,
     );
-    const room3CommandHashes = room3StateSkillsJson.commandDefinitions.map(
+    const room3CommandHashes = room3StateSkillsJson.toolDefinitions.map(
       (cmd: any) => cmd.contentHash,
     );
     assert.notDeepEqual(
@@ -805,30 +803,28 @@ Instructions live in the markdown body.
 
     // Verify the command definitions are different after content change
     assert.notDeepEqual(
-      room1State1SkillsJson.commandDefinitions,
-      room1State2SkillsJson.commandDefinitions,
+      room1State1SkillsJson.toolDefinitions,
+      room1State2SkillsJson.toolDefinitions,
       'command definitions are different after content change',
     );
 
     // Verify the command definitions have different URLs after content change
-    const room1State1CommandUrls = room1State1SkillsJson.commandDefinitions.map(
+    const room1State1CommandUrls = room1State1SkillsJson.toolDefinitions.map(
       (cmd: any) => cmd.url,
     );
-    const room1State2CommandUrls = room1State2SkillsJson.commandDefinitions.map(
+    const room1State2CommandUrls = room1State2SkillsJson.toolDefinitions.map(
       (cmd: any) => cmd.url,
     );
     const room1State1CommandSourceUrls =
-      room1State1SkillsJson.commandDefinitions.map((cmd: any) => cmd.sourceUrl);
+      room1State1SkillsJson.toolDefinitions.map((cmd: any) => cmd.sourceUrl);
     const room1State2CommandSourceUrls =
-      room1State2SkillsJson.commandDefinitions.map((cmd: any) => cmd.sourceUrl);
-    const room1State1CommandHashes =
-      room1State1SkillsJson.commandDefinitions.map(
-        (cmd: any) => cmd.contentHash,
-      );
-    const room1State2CommandHashes =
-      room1State2SkillsJson.commandDefinitions.map(
-        (cmd: any) => cmd.contentHash,
-      );
+      room1State2SkillsJson.toolDefinitions.map((cmd: any) => cmd.sourceUrl);
+    const room1State1CommandHashes = room1State1SkillsJson.toolDefinitions.map(
+      (cmd: any) => cmd.contentHash,
+    );
+    const room1State2CommandHashes = room1State2SkillsJson.toolDefinitions.map(
+      (cmd: any) => cmd.contentHash,
+    );
     assert.notDeepEqual(
       room1State1CommandUrls,
       room1State2CommandUrls,
@@ -945,7 +941,7 @@ Instructions live in the markdown body.
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '721c8c78-d8c1-4cc1-a7e9-51d2d3143e4d',
           name: 'SearchCardsByTypeAndTitleCommand_a959',
@@ -1148,7 +1144,7 @@ ${REPLACE_MARKER}
     await waitFor('[data-test-message-idx]');
 
     let expectedCommandDefinitionCount =
-      afterCodeModeRoomStateSkillsJson.commandDefinitions?.length ?? 0;
+      afterCodeModeRoomStateSkillsJson.toolDefinitions?.length ?? 0;
 
     await waitUntil(
       () => {
@@ -1156,7 +1152,7 @@ ${REPLACE_MARKER}
           roomId,
           APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
         );
-        let currentLength = skillsState?.commandDefinitions?.length ?? 0;
+        let currentLength = skillsState?.toolDefinitions?.length ?? 0;
         return currentLength === expectedCommandDefinitionCount;
       },
       {
@@ -1171,7 +1167,7 @@ ${REPLACE_MARKER}
     );
 
     if (
-      (finalRoomStateSkillsJson.commandDefinitions?.length ?? 0) !==
+      (finalRoomStateSkillsJson.toolDefinitions?.length ?? 0) !==
       expectedCommandDefinitionCount
     ) {
       console.log(
@@ -1204,32 +1200,32 @@ ${REPLACE_MARKER}
       'disabled skill cards are the same',
     );
     assert.notDeepEqual(
-      finalRoomStateSkillsJson.commandDefinitions,
-      afterCodeModeRoomStateSkillsJson.commandDefinitions,
+      finalRoomStateSkillsJson.toolDefinitions,
+      afterCodeModeRoomStateSkillsJson.toolDefinitions,
       'command definitions are different',
     );
 
     let baselineUnchangedCommandDefinitions =
-      afterCodeModeRoomStateSkillsJson.commandDefinitions.filter(
+      afterCodeModeRoomStateSkillsJson.toolDefinitions.filter(
         (cmd: any) =>
           cmd.sourceUrl !==
           `${testRealmURL}search-and-open-card-command/default`,
       );
     let baselineChangedCommandDefinitions =
-      afterCodeModeRoomStateSkillsJson.commandDefinitions.filter(
+      afterCodeModeRoomStateSkillsJson.toolDefinitions.filter(
         (cmd: any) =>
           cmd.sourceUrl ===
           `${testRealmURL}search-and-open-card-command/default`,
       );
 
     let finalUnchangedCommandDefinitions =
-      finalRoomStateSkillsJson.commandDefinitions.filter(
+      finalRoomStateSkillsJson.toolDefinitions.filter(
         (cmd: any) =>
           cmd.sourceUrl !==
           `${testRealmURL}search-and-open-card-command/default`,
       );
     let finalChangedCommandDefinitions =
-      finalRoomStateSkillsJson.commandDefinitions.filter(
+      finalRoomStateSkillsJson.toolDefinitions.filter(
         (cmd: any) =>
           cmd.sourceUrl ===
           `${testRealmURL}search-and-open-card-command/default`,
@@ -1258,14 +1254,14 @@ ${REPLACE_MARKER}
     );
 
     assert.strictEqual(
-      initialRoomStateSkillsJson.commandDefinitions.filter((cmd: any) =>
+      initialRoomStateSkillsJson.toolDefinitions.filter((cmd: any) =>
         cmd.name.includes('search-and-open-card-command'),
       ).length,
       1,
       'search-and-open-card-command is present',
     );
     assert.strictEqual(
-      initialRoomStateSkillsJson.commandDefinitions.filter((cmd: any) =>
+      initialRoomStateSkillsJson.toolDefinitions.filter((cmd: any) =>
         cmd.name.includes('placeholder'),
       ).length,
       0,
@@ -1279,14 +1275,14 @@ ${REPLACE_MARKER}
       APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
     );
     assert.strictEqual(
-      finalRoomStateSkillsJson.commandDefinitions.filter((cmd: any) =>
+      finalRoomStateSkillsJson.toolDefinitions.filter((cmd: any) =>
         cmd.name.includes('search-and-open-card-command'),
       ).length,
       1,
       'search-and-open-card-command is still present',
     );
     assert.strictEqual(
-      finalRoomStateSkillsJson.commandDefinitions.filter((cmd: any) =>
+      finalRoomStateSkillsJson.toolDefinitions.filter((cmd: any) =>
         cmd.name.includes('placeholder'),
       ).length,
       1,

--- a/packages/host/tests/integration/components/ai-module-creation-test.gts
+++ b/packages/host/tests/integration/components/ai-module-creation-test.gts
@@ -11,7 +11,7 @@ import { baseRealm } from '@cardstack/runtime-common';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
 import {
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
   APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
 } from '@cardstack/runtime-common/matrix-constants';
@@ -198,7 +198,7 @@ module('Integration | create app module via ai-assistant', function (hooks) {
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       body: 'Generate code for Preschool CRM based on product requirement document.',
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'generateAppModule',
           name: 'Generate App Module',

--- a/packages/matrix/support/matrix-constants.ts
+++ b/packages/matrix/support/matrix-constants.ts
@@ -1,13 +1,13 @@
 export const APP_BOXEL_MESSAGE_MSGTYPE = 'app.boxel.message';
 export const APP_BOXEL_COMMAND_MSGTYPE = 'app.boxel.command';
-export const APP_BOXEL_COMMAND_REQUESTS_KEY = 'app.boxel.commandRequests';
-export const APP_BOXEL_COMMAND_RESULT_REL_TYPE = 'app.boxel.commandAnnotation';
+export const APP_BOXEL_TOOL_REQUESTS_KEY = 'app.boxel.toolRequests';
+export const APP_BOXEL_TOOL_RESULT_REL_TYPE = 'app.boxel.toolAnnotation';
 export const APP_BOXEL_CARD_FORMAT = 'app.boxel.card';
-export const APP_BOXEL_COMMAND_RESULT_EVENT_TYPE = 'app.boxel.commandResult';
-export const APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE =
-  'app.boxel.commandResultWithOutput';
-export const APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE =
-  'app.boxel.commandResultWithNoOutput';
+export const APP_BOXEL_TOOL_RESULT_EVENT_TYPE = 'app.boxel.toolResult';
+export const APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE =
+  'app.boxel.toolResultWithOutput';
+export const APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE =
+  'app.boxel.toolResultWithNoOutput';
 export const APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE =
   'app.boxel.realm-server-event';
 export const APP_BOXEL_REALMS_EVENT_TYPE = 'app.boxel.realms';

--- a/packages/matrix/tests/commands.spec.ts
+++ b/packages/matrix/tests/commands.spec.ts
@@ -11,12 +11,12 @@ import {
   postNewCard,
 } from '../helpers/index.ts';
 import {
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_REL_TYPE,
 } from '../support/matrix-constants.ts';
 import { appURL } from '../support/isolated-realm-server.ts';
 
@@ -181,7 +181,7 @@ test.describe('Commands', () => {
       format: 'org.matrix.custom.html',
       body: 'some command',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '1',
           name: 'patchCardInstance',
@@ -217,7 +217,7 @@ test.describe('Commands', () => {
     await expect(async () => {
       let events = await getRoomEvents(username, password, room1);
       let commandResultEvent = (events as any).find(
-        (e: any) => e.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        (e: any) => e.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
       );
       await expect(commandResultEvent).toBeDefined();
     }).toPass();
@@ -236,7 +236,7 @@ test.describe('Commands', () => {
       format: 'org.matrix.custom.html',
       body: 'some command',
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: commandRequestId,
           name: 'SearchCardsByTypeAndTitleCommand_a959',
@@ -272,11 +272,11 @@ test.describe('Commands', () => {
       let events = await getRoomEvents(username, password, room1);
       let commandResultEvent = (events as any).find(
         (e: any) =>
-          e.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
-          e.content?.msgtype === APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE &&
+          e.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE &&
+          e.content?.msgtype === APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE &&
           e.content?.commandRequestId === commandRequestId &&
           e.content?.['m.relates_to']?.rel_type ===
-            APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
+            APP_BOXEL_TOOL_RESULT_REL_TYPE &&
           e.content?.['m.relates_to']?.key === 'applied' &&
           e.content?.['m.relates_to']?.event_id === messageEvent?.event_id,
       );
@@ -393,7 +393,7 @@ test.describe('Commands', () => {
         },
       }),
       isStreamingFinished: true,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: '5e226a0f-4014-4e21-b051-ebbb92cabdcc',
           name: 'switch-submode_dd88',
@@ -436,12 +436,12 @@ test.describe('Commands', () => {
       .find((message) => {
         return (
           message.content.msgtype ===
-          APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE
+          APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE
         );
       });
     expect(message).toBeDefined();
     expect(message!.content['m.relates_to']?.rel_type).toStrictEqual(
-      APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+      APP_BOXEL_TOOL_RESULT_REL_TYPE,
     );
     expect((message!.content['m.relates_to'] as any)?.key).toStrictEqual(
       'applied',
@@ -467,7 +467,7 @@ test.describe('Commands', () => {
           agentId,
         },
       }),
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
         {
           id: 'a8fe43a4-7bd3-40a7-8455-50e31038e3a4',
           name: 'switch-submode_dd88',

--- a/packages/matrix/tests/correctness-checks.spec.ts
+++ b/packages/matrix/tests/correctness-checks.spec.ts
@@ -13,10 +13,10 @@ import { getMatrixTestContext } from '../helpers/index.ts';
 import { registerUser, loginUser } from '../support/synapse/index.ts';
 import {
   APP_BOXEL_MESSAGE_MSGTYPE,
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
+  APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_REL_TYPE,
 } from '../support/matrix-constants.ts';
 import { appURL } from '../support/isolated-realm-server.ts';
 
@@ -130,7 +130,7 @@ test.describe('Correctness Checks', () => {
             agentId,
           },
         },
-        [APP_BOXEL_COMMAND_REQUESTS_KEY]: commandRequests,
+        [APP_BOXEL_TOOL_REQUESTS_KEY]: commandRequests,
       },
     );
 
@@ -158,17 +158,17 @@ test.describe('Correctness Checks', () => {
     await expect(async () => {
       let events = await getRoomEvents(username, password, roomId);
       commandResultEvent = events.find(
-        (e: any) => e.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        (e: any) => e.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
       );
       expect(commandResultEvent).toBeDefined();
     }).toPass();
 
     // Verify the command result has the correct structure
     expect(commandResultEvent!.content.msgtype).toStrictEqual(
-      APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+      APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
     );
     expect(commandResultEvent!.content['m.relates_to']?.rel_type).toStrictEqual(
-      APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+      APP_BOXEL_TOOL_RESULT_REL_TYPE,
     );
     expect(commandResultEvent!.content['m.relates_to']?.key).toStrictEqual(
       'applied',
@@ -308,7 +308,7 @@ ${brokenContent}
             agentId,
           },
         },
-        [APP_BOXEL_COMMAND_REQUESTS_KEY]: failingCommandRequests,
+        [APP_BOXEL_TOOL_REQUESTS_KEY]: failingCommandRequests,
       },
     );
 
@@ -326,7 +326,7 @@ ${brokenContent}
       let events = await getRoomEvents(username, password, roomId);
       failingCommandResultEvent = events.find(
         (e: any) =>
-          e.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+          e.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE &&
           e.content.commandRequestId === failingCommandRequestId,
       );
       expect(failingCommandResultEvent).toBeDefined();
@@ -450,7 +450,7 @@ ${originalContent}
             agentId,
           },
         },
-        [APP_BOXEL_COMMAND_REQUESTS_KEY]: finalCommandRequests,
+        [APP_BOXEL_TOOL_REQUESTS_KEY]: finalCommandRequests,
       },
     );
 
@@ -467,7 +467,7 @@ ${originalContent}
       let events = await getRoomEvents(username, password, roomId);
       finalCommandResultEvent = events.find(
         (e: any) =>
-          e.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+          e.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE &&
           e.content.commandRequestId === finalCommandRequestId,
       );
       expect(finalCommandResultEvent).toBeDefined();
@@ -663,7 +663,7 @@ ${brokenModuleContent}
               agentId,
             },
           },
-          [APP_BOXEL_COMMAND_REQUESTS_KEY]: commandRequests,
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: commandRequests,
         },
       );
 
@@ -680,7 +680,7 @@ ${brokenModuleContent}
         let events = await getRoomEvents(username, password, roomId);
         commandResultEvent = events.find(
           (e: any) =>
-            e.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+            e.type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE &&
             e.content.commandRequestId === commandRequestId,
         );
         expect(commandResultEvent).toBeDefined();

--- a/packages/runtime-common/ai/history.ts
+++ b/packages/runtime-common/ai/history.ts
@@ -3,6 +3,7 @@ import type {
   CardMessageContent,
   CodePatchResultEvent,
   CommandResultEvent,
+  EncodedCommandRequest,
   MatrixEvent as DiscreteMatrixEvent,
   MessageEvent,
   RealmServerEvent,
@@ -13,14 +14,16 @@ import type { IRoomEvent } from 'matrix-js-sdk';
 import { logger } from '../log.ts';
 import {
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
+  LEGACY_APP_BOXEL_COMMAND_REQUESTS_KEY,
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE,
   APP_BOXEL_REASONING_CONTENT_KEY,
+  getToolRequests,
+  isToolResultEventType,
+  isToolResultWithOutputMsgtype,
 } from '../matrix-constants.ts';
 
 import { downloadFile } from './matrix-utils.ts';
@@ -47,7 +50,7 @@ export async function constructHistory(
   for (let rawEvent of eventsWithAggregatedReplacements) {
     if (
       rawEvent.type !== 'm.room.message' &&
-      rawEvent.type !== APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
+      !isToolResultEventType(rawEvent.type) &&
       rawEvent.type !== APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE
     ) {
       continue;
@@ -104,9 +107,17 @@ export async function constructHistory(
           content[APP_BOXEL_REASONING_CONTENT_KEY] =
             content[APP_BOXEL_REASONING_CONTENT_KEY] ??
             '' + (continuationContent[APP_BOXEL_REASONING_CONTENT_KEY] ?? '');
-          content[APP_BOXEL_COMMAND_REQUESTS_KEY] = (
-            content[APP_BOXEL_COMMAND_REQUESTS_KEY] ?? []
-          ).concat(continuationContent[APP_BOXEL_COMMAND_REQUESTS_KEY] ?? []);
+          // Merge under the new key regardless of which spelling either part
+          // carried, and drop the legacy key so the merged view has a single
+          // source of truth.
+          content[APP_BOXEL_TOOL_REQUESTS_KEY] = (
+            getToolRequests<Partial<EncodedCommandRequest>>(content) ?? []
+          ).concat(
+            getToolRequests<Partial<EncodedCommandRequest>>(
+              continuationContent,
+            ) ?? [],
+          );
+          delete content[LEGACY_APP_BOXEL_COMMAND_REQUESTS_KEY];
           event.origin_server_ts = continuationEvent.origin_server_ts;
           delete content[APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY];
         }
@@ -195,7 +206,7 @@ async function downloadAttachments(event: IRoomEvent, client: MatrixClient) {
       );
     }
   } else if (
-    event.content.msgtype === APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE &&
+    isToolResultWithOutputMsgtype(event.content.msgtype) &&
     event.content.data.card
   ) {
     try {

--- a/packages/runtime-common/ai/matrix-utils.ts
+++ b/packages/runtime-common/ai/matrix-utils.ts
@@ -10,13 +10,13 @@ import { OpenAIError } from 'openai/error';
 import type { CommandRequest } from '../commands.ts';
 import { encodeCommandRequests } from '../commands.ts';
 import {
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_RELOAD_BILLING_DATA_KEY,
   APP_BOXEL_REASONING_CONTENT_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
+  isToolResultEventType,
 } from '../matrix-constants.ts';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/matrix-event';
 import type { MatrixEvent } from 'matrix-js-sdk';
@@ -65,7 +65,7 @@ export async function sendMessageEvent(
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       [APP_BOXEL_REASONING_CONTENT_KEY]: reasoning,
-      [APP_BOXEL_COMMAND_REQUESTS_KEY]: encodeCommandRequests(commandRequests),
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: encodeCommandRequests(commandRequests),
     },
     ...data,
   };
@@ -431,7 +431,7 @@ export function isCommandOrCodePatchResult(
   let type =
     (event as DiscreteMatrixEvent).type || (event as MatrixEvent).getType?.();
   return (
-    type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE ||
+    isToolResultEventType(type) ||
     type === APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE
   );
 }

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -38,15 +38,20 @@ import type {
   SkillsConfigEvent,
   Tool,
 } from 'https://cardstack.com/base/matrix-event';
-import type { SerializedFileDef } from 'https://cardstack.com/base/file-api';
+import type {
+  SerializedFile,
+  SerializedFileDef,
+} from 'https://cardstack.com/base/file-api';
 import {
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
   APP_BOXEL_CODE_PATCH_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_REQUESTS_KEY,
-  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
-  APP_BOXEL_COMMAND_RESULT_REL_TYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
-  APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+  getToolDefinitions,
+  getToolRequests,
+  isToolResultEventType,
+  isToolResultRelType,
+  isToolResultWithNoOutputMsgtype,
+  isToolResultWithOutputContent,
+  isToolResultWithOutputMsgtype,
   APP_BOXEL_MESSAGE_MSGTYPE,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_REL_TYPE,
@@ -282,9 +287,9 @@ function getShouldRespond(history: DiscreteMatrixEvent[]): boolean {
   }
 
   let commandRequests =
-    (lastEventExcludingResults.content as CardMessageContent)[
-      APP_BOXEL_COMMAND_REQUESTS_KEY
-    ] ?? [];
+    getToolRequests<Partial<EncodedCommandRequest>>(
+      lastEventExcludingResults.content as CardMessageContent,
+    ) ?? [];
   let codePatchBlocks = extractCodePatchBlocks(
     (lastEventExcludingResults.content as CardMessageContent).body,
   );
@@ -296,11 +301,9 @@ function getShouldRespond(history: DiscreteMatrixEvent[]): boolean {
     commandRequests.every((commandRequest: Partial<EncodedCommandRequest>) => {
       return recentEventsToCheck.some((event) => {
         return (
-          event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
-          (event.content.msgtype ===
-            APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE ||
-            event.content.msgtype ===
-              APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE) &&
+          isCommandResultEvent(event) &&
+          (isToolResultWithOutputMsgtype(event.content.msgtype) ||
+            isToolResultWithNoOutputMsgtype(event.content.msgtype)) &&
           event.content.commandRequestId === commandRequest.id
         );
       });
@@ -380,7 +383,9 @@ function getCheckCorrectnessCommandRequests(
     return [];
   }
   let encodedRequests =
-    (event.content as CardMessageContent)[APP_BOXEL_COMMAND_REQUESTS_KEY] ?? [];
+    getToolRequests<Partial<EncodedCommandRequest>>(
+      event.content as CardMessageContent,
+    ) ?? [];
   if (!Array.isArray(encodedRequests)) {
     return [];
   }
@@ -415,7 +420,7 @@ function isTerminalCommandResultEventFor(
   commandRequestId: string,
 ): boolean {
   if (
-    event.type !== APP_BOXEL_COMMAND_RESULT_EVENT_TYPE ||
+    !isCommandResultEvent(event) ||
     event.content.commandRequestId !== commandRequestId
   ) {
     return false;
@@ -807,7 +812,7 @@ export async function loadCurrentlySerializedFileDefs(
       ((event.type === 'm.room.message' &&
         event.content.msgtype === APP_BOXEL_MESSAGE_MSGTYPE) ||
         event.type === APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE ||
-        event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE),
+        isToolResultEventType(event.type)),
   );
 
   if (!lastMessageEventByUser) {
@@ -904,7 +909,8 @@ export async function getTools(
     (event) => event.type === APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
   ) as SkillsConfigEvent;
 
-  let commandDefinitions = skillsConfigEvent?.content?.commandDefinitions ?? [];
+  let commandDefinitions =
+    getToolDefinitions<SerializedFile>(skillsConfigEvent?.content) ?? [];
   for (let commandDefinition of commandDefinitions) {
     if (enabledCommandNames.has(commandDefinition.name)) {
       let commandDefinitionContent = await downloadFile(
@@ -989,7 +995,11 @@ function getCommandResults(
   // event_id. Without the commandRequestId fallback the result gets dropped,
   // leaving an orphan tool_use that Anthropic rejects.
   let requestIds = new Set(
-    (cardMessageEvent.content[APP_BOXEL_COMMAND_REQUESTS_KEY] ?? [])
+    (
+      getToolRequests<Partial<EncodedCommandRequest>>(
+        cardMessageEvent.content,
+      ) ?? []
+    )
       .map((r) => r.id)
       .filter(Boolean) as string[],
   );
@@ -1047,7 +1057,7 @@ function getCodePatchResults(
 
 function toToolCalls(event: CardMessageEvent): ChatCompletionMessageToolCall[] {
   const content = event.content as CardMessageContent;
-  return (content[APP_BOXEL_COMMAND_REQUESTS_KEY] ?? []).map(
+  return (getToolRequests<Partial<EncodedCommandRequest>>(content) ?? []).map(
     (commandRequest: Partial<EncodedCommandRequest>) => {
       return {
         id: commandRequest.id!,
@@ -1069,15 +1079,13 @@ async function toResultMessages(
 ): Promise<OpenAIPromptMessage[]> {
   const messageContent = event.content as CardMessageContent;
   let commandResultEntries = await Promise.all(
-    (messageContent[APP_BOXEL_COMMAND_REQUESTS_KEY] ?? []).map(
+    (getToolRequests<Partial<EncodedCommandRequest>>(messageContent) ?? []).map(
       async (commandRequest: Partial<EncodedCommandRequest>) => {
         let decodedCommandRequest = decodeCommandRequestSafe(commandRequest);
         let commandResult = commandResults.find(
           (commandResult) =>
-            (commandResult.content.msgtype ===
-              APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE ||
-              commandResult.content.msgtype ===
-                APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE) &&
+            (isToolResultWithOutputMsgtype(commandResult.content.msgtype) ||
+              isToolResultWithNoOutputMsgtype(commandResult.content.msgtype)) &&
             commandResult.content.commandRequestId === commandRequest.id,
         );
         if (!commandResult) {
@@ -1103,8 +1111,7 @@ async function toResultMessages(
             content = `Tool call ${status == 'applied' ? 'executed' : status}.\n`;
           }
         } else if (
-          commandResult.content.msgtype ===
-            APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE &&
+          isToolResultWithOutputContent(commandResult.content) &&
           commandResult.content.data.card
         ) {
           let cardContent =
@@ -1241,11 +1248,7 @@ const CORRECTNESS_FAILURE_LIMIT_INSTRUCTION = `Automated correctness fixes have 
 function extractCorrectnessResultCard(
   commandResult?: CommandResultEvent,
 ): CorrectnessResultSummary | undefined {
-  if (
-    !commandResult ||
-    commandResult.content.msgtype !==
-      APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE
-  ) {
+  if (!commandResult || !isToolResultWithOutputContent(commandResult.content)) {
     return undefined;
   }
   let cardPayload = commandResult.content.data.card;
@@ -1405,7 +1408,7 @@ function getLatestCorrectnessCheckAttemptInfo(
 ): CorrectnessCheckAttemptInfo | undefined {
   for (let index = history.length - 1; index >= 0; index--) {
     let event = history[index];
-    if (event.type !== APP_BOXEL_COMMAND_RESULT_EVENT_TYPE) {
+    if (!isToolResultEventType(event.type)) {
       continue;
     }
     let commandResult = event as CommandResultEvent;
@@ -1683,9 +1686,9 @@ function collectPendingCodePatchCorrectnessCheck(
     // Only consider messages that contain code patches or card patch commands.
     let content = event.content as CardMessageContent;
     let codePatchBlocks = extractCodePatchBlocks(content.body || '');
-    let commandRequests = (content[APP_BOXEL_COMMAND_REQUESTS_KEY] ?? []).map(
-      (request) => decodeCommandRequest(request),
-    );
+    let commandRequests = (
+      getToolRequests<Partial<EncodedCommandRequest>>(content) ?? []
+    ).map((request) => decodeCommandRequest(request));
     let relevantCommands = commandRequests.filter((request) =>
       isCardPatchCommand(request.name),
     );
@@ -1763,9 +1766,9 @@ function hasUnresolvedCodePatches(
     }
     let content = event.content as CardMessageContent;
     let codePatchBlocks = extractCodePatchBlocks(content.body || '');
-    let commandRequests = (content[APP_BOXEL_COMMAND_REQUESTS_KEY] ?? []).map(
-      (request) => decodeCommandRequest(request),
-    );
+    let commandRequests = (
+      getToolRequests<Partial<EncodedCommandRequest>>(content) ?? []
+    ).map((request) => decodeCommandRequest(request));
     let relevantCommands = commandRequests.filter((request) =>
       isCardPatchCommand(request.name),
     );
@@ -1818,9 +1821,9 @@ function buildCodePatchCorrectnessMessage(
 ): PendingCodePatchCorrectnessCheck | undefined {
   let content = messageEvent.content as CardMessageContent;
   let codePatchBlocks = extractCodePatchBlocks(content.body || '');
-  let commandRequests = (content[APP_BOXEL_COMMAND_REQUESTS_KEY] ?? []).map(
-    (request) => decodeCommandRequest(request),
-  );
+  let commandRequests = (
+    getToolRequests<Partial<EncodedCommandRequest>>(content) ?? []
+  ).map((request) => decodeCommandRequest(request));
   let relevantCommands = commandRequests.filter((request) =>
     isCardPatchCommand(request.name),
   );
@@ -2239,7 +2242,7 @@ export const buildContextMessage = async (
     return (
       (ev.type === 'm.room.message' &&
         ev.content.msgtype == APP_BOXEL_MESSAGE_MSGTYPE) ||
-      ev.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE ||
+      isToolResultEventType(ev.type) ||
       ev.type === APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE
     );
   }) as
@@ -2546,9 +2549,10 @@ export function isCommandResultEvent(
     return false;
   }
   return (
-    event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
-    event.content['m.relates_to']?.rel_type ===
-      APP_BOXEL_COMMAND_RESULT_REL_TYPE
+    isToolResultEventType(event.type) &&
+    isToolResultRelType(
+      (event as CommandResultEvent).content['m.relates_to']?.rel_type,
+    )
   );
 }
 

--- a/packages/runtime-common/matrix-constants.ts
+++ b/packages/runtime-common/matrix-constants.ts
@@ -1,7 +1,110 @@
 export const APP_BOXEL_STOP_GENERATING_EVENT_TYPE = 'app.boxel.stopGenerating';
 export const APP_BOXEL_MESSAGE_MSGTYPE = 'app.boxel.message';
 export const APP_BOXEL_CARD_FORMAT = 'app.boxel.card';
-export const APP_BOXEL_COMMAND_REQUESTS_KEY = 'app.boxel.commandRequests';
+
+// ─── Tool wire keys (command → tool rename) ───
+//
+// New events are written ONLY with the tool-named keys. The LEGACY_* spellings
+// exist because Matrix rooms replay their full history: events written before
+// the rename carry the old keys forever, so every reader must accept both
+// (the `is*` predicates and `get*` content readers below do). Never write a
+// LEGACY_* key.
+export const APP_BOXEL_TOOL_REQUESTS_KEY = 'app.boxel.toolRequests';
+export const LEGACY_APP_BOXEL_COMMAND_REQUESTS_KEY =
+  'app.boxel.commandRequests';
+export const APP_BOXEL_TOOL_RESULT_EVENT_TYPE = 'app.boxel.toolResult';
+export const LEGACY_APP_BOXEL_COMMAND_RESULT_EVENT_TYPE =
+  'app.boxel.commandResult';
+export const APP_BOXEL_TOOL_RESULT_REL_TYPE = 'app.boxel.toolAnnotation';
+export const LEGACY_APP_BOXEL_COMMAND_RESULT_REL_TYPE =
+  'app.boxel.commandAnnotation';
+export const APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE =
+  'app.boxel.toolResultWithOutput';
+export const LEGACY_APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE =
+  'app.boxel.commandResultWithOutput';
+export const APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE =
+  'app.boxel.toolResultWithNoOutput';
+export const LEGACY_APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE =
+  'app.boxel.commandResultWithNoOutput';
+
+export type ToolResultEventType =
+  | typeof APP_BOXEL_TOOL_RESULT_EVENT_TYPE
+  | typeof LEGACY_APP_BOXEL_COMMAND_RESULT_EVENT_TYPE;
+export type ToolResultRelType =
+  | typeof APP_BOXEL_TOOL_RESULT_REL_TYPE
+  | typeof LEGACY_APP_BOXEL_COMMAND_RESULT_REL_TYPE;
+export type ToolResultWithOutputMsgtype =
+  | typeof APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE
+  | typeof LEGACY_APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE;
+export type ToolResultWithNoOutputMsgtype =
+  | typeof APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE
+  | typeof LEGACY_APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE;
+
+export function isToolResultEventType(
+  type: string | undefined,
+): type is ToolResultEventType {
+  return (
+    type === APP_BOXEL_TOOL_RESULT_EVENT_TYPE ||
+    type === LEGACY_APP_BOXEL_COMMAND_RESULT_EVENT_TYPE
+  );
+}
+
+export function isToolResultRelType(
+  relType: string | undefined,
+): relType is ToolResultRelType {
+  return (
+    relType === APP_BOXEL_TOOL_RESULT_REL_TYPE ||
+    relType === LEGACY_APP_BOXEL_COMMAND_RESULT_REL_TYPE
+  );
+}
+
+export function isToolResultWithOutputMsgtype(
+  msgtype: string | undefined,
+): msgtype is ToolResultWithOutputMsgtype {
+  return (
+    msgtype === APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE ||
+    msgtype === LEGACY_APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE
+  );
+}
+
+export function isToolResultWithNoOutputMsgtype(
+  msgtype: string | undefined,
+): msgtype is ToolResultWithNoOutputMsgtype {
+  return (
+    msgtype === APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE ||
+    msgtype === LEGACY_APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE
+  );
+}
+
+// Content-level counterpart of isToolResultWithOutputMsgtype: narrows a
+// result-content union to its with-output member (either spelling), so
+// callers can read `data.card` type-safely.
+export function isToolResultWithOutputContent<T extends { msgtype?: string }>(
+  content: T,
+): content is Extract<T, { msgtype: ToolResultWithOutputMsgtype }> {
+  return isToolResultWithOutputMsgtype(content.msgtype);
+}
+
+// Reads a message content's tool requests under either spelling; the new key
+// wins when both are present (possible transiently when a streaming message
+// that began before a deploy is replaced after it).
+export function getToolRequests<T = unknown>(
+  content: Record<string, any> | undefined | null,
+): T[] | undefined {
+  return (
+    content?.[APP_BOXEL_TOOL_REQUESTS_KEY] ??
+    content?.[LEGACY_APP_BOXEL_COMMAND_REQUESTS_KEY]
+  );
+}
+
+// Reads the room-skills state event's tool definitions under either key.
+// Pre-rename rooms carry `commandDefinitions` until the host next rewrites the
+// state event (which emits only `toolDefinitions`).
+export function getToolDefinitions<T = unknown>(
+  content: Record<string, any> | undefined | null,
+): T[] | undefined {
+  return content?.toolDefinitions ?? content?.commandDefinitions;
+}
 export const APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE =
   'app.boxel.codePatchResult';
 export const APP_BOXEL_CODE_PATCH_RESULT_MSGTYPE = 'app.boxel.codePatchResult';
@@ -11,12 +114,6 @@ export const APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE =
   'app.boxel.codePatchCorrectness';
 export const APP_BOXEL_CODE_PATCH_CORRECTNESS_REL_TYPE =
   'app.boxel.codePatchCorrectnessAnnotation';
-export const APP_BOXEL_COMMAND_RESULT_EVENT_TYPE = 'app.boxel.commandResult';
-export const APP_BOXEL_COMMAND_RESULT_REL_TYPE = 'app.boxel.commandAnnotation';
-export const APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE =
-  'app.boxel.commandResultWithOutput';
-export const APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE =
-  'app.boxel.commandResultWithNoOutput';
 export const APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE = 'app.boxel.debug';
 export const APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE =
   'app.boxel.realm-server-event';


### PR DESCRIPTION
## What

Second slice of the command → tool rename (CS-11788), **stacked on #5454**. The serialized Matrix keys rename; readers accept both spellings permanently since old rooms replay their full history through prompt assembly and the host message builder.

## Wire changes

Writers (host `sendCommandResultEvent`, skills-state rewrites, room creation; ai-bot message/readRealmFile-result emission) now emit only:

- `app.boxel.toolRequests` message-content key (was `commandRequests`)
- `app.boxel.toolResult` event type + `toolResultWithOutput` / `toolResultWithNoOutput` msgtypes
- `app.boxel.toolAnnotation` rel type
- `toolDefinitions` key in the room-skills state event

## Dual-read mechanics

- `matrix-constants.ts` gains the new constants, `LEGACY_*` exports of the old strings (replay-only, documented never-write), type-guard predicates (`isToolResultEventType`, `isToolResultRelType`, msgtype/content guards), and content readers (`getToolRequests`, `getToolDefinitions`) where the new key wins on conflict.
- Every reader — prompt assembly, history construction, host message-builder / room resource / command-service / commands-utils, ai-bot main/set-title — goes through those helpers; no string literals.
- `base/matrix-event.gts` event types widen to unions of both spellings.
- Skills-state rewrites strip a lingering legacy `commandDefinitions` key so rewritten rooms carry a single spelling; history construction normalizes merged continuations onto the new key.

## Tests

- New mixed-history regression: a legacy-keyed request + legacy-typed result still pair by `tool_call_id` in the prompt; `getTools` reads definitions from a pre-rename `commandDefinitions` state event.
- Existing fixtures updated to the new spellings (they assert the new-writer world); raw-string legacy fixtures in history-construction tests are retained as legacy coverage, and an update-room-skills test seeds legacy state to prove the rewrite path.
- ai-bot suite passes locally (224/226 — the two `locking-test` failures are the pre-existing local Postgres-role environment issue); host, runtime-common, and matrix type-checks and per-package lints are clean. The Playwright matrix specs (which drive the real host + bot) assert the new spellings end-to-end in CI.

Part of CS-11788; blocks nothing else in the rename sequence — the base-class/module-path slice (CS-12038) can proceed in parallel once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)