### PR TITLE
Settle prerender_html jobs before asserting a source-cache miss

### DIFF
--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -29,6 +29,7 @@ import { query, param } from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
 import {
   expectIncrementalIndexEvent,
+  maxPrerenderHtmlJobId,
   settlePrerenderHtmlJobs,
 } from './helpers/indexing.ts';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
@@ -194,25 +195,38 @@ module(basename(import.meta.filename), function () {
           let cacheTestPath = 'cache-test-nocache.gts';
           let initialContent = '// initial cache test content';
 
-          await testRealm.write(cacheTestPath, initialContent);
           // Each write's index pass fires a fire-and-forget `prerender_html`
           // job whose worker re-reads this module with the card+source Accept
           // header — a read that repopulates #sourceCache. write() returns
           // without awaiting that job, so its seed can land at any later
           // moment, including between the noCache request below (which drops
           // the entry) and the follow-up read that asserts a miss, turning the
-          // expected miss into a spurious hit. Drain the prerender-html channel
-          // after every write so no such job is in flight during the
-          // assertions.
-          await settlePrerenderHtmlJobs(dbAdapter, testRealm.url);
+          // expected miss into a spurious hit. Settle the prerender-html
+          // channel after every write, keyed off a pre-write baseline so the
+          // fire-and-forget enqueue can't be missed, leaving no such job in
+          // flight during the assertions.
+          let beforeInitial = await maxPrerenderHtmlJobId(
+            dbAdapter,
+            testRealm.url,
+          );
+          await testRealm.write(cacheTestPath, initialContent);
+          await settlePrerenderHtmlJobs(dbAdapter, testRealm.url, {
+            afterJobId: beforeInitial,
+          });
 
           await request
             .get(`/${cacheTestPath}`)
             .set('Accept', 'application/vnd.card+source');
 
           let updatedContent = `${initialContent}\n// updated by test`;
+          let beforeUpdate = await maxPrerenderHtmlJobId(
+            dbAdapter,
+            testRealm.url,
+          );
           await testRealm.write(cacheTestPath, updatedContent);
-          await settlePrerenderHtmlJobs(dbAdapter, testRealm.url);
+          await settlePrerenderHtmlJobs(dbAdapter, testRealm.url, {
+            afterJobId: beforeUpdate,
+          });
 
           let noCacheResponse = await request
             .get(`/${cacheTestPath}?noCache=true`)
@@ -259,16 +273,24 @@ module(basename(import.meta.filename), function () {
         // reset.
         test('clearLocalSourceCaches drops cached source bytes', async function (assert) {
           let cacheTestPath = 'clear-local-caches.gts';
+          // Settle the fire-and-forget prerender_html job the write spawns
+          // before we clear the cache: that job re-reads the module with the
+          // card+source Accept header and reseeds #sourceCache, so if it lands
+          // after clearLocalSourceCaches() the afterClear fetch would be a
+          // spurious hit rather than the miss this test asserts. The baseline
+          // keys the settle to the job this write spawns so the fire-and-forget
+          // enqueue can't be missed.
+          let beforeWrite = await maxPrerenderHtmlJobId(
+            dbAdapter,
+            testRealm.url,
+          );
           await testRealm.write(
             cacheTestPath,
             '// clear-local-caches initial content',
           );
-          // Settle the fire-and-forget prerender_html job the write spawned
-          // before we clear the cache: that job re-reads the module with the
-          // card+source Accept header and reseeds #sourceCache, so if it lands
-          // after clearLocalSourceCaches() the afterClear fetch would be a
-          // spurious hit rather than the miss this test asserts.
-          await settlePrerenderHtmlJobs(dbAdapter, testRealm.url);
+          await settlePrerenderHtmlJobs(dbAdapter, testRealm.url, {
+            afterJobId: beforeWrite,
+          });
 
           await request
             .get(`/${cacheTestPath}`)

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -27,7 +27,10 @@ import {
 } from './helpers/index.ts';
 import { query, param } from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
-import { expectIncrementalIndexEvent } from './helpers/indexing.ts';
+import {
+  expectIncrementalIndexEvent,
+  settlePrerenderHtmlJobs,
+} from './helpers/indexing.ts';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import stripScopedCSSGlimmerAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-glimmer-attributes';
 import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
@@ -192,6 +195,16 @@ module(basename(import.meta.filename), function () {
           let initialContent = '// initial cache test content';
 
           await testRealm.write(cacheTestPath, initialContent);
+          // Each write's index pass fires a fire-and-forget `prerender_html`
+          // job whose worker re-reads this module with the card+source Accept
+          // header — a read that repopulates #sourceCache. write() returns
+          // without awaiting that job, so its seed can land at any later
+          // moment, including between the noCache request below (which drops
+          // the entry) and the follow-up read that asserts a miss, turning the
+          // expected miss into a spurious hit. Drain the prerender-html channel
+          // after every write so no such job is in flight during the
+          // assertions.
+          await settlePrerenderHtmlJobs(dbAdapter, testRealm.url);
 
           await request
             .get(`/${cacheTestPath}`)
@@ -199,6 +212,7 @@ module(basename(import.meta.filename), function () {
 
           let updatedContent = `${initialContent}\n// updated by test`;
           await testRealm.write(cacheTestPath, updatedContent);
+          await settlePrerenderHtmlJobs(dbAdapter, testRealm.url);
 
           let noCacheResponse = await request
             .get(`/${cacheTestPath}?noCache=true`)
@@ -227,7 +241,7 @@ module(basename(import.meta.filename), function () {
           assert.strictEqual(
             cachedResponse.headers['x-boxel-cache'],
             'miss',
-            'subsequent request fetches from disk because noCache call did not seed cache',
+            `subsequent request fetches from disk because noCache call did not seed cache (got x-boxel-cache=${cachedResponse.headers['x-boxel-cache']}, body=${JSON.stringify(cachedResponse.text)}) — a hit here means something re-seeded #sourceCache after the noCache drop, e.g. a prerender_html job that outlived the settle`,
           );
           assert.strictEqual(
             cachedResponse.text,
@@ -249,6 +263,12 @@ module(basename(import.meta.filename), function () {
             cacheTestPath,
             '// clear-local-caches initial content',
           );
+          // Settle the fire-and-forget prerender_html job the write spawned
+          // before we clear the cache: that job re-reads the module with the
+          // card+source Accept header and reseeds #sourceCache, so if it lands
+          // after clearLocalSourceCaches() the afterClear fetch would be a
+          // spurious hit rather than the miss this test asserts.
+          await settlePrerenderHtmlJobs(dbAdapter, testRealm.url);
 
           await request
             .get(`/${cacheTestPath}`)
@@ -270,7 +290,7 @@ module(basename(import.meta.filename), function () {
           assert.strictEqual(
             afterClear.headers['x-boxel-cache'],
             'miss',
-            'fetch after clearLocalSourceCaches is a miss — the #sourceCache entry was dropped',
+            `fetch after clearLocalSourceCaches is a miss — the #sourceCache entry was dropped (got x-boxel-cache=${afterClear.headers['x-boxel-cache']})`,
           );
         });
 

--- a/packages/realm-server/tests/helpers/indexing.ts
+++ b/packages/realm-server/tests/helpers/indexing.ts
@@ -200,6 +200,27 @@ export async function prerenderedHtmlRowFor(
   return rows[0];
 }
 
+// The highest prerender_html job id currently on the realm's HTML channel
+// (0 when the channel is empty). Capture this BEFORE a write, then pass it to
+// settlePrerenderHtmlJobs as `afterJobId`. The index pass enqueues the
+// prerender_html job fire-and-forget, so a settle that runs before that row is
+// inserted would see only the already-resolved jobs left by earlier work (the
+// fixture build settles its own jobs to `resolved`), find them all settled,
+// and return before the new job exists — leaving it free to run and reseed
+// caches afterward. Gating the settle on a job newer than this baseline closes
+// that window.
+export async function maxPrerenderHtmlJobId(
+  dbAdapter: DBAdapter,
+  realmURL: string | URL,
+): Promise<number> {
+  let concurrencyGroup = `prerender-html:${typeof realmURL === 'string' ? realmURL : realmURL.href}`;
+  let rows = (await query(dbAdapter, [
+    `SELECT COALESCE(MAX(id), 0)::int AS max_id FROM jobs WHERE`,
+    ...every([['concurrency_group =', param(concurrencyGroup)]]),
+  ] as Expression)) as { max_id: number }[];
+  return rows[0]?.max_id ?? 0;
+}
+
 // HTML lands on its own channel: the index pass fires a `prerender_html`
 // job (fire-and-forget) and completes without waiting for it, so a test
 // that writes and then asserts prerendered HTML must settle that channel
@@ -207,12 +228,18 @@ export async function prerenderedHtmlRowFor(
 // group has no unfulfilled jobs and no active reservations, and fails
 // loudly if any of its jobs rejected — a broken render should fail the
 // test, not silently satisfy the wait.
+//
+// Pass `afterJobId` (a baseline from maxPrerenderHtmlJobId captured before the
+// triggering write) when the point of settling is to wait for a job a specific
+// write just spawned: the settle then also holds until a job newer than the
+// baseline is visible, so the fire-and-forget enqueue can't be missed.
 export async function settlePrerenderHtmlJobs(
   dbAdapter: DBAdapter,
   realmURL: string | URL,
-  opts?: { timeout?: number },
+  opts?: { timeout?: number; afterJobId?: number },
 ): Promise<void> {
   let concurrencyGroup = `prerender-html:${typeof realmURL === 'string' ? realmURL : realmURL.href}`;
+  let afterJobId = opts?.afterJobId;
   let lastState = '';
   await waitUntil(
     async () => {
@@ -236,6 +263,11 @@ export async function settlePrerenderHtmlJobs(
         );
       }
       lastState = JSON.stringify(rows);
+      if (afterJobId != null && !rows.some((row) => row.id > afterJobId!)) {
+        // The write's job hasn't landed on the channel yet — keep waiting so we
+        // don't settle on stale, already-resolved rows.
+        return false;
+      }
       return rows.every(
         (row) => row.status === 'resolved' && row.active_reservations === 0,
       );


### PR DESCRIPTION
### What was flaky

`card-source-endpoints-test.ts > ... > supports noCache query param to bypass cache` intermittently fails with:

```
message: subsequent request fetches from disk because noCache call did not seed cache
actual  : hit
expected: miss
```

(observed on a Realm Server Tests shard). The sibling test `clearLocalSourceCaches drops cached source bytes` has the same latent race but fails much less often.

### Why

Both tests assert that a source request reports `x-boxel-cache: miss` — the noCache test to prove a `noCache=true` request does not seed `#sourceCache`, the clearLocalSourceCaches test to prove the cache is empty after a manual clear.

The realm serves that cache header from an in-memory `#sourceCache` that is populated only by the `application/vnd.card+source` GET handler. Every `realm.write()` runs an index pass that fires a fire-and-forget `prerender_html` job on its own concurrency group. That job's worker re-reads the just-written module with the card+source Accept header, and that read repopulates `#sourceCache`. `write()` returns without awaiting the job, so the reseed can land at any later moment — including after the noCache request drops the cache entry, or after `clearLocalSourceCaches()` empties the cache — which flips the expected miss into a spurious hit. (The response body is still correct, so only the cache-header assertion fails.)

### Fix

Settle the prerender-html channel with `settlePrerenderHtmlJobs` after each `write()` in both tests, so no prerender_html job is in flight during the assertions.

The settle is keyed to a pre-write baseline. The index pass enqueues the prerender_html job fire-and-forget, so a plain settle could run before that row is inserted, see only the already-resolved jobs left by the fixture build, and return before the write's own job exists. Each test snapshots the channel's high-water job id with `maxPrerenderHtmlJobId` before the write and passes it as `settlePrerenderHtmlJobs`'s new `afterJobId` option; the settle then holds until a job newer than that baseline is visible **and** every channel job is resolved. Coalescing doesn't interfere because the tests settle between writes, so there's never a pending same-realm job to merge into.

The two miss assertions also print the observed cache header and response body, so if a reseed ever slips through again the failure names the cause instead of just reporting `hit`/`miss`.

Test-only change.
