### PR TITLE
Restore boxel-ui test-app to run on port 4220

### DIFF
--- a/packages/boxel-ui/test-app/vite.config.mjs
+++ b/packages/boxel-ui/test-app/vite.config.mjs
@@ -3,6 +3,9 @@ import { extensions, classicEmberSupport, ember } from '@embroider/vite';
 import { babel } from '@rollup/plugin-babel';
 
 export default defineConfig({
+  server: {
+    port: 4220,
+  },
   plugins: [
     classicEmberSupport(),
     ember(),


### PR DESCRIPTION
Follow up to the changes in #5434. Vite server now seems to default to `4200`, however I had trouble running the boxel-ui test-app there. Previously `.ember-cli` had the port set to `4220` and carrying that behavior over seems to work.