### PR TITLE
Tolerate files deleted while an index job is in flight; never reject the indexing quiescence gate

### DIFF
--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -47,12 +47,14 @@ const realmEventsLog = logger('realm:events');
 
 // A concurrent delete can remove a file between an existence check and the
 // stat call, so treat a vanished file as nonexistent rather than letting the
-// raw ENOENT escape.
+// raw ENOENT escape. ENOTDIR is the same story via a different route: probing
+// a path nested under a regular file (e.g. `some.txt/nested`) throws it, and
+// such a path likewise just doesn't exist.
 function statIfExists(absolutePath: string): Stats | undefined {
   try {
     return statSync(absolutePath);
   } catch (err: any) {
-    if (err?.code === 'ENOENT') {
+    if (err?.code === 'ENOENT' || err?.code === 'ENOTDIR') {
       return undefined;
     }
     throw err;

--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -18,7 +18,7 @@ import type { LocalPath } from '@cardstack/runtime-common/paths';
 import type { ServerResponse } from 'http';
 import sane, { type Watcher } from 'sane';
 
-import type { ReadStream } from 'fs-extra';
+import type { ReadStream, Stats } from 'fs-extra';
 import fsExtra from 'fs-extra';
 const {
   readdirSync,
@@ -44,6 +44,20 @@ import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-con
 import { createJWT, verifyJWT } from './jwt.ts';
 
 const realmEventsLog = logger('realm:events');
+
+// A concurrent delete can remove a file between an existence check and the
+// stat call, so treat a vanished file as nonexistent rather than letting the
+// raw ENOENT escape.
+function statIfExists(absolutePath: string): Stats | undefined {
+  try {
+    return statSync(absolutePath);
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') {
+      return undefined;
+    }
+    throw err;
+  }
+}
 
 function parseMatrixSendEventError(error: unknown): {
   status?: number;
@@ -184,12 +198,9 @@ export class NodeAdapter implements RealmAdapter {
 
   async lastModified(path: string): Promise<number | undefined> {
     let absolutePath = join(this.realmDir, path);
-    if (!existsSync(absolutePath)) {
-      return undefined;
-    }
-    let stat = statSync(absolutePath);
-    // Case-insensitive file systems need this check
-    if (stat.isDirectory()) {
+    let stat = statIfExists(absolutePath);
+    // The directory check covers case-insensitive file systems
+    if (!stat || stat.isDirectory()) {
       return undefined;
     }
 
@@ -198,12 +209,9 @@ export class NodeAdapter implements RealmAdapter {
 
   async openFile(path: string): Promise<FileRef | undefined> {
     let absolutePath = join(this.realmDir, path);
-    if (!existsSync(absolutePath)) {
-      return undefined;
-    }
-    let stat = statSync(absolutePath);
-    // Case-insensitive file systems need this check
-    if (stat.isDirectory()) {
+    let stat = statIfExists(absolutePath);
+    // The directory check covers case-insensitive file systems
+    if (!stat || stat.isDirectory()) {
       return undefined;
     }
     let lazyStream: ReadStream;

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -363,6 +363,8 @@ const ALL_TEST_FILES: string[] = [
   './skip-query-backed-expansion-test',
   './worker-request-signature-test',
   './worker-request-forwarder-test',
+  './worker-reader-test',
+  './realm-index-updater-test',
 ];
 
 // TEST_FILES limits which test files are loaded (parsed and executed). Useful

--- a/packages/realm-server/tests/node-realm-test.ts
+++ b/packages/realm-server/tests/node-realm-test.ts
@@ -1,6 +1,8 @@
 import QUnit from 'qunit';
 const { module, test } = QUnit;
-import { basename } from 'path';
+import { basename, join } from 'path';
+import { tmpdir } from 'os';
+import fsExtra from 'fs-extra';
 import type { PgAdapter } from '@cardstack/postgres';
 import {
   fetchSessionRoom,
@@ -143,5 +145,40 @@ module(basename(import.meta.filename), function (hooks) {
     );
 
     assert.true(true, 'broadcast resolves even if stale room cleanup fails');
+  });
+});
+
+module(`${basename(import.meta.filename)} | file stat probing`, function () {
+  test('openFile and lastModified treat a path nested under a regular file as nonexistent', async function (assert) {
+    let dir = fsExtra.mkdtempSync(join(tmpdir(), 'node-realm-test-'));
+    try {
+      fsExtra.writeFileSync(join(dir, 'plain.txt'), 'hello');
+      let adapter = new NodeAdapter(dir);
+
+      assert.strictEqual(
+        await adapter.openFile('plain.txt/nested'),
+        undefined,
+        'openFile reports not-found instead of throwing ENOTDIR',
+      );
+      assert.strictEqual(
+        await adapter.lastModified('plain.txt/nested'),
+        undefined,
+        'lastModified reports not-found instead of throwing ENOTDIR',
+      );
+    } finally {
+      fsExtra.removeSync(dir);
+    }
+  });
+
+  test('openFile and lastModified treat a missing path as nonexistent', async function (assert) {
+    let dir = fsExtra.mkdtempSync(join(tmpdir(), 'node-realm-test-'));
+    try {
+      let adapter = new NodeAdapter(dir);
+
+      assert.strictEqual(await adapter.openFile('absent.txt'), undefined);
+      assert.strictEqual(await adapter.lastModified('absent.txt'), undefined);
+    } finally {
+      fsExtra.removeSync(dir);
+    }
   });
 });

--- a/packages/realm-server/tests/realm-index-updater-test.ts
+++ b/packages/realm-server/tests/realm-index-updater-test.ts
@@ -1,0 +1,245 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import {
+  Deferred,
+  Job,
+  RealmIndexUpdater,
+  identityResultMapper,
+  makeQueueWaiter,
+  type DBAdapter,
+  type PgPrimitive,
+  type QueuePublisher,
+  type Realm,
+} from '@cardstack/runtime-common';
+
+const realmURL = 'http://127.0.0.1:4444/test/';
+
+// The serialized shape a worker-side ENOENT lands in the jobs table with —
+// a plain object, not an Error instance.
+const serializedWorkerError: PgPrimitive = {
+  code: 'ENOENT',
+  syscall: 'open',
+  path: '/tmp/realm/doomed.txt',
+  errno: -2,
+};
+
+function makeStubRealm(): Realm {
+  return {
+    url: realmURL,
+    getRealmOwnerUsername: async () => 'test_user',
+  } as unknown as Realm;
+}
+
+// Mirrors the pg-queue publish path closely enough to exercise the waiter
+// plumbing: the job's deferred is settled through makeQueueWaiter with the
+// caller-provided mapResult, exactly as a real queue does when a worker
+// resolves or rejects the job.
+function makeStubQueue() {
+  let waiters: ReturnType<typeof makeQueueWaiter>[] = [];
+  let queue: QueuePublisher = {
+    publish: async <TResult>(args: {
+      mapResult?: (result: PgPrimitive) => TResult;
+    }) => {
+      let deferred = new Deferred<TResult>();
+      waiters.push(
+        makeQueueWaiter(
+          deferred,
+          args.mapResult ??
+            (identityResultMapper as (result: PgPrimitive) => TResult),
+        ),
+      );
+      return new Job(1, deferred);
+    },
+    destroy: async () => {},
+  };
+  return { queue, waiters };
+}
+
+async function settleMicrotasksAndUnhandledRejections() {
+  // unhandledRejection fires on a macrotask boundary after the rejection is
+  // left without a handler, so a timer tick is needed before asserting none
+  // fired.
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+module(basename(import.meta.filename), function (hooks) {
+  let unhandledRejections: unknown[] = [];
+  let captureUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+
+  hooks.beforeEach(function () {
+    unhandledRejections = [];
+    process.on('unhandledRejection', captureUnhandledRejection);
+  });
+
+  hooks.afterEach(function () {
+    process.off('unhandledRejection', captureUnhandledRejection);
+  });
+
+  test('a failing job rejects settled with a real Error carrying the serialized detail', async function (assert) {
+    let { queue, waiters } = makeStubQueue();
+    let updater = new RealmIndexUpdater({
+      realm: makeStubRealm(),
+      dbAdapter: {} as DBAdapter,
+      queue,
+    });
+
+    let { settled } = await updater.enqueueUpdate([
+      new URL(`${realmURL}doomed.txt`),
+    ]);
+    waiters[0].rejectFromResult(serializedWorkerError);
+
+    let settledError: unknown;
+    try {
+      await settled;
+    } catch (e) {
+      settledError = e;
+    }
+    assert.true(
+      settledError instanceof Error,
+      'settled rejects with an Error instance, not a plain object',
+    );
+    assert.true(
+      (settledError as Error).message.includes('ENOENT'),
+      `the Error message carries the serialized worker error detail: ${
+        (settledError as Error).message
+      }`,
+    );
+  });
+
+  test('a failing job left fire-and-forget does not produce an unhandled rejection', async function (assert) {
+    let { queue, waiters } = makeStubQueue();
+    let updater = new RealmIndexUpdater({
+      realm: makeStubRealm(),
+      dbAdapter: {} as DBAdapter,
+      queue,
+    });
+
+    // The deferred-indexing path attaches a catch to `settled` but nothing
+    // ever awaits the quiescence gate. The gate must not reject: a rejecting
+    // gate with no listener is an unhandled rejection, which aborts native
+    // Node and fails any vitest/qunit run that polices unhandled errors.
+    let { settled } = await updater.enqueueUpdate([
+      new URL(`${realmURL}doomed.txt`),
+    ]);
+    settled.catch(() => {});
+
+    waiters[0].rejectFromResult(serializedWorkerError);
+    await settleMicrotasksAndUnhandledRejections();
+
+    assert.deepEqual(
+      unhandledRejections,
+      [],
+      'no unhandled rejection escapes the fire-and-forget path',
+    );
+    assert.strictEqual(
+      updater.incrementalIndexing(),
+      undefined,
+      'the gate is drained after the job fails',
+    );
+  });
+
+  test('the quiescence gate resolves even when the job fails', async function (assert) {
+    let { queue, waiters } = makeStubQueue();
+    let updater = new RealmIndexUpdater({
+      realm: makeStubRealm(),
+      dbAdapter: {} as DBAdapter,
+      queue,
+    });
+
+    let { settled } = await updater.enqueueUpdate([
+      new URL(`${realmURL}doomed.txt`),
+    ]);
+    settled.catch(() => {});
+    let gate = updater.incrementalIndexing();
+    assert.notStrictEqual(gate, undefined, 'gate reflects the in-flight job');
+
+    waiters[0].rejectFromResult(serializedWorkerError);
+
+    // Resolves rather than rejects: the gate reports quiescence, not success.
+    await gate;
+    assert.strictEqual(
+      updater.incrementalIndexing(),
+      undefined,
+      'gate is drained once the failed job settles',
+    );
+  });
+
+  test('a pre-enqueue publish failure rejects enqueueUpdate and cleans up the gate', async function (assert) {
+    let queue: QueuePublisher = {
+      publish: async () => {
+        throw new Error('durable enqueue failed');
+      },
+      destroy: async () => {},
+    };
+    let updater = new RealmIndexUpdater({
+      realm: makeStubRealm(),
+      dbAdapter: {} as DBAdapter,
+      queue,
+    });
+
+    await assert.rejects(
+      updater.enqueueUpdate([new URL(`${realmURL}doomed.txt`)]),
+      /durable enqueue failed/,
+      'the caller hears about a failed enqueue via the method throw',
+    );
+    await settleMicrotasksAndUnhandledRejections();
+
+    assert.deepEqual(
+      unhandledRejections,
+      [],
+      'no unhandled rejection escapes the pre-enqueue failure path',
+    );
+    assert.strictEqual(
+      updater.incrementalIndexing(),
+      undefined,
+      'the gate is cleaned up after a failed enqueue',
+    );
+  });
+
+  test('a failing copy job throws from copy() and resolves the gate', async function (assert) {
+    let { queue, waiters } = makeStubQueue();
+    let updater = new RealmIndexUpdater({
+      realm: makeStubRealm(),
+      dbAdapter: {} as DBAdapter,
+      queue,
+    });
+
+    let copyPromise = updater.copy(new URL('http://127.0.0.1:4444/source/'));
+    copyPromise.catch(() => {});
+    while (waiters.length === 0) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    let gate = updater.incrementalIndexing();
+    assert.notStrictEqual(gate, undefined, 'gate reflects the in-flight copy');
+
+    waiters[0].rejectFromResult(serializedWorkerError);
+
+    let copyError: unknown;
+    try {
+      await copyPromise;
+    } catch (e) {
+      copyError = e;
+    }
+    assert.deepEqual(
+      copyError,
+      serializedWorkerError,
+      'copy() rejects with the job failure',
+    );
+    await gate;
+    await settleMicrotasksAndUnhandledRejections();
+
+    assert.deepEqual(
+      unhandledRejections,
+      [],
+      'no unhandled rejection escapes the copy failure path',
+    );
+    assert.strictEqual(
+      updater.incrementalIndexing(),
+      undefined,
+      'gate is drained once the failed copy settles',
+    );
+  });
+});

--- a/packages/realm-server/tests/worker-reader-test.ts
+++ b/packages/realm-server/tests/worker-reader-test.ts
@@ -1,0 +1,78 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename, join } from 'path';
+import { tmpdir } from 'os';
+import { PassThrough } from 'node:stream';
+import fsExtra from 'fs-extra';
+const { createReadStream } = fsExtra;
+import {
+  getReader,
+  type ResponseWithNodeStream,
+} from '@cardstack/runtime-common';
+
+const realmURL = 'http://127.0.0.1:4444/test/';
+
+function okResponseWithNodeStream(
+  stream: NodeJS.ReadableStream,
+): ResponseWithNodeStream {
+  let response = new Response(null, {
+    status: 200,
+    headers: { 'last-modified': 'Tue, 05 Nov 2024 01:02:03 GMT' },
+  }) as ResponseWithNodeStream;
+  response.nodeStream = stream as ResponseWithNodeStream['nodeStream'];
+  return response;
+}
+
+module(basename(import.meta.filename), function () {
+  test('readFile treats a file that vanishes between the response and the body read as not found', async function (assert) {
+    // A realm serving an in-process worker hands back a lazy node stream:
+    // the open() syscall happens when the body is consumed, not when the
+    // response is built. A concurrent delete in that window surfaces as an
+    // ENOENT on the body read of an otherwise-ok response. Model that with
+    // a read stream pointing at a path that no longer exists.
+    let vanishedPath = join(
+      tmpdir(),
+      `worker-reader-test-vanished-${process.pid}.txt`,
+    );
+    let reader = getReader(
+      async () => okResponseWithNodeStream(createReadStream(vanishedPath)),
+      realmURL,
+    );
+
+    let result = await reader.readFile(new URL(`${realmURL}vanished.txt`));
+
+    assert.strictEqual(
+      result,
+      undefined,
+      'a vanished file reads as not found instead of rejecting with ENOENT',
+    );
+  });
+
+  test('readFile propagates non-ENOENT body read failures', async function (assert) {
+    let stream = new PassThrough();
+    let reader = getReader(
+      async () => okResponseWithNodeStream(stream),
+      realmURL,
+    );
+
+    let readPromise = reader.readFile(new URL(`${realmURL}unlucky.txt`));
+    setImmediate(() => stream.destroy(new Error('stream exploded')));
+
+    await assert.rejects(
+      readPromise,
+      /stream exploded/,
+      'a body read failure that is not a missing file still rejects',
+    );
+  });
+
+  test('readFile returns undefined for a not-ok response', async function (assert) {
+    let reader = getReader(
+      async () => new Response(null, { status: 404 }),
+      realmURL,
+    );
+
+    let result = await reader.readFile(new URL(`${realmURL}missing.txt`));
+
+    assert.strictEqual(result, undefined, 'a 404 reads as not found');
+  });
+});

--- a/packages/runtime-common/jobs/indexing.ts
+++ b/packages/runtime-common/jobs/indexing.ts
@@ -67,7 +67,15 @@ export function mapIncrementalDoneResult(
   return (result: PgPrimitive) => {
     let parsedResult = parseIncrementalResult(result);
     if (!parsedResult) {
-      throw result;
+      // `result` is either a serialized worker error (rejected job) or a
+      // malformed success payload — a plain object either way. Wrap it in a
+      // real Error so downstream logs show the detail instead of
+      // "[object Object]" and instanceof-Error handling applies.
+      throw new Error(
+        `incremental-index job did not produce a usable result: ${JSON.stringify(
+          result,
+        )}`,
+      );
     }
     return {
       ...parsedResult,

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -54,6 +54,16 @@ export class RealmIndexUpdater {
   // gate exists to serialize. From-scratch jobs are tracked too, but only so
   // that callers wanting "all indexing has settled" semantics (e.g. publish)
   // continue to see them via `indexing()`.
+  //
+  // These deferreds are quiescence signals, not success signals: they are
+  // always fulfilled, never rejected, even when the underlying job fails.
+  // Failures travel to interested callers via the per-job promise (`settled`
+  // for incremental, `completed` for from-scratch, the method's own throw
+  // for copy) and via error_doc inside the worker. Rejecting the gate would
+  // (a) turn a background indexing failure into a 500 for whatever
+  // unrelated request happens to be awaiting the write-path gate, and
+  // (b) become an unhandled promise rejection whenever a deferred-indexing
+  // job fails while nothing is draining the gate.
   #incrementalIndexingDeferreds = new Set<Deferred<void>>();
   #fullIndexingDeferreds = new Set<Deferred<void>>();
 
@@ -252,13 +262,14 @@ export class RealmIndexUpdater {
         mapResult: mapIncrementalDoneResult(clientRequestId),
       });
     } catch (e: any) {
-      indexingDeferred.reject(e);
+      indexingDeferred.fulfill();
       this.#incrementalIndexingDeferreds.delete(indexingDeferred);
       throw e;
     }
     // Past the durable-enqueue boundary. Build the settle promise that the
     // caller can either await (synchronous-indexing path) or fire-and-forget
-    // (deferred-indexing path).
+    // (deferred-indexing path). Failures reject `settled` only — the
+    // quiescence gate always fulfills (see #incrementalIndexingDeferreds).
     let settled = (async () => {
       try {
         let { invalidations, ignoreData, stats, generation } = await job.done;
@@ -278,9 +289,6 @@ export class RealmIndexUpdater {
         if (opts?.onSettled) {
           await opts.onSettled();
         }
-      } catch (e: any) {
-        indexingDeferred.reject(e);
-        throw e;
       } finally {
         indexingDeferred.fulfill();
         this.#incrementalIndexingDeferreds.delete(indexingDeferred);
@@ -330,9 +338,6 @@ export class RealmIndexUpdater {
         );
       }
       return { generation };
-    } catch (e: any) {
-      indexingDeferred.reject(e);
-      throw e;
     } finally {
       indexingDeferred.fulfill();
       this.#incrementalIndexingDeferreds.delete(indexingDeferred);

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -59,6 +59,7 @@ import {
   CardError,
   responseWithError,
   formattedError,
+  stringifyErrorForLog,
   unsupportedMediaType,
   type SerializedError,
 } from './error.ts';
@@ -2128,11 +2129,12 @@ export class Realm {
           },
         );
         settled.catch((err: unknown) => {
-          let message = err instanceof Error ? err.message : String(err);
           // Covers worker job rejection AND post-worker realm-side work
           // (onInvalidation / handleExecutableInvalidations / broadcast).
           this.#log.error(
-            `Deferred indexing chain failed for ${this.url}: ${message}`,
+            `Deferred indexing chain failed for ${this.url} (urls: ${urls
+              .map((u) => u.href)
+              .join(', ')}): ${stringifyErrorForLog(err)}`,
           );
         });
       }
@@ -2626,12 +2628,8 @@ export class Realm {
           );
         },
         (err: unknown) => {
-          let detail =
-            err instanceof Error
-              ? `${err.message}${err.stack ? `\n${err.stack}` : ''}`
-              : String(err);
           this.#log.error(
-            `Deferred delete-indexing chain failed for ${url.href} after ${Date.now() - enqueueStart}ms: ${detail}`,
+            `Deferred delete-indexing chain failed for ${url.href} after ${Date.now() - enqueueStart}ms: ${stringifyErrorForLog(err)}`,
           );
         },
       );

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -287,6 +287,7 @@ export function getReader(
   _fetch: typeof globalThis.fetch,
   realmURL: string,
 ): Reader {
+  let readerLog = logger('worker');
   let parseResponseMetadata = (
     response: Response,
     url: URL,
@@ -332,12 +333,29 @@ export function getReader(
         return undefined;
       }
       let content: string;
-      if ('nodeStream' in response && response.nodeStream) {
-        content = await fileContentToText({
-          content: response.nodeStream,
-        });
-      } else {
-        content = await response.text();
+      try {
+        if ('nodeStream' in response && response.nodeStream) {
+          content = await fileContentToText({
+            content: response.nodeStream,
+          });
+        } else {
+          content = await response.text();
+        }
+      } catch (err: any) {
+        // An in-process realm serves file bodies as lazy node streams: the
+        // realm checks existence when it builds the response, but the
+        // underlying open() happens only when we consume the body here. A
+        // file deleted in that window surfaces as an ENOENT on the body
+        // read even though the response itself was ok. That is a
+        // not-found, same as the !response.ok branch above — callers
+        // already treat undefined as "file no longer exists".
+        if (err?.code === 'ENOENT') {
+          readerLog.info(
+            `file ${url.href} disappeared while reading its body (ENOENT); treating as not found`,
+          );
+          return undefined;
+        }
+        throw err;
       }
       let { lastModified, created, path } = parseResponseMetadata(
         response,


### PR DESCRIPTION
## Background

A [Boxel CLI Tests CI run](https://github.com/cardstack/boxel/actions/runs/29050170765/job/86229191110) failed with every one of its 282 tests passing. Vitest exited 1 because it caught an unhandled promise rejection during the realm-watch suite:

```
Unhandled Rejection
Unknown Error: ENOENT: no such file or directory, open '<tmp realm dir>/doomed.txt'
```

The realm-watch delete test writes a file and then deletes it. The write queues an incremental-index update job; when the delete lands before that job runs, the job reads a file that no longer exists. Two separate weaknesses turned that benign race into a CI failure.

**The read path turns a vanished file into a raw ENOENT instead of a not-found.** A realm serving an in-process worker hands file bodies back as lazy node streams: the realm checks the file exists when it builds the response, but the underlying `open()` happens only when the worker consumes the body. A file deleted in that window rejects the body read with a raw filesystem ENOENT. The indexer's vanished-file handling only recognizes a `CardError` 404, so the job fails instead of skipping the file the way it does when the realm answers 404 outright.

**A failed index job rejected the indexing quiescence gate.** `RealmIndexUpdater` tracks in-flight indexing with deferreds that the realm write path awaits as a gate (`incrementalIndexing()`). On job failure, `enqueueUpdate` and `copy` rejected that gate deferred. On the deferred-indexing path (`+source` / binary POSTs) nothing holds the gate, so the rejection had no handler — an unhandled rejection, which aborts native Node and fails any test runner that polices unhandled errors. It also meant a background indexing failure could 500 whatever unrelated request happened to be awaiting the write-path gate.

## What this PR does

- `getReader.readFile` treats an ENOENT while reading the body of an otherwise-ok response as not-found and returns `undefined` — the signal the index and prerender visit paths already handle gracefully as a vanished file. Non-ENOENT read failures still propagate.
- `NodeAdapter.openFile` / `lastModified` tolerate a file deleted between the existence check and the stat, returning not-found instead of throwing.
- The `RealmIndexUpdater` quiescence deferreds are now fulfill-only: they signal quiescence, not success. Job failures travel to interested callers via the `settled` promise (incremental), `completed` (from-scratch), or `copy()`'s own throw — all of which already have handlers — and via `error_doc` inside the worker. This matches the existing `publishFullIndex` behavior.
- Diagnostics for the next occurrence: `mapIncrementalDoneResult` wraps an unusable job result (a serialized worker error is the common case) in a real `Error` carrying the JSON detail, and the realm's deferred-chain failure logs use `stringifyErrorForLog` and name the written URLs. These log sites printed `[object Object]` when handed a plain serialized-error object.

## Tests

New unit tests in `packages/realm-server/tests`:

- `worker-reader-test.ts` — a body read that ENOENTs resolves to `undefined`; non-ENOENT stream failures still reject; a 404 response reads as not-found.
- `realm-index-updater-test.ts` — a failing job rejects `settled` with a real `Error` carrying the serialized detail; a fire-and-forget failure produces no unhandled rejection; the quiescence gate resolves rather than rejects on job failure; pre-enqueue publish failures and copy-job failures clean up the gate without unhandled rejections.

Run against the unfixed source, the reader test rejects with the same raw ENOENT as the CI failure and the updater tests crash the runner with the same unhandled `{"code":"ENOENT","syscall":"open",...}` rejection. With the fix, all pass, and the boxel-cli `realm-watch` integration suite passes 5/5 consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
