### PR TITLE
Prefer a markdown skill's heading title over its name slug in the skill menu

### DIFF
--- a/packages/host/app/components/ai-assistant/skill-menu/skill-toggle.gts
+++ b/packages/host/app/components/ai-assistant/skill-menu/skill-toggle.gts
@@ -60,8 +60,9 @@ export default class SkillToggle extends Component<SkillToggleSignature> {
     return this.cardResource?.card;
   }
 
-  // Title for either skill source: `cardTitle` for a Skill card, the
-  // frontmatter name / title for a skill markdown file.
+  // Title for either skill source: `cardTitle` for a Skill card; for a skill
+  // markdown file, the title indexed from its first heading, falling back to
+  // the frontmatter name slug only when the file has no heading.
   private get displayTitle(): string | undefined {
     let card = this.card as
       | {
@@ -74,7 +75,7 @@ export default class SkillToggle extends Component<SkillToggleSignature> {
     if (!card) {
       return undefined;
     }
-    return card.cardTitle ?? card.frontmatter?.name ?? card.title ?? card.name;
+    return card.cardTitle ?? card.title ?? card.frontmatter?.name ?? card.name;
   }
 
   private get isCreating() {


### PR DESCRIPTION
The room skill menu labeled markdown skills with their kebab-case frontmatter slug (`source-code-editing`) because the display-title fallback chain checked `frontmatter.name` before the file's indexed title. Reordering the chain shows the H1 the realm already extracts ("Source Code Editing"), with the slug remaining as last resort for heading-less files. Skill cards are unaffected — `cardTitle` still wins first. The prompt-facing title in prompt assembly deliberately keeps the slug, since skills cross-reference each other by slug in prose.

Before:
<img width="383" height="268" alt="image" src="https://github.com/user-attachments/assets/de6ead52-e37e-423c-b1b7-e1731aa9e77e" />


After:
<img width="373" height="154" alt="image" src="https://github.com/user-attachments/assets/f32a7fb6-482d-4664-b9ea-75639bd9f63d" />
