### PR TITLE
Record postLoginCompleted transitions in host login-timeout diagnostic

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -170,6 +170,11 @@ const MAX_UNREACHABLE_RETRY_ATTEMPTS = 6;
 
 const realmEventsLogger = logger('realm:events');
 
+// Bound on the test-only `postLoginCompleted` transition record below. A boot
+// records one →true and a teardown one →false, so a handful of entries covers
+// even a re-entrant boot; keeping the most recent dozen is ample.
+const MAX_POST_LOGIN_TRANSITIONS = 12;
+
 export default class MatrixService extends Service {
   @service declare private loaderService: LoaderService;
   @service declare private loggerService: LoggerService;
@@ -187,6 +192,19 @@ export default class MatrixService extends Service {
   @tracked private _client: ExtendedClient | undefined;
   @tracked private _isInitializingNewUser = false;
   @tracked private postLoginCompleted = false;
+  // Test-only provenance for the intermittent cold-boot "operator-mode renders
+  // the login form" flake: a bounded record of every `postLoginCompleted`
+  // transition (direction + reason + wall-clock + stack). The CI console output
+  // is a rolling buffer that evicts the causal reset before the post-timeout
+  // diagnostic runs, so this structured record — sampled into that diagnostic
+  // (see host tests/helpers/setup.ts) — survives to name which caller flipped
+  // the flag and when. Written only under `isTesting()`; never in production.
+  #postLoginTransitions: {
+    to: boolean;
+    reason: string;
+    atMs: number;
+    stack: string;
+  }[] = [];
   // When true, `app.boxel.realm-servers` is the authoritative source of
   // the user's realm list and `app.boxel.realms` events are ignored for
   // `setAvailableRealmIdentifiers`. Set during boot from whether that key
@@ -487,14 +505,52 @@ export default class MatrixService extends Service {
 
   // Test-only diagnostic for the intermittent "operator-mode renders the login
   // form" flake: names which precondition of `isLoggedIn` is unmet when a route
-  // decides to render <Auth/>. No production caller.
+  // decides to render <Auth/>, plus a compact tail of the `postLoginCompleted`
+  // transitions that got it there. No production caller.
   get loginReadinessDebug() {
+    let now = Date.now();
     return {
       authPresent: Boolean(this.getAuth()),
       clientExists: Boolean(this._client),
       clientLoggedIn: this._client?.isLoggedIn() === true,
       postLoginCompleted: this.postLoginCompleted,
+      postLoginTransitions: this.#postLoginTransitions.map(
+        (t) =>
+          `${t.to ? '→true' : '→false'}(${t.reason}, ${now - t.atMs}ms ago)`,
+      ),
     };
+  }
+
+  // Full `postLoginCompleted` transition provenance, with stacks, for the
+  // eviction-proof timeout diagnostic. `msAgo` is computed at read time so it
+  // stays meaningful after a snapshot survives owner teardown. Test-only.
+  get postLoginTransitionsDebug() {
+    let now = Date.now();
+    return this.#postLoginTransitions.map((t) => ({
+      to: t.to,
+      reason: t.reason,
+      msAgo: now - t.atMs,
+      stack: t.stack,
+    }));
+  }
+
+  // Route every `postLoginCompleted` write through here so the transition
+  // record above captures which caller flipped it and when. The recording is
+  // `isTesting()`-gated, so in production this is just the field assignment —
+  // no runtime behavior change.
+  private setPostLoginCompleted(value: boolean, reason: string) {
+    if (isTesting()) {
+      this.#postLoginTransitions.push({
+        to: value,
+        reason,
+        atMs: Date.now(),
+        stack: new Error().stack ?? '<no stack>',
+      });
+      if (this.#postLoginTransitions.length > MAX_POST_LOGIN_TRANSITIONS) {
+        this.#postLoginTransitions.shift();
+      }
+    }
+    this.postLoginCompleted = value;
   }
 
   // Test-only diagnostic exposing which boot path the current session is on.
@@ -622,7 +678,7 @@ export default class MatrixService extends Service {
             new Error().stack,
         );
       }
-      this.postLoginCompleted = false;
+      this.setPostLoginCompleted(false, 'logout');
       // Logout is the explicit boundary where we forget persisted workspace UI
       // state for the signed-in user. Generic reset paths must stay in-memory
       // only so tests and app reloads do not accidentally wipe durable state.
@@ -1084,7 +1140,7 @@ export default class MatrixService extends Service {
         if (isTesting()) console.warn('[start-phase] loginToRealms');
         await this.loginToRealms();
 
-        this.postLoginCompleted = true;
+        this.setPostLoginCompleted(true, 'start-success');
         if (isTesting()) console.warn('[start-phase] postLoginCompleted=true');
 
         // If any trusted server was unreachable during boot assembly, keep
@@ -1993,7 +2049,7 @@ export default class MatrixService extends Service {
           new Error().stack,
       );
     }
-    this.postLoginCompleted = false;
+    this.setPostLoginCompleted(false, 'resetState');
     this.bootedFromLegacyRealmsList = false;
     this._isLoadingMoreAIRooms = false;
     this.messagesToSend.clear();

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -375,6 +375,7 @@ function logRejectionDiagnostics(prefix: string, formattedReason: string) {
         : 'recent failed fetches this test: <none>',
       summarizeSettledState(),
       summarizeRealmAuth(),
+      summarizeLoginReadiness(),
       summarizeEventLoopLag(),
       summarizeDomSnapshot(),
     ]
@@ -399,6 +400,15 @@ let eventLoopLagSamplerStarted = false;
 // is torn down and the live container is empty — so this preserves what the
 // hung test was actually rendering ~during the stall.
 let lastMountedDomSnapshot = '';
+// Last matrix login-readiness + `postLoginCompleted` transition provenance
+// captured while a test was still mounted. Sampled here (rather than read at
+// QUnit.testDone) for the same reason as the DOM snapshot — the owner is torn
+// down by then — and because the CI console output is a rolling buffer that
+// evicts the causal reset before the post-timeout diagnostic runs. Preserving
+// which caller last flipped `postLoginCompleted` turns an opaque cold-boot
+// login-screen timeout (DOM shows the login form, `postLoginCompleted:false`)
+// into one that names the reset.
+let lastLoginReadinessSnapshot = '';
 function startEventLoopLagSampler() {
   if (eventLoopLagSamplerStarted) return;
   eventLoopLagSamplerStarted = true;
@@ -425,7 +435,88 @@ function startEventLoopLagSampler() {
     } catch {
       // never let diagnostics sampling throw
     }
+    try {
+      let snapshot = captureLoginReadinessSnapshot();
+      // Only overwrite with a real reading so a between-tests / post-teardown
+      // tick (owner gone) doesn't clobber the last mounted snapshot.
+      if (snapshot) {
+        lastLoginReadinessSnapshot = snapshot;
+      }
+    } catch {
+      // never let diagnostics sampling throw
+    }
   }, EVENT_LOOP_LAG_INTERVAL_MS);
+}
+
+interface PostLoginTransitionDebug {
+  to: boolean;
+  reason: string;
+  msAgo: number;
+  stack: string;
+}
+
+// Read the current test's matrix login-readiness from the container cache
+// (never `lookup`, so sampling can't instantiate the service for a test that
+// doesn't use it) and format it, including a compact tail of each recent
+// `postLoginCompleted` transition's stack. Returns undefined when there is no
+// active owner or the service was never instantiated.
+function captureLoginReadinessSnapshot(): string | undefined {
+  let owner = (
+    getContext() as
+      | { owner?: { __container__?: { cache?: Record<string, unknown> } } }
+      | undefined
+  )?.owner;
+  let service = owner?.__container__?.cache?.['service:matrix-service'] as
+    | {
+        loginReadinessDebug?: unknown;
+        postLoginTransitionsDebug?: PostLoginTransitionDebug[];
+      }
+    | undefined;
+  if (!service) {
+    return undefined;
+  }
+  let readiness = service.loginReadinessDebug;
+  let transitions = service.postLoginTransitionsDebug ?? [];
+  let transitionLines = transitions.length
+    ? transitions
+        .map((t) => {
+          // Skip the Error header + the setter frame; keep the caller chain
+          // that identifies who flipped the flag (start-success / logout /
+          // resetState → afterEach, etc.).
+          let frames = (t.stack ?? '')
+            .split('\n')
+            .slice(2, 6)
+            .map((f) => f.trim())
+            .filter(Boolean);
+          return `${t.to ? '→true' : '→false'} via ${t.reason} (${t.msAgo}ms ago)${
+            frames.length ? `\n      ${frames.join('\n      ')}` : ''
+          }`;
+        })
+        .join('\n    ')
+    : '<none recorded>';
+  return [
+    `flags: ${JSON.stringify(readiness)}`,
+    `postLoginCompleted transitions (most recent last):\n    ${transitionLines}`,
+  ].join('\n  ');
+}
+
+// Matrix login-readiness at failure time — the missing half of a cold-boot
+// login-screen timeout. The DOM snapshot shows the login form rendered; this
+// shows WHY (`postLoginCompleted:false` despite `clientLoggedIn:true`) and
+// which caller reset it. Prefers a live read when the owner is still around
+// (during-test rejection paths); on QUnit's post-teardown timeout path the
+// owner is gone, so it falls back to the last value sampled while mounted.
+function summarizeLoginReadiness(): string {
+  try {
+    let snapshot =
+      captureLoginReadinessSnapshot() ?? lastLoginReadinessSnapshot;
+    if (!snapshot) {
+      return 'matrix login readiness: <unavailable>';
+    }
+    return `matrix login readiness:\n  ${snapshot}`;
+  } catch (error) {
+    return `matrix login readiness: <unavailable: ${formatErrorForLog(error)}>`;
+  }
 }
 
 function summarizeEventLoopLag(): string {


### PR DESCRIPTION
## Background

Host acceptance tests occasionally time out sitting on the sign-in form even though the user is already authenticated: the matrix client reports `clientLoggedIn: true` but the service's `postLoginCompleted` flag is `false`, so the index route renders `<Auth/>` and the test hangs waiting for operator-mode content that never appears.

The existing `[test-timeout]` diagnostic captures the rendered DOM (which shows the login form) but not *why* `postLoginCompleted` was false. Two things hide the cause:

- The per-test browser console is a rolling buffer, and on a 60s timeout the causal reset scrolls out of it before the diagnostic is emitted.
- The diagnostic runs at `QUnit.testDone`, after the app owner is torn down, so it can't read the matrix service to reconstruct what happened.

## What this changes

Diagnostics only — no production behavior change.

- `MatrixService` keeps a bounded, `isTesting()`-gated record of every `postLoginCompleted` transition (direction, reason, time, stack), surfaced on `loginReadinessDebug` and a full-stack `postLoginTransitionsDebug`. All writes to the flag now route through a single setter, so nothing can transition without being recorded.
- The host timeout diagnostic samples this readiness every 500ms while a test is mounted — the same approach already used to preserve the DOM snapshot past teardown — and prints it in the `[test-timeout]` dump.

## Effect

The next cold-boot login-screen timeout will show, in the timeout dump, the sequence of `postLoginCompleted` transitions with a caller stack for each — e.g. that `resetState()` (called from an `afterEach`) cleared the flag N ms before the failure. That pinpoints the reset trigger so the underlying race can be fixed with certainty.

Sample output shape:

```
matrix login readiness:
  flags: {"authPresent":true,"clientExists":true,"clientLoggedIn":true,"postLoginCompleted":false,"postLoginTransitions":[...]}
  postLoginCompleted transitions (most recent last):
    →true via start-success (47000ms ago)
      at MatrixService.start (...)
    →false via resetState (1200ms ago)
      at MatrixService.resetState (...)
      at resetServiceIfPresent (...)
      at Object.<anonymous> (afterEach ...)
```

## Test plan

- `pnpm lint:types` (glint/ember-tsc) clean on `@cardstack/host`
- `eslint` clean on both changed files
- No production code path changed: the transition recording is `isTesting()`-gated and the timeout diagnostic lives entirely in test helpers
