### PR TITLE
Profile the index job's between-visit wall

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: indexing-diagnostics
-description: Investigate slow or failing indexing using the per-row diagnostics persisted split by visit — the index visit's breakdown on `boxel_index.diagnostics`, the prerender-html visit's render breakdown (launch/wait/render timings, per-format render timings) on `prerendered_html.diagnostics`, each mirrored onto its table's `error_doc.diagnostics` for error rows, joinable per row via url + the two request ids — plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most, (3) enumerating cards with broken `linksTo` / `linksToMany` targets via `diagnostics.brokenLinks` (those cards index cleanly, so this is the only indexed signal), (4) verifying the module pre-warm phase populates the definition cache under a key the indexer / on-demand prerender reads actually hit — i.e. it isn't a silent no-op — via the `definition-cache-key` hit/miss log channel, and (5) attributing a slow in-render `_search` round-trip to the realm-server's own request→response stages (parse / SQL / loadLinks / serialize / queue) via the `realm:search-timing`, `realm:requests` (`dur=`), and `realm:health` log channels keyed by the `x-boxel-logging-correlation-id` correlation id, and (6) capturing full CPU profiles / CDP traces / heap-allocation profiles to the prerender S3 artifact bucket (`boxel-prerender-artifacts-<env>`) when the summary signals name a hot function but you need the whole call tree, a JS-vs-GC-vs-layout breakdown, or a heap-growth story — the streaming trace is the only capture that survives a fully-wedged renderer; gated behind `PRERENDER_PROFILE_AFFINITY` + per-mode SSM flags and pulled with the `boxel-claude-readonly` S3 read grant, and (7) attributing a slow search-doc build to specific fields and link loads — the settle loop's per-target load timings (`searchDocSettleMs` / `searchDocLinkLoads`) vs the field walk's per-dotted-path evaluation timings (`searchDocMs` / `searchDocFieldsMs`), both on `boxel_index.diagnostics`. Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, when investigating prerender-saturation incidents, when a render stalls in `waiting-stability` on a `_search` whose SQL is fast but whose response is slow to come back, when a row's index visit is slow and you need to know which field or link load inside the search doc ate the time, or when asked to list / count cards with broken links in a realm. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
+description: Investigate slow or failing indexing using the per-row diagnostics persisted split by visit — the index visit's breakdown on `boxel_index.diagnostics`, the prerender-html visit's render breakdown (launch/wait/render timings, per-format render timings) on `prerendered_html.diagnostics`, each mirrored onto its table's `error_doc.diagnostics` for error rows, joinable per row via url + the two request ids — plus the matching prerender-server / manager logs. Covers (1) a render inside indexing timed out — classify which part of the prerender pipeline stalled, (2) an incremental or full reindex was slow but didn't fail — attribute time across the invalidation fan-out and find the rows that cost the most, (3) enumerating cards with broken `linksTo` / `linksToMany` targets via `diagnostics.brokenLinks` (those cards index cleanly, so this is the only indexed signal), (4) verifying the module pre-warm phase populates the definition cache under a key the indexer / on-demand prerender reads actually hit — i.e. it isn't a silent no-op — via the `definition-cache-key` hit/miss log channel, and (5) attributing a slow in-render `_search` round-trip to the realm-server's own request→response stages (parse / SQL / loadLinks / serialize / queue) via the `realm:search-timing`, `realm:requests` (`dur=`), and `realm:health` log channels keyed by the `x-boxel-logging-correlation-id` correlation id, and (6) capturing full CPU profiles / CDP traces / heap-allocation profiles to the prerender S3 artifact bucket (`boxel-prerender-artifacts-<env>`) when the summary signals name a hot function but you need the whole call tree, a JS-vs-GC-vs-layout breakdown, or a heap-growth story — the streaming trace is the only capture that survives a fully-wedged renderer; gated behind `PRERENDER_PROFILE_AFFINITY` + per-mode SSM flags and pulled with the `boxel-claude-readonly` S3 read grant, and (7) attributing a slow search-doc build to specific fields and link loads — the settle loop's per-target load timings (`searchDocSettleMs` / `searchDocLinkLoads`) vs the field walk's per-dotted-path evaluation timings (`searchDocMs` / `searchDocFieldsMs`), both on `boxel_index.diagnostics`, and (8) decomposing the between-visit / non-render slice of an index job's wall — the once-per-job phases (invalidation discovery, dependency ordering, module pre-warm, aggregate row writes, the final swap) on `jobs.result.phaseTimings` plus the per-row client overhead (file read / render round-trip transport / post-render bookkeeping) on `boxel_index.diagnostics.indexVisitClientMs` — the wall that runs serially between the server renders and is invisible in the per-row `totalElapsedMs`. Use when indexing fails with "Render timeout", when a user sees a 504, when a reindex took much longer than expected, when an `.gts` edit triggers a surprising amount of re-render work, when investigating prerender-saturation incidents, when a render stalls in `waiting-stability` on a `_search` whose SQL is fast but whose response is slow to come back, when a row's index visit is slow and you need to know which field or link load inside the search doc ate the time, or when asked to list / count cards with broken links in a realm. For staging/prod investigations this skill layers on top of `aws-access`, which provides the AWS session and the SSM port-forward path into the in-VPC database (authenticated as `claude_readonly_user`) — read that skill first when the question is about a deployed environment.
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
@@ -14,19 +14,21 @@ Every indexer write (`IndexWriter.updateEntry`) persists a diagnostic blob on th
 - **Whether module pre-warm is effective** — confirm the pre-warm phase populates the definition cache under a key the indexer / on-demand reads actually hit (not a silent no-op), using the `definition-cache-key` hit/miss log channel. This one isn't about the `diagnostics` column — it reads the logs. See [Mode F](#mode-f--module-pre-warm-and-definition-cache-hitmiss).
 - **Why an in-render `_search` was slow to come back** — when a render stalls in `waiting-stability` waiting on a query-backed `linksTo` / `linksToMany` search (the `boxel_index.diagnostics` shows it client-side as `queryLoadsInFlight` aging) but the SQL is fast, attribute the realm-server's request→response time across its stages (parse / SQL / loadLinks / serialize) and tell handler-time from queued-before-handler / event-loop saturation. Log-based, keyed by the correlation id. See [Mode G](#mode-g--an-in-render-_search-was-slow-server-side-search-timing).
 - **A search doc that was slow to build** — attribute a slow index visit inside the search-doc build itself: the settle loop's link loads (`searchDocSettleMs`, per target in `searchDocLinkLoads`) vs the field walk (`searchDocMs`, per dotted field path in `searchDocFieldsMs`). See [Mode J](#mode-j--a-search-doc-was-slow-to-build-per-field--per-link-attribution).
+- **The index job's wall didn't add up to its visits** — decompose the between-visit / non-render slice of an index job's wall (invalidation discovery, dependency ordering, module pre-warm, the serial per-visit client overhead, aggregate row writes, the final swap) into measured buckets: the once-per-job phases on `jobs.result.phaseTimings`, and the per-row client overhead on `boxel_index.diagnostics.indexVisitClientMs`. This is the wall that runs _between_ the server renders, so it's invisible in the per-row `totalElapsedMs` the other modes read. See [Mode K](#mode-k--the-index-jobs-between-visit-wall-non-render-overhead).
 
 The first three read from the same `diagnostics` column; the difference is the query you start with. Modes F and G are log-based.
 
 ## Where the diagnostics live
 
-Six places, all correlated:
+Seven places, all correlated:
 
-1. **`boxel_index.diagnostics` (and `boxel_index_working.diagnostics`)** — JSONB column, populated for **every** row the indexer writes, regardless of `has_error`. Source of truth for the **index visit** of a card/file: the `RenderTimeoutDiagnostics` server timings of that visit plus the host-side `PrerenderMetaDiagnostics` block (`serializeMs`, `searchDocMs`, `searchDocSettleMs`/`searchDocSettlePasses`, `searchDocFieldsMs`, `searchDocLinkLoads`, `computedCalls`/`computedCacheHits`) and three write-side stamps: `invalidationId`, `indexedAt`, `requestId`. It also carries a `brokenLinks` array on any card row whose render found a broken `linksTo` / `linksToMany` target — see [Mode E](#mode-e--enumerate-cards-with-broken-links). Note this is the one block that isn't about _timing_: a card with broken links still indexes as a clean `type='instance'` (the broken slot renders a placeholder), so `brokenLinks` is the only indexed signal that the row has a broken reference. Rows written by a fused single-visit pass (the SQLite in-browser path) carry one **combined** blob covering both visits here instead.
+1. **`boxel_index.diagnostics` (and `boxel_index_working.diagnostics`)** — JSONB column, populated for **every** row the indexer writes, regardless of `has_error`. Source of truth for the **index visit** of a card/file: the `RenderTimeoutDiagnostics` server timings of that visit plus the host-side `PrerenderMetaDiagnostics` block (`serializeMs`, `searchDocMs`, `searchDocSettleMs`/`searchDocSettlePasses`, `searchDocFieldsMs`, `searchDocLinkLoads`, `computedCalls`/`computedCacheHits`) and three write-side stamps: `invalidationId`, `indexedAt`, `requestId`. It also carries an `indexVisitClientMs` block (`read` / `renderRpc` / `bookkeeping`) — the indexer's per-row client-side overhead _outside_ the server render, i.e. this row's slice of the between-visit wall (see [Mode K](#mode-k--the-index-jobs-between-visit-wall-non-render-overhead)) — and a `brokenLinks` array on any card row whose render found a broken `linksTo` / `linksToMany` target — see [Mode E](#mode-e--enumerate-cards-with-broken-links). Note `brokenLinks` is the one block that isn't about _timing_: a card with broken links still indexes as a clean `type='instance'` (the broken slot renders a placeholder), so it's the only indexed signal that the row has a broken reference. Rows written by a fused single-visit pass (the SQLite in-browser path) carry one **combined** blob covering both visits here instead.
 2. **`prerendered_html.diagnostics` (and `prerendered_html_working.diagnostics`)** — JSONB column, populated for every row the `prerender_html` job writes, success and render-error alike. Source of truth for the **prerender-html visit**: launch/wait timings, `renderElapsedMs`/`totalElapsedMs`, the per-format `renderFormatsMs` breakdown, and the visit's HTTP correlation id under `prerenderHtmlRequestId` (never `requestId` — that name always means an index visit). See [Two visits, two tables](#two-visits-two-tables--which-timings-live-where).
 3. **`modules.diagnostics`** — JSONB column, populated for every row `persistModuleCacheEntry` writes (success and error paths). Source of truth for **module** renders (`prerenderModule` → definition extraction). Same `RenderTimeoutDiagnostics` shape with `requestId` flattened in; no `invalidationId` (modules don't go through `Batch.invalidate`). The row's existing `created_at` column is the wall-clock stamp for cross-table joins. See [Mode D](#mode-d--a-module-render-was-slow-or-hung) below.
 4. **`error_doc.diagnostics`** — derived copy of the same table's `diagnostics`, written only for error rows: an index error's copy rides `boxel_index.error_doc`, a render error's rides `prerendered_html.error_doc` (an instance's effective error is the union of the two). Exists so the existing UI read path (`error_doc` → `CardErrorJSONAPI.meta.diagnostics` via `formattedError`) keeps working without a schema rename. Non-error rows have `error_doc = null`; go to `diagnostics` directly.
 5. **Logs** — `prerender-server`, `manager`, and `remote-prerenderer` lines all carry `requestId=…`. `grep requestId=<uuid>` collates one call across all three processes. The same id lands on `boxel_index.diagnostics->>'requestId'` and `modules.diagnostics->>'requestId'` — and, for the render channel, on `prerendered_html.diagnostics->>'prerenderHtmlRequestId'` — so a hung card render and the module renders it triggered (via `getDefinition`) can be joined back to one investigation. For saturation incidents there's also the periodic `prerender-queue-snapshot` line on each prerender server.
 6. **Realm-server search-timing logs** — separate from the prerender `requestId` chain above. The realm-server emits, per instrumented `_federated-search`, a `realm:search-timing` line (request→response stage breakdown) and a `realm:requests` `-->` line with `dur=` (total) — both keyed by `corr=<id>`, the `x-boxel-logging-correlation-id` the prerendered host stamps. A periodic `realm:health` line reports event-loop lag + in-flight `_search` count during saturation windows. These are the _server's_ view of the search the card is blocked on; the card's `boxel_index.diagnostics` only has the _client's_ view (`queryLoadsInFlight`). See [Mode G](#mode-g--an-in-render-_search-was-slow-server-side-search-timing).
+7. **`jobs.result.phaseTimings`** — JSONB, one object per completed index job (on the `from-scratch-index` / `incremental-index` row's `result` column). The **job-level** phase decomposition: the once-per-job phases that surround and interleave the serial visit loop (`discoverMs`, `orderMs`, `preWarmMs`, `swapMs`, and the from-scratch-only `mtimesMs`), plus `visitLoopMs` (the whole serial loop), `writeMs` (the aggregate row-write time — tracked here, not per row, because a row can't time its own INSERT), and `totalMs`. This is the only place the _between-visit_ wall is attributed; the per-row server render lives on `boxel_index.diagnostics.totalElapsedMs` and the per-row client overhead on `boxel_index.diagnostics.indexVisitClientMs`. See [Mode K](#mode-k--the-index-jobs-between-visit-wall-non-render-overhead).
 
 For UI triage you'll typically read the JSON error response (which surfaces `error_doc.diagnostics` as `meta.diagnostics`). For operator / SQL triage — especially slow non-failing reindexes — query the `diagnostics` column directly.
 
@@ -43,10 +45,10 @@ When wrapping a query below into the staging/prod form, run it through the `psql
 
 A URL is produced by two prerender visits on two channels, and each visit's diagnostics follow its writes:
 
-| where                          | visit                | what's in it                                                                                                                                                                                                                                                                                                                                                                                                    |
-| ------------------------------ | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `boxel_index.diagnostics`      | index visit          | that visit's server timings (`launchMs`, `waits`, `renderElapsedMs`, `totalElapsedMs`), the search-doc build (`serializeMs`, `searchDocMs`, `searchDocSettleMs`/`searchDocSettlePasses`, the per-field `searchDocFieldsMs` and per-link-load `searchDocLinkLoads` detail, `computedCalls`/`computedCacheHits`), `brokenLinks`, and the write-side stamps (`invalidationId`, `indexedAt`). HTTP id: `requestId`. |
-| `prerendered_html.diagnostics` | prerender-html visit | that visit's server timings (`launchMs`, `waits`, `renderElapsedMs`, `totalElapsedMs`) plus `renderFormatsMs` — per-format wall-clock, split into a `card` and a `file` block with one number per html-route step (`isolated`, `head`, `atom`, `markdown`, `fitted`, `embedded`; the ancestor-driven `fitted`/`embedded` numbers each cover the whole ancestor chain). HTTP id: `prerenderHtmlRequestId`.       |
+| where                          | visit                | what's in it                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `boxel_index.diagnostics`      | index visit          | that visit's server timings (`launchMs`, `waits`, `renderElapsedMs`, `totalElapsedMs`), the search-doc build (`serializeMs`, `searchDocMs`, `searchDocSettleMs`/`searchDocSettlePasses`, the per-field `searchDocFieldsMs` and per-link-load `searchDocLinkLoads` detail, `computedCalls`/`computedCacheHits`), the indexer's own per-row client overhead outside the render (`indexVisitClientMs`: `read` / `renderRpc` / `bookkeeping` — see [Mode K](#mode-k--the-index-jobs-between-visit-wall-non-render-overhead)), `brokenLinks`, and the write-side stamps (`invalidationId`, `indexedAt`). HTTP id: `requestId`. |
+| `prerendered_html.diagnostics` | prerender-html visit | that visit's server timings (`launchMs`, `waits`, `renderElapsedMs`, `totalElapsedMs`) plus `renderFormatsMs` — per-format wall-clock, split into a `card` and a `file` block with one number per html-route step (`isolated`, `head`, `atom`, `markdown`, `fitted`, `embedded`; the ancestor-driven `fitted`/`embedded` numbers each cover the whole ancestor chain). HTTP id: `prerenderHtmlRequestId`.                                                                                                                                                                                                                 |
 
 So "why was indexing this card slow?" and "why was rendering this card slow?" are separately answerable per row: the index cost is `boxel_index.diagnostics`, the render cost is `prerendered_html.diagnostics`, and inside the render cost `renderFormatsMs` names the format that dominated (a slow `isolated` template vs a `fitted` render fanning out across many ancestors).
 
@@ -1133,6 +1135,98 @@ A large `searchDocMs` with **no** `searchDocFieldsMs` entries means no single fi
 - **Nothing below the field grain.** A hot leaf field's time is one number; profiling inside its `computeVia` is Mode H territory.
 - **A row can predate the instrumentation.** A row whose producing host build didn't emit these fields carries none of them; absence means "not measured", not "fast". Check `indexedAt` against when the realm was last reindexed.
 - **The bounded lists drop the tail.** Entries below the floor (or beyond the slowest 20) aren't persisted; the aggregates (`searchDocSettleMs`, `searchDocMs`) still carry the total, so the un-itemized remainder is the difference.
+
+## Mode K — the index job's between-visit wall (non-render overhead)
+
+**When to use this mode.** The other modes attribute time _inside_ a file visit — the server render (`totalElapsedMs`) and the search-doc build. But an index job's wall is more than the sum of its visits: it also runs invalidation discovery, dependency ordering, module pre-warm, the per-row client-side overhead the indexer pays around each render, the row writes, and the final swap — all **serial** with the visits, because the job runs one thing at a time. On a benchmark from-scratch, that between-visit slice was ~24% of the wall (Σ visit `totalElapsedMs` accounted for the other 76%). Use this mode when the job wall is much larger than the visit sum and you need to know _which_ non-render phase ate the difference — e.g. deciding whether pipelining the row writes behind the next visit is worth it, or whether discovery / swap dominate instead.
+
+This mode reads **two** sources that together reconstruct the whole wall:
+
+- **`jobs.result.phaseTimings`** — the once-per-job phases. Not attributable to a row, so they live on the job result.
+- **`boxel_index.diagnostics.indexVisitClientMs`** — the per-row client overhead the indexer paid around that row's render (`read` before it, `renderRpc` transport, `bookkeeping` after). Summed across the job's rows, this is the per-visit share of the wall that isn't server render and isn't the row write.
+
+### The decomposition identity
+
+For one index job:
+
+```
+totalMs  ≈  mtimesMs + discoverMs + orderMs + preWarmMs + visitLoopMs + swapMs        (job phases)
+
+visitLoopMs  ≈  Σ totalElapsedMs        (server render, per row — the well-instrumented 76%)
+              + Σ indexVisitClientMs.*  (read + renderRpc + bookkeeping, per row)
+              + writeMs                 (aggregate row writes — the I/O the tab doesn't need)
+```
+
+The `≈` covers small un-bucketed residue (loop control, progress events, resumed-row skips). `mtimesMs` / `preWarmMs` are from-scratch-only (incremental omits both). `writeMs` is aggregate on the job, **not** per row — a row can't time its own INSERT, so per-row `indexVisitClientMs` stops at `bookkeeping` (the pre-write window) and the writes roll up here. `swapMs` is the `batch.done()` transaction (realm-meta update + working→main promotion + obsolete-row prune), and `discoverMs` is the pre-loop invalidation fan-out; both are serial bookends around the visit loop, so they're the _irreducible_ part — the pipelining lever (overlap the write of row N with the visit of N+1, batch row writes) attacks `writeMs` and `bookkeeping`, not these.
+
+### Step 1 — pull the job's phase breakdown
+
+```sql
+SELECT id,
+       job_type,
+       status,
+       extract(epoch FROM (finished_at - started_at)) * 1000 AS wall_ms,
+       result->>'generation'      AS generation,
+       result->'phaseTimings'     AS phase_timings
+FROM jobs
+WHERE concurrency_group = 'indexing:<realm-url>'   -- e.g. indexing:https://app.example/team/realm/
+  AND status = 'resolved'
+ORDER BY id DESC
+LIMIT 5;
+```
+
+`phase_timings` is `{ totalMs, mtimesMs, discoverMs, orderMs, preWarmMs, visitLoopMs, writeMs, swapMs }` (ms). Read it against `wall_ms`: `totalMs` should land close to the job's wall; the gap between `visitLoopMs` and the visit render sum (step 2) is the per-visit client overhead + `writeMs`.
+
+### Step 2 — sum the per-row halves for the same job
+
+Correlate rows to the job by the generation it committed (every from-scratch row is stamped with it; an incremental stamps the rows it revisited):
+
+```sql
+SELECT count(*)                                                          AS rows,
+       round(sum((diagnostics->>'totalElapsedMs')::numeric))            AS server_render_ms,
+       round(sum((diagnostics->'indexVisitClientMs'->>'read')::numeric))        AS read_ms,
+       round(sum((diagnostics->'indexVisitClientMs'->>'renderRpc')::numeric))   AS render_rpc_ms,
+       round(sum((diagnostics->'indexVisitClientMs'->>'bookkeeping')::numeric)) AS bookkeeping_ms
+FROM boxel_index
+WHERE realm_url = '<realm-url>'
+  AND generation = <generation-from-step-1>;
+```
+
+Now `visitLoopMs` (step 1) ≈ `server_render_ms` + `read_ms` + `render_rpc_ms` + `bookkeeping_ms` + `writeMs`. Whatever bucket is largest after `server_render_ms` is where the between-visit wall went — and whether it's worth pipelining.
+
+### Step 3 — find the rows whose overhead dominates
+
+The aggregates say _how much_; this says _which rows_ (a card whose `bookkeeping` is an outlier is doing heavy dependency resolution — many `deps`, a deep relationship fan-out):
+
+```sql
+SELECT url,
+       (diagnostics->'indexVisitClientMs'->>'bookkeeping')::numeric AS bookkeeping_ms,
+       (diagnostics->'indexVisitClientMs'->>'read')::numeric        AS read_ms,
+       (diagnostics->'indexVisitClientMs'->>'renderRpc')::numeric   AS render_rpc_ms,
+       (diagnostics->>'totalElapsedMs')::numeric                    AS server_render_ms,
+       array_length(deps, 1)                                        AS dep_count
+FROM boxel_index
+WHERE realm_url = '<realm-url>'
+  AND generation = <generation>
+  AND type = 'instance'
+ORDER BY bookkeeping_ms DESC NULLS LAST
+LIMIT 20;
+```
+
+### Reading each bucket
+
+- **`read`** — file read + the file-metadata lookups (`ensureFileCreatedAt`, content hash/size). Usually small; a large `read` fleet-wide points at slow EFS / reader, not the render.
+- **`renderRpc`** — the client-observed prerender round-trip minus the server's own `totalElapsedMs`: serialization + the wire hop to the prerender server + any wait the server doesn't count. Large `renderRpc` with small server render means the transport/queue is the cost, not the render. ~0 on the fused / in-browser path (no wire hop).
+- **`bookkeeping`** — dependency resolution + index-entry construction between the render finishing and the write. The per-row cost that varies with a card's dependency shape; the top of step 3 names the heavy cards.
+- **`writeMs`** (job-level) — the Σ of the working-table upserts. This is I/O the render tab doesn't need, so it's the leading pipelining candidate (overlap it with the next visit).
+- **`discoverMs` / `swapMs`** (job-level) — the serial bookends. `discoverMs` runs before the first visit, `swapMs` after the last, so neither can overlap a visit; they're the floor the pipelining can't remove.
+
+### What Mode K can't tell you
+
+- **Per-row write time.** Rolled into the job's `writeMs` only — a row can't stamp its own INSERT duration. If you need to know whether one row's write was pathological, that's not captured; the aggregate is.
+- **Resumed rows carry no `indexVisitClientMs`.** A row a prior attempt already wrote and this attempt promoted without re-visiting keeps its old diagnostics (no fresh overhead) — so step 2's sums undercount on a resumed job. `phaseTimings` still covers the whole job wall.
+- **A job predating the instrumentation** has no `phaseTimings` on its result and no `indexVisitClientMs` on its rows; absence means "not measured", not "zero". Reindex to populate.
+- **Inflated `renderRpc` on the fused path.** The in-browser / SQLite prerenderer runs in-process with no server-observed `totalElapsedMs` to subtract, so `renderRpc` there absorbs the whole in-process render wall rather than just transport. Only trust `renderRpc` as "transport" on the split (real prerender-server) path.
 
 ## Field-by-field reading
 

--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -28,7 +28,7 @@ Seven places, all correlated:
 4. **`error_doc.diagnostics`** — derived copy of the same table's `diagnostics`, written only for error rows: an index error's copy rides `boxel_index.error_doc`, a render error's rides `prerendered_html.error_doc` (an instance's effective error is the union of the two). Exists so the existing UI read path (`error_doc` → `CardErrorJSONAPI.meta.diagnostics` via `formattedError`) keeps working without a schema rename. Non-error rows have `error_doc = null`; go to `diagnostics` directly.
 5. **Logs** — `prerender-server`, `manager`, and `remote-prerenderer` lines all carry `requestId=…`. `grep requestId=<uuid>` collates one call across all three processes. The same id lands on `boxel_index.diagnostics->>'requestId'` and `modules.diagnostics->>'requestId'` — and, for the render channel, on `prerendered_html.diagnostics->>'prerenderHtmlRequestId'` — so a hung card render and the module renders it triggered (via `getDefinition`) can be joined back to one investigation. For saturation incidents there's also the periodic `prerender-queue-snapshot` line on each prerender server.
 6. **Realm-server search-timing logs** — separate from the prerender `requestId` chain above. The realm-server emits, per instrumented `_federated-search`, a `realm:search-timing` line (request→response stage breakdown) and a `realm:requests` `-->` line with `dur=` (total) — both keyed by `corr=<id>`, the `x-boxel-logging-correlation-id` the prerendered host stamps. A periodic `realm:health` line reports event-loop lag + in-flight `_search` count during saturation windows. These are the _server's_ view of the search the card is blocked on; the card's `boxel_index.diagnostics` only has the _client's_ view (`queryLoadsInFlight`). See [Mode G](#mode-g--an-in-render-_search-was-slow-server-side-search-timing).
-7. **`jobs.result.phaseTimings`** — JSONB, one object per completed index job (on the `from-scratch-index` / `incremental-index` row's `result` column). The **job-level** phase decomposition: the once-per-job phases that surround and interleave the serial visit loop (`discoverMs`, `orderMs`, `preWarmMs`, `swapMs`, and the from-scratch-only `mtimesMs`), plus `visitLoopMs` (the whole serial loop), `writeMs` (the aggregate row-write time — tracked here, not per row, because a row can't time its own INSERT), and `totalMs`. This is the only place the _between-visit_ wall is attributed; the per-row server render lives on `boxel_index.diagnostics.totalElapsedMs` and the per-row client overhead on `boxel_index.diagnostics.indexVisitClientMs`. See [Mode K](#mode-k--the-index-jobs-between-visit-wall-non-render-overhead).
+7. **`jobs.result.phaseTimings`** — JSONB, one object per completed index job (on the `from-scratch-index` / `incremental-index` row's `result` column). The **job-level** phase decomposition: the once-per-job phases that surround and interleave the serial visit loop (`setupMs`, `discoverMs`, `orderMs`, `preWarmMs`, `swapMs`, and the from-scratch-only `mtimesMs`), plus `visitLoopMs` (the whole serial loop), `writeMs` (the aggregate row-write time — tracked here, not per row, because a row can't time its own INSERT), and `totalMs`. This is the only place the _between-visit_ wall is attributed; the per-row server render lives on `boxel_index.diagnostics.totalElapsedMs` and the per-row client overhead on `boxel_index.diagnostics.indexVisitClientMs`. See [Mode K](#mode-k--the-index-jobs-between-visit-wall-non-render-overhead).
 
 For UI triage you'll typically read the JSON error response (which surfaces `error_doc.diagnostics` as `meta.diagnostics`). For operator / SQL triage — especially slow non-failing reindexes — query the `diagnostics` column directly.
 
@@ -1150,14 +1150,19 @@ This mode reads **two** sources that together reconstruct the whole wall:
 For one index job:
 
 ```
-totalMs  ≈  mtimesMs + discoverMs + orderMs + preWarmMs + visitLoopMs + swapMs        (job phases)
+totalMs  ≈  setupMs + mtimesMs + discoverMs + orderMs + preWarmMs + visitLoopMs + swapMs   (job phases)
 
-visitLoopMs  ≈  Σ totalElapsedMs        (server render, per row — the well-instrumented 76%)
-              + Σ indexVisitClientMs.*  (read + renderRpc + bookkeeping, per row)
+visitLoopMs  ≈  Σ totalElapsedMs        (server render — the well-instrumented 76%; per VISIT)
+              + Σ read + Σ renderRpc    (indexVisitClientMs, per VISIT)
+              + Σ bookkeeping           (indexVisitClientMs, per ROW)
               + writeMs                 (aggregate row writes — the I/O the tab doesn't need)
 ```
 
-The `≈` covers small un-bucketed residue (loop control, progress events, resumed-row skips). `mtimesMs` / `preWarmMs` are from-scratch-only (incremental omits both). `writeMs` is aggregate on the job, **not** per row — a row can't time its own INSERT, so per-row `indexVisitClientMs` stops at `bookkeeping` (the pre-write window) and the writes roll up here. `swapMs` is the `batch.done()` transaction (realm-meta update + working→main promotion + obsolete-row prune), and `discoverMs` is the pre-loop invalidation fan-out; both are serial bookends around the visit loop, so they're the _irreducible_ part — the pipelining lever (overlap the write of row N with the visit of N+1, batch row writes) attacks `writeMs` and `bookkeeping`, not these.
+The `≈` covers small un-bucketed residue (loop control, progress events, resumed-row skips). `setupMs` is `createBatch` (generation bump + resumable-row scan); `mtimesMs` / `preWarmMs` are from-scratch-only (incremental omits both). `writeMs` is aggregate on the job, **not** per row — a row can't time its own INSERT, so per-row `indexVisitClientMs` stops at `bookkeeping` (the pre-write window) and the writes roll up here.
+
+**Per-VISIT vs per-ROW — the sum has to respect this.** A card-instance `.json` produces **two** rows (`type='instance'` + `type='file'`) from one visit, and they **share** the visit's blob: the same `totalElapsedMs`, `read`, and `renderRpc` land on both. So those three are per-VISIT — sum them over **one row per URL** (filter to `type='file'`, which exists exactly once per visited file) or you double-count every card `.json`. `bookkeeping` is the exception: the card indexer and the file indexer each stamp their **own** value (card dependency resolution vs file-row construction — distinct work in the same visit), so `bookkeeping` is per-ROW and is summed across **all** rows. Step 2's query does both.
+
+`swapMs` is the `batch.done()` transaction (realm-meta update + working→main promotion + obsolete-row prune), and `discoverMs` is the pre-loop invalidation fan-out; both are serial bookends around the visit loop, so they're the _irreducible_ part — the pipelining lever (overlap the write of row N with the visit of N+1, batch row writes) attacks `writeMs` and `bookkeeping`, not these.
 
 ### Step 1 — pull the job's phase breakdown
 
@@ -1175,18 +1180,21 @@ ORDER BY id DESC
 LIMIT 5;
 ```
 
-`phase_timings` is `{ totalMs, mtimesMs, discoverMs, orderMs, preWarmMs, visitLoopMs, writeMs, swapMs }` (ms). Read it against `wall_ms`: `totalMs` should land close to the job's wall; the gap between `visitLoopMs` and the visit render sum (step 2) is the per-visit client overhead + `writeMs`.
+`phase_timings` is `{ totalMs, setupMs, mtimesMs, discoverMs, orderMs, preWarmMs, visitLoopMs, writeMs, swapMs }` (ms). Read it against `wall_ms`: `totalMs` should land close to the job's wall; the gap between `visitLoopMs` and the visit render sum (step 2) is the per-visit client overhead + `writeMs`.
 
 ### Step 2 — sum the per-row halves for the same job
 
-Correlate rows to the job by the generation it committed (every from-scratch row is stamped with it; an incremental stamps the rows it revisited):
+Correlate rows to the job by the generation it committed (every from-scratch row is stamped with it; an incremental stamps the rows it revisited). The per-VISIT fields (`totalElapsedMs`, `read`, `renderRpc`) are summed over `type='file'` — one row per visited file, so a card `.json`'s shared blob is counted once, not twice — while `bookkeeping` sums over **all** rows (see the per-visit-vs-per-row note above):
 
 ```sql
-SELECT count(*)                                                          AS rows,
-       round(sum((diagnostics->>'totalElapsedMs')::numeric))            AS server_render_ms,
-       round(sum((diagnostics->'indexVisitClientMs'->>'read')::numeric))        AS read_ms,
-       round(sum((diagnostics->'indexVisitClientMs'->>'renderRpc')::numeric))   AS render_rpc_ms,
-       round(sum((diagnostics->'indexVisitClientMs'->>'bookkeeping')::numeric)) AS bookkeeping_ms
+SELECT count(*) FILTER (WHERE type = 'file')                                         AS visits,
+       round(sum((diagnostics->>'totalElapsedMs')::numeric)
+             FILTER (WHERE type = 'file'))                                           AS server_render_ms,
+       round(sum((diagnostics->'indexVisitClientMs'->>'read')::numeric)
+             FILTER (WHERE type = 'file'))                                           AS read_ms,
+       round(sum((diagnostics->'indexVisitClientMs'->>'renderRpc')::numeric)
+             FILTER (WHERE type = 'file'))                                           AS render_rpc_ms,
+       round(sum((diagnostics->'indexVisitClientMs'->>'bookkeeping')::numeric))      AS bookkeeping_ms
 FROM boxel_index
 WHERE realm_url = '<realm-url>'
   AND generation = <generation-from-step-1>;
@@ -1219,6 +1227,7 @@ LIMIT 20;
 - **`renderRpc`** — the client-observed prerender round-trip minus the server's own `totalElapsedMs`: serialization + the wire hop to the prerender server + any wait the server doesn't count. Large `renderRpc` with small server render means the transport/queue is the cost, not the render. ~0 on the fused / in-browser path (no wire hop).
 - **`bookkeeping`** — dependency resolution + index-entry construction between the render finishing and the write. The per-row cost that varies with a card's dependency shape; the top of step 3 names the heavy cards.
 - **`writeMs`** (job-level) — the Σ of the working-table upserts. This is I/O the render tab doesn't need, so it's the leading pipelining candidate (overlap it with the next visit).
+- **`setupMs`** (job-level) — `createBatch`: the generation bump and the resumable working-row scan, before any visit. Normally small; large `setupMs` is a retry job re-scanning a big working table, or DB slowness.
 - **`discoverMs` / `swapMs`** (job-level) — the serial bookends. `discoverMs` runs before the first visit, `swapMs` after the last, so neither can overlap a visit; they're the floor the pipelining can't remove.
 
 ### What Mode K can't tell you

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -537,6 +537,8 @@ module(basename(import.meta.filename), function () {
       );
       for (let phase of [
         'totalMs',
+        'setupMs',
+        'mtimesMs',
         'discoverMs',
         'orderMs',
         'preWarmMs',

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -521,6 +521,38 @@ module(basename(import.meta.filename), function () {
         'the job completed successfully',
       );
       assert.ok(indexJob.finished_at, 'the job was marked with a finish time');
+
+      // The between-visit phase decomposition rides on the job result so the
+      // ~one-in-four of the wall the job spends outside the per-row server
+      // render is queryable per job (`jobs.result.phaseTimings`).
+      let indexResult = indexJob.result as {
+        phaseTimings?: Record<string, unknown>;
+      } | null;
+      let phaseTimings = indexResult?.phaseTimings;
+      assert.ok(
+        phaseTimings,
+        `the from-scratch index job result carries a phaseTimings breakdown, got: ${JSON.stringify(
+          indexResult,
+        )}`,
+      );
+      for (let phase of [
+        'totalMs',
+        'discoverMs',
+        'orderMs',
+        'preWarmMs',
+        'visitLoopMs',
+        'writeMs',
+        'swapMs',
+      ]) {
+        assert.strictEqual(
+          typeof phaseTimings?.[phase],
+          'number',
+          `phaseTimings.${phase} is measured on the from-scratch job result, got: ${JSON.stringify(
+            phaseTimings?.[phase],
+          )}`,
+        );
+      }
+
       assert.strictEqual(
         prerenderJob.job_type,
         'prerender_html',
@@ -808,6 +840,26 @@ module(basename(import.meta.filename), function () {
         'number',
         `diagnostics.searchDocSettlePasses persists on boxel_index, got: ${JSON.stringify(diagnostics?.searchDocSettlePasses)}`,
       );
+
+      // The per-visit client overhead (file read, render round-trip transport,
+      // post-render bookkeeping) rides the same channel — the part of the index
+      // job's between-render wall attributable to this row.
+      let clientMs = (
+        diagRow?.diagnostics as {
+          indexVisitClientMs?: {
+            read?: unknown;
+            renderRpc?: unknown;
+            bookkeeping?: unknown;
+          };
+        } | null
+      )?.indexVisitClientMs;
+      for (let bucket of ['read', 'renderRpc', 'bookkeeping'] as const) {
+        assert.strictEqual(
+          typeof clientMs?.[bucket],
+          'number',
+          `diagnostics.indexVisitClientMs.${bucket} persists on boxel_index, got: ${JSON.stringify(clientMs?.[bucket])}`,
+        );
+      }
     });
 
     // Note this particular test should only be a server test as the nature of

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -240,11 +240,13 @@ export class IndexRunner {
     current.#perfLog.debug(
       `${jobIdentity(current.#jobInfo)} starting from scratch indexing for realm ${current.realmURL.href}`,
     );
+    let setupStart = Date.now();
     current.#batch = await current.#indexWriter.createBatch(
       current.realmURL,
       current.#virtualNetwork,
       current.#jobInfo,
     );
+    let setupMs = Date.now() - setupStart;
     // Announce the job at kickoff — before invalidation discovery and
     // pre-warm — so the dashboard shows it immediately. The total starts
     // at 0 and is filled in by the first `file-visited` once the
@@ -417,6 +419,7 @@ export class IndexRunner {
       generation: current.batch.currentGeneration,
       phaseTimings: {
         totalMs: Date.now() - start,
+        setupMs,
         mtimesMs,
         discoverMs,
         orderMs,
@@ -456,11 +459,13 @@ export class IndexRunner {
       `${jobIdentity(current.#jobInfo)} starting from incremental indexing for ${urls.map((u) => u.href).join()}`,
     );
 
+    let setupStart = Date.now();
     current.#batch = await current.#indexWriter.createBatch(
       current.realmURL,
       current.#virtualNetwork,
       current.#jobInfo,
     );
+    let setupMs = Date.now() - setupStart;
     // Announce the job at kickoff — before invalidation — so the
     // dashboard shows it immediately. The total starts at 0 and the
     // first `file-visited` fills it in once the counts are known.
@@ -596,6 +601,7 @@ export class IndexRunner {
       generation: current.batch.currentGeneration,
       phaseTimings: {
         totalMs: Date.now() - start,
+        setupMs,
         discoverMs,
         orderMs,
         ...(visitLoopMs !== undefined ? { visitLoopMs } : {}),

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -29,6 +29,7 @@ import {
   type Reader,
   type Stats,
   type Diagnostics,
+  type SearchIndexEntry,
 } from './index.ts';
 import { moduleFrom } from './code-ref.ts';
 import type { RealmResourceIdentifier } from './realm-identifiers.ts';
@@ -128,6 +129,10 @@ export class IndexRunner {
     totalIndexEntries: 0,
   };
   #shouldClearCacheForNextRender = true;
+  // Aggregate wall of every `batch.updateEntry` row write in the current pass.
+  // Summed here (not per row) because a row can't time its own INSERT; surfaces
+  // on the job result's `phaseTimings.writeMs`. Reset at the start of each pass.
+  #writeMsTotal = 0;
   // Identifier for this runner's indexing batch (CS-10758 step 3).
   // Threaded into PrerenderVisitArgs and released from the fromScratch /
   // incremental finally blocks. One runner = one batch: if fromScratch
@@ -223,7 +228,12 @@ export class IndexRunner {
 
   static async fromScratch(current: IndexRunner): Promise<FromScratchResult> {
     current.#dependencyResolver.reset();
+    current.#writeMsTotal = 0;
     let start = Date.now();
+    // Between-visit phase walls, assembled onto the job result's `phaseTimings`
+    // at the end. `visitLoopMs` / `swapMs` are set inside the try below.
+    let visitLoopMs: number | undefined;
+    let swapMs: number | undefined;
     current.#log.debug(
       `${jobIdentity(current.#jobInfo)} starting from scratch indexing`,
     );
@@ -250,21 +260,23 @@ export class IndexRunner {
     let invalidations: URL[] = [];
     let mtimesStart = Date.now();
     let mtimes = await current.batch.getModifiedTimes();
+    let mtimesMs = Date.now() - mtimesStart;
     current.#perfLog.debug(
-      `${jobIdentity(current.#jobInfo)} completed getting index mtimes in ${Date.now() - mtimesStart} ms`,
+      `${jobIdentity(current.#jobInfo)} completed getting index mtimes in ${mtimesMs} ms`,
     );
     let invalidateStart = Date.now();
     let discoverResult = await current.discoverInvalidations(
       current.realmURL,
       mtimes,
     );
+    let discoverMs = Date.now() - invalidateStart;
     invalidations = discoverResult.urls.map((href) => new URL(href));
     // The from-scratch URL list lives outside the batch's invalidation set
     // until each visit writes its row; feed the loader-epoch scan up front
     // so the epoch is fixed before the enqueue and the first visit.
     current.batch.noteInvalidatedURLs(discoverResult.urls);
     current.#perfLog.debug(
-      `${jobIdentity(current.#jobInfo)} completed invalidations in ${Date.now() - invalidateStart} ms`,
+      `${jobIdentity(current.#jobInfo)} completed invalidations in ${discoverMs} ms`,
     );
     current.#notifyInvalidationsReady(
       discoverResult.urls,
@@ -272,11 +284,13 @@ export class IndexRunner {
     );
 
     let visitStart = Date.now();
+    let orderStart = Date.now();
     invalidations = sortInvalidations(invalidations, current.realmURL);
     invalidations =
       await current.#dependencyResolver.orderInvalidationsByDependencies(
         invalidations,
       );
+    let orderMs = Date.now() - orderStart;
     // Pre-warm the modules cache. Combines per-row deps (which catch
     // most modules used during a from-scratch pass) with the realm-
     // wide `.gts` / `.gjs` sweep (which catches sibling card modules
@@ -291,6 +305,7 @@ export class IndexRunner {
     // and the files visited below share one `totalFiles`, so the dashboard
     // bar advances through pre-warming and into the visit phase.
     let filesCompleted = 0;
+    let preWarmStart = Date.now();
     let preWarmedCount = await current.preWarmModulesTable(
       invalidations,
       allRealmCardModules,
@@ -306,7 +321,9 @@ export class IndexRunner {
         });
       },
     );
+    let preWarmMs = Date.now() - preWarmStart;
     let totalFiles = preWarmedCount + invalidations.length;
+    let loopStart = Date.now();
     let resumedRows = current.batch.resumedRows;
     let resumedSkipped = 0;
     try {
@@ -352,13 +369,15 @@ export class IndexRunner {
           `${jobIdentity(current.#jobInfo)} skipped ${resumedSkipped} URLs already processed by prior attempt`,
         );
       }
+      visitLoopMs = Date.now() - loopStart;
       current.#perfLog.debug(
         `${jobIdentity(current.#jobInfo)} completed index visit in ${Date.now() - visitStart} ms`,
       );
       let finalizeStart = Date.now();
       let { totalIndexEntries } = await current.batch.done();
+      swapMs = Date.now() - finalizeStart;
       current.#perfLog.debug(
-        `${jobIdentity(current.#jobInfo)} completed index finalization in ${Date.now() - finalizeStart} ms`,
+        `${jobIdentity(current.#jobInfo)} completed index finalization in ${swapMs} ms`,
       );
       current.stats.totalIndexEntries = totalIndexEntries;
     } finally {
@@ -396,6 +415,16 @@ export class IndexRunner {
       ignoreData: current.#ignoreData,
       stats: current.stats,
       generation: current.batch.currentGeneration,
+      phaseTimings: {
+        totalMs: Date.now() - start,
+        mtimesMs,
+        discoverMs,
+        orderMs,
+        preWarmMs,
+        ...(visitLoopMs !== undefined ? { visitLoopMs } : {}),
+        writeMs: current.#writeMsTotal,
+        ...(swapMs !== undefined ? { swapMs } : {}),
+      },
     };
   }
 
@@ -408,7 +437,12 @@ export class IndexRunner {
     },
   ): Promise<IncrementalResult> {
     current.#dependencyResolver.reset();
+    current.#writeMsTotal = 0;
     let start = Date.now();
+    // Between-visit phase walls, assembled onto the job result's `phaseTimings`
+    // at the end. `visitLoopMs` / `swapMs` are set inside the try below.
+    let visitLoopMs: number | undefined;
+    let swapMs: number | undefined;
     let operations = new Map<string, 'update' | 'delete'>();
     for (let { url, operation } of changes) {
       if (operation === 'delete') {
@@ -438,10 +472,12 @@ export class IndexRunner {
       totalFiles: 0,
       files: [],
     });
+    let discoverStart = Date.now();
     urls.forEach((url) =>
       current.#dependencyResolver.invalidateRelationshipDependencyRowCache(url),
     );
     await current.batch.invalidate(urls);
+    let discoverMs = Date.now() - discoverStart;
     current.#notifyInvalidationsReady(
       current.batch.invalidations,
       new Set(
@@ -450,6 +486,7 @@ export class IndexRunner {
           .map(([href]) => href),
       ),
     );
+    let orderStart = Date.now();
     let invalidations = sortInvalidations(
       current.batch.invalidations.map((href) => new URL(href)),
       current.realmURL,
@@ -458,6 +495,7 @@ export class IndexRunner {
       await current.#dependencyResolver.orderInvalidationsByDependencies(
         invalidations,
       );
+    let orderMs = Date.now() - orderStart;
     let hasExecutableInvalidation = invalidations.some((url) =>
       hasExecutableExtension(url.href),
     );
@@ -485,6 +523,7 @@ export class IndexRunner {
     let hrefs = urls.map((u) => u.href);
     let resumedRows = current.batch.resumedRows;
     let resumedSkipped = 0;
+    let loopStart = Date.now();
     try {
       for (let invalidation of invalidations) {
         if (
@@ -516,8 +555,11 @@ export class IndexRunner {
           `${jobIdentity(current.#jobInfo)} skipped ${resumedSkipped} URLs already processed by prior attempt`,
         );
       }
+      visitLoopMs = Date.now() - loopStart;
 
+      let finalizeStart = Date.now();
       let { totalIndexEntries } = await current.batch.done();
+      swapMs = Date.now() - finalizeStart;
       current.stats.totalIndexEntries = totalIndexEntries;
     } finally {
       current.#onProgress?.({
@@ -552,6 +594,14 @@ export class IndexRunner {
       ignoreData: current.#ignoreData,
       stats: current.stats,
       generation: current.batch.currentGeneration,
+      phaseTimings: {
+        totalMs: Date.now() - start,
+        discoverMs,
+        orderMs,
+        ...(visitLoopMs !== undefined ? { visitLoopMs } : {}),
+        writeMs: current.#writeMsTotal,
+        ...(swapMs !== undefined ? { swapMs } : {}),
+      },
     };
   }
 
@@ -1110,7 +1160,7 @@ export class IndexRunner {
       dependencyResolver: this.#dependencyResolver,
       virtualNetwork: this.#virtualNetwork,
       updateEntry: async (entryURL, entry) => {
-        await this.batch.updateEntry(entryURL, entry);
+        await this.#writeEntry(entryURL, entry);
         this.#dependencyResolver.invalidateRelationshipDependencyRowCache(
           entryURL,
         );
@@ -1130,7 +1180,7 @@ export class IndexRunner {
     entry: InstanceEntry | InstanceErrorIndexEntry,
   ) {
     let normalizedURL = assertURLEndsWithJSON(instanceURL);
-    await this.batch.updateEntry(normalizedURL, entry);
+    await this.#writeEntry(normalizedURL, entry);
     this.#dependencyResolver.invalidateRelationshipDependencyRowCache(
       normalizedURL,
     );
@@ -1138,6 +1188,18 @@ export class IndexRunner {
       this.stats.instancesIndexed++;
     } else {
       this.stats.instanceErrors++;
+    }
+  }
+
+  // Time the row write and fold it into the pass's aggregate. The single
+  // chokepoint every `boxel_index_working` row write goes through, so the job
+  // result's `phaseTimings.writeMs` covers instance and file rows alike.
+  async #writeEntry(url: URL, entry: SearchIndexEntry): Promise<void> {
+    let start = Date.now();
+    try {
+      await this.batch.updateEntry(url, entry);
+    } finally {
+      this.#writeMsTotal += Date.now() - start;
     }
   }
 }

--- a/packages/runtime-common/index-runner/card-indexer.ts
+++ b/packages/runtime-common/index-runner/card-indexer.ts
@@ -67,6 +67,23 @@ export async function performCardIndexing({
   updateEntry,
   logWarn,
 }: CardIndexerOptions): Promise<void> {
+  // Post-render bookkeeping for this row starts now — dependency resolution and
+  // entry construction between the render completing and the row write. Stamped
+  // onto the diagnostics blob just before each write (which ends the
+  // bookkeeping window and starts the write the row can't time itself).
+  let bookkeepingStart = Date.now();
+  let withBookkeeping = (
+    d: Diagnostics | undefined,
+  ): Diagnostics | undefined =>
+    d
+      ? {
+          ...d,
+          indexVisitClientMs: {
+            ...(d.indexVisitClientMs ?? {}),
+            bookkeeping: Date.now() - bookkeepingStart,
+          },
+        }
+      : d;
   let uncaughtError: Error | undefined;
   let renderResult: RenderResponse = precomputedRenderResult;
 
@@ -202,7 +219,10 @@ export async function performCardIndexing({
     logWarn(
       `${jobIdentity(jobInfo)} encountered error indexing card instance ${path}: ${renderError.error.message}`,
     );
-    await updateEntry(instanceURL, { ...renderError, diagnostics });
+    await updateEntry(instanceURL, {
+      ...renderError,
+      diagnostics: withBookkeeping(diagnostics),
+    });
     return;
   }
 
@@ -247,7 +267,7 @@ export async function performCardIndexing({
         typeof searchDoc?._cardType === 'string'
           ? searchDoc._cardType
           : undefined,
-      diagnostics,
+      diagnostics: withBookkeeping(diagnostics),
     });
     return;
   }
@@ -268,6 +288,6 @@ export async function performCardIndexing({
     types: types!,
     displayNames: displayNames ?? [],
     deps,
-    diagnostics,
+    diagnostics: withBookkeeping(diagnostics),
   });
 }

--- a/packages/runtime-common/index-runner/file-indexer.ts
+++ b/packages/runtime-common/index-runner/file-indexer.ts
@@ -74,6 +74,21 @@ export async function performFileIndexing({
   updateEntry,
   logWarn,
 }: FileIndexerOptions): Promise<'indexed' | 'error'> {
+  // See the card indexer: bookkeeping is the post-render, pre-write window for
+  // this file's row, stamped onto the diagnostics blob just before each write.
+  let bookkeepingStart = Date.now();
+  let withBookkeeping = (
+    d: Diagnostics | undefined,
+  ): Diagnostics | undefined =>
+    d
+      ? {
+          ...d,
+          indexVisitClientMs: {
+            ...(d.indexVisitClientMs ?? {}),
+            bookkeeping: Date.now() - bookkeepingStart,
+          },
+        }
+      : d;
   let entryURL = new URL(fileURL);
   let name = path.split('/').pop() ?? path;
   let contentType = inferContentType(name);
@@ -152,7 +167,10 @@ export async function performFileIndexing({
     logWarn(
       `${jobIdentity(jobInfo)} encountered error indexing file ${path}: ${renderError.error.message}`,
     );
-    await updateEntry(entryURL, { ...renderError, diagnostics });
+    await updateEntry(entryURL, {
+      ...renderError,
+      diagnostics: withBookkeeping(diagnostics),
+    });
     return 'error';
   }
 
@@ -208,7 +226,7 @@ export async function performFileIndexing({
       error: normalizedDependencyError,
       searchData,
       types: fileTypes,
-      diagnostics,
+      diagnostics: withBookkeeping(diagnostics),
     });
     return 'error';
   }
@@ -254,7 +272,7 @@ export async function performFileIndexing({
     fittedHtml: renderResult?.fittedHTML ?? undefined,
     iconHTML: renderResult?.iconHTML ?? undefined,
     markdown: renderResult?.markdown ?? undefined,
-    diagnostics: fileDiagnostics,
+    diagnostics: withBookkeeping(fileDiagnostics),
   });
 
   return 'indexed';

--- a/packages/runtime-common/index-runner/visit-file.ts
+++ b/packages/runtime-common/index-runner/visit-file.ts
@@ -10,6 +10,7 @@ import {
   type Batch,
   type Diagnostics,
   type FileRenderResponse,
+  type IndexVisitClientTimings,
   type JobInfo,
   type LocalPath,
   type LooseCardResource,
@@ -227,6 +228,13 @@ export async function visitFileForIndexing({
     ...(fileContentSize !== undefined ? { fileContentSize } : {}),
   };
 
+  // Everything up to here — the file read, parse, and file-metadata lookups —
+  // is the visit's pre-render client overhead. The render round-trip and the
+  // post-render bookkeeping are measured separately and persisted on the row's
+  // diagnostics so the index job's between-render wall is attributable per row
+  // (see IndexVisitClientTimings).
+  let readMs = Date.now() - start;
+  let renderStart = Date.now();
   let indexResponse: RenderVisitResponse;
   try {
     indexResponse = await prerenderer.prerenderVisit({
@@ -287,6 +295,15 @@ export async function visitFileForIndexing({
     }
   }
 
+  // Client-observed wall of the render round-trip(s), minus the server's own
+  // `totalElapsedMs`, is the transport overhead (serialization + wire hop +
+  // waits the server doesn't count). Both visits contribute when the fused
+  // path runs both; in split mode only the index visit ran.
+  let renderClientMs = Date.now() - renderStart;
+  let serverRenderMs =
+    (indexResponse.meta?.diagnostics?.totalElapsedMs ?? 0) +
+    (htmlResponse?.meta?.diagnostics?.totalElapsedMs ?? 0);
+
   let card = mergeCardVisitResults(indexResponse.card, htmlResponse?.card);
   let fileRenderResult = mergeFileRenderVisitResults(
     indexResponse.fileRender,
@@ -294,9 +311,15 @@ export async function visitFileForIndexing({
   );
   let pageUnusableError =
     indexResponse.pageUnusableError ?? htmlResponse?.pageUnusableError;
-  let diagnostics = mergeVisitDiagnostics(
-    flattenPrerenderMeta(indexResponse.meta),
-    flattenPrerenderMeta(htmlResponse?.meta),
+  let diagnostics = attachIndexVisitClientTimings(
+    mergeVisitDiagnostics(
+      flattenPrerenderMeta(indexResponse.meta),
+      flattenPrerenderMeta(htmlResponse?.meta),
+    ),
+    {
+      read: readMs,
+      renderRpc: Math.max(0, renderClientMs - serverRenderMs),
+    },
   );
 
   // Route card result when we parsed a card resource. If the visits
@@ -355,6 +378,27 @@ export async function visitFileForIndexing({
   logDebug(
     `${jobIdentity(jobInfo)} completed visit of file ${url.href} in ${Date.now() - start}ms`,
   );
+}
+
+// Fold the pre-render + transport client overhead into the row's diagnostics
+// blob, creating one if the render produced none. `bookkeeping` is filled in
+// later by the card / file indexers, just before each row write, since it
+// spans work that happens downstream of this merge.
+function attachIndexVisitClientTimings(
+  diagnostics: Diagnostics | undefined,
+  timings: IndexVisitClientTimings,
+): Diagnostics | undefined {
+  let measured = Object.entries(timings).filter(([, v]) => v !== undefined);
+  if (measured.length === 0) {
+    return diagnostics;
+  }
+  return {
+    ...(diagnostics ?? {}),
+    indexVisitClientMs: {
+      ...(diagnostics?.indexVisitClientMs ?? {}),
+      ...Object.fromEntries(measured),
+    },
+  };
 }
 
 // Reassemble the two visits' card sub-results into the single RenderResponse

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -540,8 +540,8 @@ export interface PrerenderResponseMeta {
 // summed across a job's rows it accounts for most of the wall the job spends
 // between server renders. The once-per-job phases (discovery, dependency
 // ordering, module pre-warm, the final swap) and the aggregate row-write time
-// are not attributable to a single row and live on the job's
-// `Stats.phaseTimings` instead.
+// are not attributable to a single row and live on the job result's
+// `phaseTimings` (`jobs.result.phaseTimings`) instead.
 export interface IndexVisitClientTimings {
   // Wall before the render request: reading the file bytes and the
   // file-metadata lookups (created-at, content hash/size).
@@ -555,7 +555,7 @@ export interface IndexVisitClientTimings {
   // Post-render bookkeeping: dependency resolution and index-entry construction
   // between the render completing and the row write. Excludes the write itself
   // (a row cannot time its own INSERT); the job's aggregate write time lives on
-  // `Stats.phaseTimings.writeMs`.
+  // the job result's `phaseTimings.writeMs` (`jobs.result.phaseTimings.writeMs`).
   bookkeeping?: number;
 }
 

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -533,6 +533,32 @@ export interface PrerenderResponseMeta {
   requestId?: string;
 }
 
+// Per-visit client-side overhead the indexer spent producing a row, measured
+// outside the server-observed render timings (`totalElapsedMs` /
+// `renderElapsedMs`). The index job runs its file visits serially, so this
+// overhead serializes with the render and is otherwise invisible next to it;
+// summed across a job's rows it accounts for most of the wall the job spends
+// between server renders. The once-per-job phases (discovery, dependency
+// ordering, module pre-warm, the final swap) and the aggregate row-write time
+// are not attributable to a single row and live on the job's
+// `Stats.phaseTimings` instead.
+export interface IndexVisitClientTimings {
+  // Wall before the render request: reading the file bytes and the
+  // file-metadata lookups (created-at, content hash/size).
+  read?: number;
+  // Render round-trip transport: the client-observed wall of the prerender
+  // visit(s) minus the server-observed `totalElapsedMs` — the request/response
+  // plumbing between the indexer and the prerender server (serialization,
+  // network/IPC, waits not counted server-side). ~0 for the in-process (fused
+  // / in-browser) prerenderer, where there is no wire hop.
+  renderRpc?: number;
+  // Post-render bookkeeping: dependency resolution and index-entry construction
+  // between the render completing and the row write. Excludes the write itself
+  // (a row cannot time its own INSERT); the job's aggregate write time lives on
+  // `Stats.phaseTimings.writeMs`.
+  bookkeeping?: number;
+}
+
 // The shape persisted to the `diagnostics` columns — `boxel_index` for the
 // index visit's breakdown, `prerendered_html` for the prerender-html visit's
 // (the two visits' costs are independently queryable per row; join them on
@@ -579,6 +605,12 @@ export interface Diagnostics
   // by the file indexer from the extract response. Absent when the
   // frontmatter parsed (or there was none).
   frontmatterParseError?: FrontmatterParseError;
+  // Per-visit client-side overhead of producing this row (file read, render
+  // round-trip transport, post-render bookkeeping) — the index-job wall spent
+  // on this row outside the server render. See `IndexVisitClientTimings`.
+  // Omitted when nothing was measured (e.g. a resumed row promoted without a
+  // fresh visit).
+  indexVisitClientMs?: IndexVisitClientTimings;
 }
 
 // Flatten a prerender `response.meta` block into the shape persisted to

--- a/packages/runtime-common/tasks/indexer.ts
+++ b/packages/runtime-common/tasks/indexer.ts
@@ -18,7 +18,7 @@ import {
 import { IndexRunner } from '../index-runner.ts';
 import { INCREMENTAL_INDEX_JOB_TIMEOUT_SEC } from '../jobs/indexing.ts';
 import { enqueuePrerenderHtmlJob } from '../jobs/prerender-html.ts';
-import type { Stats } from '../worker.ts';
+import type { Stats, IndexPhaseTimings } from '../worker.ts';
 
 export { fromScratchIndex, incrementalIndex };
 const DEFAULT_FROM_SCRATCH_JOB_TIMEOUT_SEC = 60 * 60;
@@ -57,6 +57,9 @@ export interface IncrementalResult {
   // The realm generation this pass committed. Optional so a result produced
   // by an older worker mid-deploy still parses.
   generation?: number;
+  // Between-visit phase decomposition of the job wall (see IndexPhaseTimings).
+  // Optional so a result from a worker predating the instrumentation parses.
+  phaseTimings?: IndexPhaseTimings;
 }
 
 export interface IncrementalDoneResult extends IncrementalResult {
@@ -82,6 +85,8 @@ export interface FromScratchResult {
   stats: Stats;
   // See IncrementalResult.generation.
   generation?: number;
+  // See IncrementalResult.phaseTimings.
+  phaseTimings?: IndexPhaseTimings;
 }
 
 export function isObjectLike(value: unknown): value is JSONTypes.Object {
@@ -389,7 +394,7 @@ const fromScratchIndex: Task<FromScratchArgs, FromScratchResult> = ({
       prerenderer,
       realmOwnerUserId: userId,
     });
-    let { stats, ignoreData, invalidations, generation } =
+    let { stats, ignoreData, invalidations, generation, phaseTimings } =
       await IndexRunner.fromScratch(currentRun);
 
     log.debug(
@@ -426,6 +431,7 @@ const fromScratchIndex: Task<FromScratchArgs, FromScratchResult> = ({
       ignoreData: { ...ignoreData },
       stats,
       ...(generation !== undefined ? { generation } : {}),
+      ...(phaseTimings !== undefined ? { phaseTimings } : {}),
     };
   };
 
@@ -501,7 +507,7 @@ const incrementalIndex: Task<IncrementalArgs, IncrementalResult> = ({
       ignoreData: args.ignoreData,
       realmOwnerUserId: userId,
     });
-    let { stats, invalidations, ignoreData, generation } =
+    let { stats, invalidations, ignoreData, generation, phaseTimings } =
       await IndexRunner.incremental(currentRun, {
         changes: changes.map(({ operation, url }) => ({
           operation,
@@ -520,6 +526,7 @@ const incrementalIndex: Task<IncrementalArgs, IncrementalResult> = ({
       invalidations,
       stats,
       ...(generation !== undefined ? { generation } : {}),
+      ...(phaseTimings !== undefined ? { phaseTimings } : {}),
     };
   };
 

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -38,6 +38,44 @@ export interface Stats extends JSONTypes.Object {
   totalIndexEntries: number;
 }
 
+// Wall-clock of each phase of an index job outside the per-row server render.
+// Populated by the IndexRunner and returned alongside `stats` on the job
+// result (persisted to `jobs.result.phaseTimings`), so the ~one-in-four of the
+// job wall that falls between server renders decomposes into measured buckets.
+// The per-row server render and per-visit client overhead
+// (`boxel_index.diagnostics`) account for the rest. Kept off `Stats` — which is
+// a `JSONTypes.Object` embedded in other job results and deep-compared in
+// tests — so it carries no non-deterministic timing there. All fields
+// optional: incremental jobs skip the from-scratch-only phases (mtimes read,
+// module pre-warm), and any phase that didn't run stays absent.
+export interface IndexPhaseTimings {
+  // Whole-job wall, kickoff to return.
+  totalMs?: number;
+  // Reading the index's per-file modified times up front (from-scratch only).
+  mtimesMs?: number;
+  // Invalidation discovery: the from-scratch filesystem walk, or the
+  // incremental invalidation fan-out.
+  discoverMs?: number;
+  // Ordering the invalidation set by dependency so files precede the cards
+  // that consume them.
+  orderMs?: number;
+  // Module pre-warm before the visit loop (from-scratch only; incremental does
+  // none).
+  preWarmMs?: number;
+  // The whole serial visit loop wall. Equals Σ server render
+  // (`boxel_index.diagnostics.totalElapsedMs`) + Σ per-visit
+  // `indexVisitClientMs` + `writeMs`.
+  visitLoopMs?: number;
+  // Aggregate row-write time across the loop — the Σ of every
+  // `batch.updateEntry` INSERT. Tracked here rather than per row because a row
+  // cannot time its own write. This is the I/O the visit's tab does not need,
+  // so it is the primary candidate to overlap with the next visit.
+  writeMs?: number;
+  // The final atomic swap: `batch.done()` (realm-meta update, working → main
+  // promotion, obsolete-row prune) in one transaction.
+  swapMs?: number;
+}
+
 export interface StreamFileRef {
   stream: ByteStream;
   lastModified: number;

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -51,6 +51,10 @@ export interface Stats extends JSONTypes.Object {
 export interface IndexPhaseTimings {
   // Whole-job wall, kickoff to return.
   totalMs?: number;
+  // Batch setup before any phase below: `IndexWriter.createBatch` (generation
+  // bump + resumable working-row scan). Non-trivial on a retry job or under DB
+  // slowness, so it's bucketed rather than left as residue in `totalMs`.
+  setupMs?: number;
   // Reading the index's per-file modified times up front (from-scratch only).
   mtimesMs?: number;
   // Invalidation discovery: the from-scratch filesystem walk, or the


### PR DESCRIPTION
## Background

Indexing a realm runs one file visit at a time. Each visit renders the file through the prerender server, and that server-side render is well-instrumented: every `boxel_index` row records how long its render took (`diagnostics.totalElapsedMs`). But an index job's wall clock is bigger than the sum of those renders — the job also discovers what to invalidate, orders the work by dependency, pre-warms the module cache, pays per-visit client-side overhead around each render, writes each row, and finally swaps the staging table into place. All of that runs serially with the visits, and none of it was measured. On a benchmark full reindex it was roughly a quarter of the total wall, showing up only as an unexplained gap between "sum of renders" and "job took this long."

This PR makes that gap measurable. It adds instrumentation only — indexing behavior is unchanged, and there's no database migration (both landing spots are existing JSONB columns).

## What it adds

Two profiling channels that together account for the whole job wall:

**Per row — `boxel_index.diagnostics.indexVisitClientMs`** (and the working table). The client-side overhead the indexer paid for that specific row, outside the server render:
- `read` — reading the file bytes and its metadata lookups, before the render.
- `renderRpc` — the render round-trip transport: the client-observed prerender wall minus the server's own `totalElapsedMs` (serialization + the wire hop + waits the server doesn't count). ~0 on the in-process prerenderer.
- `bookkeeping` — dependency resolution and index-entry construction after the render, before the row write.

**Per job — `jobs.result.phaseTimings`.** The once-per-job phases that surround and interleave the serial visit loop and can't be attributed to a single row: `mtimesMs`, `discoverMs`, `orderMs`, `preWarmMs` (from-scratch only for the first and last two), `visitLoopMs`, `writeMs`, `swapMs`, and `totalMs`. The aggregate row-write time lives here rather than per row because a row can't time its own write. It's kept off the `Stats` object — which is embedded in other job results and deep-compared in tests — so it introduces no non-deterministic timing there.

Together they reconstruct the wall:

```
totalMs     ≈ mtimesMs + discoverMs + orderMs + preWarmMs + visitLoopMs + swapMs
visitLoopMs ≈ Σ totalElapsedMs (server render) + Σ indexVisitClientMs + writeMs
```

so the between-visit slice decomposes into discovery, ordering, pre-warm, per-visit client overhead, row writes, and the swap — and you can tell which bucket dominates (e.g. whether overlapping the row writes with the next visit is worth it, versus the discovery/swap bookends that can't overlap anything).

## Skill

The `indexing-diagnostics` skill gains a new **Mode K** documenting the decomposition, the two sources, and the SQL to pull a job's `phaseTimings` and sum the per-row halves, plus a query to find the rows whose bookkeeping dominates.

## Test plan

Adds realm-server coverage in `indexing-test.ts` asserting both channels populate end-to-end:
- the `from-scratch-index` job result carries a numeric `phaseTimings` breakdown;
- a freshly-indexed row carries numeric `indexVisitClientMs.read` / `.renderRpc` / `.bookkeeping`.

`indexing-test.ts` passes in full (61/61) against the local test-services stack.
