### PR TITLE
Render each card type's icon once per indexing job

### DIFF
--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -265,6 +265,10 @@ export class Prerenderer {
     let owner = this.#batchOwnership.get(affinityKey);
     if (owner?.batchId === batchId) {
       this.#batchOwnership.delete(affinityKey);
+      // The job's icon memo has no readers once its batch releases the
+      // affinity (a later job carries a different job key), so drop it
+      // rather than letting it idle until the next job replaces it.
+      this.#renderRunner.clearIconMemo(affinityKey);
       log.debug(`batch ${batchId} released ownership of ${affinityKey}`);
     }
   }
@@ -277,6 +281,13 @@ export class Prerenderer {
   ): { batchId: string; since: number } | undefined {
     let owner = this.#batchOwnership.get(affinityKey);
     return owner ? { batchId: owner.batchId, since: owner.since } : undefined;
+  }
+
+  // Read-only observability accessor used by tests. Callers outside of
+  // tests should not rely on this shape; it's a debugging surface, not a
+  // stable API.
+  getIconMemo(affinityKey: string) {
+    return this.#renderRunner.getIconMemo(affinityKey);
   }
 
   // Back-compat static re-export: older callers / tests reference

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -110,6 +110,14 @@ export class Prerenderer {
             `batch ownership cleared for ${affinityKey} due to affinity disposal`,
           );
         }
+        // Drop the affinity's icon memo with the rest of its warm state.
+        // Disposal also clears the ownership entry above, which makes the
+        // owner-matched clear in `releaseBatch` a no-op for this affinity —
+        // without this, a job whose affinity is disposed mid-run (cancel,
+        // idle eviction, capacity pressure) would leave its memo behind
+        // until another job for the same realm replaced it. A still-running
+        // job just re-renders each type's icon once as the memo re-warms.
+        this.#renderRunner.clearIconMemo(affinityKey);
       },
     });
     this.#renderRunner = new RenderRunner({

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -1282,6 +1282,15 @@ export class RenderRunner {
           );
           if (metaResult !== undefined) {
             meta = metaResult;
+          } else {
+            // The entry step failed, so the page is showing the error
+            // route: a subsequent capture would wait on fresh render
+            // output the page can no longer produce and ride out the
+            // full render timeout, evicting the tab. Skip the icon —
+            // the row is an error row either way. (A card whose meta
+            // errors deterministically — e.g. a computed that reads a
+            // broken link — takes this path on every visit.)
+            cardShortCircuit = true;
           }
           if (!cardShortCircuit) {
             let iconMemo = this.#iconMemoFor(

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -80,6 +80,16 @@ type PoolInfo = {
   timedOut: boolean;
 };
 
+// One indexing job's icon renderings for one affinity: the captured icon
+// markup keyed by the type's internal key, plus hit/miss counters for the
+// stats line emitted when the memo is replaced or released.
+type IconMemo = {
+  jobKey: string;
+  icons: Map<string, string>;
+  hits: number;
+  misses: number;
+};
+
 const CLEAR_CACHE_RETRY_SIGNATURES: readonly (readonly string[])[] = [
   // this is a side effect of glimmer scoped styles moving a DOM node that
   // glimmer is tracking. when we go to teardown the component glimmer gets mad
@@ -133,6 +143,17 @@ export class RenderRunner {
     byAffinity: new Map<string, { unusable: number; timeout: number }>(),
   };
   #lastAuthByAffinity = new Map<string, string>();
+  // Job-scoped icon memo, one slot per affinity. Icon HTML is a pure
+  // function of the card's type — the type's static `icon` component, never
+  // the instance — so within one indexing job the first visit for a type
+  // renders the icon and every later visit of that type reuses the captured
+  // markup, skipping the icon route. Indexing serializes per realm (= per
+  // affinity), so at most one job is active per slot: a visit carrying a
+  // different job key (jobId + loader epoch) replaces the slot outright. A
+  // module edit arrives as a new job with a new key, so stale markup cannot
+  // leak across module changes. Visits without a jobId (on-demand renders)
+  // never touch the memo.
+  #iconMemoByAffinity = new Map<string, IconMemo>();
 
   constructor(options: { pagePool: PagePool; boxelHostURL: string }) {
     this.#pagePool = options.pagePool;
@@ -170,6 +191,70 @@ export class RenderRunner {
 
   clearAuthCache(affinityKey: string) {
     this.#lastAuthByAffinity.delete(affinityKey);
+  }
+
+  // Resolve the icon memo for a visit. Only indexing visits participate
+  // (they carry a jobId); the loader epoch rides the job key as
+  // belt-and-braces so a memo can never outlive the module surface it was
+  // rendered against.
+  #iconMemoFor(
+    affinityKey: string,
+    jobId: string | undefined,
+    loaderEpoch: string | undefined,
+  ): IconMemo | undefined {
+    if (!jobId) {
+      return undefined;
+    }
+    let jobKey = `${jobId}|${loaderEpoch ?? ''}`;
+    let memo = this.#iconMemoByAffinity.get(affinityKey);
+    if (!memo || memo.jobKey !== jobKey) {
+      if (memo) {
+        this.#logIconMemoStats(affinityKey, memo, 'superseded');
+      }
+      memo = { jobKey, icons: new Map(), hits: 0, misses: 0 };
+      this.#iconMemoByAffinity.set(affinityKey, memo);
+    }
+    return memo;
+  }
+
+  // Drop an affinity's icon memo. Called when the indexing batch that owns
+  // the affinity releases it; the job-key check in #iconMemoFor already
+  // guarantees a later job never reads another job's entries, so this is
+  // memory hygiene, not a correctness gate.
+  clearIconMemo(affinityKey: string) {
+    let memo = this.#iconMemoByAffinity.get(affinityKey);
+    if (memo) {
+      this.#logIconMemoStats(affinityKey, memo, 'released');
+      this.#iconMemoByAffinity.delete(affinityKey);
+    }
+  }
+
+  // Read-only observability accessor used by tests. Callers outside of
+  // tests should not rely on this shape; it's a debugging surface, not a
+  // stable API.
+  getIconMemo(affinityKey: string):
+    | {
+        jobKey: string;
+        types: string[];
+        hits: number;
+        misses: number;
+      }
+    | undefined {
+    let memo = this.#iconMemoByAffinity.get(affinityKey);
+    return memo
+      ? {
+          jobKey: memo.jobKey,
+          types: [...memo.icons.keys()],
+          hits: memo.hits,
+          misses: memo.misses,
+        }
+      : undefined;
+  }
+
+  #logIconMemoStats(affinityKey: string, memo: IconMemo, reason: string) {
+    log.debug(
+      `icon memo stats affinity=${affinityKey} types=${memo.icons.size} hits=${memo.hits} misses=${memo.misses} (${reason})`,
+    );
   }
 
   // Builds the per-render profile context threaded into `withTimeout`.
@@ -1124,6 +1209,15 @@ export class RenderRunner {
           return;
         };
 
+        let emptyMeta: PrerenderMeta = {
+          serialized: null,
+          searchDoc: null,
+          displayNames: null,
+          deps: null,
+          types: null,
+        };
+        let meta: PrerenderMeta = emptyMeta;
+
         if (runHtmlSteps) {
           let isolatedStart = Date.now();
           let isolatedResult = await withTimeout(
@@ -1166,46 +1260,65 @@ export class RenderRunner {
             capturedDeps = await this.#readCapturedDeps(page);
           }
         } else {
-          // An index visit never touches the html route, so the icon render
-          // is its entry into the render app; subsequent steps are in-page
-          // child transitions.
-          let iconResult = await withTimeout(
-            page,
+          // An index visit never touches the html route, so render.meta is
+          // its entry into the render app; the icon runs after it as an
+          // in-page child transition. Meta goes first because the icon is a
+          // pure function of the card's type (`types[0]`, which meta
+          // resolves): the job-scoped memo lets the first visit for a type
+          // render the icon and every later visit of that type reuse the
+          // captured markup, skipping the icon route.
+          let metaResult = await runTimedStep<PrerenderMeta>(
+            'visit card render.meta',
             async () => {
               await transitionTo(
                 page,
-                'render.icon',
+                'render.meta',
                 url,
                 nonce,
                 serializedOptions,
               );
-              return await renderIcon(page, captureOptions);
+              return await renderMeta(page, captureOptions);
             },
-            opts?.timeoutMs,
-            this.#profileContext(affinityKey, url, 'card icon', jobId),
           );
-          if (isRenderError(iconResult)) {
-            cardShortCircuit = true;
-            let renderError = iconResult as RenderError;
-            let evicted = await this.#maybeEvict(
+          if (metaResult !== undefined) {
+            meta = metaResult;
+          }
+          if (!cardShortCircuit) {
+            let iconMemo = this.#iconMemoFor(
               affinityKey,
-              'visit card icon render',
-              renderError,
+              jobId,
+              baseOptions.loaderEpoch,
             );
-            applyStepError(renderError, evicted);
-          } else {
-            iconHTML = iconResult as string;
+            let iconTypeKey = meta.types?.[0];
+            // A clearCache visit is asked for a pristine render, so it
+            // bypasses the memo read; its fresh capture overwrites the
+            // entry below.
+            let memoizedIconHTML =
+              iconMemo && iconTypeKey !== undefined && !baseOptions.clearCache
+                ? iconMemo.icons.get(iconTypeKey)
+                : undefined;
+            if (memoizedIconHTML !== undefined) {
+              iconMemo!.hits++;
+              iconHTML = memoizedIconHTML;
+              log.debug(
+                `card icon memo hit type=${iconTypeKey} url=${url} affinity=${affinityKey}`,
+              );
+            } else {
+              let iconResult = await runTimedStep<string>(
+                'visit card icon render',
+                () => renderIcon(page, captureOptions),
+              );
+              if (iconResult !== undefined) {
+                iconHTML = iconResult;
+                if (iconMemo && iconTypeKey !== undefined) {
+                  iconMemo.misses++;
+                  iconMemo.icons.set(iconTypeKey, iconHTML);
+                }
+              }
+            }
           }
         }
 
-        let emptyMeta: PrerenderMeta = {
-          serialized: null,
-          searchDoc: null,
-          displayNames: null,
-          deps: null,
-          types: null,
-        };
-        let meta: PrerenderMeta = emptyMeta;
         let typesForAncestors: PrerenderTypes = { types: null };
         let headHTML: string | null = null;
         let atomHTML: string | null = null;
@@ -1329,7 +1442,10 @@ export class RenderRunner {
           }
         }
 
-        if (!cardShortCircuit && runIndexSteps) {
+        // The fused visit runs meta last, after the format renders above
+        // marked the linksTo / linksToMany fields they read as "used"; the
+        // index visit ran meta as its entry instead.
+        if (!cardShortCircuit && runIndexSteps && runHtmlSteps) {
           let finalMetaResult = await runTimedStep<PrerenderMeta>(
             'visit card render.meta',
             () => renderMeta(page, captureOptions),
@@ -1421,11 +1537,28 @@ export class RenderRunner {
             timeoutMs: opts?.timeoutMs,
           };
 
-          // stash file data for the render route model hook to consume
-          await page.evaluate((data) => {
-            (globalThis as any).__boxelFileRenderData = data;
-          }, effectiveFileData);
-          didStashFileRenderData = true;
+          // The index visit's only page work for a file is its icon, which
+          // is a pure function of the file's type (`effectiveTypes[0]`,
+          // resolved by the extract pass): on a memo hit the pass touches
+          // the page not at all — including the file-data stash, which only
+          // the render routes consume. A clearCache visit bypasses the memo
+          // read (see the card pass).
+          let iconMemo = runHtmlSteps
+            ? undefined
+            : this.#iconMemoFor(affinityKey, jobId, baseOptions.loaderEpoch);
+          let iconTypeKey = effectiveTypes?.[0];
+          let memoizedIconHTML =
+            iconMemo && iconTypeKey !== undefined && !baseOptions.clearCache
+              ? iconMemo.icons.get(iconTypeKey)
+              : undefined;
+
+          if (memoizedIconHTML === undefined) {
+            // stash file data for the render route model hook to consume
+            await page.evaluate((data) => {
+              (globalThis as any).__boxelFileRenderData = data;
+            }, effectiveFileData);
+            didStashFileRenderData = true;
+          }
 
           let fileError: RenderError | undefined;
           let fileShortCircuit = false;
@@ -1493,6 +1626,12 @@ export class RenderRunner {
                 }
               }
             }
+          } else if (memoizedIconHTML !== undefined) {
+            iconMemo!.hits++;
+            iconHTML = memoizedIconHTML;
+            log.debug(
+              `file icon memo hit type=${iconTypeKey} url=${url} affinity=${affinityKey}`,
+            );
           } else {
             // The file's icon belongs to the index half, and an index visit
             // never touches the html route — so the icon render is its entry
@@ -1522,6 +1661,10 @@ export class RenderRunner {
               applyStepError(renderError, evicted);
             } else {
               iconHTML = iconResult as string;
+              if (iconMemo && iconTypeKey !== undefined) {
+                iconMemo.misses++;
+                iconMemo.icons.set(iconTypeKey, iconHTML);
+              }
             }
           }
 

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -11,6 +11,7 @@ import type {
 } from '@cardstack/runtime-common';
 import type { Realm as RuntimeRealm } from '@cardstack/runtime-common';
 import type { Prerenderer } from '../prerender/index.ts';
+import { toAffinityKey } from '../prerender/affinity.ts';
 import { PagePool } from '../prerender/page-pool.ts';
 import { RenderRunner } from '../prerender/render-runner.ts';
 import { BrowserManager } from '../prerender/browser-manager.ts';
@@ -7355,6 +7356,16 @@ module(basename(import.meta.filename), function () {
                 }
               }
             `,
+            'pet.gts': `
+              import { CardDef } from '@cardstack/base/card-api';
+              const PetIcon = <template>
+                <svg data-test-icon='pet' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><circle cx='12' cy='12' r='10' /></svg>
+              </template>;
+              export class Pet extends CardDef {
+                static displayName = "Pet";
+                static icon = PetIcon;
+              }
+            `,
             'maple.json': {
               data: {
                 attributes: { name: 'Maple' },
@@ -7362,6 +7373,28 @@ module(basename(import.meta.filename), function () {
                   adoptsFrom: {
                     module: rri('./person'),
                     name: 'Person',
+                  },
+                },
+              },
+            },
+            'willow.json': {
+              data: {
+                attributes: { name: 'Willow' },
+                meta: {
+                  adoptsFrom: {
+                    module: rri('./person'),
+                    name: 'Person',
+                  },
+                },
+              },
+            },
+            'rex.json': {
+              data: {
+                attributes: {},
+                meta: {
+                  adoptsFrom: {
+                    module: rri('./pet'),
+                    name: 'Pet',
                   },
                 },
               },
@@ -7747,6 +7780,176 @@ module(basename(import.meta.filename), function () {
         },
       });
       assert.true(result.pool.reused, 'second visit reused the pooled page');
+    });
+
+    // Icon HTML is a pure function of the card's type (the type's static
+    // `icon` component), so an indexing job renders each type's icon once:
+    // the first index visit for a type renders it and every later visit of
+    // that type reuses the captured markup, skipping the icon route. The
+    // memo is scoped to the visit's jobId; visits without one (on-demand
+    // renders) always render the icon and never touch the memo.
+    module('index-visit icon memo', function () {
+      let affinityKey = toAffinityKey({
+        affinityType: 'realm',
+        affinityValue: realmURL,
+      });
+      let indexVisit = (fileName: string, extra?: Record<string, unknown>) =>
+        prerenderer.prerenderVisit({
+          affinityType: 'realm',
+          affinityValue: realmURL,
+          realm: realmURL,
+          url: `${realmURL}${fileName}`,
+          auth: auth(),
+          visitType: 'index',
+          renderOptions: {
+            cardRender: true,
+            fileExtract: true,
+            fileRender: true,
+            fileDefCodeRef: {
+              module: baseRRI('json-file-def'),
+              name: 'JsonFileDef',
+            },
+            ...((extra?.renderOptions as object) ?? {}),
+          },
+          ...(extra?.jobId ? { jobId: extra.jobId as string } : {}),
+          ...(extra?.batchId ? { batchId: extra.batchId as string } : {}),
+        });
+
+      test('one job renders each type icon once and reuses it', async function (assert) {
+        let jobId = 'icon-memo-reuse.1';
+        let first = (await indexVisit('maple.json', { jobId })).response;
+        assert.notOk(first.card?.error, 'first visit completes cleanly');
+        assert.ok(
+          first.card?.iconHTML?.startsWith('<svg'),
+          `first visit renders the card icon: ${first.card?.iconHTML}`,
+        );
+        assert.ok(
+          first.fileRender?.iconHTML,
+          'first visit renders the file icon',
+        );
+        let memo = prerenderer.getIconMemo(affinityKey);
+        assert.strictEqual(
+          memo?.misses,
+          2,
+          'card + file icons each rendered once',
+        );
+        assert.strictEqual(memo?.hits, 0, 'nothing reused yet');
+        assert.strictEqual(memo?.types.length, 2, 'two type keys memoized');
+
+        let second = (await indexVisit('willow.json', { jobId })).response;
+        assert.notOk(second.card?.error, 'second visit completes cleanly');
+        assert.strictEqual(
+          second.card?.iconHTML,
+          first.card?.iconHTML,
+          'same-type card icon is reused byte-identically',
+        );
+        assert.strictEqual(
+          second.fileRender?.iconHTML,
+          first.fileRender?.iconHTML,
+          'same-type file icon is reused byte-identically',
+        );
+        memo = prerenderer.getIconMemo(affinityKey);
+        assert.strictEqual(memo?.hits, 2, 'card + file icons each reused');
+        assert.strictEqual(memo?.misses, 2, 'no additional renders');
+
+        let third = (await indexVisit('rex.json', { jobId })).response;
+        assert.notOk(third.card?.error, 'third visit completes cleanly');
+        assert.ok(
+          third.card?.iconHTML?.includes('data-test-icon'),
+          `a different type renders its own icon: ${third.card?.iconHTML}`,
+        );
+        assert.notStrictEqual(
+          third.card?.iconHTML,
+          first.card?.iconHTML,
+          'the two card types have distinct icons',
+        );
+        memo = prerenderer.getIconMemo(affinityKey);
+        assert.strictEqual(memo?.misses, 3, 'the new card type rendered once');
+        assert.strictEqual(memo?.hits, 3, 'its file icon was reused');
+        assert.strictEqual(memo?.types.length, 3, 'three type keys memoized');
+      });
+
+      test('a different job renders icons afresh', async function (assert) {
+        await indexVisit('maple.json', { jobId: 'icon-memo-job-a.1' });
+        let memoA = prerenderer.getIconMemo(affinityKey);
+        assert.strictEqual(memoA?.misses, 2, 'first job rendered its icons');
+
+        let result = (
+          await indexVisit('willow.json', { jobId: 'icon-memo-job-b.1' })
+        ).response;
+        assert.ok(result.card?.iconHTML, 'card icon rendered');
+        let memoB = prerenderer.getIconMemo(affinityKey);
+        assert.notStrictEqual(
+          memoB?.jobKey,
+          memoA?.jobKey,
+          'the memo belongs to the new job',
+        );
+        assert.strictEqual(
+          memoB?.misses,
+          2,
+          'the new job rendered the icons itself',
+        );
+        assert.strictEqual(memoB?.hits, 0, 'nothing carried over');
+      });
+
+      test('a visit without a jobId never touches the memo', async function (assert) {
+        await indexVisit('maple.json', { jobId: 'icon-memo-anon.1' });
+        let before = prerenderer.getIconMemo(affinityKey);
+        assert.strictEqual(before?.misses, 2, 'job memo established');
+
+        let result = (await indexVisit('willow.json')).response;
+        assert.ok(
+          result.card?.iconHTML?.startsWith('<svg'),
+          'icon still renders without a jobId',
+        );
+        let after = prerenderer.getIconMemo(affinityKey);
+        assert.deepEqual(
+          after,
+          before,
+          'the jobless visit neither read nor wrote the memo',
+        );
+      });
+
+      test('a clearCache visit bypasses the memo read and releaseBatch drops the memo', async function (assert) {
+        let jobId = 'icon-memo-clear.1';
+        let batchId = 'icon-memo-clear-batch';
+        let first = (await indexVisit('maple.json', { jobId })).response;
+        assert.ok(first.card?.iconHTML, 'card icon rendered');
+
+        let second = (
+          await indexVisit('willow.json', {
+            jobId,
+            batchId,
+            renderOptions: { clearCache: true },
+          })
+        ).response;
+        assert.ok(
+          second.card?.iconHTML?.startsWith('<svg'),
+          'clearCache visit renders the icon',
+        );
+        let memo = prerenderer.getIconMemo(affinityKey);
+        assert.strictEqual(
+          memo?.hits,
+          0,
+          'the clearCache visit did not read the memo',
+        );
+        assert.strictEqual(
+          memo?.misses,
+          4,
+          'the clearCache visit re-rendered and re-stored both icons',
+        );
+
+        await prerenderer.releaseBatch({
+          batchId,
+          affinityType: 'realm',
+          affinityValue: realmURL,
+        });
+        assert.strictEqual(
+          prerenderer.getIconMemo(affinityKey),
+          undefined,
+          'releasing the owning batch drops the memo',
+        );
+      });
     });
   });
 });

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -7910,6 +7910,23 @@ module(basename(import.meta.filename), function () {
         );
       });
 
+      test('disposing the affinity drops the memo', async function (assert) {
+        await indexVisit('maple.json', { jobId: 'icon-memo-dispose.1' });
+        assert.ok(
+          prerenderer.getIconMemo(affinityKey),
+          'memo established by the visit',
+        );
+        await prerenderer.disposeAffinity({
+          affinityType: 'realm',
+          affinityValue: realmURL,
+        });
+        assert.strictEqual(
+          prerenderer.getIconMemo(affinityKey),
+          undefined,
+          'affinity disposal drops the memo with the rest of the warm state',
+        );
+      });
+
       test('a clearCache visit bypasses the memo read and releaseBatch drops the memo', async function (assert) {
         let jobId = 'icon-memo-clear.1';
         let batchId = 'icon-memo-clear-batch';

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -7399,6 +7399,37 @@ module(basename(import.meta.filename), function () {
                 },
               },
             },
+            'owner.gts': `
+              import { CardDef, StringField, field, contains, linksTo } from '@cardstack/base/card-api';
+              import { Person } from './person';
+              export class Owner extends CardDef {
+                static displayName = "Owner";
+                @field friend = linksTo(Person);
+                @field friendName = contains(StringField, {
+                  computeVia: function() {
+                    return this.friend.name;
+                  }
+                });
+              }
+            `,
+            'stray.json': {
+              data: {
+                attributes: {},
+                relationships: {
+                  friend: {
+                    links: {
+                      self: 'http://localhost:9000/link-to-nowhere',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: rri('./owner'),
+                    name: 'Owner',
+                  },
+                },
+              },
+            },
           },
         },
       ],
@@ -7908,6 +7939,32 @@ module(basename(import.meta.filename), function () {
           before,
           'the jobless visit neither read nor wrote the memo',
         );
+      });
+
+      test('a meta error short-circuits the pass and skips the icon render', async function (assert) {
+        // `stray.json`'s `friendName` computed reads a link whose target
+        // never loads, so the meta entry errors on every visit. The pass
+        // must stop there: driving the icon render against the error
+        // route would wait out the full render timeout and evict the tab.
+        let { response, pool } = await indexVisit('stray.json', {
+          jobId: 'icon-memo-meta-error.1',
+        });
+        assert.ok(
+          response.card?.error,
+          `card error captured: ${JSON.stringify(
+            response.card?.error?.error?.message ?? null,
+          )}`,
+        );
+        assert.strictEqual(
+          response.card?.iconHTML,
+          null,
+          'icon render is skipped once the meta entry has errored',
+        );
+        assert.false(
+          pool.timedOut,
+          'the visit completes without a render timeout',
+        );
+        assert.false(pool.evicted, 'the page stays usable');
       });
 
       test('disposing the affinity drops the memo', async function (assert) {


### PR DESCRIPTION
During indexing, the prerenderer's index visit renders a card's icon alongside its search-doc data. Icon markup is a pure function of the card's *type* — it comes from the type's static `icon` component, never from instance data — yet the visit rendered it once per file. A from-scratch index of an 885-card realm with 11 distinct card types performs 885 icon renders where 11 would do; each one is a route transition plus render-settle inside the hot path's per-visit floor.

The prerender server now keeps a job-scoped memo of icon markup keyed on the card's type. The first index visit for a type renders the icon; every later visit of that type in the same job reuses the captured markup and skips the icon route entirely. File icons get the same treatment keyed on the file's type — a file visit whose icon is memoized performs no page work at all in its file-render pass (the file-data stash is skipped too).

Rows are unchanged: `icon_html` on an index row is byte-identical to what a fresh render produces.

## How it works

- The index visit's card pass enters the render app via `render.meta` and renders the icon afterward as an in-page child transition. Meta goes first because the memo key is `types[0]`, which the meta pass resolves. The fused visit is unchanged: it still runs meta last, after the format renders mark the linked fields they read as used.
- A meta error short-circuits the pass: the page is showing the error route at that point, so a subsequent icon capture would wait on fresh render output the page can no longer produce and ride out the full render timeout, evicting the tab. The row lands as an error row with no icon — the same skip the html-route entry applies when its isolated render errors. A card whose meta errors deterministically (e.g. a computed that reads a broken link) takes this path on every visit.
- The memo lives on the `RenderRunner`, one slot per affinity, keyed by the visit's `jobId` plus the loader epoch. Indexing serializes per realm, so at most one job is active per slot; a visit carrying a different job key replaces the slot outright. A module edit arrives as a new job, so stale icon markup cannot survive a module change.
- Visits without a `jobId` (on-demand renders) never read or write the memo.
- `clearCache` visits bypass the memo read — they are asked for a pristine render — and overwrite the entry with their fresh capture.
- `releaseBatch` also drops the affinity's memo. Correctness doesn't depend on this (the job-key check already isolates jobs); it just frees the memory promptly.

## Testing

New tests in `prerendering-test.ts` cover same-job reuse (byte-identical markup, hit/miss counters), per-type keying (a second card type renders its own distinct icon), job-change reset, jobless visits leaving the memo untouched, clearCache bypass, releaseBatch and affinity-disposal cleanup, and the meta-error short-circuit (an instance whose computed reads a broken link produces an error row promptly, with no icon render, no render timeout, and no tab eviction). The existing lossless-partition test continues to pin the index visit's output against the fused visit's, byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
