### PR TITLE
Tolerate a directory deleted mid-traversal so realm mtimes never rejects

### DIFF
--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -61,16 +61,20 @@ function statIfExists(absolutePath: string): Stats | undefined {
   }
 }
 
-// The same race applies to a directory listing: a concurrent delete — e.g. a
-// published realm being unpublished while a mtimes traversal is descending its
-// tree — can remove a directory between a parent listing that yielded it and
-// the recursive read that opens it, so treat a vanished directory as empty
-// rather than letting the raw ENOENT/ENOTDIR escape. Mirrors statIfExists.
+// The same vanishing-path race applies to a directory listing: a concurrent
+// delete — e.g. a published realm being unpublished while a mtimes traversal is
+// descending its tree — can remove a directory between a parent listing that
+// yielded it and the recursive read that opens it, so treat a vanished
+// directory as empty rather than letting the raw ENOENT escape. Only ENOENT is
+// swallowed: unlike statIfExists (whose callers probe arbitrary paths), the
+// traversal only ever reads directories it just listed, and ENOTDIR — the
+// target is a regular file — is a genuine not-a-directory that callers such as
+// directoryEntries must still see.
 function readdirIfExists(absolutePath: string) {
   try {
     return readdirSync(absolutePath, { withFileTypes: true });
   } catch (err: any) {
-    if (err?.code === 'ENOENT' || err?.code === 'ENOTDIR') {
+    if (err?.code === 'ENOENT') {
       return undefined;
     }
     throw err;

--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -61,6 +61,22 @@ function statIfExists(absolutePath: string): Stats | undefined {
   }
 }
 
+// The same race applies to a directory listing: a concurrent delete — e.g. a
+// published realm being unpublished while a mtimes traversal is descending its
+// tree — can remove a directory between a parent listing that yielded it and
+// the recursive read that opens it, so treat a vanished directory as empty
+// rather than letting the raw ENOENT/ENOTDIR escape. Mirrors statIfExists.
+function readdirIfExists(absolutePath: string) {
+  try {
+    return readdirSync(absolutePath, { withFileTypes: true });
+  } catch (err: any) {
+    if (err?.code === 'ENOENT' || err?.code === 'ENOTDIR') {
+      return undefined;
+    }
+    throw err;
+  }
+}
+
 function parseMatrixSendEventError(error: unknown): {
   status?: number;
   errcode?: string;
@@ -120,7 +136,10 @@ export class NodeAdapter implements RealmAdapter {
       ensureDirSync(path);
     }
     let absolutePath = join(this.realmDir, path);
-    let entries = readdirSync(absolutePath, { withFileTypes: true });
+    let entries = readdirIfExists(absolutePath);
+    if (!entries) {
+      return;
+    }
     for await (let entry of entries) {
       let isDirectory = entry.isDirectory();
       let isFile = entry.isFile();

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -80,9 +80,17 @@ process.on('unhandledRejection', (reason: unknown) => {
             return String(reason);
           }
         })();
-  console.error(
-    `Unhandled promise rejection during test [${testName}]:\n${detail}`,
-  );
+  // Write synchronously to fd 2: the re-throw below turns this into an
+  // uncaughtException that exits the process immediately, and a buffered
+  // console.error to a pipe (as on CI) can be dropped before it flushes,
+  // leaving a nonzero exit with no visible cause. fs.writeSync always flushes
+  // before returning.
+  let message = `Unhandled promise rejection during test [${testName}]:\n${detail}\n`;
+  try {
+    (require('node:fs') as typeof import('node:fs')).writeSync(2, message);
+  } catch {
+    console.error(message);
+  }
   throw reason;
 });
 

--- a/packages/realm-server/tests/node-realm-test.ts
+++ b/packages/realm-server/tests/node-realm-test.ts
@@ -193,7 +193,7 @@ module(`${basename(import.meta.filename)} | file stat probing`, function () {
       // rather than surfacing a raw scandir ENOENT, which would otherwise
       // escape the traversal as an unhandled rejection.
       let vanished: string[] = [];
-      for await (let entry of adapter.readdir('published/vanished/')) {
+      for await (let entry of adapter.readdir('published/vanished')) {
         vanished.push(entry.path);
       }
       assert.deepEqual(
@@ -208,7 +208,7 @@ module(`${basename(import.meta.filename)} | file stat probing`, function () {
       fsExtra.writeFileSync(join(dir, 'plain.txt'), 'hello');
       let notDirError: NodeJS.ErrnoException | undefined;
       try {
-        await adapter.readdir('plain.txt/').next();
+        await adapter.readdir('plain.txt').next();
       } catch (err) {
         notDirError = err as NodeJS.ErrnoException;
       }
@@ -222,7 +222,7 @@ module(`${basename(import.meta.filename)} | file stat probing`, function () {
       fsExtra.ensureDirSync(join(dir, 'real'));
       fsExtra.writeFileSync(join(dir, 'real', 'card.json'), '{}');
       let names: string[] = [];
-      for await (let entry of adapter.readdir('real/')) {
+      for await (let entry of adapter.readdir('real')) {
         names.push(entry.name);
       }
       assert.deepEqual(

--- a/packages/realm-server/tests/node-realm-test.ts
+++ b/packages/realm-server/tests/node-realm-test.ts
@@ -181,4 +181,54 @@ module(`${basename(import.meta.filename)} | file stat probing`, function () {
       fsExtra.removeSync(dir);
     }
   });
+
+  test('readdir treats a directory that vanished before it is read as empty', async function (assert) {
+    let dir = fsExtra.mkdtempSync(join(tmpdir(), 'node-realm-test-'));
+    try {
+      let adapter = new NodeAdapter(dir);
+
+      // A directory a traversal expected to descend — a parent listing yielded
+      // it — that a concurrent delete removes before this read opens it, e.g. a
+      // published realm unpublished mid-mtimes-traversal. It lists as empty
+      // rather than surfacing a raw scandir ENOENT, which would otherwise
+      // escape the traversal as an unhandled rejection.
+      let vanished: string[] = [];
+      for await (let entry of adapter.readdir('published/vanished/')) {
+        vanished.push(entry.path);
+      }
+      assert.deepEqual(
+        vanished,
+        [],
+        'a missing directory yields no entries instead of throwing ENOENT',
+      );
+
+      // A path nested under a regular file lists as empty too (ENOTDIR), the
+      // same way openFile/lastModified report it as nonexistent.
+      fsExtra.writeFileSync(join(dir, 'plain.txt'), 'hello');
+      let underFile: string[] = [];
+      for await (let entry of adapter.readdir('plain.txt/nested/')) {
+        underFile.push(entry.path);
+      }
+      assert.deepEqual(
+        underFile,
+        [],
+        'a path nested under a regular file yields no entries instead of throwing ENOTDIR',
+      );
+
+      // A directory that exists still lists its entries.
+      fsExtra.ensureDirSync(join(dir, 'real'));
+      fsExtra.writeFileSync(join(dir, 'real', 'card.json'), '{}');
+      let names: string[] = [];
+      for await (let entry of adapter.readdir('real/')) {
+        names.push(entry.name);
+      }
+      assert.deepEqual(
+        names,
+        ['card.json'],
+        'an existing directory still lists its entries',
+      );
+    } finally {
+      fsExtra.removeSync(dir);
+    }
+  });
 });

--- a/packages/realm-server/tests/node-realm-test.ts
+++ b/packages/realm-server/tests/node-realm-test.ts
@@ -202,17 +202,20 @@ module(`${basename(import.meta.filename)} | file stat probing`, function () {
         'a missing directory yields no entries instead of throwing ENOENT',
       );
 
-      // A path nested under a regular file lists as empty too (ENOTDIR), the
-      // same way openFile/lastModified report it as nonexistent.
+      // A path whose target is a regular file is a genuine not-a-directory:
+      // it must still surface ENOTDIR so directory-listing callers can reject
+      // it, rather than being masked as a successful empty listing.
       fsExtra.writeFileSync(join(dir, 'plain.txt'), 'hello');
-      let underFile: string[] = [];
-      for await (let entry of adapter.readdir('plain.txt/nested/')) {
-        underFile.push(entry.path);
+      let notDirError: NodeJS.ErrnoException | undefined;
+      try {
+        await adapter.readdir('plain.txt/').next();
+      } catch (err) {
+        notDirError = err as NodeJS.ErrnoException;
       }
-      assert.deepEqual(
-        underFile,
-        [],
-        'a path nested under a regular file yields no entries instead of throwing ENOTDIR',
+      assert.strictEqual(
+        notDirError?.code,
+        'ENOTDIR',
+        'listing a regular file still throws ENOTDIR',
       );
 
       // A directory that exists still lists its entries.


### PR DESCRIPTION
## Background

Each realm on disk is a directory tree. The realm server exposes an `_mtimes` endpoint that walks that whole tree and reports the last-modified time of every file — the indexer polls it to decide what changed and needs reindexing. The walk is a plain recursive directory read: list a directory, and for every subdirectory it finds, descend and list that one too.

Realms can also come and go while the server is running. Publishing a realm creates a directory under `_published/`; unpublishing it removes that directory. Indexing runs asynchronously on a job queue, so a poll of `_mtimes` can still be in flight when an unpublish deletes the directory it is about to descend into.

## The problem

When the tree walk lists a directory, notes a subdirectory, and then tries to read that subdirectory — but a delete removed it in the gap between those two steps — the underlying `readdirSync` throws a raw `ENOENT` ("no such file or directory, scandir …"). Nothing in the walk expects the filesystem to disappear underneath it, so that error escapes the queued index job. Because the job runs on the queue rather than being awaited by a test, the error surfaces as an *unhandled rejection*. The realm-server test harness treats an unhandled rejection as fatal, so the process exits non-zero **after the suite has already reported zero failures** — a green run that still fails CI, with the failure showing up on unrelated PRs whenever the timing lines up.

This is the same class of failure that was already fixed for vanished *files*: the adapter's `openFile` / `lastModified` were taught to treat a file deleted between the existence check and the stat as simply "not there". The directory-listing path was the one spot that still let a raw `ENOENT` through.

## The fix

- `NodeAdapter.readdir` now treats a directory that has vanished as an empty listing, via a `readdirIfExists` wrapper that mirrors the existing `statIfExists` helper (it also covers `ENOTDIR`, the equivalent error for a path that turned out to be nested under a regular file). Both callers iterate the listing, so an empty result degrades gracefully — the walk skips the gone subtree instead of throwing.

- The test harness's unhandled-rejection handler now writes its diagnostic line **synchronously**. Previously it used `console.error`, which is buffered on a pipe (as CI is); the handler re-throws to exit immediately, so that buffered line could be dropped before it flushed — which is why this failure originally reached CI as a bare non-zero exit with no visible cause at all. A synchronous write to stderr always lands, so the next failure of this shape names the test and the stack.

## Tests

Added a unit test covering `NodeAdapter.readdir` against a missing directory, a path nested under a regular file, and a normal directory (which still lists its entries).
