### PR TITLE
Search-doc link loading: job-scoped document cache, concurrent loads, walk-until-stable

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1058,7 +1058,7 @@ Lines are FireLens-wrapped (`{"log":"…"}`); pull `.log`. Strip everything afte
 The index visit's cost is dominated by search-doc assembly. The host produces the doc by walking the card repeatedly until the store's load state is quiescent — the first walk that fires no lazy getter loads is the one whose doc persists — and the diagnostics split the cost along that seam, each side with per-item detail:
 
 1. **The discarded walks and their load drains** (`searchDocSettleMs`, `searchDocSettlePasses`) — the passes re-run because a computed's read of a not-yet-loaded link fired a lazy load the walk couldn't consume. This is where getter-driven link targets load; `searchDocSettlePasses` counts the discarded walks, so a card that settles on its first walk reads `0`. The generator's own `searchable`-route loads are awaited inside whichever walk reaches them (a route's hops resolve within one pass), and every performed load lands in `searchDocLinkLoads` (`{ path, target, ms }`, dotted `linksTo`/`linksToMany` field path + loaded URL). A card's independent routes and plural-field slots load **concurrently**, so the entries overlap in time — read each `ms` as that load's own span, not as a summable slice.
-2. **The doc-producing walk** (`searchDocMs`) — the stable walk over the card's fields. It never waits on getter-fired loads (those mark a walk unstable), but it can include targeted `searchable`-route loads it consumed inline — a first-walk-stable card performs all its route loads here, each itemized in `searchDocLinkLoads`. The per-field breakdown is `searchDocFieldsMs`, keyed by dotted field path with **inclusive** times (a parent includes its children — and a field's own link loads — so the keys read as a drill-down to the slow leaf).
+2. **The doc-producing walk** (`searchDocMs`) — the stable walk over the card's fields. It never waits on getter-fired loads (those mark a walk unstable), but it can include targeted `searchable`-route loads it consumed inline — a first-walk-stable card performs all its route loads here, each itemized in `searchDocLinkLoads`. Because those loads overlap each other and sibling evaluation, treat a load-entry-bearing `searchDocMs` as an upper bound on evaluation time — don't subtract the entries out. The per-field breakdown is `searchDocFieldsMs`, keyed by dotted field path with **inclusive** times (a parent includes its children — and a field's own link loads — so the keys read as a drill-down to the slow leaf).
 
 Both detail blocks are bounded — the slowest 20 entries at ≥ 1 ms — so a typical ~1 ms search doc persists neither, and their absence on a slow row is itself a signal (see step 3). Within one indexing job, loaded wire documents are cached job-scoped in the render tab, so a target shared by many cards costs a real load only on the first owner that reaches it — later owners' entries are near-zero and floor-pruned.
 
@@ -1370,8 +1370,9 @@ LIMIT 20;
                                  // load generation. Never waits on getter-fired loads
                                  // (those mark a walk unstable), but can include
                                  // targeted searchable-route loads it consumed inline,
-                                 // each itemized in `searchDocLinkLoads` — subtract
-                                 // those entries to read pure evaluation. Sum with
+                                 // each itemized in `searchDocLinkLoads` — those
+                                 // entries overlap, so read a load-bearing value as an
+                                 // upper bound on evaluation time. Sum with
                                  // `serializeMs` to get the host's contribution to
                                  // `renderElapsedMs`. Pairs with `computedCalls` so you
                                  // can normalize: a card with `computedCalls=500,

--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1058,7 +1058,7 @@ Lines are FireLens-wrapped (`{"log":"…"}`); pull `.log`. Strip everything afte
 The index visit's cost is dominated by search-doc assembly. The host produces the doc by walking the card repeatedly until the store's load state is quiescent — the first walk that fires no lazy getter loads is the one whose doc persists — and the diagnostics split the cost along that seam, each side with per-item detail:
 
 1. **The discarded walks and their load drains** (`searchDocSettleMs`, `searchDocSettlePasses`) — the passes re-run because a computed's read of a not-yet-loaded link fired a lazy load the walk couldn't consume. This is where getter-driven link targets load; `searchDocSettlePasses` counts the discarded walks, so a card that settles on its first walk reads `0`. The generator's own `searchable`-route loads are awaited inside whichever walk reaches them (a route's hops resolve within one pass), and every performed load lands in `searchDocLinkLoads` (`{ path, target, ms }`, dotted `linksTo`/`linksToMany` field path + loaded URL). A card's independent routes and plural-field slots load **concurrently**, so the entries overlap in time — read each `ms` as that load's own span, not as a summable slice.
-2. **The doc-producing walk** (`searchDocMs`) — the stable walk's evaluation of the card's fields, its loads all resident or cache hits. The per-field breakdown is `searchDocFieldsMs`, keyed by dotted field path with **inclusive** times (a parent includes its children, so the keys read as a drill-down to the slow leaf).
+2. **The doc-producing walk** (`searchDocMs`) — the stable walk over the card's fields. It never waits on getter-fired loads (those mark a walk unstable), but it can include targeted `searchable`-route loads it consumed inline — a first-walk-stable card performs all its route loads here, each itemized in `searchDocLinkLoads`. The per-field breakdown is `searchDocFieldsMs`, keyed by dotted field path with **inclusive** times (a parent includes its children — and a field's own link loads — so the keys read as a drill-down to the slow leaf).
 
 Both detail blocks are bounded — the slowest 20 entries at ≥ 1 ms — so a typical ~1 ms search doc persists neither, and their absence on a slow row is itself a signal (see step 3). Within one indexing job, loaded wire documents are cached job-scoped in the render tab, so a target shared by many cards costs a real load only on the first owner that reaches it — later owners' entries are near-zero and floor-pruned.
 
@@ -1080,7 +1080,7 @@ ORDER BY (diagnostics->>'searchDocSettleMs')::numeric
 LIMIT 20;
 ```
 
-`settle_ms + search_doc_ms` ≈ the row's search-doc production cost. Which of the two dominates picks the next step: settle-dominated → step 2 (loads), searchDoc-dominated → step 3 (fields).
+`settle_ms + search_doc_ms` ≈ the row's search-doc production cost. Which of the two dominates picks the next step: settle-dominated → step 2 (loads), searchDoc-dominated → step 3 (fields) — but check `searchDocLinkLoads` either way: a searchDoc-dominated row with matching load entries was loading inside the doc-producing walk (a first-walk-stable card's route loads land there), and step 2's load reading applies to it, not step 3's evaluation reading.
 
 **Step 2 — settle-dominated: which link loads were slow.**
 
@@ -1367,8 +1367,11 @@ LIMIT 20;
                                  // includeComputeds: true })` for this card.
   "searchDocMs": 18.3,           // host-side wall-clock of the walk that produced this
                                  // row's search doc — the first walk against a stable
-                                 // load generation, its loads all resident or cache
-                                 // hits, so this measures evaluation. Sum with
+                                 // load generation. Never waits on getter-fired loads
+                                 // (those mark a walk unstable), but can include
+                                 // targeted searchable-route loads it consumed inline,
+                                 // each itemized in `searchDocLinkLoads` — subtract
+                                 // those entries to read pure evaluation. Sum with
                                  // `serializeMs` to get the host's contribution to
                                  // `renderElapsedMs`. Pairs with `computedCalls` so you
                                  // can normalize: a card with `computedCalls=500,
@@ -1377,8 +1380,9 @@ LIMIT 20;
   "searchDocSettleMs": 812.4,    // host-side wall-clock spent BEFORE the doc-producing
                                  // walk: the discarded walk passes and the drains of
                                  // the lazy loads they fired. This is where the card's
-                                 // getter-driven link targets load, so link-load cost
-                                 // lives here, not inside `searchDocMs`. Attributed per
+                                 // getter-driven link targets load; targeted route
+                                 // loads land in whichever walk reaches them first,
+                                 // including the doc-producing one. Attributed per
                                  // target by `searchDocLinkLoads`. Near-zero when the
                                  // first walk settled.
   "searchDocSettlePasses": 3,    // walk passes discarded before one ran against a
@@ -1436,7 +1440,7 @@ All ms values are server-observed walltime.
 - `cardDocLoadsInFlight[*].ageMs` / `fileMetaDocLoadsInFlight[*].ageMs` mirror the query version for linked-field (card doc) / file-meta loads. One URL with a very large `ageMs` = one slow linksTo target; many URLs with small `ageMs` = fan-out.
 - `recentCardDocLoads[*].ms` / `recentFileMetaLoads[*].ms` are the completed-load histories; same usage as `recentQueryLoads`.
 - `computedCalls` + `computedCacheHits` together represent total compute pressure on the render.meta pass. The split tells you how much duplicate work the pass-scoped memo absorbed — a 1:0 ratio means every field was read once, a 1:5 ratio means the cards re-read each computed five extra times (typical for cards where many sibling fields share a computed input). `searchDocMs` + `serializeMs` are the host's contribution to `renderElapsedMs`; comparing `computedCalls / (searchDocMs + serializeMs)` across cards finds the slow-per-call computes that are worth profiling.
-- `searchDocSettleMs` is disjoint from `searchDocMs`: the discarded walk passes and their load drains come first; the doc-producing walk then runs against a settled store. So "producing this row's search doc" cost ≈ `searchDocSettleMs + searchDocMs`, and a slow row splits cleanly: settle-dominated → loading (read `searchDocLinkLoads` for which target), searchDoc-dominated → evaluation (read `searchDocFieldsMs` for which field). The retained `searchDocFieldsMs` entries are inclusive-time dotted paths — the top-level entries (no dot) sum to ≈ `searchDocMs` on a hot-path card; the deeper keys under a hot top-level key are the drill-down, not additional cost.
+- `searchDocSettleMs` is disjoint from `searchDocMs`: the discarded walk passes and their load drains come first; the doc-producing walk then runs. So "producing this row's search doc" cost ≈ `searchDocSettleMs + searchDocMs`, and a slow row splits: settle-dominated → getter-fired loading (read `searchDocLinkLoads` for which target), searchDoc-dominated → evaluation (read `searchDocFieldsMs` for which field) **or** targeted route loads the doc-producing walk consumed inline — a `searchDocLinkLoads` entry matching a hot field path settles which. The retained `searchDocFieldsMs` entries are inclusive-time dotted paths — the top-level entries (no dot) sum to ≈ `searchDocMs` on a hot-path card; the deeper keys under a hot top-level key are the drill-down, not additional cost.
 
 Keep the field names in lock-step with the type in `packages/runtime-common/index.ts`.
 

--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1053,12 +1053,12 @@ Lines are FireLens-wrapped (`{"log":"…"}`); pull `.log`. Strip everything afte
 
 ## Mode J — a search doc was slow to build (per-field / per-link attribution)
 
-The index visit's cost is dominated by search-doc assembly, and its diagnostics split that assembly into two disjoint phases, each with per-item detail:
+The index visit's cost is dominated by search-doc assembly. The host produces the doc by walking the card repeatedly until the store's load state is quiescent — the first walk that fires no lazy getter loads is the one whose doc persists — and the diagnostics split the cost along that seam, each side with per-item detail:
 
-1. **The settle loop** (`searchDocSettleMs`, `searchDocSettlePasses`) — the passes that drive the card's searchable-path link loads (and the links its contained/computed fields read) to quiescence. This is where link targets actually load; the per-target breakdown is `searchDocLinkLoads` (`{ path, target, ms }`, dotted `linksTo`/`linksToMany` field path + loaded URL).
-2. **The timed searchDoc walk** (`searchDocMs`) — evaluation of the card's fields against the now-settled store. The per-field breakdown is `searchDocFieldsMs`, keyed by dotted field path with **inclusive** times (a parent includes its children, so the keys read as a drill-down to the slow leaf).
+1. **The discarded walks and their load drains** (`searchDocSettleMs`, `searchDocSettlePasses`) — the passes re-run because a computed's read of a not-yet-loaded link fired a lazy load the walk couldn't consume. This is where getter-driven link targets load; `searchDocSettlePasses` counts the discarded walks, so a card that settles on its first walk reads `0`. The generator's own `searchable`-route loads are awaited inside whichever walk reaches them (a route's hops resolve within one pass), and every performed load lands in `searchDocLinkLoads` (`{ path, target, ms }`, dotted `linksTo`/`linksToMany` field path + loaded URL). A card's independent routes and plural-field slots load **concurrently**, so the entries overlap in time — read each `ms` as that load's own span, not as a summable slice.
+2. **The doc-producing walk** (`searchDocMs`) — the stable walk's evaluation of the card's fields, its loads all resident or cache hits. The per-field breakdown is `searchDocFieldsMs`, keyed by dotted field path with **inclusive** times (a parent includes its children, so the keys read as a drill-down to the slow leaf).
 
-Both detail blocks are bounded — the slowest 20 entries at ≥ 1 ms — so a typical ~1 ms search doc persists neither, and their absence on a slow row is itself a signal (see step 3).
+Both detail blocks are bounded — the slowest 20 entries at ≥ 1 ms — so a typical ~1 ms search doc persists neither, and their absence on a slow row is itself a signal (see step 3). Within one indexing job, loaded wire documents are cached job-scoped in the render tab, so a target shared by many cards costs a real load only on the first owner that reaches it — later owners' entries are near-zero and floor-pruned.
 
 **Step 1 — find the rows whose search-doc build dominates.**
 
@@ -1109,7 +1109,7 @@ ORDER BY worst_ms DESC
 LIMIT 20;
 ```
 
-Read the shape: one very slow entry = one slow target (a cross-realm link? a target whose own realm is slow? — Mode G if the load is a `_search`-backed path, the target realm's own logs otherwise); many moderate entries under one `path` = a wide `linksToMany` route fanning out (is that `searchable` depth actually needed?). An entry with an **empty `path`** is a load a field getter fired — a computed reading a link — so the fix target is the computed that reads that URL, not a `searchable` annotation. A high `passes` count with moderate per-load times means a deep chain — each pass unlocks one more hop, so depth costs serial round-trips even when each load is fine.
+Read the shape: one very slow entry = one slow target (a cross-realm link? a target whose own realm is slow? — Mode G if the load is a `_search`-backed path, the target realm's own logs otherwise); many moderate entries under one `path` = a wide `linksToMany` route fanning out — its slots load concurrently, so the wall cost is nearer the worst entry than the sum, but each load is still work for the serving realm (is that `searchable` depth actually needed?). An entry with an **empty `path`** is a load a field getter fired — a computed reading a link — so the fix target is the computed that reads that URL, not a `searchable` annotation. A high `passes` count means computed-over-link depth: each discarded walk is one wave of getter-fired loads a computed needed before it could produce a value (`searchable`-route hops resolve inside a single walk and don't add passes).
 
 **Step 3 — searchDoc-dominated: which fields were expensive to evaluate.**
 
@@ -1262,25 +1262,30 @@ A large `searchDocMs` with **no** `searchDocFieldsMs` entries means no single fi
                                  // contains-many / links-to field does this).
   "serializeMs": 42.1,           // host-side wall-clock of `serializeCard(instance, {
                                  // includeComputeds: true })` for this card.
-  "searchDocMs": 18.3,           // host-side wall-clock of `searchDoc(instance)` for
-                                 // this card. Sum with `serializeMs` to get the host's
-                                 // contribution to `renderElapsedMs`. Pairs with
-                                 // `computedCalls` so you can normalize: a card with
-                                 // `computedCalls=500, searchDocMs=80` is ~6 calls/ms
-                                 // — a sign of a hot compute that may be worth a
-                                 // dependency-aware skip.
-  "searchDocSettleMs": 812.4,    // host-side wall-clock of the searchable load-settle
-                                 // loop that runs BEFORE the timed searchDoc walk. This
-                                 // is where the card's searchable link targets actually
-                                 // load — by the time `searchDocMs` is measured they're
-                                 // resident — so link-load cost lives here, not inside
-                                 // `searchDocMs`. Attributed per target by
-                                 // `searchDocLinkLoads`.
-  "searchDocSettlePasses": 3,    // settle passes until the store's load generation held
-                                 // steady. Each pass loads one more dependency-depth
-                                 // wave (a deeper searchable hop, a computed's link), so
-                                 // a high count = a deep link/computed chain. Capped at
-                                 // 20 (a warning is logged at the cap).
+  "searchDocMs": 18.3,           // host-side wall-clock of the walk that produced this
+                                 // row's search doc — the first walk against a stable
+                                 // load generation, its loads all resident or cache
+                                 // hits, so this measures evaluation. Sum with
+                                 // `serializeMs` to get the host's contribution to
+                                 // `renderElapsedMs`. Pairs with `computedCalls` so you
+                                 // can normalize: a card with `computedCalls=500,
+                                 // searchDocMs=80` is ~6 calls/ms — a sign of a hot
+                                 // compute that may be worth a dependency-aware skip.
+  "searchDocSettleMs": 812.4,    // host-side wall-clock spent BEFORE the doc-producing
+                                 // walk: the discarded walk passes and the drains of
+                                 // the lazy loads they fired. This is where the card's
+                                 // getter-driven link targets load, so link-load cost
+                                 // lives here, not inside `searchDocMs`. Attributed per
+                                 // target by `searchDocLinkLoads`. Near-zero when the
+                                 // first walk settled.
+  "searchDocSettlePasses": 3,    // walk passes discarded before one ran against a
+                                 // stable load generation. Each discarded pass is one
+                                 // wave of loads a computed's link read fired (the
+                                 // generator's own searchable-route loads resolve
+                                 // inside a single pass), so a high count = a deep
+                                 // computed-over-link chain. 0 = the first walk
+                                 // settled. Capped at 20 (a warning is logged at the
+                                 // cap).
   "searchDocFieldsMs": {         // per-field inclusive evaluation timings from the timed
                                  // searchDoc walk, keyed by dotted field path from the
                                  // indexed card's root. A parent's time includes its
@@ -1293,18 +1298,21 @@ A large `searchDocMs` with **no** `searchDocFieldsMs` entries means no single fi
     "policies.premiumTotal": 13.8
   },
   "searchDocLinkLoads": [        // slowest link-target loads performed while producing
-                                 // this row's search doc (settle passes + any the timed
-                                 // walk still did). `path` = the dotted linksTo /
-                                 // linksToMany field path; `target` = the loaded URL (a
-                                 // linksToMany records one entry per slot, same path,
-                                 // different target). A load fired through a field
-                                 // getter — a computed reading a link — carries an
-                                 // empty path: the target and cost are attributed, the
-                                 // owning field isn't nameable there. Same bounding as
-                                 // `searchDocFieldsMs`. Separates "linked instance slow
-                                 // to load" (an entry here) from "field expensive to
-                                 // compute" (a hot `searchDocFieldsMs` path with no
-                                 // matching load entry).
+                                 // this row's search doc, across every walk pass.
+                                 // `path` = the dotted linksTo / linksToMany field
+                                 // path; `target` = the loaded URL (a linksToMany
+                                 // records one entry per slot, same path, different
+                                 // target). A load fired through a field getter — a
+                                 // computed reading a link — carries an empty path:
+                                 // the target and cost are attributed, the owning
+                                 // field isn't nameable there. A card's independent
+                                 // routes and plural slots load concurrently, so
+                                 // entries overlap in time and don't sum to wall-
+                                 // clock. Same bounding as `searchDocFieldsMs`.
+                                 // Separates "linked instance slow to load" (an entry
+                                 // here) from "field expensive to compute" (a hot
+                                 // `searchDocFieldsMs` path with no matching load
+                                 // entry).
     { "path": "author", "target": "https://realm.example/Author/1", "ms": 640.1 },
     { "path": "", "target": "https://realm.example/Publisher/2", "ms": 210.4 }
   ]
@@ -1325,7 +1333,7 @@ All ms values are server-observed walltime.
 - `cardDocLoadsInFlight[*].ageMs` / `fileMetaDocLoadsInFlight[*].ageMs` mirror the query version for linked-field (card doc) / file-meta loads. One URL with a very large `ageMs` = one slow linksTo target; many URLs with small `ageMs` = fan-out.
 - `recentCardDocLoads[*].ms` / `recentFileMetaLoads[*].ms` are the completed-load histories; same usage as `recentQueryLoads`.
 - `computedCalls` + `computedCacheHits` together represent total compute pressure on the render.meta pass. The split tells you how much duplicate work the pass-scoped memo absorbed — a 1:0 ratio means every field was read once, a 1:5 ratio means the cards re-read each computed five extra times (typical for cards where many sibling fields share a computed input). `searchDocMs` + `serializeMs` are the host's contribution to `renderElapsedMs`; comparing `computedCalls / (searchDocMs + serializeMs)` across cards finds the slow-per-call computes that are worth profiling.
-- `searchDocSettleMs` is disjoint from `searchDocMs`: the settle loop runs first and performs the link loads; the timed searchDoc walk then runs against a settled store. So "producing this row's search doc" cost ≈ `searchDocSettleMs + searchDocMs`, and a slow row splits cleanly: settle-dominated → loading (read `searchDocLinkLoads` for which target), searchDoc-dominated → evaluation (read `searchDocFieldsMs` for which field). The retained `searchDocFieldsMs` entries are inclusive-time dotted paths — the top-level entries (no dot) sum to ≈ `searchDocMs` on a hot-path card; the deeper keys under a hot top-level key are the drill-down, not additional cost.
+- `searchDocSettleMs` is disjoint from `searchDocMs`: the discarded walk passes and their load drains come first; the doc-producing walk then runs against a settled store. So "producing this row's search doc" cost ≈ `searchDocSettleMs + searchDocMs`, and a slow row splits cleanly: settle-dominated → loading (read `searchDocLinkLoads` for which target), searchDoc-dominated → evaluation (read `searchDocFieldsMs` for which field). The retained `searchDocFieldsMs` entries are inclusive-time dotted paths — the top-level entries (no dot) sum to ≈ `searchDocMs` on a hot-path card; the deeper keys under a hot top-level key are the drill-down, not additional cost.
 
 Keep the field names in lock-step with the type in `packages/runtime-common/index.ts`.
 
@@ -1349,7 +1357,7 @@ Walk the fields top-down. The _first_ positive signal wins; stop there.
 | `currentlyEvaluatingModule` non-null, or `stageAgeMs` large with empty in-flight arrays                                                                                                                                                               | **Synchronous browser stall (typically Glimmer compile during module eval)** | `recentModuleEvaluations` shows the worst offenders. A single URL with `ms > 5000` usually means "this module has a giant template that takes forever to compile". Many small entries (say 50+ at 100–500 ms each) summing into the stall budget mean card fan-out where each dependent card contributes a compile. Split the module, lazy-load the template, or reduce the component fan-out.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `blockedTimerSummary` populated                                                                                                                                                                                                                       | **Supplementary**                                                            | Tells you which timer-driven code is fighting the render. Not a root cause on its own.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `computedCalls` large (e.g. > 1000) AND `searchDocMs + serializeMs` ≈ `renderElapsedMs`                                                                                                                                                               | **Computed-field hot path**                                                  | The render.meta traversal itself is the bottleneck, not data loads or browser stalls. Look at `computedCalls / (searchDocMs + serializeMs)` — > ~5 calls/ms is fast, < ~1 call/ms means a few slow `computeVia` functions dominate. `searchDocFieldsMs` names the field: its dotted-path keys rank the walk's hot paths, so instead of inspecting the card class blind you start at the top entry (see [Mode J](#mode-j--a-search-doc-was-slow-to-build-per-field--per-link-attribution)). Consider hoisting an aggregate computed's scan into a shared rollup or adding `computeDeps` so the field can be skipped when its inputs don't change. The pass-scoped memo already eliminates duplicate reads in one traversal (visible in `computedCacheHits`); further wins require structural changes to the card.                                                                                                                                                                                                                                                                                                                                        |
-| `searchDocSettleMs` large (≫ `searchDocMs`)                                                                                                                                                                                                           | **Search-doc link-load stall**                                               | The index visit spent its time loading the card's searchable link targets, not evaluating fields. `searchDocLinkLoads` names the slow target(s) per dotted field path — one very slow entry is one slow linksTo target (is its realm slow? cross-realm?); many moderate entries are a fan-out (a wide `linksToMany` route — consider whether the `searchable` annotation needs that depth). A high `searchDocSettlePasses` alongside means a deep chain: each pass unlocks one more hop. See [Mode J](#mode-j--a-search-doc-was-slow-to-build-per-field--per-link-attribution).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `searchDocSettleMs` large (≫ `searchDocMs`)                                                                                                                                                                                                           | **Search-doc link-load stall**                                               | The index visit spent its time loading the card's link targets, not evaluating fields. `searchDocLinkLoads` names the slow target(s) per dotted field path — one very slow entry is one slow linksTo target (is its realm slow? cross-realm?); many moderate entries are a fan-out (a wide `linksToMany` route — its slots load concurrently, so wall cost tracks the worst entry, but each load is still work for the serving realm). A high `searchDocSettlePasses` alongside means a deep computed-over-link chain: each discarded walk is one wave of getter-fired loads. See [Mode J](#mode-j--a-search-doc-was-slow-to-build-per-field--per-link-attribution).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 ### Special cases
 

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -515,13 +515,27 @@ export interface CardStore {
   setCardNonTracked(id: string, instance: CardDef): void;
   setFileMetaNonTracked(id: string, instance: FileDef): void;
   makeTracked(id: string): void;
+  // `untracked` opts out of the store's load-generation tracking: safe only
+  // for a caller that awaits this promise inline and folds the resolved
+  // document into its own output, so the load-settle machinery (which exists
+  // to catch loads fired and abandoned by field getters) has nothing to wait
+  // for. The searchable generator's targeted link loads use this — it lets a
+  // walk whose targets all resolve immediately read as settled without a
+  // confirmation pass. Stores that don't implement the option simply keep
+  // tracking, which costs an extra settle pass and nothing else.
   loadCardDocument(
     url: string,
-    opts?: { dependencyTrackingContext?: RuntimeDependencyTrackingContext },
+    opts?: {
+      dependencyTrackingContext?: RuntimeDependencyTrackingContext;
+      untracked?: true;
+    },
   ): Promise<SingleCardDocument | CardError>;
   loadFileMetaDocument(
     url: string,
-    opts?: { dependencyTrackingContext?: RuntimeDependencyTrackingContext },
+    opts?: {
+      dependencyTrackingContext?: RuntimeDependencyTrackingContext;
+      untracked?: true;
+    },
   ): Promise<SingleFileMetaDocument | CardError>;
   trackLoad(load: Promise<unknown>): void;
   loaded(): Promise<void>;

--- a/packages/base/searchable.ts
+++ b/packages/base/searchable.ts
@@ -49,6 +49,12 @@ import {
 // links, and `linksToMany` id normalization match `BaseDef[queryableValue]`. The
 // declared field type is enumerated for both links and contained values (not the
 // runtime subtype), which drops non-queryable polymorphic-subtype bloat.
+//
+// Independent branches of the walk — a card's fields, a plural field's
+// slots — run concurrently, so their link loads overlap; a route's own
+// segments stay sequential (each hop needs the previous target). The doc is
+// assembled in declaration/slot order regardless of load completion order,
+// so concurrency never changes the output.
 export async function searchDocFromFields(
   instance: CardDef,
   // Collects the URLs of the link targets pulled into the doc. The indexer
@@ -101,6 +107,31 @@ type SearchableTargetResult =
   | { status: 'loaded'; card: CardDef }
   | { status: 'broken'; sentinel: LinkErrorValue | LinkNotFoundValue };
 
+// Run independent async branches concurrently, preserving declaration order
+// in the returned values. Concurrency is what lets a single walk fire every
+// link load the current store state permits: a card's independent
+// `searchable` routes — and a plural field's slots — load together instead
+// of one after another, while a single route's own segments stay sequential
+// inside their branch (each hop's load needs the previous hop's target).
+// Every branch runs to completion before the first rejection (in declaration
+// order) is rethrown, so a throwing branch — typically a computed reading a
+// link target whose load is still in flight — doesn't stop sibling branches
+// from starting THEIR loads, and no branch rejection is left floating to
+// surface as an unhandled rejection (which the prerender tab treats as
+// fatal).
+async function settleBranches<T>(
+  branches: Array<() => Promise<T>>,
+): Promise<T[]> {
+  let settled = await Promise.allSettled(branches.map((branch) => branch()));
+  let rejection = settled.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  );
+  if (rejection) {
+    throw rejection.reason;
+  }
+  return (settled as PromiseFulfilledResult<T>[]).map(({ value }) => value);
+}
+
 // Build the terminal sentinel a broken link resolves to, mirroring the shape
 // `lazilyLoadLink` plants: HTTP 404 → `link-not-found`, anything else →
 // `link-error`. `reference` is the resolved (absolute) target url.
@@ -133,6 +164,13 @@ function brokenLinkSentinel(
 // set instead. A missing / broken target resolves to a terminal sentinel; the
 // store may surface that either as a returned `CardError` or a thrown rejection
 // (e.g. a 404 / invalid-URL on the load path), so both are captured.
+//
+// The document load is `untracked`: this function awaits it and the walk
+// folds the target straight into the doc it returns, so the store's
+// load-generation settle machinery — which exists for loads fired and
+// abandoned by field getters — has nothing to observe. Untracked, a walk
+// whose targets are all resident or cache-served reads as settled without a
+// confirmation pass.
 async function loadSearchableTarget(
   store: CardStore,
   reference: string,
@@ -142,7 +180,7 @@ async function loadSearchableTarget(
     return { status: 'loaded', card: resident };
   }
   try {
-    let cardDoc = await store.loadCardDocument(reference);
+    let cardDoc = await store.loadCardDocument(reference, { untracked: true });
     if (isCardError(cardDoc)) {
       return {
         status: 'broken',
@@ -208,7 +246,13 @@ async function searchableQueryableValue(
   let makeAbsoluteURL = (reference: string) =>
     value[relativeTo] ? resolveRef(reference, value[relativeTo]) : reference;
   let nextStack = [value, ...stack];
-  let entries: [string, any][] = [];
+  // Each field is an independent branch; `settleBranches` runs them
+  // concurrently so one field's link load overlaps its siblings'. The cycle
+  // guard is concurrency-safe (`nextStack` is an immutable per-level
+  // snapshot shared read-only by every branch), sentinel plants touch
+  // disjoint field slots, and `dependencies` is a Set whose insertion set is
+  // order-independent.
+  let branches: Array<() => Promise<[string, any] | undefined>> = [];
   for (let [fieldName, field] of Object.entries(
     getFields(fieldCard, { includeComputeds: true }),
   )) {
@@ -230,21 +274,23 @@ async function searchableQueryableValue(
       (field!.fieldType === 'linksTo' || field!.fieldType === 'linksToMany') &&
       !field!.computeVia;
     let fieldPath = path === '' ? fieldName : `${path}.${fieldName}`;
-    // Inclusive per-field timing: starts before the field read — a
-    // computed's computeVia runs inside peekAtField — and covers the nested
-    // recursion and link loads below, so a slow leaf surfaces together with
-    // every ancestor on its path. Guarded on the collector so an
-    // uninstrumented walk pays no timer calls.
-    let fieldStart = timings?.fieldsMs ? performance.now() : 0;
-    let rawValue =
-      isDeclaredLink && !getDataBucket(value).has(fieldName)
-        ? null
-        : peekAtField(value, fieldName);
-    switch (field!.fieldType) {
-      case 'contains': {
-        entries.push([
-          fieldName,
-          await searchableQueryableValue(
+    branches.push(async () => {
+      // Inclusive per-field timing: starts before the field read — a
+      // computed's computeVia runs inside peekAtField — and covers the nested
+      // recursion and link loads below, so a slow leaf surfaces together with
+      // every ancestor on its path. Guarded on the collector so an
+      // uninstrumented walk pays no timer calls. Sibling branches run
+      // concurrently, so a field's span can overlap its siblings' — read the
+      // values as per-field wall-clock, not as summable slices.
+      let fieldStart = timings?.fieldsMs ? performance.now() : 0;
+      let rawValue =
+        isDeclaredLink && !getDataBucket(value).has(fieldName)
+          ? null
+          : peekAtField(value, fieldName);
+      let entryValue: any;
+      switch (field!.fieldType) {
+        case 'contains': {
+          entryValue = await searchableQueryableValue(
             field!.card,
             rawValue,
             tails,
@@ -253,44 +299,41 @@ async function searchableQueryableValue(
             dependencies,
             fieldPath,
             timings,
-          ),
-        ]);
-        break;
-      }
-      case 'containsMany': {
-        // A whole-field sentinel (e.g. a computed containsMany that consumes
-        // an unresolved link) is not iterable; treat as null, the same as the
-        // linksToMany branch below.
-        if (rawValue == null || isNonPresentLink(rawValue)) {
-          entries.push([fieldName, null]);
+          );
           break;
         }
-        let items: any[] = [];
-        for (let item of rawArrayValues(rawValue)) {
-          if (item == null) {
-            continue;
+        case 'containsMany': {
+          // A whole-field sentinel (e.g. a computed containsMany that consumes
+          // an unresolved link) is not iterable; treat as null, the same as the
+          // linksToMany branch below.
+          if (rawValue == null || isNonPresentLink(rawValue)) {
+            entryValue = null;
+            break;
           }
-          let v = await searchableQueryableValue(
-            field!.card,
-            item,
-            tails,
-            nextStack,
-            store,
-            dependencies,
-            fieldPath,
-            timings,
-          );
-          if (v != null) {
-            items.push(v);
-          }
+          let items = (
+            await settleBranches(
+              rawArrayValues(rawValue)
+                .filter((item) => item != null)
+                .map(
+                  (item) => () =>
+                    searchableQueryableValue(
+                      field!.card,
+                      item,
+                      tails,
+                      nextStack,
+                      store,
+                      dependencies,
+                      fieldPath,
+                      timings,
+                    ),
+                ),
+            )
+          ).filter((v) => v != null);
+          entryValue = items.length === 0 ? null : items;
+          break;
         }
-        entries.push([fieldName, items.length === 0 ? null : items]);
-        break;
-      }
-      case 'linksTo': {
-        entries.push([
-          fieldName,
-          await searchableLink(
+        case 'linksTo': {
+          entryValue = await searchableLink(
             value,
             field!,
             rawValue,
@@ -302,14 +345,11 @@ async function searchableQueryableValue(
             dependencies,
             fieldPath,
             timings,
-          ),
-        ]);
-        break;
-      }
-      case 'linksToMany': {
-        entries.push([
-          fieldName,
-          await searchableLinksToMany(
+          );
+          break;
+        }
+        case 'linksToMany': {
+          entryValue = await searchableLinksToMany(
             field!,
             rawValue,
             matched,
@@ -320,18 +360,25 @@ async function searchableQueryableValue(
             dependencies,
             fieldPath,
             timings,
-          ),
-        ]);
-        break;
+          );
+          break;
+        }
+        default: {
+          return undefined;
+        }
       }
-    }
-    if (timings?.fieldsMs) {
-      // Accumulate rather than assign: a plural field's items (and a card
-      // re-entered on another branch) all land under one path key.
-      timings.fieldsMs[fieldPath] =
-        (timings.fieldsMs[fieldPath] ?? 0) + (performance.now() - fieldStart);
-    }
+      if (timings?.fieldsMs) {
+        // Accumulate rather than assign: a plural field's items (and a card
+        // re-entered on another branch) all land under one path key.
+        timings.fieldsMs[fieldPath] =
+          (timings.fieldsMs[fieldPath] ?? 0) + (performance.now() - fieldStart);
+      }
+      return [fieldName, entryValue];
+    });
   }
+  let entries = (await settleBranches(branches)).filter(
+    (entry): entry is [string, any] => entry !== undefined,
+  );
   return Object.fromEntries(entries);
 }
 
@@ -442,75 +489,77 @@ async function searchableLinksToMany(
   if (rawValue == null || isNonPresentLink(rawValue)) {
     return null;
   }
-  let out: any[] = [];
+  // Slots are independent branches: each slot's target load overlaps its
+  // siblings' (see `settleBranches`), and the output preserves slot order.
   let backing = rawArrayValues(rawValue);
-  for (let [index, item] of backing.entries()) {
-    if (item == null) {
-      continue;
-    }
-    if (isLinkError(item) || isLinkNotFound(item)) {
-      let reference = makeAbsoluteURL(item.reference);
-      // A broken searchable element stays a dependency — see `searchableLink`.
-      if (matched) {
-        dependencies.add(reference);
-      }
-      out.push({ id: reference });
-      continue;
-    }
-    if (!matched) {
-      out.push({
-        id: makeAbsoluteURL(
-          isNotLoadedValue(item) ? item.reference : (item as CardDef).id,
-        ),
-      });
-      continue;
-    }
-    let target = item as CardDef;
-    if (isNotLoadedValue(item)) {
-      // Resolve a relative reference before the load — see `searchableLink`.
-      let resolvedRef = makeAbsoluteURL(item.reference);
-      let loadStart = timings?.linkLoads ? performance.now() : 0;
-      let result = await loadSearchableTarget(store, resolvedRef);
-      timings?.linkLoads?.push({
-        path,
-        target: resolvedRef,
-        ms: performance.now() - loadStart,
-      });
-      if (result.status === 'broken') {
-        // Plant the sentinel into the failed slot so `getBrokenLinks` records
-        // this broken searchable element (see `searchableLink`). Assign through
-        // the proxy so the mutation reaches the data bucket the diagnostic
-        // reads.
-        rawValue[index] = result.sentinel;
-        // A broken searchable element stays a dependency — see `searchableLink`.
-        dependencies.add(resolvedRef);
-        out.push({ id: resolvedRef });
-        continue;
-      }
-      target = result.card;
-    }
-    // The expanded target's data is now in the doc, so it is a dependency of
-    // the indexed card.
-    if (target.id != null) {
-      dependencies.add(makeAbsoluteURL(target.id));
-    }
-    let expanded = await searchableQueryableValue(
-      field.card,
-      target,
-      tails,
-      stack,
-      store,
-      dependencies,
-      path,
-      timings,
-    );
-    if (expanded != null) {
-      out.push(
-        expanded.id != null
+  let out = (
+    await settleBranches(
+      backing.map((item, index) => async () => {
+        if (item == null) {
+          return undefined;
+        }
+        if (isLinkError(item) || isLinkNotFound(item)) {
+          let reference = makeAbsoluteURL(item.reference);
+          // A broken searchable element stays a dependency — see `searchableLink`.
+          if (matched) {
+            dependencies.add(reference);
+          }
+          return { id: reference };
+        }
+        if (!matched) {
+          return {
+            id: makeAbsoluteURL(
+              isNotLoadedValue(item) ? item.reference : (item as CardDef).id,
+            ),
+          };
+        }
+        let target = item as CardDef;
+        if (isNotLoadedValue(item)) {
+          // Resolve a relative reference before the load — see `searchableLink`.
+          let resolvedRef = makeAbsoluteURL(item.reference);
+          let loadStart = timings?.linkLoads ? performance.now() : 0;
+          let result = await loadSearchableTarget(store, resolvedRef);
+          timings?.linkLoads?.push({
+            path,
+            target: resolvedRef,
+            ms: performance.now() - loadStart,
+          });
+          if (result.status === 'broken') {
+            // Plant the sentinel into the failed slot so `getBrokenLinks`
+            // records this broken searchable element (see `searchableLink`).
+            // Assign through the proxy so the mutation reaches the data bucket
+            // the diagnostic reads. Slot branches run concurrently but each
+            // writes only its own index, so plants never collide.
+            rawValue[index] = result.sentinel;
+            // A broken searchable element stays a dependency — see `searchableLink`.
+            dependencies.add(resolvedRef);
+            return { id: resolvedRef };
+          }
+          target = result.card;
+        }
+        // The expanded target's data is now in the doc, so it is a dependency
+        // of the indexed card.
+        if (target.id != null) {
+          dependencies.add(makeAbsoluteURL(target.id));
+        }
+        let expanded = await searchableQueryableValue(
+          field.card,
+          target,
+          tails,
+          stack,
+          store,
+          dependencies,
+          path,
+          timings,
+        );
+        if (expanded == null) {
+          return undefined;
+        }
+        return expanded.id != null
           ? { ...expanded, id: makeAbsoluteURL(expanded.id) }
-          : expanded,
-      );
-    }
-  }
+          : expanded;
+      }),
+    )
+  ).filter((slot) => slot !== undefined);
   return out.length === 0 ? null : out;
 }

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -194,19 +194,34 @@ export default class CardStoreWithGarbageCollection implements CardStore {
   // ── Job-scoped wire-document cache ─────────────────────────────────────
   // Successful card-source / file-meta documents fetched during an indexing
   // render, keyed by URL and scoped to the indexing job identity
-  // (`__boxelJobId`). Within one job the realm's source files are stable —
-  // a write that lands mid-job is picked up by the follow-up job its
-  // invalidation enqueues, the same one-consolidated-view-per-job contract
-  // the realm-server's job-scoped search cache serves — so a shared link
-  // target (one Policy referenced by hundreds of Claims) fetches once per
-  // job instead of once per referencing card. The identity map already
-  // short-circuits most repeat loads while a target instance stays
-  // resident; this cache covers the window after the GC sweep evicts an
-  // unreferenced target, turning its re-load into a local deserialize
-  // instead of a network round-trip. The wire-level sibling of the store
-  // service's resolved-doc search cache: gated to prerender + job id,
-  // cleared the first time a different job id is observed, never consulted
-  // by the live app.
+  // (`__boxelJobId`), so a shared link target (one Policy referenced by
+  // hundreds of Claims) fetches once per job instead of once per
+  // referencing card. The identity map already short-circuits most repeat
+  // loads while a target instance stays resident; this cache covers the
+  // window after the GC sweep evicts an unreferenced target, turning its
+  // re-load into a local deserialize instead of a network round-trip.
+  //
+  // Staleness contract — one consistent view of every target per job. For
+  // the indexed realm's own files this is exact: the job serializes with
+  // that realm's writes, and a mid-job write is picked up by the follow-up
+  // job its invalidation enqueues. A cross-realm target CAN change mid-job,
+  // and the cache pins the version first observed — deliberately, matching
+  // the job-scoped instance reuse in the link getter's lazy-load path,
+  // which pins any target the moment its instance enters the store. The
+  // delta this cache adds is bounded to the job: only a post-GC-eviction
+  // re-load could have observed a newer cross-realm version mid-job, and
+  // one pinned version beats mixing pre- and post-write versions across a
+  // single job's rows. Across jobs nothing changes: entries die with the
+  // job, and cross-realm freshness between jobs is governed by what
+  // re-indexes the consumer (dep-driven invalidation fans out within a
+  // realm; a consumer of a peer realm's card is refreshed by its own
+  // realm's next index of it). This is a looser gate than the resolved-doc
+  // search cache's same-realm-only rule because the pinned unit is
+  // narrower: a document fetched by URL, not a query result whose
+  // membership can silently change under a peer realm's swap.
+  //
+  // Gated to prerender + job id, cleared the first time a different job id
+  // is observed, never consulted by the live app.
   #jobScopedDocCache = new Map<
     string,
     SingleCardDocument | SingleFileMetaDocument
@@ -223,8 +238,9 @@ export default class CardStoreWithGarbageCollection implements CardStore {
   // per from-scratch job, so this holds several such working sets; beyond
   // it, least-recently-used entries fall out first (Map iteration order is
   // insertion order and hits re-insert), which preserves the hot shared
-  // targets that make the cache worthwhile.
-  static #MAX_JOB_SCOPED_DOC_CACHE_ENTRIES = 2048;
+  // targets that make the cache worthwhile. Public so the eviction test can
+  // size its fill against the real cap.
+  static MAX_JOB_SCOPED_DOC_CACHE_ENTRIES = 2048;
 
   // Resolve the cache slot for a document load: undefined outside an
   // indexing render (no `__boxelRenderContext`/`__boxelJobId`), so the live
@@ -277,7 +293,7 @@ export default class CardStoreWithGarbageCollection implements CardStore {
     this.#jobScopedDocCache.set(key, structuredClone(doc));
     if (
       this.#jobScopedDocCache.size >
-      CardStoreWithGarbageCollection.#MAX_JOB_SCOPED_DOC_CACHE_ENTRIES
+      CardStoreWithGarbageCollection.MAX_JOB_SCOPED_DOC_CACHE_ENTRIES
     ) {
       let oldest = this.#jobScopedDocCache.keys().next().value;
       if (oldest !== undefined) {

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -4,6 +4,7 @@ import { TrackedMap } from 'tracked-built-ins';
 
 import {
   isPrimitive,
+  isCardError,
   isCardInstance,
   isFileDefInstance,
   isBaseInstance,
@@ -190,6 +191,101 @@ export default class CardStoreWithGarbageCollection implements CardStore {
   #recentFileMetaLoads: Array<{ url: string; ms: number }> = [];
   static #MAX_DIAGNOSTIC_HISTORY = 20;
 
+  // ── Job-scoped wire-document cache ─────────────────────────────────────
+  // Successful card-source / file-meta documents fetched during an indexing
+  // render, keyed by URL and scoped to the indexing job identity
+  // (`__boxelJobId`). Within one job the realm's source files are stable —
+  // a write that lands mid-job is picked up by the follow-up job its
+  // invalidation enqueues, the same one-consolidated-view-per-job contract
+  // the realm-server's job-scoped search cache serves — so a shared link
+  // target (one Policy referenced by hundreds of Claims) fetches once per
+  // job instead of once per referencing card. The identity map already
+  // short-circuits most repeat loads while a target instance stays
+  // resident; this cache covers the window after the GC sweep evicts an
+  // unreferenced target, turning its re-load into a local deserialize
+  // instead of a network round-trip. The wire-level sibling of the store
+  // service's resolved-doc search cache: gated to prerender + job id,
+  // cleared the first time a different job id is observed, never consulted
+  // by the live app.
+  #jobScopedDocCache = new Map<
+    string,
+    SingleCardDocument | SingleFileMetaDocument
+  >();
+  #jobScopedDocCacheJobId: string | undefined;
+  // Bumped on every clear (the jobId-change clear and `reset()`). A load
+  // captures this alongside its cache key and skips its populate when the
+  // generation moved while the fetch was in flight — a document fetched
+  // under one job must not seed the next job's cache, whose realm sources
+  // may differ.
+  #jobScopedDocCacheGeneration = 0;
+  // Entry cap keeps a tab's memory flat on very large realms. The benchmark
+  // insurance realm (885 instances) shows ~255 distinct shared link targets
+  // per from-scratch job, so this holds several such working sets; beyond
+  // it, least-recently-used entries fall out first (Map iteration order is
+  // insertion order and hits re-insert), which preserves the hot shared
+  // targets that make the cache worthwhile.
+  static #MAX_JOB_SCOPED_DOC_CACHE_ENTRIES = 2048;
+
+  // Resolve the cache slot for a document load: undefined outside an
+  // indexing render (no `__boxelRenderContext`/`__boxelJobId`), so the live
+  // app and job-less renders never read or write the cache. Observing a
+  // different job id than the held one drops the previous job's entries —
+  // the entry-time clear that covers a prerender tab reused across jobs
+  // without any harder reset in between. The kind prefix keeps a card URL
+  // and a file-meta URL with the same string from sharing a slot.
+  #jobScopedDocCacheKey(
+    kind: 'card' | 'file',
+    url: string,
+  ): string | undefined {
+    let g = globalThis as unknown as {
+      __boxelRenderContext?: boolean;
+      __boxelJobId?: string;
+    };
+    if (g.__boxelRenderContext !== true || typeof g.__boxelJobId !== 'string') {
+      return undefined;
+    }
+    if (g.__boxelJobId !== this.#jobScopedDocCacheJobId) {
+      this.#jobScopedDocCache.clear();
+      this.#jobScopedDocCacheJobId = g.__boxelJobId;
+      this.#jobScopedDocCacheGeneration++;
+    }
+    return `${kind}:${url}`;
+  }
+
+  #readJobScopedDoc(
+    key: string,
+  ): SingleCardDocument | SingleFileMetaDocument | undefined {
+    let doc = this.#jobScopedDocCache.get(key);
+    if (doc === undefined) {
+      return undefined;
+    }
+    // LRU touch — re-insertion moves the entry behind the eviction horizon.
+    this.#jobScopedDocCache.delete(key);
+    this.#jobScopedDocCache.set(key, doc);
+    // Hand out a copy: consumers deserialize from (and may normalize) the
+    // returned document, and a shared mutable doc would leak one consumer's
+    // mutation into the next hit.
+    return structuredClone(doc);
+  }
+
+  #writeJobScopedDoc(
+    key: string,
+    doc: SingleCardDocument | SingleFileMetaDocument,
+  ): void {
+    // Store a private copy for the same mutation-isolation reason reads
+    // clone: the object returned to the fetching caller stays theirs.
+    this.#jobScopedDocCache.set(key, structuredClone(doc));
+    if (
+      this.#jobScopedDocCache.size >
+      CardStoreWithGarbageCollection.#MAX_JOB_SCOPED_DOC_CACHE_ENTRIES
+    ) {
+      let oldest = this.#jobScopedDocCache.keys().next().value;
+      if (oldest !== undefined) {
+        this.#jobScopedDocCache.delete(oldest);
+      }
+    }
+  }
+
   #storeHooks: StoreHooks | undefined;
 
   constructor(
@@ -242,20 +338,51 @@ export default class CardStoreWithGarbageCollection implements CardStore {
 
   async loadCardDocument(
     url: string,
-    opts?: { dependencyTrackingContext?: RuntimeDependencyTrackingContext },
+    opts?: {
+      dependencyTrackingContext?: RuntimeDependencyTrackingContext;
+      untracked?: true;
+    },
   ) {
+    // Dependency tracking runs on every call — a cache hit is still a
+    // consumption of the target, and invalidation must record the edge.
     trackRuntimeInstanceDependency(url, opts?.dependencyTrackingContext);
+    let cacheKey = this.#jobScopedDocCacheKey('card', url);
+    let cacheGeneration = this.#jobScopedDocCacheGeneration;
+    if (cacheKey !== undefined) {
+      let cached = this.#readJobScopedDoc(cacheKey);
+      if (cached !== undefined) {
+        return cached as SingleCardDocument;
+      }
+    }
     let promise = this.#cardDocsInFlight.get(url);
     if (promise) {
-      this.trackLoad(promise);
+      if (!opts?.untracked) {
+        this.trackLoad(promise);
+      }
       return await promise;
     }
     promise = loadCardDocument(this.#fetch, url, this.#virtualNetwork);
     this.#cardDocsInFlight.set(url, promise);
     this.#cardDocStartedAt.set(url, Date.now());
-    this.trackLoad(promise);
+    if (!opts?.untracked) {
+      this.trackLoad(promise);
+    }
     try {
-      return await promise;
+      let doc = await promise;
+      // Cache successful documents only: an error result may be transient
+      // (an auth hiccup, a fetch failure), and the broken-link degradation
+      // path stays live rather than pinned for the job. The generation check
+      // skips the populate when the cache was cleared while this fetch was
+      // in flight — the resolved document belongs to the job that started
+      // the load, not the one now holding the cache.
+      if (
+        cacheKey !== undefined &&
+        this.#jobScopedDocCacheGeneration === cacheGeneration &&
+        !isCardError(doc)
+      ) {
+        this.#writeJobScopedDoc(cacheKey, doc);
+      }
+      return doc;
     } finally {
       let startedAt = this.#cardDocStartedAt.get(url);
       this.#cardDocsInFlight.delete(url);
@@ -271,20 +398,46 @@ export default class CardStoreWithGarbageCollection implements CardStore {
 
   async loadFileMetaDocument(
     url: string,
-    opts?: { dependencyTrackingContext?: RuntimeDependencyTrackingContext },
+    opts?: {
+      dependencyTrackingContext?: RuntimeDependencyTrackingContext;
+      untracked?: true;
+    },
   ): Promise<SingleFileMetaDocument | CardError> {
+    // Same shape as `loadCardDocument` above: dependency tracking on every
+    // call, job-scoped cache consulted before the in-flight map, successes
+    // cached, `untracked` skips the load-generation registration.
     trackRuntimeFileDependency(url, opts?.dependencyTrackingContext);
+    let cacheKey = this.#jobScopedDocCacheKey('file', url);
+    let cacheGeneration = this.#jobScopedDocCacheGeneration;
+    if (cacheKey !== undefined) {
+      let cached = this.#readJobScopedDoc(cacheKey);
+      if (cached !== undefined) {
+        return cached as SingleFileMetaDocument;
+      }
+    }
     let promise = this.#fileMetaDocsInFlight.get(url);
     if (promise) {
-      this.trackLoad(promise);
+      if (!opts?.untracked) {
+        this.trackLoad(promise);
+      }
       return await promise;
     }
     promise = loadFileMetaDocument(this.#fetch, url, this.#virtualNetwork);
     this.#fileMetaDocsInFlight.set(url, promise);
     this.#fileMetaStartedAt.set(url, Date.now());
-    this.trackLoad(promise);
+    if (!opts?.untracked) {
+      this.trackLoad(promise);
+    }
     try {
-      return await promise;
+      let doc = await promise;
+      if (
+        cacheKey !== undefined &&
+        this.#jobScopedDocCacheGeneration === cacheGeneration &&
+        !isCardError(doc)
+      ) {
+        this.#writeJobScopedDoc(cacheKey, doc);
+      }
+      return doc;
     } finally {
       let startedAt = this.#fileMetaStartedAt.get(url);
       this.#fileMetaDocsInFlight.delete(url);
@@ -586,6 +739,14 @@ export default class CardStoreWithGarbageCollection implements CardStore {
     this.#recentQueryLoads.length = 0;
     this.#recentCardDocLoads.length = 0;
     this.#recentFileMetaLoads.length = 0;
+    // The job-scoped doc cache holds wire documents, which module changes
+    // don't invalidate — but a store reset is a hard identity boundary, and
+    // holding entries across one risks serving a document whose realm state
+    // the resetter deliberately discarded. The generation bump makes any
+    // in-flight load skip its populate on resolve.
+    this.#jobScopedDocCache.clear();
+    this.#jobScopedDocCacheJobId = undefined;
+    this.#jobScopedDocCacheGeneration++;
     this.#idResolver.reset();
   }
 

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -389,13 +389,18 @@ export default class RenderMetaRoute extends Route<Model> {
   // rethrows to the caller (the render error path). Timings recorded before
   // a mid-walk throw survive — the collector fills incrementally.
   //
-  // `searchDocMs` is the authoritative walk's own duration (its loads are
-  // resident/cache hits, so it measures evaluation); `settleMs` is
-  // everything before and around it — the discarded walks and the load
-  // drains; `settlePasses` counts the discarded walks (0 when the first
-  // walk settles). A graph that never stabilizes within the discarded-walk
-  // cap gets one forced final walk against the drained store; its output is
-  // used (or its throw propagated) with a warning.
+  // `searchDocMs` is the authoritative walk's own duration. It never waits
+  // on getter-fired loads (those mark a walk unstable), but it can include
+  // targeted `searchable`-route loads the walk consumed inline — untracked
+  // loads leave the generation unmoved, so the first walk to reach a target
+  // both loads it and can still read as stable. Each such load lands in the
+  // `linkLoads` collector, so per-load cost stays attributable inside the
+  // total. `settleMs` is everything before and around the authoritative
+  // walk — the discarded walks and their load drains; `settlePasses` counts
+  // the discarded walks (0 when the first walk settles). A graph that never
+  // stabilizes within the discarded-walk cap gets one forced final walk
+  // against the drained store; its output is used (or its throw propagated)
+  // with a warning.
   async #searchDocUntilSettled(
     instance: CardDef,
     searchable: Awaited<ReturnType<CardService['getSearchable']>>,

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -40,14 +40,16 @@ export type Model = PrerenderMeta | RenderError | undefined;
 
 const computePerfLog = logger('host:computed-perf');
 
-// Pass cap for the walk-until-stable loop below (matches the
-// READY_SETTLE_MAX_PASSES cap of the /render route's template settle), so a
-// pathological graph can't loop forever. Unlike a template render — whose
-// afterRender hooks can schedule further work that only a repeated
+// Cap on DISCARDED walk passes in the walk-until-stable loop below (matches
+// the READY_SETTLE_MAX_PASSES cap of the /render route's template settle),
+// so a pathological graph can't loop forever. Unlike a template render —
+// whose afterRender hooks can schedule further work that only a repeated
 // render-and-wait can flush — a searchable walk is a pure function of the
 // store's settled load state, so a single pass that fired no tracked loads
 // is already authoritative: re-running it against the same state would
-// produce the same doc. One stable pass therefore terminates the loop.
+// produce the same doc. One stable pass therefore terminates the loop. At
+// the cap, one final walk runs against the drained store and its output is
+// used regardless of stability (with a warning when still unstable).
 const SEARCHABLE_SETTLE_MAX_PASSES = 20;
 
 // Persistence bounds for the per-field / per-link-load search-doc timings.
@@ -391,7 +393,9 @@ export default class RenderMetaRoute extends Route<Model> {
   // resident/cache hits, so it measures evaluation); `settleMs` is
   // everything before and around it — the discarded walks and the load
   // drains; `settlePasses` counts the discarded walks (0 when the first
-  // walk settles).
+  // walk settles). A graph that never stabilizes within the discarded-walk
+  // cap gets one forced final walk against the drained store; its output is
+  // used (or its throw propagated) with a warning.
   async #searchDocUntilSettled(
     instance: CardDef,
     searchable: Awaited<ReturnType<CardService['getSearchable']>>,
@@ -406,7 +410,13 @@ export default class RenderMetaRoute extends Route<Model> {
   }> {
     let linkLoads: SearchDocLinkLoad[] = [];
     let loopStart = performance.now();
-    for (let pass = 0; pass < SEARCHABLE_SETTLE_MAX_PASSES; pass++) {
+    // Up to SEARCHABLE_SETTLE_MAX_PASSES discarded walks, plus one forced
+    // final walk at the cap. The forced walk runs AFTER the capped pass's
+    // loads drained, so it sees the most-settled state reachable within the
+    // budget — its output is used even when it is itself unstable, rather
+    // than the pre-drain output of the pass that hit the cap.
+    for (let pass = 0; pass <= SEARCHABLE_SETTLE_MAX_PASSES; pass++) {
+      let forcedFinalPass = pass === SEARCHABLE_SETTLE_MAX_PASSES;
       let observedGeneration = this.store.loadGeneration;
       let searchableDeps = new Set<string>();
       let timings: SearchDocTimings = { fieldsMs: {}, linkLoads };
@@ -427,8 +437,7 @@ export default class RenderMetaRoute extends Route<Model> {
       let searchDocMs = performance.now() - walkStart;
       await this.store.loaded();
       let stable = this.store.loadGeneration === observedGeneration;
-      let lastAllowedPass = pass === SEARCHABLE_SETTLE_MAX_PASSES - 1;
-      if (!stable && !lastAllowedPass) {
+      if (!stable && !forcedFinalPass) {
         continue;
       }
       if (!stable) {
@@ -449,7 +458,7 @@ export default class RenderMetaRoute extends Route<Model> {
         settlePasses: pass,
       };
     }
-    // Unreachable: the final loop iteration always returns or throws.
+    // Unreachable: the forced final pass always returns or throws.
     throw new Error(
       `bug: searchable walk loop for ${instance.id} exited without settling`,
     );

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -40,13 +40,15 @@ export type Model = PrerenderMeta | RenderError | undefined;
 
 const computePerfLog = logger('host:computed-perf');
 
-// Bounds for the searchable-driven load-settle loop below. Match the
-// template-render settle in the /render route (READY_SETTLE_MAX_PASSES /
-// READY_SETTLE_REQUIRED_STABLE_PASSES): keep pulling + waiting until the
-// store's load generation holds steady for a couple of passes, capped so a
-// pathological graph can't loop forever.
+// Pass cap for the walk-until-stable loop below (matches the
+// READY_SETTLE_MAX_PASSES cap of the /render route's template settle), so a
+// pathological graph can't loop forever. Unlike a template render — whose
+// afterRender hooks can schedule further work that only a repeated
+// render-and-wait can flush — a searchable walk is a pure function of the
+// store's settled load state, so a single pass that fired no tracked loads
+// is already authoritative: re-running it against the same state would
+// produce the same doc. One stable pass therefore terminates the loop.
 const SEARCHABLE_SETTLE_MAX_PASSES = 20;
-const SEARCHABLE_SETTLE_REQUIRED_STABLE_PASSES = 2;
 
 // Persistence bounds for the per-field / per-link-load search-doc timings.
 // The raw collectors are unbounded; only the slowest entries at/over the
@@ -90,7 +92,7 @@ function pruneSearchDocLinkLoads(
 
 // Multiset diff over the store's bounded completed-load histories: the
 // entries present in `after` beyond their multiplicity in `before`. Used to
-// attribute loads the settle loop fired through field getters (a computed
+// attribute loads the walk passes fired through field getters (a computed
 // reading a link loads via `lazilyLoadLink`, not via the generator's
 // targeted loading) — those loads land in the store's history but never
 // pass through the generator's collector. The histories keep only the
@@ -152,35 +154,34 @@ export default class RenderMetaRoute extends Route<Model> {
     // rather than from what the render happened to load.
     let searchable = await this.cardService.getSearchable();
 
-    // Drive the instance's linked-field loading to quiescence before
-    // serializing. The searchable annotations name which links to pull, and
-    // the card's own contained/computed fields read links too — both fire
-    // lazy loads through the field getter (tracked on the store). Nothing
-    // awaits those loads inline (a computed reading a not-yet-loaded link
-    // sees `undefined`; a broken link's terminal sentinel isn't planted
-    // until its load settles), so pull-then-wait here, repeating until the
-    // store's load generation holds steady: each pass loads whatever the
-    // current state newly permits — a deeper searchable hop once its parent
-    // resolved, a computed's link once the computed re-reads — and
-    // `store.loaded()` drains it. Cycles clip via the generator's own stack
-    // guard, so a ring loads its nodes once and then quiesces.
+    // Produce the search doc by walking until the store's load state is
+    // quiescent — the walk IS the pull. The searchable annotations name which
+    // links to pull, and the card's own contained/computed fields read links
+    // too. The generator awaits its own targeted loads inline and folds each
+    // target straight into the doc, but a computed reading a not-yet-loaded
+    // link fires a lazy getter load nothing awaits (the computed sees
+    // `undefined`, or throws until the target lands), so a pass that fired
+    // such loads is re-run once `store.loaded()` drains them: each pass
+    // evaluates whatever the newly-settled state permits — a deeper
+    // searchable hop once its parent resolved, a computed's link once the
+    // computed re-reads. The first pass whose walk left the store's load
+    // generation unmoved is authoritative — its doc, dependency set, and
+    // per-field timings are the ones consumed below. Cycles clip via the
+    // generator's own stack guard, so a ring loads its nodes once and then
+    // quiesces.
     //
     // This reproduces, for the search doc, the settle the /render route
     // provides for template renders (its readyPromise waits on the same
     // `store.loaded()` after the template pulls the links). The two are
-    // complementary: when a template render already loaded the graph (a fused
-    // visit, or an HTML render sharing this tab), the first pass finds every
-    // target resident and `store.loaded()` resolves immediately — there is
-    // nothing left to wait for.
+    // complementary: when a template render already loaded the graph (an
+    // HTML render sharing this tab), the first pass finds every target
+    // resident and is immediately stable.
     //
-    // Link-load cost lives HERE: the settle passes perform the actual
-    // target loads (each load registers its instance in the store, so the
-    // timed generation below finds everything resident). The collector
-    // gathers one entry per performed load across all passes — a target
-    // loads on the first pass that reaches it and is a resident hit
-    // afterward — for the `searchDocLinkLoads` diagnostic. Loads the passes
-    // fire indirectly through field getters (a computed reading a link)
-    // bypass the generator's collector, so the store's completed-load
+    // The collector gathers one entry per performed targeted load across all
+    // passes — a target loads on the first pass that reaches it and is a
+    // resident hit afterward — for the `searchDocLinkLoads` diagnostic.
+    // Loads fired indirectly through field getters (a computed reading a
+    // link) bypass the generator's collector, so the store's completed-load
     // histories are snapshotted around the loop and their delta is folded
     // in — with an empty `path`, since the store can't name the owning
     // field.
@@ -188,25 +189,29 @@ export default class RenderMetaRoute extends Route<Model> {
       ...this.store.recentCardDocLoads(),
       ...this.store.recentFileMetaLoads(),
     ];
-    let settleLinkLoads: SearchDocLinkLoad[] = [];
-    let settleStart = performance.now();
-    let settlePasses = await this.#settleSearchableLoads(
-      instance,
-      searchable,
-      settleLinkLoads,
-    );
-    let searchDocSettleMs = performance.now() - settleStart;
+    let {
+      searchDoc,
+      searchableDeps,
+      fieldsMs,
+      linkLoads,
+      searchDocMs,
+      settleMs: searchDocSettleMs,
+      settlePasses,
+    } = await this.#searchDocUntilSettled(instance, searchable);
     let getterFiredLoads = newLoadEntries(recentLoadsBefore, [
       ...this.store.recentCardDocLoads(),
       ...this.store.recentFileMetaLoads(),
     ]).map(({ url, ms }) => ({ path: '', target: url, ms }));
 
-    // Union the render route's captured deps with a fresh snapshot: the
-    // settle loop above loaded links through the tracked getter (each a
-    // recorded dependency), and those loads land in the still-open tracking
-    // session but after `capturedDeps` was snapshotted. A render that never
-    // pulled a link (an index visit with no HTML render) would otherwise
-    // drop the edges searchable just followed.
+    // Union the render route's captured deps with a fresh snapshot: the walk
+    // passes above loaded links through the tracked getter (each a recorded
+    // dependency), and those loads land in the still-open tracking session
+    // but after `capturedDeps` was snapshotted. A render that never pulled a
+    // link (an index visit with no HTML render) would otherwise drop the
+    // edges searchable just followed. The targets the generator expanded
+    // into the doc are dependencies too — editing an expanded target must
+    // reindex the owner even when no render loaded it — so the generator's
+    // collected set joins the union.
     //
     // The searchable module itself is loaded through a per-loader cache, so its
     // module-load hook only fires (and only records a dependency) on the first
@@ -218,6 +223,7 @@ export default class RenderMetaRoute extends Route<Model> {
         SEARCHABLE_MODULE_URL,
         ...(renderModel?.capturedDeps ?? []),
         ...snapshotRuntimeDependencies({ excludeQueryOnly: true }).deps,
+        ...searchableDeps,
       ]),
     ];
 
@@ -225,8 +231,8 @@ export default class RenderMetaRoute extends Route<Model> {
     // invoked through the descriptor or through peekAtField hit the per-instance
     // memo instead of re-running `computeVia` — one compute per distinct
     // (instance, fieldName). The pass MUST close before any await so it doesn't
-    // leak across reactive cycles; searchable-driven generation does targeted
-    // link loading (async), so it runs after the pass closes — see below.
+    // leak across reactive cycles; the walk loop above settled the store, so
+    // every link serializeCard's computeds read is already resident.
     //
     // Guarded by typeof checks: during a cold dev boot the host can briefly
     // load a base/card-api build that predates these exports (vite is still
@@ -285,29 +291,6 @@ export default class RenderMetaRoute extends Route<Model> {
       }
     }
 
-    // Run searchable-driven generation after the compute-memo pass closes: it
-    // awaits targeted link loads, and the pass cannot span an await. The
-    // generator collects the URLs of the link targets it pulls into the doc;
-    // those are dependencies of this card (unioned into `deps` below), so
-    // editing a searchable target reindexes the owner even when the render did
-    // not itself load that target.
-    let searchDocStart = performance.now();
-    let searchableDeps = new Set<string>();
-    // Per-field evaluation timings come from this timed walk (link loads
-    // settled above, so it measures evaluation, not loading); any load the
-    // walk still performs — a settle that hit its pass cap, a race — joins
-    // the settle passes' entries.
-    let searchDocTimings: SearchDocTimings = { fieldsMs: {}, linkLoads: [] };
-    let searchDoc: Record<string, any> = await searchable.searchDocFromFields(
-      instance,
-      searchableDeps,
-      searchDocTimings,
-    );
-    let searchDocMs = performance.now() - searchDocStart;
-    if (searchableDeps.size > 0) {
-      deps = [...new Set([...deps, ...searchableDeps])];
-    }
-
     let Klass = getClass(instance);
 
     let types = getTypes(Klass);
@@ -322,19 +305,13 @@ export default class RenderMetaRoute extends Route<Model> {
     // `cardTitle` computed already present in the search doc.
     searchDoc._title = searchDoc.cardTitle;
 
-    let searchDocFieldsMs = pruneSearchDocFieldsMs(
-      searchDocTimings.fieldsMs ?? {},
-    );
+    let searchDocFieldsMs = pruneSearchDocFieldsMs(fieldsMs);
     // A target the generator loaded directly also lands in the store's
     // history; keep the generator's entry (it carries the field path) and
     // drop the store's duplicate.
-    let targetedLoads = [
-      ...settleLinkLoads,
-      ...(searchDocTimings.linkLoads ?? []),
-    ];
-    let targetedUrls = new Set(targetedLoads.map(({ target }) => target));
+    let targetedUrls = new Set(linkLoads.map(({ target }) => target));
     let searchDocLinkLoads = pruneSearchDocLinkLoads([
-      ...targetedLoads,
+      ...linkLoads,
       ...getterFiredLoads.filter(({ target }) => !targetedUrls.has(target)),
     ]);
     let diagnostics: PrerenderMetaDiagnostics = {
@@ -389,56 +366,93 @@ export default class RenderMetaRoute extends Route<Model> {
     };
   }
 
-  // Pull the instance's searchable-path links (and the links its
-  // contained/computed fields read) and wait for the store to settle,
-  // repeating until the load generation is stable. Running the searchable
-  // generator IS the pull — it reads every field the search doc and pristine
-  // doc will read, firing each link's lazy load through the tracked getter —
-  // and `store.loaded()` is the wait. The intermediate search docs are
-  // discarded (a throwaway dependency set); the authoritative generation runs
-  // afterward against the settled store. See the call site for why this is
-  // needed and how it composes with the /render template settle.
+  // Walk the card with the searchable generator until the store's load
+  // state is quiescent, and return the first quiescent walk's output as the
+  // authoritative search doc. Running the generator IS the pull — it reads
+  // every field the search doc will read, awaiting its own targeted link
+  // loads inline and firing each computed-read link's lazy load through the
+  // tracked getter — and `store.loaded()` is the wait. A pass that left the
+  // store's load generation unmoved consumed only settled state, so its doc
+  // is what any re-run against that state would produce: it terminates the
+  // loop, and its dependency set and per-field timings ride out with it.
+  // Unstable passes' docs and fieldsMs are discarded; `linkLoads` is shared
+  // across passes (a target loads on the first pass that reaches it, so the
+  // union is one entry per performed load).
   //
-  // Returns the number of passes run. Each performed link-target load is
-  // recorded into `linkLoads` (the collector fills incrementally, so loads
-  // recorded before a swallowed mid-walk throw survive); a searchable build
-  // that predates the collector parameter simply leaves it empty.
-  async #settleSearchableLoads(
+  // A computed that reads a not-yet-loaded link (e.g. `this.author.name`)
+  // throws mid-walk — the getter fires the lazy load, then the read of the
+  // still-`undefined` target throws. The load it fired moves the generation,
+  // so the throw is swallowed and the next pass re-runs the computed against
+  // the loaded target. A genuine failure fires no load, reads as stable, and
+  // rethrows to the caller (the render error path). Timings recorded before
+  // a mid-walk throw survive — the collector fills incrementally.
+  //
+  // `searchDocMs` is the authoritative walk's own duration (its loads are
+  // resident/cache hits, so it measures evaluation); `settleMs` is
+  // everything before and around it — the discarded walks and the load
+  // drains; `settlePasses` counts the discarded walks (0 when the first
+  // walk settles).
+  async #searchDocUntilSettled(
     instance: CardDef,
     searchable: Awaited<ReturnType<CardService['getSearchable']>>,
-    linkLoads: SearchDocLinkLoad[],
-  ): Promise<number> {
-    let observedGeneration = this.store.loadGeneration;
-    let stablePasses = 0;
-    let timings: SearchDocTimings = { linkLoads };
+  ): Promise<{
+    searchDoc: Record<string, any>;
+    searchableDeps: Set<string>;
+    fieldsMs: Record<string, number>;
+    linkLoads: SearchDocLinkLoad[];
+    searchDocMs: number;
+    settleMs: number;
+    settlePasses: number;
+  }> {
+    let linkLoads: SearchDocLinkLoad[] = [];
+    let loopStart = performance.now();
     for (let pass = 0; pass < SEARCHABLE_SETTLE_MAX_PASSES; pass++) {
-      // A computed that reads a not-yet-loaded link (e.g.
-      // `this.author.firstName`) throws on the first pass — the getter fires
-      // the lazy load, then the read of the still-`undefined` target throws.
-      // The load it fired is what we wait on next, so swallow the throw and
-      // let it settle: a later pass re-runs the computed against the loaded
-      // target. A genuine (non-load-race) failure resurfaces in the
-      // authoritative generation the caller runs after this settles.
+      let observedGeneration = this.store.loadGeneration;
+      let searchableDeps = new Set<string>();
+      let timings: SearchDocTimings = { fieldsMs: {}, linkLoads };
+      let walkStart = performance.now();
+      let searchDoc: Record<string, any> | undefined;
+      let thrown: unknown;
+      let threw = false;
       try {
-        await searchable.searchDocFromFields(instance, undefined, timings);
-      } catch {
-        // intentionally ignored during settle — see above
+        searchDoc = await searchable.searchDocFromFields(
+          instance,
+          searchableDeps,
+          timings,
+        );
+      } catch (e) {
+        threw = true;
+        thrown = e;
       }
+      let searchDocMs = performance.now() - walkStart;
       await this.store.loaded();
-      let nextGeneration = this.store.loadGeneration;
-      if (nextGeneration === observedGeneration) {
-        if (++stablePasses >= SEARCHABLE_SETTLE_REQUIRED_STABLE_PASSES) {
-          return pass + 1;
-        }
-      } else {
-        observedGeneration = nextGeneration;
-        stablePasses = 0;
+      let stable = this.store.loadGeneration === observedGeneration;
+      let lastAllowedPass = pass === SEARCHABLE_SETTLE_MAX_PASSES - 1;
+      if (!stable && !lastAllowedPass) {
+        continue;
       }
+      if (!stable) {
+        computePerfLog.warn(
+          `render.meta searchable walk for ${instance.id} did not reach a stable load generation within ${SEARCHABLE_SETTLE_MAX_PASSES} passes; using the current store state`,
+        );
+      }
+      if (threw) {
+        throw thrown;
+      }
+      return {
+        searchDoc: searchDoc!,
+        searchableDeps,
+        fieldsMs: timings.fieldsMs ?? {},
+        linkLoads,
+        searchDocMs,
+        settleMs: performance.now() - loopStart - searchDocMs,
+        settlePasses: pass,
+      };
     }
-    computePerfLog.warn(
-      `render.meta searchable settle for ${instance.id} did not reach a stable load generation within ${SEARCHABLE_SETTLE_MAX_PASSES} passes; proceeding with the current store state`,
+    // Unreachable: the final loop iteration always returns or throws.
+    throw new Error(
+      `bug: searchable walk loop for ${instance.id} exited without settling`,
     );
-    return SEARCHABLE_SETTLE_MAX_PASSES;
   }
 }
 

--- a/packages/host/tests/integration/searchable-search-doc-test.gts
+++ b/packages/host/tests/integration/searchable-search-doc-test.gts
@@ -1,13 +1,15 @@
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import type {
-  Realm,
-  IndexedInstance,
-  SearchDocTimings,
+import {
+  rri,
+  type Realm,
+  type IndexedInstance,
+  type SearchDocTimings,
 } from '@cardstack/runtime-common';
 import type { Loader } from '@cardstack/runtime-common/loader';
 
+import CardStoreWithGarbageCollection from '@cardstack/host/lib/gc-card-store';
 import type StoreService from '@cardstack/host/services/store';
 
 import {
@@ -27,6 +29,7 @@ import {
   FieldDef,
   Component,
   StringField,
+  createFromSerialized,
   getDataBucket,
   searchDocFromFields,
 } from '../helpers/base-realm';
@@ -294,6 +297,26 @@ module('Integration | searchable search doc', function (hooks) {
       });
     }
 
+    // ---- a throwing branch beside a searchable link -------------------------
+    // On a fresh store the computed's branch throws: reading `other` fires
+    // that target's lazy load and yields `undefined`, so the `.name` read
+    // throws. The computed is declared BEFORE the searchable link, so a walk
+    // that stopped at the first failing branch would never reach the link
+    // field. Branches run concurrently and all settle before the first
+    // rejection rethrows, so the searchable link's targeted load fires (and
+    // completes) in the same walk. Once `other` is resident the computed
+    // succeeds, so the card indexes cleanly.
+    class Boom extends CardDef {
+      static displayName = 'Boom';
+      @field other = linksTo(Author);
+      @field boom = contains(StringField, {
+        computeVia: function (this: any) {
+          return this.other.name;
+        },
+      });
+      @field agent = linksTo(Agent, { searchable: true });
+    }
+
     let agentRef = (id: string) => ({ links: { self: id } });
 
     ({ realm } = await setupIntegrationTestRealm({
@@ -338,10 +361,14 @@ module('Integration | searchable search doc', function (hooks) {
         },
         'profile.gts': { Profile, FancyProfile, ArticleProfile },
         'article-query.gts': { ArticleQuery },
+        'boom.gts': { Boom },
 
         // --- leaves + chain ---
         'Agent/a1.json': card('Agent Smith', 'agent', 'Agent'),
         'Agent/a2.json': card('Agent Jones', 'agent', 'Agent'),
+        // Referenced only by Boom/b1, so its residency in a test's store is
+        // attributable to that card's walk alone.
+        'Agent/a3.json': card('Agent Braun', 'agent', 'Agent'),
         'Headquarters/h1.json': card('HQ One', 'headquarters', 'Headquarters'),
         'Company/co1.json': {
           data: {
@@ -619,6 +646,20 @@ module('Integration | searchable search doc', function (hooks) {
             id: `${testRealmURL}ArticleQuery/q1`,
             attributes: { title: 'Query' },
             meta: adoptsFrom('article-query', 'ArticleQuery'),
+          },
+        },
+
+        // --- throwing branch beside a searchable link ---
+        'Boom/b1.json': {
+          data: {
+            type: 'card',
+            id: `${testRealmURL}Boom/b1`,
+            attributes: {},
+            relationships: {
+              other: agentRef(`${testRealmURL}Author/au1`),
+              agent: agentRef(`${testRealmURL}Agent/a3`),
+            },
+            meta: adoptsFrom('boom', 'Boom'),
           },
         },
       },
@@ -1145,6 +1186,61 @@ module('Integration | searchable search doc', function (hooks) {
     let doc = await loadAndGenerate(`${testRealmURL}ArticleQuery/q1`);
     assert.strictEqual(doc.title, 'Query', 'plain fields are present');
     assert.notOk('related' in doc, 'the query-backed field is skipped');
+  });
+
+  test('a throwing branch does not stop sibling link loads in the same walk', async function (assert) {
+    // Build the instance from its bare document on a dedicated store, so both
+    // of its links start not-loaded — the shape the indexer's walk sees. (The
+    // live store's card GET sideloads the whole link graph, which would leave
+    // nothing for the walk to load.)
+    let network = getService('network');
+    let store = new CardStoreWithGarbageCollection(
+      new Map(),
+      network.fetch,
+      network.virtualNetwork,
+    );
+    let doc = {
+      data: {
+        id: `${testRealmURL}Boom/b1`,
+        type: 'card' as const,
+        attributes: {},
+        relationships: {
+          other: { links: { self: `${testRealmURL}Author/au1` } },
+          agent: { links: { self: `${testRealmURL}Agent/a3` } },
+        },
+        meta: {
+          adoptsFrom: { module: rri(`${testRealmURL}boom`), name: 'Boom' },
+        },
+      },
+    };
+    let instance = (await createFromSerialized(
+      doc.data,
+      doc,
+      new URL(doc.data.id),
+      { store },
+    )) as CardDefType;
+    let thrown: unknown;
+    try {
+      await searchDocFromFields(instance);
+    } catch (e) {
+      thrown = e;
+    }
+    // The computed branch reads its not-yet-loaded `other` target and throws.
+    assert.notStrictEqual(
+      thrown,
+      undefined,
+      'the failing branch rethrows to the caller',
+    );
+    // Branches settle together before the rethrow, so the searchable link's
+    // targeted load — a sibling of the throwing computed — has already
+    // completed and registered its target.
+    assert.ok(
+      store.getCard(`${testRealmURL}Agent/a3`),
+      'the sibling searchable target loaded during the same walk',
+    );
+    // Drain the lazy load the computed's read fired so no fetch outlives the
+    // test.
+    await store.loaded();
   });
 
   test('a linksTo target is enumerated by its DECLARED type (subtype bloat dropped)', async function (assert) {

--- a/packages/host/tests/unit/job-scoped-doc-cache-test.ts
+++ b/packages/host/tests/unit/job-scoped-doc-cache-test.ts
@@ -22,10 +22,14 @@ module('Unit | job-scoped wire-document cache', function (hooks) {
 
   let fetchCount = 0;
   let fetchStatus = 200;
+  // When set, every stub fetch awaits this before responding — lets a test
+  // hold a load in flight across a cache clear.
+  let fetchGate: Promise<void> | undefined;
 
   hooks.beforeEach(function () {
     fetchCount = 0;
     fetchStatus = 200;
+    fetchGate = undefined;
     (globalThis as any).__boxelRenderContext = true;
     (globalThis as any).__boxelJobId = '17.23';
   });
@@ -75,6 +79,9 @@ module('Unit | job-scoped wire-document cache', function (hooks) {
       init?: RequestInit,
     ): Promise<Response> => {
       fetchCount++;
+      if (fetchGate) {
+        await fetchGate;
+      }
       if (fetchStatus !== 200) {
         return new Response('not found', { status: fetchStatus });
       }
@@ -200,5 +207,71 @@ module('Unit | job-scoped wire-document cache', function (hooks) {
     let second = await store.loadFileMetaDocument(url);
     assert.strictEqual(fetchCount, 1, 'only the first load fetched');
     assert.deepEqual(second, first, 'the cached document is equivalent');
+  });
+
+  test('a load resolving across a cache clear does not seed the cleared cache', async function (assert) {
+    let store = makeStore();
+    let url = 'http://localhost:4201/test/hassan';
+    let releaseFetch!: () => void;
+    fetchGate = new Promise<void>((resolve) => (releaseFetch = resolve));
+    let inFlight = store.loadCardDocument(url);
+    // The clear lands while the fetch is still held open; the resolving
+    // load's populate must be skipped, not written into the fresh cache.
+    store.reset();
+    releaseFetch();
+    await inFlight;
+    fetchGate = undefined;
+    await store.loadCardDocument(url);
+    assert.strictEqual(
+      fetchCount,
+      2,
+      'the post-clear load re-fetches instead of hitting a stale populate',
+    );
+  });
+
+  test('eviction drops the least-recently-used entry and a hit rescues one', async function (assert) {
+    let store = makeStore();
+    let cap = CardStore.MAX_JOB_SCOPED_DOC_CACHE_ENTRIES;
+    let urlFor = (n: number) => `http://localhost:4201/test/card-${n}`;
+    // Fill to the cap, then touch the first entry so the second becomes the
+    // least-recently-used.
+    for (let n = 0; n < cap; n++) {
+      await store.loadCardDocument(urlFor(n));
+    }
+    assert.strictEqual(fetchCount, cap, 'the fill fetched once per URL');
+    await store.loadCardDocument(urlFor(0));
+    assert.strictEqual(fetchCount, cap, 'the touch was a cache hit');
+    // One more distinct URL pushes the cache over the cap.
+    await store.loadCardDocument(urlFor(cap));
+    assert.strictEqual(fetchCount, cap + 1, 'the overflow entry fetched');
+    await store.loadCardDocument(urlFor(0));
+    assert.strictEqual(
+      fetchCount,
+      cap + 1,
+      'the touched entry survived eviction',
+    );
+    await store.loadCardDocument(urlFor(1));
+    assert.strictEqual(
+      fetchCount,
+      cap + 2,
+      'the least-recently-used entry was evicted',
+    );
+  });
+
+  test('card and file-meta entries for the same URL do not share a slot', async function (assert) {
+    let store = makeStore();
+    let url = 'http://localhost:4201/test/dual.json';
+    let cardDoc = (await store.loadCardDocument(url)) as any;
+    let fileDoc = (await store.loadFileMetaDocument(url)) as any;
+    assert.strictEqual(fetchCount, 2, 'each kind fetched its own document');
+    assert.strictEqual(cardDoc.data.type, 'card', 'the card slot holds a card');
+    assert.strictEqual(
+      fileDoc.data.type,
+      'file-meta',
+      'the file slot holds file meta',
+    );
+    await store.loadCardDocument(url);
+    await store.loadFileMetaDocument(url);
+    assert.strictEqual(fetchCount, 2, 'both kinds hit their own entries');
   });
 });

--- a/packages/host/tests/unit/job-scoped-doc-cache-test.ts
+++ b/packages/host/tests/unit/job-scoped-doc-cache-test.ts
@@ -1,0 +1,204 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { isCardError } from '@cardstack/runtime-common';
+
+import CardStore, {
+  type ReferenceCount,
+} from '@cardstack/host/lib/gc-card-store';
+
+import { setupRenderingTest } from '../helpers/setup';
+
+// Exercises the store's job-scoped wire-document cache: inside an indexing
+// render (render context + job id present) a successful card-source /
+// file-meta document is cached by URL for the job's lifetime, so a link
+// target shared by many cards fetches once per job. The cache is inert
+// outside that gate, drops on a job-id change and on store reset, never
+// holds error results, and hands out isolated copies. Also covers the
+// `untracked` load option the searchable generator's targeted loads use to
+// stay out of the store's load-generation settle signal.
+module('Unit | job-scoped wire-document cache', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let fetchCount = 0;
+  let fetchStatus = 200;
+
+  hooks.beforeEach(function () {
+    fetchCount = 0;
+    fetchStatus = 200;
+    (globalThis as any).__boxelRenderContext = true;
+    (globalThis as any).__boxelJobId = '17.23';
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any).__boxelRenderContext;
+    delete (globalThis as any).__boxelJobId;
+  });
+
+  function cardDocFor(url: string) {
+    return {
+      data: {
+        id: url,
+        type: 'card',
+        attributes: { name: 'Test' },
+        meta: {
+          adoptsFrom: {
+            module: 'https://cardstack.com/base/card-api',
+            name: 'CardDef',
+          },
+        },
+      },
+    };
+  }
+
+  function fileMetaDocFor(url: string) {
+    return {
+      data: {
+        id: url,
+        type: 'file-meta',
+        attributes: {},
+        meta: {
+          adoptsFrom: {
+            module: 'https://cardstack.com/base/file-api',
+            name: 'FileDef',
+          },
+        },
+      },
+    };
+  }
+
+  function makeStore(): CardStore {
+    let referenceCount: ReferenceCount = new Map();
+    let network = getService('network');
+    let stubFetch = async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      fetchCount++;
+      if (fetchStatus !== 200) {
+        return new Response('not found', { status: fetchStatus });
+      }
+      let href =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      let requested = new URL(href);
+      requested.search = '';
+      // Card-source and file-meta requests both target `.json` URLs; the
+      // Accept header is what distinguishes the document kind requested.
+      let accept = new Headers(init?.headers).get('accept');
+      let doc = accept?.includes('file-meta')
+        ? fileMetaDocFor(requested.href)
+        : cardDocFor(requested.href.replace(/\.json$/, ''));
+      return new Response(JSON.stringify(doc), {
+        status: 200,
+        headers: { 'content-type': 'application/vnd.card+source' },
+      });
+    };
+    return new CardStore(
+      referenceCount,
+      stubFetch as typeof globalThis.fetch,
+      network.virtualNetwork,
+    );
+  }
+
+  test('a repeated card-document load within one job fetches once', async function (assert) {
+    let store = makeStore();
+    let url = 'http://localhost:4201/test/hassan';
+    let first = await store.loadCardDocument(url);
+    let second = await store.loadCardDocument(url);
+    assert.strictEqual(fetchCount, 1, 'only the first load fetched');
+    assert.deepEqual(second, first, 'the cached document is equivalent');
+    assert.notStrictEqual(second, first, 'each consumer receives its own copy');
+  });
+
+  test('a cache hit hands out a copy isolated from prior consumers', async function (assert) {
+    let store = makeStore();
+    let url = 'http://localhost:4201/test/hassan';
+    let first = (await store.loadCardDocument(url)) as any;
+    first.data.attributes.name = 'mutated by consumer';
+    let second = (await store.loadCardDocument(url)) as any;
+    assert.strictEqual(
+      second.data.attributes.name,
+      'Test',
+      'a consumer mutation does not leak into later cache hits',
+    );
+  });
+
+  test('observing a different job id drops the previous job entries', async function (assert) {
+    let store = makeStore();
+    let url = 'http://localhost:4201/test/hassan';
+    await store.loadCardDocument(url);
+    (globalThis as any).__boxelJobId = '18.24';
+    await store.loadCardDocument(url);
+    assert.strictEqual(fetchCount, 2, 'the new job re-fetches');
+  });
+
+  test('no caching outside a render context', async function (assert) {
+    delete (globalThis as any).__boxelRenderContext;
+    let store = makeStore();
+    let url = 'http://localhost:4201/test/hassan';
+    await store.loadCardDocument(url);
+    await store.loadCardDocument(url);
+    assert.strictEqual(fetchCount, 2, 'every load fetches');
+  });
+
+  test('no caching without a job id', async function (assert) {
+    delete (globalThis as any).__boxelJobId;
+    let store = makeStore();
+    let url = 'http://localhost:4201/test/hassan';
+    await store.loadCardDocument(url);
+    await store.loadCardDocument(url);
+    assert.strictEqual(fetchCount, 2, 'every load fetches');
+  });
+
+  test('error results are not cached', async function (assert) {
+    fetchStatus = 404;
+    let store = makeStore();
+    let url = 'http://localhost:4201/test/missing';
+    let first = await store.loadCardDocument(url);
+    assert.true(isCardError(first), 'the load surfaces a card error');
+    let second = await store.loadCardDocument(url);
+    assert.true(isCardError(second), 'the retry surfaces a card error too');
+    assert.strictEqual(fetchCount, 2, 'the error result was not pinned');
+  });
+
+  test('reset() drops the cache', async function (assert) {
+    let store = makeStore();
+    let url = 'http://localhost:4201/test/hassan';
+    await store.loadCardDocument(url);
+    store.reset();
+    await store.loadCardDocument(url);
+    assert.strictEqual(fetchCount, 2, 'a reset store re-fetches');
+  });
+
+  test('an untracked load does not move the load generation', async function (assert) {
+    let store = makeStore();
+    let before = store.loadGeneration;
+    await store.loadCardDocument('http://localhost:4201/test/untracked', {
+      untracked: true,
+    });
+    assert.strictEqual(
+      store.loadGeneration,
+      before,
+      'an untracked fetch leaves the settle signal unmoved',
+    );
+    await store.loadCardDocument('http://localhost:4201/test/tracked');
+    assert.notStrictEqual(
+      store.loadGeneration,
+      before,
+      'a tracked fetch moves the settle signal',
+    );
+  });
+
+  test('a repeated file-meta document load within one job fetches once', async function (assert) {
+    let store = makeStore();
+    let url = 'http://localhost:4201/test/notes.json';
+    let first = await store.loadFileMetaDocument(url);
+    let second = await store.loadFileMetaDocument(url);
+    assert.strictEqual(fetchCount, 1, 'only the first load fetched');
+    assert.deepEqual(second, first, 'the cached document is equivalent');
+  });
+});

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1561,9 +1561,16 @@ module(basename(import.meta.filename), function () {
           (diagnostics?.searchDocSettleMs ?? -1) >= 0,
           `searchDocSettleMs is non-negative, got: ${diagnostics?.searchDocSettleMs}`,
         );
+        // A card whose first walk fires no lazy getter loads settles with
+        // zero discarded passes, so 0 is the healthy floor.
+        assert.strictEqual(
+          typeof diagnostics?.searchDocSettlePasses,
+          'number',
+          `searchDocSettlePasses is stamped, got: ${diagnostics?.searchDocSettlePasses}`,
+        );
         assert.ok(
-          (diagnostics?.searchDocSettlePasses ?? 0) >= 2,
-          `searchDocSettlePasses counts at least the two stability passes, got: ${diagnostics?.searchDocSettlePasses}`,
+          (diagnostics?.searchDocSettlePasses ?? -1) >= 0,
+          `searchDocSettlePasses counts the discarded walks, got: ${diagnostics?.searchDocSettlePasses}`,
         );
         if (diagnostics?.searchDocFieldsMs !== undefined) {
           assert.ok(

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -163,8 +163,9 @@ export interface PrerenderMetaDiagnostics {
   // include targeted `searchable`-route loads it consumed inline — the
   // first walk to reach a target performs its load, and a first-walk-stable
   // card performs them all here. Each such load is itemized in
-  // `searchDocLinkLoads`, so subtract those entries to read pure evaluation
-  // time.
+  // `searchDocLinkLoads`; because loads run concurrently their entries
+  // overlap, so read a load-entry-bearing `searchDocMs` as an upper bound
+  // on evaluation time rather than subtracting the entries out.
   searchDocMs?: number;
   // Wall-clock spent driving the card's getter-fired link loads to
   // quiescence before the walk that produced the doc: the discarded walk

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -158,15 +158,19 @@ export interface PrerenderMetaDiagnostics {
   // Wall-clock of the host-side serializeCard call.
   serializeMs?: number;
   // Wall-clock of the searchable walk that produced the doc — the first
-  // walk whose loads were all resident/cache hits, so this measures
-  // evaluation rather than loading.
+  // walk against a stable load generation. It never waits on getter-fired
+  // loads (those mark a walk unstable and it is discarded), but it can
+  // include targeted `searchable`-route loads it consumed inline — the
+  // first walk to reach a target performs its load, and a first-walk-stable
+  // card performs them all here. Each such load is itemized in
+  // `searchDocLinkLoads`, so subtract those entries to read pure evaluation
+  // time.
   searchDocMs?: number;
-  // Wall-clock spent driving the card's link loads to quiescence before the
-  // walk that produced the doc: the discarded walk passes and their load
-  // drains. Link-load cost lives HERE, not inside `searchDocMs` — by the
-  // time the doc-producing walk runs, its targets are resident. Read
-  // `searchDocLinkLoads` for the per-target breakdown of this time.
-  // Near-zero when the first walk settled.
+  // Wall-clock spent driving the card's getter-fired link loads to
+  // quiescence before the walk that produced the doc: the discarded walk
+  // passes and their load drains. Read `searchDocLinkLoads` for the
+  // per-target load breakdown (its entries span both this and the
+  // doc-producing walk). Near-zero when the first walk settled.
   searchDocSettleMs?: number;
   // How many walk passes were discarded before one ran against a stable
   // load generation. Each pass loads one more dependency-depth wave, so a

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -112,8 +112,11 @@ export const FRONTMATTER_PARSE_ERROR_SYMBOL = Symbol.for(
 // loads via the getter's lazy path, not the generator's targeted loading —
 // carries an empty `path`, since the store observing it can't name the
 // owning field. Only actual loads are represented — a target already
-// resident in the store records a near-zero entry that the persistence
-// floor drops.
+// resident in the store (or served from the job-scoped document cache)
+// records a near-zero entry that the persistence floor drops. Independent
+// branches of the walk load concurrently, so entries overlap in time: each
+// `ms` is that load's own wall-clock span, and the entries don't sum to the
+// walk's elapsed time.
 export interface SearchDocLinkLoad {
   path: string;
   target: string;
@@ -154,19 +157,22 @@ export interface PrerenderMetaDiagnostics {
   computedCacheHits?: number;
   // Wall-clock of the host-side serializeCard call.
   serializeMs?: number;
-  // Wall-clock of the host-side searchDoc call.
+  // Wall-clock of the searchable walk that produced the doc — the first
+  // walk whose loads were all resident/cache hits, so this measures
+  // evaluation rather than loading.
   searchDocMs?: number;
-  // Wall-clock of the searchable load-settle loop that runs before the
-  // timed searchDoc call: the passes that drive the card's searchable-path
-  // link loads (and the links its contained/computed fields read) to
-  // quiescence. Link-load cost lives HERE, not inside `searchDocMs` — by
-  // the time the timed generation runs, its targets are resident. Read
+  // Wall-clock spent driving the card's link loads to quiescence before the
+  // walk that produced the doc: the discarded walk passes and their load
+  // drains. Link-load cost lives HERE, not inside `searchDocMs` — by the
+  // time the doc-producing walk runs, its targets are resident. Read
   // `searchDocLinkLoads` for the per-target breakdown of this time.
+  // Near-zero when the first walk settled.
   searchDocSettleMs?: number;
-  // How many settle passes ran before the store's load generation held
-  // steady. Each pass loads one more dependency-depth wave, so a high count
-  // means a deep searchable/computed link chain (capped host-side; the cap
-  // logs a warning).
+  // How many walk passes were discarded before one ran against a stable
+  // load generation. Each pass loads one more dependency-depth wave, so a
+  // high count means a deep searchable/computed link chain (capped
+  // host-side; the cap logs a warning). Zero when the first walk settled —
+  // the card fired no lazy getter loads.
   searchDocSettlePasses?: number;
   // Per-field inclusive evaluation timings from the timed searchDoc walk,
   // keyed by dotted field path from the indexed card's root (a parent's


### PR DESCRIPTION
## Background

When the indexer builds a card's search doc, the searchable generator walks the card's fields and loads the link targets its `searchable` annotations name. The walk runs inside a prerender tab whose store lives for the whole indexing job, and it repeats until the store's load state is quiescent — a computed that reads a not-yet-loaded link fires a lazy load nothing awaits, so the walk must re-run once that load lands.

Three costs stacked up on link-heavy cards:

1. **Serial loads.** Every link load ran one after another: a card with several independent `searchable` routes — or a wide `linksToMany` — paid one round-trip per target, in sequence.
2. **Re-fetched shared targets.** A target shared by many cards (one policy card referenced by hundreds of claim cards) re-fetched over the network whenever the tab's GC sweep had evicted it between references.
3. **Redundant walks.** The settle loop required two consecutive stable passes and then a separate walk produced the doc — so even a card with no links at all paid three full walks, and every card paid at least one walk more than its link depth required.

On the 885-instance benchmark realm, the settle column summed to 37 s across a calm from-scratch index (avg 2.46 passes/card; 9.2 s of that was actual loading) and 55.6 s on a contended one. The heaviest rows (aggregation cards over wide linked sets) spent 1.2–1.6 s across 4 passes while performing **zero** loads — pure walk repetition.

## What this PR does

**Concurrent link loads** (`packages/base/searchable.ts`). Independent branches of the walk — a card's fields, a plural field's slots, a `containsMany`'s items — run concurrently, so their loads overlap; a route's own segments stay sequential (each hop needs the previous target). The doc is assembled in declaration/slot order regardless of completion order, so the output is unchanged. All branches settle before the first rejection rethrows: a throwing branch (typically a computed reading a link whose load is still in flight) no longer prevents sibling branches from starting their loads, and no rejection is left floating for the prerender tab's fatal unhandled-rejection handler.

**Job-scoped wire-document cache** (`packages/host/app/lib/gc-card-store.ts`). Successful card-source / file-meta documents are cached by URL for the lifetime of the indexing job (`__boxelRenderContext` + `__boxelJobId` gate — the same gate the resolved-doc search cache uses; the live app never touches it). Within one job the realm's source files are stable — a mid-job write is picked up by the follow-up job its invalidation enqueues — so a shared link target fetches once per job; when the GC sweep evicts its instance, the re-load becomes a local deserialize instead of a network round-trip. Entries are cloned on read and write so consumers can't cross-mutate, LRU-capped, cleared the first time a different job id is observed, and generation-guarded so a load resolving across a job boundary can't seed the next job's cache.

**Walk-until-stable** (`packages/host/app/routes/render/meta.ts`). The settle loop and the authoritative walk merge into one loop: the first walk that leaves the store's load generation unmoved is the authoritative result. A walk is a pure function of the store's settled load state, so one stable pass suffices — unlike a template render, whose afterRender hooks can schedule further work (the `/render` route's template settle keeps its two-stable-pass requirement). The generator's targeted loads are `untracked`: the walk consumes them inline, so they no longer count as instability and don't force an extra pass. Link-free cards produce their doc in **one walk instead of three**.

## Diagnostics

Field names and types are unchanged; their meanings follow the merged loop:

- `searchDocMs` — the doc-producing walk (its loads are resident/cache hits, so it measures evaluation).
- `searchDocSettleMs` / `searchDocSettlePasses` — the discarded walks and their load drains. The healthy floor for passes is **0** (a card whose first walk fires no lazy getter loads); dashboards tracking pass counts will see the drop.
- `searchDocLinkLoads` — still one entry per performed load; concurrent entries overlap in time, so they don't sum to wall-clock. Cache hits record near-zero and are floor-pruned, which is what makes the cache's effect visible per row.

The `indexing-diagnostics` skill's Mode J and field reference are updated to match.

## Tests

- `packages/host/tests/unit/job-scoped-doc-cache-test.ts` — cache hit/miss, jobId-change clear, no-cache outside prerender/without job id, error results not pinned, `reset()` clear, mutation isolation, `untracked` leaving the load generation unmoved, file-meta symmetry.
- `packages/host/tests/integration/searchable-search-doc-test.gts` — the full searchable suite passes unchanged (route shapes, cycles, broken links, declared-type enumeration, parity), plus a test pinning that a throwing branch does not stop sibling link loads within the same walk.
- `packages/realm-server/tests/prerendering-test.ts` — the settle-aggregate diagnostics assertions follow the walk-until-stable contract (passes ≥ 0).
- `packages/realm-server/tests/prerendering-test.ts` + `indexing-test.ts` module runs against the full local stack.
