### PR TITLE
Add a Skill entry to the code-mode create-file modal

### DIFF
--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -29,6 +29,7 @@ import {
   CardInstance,
   File,
   Field,
+  Sparkle,
 } from '@cardstack/boxel-ui/icons';
 
 import {
@@ -82,6 +83,7 @@ export type NewFileType =
   | 'field-definition'
   | 'file-definition'
   | 'text-file'
+  | 'skill'
   | 'spec-instance';
 
 export const newFileTypes: {
@@ -123,6 +125,12 @@ export const newFileTypes: {
     icon: File,
     description: 'For plain text or markdown',
     extension: '.txt/.md',
+  },
+  {
+    id: 'skill',
+    icon: Sparkle,
+    description: 'For teaching the AI assistant',
+    extension: '.md',
   },
   { id: 'spec-instance', extension: '.json' },
 ];
@@ -188,6 +196,7 @@ export default class CreateFileModal extends Component<Signature> {
                   (and
                     (not (eq this.fileType.id 'duplicate-instance'))
                     (not (eq this.fileType.id 'text-file'))
+                    (not (eq this.fileType.id 'skill'))
                   )
                 }}
                   <FieldContainer
@@ -220,6 +229,29 @@ export default class CreateFileModal extends Component<Signature> {
                       {{/if}}
                     </div>
                   </FieldContainer>
+                {{/if}}
+                {{#if (eq this.fileType.id 'skill')}}
+                  <FieldContainer
+                    @label='Skill Name'
+                    @tag='label'
+                    class='field'
+                  >
+                    <BoxelInput
+                      data-skill-name-field
+                      data-test-skill-name-field
+                      placeholder='Trip Planner'
+                      @value={{this.displayName}}
+                      @state={{this.fileNameInputState}}
+                      @errorMessage={{this.fileNameError}}
+                      @onInput={{this.setDisplayName}}
+                    />
+                  </FieldContainer>
+                  {{#if this.skillFilePath}}
+                    <p class='skill-file-path' data-test-skill-file-path>
+                      Will be created as
+                      <code>{{this.skillFilePath}}</code>
+                    </p>
+                  {{/if}}
                 {{/if}}
                 {{#if (eq this.fileType.id 'text-file')}}
                   <FieldContainer @label='File Name' @tag='label' class='field'>
@@ -378,6 +410,18 @@ export default class CreateFileModal extends Component<Signature> {
                     >
                       Create
                     </Button>
+                  {{else if (eq this.fileType.id 'skill')}}
+                    <Button
+                      @kind='primary'
+                      @size='tall'
+                      @loading={{this.createSkillFile.isRunning}}
+                      @disabled={{this.isCreateSkillFileButtonDisabled}}
+                      {{on 'click' (perform this.createSkillFile)}}
+                      {{onKeyMod 'Enter'}}
+                      data-test-create-skill-file
+                    >
+                      Create
+                    </Button>
                   {{/if}}
                 </div>
               {{/if}}
@@ -454,6 +498,14 @@ export default class CreateFileModal extends Component<Signature> {
       }
       .create-file-error-detail {
         margin-top: var(--boxel-sp);
+      }
+      .skill-file-path {
+        margin: var(--boxel-sp-xs) 0 0;
+        color: var(--boxel-450);
+        font: var(--boxel-font-sm);
+      }
+      .skill-file-path code {
+        color: var(--boxel-600);
       }
     </style>
   </template>
@@ -539,6 +591,7 @@ export default class CreateFileModal extends Component<Signature> {
   private getDefaultSpecId(): string | undefined {
     switch (this.fileType.id) {
       case 'text-file':
+      case 'skill':
       case 'file-definition':
         return undefined;
       case 'field-definition':
@@ -626,6 +679,7 @@ export default class CreateFileModal extends Component<Signature> {
 
   @action private setDisplayName(name: string) {
     this.clearSaveError();
+    this.fileNameError = undefined;
     this.displayName = name;
     if (!this.hasUserEditedFileName) {
       // if the user starts typing in the filename field, then stop helping them
@@ -664,6 +718,8 @@ export default class CreateFileModal extends Component<Signature> {
         return '[data-create-file-modal] [data-realm-dropdown-trigger]';
       case 'text-file':
         return '[data-create-file-modal] [data-text-file-name-field]';
+      case 'skill':
+        return '[data-create-file-modal] [data-skill-name-field]';
       default:
         return false;
     }
@@ -730,11 +786,30 @@ export default class CreateFileModal extends Component<Signature> {
     );
   }
 
+  // The slug the skill name cleanses down to — the directory segment of the
+  // conventional `skills/<slug>/SKILL.md` path.
+  private get skillSlug() {
+    return cleanseString(this.displayName);
+  }
+
+  private get skillFilePath() {
+    return this.skillSlug ? `skills/${this.skillSlug}/SKILL.md` : undefined;
+  }
+
+  private get isCreateSkillFileButtonDisabled() {
+    return (
+      !this.selectedRealmURL ||
+      !this.skillSlug ||
+      this.createSkillFile.isRunning
+    );
+  }
+
   private get isCreateRunning() {
     return (
       this.createCardInstance.isRunning ||
       this.createDefinition.isRunning ||
       this.createTextFile.isRunning ||
+      this.createSkillFile.isRunning ||
       this.duplicateCardInstance.isRunning
     );
   }
@@ -1040,6 +1115,64 @@ export class ${className} extends ${exportName} {
       this.currentRequest.newFileDeferred.fulfill(url);
     } catch (e: any) {
       console.log('Error saving text file', e);
+      this.saveError = e;
+    }
+  });
+
+  // Creates `skills/<slug>/SKILL.md` with starter frontmatter. The
+  // `boxel.kind: skill` key is what makes the file a skill the AI assistant
+  // can load — the path is only a convention (discovery is by the indexed
+  // `kind` field), but following it keeps workspaces legible.
+  private createSkillFile = restartableTask(async () => {
+    if (!this.currentRequest) {
+      throw new Error(
+        `Cannot createSkillFile when there is no this.currentRequest`,
+      );
+    }
+    if (!this.selectedRealmURL) {
+      throw new Error(
+        `bug: cannot call createSkillFile without a selected realm URL`,
+      );
+    }
+    let slug = this.skillSlug;
+    if (!slug) {
+      return;
+    }
+
+    let realmPath = new RealmPaths(new URL(this.selectedRealmURL));
+    let url = realmPath.fileURL(`skills/${slug}/SKILL.md` as LocalPath);
+
+    try {
+      let response = await this.network.authedFetch(url, {
+        headers: { Accept: SupportedMimeType.CardSource },
+      });
+      if (response.ok) {
+        this.fileNameError = `This skill already exists`;
+        return;
+      }
+    } catch (_err: any) {
+      // we expect a 404 here
+    }
+
+    let name = this.displayName.trim();
+    let content = [
+      '---',
+      `name: ${slug}`,
+      'description: Describe when the assistant should use this skill.',
+      'boxel:',
+      '  kind: skill',
+      '---',
+      `# ${name}`,
+      '',
+      'Write the instructions the assistant should follow when this skill is active.',
+      '',
+    ].join('\n');
+
+    try {
+      await this.cardService.saveSource(url, content, 'create-file');
+      this.currentRequest.newFileDeferred.fulfill(url);
+    } catch (e: any) {
+      console.log('Error saving skill file', e);
       this.saveError = e;
     }
   });

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -679,9 +679,12 @@ export default class CreateFileModal extends Component<Signature> {
 
   @action private setDisplayName(name: string) {
     this.clearSaveError();
-    this.fileNameError = undefined;
     this.displayName = name;
     if (!this.hasUserEditedFileName) {
+      // the file name still derives from the display name (always true for
+      // skills, which have no separate filename field), so a filename error
+      // no longer applies once the name changes
+      this.fileNameError = undefined;
       // if the user starts typing in the filename field, then stop helping them
       this.fileName = cleanseString(name);
     }

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -354,7 +354,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
       });
     });
 
-    test('new file button has options to create card def, field def, card instance, text files, and upload file', async function (assert) {
+    test('new file button has options to create card def, field def, card instance, skill, text files, and upload file', async function (assert) {
       await visitOperatorMode();
       await waitFor('[data-test-code-mode][data-test-save-idle]');
       await waitFor('[data-test-new-file-button]');
@@ -364,7 +364,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
         .dom(
           '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text]',
         )
-        .exists({ count: 5 });
+        .exists({ count: 6 });
       assert
         .dom(
           '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Card Definition"]',
@@ -378,6 +378,11 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
       assert
         .dom(
           '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Card Instance"]',
+        )
+        .exists();
+      assert
+        .dom(
+          '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Skill"]',
         )
         .exists();
       assert

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -423,6 +423,31 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
       assert.ok(savedUrls.some((url) => url.endsWith('readme.md')));
     });
 
+    test<TestContextWithSave>('can create a skill file with starter frontmatter', async function (assert) {
+      assert.expect(2);
+      await visitOperatorMode();
+      let deferred = new Deferred<void>();
+
+      this.onSave(async (url, content) => {
+        assert.true(
+          url.href.endsWith('skills/trip-planner/SKILL.md'),
+          'conventional skills/<slug>/SKILL.md path from the cleansed name',
+        );
+        assert.true(
+          (content as string).includes('boxel:\n  kind: skill'),
+          'starter frontmatter marks the file as a skill',
+        );
+        deferred.fulfill();
+      });
+
+      await openNewFileModal('Skill');
+      await fillIn('[data-test-skill-name-field]', 'Trip Planner');
+      await click('[data-test-create-skill-file]');
+      await waitFor('[data-test-create-file-modal]', { count: 0 });
+
+      await deferred.promise;
+    });
+
     test('can upload a file via the New menu', async function (assert) {
       await visitOperatorMode();
       await waitFor('[data-test-code-mode][data-test-save-idle]');


### PR DESCRIPTION
Linear: [CS-12073](https://linear.app/cardstack/issue/CS-12073/code-mode-skill-entry-in-the-create-file-modal-with-a-starter-template)

A "Skill" file type in code mode's New menu: one Skill Name input, a live preview of the conventional `skills/<slug>/SKILL.md` path, and creation with starter frontmatter —

```markdown
---
name: <slug>
description: Describe when the assistant should use this skill.
boxel:
  kind: skill
---
# <Skill Name>

Write the instructions the assistant should follow when this skill is active.
```

The `boxel.kind: skill` key is what makes the file a skill (the path is convention only — discovery is by the indexed `kind` field), so the created file appears in the room skill chooser as soon as incremental indexing picks it up, with no edits required. Pure UI sugar over file creation; no host tool. Pairs with the `boxel-skill-authoring` reference skill (cardstack/boxel-workspaces#20) that teaches the assistant the same contract.

Covered by an acceptance test asserting the path and frontmatter of the saved file.

Draft pending: a screenshot of the modal for reviewers, and a decision on whether the entry should appear in this first cut or ride behind Phase D sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)