### PR TITLE
Recover host session instead of stranding on the login form

### DIFF
--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -105,10 +105,11 @@ export default class Card extends Route {
       this.didMatrixServiceStart = true;
     } else if (this.matrixService.needsPostLoginRecovery) {
       // `start()` above is a one-shot (guarded by `didMatrixServiceStart`). If
-      // `postLoginCompleted` was cleared after that first start while the matrix
-      // client stayed logged in — a `resetState()` racing a re-navigation — the
-      // guard would otherwise strand the app on the login form forever. Re-run
-      // `start()` to re-establish the post-login session before falling through.
+      // `postLoginCompleted` was cleared after that first start while there's
+      // still persisted auth to boot from — a `resetState()` racing a
+      // re-navigation — the guard alone would strand the app on the login form.
+      // Re-run `start()` to re-establish the post-login session before falling
+      // through.
       if (isTesting()) {
         console.warn(
           `[login-diag] index route recovering post-login session: ` +

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -103,6 +103,25 @@ export default class Card extends Route {
       await this.matrixService.ready;
       await this.matrixService.start();
       this.didMatrixServiceStart = true;
+    } else if (this.matrixService.needsPostLoginRecovery) {
+      // `start()` above is a one-shot (guarded by `didMatrixServiceStart`). If
+      // `postLoginCompleted` was cleared after that first start while the matrix
+      // client stayed logged in — a `resetState()` racing a re-navigation — the
+      // guard would otherwise strand the app on the login form forever. Re-run
+      // `start()` to re-establish the post-login session before falling through.
+      if (isTesting()) {
+        console.warn(
+          `[login-diag] index route recovering post-login session: ` +
+            JSON.stringify(this.matrixService.loginReadinessDebug),
+        );
+      }
+      await this.matrixService.start();
+      if (isTesting() && !this.matrixService.isLoggedIn) {
+        console.warn(
+          `[login-diag] index route post-login recovery did not restore session: ` +
+            JSON.stringify(this.matrixService.loginReadinessDebug),
+        );
+      }
     }
 
     if (!this.matrixService.isLoggedIn) {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -503,6 +503,19 @@ export default class MatrixService extends Service {
     return this._client?.isLoggedIn() === true && this.postLoginCompleted;
   }
 
+  // True when there's persisted auth to boot from but the post-login boot never
+  // finished (or was undone). `start()` sets `postLoginCompleted`, and the index
+  // route only calls `start()` once, so if `postLoginCompleted` is cleared
+  // afterward — a `resetState()` racing a re-navigation — nothing re-establishes
+  // the session and the route would strand the app on the login form. A route
+  // that sees this can re-run `start()` to recover; `start()` re-derives the
+  // client from the persisted auth, so it recovers even when `resetState()` left
+  // a bare (logged-out) client behind. A genuine logout clears the persisted
+  // auth, so `getAuth()` is empty there and this stays false.
+  get needsPostLoginRecovery() {
+    return !this.postLoginCompleted && Boolean(this.getAuth());
+  }
+
   // Test-only diagnostic for the intermittent "operator-mode renders the login
   // form" flake: names which precondition of `isLoggedIn` is unmet when a route
   // decides to render <Auth/>, plus a compact tail of the `postLoginCompleted`
@@ -1149,7 +1162,14 @@ export default class MatrixService extends Service {
         this.scheduleUnreachableRealmServerRetry();
       } catch (e) {
         console.log('Error starting Matrix client', e);
-        await this.logout();
+        // Only tear the session down for a failure that happened before login
+        // completed. A late, post-login rejection must not unwind an already-
+        // established session: logout() clears realm state the app has already
+        // populated and resets postLoginCompleted, which would strand the index
+        // route on the login form.
+        if (!this.postLoginCompleted) {
+          await this.logout();
+        }
       }
 
       let indexController = getOwner(this)!.lookup(

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -989,6 +989,14 @@ export default class MatrixService extends Service {
       this.saveAuth(auth);
       this.bindEventListeners();
 
+      // Whether *this* start() invocation completed the post-login boot. The
+      // catch below keys off this, not the `postLoginCompleted` field, because
+      // start() can run again on an already-established session (e.g. the
+      // /connect route starts on every visit): the field would still be true
+      // from the previous run, so a fresh attempt that fails before completing
+      // would wrongly skip logout and leave revoked auth in storage.
+      let loginCompletedThisRun = false;
+
       try {
         let deviceId = this.client.getDeviceId();
         if (deviceId) {
@@ -1154,6 +1162,7 @@ export default class MatrixService extends Service {
         await this.loginToRealms();
 
         this.setPostLoginCompleted(true, 'start-success');
+        loginCompletedThisRun = true;
         if (isTesting()) console.warn('[start-phase] postLoginCompleted=true');
 
         // If any trusted server was unreachable during boot assembly, keep
@@ -1162,12 +1171,12 @@ export default class MatrixService extends Service {
         this.scheduleUnreachableRealmServerRetry();
       } catch (e) {
         console.log('Error starting Matrix client', e);
-        // Only tear the session down for a failure that happened before login
-        // completed. A late, post-login rejection must not unwind an already-
-        // established session: logout() clears realm state the app has already
-        // populated and resets postLoginCompleted, which would strand the index
-        // route on the login form.
-        if (!this.postLoginCompleted) {
+        // Only tear the session down for a failure that happened before this
+        // run completed login. A late, post-login rejection must not unwind an
+        // already-established session: logout() clears realm state the app has
+        // already populated and resets postLoginCompleted, which would strand
+        // the index route on the login form.
+        if (!loginCompletedThisRun) {
           await this.logout();
         }
       }

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -511,9 +511,11 @@ export default class MatrixService extends Service {
   // that sees this can re-run `start()` to recover; `start()` re-derives the
   // client from the persisted auth, so it recovers even when `resetState()` left
   // a bare (logged-out) client behind. A genuine logout clears the persisted
-  // auth, so `getAuth()` is empty there and this stays false.
+  // auth, so this stays false there. The index route reads this on every model
+  // refresh, so it only tests for the auth key's presence — the value is never
+  // parsed here.
   get needsPostLoginRecovery() {
-    return !this.postLoginCompleted && Boolean(this.getAuth());
+    return !this.postLoginCompleted && Boolean(this.storage?.getItem('auth'));
   }
 
   // Test-only diagnostic for the intermittent "operator-mode renders the login

--- a/packages/host/tests/acceptance/basic-test.gts
+++ b/packages/host/tests/acceptance/basic-test.gts
@@ -1,4 +1,4 @@
-import { click, find, visit, waitFor } from '@ember/test-helpers';
+import { click, find, settled, visit, waitFor } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -113,6 +113,39 @@ module('Acceptance | basic tests', function (hooks) {
     assert
       .dom('[data-test-operator-mode-stack="0"] [data-test-index-card]')
       .containsText('Hello, world');
+  });
+
+  test('recovers to the app when postLoginCompleted is cleared after boot', async function (assert) {
+    await visit('/');
+    assert
+      .dom('[data-test-workspace-chooser]')
+      .exists('app booted and rendered before the reset');
+
+    // Reproduce the post-boot login-reset race deterministically. The persisted
+    // auth is left intact (a genuine logout clears it), but postLoginCompleted
+    // gets cleared — exactly what a resetState() racing a re-navigation does.
+    // The <Auth/> gate is reactive, so the app swaps to the login form at once.
+    let matrixService = getService('matrix-service');
+    matrixService.resetState();
+    await settled();
+    assert
+      .dom('[data-test-login-form]')
+      .exists('clearing postLoginCompleted strands the app on the login form');
+
+    // Re-run the index route model (as any re-navigation would). The one-shot
+    // start() guard already latched on boot, so without the recovery path the
+    // route would render <Auth/> forever; with it, the session re-establishes.
+    await getService('router').refresh();
+    await settled();
+
+    assert
+      .dom('[data-test-login-form]')
+      .doesNotExist(
+        'the index route recovers the session instead of stranding',
+      );
+    assert
+      .dom('[data-test-workspace-chooser]')
+      .exists('recovered back to the booted app');
   });
 
   test('submode switcher exposes an app version tooltip', async function (assert) {

--- a/packages/host/tests/acceptance/basic-test.gts
+++ b/packages/host/tests/acceptance/basic-test.gts
@@ -133,8 +133,9 @@ module('Acceptance | basic tests', function (hooks) {
       .exists('clearing postLoginCompleted strands the app on the login form');
 
     // Re-run the index route model (as any re-navigation would). The one-shot
-    // start() guard already latched on boot, so without the recovery path the
-    // route would render <Auth/> forever; with it, the session re-establishes.
+    // start() guard already latched on boot, so re-establishing the session is
+    // the only path back to the app — assert the route takes it rather than
+    // rendering <Auth/>.
     await getService('router').refresh();
     await settled();
 


### PR DESCRIPTION
When the host app boots, the index route calls the matrix service's `start()` exactly once, guarded by a `didMatrixServiceStart` flag. `start()` finishes by setting `postLoginCompleted = true`, and the app is only considered logged in when both the matrix client is authenticated **and** that flag is set.

The problem is what happens if `postLoginCompleted` gets flipped back to `false` *after* that one-shot start. `resetState()` clears the flag (and recreates a bare matrix client), and in the acceptance suite a `resetState()` from one test's teardown can land while the next test is already booting. Because the one-shot guard has already latched, the index route never re-runs `start()` — so it renders the login form and stays there. The matrix client is still authenticated the whole time; only the post-login flag is missing. An in-flight `_info` request that was orphaned by the reset never settles, which keeps a test waiter open and hangs the test until it times out five minutes later.

This is the intermittent "acceptance test times out sitting on the login form" flake. The login-timeout diagnostic's `postLoginCompleted` transition trace shows the trigger: the last transition before the hang is `→false via resetState`, with no `start()` afterward to recover.

## Changes

- **The index route now recovers instead of stranding.** When it would render the login form but there's persisted auth and `postLoginCompleted` is unset, it re-runs `start()` to re-establish the session. `start()` re-derives the client from the stored auth, so this recovers even when the reset left a bare, logged-out client behind. A genuine logout clears the stored auth, so recovery correctly does not fire there.
- **A post-login error in `start()` no longer tears the session down.** The catch now only calls `logout()` when login had not yet completed. A late/post-login rejection must not unwind an already-established session — `logout()` clears realm state the app is relying on and resets `postLoginCompleted`, which is another way to reach the same stranded-on-login state.
- **Diagnostics on the recovery path.** Test-only log lines record when the route attempts recovery and, if `start()` still doesn't restore the session, the login-readiness state it left behind — so a future failure that slips past this fix is still diagnosable.
- **A regression test** drives the exact strand deterministically: boot the app, clear `postLoginCompleted` while auth stays intact, re-run the route, and assert it recovers to the app instead of the login form.

## Testing

Run locally against the test-services stack:

- `pnpm --dir packages/host lint:types` — clean.
- `Acceptance | basic tests` (including the new regression test) — 4/4 pass; the recovery path's diagnostic fires as expected.
- The regression test **fails** when the recovery branch is removed, confirming it guards the real behavior.
- `Acceptance | Spec preview` (the module that produced the CI timeout) — 28 tests, 26 pass, 2 pre-existing skips, 0 fail, including `renders linked examples in isolated spec view when user can write (via view instance)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
