### PR TITLE
Ignore background re-index events in the index-event-ignored acceptance test

### DIFF
--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -1318,24 +1318,30 @@ module('Acceptance | interact submode tests', function (hooks) {
       });
       const messageService = getService('message-service');
       const receivedEventDeferred = new Deferred<void>();
+      let handledIncrementalEvent = false;
       messageService.listenerCallbacks
         .get(testRealmURL)!
         .push((ev: RealmEventContent) => {
-          if (ev.eventName === 'update') {
-            // eslint-disable-next-line qunit/no-early-return
-            return; // ignore file update events
-          }
+          // React only to the incremental index event produced by this
+          // edit. File "update" events, the "incremental-index-initiation"
+          // event that precedes indexing, and any from-scratch ("full") or
+          // "copy" re-index of this realm all reach this listener too — the
+          // re-index events carry no clientRequestId and would fail the
+          // assertions below — so ignore everything that is not the single
+          // incremental event under test.
           if (
-            ev.eventName === 'index' &&
-            ev.indexType === 'incremental-index-initiation'
+            handledIncrementalEvent ||
+            ev.eventName !== 'index' ||
+            ev.indexType !== 'incremental'
           ) {
             // eslint-disable-next-line qunit/no-early-return
-            return; // ignore the index initiation event
+            return;
           }
+          handledIncrementalEvent = true;
           ev = ev as IncrementalIndexEventContent;
           assert.ok(
             ev.clientRequestId,
-            'client request ID is included in event',
+            `client request ID is included in event: ${JSON.stringify(ev)}`,
           );
           assert.strictEqual(
             ev.eventName,

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -1318,10 +1318,9 @@ module('Acceptance | interact submode tests', function (hooks) {
       });
       const messageService = getService('message-service');
       const receivedEventDeferred = new Deferred<void>();
-      let handledIncrementalEvent = false;
-      messageService.listenerCallbacks
-        .get(testRealmURL)!
-        .push((ev: RealmEventContent) => {
+      const unsubscribe = messageService.subscribe(
+        testRealmURL,
+        (ev: RealmEventContent) => {
           // React only to the incremental index event produced by this
           // edit. File "update" events, the "incremental-index-initiation"
           // event that precedes indexing, and any from-scratch ("full") or
@@ -1329,15 +1328,13 @@ module('Acceptance | interact submode tests', function (hooks) {
           // re-index events carry no clientRequestId and would fail the
           // assertions below — so ignore everything that is not the single
           // incremental event under test.
-          if (
-            handledIncrementalEvent ||
-            ev.eventName !== 'index' ||
-            ev.indexType !== 'incremental'
-          ) {
+          if (ev.eventName !== 'index' || ev.indexType !== 'incremental') {
             // eslint-disable-next-line qunit/no-early-return
             return;
           }
-          handledIncrementalEvent = true;
+          // Stop listening once the incremental event is handled so a later
+          // event can't re-run these assertions and overrun assert.expect(6).
+          unsubscribe();
           ev = ev as IncrementalIndexEventContent;
           assert.ok(
             ev.clientRequestId,
@@ -1359,7 +1356,8 @@ module('Acceptance | interact submode tests', function (hooks) {
             'invalidations are correct',
           ); // the card that was edited
           receivedEventDeferred.fulfill();
-        });
+        },
+      );
       await click('[data-test-edit-button]');
       fillIn('[data-test-field="firstName"] input', 'FadhlanXXX');
       let inputElement = find(


### PR DESCRIPTION
## What this fixes

The host acceptance test **"stack item edit results in index event that is ignored"** fails intermittently in CI.

When you edit a card, the host saves it, which makes the realm run an *incremental* index. The index result comes back to the browser as a realm event tagged with the client's request id, and the host uses that id to recognize "this change came from me" and skip re-rendering — which is what keeps the text cursor and selection in place while you type. The test drives an edit, listens for that index event, and asserts the event carries a `clientRequestId`.

The problem is what else can arrive on that same realm-event channel. A realm can also broadcast a *from-scratch* (`full`) or `copy` re-index event, and those carry **no** `clientRequestId` by design. The test's listener only skipped file `update` events and the `incremental-index-initiation` pre-event, so whenever a background re-index of the test realm happened to fire while the test was running, that event slipped through to the assertion and failed it. Background re-indexes are exactly what the startup/login recovery churn produces, so the failure showed up as flakiness rather than a hard fail.

## The change

The listener now reacts only to the single `incremental` index event the edit produces and ignores every other realm event (updates, the initiation pre-event, and `full`/`copy` re-indexes). A one-shot guard makes the assertion block run exactly once, so a second qualifying event can't overrun `assert.expect(6)`.

This narrows *what the test reacts to* without weakening *what it checks* — the incremental event still has to carry a `clientRequestId`, be named `index`, be of type `incremental`, and invalidate the edited card.

## Diagnostics

If an `incremental` event ever does arrive without a `clientRequestId` (a real regression rather than a stray re-index), the assertion message now prints the full event payload so the next failure shows exactly what reached the listener instead of just "expected true".
