### PR TITLE
Fix flaky matrix head-tags test: gate published-realm navigation on prerender readiness

### DIFF
--- a/packages/matrix/tests/head-tags.spec.ts
+++ b/packages/matrix/tests/head-tags.spec.ts
@@ -85,6 +85,13 @@ test.describe('Head tags', () => {
 
     let publishedRealmURLString = `https://${user.username}.localhost:4205/new-workspace/index`;
 
+    // Publishing returns before the published realm finishes re-indexing and
+    // prerendering, so a cold navigation races that work — the served HTML can
+    // still be missing its head tags, which surfaces here as the og:title
+    // element not being found. Gate on the SSR marker so the document render is
+    // warm before the browser asks for it.
+    await waitForPublishedMarker(page, publishedRealmURLString, 'og:title');
+
     await page.goto(publishedRealmURLString);
 
     await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(


### PR DESCRIPTION
## Background

Publishing a realm returns before the published realm finishes re-indexing and prerendering, so navigating to a freshly published realm "cold" races that work — the served HTML can still be missing its prerendered head tags.

## The flake

The "the HTML response from a published realm has relevant meta tags" test navigated to the published realm immediately after publishing and asserted on `og:title`. Intermittently that meta element was not yet in the document, surfacing as `element(s) not found`.

## The fix

Gate the navigation on `waitForPublishedMarker` — the same readiness probe the sibling host-mode head-tags test in this file already uses and documents — so the published document is prerendered before the browser asks for it.

## Testing

`packages/matrix` type-checks clean; CI exercises the published-realm flow.
