### PR TITLE
Fix flaky whole-realm parse discovery test via indexer-settled seeding

### DIFF
--- a/packages/software-factory/src/parse-execution.ts
+++ b/packages/software-factory/src/parse-execution.ts
@@ -280,6 +280,17 @@ export async function discoverJsonExampleFiles(
       }
     }
   }
+  // Diagnostic: whole-realm JSON discovery hinges on the Spec index being
+  // caught up. Source POST indexing is async, so a caller that just wrote a
+  // Spec can observe it in search before its `linkedExamples` link resolves,
+  // surfacing here as Spec cards found but zero example URLs — which silently
+  // drops those examples from the parse set. Logging the shape of each
+  // discovery makes that gap visible when tracing why an example went
+  // unchecked (a Spec legitimately having no examples looks identical, so
+  // this stays at debug rather than warning).
+  log.debug(
+    `spec discovery: totalSpecCards=${result.totalSpecCards ?? 'n/a'} specs=${result.specs.length} exampleUrls=${urls.length}`,
+  );
   return urls.sort((a, b) => a.localeCompare(b));
 }
 

--- a/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
+++ b/packages/software-factory/tests/helpers/instantiate-test-fixtures.ts
@@ -5,12 +5,12 @@
  * tool). Keeping the card modules, examples, and specs in one place ensures
  * the two surfaces are exercised against identical inputs.
  */
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { dirname, isAbsolute, join } from 'node:path';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
-import { expect } from '@playwright/test';
+
+import { seedFilesAndWaitForIndex } from './seed-and-wait-for-index.ts';
 
 // ---------------------------------------------------------------------------
 // Card modules
@@ -183,95 +183,6 @@ export function tagsCardSpecJson(): string {
 // ---------------------------------------------------------------------------
 // Seeding helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Stage the given files in a fresh temp dir and push them to the realm
- * with `client.sync(..., { preferLocal: true, waitForIndex: true })`.
- * The `_atomic` upload appends `?waitForIndex=true`, so the realm-server
- * returns only after the indexer has processed every uploaded file.
- *
- * Why this shape instead of per-file `client.write` + a search-poll
- * gate: realm-side source POST indexing is async, so writing files
- * one-by-one and waiting for the realm to ack with GET (or for the
- * downstream `_federated-search` to surface them) is a polling race —
- * which is exactly the flake this skill was filed to address. CI
- * evidence on PR #4782 (run 25768256725) showed even a 90s poll
- * sometimes never sees the Spec surface in search. The `_atomic`
- * waitForIndex query param is the realm-server's first-class hook for
- * read-after-write consistency in tests; using it here trades a
- * one-shot push latency for a deterministic "indexer is settled"
- * boundary.
- */
-async function seedFilesAndWaitForIndex(
-  client: BoxelCLIClient,
-  realmUrl: string,
-  files: { path: string; content: string }[],
-): Promise<void> {
-  for (let { path } of files) {
-    if (isAbsolute(path) || path.split('/').includes('..')) {
-      throw new Error(
-        `seedFilesAndWaitForIndex path must be a realm-relative path under the staging dir; got ${JSON.stringify(path)}`,
-      );
-    }
-  }
-
-  // Retry the sync once on failure. The realm-server's /_atomic
-  // endpoint can return 500 ("Write Error") for transient causes —
-  // for example a concurrent indexing pass or a worker-side
-  // fileSerialization that doesn't recur on retry — and a one-shot
-  // retry with a short backoff lets the helper recover instead of
-  // surfacing the failure as a confusing test flake.
-  //
-  // Each attempt uses a fresh staging dir: `RealmSyncer` writes
-  // `.boxel-sync.json` even when the batch failed, recording hashes
-  // for the staged files. A retry against the same dir would see
-  // those hashes match the (unchanged) local files, classify the
-  // entries as "unchanged locally / deleted remotely" (since the
-  // failed batch never actually wrote them), and with `preferLocal:
-  // true` resolve as a noop — silently skipping the upload while
-  // reporting success. Fresh dir = no stale manifest = honest
-  // re-upload on attempt 2.
-  const maxAttempts = 2;
-  let syncResult: Awaited<ReturnType<typeof client.sync>> | undefined;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    let stagingDir = mkdtempSync(join(tmpdir(), 'sf-instantiate-seed-'));
-    try {
-      for (let { path, content } of files) {
-        let absolute = join(stagingDir, path);
-        mkdirSync(dirname(absolute), { recursive: true });
-        writeFileSync(absolute, content);
-      }
-      syncResult = await client.sync(realmUrl, stagingDir, {
-        preferLocal: true,
-        waitForIndex: true,
-      });
-    } finally {
-      rmSync(stagingDir, { recursive: true, force: true });
-    }
-    if (!syncResult.hasError) {
-      if (attempt > 1) {
-        console.log(
-          `seedFilesAndWaitForIndex: sync succeeded on attempt ${attempt}/${maxAttempts} for ${realmUrl}`,
-        );
-      }
-      break;
-    }
-    console.log(
-      `seedFilesAndWaitForIndex: sync attempt ${attempt}/${maxAttempts} for ${realmUrl} failed: ${
-        syncResult.error ?? '(no error message)'
-      }`,
-    );
-    if (attempt < maxAttempts) {
-      await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
-    }
-  }
-  expect(
-    syncResult!.hasError,
-    `seed sync to ${realmUrl} reported an error after ${maxAttempts} attempt(s): ${
-      syncResult!.error ?? '(no error message)'
-    }`,
-  ).toBe(false);
-}
 
 /**
  * Seed `instantiate-test-card.gts` + one linked example + a Spec that

--- a/packages/software-factory/tests/helpers/seed-and-wait-for-index.ts
+++ b/packages/software-factory/tests/helpers/seed-and-wait-for-index.ts
@@ -1,0 +1,109 @@
+/**
+ * Seed files into a realm and block until the indexer has settled.
+ *
+ * Stages the given files in a fresh temp dir and pushes them with
+ * `client.sync(..., { preferLocal: true, waitForIndex: true })`. The
+ * `_atomic` upload appends `?waitForIndex=true`, so the realm-server
+ * returns only after the indexer has processed every uploaded file —
+ * including resolving a Spec's `linkedExamples` links to the examples
+ * seeded in the same batch.
+ *
+ * Tests that assert on indexed state (search results, whole-realm
+ * spec/example discovery) need this boundary. A per-file `client.write` +
+ * `waitForFile` gate does not provide it: `waitForFile` polls a source
+ * GET, which succeeds the moment the file lands on disk, while indexing
+ * runs asynchronously afterward with no ordering guarantee relative to a
+ * subsequent read. A search or `_federated-search` issued off
+ * source-existence can therefore miss a freshly-written card regardless
+ * of how long it polls. The `_atomic` waitForIndex query param is the
+ * realm-server's first-class hook for read-after-write consistency in
+ * tests, trading a one-shot push latency for a deterministic "indexer is
+ * settled" boundary.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join } from 'node:path';
+
+import type { BoxelCLIClient } from '@cardstack/boxel-cli/api';
+import { expect } from '@playwright/test';
+
+export async function seedFilesAndWaitForIndex(
+  client: BoxelCLIClient,
+  realmUrl: string,
+  files: { path: string; content: string }[],
+): Promise<void> {
+  for (let { path } of files) {
+    let segments = path.split('/');
+    // Every path must resolve to a concrete file directly under the staging
+    // dir: no absolute paths, no `..` escape, and no empty segment — the
+    // latter rejects the empty string, a leading/trailing slash, and
+    // doubled slashes, all of which would otherwise target the staging dir
+    // root or an ambiguous location rather than a named file.
+    if (
+      isAbsolute(path) ||
+      segments.includes('..') ||
+      segments.some((segment) => segment === '')
+    ) {
+      throw new Error(
+        `seedFilesAndWaitForIndex path must be a non-empty realm-relative file path with no absolute, "..", or empty segments; got ${JSON.stringify(path)}`,
+      );
+    }
+  }
+
+  // Retry the sync once on failure. The realm-server's /_atomic
+  // endpoint can return 500 ("Write Error") for transient causes —
+  // for example a concurrent indexing pass or a worker-side
+  // fileSerialization that doesn't recur on retry — and a one-shot
+  // retry with a short backoff lets the helper recover instead of
+  // surfacing the failure as a confusing test flake.
+  //
+  // Each attempt uses a fresh staging dir: `RealmSyncer` writes
+  // `.boxel-sync.json` even when the batch failed, recording hashes
+  // for the staged files. A retry against the same dir would see
+  // those hashes match the (unchanged) local files, classify the
+  // entries as "unchanged locally / deleted remotely" (since the
+  // failed batch never actually wrote them), and with `preferLocal:
+  // true` resolve as a noop — silently skipping the upload while
+  // reporting success. Fresh dir = no stale manifest = honest
+  // re-upload on attempt 2.
+  const maxAttempts = 2;
+  let syncResult: Awaited<ReturnType<typeof client.sync>> | undefined;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let stagingDir = mkdtempSync(join(tmpdir(), 'sf-seed-'));
+    try {
+      for (let { path, content } of files) {
+        let absolute = join(stagingDir, path);
+        mkdirSync(dirname(absolute), { recursive: true });
+        writeFileSync(absolute, content);
+      }
+      syncResult = await client.sync(realmUrl, stagingDir, {
+        preferLocal: true,
+        waitForIndex: true,
+      });
+    } finally {
+      rmSync(stagingDir, { recursive: true, force: true });
+    }
+    if (!syncResult.hasError) {
+      if (attempt > 1) {
+        console.log(
+          `seedFilesAndWaitForIndex: sync succeeded on attempt ${attempt}/${maxAttempts} for ${realmUrl}`,
+        );
+      }
+      break;
+    }
+    console.log(
+      `seedFilesAndWaitForIndex: sync attempt ${attempt}/${maxAttempts} for ${realmUrl} failed: ${
+        syncResult.error ?? '(no error message)'
+      }`,
+    );
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
+    }
+  }
+  expect(
+    syncResult!.hasError,
+    `seed sync to ${realmUrl} reported an error after ${maxAttempts} attempt(s): ${
+      syncResult!.error ?? '(no error message)'
+    }`,
+  ).toBe(false);
+}

--- a/packages/software-factory/tests/run-parse-in-memory.spec.ts
+++ b/packages/software-factory/tests/run-parse-in-memory.spec.ts
@@ -11,6 +11,7 @@ import {
   VALID_EXAMPLE_JSON,
   VALID_MODULE_GTS,
 } from './helpers/parse-test-fixtures.ts';
+import { seedFilesAndWaitForIndex } from './helpers/seed-and-wait-for-index.ts';
 import { buildTestClient } from './helpers/test-client.ts';
 import { createTestWorkspace } from './helpers/workspace-fixture.ts';
 
@@ -98,45 +99,18 @@ test.describe('runParseInMemory e2e', () => {
     try {
       await clearParseableFixtures(client, realmUrl);
 
-      // Seed: one clean GTS module, a Spec pointing at a valid JSON example.
-      let writeModule = await client.write(
-        realmUrl,
-        'parse-test-card.gts',
-        VALID_MODULE_GTS,
-      );
-      expect(writeModule.ok).toBe(true);
-      expect(
-        await client.waitForFile(realmUrl, 'parse-test-card.gts', {
-          pollMs: 300,
-          timeoutMs: 30_000,
-        }),
-      ).toBe(true);
-
-      let writeExample = await client.write(
-        realmUrl,
-        'ParseTestCard/example-1.json',
-        VALID_EXAMPLE_JSON,
-      );
-      expect(writeExample.ok).toBe(true);
-      expect(
-        await client.waitForFile(realmUrl, 'ParseTestCard/example-1.json', {
-          pollMs: 300,
-          timeoutMs: 30_000,
-        }),
-      ).toBe(true);
-
-      let writeSpec = await client.write(
-        realmUrl,
-        'Spec/parse-test-spec.json',
-        validSpecJson(),
-      );
-      expect(writeSpec.ok).toBe(true);
-      expect(
-        await client.waitForFile(realmUrl, 'Spec/parse-test-spec.json', {
-          pollMs: 300,
-          timeoutMs: 30_000,
-        }),
-      ).toBe(true);
+      // Seed one clean GTS module, a valid JSON example, and a Spec that
+      // links the example — in a single indexer-settled batch. Whole-realm
+      // parse discovers JSON examples through `_federated-search` on Spec
+      // cards, so the Spec must be indexed with its `linkedExamples` link
+      // resolved before discovery runs. `seedFilesAndWaitForIndex` provides
+      // that boundary; a source-existence gate (`write` + `waitForFile`)
+      // does not, since a card can be on disk yet not yet searchable.
+      await seedFilesAndWaitForIndex(client, realmUrl, [
+        { path: 'parse-test-card.gts', content: VALID_MODULE_GTS },
+        { path: 'ParseTestCard/example-1.json', content: VALID_EXAMPLE_JSON },
+        { path: 'Spec/parse-test-spec.json', content: validSpecJson() },
+      ]);
 
       workspace = createTestWorkspace();
       await client.pull(realmUrl, workspace.dir);


### PR DESCRIPTION
## What

Fixes an intermittent failure in the software-factory Playwright suite:

```
run-parse-in-memory.spec.ts › runParseInMemory e2e ›
  clean realm returns status: passed with no realm artifacts

Error: expect(received).toContain(expected)
Expected value: "ParseTestCard/example-1.json"
Received array: ["parse-test-card.gts"]
```

## Background

`runParseInMemory` does whole-realm parse discovery in two parts:

- `.gts` / `.gjs` / `.ts` modules come from the realm's source file
  listing (`_mtimes`).
- `.json` example instances are discovered indirectly — it runs
  `_federated-search` for `Spec` cards and follows each Spec's
  `linkedExamples` links.

The JSON path therefore depends on the realm's **index** being caught
up, not just on the source files existing.

## Root cause

The failing test seeded its module, example, and Spec with per-file
`client.write` followed by `client.waitForFile`. `waitForFile` polls a
source GET, which succeeds the moment the file lands on disk — it says
nothing about whether the card has been indexed and is searchable.
Realm-side source-POST indexing runs asynchronously afterward with no
ordering guarantee relative to a following read, so the subsequent
`_federated-search` can run before the Spec (or its resolved
`linkedExamples` link) is in the index. When that happens, discovery
finds no example, the example is absent from `parseableFiles`, and the
`toContain` assertion fails — intermittently, since indexing usually
wins the race.

## Fix

- Seed the module + example + Spec in one
  `client.sync(..., { waitForIndex: true })` batch. The `_atomic`
  `?waitForIndex=true` hook returns only after the indexer has processed
  every uploaded file, including resolving a Spec's `linkedExamples` to
  examples uploaded in the same batch — a deterministic "indexer settled"
  boundary. `run-instantiate-in-memory.spec.ts` seeds through the same
  hook for the same read-after-write reason; this extracts the shared
  `seedFilesAndWaitForIndex` helper into `tests/helpers` so both specs use
  one implementation.
- Add a debug-level log to `discoverJsonExampleFiles` recording the shape
  of each discovery (`totalSpecCards` / specs / example URLs). The
  agent-facing `run_parse` path can't use `waitForIndex` and can still
  race a just-written Spec, so this makes a silently-dropped example
  diagnosable there. It stays at debug because a Spec legitimately having
  no examples is indistinguishable from a Spec whose examples aren't
  indexed yet.

## Verification

- `eslint` and `ember-tsc` (glint) pass on all changed files.
- The fix reuses the same seeding mechanism the `run-instantiate-in-memory`
  test relies on, with an identical module + example + Spec shape and an
  identical `toContain('…/example-1.json')` assertion. The load-dependent
  race doesn't reproduce on an unloaded local machine; CI exercises the
  test on this PR.
