### PR TITLE
Surface skill tools dropped for missing indexed definitions in readRealmFile results

### DIFF
--- a/packages/ai-bot/lib/read-realm-file-fulfillment.ts
+++ b/packages/ai-bot/lib/read-realm-file-fulfillment.ts
@@ -100,8 +100,11 @@ async function uploadTextToMatrix(
 // are named in the result's failureReason: the result stays `applied` while at
 // least one file came back (so the successful content isn't thrown away), and
 // resolves as invalid only when nothing did — either way a partial or failed
-// read never reads as a clean one. Returns one outcome per call; never throws
-// (a publish failure is logged so the turn still settles).
+// read never reads as a clean one. failureReason also names any skill tools
+// that were declared but couldn't be offered (no usable indexed definition),
+// so a degraded skill read never looks like a tool-less one. Returns one
+// outcome per call; never throws (a publish failure is logged so the turn
+// still settles).
 export async function fulfillReadRealmFileCalls(
   botToolCalls: ChatCompletionMessageToolCall[],
   deps: ReadRealmFileFulfillmentDeps,
@@ -128,6 +131,11 @@ type FileRead =
       // declares, when the file is a skill whose index row carries usable
       // (schema-stamped) entries.
       discoveredTools?: DiscoveredToolDefinition[];
+      // Present when the file declares tools that could not be offered
+      // (no usable stamped definition in the index); rides the result's
+      // failureReason so the model learns the skill's tools are unavailable
+      // and why, instead of hunting for a tool that will never appear.
+      degradedToolsNote?: string;
     }
   | { url: string; error: string };
 
@@ -181,7 +189,13 @@ async function readAndUpload(
     log.error(`readRealmFile: upload failed for ${url}: ${e?.message ?? e}`);
     return { url, error: `could not store ${url} for reading` };
   }
+  let declaredToolCount = result.tools?.length ?? 0;
   let discoveredTools = discoveredToolDefinitions(url, result.tools);
+  let degradedToolCount = declaredToolCount - discoveredTools.length;
+  let degradedToolsNote =
+    degradedToolCount > 0
+      ? `${url}: ${degradedToolCount} of ${declaredToolCount} tools declared by this skill lack a usable definition in the realm's index, so they cannot be offered as callable tools. This usually means the realm's index is stale — suggest that the user reindex the realm.`
+      : undefined;
   return {
     url,
     attachment: {
@@ -192,6 +206,7 @@ async function readAndUpload(
       contentSize: Buffer.byteLength(result.content),
     },
     ...(discoveredTools.length ? { discoveredTools } : {}),
+    ...(degradedToolsNote ? { degradedToolsNote } : {}),
   };
 }
 
@@ -239,19 +254,24 @@ async function fulfillOne(
   let discoveredTools = successfulReads.flatMap(
     (read) => read.discoveredTools ?? [],
   );
+  let readFailures = reads
+    .filter(
+      (read): read is Extract<FileRead, { error: string }> => 'error' in read,
+    )
+    // Most read errors already name the file; prefix the ones (e.g. realm
+    // access errors) that don't, so the model knows which URL to retry.
+    .map((read) =>
+      read.error.includes(read.url) ? read.error : `${read.url}: ${read.error}`,
+    );
+  // Degraded-tool notes share failureReason with read failures: it is the
+  // one channel prompt assembly already folds into the model-visible tool
+  // message, on failed and applied results alike. They stay out of the
+  // outcome's ok/error, which report file reads only.
+  let degradedToolsNotes = successfulReads
+    .map((read) => read.degradedToolsNote)
+    .filter((note): note is string => Boolean(note));
   let failureReason =
-    reads
-      .filter(
-        (read): read is Extract<FileRead, { error: string }> => 'error' in read,
-      )
-      // Most read errors already name the file; prefix the ones (e.g. realm
-      // access errors) that don't, so the model knows which URL to retry.
-      .map((read) =>
-        read.error.includes(read.url)
-          ? read.error
-          : `${read.url}: ${read.error}`,
-      )
-      .join('\n') || undefined;
+    [...readFailures, ...degradedToolsNotes].join('\n') || undefined;
 
   if (attachedFiles.length === 0) {
     return await publishFailure(call.id, failureReason!, deps);
@@ -274,8 +294,8 @@ async function fulfillOne(
   });
   return {
     commandRequestId: call.id,
-    ok: !failureReason,
-    ...(failureReason ? { error: failureReason } : {}),
+    ok: readFailures.length === 0,
+    ...(readFailures.length ? { error: readFailures.join('\n') } : {}),
   };
 }
 

--- a/packages/ai-bot/lib/read-realm-file.ts
+++ b/packages/ai-bot/lib/read-realm-file.ts
@@ -152,10 +152,11 @@ export async function executeReadRealmFile(
     : { ok: false, error: raw.error };
 }
 
-// The `attributes.content` and `attributes.frontmatter.tools` of a file-meta
-// document, or undefined when the body isn't a document carrying a string
-// `content` (malformed JSON, an error document, a row indexed without a
-// body). Tools pass through as indexed.
+// The `attributes.content` and `attributes.frontmatter.tools` (falling back
+// to the pre-rename `frontmatter.commands`) of a file-meta document, or
+// undefined when the body isn't a document carrying a string `content`
+// (malformed JSON, an error document, a row indexed without a body). Tools
+// pass through as indexed.
 function parseFileMetaBody(
   body: string,
 ): { content: string; tools?: ReadRealmFileTool[] } | undefined {
@@ -170,7 +171,13 @@ function parseFileMetaBody(
   if (typeof content !== 'string') {
     return undefined;
   }
-  let rawTools = attributes?.frontmatter?.tools;
+  // Index rows extracted before the command -> tool rename persist the
+  // declared entries under `commands`. Reading them too means a pre-rename
+  // row still reports what the skill declares; such entries carry no stamped
+  // definition, which the fulfillment layer surfaces as a degradation note
+  // instead of pretending the skill declares nothing.
+  let rawTools =
+    attributes?.frontmatter?.tools ?? attributes?.frontmatter?.commands;
   let tools = Array.isArray(rawTools)
     ? rawTools.filter(
         (tool): tool is ReadRealmFileTool =>

--- a/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
@@ -102,7 +102,10 @@ module('fulfillReadRealmFileCalls', () => {
     },
   };
 
-  function fileMetaFetch(tools: unknown[]) {
+  function fileMetaFetch(
+    tools: unknown[],
+    frontmatterKey: 'tools' | 'commands' = 'tools',
+  ) {
     return (async () =>
       new Response(
         JSON.stringify({
@@ -112,7 +115,7 @@ module('fulfillReadRealmFileCalls', () => {
             attributes: {
               sourceUrl: FILE_URL,
               content: '# Trip Planner',
-              frontmatter: { tools },
+              frontmatter: { [frontmatterKey]: tools },
             },
           },
         }),
@@ -143,6 +146,69 @@ module('fulfillReadRealmFileCalls', () => {
       [{ sourceSkillUrl: FILE_URL, ...STAMPED_TOOL }],
       'stamped definitions ride the result tagged with the skill URL; the ' +
         'unstamped entry is dropped',
+    );
+    assert.true(
+      sent[0].content.failureReason.includes(FILE_URL) &&
+        sent[0].content.failureReason.includes('1 of 2') &&
+        sent[0].content.failureReason.includes('reindex'),
+      'the dropped entry is named in the failure note so the model can ' +
+        'surface the stale index instead of hunting for the tool',
+    );
+  });
+
+  test('a skill whose declared tools all lack definitions carries a degradation note', async () => {
+    let { client, sent } = fakeClient();
+
+    let outcomes = await fulfillReadRealmFileCalls(
+      [readRealmFileCall('c1', { urls: [FILE_URL] })],
+      baseDeps(client, {
+        fetch: fileMetaFetch([UNSTAMPED_TOOL]),
+        uploadText: async () => 'https://localhost/media/trip-planner',
+      }),
+    );
+
+    assert.deepEqual(
+      outcomes,
+      [{ commandRequestId: 'c1', ok: true }],
+      'a degraded skill read is still a successful file read',
+    );
+    let { content } = sent[0];
+    assert.strictEqual(
+      content['m.relates_to'].key,
+      'applied',
+      'the file content still comes back',
+    );
+    assert.true(
+      content.failureReason.includes(FILE_URL) &&
+        content.failureReason.includes('1 of 1') &&
+        content.failureReason.includes('reindex'),
+      'the note names the skill, the count, and the remedy',
+    );
+    let data = dataOf(sent[0]);
+    assert.strictEqual(data.attachedFiles.length, 1);
+    assert.false(
+      'discoveredTools' in data,
+      'no usable definitions means no discoveredTools key',
+    );
+  });
+
+  test('a pre-rename index row (frontmatter.commands) degrades with a note instead of silently', async () => {
+    let { client, sent } = fakeClient();
+
+    await fulfillReadRealmFileCalls(
+      [readRealmFileCall('c1', { urls: [FILE_URL] })],
+      baseDeps(client, {
+        fetch: fileMetaFetch([UNSTAMPED_TOOL, UNSTAMPED_TOOL], 'commands'),
+        uploadText: async () => 'https://localhost/media/trip-planner',
+      }),
+    );
+
+    let { content } = sent[0];
+    assert.strictEqual(content['m.relates_to'].key, 'applied');
+    assert.true(
+      content.failureReason.includes('2 of 2') &&
+        content.failureReason.includes('reindex'),
+      'entries under the legacy key count as declared tools',
     );
   });
 

--- a/packages/ai-bot/tests/read-realm-file-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-test.ts
@@ -412,6 +412,31 @@ module('executeReadRealmFile markdown file-meta', () => {
     );
   });
 
+  test('a pre-rename row (frontmatter.commands) reports its entries as tools', async () => {
+    let sessions = stubSessions({ token: 'unused' });
+    let unstamped = { codeRef: { module: `${REALM}tools/plan`, name: 'x' } };
+    let { fetch } = recordingFetch(() =>
+      fileMetaResponse({
+        content: BODY,
+        frontmatter: { commands: [unstamped] },
+      }),
+    );
+
+    let result = await executeReadRealmFile(FILE_URL, {
+      onBehalfOf: ON_BEHALF_OF,
+      delegatedUserRealmSessions: sessions,
+      fetch,
+    });
+
+    assert.true(result.ok);
+    assert.deepEqual(
+      (result as { ok: true; tools?: unknown[] }).tools,
+      [unstamped],
+      'legacy-key entries pass through so downstream can report the skill ' +
+        'declares tools it cannot offer',
+    );
+  });
+
   test('an unindexed .md (file-meta 404) falls back to raw source', async () => {
     let sessions = stubSessions({ token: 'unused' });
     let raw = '---\nname: trip\n---\n# Raw body';

--- a/packages/base/matrix-event.gts
+++ b/packages/base/matrix-event.gts
@@ -366,7 +366,8 @@ export interface ToolResultWithOutputContent {
   commandRequestId: string;
   // Present if status is 'failed' or 'invalid', or on an 'applied' result
   // where part of the work failed (e.g. a multi-file read that fetched only
-  // some of its files).
+  // some of its files, or a skill read whose declared tools lack usable
+  // indexed definitions and so cannot be offered).
   failureReason?: string;
   data: {
     // we retrieve the content on the server side by downloading the file


### PR DESCRIPTION
## What

When a `readRealmFile` read of a skill markdown file finds declared frontmatter tools that lack a usable stamped `definition` in the realm's index, the result event's `failureReason` now names the skill, the dropped count, and the remedy (reindex the realm). Previously those entries were dropped silently — the model received the skill's instructions describing tools it could never call, and would loop re-reading docs hunting for them.

`failureReason` is used because it is the one channel prompt assembly already folds into the model-visible tool message on both failed and applied results (the same way a partial multi-file read names its 404s). The result stays `applied`, the file content still attaches, and the fulfillment outcome's `ok`/`error` continue to report file reads only.

The read layer also falls back to the pre-rename `frontmatter.commands` key when `tools` is absent, so a skill indexed before the command→tool rename reports what it declares (those entries carry no definition, which triggers the same degradation note) instead of appearing tool-less.

## Why

A stale skills-realm index — one written before tool definitions were stamped at index time — strips every tool a skill declares with no signal to the model or user. Observed end state: the assistant reads 20 skill docs across 11 tool rounds, hallucinates the tool call as a JSON code block, and exhausts the user's credits with zero work product. With this change the first skill read reports the degradation and the model can tell the user the realm needs reindexing.

## Test plan

- New unit tests: a skill whose declared tools all lack definitions carries the note on an `applied` result with `ok: true`; a mixed stamped/unstamped read names the dropped count while still embedding the usable definition; a pre-rename `frontmatter.commands` row degrades with a note instead of silently; legacy-key entries pass through the read layer as declared tools.
- `pnpm test` in `packages/ai-bot`: 246 passing; the 2 failures are the locking tests that require CI's postgres role and fail on any local run.
- `pnpm lint` (eslint + ember-tsc) clean in `packages/ai-bot`.
- Not exercised against a live bot session: the local skills realm index is freshly stamped, so the degraded state no longer reproduces there without reverting the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)