### PR TITLE
Make tool validation race-safe and invalid results terminal for auto-execution

### DIFF
--- a/packages/host/app/lib/matrix-classes/message-builder.ts
+++ b/packages/host/app/lib/matrix-classes/message-builder.ts
@@ -11,7 +11,7 @@ import { type ResolvedCodeRef, getClass } from '@cardstack/runtime-common';
 import type { ToolRequest } from '@cardstack/runtime-common/commands';
 import {
   AI_BOT_EXECUTOR,
-  decodeCommandRequest,
+  decodeToolRequest,
 } from '@cardstack/runtime-common/commands';
 import {
   getToolRequests,
@@ -254,12 +254,12 @@ export default class MessageBuilder {
         (c) => c.toolRequest.id === encodedCommandRequest.id,
       );
       if (command) {
-        command.toolRequest = decodeCommandRequest(encodedCommandRequest);
+        command.toolRequest = decodeToolRequest(encodedCommandRequest);
       } else {
         message.tools.push(
           await this.buildMessageCommand(
             message,
-            decodeCommandRequest(encodedCommandRequest),
+            decodeToolRequest(encodedCommandRequest),
           ),
         );
       }
@@ -310,7 +310,7 @@ export default class MessageBuilder {
     for (let toolRequest of toolRequests) {
       let command = await this.buildMessageCommand(
         message,
-        decodeCommandRequest(toolRequest),
+        decodeToolRequest(toolRequest),
       );
       commands.push(command);
     }

--- a/packages/host/app/services/tool-service.ts
+++ b/packages/host/app/services/tool-service.ts
@@ -59,6 +59,12 @@ const DELAY_FOR_APPLYING_UI = isTesting() ? 50 : 500;
 // In tests we shorten this so the stuck-timeout invalidation path can be
 // exercised in a single test without holding a real test open for a minute.
 const STUCK_PROCESSING_TIMEOUT_MS = isTesting() ? 1000 : 60_000;
+// How many times drainToolProcessingQueue requeues an event whose finalized
+// content the room resource hasn't folded into its Message yet, before
+// giving up and validating whatever state is there (guaranteeing a terminal
+// result either way). Requeues are ~100ms apart (the drain debounce), so
+// this allows well over the normal sub-second catch-up.
+const MAX_TOOL_FINALIZATION_RETRIES = isTesting() ? 10 : 100;
 
 type GenericCommand = Command<
   typeof CardDef | undefined,
@@ -78,6 +84,15 @@ export default class ToolService extends Service {
   @service declare private store: StoreService;
   currentlyExecutingToolRequestIds = new TrackedSet<string>();
   executedToolRequestIds = new TrackedSet<string>();
+  // Requests the auto-execution flow has resolved 'invalid'. An invalid
+  // result is terminal for auto-execution: without this record, a later
+  // drain pass can re-validate the same request against updated room state,
+  // execute it, and post a contradictory 'applied' result — and the model,
+  // having already seen 'invalid', re-issues the call, so the command runs
+  // twice. Local (not derived from room events) because the result event
+  // round-trip is slower than consecutive drain passes. The user's manual
+  // "Try Anyway" path doesn't consult this — it goes straight to `run`.
+  invalidatedToolRequestIds = new TrackedSet<string>();
   acceptingAllRoomIds = new TrackedSet<string>();
   private aiAssistantClientRequestIdsByRoom = new Map<
     string,
@@ -97,6 +112,9 @@ export default class ToolService extends Service {
     { unsubscribe: () => void; timeoutId: ReturnType<typeof setTimeout> }
   >();
   private toolProcessingEventQueue: string[] = [];
+  // How many times each queued event has been requeued waiting for the room
+  // resource to fold the event's finalized content into its Message.
+  private toolFinalizationRetries = new Map<string, number>();
   private codePatchProcessingEventQueue: string[] = [];
   private flushToolProcessingQueue: Promise<void> | undefined;
   private flushCodePatchProcessingQueue: Promise<void> | undefined;
@@ -109,6 +127,7 @@ export default class ToolService extends Service {
   resetState() {
     this.currentlyExecutingToolRequestIds.clear();
     this.executedToolRequestIds.clear();
+    this.invalidatedToolRequestIds.clear();
     this.acceptingAllRoomIds.clear();
     this.aiAssistantClientRequestIdsByRoom.clear();
     for (let invalidation of this.aiAssistantInvalidations.values()) {
@@ -119,6 +138,7 @@ export default class ToolService extends Service {
       this.cleanupInvalidationWaiter(key);
     }
     this.toolProcessingEventQueue = [];
+    this.toolFinalizationRetries.clear();
     this.codePatchProcessingEventQueue = [];
     this.flushToolProcessingQueue = undefined;
     this.flushCodePatchProcessingQueue = undefined;
@@ -365,8 +385,39 @@ export default class ToolService extends Service {
         }
 
         let message = roomResource.messages.find((m) => m.eventId === eventId);
-        if (!message) {
-          continue;
+        // Events are only queued once their content is finalized
+        // (isStreamingFinished), but the room resource folds that content
+        // into its Message asynchronously — at drain time the Message may
+        // not exist yet, or may still hold a streaming snapshot whose tool
+        // arguments are partial or unparsed. Validating that snapshot posts
+        // a spurious 'invalid' result for a request that is actually fine
+        // (CS-12103). Requeue until the Message reports the finalized state;
+        // bounded so a message that never catches up still falls through
+        // and resolves with a real (terminal) validation result.
+        if (
+          !message ||
+          (!message.isStreamingOfEventFinished && !message.isCanceled)
+        ) {
+          let compoundKey = `${roomId}|${eventId}`;
+          let retries = this.toolFinalizationRetries.get(compoundKey) ?? 0;
+          if (retries < MAX_TOOL_FINALIZATION_RETRIES) {
+            this.toolFinalizationRetries.set(compoundKey, retries + 1);
+            if (!this.toolProcessingEventQueue.includes(compoundKey)) {
+              this.toolProcessingEventQueue.push(compoundKey);
+            }
+            debounce(this, this.drainToolProcessingQueue, 100);
+            continue;
+          }
+          this.toolFinalizationRetries.delete(compoundKey);
+          if (!message) {
+            // Nothing addressable to validate or invalidate.
+            console.error(
+              `Tool processing gave up waiting for message ${eventId} in room ${roomId} to appear in the room resource`,
+            );
+            continue;
+          }
+        } else {
+          this.toolFinalizationRetries.delete(`${roomId}|${eventId}`);
         }
         if (message.agentId !== this.matrixService.agentId) {
           // This command was sent by another agent, so we will not auto-execute it
@@ -387,6 +438,12 @@ export default class ToolService extends Service {
             continue;
           }
           if (this.executedToolRequestIds.has(messageTool.id!)) {
+            continue;
+          }
+          // The status check below covers this too, but only once the
+          // invalid result event has round-tripped into the room resource;
+          // this local record closes the window in between.
+          if (this.invalidatedToolRequestIds.has(messageTool.id!)) {
             continue;
           }
           if (
@@ -471,6 +528,9 @@ export default class ToolService extends Service {
       if (this.executedToolRequestIds.has(commandRequestId)) {
         continue;
       }
+      if (this.invalidatedToolRequestIds.has(commandRequestId)) {
+        continue;
+      }
       if (
         messageTool.status === 'applied' ||
         messageTool.status === 'invalid'
@@ -487,6 +547,9 @@ export default class ToolService extends Service {
         // button is still the user's fallback for those.
         continue;
       }
+      // Terminal for auto-execution: a later drain pass must not execute a
+      // request the model has been told was not started.
+      this.invalidatedToolRequestIds.add(commandRequestId);
       let invokedToolFromEventId =
         this.getCurrentEventIdForCommandRequest(roomId, commandRequestId) ??
         messageTool.eventId;
@@ -851,6 +914,13 @@ export default class ToolService extends Service {
       }
     }
     if (error) {
+      // An invalid result is terminal for auto-execution: record it before
+      // publishing so no concurrent drain pass re-validates and executes
+      // this request after the model has been told it failed. (The user can
+      // still run it manually — "Try Anyway" bypasses the drain.)
+      if (command.toolRequest.id) {
+        this.invalidatedToolRequestIds.add(command.toolRequest.id);
+      }
       // CS-11045: Same canonical-event-id resolution as the run task — emit
       // the invalid commandResult linked to the bot-message event currently
       // owning the toolRequest in room state, so ai-bot's /messages view

--- a/packages/host/app/tools/utils.ts
+++ b/packages/host/app/tools/utils.ts
@@ -4,7 +4,7 @@ import {
   getToolRequests,
   isToolResultEventType,
   isToolResultRelType,
-  decodeCommandRequest,
+  decodeToolRequest,
   type ToolContext,
   type ToolRequest,
 } from '@cardstack/runtime-common';
@@ -105,7 +105,7 @@ export async function waitForCompletedCommandRequest(
         );
         if (
           toolRequest &&
-          commandRequestPredicate(decodeCommandRequest(toolRequest))
+          commandRequestPredicate(decodeToolRequest(toolRequest))
         ) {
           result = toolResultEvent;
           return true;

--- a/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
@@ -2072,6 +2072,76 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
     );
   });
 
+  test('an invalid result is terminal for auto-execution: a later drain pass does not re-resolve the request', async function (assert) {
+    let roomId = await renderAiAssistantPanel();
+    let matrixService = getService('matrix-service');
+    let toolService = getService('tool-service');
+
+    // Capture result events without forwarding them. The swallowed event
+    // recreates the window where the invalid result has not round-tripped
+    // into the room resource yet, so the MessageTool's status still reads
+    // 'ready' — the window in which a second drain pass used to re-validate
+    // the request and post a contradictory second result (CS-12103's
+    // invalid-then-applied signature).
+    let captured: Array<{ toolCallId: string; status: string }> = [];
+    let originalSend = matrixService.sendToolResultEvent.bind(matrixService);
+    (matrixService as any).sendToolResultEvent = async (params: any) => {
+      captured.push({ toolCallId: params.toolCallId, status: params.status });
+    };
+    try {
+      let eventId = simulateRemoteMessage(roomId, '@aibot:localhost', {
+        body: 'Do the thing',
+        msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+        format: 'org.matrix.custom.html',
+        isStreamingFinished: true,
+        [APP_BOXEL_TOOL_REQUESTS_KEY]: [
+          {
+            id: 'cs-12103-invalid-terminal',
+            name: 'no-such-command',
+            arguments: JSON.stringify({
+              description: 'do it',
+              attributes: {},
+            }),
+          },
+        ],
+        data: {
+          context: {
+            agentId: matrixService.agentId,
+          },
+        },
+      });
+      await settled();
+
+      assert.deepEqual(
+        captured,
+        [{ toolCallId: 'cs-12103-invalid-terminal', status: 'invalid' }],
+        'validation resolves the request invalid exactly once',
+      );
+      assert.true(
+        toolService.invalidatedToolRequestIds.has('cs-12103-invalid-terminal'),
+        'the terminal resolution is recorded locally, not just in the (still in-flight) result event',
+      );
+
+      // A later pass over the same event — e.g. a trailing m.replace
+      // re-queuing it — must not re-validate a request the model has
+      // already been told failed.
+      toolService.queueEventForToolProcessing({
+        event_id: eventId,
+        room_id: roomId,
+        content: {} as any,
+      });
+      await settled();
+
+      assert.strictEqual(
+        captured.length,
+        1,
+        'the resolved request gets no second result and is not executed',
+      );
+    } finally {
+      (matrixService as any).sendToolResultEvent = originalSend;
+    }
+  });
+
   test('Accept All bar still renders for a command that requires user approval', async function (assert) {
     let roomId = await renderAiAssistantPanel(`${testRealmURL}Person/fadhlan`);
 

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -343,6 +343,7 @@ const ALL_TEST_FILES: string[] = [
   './package-shim-handler-test',
   './command-parsing-utils-test',
   './command-function-name-test',
+  './tool-request-decoding-test',
   './query-matches-filter-test',
   './parse-search-url-test',
   './matches-filter-integration-test',

--- a/packages/realm-server/tests/tool-request-decoding-test.ts
+++ b/packages/realm-server/tests/tool-request-decoding-test.ts
@@ -1,0 +1,25 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import { runSharedTest } from '@cardstack/runtime-common/helpers';
+import toolRequestDecodingTests from '@cardstack/runtime-common/tests/tool-request-decoding-test';
+
+module(basename(import.meta.filename), function () {
+  module('tool request decoding', function () {
+    test('decodes an encoded request with stringified arguments', async function (assert) {
+      await runSharedTest(toolRequestDecodingTests, assert, {});
+    });
+
+    test('a partial (still-streaming) arguments string decodes without throwing, leaving arguments undefined', async function (assert) {
+      await runSharedTest(toolRequestDecodingTests, assert, {});
+    });
+
+    test('a doubly-encoded attributes string is decoded', async function (assert) {
+      await runSharedTest(toolRequestDecodingTests, assert, {});
+    });
+
+    test('malformed nested attributes keep the outer decode', async function (assert) {
+      await runSharedTest(toolRequestDecodingTests, assert, {});
+    });
+  });
+});

--- a/packages/runtime-common/commands.ts
+++ b/packages/runtime-common/commands.ts
@@ -220,14 +220,17 @@ export function decodeToolRequest(
     decodedCommandRequest.name = commandRequest.name;
   }
   if (commandRequest.arguments) {
-    decodedCommandRequest.arguments = JSON.parse(commandRequest.arguments);
     try {
+      decodedCommandRequest.arguments = JSON.parse(commandRequest.arguments);
       let attributes = decodedCommandRequest.arguments?.attributes;
       if (typeof attributes === 'string') {
         decodedCommandRequest.arguments!.attributes = JSON.parse(attributes);
       }
     } catch {
-      // ignore malformed nested json; validation will report a clearer error later
+      // ignore malformed json — e.g. a still-streaming arguments payload or
+      // malformed nested attributes; `arguments` stays undefined (or keeps
+      // the outer parse) and validation reports a clearer error once the
+      // request is finalized
     }
   }
   if (commandRequest.executedBy != null) {

--- a/packages/runtime-common/tests/tool-request-decoding-test.ts
+++ b/packages/runtime-common/tests/tool-request-decoding-test.ts
@@ -1,0 +1,75 @@
+import type { SharedTests } from '../helpers/index.ts';
+import { decodeToolRequest } from '../commands.ts';
+
+const tests = Object.freeze({
+  'decodes an encoded request with stringified arguments': async (assert) => {
+    assert.deepEqual(
+      decodeToolRequest({
+        id: 'tool-1',
+        name: 'show-card_566f',
+        arguments: JSON.stringify({
+          description: 'show it',
+          attributes: { cardId: 'https://realm/Card/1' },
+        }),
+      }),
+      {
+        id: 'tool-1',
+        name: 'show-card_566f',
+        arguments: {
+          description: 'show it',
+          attributes: { cardId: 'https://realm/Card/1' },
+        },
+      },
+    );
+  },
+
+  'a partial (still-streaming) arguments string decodes without throwing, leaving arguments undefined':
+    async (assert) => {
+      let decoded = decodeToolRequest({
+        id: 'tool-1',
+        name: 'switch-submode_dd88',
+        // A truncated stream of {"description":"Switch to code mode","attr…
+        arguments: '{"description":"Switch to code mode","attr',
+      });
+      assert.strictEqual(decoded.id, 'tool-1');
+      assert.strictEqual(decoded.name, 'switch-submode_dd88');
+      assert.strictEqual(
+        decoded.arguments,
+        undefined,
+        'unparseable arguments decode to undefined for validation to report, not a throw that breaks message building',
+      );
+    },
+
+  'a doubly-encoded attributes string is decoded': async (assert) => {
+    let decoded = decodeToolRequest({
+      id: 'tool-1',
+      name: 'show-card_566f',
+      arguments: JSON.stringify({
+        description: 'show it',
+        attributes: JSON.stringify({ cardId: 'https://realm/Card/1' }),
+      }),
+    });
+    assert.deepEqual(decoded.arguments?.attributes, {
+      cardId: 'https://realm/Card/1',
+    });
+  },
+
+  'malformed nested attributes keep the outer decode': async (assert) => {
+    let decoded = decodeToolRequest({
+      id: 'tool-1',
+      name: 'show-card_566f',
+      arguments: JSON.stringify({
+        description: 'show it',
+        attributes: '{not json',
+      }),
+    });
+    assert.strictEqual(decoded.arguments?.description, 'show it');
+    assert.strictEqual(
+      decoded.arguments?.attributes,
+      '{not json',
+      'the outer parse survives; validation reports the malformed attributes',
+    );
+  },
+} as SharedTests<{}>);
+
+export default tests;


### PR DESCRIPTION
## What

A tool request could receive two contradictory results — `invalid` ("validation failed: data must be object") followed seconds later by `applied` — and the model, told the call failed, would re-issue it, executing the command twice. Two changes close this:

**Validate only finalized arguments.** Events are queued for tool processing only once `isStreamingFinished`, but the room resource folds that content into its `Message` asynchronously — at drain time the Message can still hold a streaming snapshot whose tool arguments are partial or unparsed. `drainToolProcessingQueue` now requeues the event (bounded, ~100ms apart) until the Message reports the event's streaming finished, then validates. If the Message never catches up, it falls through and validates anyway, so every request still reaches a terminal result.

**An invalid result is terminal for auto-execution.** `invalidatedToolRequestIds` records every request the auto flow resolves `invalid` (schema validation, unknown command, and the stuck-processing invalidation). Later drain passes skip recorded ids, so a request can't be re-validated against updated room state and executed after the model was told it failed. The record is local because the result event's round-trip into the room resource is slower than consecutive drain passes — the existing `status === 'invalid'` check only closes the window after the round-trip. The user's manual "Try Anyway" path bypasses the drain and still works.

Supporting changes:
- `decodeToolRequest` no longer throws on an unparseable `arguments` string (e.g. a still-streaming payload); `arguments` decodes to `undefined` for validation to report.
- In-repo callers move off the pre-rename `decodeCommandRequest` alias; the alias itself stays for out-of-tree realm content pending CS-12042.

## Tests

- New integration test: a request resolved `invalid` gets exactly one result and is not re-resolved by a later drain pass. The test's result-event spy deliberately doesn't forward the event, recreating the not-yet-round-tripped window in which the old code re-validated (the mock Matrix's synchronous round-trip is why this race never showed in CI).
- New shared runtime-common tests for `decodeToolRequest`: partial streaming arguments, doubly-encoded attributes, malformed nested attributes (run locally: 7 passed).
- The live race itself isn't deterministically reproducible in the test harness; the finalization gate is covered by type-check plus the existing tool suites, which exercise the finalized path.
- `pnpm lint` clean in host, runtime-common, realm-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)