### PR TITLE
Add caching for `/_skill-validation`

### DIFF
--- a/packages/realm-server/handlers/handle-skill-validation.ts
+++ b/packages/realm-server/handlers/handle-skill-validation.ts
@@ -63,7 +63,10 @@ interface ComputeDeps {
   definitionLookup: CreateRoutesArgs['definitionLookup'];
   virtualNetwork: CreateRoutesArgs['virtualNetwork'];
   prerenderer: NonNullable<CreateRoutesArgs['prerenderer']>;
-  createPrerenderAuth: (userId: string, permissions: RealmPermissions) => string;
+  createPrerenderAuth: (
+    userId: string,
+    permissions: RealmPermissions,
+  ) => string;
 }
 
 interface CachedValidation {

--- a/packages/realm-server/handlers/handle-skill-validation.ts
+++ b/packages/realm-server/handlers/handle-skill-validation.ts
@@ -4,6 +4,7 @@ import {
   RealmPaths,
   SupportedMimeType,
   fetchUserPermissions,
+  logger,
   markdownDefRef,
   skillCardRef,
   systemInitiatedPriority,
@@ -32,12 +33,75 @@ import { buildCreatePrerenderAuth } from '../prerender/auth.ts';
 // prerenderer (a real host in headless Chrome, with the same shims and virtual
 // network a user's browser has), so a module this endpoint passes is one the
 // deployed host can actually load.
+//
+// The validation sweep prerenders every distinct tool module, which costs
+// seconds warm and tens of seconds on a cold prerender loader. To keep this
+// usable as a frequent monitor, the per-realm result is cached and refreshed
+// off the request path: a poll serves the last computed result immediately and,
+// when that result is older than REFRESH_AFTER_MS, kicks a background refresh
+// for the next poll. Only the first poll after a process start pays the sweep
+// synchronously, so the response is always a definite pass/fail. The served
+// result is therefore at most one refresh interval stale — `ageSeconds` on the
+// response reports how old it is.
 
 interface SkillToolFailure {
   skill: string;
   module: string;
   name: string;
   error: string;
+}
+
+interface SkillValidationAttributes {
+  status: 'pass' | 'fail';
+  skillsChecked: number;
+  toolsChecked: number;
+  failures: SkillToolFailure[];
+}
+
+interface ComputeDeps {
+  dbAdapter: CreateRoutesArgs['dbAdapter'];
+  definitionLookup: CreateRoutesArgs['definitionLookup'];
+  virtualNetwork: CreateRoutesArgs['virtualNetwork'];
+  prerenderer: NonNullable<CreateRoutesArgs['prerenderer']>;
+  createPrerenderAuth: (userId: string, permissions: RealmPermissions) => string;
+}
+
+interface CachedValidation {
+  computedAt: number;
+  attributes: SkillValidationAttributes;
+}
+
+// Serve a cached result this fresh as-is; older than this, serve it but kick a
+// background refresh. Kept below the monitor's cadence so each poll refreshes
+// the previous poll's result off the request path.
+const REFRESH_AFTER_MS = 4 * 60 * 1000;
+const validationCache = new Map<string, CachedValidation>();
+const refreshInFlight = new Map<string, Promise<CachedValidation>>();
+const log = logger('realm:skill-validation');
+
+// Recompute and cache one realm's result, deduping concurrent refreshes so a
+// poll landing during an in-flight sweep joins it rather than starting another.
+function refreshValidation(
+  realm: Realm,
+  deps: ComputeDeps,
+): Promise<CachedValidation> {
+  let existing = refreshInFlight.get(realm.url);
+  if (existing) {
+    return existing;
+  }
+  let pending = (async () => {
+    let attributes = await computeValidation(realm, deps);
+    let entry: CachedValidation = { computedAt: Date.now(), attributes };
+    validationCache.set(realm.url, entry);
+    return entry;
+  })();
+  refreshInFlight.set(realm.url, pending);
+  pending.finally(() => {
+    if (refreshInFlight.get(realm.url) === pending) {
+      refreshInFlight.delete(realm.url);
+    }
+  });
+  return pending;
 }
 
 export default function handleSkillValidation({
@@ -106,70 +170,46 @@ export default function handleSkillValidation({
       return;
     }
 
-    let indexQueryEngine = new IndexQueryEngine(
+    let deps: ComputeDeps = {
       dbAdapter,
       definitionLookup,
       virtualNetwork,
-    );
-    let skills: { id: string; tools: ToolRef[] }[];
-    try {
-      let { cards } = await indexQueryEngine.searchCards(
-        new URL(realm.url),
-        { filter: { type: skillCardRef } },
-        {},
-      );
-      // Discover markdown skills with a type-only file search, then narrow to
-      // `kind: 'skill'` here. An `eq: { kind }` filter would make the query
-      // resolve MarkdownDef's field definition; when that lookup misses, the
-      // search engine swallows the resulting error into an empty result set,
-      // silently dropping every markdown skill. A type match is
-      // definition-free — it matches the indexed `types` column — so discovery
-      // stays reliable regardless of which definitions are loaded here.
-      let { files: markdownFiles } = await indexQueryEngine.searchFiles(
-        new URL(realm.url),
-        { filter: { type: markdownDefRef } },
-        {},
-      );
-      let files = markdownFiles.filter(
-        (file) =>
-          (file.searchDoc?.kind ?? file.resource?.attributes?.kind) === 'skill',
-      );
-      skills = [
-        ...cards.map((card) => ({
-          id: card.id!,
-          tools: cardToolRefsFor(card),
-        })),
-        ...files.map((file) => ({
-          id: file.canonicalURL,
-          tools: markdownToolRefsFor(file),
-        })),
-      ];
-    } catch (e: any) {
-      await sendResponseForSystemError(
-        ctxt,
-        `unable to search for skills in realm ${realm.url}: ${e.message}`,
-      );
-      return;
+      prerenderer,
+      createPrerenderAuth,
+    };
+
+    // Serve the cached result. Only compute on the request path when nothing
+    // is cached yet (the first poll after a process start) or the caller asks
+    // for a fresh result with `refresh=true`; a stale-but-present result is
+    // otherwise served immediately while a background refresh recomputes it for
+    // the next poll.
+    let forceRefresh = ctxt.URL.searchParams.get('refresh') === 'true';
+    let cached = validationCache.get(realm.url);
+    let entry: CachedValidation;
+    if (forceRefresh || !cached) {
+      try {
+        entry = await refreshValidation(realm, deps);
+      } catch (e: any) {
+        await sendResponseForSystemError(
+          ctxt,
+          `unable to validate skills in realm ${realm.url}: ${e.message}`,
+        );
+        return;
+      }
+    } else {
+      entry = cached;
+      if (Date.now() - entry.computedAt > REFRESH_AFTER_MS) {
+        // A failure here leaves the last good result in place (logged, not
+        // surfaced) rather than blocking or failing the poll.
+        refreshValidation(realm, deps).catch((e: any) => {
+          log.error(
+            `background skill-validation refresh for ${realm.url} failed: ${e.message}`,
+          );
+        });
+      }
     }
 
-    let failures: SkillToolFailure[];
-    try {
-      failures = await validateToolModules({
-        skills,
-        realm,
-        dbAdapter,
-        prerenderer,
-        createPrerenderAuth,
-      });
-    } catch (e: any) {
-      await sendResponseForSystemError(
-        ctxt,
-        `unable to validate skill modules in realm ${realm.url}: ${e.message}`,
-      );
-      return;
-    }
-
-    let toolCount = skills.reduce((sum, s) => sum + s.tools.length, 0);
+    let ageSeconds = Math.round((Date.now() - entry.computedAt) / 1000);
     return setContextResponse(
       ctxt,
       new Response(
@@ -177,12 +217,7 @@ export default function handleSkillValidation({
           data: {
             type: 'skill-validation',
             id: realm.url,
-            attributes: {
-              status: failures.length === 0 ? 'pass' : 'fail',
-              skillsChecked: skills.length,
-              toolsChecked: toolCount,
-              failures,
-            },
+            attributes: { ...entry.attributes, ageSeconds },
           },
         }),
         {
@@ -190,6 +225,74 @@ export default function handleSkillValidation({
         },
       ),
     );
+  };
+}
+
+// Enumerate the realm's skills (legacy Skill cards + markdown skills) and
+// validate every distinct tool module they reference. Throws on a search/DB
+// failure; a returned result always carries a definite pass/fail status.
+async function computeValidation(
+  realm: Realm,
+  deps: ComputeDeps,
+): Promise<SkillValidationAttributes> {
+  let {
+    dbAdapter,
+    definitionLookup,
+    virtualNetwork,
+    prerenderer,
+    createPrerenderAuth,
+  } = deps;
+  let indexQueryEngine = new IndexQueryEngine(
+    dbAdapter,
+    definitionLookup,
+    virtualNetwork,
+  );
+
+  let { cards } = await indexQueryEngine.searchCards(
+    new URL(realm.url),
+    { filter: { type: skillCardRef } },
+    {},
+  );
+  // Discover markdown skills with a type-only file search, then narrow to
+  // `kind: 'skill'` here. An `eq: { kind }` filter would make the query
+  // resolve MarkdownDef's field definition; when that lookup misses, the
+  // search engine swallows the resulting error into an empty result set,
+  // silently dropping every markdown skill. A type match is definition-free —
+  // it matches the indexed `types` column — so discovery stays reliable
+  // regardless of which definitions are loaded here.
+  let { files: markdownFiles } = await indexQueryEngine.searchFiles(
+    new URL(realm.url),
+    { filter: { type: markdownDefRef } },
+    {},
+  );
+  let files = markdownFiles.filter(
+    (file) =>
+      (file.searchDoc?.kind ?? file.resource?.attributes?.kind) === 'skill',
+  );
+  let skills = [
+    ...cards.map((card) => ({
+      id: card.id!,
+      tools: cardToolRefsFor(card),
+    })),
+    ...files.map((file) => ({
+      id: file.canonicalURL,
+      tools: markdownToolRefsFor(file),
+    })),
+  ];
+
+  let failures = await validateToolModules({
+    skills,
+    realm,
+    dbAdapter,
+    prerenderer,
+    createPrerenderAuth,
+  });
+  let toolCount = skills.reduce((sum, s) => sum + s.tools.length, 0);
+  return {
+    status: failures.length === 0 ? 'pass' : 'fail',
+    skillsChecked: skills.length,
+    toolsChecked: toolCount,
+    failures,
   };
 }
 

--- a/packages/realm-server/handlers/handle-skill-validation.ts
+++ b/packages/realm-server/handlers/handle-skill-validation.ts
@@ -102,12 +102,11 @@ function refreshValidation(
       // Clean up inside the promise body rather than via `pending.finally(...)`:
       // that would spawn a second promise which, on a refresh rejection,
       // rejects unobserved and surfaces as an unhandled rejection (the only
-      // observed promise is `pending`, returned to the caller). Identity-check
-      // so a newer in-flight entry installed after this one settled isn't
-      // dropped.
-      if (refreshInFlight.get(realm.url) === pending) {
-        refreshInFlight.delete(realm.url);
-      }
+      // observed promise is `pending`, returned to the caller). A concurrent
+      // call for this realm gets the existing in-flight promise (the guard
+      // above), so no other refresh can be queued while this one runs — the
+      // map entry is always this one, so clear it unconditionally.
+      refreshInFlight.delete(realm.url);
     }
   })();
   refreshInFlight.set(realm.url, pending);

--- a/packages/realm-server/handlers/handle-skill-validation.ts
+++ b/packages/realm-server/handlers/handle-skill-validation.ts
@@ -93,17 +93,24 @@ function refreshValidation(
     return existing;
   }
   let pending = (async () => {
-    let attributes = await computeValidation(realm, deps);
-    let entry: CachedValidation = { computedAt: Date.now(), attributes };
-    validationCache.set(realm.url, entry);
-    return entry;
+    try {
+      let attributes = await computeValidation(realm, deps);
+      let entry: CachedValidation = { computedAt: Date.now(), attributes };
+      validationCache.set(realm.url, entry);
+      return entry;
+    } finally {
+      // Clean up inside the promise body rather than via `pending.finally(...)`:
+      // that would spawn a second promise which, on a refresh rejection,
+      // rejects unobserved and surfaces as an unhandled rejection (the only
+      // observed promise is `pending`, returned to the caller). Identity-check
+      // so a newer in-flight entry installed after this one settled isn't
+      // dropped.
+      if (refreshInFlight.get(realm.url) === pending) {
+        refreshInFlight.delete(realm.url);
+      }
+    }
   })();
   refreshInFlight.set(realm.url, pending);
-  pending.finally(() => {
-    if (refreshInFlight.get(realm.url) === pending) {
-      refreshInFlight.delete(realm.url);
-    }
-  });
   return pending;
 }
 

--- a/packages/realm-server/handlers/handle-skill-validation.ts
+++ b/packages/realm-server/handlers/handle-skill-validation.ts
@@ -78,17 +78,25 @@ interface CachedValidation {
 // background refresh. Kept below the monitor's cadence so each poll refreshes
 // the previous poll's result off the request path.
 const REFRESH_AFTER_MS = 4 * 60 * 1000;
-const validationCache = new Map<string, CachedValidation>();
-const refreshInFlight = new Map<string, Promise<CachedValidation>>();
 const log = logger('realm:skill-validation');
+
+// Per-realm result cache plus the in-flight refresh dedup map, both keyed by
+// realm URL. Held per handler instance (see below) rather than at module scope
+// so servers sharing a process — every realm-server test fixture — don't share
+// each other's cached results.
+interface ValidationCache {
+  results: Map<string, CachedValidation>;
+  refreshInFlight: Map<string, Promise<CachedValidation>>;
+}
 
 // Recompute and cache one realm's result, deduping concurrent refreshes so a
 // poll landing during an in-flight sweep joins it rather than starting another.
 function refreshValidation(
   realm: Realm,
   deps: ComputeDeps,
+  cache: ValidationCache,
 ): Promise<CachedValidation> {
-  let existing = refreshInFlight.get(realm.url);
+  let existing = cache.refreshInFlight.get(realm.url);
   if (existing) {
     return existing;
   }
@@ -96,7 +104,7 @@ function refreshValidation(
     try {
       let attributes = await computeValidation(realm, deps);
       let entry: CachedValidation = { computedAt: Date.now(), attributes };
-      validationCache.set(realm.url, entry);
+      cache.results.set(realm.url, entry);
       return entry;
     } finally {
       // Clean up inside the promise body rather than via `pending.finally(...)`:
@@ -106,10 +114,10 @@ function refreshValidation(
       // call for this realm gets the existing in-flight promise (the guard
       // above), so no other refresh can be queued while this one runs — the
       // map entry is always this one, so clear it unconditionally.
-      refreshInFlight.delete(realm.url);
+      cache.refreshInFlight.delete(realm.url);
     }
   })();
-  refreshInFlight.set(realm.url, pending);
+  cache.refreshInFlight.set(realm.url, pending);
   return pending;
 }
 
@@ -127,6 +135,10 @@ export default function handleSkillValidation({
     realmSecretSeed,
     serverURL,
   );
+  let cache: ValidationCache = {
+    results: new Map(),
+    refreshInFlight: new Map(),
+  };
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     if (
       !(await isAuthorizedToViewMonitoring(ctxt.request, realmServerSecretSeed))
@@ -193,11 +205,11 @@ export default function handleSkillValidation({
     // otherwise served immediately while a background refresh recomputes it for
     // the next poll.
     let forceRefresh = ctxt.URL.searchParams.get('refresh') === 'true';
-    let cached = validationCache.get(realm.url);
+    let cached = cache.results.get(realm.url);
     let entry: CachedValidation;
     if (forceRefresh || !cached) {
       try {
-        entry = await refreshValidation(realm, deps);
+        entry = await refreshValidation(realm, deps, cache);
       } catch (e: any) {
         await sendResponseForSystemError(
           ctxt,
@@ -210,7 +222,7 @@ export default function handleSkillValidation({
       if (Date.now() - entry.computedAt > REFRESH_AFTER_MS) {
         // A failure here leaves the last good result in place (logged, not
         // surfaced) rather than blocking or failing the poll.
-        refreshValidation(realm, deps).catch((e: any) => {
+        refreshValidation(realm, deps, cache).catch((e: any) => {
           log.error(
             `background skill-validation refresh for ${realm.url} failed: ${e.message}`,
           );

--- a/packages/realm-server/tests/server-endpoints/skill-validation-test.ts
+++ b/packages/realm-server/tests/server-endpoints/skill-validation-test.ts
@@ -132,9 +132,12 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       });
 
       test('reports each tool codeRef that fails to resolve', async function (assert) {
+        // refresh=true forces a synchronous recompute so the assertion doesn't
+        // depend on the per-realm result cache (the two modules here share a
+        // realm URL).
         let response = await request
           .get(
-            `/_skill-validation?realm=${encodeURIComponent(testRealmURL.href)}`,
+            `/_skill-validation?realm=${encodeURIComponent(testRealmURL.href)}&refresh=true`,
           )
           .set(
             'Authorization',
@@ -223,7 +226,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       test('passes when every tool codeRef resolves in a private realm', async function (assert) {
         let response = await request
           .get(
-            `/_skill-validation?realm=${encodeURIComponent(testRealmURL.href)}`,
+            `/_skill-validation?realm=${encodeURIComponent(testRealmURL.href)}&refresh=true`,
           )
           .set(
             'Authorization',

--- a/packages/realm-server/tests/server-endpoints/skill-validation-test.ts
+++ b/packages/realm-server/tests/server-endpoints/skill-validation-test.ts
@@ -2,8 +2,14 @@ import QUnit from 'qunit';
 const { module, test } = QUnit;
 import { basename } from 'path';
 import type { Test, SuperTest } from 'supertest';
-import { rri, type LooseSingleCardDocument } from '@cardstack/runtime-common';
 import {
+  rri,
+  type LooseSingleCardDocument,
+  type ModulePrerenderArgs,
+  type Prerenderer,
+} from '@cardstack/runtime-common';
+import {
+  getTestPrerenderer,
   realmServerSecretSeed,
   setupPermissionedRealmCached,
   testRealmURL,
@@ -56,6 +62,39 @@ function skillDoc(
         },
       },
     },
+  };
+}
+
+// A prerenderer that counts `prerenderModule` calls and delegates everything
+// else (realm indexing during setup needs a real `prerenderVisit`, so a pure
+// stub won't do). The count lets a test observe when the validation endpoint
+// actually reruns the sweep versus serving its cached result.
+interface CountingPrerenderer {
+  prerenderer: Prerenderer;
+  setDelegate: (delegate: Prerenderer) => void;
+  moduleCalls: () => number;
+}
+function makeCountingPrerenderer(): CountingPrerenderer {
+  let delegate: Prerenderer | undefined;
+  let moduleCalls = 0;
+  let prerenderer = new Proxy({} as Prerenderer, {
+    get(_target, prop, receiver) {
+      if (prop === 'prerenderModule') {
+        return (args: ModulePrerenderArgs) => {
+          moduleCalls++;
+          return delegate!.prerenderModule(args);
+        };
+      }
+      let value = Reflect.get(delegate!, prop, receiver);
+      return typeof value === 'function' ? value.bind(delegate!) : value;
+    },
+  });
+  return {
+    prerenderer,
+    setDelegate: (d) => {
+      delegate = d;
+    },
+    moduleCalls: () => moduleCalls,
   };
 }
 
@@ -132,12 +171,9 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       });
 
       test('reports each tool codeRef that fails to resolve', async function (assert) {
-        // refresh=true forces a synchronous recompute so the assertion doesn't
-        // depend on the per-realm result cache (the two modules here share a
-        // realm URL).
         let response = await request
           .get(
-            `/_skill-validation?realm=${encodeURIComponent(testRealmURL.href)}&refresh=true`,
+            `/_skill-validation?realm=${encodeURIComponent(testRealmURL.href)}`,
           )
           .set(
             'Authorization',
@@ -226,7 +262,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       test('passes when every tool codeRef resolves in a private realm', async function (assert) {
         let response = await request
           .get(
-            `/_skill-validation?realm=${encodeURIComponent(testRealmURL.href)}&refresh=true`,
+            `/_skill-validation?realm=${encodeURIComponent(testRealmURL.href)}`,
           )
           .set(
             'Authorization',
@@ -238,6 +274,85 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
         assert.strictEqual(attributes.skillsChecked, 3, 'all skills checked');
         assert.strictEqual(attributes.toolsChecked, 2, 'tools checked');
         assert.deepEqual(attributes.failures, [], 'no failures');
+      });
+    });
+
+    module('_skill-validation result caching', function (hooks) {
+      let request: SuperTest<Test>;
+      let counting = makeCountingPrerenderer();
+
+      // Registered before setupPermissionedRealmCached so it runs first: the
+      // delegate is in place before the template build and server boot route
+      // their prerender work through the counting proxy.
+      hooks.before(async function () {
+        counting.setDelegate(await getTestPrerenderer());
+      });
+
+      setupPermissionedRealmCached(hooks, {
+        fileSystem: {
+          'test-tool.gts': TOOL_MODULE_SOURCE,
+          'valid-skill.json': skillDoc([
+            { module: `${testRealmURL.href}test-tool`, name: 'default' },
+          ]),
+        },
+        permissions: {
+          '*': ['read', 'write'],
+        },
+        prerenderer: counting.prerenderer,
+        onRealmSetup(args) {
+          request = args.request;
+        },
+      });
+
+      test('serves a cached result and only reruns the sweep on refresh=true', async function (assert) {
+        let token = await monitoringAuthToken(realmServerSecretSeed);
+        let poll = (query = '') =>
+          request
+            .get(
+              `/_skill-validation?realm=${encodeURIComponent(
+                testRealmURL.href,
+              )}${query}`,
+            )
+            .set('Authorization', `Bearer ${token}`);
+
+        // Nothing is cached after boot, so the first poll computes on the
+        // request path — one prerenderModule per unique tool module (one here).
+        let beforeCold = counting.moduleCalls();
+        let first = await poll();
+        assert.strictEqual(first.status, 200, 'first poll succeeds');
+        assert.strictEqual(
+          first.body.data.attributes.status,
+          'pass',
+          'first poll passes',
+        );
+        assert.ok(
+          counting.moduleCalls() > beforeCold,
+          'the cold poll runs the sweep',
+        );
+
+        // A second poll well inside the refresh interval serves the cached
+        // result without touching the prerenderer.
+        let afterCold = counting.moduleCalls();
+        let second = await poll();
+        assert.strictEqual(second.status, 200, 'second poll succeeds');
+        assert.strictEqual(
+          second.body.data.attributes.status,
+          'pass',
+          'second poll passes',
+        );
+        assert.strictEqual(
+          counting.moduleCalls(),
+          afterCold,
+          'the warm poll serves the cache without rerunning the sweep',
+        );
+
+        // refresh=true forces a synchronous recompute regardless of cache age.
+        let refreshed = await poll('&refresh=true');
+        assert.strictEqual(refreshed.status, 200, 'refresh poll succeeds');
+        assert.ok(
+          counting.moduleCalls() > afterCold,
+          'refresh=true reruns the sweep',
+        );
       });
     });
   });


### PR DESCRIPTION
The purpose of the `/_skill-validation` endpoint is to give us an early warning if skills are likely to be broken in the assistant. Since it’s been deployed it’s been flaky (which is why I kept it in the drafts channel):

<img width="728" height="2106" alt="s 2026-07-15 at 12 16 15@2x" src="https://github.com/user-attachments/assets/3dd7e137-3191-43b5-8899-5451f83f672d" />

This is because it needs to prerender every tool module, which sometimes reaches Checkly “degraded” status, and occasionally even exceeds the Checkly 30s maximum. We shouldn’t have alarms going off for reasons unrelated to their actual goals.

This PR adds caching of the validation results. A request for `/_skill-validation` schedules a validation refresh so the next request gets its results. The response includes `ageSeconds` to indicate when the results are from.