### PR TITLE
Add template-lint rule forbidding nested `<style scoped>`

### DIFF
--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -942,6 +942,57 @@ export default class Sample extends Component {
       );
     });
 
+    test('flags a nested plain `<style>` that the fix pass auto-scopes (no-nested-scoped-style)', async function (assert) {
+      // The riskiest interaction between the two style rules: a nested
+      // `<style>` with no `scoped` attribute. `require-scoped-style` adds
+      // `scoped` during the fix pass, and the verify of the fixed output is
+      // what rejects the (now scoped) nested style — so this asserts the
+      // fix-then-reject combination survives changes to rule ordering or
+      // fix application.
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('X-Filename', 'nested-plain-style.gts').send(`<template>
+  <div class="my-card">
+    <style>
+      .my-card { color: red; }
+    </style>
+  </div>
+</template>
+`);
+      assert.strictEqual(response.status, 200);
+      let body = JSON.parse(response.text);
+      let messages = body.messages as {
+        source: string;
+        ruleId: string | null;
+        severity: number;
+      }[];
+      let hit = messages.find(
+        (m) =>
+          m.source === 'template-lint' && m.ruleId === 'no-nested-scoped-style',
+      );
+      assert.ok(
+        hit,
+        `auto-scoped nested <style> should be flagged by template-lint: ${JSON.stringify(
+          messages,
+        )}`,
+      );
+      assert.strictEqual(
+        hit?.severity,
+        2,
+        'the nesting error is not fixable, so it survives the fix pass at error severity',
+      );
+      assert.ok(
+        (body.output as string).includes('<style scoped>'),
+        `the fix pass still auto-scopes the style even though its placement is rejected: ${body.output}`,
+      );
+    });
+
     test('lints .gjs files with the gts parser (host config has no .gjs override)', async function (assert) {
       let response = await request
         .post('/_lint')

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -874,6 +874,74 @@ export default class Sample extends Component {
       );
     });
 
+    test('flags a `<style scoped>` nested inside an element (no-nested-scoped-style)', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('X-Filename', 'nested-style.gts').send(`<template>
+  <div class="my-card">
+    <style scoped>
+      .my-card { color: red; }
+    </style>
+  </div>
+</template>
+`);
+      assert.strictEqual(response.status, 200);
+      let body = JSON.parse(response.text);
+      let messages = body.messages as {
+        source: string;
+        ruleId: string | null;
+        severity: number;
+      }[];
+      let hit = messages.find(
+        (m) =>
+          m.source === 'template-lint' && m.ruleId === 'no-nested-scoped-style',
+      );
+      assert.ok(
+        hit,
+        `nested <style scoped> should be flagged by template-lint: ${JSON.stringify(
+          messages,
+        )}`,
+      );
+      assert.strictEqual(
+        hit?.severity,
+        2,
+        'no-nested-scoped-style is error severity (nested scoped styles fail transpilation)',
+      );
+    });
+
+    test('does not flag a `<style scoped>` at the template root (no-nested-scoped-style)', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('X-Filename', 'root-style.gts').send(`<template>
+  <div class="my-card">Hello</div>
+  <style scoped>
+    .my-card { color: red; }
+  </style>
+</template>
+`);
+      assert.strictEqual(response.status, 200);
+      let body = JSON.parse(response.text);
+      let messages = body.messages as { ruleId: string | null }[];
+      assert.notOk(
+        messages.some((m) => m.ruleId === 'no-nested-scoped-style'),
+        `root-level <style scoped> should not be flagged: ${JSON.stringify(
+          messages,
+        )}`,
+      );
+    });
+
     test('lints .gjs files with the gts parser (host config has no .gjs override)', async function (assert) {
       let response = await request
         .post('/_lint')

--- a/packages/template-lint/lib/no-nested-scoped-style.mjs
+++ b/packages/template-lint/lib/no-nested-scoped-style.mjs
@@ -1,0 +1,50 @@
+import { Rule } from 'ember-template-lint';
+
+// A `<style scoped>` element must be a direct child of the template root.
+// glimmer-scoped-css throws during module transpilation for any other
+// placement ("<style> tags must be at the root of the template, they cannot be
+// nested"), so catch it here at lint time instead. We track the enclosing
+// container nodes (elements and blocks) as we descend; a scoped style is only
+// valid when that stack is empty (i.e. its immediate parent is the template).
+export default class NoNestedScopedStyle extends Rule {
+  visitor() {
+    let containers = [];
+
+    let checkStyle = (node) => {
+      if (node.tag !== 'style') {
+        return;
+      }
+      let hasScoped = node.attributes.some((attr) => attr.name === 'scoped');
+      if (!hasScoped) {
+        return;
+      }
+      if (containers.length > 0) {
+        this.log({
+          message:
+            '`<style scoped>` must be a direct child of `<template>`, not nested inside another element or block. Nested scoped styles fail module transpilation.',
+          node,
+        });
+      }
+    };
+
+    return {
+      ElementNode: {
+        enter(node) {
+          checkStyle(node);
+          containers.push(node);
+        },
+        exit() {
+          containers.pop();
+        },
+      },
+      Block: {
+        enter(node) {
+          containers.push(node);
+        },
+        exit() {
+          containers.pop();
+        },
+      },
+    };
+  }
+}

--- a/packages/template-lint/lib/no-nested-scoped-style.mjs
+++ b/packages/template-lint/lib/no-nested-scoped-style.mjs
@@ -6,6 +6,11 @@ import { Rule } from 'ember-template-lint';
 // nested"), so catch it here at lint time instead. We track the enclosing
 // container nodes (elements and blocks) as we descend; a scoped style is only
 // valid when that stack is empty (i.e. its immediate parent is the template).
+//
+// A nested `<style>` without `scoped` needs no special handling here: under
+// verifyAndFix, `require-scoped-style` adds `scoped` in the fix pass and the
+// verify of the fixed output is where this rule judges placement. The nesting
+// error itself is not fixable, so it survives to the final message list.
 export default class NoNestedScopedStyle extends Rule {
   visitor() {
     let containers = [];

--- a/packages/template-lint/plugin.mjs
+++ b/packages/template-lint/plugin.mjs
@@ -1,4 +1,5 @@
 import requireScopedStyle from './lib/require-scoped-style.mjs';
+import noNestedScopedStyle from './lib/no-nested-scoped-style.mjs';
 import noDataTestSelector from './lib/no-data-test-selector.mjs';
 import noUnusedBlockParamsExceptUnderscore from './lib/no-unused-block-params-except-underscore.mjs';
 
@@ -7,6 +8,7 @@ export default {
 
   rules: {
     'require-scoped-style': requireScopedStyle,
+    'no-nested-scoped-style': noNestedScopedStyle,
     'no-data-test-selector': noDataTestSelector,
     'no-unused-block-params-except-underscore':
       noUnusedBlockParamsExceptUnderscore,
@@ -17,6 +19,7 @@ export default {
       extends: 'recommended',
       rules: {
         'require-scoped-style': true,
+        'no-nested-scoped-style': true,
         'no-data-test-selector': true,
 
         // Replace core `no-unused-block-params` with an underscore-aware


### PR DESCRIPTION
## CS-12126

A `<style scoped>` element must be a direct child of `<template>` (conventionally after the root markup):

```gts
<template>
  <article class='my-card'>...</article>
  <style scoped>
    .my-card { padding: var(--boxel-sp); }
  </style>
</template>
```

Nesting it inside an element or block currently passes linting, then fails at module transpilation with `<style> tags must be at the root of the template, they cannot be nested`. This adds a lint rule that catches it up front.

## Where the rule lives

`@cardstack/template-lint` (`no-nested-scoped-style`, enabled in its `recommended` config next to `require-scoped-style`) rather than the boxel ESLint plugin — because:

- Card content in the realm packages (`base`, `catalog`, `experiments-realm`, `skills-realm`, …) is linted by **ember-template-lint only**, not the `@cardstack/boxel` ESLint plugin. Template-lint is the only home that covers committed card content in CI.
- The card-authoring `/_lint` endpoint runs host's ember-template-lint config, so the rule fires there too.

It mirrors glimmer-scoped-css's exact failure condition: a scoped `<style>` is valid only when its immediate glimmer parent is the template root. Detection tracks a stack of enclosing `ElementNode`/`Block` nodes (ember-template-lint's visitor has no `parent` reference).

## Testing

- Verified through the actual `/_lint` code path (host `.template-lintrc.js` via `new TemplateLinter({ workingDir: <host> })` + `verifyAndFix`): nested scoped style → error; root-level → clean; a nested plain `<style>` gets `scoped` auto-added by `require-scoped-style` and is then flagged.
- Swept all 543 committed template files that use scoped styles — **0 existing violations**, so enabling it as recommended does not break CI.
- Added two end-to-end `/_lint` tests in `packages/realm-server/tests/realm-endpoints/lint-test.ts` (nested → flagged `severity 2`, root → not flagged). These run in CI's full realm-server suite; I couldn't complete a local isolated run because the module's cached-realm fixture bootstrap needs a fully-booted dev stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)