### PR TITLE
Make MarkdownDef embedded preview height configurable

### DIFF
--- a/packages/base/markdown-file-def.gts
+++ b/packages/base/markdown-file-def.gts
@@ -249,14 +249,28 @@ class Embedded extends Component<typeof MarkdownDef> {
         font-weight: 600;
       }
 
+      /*
+        Embedded markdown is a bounded preview by default: a max-height clip
+        plus a bottom fade hinting that there is more to open and read. The
+        embedding context can retune this across the embed boundary via two
+        custom properties (the only lever it has, since it cannot pass args
+        into a framework-driven embedded render):
+          - a taller bounded preview:
+              --markdown-embedded-max-height: 500px;
+          - full, unbounded content (drop the clip AND the fade together):
+              --markdown-embedded-max-height: none;
+              --markdown-embedded-mask: none;
+      */
       .markdown-embedded__content {
-        max-height: 200px;
+        max-height: var(--markdown-embedded-max-height, 200px);
         overflow: hidden;
-        mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
-        -webkit-mask-image: linear-gradient(
-          to bottom,
-          black 60%,
-          transparent 100%
+        mask-image: var(
+          --markdown-embedded-mask,
+          linear-gradient(to bottom, black 60%, transparent 100%)
+        );
+        -webkit-mask-image: var(
+          --markdown-embedded-mask,
+          linear-gradient(to bottom, black 60%, transparent 100%)
         );
       }
 


### PR DESCRIPTION
## What

The base `MarkdownDef` embedded format hardcoded a `200px` height clip plus a bottom fade mask on `.markdown-embedded__content`. Embedded markdown is meant to be a bounded preview, but the bound was one-size and the embedding context had no way to retune it — long docs got clipped at 200px whether or not that suited the container.

This exposes the preview treatment as two CSS custom properties so the embedding context can retune it across the embed boundary. Custom properties are the only lever available here: a framework-driven embedded render can't take component args, but inherited custom properties cascade in from an ancestor.

- `--markdown-embedded-max-height` (default `200px`) — the height ceiling
- `--markdown-embedded-mask` (default the bottom fade) — the clip affordance

Defaults preserve today's 200px-fade preview exactly.

```css
/* taller bounded preview — keeps the "there's more" fade */
--markdown-embedded-max-height: 500px;

/* full, unbounded content — drop the clip AND the fade together */
--markdown-embedded-max-height: none;
--markdown-embedded-mask: none;
```

The two properties are paired for the unbounded case because with `max-height: none` the `overflow: hidden` no longer clips anything, so a leftover mask would fade the bottom of the whole document. A comment above the rule spells that out.

## Skill update prompt

Once this merges, run the following to update the component-styling skill:

> The base `MarkdownDef` embedded format (`packages/base/markdown-file-def.gts`) now exposes two CSS custom properties for tuning its bounded preview: `--markdown-embedded-max-height` (default `200px`) and `--markdown-embedded-mask` (default a bottom fade). Update the gts/component-styling skill accordingly:
>
> - Replace any guidance that tells a consuming card to override `.markdown-embedded__content` with `:deep()` and specificity tricks (e.g. an "Expanding embedded MarkdownDef" section). Reaching into another card's scoped CSS with `:deep()` to undo its styling is the anti-pattern, not the pattern to teach.
> - Document the knobs instead: set `--markdown-embedded-max-height` on an ancestor of the embedded render for a taller bounded preview; set both `--markdown-embedded-max-height: none` and `--markdown-embedded-mask: none` together for full, unbounded content.
> - Explain why custom properties are the mechanism: a framework-driven embedded render can't receive component args, so an inherited custom property is the only lever the embedding context has across the embed boundary.
> - Note the alternative for truly unbounded display: render the card's isolated format, which is unbounded by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
