### PR TITLE
Fix OpenRouter model sync sending wrong command input key

### DIFF
--- a/packages/realm-server/scripts/sync-openrouter-models.ts
+++ b/packages/realm-server/scripts/sync-openrouter-models.ts
@@ -54,7 +54,7 @@ export async function enqueueSyncOpenRouterModels({
     realmUsername: REALM_USERNAME,
     runAs: REALM_USERNAME,
     command: COMMAND_SPECIFIER,
-    commandInput: { realmUrl: realmURL },
+    commandInput: { realmIdentifier: realmURL },
   };
 
   try {


### PR DESCRIPTION
## Problem

The OpenRouter model realm had stopped updating. The daily scheduled sync (and any manual `pnpm openrouter:sync`) was silently failing: every enqueued `run-command` job resolved with

> `realmIdentifier is required`

so the realm's model list drifted ~3 months stale.

## Root cause

`scripts/sync-openrouter-models.ts` enqueues the job with `commandInput: { realmUrl: realmURL }`, but the `sync-openrouter-models` tool reads `input.realmIdentifier` (its input card is `RealmIdentifierCard`, whose field is `realmIdentifier`). The mismatched key left `realmIdentifier` undefined, so the tool threw before making any API call. This looks like fallout from the command→tool rename that changed the input field name without updating the enqueue script.

## Fix

Send `{ realmIdentifier }` to match the tool's input card. Verified by re-running the sync locally: the job now succeeds ("Successfully synced ... models from API").

🤖 Generated with [Claude Code](https://claude.com/claude-code)