### PR TITLE
Use a Set for O(1) included-dedup in loadLinks (+ fix flaky host-test socket timeout)

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -734,6 +734,19 @@ jobs:
           name: testem-log-${{ matrix.shardIndex }}
           path: junit/host-testem.log
           retention-days: 30
+      # testem's internal server log — records the browser↔testem socket
+      # handshake (attach / disconnect / disconnectCount / reconnection-limit
+      # refusal / process exit) that the TAP output omits. It's the only
+      # server-side view of the intermittent post-suite `Browser timeout
+      # exceeded` synthetic failure.
+      - name: Upload testem debug log
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: testem-debug-log-${{ matrix.shardIndex }}
+          path: junit/host-testem-debug-${{ matrix.shardIndex }}.log
+          retention-days: 30
+          if-no-files-found: ignore
 
   host-percy-finalize:
     name: Finalise Percy

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -13,6 +13,16 @@ if (typeof module !== 'undefined') {
     browser_timeout: 120,
     browser_no_activity_timeout: 120,
     browser_disconnect_timeout: 60,
+    // socket.io pingTimeout. testem otherwise derives this from
+    // browser_disconnect_timeout (60s), which is too tight for this suite: on
+    // a CI runner the whole service stack and Chrome contend for two vCPUs, so
+    // the browser can be too starved to answer a socket.io ping within 60s
+    // even while every test is still passing — the control socket then drops
+    // and testem reports the browser dead mid-run. browser_no_activity_timeout
+    // (120s) still bounds a genuinely stuck browser that stops producing
+    // results, so widening the ping tolerance only keeps a slow-but-
+    // progressing browser connected.
+    socket_heartbeat_timeout: 300,
     launch_in_ci: ['Chrome'],
     launch_in_dev: ['Chrome'],
     browser_start_timeout: 240,
@@ -78,6 +88,54 @@ if (typeof module !== 'undefined') {
     const multiReporter = new MultiReporter({ reporters });
 
     config.reporter = multiReporter;
+
+    // Capture testem's own server-side log of the browser↔testem control
+    // channel — socket attach / reconnect (`tryAttach`), the `socket
+    // reconnection limit has been exceeded` refusal, `Browser … finished all
+    // tests`, and process exit. These events are the only record of the
+    // handshake behind a `Browser timeout exceeded` failure (the socket drop
+    // the socket_heartbeat_timeout above guards against); the TAP output shows
+    // the passing tests but nothing about the socket afterward. It is kept so
+    // any such failure is diagnosable directly from the CI artifact.
+    //
+    // A file-level `debug` option can't reach this: testem's
+    // `Api.configureLogging()` binds the log output stream from CLI/default
+    // options *before* it reads this config file, so the assignment is
+    // ignored. But testem's `log` is a singleton EventEmitter that emits a
+    // `log.<level>` event on every message regardless of that stream, so
+    // subscribe to those events directly and tee them to a file (uploaded as
+    // a CI artifact). `Browser … finished all tests` here is also the
+    // authoritative signal that the browser reported suite completion —
+    // browser-side `console.log` after the last test isn't reliably flushed
+    // into the TAP output, so it can't stand in for this.
+    const testemInternalLog = require('testem/lib/log');
+    const debugStream = fs.createWriteStream(
+      path.join(
+        junitDir,
+        `host-testem-debug-${process.env.HOST_TEST_PARTITION}.log`,
+      ),
+    );
+    for (const level of [
+      'error',
+      'warn',
+      'notice',
+      'info',
+      'verbose',
+      'http',
+      'timing',
+    ]) {
+      testemInternalLog.on(`log.${level}`, (record) => {
+        try {
+          const prefix = record && record.prefix ? `${record.prefix} ` : '';
+          const message = record ? record.message : '';
+          debugStream.write(
+            `${new Date().toISOString()} [${level}] ${prefix}${message}\n`,
+          );
+        } catch (e) {
+          // best-effort diagnostics — never let logging break the run
+        }
+      });
+    }
   }
 
   module.exports = config;

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -1414,6 +1414,16 @@ export class RealmIndexQueryEngine {
       vnForIdentity.equivalentURLForms(vnForIdentity.toURLHref(id));
     let omitSet = new Set(omit.flatMap((id) => allIdForms(id)));
     let visited = new Set<string>();
+    // Mirror the id of every resource in included[] so dedup is O(1): the
+    // relationship-target check (per entry) and the pre-push check (per
+    // resource) are Set lookups rather than linear scans of an array that
+    // grows to the full transitive-closure size.
+    let includedIds = new Set<string>();
+    for (let existing of included) {
+      if (existing.id != null) {
+        includedIds.add(existing.id);
+      }
+    }
 
     type LayerItem = {
       resource: LooseCardResource | FileMetaResource;
@@ -1800,7 +1810,7 @@ export class RealmIndexQueryEngine {
         if (
           foundLinks ||
           omitSet.has(entry.relationshipIdStr) ||
-          included.find((i) => i.id === entry.relationshipIdStr)
+          includedIds.has(entry.relationshipIdStr)
         ) {
           entry.relationship.data = {
             type: linkResource?.type ?? CardResourceType,
@@ -1848,7 +1858,7 @@ export class RealmIndexQueryEngine {
         if (omitSet.has(resource.id)) {
           continue;
         }
-        if (included.find((r) => r.id === resource.id)) {
+        if (includedIds.has(resource.id)) {
           continue;
         }
         let rewritten = cloneDeep({
@@ -1872,6 +1882,7 @@ export class RealmIndexQueryEngine {
           ),
         );
         included.push(rewritten);
+        includedIds.add(resource.id);
       }
 
       layer = nextLayer;


### PR DESCRIPTION
This PR carries two independent changes.

## O(1) included-dedup in `loadLinks`

`RealmIndexQueryEngine.loadLinks` assembles the JSON:API `included[]` array for a search response by walking the transitive closure of linked resources. Two dedup checks run inside that walk — whether a relationship's target is already included, and whether a resource is already included — and both were linear scans (`included.find(...)`) over an array that grows to the full closure size, making the walk O(n²) in the number of included resources.

This mirrors each included resource's id into a `Set` and turns both checks into O(1) lookups, keeping the array and the Set in sync as resources are pushed.

## Fix for the flaky host-test socket timeout

Host test shards intermittently fail with a synthetic `Browser timeout exceeded: 60s`, attributed to whichever test ran last, even though every real test passes. testem emits that when the browser's socket.io control channel drops before the suite reports done. On a two-vCPU CI runner the whole service stack and Chrome contend for CPU, so the browser can be too starved to answer a socket.io ping within the 60s testem derives from `browser_disconnect_timeout` — the control socket drops mid-run while the browser is healthy and still finishing the suite.

`socket_heartbeat_timeout` (socket.io's `pingTimeout`) is raised to 300s so a slow-but-progressing browser stays connected. `browser_no_activity_timeout` (120s) still bounds a genuinely stuck browser that stops producing results. testem's control-channel log is also teed to a per-shard CI artifact (`host-testem-debug-*`) so any recurrence is diagnosable from the artifact.
