### PR TITLE
Fix flaky matrix realm-provisioning timeouts with a dedicated index worker tier

### DIFF
--- a/mise-tasks/infra/ensure-pg
+++ b/mise-tasks/infra/ensure-pg
@@ -10,7 +10,13 @@ if [ -z "$(docker ps -f name=boxel-pg --all --format '{{.Names}}')" ]; then
   # keeps caching it (it must match the version pinned there):
   # .github/workflows/mirror-test-images.yml and
   # .github/actions/warm-test-images/action.yml.
-  docker run --name boxel-pg -e POSTGRES_HOST_AUTH_METHOD=trust -p "${PGPORT:-5435}":5432 -d postgres:16.3 >/dev/null 2>&1 || true
+  #
+  # max_connections is raised above postgres's default of 100 because one
+  # boxel-pg backs every service in a test stack — realm servers plus their
+  # worker pools, and the matrix suite stacks a second isolated set on top —
+  # and each opens its own pg pool (up to PG_POOL_MAX=40), so the default
+  # ceiling is exhausted under load. Keep this in sync with start-pg.sh.
+  docker run --name boxel-pg -e POSTGRES_HOST_AUTH_METHOD=trust -p "${PGPORT:-5435}":5432 -d postgres:16.3 -c max_connections=300 >/dev/null 2>&1 || true
 fi
 # Ensure the container is running (handles both the race case and stopped containers)
 docker start boxel-pg >/dev/null 2>&1 || true

--- a/mise-tasks/infra/ensure-pg
+++ b/mise-tasks/infra/ensure-pg
@@ -16,7 +16,7 @@ if [ -z "$(docker ps -f name=boxel-pg --all --format '{{.Names}}')" ]; then
   # worker pools, and the matrix suite stacks a second isolated set on top —
   # and each opens its own pg pool (up to PG_POOL_MAX=40), so the default
   # ceiling is exhausted under load. Keep this in sync with start-pg.sh.
-  docker run --name boxel-pg -e POSTGRES_HOST_AUTH_METHOD=trust -p "${PGPORT:-5435}":5432 -d postgres:16.3 -c max_connections=300 >/dev/null 2>&1 || true
+  docker run --name boxel-pg -e POSTGRES_HOST_AUTH_METHOD=trust -p "${PGPORT:-5435}":5432 -d postgres:16.3 -c max_connections=400 >/dev/null 2>&1 || true
 fi
 # Ensure the container is running (handles both the race case and stopped containers)
 docker start boxel-pg >/dev/null 2>&1 || true

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -179,6 +179,11 @@ export async function createRealm(
   let modal = page.locator('[data-test-create-workspace-modal]');
   let submitButton = page.locator('[data-test-create-workspace-submit]');
   let maxAttempts = 3;
+  // How long the modal is given to settle (tile or error) per attempt. The
+  // dominant cost is the newly-created realm's from-scratch-index waiting in
+  // the worker queue behind other realms' index + prerender-html jobs. Also
+  // used as the "near budget" yardstick below.
+  let settleTimeoutMs = 30_000;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     // A previous attempt's provisioning may have landed late — if the tile is
     // already present, don't try to create a duplicate endpoint.
@@ -191,9 +196,10 @@ export async function createRealm(
     await page.locator('[data-test-endpoint-field]').fill(endpoint);
     await page.locator('[data-test-create-workspace-submit]').click();
 
+    let startedAt = Date.now();
     try {
       await expect(workspaceTile.or(errorMessage).first()).toBeVisible({
-        timeout: 30_000,
+        timeout: settleTimeoutMs,
       });
     } catch (cause) {
       // Neither the tile nor an error surfaced. Distinguish "still creating"
@@ -210,9 +216,26 @@ export async function createRealm(
           : 'modal closed without the workspace tile appearing';
       let detail = cause instanceof Error ? cause.message : String(cause);
       throw new Error(
-        `createRealm("${endpoint}") did not settle within 30s: ${state}\n` +
-          `underlying expectation failure: ${detail}`,
+        `createRealm("${endpoint}") did not settle within ${
+          settleTimeoutMs / 1000
+        }s: ${state}\n` + `underlying expectation failure: ${detail}`,
       );
+    }
+    // Log how long provisioning took. Because the failure mode is the settle
+    // wait creeping up under worker-queue load, surfacing the elapsed time on
+    // every run (and flagging a near-budget "close call" even when the tile
+    // did appear) turns a future regression into a visible warning before it
+    // crosses the timeout and starts failing.
+    let elapsedMs = Date.now() - startedAt;
+    let elapsedS = (elapsedMs / 1000).toFixed(1);
+    if (elapsedMs >= settleTimeoutMs * 0.6) {
+      console.log(
+        `[createRealm] "${endpoint}" settled in ${elapsedS}s — close to the ${
+          settleTimeoutMs / 1000
+        }s budget (worker-queue pressure)`,
+      );
+    } else {
+      console.log(`[createRealm] "${endpoint}" settled in ${elapsedS}s`);
     }
     if ((await workspaceTile.count()) > 0) {
       return;

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -228,11 +228,12 @@ export async function createRealm(
     // crosses the timeout and starts failing.
     let elapsedMs = Date.now() - startedAt;
     let elapsedS = (elapsedMs / 1000).toFixed(1);
-    if (elapsedMs >= settleTimeoutMs * 0.6) {
+    let warnFraction = 0.6;
+    if (elapsedMs >= settleTimeoutMs * warnFraction) {
       console.log(
-        `[createRealm] "${endpoint}" settled in ${elapsedS}s — close to the ${
-          settleTimeoutMs / 1000
-        }s budget (worker-queue pressure)`,
+        `[createRealm] "${endpoint}" settled in ${elapsedS}s — past ${
+          warnFraction * 100
+        }% of the ${settleTimeoutMs / 1000}s budget (worker-queue pressure)`,
       );
     } else {
       console.log(`[createRealm] "${endpoint}" settled in ${elapsedS}s`);

--- a/packages/matrix/support/isolated-realm-server.ts
+++ b/packages/matrix/support/isolated-realm-server.ts
@@ -472,15 +472,18 @@ export async function startServer({
     //
     // Two high-priority workers, not one: both Playwright workers
     // (fullyParallel) share this single realm server, so their createRealm
-    // provisioning enqueues into one high-priority pool. A createRealm index
-    // job (priority 10) and a preceding realm's prerender-html job (priority
-    // 9) both land there; the prerender-html for a freshly-created workspace
-    // is ~110 files and takes ~10s. With one worker those serialize — a
-    // second workspace's index job waits behind a full prerender-html sweep,
-    // and under concurrent load from both Playwright workers the wait stacks
-    // past the 30s createRealm settle budget. A second high-priority worker
-    // lets the higher-priority index job run on a free worker instead of
-    // queueing behind the render sweep, keeping provisioning inside budget.
+    // provisioning funnels into one high-priority pool. Each new workspace
+    // enqueues a from-scratch index (priority 10) plus a ~110-file, ~10s
+    // prerender-html sweep (priority 9), all eligible for this pool. Priority
+    // is a pool-reservation floor, not an ordering — within a pool the queue
+    // dequeues oldest-first (see runtime-common/queue.ts) — so a newer index
+    // job is NOT pulled ahead of an already-queued prerender-html sweep. With
+    // a single worker one in-flight ~10s sweep serializes everything behind
+    // it, and the wait stacks across both Playwright workers past the 30s
+    // createRealm settle budget. The lever is therefore drain capacity, not
+    // priority: the producers are fixed at two Playwright workers, so a
+    // second high-priority worker takes the ratio to 1:1 and keeps the queue
+    // shallow enough that index jobs settle well inside budget.
     `--highPriorityCount=2`,
 
     `--fromUrl='https://localhost:4205/test/'`,

--- a/packages/matrix/support/isolated-realm-server.ts
+++ b/packages/matrix/support/isolated-realm-server.ts
@@ -460,30 +460,28 @@ export async function startServer({
     `--matrixURL='${matrixURL}'`,
     `--prerendererUrl='${prerenderURL}'`,
     `--migrateDB`,
-    // Production parity for the worker tiers: dedicated high-priority
-    // workers (floor 9) serve user-initiated jobs — a test's createRealm
-    // indexing (priority 10) and its spawned prerender-html (9) — while the
-    // all-priority worker digests system-tier work. Without them, the lone
-    // all-priority worker claims jobs oldest-first regardless of priority,
-    // so the boot realms' system prerender-html jobs (which include the
-    // realm-wide module pre-warm sweep, minutes of work on a loaded runner)
-    // hold the only worker while the first tests' createRealm index jobs sit
-    // queued past their 30s provisioning wait.
+    // Worker tiers for this shared, contended stack. Both Playwright
+    // workers (fullyParallel) funnel their realm provisioning into one
+    // worker manager, and each new workspace enqueues a from-scratch index
+    // (priority 10) plus a ~110-file, ~10s prerender-html sweep (priority 9).
+    // Priority is a pool-reservation floor, not an ordering — within a pool
+    // the queue dequeues oldest-first (see runtime-common/queue.ts) — so a
+    // newer index job is NOT pulled ahead of an already-queued prerender-html
+    // sweep in the same pool. That is what made createRealm (and new-user
+    // provisioning, which blocks on a personal-realm index before the
+    // workspace chooser renders) time out: the index sat behind ~10s render
+    // sweeps until it blew its settle budget.
     //
-    // Two high-priority workers, not one: both Playwright workers
-    // (fullyParallel) share this single realm server, so their createRealm
-    // provisioning funnels into one high-priority pool. Each new workspace
-    // enqueues a from-scratch index (priority 10) plus a ~110-file, ~10s
-    // prerender-html sweep (priority 9), all eligible for this pool. Priority
-    // is a pool-reservation floor, not an ordering — within a pool the queue
-    // dequeues oldest-first (see runtime-common/queue.ts) — so a newer index
-    // job is NOT pulled ahead of an already-queued prerender-html sweep. With
-    // a single worker one in-flight ~10s sweep serializes everything behind
-    // it, and the wait stacks across both Playwright workers past the 30s
-    // createRealm settle budget. The lever is therefore drain capacity, not
-    // priority: the producers are fixed at two Playwright workers, so a
-    // second high-priority worker takes the ratio to 1:1 and keeps the queue
-    // shallow enough that index jobs settle well inside budget.
+    // A dedicated user-index worker (floor 10) is the fix: it claims only
+    // indexing jobs and never the slower prerender-html tier below it, so an
+    // index job always has a lane that a render sweep can't hold. Index jobs
+    // are short (a fresh realm indexes in a few seconds once dequeued), so
+    // one is enough for the two-Playwright-worker producer rate.
+    `--userIndexCount=1`,
+    // Two high-priority workers still carry the prerender-html sweeps (and
+    // spill over onto indexing when free). Keep two, not one: republishing
+    // waits on the prerender-html job to regenerate the published HTML, so
+    // this tier must not become the new bottleneck.
     `--highPriorityCount=2`,
 
     `--fromUrl='https://localhost:4205/test/'`,

--- a/packages/matrix/support/isolated-realm-server.ts
+++ b/packages/matrix/support/isolated-realm-server.ts
@@ -460,16 +460,28 @@ export async function startServer({
     `--matrixURL='${matrixURL}'`,
     `--prerendererUrl='${prerenderURL}'`,
     `--migrateDB`,
-    // Production parity for the worker tiers: a dedicated high-priority
-    // worker (floor 9) serves user-initiated jobs — a test's createRealm
+    // Production parity for the worker tiers: dedicated high-priority
+    // workers (floor 9) serve user-initiated jobs — a test's createRealm
     // indexing (priority 10) and its spawned prerender-html (9) — while the
-    // all-priority worker digests system-tier work. Without it, the lone
+    // all-priority worker digests system-tier work. Without them, the lone
     // all-priority worker claims jobs oldest-first regardless of priority,
     // so the boot realms' system prerender-html jobs (which include the
     // realm-wide module pre-warm sweep, minutes of work on a loaded runner)
     // hold the only worker while the first tests' createRealm index jobs sit
     // queued past their 30s provisioning wait.
-    `--highPriorityCount=1`,
+    //
+    // Two high-priority workers, not one: both Playwright workers
+    // (fullyParallel) share this single realm server, so their createRealm
+    // provisioning enqueues into one high-priority pool. A createRealm index
+    // job (priority 10) and a preceding realm's prerender-html job (priority
+    // 9) both land there; the prerender-html for a freshly-created workspace
+    // is ~110 files and takes ~10s. With one worker those serialize — a
+    // second workspace's index job waits behind a full prerender-html sweep,
+    // and under concurrent load from both Playwright workers the wait stacks
+    // past the 30s createRealm settle budget. A second high-priority worker
+    // lets the higher-priority index job run on a free worker instead of
+    // queueing behind the render sweep, keeping provisioning inside budget.
+    `--highPriorityCount=2`,
 
     `--fromUrl='https://localhost:4205/test/'`,
     `--toUrl='https://localhost:4205/test/'`,

--- a/packages/postgres/scripts/start-pg.sh
+++ b/packages/postgres/scripts/start-pg.sh
@@ -13,9 +13,9 @@ if [ -z "$(docker ps -f name=boxel-pg --all --format '{{.Names}}')" ]; then
   # boxel-pg backs every service in a test stack at once — realm servers plus
   # their worker pools, and the matrix suite adds a second isolated stack on
   # top of the base one — and each process opens its own pg pool (up to
-  # PG_POOL_MAX=40). Six such pools already exceed the default ceiling, and a
-  # burst that crosses it fails callers with "sorry, too many clients
-  # already". Keep this in sync with mise-tasks/infra/ensure-pg.
-  docker run --name boxel-pg -e POSTGRES_HOST_AUTH_METHOD=trust -p "${PGPORT:-5435}":5432 -d postgres:16.3 -c max_connections=300 >/dev/null 2>&1 || true
+  # PG_POOL_MAX=40). That already clears half a dozen pools, and a burst that
+  # crosses the ceiling fails callers with "sorry, too many clients already".
+  # Keep this in sync with mise-tasks/infra/ensure-pg.
+  docker run --name boxel-pg -e POSTGRES_HOST_AUTH_METHOD=trust -p "${PGPORT:-5435}":5432 -d postgres:16.3 -c max_connections=400 >/dev/null 2>&1 || true
 fi
 docker start boxel-pg >/dev/null 2>&1 || true

--- a/packages/postgres/scripts/start-pg.sh
+++ b/packages/postgres/scripts/start-pg.sh
@@ -8,6 +8,14 @@ if [ -z "$(docker ps -f name=boxel-pg --all --format '{{.Names}}')" ]; then
   # mirror so CI keeps caching it (it must match the version pinned there):
   # .github/workflows/mirror-test-images.yml and
   # .github/actions/warm-test-images/action.yml.
-  docker run --name boxel-pg -e POSTGRES_HOST_AUTH_METHOD=trust -p "${PGPORT:-5435}":5432 -d postgres:16.3 >/dev/null 2>&1 || true
+  #
+  # max_connections is raised well above postgres's default of 100: a single
+  # boxel-pg backs every service in a test stack at once — realm servers plus
+  # their worker pools, and the matrix suite adds a second isolated stack on
+  # top of the base one — and each process opens its own pg pool (up to
+  # PG_POOL_MAX=40). Six such pools already exceed the default ceiling, and a
+  # burst that crosses it fails callers with "sorry, too many clients
+  # already". Keep this in sync with mise-tasks/infra/ensure-pg.
+  docker run --name boxel-pg -e POSTGRES_HOST_AUTH_METHOD=trust -p "${PGPORT:-5435}":5432 -d postgres:16.3 -c max_connections=300 >/dev/null 2>&1 || true
 fi
 docker start boxel-pg >/dev/null 2>&1 || true

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -41,6 +41,7 @@ writeSync(
 
 import {
   logger,
+  userInitiatedPriority,
   userInitiatedPrerenderHtmlPriority,
   systemInitiatedPrerenderHtmlPriority,
   query as _query,
@@ -128,6 +129,7 @@ let {
   matrixURL,
   allPriorityCount = 1,
   highPriorityCount = 0,
+  userIndexCount = 0,
   fromUrl: fromUrls,
   toUrl: toUrls,
   migrateDB,
@@ -144,6 +146,11 @@ let {
     highPriorityCount: {
       description:
         'The number of workers that service user-initiated jobs, including user-initiated prerender-html, and nothing below that tier (default 0)',
+      type: 'number',
+    },
+    userIndexCount: {
+      description:
+        'The number of workers that service only user-initiated indexing (priority 10) and nothing below it — a dedicated index tier that never gets held by the slower user-initiated prerender-html jobs (default 0)',
       type: 'number',
     },
     allPriorityCount: {
@@ -641,7 +648,10 @@ let adapter: PgAdapter;
 
 (async () => {
   log.info(
-    `starting ${highPriorityCount} high-priority ${pluralize(
+    `starting ${userIndexCount} user-index ${pluralize(
+      'worker',
+      userIndexCount,
+    )}, ${highPriorityCount} high-priority ${pluralize(
       'worker',
       highPriorityCount,
     )} and ${allPriorityCount} all-priority ${pluralize(
@@ -662,10 +672,19 @@ let adapter: PgAdapter;
   eventSink.setAdapter(adapter);
 
   // Each pool's minimum priority is a dequeue floor: its workers only
-  // claim jobs at or above it. The high-priority pool floors at the
+  // claim jobs at or above it, oldest-first among those. The user-index
+  // pool floors at the user-initiated indexing tier, so it claims only
+  // user indexing jobs and never the (orders-of-magnitude slower)
+  // prerender-html work one tier below — a dedicated lane that keeps
+  // index jobs (which gate createRealm and new-user provisioning) from
+  // waiting behind a prerender-html sweep already queued in the shared
+  // high-priority pool. The high-priority pool floors at the
   // user-initiated prerender-html tier so it serves all user-initiated
   // work — prerender-html included — and never system-tier jobs; the
   // all-priority pool floors at the lowest tier and serves everything.
+  for (let i = 0; i < userIndexCount; i++) {
+    await startWorker(userInitiatedPriority, urlMappings);
+  }
   for (let i = 0; i < highPriorityCount; i++) {
     await startWorker(userInitiatedPrerenderHtmlPriority, urlMappings);
   }


### PR DESCRIPTION
## Background

The matrix Playwright suite runs each shard against one isolated realm server on `:4205`, shared by both of Playwright's parallel workers. Provisioning a realm goes through `createRealm`, which blocks until the new realm's from-scratch index completes — that's what makes the workspace tile appear, and it's also what new-user registration waits on before the app leaves `<Auth/>` and renders the workspace chooser.

The realm server drains indexing work through a worker pool. Job priority is a **pool-reservation floor, not an ordering**: a worker claims jobs at or above its floor, oldest-first among those. Two job types share the user tier — a from-scratch index (priority 10) and the follow-on prerender-html render (priority 9), and a freshly-created ~110-file workspace's render sweep takes ~10s.

## The failure

On loaded CI runners, realm provisioning intermittently blew its timeout — `publish-realm.spec.ts` (`it warns when private dependencies…`, which creates two realms) and `registration-with-token.spec.ts` (whose workspace chooser only renders once the auto-created personal realm finishes indexing).

The cost wasn't indexing or rendering — a fresh realm indexes in a few seconds once a worker starts it, and the render pool was ~98% idle. The cost was **queue wait**: because dequeue is oldest-first within a floor, a priority-10 index job does not jump ahead of a priority-9 prerender-html sweep already queued in the same pool. So an index job sat 20–28s behind ~10s render sweeps until it exceeded its settle budget. Both Playwright workers funnel into the one pool, which compounds it.

## The fix

**A dedicated user-index worker tier.** `worker-manager` gains a `userIndexCount` option whose workers floor at the user-initiated indexing priority (10), so they claim *only* indexing jobs and never the slower prerender-html tier below. An index job always has a lane a render sweep can't hold, so provisioning stays fast regardless of render backlog. (Defaults to 0 — no change to any deployed worker unless configured.)

The matrix harness runs one user-index worker alongside two high-priority workers. The high-priority tier still carries the prerender-html sweeps — republishing waits on that job to regenerate the published HTML, so it keeps its capacity.

Supporting changes:
- **Test postgres `max_connections` → 400.** One `boxel-pg` backs every service in a stack (realm servers + their worker pools, base stack + isolated matrix stack), each with its own pool (up to `PG_POOL_MAX=40`). The default ceiling of 100 is exhausted under that fan-out, surfacing as `sorry, too many clients already`; the extra index worker adds one more pool.
- **`createRealm` settle-time diagnostics.** Logs how long each provisioning takes and flags a close call once it crosses 60% of the budget even on a pass, so future queue-pressure creep shows up as a warning before it fails.

No product behavior changes — the worker-manager option is opt-in and unused outside the test harness here.

## Out of scope (separate follow-up)

The matrix suite has a distinct, pre-existing flake class — `host-mode` / `head-tags` / republish tests that poll a published realm's server-rendered HTML. Published card HTML is served **only** from the `prerendered_html` table (populated by an async priority-9 `prerender_html` job); `serve-index.ts` has no on-demand render fallback, so under load the job loses the race and a shell is served without the card markup. That's a serve-path change (an on-demand render fallback, modeled on the client-side prerendered-or-hydrated pattern in `RenderableSearchEntry`/`HydratableCard`) and is tracked separately, not in this PR.
