### PR TITLE
Enforce hard resource bounds on search so no userland query can overwhelm the realm-server

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -36,7 +36,6 @@ import {
   isSpecCard,
   isCardErrorJSONAPI,
   internalKeyFor,
-  GetCardsContextName,
   GetCardContextName,
   loadCardDef,
   rri,
@@ -137,7 +136,6 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
   @service declare private specPanelService: SpecPanelService;
   @service declare private store: StoreService;
 
-  @consume(GetCardsContextName) declare private getCards: getCards;
   @consume(GetCardContextName) declare private getCard: getCard;
 
   @tracked private specSearch: ReturnType<getCards<Spec>> | undefined;
@@ -462,8 +460,10 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
     }
   };
 
+  // Host code-submode UI searches the store directly (uncapped); the card caps
+  // live on the `@context` surfaces this component does not consume.
   private findSpecsForSelectedDefinition = () => {
-    this.specSearch = this.getCards(
+    this.specSearch = this.store.getSearchResource(
       this,
       () => this.queryForSpecsForSelectedDefinition,
       () => this.realmServer.availableRealmIdentifiers,

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -40,7 +40,6 @@ import {
   internalKeyFor,
   type ResolvedCodeRef,
   GetCardContextName,
-  GetCardsContextName,
   type getCard,
   type getCards,
   chooseCard,
@@ -124,7 +123,6 @@ interface Signature {
 
 export default class PlaygroundPanel extends Component<Signature> {
   @consume(GetCardContextName) declare private getCard: getCard;
-  @consume(GetCardsContextName) declare private getCards: getCards;
   @consume(CardContextName) declare private cardContext: CardContext;
   @service declare private aiAssistantPanelService: AiAssistantPanelService;
   @service declare private toolService: ToolService;
@@ -366,7 +364,9 @@ export default class PlaygroundPanel extends Component<Signature> {
     if (!this.args.isFileDef) {
       return;
     }
-    this.fileSearchResults = this.getCards(
+    // Host code-submode UI searches the store directly (uncapped); the card
+    // caps live on the `@context` surfaces this component does not consume.
+    this.fileSearchResults = this.store.getSearchResource(
       this,
       () => this.fileMetaQuery,
       () => this.realmServer.availableRealmIdentifiers,

--- a/packages/host/app/components/operator-mode/code-submode/playground/spec-search.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/spec-search.gts
@@ -1,19 +1,16 @@
 import type Owner from '@ember/owner';
 import { next } from '@ember/runloop';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { consume } from 'ember-provide-consume-context';
-
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
-import {
-  GetCardsContextName,
-  type getCards,
-  type Query,
-} from '@cardstack/runtime-common';
+import type { getCards, Query } from '@cardstack/runtime-common';
 
 import consumeContext from '@cardstack/host/helpers/consume-context';
+
+import type StoreService from '@cardstack/host/services/store';
 
 interface Signature {
   Args: {
@@ -33,12 +30,15 @@ export default class SpecSearch extends Component<Signature> {
     {{/if}}
   </template>
 
-  @consume(GetCardsContextName) declare private getCards: getCards;
+  @service declare private store: StoreService;
 
   @tracked private specResults: ReturnType<getCards> | undefined;
 
+  // Host code-submode UI searches through the store directly (uncapped). The
+  // card caps live on the `@context` surfaces (`getCards` / `@context.store`),
+  // which this host component does not consume.
   private searchSpec = () => {
-    this.specResults = this.getCards(
+    this.specResults = this.store.getSearchResource(
       this,
       () => this.args.query,
       () => this.args.realms,

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -107,7 +107,7 @@ export default class OperatorModeContainer extends Component<Signature> {
       getCard: this.getCard,
       getCards: this.getCards,
       getCardCollection: this.getCardCollection,
-      store: this.store,
+      store: this.store.cardFacingStore,
       toolContext: this.toolContext,
       // populated alongside toolContext for content still reading the
       // pre-rename spelling

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 import { buildWaiter } from '@ember/test-waiters';
 import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
@@ -22,6 +23,7 @@ import {
   GetCardCollectionContextName,
   CommandContextName,
   type getCard as GetCardType,
+  type Query,
 } from '@cardstack/runtime-common';
 
 import Auth from '@cardstack/host/components/matrix/auth';
@@ -83,10 +85,37 @@ export default class OperatorModeContainer extends Component<Signature> {
     return getCard as unknown as GetCardType;
   }
 
+  // The realm a card's no-realm search targets — the operator-mode current
+  // realm. Read lazily by the card search surfaces below.
+  private get currentRealm(): string | undefined {
+    return this.operatorModeStateService.realmURL;
+  }
+
+  // The store handed to cards as `@context.store`: bound to the current realm
+  // and the card caps (see StoreService.cardFacingStore).
+  @cached
+  private get cardStore() {
+    return this.store.cardFacingStore(() => this.currentRealm);
+  }
+
   @provide(GetCardsContextName)
   // @ts-ignore "getCards" is declared but not used
   private get getCards() {
-    return this.store.getSearchResource.bind(this.store);
+    let store = this.store;
+    let getDefaultRealm = () => this.currentRealm;
+    // Card `getCards`: run under the card caps and default a no-realm search to
+    // the current realm.
+    return (
+      parent: object,
+      getQuery: () => Query | undefined,
+      getRealms?: () => string[] | undefined,
+      opts?: { isLive?: boolean; doWhileRefreshing?: () => void },
+    ) =>
+      store.getSearchResource(parent, getQuery, getRealms, {
+        ...opts,
+        cardInitiated: true,
+        getDefaultRealm,
+      });
   }
 
   @provide(GetCardCollectionContextName)
@@ -107,7 +136,7 @@ export default class OperatorModeContainer extends Component<Signature> {
       getCard: this.getCard,
       getCards: this.getCards,
       getCardCollection: this.getCardCollection,
-      store: this.store.cardFacingStore,
+      store: this.cardStore,
       toolContext: this.toolContext,
       // populated alongside toolContext for content still reading the
       // pre-rename spelling

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -124,6 +124,10 @@ export interface Args<T extends CardDef | FileDef = CardDef> {
     isLive: boolean;
     isAutoSaved?: boolean;
     storeService?: StoreService;
+    // Route this resource's search through the store's concurrency throttle.
+    // Set only by `StoreService.getSearchResource` (the card `@context`
+    // surface); host-internal `getSearch` callers leave it unset.
+    throttle?: boolean;
     doWhileRefreshing?: (() => void) | undefined;
     seed?:
       | {
@@ -181,6 +185,7 @@ export class SearchResource<
   // changes, but reading this keeps the derivation self-contained).
   @tracked private activeQuery: Query | undefined;
   #isLive = false;
+  #throttle = false;
   #seedApplied = false;
   #doWhileRefreshing: (() => void) | undefined;
   #previousQuery: Query | undefined;
@@ -317,6 +322,7 @@ export class SearchResource<
       seed,
       owner,
       storeService,
+      throttle,
     } = named;
 
     setOwner(this, owner); // works around problem where lifetime parent is used as owner when they should be allowed to differ
@@ -324,6 +330,9 @@ export class SearchResource<
     // subsequent modify() calls.
     if (storeService !== undefined) {
       this.#storeServiceOverride = storeService;
+    }
+    if (throttle !== undefined) {
+      this.#throttle = throttle;
     }
 
     if (query === undefined) {
@@ -762,14 +771,16 @@ export class SearchResource<
         'search-resource:search',
       );
       try {
-        let { instances, meta } = await this.runtimeStore.search<T>(
-          query,
-          this.realmsToSearch,
-          {
+        let doSearch = () =>
+          this.runtimeStore.search<T>(query, this.realmsToSearch, {
             includeMeta: true,
             dependencyTrackingContext,
-          },
-        );
+          });
+        // Card-`@context` searches run under the store's concurrency throttle;
+        // host-internal searches (throttle unset) run directly.
+        let { instances, meta } = this.#throttle
+          ? await this.runtimeStore.performThrottledSearch(doSearch)
+          : await doSearch();
         this.#log.info(
           `search task complete; total instances=${instances.length}; refs=${instances
             .map((r) => r.id)
@@ -828,6 +839,7 @@ export function getSearch<T extends CardDef | FileDef = CardDef>(
   opts?: {
     isLive?: boolean;
     storeService?: StoreService;
+    throttle?: boolean;
     doWhileRefreshing?: (() => void) | undefined;
     seed?:
       | {
@@ -853,6 +865,7 @@ export function getSearch<T extends CardDef | FileDef = CardDef>(
       realms: getRealms ? getRealms() : undefined,
       isLive: opts?.isLive != null ? opts.isLive : false,
       storeService: opts?.storeService,
+      throttle: opts?.throttle,
       // TODO refactor this out
       doWhileRefreshing: opts?.doWhileRefreshing,
       seed: opts?.seed,

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -360,15 +360,15 @@ export class SearchResource<
     this.activeQuery = query;
     this.#doWhileRefreshing = doWhileRefreshing;
     this.#dependencyTracking = named.dependencyTracking;
-    let noRealms = realms === undefined || realms.length === 0;
     // A no-realm card search targets the current realm (the realm the
     // `@context` was provided with), never every visible realm. A host-internal
     // search (not card-initiated) keeps the all-realms default.
-    this.realmsToSearch = !noRealms
-      ? realms.map(ri)
-      : this.#cardInitiated
-        ? this.#currentRealmList()
-        : this.realmServer.availableRealmIdentifiers;
+    this.realmsToSearch =
+      realms !== undefined && realms.length > 0
+        ? realms.map(ri)
+        : this.#cardInitiated
+          ? this.#currentRealmList()
+          : this.realmServer.availableRealmIdentifiers;
     this.#log.info(
       `modify: prepared realms for subscription=${this.realmsToSearch.join(',')}`,
     );

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -124,10 +124,13 @@ export interface Args<T extends CardDef | FileDef = CardDef> {
     isLive: boolean;
     isAutoSaved?: boolean;
     storeService?: StoreService;
-    // Route this resource's search through the store's concurrency throttle.
-    // Set only by `StoreService.getSearchResource` (the card `@context`
-    // surface); host-internal `getSearch` callers leave it unset.
-    throttle?: boolean;
+    // Run this resource's search under the card caps (page, realms,
+    // concurrency). Set only by `StoreService.getSearchResource` (the card
+    // `@context` surface); host-internal `getSearch` callers leave it unset.
+    cardInitiated?: boolean;
+    // The realm a no-realm card search targets (the realm the `@context` was
+    // provided with). Only meaningful with `cardInitiated`.
+    getDefaultRealm?: () => string | undefined;
     doWhileRefreshing?: (() => void) | undefined;
     seed?:
       | {
@@ -185,7 +188,8 @@ export class SearchResource<
   // changes, but reading this keeps the derivation self-contained).
   @tracked private activeQuery: Query | undefined;
   #isLive = false;
-  #throttle = false;
+  #cardInitiated = false;
+  #getDefaultRealm: (() => string | undefined) | undefined;
   #seedApplied = false;
   #doWhileRefreshing: (() => void) | undefined;
   #previousQuery: Query | undefined;
@@ -322,7 +326,8 @@ export class SearchResource<
       seed,
       owner,
       storeService,
-      throttle,
+      cardInitiated,
+      getDefaultRealm,
     } = named;
 
     setOwner(this, owner); // works around problem where lifetime parent is used as owner when they should be allowed to differ
@@ -331,8 +336,11 @@ export class SearchResource<
     if (storeService !== undefined) {
       this.#storeServiceOverride = storeService;
     }
-    if (throttle !== undefined) {
-      this.#throttle = throttle;
+    if (cardInitiated !== undefined) {
+      this.#cardInitiated = cardInitiated;
+    }
+    if (getDefaultRealm !== undefined) {
+      this.#getDefaultRealm = getDefaultRealm;
     }
 
     if (query === undefined) {
@@ -352,10 +360,15 @@ export class SearchResource<
     this.activeQuery = query;
     this.#doWhileRefreshing = doWhileRefreshing;
     this.#dependencyTracking = named.dependencyTracking;
-    this.realmsToSearch =
-      realms === undefined || realms.length === 0
-        ? this.realmServer.availableRealmIdentifiers
-        : realms.map(ri);
+    let noRealms = realms === undefined || realms.length === 0;
+    // A no-realm card search targets the current realm (the realm the
+    // `@context` was provided with), never every visible realm. A host-internal
+    // search (not card-initiated) keeps the all-realms default.
+    this.realmsToSearch = !noRealms
+      ? realms.map(ri)
+      : this.#cardInitiated
+        ? this.#currentRealmList()
+        : this.realmServer.availableRealmIdentifiers;
     this.#log.info(
       `modify: prepared realms for subscription=${this.realmsToSearch.join(',')}`,
     );
@@ -716,6 +729,14 @@ export class SearchResource<
     return runtimeDependencyContextWithSource(this.#dependencyTracking, source);
   }
 
+  // The realm a no-realm card search targets: the current realm from the
+  // `@context` provider, or an empty list if none is known (which yields no
+  // results rather than fanning out to every realm).
+  #currentRealmList(): RealmIdentifier[] {
+    let current = this.#getDefaultRealm?.();
+    return current ? [ri(current)] : [];
+  }
+
   private applySeed = task(
     async (seed: NonNullable<Args<T>['named']['seed']>) => {
       let dependencyTrackingContext = this.dependencyTrackingContext(
@@ -771,16 +792,19 @@ export class SearchResource<
         'search-resource:search',
       );
       try {
-        let doSearch = () =>
-          this.runtimeStore.search<T>(query, this.realmsToSearch, {
+        // A card-`@context` search runs card-initiated — under the page,
+        // realms, and concurrency caps inside `store.search`. `realmsToSearch`
+        // has already resolved a no-realm card search to the current realm
+        // (see modify). Host-internal searches pass no flag and are unbounded.
+        let { instances, meta } = await this.runtimeStore.search<T>(
+          query,
+          this.realmsToSearch,
+          {
             includeMeta: true,
             dependencyTrackingContext,
-          });
-        // Card-`@context` searches run under the store's concurrency throttle;
-        // host-internal searches (throttle unset) run directly.
-        let { instances, meta } = this.#throttle
-          ? await this.runtimeStore.performThrottledSearch(doSearch)
-          : await doSearch();
+            cardInitiated: this.#cardInitiated,
+          },
+        );
         this.#log.info(
           `search task complete; total instances=${instances.length}; refs=${instances
             .map((r) => r.id)
@@ -839,7 +863,8 @@ export function getSearch<T extends CardDef | FileDef = CardDef>(
   opts?: {
     isLive?: boolean;
     storeService?: StoreService;
-    throttle?: boolean;
+    cardInitiated?: boolean;
+    getDefaultRealm?: () => string | undefined;
     doWhileRefreshing?: (() => void) | undefined;
     seed?:
       | {
@@ -865,7 +890,8 @@ export function getSearch<T extends CardDef | FileDef = CardDef>(
       realms: getRealms ? getRealms() : undefined,
       isLive: opts?.isLive != null ? opts.isLive : false,
       storeService: opts?.storeService,
-      throttle: opts?.throttle,
+      cardInitiated: opts?.cardInitiated,
+      getDefaultRealm: opts?.getDefaultRealm,
       // TODO refactor this out
       doWhileRefreshing: opts?.doWhileRefreshing,
       seed: opts?.seed,

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1047,6 +1047,11 @@ export default class StoreService extends Service implements StoreInterface {
   async search<T extends CardDef | FileDef = CardDef>(
     query: Query,
     realms?: string[],
+    opts?: {
+      includeMeta?: false;
+      dependencyTrackingContext?: RuntimeDependencyTrackingContext;
+      cardInitiated?: boolean;
+    },
   ): Promise<T[]>;
   async search<T extends CardDef | FileDef = CardDef>(
     query: Query,

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -48,6 +48,8 @@ import {
   logger,
   formattedError,
   stringifyErrorForLog,
+  applySearchPageBound,
+  assertRealmsBound,
   isJsonContentType,
   SEARCH_CONCURRENCY_CAP,
   SupportedMimeType,
@@ -1052,6 +1054,7 @@ export default class StoreService extends Service implements StoreInterface {
     opts: {
       includeMeta: true;
       dependencyTrackingContext?: RuntimeDependencyTrackingContext;
+      cardInitiated?: boolean;
     },
   ): Promise<{ instances: T[]; meta: QueryResultsMeta }>;
   async search<T extends CardDef | FileDef = CardDef>(
@@ -1060,6 +1063,11 @@ export default class StoreService extends Service implements StoreInterface {
     opts?: {
       includeMeta?: boolean;
       dependencyTrackingContext?: RuntimeDependencyTrackingContext;
+      // Set only by the card `@context` surfaces (getCards + the card-facing
+      // store). Applies the caps that protect against untrusted card code —
+      // page size, realms fan-out, and the concurrency throttle — none of which
+      // constrain the host app's own direct search calls.
+      cardInitiated?: boolean;
     },
   ): Promise<T[] | { instances: T[]; meta: QueryResultsMeta }> {
     if ('asData' in query && query.asData) {
@@ -1073,11 +1081,23 @@ export default class StoreService extends Service implements StoreInterface {
         ? { instances: [], meta: { page: { total: 0 } } }
         : [];
     }
-    let result = await this.fetchAndHydrateSearchResults<T>(
-      query,
-      searchRealms,
-      opts?.dependencyTrackingContext,
-    );
+    if (opts?.cardInitiated) {
+      // Enforce the card-facing caps on the resolved request. The realms cap
+      // runs on the normalized list, so a card that omits realms — which
+      // defaults to every realm visible to the user — is still bounded. These
+      // throw a SearchBoundError the caller surfaces as a search error.
+      assertRealmsBound(searchRealms);
+      query = applySearchPageBound(query);
+    }
+    let run = () =>
+      this.fetchAndHydrateSearchResults<T>(
+        query,
+        searchRealms,
+        opts?.dependencyTrackingContext,
+      );
+    let result = opts?.cardInitiated
+      ? await this.performThrottledSearch(run)
+      : await run();
     return opts?.includeMeta ? result : result.instances;
   }
 
@@ -1151,30 +1171,31 @@ export default class StoreService extends Service implements StoreInterface {
     return this.searchThrottle.perform(run) as unknown as Promise<R>;
   }
 
-  private cardFacingStoreCache: StoreInterface | undefined;
-  // The store handed to cards as `@context.store`. It behaves exactly like the
-  // store service except `search` runs under the same concurrency throttle as
-  // the `getCards` @context surface — so a card can't dodge the cap by reaching
-  // for `@context.store.search` directly instead of `getCards`. Every other
-  // method delegates straight through. The host app injects the store service
-  // itself, never this view, so host search is never throttled.
-  get cardFacingStore(): StoreInterface {
-    if (!this.cardFacingStoreCache) {
-      let store = this;
-      this.cardFacingStoreCache = new Proxy(store, {
-        get(target, prop) {
-          if (prop === 'search') {
-            return (query: Query, realmURLs?: string[]) =>
-              store.performThrottledSearch(() =>
-                store.search(query, realmURLs),
-              );
-          }
-          let value = Reflect.get(target, prop, target);
-          return typeof value === 'function' ? value.bind(target) : value;
-        },
-      }) as unknown as StoreInterface;
-    }
-    return this.cardFacingStoreCache;
+  // The store handed to cards as `@context.store`, bound to the realm the
+  // `@context` was provided with (`getCurrentRealm`). It behaves exactly like
+  // the store service except `search` runs card-initiated — under the page,
+  // realms, and concurrency caps — and a search that names no realm targets the
+  // current realm instead of every realm the user can see. So a card can't
+  // dodge the caps (or fan out to all realms) by reaching for
+  // `@context.store.search` directly instead of `getCards`. Every other method
+  // delegates straight through. The host app injects the store service itself,
+  // never this view, so host search is unconstrained. `searchEntries` isn't on
+  // the card-facing `Store` interface, so the html leg needs no handling here.
+  cardFacingStore(getCurrentRealm: () => string | undefined): StoreInterface {
+    let store = this;
+    return new Proxy(store, {
+      get(target, prop) {
+        if (prop === 'search') {
+          return (query: Query, realmURLs?: string[]) => {
+            let current = getCurrentRealm();
+            let realms = realmURLs ?? (current ? [current] : ([] as string[]));
+            return target.search(query, realms, { cardInitiated: true });
+          };
+        }
+        let value = Reflect.get(target, prop, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as unknown as StoreInterface;
   }
 
   private async fetchAndHydrateSearchResults<
@@ -1514,6 +1535,12 @@ export default class StoreService extends Service implements StoreInterface {
       isLive?: boolean;
       doWhileRefreshing?: (() => void) | undefined;
       dependencyTracking?: RuntimeDependencyTrackingContext;
+      // Set by the `@context` providers (the card-facing `getCards`): run the
+      // search under the card caps and default a no-realm search to
+      // `getDefaultRealm`. Left unset by non-`@context` callers (query-field
+      // support, the render-store hook), which stay unconstrained.
+      cardInitiated?: boolean;
+      getDefaultRealm?: () => string | undefined;
       seed?: {
         cards: T[];
         searchURL?: string;
@@ -1532,12 +1559,12 @@ export default class StoreService extends Service implements StoreInterface {
     if (this.isRenderStore && opts) {
       opts.isLive = false;
     }
+    // `cardInitiated` + `getDefaultRealm` ride through `opts`: the `@context`
+    // providers pass them (card-facing `getCards`); other callers don't and stay
+    // unconstrained.
     return getSearch<T>(parent, getOwner(this)!, getQuery, getRealms, {
       ...opts,
       storeService: this,
-      // Card-facing surface: throttle these item-leg searches (host-internal
-      // `store.search` / `getSearch` callers pass no throttle flag).
-      throttle: true,
     }) as unknown as SearchResource<T>;
   }
 

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -49,6 +49,7 @@ import {
   formattedError,
   stringifyErrorForLog,
   isJsonContentType,
+  SEARCH_CONCURRENCY_CAP,
   SupportedMimeType,
   RealmPaths,
   type CardAPIForMatching,
@@ -1124,6 +1125,30 @@ export default class StoreService extends Service implements StoreInterface {
       : this.realmServer.availableRealmIdentifiers;
   }
 
+  // Client-side concurrency throttle for card-initiated (`@context`) item-leg
+  // searches. `getSearchResource` — the function bound as `getCards` on the
+  // card `@context` — routes its search through this task; the host app's own
+  // direct `store.search` / `getSearch` callers do not, so the trusted host is
+  // never throttled. `enqueue` + `maxConcurrency` queues (never drops) excess
+  // card searches, so a card firing many searches at once (e.g. a per-keystroke
+  // grid) can't fan a burst of concurrent `_federated-search` requests at the
+  // realm-server. The server's per-request bounds (page / realms / time) are
+  // the un-overridable backstop; this keeps well-behaved cards from tripping
+  // them in the first place.
+  private searchThrottle = task(
+    { maxConcurrency: SEARCH_CONCURRENCY_CAP, enqueue: true },
+    async (run: () => Promise<unknown>): Promise<unknown> => {
+      return await run();
+    },
+  );
+
+  // Run a card-`@context` search under the concurrency throttle. Returns the
+  // task instance (a thenable) so a caller awaiting it inside its own
+  // (restartable) task links cancellation and frees the slot when superseded.
+  performThrottledSearch<R>(run: () => Promise<R>): Promise<R> {
+    return this.searchThrottle.perform(run) as unknown as Promise<R>;
+  }
+
   private async fetchAndHydrateSearchResults<
     T extends CardDef | FileDef = CardDef,
   >(
@@ -1482,6 +1507,9 @@ export default class StoreService extends Service implements StoreInterface {
     return getSearch<T>(parent, getOwner(this)!, getQuery, getRealms, {
       ...opts,
       storeService: this,
+      // Card-facing surface: throttle these item-leg searches (host-internal
+      // `store.search` / `getSearch` callers pass no throttle flag).
+      throttle: true,
     }) as unknown as SearchResource<T>;
   }
 

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1142,11 +1142,39 @@ export default class StoreService extends Service implements StoreInterface {
     },
   );
 
-  // Run a card-`@context` search under the concurrency throttle. Returns the
-  // task instance (a thenable) so a caller awaiting it inside its own
-  // (restartable) task links cancellation and frees the slot when superseded.
+  // Run a card-`@context` search under the concurrency throttle. The value is,
+  // at runtime, the ember-concurrency task instance, so awaiting it inside a
+  // caller's own (restartable) task links cancellation — a superseded search
+  // frees its slot. Typed as a plain Promise because callers only ever await
+  // the result; they don't drive the task instance directly.
   performThrottledSearch<R>(run: () => Promise<R>): Promise<R> {
     return this.searchThrottle.perform(run) as unknown as Promise<R>;
+  }
+
+  private cardFacingStoreCache: StoreInterface | undefined;
+  // The store handed to cards as `@context.store`. It behaves exactly like the
+  // store service except `search` runs under the same concurrency throttle as
+  // the `getCards` @context surface — so a card can't dodge the cap by reaching
+  // for `@context.store.search` directly instead of `getCards`. Every other
+  // method delegates straight through. The host app injects the store service
+  // itself, never this view, so host search is never throttled.
+  get cardFacingStore(): StoreInterface {
+    if (!this.cardFacingStoreCache) {
+      let store = this;
+      this.cardFacingStoreCache = new Proxy(store, {
+        get(target, prop) {
+          if (prop === 'search') {
+            return (query: Query, realmURLs?: string[]) =>
+              store.performThrottledSearch(() =>
+                store.search(query, realmURLs),
+              );
+          }
+          let value = Reflect.get(target, prop, target);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      }) as unknown as StoreInterface;
+    }
+    return this.cardFacingStoreCache;
   }
 
   private async fetchAndHydrateSearchResults<

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1162,11 +1162,11 @@ export default class StoreService extends Service implements StoreInterface {
     },
   );
 
-  // Run a card-`@context` search under the concurrency throttle. The value is,
-  // at runtime, the ember-concurrency task instance, so awaiting it inside a
-  // caller's own (restartable) task links cancellation — a superseded search
-  // frees its slot. Typed as a plain Promise because callers only ever await
-  // the result; they don't drive the task instance directly.
+  // Run `run` under the card-search concurrency throttle (`enqueue` +
+  // maxConcurrency), so no more than the cap of card-initiated searches hit the
+  // realm-server at once and the rest queue. Called from `search` when
+  // `cardInitiated`. Typed as a plain Promise since the caller only awaits the
+  // result. Public so a test can exercise the throttle with controllable work.
   performThrottledSearch<R>(run: () => Promise<R>): Promise<R> {
     return this.searchThrottle.perform(run) as unknown as Promise<R>;
   }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1080,17 +1080,24 @@ export default class StoreService extends Service implements StoreInterface {
         `store.search returns instances only — use store.searchEntries for the raw entry wire format`,
       );
     }
-    let searchRealms = this.normalizeSearchRealms(realms);
+    // Host callers resolve an absent/empty realm list to every realm the user
+    // can see. Card `@context` callers arrive with the current realm already
+    // resolved into `realms` (see cardFacingStore / SearchResource); an empty
+    // list there means the card's current realm is unknown, so search nothing
+    // rather than fan out to every realm.
+    let searchRealms = opts?.cardInitiated
+      ? this.normalizeRealmPaths(realms)
+      : this.normalizeSearchRealms(realms);
     if (searchRealms.length === 0) {
       return opts?.includeMeta
         ? { instances: [], meta: { page: { total: 0 } } }
         : [];
     }
     if (opts?.cardInitiated) {
-      // Enforce the card-facing caps on the resolved request. The realms cap
-      // runs on the normalized list, so a card that omits realms — which
-      // defaults to every realm visible to the user — is still bounded. These
-      // throw a SearchBoundError the caller surfaces as a search error.
+      // Enforce the card-facing caps on the resolved request: the realms cap on
+      // the (already current-realm-resolved) list, and the page cap on the
+      // query. These throw a SearchBoundError the caller surfaces as a search
+      // error.
       assertRealmsBound(searchRealms);
       query = applySearchPageBound(query);
     }
@@ -1141,10 +1148,19 @@ export default class StoreService extends Service implements StoreInterface {
     await this.addResourceFromSearchData(resource);
   }
 
-  private normalizeSearchRealms(realms: string[] | undefined): string[] {
-    let normalizedRealms = (realms ?? [])
+  // Canonicalize a realm list to RealmPaths URLs, dropping unparseable entries.
+  // No fallback: an empty input yields an empty list (the card path relies on
+  // this to mean "search nothing" rather than "search everything").
+  private normalizeRealmPaths(realms: string[] | undefined): string[] {
+    return (realms ?? [])
       .map((realm) => new RealmPaths(new URL(realm)).url)
       .filter(Boolean);
+  }
+
+  // The host default: an absent/empty realm list means every realm the user can
+  // see.
+  private normalizeSearchRealms(realms: string[] | undefined): string[] {
+    let normalizedRealms = this.normalizeRealmPaths(realms);
     return normalizedRealms.length > 0
       ? normalizedRealms
       : this.realmServer.availableRealmIdentifiers;

--- a/packages/host/app/templates/host-freestyle.gts
+++ b/packages/host/app/templates/host-freestyle.gts
@@ -84,7 +84,7 @@ class HostFreestyleComponent extends Component<HostFreestyleSignature> {
       getCard: this.getCard,
       getCards: this.store.getSearchResource.bind(this.store),
       getCardCollection,
-      store: this.store.cardFacingStore,
+      store: this.store,
       toolContext: this.toolService.toolContext,
       commandContext: this.toolService.toolContext,
       searchResultsComponent: SearchResults,

--- a/packages/host/app/templates/host-freestyle.gts
+++ b/packages/host/app/templates/host-freestyle.gts
@@ -84,7 +84,7 @@ class HostFreestyleComponent extends Component<HostFreestyleSignature> {
       getCard: this.getCard,
       getCards: this.store.getSearchResource.bind(this.store),
       getCardCollection,
-      store: this.store,
+      store: this.store.cardFacingStore,
       toolContext: this.toolService.toolContext,
       commandContext: this.toolService.toolContext,
       searchResultsComponent: SearchResults,

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -5,6 +5,7 @@ import type RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
 import { isDevelopingApp } from '@embroider/macros';
 import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
 
 import { modifier } from 'ember-modifier';
 import { pageTitle } from 'ember-page-title';
@@ -22,6 +23,7 @@ import {
   CardContextName,
   CommandContextName,
   type getCard as GetCardType,
+  type Query,
 } from '@cardstack/runtime-common';
 
 import SearchResults from '@cardstack/host/components/card-search/search-results';
@@ -70,9 +72,31 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
     return getCard as unknown as GetCardType;
   }
 
+  // The realm a card's no-realm search targets — the current realm.
+  private get currentRealm(): string | undefined {
+    return this.operatorModeStateService.realmURL;
+  }
+
+  @cached
+  private get cardStore() {
+    return this.store.cardFacingStore(() => this.currentRealm);
+  }
+
   @provide(GetCardsContextName)
   private get getCards() {
-    return this.store.getSearchResource.bind(this.store);
+    let store = this.store;
+    let getDefaultRealm = () => this.currentRealm;
+    return (
+      parent: object,
+      getQuery: () => Query | undefined,
+      getRealms?: () => string[] | undefined,
+      opts?: { isLive?: boolean; doWhileRefreshing?: () => void },
+    ) =>
+      store.getSearchResource(parent, getQuery, getRealms, {
+        ...opts,
+        cardInitiated: true,
+        getDefaultRealm,
+      });
   }
 
   @provide(GetCardCollectionContextName)
@@ -142,7 +166,7 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
       getCard: this.getCard,
       getCards: this.getCards,
       getCardCollection: this.getCardCollection,
-      store: this.store.cardFacingStore,
+      store: this.cardStore,
       toolContext: this.toolContext,
       commandContext: this.toolContext,
       searchResultsComponent: SearchResults,

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -142,7 +142,7 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
       getCard: this.getCard,
       getCards: this.getCards,
       getCardCollection: this.getCardCollection,
-      store: this.store,
+      store: this.store.cardFacingStore,
       toolContext: this.toolContext,
       commandContext: this.toolContext,
       searchResultsComponent: SearchResults,

--- a/packages/host/app/templates/render/html.gts
+++ b/packages/host/app/templates/render/html.gts
@@ -53,7 +53,7 @@ class RenderHtmlTemplate extends Component<Signature> {
       getCard: this.getCard,
       getCards: this.getCards,
       getCardCollection: this.getCardCollection,
-      store: this.store,
+      store: this.store.cardFacingStore,
       searchResultsComponent: SearchResults,
       mode: 'host',
       submode: 'host',

--- a/packages/host/app/templates/render/html.gts
+++ b/packages/host/app/templates/render/html.gts
@@ -42,7 +42,7 @@ class RenderHtmlTemplate extends Component<Signature> {
   // A no-realm card search during prerender targets the realm of the card
   // being rendered.
   private get currentRealm(): string | undefined {
-    return this.args.model?.[realmURL]?.href;
+    return this.args.model?.instance?.[realmURL]?.href;
   }
 
   @cached

--- a/packages/host/app/templates/render/html.gts
+++ b/packages/host/app/templates/render/html.gts
@@ -1,5 +1,6 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
 
 import { provide } from 'ember-provide-consume-context';
 import RouteTemplate from 'ember-route-template';
@@ -12,6 +13,8 @@ import {
   GetCardsContextName,
   GetCardCollectionContextName,
   CardContextName,
+  realmURL,
+  type Query,
 } from '@cardstack/runtime-common';
 
 import SearchResults from '@cardstack/host/components/card-search/search-results';
@@ -36,9 +39,32 @@ class RenderHtmlTemplate extends Component<Signature> {
     return getCard as unknown as GetCardType;
   }
 
+  // A no-realm card search during prerender targets the realm of the card
+  // being rendered.
+  private get currentRealm(): string | undefined {
+    return this.args.model?.[realmURL]?.href;
+  }
+
+  @cached
+  private get cardStore() {
+    return this.store.cardFacingStore(() => this.currentRealm);
+  }
+
   @provide(GetCardsContextName)
   private get getCards() {
-    return this.store.getSearchResource.bind(this.store);
+    let store = this.store;
+    let getDefaultRealm = () => this.currentRealm;
+    return (
+      parent: object,
+      getQuery: () => Query | undefined,
+      getRealms?: () => string[] | undefined,
+      opts?: { isLive?: boolean; doWhileRefreshing?: () => void },
+    ) =>
+      store.getSearchResource(parent, getQuery, getRealms, {
+        ...opts,
+        cardInitiated: true,
+        getDefaultRealm,
+      });
   }
 
   @provide(GetCardCollectionContextName)
@@ -53,7 +79,7 @@ class RenderHtmlTemplate extends Component<Signature> {
       getCard: this.getCard,
       getCards: this.getCards,
       getCardCollection: this.getCardCollection,
-      store: this.store.cardFacingStore,
+      store: this.cardStore,
       searchResultsComponent: SearchResults,
       mode: 'host',
       submode: 'host',

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -12,6 +12,7 @@ import {
   Deferred,
   isFileDefInstance,
   rri,
+  SEARCH_CONCURRENCY_CAP,
   type Realm,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
@@ -2000,6 +2001,61 @@ module(`Integration | search resource`, function (hooks) {
       assert.ok(
         ids.includes(rri(`${testRealmURL}books/local-add`)),
         'the local-only matching candidate is present',
+      );
+    });
+
+    // The card `@context` search surface (`getSearchResource`) routes item-leg
+    // searches through the store's concurrency throttle so a card firing many
+    // at once can't burst concurrent `_federated-search` requests at the
+    // realm-server. `enqueue` queues the excess rather than dropping it.
+    test('performThrottledSearch caps concurrent card searches at the configured limit', async function (assert) {
+      let inFlight = 0;
+      let maxInFlight = 0;
+      let started = 0;
+      let gates: Deferred<void>[] = [];
+      let count = SEARCH_CONCURRENCY_CAP + 2;
+      let makeRun = () => {
+        let gate = new Deferred<void>();
+        gates.push(gate);
+        return async () => {
+          started++;
+          inFlight++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await gate.promise;
+          inFlight--;
+        };
+      };
+      let results = Array.from({ length: count }, () =>
+        storeService.performThrottledSearch(makeRun()),
+      );
+      try {
+        await waitUntil(() => started >= SEARCH_CONCURRENCY_CAP);
+        assert.strictEqual(
+          maxInFlight,
+          SEARCH_CONCURRENCY_CAP,
+          'no more than the cap run at once',
+        );
+        assert.strictEqual(
+          started,
+          SEARCH_CONCURRENCY_CAP,
+          'excess searches are queued, not started',
+        );
+      } finally {
+        for (let gate of gates) {
+          gate.fulfill();
+          await settled();
+        }
+        await Promise.all(results);
+      }
+      assert.strictEqual(
+        maxInFlight,
+        SEARCH_CONCURRENCY_CAP,
+        'the cap held across the whole drain',
+      );
+      assert.strictEqual(
+        started,
+        count,
+        'every queued search eventually ran (enqueue, not drop)',
       );
     });
   });

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -13,6 +13,7 @@ import {
   isFileDefInstance,
   rri,
   SEARCH_CONCURRENCY_CAP,
+  SearchBoundError,
   type Realm,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
@@ -2056,6 +2057,65 @@ module(`Integration | search resource`, function (hooks) {
         started,
         count,
         'every queued search eventually ran (enqueue, not drop)',
+      );
+    });
+
+    // A card-initiated search is capped; the same call from the host (no
+    // cardInitiated flag) is not. The caps throw before any network round-trip,
+    // so these assertions are self-contained.
+    test('a card-initiated search over the realms cap is rejected; the host is not', async function (assert) {
+      let query = { filter: { eq: {} } } as Query;
+      let realms = ['http://r1/', 'http://r2/', 'http://r3/'];
+      await assert.rejects(
+        storeService.search(query, realms, { cardInitiated: true }),
+        (e: Error) => e instanceof SearchBoundError,
+        'a card search over the realms cap throws a SearchBoundError',
+      );
+      // The host path skips the cap entirely — it never throws a
+      // SearchBoundError (it proceeds to the network, mocked elsewhere).
+      let hostErr: unknown;
+      try {
+        await storeService.search(query, realms);
+      } catch (e) {
+        hostErr = e;
+      }
+      assert.false(
+        hostErr instanceof SearchBoundError,
+        'the host search is not subject to the realms cap',
+      );
+    });
+
+    test('a card-initiated search over the page cap is rejected', async function (assert) {
+      await assert.rejects(
+        storeService.search({ page: { size: 1000 } } as Query, ['http://r1/'], {
+          cardInitiated: true,
+        }),
+        (e: Error) => e instanceof SearchBoundError,
+        'a card search over the page cap throws a SearchBoundError',
+      );
+    });
+
+    test('the card-facing store defaults a no-realm search to the current realm', async function (assert) {
+      // No explicit realms and no current realm → an empty realm set (no
+      // results), never a fan-out to every visible realm.
+      let noRealm = storeService.cardFacingStore(() => undefined);
+      let results = await noRealm.search({ filter: { eq: {} } } as Query);
+      assert.deepEqual(
+        results,
+        [],
+        'a no-realm search with no current realm is empty',
+      );
+
+      // An explicit over-cap realm list is still rejected through the facade.
+      let bound = storeService.cardFacingStore(() => 'http://current/');
+      await assert.rejects(
+        bound.search({ filter: { eq: {} } } as Query, [
+          'http://r1/',
+          'http://r2/',
+          'http://r3/',
+        ]),
+        (e: Error) => e instanceof SearchBoundError,
+        'the facade enforces the realms cap on an explicit list',
       );
     });
   });

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -1,11 +1,16 @@
 import type Koa from 'koa';
 import {
+  applySearchPageBound,
+  assertRealmsBound,
   buildSearchErrorResponse,
   DURING_PRERENDER_HEADER,
   ifNoneMatchMatches,
+  isItemLegSearch,
   parseSearchRequestPayload,
   parseSearchEntryQueryFromPayload,
+  runWithSearchTimeBudget,
   sanitizeConsumingRealmHeader,
+  SearchBoundError,
   SearchRequestError,
   searchEntryRealms,
   sanitizeLoggingCorrelationId,
@@ -107,6 +112,28 @@ export default function handleSearch(opts: {
     if (omitIncluded) searchOpts.omitIncluded = true;
     if (jobPriority !== null) searchOpts.priority = jobPriority;
 
+    // Hard resource bounds apply to the item leg only (the live serialization +
+    // `loadLinks` path), and never to the realm-server's own during-prerender
+    // traffic. The prerendered-HTML leg — the platform's grid / search sheet —
+    // stays unbounded. Realms + page are validated up front (a 400 the author
+    // can act on); the time budget wraps the actual search below.
+    let bounded = isItemLegSearch(parsed.fieldset) && !cacheOnlyDefinitions;
+    if (bounded) {
+      try {
+        assertRealmsBound(realmList);
+        parsed.itemQuery = applySearchPageBound(parsed.itemQuery);
+      } catch (e) {
+        if (e instanceof SearchBoundError) {
+          await setContextResponse(
+            ctxt,
+            buildSearchErrorResponse(e.message, e.status),
+          );
+          return;
+        }
+        throw e;
+      }
+    }
+
     // The inner cache key: the membership query is the key's `query` member
     // (canonicalized by the cache), and every other body-changing request
     // member folds into `opts` — the parsed fieldset, the applied (bound or
@@ -152,18 +179,31 @@ export default function handleSearch(opts: {
     // Lazy-mount inside runSearch so cache hits (304 / cached body) skip the
     // lazy-mount work entirely.
     let runSearch = async () => {
-      let resolveRealms = () =>
-        resolveRealmsForFederatedRequest(reconciler, realmList, {
-          consumingRealm,
+      let doRun = async (signal?: AbortSignal) => {
+        let resolveRealms = () =>
+          resolveRealmsForFederatedRequest(reconciler, realmList, {
+            consumingRealm,
+          });
+        let realmInstances = timings
+          ? await timings.time('resolveRealms', resolveRealms)
+          : await resolveRealms();
+        let doc = await searchEntryRealms(realmInstances, parsed, {
+          ...runSearchOpts,
+          ...(signal ? { signal } : {}),
         });
-      let realmInstances = timings
-        ? await timings.time('resolveRealms', resolveRealms)
-        : await resolveRealms();
-      let doc = await searchEntryRealms(realmInstances, parsed, runSearchOpts);
-      // Serialize compact: an entry doc can run to many MB, so indentation
-      // whitespace is pure wire overhead the consumer parses straight back off.
-      let stringify = async () => JSON.stringify(doc);
-      return timings ? await timings.time('stringify', stringify) : stringify();
+        // If the budget already fired, skip stringifying a document we're about
+        // to discard (the time-budget race has already resolved with the 408).
+        signal?.throwIfAborted();
+        // Serialize compact: an entry doc can run to many MB, so indentation
+        // whitespace is pure wire overhead the consumer parses straight back off.
+        let stringify = async () => JSON.stringify(doc);
+        return timings
+          ? await timings.time('stringify', stringify)
+          : stringify();
+      };
+      // Cut an over-budget item-leg search off (408) rather than run it to
+      // completion; the signal stops the `loadLinks` fan-out promptly.
+      return bounded ? runWithSearchTimeBudget(doRun) : doRun();
     };
 
     let emitTimeline = () => {
@@ -179,16 +219,31 @@ export default function handleSearch(opts: {
     };
 
     let jobId = searchCache ? prerenderJobId : null;
-    await respondWithJobScopedSearchCache(ctxt, {
-      searchCache,
-      jobId,
-      consumingRealm,
-      realms: realmList,
-      query: parsed.itemQuery,
-      opts: cacheKeyOpts,
-      runSearch,
-      emitTimeline,
-    });
+    try {
+      await respondWithJobScopedSearchCache(ctxt, {
+        searchCache,
+        jobId,
+        consumingRealm,
+        realms: realmList,
+        query: parsed.itemQuery,
+        opts: cacheKeyOpts,
+        runSearch,
+        emitTimeline,
+      });
+    } catch (e) {
+      // The per-request time budget fired inside `runSearch`. A bounded search
+      // is never cacheable (cacheable ⟹ during-prerender ⟹ not bounded), so
+      // this only surfaces on the fresh-compute path and leaves no cache entry.
+      if (e instanceof SearchBoundError) {
+        await setContextResponse(
+          ctxt,
+          buildSearchErrorResponse(e.message, e.status),
+        );
+        emitTimeline();
+        return;
+      }
+      throw e;
+    }
   };
 }
 

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -1,7 +1,5 @@
 import type Koa from 'koa';
 import {
-  applySearchPageBound,
-  assertRealmsBound,
   buildSearchErrorResponse,
   DURING_PRERENDER_HEADER,
   ifNoneMatchMatches,
@@ -112,27 +110,12 @@ export default function handleSearch(opts: {
     if (omitIncluded) searchOpts.omitIncluded = true;
     if (jobPriority !== null) searchOpts.priority = jobPriority;
 
-    // Hard resource bounds apply to the item leg only (the live serialization +
-    // `loadLinks` path), and never to the realm-server's own during-prerender
-    // traffic. The prerendered-HTML leg — the platform's grid / search sheet —
-    // stays unbounded. Realms + page are validated up front (a 400 the author
-    // can act on); the time budget wraps the actual search below.
-    let bounded = isItemLegSearch(parsed.fieldset) && !cacheOnlyDefinitions;
-    if (bounded) {
-      try {
-        assertRealmsBound(realmList);
-        parsed.itemQuery = applySearchPageBound(parsed.itemQuery);
-      } catch (e) {
-        if (e instanceof SearchBoundError) {
-          await setContextResponse(
-            ctxt,
-            buildSearchErrorResponse(e.message, e.status),
-          );
-          return;
-        }
-        throw e;
-      }
-    }
+    // The time budget is the one bound enforced server-side — a wall-clock
+    // cutoff can't live anywhere else. Page-size and realms caps are enforced
+    // client-side at the card `@context` surface (untrusted card code), so the
+    // trusted host can legitimately exceed them. Applies to the item leg only;
+    // the prerendered-HTML leg and during-prerender traffic are exempt.
+    let timeBounded = isItemLegSearch(parsed.fieldset) && !cacheOnlyDefinitions;
 
     // The inner cache key: the membership query is the key's `query` member
     // (canonicalized by the cache), and every other body-changing request
@@ -203,7 +186,7 @@ export default function handleSearch(opts: {
       };
       // Cut an over-budget item-leg search off (408) rather than run it to
       // completion; the signal stops the `loadLinks` fan-out promptly.
-      return bounded ? runWithSearchTimeBudget(doRun) : doRun();
+      return timeBounded ? runWithSearchTimeBudget(doRun) : doRun();
     };
 
     let emitTimeline = () => {

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -1,5 +1,6 @@
 import type Koa from 'koa';
 import {
+  applyServerSearchPageBound,
   buildSearchErrorResponse,
   DURING_PRERENDER_HEADER,
   ifNoneMatchMatches,
@@ -110,12 +111,34 @@ export default function handleSearch(opts: {
     if (omitIncluded) searchOpts.omitIncluded = true;
     if (jobPriority !== null) searchOpts.priority = jobPriority;
 
-    // The time budget is the one bound enforced server-side — a wall-clock
-    // cutoff can't live anywhere else. Page-size and realms caps are enforced
-    // client-side at the card `@context` surface (untrusted card code), so the
-    // trusted host can legitimately exceed them. Applies to the item leg only;
-    // the prerendered-HTML leg and during-prerender traffic are exempt.
-    let timeBounded = isItemLegSearch(parsed.fieldset) && !cacheOnlyDefinitions;
+    // Two bounds are enforced server-side on the live item leg (never during
+    // prerender, never on the prerendered-HTML leg): a hard page-size ceiling
+    // (applied just below) and the wall-clock time budget (further down). Both
+    // hold for every caller — a wall-clock cutoff can't live client-side, and a
+    // page ceiling must bound the result set even when the client card cap was
+    // skipped. The realms fan-out and concurrency caps stay client-side on the
+    // card `@context` surface, since the trusted host must be free to exceed
+    // them.
+    let itemLegBounded =
+      isItemLegSearch(parsed.fieldset) && !cacheOnlyDefinitions;
+
+    // The server hard page ceiling. An explicit item-leg page over the ceiling
+    // is rejected fast (400); an absent page is clamped so the query carries a
+    // LIMIT and the server never assembles/serializes an unbounded result set.
+    if (itemLegBounded) {
+      try {
+        parsed.itemQuery = applyServerSearchPageBound(parsed.itemQuery);
+      } catch (e) {
+        if (e instanceof SearchBoundError) {
+          await setContextResponse(
+            ctxt,
+            buildSearchErrorResponse(e.message, e.status),
+          );
+          return;
+        }
+        throw e;
+      }
+    }
 
     // The inner cache key: the membership query is the key's `query` member
     // (canonicalized by the cache), and every other body-changing request
@@ -186,7 +209,7 @@ export default function handleSearch(opts: {
       };
       // Cut an over-budget item-leg search off (408) rather than run it to
       // completion; the signal stops the `loadLinks` fan-out promptly.
-      return timeBounded ? runWithSearchTimeBudget(doRun) : doRun();
+      return itemLegBounded ? runWithSearchTimeBudget(doRun) : doRun();
     };
 
     let emitTimeline = () => {

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -352,6 +352,7 @@ const ALL_TEST_FILES: string[] = [
   './superseded-search-surface-removed-test',
   './search-entry-test',
   './search-entries-engine-test',
+  './search-bounds-test',
   './coerce-error-message-test',
   './realm-operations-test',
   './resolve-published-realm-url-test',

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -79,10 +79,6 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
       onRealmSetup,
     });
 
-    hooks.afterEach(function () {
-      resetSearchBoundsForTests();
-    });
-
     function postSearch(body: Record<string, unknown>) {
       return request
         .post(searchPath)

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -2,7 +2,12 @@ import QUnit from 'qunit';
 const { module, test } = QUnit;
 import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { rri, type Realm } from '@cardstack/runtime-common';
+import {
+  rri,
+  setSearchBoundsForTests,
+  resetSearchBoundsForTests,
+  type Realm,
+} from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
 import {
   setupPermissionedRealmCached,
@@ -271,20 +276,65 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
       assert.true(get.body.errors[0].message.includes('method must be QUERY'));
     });
 
-    test('the page-size bound is not enforced server-side', async function (assert) {
-      // The page cap lives at the card `@context` surface, not the server, so
-      // an oversized item-leg page runs as asked rather than 400ing.
-      let response = await postSearch({
-        filter: personFilter(),
-        fields: { entry: ['item'] },
-        page: { size: 1000 },
-      });
-      assert.strictEqual(
-        response.status,
-        200,
-        'an oversized item-leg page is not rejected server-side',
-      );
-      assert.strictEqual(response.body.meta.page.total, 2);
+    test('the item-leg page size is capped server-side', async function (assert) {
+      // The server enforces a hard page ceiling on the live item leg for every
+      // caller (the card `@context` cap is a separate, lower client-side
+      // limit). Lower the ceiling for the test so the two-card realm exercises
+      // both branches.
+      setSearchBoundsForTests({ serverMaxPageSize: 1 });
+      try {
+        // An explicit item-leg page over the ceiling is rejected.
+        let over = await postSearch({
+          filter: personFilter(),
+          fields: { entry: ['item'] },
+          page: { size: 2 },
+        });
+        assert.strictEqual(
+          over.status,
+          400,
+          'an over-ceiling item-leg page is rejected',
+        );
+
+        // An absent page is clamped to the ceiling; the true match count still
+        // rides meta.page.total so a caller can paginate.
+        let clamped = await postSearch({
+          filter: personFilter(),
+          fields: { entry: ['item'] },
+        });
+        assert.strictEqual(clamped.status, 200);
+        assert.strictEqual(
+          clamped.body.data.length,
+          1,
+          'the returned page is clamped to the ceiling',
+        );
+        assert.strictEqual(
+          clamped.body.meta.page.total,
+          2,
+          'the true match count is preserved',
+        );
+      } finally {
+        resetSearchBoundsForTests();
+      }
+    });
+
+    test('the prerendered (html) leg is exempt from the page ceiling', async function (assert) {
+      // The ceiling bounds the live item leg only. The default/html fieldset is
+      // the cheap precomputed path and runs as asked even below the ceiling.
+      setSearchBoundsForTests({ serverMaxPageSize: 1 });
+      try {
+        let response = await postSearch({
+          filter: personFilter(),
+          page: { size: 2 },
+        });
+        assert.strictEqual(
+          response.status,
+          200,
+          'an oversized html-leg page is not rejected',
+        );
+        assert.strictEqual(response.body.data.length, 2);
+      } finally {
+        resetSearchBoundsForTests();
+      }
     });
   });
 });

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -2,7 +2,13 @@ import QUnit from 'qunit';
 const { module, test } = QUnit;
 import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { rri, type Realm } from '@cardstack/runtime-common';
+import {
+  MAX_SEARCH_PAGE_SIZE,
+  resetSearchBoundsForTests,
+  rri,
+  setSearchBoundsForTests,
+  type Realm,
+} from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
 import {
   setupPermissionedRealmCached,
@@ -77,6 +83,10 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
         },
       },
       onRealmSetup,
+    });
+
+    hooks.afterEach(function () {
+      resetSearchBoundsForTests();
     });
 
     function postSearch(body: Record<string, unknown>) {
@@ -269,6 +279,49 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
         .set('Accept', 'application/vnd.card+json');
       assert.strictEqual(get.status, 400);
       assert.true(get.body.errors[0].message.includes('method must be QUERY'));
+    });
+
+    test('an item-leg search with an explicit oversized page is a 400', async function (assert) {
+      let response = await postSearch({
+        filter: personFilter(),
+        fields: { entry: ['item'] },
+        page: { size: MAX_SEARCH_PAGE_SIZE + 1 },
+      });
+      assert.strictEqual(response.status, 400, 'page.size over the max → 400');
+      assert.true(
+        response.body.errors[0].message.includes('page.size'),
+        'the error names page.size',
+      );
+    });
+
+    test('an item-leg search with no page is clamped, not rejected', async function (assert) {
+      setSearchBoundsForTests({ maxPageSize: 1 });
+      let response = await postSearch({
+        filter: personFilter(),
+        fields: { entry: ['item'] },
+      });
+      assert.strictEqual(response.status, 200, 'a missing page is allowed');
+      assert.strictEqual(
+        response.body.data.length,
+        1,
+        'results are clamped to the page cap',
+      );
+      assert.strictEqual(
+        response.body.meta.page.total,
+        2,
+        'meta.page.total still reflects the full match count',
+      );
+    });
+
+    test('the prerendered-HTML leg is exempt from the page cap', async function (assert) {
+      setSearchBoundsForTests({ maxPageSize: 1 });
+      let response = await postSearch({ filter: personFilter() });
+      assert.strictEqual(response.status, 200, 'the html leg is not bounded');
+      assert.strictEqual(
+        response.body.meta.page.total,
+        2,
+        'all rows returned regardless of the item-leg page cap',
+      );
     });
   });
 });

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -2,13 +2,7 @@ import QUnit from 'qunit';
 const { module, test } = QUnit;
 import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import {
-  MAX_SEARCH_PAGE_SIZE,
-  resetSearchBoundsForTests,
-  rri,
-  setSearchBoundsForTests,
-  type Realm,
-} from '@cardstack/runtime-common';
+import { rri, type Realm } from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
 import {
   setupPermissionedRealmCached,
@@ -281,47 +275,20 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
       assert.true(get.body.errors[0].message.includes('method must be QUERY'));
     });
 
-    test('an item-leg search with an explicit oversized page is a 400', async function (assert) {
+    test('the page-size bound is not enforced server-side', async function (assert) {
+      // The page cap lives at the card `@context` surface, not the server, so
+      // an oversized item-leg page runs as asked rather than 400ing.
       let response = await postSearch({
         filter: personFilter(),
         fields: { entry: ['item'] },
-        page: { size: MAX_SEARCH_PAGE_SIZE + 1 },
+        page: { size: 1000 },
       });
-      assert.strictEqual(response.status, 400, 'page.size over the max → 400');
-      assert.true(
-        response.body.errors[0].message.includes('page.size'),
-        'the error names page.size',
-      );
-    });
-
-    test('an item-leg search with no page is clamped, not rejected', async function (assert) {
-      setSearchBoundsForTests({ maxPageSize: 1 });
-      let response = await postSearch({
-        filter: personFilter(),
-        fields: { entry: ['item'] },
-      });
-      assert.strictEqual(response.status, 200, 'a missing page is allowed');
       assert.strictEqual(
-        response.body.data.length,
-        1,
-        'results are clamped to the page cap',
+        response.status,
+        200,
+        'an oversized item-leg page is not rejected server-side',
       );
-      assert.strictEqual(
-        response.body.meta.page.total,
-        2,
-        'meta.page.total still reflects the full match count',
-      );
-    });
-
-    test('the prerendered-HTML leg is exempt from the page cap', async function (assert) {
-      setSearchBoundsForTests({ maxPageSize: 1 });
-      let response = await postSearch({ filter: personFilter() });
-      assert.strictEqual(response.status, 200, 'the html leg is not bounded');
-      assert.strictEqual(
-        response.body.meta.page.total,
-        2,
-        'all rows returned regardless of the item-leg page cap',
-      );
+      assert.strictEqual(response.body.meta.page.total, 2);
     });
   });
 });

--- a/packages/realm-server/tests/search-bounds-test.ts
+++ b/packages/realm-server/tests/search-bounds-test.ts
@@ -3,6 +3,7 @@ const { module, test } = QUnit;
 import { basename } from 'path';
 import {
   applySearchPageBound,
+  applyServerSearchPageBound,
   assertRealmsBound,
   isItemLegSearch,
   runWithSearchTimeBudget,
@@ -10,6 +11,7 @@ import {
   resetSearchBoundsForTests,
   SearchBoundError,
   MAX_SEARCH_PAGE_SIZE,
+  SERVER_MAX_SEARCH_PAGE_SIZE,
   MAX_REALMS_PER_SEARCH_REQUEST,
   type Query,
 } from '@cardstack/runtime-common';
@@ -120,6 +122,63 @@ module(basename(import.meta.filename), function (hooks) {
       );
       let clamped = applySearchPageBound({} as Query);
       assert.deepEqual(clamped.page, { size: 10 });
+    });
+  });
+
+  module('applyServerSearchPageBound', function () {
+    test('the server ceiling is higher than the card @context cap', function (assert) {
+      assert.true(
+        SERVER_MAX_SEARCH_PAGE_SIZE > MAX_SEARCH_PAGE_SIZE,
+        'the server backstop lets the host page larger than a card',
+      );
+    });
+
+    test('a page at or under the server ceiling passes through unchanged', function (assert) {
+      let query = { page: { size: SERVER_MAX_SEARCH_PAGE_SIZE } } as Query;
+      assert.strictEqual(applyServerSearchPageBound(query), query);
+    });
+
+    test('an absent page is clamped to the server ceiling', function (assert) {
+      let bounded = applyServerSearchPageBound({ filter: { eq: {} } } as Query);
+      assert.deepEqual(bounded.page, { size: SERVER_MAX_SEARCH_PAGE_SIZE });
+    });
+
+    test('an explicit page over the server ceiling is rejected with a 400', function (assert) {
+      try {
+        applyServerSearchPageBound({
+          page: { size: SERVER_MAX_SEARCH_PAGE_SIZE + 1 },
+        } as Query);
+        assert.ok(false, 'expected a SearchBoundError');
+      } catch (e) {
+        assert.true(e instanceof SearchBoundError);
+        assert.strictEqual((e as SearchBoundError).status, 400);
+      }
+    });
+
+    test('a page allowed by the server ceiling can still exceed the card cap', function (assert) {
+      // The same page the card cap would reject is fine at the server ceiling —
+      // this is what lets the trusted host page larger than a card.
+      let query = { page: { size: MAX_SEARCH_PAGE_SIZE + 1 } } as Query;
+      assert.throws(
+        () => applySearchPageBound(query),
+        (e: Error) => e instanceof SearchBoundError,
+        'the card cap rejects it',
+      );
+      assert.strictEqual(
+        applyServerSearchPageBound(query),
+        query,
+        'the server ceiling passes it through',
+      );
+    });
+
+    test('the override lowers the effective server ceiling independently', function (assert) {
+      setSearchBoundsForTests({ serverMaxPageSize: 3 });
+      assert.throws(
+        () => applyServerSearchPageBound({ page: { size: 4 } } as Query),
+        (e: Error) => e instanceof SearchBoundError,
+      );
+      let clamped = applyServerSearchPageBound({} as Query);
+      assert.deepEqual(clamped.page, { size: 3 });
     });
   });
 

--- a/packages/realm-server/tests/search-bounds-test.ts
+++ b/packages/realm-server/tests/search-bounds-test.ts
@@ -1,0 +1,155 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import {
+  applySearchPageBound,
+  assertRealmsBound,
+  isItemLegSearch,
+  runWithSearchTimeBudget,
+  setSearchBoundsForTests,
+  resetSearchBoundsForTests,
+  SearchBoundError,
+  MAX_SEARCH_PAGE_SIZE,
+  MAX_REALMS_PER_SEARCH_REQUEST,
+  type Query,
+} from '@cardstack/runtime-common';
+import type { SearchEntryFieldset } from '@cardstack/runtime-common';
+
+const htmlLeg: SearchEntryFieldset = {
+  html: true,
+  item: { kind: 'none' },
+  itemAsFallback: true,
+};
+const itemLegFull: SearchEntryFieldset = {
+  html: false,
+  item: { kind: 'full' },
+  itemAsFallback: false,
+};
+const itemLegSparse: SearchEntryFieldset = {
+  html: false,
+  item: { kind: 'sparse', fields: ['title'] },
+  itemAsFallback: false,
+};
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+module(basename(import.meta.filename), function (hooks) {
+  hooks.afterEach(function () {
+    resetSearchBoundsForTests();
+  });
+
+  module('isItemLegSearch', function () {
+    test('the prerendered/default fieldset (kind none) is not the item leg', function (assert) {
+      assert.false(isItemLegSearch(htmlLeg));
+    });
+
+    test('an explicit item / item.<field> fieldset is the item leg', function (assert) {
+      assert.true(isItemLegSearch(itemLegFull));
+      assert.true(isItemLegSearch(itemLegSparse));
+    });
+  });
+
+  module('applySearchPageBound', function () {
+    test('an absent page is clamped to the max (mandatory pagination)', function (assert) {
+      let bounded = applySearchPageBound({ filter: { eq: {} } } as Query);
+      assert.deepEqual(
+        bounded.page,
+        { size: MAX_SEARCH_PAGE_SIZE },
+        'a default page size is injected',
+      );
+    });
+
+    test('a page at or under the max passes through unchanged', function (assert) {
+      let query = { page: { size: MAX_SEARCH_PAGE_SIZE, number: 2 } } as Query;
+      assert.strictEqual(applySearchPageBound(query), query);
+    });
+
+    test('an explicit page.size over the max is rejected with a 400', function (assert) {
+      try {
+        applySearchPageBound({
+          page: { size: MAX_SEARCH_PAGE_SIZE + 1 },
+        } as Query);
+        assert.ok(false, 'expected a SearchBoundError');
+      } catch (e) {
+        assert.true(e instanceof SearchBoundError);
+        assert.strictEqual((e as SearchBoundError).status, 400);
+      }
+    });
+
+    test('a numeric-string page.size over the max is also rejected', function (assert) {
+      try {
+        applySearchPageBound({
+          page: { size: String(MAX_SEARCH_PAGE_SIZE + 500) },
+        } as unknown as Query);
+        assert.ok(false, 'expected a SearchBoundError');
+      } catch (e) {
+        assert.true(e instanceof SearchBoundError);
+        assert.strictEqual((e as SearchBoundError).status, 400);
+      }
+    });
+
+    test('the override lowers the effective cap', function (assert) {
+      setSearchBoundsForTests({ maxPageSize: 10 });
+      assert.throws(
+        () => applySearchPageBound({ page: { size: 11 } } as Query),
+        (e: Error) => e instanceof SearchBoundError,
+      );
+      let clamped = applySearchPageBound({} as Query);
+      assert.deepEqual(clamped.page, { size: 10 });
+    });
+  });
+
+  module('assertRealmsBound', function () {
+    test('a request at the cap is allowed', function (assert) {
+      let realms = Array.from(
+        { length: MAX_REALMS_PER_SEARCH_REQUEST },
+        (_v, i) => `http://r${i}/`,
+      );
+      assert.strictEqual(assertRealmsBound(realms), undefined);
+    });
+
+    test('a request over the cap is rejected with a 400', function (assert) {
+      let realms = Array.from(
+        { length: MAX_REALMS_PER_SEARCH_REQUEST + 1 },
+        (_v, i) => `http://r${i}/`,
+      );
+      try {
+        assertRealmsBound(realms);
+        assert.ok(false, 'expected a SearchBoundError');
+      } catch (e) {
+        assert.true(e instanceof SearchBoundError);
+        assert.strictEqual((e as SearchBoundError).status, 400);
+      }
+    });
+  });
+
+  module('runWithSearchTimeBudget', function () {
+    test('a search that finishes within budget returns its value', async function (assert) {
+      let result = await runWithSearchTimeBudget(async () => {
+        await wait(5);
+        return 'ok';
+      }, 1000);
+      assert.strictEqual(result, 'ok');
+    });
+
+    test('an over-budget search is cut off with a 408 and the signal aborts', async function (assert) {
+      let aborted = false;
+      try {
+        await runWithSearchTimeBudget(async (signal) => {
+          signal.addEventListener('abort', () => {
+            aborted = true;
+          });
+          await wait(200);
+          return 'too-late';
+        }, 20);
+        assert.ok(false, 'expected a SearchBoundError');
+      } catch (e) {
+        assert.true(e instanceof SearchBoundError);
+        assert.strictEqual((e as SearchBoundError).status, 408);
+      }
+      assert.true(aborted, 'the runner signal was aborted on timeout');
+    });
+  });
+});

--- a/packages/realm-server/tests/search-bounds-test.ts
+++ b/packages/realm-server/tests/search-bounds-test.ts
@@ -66,6 +66,28 @@ module(basename(import.meta.filename), function (hooks) {
       assert.strictEqual(applySearchPageBound(query), query);
     });
 
+    test('a page object with a missing size is clamped, not left unbounded', function (assert) {
+      let bounded = applySearchPageBound({
+        page: { number: 0 },
+      } as unknown as Query);
+      assert.deepEqual(
+        bounded.page,
+        { number: 0, size: MAX_SEARCH_PAGE_SIZE },
+        'the cap is injected and page.number is preserved',
+      );
+    });
+
+    test('a non-positive page.size is clamped, not left unbounded', function (assert) {
+      for (let bad of [-1, 0]) {
+        let bounded = applySearchPageBound({ page: { size: bad } } as Query);
+        assert.strictEqual(
+          bounded.page?.size,
+          MAX_SEARCH_PAGE_SIZE,
+          `size ${bad} is clamped to the cap`,
+        );
+      }
+    });
+
     test('an explicit page.size over the max is rejected with a 400', function (assert) {
       try {
         applySearchPageBound({

--- a/packages/realm-server/tests/server-endpoints/search-test.ts
+++ b/packages/realm-server/tests/server-endpoints/search-test.ts
@@ -16,6 +16,8 @@ import {
   rri,
   query,
   param,
+  setSearchBoundsForTests,
+  resetSearchBoundsForTests,
   type Expression,
 } from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
@@ -467,26 +469,47 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
       );
     });
 
-    test('page/realms bounds are not enforced server-side', async function (assert) {
-      // The page-size and realms caps live at the card `@context` surface, not
-      // the server — so the trusted host (and any other caller) can exceed
-      // them. An oversized item-leg page runs as asked rather than 400ing.
-      let response = await postSearch({
-        filter: personFilter(),
-        fields: { entry: ['item'] },
-        realms: [testRealm.url, secondaryRealm.url],
-        page: { size: 1000 },
-      });
-      assert.strictEqual(
-        response.status,
-        200,
-        'an oversized item-leg page is not rejected server-side',
-      );
-      assert.strictEqual(
-        response.body.meta.page.total,
-        4,
-        'all matching rows are returned',
-      );
+    test('the item-leg page size is capped server-side; realms fan-out is not', async function (assert) {
+      // The server enforces a hard page ceiling on the live item leg for every
+      // caller (the ceiling is applied per realm before results merge). The
+      // realms fan-out cap is a separate client-side limit on the card
+      // `@context` surface, so the server accepts a wide federated request.
+      setSearchBoundsForTests({ serverMaxPageSize: 2 });
+      try {
+        // An explicit item-leg page over the ceiling is rejected.
+        let over = await postSearch({
+          filter: personFilter(),
+          fields: { entry: ['item'] },
+          realms: [testRealm.url, secondaryRealm.url],
+          page: { size: 3 },
+        });
+        assert.strictEqual(
+          over.status,
+          400,
+          'an over-ceiling item-leg page is rejected',
+        );
+
+        // A multi-realm request within the ceiling is accepted — the realms
+        // fan-out is not capped server-side — and both realms are searched.
+        let wide = await postSearch({
+          filter: personFilter(),
+          fields: { entry: ['item'] },
+          realms: [testRealm.url, secondaryRealm.url],
+          page: { size: 2 },
+        });
+        assert.strictEqual(
+          wide.status,
+          200,
+          'a multi-realm request within the page ceiling is accepted',
+        );
+        assert.strictEqual(
+          wide.body.meta.page.total,
+          4,
+          'both realms are searched',
+        );
+      } finally {
+        resetSearchBoundsForTests();
+      }
     });
   });
 });

--- a/packages/realm-server/tests/server-endpoints/search-test.ts
+++ b/packages/realm-server/tests/server-endpoints/search-test.ts
@@ -13,9 +13,13 @@ import type {
 import {
   archiveRealm,
   baseCardRef,
+  DURING_PRERENDER_HEADER,
+  MAX_SEARCH_PAGE_SIZE,
   rri,
   query,
   param,
+  resetSearchBoundsForTests,
+  setSearchBoundsForTests,
   type Expression,
 } from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
@@ -158,6 +162,10 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
       afterEach: async () => {
         await stopSearchRealmServer();
       },
+    });
+
+    hooks.afterEach(function () {
+      resetSearchBoundsForTests();
     });
 
     function ownerToken() {
@@ -464,6 +472,103 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
         afterIndex,
         afterHtml,
         'a newer index generation → a new ETag',
+      );
+    });
+
+    test('an item-leg search over the realms cap is a 400', async function (assert) {
+      setSearchBoundsForTests({ maxRealmsPerRequest: 1 });
+      let overCap = await postSearch({
+        filter: personFilter(),
+        fields: { entry: ['item'] },
+        realms: [testRealm.url, secondaryRealm.url],
+      });
+      assert.strictEqual(
+        overCap.status,
+        400,
+        'two realms over a cap of one → 400',
+      );
+      assert.ok(
+        String(overCap.body?.errors?.[0]?.message ?? overCap.text).includes(
+          'realms',
+        ),
+        'the error names the realms cap',
+      );
+      let atCap = await postSearch({
+        filter: personFilter(),
+        fields: { entry: ['item'] },
+        realms: [testRealm.url],
+      });
+      assert.strictEqual(atCap.status, 200, 'a single realm is within the cap');
+    });
+
+    test('an item-leg search with an explicit oversized page is a 400', async function (assert) {
+      let response = await postSearch({
+        filter: personFilter(),
+        fields: { entry: ['item'] },
+        realms: [testRealm.url],
+        page: { size: MAX_SEARCH_PAGE_SIZE + 1 },
+      });
+      assert.strictEqual(response.status, 400, 'page.size over the max → 400');
+      assert.ok(
+        String(response.body?.errors?.[0]?.message ?? response.text).includes(
+          'page.size',
+        ),
+        'the error names page.size',
+      );
+    });
+
+    test('an item-leg search with no page is clamped, not rejected', async function (assert) {
+      setSearchBoundsForTests({ maxPageSize: 1 });
+      let response = await postSearch({
+        filter: personFilter(),
+        fields: { entry: ['item'] },
+        realms: [testRealm.url],
+      });
+      assert.strictEqual(response.status, 200, 'a missing page is allowed');
+      assert.strictEqual(
+        response.body.data.length,
+        1,
+        'results are clamped to the page cap',
+      );
+      assert.strictEqual(
+        response.body.meta.page.total,
+        2,
+        'meta.page.total still reflects the full match count',
+      );
+    });
+
+    test('the prerendered-HTML leg is exempt from the item-leg caps', async function (assert) {
+      // Drop both caps below what this request asks for; the default (html) leg
+      // must still fan out to both realms with no page and succeed.
+      setSearchBoundsForTests({ maxRealmsPerRequest: 1, maxPageSize: 1 });
+      let response = await postSearch({
+        filter: personFilter(),
+        realms: [testRealm.url, secondaryRealm.url],
+      });
+      assert.strictEqual(response.status, 200, 'the html leg is not bounded');
+      assert.strictEqual(
+        response.body.meta.page.total,
+        4,
+        'all rows across both realms',
+      );
+    });
+
+    test('during-prerender item-leg traffic is exempt from the caps', async function (assert) {
+      setSearchBoundsForTests({ maxRealmsPerRequest: 1, maxPageSize: 1 });
+      let response = await postSearch({
+        filter: personFilter(),
+        fields: { entry: ['item'] },
+        realms: [testRealm.url, secondaryRealm.url],
+      }).set(DURING_PRERENDER_HEADER, testRealm.url);
+      assert.strictEqual(
+        response.status,
+        200,
+        'internal prerender search is not bounded',
+      );
+      assert.strictEqual(
+        response.body.meta.page.total,
+        4,
+        'all rows across both realms',
       );
     });
   });

--- a/packages/realm-server/tests/server-endpoints/search-test.ts
+++ b/packages/realm-server/tests/server-endpoints/search-test.ts
@@ -13,13 +13,9 @@ import type {
 import {
   archiveRealm,
   baseCardRef,
-  DURING_PRERENDER_HEADER,
-  MAX_SEARCH_PAGE_SIZE,
   rri,
   query,
   param,
-  resetSearchBoundsForTests,
-  setSearchBoundsForTests,
   type Expression,
 } from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
@@ -162,10 +158,6 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
       afterEach: async () => {
         await stopSearchRealmServer();
       },
-    });
-
-    hooks.afterEach(function () {
-      resetSearchBoundsForTests();
     });
 
     function ownerToken() {
@@ -475,100 +467,25 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
       );
     });
 
-    test('an item-leg search over the realms cap is a 400', async function (assert) {
-      setSearchBoundsForTests({ maxRealmsPerRequest: 1 });
-      let overCap = await postSearch({
-        filter: personFilter(),
-        fields: { entry: ['item'] },
-        realms: [testRealm.url, secondaryRealm.url],
-      });
-      assert.strictEqual(
-        overCap.status,
-        400,
-        'two realms over a cap of one → 400',
-      );
-      assert.ok(
-        String(overCap.body?.errors?.[0]?.message ?? overCap.text).includes(
-          'realms',
-        ),
-        'the error names the realms cap',
-      );
-      let atCap = await postSearch({
-        filter: personFilter(),
-        fields: { entry: ['item'] },
-        realms: [testRealm.url],
-      });
-      assert.strictEqual(atCap.status, 200, 'a single realm is within the cap');
-    });
-
-    test('an item-leg search with an explicit oversized page is a 400', async function (assert) {
-      let response = await postSearch({
-        filter: personFilter(),
-        fields: { entry: ['item'] },
-        realms: [testRealm.url],
-        page: { size: MAX_SEARCH_PAGE_SIZE + 1 },
-      });
-      assert.strictEqual(response.status, 400, 'page.size over the max → 400');
-      assert.ok(
-        String(response.body?.errors?.[0]?.message ?? response.text).includes(
-          'page.size',
-        ),
-        'the error names page.size',
-      );
-    });
-
-    test('an item-leg search with no page is clamped, not rejected', async function (assert) {
-      setSearchBoundsForTests({ maxPageSize: 1 });
-      let response = await postSearch({
-        filter: personFilter(),
-        fields: { entry: ['item'] },
-        realms: [testRealm.url],
-      });
-      assert.strictEqual(response.status, 200, 'a missing page is allowed');
-      assert.strictEqual(
-        response.body.data.length,
-        1,
-        'results are clamped to the page cap',
-      );
-      assert.strictEqual(
-        response.body.meta.page.total,
-        2,
-        'meta.page.total still reflects the full match count',
-      );
-    });
-
-    test('the prerendered-HTML leg is exempt from the item-leg caps', async function (assert) {
-      // Drop both caps below what this request asks for; the default (html) leg
-      // must still fan out to both realms with no page and succeed.
-      setSearchBoundsForTests({ maxRealmsPerRequest: 1, maxPageSize: 1 });
-      let response = await postSearch({
-        filter: personFilter(),
-        realms: [testRealm.url, secondaryRealm.url],
-      });
-      assert.strictEqual(response.status, 200, 'the html leg is not bounded');
-      assert.strictEqual(
-        response.body.meta.page.total,
-        4,
-        'all rows across both realms',
-      );
-    });
-
-    test('during-prerender item-leg traffic is exempt from the caps', async function (assert) {
-      setSearchBoundsForTests({ maxRealmsPerRequest: 1, maxPageSize: 1 });
+    test('page/realms bounds are not enforced server-side', async function (assert) {
+      // The page-size and realms caps live at the card `@context` surface, not
+      // the server — so the trusted host (and any other caller) can exceed
+      // them. An oversized item-leg page runs as asked rather than 400ing.
       let response = await postSearch({
         filter: personFilter(),
         fields: { entry: ['item'] },
         realms: [testRealm.url, secondaryRealm.url],
-      }).set(DURING_PRERENDER_HEADER, testRealm.url);
+        page: { size: 1000 },
+      });
       assert.strictEqual(
         response.status,
         200,
-        'internal prerender search is not bounded',
+        'an oversized item-leg page is not rejected server-side',
       );
       assert.strictEqual(
         response.body.meta.page.total,
         4,
-        'all rows across both realms',
+        'all matching rows are returned',
       );
     });
   });

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1040,6 +1040,7 @@ export * from './instance-filter-matcher.ts';
 export * from './search-utils.ts';
 export * from './search-resource-helpers.ts';
 export * from './search-entry.ts';
+export * from './search-bounds.ts';
 export * from './request-timings.ts';
 export * from './prerendered-html-format.ts';
 export * from './query-field-utils.ts';

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -146,6 +146,12 @@ type Options = {
   // across stages. Absent (and so a no-op) for everything except
   // instrumented `_federated-search` calls.
   timings?: RequestTimings;
+  // Cooperative-cancellation signal for the search handler's per-request time
+  // budget. When present, `loadLinks` checks it between BFS layers so an
+  // over-budget item-leg search stops its relationship-assembly fan-out
+  // promptly instead of running every layer to completion. Threaded like
+  // `timings`; absent for everything except a bounded live search.
+  signal?: AbortSignal;
 } & QueryOptions;
 
 type SearchResult = SearchResultDoc | SearchResultError;
@@ -1450,6 +1456,12 @@ export class RealmIndexQueryEngine {
 
     let layerIndex = 0;
     while (layer.length > 0) {
+      // Bail before each layer's batched DB queries + cross-realm fetches if
+      // the search's time budget has fired, so an over-budget item-leg search
+      // stops here rather than expanding the full transitive closure. The
+      // federated fan-out treats the resulting rejection as a failed realm; the
+      // handler's time-budget race is what actually returns the 408.
+      opts?.signal?.throwIfAborted();
       let currentLayerIndex = layerIndex++;
       // Step 1: run populateQueryFields for every resource in this layer in
       // parallel. Each runs an independent searchCards query for its

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3,6 +3,7 @@ import type { RealmVisibility } from './realm-visibility.ts';
 import type { SearchOpts } from './search-utils.ts';
 import { buildSearchErrorBody, SearchRequestError } from './search-utils.ts';
 import {
+  applyServerSearchPageBound,
   isItemLegSearch,
   runWithSearchTimeBudget,
   SearchBoundError,
@@ -5712,12 +5713,21 @@ export class Realm {
     try {
       let searchEntryQuery = parseSearchEntryQueryFromPayload(payload);
       let duringPrerender = isDuringPrerenderRequest(request);
-      // The time budget is the one bound enforced server-side (a wall-clock
-      // cutoff can't live client-side). Page-size and realms caps are enforced
-      // at the card `@context` surface. Applies to the live item leg only,
-      // never during-prerender traffic or the prerendered-HTML leg.
-      let timeBounded =
+      // Two bounds hold server-side on the live item leg (never during
+      // prerender, never on the prerendered-HTML leg): a hard page-size ceiling
+      // and the wall-clock time budget. Both hold for every caller — a page
+      // ceiling bounds the result set even when the client card cap was
+      // skipped, and a wall-clock cutoff can't live client-side. The realms and
+      // concurrency caps stay on the card `@context` surface.
+      let itemLegBounded =
         isItemLegSearch(searchEntryQuery.fieldset) && !duringPrerender;
+      // Reject an over-ceiling explicit page (400, caught below); clamp an
+      // absent page so the query carries a LIMIT.
+      if (itemLegBounded) {
+        searchEntryQuery.itemQuery = applyServerSearchPageBound(
+          searchEntryQuery.itemQuery,
+        );
+      }
       let runSearch = (signal?: AbortSignal) =>
         this.searchEntries(searchEntryQuery, {
           cacheOnlyDefinitions: duringPrerender,
@@ -5730,7 +5740,7 @@ export class Realm {
         });
       // Cut an over-budget item-leg search off (408) rather than run it to
       // completion; the signal stops the `loadLinks` fan-out promptly.
-      let doc = timeBounded
+      let doc = itemLegBounded
         ? await runWithSearchTimeBudget(runSearch)
         : await runSearch();
       return createResponse({

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3,7 +3,6 @@ import type { RealmVisibility } from './realm-visibility.ts';
 import type { SearchOpts } from './search-utils.ts';
 import { buildSearchErrorBody, SearchRequestError } from './search-utils.ts';
 import {
-  applySearchPageBound,
   isItemLegSearch,
   runWithSearchTimeBudget,
   SearchBoundError,
@@ -5713,16 +5712,12 @@ export class Realm {
     try {
       let searchEntryQuery = parseSearchEntryQueryFromPayload(payload);
       let duringPrerender = isDuringPrerenderRequest(request);
-      // Item-leg bounds (page size + time budget) apply to the live
-      // serialization path only, never to during-prerender traffic or the
-      // prerendered-HTML leg. No realms cap here — `_search` is single-realm.
-      let bounded =
+      // The time budget is the one bound enforced server-side (a wall-clock
+      // cutoff can't live client-side). Page-size and realms caps are enforced
+      // at the card `@context` surface. Applies to the live item leg only,
+      // never during-prerender traffic or the prerendered-HTML leg.
+      let timeBounded =
         isItemLegSearch(searchEntryQuery.fieldset) && !duringPrerender;
-      if (bounded) {
-        searchEntryQuery.itemQuery = applySearchPageBound(
-          searchEntryQuery.itemQuery,
-        );
-      }
       let runSearch = (signal?: AbortSignal) =>
         this.searchEntries(searchEntryQuery, {
           cacheOnlyDefinitions: duringPrerender,
@@ -5735,7 +5730,7 @@ export class Realm {
         });
       // Cut an over-budget item-leg search off (408) rather than run it to
       // completion; the signal stops the `loadLinks` fan-out promptly.
-      let doc = bounded
+      let doc = timeBounded
         ? await runWithSearchTimeBudget(runSearch)
         : await runSearch();
       return createResponse({

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3,6 +3,12 @@ import type { RealmVisibility } from './realm-visibility.ts';
 import type { SearchOpts } from './search-utils.ts';
 import { buildSearchErrorBody, SearchRequestError } from './search-utils.ts';
 import {
+  applySearchPageBound,
+  isItemLegSearch,
+  runWithSearchTimeBudget,
+  SearchBoundError,
+} from './search-bounds.ts';
+import {
   fieldsetFromParam,
   htmlQueryFromParams,
   parseSearchEntryQueryFromPayload,
@@ -5663,6 +5669,7 @@ export class Realm {
       // `!== undefined` so an explicit priority 0 (system-initiated) survives.
       ...(opts?.priority !== undefined ? { priority: opts.priority } : {}),
       ...(opts?.timings ? { timings: opts.timings } : {}),
+      ...(opts?.signal ? { signal: opts.signal } : {}),
     };
     return await this.#realmIndexQueryEngine.searchEntries(
       searchEntryQuery,
@@ -5706,14 +5713,31 @@ export class Realm {
     try {
       let searchEntryQuery = parseSearchEntryQueryFromPayload(payload);
       let duringPrerender = isDuringPrerenderRequest(request);
-      let doc = await this.searchEntries(searchEntryQuery, {
-        cacheOnlyDefinitions: duringPrerender,
-        // Inside a prerender the search skips the `loadLinks`
-        // relationship-assembly pass entirely: the host re-resolves every
-        // result from its raw card+source file, so the transitive
-        // `included[]` expansion is throwaway work in this path.
-        omitIncluded: duringPrerender,
-      });
+      // Item-leg bounds (page size + time budget) apply to the live
+      // serialization path only, never to during-prerender traffic or the
+      // prerendered-HTML leg. No realms cap here — `_search` is single-realm.
+      let bounded =
+        isItemLegSearch(searchEntryQuery.fieldset) && !duringPrerender;
+      if (bounded) {
+        searchEntryQuery.itemQuery = applySearchPageBound(
+          searchEntryQuery.itemQuery,
+        );
+      }
+      let runSearch = (signal?: AbortSignal) =>
+        this.searchEntries(searchEntryQuery, {
+          cacheOnlyDefinitions: duringPrerender,
+          // Inside a prerender the search skips the `loadLinks`
+          // relationship-assembly pass entirely: the host re-resolves every
+          // result from its raw card+source file, so the transitive
+          // `included[]` expansion is throwaway work in this path.
+          omitIncluded: duringPrerender,
+          ...(signal ? { signal } : {}),
+        });
+      // Cut an over-budget item-leg search off (408) rather than run it to
+      // completion; the signal stops the `loadLinks` fan-out promptly.
+      let doc = bounded
+        ? await runWithSearchTimeBudget(runSearch)
+        : await runSearch();
       return createResponse({
         body: JSON.stringify(doc, null, 2),
         init: {
@@ -5722,6 +5746,16 @@ export class Realm {
         requestContext,
       });
     } catch (e) {
+      if (e instanceof SearchBoundError) {
+        return createResponse({
+          body: JSON.stringify(buildSearchErrorBody(e.message, e.status)),
+          init: {
+            status: e.status,
+            headers: { 'content-type': SupportedMimeType.CardJson },
+          },
+          requestContext,
+        });
+      }
       if (e instanceof SearchRequestError) {
         return createResponse({
           body: JSON.stringify(buildSearchErrorBody(e.message)),

--- a/packages/runtime-common/search-bounds.ts
+++ b/packages/runtime-common/search-bounds.ts
@@ -159,17 +159,25 @@ export function assertRealmsBound(realms: string[]): void {
 // than every row. Returns the (possibly clamped) query without mutating input.
 export function applySearchPageBound(query: Query): Query {
   let page = query.page;
-  if (page != null) {
-    let size = Number((page as { size?: unknown }).size);
-    if (Number.isFinite(size) && size > maxPageSize) {
-      throw new SearchBoundError(
-        400,
-        `page.size ${size} exceeds the maximum of ${maxPageSize}; request a smaller page, or ${HTML_LEG_HINT}`,
-      );
-    }
-    return query;
+  if (page == null) {
+    // No page at all: apply the mandatory cap so the result set is bounded.
+    return { ...query, page: { size: maxPageSize } } as Query;
   }
-  return { ...query, page: { size: maxPageSize } } as Query;
+  let size = Number((page as { size?: unknown }).size);
+  if (!Number.isFinite(size) || size < 1) {
+    // A page object with a missing / non-numeric / non-positive size can't
+    // bound the result set — and would compile to `LIMIT undefined` / a
+    // negative limit — so treat it like an absent page and clamp to the cap
+    // rather than let it through unbounded.
+    return { ...query, page: { ...page, size: maxPageSize } } as Query;
+  }
+  if (size > maxPageSize) {
+    throw new SearchBoundError(
+      400,
+      `page.size ${size} exceeds the maximum of ${maxPageSize}; request a smaller page, or ${HTML_LEG_HINT}`,
+    );
+  }
+  return query;
 }
 
 // Run an item-leg search under the wall-clock budget. The runner receives an

--- a/packages/runtime-common/search-bounds.ts
+++ b/packages/runtime-common/search-bounds.ts
@@ -2,28 +2,37 @@ import type { Query } from './query.ts';
 import type { SearchEntryFieldset } from './search-entry.ts';
 
 // ---------------------------------------------------------------------------
-// Hard resource bounds for search — server-enforced limits a query cannot
-// override, so no single userland search can exhaust the realm-server's single
-// event loop. Card code is untrusted, re-editable input; these bounds hold
-// whatever a card asks for.
-//
-// The bounds apply to the ITEM leg only (the live serialization + `loadLinks`
-// path whose per-request cost they contain): a page-size ceiling, a
-// realms-per-request ceiling for federated search, and a wall-clock budget. The
+// Hard resource bounds for search, so no single search can exhaust the
+// realm-server's single event loop. They apply to the ITEM leg only — the live
+// serialization + `loadLinks` path whose per-request cost they contain. The
 // prerendered-HTML leg is the cheap precomputed path and is left unbounded, as
 // is the realm-server's own during-prerender traffic. When a request trips a
 // ceiling, the error steers the author toward the HTML leg
 // (`@context.searchResultsComponent`), which the ceilings don't apply to.
 //
-// Concurrency is not enforced here: it is a client-side throttle on the card
-// `@context` surface (the trusted host app must not be throttled, and the
-// host/card distinction only exists on the client). This module exports the
-// shared cap constant the host reuses.
+// Where each bound lives follows one rule: the server can't tell a trusted-host
+// request from untrusted card code, so a bound the host must be free to exceed
+// is enforced client-side on the card `@context` surface, and a bound that must
+// hold for every caller is enforced server-side.
 //
-// All four bounds are exported consts, overridable via env for ops tuning.
+//   - Page size — two ceilings. The card `@context` cap (MAX_SEARCH_PAGE_SIZE)
+//     is enforced client-side, so a card gets a small page while the host can
+//     page larger. The server ceiling (SERVER_MAX_SEARCH_PAGE_SIZE, higher) is
+//     enforced server-side on every item-leg request — the host, and any card
+//     that skips the client cap, included — so the result set the server
+//     assembles and serializes is always bounded. The true match count still
+//     rides `meta.page.total`, so a caller can paginate.
+//   - Realms fan-out (MAX_REALMS_PER_SEARCH_REQUEST) and concurrency
+//     (SEARCH_CONCURRENCY_CAP) — client-side only, on the card `@context`
+//     surface: the host federates widely and runs its own searches freely.
+//   - Time budget (SEARCH_TIME_BUDGET_MS) — server-side only: a wall-clock
+//     cutoff of the server's own work can't live anywhere else.
+//
+// All bounds are exported consts, overridable via env for ops tuning.
 // ---------------------------------------------------------------------------
 
 const DEFAULT_MAX_SEARCH_PAGE_SIZE = 100;
+const DEFAULT_SERVER_MAX_SEARCH_PAGE_SIZE = 500;
 const DEFAULT_MAX_REALMS_PER_SEARCH_REQUEST = 2;
 const DEFAULT_SEARCH_TIME_BUDGET_MS = 30_000;
 const DEFAULT_SEARCH_CONCURRENCY_CAP = 2;
@@ -50,12 +59,26 @@ function parsePositiveInt(
 let env: Record<string, string | undefined> =
   typeof process !== 'undefined' ? (process.env ?? {}) : {};
 
-// Max results serialized/hydrated per item-leg request. An explicit page.size
+// The card `@context` page cap: max results a card-initiated item-leg search
+// requests. Enforced client-side (see host StoreService). An explicit page.size
 // above this is rejected; an absent page is clamped to it (mandatory
-// pagination) so a non-paginating caller gets the first page, not every row.
+// pagination) so a non-paginating card gets the first page, not every row.
 export const MAX_SEARCH_PAGE_SIZE = parsePositiveInt(
   env.MAX_SEARCH_PAGE_SIZE,
   DEFAULT_MAX_SEARCH_PAGE_SIZE,
+  MIN_PAGE_SIZE,
+);
+
+// The server-side hard page ceiling, enforced on every item-leg request
+// regardless of caller (the trusted host and any card that skips the client cap
+// included). Higher than the card `@context` cap — the host may legitimately
+// page larger — but no request may make the server assemble/serialize an
+// unbounded page. Same shape as the card cap: an explicit page above it is
+// rejected; an absent page is clamped to it (the true total rides
+// `meta.page.total`, so a caller can still paginate).
+export const SERVER_MAX_SEARCH_PAGE_SIZE = parsePositiveInt(
+  env.SERVER_MAX_SEARCH_PAGE_SIZE,
+  DEFAULT_SERVER_MAX_SEARCH_PAGE_SIZE,
   MIN_PAGE_SIZE,
 );
 
@@ -88,16 +111,21 @@ export const SEARCH_CONCURRENCY_CAP = parsePositiveInt(
 // `setSearchBoundsForTests` to exercise a bound without adding realms or
 // waiting out the real time budget. Mirrors `setSearchTimingSinkForTests`.
 let maxPageSize = MAX_SEARCH_PAGE_SIZE;
+let serverMaxPageSize = SERVER_MAX_SEARCH_PAGE_SIZE;
 let maxRealmsPerRequest = MAX_REALMS_PER_SEARCH_REQUEST;
 let timeBudgetMs = SEARCH_TIME_BUDGET_MS;
 
 export function setSearchBoundsForTests(overrides: {
   maxPageSize?: number;
+  serverMaxPageSize?: number;
   maxRealmsPerRequest?: number;
   timeBudgetMs?: number;
 }): void {
   if (overrides.maxPageSize !== undefined) {
     maxPageSize = overrides.maxPageSize;
+  }
+  if (overrides.serverMaxPageSize !== undefined) {
+    serverMaxPageSize = overrides.serverMaxPageSize;
   }
   if (overrides.maxRealmsPerRequest !== undefined) {
     maxRealmsPerRequest = overrides.maxRealmsPerRequest;
@@ -109,6 +137,7 @@ export function setSearchBoundsForTests(overrides: {
 
 export function resetSearchBoundsForTests(): void {
   maxPageSize = MAX_SEARCH_PAGE_SIZE;
+  serverMaxPageSize = SERVER_MAX_SEARCH_PAGE_SIZE;
   maxRealmsPerRequest = MAX_REALMS_PER_SEARCH_REQUEST;
   timeBudgetMs = SEARCH_TIME_BUDGET_MS;
 }
@@ -153,15 +182,16 @@ export function assertRealmsBound(realms: string[]): void {
   }
 }
 
-// Enforce mandatory pagination on an item-leg query. An explicit page.size over
-// the max is rejected (the author asked for more than allowed); an absent page
-// is clamped to the max so a non-paginating caller gets the first page rather
-// than every row. Returns the (possibly clamped) query without mutating input.
-export function applySearchPageBound(query: Query): Query {
+// Enforce mandatory pagination on an item-leg query against `max`. An explicit
+// page.size over `max` is rejected (the caller asked for more than allowed); an
+// absent page is clamped to `max` so a non-paginating caller gets the first
+// page rather than every row. Returns the (possibly clamped) query without
+// mutating input.
+function boundPageSize(query: Query, max: number): Query {
   let page = query.page;
   if (page == null) {
     // No page at all: apply the mandatory cap so the result set is bounded.
-    return { ...query, page: { size: maxPageSize } } as Query;
+    return { ...query, page: { size: max } } as Query;
   }
   let size = Number((page as { size?: unknown }).size);
   if (!Number.isFinite(size) || size < 1) {
@@ -169,15 +199,29 @@ export function applySearchPageBound(query: Query): Query {
     // bound the result set — and would compile to `LIMIT undefined` / a
     // negative limit — so treat it like an absent page and clamp to the cap
     // rather than let it through unbounded.
-    return { ...query, page: { ...page, size: maxPageSize } } as Query;
+    return { ...query, page: { ...page, size: max } } as Query;
   }
-  if (size > maxPageSize) {
+  if (size > max) {
     throw new SearchBoundError(
       400,
-      `page.size ${size} exceeds the maximum of ${maxPageSize}; request a smaller page, or ${HTML_LEG_HINT}`,
+      `page.size ${size} exceeds the maximum of ${max}; request a smaller page, or ${HTML_LEG_HINT}`,
     );
   }
   return query;
+}
+
+// The card `@context` page cap, enforced client-side on card-initiated
+// item-leg searches (see host StoreService).
+export function applySearchPageBound(query: Query): Query {
+  return boundPageSize(query, maxPageSize);
+}
+
+// The server-side hard page ceiling, enforced on every item-leg request the
+// server handles regardless of caller. Higher than the card `@context` cap; the
+// backstop that bounds what the server assembles/serializes even when the
+// client cap was skipped.
+export function applyServerSearchPageBound(query: Query): Query {
+  return boundPageSize(query, serverMaxPageSize);
 }
 
 // Run an item-leg search under the wall-clock budget. The runner receives an

--- a/packages/runtime-common/search-bounds.ts
+++ b/packages/runtime-common/search-bounds.ts
@@ -1,0 +1,209 @@
+import type { Query } from './query.ts';
+import type { SearchEntryFieldset } from './search-entry.ts';
+
+// ---------------------------------------------------------------------------
+// Hard resource bounds for search — server-enforced limits a query cannot
+// override, so no single userland search can exhaust the realm-server's single
+// event loop. Card code is untrusted, re-editable input; these bounds hold
+// whatever a card asks for.
+//
+// The bounds apply to the ITEM leg only (the live serialization + `loadLinks`
+// path whose per-request cost they contain): a page-size ceiling, a
+// realms-per-request ceiling for federated search, and a wall-clock budget. The
+// prerendered-HTML leg is the cheap precomputed path and is left unbounded, as
+// is the realm-server's own during-prerender traffic. When a request trips a
+// ceiling, the error steers the author toward the HTML leg
+// (`@context.searchResultsComponent`), which the ceilings don't apply to.
+//
+// Concurrency is not enforced here: it is a client-side throttle on the card
+// `@context` surface (the trusted host app must not be throttled, and the
+// host/card distinction only exists on the client). This module exports the
+// shared cap constant the host reuses.
+//
+// All four bounds are exported consts, overridable via env for ops tuning.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_SEARCH_PAGE_SIZE = 100;
+const DEFAULT_MAX_REALMS_PER_SEARCH_REQUEST = 2;
+const DEFAULT_SEARCH_TIME_BUDGET_MS = 30_000;
+const DEFAULT_SEARCH_CONCURRENCY_CAP = 2;
+
+const MIN_PAGE_SIZE = 1;
+const MIN_REALMS = 1;
+const MIN_TIME_BUDGET_MS = 1_000;
+const MIN_CONCURRENCY = 1;
+
+// Clamp an env override to a positive integer, falling back (also clamped) when
+// the value is missing or non-numeric so a bad env var can't disable a bound.
+function parsePositiveInt(
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+): number {
+  let parsed = raw != null ? Number(raw) : NaN;
+  if (!Number.isFinite(parsed)) {
+    return Math.max(min, fallback);
+  }
+  return Math.max(min, Math.floor(parsed));
+}
+
+let env: Record<string, string | undefined> =
+  typeof process !== 'undefined' ? (process.env ?? {}) : {};
+
+// Max results serialized/hydrated per item-leg request. An explicit page.size
+// above this is rejected; an absent page is clamped to it (mandatory
+// pagination) so a non-paginating caller gets the first page, not every row.
+export const MAX_SEARCH_PAGE_SIZE = parsePositiveInt(
+  env.MAX_SEARCH_PAGE_SIZE,
+  DEFAULT_MAX_SEARCH_PAGE_SIZE,
+  MIN_PAGE_SIZE,
+);
+
+// Max realms a single federated item-leg request may fan out to.
+export const MAX_REALMS_PER_SEARCH_REQUEST = parsePositiveInt(
+  env.MAX_REALMS_PER_SEARCH_REQUEST,
+  DEFAULT_MAX_REALMS_PER_SEARCH_REQUEST,
+  MIN_REALMS,
+);
+
+// Wall-clock budget for a single item-leg search. Over-budget searches are cut
+// off rather than run to completion.
+export const SEARCH_TIME_BUDGET_MS = parsePositiveInt(
+  env.SEARCH_TIME_BUDGET_MS,
+  DEFAULT_SEARCH_TIME_BUDGET_MS,
+  MIN_TIME_BUDGET_MS,
+);
+
+// Max concurrent card-initiated item-leg searches. Enforced client-side on the
+// `@context` surface (see host StoreService); exported here so the client and
+// the shared contract agree on one number.
+export const SEARCH_CONCURRENCY_CAP = parsePositiveInt(
+  env.SEARCH_CONCURRENCY_CAP,
+  DEFAULT_SEARCH_CONCURRENCY_CAP,
+  MIN_CONCURRENCY,
+);
+
+// The effective values the enforcement functions read. They default to the
+// exported consts (the ops-facing knobs); a test overrides them via
+// `setSearchBoundsForTests` to exercise a bound without adding realms or
+// waiting out the real time budget. Mirrors `setSearchTimingSinkForTests`.
+let maxPageSize = MAX_SEARCH_PAGE_SIZE;
+let maxRealmsPerRequest = MAX_REALMS_PER_SEARCH_REQUEST;
+let timeBudgetMs = SEARCH_TIME_BUDGET_MS;
+
+export function setSearchBoundsForTests(overrides: {
+  maxPageSize?: number;
+  maxRealmsPerRequest?: number;
+  timeBudgetMs?: number;
+}): void {
+  if (overrides.maxPageSize !== undefined) {
+    maxPageSize = overrides.maxPageSize;
+  }
+  if (overrides.maxRealmsPerRequest !== undefined) {
+    maxRealmsPerRequest = overrides.maxRealmsPerRequest;
+  }
+  if (overrides.timeBudgetMs !== undefined) {
+    timeBudgetMs = overrides.timeBudgetMs;
+  }
+}
+
+export function resetSearchBoundsForTests(): void {
+  maxPageSize = MAX_SEARCH_PAGE_SIZE;
+  maxRealmsPerRequest = MAX_REALMS_PER_SEARCH_REQUEST;
+  timeBudgetMs = SEARCH_TIME_BUDGET_MS;
+}
+
+// The item leg (`fields[entry]` includes "item" / "item.<field>") is the live
+// serialization + `loadLinks` path — the one whose cost the bounds contain. The
+// default/prerendered fieldset resolves to `kind: 'none'` (html-preferred, item
+// only as a per-row fallback) and is exempt.
+export function isItemLegSearch(fieldset: SearchEntryFieldset): boolean {
+  return fieldset.item.kind !== 'none';
+}
+
+// The HTTP statuses a bound violation maps to. 408 for the time budget so a
+// client reads it as "took too long — narrow the query / retry".
+export type SearchBoundStatus = 400 | 408;
+
+export class SearchBoundError extends Error {
+  status: SearchBoundStatus;
+  constructor(status: SearchBoundStatus, message: string) {
+    super(message);
+    this.status = status;
+    this.name = 'SearchBoundError';
+  }
+}
+
+// The bounds cap the item leg only, so a genuinely large or wide result set
+// belongs on the prerendered-HTML leg (rendered lazily, never live-serialized).
+// Every bound error points there so an author can switch rather than fight the
+// cap.
+const HTML_LEG_HINT =
+  'for large or wide result sets, use prerendered HTML search results (@context.searchResultsComponent), which this cap does not apply to';
+
+// Reject a federated item-leg request that fans out to more realms than the
+// cap. It can't be clamped (we can't choose which realms to drop), so the
+// author must narrow the `realms` list.
+export function assertRealmsBound(realms: string[]): void {
+  if (realms.length > maxRealmsPerRequest) {
+    throw new SearchBoundError(
+      400,
+      `search spans ${realms.length} realms, exceeding the per-request limit of ${maxRealmsPerRequest}; narrow the "realms" list, or ${HTML_LEG_HINT}`,
+    );
+  }
+}
+
+// Enforce mandatory pagination on an item-leg query. An explicit page.size over
+// the max is rejected (the author asked for more than allowed); an absent page
+// is clamped to the max so a non-paginating caller gets the first page rather
+// than every row. Returns the (possibly clamped) query without mutating input.
+export function applySearchPageBound(query: Query): Query {
+  let page = query.page;
+  if (page != null) {
+    let size = Number((page as { size?: unknown }).size);
+    if (Number.isFinite(size) && size > maxPageSize) {
+      throw new SearchBoundError(
+        400,
+        `page.size ${size} exceeds the maximum of ${maxPageSize}; request a smaller page, or ${HTML_LEG_HINT}`,
+      );
+    }
+    return query;
+  }
+  return { ...query, page: { size: maxPageSize } } as Query;
+}
+
+// Run an item-leg search under the wall-clock budget. The runner receives an
+// AbortSignal it threads into `loadLinks` so the expensive async work stops
+// promptly on timeout; the Promise.race guarantees the 408 return even though
+// the federated fan-out swallows the abort (it treats an aborted realm as a
+// failed realm). The abandoned runner promise gets a no-op catch so its late
+// abort rejection isn't an unhandled rejection.
+export async function runWithSearchTimeBudget<T>(
+  run: (signal: AbortSignal) => Promise<T>,
+  budgetMs: number = timeBudgetMs,
+): Promise<T> {
+  let controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(
+        new SearchBoundError(
+          408,
+          `search exceeded the ${Math.round(
+            budgetMs / 1000,
+          )}s request time limit and was cancelled; narrow the query, request a smaller page, or ${HTML_LEG_HINT}`,
+        ),
+      );
+    }, budgetMs);
+  });
+  let running = run(controller.signal);
+  running.catch(() => {});
+  try {
+    return await Promise.race([running, timedOut]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/runtime-common/search-utils.ts
+++ b/packages/runtime-common/search-utils.ts
@@ -129,6 +129,11 @@ export type SearchOpts = {
   // applies it as a SQL `i.url IN (...)` filter, so it must reach the engine
   // opts — not only the cache key — for the subset to actually narrow results.
   cardUrls?: string[];
+  // Cooperative-cancellation signal for the per-request time budget. When the
+  // search handler cuts an over-budget item-leg search off, this aborts so the
+  // engine's `loadLinks` fan-out stops promptly instead of running to
+  // completion. Threaded the same way as `timings`.
+  signal?: AbortSignal;
 };
 
 // Indirection so a host integration test can deterministically capture


### PR DESCRIPTION
## Background

A card that issues an unbounded, all-realms search can pin the realm-server's single Node event loop — SQL is cheap, but assembling and serializing large **item-leg** (live card serialization + `loadLinks`) results across many realms is synchronous CPU work — until it fails health checks. The fix has to protect the platform from **untrusted card code**, which can only reach search through the `@context` surface, while leaving the **trusted host app** free to fetch a large page or federate widely for a real feature.

That threat model drives where each bound lives. The server can't tell a card apart from the host, so:

- **Client `@context` (card-initiated searches only):** the caps that shape *what/how much a card asks for* — page size, realms fan-out, concurrency, and a no-realm → current-realm default. Enforced client-side because the host must be able to exceed them.
- **Server (every caller):** a **hard page-size ceiling** and the **time budget** — the two bounds that must hold no matter who calls, including the host and any card that reaches search another way. A wall-clock cutoff can't live client-side, and a page ceiling is the only thing that bounds the result set the server assembles/serializes when the client cap is skipped. The ceiling is generous (higher than the card cap) so the host can still page larger than a card.

## The bounds

| Bound | Where | Scope |
|---|---|---|
| No realm → **current realm** (not all realms) | Client `@context` | card, item leg |
| **Realms cap (2)** if realms explicitly given | Client `@context` | card, item leg |
| **Card page cap (100)** | Client `@context` | card, item leg |
| **Concurrency (2)** | Client `@context` | card, item leg |
| **Server page ceiling (500)** | Server | **every caller**, item leg |
| **Time budget (30s → 408)** | Server | every caller, item leg |

The client caps + no-realm default apply only to card access through `@context`; host `store.search` / `store.searchEntries` / host-rendered `<SearchResults>` keep the all-realms default and skip them. The **server** bounds (page ceiling + time budget) hold for **every** item-leg request — the host included — so the platform is protected even if a card bypasses the client surface. The prerendered-HTML leg and the realm-server's own during-prerender traffic are exempt from all of it.

All caps are exported, env-overridable consts in `runtime-common/search-bounds.ts` (`MAX_SEARCH_PAGE_SIZE`, `SERVER_MAX_SEARCH_PAGE_SIZE`, `MAX_REALMS_PER_SEARCH_REQUEST`, `SEARCH_TIME_BUDGET_MS`, `SEARCH_CONCURRENCY_CAP`) — **reviewers, please weigh in on the values, especially the 100 card cap vs the 500 server ceiling.**

## How it works

- **`store.search`** takes a `cardInitiated` opt. When set, it runs the realms cap + card page cap on the resolved request and executes under an ember-concurrency `enqueue`/`maxConcurrency` throttle; a no-realm card search resolves to the current realm, or to empty (no fan-out) when the current realm is unknown. Host callers omit the flag and are untouched by the client caps.
- **`store.cardFacingStore(getCurrentRealm)`** is the `@context.store` view: its `search` is card-initiated and current-realm-defaulting.
- **The `@context` providers** (operator-mode container, prerender render-route, host index) bind `getCards` + the card-facing store to *their* current realm via a closure. The dev `host-freestyle` gallery stays on the raw store.
- **Both server search handlers** (`handle-search.ts`, `realm.ts`) enforce the item-leg page ceiling and the time budget for every caller: an explicit page over the ceiling is rejected (400), an absent page is clamped so the query carries a `LIMIT` (the true match count still rides `meta.page.total`, so a caller can paginate), and an over-budget search is cut off (408) with an `AbortSignal` threaded into `loadLinks`.

## Follow-up

The html-leg current-realm default for `@context.searchResultsComponent` (currying the current realm onto the shared component) is a focused fast-follow. The html leg is the cheap, precomputed path — the server page ceiling and time budget already bound the expensive item leg — so a card's no-realm html search hitting all realms is a low-severity interim gap.

## Testing

- **Unit** (`realm-server/tests/search-bounds-test.ts`): card page cap and server page ceiling (clamp/reject incl. missing/negative size; ceiling higher than the card cap), realms reject, item-leg detection, time-budget cutoff (verifies the abort).
- **Client** (`host/tests/integration/resources/search-test.ts`): a card-initiated search over the realms/page cap is rejected while the host path is not; the card-facing store defaults a no-realm search to the current realm and yields empty when none; the concurrency throttle queues at the cap.
- **Server** (`realm-server/tests/.../search-test.ts`): an item-leg page over the server ceiling is rejected and an absent page is clamped (total preserved); the html leg and the realms fan-out are not page/realms-capped server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
