### PR TITLE
fix: dedup card .json file rows in boxel-cli search output

### DIFF
--- a/packages/boxel-cli/src/commands/search.ts
+++ b/packages/boxel-cli/src/commands/search.ts
@@ -7,6 +7,13 @@ import {
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { resolveRealmIdentifier } from '../lib/resolve-realm-identifier.ts';
 import { resourceIdentity } from '@cardstack/runtime-common/resource-identity';
+import { CARD_INSTANCE_FILE_KEY } from '@cardstack/runtime-common/search-doc-keys';
+import {
+  baseRef,
+  baseCardRef,
+  baseFieldRef,
+  baseFileRef,
+} from '@cardstack/runtime-common/constants';
 import { FG_RED, DIM, RESET } from '../lib/colors.ts';
 import { cliLog } from '../lib/cli-log.ts';
 
@@ -206,6 +213,97 @@ export function itemsFromSearchEntryDoc(
   return items;
 }
 
+// A mixed (`scope: 'all'`) entry search returns both rows of a dual-indexed
+// card `.json` — an `instance` row and a `file` row — so a card `.json` shows
+// up twice unless the filter discriminates. The dedup filter keeps card
+// instances and plain files but drops the redundant `.json` file row: the
+// `_isCardInstanceFile` key is stamped only on that file row, so `eq: false`
+// (which matches an absent key too) keeps every other row and drops it.
+//
+// Mirrors the host's search-sheet dedup (`excludeCardInstanceFileRows` /
+// `scopeFilters` in host `card-search/query-builder.ts`). The type-anchor
+// detection mirrors `getTypeRefsFromFilter` / `hasNarrowingPositiveTypeRef`
+// there, reimplemented locally because runtime-common's query-field-utils pulls
+// its `https://cardstack.com/base/*` imports into boxel-cli's dependency-light
+// graph (same boundary the wire-translation helpers above note).
+const ROOT_TYPE_REFS = [baseRef, baseCardRef, baseFieldRef, baseFileRef];
+
+// Root refs (BaseDef/CardDef/FieldDef/FileDef) span kinds rather than narrowing
+// to one, so an anchor on one of them must not suppress the dedup: a
+// `type: baseRef` query still matches both rows of a card `.json`.
+function isRootTypeRef(ref: unknown): boolean {
+  if (typeof ref !== 'object' || ref == null) {
+    return false;
+  }
+  let { module, name } = ref as { module?: unknown; name?: unknown };
+  return ROOT_TYPE_REFS.some(
+    (root) => root.module === module && root.name === name,
+  );
+}
+
+interface TypeRefResult {
+  ref: unknown;
+  negated: boolean;
+}
+
+// Walk a card-rooted filter and collect every type/on anchor with its polarity
+// (flipped under each enclosing `not`).
+function collectTypeRefs(filter: unknown, negated = false): TypeRefResult[] {
+  if (typeof filter !== 'object' || filter == null || Array.isArray(filter)) {
+    return [];
+  }
+  let f = filter as Record<string, unknown>;
+  if (f.on != null) {
+    return [{ ref: f.on, negated }];
+  }
+  if (f.type != null) {
+    return [{ ref: f.type, negated }];
+  }
+  if (f.not != null) {
+    return collectTypeRefs(f.not, !negated);
+  }
+  if (Array.isArray(f.every)) {
+    return f.every.flatMap((node) => collectTypeRefs(node, negated));
+  }
+  if (Array.isArray(f.any)) {
+    return f.any.flatMap((node) => collectTypeRefs(node, negated));
+  }
+  return [];
+}
+
+// True when the filter carries a positive, kind-narrowing type anchor — a
+// picked card type matches only instance rows (no dupe to drop) and a picked
+// file type must stay free to surface a `.json` file row that legitimately
+// matches it. Root refs don't count (see `isRootTypeRef`).
+function hasNarrowingTypeAnchor(filter: unknown): boolean {
+  return collectTypeRefs(filter).some(
+    (r) => !r.negated && !isRootTypeRef(r.ref),
+  );
+}
+
+/**
+ * Make a search query invariant to the mixed entry-search default: compose the
+ * `_isCardInstanceFile` dedup filter so each card `.json` surfaces once (via its
+ * instance row) while plain files stay listed.
+ *
+ * Skipped when the wire `scope` already pins a single kind (`'cards'`/`'files'`)
+ * or the filter carries a narrowing positive type anchor — the same rule the
+ * host applies. Exported for unit testing.
+ */
+export function composeMixedScopeDedup(
+  query: Record<string, unknown>,
+): Record<string, unknown> {
+  if (query.scope === 'cards' || query.scope === 'files') {
+    return query;
+  }
+  if (hasNarrowingTypeAnchor(query.filter)) {
+    return query;
+  }
+  let dedup = { eq: { [CARD_INSTANCE_FILE_KEY]: false } };
+  let filter = query.filter == null ? dedup : { every: [query.filter, dedup] };
+  return { ...query, filter };
+}
+
 /**
  * Federated search across one or more realms via the `_federated-search`
  * server endpoint.
@@ -232,6 +330,8 @@ export async function search(
 
   let realmServerUrl = active.profile.realmServerUrl.replace(/\/$/, '');
   let searchUrl = `${realmServerUrl}/_federated-search`;
+
+  query = composeMixedScopeDedup(query);
 
   let realms: string[] = [];
   for (let realm of Array.isArray(realmUrls) ? realmUrls : [realmUrls]) {

--- a/packages/boxel-cli/src/commands/search.ts
+++ b/packages/boxel-cli/src/commands/search.ts
@@ -8,12 +8,6 @@ import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { resolveRealmIdentifier } from '../lib/resolve-realm-identifier.ts';
 import { resourceIdentity } from '@cardstack/runtime-common/resource-identity';
 import { CARD_INSTANCE_FILE_KEY } from '@cardstack/runtime-common/search-doc-keys';
-import {
-  baseRef,
-  baseCardRef,
-  baseFieldRef,
-  baseFileRef,
-} from '@cardstack/runtime-common/constants';
 import { FG_RED, DIM, RESET } from '../lib/colors.ts';
 import { cliLog } from '../lib/cli-log.ts';
 
@@ -221,64 +215,35 @@ export function itemsFromSearchEntryDoc(
 // (which matches an absent key too) keeps every other row and drops it.
 //
 // Mirrors the host's search-sheet dedup (`excludeCardInstanceFileRows` /
-// `scopeFilters` in host `card-search/query-builder.ts`). The type-anchor
-// detection mirrors `getTypeRefsFromFilter` / `hasNarrowingPositiveTypeRef`
-// there, reimplemented locally because runtime-common's query-field-utils pulls
-// its `https://cardstack.com/base/*` imports into boxel-cli's dependency-light
-// graph (same boundary the wire-translation helpers above note).
-const ROOT_TYPE_REFS = [baseRef, baseCardRef, baseFieldRef, baseFileRef];
-
-// Root refs (BaseDef/CardDef/FieldDef/FileDef) span kinds rather than narrowing
-// to one, so an anchor on one of them must not suppress the dedup: a
-// `type: baseRef` query still matches both rows of a card `.json`.
-function isRootTypeRef(ref: unknown): boolean {
-  if (typeof ref !== 'object' || ref == null) {
+// `scopeFilters` in host `card-search/query-builder.ts`). The type-anchor check
+// is a local walk rather than an import of runtime-common's
+// `getTypeRefsFromFilter`, whose module pulls the `@cardstack/base/*` graph into
+// boxel-cli's dependency-light build (the same boundary the wire-translation
+// helpers above note).
+//
+// True when the filter carries a positive (non-negated) `type`/`on` anchor. A
+// picked type discriminates the kind by itself — a card type matches only
+// instance rows (no dupe to drop), a file type must stay free to surface a
+// `.json` file row that legitimately matches it — so the dedup is skipped.
+// Polarity flips under each enclosing `not`, so a negated anchor doesn't count.
+function hasPositiveTypeAnchor(filter: unknown, negated = false): boolean {
+  if (typeof filter !== 'object' || filter == null || Array.isArray(filter)) {
     return false;
   }
-  let { module, name } = ref as { module?: unknown; name?: unknown };
-  return ROOT_TYPE_REFS.some(
-    (root) => root.module === module && root.name === name,
-  );
-}
-
-interface TypeRefResult {
-  ref: unknown;
-  negated: boolean;
-}
-
-// Walk a card-rooted filter and collect every type/on anchor with its polarity
-// (flipped under each enclosing `not`).
-function collectTypeRefs(filter: unknown, negated = false): TypeRefResult[] {
-  if (typeof filter !== 'object' || filter == null || Array.isArray(filter)) {
-    return [];
-  }
   let f = filter as Record<string, unknown>;
-  if (f.on != null) {
-    return [{ ref: f.on, negated }];
-  }
-  if (f.type != null) {
-    return [{ ref: f.type, negated }];
+  if (f.on != null || f.type != null) {
+    return !negated;
   }
   if (f.not != null) {
-    return collectTypeRefs(f.not, !negated);
+    return hasPositiveTypeAnchor(f.not, !negated);
   }
   if (Array.isArray(f.every)) {
-    return f.every.flatMap((node) => collectTypeRefs(node, negated));
+    return f.every.some((node) => hasPositiveTypeAnchor(node, negated));
   }
   if (Array.isArray(f.any)) {
-    return f.any.flatMap((node) => collectTypeRefs(node, negated));
+    return f.any.some((node) => hasPositiveTypeAnchor(node, negated));
   }
-  return [];
-}
-
-// True when the filter carries a positive, kind-narrowing type anchor — a
-// picked card type matches only instance rows (no dupe to drop) and a picked
-// file type must stay free to surface a `.json` file row that legitimately
-// matches it. Root refs don't count (see `isRootTypeRef`).
-function hasNarrowingTypeAnchor(filter: unknown): boolean {
-  return collectTypeRefs(filter).some(
-    (r) => !r.negated && !isRootTypeRef(r.ref),
-  );
+  return false;
 }
 
 /**
@@ -287,8 +252,8 @@ function hasNarrowingTypeAnchor(filter: unknown): boolean {
  * instance row) while plain files stay listed.
  *
  * Skipped when the wire `scope` already pins a single kind (`'cards'`/`'files'`)
- * or the filter carries a narrowing positive type anchor — the same rule the
- * host applies. Exported for unit testing.
+ * or the filter carries a positive type anchor — the same rule the host applies.
+ * Exported for unit testing.
  */
 export function composeMixedScopeDedup(
   query: Record<string, unknown>,
@@ -296,7 +261,7 @@ export function composeMixedScopeDedup(
   if (query.scope === 'cards' || query.scope === 'files') {
     return query;
   }
-  if (hasNarrowingTypeAnchor(query.filter)) {
+  if (hasPositiveTypeAnchor(query.filter)) {
     return query;
   }
   let dedup = { eq: { [CARD_INSTANCE_FILE_KEY]: false } };

--- a/packages/boxel-cli/src/commands/search.ts
+++ b/packages/boxel-cli/src/commands/search.ts
@@ -215,33 +215,60 @@ export function itemsFromSearchEntryDoc(
 // (which matches an absent key too) keeps every other row and drops it.
 //
 // Mirrors the host's search-sheet dedup (`excludeCardInstanceFileRows` /
-// `scopeFilters` in host `card-search/query-builder.ts`). The type-anchor check
-// is a local walk rather than an import of runtime-common's
-// `getTypeRefsFromFilter`, whose module pulls the `@cardstack/base/*` graph into
-// boxel-cli's dependency-light build (the same boundary the wire-translation
-// helpers above note).
-//
-// True when the filter carries a positive (non-negated) `type`/`on` anchor. A
-// picked type discriminates the kind by itself — a card type matches only
-// instance rows (no dupe to drop), a file type must stay free to surface a
-// `.json` file row that legitimately matches it — so the dedup is skipped.
-// Polarity flips under each enclosing `not`, so a negated anchor doesn't count.
-function hasPositiveTypeAnchor(filter: unknown, negated = false): boolean {
+// `scopeFilters` in host `card-search/query-builder.ts`). The type-anchor
+// detection mirrors `getTypeRefsFromFilter` / `hasNarrowingPositiveTypeRef`
+// there, reimplemented locally — with the root refs as literals — because both
+// runtime-common modules pull the `@cardstack/base/*` graph into boxel-cli's
+// dependency-light build (the same boundary the wire-translation helpers above
+// note).
+
+// Root refs (BaseDef/CardDef/FieldDef/FileDef) span kinds rather than
+// narrowing to one — every file row carries `BaseDef` in its type chain, so a
+// `type: BaseDef` query matches both rows of a card `.json` and still needs
+// the dedup. The base-realm module can be spelled as its URL or its scoped
+// alias; both resolve to the same module server-side.
+const ROOT_TYPE_REF_MODULES = [
+  'https://cardstack.com/base/card-api',
+  '@cardstack/base/card-api',
+];
+const ROOT_TYPE_REF_NAMES = ['BaseDef', 'CardDef', 'FieldDef', 'FileDef'];
+
+function isRootTypeRef(ref: unknown): boolean {
+  if (typeof ref !== 'object' || ref == null) {
+    return false;
+  }
+  let { module, name } = ref as { module?: unknown; name?: unknown };
+  return (
+    typeof module === 'string' &&
+    typeof name === 'string' &&
+    ROOT_TYPE_REF_MODULES.includes(module) &&
+    ROOT_TYPE_REF_NAMES.includes(name)
+  );
+}
+
+// True when the filter carries a positive (non-negated), kind-narrowing
+// `type`/`on` anchor. A narrowing type discriminates the kind by itself — a
+// card type matches only instance rows (no dupe to drop), a file type must
+// stay free to surface a `.json` file row that legitimately matches it — so
+// the dedup is skipped. Polarity flips under each enclosing `not`, so a
+// negated anchor doesn't count — and neither does a kind-spanning root ref
+// (see `isRootTypeRef`).
+function hasNarrowingTypeAnchor(filter: unknown, negated = false): boolean {
   if (typeof filter !== 'object' || filter == null || Array.isArray(filter)) {
     return false;
   }
   let f = filter as Record<string, unknown>;
   if (f.on != null || f.type != null) {
-    return !negated;
+    return !negated && !isRootTypeRef(f.on ?? f.type);
   }
   if (f.not != null) {
-    return hasPositiveTypeAnchor(f.not, !negated);
+    return hasNarrowingTypeAnchor(f.not, !negated);
   }
   if (Array.isArray(f.every)) {
-    return f.every.some((node) => hasPositiveTypeAnchor(node, negated));
+    return f.every.some((node) => hasNarrowingTypeAnchor(node, negated));
   }
   if (Array.isArray(f.any)) {
-    return f.any.some((node) => hasPositiveTypeAnchor(node, negated));
+    return f.any.some((node) => hasNarrowingTypeAnchor(node, negated));
   }
   return false;
 }
@@ -252,8 +279,8 @@ function hasPositiveTypeAnchor(filter: unknown, negated = false): boolean {
  * instance row) while plain files stay listed.
  *
  * Skipped when the wire `scope` already pins a single kind (`'cards'`/`'files'`)
- * or the filter carries a positive type anchor — the same rule the host applies.
- * Exported for unit testing.
+ * or the filter carries a narrowing positive type anchor — the same rule the
+ * host applies. Exported for unit testing.
  */
 export function composeMixedScopeDedup(
   query: Record<string, unknown>,
@@ -261,7 +288,7 @@ export function composeMixedScopeDedup(
   if (query.scope === 'cards' || query.scope === 'files') {
     return query;
   }
-  if (hasPositiveTypeAnchor(query.filter)) {
+  if (hasNarrowingTypeAnchor(query.filter)) {
     return query;
   }
   let dedup = { eq: { [CARD_INSTANCE_FILE_KEY]: false } };

--- a/packages/boxel-cli/tests/commands/search-query.test.ts
+++ b/packages/boxel-cli/tests/commands/search-query.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
+import { baseRef } from '@cardstack/runtime-common/constants';
 import {
   searchEntryRequestBody,
   itemsFromSearchEntryDoc,
+  composeMixedScopeDedup,
 } from '../../src/commands/search.ts';
 
 const SkillRef = {
@@ -12,6 +14,8 @@ const CardDefRef = {
   module: 'https://cardstack.com/base/card-api',
   name: 'CardDef',
 };
+
+const DEDUP = { eq: { _isCardInstanceFile: false } };
 
 describe('searchEntryRequestBody — card-rooted query → entry wire grammar', () => {
   it('always requests the data-only fieldset and the given realms', () => {
@@ -180,5 +184,72 @@ describe('itemsFromSearchEntryDoc — flatten a data-only entry doc to items', (
 
   it('returns an empty array for an empty document', () => {
     expect(itemsFromSearchEntryDoc({})).toEqual([]);
+  });
+});
+
+describe('composeMixedScopeDedup — invariant mixed-scope output', () => {
+  it('injects the dedup as the sole filter when the query has none', () => {
+    expect(composeMixedScopeDedup({})).toEqual({ filter: DEDUP });
+  });
+
+  it('injects the dedup for a cardUrls-only lookup (no filter)', () => {
+    let query = { cardUrls: ['https://realm/a/x.json'] };
+    expect(composeMixedScopeDedup(query)).toEqual({
+      cardUrls: ['https://realm/a/x.json'],
+      filter: DEDUP,
+    });
+  });
+
+  it('ANDs the dedup with an existing anchorless filter', () => {
+    expect(composeMixedScopeDedup({ filter: { matches: 'hello' } })).toEqual({
+      filter: { every: [{ matches: 'hello' }, DEDUP] },
+    });
+    expect(
+      composeMixedScopeDedup({ filter: { eq: { _title: 'Mango' } } }),
+    ).toEqual({ filter: { every: [{ eq: { _title: 'Mango' } }, DEDUP] } });
+  });
+
+  it('leaves a narrowing positive type anchor unchanged', () => {
+    let byType = { filter: { type: SkillRef } };
+    expect(composeMixedScopeDedup(byType)).toBe(byType);
+    let byOn = { filter: { on: CardDefRef, eq: { cardTitle: 'x' } } };
+    expect(composeMixedScopeDedup(byOn)).toBe(byOn);
+    let nested = {
+      filter: { every: [{ type: SkillRef }, { eq: { status: 'active' } }] },
+    };
+    expect(composeMixedScopeDedup(nested)).toBe(nested);
+  });
+
+  it('still dedups when the only anchor is a kind-spanning root ref', () => {
+    expect(composeMixedScopeDedup({ filter: { type: baseRef } })).toEqual({
+      filter: { every: [{ type: baseRef }, DEDUP] },
+    });
+  });
+
+  it('still dedups when the type anchor is negated', () => {
+    expect(
+      composeMixedScopeDedup({ filter: { not: { type: SkillRef } } }),
+    ).toEqual({ filter: { every: [{ not: { type: SkillRef } }, DEDUP] } });
+  });
+
+  it('skips the dedup when scope already pins a single kind', () => {
+    let cards = { scope: 'cards' };
+    expect(composeMixedScopeDedup(cards)).toBe(cards);
+    let files = { scope: 'files' };
+    expect(composeMixedScopeDedup(files)).toBe(files);
+  });
+
+  it('injects the dedup for the explicit mixed scope', () => {
+    expect(composeMixedScopeDedup({ scope: 'all' })).toEqual({
+      scope: 'all',
+      filter: DEDUP,
+    });
+  });
+
+  it('translates to the item.-prefixed dedup key on the wire', () => {
+    let body = searchEntryRequestBody(composeMixedScopeDedup({}), [
+      'https://realm/a/',
+    ]);
+    expect(body.filter).toEqual({ eq: { 'item._isCardInstanceFile': false } });
   });
 });

--- a/packages/boxel-cli/tests/commands/search-query.test.ts
+++ b/packages/boxel-cli/tests/commands/search-query.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import { baseRef } from '@cardstack/runtime-common/constants';
 import {
   searchEntryRequestBody,
   itemsFromSearchEntryDoc,
@@ -218,12 +217,6 @@ describe('composeMixedScopeDedup — invariant mixed-scope output', () => {
       filter: { every: [{ type: SkillRef }, { eq: { status: 'active' } }] },
     };
     expect(composeMixedScopeDedup(nested)).toBe(nested);
-  });
-
-  it('still dedups when the only anchor is a kind-spanning root ref', () => {
-    expect(composeMixedScopeDedup({ filter: { type: baseRef } })).toEqual({
-      filter: { every: [{ type: baseRef }, DEDUP] },
-    });
   });
 
   it('still dedups when the type anchor is negated', () => {

--- a/packages/boxel-cli/tests/commands/search-query.test.ts
+++ b/packages/boxel-cli/tests/commands/search-query.test.ts
@@ -13,6 +13,10 @@ const CardDefRef = {
   module: 'https://cardstack.com/base/card-api',
   name: 'CardDef',
 };
+const BaseDefRef = {
+  module: 'https://cardstack.com/base/card-api',
+  name: 'BaseDef',
+};
 
 const DEDUP = { eq: { _isCardInstanceFile: false } };
 
@@ -211,12 +215,29 @@ describe('composeMixedScopeDedup — invariant mixed-scope output', () => {
   it('leaves a narrowing positive type anchor unchanged', () => {
     let byType = { filter: { type: SkillRef } };
     expect(composeMixedScopeDedup(byType)).toBe(byType);
-    let byOn = { filter: { on: CardDefRef, eq: { cardTitle: 'x' } } };
+    let byOn = { filter: { on: SkillRef, eq: { skillTitle: 'x' } } };
     expect(composeMixedScopeDedup(byOn)).toBe(byOn);
     let nested = {
       filter: { every: [{ type: SkillRef }, { eq: { status: 'active' } }] },
     };
     expect(composeMixedScopeDedup(nested)).toBe(nested);
+  });
+
+  it('still dedups when the only anchor is a kind-spanning root ref', () => {
+    // Every file row carries BaseDef in its type chain, so a root-ref anchor
+    // matches both rows of a card `.json` — it doesn't narrow the kind.
+    expect(composeMixedScopeDedup({ filter: { type: BaseDefRef } })).toEqual({
+      filter: { every: [{ type: BaseDefRef }, DEDUP] },
+    });
+    let byOn = { filter: { on: CardDefRef, eq: { cardTitle: 'x' } } };
+    expect(composeMixedScopeDedup(byOn)).toEqual({
+      filter: { every: [byOn.filter, DEDUP] },
+    });
+    // The scoped-alias spelling of the base-realm module counts too.
+    let aliasRef = { module: '@cardstack/base/card-api', name: 'FileDef' };
+    expect(composeMixedScopeDedup({ filter: { type: aliasRef } })).toEqual({
+      filter: { every: [{ type: aliasRef }, DEDUP] },
+    });
   });
 
   it('still dedups when the type anchor is negated', () => {

--- a/packages/boxel-cli/tests/integration/search.test.ts
+++ b/packages/boxel-cli/tests/integration/search.test.ts
@@ -56,6 +56,10 @@ beforeAll(async () => {
               },
             },
           }),
+          // A plain (non-card) file: it has only a `file` row, so it must still
+          // appear in a mixed list-all after the card `.json` file rows are
+          // deduped away.
+          'readme.txt': 'plain file contents',
         },
         permissions: {
           [ownerUserId]: ['read', 'write', 'realm-owner'],
@@ -86,17 +90,47 @@ afterAll(async () => {
 });
 
 describe('federated search (integration)', () => {
-  it('returns all results when no filter is supplied', async () => {
+  it('returns each card once (no `.json` file-row dupe) plus plain files', async () => {
     let result = await search(realmHref, {}, { profileManager });
     expect(result.ok, `search failed: ${result.error}`).toBe(true);
-    let titles = (result.data ?? []).map(
-      (entry) =>
-        (entry as { attributes?: { cardTitle?: string } }).attributes
-          ?.cardTitle,
+    let entries = (result.data ?? []) as {
+      id?: string;
+      type?: string;
+      attributes?: { cardTitle?: string };
+    }[];
+
+    // Each card `.json` is dual-indexed (an instance row + a file row); the
+    // dedup drops the file row so the card appears exactly once.
+    let cardTitles = entries
+      .filter((e) => e.type === 'card')
+      .map((e) => e.attributes?.cardTitle)
+      .sort();
+    expect(cardTitles).toEqual(['Other Card', 'Shared Card']);
+
+    // No id appears twice.
+    let ids = entries.map((e) => e.id);
+    expect(ids.length).toBe(new Set(ids).size);
+
+    // The plain (non-card) file is still listed.
+    let fileIds = entries
+      .filter((e) => e.type === 'file-meta')
+      .map((e) => e.id);
+    expect(fileIds).toContain(`${realmHref}readme.txt`);
+    // ...and neither card's `.json` file row leaked in.
+    expect(fileIds).not.toContain(`${realmHref}shared-card.json`);
+    expect(fileIds).not.toContain(`${realmHref}other-card.json`);
+  });
+
+  it('returns a single entry for a cardUrls `.json` lookup', async () => {
+    let result = await search(
+      realmHref,
+      { cardUrls: [`${realmHref}shared-card.json`] },
+      { profileManager },
     );
-    expect(titles).toEqual(
-      expect.arrayContaining(['Shared Card', 'Other Card']),
-    );
+    expect(result.ok, `search failed: ${result.error}`).toBe(true);
+    let entries = result.data ?? [];
+    expect(entries.length).toBe(1);
+    expect((entries[0] as { id?: string }).id).toBe(`${realmHref}shared-card`);
   });
 
   it('filters by cardTitle and returns only the matching card', async () => {


### PR DESCRIPTION
## Background and Goal

CS-11775 shipped the realm-server "mixed entry search" default: `_search` / `_federated-search` now return **both** an `instance` row and a `file` row for every dual-indexed card `.json`, unless the caller's filter discriminates. That leaves three `boxel search` cases returning duplicated/leaked rows: filter-less list-all, `cardUrls` lookups (a card `.json` URL matches both of its rows), and term searches on keys files also carry (`_title`).

This makes `boxel search` output invariant to that default — each card surfaces once (via its instance row), plain files stay listed, and type-anchored searches are unchanged.

## Where to start

- `packages/boxel-cli/src/commands/search.ts` — new `composeMixedScopeDedup(query)` composes the `_isCardInstanceFile` dedup filter (`{ eq: { _isCardInstanceFile: false } }`, which matches an absent key too and drops the redundant `.json` file row). It's applied at the top of `search()`, so both `boxel search` and `BoxelCLIClient.search` are covered.

## Key decisions and non-obvious mechanics

- **Mirrors the host search-sheet dedup** (`excludeCardInstanceFileRows` / `scopeFilters` in `packages/host/app/utils/card-search/query-builder.ts`). The dedup is skipped when `scope` already pins a single kind (`'cards'`/`'files'`) or the filter carries a *narrowing* positive type anchor. Root refs (`BaseDef`/`CardDef`/`FieldDef`/`FileDef`) don't count as narrowing — they span kinds, so a `type: baseRef` query still needs the dedup — matching `hasNarrowingPositiveTypeRef` on the host.
- **Kept dependency-light — why the root refs are local literals, not imports.** boxel-cli is a plain Node CLI (`tsc --noEmit`, no glint/content-tag), while `@cardstack/base` is the base realm's `.gts` content: it only resolves through the host's tsconfig `paths` mapping (`@cardstack/base/*` / `https://cardstack.com/base/*` → `packages/base/*.gts`) plus the Ember/Glint toolchain that can parse `<template>` tags — and its runtime graph (`@glimmer/component`, `ember-concurrency`, …) doesn't execute under plain Node. The refs aren't defined there anyway; the nearest source is `runtime-common/constants`, but its type imports reach the runtime-common index barrel, which drags content-tag and the virtual `@cardstack/base/*` modules into the CLI's type-check (`TS2307`). So, like the existing local `toItemFilter` / `SearchEntryDoc`, the type-anchor detection is reimplemented locally: only `CARD_INSTANCE_FILE_KEY` (from `search-doc-keys`, zero imports) is imported, and the root refs are literals. The literals also cover both base-realm module spellings (URL and `@cardstack/base/` alias) — CLI users author raw JSON and may write either, whereas `constants` carries only the alias form. These refs are part of the public query grammar, as stable as the `on`/`type` keywords themselves; if a single source of truth is wanted later, the move is extracting them into an import-clean runtime-common subpath alongside `search-doc-keys`, as a separate refactor.
- **Plain files preserved.** A bare `{ eq: { _isCardInstanceFile: false } }` with no explicit anchor does not restrict to card types — the engine only emits a `types contains` restriction from an explicit `on`/`type`, so the existence test compiles to `IS NULL` and plain file rows survive.

## Release ordering

The `_isCardInstanceFile` field ships with the realm-server (CS-11775, PR #5428); an old server rejects it as unknown. This CLI release must go out **with or after** that realm-server deploy.

## Tests

- Unit: `composeMixedScopeDedup` covers no-filter, `cardUrls`-only, anchorless-filter AND-compose, positive type anchor (skip), root ref (dedup), negated type (dedup), `scope: cards|files` (skip) / `scope: all` (dedup), and the wire `item._isCardInstanceFile` translation.
- Integration: list-all returns each card once + the plain `readme.txt`, no `.json` file-row leaks; a `cardUrls` `.json` lookup returns a single entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

