### PR TITLE
Render embed chooser current-target tile as a fitted card

### DIFF
--- a/packages/host/app/components/markdown-embed-chooser/tab-panel.gts
+++ b/packages/host/app/components/markdown-embed-chooser/tab-panel.gts
@@ -62,9 +62,8 @@ interface Signature {
     // (The pane's format seed comes from the shared `@selection`, which the
     // modal seeds from this same target.)
     initialTarget?: MarkdownEmbedInitialTarget;
-    // The editing document's own URL. The label and the inserted ref are both
-    // relativized against it, so a fallback URL label reads as `../Type/id` —
-    // the same form the pane serializes into the directive.
+    // The editing document's own URL. The pane relativizes the inserted ref
+    // against it, so the directive serializes in the `../Type/id` form.
     documentBaseUrl?: string;
     // Fired when the user clicks "Remove" in `current` mode. The modal
     // resolves its deferred with `{ remove: true }`.

--- a/packages/host/app/components/markdown-embed-chooser/tab-panel.gts
+++ b/packages/host/app/components/markdown-embed-chooser/tab-panel.gts
@@ -23,9 +23,8 @@ import {
 import {
   cardTypeName,
   fileNameFromUrl,
+  type BfmSizeSpec,
 } from '@cardstack/runtime-common/bfm-card-references';
-
-import { maybeRelativeReference } from '@cardstack/runtime-common/url';
 
 import MiniCardChooser from '@cardstack/host/components/card-chooser/mini';
 import MiniFileChooser from '@cardstack/host/components/file-chooser/mini';
@@ -37,6 +36,7 @@ import type {
 import type StoreService from '@cardstack/host/services/store';
 
 import MarkdownEmbedPreviewPane from './pane';
+import MarkdownEmbedPreview from './preview';
 import TabPills from './tab-pills';
 
 import type EmbedFormatSelection from './format-selection';
@@ -128,31 +128,12 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
     return dirty ? 'Accept' : 'Done';
   }
 
-  private get currentTargetLabel(): string {
-    let t = this.selectedTarget;
-    if (!t) return this.toDisplayUrl(this.selectedUrl ?? '');
-    if (this.args.refType === 'file') {
-      return fileNameFromUrl(t.id ?? this.selectedUrl ?? '');
-    }
-    return (
-      (t as CardDef).cardTitle ??
-      this.toDisplayUrl(t.id ?? this.selectedUrl ?? '')
-    );
-  }
-
-  // When the label falls back to showing a raw URL (a broken ref, or a card
-  // with no title), relativize it against the editing document's own URL —
-  // yielding the `../Type/id` form the pane serializes into the directive, so
-  // the label matches what gets inserted. Falls back to the absolute URL when
-  // there's no base or either URL can't be parsed.
-  private toDisplayUrl(url: string): string {
-    let base = this.args.documentBaseUrl;
-    if (!url || !base) return url;
-    try {
-      return maybeRelativeReference(new URL(url), new URL(base), undefined);
-    } catch {
-      return url;
-    }
+  // The current-target tile renders the placed card/file as a compact fitted
+  // chip — a fixed Double Strip (250×65), independent of the format the user
+  // picks for the actual embed in the preview pane. It's an identity marker for
+  // "what's placed here now", not the embed being configured.
+  private get currentTileSize(): BfmSizeSpec {
+    return { format: 'fitted', width: 250, height: 65 };
   }
 
   @action
@@ -271,12 +252,19 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
             class='markdown-embed-chooser-tab-panel__current'
             data-test-markdown-embed-chooser-current
           >
-            <span
-              class='markdown-embed-chooser-tab-panel__current-label'
-              data-test-markdown-embed-chooser-current-label
-            >
-              {{this.currentTargetLabel}}
-            </span>
+            <MarkdownEmbedPreview
+              class='markdown-embed-chooser-tab-panel__current-preview'
+              @target={{this.selectedTarget}}
+              @format='fitted'
+              @sizeSpec={{this.currentTileSize}}
+              @kind='block'
+              @brokenUrl={{this.brokenUrl}}
+              @brokenState={{this.brokenState}}
+              @brokenDisplayName={{this.brokenDisplayName}}
+              @brokenItemType={{this.brokenItemType}}
+              @errorDoc={{this.brokenErrorDoc}}
+              data-test-markdown-embed-chooser-current-preview
+            />
             <div class='markdown-embed-chooser-tab-panel__current-actions'>
               <BoxelButton
                 {{on 'click' this.startReplace}}
@@ -415,9 +403,10 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
         padding: var(--boxel-sp);
         text-align: center;
       }
-      .markdown-embed-chooser-tab-panel__current-label {
-        font: 600 var(--boxel-font);
-        word-break: break-word;
+      /* The fitted chip carries its own fixed footprint; keep it from
+         stretching to the centered column's cross axis. */
+      .markdown-embed-chooser-tab-panel__current-preview {
+        flex: 0 0 auto;
       }
       .markdown-embed-chooser-tab-panel__current-actions {
         display: flex;

--- a/packages/host/app/components/markdown-embed-chooser/tab-panel.gts
+++ b/packages/host/app/components/markdown-embed-chooser/tab-panel.gts
@@ -7,7 +7,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
 
-import { BoxelButton } from '@cardstack/boxel-ui/components';
+import { BoxelButton, LoadingIndicator } from '@cardstack/boxel-ui/components';
 import type {
   BrokenLinkErrorDoc,
   BrokenLinkItemType,
@@ -41,6 +41,18 @@ import TabPills from './tab-pills';
 
 import type EmbedFormatSelection from './format-selection';
 import type { CardDef, FileDef } from '@cardstack/base/card-api';
+
+// The current-target tile renders the placed card/file as a compact fitted
+// chip — a fixed Double Strip (250×65), independent of the format the user
+// picks for the actual embed in the preview pane. It's an identity marker for
+// "what's placed here now", not the embed being configured. Frozen module
+// constant so the tile hands `MarkdownEmbedPreview` a stable object identity
+// across renders rather than a fresh one each time.
+const CURRENT_TILE_SIZE: BfmSizeSpec = Object.freeze<BfmSizeSpec>({
+  format: 'fitted',
+  width: 250,
+  height: 65,
+});
 
 interface Signature {
   Element: HTMLDivElement;
@@ -125,14 +137,6 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
     if (!this.isEditMode) return undefined;
     let dirty = this.args.selection.isDirty || this.targetChanged;
     return dirty ? 'Accept' : 'Done';
-  }
-
-  // The current-target tile renders the placed card/file as a compact fitted
-  // chip — a fixed Double Strip (250×65), independent of the format the user
-  // picks for the actual embed in the preview pane. It's an identity marker for
-  // "what's placed here now", not the embed being configured.
-  private get currentTileSize(): BfmSizeSpec {
-    return { format: 'fitted', width: 250, height: 65 };
   }
 
   @action
@@ -251,19 +255,30 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
             class='markdown-embed-chooser-tab-panel__current'
             data-test-markdown-embed-chooser-current
           >
-            <MarkdownEmbedPreview
-              class='markdown-embed-chooser-tab-panel__current-preview'
-              @target={{this.selectedTarget}}
-              @format='fitted'
-              @sizeSpec={{this.currentTileSize}}
-              @kind='block'
-              @brokenUrl={{this.brokenUrl}}
-              @brokenState={{this.brokenState}}
-              @brokenDisplayName={{this.brokenDisplayName}}
-              @brokenItemType={{this.brokenItemType}}
-              @errorDoc={{this.brokenErrorDoc}}
-              data-test-markdown-embed-chooser-current-preview
-            />
+            {{#if this.hasPreview}}
+              <MarkdownEmbedPreview
+                class='markdown-embed-chooser-tab-panel__current-preview'
+                @target={{this.selectedTarget}}
+                @format='fitted'
+                @sizeSpec={{CURRENT_TILE_SIZE}}
+                @kind='block'
+                @brokenUrl={{this.brokenUrl}}
+                @brokenState={{this.brokenState}}
+                @brokenDisplayName={{this.brokenDisplayName}}
+                @brokenItemType={{this.brokenItemType}}
+                @errorDoc={{this.brokenErrorDoc}}
+                data-test-markdown-embed-chooser-current-preview
+              />
+            {{else}}
+              {{! Hold the tile's 250×65 footprint while the preload resolves so
+                the Replace / Remove buttons don't jump when the chip arrives. }}
+              <div
+                class='markdown-embed-chooser-tab-panel__current-loading'
+                data-test-markdown-embed-chooser-current-loading
+              >
+                <LoadingIndicator />
+              </div>
+            {{/if}}
             <div class='markdown-embed-chooser-tab-panel__current-actions'>
               <BoxelButton
                 {{on 'click' this.startReplace}}
@@ -402,10 +417,24 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
         padding: var(--boxel-sp);
         text-align: center;
       }
-      /* The fitted chip carries its own fixed footprint; keep it from
-         stretching to the centered column's cross axis. */
-      .markdown-embed-chooser-tab-panel__current-preview {
+      /* The fitted chip (and its loading stand-in) carries its own fixed
+         footprint; the column centers it, so keep flex from shrinking it on the
+         main axis. `align-items: center` already prevents cross-axis stretch. */
+      .markdown-embed-chooser-tab-panel__current-preview,
+      .markdown-embed-chooser-tab-panel__current-loading {
         flex: 0 0 auto;
+      }
+      /* Same 250×65 footprint as the resolved fitted chip so Replace / Remove
+         hold their position while the preload resolves. */
+      .markdown-embed-chooser-tab-panel__current-loading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 250px;
+        height: 65px;
+        border: 1px solid var(--boxel-300);
+        border-radius: var(--boxel-border-radius);
+        background-color: var(--boxel-light);
       }
       .markdown-embed-chooser-tab-panel__current-actions {
         display: flex;

--- a/packages/host/tests/integration/components/markdown-embed-chooser-modal-test.gts
+++ b/packages/host/tests/integration/components/markdown-embed-chooser-modal-test.gts
@@ -380,17 +380,14 @@ module('Integration | markdown-embed-chooser-modal', function (hooks) {
         '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-chooser-current]',
       )
       .exists('the current-target tile renders for the broken preload');
-    // The label falls back to the ref (no title to show). It relativizes
-    // against the editing document's URL, so it reads as the `../`-relative
-    // path — the same form the pane serializes into the directive.
+    // The tile itself renders the compact broken visual (not a text label),
+    // so a broken preload reads as the same warning box the resolved chip would
+    // occupy.
     assert
       .dom(
-        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-chooser-current-label]',
+        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-chooser-current] [data-test-broken-link-template]',
       )
-      .hasText(
-        '../books/ghost',
-        'a broken ref labels as its document-relative path',
-      );
+      .exists('the current-target tile shows the compact broken visual');
     assert
       .dom('[data-test-markdown-embed-chooser-remove]')
       .exists('Remove is available');
@@ -402,7 +399,7 @@ module('Integration | markdown-embed-chooser-modal', function (hooks) {
     await pending;
   });
 
-  test('a broken ref in a different realm than the document keeps its full URL as the label', async function (assert) {
+  test('edit-mode preload renders the current-target tile as a fitted card chip', async function (assert) {
     await render(
       <template>
         <HostContextProvider>
@@ -414,28 +411,59 @@ module('Integration | markdown-embed-chooser-modal', function (hooks) {
     let svc = getService(
       'markdown-embed-chooser',
     ) as MarkdownEmbedChooserService;
-    // A broken ref in the base realm while the editing document lives in the
-    // test realm — the two are in different namespaces, so the ref can't be
-    // relativized and keeps its absolute URL.
-    let brokenUrl = `${baseRealm.url}ghost-card`;
     let pending = svc.editEmbed({
       refType: 'card',
-      url: brokenUrl,
+      url: mango,
       sizeSpec: 'embedded',
-      documentBaseUrl: `${testRealmURL}posts/my-post`,
     });
+    // The tile renders the resolved card itself, in fitted format — not a text
+    // label. The card body paints asynchronously, so wait for it. The pane
+    // preview stays on the picked format (embedded), so the fitted render of
+    // this card is unique to the tile.
     await waitFor(
-      '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-broken-link-template]',
+      `[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-chooser-current] [data-test-card="${mango}"][data-test-card-format="fitted"]`,
       { timeout: 5000 },
     );
     assert
       .dom(
-        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-chooser-current-label]',
+        `[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-chooser-current] [data-test-card="${mango}"][data-test-card-format="fitted"]`,
       )
-      .hasText(
-        brokenUrl,
-        'a broken ref in another realm keeps its absolute URL',
+      .exists(
+        'the current-target tile renders the card itself in fitted format',
       );
+
+    svc.resolve(undefined);
+    await pending;
+  });
+
+  test('edit-mode preload of a file renders the current-target tile as a fitted chip', async function (assert) {
+    await render(
+      <template>
+        <HostContextProvider>
+          <MarkdownEmbedChooserModal />
+        </HostContextProvider>
+      </template>,
+    );
+
+    let svc = getService(
+      'markdown-embed-chooser',
+    ) as MarkdownEmbedChooserService;
+    let pending = svc.editEmbed({
+      refType: 'file',
+      url: readme,
+      sizeSpec: 'embedded',
+    });
+    await waitFor(
+      '[data-test-markdown-embed-chooser-tab-panel="file"] [data-test-markdown-embed-chooser-current-preview]',
+      { timeout: 5000 },
+    );
+
+    // Files render through the same fitted path as cards.
+    assert
+      .dom(
+        '[data-test-markdown-embed-chooser-tab-panel="file"] [data-test-markdown-embed-chooser-current] [data-test-markdown-embed-preview-format="fitted"]',
+      )
+      .exists('the file current-target tile renders in its fitted template');
 
     svc.resolve(undefined);
     await pending;


### PR DESCRIPTION
## Summary

In the markdown embed chooser's edit mode, the current-target tile (above the **Replace** / **Remove** buttons) showed only a text label — the filename for files, the card title for cards. Per the design, it should render the placed card/file **itself** in its fitted template — a compact "Double Strip" chip (thumbnail + title).

This replaces the text label with the resolved target rendered fitted, reusing the existing `MarkdownEmbedPreview` component. Both cards and files render through the same fitted path, and a broken/unresolvable preload shows the compact broken-link visual in the tile. The tile's fitted size is fixed (it's an identity chip); the format dropdown on the right still drives the larger preview pane independently.

Resolves [CS-12110](https://linear.app/cardstack/issue/CS-12110/embed-chooser-current-target-tile-shows-only-name-never-the). The ticket originally proposed showing the name plus a relativized URL; the design instead calls for the fitted card render, which is what this implements.

## Changes

- `packages/host/app/components/markdown-embed-chooser/tab-panel.gts` — drop the `currentTargetLabel` / `toDisplayUrl` text-label getters (and the now-unused `maybeRelativeReference` import); render `MarkdownEmbedPreview` at a fixed fitted 250×65 with the tile's existing broken-ref args.
- `packages/host/tests/integration/components/markdown-embed-chooser-modal-test.gts` — the broken-ref test now asserts the compact broken visual in the tile; new tests cover a resolved card and a resolved file each rendering fitted.

## Testing

- `markdown-embed-chooser-modal` (14), `codemirror embed toolbar` (8), and the `markdown embed chooser` acceptance suite (4) all pass headless against the realm stack.
- `lint:types`, eslint, and template-lint are clean.

## Before
<img width="1136" height="620" alt="Screenshot 2026-07-16 at 21 16 45" src="https://github.com/user-attachments/assets/33277267-3728-4c56-b3cb-2cd88ff15650" />

## After


<img width="1069" height="611" alt="Screenshot 2026-07-16 at 19 58 08" src="https://github.com/user-attachments/assets/666f2988-d653-44b1-94da-eae30931bc6b" />
