### PR TITLE
Enable Sign in with Google on staging host

### DIFF
--- a/packages/host/config/staging.env
+++ b/packages/host/config/staging.env
@@ -8,3 +8,4 @@ MATRIX_SERVER_NAME=stack.cards
 PUBLISHED_REALM_BOXEL_SPACE_DOMAIN=staging.boxel.dev
 PUBLISHED_REALM_BOXEL_SITE_DOMAIN=staging.boxel.build
 ICONS_URL=https://boxel-icons.boxel.ai
+GOOGLE_AUTH_ENABLED=true


### PR DESCRIPTION
## What

Sets `GOOGLE_AUTH_ENABLED=true` in `packages/host/config/staging.env` so the "Continue with Google" login button is enabled on the **staging** host build. Production is intentionally left off.

- `.github/workflows/build-host.yml` cats the env file into the staging build environment, so this reaches `process.env.GOOGLE_AUTH_ENABLED` at build time.
- `packages/host/config/environment.js` parses it into `featureFlags.GOOGLE_AUTH_ENABLED`.
- `environment-service.ts` surfaces it as `googleAuthEnabled`, and `matrix/login.gts` shows the button when `googleAuthEnabled && googleSsoAvailable`.

## Why

Companion to the infra change that wires Google OIDC into the staging Synapse (`user_mapping_provider` module, `oidc_providers` block, `sso.client_whitelist`, SSM-sourced client id/secret). That work provisions the server side; this flips the host feature flag so the button appears on staging.

## Safety / ordering

`googleSsoAvailable` is detected live from `matrixService.loginFlows()` (it looks for the `oidc-google` identity provider). The button stays hidden until staging Synapse actually advertises that flow, so this PR is safe to merge independently of the Synapse OIDC apply — no coupling risk.

Prerequisites for the button to actually appear on staging (server side, tracked separately):
- Staging Synapse OIDC config applied.
- Synapse Google OAuth client id/secret provisioned as SecureString SSM params under the staging Synapse param path.
- The `sync-synapse-assets` workflow has run so the custom mapping-provider module is present in the staging Synapse assets bucket (runs on merge to main).

## Testing

- `packages/host/config/staging.env` diff is the single added line; `production.env` unchanged.
- After staging deploy + Synapse OIDC apply: load the staging host login page, confirm the "Continue with Google" button appears and the SSO redirect targets the staging Synapse `/oidc/callback`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)