### PR TITLE
Pipeline index row writes and bookkeeping behind the next visit's render

### DIFF
--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -13,6 +13,7 @@ import {
   mergeErrorsByGeneration,
   ri,
   rri,
+  type FileEntry,
   type LooseCardResource,
   type IndexedInstance,
   type BoxelIndexTable,
@@ -249,6 +250,71 @@ module('Unit | index-writer', function (hooks) {
         },
       ],
       'the "production" realm generations are correct',
+    );
+  });
+
+  test('buffered index writes defer until flush, and a dependency read flushes them first', async function (assert) {
+    await setupIndex(
+      adapter,
+      [{ realm_url: testRealmURL, current_generation: 1 }],
+      [],
+    );
+    // Force the server (split) write path so a flush coalesces the buffered
+    // rows into one multi-row upsert; SQLite otherwise takes the fused
+    // per-row path. Both paths share the buffer + flush-on-dependency-read
+    // semantics this test pins.
+    let batch = await indexWriter.createBatch(
+      new URL(testRealmURL),
+      virtualNetwork,
+      undefined,
+      { splitPrerenderHtml: true },
+    );
+
+    let depURL = new URL(`${testRealmURL}a.json`);
+    let dependentURL = new URL(`${testRealmURL}b.json`);
+    let fileEntry = (name: string): FileEntry => ({
+      type: 'file',
+      lastModified: 1,
+      resourceCreatedAt: 1,
+      deps: new Set<string>(),
+      searchData: { name },
+    });
+
+    await batch.bufferEntry(depURL, fileEntry('a'));
+    await batch.bufferEntry(dependentURL, fileEntry('b'));
+
+    // The invalidation set knows both URLs immediately — the swap in `done()`
+    // and the dependency skip both key off it — but nothing is written yet.
+    assert.deepEqual(
+      [...batch.invalidations].sort(),
+      [depURL.href, dependentURL.href],
+      'buffered URLs join the invalidation set synchronously',
+    );
+    let beforeFlush = await adapter.execute(
+      `SELECT url FROM boxel_index_working WHERE realm_url = $1`,
+      { bind: [testRealmURL] },
+    );
+    assert.deepEqual(beforeFlush, [], 'no rows are written while buffered');
+
+    // A dependency-error read that touches a buffered URL flushes the buffer
+    // first, so a dependent's bookkeeping sees the dependency's row.
+    let depRows = await batch.getDependencyRows([depURL.href]);
+    assert.deepEqual(
+      depRows.map((r) => r.url),
+      [depURL.href],
+      'the dependency read returns the now-flushed buffered row',
+    );
+
+    // The flush wrote every buffered row, not only the one queried — so a
+    // dependent's transitively-earlier writes are all visible too.
+    let afterFlush = await adapter.execute(
+      `SELECT url FROM boxel_index_working WHERE realm_url = $1 ORDER BY url COLLATE "POSIX"`,
+      { bind: [testRealmURL] },
+    );
+    assert.deepEqual(
+      afterFlush,
+      [{ url: depURL.href }, { url: dependentURL.href }],
+      'the flush coalesced all buffered rows into the working table',
     );
   });
 

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -46,9 +46,22 @@ import {
   discoverInvalidations,
   type DiscoverInvalidationsResult,
 } from './index-runner/discover-invalidations.ts';
-import { visitFileForIndexing } from './index-runner/visit-file.ts';
+import {
+  renderFileForIndexing,
+  routeIndexVisitResult,
+  type IndexVisitRenderResult,
+} from './index-runner/visit-file.ts';
 import { performCardIndexing } from './index-runner/card-indexer.ts';
 import { performFileIndexing } from './index-runner/file-indexer.ts';
+
+// The result of a prefetched render, with any thrown error captured rather
+// than rejected so an un-awaited prefetch can't surface as an unhandled
+// rejection. `skipped` covers files the render short-circuited (ignored /
+// different realm).
+type VisitRenderOutcome =
+  | { status: 'rendered'; result: IndexVisitRenderResult }
+  | { status: 'skipped' }
+  | { status: 'error'; error: unknown };
 
 export class IndexRunner {
   #indexingInstances = new Map<string, Promise<void>>();
@@ -103,10 +116,6 @@ export class IndexRunner {
     totalIndexEntries: 0,
   };
   #shouldClearCacheForNextRender = true;
-  // Aggregate wall of every `batch.updateEntry` row write in the current pass.
-  // Summed here (not per row) because a row can't time its own INSERT; surfaces
-  // on the job result's `phaseTimings.writeMs`. Reset at the start of each pass.
-  #writeMsTotal = 0;
   // Identifier for this runner's indexing batch (CS-10758 step 3).
   // Threaded into PrerenderVisitArgs and released from the fromScratch /
   // incremental finally blocks. One runner = one batch: if fromScratch
@@ -202,7 +211,6 @@ export class IndexRunner {
 
   static async fromScratch(current: IndexRunner): Promise<FromScratchResult> {
     current.#dependencyResolver.reset();
-    current.#writeMsTotal = 0;
     let start = Date.now();
     // Between-visit phase walls, assembled onto the job result's `phaseTimings`
     // at the end. `visitLoopMs` / `swapMs` are set inside the try below.
@@ -280,43 +288,39 @@ export class IndexRunner {
     let resumedRows = current.batch.resumedRows;
     let resumedSkipped = 0;
     try {
-      for (let invalidation of invalidations) {
-        // Resume guard. If a previous attempt of this same job already
-        // wrote URL_X to the working table AND the EFS mtime hasn't
-        // changed since, skip the visit — the existing working row is
-        // still authoritative and `applyBatchUpdates` will promote it
-        // (the constructor pre-seeded it into `#invalidations`). If
-        // mtime DID change, fall through to a normal visit so the
-        // upsert in `updateEntry` overwrites the resumed row with
-        // current content.
-        let resumedMtime = resumedRows.get(invalidation.href);
-        if (resumedMtime !== undefined) {
-          let currentMtime = discoverResult.filesystemMtimes[invalidation.href];
-          if (currentMtime !== undefined && currentMtime === resumedMtime) {
-            resumedSkipped++;
-            filesCompleted++;
-            current.#onProgress?.({
-              type: 'file-visited',
-              realmURL: current.realmURL.href,
-              jobId: current.#jobInfo.jobId,
-              url: invalidation.href,
-              filesCompleted,
-              totalFiles,
-            });
-            continue;
+      await current.#runVisitLoop(invalidations, {
+        // Resume guard. If a previous attempt of this same job already wrote
+        // URL_X to the working table AND the EFS mtime hasn't changed since,
+        // skip the visit — the existing working row is still authoritative
+        // and `applyBatchUpdates` will promote it (the constructor pre-seeded
+        // it into `#invalidations`). If mtime DID change, fall through to a
+        // normal visit so the upsert in `updateEntry` overwrites the resumed
+        // row with current content.
+        skipReason: (url) => {
+          let resumedMtime = resumedRows.get(url.href);
+          if (resumedMtime === undefined) {
+            return undefined;
           }
-        }
-        await current.tryToVisit(invalidation);
-        filesCompleted++;
-        current.#onProgress?.({
-          type: 'file-visited',
-          realmURL: current.realmURL.href,
-          jobId: current.#jobInfo.jobId,
-          url: invalidation.href,
-          filesCompleted,
-          totalFiles,
-        });
-      }
+          let currentMtime = discoverResult.filesystemMtimes[url.href];
+          return currentMtime !== undefined && currentMtime === resumedMtime
+            ? 'resumed'
+            : undefined;
+        },
+        onSkip: () => {
+          resumedSkipped++;
+        },
+        onVisited: (url) => {
+          filesCompleted++;
+          current.#onProgress?.({
+            type: 'file-visited',
+            realmURL: current.realmURL.href,
+            jobId: current.#jobInfo.jobId,
+            url: url.href,
+            filesCompleted,
+            totalFiles,
+          });
+        },
+      });
       if (resumedSkipped > 0) {
         current.#perfLog.debug(
           `${jobIdentity(current.#jobInfo)} skipped ${resumedSkipped} URLs already processed by prior attempt`,
@@ -375,7 +379,7 @@ export class IndexRunner {
         discoverMs,
         orderMs,
         ...(visitLoopMs !== undefined ? { visitLoopMs } : {}),
-        writeMs: current.#writeMsTotal,
+        writeMs: current.batch.writeMs,
         ...(swapMs !== undefined ? { swapMs } : {}),
       },
     };
@@ -390,7 +394,6 @@ export class IndexRunner {
     },
   ): Promise<IncrementalResult> {
     current.#dependencyResolver.reset();
-    current.#writeMsTotal = 0;
     let start = Date.now();
     // Between-visit phase walls, assembled onto the job result's `phaseTimings`
     // at the end. `visitLoopMs` / `swapMs` are set inside the try below.
@@ -480,31 +483,41 @@ export class IndexRunner {
     let resumedSkipped = 0;
     let loopStart = Date.now();
     try {
-      for (let invalidation of invalidations) {
-        if (
-          operations.get(invalidation.href) === 'delete' &&
-          hrefs.includes(invalidation.href)
-        ) {
-          // file is deleted, there is nothing to visit
-        } else if (resumedRows.has(invalidation.href)) {
-          // Previous attempt of this job already produced a working
-          // row for this URL. `args.changes` is the deterministic seed
-          // for incremental jobs; if the file changed again, that's a
-          // different changeset enqueued as a separate job. Skip.
-          resumedSkipped++;
-        } else {
-          await current.tryToVisit(invalidation);
-        }
-        filesCompleted++;
-        current.#onProgress?.({
-          type: 'file-visited',
-          realmURL: current.realmURL.href,
-          jobId: current.#jobInfo.jobId,
-          url: invalidation.href,
-          filesCompleted,
-          totalFiles,
-        });
-      }
+      await current.#runVisitLoop(invalidations, {
+        skipReason: (url) => {
+          if (
+            operations.get(url.href) === 'delete' &&
+            hrefs.includes(url.href)
+          ) {
+            // file is deleted, there is nothing to visit
+            return 'delete';
+          }
+          // Previous attempt of this job already produced a working row for
+          // this URL. `args.changes` is the deterministic seed for
+          // incremental jobs; if the file changed again, that's a different
+          // changeset enqueued as a separate job. Skip.
+          if (resumedRows.has(url.href)) {
+            return 'resumed';
+          }
+          return undefined;
+        },
+        onSkip: (_url, reason) => {
+          if (reason === 'resumed') {
+            resumedSkipped++;
+          }
+        },
+        onVisited: (url) => {
+          filesCompleted++;
+          current.#onProgress?.({
+            type: 'file-visited',
+            realmURL: current.realmURL.href,
+            jobId: current.#jobInfo.jobId,
+            url: url.href,
+            filesCompleted,
+            totalFiles,
+          });
+        },
+      });
       if (resumedSkipped > 0) {
         current.#perfLog.debug(
           `${jobIdentity(current.#jobInfo)} skipped ${resumedSkipped} URLs already processed by prior attempt`,
@@ -555,7 +568,7 @@ export class IndexRunner {
         discoverMs,
         orderMs,
         ...(visitLoopMs !== undefined ? { visitLoopMs } : {}),
-        writeMs: current.#writeMsTotal,
+        writeMs: current.batch.writeMs,
         ...(swapMs !== undefined ? { swapMs } : {}),
       },
     };
@@ -582,9 +595,16 @@ export class IndexRunner {
     });
   }
 
-  private async tryToVisit(url: URL) {
+  // The render (tab-bound) half of a visit. Reads the file and runs the
+  // prerender round-trip(s) but never touches the index tables, so a
+  // prefetched render can run while the previous visit's rows are still being
+  // written. Rejections are folded into the returned outcome — a prefetched
+  // render sits un-awaited for a tick, and an escaping rejection there would
+  // be an unhandled-rejection rather than something the loop can route to a
+  // file-error row.
+  async #renderVisit(url: URL): Promise<VisitRenderOutcome> {
     try {
-      await visitFileForIndexing({
+      let result = await renderFileForIndexing({
         url,
         realmURL: this.#realmURL,
         ignoreMap: this.ignoreMap,
@@ -600,85 +620,164 @@ export class IndexRunner {
         consumeClearCacheForRender: () => this.#consumeClearCacheForRender(),
         logDebug: (message) => this.#log.debug(message),
         logWarn: (message) => this.#log.warn(message),
-        indexCardWithResult: async (args) => await this.indexCard(args),
-        indexFileWithResults: async (args) => await this.indexFile(args),
       });
-    } catch (err: any) {
-      if (isCardError(err) && err.status === 404) {
-        this.#log.info(
-          `${jobIdentity(this.#jobInfo)} tried to visit file ${url.href}, but it no longer exists`,
-        );
+      return result ? { status: 'rendered', result } : { status: 'skipped' };
+    } catch (error) {
+      return { status: 'error', error };
+    }
+  }
+
+  // The bookkeeping + row-write (worker/DB-bound) half of a visit. Runs in
+  // the shadow of the next visit's render.
+  async #finishVisit(result: IndexVisitRenderResult): Promise<void> {
+    await routeIndexVisitResult(result, {
+      indexCardWithResult: async (args) => await this.indexCard(args),
+      indexFileWithResults: async (args) => await this.indexFile(args),
+    });
+  }
+
+  // Render-ahead visit loop. Visits are FINISHED strictly in order — the
+  // post-render bookkeeping reads prior visits' index rows (dependency-error
+  // propagation), and the visit order sequences dependencies before their
+  // dependents — but the NEXT visit's render is started before the current
+  // visit's bookkeeping + row write, so the tab renders file N+1 while the
+  // worker writes file N. Since a render reads only production `boxel_index`
+  // (never this pass's uncommitted `boxel_index_working` rows), rendering
+  // ahead cannot observe a write that hasn't landed yet.
+  //
+  // `skipReason` suppresses the render for URLs a prior attempt already
+  // resolved (`'resumed'`) or that were deleted (`'delete'`); it must be pure
+  // because the prefetch look-ahead and the finish cursor each call it. Every
+  // URL still reports progress in order via `onVisited`.
+  async #runVisitLoop(
+    invalidations: URL[],
+    {
+      skipReason,
+      onSkip,
+      onVisited,
+    }: {
+      skipReason: (url: URL) => 'resumed' | 'delete' | undefined;
+      onSkip: (url: URL, reason: 'resumed' | 'delete') => void;
+      onVisited: (url: URL) => void;
+    },
+  ): Promise<void> {
+    let n = invalidations.length;
+    let renders = new Map<number, Promise<VisitRenderOutcome>>();
+    // Start the render for the next non-skipped URL at or after `from`,
+    // keeping exactly one render in flight ahead of the finish cursor.
+    let prefetch = (from: number) => {
+      for (let j = from; j < n; j++) {
+        if (renders.has(j)) {
+          return;
+        }
+        if (skipReason(invalidations[j])) {
+          continue;
+        }
+        renders.set(j, this.#renderVisit(invalidations[j]));
         return;
       }
-      // A transport-level failure of the index visit — its
-      // prerender-server request timing out/aborting, or a reader/network
-      // error — never reaches performCardIndexing/performFileIndexing's
-      // own error-entry construction: visitFileForIndexing rethrows
-      // before calling indexCardWithResult/indexFileWithResults. (HTML
-      // prerendering is a separate job; the request here is the index
-      // pass's own visit.) Left uncaught, one file's failure propagates
-      // out of the fromScratch/incremental visit loop, skips
-      // batch.done(), and discards every other successfully-visited
-      // file's rows for the whole job. Persist a file-error row instead
-      // so the failure is isolated to this URL, matching the error_doc
-      // pattern used for in-band render errors.
-      let message = coerceErrorMessage(
-        err,
-        `Indexing failed for ${url.href} with no error message (${jobIdentity(this.#jobInfo)})`,
+    };
+    prefetch(0);
+    for (let i = 0; i < n; i++) {
+      let url = invalidations[i];
+      let reason = skipReason(url);
+      if (reason) {
+        onSkip(url, reason);
+        onVisited(url);
+        prefetch(i + 1);
+        continue;
+      }
+      let outcome = await renders.get(i)!;
+      renders.delete(i);
+      // Kick off the next render now so its round-trip overlaps the finish
+      // work below.
+      prefetch(i + 1);
+      try {
+        if (outcome.status === 'error') {
+          throw outcome.error;
+        }
+        if (outcome.status === 'rendered') {
+          await this.#finishVisit(outcome.result);
+        }
+      } catch (err) {
+        await this.#handleVisitError(url, err);
+      }
+      onVisited(url);
+    }
+  }
+
+  async #handleVisitError(url: URL, err: any): Promise<void> {
+    if (isCardError(err) && err.status === 404) {
+      this.#log.info(
+        `${jobIdentity(this.#jobInfo)} tried to visit file ${url.href}, but it no longer exists`,
       );
-      this.#log.warn(
-        `${jobIdentity(this.#jobInfo)} failed to index ${url.href}, recording file-error: ${message}`,
-      );
-      let error = isCardError(err)
-        ? serializableError(err)
-        : serializableError(
-            Object.assign(new CardError(message, { status: 500 }), {
-              stack: (err as Error)?.stack,
-            }),
-          );
-      error.message = message;
-      let fileEntry: FileErrorIndexEntry = {
-        type: 'file-error',
+      return;
+    }
+    // A transport-level failure of the visit — its prerender-server request
+    // timing out/aborting, or a reader/network error — never reaches
+    // performCardIndexing/performFileIndexing's own error-entry construction:
+    // renderFileForIndexing rejects before `#finishVisit` routes it. (HTML
+    // prerendering is a separate job; the request here is the index pass's own
+    // visit.) Left uncaught, one file's failure propagates out of the
+    // fromScratch/incremental visit loop, skips batch.done(), and discards
+    // every other successfully-visited file's rows for the whole job. Persist
+    // a file-error row instead so the failure is isolated to this URL,
+    // matching the error_doc pattern used for in-band render errors.
+    let message = coerceErrorMessage(
+      err,
+      `Indexing failed for ${url.href} with no error message (${jobIdentity(this.#jobInfo)})`,
+    );
+    this.#log.warn(
+      `${jobIdentity(this.#jobInfo)} failed to index ${url.href}, recording file-error: ${message}`,
+    );
+    let error = isCardError(err)
+      ? serializableError(err)
+      : serializableError(
+          Object.assign(new CardError(message, { status: 500 }), {
+            stack: (err as Error)?.stack,
+          }),
+        );
+    error.message = message;
+    let fileEntry: FileErrorIndexEntry = {
+      type: 'file-error',
+      error,
+    };
+    await this.batch.bufferEntry(url, fileEntry);
+    this.#dependencyResolver.invalidateRelationshipDependencyRowCache(url);
+    this.stats.fileErrors++;
+    // `Batch.invalidate()` already tombstoned every type this URL previously
+    // had in the index — for an existing card that's both `instance` and
+    // `file`. Overwriting only the `file` tombstone above would let
+    // batch.done() promote the untouched `instance` tombstone, silently
+    // removing a previously-good card from search over a transient error. The
+    // index is the oracle for "was this a card?": the batch records which live
+    // row types it tombstoned, so an existing card is protected even when the
+    // file can't be read — which may be exactly how the visit failed.
+    // Re-parsing the source is only the fallback for a brand-new file, which
+    // has no prior row to protect but should still surface its failure as an
+    // instance error when it's a card.
+    let isCardInstance =
+      this.batch.tombstonedLiveTypes(url.href)?.includes('instance') ?? false;
+    if (!isCardInstance && url.href.endsWith('.json')) {
+      try {
+        let fileRef = await this.#reader.readFile(url);
+        let resource = fileRef?.content
+          ? (JSON.parse(fileRef.content)?.data as unknown)
+          : undefined;
+        isCardInstance = Boolean(resource && isCardResource(resource));
+      } catch (parseErr) {
+        this.#log.warn(
+          `${jobIdentity(this.#jobInfo)} could not determine whether ${url.href} is a card instance after its visit failed: ${(parseErr as Error)?.message}`,
+        );
+      }
+    }
+    if (isCardInstance) {
+      let instanceEntry: InstanceErrorIndexEntry = {
+        type: 'instance-error',
         error,
       };
-      await this.batch.updateEntry(url, fileEntry);
-      this.#dependencyResolver.invalidateRelationshipDependencyRowCache(url);
-      this.stats.fileErrors++;
-      // `Batch.invalidate()` already tombstoned every type this URL
-      // previously had in the index — for an existing card that's both
-      // `instance` and `file`. Overwriting only the `file` tombstone
-      // above would let batch.done() promote the untouched `instance`
-      // tombstone, silently removing a previously-good card from search
-      // over a transient error. The index is the oracle for "was this a
-      // card?": the batch records which live row types it tombstoned, so
-      // an existing card is protected even when the file can't be read —
-      // which may be exactly how the visit failed. Re-parsing the source
-      // is only the fallback for a brand-new file, which has no prior
-      // row to protect but should still surface its failure as an
-      // instance error when it's a card.
-      let isCardInstance =
-        this.batch.tombstonedLiveTypes(url.href)?.includes('instance') ?? false;
-      if (!isCardInstance && url.href.endsWith('.json')) {
-        try {
-          let fileRef = await this.#reader.readFile(url);
-          let resource = fileRef?.content
-            ? (JSON.parse(fileRef.content)?.data as unknown)
-            : undefined;
-          isCardInstance = Boolean(resource && isCardResource(resource));
-        } catch (parseErr) {
-          this.#log.warn(
-            `${jobIdentity(this.#jobInfo)} could not determine whether ${url.href} is a card instance after its visit failed: ${(parseErr as Error)?.message}`,
-          );
-        }
-      }
-      if (isCardInstance) {
-        let instanceEntry: InstanceErrorIndexEntry = {
-          type: 'instance-error',
-          error,
-        };
-        await this.batch.updateEntry(url, instanceEntry);
-        this.stats.instanceErrors++;
-      }
+      await this.batch.bufferEntry(url, instanceEntry);
+      this.stats.instanceErrors++;
     }
   }
 
@@ -912,16 +1011,13 @@ export class IndexRunner {
     }
   }
 
-  // Time the row write and fold it into the pass's aggregate. The single
-  // chokepoint every `boxel_index_working` row write goes through, so the job
-  // result's `phaseTimings.writeMs` covers instance and file rows alike.
+  // The single chokepoint every `boxel_index_working` row write goes through.
+  // Hands the row to the batch's write-behind buffer rather than upserting it
+  // inline, so the visit loop can start the next file's render while this row
+  // (and its neighbors, coalesced into a multi-row upsert) drains. The batch
+  // times the physical writes; the job result reads `batch.writeMs`.
   async #writeEntry(url: URL, entry: SearchIndexEntry): Promise<void> {
-    let start = Date.now();
-    try {
-      await this.batch.updateEntry(url, entry);
-    } finally {
-      this.#writeMsTotal += Date.now() - start;
-    }
+    await this.batch.bufferEntry(url, entry);
   }
 }
 

--- a/packages/runtime-common/index-runner/visit-file.ts
+++ b/packages/runtime-common/index-runner/visit-file.ts
@@ -25,7 +25,7 @@ import { CardError, mergeErrorsByGeneration } from '../error.ts';
 import { resolveFileDefCodeRef } from '../file-def-code-ref.ts';
 import type { VirtualNetwork } from '../virtual-network.ts';
 
-interface VisitFileOptions {
+interface RenderFileForIndexingOptions {
   url: URL;
   realmURL: URL;
   ignoreMap: Map<string, Ignore>;
@@ -50,16 +50,47 @@ interface VisitFileOptions {
   consumeClearCacheForRender(): boolean;
   logDebug(message: string): void;
   logWarn(message: string): void;
+}
+
+// The tab-bound half of a visit: everything `renderFileForIndexing` produces
+// from the file read + prerender round-trip(s), handed to
+// `routeIndexVisitResult` for the DB-bound half (bookkeeping + row writes).
+// Splitting the two lets the index loop keep the next visit's render in flight
+// while this visit's writes drain — the tab is the scarce resource, and the
+// writes/bookkeeping use only the worker + DB, so they ride in the shadow of a
+// render that happens anyway.
+export interface IndexVisitRenderResult {
+  localPath: LocalPath;
+  lastModified: number;
+  resourceCreatedAt: number;
+  // Recorded as the file-index row's `hasModulePrerender` hint.
+  isModule: boolean;
+  // Present when the file parsed as a card resource — drives the extra
+  // `instance` row.
+  parsedCardResource: LooseCardResource | undefined;
+  // Merged card sub-result (search-doc side from the index visit, HTML side
+  // from the prerender-html visit). Undefined when no visit produced one.
+  card: RenderResponse | undefined;
+  fileExtract: RenderVisitResponse['fileExtract'];
+  fileRender: FileRenderResponse | undefined;
+  // A page-unusable/auth short-circuit reported by either visit. Used to
+  // synthesize a card error entry when a card resource produced no card
+  // result.
+  pageUnusableError: RenderVisitResponse['pageUnusableError'];
+  // Timing / diagnostic payload flattened from the visits' `response.meta`
+  // (server timings + host-side breadcrumbs + HTTP requestId). Persisted onto
+  // `boxel_index.diagnostics` so operators can investigate slow renders after
+  // the fact.
+  diagnostics: Diagnostics | undefined;
+}
+
+interface RouteIndexVisitCallbacks {
   indexCardWithResult(args: {
     path: LocalPath;
     lastModified: number;
     resourceCreatedAt: number;
     resource: LooseCardResource;
     renderResult: NonNullable<RenderVisitResponse['card']>;
-    // Timing / diagnostic payload flattened from the visits'
-    // `response.meta` (server timings + host-side breadcrumbs +
-    // HTTP requestId). Persisted onto `boxel_index.diagnostics`
-    // so operators can investigate slow renders after the fact.
     diagnostics?: Diagnostics;
   }): Promise<void>;
   indexFileWithResults(args: {
@@ -76,9 +107,9 @@ interface VisitFileOptions {
   }): Promise<void>;
 }
 
-// Visits a file for indexing as two consolidated prerender visits along the
-// search-doc/HTML seam, then routes the merged sub-results into the
-// card/file indexers:
+// Renders a file for indexing as two consolidated prerender visits along the
+// search-doc/HTML seam, returning the merged sub-results for
+// `routeIndexVisitResult` to write:
 //
 //   1. the index visit — file extract, card meta (search doc / serialized /
 //      types / display names / deps) and the card + file icons. Never runs
@@ -90,8 +121,11 @@ interface VisitFileOptions {
 //
 // The merged writes are identical to what a single fused visit produces;
 // the seam separates HTML production from search-doc production so each can
-// run on its own channel.
-export async function visitFileForIndexing({
+// run on its own channel. This function touches only the reader + prerender
+// tab (never the index tables), so the caller can start the next file's
+// render before this one's row writes land. Returns `undefined` when the
+// file is ignored or belongs to a different realm.
+export async function renderFileForIndexing({
   url,
   realmURL,
   ignoreMap,
@@ -107,11 +141,9 @@ export async function visitFileForIndexing({
   consumeClearCacheForRender,
   logDebug,
   logWarn,
-  indexCardWithResult,
-  indexFileWithResults,
-}: VisitFileOptions): Promise<void> {
+}: RenderFileForIndexingOptions): Promise<IndexVisitRenderResult | undefined> {
   if (isIgnored(realmURL, ignoreMap, url)) {
-    return;
+    return undefined;
   }
   let start = Date.now();
   logDebug(`${jobIdentity(jobInfo)} begin visit of file ${url.href}`);
@@ -123,7 +155,7 @@ export async function visitFileForIndexing({
     logDebug(
       `${jobIdentity(jobInfo)} Visit of ${url.href} skipped (different realm than ${realmURL.href})`,
     );
-    return;
+    return undefined;
   }
 
   let fileRef = await reader.readFile(url);
@@ -322,6 +354,46 @@ export async function visitFileForIndexing({
     },
   );
 
+  logDebug(
+    `${jobIdentity(jobInfo)} completed render of file ${url.href} in ${Date.now() - start}ms`,
+  );
+
+  return {
+    localPath,
+    lastModified,
+    resourceCreatedAt,
+    isModule,
+    parsedCardResource,
+    card,
+    fileExtract: indexResponse.fileExtract,
+    fileRender: fileRenderResult,
+    pageUnusableError,
+    diagnostics,
+  };
+}
+
+// The DB-bound half of a visit: route the merged render sub-results into the
+// card/file indexers, which do the post-render bookkeeping (dependency-error
+// propagation) and write the rows. Kept separate from `renderFileForIndexing`
+// so the index loop can overlap this visit's writes with the next visit's
+// render.
+export async function routeIndexVisitResult(
+  result: IndexVisitRenderResult,
+  { indexCardWithResult, indexFileWithResults }: RouteIndexVisitCallbacks,
+): Promise<void> {
+  let {
+    localPath,
+    lastModified,
+    resourceCreatedAt,
+    isModule,
+    parsedCardResource,
+    card,
+    fileExtract,
+    fileRender,
+    pageUnusableError,
+    diagnostics,
+  } = result;
+
   // Route card result when we parsed a card resource. If the visits
   // short-circuited (page-unusable/auth), the card sub-result may be
   // missing. In that case, synthesize an error RenderResponse from
@@ -370,14 +442,10 @@ export async function visitFileForIndexing({
     resourceCreatedAt,
     hasModulePrerender: isModule,
     isCardInstance: Boolean(parsedCardResource),
-    extractResult: indexResponse.fileExtract,
-    renderResult: fileRenderResult,
+    extractResult: fileExtract,
+    renderResult: fileRender,
     diagnostics,
   });
-
-  logDebug(
-    `${jobIdentity(jobInfo)} completed visit of file ${url.href} in ${Date.now() - start}ms`,
-  );
 }
 
 // Fold the pre-render + transport client overhead into the row's diagnostics

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -790,8 +790,6 @@ export class Batch {
       return;
     }
     let buffered = this.#writeBuffer;
-    this.#writeBuffer = [];
-    this.#writeBufferUrls.clear();
     let start = Date.now();
     try {
       if (this.#splitPrerenderHtml) {
@@ -812,6 +810,15 @@ export class Batch {
           await this.#writeEntryNow(url, entry);
         }
       }
+      // Clear only after the rows have durably landed. If a write throws, the
+      // buffer is retained so the healthy rows in it aren't lost: a later
+      // flush (the next dependency read, the size cap, or `done()`) retries
+      // them. `done()` flushes before it promotes, so a persistent failure
+      // surfaces there and aborts the batch before any swap — rather than
+      // dropping the buffered rows while their URLs stay in the invalidation
+      // set, which would let the swap promote tombstones or stale rows.
+      this.#writeBuffer = [];
+      this.#writeBufferUrls.clear();
     } finally {
       this.#writeMs += Date.now() - start;
     }

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -945,19 +945,30 @@ export class Batch {
       // row's values align with the single `nameExpressions` list.
       let columns = Object.keys(group[0].preparedEntry).sort();
       let nameExpressions = columns.map((column) => [column]);
-      let valueExpressions = group.map(
-        (row) =>
-          asExpressions(orderKeys(row.preparedEntry, columns), { jsonFields })
-            .valueExpressions,
-      );
-      await this.#query([
-        ...upsertMultipleRows(
-          'boxel_index_working',
-          'boxel_index_working_pkey',
-          nameExpressions,
-          valueExpressions,
-        ),
-      ]);
+      // Keep each INSERT within the adapter's bind-parameter ceiling: one
+      // multi-row upsert binds `rows * columns` params, and SQLite caps that
+      // (~999) — reachable when a batch flushes in split mode under SQLite
+      // (forced in tests) — while Postgres tolerates far more. Chunk the group
+      // so the statement stays under the limit, mirroring the per-adapter
+      // chunking in `getDependencyRows`.
+      let bindBudget = this.#dbAdapter.kind === 'sqlite' ? 900 : 60000;
+      let rowsPerUpsert = Math.max(1, Math.floor(bindBudget / columns.length));
+      for (let i = 0; i < group.length; i += rowsPerUpsert) {
+        let slice = group.slice(i, i + rowsPerUpsert);
+        let valueExpressions = slice.map(
+          (row) =>
+            asExpressions(orderKeys(row.preparedEntry, columns), { jsonFields })
+              .valueExpressions,
+        );
+        await this.#query([
+          ...upsertMultipleRows(
+            'boxel_index_working',
+            'boxel_index_working_pkey',
+            nameExpressions,
+            valueExpressions,
+          ),
+        ]);
+      }
     }
   }
 

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -252,6 +252,12 @@ function prerenderedHtmlEntryFrom(
   };
 }
 
+// Rows held in the write-behind buffer before a flush is forced (see
+// `Batch.bufferEntry`). Dependency reads flush earlier; this only bounds
+// memory across long runs of dependency-free files. Renders dwarf the writes,
+// so even a forced flush lands in a render's shadow.
+const WRITE_BUFFER_FLUSH_THRESHOLD = 100;
+
 export class Batch {
   readonly ready: Promise<void>;
   #invalidations = new Set<string>();
@@ -276,6 +282,15 @@ export class Batch {
   // of each incremental `invalidate()` call so the ID identifies a
   // single triggering change, not the whole batch lifetime.
   #currentInvalidationId: string;
+  // Write-behind buffer for the index visit loop (see `bufferEntry`). Rows
+  // accumulate here so the prerender tab renders the next file while these
+  // drain; `#writeBufferUrls` mirrors their URLs for the dependency-read
+  // flush check in `getDependencyRows`.
+  #writeBuffer: { url: URL; entry: SearchIndexEntry }[] = [];
+  #writeBufferUrls = new Set<string>();
+  // Aggregate wall of every physical `boxel_index_working` write in this
+  // batch, surfaced on the job result's `phaseTimings.writeMs`.
+  #writeMs = 0;
   #dbAdapter: DBAdapter;
   #perfLog = logger('index-perf');
   // The source realm of a copy batch, set by `copyFrom`. `applyBatchUpdates`
@@ -730,6 +745,89 @@ export class Batch {
     ]);
   }
 
+  // Enqueue a row write behind the write buffer instead of upserting it
+  // inline. The index visit loop routes its writes here so the prerender tab
+  // can start the next file's render while these rows drain. The URL joins
+  // `#invalidations` synchronously — the swap in `done()`, the resume marker,
+  // and the dependency-error skip all key off it, so buffering must not defer
+  // that — while the physical upsert is held until `flushWriteBuffer`. The one
+  // mid-pass reader of buffered rows, dependency-error bookkeeping via
+  // `getDependencyRows`, flushes the buffer first when it queries a
+  // still-buffered URL, so a dependent never reads a stale row for a
+  // dependency written earlier in the same pass.
+  async bufferEntry(url: URL, entry: SearchIndexEntry): Promise<void> {
+    if (this.#prerenderHtmlOnly) {
+      throw new Error(
+        `a prerenderHtmlOnly batch writes only the prerendered_html channel — use updatePrerenderedHtmlEntry`,
+      );
+    }
+    if (!new RealmPaths(this.realmURL, this.virtualNetwork).inRealm(url)) {
+      // TODO this is a workaround for CS-6886. after we have solved that issue we can
+      // drop this band-aid
+      return;
+    }
+    this.#assertErrorEntryHasMessage(url, entry);
+    this.#invalidations.add(url.href);
+    this.#writeBuffer.push({ url, entry });
+    this.#writeBufferUrls.add(url.href);
+    // Bound memory for long runs of dependency-free files; dependency reads
+    // flush earlier. Renders dwarf the writes, so a forced flush here still
+    // rides in the shadow of the render that started before it.
+    if (this.#writeBuffer.length >= WRITE_BUFFER_FLUSH_THRESHOLD) {
+      await this.flushWriteBuffer();
+    }
+  }
+
+  // Drain the write buffer. In split mode (server / pg) the batch writes only
+  // `boxel_index`, so the held rows coalesce into multi-row upserts grouped by
+  // column signature — instance/file success rows share one signature, error
+  // rows fold in the last-known-good production columns and group separately —
+  // turning one round-trip per row into a handful per drain. In fused mode
+  // (SQLite) each row also lands its HTML half on the `prerendered_html`
+  // channel, so the proven per-row path runs instead.
+  async flushWriteBuffer(): Promise<void> {
+    if (this.#writeBuffer.length === 0) {
+      return;
+    }
+    let buffered = this.#writeBuffer;
+    this.#writeBuffer = [];
+    this.#writeBufferUrls.clear();
+    let start = Date.now();
+    try {
+      if (this.#splitPrerenderHtml) {
+        // Last write wins when the same (url, type) was buffered twice: a
+        // single multi-row upsert can't touch one conflict target twice.
+        let deduped = new Map<string, { url: URL; entry: SearchIndexEntry }>();
+        for (let item of buffered) {
+          deduped.set(`${item.url.href}|${rowType(item.entry)}`, item);
+        }
+        let prepared = await Promise.all(
+          [...deduped.values()].map(({ url, entry }) =>
+            this.#prepareIndexRow(url, entry),
+          ),
+        );
+        await this.#upsertIndexRows(prepared);
+      } else {
+        for (let { url, entry } of buffered) {
+          await this.#writeEntryNow(url, entry);
+        }
+      }
+    } finally {
+      this.#writeMs += Date.now() - start;
+    }
+  }
+
+  // Aggregate wall of every physical `boxel_index_working` write in this
+  // batch — the single-row `updateEntry` path plus every `flushWriteBuffer`
+  // drain — surfaced on the job result's `phaseTimings.writeMs`.
+  get writeMs(): number {
+    return this.#writeMs;
+  }
+
+  // Immediate single-row write, for callers outside the buffered index loop
+  // (realm copy fix-ups, tests). Runs the same guards + invalidation
+  // bookkeeping the buffered path does, then writes without waiting for a
+  // flush.
   async updateEntry(url: URL, entry: SearchIndexEntry): Promise<void> {
     if (this.#prerenderHtmlOnly) {
       throw new Error(
@@ -741,15 +839,25 @@ export class Batch {
       // drop this band-aid
       return;
     }
-    // An instance-error / file-error entry whose `.error.message` is
-    // empty would persist as a row with `has_error = true` and an
-    // error_doc that is null or missing the human-readable text. Such
-    // a row is invisible to UI and DB-only triage, and historically
-    // produced indexing jobs that re-reserved indefinitely without
-    // ever rejecting. Throw at the boundary so the caller's stderr log
-    // carries the underlying render error and the worker can finalize
-    // the reservation against the per-job cap instead of silently
-    // writing a black-hole row.
+    this.#assertErrorEntryHasMessage(url, entry);
+    this.#invalidations.add(url.href);
+    let start = Date.now();
+    try {
+      await this.#writeEntryNow(url, entry);
+    } finally {
+      this.#writeMs += Date.now() - start;
+    }
+  }
+
+  // An instance-error / file-error entry whose `.error.message` is empty would
+  // persist as a row with `has_error = true` and an error_doc that is null or
+  // missing the human-readable text. Such a row is invisible to UI and DB-only
+  // triage, and historically produced indexing jobs that re-reserved
+  // indefinitely without ever rejecting. Throw at the boundary so the caller's
+  // stderr log carries the underlying render error and the worker can finalize
+  // the reservation against the per-job cap instead of silently writing a
+  // black-hole row.
+  #assertErrorEntryHasMessage(url: URL, entry: SearchIndexEntry): void {
     if (
       isErrorEntry(entry) &&
       (!entry.error ||
@@ -763,27 +871,113 @@ export class Batch {
           `failure text.`,
       );
     }
+  }
+
+  // Physically write one prepared row. On the fused path the entry's HTML half
+  // lands first: the boxel_index_working row is the resume marker
+  // (`loadResumedRows` skips URLs it finds), so writing it last means a crash
+  // between the two writes re-visits the URL rather than resuming a row whose
+  // rendering never landed. (A split-mode batch writes no HTML — its spawned
+  // `prerender_html` job owns that channel.)
+  async #writeEntryNow(url: URL, entry: SearchIndexEntry): Promise<void> {
+    let { preparedEntry, htmlEntry } = await this.#prepareIndexRow(url, entry);
+    if (!this.#splitPrerenderHtml) {
+      await this.writePrerenderedHtmlRow(url, htmlEntry);
+    }
+    let { nameExpressions, valueExpressions } = asExpressions(preparedEntry, {
+      jsonFields: this.#jsonColumnNames(),
+    });
+    await this.#query([
+      ...upsert(
+        'boxel_index_working',
+        'boxel_index_working_pkey',
+        nameExpressions,
+        valueExpressions,
+      ),
+    ]);
+  }
+
+  // Coalesce prepared rows into multi-row upserts. `asExpressions` derives the
+  // column list from an object's keys, and one multi-row `VALUES` clause
+  // requires every row to present the same columns in the same order — so
+  // group by column signature and emit one upsert per group (success
+  // instance/file rows fall in one group; error rows, which fold in the
+  // last-known-good production columns, may each form their own).
+  async #upsertIndexRows(rows: PreparedIndexRow[]): Promise<void> {
+    if (rows.length === 0) {
+      return;
+    }
+    let jsonFields = this.#jsonColumnNames();
+    let groups = new Map<string, PreparedIndexRow[]>();
+    for (let row of rows) {
+      let signature = Object.keys(row.preparedEntry).sort().join(',');
+      let group = groups.get(signature);
+      if (group) {
+        group.push(row);
+      } else {
+        groups.set(signature, [row]);
+      }
+    }
+    for (let group of groups.values()) {
+      if (group.length === 1) {
+        let { nameExpressions, valueExpressions } = asExpressions(
+          group[0].preparedEntry,
+          { jsonFields },
+        );
+        await this.#query([
+          ...upsert(
+            'boxel_index_working',
+            'boxel_index_working_pkey',
+            nameExpressions,
+            valueExpressions,
+          ),
+        ]);
+        continue;
+      }
+      // One stable column order shared by every row in the group, so each
+      // row's values align with the single `nameExpressions` list.
+      let columns = Object.keys(group[0].preparedEntry).sort();
+      let nameExpressions = columns.map((column) => [column]);
+      let valueExpressions = group.map(
+        (row) =>
+          asExpressions(orderKeys(row.preparedEntry, columns), { jsonFields })
+            .valueExpressions,
+      );
+      await this.#query([
+        ...upsertMultipleRows(
+          'boxel_index_working',
+          'boxel_index_working_pkey',
+          nameExpressions,
+          valueExpressions,
+        ),
+      ]);
+    }
+  }
+
+  #jsonColumnNames(): string[] {
+    return [...Object.entries(coerceTypes)]
+      .filter(([, type]) => type === 'JSON')
+      .map(([column]) => column);
+  }
+
+  // Build the sanitized `boxel_index_working` row payload — and the paired
+  // `prerendered_html` entry the fused path writes — for an entry, without
+  // performing the upsert.
+  //
+  // The per-row diagnostics blob is assembled here: render-side fields come
+  // from the Prerenderer's `response.meta` (already flattened in
+  // `visit-file.ts`); the write-side `invalidationId` (minted once per Batch,
+  // so every row from the same pass shares a queryable correlation key) and
+  // `indexedAt` are stamped now. The canonical storage is the `diagnostics`
+  // column; for error rows the blob is ALSO mirrored onto
+  // `error_doc.diagnostics` so the UI read path keeps working unchanged.
+  // jsonb-illegal bytes are stripped once, over the whole row, by the
+  // `sanitizeForJsonb` at the end.
+  async #prepareIndexRow(
+    url: URL,
+    entry: SearchIndexEntry,
+  ): Promise<PreparedIndexRow> {
     let href = url.href;
-    this.#invalidations.add(url.href);
-    // Build the per-row diagnostics blob. Render-side fields
-    // come from the Prerenderer's `response.meta` (already flattened
-    // in `visit-file.ts`); write-side stamps are added here:
-    //
-    //   - `invalidationId` — minted once per Batch (covers both
-    //     incremental `invalidate()` calls and fromScratch), so every
-    //     row from the same indexing pass shares a queryable
-    //     correlation key.
-    //   - `indexedAt` — wall-clock the write happened.
-    //
-    // The canonical storage is the `diagnostics` column. For
-    // error rows we ALSO mirror the blob onto `error_doc.diagnostics`
-    // so the UI read path (error doc → CardErrorJSONAPI.meta.
-    // diagnostics via `formattedError`) keeps working unchanged —
-    // no schema rename needed. The column remains source of truth;
-    // the error-doc copy is derived.
-    // jsonb-illegal bytes are stripped once at the write boundary below
-    // (see the sanitizeForJsonb call before asExpressions), so this and every
-    // other content column is covered in one place.
     let diagnostics: Diagnostics = {
       ...(entry.diagnostics ?? {}),
       invalidationId: this.#currentInvalidationId,
@@ -935,38 +1129,10 @@ export class Batch {
     // display_names, diagnostics, error_doc) in one place, including rendered
     // card content that can carry a split emoji surrogate or a stray NUL folded
     // in from an upstream resolver.
-    let { nameExpressions, valueExpressions } = asExpressions(
-      sanitizeForJsonb(preparedEntry),
-      {
-        jsonFields: [...Object.entries(coerceTypes)]
-          .filter(([_, type]) => type === 'JSON')
-          .map(([column]) => column),
-      },
-    );
-
-    // On the fused path there is no separate `prerender_html` job, so the
-    // entry's HTML half lands on the prerendered_html channel here, in the
-    // same visit that produced it. (A split-mode index batch writes no HTML
-    // at all — its spawned `prerender_html` job owns that channel.) The HTML
-    // half goes first: the boxel_index_working row is the resume marker
-    // (`loadResumedRows` skips URLs it finds), so writing it last means a
-    // crash between the two writes re-visits the URL rather than resuming a
-    // row whose rendering never landed.
-    if (!this.#splitPrerenderHtml) {
-      await this.writePrerenderedHtmlRow(
-        url,
-        prerenderedHtmlEntryFrom(entry, diagnostics),
-      );
-    }
-
-    await this.#query([
-      ...upsert(
-        'boxel_index_working',
-        'boxel_index_working_pkey',
-        nameExpressions,
-        valueExpressions,
-      ),
-    ]);
+    return {
+      preparedEntry: sanitizeForJsonb(preparedEntry) as Record<string, unknown>,
+      htmlEntry: prerenderedHtmlEntryFrom(entry, diagnostics),
+    };
   }
 
   // Seed a prerenderHtmlOnly batch's invalidation set from the changes the
@@ -1196,6 +1362,10 @@ export class Batch {
   }
 
   async done(): Promise<{ totalIndexEntries: number }> {
+    // Drain any rows the visit loop left buffered before the swap reads the
+    // working table. A no-op for a prerenderHtmlOnly batch (which never
+    // buffers) and for a pass whose last write already forced a flush.
+    await this.flushWriteBuffer();
     if (this.#prerenderHtmlOnly) {
       // A prerenderHtmlOnly batch touches nothing but the prerendered_html
       // channel: no realm_meta, no realm_generations bump, no boxel_index
@@ -1921,6 +2091,18 @@ export class Batch {
     }
 
     let uniqueUrls = [...new Set(urls)];
+    // Dependency-error bookkeeping is the only mid-pass reader of this pass's
+    // own writes. Flush the write-behind buffer when this query would touch a
+    // still-buffered URL so the dependent sees the dependency's row. The check
+    // matches on the same URL strings the SQL below binds into `url IN (...)`,
+    // so it flushes exactly when the query could otherwise miss a held row —
+    // and skips the flush (preserving batching) when it wouldn't.
+    if (
+      this.#writeBuffer.length > 0 &&
+      uniqueUrls.some((url) => this.#writeBufferUrls.has(url))
+    ) {
+      await this.flushWriteBuffer();
+    }
     // SQLite has a lower parameter limit than Postgres. Chunk URL lookups to
     // keep IN-clause parameter counts within safe bounds for both adapters.
     let urlBatchSize = this.#dbAdapter.kind === 'sqlite' ? 900 : 5000;
@@ -2276,4 +2458,32 @@ function baseTypeFromError(entry: {
     case 'file-error':
       return 'file';
   }
+}
+
+// The `boxel_index` row type an entry lands under — the pkey is
+// (url, realm_url, type), so this keys the flush dedup that keeps a single
+// multi-row upsert from touching one conflict target twice.
+function rowType(entry: SearchIndexEntry): BoxelIndexTable['type'] {
+  return isErrorEntry(entry) ? baseTypeFromError(entry) : entry.type;
+}
+
+// A `boxel_index_working` row payload built but not yet upserted, plus the
+// paired `prerendered_html` entry the fused path writes for it.
+interface PreparedIndexRow {
+  preparedEntry: Record<string, unknown>;
+  htmlEntry: PrerenderedHtmlEntry | PrerenderedHtmlErrorEntry;
+}
+
+// Return a copy of `obj` with its keys in `keys` order, so a batch of rows
+// sharing the same key set serializes to value tuples aligned with one shared
+// column list.
+function orderKeys(
+  obj: Record<string, unknown>,
+  keys: string[],
+): Record<string, unknown> {
+  let ordered: Record<string, unknown> = {};
+  for (let key of keys) {
+    ordered[key] = obj[key];
+  }
+  return ordered;
 }


### PR DESCRIPTION
## What

The index job's visit loop was fully serial — for each file it did `read → render → bookkeeping → write`, awaiting the Postgres row write before the next file's render started. The write is a DB upsert and the bookkeeping is worker-side CPU; **neither uses the prerender tab**, so the tab sat idle while they ran when it could have been rendering the next file.

This reworks the loop so the writes and bookkeeping ride in the shadow of a render that happens anyway:

1. **Overlap.** Each visit is split into a tab-bound render half (`renderFileForIndexing`) and a worker/DB-bound routing half (`routeIndexVisitResult`), driven by a render-ahead loop (`IndexRunner.#runVisitLoop`) that starts the next file's render *before* finishing the current file's bookkeeping + write. A render reads only production `boxel_index`, never this pass's uncommitted `boxel_index_working` rows, so rendering ahead can't observe a write that hasn't landed.

2. **Batch.** Row writes are deferred through a write-behind buffer on the batch (`bufferEntry` / `flushWriteBuffer`) and coalesced into multi-row upserts (`upsertMultipleRows`) grouped by column signature, instead of one round-trip per row.

## Correctness — bounded in-flight window

Some bookkeeping reads *prior* rows' index state (dependency-error propagation checks whether a dependency already wrote an error row), so writes can't be deferred arbitrarily. Dependency-error bookkeeping is the **only** mid-pass reader of the pass's own writes, and it goes through `getDependencyRows`, which now flushes the buffer first whenever it queries a still-buffered URL. The flush check matches on the same URL strings the SQL binds into `url IN (...)`, so it drains exactly when a query could otherwise miss a held row — and skips the flush (preserving batching) when it can't. Buffered URLs join the invalidation set synchronously, preserving the swap / resume / dependency-skip semantics that key off it. The visit order already sequences dependencies before dependents, and finishes stay strictly in order, so a dependent always sees its dependency's row.

## Expected effect

On the profiled `ctse/military-pigeon` from-scratch, row writes summed to ~20 s and per-row bookkeeping to ~10 s (~11 % of a 278.5 s wall). Render (~211 s) dwarfs the writes, so there is ample render shadow to absorb them. Standalone value is highest while the visit loop is still serial; re-measure once visit parallelism (multi-tab per realm) lands, since each visit's write would then overlap the other concurrent renders anyway.

## Testing

- Added a unit test pinning the buffer + flush-on-dependency-read invariant (buffered writes defer until flush; a dependency read flushes them first; the multi-row upsert lands every buffered row).
- Existing from-scratch / incremental indexing suites exercise the render-ahead pipeline and batched writer end-to-end, including the dependency-error propagation chains this change must preserve.
- `runtime-common` type-check, eslint, and prettier pass on the changed files.

Linear: CS-12155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LFGXNpyeE8JGwtAhANDy3)_