### PR TITLE
Add incident-report skill for consistent, shareable outage write-ups

### DIFF
--- a/.claude/skills/incident-report/SKILL.md
+++ b/.claude/skills/incident-report/SKILL.md
@@ -24,7 +24,7 @@ Pin, with sources: the exact incident window, per-code error counts (503 vs 504 
 
 ## The deliverable
 
-Default to an **Artifact** (via the `Artifact` tool) — it renders the house style directly. An incident report is meant to be read by the whole team, so its end state is **shared with the "Cardstack" organization**, not left private (see Publish & track). Load the `artifact-design` skill's fundamentals if you need a refresher, but the palette and structure here are already decided; do not re-derive them.
+Default to an **Artifact** (via the `Artifact` tool) — it renders the house style directly. An incident report is meant to be read by the whole team, so its end state is **shared with the "Cardstack" organization**, not left private (see Publish & track). The palette and structure here are already decided; do not re-derive them.
 
 Keep a plain-markdown copy in the scratchpad too when useful as a working draft, but the shared deliverable is the Artifact.
 

--- a/.claude/skills/incident-report/SKILL.md
+++ b/.claude/skills/incident-report/SKILL.md
@@ -21,7 +21,7 @@ Pin, with sources: the exact incident window, per-code error counts (503 vs 504 
 
 ## The deliverable
 
-Default to an **Artifact** (via the `Artifact` tool) — it is shareable with the team, private until shared, and renders the house style directly. Load the `artifact-design` skill's fundamentals if you need a refresher, but the palette and structure here are already decided; do not re-derive them.
+Default to an **Artifact** (via the `Artifact` tool) — it renders the house style directly. An incident report is meant to be read by the whole team, so its end state is **shared with the "Cardstack" organization**, not left private (see Publish & track). Load the `artifact-design` skill's fundamentals if you need a refresher, but the palette and structure here are already decided; do not re-derive them.
 
 Keep a plain-markdown copy in the scratchpad too when useful as a working draft, but the shared deliverable is the Artifact.
 
@@ -74,8 +74,9 @@ Not every incident needs all nine at full weight, but keep the order and the sec
 
 1. Write the filled HTML to the scratchpad (or the report's working dir).
 2. Publish with the `Artifact` tool: favicon `🚨`, a concise `<title>`/title (`Staging 504 Incident Report — <date>`), and a one-sentence `description`.
-3. To revise, edit the same file and republish with the **same file path** so the URL is stable.
-4. Post the Artifact link to the tracking ticket (Linear) as a comment — not a description edit — and attach it alongside any prior related report. If it's a recurrence, comment on the existing ticket rather than opening a new one, and spell out same-mode / different-trigger.
+3. **Set visibility to the "Cardstack" organization.** The report is for the whole team — it must not stay private. The `Artifact` tool publishes private-by-default and has no visibility parameter, so this is a one-time action in the page's **share menu**: choose share with the "Cardstack" organization (org members can open it). If you (Claude) can't reach the share menu, publish, then explicitly tell the user to flip visibility to the Cardstack org and hand them the URL — don't leave it silently private.
+4. To revise, edit the same file and republish with the **same file path** so the URL (and its sharing) is stable.
+5. Post the Artifact link to the tracking ticket (Linear) as a comment — not a description edit — and attach it alongside any prior related report. If it's a recurrence, comment on the existing ticket rather than opening a new one, and spell out same-mode / different-trigger.
 
 ## Files
 

--- a/.claude/skills/incident-report/SKILL.md
+++ b/.claude/skills/incident-report/SKILL.md
@@ -7,7 +7,10 @@ description: Write up a production or staging incident (outage, degradation, 5xx
 
 This skill keeps every boxel incident write-up in one recognizable house style and one honest voice, so a reader who has seen one report can read the next at a glance. It covers **how to structure, word, and publish** the report — not how to investigate. Gather the evidence first (see Step 0), then render it here.
 
-The canonical examples are the 2026-07-15 staging 503 report and the 2026-07-16 staging 504 report — both built to the structure and tone below. New reports should look and read like their siblings.
+The canonical examples — both built to the structure and tone below; new reports should look and read like these siblings (open in a browser signed in to the Cardstack org):
+
+- 2026-07-15 staging 503 — <https://claude.ai/code/artifact/97592f4d-372b-4727-8220-c3a32b96d001>
+- 2026-07-16 staging 504 — <https://claude.ai/code/artifact/02f27e4b-ddbf-485e-a1fd-319eedd2dca1>
 
 ## Step 0 — investigate first; the report renders evidence, never assumptions
 

--- a/.claude/skills/incident-report/SKILL.md
+++ b/.claude/skills/incident-report/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: incident-report
+description: Write up a production or staging incident (outage, degradation, 5xx / latency spike, indexing stall, task-recycle event) as a consistent, shareable report in the team's established house style — a slate-blue technical Artifact with a facts grid, stat tiles, a typed timeline, a trigger-vs-vulnerability root cause, a "ruled out" list, prioritized action items, and an evidence appendix. Use whenever asked to "create/write an incident report", "postmortem", "write this up for the team", or after investigating a deployed-environment incident and needing a deliverable others will read. Pairs with the aws-access, tail-logs, indexing-diagnostics, and prerender-sizing skills, which gather the evidence this report is built from.
+---
+
+# Incident report
+
+This skill keeps every boxel incident write-up in one recognizable house style and one honest voice, so a reader who has seen one report can read the next at a glance. It covers **how to structure, word, and publish** the report — not how to investigate. Gather the evidence first (see Step 0), then render it here.
+
+The canonical examples are the 2026-07-15 staging 503 report and the 2026-07-16 staging 504 report — both built to the structure and tone below. New reports should look and read like their siblings.
+
+## Step 0 — investigate first; the report renders evidence, never assumptions
+
+A report is only as good as what it's built on. Before writing a line, pin the facts with real data:
+
+- **Deployed-env access + logs** → the `aws-access` skill (ALB/ECS/CloudWatch metrics, RDS, EFS) and `tail-logs` (Loki).
+- **Slow/failed indexing or renders** → `indexing-diagnostics`.
+- **Prerender pool saturation / sizing** → `prerender-sizing`.
+
+Pin, with sources: the exact incident window, per-code error counts (503 vs 504 vs target-5xx — they mean different things), the peak/precursor spikes, target response times, the deploy/task-def timeline, the health-check + rollout config, and any git/PR/ticket that correlates. If a claim can't be backed by a metric, a log line, or config, either verify it or mark it explicitly as inferred. The "ruled out" section (below) is not optional — an incident report that only argues *for* one cause is weaker than one that also says what it isn't.
+
+## The deliverable
+
+Default to an **Artifact** (via the `Artifact` tool) — it is shareable with the team, private until shared, and renders the house style directly. Load the `artifact-design` skill's fundamentals if you need a refresher, but the palette and structure here are already decided; do not re-derive them.
+
+Keep a plain-markdown copy in the scratchpad too when useful as a working draft, but the shared deliverable is the Artifact.
+
+Start from `template.html` in this skill directory — it is the full house stylesheet plus a section scaffold with placeholders. Copy it, fill every section with the pinned evidence, delete the guidance comments, and publish.
+
+## House style (already decided — keep it consistent)
+
+- **Palette:** slate-blue accent (`#35506B` light / `#7BA0CC` dark) on cool, slightly hue-biased neutrals; semantic `critical` / `warning` / `good` that are **separate from the accent** and used only for severity, never decoration. Full token set (light + dark, `prefers-color-scheme` + `data-theme` overrides) is in `template.html` — theme-aware in both directions.
+- **Type:** system sans for prose; a monospace face (`ui-monospace`, …) for **all** timestamps, counts, durations, config values, and code. Use `font-variant-numeric: tabular-nums` anywhere digits align in a column.
+- **Favicon:** `🚨` (keep it stable across redeploys of the same report).
+- **Layout:** a single document column (`max-width: 940px`), scan-first — summary and key numbers before the detail. Wide tables live inside an `overflow-x: auto` container so the page body never scrolls sideways.
+
+## Required structure (in this order)
+
+1. **Header** — eyebrow (`Incident Report` + status pills: `Staging/Prod outage`, `Resolved`/`Ongoing`, and any relation like `Recurrence of CS-xxxxx`), a one-line headline that states what actually happened, and a lede (≤3 sentences) that a non-oncall teammate can follow.
+2. **Facts grid** — Environment, Window (UTC), Duration, Trigger, Production impact, Data loss.
+3. **Stat tiles** — 4–6 key numbers (peak error count, max response time, request-volume delta, task count, the one config value that mattered, etc.). Color the alarming ones `critical`/`warning`.
+4. **Summary** — a 2–3 paragraph callout: what broke, the mechanism in plain terms, whether it recovered on its own.
+5. **Root cause** — two cards side by side: **the vulnerability** (the standing weakness that let this become an outage) and **the trigger** (the specific thing that set it off this time). Keeping them separate is the point — the same vulnerability can be hit by different triggers, and conflating them produces the wrong fix. Follow with a short "why this was milder/worse than <prior incident>" paragraph if there's a comparable one.
+6. **Timeline** — a typed vertical timeline (normal / hot / deploy / recover markers). UTC first, local (e.g. EDT) in grey. This is a genuine sequence, so the timeline (and only here, ordered markers) is appropriate.
+7. **Contributing factors & ruled out** — two columns. Contributing factors as a `critical`-marked list; ruled-out as a `good`-marked list with the evidence that rules each out.
+8. **Action items** — a prioritized table (Prio / Action / Layer / Status). Lead with the cheapest high-leverage fixes; tie durable guarantees to their tracking tickets. If a fix is config-only vs code, say so.
+9. **Evidence appendix** — the raw tables the narrative rests on (per-minute error counts, health/metric samples, deploy & config facts, code/commit refs).
+
+Not every incident needs all nine at full weight, but keep the order and the section identities so reports stay comparable. Drop a section only when it would be empty, not to save effort.
+
+## Tone & content rules (the voice)
+
+- **Honest and specific over reassuring.** No apologies, no hedging-as-filler. "Both tasks failed the health check and were replaced" beats "there may have been some instability."
+- **Separate trigger from vulnerability** everywhere, not just in the root-cause cards.
+- **Quantify.** Every claim of severity carries a number and its source. Prefer real observed values to round numbers.
+- **Times in UTC, with local in parentheses** the first time each is shown. State the timezone conversion once so readers can check it. Beware quoting a Slack/Sentry timestamp that's already local.
+- **Name the honest caveat.** If a proposed fix only covers the observed flavor and not a worse one, say so explicitly (e.g. "config tuning avoids this mild event; a sustained overload still needs load-shedding"). Over-claiming a fix is the most common way these reports mislead.
+- **Recommendations are actionable and layered:** config-only first, then code, then structural; each tied to a ticket where one exists.
+- **Evergreen within the doc, but a report is inherently a point-in-time record** — it's fine (expected) for it to describe the journey and reference tickets/PRs/commits, unlike code comments and PR text. This is the one place the evergreen rule does not apply.
+
+## Numbers & formatting conventions
+
+- Distinguish HTTP codes precisely: ALB-generated `5xx` (no responsive target) vs target-generated `5xx` (app returned it); `503` (no healthy/available target) vs `504` (target didn't answer in time). Watch for red herrings like `dur=504ms` matching a "504" grep.
+- Put counts, durations, and config in monospace; align columns with tabular-nums.
+- Give per-minute granularity for the spike itself and coarser buckets for context.
+
+## Privacy
+
+- **Artifact / Linear are internal** (Linear is staff-only) — staging/prod detail, realm names, task IDs, and log excerpts are fine there. This is the same posture as the existing reports.
+- **Never include secrets** in any destination: no JWTs / `boxel-session` tokens, no DB credentials, no signed URLs. Redact before pasting a log line that contains them.
+- **GitHub is public.** If any of this content is ever headed for a PR, commit, or public issue, the `pr-privacy` skill applies and most of this data must be redacted or kept out. Keep incident detail in the Artifact/Linear, link from GitHub.
+
+## Publish & track
+
+1. Write the filled HTML to the scratchpad (or the report's working dir).
+2. Publish with the `Artifact` tool: favicon `🚨`, a concise `<title>`/title (`Staging 504 Incident Report — <date>`), and a one-sentence `description`.
+3. To revise, edit the same file and republish with the **same file path** so the URL is stable.
+4. Post the Artifact link to the tracking ticket (Linear) as a comment — not a description edit — and attach it alongside any prior related report. If it's a recurrence, comment on the existing ticket rather than opening a new one, and spell out same-mode / different-trigger.
+
+## Files
+
+- `template.html` — the house stylesheet + section scaffold. Start here.

--- a/.claude/skills/incident-report/template.html
+++ b/.claude/skills/incident-report/template.html
@@ -1,0 +1,269 @@
+<!--
+  Boxel incident-report house template.
+  Copy this file, fill every {{PLACEHOLDER}} with pinned evidence, delete these
+  guidance comments, then publish with the Artifact tool (favicon 🚨).
+  This is Artifact *body* content: no <!doctype>/<html>/<head>/<body> — the
+  Artifact tool wraps those. Keep the <style> block and the .wrap container.
+  The palette + light/dark tokens below ARE the house style; don't re-derive them.
+-->
+<style>
+  :root {
+    --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
+
+    --bg: #F5F7F9; --surface: #FFFFFF; --surface-2: #EDF1F4; --border: #DBE2E8;
+    --border-strong: #C5CFD8; --ink: #14191F; --ink-2: #3E4954; --ink-3: #6B7681;
+    --accent: #35506B; --accent-soft: #E7EDF2;
+    --critical: #B92B37; --critical-bg: #FBECEE; --warning: #9E6410; --warning-bg: #FBF2E0;
+    --good: #1C7049; --good-bg: #E6F3EC; --info: #2B6CB0;
+    --radius: 8px; --maxw: 940px;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0E1318; --surface: #151C24; --surface-2: #1B2430; --border: #29333F;
+      --border-strong: #3A4653; --ink: #E7EDF2; --ink-2: #AEB9C4; --ink-3: #7E8A96;
+      --accent: #7BA0CC; --accent-soft: #1B2836;
+      --critical: #F0656F; --critical-bg: #2A181B; --warning: #E0A54A; --warning-bg: #29210F;
+      --good: #56C089; --good-bg: #12241A; --info: #6BA6E0;
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #F5F7F9; --surface: #FFFFFF; --surface-2: #EDF1F4; --border: #DBE2E8;
+    --border-strong: #C5CFD8; --ink: #14191F; --ink-2: #3E4954; --ink-3: #6B7681;
+    --accent: #35506B; --accent-soft: #E7EDF2;
+    --critical: #B92B37; --critical-bg: #FBECEE; --warning: #9E6410; --warning-bg: #FBF2E0;
+    --good: #1C7049; --good-bg: #E6F3EC; --info: #2B6CB0;
+  }
+  :root[data-theme="dark"] {
+    --bg: #0E1318; --surface: #151C24; --surface-2: #1B2430; --border: #29333F;
+    --border-strong: #3A4653; --ink: #E7EDF2; --ink-2: #AEB9C4; --ink-3: #7E8A96;
+    --accent: #7BA0CC; --accent-soft: #1B2836;
+    --critical: #F0656F; --critical-bg: #2A181B; --warning: #E0A54A; --warning-bg: #29210F;
+    --good: #56C089; --good-bg: #12241A; --info: #6BA6E0;
+  }
+
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--ink); font-family: var(--font-sans); font-size: 16px; line-height: 1.6; -webkit-font-smoothing: antialiased; }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 40px 24px 80px; }
+
+  .doc-head { border-left: 4px solid var(--critical); padding-left: 20px; margin-bottom: 32px; }
+  .eyebrow { font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); margin: 0 0 10px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  h1 { font-size: 1.95rem; line-height: 1.15; letter-spacing: -0.02em; text-wrap: balance; margin: 0 0 12px; font-weight: 680; }
+  .lede { font-size: 1.08rem; color: var(--ink-2); max-width: 68ch; margin: 0; }
+
+  .pill { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 0.7rem; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; padding: 3px 9px; border-radius: 999px; border: 1px solid transparent; }
+  .pill::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+  .pill-resolved { color: var(--good); background: var(--good-bg); border-color: color-mix(in srgb, var(--good) 30%, transparent); }
+  .pill-critical { color: var(--critical); background: var(--critical-bg); border-color: color-mix(in srgb, var(--critical) 30%, transparent); }
+  .pill-info { color: var(--info); background: color-mix(in srgb, var(--info) 12%, transparent); border-color: color-mix(in srgb, var(--info) 30%, transparent); }
+
+  .facts { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1px; background: var(--border); border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; margin-bottom: 28px; }
+  .fact { background: var(--surface); padding: 14px 16px; }
+  .fact dt { font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 0.09em; text-transform: uppercase; color: var(--ink-3); margin: 0 0 5px; }
+  .fact dd { margin: 0; font-size: 0.92rem; font-weight: 550; color: var(--ink); }
+  .fact dd small { display: block; font-weight: 400; color: var(--ink-3); font-size: 0.8rem; }
+
+  .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(158px, 1fr)); gap: 12px; margin: 28px 0; }
+  .stat { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 16px; }
+  .stat .num { font-family: var(--font-mono); font-size: 1.7rem; font-weight: 600; letter-spacing: -0.02em; color: var(--ink); font-variant-numeric: tabular-nums; line-height: 1.05; }
+  .stat .num .unit { font-size: 0.9rem; color: var(--ink-3); font-weight: 500; }
+  .stat .lbl { margin-top: 6px; font-size: 0.82rem; color: var(--ink-2); }
+  .stat.is-critical .num { color: var(--critical); }
+  .stat.is-warning .num { color: var(--warning); }
+
+  section { margin-top: 44px; }
+  h2 { font-size: 1.28rem; letter-spacing: -0.01em; margin: 0 0 4px; font-weight: 640; display: flex; align-items: baseline; gap: 12px; }
+  h2 .idx { font-family: var(--font-mono); font-size: 0.8rem; color: var(--accent); font-weight: 600; }
+  .section-sub { color: var(--ink-3); font-size: 0.9rem; margin: 0 0 18px; }
+  h3 { font-size: 1.02rem; margin: 26px 0 8px; font-weight: 620; }
+  p { margin: 0 0 14px; }
+  a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in srgb, var(--accent) 35%, transparent); }
+  code { font-family: var(--font-mono); font-size: 0.85em; background: var(--surface-2); border: 1px solid var(--border); border-radius: 4px; padding: 0.08em 0.36em; color: var(--ink); word-break: break-word; }
+  strong { font-weight: 620; color: var(--ink); }
+
+  .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: var(--radius); padding: 16px 18px; }
+  .callout.key { border-left-color: var(--good); }
+  .callout.warn { border-left-color: var(--warning); }
+
+  ul.clean { margin: 0 0 14px; padding-left: 0; list-style: none; }
+  ul.clean li { position: relative; padding-left: 22px; margin-bottom: 9px; color: var(--ink-2); }
+  ul.clean li::before { content: ""; position: absolute; left: 4px; top: 0.62em; width: 6px; height: 6px; border-radius: 1px; background: var(--accent); }
+  ul.clean.bad li::before { background: var(--critical); }
+  ul.clean.ruled li::before { background: var(--good); transform: rotate(45deg); }
+
+  .timeline { border-left: 2px solid var(--border-strong); margin-left: 8px; padding-left: 0; }
+  .tl-row { position: relative; padding: 0 0 20px 26px; }
+  .tl-row::before { content: ""; position: absolute; left: -7px; top: 4px; width: 12px; height: 12px; border-radius: 50%; background: var(--surface); border: 2px solid var(--accent); }
+  .tl-row.hot::before { background: var(--critical); border-color: var(--critical); }
+  .tl-row.deploy::before { background: var(--warning); border-color: var(--warning); }
+  .tl-row.recover::before { background: var(--good); border-color: var(--good); }
+  .tl-time { font-family: var(--font-mono); font-size: 0.78rem; font-weight: 600; color: var(--ink); font-variant-numeric: tabular-nums; }
+  .tl-time .edt { color: var(--ink-3); font-weight: 400; }
+  .tl-body { color: var(--ink-2); font-size: 0.93rem; margin-top: 2px; }
+
+  .table-scroll { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--radius); margin: 14px 0; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.86rem; }
+  th, td { text-align: left; padding: 9px 14px; border-bottom: 1px solid var(--border); white-space: nowrap; }
+  thead th { font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.07em; text-transform: uppercase; color: var(--ink-3); background: var(--surface-2); font-weight: 600; }
+  tbody tr:last-child td { border-bottom: none; }
+  td.mono, th.mono, .num-col { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+  td.wrap-ok { white-space: normal; }
+  tbody tr:hover td { background: var(--surface-2); }
+  td .was { color: var(--critical); font-family: var(--font-mono); }
+  td .now { color: var(--good); font-family: var(--font-mono); }
+
+  .prio { font-family: var(--font-mono); font-size: 0.68rem; font-weight: 700; letter-spacing: 0.04em; padding: 2px 7px; border-radius: 4px; }
+  .p0 { color: var(--critical); background: var(--critical-bg); }
+  .p1 { color: var(--warning); background: var(--warning-bg); }
+  .p2 { color: var(--info); background: color-mix(in srgb, var(--info) 12%, transparent); }
+  .st-done { color: var(--good); font-weight: 600; }
+  .st-open { color: var(--ink-3); }
+
+  .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+  @media (max-width: 620px) { .two-col { grid-template-columns: 1fr; } }
+  .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 18px 20px; }
+  .card h3 { margin-top: 0; }
+  .card.crit { border-top: 3px solid var(--critical); }
+  .card.trig { border-top: 3px solid var(--warning); }
+
+  footer.doc-foot { margin-top: 56px; padding-top: 18px; border-top: 1px solid var(--border); font-family: var(--font-mono); font-size: 0.74rem; color: var(--ink-3); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 8px; }
+  .kbd-note { color: var(--ink-3); font-size: 0.82rem; font-style: italic; }
+</style>
+
+<div class="wrap">
+
+  <!-- ── HEADER: eyebrow pills + one-line headline + ≤3-sentence lede ── -->
+  <header class="doc-head">
+    <p class="eyebrow">
+      <span>Incident Report</span>
+      <span class="pill pill-critical">{{Staging|Prod outage}}</span>
+      <span class="pill pill-resolved">{{Resolved · auto-recovered | Ongoing}}</span>
+      <!-- optional relation pill: <span class="pill pill-info">Recurrence of CS-xxxxx</span> -->
+    </p>
+    <h1>{{One-line headline: what actually happened}}</h1>
+    <p class="lede">{{2–3 sentences a non-oncall teammate can follow: what broke, the mechanism, and that it recovered / is ongoing.}}</p>
+  </header>
+
+  <!-- ── FACTS GRID ── -->
+  <dl class="facts">
+    <div class="fact"><dt>Environment</dt><dd>{{Staging}}<small>{{host}}</small></dd></div>
+    <div class="fact"><dt>Window (UTC)</dt><dd>{{HH:MM – HH:MM}}<small>{{HH:MM – HH:MM local}}</small></dd></div>
+    <div class="fact"><dt>Duration</dt><dd>{{~N min}}<small>{{single burst | intermittent}}</small></dd></div>
+    <div class="fact"><dt>Trigger</dt><dd>{{short}}<small>{{detail}}</small></dd></div>
+    <div class="fact"><dt>Production impact</dt><dd>{{None | ...}}</dd></div>
+    <div class="fact"><dt>Data loss</dt><dd>{{None}}</dd></div>
+  </dl>
+
+  <!-- ── STAT TILES: 4–6 key numbers; mark alarming ones is-critical / is-warning ── -->
+  <div class="stats">
+    <div class="stat is-critical"><div class="num">{{N}}</div><div class="lbl">{{peak error count / what}}</div></div>
+    <div class="stat is-critical"><div class="num">{{N}}<span class="unit"> s</span></div><div class="lbl">{{max target response time}}</div></div>
+    <div class="stat is-warning"><div class="num">{{N}}<span class="unit"> /5min</span></div><div class="lbl">{{request-volume delta}}</div></div>
+    <div class="stat"><div class="num">{{N}}</div><div class="lbl">{{tasks / capacity}}</div></div>
+    <div class="stat is-warning"><div class="num">{{N}}</div><div class="lbl">{{the one config value that mattered}}</div></div>
+    <div class="stat"><div class="num">{{N}}</div><div class="lbl">{{context number}}</div></div>
+  </div>
+
+  <!-- ── SUMMARY ── -->
+  <section>
+    <h2>Summary</h2>
+    <div class="callout">
+      <p style="margin:0 0 12px">{{What broke, in plain terms, with the key numbers.}}</p>
+      <p style="margin:0">{{The mechanism, and whether it recovered on its own.}}</p>
+    </div>
+  </section>
+
+  <!-- Optional: lead with the reader's key question when there is one (e.g. "Can we
+       simply avoid it?"). Give a one-word verdict in the h2, then evidence + a
+       current-vs-recommended config table. Reuse the table markup below. -->
+
+  <!-- ── ROOT CAUSE: vulnerability (standing) vs trigger (this time) ── -->
+  <section>
+    <h2><span class="idx">01</span>Root cause</h2>
+    <p class="section-sub">A standing weakness, met by a specific trigger. Keeping them separate is the point.</p>
+    <div class="two-col">
+      <div class="card crit">
+        <h3>The vulnerability</h3>
+        <ul class="clean bad">
+          <li>{{the standing weakness that let this become an outage}}</li>
+        </ul>
+      </div>
+      <div class="card trig">
+        <h3>The trigger</h3>
+        <ul class="clean">
+          <li>{{the specific thing that set it off this time}}</li>
+        </ul>
+      </div>
+    </div>
+    <h3>{{Why milder/worse than <prior incident>, if comparable}}</h3>
+    <p>{{comparison with numbers}}</p>
+  </section>
+
+  <!-- ── TIMELINE: types = (none)|hot|deploy|recover. UTC first, local in grey. ── -->
+  <section>
+    <h2><span class="idx">02</span>Timeline</h2>
+    <p class="section-sub">All times UTC (local in grey). Reconstructed from {{sources}}.</p>
+    <div class="timeline">
+      <div class="tl-row"><div class="tl-time">{{HH:MM}} <span class="edt">· {{HH:MM local}}</span></div><div class="tl-body">{{event}}</div></div>
+      <div class="tl-row deploy"><div class="tl-time">{{HH:MM}}</div><div class="tl-body">{{deploy / config change}}</div></div>
+      <div class="tl-row hot"><div class="tl-time">{{HH:MM}}</div><div class="tl-body">{{peak impact, with numbers}}</div></div>
+      <div class="tl-row recover"><div class="tl-time">{{HH:MM}}</div><div class="tl-body">{{recovery}}</div></div>
+    </div>
+  </section>
+
+  <!-- ── CONTRIBUTING FACTORS & RULED OUT ── -->
+  <section>
+    <h2><span class="idx">03</span>Contributing factors &amp; what was ruled out</h2>
+    <div class="two-col">
+      <div>
+        <h3>Contributing factors</h3>
+        <ul class="clean bad"><li>{{factor}}</li></ul>
+      </div>
+      <div>
+        <h3>Ruled out</h3>
+        <ul class="clean ruled"><li>{{not-the-cause + the evidence that rules it out}}</li></ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── ACTION ITEMS: cheapest high-leverage first; note config-only vs code; tie to tickets ── -->
+  <section>
+    <h2><span class="idx">04</span>Action items</h2>
+    <div class="table-scroll">
+      <table>
+        <thead><tr><th>Prio</th><th>Action</th><th>Layer</th><th>Status</th></tr></thead>
+        <tbody>
+          <tr><td><span class="prio p1">P1</span></td><td class="wrap-ok">{{action}}</td><td>{{layer}}</td><td class="st-open">Open</td></tr>
+          <tr><td><span class="prio p0">GUARD</span></td><td class="wrap-ok">{{durable guarantee}} (<code>CS-xxxxx</code>)</td><td>{{layer}}</td><td class="st-done">{{Staged}}</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- Optional current-vs-recommended config table (reuse anywhere):
+  <div class="table-scroll"><table>
+    <thead><tr><th>Lever</th><th class="mono">Now</th><th class="mono">Recommended</th><th>Why</th></tr></thead>
+    <tbody><tr><td class="wrap-ok"><code>setting</code></td><td><span class="was">old</span></td><td><span class="now">new</span></td><td class="wrap-ok">why</td></tr></tbody>
+  </table></div>
+  -->
+
+  <!-- ── EVIDENCE APPENDIX: the raw tables the narrative rests on ── -->
+  <section>
+    <h2><span class="idx">05</span>Evidence appendix</h2>
+    <h3>{{table name, e.g. errors per minute}}</h3>
+    <div class="table-scroll">
+      <table>
+        <thead><tr><th class="mono">{{col}}</th><th class="mono">{{col}}</th><th>Note</th></tr></thead>
+        <tbody>
+          <tr><td class="mono">{{v}}</td><td class="mono">{{v}}</td><td>{{note}}</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <footer class="doc-foot">
+    <span>Boxel · {{Env}} incident · {{YYYY-MM-DD}}</span>
+    <span>Sources: {{ALB CloudWatch · ECS · logs · git · …}}</span>
+  </footer>
+
+</div>


### PR DESCRIPTION
## Background

When a deployed-environment incident happens (recent examples: the 2026-07-15 staging 503 and the 2026-07-16 staging 504), we write it up as a shareable report — published as an Artifact in a specific slate-blue technical style and a specific honest voice (separate the trigger from the standing vulnerability, quantify everything, name the honest caveat, always include a "ruled out" section). Until now that style and tone lived only inside the finished artifacts, so every new report re-derived them by hand and risked drifting.

## What this adds

A `.claude/skills/incident-report` skill that codifies the house format and voice so each report reads like its siblings, alongside the operational skills it depends on (`aws-access`, `tail-logs`, `indexing-diagnostics`, `prerender-sizing`) which gather the evidence a report renders.

- **`SKILL.md`** — when to reach for it, "investigate first" (evidence before narrative), the required section order and what each section holds, the tone rules, HTTP-code/formatting conventions, a privacy note (Artifact/Linear internal vs GitHub public), and the publish-and-track steps (including sharing the Artifact with the Cardstack org).
- **`template.html`** — the full light/dark house stylesheet plus a section scaffold with placeholders, ready to copy, fill, and publish with the Artifact tool.

## Canonical examples

The reports this skill is modeled on (open in a browser signed in to the Cardstack org):

- 2026-07-15 staging 503 — https://claude.ai/code/artifact/97592f4d-372b-4727-8220-c3a32b96d001
- 2026-07-16 staging 504 — https://claude.ai/code/artifact/02f27e4b-ddbf-485e-a1fd-319eedd2dca1

## Notes

- Docs/skill only — no product code changes.
- Placement follows the existing operational skills (`aws-access`, `tail-logs`, `indexing-diagnostics`) under `.claude/skills/`.
