### PR TITLE
Responsive field label layout in the default card template (CS-11384)

### DIFF
--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -305,8 +305,9 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
         gap: var(--boxel-sp-xs);
       }
       .preview-toggle {
-        margin-left: auto;
         min-width: 10.5rem;
+        margin-left: auto;
+        margin-top: calc(-1 * var(--boxel-sp-xs));
         justify-content: space-between;
       }
       .preview-toggle-icon {
@@ -318,8 +319,11 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
       .default-preview {
         display: grid;
         gap: var(--boxel-sp);
+        margin-top: var(--boxel-sp-xs);
         margin-bottom: var(--boxel-sp-xl);
-        padding: var(--boxel-sp-lg);
+        padding-top: var(--boxel-sp-xl);
+        padding-inline: var(--boxel-sp-lg);
+        padding-bottom: var(--boxel-sp-lg);
         background-color: var(--accent);
         border-radius: var(--radius);
         color: var(--accent-foreground);
@@ -329,7 +333,6 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
         --boxel-field-content-padding: 0;
         min-height: unset;
         padding-top: unset;
-        padding-right: var(--boxel-sp-4xs);
       }
 
       .card-info-fields {
@@ -342,18 +345,19 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
         grid-template-columns:
           var(--boxel-field-label-size, minmax(8rem, 25%))
           1fr;
-        align-items: center;
+        align-items: start;
         justify-items: center;
       }
       .card-info-thumbnail-preview {
         grid-area: thumbnail;
+        margin-top: var(--boxel-sp-sm);
+        margin-right: var(--boxel-sp-xl);
         border: 1px solid var(--border);
       }
       .card-info-thumbnail-popup-toggle {
         grid-area: thumbnail-toggle;
-        max-width: 9.375rem;
-        margin-inline: var(--boxel-sp-xs);
-        padding-inline: var(--boxel-sp-xs);
+        margin-top: var(--boxel-sp-xs);
+        margin-right: var(--boxel-sp-xl);
       }
       .card-info-edit-fields {
         grid-area: name-summary;
@@ -437,8 +441,12 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
         .card-info-preview-group {
           margin-bottom: var(--boxel-sp);
         }
+        .preview-toggle {
+          margin-top: unset;
+        }
         .default-preview {
-          margin-bottom: 0;
+          margin-top: unset;
+          margin-bottom: var(--boxel-sp-xs);
         }
         .card-info-fields {
           --thumbnail-container-size: 4.375rem;
@@ -449,10 +457,15 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
         .card-info-edit-field-group {
           gap: var(--boxel-sp-xs);
         }
+        .card-info-thumbnail-preview {
+          margin-top: 0;
+          margin-right: 0;
+        }
         .card-info-thumbnail-popup-toggle {
           align-self: start;
           max-width: var(--thumbnail-container-size);
           min-width: unset;
+          margin-top: 0;
           margin-inline: 0;
           padding-inline: 0;
           border-radius: var(--boxel-border-radius-sm);

--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -131,180 +131,182 @@ interface EditSignature {
 
 class CardInfoEditor extends GlimmerComponent<EditSignature> {
   <template>
-    <div class='cardInfo-editor'>
-      <Button
-        class={{cn 'preview-toggle' is-preview-visible=this.isPreviewVisible}}
-        @size='extra-small'
-        @kind='text-only'
-        {{on 'click' this.togglePreview}}
-        data-test-toggle-preview
-      >
-        {{if this.isPreviewVisible 'Hide' 'Show'}}
-        Default Preview
-        <ChevronRight
-          class='preview-toggle-icon'
-          width='14'
-          height='14'
-          role='presentation'
-        />
-      </Button>
-      {{#if this.isPreviewVisible}}
-        <div class='default-preview'>
-          <FieldContainer
-            @label='Card Type'
-            @icon={{@model.constructor.icon}}
-            data-test-edit-preview='cardType'
-          >
-            {{@model.constructor.displayName}}
-          </FieldContainer>
-          {{#each this.previewFields as |item|}}
-            {{#let item.Field as |Field|}}
-              <FieldContainer
-                @label={{item.label}}
-                @icon={{if
-                  (eq item.key 'cardThumbnailURL')
-                  LinkIcon
-                  (getFieldIcon @model item.key)
-                }}
-                data-test-edit-preview={{item.key}}
-                data-edit-preview-field={{item.key}}
-              >
-                {{#if item.value}}
-                  <Field @format='atom' />
-                {{else}}
-                  <em class='null-preview'>
-                    {{#if (and (eq item.key 'cardTheme') @hideThemeChooser)}}
-                      (Self)
-                    {{else}}
-                      None
-                    {{/if}}
-                  </em>
-                {{/if}}
-              </FieldContainer>
-            {{/let}}
-          {{/each}}
-        </div>
-      {{/if}}
-      <FieldContainer class='main-fields'>
-        <:label>
-          <div class='cardInfo-thumbnail-container'>
-            <CardInfoImageContainer
-              class='cardInfo-thumbnail-preview'
-              @cardThumbnailURL={{@model.cardThumbnailURL}}
+    <div class='card-info-editor'>
+      <div class='card-info-preview-group'>
+        <Button
+          class={{cn 'preview-toggle' is-preview-visible=this.isPreviewVisible}}
+          @size='extra-small'
+          @kind='text-only'
+          {{on 'click' this.togglePreview}}
+          data-test-toggle-preview
+        >
+          {{if this.isPreviewVisible 'Hide' 'Show'}}
+          Default Preview
+          <ChevronRight
+            class='preview-toggle-icon'
+            width='14'
+            height='14'
+            role='presentation'
+          />
+        </Button>
+        {{#if this.isPreviewVisible}}
+          <div class='default-preview'>
+            <FieldContainer
+              class='preview-field'
+              @label='Card Type'
               @icon={{@model.constructor.icon}}
-              data-test-thumbnail-image
-            />
-            <Button
-              class='cardInfo-thumbnail-popup-toggle'
-              @size='extra-small'
-              @kind='secondary-light'
-              {{on 'click' this.toggleThumbnailEditor}}
-              data-test-toggle-thumbnail-editor
+              data-test-edit-preview='cardType'
             >
-              Change
-              {{#unless @hideThemeChooser}}Theme & {{/unless}}Thumbnail
-            </Button>
-          </div>
-        </:label>
-        <:default>
-          <div class='card-info-edit-fields'>
-            <FieldContainer
-              class='card-info-field'
-              @label='Name'
-              @tag='label'
-              @labelFontSize='default'
-              @icon={{NameIcon}}
-              @vertical={{true}}
-              data-test-field='cardInfo-name'
-            >
-              <@fields.cardInfo.name />
+              {{@model.constructor.displayName}}
             </FieldContainer>
-            <FieldContainer
-              class='card-info-field'
-              @label='Summary'
-              @tag='label'
-              @labelFontSize='default'
-              @icon={{SummaryIcon}}
-              @vertical={{true}}
-              data-test-field='cardInfo-summary'
-            >
-              <@fields.cardInfo.summary />
-            </FieldContainer>
+            {{#each this.previewFields as |item|}}
+              {{#let item.Field as |Field|}}
+                <FieldContainer
+                  class='preview-field'
+                  @label={{item.label}}
+                  @icon={{if
+                    (eq item.key 'cardThumbnailURL')
+                    LinkIcon
+                    (getFieldIcon @model item.key)
+                  }}
+                  data-test-edit-preview={{item.key}}
+                  data-edit-preview-field={{item.key}}
+                >
+                  {{#if item.value}}
+                    <Field @format='atom' />
+                  {{else}}
+                    <em class='null-preview'>
+                      {{#if (and (eq item.key 'cardTheme') @hideThemeChooser)}}
+                        (Self)
+                      {{else}}
+                        None
+                      {{/if}}
+                    </em>
+                  {{/if}}
+                </FieldContainer>
+              {{/let}}
+            {{/each}}
           </div>
-        </:default>
-      </FieldContainer>
-      {{#if this.isThumbnailEditorVisible}}
-        <div class='hidden-fields'>
+        {{/if}}
+      </div>
+      <div class='card-info-fields'>
+        <CardInfoImageContainer
+          class='card-info-thumbnail-preview'
+          @cardThumbnailURL={{@model.cardThumbnailURL}}
+          @icon={{@model.constructor.icon}}
+          data-test-thumbnail-image
+        />
+        <div class='card-info-edit-fields card-info-edit-field-group'>
           <FieldContainer
             class='card-info-field'
-            @label='Thumbnail URL'
+            @label='Name'
             @tag='label'
-            @icon={{ImageIcon}}
-            data-test-field='cardInfo-thumbnailURL'
+            @labelFontSize='default'
+            @icon={{NameIcon}}
+            @vertical={{true}}
+            data-test-field='cardInfo-name'
           >
-            <div class='thumbnail-picker' data-thumbnail-picker-controls>
-              <div class='thumbnail-picker-inputs'>
-                <span
-                  class='thumbnail-picker-input-slot'
-                  data-test-thumbnail-input
-                >
-                  <@fields.cardInfo.cardThumbnailURL />
-                </span>
-                {{#if this.hasThumbnailUrl}}
-                  <IconButton
-                    class='thumbnail-picker-clear'
-                    @icon={{XIcon}}
-                    @width='16px'
-                    @height='16px'
-                    aria-label='Clear thumbnail'
-                    data-test-thumbnail-clear
-                    {{on 'click' this.clearThumbnail}}
-                  />
-                {{else if this.computedThumbnailFallback}}
-                  <span
-                    class='thumbnail-picker-placeholder'
-                    data-test-thumbnail-placeholder
-                    aria-hidden='true'
-                  >{{this.computedThumbnailFallback}}</span>
-                {{/if}}
-              </div>
-              {{#unless this.hasThumbnailUrl}}
-                <span class='thumbnail-picker-or'>or</span>
-                <Button
-                  @kind='secondary'
-                  @size='extra-small'
-                  data-test-thumbnail-select-image
-                  {{on 'click' this.selectThumbnailImage}}
-                >
-                  Select Image
-                </Button>
-              {{/unless}}
-            </div>
+            <@fields.cardInfo.name />
           </FieldContainer>
-          {{#unless @hideThemeChooser}}
-            <FieldContainer
-              class='card-info-field theme-field'
-              @label='Theme'
-              @icon={{ThemeIcon}}
-              data-test-field='cardInfo-theme'
-            >
-              <@fields.cardInfo.theme />
-            </FieldContainer>
-          {{/unless}}
+          <FieldContainer
+            class='card-info-field'
+            @label='Summary'
+            @tag='label'
+            @labelFontSize='default'
+            @icon={{SummaryIcon}}
+            @vertical={{true}}
+            data-test-field='cardInfo-summary'
+          >
+            <@fields.cardInfo.summary />
+          </FieldContainer>
         </div>
-      {{/if}}
+        <Button
+          class='card-info-thumbnail-popup-toggle'
+          @size='extra-small'
+          @kind='secondary-light'
+          {{on 'click' this.toggleThumbnailEditor}}
+          data-test-toggle-thumbnail-editor
+        >
+          Change
+          {{#unless @hideThemeChooser}}Theme & {{/unless}}Thumbnail
+        </Button>
+        {{#if this.isThumbnailEditorVisible}}
+          <div class='hidden-fields card-info-edit-field-group'>
+            <FieldContainer
+              class='card-info-field'
+              @label='Thumbnail URL'
+              @tag='label'
+              @icon={{ImageIcon}}
+              data-test-field='cardInfo-thumbnailURL'
+            >
+              <div class='thumbnail-picker' data-thumbnail-picker-controls>
+                <div class='thumbnail-picker-inputs'>
+                  <span
+                    class='thumbnail-picker-input-slot'
+                    data-test-thumbnail-input
+                  >
+                    <@fields.cardInfo.cardThumbnailURL />
+                  </span>
+                  {{#if this.hasThumbnailUrl}}
+                    <IconButton
+                      class='thumbnail-picker-clear'
+                      @icon={{XIcon}}
+                      @width='16px'
+                      @height='16px'
+                      aria-label='Clear thumbnail'
+                      data-test-thumbnail-clear
+                      {{on 'click' this.clearThumbnail}}
+                    />
+                  {{else if this.computedThumbnailFallback}}
+                    <span
+                      class='thumbnail-picker-placeholder'
+                      data-test-thumbnail-placeholder
+                      aria-hidden='true'
+                    >{{this.computedThumbnailFallback}}</span>
+                  {{/if}}
+                </div>
+                {{#unless this.hasThumbnailUrl}}
+                  <span class='thumbnail-picker-or'>or</span>
+                  <Button
+                    @kind='secondary'
+                    @size='extra-small'
+                    data-test-thumbnail-select-image
+                    {{on 'click' this.selectThumbnailImage}}
+                  >
+                    Select Image
+                  </Button>
+                {{/unless}}
+              </div>
+            </FieldContainer>
+            {{#unless @hideThemeChooser}}
+              <FieldContainer
+                class='card-info-field theme-field'
+                @label='Theme'
+                @icon={{ThemeIcon}}
+                data-test-field='cardInfo-theme'
+              >
+                <@fields.cardInfo.theme />
+              </FieldContainer>
+            {{/unless}}
+          </div>
+        {{/if}}
+      </div>
     </div>
     <style scoped>
-      .cardInfo-editor {
-        --thumbnail-container-size: 6.25rem;
+      .card-info-editor {
+        container-name: cardInfo-editor-template;
+        container-type: inline-size;
         position: relative;
         width: 100%;
         max-width: 100%;
       }
+
+      .card-info-preview-group {
+        display: grid;
+        gap: var(--boxel-sp-xs);
+      }
       .preview-toggle {
-        position: absolute;
-        top: calc(-1 * var(--boxel-sp-lg));
-        right: 0;
+        margin-left: auto;
         min-width: 10.5rem;
         justify-content: space-between;
       }
@@ -314,35 +316,55 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
       .is-preview-visible .preview-toggle-icon {
         transform: rotate(-90deg);
       }
-      .preview-toggle + .default-preview {
-        margin-top: var(--boxel-sp-lg);
-      }
-      .default-preview + .main-fields {
-        margin-top: var(--boxel-sp-lg);
-      }
       .default-preview {
+        display: grid;
+        gap: var(--boxel-sp);
+        margin-bottom: var(--boxel-sp-xl);
         padding: var(--boxel-sp-lg);
-        background-color: var(--accent, var(--boxel-200));
-        border-radius: var(--radius, var(--boxel-border-radius));
-        color: var(--accent-foreground, var(--boxel-dark));
+        background-color: var(--accent);
+        border-radius: var(--radius);
+        color: var(--accent-foreground);
       }
-      .cardInfo-thumbnail-container {
-        display: flex;
-        flex-direction: column;
+      .preview-field,
+      .preview-field > :deep(.label-container) {
+        --boxel-field-content-padding: 0;
+        min-height: unset;
+        padding-top: unset;
+      }
+
+      .card-info-fields {
+        --thumbnail-container-size: 6.25rem;
+        display: grid;
+        grid-template-areas:
+          'thumbnail name-summary'
+          'thumbnail-toggle name-summary'
+          'hidden-fields hidden-fields';
+        grid-template-columns:
+          var(--boxel-field-label-size, minmax(8rem, 25%))
+          1fr;
         align-items: center;
-        padding-right: var(--boxel-sp-xl);
+        justify-items: center;
       }
-      .cardInfo-thumbnail-preview {
-        border: 1px solid var(--border, var(--boxel-form-control-border-color));
+      .card-info-thumbnail-preview {
+        grid-area: thumbnail;
+        border: 1px solid var(--border);
       }
-      .cardInfo-thumbnail-popup-toggle {
-        margin-top: var(--boxel-sp-xs);
+      .card-info-thumbnail-popup-toggle {
+        grid-area: thumbnail-toggle;
+        max-width: 9.375rem;
+        padding-inline: var(--boxel-sp-xs);
       }
-      .card-info-field + .card-info-field {
-        margin-top: var(--boxel-sp-lg);
+      .card-info-edit-fields {
+        grid-area: name-summary;
       }
       .hidden-fields {
+        grid-area: hidden-fields;
         margin-top: var(--boxel-sp);
+      }
+      .card-info-edit-field-group {
+        width: 100%;
+        display: grid;
+        gap: var(--boxel-sp-lg);
       }
       .theme-field :deep(.links-to-editor .field-component-card) {
         min-height: var(--boxel-form-control-height);
@@ -408,6 +430,36 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
       .default-preview :deep([data-edit-preview-field='cardThumbnailURL']) {
         overflow-wrap: anywhere;
         min-width: 0;
+      }
+
+      @container cardInfo-editor-template (width < 425px) {
+        .card-info-preview-group {
+          margin-bottom: var(--boxel-sp);
+        }
+        .default-preview {
+          margin-bottom: 0;
+        }
+        .card-info-fields {
+          --thumbnail-container-size: 4.375rem;
+          grid-template-columns: var(--thumbnail-container-size) 1fr;
+          gap: var(--boxel-sp-sm);
+          align-items: flex-end;
+        }
+        .card-info-edit-field-group {
+          gap: var(--boxel-sp-xs);
+        }
+        .card-info-thumbnail-popup-toggle {
+          align-self: start;
+          max-width: var(--thumbnail-container-size);
+          min-width: unset;
+          padding-inline: 0;
+          border-radius: var(--boxel-border-radius-sm);
+          font-size: 0.6875rem;
+        }
+        .card-info-thumbnail-preview :deep(.icon) {
+          width: 1.25rem;
+          height: 1.25rem;
+        }
       }
     </style>
   </template>

--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -235,7 +235,6 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
             <FieldContainer
               class='card-info-field'
               @label='Thumbnail URL'
-              @tag='label'
               @icon={{ImageIcon}}
               data-test-field='cardInfo-thumbnailURL'
             >
@@ -330,6 +329,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
         --boxel-field-content-padding: 0;
         min-height: unset;
         padding-top: unset;
+        padding-right: var(--boxel-sp-4xs);
       }
 
       .card-info-fields {

--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -352,6 +352,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
       .card-info-thumbnail-popup-toggle {
         grid-area: thumbnail-toggle;
         max-width: 9.375rem;
+        margin-inline: var(--boxel-sp-xs);
         padding-inline: var(--boxel-sp-xs);
       }
       .card-info-edit-fields {
@@ -452,6 +453,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
           align-self: start;
           max-width: var(--thumbnail-container-size);
           min-width: unset;
+          margin-inline: 0;
           padding-inline: 0;
           border-radius: var(--boxel-border-radius-sm);
           font-size: 0.6875rem;

--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -294,7 +294,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
     </div>
     <style scoped>
       .card-info-editor {
-        container-name: cardInfo-editor-template;
+        container-name: card-info-editor-template;
         container-type: inline-size;
         position: relative;
         width: 100%;
@@ -433,7 +433,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
         min-width: 0;
       }
 
-      @container cardInfo-editor-template (width < 425px) {
+      @container card-info-editor-template (width < 425px) {
         .card-info-preview-group {
           margin-bottom: var(--boxel-sp);
         }

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -192,34 +192,6 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
           min-height: unset;
         }
       }
-      /* this aligns edit fields with containsMany, linksTo, and linksToMany fields */
-      .default-card-template--inner.edit
-        > :is(.own-display-fields, .notes-footer)
-        > :deep(
-          .boxel-field
-            > .content
-            > *:not(.links-to-many-editor):not(.contains-many-editor):not(
-              .links-to-editor
-            )
-        ) {
-        padding-right: var(--boxel-icon-lg);
-      }
-      .default-card-template--inner.edit
-        > :is(.own-display-fields, .notes-footer)
-        > :deep(
-          .boxel-field
-            > .content
-            > *:not(.links-to-many-editor):not(.contains-many-editor)
-        ) {
-        padding-left: var(--boxel-icon-lg);
-      }
-      /* Add padding for readonly fields */
-      .default-card-template--inner.edit
-        > :is(.own-display-fields, .notes-footer)
-        > :deep(.boxel-field > .content .read-only) {
-        padding-left: var(--boxel-icon-lg);
-        padding-right: var(--boxel-icon-lg);
-      }
       .in-isolated.field-component-card.fitted-format {
         min-height: 65px;
       }

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -61,58 +61,63 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
       class={{cn 'default-card-template' @format}}
       data-test-base-template={{@format}}
     >
-      <Header @hasBottomBorder={{true}} class='card-info-header'>
-        {{#if (eq @format 'isolated')}}
-          <CardInfoTemplates.view
-            @cardTitle={{@model.cardTitle}}
-            @cardDescription={{@model.cardDescription}}
-            @cardThumbnailURL={{@model.cardThumbnailURL}}
-            @icon={{@model.constructor.icon}}
-          />
-        {{else}}
-          <CardInfoTemplates.edit
-            @fields={{@fields}}
-            @model={{@model}}
-            @hideThemeChooser={{this.isThemeCard}}
-          />
+      <div class={{cn 'default-card-template--inner' @format}}>
+        <Header @hasBottomBorder={{true}} class='card-info-header'>
+          {{#if (eq @format 'isolated')}}
+            <CardInfoTemplates.view
+              @cardTitle={{@model.cardTitle}}
+              @cardDescription={{@model.cardDescription}}
+              @cardThumbnailURL={{@model.cardThumbnailURL}}
+              @icon={{@model.constructor.icon}}
+            />
+          {{else}}
+            <CardInfoTemplates.edit
+              @fields={{@fields}}
+              @model={{@model}}
+              @hideThemeChooser={{this.isThemeCard}}
+            />
+          {{/if}}
+        </Header>
+        {{#if this.displayFields}}
+          <section class='own-display-fields'>
+            {{#each-in this.displayFields as |key Field|}}
+              <FieldContainer
+                @label={{startCase key}}
+                @icon={{getFieldIcon @model key}}
+                data-test-field={{key}}
+              >
+                <Field class='in-isolated' />
+              </FieldContainer>
+            {{/each-in}}
+          </section>
         {{/if}}
-      </Header>
-      {{#if this.displayFields}}
-        <section class='own-display-fields'>
-          {{#each-in this.displayFields as |key Field|}}
-            <FieldContainer
-              @label={{startCase key}}
-              @icon={{getFieldIcon @model key}}
-              data-test-field={{key}}
-            >
-              <Field class='in-isolated' />
-            </FieldContainer>
-          {{/each-in}}
-        </section>
-      {{/if}}
-      <footer class='notes-footer'>
-        <FieldContainer
-          @label='Notes'
-          @icon={{getFieldIcon @model.cardInfo 'notes'}}
-          data-test-field='cardInfo-notes'
-        >
-          <@fields.cardInfo.notes />
-        </FieldContainer>
-      </footer>
+        <footer class='notes-footer'>
+          <FieldContainer
+            @label='Notes'
+            @icon={{getFieldIcon @model.cardInfo 'notes'}}
+            data-test-field='cardInfo-notes'
+          >
+            <@fields.cardInfo.notes />
+          </FieldContainer>
+        </footer>
+      </div>
     </div>
     <style scoped>
       .default-card-template {
-        --hr-color: rgba(0 0 0 / 10%);
+        container-name: default-template;
+        container-type: inline-size;
+      }
+      .default-card-template--inner {
+        --boxel-default-template-padding: var(--boxel-sp-xl);
+        --boxel-default-template-hr-color: rgba(0 0 0 / 10%);
         display: grid;
       }
       .card-info-header {
         --boxel-header-min-height: 9.375rem; /* 150px */
-        --boxel-header-padding: var(--boxel-sp-xxl) var(--boxel-sp-xl)
-          var(--boxel-sp-xl);
+        --boxel-header-padding: var(--boxel-default-template-padding);
         --boxel-header-gap: var(--boxel-sp-lg);
-        --boxel-header-border-color: var(--hr-color);
-        align-items: flex-start;
-        background-color: var(--muted, var(--boxel-100));
+        --boxel-header-border-color: var(--boxel-default-template-hr-color);
+        background-color: var(--muted);
       }
       .card-info-header :deep(.info) {
         align-self: center;
@@ -123,14 +128,14 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
       .own-display-fields {
         display: grid;
         gap: var(--boxel-sp-lg);
-        padding: var(--boxel-sp-xl);
-        background-color: var(--background, var(--boxel-light));
+        padding: var(--boxel-default-template-padding);
+        background-color: var(--background);
       }
       .own-display-fields + .notes-footer {
-        border-top: 1px solid var(--hr-color);
+        border-top: 1px solid var(--boxel-default-template-hr-color);
       }
       .notes-footer {
-        padding: var(--boxel-sp-xl);
+        padding: var(--boxel-default-template-padding);
       }
       .tags {
         display: flex;
@@ -139,22 +144,20 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
         margin-top: var(--boxel-sp-xs);
       }
       .default-card-template.edit > .notes-footer {
-        background-color: var(--muted, var(--boxel-100));
-      }
-      .default-card-template.edit {
-        container-name: default-edit-template;
-        container-type: inline-size;
+        background-color: var(--muted);
       }
       /* stack field labels above their inputs when the template is narrow */
-      @container default-edit-template (width < 400px) {
-        .default-card-template.edit :deep(.boxel-field.horizontal) {
+      @container default-template (width < 425px) {
+        .default-card-template--inner {
+          --boxel-default-template-padding: var(--boxel-sp);
+        }
+        :deep(.boxel-field.horizontal:not(.theme-field)) {
           grid-template-columns: 1fr;
           grid-template-rows: auto 1fr;
-          gap: var(--boxel-sp-4xs);
+          gap: var(--boxel-sp-xs);
           min-height: unset;
         }
-        .default-card-template.edit
-          :deep(.boxel-field.horizontal > .label-container) {
+        :deep(.boxel-field.horizontal:not(.theme-field) > .label-container) {
           padding-top: 0;
         }
       }

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -141,6 +141,23 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
       .default-card-template.edit > .notes-footer {
         background-color: var(--muted, var(--boxel-100));
       }
+      .default-card-template.edit {
+        container-name: default-edit-template;
+        container-type: inline-size;
+      }
+      /* stack field labels above their inputs when the template is narrow */
+      @container default-edit-template (width < 400px) {
+        .default-card-template.edit :deep(.boxel-field.horizontal) {
+          grid-template-columns: 1fr;
+          grid-template-rows: auto 1fr;
+          gap: var(--boxel-sp-4xs);
+          min-height: unset;
+        }
+        .default-card-template.edit
+          :deep(.boxel-field.horizontal > .label-container) {
+          padding-top: 0;
+        }
+      }
       /* this aligns edit fields with containsMany, linksTo, and linksToMany fields */
       .default-card-template.edit
         > :deep(

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -7,6 +7,7 @@ import {
   getFieldIcon,
   getField,
   cardDefComputedFields,
+  primitive,
 } from '@cardstack/runtime-common';
 import CardInfoTemplates from './card-info';
 
@@ -50,6 +51,22 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
     return Object.fromEntries(fields) as FieldsTypeFor<CardDef>;
   }
 
+  // A field can safely render inside a <label> only when its editor is a
+  // single form control: compound and linked editors contain buttons that an
+  // implicit label association would activate when the label text is clicked,
+  // and computed fields render a read-only view with no control to label.
+  private editFieldTag = (fieldName: string): 'label' | undefined => {
+    if (this.args.format !== 'edit') {
+      return undefined;
+    }
+    let field = getField(this.args.model.constructor, fieldName);
+    return field?.fieldType === 'contains' &&
+      !field.computeVia &&
+      primitive in field.card
+      ? 'label'
+      : undefined;
+  };
+
   private get isThemeCard() {
     return Boolean(
       Object.entries(this.args.fields).find(([key]) => key === 'cssVariables'),
@@ -84,6 +101,7 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
               <FieldContainer
                 @label={{startCase key}}
                 @icon={{getFieldIcon @model key}}
+                @tag={{this.editFieldTag key}}
                 data-test-field={{key}}
               >
                 <Field class='in-isolated' />
@@ -95,6 +113,7 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
           <FieldContainer
             @label='Notes'
             @icon={{getFieldIcon @model.cardInfo 'notes'}}
+            @tag={{if (eq @format 'edit') 'label'}}
             data-test-field='cardInfo-notes'
           >
             <@fields.cardInfo.notes />
@@ -171,6 +190,7 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
       }
       .default-card-template.isolated
         :deep(.boxel-field.horizontal:not(.theme-field) > .content) {
+        --boxel-outline-width: 0;
         align-self: start;
       }
       /* below the label min-width (8rem) plus the content flex-basis (14rem)

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -163,6 +163,16 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
         flex: 1 1 14rem;
         min-width: 0;
       }
+      /* isolated fields render text rather than form controls: align the
+         label with the top of the content instead of an input's first line */
+      .default-card-template.isolated
+        :deep(.boxel-field.horizontal:not(.theme-field) > .label-container) {
+        padding-top: 0;
+      }
+      .default-card-template.isolated
+        :deep(.boxel-field.horizontal:not(.theme-field) > .content) {
+        align-self: start;
+      }
       /* below the label min-width (8rem) plus the content flex-basis (14rem)
          the label wraps above the input: give it the full line so its text
          doesn't wrap inside the label column, and drop the padding that

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -143,7 +143,7 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
         gap: var(--boxel-sp-xs);
         margin-top: var(--boxel-sp-xs);
       }
-      .default-card-template.edit > .notes-footer {
+      .default-card-template--inner.edit > .notes-footer {
         background-color: var(--muted);
       }
       /* keep field labels beside their inputs, wrapping the label above the

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -146,19 +146,37 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
       .default-card-template.edit > .notes-footer {
         background-color: var(--muted);
       }
-      /* stack field labels above their inputs when the template is narrow */
+      /* keep field labels beside their inputs, wrapping the label above the
+         input only when the field's content area gets too narrow */
+      :deep(.boxel-field.horizontal:not(.theme-field)) {
+        display: flex;
+        flex-wrap: wrap;
+        row-gap: var(--boxel-sp-xs);
+        container-name: horizontal-field;
+        container-type: inline-size;
+      }
+      :deep(.boxel-field.horizontal:not(.theme-field) > .label-container) {
+        flex: 0 0 25%;
+        min-width: 8rem;
+      }
+      :deep(.boxel-field.horizontal:not(.theme-field) > .content) {
+        flex: 1 1 14rem;
+        min-width: 0;
+      }
+      /* below the label min-width (8rem) plus the content flex-basis (14rem)
+         the label has wrapped above the input, so drop the padding that
+         aligns it with the input's first line */
+      @container horizontal-field (width < 22rem) {
+        :deep(.label-container) {
+          padding-top: 0;
+        }
+      }
       @container default-template (width < 425px) {
         .default-card-template--inner {
           --boxel-default-template-padding: var(--boxel-sp);
         }
         :deep(.boxel-field.horizontal:not(.theme-field)) {
-          grid-template-columns: 1fr;
-          grid-template-rows: auto 1fr;
-          gap: var(--boxel-sp-xs);
           min-height: unset;
-        }
-        :deep(.boxel-field.horizontal:not(.theme-field) > .label-container) {
-          padding-top: 0;
         }
       }
       /* this aligns edit fields with containsMany, linksTo, and linksToMany fields */

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -164,10 +164,12 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
         min-width: 0;
       }
       /* below the label min-width (8rem) plus the content flex-basis (14rem)
-         the label has wrapped above the input, so drop the padding that
+         the label wraps above the input: give it the full line so its text
+         doesn't wrap inside the label column, and drop the padding that
          aligns it with the input's first line */
       @container horizontal-field (width < 22rem) {
-        :deep(.label-container) {
+        :deep(.boxel-field.horizontal:not(.theme-field) > .label-container) {
+          flex-basis: 100%;
           padding-top: 0;
         }
       }

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -7,7 +7,6 @@ import {
   getFieldIcon,
   getField,
   cardDefComputedFields,
-  primitive,
 } from '@cardstack/runtime-common';
 import CardInfoTemplates from './card-info';
 
@@ -51,22 +50,6 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
     return Object.fromEntries(fields) as FieldsTypeFor<CardDef>;
   }
 
-  // A field can safely render inside a <label> only when its editor is a
-  // single form control: compound and linked editors contain buttons that an
-  // implicit label association would activate when the label text is clicked,
-  // and computed fields render a read-only view with no control to label.
-  private editFieldTag = (fieldName: string): 'label' | undefined => {
-    if (this.args.format !== 'edit') {
-      return undefined;
-    }
-    let field = getField(this.args.model.constructor, fieldName);
-    return field?.fieldType === 'contains' &&
-      !field.computeVia &&
-      primitive in field.card
-      ? 'label'
-      : undefined;
-  };
-
   private get isThemeCard() {
     return Boolean(
       Object.entries(this.args.fields).find(([key]) => key === 'cssVariables'),
@@ -101,7 +84,6 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
               <FieldContainer
                 @label={{startCase key}}
                 @icon={{getFieldIcon @model key}}
-                @tag={{this.editFieldTag key}}
                 data-test-field={{key}}
               >
                 <Field class='in-isolated' />
@@ -113,7 +95,6 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
           <FieldContainer
             @label='Notes'
             @icon={{getFieldIcon @model.cardInfo 'notes'}}
-            @tag={{if (eq @format 'edit') 'label'}}
             data-test-field='cardInfo-notes'
           >
             <@fields.cardInfo.notes />

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -193,7 +193,8 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
         }
       }
       /* this aligns edit fields with containsMany, linksTo, and linksToMany fields */
-      .default-card-template.edit
+      .default-card-template--inner.edit
+        > :is(.own-display-fields, .notes-footer)
         > :deep(
           .boxel-field
             > .content
@@ -203,7 +204,8 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
         ) {
         padding-right: var(--boxel-icon-lg);
       }
-      .default-card-template.edit
+      .default-card-template--inner.edit
+        > :is(.own-display-fields, .notes-footer)
         > :deep(
           .boxel-field
             > .content
@@ -212,7 +214,9 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
         padding-left: var(--boxel-icon-lg);
       }
       /* Add padding for readonly fields */
-      .default-card-template.edit > :deep(.boxel-field > .content .read-only) {
+      .default-card-template--inner.edit
+        > :is(.own-display-fields, .notes-footer)
+        > :deep(.boxel-field > .content .read-only) {
         padding-left: var(--boxel-icon-lg);
         padding-right: var(--boxel-icon-lg);
       }

--- a/packages/base/realm-config.gts
+++ b/packages/base/realm-config.gts
@@ -374,30 +374,29 @@ class RealmConfigEdit extends Component<typeof RealmConfig> {
     </div>
     <style scoped>
       .realm-config-edit {
-        --hr-color: rgba(0 0 0 / 10%);
+        --realm-config-padding: var(--boxel-sp-xl);
+        --realm-config-hr-color: rgba(0 0 0 / 10%);
         display: grid;
       }
       .card-info-header {
         --boxel-header-min-height: 9.375rem;
-        --boxel-header-padding: var(--boxel-sp-xxl) var(--boxel-sp-xl)
-          var(--boxel-sp-xl);
+        --boxel-header-padding: var(--realm-config-padding);
         --boxel-header-gap: var(--boxel-sp-lg);
-        --boxel-header-border-color: var(--hr-color);
-        align-items: flex-start;
-        background-color: var(--muted, var(--boxel-100));
+        --boxel-header-border-color: var(--realm-config-hr-color);
+        background-color: var(--muted);
       }
       .own-display-fields {
         display: grid;
         gap: var(--boxel-sp-lg);
-        padding: var(--boxel-sp-xl);
-        background-color: var(--background, var(--boxel-light));
+        padding: var(--realm-config-padding);
+        background-color: var(--background);
       }
       .own-display-fields + .notes-footer {
-        border-top: 1px solid var(--hr-color);
+        border-top: 1px solid var(--realm-config-hr-color);
       }
       .notes-footer {
-        padding: var(--boxel-sp-xl);
-        background-color: var(--muted, var(--boxel-100));
+        padding: var(--realm-config-padding);
+        background-color: var(--muted);
       }
       .warning {
         background: #fef3c7;

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -2348,6 +2348,40 @@ module('Integration | card-basics', function (hooks) {
       assert.dom('[data-test-edit-preview]').doesNotExist();
     });
 
+    test('edit format wraps only simple contained fields in a label element', async function (assert) {
+      class Pet extends CardDef {}
+      class PetPerson extends CardDef {
+        @field nickname = contains(StringField);
+        @field aliases = containsMany(StringField);
+        @field pet = linksTo(Pet);
+        @field greeting = contains(StringField, {
+          computeVia: function (this: PetPerson) {
+            return `Hi ${this.nickname}`;
+          },
+        });
+      }
+      loader.shimModule(`${testRealmURL}test-cards`, { PetPerson, Pet });
+
+      let instance = new PetPerson({ nickname: 'Bee' });
+      await renderCard(loader, instance, 'edit');
+
+      // a <label> wrapper is only safe when the editor is a single form
+      // control: compound and linked editors contain buttons that an implicit
+      // label association would activate when the label text is clicked
+      assert
+        .dom('[data-test-field="nickname"]')
+        .hasTagName('label', 'primitive contains field is a label');
+      assert
+        .dom('[data-test-field="aliases"]')
+        .hasTagName('div', 'containsMany field is not a label');
+      assert
+        .dom('[data-test-field="pet"]')
+        .hasTagName('div', 'linksTo field is not a label');
+      assert
+        .dom('[data-test-field="greeting"]')
+        .hasTagName('div', 'computed field is not a label');
+    });
+
     test('render card-def instance with cardInfo overrides', async function (assert) {
       class Team extends CardDef {}
       class Person extends CardDef {

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -2348,40 +2348,6 @@ module('Integration | card-basics', function (hooks) {
       assert.dom('[data-test-edit-preview]').doesNotExist();
     });
 
-    test('edit format wraps only simple contained fields in a label element', async function (assert) {
-      class Pet extends CardDef {}
-      class PetPerson extends CardDef {
-        @field nickname = contains(StringField);
-        @field aliases = containsMany(StringField);
-        @field pet = linksTo(Pet);
-        @field greeting = contains(StringField, {
-          computeVia: function (this: PetPerson) {
-            return `Hi ${this.nickname}`;
-          },
-        });
-      }
-      loader.shimModule(`${testRealmURL}test-cards`, { PetPerson, Pet });
-
-      let instance = new PetPerson({ nickname: 'Bee' });
-      await renderCard(loader, instance, 'edit');
-
-      // a <label> wrapper is only safe when the editor is a single form
-      // control: compound and linked editors contain buttons that an implicit
-      // label association would activate when the label text is clicked
-      assert
-        .dom('[data-test-field="nickname"]')
-        .hasTagName('label', 'primitive contains field is a label');
-      assert
-        .dom('[data-test-field="aliases"]')
-        .hasTagName('div', 'containsMany field is not a label');
-      assert
-        .dom('[data-test-field="pet"]')
-        .hasTagName('div', 'linksTo field is not a label');
-      assert
-        .dom('[data-test-field="greeting"]')
-        .hasTagName('div', 'computed field is not a label');
-    });
-
     test('render card-def instance with cardInfo overrides', async function (assert) {
       class Team extends CardDef {}
       class Person extends CardDef {


### PR DESCRIPTION
**Summary**

Improves how the default isolated/edit template lays out field labels at narrow widths, and reworks the card-info editor.

- **Per-field label wrapping.** Horizontal field rows now use `flex-wrap` instead of a fixed 425px breakpoint: a label stays beside its input until the field's content area would drop below 14rem, then wraps above it. Each field decides from its own available space, so nested fields and edit-format padding are handled automatically. A per-field container query keeps the stacked state in sync with the wrap point — wrapped labels take the full line (no text wrapping inside the label column) and drop the input-alignment padding.
- **Isolated-format label alignment.** Isolated fields render text rather than form controls, so the label no longer carries the input-alignment padding there; labels now align with the top of their content.
- **Card-info editor rework.** Adds a collapsible "Default Preview" section showing the card type and computed cardInfo fields as atoms, a thumbnail preview with a combined theme/thumbnail editor toggle, and a thumbnail URL picker with clear button and image-selection fallback. The editor adapts its layout below 425px.
- Reverted: ~- **Semantic `<label>` wrappers, safely gated.** Edit-format fields whose editor is a single form control (primitive, non-computed contains fields) render inside a `<label>`. Compound and linked editors keep a `div` — an implicit label association would forward label clicks to their first button (e.g. remove on a linksTo field). Covered by a new integration test.~


## Screenshots

Note: Please pay attention to before & after of standard field, linked field, compound field for edit and isolated templates, and provide your opinion. I kept the cardInfo section horizontally oriented with some vertical fields, but made it more compact.

## A. Edit View (Standard Template):

Before & After:

<img width="350" height="auto" alt="cs-11384-before-edit" src="https://github.com/user-attachments/assets/6a95aef5-db1f-4521-934e-785771070df0" /><img width="350" height="auto" alt="cs-11384-after-edit-1b" src="https://github.com/user-attachments/assets/20f1824b-84ff-4b48-b5eb-3fb1da13fd2d" />

<img width="350" height="auto" alt="cs-11384-before-edit-2" src="https://github.com/user-attachments/assets/11b08610-d72c-4d53-a000-c30a40edbd4e" /><img width="350" height="auto" alt="cs-11384-after-edit-2" src="https://github.com/user-attachments/assets/477b7552-8a86-4b65-8cee-9e2e7ebebca2" />

<img width="350" height="auto" alt="cs-11384-compound-edit-before" src="https://github.com/user-attachments/assets/96059526-387f-42da-8548-1668068e4e15" /><img width="350" height="auto" alt="cs-11384-compound-edit-after" src="https://github.com/user-attachments/assets/0365b521-9660-405f-b42b-ecfe8a4a4094" />

## B. Isolated View (Standard Template):

Before & After:
<img width="350" height="auto" alt="iso-before-1" src="https://github.com/user-attachments/assets/e39e5ace-962c-41f4-8200-4f3cf390a09c" /><img width="350" height="auto" alt="cs-11384-after-isolated-1" src="https://github.com/user-attachments/assets/9032b9f9-2c50-4f09-83c8-32f888295c19" />

<img width="350" height="auto" alt="cs-11384-before-isolated-2" src="https://github.com/user-attachments/assets/df597364-1f05-4380-bce1-cb8bcaebad43" /><img width="350" height="auto" alt="cs-11384-after-isolated-2" src="https://github.com/user-attachments/assets/9eac7488-3e69-467b-a7f8-016139517cf4" />

<img width="350" height="auto" alt="cs-11384-compound-iso-before" src="https://github.com/user-attachments/assets/987c301a-8a01-4ea8-a106-a3a13c25fc6f" /><img width="350" height="auto" alt="cs-11384-compound-iso-after" src="https://github.com/user-attachments/assets/cdd9e892-1610-48a4-a51e-69d6c49b5c42" />