### PR TITLE
Fuse the index visit's meta and file-extract into one render transition

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -1244,12 +1244,12 @@ LIMIT 20;
 
 The index visit runs at most three route steps, and `indexRoutesMs` records each one's wall-clock, split by the card indexing and the FileDef file indexing (the index-half sibling of the render channel's `renderFormatsMs`):
 
-- **`card.meta`** — the `render.meta` route: instantiate the card, run computeds, build the search doc, and resolve `types` / `displayNames` / `deps`. The types chain is a prototype-chain walk inside this route, not a step of its own — its cost is inside this number. `serializeMs` / `searchDocMs` / `searchDocSettleMs` break the _doc build_ out of it (Mode J); the remainder of `card.meta` is the route's own transition + settle.
+- **`card.meta`** — the `render.meta` route: instantiate the card, run computeds, build the search doc, and resolve `types` / `displayNames` / `deps`. The types chain is a prototype-chain walk inside this route, not a step of its own — its cost is inside this number. On a card-instance index visit this is the **fused** transition: it also performs the file row's extract, whose share is itemized as `diagnostics.fileExtractMs`. `serializeMs` / `searchDocMs` / `searchDocSettleMs` break the _doc build_ out of it (Mode J); the remainder of `card.meta` net of `fileExtractMs` is the route's own transition + settle.
 - **`card.icon`** — the `render.icon` route. Present only when the icon route actually ran; **absent when the per-type icon memo served the icon**, since a memo hit renders nothing and costs ~0 this visit. So across one job's cards of a given type, expect `card.icon` on the first card of the type and none on the rest.
-- **`file.fileExtract`** — the `render.file-extract` route: the file's resource, types, and deps.
+- **`file.fileExtract`** — a standalone `render.file-extract` route transition: the file's resource, types, and deps. Present on non-card files (they have no card side to fuse into), on the fallback extract a card render error triggers, and on a prerender-html visit that self-resolves its file resource. **Absent on a card-instance visit's happy path** — there the extract runs inside the fused `card.meta` transition and shows up as `fileExtractMs` instead.
 - **`file.icon`** — the file's `render.icon` route, same memo behavior as `card.icon`.
 
-`meta` and `icon` are the card's routes; `fileExtract` and `icon` are the file's. A card-instance `.json` produces both a `card` block (from the instance visit) and a `file` block (from the FileDef visit) in the same visit.
+`meta` and `icon` are the card's routes; `fileExtract` and `icon` are the file's. A card-instance `.json` produces both a `card` block and a `file` block from the same visit: the instance row's payload and the file row's extract both come out of the one fused `card.meta` transition, while `file.icon` still records when the file icon renders.
 
 **The residual is the plumbing.** `indexRoutesMs`'s numbers sum to less than `renderElapsedMs`; the gap is the inter-route machinery (route transitions, instantiation, settle handoffs) — the part of the floor that isn't a route step. On a trivial card that residual, plus `card.meta` net of its (near-zero) doc build, _is_ the floor.
 
@@ -1281,7 +1281,7 @@ A row here with a large `render_ms`, a near-zero doc cost, and a `meta_ms` that'
 ```sql
 SELECT
   diagnostics->'indexRoutesMs'->'card' AS card_routes,   -- {"meta":…, "icon":…}
-  diagnostics->'indexRoutesMs'->'file' AS file_routes,   -- {"fileExtract":…, "icon":…}
+  diagnostics->'indexRoutesMs'->'file' AS file_routes,   -- {"icon":…} on a card row (extract fused into meta); {"fileExtract":…, "icon":…} where a standalone extract ran
   (diagnostics->>'renderElapsedMs')::int AS render_ms
 FROM boxel_index
 WHERE url = '<card-url>' AND type = 'instance';

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -29,6 +29,7 @@ import {
   type RunCommandArgs,
   type RunCommandResponse,
   type Format,
+  type FusedIndexMeta,
   type PrerenderMeta,
   type RenderRouteOptions,
   VISIT_PASS_ORDER,
@@ -206,10 +207,11 @@ export default class CardPrerender extends Component {
   // Composite visit task — runs the caller-selected subset of
   // {fileExtract, cardRender, fileRender} on a shared nonce and with a single
   // clearCache consumption. Mirrors the server-side prerenderVisitAttempt,
-  // including its visitType bifurcation: an 'index' visit runs the extract,
-  // the card's meta + icon and the file's icon — never an html-format
-  // render; a 'prerender-html' visit runs only the html formats + markdown.
-  // No visitType runs the fused union.
+  // including its visitType bifurcation: an 'index' visit of a card instance
+  // runs the fused meta entry (which carries the file extract) plus the
+  // card's and the file's icons — never an html-format render; a non-card
+  // index visit runs the standalone extract; a 'prerender-html' visit runs
+  // only the html formats + markdown. No visitType runs the fused union.
   private prerenderVisitTask = enqueueTask(
     async ({
       url,
@@ -237,6 +239,15 @@ export default class CardPrerender extends Component {
         cardRender: Boolean(baseOptions.cardRender),
         fileRender: Boolean(baseOptions.fileRender),
       };
+      // A card-instance index visit fuses the extract into the render.meta
+      // entry — one route entry produces both the instance row and the file
+      // row — mirroring the server-side runner. No capability probe is
+      // needed: this driver and the render routes ship in the same build.
+      let fusedIndexPass =
+        visitType === 'index' && requested.cardRender && requested.fileExtract;
+      if (fusedIndexPass) {
+        requested.fileExtract = false;
+      }
       if (shouldClearCache) {
         this.loaderService.resetLoader({
           clearFetchCache: true,
@@ -246,12 +257,17 @@ export default class CardPrerender extends Component {
       }
       let clearCacheConsumed = !shouldClearCache;
       let optionsForPass = (
-        pass: 'fileExtract' | 'cardRender' | 'fileRender',
+        pass: 'fileExtract' | 'cardRender' | 'fileRender' | 'fusedIndex',
       ): RenderRouteOptions => {
         let out: RenderRouteOptions = {
           ...baseOptions,
-          fileExtract: pass === 'fileExtract' ? true : undefined,
-          cardRender: pass === 'cardRender' ? true : undefined,
+          // The fused index pass carries both flags — the render route
+          // serves it from the card branch and folds the file extract into
+          // the render.meta payload.
+          fileExtract:
+            pass === 'fileExtract' || pass === 'fusedIndex' ? true : undefined,
+          cardRender:
+            pass === 'cardRender' || pass === 'fusedIndex' ? true : undefined,
           fileRender: pass === 'fileRender' ? true : undefined,
         };
         if (!clearCacheConsumed) {
@@ -275,8 +291,15 @@ export default class CardPrerender extends Component {
       // is explicit below.
       void VISIT_PASS_ORDER;
 
-      // ── fileExtract pass ───────────────────────────────────────────────
-      if (requested.fileExtract) {
+      // Runs a standalone render.file-extract route entry and stores its
+      // result on `response.fileExtract`. Serves the fileExtract pass and
+      // the fused-index fallback (a card render error must still yield a
+      // file row). Self-contained: bumps the nonce and clears any earlier
+      // pass's render error so it keys and captures independently of
+      // whatever ran before it.
+      let runFileExtractPass = async () => {
+        this.#nonce++;
+        this.localIndexer.renderError = undefined;
         let passOptions = optionsForPass('fileExtract');
         try {
           let routeInfo = await this.router.recognizeAndLoad(
@@ -321,6 +344,11 @@ export default class CardPrerender extends Component {
           // behaves the same way — only genuine page-unusable conditions
           // (eviction, auth failure) short-circuit the visit.
         }
+      };
+
+      // ── fileExtract pass ───────────────────────────────────────────────
+      if (requested.fileExtract) {
+        await runFileExtractPass();
       }
 
       // ── cardRender pass ────────────────────────────────────────────────
@@ -337,7 +365,9 @@ export default class CardPrerender extends Component {
         this.#currentContext = context;
         this.localIndexer.renderError = undefined;
         this.localIndexer.prerenderStatus = 'loading';
-        let initialRenderOptions = optionsForPass('cardRender');
+        let initialRenderOptions = optionsForPass(
+          fusedIndexPass ? 'fusedIndex' : 'cardRender',
+        );
         let cardError: RenderError | undefined;
         let isolatedHTML: string | null = null;
         let headHTML: string | null = null;
@@ -377,10 +407,18 @@ export default class CardPrerender extends Component {
             }
           }
           if (runIndexSteps) {
-            meta = await this.renderMeta.perform(
+            let metaResult = (await this.renderMeta.perform(
               url,
               runHtmlSteps ? subsequentRenderOptions : initialRenderOptions,
-            );
+            )) as FusedIndexMeta;
+            // Split the extract off before `meta` is spread into
+            // `response.card` below — the card row's payload must never
+            // carry the file half.
+            let { fileExtract: fusedExtract, ...cardMeta } = metaResult;
+            meta = cardMeta;
+            if (fusedExtract) {
+              response.fileExtract = fusedExtract;
+            }
           }
           if (runHtmlSteps) {
             headHTML = await this.renderHTML.perform(
@@ -483,6 +521,15 @@ export default class CardPrerender extends Component {
           markdown,
           ...(cardError ? { error: cardError } : {}),
         };
+
+        // ── fused-extract fallback ─────────────────────────────────────
+        // A fused index pass carries the file extract inside render.meta,
+        // so a card render error leaves the file half missing. Run the
+        // standalone extract entry — a broken card must still yield a good
+        // file row.
+        if (fusedIndexPass && !response.fileExtract) {
+          await runFileExtractPass();
+        }
       }
 
       // ── fileRender pass ────────────────────────────────────────────────

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -410,11 +410,14 @@ export default class CardPrerender extends Component {
             let metaResult = (await this.renderMeta.perform(
               url,
               runHtmlSteps ? subsequentRenderOptions : initialRenderOptions,
-            )) as FusedIndexMeta;
+            )) as FusedIndexMeta | undefined;
             // Split the extract off before `meta` is spread into
             // `response.card` below — the card row's payload must never
-            // carry the file half.
-            let { fileExtract: fusedExtract, ...cardMeta } = metaResult;
+            // carry the file half. The meta route's abort path resolves
+            // with no payload; falling back to the empty meta keeps that
+            // producing an empty card payload rather than a throw.
+            let { fileExtract: fusedExtract, ...cardMeta } = (metaResult ??
+              meta) as FusedIndexMeta;
             meta = cardMeta;
             if (fusedExtract) {
               response.fileExtract = fusedExtract;

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -205,13 +205,15 @@ export default class CardPrerender extends Component {
   );
 
   // Composite visit task — runs the caller-selected subset of
-  // {fileExtract, cardRender, fileRender} on a shared nonce and with a single
-  // clearCache consumption. Mirrors the server-side prerenderVisitAttempt,
-  // including its visitType bifurcation: an 'index' visit of a card instance
-  // runs the fused meta entry (which carries the file extract) plus the
-  // card's and the file's icons — never an html-format render; a non-card
-  // index visit runs the standalone extract; a 'prerender-html' visit runs
-  // only the html formats + markdown. No visitType runs the fused union.
+  // {fileExtract, cardRender, fileRender} in one visit with a single
+  // clearCache consumption; each pass takes its own nonce so the render
+  // route's model cache keys them distinctly. Mirrors the server-side
+  // prerenderVisitAttempt, including its visitType bifurcation: an 'index'
+  // visit of a card instance runs the fused meta entry (which carries the
+  // file extract) plus the card's and the file's icons — never an
+  // html-format render; a non-card index visit runs the standalone extract;
+  // a 'prerender-html' visit runs only the html formats + markdown. No
+  // visitType runs the fused union.
   private prerenderVisitTask = enqueueTask(
     async ({
       url,

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -89,19 +89,6 @@ const READY_SETTLE_MAX_PASSES = 20;
 const READY_SETTLE_REQUIRED_STABLE_PASSES = 2;
 const SETTLE_LOG_PRECISION = 1;
 
-// Capability contract with the prerender drivers. A pooled page pins
-// whatever host build it loaded, and the host and the prerender server
-// deploy independently, so the driver probes this per page (alongside its
-// per-visit auth/job stamping) before choosing a render strategy the host
-// must understand. `fusedIndexMeta`: render options carrying both
-// `cardRender` and `fileExtract` produce a single render.meta payload that
-// includes the file-extract result; a page without the flag gets one
-// transition per pass instead.
-(globalThis as any).__boxelHostCapabilities = {
-  ...(globalThis as any).__boxelHostCapabilities,
-  fusedIndexMeta: true,
-};
-
 export default class RenderRoute extends Route<Model> {
   @service('render-store') declare store: RenderStoreService;
   @service declare router: RouterService;

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -89,6 +89,19 @@ const READY_SETTLE_MAX_PASSES = 20;
 const READY_SETTLE_REQUIRED_STABLE_PASSES = 2;
 const SETTLE_LOG_PRECISION = 1;
 
+// Capability contract with the prerender drivers. A pooled page pins
+// whatever host build it loaded, and the host and the prerender server
+// deploy independently, so the driver probes this per page (alongside its
+// per-visit auth/job stamping) before choosing a render strategy the host
+// must understand. `fusedIndexMeta`: render options carrying both
+// `cardRender` and `fileExtract` produce a single render.meta payload that
+// includes the file-extract result; a page without the flag gets one
+// transition per pass instead.
+(globalThis as any).__boxelHostCapabilities = {
+  ...(globalThis as any).__boxelHostCapabilities,
+  fusedIndexMeta: true,
+};
+
 export default class RenderRoute extends Route<Model> {
   @service('render-store') declare store: RenderStoreService;
   @service declare router: RouterService;
@@ -328,8 +341,12 @@ export default class RenderRoute extends Route<Model> {
     beginRuntimeDependencyTrackingSession({
       sessionKey: key,
       rootURL: id,
+      // A fused index render (cardRender + fileExtract in one pass) hydrates
+      // the card, so its session root is the instance; the file extract it
+      // performs runs in its own session (see the render.meta route).
       rootKind:
-        parsedOptions.fileExtract || parsedOptions.fileRender
+        !parsedOptions.cardRender &&
+        (parsedOptions.fileExtract || parsedOptions.fileRender)
           ? 'file'
           : 'instance',
     });
@@ -384,7 +401,11 @@ export default class RenderRoute extends Route<Model> {
         this.lastStoreResetKey = resetKey;
       }
     }
-    if (parsedOptions.fileExtract) {
+    // A fused index render carries both `fileExtract` and `cardRender`; the
+    // card branch below serves it (hydration + settle) and the render.meta
+    // route performs the extract against the hydrated model's file. Only a
+    // fileExtract-only render gets this trivial model.
+    if (parsedOptions.fileExtract && !parsedOptions.cardRender) {
       let state = new TrackedMap<string, unknown>();
       state.set('status', 'ready');
       let readyDeferred = new Deferred<void>();

--- a/packages/host/app/routes/render/file-extract.ts
+++ b/packages/host/app/routes/render/file-extract.ts
@@ -1,33 +1,24 @@
 import { registerDestructor } from '@ember/destroyable';
-import { getOwner, setOwner } from '@ember/owner';
+import { getOwner } from '@ember/owner';
 import Route from '@ember/routing/route';
 import type Transition from '@ember/routing/transition';
 import { service } from '@ember/service';
 
 import { isTesting } from '@embroider/macros';
 
-import {
-  baseFileRef,
-  baseRealm,
-  formattedError,
-  snapshotRuntimeDependencies,
-  ToolContextStamp,
-  trackRuntimeModuleDependency,
-  withRuntimeDependencyTrackingContext,
-  type RenderError,
-  type ToolContext,
-} from '@cardstack/runtime-common';
+import type { RenderError } from '@cardstack/runtime-common';
 
-import { errorJsonApiToErrorEntry } from '../../lib/window-error-handler';
 import { createAuthErrorGuard } from '../../utils/auth-error-guard';
+
 import {
-  FileDefAttributesExtractor,
-  type FileDefExtractResult,
-} from '../../utils/file-def-attributes-extractor';
+  buildFileExtractError,
+  runFileExtract,
+} from '../../utils/file-extract-runner';
 
 import type LoaderService from '../../services/loader-service';
 import type NetworkService from '../../services/network';
 import type RealmService from '../../services/realm';
+import type { FileDefExtractResult } from '../../utils/file-def-attributes-extractor';
 import type { Model as RenderModel } from '../render';
 export type Model = { id: string; nonce: string } & FileDefExtractResult;
 
@@ -88,88 +79,22 @@ export default class RenderFileExtractRoute extends Route<Model> {
       };
     }
 
-    let fileDefCodeRef = parsedOptions.fileDefCodeRef ?? baseFileRef;
-    let contentHash: string | undefined = parsedOptions.fileContentHash;
-    let contentSize: number | undefined = parsedOptions.fileContentSize;
-    // This route is the indexing path, so skill tool schemas are generated
-    // during the extract and persisted with the row. Tool classes never read
-    // the context during schema generation, but host-package tools resolve
-    // services (e.g. the loader) through the context's owner at construction —
-    // so the context must carry one, the same shape the tool service hands to
-    // real invocations.
-    let toolContext: ToolContext = { [ToolContextStamp]: true };
-    setOwner(toolContext, getOwner(this)!);
-    let extractor = new FileDefAttributesExtractor({
+    let result = await runFileExtract({
+      fileURL: id,
+      renderOptions: parsedOptions,
       loaderService: this.loaderService,
       network: this.network,
       authGuard: this.#authGuard,
-      fileURL: id,
-      fileDefCodeRef,
-      baseFileDefCodeRef: baseFileRef,
-      contentHash,
-      contentSize,
-      buildError: this.#buildError.bind(this),
-      toolContext,
+      owner: getOwner(this)!,
     });
-    let fileApiURL = `${baseRealm.url}file-api`;
-    let result: FileDefExtractResult;
-    try {
-      result = await withRuntimeDependencyTrackingContext(
-        {
-          mode: 'non-query',
-          source: 'render:file-extract',
-          consumer: id,
-          consumerKind: 'file',
-        },
-        async () => {
-          // `${baseRealm.url}file-api` is the public URL the indexer
-          // uses to invalidate file extracts, but the FileDef class
-          // physically lives in `card-api` (`baseFileRef.module`). The
-          // extractor only imports `card-api`, so without this line
-          // `file-api` never enters the tracker.
-          //
-          // Stamp the dep on the tracker directly rather than relying
-          // on `loader.import(fileApiURL)` to do it. `loader.import`'s
-          // synchronous `trackRuntimeModuleDependency` call sits behind
-          // a moduleShims check, the resolveImport URL rewrite, and the
-          // advanceToState machine — any of which can interpose if the
-          // page's loader was replaced (e.g. after
-          // `BrowserManager.restartBrowser()`), which is exactly the
-          // condition the file-extract test flakes under. Stamping the
-          // tracker directly here is one synchronous call with no
-          // moving parts.
-          trackRuntimeModuleDependency(fileApiURL);
-          return extractor.extract();
-        },
-      );
-    } catch (error) {
-      result = {
-        status: 'error',
-        searchDoc: null,
-        deps: [fileDefCodeRef.module],
-        error: this.#buildError(id, error),
-      };
-    }
-    let { deps } = snapshotRuntimeDependencies({ excludeQueryOnly: true });
-    // Belt-and-suspenders: if the tracker call above didn't land in
-    // the snapshot for any reason (session ended, URL normalization
-    // mismatch), explicitly stamp `file-api` into the merged deps.
-    // The indexer's invalidation contract requires this URL to be
-    // present for file extracts; missing it produces silent
-    // never-invalidated rows.
-    let mergedDeps = [
-      ...new Set([...(result.deps ?? []), ...deps, fileApiURL]),
-    ];
     return {
       id,
       nonce,
       ...result,
-      deps: mergedDeps,
     };
   }
 
   #buildError(url: string, error: any): RenderError {
-    let errorJSONAPI = formattedError(url, error).errors[0];
-    return errorJsonApiToErrorEntry(errorJSONAPI) as RenderError;
+    return buildFileExtractError(url, error);
   }
 }

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -1,3 +1,4 @@
+import { getOwner } from '@ember/owner';
 import Route from '@ember/routing/route';
 import type Transition from '@ember/routing/transition';
 
@@ -8,6 +9,7 @@ import { isEqual } from 'lodash-es';
 import type { CodeRef } from '@cardstack/runtime-common';
 import {
   baseRef,
+  beginRuntimeDependencyTrackingSession,
   identifyCard,
   internalKeyFor,
   logger,
@@ -18,16 +20,23 @@ import {
   type SearchDocLinkLoad,
   type SearchDocTimings,
   type SingleCardDocument,
-  type PrerenderMeta,
+  type FusedIndexMeta,
   type PrerenderMetaDiagnostics,
   type RenderError,
 } from '@cardstack/runtime-common';
 
 import type CardService from '@cardstack/host/services/card-service';
+import type LoaderService from '@cardstack/host/services/loader-service';
 import type NetworkService from '@cardstack/host/services/network';
 import type RenderStoreService from '@cardstack/host/services/render-store';
 
+import { createAuthErrorGuard } from '../../utils/auth-error-guard';
+
+import { runFileExtract } from '../../utils/file-extract-runner';
+
 import { friendlyCardType } from '../../utils/render-error';
+
+import type { FileDefExtractResult } from '../../utils/file-def-attributes-extractor';
 
 import type { Model as ParentModel } from '../render';
 import type {
@@ -36,7 +45,7 @@ import type {
   ComputePassSnapshot,
 } from '@cardstack/base/card-api';
 
-export type Model = PrerenderMeta | RenderError | undefined;
+export type Model = FusedIndexMeta | RenderError | undefined;
 
 const computePerfLog = logger('host:computed-perf');
 
@@ -131,8 +140,10 @@ const SEARCHABLE_MODULE_URL = 'https://cardstack.com/base/searchable';
 
 export default class RenderMetaRoute extends Route<Model> {
   @service declare cardService: CardService;
+  @service declare private loaderService: LoaderService;
   @service declare private network: NetworkService;
   @service('render-store') declare private store: RenderStoreService;
+  #authGuard = createAuthErrorGuard();
 
   async model(_: unknown, transition: Transition) {
     let api = await this.cardService.getAPI();
@@ -145,7 +156,7 @@ export default class RenderMetaRoute extends Route<Model> {
     await renderModel?.readyPromise;
     let instance: CardDef | undefined = renderModel?.instance;
 
-    if (!instance) {
+    if (!renderModel || !instance) {
       // the lack of an instance is dealt with in the parent route
       transition.abort();
       return;
@@ -356,7 +367,7 @@ export default class RenderMetaRoute extends Route<Model> {
       `render.meta computed counts cardId=${instance.id} calls=${diagnostics.computedCalls ?? 'n/a'} cacheHits=${diagnostics.computedCacheHits ?? 'n/a'} serializeMs=${diagnostics.serializeMs} searchDocMs=${diagnostics.searchDocMs} searchDocSettleMs=${diagnostics.searchDocSettleMs} searchDocSettlePasses=${diagnostics.searchDocSettlePasses}`,
     );
 
-    return {
+    let metaPayload: FusedIndexMeta = {
       serialized,
       displayNames,
       types: types.map((t) =>
@@ -365,6 +376,54 @@ export default class RenderMetaRoute extends Route<Model> {
       searchDoc,
       deps: this.network.virtualNetwork.unresolveURLs(deps),
       diagnostics,
+    };
+
+    let parsedOptions = renderModel.renderOptions;
+    if (!parsedOptions?.fileExtract) {
+      return metaPayload;
+    }
+
+    // Fused index render: the render options carry `fileExtract` alongside
+    // `cardRender`, so this one transition also produces the file row's
+    // extract. It runs only now — the card payload above is fully
+    // materialized and its dependency snapshot taken, so nothing the extract
+    // does can leak into the card row. The extract gets a fresh tracking
+    // session: the tracker is session-scoped and a snapshot reads the whole
+    // session, so sharing the card's session would fold the hydration graph
+    // into the file row's deps. The instance id is the canonical (extension-
+    // less) card URL; the extract targets the `.json` file that stores it,
+    // the same URL a standalone render.file-extract receives.
+    let fileURL = renderModel.cardId.endsWith('.json')
+      ? renderModel.cardId
+      : `${renderModel.cardId}.json`;
+    let extractStart = performance.now();
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: `${renderModel.cardId}|${renderModel.nonce}|file-extract`,
+      rootURL: fileURL,
+      rootKind: 'file',
+    });
+    this.#authGuard.register();
+    let extractResult: FileDefExtractResult;
+    try {
+      extractResult = await runFileExtract({
+        fileURL,
+        renderOptions: parsedOptions,
+        loaderService: this.loaderService,
+        network: this.network,
+        authGuard: this.#authGuard,
+        owner: getOwner(this)!,
+      });
+    } finally {
+      this.#authGuard.unregister();
+    }
+    diagnostics.fileExtractMs = roundMs(performance.now() - extractStart);
+    return {
+      ...metaPayload,
+      fileExtract: {
+        id: fileURL,
+        nonce: renderModel.nonce,
+        ...extractResult,
+      },
     };
   }
 

--- a/packages/host/app/utils/file-extract-runner.ts
+++ b/packages/host/app/utils/file-extract-runner.ts
@@ -1,0 +1,139 @@
+import { setOwner } from '@ember/owner';
+import type Owner from '@ember/owner';
+
+import {
+  baseFileRef,
+  baseRealm,
+  formattedError,
+  snapshotRuntimeDependencies,
+  ToolContextStamp,
+  trackRuntimeModuleDependency,
+  withRuntimeDependencyTrackingContext,
+  type RenderError,
+  type RenderRouteOptions,
+  type ToolContext,
+} from '@cardstack/runtime-common';
+
+import { errorJsonApiToErrorEntry } from '../lib/window-error-handler';
+
+import {
+  FileDefAttributesExtractor,
+  type FileDefExtractResult,
+} from './file-def-attributes-extractor';
+
+import type { AuthErrorGuard } from './auth-error-guard';
+
+import type LoaderService from '../services/loader-service';
+import type NetworkService from '../services/network';
+
+export function buildFileExtractError(url: string, error: any): RenderError {
+  let errorJSONAPI = formattedError(url, error).errors[0];
+  return errorJsonApiToErrorEntry(errorJSONAPI) as RenderError;
+}
+
+// Runs the FileDef attribute extract for `fileURL` and returns the extract
+// result carrying the dependency set the file row persists. Shared by the
+// standalone render.file-extract route and the fused branch of render.meta so
+// both produce the identical file-row payload.
+//
+// The caller owns the dependency-tracking SESSION this runs inside: the
+// extract snapshots the whole current session, so it must not share one with
+// card hydration — the standalone route inherits the parent render route's
+// session (whose fileExtract-mode model tracks nothing else), while the fused
+// meta branch starts a fresh session first.
+//
+// Throws never escape: an extractor failure is caught into a
+// `status: 'error'` result so it surfaces through the route's payload (and
+// from there the route-level error handling). Letting it escape would reach
+// the window-level error trap, which marks the page unusable and evicts it —
+// a remedy reserved for errors that wedge the Ember run loop.
+export async function runFileExtract({
+  fileURL,
+  renderOptions,
+  loaderService,
+  network,
+  authGuard,
+  owner,
+}: {
+  fileURL: string;
+  renderOptions: RenderRouteOptions;
+  loaderService: LoaderService;
+  network: NetworkService;
+  authGuard: AuthErrorGuard;
+  owner: Owner;
+}): Promise<FileDefExtractResult> {
+  let fileDefCodeRef = renderOptions.fileDefCodeRef ?? baseFileRef;
+  let contentHash: string | undefined = renderOptions.fileContentHash;
+  let contentSize: number | undefined = renderOptions.fileContentSize;
+  // This runs on the indexing path, so skill tool schemas are generated
+  // during the extract and persisted with the row. Tool classes never read
+  // the context during schema generation, but host-package tools resolve
+  // services (e.g. the loader) through the context's owner at construction —
+  // so the context must carry one, the same shape the tool service hands to
+  // real invocations.
+  let toolContext: ToolContext = { [ToolContextStamp]: true };
+  setOwner(toolContext, owner);
+  let extractor = new FileDefAttributesExtractor({
+    loaderService,
+    network,
+    authGuard,
+    fileURL,
+    fileDefCodeRef,
+    baseFileDefCodeRef: baseFileRef,
+    contentHash,
+    contentSize,
+    buildError: buildFileExtractError,
+    toolContext,
+  });
+  let fileApiURL = `${baseRealm.url}file-api`;
+  let result: FileDefExtractResult;
+  try {
+    result = await withRuntimeDependencyTrackingContext(
+      {
+        mode: 'non-query',
+        source: 'render:file-extract',
+        consumer: fileURL,
+        consumerKind: 'file',
+      },
+      async () => {
+        // `${baseRealm.url}file-api` is the public URL the indexer
+        // uses to invalidate file extracts, but the FileDef class
+        // physically lives in `card-api` (`baseFileRef.module`). The
+        // extractor only imports `card-api`, so without this line
+        // `file-api` never enters the tracker.
+        //
+        // Stamp the dep on the tracker directly rather than relying
+        // on `loader.import(fileApiURL)` to do it. `loader.import`'s
+        // synchronous `trackRuntimeModuleDependency` call sits behind
+        // a moduleShims check, the resolveImport URL rewrite, and the
+        // advanceToState machine — any of which can interpose if the
+        // page's loader was replaced (e.g. after
+        // `BrowserManager.restartBrowser()`), which is exactly the
+        // condition the file-extract test flakes under. Stamping the
+        // tracker directly here is one synchronous call with no
+        // moving parts.
+        trackRuntimeModuleDependency(fileApiURL);
+        return extractor.extract();
+      },
+    );
+  } catch (error) {
+    result = {
+      status: 'error',
+      searchDoc: null,
+      deps: [fileDefCodeRef.module],
+      error: buildFileExtractError(fileURL, error),
+    };
+  }
+  let { deps } = snapshotRuntimeDependencies({ excludeQueryOnly: true });
+  // Belt-and-suspenders: if the tracker call above didn't land in
+  // the snapshot for any reason (session ended, URL normalization
+  // mismatch), explicitly stamp `file-api` into the merged deps.
+  // The indexer's invalidation contract requires this URL to be
+  // present for file extracts; missing it produces silent
+  // never-invalidated rows.
+  let mergedDeps = [...new Set([...(result.deps ?? []), ...deps, fileApiURL])];
+  return {
+    ...result,
+    deps: mergedDeps,
+  };
+}

--- a/packages/host/app/utils/register-boxel-transition.ts
+++ b/packages/host/app/utils/register-boxel-transition.ts
@@ -1,6 +1,21 @@
 import { registerDestructor } from '@ember/destroyable';
 import type RouterService from '@ember/routing/router-service';
 
+// Capability contract with the prerender drivers. A pooled page pins
+// whatever host build it loaded, and the host and the prerender server
+// deploy independently, so the driver probes this per page (alongside its
+// per-visit auth/job stamping) before choosing a render strategy the host
+// must understand. Stamped in this module because the pool bootstraps every
+// page through the standby route, which evaluates it before the driver's
+// first transition can run. `fusedIndexMeta`: render options carrying both
+// `cardRender` and `fileExtract` produce a single render.meta payload that
+// includes the file-extract result; a page without the flag gets one
+// transition per pass instead.
+(globalThis as any).__boxelHostCapabilities = {
+  ...(globalThis as any).__boxelHostCapabilities,
+  fusedIndexMeta: true,
+};
+
 export function registerBoxelTransitionTo(
   router: RouterService,
   owner: object,

--- a/packages/host/tests/acceptance/prerender-meta-test.gts
+++ b/packages/host/tests/acceptance/prerender-meta-test.gts
@@ -1,4 +1,4 @@
-import { visit } from '@ember/test-helpers';
+import { visit, waitUntil } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 
@@ -7,6 +7,8 @@ import { module, test } from 'qunit';
 import {
   baseRealmRRI,
   diffDoc,
+  type FileExtractResponse,
+  type FusedIndexMeta,
   type PrerenderMeta,
   type RenderRouteOptions,
   rri,
@@ -59,6 +61,31 @@ module('Acceptance | prerender | meta', function (hooks) {
     `/render/${encodeURIComponent(
       url,
     )}/${nonce}/${DEFAULT_RENDER_OPTIONS_SEGMENT}${suffix}`;
+  const customRenderPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    nonce: number,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}`;
+
+  async function captureFileExtractResult(): Promise<FileExtractResponse> {
+    await waitUntil(
+      () => {
+        let status = document
+          .querySelector('[data-prerender-file-extract]')
+          ?.getAttribute('data-prerender-file-extract-status');
+        return status === 'ready' || status === 'error';
+      },
+      { timeout: 5000 },
+    );
+    let text =
+      document
+        .querySelector('[data-prerender-file-extract] pre')
+        ?.textContent?.trim() ?? '';
+    return JSON.parse(text) as FileExtractResponse;
+  }
 
   hooks.beforeEach(async function () {
     let loader = getService('loader-service').loader;
@@ -552,6 +579,70 @@ module('Acceptance | prerender | meta', function (hooks) {
         cardTitle: 'Molly',
       },
       'search doc is correct',
+    );
+  });
+
+  test('a render carrying both cardRender and fileExtract returns the file extract alongside the meta payload', async function (assert) {
+    let url = `${testRealmURL}Pet/paper.json`;
+
+    // The standalone file-extract route's payload for the same file is the
+    // reference the fused payload must reproduce.
+    await visit(
+      customRenderPath(url, { clearCache: true, fileExtract: true }, 1) +
+        '/file-extract',
+    );
+    let standalone = await captureFileExtractResult();
+
+    await visit(
+      customRenderPath(
+        url,
+        { clearCache: true, cardRender: true, fileExtract: true },
+        2,
+      ) + '/meta',
+    );
+    let { value } = await capturePrerenderResult('textContent');
+    let fused: FusedIndexMeta = JSON.parse(value);
+
+    assert.deepEqual(
+      fused.types,
+      [
+        `${testRealmURL}cat/Cat`,
+        `${testRealmURL}pet/Pet`,
+        `${baseRealmRRI}card-api/CardDef`,
+        `${baseRealmRRI}card-api/BaseDef`,
+      ],
+      'card meta types are present on the fused payload',
+    );
+    assert.ok(fused.serialized, 'card meta serialized doc is present');
+    assert.ok(fused.searchDoc, 'card meta search doc is present');
+    assert.strictEqual(
+      typeof fused.diagnostics?.fileExtractMs,
+      'number',
+      'the extract share of the transition is itemized in diagnostics',
+    );
+
+    let fileExtract = fused.fileExtract!;
+    assert.ok(fileExtract, 'file extract rides the meta payload');
+    // The nonce is per-visit and the deps have no ordering contract; every
+    // other field must match the standalone route byte for byte.
+    let { deps: fusedDeps, nonce: _fusedNonce, ...fusedRest } = fileExtract;
+    let {
+      deps: standaloneDeps,
+      nonce: _standaloneNonce,
+      ...standaloneRest
+    } = standalone;
+    assert.deepEqual(
+      fusedRest,
+      standaloneRest,
+      'fused extract payload matches the standalone file-extract route',
+    );
+    // The card side of the payload owns the hydration graph; the file side
+    // carries only the extract's own dependencies, so any hydration module
+    // leaking into the fused extract breaks this set-equality.
+    assert.deepEqual(
+      [...(fusedDeps ?? [])].sort(),
+      [...(standaloneDeps ?? [])].sort(),
+      'fused extract deps are set-equal to the standalone extract deps',
     );
   });
 });

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -646,7 +646,12 @@ export class Prerenderer {
 
   async prerenderVisit(
     rawArgs: PrerenderVisitArgs & {
-      opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
+      opts?: {
+        timeoutMs?: number;
+        simulateTimeoutMs?: number;
+        // Test-only: see the matching field on `prerenderVisitAttempt`.
+        simulateLegacyHost?: true;
+      };
       signal?: AbortSignal;
       // Test-only hook fired right after a page is acquired and its
       // bucket has been reset. Used by tests that need to seed the

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -1185,10 +1185,18 @@ export class RenderRunner {
             };
           }
         }
-        extractResponse.error = this.#mergeConsoleErrors(
+        // The merge always runs so the pass drains the page's console-error
+        // buffer, but only a produced error is assigned: an unconditional
+        // assignment would plant an `error: undefined` own-key, making a
+        // standalone extract deep-unequal to a fused one that carries no
+        // error key at all.
+        let mergedExtractError = this.#mergeConsoleErrors(
           pageId,
           extractResponse.error,
         );
+        if (mergedExtractError) {
+          extractResponse.error = mergedExtractError;
+        }
         response.fileExtract = extractResponse;
         if (poolInfo.evicted) {
           response.pageUnusableError =

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -1606,10 +1606,13 @@ export class RenderRunner {
         // (the window-level trap in the host's render route); a route-level
         // card error leaves the page fully able to serve transitions. A
         // broken card must still yield a good file row, so run the
-        // standalone extract transition. Auth failure is the exception:
-        // the extract would hit the same wall, so mirror the card error
-        // onto the file half and end the visit — the same short-circuit a
-        // standalone extract pass takes on auth failure.
+        // standalone extract transition. On the eviction path no fallback
+        // is possible (nothing can run on an unusable page), so the file
+        // half is absent for that attempt and its row degrades to an error
+        // row until the next index of the file. Auth failure is the other
+        // exception: the extract would hit the same wall, so mirror the
+        // card error onto the file half and end the visit — the same
+        // short-circuit a standalone extract pass takes on auth failure.
         if (fusedIndexPass && !response.fileExtract) {
           if (cardError && this.#isAuthError(cardError)) {
             response.fileExtract = {

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -1,4 +1,5 @@
 import {
+  type FusedIndexMeta,
   type PrerenderMeta,
   type PrerenderTypes,
   type RenderError,
@@ -837,7 +838,14 @@ export class RenderRunner {
     signal,
     onTabAcquired,
   }: PrerenderVisitArgs & {
-    opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
+    opts?: {
+      timeoutMs?: number;
+      simulateTimeoutMs?: number;
+      // Test-only: pretend the page's host build doesn't advertise the
+      // `fusedIndexMeta` capability, exercising the per-pass transition
+      // path a page pinned to such a build takes.
+      simulateLegacyHost?: true;
+    };
     signal?: AbortSignal;
     // See the matching param on `prerenderModuleAttempt`.
     onTabAcquired?: (info: { pageId: string }) => void;
@@ -922,9 +930,11 @@ export class RenderRunner {
     // `icon` for a file), recorded onto `response.meta.diagnostics.indexRoutesMs`
     // as each step completes. Decomposes the index visit's per-visit floor
     // into measured route buckets instead of leaving it inferred from
-    // `renderElapsedMs`. Recorded wherever the step runs — on an index visit
-    // that is every leg; a self-sufficient prerender-html visit records only
-    // its `fileExtract` leg.
+    // `renderElapsedMs`. Recorded wherever the step runs — a fused index
+    // pass folds the extract into the `meta` bucket (no `fileExtract` leg;
+    // the extract's share is itemized as `diagnostics.fileExtractMs`); a
+    // self-sufficient prerender-html visit records only its `fileExtract`
+    // leg.
     let recordIndexRouteMs = (
       rendering: 'card' | 'file',
       route: string,
@@ -956,8 +966,12 @@ export class RenderRunner {
       // originating priority instead of silently dropping to 0. Always
       // overwrite (including with undefined) so a tab reused across
       // multiple visits never bleeds a prior visit's values into the
-      // next render.
-      await page.evaluate(
+      // next render. The same round-trip reads back the page's host
+      // capabilities: the page pins whatever host build it loaded, and the
+      // host deploys independently of this server, so render strategies the
+      // host must understand are gated per page on its advertised
+      // `__boxelHostCapabilities`.
+      let hostCapabilities = await page.evaluate(
         (
           sessionAuth: string,
           id: string | undefined,
@@ -969,11 +983,37 @@ export class RenderRunner {
           (
             globalThis as unknown as { __boxelJobPriority?: number }
           ).__boxelJobPriority = jobPriority;
+          return (
+            (
+              globalThis as unknown as {
+                __boxelHostCapabilities?: Record<string, boolean>;
+              }
+            ).__boxelHostCapabilities ?? {}
+          );
         },
         auth,
         jobId,
         priority,
       );
+      // A card-instance index visit fuses the file extract into the
+      // render.meta transition — one transition + settle for both the
+      // instance row and the file row — when the page's host build supports
+      // it. Other visit shapes keep per-pass transitions: the fused (union)
+      // visit runs meta last (after the html renders mark linksTo fields
+      // used), and a prerender-html visit's extract is its own
+      // self-sufficiency step.
+      let fusedIndexPass =
+        visitType === 'index' &&
+        requested.cardRender &&
+        requested.fileExtract &&
+        Boolean(hostCapabilities?.fusedIndexMeta) &&
+        !opts?.simulateLegacyHost;
+      if (fusedIndexPass) {
+        requested.fileExtract = false;
+        log.debug(
+          `visit prerender url=${url} affinity=${affinityKey} fusing fileExtract into render.meta`,
+        );
+      }
       // defense-in-depth: clear any stale file render data left on globalThis
       // from a prior visit before we start running passes.
       await page
@@ -990,16 +1030,20 @@ export class RenderRunner {
       // must not attempt another loader reset, so we strip it after first use.
       let clearCacheConsumed = false;
       let optionsForPass = (
-        pass: 'fileExtract' | 'cardRender' | 'fileRender',
+        pass: 'fileExtract' | 'cardRender' | 'fileRender' | 'fusedIndex',
       ) => {
         let optionsForThisPass: RenderRouteOptions = {
           ...baseOptions,
-          // Always set only the flag for the current pass so the host route
+          // Set only the flag(s) for the current pass so the host route
           // picks the right branch in #buildModel regardless of what other
-          // passes are part of this visit.
-          fileExtract: pass === 'fileExtract' ? true : undefined,
+          // passes are part of this visit. The fused index pass carries both
+          // flags — the host serves it from the card branch and folds the
+          // file extract into the render.meta payload.
+          fileExtract:
+            pass === 'fileExtract' || pass === 'fusedIndex' ? true : undefined,
           fileRender: pass === 'fileRender' ? true : undefined,
-          cardRender: pass === 'cardRender' ? true : undefined,
+          cardRender:
+            pass === 'cardRender' || pass === 'fusedIndex' ? true : undefined,
         };
         if (!clearCacheConsumed && baseOptions.clearCache) {
           optionsForThisPass.clearCache = true;
@@ -1018,8 +1062,13 @@ export class RenderRunner {
         return optionsForThisPass;
       };
 
-      // ── fileExtract pass ───────────────────────────────────────────────
-      if (requested.fileExtract) {
+      // Runs a standalone render.file-extract transition and stores its
+      // result on `response.fileExtract`. Serves the fileExtract pass and
+      // the fused-index fallback (a card render error must still yield a
+      // file row). Returns 'short-circuit' when the visit must stop here:
+      // the page was evicted (unusable), or the extract hit an auth wall
+      // every later pass would hit too.
+      let runFileExtractPass = async (): Promise<'ok' | 'short-circuit'> => {
         let extractOptions = optionsForPass('fileExtract');
         let serializedOptions = serializeRenderRouteOptions(extractOptions);
         let captureOptions: CaptureOptions = {
@@ -1069,14 +1118,7 @@ export class RenderRunner {
           if (poolInfo.evicted) {
             response.fileExtract = extractResponse;
             response.pageUnusableError = renderError;
-            return this.#finalizeVisit(
-              response,
-              pageId,
-              renderStart,
-              launchMs,
-              waits,
-              poolInfo,
-            );
+            return 'short-circuit';
           }
           if (this.#isAuthError(renderError)) {
             // Auth failure means the caller isn't allowed — the page itself
@@ -1084,14 +1126,7 @@ export class RenderRunner {
             // subsequent passes (they'd hit the same auth failure) without
             // marking the page unusable.
             response.fileExtract = extractResponse;
-            return this.#finalizeVisit(
-              response,
-              pageId,
-              renderStart,
-              launchMs,
-              waits,
-              poolInfo,
-            );
+            return 'short-circuit';
           }
         } else {
           let fileCapture = capture as FileExtractCapture;
@@ -1158,6 +1193,14 @@ export class RenderRunner {
         if (poolInfo.evicted) {
           response.pageUnusableError =
             extractResponse.error ?? response.pageUnusableError;
+          return 'short-circuit';
+        }
+        return 'ok';
+      };
+
+      // ── fileExtract pass ───────────────────────────────────────────────
+      if (requested.fileExtract) {
+        if ((await runFileExtractPass()) === 'short-circuit') {
           return this.#finalizeVisit(
             response,
             pageId,
@@ -1172,7 +1215,9 @@ export class RenderRunner {
       // ── cardRender pass ────────────────────────────────────────────────
       throwIfAborted(signal, 'rendering');
       if (requested.cardRender) {
-        let cardOptions = optionsForPass('cardRender');
+        let cardOptions = optionsForPass(
+          fusedIndexPass ? 'fusedIndex' : 'cardRender',
+        );
         let serializedOptions = serializeRenderRouteOptions(cardOptions);
         let optionsSegment = encodeURIComponent(serializedOptions);
         let nonce = String(++this.#nonce);
@@ -1293,8 +1338,10 @@ export class RenderRunner {
           // pure function of the card's type (`types[0]`, which meta
           // resolves): the job-scoped memo lets the first visit for a type
           // render the icon and every later visit of that type reuse the
-          // captured markup, skipping the icon route.
-          let metaResult = await runTimedStep<PrerenderMeta>(
+          // captured markup, skipping the icon route. On a fused index pass
+          // this one transition also returns the file row's extract inside
+          // the payload.
+          let metaResult = await runTimedStep<FusedIndexMeta>(
             'visit card render.meta',
             async () => {
               await transitionTo(
@@ -1310,7 +1357,14 @@ export class RenderRunner {
             'meta',
           );
           if (metaResult !== undefined) {
-            meta = metaResult;
+            // Split the extract off before `meta` is spread into
+            // `cardResponse` below — the card row's payload must never
+            // carry the file half.
+            let { fileExtract: fusedExtract, ...cardMeta } = metaResult;
+            meta = cardMeta;
+            if (fusedExtract) {
+              response.fileExtract = fusedExtract;
+            }
           } else {
             // The entry step failed, so the page is showing the error
             // route: a subsequent capture would wait on fresh render
@@ -1534,6 +1588,49 @@ export class RenderRunner {
             waits,
             poolInfo,
           );
+        }
+
+        // ── fused-extract fallback ─────────────────────────────────────
+        // A fused index pass carries the file extract inside render.meta,
+        // so a card render error leaves the file half missing. The page is
+        // still operational here — the eviction path returned above, and
+        // eviction is reserved for errors that wedge the Ember run loop
+        // (the window-level trap in the host's render route); a route-level
+        // card error leaves the page fully able to serve transitions. A
+        // broken card must still yield a good file row, so run the
+        // standalone extract transition. Auth failure is the exception:
+        // the extract would hit the same wall, so mirror the card error
+        // onto the file half and end the visit — the same short-circuit a
+        // standalone extract pass takes on auth failure.
+        if (fusedIndexPass && !response.fileExtract) {
+          if (cardError && this.#isAuthError(cardError)) {
+            response.fileExtract = {
+              id: url,
+              nonce,
+              status: 'error',
+              searchDoc: null,
+              deps: cardError.error.deps ?? [],
+              error: cardError,
+            };
+            return this.#finalizeVisit(
+              response,
+              pageId,
+              renderStart,
+              launchMs,
+              waits,
+              poolInfo,
+            );
+          }
+          if ((await runFileExtractPass()) === 'short-circuit') {
+            return this.#finalizeVisit(
+              response,
+              pageId,
+              renderStart,
+              launchMs,
+              waits,
+              poolInfo,
+            );
+          }
         }
       }
 

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -7984,6 +7984,42 @@ module(basename(import.meta.filename), function () {
       }
     });
 
+    test('an eviction during the fused pass ends the visit without a fallback extract', async function (assert) {
+      const cardFileURL = `${realmURL}maple.json`;
+      // A render timeout is a wedged-page signal: the page gets evicted and
+      // no further transition can run on it, so the fused visit ends with
+      // the file half absent. The file row degrades to an error row for
+      // this attempt and heals on the next index of the file — the pinned
+      // trade-off for carrying the extract inside the meta transition.
+      let { response, pool } = await prerenderer.prerenderVisit({
+        affinityType: 'realm',
+        affinityValue: realmURL,
+        realm: realmURL,
+        url: cardFileURL,
+        auth: auth(),
+        visitType: 'index',
+        renderOptions: { cardRender: true, fileExtract: true },
+        opts: { timeoutMs: 1, simulateTimeoutMs: 200 },
+      });
+
+      assert.true(pool.timedOut, 'the fused transition timed out');
+      assert.true(pool.evicted, 'the timeout evicted the page');
+      assert.ok(
+        response.pageUnusableError,
+        'the visit reports the page unusable',
+      );
+      assert.strictEqual(
+        response.fileExtract,
+        undefined,
+        'no fallback extract runs on an evicted page',
+      );
+      assert.strictEqual(
+        response.meta?.diagnostics?.indexRoutesMs?.file?.fileExtract,
+        undefined,
+        'no standalone extract transition was recorded',
+      );
+    });
+
     test('reuses a single pooled page for all three passes', async function (assert) {
       const cardFileURL = `${realmURL}maple.json`;
       // Warm the pool

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -3266,6 +3266,45 @@ module(basename(import.meta.filename), function () {
       );
       assert.false(result.pool.timedOut, 'prerender did not time out');
     });
+
+    test('a fused index visit mirrors an auth error onto the file half without a fallback transition', async function (assert) {
+      const cardFileURL = `${providerRealmURL}secret.json`;
+
+      let { response, pool } = await prerenderer.prerenderVisit({
+        affinityType: 'realm',
+        affinityValue: providerRealmURL,
+        realm: providerRealmURL,
+        url: cardFileURL,
+        auth: auth(),
+        visitType: 'index',
+        renderOptions: { cardRender: true, fileExtract: true },
+      });
+
+      assert.strictEqual(
+        response.card?.error?.error.status,
+        401,
+        'card half carries the auth error',
+      );
+      assert.strictEqual(
+        response.fileExtract?.status,
+        'error',
+        'file half is an error row',
+      );
+      assert.strictEqual(
+        response.fileExtract?.error?.error.status,
+        401,
+        'file half mirrors the auth error',
+      );
+      // A fallback extract would hit the same auth wall, so none runs — the
+      // file half is synthesized from the card error instead.
+      assert.strictEqual(
+        response.meta?.diagnostics?.indexRoutesMs?.file?.fileExtract,
+        undefined,
+        'no standalone extract transition runs on the auth path',
+      );
+      assert.false(pool.timedOut, 'auth failure is not reported as a timeout');
+      assert.false(pool.evicted, 'auth failure does not evict the page');
+    });
   });
 
   module('prerender - public query fallback', function (hooks) {
@@ -7791,10 +7830,13 @@ module(basename(import.meta.filename), function () {
 
       // Per-route index timings are the index-half sibling of
       // renderFormatsMs: they ride the index visit's meta — one number per
-      // index-half route step (meta / icon for the card, fileExtract / icon
-      // for the file) — while the prerender-html visit, which runs no
-      // index-half route here, reports none. (No jobId is threaded, so the
-      // per-type icon memo is inactive and each icon route actually runs.)
+      // index-half route step — while the prerender-html visit, which runs
+      // no index-half route here, reports none. The index visit of a card
+      // instance fuses the extract into its render.meta transition, so
+      // `card.meta` covers both halves (the extract's share itemized as
+      // `fileExtractMs`) and no standalone `file.fileExtract` leg exists.
+      // (No jobId is threaded, so the per-type icon memo is inactive and
+      // each icon route actually runs.)
       let indexRoutesMs = index.meta?.diagnostics?.indexRoutesMs;
       assert.strictEqual(
         typeof indexRoutesMs?.card?.meta,
@@ -7807,9 +7849,14 @@ module(basename(import.meta.filename), function () {
         'index visit records the card icon route timing',
       );
       assert.strictEqual(
-        typeof indexRoutesMs?.file?.fileExtract,
+        indexRoutesMs?.file?.fileExtract,
+        undefined,
+        'index visit runs no standalone file extract transition',
+      );
+      assert.strictEqual(
+        typeof index.meta?.diagnostics?.fileExtractMs,
         'number',
-        'index visit records the file extract route timing',
+        'index visit itemizes the extract share of the fused meta transition',
       );
       assert.strictEqual(
         typeof indexRoutesMs?.file?.icon,
@@ -7820,7 +7867,8 @@ module(basename(import.meta.filename), function () {
         html.meta?.diagnostics?.indexRoutesMs,
         'prerender-html visit records no per-route index timings',
       );
-      // The fused visit runs both halves, so it records the index routes too.
+      // The fused (union) visit runs meta last, after the html renders, so
+      // its extract stays a standalone transition and records its own leg.
       let fusedIndexRoutesMs = fused.meta?.diagnostics?.indexRoutesMs;
       assert.strictEqual(
         typeof fusedIndexRoutesMs?.card?.meta,
@@ -7832,6 +7880,108 @@ module(basename(import.meta.filename), function () {
         'number',
         'fused visit records the card icon route timing',
       );
+      assert.strictEqual(
+        typeof fusedIndexRoutesMs?.file?.fileExtract,
+        'number',
+        'fused visit records the standalone file extract route timing',
+      );
+    });
+
+    test('a legacy host without the fused capability gets per-pass transitions with identical output', async function (assert) {
+      const cardFileURL = `${realmURL}maple.json`;
+      const fileDefCodeRef = {
+        module: baseRRI('json-file-def'),
+        name: 'JsonFileDef',
+      };
+      let visitArgs = {
+        affinityType: 'realm' as const,
+        affinityValue: realmURL,
+        realm: realmURL,
+        url: cardFileURL,
+        auth: auth(),
+        visitType: 'index' as const,
+        renderOptions: {
+          cardRender: true,
+          fileExtract: true,
+          fileRender: true,
+          fileDefCodeRef,
+        } as const,
+      };
+      let legacy = (
+        await prerenderer.prerenderVisit({
+          ...visitArgs,
+          opts: { simulateLegacyHost: true },
+        })
+      ).response;
+      let fused = (await prerenderer.prerenderVisit(visitArgs)).response;
+
+      // The legacy path pays a standalone extract transition; the fused
+      // path folds the extract into render.meta and itemizes its share.
+      assert.strictEqual(
+        typeof legacy.meta?.diagnostics?.indexRoutesMs?.file?.fileExtract,
+        'number',
+        'legacy host records a standalone file extract transition',
+      );
+      assert.strictEqual(
+        legacy.meta?.diagnostics?.fileExtractMs,
+        undefined,
+        'legacy host has no fused extract share to itemize',
+      );
+      assert.strictEqual(
+        fused.meta?.diagnostics?.indexRoutesMs?.file?.fileExtract,
+        undefined,
+        'fused host runs no standalone file extract transition',
+      );
+      assert.strictEqual(
+        typeof fused.meta?.diagnostics?.fileExtractMs,
+        'number',
+        'fused host itemizes the extract share of the meta transition',
+      );
+
+      // Both strategies produce the same output.
+      assert.deepEqual(
+        fused.card?.serialized,
+        legacy.card?.serialized,
+        'serialized doc matches the legacy path',
+      );
+      assert.deepEqual(
+        fused.card?.searchDoc,
+        legacy.card?.searchDoc,
+        'search doc matches the legacy path',
+      );
+      assert.deepEqual(
+        fused.card?.types,
+        legacy.card?.types,
+        'types match the legacy path',
+      );
+      assert.deepEqual(
+        fused.card?.displayNames,
+        legacy.card?.displayNames,
+        'display names match the legacy path',
+      );
+      assert.deepEqual(
+        [...new Set(fused.card?.deps ?? [])].sort(),
+        [...new Set(legacy.card?.deps ?? [])].sort(),
+        'card deps match the legacy path as a set',
+      );
+      {
+        let { deps: fusedDeps, nonce: _n1, ...fusedRest } = fused.fileExtract!;
+        let {
+          deps: legacyDeps,
+          nonce: _n2,
+          ...legacyRest
+        } = legacy.fileExtract!;
+        assert.deepEqual(
+          fusedRest,
+          legacyRest,
+          'file extract matches the legacy path',
+        );
+        assert.deepEqual(
+          [...new Set(fusedDeps)].sort(),
+          [...new Set(legacyDeps)].sort(),
+          'file extract deps match the legacy path as a set',
+        );
+      }
     });
 
     test('reuses a single pooled page for all three passes', async function (assert) {
@@ -8011,6 +8161,20 @@ module(basename(import.meta.filename), function () {
           response.card?.iconHTML,
           null,
           'icon render is skipped once the meta entry has errored',
+        );
+        // The extract normally rides the fused meta transition, which the
+        // card error lost — the fallback standalone extract transition must
+        // still produce the file row (the card error is a route-level error;
+        // the page stays fully operational).
+        assert.strictEqual(
+          response.fileExtract?.status,
+          'ready',
+          'the fallback extract still produces the file row',
+        );
+        assert.strictEqual(
+          typeof response.meta?.diagnostics?.indexRoutesMs?.file?.fileExtract,
+          'number',
+          'the fallback extract records its standalone route timing',
         );
         assert.false(
           pool.timedOut,

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -236,6 +236,12 @@ export interface PrerenderMetaDiagnostics {
   // cards-with-broken-links are cheaply enumerable. Omitted entirely
   // when the card has no broken links.
   brokenLinks?: BrokenLinkSummary[];
+  // Wall-clock of the file extract a fused index render performs inside the
+  // render.meta route after the card payload is materialized (see
+  // FusedIndexMeta). This is the extract's share of the visit's
+  // `indexRoutesMs.card.meta` bucket; a standalone render.file-extract
+  // transition reports through `indexRoutesMs.file.fileExtract` instead.
+  fileExtractMs?: number;
   // Unresolvable `searchable` annotation paths found while building the
   // module's definitions, persisted to `modules.diagnostics`. Populated by the
   // module-prerender route's definition-build validation, not a card render.
@@ -255,6 +261,19 @@ export interface PrerenderMeta {
   // `response.meta.diagnostics` so it persists to
   // `boxel_index.diagnostics` for SQL-side perf triage.
   diagnostics?: PrerenderMetaDiagnostics;
+}
+
+// A render.meta payload that also carries the file-extract result for the
+// same file. Produced when the render options request both `cardRender` and
+// `fileExtract`: the meta route materializes the full card payload first,
+// then runs the file extract in its own dependency-tracking session, so an
+// index visit of a card-instance file pays a single route transition for
+// both the instance row and the file row. Drivers split `fileExtract` off
+// the capture before treating the remainder as the card payload; hosts that
+// don't advertise the `fusedIndexMeta` capability never receive both flags
+// and produce a plain PrerenderMeta.
+export interface FusedIndexMeta extends PrerenderMeta {
+  fileExtract?: FileExtractResponse;
 }
 
 // Lightweight payload produced by the host app's render.types route. The
@@ -353,12 +372,17 @@ export interface RenderTimeoutDiagnostics {
   // The `meta` number covers the whole `render.meta` route, so the
   // types / displayNames chain that route builds is inside that bucket, not a
   // step of its own — the standalone `types` route is html-half work driving
-  // the fitted/embedded renders, and never runs on an index visit. Only
+  // the fitted/embedded renders, and never runs on an index visit. On a
+  // card-instance index visit against a fused-capable host, `meta` is the
+  // consolidated transition and also contains the file extract (its share is
+  // itemized as `diagnostics.fileExtractMs`), so `fileExtract` is absent;
+  // `fileExtract` appears where a standalone render.file-extract transition
+  // ran — non-card files, the fallback extract after a card render error, and
+  // a prerender-html visit that resolves its own file resource. Only
   // populated where the index-half step actually runs, so it decomposes the
   // per-visit floor into measured route buckets rather than leaving it
   // inferred from `renderElapsedMs`: on an index visit it rides
-  // `boxel_index.diagnostics`; the `fileExtract` leg can also appear on a
-  // prerender-html visit that resolves its own file resource.
+  // `boxel_index.diagnostics`.
   indexRoutesMs?: {
     card?: Record<string, number>;
     file?: Record<string, number>;


### PR DESCRIPTION
When the indexer visits a card-instance `.json` file, one prerender visit produces two payloads: the file row's extract (resource, content hash, FileDef types, deps) and the instance row's meta (search doc, serialized card, types, deps). Those payloads came from two separate route transitions over the same file — `render.file-extract`, then `render.meta` — and the per-route `indexRoutesMs` diagnostics show that on trivial cards nearly all of that cost is the transition/settle machinery around each route, not the payload computation: on a staging from-scratch reindex of a benchmark realm, instances with under 5 ms of search-doc work still averaged ~150 ms per visit, with the extract leg costing a flat ~80–100 ms regardless of card complexity.

This PR collapses the pair into a single transition, so a card-instance index visit pays one transition + settle instead of two.

## How it works

**Host.** Render options carrying both `cardRender` and `fileExtract` take the card branch of the render route (source fetch, hydration, settle). The meta route materializes the full card payload first, then runs the file extract and returns it as a `fileExtract` sub-object on the same JSON payload (`FusedIndexMeta`). The extract body is shared with the standalone `render.file-extract` route through the new `file-extract-runner` util, so both entry points produce identical file-row payloads. The extract runs in a fresh dependency-tracking session: the tracker is session-scoped and a snapshot reads the whole session, so sharing the card's session would fold the hydration graph into the file row's deps. Because the card payload (including its deps snapshot) is fully materialized before the extract starts, nothing the extract does can leak into the instance row.

**Server driver.** A `visitType: 'index'` visit that requests both `cardRender` and `fileExtract` sends one fused pass. Everything else keeps per-pass transitions: non-card files, the on-demand prerender proxy's single-flag requests, a prerender-html visit's self-resolving extract, and the fused (union) visit, whose meta must run after the html renders.

**Deploy skew.** The host and the prerender server deploy independently, and a pooled page pins whatever host build it loaded. The runner therefore probes each page's `__boxelHostCapabilities.fusedIndexMeta` global on the same CDP round-trip that stamps auth/jobId (zero extra round-trips). The capability is stamped by the module the standby route evaluates during page bootstrap, so it is always visible before the first probe. A page without it gets the per-pass sequence.

**Errors.** The host render route has two error traps with different recoverability: the route `error()` hook catches errors Ember's machinery survives, while the window-level trap catches errors that wedge the run loop and is the only path that marks a page unusable (evicted). The fused pass preserves that split: after a route-level card error the page is still fully operational, so a fallback standalone extract transition still produces the file row — a broken card must still yield a good file row. An auth failure is mirrored onto the file half instead (a fallback transition would hit the same wall), matching the short-circuit a standalone extract takes on auth failure. Host-side, the extract's throws are contained into a `status: 'error'` result so they surface through the route's payload rather than the window trap.

**In-browser driver.** `card-prerender.gts` mirrors the fused pass and the fallback. It needs no capability probe — the driver and the render routes ship in the same build.

**Icon memo.** Unchanged: the card icon still keys off `meta.types[0]` after the split, and the file icon keys off the extract's types, which the split populates before the fileRender pass runs.

## Diagnostics

The fused transition records under `indexRoutesMs.card.meta`, with the extract's share itemized as `diagnostics.fileExtractMs`. `indexRoutesMs.file.fileExtract` now specifically marks a standalone extract transition (non-card files, the fallback after a card error, prerender-html self-resolve). The `indexRoutesMs` type docs and the indexing-diagnostics skill are updated to match.

One adjacent fix: the standalone extract pass no longer plants an `error: undefined` own-key on clean extracts. The console-error merge still runs unconditionally (it drains the page's buffer between passes), but its result is only assigned when it yields an error — the phantom key was invisible over HTTP but made in-process responses deep-unequal to fused ones.

## Measurements

Local bench (trivial card, 20 warm-tab index visits per mode, in-process prerenderer): whole-visit `renderElapsedMs` p50 106 ms → 99 ms, mean 109 ms → 102 ms. The per-leg accounting shows the extract's actual work is ~8–9 ms now riding inside the meta transition; everything else the extract leg used to cost was transition machinery. The absolute saving is machine-dependent — a local in-process transition round-trip is far cheaper than the ~80–100 ms envelope measured on staging, which is the cost this removes at scale.

## Tests

- `prerendering-test.ts` composite-pass orchestration: the fused/index/prerender-html partition test asserts byte-identical outputs and the new `indexRoutesMs` accounting; new tests cover legacy-host equivalence (a host without the capability produces identical output via per-pass transitions), auth-error mirroring with no fallback transition, and the fallback extract after a deterministic card error (with `evicted: false` pinned — route-level errors must not evict).
- `indexing-test.ts`: full module green — persisted `search_doc` / `deps` / `types` / file-meta rows are unchanged under the fused pipeline.
- Host: new acceptance test pins that a fused render's `fileExtract` sub-object equals the standalone `render.file-extract` payload for the same file (deps set-equal, proving session isolation); prerender meta/file-extract/html/module suites, all file-def suites, and the in-browser realm-indexing integration suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
