### PR TITLE
Unify card/file identity: stamp id into file search_doc

### DIFF
--- a/packages/host/tests/integration/store-search-test.gts
+++ b/packages/host/tests/integration/store-search-test.gts
@@ -235,6 +235,28 @@ module('Integration | store search public API', function (hooks) {
     );
   });
 
+  test('a file is matchable by eq on its id (the unified card/file identity key)', async function (assert) {
+    // The file-indexer stamps `id` (= the file URL) into the file search_doc,
+    // so a file is addressable by `eq: { id }` the same way a card instance is.
+    let fileURL = `${testRealmURL}files/hello.txt`;
+    let doc = await storeService.searchEntries(
+      {
+        filter: {
+          'item.on': baseFileRef,
+          eq: { 'item.id': fileURL },
+        },
+        fields: { entry: ['item'] },
+      },
+      [testRealmURL],
+    );
+
+    assert.deepEqual(
+      doc.data.map((entry) => entry.id),
+      [fileURL],
+      'exactly the file with that id is returned',
+    );
+  });
+
   test('the file tree consumer works via searchEntries', async function (assert) {
     let fileTree = fileTreeFromIndex(storeService, () => testRealmURL);
     fileTree.entries; // reading the resource activates it

--- a/packages/host/tests/unit/instance-filter-matcher-test.ts
+++ b/packages/host/tests/unit/instance-filter-matcher-test.ts
@@ -21,7 +21,7 @@ import { shimExternals } from '@cardstack/host/lib/externals';
 
 import { testRealmURL, p } from '../helpers';
 
-import type { CardDef } from '@cardstack/base/card-api';
+import type { CardDef, FileDef } from '@cardstack/base/card-api';
 
 let { resolvedBaseRealmURL } = ENV;
 
@@ -33,6 +33,7 @@ module('Unit | instance-filter-matcher', function (hooks) {
   let catRef: CodeRef;
   let eventRef: CodeRef;
   let cards: Record<string, CardDef> = {};
+  let fileDef: FileDef;
 
   hooks.beforeEach(async function () {
     let virtualNetwork = new VirtualNetwork();
@@ -80,6 +81,7 @@ module('Unit | instance-filter-matcher', function (hooks) {
       linksToMany,
       CardDef,
       FieldDef,
+      FileDef,
       setCardAsSavedForTest,
     } = cardApi;
     let { default: StringField } = string;
@@ -168,6 +170,15 @@ module('Unit | instance-filter-matcher', function (hooks) {
       card.id = rri(`${testRealmURL}${name}`);
       setCardAsSavedForTest(card);
     }
+
+    let fileURL = `${testRealmURL}files/hello.md`;
+    fileDef = new FileDef({
+      id: fileURL,
+      sourceUrl: fileURL,
+      url: fileURL,
+      name: 'hello.md',
+      contentType: 'text/markdown',
+    });
   });
 
   function match(card: CardDef, filter: Filter) {
@@ -719,9 +730,53 @@ module('Unit | instance-filter-matcher', function (hooks) {
     );
     assert.true(isClientEvaluable({ contains: { _title: 'x' } }));
     assert.true(isClientEvaluable({ eq: { name: 'Mango' } }), 'a real field');
+    assert.true(
+      isClientEvaluable({ eq: { id: 'x' } }),
+      'the id identity key is a real field and stays client-evaluable (so file id filters route through the matcher, not server-only)',
+    );
     assert.false(
       isClientEvaluable({ eq: { _mysteryServerKey: 1 } }),
       'an unshimmed underscore key forces server-only evaluation',
+    );
+  });
+
+  // -- file rows: the unified `id` identity key -------------------------------
+  // The file-indexer stamps `id` (= the file URL) into a file's search doc, so a
+  // mixed card/file query can address either kind by `eq: { id }`. `id` is a
+  // real FileDef field (not a synthetic key), so the client matcher resolves it
+  // via the normal field path — but guard it, because live reconciliation of a
+  // file id filter would drop correct rows if it ever diverged from the server.
+
+  test('eq on id matches a FileDef by its url', function (assert) {
+    assert.strictEqual(
+      matchInstanceAgainstFilter(
+        fileDef,
+        { eq: { id: `${testRealmURL}files/hello.md` } },
+        api,
+      ),
+      'match',
+      'a file matches its own id',
+    );
+    assert.strictEqual(
+      matchInstanceAgainstFilter(
+        fileDef,
+        { eq: { id: `${testRealmURL}files/other.md` } },
+        api,
+      ),
+      'no-match',
+      'a file does not match a different id',
+    );
+  });
+
+  test('not: eq on id excludes a FileDef by its url (the already-selected exclusion)', function (assert) {
+    assert.strictEqual(
+      matchInstanceAgainstFilter(
+        fileDef,
+        { not: { eq: { id: `${testRealmURL}files/hello.md` } } },
+        api,
+      ),
+      'no-match',
+      'excluding a file by its id removes it',
     );
   });
 });

--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -844,6 +844,128 @@ module(basename(import.meta.filename), function () {
       assert.strictEqual(fileItems.length, 0, 'no file rows leak in');
     });
 
+    test('a mixed `any` spanning a card-type anchor and a FileDef field-eq returns both kinds', async function (assert) {
+      // A mixed-kind chooser scopes its results with an OR across a card type
+      // and a FileDef-anchored field predicate (e.g. skill cards + skill `.md`
+      // files). Two positive type/on conditions compose under `any`: the
+      // branches live in separate SQL subexpressions, so the shared `types`
+      // cross-join alias — which blocks two positive type conditions under a
+      // single `every` chain — is not a problem for the OR shape. The file
+      // branch is a plain field-eq, so this generalizes to a filter like
+      // `{ on: MarkdownDef, eq: { kind: 'skill' } }`.
+      let helloUrl = `${realmHref}hello.md`;
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        parseSearchEntryQueryFromPayload({
+          filter: {
+            any: [
+              { 'item.on': { module: `${realmHref}person`, name: 'Person' } },
+              {
+                'item.on': { module: baseRRI('card-api'), name: 'FileDef' },
+                eq: { 'item.name': 'hello.md' },
+              },
+            ],
+          },
+          fields: { entry: ['item'] },
+        }),
+      );
+      assert.ok(
+        entryFor(doc, johnId),
+        'John (card instance) matches the card-type branch',
+      );
+      assert.ok(
+        entryFor(doc, janeId),
+        'Jane (card instance) matches the card-type branch',
+      );
+      assert.strictEqual(
+        itemIn(doc, johnId)?.type,
+        'card',
+        'John carries a card item',
+      );
+      assert.ok(
+        entryFor(doc, helloUrl),
+        'hello.md (file) matches the FileDef field-eq branch',
+      );
+      assert.strictEqual(
+        itemIn(doc, helloUrl)?.type,
+        'file-meta',
+        'hello.md carries a file-meta item',
+      );
+    });
+
+    test('a file row is matchable and excludable by `eq: { item.id }`', async function (assert) {
+      // The file-indexer stamps `id` (= the file URL) into the file search_doc,
+      // so a file is addressable by `eq: { id }` the same way a card instance
+      // row is — the unified identity key a mixed-kind chooser uses across both
+      // kinds (e.g. to exclude an already-selected item regardless of kind).
+      let helloUrl = `${realmHref}hello.md`;
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        parseSearchEntryQueryFromPayload({
+          filter: {
+            'item.on': { module: baseRRI('card-api'), name: 'FileDef' },
+            eq: { 'item.id': helloUrl },
+          },
+          fields: { entry: ['item'] },
+        }),
+      );
+      assert.ok(entryFor(doc, helloUrl), 'the file matches eq on item.id');
+      assert.strictEqual(
+        doc.meta.page.total,
+        1,
+        'exactly one row matches the id',
+      );
+
+      // And `not: { eq: { id } }` excludes it — the exclusion polarity a chooser
+      // relies on for already-selected items.
+      let excluded = await testRealm.realmIndexQueryEngine.searchEntries(
+        parseSearchEntryQueryFromPayload({
+          filter: {
+            every: [
+              { 'item.on': { module: baseRRI('card-api'), name: 'FileDef' } },
+              { not: { eq: { 'item.id': helloUrl } } },
+            ],
+          },
+          fields: { entry: ['item'] },
+        }),
+      );
+      assert.notOk(
+        entryFor(excluded, helloUrl),
+        'not: { eq: { id } } excludes the file row',
+      );
+    });
+
+    test('a dual-indexed card `.json` file row carries `id` = the `.json` URL (distinct from the instance row)', async function (assert) {
+      // A card `.json` produces two rows: the instance row (id `.../john`) and
+      // its dual-indexed file row (id `.../john.json`). The file row's stamped
+      // `id` is its own `.json` URL, so `eq: { id: '.../john.json' }` selects
+      // exactly that file row — never the instance — and the instance stays
+      // addressable by its bare id. `scope: 'all'` keeps both rows in play so
+      // the file row isn't deduped away before the id predicate runs.
+      let jsonUrl = `${johnId}.json`;
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        parseSearchEntryQueryFromPayload({
+          scope: 'all',
+          filter: {
+            'item.on': { module: baseRRI('card-api'), name: 'FileDef' },
+            eq: { 'item.id': jsonUrl },
+          },
+          fields: { entry: ['item'] },
+        }),
+      );
+      assert.ok(
+        entryFor(doc, jsonUrl),
+        'the card `.json` file row matches its own `.json` id',
+      );
+      assert.strictEqual(
+        itemIn(doc, jsonUrl)?.type,
+        'file-meta',
+        'the matched row is the file-meta row, not the card instance',
+      );
+      assert.notOk(
+        entryFor(doc, johnId),
+        'the bare-id card instance row is not matched by the `.json` id',
+      );
+    });
+
     test('A-Z `_title` sort gives file rows real sort values (not a NULL that sinks them)', async function (assert) {
       // Regression guard for the mixed-search A-Z sort. A file row carries the
       // synthetic `_title` but not `cardTitle`, so sorting on `cardTitle`

--- a/packages/runtime-common/index-runner/file-indexer.ts
+++ b/packages/runtime-common/index-runner/file-indexer.ts
@@ -217,6 +217,12 @@ export async function performFileIndexing({
     ...(extractResult.searchDoc ?? {}),
     ...(isCardInstance ? { [CARD_INSTANCE_FILE_KEY]: true } : {}),
     _title: name,
+    // Stamp `id` (the file's own URL) so a file row is addressable by
+    // `eq: { id }` the same way a card instance row is — `FileDef` already
+    // declares an `id` field, the search_doc just never carried it. Placed
+    // last (like `_title`) so it deterministically equals the file URL
+    // regardless of what the extractor's searchDoc contained.
+    id: fileURL,
   };
 
   // A frontmatter parse failure — or any diagnostics bag the frontmatter

--- a/packages/runtime-common/instance-filter-matcher.ts
+++ b/packages/runtime-common/instance-filter-matcher.ts
@@ -129,7 +129,7 @@ function operatorPathsClientEvaluable(
 }
 
 export function matchInstanceAgainstFilter(
-  instance: CardDef,
+  instance: BaseDef,
   filter: Filter,
   api: CardAPIForMatching,
 ): MatchResult {


### PR DESCRIPTION
Closes CS-12204.

## What

`FileDef` already declares an `id` field, but the file-indexer never copied it into a file's `search_doc` — so a file row could not be matched by `eq: { id }` the way a card instance row can. This stamps `id` (= the file's own URL) into the file search_doc on both the `file` and `file-error` rows, unifying identity across cards and files so a mixed card/file query can address either kind by one key.

This is the index-layer foundation (Phase 1) for the mixed cards+files chooser (parent CS-11809): a mixed-kind chooser needs a single `not: { eq: { id } }` to exclude an already-selected item regardless of whether it's a card or a file.

## Why `id`, not a synthetic key

`id` is the same concept under the same key name the engine already understands for cards — unlike the synthetic `_title`/`_cardType` keys, which exist because cards and files store those under different real keys. `id` needs no client shim: it resolves through the normal field path on both `CardDef` and `FileDef` (both declare `@field id`). The engine's only `id` special-casing is for a `linksTo` path stopping at `.id`, not top-level `eq: { id }`.

## Tests

- **realm-server** (`search-entries-engine-test.ts`): a file is matchable and excludable by `eq: { item.id }`; a dual-indexed card `.json` file row carries `id` = its own `.json` URL (distinct from the instance row, which stays addressable by its bare id). Full module green (33/33).
- **host store search** (`store-search-test.gts`): a file is returned by an `eq: { id }` query through the store path.
- **host client-matcher parity** (`instance-filter-matcher-test.ts`): a `FileDef` matches / is excluded by `eq: { id }`, and `id` stays client-evaluable (so live-search reconciliation routes id filters through the matcher rather than server-only).

## Deployment / reindex note

The `id` key only appears on file rows **reindexed after this lands**. Deploy realm-server, then reindex the affected realms (as with the CS-11774/#5428 index changes). Consumers that rely on file `eq: { id }` must tolerate the pre-reindex window — the Phase 3 chooser keeps a client-side exclusion fallback for exactly this reason. Rolling back needs no index migration: the extra key is inert to old code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
