### PR TITLE
Make block card/file embed refs use the legible inline highlight

### DIFF
--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -1602,17 +1602,6 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           color: var(--boxel-400, #666);
         }
 
-        .codemirror-editor :deep(.cm-bfm-card-ref--block) {
-          display: inline-block;
-          font-size: 0.85em;
-          color: var(--boxel-400, #666);
-          padding: 2px 6px;
-        }
-
-        .codemirror-editor :deep(.cm-bfm-card-ref--active) {
-          background-color: var(--boxel-highlight-hover, #e8f0fe);
-        }
-
         /* ── Card widget containers ── */
         .codemirror-editor :deep(.cm-card-widget) {
           user-select: none;

--- a/packages/host/app/lib/codemirror-context.ts
+++ b/packages/host/app/lib/codemirror-context.ts
@@ -672,8 +672,7 @@ function buildCardDecorations(
           from,
           to,
           value: Decoration.mark({
-            class:
-              'cm-bfm-card-ref cm-bfm-card-ref--block cm-bfm-card-ref--active',
+            class: 'cm-bfm-card-ref cm-bfm-card-ref--inline',
           }),
         });
       } else if (onCursor) {
@@ -682,8 +681,7 @@ function buildCardDecorations(
           from,
           to,
           value: Decoration.mark({
-            class:
-              'cm-bfm-card-ref cm-bfm-card-ref--block cm-bfm-card-ref--active',
+            class: 'cm-bfm-card-ref cm-bfm-card-ref--inline',
           }),
         });
         let previewWidget = new CardWidget(cardId, 'block', refType);


### PR DESCRIPTION
## Problem

In the compose-mode markdown editor (`RichMarkdownField` → CodeMirror), a block card/file embed reference (`::card[...]` / `::file[...]`) was highlighted with a **teal** background and taller padding, making the grey syntax text illegible. The inline reference (`:card[...]`) already used a legible light-grey highlight.

Per design feedback on [CS-11750](https://linear.app/cardstack/issue/CS-11750/readability-of-compose-mode-cardfile-embed-synatx), both inline and block references should use the same light-grey treatment.

## Root cause

Block refs always received an extra `cm-bfm-card-ref--active` class, whose CSS painted `background-color: var(--boxel-highlight-hover)` — which resolves to the teal `--boxel-dark-teal` (`#00da9f`). They also carried `cm-bfm-card-ref--block`, adding `display: inline-block` + extra vertical padding (the taller pill). Inline refs never got either.

## Fix

- In `buildCardDecorations` (`packages/host/app/lib/codemirror-context.ts`), the two block-ref branches now emit the same `cm-bfm-card-ref cm-bfm-card-ref--inline` class the inline branches use.
- Removed the now-unused `.cm-bfm-card-ref--block` and `.cm-bfm-card-ref--active` CSS rules from `packages/base/codemirror-editor.gts`.

Purely a highlight/CSS change — no parsing, widget, or toolbar behavior is affected. The block preview widget (rendered below the cursor line) uses separate `cm-card-widget--block` classes and is unchanged.

## Testing

- `pnpm lint:types` in `packages/host` — no new type errors from this change.
- Visual: open `RichMarkdownPlayground` in compose mode; with the cursor on a `::card[...]` line the block ref now shows grey text on a light-grey highlight matching the inline `:card[...]`, with no teal.

## Screen Recording


https://github.com/user-attachments/assets/45bda60a-3a1f-422a-9c7b-ba2998e9eea3



🤖 Generated with [Claude Code](https://claude.com/claude-code)