### PR TITLE
Test PR (catalog copy): Poster board step 2

### DIFF
--- a/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
+++ b/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
@@ -1,0 +1,55 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "cardInfo": {
+        "name": "Demo Poster Board"
+      },
+      "frameSettings": [
+        {
+          "cardIndex": 3,
+          "x": 460,
+          "y": 340
+        },
+        {
+          "cardIndex": 4,
+          "x": 680,
+          "y": 90
+        }
+      ]
+    },
+    "relationships": {
+      "cards.0": {
+        "links": {
+          "self": "../../4b6602-wine-cellar-card-definition/WineBottle/011f0239-9a66-405f-a874-32bb4146ee7b"
+        }
+      },
+      "cards.1": {
+        "links": {
+          "self": "../../d29736-tier-list/TierList/my-language-ranking"
+        }
+      },
+      "cards.2": {
+        "links": {
+          "self": "../../blog-app/games/Wordle/play"
+        }
+      },
+      "cards.3": {
+        "links": {
+          "self": "../../673fb6-blackjack-cardgame-definition/Blackjack/be0fd885-7672-4379-a001-ea8611da2ec2"
+        }
+      },
+      "cards.4": {
+        "links": {
+          "self": "../../4b6602-wine-cellar-card-definition/WineBottle/7bc1c7b6-f051-4a45-aaba-8f41b62eed0d"
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../poster-board",
+        "name": "PosterBoard"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/poster-board/README.md
+++ b/packages/experiments-realm/poster-board/README.md
@@ -1,0 +1,53 @@
+# Poster Board
+
+A FigJam-style infinite-canvas board card: pan, wheel/pinch zoom at the
+cursor with momentum, and a zoom toolbar. `rig.gts` is the pure-TS camera
+engine; `poster-board.gts` is the `PosterBoard` card def that renders it.
+
+## Running the tests
+
+Tests live in `poster-board.test.gts` and run on the catalog live-test
+infrastructure (see `../tests/live/README.md` for the full details): the
+realm serves the test file, and the host's QUnit runner discovers and loads
+it at runtime.
+
+### 1. Start the servers
+
+From the monorepo project root:
+
+```bash
+mise run dev-all
+```
+
+This brings up the whole dev stack — host dev server (port 4200) plus the
+realm server stack (base + catalog realms, matrix, smtp) — in the right
+order.
+
+### 2a. Run in the browser (interactive)
+
+```
+https://localhost:4200/tests/index.html?liveTest=true&realmURL=https%3A%2F%2Flocalhost%3A4201%2Fcatalog%2F&filter=poster-board
+```
+
+`filter=` matches QUnit module names — `poster-board` selects the
+`Rendering | poster-board card` module. Drop it to run every live test in
+the catalog realm.
+
+### 2b. Run headless (CLI)
+
+```bash
+cd packages/host && pnpm build   # test page runs from ./dist
+REALM_URL="https://localhost:4201/catalog/" \
+  npx ember test --config-file testem-live.js --path ./dist --filter "poster-board"
+```
+
+Or run the full catalog suite the CI way: `REALM_URL="https://localhost:4201/catalog/" pnpm test:live`.
+
+### Caveats
+
+- After adding or moving a `.test.gts` file, the realm has to re-index before
+  the runner's `_mtimes` discovery sees it — restart `mise run dev-all` if a
+  new test doesn't show up.
+- The live-test CI job does **not** run on catalog-only PRs (its path filter
+  excludes `packages/catalog/contents/**`) — run the tests locally before
+  merging and say so in the PR.

--- a/packages/experiments-realm/poster-board/poster-board.gts
+++ b/packages/experiments-realm/poster-board/poster-board.gts
@@ -1,0 +1,426 @@
+import {
+  CardDef,
+  Component,
+  FieldDef,
+  field,
+  contains,
+  containsMany,
+  linksToMany,
+} from 'https://cardstack.com/base/card-api';
+import NumberField from 'https://cardstack.com/base/number';
+import { tracked } from '@glimmer/tracking';
+import { htmlSafe } from '@ember/template';
+import { get } from '@ember/helper';
+import { on } from '@ember/modifier';
+import Modifier from 'ember-modifier';
+import { FittedCardContainer } from '@cardstack/boxel-ui/components';
+import { fittedFormatById } from '@cardstack/boxel-ui/helpers';
+import LayoutDashboardIcon from '@cardstack/boxel-icons/layout-dashboard';
+import { RigState, SurfaceRig, type PanSession } from './rig';
+
+// Tiles use the shared cardsgrid-tile fitted size so boards show cards at a
+// size their fitted views are designed for. FittedCardContainer applies the
+// dimensions; these constants drive the grid placement math.
+const cardsgridTile = fittedFormatById.get('cardsgrid-tile')!;
+const TILE_WIDTH = cardsgridTile.width;
+const TILE_HEIGHT = cardsgridTile.height;
+const TILE_GAP = 32;
+const GRID_COLUMNS = 4;
+// Breathing room between the world origin and the default grid (~--boxel-sp-xs)
+const GRID_PADDING = 10;
+
+interface TilePlacement {
+  index: number;
+  x: number;
+  y: number;
+}
+
+// Cards without a persisted frame setting flow into a fixed grid.
+function defaultPlacement(index: number): TilePlacement {
+  return {
+    index,
+    x: GRID_PADDING + (index % GRID_COLUMNS) * (TILE_WIDTH + TILE_GAP),
+    y:
+      GRID_PADDING +
+      Math.floor(index / GRID_COLUMNS) * (TILE_HEIGHT + TILE_GAP),
+  };
+}
+
+export class FrameSettingsField extends FieldDef {
+  static displayName = 'Frame Settings';
+
+  @field cardIndex = contains(NumberField);
+  @field x = contains(NumberField);
+  @field y = contains(NumberField);
+}
+
+interface OnInsertSignature {
+  Element: HTMLElement;
+  Args: {
+    Positional: [(el: HTMLElement) => void];
+  };
+}
+
+class OnInsert extends Modifier<OnInsertSignature> {
+  modify(el: HTMLElement, [callback]: [(el: HTMLElement) => void]) {
+    callback(el);
+  }
+}
+
+class Isolated extends Component<typeof PosterBoard> {
+  rig = new RigState();
+  surfaceRig = new SurfaceRig(this.rig);
+
+  @tracked isPanning = false;
+  private panSession: PanSession | null = null;
+  private rootElement: HTMLElement | null = null;
+  private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
+
+  get zoomLabel() {
+    return Math.round(this.rig.magnify * 100) + '%';
+  }
+
+  get planeStyle() {
+    const r = this.rig;
+    return htmlSafe(
+      `transform: scale(${r.magnify}) translate(${r.worldX}px, ${r.worldY}px); transform-origin: 0 0;`,
+    );
+  }
+
+  get rootStyle() {
+    return htmlSafe(`cursor: ${this.isPanning ? 'grabbing' : 'grab'};`);
+  }
+
+  // ── Tile placement ─────────────────────────────────────
+
+  get tilePlacements(): TilePlacement[] {
+    let cards = this.args.model?.cards ?? [];
+    let settings = this.args.model?.frameSettings ?? [];
+    return cards.map((_card, index) => {
+      let setting = settings.find((s) => Number(s.cardIndex) === index);
+      // Number() guards against non-numeric values in hand-edited JSON
+      let x = Number(setting?.x);
+      let y = Number(setting?.y);
+      if (setting && Number.isFinite(x) && Number.isFinite(y)) {
+        return { index, x, y };
+      }
+      return defaultPlacement(index);
+    });
+  }
+
+  get hasCards() {
+    return this.tilePlacements.length > 0;
+  }
+
+  tileStyle = (tile: TilePlacement) =>
+    htmlSafe(`left: ${tile.x}px; top: ${tile.y}px;`);
+
+  // ── Wheel ──────────────────────────────────────────────
+
+  handleWheel = (event: Event) => {
+    this.surfaceRig.handleWheel(event as WheelEvent);
+  };
+
+  // ── Pointer pan ────────────────────────────────────────
+
+  handlePointerDown = (rawEvent: Event) => {
+    const event = rawEvent as PointerEvent;
+    const target = event.target as HTMLElement;
+    if (target.closest('[data-poster-board-hud]')) {
+      return;
+    }
+    this.panSession = this.surfaceRig.startPan(event.clientX, event.clientY);
+    this.isPanning = true;
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    event.preventDefault();
+  };
+
+  handlePointerMove = (rawEvent: Event) => {
+    const event = rawEvent as PointerEvent;
+    this.panSession?.move(event.clientX, event.clientY);
+  };
+
+  handlePointerUp = (rawEvent: Event) => {
+    const event = rawEvent as PointerEvent;
+    if (!this.panSession) {
+      return;
+    }
+    this.panSession.end();
+    this.panSession = null;
+    this.isPanning = false;
+    try {
+      (event.currentTarget as HTMLElement).releasePointerCapture(
+        event.pointerId,
+      );
+    } catch {
+      // pointer capture may already be released (e.g. pointercancel)
+    }
+  };
+
+  // ── Zoom controls ──────────────────────────────────────
+
+  zoomIn = () => {
+    this.surfaceRig.zoomCentered(1.2, this.rootElement);
+  };
+
+  zoomOut = () => {
+    this.surfaceRig.zoomCentered(1 / 1.2, this.rootElement);
+  };
+
+  zoom100 = () => {
+    this.surfaceRig.zoomCentered(1 / this.rig.magnify, this.rootElement);
+  };
+
+  resetView = () => {
+    this.surfaceRig.stopAll();
+    this.rig.worldX = 0;
+    this.rig.worldY = 0;
+    this.rig.magnify = 1;
+  };
+
+  handleKeyDown = (event: KeyboardEvent) => {
+    const target = event.target as HTMLElement;
+    if (
+      target.tagName === 'INPUT' ||
+      target.tagName === 'TEXTAREA' ||
+      target.isContentEditable
+    ) {
+      return;
+    }
+    if (event.shiftKey && (event.key === '=' || event.key === '+')) {
+      event.preventDefault();
+      this.zoomIn();
+    } else if (event.shiftKey && event.key === '-') {
+      event.preventDefault();
+      this.zoomOut();
+    } else if (event.shiftKey && event.key === '0') {
+      event.preventDefault();
+      this.zoom100();
+    }
+  };
+
+  // ── Lifecycle ──────────────────────────────────────────
+
+  handleInserted = (el: HTMLElement) => {
+    this.rootElement = el;
+    this.keydownHandler = this.handleKeyDown;
+    window.addEventListener('keydown', this.keydownHandler);
+  };
+
+  willDestroy(): void {
+    if (this.keydownHandler) {
+      window.removeEventListener('keydown', this.keydownHandler);
+      this.keydownHandler = null;
+    }
+    this.surfaceRig.destroy();
+    super.willDestroy();
+  }
+
+  <template>
+    {{! template-lint-disable no-inline-styles no-pointer-down-event-binding }}
+    <div
+      class='poster-board-root'
+      style={{this.rootStyle}}
+      {{OnInsert this.handleInserted}}
+      {{on 'wheel' this.handleWheel}}
+      {{on 'pointerdown' this.handlePointerDown}}
+      {{on 'pointermove' this.handlePointerMove}}
+      {{on 'pointerup' this.handlePointerUp}}
+      {{on 'pointercancel' this.handlePointerUp}}
+      data-test-poster-board
+    >
+      <div class='poster-board-plane' style={{this.planeStyle}}>
+        <div class='poster-board-grid' aria-hidden='true'></div>
+        {{#each this.tilePlacements key='index' as |tile|}}
+          <FittedCardContainer
+            @size='cardsgrid-tile'
+            @style={{this.tileStyle tile}}
+            class='poster-board-tile'
+            data-test-poster-board-tile={{tile.index}}
+          >
+            {{#let (get @fields.cards tile.index) as |LinkedCard|}}
+              <LinkedCard @format='fitted' />
+            {{/let}}
+          </FittedCardContainer>
+        {{/each}}
+        {{#unless this.hasCards}}
+          <header class='poster-board-hint'>
+            <h1 class='poster-board-hint-title'><@fields.cardTitle /></h1>
+            <p class='poster-board-hint-line'>Scroll to pan · ⌘ or Ctrl + scroll
+              to zoom · Drag to pan</p>
+          </header>
+        {{/unless}}
+      </div>
+
+      <div
+        class='poster-board-hud'
+        role='toolbar'
+        aria-label='Zoom controls'
+        data-poster-board-hud
+        data-test-poster-board-hud
+      >
+        <button
+          type='button'
+          class='poster-board-hud-btn'
+          aria-label='Zoom in'
+          {{on 'click' this.zoomIn}}
+          data-test-zoom-in
+        >+</button>
+        <output
+          class='poster-board-hud-zoom'
+          aria-label='Zoom level'
+          data-test-zoom-level
+        >{{this.zoomLabel}}</output>
+        <button
+          type='button'
+          class='poster-board-hud-btn'
+          aria-label='Zoom out'
+          {{on 'click' this.zoomOut}}
+          data-test-zoom-out
+        >−</button>
+        <button
+          type='button'
+          class='poster-board-hud-btn poster-board-hud-btn-wide'
+          {{on 'click' this.zoom100}}
+          data-test-zoom-reset
+        >100%</button>
+        <button
+          type='button'
+          class='poster-board-hud-btn poster-board-hud-btn-wide'
+          {{on 'click' this.resetView}}
+          data-test-fit
+        >Fit</button>
+      </div>
+    </div>
+
+    <style scoped>
+      .poster-board-root {
+        --pb-grid-extent: 625rem;
+        --pb-grid-cell-size: 1.5rem;
+        --pb-hud-btn-size: 1.625rem;
+        --pb-hud-btn-font-size: 0.8125rem;
+        --pb-hud-label-font-size: 0.625rem;
+        --pb-hud-zoom-min-width: 2.125rem;
+        --pb-hud-border-radius: 0.5rem;
+        --pb-hud-btn-border-radius: 0.3125rem;
+        position: relative;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        touch-action: none;
+        min-width: 0;
+      }
+
+      .poster-board-plane {
+        will-change: transform;
+      }
+
+      .poster-board-tile {
+        position: absolute;
+      }
+
+      .poster-board-grid {
+        position: absolute;
+        inset: calc(var(--pb-grid-extent) / -2);
+        width: var(--pb-grid-extent);
+        height: var(--pb-grid-extent);
+        pointer-events: none;
+        background-image: radial-gradient(
+          circle,
+          color-mix(in oklch, var(--muted-foreground) 35%, transparent) 1px,
+          transparent 1px
+        );
+        background-size: var(--pb-grid-cell-size) var(--pb-grid-cell-size);
+      }
+
+      .poster-board-hint {
+        position: absolute;
+        top: 2.5rem;
+        left: 2.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-2xs);
+        pointer-events: none;
+        user-select: none;
+      }
+
+      .poster-board-hint-title {
+        margin: 0;
+        font-size: var(--boxel-font-size-lg);
+        font-weight: 600;
+      }
+
+      .poster-board-hint-line {
+        margin: 0;
+        font-size: var(--boxel-font-size-sm);
+        color: var(--muted-foreground);
+      }
+
+      .poster-board-hud {
+        position: absolute;
+        top: var(--boxel-sp-xs);
+        right: var(--boxel-sp-xs);
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp-4xs);
+        padding: var(--boxel-sp-4xs) var(--boxel-sp-2xs);
+        background: color-mix(in oklch, var(--card) 88%, transparent);
+        color: var(--card-foreground);
+        border: 1px solid var(--border);
+        border-radius: var(--pb-hud-border-radius);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        box-shadow: 0 0.125rem 0.5rem
+          color-mix(in oklch, var(--foreground) 8%, transparent);
+        z-index: 10;
+        cursor: default;
+      }
+
+      .poster-board-hud-btn {
+        width: var(--pb-hud-btn-size);
+        height: var(--pb-hud-btn-size);
+        border: none;
+        border-radius: var(--pb-hud-btn-border-radius);
+        background: var(--muted);
+        color: var(--foreground);
+        font-size: var(--pb-hud-btn-font-size);
+        font-weight: 700;
+        cursor: pointer;
+        display: grid;
+        place-items: center;
+        transition: background 0.12s;
+      }
+
+      .poster-board-hud-btn:hover {
+        background: var(--border);
+      }
+
+      .poster-board-hud-btn-wide {
+        width: auto;
+        padding: 0 var(--boxel-sp-2xs);
+        font-size: var(--pb-hud-label-font-size);
+        font-weight: 600;
+      }
+
+      .poster-board-hud-zoom {
+        display: inline-block;
+        min-width: var(--pb-hud-zoom-min-width);
+        text-align: center;
+        font-size: var(--pb-hud-label-font-size);
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+      }
+    </style>
+  </template>
+}
+
+export class PosterBoard extends CardDef {
+  static displayName = 'Poster Board';
+  static icon = LayoutDashboardIcon;
+  static prefersWideFormat = true;
+
+  @field cards = linksToMany(() => CardDef);
+  @field frameSettings = containsMany(FrameSettingsField);
+
+  static isolated = Isolated;
+}

--- a/packages/experiments-realm/poster-board/poster-board.test.gts
+++ b/packages/experiments-realm/poster-board/poster-board.test.gts
@@ -1,0 +1,133 @@
+import { click, triggerEvent } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import { saveCard, testRealmURL } from '@cardstack/host/tests/helpers';
+import {
+  CardDef,
+  setupBaseRealm,
+} from '@cardstack/host/tests/helpers/base-realm';
+import { renderCard } from '@cardstack/host/tests/helpers/render-component';
+import { setupRenderingTest } from '@cardstack/host/tests/helpers/setup';
+
+import { FrameSettingsField, PosterBoard } from './poster-board';
+
+async function renderPosterBoard() {
+  let loader = getService('loader-service').loader;
+  let card = new PosterBoard({});
+  await renderCard(loader, card, 'isolated');
+}
+
+export function runTests() {
+  module('Rendering | poster-board card', function (hooks) {
+    setupRenderingTest(hooks);
+    setupBaseRealm(hooks);
+
+    test('poster-board renders isolated view with zoom toolbar', async function (assert) {
+      await renderPosterBoard();
+
+      assert.dom('[data-test-poster-board]').exists('board surface renders');
+      assert.dom('[data-test-poster-board-hud]').exists('zoom toolbar renders');
+      assert
+        .dom('[data-test-poster-board] h1')
+        .hasText('Untitled Poster Board', 'computed card title renders');
+      assert
+        .dom('[data-test-zoom-level]')
+        .hasText('100%', 'zoom starts at 100%');
+    });
+
+    test('poster-board zoom buttons change and reset the zoom level', async function (assert) {
+      await renderPosterBoard();
+
+      await click('[data-test-zoom-in]');
+      assert.dom('[data-test-zoom-level]').hasText('120%', 'zoom in → 120%');
+
+      await click('[data-test-zoom-out]');
+      assert
+        .dom('[data-test-zoom-level]')
+        .hasText('100%', 'zoom out returns to 100%');
+
+      await click('[data-test-zoom-in]');
+      await click('[data-test-zoom-in]');
+      await click('[data-test-zoom-reset]');
+      assert
+        .dom('[data-test-zoom-level]')
+        .hasText('100%', '100% button resets zoom');
+    });
+
+    test('poster-board fit button resets the view', async function (assert) {
+      await renderPosterBoard();
+
+      await click('[data-test-zoom-in]');
+      await click('[data-test-zoom-in]');
+      await click('[data-test-fit]');
+
+      assert
+        .dom('[data-test-zoom-level]')
+        .hasText('100%', 'fit resets zoom to 100%');
+    });
+
+    test('poster-board zoom reset is not undone by pending pinch momentum', async function (assert) {
+      await renderPosterBoard();
+
+      // Pinch-style zoom (ctrl+wheel) records velocity and schedules
+      // momentum to start after a short idle delay
+      await triggerEvent('[data-test-poster-board]', 'wheel', {
+        deltaY: -120,
+        ctrlKey: true,
+      });
+      await click('[data-test-zoom-reset]');
+
+      // Wait past the momentum-start delay (45ms); without clearing it,
+      // the stale pinch velocity would resume and drift off 100%
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      assert
+        .dom('[data-test-zoom-level]')
+        .hasText('100%', 'zoom stays at 100% after momentum delay elapses');
+    });
+
+    test('poster-board renders linked cards at persisted and grid-default positions', async function (assert) {
+      let loader = getService('loader-service').loader;
+
+      class Note extends CardDef {
+        static displayName = 'Note';
+      }
+      loader.shimModule(`${testRealmURL}note`, { Note });
+
+      let note1 = new Note();
+      let note2 = new Note();
+      await saveCard(note1, `${testRealmURL}Note/1`, loader);
+      await saveCard(note2, `${testRealmURL}Note/2`, loader);
+
+      let board = new PosterBoard({
+        cards: [note1, note2],
+        frameSettings: [
+          new FrameSettingsField({ cardIndex: 1, x: 500, y: 120 }),
+        ],
+      });
+      await renderCard(loader, board, 'isolated');
+
+      assert
+        .dom('[data-test-poster-board-tile]')
+        .exists({ count: 2 }, 'a tile renders per linked card');
+      assert
+        .dom('[data-test-poster-board-tile="0"]')
+        .hasStyle(
+          { left: '10px', top: '10px' },
+          'card without settings lands at its padded grid-default slot',
+        );
+      assert
+        .dom('[data-test-poster-board-tile="1"]')
+        .hasStyle(
+          { left: '500px', top: '120px' },
+          'card with frame settings renders at its persisted position',
+        );
+      assert
+        .dom('[data-test-poster-board] h1')
+        .doesNotExist('hint header is hidden when the board has cards');
+    });
+  });
+}

--- a/packages/experiments-realm/poster-board/rig.gts
+++ b/packages/experiments-realm/poster-board/rig.gts
@@ -1,0 +1,373 @@
+import { tracked } from '@glimmer/tracking';
+
+// Pure-TS pan/zoom engine for the board surface. "Rig" as in camera rig: the
+// world stays put while RigState holds the camera (worldX/worldY/magnify) and
+// SurfaceRig moves it with momentum. No DOM dependencies — consumers wire
+// handleWheel / startPan to elements and render from RigState.
+//
+// API at a glance:
+//   handleWheel(event)            wheel → pan; ctrl/cmd+wheel (pinch) → zoom at cursor
+//   startPan(x, y) → PanSession   pointer drag; session.move(x, y) / session.end()
+//   zoomAtPoint(factor, x, y)     programmatic zoom keeping a local point fixed
+//   zoomCentered(factor, el?)     programmatic zoom around an element's center
+//   startPanMomentum() / startZoomMomentum() / stopKineticPan() / stopZoomMomentum()
+//   stopAll() / destroy()         cancel every momentum loop and pending timeout
+
+// ── Constants ──────────────────────────────────────────────
+export const MIN_ZOOM = 0.2; // default zoom clamp; override via SurfaceRigOptions
+export const MAX_ZOOM = 5;
+const ZOOM_SENSITIVITY = 0.0032; // wheel delta → zoom ratio
+const PINCH_ZOOM_BOOST = 1.7; // extra speed for pinch gestures
+const PAN_INERTIA_DECAY = 0.9; // momentum decay per 60fps-normalized frame
+const PAN_INERTIA_MIN_SPEED = 0.0008; // below this, pan momentum stops
+const ZOOM_INERTIA_DECAY = 0.86; // zoom momentum dies faster than pan
+const ZOOM_INERTIA_MIN_SPEED = 0.00008;
+const MOMENTUM_START_DELAY_MS = 45; // idle time after last wheel before momentum
+
+// ── RigState ───────────────────────────────────────────────
+// The camera: starts at the origin, 100% zoom.
+export class RigState {
+  @tracked worldX = 0;
+  @tracked worldY = 0;
+  @tracked magnify = 1;
+}
+
+// ── PanSession ─────────────────────────────────────────────
+export interface PanSession {
+  move(clientX: number, clientY: number): void;
+  end(): void;
+}
+
+// ── SurfaceRig engine ──────────────────────────────────────
+export interface SurfaceRigOptions {
+  minZoom?: number;
+  maxZoom?: number;
+  onChange?: () => void; // fired after every camera change
+  isInteracting?: () => boolean; // true stops momentum loops (e.g. during a drag)
+}
+
+export class SurfaceRig {
+  rig: RigState;
+  private minZoom: number;
+  private maxZoom: number;
+  private onChange: (() => void) | undefined;
+  private isInteracting: (() => boolean) | undefined;
+
+  // Pan momentum state
+  panVelocityX = 0;
+  panVelocityY = 0;
+  private kineticRafId: number | null = null;
+  private kineticLastTime = 0;
+
+  // Zoom momentum state
+  zoomVelocity = 0;
+  zoomAnchorX = 0;
+  zoomAnchorY = 0;
+  private zoomMomentumRafId: number | null = null;
+  private zoomMomentumLastTime = 0;
+
+  // Shared
+  private momentumStartTimeout: ReturnType<typeof setTimeout> | null = null;
+  private lastWheelSampleTime = 0;
+
+  // Pan session tracking
+  private lastPanSampleTime = 0;
+  private lastPanWorldX = 0;
+  private lastPanWorldY = 0;
+
+  constructor(rig: RigState, opts?: SurfaceRigOptions) {
+    this.rig = rig;
+    this.minZoom = opts?.minZoom ?? MIN_ZOOM;
+    this.maxZoom = opts?.maxZoom ?? MAX_ZOOM;
+    this.onChange = opts?.onChange;
+    this.isInteracting = opts?.isInteracting;
+  }
+
+  // ── Wheel handler ──────────────────────────────────────
+
+  handleWheel = (event: WheelEvent) => {
+    this.clearMomentumStartTimeout();
+    this.stopKineticPan();
+    this.stopZoomMomentum();
+
+    event.preventDefault();
+
+    const rig = this.rig;
+    const isZoom = event.ctrlKey || event.metaKey;
+    const now = performance.now();
+    const dt = Math.max(
+      8,
+      this.lastWheelSampleTime ? now - this.lastWheelSampleTime : 16,
+    );
+    this.lastWheelSampleTime = now;
+
+    if (isZoom) {
+      const surface = event.currentTarget as HTMLElement | null;
+      if (!surface) return;
+
+      const rect = surface.getBoundingClientRect();
+      const localX = event.clientX - rect.left;
+      const localY = event.clientY - rect.top;
+
+      const current = rig.magnify;
+      const deltaScale =
+        event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? 120 : 1;
+      const zoomStrength = ZOOM_SENSITIVITY * PINCH_ZOOM_BOOST;
+      const next = clamp(
+        current * Math.exp(-(event.deltaY * deltaScale) * zoomStrength),
+        this.minZoom,
+        this.maxZoom,
+      );
+
+      if (next === current) return;
+
+      rig.worldX = rig.worldX + localX / next - localX / current;
+      rig.worldY = rig.worldY + localY / next - localY / current;
+      rig.magnify = next;
+
+      this.zoomAnchorX = localX;
+      this.zoomAnchorY = localY;
+      this.zoomVelocity = Math.log(next / current) / dt;
+      this.scheduleMomentumStart();
+      this.onChange?.();
+      return;
+    }
+
+    const panScale = 1 / rig.magnify;
+    const dxWorld = -event.deltaX * panScale;
+    const dyWorld = -event.deltaY * panScale;
+    rig.worldX += dxWorld;
+    rig.worldY += dyWorld;
+    this.panVelocityX = dxWorld / dt;
+    this.panVelocityY = dyWorld / dt;
+    this.scheduleMomentumStart();
+    this.onChange?.();
+  };
+
+  // ── Pointer pan session ────────────────────────────────
+
+  startPan(startClientX: number, startClientY: number): PanSession {
+    this.clearMomentumStartTimeout();
+    this.stopKineticPan();
+    this.stopZoomMomentum();
+
+    const rig = this.rig;
+    const startRigX = rig.worldX;
+    const startRigY = rig.worldY;
+    this.lastPanWorldX = rig.worldX;
+    this.lastPanWorldY = rig.worldY;
+    this.lastPanSampleTime = performance.now();
+    this.panVelocityX = 0;
+    this.panVelocityY = 0;
+
+    return {
+      move: (clientX: number, clientY: number) => {
+        const dx = clientX - startClientX;
+        const dy = clientY - startClientY;
+        const nextWorldX = startRigX + dx / rig.magnify;
+        const nextWorldY = startRigY + dy / rig.magnify;
+        rig.worldX = nextWorldX;
+        rig.worldY = nextWorldY;
+
+        const now = performance.now();
+        const dt = Math.max(1, now - this.lastPanSampleTime);
+        this.panVelocityX = (nextWorldX - this.lastPanWorldX) / dt;
+        this.panVelocityY = (nextWorldY - this.lastPanWorldY) / dt;
+        this.lastPanWorldX = nextWorldX;
+        this.lastPanWorldY = nextWorldY;
+        this.lastPanSampleTime = now;
+        this.onChange?.();
+      },
+      end: () => {
+        this.startPanMomentum();
+        this.onChange?.();
+      },
+    };
+  }
+
+  // ── Programmatic zoom (centered on element) ────────────
+  // A programmatic zoom is an explicit camera command: stop momentum loops
+  // and the pending momentum-start timeout first, so stale wheel/pinch
+  // velocity can't resume afterwards and drift the camera off its target.
+
+  zoomCentered(factor: number, el?: HTMLElement | null) {
+    if (!el) {
+      this.stopAll();
+      this.rig.magnify = clamp(
+        this.rig.magnify * factor,
+        this.minZoom,
+        this.maxZoom,
+      );
+      this.onChange?.();
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    const cx = rect.width / 2;
+    const cy = rect.height / 2;
+    this.zoomAtPoint(factor, cx, cy);
+  }
+
+  zoomAtPoint(factor: number, localX: number, localY: number) {
+    this.stopAll();
+    const rig = this.rig;
+    const oldZoom = rig.magnify;
+    const newZoom = clamp(oldZoom * factor, this.minZoom, this.maxZoom);
+    rig.worldX += localX / newZoom - localX / oldZoom;
+    rig.worldY += localY / newZoom - localY / oldZoom;
+    rig.magnify = newZoom;
+    this.onChange?.();
+  }
+
+  // ── Momentum: pan ──────────────────────────────────────
+
+  startPanMomentum() {
+    const speed = Math.hypot(this.panVelocityX, this.panVelocityY);
+    if (speed < PAN_INERTIA_MIN_SPEED) return;
+
+    const step = (now: number) => {
+      if (this.isInteracting?.()) {
+        this.stopKineticPan();
+        return;
+      }
+
+      if (!this.kineticLastTime) {
+        this.kineticLastTime = now;
+      }
+
+      const dt = Math.max(1, now - this.kineticLastTime);
+      this.kineticLastTime = now;
+
+      const rig = this.rig;
+      rig.worldX += this.panVelocityX * dt;
+      rig.worldY += this.panVelocityY * dt;
+
+      const decay = Math.pow(PAN_INERTIA_DECAY, dt / 16.67);
+      this.panVelocityX *= decay;
+      this.panVelocityY *= decay;
+
+      const nextSpeed = Math.hypot(this.panVelocityX, this.panVelocityY);
+      if (nextSpeed < PAN_INERTIA_MIN_SPEED) {
+        this.stopKineticPan();
+        return;
+      }
+
+      this.kineticRafId = requestAnimationFrame(step);
+      this.onChange?.();
+    };
+
+    this.stopKineticPan(false);
+    this.kineticRafId = requestAnimationFrame(step);
+  }
+
+  stopKineticPan(clearVelocity = true) {
+    if (this.kineticRafId !== null) {
+      cancelAnimationFrame(this.kineticRafId);
+      this.kineticRafId = null;
+    }
+    this.kineticLastTime = 0;
+    if (clearVelocity) {
+      this.panVelocityX = 0;
+      this.panVelocityY = 0;
+    }
+  }
+
+  // ── Momentum: zoom ─────────────────────────────────────
+
+  startZoomMomentum() {
+    if (Math.abs(this.zoomVelocity) < ZOOM_INERTIA_MIN_SPEED) return;
+
+    const step = (now: number) => {
+      if (this.isInteracting?.()) {
+        this.stopZoomMomentum();
+        return;
+      }
+
+      if (!this.zoomMomentumLastTime) {
+        this.zoomMomentumLastTime = now;
+      }
+
+      const dt = Math.max(1, now - this.zoomMomentumLastTime);
+      this.zoomMomentumLastTime = now;
+
+      const rig = this.rig;
+      const current = rig.magnify;
+      const next = clamp(
+        current * Math.exp(this.zoomVelocity * dt),
+        this.minZoom,
+        this.maxZoom,
+      );
+
+      if (next === current) {
+        this.stopZoomMomentum();
+        return;
+      }
+
+      rig.worldX =
+        rig.worldX + this.zoomAnchorX / next - this.zoomAnchorX / current;
+      rig.worldY =
+        rig.worldY + this.zoomAnchorY / next - this.zoomAnchorY / current;
+      rig.magnify = next;
+
+      const decay = Math.pow(ZOOM_INERTIA_DECAY, dt / 16.67);
+      this.zoomVelocity *= decay;
+
+      if (Math.abs(this.zoomVelocity) < ZOOM_INERTIA_MIN_SPEED) {
+        this.stopZoomMomentum();
+        return;
+      }
+
+      this.zoomMomentumRafId = requestAnimationFrame(step);
+      this.onChange?.();
+    };
+
+    this.stopZoomMomentum(false);
+    this.zoomMomentumRafId = requestAnimationFrame(step);
+  }
+
+  stopZoomMomentum(clearVelocity = true) {
+    if (this.zoomMomentumRafId !== null) {
+      cancelAnimationFrame(this.zoomMomentumRafId);
+      this.zoomMomentumRafId = null;
+    }
+    this.zoomMomentumLastTime = 0;
+    if (clearVelocity) {
+      this.zoomVelocity = 0;
+    }
+  }
+
+  // ── Momentum scheduling ────────────────────────────────
+
+  scheduleMomentumStart() {
+    this.clearMomentumStartTimeout();
+    this.momentumStartTimeout = setTimeout(() => {
+      this.momentumStartTimeout = null;
+      this.startPanMomentum();
+      this.startZoomMomentum();
+    }, MOMENTUM_START_DELAY_MS);
+  }
+
+  clearMomentumStartTimeout() {
+    if (this.momentumStartTimeout !== null) {
+      clearTimeout(this.momentumStartTimeout);
+      this.momentumStartTimeout = null;
+    }
+  }
+
+  // ── Stop everything ────────────────────────────────────
+
+  stopAll() {
+    this.clearMomentumStartTimeout();
+    this.stopKineticPan();
+    this.stopZoomMomentum();
+  }
+
+  destroy() {
+    this.stopAll();
+  }
+}
+
+// ── Utility ──────────────────────────────────────────────
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}


### PR DESCRIPTION
Test PR for review feedback on the poster-board (steps 1+2) — a verbatim copy of the boxel-catalog `poster-board/` placed in the experiments realm so monorepo review tooling can see it. **Not intended to merge**; the canonical PRs are cardstack/boxel-catalog#666 (pan/zoom board) and cardstack/boxel-catalog#667 (linked-card tiles).

Contents: `rig.gts` (camera engine with momentum), `poster-board.gts` (PosterBoard card def: pan/zoom surface + fitted card tiles placed by `frameSettings` or a default grid), live tests (5 tests / 13 assertions, passing against the catalog realm), README, and the demo instance. Note the demo instance's `cards` links point at catalog-realm paths, so they resolve as broken links inside the experiments realm — expected for this copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)