### PR TITLE
AI Assistant skill menu: one mixed chooser for cards + skill files

### DIFF
--- a/packages/host/app/components/ai-assistant/skill-menu/index.gts
+++ b/packages/host/app/components/ai-assistant/skill-menu/index.gts
@@ -17,6 +17,8 @@ import { baseRRI, chooseCard, skillCardRef } from '@cardstack/runtime-common';
 import SkillToggle from '@cardstack/host/components/ai-assistant/skill-menu/skill-toggle';
 import PillMenu from '@cardstack/host/components/pill-menu';
 
+import { skillsRealmURL } from '@cardstack/host/lib/utils';
+
 import type { RoomSkill } from '@cardstack/host/resources/room';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 
@@ -206,12 +208,13 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
           ...exclusions,
         ],
       },
-      // Scope to the user's own workspaces. The mixed chooser (`includeFiles`)
-      // renders a tile per matching row; without a realm scope it fans out
-      // across every server realm — including large shared realms — and the
-      // intended skills may never finish rendering. Skills a user attaches
-      // come from their workspaces.
-      realms: this.realmServer.userRealmIdentifiers,
+      // Scope to the user's own workspaces plus the shared Boxel Skills realm,
+      // where most attachable skills live. A bounded scope keeps the mixed
+      // chooser (`includeFiles`) from fanning out across every server realm
+      // (base, catalog, …) and stalling on their contents.
+      realms: [
+        ...new Set([...this.realmServer.userRealmIdentifiers, skillsRealmURL]),
+      ],
     };
     let chosen = await chooseCard(query, { includeFiles: true });
     if (!chosen) {

--- a/packages/host/app/components/ai-assistant/skill-menu/index.gts
+++ b/packages/host/app/components/ai-assistant/skill-menu/index.gts
@@ -208,14 +208,29 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
           ...exclusions,
         ],
       },
-      // Scope to the user's own workspaces plus the shared Boxel Skills realm,
-      // where most attachable skills live. A bounded scope keeps the mixed
-      // chooser (`includeFiles`) from fanning out across every server realm
-      // (base, catalog, …) and stalling on their contents.
+      // Scope to the realms where attachable skills live: the user's own
+      // workspaces, any catalog realms, and the shared Boxel Skills realm.
       realms: [
-        ...new Set([...this.realmServer.userRealmIdentifiers, skillsRealmURL]),
+        ...new Set([
+          ...this.realmServer.userRealmIdentifiers,
+          ...this.realmServer.catalogRealmIdentifiers,
+          skillsRealmURL,
+        ]),
       ],
     };
+    // TEMP DIAGNOSTIC — remove before merge.
+    console.warn(
+      '[SKILL-SCOPE] user=',
+      JSON.stringify(this.realmServer.userRealmIdentifiers),
+      'catalog=',
+      JSON.stringify(this.realmServer.catalogRealmIdentifiers),
+      'skills=',
+      skillsRealmURL,
+      'available=',
+      JSON.stringify(this.realmServer.availableRealmIdentifiers),
+      'FINAL=',
+      JSON.stringify(query.realms),
+    );
     let chosen = await chooseCard(query, { includeFiles: true });
     if (!chosen) {
       return;

--- a/packages/host/app/components/ai-assistant/skill-menu/index.gts
+++ b/packages/host/app/components/ai-assistant/skill-menu/index.gts
@@ -179,14 +179,20 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
   // (`includeFiles`) surfaces both in a single list and tags each pick with its
   // kind, which routes the result to the matching attach callback.
   private doAttachSkill = restartableTask(async () => {
-    // Exclude already-attached skills. The `not: { eq: { id } }` clauses are
-    // built client-side from the menu's own skill list, so card skills are
-    // excluded immediately; file skills are excluded once their rows carry
-    // `id` in the search doc (Phase 1 reindex), and the feature ships without
-    // waiting on that reindex.
+    // Exclude already-attached skills, matched client-side against the menu's
+    // own skill list by `id`. Card skills are excluded immediately; file skills
+    // once their rows carry `id` in the search doc (Phase 1 reindex), and the
+    // feature ships without waiting on that reindex.
+    //
+    // The exclusion must be NULL-safe: a bare `not: { eq: { id } }` drops any
+    // row whose `id` is absent, because negated `eq` compiles to `NOT (id = X)`
+    // and `NOT (NULL = X)` is NULL (excluded) under three-valued logic. On a
+    // realm not yet carrying the stamped `id`, every skill-file row lacks `id`,
+    // so that would hide *all* skill files whenever any skill is attached. The
+    // `{ eq: { id: null } }` branch (an `IS NULL` test) keeps those rows.
     let exclusions =
       this.args.skills?.map((skill: RoomSkill) => ({
-        not: { eq: { id: skill.cardId } },
+        any: [{ eq: { id: null } }, { not: { eq: { id: skill.cardId } } }],
       })) ?? [];
     let query = {
       filter: {

--- a/packages/host/app/components/ai-assistant/skill-menu/index.gts
+++ b/packages/host/app/components/ai-assistant/skill-menu/index.gts
@@ -1,6 +1,7 @@
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import { tracked } from '@glimmer/tracking';
@@ -17,6 +18,7 @@ import SkillToggle from '@cardstack/host/components/ai-assistant/skill-menu/skil
 import PillMenu from '@cardstack/host/components/pill-menu';
 
 import type { RoomSkill } from '@cardstack/host/resources/room';
+import type RealmServerService from '@cardstack/host/services/realm-server';
 
 // A skill expressed as a markdown file is a `MarkdownDef` whose frontmatter
 // declares `boxel.kind: skill`. One branch of the mixed chooser's base filter
@@ -134,6 +136,8 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
     </style>
   </template>
 
+  @service declare private realmServer: RealmServerService;
+
   @tracked private isExpanded = false;
   @tracked private isAttachingSkill = false;
 
@@ -196,6 +200,12 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
           ...exclusions,
         ],
       },
+      // Scope to the user's own workspaces. The mixed chooser (`includeFiles`)
+      // renders a tile per matching row; without a realm scope it fans out
+      // across every server realm — including large shared realms — and the
+      // intended skills may never finish rendering. Skills a user attaches
+      // come from their workspaces.
+      realms: this.realmServer.userRealmIdentifiers,
     };
     let chosen = await chooseCard(query, { includeFiles: true });
     if (!chosen) {

--- a/packages/host/app/components/ai-assistant/skill-menu/index.gts
+++ b/packages/host/app/components/ai-assistant/skill-menu/index.gts
@@ -11,18 +11,16 @@ import pluralize from 'pluralize';
 
 import { Button } from '@cardstack/boxel-ui/components';
 
-import { baseRRI, skillCardRef } from '@cardstack/runtime-common';
-import { chooseCard, chooseFile } from '@cardstack/runtime-common';
+import { baseRRI, chooseCard, skillCardRef } from '@cardstack/runtime-common';
 
 import SkillToggle from '@cardstack/host/components/ai-assistant/skill-menu/skill-toggle';
 import PillMenu from '@cardstack/host/components/pill-menu';
 
 import type { RoomSkill } from '@cardstack/host/resources/room';
 
-import type { FileDef } from '@cardstack/base/file-api';
-
 // A skill expressed as a markdown file is a `MarkdownDef` whose frontmatter
-// declares `boxel.kind: skill`. The file chooser is scoped to exactly those.
+// declares `boxel.kind: skill`. One branch of the mixed chooser's base filter
+// selects exactly those.
 const markdownDefRef = {
   module: baseRRI('markdown-file-def'),
   name: 'MarkdownDef',
@@ -75,8 +73,8 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
           class='attach-button'
           @kind='primary'
           @size='extra-small'
-          {{on 'click' this.attachSkillCard}}
-          @disabled={{this.doAttachSkillCard.isRunning}}
+          {{on 'click' this.attachSkill}}
+          @disabled={{this.doAttachSkill.isRunning}}
           @loading={{this.isAttachingSkill}}
           data-test-pill-menu-add-button
         >
@@ -84,21 +82,6 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
             Adding Skill
           {{else}}
             Choose a Skill to add
-          {{/if}}
-        </Button>
-        <Button
-          class='attach-button'
-          @kind='primary'
-          @size='extra-small'
-          {{on 'click' this.attachSkillMarkdown}}
-          @disabled={{this.doAttachSkillMarkdown.isRunning}}
-          @loading={{this.isAttachingSkillMarkdown}}
-          data-test-pill-menu-add-markdown-button
-        >
-          {{#if this.isAttachingSkillMarkdown}}
-            Adding Skill
-          {{else}}
-            Choose a skill file to add
           {{/if}}
         </Button>
       </:footer>
@@ -153,7 +136,6 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
 
   @tracked private isExpanded = false;
   @tracked private isAttachingSkill = false;
-  @tracked private isAttachingSkillMarkdown = false;
 
   private urlForRealmLookup(skill: RoomSkill) {
     return skill.fileDef.sourceUrl;
@@ -184,53 +166,50 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
   }
 
   @action
-  private attachSkillCard() {
-    this.doAttachSkillCard.perform();
+  private attachSkill() {
+    this.doAttachSkill.perform();
   }
 
-  private doAttachSkillCard = restartableTask(async () => {
-    let selectedCardIds =
+  // One chooser attaches either kind of skill: a Skill card or a skill-bearing
+  // markdown file (a MarkdownDef with `boxel.kind: skill`). The mixed chooser
+  // (`includeFiles`) surfaces both in a single list and tags each pick with its
+  // kind, which routes the result to the matching attach callback.
+  private doAttachSkill = restartableTask(async () => {
+    // Exclude already-attached skills. The `not: { eq: { id } }` clauses are
+    // built client-side from the menu's own skill list, so card skills are
+    // excluded immediately; file skills are excluded once their rows carry
+    // `id` in the search doc (Phase 1 reindex), and the feature ships without
+    // waiting on that reindex.
+    let exclusions =
       this.args.skills?.map((skill: RoomSkill) => ({
         not: { eq: { id: skill.cardId } },
       })) ?? [];
-    // query for only displaying skill cards that are not already selected
     let query = {
       filter: {
-        every: [{ type: skillCardRef }, ...selectedCardIds],
+        every: [
+          {
+            any: [
+              { type: skillCardRef },
+              { on: markdownDefRef, eq: { kind: 'skill' } },
+            ],
+          },
+          ...exclusions,
+        ],
       },
     };
-    let cardId = await chooseCard(query);
-    if (cardId) {
-      try {
-        this.isAttachingSkill = true;
-        await this.args.onChooseCard?.(cardId);
-      } finally {
-        this.isAttachingSkill = false;
-      }
+    let chosen = await chooseCard(query, { includeFiles: true });
+    if (!chosen) {
+      return;
     }
-  });
-
-  @action
-  private attachSkillMarkdown() {
-    this.doAttachSkillMarkdown.perform();
-  }
-
-  // Parallel to doAttachSkillCard: pick a skill markdown file (a MarkdownDef
-  // with `boxel.kind: skill`) rather than a Skill card. The file chooser is
-  // scoped to skill markdown via the indexed `kind` field.
-  private doAttachSkillMarkdown = restartableTask(async () => {
-    let file = await chooseFile<FileDef>({
-      fileType: markdownDefRef,
-      fileTypeName: 'Skill',
-      fileFieldFilter: { kind: 'skill' },
-    });
-    if (file?.sourceUrl) {
-      try {
-        this.isAttachingSkillMarkdown = true;
-        await this.args.onChooseSkillMarkdown?.(file.sourceUrl);
-      } finally {
-        this.isAttachingSkillMarkdown = false;
+    try {
+      this.isAttachingSkill = true;
+      if (chosen.kind === 'file') {
+        await this.args.onChooseSkillMarkdown?.(chosen.id);
+      } else {
+        await this.args.onChooseCard?.(chosen.id);
       }
+    } finally {
+      this.isAttachingSkill = false;
     }
   });
 

--- a/packages/host/app/components/ai-assistant/skill-menu/index.gts
+++ b/packages/host/app/components/ai-assistant/skill-menu/index.gts
@@ -218,19 +218,6 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
         ]),
       ],
     };
-    // TEMP DIAGNOSTIC — remove before merge.
-    console.warn(
-      '[SKILL-SCOPE] user=',
-      JSON.stringify(this.realmServer.userRealmIdentifiers),
-      'catalog=',
-      JSON.stringify(this.realmServer.catalogRealmIdentifiers),
-      'skills=',
-      skillsRealmURL,
-      'available=',
-      JSON.stringify(this.realmServer.availableRealmIdentifiers),
-      'FINAL=',
-      JSON.stringify(query.realms),
-    );
     let chosen = await chooseCard(query, { includeFiles: true });
     if (!chosen) {
       return;

--- a/packages/host/app/components/card-search/panel.gts
+++ b/packages/host/app/components/card-search/panel.gts
@@ -67,7 +67,11 @@ export default class SearchPanel extends Component<Signature> {
 
   private get initialFocusedSectionId(): string | null {
     let realmURLs = this.args.initialSelectedRealms;
-    if (!realmURLs || realmURLs.length === 0) {
+    // Only auto-focus a section when the search is pinned to a single realm.
+    // Focusing collapses every other realm's section to its header, so for a
+    // multi-realm scope (e.g. the skill chooser's user + catalog + skills)
+    // focusing the first realm would hide the results of all the others.
+    if (!realmURLs || realmURLs.length !== 1) {
       return null;
     }
     return `realm:${realmURLs[0].href}`;

--- a/packages/host/app/utils/card-search/query-builder.ts
+++ b/packages/host/app/utils/card-search/query-builder.ts
@@ -210,12 +210,18 @@ export function buildSearchQuery(
   const searchTerm = searchKey?.trim() || undefined;
   let filters: Filter[];
   if (baseFilter) {
-    // When typeFilter is present, strip the baseFilter's (parent) type
-    // constraint as redundant — the picked subtype already implies it. Safe
-    // because the type picker only offers subtypes of the baseFilter type.
-    const effectiveBaseFilter = typeFilter
-      ? stripTypeFromFilter(baseFilter)
-      : baseFilter;
+    // When typeFilter is present, strip a *simple* baseFilter's type constraint
+    // as redundant — the picked subtype already implies it. Only safe for a
+    // single-type base filter. A compound base filter (e.g. the skill menu's
+    // `any: [{ type: skillCardRef }, { on: markdownDefRef, eq: { kind: 'skill' }
+    // }]`) must stay intact: stripping the type branch collapses the `any` and
+    // promotes the sibling field constraint into a required top-level `every`
+    // clause — which would wrongly exclude the other branch's kind (skill cards
+    // vanish, only markdown skills survive).
+    const effectiveBaseFilter =
+      typeFilter && isCardTypeFilter(baseFilter)
+        ? stripTypeFromFilter(baseFilter)
+        : baseFilter;
     filters = [
       ...(effectiveBaseFilter ? [effectiveBaseFilter] : []),
       ...(typeFilter ? [typeFilter] : []),
@@ -267,9 +273,12 @@ export function buildRecentsQuery(
     : undefined;
   let filters: Filter[];
   if (baseFilter) {
-    const effectiveBaseFilter = typeFilter
-      ? stripTypeFromFilter(baseFilter)
-      : baseFilter;
+    // Only strip a simple single-type base filter (see `buildSearchQuery`);
+    // a compound base filter must stay intact or the `any` collapses.
+    const effectiveBaseFilter =
+      typeFilter && isCardTypeFilter(baseFilter)
+        ? stripTypeFromFilter(baseFilter)
+        : baseFilter;
     filters = [
       ...(effectiveBaseFilter ? [effectiveBaseFilter] : []),
       ...(typeFilter ? [typeFilter] : []),

--- a/packages/host/app/utils/card-search/query-builder.ts
+++ b/packages/host/app/utils/card-search/query-builder.ts
@@ -60,12 +60,12 @@ function stripTypeFromFilter(filter: Filter): Filter | undefined {
     return on ? { every: children, on } : { every: children };
   }
   if (isAnyFilter(filter)) {
-    const children = filter.any
-      .map((f) => stripTypeFromFilter(f))
-      .filter((f): f is Filter => f !== undefined);
-    if (children.length === 0) return undefined;
-    if (children.length === 1) return on ? { ...children[0], on } : children[0];
-    return on ? { any: children, on } : { any: children };
+    // Never strip within an `any`: the branches are alternatives, so dropping
+    // a branch's type (or collapsing a stripped-empty branch) changes which
+    // rows match. e.g. the skill menu's `any: [{ type: skillCardRef }, { on:
+    // markdownDefRef, eq: { kind: 'skill' } }]` would collapse to the markdown
+    // branch alone, excluding skill cards. Keep the alternation intact.
+    return filter;
   }
   if (isNotFilter(filter)) {
     const inner = stripTypeFromFilter(filter.not);
@@ -210,18 +210,14 @@ export function buildSearchQuery(
   const searchTerm = searchKey?.trim() || undefined;
   let filters: Filter[];
   if (baseFilter) {
-    // When typeFilter is present, strip a *simple* baseFilter's type constraint
-    // as redundant — the picked subtype already implies it. Only safe for a
-    // single-type base filter. A compound base filter (e.g. the skill menu's
-    // `any: [{ type: skillCardRef }, { on: markdownDefRef, eq: { kind: 'skill' }
-    // }]`) must stay intact: stripping the type branch collapses the `any` and
-    // promotes the sibling field constraint into a required top-level `every`
-    // clause — which would wrongly exclude the other branch's kind (skill cards
-    // vanish, only markdown skills survive).
-    const effectiveBaseFilter =
-      typeFilter && isCardTypeFilter(baseFilter)
-        ? stripTypeFromFilter(baseFilter)
-        : baseFilter;
+    // When typeFilter is present, strip the baseFilter's (parent) type
+    // constraint as redundant — the picked subtype already implies it.
+    // `stripTypeFromFilter` only unwraps a top-level `{ type }` node and leaves
+    // any `any`-alternation intact, so a compound base filter passes through
+    // whole.
+    const effectiveBaseFilter = typeFilter
+      ? stripTypeFromFilter(baseFilter)
+      : baseFilter;
     filters = [
       ...(effectiveBaseFilter ? [effectiveBaseFilter] : []),
       ...(typeFilter ? [typeFilter] : []),
@@ -273,12 +269,9 @@ export function buildRecentsQuery(
     : undefined;
   let filters: Filter[];
   if (baseFilter) {
-    // Only strip a simple single-type base filter (see `buildSearchQuery`);
-    // a compound base filter must stay intact or the `any` collapses.
-    const effectiveBaseFilter =
-      typeFilter && isCardTypeFilter(baseFilter)
-        ? stripTypeFromFilter(baseFilter)
-        : baseFilter;
+    const effectiveBaseFilter = typeFilter
+      ? stripTypeFromFilter(baseFilter)
+      : baseFilter;
     filters = [
       ...(effectiveBaseFilter ? [effectiveBaseFilter] : []),
       ...(typeFilter ? [typeFilter] : []),

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -416,23 +416,19 @@ Instructions live in the markdown body.
     assert.dom('[data-test-skill-menu]').containsText('Skills: 2 of 2 active');
   });
 
-  test('skill picker can add a skill markdown file through the UI', async function (assert) {
+  test('skill picker can add a skill markdown file through the single mixed chooser', async function (assert) {
     const roomId = await renderAiAssistantPanel();
     let skillId = `${testRealmURL}realm-sync-skill.md`;
 
     await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await waitFor(
-      '[data-test-skill-menu] [data-test-pill-menu-add-markdown-button]',
-    );
-    await click(
-      '[data-test-skill-menu] [data-test-pill-menu-add-markdown-button]',
-    );
+    await waitFor('[data-test-skill-menu] [data-test-pill-menu-add-button]');
+    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
 
-    // The file chooser is scoped to skill markdown files.
-    await waitFor('[data-test-choose-file-modal]');
-    await waitFor('[data-test-file="realm-sync-skill.md"]');
-    await click('[data-test-file="realm-sync-skill.md"]');
-    await click('[data-test-choose-file-modal-add-button]');
+    // A skill markdown file surfaces as a result tile in the same mixed chooser
+    // as skill cards; picking it routes to the markdown-attach path by kind.
+    await waitFor(`[data-test-item-button="${skillId}"]`);
+    await click(`[data-test-item-button="${skillId}"]`);
+    await click('[data-test-card-chooser-go-button]');
 
     await waitUntil(
       () =>
@@ -468,37 +464,47 @@ Instructions live in the markdown body.
       );
   });
 
-  test('canceling the skill-file chooser re-enables the add-markdown button', async function (assert) {
+  test('the separate skill-file button is retired in favor of the single mixed chooser', async function (assert) {
     await renderAiAssistantPanel();
 
     await click('[data-test-skill-menu][data-test-pill-menu-button]');
-    await waitFor(
-      '[data-test-skill-menu] [data-test-pill-menu-add-markdown-button]',
-    );
-    await click(
-      '[data-test-skill-menu] [data-test-pill-menu-add-markdown-button]',
-    );
+    await waitFor('[data-test-skill-menu] [data-test-pill-menu-add-button]');
 
-    await waitFor('[data-test-choose-file-modal]');
-    await click('[data-test-choose-file-modal-cancel-button]');
+    assert
+      .dom('[data-test-skill-menu] [data-test-pill-menu-add-button]')
+      .exists('a single add button remains');
+    assert
+      .dom('[data-test-skill-menu] [data-test-pill-menu-add-markdown-button]')
+      .doesNotExist(
+        'the second, file-tree skill button is gone — one chooser handles both kinds',
+      );
+  });
+
+  test('canceling the skill chooser re-enables the add button', async function (assert) {
+    await renderAiAssistantPanel();
+
+    await click('[data-test-skill-menu][data-test-pill-menu-button]');
+    await waitFor('[data-test-skill-menu] [data-test-pill-menu-add-button]');
+    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
+
+    await waitFor('[data-test-card-chooser-modal]');
+    await click('[data-test-card-chooser-cancel-button]');
 
     // Canceling settles the chooser promise, so the trigger button returns to
     // its enabled state. A chooser that left its deferred unsettled would hang
     // the attach task and leave this button stuck disabled.
     await waitUntil(
-      () => !document.querySelector('[data-test-choose-file-modal]'),
+      () => !document.querySelector('[data-test-card-chooser-modal]'),
     );
     assert
-      .dom('[data-test-skill-menu] [data-test-pill-menu-add-markdown-button]')
-      .isNotDisabled('the add-markdown button is re-enabled after canceling');
+      .dom('[data-test-skill-menu] [data-test-pill-menu-add-button]')
+      .isNotDisabled('the add button is re-enabled after canceling');
 
     // The chooser can be reopened after canceling.
-    await click(
-      '[data-test-skill-menu] [data-test-pill-menu-add-markdown-button]',
-    );
-    await waitFor('[data-test-choose-file-modal]');
+    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
+    await waitFor('[data-test-card-chooser-modal]');
     assert
-      .dom('[data-test-choose-file-modal]')
+      .dom('[data-test-card-chooser-modal]')
       .exists('the chooser reopens after canceling');
   });
 
@@ -527,6 +533,35 @@ Instructions live in the markdown body.
     assert
       .dom(`[data-test-item-button="${availableSkillId}"]`)
       .exists('a different skill remains available in the picker');
+  });
+
+  test('skill picker excludes an already-attached markdown skill', async function (assert) {
+    await renderAiAssistantPanel();
+    let attachedMarkdownSkillId = `${testRealmURL}realm-sync-skill.md`;
+    let availableCardSkillId = `${testRealmURL}Skill/example`;
+
+    // The file row carries `id` in its search doc (Phase 1), so the same
+    // client-built `not: { eq: { id } }` exclusion that hides an attached card
+    // skill also hides an attached markdown skill from the mixed chooser.
+    await addSkillToAiAssistant(attachedMarkdownSkillId);
+
+    if (
+      !document.querySelector(
+        '[data-test-skill-menu] [data-test-pill-menu-add-button]',
+      )
+    ) {
+      await click('[data-test-skill-menu][data-test-pill-menu-button]');
+    }
+    await waitFor('[data-test-skill-menu] [data-test-pill-menu-add-button]');
+    await click('[data-test-skill-menu] [data-test-pill-menu-add-button]');
+    await waitFor(`[data-test-item-button="${availableCardSkillId}"]`);
+
+    assert
+      .dom(`[data-test-item-button="${attachedMarkdownSkillId}"]`)
+      .doesNotExist('the already-attached markdown skill is excluded');
+    assert
+      .dom(`[data-test-item-button="${availableCardSkillId}"]`)
+      .exists('an unattached skill card remains available');
   });
 
   test('skill pill menu opens the skill card', async function (assert) {

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -10,6 +10,7 @@ import {
   REPLACE_MARKER,
   SEARCH_MARKER,
   SEPARATOR_MARKER,
+  ensureTrailingSlash,
   rri,
   skillCardRef,
 } from '@cardstack/runtime-common';
@@ -22,6 +23,7 @@ import {
 } from '@cardstack/runtime-common/matrix-constants';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
+import ENV from '@cardstack/host/config/environment';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
@@ -56,6 +58,8 @@ import { setupRenderingTest } from '../../../helpers/setup';
 
 import type { FileDef } from '@cardstack/base/file-api';
 
+const testRealmServerURL = ensureTrailingSlash(ENV.realmServerURL);
+
 module('Integration | ai-assistant-panel | skills', function (hooks) {
   const realmName = 'Operator Mode Workspace';
   let loader: Loader;
@@ -79,6 +83,11 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',
     activeRealms: [testRealmURL],
+    // Populate the user's realm list so `realmServer.userRealmIdentifiers` is
+    // non-empty — the skill menu scopes its mixed chooser to those realms, and
+    // without this the search fans out across every server realm (the large
+    // shared skills realm included) and the intended tiles never render.
+    activeRealmServers: [testRealmServerURL],
     autostart: true,
     now: (() => {
       // deterministic clock so that, for example, screenshots

--- a/packages/host/tests/unit/card-search-query-builder-test.ts
+++ b/packages/host/tests/unit/card-search-query-builder-test.ts
@@ -189,6 +189,39 @@ module('Unit | card-search/query-builder', function () {
       });
     });
 
+    test('a compound `any` base filter stays intact when types are selected (not collapsed)', function (assert) {
+      // The skill menu's base filter spans a card type and a file-field
+      // constraint. Regression: stripping the type branch collapsed the `any`
+      // to just the `{ on, eq }` branch and promoted it into a required `every`
+      // clause, so skill cards were excluded (only markdown skills survived).
+      let authorRef = {
+        module: 'http://test-realm/test/author' as RealmResourceIdentifier,
+        name: 'Author',
+      };
+      let markdownRef = {
+        module:
+          'https://cardstack.com/base/markdown-file-def' as RealmResourceIdentifier,
+        name: 'MarkdownDef',
+      };
+      let baseFilter: Filter = {
+        any: [{ type: authorRef }, { on: markdownRef, eq: { kind: 'skill' } }],
+      };
+      let query = buildSearchQuery('', SORT_AZ, baseFilter, [
+        `${authorRef.module}/${authorRef.name}`,
+        `${markdownRef.module}/${markdownRef.name}`,
+      ]);
+      assert.deepEqual(query, {
+        filter: {
+          every: [
+            // Kept whole — both branches survive so cards AND files match.
+            baseFilter,
+            { any: [{ type: authorRef }, { type: markdownRef }] },
+          ],
+        },
+        sort: SORT_AZ.sort,
+      });
+    });
+
     test('cardsOnly adds no filter anchor — the card scope is pinned on the wire', function (assert) {
       let query = buildSearchQuery('', SORT_AZ, undefined, undefined, {
         cardsOnly: true,

--- a/packages/matrix/tests/skills.spec.ts
+++ b/packages/matrix/tests/skills.spec.ts
@@ -16,51 +16,11 @@ import {
   createRealm,
 } from '../helpers/index.ts';
 import { appURL } from '../support/isolated-realm-server.ts';
-import { createHash, randomUUID } from 'crypto';
+import { randomUUID } from 'crypto';
 
 test.describe('Skills', () => {
   let firstUser: { username: string; password: string; credentials: any };
   let secondUser: { username: string; password: string; credentials: any };
-
-  // The skill chooser now searches the shared Boxel Skills realm alongside the
-  // user's own workspaces. In the e2e env that realm is indexed from scratch on
-  // server startup, so the chooser's federated search stalls until indexing
-  // finishes — long enough to blow the per-test timeout. Wait once for the
-  // realm-server index queue to drain (`/_queue-status` → `pending: 0`) before
-  // this module's tests run. Scoped here (not the shared harness) so only these
-  // tests, which depend on the skills realm being searchable, pay the wait.
-  test.beforeAll(async ({ playwright }) => {
-    test.setTimeout(300_000);
-    // `/_queue-status` is monitoring-gated: the bearer token is
-    // sha256('MONITORING' + realm-server secret seed), matching realm-server's
-    // `monitoringAuthToken`. The e2e realm server runs with this seed.
-    const seed = process.env.REALM_SERVER_SECRET_SEED ?? "mum's the word";
-    const token = createHash('sha256')
-      .update('MONITORING')
-      .update(seed)
-      .digest('hex');
-    const queueStatusURL = `${new URL(appURL).origin}/_queue-status`;
-    const request = await playwright.request.newContext({
-      ignoreHTTPSErrors: true,
-    });
-    try {
-      await expect(async () => {
-        const res = await request.get(queueStatusURL, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        expect(res.status(), 'unexpected /_queue-status response').toBe(200);
-        const body = (await res.json()) as {
-          data?: { attributes?: { pending?: number } };
-        };
-        expect(
-          body?.data?.attributes?.pending,
-          'realm-server index queue still draining',
-        ).toBe(0);
-      }).toPass({ timeout: 290_000, intervals: [2_000, 5_000, 10_000] });
-    } finally {
-      await request.dispose();
-    }
-  });
 
   test.beforeEach(async () => {
     firstUser = await createSubscribedUser('user-1');

--- a/packages/matrix/tests/skills.spec.ts
+++ b/packages/matrix/tests/skills.spec.ts
@@ -22,6 +22,36 @@ test.describe('Skills', () => {
   let firstUser: { username: string; password: string; credentials: any };
   let secondUser: { username: string; password: string; credentials: any };
 
+  // The skill chooser now searches the shared Boxel Skills realm alongside the
+  // user's own workspaces. In the e2e env that realm is indexed from scratch on
+  // server startup, so the chooser's federated search stalls until it is ready
+  // — long enough to blow the per-test timeout. Warm it once for this module by
+  // waiting until a known skill card is served from the realm's index. Scoped
+  // here (not the shared harness) so only these tests, which depend on the
+  // skills realm being searchable, pay the wait. The Skills realm is public-
+  // read, so no auth is needed.
+  test.beforeAll(async ({ playwright }) => {
+    test.setTimeout(180_000);
+    const skillsRealmURL = `${new URL(appURL).origin}/skills/`;
+    const probe = `${skillsRealmURL}Skill/boxel-environment`;
+    const request = await playwright.request.newContext({
+      ignoreHTTPSErrors: true,
+    });
+    try {
+      await expect(async () => {
+        const res = await request.get(probe, {
+          headers: { Accept: 'application/vnd.card+json' },
+        });
+        expect(
+          res.status(),
+          `Boxel Skills realm not indexed yet (${probe})`,
+        ).toBe(200);
+      }).toPass({ timeout: 170_000, intervals: [2_000, 5_000, 10_000] });
+    } finally {
+      await request.dispose();
+    }
+  });
+
   test.beforeEach(async () => {
     firstUser = await createSubscribedUser('user-1');
     secondUser = await createSubscribedUser('user-2');

--- a/packages/matrix/tests/skills.spec.ts
+++ b/packages/matrix/tests/skills.spec.ts
@@ -16,7 +16,7 @@ import {
   createRealm,
 } from '../helpers/index.ts';
 import { appURL } from '../support/isolated-realm-server.ts';
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 
 test.describe('Skills', () => {
   let firstUser: { username: string; password: string; credentials: any };
@@ -24,29 +24,39 @@ test.describe('Skills', () => {
 
   // The skill chooser now searches the shared Boxel Skills realm alongside the
   // user's own workspaces. In the e2e env that realm is indexed from scratch on
-  // server startup, so the chooser's federated search stalls until it is ready
-  // — long enough to blow the per-test timeout. Warm it once for this module by
-  // waiting until a known skill card is served from the realm's index. Scoped
-  // here (not the shared harness) so only these tests, which depend on the
-  // skills realm being searchable, pay the wait. The Skills realm is public-
-  // read, so no auth is needed.
+  // server startup, so the chooser's federated search stalls until indexing
+  // finishes — long enough to blow the per-test timeout. Wait once for the
+  // realm-server index queue to drain (`/_queue-status` → `pending: 0`) before
+  // this module's tests run. Scoped here (not the shared harness) so only these
+  // tests, which depend on the skills realm being searchable, pay the wait.
   test.beforeAll(async ({ playwright }) => {
-    test.setTimeout(180_000);
-    const skillsRealmURL = `${new URL(appURL).origin}/skills/`;
-    const probe = `${skillsRealmURL}Skill/boxel-environment`;
+    test.setTimeout(300_000);
+    // `/_queue-status` is monitoring-gated: the bearer token is
+    // sha256('MONITORING' + realm-server secret seed), matching realm-server's
+    // `monitoringAuthToken`. The e2e realm server runs with this seed.
+    const seed = process.env.REALM_SERVER_SECRET_SEED ?? "mum's the word";
+    const token = createHash('sha256')
+      .update('MONITORING')
+      .update(seed)
+      .digest('hex');
+    const queueStatusURL = `${new URL(appURL).origin}/_queue-status`;
     const request = await playwright.request.newContext({
       ignoreHTTPSErrors: true,
     });
     try {
       await expect(async () => {
-        const res = await request.get(probe, {
-          headers: { Accept: 'application/vnd.card+json' },
+        const res = await request.get(queueStatusURL, {
+          headers: { Authorization: `Bearer ${token}` },
         });
+        expect(res.status(), 'unexpected /_queue-status response').toBe(200);
+        const body = (await res.json()) as {
+          data?: { attributes?: { pending?: number } };
+        };
         expect(
-          res.status(),
-          `Boxel Skills realm not indexed yet (${probe})`,
-        ).toBe(200);
-      }).toPass({ timeout: 170_000, intervals: [2_000, 5_000, 10_000] });
+          body?.data?.attributes?.pending,
+          'realm-server index queue still draining',
+        ).toBe(0);
+      }).toPass({ timeout: 290_000, intervals: [2_000, 5_000, 10_000] });
     } finally {
       await request.dispose();
     }

--- a/packages/matrix/tests/skills.spec.ts
+++ b/packages/matrix/tests/skills.spec.ts
@@ -39,6 +39,10 @@ test.describe('Skills', () => {
         .click();
     }
     await page.locator('[data-test-pill-menu-add-button]').click();
+    // The chooser spans the shared Boxel Skills realm (dozens of skills), so the
+    // target tile can render below the fold. Narrow to it by URL first so it's
+    // the visible result before clicking.
+    await page.locator('[data-test-search-field]').fill(cardId);
     await page.locator(`[data-test-item-button="${cardId}"]`).click();
     await page.locator('[data-test-card-chooser-go-button]').click();
 


### PR DESCRIPTION
Closes CS-12206. Phase 3 (the user-facing payoff) of the mixed cards+files chooser (parent CS-11809). Stacked on #5546 (CS-12205, mixed chooser) → #5531 (CS-12204, file `id`). Review/merge those first.

## What

One button in the AI Assistant skill menu now attaches **either** a Skill card **or** a skill-bearing markdown file, from a single search chooser.

- Collapse `attachSkillCard` + `attachSkillMarkdown` into one action that opens the mixed chooser via `chooseCard(query, { includeFiles: true })`. The base filter spans both kinds — `any` of `{ type: skillCardRef }` and `{ on: markdownDefRef, eq: { kind: 'skill' } }`.
- **Route by kind:** a card pick → `onChooseCard(id)`, a file pick → `onChooseSkillMarkdown(id)`. Both already flow to the same `attachSkillTask` in `matrix/room.gts`, so no consumer change.
- **Exclude already-attached** (locked decision #3): `not: { eq: { id } }` clauses built client-side from the menu's own skill list. Card skills are excluded immediately; file skills once their rows carry `id` in the search doc (Phase 1 reindex) — so the feature ships without waiting on a deployed reindex.
- **Retire the file-tree skill path** (locked decision #4): the second button and its `chooseFile`-based attach are removed. `chooseFile` / `FileChooserModal` stay for their other consumers (message file attach, Playground, markdown-embed) — untouched.

## Tests (`skills-test.gts`)

- The single button attaches a **skill card** (existing test, now through the mixed chooser) and a **skill markdown file** (rewritten off the retired file-tree flow to click the file's result tile).
- Already-attached **card** and **markdown** skills are both excluded from the picker.
- The retired skill-file button is gone.
- Canceling the chooser re-enables the add button.

`lint:types` (host), eslint, and ember-template-lint are green.

## Note

Depends on #5546 and #5531. In CI the index is fresh (Phase 1 `id` stamping active), so the markdown-skill exclusion is exercised end-to-end. In a deployed environment, file-skill exclusion becomes effective after the affected realms are reindexed; card-skill exclusion needs no reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)