### PR TITLE
Persist error rows for failed prerender-html visits and back off repeatedly-rejected repair batches

### DIFF
--- a/packages/realm-server/tests/prerender-html-reconcile-test.ts
+++ b/packages/realm-server/tests/prerender-html-reconcile-test.ts
@@ -17,6 +17,7 @@ import {
   insertPermissions,
   logger,
   param,
+  PRERENDER_HTML_VISIT_FAILURE_RETRY_CAP,
   prerenderHtmlRepairBackoffMs,
   prerenderHtmlReconcile,
   query,
@@ -137,6 +138,7 @@ module(basename(import.meta.filename), function (hooks) {
     generation,
     isDeleted = false,
     errorDoc = null,
+    renderedMinutesAgo,
   }: {
     url: string;
     realmURL: string;
@@ -144,6 +146,7 @@ module(basename(import.meta.filename), function (hooks) {
     generation: number;
     isDeleted?: boolean;
     errorDoc?: Record<string, unknown> | null;
+    renderedMinutesAgo?: number;
   }) {
     let { nameExpressions, valueExpressions } = asExpressions(
       {
@@ -154,6 +157,9 @@ module(basename(import.meta.filename), function (hooks) {
         generation,
         is_deleted: isDeleted,
         error_doc: errorDoc,
+        ...(renderedMinutesAgo !== undefined
+          ? { rendered_at: Date.now() - renderedMinutesAgo * 60 * 1000 }
+          : {}),
       },
       { jsonFields: ['error_doc'] },
     );
@@ -935,7 +941,7 @@ module(basename(import.meta.filename), function (hooks) {
     );
   });
 
-  test('a render-failure row at the current generation is the recorded outcome, not residue', async function (assert) {
+  test('a deterministic render-error row at the current generation is the recorded outcome, not residue', async function (assert) {
     const realmURL = 'http://example.com/recorded/';
     await seedOwner(realmURL);
     await seedRealmGeneration(realmURL, 5);
@@ -944,16 +950,18 @@ module(basename(import.meta.filename), function (hooks) {
       realmURL,
       generation: 5,
     });
-    // The row a failed visit persists: current generation, error doc. It
-    // reads as fresh, so the sweep never re-enqueues it — the retry lane for
-    // this row is its next invalidation (an edit or a full reindex).
+    // A render error without the visit-request-failure marker is a verdict
+    // about the content: it reads as fresh, so the sweep never re-enqueues
+    // it — the retry lane for this row is its next invalidation (an edit or
+    // a full reindex).
     await seedPrerenderedHtmlRow({
       url: `${realmURL}mango.json`,
       realmURL,
       generation: 5,
       errorDoc: {
-        message: 'Prerender request aborted after exceeding its timeout',
+        message: 'intentional render failure',
       },
+      renderedMinutesAgo: 120,
     });
 
     let result = await runReconcile();
@@ -967,5 +975,107 @@ module(basename(import.meta.filename), function (hooks) {
       0,
       'no repair job is enqueued for the recorded failure',
     );
+  });
+
+  test('a visit-request failure below the retry cap is retried once it ages past the minimum', async function (assert) {
+    const realmURL = 'http://example.com/retry-lane/';
+    await seedOwner(realmURL);
+    await seedRealmGeneration(realmURL, 5, 'epoch-a');
+    await seedIndexRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 5,
+    });
+    // Current generation — fresh by the generation measure — but the error
+    // describes the visit's own request, the run is below the cap, and the
+    // rendering is old enough to be eligible.
+    await seedPrerenderedHtmlRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 5,
+      errorDoc: {
+        message: 'Prerender request aborted after exceeding its timeout',
+        visitRequestFailure: true,
+        consecutiveVisitFailures: 1,
+      },
+      renderedMinutesAgo: 60,
+    });
+
+    let result = await runReconcile();
+    assert.deepEqual(
+      result,
+      { realmsRepaired: 1, urlsEnqueued: 1, realmsInBackoff: 0 },
+      'the failed visit gets another attempt',
+    );
+    let jobs = await prerenderHtmlJobs(realmURL);
+    assert.strictEqual(jobs.length, 1);
+    assert.ok(
+      jobs[0].args.changes.some(
+        (change) =>
+          change.url === `${realmURL}mango.json` &&
+          change.operation === 'update',
+      ),
+      'the retry re-renders the failed URL',
+    );
+  });
+
+  test('a visit-request failure at the retry cap is terminal', async function (assert) {
+    const realmURL = 'http://example.com/retry-capped/';
+    await seedOwner(realmURL);
+    await seedRealmGeneration(realmURL, 5);
+    await seedIndexRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 5,
+    });
+    await seedPrerenderedHtmlRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 5,
+      errorDoc: {
+        message: 'Prerender request aborted after exceeding its timeout',
+        visitRequestFailure: true,
+        consecutiveVisitFailures: PRERENDER_HTML_VISIT_FAILURE_RETRY_CAP,
+      },
+      renderedMinutesAgo: 600,
+    });
+
+    let result = await runReconcile();
+    assert.deepEqual(
+      result,
+      { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 },
+      'a capped run stands as the recorded outcome — the sweep stops burning the affinity lane on it',
+    );
+    assert.strictEqual((await prerenderHtmlJobs(realmURL)).length, 0);
+  });
+
+  test('a visit-request failure younger than the minimum age is not retried yet', async function (assert) {
+    const realmURL = 'http://example.com/retry-fresh/';
+    await seedOwner(realmURL);
+    await seedRealmGeneration(realmURL, 5);
+    await seedIndexRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 5,
+    });
+    await seedPrerenderedHtmlRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 5,
+      errorDoc: {
+        message: 'Prerender request aborted after exceeding its timeout',
+        visitRequestFailure: true,
+        consecutiveVisitFailures: 1,
+      },
+      renderedMinutesAgo: 5,
+    });
+
+    let result = await runReconcile();
+    assert.deepEqual(
+      result,
+      { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 },
+      'a just-recorded failure waits out the minimum age before its retry',
+    );
+    assert.strictEqual((await prerenderHtmlJobs(realmURL)).length, 0);
   });
 });

--- a/packages/realm-server/tests/prerender-html-reconcile-test.ts
+++ b/packages/realm-server/tests/prerender-html-reconcile-test.ts
@@ -12,9 +12,12 @@ import type {
 } from '@cardstack/runtime-common';
 import {
   asExpressions,
+  findPrerenderHtmlRejectionStreaks,
   insert,
   insertPermissions,
   logger,
+  param,
+  prerenderHtmlRepairBackoffMs,
   prerenderHtmlReconcile,
   query,
 } from '@cardstack/runtime-common';
@@ -166,14 +169,16 @@ module(basename(import.meta.filename), function (hooks) {
     urls,
     status = 'unfulfilled',
     operation = 'update',
+    finishedMinutesAgo,
   }: {
     realmURL: string;
     generation: number;
     urls: string[];
     status?: string;
     operation?: string;
+    finishedMinutesAgo?: number;
   }) {
-    return insertJob(dbAdapter, {
+    let job = await insertJob(dbAdapter, {
       job_type: 'prerender_html',
       concurrency_group: prerenderHtmlConcurrencyGroup(realmURL),
       status,
@@ -187,6 +192,15 @@ module(basename(import.meta.filename), function (hooks) {
         changes: urls.map((url) => ({ url, operation })),
       },
     });
+    if (finishedMinutesAgo !== undefined) {
+      // Stamped on the database clock, the same clock the queue's own
+      // finalize uses and the rejection-streak scan measures against.
+      await query(dbAdapter, [
+        `UPDATE jobs SET finished_at = NOW() - INTERVAL '${finishedMinutesAgo} minutes' WHERE id =`,
+        param(job.id),
+      ] as Expression);
+    }
+    return job;
   }
 
   async function prerenderHtmlJobs(
@@ -264,7 +278,7 @@ module(basename(import.meta.filename), function (hooks) {
     let result = await runReconcile();
     assert.deepEqual(
       result,
-      { realmsRepaired: 1, urlsEnqueued: 2 },
+      { realmsRepaired: 1, urlsEnqueued: 2, realmsInBackoff: 0 },
       'only the stale and absent rows were repaired',
     );
 
@@ -325,7 +339,7 @@ module(basename(import.meta.filename), function (hooks) {
     let result = await runReconcile();
     assert.deepEqual(
       result,
-      { realmsRepaired: 0, urlsEnqueued: 0 },
+      { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 },
       'nothing is enqueued when an active job already covers the row',
     );
 
@@ -354,20 +368,23 @@ module(basename(import.meta.filename), function (hooks) {
     });
     // A rejected job is a whole-job failure (the handler threw — often a
     // transient upstream outage) whose HTML never landed. That is the residue
-    // the sweep exists to repair, so it must not count as coverage. A per-URL
-    // deterministic render error is different: it records a current-generation
-    // error_doc row that reads as fresh and never appears stale here.
+    // the sweep exists to repair, so it must not count as coverage, and a
+    // single rejection retries at the sweep's own cadence with no backoff. A
+    // per-URL deterministic render error is different: it records a
+    // current-generation error_doc row that reads as fresh and never appears
+    // stale here.
     await seedPrerenderHtmlJob({
       realmURL,
       generation: 5,
       urls: [`${realmURL}mango.json`],
       status: 'rejected',
+      finishedMinutesAgo: 10,
     });
 
     let result = await runReconcile();
     assert.deepEqual(
       result,
-      { realmsRepaired: 1, urlsEnqueued: 1 },
+      { realmsRepaired: 1, urlsEnqueued: 1, realmsInBackoff: 0 },
       'the rejected job does not suppress repair of its stale row',
     );
 
@@ -412,7 +429,7 @@ module(basename(import.meta.filename), function (hooks) {
     let result = await runReconcile();
     assert.deepEqual(
       result,
-      { realmsRepaired: 1, urlsEnqueued: 1 },
+      { realmsRepaired: 1, urlsEnqueued: 1, realmsInBackoff: 0 },
       'the row is repaired despite the stale lower-generation job',
     );
 
@@ -451,7 +468,7 @@ module(basename(import.meta.filename), function (hooks) {
     let result = await runReconcile();
     assert.deepEqual(
       result,
-      { realmsRepaired: 0, urlsEnqueued: 0 },
+      { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 },
       'bot-owned realms are left to the deploy-time from-scratch reindex',
     );
     assert.strictEqual(
@@ -481,7 +498,7 @@ module(basename(import.meta.filename), function (hooks) {
     let result = await runReconcile();
     assert.deepEqual(
       result,
-      { realmsRepaired: 0, urlsEnqueued: 0 },
+      { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 },
       'a system whose HTML is current finds nothing to repair',
     );
     assert.strictEqual(
@@ -509,7 +526,7 @@ module(basename(import.meta.filename), function (hooks) {
     let first = await runReconcile();
     assert.deepEqual(
       first,
-      { realmsRepaired: 1, urlsEnqueued: 1 },
+      { realmsRepaired: 1, urlsEnqueued: 1, realmsInBackoff: 0 },
       'the first sweep enqueues the repair',
     );
     assert.strictEqual(
@@ -521,7 +538,7 @@ module(basename(import.meta.filename), function (hooks) {
     let second = await runReconcile();
     assert.deepEqual(
       second,
-      { realmsRepaired: 0, urlsEnqueued: 0 },
+      { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 },
       'the second sweep finds the row already covered by the queued repair',
     );
     assert.strictEqual(
@@ -566,7 +583,7 @@ module(basename(import.meta.filename), function (hooks) {
     let result = await runReconcile();
     assert.deepEqual(
       result,
-      { realmsRepaired: 2, urlsEnqueued: 2 },
+      { realmsRepaired: 2, urlsEnqueued: 2, realmsInBackoff: 0 },
       'both realms were repaired in one sweep',
     );
     let jobsA = await prerenderHtmlJobs(realmA);
@@ -617,7 +634,7 @@ module(basename(import.meta.filename), function (hooks) {
     let result = await runReconcile();
     assert.deepEqual(
       result,
-      { realmsRepaired: 1, urlsEnqueued: 1 },
+      { realmsRepaired: 1, urlsEnqueued: 1, realmsInBackoff: 0 },
       'the live row is repaired despite the pending delete job',
     );
     // The repair enqueue coalesces with the pending delete (update wins per URL).
@@ -651,13 +668,214 @@ module(basename(import.meta.filename), function (hooks) {
     let result = await runReconcile();
     assert.deepEqual(
       result,
-      { realmsRepaired: 0, urlsEnqueued: 0 },
+      { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 },
       'a realm without a generation row is skipped rather than crashing',
     );
     assert.strictEqual(
       (await prerenderHtmlJobs(realmURL)).length,
       0,
       'no repair job is enqueued',
+    );
+  });
+
+  test('the repair backoff schedule doubles per consecutive rejection and caps', function (assert) {
+    const HOUR = 60 * 60 * 1000;
+    assert.strictEqual(
+      prerenderHtmlRepairBackoffMs(0),
+      0,
+      'no rejections, no backoff',
+    );
+    assert.strictEqual(
+      prerenderHtmlRepairBackoffMs(1),
+      0,
+      'a single rejection retries at the sweep’s own cadence',
+    );
+    assert.strictEqual(prerenderHtmlRepairBackoffMs(2), 2 * HOUR);
+    assert.strictEqual(prerenderHtmlRepairBackoffMs(3), 4 * HOUR);
+    assert.strictEqual(prerenderHtmlRepairBackoffMs(4), 8 * HOUR);
+    assert.strictEqual(
+      prerenderHtmlRepairBackoffMs(10),
+      8 * HOUR,
+      'the schedule caps rather than growing without bound',
+    );
+  });
+
+  test('a rejection streak counts newest-first and stops at the first resolved job', async function (assert) {
+    const realmURL = 'http://example.com/streak/';
+    // Oldest → newest: rejected, resolved, rejected, rejected. The streak is
+    // the two newest rejections; the resolved job fences off the older one.
+    await seedPrerenderHtmlJob({
+      realmURL,
+      generation: 1,
+      urls: [`${realmURL}mango.json`],
+      status: 'rejected',
+      finishedMinutesAgo: 40,
+    });
+    await seedPrerenderHtmlJob({
+      realmURL,
+      generation: 2,
+      urls: [`${realmURL}mango.json`],
+      status: 'resolved',
+      finishedMinutesAgo: 30,
+    });
+    await seedPrerenderHtmlJob({
+      realmURL,
+      generation: 3,
+      urls: [`${realmURL}mango.json`],
+      status: 'rejected',
+      finishedMinutesAgo: 20,
+    });
+    await seedPrerenderHtmlJob({
+      realmURL,
+      generation: 4,
+      urls: [`${realmURL}mango.json`],
+      status: 'rejected',
+      finishedMinutesAgo: 10,
+    });
+
+    let streaks = await findPrerenderHtmlRejectionStreaks(dbAdapter, [
+      realmURL,
+    ]);
+    let streak = streaks.get(realmURL);
+    assert.strictEqual(streak?.consecutiveRejections, 2);
+    let msSinceLastRejection = streak?.msSinceLastRejection ?? -1;
+    assert.true(
+      msSinceLastRejection >= 9 * 60 * 1000,
+      `the streak is measured from the newest rejection (got ${msSinceLastRejection}ms)`,
+    );
+    assert.true(
+      msSinceLastRejection <= 11 * 60 * 1000,
+      `the newest rejection is the ten-minute-old one (got ${msSinceLastRejection}ms)`,
+    );
+
+    let unrelated = await findPrerenderHtmlRejectionStreaks(dbAdapter, [
+      'http://example.com/other/',
+    ]);
+    assert.strictEqual(
+      unrelated.size,
+      0,
+      'realms outside the requested set are not scanned',
+    );
+  });
+
+  test('a realm whose newest finished job resolved has no streak', async function (assert) {
+    const realmURL = 'http://example.com/reset/';
+    await seedPrerenderHtmlJob({
+      realmURL,
+      generation: 1,
+      urls: [`${realmURL}mango.json`],
+      status: 'rejected',
+      finishedMinutesAgo: 20,
+    });
+    await seedPrerenderHtmlJob({
+      realmURL,
+      generation: 2,
+      urls: [`${realmURL}mango.json`],
+      status: 'resolved',
+      finishedMinutesAgo: 10,
+    });
+
+    let streaks = await findPrerenderHtmlRejectionStreaks(dbAdapter, [
+      realmURL,
+    ]);
+    assert.strictEqual(
+      streaks.size,
+      0,
+      'a resolved job resets the realm to full repair frequency',
+    );
+  });
+
+  test('defers repair while a realm is inside its rejection-streak backoff window', async function (assert) {
+    const realmURL = 'http://example.com/backoff/';
+    await seedOwner(realmURL);
+    await seedRealmGeneration(realmURL, 5);
+    await seedIndexRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 5,
+    });
+    await seedPrerenderedHtmlRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 4,
+    });
+    // Two consecutive rejections, the newest ten minutes ago: the realm owes
+    // a two-hour wait before its next repair attempt.
+    await seedPrerenderHtmlJob({
+      realmURL,
+      generation: 5,
+      urls: [`${realmURL}mango.json`],
+      status: 'rejected',
+      finishedMinutesAgo: 70,
+    });
+    await seedPrerenderHtmlJob({
+      realmURL,
+      generation: 5,
+      urls: [`${realmURL}mango.json`],
+      status: 'rejected',
+      finishedMinutesAgo: 10,
+    });
+
+    let result = await runReconcile();
+    assert.deepEqual(
+      result,
+      { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 1 },
+      'the realm’s residue is deferred, not repaired',
+    );
+    let unfulfilled = (await prerenderHtmlJobs(realmURL)).filter(
+      (job) => job.status === 'unfulfilled',
+    );
+    assert.strictEqual(
+      unfulfilled.length,
+      0,
+      'no repair job is enqueued while the backoff window is open',
+    );
+  });
+
+  test('repairs once the backoff window has elapsed', async function (assert) {
+    const realmURL = 'http://example.com/backoff-done/';
+    await seedOwner(realmURL);
+    await seedRealmGeneration(realmURL, 5);
+    await seedIndexRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 5,
+    });
+    await seedPrerenderedHtmlRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 4,
+    });
+    // The same two-rejection streak, but the newest rejection is three hours
+    // old — past the two-hour interval the streak owes.
+    await seedPrerenderHtmlJob({
+      realmURL,
+      generation: 5,
+      urls: [`${realmURL}mango.json`],
+      status: 'rejected',
+      finishedMinutesAgo: 240,
+    });
+    await seedPrerenderHtmlJob({
+      realmURL,
+      generation: 5,
+      urls: [`${realmURL}mango.json`],
+      status: 'rejected',
+      finishedMinutesAgo: 180,
+    });
+
+    let result = await runReconcile();
+    assert.deepEqual(
+      result,
+      { realmsRepaired: 1, urlsEnqueued: 1, realmsInBackoff: 0 },
+      'the deferred repair goes out once the window has elapsed',
+    );
+    let unfulfilled = (await prerenderHtmlJobs(realmURL)).filter(
+      (job) => job.status === 'unfulfilled',
+    );
+    assert.strictEqual(
+      unfulfilled.length,
+      1,
+      'the repair job is enqueued once the realm is eligible',
     );
   });
 });

--- a/packages/realm-server/tests/prerender-html-reconcile-test.ts
+++ b/packages/realm-server/tests/prerender-html-reconcile-test.ts
@@ -878,4 +878,94 @@ module(basename(import.meta.filename), function (hooks) {
       'the repair job is enqueued once the realm is eligible',
     );
   });
+
+  test('one realm in backoff does not defer another realm’s repair in the same sweep', async function (assert) {
+    const deferredRealm = 'http://example.com/mixed-deferred/';
+    const healthyRealm = 'http://example.com/mixed-healthy/';
+    for (let realmURL of [deferredRealm, healthyRealm]) {
+      await seedOwner(realmURL);
+      await seedRealmGeneration(realmURL, 5);
+      await seedIndexRow({
+        url: `${realmURL}mango.json`,
+        realmURL,
+        generation: 5,
+      });
+      await seedPrerenderedHtmlRow({
+        url: `${realmURL}mango.json`,
+        realmURL,
+        generation: 4,
+      });
+    }
+    await seedPrerenderHtmlJob({
+      realmURL: deferredRealm,
+      generation: 5,
+      urls: [`${deferredRealm}mango.json`],
+      status: 'rejected',
+      finishedMinutesAgo: 70,
+    });
+    await seedPrerenderHtmlJob({
+      realmURL: deferredRealm,
+      generation: 5,
+      urls: [`${deferredRealm}mango.json`],
+      status: 'rejected',
+      finishedMinutesAgo: 10,
+    });
+
+    let result = await runReconcile();
+    assert.deepEqual(
+      result,
+      { realmsRepaired: 1, urlsEnqueued: 1, realmsInBackoff: 1 },
+      'the sweep defers only the realm that owes a backoff wait',
+    );
+    let deferredJobs = (await prerenderHtmlJobs(deferredRealm)).filter(
+      (job) => job.status === 'unfulfilled',
+    );
+    assert.strictEqual(
+      deferredJobs.length,
+      0,
+      'the deferred realm gets no job',
+    );
+    let healthyJobs = (await prerenderHtmlJobs(healthyRealm)).filter(
+      (job) => job.status === 'unfulfilled',
+    );
+    assert.strictEqual(
+      healthyJobs.length,
+      1,
+      'the healthy realm is repaired in the same sweep',
+    );
+  });
+
+  test('a render-failure row at the current generation is the recorded outcome, not residue', async function (assert) {
+    const realmURL = 'http://example.com/recorded/';
+    await seedOwner(realmURL);
+    await seedRealmGeneration(realmURL, 5);
+    await seedIndexRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 5,
+    });
+    // The row a failed visit persists: current generation, error doc. It
+    // reads as fresh, so the sweep never re-enqueues it — the retry lane for
+    // this row is its next invalidation (an edit or a full reindex).
+    await seedPrerenderedHtmlRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 5,
+      errorDoc: {
+        message: 'Prerender request aborted after exceeding its timeout',
+      },
+    });
+
+    let result = await runReconcile();
+    assert.deepEqual(
+      result,
+      { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 },
+      'the recorded failure is not repairable residue',
+    );
+    assert.strictEqual(
+      (await prerenderHtmlJobs(realmURL)).length,
+      0,
+      'no repair job is enqueued for the recorded failure',
+    );
+  });
 });

--- a/packages/realm-server/tests/prerender-html-split-test.ts
+++ b/packages/realm-server/tests/prerender-html-split-test.ts
@@ -473,6 +473,8 @@ module(basename(import.meta.filename), function () {
         error_doc: {
           message?: string;
           diagnostics?: Record<string, unknown>;
+          visitRequestFailure?: boolean;
+          consecutiveVisitFailures?: number;
         } | null;
         deps: string[] | null;
         last_known_good_deps: string[] | null;
@@ -1242,6 +1244,58 @@ module(basename(import.meta.filename), function () {
         );
         assert.strictEqual(stats.instanceErrors, 1);
         assert.strictEqual(stats.fileErrors, 1);
+      });
+
+      test('consecutive visit-request failures extend the recorded run; a successful render clears it', async function (assert) {
+        let url = `${testRealm}mango.json`;
+        let passArgs = (
+          generation: number,
+          prerenderer: Prerenderer,
+        ): Parameters<typeof runPrerenderHtmlPass>[0] => ({
+          realmURL: new URL(testRealm),
+          changes: [{ url, operation: 'update' }],
+          generation,
+          loaderEpoch: 'epoch-a',
+          ...noPreWarmDeps,
+          indexWriter,
+          virtualNetwork,
+          reader: stubReader(new Map([[url, cardJSON()]])),
+          prerenderer,
+          auth: 'test-auth',
+          jobInfo: jobInfo(),
+        });
+
+        await runPrerenderHtmlPass(passArgs(1, abortingPrerenderer('mango')));
+        let row = await productionRow(url);
+        assert.true(Boolean(row.error_doc?.visitRequestFailure));
+        assert.strictEqual(
+          row.error_doc?.consecutiveVisitFailures,
+          1,
+          'the first failure starts a run of one',
+        );
+
+        await runPrerenderHtmlPass(passArgs(2, abortingPrerenderer('mango')));
+        row = await productionRow(url);
+        assert.strictEqual(
+          row.error_doc?.consecutiveVisitFailures,
+          2,
+          'a repeat failure extends the run',
+        );
+
+        let succeeding: Prerenderer = {
+          ...abortingPrerenderer('never-matches'),
+          async prerenderVisit() {
+            return renderedVisitResponse('recovered');
+          },
+        };
+        await runPrerenderHtmlPass(passArgs(3, succeeding));
+        row = await productionRow(url);
+        assert.strictEqual(
+          row.error_doc,
+          null,
+          'a successful render replaces the row and ends the run',
+        );
+        assert.strictEqual(row.isolated_html, '<h1>recovered</h1>');
       });
 
       test('a retry re-visits URLs whose prior attempt recorded a render failure', async function (assert) {

--- a/packages/realm-server/tests/prerender-html-split-test.ts
+++ b/packages/realm-server/tests/prerender-html-split-test.ts
@@ -1206,6 +1206,63 @@ module(basename(import.meta.filename), function () {
         assert.strictEqual(stats.instanceErrors, 1);
         assert.strictEqual(stats.fileErrors, 2);
       });
+
+      test('the tombstoned-live-types oracle protects a card whose source no longer parses as one', async function (assert) {
+        let url = `${testRealm}mango.json`;
+        await writeInstance(1, url, '<h1>good</h1>');
+
+        // The source served at failure time is JSON but not a card resource,
+        // so the re-parse fallback cannot classify the URL — the instance
+        // error can only come from the batch's record of the live production
+        // row types its tombstone seeding overwrote.
+        let { stats } = await runPrerenderHtmlPass({
+          realmURL: new URL(testRealm),
+          changes: [{ url, operation: 'update' }],
+          generation: 2,
+          loaderEpoch: 'epoch-a',
+          ...noPreWarmDeps,
+          indexWriter,
+          virtualNetwork,
+          reader: stubReader(new Map([[url, '{"hello":"world"}']])),
+          prerenderer: abortingPrerenderer('mango'),
+          auth: 'test-auth',
+          jobInfo: jobInfo(),
+        });
+
+        let instanceRow = await productionRow(url);
+        assert.ok(
+          instanceRow.error_doc?.message?.includes('aborted after'),
+          'the previously-live instance row records the failure instead of staying tombstoned',
+        );
+        assert.false(Boolean(instanceRow.is_deleted));
+        assert.strictEqual(
+          instanceRow.isolated_html,
+          '<h1>good</h1>',
+          'the last-known-good HTML survives',
+        );
+        assert.strictEqual(stats.instanceErrors, 1);
+        assert.strictEqual(stats.fileErrors, 1);
+      });
+
+      test('a retry re-visits URLs whose prior attempt recorded a render failure', async function (assert) {
+        let url = `${testRealm}1.json`;
+        let info = jobInfo();
+        let attempt1 = await makeBatch(3, info);
+        await attempt1.seedPrerenderedHtmlInvalidations([
+          { url, operation: 'update' },
+        ]);
+        await attempt1.updatePrerenderedHtmlEntry(new URL(url), {
+          type: 'instance-error',
+          error: { message: 'boom', status: 500, additionalErrors: null },
+        });
+        // No done() — the attempt dies before its swap.
+
+        let attempt2 = await makeBatch(3, { ...info, reservationId: 2 });
+        assert.false(
+          attempt2.resumedRows.has(url),
+          'an error row is not resumed — the retry gives the URL a second chance to render',
+        );
+      });
     });
 
     module('progress reporting', function () {

--- a/packages/realm-server/tests/prerender-html-split-test.ts
+++ b/packages/realm-server/tests/prerender-html-split-test.ts
@@ -1030,6 +1030,184 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    module('per-URL failure isolation', function () {
+      function renderedVisitResponse(tag: string) {
+        return {
+          card: {
+            serialized: null,
+            searchDoc: null,
+            displayNames: null,
+            deps: [],
+            types: null,
+            isolatedHTML: `<h1>${tag}</h1>`,
+            headHTML: null,
+            atomHTML: null,
+            embeddedHTML: null,
+            fittedHTML: null,
+            iconHTML: null,
+            markdown: null,
+          },
+          fileRender: {
+            isolatedHTML: `<pre>${tag}</pre>`,
+            headHTML: null,
+            atomHTML: null,
+            embeddedHTML: null,
+            fittedHTML: null,
+            iconHTML: null,
+            markdown: null,
+          },
+        };
+      }
+
+      // A transport-level failure — the visit's prerender request rejecting
+      // before any response document exists — can only be simulated at the
+      // Prerenderer seam; the in-band error paths all require a response.
+      function abortingPrerenderer(failUrlSubstring: string): Prerenderer {
+        return {
+          async prerenderVisit(args) {
+            if (args.url.includes(failUrlSubstring)) {
+              throw new Error(
+                'Prerender request to http://prerender-manager/prerender-visit aborted after 120000ms (requestId=test-abort)',
+              );
+            }
+            return renderedVisitResponse('rendered');
+          },
+          async prerenderModule() {
+            throw new Error('not used by the prerender-html pass');
+          },
+          async runCommand() {
+            throw new Error('not used by the prerender-html pass');
+          },
+        };
+      }
+
+      function cardJSON() {
+        return JSON.stringify({
+          data: {
+            type: 'card',
+            meta: { adoptsFrom: { module: `${testRealm}pine`, name: 'Pine' } },
+          },
+        });
+      }
+
+      test('a failed visit request lands error rows at the batch generation and the rest of the batch still swaps', async function (assert) {
+        let failedURL = `${testRealm}mango.json`;
+        let healthyURL = `${testRealm}pine.json`;
+        await writeInstance(1, failedURL, '<h1>good</h1>', {
+          deps: [`${testRealm}dep.gts`],
+        });
+
+        let { stats } = await runPrerenderHtmlPass({
+          realmURL: new URL(testRealm),
+          changes: [
+            { url: failedURL, operation: 'update' },
+            { url: healthyURL, operation: 'update' },
+          ],
+          generation: 2,
+          loaderEpoch: 'epoch-a',
+          ...noPreWarmDeps,
+          indexWriter,
+          virtualNetwork,
+          reader: stubReader(
+            new Map([
+              [failedURL, cardJSON()],
+              [healthyURL, cardJSON()],
+            ]),
+          ),
+          prerenderer: abortingPrerenderer('mango'),
+          auth: 'test-auth',
+          jobInfo: jobInfo(),
+        });
+
+        let instanceRow = await productionRow(failedURL);
+        assert.strictEqual(
+          instanceRow.generation,
+          2,
+          'the error row carries the batch generation, so the reconcile sweep reads the failure as this generation’s recorded outcome',
+        );
+        assert.ok(
+          instanceRow.error_doc?.message?.includes('aborted after 120000ms'),
+          'the instance error doc carries the underlying request failure',
+        );
+        assert.strictEqual(
+          instanceRow.isolated_html,
+          '<h1>good</h1>',
+          'the last-known-good HTML is preserved beneath the error',
+        );
+        assert.false(Boolean(instanceRow.is_deleted));
+
+        let fileRow = await productionRow(failedURL, 'file');
+        assert.strictEqual(fileRow.generation, 2);
+        assert.ok(
+          fileRow.error_doc?.message?.includes('aborted after 120000ms'),
+          'the file rendering records the same failure',
+        );
+
+        let healthyRow = await productionRow(healthyURL);
+        assert.strictEqual(
+          healthyRow.isolated_html,
+          '<h1>rendered</h1>',
+          'the failure does not discard the rest of the batch',
+        );
+        assert.strictEqual(healthyRow.error_doc, null);
+
+        assert.strictEqual(stats.instanceErrors, 1);
+        assert.strictEqual(stats.fileErrors, 1);
+        assert.strictEqual(stats.instancesIndexed, 1);
+        assert.strictEqual(stats.filesIndexed, 1);
+      });
+
+      test('a failed visit of a URL with no prior rendering still records which rows it owes', async function (assert) {
+        let newCardURL = `${testRealm}brand-new.json`;
+        let plainFileURL = `${testRealm}notes.txt`;
+
+        let { stats } = await runPrerenderHtmlPass({
+          realmURL: new URL(testRealm),
+          changes: [
+            { url: newCardURL, operation: 'update' },
+            { url: plainFileURL, operation: 'update' },
+          ],
+          generation: 1,
+          loaderEpoch: 'epoch-a',
+          ...noPreWarmDeps,
+          indexWriter,
+          virtualNetwork,
+          reader: stubReader(
+            new Map([
+              [newCardURL, cardJSON()],
+              [plainFileURL, 'plain text'],
+            ]),
+          ),
+          // Every visit fails: there is no last-known-good rendering to
+          // protect, so instance-ness comes from re-parsing the source.
+          prerenderer: abortingPrerenderer(''),
+          auth: 'test-auth',
+          jobInfo: jobInfo(),
+        });
+
+        let cardInstanceRow = await productionRow(newCardURL);
+        assert.ok(
+          cardInstanceRow.error_doc?.message?.includes('aborted after'),
+          'a card resource surfaces its failure as an instance error even with no prior row to protect',
+        );
+        assert.strictEqual(cardInstanceRow.isolated_html, null);
+        let cardFileRow = await productionRow(newCardURL, 'file');
+        assert.ok(cardFileRow.error_doc?.message?.includes('aborted after'));
+
+        let plainInstanceRow = await productionRow(plainFileURL);
+        assert.strictEqual(
+          plainInstanceRow,
+          undefined,
+          'a non-card file owes no instance rendering',
+        );
+        let plainFileRow = await productionRow(plainFileURL, 'file');
+        assert.ok(plainFileRow.error_doc?.message?.includes('aborted after'));
+
+        assert.strictEqual(stats.instanceErrors, 1);
+        assert.strictEqual(stats.fileErrors, 2);
+      });
+    });
+
     module('progress reporting', function () {
       function stubPrerenderer(
         visit: (url: string) => void = () => {},
@@ -1130,7 +1308,7 @@ module(basename(import.meta.filename), function () {
         );
       });
 
-      test('a visit failure still emits indexing-finished so consumers clear the job', async function (assert) {
+      test('a visit failure is isolated to its URL and the stream still reaches indexing-finished', async function (assert) {
         let events: IndexingProgressEvent[] = [];
         let prerenderer: Prerenderer = {
           ...stubPrerenderer(),
@@ -1138,27 +1316,34 @@ module(basename(import.meta.filename), function () {
             throw new Error('renderer died');
           },
         };
-        await assert.rejects(
-          runPrerenderHtmlPass({
-            realmURL: new URL(testRealm),
-            changes: [{ url: `${testRealm}a.txt`, operation: 'update' }],
-            generation: 1,
-            loaderEpoch: 'epoch-a',
-            indexWriter,
-            virtualNetwork,
-            reader: stubReader(new Map([[`${testRealm}a.txt`, 'alpha']])),
-            prerenderer,
-            auth: 'test-auth',
-            jobInfo: jobInfo(),
-            onProgress: (event) => events.push(event),
-            ...noPreWarmDeps,
-          }),
-          /renderer died/,
-        );
+        let { stats } = await runPrerenderHtmlPass({
+          realmURL: new URL(testRealm),
+          changes: [{ url: `${testRealm}a.txt`, operation: 'update' }],
+          generation: 1,
+          loaderEpoch: 'epoch-a',
+          indexWriter,
+          virtualNetwork,
+          reader: stubReader(new Map([[`${testRealm}a.txt`, 'alpha']])),
+          prerenderer,
+          auth: 'test-auth',
+          jobInfo: jobInfo(),
+          onProgress: (event) => events.push(event),
+          ...noPreWarmDeps,
+        });
         assert.deepEqual(
           events.map((e) => e.type),
-          ['indexing-started', 'indexing-finished'],
-          'the stream terminates even when the pass dies mid-visit',
+          ['indexing-started', 'file-visited', 'indexing-finished'],
+          'the failed URL still advances the stream to completion',
+        );
+        assert.strictEqual(
+          stats.fileErrors,
+          1,
+          'the failure is recorded as a file error rather than rejecting the pass',
+        );
+        let row = await productionRow(`${testRealm}a.txt`, 'file');
+        assert.ok(
+          row.error_doc?.message?.includes('renderer died'),
+          'the failure is persisted as an error row so the batch swap still lands',
         );
       });
     });

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -34,6 +34,20 @@ export interface SerializedError {
   // existing UI read path (formattedError → CardErrorJSONAPI.meta.
   // diagnostics) continues to work unchanged.
   diagnostics?: Record<string, unknown>;
+  // Set when the failure describes the visit's own request — it aborted or
+  // errored before any response document existed — rather than a verdict
+  // about the content. A `prerendered_html` error row carrying this marker
+  // is eligible for the reconcile sweep's bounded retry lane, unlike a
+  // deterministic render error.
+  visitRequestFailure?: true;
+  // How many consecutive `visitRequestFailure` rows this URL has recorded,
+  // maintained by the prerendered-html writer: incremented while each
+  // successive write carries the marker, cleared whenever a render
+  // succeeds (the error row is simply replaced). The reconcile sweep stops
+  // retrying once this reaches its cap, making the row terminal so a
+  // persistently failing visit cannot keep consuming its realm's prerender
+  // affinity lane.
+  consecutiveVisitFailures?: number;
 }
 
 // A persisted error document: the `SerializedError` plus the index metadata

--- a/packages/runtime-common/index-runner/prerender-html-visit.ts
+++ b/packages/runtime-common/index-runner/prerender-html-visit.ts
@@ -24,6 +24,12 @@ import {
 } from '../index.ts';
 import type { IndexingProgressEvent } from '../worker.ts';
 import type { VirtualNetwork } from '../virtual-network.ts';
+import {
+  CardError,
+  coerceErrorMessage,
+  isCardError,
+  serializableError,
+} from '../error.ts';
 import { resolveFileDefCodeRef } from '../file-def-code-ref.ts';
 import { canonicalURL } from './dependency-url.ts';
 import { uniqueDeps } from './dependency-collections.ts';
@@ -83,8 +89,12 @@ export interface PrerenderHtmlPassResult {
 // 'prerender-html' visit that renders from card+source (it never reads
 // `boxel_index`), writing HTML or render-error rows into
 // `prerendered_html_working`; 'delete' URLs are never visited so their
-// tombstones survive. `batch.done()` swaps the set into production under the
-// monotonic generation guard.
+// tombstones survive. A visit that fails without producing a response
+// document at all (its prerender request aborting/timing out, a reader
+// error) lands error rows too, via the same per-URL isolation the index
+// loop applies (`handleVisitFailure`) — one URL's failure never discards
+// the rest of the batch. `batch.done()` swaps the set into production under
+// the monotonic generation guard.
 export async function runPrerenderHtmlPass({
   realmURL,
   changes,
@@ -271,22 +281,34 @@ export async function runPrerenderHtmlPass({
         // authoritative for this job.
         resumedSkipped++;
       } else {
-        await visitForPrerenderedHtml({
-          url: new URL(href),
-          realmURL,
-          realmPaths,
-          reader,
-          batch,
-          prerenderer,
-          virtualNetwork,
-          auth,
-          batchId,
-          jobInfo,
-          jobPriority,
-          loaderEpoch,
-          stats,
-          log,
-        });
+        try {
+          await visitForPrerenderedHtml({
+            url: new URL(href),
+            realmURL,
+            realmPaths,
+            reader,
+            batch,
+            prerenderer,
+            virtualNetwork,
+            auth,
+            batchId,
+            jobInfo,
+            jobPriority,
+            loaderEpoch,
+            stats,
+            log,
+          });
+        } catch (err) {
+          await handleVisitFailure({
+            url: new URL(href),
+            err,
+            batch,
+            reader,
+            jobInfo,
+            stats,
+            log,
+          });
+        }
       }
       filesCompleted++;
       onProgress?.({
@@ -532,5 +554,94 @@ async function visitForPrerenderedHtml({
       ...(diagnostics ? { diagnostics } : {}),
     });
     stats.filesIndexed++;
+  }
+}
+
+// Per-URL failure isolation, mirroring the index visit loop's
+// (`IndexRunner`'s) handling of the same class of failure. A
+// transport-level failure of the visit — its prerender request timing out /
+// aborting before a response document exists, or a reader/network error —
+// never reaches the in-band error-entry construction in
+// `visitForPrerenderedHtml`; the visit rejects instead. Left uncaught, one
+// URL's failure propagates out of the visit loop, skips `batch.done()`, and
+// discards every other rendered URL's rows for the whole job — and because
+// nothing is persisted for the failed URL either, the reconcile sweep reads
+// it as "never attempted" and re-enqueues the identical batch every tick.
+// Persisting error rows contains the failure to this URL: they carry the
+// batch's generation, so the recorded failure reads as this generation's
+// outcome rather than as residue to repair, and the last-known-good HTML is
+// preserved beneath the error like any other render failure's row.
+async function handleVisitFailure({
+  url,
+  err,
+  batch,
+  reader,
+  jobInfo,
+  stats,
+  log,
+}: {
+  url: URL;
+  err: unknown;
+  batch: Batch;
+  reader: Reader;
+  jobInfo: JobInfo;
+  stats: Stats;
+  log: ReturnType<typeof logger>;
+}): Promise<void> {
+  if (isCardError(err) && err.status === 404) {
+    log.info(
+      `${jobIdentity(jobInfo)} tried to prerender file ${url.href}, but it no longer exists`,
+    );
+    return;
+  }
+  let message = coerceErrorMessage(
+    err,
+    `Prerendering failed for ${url.href} with no error message (${jobIdentity(jobInfo)})`,
+  );
+  log.warn(
+    `${jobIdentity(jobInfo)} failed to prerender ${url.href}, recording error rows: ${message}`,
+  );
+  let error = isCardError(err)
+    ? serializableError(err)
+    : serializableError(
+        Object.assign(new CardError(message, { status: 500 }), {
+          stack: (err as Error)?.stack,
+        }),
+      );
+  error.message = message;
+  await batch.updatePrerenderedHtmlEntry(url, { type: 'file-error', error });
+  stats.fileErrors++;
+  // The up-front seeding tombstoned every type this URL previously had in
+  // `prerendered_html` — for an existing card that's both `instance` and
+  // `file`. Overwriting only the `file` tombstone above would let the swap
+  // promote the untouched `instance` tombstone, silently removing a
+  // previously-good card's HTML over a transient failure. The batch records
+  // which live row types it tombstoned, so an existing card is protected
+  // even when the file can't be read — which may be exactly how the visit
+  // failed. Re-parsing the source is only the fallback for a URL with no
+  // prior rendering, which has no row to protect but should still surface
+  // its failure as an instance error when it's a card.
+  let isCardInstance =
+    batch.prerenderedHtmlTombstonedLiveTypes(url.href)?.includes('instance') ??
+    false;
+  if (!isCardInstance && url.href.endsWith('.json')) {
+    try {
+      let fileRef = await reader.readFile(url);
+      let resource = fileRef?.content
+        ? (JSON.parse(fileRef.content)?.data as unknown)
+        : undefined;
+      isCardInstance = Boolean(resource && isCardResource(resource));
+    } catch (parseErr) {
+      log.warn(
+        `${jobIdentity(jobInfo)} could not determine whether ${url.href} is a card instance after its visit failed: ${(parseErr as Error)?.message}`,
+      );
+    }
+  }
+  if (isCardInstance) {
+    await batch.updatePrerenderedHtmlEntry(url, {
+      type: 'instance-error',
+      error,
+    });
+    stats.instanceErrors++;
   }
 }

--- a/packages/runtime-common/index-runner/prerender-html-visit.ts
+++ b/packages/runtime-common/index-runner/prerender-html-visit.ts
@@ -568,9 +568,19 @@ async function visitForPrerenderedHtml({
 // nothing is persisted for the failed URL either, the reconcile sweep reads
 // it as "never attempted" and re-enqueues the identical batch every tick.
 // Persisting error rows contains the failure to this URL: they carry the
-// batch's generation, so the recorded failure reads as this generation's
-// outcome rather than as residue to repair, and the last-known-good HTML is
-// preserved beneath the error like any other render failure's row.
+// batch's generation and the last-known-good HTML is preserved beneath the
+// error like any other render failure's row.
+//
+// The error is marked `visitRequestFailure` because this failure describes
+// the request, not the content — the render never returned a verdict, so a
+// retry can legitimately succeed (e.g. an abort under temporary prerender
+// congestion). The reconcile sweep gives such rows a bounded retry lane:
+// re-rendered at most `PRERENDER_HTML_VISIT_FAILURE_RETRY_CAP` consecutive
+// times, spaced by the sweep cadence, then terminal exactly like a
+// deterministic render error. The bound is what protects the fleet — each
+// retry of a genuinely pathological visit burns its realm's prerender
+// affinity lane for the full request timeout, so retries must converge to
+// "recorded error, move on" rather than repeat indefinitely.
 async function handleVisitFailure({
   url,
   err,
@@ -609,6 +619,7 @@ async function handleVisitFailure({
         }),
       );
   error.message = message;
+  error.visitRequestFailure = true;
   await batch.updatePrerenderedHtmlEntry(url, { type: 'file-error', error });
   stats.fileErrors++;
   // The up-front seeding tombstoned every type this URL previously had in

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -1345,6 +1345,17 @@ export class Batch {
           },
           url,
         );
+        if (errorDoc.visitRequestFailure) {
+          // Consecutive-failure bookkeeping for the reconcile sweep's
+          // bounded retry lane: extend the prior row's run when it was also
+          // a visit-request failure, otherwise this write starts a run of
+          // one. A successful render ends the run by replacing the row
+          // outright, so no explicit clear is needed.
+          let priorRun = production?.error_doc?.visitRequestFailure
+            ? (production.error_doc.consecutiveVisitFailures ?? 1)
+            : 0;
+          errorDoc.consecutiveVisitFailures = priorRun + 1;
+        }
         payload = {
           type,
           fitted_html: production?.fitted_html ?? null,

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -273,6 +273,10 @@ export class Batch {
   // with stale content.
   #resumedRows = new Map<string, number | null>();
   #tombstonedLiveTypes = new Map<string, BoxelIndexTable['type'][]>();
+  #prerenderedHtmlTombstonedLiveTypes = new Map<
+    string,
+    PrerenderedHtmlTable['type'][]
+  >();
   // Correlation ID minted once per Batch and stamped into every row's
   // `diagnostics` via `updateEntry`, so operators can
   // `SELECT ... WHERE diagnostics->>'invalidationId' = '...'`
@@ -534,6 +538,21 @@ export class Batch {
    */
   tombstonedLiveTypes(url: string): BoxelIndexTable['type'][] | undefined {
     return this.#tombstonedLiveTypes.get(url);
+  }
+
+  /**
+   * The prerendered_html analog of `tombstonedLiveTypes`: row types
+   * `tombstonePrerenderedHtmlEntries` overwrote with tombstones this pass,
+   * restricted to rows that were live in production `prerendered_html`.
+   * The prerender-html visit loop's per-URL failure isolation consults
+   * this to decide whether a failed URL had a card instance to protect —
+   * the rendered table is a more reliable oracle than re-reading the
+   * file, since the read path may be exactly what failed.
+   */
+  prerenderedHtmlTombstonedLiveTypes(
+    url: string,
+  ): PrerenderedHtmlTable['type'][] | undefined {
+    return this.#prerenderedHtmlTombstonedLiveTypes.get(url);
   }
 
   /**
@@ -1402,13 +1421,17 @@ export class Batch {
 
   private async existingPrerenderedHtmlTypes(
     invalidations: string[],
-  ): Promise<Map<string, PrerenderedHtmlTable['type'][]>> {
+  ): Promise<
+    Map<string, { type: PrerenderedHtmlTable['type']; isDeleted: boolean }[]>
+  > {
     if (invalidations.length === 0) {
       return new Map();
     }
     let uniqueInvalidations = [...new Set(invalidations)];
+    // One row per (url, type) — the table's primary key is
+    // (url, realm_url, type) and the realm is pinned below.
     let rows = (await this.#query([
-      'SELECT DISTINCT url, type FROM prerendered_html WHERE',
+      'SELECT url, type, is_deleted FROM prerendered_html WHERE',
       ...every([
         ['realm_url =', param(this.realmURL.href)],
         [
@@ -1418,14 +1441,21 @@ export class Batch {
           ),
         ],
       ]),
-    ] as Expression)) as Pick<PrerenderedHtmlTable, 'url' | 'type'>[];
-    let typesByUrl = new Map<string, PrerenderedHtmlTable['type'][]>();
+    ] as Expression)) as Pick<
+      PrerenderedHtmlTable,
+      'url' | 'type' | 'is_deleted'
+    >[];
+    let typesByUrl = new Map<
+      string,
+      { type: PrerenderedHtmlTable['type']; isDeleted: boolean }[]
+    >();
     for (let row of rows) {
+      let entry = { type: row.type, isDeleted: Boolean(row.is_deleted) };
       let existing = typesByUrl.get(row.url);
       if (existing) {
-        existing.push(row.type);
+        existing.push(entry);
       } else {
-        typesByUrl.set(row.url, [row.type]);
+        typesByUrl.set(row.url, [entry]);
       }
     }
     return typesByUrl;
@@ -1876,6 +1906,14 @@ export class Batch {
   // through the swap.
   private async tombstonePrerenderedHtmlEntries(urls: string[]): Promise<void> {
     let existingTypes = await this.existingPrerenderedHtmlTypes(urls);
+    for (let [url, entries] of existingTypes) {
+      let liveTypes = entries
+        .filter((entry) => !entry.isDeleted)
+        .map((entry) => entry.type);
+      if (liveTypes.length > 0) {
+        this.#prerenderedHtmlTombstonedLiveTypes.set(url, liveTypes);
+      }
+    }
     let columns = [
       'url',
       'file_alias',
@@ -1895,7 +1933,7 @@ export class Batch {
       if (!types || types.length === 0) {
         return [];
       }
-      return types.map((type) =>
+      return types.map(({ type }) =>
         [
           id,
           // The same file_alias form the live prerendered_html writes use, so

--- a/packages/runtime-common/prerender-html-reconcile.ts
+++ b/packages/runtime-common/prerender-html-reconcile.ts
@@ -1,6 +1,13 @@
 import type { DBAdapter } from './db.ts';
-import { query, type Expression } from './expression.ts';
+import {
+  addExplicitParens,
+  param,
+  query,
+  separatedByCommas,
+  type Expression,
+} from './expression.ts';
 import type { IncrementalChange } from './tasks/indexer.ts';
+import { prerenderHtmlConcurrencyGroup } from './jobs/prerender-html.ts';
 
 // The catch-up sweep's read side. It reconciles two independently-advancing
 // channels — the search-doc index (`boxel_index`) and the prerendered HTML
@@ -73,12 +80,13 @@ export async function findStalePrerenderedHtmlRows(
 // failure: the handler threw — a transient upstream outage, a job timeout —
 // before the swap, so its HTML never landed. That is exactly the residue this
 // sweep repairs; re-enqueuing renders the row once the transient cause clears,
-// and a job that keeps failing simply re-rejects at the background tier rather
-// than pinning the row stale forever. A per-URL render that deterministically
-// fails never reaches this path: it records an `error_doc` row at the current
-// generation, which reads as fresh and so never appears stale. The per-row
-// generation gate means an older job never masks residue the index has moved
-// past.
+// and a realm whose jobs keep rejecting is retried on the rejection-streak
+// backoff schedule (`findPrerenderHtmlRejectionStreaks`) rather than at full
+// sweep frequency forever. A per-URL failure — a render error, or the visit's
+// own request failing outright — never reaches this path: the visit loop
+// records an `error_doc` row at the current generation, which reads as fresh
+// and so never appears stale. The per-row generation gate means an older job
+// never masks residue the index has moved past.
 export async function findActivePrerenderHtmlJobCoverage(
   dbAdapter: DBAdapter,
 ): Promise<Map<string, Map<string, number>>> {
@@ -198,4 +206,111 @@ export function planPrerenderHtmlRepairs(
     plan.set(realmURL, [...urls]);
   }
   return plan;
+}
+
+export interface PrerenderHtmlRejectionStreak {
+  // Rejected `prerender_html` jobs for the realm with no resolved job in
+  // between, newest first, within the scan's lookback window.
+  consecutiveRejections: number;
+  // Milliseconds since the newest rejection finished, measured on the
+  // database clock (the same clock that stamped `finished_at`) so callers
+  // never compare across clock domains.
+  msSinceLastRejection: number;
+}
+
+// The backoff schedule for repairing a realm whose prerender_html jobs keep
+// rejecting: one rejection retries at the sweep's own cadence (whole-job
+// failures are usually transient — an upstream outage, a job timeout — and a
+// single one warrants a prompt retry), and each further consecutive rejection
+// doubles the wait, capped so a persistently failing realm still gets a few
+// renders a day rather than none. Every retry that fails extends the streak,
+// so the interval keeps its shape however often the sweep itself runs; the
+// first resolved job resets the realm to full frequency.
+export const PRERENDER_HTML_REPAIR_BACKOFF_BASE_MS = 60 * 60 * 1000;
+export const PRERENDER_HTML_REPAIR_BACKOFF_CAP_MS = 8 * 60 * 60 * 1000;
+
+export function prerenderHtmlRepairBackoffMs(
+  consecutiveRejections: number,
+): number {
+  if (consecutiveRejections <= 1) {
+    return 0;
+  }
+  return Math.min(
+    PRERENDER_HTML_REPAIR_BACKOFF_BASE_MS * 2 ** (consecutiveRejections - 1),
+    PRERENDER_HTML_REPAIR_BACKOFF_CAP_MS,
+  );
+}
+
+// Bounded lookback for the streak scan: long enough to hold a
+// several-rejection streak even at the capped retry interval, short enough
+// that the scan never trawls the full jobs history. A streak whose older
+// rejections fall outside the window just under-counts — the backoff is
+// already at (or near) its cap by then, so the clamp costs nothing.
+const REJECTION_STREAK_LOOKBACK_HOURS = 48;
+
+// Consecutive-rejection streaks for the given realms' prerender_html jobs,
+// keyed by realm. A realm appears only when its most recent finished job
+// within the lookback window was rejected; a newest-first walk stops at the
+// first resolved job. Only finished jobs participate — an unfulfilled job is
+// active coverage, which `findActivePrerenderHtmlJobCoverage` already
+// accounts for.
+export async function findPrerenderHtmlRejectionStreaks(
+  dbAdapter: DBAdapter,
+  realmURLs: string[],
+): Promise<Map<string, PrerenderHtmlRejectionStreak>> {
+  let streaks = new Map<string, PrerenderHtmlRejectionStreak>();
+  if (realmURLs.length === 0) {
+    return streaks;
+  }
+  let realmByGroup = new Map(
+    realmURLs.map((realmURL) => [
+      prerenderHtmlConcurrencyGroup(realmURL),
+      realmURL,
+    ]),
+  );
+  let rows = (await query(dbAdapter, [
+    `SELECT concurrency_group, status,
+       (EXTRACT(EPOCH FROM (NOW() - finished_at)) * 1000)::bigint AS ms_since_finished
+     FROM jobs
+     WHERE job_type = 'prerender_html'
+       AND status IN ('resolved', 'rejected')
+       AND finished_at IS NOT NULL
+       AND finished_at > NOW() - INTERVAL '${REJECTION_STREAK_LOOKBACK_HOURS} hours'
+       AND concurrency_group IN`,
+    ...addExplicitParens(
+      separatedByCommas(
+        [...realmByGroup.keys()].map((group) => [param(group)]),
+      ),
+    ),
+    `ORDER BY finished_at DESC`,
+  ] as Expression)) as {
+    concurrency_group: string;
+    status: string;
+    ms_since_finished: number | string;
+  }[];
+
+  // Rows arrive newest-first across all realms; filtering per realm
+  // preserves each realm's newest-first order, so a streak is the run of
+  // rejections before that realm's first non-rejected row.
+  let settled = new Set<string>();
+  for (let row of rows) {
+    let realmURL = realmByGroup.get(row.concurrency_group);
+    if (!realmURL || settled.has(realmURL)) {
+      continue;
+    }
+    if (row.status !== 'rejected') {
+      settled.add(realmURL);
+      continue;
+    }
+    let streak = streaks.get(realmURL);
+    if (streak) {
+      streak.consecutiveRejections++;
+    } else {
+      streaks.set(realmURL, {
+        consecutiveRejections: 1,
+        msSinceLastRejection: Number(row.ms_since_finished),
+      });
+    }
+  }
+  return streaks;
 }

--- a/packages/runtime-common/prerender-html-reconcile.ts
+++ b/packages/runtime-common/prerender-html-reconcile.ts
@@ -33,6 +33,22 @@ export interface RealmGenerationInfo {
   loaderEpoch: string;
 }
 
+// How many consecutive visit-request failures a URL may record before the
+// sweep stops retrying it. The retry lane exists because a
+// `visitRequestFailure` error describes the request, not the content — the
+// render never returned a verdict, so a retry can legitimately succeed once
+// e.g. temporary prerender congestion clears. The cap is the fleet
+// protection: each retry of a genuinely pathological visit occupies its
+// realm's prerender affinity lane for the full request timeout, so after
+// this many consecutive failures the row is terminal — the recorded error
+// stands until the URL's next invalidation — rather than the sweep
+// re-burning that lane indefinitely.
+export const PRERENDER_HTML_VISIT_FAILURE_RETRY_CAP = 3;
+// A failed row becomes retry-eligible only once its recorded rendering is
+// this old, so retries space out to the sweep's own cadence instead of a
+// sweep tick that lands just after the failure immediately re-rendering it.
+export const PRERENDER_HTML_VISIT_FAILURE_RETRY_MIN_AGE_MS = 45 * 60 * 1000;
+
 // Index rows whose prerendered HTML is behind the search-doc index, or absent
 // entirely, restricted to live, non-errored rows:
 //   - `is_deleted` rows are tombstones — a deletion's tombstone-render is not
@@ -43,6 +59,16 @@ export interface RealmGenerationInfo {
 // Staleness is measured per row against its own `boxel_index.generation`, not
 // against the realm's current generation: a row the latest pass did not revisit
 // keeps its own generation and its HTML at that generation is fresh for it.
+//
+// A third arm admits the bounded retry lane for visit-request failures: an
+// HTML row whose `error_doc` carries the `visitRequestFailure` marker is
+// repairable even at a current generation — the failure describes the
+// request rather than the content — until its consecutive-failure run
+// reaches `PRERENDER_HTML_VISIT_FAILURE_RETRY_CAP`, after which it reads as
+// terminal exactly like a deterministic render error. The jsonb operators
+// here are Postgres-only, like the `jobs`-table scans in this module: the
+// reconcile task that issues this query runs solely behind the Postgres
+// queue.
 export async function findStalePrerenderedHtmlRows(
   dbAdapter: DBAdapter,
 ): Promise<StalePrerenderedHtmlRow[]> {
@@ -54,7 +80,14 @@ export async function findStalePrerenderedHtmlRows(
      WHERE i.is_deleted IS NOT TRUE
        AND i.has_error IS NOT TRUE
        AND i.error_doc IS NULL
-       AND (ph.url IS NULL OR ph.generation < i.generation)`,
+       AND (ph.url IS NULL
+         OR ph.generation < i.generation
+         OR ((ph.error_doc->>'visitRequestFailure')::boolean IS TRUE
+           AND COALESCE((ph.error_doc->>'consecutiveVisitFailures')::int, 1)
+             < ${PRERENDER_HTML_VISIT_FAILURE_RETRY_CAP}
+           AND ph.rendered_at
+             < (EXTRACT(EPOCH FROM NOW()) * 1000)::bigint
+               - ${PRERENDER_HTML_VISIT_FAILURE_RETRY_MIN_AGE_MS}))`,
   ] as Expression)) as {
     realm_url: string;
     url: string;
@@ -82,10 +115,12 @@ export async function findStalePrerenderedHtmlRows(
 // sweep repairs; re-enqueuing renders the row once the transient cause clears,
 // and a realm whose jobs keep rejecting is retried on the rejection-streak
 // backoff schedule (`findPrerenderHtmlRejectionStreaks`) rather than at full
-// sweep frequency forever. A per-URL failure — a render error, or the visit's
-// own request failing outright — never reaches this path: the visit loop
-// records an `error_doc` row at the current generation, which reads as fresh
-// and so never appears stale. The per-row generation gate means an older job
+// sweep frequency forever. A deterministic per-URL render error never reaches
+// this path: the visit loop records an `error_doc` row at the current
+// generation, which reads as fresh and so never appears stale. A
+// visit-request failure records the same kind of row but re-enters the sweep
+// through the bounded retry lane in `findStalePrerenderedHtmlRows` until its
+// consecutive-failure cap. The per-row generation gate means an older job
 // never masks residue the index has moved past.
 export async function findActivePrerenderHtmlJobCoverage(
   dbAdapter: DBAdapter,

--- a/packages/runtime-common/tasks/prerender-html-reconcile.ts
+++ b/packages/runtime-common/tasks/prerender-html-reconcile.ts
@@ -15,8 +15,10 @@ import { FROM_SCRATCH_JOB_TIMEOUT_SEC } from './indexer.ts';
 import {
   fetchRealmGenerations,
   findActivePrerenderHtmlJobCoverage,
+  findPrerenderHtmlRejectionStreaks,
   findStalePrerenderedHtmlRows,
   planPrerenderHtmlRepairs,
+  prerenderHtmlRepairBackoffMs,
 } from '../prerender-html-reconcile.ts';
 
 // The cron enqueues this job with no arguments; it scans every realm.
@@ -25,6 +27,10 @@ type PrerenderHtmlReconcileArgs = JSONTypes.Object;
 export interface PrerenderHtmlReconcileResult extends JSONTypes.Object {
   realmsRepaired: number;
   urlsEnqueued: number;
+  // Realms with repairable residue that were skipped this scan because their
+  // prerender_html jobs' rejection streak has them waiting out a backoff
+  // interval (see `prerenderHtmlRepairBackoffMs`).
+  realmsInBackoff: number;
 }
 
 export { prerenderHtmlReconcile };
@@ -58,8 +64,11 @@ registerQueueJobDefinition({
 // the publish, or whose swap lost a race, leaves index rows stale with nothing
 // scheduled to repair them. Job death itself is the queue's problem (lease
 // expiry re-runs it), so this sweep only enqueues repair where no queued or
-// running job already covers the row. Purely additive: a sweep over a healthy
-// system finds nothing and enqueues nothing.
+// running job already covers the row — and a realm whose repair jobs keep
+// rejecting is deferred on the rejection-streak backoff schedule, so a
+// persistent whole-job failure is retried a few times a day instead of
+// burning a full render batch every scan. Purely additive: a sweep over a
+// healthy system finds nothing and enqueues nothing.
 const prerenderHtmlReconcile: Task<
   PrerenderHtmlReconcileArgs,
   PrerenderHtmlReconcileResult
@@ -74,7 +83,7 @@ const prerenderHtmlReconcile: Task<
         `${jobIdentity(jobInfo)} prerender-html reconcile: no stale rows`,
       );
       reportStatus(jobInfo, 'finish');
-      return { realmsRepaired: 0, urlsEnqueued: 0 };
+      return { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 };
     }
 
     let coverage = await findActivePrerenderHtmlJobCoverage(dbAdapter);
@@ -84,9 +93,12 @@ const prerenderHtmlReconcile: Task<
         `${jobIdentity(jobInfo)} prerender-html reconcile: ${staleRows.length} stale row(s), all covered by active prerender_html jobs`,
       );
       reportStatus(jobInfo, 'finish');
-      return { realmsRepaired: 0, urlsEnqueued: 0 };
+      return { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 };
     }
 
+    let rejectionStreaks = await findPrerenderHtmlRejectionStreaks(dbAdapter, [
+      ...plan.keys(),
+    ]);
     let generations = await fetchRealmGenerations(dbAdapter);
     let realmOwners = await fetchAllRealmsWithOwners(dbAdapter);
     let ownerByRealm = new Map(
@@ -95,6 +107,7 @@ const prerenderHtmlReconcile: Task<
 
     let realmsRepaired = 0;
     let urlsEnqueued = 0;
+    let realmsInBackoff = 0;
     for (let [realmURL, urls] of plan) {
       // Render as the realm's owner, mirroring how an index pass spawns the
       // prerender job. Realms owned only by a bot (`realm/…`) are re-enqueued
@@ -116,6 +129,25 @@ const prerenderHtmlReconcile: Task<
           `${jobIdentity(jobInfo)} prerender-html reconcile: skipping realm without a generation row: ${realmURL} (${urls.length} stale url(s))`,
         );
         continue;
+      }
+      let streak = rejectionStreaks.get(realmURL);
+      if (streak) {
+        let backoffMs = prerenderHtmlRepairBackoffMs(
+          streak.consecutiveRejections,
+        );
+        if (streak.msSinceLastRejection < backoffMs) {
+          realmsInBackoff++;
+          // Info, not debug: this is the operator's signal that a realm's
+          // HTML repair keeps failing wholesale — the per-URL error rows
+          // cover render failures, so a streak here points at something
+          // job-level (upstream outage, job timeout).
+          log.info(
+            `${jobIdentity(jobInfo)} prerender-html reconcile: deferring repair for ${realmURL} (${urls.length} stale url(s)): ` +
+              `${streak.consecutiveRejections} consecutive rejected prerender_html job(s), ` +
+              `next attempt eligible in ${Math.ceil((backoffMs - streak.msSinceLastRejection) / 60_000)} minute(s)`,
+          );
+          continue;
+        }
       }
       try {
         await enqueuePrerenderHtmlJob(queuePublisher, {
@@ -146,8 +178,8 @@ const prerenderHtmlReconcile: Task<
     }
 
     log.info(
-      `${jobIdentity(jobInfo)} prerender-html reconcile: enqueued repair for ${urlsEnqueued} url(s) across ${realmsRepaired} realm(s) (from ${staleRows.length} stale row(s))`,
+      `${jobIdentity(jobInfo)} prerender-html reconcile: enqueued repair for ${urlsEnqueued} url(s) across ${realmsRepaired} realm(s) (from ${staleRows.length} stale row(s), ${realmsInBackoff} realm(s) in backoff)`,
     );
     reportStatus(jobInfo, 'finish');
-    return { realmsRepaired, urlsEnqueued };
+    return { realmsRepaired, urlsEnqueued, realmsInBackoff };
   };

--- a/packages/runtime-common/tasks/prerender-html-reconcile.ts
+++ b/packages/runtime-common/tasks/prerender-html-reconcile.ts
@@ -64,10 +64,13 @@ registerQueueJobDefinition({
 // the publish, or whose swap lost a race, leaves index rows stale with nothing
 // scheduled to repair them. Job death itself is the queue's problem (lease
 // expiry re-runs it), so this sweep only enqueues repair where no queued or
-// running job already covers the row — and a realm whose repair jobs keep
-// rejecting is deferred on the rejection-streak backoff schedule, so a
-// persistent whole-job failure is retried a few times a day instead of
-// burning a full render batch every scan. Purely additive: a sweep over a
+// running job already covers the row. Two bounds keep repeated failure from
+// poisoning the prerender fleet: a realm whose repair jobs keep rejecting is
+// deferred on the rejection-streak backoff schedule (a persistent whole-job
+// failure retries a few times a day instead of burning a render batch every
+// scan), and an individual URL whose visit requests keep failing is retried
+// only up to its consecutive-failure cap before its recorded error stands
+// (see `findStalePrerenderedHtmlRows`). Purely additive: a sweep over a
 // healthy system finds nothing and enqueues nothing.
 const prerenderHtmlReconcile: Task<
   PrerenderHtmlReconcileArgs,


### PR DESCRIPTION
When a `prerender_html` job's visit request fails without ever producing a response document — the prerender manager aborting a request that exceeds its client timeout, or a reader/network failure — the job handler threw, the whole job rejected, and nothing was persisted for the URL that failed: no error row, no failure memory. The hourly `prerender-html-reconcile` sweep distinguishes "recorded outcome" from "never attempted" purely by what is in `prerendered_html`, so the batch's rows read as never-attempted residue and the sweep re-enqueued the identical batch every tick — each retry re-rendering the batch up to the failing visit and rejecting again, with no operator signal and no convergence. This PR contains that churn at two layers.

**Per-URL failure isolation in the prerender-html visit loop.** The index channel's visit loop already isolates a transport-level visit failure to its file: error rows land, the batch still commits. The prerender-html loop now applies the same isolation (`handleVisitFailure` in `index-runner/prerender-html-visit.ts`): a failed visit lands a `file-error` row — plus an `instance-error` row when the URL is a card — at the batch's generation, with the last-known-good HTML preserved beneath the error, and the pass keeps visiting the rest of the batch. The job resolves, the swap lands, and the reconcile sweep reads the failure as that generation's recorded outcome rather than residue to repair. The failing request's message (including its correlation id) is on `error_doc`, so the failure is visible in the data and greppable back to the manager / prerender-server logs.

A visit-request failure differs from a deterministic render error in one important way: it describes the request, not the content — the render never returned a verdict, so a retry can legitimately succeed once e.g. temporary prerender congestion clears. The error doc therefore carries a `visitRequestFailure` marker plus a consecutive-failure count maintained by the writer, and the reconcile sweep gives such rows a **bounded retry lane**: an eligible row (below the consecutive-failure cap, rendering older than a minimum age so retries space out to the sweep cadence) re-enters the repair plan even at a current generation. The bound is the fleet protection — each retry of a genuinely pathological visit occupies its realm's prerender affinity lane for the full request timeout, so after the cap the recorded error stands, exactly like a deterministic render error, until the URL's next invalidation. A successful render clears the run by replacing the row. Terminal rows participate in the read-side error union, so a capped card leaves default (non-`includeErrors`) search scopes until its next edit or a deploy's full reindex.

Because the pass seeds tombstones for the whole invalidation set up front, the failure handler must know whether the failed URL previously had a live `instance` rendering — writing only the file-error row would let a previously-good card's instance tombstone survive the swap and silently drop its HTML. The batch now records which live `prerendered_html` row types its tombstone seeding overwrote (the analog of the index channel's `tombstonedLiveTypes`), and the handler falls back to re-parsing the source only for URLs with no prior rendering to protect.

**Rejection-streak backoff in the reconcile sweep.** Whole-job rejections still exist (job timeout, worker death, an upstream outage before any visit lands). The sweep now scans the finished `prerender_html` jobs for the realms it plans to repair and defers any realm whose jobs have rejected consecutively: a single rejection retries at the sweep's own cadence, further consecutive rejections wait 2h/4h/8h-capped intervals, and the first resolved job resets the realm to full frequency. Deferrals are logged at info and counted on the job result (`realmsInBackoff`), so a realm stuck in this state is an operator-visible signal instead of silent hourly churn.

Out of scope: the render-side work that would make the failing visits themselves succeed (abort propagation into the render, bounding pathological render costs, scheduler fairness). This PR records the failures and stops the unbounded retry loop.

**Test plan**

- `packages/realm-server/tests/prerender-html-split-test.ts` — new "per-URL failure isolation" module: a failed visit request lands instance+file error rows at the batch generation with last-known-good HTML preserved while the rest of the batch still swaps; a URL with no prior rendering records its failure via source re-parse (card) or as file-only (non-card); the tombstoned-live-types oracle protects a card whose source no longer parses as one; consecutive visit-request failures extend the recorded run and a successful render clears it; error rows are not resumed across job attempts (the retry re-visits); the progress stream reaches `indexing-finished` and the swap still lands when a visit fails.
- `packages/realm-server/tests/prerender-html-reconcile-test.ts` — backoff schedule coverage; streak counting (newest-first, fenced by the first resolved job, scoped to the requested realms, measured on the database clock); task-level deferral inside the backoff window and repair once it elapses; one realm's backoff never defers another realm's repair in the same sweep; the visit-failure retry lane (an under-cap failure is retried once aged, a capped run is terminal, a fresh failure waits out the minimum age, a deterministic render error is never retried); a single rejection still repairs at the next sweep.
- Both modules green locally against the test-services stack, plus the fused-channel `indexing-test.ts` "per-file failure isolation" module as a regression check on the shared tombstone bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
