### PR TITLE
Render accordion aria-expanded as "true"/"false" strings (CS-12256)

### DIFF
--- a/packages/boxel-ui/addon/src/components/accordion/item/index.gts
+++ b/packages/boxel-ui/addon/src/components/accordion/item/index.gts
@@ -32,7 +32,7 @@ const AccordionItem: TemplateOnlyComponent<AccordionItemSignature> = <template>
         {{on 'click' (optional @onClick)}}
         id={{@id}}
         aria-controls='section-{{@id}}'
-        aria-expanded={{@isOpen}}
+        aria-expanded={{if @isOpen 'true' 'false'}}
         disabled={{@disabled}}
       >
         <ChevronRight
@@ -114,7 +114,7 @@ const AccordionItem: TemplateOnlyComponent<AccordionItemSignature> = <template>
       .boxel-accordion-item-icon {
         flex-shrink: 0;
       }
-      [aria-expanded] .boxel-accordion-item-icon {
+      [aria-expanded='true'] .boxel-accordion-item-icon {
         transform: rotate(90deg);
       }
 

--- a/packages/boxel-ui/test-app/tests/integration/components/accordion-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/accordion-test.gts
@@ -1,0 +1,48 @@
+import { click, render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { tracked } from '@glimmer/tracking';
+import { Accordion } from '@cardstack/boxel-ui/components';
+
+class State {
+  @tracked isOpen = false;
+}
+
+module('Integration | Component | accordion', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('item trigger exposes aria-expanded as "true"/"false" strings', async function (assert) {
+    let state = new State();
+    let toggle = () => (state.isOpen = !state.isOpen);
+
+    await render(
+      <template>
+        <Accordion as |A|>
+          <A.Item @id='details' @isOpen={{state.isOpen}} @onClick={{toggle}}>
+            <:title>Details</:title>
+            <:content>Content body</:content>
+          </A.Item>
+        </Accordion>
+      </template>,
+    );
+
+    assert
+      .dom('#details')
+      .hasAttribute('aria-expanded', 'false', 'closed item reads false');
+    assert
+      .dom('#section-details')
+      .hasAttribute('data-state', 'closed', 'closed item content is closed');
+
+    await click('#details');
+
+    assert
+      .dom('#details')
+      .hasAttribute('aria-expanded', 'true', 'open item reads true');
+    assert
+      .dom('#section-details')
+      .hasAttribute('data-state', 'open', 'open item content is open');
+    assert
+      .dom('#section-details')
+      .hasAttribute('aria-hidden', 'false', 'open item content is visible');
+  });
+});


### PR DESCRIPTION
This PR was created as a result of a failing issue-tracker live card test.

## Background

The `AccordionItem` trigger bound `aria-expanded` to a raw boolean, which Glimmer renders as an empty-valued attribute when open and removes entirely when closed. Both states are invalid for `aria-expanded`, an enumerated attribute whose meaningful values are the strings `"true"` and `"false"` — and the attribute should stay present on a toggle so assistive technology announces the collapsed state. Every Accordion in the app was affected.

## Changes

- The trigger renders `aria-expanded={{if @isOpen 'true' 'false'}}`, matching how the content region already handles `aria-hidden`.
- The chevron-rotation CSS keyed off attribute *presence* (`[aria-expanded]`), which only worked because of the presence-only-when-open bug; it now targets `[aria-expanded='true']`.
- New integration test pins the `"true"`/`"false"` contract plus the `data-state`/`aria-hidden` signals on the content region, so a regression here fails loudly instead of silently.

## Testing

Full boxel-ui test-app suite passes (394/394) including the new accordion test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)