### PR TITLE
Pre-warm only realm-own modules in the prerender-html sweep

### DIFF
--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -4,15 +4,20 @@ import { basename } from 'path';
 import {
   CachingDefinitionLookup,
   internalKeyFor,
+  logger,
   trimExecutableExtension,
   type ErrorEntry,
+  type JobInfo,
   type ModuleDefinitionResult,
   type ModulePrerenderArgs,
   type ModuleRenderResponse,
   type Prerenderer,
+  type Reader,
   rri,
   VirtualNetwork,
 } from '@cardstack/runtime-common';
+import { preWarmModulesTable } from '@cardstack/runtime-common/index-runner/prewarm-modules';
+import type { DependencyIndexRow } from '@cardstack/runtime-common/index-writer';
 import {
   setupPermissionedRealmsCached,
   createVirtualNetwork,
@@ -2716,6 +2721,140 @@ module(basename(import.meta.filename), function () {
         rows.length,
         0,
         'pre-warm persisted no row (no error_doc) for the failed module',
+      );
+    });
+
+    test('pre-warm sweep warms only realm-own modules, skipping cross-realm deps', async function (assert) {
+      // The populate keys every row on the job realm's cache context, while
+      // the render-phase reader keys a module's row on the realm the module
+      // lives in. A cross-realm dep (a base module, an icon module) pulled in
+      // through the deps layer must therefore be skipped: warming it would
+      // fire a real prerender and persist a row under a key no reader ever
+      // consults — for a realm whose instances depend on the shared base
+      // modules, that is ~a hundred wasted serial prerenders on the critical
+      // path of every fresh publish.
+      let virtualNetwork = createVirtualNetwork();
+      let prerenderedModuleUrls: string[] = [];
+      let capturingPrerenderer: Prerenderer = {
+        async prerenderModule(args: ModulePrerenderArgs) {
+          prerenderedModuleUrls.push(args.url);
+          let moduleURL = new URL(args.url);
+          let modulePathWithoutExtension = moduleURL.href.replace(
+            /\.(gts|ts)$/,
+            '',
+          );
+          return Promise.resolve({
+            id: 'example-id',
+            status: 'ready',
+            nonce: '12345',
+            isShimmed: false,
+            lastModified: +new Date(),
+            createdAt: +new Date(),
+            deps: [],
+            definitions: {
+              [`${modulePathWithoutExtension}/Example`]: {
+                type: 'definition',
+                moduleURL: moduleURL.href,
+                definition: {
+                  type: 'card-def',
+                  codeRef: { module: rri(moduleURL.href), name: 'Example' },
+                  displayName: 'Example',
+                  fields: {},
+                  fieldDefs: {},
+                },
+                types: [],
+              },
+            },
+          }) as Promise<ModuleRenderResponse>;
+        },
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+      };
+      let workerLookup = new CachingDefinitionLookup(
+        adapter,
+        capturingPrerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+
+      let sweepModule = `${realmURL}pet.gts`;
+      let realmOwnHelper = `${realmURL}lib/helpers.ts`;
+      let baseDep = 'https://cardstack.com/base/card-api';
+      let iconDep =
+        'http://localhost:4206/@cardstack/boxel-icons/v1/icons/rocket';
+      let instanceUrl = `${realmURL}Pet/1.json`;
+      // Never consulted: the instance's deps row below supplies the dep
+      // signal, so the novel-`.json` disk fallback stays untaken.
+      let unusedReader: Reader = {
+        readFile: () => {
+          throw new Error('reader should not be consulted in this test');
+        },
+        readStream: () => {
+          throw new Error('reader should not be consulted in this test');
+        },
+        mtimes: () => {
+          throw new Error('reader should not be consulted in this test');
+        },
+      };
+      let jobInfo: JobInfo = { jobId: 1, reservationId: 1, priority: 10 };
+
+      let warmed = await preWarmModulesTable({
+        realmURL: new URL(realmURL),
+        invalidations: [new URL(instanceUrl)],
+        allRealmCardModules: [sweepModule],
+        definitionLookup: workerLookup,
+        virtualNetwork,
+        reader: unusedReader,
+        getDependencyRows: async () =>
+          [
+            {
+              url: instanceUrl,
+              type: 'instance',
+              deps: [realmOwnHelper, baseDep, iconDep],
+              hasError: false,
+              isDeleted: false,
+              errorDoc: null,
+            },
+          ] as DependencyIndexRow[],
+        getModuleCacheContext: async () => ({
+          resolvedRealmURL: realmURL,
+          cacheScope: 'realm-auth' as const,
+          authUserId: testUserId,
+        }),
+        prerenderUserId: testUserId,
+        jobPriority: 10,
+        jobInfo,
+        log: logger('test-prewarm'),
+        perfLog: logger('test-prewarm-perf'),
+      });
+
+      assert.strictEqual(
+        warmed,
+        2,
+        'only the realm-own modules were warmed (sweep module + deps-layer helper)',
+      );
+      assert.deepEqual(
+        prerenderedModuleUrls.sort(),
+        [sweepModule, realmOwnHelper].sort(),
+        'the prerenderer fired only for realm-own modules',
+      );
+      let rows = (await adapter.execute(`SELECT url FROM modules`)) as {
+        url: string;
+      }[];
+      assert.strictEqual(
+        rows.length,
+        2,
+        'exactly the two realm-own modules were persisted',
+      );
+      assert.ok(
+        rows.every((row) => row.url.startsWith(realmURL)),
+        `every persisted module row is realm-own (got: ${rows
+          .map((row) => row.url)
+          .join(', ')})`,
       );
     });
   });

--- a/packages/runtime-common/index-runner/prewarm-modules.ts
+++ b/packages/runtime-common/index-runner/prewarm-modules.ts
@@ -178,6 +178,14 @@ export interface PreWarmModulesTableArgs {
 //   3. `adoptsFrom.module` read from disk — for novel `.json` URLs without a
 //      prior `deps` row.
 //
+// Every source is then narrowed to modules that live in this realm. The
+// populate keys rows on this realm's cache context, while the render-phase
+// reader keys a module's row on the realm the module lives in — so warming a
+// cross-realm dep (a base module, an icon module) renders and persists a row
+// under a key the reader never consults. Cross-realm modules are served by
+// their owning realm's cache (populated by that realm's own sweep) or by the
+// on-demand read-through.
+//
 // Cache hits are O(1) DB reads inside DefinitionLookup. Cache misses go
 // through the read-through populate path, the same flow `lookupDefinition`
 // uses; DefinitionLookup owns the in-flight dedup and the cross-process
@@ -264,7 +272,41 @@ export async function preWarmModulesTable({
     }
   }
 
-  if (toWarm.size === 0) {
+  // Warm only this realm's own modules. The populate below keys every row on
+  // this realm's cache context, but the render-phase reader
+  // (`buildLookupContext`) keys a module's row on the realm the module
+  // *lives in* — a cross-realm dep pulled in through the deps / adoptsFrom
+  // layers (base modules, icon modules) would be rendered and persisted
+  // under a key that reader never consults. Those modules are the owning
+  // realm's to cache: its own pre-warm sweep populates them under the key
+  // the reader does hit, and anything it misses falls back to the safe
+  // on-demand read-through. The realm match mirrors `buildLookupContext`'s
+  // form-agnostic check, so a dep recorded in RRI form still matches the
+  // realm that owns it.
+  let unresolvedRealmHref = virtualNetwork.unresolveURL(realmURL.href);
+  let crossRealmSkipped = 0;
+  let realmOwnModules: string[] = [];
+  for (let moduleUrl of toWarm) {
+    if (
+      moduleUrl.startsWith(realmURL.href) ||
+      virtualNetwork.unresolveURL(moduleUrl).startsWith(unresolvedRealmHref)
+    ) {
+      realmOwnModules.push(moduleUrl);
+    } else {
+      crossRealmSkipped++;
+    }
+  }
+  if (crossRealmSkipped > 0) {
+    // Info, not debug: when a sweep is unexpectedly slow (or a mid-render
+    // sub-prerender fires for a module pre-warm was expected to cover), the
+    // first question is what the warm set actually contained — this line
+    // answers it from CI logs without a log-level override.
+    log.info(
+      `${jobIdentity(jobInfo)} module pre-warm: skipping ${crossRealmSkipped} cross-realm dep(s) cached under their own realm's key (${realmOwnModules.length} realm-own module(s) to warm)`,
+    );
+  }
+
+  if (realmOwnModules.length === 0) {
     return 0;
   }
 
@@ -311,7 +353,7 @@ export async function preWarmModulesTable({
   // cache miss; DefinitionLookup owns the in-flight dedup and cross-process
   // coalescer, so different modules run independently while same-URL callers
   // share one prerender.
-  let urls = [...toWarm];
+  let urls = realmOwnModules;
   let totalToWarm = urls.length;
   let failed = 0;
   let warmed = 0;
@@ -353,7 +395,7 @@ export async function preWarmModulesTable({
   }
 
   perfLog.debug(
-    `${jobIdentity(jobInfo)} pre-warm complete in ${Date.now() - preWarmStart} ms (candidates=${urls.length} failed=${failed} concurrency=${concurrency})`,
+    `${jobIdentity(jobInfo)} pre-warm complete in ${Date.now() - preWarmStart} ms (candidates=${urls.length} crossRealmSkipped=${crossRealmSkipped} failed=${failed} concurrency=${concurrency})`,
   );
   return warmed;
 }


### PR DESCRIPTION
## Background

The `prerender_html` job for a from-scratch pass runs a module pre-warm sweep before its format renders fire. The sweep exists so that a mid-render `lookupDefinition` (fired by `_federated-search` → `populateQueryFields` during a format render) hits a populated `modules` row instead of spawning a nested prerender into the same affinity-scoped tab queue.

The sweep's warm set is assembled from three sources: the realm-wide `.gts`/`.gjs` file list, the invalidated URLs' `boxel_index.deps`, and `adoptsFrom.module` read from disk. The deps layer pulls in **cross-realm** modules — base card-API modules and boxel-icons modules — and for a small workspace realm those dominate: a 3-file realm's warm set is ~112 modules, of which ~110 live in other realms.

## The problem

The pre-warm populate keys every row it writes on the **job realm's** cache context (`resolvedRealmURL = the consuming realm`). But the render-phase reader (`buildLookupContext`) keys a module's cache row on the realm the module **lives in** — a local-realm prefix match, or the remote probe's `x-boxel-realm-url`. So every cross-realm module warm is a guaranteed cache miss that fires a real module prerender (~100–200ms, serial) and persists a row under a key no reader ever consults.

Cost, measured from Matrix CI logs: 9–22s of wasted module prerenders per sweep, on the critical path of

- every fresh realm's first `prerender_html` job (realm creation settle),
- every publish and republish (the published realm is from-scratch indexed each time, and its module-cache rows are cleared, so it re-pays the full sweep every publish).

With a few publish-flow tests running concurrently, these sweeps convoy the non-index workers: `prerender_html` jobs queued 8–40s, and end-to-end publish→served-HTML latency reached ~57s. That is what has been intermittently failing the Matrix CI shards — `host-mode.spec.ts` "routing rule resolves a bare path to its target card" (realm-create settle 30s, published-marker wait 45s) and `publish-realm.spec.ts` "republishing reflects updated source content on the published URL" (republished sentinel never served within the poll budget; also failed on a `main` run on 2026-07-17). The earlier readiness-gate stabilizations (#5496, #5185) sized their waits for a healthy pipeline; the wasted sweeps pushed the pipeline past them.

## The fix

Narrow the warm set to modules that live in the job's realm, using the same form-agnostic realm match the reader uses (raw prefix or RRI-normalized prefix via `unresolveURL`). Cross-realm modules are correctly served by their owning realm's cache — populated by that realm's own sweep under the key the reader actually reads — or by the on-demand read-through, which is deadlock-safe by design (the PagePool materializes a tab for sub-prerenders rather than queueing behind the render).

With the sweep reduced to realm-own modules, a small realm's sweep drops from ~112 serial module prerenders (~10–22s) to a handful, and the queue convoy behind these jobs shrinks correspondingly.

## Diagnostics

The sweep now logs the cross-realm skip count at info level (plus a `crossRealmSkipped` field in the perf log line), so if a sweep is still slow in a future CI failure, the log shows what the warm set actually contained without a log-level override. The `definition-cache-key` debug channel remains the tool for verifying key match per lookup.

## Testing

New test in `definition-lookup-test.ts` (`module pre-warm (worker bare lookup)` module): drives `preWarmModulesTable` with a warm set mixing realm-own modules (sweep layer + deps-layer helper) and cross-realm deps (a base module, an icon module), asserting the prerenderer fires only for realm-own modules and only realm-own rows are persisted under the realm's key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1q53qZJhCdeLLuaNa4YFw
