### PR TITLE
ai-bot: add AI_BOT_STREAMING_MODE=off to skip mid-stream Matrix edits

### DIFF
--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -73,6 +73,14 @@ export class Responder {
     return this.matrixResponsePublisher.originalResponseEventId;
   }
 
+  private get streamingMode(): 'room-edits' | 'off' | 'to-device' {
+    const mode = process.env.AI_BOT_STREAMING_MODE;
+    if (mode === 'off' || mode === 'to-device') {
+      return mode;
+    }
+    return 'room-edits';
+  }
+
   async ensureThinkingMessageSent() {
     await this.matrixResponsePublisher.ensureThinkingMessageSent();
   }
@@ -161,7 +169,7 @@ export class Responder {
       isStreamingFinished: this.responseState.isStreamingFinished,
       responseStateChanged,
     });
-    if (responseStateChanged) {
+    if (responseStateChanged && this.streamingMode !== 'off') {
       await this.sendMessageEventWithThrottling();
     }
 

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -264,6 +264,50 @@ module('Responding', (hooks) => {
     );
   });
 
+  test('`off` streaming mode: only sends the thinking placeholder and a single final consolidated event', async () => {
+    process.env.AI_BOT_STREAMING_MODE = 'off';
+    try {
+      await responder.ensureThinkingMessageSent();
+
+      for (let i = 0; i < 10; i++) {
+        await responder.onChunk({} as any, snapshotWithContent('content ' + i));
+      }
+
+      let sentEvents = fakeMatrixClient.getSentEvents();
+      assert.equal(
+        sentEvents.length,
+        1,
+        'No intermediate content events are sent while streaming in off mode',
+      );
+
+      await responder.finalize();
+
+      sentEvents = fakeMatrixClient.getSentEvents();
+      assert.equal(
+        sentEvents.length,
+        2,
+        'Only the thinking placeholder and one final consolidated event are sent',
+      );
+      assert.equal(
+        sentEvents[1].content.body,
+        'content 9',
+        'Final event carries the complete accumulated content',
+      );
+      assert.deepEqual(
+        sentEvents[1].content['m.relates_to'],
+        { rel_type: 'm.replace', event_id: '0' },
+        'Final event replaces the thinking placeholder',
+      );
+      assert.deepEqual(
+        sentEvents[1].content.isStreamingFinished,
+        true,
+        'isStreamingFinished is set on the final event',
+      );
+    } finally {
+      delete process.env.AI_BOT_STREAMING_MODE;
+    }
+  });
+
   test('Sends tool call event and replaces thinking message when tool call happens with no content', async () => {
     const patchArgs = {
       description: 'A new thing',


### PR DESCRIPTION
## Summary

- Adds `AI_BOT_STREAMING_MODE` env var to `packages/ai-bot/lib/responder.ts`. Default is `room-edits` (current behavior); `off` skips the throttled per-chunk `m.replace` edit and only emits the initial thinking placeholder plus the final consolidated event at stream end.
- Reduces Matrix room events per turn from ~600 to 2 in `off` mode.
- Cancellation and final-event semantics (`isStreamingFinished`, `isCanceled`, continuation chaining for >16kB bodies) route through the same finalize/flush path in both modes — only the `onChunk` call is gated.

## Context

Phase 1 of [CS-12124](https://linear.app/cardstack/issue/CS-12124/implementation-plan-replace-matrix-room-edit-streaming-with-to-device), the plan for the [Improve Synapse Performance by Killing Streaming](https://linear.app/cardstack/project/improve-synapse-performance-by-killing-streaming-1d7d8ac245b1) project. Synapse was observed at 125% CPU with a single active AI Assistant user, driven by ~600 `m.replace` edits per response. This PR ships the lowest-risk mode — pure "no streaming" — so we can measure the immediate CPU relief and dogfood the fallback UX while [CS-12263](https://linear.app/cardstack/issue/CS-12263) adds streaming back over Matrix's `sendToDevice` transport.

The `to-device` value is accepted by the getter but behaves like `room-edits` today; the substitution comes in CS-12263.

## Test plan

- [x] New `Responding` test: in `off` mode, 10 rapid chunks + `finalize()` produce exactly 2 events (thinking + final) with `isStreamingFinished=true` and `m.replace` pointing at the placeholder.
- [x] All 20 existing `Responding` tests pass.
- [x] All 5 `Responder Cancellation` tests pass — `finalize({isCanceled:true})` still emits the final `isCanceled` event through the same path.
- [ ] Staging: set `AI_BOT_STREAMING_MODE=off` on the ai-bot task, run a chat turn, verify only 2 room events land per turn and Synapse CPU drops on the dashboard.