### PR TITLE
Interrupt in-flight prerender renders when the client disconnects

### DIFF
--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -395,7 +395,9 @@ export function buildPrerenderApp(options: {
       let ac = new AbortController();
       const onClientClose = () => {
         if (ctxt.res.writableEnded) return;
-        ac.abort();
+        // The reason string rides on `PrerenderCancelledError.message`
+        // so cancel log lines say why the render was interrupted.
+        ac.abort('client disconnected');
       };
       ctxt.res.on('close', onClientClose);
       try {
@@ -656,7 +658,9 @@ export function buildPrerenderApp(options: {
     let ac = new AbortController();
     const onClientClose = () => {
       if (ctxt.res.writableEnded) return;
-      ac.abort();
+      // The reason string rides on `PrerenderCancelledError.message`
+      // so cancel log lines say why the render was interrupted.
+      ac.abort('client disconnected');
     };
     ctxt.res.on('close', onClientClose);
     try {

--- a/packages/realm-server/prerender/prerender-cancel.ts
+++ b/packages/realm-server/prerender/prerender-cancel.ts
@@ -6,8 +6,11 @@
 // that signal from its Koa handler and threads it down through
 // `Prerenderer` → `RenderRunner` → `PagePool.getPage` so queued
 // waits (render semaphore, per-affinity tab queue) can bail out
-// without entering render, and an in-flight render can be torn
-// down cleanly via `#maybeEvict`.
+// without entering render, and in-flight render steps race the
+// signal (`withTimeout` / `abortable`) so a mid-render abort
+// interrupts the step immediately — even against a wedged renderer
+// whose CDP calls would otherwise pin the visit until a protocol
+// timeout — and the Prerenderer tears the tab down.
 //
 // `PrerenderCancelledError` is the distinct-named rejection
 // callers look for to decide "this is a user cancel, route the tab
@@ -57,5 +60,48 @@ export function throwIfAborted(
       state,
       reason: typeof signal.reason === 'string' ? signal.reason : undefined,
     });
+  }
+}
+
+// Races `run()` against the signal so a page operation that can't
+// observe cancellation itself (a CDP evaluate against a wedged
+// renderer never returns) is abandoned the moment the caller goes
+// away, throwing `PrerenderCancelledError` instead of waiting on the
+// operation's own (protocol-level) timeout. The abandoned promise
+// keeps running until the cancel handler disposes the page — its
+// eventual rejection is absorbed by the race, never surfacing as an
+// unhandled rejection.
+export async function abortable<T>(
+  signal: AbortSignal | undefined,
+  run: () => Promise<T>,
+  state: PrerenderCancelState = 'rendering',
+): Promise<T> {
+  if (!signal) {
+    return run();
+  }
+  throwIfAborted(signal, state);
+  let onAbort: (() => void) | undefined;
+  try {
+    return await Promise.race([
+      run(),
+      new Promise<never>((_resolve, reject) => {
+        onAbort = () =>
+          reject(
+            new PrerenderCancelledError({
+              state,
+              reason:
+                typeof signal.reason === 'string' ? signal.reason : undefined,
+            }),
+          );
+        signal.addEventListener('abort', onAbort, { once: true });
+      }),
+    ]);
+  } finally {
+    // The signal outlives any one operation (it spans the whole
+    // request), so every race must detach its listener or a visit's
+    // worth of steps accumulates listeners on the shared signal.
+    if (onAbort) {
+      signal.removeEventListener('abort', onAbort);
+    }
   }
 }

--- a/packages/realm-server/prerender/prerender-cancel.ts
+++ b/packages/realm-server/prerender/prerender-cancel.ts
@@ -31,6 +31,10 @@ export type PrerenderCancelState = 'queued' | 'rendering' | 'releasing';
 export class PrerenderCancelledError extends Error {
   name = 'PrerenderCancelledError';
   state: PrerenderCancelState;
+  // Why the caller aborted (e.g. the close listener's disconnect
+  // reason). Carried as its own field — not only embedded in the
+  // message — so log lines can print it without re-parsing.
+  reason?: string;
   constructor(
     opts?: { state?: PrerenderCancelState; reason?: string } | string,
   ) {
@@ -44,6 +48,7 @@ export class PrerenderCancelledError extends Error {
     }
     super(reason ? `prerender cancelled: ${reason}` : 'prerender cancelled');
     this.state = state;
+    this.reason = reason;
   }
 }
 

--- a/packages/realm-server/prerender/prerender-cancel.ts
+++ b/packages/realm-server/prerender/prerender-cancel.ts
@@ -93,7 +93,17 @@ export async function abortable<T>(
                 typeof signal.reason === 'string' ? signal.reason : undefined,
             }),
           );
-        signal.addEventListener('abort', onAbort, { once: true });
+        // AbortSignal never replays `abort` for listeners attached
+        // after the fact, so re-check before attaching. No await
+        // separates the entry check above from this attach, so no
+        // abort can land between them — the re-check keeps the
+        // no-missed-abort guarantee local instead of resting on that
+        // ordering.
+        if (signal.aborted) {
+          onAbort();
+        } else {
+          signal.addEventListener('abort', onAbort, { once: true });
+        }
       }),
     ]);
   } finally {

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -61,6 +61,11 @@ export class Prerenderer {
   #affinityIdleEvictMs: number;
   #semaphore: AsyncSemaphore;
   #restartInFlight: Promise<void> | null = null;
+  // Count of actual browser restarts performed (coalesced callers share
+  // one). Read by tests to assert a flow did NOT pay a restart — e.g. a
+  // visit following a cancelled render must acquire a fresh page rather
+  // than detour through the restart recovery lane.
+  #browserRestartCount = 0;
   // `clearCache` batch ownership (CS-10758 step 3). Maps affinityKey to
   // `{ batchId, since }` for the batch that currently owns the affinity's
   // warm loader. See `#gateClearCache` for the full policy. Populated on
@@ -243,7 +248,8 @@ export class Prerenderer {
     let elapsed = Date.now() - startedAt;
     log.info(
       `render cancelled after ${elapsed}ms in state=${err.state} ` +
-        `affinity=${affinityKey} target=${target}`,
+        `affinity=${affinityKey} target=${target} ` +
+        `reason=${err.reason ?? '<none>'}`,
     );
     if (err.state === 'rendering') {
       try {
@@ -256,9 +262,13 @@ export class Prerenderer {
         // instead of racing a background close at the pool ceiling
         // (which reads as "no standby available" and needlessly
         // routes that visit through the browser-restart recovery
-        // lane). The shared BrowserContext is retained so that next
-        // visit reuses the warm HTTP cache rather than paying the
-        // cold module-source waterfall.
+        // lane). That guarantee is scoped to visits arriving after
+        // this disposal: a waiter already holding the tab-queue
+        // lease when the cancel lands still receives the doomed
+        // page, since the lease handoff carries no revalidation.
+        // The shared BrowserContext is retained so the next visit
+        // reuses the warm HTTP cache rather than paying the cold
+        // module-source waterfall.
         await this.#pagePool.disposeAffinity(affinityKey, {
           retainSharedContext: true,
         });
@@ -293,6 +303,13 @@ export class Prerenderer {
       this.#renderRunner.clearIconMemo(affinityKey);
       log.debug(`batch ${batchId} released ownership of ${affinityKey}`);
     }
+  }
+
+  // Read-only observability accessor used by tests. Callers outside of
+  // tests should not rely on this; it's a debugging surface, not a
+  // stable API.
+  getBrowserRestartCount(): number {
+    return this.#browserRestartCount;
   }
 
   // Read-only observability accessor used by tests. Callers outside of
@@ -909,6 +926,7 @@ export class Prerenderer {
 
   async #runRestart(): Promise<void> {
     log.warn('Restarting prerender browser');
+    this.#browserRestartCount++;
     await this.#pagePool.closeAll();
     await this.#browserManager.restartBrowser();
     await this.#pagePool.warmStandbys().catch((e) => {

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -247,18 +247,19 @@ export class Prerenderer {
     );
     if (err.state === 'rendering') {
       try {
-        // Same disposal envelope as the render-error eviction path:
-        // mark the entries closing synchronously (so a queued waiter
-        // for this affinity is routed to a fresh page instead of
-        // adopting the abandoned — possibly wedged — one), close them
-        // in the background (a wedged tab's teardown must not
-        // serialize this cancel handler), and keep the shared
-        // BrowserContext so the next visit reuses its warm HTTP
-        // cache instead of paying the cold module-source waterfall.
-        // Closing the page is also what interrupts any CDP call the
-        // cancelled render abandoned mid-flight.
+        // Closing the page is what interrupts any CDP call the
+        // cancelled render abandoned mid-flight. The teardown is
+        // awaited: the caller is gone, so nothing is delayed by
+        // waiting, and by the time the cancellation propagates the
+        // pool's slot accounting has already released this page —
+        // the affinity's next visit materializes a fresh page
+        // instead of racing a background close at the pool ceiling
+        // (which reads as "no standby available" and needlessly
+        // routes that visit through the browser-restart recovery
+        // lane). The shared BrowserContext is retained so that next
+        // visit reuses the warm HTTP cache rather than paying the
+        // cold module-source waterfall.
         await this.#pagePool.disposeAffinity(affinityKey, {
-          awaitIdle: false,
           retainSharedContext: true,
         });
         this.#renderRunner.clearAuthCache(affinityKey);

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -247,7 +247,20 @@ export class Prerenderer {
     );
     if (err.state === 'rendering') {
       try {
-        await this.#pagePool.disposeAffinity(affinityKey);
+        // Same disposal envelope as the render-error eviction path:
+        // mark the entries closing synchronously (so a queued waiter
+        // for this affinity is routed to a fresh page instead of
+        // adopting the abandoned — possibly wedged — one), close them
+        // in the background (a wedged tab's teardown must not
+        // serialize this cancel handler), and keep the shared
+        // BrowserContext so the next visit reuses its warm HTTP
+        // cache instead of paying the cold module-source waterfall.
+        // Closing the page is also what interrupts any CDP call the
+        // cancelled render abandoned mid-flight.
+        await this.#pagePool.disposeAffinity(affinityKey, {
+          awaitIdle: false,
+          retainSharedContext: true,
+        });
         this.#renderRunner.clearAuthCache(affinityKey);
       } catch (disposeErr: any) {
         log.warn(

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -22,7 +22,11 @@ import {
 import type { SerializedError } from '@cardstack/runtime-common/error';
 import type { ConsoleErrorEntry, PagePool } from './page-pool.ts';
 import { toAffinityKey } from './affinity.ts';
-import { abortable, throwIfAborted } from './prerender-cancel.ts';
+import {
+  abortable,
+  PrerenderCancelledError,
+  throwIfAborted,
+} from './prerender-cancel.ts';
 import {
   captureResult,
   captureModule,
@@ -485,6 +489,13 @@ export class RenderRunner {
         pool: poolInfo,
       };
     } catch (e) {
+      // Cancellations must reach the Prerenderer's cancel handler —
+      // converting one into an error response here would return the
+      // abandoned (possibly wedged) tab to the pool with no disposal,
+      // and there is no caller left to read the response anyway.
+      if (e instanceof PrerenderCancelledError) {
+        throw e;
+      }
       log.error('Error running command in headless chrome:', e);
       let response: RunCommandResponse = {
         status: 'error',
@@ -2010,13 +2021,24 @@ export class RenderRunner {
       );
     } finally {
       if (didStashFileRenderData) {
-        await page
-          .evaluate(() => {
-            delete (globalThis as any).__boxelFileRenderData;
-          })
-          .catch(() => {
-            /* best-effort cleanup */
-          });
+        // The stash only matters to a page that will render again, and
+        // against a wedged page this evaluate can hang until the
+        // protocol timeout — so race it against the signal and swallow
+        // the cancellation: a cancelled visit's page is about to be
+        // disposed, and holding up `release()` (and the disposal
+        // behind it) for cosmetic cleanup would pin the affinity for
+        // exactly the window this cancellation exists to reclaim.
+        await abortable(signal, () =>
+          page
+            .evaluate(() => {
+              delete (globalThis as any).__boxelFileRenderData;
+            })
+            .catch(() => {
+              /* best-effort cleanup */
+            }),
+        ).catch(() => {
+          /* caller gone — the page is being disposed, stash and all */
+        });
       }
       release();
     }

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -22,7 +22,7 @@ import {
 import type { SerializedError } from '@cardstack/runtime-common/error';
 import type { ConsoleErrorEntry, PagePool } from './page-pool.ts';
 import { toAffinityKey } from './affinity.ts';
-import { throwIfAborted } from './prerender-cancel.ts';
+import { abortable, throwIfAborted } from './prerender-cancel.ts';
 import {
   captureResult,
   captureModule,
@@ -347,27 +347,31 @@ export class RenderRunner {
       let requestId = randomUUID();
       let nonce = String(this.#nonce);
       let storageKey = `${commandRequestStorageKeyPrefix}${requestId}`;
-      await page.evaluate(
-        (sessionAuth, key, commandToRun, input, requestNonce, createdAt) => {
-          localStorage.setItem('boxel-session', sessionAuth);
-          localStorage.setItem(
-            key,
-            JSON.stringify({
-              command: commandToRun,
-              input,
-              nonce: requestNonce,
-              createdAt,
-            }),
-          );
-        },
-        auth,
-        storageKey,
-        command,
-        commandInput ?? null,
-        nonce,
-        Date.now(),
+      await abortable(signal, () =>
+        page.evaluate(
+          (sessionAuth, key, commandToRun, input, requestNonce, createdAt) => {
+            localStorage.setItem('boxel-session', sessionAuth);
+            localStorage.setItem(
+              key,
+              JSON.stringify({
+                command: commandToRun,
+                input,
+                nonce: requestNonce,
+                createdAt,
+              }),
+            );
+          },
+          auth,
+          storageKey,
+          command,
+          commandInput ?? null,
+          nonce,
+          Date.now(),
+        ),
       );
-      await transitionTo(page, 'command-runner', requestId, nonce);
+      await abortable(signal, () =>
+        transitionTo(page, 'command-runner', requestId, nonce),
+      );
       log.info(
         'command-runner url: %s',
         buildCommandRunnerURL(page, nonce, requestId),
@@ -433,6 +437,7 @@ export class RenderRunner {
         },
         opts?.timeoutMs,
         this.#profileContext(affinityKey, command, 'command-runner'),
+        signal,
       );
 
       if (isRenderError(waitResult)) {
@@ -554,9 +559,11 @@ export class RenderRunner {
       // try so `finally { release() }` frees the tab slot if the caller
       // aborted during the getPage handoff.
       throwIfAborted(signal, 'queued');
-      await page.evaluate((sessionAuth) => {
-        localStorage.setItem('boxel-session', sessionAuth);
-      }, auth);
+      await abortable(signal, () =>
+        page.evaluate((sessionAuth) => {
+          localStorage.setItem('boxel-session', sessionAuth);
+        }, auth),
+      );
 
       let renderStart = Date.now();
       let nonce = String(this.#nonce);
@@ -585,6 +592,7 @@ export class RenderRunner {
         },
         opts?.timeoutMs,
         this.#profileContext(affinityKey, url, `screenshot ${format}`),
+        signal,
       );
 
       let response: ScreenshotPrerenderResponse;
@@ -694,9 +702,11 @@ export class RenderRunner {
       // inside the try so `finally { release() }` frees the tab slot
       // if the caller aborted during the getPage handoff.
       throwIfAborted(signal, 'queued');
-      await page.evaluate((sessionAuth) => {
-        localStorage.setItem('boxel-session', sessionAuth);
-      }, auth);
+      await abortable(signal, () =>
+        page.evaluate((sessionAuth) => {
+          localStorage.setItem('boxel-session', sessionAuth);
+        }, auth),
+      );
 
       let renderStart = Date.now();
       let options = renderOptions ?? {};
@@ -722,6 +732,7 @@ export class RenderRunner {
         },
         opts?.timeoutMs,
         this.#profileContext(affinityKey, url, 'module'),
+        signal,
       );
 
       let response: ModuleRenderResponse;
@@ -971,29 +982,31 @@ export class RenderRunner {
       // host deploys independently of this server, so render strategies the
       // host must understand are gated per page on its advertised
       // `__boxelHostCapabilities`.
-      let hostCapabilities = await page.evaluate(
-        (
-          sessionAuth: string,
-          id: string | undefined,
-          jobPriority: number | undefined,
-        ) => {
-          localStorage.setItem('boxel-session', sessionAuth);
-          (globalThis as unknown as { __boxelJobId?: string }).__boxelJobId =
-            id;
+      let hostCapabilities = await abortable(signal, () =>
+        page.evaluate(
           (
-            globalThis as unknown as { __boxelJobPriority?: number }
-          ).__boxelJobPriority = jobPriority;
-          return (
+            sessionAuth: string,
+            id: string | undefined,
+            jobPriority: number | undefined,
+          ) => {
+            localStorage.setItem('boxel-session', sessionAuth);
+            (globalThis as unknown as { __boxelJobId?: string }).__boxelJobId =
+              id;
             (
-              globalThis as unknown as {
-                __boxelHostCapabilities?: Record<string, boolean>;
-              }
-            ).__boxelHostCapabilities ?? {}
-          );
-        },
-        auth,
-        jobId,
-        priority,
+              globalThis as unknown as { __boxelJobPriority?: number }
+            ).__boxelJobPriority = jobPriority;
+            return (
+              (
+                globalThis as unknown as {
+                  __boxelHostCapabilities?: Record<string, boolean>;
+                }
+              ).__boxelHostCapabilities ?? {}
+            );
+          },
+          auth,
+          jobId,
+          priority,
+        ),
       );
       // A card-instance index visit fuses the file extract into the
       // render.meta transition — one transition + settle for both the
@@ -1016,13 +1029,15 @@ export class RenderRunner {
       }
       // defense-in-depth: clear any stale file render data left on globalThis
       // from a prior visit before we start running passes.
-      await page
-        .evaluate(() => {
-          delete (globalThis as any).__boxelFileRenderData;
-        })
-        .catch(() => {
-          /* best-effort */
-        });
+      await abortable(signal, () =>
+        page
+          .evaluate(() => {
+            delete (globalThis as any).__boxelFileRenderData;
+          })
+          .catch(() => {
+            /* best-effort */
+          }),
+      );
 
       // Serialized options carry the pass flags into the route — the host
       // render/module routes consume these to decide which mode to run. The
@@ -1092,6 +1107,7 @@ export class RenderRunner {
           },
           opts?.timeoutMs,
           this.#profileContext(affinityKey, url, 'file-extract', jobId),
+          signal,
         );
         recordIndexRouteMs('file', 'fileExtract', Date.now() - extractStart);
         let extractResponse: FileExtractResponse;
@@ -1273,6 +1289,7 @@ export class RenderRunner {
               fn,
               opts?.timeoutMs,
               this.#profileContext(affinityKey, url, step, jobId),
+              signal,
             ),
           );
           let elapsed = Date.now() - stepStart;
@@ -1316,6 +1333,7 @@ export class RenderRunner {
             },
             opts?.timeoutMs,
             this.#profileContext(affinityKey, url, 'card isolated/0', jobId),
+            signal,
           );
           recordFormatMs('card', 'isolated', Date.now() - isolatedStart);
           if (isRenderError(isolatedResult)) {
@@ -1337,7 +1355,9 @@ export class RenderRunner {
             // read it here so the HTML rendering still reports what it
             // pulled in — the indexing job unions this with the index
             // visit's meta deps.
-            capturedDeps = await this.#readCapturedDeps(page);
+            capturedDeps = await abortable(signal, () =>
+              this.#readCapturedDeps(page),
+            );
           }
         } else {
           // An index visit never touches the html route, so render.meta is
@@ -1713,9 +1733,11 @@ export class RenderRunner {
 
           if (memoizedIconHTML === undefined) {
             // stash file data for the render route model hook to consume
-            await page.evaluate((data) => {
-              (globalThis as any).__boxelFileRenderData = data;
-            }, effectiveFileData);
+            await abortable(signal, () =>
+              page.evaluate((data) => {
+                (globalThis as any).__boxelFileRenderData = data;
+              }, effectiveFileData),
+            );
             didStashFileRenderData = true;
           }
 
@@ -1759,6 +1781,7 @@ export class RenderRunner {
               },
               opts?.timeoutMs,
               this.#profileContext(affinityKey, url, 'file isolated/0', jobId),
+              signal,
             );
             recordFormatMs('file', 'isolated', Date.now() - isolatedStart);
             if (isRenderError(isolatedResult)) {
@@ -1810,6 +1833,7 @@ export class RenderRunner {
               },
               opts?.timeoutMs,
               this.#profileContext(affinityKey, url, 'file icon', jobId),
+              signal,
             );
             recordIndexRouteMs('file', 'icon', Date.now() - iconStart);
             if (isRenderError(iconResult)) {
@@ -1840,6 +1864,7 @@ export class RenderRunner {
                   () => renderHTML(page, 'head', 0, captureOptions),
                   opts?.timeoutMs,
                   this.#profileContext(affinityKey, url, 'file head/0', jobId),
+                  signal,
                 ),
             );
             recordFormatMs('file', 'head', Date.now() - headStart);
@@ -1934,6 +1959,7 @@ export class RenderRunner {
                   step.cb,
                   opts?.timeoutMs,
                   this.#profileContext(affinityKey, url, step.name, jobId),
+                  signal,
                 ),
               );
               let elapsed = Date.now() - stepStart;

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -35,6 +35,7 @@ import {
   uploadArtifact,
   type ArtifactKeyParts,
 } from './artifact-sink.ts';
+import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel.ts';
 
 import type { CDPSession, Page } from 'puppeteer';
 
@@ -1588,7 +1589,11 @@ export async function withTimeout<T>(
   fn: () => Promise<T>,
   timeoutMs = cardRenderTimeout,
   profileContext?: RenderProfileContext,
+  signal?: AbortSignal,
 ): Promise<T | RenderError> {
+  // A caller that has already gone away gets no render at all — bail
+  // before the render bookkeeping below so the counter stays balanced.
+  throwIfAborted(signal, 'rendering');
   // Every render funnels through here, so this counter is the live
   // count of concurrent renders in this process. Capture it (including
   // this render) at the moment the race resolves — the timeout block
@@ -1619,8 +1624,9 @@ export async function withTimeout<T>(
   // otherwise a render that finishes fast leaves a pending timer holding
   // the event loop for the full `timeoutMs`.
   let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+  let abortListener: (() => void) | undefined;
   try {
-    result = await Promise.race([
+    let racers: Array<Promise<T | { timeout: true }>> = [
       renderFn().catch((err) => {
         // Puppeteer's own TimeoutError (from waitForFunction/waitForSelector)
         // should be treated the same as our outer timeout
@@ -1634,11 +1640,43 @@ export async function withTimeout<T>(
           r({ timeout: true });
         }, timeoutMs);
       }),
-    ]);
+    ];
+    if (signal) {
+      // A client abort mid-render must interrupt the wait NOW — a
+      // wedged renderer can pin the render promise until a protocol
+      // timeout, long after anyone is listening for the result. Reject
+      // (rather than resolve a timeout marker) so the cancel surfaces
+      // as `PrerenderCancelledError` and skips the timeout-path
+      // diagnostics below: those burn seconds of CDP probing to
+      // explain a hang to a caller, and this caller is gone. The
+      // abandoned render promise stays pending until the cancel
+      // handler disposes the page; its eventual rejection is absorbed
+      // by this settled race.
+      racers.push(
+        new Promise<never>((_resolve, reject) => {
+          abortListener = () =>
+            reject(
+              new PrerenderCancelledError({
+                state: 'rendering',
+                reason:
+                  typeof signal.reason === 'string' ? signal.reason : undefined,
+              }),
+            );
+          signal.addEventListener('abort', abortListener, { once: true });
+        }),
+      );
+    }
+    result = await Promise.race(racers);
     concurrentRenders = activeRenderCount;
   } finally {
     activeRenderCount--;
     clearTimeout(timeoutTimer);
+    // The signal spans the whole request while this race is per-step:
+    // detach so a multi-step visit doesn't stack one listener per step
+    // on the shared signal.
+    if (signal && abortListener) {
+      signal.removeEventListener('abort', abortListener);
+    }
   }
   if (
     result &&

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -1662,7 +1662,17 @@ export async function withTimeout<T>(
                   typeof signal.reason === 'string' ? signal.reason : undefined,
               }),
             );
-          signal.addEventListener('abort', abortListener, { once: true });
+          // AbortSignal never replays `abort` for listeners attached
+          // after the fact, so re-check before attaching. No await
+          // separates the entry check above from this attach, so no
+          // abort can land between them — the re-check keeps the
+          // no-missed-abort guarantee local instead of resting on that
+          // ordering.
+          if (signal.aborted) {
+            abortListener();
+          } else {
+            signal.addEventListener('abort', abortListener, { once: true });
+          }
         }),
       );
     }

--- a/packages/realm-server/tests/prerender-cancellation-test.ts
+++ b/packages/realm-server/tests/prerender-cancellation-test.ts
@@ -63,6 +63,11 @@ module(basename(import.meta.filename), function () {
         'prerender cancelled: req-closed',
         'reason in message',
       );
+      assert.strictEqual(
+        err.reason,
+        'req-closed',
+        'reason exposed as its own field for log lines',
+      );
     });
 
     test('isPrerenderCancellation matches only this error', function (assert) {

--- a/packages/realm-server/tests/prerender-cancellation-test.ts
+++ b/packages/realm-server/tests/prerender-cancellation-test.ts
@@ -1,24 +1,32 @@
 import QUnit from 'qunit';
 const { module, test } = QUnit;
 import { basename } from 'path';
+import { getEventListeners } from 'node:events';
 import {
   PrerenderCancelledError,
   isPrerenderCancellation,
   throwIfAborted,
+  abortable,
 } from '../prerender/prerender-cancel.ts';
 import { TabQueue } from '../prerender/page-pool.ts';
 import { AsyncSemaphore } from '../prerender/async-semaphore.ts';
+import { withTimeout, isRenderError } from '../prerender/utils.ts';
+import type { RenderError } from '@cardstack/runtime-common';
+import type { Page } from 'puppeteer';
 
-// These tests cover the cancellation plumbing added in CS-10873 at the
-// level closest to the logic — no Chrome, no HTTP. They pin down the
-// behaviors that the manager / prerender-server rely on:
+// These tests cover the cancellation plumbing at the level closest to
+// the logic — no Chrome, no HTTP. They pin down the behaviors that the
+// manager / prerender-server rely on:
 //
 //   1. An abort delivered *while queued* produces a `'queued'`-state
 //      `PrerenderCancelledError` and releases the slot so later
 //      waiters aren't blocked behind a cancelled holder.
-//   2. An abort delivered *after* acquisition is the caller's
-//      responsibility to react to via `throwIfAborted(signal, state)`,
-//      which the render path does at pass boundaries.
+//   2. An abort delivered *mid-render* interrupts the in-flight step
+//      immediately: `withTimeout` / `abortable` race the signal, so a
+//      wedged page operation that would otherwise pin the step until
+//      its render/protocol timeout is abandoned the moment the caller
+//      disconnects, surfacing a `'rendering'`-state cancellation the
+//      prerenderer turns into tab disposal.
 //   3. The error shape is what the prerenderer's cancel-handler
 //      branches on — `name`, `state`, and the `instanceof` guard.
 //
@@ -108,6 +116,187 @@ module(basename(import.meta.filename), function () {
           'queued default',
         );
       }
+    });
+  });
+
+  module('withTimeout cancellation', function () {
+    // `withTimeout` only touches the page on its timeout path, and every
+    // page read there is gated on `!page.isClosed()` — so a stub that
+    // reports closed exercises the full race without Chrome.
+    let stubPage = {
+      url: () => 'http://localhost:4200/render/stub-card/1/opts/html',
+      isClosed: () => true,
+    } as unknown as Page;
+
+    test('abort mid-step interrupts the wait without burning the step timeout', async function (assert) {
+      let ac = new AbortController();
+      let start = Date.now();
+      let neverSettles = new Promise<never>(() => {});
+      let result = withTimeout(
+        stubPage,
+        () => neverSettles,
+        30_000,
+        undefined,
+        ac.signal,
+      );
+      setTimeout(() => ac.abort('client disconnected'), 20);
+      try {
+        await result;
+        assert.ok(false, 'should have thrown');
+      } catch (e) {
+        assert.true(isPrerenderCancellation(e), 'cancel error');
+        assert.strictEqual(
+          (e as PrerenderCancelledError).state,
+          'rendering',
+          'tagged as a mid-render cancel',
+        );
+        assert.ok(
+          ((e as PrerenderCancelledError).message ?? '').includes(
+            'client disconnected',
+          ),
+          'abort reason threaded into the message',
+        );
+      }
+      assert.true(
+        Date.now() - start < 10_000,
+        'interrupted well before the step timeout',
+      );
+    });
+
+    test('already-aborted signal cancels before the step starts', async function (assert) {
+      let ac = new AbortController();
+      ac.abort();
+      let started = false;
+      try {
+        await withTimeout(
+          stubPage,
+          async () => {
+            started = true;
+          },
+          1_000,
+          undefined,
+          ac.signal,
+        );
+        assert.ok(false, 'should have thrown');
+      } catch (e) {
+        assert.true(isPrerenderCancellation(e), 'cancel error');
+        assert.strictEqual((e as PrerenderCancelledError).state, 'rendering');
+      }
+      assert.false(started, 'step body never ran');
+    });
+
+    test('timeout path is unchanged when the signal never fires', async function (assert) {
+      let ac = new AbortController();
+      let result = await withTimeout(
+        stubPage,
+        () => new Promise<never>(() => {}),
+        50,
+        undefined,
+        ac.signal,
+      );
+      assert.true(isRenderError(result), 'timeout yields a render error');
+      assert.strictEqual(
+        (result as RenderError).error.title,
+        'Render timeout',
+        'canonical timeout error',
+      );
+    });
+
+    test('a completed step resolves its value and detaches the abort listener', async function (assert) {
+      let ac = new AbortController();
+      let value = await withTimeout(
+        stubPage,
+        async () => 'rendered',
+        1_000,
+        undefined,
+        ac.signal,
+      );
+      assert.strictEqual(value, 'rendered', 'value passed through');
+      // The signal spans the whole request while the race is per-step;
+      // a leaked listener per step would pile up across a visit.
+      assert.strictEqual(
+        getEventListeners(ac.signal, 'abort').length,
+        0,
+        'no listener left behind',
+      );
+    });
+  });
+
+  module('abortable', function () {
+    test('passes the value through when no signal is provided', async function (assert) {
+      assert.strictEqual(await abortable(undefined, async () => 42), 42);
+    });
+
+    test('resolves and detaches its listener when the operation completes', async function (assert) {
+      let ac = new AbortController();
+      let value = await abortable(ac.signal, async () => 'done');
+      assert.strictEqual(value, 'done');
+      assert.strictEqual(
+        getEventListeners(ac.signal, 'abort').length,
+        0,
+        'no listener left behind',
+      );
+    });
+
+    test('abort mid-operation rejects with a rendering-state cancel by default', async function (assert) {
+      let ac = new AbortController();
+      let op = abortable(ac.signal, () => new Promise<never>(() => {}));
+      setTimeout(() => ac.abort('client disconnected'), 20);
+      try {
+        await op;
+        assert.ok(false, 'should have thrown');
+      } catch (e) {
+        assert.true(isPrerenderCancellation(e), 'cancel error');
+        assert.strictEqual((e as PrerenderCancelledError).state, 'rendering');
+        assert.ok(
+          ((e as PrerenderCancelledError).message ?? '').includes(
+            'client disconnected',
+          ),
+          'reason threaded through',
+        );
+      }
+    });
+
+    test('already-aborted signal rejects before the operation starts', async function (assert) {
+      let ac = new AbortController();
+      ac.abort();
+      let started = false;
+      try {
+        await abortable(ac.signal, async () => {
+          started = true;
+        });
+        assert.ok(false, 'should have thrown');
+      } catch (e) {
+        assert.true(isPrerenderCancellation(e), 'cancel error');
+      }
+      assert.false(started, 'operation never ran');
+    });
+
+    test('the abandoned operation rejecting later does not surface anywhere', async function (assert) {
+      // Once the page is disposed, the abandoned CDP call rejects —
+      // that rejection must be absorbed by the settled race, not
+      // escape as an unhandled rejection (which fails the suite).
+      let ac = new AbortController();
+      let rejectLater!: (err: Error) => void;
+      let op = abortable(
+        ac.signal,
+        () =>
+          new Promise<never>((_resolve, reject) => {
+            rejectLater = reject;
+          }),
+      );
+      ac.abort();
+      try {
+        await op;
+        assert.ok(false, 'should have thrown');
+      } catch (e) {
+        assert.true(isPrerenderCancellation(e), 'cancel error');
+      }
+      rejectLater(new Error('Protocol error (Target closed)'));
+      // Give the microtask queue a turn — an unhandled rejection here
+      // would be reported by the test harness.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      assert.ok(true, 'late rejection absorbed');
     });
   });
 

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -7537,6 +7537,7 @@ module(basename(import.meta.filename), function () {
     test('client abort mid-render interrupts the in-flight visit and frees the affinity', async function (assert) {
       const cardFileURL = `${realmURL}maple.json`;
       let ac = new AbortController();
+      let restartsBefore = prerenderer.getBrowserRestartCount();
       let start = Date.now();
       try {
         await prerenderer.prerenderVisit({
@@ -7594,6 +7595,16 @@ module(basename(import.meta.filename), function () {
       assert.notOk(
         followUp.response.pageUnusableError,
         'follow-up visit is not poisoned by the cancelled render',
+      );
+      // A restart-lane detour would also render normally (restart →
+      // retry succeeds), so the success assertions alone can't tell a
+      // clean fresh-page acquisition from recovery. The counter can:
+      // the awaited cancel disposal means the follow-up acquires a
+      // page without a browser restart.
+      assert.strictEqual(
+        prerenderer.getBrowserRestartCount(),
+        restartsBefore,
+        'follow-up visit did not pay a browser restart',
       );
     });
 

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -7534,6 +7534,69 @@ module(basename(import.meta.filename), function () {
       assert.notOk(result.response.fileRender, 'fileRender skipped');
     });
 
+    test('client abort mid-render interrupts the in-flight visit and frees the affinity', async function (assert) {
+      const cardFileURL = `${realmURL}maple.json`;
+      let ac = new AbortController();
+      let start = Date.now();
+      try {
+        await prerenderer.prerenderVisit({
+          affinityType: 'realm',
+          affinityValue: realmURL,
+          realm: realmURL,
+          url: cardFileURL,
+          auth: auth(),
+          renderOptions: { cardRender: true },
+          // The simulated delay holds the render step in-flight so the
+          // abort lands mid-step; the matching timeout means the only
+          // way this visit ends early is the abort being observed
+          // inside the step, not at a pass boundary after the step has
+          // burned its full budget.
+          opts: { timeoutMs: 15_000, simulateTimeoutMs: 15_000 },
+          signal: ac.signal,
+          onTabAcquired: () => {
+            setTimeout(() => ac.abort('client disconnected'), 250);
+          },
+        });
+        assert.ok(false, 'visit should have been cancelled');
+      } catch (e: any) {
+        assert.strictEqual(
+          e?.name,
+          'PrerenderCancelledError',
+          'visit rejects with the cancellation error',
+        );
+        assert.strictEqual(
+          e?.state,
+          'rendering',
+          'tagged as a mid-render cancel',
+        );
+      }
+      let elapsedMs = Date.now() - start;
+      assert.ok(
+        elapsedMs < 10_000,
+        `cancelled promptly (${elapsedMs}ms) instead of waiting out the render step`,
+      );
+
+      // The cancel handler disposes the abandoned tab; the affinity
+      // itself must stay usable — the next visit gets a fresh page and
+      // renders normally.
+      let followUp = await prerenderer.prerenderVisit({
+        affinityType: 'realm',
+        affinityValue: realmURL,
+        realm: realmURL,
+        url: cardFileURL,
+        auth: auth(),
+        renderOptions: { cardRender: true },
+      });
+      assert.ok(
+        followUp.response.card?.isolatedHTML?.includes('Maple'),
+        'follow-up visit on the same affinity renders normally',
+      );
+      assert.notOk(
+        followUp.response.pageUnusableError,
+        'follow-up visit is not poisoned by the cancelled render',
+      );
+    });
+
     test('fileExtract-only visit returns only the extract', async function (assert) {
       const moduleURL = `${realmURL}person.gts`;
       let result = await prerenderer.prerenderVisit({


### PR DESCRIPTION
## Background

When a card is indexed (or its HTML is prerendered on demand), a worker sends the render request to the prerender manager, which proxies it to one of the prerender servers. The prerender server drives a headless Chrome tab through the host app's render routes — a "visit": one page acquisition, then a sequence of steps (route transitions, an HTML capture per format, a metadata pass), each executed as CDP calls against the tab.

Client disconnects already propagate through this chain as an abort signal. If the worker gives up on a slow render, or the manager's own caller disconnects, the manager aborts its upstream fetch; the prerender server's HTTP layer notices its socket close and fires an `AbortController` whose signal is threaded down through the prerenderer into the render pipeline. (The manager half of this — client socket close aborts the upstream fetch — is pinned by an existing test in `prerender-manager-test.ts`.)

The gap was in how the prerender server *observed* that signal. It was consulted at a few fixed checkpoints: while a render was queued (waiting on the render semaphore or the per-affinity tab queue), and at the boundaries between a visit's passes. Between checkpoints — that is, while a render step was actually executing — nothing looked at it.

## The failure this produces

Every render step runs under `withTimeout`, a watchdog that races the step against a timer (60 s per step by default). A card whose render wedges the page's JS run loop means the in-flight CDP call cannot return, so the step burns its full 60 s; the timeout path then spends several more seconds on hang diagnostics (a main-thread responsiveness probe, CPU sampling, a paused-stack capture) — all to explain the hang to a caller who, in this scenario, disconnected long ago. Only when the visit reaches its next pass boundary does the cancellation actually surface, and if no checkpoint remains between the burn and the end of the visit, it never surfaces at all: the visit runs every remaining step to completion and serializes a response onto a dead socket.

On a saturated deployment this is expensive in exactly the wrong moment: renders were observed continuing for minutes (in one case over seven) after their requests had been aborted, with the tab occupied for that whole window and every queued render for the same affinity waiting behind it. The burned capacity is also invisible — the caller's job has already failed, so nothing is persisted about the work the tab kept doing.

## What this changes

**`withTimeout` races the abort signal.** The watchdog now takes the visit's abort signal and adds it to the race alongside the step promise and the timer. An abort mid-step rejects immediately with a `rendering`-state `PrerenderCancelledError` — the same error the pass-boundary checks produce — so the existing cancel handling upstream takes over. Two deliberate details:

- The abort *rejects* rather than resolving the timeout marker, which means the timeout path's hang diagnostics are skipped entirely. Those diagnostics exist to explain a hang to a waiting caller; there is no caller.
- The signal spans the whole request while the race is per-step, so each race detaches its abort listener on the way out — a multi-step visit doesn't stack listeners on the shared signal.

**Raw page operations get the same race.** A handful of page operations run outside `withTimeout` (the session/capability setup evaluates at the start of a visit, the file-data stash, the captured-deps read, the command-runner's setup and transition). Against a wedged page these hang until Puppeteer's protocol timeout. They are now wrapped in a small `abortable(signal, fn)` helper that races the operation against the signal with the same rejection semantics. In both `withTimeout` and `abortable`, the abandoned operation's promise stays pending until the tab is torn down; its eventual rejection ("Target closed") is absorbed by the already-settled race, so it can't escape as an unhandled rejection.

**Cancel-handler disposal keeps the warm context and is awaited.** A `rendering`-state cancel has always disposed the affinity's tab — the tab's route state is uncertain mid-transition, and closing the page is precisely what interrupts whatever CDP call the cancelled render abandoned (page close is a browser-process operation, so it lands even when the page's JS thread is pegged). Two aspects of that disposal are tuned here:

- The shared `BrowserContext` is retained. The context holds the realm's warm HTTP cache and session state, which are unaffected by the cancel; the next visit for this affinity spawns a fresh page in the warm context instead of paying the cold module-source waterfall.
- The teardown stays awaited (the default) rather than backgrounded. The caller is gone, so awaiting delays nobody — and it means that by the time the cancellation propagates out, the pool's slot accounting has already released the page. The next visit for the affinity then materializes a fresh page normally. A backgrounded close would leave the closing page counting against the pool ceiling, and a visit arriving in that window can find no standby and get needlessly routed through the browser-restart recovery lane. This is a deliberate divergence from the render-error eviction path, which backgrounds its teardown because it runs mid-visit with a live caller still waiting for the error response.

**Cancel log lines say why.** The prerender server's close listeners abort with a reason string, which rides through `PrerenderCancelledError` into the `render cancelled` log line.

## What doesn't change

Queued-state cancellation (bailing out of the semaphore / tab-queue waits), the pass-boundary checks, and the timeout path for a render whose caller is still connected all behave exactly as before — the timeout race, its diagnostics, and the canonical `Render timeout` error doc are untouched when the signal never fires. The manager needed no changes.

One boundary worth naming: the abort interrupts the *server's wait*, not Chrome's work. An in-page hot loop keeps spinning until the disposal's page close lands; the win is that the visit stops consuming its slot, responds to nothing, and hands the affinity a fresh tab immediately, instead of after multiple watchdog cycles.

## Where the changes live

- `packages/realm-server/prerender/utils.ts` — `withTimeout` gains the signal race
- `packages/realm-server/prerender/prerender-cancel.ts` — the `abortable` helper
- `packages/realm-server/prerender/render-runner.ts` — threads the signal into every step's `withTimeout` call and wraps the raw page operations
- `packages/realm-server/prerender/prerenderer.ts` — cancel-handler disposal retains the shared context
- `packages/realm-server/prerender/prerender-app.ts` — abort reasons on the close listeners

## Testing

Unit tests (no Chrome) pin the race mechanics in `prerender-cancellation-test.ts`: an abort mid-step rejects with a `rendering`-state cancel well before the step timeout; an already-aborted signal prevents the step from starting; the timeout path is byte-for-byte unchanged when the signal never fires; completed steps detach their abort listeners; and a late rejection from an abandoned operation is absorbed rather than surfacing as an unhandled rejection. These were verified to fail against the previous `withTimeout`.

An integration test (real Chrome) in `prerendering-test.ts` holds a render step in-flight, aborts the signal mid-step, and asserts the visit rejects promptly with the cancellation error — then runs a follow-up visit on the same affinity and asserts it renders normally, pinning that the cancelled tab's disposal neither poisons the affinity nor detours the next visit through the restart lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015N4eRPdSqvC4uAR1Th1tea
