### PR TITLE
Wire the ai-bot to-device streaming channel end-to-end (ai-bot side)

### DIFF
--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -19,7 +19,7 @@ import type { MatrixClient } from 'matrix-js-sdk';
 
 let log = logger('ai-bot');
 
-function toCommandRequest(
+export function toCommandRequest(
   toolCall: ChatCompletionMessageFunctionToolCall,
 ): Partial<ToolRequest> {
   let { id, function: f } = toolCall;

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -1,5 +1,9 @@
 import { logger } from '@cardstack/runtime-common';
-import { APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE } from '@cardstack/runtime-common/matrix-constants';
+import {
+  APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE,
+  APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE,
+  type AppBoxelResponseStreamContent,
+} from '@cardstack/runtime-common/matrix-constants';
 import { isToolOrCodePatchResult } from '@cardstack/runtime-common/ai';
 
 import { errorReporter } from './sentry.ts';
@@ -49,7 +53,18 @@ export class Responder {
     );
   }
 
-  constructor(client: MatrixClient, roomId: string, agentId: string) {
+  private client: MatrixClient;
+  private streamPreviewTarget: { userId: string; deviceId: string } | undefined;
+  private _streamPreviewSequence = 0;
+
+  constructor(
+    client: MatrixClient,
+    roomId: string,
+    agentId: string,
+    streamPreviewTarget?: { userId: string; deviceId: string },
+  ) {
+    this.client = client;
+    this.streamPreviewTarget = streamPreviewTarget;
     this.matrixResponsePublisher = new MatrixResponsePublisher(
       client,
       roomId,
@@ -81,6 +96,19 @@ export class Responder {
     return 'room-edits';
   }
 
+  // Whether mid-turn state changes should trigger a throttled preview send.
+  // In `off` mode we never send mid-turn events. In `to-device` mode without a
+  // preview target (older client that didn't stamp its device id on the prompt)
+  // we also skip mid-turn — the sensible fallback since we can't target a
+  // preview at anyone in particular. The final consolidated room edit still
+  // lands from `finalize`/`flush`.
+  private get shouldStreamMidTurn(): boolean {
+    const mode = this.streamingMode;
+    if (mode === 'off') return false;
+    if (mode === 'to-device' && !this.streamPreviewTarget) return false;
+    return true;
+  }
+
   async ensureThinkingMessageSent() {
     await this.matrixResponsePublisher.ensureThinkingMessageSent();
   }
@@ -96,10 +124,52 @@ export class Responder {
   sendMessageEventWithThrottlingInternal: () => unknown = throttle(
     () => {
       this.needsMessageSend = false;
-      this.sendMessageEvent();
+      // The final consolidated event always lands as a room edit — never a
+      // to-device preview — because to-device is ephemeral and durable state
+      // must be in the room. Intermediate previews in to-device mode go over
+      // sendToDevice targeted at the originating device only.
+      if (
+        this.streamingMode === 'to-device' &&
+        this.streamPreviewTarget &&
+        !this.responseState.isStreamingFinished
+      ) {
+        this.sendToDevicePreview();
+      } else {
+        this.sendMessageEvent();
+      }
     },
     Number(process.env.AI_BOT_STREAM_THROTTLE_MS ?? 250),
   );
+
+  private sendToDevicePreview = async (): Promise<void> => {
+    if (!this.streamPreviewTarget) return;
+    const parentEventId = this.matrixResponsePublisher.originalResponseEventId;
+    if (!parentEventId) {
+      // Haven't sent the thinking placeholder yet — the client would have
+      // nothing to attach the preview to.
+      return;
+    }
+    const payload: AppBoxelResponseStreamContent = {
+      roomId: this.matrixResponsePublisher.roomId,
+      parentEventId,
+      sequence: this._streamPreviewSequence++,
+      body: this.responseState.latestContent ?? '',
+      reasoning: this.responseState.latestReasoning ?? '',
+      toolRequests: this.responseState.toolCalls ?? [],
+      isFinal: false,
+    };
+    try {
+      await this.client.sendToDevice(APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE, {
+        [this.streamPreviewTarget.userId]: {
+          [this.streamPreviewTarget.deviceId]: payload,
+        },
+      } as any);
+    } catch (e) {
+      // Preview loss is non-fatal; the final room edit still lands. Log at
+      // debug so a wedged homeserver doesn't spam sentry.
+      log.debug('to-device response-stream preview send failed', e);
+    }
+  };
 
   sendMessageEvent = async () => {
     // Only send if the delta is meaningful, unless we are finalizing.
@@ -169,7 +239,7 @@ export class Responder {
       isStreamingFinished: this.responseState.isStreamingFinished,
       responseStateChanged,
     });
-    if (responseStateChanged && this.streamingMode !== 'off') {
+    if (responseStateChanged && this.shouldStreamMidTurn) {
       await this.sendMessageEventWithThrottling();
     }
 

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -158,12 +158,20 @@ export class Responder {
       toolRequests: this.responseState.toolCalls ?? [],
       isFinal: false,
     };
+    // matrix-js-sdk's sendToDevice takes a Map<userId, Map<deviceId, content>>
+    // and iterates it internally — a plain nested object throws
+    // `TypeError: contentMap is not iterable` at runtime.
+    const contentMap = new Map([
+      [
+        this.streamPreviewTarget.userId,
+        new Map([[this.streamPreviewTarget.deviceId, payload]]),
+      ],
+    ]);
     try {
-      await this.client.sendToDevice(APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE, {
-        [this.streamPreviewTarget.userId]: {
-          [this.streamPreviewTarget.deviceId]: payload,
-        },
-      } as any);
+      await this.client.sendToDevice(
+        APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE,
+        contentMap,
+      );
     } catch (e) {
       // Preview loss is non-fatal; the final room edit still lands. Log at
       // debug so a wedged homeserver doesn't spam sentry.

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -15,7 +15,9 @@ import type { FunctionToolCall } from '@cardstack/runtime-common/helpers/ai';
 import type OpenAI from 'openai';
 import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'matrix-js-sdk';
-import MatrixResponsePublisher from './matrix/response-publisher.ts';
+import MatrixResponsePublisher, {
+  toCommandRequest,
+} from './matrix/response-publisher.ts';
 import ResponseState from './response-state.ts';
 import type { MatrixClient } from 'matrix-js-sdk';
 
@@ -155,8 +157,15 @@ export class Responder {
       sequence: this._streamPreviewSequence++,
       body: this.responseState.latestContent ?? '',
       reasoning: this.responseState.latestReasoning ?? '',
-      toolRequests: this.responseState.toolCalls ?? [],
-      isFinal: false,
+      // Normalize to the same shape the room event carries (see
+      // toCommandRequest) so a client reads toolRequests identically on both
+      // channels; arguments come through as objects, empty until the streamed
+      // JSON completes.
+      toolRequests: (this.responseState.toolCalls ?? [])
+        .filter(Boolean)
+        .map((toolCall) =>
+          toCommandRequest(toolCall as ChatCompletionMessageFunctionToolCall),
+        ),
     };
     // matrix-js-sdk's sendToDevice takes a Map<userId, Map<deviceId, content>>
     // and iterates it internally — a plain nested object throws

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -73,6 +73,14 @@ export class Responder {
     return this.matrixResponsePublisher.originalResponseEventId;
   }
 
+  private get streamingMode(): 'room-edits' | 'off' | 'to-device' {
+    const mode = process.env.AI_BOT_STREAMING_MODE;
+    if (mode === 'off' || mode === 'to-device') {
+      return mode;
+    }
+    return 'room-edits';
+  }
+
   async ensureThinkingMessageSent() {
     await this.matrixResponsePublisher.ensureThinkingMessageSent();
   }
@@ -161,7 +169,7 @@ export class Responder {
       isStreamingFinished: this.responseState.isStreamingFinished,
       responseStateChanged,
     });
-    if (responseStateChanged) {
+    if (responseStateChanged && this.streamingMode !== 'off') {
       await this.sendMessageEventWithThrottling();
     }
 

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -226,11 +226,18 @@ export class Responder {
       Boolean(call),
     );
 
+    // When we're not sending mid-turn, `finalize()` owns the
+    // `isStreamingFinished` transition — otherwise the flag would flip here,
+    // the mid-turn send would be gated off, and `finalize()` would see no
+    // transition and skip the final send too, leaving only the thinking
+    // placeholder in the room.
+    const isStreamingFinished =
+      this.shouldStreamMidTurn && chunk.choices?.[0]?.finish_reason === 'stop';
     const responseStateChanged = this.responseState.update(
       newReasoningContent,
       snapshot.choices?.[0]?.message?.content,
       toolCalls,
-      chunk.choices?.[0]?.finish_reason === 'stop',
+      isStreamingFinished,
     );
     log.debug('onChunk', {
       reasoning: this.responseState.latestReasoning,

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -469,19 +469,42 @@ Common issues are:
               : event.getContent().data;
           const agentId = contentData.context?.agentId;
           // Route to-device streaming previews (see APP_BOXEL_STREAMING_MODE
-          // handling in Responder) at the device that composed this prompt.
-          // Absent on older clients that didn't stamp the id — Responder falls
-          // back to the `off`-mode behavior in that case.
-          const originatingDeviceId = (
-            event.getContent() as Record<string, unknown>
-          )?.[APP_BOXEL_ORIGINATING_DEVICE_ID_KEY];
-          const promptSenderUserId = event.getSender();
-          const streamPreviewTarget =
-            typeof originatingDeviceId === 'string' &&
-            originatingDeviceId &&
-            promptSenderUserId
-              ? { userId: promptSenderUserId, deviceId: originatingDeviceId }
+          // handling in Responder) at the device that composed the prompt for
+          // this turn. A continuation triggered by a tool / code-patch result
+          // carries no device id, so fall back to the most recent stamped
+          // user-prompt event in the turn's history — otherwise multi-step
+          // turns would stop streaming after the first tool call even on the
+          // originating device. Absent entirely on older clients that never
+          // stamped the id — Responder falls back to the `off`-mode behavior.
+          const readDeviceTarget = (
+            content: Record<string, unknown> | undefined,
+            sender: string | undefined | null,
+          ): { userId: string; deviceId: string } | undefined => {
+            const deviceId = content?.[APP_BOXEL_ORIGINATING_DEVICE_ID_KEY];
+            return typeof deviceId === 'string' && deviceId && sender
+              ? { userId: sender, deviceId }
               : undefined;
+          };
+          let streamPreviewTarget = readDeviceTarget(
+            event.getContent() as Record<string, unknown>,
+            event.getSender(),
+          );
+          if (!streamPreviewTarget) {
+            for (let i = eventList.length - 1; i >= 0; i--) {
+              const candidate = eventList[i] as unknown as {
+                content?: Record<string, unknown>;
+                sender?: string;
+              };
+              const target = readDeviceTarget(
+                candidate.content,
+                candidate.sender,
+              );
+              if (target) {
+                streamPreviewTarget = target;
+                break;
+              }
+            }
+          }
           const responder = new Responder(
             client,
             room.roomId,

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -31,6 +31,7 @@ import {
   INITIAL_SLIDING_SYNC_LIST_TIMELINE_LIMIT,
   SLIDING_SYNC_TIMEOUT,
   APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE,
+  APP_BOXEL_ORIGINATING_DEVICE_ID_KEY,
   isToolResultEventType,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -467,7 +468,26 @@ Common issues are:
               ? JSON.parse(event.getContent().data)
               : event.getContent().data;
           const agentId = contentData.context?.agentId;
-          const responder = new Responder(client, room.roomId, agentId);
+          // Route to-device streaming previews (see APP_BOXEL_STREAMING_MODE
+          // handling in Responder) at the device that composed this prompt.
+          // Absent on older clients that didn't stamp the id — Responder falls
+          // back to the `off`-mode behavior in that case.
+          const originatingDeviceId = (
+            event.getContent() as Record<string, unknown>
+          )?.[APP_BOXEL_ORIGINATING_DEVICE_ID_KEY];
+          const promptSenderUserId = event.getSender();
+          const streamPreviewTarget =
+            typeof originatingDeviceId === 'string' &&
+            originatingDeviceId &&
+            promptSenderUserId
+              ? { userId: promptSenderUserId, deviceId: originatingDeviceId }
+              : undefined;
+          const responder = new Responder(
+            client,
+            room.roomId,
+            agentId,
+            streamPreviewTarget,
+          );
 
           if (Responder.eventWillDefinitelyTriggerResponse(event)) {
             await responder.ensureThinkingMessageSent();

--- a/packages/ai-bot/tests/helpers/fake-matrix-client.ts
+++ b/packages/ai-bot/tests/helpers/fake-matrix-client.ts
@@ -7,6 +7,7 @@ import type {
   Method,
 } from 'matrix-js-sdk';
 import { MatrixClient } from 'matrix-js-sdk';
+import { recursiveMapToObject } from 'matrix-js-sdk/lib/utils.js';
 
 export class FakeMatrixClient extends MatrixClient {
   private eventId = 0;
@@ -103,10 +104,21 @@ export class FakeMatrixClient extends MatrixClient {
 
   async sendToDevice(
     eventType: string,
-    contentMap: any,
+    contentMap: Map<string, Map<string, IContent>>,
     _txnId?: string,
   ): Promise<any> {
-    this.sentToDeviceEvents.push({ eventType, contentMap });
+    // The real matrix-js-sdk client requires a nested Map and iterates it
+    // internally (via recursiveMapToObject + `for...of`), throwing
+    // `TypeError: contentMap is not iterable` on a plain object. Enforce the
+    // same contract here so a plain-object payload fails the test the way it
+    // fails in production. Store the normalized plain object for assertions.
+    if (!(contentMap instanceof Map)) {
+      throw new TypeError('sendToDevice contentMap must be a Map');
+    }
+    this.sentToDeviceEvents.push({
+      eventType,
+      contentMap: recursiveMapToObject(contentMap),
+    });
     return {};
   }
 

--- a/packages/ai-bot/tests/helpers/fake-matrix-client.ts
+++ b/packages/ai-bot/tests/helpers/fake-matrix-client.ts
@@ -16,6 +16,10 @@ export class FakeMatrixClient extends MatrixClient {
     eventType: string;
     content: IContent;
   }[] = [];
+  private sentToDeviceEvents: {
+    eventType: string;
+    contentMap: Record<string, Record<string, IContent>>;
+  }[] = [];
 
   baseUrl = 'https://example.com';
 
@@ -97,6 +101,19 @@ export class FakeMatrixClient extends MatrixClient {
     return this.sentEvents;
   }
 
+  async sendToDevice(
+    eventType: string,
+    contentMap: any,
+    _txnId?: string,
+  ): Promise<any> {
+    this.sentToDeviceEvents.push({ eventType, contentMap });
+    return {};
+  }
+
+  getSentToDeviceEvents() {
+    return this.sentToDeviceEvents;
+  }
+
   sendStateEvent<K extends keyof StateEvents>(
     _roomId: string,
     _eventType: K,
@@ -109,6 +126,7 @@ export class FakeMatrixClient extends MatrixClient {
 
   resetSentEvents() {
     this.sentEvents = [];
+    this.sentToDeviceEvents = [];
     this.eventId = 0;
   }
 

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -11,6 +11,7 @@ import {
   APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
+  APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 import type OpenAI from 'openai';
 import { FakeMatrixClient } from './helpers/fake-matrix-client.ts';
@@ -262,6 +263,135 @@ module('Responding', (hooks) => {
       },
       'The updated content should replace the original thinking message',
     );
+  });
+
+  test('`to-device` streaming mode: streams previews to the target device and lands one final consolidated room event', async () => {
+    process.env.AI_BOT_STREAMING_MODE = 'to-device';
+    try {
+      responder = new Responder(fakeMatrixClient, 'room-id', 'abc123agentId', {
+        userId: '@alice:example.com',
+        deviceId: 'DEVICEALICE',
+      });
+
+      await responder.ensureThinkingMessageSent();
+
+      // Stream several chunks — each is a state change that should trigger a
+      // throttled to-device preview, not a room edit.
+      for (let i = 0; i < 5; i++) {
+        await responder.onChunk({} as any, snapshotWithContent('content ' + i));
+        // Advance past the throttle window so each chunk gets its own send.
+        await clock.tickAsync(300);
+      }
+
+      let roomEvents = fakeMatrixClient.getSentEvents();
+      assert.equal(
+        roomEvents.length,
+        1,
+        'Only the thinking placeholder has landed as a room event so far',
+      );
+
+      let toDeviceEvents = fakeMatrixClient.getSentToDeviceEvents();
+      assert.ok(
+        toDeviceEvents.length >= 1,
+        'At least one preview was sent over to-device',
+      );
+      assert.ok(
+        toDeviceEvents.every(
+          (e) => e.eventType === APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE,
+        ),
+        'All to-device events use the response-stream type',
+      );
+      let firstPreview =
+        toDeviceEvents[0].contentMap['@alice:example.com']?.['DEVICEALICE'];
+      assert.ok(firstPreview, 'Preview targets the originating device');
+      assert.equal(
+        (firstPreview as any).parentEventId,
+        '0',
+        'Preview attaches to the thinking placeholder event id',
+      );
+      assert.equal(
+        (firstPreview as any).roomId,
+        'room-id',
+        'Preview carries the correct roomId',
+      );
+      assert.deepEqual(
+        toDeviceEvents.map(
+          (e) =>
+            (e as any).contentMap['@alice:example.com']?.['DEVICEALICE']
+              ?.sequence,
+        ),
+        toDeviceEvents.map((_, i) => i),
+        'Sequence numbers are monotonic and start at 0',
+      );
+
+      await responder.finalize();
+
+      roomEvents = fakeMatrixClient.getSentEvents();
+      assert.equal(
+        roomEvents.length,
+        2,
+        'Placeholder plus one final consolidated room event',
+      );
+      assert.equal(
+        roomEvents[1].content.body,
+        'content 4',
+        'Final room event carries the full accumulated content',
+      );
+      assert.deepEqual(
+        roomEvents[1].content['m.relates_to'],
+        { rel_type: 'm.replace', event_id: '0' },
+        'Final room event replaces the thinking placeholder',
+      );
+      assert.deepEqual(
+        roomEvents[1].content.isStreamingFinished,
+        true,
+        'isStreamingFinished is set on the final room event',
+      );
+    } finally {
+      delete process.env.AI_BOT_STREAMING_MODE;
+    }
+  });
+
+  test('`to-device` streaming mode without a target device falls back to `off` behavior', async () => {
+    process.env.AI_BOT_STREAMING_MODE = 'to-device';
+    try {
+      // No streamPreviewTarget passed (simulates a prompt from an older client
+      // that didn't stamp the originating device id).
+      responder = new Responder(fakeMatrixClient, 'room-id', 'abc123agentId');
+
+      await responder.ensureThinkingMessageSent();
+
+      for (let i = 0; i < 5; i++) {
+        await responder.onChunk({} as any, snapshotWithContent('content ' + i));
+        await clock.tickAsync(300);
+      }
+
+      let roomEvents = fakeMatrixClient.getSentEvents();
+      assert.equal(
+        roomEvents.length,
+        1,
+        'No intermediate room events while streaming',
+      );
+      let toDeviceEvents = fakeMatrixClient.getSentToDeviceEvents();
+      assert.equal(
+        toDeviceEvents.length,
+        0,
+        'No to-device previews sent when target device is unknown',
+      );
+
+      await responder.finalize();
+
+      roomEvents = fakeMatrixClient.getSentEvents();
+      assert.equal(
+        roomEvents.length,
+        2,
+        'Final consolidated room event still lands',
+      );
+      assert.equal(roomEvents[1].content.body, 'content 4');
+      assert.deepEqual(roomEvents[1].content.isStreamingFinished, true);
+    } finally {
+      delete process.env.AI_BOT_STREAMING_MODE;
+    }
   });
 
   test('`off` streaming mode: only sends the thinking placeholder and a single final consolidated event', async () => {

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -394,6 +394,42 @@ module('Responding', (hooks) => {
     }
   });
 
+  test('`to-device` streaming mode: previews carry tool requests in the room-event wire shape', async () => {
+    process.env.AI_BOT_STREAMING_MODE = 'to-device';
+    try {
+      responder = new Responder(fakeMatrixClient, 'room-id', 'abc123agentId', {
+        userId: '@alice:example.com',
+        deviceId: 'DEVICEALICE',
+      });
+
+      await responder.ensureThinkingMessageSent();
+
+      await responder.onChunk(
+        {} as any,
+        snapshotWithToolCall({
+          id: 'tool-1',
+          name: 'searchCards',
+          arguments: { query: 'pets' },
+        }),
+      );
+      await clock.tickAsync(300);
+
+      let toDeviceEvents = fakeMatrixClient.getSentToDeviceEvents();
+      assert.ok(toDeviceEvents.length >= 1, 'A preview was sent');
+      let preview =
+        toDeviceEvents[toDeviceEvents.length - 1].contentMap[
+          '@alice:example.com'
+        ]?.['DEVICEALICE'];
+      assert.deepEqual(
+        (preview as any).toolRequests,
+        [{ id: 'tool-1', name: 'searchCards', arguments: { query: 'pets' } }],
+        'toolRequests is normalized to the room event’s { id, name, arguments: <object> } shape, not the raw OpenAI { function: { name, arguments: <string> } } shape',
+      );
+    } finally {
+      delete process.env.AI_BOT_STREAMING_MODE;
+    }
+  });
+
   test('`off` streaming mode: only sends the thinking placeholder and a single final consolidated event', async () => {
     process.env.AI_BOT_STREAMING_MODE = 'off';
     try {

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -400,7 +400,17 @@ module('Responding', (hooks) => {
       await responder.ensureThinkingMessageSent();
 
       for (let i = 0; i < 10; i++) {
-        await responder.onChunk({} as any, snapshotWithContent('content ' + i));
+        // The last chunk carries `finish_reason: 'stop'` — this pins the
+        // end-of-stream transition and would regress the bug where off mode
+        // let onChunk flip isStreamingFinished, causing finalize to skip the
+        // final consolidated send.
+        let chunk =
+          i === 9
+            ? ({
+                choices: [{ finish_reason: 'stop', index: 0, delta: {} }],
+              } as any)
+            : ({} as any);
+        await responder.onChunk(chunk, snapshotWithContent('content ' + i));
       }
 
       let sentEvents = fakeMatrixClient.getSentEvents();

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -264,6 +264,50 @@ module('Responding', (hooks) => {
     );
   });
 
+  test('`off` streaming mode: only sends the thinking placeholder and a single final consolidated event', async () => {
+    process.env.AI_BOT_STREAMING_MODE = 'off';
+    try {
+      await responder.ensureThinkingMessageSent();
+
+      for (let i = 0; i < 10; i++) {
+        await responder.onChunk({} as any, snapshotWithContent('content ' + i));
+      }
+
+      let sentEvents = fakeMatrixClient.getSentEvents();
+      assert.equal(
+        sentEvents.length,
+        1,
+        'No intermediate content events are sent while streaming in off mode',
+      );
+
+      await responder.finalize();
+
+      sentEvents = fakeMatrixClient.getSentEvents();
+      assert.equal(
+        sentEvents.length,
+        2,
+        'Only the thinking placeholder and one final consolidated event are sent',
+      );
+      assert.equal(
+        sentEvents[1].content.body,
+        'content 9',
+        'Final event carries the complete accumulated content',
+      );
+      assert.deepEqual(
+        sentEvents[1].content['m.relates_to'],
+        { rel_type: 'm.replace', event_id: '0' },
+        'Final event replaces the thinking placeholder',
+      );
+      assert.deepEqual(
+        sentEvents[1].content.isStreamingFinished,
+        true,
+        'isStreamingFinished is set on the final event',
+      );
+    } finally {
+      delete process.env.AI_BOT_STREAMING_MODE;
+    }
+  });
+
   test('Sends tool call event and replaces thinking message when tool call happens with no content', async () => {
     const patchArgs = {
       description: 'A new thing',

--- a/packages/base/matrix-event.gts
+++ b/packages/base/matrix-event.gts
@@ -20,6 +20,7 @@ import type {
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
+  APP_BOXEL_ORIGINATING_DEVICE_ID_KEY,
   APP_BOXEL_REALM_EVENT_TYPE,
   APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE,
   APP_BOXEL_REASONING_CONTENT_KEY,
@@ -250,6 +251,7 @@ export interface CardMessageContent {
   [APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY]?: boolean;
   [APP_BOXEL_CONTINUATION_OF_CONTENT_KEY]?: string; // event_id of the message we are continuing
   [APP_BOXEL_REASONING_CONTENT_KEY]?: string;
+  [APP_BOXEL_ORIGINATING_DEVICE_ID_KEY]?: string;
   [APP_BOXEL_TOOL_REQUESTS_KEY]?: Partial<EncodedToolRequest>[];
   // Replay-only: messages written before the command → tool rename carry
   // their requests under this key. Read via `getToolRequests`; never write.

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -58,6 +58,7 @@ import {
   APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
   APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
   APP_BOXEL_MESSAGE_MSGTYPE,
+  APP_BOXEL_ORIGINATING_DEVICE_ID_KEY,
   APP_BOXEL_REALM_EVENT_TYPE,
   APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE,
   APP_BOXEL_REALMS_EVENT_TYPE,
@@ -1844,11 +1845,15 @@ export default class MatrixService extends Service {
       attachedFiles,
     );
 
+    let originatingDeviceId = this.client.getDeviceId() ?? undefined;
     await this.sendEvent(roomId, 'm.room.message', {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       body: body || '',
       format: 'org.matrix.custom.html',
       clientGeneratedId,
+      ...(originatingDeviceId
+        ? { [APP_BOXEL_ORIGINATING_DEVICE_ID_KEY]: originatingDeviceId }
+        : {}),
       data: {
         attachedFiles: contentData.attachedFiles,
         attachedCards: contentData.attachedCards,

--- a/packages/matrix/package.json
+++ b/packages/matrix/package.json
@@ -15,6 +15,7 @@
     "@types/uuid": "catalog:",
     "fs-extra": "catalog:",
     "jsonwebtoken": "catalog:",
+    "matrix-js-sdk": "catalog:",
     "pg": "catalog:",
     "start-server-and-test": "catalog:",
     "tmp": "catalog:",

--- a/packages/matrix/support/matrix-constants.ts
+++ b/packages/matrix/support/matrix-constants.ts
@@ -13,6 +13,7 @@ export const APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE =
 export const APP_BOXEL_REALMS_EVENT_TYPE = 'app.boxel.realms';
 export const APP_BOXEL_REALM_SERVERS_EVENT_TYPE = 'app.boxel.realm-servers';
 export const APP_BOXEL_SYSTEM_CARD_EVENT_TYPE = 'app.boxel.system-card';
+export const APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE = 'app.boxel.response-stream';
 export const APP_BOXEL_CODE_PATCH_CORRECTNESS_MSGTYPE =
   'app.boxel.codePatchCorrectness';
 export const APP_BOXEL_CODE_PATCH_CORRECTNESS_REL_TYPE =

--- a/packages/matrix/tests/response-stream-to-device.spec.ts
+++ b/packages/matrix/tests/response-stream-to-device.spec.ts
@@ -1,0 +1,111 @@
+import { createClient } from 'matrix-js-sdk';
+
+import { expect, test } from './fixtures.ts';
+import { getMatrixTestContext } from '../helpers/index.ts';
+import { registerUser, loginUser, sync } from '../support/synapse/index.ts';
+import { getSynapseURL } from '../support/environment-config.ts';
+import { APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE } from '../support/matrix-constants.ts';
+
+// The ai-bot's Responder streams to-device previews by calling the real
+// matrix-js-sdk `sendToDevice`, which takes a Map<userId, Map<deviceId,
+// content>> and iterates it internally (recursiveMapToObject). A plain nested
+// object throws `TypeError: contentMap is not iterable` before anything reaches
+// the wire. The ai-bot unit suite can't catch this: its FakeMatrixClient never
+// exercises the real contract. This spec drives the real SDK against the
+// dockerized Synapse so a regression in the payload shape fails here.
+
+test.describe('ai-bot to-device response-stream previews', () => {
+  test('a real matrix-js-sdk sendToDevice delivers a preview to the target device, and a plain-object payload is rejected', async () => {
+    let { synapse } = getMatrixTestContext();
+
+    // The bot is the sender; the human is the recipient on a specific device —
+    // the originating device the preview is targeted at.
+    for (let username of ['stream-bot', 'stream-human']) {
+      try {
+        await registerUser(synapse, username, 'password');
+      } catch {
+        // May already exist if Synapse is reused across runs.
+      }
+    }
+    let bot = await loginUser('stream-bot', 'password');
+    let human = await loginUser('stream-human', 'password');
+
+    let botClient = createClient({
+      baseUrl: getSynapseURL(synapse),
+      accessToken: bot.accessToken,
+      userId: bot.userId,
+      deviceId: bot.deviceId,
+    });
+
+    // Exactly the payload shape the Responder builds in
+    // packages/ai-bot/lib/responder.ts (sendToDevicePreview).
+    let payload = {
+      roomId: '!fake-room:localhost',
+      parentEventId: '$fake-parent-event',
+      sequence: 0,
+      body: 'partial answer so far',
+      reasoning: 'thinking…',
+      toolRequests: [],
+      isFinal: false,
+    };
+
+    // Positive path: the real client accepts the Map contract and Synapse
+    // delivers the preview to the recipient's device.
+    let contentMap = new Map([
+      [human.userId, new Map([[human.deviceId, payload]])],
+    ]);
+    await botClient.sendToDevice(
+      APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE,
+      contentMap,
+    );
+
+    let received = await pollForToDeviceEvent(
+      human.accessToken,
+      APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE,
+    );
+    if (!received) {
+      throw new Error('recipient device never received a to-device preview');
+    }
+    expect(received.sender).toBe(bot.userId);
+    expect(received.content).toMatchObject(payload);
+
+    // Negative path: the plain nested object the buggy code passed throws the
+    // real SDK's TypeError before anything is sent — the exact production
+    // failure the unit fake could not surface.
+    let threw: unknown;
+    try {
+      await botClient.sendToDevice(APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE, {
+        [human.userId]: { [human.deviceId]: payload },
+      } as any);
+    } catch (e) {
+      threw = e;
+    }
+    expect(
+      threw,
+      'the real SDK rejects a plain-object contentMap',
+    ).toBeInstanceOf(TypeError);
+
+    botClient.stopClient();
+  });
+});
+
+// Poll the recipient's /sync for a to-device event of the given type. Repeated
+// initial syncs (no `since`) keep returning pending to-device events until the
+// device acknowledges them by syncing past their batch, so polling is stable.
+async function pollForToDeviceEvent(
+  accessToken: string,
+  type: string,
+  timeoutMs = 20_000,
+): Promise<{ type: string; sender: string; content: any } | undefined> {
+  let deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    let res = await sync(accessToken);
+    let events = res?.to_device?.events ?? [];
+    let match = events.find((e: { type: string }) => e.type === type);
+    if (match) {
+      return match;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return undefined;
+}

--- a/packages/matrix/tests/response-stream-to-device.spec.ts
+++ b/packages/matrix/tests/response-stream-to-device.spec.ts
@@ -46,7 +46,6 @@ test.describe('ai-bot to-device response-stream previews', () => {
       body: 'partial answer so far',
       reasoning: 'thinking…',
       toolRequests: [],
-      isFinal: false,
     };
 
     // Positive path: the real client accepts the Map contract and Synapse

--- a/packages/runtime-common/matrix-constants.ts
+++ b/packages/runtime-common/matrix-constants.ts
@@ -160,6 +160,13 @@ export interface AppBoxelResponseStreamContent {
   // lets the client discard preview state promptly.
   isFinal: boolean;
 }
+
+// Device id (from matrixClient.getDeviceId()) of the client that composed a
+// user-prompt event, stamped so ai-bot knows which device to target with
+// app.boxel.response-stream to-device previews for that turn.
+export const APP_BOXEL_ORIGINATING_DEVICE_ID_KEY =
+  'app.boxel.originating-device-id';
+
 export const APP_BOXEL_LLM_MODE = 'app.boxel.llm-mode';
 export const APP_BOXEL_RELOAD_BILLING_DATA_KEY = 'app.boxel.reloadBillingData';
 export type LLMMode = 'ask' | 'act';

--- a/packages/runtime-common/matrix-constants.ts
+++ b/packages/runtime-common/matrix-constants.ts
@@ -153,12 +153,11 @@ export interface AppBoxelResponseStreamContent {
   sequence: number;
   body: string;
   reasoning: string;
-  // Same wire shape as APP_BOXEL_TOOL_REQUESTS_KEY on the room event, though
-  // each request's `arguments` JSON may still be partial during streaming.
+  // Same wire shape as APP_BOXEL_TOOL_REQUESTS_KEY on the room event: ai-bot
+  // runs previews through the same normalization, so each request is
+  // `{ id, name, arguments: <object> }`. `arguments` is `{}` while the tool
+  // call's JSON is still incomplete mid-stream.
   toolRequests: unknown[];
-  // Set on the final preview immediately before ai-bot flushes the room edit;
-  // lets the client discard preview state promptly.
-  isFinal: boolean;
 }
 
 // Device id (from matrixClient.getDeviceId()) of the client that composed a

--- a/packages/runtime-common/matrix-constants.ts
+++ b/packages/runtime-common/matrix-constants.ts
@@ -135,6 +135,31 @@ export const APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY =
   'app.boxel.has-continuation';
 export const APP_BOXEL_CONTINUATION_OF_CONTENT_KEY =
   'app.boxel.continuation-of';
+
+// To-device event type carrying live streaming previews of the bot's response.
+// Emitted by ai-bot to the originating device only so the browser can render
+// the in-flight state without landing a Matrix room edit for every ~250 ms of
+// tokens; the final consolidated state still lands as a room event because
+// to-device messages are ephemeral and not persisted.
+export const APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE = 'app.boxel.response-stream';
+
+export interface AppBoxelResponseStreamContent {
+  roomId: string;
+  // Event id of the thinking placeholder this stream will eventually replace;
+  // keys the client's preview state so concurrent turns don't collide.
+  parentEventId: string;
+  // Monotonic per turn. Payload carries the full accumulated state (not
+  // deltas), so gaps or reordering are non-fatal — last-writer-wins by sequence.
+  sequence: number;
+  body: string;
+  reasoning: string;
+  // Same wire shape as APP_BOXEL_TOOL_REQUESTS_KEY on the room event, though
+  // each request's `arguments` JSON may still be partial during streaming.
+  toolRequests: unknown[];
+  // Set on the final preview immediately before ai-bot flushes the room edit;
+  // lets the client discard preview state promptly.
+  isFinal: boolean;
+}
 export const APP_BOXEL_LLM_MODE = 'app.boxel.llm-mode';
 export const APP_BOXEL_RELOAD_BILLING_DATA_KEY = 'app.boxel.reloadBillingData';
 export type LLMMode = 'ask' | 'act';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1221,7 +1221,7 @@ importers:
         version: 5.5.6(@types/eslint@8.56.5)(eslint-config-prettier@9.1.2(eslint@8.57.1))(eslint@8.57.1)(prettier@3.8.4)
       http-server:
         specifier: ^14.1.1
-        version: 14.1.1
+        version: 14.1.1(debug@4.3.4)
       lucide-static:
         specifier: ^0.447.0
         version: 0.447.0
@@ -2471,6 +2471,9 @@ importers:
       jsonwebtoken:
         specifier: 'catalog:'
         version: 9.0.3
+      matrix-js-sdk:
+        specifier: 'catalog:'
+        version: 38.3.0(patch_hash=cee0baf579283943dc5a6b48977e8ed40a13fc111b5de9c91814893f9a4989fb)
       pg:
         specifier: 'catalog:'
         version: 8.21.0
@@ -2732,7 +2735,7 @@ importers:
         version: 11.1.0
       http-server:
         specifier: 'catalog:'
-        version: 14.1.1
+        version: 14.1.1(debug@4.3.4)
       js-yaml:
         specifier: 'catalog:'
         version: 4.2.0
@@ -2825,7 +2828,7 @@ importers:
         version: 3.2.0
       wait-on:
         specifier: ^9.0.4
-        version: 9.0.10
+        version: 9.0.10(debug@4.3.4)
       wtfnode:
         specifier: ^0.10.1
         version: 0.10.1
@@ -20603,7 +20606,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.18.0:
+  axios@1.18.0(debug@4.3.4):
     dependencies:
       follow-redirects: 1.16.0(debug@4.3.4)
       form-data: 4.0.6
@@ -22875,7 +22878,7 @@ snapshots:
       heimdalljs-fs-monitor: 1.1.2
       heimdalljs-graph: 1.0.0
       heimdalljs-logger: 0.1.10
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.3.4)
       inflection: 2.0.1
       inquirer: 9.3.8(@types/node@24.13.2)
       is-git-url: 1.0.0
@@ -23017,7 +23020,7 @@ snapshots:
       heimdalljs-fs-monitor: 1.1.2
       heimdalljs-graph: 1.0.0
       heimdalljs-logger: 0.1.10
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.3.4)
       inflection: 3.0.2
       inquirer: 13.4.3(@types/node@25.9.3)
       is-git-url: 1.0.0
@@ -25378,7 +25381,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy@1.18.1:
+  http-proxy@1.18.1(debug@4.3.4):
     dependencies:
       eventemitter3: 4.0.7
       follow-redirects: 1.16.0(debug@4.3.4)
@@ -25386,14 +25389,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-server@14.1.1:
+  http-server@14.1.1(debug@4.3.4):
     dependencies:
       basic-auth: 2.0.1
       chalk: 4.1.2
       corser: 2.0.1
       he: 1.2.0
       html-encoding-sniffer: 3.0.0
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.3.4)
       mime: 1.6.0
       minimist: 1.2.8
       opener: 1.5.2
@@ -26149,7 +26152,7 @@ snapshots:
 
   koa-proxies@0.12.4(koa@2.16.4):
     dependencies:
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.3.4)
       koa: 2.16.4
       path-match: 1.2.4
       uuid: 8.3.2
@@ -29211,7 +29214,7 @@ snapshots:
       execa: 9.6.1
       express: 5.2.1
       glob: 13.0.6
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.3.4)
       js-yaml: 4.2.0
       lodash: 4.18.1
       minimatch: 10.2.5
@@ -30011,9 +30014,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  wait-on@9.0.10:
+  wait-on@9.0.10(debug@4.3.4):
     dependencies:
-      axios: 1.18.0
+      axios: 1.18.0(debug@4.3.4)
       joi: 18.2.1
       lodash: 4.18.1
       minimist: 1.2.8


### PR DESCRIPTION
## Summary

- **CS-12261** — adds `APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE = 'app.boxel.response-stream'` and the `AppBoxelResponseStreamContent` interface (fields: `roomId`, `parentEventId`, `sequence`, `body`, `reasoning`, `toolRequests`) to `packages/runtime-common/matrix-constants.ts`.
- **CS-12262** — adds `APP_BOXEL_ORIGINATING_DEVICE_ID_KEY` and stamps the sending device id onto every boxel user-prompt event (`sendMessage` in `packages/host/app/services/matrix-service.ts`). Also adds the optional key to the `CardMessageContent` interface in `packages/base/matrix-event.gts`.
- **CS-12263** — implements `AI_BOT_STREAMING_MODE=to-device` in the ai-bot's `Responder`: throttled state changes route to `matrixClient.sendToDevice()` targeted at the (userId, deviceId) that composed the prompt, carrying an `app.boxel.response-stream` payload. The **final** consolidated event still lands as a room edit (routed via `flush` → `sendMessageEvent`, not the throttled internal) so durable state is always in the room — to-device previews are ephemeral by design.
- Also merged in **CS-12260** (`off` mode) as a base commit, since CS-12263 sits on top of the `streamingMode` gate that CS-12260 introduced. #5556 remains open with the standalone CS-12260 patch; whichever of the two lands first, the other's diff auto-shrinks.

Together this is the full ai-bot side of the [Improve Synapse Performance by Killing Streaming](https://linear.app/cardstack/project/improve-synapse-performance-by-killing-streaming-1d7d8ac245b1) project's to-device path. The host receiver ([CS-12264](https://linear.app/cardstack/issue/CS-12264)) is the last remaining wire — until it lands, running with `AI_BOT_STREAMING_MODE=to-device` produces to-device previews the browser doesn't yet consume, and the UX falls back to "thinking → complete response arrives at once", identical to `off` mode.

## Design notes

- **Final always lands as a room event.** The throttled internal checks `responseState.isStreamingFinished` and routes to `sendMessageEvent` (room edit) whenever true, regardless of mode. `flush` in `finalize` uses `sendMessageEvent` directly. So the leading-edge case where the throttled internal fires during `finalize` still produces a room edit, not a to-device preview.
- **Older-client fallback.** When mode is `to-device` but the prompt lacks the originating device id (older client without CS-12262), the responder falls back to `off` behavior — no mid-stream sends, one final room edit. Deployment can enable `to-device` mode without waiting for every user's session to refresh.
- **Preview payload shape.** Full accumulated body / reasoning / toolRequests, with a monotonic per-turn `sequence` for last-writer-wins reconciliation on the client. Not deltas — gaps and reordering are tolerated by design.
- **Encryption.** to-device previews use the plaintext `client.sendToDevice()` path today. Acceptable for Cardstack's own Synapse (the operator can see the traffic either way) and for previews that will also land in the room as the final. For federated deployments or a stronger threat model, swap to `client.encryptAndSendToDevice()` as follow-up.
- **`toolRequests` shape.** Previews run `toolCalls` through the same `toCommandRequest()` the room event uses, so both channels carry `{ id, name, arguments: <object> }`; `arguments` is `{}` until the streamed JSON completes. Typed `unknown[]` on the shared interface (the receiver, CS-12264, validates at the boundary), but the runtime shape now matches the room event.
- **No `isFinal` field.** The final state always lands as a room edit, never a to-device preview, so an `isFinal` preview flag would never be set — the room edit replacing the thinking placeholder is already the terminal signal. Dropped from the schema; reintroduce if the receiver ever needs an explicit "discard preview state now" signal.
- **Multi-step turns keep streaming.** The originating device id is taken from the triggering event, or — when a continuation is triggered by a tool / code-patch result that carries none — from the most recent stamped user-prompt event in the turn's history. So a turn that continues after a tool call still previews to the device that started it, rather than dropping to `off` behavior.
- **`sendToDevice` takes a `Map`, not a plain object.** matrix-js-sdk's `sendToDevice(eventType, contentMap)` requires `Map<userId, Map<deviceId, content>>` and iterates it internally (`recursiveMapToObject`); a plain nested object throws `TypeError: contentMap is not iterable` before anything reaches the wire — swallowed by the preview send's `try/catch`, so previews would have failed silently. The Responder builds the real `Map`. `FakeMatrixClient.sendToDevice` now rejects a non-`Map` argument so a regression fails the unit suite the way it fails in production.

## Test plan

- [x] Ai-bot: 22 `Responding` tests pass, including two new ones — `\`to-device\` streaming mode: streams previews to the target device and lands one final consolidated room event`, and `\`to-device\` streaming mode without a target device falls back to \`off\` behavior`. The CS-12260 `off` mode test also still passes.
- [x] All 5 `Responder Cancellation` tests pass — `finalize({isCanceled:true})` still routes the final send to the room-edit path.
- [x] Typecheck: no errors touching any of the modified files (the `../base/...` / `@cardstack/boxel-ui/*` errors are the pre-existing local-dist issue).
- [x] Verified the `FakeMatrixClient` `Map` guard bites: temporarily reverting the Responder to the plain-object payload flips the `to-device` streaming unit test to failing (`not ok`), because the swallowed `TypeError` leaves no preview sent. Restored, back to green.
- [ ] Matrix e2e (`packages/matrix/tests/response-stream-to-device.spec.ts`): drives a real matrix-js-sdk client against the dockerized Synapse — delivers a `response-stream` preview to the target device and asserts the real SDK rejects a plain-object `contentMap`. Typechecks + lints locally; first real run to be watched in CI (needs the full Synapse + realm-server stack, not run locally).
- [ ] Staging: set `AI_BOT_STREAMING_MODE=to-device` on the ai-bot task after CS-12264 lands. Verify (a) the browser renders the streaming preview, (b) only 2 room events land per turn, (c) other devices in the same account see the final response but no live preview.

## Commits

- `f85e59c65e` — CS-12261: `app.boxel.response-stream` schema
- `7dd96110a8` — CS-12262: stamp originating device id on prompts
- `91eb30c3de` — merge CS-12260 (`off` mode) as base
- `0ff3c38c15` — CS-12263: `to-device` streaming mode
- `c5ad13b90b` — fix: send previews as a `Map`; harden the fake + add a real-SDK matrix e2e boundary test
- `16619683b9` — review findings: normalize preview `toolRequests` via `toCommandRequest`; drop `isFinal`; thread the originating device id through multi-step turns
