### PR TITLE
Capture host test-timeout diagnostics at the moment QUnit gives up

### DIFF
--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -1,6 +1,7 @@
 import { registerDestructor } from '@ember/destroyable';
 import { getOwner } from '@ember/owner';
 import { service } from '@ember/service';
+import { isTesting } from '@embroider/macros';
 import { tracked, cached } from '@glimmer/tracking';
 
 import { restartableTask, timeout } from 'ember-concurrency';
@@ -153,7 +154,34 @@ export class RoomResource extends Resource<Args> {
 
   processingLastStartedAt = 0;
 
+  // `modify` restarts `processRoomTask` on every timeline/room-state
+  // invalidation. A restart storm — processing whose own effects re-invalidate
+  // the deps thunk — keeps the runloop occupied so `settled()` never resolves,
+  // hanging any awaited test helper with no console output at all. Track the
+  // restart rate (testing only) so a silent test hang can be attributed to (or
+  // cleared of) a processing loop from CI output alone.
+  private processingRestartWindowStartedAt = 0;
+  private processingRestartsInWindow = 0;
+
+  private notePerformForRestartTrace(roomId: string) {
+    if (!isTesting()) {
+      return;
+    }
+    let now = Date.now();
+    if (now - this.processingRestartWindowStartedAt > 1_000) {
+      if (this.processingRestartsInWindow > 20) {
+        console.log(
+          `[room-processing-trace] processRoomTask restarted ${this.processingRestartsInWindow} times in the last second for room ${roomId}`,
+        );
+      }
+      this.processingRestartWindowStartedAt = now;
+      this.processingRestartsInWindow = 0;
+    }
+    this.processingRestartsInWindow++;
+  }
+
   private processRoomTask = restartableTask(async (roomId: string) => {
+    this.notePerformForRestartTrace(roomId);
     this.processingLastStartedAt = Date.now();
     try {
       this.matrixRoom = roomId

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -161,9 +161,16 @@ function installTimeoutDiagnosticsOnce() {
       ) {
         return;
       }
-      let label = `${details.module ?? '<unknown module>'} > ${
-        details.name ?? '<unknown test>'
-      }`;
+      // Fall back to the testStart-maintained label when the log payload
+      // carries neither module nor name — otherwise two different tests
+      // whose payloads both lack metadata would collapse into one label and
+      // the second test's full dump would be suppressed as a repeat.
+      let label =
+        details.module || details.name
+          ? `${details.module ?? '<unknown module>'} > ${
+              details.name ?? '<unknown test>'
+            }`
+          : currentTestLabel;
       if (lastTimeoutMomentTestLabel === label) {
         console.error(
           [

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @cardstack/host/wrapped-setup-helpers-only */
 // This is the one place we allow these to be used directly.
 
+import { _backburner } from '@ember/runloop';
+
 import { getContext, getSettledState, settled } from '@ember/test-helpers';
 
 import { getPendingWaiterState } from '@ember/test-waiters';
@@ -138,6 +140,47 @@ function installTimeoutDiagnosticsOnce() {
       }`;
     });
   }
+  // QUnit pushes the "Test took longer than Nms; test timed out." failure
+  // synchronously from its timeout handler, while the hung app is still
+  // mounted and the test owner still exists. That instant — not testDone — is
+  // when the evidence is intact: teardown hooks run in between and reset
+  // services, re-render the login screen, and re-arm queues, so the
+  // testDone-time dump below reports the post-teardown world (all settled,
+  // teardown-era DOM) instead of what was actually stuck. Capture a full dump
+  // at the moment of the first timeout; later timeouts of the same test (a
+  // hung afterEach/teardown `settled()` re-arms QUnit's timer, so one test can
+  // time out repeatedly) get a compact dump naming what teardown is stuck on.
+  if (typeof qunitGlobal.log === 'function') {
+    let lastTimeoutMomentTestLabel: string | undefined;
+    qunitGlobal.log((details: QUnitLogDetails) => {
+      if (
+        !details ||
+        details.result !== false ||
+        typeof details.message !== 'string' ||
+        !details.message.includes('test timed out')
+      ) {
+        return;
+      }
+      let label = `${details.module ?? '<unknown module>'} > ${
+        details.name ?? '<unknown test>'
+      }`;
+      if (lastTimeoutMomentTestLabel === label) {
+        console.error(
+          [
+            '[test-timeout-moment+] same test timed out again (teardown also hung)',
+            summarizeSettledState(),
+            summarizePendingRunloopTimers(),
+          ].join('\n'),
+        );
+        return;
+      }
+      lastTimeoutMomentTestLabel = label;
+      logRejectionDiagnostics(
+        '[test-timeout-moment]',
+        `test "${label}" hit QUnit's timeout; state captured at the moment of timeout, before teardown hooks ran`,
+      );
+    });
+  }
   qunitGlobal.testDone((details: QUnitTestDoneDetails) => {
     if (
       details &&
@@ -171,10 +214,18 @@ interface QUnitTestStartDetails {
   module?: string;
 }
 
+interface QUnitLogDetails {
+  result?: boolean;
+  message?: string;
+  name?: string;
+  module?: string;
+}
+
 function getQUnitWithCallbacks():
   | {
       testDone?: (cb: (details: QUnitTestDoneDetails) => void) => void;
       testStart?: (cb: (details: QUnitTestStartDetails) => void) => void;
+      log?: (cb: (details: QUnitLogDetails) => void) => void;
     }
   | undefined {
   let q = (globalThis as { QUnit?: unknown }).QUnit;
@@ -182,6 +233,7 @@ function getQUnitWithCallbacks():
     ? (q as {
         testDone?: (cb: (details: QUnitTestDoneDetails) => void) => void;
         testStart?: (cb: (details: QUnitTestStartDetails) => void) => void;
+        log?: (cb: (details: QUnitLogDetails) => void) => void;
       })
     : undefined;
 }
@@ -374,6 +426,7 @@ function logRejectionDiagnostics(prefix: string, formattedReason: string) {
         ? `recent failed fetches this test (${recent.length}):\n  ${recent.join('\n  ')}`
         : 'recent failed fetches this test: <none>',
       summarizeSettledState(),
+      summarizePendingRunloopTimers(),
       summarizeRealmAuth(),
       summarizeLoginReadiness(),
       summarizeEventLoopLag(),
@@ -605,6 +658,51 @@ function summarizeRealmAuth(): string {
       : 'realm auth: <no realm resources>';
   } catch (error) {
     return `realm auth: <unavailable: ${formatErrorForLog(error)}>`;
+  }
+}
+
+// `hasPendingTimers=true` alone can't say WHICH `later`/`debounce` is keeping
+// `settled()` from resolving — and a continuously re-armed debounce blocks a
+// test forever with no console output at all. Name each pending runloop timer
+// (its target class and method) so a silent settled() hang points at the code
+// that scheduled it. Reads backburner's private `_timers` flat array (stride
+// 6: executeAt, id, target, method, args, stack — see backburner.js); fully
+// defensive since the layout is an implementation detail.
+function summarizePendingRunloopTimers(): string {
+  try {
+    let bb = _backburner as unknown as {
+      _timers?: unknown[];
+      _autorun?: unknown;
+    };
+    let timers = bb._timers ?? [];
+    if (timers.length === 0) {
+      return `pending runloop timers: <none>${bb._autorun ? ' (autorun pending)' : ''}`;
+    }
+    let now = Date.now();
+    let lines: string[] = [];
+    const STRIDE = 6;
+    const LIMIT = 10;
+    for (let i = 0; i < timers.length && lines.length < LIMIT; i += STRIDE) {
+      let executeAt = timers[i];
+      let target = timers[i + 2];
+      let method = timers[i + 3];
+      let methodName =
+        typeof method === 'function'
+          ? method.name || '<anonymous fn>'
+          : String(method);
+      let targetName =
+        target === null || target === undefined
+          ? '<no target>'
+          : ((target as object).constructor?.name ?? typeof target);
+      let due =
+        typeof executeAt === 'number' ? `${executeAt - now}ms` : '<unknown>';
+      lines.push(`${targetName}#${methodName} (due in ${due})`);
+    }
+    let count = Math.floor(timers.length / STRIDE);
+    let suffix = count > LIMIT ? `\n  … +${count - LIMIT} more` : '';
+    return `pending runloop timers (${count}):\n  ${lines.join('\n  ')}${suffix}`;
+  } catch (error) {
+    return `pending runloop timers: <unavailable: ${formatErrorForLog(error)}>`;
   }
 }
 


### PR DESCRIPTION
When a host acceptance test times out silently — a `settled()` or `waitFor` that never resolves, with no rejection and no console output — the diagnostic dump that fires at `QUnit.testDone` is too late to see anything. QUnit's timeout recovery runs the `afterEach` hooks first, and those reset the matrix service, re-render the app to the login screen, re-boot the session, and re-arm processing queues. By the time the dump executes, it faithfully reports a fully-settled state and a teardown-era DOM snapshot: every field reads clean for a test that just spent 60+ seconds wedged. The code-patches LLM-mode acceptance test flaked in CI in exactly this shape — a 182s runtime (the test body plus two teardown `settled()` waits, each burning a fresh 60s QUnit timer), an all-quiet settled state, an interact-submode DOM snapshot from mid-teardown, and no line of output naming what was stuck.

This teaches the timeout diagnostics to capture evidence while it still exists:

- **A dump at the moment of timeout.** QUnit pushes the "test timed out" failure synchronously from its timeout handler, while the hung app is still mounted and the test owner is still alive. A `QUnit.log` hook now fires the full diagnostic set (`[test-timeout-moment]`) right there — in-flight fetches, settled state with pending waiter names and begin-async origins, realm auth, login readiness, and a DOM snapshot of what the test was actually looking at. Repeat timeouts of the same test (a hung teardown `settled()` re-arms QUnit's timer, so one test can time out several times) log a compact `[test-timeout-moment+]` dump showing what teardown is stuck on. The `testDone` dump stays, since it adds the total runtime and catches failures the log hook can't.

- **Pending runloop timers, by name.** `getSettledState().hasPendingTimers` is a boolean, so a hang caused by a `later`/`debounce` that keeps re-arming is indistinguishable from any other quiet hang. Every dump now lists each pending backburner timer as `TargetClass#method (due in Nms)`, so a permanently re-armed debounce or a stuck poll names the code that scheduled it.

- **Room-processing restart rate.** `RoomResource.modify` restarts `processRoomTask` on every timeline/room-state invalidation. If processing's own effects re-invalidate the resource's deps thunk, the restart storm keeps the runloop occupied and `settled()` never resolves — silently. A testing-only trace logs when the task restarts more than 20 times within a second, so the next silent hang either names this loop or rules it out.

This is diagnostics-only: no behavior change outside test builds, and no attempt to patch over the flake with a retry or a longer timeout. The failure is not yet reproducible on demand, and the current CI output does not contain enough signal to pin the stuck gate; the next occurrence will print it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
