### PR TITLE
PosterBoard step 2: render cards at grid positions

### DIFF
--- a/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
+++ b/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
@@ -34,32 +34,27 @@
       },
       "cards.3": {
         "links": {
-          "self": "@cardstack/base/Theme/boxel-brand-guide"
+          "self": "../../llm-model-environment/Model/bd5a43c0-0681-476d-af80-be4ad46d908c"
         }
       },
       "cards.4": {
         "links": {
-          "self": "@cardstack/base/Theme/cardstack-brand-guide"
+          "self": "../../Country/argentina"
         }
       },
       "cards.5": {
         "links": {
-          "self": "../../llm-model-environment/Model/bd5a43c0-0681-476d-af80-be4ad46d908c"
+          "self": "../../llm-model-environment/Environment/3f6cde92-99b2-4bb5-a471-20d907cb682b"
         }
       },
       "cards.6": {
         "links": {
-          "self": "../../Country/argentina"
+          "self": "../../carving-turn-entry"
         }
       },
       "cards.7": {
         "links": {
-          "self": "../../llm-model-environment/Environment/3f6cde92-99b2-4bb5-a471-20d907cb682b"
-        }
-      },
-      "cards.8": {
-        "links": {
-          "self": "../../carving-turn-entry"
+          "self": "../../DetailedStyleReference/8af54c49-13b5-4bd4-9b2d-95dd569c1f44"
         }
       }
     }

--- a/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
+++ b/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
@@ -31,6 +31,36 @@
         "links": {
           "self": "../../Contact/a01fc5c9-d70d-4b9c-aae4-384cf2b79b25"
         }
+      },
+      "cards.3": {
+        "links": {
+          "self": "@cardstack/base/Theme/boxel-brand-guide"
+        }
+      },
+      "cards.4": {
+        "links": {
+          "self": "@cardstack/base/Theme/cardstack-brand-guide"
+        }
+      },
+      "cards.5": {
+        "links": {
+          "self": "../../llm-model-environment/Model/bd5a43c0-0681-476d-af80-be4ad46d908c"
+        }
+      },
+      "cards.6": {
+        "links": {
+          "self": "../../Country/argentina"
+        }
+      },
+      "cards.7": {
+        "links": {
+          "self": "../../llm-model-environment/Environment/3f6cde92-99b2-4bb5-a471-20d907cb682b"
+        }
+      },
+      "cards.8": {
+        "links": {
+          "self": "../../carving-turn-entry"
+        }
       }
     }
   }

--- a/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
+++ b/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
@@ -3,13 +3,34 @@
     "type": "card",
     "attributes": {
       "cardInfo": {
-        "name": "Demo Poster Board"
-      }
+        "name": "Demo Poster Board",
+        "summary": null,
+        "cardThumbnailURL": null,
+        "notes": null
+      },
+      "frameSettings": []
     },
     "meta": {
       "adoptsFrom": {
         "module": "../poster-board",
         "name": "PosterBoard"
+      }
+    },
+    "relationships": {
+      "cards.0": {
+        "links": {
+          "self": "../../Author/jane-doe"
+        }
+      },
+      "cards.1": {
+        "links": {
+          "self": "../../Author/0b9c06fd-3833-4947-a0b8-ac24b8e71ee7"
+        }
+      },
+      "cards.2": {
+        "links": {
+          "self": "../../Contact/a01fc5c9-d70d-4b9c-aae4-384cf2b79b25"
+        }
       }
     }
   }

--- a/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
+++ b/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
@@ -48,6 +48,30 @@
         {
           "x": null,
           "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
         }
       ]
     },
@@ -100,12 +124,42 @@
       },
       "tiles.8.card": {
         "links": {
-          "self": "../../Chess/c09f9bb3-df3f-4337-a6bd-cc4c96a5caa3"
+          "self": "@cardstack/base/Theme/boxel-brand-guide"
         }
       },
       "tiles.9.card": {
         "links": {
-          "self": "../../index"
+          "self": "@cardstack/catalog/4b6602-wine-cellar-card-definition/WineBottle/011f0239-9a66-405f-a874-32bb4146ee7b"
+        }
+      },
+      "tiles.10.card": {
+        "links": {
+          "self": "@cardstack/base/cards/brand-guide"
+        }
+      },
+      "tiles.11.card": {
+        "links": {
+          "self": "@cardstack/catalog/Theme/cardstack-brand-guide"
+        }
+      },
+      "tiles.12.card": {
+        "links": {
+          "self": "@cardstack/skills/index"
+        }
+      },
+      "tiles.13.card": {
+        "links": {
+          "self": "@cardstack/catalog/c7eda3-travel-itinerary-planner/TravelItinerary/7e50c44f-7124-4347-b48d-b2433896fb6e"
+        }
+      },
+      "tiles.14.card": {
+        "links": {
+          "self": "../../GardenItem/c73d38e9-bd83-4089-9667-0b29dbc37008"
+        }
+      },
+      "tiles.15.card": {
+        "links": {
+          "self": "@cardstack/catalog/4b6602-wine-cellar-card-definition/WineBottle/a227be75-3301-4f02-b99a-66e05fe87432"
         }
       }
     }

--- a/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
+++ b/packages/experiments-realm/poster-board/PosterBoard/demo-poster-board.json
@@ -8,7 +8,48 @@
         "cardThumbnailURL": null,
         "notes": null
       },
-      "frameSettings": []
+      "tiles": [
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        },
+        {
+          "x": null,
+          "y": null
+        }
+      ]
     },
     "meta": {
       "adoptsFrom": {
@@ -17,44 +58,54 @@
       }
     },
     "relationships": {
-      "cards.0": {
+      "tiles.0.card": {
         "links": {
           "self": "../../Author/jane-doe"
         }
       },
-      "cards.1": {
+      "tiles.1.card": {
         "links": {
           "self": "../../Author/0b9c06fd-3833-4947-a0b8-ac24b8e71ee7"
         }
       },
-      "cards.2": {
+      "tiles.2.card": {
         "links": {
           "self": "../../Contact/a01fc5c9-d70d-4b9c-aae4-384cf2b79b25"
         }
       },
-      "cards.3": {
+      "tiles.3.card": {
         "links": {
           "self": "../../llm-model-environment/Model/bd5a43c0-0681-476d-af80-be4ad46d908c"
         }
       },
-      "cards.4": {
+      "tiles.4.card": {
         "links": {
           "self": "../../Country/argentina"
         }
       },
-      "cards.5": {
+      "tiles.5.card": {
         "links": {
           "self": "../../llm-model-environment/Environment/3f6cde92-99b2-4bb5-a471-20d907cb682b"
         }
       },
-      "cards.6": {
+      "tiles.6.card": {
         "links": {
           "self": "../../carving-turn-entry"
         }
       },
-      "cards.7": {
+      "tiles.7.card": {
         "links": {
           "self": "../../DetailedStyleReference/8af54c49-13b5-4bd4-9b2d-95dd569c1f44"
+        }
+      },
+      "tiles.8.card": {
+        "links": {
+          "self": "../../Chess/c09f9bb3-df3f-4337-a6bd-cc4c96a5caa3"
+        }
+      },
+      "tiles.9.card": {
+        "links": {
+          "self": "../../index"
         }
       }
     }

--- a/packages/experiments-realm/poster-board/poster-board.gts
+++ b/packages/experiments-realm/poster-board/poster-board.gts
@@ -46,14 +46,13 @@ interface TilePlacement {
   y: number;
 }
 
-// Cards without a persisted frame setting flow into a fixed grid.
-function defaultPlacement(index: number): TilePlacement {
+// Cards without a persisted position flow into a fixed grid, `slot` being
+// their ordinal among the board's placed tiles.
+function gridSlot(slot: number): Pick<TilePlacement, 'x' | 'y'> {
   return {
-    index,
-    x: GRID_PADDING + (index % GRID_COLUMNS) * (TILE_WIDTH + TILE_GAP),
+    x: GRID_PADDING + (slot % GRID_COLUMNS) * (TILE_WIDTH + TILE_GAP),
     y:
-      GRID_PADDING +
-      Math.floor(index / GRID_COLUMNS) * (TILE_HEIGHT + TILE_GAP),
+      GRID_PADDING + Math.floor(slot / GRID_COLUMNS) * (TILE_HEIGHT + TILE_GAP),
   };
 }
 
@@ -181,15 +180,25 @@ class Isolated extends Component<typeof PosterBoard> {
     });
   }
 
+  // A tile whose link was cleared renders nothing, so it holds no grid slot
+  // either: unpositioned tiles flow into the grid in linked order, and clearing
+  // a link reflows them the same way removing the tile does.
   get tilePlacements(): TilePlacement[] {
-    return this.tiles.map((tile, index) => {
+    let refs = this.linkedRefs;
+    let placements: TilePlacement[] = [];
+    this.tiles.forEach((tile, index) => {
+      if (refs[index] === undefined) {
+        return;
+      }
       let x = coordinate(tile.x);
       let y = coordinate(tile.y);
-      if (x !== undefined && y !== undefined) {
-        return { index, x, y };
-      }
-      return defaultPlacement(index);
+      placements.push(
+        x !== undefined && y !== undefined
+          ? { index, x, y }
+          : { index, ...gridSlot(placements.length) },
+      );
     });
+    return placements;
   }
 
   get hasCards() {

--- a/packages/experiments-realm/poster-board/poster-board.gts
+++ b/packages/experiments-realm/poster-board/poster-board.gts
@@ -83,7 +83,6 @@ class Isolated extends Component<typeof PosterBoard> {
   private panSession: PanSession | null = null;
   private activePointerId: number | null = null;
   private rootElement: HTMLElement | null = null;
-  private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
 
   get zoomLabel() {
     return Math.round(this.rig.magnify * 100) + '%';
@@ -313,15 +312,9 @@ class Isolated extends Component<typeof PosterBoard> {
 
   handleInserted = (el: HTMLElement) => {
     this.rootElement = el;
-    this.keydownHandler = this.handleKeyDown;
-    window.addEventListener('keydown', this.keydownHandler);
   };
 
   willDestroy(): void {
-    if (this.keydownHandler) {
-      window.removeEventListener('keydown', this.keydownHandler);
-      this.keydownHandler = null;
-    }
     this.surfaceRig.destroy();
     super.willDestroy();
   }

--- a/packages/experiments-realm/poster-board/poster-board.gts
+++ b/packages/experiments-realm/poster-board/poster-board.gts
@@ -6,7 +6,8 @@ import {
   contains,
   containsMany,
   getRelationshipMembershipState,
-  linksToMany,
+  linksTo,
+  resolveRef,
 } from '@cardstack/base/card-api';
 import NumberField from '@cardstack/base/number';
 import { tracked } from '@glimmer/tracking';
@@ -54,12 +55,34 @@ function defaultPlacement(index: number): TilePlacement {
   };
 }
 
-export class FrameSettingsField extends FieldDef {
-  static displayName = 'Frame Settings';
+// A persisted coordinate, or undefined when the tile has never been placed.
+// Unset number fields serialize as null, and Number(null) is 0 — so null and
+// non-numeric values from hand-edited JSON both count as "not placed".
+function coordinate(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') {
+    return undefined;
+  }
+  let n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
 
-  @field cardIndex = contains(NumberField);
+// One tile on the board: the card it shows and where it sits. Keeping the
+// link and its position on the same element means a position can never drift
+// from its card when tiles are added, removed, or reordered.
+export class BoardTile extends FieldDef {
+  static displayName = 'Board Tile';
+
+  @field card = linksTo(() => CardDef);
   @field x = contains(NumberField);
   @field y = contains(NumberField);
+}
+
+// A tile's link state, read from the relationship membership state — a pure
+// read that never triggers the lazy link load, so the board renders tiles
+// without ever fetching the linked instances.
+function tileLinkState(tile: BoardTile) {
+  return getRelationshipMembershipState(tile as unknown as CardDef, 'card')
+    .membership?.[0];
 }
 
 interface OnInsertSignature {
@@ -101,27 +124,27 @@ class Isolated extends Component<typeof PosterBoard> {
 
   // ── Tile placement ─────────────────────────────────────
 
-  // The linked cards' reference URLs, read from the relationship membership
-  // state — a pure read that never triggers the lazy link load, so the board
-  // renders tiles without ever fetching the linked instances. Index-aligned
-  // with the cards slots; only a `not-set` slot lacks a reference.
-  get linkedRefs(): (string | undefined)[] {
+  get tiles(): BoardTile[] {
     let owner = this.args.model as unknown as PosterBoard | undefined;
-    if (!owner) {
-      return [];
-    }
-    let { membership } = getRelationshipMembershipState(owner, 'cards');
-    return (membership ?? []).map((slot) => slot.reference);
+    return owner?.tiles ?? [];
+  }
+
+  // The tiles' card reference URLs, index-aligned with `tiles`; only a
+  // `not-set` link lacks a reference. Relative wire references are resolved
+  // against the board's URL so they address the index like absolute ones.
+  get linkedRefs(): (string | undefined)[] {
+    let relativeTo = this.args.model?.id;
+    return this.tiles.map((tile) => {
+      let ref = tileLinkState(tile)?.reference;
+      return ref === undefined ? undefined : resolveRef(ref, relativeTo);
+    });
   }
 
   get tilePlacements(): TilePlacement[] {
-    let settings = this.args.model?.frameSettings ?? [];
-    return this.linkedRefs.map((_ref, index) => {
-      let setting = settings.find((s) => Number(s.cardIndex) === index);
-      // Number() guards against non-numeric values in hand-edited JSON
-      let x = Number(setting?.x);
-      let y = Number(setting?.y);
-      if (setting && Number.isFinite(x) && Number.isFinite(y)) {
+    return this.tiles.map((tile, index) => {
+      let x = coordinate(tile.x);
+      let y = coordinate(tile.y);
+      if (x !== undefined && y !== undefined) {
         return { index, x, y };
       }
       return defaultPlacement(index);
@@ -136,7 +159,7 @@ class Isolated extends Component<typeof PosterBoard> {
   // URLs. `fitted` is bound through `htmlQuery` — a bare `eq.format` would be
   // read as an `item.` field path and rejected. Instance index rows key on
   // the `.json` file URL, and `scope: 'cards'` drops each card's dual-indexed
-  // file row. Undefined (no linked cards) leaves the search idle.
+  // file row. Undefined (no tiles with a card) leaves the search idle.
   get tilesQuery(): SearchEntryWireQuery | undefined {
     let refs = this.linkedRefs.filter(
       (ref): ref is string => ref !== undefined,
@@ -162,23 +185,19 @@ class Isolated extends Component<typeof PosterBoard> {
   };
 
   // Empty string (a `not-set` slot) is falsy, so the template's `{{#if ref}}`
-  // guard skips the placeholder for slots with nothing to point at — glint
+  // guard skips the placeholder for tiles with nothing to point at — glint
   // doesn't narrow in templates, so the fallback keeps the type `string`.
   refAt = (index: number): string => this.linkedRefs[index] ?? '';
 
-  // Terminal failures (error / not-found) per cards slot, index-aligned with
+  // Terminal failures (error / not-found) per tile, index-aligned with
   // tilePlacements. Since the board never loads its links, membership
   // normally reports `not-loaded`; broken kinds surface here when the links
   // were loaded elsewhere (e.g. the edit format), bringing the real errorDoc
-  // with them. Slots whose entry never arrives fall back to the synthesized
+  // with them. Tiles whose entry never arrives fall back to the synthesized
   // not-found placeholder below.
   brokenSlotAt = (index: number) => {
-    let owner = this.args.model as unknown as PosterBoard | undefined;
-    if (!owner) {
-      return undefined;
-    }
-    let { membership } = getRelationshipMembershipState(owner, 'cards');
-    let rel = (membership ?? [])[index];
+    let tile = this.tiles[index];
+    let rel = tile ? tileLinkState(tile) : undefined;
     return rel && (rel.kind === 'error' || rel.kind === 'not-found')
       ? rel
       : undefined;
@@ -588,8 +607,7 @@ export class PosterBoard extends CardDef {
   static icon = LayoutDashboardIcon;
   static prefersWideFormat = true;
 
-  @field cards = linksToMany(() => CardDef);
-  @field frameSettings = containsMany(FrameSettingsField);
+  @field tiles = containsMany(BoardTile);
 
   static isolated = Isolated;
 }

--- a/packages/experiments-realm/poster-board/poster-board.gts
+++ b/packages/experiments-realm/poster-board/poster-board.gts
@@ -16,6 +16,7 @@ import { on } from '@ember/modifier';
 import Modifier from 'ember-modifier';
 import {
   searchEntryWireQueryFromQuery,
+  type ErrorEntry,
   type RenderableSearchEntryLike,
   type SearchEntryWireQuery,
 } from '@cardstack/runtime-common';
@@ -212,6 +213,11 @@ class Isolated extends Component<typeof PosterBoard> {
     message: 'This card has no entry in the search index',
   };
 
+  // A failed search request (network, auth, server) settles with `errors`
+  // populated and no entries at all; that is a board-wide failure, not a
+  // per-card 404, so every tile reports the search error instead.
+  searchErrorDoc = (errors: ErrorEntry[] | undefined) => errors?.[0]?.error;
+
   tileStyle = (tile: TilePlacement) =>
     htmlSafe(`left: ${tile.x}px; top: ${tile.y}px;`);
 
@@ -390,13 +396,28 @@ class Isolated extends Component<typeof PosterBoard> {
                         {{#unless results.isLoading}}
                           {{#let (this.refAt tile.index) as |ref|}}
                             {{#if ref}}
-                              <BrokenLinkTemplate
-                                @brokenUrl={{ref}}
-                                @errorDoc={{this.missingEntryErrorDoc}}
-                                @state='not-found'
-                                @format='fitted'
-                                data-test-poster-board-broken-tile={{tile.index}}
-                              />
+                              {{#let
+                                (this.searchErrorDoc results.errors)
+                                as |searchError|
+                              }}
+                                {{#if searchError}}
+                                  <BrokenLinkTemplate
+                                    @brokenUrl={{ref}}
+                                    @errorDoc={{searchError}}
+                                    @state='error'
+                                    @format='fitted'
+                                    data-test-poster-board-broken-tile={{tile.index}}
+                                  />
+                                {{else}}
+                                  <BrokenLinkTemplate
+                                    @brokenUrl={{ref}}
+                                    @errorDoc={{this.missingEntryErrorDoc}}
+                                    @state='not-found'
+                                    @format='fitted'
+                                    data-test-poster-board-broken-tile={{tile.index}}
+                                  />
+                                {{/if}}
+                              {{/let}}
                             {{/if}}
                           {{/let}}
                         {{/unless}}

--- a/packages/experiments-realm/poster-board/poster-board.gts
+++ b/packages/experiments-realm/poster-board/poster-board.gts
@@ -229,9 +229,12 @@ class Isolated extends Component<typeof PosterBoard> {
   };
 
   get tilesQuery(): SearchEntryWireQuery | undefined {
-    let urls = this.linkedUrls.filter(
-      (url): url is string => url !== undefined,
-    );
+    // Two tiles may show the same card; the index holds one row for it.
+    let urls = [
+      ...new Set(
+        this.linkedUrls.filter((url): url is string => url !== undefined),
+      ),
+    ];
     if (urls.length === 0) {
       return undefined;
     }
@@ -608,15 +611,18 @@ class Isolated extends Component<typeof PosterBoard> {
 
       /* Tile content is display-only — the overlay layer owns hover/click.
          The overlay binds its listeners to the card's root element, so that
-         element must keep receiving pointer events; only its descendants opt
-         out, so links/buttons in the card never intercept a click and text
-         never starts a selection. `user-select` resolves through the parent,
-         so setting it once on the root covers the subtree. */
+         element must keep receiving pointer events; only the card's own
+         controls opt out, so a link or button never intercepts a click, and
+         text never starts a selection. Other descendants stay hit-testable so
+         a card's own scroller still receives wheel events (see handleWheel).
+         `user-select` resolves through the parent, so setting it once on the
+         root covers the subtree. */
       .poster-board-tile-card {
         user-select: none;
       }
 
-      .poster-board-tile-card :deep(*) {
+      .poster-board-tile-card
+        :deep(a, button, input, select, textarea, label, [role='button']) {
         pointer-events: none;
       }
 

--- a/packages/experiments-realm/poster-board/poster-board.gts
+++ b/packages/experiments-realm/poster-board/poster-board.gts
@@ -444,7 +444,7 @@ class Isolated extends Component<typeof PosterBoard> {
       {{on 'pointerup' this.handlePointerUp}}
       {{on 'pointercancel' this.handlePointerUp}}
       {{on 'keydown' this.handleKeyDown}}
-      role='application'
+      role='region'
       aria-label='Poster board canvas'
       tabindex='0'
       data-test-poster-board

--- a/packages/experiments-realm/poster-board/poster-board.gts
+++ b/packages/experiments-realm/poster-board/poster-board.gts
@@ -1,10 +1,66 @@
-import { CardDef, Component } from 'https://cardstack.com/base/card-api';
+import {
+  CardDef,
+  Component,
+  FieldDef,
+  field,
+  contains,
+  containsMany,
+  getRelationshipMembershipState,
+  linksToMany,
+} from 'https://cardstack.com/base/card-api';
+import NumberField from 'https://cardstack.com/base/number';
 import { tracked } from '@glimmer/tracking';
 import { htmlSafe } from '@ember/template';
 import { on } from '@ember/modifier';
 import Modifier from 'ember-modifier';
+import {
+  searchEntryWireQueryFromQuery,
+  type RenderableSearchEntryLike,
+  type SearchEntryWireQuery,
+} from '@cardstack/runtime-common';
+import {
+  BrokenLinkTemplate,
+  FittedCardContainer,
+} from '@cardstack/boxel-ui/components';
+import { fittedFormatById } from '@cardstack/boxel-ui/helpers';
 import LayoutDashboardIcon from '@cardstack/boxel-icons/layout-dashboard';
 import { RigState, SurfaceRig, type PanSession } from './rig';
+
+// Tiles use the shared cardsgrid-tile fitted size so boards show cards at a
+// size their fitted views are designed for. FittedCardContainer applies the
+// dimensions; these constants drive the grid placement math.
+const cardsgridTile = fittedFormatById.get('cardsgrid-tile')!;
+const TILE_WIDTH = cardsgridTile.width;
+const TILE_HEIGHT = cardsgridTile.height;
+const TILE_GAP = 32;
+const GRID_COLUMNS = 4;
+// Breathing room between the world origin and the default grid (~--boxel-sp-xs)
+const GRID_PADDING = 10;
+
+interface TilePlacement {
+  index: number;
+  x: number;
+  y: number;
+}
+
+// Cards without a persisted frame setting flow into a fixed grid.
+function defaultPlacement(index: number): TilePlacement {
+  return {
+    index,
+    x: GRID_PADDING + (index % GRID_COLUMNS) * (TILE_WIDTH + TILE_GAP),
+    y:
+      GRID_PADDING +
+      Math.floor(index / GRID_COLUMNS) * (TILE_HEIGHT + TILE_GAP),
+  };
+}
+
+export class FrameSettingsField extends FieldDef {
+  static displayName = 'Frame Settings';
+
+  @field cardIndex = contains(NumberField);
+  @field x = contains(NumberField);
+  @field y = contains(NumberField);
+}
 
 interface OnInsertSignature {
   Element: HTMLElement;
@@ -27,6 +83,7 @@ class Isolated extends Component<typeof PosterBoard> {
   private panSession: PanSession | null = null;
   private activePointerId: number | null = null;
   private rootElement: HTMLElement | null = null;
+  private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
 
   get zoomLabel() {
     return Math.round(this.rig.magnify * 100) + '%';
@@ -42,6 +99,103 @@ class Isolated extends Component<typeof PosterBoard> {
   get rootStyle() {
     return htmlSafe(`cursor: ${this.isPanning ? 'grabbing' : 'grab'};`);
   }
+
+  // ── Tile placement ─────────────────────────────────────
+
+  // The linked cards' reference URLs, read from the relationship membership
+  // state — a pure read that never triggers the lazy link load, so the board
+  // renders tiles without ever fetching the linked instances. Index-aligned
+  // with the cards slots; only a `not-set` slot lacks a reference.
+  get linkedRefs(): (string | undefined)[] {
+    let owner = this.args.model as unknown as PosterBoard | undefined;
+    if (!owner) {
+      return [];
+    }
+    let { membership } = getRelationshipMembershipState(owner, 'cards');
+    return (membership ?? []).map((slot) => slot.reference);
+  }
+
+  get tilePlacements(): TilePlacement[] {
+    let settings = this.args.model?.frameSettings ?? [];
+    return this.linkedRefs.map((_ref, index) => {
+      let setting = settings.find((s) => Number(s.cardIndex) === index);
+      // Number() guards against non-numeric values in hand-edited JSON
+      let x = Number(setting?.x);
+      let y = Number(setting?.y);
+      if (setting && Number.isFinite(x) && Number.isFinite(y)) {
+        return { index, x, y };
+      }
+      return defaultPlacement(index);
+    });
+  }
+
+  get hasCards() {
+    return this.tilePlacements.length > 0;
+  }
+
+  // Tiles render as prerendered fitted HTML addressed by the linked cards'
+  // URLs. `fitted` is bound through `htmlQuery` — a bare `eq.format` would be
+  // read as an `item.` field path and rejected. Instance index rows key on
+  // the `.json` file URL, and `scope: 'cards'` drops each card's dual-indexed
+  // file row. Undefined (no linked cards) leaves the search idle.
+  get tilesQuery(): SearchEntryWireQuery | undefined {
+    let refs = this.linkedRefs.filter(
+      (ref): ref is string => ref !== undefined,
+    );
+    if (refs.length === 0) {
+      return undefined;
+    }
+    return {
+      ...searchEntryWireQueryFromQuery({}, { scope: 'cards' }),
+      cardUrls: refs.map((ref) => `${ref}.json`),
+      filter: { eq: { htmlQuery: { eq: { format: 'fitted' } } } },
+    };
+  }
+
+  // Results come back in engine order, not linked order, so each tile finds
+  // its own entry by reference URL (`entry.id` is the extensionless card id).
+  entryFor = (
+    index: number,
+    entries: RenderableSearchEntryLike[],
+  ): RenderableSearchEntryLike | undefined => {
+    let ref = this.linkedRefs[index];
+    return ref ? entries.find((entry) => entry.id === ref) : undefined;
+  };
+
+  // Empty string (a `not-set` slot) is falsy, so the template's `{{#if ref}}`
+  // guard skips the placeholder for slots with nothing to point at — glint
+  // doesn't narrow in templates, so the fallback keeps the type `string`.
+  refAt = (index: number): string => this.linkedRefs[index] ?? '';
+
+  // Terminal failures (error / not-found) per cards slot, index-aligned with
+  // tilePlacements. Since the board never loads its links, membership
+  // normally reports `not-loaded`; broken kinds surface here when the links
+  // were loaded elsewhere (e.g. the edit format), bringing the real errorDoc
+  // with them. Slots whose entry never arrives fall back to the synthesized
+  // not-found placeholder below.
+  brokenSlotAt = (index: number) => {
+    let owner = this.args.model as unknown as PosterBoard | undefined;
+    if (!owner) {
+      return undefined;
+    }
+    let { membership } = getRelationshipMembershipState(owner, 'cards');
+    let rel = (membership ?? [])[index];
+    return rel && (rel.kind === 'error' || rel.kind === 'not-found')
+      ? rel
+      : undefined;
+  };
+
+  // A card can lack an index entry entirely (deleted target, unsaved link, a
+  // reference outside the searched realms) — the wire document simply omits
+  // it, leaving no errorDoc to thread through.
+  missingEntryErrorDoc = {
+    status: 404,
+    title: 'Not Found',
+    message: 'This card has no entry in the search index',
+  };
+
+  tileStyle = (tile: TilePlacement) =>
+    htmlSafe(`left: ${tile.x}px; top: ${tile.y}px;`);
 
   // ── Wheel ──────────────────────────────────────────────
 
@@ -63,7 +217,10 @@ class Isolated extends Component<typeof PosterBoard> {
       return;
     }
     const target = event.target as HTMLElement;
-    if (target.closest('[data-poster-board-hud]')) {
+    // Pointers that start on the HUD or inside a card tile are not pans:
+    // capturing them would break the tile's own focus/selection behavior
+    // (and tile pointerdown becomes drag-to-move in step 3)
+    if (target.closest('[data-poster-board-hud], [data-poster-board-tile]')) {
       return;
     }
     this.panSession = this.surfaceRig.startPan(event.clientX, event.clientY);
@@ -156,9 +313,15 @@ class Isolated extends Component<typeof PosterBoard> {
 
   handleInserted = (el: HTMLElement) => {
     this.rootElement = el;
+    this.keydownHandler = this.handleKeyDown;
+    window.addEventListener('keydown', this.keydownHandler);
   };
 
   willDestroy(): void {
+    if (this.keydownHandler) {
+      window.removeEventListener('keydown', this.keydownHandler);
+      this.keydownHandler = null;
+    }
     this.surfaceRig.destroy();
     super.willDestroy();
   }
@@ -168,9 +331,6 @@ class Isolated extends Component<typeof PosterBoard> {
     <div
       class='poster-board-root'
       style={{this.rootStyle}}
-      role='application'
-      aria-label='Poster board canvas'
-      tabindex='0'
       {{OnInsert this.handleInserted}}
       {{on 'wheel' this.handleWheel}}
       {{on 'pointerdown' this.handlePointerDown}}
@@ -178,15 +338,71 @@ class Isolated extends Component<typeof PosterBoard> {
       {{on 'pointerup' this.handlePointerUp}}
       {{on 'pointercancel' this.handlePointerUp}}
       {{on 'keydown' this.handleKeyDown}}
+      role='application'
+      aria-label='Poster board canvas'
+      tabindex='0'
       data-test-poster-board
     >
       <div class='poster-board-plane' style={{this.planeStyle}}>
         <div class='poster-board-grid' aria-hidden='true'></div>
-        <header class='poster-board-hint'>
-          <h1 class='poster-board-hint-title'><@fields.cardTitle /></h1>
-          <p class='poster-board-hint-line'>Scroll or drag to pan · Pinch or
-            Shift + / Shift - to zoom</p>
-        </header>
+        {{#let (component @context.searchResultsComponent) as |SearchResults|}}
+          {{! Overlays default on: each tile registers with the operator-mode
+              overlay layer, giving it the standard hover chrome (type chip,
+              options menu, selection, click-to-open) anchored to the tile. }}
+          <SearchResults @query={{this.tilesQuery}} @mode='none' as |results|>
+            {{#each this.tilePlacements key='index' as |tile|}}
+              <FittedCardContainer
+                @size='cardsgrid-tile'
+                @style={{this.tileStyle tile}}
+                class='poster-board-tile'
+                data-poster-board-tile
+                data-test-poster-board-tile={{tile.index}}
+              >
+                {{#let (this.brokenSlotAt tile.index) as |broken|}}
+                  {{#if broken}}
+                    <BrokenLinkTemplate
+                      @brokenUrl={{broken.reference}}
+                      @errorDoc={{broken.errorDoc}}
+                      @state={{broken.kind}}
+                      @format='fitted'
+                      data-test-poster-board-broken-tile={{tile.index}}
+                    />
+                  {{else}}
+                    {{#let
+                      (this.entryFor tile.index results.entries)
+                      as |entry|
+                    }}
+                      {{#if entry}}
+                        <entry.component class='poster-board-tile-card' />
+                      {{else}}
+                        {{#unless results.isLoading}}
+                          {{#let (this.refAt tile.index) as |ref|}}
+                            {{#if ref}}
+                              <BrokenLinkTemplate
+                                @brokenUrl={{ref}}
+                                @errorDoc={{this.missingEntryErrorDoc}}
+                                @state='not-found'
+                                @format='fitted'
+                                data-test-poster-board-broken-tile={{tile.index}}
+                              />
+                            {{/if}}
+                          {{/let}}
+                        {{/unless}}
+                      {{/if}}
+                    {{/let}}
+                  {{/if}}
+                {{/let}}
+              </FittedCardContainer>
+            {{/each}}
+          </SearchResults>
+        {{/let}}
+        {{#unless this.hasCards}}
+          <header class='poster-board-hint'>
+            <h1 class='poster-board-hint-title'><@fields.cardTitle /></h1>
+            <p class='poster-board-hint-line'>Scroll or drag to pan · Pinch or
+              Shift + / Shift - to zoom</p>
+          </header>
+        {{/unless}}
       </div>
 
       <div
@@ -259,6 +475,24 @@ class Isolated extends Component<typeof PosterBoard> {
 
       .poster-board-plane {
         will-change: transform;
+      }
+
+      .poster-board-tile {
+        position: absolute;
+      }
+
+      /* Tile content is display-only — the overlay layer owns hover/click.
+         The overlay binds its listeners to the card's root element, so that
+         element must keep receiving pointer events; only its descendants opt
+         out, so links/buttons in the card never intercept a click and text
+         never starts a selection. `user-select` resolves through the parent,
+         so setting it once on the root covers the subtree. */
+      .poster-board-tile-card {
+        user-select: none;
+      }
+
+      .poster-board-tile-card :deep(*) {
+        pointer-events: none;
       }
 
       .poster-board-grid {
@@ -360,6 +594,9 @@ export class PosterBoard extends CardDef {
   static displayName = 'Poster Board';
   static icon = LayoutDashboardIcon;
   static prefersWideFormat = true;
+
+  @field cards = linksToMany(() => CardDef);
+  @field frameSettings = containsMany(FrameSettingsField);
 
   static isolated = Isolated;
 }

--- a/packages/experiments-realm/poster-board/poster-board.gts
+++ b/packages/experiments-realm/poster-board/poster-board.gts
@@ -7,6 +7,7 @@ import {
   containsMany,
   getRelationshipMembershipState,
   linksTo,
+  resolveInstanceURL,
   resolveRef,
 } from '@cardstack/base/card-api';
 import NumberField from '@cardstack/base/number';
@@ -200,28 +201,48 @@ class Isolated extends Component<typeof PosterBoard> {
   // read as an `item.` field path and rejected. Instance index rows key on
   // the `.json` file URL, and `scope: 'cards'` drops each card's dual-indexed
   // file row. Undefined (no tiles with a card) leaves the search idle.
-  get tilesQuery(): SearchEntryWireQuery | undefined {
-    let refs = this.linkedRefs.filter(
-      (ref): ref is string => ref !== undefined,
+  // References reach card code in canonical RRI form (`@scope/realm/…` for a
+  // prefix-mapped realm) while the index keys rows on URLs, so both the query
+  // and the entry matching speak the store-resolved URL. The base realm's rows
+  // key on its virtual URL, which no client-side resolution reaches; those
+  // tiles need the server-side expansion in CS-12744.
+  get linkedUrls(): (string | undefined)[] {
+    return this.linkedRefs.map((ref) =>
+      ref === undefined ? undefined : this.hrefFor(ref),
     );
-    if (refs.length === 0) {
+  }
+
+  hrefFor = (reference: string): string => {
+    // `@model` is typed with optional fields, so it needs the same cast
+    // `tileLinkState` uses to hand a card to card-api.
+    let model = this.args.model as unknown as CardDef | undefined;
+    return (model && resolveInstanceURL(model, reference)?.href) ?? reference;
+  };
+
+  get tilesQuery(): SearchEntryWireQuery | undefined {
+    let urls = this.linkedUrls.filter(
+      (url): url is string => url !== undefined,
+    );
+    if (urls.length === 0) {
       return undefined;
     }
     return {
       ...searchEntryWireQueryFromQuery({}, { scope: 'cards' }),
-      cardUrls: refs.map((ref) => `${ref}.json`),
+      cardUrls: urls.map((url) => `${url}.json`),
       filter: { eq: { htmlQuery: { eq: { format: 'fitted' } } } },
     };
   }
 
   // Results come back in engine order, not linked order, so each tile finds
-  // its own entry by reference URL (`entry.id` is the extensionless card id).
+  // its own entry by resolved URL (`entry.id` is the extensionless card id).
   entryFor = (
     index: number,
     entries: RenderableSearchEntryLike[],
   ): RenderableSearchEntryLike | undefined => {
-    let ref = this.linkedRefs[index];
-    return ref ? entries.find((entry) => entry.id === ref) : undefined;
+    let url = this.linkedUrls[index];
+    return url
+      ? entries.find((entry) => this.hrefFor(entry.id) === url)
+      : undefined;
   };
 
   // Empty string (a `not-set` slot) is falsy, so the template's `{{#if ref}}`

--- a/packages/experiments-realm/poster-board/poster-board.gts
+++ b/packages/experiments-realm/poster-board/poster-board.gts
@@ -7,8 +7,8 @@ import {
   containsMany,
   getRelationshipMembershipState,
   linksToMany,
-} from 'https://cardstack.com/base/card-api';
-import NumberField from 'https://cardstack.com/base/number';
+} from '@cardstack/base/card-api';
+import NumberField from '@cardstack/base/number';
 import { tracked } from '@glimmer/tracking';
 import { htmlSafe } from '@ember/template';
 import { on } from '@ember/modifier';

--- a/packages/experiments-realm/poster-board/poster-board.gts
+++ b/packages/experiments-realm/poster-board/poster-board.gts
@@ -99,6 +99,44 @@ class OnInsert extends Modifier<OnInsertSignature> {
   }
 }
 
+// A wheel gesture over content that can still scroll in that direction (an
+// error panel, a card with its own scroller) belongs to that content, not to
+// the canvas. Walks from the event target up to the board root.
+function wheelTargetsScrollable(event: WheelEvent): boolean {
+  const root = event.currentTarget as Element | null;
+  // Synthetic wheel events may omit one delta; treat it as no movement.
+  const deltaX = event.deltaX || 0;
+  const deltaY = event.deltaY || 0;
+  const vertical = Math.abs(deltaY) >= Math.abs(deltaX);
+  let el = event.target instanceof Element ? event.target : null;
+  while (el && el !== root) {
+    if (vertical ? canScroll(el, 'y', deltaY) : canScroll(el, 'x', deltaX)) {
+      return true;
+    }
+    el = el.parentElement;
+  }
+  return false;
+}
+
+function canScroll(el: Element, axis: 'x' | 'y', delta: number): boolean {
+  const style = getComputedStyle(el);
+  const overflow = axis === 'y' ? style.overflowY : style.overflowX;
+  if (overflow !== 'auto' && overflow !== 'scroll') {
+    return false;
+  }
+  const size = axis === 'y' ? el.clientHeight : el.clientWidth;
+  const extent = axis === 'y' ? el.scrollHeight : el.scrollWidth;
+  const offset = axis === 'y' ? el.scrollTop : el.scrollLeft;
+  if (extent <= size) {
+    return false;
+  }
+  return delta > 0 ? offset + size < extent - 1 : offset > 0;
+}
+
+// Wheel events inside one trackpad gesture (inertia included) arrive every
+// frame; a gap this long means a new gesture began.
+const WHEEL_GESTURE_GAP_MS = 150;
+
 class Isolated extends Component<typeof PosterBoard> {
   rig = new RigState();
   surfaceRig = new SurfaceRig(this.rig);
@@ -107,6 +145,7 @@ class Isolated extends Component<typeof PosterBoard> {
   private panSession: PanSession | null = null;
   private activePointerId: number | null = null;
   private rootElement: HTMLElement | null = null;
+  private lastContentWheelTime = -Infinity;
 
   get zoomLabel() {
     return Math.round(this.rig.magnify * 100) + '%';
@@ -224,7 +263,23 @@ class Isolated extends Component<typeof PosterBoard> {
   // ── Wheel ──────────────────────────────────────────────
 
   handleWheel = (event: Event) => {
-    this.surfaceRig.handleWheel(event as WheelEvent);
+    const wheel = event as WheelEvent;
+    const now = performance.now();
+    // Ctrl/Cmd+wheel is a pinch, never a scroll, so it always zooms the board.
+    if (
+      !(wheel.ctrlKey || wheel.metaKey) &&
+      (now - this.lastContentWheelTime < WHEEL_GESTURE_GAP_MS ||
+        wheelTargetsScrollable(wheel))
+    ) {
+      // The gesture belongs to the content for as long as it lasts, as macOS
+      // latches a scroll to the scroller it started on. Any canvas momentum
+      // still running from earlier wheel events would drift under it.
+      this.lastContentWheelTime = now;
+      this.surfaceRig.stopAll();
+      return;
+    }
+    this.lastContentWheelTime = -Infinity;
+    this.surfaceRig.handleWheel(wheel);
   };
 
   // ── Pointer pan ────────────────────────────────────────
@@ -361,7 +416,11 @@ class Isolated extends Component<typeof PosterBoard> {
       tabindex='0'
       data-test-poster-board
     >
-      <div class='poster-board-plane' style={{this.planeStyle}}>
+      <div
+        class='poster-board-plane'
+        style={{this.planeStyle}}
+        data-test-poster-board-plane
+      >
         <div class='poster-board-grid' aria-hidden='true'></div>
         {{#let (component @context.searchResultsComponent) as |SearchResults|}}
           {{! Overlays default on: each tile registers with the operator-mode
@@ -493,6 +552,9 @@ class Isolated extends Component<typeof PosterBoard> {
         width: 100%;
         height: 100%;
         overflow: hidden;
+        /* Scroll a tile's own scroller can't absorb stops here instead of
+           chaining to whatever scrolls around the board. */
+        overscroll-behavior: contain;
         touch-action: none;
         min-width: 0;
       }

--- a/packages/experiments-realm/poster-board/poster-board.test.gts
+++ b/packages/experiments-realm/poster-board/poster-board.test.gts
@@ -55,8 +55,7 @@ let capturedQueries: (SearchEntryWireQuery | undefined)[] = [];
 function stubEntry(id: string): RenderableSearchEntryLike {
   // The board stamps its content class through `...attributes`, the same way
   // it lands on real prerendered HTML's root element.
-  // The scroller stands in for content that owns its own wheel gestures, like
-  // the broken-link error panel.
+  // The scroller stands in for card content that owns its own wheel gestures.
   let component: TOC<{ Element: Element }> = <template>
     {{! template-lint-disable no-inline-styles }}
     <div data-test-stub-entry={{id}} ...attributes>
@@ -429,6 +428,35 @@ export function runTests() {
         { eq: { htmlQuery: { eq: { format: 'fitted' } } } },
         'the fitted rendering is bound through htmlQuery',
       );
+    });
+
+    test('poster-board renders a card linked from two tiles in both tiles', async function (assert) {
+      let { note1 } = await makeSavedNotes();
+      stubEntries = [stubEntry(note1.id)];
+      await renderPosterBoard(
+        new PosterBoard({
+          tiles: [
+            new BoardTile({ card: note1 }),
+            new BoardTile({ card: note1 }),
+          ],
+        }),
+      );
+
+      assert.deepEqual(
+        capturedQueries.at(-1)?.cardUrls,
+        [`${note1.id}.json`],
+        'the query asks for the shared card once',
+      );
+      assert
+        .dom(
+          `[data-test-poster-board-tile="0"] [data-test-stub-entry="${note1.id}"]`,
+        )
+        .exists('the first tile renders the card');
+      assert
+        .dom(
+          `[data-test-poster-board-tile="1"] [data-test-stub-entry="${note1.id}"]`,
+        )
+        .exists('the second tile renders the same card');
     });
 
     test('poster-board leaves wheel gestures to scrollable tile content', async function (assert) {

--- a/packages/experiments-realm/poster-board/poster-board.test.gts
+++ b/packages/experiments-realm/poster-board/poster-board.test.gts
@@ -275,6 +275,39 @@ export function runTests() {
         );
     });
 
+    test('poster-board skips a tile whose link was cleared without leaving a gap', async function (assert) {
+      let { note1, note2 } = await makeSavedNotes();
+      stubEntries = [stubEntry(note1.id), stubEntry(note2.id)];
+
+      await renderPosterBoard(
+        new PosterBoard({
+          tiles: [
+            new BoardTile({ card: note1 }),
+            new BoardTile({ card: null }),
+            new BoardTile({ card: note2 }),
+          ],
+        }),
+      );
+
+      assert
+        .dom('[data-test-poster-board-tile]')
+        .exists({ count: 2 }, 'the unlinked tile renders nothing');
+      assert
+        .dom('[data-test-poster-board-tile="1"]')
+        .doesNotExist('no element stands in for the unlinked tile');
+      assert
+        .dom('[data-test-poster-board-tile="2"]')
+        .hasStyle(
+          { left: '212px', top: '10px' },
+          'the tile after the cleared link takes the next grid slot',
+        );
+      assert
+        .dom(
+          `[data-test-poster-board-tile="2"] [data-test-stub-entry="${note2.id}"]`,
+        )
+        .exists('the moved tile still shows its own card');
+    });
+
     test('poster-board keeps a persisted position with its tile when an earlier tile is removed', async function (assert) {
       let { note1, note2 } = await makeSavedNotes();
       stubEntries = [stubEntry(note1.id), stubEntry(note2.id)];

--- a/packages/experiments-realm/poster-board/poster-board.test.gts
+++ b/packages/experiments-realm/poster-board/poster-board.test.gts
@@ -1,12 +1,10 @@
 import type { TOC } from '@ember/component/template-only';
 import type Owner from '@ember/owner';
-import { click, render, triggerEvent } from '@ember/test-helpers';
+import { click, triggerEvent } from '@ember/test-helpers';
 
 import GlimmerComponent from '@glimmer/component';
 
 import { getService } from '@universal-ember/test-support';
-
-import { provide } from 'ember-provide-consume-context';
 
 import { module, test } from 'qunit';
 
@@ -18,23 +16,30 @@ import {
   type SearchResultsComponentSignature,
 } from '@cardstack/runtime-common';
 
-import { saveCard, testRealmURL } from '@cardstack/host/tests/helpers';
+import {
+  provideConsumeContext,
+  saveCard,
+  testRealmURL,
+} from '@cardstack/host/tests/helpers';
 import {
   CardDef,
   setupBaseRealm,
 } from '@cardstack/host/tests/helpers/base-realm';
+import { renderCard } from '@cardstack/host/tests/helpers/render-component';
 import { setupRenderingTest } from '@cardstack/host/tests/helpers/setup';
 
 import { FrameSettingsField, PosterBoard } from './poster-board';
 
-// Host services register themselves in this registry from their own app files,
-// which this package's TS project never loads. Declare the one service these
-// tests touch, structurally, with just the member they use — `Loader` is the
-// real type, so downstream `saveCard` / `loader.import` calls check for real.
-declare module '@ember/service' {
-  interface Registry {
-    'loader-service': { loader: Loader };
-  }
+import type { CardContext } from 'https://cardstack.com/base/card-api';
+
+// This file is type-checked by two projects: experiments-realm's (which never
+// loads host's service-registry augmentations, so `getService` returns a bare
+// object) and host's (which loads the real `LoaderService` registry entry). A
+// registry augmentation here would conflict with host's, so cast structurally
+// to just the member these tests use — `Loader` is the real type, so
+// downstream `saveCard` / `loader.import` calls check for real.
+function loaderService(): { loader: Loader } {
+  return getService('loader-service') as unknown as { loader: Loader };
 }
 
 // The board renders its tiles through `@context.searchResultsComponent`, which
@@ -81,38 +86,13 @@ class StubSearchResults extends GlimmerComponent<SearchResultsComponentSignature
   <template>{{yield this.results}}</template>
 }
 
-class TestCardContextProvider extends GlimmerComponent<{
-  Blocks: { default: [] };
-}> {
-  @provide(CardContextName)
-  get cardContext() {
-    return { searchResultsComponent: StubSearchResults };
-  }
-
-  <template>
-    {{! template-lint-disable no-yield-only }}
-    {{yield}}
-  </template>
-}
-
 async function renderPosterBoard(board?: PosterBoard) {
-  let loader = getService('loader-service').loader;
-  let api = await loader.import<
-    typeof import('https://cardstack.com/base/card-api')
-  >('https://cardstack.com/base/card-api');
-  let card = board ?? new PosterBoard({});
-  let Board = api.getComponent(card);
-  await render(
-    <template>
-      <TestCardContextProvider>
-        <Board @format='isolated' />
-      </TestCardContextProvider>
-    </template>,
-  );
+  let loader = loaderService().loader;
+  await renderCard(loader, board ?? new PosterBoard({}), 'isolated');
 }
 
 async function makeSavedNotes() {
-  let loader = getService('loader-service').loader;
+  let loader = loaderService().loader;
   class Note extends CardDef {
     static displayName = 'Note';
   }
@@ -132,6 +112,11 @@ export function runTests() {
     hooks.beforeEach(function () {
       stubEntries = [];
       capturedQueries = [];
+      // Partial by design: CardContextConsumer spreads defaults over what the
+      // provider supplies, so only the member the board reads is stubbed.
+      provideConsumeContext(CardContextName, {
+        searchResultsComponent: StubSearchResults,
+      } as unknown as CardContext);
     });
 
     test('poster-board renders its zoom toolbar and the controls zoom, reset, and fit', async function (assert) {

--- a/packages/experiments-realm/poster-board/poster-board.test.gts
+++ b/packages/experiments-realm/poster-board/poster-board.test.gts
@@ -1,25 +1,138 @@
-import { click, triggerEvent } from '@ember/test-helpers';
+import type { TOC } from '@ember/component/template-only';
+import type Owner from '@ember/owner';
+import { click, render, triggerEvent } from '@ember/test-helpers';
+
+import GlimmerComponent from '@glimmer/component';
 
 import { getService } from '@universal-ember/test-support';
 
+import { provide } from 'ember-provide-consume-context';
+
 import { module, test } from 'qunit';
 
-import { setupBaseRealm } from '@cardstack/host/tests/helpers/base-realm';
-import { renderCard } from '@cardstack/host/tests/helpers/render-component';
+import {
+  CardContextName,
+  type Loader,
+  type RenderableSearchEntryLike,
+  type SearchEntryWireQuery,
+  type SearchResultsComponentSignature,
+} from '@cardstack/runtime-common';
+
+import { saveCard, testRealmURL } from '@cardstack/host/tests/helpers';
+import {
+  CardDef,
+  setupBaseRealm,
+} from '@cardstack/host/tests/helpers/base-realm';
 import { setupRenderingTest } from '@cardstack/host/tests/helpers/setup';
 
-import { PosterBoard } from './poster-board';
+import { FrameSettingsField, PosterBoard } from './poster-board';
 
-async function renderPosterBoard() {
+// Host services register themselves in this registry from their own app files,
+// which this package's TS project never loads. Declare the one service these
+// tests touch, structurally, with just the member they use — `Loader` is the
+// real type, so downstream `saveCard` / `loader.import` calls check for real.
+declare module '@ember/service' {
+  interface Registry {
+    'loader-service': { loader: Loader };
+  }
+}
+
+// The board renders its tiles through `@context.searchResultsComponent`, which
+// only the host app provides (operator mode / index / prerender routes). The
+// stub below stands in for it: it captures each query the board issues and
+// yields a test-controlled entry set, so tile mapping and fallbacks are
+// exercised deterministically without a live prerender index.
+let stubEntries: RenderableSearchEntryLike[] = [];
+let capturedQueries: (SearchEntryWireQuery | undefined)[] = [];
+
+function stubEntry(id: string): RenderableSearchEntryLike {
+  // The board stamps its content class through `...attributes`, the same way
+  // it lands on real prerendered HTML's root element.
+  let component: TOC<{ Element: Element }> = <template>
+    <div data-test-stub-entry={{id}} ...attributes>
+      <button type='button' data-test-stub-entry-button>Stub button</button>
+    </div>
+  </template>;
+  return {
+    id,
+    type: 'card',
+    realmUrl: testRealmURL,
+    name: id.replace(testRealmURL, ''),
+    isError: false,
+    component,
+  };
+}
+
+class StubSearchResults extends GlimmerComponent<SearchResultsComponentSignature> {
+  constructor(owner: Owner, args: SearchResultsComponentSignature['Args']) {
+    super(owner, args);
+    capturedQueries.push(args.query);
+  }
+
+  get results() {
+    return {
+      entries: stubEntries,
+      isLoading: false,
+      meta: { page: { total: stubEntries.length } },
+      errors: undefined,
+    };
+  }
+
+  <template>{{yield this.results}}</template>
+}
+
+class TestCardContextProvider extends GlimmerComponent<{
+  Blocks: { default: [] };
+}> {
+  @provide(CardContextName)
+  get cardContext() {
+    return { searchResultsComponent: StubSearchResults };
+  }
+
+  <template>
+    {{! template-lint-disable no-yield-only }}
+    {{yield}}
+  </template>
+}
+
+async function renderPosterBoard(board?: PosterBoard) {
   let loader = getService('loader-service').loader;
-  let card = new PosterBoard({});
-  await renderCard(loader, card, 'isolated');
+  let api = await loader.import<
+    typeof import('https://cardstack.com/base/card-api')
+  >('https://cardstack.com/base/card-api');
+  let card = board ?? new PosterBoard({});
+  let Board = api.getComponent(card);
+  await render(
+    <template>
+      <TestCardContextProvider>
+        <Board @format='isolated' />
+      </TestCardContextProvider>
+    </template>,
+  );
+}
+
+async function makeSavedNotes() {
+  let loader = getService('loader-service').loader;
+  class Note extends CardDef {
+    static displayName = 'Note';
+  }
+  loader.shimModule(`${testRealmURL}note`, { Note });
+  let note1 = new Note();
+  let note2 = new Note();
+  await saveCard(note1, `${testRealmURL}Note/1`, loader);
+  await saveCard(note2, `${testRealmURL}Note/2`, loader);
+  return { note1, note2 };
 }
 
 export function runTests() {
   module('Rendering | poster-board card', function (hooks) {
     setupRenderingTest(hooks);
     setupBaseRealm(hooks);
+
+    hooks.beforeEach(function () {
+      stubEntries = [];
+      capturedQueries = [];
+    });
 
     test('poster-board renders its zoom toolbar and the controls zoom, reset, and fit', async function (assert) {
       await renderPosterBoard();
@@ -104,6 +217,97 @@ export function runTests() {
         shiftKey: true,
       });
       assert.dom('[data-test-zoom-level]').hasText('83%', 'Shift+- zooms out');
+    });
+
+    test('poster-board renders prerendered entries at persisted and grid-default positions, mapped by reference', async function (assert) {
+      let { note1, note2 } = await makeSavedNotes();
+
+      // Reversed relative to the linked order: the board must map each tile
+      // to its entry by reference, never by result position
+      stubEntries = [stubEntry(note2.id), stubEntry(note1.id)];
+
+      let board = new PosterBoard({
+        cards: [note1, note2],
+        frameSettings: [
+          new FrameSettingsField({ cardIndex: 1, x: 500, y: 120 }),
+        ],
+      });
+      await renderPosterBoard(board);
+
+      assert
+        .dom('[data-test-poster-board-tile]')
+        .exists({ count: 2 }, 'a tile renders per linked card');
+      assert
+        .dom('[data-test-poster-board-tile="0"]')
+        .hasStyle(
+          { left: '10px', top: '10px' },
+          'card without settings lands at its padded grid-default slot',
+        );
+      assert
+        .dom('[data-test-poster-board-tile="1"]')
+        .hasStyle(
+          { left: '500px', top: '120px' },
+          'card with frame settings renders at its persisted position',
+        );
+      assert
+        .dom(
+          `[data-test-poster-board-tile="0"] [data-test-stub-entry="${note1.id}"]`,
+        )
+        .exists('first tile shows the first linked card despite result order');
+      assert
+        .dom(
+          `[data-test-poster-board-tile="1"] [data-test-stub-entry="${note2.id}"]`,
+        )
+        .exists(
+          'second tile shows the second linked card despite result order',
+        );
+      assert
+        .dom('[data-test-poster-board] h1')
+        .doesNotExist('hint header is hidden when the board has cards');
+
+      await triggerEvent('[data-test-poster-board-tile="0"]', 'pointerdown', {
+        button: 0,
+        pointerId: 7,
+        clientX: 20,
+        clientY: 20,
+      });
+      assert
+        .dom('[data-test-poster-board]')
+        .hasStyle(
+          { cursor: 'grab' },
+          'pointerdown on a card tile does not start a board pan',
+        );
+    });
+
+    test("poster-board queries prerendered fitted html by the linked cards' URLs", async function (assert) {
+      await renderPosterBoard();
+      assert.deepEqual(
+        capturedQueries,
+        [undefined],
+        'a board with no cards issues no query',
+      );
+
+      let { note1, note2 } = await makeSavedNotes();
+      capturedQueries = [];
+      stubEntries = [stubEntry(note1.id), stubEntry(note2.id)];
+      await renderPosterBoard(new PosterBoard({ cards: [note1, note2] }));
+
+      let query = capturedQueries[capturedQueries.length - 1];
+      assert.deepEqual(
+        query?.cardUrls,
+        [`${note1.id}.json`, `${note2.id}.json`],
+        'cards are addressed by their .json file URLs',
+      );
+      assert.strictEqual(
+        query?.scope,
+        'cards',
+        'the card scope drops dual-indexed file rows',
+      );
+      assert.deepEqual(
+        query?.filter,
+        { eq: { htmlQuery: { eq: { format: 'fitted' } } } },
+        'the fitted rendering is bound through htmlQuery',
+      );
     });
 
     test('poster-board zoom reset is not undone by pending pinch momentum', async function (assert) {

--- a/packages/experiments-realm/poster-board/poster-board.test.gts
+++ b/packages/experiments-realm/poster-board/poster-board.test.gts
@@ -1,6 +1,6 @@
 import type { TOC } from '@ember/component/template-only';
 import type Owner from '@ember/owner';
-import { click, triggerEvent } from '@ember/test-helpers';
+import { click, settled, triggerEvent } from '@ember/test-helpers';
 
 import GlimmerComponent from '@glimmer/component';
 
@@ -28,7 +28,7 @@ import {
 import { renderCard } from '@cardstack/host/tests/helpers/render-component';
 import { setupRenderingTest } from '@cardstack/host/tests/helpers/setup';
 
-import { FrameSettingsField, PosterBoard } from './poster-board';
+import { BoardTile, PosterBoard } from './poster-board';
 
 import type { CardContext } from 'https://cardstack.com/base/card-api';
 
@@ -45,8 +45,8 @@ function loaderService(): { loader: Loader } {
 // The board renders its tiles through `@context.searchResultsComponent`, which
 // only the host app provides (operator mode / index / prerender routes). The
 // stub below stands in for it: it captures each query the board issues and
-// yields a test-controlled entry set, so tile mapping and fallbacks are
-// exercised deterministically without a live prerender index.
+// yields a test-controlled entry set, so tile mapping and the missing-entry
+// fallback are exercised deterministically without a live prerender index.
 let stubEntries: RenderableSearchEntryLike[] = [];
 let capturedQueries: (SearchEntryWireQuery | undefined)[] = [];
 
@@ -212,9 +212,11 @@ export function runTests() {
       stubEntries = [stubEntry(note2.id), stubEntry(note1.id)];
 
       let board = new PosterBoard({
-        cards: [note1, note2],
-        frameSettings: [
-          new FrameSettingsField({ cardIndex: 1, x: 500, y: 120 }),
+        tiles: [
+          // Unplaced tiles serialize with null coordinates, which must fall
+          // back to the grid rather than coerce to (0, 0)
+          new BoardTile({ card: note1, x: null, y: null }),
+          new BoardTile({ card: note2, x: 500, y: 120 }),
         ],
       });
       await renderPosterBoard(board);
@@ -226,13 +228,13 @@ export function runTests() {
         .dom('[data-test-poster-board-tile="0"]')
         .hasStyle(
           { left: '10px', top: '10px' },
-          'card without settings lands at its padded grid-default slot',
+          'tile without a position lands at its padded grid-default slot',
         );
       assert
         .dom('[data-test-poster-board-tile="1"]')
         .hasStyle(
           { left: '500px', top: '120px' },
-          'card with frame settings renders at its persisted position',
+          'tile with a position renders there',
         );
       assert
         .dom(
@@ -264,6 +266,65 @@ export function runTests() {
         );
     });
 
+    test('poster-board keeps a persisted position with its tile when an earlier tile is removed', async function (assert) {
+      let { note1, note2 } = await makeSavedNotes();
+      stubEntries = [stubEntry(note1.id), stubEntry(note2.id)];
+
+      let board = new PosterBoard({
+        tiles: [
+          new BoardTile({ card: note1 }),
+          new BoardTile({ card: note2, x: 500, y: 120 }),
+        ],
+      });
+      await renderPosterBoard(board);
+      assert
+        .dom('[data-test-poster-board-tile="1"]')
+        .hasStyle({ left: '500px', top: '120px' }, 'position starts on note2');
+
+      // Removing the first tile shifts note2 into slot 0; its position moves
+      // with the tile
+      board.tiles = [board.tiles[1]];
+      await settled();
+      assert
+        .dom('[data-test-poster-board-tile]')
+        .exists({ count: 1 }, 'one tile remains');
+      assert
+        .dom('[data-test-poster-board-tile="0"]')
+        .hasStyle(
+          { left: '500px', top: '120px' },
+          'note2 keeps its persisted position in its new slot',
+        );
+      assert
+        .dom(
+          `[data-test-poster-board-tile="0"] [data-test-stub-entry="${note2.id}"]`,
+        )
+        .exists('the remaining tile shows note2');
+    });
+
+    test('poster-board falls back to a not-found placeholder when a linked card has no index entry', async function (assert) {
+      let { note1 } = await makeSavedNotes();
+
+      // stubEntries stays empty with isLoading false: the settled result set
+      // simply omits the linked card, as when its index row is gone
+      await renderPosterBoard(
+        new PosterBoard({ tiles: [new BoardTile({ card: note1 })] }),
+      );
+
+      assert
+        .dom('[data-test-poster-board-broken-tile="0"]')
+        .exists('the entry-less tile renders the broken-link placeholder');
+      assert
+        .dom('[data-test-poster-board-broken-tile="0"]')
+        .hasAttribute(
+          'data-test-broken-link-state',
+          'not-found',
+          'the placeholder reports the not-found state',
+        );
+      assert
+        .dom('[data-test-stub-entry]')
+        .doesNotExist('no card content renders for the missing entry');
+    });
+
     test("poster-board queries prerendered fitted html by the linked cards' URLs", async function (assert) {
       await renderPosterBoard();
       assert.deepEqual(
@@ -275,7 +336,14 @@ export function runTests() {
       let { note1, note2 } = await makeSavedNotes();
       capturedQueries = [];
       stubEntries = [stubEntry(note1.id), stubEntry(note2.id)];
-      await renderPosterBoard(new PosterBoard({ cards: [note1, note2] }));
+      await renderPosterBoard(
+        new PosterBoard({
+          tiles: [
+            new BoardTile({ card: note1 }),
+            new BoardTile({ card: note2 }),
+          ],
+        }),
+      );
 
       let query = capturedQueries[capturedQueries.length - 1];
       assert.deepEqual(

--- a/packages/experiments-realm/poster-board/poster-board.test.gts
+++ b/packages/experiments-realm/poster-board/poster-board.test.gts
@@ -55,9 +55,15 @@ let capturedQueries: (SearchEntryWireQuery | undefined)[] = [];
 function stubEntry(id: string): RenderableSearchEntryLike {
   // The board stamps its content class through `...attributes`, the same way
   // it lands on real prerendered HTML's root element.
+  // The scroller stands in for content that owns its own wheel gestures, like
+  // the broken-link error panel.
   let component: TOC<{ Element: Element }> = <template>
+    {{! template-lint-disable no-inline-styles }}
     <div data-test-stub-entry={{id}} ...attributes>
       <button type='button' data-test-stub-entry-button>Stub button</button>
+      <div style='height: 40px; overflow-y: auto' data-test-stub-entry-scroller>
+        <div style='height: 400px'></div>
+      </div>
     </div>
   </template>;
   return {
@@ -345,7 +351,6 @@ export function runTests() {
       await renderPosterBoard(
         new PosterBoard({ tiles: [new BoardTile({ card: note1 })] }),
       );
-
       assert
         .dom('[data-test-poster-board-broken-tile="0"]')
         .hasAttribute(
@@ -391,6 +396,57 @@ export function runTests() {
         { eq: { htmlQuery: { eq: { format: 'fitted' } } } },
         'the fitted rendering is bound through htmlQuery',
       );
+    });
+
+    test('poster-board leaves wheel gestures to scrollable tile content', async function (assert) {
+      let { note1 } = await makeSavedNotes();
+      stubEntries = [stubEntry(note1.id)];
+      await renderPosterBoard(
+        new PosterBoard({ tiles: [new BoardTile({ card: note1 })] }),
+      );
+      let plane = '[data-test-poster-board-plane]';
+      let scroller = '[data-test-stub-entry-scroller]';
+      let restingTransform = document
+        .querySelector(plane)!
+        .getAttribute('style');
+
+      await triggerEvent(scroller, 'wheel', { deltaY: 120 });
+      assert
+        .dom(plane)
+        .hasAttribute(
+          'style',
+          restingTransform!,
+          'scrolling down over content that can scroll leaves the camera alone',
+        );
+
+      await triggerEvent(scroller, 'wheel', { deltaY: -120 });
+      assert
+        .dom(plane)
+        .hasAttribute(
+          'style',
+          restingTransform!,
+          'within the same gesture, reaching the content edge stays with the content',
+        );
+
+      // A pause ends the gesture; the next one starts fresh
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      await triggerEvent(scroller, 'wheel', { deltaY: -120 });
+      assert.notEqual(
+        document.querySelector(plane)!.getAttribute('style'),
+        restingTransform,
+        'a new gesture at the top of the content falls through to pan the board',
+      );
+
+      let panned = document.querySelector(plane)!.getAttribute('style');
+      await triggerEvent(scroller, 'wheel', { deltaY: -120, ctrlKey: true });
+      assert.notEqual(
+        document.querySelector(plane)!.getAttribute('style'),
+        panned,
+        'a pinch over scrollable content still zooms the board',
+      );
+      assert
+        .dom('[data-test-zoom-level]')
+        .doesNotIncludeText('100%', 'the pinch changed the zoom level');
     });
 
     test('poster-board zoom reset is not undone by pending pinch momentum', async function (assert) {

--- a/packages/experiments-realm/poster-board/poster-board.test.gts
+++ b/packages/experiments-realm/poster-board/poster-board.test.gts
@@ -10,6 +10,7 @@ import { module, test } from 'qunit';
 
 import {
   CardContextName,
+  type ErrorEntry,
   type Loader,
   type RenderableSearchEntryLike,
   type SearchEntryWireQuery,
@@ -48,6 +49,7 @@ function loaderService(): { loader: Loader } {
 // yields a test-controlled entry set, so tile mapping and the missing-entry
 // fallback are exercised deterministically without a live prerender index.
 let stubEntries: RenderableSearchEntryLike[] = [];
+let stubErrors: ErrorEntry[] | undefined;
 let capturedQueries: (SearchEntryWireQuery | undefined)[] = [];
 
 function stubEntry(id: string): RenderableSearchEntryLike {
@@ -79,7 +81,7 @@ class StubSearchResults extends GlimmerComponent<SearchResultsComponentSignature
       entries: stubEntries,
       isLoading: false,
       meta: { page: { total: stubEntries.length } },
-      errors: undefined,
+      errors: stubErrors,
     };
   }
 
@@ -111,6 +113,7 @@ export function runTests() {
 
     hooks.beforeEach(function () {
       stubEntries = [];
+      stubErrors = undefined;
       capturedQueries = [];
       // Partial by design: CardContextConsumer spreads defaults over what the
       // provider supplies, so only the member the board reads is stubbed.
@@ -323,6 +326,33 @@ export function runTests() {
       assert
         .dom('[data-test-stub-entry]')
         .doesNotExist('no card content renders for the missing entry');
+    });
+
+    test('poster-board reports a failed search as an error, not as missing cards', async function (assert) {
+      let { note1 } = await makeSavedNotes();
+      stubErrors = [
+        {
+          type: 'instance-error',
+          error: {
+            status: 500,
+            title: 'Search Error',
+            message: 'search request failed',
+            additionalErrors: null,
+          },
+        },
+      ];
+
+      await renderPosterBoard(
+        new PosterBoard({ tiles: [new BoardTile({ card: note1 })] }),
+      );
+
+      assert
+        .dom('[data-test-poster-board-broken-tile="0"]')
+        .hasAttribute(
+          'data-test-broken-link-state',
+          'error',
+          'a search failure surfaces as an error placeholder, never as a 404',
+        );
     });
 
     test("poster-board queries prerendered fitted html by the linked cards' URLs", async function (assert) {

--- a/packages/experiments-realm/tsconfig.json
+++ b/packages/experiments-realm/tsconfig.json
@@ -34,9 +34,16 @@
         "../base/*.d.ts",
         "../base/*"
       ],
-      "@cardstack/host/tests/*": ["../host/tests/*"]
+      "@cardstack/host/tests/*": ["../host/tests/*"],
+      "ember-provide-consume-context": [
+        "../base/node_modules/ember-provide-consume-context/declarations/index.d.ts"
+      ]
     },
     "types": ["@cardstack/local-types"]
   },
-  "include": ["**/*.ts", "**/*.gts"]
+  "include": [
+    "**/*.ts",
+    "**/*.gts",
+    "../host/node_modules/qunit-dom/dist/es/install.d.ts"
+  ]
 }

--- a/packages/experiments-realm/tsconfig.json
+++ b/packages/experiments-realm/tsconfig.json
@@ -34,10 +34,7 @@
         "../base/*.d.ts",
         "../base/*"
       ],
-      "@cardstack/host/tests/*": ["../host/tests/*"],
-      "ember-provide-consume-context": [
-        "../base/node_modules/ember-provide-consume-context/declarations/index.d.ts"
-      ]
+      "@cardstack/host/tests/*": ["../host/tests/*"]
     },
     "types": ["@cardstack/local-types"]
   },

--- a/packages/host/app/lib/html-component.ts
+++ b/packages/host/app/lib/html-component.ts
@@ -137,8 +137,13 @@ setComponentManager(
   _SimpleHTMLComponent.prototype,
 );
 
+// One HTMLComponent may be mounted in several places at once (a search
+// consumer that shows the same entry twice). The parsed nodes are owned by the
+// component, and appendChild would move them from the earlier mount into the
+// later one, so a mount that finds them already live in the document takes a
+// copy. Nodes left inside a torn-down root are disconnected and move freely.
 const withChildren = modifier((element: Element, [children]: [Node[]]) => {
   for (let child of children) {
-    element.appendChild(child);
+    element.appendChild(child.isConnected ? child.cloneNode(true) : child);
   }
 });

--- a/packages/host/tests/integration/components/html-component-test.gts
+++ b/packages/host/tests/integration/components/html-component-test.gts
@@ -1,0 +1,31 @@
+import { render } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import { htmlComponent } from '@cardstack/host/lib/html-component';
+
+import { setupRenderingTest } from '../../helpers/setup';
+
+module('Integration | Component | html-component', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('one component mounted twice renders its content in both places', async function (assert) {
+    let Inert = htmlComponent(
+      `<div class='card'><span data-test-inert-body>Body</span></div>`,
+    );
+
+    await render(
+      <template>
+        <div data-test-first-mount><Inert /></div>
+        <div data-test-second-mount><Inert /></div>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-first-mount] [data-test-inert-body]')
+      .hasText('Body', 'the first mount keeps its content');
+    assert
+      .dom('[data-test-second-mount] [data-test-inert-body]')
+      .hasText('Body', 'the second mount has its own content');
+  });
+});


### PR DESCRIPTION
Render prerendered html versions of selected cards on the poster board.

Sample card is in experiments-realm. Just renders the attached cards.

The live card tests are in the same directory and are not part of CI. They can be run locally via `https://localhost:4200/tests/index.html?liveTest=true&realmURL=https%3A%2F%2Flocalhost%3A4201%2Fexperiments%2F&filter=poster-board`

**Known limitation:** tiles linking a card in a prefix-mapped realm (`@cardstack/base/...`, `@cardstack/catalog/...`) render the not-found placeholder. Card links are canonicalized to the realm alias, but the search `cardUrls` filter only matches the index's URL form, so those cards get no rows back. Fixing that is outside this card: [CS-12744](https://linear.app/cardstack/issue/CS-12744) (search should match every equivalent URL form) and [CS-12745](https://linear.app/cardstack/issue/CS-12745) (realm write path rewrites alias links to resolved URLs).

Linear: [CS-12214](https://linear.app/cardstack/issue/CS-12214)

<img width="1068" height="995" alt="poster-board-render-cards" src="https://github.com/user-attachments/assets/78c63459-220c-4576-a6c0-47711df527e6" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
