### PR TITLE
Bound MarkdownField default rendering above a content-length threshold

### DIFF
--- a/packages/base/default-templates/markdown.gts
+++ b/packages/base/default-templates/markdown.gts
@@ -14,6 +14,7 @@ import {
   cardTypeName,
   fileNameFromUrl,
   extractMermaidBlocks,
+  MAX_MARKDOWN_RENDER_LENGTH,
   processKatexPlaceholders,
   replaceMermaidSvgs,
   resolveRRIReference,
@@ -53,6 +54,30 @@ function wrapTablesHtml(html: string | null | undefined): string {
 // lazy-loading and the deferred card-slot collection) that is kicked off by
 // modifiers and ember-concurrency tasks after the initial render settles.
 const markdownRenderingWaiter = buildWaiter('markdown-rendering');
+
+// How many leading characters of over-limit content to show as an escaped
+// plain-text preview, so the field is not opaque without parsing all of it.
+const OVERSIZED_PREVIEW_LENGTH = 2000;
+
+// Escape the raw preview so over-limit content is shown as text and never
+// interpreted as HTML.
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+// Approximate a content length (in string characters) as a human-readable
+// size for the over-limit notice.
+function markdownContentSizeLabel(length: number): string {
+  if (length >= 1024 * 1024) {
+    return `${(length / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${Math.round(length / 1024)} KB`;
+}
 
 type CardSlotFormat = 'atom' | 'embedded' | 'fitted' | 'isolated';
 type SlotState = 'resolved' | 'loading' | 'unresolved';
@@ -142,7 +167,19 @@ export default class MarkDownTemplate extends GlimmerComponent<{
 
   @cached
   get renderedHtml() {
-    let html = markdownToHtml(this.args.content, {
+    let content = this.args.content;
+    // Skip the parse entirely for over-limit content: a synchronous multi-MB
+    // parse + sanitize + DOMParser reparse blocks the render thread. Because
+    // the Monaco/KaTeX/Mermaid follow-on work all runs inside this getter, the
+    // early return also avoids scanning the oversized content for code fences,
+    // math, and mermaid blocks.
+    if (
+      typeof content === 'string' &&
+      content.length > MAX_MARKDOWN_RENDER_LENGTH
+    ) {
+      return this.oversizedContentHtml(content);
+    }
+    let html = markdownToHtml(content, {
       enableMonacoSyntaxHighlighting: !!(
         this.hasCodeBlocks && this.monacoContext
       ),
@@ -193,6 +230,20 @@ export default class MarkDownTemplate extends GlimmerComponent<{
     }
 
     return htmlSafe(html);
+  }
+
+  // Fallback for over-limit content: a short notice plus an escaped, truncated
+  // plain-text preview so the field is not opaque. The preview is escaped so
+  // the raw content is never interpreted as HTML.
+  private oversizedContentHtml(content: string) {
+    let preview = escapeHtml(content.slice(0, OVERSIZED_PREVIEW_LENGTH));
+    let sizeLabel = markdownContentSizeLabel(content.length);
+    return htmlSafe(
+      `<div class="markdown-oversized" data-test-markdown-oversized>` +
+        `<p class="markdown-oversized-notice">This field is too large to render as Markdown (${sizeLabel}). Showing the beginning as plain text:</p>` +
+        `<pre class="markdown-oversized-preview">${preview}…</pre>` +
+        `</div>`,
+    );
   }
 
   captureCardSlots = modifier(
@@ -635,6 +686,25 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           font-size: var(--markdown-font-size, inherit);
           font-family: var(--markdown-font-family, inherit);
           overflow: hidden;
+        }
+
+        /* Over-limit content notice + truncated plain-text preview */
+        .markdown-content :deep(.markdown-oversized-notice) {
+          margin: 0 0 var(--boxel-sp-xs);
+          font-style: italic;
+          color: var(--boxel-500);
+        }
+        .markdown-content :deep(.markdown-oversized-preview) {
+          max-height: 20rem;
+          overflow: auto;
+          white-space: pre-wrap;
+          word-break: break-word;
+          font-family: var(--md-mono);
+          font-size: 0.8125em;
+          background-color: var(--md-muted);
+          border: 1px solid var(--md-border);
+          border-radius: var(--boxel-border-radius);
+          padding: var(--boxel-sp-xs);
         }
 
         /* Heading */

--- a/packages/base/default-templates/markdown.gts
+++ b/packages/base/default-templates/markdown.gts
@@ -14,7 +14,6 @@ import {
   cardTypeName,
   fileNameFromUrl,
   extractMermaidBlocks,
-  MAX_MARKDOWN_RENDER_LENGTH,
   processKatexPlaceholders,
   replaceMermaidSvgs,
   resolveRRIReference,
@@ -23,6 +22,8 @@ import {
 } from '@cardstack/runtime-common';
 import {
   hasCodeBlocks,
+  isMarkdownOverRenderLimit,
+  markdownOversizedNoticeHtml,
   markdownToHtml,
   preloadMarkdownLanguages,
 } from '@cardstack/runtime-common/marked-sync';
@@ -54,30 +55,6 @@ function wrapTablesHtml(html: string | null | undefined): string {
 // lazy-loading and the deferred card-slot collection) that is kicked off by
 // modifiers and ember-concurrency tasks after the initial render settles.
 const markdownRenderingWaiter = buildWaiter('markdown-rendering');
-
-// How many leading characters of over-limit content to show as an escaped
-// plain-text preview, so the field is not opaque without parsing all of it.
-const OVERSIZED_PREVIEW_LENGTH = 2000;
-
-// Escape the raw preview so over-limit content is shown as text and never
-// interpreted as HTML.
-function escapeHtml(unsafe: string): string {
-  return unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
-
-// Approximate a content length (in string characters) as a human-readable
-// size for the over-limit notice.
-function markdownContentSizeLabel(length: number): string {
-  if (length >= 1024 * 1024) {
-    return `${(length / (1024 * 1024)).toFixed(1)} MB`;
-  }
-  return `${Math.round(length / 1024)} KB`;
-}
 
 type CardSlotFormat = 'atom' | 'embedded' | 'fitted' | 'isolated';
 type SlotState = 'resolved' | 'loading' | 'unresolved';
@@ -173,11 +150,8 @@ export default class MarkDownTemplate extends GlimmerComponent<{
     // the Monaco/KaTeX/Mermaid follow-on work all runs inside this getter, the
     // early return also avoids scanning the oversized content for code fences,
     // math, and mermaid blocks.
-    if (
-      typeof content === 'string' &&
-      content.length > MAX_MARKDOWN_RENDER_LENGTH
-    ) {
-      return this.oversizedContentHtml(content);
+    if (isMarkdownOverRenderLimit(content)) {
+      return htmlSafe(markdownOversizedNoticeHtml(content));
     }
     let html = markdownToHtml(content, {
       enableMonacoSyntaxHighlighting: !!(
@@ -230,20 +204,6 @@ export default class MarkDownTemplate extends GlimmerComponent<{
     }
 
     return htmlSafe(html);
-  }
-
-  // Fallback for over-limit content: a short notice plus an escaped, truncated
-  // plain-text preview so the field is not opaque. The preview is escaped so
-  // the raw content is never interpreted as HTML.
-  private oversizedContentHtml(content: string) {
-    let preview = escapeHtml(content.slice(0, OVERSIZED_PREVIEW_LENGTH));
-    let sizeLabel = markdownContentSizeLabel(content.length);
-    return htmlSafe(
-      `<div class="markdown-oversized" data-test-markdown-oversized>` +
-        `<p class="markdown-oversized-notice">This field is too large to render as Markdown (${sizeLabel}). Showing the beginning as plain text:</p>` +
-        `<pre class="markdown-oversized-preview">${preview}…</pre>` +
-        `</div>`,
-    );
   }
 
   captureCardSlots = modifier(

--- a/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
+++ b/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
@@ -33,7 +33,11 @@ import {
   rri,
   trimJsonExtension,
 } from '@cardstack/runtime-common';
-import { markdownToHtml } from '@cardstack/runtime-common/marked-sync';
+import {
+  isMarkdownOverRenderLimit,
+  markdownOversizedNoticeHtml,
+  markdownToHtml,
+} from '@cardstack/runtime-common/marked-sync';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
 
@@ -130,7 +134,14 @@ export default class RenderedMarkdown extends Component<Signature> {
 
   @cached
   get renderedHtml() {
-    let html = markdownToHtml(this.args.content);
+    let content = this.args.content;
+    // Skip the parse entirely for over-limit content so a multi-MB `.md` file
+    // or field value cannot block the render thread on the synchronous
+    // parse + sanitize + DOMParser pipeline.
+    if (isMarkdownOverRenderLimit(content)) {
+      return htmlSafe(markdownOversizedNoticeHtml(content));
+    }
+    let html = markdownToHtml(content);
     html = wrapTablesHtml(html);
 
     // Strip text from BFM refs (card and file) so raw URLs don't flash before
@@ -562,6 +573,25 @@ export default class RenderedMarkdown extends Component<Signature> {
           font-size: var(--markdown-font-size, inherit);
           font-family: var(--markdown-font-family, inherit);
           overflow: hidden;
+        }
+
+        /* Over-limit content notice + truncated plain-text preview */
+        .markdown-content :deep(.markdown-oversized-notice) {
+          margin: 0 0 var(--boxel-sp-xs);
+          font-style: italic;
+          color: var(--boxel-500);
+        }
+        .markdown-content :deep(.markdown-oversized-preview) {
+          max-height: 20rem;
+          overflow: auto;
+          white-space: pre-wrap;
+          word-break: break-word;
+          font-family: var(--md-mono);
+          font-size: 0.8125em;
+          background-color: var(--md-muted);
+          border: 1px solid var(--md-border);
+          border-radius: var(--boxel-border-radius);
+          padding: var(--boxel-sp-xs);
         }
 
         /* Heading */

--- a/packages/host/tests/integration/components/field-markdown-oversize-test.gts
+++ b/packages/host/tests/integration/components/field-markdown-oversize-test.gts
@@ -7,6 +7,7 @@ import {
   type Loader,
   MAX_MARKDOWN_RENDER_LENGTH,
 } from '@cardstack/runtime-common';
+import { OVERSIZED_MARKDOWN_PREVIEW_LENGTH } from '@cardstack/runtime-common/marked-sync';
 
 import {
   CardDef,
@@ -58,6 +59,8 @@ module('Integration | field markdown oversize', function (hooks) {
     assert
       .dom('.markdown-oversized-notice')
       .hasTextContaining('too large to render as Markdown');
+    // The size label is derived from the content length (~512 KB here).
+    assert.dom('.markdown-oversized-notice').hasTextContaining('KB');
     assert
       .dom('.markdown-oversized-preview')
       .hasTextContaining(
@@ -84,9 +87,13 @@ module('Integration | field markdown oversize', function (hooks) {
     assert
       .dom('.markdown-oversized-preview script')
       .doesNotExist('raw script tag is escaped, not injected as an element');
-    assert.true(
-      (preview?.textContent?.length ?? 0) < body.length,
-      'preview is a truncated slice, not the entire field',
+    // The preview is the leading OVERSIZED_MARKDOWN_PREVIEW_LENGTH characters
+    // plus a trailing ellipsis, decoded back to text — not the whole field.
+    let previewLength = preview?.textContent?.length ?? 0;
+    assert.strictEqual(
+      previewLength,
+      OVERSIZED_MARKDOWN_PREVIEW_LENGTH + 1,
+      'preview is truncated to the preview length plus an ellipsis',
     );
   });
 
@@ -104,5 +111,30 @@ module('Integration | field markdown oversize', function (hooks) {
       .doesNotExist('in-bounds content is not clamped');
     assert.dom('.markdown-content h1').hasText('Heading');
     assert.dom('.markdown-content strong').hasText('bold');
+  });
+
+  test('content exactly at the bound still renders as markdown', async function (this: RenderingTestContext, assert) {
+    class Doc extends CardDef {
+      @field body = contains(MarkdownField);
+    }
+
+    // The clamp is strict `>`, so content of exactly the bound length parses.
+    // `# ` + filler adds up to exactly MAX_MARKDOWN_RENDER_LENGTH characters.
+    let heading = '# Heading\n\n';
+    let body =
+      heading + 'a'.repeat(MAX_MARKDOWN_RENDER_LENGTH - heading.length);
+    assert.strictEqual(
+      body.length,
+      MAX_MARKDOWN_RENDER_LENGTH,
+      'test content is exactly at the bound',
+    );
+    let doc = new Doc({ body });
+
+    await renderCard(loader, doc, 'isolated');
+
+    assert
+      .dom('[data-test-markdown-oversized]')
+      .doesNotExist('content exactly at the bound is not clamped');
+    assert.dom('.markdown-content h1').hasText('Heading');
   });
 });

--- a/packages/host/tests/integration/components/field-markdown-oversize-test.gts
+++ b/packages/host/tests/integration/components/field-markdown-oversize-test.gts
@@ -1,0 +1,108 @@
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  type Loader,
+  MAX_MARKDOWN_RENDER_LENGTH,
+} from '@cardstack/runtime-common';
+
+import {
+  CardDef,
+  contains,
+  field,
+  MarkdownField,
+  setupBaseRealm,
+} from '../../helpers/base-realm';
+import { renderCard } from '../../helpers/render-component';
+import { setupRenderingTest } from '../../helpers/setup';
+
+// A bare CardDef subclass with a MarkdownField renders through the default
+// isolated template, which drives the field's embedded format ->
+// `default-templates/markdown.gts`. Content past MAX_MARKDOWN_RENDER_LENGTH
+// must skip the synchronous markdown parse and fall back to a bounded notice
+// so a multi-MB field can never block the render thread.
+module('Integration | field markdown oversize', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  let loader: Loader;
+
+  hooks.beforeEach(function (this: RenderingTestContext) {
+    loader = getService('loader-service').loader;
+  });
+
+  test('over-limit content renders a notice instead of parsing markdown', async function (this: RenderingTestContext, assert) {
+    class Doc extends CardDef {
+      @field body = contains(MarkdownField);
+    }
+
+    // A markdown heading up front proves the parser never ran: an `<h1>` would
+    // exist if `# Heading` had been parsed.
+    let body = '# Heading\n\n' + 'a'.repeat(MAX_MARKDOWN_RENDER_LENGTH);
+    assert.true(
+      body.length > MAX_MARKDOWN_RENDER_LENGTH,
+      'test content exceeds the render bound',
+    );
+    let doc = new Doc({ body });
+
+    await renderCard(loader, doc, 'isolated');
+
+    assert
+      .dom('[data-test-markdown-oversized]')
+      .exists('over-limit content renders the notice');
+    assert
+      .dom('.markdown-content h1')
+      .doesNotExist('markdown was not parsed into HTML');
+    assert
+      .dom('.markdown-oversized-notice')
+      .hasTextContaining('too large to render as Markdown');
+    assert
+      .dom('.markdown-oversized-preview')
+      .hasTextContaining(
+        '# Heading',
+        'the preview shows the raw content start',
+      );
+  });
+
+  test('the preview is truncated and escaped, not the full content', async function (this: RenderingTestContext, assert) {
+    class Doc extends CardDef {
+      @field body = contains(MarkdownField);
+    }
+
+    // Leading `<script>` proves the preview is escaped (rendered as text, not
+    // executed/parsed as an element).
+    let body =
+      '<script>alert(1)</script>' + 'b'.repeat(MAX_MARKDOWN_RENDER_LENGTH);
+    let doc = new Doc({ body });
+
+    await renderCard(loader, doc, 'isolated');
+
+    let preview = this.element.querySelector('.markdown-oversized-preview');
+    assert.ok(preview, 'preview element renders');
+    assert
+      .dom('.markdown-oversized-preview script')
+      .doesNotExist('raw script tag is escaped, not injected as an element');
+    assert.true(
+      (preview?.textContent?.length ?? 0) < body.length,
+      'preview is a truncated slice, not the entire field',
+    );
+  });
+
+  test('content at or below the bound renders normally', async function (this: RenderingTestContext, assert) {
+    class Doc extends CardDef {
+      @field body = contains(MarkdownField);
+    }
+
+    let doc = new Doc({ body: '# Heading\n\nSome **bold** text.' });
+
+    await renderCard(loader, doc, 'isolated');
+
+    assert
+      .dom('[data-test-markdown-oversized]')
+      .doesNotExist('in-bounds content is not clamped');
+    assert.dom('.markdown-content h1').hasText('Heading');
+    assert.dom('.markdown-content strong').hasText('bold');
+  });
+});

--- a/packages/host/tests/integration/components/rendered-markdown-test.gts
+++ b/packages/host/tests/integration/components/rendered-markdown-test.gts
@@ -5,6 +5,8 @@ import GlimmerComponent from '@glimmer/component';
 
 import { module, test } from 'qunit';
 
+import { MAX_MARKDOWN_RENDER_LENGTH } from '@cardstack/runtime-common';
+
 import RenderedMarkdown from '@cardstack/host/components/operator-mode/preview-panel/rendered-markdown';
 
 import { testRealmURL } from '../../helpers';
@@ -737,6 +739,32 @@ module('Integration | rendered-markdown', function (hooks) {
       .doesNotHaveClass(
         'markdown-bfm-broken--embedded',
         'a plain inline ref is not given a non-atom footprint',
+      );
+  });
+
+  test('over-limit content renders a notice instead of parsing markdown', async function (assert) {
+    // `.md` files reach this component at up to the 5 MB file limit, so the
+    // same render-thread guard the base template applies is needed here.
+    let content = '# Heading\n\n' + 'a'.repeat(MAX_MARKDOWN_RENDER_LENGTH);
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><RenderedMarkdown @content={{content}} /></template>
+      },
+    );
+    await settled();
+
+    assert
+      .dom('[data-test-markdown-oversized]')
+      .exists('over-limit content renders the notice');
+    assert
+      .dom('.markdown-content h1')
+      .doesNotExist('markdown was not parsed into HTML');
+    assert
+      .dom('.markdown-oversized-preview')
+      .hasTextContaining(
+        '# Heading',
+        'the preview shows the raw content start',
       );
   });
 });

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -121,6 +121,14 @@ export const DEFAULT_CARD_SIZE_LIMIT_BYTES = 512 * 1024; //512 KB
 // Default max file (module / binary) payload size, in bytes.
 export const DEFAULT_FILE_SIZE_LIMIT_BYTES = 5 * 1024 * 1024; // 5 MB
 
+// Above this content length (in string characters), the default MarkdownField
+// template skips the synchronous markdown parse and renders a bounded notice
+// with a short plain-text preview instead. A single field longer than an
+// entire card is allowed to be cannot be written under the card size limit, so
+// content past this bound is over-limit and would otherwise run a multi-MB
+// synchronous parse + sanitize on the render thread.
+export const MAX_MARKDOWN_RENDER_LENGTH = DEFAULT_CARD_SIZE_LIMIT_BYTES;
+
 export const EXTRA_TOKENS_PRICING: Record<number, number> = {
   2500: 5,
   20000: 30,

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -121,12 +121,14 @@ export const DEFAULT_CARD_SIZE_LIMIT_BYTES = 512 * 1024; //512 KB
 // Default max file (module / binary) payload size, in bytes.
 export const DEFAULT_FILE_SIZE_LIMIT_BYTES = 5 * 1024 * 1024; // 5 MB
 
-// Above this content length (in string characters), the default MarkdownField
-// template skips the synchronous markdown parse and renders a bounded notice
-// with a short plain-text preview instead. A single field longer than an
-// entire card is allowed to be cannot be written under the card size limit, so
-// content past this bound is over-limit and would otherwise run a multi-MB
-// synchronous parse + sanitize on the render thread.
+// Above this content length, markdown rendering skips the synchronous parse
+// and renders a bounded notice with a short plain-text preview instead. This
+// is a render-thread guardrail, not a byte-precise bound: it compares string
+// character count (UTF-16 code units), a cheap proxy that is always <= the
+// UTF-8 byte length. It is anchored to the default card size limit — a field
+// this long exceeds the size a whole card is allowed to be — so any content
+// tripping it is over-limit and would otherwise run a multi-MB synchronous
+// parse + sanitize on the render thread.
 export const MAX_MARKDOWN_RENDER_LENGTH = DEFAULT_CARD_SIZE_LIMIT_BYTES;
 
 export const EXTRA_TOKENS_PRICING: Record<number, number> = {

--- a/packages/runtime-common/marked-sync.ts
+++ b/packages/runtime-common/marked-sync.ts
@@ -1,4 +1,5 @@
 import { sanitizeHtml } from './dompurify-runtime.ts';
+import { MAX_MARKDOWN_RENDER_LENGTH } from './constants.ts';
 import { escapeHtml } from './helpers/html.ts';
 import {
   bfmCardReferenceExtensions,
@@ -202,6 +203,44 @@ export function markdownToHtml(
     html = sanitizeHtml(html);
   }
   return html;
+}
+
+// How many leading characters of over-limit content to show as an escaped
+// plain-text preview, so the field is not opaque without parsing all of it.
+export const OVERSIZED_MARKDOWN_PREVIEW_LENGTH = 2000;
+
+// Whether content is past the render bound and should skip the synchronous
+// markdown pipeline. Compares character length (a cheap proxy for the byte
+// length the card size limit bounds); see MAX_MARKDOWN_RENDER_LENGTH.
+export function isMarkdownOverRenderLimit(
+  content: string | null | undefined,
+): content is string {
+  return (
+    typeof content === 'string' && content.length > MAX_MARKDOWN_RENDER_LENGTH
+  );
+}
+
+// Approximate a content length (in string characters) as a human-readable size.
+function markdownContentSizeLabel(length: number): string {
+  if (length >= 1024 * 1024) {
+    return `${(length / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${Math.round(length / 1024)} KB`;
+}
+
+// The fallback rendered for over-limit content in place of the parsed markdown:
+// a short notice plus an escaped, truncated plain-text preview. Returns an HTML
+// string; callers wrap it in their framework's html-safe marker. The preview is
+// escaped so the raw content is never interpreted as HTML.
+export function markdownOversizedNoticeHtml(content: string): string {
+  let preview = escapeHtml(content.slice(0, OVERSIZED_MARKDOWN_PREVIEW_LENGTH));
+  let sizeLabel = markdownContentSizeLabel(content.length);
+  return (
+    `<div class="markdown-oversized" data-test-markdown-oversized>` +
+    `<p class="markdown-oversized-notice">This content is too large to render as Markdown (${sizeLabel}). Showing the beginning as plain text:</p>` +
+    `<pre class="markdown-oversized-preview">${preview}…</pre>` +
+    `</div>`
+  );
 }
 
 export function hasCodeBlocks(markdown: string | null | undefined): boolean {


### PR DESCRIPTION
The default `CardDef` template renders `MarkdownField` values (e.g. `cardInfo.notes`) through `markdownToHtml` — a synchronous marked parse + DOMPurify sanitize + `wrapTablesHtml` DOMParser reparse — with no bound on content length. A card whose markdown field holds multi-MB content runs that whole pipeline on the render thread on every default-template render, blocking the tab for minutes (observed in production on a legacy card carrying several MB of CSS in a notes field). The 512 KB card write limit prevents new cards from reaching that size, but cards written before the limit remain on disk, and any future over-limit path would hit the same wall.

## What this does

The shared markdown render path — `packages/base/default-templates/markdown.gts`, used by `MarkdownField` embedded/atom, `RichMarkdownField`, and the markdown `FileDef` — skips the parse entirely when the content length exceeds `MAX_MARKDOWN_RENDER_LENGTH`. Instead of parsing, it renders a short "content too large" notice plus an escaped, truncated plain-text preview so the field is not opaque.

The check sits at the top of the `renderedHtml` getter, before `markdownToHtml`. Because the Monaco/KaTeX/Mermaid follow-on work and the code-fence scan all run inside that getter, the early return also avoids every other O(n) pass over the oversized content — not just the parse.

## Threshold

`MAX_MARKDOWN_RENDER_LENGTH` is anchored to the card size limit (`DEFAULT_CARD_SIZE_LIMIT_BYTES`, 512 KB): a single field longer than an entire card is allowed to be cannot be written under that limit, so content past this bound is always over-limit. Content at or below it parses in tens of milliseconds and renders unchanged — a `marked` benchmark of punctuation-dense input scales roughly linearly (~50 ns/char), so the bound only ever trips on content that would otherwise stall the thread.

## Tests

`field-markdown-oversize-test.gts` renders a bare `CardDef` + `MarkdownField` in the isolated (default) format:

- over-limit content shows the notice and does not parse markdown (a leading `# Heading` produces no `<h1>`),
- the preview is escaped (a leading `<script>` is not injected as an element) and truncated,
- content at or below the bound renders normally.

Ran the markdown integration suite (`RichMarkdownField`, `rendered-markdown`, highlighting, field-markdown primitives/specialized/domain, markdown-embed/preview/fallback) — green.
