### PR TITLE
Give the SF template build a realistic queue-idle budget + diagnostics

### DIFF
--- a/packages/realm-test-harness/src/database.ts
+++ b/packages/realm-test-harness/src/database.ts
@@ -723,35 +723,135 @@ function startIndexingProgressReporter(
   };
 }
 
+// A combined-template build reaches "realm server ready" once the pinned base
+// realm is indexed, but the non-pinned user realms are still
+// from-scratch-indexing when this wait begins — and after each realm's index
+// job resolves, its whole-realm prerender_html job (every card's HTML) drains
+// through the same queue. On a slow or loaded runner that legitimately-remaining
+// work runs well past a 30s window, so a tight timeout kills a build that is in
+// fact still making steady progress (the indexing progress reporter keeps
+// printing throughout). Budget generously, matching the realm-server multi-realm
+// helper that drains the identical prerender_html tail. Override via env for
+// local iteration.
+const QUEUE_IDLE_TIMEOUT_MS = Number(
+  process.env.TEST_HARNESS_QUEUE_IDLE_TIMEOUT_MS ?? 300_000,
+);
+
 export async function waitForQueueIdle(databaseName: string): Promise<void> {
   await logTimed(templateLog, `waitForQueueIdle ${databaseName}`, async () => {
-    await waitUntil(
-      async () => {
-        let client = new PgClient(pgAdminConnectionConfig(databaseName));
-        try {
-          await client.connect();
-          let {
-            rows: [{ count: unfulfilledJobs }],
-          } = await client.query<{ count: number }>(
-            `SELECT COUNT(*)::int AS count FROM jobs WHERE status = 'unfulfilled'`,
-          );
-          let {
-            rows: [{ count: activeReservations }],
-          } = await client.query<{ count: number }>(
-            `SELECT COUNT(*)::int AS count FROM job_reservations WHERE completed_at IS NULL`,
-          );
-          return unfulfilledJobs === 0 && activeReservations === 0;
-        } finally {
-          await client.end();
-        }
-      },
-      {
-        timeout: 30_000,
-        interval: 100,
-        timeoutMessage: `Timed out waiting for queue to become idle in ${databaseName}`,
-      },
-    );
+    try {
+      await waitUntil(
+        async () => {
+          let client = new PgClient(pgAdminConnectionConfig(databaseName));
+          try {
+            await client.connect();
+            // A rejected job means the template would snapshot with silently
+            // missing data (e.g. absent prerendered HTML) and resurface later
+            // as confusing failures in unrelated tests. Fail here, loudly and
+            // immediately, instead of draining the full timeout first.
+            let { rows: rejected } = await client.query<{
+              id: number;
+              job_type: string;
+            }>(`SELECT id, job_type FROM jobs WHERE status = 'rejected'`);
+            if (rejected.length > 0) {
+              throw new Error(
+                `job(s) rejected while waiting for queue to become idle in ${databaseName}: ${rejected
+                  .map((row) => `${row.job_type}#${row.id}`)
+                  .join(', ')}`,
+              );
+            }
+            let {
+              rows: [{ count: unfulfilledJobs }],
+            } = await client.query<{ count: number }>(
+              `SELECT COUNT(*)::int AS count FROM jobs WHERE status = 'unfulfilled'`,
+            );
+            let {
+              rows: [{ count: activeReservations }],
+            } = await client.query<{ count: number }>(
+              `SELECT COUNT(*)::int AS count FROM job_reservations WHERE completed_at IS NULL`,
+            );
+            return unfulfilledJobs === 0 && activeReservations === 0;
+          } finally {
+            await client.end();
+          }
+        },
+        {
+          timeout: QUEUE_IDLE_TIMEOUT_MS,
+          interval: 100,
+          timeoutMessage: `Timed out waiting for queue to become idle in ${databaseName}`,
+        },
+      );
+    } catch (error) {
+      // Whether we timed out or bailed on a rejected job, dump what the queue
+      // still holds so the next CI failure is diagnosable in one pass — is it a
+      // slow-but-progressing prerender_html drain (raise the budget) or a
+      // genuinely wedged worker holding a reservation (a real bug)?
+      let backlog = await describeQueueBacklog(databaseName).catch(
+        (e) =>
+          `  (failed to gather queue diagnostics: ${(e as Error).message})`,
+      );
+      let err = error instanceof Error ? error : new Error(String(error));
+      err.message = `${err.message}\n${backlog}`;
+      throw err;
+    }
   });
+}
+
+// Snapshot of what the queue still holds, for the waitForQueueIdle failure
+// path. Best-effort: any query error is reported inline rather than masking the
+// original timeout / rejection.
+async function describeQueueBacklog(databaseName: string): Promise<string> {
+  let client = new PgClient(pgAdminConnectionConfig(databaseName));
+  try {
+    await client.connect();
+    let { rows: statusRows } = await client.query<{
+      status: string;
+      job_type: string;
+      count: number;
+    }>(
+      `SELECT status, job_type, COUNT(*)::int AS count
+         FROM jobs
+        WHERE status IN ('unfulfilled', 'rejected')
+        GROUP BY status, job_type
+        ORDER BY status, count DESC`,
+    );
+    let { rows: reservationRows } = await client.query<{
+      job_id: number;
+      job_type: string | null;
+      worker_id: string | null;
+      age_s: number | null;
+      locked_for_s: number | null;
+    }>(
+      `SELECT jr.job_id, j.job_type, jr.worker_id,
+              EXTRACT(EPOCH FROM (now() - jr.created_at))::int AS age_s,
+              EXTRACT(EPOCH FROM (jr.locked_until - now()))::int AS locked_for_s
+         FROM job_reservations jr
+         LEFT JOIN jobs j ON j.id = jr.job_id
+        WHERE jr.completed_at IS NULL
+        ORDER BY jr.created_at ASC
+        LIMIT 20`,
+    );
+    let jobs =
+      statusRows.length > 0
+        ? statusRows
+            .map((r) => `${r.job_type}[${r.status}]=${r.count}`)
+            .join(', ')
+        : 'none';
+    let reservations =
+      reservationRows.length > 0
+        ? reservationRows
+            .map(
+              (r) =>
+                `job ${r.job_id} (${r.job_type ?? '?'}) worker=${
+                  r.worker_id ?? '?'
+                } age=${r.age_s ?? '?'}s locked_for=${r.locked_for_s ?? '?'}s`,
+            )
+            .join('\n    ')
+        : 'none';
+    return `  pending jobs: ${jobs}\n  in-flight reservations (oldest first):\n    ${reservations}`;
+  } finally {
+    await client.end().catch(() => undefined);
+  }
 }
 
 /**

--- a/packages/realm-test-harness/src/database.ts
+++ b/packages/realm-test-harness/src/database.ts
@@ -732,10 +732,13 @@ function startIndexingProgressReporter(
 // fact still making steady progress (the indexing progress reporter keeps
 // printing throughout). Budget generously, matching the realm-server multi-realm
 // helper that drains the identical prerender_html tail. Override via env for
-// local iteration.
-const QUEUE_IDLE_TIMEOUT_MS = Number(
-  process.env.TEST_HARNESS_QUEUE_IDLE_TIMEOUT_MS ?? 300_000,
-);
+// local iteration; a malformed override (empty string coerces to 0,
+// non-numeric to NaN) is ignored rather than allowed to collapse the wait into
+// an immediate failure.
+const QUEUE_IDLE_TIMEOUT_MS = (() => {
+  let override = Number(process.env.TEST_HARNESS_QUEUE_IDLE_TIMEOUT_MS);
+  return Number.isFinite(override) && override > 0 ? override : 300_000;
+})();
 
 export async function waitForQueueIdle(databaseName: string): Promise<void> {
   await logTimed(templateLog, `waitForQueueIdle ${databaseName}`, async () => {
@@ -752,12 +755,21 @@ export async function waitForQueueIdle(databaseName: string): Promise<void> {
             let { rows: rejected } = await client.query<{
               id: number;
               job_type: string;
-            }>(`SELECT id, job_type FROM jobs WHERE status = 'rejected'`);
+            }>(
+              `SELECT id, job_type FROM jobs WHERE status = 'rejected' ORDER BY id`,
+            );
             if (rejected.length > 0) {
+              let sampleLimit = 20;
+              let sample = rejected
+                .slice(0, sampleLimit)
+                .map((row) => `${row.job_type}#${row.id}`)
+                .join(', ');
+              let overflow =
+                rejected.length > sampleLimit
+                  ? ` (+${rejected.length - sampleLimit} more)`
+                  : '';
               throw new Error(
-                `job(s) rejected while waiting for queue to become idle in ${databaseName}: ${rejected
-                  .map((row) => `${row.job_type}#${row.id}`)
-                  .join(', ')}`,
+                `${rejected.length} job(s) rejected while waiting for queue to become idle in ${databaseName}: ${sample}${overflow}`,
               );
             }
             let {


### PR DESCRIPTION
The software-factory Playwright shards build a combined template database once before any test runs (the `cache:prepare` step). That build spins up an isolated realm stack, full-indexes the base realm plus the fixture realms, then calls `waitForQueueIdle` to make sure the job queue has fully drained before it snapshots the database for the tests to clone.

The realm server reports "ready" as soon as the *pinned* base realm is indexed — but the non-pinned fixture realms are still from-scratch-indexing at that point, and after each realm's index job resolves its whole-realm `prerender_html` job (one per card) drains through the same queue. So when `waitForQueueIdle` starts, there can legitimately be a full multi-realm index tail plus a large batch of prerender jobs left to process. The harness gave that only a **30s** window. On a slow or loaded CI runner it doesn't finish in time, `waitForQueueIdle` times out, and the whole shard fails during setup — before a single test executes. On a healthy runner the same work drains comfortably, which is why it only shows up intermittently.

The sibling `waitForQueueIdle` in the realm-server multi-realm helper drains the *identical* prerender_html tail and already budgets 300s for exactly this reason, with a comment explaining why. The harness copy was simply never brought in line.

This change:

- Raises the harness budget to 300s (env-overridable via `TEST_HARNESS_QUEUE_IDLE_TIMEOUT_MS`) so a slow-but-progressing drain isn't killed mid-flight.
- Fails fast if any job is `rejected` instead of waiting out the full timeout — a rejected job means the snapshot would silently miss data (e.g. absent prerendered HTML) and resurface as confusing failures in unrelated tests, so it's better to surface it loudly and immediately.
- On any failure (timeout or rejection), dumps what the queue still holds: unfulfilled/rejected jobs grouped by type, and the oldest open reservations with worker id, age, and remaining lock time. If the raised budget turns out not to be enough, the next failure will say in one pass whether it's a slow-but-progressing prerender drain (raise the budget further) or a genuinely wedged worker holding a reservation (a real bug worth chasing).

The generous timeout matches the established sibling; the fail-fast and the backlog dump are the diagnostic insurance for the case where it still isn't sufficient.

### Verification

- `pnpm lint` (types + eslint/prettier) on `@cardstack/realm-test-harness` is green.
- The three diagnostic queries were run against Postgres 16 in a throwaway database seeded with a mix of rejected/unfulfilled jobs and open/completed reservations; each returns and formats as intended, and the completed reservation is correctly excluded from the in-flight list.

The timeout itself is a CI-load-dependent race and isn't reproducible on a fast local machine, which is exactly why the fix pairs a realistic budget with diagnostics rather than a tighter assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
