### PR TITLE
Client: hydrate ai-bot to-device streaming previews into room messages

### DIFF
--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -25,9 +25,13 @@ import {
   getToolRequests,
   isToolResultRelType,
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
+  APP_BOXEL_MESSAGE_MSGTYPE,
   APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE,
+  APP_BOXEL_REASONING_CONTENT_KEY,
+  APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_LLM_MODE,
   DEFAULT_FALLBACK_MODEL_ID,
+  type AppBoxelResponseStreamContent,
   type LLMMode,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -94,6 +98,12 @@ interface Args {
 export class RoomResource extends Resource<Args> {
   #skillIds = new Set<string>();
   #hasRegisteredDestructor = false;
+  #responseStreamPreviewDisposer: (() => void) | undefined;
+  // Highest to-device preview `sequence` applied per streaming message
+  // (keyed by parentEventId). Previews carry full accumulated state, so an
+  // out-of-order or duplicate delivery is simply dropped rather than regressing
+  // the message to older content.
+  #lastPreviewSequence = new Map<string, number>();
   private _messageCache: TrackedMap<string, Message> = new TrackedMap();
   private _nameEventsCache: TrackedMap<string, RoomNameEvent> =
     new TrackedMap();
@@ -123,6 +133,10 @@ export class RoomResource extends Resource<Args> {
     this.processing = this.processRoomTask.perform(named.roomId);
     if (!this.#hasRegisteredDestructor) {
       this.#hasRegisteredDestructor = true;
+      this.#responseStreamPreviewDisposer =
+        this.matrixService.onResponseStreamPreview((payload) =>
+          this.hydrateResponseStreamPreview(payload),
+        );
       registerDestructor(this, () => this.teardown());
     }
   }
@@ -131,6 +145,9 @@ export class RoomResource extends Resource<Args> {
     this.processRoomTask.cancelAll();
     this.activateLLMTask.cancelAll();
     this.activateLLMModeTask.cancelAll();
+    this.#responseStreamPreviewDisposer?.();
+    this.#responseStreamPreviewDisposer = undefined;
+    this.#lastPreviewSequence.clear();
     for (let id of this.#skillIds ?? []) {
       this.store.dropReference(id);
     }
@@ -713,6 +730,66 @@ export class RoomResource extends Resource<Args> {
         continuedFromMessage.continuedInMessage = message;
       }
     }
+  }
+
+  // Hydrate an in-flight `app.boxel.response-stream` to-device preview (ai-bot
+  // in AI_BOT_STREAMING_MODE=to-device) into the same Message the final room
+  // edit will eventually reconcile. Shaping the preview as the CardMessage edit
+  // it mirrors lets us reuse MessageBuilder.updateMessage — including its tool
+  // request chunk merging — and its `setUpdated(new Date())` resets the
+  // streaming stall timeout so long responses don't trip the fallback.
+  private async hydrateResponseStreamPreview(
+    payload: AppBoxelResponseStreamContent,
+  ) {
+    if (!payload || payload.roomId !== this.roomId) {
+      return;
+    }
+    let message = this._messageCache.get(payload.parentEventId);
+    // Either the thinking placeholder this preview belongs to hasn't loaded
+    // yet, or the turn already landed its final consolidated room edit. In both
+    // cases the room-event path is authoritative and reconciles the true state,
+    // so there is nothing for an ephemeral preview to add.
+    if (!message || message.isStreamingOfEventFinished) {
+      return;
+    }
+    let lastSequence =
+      this.#lastPreviewSequence.get(payload.parentEventId) ?? -1;
+    if (payload.sequence <= lastSequence) {
+      return;
+    }
+    this.#lastPreviewSequence.set(payload.parentEventId, payload.sequence);
+
+    let author = this.upsertRoomMember({
+      roomId: payload.roomId,
+      userId: this.matrixService.aiBotUserId,
+    });
+    // origin_server_ts is pinned to the message's creation time so a preview
+    // never advances past — and thus never suppresses (see
+    // MessageBuilder.applyToolRequestChunk) — the real, later final room edit.
+    let syntheticEvent = {
+      type: 'm.room.message',
+      event_id: payload.parentEventId,
+      room_id: payload.roomId,
+      sender: this.matrixService.aiBotUserId,
+      origin_server_ts: message.created.getTime(),
+      content: {
+        msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+        body: payload.body,
+        [APP_BOXEL_REASONING_CONTENT_KEY]: payload.reasoning,
+        [APP_BOXEL_TOOL_REQUESTS_KEY]: payload.toolRequests,
+        isStreamingFinished: false,
+      },
+    } as unknown as CardMessageEvent;
+
+    let messageBuilder = new MessageBuilder(syntheticEvent, getOwner(this)!, {
+      roomId: payload.roomId,
+      effectiveEventId: payload.parentEventId,
+      author,
+      index: message.index ?? 0,
+      events: this.events,
+      skills: this.skills,
+    });
+    await messageBuilder.updateMessage(message);
   }
 
   private async updateMessageCommandResult({

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -793,6 +793,18 @@ export class RoomResource extends Resource<Args> {
     message: Message,
     payload: AppBoxelResponseStreamContent,
   ) {
+    // The synchronous gate checked isStreamingOfEventFinished at *enqueue* time,
+    // but this apply may have waited behind a predecessor on the chain while the
+    // final consolidated room edit landed and finalized the message. Re-check
+    // now: updateMessage rewrites body / reasoning / isStreamingFinished
+    // synchronously (before its first await), so an apply that *starts* after
+    // finalization would un-finish the completed message with stale content —
+    // leaving it stuck "streaming" until the stall timeout trips. An apply that
+    // started before finalization is safe: the final edit's synchronous writes
+    // still land last.
+    if (message.isStreamingOfEventFinished) {
+      return;
+    }
     try {
       let author = this.upsertRoomMember({
         roomId: payload.roomId,

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -12,6 +12,7 @@ import { TrackedMap } from 'tracked-built-ins';
 
 import {
   isCardInstance,
+  logger,
   rri,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
@@ -85,6 +86,8 @@ export type RoomSkill = {
   isActive: boolean;
 };
 
+const responseStreamLog = logger('matrix:response-stream');
+
 interface Args {
   named: {
     roomId: string | undefined;
@@ -102,8 +105,12 @@ export class RoomResource extends Resource<Args> {
   // Highest to-device preview `sequence` applied per streaming message
   // (keyed by parentEventId). Previews carry full accumulated state, so an
   // out-of-order or duplicate delivery is simply dropped rather than regressing
-  // the message to older content.
+  // the message to older content. Both maps are pruned when a message finalizes
+  // (see hydrateResponseStreamPreview) and cleared in teardown().
   #lastPreviewSequence = new Map<string, number>();
+  // Serializes preview applies per streaming message so their async tool-request
+  // builds land in sequence order rather than promise-completion order.
+  #previewApplyChain = new Map<string, Promise<void>>();
   private _messageCache: TrackedMap<string, Message> = new TrackedMap();
   private _nameEventsCache: TrackedMap<string, RoomNameEvent> =
     new TrackedMap();
@@ -148,6 +155,7 @@ export class RoomResource extends Resource<Args> {
     this.#responseStreamPreviewDisposer?.();
     this.#responseStreamPreviewDisposer = undefined;
     this.#lastPreviewSequence.clear();
+    this.#previewApplyChain.clear();
     for (let id of this.#skillIds ?? []) {
       this.store.dropReference(id);
     }
@@ -738,9 +746,16 @@ export class RoomResource extends Resource<Args> {
   // it mirrors lets us reuse MessageBuilder.updateMessage — including its tool
   // request chunk merging — and its `setUpdated(new Date())` resets the
   // streaming stall timeout so long responses don't trip the fallback.
-  private async hydrateResponseStreamPreview(
-    payload: AppBoxelResponseStreamContent,
-  ) {
+  //
+  // This method gates an incoming preview (roomId / staleness / duplicate)
+  // synchronously and then enqueues its apply on a per-message chain. The gate
+  // must be synchronous: it decides ordering by arrival, and
+  // applyResponseStreamPreview awaits async tool-request builds, so without
+  // serialization two overlapping previews would resolve their tool args in
+  // promise-completion order rather than sequence order (every synthetic event
+  // pins the same origin_server_ts, so MessageBuilder.applyToolRequestChunk's
+  // timestamp guard can't reorder them).
+  private hydrateResponseStreamPreview(payload: AppBoxelResponseStreamContent) {
     if (!payload || payload.roomId !== this.roomId) {
       return;
     }
@@ -750,6 +765,13 @@ export class RoomResource extends Resource<Args> {
     // cases the room-event path is authoritative and reconciles the true state,
     // so there is nothing for an ephemeral preview to add.
     if (!message || message.isStreamingOfEventFinished) {
+      // Once the message is finalized its tracking entries are dead — prune
+      // them opportunistically so a long-lived room doesn't accumulate one per
+      // AI turn (teardown() is the backstop).
+      if (message?.isStreamingOfEventFinished) {
+        this.#lastPreviewSequence.delete(payload.parentEventId);
+        this.#previewApplyChain.delete(payload.parentEventId);
+      }
       return;
     }
     let lastSequence =
@@ -759,37 +781,69 @@ export class RoomResource extends Resource<Args> {
     }
     this.#lastPreviewSequence.set(payload.parentEventId, payload.sequence);
 
-    let author = this.upsertRoomMember({
-      roomId: payload.roomId,
-      userId: this.matrixService.aiBotUserId,
-    });
-    // origin_server_ts is pinned to the message's creation time so a preview
-    // never advances past — and thus never suppresses (see
-    // MessageBuilder.applyToolRequestChunk) — the real, later final room edit.
-    let syntheticEvent = {
-      type: 'm.room.message',
-      event_id: payload.parentEventId,
-      room_id: payload.roomId,
-      sender: this.matrixService.aiBotUserId,
-      origin_server_ts: message.created.getTime(),
-      content: {
-        msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
-        body: payload.body,
-        [APP_BOXEL_REASONING_CONTENT_KEY]: payload.reasoning,
-        [APP_BOXEL_TOOL_REQUESTS_KEY]: payload.toolRequests,
-        isStreamingFinished: false,
-      },
-    } as unknown as CardMessageEvent;
+    let previous =
+      this.#previewApplyChain.get(payload.parentEventId) ?? Promise.resolve();
+    let next = previous.then(() =>
+      this.applyResponseStreamPreview(message, payload),
+    );
+    this.#previewApplyChain.set(payload.parentEventId, next);
+  }
 
-    let messageBuilder = new MessageBuilder(syntheticEvent, getOwner(this)!, {
-      roomId: payload.roomId,
-      effectiveEventId: payload.parentEventId,
-      author,
-      index: message.index ?? 0,
-      events: this.events,
-      skills: this.skills,
-    });
-    await messageBuilder.updateMessage(message);
+  private async applyResponseStreamPreview(
+    message: Message,
+    payload: AppBoxelResponseStreamContent,
+  ) {
+    try {
+      let author = this.upsertRoomMember({
+        roomId: payload.roomId,
+        userId: this.matrixService.aiBotUserId,
+      });
+      // origin_server_ts is pinned to the message's creation time so a preview
+      // never advances past — and thus never suppresses (see
+      // MessageBuilder.applyToolRequestChunk) — the real, later final room edit.
+      //
+      // A preview intentionally owns only body / reasoning / toolRequests. The
+      // other fields updateMessage writes (attachedCards/Files, continuationOf,
+      // hasContinuation, status, reloadBillingData) are reset to empty/false on
+      // every apply because the synthetic event doesn't carry them; that's
+      // benign for a streaming response — the final room edit restores the truth
+      // — but a placeholder that legitimately carried any of those would have it
+      // wiped until finalization.
+      let syntheticEvent = {
+        type: 'm.room.message',
+        event_id: payload.parentEventId,
+        room_id: payload.roomId,
+        sender: this.matrixService.aiBotUserId,
+        origin_server_ts: message.created.getTime(),
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          body: payload.body,
+          [APP_BOXEL_REASONING_CONTENT_KEY]: payload.reasoning,
+          [APP_BOXEL_TOOL_REQUESTS_KEY]: payload.toolRequests,
+          isStreamingFinished: false,
+        },
+      } as unknown as CardMessageEvent;
+
+      let messageBuilder = new MessageBuilder(syntheticEvent, getOwner(this)!, {
+        roomId: payload.roomId,
+        effectiveEventId: payload.parentEventId,
+        author,
+        index: message.index ?? 0,
+        events: this.events,
+        skills: this.skills,
+      });
+      await messageBuilder.updateMessage(message);
+    } catch (err) {
+      // A dropped preview is harmless — the final room edit reconciles the true
+      // state — so swallow (mirroring ai-bot's best-effort sendToDevicePreview)
+      // rather than surface an unhandled rejection from this fire-and-forget
+      // handler. updateMessage can throw when a new tool id triggers an async
+      // skill/loader resolve.
+      responseStreamLog.debug(
+        `dropped response-stream preview (seq ${payload.sequence}) for ${payload.parentEventId}`,
+        err,
+      );
+    }
   }
 
   private async updateMessageCommandResult({

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -59,6 +59,8 @@ import {
   APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
   APP_BOXEL_MESSAGE_MSGTYPE,
   APP_BOXEL_ORIGINATING_DEVICE_ID_KEY,
+  APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE,
+  type AppBoxelResponseStreamContent,
   APP_BOXEL_REALM_EVENT_TYPE,
   APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE,
   APP_BOXEL_REALMS_EVENT_TYPE,
@@ -433,6 +435,7 @@ export default class MatrixService extends Service {
       [this.matrixSDK.RoomEvent.Timeline, this.onTimeline],
       [this.matrixSDK.RoomEvent.LocalEchoUpdated, this.onUpdateEventStatus],
       [this.matrixSDK.RoomEvent.Receipt, this.onReceipt],
+      [this.matrixSDK.ClientEvent.ToDeviceEvent, this.onToDeviceEvent],
       [this.matrixSDK.RoomStateEvent.Update, this.onRoomStateUpdate],
       [
         this.matrixSDK.ClientEvent.AccountData,
@@ -2707,6 +2710,34 @@ export default class MatrixService extends Service {
     this.timelineQueue.push({ event: e });
     debounce(this, this.drainTimeline, 100);
   };
+
+  // ai-bot streams in-flight response previews as `app.boxel.response-stream`
+  // to-device messages (see AI_BOT_STREAMING_MODE=to-device). The raw client is
+  // private and all its event bindings live here, so we fan the previews out to
+  // the RoomResource(s) that registered via `onResponseStreamPreview`; each
+  // handler self-filters by roomId.
+  #responseStreamPreviewHandlers = new Set<
+    (payload: AppBoxelResponseStreamContent) => void
+  >();
+
+  private onToDeviceEvent = (e: MatrixEvent) => {
+    if (e.getType() !== APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE) {
+      return;
+    }
+    let payload = e.getContent() as AppBoxelResponseStreamContent;
+    for (let handler of this.#responseStreamPreviewHandlers) {
+      handler(payload);
+    }
+  };
+
+  onResponseStreamPreview(
+    handler: (payload: AppBoxelResponseStreamContent) => void,
+  ): () => void {
+    this.#responseStreamPreviewHandlers.add(handler);
+    return () => {
+      this.#responseStreamPreviewHandlers.delete(handler);
+    };
+  }
 
   private onUpdateEventStatus = (
     e: MatrixEvent,

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -2724,6 +2724,14 @@ export default class MatrixService extends Service {
     if (e.getType() !== APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE) {
       return;
     }
+    // A to-device message can be sent by any Matrix user directly to a device —
+    // room membership isn't required — so, unlike the room-event path (which
+    // implicitly trusts in-room ai-bot authorship), verify the sender before
+    // hydrating a preview into the assistant's bubble. This also short-circuits
+    // the fan-out for unrelated to-device traffic.
+    if (e.getSender() !== this.aiBotUserId) {
+      return;
+    }
     let payload = e.getContent() as AppBoxelResponseStreamContent;
     for (let handler of this.#responseStreamPreviewHandlers) {
       handler(payload);

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -759,8 +759,12 @@ export class MockClient implements ExtendedClient {
   // streaming previews) to ClientEvent.ToDeviceEvent listeners. To-device
   // messages are ephemeral, so unlike room events they are not recorded in
   // serverState.
-  simulateToDeviceEvent(type: string, content: Record<string, any>) {
-    let event = new MatrixEvent({ type, content });
+  simulateToDeviceEvent(
+    type: string,
+    content: Record<string, any>,
+    sender?: string,
+  ) {
+    let event = new MatrixEvent({ type, content, sender });
     let handlers = this.listeners[this.sdk.ClientEvent.ToDeviceEvent];
     if (handlers) {
       for (let handler of handlers) {

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -755,6 +755,20 @@ export class MockClient implements ExtendedClient {
     }
   }
 
+  // Dispatch a to-device event (e.g. ai-bot's `app.boxel.response-stream`
+  // streaming previews) to ClientEvent.ToDeviceEvent listeners. To-device
+  // messages are ephemeral, so unlike room events they are not recorded in
+  // serverState.
+  simulateToDeviceEvent(type: string, content: Record<string, any>) {
+    let event = new MatrixEvent({ type, content });
+    let handlers = this.listeners[this.sdk.ClientEvent.ToDeviceEvent];
+    if (handlers) {
+      for (let handler of handlers) {
+        handler(event);
+      }
+    }
+  }
+
   private emitLocalEchoUpdated(event: MatrixEvent, oldEventId?: string) {
     let handlers = this.listeners[this.sdk.RoomEvent.LocalEchoUpdated];
     if (handlers) {

--- a/packages/host/tests/helpers/mock-matrix/_sdk.ts
+++ b/packages/host/tests/helpers/mock-matrix/_sdk.ts
@@ -15,6 +15,7 @@ type PublicAPI<T> = { [K in keyof T]: T[K] };
 
 export class MockSDK implements PublicAPI<ExtendedMatrixSDK> {
   serverState: ServerState;
+  client: MockClient | undefined;
 
   constructor(
     private sdkOpts: Config,
@@ -27,13 +28,14 @@ export class MockSDK implements PublicAPI<ExtendedMatrixSDK> {
   }
 
   createClient(clientOpts: MatrixSDK.ICreateClientOpts) {
-    return new MockClient(
+    this.client = new MockClient(
       this.owner,
       this,
       this.serverState,
       clientOpts,
       this.sdkOpts,
     );
+    return this.client;
   }
 
   getRoomEvents(roomId: string) {
@@ -58,6 +60,7 @@ export class MockSDK implements PublicAPI<ExtendedMatrixSDK> {
 
   ClientEvent = {
     AccountData: 'accountData',
+    ToDeviceEvent: 'toDeviceEvent',
   } as ExtendedMatrixSDK['ClientEvent'];
 
   RoomStateEvent = {

--- a/packages/host/tests/helpers/mock-matrix/_utils.ts
+++ b/packages/host/tests/helpers/mock-matrix/_utils.ts
@@ -98,8 +98,12 @@ export class MockUtils {
     );
   };
 
-  simulateToDeviceEvent = (type: string, content: Record<string, any>) => {
-    this.testState.sdk!.client!.simulateToDeviceEvent(type, content);
+  simulateToDeviceEvent = (
+    type: string,
+    content: Record<string, any>,
+    sender?: string,
+  ) => {
+    this.testState.sdk!.client!.simulateToDeviceEvent(type, content, sender);
   };
 
   setReadReceipt = (roomId: string, eventId: string, reader: string) => {

--- a/packages/host/tests/helpers/mock-matrix/_utils.ts
+++ b/packages/host/tests/helpers/mock-matrix/_utils.ts
@@ -98,6 +98,10 @@ export class MockUtils {
     );
   };
 
+  simulateToDeviceEvent = (type: string, content: Record<string, any>) => {
+    this.testState.sdk!.client!.simulateToDeviceEvent(type, content);
+  };
+
   setReadReceipt = (roomId: string, eventId: string, reader: string) => {
     return this.testState.sdk!.serverState.addReceiptEvent(
       roomId,

--- a/packages/host/tests/integration/components/ai-assistant-panel/to-device-streaming-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/to-device-streaming-test.gts
@@ -120,15 +120,21 @@ module(
       sequence: number,
       body: string,
       reasoning = '',
+      toolRequests: unknown[] = [],
+      sender: string = matrixService.aiBotUserId,
     ) {
-      simulateToDeviceEvent(APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE, {
-        roomId,
-        parentEventId,
-        sequence,
-        body,
-        reasoning,
-        toolRequests: [],
-      });
+      simulateToDeviceEvent(
+        APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE,
+        {
+          roomId,
+          parentEventId,
+          sequence,
+          body,
+          reasoning,
+          toolRequests,
+        },
+        sender,
+      );
     }
 
     test('a preview hydrates body and reasoning into the streaming message', async function (assert) {
@@ -163,7 +169,12 @@ module(
       await waitFor(`[data-test-room="${roomId}"] [data-test-message-idx="0"]`);
 
       let roomResource = matrixService.roomResources.get(roomId)!;
-      let createdAt = roomResource.messages[0].created.getTime();
+
+      // Capture `updated` *after* the placeholder loads but *before* any preview.
+      // `updated` is seeded to construction time, so asserting it merely exceeds
+      // `created` (an earlier ts) would pass even if `setUpdated` never ran — we
+      // want to prove a preview actually advances it.
+      let updatedBeforePreviews = roomResource.messages[0].updated.getTime();
 
       preview(roomId, eventId, 0, 'You should');
       await settled();
@@ -178,8 +189,8 @@ module(
       // is exactly the value room-message.gts compares against to decide the
       // streaming stall timeout — so the timeout resets for free.
       assert.ok(
-        roomResource.messages[0].updated.getTime() >= createdAt,
-        'the message updated timestamp advances as previews arrive',
+        roomResource.messages[0].updated.getTime() > updatedBeforePreviews,
+        'an applied preview advances the message updated timestamp',
       );
     });
 
@@ -236,6 +247,77 @@ module(
       assert
         .dom('[data-test-message-idx="0"]')
         .containsText('A valid preview lands.');
+    });
+
+    test('overlapping tool-request previews resolve to the highest sequence, without duplicating the tool', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+      let eventId = sendPlaceholder(roomId);
+      await waitFor(`[data-test-room="${roomId}"] [data-test-message-idx="0"]`);
+
+      let roomResource = matrixService.roomResources.get(roomId)!;
+
+      // Two previews carrying the same tool id arrive back-to-back (no settle in
+      // between) so both applies are enqueued on #previewApplyChain before
+      // either finishes. The chain runs them in sequence order, and updateMessage
+      // reuses the existing MessageTool for a known id — so the message must end
+      // with a single tool whose arguments come from the higher-sequence preview.
+      let toolRequest = (firstName: string) => [
+        {
+          id: 'tool-1',
+          name: 'patchCardInstance',
+          arguments: JSON.stringify({
+            attributes: {
+              cardId: `${testRealmURL}Person/fadhlan`,
+              patch: { attributes: { firstName } },
+            },
+          }),
+        },
+      ];
+
+      preview(roomId, eventId, 0, 'Renaming', '', toolRequest('Alice'));
+      preview(roomId, eventId, 1, 'Renaming', '', toolRequest('Bob'));
+      await settled();
+
+      let tools = roomResource.messages[0].tools;
+      assert.strictEqual(tools.length, 1, 'the tool id is not duplicated');
+      assert.strictEqual(
+        (tools[0].arguments as any)?.attributes?.patch?.attributes?.firstName,
+        'Bob',
+        'the higher-sequence preview owns the tool arguments',
+      );
+    });
+
+    test('a preview from a sender other than the ai bot is ignored', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+      let eventId = sendPlaceholder(roomId);
+      await waitFor(`[data-test-room="${roomId}"] [data-test-message-idx="0"]`);
+
+      // A to-device message can be delivered by any Matrix user, so a spoofed
+      // sender must never reach the assistant's bubble.
+      preview(
+        roomId,
+        eventId,
+        0,
+        'Injected by an impostor.',
+        '',
+        [],
+        '@impostor:localhost',
+      );
+      await settled();
+      assert
+        .dom('[data-test-message-idx="0"]')
+        .doesNotContainText('Injected by an impostor.');
+
+      // The genuine ai-bot sender still applies.
+      preview(roomId, eventId, 1, 'The real preview.');
+      await waitUntil(() =>
+        document
+          .querySelector('[data-test-message-idx="0"]')
+          ?.textContent?.includes('The real preview.'),
+      );
+      assert
+        .dom('[data-test-message-idx="0"]')
+        .containsText('The real preview.');
     });
   },
 );

--- a/packages/host/tests/integration/components/ai-assistant-panel/to-device-streaming-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/to-device-streaming-test.gts
@@ -1,0 +1,241 @@
+import { click, waitFor, waitUntil, settled } from '@ember/test-helpers';
+import GlimmerComponent from '@glimmer/component';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import {
+  APP_BOXEL_MESSAGE_MSGTYPE,
+  APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE,
+} from '@cardstack/runtime-common/matrix-constants';
+
+import OperatorMode from '@cardstack/host/components/operator-mode/container';
+
+import type MatrixService from '@cardstack/host/services/matrix-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+
+import {
+  testRealmURL,
+  setupCardLogs,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupOnSave,
+  setupOperatorModeStateCleanup,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+  realmConfigCardJSON,
+} from '../../../helpers';
+import { setupBaseRealm } from '../../../helpers/base-realm';
+import { setupMockMatrix } from '../../../helpers/mock-matrix';
+import { renderComponent } from '../../../helpers/render-component';
+import { setupRenderingTest } from '../../../helpers/setup';
+
+module(
+  'Integration | ai-assistant-panel | to-device streaming previews',
+  function (hooks) {
+    const realmName = 'Operator Mode Workspace';
+    let loader: Loader;
+    let matrixService: MatrixService;
+    let operatorModeStateService: OperatorModeStateService;
+
+    setupRenderingTest(hooks);
+    setupOperatorModeStateCleanup(hooks);
+    setupBaseRealm(hooks);
+
+    hooks.beforeEach(function () {
+      loader = getService('loader-service').loader;
+    });
+
+    setupLocalIndexing(hooks);
+    setupOnSave(hooks);
+    setupRealmCacheTeardown(hooks);
+    setupCardLogs(
+      hooks,
+      async () => await loader.import('@cardstack/base/card-api'),
+    );
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
+      autostart: true,
+    });
+
+    let { simulateRemoteMessage, simulateToDeviceEvent } = mockMatrixUtils;
+
+    let noop = () => {};
+
+    hooks.beforeEach(async function () {
+      operatorModeStateService = getService('operator-mode-state-service');
+      matrixService = getService('matrix-service');
+
+      await withCachedRealmSetup(async () => {
+        await setupIntegrationTestRealm({
+          mockMatrixUtils,
+          contents: {
+            'realm.json': realmConfigCardJSON({ name: realmName }),
+          },
+        });
+      });
+    });
+
+    async function renderAiAssistantPanel() {
+      operatorModeStateService.restore({ stacks: [[]] });
+      await renderComponent(
+        class TestDriver extends GlimmerComponent {
+          <template><OperatorMode @onClose={{noop}} /></template>
+        },
+      );
+      await waitFor('[data-test-open-ai-assistant]');
+      await click('[data-test-open-ai-assistant]');
+      await waitFor('[data-test-room-settled]');
+      let roomId = document
+        .querySelector('[data-test-room]')
+        ?.getAttribute('data-test-room');
+      if (!roomId) {
+        throw new Error('Expected a room ID');
+      }
+      return roomId;
+    }
+
+    // Sends the "thinking" placeholder ai-bot lands before it streams. In
+    // to-device mode this is the only room event until the final consolidated
+    // edit; the in-flight state arrives as to-device previews keyed by this
+    // event id.
+    function sendPlaceholder(roomId: string) {
+      return simulateRemoteMessage(roomId, '@aibot:localhost', {
+        body: '',
+        msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+        format: 'org.matrix.custom.html',
+        isStreamingFinished: false,
+        data: { context: { agentId: matrixService.agentId } },
+      });
+    }
+
+    function preview(
+      roomId: string,
+      parentEventId: string,
+      sequence: number,
+      body: string,
+      reasoning = '',
+    ) {
+      simulateToDeviceEvent(APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE, {
+        roomId,
+        parentEventId,
+        sequence,
+        body,
+        reasoning,
+        toolRequests: [],
+      });
+    }
+
+    test('a preview hydrates body and reasoning into the streaming message', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+      let eventId = sendPlaceholder(roomId);
+      await waitFor(`[data-test-room="${roomId}"] [data-test-message-idx="0"]`);
+
+      preview(
+        roomId,
+        eventId,
+        0,
+        'You should get a poodle.',
+        'They mentioned they like small dogs.',
+      );
+
+      await waitUntil(() =>
+        document
+          .querySelector('[data-test-message-idx="0"]')
+          ?.textContent?.includes('You should get a poodle.'),
+      );
+      assert
+        .dom('[data-test-message-idx="0"]')
+        .containsText('You should get a poodle.');
+      assert
+        .dom('[data-test-message-idx="0"]')
+        .containsText('They mentioned they like small dogs.');
+    });
+
+    test('previews accumulate full state and bump the message updated timestamp', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+      let eventId = sendPlaceholder(roomId);
+      await waitFor(`[data-test-room="${roomId}"] [data-test-message-idx="0"]`);
+
+      let roomResource = matrixService.roomResources.get(roomId)!;
+      let createdAt = roomResource.messages[0].created.getTime();
+
+      preview(roomId, eventId, 0, 'You should');
+      await settled();
+      preview(roomId, eventId, 1, 'You should get a poodle.');
+      await waitUntil(() =>
+        document
+          .querySelector('[data-test-message-idx="0"]')
+          ?.textContent?.includes('You should get a poodle.'),
+      );
+
+      // updateMessage stamps a fresh `updated` on every applied preview, which
+      // is exactly the value room-message.gts compares against to decide the
+      // streaming stall timeout — so the timeout resets for free.
+      assert.ok(
+        roomResource.messages[0].updated.getTime() >= createdAt,
+        'the message updated timestamp advances as previews arrive',
+      );
+    });
+
+    test('an out-of-order or duplicate preview is dropped by sequence', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+      let eventId = sendPlaceholder(roomId);
+      await waitFor(`[data-test-room="${roomId}"] [data-test-message-idx="0"]`);
+
+      preview(roomId, eventId, 5, 'The latest accumulated text.');
+      await waitUntil(() =>
+        document
+          .querySelector('[data-test-message-idx="0"]')
+          ?.textContent?.includes('The latest accumulated text.'),
+      );
+
+      // A lower sequence arriving late must not regress the message to older
+      // content.
+      preview(roomId, eventId, 3, 'Stale earlier text.');
+      await settled();
+
+      assert
+        .dom('[data-test-message-idx="0"]')
+        .containsText('The latest accumulated text.');
+      assert
+        .dom('[data-test-message-idx="0"]')
+        .doesNotContainText('Stale earlier text.');
+    });
+
+    test('a preview for an unknown parent event or another room is a no-op', async function (assert) {
+      let roomId = await renderAiAssistantPanel();
+      let eventId = sendPlaceholder(roomId);
+      await waitFor(`[data-test-room="${roomId}"] [data-test-message-idx="0"]`);
+
+      // Unknown parent event id — placeholder never loaded / already finalized.
+      preview(roomId, '$does-not-exist', 0, 'Orphan preview.');
+      // Correct parent, wrong room — must not leak across rooms.
+      preview('!some-other-room:localhost', eventId, 0, 'Wrong room preview.');
+      await settled();
+
+      assert
+        .dom('[data-test-message-idx="0"]')
+        .doesNotContainText('Orphan preview.');
+      assert
+        .dom('[data-test-message-idx="0"]')
+        .doesNotContainText('Wrong room preview.');
+
+      // The room still works: a valid preview for the real message applies.
+      preview(roomId, eventId, 1, 'A valid preview lands.');
+      await waitUntil(() =>
+        document
+          .querySelector('[data-test-message-idx="0"]')
+          ?.textContent?.includes('A valid preview lands.'),
+      );
+      assert
+        .dom('[data-test-message-idx="0"]')
+        .containsText('A valid preview lands.');
+    });
+  },
+);


### PR DESCRIPTION
Consume ai-bot's `app.boxel.response-stream` to-device streaming previews on the client so the browser renders streaming UX when ai-bot runs in `AI_BOT_STREAMING_MODE=to-device` — without a Matrix room event per throttle window.

## What this does

- **Central binding (matrix-service).** All raw-client event bindings live in `matrix-service`, so it binds `ClientEvent.ToDeviceEvent` centrally, filters for `app.boxel.response-stream`, and fans payloads out to `RoomResource`s that register via a new `onResponseStreamPreview(handler)` (returns a disposer). Each handler self-filters by roomId. This deviates from the ticket's literal "`matrixClient.on` in room.ts" because the raw client is private and centralizing bindings is the established pattern.
- **Reconciliation (room.ts).** `RoomResource` registers in `modify()` / disposes in `teardown()`. `hydrateResponseStreamPreview()` shapes each preview as the `CardMessage` edit it mirrors and runs it through the existing `MessageBuilder.updateMessage` path, reusing its tool-request chunk merging.
- **Ordering.** The synthetic event's `origin_server_ts` is pinned to the message's creation time so a preview never advances past — and thus never suppresses (via `applyToolRequestChunk`) — the real, later final room edit. A per-message `sequence` gate drops out-of-order / duplicate previews; payloads carry full accumulated state, so last-writer-wins is safe.
- **Stall timeout.** No `room-message.gts` change was needed: `updateMessage` stamps a fresh `updated` on every applied preview, which is exactly the value the streaming stall-timeout getter compares against — so long responses reset the timeout for free.

## Test coverage

mock-matrix had no to-device support, so this adds `simulateToDeviceEvent` (mock client + `ClientEvent.ToDeviceEvent` on the mock SDK + `MockUtils`), plus an integration test covering preview hydration (body + reasoning), the sequence gate dropping stale previews, and unknown-parent / cross-room no-ops.

## Base

Stacked on `cs-12261-response-stream-event-schema`, which defines the `app.boxel.response-stream` event schema this consumes.

## Test plan

- [x] Typecheck (`lint:types`) clean for all changed files.
- [x] ESLint / template-lint clean.
- [ ] Host integration suite — not run locally (needs the full realm + Matrix server harness); relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)