### PR TITLE
Age prerender wait-queue waiters so on-demand traffic can't starve job visits

### DIFF
--- a/packages/realm-server/prerender/async-semaphore.ts
+++ b/packages/realm-server/prerender/async-semaphore.ts
@@ -1,4 +1,8 @@
 import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel.ts';
+import {
+  resolveQueueAgingIntervalMs,
+  selectNextWaiterIndex,
+} from './queue-aging.ts';
 
 // Pure in-memory counting semaphore with AbortSignal-aware queueing.
 // Exported so cancellation-plumbing unit tests can drive it directly
@@ -7,6 +11,13 @@ import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel.ts';
 //   - PagePool global render-semaphore (per-server tab cap)
 //   - PagePool file-queue admission control (CS-10946)
 //
+// Dequeue is priority-then-FIFO, with anti-starvation aging: a queued
+// waiter's effective priority rises with how long it has waited (see
+// queue-aging.ts), so a continuous stream of higher-priority arrivals cannot
+// defer a lower-priority waiter indefinitely. `now` and the aging interval are
+// injectable for deterministic tests; production takes `Date.now` and the
+// env-resolved interval.
+//
 // Capacity is mutable post-construction via `setCapacity(n)` so callers
 // (PagePool dynamic tab expansion / contraction) can grow the
 // concurrency cap without rebuilding the semaphore. In-flight slots
@@ -14,24 +25,34 @@ import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel.ts';
 // admitting new waiters until `inUseCount` falls back under the new cap.
 export class AsyncSemaphore {
   #capacity: number;
+  #now: () => number;
+  #agingIntervalMs: number;
   // Tracked directly so resize works correctly. The original
   // `#capacity - #available` formulation fell apart when capacity could
   // change while requests were in flight.
   #inUse: number;
   // `resolve` hands the acquirer the release function once a slot
   // frees. `onCancel` gives the cancellation path a way to splice
-  // the entry out of the queue without racing #release. `priority`
-  // controls dequeue order: higher priority first, FIFO within the
-  // same priority. Default priority is `0`.
+  // the entry out of the queue without racing #release. `priority` is
+  // the base priority; `enqueuedAt` is the wait-start timestamp that
+  // aging uses to raise a starved waiter's effective priority. Dequeue
+  // order: highest effective priority first, FIFO within a tier.
   #queue: Array<{
     resolve: (release: () => void) => void;
     onCancel: () => void;
     priority: number;
+    enqueuedAt: number;
   }> = [];
 
-  constructor(max: number) {
+  constructor(
+    max: number,
+    options?: { now?: () => number; agingIntervalMs?: number },
+  ) {
     this.#capacity = normalizeCapacity(max);
     this.#inUse = 0;
+    this.#now = options?.now ?? Date.now;
+    this.#agingIntervalMs =
+      options?.agingIntervalMs ?? resolveQueueAgingIntervalMs();
   }
 
   // Current cap. Mutable via `setCapacity`; callers reading this
@@ -103,19 +124,14 @@ export class AsyncSemaphore {
           );
         },
         priority,
+        enqueuedAt: this.#now(),
       };
       let onAbort = entry.onCancel;
-      // Priority-ordered insertion: highest priority first, FIFO within
-      // the same priority. Find the first existing entry with strictly
-      // lower priority and insert before it; if none, append. Same-
-      // priority entries land after all existing same-priority entries
-      // → FIFO preserved.
-      let insertIdx = this.#queue.findIndex((e) => e.priority < priority);
-      if (insertIdx === -1) {
-        this.#queue.push(entry);
-      } else {
-        this.#queue.splice(insertIdx, 0, entry);
-      }
+      // Append; dequeue selection (`selectNextWaiterIndex`) picks the
+      // highest effective priority — base priority plus aging boost —
+      // rather than trusting insertion order, since aging changes relative
+      // order over time.
+      this.#queue.push(entry);
       signal?.addEventListener('abort', onAbort, { once: true });
     });
   }
@@ -135,7 +151,15 @@ export class AsyncSemaphore {
     // Wake waiters up to the new cap. Same hand-off shape as #release
     // (increment inUse, resolve the next waiter), iterated.
     while (this.#inUse < this.#capacity && this.#queue.length > 0) {
-      let next = this.#queue.shift()!;
+      let idx = selectNextWaiterIndex(
+        this.#queue,
+        this.#now(),
+        this.#agingIntervalMs,
+      );
+      if (idx === -1) {
+        break;
+      }
+      let [next] = this.#queue.splice(idx, 1);
       this.#inUse++;
       next.resolve(this.#release);
     }
@@ -143,13 +167,20 @@ export class AsyncSemaphore {
 
   #release = () => {
     this.#inUse--;
-    // If a waiter is queued AND we have spare capacity, hand it the
-    // slot (no net change in `#inUse`). Otherwise the slot stays free
-    // until the next acquire.
+    // If a waiter is queued AND we have spare capacity, hand the slot to
+    // the highest effective-priority waiter (no net change in `#inUse`).
+    // Otherwise the slot stays free until the next acquire.
     if (this.#inUse < this.#capacity && this.#queue.length > 0) {
-      let next = this.#queue.shift()!;
-      this.#inUse++;
-      next.resolve(this.#release);
+      let idx = selectNextWaiterIndex(
+        this.#queue,
+        this.#now(),
+        this.#agingIntervalMs,
+      );
+      if (idx !== -1) {
+        let [next] = this.#queue.splice(idx, 1);
+        this.#inUse++;
+        next.resolve(this.#release);
+      }
     }
   };
 }

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -10,6 +10,10 @@ import { resolvePrerenderManagerURL } from './config.ts';
 import type { BrowserManager } from './browser-manager.ts';
 import { PrerenderCancelledError, throwIfAborted } from './prerender-cancel.ts';
 import { AsyncSemaphore } from './async-semaphore.ts';
+import {
+  resolveQueueAgingIntervalMs,
+  selectNextWaiterIndex,
+} from './queue-aging.ts';
 import { attachRuntimeExceptionCapture } from './runtime-exception-capture.ts';
 import { attachNetworkInflightTracker } from './network-inflight-tracker.ts';
 
@@ -24,9 +28,12 @@ type RenderSemaphore = {
 // Exported so cancellation-plumbing unit tests can drive it
 // directly — it's a per-tab serializer with no Chrome dependency.
 //
-// Priority-bucketed dequeue: higher priority first, FIFO within the
-// same priority. Default priority is `0` so callers that don't
-// specify get straight FIFO.
+// Dequeue is priority-then-FIFO with anti-starvation aging: a queued
+// waiter's effective priority rises with how long it has waited (see
+// queue-aging.ts), so a continuous stream of higher-priority arrivals cannot
+// defer a lower-priority waiter on this tab indefinitely. Default priority is
+// `0`; `now` and the aging interval are injectable for deterministic tests,
+// defaulting to `Date.now` and the env-resolved interval.
 export class TabQueue {
   // `held` is true while a caller holds the lease (post-acquire,
   // pre-release). Subsequent acquires queue rather than running.
@@ -35,8 +42,17 @@ export class TabQueue {
     resolve: () => void;
     reject: (err: unknown) => void;
     priority: number;
+    enqueuedAt: number;
     settled: boolean;
   }> = [];
+  #now: () => number;
+  #agingIntervalMs: number;
+
+  constructor(options?: { now?: () => number; agingIntervalMs?: number }) {
+    this.#now = options?.now ?? Date.now;
+    this.#agingIntervalMs =
+      options?.agingIntervalMs ?? resolveQueueAgingIntervalMs();
+  }
 
   async acquire(
     signal?: AbortSignal,
@@ -55,20 +71,23 @@ export class TabQueue {
       resolve: () => void;
       reject: (err: unknown) => void;
       priority: number;
+      enqueuedAt: number;
       settled: boolean;
     };
     let onAbort: (() => void) | undefined;
     try {
       await new Promise<void>((resolve, reject) => {
-        entry = { resolve, reject, priority, settled: false };
-        // Priority-ordered insertion (matches `AsyncSemaphore`):
-        // highest priority first, FIFO within priority.
-        let insertIdx = this.#queue.findIndex((e) => e.priority < priority);
-        if (insertIdx === -1) {
-          this.#queue.push(entry);
-        } else {
-          this.#queue.splice(insertIdx, 0, entry);
-        }
+        entry = {
+          resolve,
+          reject,
+          priority,
+          enqueuedAt: this.#now(),
+          settled: false,
+        };
+        // Append; the release path (`selectNextWaiterIndex`) picks the
+        // highest effective priority — base priority plus aging boost —
+        // rather than trusting insertion order.
+        this.#queue.push(entry);
         if (signal) {
           onAbort = () => {
             if (entry.settled) return;
@@ -98,12 +117,17 @@ export class TabQueue {
     return () => {
       if (released) return;
       released = true;
-      // Highest-priority oldest waiter (front of queue) gets the lease.
-      // Skip already-settled (cancelled) entries — they were spliced
-      // by `onAbort` but for safety we tolerate stale entries here.
-      while (this.#queue.length > 0) {
-        let next = this.#queue.shift()!;
-        if (next.settled) continue;
+      // Hand the lease to the highest effective-priority waiter (base
+      // priority plus aging boost), breaking ties toward the oldest.
+      // `selectNextWaiterIndex` skips already-settled (cancelled) entries;
+      // when none remain the lease frees.
+      let idx = selectNextWaiterIndex(
+        this.#queue,
+        this.#now(),
+        this.#agingIntervalMs,
+      );
+      if (idx !== -1) {
+        let [next] = this.#queue.splice(idx, 1);
         next.settled = true;
         // `#held` stays true: the lease just transferred.
         next.resolve();

--- a/packages/realm-server/prerender/queue-aging.ts
+++ b/packages/realm-server/prerender/queue-aging.ts
@@ -1,0 +1,123 @@
+import { userInitiatedPriority } from '@cardstack/runtime-common';
+
+// Anti-starvation aging for the prerender server's priority wait-queues: the
+// per-tab `TabQueue` and the `AsyncSemaphore` backing the per-server render
+// cap and per-affinity file admission.
+//
+// Both queues order waiters by priority, FIFO within a priority. That
+// ordering on its own lets an unbroken stream of higher-priority arrivals
+// defer a lower-priority waiter for as long as the stream lasts: a
+// background (priority `systemInitiatedPrerenderHtmlPriority`) prerender-html
+// job visit queued behind on-demand (priority `userInitiatedPriority`) index
+// visits of the same realm affinity never reaches the front while the
+// on-demand traffic continues, so the manager aborts its request before it
+// ever starts rendering.
+//
+// Aging removes the unbounded part. A waiter's *effective* priority for
+// dequeue selection rises with how long it has waited, so a waiter that has
+// been passed over long enough outranks freshly-arrived higher-priority work
+// and is chosen next. The stamped base priority is left intact — aging steers
+// only which queued waiter is selected, not the priority reported to
+// diagnostics or the manager.
+
+// A waiter's effective priority is `basePriority + waitedMs / interval`, so a
+// background (priority-0) waiter reaches the top user tier
+// (`userInitiatedPriority`) after `userInitiatedPriority` intervals of waiting
+// and, being the older entry, wins the tie against a fresh arrival at that tier
+// from that point on. The interval is chosen so that crossover lands at the
+// target below — an order of magnitude inside the prerender request timeout
+// that bounds a visit — so a continuous on-demand stream can no longer hold a
+// job-lane visit off until its client aborts.
+const DEFAULT_ANTI_STARVATION_CROSSOVER_MS = 30_000;
+const DEFAULT_QUEUE_AGING_INTERVAL_MS =
+  DEFAULT_ANTI_STARVATION_CROSSOVER_MS / userInitiatedPriority;
+
+// Set `PRERENDER_QUEUE_AGING_INTERVAL_MS` (milliseconds of waiting per one
+// effective-priority point) to tune the crossover: smaller ages starved
+// waiters up faster (background work overtakes user work sooner under sustained
+// pressure), larger keeps strict priority order for longer. A value of `0`
+// disables aging entirely, restoring pure priority-then-FIFO dequeue.
+export function resolveQueueAgingIntervalMs(): number {
+  let raw = process.env.PRERENDER_QUEUE_AGING_INTERVAL_MS;
+  if (raw == null) {
+    return DEFAULT_QUEUE_AGING_INTERVAL_MS;
+  }
+  let parsed = Number(raw);
+  // A non-finite or negative interval would corrupt the wait-time math; fall
+  // back to the default rather than let it through.
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_QUEUE_AGING_INTERVAL_MS;
+  }
+  return parsed;
+}
+
+// Effective priority for dequeue ordering: base priority plus one point per
+// `intervalMs` of waiting. `intervalMs <= 0` disables aging (effective ===
+// base). A waiter that has not waited (or that acquired immediately without
+// queueing) keeps its base priority.
+export function effectivePriority(
+  basePriority: number,
+  enqueuedAt: number,
+  now: number,
+  intervalMs: number,
+): number {
+  if (intervalMs <= 0) {
+    return basePriority;
+  }
+  let waitedMs = now - enqueuedAt;
+  if (waitedMs <= 0) {
+    return basePriority;
+  }
+  return basePriority + waitedMs / intervalMs;
+}
+
+export interface AgingWaiter {
+  priority: number;
+  enqueuedAt: number;
+  // Set by the queue when a waiter is cancelled but not yet removed from the
+  // backing array; such entries are never selected.
+  settled?: boolean;
+}
+
+// Index of the waiter to serve next: the highest effective priority, breaking
+// ties toward the earliest-enqueued waiter so ordering stays FIFO within an
+// effective-priority tier. Returns `-1` when no live waiter is queued.
+//
+// Scanning the whole queue (rather than trusting a sorted front) is required
+// because aging changes relative order over time: an entry inserted later can
+// outrank an earlier one once it has waited long enough. The queues are bounded
+// by the per-affinity tab cap and the render/admission concurrency caps, so the
+// scan is over a small array.
+export function selectNextWaiterIndex(
+  queue: ReadonlyArray<AgingWaiter>,
+  now: number,
+  intervalMs: number,
+): number {
+  let bestIdx = -1;
+  let bestEffective = -Infinity;
+  let bestEnqueuedAt = Infinity;
+  for (let i = 0; i < queue.length; i++) {
+    let entry = queue[i];
+    if (entry.settled) {
+      continue;
+    }
+    let eff = effectivePriority(
+      entry.priority,
+      entry.enqueuedAt,
+      now,
+      intervalMs,
+    );
+    // Strictly-better replacement only: among entries that tie on effective
+    // priority the earliest-scanned (earliest-enqueued, since insertion
+    // appends) stays selected, preserving FIFO.
+    if (
+      eff > bestEffective ||
+      (eff === bestEffective && entry.enqueuedAt < bestEnqueuedAt)
+    ) {
+      bestIdx = i;
+      bestEffective = eff;
+      bestEnqueuedAt = entry.enqueuedAt;
+    }
+  }
+  return bestIdx;
+}

--- a/packages/realm-server/tests/page-pool-priority-test.ts
+++ b/packages/realm-server/tests/page-pool-priority-test.ts
@@ -213,4 +213,214 @@ module(basename(import.meta.filename), function () {
       rLow();
     });
   });
+
+  // Anti-starvation aging for both wait-queues. Priority-then-FIFO alone lets
+  // an unbroken stream of higher-priority arrivals defer a lower-priority
+  // waiter forever — the shape of the single-account prerender starvation
+  // where on-demand (priority-10) index visits held a background
+  // (priority-0) prerender-html job visit off its realm-affinity lane until
+  // the manager aborted the request. Aging raises a waiter's effective
+  // priority with its wait, so a starved waiter eventually outranks fresh
+  // higher-priority work. A fake clock drives wait time deterministically.
+  module('priority aging (anti-starvation)', function () {
+    test('AsyncSemaphore: a starved low-priority waiter overtakes a fresh high-priority arrival once aged', async function (assert) {
+      let clock = { t: 0 };
+      // A priority-0 waiter reaches effective priority 10 (the top user tier)
+      // after 10 * 1000ms = 10s of waiting, then wins as the older entry.
+      let sem = new AsyncSemaphore(1, {
+        now: () => clock.t,
+        agingIntervalMs: 1000,
+      });
+      let hold = await sem.acquire(undefined, 10); // occupy the only slot
+
+      let order: string[] = [];
+      let job = sem.acquire(undefined, 0).then((r) => {
+        order.push('job');
+        return r;
+      });
+      await Promise.resolve();
+
+      // The job has now waited past the crossover; a fresh priority-10 visit
+      // arrives.
+      clock.t = 10_500;
+      let freshHi = sem.acquire(undefined, 10).then((r) => {
+        order.push('freshHi');
+        return r;
+      });
+      await Promise.resolve();
+      assert.strictEqual(sem.pendingCount, 2, 'job + freshHi queued');
+
+      // The running visit completes: the aged job outranks the fresh arrival.
+      hold();
+      let rJob = await job;
+      assert.deepEqual(
+        order,
+        ['job'],
+        'aged priority-0 waiter served before fresh priority-10',
+      );
+      rJob();
+      let rHi = await freshHi;
+      assert.deepEqual(order, ['job', 'freshHi'], 'fresh priority-10 next');
+      rHi();
+    });
+
+    test('AsyncSemaphore: before the aging crossover a fresh high-priority arrival still wins', async function (assert) {
+      let clock = { t: 0 };
+      let sem = new AsyncSemaphore(1, {
+        now: () => clock.t,
+        agingIntervalMs: 1000,
+      });
+      let hold = await sem.acquire(undefined, 10);
+
+      let order: string[] = [];
+      let job = sem.acquire(undefined, 0).then((r) => {
+        order.push('job');
+        return r;
+      });
+      await Promise.resolve();
+
+      // Job aged to effective priority 9 — still below the top user tier.
+      clock.t = 9000;
+      let freshHi = sem.acquire(undefined, 10).then((r) => {
+        order.push('freshHi');
+        return r;
+      });
+      await Promise.resolve();
+
+      hold();
+      let rHi = await freshHi;
+      assert.deepEqual(
+        order,
+        ['freshHi'],
+        'fresh priority-10 outranks a not-yet-aged priority-0 waiter',
+      );
+      rHi();
+      let rJob = await job;
+      assert.deepEqual(order, ['freshHi', 'job']);
+      rJob();
+    });
+
+    test('AsyncSemaphore: a continuous high-priority stream cannot defer a low-priority waiter past the aging window', async function (assert) {
+      let clock = { t: 0 };
+      let sem = new AsyncSemaphore(1, {
+        now: () => clock.t,
+        agingIntervalMs: 1000,
+      });
+      let flush = async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      };
+
+      let pending = new Map<string, () => void>();
+      let jobServedAt: number | null = null;
+      let record = (label: string) => (release: () => void) => {
+        if (label === 'job') {
+          jobServedAt = clock.t;
+        }
+        pending.set(label, release);
+        return release;
+      };
+
+      // A high-priority visit is already rendering (holds the only slot).
+      pending.set('boot', await sem.acquire(undefined, 10));
+      let holder = 'boot';
+
+      // The background job-lane visit enqueues while the stream is in flight.
+      void sem.acquire(undefined, 0).then(record('job'));
+      await flush();
+
+      // Each tick: a fresh priority-10 visit arrives, then the running visit
+      // completes and the scheduler picks the next waiter.
+      for (let tick = 0; tick < 1000 && jobServedAt == null; tick++) {
+        clock.t += 2000; // 2s between on-demand arrivals
+        void sem.acquire(undefined, 10).then(record(`hi${tick}`));
+        await flush();
+        let release = pending.get(holder)!;
+        pending.delete(holder);
+        release();
+        await flush();
+        holder = [...pending.keys()].find((k) => k !== 'job') ?? 'job';
+      }
+
+      assert.notStrictEqual(
+        jobServedAt,
+        null,
+        'the starved job-lane visit was eventually served',
+      );
+      let servedAt = jobServedAt ?? Infinity;
+      assert.ok(
+        servedAt <= 12_000,
+        `job served at t=${servedAt}ms — inside the aging window (~10s), not deferred toward the ~120s abort`,
+      );
+      pending.get('job')?.();
+    });
+
+    test('TabQueue: a starved low-priority waiter overtakes a fresh high-priority arrival once aged', async function (assert) {
+      let clock = { t: 0 };
+      let q = new TabQueue({ now: () => clock.t, agingIntervalMs: 1000 });
+      let hold = await q.acquire(undefined, 10); // hold the tab lease
+
+      let order: string[] = [];
+      let job = q.acquire(undefined, 0).then((r) => {
+        order.push('job');
+        return r;
+      });
+      await Promise.resolve();
+
+      clock.t = 10_500;
+      let freshHi = q.acquire(undefined, 10).then((r) => {
+        order.push('freshHi');
+        return r;
+      });
+      await Promise.resolve();
+
+      hold();
+      let rJob = await job;
+      assert.deepEqual(
+        order,
+        ['job'],
+        'aged priority-0 waiter takes the tab lease before fresh priority-10',
+      );
+      rJob();
+      let rHi = await freshHi;
+      assert.deepEqual(order, ['job', 'freshHi']);
+      rHi();
+    });
+
+    test('aging disabled (interval 0) keeps strict priority-then-FIFO', async function (assert) {
+      let clock = { t: 0 };
+      let sem = new AsyncSemaphore(1, {
+        now: () => clock.t,
+        agingIntervalMs: 0,
+      });
+      let hold = await sem.acquire(undefined, 10);
+
+      let order: string[] = [];
+      let job = sem.acquire(undefined, 0).then((r) => {
+        order.push('job');
+        return r;
+      });
+      await Promise.resolve();
+
+      // Advance far past any crossover — with aging off, wait time is ignored.
+      clock.t = 10_000_000;
+      let freshHi = sem.acquire(undefined, 10).then((r) => {
+        order.push('freshHi');
+        return r;
+      });
+      await Promise.resolve();
+
+      hold();
+      let rHi = await freshHi;
+      assert.deepEqual(
+        order,
+        ['freshHi'],
+        'priority-10 always wins with aging disabled, regardless of wait',
+      );
+      rHi();
+      let rJob = await job;
+      assert.deepEqual(order, ['freshHi', 'job']);
+      rJob();
+    });
+  });
 });


### PR DESCRIPTION
The prerender server orders work within a realm-affinity lane by priority: user-initiated on-demand index visits at priority 10, system-initiated `prerender_html` job visits at priority 0. Two shared primitives enforce that ordering — the per-tab `TabQueue` serializer and the `AsyncSemaphore` backing the per-server render cap and per-affinity file admission. Both were strict priority-then-FIFO with no time component, so once a lower-priority waiter is queued behind higher-priority work, an unbroken stream of higher-priority arrivals keeps jumping ahead of it forever.

That is a real starvation hole: under a continuous burst of on-demand visits confined to a single account's affinity, that account's own background `prerender_html` job visit never reaches the front of its tab queue. It only starts rendering after the manager's request timeout has already aborted the visit — the render then completes for nobody and the job rejects, even though the card itself renders in about a second. The affinity lane correctly contains the blast radius to the one account, but leaves that account no way to make forward progress on its published HTML.

This adds anti-starvation aging, shared by both primitives in a new `queue-aging.ts`:

- A queued waiter's **effective priority** for dequeue selection is `basePriority + waitedMs / interval` — it rises with how long the waiter has been passed over, so a long-starved waiter eventually outranks freshly-arrived higher-priority work and is chosen next.
- Dequeue now **scans** the queue for the highest effective priority, breaking ties toward the earliest-enqueued (FIFO within a tier), rather than trusting a sorted front — aging changes relative order over time, so the front is no longer guaranteed best. The queues are bounded by the per-affinity tab cap and the concurrency caps, so the scan is over a small array.
- The stamped **base priority is untouched** — aging steers only which queued waiter is selected, not the priority reported to diagnostics or to the manager's cross-server routing.

The default interval puts a background (priority-0) waiter past the top user tier roughly 30s into its wait — an order of magnitude inside the ~120s request timeout that bounds a visit — so under a continuous on-demand stream a job visit now starts well before its client aborts. `PRERENDER_QUEUE_AGING_INTERVAL_MS` tunes the crossover (milliseconds of waiting per effective-priority point); `0` disables aging and restores pure priority-then-FIFO.

With aging off, dequeue selection is equivalent to the previous sorted-insertion behavior (highest base priority, FIFO within a priority), so existing priority ordering is preserved.

## Scope

This is the scheduler-fairness piece only. Propagating the manager's abort into the in-flight render, detecting a wedged tab before a multi-minute burn, persisting an error row and backing off repeatedly-rejected repair batches, and bounding pathological render costs are separate changes.

## Test plan

`tests/page-pool-priority-test.ts` gains a "priority aging (anti-starvation)" module driving both primitives with an injected clock:

- a starved priority-0 waiter overtakes a fresh priority-10 arrival once it has aged past the crossover;
- before the crossover, a fresh priority-10 arrival still wins;
- under a continuous priority-10 stream, the priority-0 waiter is served inside the aging window rather than deferred toward the abort budget;
- the same overtake holds for `TabQueue`;
- with aging disabled, dequeue stays strict priority-then-FIFO (the negative control).

The existing priority, semaphore-resize, cancellation, expansion, deadlock, standby-refill, eviction-recovery, cert-verifier, and affinity-activity unit suites all remain green against the changed primitives. Real-Chrome prerender integration coverage (`prerendering-test.ts`) runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
