### PR TITLE
Remove GOOGLE_AUTH_ENABLED flag; gate Google sign-in on homeserver capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ mise run infra:stop-admin
 
 #### Google Sign-In (local dev)
 
-The dev Synapse template ships with a Google OIDC block and a custom `user_mapping_provider` (`packages/matrix/support/synapse/modules/boxel_oidc_mapping_provider.py`) that auto-links Google sign-ins to existing Matrix accounts by verified email. The whole block is **gated on env vars** — without them, `packages/matrix/support/synapse/index.ts` strips the OIDC block from the generated `homeserver.yaml` so Synapse boots cleanly for unrelated work. The host's "Sign in with Google" button is also gated on the `GOOGLE_AUTH_ENABLED` feature flag (defaults `true` in `development`).
+The dev Synapse template ships with a Google OIDC block and a custom `user_mapping_provider` (`packages/matrix/support/synapse/modules/boxel_oidc_mapping_provider.py`) that auto-links Google sign-ins to existing Matrix accounts by verified email. The whole block is **gated on env vars** — without them, `packages/matrix/support/synapse/index.ts` strips the OIDC block from the generated `homeserver.yaml` so Synapse boots cleanly for unrelated work. The host's "Sign in with Google" button appears whenever the homeserver's login flows advertise the `oidc-google` IdP, so it shows up automatically once the OIDC block is in place.
 
 To enable Google sign-in locally:
 

--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -25,7 +25,6 @@ import {
   isMatrixError,
   type MatrixError,
 } from '@cardstack/host/lib/matrix-utils';
-import type EnvironmentService from '@cardstack/host/services/environment-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
 import AuthButton from './auth-button';
@@ -225,7 +224,6 @@ export default class Login extends Component<Signature> {
   @tracked private password: string | undefined;
   @tracked private googleSsoAvailable = false;
   @tracked private exchangingSsoToken = false;
-  @service declare private environmentService: EnvironmentService;
   @service declare private matrixService: MatrixService;
   @service declare router: RouterService;
 
@@ -240,9 +238,7 @@ export default class Login extends Component<Signature> {
           JSON.stringify(this.matrixService.loginReadinessDebug),
       );
     }
-    if (this.environmentService.googleAuthEnabled) {
-      this.detectGoogleSso.perform();
-    }
+    this.detectGoogleSso.perform();
     // Synchronously flip into the SSO-exchanging state if the URL has a
     // loginToken — the task itself is async (awaits matrix-sdk load + token
     // exchange + matrixService.start), and without this the password form
@@ -254,7 +250,7 @@ export default class Login extends Component<Signature> {
   }
 
   private get showGoogleButton() {
-    return this.environmentService.googleAuthEnabled && this.googleSsoAvailable;
+    return this.googleSsoAvailable;
   }
 
   private get isLoginButtonDisabled() {

--- a/packages/host/app/config/environment.ts
+++ b/packages/host/app/config/environment.ts
@@ -56,7 +56,6 @@ export default config as {
   stripePaymentLink: string;
   featureFlags?: {
     AI_PATCHING_CORRECTNESS_CHECKS?: boolean;
-    GOOGLE_AUTH_ENABLED?: boolean;
   };
   publishedRealmDomainOverrides: string;
   publishedRealmBoxelSpaceDomain: string;

--- a/packages/host/app/services/environment-service.ts
+++ b/packages/host/app/services/environment-service.ts
@@ -1,30 +1,21 @@
 import type Owner from '@ember/owner';
 import Service from '@ember/service';
 
-import { tracked } from '@glimmer/tracking';
-
 import config from '@cardstack/host/config/environment';
 
-const {
-  autoSaveDelayMs,
-  cardSizeLimitBytes,
-  fileSizeLimitBytes,
-  featureFlags,
-} = config;
+const { autoSaveDelayMs, cardSizeLimitBytes, fileSizeLimitBytes } = config;
 
 // we use this service to help instrument environment settings in tests
 export default class EnvironmentService extends Service {
   autoSaveDelayMs: number;
   cardSizeLimitBytes: number;
   fileSizeLimitBytes: number;
-  @tracked googleAuthEnabled: boolean;
 
   constructor(owner: Owner) {
     super(owner);
     this.autoSaveDelayMs = autoSaveDelayMs;
     this.cardSizeLimitBytes = cardSizeLimitBytes;
     this.fileSizeLimitBytes = fileSizeLimitBytes;
-    this.googleAuthEnabled = featureFlags?.GOOGLE_AUTH_ENABLED === true;
   }
 }
 

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -188,14 +188,7 @@ module.exports = function (environment) {
         ? `${normalized}/`
         : `${normalized}/test/`;
     })(),
-    featureFlags: {
-      // True locally so `pnpm start` shows the Sign in with Google button by
-      // default; staging/prod stays false until the staging Synapse OIDC
-      // config lands and flips this on via the deployed env var.
-      GOOGLE_AUTH_ENABLED: process.env.GOOGLE_AUTH_ENABLED
-        ? process.env.GOOGLE_AUTH_ENABLED === 'true'
-        : environment === 'development',
-    },
+    featureFlags: {},
   };
 
   if (environment === 'test') {

--- a/packages/host/config/staging.env
+++ b/packages/host/config/staging.env
@@ -8,4 +8,3 @@ MATRIX_SERVER_NAME=stack.cards
 PUBLISHED_REALM_BOXEL_SPACE_DOMAIN=staging.boxel.dev
 PUBLISHED_REALM_BOXEL_SITE_DOMAIN=staging.boxel.build
 ICONS_URL=https://boxel-icons.boxel.ai
-GOOGLE_AUTH_ENABLED=true

--- a/packages/host/tests/integration/components/matrix/login-test.gts
+++ b/packages/host/tests/integration/components/matrix/login-test.gts
@@ -5,7 +5,6 @@ import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 
 import Login from '@cardstack/host/components/matrix/login';
-import type EnvironmentService from '@cardstack/host/services/environment-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
 import { setupMockMatrix } from '../../../helpers/mock-matrix';
@@ -46,12 +45,6 @@ module('Integration | Component | matrix/login', function (hooks) {
   let { setLoginFlows, setSsoLoginUrl, setLoginWithTokenInterceptor } =
     mockMatrixUtils;
 
-  function getEnvironmentService(testContext: any): EnvironmentService {
-    return testContext.owner.lookup(
-      'service:environment-service',
-    ) as EnvironmentService;
-  }
-
   function getMatrixService(testContext: any): MatrixService {
     return testContext.owner.lookup('service:matrix-service') as MatrixService;
   }
@@ -64,30 +57,19 @@ module('Integration | Component | matrix/login', function (hooks) {
     window.location.href = '/';
   });
 
-  test('hides Google button when GOOGLE_AUTH_ENABLED flag is off', async function (assert) {
-    getEnvironmentService(this).googleAuthEnabled = false;
-    setLoginFlows(GOOGLE_SSO_FLOW);
-    await render(<template><Login @setMode={{noop}} /></template>);
-    assert.dom('[data-test-google-login-btn]').doesNotExist();
-    assert.dom('[data-test-login-form]').exists();
-  });
-
   test('hides Google button when server advertises only m.login.password', async function (assert) {
-    getEnvironmentService(this).googleAuthEnabled = true;
     setLoginFlows(PASSWORD_ONLY_FLOW);
     await render(<template><Login @setMode={{noop}} /></template>);
     assert.dom('[data-test-google-login-btn]').doesNotExist();
   });
 
   test('hides Google button when m.login.sso is advertised but oidc-google IDP is missing', async function (assert) {
-    getEnvironmentService(this).googleAuthEnabled = true;
     setLoginFlows(OTHER_SSO_FLOW);
     await render(<template><Login @setMode={{noop}} /></template>);
     assert.dom('[data-test-google-login-btn]').doesNotExist();
   });
 
-  test('shows Google button when flag on AND oidc-google IDP advertised', async function (assert) {
-    getEnvironmentService(this).googleAuthEnabled = true;
+  test('shows Google button when oidc-google IDP advertised', async function (assert) {
     setLoginFlows(GOOGLE_SSO_FLOW);
     await render(<template><Login @setMode={{noop}} /></template>);
     assert.dom('[data-test-google-login-btn]').exists();
@@ -96,7 +78,6 @@ module('Integration | Component | matrix/login', function (hooks) {
   test('clicking Sign in with Google navigates via getSsoLoginUrl', async function (assert) {
     let expectedUrl =
       'http://localhost:8008/_matrix/client/v3/login/sso/redirect/oidc-google?redirectUrl=test';
-    getEnvironmentService(this).googleAuthEnabled = true;
     setLoginFlows(GOOGLE_SSO_FLOW);
     setSsoLoginUrl(expectedUrl);
     await render(<template><Login @setMode={{noop}} /></template>);


### PR DESCRIPTION
## What & why

The "Continue with Google" button on the login screen was gated by **two** conditions:
1. a build-time `GOOGLE_AUTH_ENABLED` feature flag, and
2. a runtime check for whether the homeserver advertises the `oidc-google` identity provider (`googleSsoAvailable`).

Now that Synapse serves the Google OIDC config, the build-time flag is redundant. This PR removes it so the button is shown **purely based on homeserver capability** — it appears wherever the homeserver's `/_matrix/client/v3/login` flows advertise the `oidc-google` IdP, and stays hidden everywhere else.

## Changes

- Remove `GOOGLE_AUTH_ENABLED` from host config (`config/environment.js`, `app/config/environment.ts`) and from `environment-service.ts` (the `googleAuthEnabled` field is gone).
- `login.gts`: always probe the homeserver login flows on mount and derive `showGoogleButton` from `googleSsoAvailable` alone; the `environmentService` injection is no longer needed.
- `login-test.gts`: drop the now-impossible "flag off" test, remove the flag setters from the remaining tests, and re-title the positive case to reflect capability-driven behavior.

## Behavior change

Because the button is now capability-driven, it will render in **any** environment whose homeserver advertises the `oidc-google` IdP (currently staging and production). There is no longer a per-environment build flag to hide it.

## Testing

- `eslint` passes on all changed files.
- Login component integration tests updated; full `lint:types` + test suite run in CI.