### PR TITLE
Revalidate the prerender tab-queue lease after acquire

### DIFF
--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -1892,10 +1892,13 @@ export class PagePool {
   // affinity's set synchronously before it awaits the per-entry close).
   // A parked `TabQueue` waiter that receives the lease across that
   // boundary would otherwise render on a page about to be closed under
-  // it. Cross-affinity donors are still tagged with their donor
-  // `affinityKey` here (the reassign to the requesting affinity happens
-  // back in `getPage`), so the membership check keys off the entry's
-  // own current `affinityKey`.
+  // it. Membership keys off the entry's own current `affinityKey`, which
+  // covers both selection shapes: commandeer / adoption paths re-tag the
+  // entry to the requesting affinity in place (`#assignStandbyToAffinity`
+  // / `#reassignAffinityTab`), while a cross-affinity steal returns the
+  // entry still tagged with its donor affinity and defers the reassign to
+  // `getPage`. Either way the entry is looked up under whatever affinity
+  // currently owns it.
   #isEntryLive(entry: PoolEntry): boolean {
     if (entry.closing) return false;
     let affinityKey = entry.affinityKey;

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -1885,7 +1885,91 @@ export class PagePool {
     }
   }
 
+  // Is this entry still a valid target to hand a caller? A tab is
+  // doomed the moment a dispose path marks it `closing` (the
+  // `awaitIdle: false` eviction lane) or detaches it from
+  // `#affinityPages` (the `awaitIdle: true` cancel lane deletes the
+  // affinity's set synchronously before it awaits the per-entry close).
+  // A parked `TabQueue` waiter that receives the lease across that
+  // boundary would otherwise render on a page about to be closed under
+  // it. Cross-affinity donors are still tagged with their donor
+  // `affinityKey` here (the reassign to the requesting affinity happens
+  // back in `getPage`), so the membership check keys off the entry's
+  // own current `affinityKey`.
+  #isEntryLive(entry: PoolEntry): boolean {
+    if (entry.closing) return false;
+    let affinityKey = entry.affinityKey;
+    if (!affinityKey) return false;
+    return this.#affinityPages.get(affinityKey)?.has(entry) ?? false;
+  }
+
+  // `#selectEntryForAffinityOnce` filters `entry.closing` at selection
+  // time, but a caller that parks on a tab's `TabQueue` and receives the
+  // lease later has no such guard: when a render ends on a pooled tab,
+  // its `release()` hands the lease to the next same-affinity waiter
+  // BEFORE the caller's error propagates to teardown, so a `rendering`-
+  // state cancel or a render-error eviction can dispose the tab in the
+  // window right after the handoff. The parked waiter would then start
+  // its visit on a page being closed under it — its first CDP call
+  // rejects with a raw protocol error (not a `PrerenderCancelledError`),
+  // which routes the visit through `#restartBrowser`, a full-pool
+  // restart paid by a bystander.
+  //
+  // Revalidate the entry after each selection resolves. If it was doomed
+  // in that window, release the dead lease (which also lets the dispose
+  // path's own `#closeEntry` acquire proceed) and re-select — the next
+  // pass filters the now-`closing` entry out and lands on a fresh tab
+  // (orphan-context spawn, standby commandeer, or cross-affinity steal).
+  // Bounded so a sustained dispose storm degrades to the prior behavior
+  // rather than spinning here.
   async #selectEntryForAffinity(
+    affinityKey: string,
+    queue: PrerenderQueue,
+    signal?: AbortSignal,
+    priority: number = 0,
+  ): Promise<{
+    entry: PoolEntry;
+    reused: boolean;
+    releaseTab: () => void;
+    tabStartupMs: number;
+  }> {
+    const MAX_RESELECT_ATTEMPTS = 3;
+    let carriedStartupMs = 0;
+    for (let attempt = 0; attempt < MAX_RESELECT_ATTEMPTS; attempt++) {
+      let result = await this.#selectEntryForAffinityOnce(
+        affinityKey,
+        queue,
+        signal,
+        priority,
+      );
+      if (
+        this.#isEntryLive(result.entry) ||
+        attempt === MAX_RESELECT_ATTEMPTS - 1
+      ) {
+        result.tabStartupMs += carriedStartupMs;
+        return result;
+      }
+      carriedStartupMs += result.tabStartupMs;
+      // A doomed cross-affinity donor was marked `transitioning` by the
+      // steal path; clear it so the donor isn't left half-migrated.
+      result.entry.transitioning = false;
+      try {
+        result.releaseTab();
+      } catch (_e) {
+        // best-effort — the dispose path's own close will clean up.
+      }
+      log.debug(
+        `re-selecting tab for ${affinityKey}: acquired lease on a doomed ` +
+          `entry (pageId=${result.entry.pageId}) disposed after handoff; ` +
+          `attempt ${attempt + 1}`,
+      );
+    }
+    // Unreachable: the final iteration always returns above. Present so
+    // the compiler sees a definite return.
+    throw new Error('No standby page available for prerender');
+  }
+
+  async #selectEntryForAffinityOnce(
     affinityKey: string,
     queue: PrerenderQueue,
     signal?: AbortSignal,

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -262,10 +262,10 @@ export class Prerenderer {
         // instead of racing a background close at the pool ceiling
         // (which reads as "no standby available" and needlessly
         // routes that visit through the browser-restart recovery
-        // lane). That guarantee is scoped to visits arriving after
-        // this disposal: a waiter already holding the tab-queue
-        // lease when the cancel lands still receives the doomed
-        // page, since the lease handoff carries no revalidation.
+        // lane). A waiter that received the tab-queue lease in the
+        // window between release and this disposal is covered too:
+        // PagePool revalidates the lease after acquire and re-selects
+        // a live page rather than handing back the doomed one.
         // The shared BrowserContext is retained so the next visit
         // reuses the warm HTTP cache rather than paying the cold
         // module-source waterfall.

--- a/packages/realm-server/tests/page-pool-lease-revalidation-test.ts
+++ b/packages/realm-server/tests/page-pool-lease-revalidation-test.ts
@@ -1,0 +1,260 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import { PagePool } from '../prerender/page-pool.ts';
+
+// Tab-queue lease revalidation.
+//
+// When a render ends on a pooled tab, `finally { release() }` hands the
+// tab-queue lease to the next same-affinity waiter BEFORE the caller's
+// error propagates up to any teardown. A `rendering`-state cancel or a
+// render-error eviction then disposes the tab in that window. A waiter
+// parked on the tab's `TabQueue` that received the lease with no
+// revalidation would start its visit on a page being closed under it —
+// its first CDP call rejects with a raw protocol error (not a
+// `PrerenderCancelledError`), which routes the whole visit through a
+// full-pool browser restart paid by a bystander.
+//
+// PagePool revalidates the entry after each selection resolves: a doomed
+// lease (entry marked `closing`, or detached from `#affinityPages`) is
+// released — which also lets the dispose path's own close proceed — and
+// the caller re-selects a live tab.
+
+function makeBrowserStub() {
+  let browser = {
+    async createBrowserContext() {
+      let context: any;
+      context = {
+        async newPage() {
+          return {
+            async goto() {
+              return undefined;
+            },
+            async waitForFunction() {
+              return true;
+            },
+            async evaluate(fn: any, ...args: any[]) {
+              return typeof fn === 'function' ? fn(...args) : undefined;
+            },
+            async close() {},
+            browserContext() {
+              return context;
+            },
+            on() {},
+            off() {},
+            removeAllListeners() {},
+          };
+        },
+        async close() {},
+      };
+      return context;
+    },
+  };
+  return {
+    async getBrowser() {
+      return browser as any;
+    },
+    async cleanupUserDataDirs() {},
+  };
+}
+
+// Env vars that reshape the pool envelope (dynamic min/max, tab cap,
+// high-priority tier). The dev-stack shell sets some of these, which
+// would let an affinity hold multiple tabs and stop the second caller
+// from parking. Clear them so the pool runs in the deterministic
+// legacy-fixed shape this test drives, then restore.
+const POOL_ENV_KEYS = [
+  'PRERENDER_PAGE_POOL_MIN',
+  'PRERENDER_PAGE_POOL_MAX',
+  'PRERENDER_PAGE_POOL_INITIAL',
+  'PRERENDER_AFFINITY_TAB_MAX',
+  'PRERENDER_PAGE_POOL_HIGH_PRIORITY_MAX',
+  'PRERENDER_HIGH_PRIORITY_THRESHOLD',
+  'PRERENDER_AFFINITY_FILE_CONCURRENCY',
+  'PRERENDER_POOL_IDLE_CONTRACTION_MS',
+  'PRERENDER_SHARED_CONTEXT_CAP',
+];
+
+module(basename(import.meta.filename), function (hooks) {
+  let pools: PagePool[] = [];
+  let savedEnv: Record<string, string | undefined> = {};
+
+  hooks.beforeEach(() => {
+    for (let key of POOL_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    // Pin a one-tab-per-affinity envelope so the second same-affinity
+    // caller parks on the tab's queue rather than spawning a second
+    // tab. A small dynamic envelope (min < max) keeps a standby slot
+    // available for the re-selection to land on and avoids the
+    // legacy-fixed single-tab deadlock warning; `file` callers still
+    // can't expand past the per-affinity cap, so they park.
+    process.env.PRERENDER_PAGE_POOL_MIN = '1';
+    process.env.PRERENDER_PAGE_POOL_MAX = '2';
+    process.env.PRERENDER_AFFINITY_TAB_MAX = '1';
+  });
+
+  hooks.afterEach(async () => {
+    for (let pool of pools.splice(0)) {
+      try {
+        await pool.closeAll();
+      } catch {
+        // best-effort
+      }
+    }
+    for (let key of POOL_ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    savedEnv = {};
+  });
+
+  // The pool envelope comes from the env pinned in beforeEach; the
+  // `maxPages` option below is a floor the dynamic knobs override.
+  function makePool(): PagePool {
+    let pool = new PagePool({
+      maxPages: 2,
+      serverURL: 'http://localhost',
+      browserManager: makeBrowserStub() as any,
+      boxelHostURL: 'http://localhost:4200',
+      standbyTimeoutMs: 500,
+      disableFileAdmission: true,
+    });
+    pools.push(pool);
+    return pool;
+  }
+
+  async function waitFor(
+    fn: () => boolean,
+    label: string,
+    timeoutMs = 1000,
+  ): Promise<void> {
+    let start = Date.now();
+    while (!fn()) {
+      if (Date.now() - start > timeoutMs) {
+        throw new Error(`timed out waiting for: ${label}`);
+      }
+      await new Promise<void>((r) => setTimeout(r, 2));
+    }
+  }
+
+  // Live count on the affinity's tab queue(s): active holder + queued
+  // waiters. Reaching 2 confirms the second caller has parked behind the
+  // holder rather than spawning a second tab.
+  function affinityPending(pool: PagePool, affinityKey: string): number {
+    let row = pool
+      .getQueueDepthSnapshot()
+      .affinities.find((a) => a.affinityKey === affinityKey);
+    return row?.pendingTotal ?? 0;
+  }
+
+  test('parked waiter re-selects a live tab when its tab is disposed via a rendering-state cancel (awaitIdle: true)', async function (assert) {
+    let pool = makePool();
+
+    // Warm affinity 'A' and keep the lease held — the in-flight render.
+    let held = await pool.getPage('A');
+    // One warm standby: the fresh tab the re-selection lands on.
+    await pool.warmStandbys();
+
+    // A second same-affinity caller. 'A' is at its one-tab cap, so this
+    // parks on the tab's queue rather than spawning a second tab.
+    let waiterPromise = pool.getPage('A');
+    await waitFor(
+      () => affinityPending(pool, 'A') >= 2,
+      'second caller parked on the tab queue',
+    );
+
+    // Release-then-dispose, synchronously and in that order — exactly
+    // the ordering `finally { release() }` produces ahead of the cancel
+    // teardown. The lease hands off to the parked waiter, THEN the
+    // dispose deletes the affinity's set and marks the tab closing.
+    held.release();
+    let disposePromise = pool.disposeAffinity('A', {
+      retainSharedContext: true,
+    });
+
+    let waiter = await waiterPromise;
+
+    assert.notStrictEqual(
+      waiter.pageId,
+      held.pageId,
+      'waiter did not receive the doomed tab; it re-selected a fresh live page',
+    );
+    assert.false(
+      waiter.reused,
+      'the re-selected page is a freshly materialized tab, not a reuse of the disposed one',
+    );
+
+    waiter.release();
+    await disposePromise;
+  });
+
+  test('parked waiter re-selects a live tab when its tab is disposed via a render-error eviction (awaitIdle: false)', async function (assert) {
+    let pool = makePool();
+
+    let held = await pool.getPage('A');
+    await pool.warmStandbys();
+
+    let waiterPromise = pool.getPage('A');
+    await waitFor(
+      () => affinityPending(pool, 'A') >= 2,
+      'second caller parked on the tab queue',
+    );
+
+    // The eviction path disposes mid-visit, while the render still holds
+    // the lease: it marks the tab closing and backgrounds the close.
+    // Then the render's release hands the now-doomed lease to the parked
+    // waiter.
+    let disposePromise = pool.disposeAffinity('A', {
+      awaitIdle: false,
+      retainSharedContext: true,
+    });
+    held.release();
+
+    let waiter = await waiterPromise;
+
+    assert.notStrictEqual(
+      waiter.pageId,
+      held.pageId,
+      'waiter did not receive the doomed tab; it re-selected a fresh live page',
+    );
+    assert.false(
+      waiter.reused,
+      'the re-selected page is a freshly materialized tab, not a reuse of the disposed one',
+    );
+
+    waiter.release();
+    await disposePromise;
+  });
+
+  test('a healthy parked waiter still receives the tab on a normal release (no spurious re-selection)', async function (assert) {
+    let pool = makePool();
+
+    let held = await pool.getPage('A');
+
+    let waiterPromise = pool.getPage('A');
+    await waitFor(
+      () => affinityPending(pool, 'A') >= 2,
+      'second caller parked on the tab queue',
+    );
+
+    // Plain hand-off: no dispose. The waiter should reuse the same tab
+    // the holder just released — revalidation must not force a spurious
+    // re-selection when the entry is still live.
+    held.release();
+    let waiter = await waiterPromise;
+
+    assert.strictEqual(
+      waiter.pageId,
+      held.pageId,
+      'waiter reused the same live tab on a normal hand-off',
+    );
+    assert.true(waiter.reused, 'the hand-off is reported as a reuse');
+
+    waiter.release();
+  });
+});


### PR DESCRIPTION
## Background

The prerender server drives headless Chrome tabs to render cards. A pool of tabs is keyed by affinity (realm), and each tab has a `TabQueue` that serializes the visits landing on it: a caller `acquire()`s the lease, renders, and `release()`s it, at which point the lease hands off to the next parked waiter for that tab.

Two dispose paths tear a tab down under specific conditions: a `rendering`-state cancel (the client disconnected mid-render) disposes the affinity keeping its warm context, and a render-error eviction disposes it when a render surfaces an unusable-page/timeout error. Both run *after* the render's `finally { release() }` — the release hands the lease to the next same-affinity waiter before the error has propagated up to the teardown.

## The hole

`PagePool` selected tabs by filtering out `entry.closing` candidates — but only at selection time. A caller that had already parked on a tab's `TabQueue` and received the lease across the release→dispose window had no such guard. When the tab was disposed right after the handoff, the parked waiter started its visit on a page being closed under it. Its first CDP call rejected with a raw protocol error — not a `PrerenderCancelledError` — so the visit's catch treated it as a genuine render failure and routed it through `#restartBrowser`: a full-pool restart, paid by a bystander visit that did nothing wrong.

The window predates immediate mid-render cancellation, but that work makes `rendering`-state cancels far more frequent, so the window sees more traffic.

## What this changes

Selection is wrapped in a bounded re-selection loop that revalidates the acquired entry after each `TabQueue.acquire()` resolves: the entry must still be un-`closing` and still tracked in `#affinityPages`. If it was doomed in the handoff window, the dead lease is released — which also lets the dispose path's own `#closeEntry` acquire proceed — and the caller re-selects. The next pass filters the now-`closing` entry out and lands on a fresh tab (orphan-context spawn, standby commandeer, or cross-affinity steal). A still-live entry returns immediately, so a normal hand-off keeps reusing the same warm tab with no spurious re-selection. The loop is bounded so a sustained dispose storm degrades to the prior behavior rather than spinning.

The cancel-handler comment that documented this hole is updated to describe the covered behavior.

## Testing

`page-pool-lease-revalidation-test.ts` pins the contract with a stub browser (no Chrome): a parked waiter re-selects a fresh live tab when its tab is disposed via a `rendering`-state cancel (`awaitIdle: true`) and via a render-error eviction (`awaitIdle: false`), and a healthy hand-off with no dispose still reuses the same tab. The two dispose tests were verified to fail without the fix — the waiter receives the identical doomed tab (same pageId, `reused: true`) and detours as described. The sibling page-pool suites (eviction-recovery, standby-refill, expansion, priority, cert-verifier, prerender-deadlock) still pass. The end-to-end protocol-error → restart detour only reproduces with real Chrome, so it stays covered by the integration suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Timing and backstop

The two dispose lanes reach the doomed-entry state differently, and the revalidation covers them with different reliability:

- **Eviction (`awaitIdle: false`)** marks the entry `closing` synchronously, before the render's `finally { release() }`. The parked waiter therefore always observes it doomed on revalidation and re-selects — reliably. This is the higher-value case: the tab is known-unusable (the render that triggered eviction already failed on it), so reusing it would fail again.
- **Cancel (`awaitIdle: true`)** disposes after `release()`; the entry is doomed a microtask hop later, ahead of the parked waiter's revalidation, so the re-selection fires. This ordering is a property of the current release→dispose propagation rather than an enforced barrier.

Independent of the revalidation, `#closeEntry` acquires the tab's queue lease before it closes the page, and every dispose path marks the entry `closing` before that acquire — so a waiter that already holds the lease sits ahead of `#closeEntry` and the page cannot be closed under it at the JS layer. The revalidation's job is to keep a waiter from *rendering on a doomed tab* (and detouring through the browser-restart lane); the lease discipline is the backstop against a page-close mid-render. Draining/rejecting parked waiters at dispose time would make the cancel lane timing-independent as well; that's a reasonable follow-up rather than part of this change.
