### PR TITLE
Hide AI assistant by default

### DIFF
--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -143,12 +143,13 @@ export type ModuleInspectorView = 'schema' | 'spec' | 'preview';
 export const DEFAULT_MODULE_INSPECTOR_VIEW: ModuleInspectorView = 'schema';
 
 // Read the user's persisted AI Assistant open/closed preference. Defaults to
-// `true` for first-ever visits; URL state still takes precedence over this.
+// `false` for first-ever visits, so the panel is closed unless the URL state
+// (which takes precedence) or a remembered preference opens it.
 function readPersistedAiAssistantOpen(): boolean {
   let raw = window.localStorage.getItem(AiAssistantOpen);
   if (raw === 'true') return true;
   if (raw === 'false') return false;
-  return true;
+  return false;
 }
 
 export default class OperatorModeStateService extends Service {

--- a/packages/host/app/utils/local-storage-keys.ts
+++ b/packages/host/app/utils/local-storage-keys.ts
@@ -27,4 +27,5 @@ export function clearLocalStorage(storage: Storage | undefined) {
   storage?.removeItem(ScrollPositions);
   storage?.removeItem(AiAssistantMessageDrafts);
   storage?.removeItem(AiAssistantPendingSends);
+  storage?.removeItem(AiAssistantOpen);
 }

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1502,6 +1502,31 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     assert.dom('[data-test-ai-assistant-panel]').exists();
   });
 
+  test('ai assistant panel is closed by default when the URL omits aiAssistantOpen', async function (assert) {
+    // Hand-build the state so the aiAssistantOpen key is absent (visitOperatorMode
+    // always injects it), and leave localStorage unseeded — a first-ever visit.
+    let operatorModeStateParam = stringify({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}index`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    })!;
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+    assert.dom('[data-test-ai-assistant-panel]').doesNotExist();
+    assert.false(
+      getService('operator-mode-state-service').aiAssistantOpen,
+      'panel is closed by default with no URL param and no persisted preference',
+    );
+  });
+
   test('auto-attached cards behaviour', async function (assert) {
     await visitOperatorMode({
       submode: 'interact',

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -31,6 +31,7 @@ import ENV from '@cardstack/host/config/environment';
 import { tokenRefreshPeriodSec } from '@cardstack/host/services/realm';
 
 import {
+  AiAssistantOpen,
   ScrollPositions,
   SessionLocalStorageKey,
 } from '@cardstack/host/utils/local-storage-keys';
@@ -1581,6 +1582,7 @@ module('Acceptance | operator mode tests', function (hooks) {
         ScrollPositions,
         JSON.stringify({ 'file-tree': [`${testRealmURL}Pet/mango.json`, 2] }),
       );
+      window.localStorage.setItem(AiAssistantOpen, 'true');
 
       await click('[data-test-profile-icon-button]');
       await click('[data-test-signout-button]');
@@ -1588,6 +1590,11 @@ module('Acceptance | operator mode tests', function (hooks) {
       assert.strictEqual(getRecentFiles(), null);
       assert.strictEqual(window.localStorage.getItem(ScrollPositions), null);
       assert.strictEqual(getPlaygroundSelections(), null);
+      assert.strictEqual(
+        window.localStorage.getItem(AiAssistantOpen),
+        null,
+        'AI assistant open preference is cleared on logout',
+      );
 
       assert.dom('[data-test-login-btn]').exists();
     });

--- a/packages/host/tests/unit/services/operator-mode-state-service-test.ts
+++ b/packages/host/tests/unit/services/operator-mode-state-service-test.ts
@@ -134,12 +134,21 @@ module('Unit | Service | operator-mode-state-service', function (hooks) {
     );
   });
 
-  test('URL with no aiAssistantOpen key falls back to localStorage (open default)', function (assert) {
-    // no localStorage seeded — first-ever visit
+  test('URL with no aiAssistantOpen key falls back to localStorage (remembered open)', function (assert) {
+    window.localStorage.setItem(AiAssistantOpen, 'true');
     service.restore({ stacks: [] });
     assert.true(
       service.aiAssistantOpen,
-      'panel opens by default when neither URL nor localStorage carry a preference',
+      'panel reopens when URL state omits the key but localStorage remembers open',
+    );
+  });
+
+  test('closed by default when neither URL nor localStorage carry a preference', function (assert) {
+    // no localStorage seeded — first-ever visit
+    service.restore({ stacks: [] });
+    assert.false(
+      service.aiAssistantOpen,
+      'panel stays closed by default when neither URL nor localStorage carry a preference',
     );
   });
 

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -31,6 +31,7 @@ interface ProfileAssertions {
 interface LoginOptions {
   url?: string;
   showAllCards?: boolean; //default true
+  openAiAssistant?: boolean; //default false; opens the AI assistant panel after login
 }
 
 // Shared SQL executor is created on demand for tests
@@ -157,7 +158,21 @@ export async function reloadAndOpenAiAssistant(page: Page) {
 }
 
 export async function openAiAssistant(page: Page) {
-  await page.locator('[data-test-open-ai-assistant]').click();
+  // The AI assistant panel is closed by default; the toggle button both opens
+  // and closes it. Wait for the toggle to render (operator mode's open/closed
+  // state is restored synchronously before first paint, so once the button is
+  // present the panel's presence already reflects that state) and only click
+  // when the panel is actually closed — otherwise a call made when it is
+  // already open (restored from URL/localStorage state) would toggle it back
+  // closed.
+  let openButton = page.locator('[data-test-open-ai-assistant]');
+  await openButton.waitFor();
+  let panel = page.locator('[data-test-ai-assistant-panel]');
+  if (await panel.isVisible()) {
+    return;
+  }
+  await openButton.click();
+  await panel.waitFor();
 }
 
 export async function createRealm(
@@ -440,6 +455,10 @@ export async function login(
   }, localStorageAuth);
 
   await openRoot(page, opts?.url);
+
+  if (opts?.openAiAssistant) {
+    await openAiAssistant(page);
+  }
 }
 
 export async function enterWorkspace(

--- a/packages/matrix/tests/auth-rooms.spec.ts
+++ b/packages/matrix/tests/auth-rooms.spec.ts
@@ -4,7 +4,7 @@ import {
   getRoomMembers,
   getRoomRetentionPolicy,
 } from '../support/synapse/index.ts';
-import { createSubscribedUser } from '../helpers/index.ts';
+import { createSubscribedUser, openAiAssistant } from '../helpers/index.ts';
 import { appURL } from '../support/isolated-realm-server.ts';
 
 test.describe('Auth rooms', () => {
@@ -21,6 +21,7 @@ test.describe('Auth rooms', () => {
     await expect(page.locator('[data-test-login-btn]')).toBeEnabled();
     await page.locator('[data-test-login-btn]').click();
 
+    await openAiAssistant(page);
     await page.locator('[data-test-room-settled]').waitFor();
     let realmRoomsByUser = new Map<string, string>();
     expect(async () => {

--- a/packages/matrix/tests/correctness-checks.spec.ts
+++ b/packages/matrix/tests/correctness-checks.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from './fixtures.ts';
 import { putEvent } from '../support/synapse/index.ts';
 import {
   getRoomId,
+  openAiAssistant,
   createSubscribedUserAndLogin,
   getRoomEvents,
   showAllCards,
@@ -57,6 +58,7 @@ test.describe('Correctness Checks', () => {
     });
 
     await page.goto(realmURL);
+    await openAiAssistant(page);
     let roomId = await getRoomId(page);
     await showAllCards(page);
     let testCard = page.locator(`[data-test-cards-grid-item="${cardId}"]`);
@@ -539,6 +541,7 @@ export class ImportCheck extends CardDef {
     await postCardSource(page, realmURL, modulePath, originalModuleContent);
 
     await page.goto(realmURL);
+    await openAiAssistant(page);
     let roomId = await getRoomId(page);
 
     let agentId = await page.evaluate(() => {

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -9,6 +9,7 @@ import {
   createRoom,
   createSubscribedUserAndLogin,
   getRoomId,
+  openAiAssistant,
   openRoom,
   assertMessages,
   writeMessage,
@@ -38,6 +39,7 @@ test.describe('Room messages', () => {
       page,
       'send-message',
     );
+    await openAiAssistant(page);
     let room1 = await getRoomId(page);
     await expect(page.locator('[data-test-new-session]')).toHaveCount(1);
     await expect(page.locator('[data-test-message-field]')).toHaveValue('');
@@ -90,7 +92,10 @@ test.describe('Room messages', () => {
     await assertMessages(page, messages);
 
     await logout(page);
-    await login(page, username, password, { url: appURL });
+    await login(page, username, password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await openRoom(page, room1);
     await assertMessages(page, messages);
 
@@ -113,6 +118,7 @@ test.describe('Room messages', () => {
       page,
       'load-events',
     );
+    await openAiAssistant(page);
     let room1 = await getRoomId(page);
 
     for (let i = 1; i <= totalMessageCount; i++) {
@@ -136,7 +142,10 @@ test.describe('Room messages', () => {
 
     await logout(page);
 
-    await login(page, username, password, { url: appURL });
+    await login(page, username, password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await openRoom(page, room1);
 
     await expect(page.locator('[data-test-message-idx]')).toHaveCount(
@@ -148,6 +157,7 @@ test.describe('Room messages', () => {
     page,
   }) => {
     const { username } = await createSubscribedUserAndLogin(page, 'markdown');
+    await openAiAssistant(page);
     let room1 = await getRoomId(page);
     await sendMessage(page, room1, 'message with _style_');
     await assertMessages(page, [
@@ -172,6 +182,7 @@ test.describe('Room messages', () => {
 
   test(`it can create a room specific pending message`, async ({ page }) => {
     await createSubscribedUserAndLogin(page, 'pending-message');
+    await openAiAssistant(page);
     let room1 = await getRoomId(page);
     await sendMessage(page, room1, 'Hello');
     let room2 = await createRoom(page);
@@ -210,6 +221,7 @@ test.describe('Room messages', () => {
       page,
       'add-card-markdown',
     );
+    await openAiAssistant(page);
     await page.locator(`[data-test-room-settled]`).waitFor();
 
     await page.locator('[data-test-attach-button]').click();
@@ -248,6 +260,7 @@ test.describe('Room messages', () => {
     const testCard = `${appURL}/mango-puppy`; // this is a 153KB card
     const { username, password, credentials } =
       await createSubscribedUserAndLogin(page, 'strip-base64');
+    await openAiAssistant(page);
     await page.locator(`[data-test-room-settled]`).waitFor();
     await page.locator('[data-test-attach-button]').click();
     await page.locator('[data-test-attach-card-btn]').click();
@@ -290,6 +303,7 @@ test.describe('Room messages', () => {
   test('can send only a card as a message', async ({ page }) => {
     const testCard = `${appURL}/hassan`;
     const { username } = await createSubscribedUserAndLogin(page, 'card-only');
+    await openAiAssistant(page);
     let room1 = await getRoomId(page);
     await sendMessage(page, room1, undefined, [testCard]);
     await assertMessages(page, [
@@ -305,6 +319,7 @@ test.describe('Room messages', () => {
       page,
       'auto-attach-file',
     );
+    await openAiAssistant(page);
     await showAllCards(page);
     const testCard = `${appURL}/hassan`;
     await page.locator(`[data-test-cards-grid-item="${testCard}"]`).click();
@@ -361,6 +376,7 @@ test.describe('Room messages', () => {
       page,
       'ensure-files',
     );
+    await openAiAssistant(page);
     await showAllCards(page);
     const testCard = `${appURL}/hassan`;
     await page.locator(`[data-test-cards-grid-item="${testCard}"]`).click();
@@ -467,6 +483,7 @@ test.describe('Room messages', () => {
       page,
       'unsupported-type',
     );
+    await openAiAssistant(page);
     let room1 = await getRoomId(page);
 
     // Send a card that contains a type that matrix doesn't support
@@ -486,6 +503,7 @@ test.describe('Room messages', () => {
       page,
       'remove-card',
     );
+    await openAiAssistant(page);
     await page.locator(`[data-test-room-settled]`).waitFor();
 
     await selectCardFromCatalog(page, testCard);
@@ -545,6 +563,7 @@ test.describe('Room messages', () => {
       page,
       'render-multiple',
     );
+    await openAiAssistant(page);
     const message1 = {
       from: username,
       message: 'message 1',
@@ -569,7 +588,10 @@ test.describe('Room messages', () => {
     await assertMessages(page, [message1, message2]);
 
     await logout(page);
-    await login(page, username, password, { url: appURL });
+    await login(page, username, password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await openRoom(page, room1);
     await assertMessages(page, [message1, message2]);
   });
@@ -581,6 +603,7 @@ test.describe('Room messages', () => {
       page,
       'multi-card',
     );
+    await openAiAssistant(page);
     const message = {
       from: username,
       message: 'message 1',
@@ -602,7 +625,10 @@ test.describe('Room messages', () => {
     await assertMessages(page, [message]);
 
     await logout(page);
-    await login(page, username, password, { url: appURL });
+    await login(page, username, password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await openRoom(page, room1);
     await assertMessages(page, [message]);
   });
@@ -616,6 +642,7 @@ test.describe('Room messages', () => {
       page,
       'no-duplicate-cards',
     );
+    await openAiAssistant(page);
     await page.locator(`[data-test-room-settled]`).waitFor();
 
     await selectCardFromCatalog(page, testCard2);
@@ -647,6 +674,7 @@ test.describe('Room messages', () => {
     const testCard5 = `${appURL}/van-gogh`;
 
     await createSubscribedUserAndLogin(page, 'view-all');
+    await openAiAssistant(page);
     await page.locator(`[data-test-room-settled]`).waitFor();
 
     await selectCardFromCatalog(page, testCard1);
@@ -677,6 +705,7 @@ test.describe('Room messages', () => {
       credentials: Credentials;
     }> {
       const user = await createSubscribedUserAndLogin(page, prefix);
+      await openAiAssistant(page);
       await getRoomId(page);
       await showAllCards(page);
       return user;
@@ -972,6 +1001,7 @@ test.describe('Room messages', () => {
       page,
       'ai-panel-open',
     );
+    await openAiAssistant(page);
     await page
       .locator('[data-test-stack-card] [data-test-close-button]')
       .click();
@@ -999,6 +1029,7 @@ test.describe('Room messages', () => {
       page,
       'attach-multiple',
     );
+    await openAiAssistant(page);
     await page.locator(`[data-test-room-settled]`).waitFor();
     await showAllCards(page);
 
@@ -1039,6 +1070,7 @@ test.describe('Room messages', () => {
 
   test('it escapes html code sent by the user', async ({ page }) => {
     await createSubscribedUserAndLogin(page, 'escape-html');
+    await openAiAssistant(page);
     await page
       .locator('[data-test-message-field]')
       .fill('<h1>Hello, world!</h1><script>alert("Hello, world!")</script>');
@@ -1058,6 +1090,7 @@ test.describe('Room messages', () => {
 
   test('displays error message if message is too large', async ({ page }) => {
     await createSubscribedUserAndLogin(page, 'message-too-large');
+    await openAiAssistant(page);
 
     await page.locator('[data-test-message-field]').fill('a'.repeat(65000));
     await page.locator('[data-test-send-message-btn]').click();
@@ -1080,6 +1113,7 @@ test.describe('Room messages', () => {
       page,
       'filter-m-replace',
     );
+    await openAiAssistant(page);
     let room1 = await getRoomId(page);
 
     let event1 = await putEvent(

--- a/packages/matrix/tests/room-creation.spec.ts
+++ b/packages/matrix/tests/room-creation.spec.ts
@@ -8,6 +8,7 @@ import {
   openRoom,
   openRenameMenu,
   reloadAndOpenAiAssistant,
+  openAiAssistant,
   clearLocalStorage,
   sendMessage,
   getRoomId,
@@ -35,7 +36,10 @@ test.describe('Room creation', () => {
   });
 
   test('it can create a room', async ({ page }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
 
     let room1: string;
     await expect(async () => {
@@ -54,6 +58,7 @@ test.describe('Room creation', () => {
     const page2 = await context.newPage();
     await setRealmRedirects(page2);
     await page2.goto(appURL);
+    await openAiAssistant(page2);
     await openRoom(page, room1);
     await openRoom(page2, room2);
     await page.reload();
@@ -66,7 +71,10 @@ test.describe('Room creation', () => {
     }).toPass();
 
     await logout(page);
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await expect(async () => {
       await assertRooms(page, [room1, room2]);
     }).toPass();
@@ -75,6 +83,7 @@ test.describe('Room creation', () => {
     await logout(page);
     await login(page, secondUser.username, secondUser.password, {
       url: appURL,
+      openAiAssistant: true,
     });
     await expect(async () => {
       let room1New = await getRoomId(page); // Automatically created room
@@ -87,7 +96,10 @@ test.describe('Room creation', () => {
   test('it does not create a new room when another new room is available [CS-6640]', async ({
     page,
   }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
 
     let room = await getRoomId(page); // Automatically created room
     await expect(page.locator(`[data-test-create-room-btn]`)).toBeDisabled();
@@ -109,13 +121,17 @@ test.describe('Room creation', () => {
     await assertRooms(page, [room, newRoom]);
 
     await logout(page);
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await assertRooms(page, [room, newRoom]);
 
     // user2 should not be able to see user1's room
     await logout(page);
     await login(page, secondUser.username, secondUser.password, {
       url: appURL,
+      openAiAssistant: true,
     });
     await expect(async () => {
       let user2Room = await getRoomId(page);
@@ -128,7 +144,10 @@ test.describe('Room creation', () => {
   // skipping flaky test: re-enabled while we work on the fix.
   // https://linear.app/cardstack/issue/CS-7637/flaky-test-room-creationspects1217-%E2%80%BA-room-creation-%E2%80%BA-it-can-rename-a
   test('it can rename a room [CS-7637]', async ({ page }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
 
     let room1 = await getRoomId(page);
     await assertRooms(page, [room1]);
@@ -176,12 +195,18 @@ test.describe('Room creation', () => {
     await assertRooms(page, [room1, room2, room3]);
 
     await logout(page);
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await assertRooms(page, [room1, room2, room3]);
   });
 
   test('it can cancel renaming a room', async ({ page }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
 
     let room1 = await getRoomId(page);
     await assertRooms(page, [room1]);
@@ -219,7 +244,10 @@ test.describe('Room creation', () => {
   test('room names do not persist across different user sessions', async ({
     page,
   }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
 
     let room = await getRoomId(page);
     await sendMessage(page, room, 'Hello');
@@ -242,6 +270,7 @@ test.describe('Room creation', () => {
     await logout(page);
     await login(page, xUser.username, xUser.password, {
       url: appURL,
+      openAiAssistant: true,
     });
 
     await expect(page.locator(`[data-test-close-ai-assistant]`)).toHaveCount(1);
@@ -251,7 +280,10 @@ test.describe('Room creation', () => {
   });
   // CS-9594 tracking this test erroring
   test.skip('it can delete a room', async ({ page }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await page.locator(`[data-test-room-settled]`).waitFor();
     let roomsBeforeDeletion = await getRoomsFromSync(
       firstUser.username,
@@ -313,7 +345,10 @@ test.describe('Room creation', () => {
   });
 
   test('it can cancel deleting a room', async ({ page }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     let room = await getRoomId(page);
     await assertRooms(page, [room]);
 
@@ -345,7 +380,10 @@ test.describe('Room creation', () => {
     // This test creates 3 rooms, sends messages, deletes all 3, then waits
     // for auto-creation — needs more than the default 60s timeout.
     test.setTimeout(120_000);
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await page.locator(`[data-test-room-settled]`).waitFor();
     let room1 = await getRoomId(page);
     await sendMessage(page, room1, 'Room 1');
@@ -412,7 +450,10 @@ test.describe('Room creation', () => {
   test('it orders past-sessions list items based on last activity in reverse chronological order [CS-7603]', async ({
     page,
   }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     let room1 = await getRoomId(page);
     await sendMessage(page, room1, 'Room 1');
     let room2 = await createRoomWithMessage(page, 'Room 2');

--- a/packages/matrix/tests/skills.spec.ts
+++ b/packages/matrix/tests/skills.spec.ts
@@ -5,6 +5,7 @@ import {
   logout,
   createRoom,
   getRoomId,
+  openAiAssistant,
   openRoom,
   assertMessages,
   sendMessage,
@@ -61,7 +62,10 @@ test.describe('Skills', () => {
   const serverIndexUrl = new URL(appURL).origin;
 
   test(`it can attach skill cards and toggle activation`, async ({ page }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await getRoomId(page);
     await expect(page.locator('[data-test-new-session]')).toHaveCount(1);
     await expect(page.locator('[data-test-skill-menu]')).toHaveCount(1);
@@ -141,7 +145,10 @@ test.describe('Skills', () => {
   test.skip('it will attach code editing skills in code mode by default', async ({
     page,
   }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await page.locator(`[data-test-room-settled]`).waitFor();
 
     await page.locator('[data-test-submode-switcher] button').click();
@@ -168,7 +175,10 @@ test.describe('Skills', () => {
   test(`room skills state does not leak when switching rooms`, async ({
     page,
   }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     let room1 = await getRoomId(page);
 
     await attachSkill(page, skillCard1, true);
@@ -221,7 +231,10 @@ test.describe('Skills', () => {
   });
 
   test(`can attach more skills during chat`, async ({ page }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     let room1 = await getRoomId(page);
     await attachSkill(page, skillCard2, true);
     await sendMessage(page, room1, 'Message 1');
@@ -238,7 +251,10 @@ test.describe('Skills', () => {
   });
 
   test(`can disable all skills`, async ({ page }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     let room1 = await getRoomId(page);
     await attachSkill(page, skillCard1, true);
     await attachSkill(page, skillCard2);
@@ -281,7 +297,10 @@ test.describe('Skills', () => {
   });
 
   test(`previously disabled skills can be enabled`, async ({ page }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     let room1 = await getRoomId(page);
     await attachSkill(page, skillCard1, true);
     await attachSkill(page, skillCard2);
@@ -313,7 +332,10 @@ test.describe('Skills', () => {
   test(`skills are persisted per room and do not leak between different users`, async ({
     page,
   }) => {
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     let room1 = await getRoomId(page);
     await attachSkill(page, skillCard1, true);
     await attachSkill(page, skillCard2);
@@ -331,6 +353,7 @@ test.describe('Skills', () => {
     await logout(page);
     await login(page, secondUser.username, secondUser.password, {
       url: appURL,
+      openAiAssistant: true,
     });
     await getRoomId(page);
     await expect(page.locator('[data-test-active-skills-count]')).toContainText(
@@ -342,7 +365,10 @@ test.describe('Skills', () => {
     );
 
     await logout(page);
-    await login(page, firstUser.username, firstUser.password, { url: appURL });
+    await login(page, firstUser.username, firstUser.password, {
+      url: appURL,
+      openAiAssistant: true,
+    });
     await openRoom(page, room1);
     await expect(page.locator('[data-test-active-skills-count]')).toContainText(
       '2 Skills',
@@ -361,6 +387,7 @@ test.describe('Skills', () => {
     await createRealm(page, realmName);
     const realmURL = new URL(`${username}/${realmName}/`, serverIndexUrl).href;
     await page.goto(realmURL);
+    await openAiAssistant(page);
     await showAllCards(page);
 
     // create a skill card
@@ -445,7 +472,7 @@ test.describe('Skills', () => {
     ).toHaveText(
       'Here is an updated command you might find useful: * switch-submode: use this with "code" to go to code mode and "interact" to go to interact mode.',
     );
-    await page.locator('[data-test-open-ai-assistant]').click();
+    await openAiAssistant(page);
     await expect(
       page.locator('[data-test-field="instructions"] .content'),
     ).toHaveText(

--- a/packages/matrix/tests/tools.spec.ts
+++ b/packages/matrix/tests/tools.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from './fixtures.ts';
 import { putEvent } from '../support/synapse/index.ts';
 import {
   getRoomId,
+  openAiAssistant,
   sendMessage,
   createSubscribedUserAndLogin,
   getRoomEvents,
@@ -56,6 +57,7 @@ test.describe('Commands', () => {
     });
 
     await page.goto(realmURL);
+    await openAiAssistant(page);
     let room1 = await getRoomId(page);
     await showAllCards(page);
     let realmCard = page.locator(`[data-test-cards-grid-item="${cardId}"]`);
@@ -113,6 +115,7 @@ test.describe('Commands', () => {
     });
 
     await page.goto(realmURL);
+    await openAiAssistant(page);
     let room1 = await getRoomId(page);
     await showAllCards(page);
     let realmCard = page.locator(`[data-test-cards-grid-item="${cardId}"]`);
@@ -168,6 +171,7 @@ test.describe('Commands', () => {
     });
 
     await page.goto(realmURL);
+    await openAiAssistant(page);
     let room1 = await getRoomId(page);
     await showAllCards(page);
     let newCard = page.locator(`[data-test-cards-grid-item="${cardId}"]`);
@@ -230,6 +234,7 @@ test.describe('Commands', () => {
   }) => {
     const { username, password, credentials } =
       await createSubscribedUserAndLogin(page, 'commands-search');
+    await openAiAssistant(page);
     let room1 = await getRoomId(page);
     let cardId = `${appURL}/hassan`;
     let commandRequestId = '1';
@@ -307,6 +312,7 @@ test.describe('Commands', () => {
     const realmURL = new URL(`${username}/${realmName}/`, serverIndexUrl).href;
 
     await page.goto(realmURL);
+    await openAiAssistant(page);
     await showAllCards(page);
 
     // create a skill card


### PR DESCRIPTION
## Summary

The AI Assistant panel opened by default on a first-ever visit. This defaults it to **closed** so the initial experience — particularly for new users during onboarding — isn't dominated by the assistant.

Resolution order is unchanged aside from the first-visit default:

- **Fresh visit, never toggled** → closed
- **URL `operatorModeState` carries `aiAssistantOpen`** → wins (open or closed)
- **Opened last session (same login)** → reopens, via the remembered `boxel-ai-assistant-open` localStorage preference
- **On logout** → the remembered preference is cleared, so the next login starts closed

## Changes

- `operator-mode-state-service`: `readPersistedAiAssistantOpen()` now defaults to `false` (was `true`) for first-ever visits.
- `local-storage-keys`: `clearLocalStorage()` (called on logout) now removes the `boxel-ai-assistant-open` key.

## Test coverage

- **Unit** (`operator-mode-state-service-test`): closed-by-default with no URL/localStorage; remembered-open path; existing URL-precedence tests unchanged.
- **Acceptance**: end-to-end closed-by-default when the URL omits `aiAssistantOpen` (`ai-assistant-test`); logout clears the preference (`operator-mode-acceptance-test`).

Resolves [CS-12273](https://linear.app/cardstack/issue/CS-12273/hide-ai-assistant-by-default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)