### PR TITLE
fix: Add more typecheck fixes for CLI parse

### DIFF
--- a/packages/boxel-cli/scripts/build-types.ts
+++ b/packages/boxel-cli/scripts/build-types.ts
@@ -14,6 +14,14 @@
  *                                   --declaration --emitDeclarationOnly`).
  *                                   Source `.d.ts` files in `base/types`
  *                                   are passed through as-is.
+ * - `bundled-types/runtime-common/` — auto-generated `.d.ts` for
+ *                                   `packages/runtime-common`. See
+ *                                   `buildRuntimeCommonDts()`. Backs the
+ *                                   `@cardstack/runtime-common` path
+ *                                   alias; base's `.d.ts` import its
+ *                                   `primitive`/`realmURL` symbols and
+ *                                   field/query types, on which card
+ *                                   field-value typing depends.
  * - `bundled-types/host-types/`  — `packages/host/types/*` ambient
  *                                   `.d.ts` files, referenced via the
  *                                   `'*': ['<host>/types/*']` fallback
@@ -303,8 +311,108 @@ function annotateInferredTypes(code: string): string {
     );
 }
 
+/**
+ * Generate `.d.ts` for every module in `packages/runtime-common` and
+ * copy them into the destination. Runtime-common is plain `.ts` (no
+ * `<template>`), so unlike `base/` there's no content-tag preprocess and
+ * no `: any` annotation — the declarations emit faithfully.
+ *
+ * That fidelity is the point: `base/`'s bundled `.d.ts` imports the
+ * `primitive` / `realmURL` `unique symbol`s and the field / query types
+ * from `@cardstack/runtime-common`, and card-api's field-value mapping
+ * (`@model.someNumberField` → `number`, via `T extends { [primitive]:
+ * infer P }`) only resolves when those symbol identities are present.
+ * Card code reaches these through the `@cardstack/runtime-common` path
+ * alias in parse.ts's tsconfig.
+ */
+function buildRuntimeCommonDts(rcSrc: string, rcDst: string): void {
+  let tmpDir = mkdtempSync(join(tmpdir(), 'boxel-cli-rc-dts-'));
+  try {
+    // Copy `.ts` source into tmpDir (skip node_modules/dist/tests).
+    // Pre-existing `.d.ts` are passed through; tsc emits the rest.
+    let preexistingDts: string[] = [];
+    let walk = (dir: string): void => {
+      for (let entry of readdirSync(dir, { withFileTypes: true })) {
+        if (
+          entry.name === 'node_modules' ||
+          entry.name === 'dist' ||
+          entry.name.startsWith('.cache')
+        ) {
+          continue;
+        }
+        let full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        let rel = relative(rcSrc, full);
+        if (!rel.endsWith('.ts')) continue;
+        // Tests aren't part of the type surface and drag in test deps.
+        if (rel.endsWith('.test.ts') || rel.startsWith('tests/')) continue;
+        let dst = join(tmpDir, rel);
+        mkdirSync(dirname(dst), { recursive: true });
+        writeFileSync(dst, readFileSync(full, 'utf8'), 'utf8');
+        if (rel.endsWith('.d.ts')) preexistingDts.push(rel);
+      }
+    };
+    walk(rcSrc);
+
+    // Link host's node_modules so runtime-common's imports resolve.
+    let nodeModulesLink = join(tmpDir, 'node_modules');
+    if (!existsSync(nodeModulesLink)) {
+      execFileSync(
+        'ln',
+        [
+          '-sf',
+          join(MONOREPO_PACKAGES, 'host', 'node_modules'),
+          'node_modules',
+        ],
+        { cwd: tmpDir },
+      );
+    }
+
+    let outDir = join(tmpDir, '.dts-out');
+    let tsconfig = {
+      extends: join(MONOREPO_PACKAGES, 'host', 'tsconfig.json'),
+      compilerOptions: {
+        noEmit: false,
+        declaration: true,
+        emitDeclarationOnly: true,
+        outDir,
+        inlineSourceMap: false,
+        inlineSources: false,
+        noUnusedLocals: false,
+        noUnusedParameters: false,
+        skipLibCheck: true,
+        rootDir: tmpDir,
+      },
+      include: ['**/*.ts'],
+    };
+    let tsconfigPath = join(tmpDir, 'tsconfig.json');
+    writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 2), 'utf8');
+
+    // Same sandboxed emit as base/: declarations for imports that reach
+    // outside rootDir (host, base) are dropped rather than written to
+    // their source locations.
+    runTscEmitOnly(tsconfigPath, outDir);
+
+    rmSync(rcDst, { recursive: true, force: true });
+    mkdirSync(rcDst, { recursive: true });
+    if (existsSync(outDir)) {
+      cpSync(outDir, rcDst, { recursive: true });
+    }
+    for (let rel of preexistingDts) {
+      let to = join(rcDst, rel);
+      mkdirSync(dirname(to), { recursive: true });
+      cpSync(join(tmpDir, rel), to);
+    }
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
 // ---------------------------------------------------------------------------
-// Simple-copy vendors (everything except `base/`)
+// Simple-copy vendors (everything except `base/` and `runtime-common/`)
 // ---------------------------------------------------------------------------
 
 interface Vendor {
@@ -482,6 +590,21 @@ function main(): void {
   let baseSize = dirSize(baseDst);
   total += baseSize;
   console.log(`${(baseSize / 1024 / 1024).toFixed(2)} MB`);
+
+  // runtime-common runs through the .d.ts pipeline too: base's bundled
+  // declarations import its symbols and types, and card field-value
+  // typing depends on them.
+  let rcSrc = join(MONOREPO_PACKAGES, 'runtime-common');
+  let rcDst = join(outRoot, 'runtime-common');
+  if (!safeIsDirectory(rcSrc)) {
+    console.error(`Missing packages/runtime-common at ${rcSrc}`);
+    process.exit(1);
+  }
+  process.stdout.write('  runtime-common … (running tsc --declaration) ');
+  buildRuntimeCommonDts(rcSrc, rcDst);
+  let rcSize = dirSize(rcDst);
+  total += rcSize;
+  console.log(`${(rcSize / 1024 / 1024).toFixed(2)} MB`);
 
   // Other vendors are simple copies with filters.
   for (let vendor of VENDORS) {

--- a/packages/boxel-cli/scripts/build-types.ts
+++ b/packages/boxel-cli/scripts/build-types.ts
@@ -346,13 +346,18 @@ function buildRuntimeCommonDts(rcSrc: string, rcDst: string): void {
           continue;
         }
         let rel = relative(rcSrc, full);
-        if (!rel.endsWith('.ts')) continue;
+        // Include `.mts` / `.cts` too, not just `.ts`: runtime-common has
+        // `marked.mts`, imported by exported modules (bfm-math, marked-
+        // sync, …). Dropping it leaves dangling `./marked.mts` references
+        // in their emitted `.d.ts` — which, under parse's skipLibCheck,
+        // silently collapse the affected types to `any`.
+        if (!/\.(m|c)?ts$/.test(rel)) continue;
         // Tests aren't part of the type surface and drag in test deps.
-        if (rel.endsWith('.test.ts') || rel.startsWith('tests/')) continue;
+        if (/\.test\.(m|c)?ts$/.test(rel) || rel.startsWith('tests/')) continue;
         let dst = join(tmpDir, rel);
         mkdirSync(dirname(dst), { recursive: true });
         writeFileSync(dst, readFileSync(full, 'utf8'), 'utf8');
-        if (rel.endsWith('.d.ts')) preexistingDts.push(rel);
+        if (/\.d\.(m|c)?ts$/.test(rel)) preexistingDts.push(rel);
       }
     };
     walk(rcSrc);
@@ -386,7 +391,9 @@ function buildRuntimeCommonDts(rcSrc: string, rcDst: string): void {
         skipLibCheck: true,
         rootDir: tmpDir,
       },
-      include: ['**/*.ts'],
+      // `**/*.ts` doesn't match `.mts` / `.cts`, so include them too or
+      // tsc won't emit declarations for `marked.mts` (copied above).
+      include: ['**/*.ts', '**/*.mts', '**/*.cts'],
     };
     let tsconfigPath = join(tmpDir, 'tsconfig.json');
     writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 2), 'utf8');

--- a/packages/boxel-cli/scripts/build-types.ts
+++ b/packages/boxel-cli/scripts/build-types.ts
@@ -418,6 +418,79 @@ function buildRuntimeCommonDts(rcSrc: string, rcDst: string): void {
   }
 }
 
+/**
+ * Fail the build if any emitted declaration in `bundleDir` imports a
+ * *relative* module that isn't present in the bundle. Generated `.d.ts`
+ * keep the source's relative specifiers (e.g. `./marked.mts`), so a
+ * source file dropped from the emit leaves a dangling reference. Under
+ * `boxel parse`'s `skipLibCheck` that never errors — the referenced types
+ * silently collapse to `any`, quietly weakening the type-check the bundle
+ * exists to strengthen. Catch it here, at build time, where it's loud.
+ *
+ * Only relative specifiers are checked; bare package imports resolve
+ * against node_modules at parse time (see parse.ts's linkResolvedDeps),
+ * and non-module assets (`.json`, `.css`, …) are skipped.
+ */
+function assertBundleDeclRefsResolve(bundleDir: string, label: string): void {
+  let declFiles: string[] = [];
+  let walk = (dir: string): void => {
+    for (let entry of readdirSync(dir, { withFileTypes: true })) {
+      let full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.d\.(m|c)?ts$/.test(entry.name)) declFiles.push(full);
+    }
+  };
+  walk(bundleDir);
+
+  // Captures the relative specifier of `from '…'`, `import('…')`, and
+  // `require('…')`.
+  let specRe =
+    /(?:\bfrom\s*|(?:\bimport|\brequire)\s*\(\s*)['"](\.\.?\/[^'"]+)['"]/g;
+  let dangling: string[] = [];
+  for (let file of declFiles) {
+    let content = readFileSync(file, 'utf8');
+    let match: RegExpExecArray | null;
+    while ((match = specRe.exec(content))) {
+      let spec = match[1];
+      let ext = spec.match(/\.[a-z0-9]+$/i)?.[0];
+      // Skip non-module assets; a specifier is a module ref when it's
+      // extensionless or carries a TS/JS extension.
+      if (
+        ext &&
+        !['.ts', '.mts', '.cts', '.js', '.mjs', '.cjs'].includes(ext)
+      ) {
+        continue;
+      }
+      let base = resolve(dirname(file), spec);
+      let stem = base.replace(/\.(d\.)?(m|c)?[tj]s$/i, '');
+      let candidates = [
+        base,
+        stem + '.d.ts',
+        stem + '.d.mts',
+        stem + '.d.cts',
+        join(stem, 'index.d.ts'),
+        join(stem, 'index.d.mts'),
+        join(stem, 'index.d.cts'),
+      ];
+      if (!candidates.some((c) => existsSync(c))) {
+        dangling.push(`${relative(bundleDir, file)} → ${spec}`);
+      }
+    }
+  }
+
+  if (dangling.length) {
+    console.error(
+      `\nBundle integrity check failed for ${label}: emitted declarations ` +
+        `reference files missing from the bundle. A dropped source leaves a ` +
+        `dangling relative import that skipLibCheck silently turns into ` +
+        `\`any\`. Include the missing source in the .d.ts build:\n` +
+        dangling.map((d) => `  ${d}`).join('\n') +
+        '\n',
+    );
+    process.exit(1);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Simple-copy vendors (everything except `base/` and `runtime-common/`)
 // ---------------------------------------------------------------------------
@@ -609,6 +682,7 @@ function main(): void {
   }
   process.stdout.write('  runtime-common … (running tsc --declaration) ');
   buildRuntimeCommonDts(rcSrc, rcDst);
+  assertBundleDeclRefsResolve(rcDst, 'runtime-common');
   let rcSize = dirSize(rcDst);
   total += rcSize;
   console.log(`${(rcSize / 1024 / 1024).toFixed(2)} MB`);

--- a/packages/boxel-cli/src/commands/parse.ts
+++ b/packages/boxel-cli/src/commands/parse.ts
@@ -99,6 +99,14 @@ const BOXEL_UI_PATH = BUNDLED_TYPES_DIR
 const LOCAL_TYPES_PATH = BUNDLED_TYPES_DIR
   ? join(BUNDLED_TYPES_DIR, 'local-types')
   : join(PACKAGES_PATH, 'local-types');
+// `@cardstack/runtime-common` is a devDependency, so `npm install` of a
+// published CLI never installs it. Bundle its generated `.d.ts` and
+// alias the bare + subpath specifiers to it; base's bundled `.d.ts`
+// import its `primitive` symbol and field/query types, which card
+// field-value typing depends on.
+const RUNTIME_COMMON_PATH = BUNDLED_TYPES_DIR
+  ? join(BUNDLED_TYPES_DIR, 'runtime-common')
+  : join(PACKAGES_PATH, 'runtime-common');
 // Ambient module decls for paths boxel-cli doesn't ship full types
 // for (e.g. `@cardstack/boxel-icons/*` — 130MB if shipped). Generated
 // by `scripts/build-types.ts`. Only present in published / built
@@ -592,6 +600,8 @@ async function runGlintCheck(
           paths: {
             '@cardstack/base/*': [`${BASE_PKG_PATH}/*`],
             'https://cardstack.com/base/*': [`${BASE_PKG_PATH}/*`],
+            '@cardstack/runtime-common': [`${RUNTIME_COMMON_PATH}/index`],
+            '@cardstack/runtime-common/*': [`${RUNTIME_COMMON_PATH}/*`],
             '@cardstack/host/tests/*': [`${HOST_TESTS_PATH}/*`],
             '@cardstack/host/*': [`${HOST_APP_PATH}/*`],
             '@cardstack/boxel-host/commands/*': [`${HOST_APP_PATH}/commands/*`],

--- a/packages/boxel-cli/src/commands/parse.ts
+++ b/packages/boxel-cli/src/commands/parse.ts
@@ -135,18 +135,25 @@ const HOST_NODE_MODULES_PATH = join(PACKAGES_PATH, 'host', 'node_modules');
 // one would hide the rest. Resolve each package from the CLI's location
 // instead (Node's resolver walks the ancestor chain, finding nested and
 // hoisted alike) and symlink each into the workspace individually.
-const GLINT_RESOLVE_PACKAGES = [
-  '@glint/ember-tsc',
-  'content-tag',
-  '@glimmer/component',
-  '@glimmer/tracking',
-  'qunit',
-  // qunit ships no types of its own — `@types/qunit` supplies them, and
-  // qunit-dom augments that `Assert` interface. Both must be linked or a
-  // `.test.gts` calling `assert.dom(...)` fails to resolve `qunit`.
-  '@types/qunit',
-  'qunit-dom',
-];
+//
+// The set to link is exactly the CLI's own declared `dependencies`: each
+// is there so card code (or a `.test.gts`) can resolve it —
+// `@glint/ember-tsc`, `content-tag`, `@glimmer/*`, `qunit`, `qunit-dom`,
+// `@types/qunit`, `@universal-ember/test-support`, … Deriving the list
+// from package.json (rather than hand-maintaining one) keeps it from
+// silently drifting out of date — a curated list already dropped
+// `@types/qunit` and `@universal-ember/test-support`, each a
+// published-install-only "Cannot find module" regression.
+const CLI_DEPENDENCY_PACKAGES = (() => {
+  try {
+    let pkg = JSON.parse(
+      readFileSync(join(BOXEL_CLI_PATH, 'package.json'), 'utf8'),
+    ) as { dependencies?: Record<string, string> };
+    return Object.keys(pkg.dependencies ?? {});
+  } catch {
+    return [];
+  }
+})();
 
 let cachedTsconfigContent: string | undefined;
 
@@ -563,11 +570,11 @@ function resolvePackageRoot(pkg: string): string | undefined {
  * Assemble the temp workspace's `node_modules` by symlinking each
  * resolvable runtime dep individually. Unlike a single node_modules
  * symlink, this gathers deps that a published install may have split
- * across the nested and hoisted node_modules (see GLINT_RESOLVE_PACKAGES).
+ * across the nested and hoisted node_modules (see CLI_DEPENDENCY_PACKAGES).
  */
 function linkResolvedDeps(nodeModulesDir: string): void {
   mkdirSync(nodeModulesDir, { recursive: true });
-  for (let pkg of GLINT_RESOLVE_PACKAGES) {
+  for (let pkg of CLI_DEPENDENCY_PACKAGES) {
     let root = resolvePackageRoot(pkg);
     if (!root) continue;
     let dest = join(nodeModulesDir, pkg);

--- a/packages/boxel-cli/src/commands/parse.ts
+++ b/packages/boxel-cli/src/commands/parse.ts
@@ -709,7 +709,7 @@ async function runGlintCheck(
         file: originalFile.path,
         line: parseInt(lineStr, 10),
         column: parseInt(colStr, 10),
-        message,
+        message: explainDiagnostic(tsCode, message),
       });
     }
 
@@ -731,6 +731,28 @@ async function runGlintCheck(
       // best-effort cleanup
     }
   }
+}
+
+/**
+ * Turn a few cryptic TS diagnostics into actionable guidance for card
+ * authors. The raw text is accurate but doesn't say what to change.
+ */
+function explainDiagnostic(tsCode: string, message: string): string {
+  // TS1206 "Decorators are not valid here." Card code hits this when a
+  // decorator (`@tracked`, `@field`) sits on a member of a format-class
+  // *expression* (`static isolated = class { … }`). TypeScript's legacy
+  // decorators are only allowed on class *declarations*, so this pattern
+  // can't type-check even though it runs. The fix is to move the reactive
+  // state into a top-level component the format class renders.
+  if (tsCode === 'TS1206') {
+    return (
+      `${message} Decorators like @tracked aren't allowed inside a ` +
+      `format-class expression (e.g. \`static isolated = class { … }\`). ` +
+      `Move reactive state into a top-level component that the format ` +
+      `class renders.`
+    );
+  }
+  return message;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/boxel-cli/src/commands/parse.ts
+++ b/packages/boxel-cli/src/commands/parse.ts
@@ -115,42 +115,38 @@ const SHIMS_PATH = BUNDLED_TYPES_DIR
   ? join(BUNDLED_TYPES_DIR, 'shims')
   : undefined;
 
-// Node modules: in-monorepo, host has every transitive dep glint needs
-// already installed. In a published install we don't ship host's
-// node_modules, so we resolve against the CLI's own runtime deps:
-// `@glint/ember-tsc`, `typescript`, and `content-tag`, plus the packages
-// card code itself commonly imports — `@glimmer/component` and
-// `@glimmer/tracking`. Imports outside that set surface as "Cannot find
-// module …" parse errors; the fix is adding the package as a boxel-cli
-// dependency, not shimming it.
+// The temp parse workspace needs the CLI's runtime deps resolvable so
+// glint can type-check card code: `@glint/ember-tsc` (and its
+// `-private/dsl`, which every compiled template imports), `content-tag`,
+// the packages card code commonly imports — `@glimmer/component`,
+// `@glimmer/tracking` — plus `qunit` / `qunit-dom` for `.test.gts`.
+// Imports outside that set surface as "Cannot find module …"; the fix is
+// adding the package as a boxel-cli dependency, not shimming it.
 //
-// Those deps live in different places depending on the install layout:
-//   - pnpm keeps them in the CLI's own nested `node_modules`
-//     (`<cli>/node_modules`).
-//   - npm hoists them to the install root's `node_modules`, leaving the
-//     CLI's nested dir empty or absent.
-// Resolving against the nested dir alone would find nothing under npm:
-// `qunit-dom` and every compiled template's
-// `@glint/ember-tsc/-private/dsl` import go unresolved and glint exits
-// non-zero having type-checked nothing. Prefer the nested dir when it
-// actually carries the deps; otherwise use the `node_modules` that Node's
-// own resolver finds `@glint/ember-tsc` in — the hoisted root under npm.
-// Both resolve the CLI's runtime deps identically.
-const NODE_MODULES_PATH = (() => {
-  if (!BUNDLED_TYPES_DIR) {
-    return join(PACKAGES_PATH, 'host', 'node_modules');
-  }
-  let nested = join(BOXEL_CLI_PATH, 'node_modules');
-  if (existsSync(join(nested, '@glint', 'ember-tsc'))) {
-    return nested;
-  }
-  // `<node_modules>/@glint/ember-tsc/lib/index.js` → walk back to the
-  // `node_modules` that contains it (three levels up from the lib dir).
-  let mainEntry = require.resolve('@glint/ember-tsc', {
-    paths: [BOXEL_CLI_PATH],
-  });
-  return resolve(dirname(mainEntry), '..', '..', '..');
-})();
+// In the monorepo (no bundled-types) host's node_modules carries the full
+// transitive set in one place, so a single symlink suffices.
+const HOST_NODE_MODULES_PATH = join(PACKAGES_PATH, 'host', 'node_modules');
+
+// In a published install those deps can be split across dirs. Usually
+// they're all at the install root (npm hoisting) or all in the CLI's own
+// nested node_modules (pnpm) — but a consumer that pins an incompatible
+// `@glint/ember-tsc` makes npm nest the CLI's copy while other deps stay
+// hoisted, so no single node_modules dir holds them all and symlinking
+// one would hide the rest. Resolve each package from the CLI's location
+// instead (Node's resolver walks the ancestor chain, finding nested and
+// hoisted alike) and symlink each into the workspace individually.
+const GLINT_RESOLVE_PACKAGES = [
+  '@glint/ember-tsc',
+  'content-tag',
+  '@glimmer/component',
+  '@glimmer/tracking',
+  'qunit',
+  // qunit ships no types of its own — `@types/qunit` supplies them, and
+  // qunit-dom augments that `Assert` interface. Both must be linked or a
+  // `.test.gts` calling `assert.dom(...)` fails to resolve `qunit`.
+  '@types/qunit',
+  'qunit-dom',
+];
 
 let cachedTsconfigContent: string | undefined;
 
@@ -544,10 +540,47 @@ async function fetchSource(
 // ---------------------------------------------------------------------------
 
 /**
+ * Locate an installed package's root by walking `node_modules` up the
+ * ancestor chain from the CLI, exactly as Node's own resolver does — so
+ * it finds the package whether it's nested in the CLI's node_modules or
+ * hoisted to the install root, and (unlike `require.resolve`) it also
+ * finds type-only `@types/*` packages, which have no runtime entry.
+ * Returns undefined when the package isn't installed (a card importing it
+ * then gets a normal "Cannot find module" diagnostic).
+ */
+function resolvePackageRoot(pkg: string): string | undefined {
+  let dir = BOXEL_CLI_PATH;
+  for (;;) {
+    let candidate = join(dir, 'node_modules', pkg);
+    if (existsSync(join(candidate, 'package.json'))) return candidate;
+    let parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+/**
+ * Assemble the temp workspace's `node_modules` by symlinking each
+ * resolvable runtime dep individually. Unlike a single node_modules
+ * symlink, this gathers deps that a published install may have split
+ * across the nested and hoisted node_modules (see GLINT_RESOLVE_PACKAGES).
+ */
+function linkResolvedDeps(nodeModulesDir: string): void {
+  mkdirSync(nodeModulesDir, { recursive: true });
+  for (let pkg of GLINT_RESOLVE_PACKAGES) {
+    let root = resolvePackageRoot(pkg);
+    if (!root) continue;
+    let dest = join(nodeModulesDir, pkg);
+    mkdirSync(dirname(dest), { recursive: true }); // scoped pkgs → @scope dir
+    symlinkSync(root, dest);
+  }
+}
+
+/**
  * Run `ember-tsc --noEmit` against a set of `.gts` / `.gjs` / `.ts`
- * files in a temp dir. Symlinks the host package's node_modules and
- * writes a tsconfig with the same monorepo path mappings the realm
- * uses at runtime, then parses TS diagnostics from stdout.
+ * files in a temp dir. Makes the CLI's runtime deps resolvable in the
+ * workspace and writes a tsconfig with the same monorepo path mappings
+ * the realm uses at runtime, then parses TS diagnostics from stdout.
  */
 async function runGlintCheck(
   files: { path: string; content: string }[],
@@ -629,7 +662,14 @@ async function runGlintCheck(
       'utf8',
     );
 
-    symlinkSync(NODE_MODULES_PATH, join(tempDir, 'node_modules'));
+    if (BUNDLED_TYPES_DIR) {
+      // Published install: deps may be split across nested + hoisted
+      // node_modules, so resolve and link each individually.
+      linkResolvedDeps(join(tempDir, 'node_modules'));
+    } else {
+      // Monorepo dev: host's node_modules has the full set in one place.
+      symlinkSync(HOST_NODE_MODULES_PATH, join(tempDir, 'node_modules'));
+    }
 
     // Resolve the package's JS bin entry directly and run it with
     // `node`. Avoids the `.bin/ember-tsc` shim, which is a shell script

--- a/packages/boxel-cli/tests/fixtures/parse/helpers-and-fields/event.gts
+++ b/packages/boxel-cli/tests/fixtures/parse/helpers-and-fields/event.gts
@@ -9,8 +9,8 @@ import NumberField from 'https://cardstack.com/base/number';
 import TextAreaField from 'https://cardstack.com/base/text-area';
 import { formatDateTime } from '@cardstack/boxel-ui/helpers';
 
-// Exercises the common template shapes: the positional
-// `formatDateTime` helper call, and direct interpolation of
+// Exercises the common template shapes: a `formatDateTime` helper call
+// with its `format` named arg, and direct interpolation of
 // `contains(NumberField)` / `contains(TextAreaField)` values.
 export class Event extends CardDef {
   static displayName = 'Event';
@@ -19,7 +19,7 @@ export class Event extends CardDef {
   @field notes = contains(TextAreaField);
   static isolated = class extends Component<typeof Event> {
     <template>
-      <time>{{formatDateTime @model.when 'MMM D'}}</time>
+      <time>{{formatDateTime @model.when format='MMM D'}}</time>
       <span>{{@model.capacity}}</span>
       <p>{{@model.notes}}</p>
     </template>

--- a/packages/boxel-cli/tests/fixtures/parse/test-support/reads-service.test.gts
+++ b/packages/boxel-cli/tests/fixtures/parse/test-support/reads-service.test.gts
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { getService } from '@universal-ember/test-support';
+
+// Realm `.test.gts` files reach for `@universal-ember/test-support`
+// (e.g. `getService`), a direct dependency of the CLI. parse type-checks
+// every discovered `.test.gts`, so the package must resolve in the parse
+// workspace or these tests fail with "Cannot find module".
+module('test-support', function () {
+  test('resolves @universal-ember/test-support', function (assert) {
+    assert.ok(typeof getService === 'function');
+  });
+});

--- a/packages/boxel-cli/tests/integration/parse.test.ts
+++ b/packages/boxel-cli/tests/integration/parse.test.ts
@@ -42,6 +42,10 @@ async function parseFixture(name: string): Promise<ParseRealmResult> {
 //     (the `realmURL` symbol, the `Query` type).
 //   - boxel-host-tools: the `@cardstack/boxel-host/tools/*` alias + the
 //     bundled `tools/` source.
+//   - helpers-and-fields: a `@cardstack/boxel-ui/helpers` call
+//     (`formatDateTime` with its `format` named arg) plus direct
+//     interpolation of `contains(NumberField)` / `contains(TextAreaField)`
+//     field values.
 // ---------------------------------------------------------------------------
 const CLEAN_FIXTURES: { name: string; covers: string }[] = [
   {
@@ -50,6 +54,10 @@ const CLEAN_FIXTURES: { name: string; covers: string }[] = [
   },
   { name: 'runtime-common', covers: 'bare @cardstack/runtime-common import' },
   { name: 'boxel-host-tools', covers: '@cardstack/boxel-host/tools/* import' },
+  {
+    name: 'helpers-and-fields',
+    covers: 'boxel-ui helper call + field interpolation',
+  },
 ];
 
 describe('boxel parse (against the installed CLI)', () => {
@@ -100,8 +108,7 @@ describe('boxel parse (against the installed CLI)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Known typing gaps, deferred to follow-up work. Two card patterns don't
-// type-check clean yet:
+// Known typing gap, deferred to follow-up work:
 //
 //   - tracked-format-class — `@tracked` alongside a `<template>` inside a
 //     `static isolated = class … {}` expression trips glint's
@@ -109,19 +116,14 @@ describe('boxel parse (against the installed CLI)', () => {
 //     limitation for decorators in class expressions; it reproduces in
 //     both the monorepo and the published layout, so it isn't a
 //     bundled-types gap.
-//   - helpers-and-fields — the bundled `@cardstack/boxel-ui/helpers`
-//     `formatDateTime` typing rejects the common positional call
-//     `(formatDateTime @model.when 'MMM D')`. (Its field interpolations
-//     type-check now; the positional helper is the remaining error, and
-//     only in the published layout.)
 //
-// Marked `it.fails`: each is an expected failure while the published CLI
-// lacks support for the pattern, so it runs without failing CI. An
-// unexpected pass makes `it.fails` itself fail — the signal to remove the
-// marker and move the case into the block above.
+// Marked `it.fails`: an expected failure while the CLI lacks support for
+// the pattern, so it runs without failing CI. An unexpected pass makes
+// `it.fails` itself fail — the signal to remove the marker and move the
+// case into the block above.
 // ---------------------------------------------------------------------------
 describe('boxel parse — known typing gaps (deferred)', () => {
-  const DEFERRED = ['helpers-and-fields', 'tracked-format-class'];
+  const DEFERRED = ['tracked-format-class'];
 
   describe.each(DEFERRED)('%s', (name) => {
     it.fails(

--- a/packages/boxel-cli/tests/integration/parse.test.ts
+++ b/packages/boxel-cli/tests/integration/parse.test.ts
@@ -33,22 +33,39 @@ async function parseFixture(name: string): Promise<ParseRealmResult> {
 
 // ---------------------------------------------------------------------------
 // Primary behavior: glint runs against an npm install and the CLI's
-// tsconfig aliases resolve, so real cards type-check clean.
+// tsconfig aliases + bundled types resolve, so real cards type-check
+// clean. Each fixture pins a distinct resolution surface:
+//   - plain-glimmer: field value types (`@model.someNumberField` →
+//     `number`), which resolve through the `primitive` symbol bundled
+//     from @cardstack/runtime-common.
+//   - runtime-common: the bare `@cardstack/runtime-common` import
+//     (the `realmURL` symbol, the `Query` type).
+//   - boxel-host-tools: the `@cardstack/boxel-host/tools/*` alias + the
+//     bundled `tools/` source.
 // ---------------------------------------------------------------------------
+const CLEAN_FIXTURES: { name: string; covers: string }[] = [
+  {
+    name: 'plain-glimmer',
+    covers: 'field value types via the primitive symbol',
+  },
+  { name: 'runtime-common', covers: 'bare @cardstack/runtime-common import' },
+  { name: 'boxel-host-tools', covers: '@cardstack/boxel-host/tools/* import' },
+];
+
 describe('boxel parse (against the installed CLI)', () => {
-  it(
-    'type-checks a card importing @cardstack/boxel-host/tools/* clean',
-    async () => {
-      // Exercises the host-tools path alias + the bundled `tools/`
-      // source. Also proves glint ran end-to-end on a real card in the
-      // installed layout.
-      let result = await parseFixture('boxel-host-tools');
-      expect(result.errors).toEqual([]);
-      expect(result.status).toBe('passed');
-      expect(result.filesChecked).toBeGreaterThanOrEqual(1);
-    },
-    { timeout: 180_000 },
-  );
+  describe.each(CLEAN_FIXTURES)('$name — $covers', ({ name }) => {
+    it(
+      'type-checks clean',
+      async () => {
+        let result = await parseFixture(name);
+        // Surface the actual diagnostics on failure, not a bare count.
+        expect(result.errors).toEqual([]);
+        expect(result.status).toBe('passed');
+        expect(result.filesChecked).toBeGreaterThanOrEqual(1);
+      },
+      { timeout: 180_000 },
+    );
+  });
 
   it(
     'type-checks a .test.gts using assert.dom clean (qunit-dom augmentation)',
@@ -83,23 +100,20 @@ describe('boxel parse (against the installed CLI)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Known typing gaps, deferred to follow-up work. These are card patterns
-// that type-check clean in the monorepo (against host's real types) but
-// not yet in a published install, because the bundled types / glint
-// config don't cover them:
+// Known typing gaps, deferred to follow-up work. Two card patterns don't
+// type-check clean yet:
 //
-//   - runtime-common / field values: card-api resolves field value types
-//     (`@model.someNumberField` → `number`) through the `primitive`
-//     unique symbol imported from `@cardstack/runtime-common`. That
-//     package is a devDependency, which `npm install` of the published
-//     CLI does not install, so the mapping collapses to the field class
-//     (`NumberField`). Fix: bundle runtime-common's generated types.
-//   - decorators: `@tracked` alongside a `<template>` inside a
+//   - tracked-format-class — `@tracked` alongside a `<template>` inside a
 //     `static isolated = class … {}` expression trips glint's
 //     "Decorators are not valid here". A glint/ember-tsc transform
-//     limitation for decorators in class expressions.
-//   - helper arg shapes: the bundled `formatDateTime` typing rejects the
-//     common positional call `(formatDateTime @model.when 'MMM D')`.
+//     limitation for decorators in class expressions; it reproduces in
+//     both the monorepo and the published layout, so it isn't a
+//     bundled-types gap.
+//   - helpers-and-fields — the bundled `@cardstack/boxel-ui/helpers`
+//     `formatDateTime` typing rejects the common positional call
+//     `(formatDateTime @model.when 'MMM D')`. (Its field interpolations
+//     type-check now; the positional helper is the remaining error, and
+//     only in the published layout.)
 //
 // Marked `it.fails`: each is an expected failure while the published CLI
 // lacks support for the pattern, so it runs without failing CI. An
@@ -107,12 +121,7 @@ describe('boxel parse (against the installed CLI)', () => {
 // marker and move the case into the block above.
 // ---------------------------------------------------------------------------
 describe('boxel parse — known typing gaps (deferred)', () => {
-  const DEFERRED = [
-    'plain-glimmer',
-    'runtime-common',
-    'helpers-and-fields',
-    'tracked-format-class',
-  ];
+  const DEFERRED = ['helpers-and-fields', 'tracked-format-class'];
 
   describe.each(DEFERRED)('%s', (name) => {
     it.fails(

--- a/packages/boxel-cli/tests/integration/parse.test.ts
+++ b/packages/boxel-cli/tests/integration/parse.test.ts
@@ -46,6 +46,8 @@ async function parseFixture(name: string): Promise<ParseRealmResult> {
 //     (`formatDateTime` with its `format` named arg) plus direct
 //     interpolation of `contains(NumberField)` / `contains(TextAreaField)`
 //     field values.
+//   - test-support: a `.test.gts` importing `@universal-ember/test-support`
+//     (a CLI dependency card test files rely on).
 // ---------------------------------------------------------------------------
 const CLEAN_FIXTURES: { name: string; covers: string }[] = [
   {
@@ -57,6 +59,10 @@ const CLEAN_FIXTURES: { name: string; covers: string }[] = [
   {
     name: 'helpers-and-fields',
     covers: 'boxel-ui helper call + field interpolation',
+  },
+  {
+    name: 'test-support',
+    covers: '@universal-ember/test-support import in a .test.gts',
   },
 ];
 

--- a/packages/boxel-cli/tests/integration/parse.test.ts
+++ b/packages/boxel-cli/tests/integration/parse.test.ts
@@ -108,32 +108,35 @@ describe('boxel parse (against the installed CLI)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Known typing gap, deferred to follow-up work:
-//
-//   - tracked-format-class — `@tracked` alongside a `<template>` inside a
-//     `static isolated = class … {}` expression trips glint's
-//     "Decorators are not valid here". A glint/ember-tsc transform
-//     limitation for decorators in class expressions; it reproduces in
-//     both the monorepo and the published layout, so it isn't a
-//     bundled-types gap.
-//
-// Marked `it.fails`: an expected failure while the CLI lacks support for
-// the pattern, so it runs without failing CI. An unexpected pass makes
-// `it.fails` itself fail — the signal to remove the marker and move the
-// case into the block above.
+// Actionable diagnostics: `@tracked` (or any decorator) on a member of a
+// format-class *expression* (`static isolated = class { … }`) can't
+// type-check under TypeScript's legacy decorators — they're allowed only
+// on class *declarations*. The code runs, but glint rejects it, and the
+// raw "Decorators are not valid here" is cryptic. parse must both flag it
+// (never silently pass) and explain the fix: move reactive state into a
+// top-level component the format class renders.
 // ---------------------------------------------------------------------------
-describe('boxel parse — known typing gaps (deferred)', () => {
-  const DEFERRED = ['tracked-format-class'];
+describe('boxel parse — actionable diagnostics', () => {
+  it(
+    'flags a decorator in a format-class expression with guidance',
+    async () => {
+      let result = await parseFixture('tracked-format-class');
+      expect(result.status).toBe('failed');
 
-  describe.each(DEFERRED)('%s', (name) => {
-    it.fails(
-      'does not yet type-check clean in a published install',
-      async () => {
-        let result = await parseFixture(name);
-        expect(result.errors).toEqual([]);
-        expect(result.status).toBe('passed');
-      },
-      { timeout: 180_000 },
-    );
-  });
+      let guided = result.errors.find((e) =>
+        /format-class expression/.test(e.message),
+      );
+      expect(
+        guided,
+        'expected an actionable decorator diagnostic',
+      ).toBeTruthy();
+      // Keeps the underlying TS text and adds the fix.
+      expect(guided!.message).toMatch(/Decorators are not valid here/);
+      expect(guided!.message).toMatch(/top-level component/);
+      // Located at the decorated member, not attributed to the wrong file.
+      expect(guided!.file).toBe('toggle.gts');
+      expect(guided!.line).toBeGreaterThan(0);
+    },
+    { timeout: 180_000 },
+  );
 });


### PR DESCRIPTION
This addresses the other parse failures that #5551 added failing tests for.