### PR TITLE
Resolve relative references in serialized card documents against each resource's own id

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -4258,11 +4258,15 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
 
   let existingOverrides = getFieldOverrides(instance);
   let loadedValues = getDataBucket(instance);
+  // A resource's references (adoptsFrom, relationship links) are relative to the
+  // resource's own id, independent of the document that delivered it. So resolve
+  // them against this instance's own id when it is saved, and fall back to the
+  // threaded deserialization context only for an unsaved instance that has no id
+  // of its own.
   let instanceRelativeTo: RealmResourceIdentifier | URL | undefined =
-    instance[relativeTo] ??
     ('id' in instance && typeof instance.id === 'string'
       ? (instance.id as RealmResourceIdentifier)
-      : undefined);
+      : undefined) ?? instance[relativeTo];
 
   function getFieldMeta(
     fieldsMeta: CardFields | undefined,
@@ -4335,8 +4339,9 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
     }
     let override = await loadCardDef(overrideMeta.adoptsFrom, {
       loader: myLoader(),
-      // Prefer the deserialization context (instanceRelativeTo) so overrides resolve
-      // relative to the document we fetched (e.g. catalog/index), then fall back to the resource id.
+      // A field override's module ref is relative to this resource's own id, the
+      // same rule as adoptsFrom; instanceRelativeTo already resolves to the
+      // instance's own id when saved, with resource.id as the fallback.
       relativeTo:
         instanceRelativeTo ?? (resource.id ? rri(resource.id) : undefined),
       dependencyTrackingContext: opts?.dependencyTrackingContext,
@@ -4445,12 +4450,14 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
       if (overrideApplied) {
         field = (getField(instance, fieldName) ?? field) as Field<T>;
       }
-      // Prefer the deserialization context ([relativeTo]) when available; fall back to the instance id
+      // A resource's relationship links are relative to the resource's own id,
+      // independent of the document that delivered it — so resolve against this
+      // instance's own id when saved, falling back to the threaded context only
+      // for an unsaved instance with no id of its own.
       let relativeToVal: RealmResourceIdentifier | URL | undefined =
-        instance[relativeTo] ??
         ('id' in instance && typeof instance.id === 'string'
           ? (instance.id as RealmResourceIdentifier)
-          : undefined);
+          : undefined) ?? instance[relativeTo];
       let deserializedValue = await getDeserializedValue({
         card,
         loadedValue: loadedValues.get(fieldName),

--- a/packages/base/card-serialization.ts
+++ b/packages/base/card-serialization.ts
@@ -118,7 +118,14 @@ export async function cardClassFromResource<CardT extends BaseDefConstructor>(
       resource.meta.adoptsFrom,
       {
         loader: myLoader(),
-        relativeTo: relativeTo ?? (resource.id ? rri(resource.id) : undefined),
+        // Every reference in a resource — its `adoptsFrom.module` and its
+        // relationship links alike — is transmitted relative to the resource's
+        // OWN id, independent of the document that delivered it. So a resource
+        // with an id resolves its module against that id, even when it arrived
+        // embedded in another document's `included[]`. The caller's `relativeTo`
+        // is the base only for an id-less resource (a contained field), which
+        // shares its parent's base.
+        relativeTo: resource.id ? rri(resource.id) : relativeTo,
       },
     );
     if (!card) {

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -1026,7 +1026,7 @@ module('Integration | card-copy', function (hooks) {
       let included = json.included?.[0]!;
       assert.strictEqual(included.id, `${testRealmURL}Pet/mango`);
       assert.deepEqual(included.meta.adoptsFrom, {
-        module: testRRI('pet'),
+        module: rri('../pet'),
         name: 'Pet',
       });
       assert.deepEqual(included.meta.realmURL, testRealmURL);

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -6269,6 +6269,130 @@ module('Integration | serialization', function (hooks) {
       }
     });
 
+    test("resolves a nested linked card's relative adoptsFrom module against its own id, not the parent card's", async function (assert) {
+      // A linked card in a subdirectory carries an `adoptsFrom.module` relative
+      // to its own id (a card's type is intrinsic to the card, independent of
+      // the document that delivered it). When it is hydrated out of a parent
+      // card's document, its module must still resolve against the linked card's
+      // own id — resolving against the parent's base would fetch a module one
+      // directory off and present the existing card as Card Not Found.
+      class SubSection extends CardDef {
+        @field label = contains(StringField);
+      }
+      class Section extends CardDef {
+        @field label = contains(StringField);
+        @field detail = linksTo(SubSection);
+      }
+      class Workspace extends CardDef {
+        @field label = contains(StringField);
+        @field entryPoints = linksToMany(Section);
+      }
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'test-cards.gts': { Workspace },
+          'sections/section.gts': { Section },
+          'sections/subs/sub-section.gts': { SubSection },
+        },
+      });
+      let doc: LooseSingleCardDocument = {
+        data: {
+          id: `${testRealmURL}index`,
+          type: 'card',
+          attributes: {
+            label: 'Sample workspace',
+            cardInfo: {},
+          },
+          relationships: {
+            'entryPoints.0': {
+              links: {
+                self: `${testRealmURL}sections/section-1`,
+              },
+              data: {
+                id: `${testRealmURL}sections/section-1`,
+                type: 'card',
+              },
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: testRRI('test-cards'),
+              name: 'Workspace',
+            },
+          },
+        },
+        included: [
+          {
+            id: testRRI('sections/section-1'),
+            type: 'card',
+            attributes: {
+              label: 'Section one',
+              cardInfo: {},
+            },
+            relationships: {
+              detail: {
+                links: {
+                  self: `${testRealmURL}sections/subs/sub-section-1`,
+                },
+                data: {
+                  id: `${testRealmURL}sections/subs/sub-section-1`,
+                  type: 'card',
+                },
+              },
+            },
+            meta: {
+              // Relative to the section's own id (sections/section-1); resolving
+              // against the workspace root (index) would look one directory up.
+              adoptsFrom: {
+                module: rri('./section'),
+                name: 'Section',
+              },
+            },
+          },
+          {
+            id: testRRI('sections/subs/sub-section-1'),
+            type: 'card',
+            attributes: {
+              label: 'Detail one',
+              cardInfo: {},
+            },
+            meta: {
+              // Relative to the sub-section's own id
+              // (sections/subs/sub-section-1); resolving against the parent
+              // section (sections/) would look one directory up.
+              adoptsFrom: {
+                module: rri('./sub-section'),
+                name: 'SubSection',
+              },
+            },
+          },
+        ],
+      };
+      let card = await createFromSerialized<typeof Workspace>(
+        doc.data,
+        doc,
+        rri(`${testRealmURL}index`),
+      );
+
+      assert.ok(card instanceof Workspace, 'card is an instance of Workspace');
+      let { entryPoints } = card;
+      assert.strictEqual(entryPoints.length, 1, 'entryPoints has 1 item');
+      let [section] = entryPoints;
+      if (section instanceof Section) {
+        assert.true(isSaved(section), 'Section card is saved');
+        assert.strictEqual(section.label, 'Section one');
+        let { detail } = section;
+        if (detail instanceof SubSection) {
+          assert.true(isSaved(detail), 'SubSection card is saved');
+          assert.strictEqual(detail.label, 'Detail one');
+        } else {
+          assert.ok(false, 'section "detail" is not an instance of SubSection');
+        }
+      } else {
+        assert.ok(false, 'entryPoints[0] is not an instance of Section');
+      }
+    });
+
     test('can deserialize a linksToMany relationship from array format', async function (assert) {
       class Pet extends CardDef {
         @field firstName = contains(StringField);

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -2507,7 +2507,7 @@ module(`Integration | realm indexing`, function (hooks) {
             id: testRRI('Chain/1'),
             type: 'card',
             links: {
-              self: `../Chain/1`,
+              self: `./1`,
             },
             attributes: {
               name: 'Ethereum Mainnet',
@@ -2544,7 +2544,7 @@ module(`Integration | realm indexing`, function (hooks) {
             id: testRRI('Chain/2'),
             type: 'card',
             links: {
-              self: `../Chain/2`,
+              self: `./2`,
             },
             attributes: {
               name: 'Polygon',
@@ -3048,7 +3048,7 @@ module(`Integration | realm indexing`, function (hooks) {
         {
           id: testRRI('Pet/mango'),
           type: 'card',
-          links: { self: `../Pet/mango` },
+          links: { self: `./mango` },
           attributes: {
             cardDescription: null,
             firstName: 'Mango',
@@ -3082,7 +3082,7 @@ module(`Integration | realm indexing`, function (hooks) {
         {
           id: testRRI('Pet/vanGogh'),
           type: 'card',
-          links: { self: `../Pet/vanGogh` },
+          links: { self: `./vanGogh` },
           attributes: {
             cardDescription: null,
             firstName: 'Van Gogh',

--- a/packages/host/tests/integration/realm-test.gts
+++ b/packages/host/tests/integration/realm-test.gts
@@ -801,7 +801,7 @@ module('Integration | realm', function (hooks) {
             realmURL: testRealmURL,
           },
           links: {
-            self: `../dir/owner`,
+            self: `./owner`,
           },
         },
       ],
@@ -1324,7 +1324,7 @@ module('Integration | realm', function (hooks) {
         {
           type: 'card',
           id: `${testRealmURL}dir/friend`,
-          links: { self: `./dir/friend` },
+          links: { self: `./friend` },
           attributes: {
             cardDescription: 'Person',
             email: null,
@@ -1352,7 +1352,7 @@ module('Integration | realm', function (hooks) {
         {
           type: 'card',
           id: `${testRealmURL}dir/van-gogh`,
-          links: { self: `./dir/van-gogh` },
+          links: { self: `./van-gogh` },
           attributes: {
             firstName: 'Van Gogh',
             cardTitle: 'Van Gogh',
@@ -3310,10 +3310,14 @@ module('Integration | realm', function (hooks) {
         `${mountedRealmURL}spreadsheet/Spreadsheet/${spreadsheet1Id}`,
     );
     assert.ok(included, 'linked spreadsheet card is included');
+    // The included card's module is relativized against its own id
+    // (spreadsheet/Spreadsheet/spreadsheet-1), not the primary document
+    // (index). `../spreadsheet` resolves to spreadsheet/spreadsheet from the
+    // card's own directory; the consumer resolves it against the same id.
     assert.strictEqual(
       included?.meta?.adoptsFrom?.module,
-      './spreadsheet/spreadsheet',
-      'adoptsFrom.module has the correct path',
+      '../spreadsheet',
+      'included adoptsFrom.module is relative to the resource own id',
     );
   });
 

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -3205,7 +3205,7 @@ module(basename(import.meta.filename), function () {
                   relationships: {
                     'friends.0': {
                       links: {
-                        self: './Friend/local-id-2',
+                        self: './local-id-2',
                       },
                       data: {
                         id: `${testRealmHref}Friend/local-id-2`,
@@ -3214,7 +3214,7 @@ module(basename(import.meta.filename), function () {
                     },
                     'friends.1': {
                       links: {
-                        self: './Friend/local-id-3',
+                        self: './local-id-3',
                       },
                       data: {
                         id: `${testRealmHref}Friend/local-id-3`,
@@ -3224,7 +3224,7 @@ module(basename(import.meta.filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: rri('./friend'),
+                      module: rri('../friend'),
                       name: 'Friend',
                     },
                   },
@@ -3241,7 +3241,7 @@ module(basename(import.meta.filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: rri('./friend'),
+                      module: rri('../friend'),
                       name: 'Friend',
                     },
                   },
@@ -3258,7 +3258,7 @@ module(basename(import.meta.filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: rri('./friend'),
+                      module: rri('../friend'),
                       name: 'Friend',
                     },
                   },

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -1926,7 +1926,17 @@ function collectFilterRefs(filter: Filter, refs: CodeRef[]) {
   }
 }
 
-// Exported for testing (CS-10498 regression test)
+// Rewrite the references inside a served single-card document into their
+// portable relative form: the primary resource and each `included[]` resource
+// have their module deps (`adoptsFrom`, field code refs) and instance/
+// relationship URLs relativized against that resource's OWN id. This is one
+// application of the codebase-wide rule that every resource's references are
+// relative to its own id, independent of the document that delivers it —
+// collection responses (`/_search`) already carry that own-id-relative form
+// natively, so they are not rebased here. A consumer inverts the rule the same
+// way everywhere: resolve a resource's references against that resource's own
+// id (`data.id` / `included[].id`), never against the enclosing document. See
+// relativizeResource. Exported for testing.
 export function relativizeDocument(
   doc: SingleCardDocument,
   realmURL: URL,
@@ -1979,6 +1989,11 @@ function relativizeResource(
   let resourceURL = resource.id
     ? virtualNetwork.toURL(resource.id)
     : primaryURL;
+  // Every reference in this resource — instance/relationship URLs and module
+  // deps — is relativized against the resource's own id (`resourceURL`), so the
+  // resource reads the same whether it is a document's primary or embedded in
+  // another document's `included[]`. For the primary resource `resourceURL` is
+  // the primary URL, so only `included[]` / collection members shift base.
   visitInstanceURLs(resource, (url, setURL) => {
     // Scoped RRIs (e.g. @cardstack/catalog/foo) are already in their canonical
     // portable form — don't resolve or relativize them. A scoped reference is
@@ -1989,7 +2004,7 @@ function relativizeResource(
       return;
     }
     let urlObj = virtualNetwork.resolveURL(url, resourceURL);
-    setURL(maybeRelativeReference(urlObj, primaryURL, realmURL));
+    setURL(maybeRelativeReference(urlObj, resourceURL, realmURL));
   });
   visitModuleDeps(resource, (moduleURL, setModuleURL) => {
     // Scoped RRIs are already in canonical portable form — see the note in the
@@ -2001,7 +2016,7 @@ function relativizeResource(
     setModuleURL(
       maybeRelativeReference(
         absoluteModuleURL,
-        primaryURL,
+        resourceURL,
         realmURL,
       ) as RealmResourceIdentifier,
     );


### PR DESCRIPTION
Serialized card documents carry relative references — a card's `adoptsFrom` module and its relationship links — and those references were being resolved against different bases depending on how the document was assembled. The single-card path rebased `included[]` refs onto the primary document URL; the search / prerendered path (which the host actually loads cards through) left them relative to each resource's own id. A consumer can't tell which base a given ref used, so no single resolution rule was correct for both.

The concrete symptom: when the host hydrates a linked card out of a parent card's document (the linked resource rides in `included[]`), a linked instance that lives in a subdirectory — instances are stored under a `<CardType>/` container, so their id is a directory deeper than the module that defines them — had its relative `adoptsFrom.module` resolved against the parent card's base. It landed one directory off, fetched a module URL that doesn't exist, threw `could not find card`, and presented an existing, cleanly-indexed card as **Card Not Found**.

## The rule

**Every reference in a resource — its `adoptsFrom` module and its relationship/instance links — is relative to that resource's own id, independent of the document that delivers it.** One rule for the document's primary resource, for each `included[]` resource, and for every member of a collection response. A consumer inverts it the same way everywhere: resolve a resource's references against that resource's own id (`data.id` / `included[].id`), never against the enclosing document.

JSON:API gives no explicit guidance here — its relative-URL handling is scoped to `links`, and `adoptsFrom` lives in `meta`, which the spec treats as opaque; the closest binding authority it defers to, RFC 3986 §5.1, establishes one base per *document* with no per-embedded-resource base. So the convention is ours to define, and own-id is the one that makes sense and is the only base that works uniformly across single-card documents, `included[]`, and collections (a collection has no single primary to rebase against).

## Changes

- `relativizeResource` relativizes every reference in a resource — module deps and instance/relationship URLs alike — against the resource's own id. For a document's primary resource the base is unchanged; only `included[]` / collection members shift.
- `cardClassFromResource` and `_updateFromSerialized` resolve a resource's `adoptsFrom` and relationship links against its own id when saved, falling back to the caller's base only for an id-less contained field.
- Crystal-clear comments at the serializer and the resolver state the single rule, since it's subtle and easy to re-break.

One deliberate artifact of applying the rule uniformly: a resource's own `links.self` is also relativized against its own id, so an included resource's self-link becomes self-referential (e.g. `./owner` rather than the previous document-relative `../dir/owner`). Consumers resolve it against `included[].id`, so it round-trips correctly.

Because the wire form of `included[]` references changes (own-id-relative rather than document-relative), served-output and save-payload expectations across the suite are updated to match the rule.

## Test

A new deserialization test hydrates a two-level link graph — a root card whose `linksToMany` targets live in a subdirectory, each with a further `linksTo` into a deeper subdirectory, every linked resource carrying an own-id-relative `adoptsFrom`. It fails on the old resolution base (`http://test-realm/test/section not found`) and passes with the fix.
