### PR TITLE
ai-bot: per-turn telemetry line for streaming-mode comparison

### DIFF
--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -63,6 +63,11 @@ export default class MatrixResponsePublisher {
   readonly responseState: ResponseState;
   eventSizeMax = DEFAULT_EVENT_SIZE_MAX;
   responseEvents: ResponseEventData[] | undefined;
+  // Count of Matrix room events this publisher has sent this turn (thinking
+  // placeholder, streamed message edits, continuation splits, and errors).
+  // Read by the Responder's per-turn telemetry line to compare room-event
+  // volume across streaming modes.
+  roomEventsEmitted = 0;
   private sendingMessage = Promise.resolve(); // track pending send operation
 
   get currentResponseEvent() {
@@ -146,6 +151,7 @@ export default class MatrixResponsePublisher {
           ),
           reasoningAndContent.reasoning,
         );
+        this.roomEventsEmitted++;
         if (!this.currentResponseEvent.eventId) {
           this.currentResponseEvent.eventId = messageEvent.event_id;
         }
@@ -189,6 +195,7 @@ export default class MatrixResponsePublisher {
           ),
         contentAndReasoning.reasoning,
       );
+      this.roomEventsEmitted++;
       if (!this.currentResponseEvent.eventId) {
         this.currentResponseEvent.eventId = messageEvent.event_id;
       }
@@ -209,6 +216,7 @@ export default class MatrixResponsePublisher {
       this.originalResponseEventId,
       opts,
     );
+    this.roomEventsEmitted++;
   }
 
   async ensureThinkingMessageSent() {
@@ -231,5 +239,6 @@ export default class MatrixResponsePublisher {
     this.responseEvents = [
       new ResponseEventData(initialMessage.event_id, this.eventSizeMax),
     ];
+    this.roomEventsEmitted++;
   }
 }

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -59,14 +59,18 @@ export class Responder {
   private streamPreviewTarget: { userId: string; deviceId: string } | undefined;
   private _streamPreviewSequence = 0;
 
-  // Per-turn telemetry, logged once from finalize() to compare streaming modes.
-  // startedAt is set at construction — the turn boundary as the Responder sees
-  // it. Room-event count lives on the publisher; to-device previews and token
-  // usage are tallied here.
+  // Per-turn telemetry, logged once per turn to compare streaming modes.
+  // startedAt is the turn boundary as the Responder sees it (construction, i.e.
+  // before prompt construction and the per-user cost-lock wait); streamStartedAt
+  // marks the first chunk, so streamMs isolates the generation+streaming+finalize
+  // window from that mode-independent pre-generation time. Room-event count lives
+  // on the publisher; to-device previews and token usage are tallied here.
   private startedAt = Date.now();
+  private streamStartedAt: number | undefined;
   private toDeviceEventsEmitted = 0;
   private promptTokens: number | undefined;
   private completionTokens: number | undefined;
+  private telemetryLogged = false;
 
   constructor(
     client: MatrixClient,
@@ -244,6 +248,10 @@ export class Responder {
     chunk: OpenAI.Chat.Completions.ChatCompletionChunk,
     snapshot: ChatCompletionSnapshot,
   ) {
+    // Mark the start of the streaming window on the first chunk so streamMs
+    // measures generation+streaming+finalize, not the pre-generation wait.
+    this.streamStartedAt ??= Date.now();
+
     // reasoning does not support snapshots, so we need to handle the delta
     const newReasoningContent = (
       chunk.choices?.[0]?.delta as { reasoning?: string }
@@ -315,7 +323,14 @@ export class Responder {
         agentId: this.matrixResponsePublisher.agentId,
       },
     });
-    return await this.matrixResponsePublisher.sendError(error, opts);
+    let result = await this.matrixResponsePublisher.sendError(error, opts);
+    // An errored turn still emits room events (the placeholder + this error
+    // event, plus any mid-turn edits already sent), and several error paths in
+    // main.ts end the turn here without ever calling finalize(). Log telemetry
+    // so that room-event volume is not missing from the comparison; the guard
+    // in logTurnTelemetry keeps it to a single line when finalize() also runs.
+    this.logTurnTelemetry();
+    return result;
   }
 
   async flush() {
@@ -357,10 +372,17 @@ export class Responder {
 
   // Per-turn measurements used to compare streaming modes. Exposed as a getter
   // so tests can assert the counts directly rather than parse the log line.
+  // durationMs is whole-turn wall-clock (includes pre-generation queue/lock
+  // wait); streamMs isolates the streaming window and is undefined for turns
+  // that errored before the first chunk.
   get turnTelemetry() {
     return {
       mode: this.streamingMode,
       durationMs: Date.now() - this.startedAt,
+      streamMs:
+        this.streamStartedAt === undefined
+          ? undefined
+          : Date.now() - this.streamStartedAt,
       roomEvents: this.matrixResponsePublisher.roomEventsEmitted,
       toDeviceEvents: this.toDeviceEventsEmitted,
       promptTokens: this.promptTokens,
@@ -375,11 +397,19 @@ export class Responder {
   // One structured, greppable line per turn so a scripted load run can compare
   // Matrix event volume and latency across streaming modes in Loki. Keep it
   // single-line key=value to stay consistent with the repo's other
-  // request-timing channels (e.g. realm:requests `dur=`).
+  // request-timing channels (e.g. realm:requests `dur=`). Fires at most once
+  // per turn — from finalize() on the normal/canceled paths, or from onError()
+  // on the error paths that never finalize — so every turn that emitted room
+  // events also emits exactly one line.
   private logTurnTelemetry() {
+    if (this.telemetryLogged) {
+      return;
+    }
+    this.telemetryLogged = true;
     let t = this.turnTelemetry;
     log.info(
       `[turn-telemetry] mode=${t.mode} durationMs=${t.durationMs} ` +
+        `streamMs=${t.streamMs ?? ''} ` +
         `roomEvents=${t.roomEvents} toDeviceEvents=${t.toDeviceEvents} ` +
         `promptTokens=${t.promptTokens ?? ''} ` +
         `completionTokens=${t.completionTokens ?? ''} ` +

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -59,6 +59,15 @@ export class Responder {
   private streamPreviewTarget: { userId: string; deviceId: string } | undefined;
   private _streamPreviewSequence = 0;
 
+  // Per-turn telemetry, logged once from finalize() to compare streaming modes.
+  // startedAt is set at construction — the turn boundary as the Responder sees
+  // it. Room-event count lives on the publisher; to-device previews and token
+  // usage are tallied here.
+  private startedAt = Date.now();
+  private toDeviceEventsEmitted = 0;
+  private promptTokens: number | undefined;
+  private completionTokens: number | undefined;
+
   constructor(
     client: MatrixClient,
     roomId: string,
@@ -181,6 +190,7 @@ export class Responder {
         APP_BOXEL_RESPONSE_STREAM_EVENT_TYPE,
         contentMap,
       );
+      this.toDeviceEventsEmitted++;
     } catch (e) {
       // Preview loss is non-fatal; the final room edit still lands. Log at
       // debug so a wedged homeserver doesn't spam sentry.
@@ -270,6 +280,8 @@ export class Responder {
     // This usage value is set *once* and *only once* at the end of the conversation
     // It will be null at all other times.
     if (chunk.usage) {
+      this.promptTokens = chunk.usage.prompt_tokens;
+      this.completionTokens = chunk.usage.completion_tokens;
       log.info(
         `Request used ${chunk.usage.prompt_tokens} prompt tokens and ${chunk.usage.completion_tokens} completion tokens`,
       );
@@ -340,5 +352,39 @@ export class Responder {
       await this.sendMessageEventWithThrottling();
     }
     await this.flush();
+    this.logTurnTelemetry();
+  }
+
+  // Per-turn measurements used to compare streaming modes. Exposed as a getter
+  // so tests can assert the counts directly rather than parse the log line.
+  get turnTelemetry() {
+    return {
+      mode: this.streamingMode,
+      durationMs: Date.now() - this.startedAt,
+      roomEvents: this.matrixResponsePublisher.roomEventsEmitted,
+      toDeviceEvents: this.toDeviceEventsEmitted,
+      promptTokens: this.promptTokens,
+      completionTokens: this.completionTokens,
+      canceled: this.responseState.isCanceled,
+      roomId: this.matrixResponsePublisher.roomId,
+      agentId: this.matrixResponsePublisher.agentId,
+      responseEventId: this.responseEventId,
+    };
+  }
+
+  // One structured, greppable line per turn so a scripted load run can compare
+  // Matrix event volume and latency across streaming modes in Loki. Keep it
+  // single-line key=value to stay consistent with the repo's other
+  // request-timing channels (e.g. realm:requests `dur=`).
+  private logTurnTelemetry() {
+    let t = this.turnTelemetry;
+    log.info(
+      `[turn-telemetry] mode=${t.mode} durationMs=${t.durationMs} ` +
+        `roomEvents=${t.roomEvents} toDeviceEvents=${t.toDeviceEvents} ` +
+        `promptTokens=${t.promptTokens ?? ''} ` +
+        `completionTokens=${t.completionTokens ?? ''} ` +
+        `canceled=${t.canceled} roomId=${t.roomId} agentId=${t.agentId} ` +
+        `responseEventId=${t.responseEventId ?? ''}`,
+    );
   }
 }

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -399,9 +399,76 @@ module('Responding', (hooks) => {
       assert.equal(telemetry.canceled, false, 'not canceled');
       assert.equal(telemetry.roomId, 'room-id', 'roomId recorded');
       assert.equal(telemetry.agentId, 'abc123agentId', 'agentId recorded');
+      assert.ok(
+        telemetry.streamMs !== undefined &&
+          telemetry.streamMs <= telemetry.durationMs,
+        'streamMs isolates the streaming window and is no larger than whole-turn durationMs',
+      );
     } finally {
       delete process.env.AI_BOT_STREAMING_MODE;
     }
+  });
+
+  test('per-turn telemetry counts room-edits mid-turn events (the comparison baseline)', async () => {
+    // Default mode is room-edits with no preview target — the "before" side of
+    // the streaming-mode comparison, where each mid-turn edit is its own room
+    // event. Pins that this stays high, so a regression that stopped counting
+    // mid-turn edits can't silently collapse it to ~2 like the other modes.
+    await responder.ensureThinkingMessageSent();
+    for (let i = 0; i < 5; i++) {
+      await responder.onChunk({} as any, snapshotWithContent('content ' + i));
+      await clock.tickAsync(300);
+    }
+    await responder.finalize();
+
+    let telemetry = responder.turnTelemetry;
+    assert.equal(telemetry.mode, 'room-edits', 'default mode is room-edits');
+    assert.ok(
+      telemetry.roomEvents > 2,
+      `room-edits emits a room event per mid-turn edit (got ${telemetry.roomEvents})`,
+    );
+    assert.equal(
+      telemetry.toDeviceEvents,
+      0,
+      'room-edits never uses the to-device channel',
+    );
+  });
+
+  test('per-turn telemetry is emitted once for a turn that errors without finalize', async () => {
+    // Several error paths in main.ts end a turn via onError() without ever
+    // calling finalize(); those turns still emit room events, so telemetry has
+    // to land from onError() too or the comparison loses them. Count actual
+    // emissions (guard-passes), not method invocations, by watching the
+    // telemetryLogged flag flip.
+    let emits = 0;
+    const responderAny = responder as unknown as {
+      logTurnTelemetry: () => void;
+      telemetryLogged: boolean;
+    };
+    const original = responderAny.logTurnTelemetry.bind(responder);
+    responderAny.logTurnTelemetry = () => {
+      const before = responderAny.telemetryLogged;
+      original();
+      if (!before && responderAny.telemetryLogged) {
+        emits++;
+      }
+    };
+
+    await responder.ensureThinkingMessageSent();
+    await responder.onChunk({} as any, snapshotWithContent('partial'));
+    await clock.tickAsync(300);
+    assert.equal(emits, 0, 'nothing is logged mid-turn');
+
+    await responder.onError('boom');
+    assert.equal(emits, 1, 'the error path emits the telemetry line');
+    assert.ok(
+      responder.turnTelemetry.roomEvents >= 2,
+      'the errored turn reports the room events it emitted (placeholder + error)',
+    );
+
+    // A late finalize() must not emit a second line for the same turn.
+    await responder.finalize();
+    assert.equal(emits, 1, 'the once-per-turn guard suppresses a duplicate');
   });
 
   test('`to-device` streaming mode without a target device falls back to `off` behavior', async () => {

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -352,6 +352,58 @@ module('Responding', (hooks) => {
     }
   });
 
+  test('per-turn telemetry records mode, event counts, and token usage', async () => {
+    process.env.AI_BOT_STREAMING_MODE = 'to-device';
+    try {
+      responder = new Responder(fakeMatrixClient, 'room-id', 'abc123agentId', {
+        userId: '@alice:example.com',
+        deviceId: 'DEVICEALICE',
+      });
+
+      await responder.ensureThinkingMessageSent();
+
+      for (let i = 0; i < 5; i++) {
+        await responder.onChunk({} as any, snapshotWithContent('content ' + i));
+        await clock.tickAsync(300);
+      }
+
+      // The final chunk carries usage (the only chunk that does), which the
+      // Responder tallies for the telemetry line.
+      await responder.onChunk(
+        { usage: { prompt_tokens: 120, completion_tokens: 42 } } as any,
+        snapshotWithContent('content 4'),
+      );
+
+      let toDeviceCount = fakeMatrixClient.getSentToDeviceEvents().length;
+      await responder.finalize();
+
+      let telemetry = responder.turnTelemetry;
+      assert.equal(telemetry.mode, 'to-device', 'mode is recorded');
+      assert.equal(
+        telemetry.roomEvents,
+        2,
+        'room events = thinking placeholder + one final consolidated event',
+      );
+      assert.equal(
+        telemetry.toDeviceEvents,
+        toDeviceCount,
+        'to-device count matches the previews actually sent',
+      );
+      assert.ok(telemetry.toDeviceEvents >= 1, 'at least one preview was sent');
+      assert.equal(telemetry.promptTokens, 120, 'prompt tokens captured');
+      assert.equal(
+        telemetry.completionTokens,
+        42,
+        'completion tokens captured',
+      );
+      assert.equal(telemetry.canceled, false, 'not canceled');
+      assert.equal(telemetry.roomId, 'room-id', 'roomId recorded');
+      assert.equal(telemetry.agentId, 'abc123agentId', 'agentId recorded');
+    } finally {
+      delete process.env.AI_BOT_STREAMING_MODE;
+    }
+  });
+
   test('`to-device` streaming mode without a target device falls back to `off` behavior', async () => {
     process.env.AI_BOT_STREAMING_MODE = 'to-device';
     try {


### PR DESCRIPTION
Instrumentation to quantify the ai-bot streaming-mode work with measured before/after numbers rather than estimates.

## What

Every finished ai-bot turn emits one structured, greppable line from the `Responder`:

```
[turn-telemetry] mode=… durationMs=… roomEvents=… toDeviceEvents=… promptTokens=… completionTokens=… canceled=… roomId=… agentId=… responseEventId=…
```

These are the per-turn numbers needed to compare the `room-edits`, `off`, and `to-device` streaming modes under load: room-event volume is what drives Synapse CPU, and to-device count / duration / tokens show whether cutting room events costs latency.

## How

- **Room-event count** is tallied at the single choke point every room event passes through — `MatrixResponsePublisher` (thinking placeholder, streamed edits, continuation splits, and errors) — so the count reflects true Matrix load regardless of mode.
- The **Responder** tallies to-device previews and token usage (from the end-of-stream `chunk.usage`) and emits the line from `finalize()`.
- Counts are also exposed via a `turnTelemetry` getter so tests assert them directly instead of parsing the log.

Format is single-line `key=value` to match the repo's other request-timing channels (e.g. `realm:requests dur=`), so it parses cleanly with Loki's `pattern` + `unwrap`.

## Testing

- New unit test asserts the per-turn counts (`roomEvents`, `toDeviceEvents`, tokens, mode) for a `to-device` turn.
- Existing responder / streaming-mode tests pass unchanged (the line renders correctly across `room-edits` / `off` / `to-device`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)