### PR TITLE
Add Workspace test coverage: unit, integration, acceptance

### DIFF
--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -94,19 +94,44 @@ type JobCard = CardDef & {
 
 // honest ETA (same rules as the job card): linear from arrival rate,
 // only once 3 pieces are in, suppressed when implausible (> 30 min).
-function etaMinutes(job: JobCard): number | undefined {
+// The subset of a job card the ETA reads. A full `JobCard` satisfies it.
+export interface EtaJob {
+  progressDone?: number;
+  progressTotal?: number;
+  startedAt?: string | Date;
+}
+
+export function etaMinutes(
+  job: EtaJob,
+  now: number = Date.now(),
+): number | undefined {
   let done = job.progressDone ?? 0;
   let total = job.progressTotal ?? 0;
   let started = job.startedAt ? new Date(job.startedAt).getTime() : undefined;
   if (done < 3 || total <= done || !started) {
     return undefined;
   }
-  let elapsed = Date.now() - started;
+  let elapsed = now - started;
   if (elapsed <= 0) {
     return undefined;
   }
   let mins = Math.round(((elapsed / done) * (total - done)) / 60000);
   return mins > 30 ? undefined : mins;
+}
+
+// A card modified within this window of its creation reads as "Created" in
+// the Activity feed rather than "Updated".
+const CREATED_WINDOW_MS = 120000;
+
+export function classifyActivityVerb(
+  modMs: number | undefined,
+  createdMs: number | undefined,
+): 'Created' | 'Updated' {
+  return modMs !== undefined &&
+    createdMs !== undefined &&
+    Math.abs(modMs - createdMs) < CREATED_WINDOW_MS
+    ? 'Created'
+    : 'Updated';
 }
 
 type RealmConfigCard = CardDef & { iconURL?: string }; // RealmConfig shape
@@ -3226,12 +3251,7 @@ class Isolated extends Component<typeof Workspace> {
       let card = instance as CardDef;
       let modMs = toMs(getCardMeta(card, 'lastModified'));
       let createdMs = toMs(getCardMeta(card, 'resourceCreatedAt'));
-      let verb: 'Created' | 'Updated' =
-        modMs !== undefined &&
-        createdMs !== undefined &&
-        Math.abs(modMs - createdMs) < 120000
-          ? 'Created'
-          : 'Updated';
+      let verb = classifyActivityVerb(modMs, createdMs);
       let day = modMs !== undefined ? dayLabelFor(modMs) : '';
       let ctor = card.constructor as typeof CardDef; // type identity for the log line
       this.feedItems.push({

--- a/packages/host/tests/acceptance/workspace-test.gts
+++ b/packages/host/tests/acceptance/workspace-test.gts
@@ -1,0 +1,85 @@
+import { click, visit, waitFor } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  setupLocalIndexing,
+  setupAcceptanceTestRealm,
+  testRealmURL,
+  setupAuthEndpoints,
+  setupUserSubscription,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+const STACK = '[data-test-operator-mode-stack="0"]';
+
+module('Acceptance | workspace card', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+  });
+
+  let { createAndJoinRoom } = mockMatrixUtils;
+
+  hooks.beforeEach(async function () {
+    createAndJoinRoom({ sender: '@testuser:localhost', name: 'room-test' });
+    setupUserSubscription();
+    setupAuthEndpoints();
+
+    let loader = getService('loader-service').loader;
+    let { field, contains, CardDef, Component } = await loader.import<
+      typeof import('@cardstack/base/card-api')
+    >('@cardstack/base/card-api');
+    let { default: StringField } = await loader.import<
+      typeof import('@cardstack/base/string')
+    >('@cardstack/base/string');
+    let { Workspace } = await loader.import<
+      typeof import('@cardstack/base/workspace')
+    >('@cardstack/base/workspace');
+
+    class Note extends CardDef {
+      @field cardTitle = contains(StringField);
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <div data-test-note><@fields.cardTitle /></div>
+        </template>
+      };
+    }
+
+    await setupAcceptanceTestRealm({
+      mockMatrixUtils,
+      contents: {
+        ...SYSTEM_CARD_FIXTURE_CONTENTS,
+        'note.gts': { Note },
+        'index.json': new Workspace(),
+        'Note/1.json': new Note({ cardTitle: 'First Note' }),
+      },
+    });
+  });
+
+  test('a realm indexed by Workspace renders its shell and switches segments', async function (assert) {
+    await visit('/');
+    assert.dom('[data-test-workspace-chooser]').exists();
+    await click('[data-test-workspace-button="Unnamed Workspace"]');
+
+    await waitFor(`${STACK} nav.tabs`);
+    assert
+      .dom(`${STACK} nav.tabs .tab`)
+      .exists({ count: 3 }, 'Home, Library, and Activity tabs render');
+    assert
+      .dom(`${STACK} nav.tabs .tab.active`)
+      .hasText('Home', 'Home is the default segment');
+
+    await click(`${STACK} nav.tabs .tab:nth-child(2)`);
+    assert.dom(`${STACK} .library`).exists('Library pane renders');
+
+    await click(`${STACK} nav.tabs .tab:nth-child(3)`);
+    assert.dom(`${STACK} .activity-pane`).exists('Activity pane renders');
+  });
+});

--- a/packages/host/tests/integration/components/workspace-behavior-test.gts
+++ b/packages/host/tests/integration/components/workspace-behavior-test.gts
@@ -1,0 +1,44 @@
+import { click } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type { Loader } from '@cardstack/runtime-common';
+
+import { Workspace, setupBaseRealm } from '../../helpers/base-realm';
+import { renderCard } from '../../helpers/render-component';
+import { setupRenderingTest } from '../../helpers/setup';
+
+const HOME = 'nav.tabs .tab:nth-child(1)';
+const LIBRARY = 'nav.tabs .tab:nth-child(2)';
+const ACTIVITY = 'nav.tabs .tab:nth-child(3)';
+
+module('Integration | Card | workspace | segments', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  let loader: Loader;
+
+  hooks.beforeEach(function () {
+    loader = getService('loader-service').loader;
+  });
+
+  test('clicking a tab moves the active segment', async function (assert) {
+    await renderCard(loader, new Workspace({}), 'isolated');
+    assert.dom('nav.tabs .tab.active').hasText('Home', 'Home is active first');
+
+    await click(LIBRARY);
+    assert.dom('nav.tabs .tab.active').hasText('Library');
+
+    await click(ACTIVITY);
+    assert.dom('nav.tabs .tab.active').hasText('Activity');
+
+    await click(HOME);
+    assert.dom('nav.tabs .tab.active').hasText('Home');
+  });
+
+  test('the Frame search input is present and editable', async function (assert) {
+    await renderCard(loader, new Workspace({}), 'isolated');
+    assert.dom('.search-box .search-input').exists('Cmd+K frame search input');
+  });
+});

--- a/packages/host/tests/integration/components/workspace-unit-test.gts
+++ b/packages/host/tests/integration/components/workspace-unit-test.gts
@@ -1,0 +1,108 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupRenderingTest } from '../../helpers/setup';
+
+module('Integration | Card | workspace | pure functions', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  let ws: typeof import('@cardstack/base/workspace');
+
+  hooks.beforeEach(async function () {
+    ws = await getService('loader-service').loader.import<
+      typeof import('@cardstack/base/workspace')
+    >('@cardstack/base/workspace');
+  });
+
+  module('etaMinutes', function () {
+    const START = 1_000_000;
+    const startedAt = new Date(START).toISOString();
+
+    test('projects remaining minutes from the observed arrival rate', function (assert) {
+      // 4 of 12 done one minute in -> 15s/item -> 8 remaining -> 2 min.
+      assert.strictEqual(
+        ws.etaMinutes(
+          { progressDone: 4, progressTotal: 12, startedAt },
+          START + 60_000,
+        ),
+        2,
+      );
+    });
+
+    test('is undefined until at least 3 items are done', function (assert) {
+      assert.strictEqual(
+        ws.etaMinutes(
+          { progressDone: 2, progressTotal: 12, startedAt },
+          START + 60_000,
+        ),
+        undefined,
+      );
+    });
+
+    test('is undefined when the total does not exceed what is done', function (assert) {
+      assert.strictEqual(
+        ws.etaMinutes(
+          { progressDone: 12, progressTotal: 12, startedAt },
+          START + 60_000,
+        ),
+        undefined,
+      );
+    });
+
+    test('is undefined without a start time', function (assert) {
+      assert.strictEqual(
+        ws.etaMinutes({ progressDone: 4, progressTotal: 12 }, START + 60_000),
+        undefined,
+      );
+    });
+
+    test('is undefined when no time has elapsed', function (assert) {
+      assert.strictEqual(
+        ws.etaMinutes({ progressDone: 4, progressTotal: 12, startedAt }, START),
+        undefined,
+      );
+    });
+
+    test('is suppressed when the estimate exceeds 30 minutes', function (assert) {
+      // 3 of 100 one minute in -> ~32 min remaining -> implausible, suppressed.
+      assert.strictEqual(
+        ws.etaMinutes(
+          { progressDone: 3, progressTotal: 100, startedAt },
+          START + 60_000,
+        ),
+        undefined,
+      );
+    });
+  });
+
+  module('classifyActivityVerb', function () {
+    const created = 1_000_000;
+
+    test('"Created" when modified within two minutes of creation', function (assert) {
+      assert.strictEqual(
+        ws.classifyActivityVerb(created + 60_000, created),
+        'Created',
+      );
+    });
+
+    test('"Updated" when modified well after creation', function (assert) {
+      assert.strictEqual(
+        ws.classifyActivityVerb(created + 300_000, created),
+        'Updated',
+      );
+    });
+
+    test('"Updated" when either timestamp is missing', function (assert) {
+      assert.strictEqual(
+        ws.classifyActivityVerb(undefined, created),
+        'Updated',
+      );
+      assert.strictEqual(
+        ws.classifyActivityVerb(created, undefined),
+        'Updated',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for the Workspace card across three layers, plus the small refactors that make the pure logic directly testable.

## Refactor (in `workspace.gts`)

- `etaMinutes` is exported and takes an injectable `now` (defaulting to `Date.now()`), so the projection is deterministic under test.
- The Activity feed's inline "Created vs Updated" logic is extracted into an exported `classifyActivityVerb(modMs, createdMs)` with a named `CREATED_WINDOW_MS`.

## Tests

- **Unit** (`workspace-unit-test.gts`) — `etaMinutes` projection and every early-return (fewer than 3 done, total not exceeding done, no start time, no elapsed) plus the >30-minute suppression; `classifyActivityVerb` across the created-window boundary and missing timestamps.
- **Integration** (`workspace-behavior-test.gts`) — segment switching across the Home/Library/Activity tabs and presence of the Frame search input, via a bare render.
- **Acceptance** (`workspace-test.gts`) — a realm whose `index.json` adopts Workspace renders its shell in operator mode and switches segments, exercising the live realm-backed paths (`subscribeToRealm`, the `_types` fetch, and the Activity feed).

## Scope

Publish/unpublish coverage is deferred until the realm-server recognizes Workspace adoption. Deeper search-debounce, feed-pagination, and subscription-refresh cases (which need heavier realm-data/timing harness) remain follow-ups within this test surface.

## Stacking

Based on the Workspace port branch (`cs-12277-extract-workspace-carddef`), since these tests and the refactor build on `workspace.gts`. Retargets to `main` once the port merges. Draft until then.

## Test plan

glint / template-lint / prettier clean. Run locally against a full dev stack, per module: unit **9 passed**, integration segments **2 passed**, acceptance **1 passed**, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)