### PR TITLE
Recognize Workspace as a default realm index card

### DIFF
--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -718,8 +718,8 @@ export default class CardPrerender extends Component {
         throw new Error(this.localIndexer.renderError);
       }
       // The html sub-route flags this when the card is the realm's
-      // default CardsGrid index and the realm has not opted in to
-      // keeping its prerendered isolated HTML. Short-circuit the
+      // default index card (CardsGrid or Workspace) and the realm has
+      // not opted in to keeping its prerendered isolated HTML. Short-circuit the
       // Glimmer render entirely and return the boilerplate so the
       // indexer pays a constant write cost regardless of realm size.
       if (

--- a/packages/host/app/routes/render/html.ts
+++ b/packages/host/app/routes/render/html.ts
@@ -20,14 +20,14 @@ import { getClass, getTypes } from './meta';
 import type { Model as ParentModel } from '../render';
 import type { BoxComponent, CardDef, Format } from '@cardstack/base/card-api';
 
-// Stable internal key for the base CardsGrid type. We compare against
-// the internalKeyFor representation of the cards-grid module + name so
-// the check tolerates whatever resolved form the host's identify path
-// produces (e.g. realm-aliased base URLs).
-const CARDS_GRID_REF = {
-  module: '@cardstack/base/cards-grid',
-  name: 'CardsGrid',
-} as ResolvedCodeRef;
+// Stable internal keys for the base card types recognized as a realm's
+// default index. We compare against the internalKeyFor representation of
+// each module + name so the check tolerates whatever resolved form the
+// host's identify path produces (e.g. realm-aliased base URLs).
+const DEFAULT_REALM_INDEX_REFS = [
+  { module: '@cardstack/base/cards-grid', name: 'CardsGrid' },
+  { module: '@cardstack/base/workspace', name: 'Workspace' },
+] as ResolvedCodeRef[];
 
 export interface Model {
   instance: CardDef;
@@ -107,20 +107,21 @@ export default class RenderHtmlRoute extends Route<Model> {
     let useRealmIndexBoilerplate =
       format === 'isolated' &&
       level === 0 &&
-      this.#isDefaultRealmCardsGridIndex(instance, types);
+      this.#isDefaultRealmIndexCard(instance, types);
 
     return { format, instance, Component, useRealmIndexBoilerplate };
   }
 
   // True when the card under render is the realm's default index card
-  // AND its type chain begins with the base CardsGrid AND the realm
-  // has NOT opted in to keeping its prerendered isolated HTML via
+  // AND its type chain begins with a recognized default index card
+  // (CardsGrid or Workspace) AND the realm has NOT opted in to keeping
+  // its prerendered isolated HTML via
   // `RealmInfo.includePrerenderedDefaultRealmIndex`. The orchestrator
   // substitutes a boilerplate placeholder for the captured HTML in
   // that case so the indexer doesn't pay for the (expensive) grid
   // fan-out render of every card in the realm. Published realms
   // receive the opt-in automatically from the publish handler.
-  #isDefaultRealmCardsGridIndex(instance: CardDef, types: CodeRef[]): boolean {
+  #isDefaultRealmIndexCard(instance: CardDef, types: CodeRef[]): boolean {
     let cardRealmURL = instance[realmURL];
     if (
       !cardRealmURL ||
@@ -138,8 +139,10 @@ export default class RenderHtmlRoute extends Route<Model> {
     }
     let vn = this.network.virtualNetwork;
     let topKey = internalKeyFor(topType, undefined, vn);
-    let cardsGridKey = internalKeyFor(CARDS_GRID_REF, undefined, vn);
-    if (topKey !== cardsGridKey) {
+    let isDefaultIndexType = DEFAULT_REALM_INDEX_REFS.some(
+      (ref) => internalKeyFor(ref, undefined, vn) === topKey,
+    );
+    if (!isDefaultIndexType) {
       return false;
     }
     let info = this.realm.info(cardRealmURL.href);

--- a/packages/host/app/routes/render/html.ts
+++ b/packages/host/app/routes/render/html.ts
@@ -36,7 +36,8 @@ export interface Model {
   // True when this render should be short-circuited to the realm-
   // index boilerplate placeholder instead of running through Glimmer.
   // Set only when `format === 'isolated'`, the card is the realm's
-  // default index, the type chain is base CardsGrid, and the realm
+  // default index, the type chain begins with a recognized default
+  // index card (CardsGrid or Workspace), and the realm
   // has not opted in via `includePrerenderedDefaultRealmIndex` on its
   // RealmConfig card. The orchestrator in `card-prerender.gts`
   // honours this flag by substituting the boilerplate string and

--- a/packages/host/app/utils/realm-index-boilerplate.ts
+++ b/packages/host/app/utils/realm-index-boilerplate.ts
@@ -1,9 +1,8 @@
 // Placeholder content the host returns as `isolatedHTML` when it
 // decides to skip the full isolated render for the realm's default
-// CardsGrid index card. The decision is made per-render in
-// `card-prerender.gts` based on the card URL, its adoptsFrom chain,
-// and the realm's `includePrerenderedDefaultRealmIndex` config field
-// — see the realm-index opt-in PR for the surrounding rationale.
+// index card (CardsGrid or Workspace). The decision is made per-render
+// in `card-prerender.gts` based on the card URL, its adoptsFrom chain,
+// and the realm's `includePrerenderedDefaultRealmIndex` config field.
 //
 // The boilerplate is intentionally minimal. Anywhere the placeholder
 // could be visible (the published-realm SSR injection slot, the
@@ -17,8 +16,8 @@
 // payload.
 export const REALM_INDEX_BOILERPLATE_HTML = `<section data-prerender>
   <div
-    class="boxel-cards-grid-shell"
-    data-boxel-cards-grid-index
+    class="boxel-realm-index-shell"
+    data-boxel-realm-index
     aria-busy="true"
   >
     Prerendered HTML for default realm index is disabled (can be configured in realm.json)

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -5191,6 +5191,45 @@ posts/ignore-me.json
     );
   });
 
+  test('isolated HTML for a default Workspace realm-index card is replaced with the boilerplate when realm has not opted in', async function (assert) {
+    let { realm } = await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'index.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: '@cardstack/base/workspace',
+                name: 'Workspace',
+              },
+            },
+          },
+        },
+        'realm.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: '@cardstack/base/realm-config',
+                name: 'RealmConfig',
+              },
+            },
+          },
+        },
+      },
+    });
+    let entry = await getInstance(realm, new URL(`${testRealmURL}index`));
+    assert.ok(entry, 'realm index card is indexed');
+    assert.strictEqual(
+      entry?.isolatedHtml,
+      REALM_INDEX_BOILERPLATE_HTML,
+      'isolated_html is the boilerplate constant when a Workspace-indexed realm has not opted in',
+    );
+  });
+
   test('isolated HTML for a non-CardsGrid index card is rendered normally regardless of opt-in', async function (assert) {
     class PlainHomePage extends CardDef {
       static displayName = 'Plain Home Page';

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -54,11 +54,39 @@ const log = logger('handle-publish');
 // disk is the absolute URL. Listing both forms keeps the detection
 // future-proof: once `@cardstack/base/` becomes a live prefix
 // mapping, `index.json` files that use it are still caught.
-const CARDS_GRID_MODULE_FORMS = new Set<string>([
-  'https://cardstack.com/base/cards-grid',
-  '@cardstack/base/cards-grid',
-]);
-const CARDS_GRID_NAME = 'CardsGrid';
+// The base CardDefs recognized as a realm's default index card. A realm
+// whose index adopts one of these opts into the prerendered default-index
+// fast-path on publish; a realm with a bespoke index card is left alone.
+// Both module forms are listed per card (see the note above): the absolute
+// base-realm URL and the `@cardstack/base/` prefix form.
+const DEFAULT_REALM_INDEX_ADOPTIONS: { name: string; modules: Set<string> }[] =
+  [
+    {
+      name: 'CardsGrid',
+      modules: new Set([
+        'https://cardstack.com/base/cards-grid',
+        '@cardstack/base/cards-grid',
+      ]),
+    },
+    {
+      name: 'Workspace',
+      modules: new Set([
+        'https://cardstack.com/base/workspace',
+        '@cardstack/base/workspace',
+      ]),
+    },
+  ];
+
+function isDefaultRealmIndexAdoption(adoptsFrom: {
+  module: string;
+  name: string;
+}): boolean {
+  return DEFAULT_REALM_INDEX_ADOPTIONS.some(
+    (adoption) =>
+      adoption.modules.has(adoptsFrom.module) &&
+      adoption.name === adoptsFrom.name,
+  );
+}
 
 const PUBLISHED_REALM_DOMAIN_OVERRIDES = getPublishedRealmDomainOverrides(
   process.env.PUBLISHED_REALM_DOMAIN_OVERRIDES,
@@ -138,8 +166,8 @@ async function maybeApplyPublishedRealmOverride(
   };
 }
 
-// If the published realm's index card is the default CardsGrid, write
-// `includePrerenderedDefaultRealmIndex: true` into the realm's
+// If the published realm's index card is a default index card (CardsGrid or
+// Workspace), write `includePrerenderedDefaultRealmIndex: true` into the realm's
 // RealmConfig card on disk so the indexer (which the publish handler
 // kicks off below) produces a real isolated HTML for the index card
 // instead of the boilerplate placeholder. Anonymous visitors of a
@@ -178,10 +206,7 @@ async function ensureRealmIndexBoilerplateOptIn(
   if (!isResolvedCodeRef(adoptsFrom)) {
     return;
   }
-  if (
-    !CARDS_GRID_MODULE_FORMS.has(adoptsFrom.module) ||
-    adoptsFrom.name !== CARDS_GRID_NAME
-  ) {
+  if (!isDefaultRealmIndexAdoption(adoptsFrom)) {
     return;
   }
   let realmConfigDoc: Record<string, unknown>;

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -46,7 +46,7 @@ import { upsertPublishedRealmInRegistry } from '../lib/realm-registry-writes.ts'
 
 const log = logger('handle-publish');
 
-// The CardsGrid CardDef can be referenced two equivalent ways in a
+// A base CardDef can be referenced two equivalent ways in a
 // `meta.adoptsFrom.module` field — the absolute base-realm URL, or
 // the registered `@cardstack/base/` prefix form. `@cardstack/base/`
 // isn't currently wired as a virtual-network mapping in production

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -646,6 +646,77 @@ module(basename(import.meta.filename), function () {
         );
       });
 
+      test('publishing a realm whose index adopts the default Workspace card writes includePrerenderedDefaultRealmIndex into the published realm.json', async function (assert) {
+        let sourceRealmPath = new URL(sourceRealmUrlString).pathname;
+
+        // Point the source realm's index at the base Workspace card — the
+        // other recognized default index besides CardsGrid.
+        let workspaceIndexResponse = await request
+          .post(`${sourceRealmPath}index.json`)
+          .set('Accept', 'application/vnd.card+source')
+          .send(
+            JSON.stringify({
+              data: {
+                type: 'card',
+                attributes: {},
+                meta: {
+                  adoptsFrom: {
+                    module: '@cardstack/base/workspace',
+                    name: 'Workspace',
+                  },
+                },
+              },
+            }),
+          );
+        assert.strictEqual(
+          workspaceIndexResponse.status,
+          204,
+          'Workspace index.json can be written',
+        );
+
+        let response = await request
+          .post('/_publish-realm')
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createRealmServerJWT(
+              { user: ownerUserId, sessionRoom: 'session-room-test' },
+              realmSecretSeed,
+            )}`,
+          )
+          .send(
+            JSON.stringify({
+              sourceRealmURL: sourceRealmUrlString,
+              publishedRealmURL:
+                'http://testuser.localhost:4445/workspace-default/',
+            }),
+          );
+        assert.strictEqual(response.status, 202, 'HTTP 202 status');
+
+        let publishedRealmId = response.body.data.id;
+        let publishedDir = join(dir.name, 'realm_server_3', '_published');
+        let publishedRealmConfigPath = join(
+          publishedDir,
+          publishedRealmId,
+          'realm.json',
+        );
+        assert.ok(
+          existsSync(publishedRealmConfigPath),
+          'published realm.json exists on disk',
+        );
+        let publishedRealmConfig = readJsonSync(publishedRealmConfigPath) as {
+          data?: {
+            attributes?: { includePrerenderedDefaultRealmIndex?: boolean };
+          };
+        };
+        assert.true(
+          publishedRealmConfig?.data?.attributes
+            ?.includePrerenderedDefaultRealmIndex,
+          'published realm.json carries includePrerenderedDefaultRealmIndex: true for a Workspace index',
+        );
+      });
+
       test('POST /_publish-realm serves cached module entries for published realm URLs', async function (assert) {
         let requestedPublishedRealmURL = 'http://localhost:4445/test-realm/';
         let sourceRealmPath = new URL(sourceRealmUrlString).pathname;

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -226,9 +226,10 @@ export type RealmInfo = {
   publishable: boolean | null;
   lastPublishedAt: string | Record<string, string> | null;
   // Opt-in to producing the full prerendered isolated HTML for the
-  // realm's default CardsGrid index card. When undefined / null /
-  // false the host's render route substitutes a small boilerplate
-  // placeholder instead and skips the (expensive) isolated render.
+  // realm's default index card (CardsGrid or Workspace). When
+  // undefined / null / false the host's render route substitutes a
+  // small boilerplate placeholder instead and skips the (expensive)
+  // isolated render.
   // The lever is primarily set by the publish handler on the
   // published realm snapshot so anonymous-visitor SSR injection has
   // real content; unpublished realms typically have nothing reading


### PR DESCRIPTION
## What

Both the publish handler and the prerender fast-path only recognized `CardsGrid` as a realm's default index card. This teaches them to recognize `Workspace` too, so Workspace-indexed realms get the same default-index handling.

## Changes

- **`handle-publish-realm.ts`** — the CardsGrid-specific `CARDS_GRID_MODULE_FORMS` + name check becomes a list of recognized default-index adoptions (CardsGrid + Workspace). Publishing a realm whose `index.json` adopts either now writes `includePrerenderedDefaultRealmIndex: true` so the published homepage gets real prerendered content.
- **`routes/render/html.ts`** — `#isDefaultRealmCardsGridIndex` → `#isDefaultRealmIndexCard`, comparing the index card's top type against a list of recognized default-index refs via `internalKeyFor`. A realm indexed by CardsGrid or Workspace (and not opted in) short-circuits the isolated render to the boilerplate placeholder.
- **`realm-index-boilerplate.ts`** — the placeholder serves both index cards now, so its cards-grid-specific class/data attributes are generalized to realm-index-neutral names (no other consumers reference them).

A realm with a bespoke (non-default) index card is still left alone in both paths.

## Why this matters for the project

Making Workspace the actual default for new realms (`create-realm.ts`) depends on this — otherwise a newly created Workspace-indexed realm would lose the prerendered-default-index fast-path on publish.

## Tests

- **Realm-server** (`publish-unpublish-realm-test.ts`) — publishing a realm whose index adopts Workspace writes `includePrerenderedDefaultRealmIndex`, mirroring the existing CardsGrid case.
- **Host** (`realm-indexing-test.gts`) — a Workspace-indexed realm that has not opted in gets the boilerplate placeholder as its isolated HTML, mirroring the existing CardsGrid case.

## Stacking

Based on the Workspace port branch — the recognition is meaningless without the card, and the tests set up Workspace-indexed realms. Retargets to `main` once the port merges. Draft until then.

## Test plan

realm-server `ember-tsc` + host glint clean; eslint + prettier clean. Host boilerplate test run locally against a full dev stack — **1 passed**. The realm-server publish test is static-verified and mirrors an existing passing test; it runs in CI (the realm-server publish harness needs test-pg + its own prerender, not wired up in this local session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)