### PR TITLE
feat: bump boxel-skills to v0.0.30

### DIFF
--- a/packages/boxel-cli/scripts/build-skills.ts
+++ b/packages/boxel-cli/scripts/build-skills.ts
@@ -37,7 +37,7 @@ import {
 import { relative, resolve } from 'path';
 import { format, resolveConfig } from 'prettier';
 
-const BOXEL_SKILLS_VERSION = 'v0.0.28';
+const BOXEL_SKILLS_VERSION = 'v0.0.29';
 const BOXEL_SKILLS_REPO_URL = 'https://github.com/cardstack/boxel-skills.git';
 
 const PLUGIN_DIR = resolve(import.meta.dirname, '..', 'plugin');

--- a/packages/boxel-cli/scripts/build-skills.ts
+++ b/packages/boxel-cli/scripts/build-skills.ts
@@ -37,7 +37,7 @@ import {
 import { relative, resolve } from 'path';
 import { format, resolveConfig } from 'prettier';
 
-const BOXEL_SKILLS_VERSION = 'v0.0.29';
+const BOXEL_SKILLS_VERSION = 'v0.0.30';
 const BOXEL_SKILLS_REPO_URL = 'https://github.com/cardstack/boxel-skills.git';
 
 const PLUGIN_DIR = resolve(import.meta.dirname, '..', 'plugin');


### PR DESCRIPTION
Bumps the pinned boxel-skills release consumed by `build:skills` from `v0.0.28` to `v0.0.30`, which brings the `boxel-skill-authoring` and `ember-best-practices` skills into the vendored plugin content, plus the reworked `distill-learnings` command (two-destination flow) and the removal of the obsolete `distill-from-boxel-skills` command.

Release notes: https://github.com/cardstack/boxel-skills/releases/tag/v0.0.30

On merge, the publish workflow regenerates `packages/boxel-cli/plugin/` from the new tag and publishes the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)