### PR TITLE
Add homepage realm test suite (CS-12299)

### DIFF
--- a/packages/boxel-homepage-realm/package.json
+++ b/packages/boxel-homepage-realm/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "test": "node --test 'tests/*.test.ts'",
+    "test": "pnpm boxel-homepage:setup && node --test 'tests/*.test.ts'",
     "boxel-homepage:setup": "sh ./scripts/boxel-homepage-setup.sh",
     "boxel-homepage:update": "pnpm boxel-homepage:setup && cd contents && git pull",
     "boxel-homepage:reset": "rm -rf contents && pnpm boxel-homepage:setup"

--- a/packages/boxel-homepage-realm/package.json
+++ b/packages/boxel-homepage-realm/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
+    "test": "node --test 'tests/*.test.ts'",
     "boxel-homepage:setup": "sh ./scripts/boxel-homepage-setup.sh",
     "boxel-homepage:update": "pnpm boxel-homepage:setup && cd contents && git pull",
     "boxel-homepage:reset": "rm -rf contents && pnpm boxel-homepage:setup"

--- a/packages/boxel-homepage-realm/tests/allowed-orphans.txt
+++ b/packages/boxel-homepage-realm/tests/allowed-orphans.txt
@@ -1,0 +1,4 @@
+# Instances deliberately not linked from any routed page.
+# cards-grid is the workbench grid.
+# Prune entries as they get wired in or deleted; new orphans fail the test.
+cards-grid.json

--- a/packages/boxel-homepage-realm/tests/grid-cards.test.ts
+++ b/packages/boxel-homepage-realm/tests/grid-cards.test.ts
@@ -120,3 +120,60 @@ test('gridCards getter in animated-grid.gts stays @cached', () => {
     'gridCards must delegate to the tested lib/grid-cards module',
   );
 });
+
+test('hero grid animation contracts in animated-grid.gts', () => {
+  const source = readFileSync(
+    fileURLToPath(
+      new URL(
+        '../contents/boxel-ai-website/animated-grid.gts',
+        import.meta.url,
+      ),
+    ),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /captureGridPlane = modifier[\s\S]*?IntersectionObserver/,
+    'animation loop must be gated behind an IntersectionObserver',
+  );
+  assert.match(
+    source,
+    /\} finally \{[\s\S]*?delete activeCard\.dataset\.active;[\s\S]*?delete popup\.dataset\.visible;/,
+    'cancellation must clear the highlighted tile and popup (regression: ' +
+      'stranded data-active tiles accumulated after scroll-out cancels)',
+  );
+  assert.match(
+    source,
+    /for \(const card of cards\) \{\s*delete card\.dataset\.active;/,
+    'each run must sweep stale highlights from prior cancelled runs',
+  );
+  assert.match(
+    source,
+    /resumeSignal/,
+    'pause must park on a promise resolved by resumeAnimation',
+  );
+  assert.doesNotMatch(
+    source,
+    /await timeout\(200\)/,
+    'pause must not busy-poll',
+  );
+  assert.doesNotMatch(
+    source,
+    /classList\./,
+    'JS-driven state uses data attributes, not classnames',
+  );
+});
+
+test('grid tile active state is a data attribute, not a class', () => {
+  const source = readFileSync(
+    fileURLToPath(
+      new URL(
+        '../contents/boxel-ai-website/components/animated-grid-card.gts',
+        import.meta.url,
+      ),
+    ),
+    'utf8',
+  );
+  assert.match(source, /\.hero-mini-card\[data-active\]/);
+  assert.doesNotMatch(source, /\.hero-mini-card\.active/);
+});

--- a/packages/boxel-homepage-realm/tests/grid-cards.test.ts
+++ b/packages/boxel-homepage-realm/tests/grid-cards.test.ts
@@ -1,0 +1,122 @@
+// Regression tests for the AnimatedGrid hero-grid layout logic
+// (contents/boxel-ai-website/lib/grid-cards.ts) and for the caching
+// contract of the gridCards getter in animated-grid.gts.
+//
+// Run with: pnpm test (node --test; Node >= 23 strips types natively)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildGridPool,
+  buildGridSlots,
+  makeSeededRandom,
+} from '../contents/boxel-ai-website/lib/grid-cards.ts';
+
+// The production dimensions: 25 cols x 15 rows, 28 noun sample cards.
+const CELLS = 375;
+const SAMPLES = 28;
+
+test('pool fills every cell with a valid sample index', () => {
+  const pool = buildGridPool(CELLS, SAMPLES, makeSeededRandom(42));
+  assert.equal(pool.length, CELLS);
+  for (const idx of pool) {
+    assert.ok(Number.isInteger(idx) && idx >= 0 && idx < SAMPLES);
+  }
+});
+
+test('pool is deterministic for a given seed', () => {
+  const a = buildGridPool(CELLS, SAMPLES, makeSeededRandom(7));
+  const b = buildGridPool(CELLS, SAMPLES, makeSeededRandom(7));
+  assert.deepEqual(a, b);
+});
+
+test('different seeds produce different layouts', () => {
+  const a = buildGridPool(CELLS, SAMPLES, makeSeededRandom(1));
+  const b = buildGridPool(CELLS, SAMPLES, makeSeededRandom(2));
+  assert.notDeepEqual(a, b);
+});
+
+test('every sample card appears in the grid', () => {
+  const pool = buildGridPool(CELLS, SAMPLES, makeSeededRandom(42));
+  assert.equal(new Set(pool).size, SAMPLES);
+});
+
+test('adjacent duplicates are broken up', () => {
+  // Deterministic rng, so this can never flake; a sweep of seeds guards the
+  // dedupe pass rather than one lucky shuffle.
+  for (let seed = 0; seed < 50; seed++) {
+    const pool = buildGridPool(CELLS, SAMPLES, makeSeededRandom(seed));
+    let adjacent = 0;
+    for (let i = 0; i < pool.length - 1; i++) {
+      if (pool[i] === pool[i + 1]) adjacent++;
+    }
+    assert.ok(
+      adjacent <= 2,
+      `seed ${seed}: ${adjacent} adjacent duplicate pairs`,
+    );
+  }
+});
+
+test('slots cover all cells when every card resolves', () => {
+  const cards = Array.from({ length: SAMPLES }, (_, i) => ({ id: i }));
+  const slots = buildGridSlots(cards, CELLS, makeSeededRandom(42));
+  assert.equal(slots.length, CELLS);
+  for (const slot of slots) {
+    assert.equal(slot.card, cards[slot.index]);
+  }
+});
+
+test('cells for unresolved card links are dropped, not emitted as broken tiles', () => {
+  // Simulate a linksToMany entry that failed to resolve (the bug that used
+  // to emit `[]` as a grid entry, rendering a blank tile whose popup fell
+  // back to sample 0).
+  const cards: ({ id: number } | null)[] = Array.from(
+    { length: SAMPLES },
+    (_, i) => ({ id: i }),
+  );
+  cards[5] = null;
+
+  const pool = buildGridPool(CELLS, SAMPLES, makeSeededRandom(42));
+  const cellsForMissing = pool.filter((i) => i === 5).length;
+  const slots = buildGridSlots(cards, CELLS, makeSeededRandom(42));
+
+  assert.ok(cellsForMissing > 0, 'seed 42 should map some cells to sample 5');
+  assert.equal(slots.length, CELLS - cellsForMissing);
+  for (const slot of slots) {
+    assert.notEqual(slot.index, 5);
+    assert.ok(slot.card != null);
+  }
+});
+
+test('no cards yields an empty grid (empty-state branch)', () => {
+  assert.deepEqual(buildGridSlots([], CELLS, makeSeededRandom(42)), []);
+});
+
+test('gridCards getter in animated-grid.gts stays @cached', () => {
+  // The isolated template reads gridCards twice ({{#if}} + {{#each}});
+  // without @cached the 375-cell layout builds twice per render and every
+  // read hands {{#each}} a new array identity. Guard the source contract
+  // since the component itself cannot be instantiated outside the host.
+  const source = readFileSync(
+    fileURLToPath(
+      new URL(
+        '../contents/boxel-ai-website/animated-grid.gts',
+        import.meta.url,
+      ),
+    ),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /@cached\s+private get gridCards\(\)/,
+    'gridCards must keep the @cached decorator',
+  );
+  assert.match(
+    source,
+    /buildGridSlots\(/,
+    'gridCards must delegate to the tested lib/grid-cards module',
+  );
+});

--- a/packages/boxel-homepage-realm/tests/realm-integrity.test.ts
+++ b/packages/boxel-homepage-realm/tests/realm-integrity.test.ts
@@ -281,7 +281,9 @@ test('navbar anchors exist in the home layout template', () => {
       if (typeof href !== 'string') continue;
       const match = href.match(/#([\w-]+)/);
       if (!match) continue;
-      if (!new RegExp(`id=['"]${match[1]}['"]`).test(layout)) {
+      // anchors render either as a literal id or via a SectionSlot @anchor
+      const anchorPattern = new RegExp(`(id|@anchor)=['"]${match[1]}['"]`);
+      if (!anchorPattern.test(layout)) {
         failures.push(`${rel(f)}: ${href}`);
       }
     }

--- a/packages/boxel-homepage-realm/tests/realm-integrity.test.ts
+++ b/packages/boxel-homepage-realm/tests/realm-integrity.test.ts
@@ -1,0 +1,294 @@
+// Structural integrity tests for the homepage realm (contents/).
+//
+// These walk the realm's files and assert link-graph invariants that the
+// realm server itself only surfaces at index time (as error documents) or
+// not at all. Each guards a class of defect found in review: dangling
+// adoptsFrom/relationship links, unreachable instances, orphaned assets,
+// stray extensionless files, and instance data keys that match no card field.
+//
+// Run with: pnpm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname, resolve, relative, extname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CONTENTS = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../contents',
+);
+
+const EXECUTABLE_EXTENSIONS = ['.gts', '.ts', '.js', '.gjs'];
+const SKIP_DIRS = new Set(['.git', '.boxel-history', 'node_modules']);
+
+// Fields every card inherits from CardDef (base realm card-api).
+const CARD_DEF_FIELDS = new Set([
+  'cardInfo',
+  'cardTitle',
+  'cardDescription',
+  'title',
+  'description',
+  'thumbnailURL',
+]);
+
+// Instances that are deliberately not linked from any routed page.
+// Prune entries when the instance gets wired in or deleted; a NEW unlisted
+// orphan fails the reachability test.
+const ALLOWED_ORPHANS = new Set<string>([
+  // populated below from the current, reviewed state of the realm
+  ...loadAllowedOrphans(),
+]);
+
+function loadAllowedOrphans(): string[] {
+  const file = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'allowed-orphans.txt',
+  );
+  if (!existsSync(file)) return [];
+  return readFileSync(file, 'utf8')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#'));
+}
+
+interface WalkResult {
+  jsonFiles: string[]; // card instance documents
+  sourceFiles: string[]; // .gts/.ts/.js/.gjs modules
+  otherFiles: string[]; // everything else (assets, markdown, ...)
+}
+
+function walk(dir: string, out: WalkResult): WalkResult {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      if (!SKIP_DIRS.has(name) && !name.startsWith('.')) walk(full, out);
+      continue;
+    }
+    if (name.startsWith('.')) continue;
+    if (name.endsWith('.json')) out.jsonFiles.push(full);
+    else if (EXECUTABLE_EXTENSIONS.includes(extname(name)))
+      out.sourceFiles.push(full);
+    else out.otherFiles.push(full);
+  }
+  return out;
+}
+
+const files = walk(CONTENTS, {
+  jsonFiles: [],
+  sourceFiles: [],
+  otherFiles: [],
+});
+
+const instances = files.jsonFiles.filter((f) => {
+  try {
+    const doc = JSON.parse(readFileSync(f, 'utf8'));
+    return doc?.data?.type === 'card';
+  } catch {
+    return false;
+  }
+});
+
+function rel(f: string): string {
+  return relative(CONTENTS, f);
+}
+
+function readJson(f: string): any {
+  return JSON.parse(readFileSync(f, 'utf8'));
+}
+
+// Recursively collect every {links: {self}} target and every adoptsFrom in a doc.
+function collectRefs(node: any, links: string[], modules: string[]) {
+  if (node == null || typeof node !== 'object') return;
+  if (typeof node.adoptsFrom?.module === 'string') {
+    modules.push(node.adoptsFrom.module);
+  }
+  if (typeof node.links?.self === 'string') {
+    links.push(node.links.self);
+  }
+  for (const value of Object.values(node)) collectRefs(value, links, modules);
+}
+
+function resolvesAsModule(fromFile: string, specifier: string): boolean {
+  const base = resolve(dirname(fromFile), specifier);
+  if (existsSync(base) && statSync(base).isFile()) return true;
+  return EXECUTABLE_EXTENSIONS.some((ext) => existsSync(base + ext));
+}
+
+function resolvesAsLink(fromFile: string, target: string): boolean {
+  const base = resolve(dirname(fromFile), target);
+  if (extname(target)) {
+    // file link (image, markdown, ...) — the literal file must exist
+    return existsSync(base);
+  }
+  // card link — extensionless instance URL backed by a .json document
+  return existsSync(base + '.json');
+}
+
+test('every adoptsFrom module resolves', () => {
+  const failures: string[] = [];
+  for (const f of instances) {
+    const links: string[] = [];
+    const modules: string[] = [];
+    collectRefs(readJson(f), links, modules);
+    for (const mod of modules) {
+      if (!mod.startsWith('.')) continue; // base-realm / absolute URLs
+      if (!resolvesAsModule(f, mod)) {
+        failures.push(`${rel(f)} -> ${mod}`);
+      }
+    }
+  }
+  assert.deepEqual(
+    failures,
+    [],
+    `dangling adoptsFrom:\n${failures.join('\n')}`,
+  );
+});
+
+test('every relationship link resolves', () => {
+  const failures: string[] = [];
+  for (const f of instances) {
+    const links: string[] = [];
+    const modules: string[] = [];
+    collectRefs(readJson(f), links, modules);
+    for (const target of links) {
+      if (/^[a-z]+:/i.test(target)) continue; // http(s) etc.
+      if (!resolvesAsLink(f, target)) {
+        failures.push(`${rel(f)} -> ${target}`);
+      }
+    }
+  }
+  assert.deepEqual(failures, [], `dangling links:\n${failures.join('\n')}`);
+});
+
+test('every instance is reachable from a routed page (or allowlisted)', () => {
+  const realmConfig = join(CONTENTS, 'realm.json');
+  const roots: string[] = [];
+  {
+    const links: string[] = [];
+    const modules: string[] = [];
+    collectRefs(readJson(realmConfig), links, modules);
+    for (const target of links) {
+      const resolved = resolve(CONTENTS, target) + '.json';
+      if (existsSync(resolved)) roots.push(resolved);
+    }
+  }
+  assert.ok(roots.length >= 4, 'realm.json should route at least 4 pages');
+
+  const reachable = new Set<string>();
+  const queue = [...roots];
+  while (queue.length) {
+    const f = queue.pop()!;
+    if (reachable.has(f)) continue;
+    reachable.add(f);
+    const links: string[] = [];
+    const modules: string[] = [];
+    collectRefs(readJson(f), links, modules);
+    for (const target of links) {
+      if (/^[a-z]+:/i.test(target) || extname(target)) continue;
+      const resolved = resolve(dirname(f), target) + '.json';
+      if (existsSync(resolved)) queue.push(resolved);
+    }
+  }
+
+  const orphans = instances
+    .filter((f) => f !== realmConfig && !reachable.has(f))
+    .map(rel)
+    .filter((r) => !ALLOWED_ORPHANS.has(r));
+  assert.deepEqual(
+    orphans,
+    [],
+    `unreachable instances (wire them in, delete them, or add to tests/allowed-orphans.txt):\n${orphans.join('\n')}`,
+  );
+});
+
+test('instance attribute keys match a declared @field', () => {
+  const allSource = files.sourceFiles
+    .map((f) => readFileSync(f, 'utf8'))
+    .join('\n');
+  const failures: string[] = [];
+  for (const f of instances) {
+    if (basename(f) === 'realm.json') continue;
+    const doc = readJson(f);
+    // Only check cards whose class is defined in this realm; base-realm and
+    // external classes declare their fields outside these sources.
+    if (!doc?.data?.meta?.adoptsFrom?.module?.startsWith('.')) continue;
+    const attributes = doc?.data?.attributes ?? {};
+    const keys: string[] = [];
+    const collectKeys = (node: any) => {
+      if (Array.isArray(node)) return node.forEach(collectKeys);
+      if (node == null || typeof node !== 'object') return;
+      for (const [key, value] of Object.entries(node)) {
+        if (key === 'cardInfo') continue; // free-form base field
+        keys.push(key);
+        collectKeys(value);
+      }
+    };
+    collectKeys(attributes);
+    for (const key of new Set(keys)) {
+      if (CARD_DEF_FIELDS.has(key)) continue;
+      if (!new RegExp(`@field\\s+${key}\\b`).test(allSource)) {
+        failures.push(`${rel(f)}: "${key}"`);
+      }
+    }
+  }
+  assert.deepEqual(
+    failures,
+    [],
+    `attribute keys with no matching @field declaration:\n${failures.join('\n')}`,
+  );
+});
+
+test('every screenshot asset is referenced', () => {
+  const shotsDir = join(CONTENTS, 'boxel-ai-website', 'screenshots');
+  if (!existsSync(shotsDir)) return;
+  const allText = [...files.sourceFiles, ...files.jsonFiles]
+    .map((f) => readFileSync(f, 'utf8'))
+    .join('\n');
+  const orphaned = readdirSync(shotsDir).filter(
+    (name) => !name.startsWith('.') && !allText.includes(name),
+  );
+  assert.deepEqual(
+    orphaned,
+    [],
+    `unreferenced screenshots (delete them):\n${orphaned.join('\n')}`,
+  );
+});
+
+test('no extensionless files shadow card-instance URLs', () => {
+  const strays = files.otherFiles
+    .filter((f) => !extname(f) && basename(f) !== 'LICENSE')
+    .map(rel);
+  assert.deepEqual(
+    strays,
+    [],
+    `extensionless files (these shadow instance URL resolution):\n${strays.join('\n')}`,
+  );
+});
+
+test('navbar anchors exist in the home layout template', () => {
+  const layout = readFileSync(
+    join(CONTENTS, 'boxel-ai-website', 'boxel-home-layout.gts'),
+    'utf8',
+  );
+  const failures: string[] = [];
+  for (const f of instances) {
+    const navLinks = readJson(f)?.data?.attributes?.navLinks;
+    if (!Array.isArray(navLinks)) continue;
+    for (const link of navLinks) {
+      const href: string | undefined = link?.href ?? link?.url;
+      if (typeof href !== 'string') continue;
+      const match = href.match(/#([\w-]+)/);
+      if (!match) continue;
+      if (!new RegExp(`id=['"]${match[1]}['"]`).test(layout)) {
+        failures.push(`${rel(f)}: ${href}`);
+      }
+    }
+  }
+  assert.deepEqual(
+    failures,
+    [],
+    `nav anchors with no matching id in boxel-home-layout.gts:\n${failures.join('\n')}`,
+  );
+});

--- a/packages/boxel-homepage-realm/tests/realm-integrity.test.ts
+++ b/packages/boxel-homepage-realm/tests/realm-integrity.test.ts
@@ -22,16 +22,6 @@ const CONTENTS = resolve(
 const EXECUTABLE_EXTENSIONS = ['.gts', '.ts', '.js', '.gjs'];
 const SKIP_DIRS = new Set(['.git', '.boxel-history', 'node_modules']);
 
-// Fields every card inherits from CardDef (base realm card-api).
-const CARD_DEF_FIELDS = new Set([
-  'cardInfo',
-  'cardTitle',
-  'cardDescription',
-  'title',
-  'description',
-  'thumbnailURL',
-]);
-
 // Instances that are deliberately not linked from any routed page.
 // Prune entries when the instance gets wired in or deleted; a NEW unlisted
 // orphan fails the reachability test.
@@ -220,14 +210,16 @@ test('instance attribute keys match a declared @field', () => {
       if (Array.isArray(node)) return node.forEach(collectKeys);
       if (node == null || typeof node !== 'object') return;
       for (const [key, value] of Object.entries(node)) {
-        if (key === 'cardInfo') continue; // free-form base field
+        // cardInfo is CardDef's free-form base field; its subtree (name,
+        // summary, cardThumbnailURL, ...) is declared in base card-api, not
+        // in this realm's sources.
+        if (key === 'cardInfo') continue;
         keys.push(key);
         collectKeys(value);
       }
     };
     collectKeys(attributes);
     for (const key of new Set(keys)) {
-      if (CARD_DEF_FIELDS.has(key)) continue;
       if (!new RegExp(`@field\\s+${key}\\b`).test(allSource)) {
         failures.push(`${rel(f)}: "${key}"`);
       }

--- a/packages/boxel-homepage-realm/tests/realm-integrity.test.ts
+++ b/packages/boxel-homepage-realm/tests/realm-integrity.test.ts
@@ -294,3 +294,32 @@ test('navbar anchors exist in the home layout template', () => {
     `nav anchors with no matching id in boxel-home-layout.gts:\n${failures.join('\n')}`,
   );
 });
+
+test('frame and CTA tokens stay adopted (no literal 80rem, no per-use fallbacks)', () => {
+  // Guards the define-once token work: the page frame is
+  // --site-max-width/--content-gutter (site-page-shell), consumed via
+  // one --_max-width/--_gutter alias per component; the CTA palette
+  // (--cta-contrast-*, --cta-arrow-*, --border-strong) is defined only
+  // in the shell and read plainly everywhere else.
+  const siteDir = join(CONTENTS, 'boxel-ai-website');
+  const failures: string[] = [];
+  for (const f of files.sourceFiles) {
+    if (!f.startsWith(siteDir)) continue;
+    const source = readFileSync(f, 'utf8');
+    const shortName = rel(f);
+    const isShell = shortName.endsWith('components/site-page-shell.gts');
+    for (const [index, line] of source.split('\n').entries()) {
+      const at = `${shortName}:${index + 1}`;
+      if (/max-width:\s*80rem/.test(line) && !isShell) {
+        failures.push(`${at}: literal 80rem (use the --_max-width alias)`);
+      }
+      if (/var\(--(cta-contrast|cta-arrow)-[a-z]+\s*,/.test(line)) {
+        failures.push(`${at}: per-use fallback on a CTA token`);
+      }
+      if (/var\(--border-strong\s*,/.test(line)) {
+        failures.push(`${at}: per-use fallback on --border-strong`);
+      }
+    }
+  }
+  assert.deepEqual(failures, [], failures.join('\n'));
+});

--- a/packages/boxel-homepage-realm/tests/serial-list.test.ts
+++ b/packages/boxel-homepage-realm/tests/serial-list.test.ts
@@ -1,0 +1,27 @@
+// Regression tests for the footer colophon's serial-comma separator
+// (contents/boxel-ai-website/lib/serial-list.ts).
+//
+// Run with: pnpm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { serialSeparator } from '../contents/boxel-ai-website/lib/serial-list.ts';
+
+function joined(items: string[]): string {
+  return items
+    .map((word, i) => word + serialSeparator(i, items.length))
+    .join('');
+}
+
+test('serial comma list shapes', () => {
+  assert.equal(joined(['designed']), 'designed');
+  // two items: bare "and", no comma splice ("designed, and coded" was the bug)
+  assert.equal(joined(['designed', 'coded']), 'designed and coded');
+  assert.equal(joined(['a', 'b', 'c']), 'a, b, and c');
+  assert.equal(
+    joined(['designed', 'coded', 'edited', 'published', 'hosted']),
+    'designed, coded, edited, published, and hosted',
+  );
+  assert.equal(joined([]), '');
+});

--- a/packages/boxel-homepage-realm/tests/terminal-scroll.test.ts
+++ b/packages/boxel-homepage-realm/tests/terminal-scroll.test.ts
@@ -1,0 +1,83 @@
+// Regression tests for the CLI terminal auto-scroll decision logic
+// (contents/boxel-ai-website/lib/terminal-scroll.ts) and the visibility
+// gating contract of the terminal animation in cli-section.gts.
+//
+// Run with: pnpm test
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+  activeLineIndex,
+  isSequenceSettled,
+  scrollTargetFor,
+} from '../contents/boxel-ai-website/lib/terminal-scroll.ts';
+
+const DELAYS = [0, 0.5, 1.2, 2.0, 3.5]; // ascending, like authored lines
+
+test('activeLineIndex tracks the last fired line', () => {
+  assert.equal(activeLineIndex(DELAYS, -0.1), -1); // nothing fired yet
+  assert.equal(activeLineIndex(DELAYS, 0), 0); // fires at its exact delay
+  assert.equal(activeLineIndex(DELAYS, 0.6), 1);
+  assert.equal(activeLineIndex(DELAYS, 2.0), 3);
+  assert.equal(activeLineIndex(DELAYS, 999), 4); // all fired
+  assert.equal(activeLineIndex([], 5), -1); // no lines
+});
+
+test('activeLineIndex stops scanning at the first future delay', () => {
+  // Original DOM loop broke at the first delay > elapsed; an out-of-order
+  // later line must not be picked even if its delay has fired.
+  assert.equal(activeLineIndex([0, 5, 1], 2), 0);
+});
+
+test('isSequenceSettled fires only after the last delay plus settle time', () => {
+  assert.equal(isSequenceSettled(DELAYS, 3.5), false); // last line just fired
+  assert.equal(isSequenceSettled(DELAYS, 5.4), false); // still settling (3.5+2)
+  assert.equal(isSequenceSettled(DELAYS, 5.6), true);
+  assert.equal(isSequenceSettled(DELAYS, 4.1, 0.5), true); // custom settle
+  assert.equal(isSequenceSettled([], 999), false); // no lines: never settles
+});
+
+test('scrollTargetFor scrolls forward only, and only when content overflows', () => {
+  // line bottom 300px, viewport 200px -> target 300-200+16 = 116
+  assert.equal(scrollTargetFor(300, 200, 0), 116);
+  // never scrolls backwards
+  assert.equal(scrollTargetFor(300, 200, 116), null);
+  assert.equal(scrollTargetFor(300, 200, 150), null);
+  // content still fits the viewport: no scroll
+  assert.equal(scrollTargetFor(100, 200, 0), null);
+  // custom bottom padding
+  assert.equal(scrollTargetFor(300, 200, 0, 0), 100);
+});
+
+test('terminal animation stays visibility-gated in cli-section.gts', () => {
+  // The cycle must be driven by the IntersectionObserver gate, not the
+  // constructor — a constructor perform() runs the animation (and its
+  // forced-reflow interval) for the life of the page even offscreen.
+  const source = readFileSync(
+    fileURLToPath(
+      new URL(
+        '../contents/boxel-ai-website/sections/cli-section.gts',
+        import.meta.url,
+      ),
+    ),
+    'utf8',
+  );
+  assert.doesNotMatch(
+    source,
+    /constructor[^}]*cycleTerminal\.perform/s,
+    'cycleTerminal must not be performed from the constructor',
+  );
+  assert.match(
+    source,
+    /gateTerminal = modifier[\s\S]*?IntersectionObserver/,
+    'gateTerminal must gate the cycle behind an IntersectionObserver',
+  );
+  assert.match(
+    source,
+    /activeLineIndex\(|isSequenceSettled\(/,
+    'AutoScroll must delegate decisions to the tested lib/terminal-scroll module',
+  );
+});


### PR DESCRIPTION
Linear: [CS-12299](https://linear.app/cardstack/issue/CS-12299/add-homepage-realm-test-suite-realm-integrity-pure-logic-source)

25-test suite for the homepage realm, built during the CS-12248 hardening pass (cardstack/boxel-home#63). Plain `node --test` over `packages/boxel-homepage-realm/tests/` — no build step, Node ≥23 strips types natively, runs in ~150ms via `pnpm test` in the package.

## What it covers

- **`realm-integrity.test.ts`** — 8 structural invariants over `contents/`: every `adoptsFrom.module` and relationship `links.self` resolves to a file; every instance is reachable from a `realm.json`-routed page (or allowlisted in `allowed-orphans.txt`, currently one entry); JSON attribute keys match `@field` declarations; every screenshot asset is referenced; no extensionless files shadow card-instance URLs; navbar `navLinks` anchors exist in the layout; frame/CTA design tokens stay adopted (no literal `80rem`, no per-use token fallbacks). Five of the CS-12248 review findings (dangling theme link, unreachable sections, stray extensionless card, orphaned screenshots, phantom attribute key) would have been caught automatically by this file.
- **`grid-cards.test.ts`** — pure-logic units for the hero grid layout (`lib/grid-cards.ts`: deterministic seeded shuffle, adjacency dedupe, unresolved-link dropping) plus source contracts on `animated-grid.gts` (`@cached` getter, IntersectionObserver gating, cancellation cleanup, data-attribute state).
- **`terminal-scroll.test.ts`** — units for the CLI terminal auto-scroll decisions (`lib/terminal-scroll.ts`) plus the visibility-gating contract on `cli-section.gts`.
- **`serial-list.test.ts`** — Oxford-comma list joins (`lib/serial-list.ts`), including the 2-item regression case.

## Notes

- The `lib/` modules under test live in the contents repo (cardstack/boxel-home) and are imported by relative path; the source-contract tests read `.gts` sources as text, so nothing here needs the host build.
- The suite pairs with the contents-side changes in cardstack/boxel-home#63 — the integrity tests assert the post-cleanup state, so this PR should land at or after that one (they pass against boxel-home `cs-12248-update-website`).
- CI wiring for `pnpm test` in this package is not included here; follow-up on CS-12299: CS-12317

🤖 Generated with [Claude Code](https://claude.com/claude-code)