### PR TITLE
Preserve broken-link sentinels across instance reloads

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1456,7 +1456,13 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
     loadedValue: any,
     relativeTo: RealmResourceIdentifier | URL | undefined,
     opts: DeserializeOpts,
-  ): Promise<BaseInstanceType<CardT> | null | NotLoadedValue> {
+  ): Promise<
+    | BaseInstanceType<CardT>
+    | null
+    | NotLoadedValue
+    | LinkErrorValue
+    | LinkNotFoundValue
+  > {
     if (!isRelationship(value)) {
       throw new Error(
         `linkTo field '${

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1491,6 +1491,17 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
     let resource =
       resourceId != null ? resourceFrom(doc, resourceId) : undefined;
     if (!resource) {
+      // A terminal sentinel (link-error / link-not-found) is carried forward only
+      // when the wire reference is unchanged, so a known-broken link is not
+      // re-armed to a fresh not-loaded marker — which the getter WOULD retry — on
+      // reload. A re-pointed reference re-arms (the sentinel no longer describes
+      // the target); a target that has since become resolvable is present in the
+      // reload document, so `resource` is truthy above and this branch never runs.
+      if (isLinkError(loadedValue) || isLinkNotFound(loadedValue)) {
+        return resolveRef(loadedValue.reference, relativeTo) === href
+          ? loadedValue
+          : { type: 'not-loaded', reference };
+      }
       if (loadedValue !== undefined) {
         return loadedValue;
       }
@@ -2081,6 +2092,24 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
           resource = resourceFrom(doc, reference);
         }
         if (!resource) {
+          // Carry a terminal sentinel (link-error / link-not-found) forward when
+          // the wire reference is unchanged, so a known-broken element is not
+          // re-armed to a fresh not-loaded marker — which the next render would
+          // re-fetch — on every reload. The WatchedArray hides sentinels from
+          // index access, so scan the raw backing array to find one. A target
+          // that has since become resolvable is present in the reload document,
+          // so `resource` is truthy above and this branch never runs: the element
+          // loads and the card heals.
+          if (Array.isArray(loadedValues)) {
+            let carried = rawArrayValues(loadedValues).find(
+              (v) =>
+                (isLinkError(v) || isLinkNotFound(v)) &&
+                resolveRef(v.reference, relativeTo) === normalizedReference,
+            );
+            if (carried) {
+              return carried;
+            }
+          }
           return {
             type: 'not-loaded',
             reference,

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1751,15 +1751,6 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       // shape; the structured failure surfaces through `getRelationshipMembershipState`.
       let bucketEntry = deserialized.get(this.name);
       if (isLinkError(bucketEntry) || isLinkNotFound(bucketEntry)) {
-        // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes.
-        console.error(
-          '[CS-11221 DIAG] linksToMany getter returning emptyValue (bucket sentinel)',
-          {
-            fieldName: this.name,
-            ownerType: instance?.constructor?.name,
-            sentinelType: (bucketEntry as { type?: string })?.type,
-          },
-        );
         return this.emptyValue(instance) as BaseInstanceType<FieldT>;
       }
       let records = searchResource.instances ?? ([] as any[]);

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -262,17 +262,6 @@ function surfaceSearchResourceErrorState(
   }
 
   let sentinel = buildQueryFieldSentinel(instance, field, errors);
-  // DIAGNOSTIC LOGGING (CS-11221) — remove after CI passes. Don't read
-  // `instance.id` here: the field getter for `id` initializes the bucket
-  // via emptyValue, violating the pure-read contract callers depend on.
-  console.error('[CS-11221 DIAG] surface plant sentinel', {
-    fieldName: field.name,
-    ownerType: instance?.constructor?.name,
-    sentinelType: sentinel.type,
-    errorCount: errors.length,
-    firstErrorStatus: errors[0]?.error?.status,
-    firstErrorMessage: errors[0]?.error?.message,
-  });
   bucket.set(field.name, sentinel);
   fieldState.surfacedErrorSentinel = sentinel;
 }

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -817,14 +817,6 @@ export class SearchResource<
         if (didCancel(err)) {
           throw err;
         }
-        // DIAGNOSTIC LOGGING (CS-11221).
-        console.error('[CS-11221 DIAG] search task caught error', {
-          query: JSON.stringify(query),
-          realms: this.realmsToSearch,
-          errMessage: (err as { message?: unknown })?.message,
-          errStatus: (err as { status?: unknown })?.status,
-          errName: (err as { name?: unknown })?.name,
-        });
         this.#log.error(`search task failed`, err);
         this._errors = [searchErrorEntry(err)];
         this._meta = { page: { total: 0 } };

--- a/packages/host/tests/integration/components/linksto-sentinel-reload-test.gts
+++ b/packages/host/tests/integration/components/linksto-sentinel-reload-test.gts
@@ -1,0 +1,284 @@
+import { settled, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  PermissionsContextName,
+  type LooseSingleCardDocument,
+  type Permissions,
+  type SingleCardDocument,
+} from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import type CardStore from '@cardstack/host/lib/gc-card-store';
+import type StoreService from '@cardstack/host/services/store';
+
+import {
+  provideConsumeContext,
+  setupCardLogs,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+  testRRI,
+} from '../../helpers';
+import {
+  CardDef,
+  contains,
+  field,
+  getRelationshipMembershipState,
+  linksTo,
+  linksToMany,
+  setupBaseRealm,
+  StringField,
+  updateFromSerialized,
+} from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+import type { CardDef as CardDefType } from '@cardstack/base/card-api';
+
+const MANGO = `${testRealmURL}Pet/mango`;
+const GHOST = `${testRealmURL}Pet/ghost`;
+
+const PERSON = `${testRealmURL}Person/hassan`;
+
+let loader: Loader;
+let storeService: StoreService;
+let cardStore: CardStore;
+let testRealm: Realm;
+
+// The card GET the host reloads from serves a broken link as a plain relationship
+// link (identical to a not-yet-loaded link) with the target absent from
+// `included` — the same wire `reloadInstance` feeds back into
+// `updateFromSerialized`.
+function personDoc(): LooseSingleCardDocument {
+  return {
+    data: {
+      id: PERSON,
+      type: 'card',
+      attributes: { firstName: 'Hassan' },
+      relationships: {
+        pet: { links: { self: GHOST } },
+        'pets.0': { links: { self: MANGO } },
+        'pets.1': { links: { self: GHOST } },
+      },
+      meta: { adoptsFrom: { module: testRRI('test-cards'), name: 'Person' } },
+    },
+  };
+}
+
+module('Integration | linksTo sentinel reload', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  setupCardLogs(
+    hooks,
+    async () => await loader.import('@cardstack/base/card-api'),
+  );
+
+  hooks.beforeEach(async function () {
+    let permissions: Permissions = { canWrite: true, canRead: true };
+    provideConsumeContext(PermissionsContextName, permissions);
+    loader = getService('loader-service').loader;
+    storeService = getService('store');
+    cardStore = (storeService as any).store as CardStore;
+
+    class Pet extends CardDef {
+      @field firstName = contains(StringField);
+    }
+    class Person extends CardDef {
+      @field firstName = contains(StringField);
+      @field pet = linksTo(Pet);
+      @field pets = linksToMany(Pet);
+    }
+
+    ({ realm: testRealm } = await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'test-cards.gts': { Person, Pet },
+        'Pet/mango.json': {
+          data: {
+            attributes: { firstName: 'Mango' },
+            meta: {
+              adoptsFrom: { module: testRRI('test-cards'), name: 'Pet' },
+            },
+          },
+        },
+        // Person/hassan pins a present link (mango) and two broken links (ghost)
+        // across both arities.
+        'Person/hassan.json': personDoc() as SingleCardDocument,
+      },
+    }));
+    await getService('realm').login(testRealmURL);
+  });
+
+  // Count card-document loads against the broken reference — the fetch a
+  // re-armed link kicks off on the next render.
+  function trackGhostLoads(): { count: () => number; restore: () => void } {
+    let count = 0;
+    let original = cardStore.loadCardDocument.bind(cardStore);
+    (cardStore as any).loadCardDocument = (url: string | URL, opts: any) => {
+      let href = typeof url === 'string' ? url : url.href;
+      if (href.includes('Pet/ghost')) {
+        count++;
+      }
+      return original(url, opts);
+    };
+    return {
+      count: () => count,
+      restore: () => {
+        (cardStore as any).loadCardDocument = original;
+      },
+    };
+  }
+
+  async function loadHassan(): Promise<CardDefType> {
+    storeService.addReference(PERSON);
+    await storeService.flush();
+    return storeService.peek(PERSON) as CardDefType;
+  }
+
+  // Read both relationships the way a render does, driving the lazy loads.
+  function readLinks(person: CardDefType) {
+    (person as any).pet;
+    (person as any).pets;
+  }
+
+  function petKind(person: CardDefType): string {
+    return getRelationshipMembershipState(person, 'pet').membership![0].kind;
+  }
+  function petsKinds(person: CardDefType): string[] {
+    return getRelationshipMembershipState(person, 'pets').membership!.map(
+      (s) => s.kind,
+    );
+  }
+
+  test('N reloads with an unchanged broken reference produce no re-fetch (AC1)', async function (assert) {
+    let person = await loadHassan();
+    readLinks(person);
+    await waitUntil(() => petKind(person) === 'not-found');
+    await waitUntil(() => petsKinds(person).includes('not-found'));
+
+    let tracker = trackGhostLoads();
+    try {
+      let doc = personDoc();
+      for (let i = 0; i < 5; i++) {
+        await updateFromSerialized(person as any, doc, cardStore);
+        // Read before any render touches the field: a carried sentinel stays
+        // terminal (`not-found`); a re-armed slot reverts to `not-loaded`, which
+        // the next render would re-fetch.
+        assert.strictEqual(
+          petKind(person),
+          'not-found',
+          `reload ${i}: singular link stays terminal (not re-armed)`,
+        );
+        assert.deepEqual(
+          petsKinds(person),
+          ['present', 'not-found'],
+          `reload ${i}: plural links stay terminal (not re-armed)`,
+        );
+        readLinks(person); // the render each incremental event drives
+        await settled();
+      }
+    } finally {
+      tracker.restore();
+    }
+
+    assert.strictEqual(
+      tracker.count(),
+      0,
+      'the known-broken links are not re-fetched across 5 reloads',
+    );
+  });
+
+  test('creating the missing target heals the card on the next reload (AC2)', async function (assert) {
+    let person = await loadHassan();
+    readLinks(person);
+    await waitUntil(() => petKind(person) === 'not-found');
+    await waitUntil(() => petsKinds(person).includes('not-found'));
+
+    // The missing target comes into existence; the consumer reloads, and its
+    // reload document includes the freshly-created target so the link resolves.
+    await testRealm.write(
+      'Pet/ghost.json',
+      JSON.stringify({
+        data: {
+          attributes: { firstName: 'Ghost' },
+          meta: {
+            adoptsFrom: { module: testRRI('test-cards'), name: 'Pet' },
+          },
+        },
+      } as LooseSingleCardDocument),
+    );
+
+    let doc = (await getService('card-service').fetchJSON(
+      PERSON,
+    )) as LooseSingleCardDocument;
+    await updateFromSerialized(person as any, doc, cardStore);
+    readLinks(person);
+    await waitUntil(() => petKind(person) === 'present');
+    await waitUntil(() => !petsKinds(person).includes('not-found'));
+
+    assert.strictEqual(petKind(person), 'present', 'singular link healed');
+    assert.deepEqual(
+      petsKinds(person),
+      ['present', 'present'],
+      'plural links healed',
+    );
+  });
+
+  test('a reload that re-points a broken link to a different reference re-arms it', async function (assert) {
+    let CASPER = `${testRealmURL}Pet/casper`;
+    let person = await loadHassan();
+    readLinks(person);
+    await waitUntil(() => petKind(person) === 'not-found');
+    await waitUntil(() => petsKinds(person).includes('not-found'));
+
+    // The links are re-pointed to a different (still-missing) target. The stale
+    // sentinel no longer describes the reference, so it must not be carried — the
+    // slot re-arms to not-loaded, and the next render retries the new target.
+    let repointed: LooseSingleCardDocument = {
+      data: {
+        id: PERSON,
+        type: 'card',
+        attributes: { firstName: 'Hassan' },
+        relationships: {
+          pet: { links: { self: CASPER } },
+          'pets.0': { links: { self: MANGO } },
+          'pets.1': { links: { self: CASPER } },
+        },
+        meta: { adoptsFrom: { module: testRRI('test-cards'), name: 'Person' } },
+      },
+    };
+    await updateFromSerialized(person as any, repointed, cardStore);
+
+    assert.strictEqual(
+      getRelationshipMembershipState(person, 'pet').membership![0].kind,
+      'not-loaded',
+      're-pointed singular link re-arms to not-loaded (stale sentinel dropped)',
+    );
+    assert.strictEqual(
+      getRelationshipMembershipState(person, 'pets').membership![1].kind,
+      'not-loaded',
+      're-pointed plural element re-arms to not-loaded (stale sentinel dropped)',
+    );
+
+    readLinks(person);
+    await waitUntil(() => petKind(person) === 'not-found');
+    let petState = getRelationshipMembershipState(person, 'pet').membership![0];
+    assert.strictEqual(
+      petState.reference,
+      CASPER,
+      'the retried link surfaces the new reference, not the stale one',
+    );
+  });
+});

--- a/packages/host/tests/integration/components/linksto-sentinel-reload-test.gts
+++ b/packages/host/tests/integration/components/linksto-sentinel-reload-test.gts
@@ -126,9 +126,8 @@ module('Integration | linksTo sentinel reload', function (hooks) {
   function trackGhostLoads(): { count: () => number; restore: () => void } {
     let count = 0;
     let original = cardStore.loadCardDocument.bind(cardStore);
-    (cardStore as any).loadCardDocument = (url: string | URL, opts: any) => {
-      let href = typeof url === 'string' ? url : url.href;
-      if (href.includes('Pet/ghost')) {
+    (cardStore as any).loadCardDocument = (url: string, opts: any) => {
+      if (url.includes('Pet/ghost')) {
         count++;
       }
       return original(url, opts);

--- a/packages/host/tests/integration/components/linksto-sentinel-reload-test.gts
+++ b/packages/host/tests/integration/components/linksto-sentinel-reload-test.gts
@@ -125,12 +125,12 @@ module('Integration | linksTo sentinel reload', function (hooks) {
   // re-armed link kicks off on the next render.
   function trackGhostLoads(): { count: () => number; restore: () => void } {
     let count = 0;
-    let original = cardStore.loadCardDocument.bind(cardStore);
-    (cardStore as any).loadCardDocument = (url: string, opts: any) => {
+    let original = cardStore.loadCardDocument;
+    (cardStore as any).loadCardDocument = function (url: string, opts: any) {
       if (url.includes('Pet/ghost')) {
         count++;
       }
-      return original(url, opts);
+      return original.call(cardStore, url, opts);
     };
     return {
       count: () => count,
@@ -161,7 +161,7 @@ module('Integration | linksTo sentinel reload', function (hooks) {
     );
   }
 
-  test('N reloads with an unchanged broken reference produce no re-fetch (AC1)', async function (assert) {
+  test('N reloads with an unchanged broken reference produce no re-fetch', async function (assert) {
     let person = await loadHassan();
     readLinks(person);
     await waitUntil(() => petKind(person) === 'not-found');
@@ -199,7 +199,7 @@ module('Integration | linksTo sentinel reload', function (hooks) {
     );
   });
 
-  test('creating the missing target heals the card on the next reload (AC2)', async function (assert) {
+  test('creating the missing target heals the card on the next reload', async function (assert) {
     let person = await loadHassan();
     readLinks(person);
     await waitUntil(() => petKind(person) === 'not-found');


### PR DESCRIPTION
The client tolerates a broken link by planting a typed terminal sentinel (`link-not-found` / `link-error`) in the instance's data bucket when a lazy link load fails. The field getter surfaces these as `undefined` and never retries them — bounded, by design. But a sentinel's lifetime is the instance's data bucket, and rebuilding an instance's relationships from the wire planted a fresh `not-loaded` marker regardless of the prior state. So every reload erased every sentinel and re-armed every broken link; the next render re-fetched each one, hit the same 404, and re-planted the sentinel.

A realm's index card is a dependent of nearly everything in its realm, so it reloads on almost every incremental event. Under an agent write burst (a write every few seconds) this kept an open card with broken links churning in "Loading card…", re-attempting every broken link on every event.

This change carries a terminal sentinel forward across re-deserialization when the wire reference is unchanged, instead of planting a fresh `not-loaded` marker:

- `linksToMany` was the re-arm path. Its per-element carry-forward only matched loaded card instances, and the `WatchedArray` proxy hides sentinel slots from index access, so a sentinel was invisible to that scan and always fell through to `not-loaded`. It now scans the raw backing array for a sentinel whose reference matches the wire element.
- `linksTo` already carried the prior value forward, so it did not re-arm; it now re-arms correctly when the reference is re-pointed to a different target (the stale sentinel no longer describes the link).

Healing is unchanged. When a missing target comes into existence, the consumer is invalidated (the broken reference is carried in its `deps`) and its reload document includes the now-resolvable target, so `resource` is found and the link loads — the carry-forward branch only runs while the target is still missing. Store resets (loader-epoch changes) still discard sentinels; that boundary is the whole identity map, and instance reloads — not resets — are the dominant re-arm path.

New integration coverage (`linksto-sentinel-reload`):
- N reloads with an unchanged broken reference produce no re-fetch, across both arities.
- Creating the missing target heals the card on the next reload.
- A reload that re-points a broken link to a different reference re-arms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
