### PR TITLE
Make to-device the default ai-bot streaming mode

### DIFF
--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -103,12 +103,17 @@ export class Responder {
     return this.matrixResponsePublisher.originalResponseEventId;
   }
 
+  // to-device is the default: mid-turn previews stream over the ephemeral
+  // to-device channel and only one consolidated room edit lands per turn,
+  // keeping Synapse's room-event load flat. `room-edits` (the legacy per-edit
+  // behavior) and `off` (no mid-turn previews at all) remain available as
+  // explicit AI_BOT_STREAMING_MODE overrides.
   private get streamingMode(): 'room-edits' | 'off' | 'to-device' {
     const mode = process.env.AI_BOT_STREAMING_MODE;
-    if (mode === 'off' || mode === 'to-device') {
+    if (mode === 'off' || mode === 'room-edits') {
       return mode;
     }
-    return 'room-edits';
+    return 'to-device';
   }
 
   // Whether mid-turn state changes should trigger a throttled preview send.

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -468,7 +468,7 @@ Common issues are:
               ? JSON.parse(event.getContent().data)
               : event.getContent().data;
           const agentId = contentData.context?.agentId;
-          // Route to-device streaming previews (see APP_BOXEL_STREAMING_MODE
+          // Route to-device streaming previews (see AI_BOT_STREAMING_MODE
           // handling in Responder) at the device that composed the prompt for
           // this turn. A continuation triggered by a tool / code-patch result
           // carries no device id, so fall back to the most recent stamped

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -100,6 +100,11 @@ module('Responding', (hooks) => {
     clock = FakeTimers.install();
     fakeMatrixClient = new FakeMatrixClient();
     responder = new Responder(fakeMatrixClient, 'room-id', 'abc123agentId');
+    // Most tests here exercise room-edit streaming mechanics (thinking-message
+    // replacement, throttled edits, event splitting). Since the default mode is
+    // now to-device, pin room-edits as the module baseline; tests that target a
+    // different mode override this and reset it in their own teardown.
+    process.env.AI_BOT_STREAMING_MODE = 'room-edits';
   });
 
   hooks.afterEach(() => {
@@ -108,6 +113,7 @@ module('Responding', (hooks) => {
     responder.finalize();
     fakeMatrixClient.resetSentEvents();
     responder.matrixResponsePublisher.eventSizeMax = DEFAULT_EVENT_SIZE_MAX;
+    delete process.env.AI_BOT_STREAMING_MODE;
   });
 
   test('Sends thinking message', async () => {
@@ -410,8 +416,8 @@ module('Responding', (hooks) => {
   });
 
   test('per-turn telemetry counts room-edits mid-turn events (the comparison baseline)', async () => {
-    // Default mode is room-edits with no preview target — the "before" side of
-    // the streaming-mode comparison, where each mid-turn edit is its own room
+    // The module baseline is room-edits (set in beforeEach) — the "before" side
+    // of the streaming-mode comparison, where each mid-turn edit is its own room
     // event. Pins that this stays high, so a regression that stopped counting
     // mid-turn edits can't silently collapse it to ~2 like the other modes.
     await responder.ensureThinkingMessageSent();
@@ -422,7 +428,7 @@ module('Responding', (hooks) => {
     await responder.finalize();
 
     let telemetry = responder.turnTelemetry;
-    assert.equal(telemetry.mode, 'room-edits', 'default mode is room-edits');
+    assert.equal(telemetry.mode, 'room-edits', 'room-edits mode is active');
     assert.ok(
       telemetry.roomEvents > 2,
       `room-edits emits a room event per mid-turn edit (got ${telemetry.roomEvents})`,
@@ -431,6 +437,27 @@ module('Responding', (hooks) => {
       telemetry.toDeviceEvents,
       0,
       'room-edits never uses the to-device channel',
+    );
+  });
+
+  test('default streaming mode (no env var) is to-device', async () => {
+    // Guards the default flip: with AI_BOT_STREAMING_MODE unset the turn runs
+    // in to-device mode, so only the placeholder + one consolidated room edit
+    // land regardless of whether a preview target is present.
+    delete process.env.AI_BOT_STREAMING_MODE;
+    await responder.ensureThinkingMessageSent();
+    for (let i = 0; i < 5; i++) {
+      await responder.onChunk({} as any, snapshotWithContent('content ' + i));
+      await clock.tickAsync(300);
+    }
+    await responder.finalize();
+
+    let telemetry = responder.turnTelemetry;
+    assert.equal(telemetry.mode, 'to-device', 'default mode is to-device');
+    assert.equal(
+      telemetry.roomEvents,
+      2,
+      `default collapses to placeholder + one final room edit (got ${telemetry.roomEvents})`,
     );
   });
 


### PR DESCRIPTION
## What

Makes `to-device` the default ai-bot streaming mode. The `AI_BOT_STREAMING_MODE` fallback flips from `room-edits` to `to-device`:

- mid-turn previews stream over the ephemeral to-device channel, and only **one** consolidated room edit lands per turn;
- `room-edits` (the legacy per-edit behavior) and `off` (no mid-turn previews) remain available as **explicit** `AI_BOT_STREAMING_MODE` overrides.

## Why

A single active assistant conversation drives Synapse CPU largely through the volume of durable room events. A staging run comparing all three modes (fixed ~3,100-token response, 3 turns/mode) measured:

| Mode | Room events/turn | To-device events/turn | Synapse CPU during load | Latency (median) |
| -- | -- | -- | -- | -- |
| `room-edits` | 142 | 0 | 0.14 cores (7.1%) | 63.9s |
| `off` | 2 | 0 | 0.02 cores (idle) | 62.6s |
| `to-device` | 2 | ~140 | 0.06 cores (3.0%) | 61.8s |

`to-device` cuts durable room events ~72× (142 → 2) while preserving mid-turn streaming (the previews just move to the to-device channel), at lower Synapse CPU than `room-edits` and with no latency regression. The deployed host client already stamps its originating device id, so previews stream for current clients; older clients that don't stamp it degrade gracefully to `off`-mode behavior (placeholder + final edit).

## Changes

- `responder.ts` — flip the `streamingMode` fallback to `to-device`.
- `main.ts` — fix a stale env-var name in a comment (`APP_BOXEL_STREAMING_MODE` → `AI_BOT_STREAMING_MODE`).
- `tests/responding-test.ts` — the legacy tests exercise room-edit mechanics (thinking-message replacement, throttled edits, event splitting), so pin `room-edits` as the module baseline in `beforeEach`/`afterEach`; add a test asserting the unset default is now `to-device`.

## Testing

- `node tests/index.ts` — green except the two `AI Bot Locking` tests, which require CI's Postgres role and pass there.
- `pnpm lint:js` / `pnpm lint:types` clean.

## Deploy note

Making this the effective default in a deployed env requires that the ai-bot task definition **not** pin `AI_BOT_STREAMING_MODE` (an explicit env value overrides this code default). No infra env pin should be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
