### PR TITLE
Size the host memory-baseline hard gate to each module's observed swing

### DIFF
--- a/packages/host/scripts/check-memory-baseline.mjs
+++ b/packages/host/scripts/check-memory-baseline.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 // Compares per-module memory deltas from a CI run against a committed baseline.
-// Exits 0 on pass/warn, exits 1 on hard failure (>2x baseline or +50MB absolute).
+// Exits 0 on pass/warn, exits 1 on hard failure — when a module's delta clears
+// its recent ceiling by more than the larger of +50MB, 100% of the baseline, or
+// the module's own observed run-to-run swing.
 //
 // Usage: node check-memory-baseline.mjs <reports-dir> <baseline-json>
 //
@@ -134,14 +136,13 @@ for (const [mod, data] of Object.entries(current)) {
     effectiveBase * SOFT_RELATIVE,
   );
   // The hard threshold also absorbs the module's demonstrated peak-to-peak
-  // noise, so a run must clear the ceiling by more than the module has already
-  // shown it can move on its own before it blocks. This is what keeps a module
-  // whose recent window is entirely negative honest: its baseline and ceiling
-  // both floor to zero, so the absolute gate alone would fail any single
-  // positive reading — including one from a module that routinely swings by
-  // >100MB and merely landed positive this run. Sizing the threshold to the
-  // observed swing lets that reading through while a genuine step past the
-  // swing still blocks.
+  // noise. When a module's recent window is entirely negative, its mean baseline
+  // and its ceiling both floor to zero, so the +50MB absolute term alone would
+  // block any single reading over 50MB — even from a module that routinely
+  // swings by >100MB and merely landed positive this run. Sizing the threshold
+  // to the observed swing means a run has to clear the recent ceiling by more
+  // than the module's own run-to-run range before it blocks; tighter-window
+  // modules fall back to the absolute/relative terms.
   const hardThreshold = Math.max(
     HARD_ABSOLUTE_MB,
     effectiveBase * HARD_RELATIVE,
@@ -195,7 +196,7 @@ const baselineHeader =
 
 if (failures.length > 0) {
   lines.push(
-    `### Failures (>${HARD_RELATIVE * 100}% increase or +${HARD_ABSOLUTE_MB}MB)\n`,
+    `### Failures (over recent ceiling by >${HARD_ABSOLUTE_MB}MB, >${HARD_RELATIVE * 100}%, or the observed swing)\n`,
   );
   lines.push(
     `| Module | ${baselineHeader} | Current | Change | Recent samples |`,

--- a/packages/host/scripts/check-memory-baseline.mjs
+++ b/packages/host/scripts/check-memory-baseline.mjs
@@ -72,6 +72,24 @@ const baselineCeiling = (entry) => {
   return entry?.delta_mb;
 };
 
+// The peak-to-peak spread of the recent window (max sample − min sample). This
+// is the module's own demonstrated run-to-run noise: a module whose post-GC
+// boundary delta swings because the settle-GC drains a large transient on some
+// runs but not others will show a wide spread even with no leak. The hard gate
+// folds this spread into its threshold so a value inside the module's already-
+// exhibited swing can't block the build — an all-negative window like
+// [-73, -74, -8, -19, -120] spans 112MB, so a one-off +54 reading is noise, not
+// a regression, even though it clears the (floored-at-zero) ceiling by >50MB.
+// Modules with a tight window (spread < the absolute hard threshold) are
+// unaffected. Zero for a single-value baseline that carries no sample window,
+// leaving the absolute/relative thresholds to govern on their own.
+const baselineSpread = (entry) => {
+  if (Array.isArray(entry?.samples) && entry.samples.length > 1) {
+    return Math.max(...entry.samples) - Math.min(...entry.samples);
+  }
+  return 0;
+};
+
 const fmtSamples = (entry) =>
   Array.isArray(entry?.samples) && entry.samples.length > 0
     ? `[${entry.samples.map((s) => s.toFixed(1)).join(', ')}]`
@@ -115,9 +133,19 @@ for (const [mod, data] of Object.entries(current)) {
     SOFT_ABSOLUTE_MB,
     effectiveBase * SOFT_RELATIVE,
   );
+  // The hard threshold also absorbs the module's demonstrated peak-to-peak
+  // noise, so a run must clear the ceiling by more than the module has already
+  // shown it can move on its own before it blocks. This is what keeps a module
+  // whose recent window is entirely negative honest: its baseline and ceiling
+  // both floor to zero, so the absolute gate alone would fail any single
+  // positive reading — including one from a module that routinely swings by
+  // >100MB and merely landed positive this run. Sizing the threshold to the
+  // observed swing lets that reading through while a genuine step past the
+  // swing still blocks.
   const hardThreshold = Math.max(
     HARD_ABSOLUTE_MB,
     effectiveBase * HARD_RELATIVE,
+    baselineSpread(base),
   );
 
   const pct =


### PR DESCRIPTION
The "Host Memory Baseline" check compares each test module's post-GC heap boundary delta against a rolling window of recent main runs and hard-fails on a large regression. That metric is dominated by non-deterministic settle-GC drain timing at the module boundary, so heavy modules routinely swing run-to-run by well over 100MB without leaking anything — a negative reading just means the previous module's garbage got reclaimed inside this module's window.

The hard gate already anchors to the recent *ceiling* (max sample) rather than the mean, precisely so a high-variance module can't be blocked by a value it has already exhibited. But when a module's entire recent window is negative, both its mean baseline and its ceiling floor to zero, and the gate collapses to "any single reading over +50MB fails." A module that has been sitting at samples like `[-73, -74, -8, -19, -120]` then gets blocked the one run it lands at `+54`:

| Module | Baseline (mean of last 5) | Current | Change | Recent samples |
|--------|----------|---------|--------|----------------|
| Integration \| ai-assistant-panel \| general | 0.0 MB | 54.3 MB | +54.3 MB | [-73.0, -74.1, -7.6, -19.4, -120.1] |

The baseline showing `0.0` and the change being the raw measured value is the tell: nothing about the module's actual behaviour is informing the threshold. That window spans 112MB peak-to-peak, so a one-off +54 is squarely inside the module's own noise.

This folds the recent window's peak-to-peak spread into the hard threshold, alongside the existing absolute and relative terms. A run now has to clear the ceiling by more than the module has already shown it can move on its own before it blocks. Behaviour at the edges:

- Tight-window modules (spread below the +50MB absolute threshold) are unchanged.
- A genuine regression still fails — the delta has to clear the recent ceiling (the module's highest recent sample) by more than the module's own observed swing, so a step well past a demonstrated range is still caught.
- The soft, mean-anchored warning is untouched, so a module trending upward still surfaces early; it just no longer *blocks* on within-noise excursions.

**This is a strict relaxation of the current gate.** The measured delta and the ceiling it's compared against are unchanged, and the threshold only ever grows (the added spread term is non-negative), so `hardThreshold` can only increase. No module that clears the hard gate today can begin to fail under this change — it lands with no re-baselining and introduces no new reds.

That monotonicity is also why the spread is layered *on top of* the ceiling anchor rather than replacing it with a single mean anchor. Anchoring the excursion at the mean would tighten the wide-swing modules, but it would begin blocking moderate-variance modules that pass today — e.g. a `[40, 60, 40, 60, 50]` window would hard-fail at `+100MB`, where both the current gate and this change pass. The cost of keeping the ceiling anchor is that a very wide window tolerates a correspondingly large excursion before it hard-blocks; that excursion still prints as a non-blocking warning, and a sustained regression re-crosses the gate once it folds into the rolling baseline.

Verified against reconstructed data from the failing run and synthetic leak/low-variance cases: the false failure drops to a non-blocking warning, while both a low-variance step-change and a noisy value that clears its own swing still hard-fail.
