### PR TITLE
Markdown embed chooser: show a size-matched card placeholder while a pick loads

### DIFF
--- a/packages/host/app/components/markdown-embed-chooser/pane.gts
+++ b/packages/host/app/components/markdown-embed-chooser/pane.gts
@@ -59,6 +59,10 @@ interface Signature {
     // Overrides the dynamic "Insert as …" CTA label. Used in edit mode to
     // show 'Done' (clean) or 'Accept' (dirty) per the design spec.
     ctaLabelOverride?: string;
+    // True while the picked target is still resolving. The viewport renders a
+    // size-matched loading placeholder and the CTA is held disabled until the
+    // instance (or an error) lands.
+    loading?: boolean;
   };
 }
 
@@ -124,6 +128,9 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
   // for editing seeds the Custom category with no dimensions but is a valid,
   // supported form, so its unchanged (non-dirty) state keeps the CTA enabled.
   private get ctaDisabled(): boolean {
+    if (this.args.loading) {
+      return true;
+    }
     return !this.args.selection.hasValidSize && this.args.selection.isDirty;
   }
 
@@ -170,6 +177,7 @@ export default class MarkdownEmbedPreviewPane extends Component<Signature> {
       <div class='markdown-embed-preview-pane__viewport'>
         <MarkdownEmbedPreview
           @target={{@target}}
+          @loading={{@loading}}
           @brokenUrl={{@brokenUrl}}
           @brokenDisplayName={{@brokenDisplayName}}
           @brokenItemType={{@brokenItemType}}

--- a/packages/host/app/components/markdown-embed-chooser/preview/index.gts
+++ b/packages/host/app/components/markdown-embed-chooser/preview/index.gts
@@ -3,7 +3,10 @@ import { htmlSafe } from '@ember/template';
 
 import Component from '@glimmer/component';
 
-import { BrokenLinkTemplate } from '@cardstack/boxel-ui/components';
+import {
+  BrokenLinkTemplate,
+  LoadingIndicator,
+} from '@cardstack/boxel-ui/components';
 import type {
   BrokenLinkErrorDoc,
   BrokenLinkItemType,
@@ -30,7 +33,10 @@ const EMPTY_ERROR_DOC: BrokenLinkErrorDoc = Object.freeze({});
 interface EmbedSignature {
   Element: HTMLElement;
   Args: {
-    target: CardDef | FileDef;
+    // The resolved instance to render. Absent while `loading` — the box then
+    // holds a spinner in place of the card body, keeping the same footprint.
+    target?: CardDef | FileDef;
+    loading?: boolean;
     format: Format;
     kind: 'inline' | 'block';
     sizeStyle?: ReturnType<typeof htmlSafe>;
@@ -52,33 +58,45 @@ const Embed: TOC<EmbedSignature> = <template>
           "markdown-embed-preview--inline-embed"
         }}
         {{if @sizeStyle "markdown-embed-preview--fitted"}}
-        {{if (not (eq @format "atom")) "markdown-embed-preview--card-frame"}}'
+        {{if (not (eq @format "atom")) "markdown-embed-preview--card-frame"}}
+        {{if @loading "is-loading"}}'
       style={{@sizeStyle}}
-      data-test-markdown-embed-preview
-      data-test-markdown-embed-preview-format={{@format}}
+      data-test-markdown-embed-preview={{if (not @loading) 'true'}}
+      data-test-markdown-embed-preview-format={{if (not @loading) @format}}
+      data-test-markdown-embed-preview-loading={{if @loading 'true'}}
       ...attributes
     >
-      <CardRenderer
-        @card={{@target}}
-        @format={{@format}}
-        @displayContainer={{false}}
-      />
+      {{#if @target}}
+        <CardRenderer
+          @card={{@target}}
+          @format={{@format}}
+          @displayContainer={{false}}
+        />
+      {{else if @loading}}
+        <LoadingIndicator class='markdown-embed-preview__spinner' />
+      {{/if}}
     </span>
   {{else}}
     <div
       class='markdown-embed-preview markdown-embed-preview--block
         {{if @sizeStyle "markdown-embed-preview--fitted"}}
-        {{if (not (eq @format "atom")) "markdown-embed-preview--card-frame"}}'
+        {{if (not (eq @format "atom")) "markdown-embed-preview--card-frame"}}
+        {{if @loading "is-loading"}}'
       style={{@sizeStyle}}
-      data-test-markdown-embed-preview
-      data-test-markdown-embed-preview-format={{@format}}
+      data-test-markdown-embed-preview={{if (not @loading) 'true'}}
+      data-test-markdown-embed-preview-format={{if (not @loading) @format}}
+      data-test-markdown-embed-preview-loading={{if @loading 'true'}}
       ...attributes
     >
-      <CardRenderer
-        @card={{@target}}
-        @format={{@format}}
-        @displayContainer={{false}}
-      />
+      {{#if @target}}
+        <CardRenderer
+          @card={{@target}}
+          @format={{@format}}
+          @displayContainer={{false}}
+        />
+      {{else if @loading}}
+        <LoadingIndicator class='markdown-embed-preview__spinner' />
+      {{/if}}
     </div>
   {{/if}}
   <style scoped>
@@ -108,6 +126,24 @@ const Embed: TOC<EmbedSignature> = <template>
       border-radius: var(--boxel-border-radius);
       background-color: var(--boxel-light);
       overflow: hidden;
+    }
+    /* Loading placeholder: keep the resolved embed's footprint (size + frame)
+       but center a small spinner where the card body will land. Force a flex
+       box so the spinner centers in the block / inline-embed variants (the atom
+       variant is already inline-flex). */
+    .markdown-embed-preview.is-loading {
+      align-items: center;
+      justify-content: center;
+    }
+    .markdown-embed-preview--block.is-loading {
+      display: flex;
+    }
+    .markdown-embed-preview--inline-embed.is-loading {
+      display: inline-flex;
+    }
+    /* Small enough to sit inside an atom pill, unobtrusive in larger frames. */
+    .markdown-embed-preview__spinner {
+      --boxel-loading-indicator-size: 1.25rem;
     }
   </style>
 </template>;
@@ -194,6 +230,10 @@ interface Signature {
     // nothing. Absent when the ref failed to resolve; the broken-ref args
     // below then drive the render.
     target?: CardDef | FileDef;
+    // True while the caller is still resolving the target. Renders a
+    // size-matched loading placeholder (the card's footprint with a spinner)
+    // in the embed's slot until `target` or a broken-ref state arrives.
+    loading?: boolean;
     // Broken-ref render: when `brokenUrl` is present (and `target` is not),
     // render `BrokenLinkTemplate` instead of the embed. The same warning box +
     // reveal overlay the base `linksTo` broken UI shows, format-aware so the
@@ -327,6 +367,13 @@ export default class MarkdownEmbedPreview extends Component<Signature> {
               @kind={{this.kind}}
               @sizeStyle={{this.sizeStyle}}
             />
+          {{else if @loading}}
+            <Embed
+              @loading={{true}}
+              @format={{this.renderFormat}}
+              @kind={{this.kind}}
+              @sizeStyle={{this.sizeStyle}}
+            />
           {{else if @brokenUrl}}
             <BrokenEmbed
               @brokenUrl={{@brokenUrl}}
@@ -360,6 +407,14 @@ export default class MarkdownEmbedPreview extends Component<Signature> {
     {{else if @target}}
       <Embed
         @target={{@target}}
+        @format={{this.renderFormat}}
+        @kind={{this.kind}}
+        @sizeStyle={{this.sizeStyle}}
+        ...attributes
+      />
+    {{else if @loading}}
+      <Embed
+        @loading={{true}}
         @format={{this.renderFormat}}
         @kind={{this.kind}}
         @sizeStyle={{this.sizeStyle}}

--- a/packages/host/app/components/markdown-embed-chooser/tab-panel.gts
+++ b/packages/host/app/components/markdown-embed-chooser/tab-panel.gts
@@ -199,10 +199,18 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
   }
 
   // A pick is resolving: its URL is set but neither the instance nor an error
-  // has landed yet. Drives the loading indicator so a slow (cold) load reads as
-  // "loading", not as the "nothing selected" placeholder.
+  // has landed yet. Drives the loading placeholder so a slow (cold) load reads
+  // as "loading", not as the "nothing selected" placeholder.
   private get isLoading(): boolean {
     return this.loadTarget.isRunning;
+  }
+
+  // The pane mounts while a pick is loading, resolved, or errored — so the
+  // format/size controls and the size-matched preview stay put across the
+  // load (no jump to a bare spinner). The empty placeholder shows only before
+  // anything is picked.
+  private get showPane(): boolean {
+    return this.hasPreview || this.isLoading;
   }
 
   // Broken-ref state threaded to the pane. Each is undefined unless the load
@@ -343,9 +351,10 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
         {{/if}}
       </div>
       <div class='markdown-embed-chooser-tab-panel__right'>
-        {{#if this.hasPreview}}
+        {{#if this.showPane}}
           <MarkdownEmbedPreviewPane
             @target={{this.selectedTarget}}
+            @loading={{this.isLoading}}
             @refType={{@refType}}
             @selection={{@selection}}
             @documentBaseUrl={{@documentBaseUrl}}
@@ -357,13 +366,6 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
             @brokenItemType={{this.brokenItemType}}
             @errorDoc={{this.brokenErrorDoc}}
           />
-        {{else if this.isLoading}}
-          <div
-            class='markdown-embed-chooser-tab-panel__loading'
-            data-test-markdown-embed-preview-loading
-          >
-            <LoadingIndicator />
-          </div>
         {{else}}
           <p
             class='markdown-embed-chooser-tab-panel__empty'
@@ -440,15 +442,6 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
         font: var(--boxel-font-sm);
         color: var(--boxel-450);
         text-align: center;
-      }
-      /* Shown while a picked row's instance is still resolving, in place of the
-         empty placeholder, so a slow (cold) load doesn't read as "no selection". */
-      .markdown-embed-chooser-tab-panel__loading {
-        flex: 1 1 auto;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: var(--boxel-sp);
       }
       .markdown-embed-chooser-tab-panel__current {
         display: flex;

--- a/packages/host/app/components/markdown-embed-chooser/tab-panel.gts
+++ b/packages/host/app/components/markdown-embed-chooser/tab-panel.gts
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { restartableTask } from 'ember-concurrency';
+import { didCancel, restartableTask } from 'ember-concurrency';
 
 import { BoxelButton, LoadingIndicator } from '@cardstack/boxel-ui/components';
 import type {
@@ -158,25 +158,51 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
       this.selectedUrl = url;
       this.selectedTarget = undefined;
       this.selectedError = undefined;
-      let result =
-        refType === 'card'
-          ? await this.store.get(url)
-          : await this.store.get<FileDef>(url, { type: 'file-meta' });
-      if (isCardErrorJSONAPI(result)) {
-        // Keep `selectedUrl` and leave `selectedTarget` undefined; the pane
-        // renders the broken-ref visual from `selectedError` instead of the
-        // resolved embed.
-        this.selectedError = result;
-        return;
+      try {
+        let result =
+          refType === 'card'
+            ? await this.store.get(url)
+            : await this.store.get<FileDef>(url, { type: 'file-meta' });
+        if (isCardErrorJSONAPI(result)) {
+          // Keep `selectedUrl` and leave `selectedTarget` undefined; the pane
+          // renders the broken-ref visual from `selectedError` instead of the
+          // resolved embed.
+          this.selectedError = result;
+          return;
+        }
+        this.selectedTarget = result as CardDef | FileDef;
+      } catch (e) {
+        // A superseding pick cancels this run; let that bubble so the newer
+        // load owns the state. `store.get` resolves its own errors as
+        // `CardErrorJSONAPI` (handled above), so reaching here means an
+        // unexpected throw — surface it as a broken ref rather than leaving
+        // the pane spinning on its loading state forever.
+        if (didCancel(e)) {
+          throw e;
+        }
+        this.selectedError = {
+          id: url,
+          status: 500,
+          title: 'Failed to load',
+          message: e instanceof Error ? e.message : String(e),
+        } as CardErrorJSONAPI;
       }
-      this.selectedTarget = result as CardDef | FileDef;
     },
   );
 
   // The pane mounts once a row is picked and either resolves (selectedTarget)
-  // or fails (selectedError); the empty placeholder shows only before then.
+  // or fails (selectedError). Before then the right column shows the loading
+  // indicator while `isLoading`, falling back to the empty placeholder only
+  // when nothing is being resolved.
   private get hasPreview(): boolean {
     return !!this.selectedTarget || !!this.selectedError;
+  }
+
+  // A pick is resolving: its URL is set but neither the instance nor an error
+  // has landed yet. Drives the loading indicator so a slow (cold) load reads as
+  // "loading", not as the "nothing selected" placeholder.
+  private get isLoading(): boolean {
+    return this.loadTarget.isRunning;
   }
 
   // Broken-ref state threaded to the pane. Each is undefined unless the load
@@ -331,6 +357,13 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
             @brokenItemType={{this.brokenItemType}}
             @errorDoc={{this.brokenErrorDoc}}
           />
+        {{else if this.isLoading}}
+          <div
+            class='markdown-embed-chooser-tab-panel__loading'
+            data-test-markdown-embed-preview-loading
+          >
+            <LoadingIndicator />
+          </div>
         {{else}}
           <p
             class='markdown-embed-chooser-tab-panel__empty'
@@ -407,6 +440,15 @@ export default class MarkdownEmbedChooserTabPanel extends Component<Signature> {
         font: var(--boxel-font-sm);
         color: var(--boxel-450);
         text-align: center;
+      }
+      /* Shown while a picked row's instance is still resolving, in place of the
+         empty placeholder, so a slow (cold) load doesn't read as "no selection". */
+      .markdown-embed-chooser-tab-panel__loading {
+        flex: 1 1 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: var(--boxel-sp);
       }
       .markdown-embed-chooser-tab-panel__current {
         display: flex;

--- a/packages/host/tests/integration/components/markdown-embed-chooser-modal-test.gts
+++ b/packages/host/tests/integration/components/markdown-embed-chooser-modal-test.gts
@@ -3,6 +3,7 @@ import {
   click,
   fillIn,
   render,
+  settled,
   triggerEvent,
   triggerKeyEvent,
   waitFor,
@@ -572,6 +573,147 @@ module('Integration | markdown-embed-chooser-modal', function (hooks) {
       { refType: 'card', url: mango, bfm: `:card[${mango}]` },
       'resolves with the serialized BFM directive for the picked card',
     );
+  });
+
+  test('the preview pane shows a loading indicator (not the empty placeholder) while a picked card resolves', async function (assert) {
+    // Gate the store load for the picked card so the loading window is
+    // observable. Other loads (search, base realm) pass straight through.
+    let store = getService('store') as StoreService;
+    let origGet = store.get.bind(store);
+    let releaseLoad!: () => void;
+    let gate = new Promise<void>((resolve) => (releaseLoad = resolve));
+    store.get = ((id: string, opts?: unknown) => {
+      if (id === mango) {
+        return gate.then(() => origGet(id, opts as never));
+      }
+      return origGet(id, opts as never);
+    }) as typeof store.get;
+
+    await render(
+      <template>
+        <HostContextProvider>
+          <MarkdownEmbedChooserModal />
+        </HostContextProvider>
+      </template>,
+    );
+
+    let svc = getService(
+      'markdown-embed-chooser',
+    ) as MarkdownEmbedChooserService;
+    let pending = svc.chooseCardOrFile({ defaultTab: 'card' });
+    await waitFor('[data-test-markdown-embed-chooser-modal]');
+
+    await fillIn(
+      '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-search-field]',
+      'Mango',
+    );
+    await waitFor(
+      `[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-item-button="${mango}"]`,
+      { timeout: 5000 },
+    );
+
+    // Fire the click natively rather than via `click()` (which awaits
+    // settledness and would block on the gated load task) so we can assert the
+    // in-flight loading state.
+    (
+      document.querySelector(
+        `[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-item-button="${mango}"]`,
+      ) as HTMLElement
+    ).click();
+
+    await waitFor(
+      '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-preview-loading]',
+      { timeout: 5000 },
+    );
+    assert
+      .dom(
+        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-preview-loading]',
+      )
+      .exists(
+        'the preview pane shows a loading indicator while the pick loads',
+      );
+    assert
+      .dom(
+        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-preview-empty]',
+      )
+      .doesNotExist('the empty placeholder is suppressed during loading');
+
+    releaseLoad();
+    await settled();
+
+    assert
+      .dom(
+        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-preview]',
+      )
+      .exists('the resolved card renders its embed once the load completes');
+    assert
+      .dom(
+        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-preview-loading]',
+      )
+      .doesNotExist('the loading indicator clears once the preview is shown');
+
+    svc.resolve(undefined);
+    await pending;
+  });
+
+  test('a card load that throws shows the broken preview, not a stuck loading/empty state', async function (assert) {
+    let store = getService('store') as StoreService;
+    let origGet = store.get.bind(store);
+    store.get = ((id: string, opts?: unknown) => {
+      if (id === mango) {
+        return Promise.reject(new Error('boom'));
+      }
+      return origGet(id, opts as never);
+    }) as typeof store.get;
+
+    await render(
+      <template>
+        <HostContextProvider>
+          <MarkdownEmbedChooserModal />
+        </HostContextProvider>
+      </template>,
+    );
+
+    let svc = getService(
+      'markdown-embed-chooser',
+    ) as MarkdownEmbedChooserService;
+    let pending = svc.chooseCardOrFile({ defaultTab: 'card' });
+    await waitFor('[data-test-markdown-embed-chooser-modal]');
+
+    await fillIn(
+      '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-search-field]',
+      'Mango',
+    );
+    await waitFor(
+      `[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-item-button="${mango}"]`,
+      { timeout: 5000 },
+    );
+    await click(
+      `[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-item-button="${mango}"]`,
+    );
+
+    await waitFor(
+      '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-broken-link-template]',
+      { timeout: 5000 },
+    );
+    assert
+      .dom(
+        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-broken-link-template]',
+      )
+      .exists('a thrown load surfaces the broken-ref visual');
+    assert
+      .dom(
+        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-preview-empty]',
+      )
+      .doesNotExist('the empty placeholder is suppressed for a failed load');
+    assert
+      .dom(
+        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-preview-loading]',
+      )
+      .doesNotExist('the pane does not stay stuck on the loading indicator');
+
+    svc.resolve(undefined);
+    await pending;
   });
 
   test('a picked card serializes a document-relative ref when a base URL is supplied', async function (assert) {

--- a/packages/host/tests/integration/components/markdown-embed-chooser-modal-test.gts
+++ b/packages/host/tests/integration/components/markdown-embed-chooser-modal-test.gts
@@ -637,6 +637,18 @@ module('Integration | markdown-embed-chooser-modal', function (hooks) {
         '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-preview-empty]',
       )
       .doesNotExist('the empty placeholder is suppressed during loading');
+    assert
+      .dom(
+        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-preview-pane]',
+      )
+      .exists(
+        'the preview pane (with its format controls) stays mounted while loading',
+      );
+    assert
+      .dom(
+        '[data-test-markdown-embed-chooser-tab-panel="card"] [data-test-markdown-embed-preview]',
+      )
+      .doesNotExist('the resolved embed is not shown until the load completes');
 
     releaseLoad();
     await settled();


### PR DESCRIPTION
## Background and Goal

In the markdown embed chooser modal, the right **preview pane** showed the empty "Search for a card/file & preview its format here" placeholder *while a picked card/file was still resolving* — so a slow (cold) load read as "nothing selected" rather than "loading". Reported in [CS-12321](https://linear.app/cardstack/issue/CS-12321).

Now, while a pick resolves, the pane stays mounted (format selector + placement/size controls) and its embed slot shows a **size-matched card placeholder** — the resolved embed's footprint (fitted W×H, inline embedded/isolated footprint, or atom pill) with a small centered spinner — which swaps to the real embed once it loads. The placeholder reads the shared format/size selection live, so changing the format resizes it. The CTA is disabled until the instance (or an error) lands.

## Where to start

- `packages/host/app/components/markdown-embed-chooser/preview/index.gts` — the `Embed` primitive renders a spinner in place of the card body when `@loading`, reusing the existing `sizeStyle`/footprint logic so the placeholder matches the eventual embed. Tagged `data-test-markdown-embed-preview-loading` (and it omits the resolved `data-test-markdown-embed-preview` while loading).
- `packages/host/app/components/markdown-embed-chooser/pane.gts` — forwards `@loading` to the preview and holds the CTA disabled while loading.
- `packages/host/app/components/markdown-embed-chooser/tab-panel.gts` — renders the pane whenever a pick is loading, resolved, or errored (`hasPreview || isLoading`) so there's no jump to a bare spinner; the empty placeholder shows only before anything is picked. `loadTarget` is wrapped so a superseding pick's cancelation re-throws (newer load wins) while an unexpected rejection routes to the existing broken-ref visual instead of spinning forever.

## Tests

Two integration tests in `markdown-embed-chooser-modal-test.gts`:
- while a pick resolves, the pane stays mounted, the sized loading placeholder shows (not the empty placeholder), and the resolved embed appears only after the load completes;
- a load that throws surfaces the broken-ref visual rather than a stuck loading/empty state.

## Notes

Scope is the loading state only — **Replace** and **Remove** are unchanged from `main` (Remove keeps its existing remove-and-close behavior).

## Screen Recording

https://github.com/user-attachments/assets/7019666d-3fd2-4588-8ac2-a0fd35e12587



🤖 Generated with [Claude Code](https://claude.com/claude-code)