### PR TITLE
Render BFM embeds across the full format × placement matrix

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2913,6 +2913,14 @@ export class CSSField extends TextAreaField {
   };
 }
 
+// A plain markdown StringField. BFM embed directives (`:card[…]` / `:file[…]`)
+// in its content render as (correctly-sized) broken-link placeholders and do
+// NOT resolve: a StringField is a bare string with no `id` to resolve relative
+// refs against, no `linksToMany` storage to hold resolved instances, and no
+// query to populate them at index time. Resolution is an index-time
+// relationship concern — use `RichMarkdownField` (or a `.md` `MarkdownDef`
+// file), which own the `linkedCards`/`linkedFiles` relationships, when embeds
+// must render live.
 export class MarkdownField extends StringField {
   static displayName = 'Markdown';
   static icon = MarkdownIcon;

--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -55,8 +55,9 @@ interface CardWidgetTarget {
   kind: 'inline' | 'block';
   // 'card' refs resolve to CardDef instances; 'file' refs to FileDef instances.
   refType: 'card' | 'file';
-  // Inline sizing derived from the directive's size specifier (width/height plus
-  // `overflow: hidden` for fitted). Undefined for non-fitted formats.
+  // Inline sizing derived from the directive's format — fitted dimensions plus
+  // `overflow: hidden`, or the shared non-atom footprint from
+  // `bfmResolvedEmbedStyle`. Undefined for atom and block embedded.
   style?: string;
 }
 

--- a/packages/base/default-templates/markdown.gts
+++ b/packages/base/default-templates/markdown.gts
@@ -10,6 +10,7 @@ import LinkOffIcon from '@cardstack/boxel-icons/link-off';
 
 import {
   bfmRefFormatAndSize,
+  bfmResolvedEmbedStyle,
   buildWaiter,
   cardTypeName,
   fileNameFromUrl,
@@ -271,14 +272,14 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           let format: CardSlotFormat = derived.format;
           let sizeStyle: string | undefined = derived.sizeStyle;
 
-          // Fitted slots carry an inline width/height plus `overflow: hidden`
-          // so the resolved instance occupies the requested footprint.
-          let resolvedStyle: ReturnType<typeof htmlSafe> | undefined;
-          if (format === 'fitted') {
-            resolvedStyle = htmlSafe(
-              sizeStyle ? `${sizeStyle}; overflow: hidden` : 'overflow: hidden',
-            );
-          }
+          // Non-atom resolved slots carry a footprint so the instance occupies
+          // a definite box instead of collapsing (isolated/inline-embedded
+          // default templates lay out at 100%). Fitted uses its requested
+          // dimensions; embedded/isolated get shared defaults. Same helper as
+          // the other render surfaces so footprints stay in lockstep.
+          let resolvedStyleRaw = bfmResolvedEmbedStyle(format, kind, sizeStyle);
+          let resolvedStyle: ReturnType<typeof htmlSafe> | undefined =
+            resolvedStyleRaw ? htmlSafe(resolvedStyleRaw) : undefined;
 
           let resolvedUrl = resolveUrl(rawUrl, baseUrl);
 

--- a/packages/base/default-templates/markdown.gts
+++ b/packages/base/default-templates/markdown.gts
@@ -272,14 +272,18 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           let format: CardSlotFormat = derived.format;
           let sizeStyle: string | undefined = derived.sizeStyle;
 
-          // Non-atom resolved slots carry a footprint so the instance occupies
-          // a definite box instead of collapsing (isolated/inline-embedded
+          // Non-atom slots carry a footprint so the instance occupies a
+          // definite box instead of collapsing (isolated/inline-embedded
           // default templates lay out at 100%). Fitted uses its requested
-          // dimensions; embedded/isolated get shared defaults. Same helper as
-          // the other render surfaces so footprints stay in lockstep.
-          let resolvedStyleRaw = bfmResolvedEmbedStyle(format, kind, sizeStyle);
-          let resolvedStyle: ReturnType<typeof htmlSafe> | undefined =
-            resolvedStyleRaw ? htmlSafe(resolvedStyleRaw) : undefined;
+          // dimensions; embedded/isolated get shared defaults. The same style
+          // goes on the loading shimmer and broken-link box so the layout
+          // doesn't jump as the slot transitions between states, and the same
+          // helper drives the other render surfaces so footprints stay in
+          // lockstep.
+          let styleRaw = bfmResolvedEmbedStyle(format, kind, sizeStyle);
+          let style: ReturnType<typeof htmlSafe> | undefined = styleRaw
+            ? htmlSafe(styleRaw)
+            : undefined;
 
           let resolvedUrl = resolveUrl(rawUrl, baseUrl);
 
@@ -295,7 +299,7 @@ export default class MarkDownTemplate extends GlimmerComponent<{
               state: 'resolved',
               format,
               instance,
-              style: resolvedStyle,
+              style,
             });
             continue;
           }
@@ -304,7 +308,6 @@ export default class MarkDownTemplate extends GlimmerComponent<{
           // linked instances have settled (showFallback), then fall back to the
           // broken-link box. Skipping the broken state on the first modifier
           // run avoids flashing it for refs that will soon resolve.
-          let style = sizeStyle ? htmlSafe(sizeStyle) : undefined;
           if (!showFallback) {
             slots.push({
               element: el,
@@ -991,8 +994,9 @@ export default class MarkDownTemplate extends GlimmerComponent<{
 
         /* Placeholder footprint shared by loading + broken states. The
            default block sizes approximate the eventual card so the layout does
-           not jump when the card resolves; explicit fitted dimensions arrive
-           as an inline style that overrides these. */
+           not jump when the card resolves; the slot's shared inline footprint
+           (fitted dimensions, inline embedded/isolated defaults, block
+           isolated min-height) overrides these when present. */
         .markdown-bfm-loading--embedded,
         .markdown-bfm-broken--embedded {
           width: 100%;

--- a/packages/host/app/components/markdown-embed-chooser/preview/index.gts
+++ b/packages/host/app/components/markdown-embed-chooser/preview/index.gts
@@ -13,6 +13,7 @@ import { eq, not } from '@cardstack/boxel-ui/helpers';
 
 import {
   bfmRefFormatAndSize,
+  bfmResolvedEmbedStyle,
   type BfmSizeSpec,
 } from '@cardstack/runtime-common/bfm-card-references';
 
@@ -266,38 +267,25 @@ export default class MarkdownEmbedPreview extends Component<Signature> {
     return sizeStyle ? htmlSafe(sizeStyle) : undefined;
   }
 
-  // Fitted slots carry an inline width/height plus `overflow: hidden` so the
-  // instance occupies the requested footprint — derived through the same helper
-  // the live markdown renderer uses (`rendered-markdown.gts`). Inline embedded
-  // and isolated have no intrinsic inline width: the default template's
-  // `width/height: 100%` resolves against the inline-block wrapper, which is
-  // itself shrink-wrapping, and the box collapses. Give the wrapper a definite
-  // footprint that matches the live renderer's loading placeholders so the
-  // preview shows a real card body.
+  // Resolved-embed footprint, shared with the live markdown render surfaces
+  // (saved `MarkdownTemplate`, host preview panel, CodeMirror editor) through
+  // `bfmResolvedEmbedStyle`. Isolated and inline embedded have no intrinsic
+  // inline width — their default `width/height: 100%` resolves against a
+  // shrink-wrapping wrapper and the box collapses — so the helper hands back a
+  // definite footprint that matches the live renderers' loading placeholders.
   private get sizeStyle(): ReturnType<typeof htmlSafe> | undefined {
     let { format } = this.args;
+    let fittedSizeStyle: string | undefined;
     if (format === 'fitted') {
       let { width, height } = this.args.sizeSpec ?? { format: 'fitted' };
-      let { sizeStyle } = bfmRefFormatAndSize(
+      fittedSizeStyle = bfmRefFormatAndSize(
         'fitted',
         width === undefined ? undefined : String(width),
         height === undefined ? undefined : String(height),
-      );
-      return htmlSafe(
-        sizeStyle ? `${sizeStyle}; overflow: hidden` : 'overflow: hidden',
-      );
+      ).sizeStyle;
     }
-    if (
-      this.kind === 'inline' &&
-      (format === 'embedded' || format === 'isolated')
-    ) {
-      let footprint =
-        format === 'isolated'
-          ? 'width: 24rem; height: 18.75rem'
-          : 'width: 16rem; height: 9.375rem';
-      return htmlSafe(`${footprint}; overflow: hidden`);
-    }
-    return undefined;
+    let style = bfmResolvedEmbedStyle(format, this.kind, fittedSizeStyle);
+    return style ? htmlSafe(style) : undefined;
   }
 
   <template>

--- a/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
+++ b/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
@@ -23,6 +23,7 @@ import { eq } from '@cardstack/boxel-ui/helpers';
 
 import {
   bfmRefFormatAndSize,
+  bfmResolvedEmbedStyle,
   CardContextName,
   cardTypeName,
   extractCardReferenceUrls,
@@ -271,14 +272,14 @@ export default class RenderedMarkdown extends Component<Signature> {
           let format: CardSlotFormat = derived.format;
           let sizeStyle: string | undefined = derived.sizeStyle;
 
-          // Fitted slots carry an inline width/height plus `overflow: hidden`
-          // so the resolved instance occupies the requested footprint.
-          let resolvedStyle: ReturnType<typeof htmlSafe> | undefined;
-          if (format === 'fitted') {
-            resolvedStyle = htmlSafe(
-              sizeStyle ? `${sizeStyle}; overflow: hidden` : 'overflow: hidden',
-            );
-          }
+          // Non-atom resolved slots carry a footprint so the instance occupies
+          // a definite box instead of collapsing (isolated/inline-embedded
+          // default templates lay out at 100%). Fitted uses its requested
+          // dimensions; embedded/isolated get shared defaults. Same helper as
+          // the other render surfaces so footprints stay in lockstep.
+          let resolvedStyleRaw = bfmResolvedEmbedStyle(format, kind, sizeStyle);
+          let resolvedStyle: ReturnType<typeof htmlSafe> | undefined =
+            resolvedStyleRaw ? htmlSafe(resolvedStyleRaw) : undefined;
 
           let resolvedUrl = resolveUrl(rawUrl, baseUrl);
 

--- a/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
+++ b/packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts
@@ -272,14 +272,18 @@ export default class RenderedMarkdown extends Component<Signature> {
           let format: CardSlotFormat = derived.format;
           let sizeStyle: string | undefined = derived.sizeStyle;
 
-          // Non-atom resolved slots carry a footprint so the instance occupies
-          // a definite box instead of collapsing (isolated/inline-embedded
+          // Non-atom slots carry a footprint so the instance occupies a
+          // definite box instead of collapsing (isolated/inline-embedded
           // default templates lay out at 100%). Fitted uses its requested
-          // dimensions; embedded/isolated get shared defaults. Same helper as
-          // the other render surfaces so footprints stay in lockstep.
-          let resolvedStyleRaw = bfmResolvedEmbedStyle(format, kind, sizeStyle);
-          let resolvedStyle: ReturnType<typeof htmlSafe> | undefined =
-            resolvedStyleRaw ? htmlSafe(resolvedStyleRaw) : undefined;
+          // dimensions; embedded/isolated get shared defaults. The same style
+          // goes on the loading shimmer and broken-link box so the layout
+          // doesn't jump as the slot transitions between states, and the same
+          // helper drives the other render surfaces so footprints stay in
+          // lockstep.
+          let styleRaw = bfmResolvedEmbedStyle(format, kind, sizeStyle);
+          let style: ReturnType<typeof htmlSafe> | undefined = styleRaw
+            ? htmlSafe(styleRaw)
+            : undefined;
 
           let resolvedUrl = resolveUrl(rawUrl, baseUrl);
 
@@ -293,7 +297,7 @@ export default class RenderedMarkdown extends Component<Signature> {
                 state: 'resolved',
                 format,
                 file,
-                style: resolvedStyle,
+                style,
               });
               continue;
             }
@@ -307,7 +311,7 @@ export default class RenderedMarkdown extends Component<Signature> {
                 state: 'resolved',
                 format,
                 card,
-                style: resolvedStyle,
+                style,
               });
               continue;
             }
@@ -315,7 +319,6 @@ export default class RenderedMarkdown extends Component<Signature> {
 
           // No matching instance yet: show the sized loading shimmer until the
           // load settles (showFallback), then fall back to the broken-link box.
-          let style = sizeStyle ? htmlSafe(sizeStyle) : undefined;
           if (!showFallback) {
             slots.push({
               element: el,
@@ -874,8 +877,9 @@ export default class RenderedMarkdown extends Component<Signature> {
 
         /* Placeholder footprint shared by loading + broken states. The
            default block sizes approximate the eventual card so the layout does
-           not jump when the card resolves; explicit fitted dimensions arrive
-           as an inline style that overrides these. */
+           not jump when the card resolves; the slot's shared inline footprint
+           (fitted dimensions, inline embedded/isolated defaults, block
+           isolated min-height) overrides these when present. */
         .markdown-bfm-loading--embedded,
         .markdown-bfm-broken--embedded {
           width: 100%;

--- a/packages/host/app/lib/codemirror-context.ts
+++ b/packages/host/app/lib/codemirror-context.ts
@@ -48,6 +48,7 @@ import {
   type BfmRefFormat,
   type BfmRefRange,
   bfmRefFormatAndSize,
+  bfmResolvedEmbedStyle,
   extractBfmRefRanges,
   parseBfmSizeSpec,
 } from '@cardstack/runtime-common/bfm-card-references';
@@ -941,14 +942,10 @@ function createCardTargetNotifier(
                 el.getAttribute('data-boxel-bfm-height') ?? undefined,
                 kind === 'inline' ? 'atom' : 'embedded',
               );
-              // Fitted slots carry the width/height plus `overflow: hidden` so
-              // the resolved instance occupies the requested footprint.
-              let style =
-                format === 'fitted'
-                  ? sizeStyle
-                    ? `${sizeStyle}; overflow: hidden`
-                    : 'overflow: hidden'
-                  : undefined;
+              // Non-atom slots carry a footprint so the resolved instance
+              // occupies a definite box instead of collapsing. Same helper as
+              // the saved/preview renderers so footprints stay in lockstep.
+              let style = bfmResolvedEmbedStyle(format, kind, sizeStyle);
               targets.push({
                 element: el as HTMLElement,
                 cardId,

--- a/packages/host/app/lib/codemirror-context.ts
+++ b/packages/host/app/lib/codemirror-context.ts
@@ -63,9 +63,10 @@ export interface CardWidgetTarget {
   // 'card' refs (`:card[URL]`) resolve to CardDef instances; 'file' refs
   // (`:file[URL]`) resolve to FileDef instances.
   refType: 'card' | 'file';
-  // Inline sizing (`width`/`height`, plus `overflow: hidden` for fitted) derived
-  // from the directive's size specifier. Undefined for non-fitted formats.
-  // Mirrors the style the saved/preview markdown renderers apply.
+  // Inline sizing derived from the directive's format — fitted dimensions plus
+  // `overflow: hidden`, or the shared non-atom footprint from
+  // `bfmResolvedEmbedStyle`. Undefined for atom and block embedded. Mirrors
+  // the style the saved/preview markdown renderers apply.
   style?: string;
 }
 

--- a/packages/host/tests/acceptance/markdown-file-def-test.gts
+++ b/packages/host/tests/acceptance/markdown-file-def-test.gts
@@ -324,6 +324,29 @@ module('Acceptance | markdown BFM card references', function (hooks) {
             '',
             '::file[https://nonexistent.example/gone.pdf]',
           ].join('\n'),
+          // A plain markdown target embedded across the full format matrix.
+          // MarkdownDef defines atom/embedded/fitted/isolated, so each combo
+          // renders a distinct `data-test-markdown-*` hook.
+          'documents/target.md': ['# Target Doc', '', 'Body text.'].join('\n'),
+          'bfm-file-matrix.md': [
+            '# BFM File Matrix',
+            '',
+            `:file[${testRealmURL}documents/target.md | atom]`,
+            '',
+            `:file[${testRealmURL}documents/target.md | embedded]`,
+            '',
+            `:file[${testRealmURL}documents/target.md | fitted w:200 h:150]`,
+            '',
+            `:file[${testRealmURL}documents/target.md | isolated]`,
+            '',
+            `::file[${testRealmURL}documents/target.md | atom]`,
+            '',
+            `::file[${testRealmURL}documents/target.md | embedded]`,
+            '',
+            `::file[${testRealmURL}documents/target.md | fitted w:200 h:150]`,
+            '',
+            `::file[${testRealmURL}documents/target.md | isolated]`,
+          ].join('\n'),
           'mermaid-test.md': [
             '# Mermaid Test',
             '',
@@ -470,6 +493,35 @@ module('Acceptance | markdown BFM card references', function (hooks) {
         `${testRealmURL}documents/notes.txt`,
         'inline fallback path is hidden after the file resolves',
       );
+  });
+
+  test('every file format renders in both inline and block placement', async function (assert) {
+    // CS-12320: the file half of the resolved-render matrix. Each format ×
+    // placement must render the referenced markdown file in the requested
+    // format — isolated must not collapse.
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}bfm-file-matrix.md`,
+    });
+    await settled();
+
+    for (let [placement, wrapper] of [
+      ['inline', '[data-test-markdown-bfm-inline-file]'],
+      ['block', '[data-test-markdown-bfm-block-file]'],
+    ] as const) {
+      for (let format of ['atom', 'embedded', 'fitted', 'isolated'] as const) {
+        assert
+          .dom(`${wrapper} [data-test-markdown-${format}]`)
+          .exists(`${format} file renders in ${placement} placement`);
+      }
+    }
+
+    assert
+      .dom('[data-test-markdown-bfm-unresolved-inline]')
+      .doesNotExist('no unresolved inline file placeholders remain');
+    assert
+      .dom('[data-test-markdown-bfm-unresolved-block]')
+      .doesNotExist('no unresolved block file placeholders remain');
   });
 
   test('shows fallback for unresolvable file references', async function (assert) {

--- a/packages/host/tests/acceptance/markdown-file-def-test.gts
+++ b/packages/host/tests/acceptance/markdown-file-def-test.gts
@@ -516,6 +516,28 @@ module('Acceptance | markdown BFM card references', function (hooks) {
       }
     }
 
+    // A rendered template alone doesn't prove the slot is visible — the
+    // collapse bug left the instance in the DOM at zero size. Pin the
+    // footprint on the slot the collapse hit hardest.
+    assert
+      .dom(
+        '[data-test-markdown-bfm-block-file]:has([data-test-markdown-isolated])',
+      )
+      .hasAttribute(
+        'style',
+        /min-height: 18\.75rem/,
+        'block isolated file slot carries a growable min-height',
+      );
+    assert
+      .dom(
+        '[data-test-markdown-bfm-inline-file]:has([data-test-markdown-isolated])',
+      )
+      .hasAttribute(
+        'style',
+        /width: 24rem/,
+        'inline isolated file slot carries the shared footprint',
+      );
+
     assert
       .dom('[data-test-markdown-bfm-unresolved-inline]')
       .doesNotExist('no unresolved inline file placeholders remain');

--- a/packages/host/tests/integration/components/codemirror-editor-test.gts
+++ b/packages/host/tests/integration/components/codemirror-editor-test.gts
@@ -515,14 +515,45 @@ module('Integration | codemirror-context', function (hooks) {
     }
   });
 
-  test('block isolated embed threads isolated format with no size style', async function (assert) {
+  test('block isolated embed threads isolated format with a growable footprint', async function (assert) {
     let { targets, destroy } = await collectTargets(
       '::card[https://example.com/cards/1 | isolated]',
     );
     try {
       let target = targets.find((t) => t.kind === 'block');
       assert.strictEqual(target?.format, 'isolated', 'format is isolated');
-      assert.notOk(target?.style, 'isolated embed has no inline size style');
+      // CS-12320: block isolated gets a growable min-height so it does not
+      // collapse (its default template lays out at height: 100%).
+      assert.strictEqual(
+        target?.style,
+        'min-height: 18.75rem',
+        'isolated embed carries a growable min-height footprint',
+      );
+    } finally {
+      destroy();
+    }
+  });
+
+  test('inline isolated / embedded embeds carry a definite footprint', async function (assert) {
+    // CS-12320: inline isolated/embedded collapse without a definite width +
+    // height (the default template lays out at 100% inside a shrink-wrapping
+    // inline-block wrapper).
+    let { targets, destroy } = await collectTargets(
+      ':card[https://example.com/cards/1 | isolated] and :card[https://example.com/cards/2 | embedded]',
+    );
+    try {
+      let isolated = targets.find((t) => t.format === 'isolated');
+      assert.strictEqual(
+        isolated?.style,
+        'width: 24rem; height: 18.75rem; overflow: hidden',
+        'inline isolated carries the shared footprint',
+      );
+      let embedded = targets.find((t) => t.format === 'embedded');
+      assert.strictEqual(
+        embedded?.style,
+        'width: 16rem; height: 9.375rem; overflow: hidden',
+        'inline embedded carries the shared footprint',
+      );
     } finally {
       destroy();
     }
@@ -573,7 +604,12 @@ module('Integration | codemirror-context', function (hooks) {
         (t) => t.refType === 'file' && t.format === 'isolated',
       );
       assert.ok(isolated, 'isolated file target is present');
-      assert.notOk(isolated?.style, 'isolated file target has no size style');
+      // CS-12320: block isolated gets a growable min-height footprint.
+      assert.strictEqual(
+        isolated?.style,
+        'min-height: 18.75rem',
+        'isolated file target carries a growable min-height footprint',
+      );
     } finally {
       destroy();
     }

--- a/packages/host/tests/integration/components/rich-markdown-field-test.gts
+++ b/packages/host/tests/integration/components/rich-markdown-field-test.gts
@@ -502,6 +502,133 @@ module('Integration | RichMarkdownField', function (hooks) {
       .doesNotExist('no unresolved Pill remains after card resolves (block)');
   });
 
+  test('every card format renders in both inline and block placement (saved MarkdownTemplate path)', async function (assert) {
+    // CS-12320: the resolved-render matrix. Each format × placement must render
+    // the referenced card in the requested format — not collapse (isolated) or
+    // fall back. Exercises the saved MarkdownTemplate render path (not the
+    // CodeMirror compose preview).
+    class Pet extends CardDef {
+      static displayName = 'Pet';
+      @field name = contains(StringField);
+      @field cardTitle = contains(StringField, {
+        computeVia: function (this: Pet) {
+          return this.name;
+        },
+      });
+      static atom = class Atom extends Component<typeof this> {
+        <template>
+          <span data-test-pet-atom>{{@model.name}}</span>
+        </template>
+      };
+      static embedded = class Embedded extends Component<typeof this> {
+        <template>
+          <div data-test-pet-embedded>{{@model.name}}</div>
+        </template>
+      };
+      static fitted = class Fitted extends Component<typeof this> {
+        <template>
+          <div data-test-pet-fitted>{{@model.name}}</div>
+        </template>
+      };
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <div data-test-pet-isolated>{{@model.name}}</div>
+        </template>
+      };
+    }
+
+    class ArticleCard extends CardDef {
+      @field body = contains(RichMarkdownField);
+      static isolated = class Isolated extends Component<typeof this> {
+        <template><@fields.body /></template>
+      };
+    }
+
+    let url = `${testRealmURL}Pet/mango`;
+    let content = [
+      `:card[${url} | atom]`,
+      `:card[${url} | embedded]`,
+      `:card[${url} | fitted w:200 h:150]`,
+      `:card[${url} | isolated]`,
+      `::card[${url} | atom]`,
+      `::card[${url} | embedded]`,
+      `::card[${url} | fitted w:200 h:150]`,
+      `::card[${url} | isolated]`,
+    ].join('\n\n');
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'pet.gts': { Pet },
+        'article.gts': { ArticleCard },
+        'Pet/mango.json': {
+          data: {
+            attributes: { name: 'Mango', cardTitle: 'Mango' },
+            meta: { adoptsFrom: { module: '../pet', name: 'Pet' } },
+          },
+        },
+        'article-1.json': {
+          data: {
+            attributes: { body: { content } },
+            meta: { adoptsFrom: { module: './article', name: 'ArticleCard' } },
+          },
+        },
+      },
+    });
+
+    let store = getService('store');
+    let article = (await store.get(`${testRealmURL}article-1`)) as BaseDef;
+    await store.loaded();
+
+    await renderCard(loader, article, 'isolated');
+    await waitFor('[data-test-pet-isolated]', { timeout: 10_000 });
+
+    let inline = '[data-test-markdown-bfm-inline-card]';
+    let block = '[data-test-markdown-bfm-block-card]';
+    for (let [placement, wrapper] of [
+      ['inline', inline],
+      ['block', block],
+    ] as const) {
+      for (let format of ['atom', 'embedded', 'fitted', 'isolated'] as const) {
+        assert
+          .dom(`${wrapper} [data-test-pet-${format}]`)
+          .exists(`${format} card renders in ${placement} placement`);
+      }
+    }
+
+    // The bug this ticket fixes: isolated (and inline embedded) collapse
+    // without a definite footprint. Spot-check that the shared footprint
+    // reached the resolved slot.
+    assert
+      .dom(`${inline}:has([data-test-pet-isolated])`)
+      .hasAttribute(
+        'style',
+        /width: 24rem/,
+        'inline isolated slot carries the shared footprint',
+      );
+    assert
+      .dom(`${block}:has([data-test-pet-isolated])`)
+      .hasAttribute(
+        'style',
+        /min-height: 18\.75rem/,
+        'block isolated slot carries a growable min-height',
+      );
+    assert
+      .dom(`${inline}:has([data-test-pet-embedded])`)
+      .hasAttribute(
+        'style',
+        /width: 16rem/,
+        'inline embedded slot carries the shared footprint',
+      );
+
+    assert
+      .dom('[data-test-markdown-bfm-unresolved-inline]')
+      .doesNotExist('no unresolved inline placeholders remain');
+    assert
+      .dom('[data-test-markdown-bfm-unresolved-block]')
+      .doesNotExist('no unresolved block placeholders remain');
+  });
+
   test('compose preview resolves a relative card ref against a prefix-form base', async function (assert) {
     // Regression guard for the compose/edit path: when the realm is
     // prefix-mapped the editor's reference base is a prefix-form RRI, and a

--- a/packages/host/tests/unit/bfm-card-references-test.ts
+++ b/packages/host/tests/unit/bfm-card-references-test.ts
@@ -8,6 +8,7 @@ import {
   extractBfmReferences,
   extractBfmRefRanges,
   bfmRefFormatAndSize,
+  bfmResolvedEmbedStyle,
   bfmCardReferenceExtensions,
   bfmExtensionsForKeyword,
   parseBfmSizeSpec,
@@ -1044,6 +1045,60 @@ module('Unit | bfm-card-references', function () {
         format: 'fitted',
         sizeStyle: 'width: 400px',
       });
+    });
+  });
+
+  module('bfmResolvedEmbedStyle', function () {
+    test('atom has no footprint in either placement', function (assert) {
+      assert.strictEqual(bfmResolvedEmbedStyle('atom', 'inline'), undefined);
+      assert.strictEqual(bfmResolvedEmbedStyle('atom', 'block'), undefined);
+    });
+
+    test('inline embedded gets a definite footprint so it does not collapse', function (assert) {
+      assert.strictEqual(
+        bfmResolvedEmbedStyle('embedded', 'inline'),
+        'width: 16rem; height: 9.375rem; overflow: hidden',
+      );
+    });
+
+    test('block embedded flows naturally (no footprint)', function (assert) {
+      assert.strictEqual(bfmResolvedEmbedStyle('embedded', 'block'), undefined);
+    });
+
+    test('inline isolated gets a definite footprint so it does not collapse', function (assert) {
+      assert.strictEqual(
+        bfmResolvedEmbedStyle('isolated', 'inline'),
+        'width: 24rem; height: 18.75rem; overflow: hidden',
+      );
+    });
+
+    test('block isolated gets a growable min-height so it does not collapse', function (assert) {
+      assert.strictEqual(
+        bfmResolvedEmbedStyle('isolated', 'block'),
+        'min-height: 18.75rem',
+      );
+    });
+
+    test('fitted with dimensions carries them plus overflow clipping', function (assert) {
+      assert.strictEqual(
+        bfmResolvedEmbedStyle('fitted', 'block', 'width: 400px; height: 300px'),
+        'width: 400px; height: 300px; overflow: hidden',
+      );
+      assert.strictEqual(
+        bfmResolvedEmbedStyle(
+          'fitted',
+          'inline',
+          'width: 400px; height: 300px',
+        ),
+        'width: 400px; height: 300px; overflow: hidden',
+      );
+    });
+
+    test('fitted without dimensions still clips overflow', function (assert) {
+      assert.strictEqual(
+        bfmResolvedEmbedStyle('fitted', 'block'),
+        'overflow: hidden',
+      );
     });
   });
 

--- a/packages/runtime-common/bfm-card-references.ts
+++ b/packages/runtime-common/bfm-card-references.ts
@@ -238,6 +238,55 @@ export function bfmRefFormatAndSize(
 }
 
 /**
+ * Inline style for a *resolved* BFM embed slot so `isolated` / `embedded` /
+ * `fitted` occupy a definite footprint instead of collapsing to zero.
+ *
+ * The default `isolated` and (inline) `embedded` card/file templates lay out
+ * with `width`/`height: 100%`, which resolves against a shrink-wrapping
+ * inline-block — or an unbounded block — and collapses. Every render surface
+ * (the saved `MarkdownTemplate`, the host preview panel, the CodeMirror source
+ * editor, and the embed chooser preview) shares this helper so a resolved
+ * embed occupies the same footprint everywhere, matching the loading/broken
+ * placeholders.
+ *
+ * `fittedSizeStyle` is the `width`/`height` string that `bfmRefFormatAndSize`
+ * derives for a fitted spec; it is ignored for the other formats.
+ *
+ * Footprints:
+ *  - `atom`                 — none (intrinsic pill).
+ *  - `fitted`               — the requested dimensions + `overflow: hidden`.
+ *  - inline `embedded`      — 16rem × 9.375rem (matches `--embedded` placeholder height).
+ *  - inline `isolated`      — 24rem × 18.75rem (matches `--isolated` placeholder height).
+ *  - block `embedded`       — none (flows naturally at full width).
+ *  - block `isolated`       — `min-height: 18.75rem`, growable (matches `--isolated` placeholder).
+ */
+export function bfmResolvedEmbedStyle(
+  format: BfmRefFormat,
+  kind: 'inline' | 'block',
+  fittedSizeStyle?: string,
+): string | undefined {
+  if (format === 'fitted') {
+    return fittedSizeStyle
+      ? `${fittedSizeStyle}; overflow: hidden`
+      : 'overflow: hidden';
+  }
+  if (kind === 'inline') {
+    if (format === 'embedded') {
+      return 'width: 16rem; height: 9.375rem; overflow: hidden';
+    }
+    if (format === 'isolated') {
+      return 'width: 24rem; height: 18.75rem; overflow: hidden';
+    }
+    return undefined; // inline atom
+  }
+  // block placement
+  if (format === 'isolated') {
+    return 'min-height: 18.75rem';
+  }
+  return undefined; // block atom / block embedded flow naturally
+}
+
+/**
  * Builds the `data-boxel-bfm-format` / `-width` / `-height` attribute string
  * for a BFM size specifier (the part after `|`). Returns `''` when there is no
  * specifier or it doesn't parse. Shared by the inline and block renderers so

--- a/packages/runtime-common/bfm-card-references.ts
+++ b/packages/runtime-common/bfm-card-references.ts
@@ -238,16 +238,17 @@ export function bfmRefFormatAndSize(
 }
 
 /**
- * Inline style for a *resolved* BFM embed slot so `isolated` / `embedded` /
- * `fitted` occupy a definite footprint instead of collapsing to zero.
+ * Inline style for a BFM embed slot so `isolated` / `embedded` / `fitted`
+ * occupy a definite footprint instead of collapsing to zero. Applied to the
+ * resolved instance and to its loading-shimmer / broken-link placeholders
+ * alike, so the layout doesn't jump as a slot transitions between states.
  *
  * The default `isolated` and (inline) `embedded` card/file templates lay out
  * with `width`/`height: 100%`, which resolves against a shrink-wrapping
  * inline-block — or an unbounded block — and collapses. Every render surface
  * (the saved `MarkdownTemplate`, the host preview panel, the CodeMirror source
- * editor, and the embed chooser preview) shares this helper so a resolved
- * embed occupies the same footprint everywhere, matching the loading/broken
- * placeholders.
+ * editor, and the embed chooser preview) shares this helper so an embed
+ * occupies the same footprint everywhere.
  *
  * `fittedSizeStyle` is the `width`/`height` string that `bfmRefFormatAndSize`
  * derives for a fitted spec; it is ignored for the other formats.


### PR DESCRIPTION
## Summary

Embedding a card or file in a markdown field only rendered correctly for the **default** format+placement combos. Notably `isolated` displayed **nothing** in either placement, inline `embedded` collapsed, and several other combos were unverified.

Root cause: across every render surface, a resolved embed slot was only given a sizing style when `format === 'fitted'`. The `isolated` and inline `embedded` default templates lay out at `width/height: 100%`, which resolves against a shrink-wrapping inline-block (or an unbounded block) and collapses to zero — the instance was in the DOM but invisible.

## Change

- **New shared helper** `bfmResolvedEmbedStyle(format, kind, fittedSizeStyle)` in `packages/runtime-common/bfm-card-references.ts` hands every non-atom embed slot a definite footprint — the resolved instance, the loading shimmer, and the broken-link box all take the same style, so the layout doesn't jump as a slot transitions between states:
  - inline `embedded` → `16rem × 9.375rem`
  - inline `isolated` → `24rem × 18.75rem`
  - block `isolated` → growable `min-height: 18.75rem`
  - `fitted` → its requested dimensions + `overflow: hidden`
- **Applied in all four render surfaces** so footprints stay in lockstep, and the embed-chooser preview (which previously carried its own copy of this logic) now delegates to the helper — no duplicated code:
  - `packages/base/default-templates/markdown.gts` (saved / isolated / embedded-nested)
  - `packages/host/app/components/operator-mode/preview-panel/rendered-markdown.gts` (preview panel)
  - `packages/host/app/lib/codemirror-context.ts` (CodeMirror source editor)
  - `packages/host/app/components/markdown-embed-chooser/preview/index.gts` (chooser preview)
- **`CardWidgetTarget.style` docs** (host `codemirror-context.ts` and the duplicate interface in `packages/base/codemirror-editor.gts`) describe the new contract: fitted dimensions plus `overflow: hidden`, or the shared non-atom footprint; undefined only for atom and block embedded.
- **Plain `MarkdownField`** (a `StringField`) has no relationship to resolve embeds, so its directives stay unresolved by design — documented at the class.

## Matrix now covered

For **card** and **file**, each of `atom` / `embedded` / `fitted` / `isolated`, in both **inline** and **block** placement (16 combinations).

## Tests

- Unit test for `bfmResolvedEmbedStyle`.
- Full card matrix on the saved `MarkdownTemplate` render path + isolated/embedded footprint assertions (`rich-markdown-field-test.gts`).
- Full file matrix in code-mode preview, including block-isolated `min-height` and inline-isolated `width` footprint pins so the file path guards the collapse fix independently (`markdown-file-def-test.gts`).
- Updated/added CodeMirror-editor footprint assertions (`codemirror-editor-test.gts`).

## Verification

`ember-tsc` (glint) + eslint clean on all changed files. Affected suites run locally against the dev stack: `Integration | rendered-markdown` 27/27, `Integration | RichMarkdownField` 28/28, `Acceptance | markdown BFM card references` 11/11, `Integration | codemirror-context` 52/52. Verified live in the dev stack against `experiments/bfm-showcase.md`: block `isolated` renders the full Author card (name/title/quote/portrait) instead of nothing; inline atom, block embedded, all fitted variants (strip / double-wide-strip / tile / compact-card), and file embeds (inline atom + block embedded image) all render correctly, and inline embedded/isolated placeholders occupy the same width as the card they resolve into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
