### PR TITLE
Switch: reset -webkit-appearance for iOS + size-agnostic pill radius (CS-12328)

### DIFF
--- a/packages/boxel-ui/addon/src/components/switch/index.gts
+++ b/packages/boxel-ui/addon/src/components/switch/index.gts
@@ -47,7 +47,10 @@ export default class Switch extends Component<SwitchSiganture> {
 
           width: var(--boxel-switch-width, 2.125rem);
           height: var(--boxel-switch-height, 1.25rem);
-          border-radius: 1.25rem;
+          /* full pill regardless of rendered size: a fixed radius tuned to
+             the natural height squares off when a consumer sizes the switch
+             taller */
+          border-radius: 999px;
           padding: 1px;
           display: inline-flex;
           align-items: center;
@@ -60,6 +63,9 @@ export default class Switch extends Component<SwitchSiganture> {
         }
 
         input[type='checkbox'] {
+          /* -webkit- prefix is required for iOS Safari, which otherwise
+             keeps the native checkbox and ignores our thumb styling */
+          -webkit-appearance: none;
           appearance: none;
         }
 


### PR DESCRIPTION
## What

Two cross-browser / robustness fixes to the boxel-ui `Switch` (`packages/boxel-ui/addon/src/components/switch/index.gts`):

1. **iOS Safari native control leak.** The thumb `<input type="checkbox">` was reset with unprefixed `appearance: none` only. iOS Safari keeps rendering the *native* checkbox unless `-webkit-appearance: none` is also set, so on iOS the thumb ignored `background` / `box-shadow` / `border-radius` and rendered as a squared native control. Added `-webkit-appearance: none` alongside `appearance: none`.

2. **Track radius tied to natural size.** The track used a fixed `border-radius: 1.25rem` tuned to the default height, so consumers that size the Switch taller (e.g. the homepage mode toggle) got a non-pill track. Switched to `border-radius: 999px` — renders identically at the natural size and stays a full pill at any size.

## Why

Surfaced by the homepage mode-toggle bug (CS-12311): the toggle looked squared only on real iOS Safari, never in desktop responsive view — the tell-tale sign of a native-control-appearance leak rather than a radius-math problem. Affects **every** `Switch` instance on iOS, not just the homepage toggle.

## Follow-up

cardstack/boxel-home carries a temporary consumer-side override for this in `boxel-ai-website/components/site-navbar.gts` (PR #68). Once this lands and boxel-ui is bumped there, that override should be removed (tracked in CS-12328).

## Testing

- [ ] Verify the switch renders as a rounded pill with a circular thumb on real iOS Safari.
- [ ] Verify no visual change at the natural size in Chrome/Firefox/desktop Safari.

Fixes CS-12328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)