### PR TITLE
Fix flaky persist-scroll-position gesture test

### DIFF
--- a/packages/host/tests/integration/modifiers/persist-scroll-position-test.gts
+++ b/packages/host/tests/integration/modifiers/persist-scroll-position-test.gts
@@ -128,6 +128,15 @@ module('Integration | modifier | persist-scroll-position', function (hooks) {
     await triggerEvent(scroller, 'scroll');
     assert.deepEqual(recorded, [], 'a gesture-less scroll is ignored');
 
+    // A programmatic `scrollTop` assignment fires its `scroll` event on the
+    // next rendering, not synchronously, and `settled()` does not await that
+    // frame. Drain it here — while there is still no gesture, so the modifier
+    // ignores it — otherwise it can land during the wheel below, after the
+    // gesture has flipped the modifier into recording mode, and be recorded as
+    // a spurious user offset (90).
+    // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- must await the browser's post-assignment scroll frame
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
     // After a real gesture, the user's scrolling is recorded. (A single move
     // can emit more than one `scroll` — the native one plus the synthetic test
     // event — so assert the value rather than the call count.)
@@ -138,7 +147,9 @@ module('Integration | modifier | persist-scroll-position', function (hooks) {
       recorded.length >= 1 && recorded.every((v) => v === 120);
     assert.ok(
       recordedOnlyTheUserOffset,
-      'the user scroll offset (120) is recorded',
+      `the user scroll offset (120) is recorded (recorded: ${JSON.stringify(
+        recorded,
+      )})`,
     );
   });
 


### PR DESCRIPTION
`Integration | modifier | persist-scroll-position: records the offset only after a genuine user scroll gesture` is flaky — it surfaces on host shards (which `main` CI skips, so it goes unnoticed there) and reproduces locally under load at roughly a two-in-three failure rate.

## Root cause

A programmatic `scrollTop` assignment fires its `scroll` event on the **next rendering frame**, not synchronously, and `settled()` does not await that frame. The test's gesture-less phase sets `scrollTop = 90` (asserting it is *not* recorded, since no gesture has happened). That assignment's native `scroll` event stays pending. Under load it lands during the following `await triggerEvent(scroller, 'wheel')` settle — *after* the wheel has flipped the modifier from restoring into recording — so the modifier records `90` as a user offset. `recorded` becomes `[90, 120, …]` and the `every(v === 120)` assertion fails.

Confirmed by logging each `onChange` and the wheel boundary: on a failing run, `onChange 90` fires between the pre-wheel and post-wheel markers.

## Fix

Await one animation frame after the gesture-less scroll, so its pending `scroll` event drains while there is still no gesture — the modifier ignores it, as intended — before the wheel switches on recording. The recording path is otherwise unchanged.

Also surface the `recorded` array in the assertion message, so if this ever regresses the failure output names exactly what leaked instead of a bare boolean.

## Verification

Reproduced the failure locally (full-module run under load), then confirmed the fix: 5 consecutive green full-module runs, and the single test green in isolation. The drain consumes precisely the event that was leaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
