### PR TITLE
Fix default templates crashing when card model is transiently undefined

### DIFF
--- a/packages/base/default-templates/field-edit.gts
+++ b/packages/base/default-templates/field-edit.gts
@@ -1,5 +1,5 @@
 import GlimmerComponent from '@glimmer/component';
-import type { FieldDef } from '../card-api';
+import type { BaseDef, FieldDef } from '../card-api';
 import { FieldContainer } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 import { startCase } from 'lodash-es';
@@ -7,12 +7,13 @@ import { getField } from '@cardstack/runtime-common';
 
 export default class FieldDefEditTemplate extends GlimmerComponent<{
   Args: {
+    cardOrField: typeof BaseDef;
     model: FieldDef;
     fields: Record<string, new () => GlimmerComponent>;
   };
 }> {
   getFieldIcon = (key: string) => {
-    return getField(this.args.model.constructor, key)?.card?.icon;
+    return getField(this.args.cardOrField, key)?.card?.icon;
   };
   <template>
     <div class='field-def-edit-template'>

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -1,5 +1,5 @@
 import GlimmerComponent from '@glimmer/component';
-import type { CardDef, FieldsTypeFor, Format } from '../card-api';
+import type { BaseDef, CardDef, FieldsTypeFor, Format } from '../card-api';
 import { FieldContainer, Header } from '@cardstack/boxel-ui/components';
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
 import { startCase } from 'lodash-es';
@@ -12,6 +12,7 @@ import CardInfoTemplates from './card-info';
 
 export default class DefaultCardDefTemplate extends GlimmerComponent<{
   Args: {
+    cardOrField: typeof BaseDef;
     model: CardDef;
     fields: FieldsTypeFor<CardDef>;
     format: Format;
@@ -29,7 +30,9 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
   // then display its edit format alongside other top-level fields.
   private get cardInfoFieldDisplayNames(): string[] | undefined {
     let fieldNames = this.standardComputedFields.filter((fieldName) => {
-      const field = getField(this.args.model.constructor, fieldName);
+      // the card class arrives as @cardOrField, so this works even while
+      // the model instance is still loading
+      const field = getField(this.args.cardOrField, fieldName);
       return field?.computeVia == undefined;
     });
 
@@ -38,6 +41,9 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
 
   // Fields to display in between the cardInfo header and notes footer
   private get displayFields(): FieldsTypeFor<CardDef> | undefined {
+    if (!this.args.fields) {
+      return undefined;
+    }
     let excludedFields = this.excludedFields.filter(
       (name) => !this.cardInfoFieldDisplayNames?.includes(name),
     );
@@ -52,7 +58,9 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
 
   private get isThemeCard() {
     return Boolean(
-      Object.entries(this.args.fields).find(([key]) => key === 'cssVariables'),
+      Object.entries(this.args.fields ?? {}).find(
+        ([key]) => key === 'cssVariables',
+      ),
     );
   }
 
@@ -69,7 +77,7 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
             @cardThumbnailURL={{@model.cardThumbnailURL}}
             @icon={{@model.constructor.icon}}
           />
-        {{else}}
+        {{else if @fields.cardInfo}}
           <CardInfoTemplates.edit
             @fields={{@fields}}
             @model={{@model}}
@@ -90,15 +98,17 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
           {{/each-in}}
         </section>
       {{/if}}
-      <footer class='notes-footer'>
-        <FieldContainer
-          @label='Notes'
-          @icon={{getFieldIcon @model.cardInfo 'notes'}}
-          data-test-field='cardInfo-notes'
-        >
-          <@fields.cardInfo.notes />
-        </FieldContainer>
-      </footer>
+      {{#if @fields.cardInfo.notes}}
+        <footer class='notes-footer'>
+          <FieldContainer
+            @label='Notes'
+            @icon={{getFieldIcon @model.cardInfo 'notes'}}
+            data-test-field='cardInfo-notes'
+          >
+            <@fields.cardInfo.notes />
+          </FieldContainer>
+        </footer>
+      {{/if}}
     </div>
     <style scoped>
       .default-card-template {


### PR DESCRIPTION
## Problem

Production host intermittently crashes while rendering a card:

```
TypeError: Cannot read properties of undefined (reading 'constructor')
    at get cardInfoFieldDisplayNames (https://cardstack.com/base/default-templates/isolated-and-edit:10:50)
```

The default isolated/edit template derives the card class from `this.args.model.constructor` inside tracked getters, and dereferences `this.args.fields` unguarded. The host can render a format component for a tick while the model instance is still resolving — on initial load, and on a store re-resolve when an incremental index invalidation lands under an open card — so the first tracked getter throws and takes down the render. Reproduced repeatedly on a realm with heavy `linksTo` graphs and frequent CLI pushes (live invalidations of open cards).

## Fix

- **Take the class from `@cardOrField` instead of `model.constructor`.** Every format component already receives the class as an arg, independent of the instance — `head.gts` and `embedded.gts` use it for exactly this reason. `isolated-and-edit.gts` and `field-edit.gts` were the two templates digging it out of the instance instead.
- **Guard the `@fields` dereferences** (`displayFields`, `isThemeCard`) and render the CardInfo edit header and notes footer only when `@fields.cardInfo` exists — invoking `<@fields.cardInfo.notes />` with undefined `@fields` throws "attempted to invoke undefined component".

Behavior is unchanged whenever model/fields are present; a render pass with no data now produces an empty shell for that frame instead of throwing. This matches the defensive convention `card-info.gts` already follows throughout.

## Verification

- `ember-template-lint` clean on both files
- host `lint:types` error count identical before/after (7 pre-existing, unrelated `.at()` lib-target errors)
- The pre-commit eslint parse errors on these files are pre-existing for all `packages/base` gts files (the eslint config doesn't parse `<template>` there; the package's own lint is ember-template-lint, which passes)
- Existing tests asserting the notes footer (`card-basics-test`) are unaffected by construction — the guards only change behavior when fields are absent, which previously crashed

Tracked in CS-12330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)