### PR TITLE
Announce Button's disabled links to assistive tech

### DIFF
--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -100,9 +100,20 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
         {{yield}}
       </button>
     {{else if (eq @as 'anchor')}}
+      {{! An <a> we've stripped the href from is not a link — it maps to the
+          generic role, where aria-disabled is not supported and gets dropped.
+          role='link' is what makes the disabled state reach assistive tech;
+          without it the CSS below fades the element and announces nothing.
+
+          Keyed on @disabled only, never on a falsy @href: callers are free to
+          pass href as a plain attribute through ...attributes (see
+          base/skill-plus.gts, base/default-templates/theme-dashboard.gts), and
+          those are real links that must not be labelled unavailable. }}
       <a
         class={{classes}}
         href={{unless @disabled (if @href (sanitizeHtml @href))}}
+        role={{if @disabled 'link'}}
+        aria-disabled={{if @disabled 'true'}}
         data-test-boxel-button
         ...attributes
       >

--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -85,7 +85,13 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
       <button
         class={{classes}}
         aria-label={{if @loading 'loading'}}
-        aria-disabled={{@disabled}}
+        {{! 'true', not the raw boolean: Glimmer renders a bare true as
+            aria-disabled="", and ARIA treats any value that isn't exactly
+            "true"/"false" as the default, false. The native disabled
+            attribute below carries the real state either way, so this was
+            benign — but it contradicted itself, and matched none of the
+            [aria-disabled='true'] selectors used across the codebase. }}
+        aria-disabled={{if @disabled 'true'}}
         disabled={{@disabled}}
         data-test-boxel-button
         ...attributes

--- a/packages/boxel-ui/test-app/tests/integration/components/button-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/button-test.gts
@@ -1,0 +1,95 @@
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { Button } from '@cardstack/boxel-ui/components';
+
+module('Integration | Component | button', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('renders a <button> by default and when @as="button"', async function (assert) {
+    await render(
+      <template>
+        <Button>Go</Button>
+      </template>,
+    );
+    assert.dom('[data-test-boxel-button]').hasTagName('button');
+    assert
+      .dom('[data-test-boxel-button]')
+      .doesNotHaveAttribute('aria-disabled');
+
+    await render(
+      <template>
+        <Button @as='button'>Go</Button>
+      </template>,
+    );
+    assert.dom('[data-test-boxel-button]').hasTagName('button');
+  });
+
+  test('@as="anchor" renders a link with the sanitized href', async function (assert) {
+    await render(
+      <template>
+        <Button @as='anchor' @href='https://example.com/x'>Go</Button>
+      </template>,
+    );
+    assert.dom('[data-test-boxel-button]').hasTagName('a');
+    assert
+      .dom('[data-test-boxel-button]')
+      .hasAttribute('href', 'https://example.com/x');
+  });
+
+  // An <a> with no href maps to the generic role, where aria-disabled is not
+  // supported — so role='link' is what makes the state reach assistive tech.
+  test('a disabled anchor is announced as an unavailable link', async function (assert) {
+    await render(
+      <template>
+        <Button @as='anchor' @href='https://example.com/x' @disabled={{true}}>
+          Go
+        </Button>
+      </template>,
+    );
+    assert.dom('[data-test-boxel-button]').doesNotHaveAttribute('href');
+    assert.dom('[data-test-boxel-button]').hasAttribute('role', 'link');
+    assert.dom('[data-test-boxel-button]').hasAria('disabled', 'true');
+  });
+
+  test('an enabled anchor carries neither role nor aria-disabled', async function (assert) {
+    await render(
+      <template>
+        <Button @as='anchor' @href='https://example.com/x' @disabled={{false}}>
+          Go
+        </Button>
+      </template>,
+    );
+    assert.dom('[data-test-boxel-button]').doesNotHaveAttribute('role');
+    assert
+      .dom('[data-test-boxel-button]')
+      .doesNotHaveAttribute('aria-disabled');
+  });
+
+  // Regression guard: the disabled state is keyed on @disabled, never on a
+  // falsy @href. Callers legitimately pass href as a plain attribute through
+  // ...attributes (base/skill-plus.gts, base/default-templates/theme-dashboard.gts),
+  // and those are real links that must not be labelled unavailable.
+  test('an href passed via ...attributes is not treated as disabled', async function (assert) {
+    await render(
+      <template>
+        <Button @as='anchor' href='#top'>Back to top</Button>
+      </template>,
+    );
+    assert.dom('[data-test-boxel-button]').hasAttribute('href', '#top');
+    assert.dom('[data-test-boxel-button]').doesNotHaveAttribute('role');
+    assert
+      .dom('[data-test-boxel-button]')
+      .doesNotHaveAttribute('aria-disabled');
+  });
+
+  test('a disabled <button> keeps the native disabled attribute', async function (assert) {
+    await render(
+      <template>
+        <Button @disabled={{true}}>Go</Button>
+      </template>,
+    );
+    assert.dom('[data-test-boxel-button]').isDisabled();
+    assert.dom('[data-test-boxel-button]').hasAria('disabled', 'true');
+  });
+});


### PR DESCRIPTION
`Button` has styled a hrefless anchor as a disabled link for a while — the CSS matches `a.boxel-button:not([href])`, `[href='']` and `.disabled-link`, applying `opacity: 0.5`, the disabled colour and `pointer-events: none`. But the `@as='anchor'` branch only suppresses the `href`: no `disabled` attribute, no `aria-disabled`. **So the state has been visual-only for every caller**, and `@disabled={{true}}` on an anchor produced DOM identical to just omitting `@href`.

```diff
  <a
    class={{classes}}
    href={{unless @disabled (if @href (sanitizeHtml @href))}}
+   role={{if @disabled 'link'}}
+   aria-disabled={{if @disabled 'true'}}
    data-test-boxel-button
    ...attributes
  >
```

## Two things worth reviewing rather than skimming

**`role='link'` is the part that does the work.** An `<a>` we've stripped the `href` from is not a link — it maps to the `generic` role, where `aria-disabled` is not supported and browsers drop it. Adding `aria-disabled` alone would have looked like a fix and changed nothing observable.

**Keyed on `@disabled` only, deliberately never on a falsy `@href`.** Inferring from `@href` was my first instinct and it would have introduced a bug: callers legitimately pass `href` as a plain attribute through `...attributes`, where `@href` is `undefined` but the link is real. Two in-tree examples, both `href='#top'`:

- `packages/base/skill-plus.gts`
- `packages/base/default-templates/theme-dashboard.gts`

Those would have been labelled unavailable. There's a test guarding exactly that case.

## Blast radius

Anchor-`Button` callers surveyed. Only one passes `@disabled`, and it gains the intended behaviour for free:

- `packages/host/app/components/operator-mode/publish-realm-modal.gts` — `@as='anchor'` with `@disabled={{this.isUnpublishingAnyRealms}}`, in two places

The rest pass a real `@href` or a plain `href` attribute and are unaffected: `host-submode.gts`, `host-submode/open-site-popover.gts`, `skill-plus.gts`, `theme-dashboard.gts`.

## Tests

Adds `packages/boxel-ui/test-app/tests/integration/components/button-test.gts` — **the first test coverage `Button` has**. Six tests: default/`@as='button'` tag, anchor href sanitisation, the disabled-anchor `role`/`aria-disabled` pair, the enabled-anchor negative case, the `...attributes` regression guard, and the native `disabled` attribute on `<button>`.

**I could not run them locally, and I'd rather say so than imply otherwise.** The boxel-ui test-app harness dies at boot with `Uncaught TypeError: window.require is not a function` before any test executes. It fails identically on a stashed clean tree with an untouched `accordion-test`, and again after `mise run build:ui` (the step CI runs first), so it is pre-existing and unrelated to this change. What did pass locally, in both `addon` and `test-app`: `eslint`, `ember-template-lint`, `ember-tsc --noEmit`. **CI's `Boxel UI Tests` job is the first real execution of these assertions** — please don't merge on my word that they pass.

That local breakage may deserve its own issue; it's plausibly why `Button` had no tests to begin with.

## Follow-ups this unblocks

Tracked on [CS-12305](https://linear.app/cardstack/issue/CS-12305/upstream-portable-homepage-modules-to-boxel-ui), which lists the three places that assert the current behaviour and go stale together when this lands:

1. `boxel-home` `sections/hero-section.gts` — drop the hand-passed `aria-disabled` and its `TODO (boxel-ui, CS-12305)` comment ([boxel-home#70](https://github.com/cardstack/boxel-home/pull/70))
2. `boxel-skills` `skills/boxel-ui-guidelines/references/use-boxel-ui-components.md` — remove the dated version note ([boxel-skills#103](https://github.com/cardstack/boxel-skills/pull/103))
3. `boxel-skills` `Skill/boxel-ui-guidelines.md` — the same note in the mirrored tree

Also noted there: this makes the surrounding convention **more** load-bearing, not less. Today a plain label written as a hrefless anchor is merely silent to assistive tech; afterwards it will actively announce itself as an unavailable link. Whether an optional `href` means "unavailable link" or "not a link" becomes a decision authors have to make deliberately.

Draft until CI has actually run the tests.

🤖 Drafted by Claude (Opus 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)