### PR TITLE
Migrate committed realm index cards to the Workspace card

### DIFF
--- a/packages/base/index.json
+++ b/packages/base/index.json
@@ -3,8 +3,8 @@
     "type": "card",
     "meta": {
       "adoptsFrom": {
-        "module": "./cards-grid",
-        "name": "CardsGrid"
+        "module": "./workspace",
+        "name": "Workspace"
       }
     }
   }

--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -636,6 +636,7 @@ class Isolated extends Component<typeof Workspace> {
                       (eq option.id this.activeFilter.id)
                       "selected"
                     }}'
+                  data-test-workspace-filter={{option.id}}
                   {{on 'click' (this.selectFilter option)}}
                 >
                   {{#let (this.iconComponent option) as |Icon|}}
@@ -660,6 +661,7 @@ class Isolated extends Component<typeof Workspace> {
                           (eq option.id this.activeFilter.id)
                           "selected"
                         }}'
+                      data-test-workspace-filter={{option.id}}
                       {{on 'click' (this.selectFilter option)}}
                     >
                       {{#if (this.iconHtml option)}}
@@ -700,6 +702,7 @@ class Isolated extends Component<typeof Workspace> {
                         (eq option.id this.activeFilter.id)
                         "selected"
                       }}'
+                    data-test-workspace-filter={{option.id}}
                     {{on 'click' (this.selectFilter option)}}
                   >
                     {{#if (this.iconHtml option)}}

--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -2823,7 +2823,21 @@ class Isolated extends Component<typeof Workspace> {
     } //
     // Bound hydration and federated-search scope. Default to 100 but let a
     // caller that needs fewer (e.g. a single-row preview) request a smaller page.
-    return store.search({ page: { size: 100 }, ...query } as Query, [realm]);
+    try {
+      return await store.search({ page: { size: 100 }, ...query } as Query, [
+        realm,
+      ]);
+    } catch (e) {
+      // These searches feed passive panels — the Home inventory, the recent
+      // preview, the Activity feed — every one of which reads fine as empty.
+      // The realm can also be unsearchable for reasons the card can't fix: the
+      // host refuses to mint a token for a realm on a different realm server
+      // than its own, so a Workspace rendered from a foreign realm server
+      // rejects here on every panel. Degrade to empty instead of letting the
+      // rejection escape the task and surface as an unhandled error.
+      console.warn(`Workspace search failed for realm ${realm}`, e);
+      return [];
+    }
   }; //
 
   // The four library-group rows keep stable identities (@cached, no tracked

--- a/packages/experiments-realm/index.json
+++ b/packages/experiments-realm/index.json
@@ -3,8 +3,8 @@
     "type": "card",
     "meta": {
       "adoptsFrom": {
-        "module": "https://cardstack.com/base/cards-grid",
-        "name": "CardsGrid"
+        "module": "https://cardstack.com/base/workspace",
+        "name": "Workspace"
       }
     }
   }

--- a/packages/host/tests/integration/components/workspace-behavior-test.gts
+++ b/packages/host/tests/integration/components/workspace-behavior-test.gts
@@ -46,4 +46,24 @@ module('Integration | Card | workspace | segments', function (hooks) {
     await renderCard(loader, new Workspace({}), 'isolated');
     assert.dom('.search-box .search-input').exists('Cmd+K frame search input');
   });
+
+  // The Library rail opens on "Everything", which lists a card twice — once as
+  // the instance and once as the file-meta row for its `.json` — and both rows
+  // carry the same extension-stripped `data-test-cards-grid-item`. Callers that
+  // need one element per card (notably the matrix `showAllCards` helper, which
+  // drives realm indexes end to end) select "Cards" instead, so these filter ids
+  // are a contract rather than an implementation detail.
+  test('the Library rail exposes stable filter hooks', async function (assert) {
+    await renderCard(loader, new Workspace({}), 'isolated');
+    await click(LIBRARY);
+
+    for (let id of ['everything', 'cards', 'files']) {
+      assert
+        .dom(`[data-test-workspace-filter="${id}"]`)
+        .exists(`the "${id}" rail filter is addressable`);
+    }
+    assert
+      .dom('[data-test-workspace-filter="everything"]')
+      .hasClass('selected', 'the Library opens on Everything');
+  });
 });

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -490,6 +490,12 @@ export async function showAllCards(page: Page) {
   }
   if ((await libraryTab.count()) > 0) {
     await libraryTab.click();
+    // The Library opens on "Everything", which lists a card instance twice —
+    // once as the instance and once as the file-meta row for its `.json` — and
+    // both rows carry the same extension-stripped `data-test-cards-grid-item`.
+    // Selecting "Cards" narrows to instances only, so a locator keyed on a card
+    // id resolves to exactly one element, matching CardsGrid's "All Cards".
+    await page.locator(`[data-test-workspace-filter="cards"]`).click();
   }
 }
 

--- a/packages/realm-server/scripts/bench-realm/fixtures/realm-snapshot/index.json
+++ b/packages/realm-server/scripts/bench-realm/fixtures/realm-snapshot/index.json
@@ -3,8 +3,8 @@
     "type": "card",
     "meta": {
       "adoptsFrom": {
-        "module": "https://cardstack.com/base/cards-grid",
-        "name": "CardsGrid"
+        "module": "https://cardstack.com/base/workspace",
+        "name": "Workspace"
       }
     }
   }

--- a/packages/software-factory/realm/index.json
+++ b/packages/software-factory/realm/index.json
@@ -3,8 +3,8 @@
     "type": "card",
     "meta": {
       "adoptsFrom": {
-        "module": "https://cardstack.com/base/cards-grid",
-        "name": "CardsGrid"
+        "module": "https://cardstack.com/base/workspace",
+        "name": "Workspace"
       }
     }
   }

--- a/packages/test-realm-cards/contents/index.json
+++ b/packages/test-realm-cards/contents/index.json
@@ -4,8 +4,8 @@
     "attributes": {},
     "meta": {
       "adoptsFrom": {
-        "module": "https://cardstack.com/base/cards-grid",
-        "name": "CardsGrid"
+        "module": "https://cardstack.com/base/workspace",
+        "name": "Workspace"
       }
     }
   }


### PR DESCRIPTION
## What

Switch the realm `index.json` files tracked in this repo from adopting `CardsGrid` to adopting `Workspace`:

- `packages/base/index.json` (keeps the relative `./workspace` form the base realm uses)
- `packages/experiments-realm/index.json`
- `packages/software-factory/realm/index.json`
- `packages/test-realm-cards/contents/index.json`
- `packages/realm-server/scripts/bench-realm/fixtures/realm-snapshot/index.json`

The last four keep the `https://cardstack.com/base/…` module form the surrounding realm content already uses; both that and `@cardstack/base/…` are recognized as a default index adoption. CardsGrid stays available for realms that still adopt it.

## The generated dev realms are not touched

`packages/realm-server/.gitignore` line 1 is `/realms`, so the eight realms under `packages/realm-server/realms/localhost_4201/` are untracked local scaffolding — there is nothing in the repo to migrate. New realms already get a Workspace index from the create-realm handler, so a developer who regenerates them picks this up automatically.

## Why the matrix helper changes

The Workspace Library tab opens on the **Everything** filter, which lists cards *and* file-meta rows. Every file gets a file entry, card JSON included, and `card-list.gts` renders `data-test-cards-grid-item={{removeFileExtension entry.id}}` — so a card instance and the file row for its own `.json` collapse to the *same* attribute value. CardsGrid's "All Cards" was cards-only (`not: { eq: { _cardType } }`), so nothing hit this before a realm's index actually became a Workspace.

Concretely, on the fixture realm this PR migrates, an unfiltered realm search returns 61 rows containing 18 extension-stripped duplicate pairs, among them:

```
<test-realm>/hassan.json
<test-realm>/hassan
```

`showAllCards` previously stopped at the Library tab, so every locator keyed on a card id — roughly 19 sites across `messages`, `tools`, `live-cards`, `correctness-checks`, and `helpers/setupTwoStackItems` — would have resolved to two elements and failed Playwright's strict mode.

`showAllCards` now clicks the Library tab and then the **Cards** filter, which is instances only and matches what "All Cards" listed. To give that click a stable target, the Library rail rows carry `data-test-workspace-filter={{option.id}}`, and a host test pins `everything` / `cards` / `files` as a contract so renaming one fails in the host suite rather than in a 37-minute matrix run.

## Workspace searches now fail soft

Migrating the test-realm fixture surfaced a crash. The Workspace's Home panels — inventory, recent preview, activity feed — search the card's own realm as soon as it renders, where CardsGrid didn't search until you picked a filter. When that search rejects, the rejection escapes the enclosing task as an unhandled error, which in the host suite aborts a whole shard rather than failing one test.

The realm can be unsearchable for reasons the card can't fix: the host refuses to mint a token for a realm on a different realm server than its own, so every panel on a Workspace rendered from a foreign realm server rejects. The host suite runs exactly that topology — `card-delete` opens the live test realm-server's index card in its right stack, which this branch turns into a Workspace:

```
RealmServerService.assertOwnRealmServer (realm-server.ts:350)
  ← StoreService.fetchSearchEntryDoc (store.ts:1040)
  … ← StoreService.fetchAndHydrateSearchResults
```

`searchRealm` already declines to search when it has no store or no realm and returns empty. It now fails the same way, with a warning so the cause stays visible. Every panel it feeds reads fine empty.

## Test plan

Verified against a live `dev-all` stack: `/base/index`, `/software-factory/index`, and the fixture realm's index all index cleanly with `adoptsFrom: { name: 'Workspace', module: '@cardstack/base/workspace' }`, and the experiments index renders the Home/Library/Activity shell with correct realm stats.

- Host `Integration | Card | workspace` — 23 passed, 0 failed (includes the new rail-hook test).
- Host `Integration | card-delete` — 44 passed, 0 failed (was 44 plus the global failure above).
- Host `realm indexing`, which covers the default-index prerender fast path — 140 passed, 0 failed.
- Host `ember-tsc --noEmit` clean; eslint, ember-template-lint, and prettier clean on the changed files.

**Matrix is CI-only**, and all three Matrix Client Tests shards pass on this branch, which is the confirmation for `showAllCards`. The duplicate-row problem it addresses was also reproduced directly against the migrated fixture realm, and a live browser check of the experiments realm confirms the **Cards** filter renders one row per card (100 rows, no duplicate ids).

Two pre-existing issues surfaced while testing and are deliberately untouched: `packages/base/workspace.gts` trips an eslint parse error at its `<template>` (packages/base is template-lint-only in CI, so it doesn't block), and `ember test --path dist` aborts at boot with `window.require is not a function`. Both reproduce on `main`; the host tests above were run through the dev server's test page instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
