### PR TITLE
Wire unpublish into the Workspace edit format

### DIFF
--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -5,14 +5,17 @@ import { htmlSafe, type SafeString } from '@ember/template';
 import { cached, tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { modifier } from 'ember-modifier';
-import { TrackedArray } from 'tracked-built-ins';
+import { TrackedArray, TrackedSet } from 'tracked-built-ins';
 
 import { BoxelInput } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 import BooleanField from './boolean';
-// host-mode mutation: publish is a registered host tool (tools/index.ts)
-import PublishRealmCommand from '@cardstack/boxel-host/tools/publish-realm';
-import { PublishRealmInput } from './command';
+// host-mode mutation: publish and unpublish are registered host tools
+// (tools/index.ts shims them onto the loader's virtual network, so these
+// specifiers resolve for card code in operator mode and under prerender)
+import PublishRealmTool from '@cardstack/boxel-host/tools/publish-realm';
+import UnpublishRealmTool from '@cardstack/boxel-host/tools/unpublish-realm';
+import { PublishRealmInput, UnpublishRealmInput } from './command';
 
 import LayoutGridPlusIcon from '@cardstack/boxel-icons/layout-grid-plus';
 import Captions from '@cardstack/boxel-icons/captions';
@@ -3403,9 +3406,10 @@ export class Workspace extends CardDef {
       return this.args.model.pinnedSize === 'compact' ? 'compact' : 'regular';
     }
 
-    // Hosting: present published sites (free on realmInfo) and mutate
-    // via the registered publish-realm host command. First-time publish
-    // (domain choice) stays in the workspace menu's publish flow.
+    // Hosting: present published sites (free on realmInfo) and mutate via the
+    // registered publish-realm / unpublish-realm host tools. First-time publish
+    // (domain choice) stays in the host submode's publish flow; this format
+    // acts on destinations that already exist.
     get publishedSites() {
       return publishedSitesOf(this.args.model);
     }
@@ -3425,7 +3429,7 @@ export class Workspace extends CardDef {
       if (!commandContext || !realm || !urls.length) {
         return;
       }
-      await new PublishRealmCommand(commandContext).execute(
+      await new PublishRealmTool(commandContext).execute(
         new PublishRealmInput({
           realmURL: realm,
           publishedRealmURLs: urls,
@@ -3435,6 +3439,44 @@ export class Workspace extends CardDef {
 
     get publishBusy() {
       return this.republishTask.isRunning;
+    }
+
+    unpublish = (publishedRealmURL: string) => () => {
+      this.unpublishTask.perform(publishedRealmURL);
+    };
+
+    // Which site is in flight, so one row can label itself while the others
+    // stay idle — `unpublishTask.isRunning` is true for all of them. A
+    // TrackedSet rather than a `@tracked` field because this is a class
+    // expression, where decorators aren't allowed.
+    private unpublishing = new TrackedSet<string>();
+
+    private unpublishTask = restartableTask(
+      async (publishedRealmURL: string) => {
+        let commandContext = this.args.context?.commandContext;
+        let realm = this.args.model[realmURL]?.href;
+        if (!commandContext || !realm) {
+          return;
+        }
+        this.unpublishing.add(publishedRealmURL);
+        try {
+          await new UnpublishRealmTool(commandContext).execute(
+            new UnpublishRealmInput({
+              realmURL: realm,
+              publishedRealmURL,
+            }),
+          );
+        } finally {
+          this.unpublishing.delete(publishedRealmURL);
+        }
+      },
+    );
+
+    isUnpublishing = (publishedRealmURL: string) =>
+      this.unpublishing.has(publishedRealmURL);
+
+    get unpublishBusy() {
+      return this.unpublishTask.isRunning;
     }
 
     <template>
@@ -3707,6 +3749,17 @@ export class Workspace extends CardDef {
                     {{#if site.when}}
                       <span class='site-when'>{{site.when}}</span>
                     {{/if}}
+                    <button
+                      type='button'
+                      class='publish-btn unpublish-btn'
+                      disabled={{this.unpublishBusy}}
+                      data-test-unpublish-site={{site.url}}
+                      {{on 'click' (this.unpublish site.url)}}
+                    >{{if
+                        (this.isUnpublishing site.url)
+                        'Unpublishing…'
+                        'Unpublish'
+                      }}</button>
                   </div>
                 </div>
               {{/each}}
@@ -3730,7 +3783,7 @@ export class Workspace extends CardDef {
                 <div class='setting-text'>
                   <span class='setting-label'>Publishing</span>
                   <p class='setting-help'>Not published. Use Publish in the
-                    workspace menu to put this space on the web.</p>
+                    Host submode toolbar to put this space on the web.</p>
                 </div>
               </div>
             {{else}}
@@ -3940,6 +3993,18 @@ export class Workspace extends CardDef {
         .publish-btn:disabled {
           opacity: 0.6;
           cursor: default;
+        }
+        /* Sits at the end of the site row, and reads as the destructive
+          counterpart to Republish rather than a second primary action. */
+        .unpublish-btn {
+          margin-left: auto;
+          padding: 5px 10px;
+          font-size: 11.5px;
+          color: var(--grid-ink-quiet);
+        }
+        .unpublish-btn:hover:not(:disabled) {
+          border-color: var(--grid-broken);
+          color: var(--grid-broken);
         }
         .choice-opt:focus-visible,
         .order-move:focus-visible,

--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -5,7 +5,7 @@ import { htmlSafe, type SafeString } from '@ember/template';
 import { cached, tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { modifier } from 'ember-modifier';
-import { TrackedArray, TrackedSet } from 'tracked-built-ins';
+import { TrackedArray, TrackedObject, TrackedSet } from 'tracked-built-ins';
 
 import { BoxelInput } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
@@ -13,9 +13,16 @@ import BooleanField from './boolean';
 // host-mode mutation: publish and unpublish are registered host tools
 // (tools/index.ts shims them onto the loader's virtual network, so these
 // specifiers resolve for card code in operator mode and under prerender)
+import GetPublishedRealmsTool from '@cardstack/boxel-host/tools/get-published-realms';
 import PublishRealmTool from '@cardstack/boxel-host/tools/publish-realm';
 import UnpublishRealmTool from '@cardstack/boxel-host/tools/unpublish-realm';
-import { PublishRealmInput, UnpublishRealmInput } from './command';
+import {
+  GetPublishedRealmsInput,
+  PublishRealmInput,
+  UnpublishRealmInput,
+  type PublishedRealmInfo,
+  type PublishTargetResult,
+} from './command';
 
 import LayoutGridPlusIcon from '@cardstack/boxel-icons/layout-grid-plus';
 import Captions from '@cardstack/boxel-icons/captions';
@@ -157,30 +164,42 @@ function homeModulesOf(model: Partial<Workspace>): string[] {
   return configured;
 }
 
+interface PublishedSite {
+  url: string;
+  host: string;
+  when?: string;
+}
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+// One row of the hosting list. `at` is an epoch-ms timestamp in whichever form
+// its source hands over — a number from meta.realmInfo, a string from the
+// get-published-realms tool — and is absent for a destination the server has
+// no publish timestamp for, which must read as "no date" rather than 1970.
+function publishedSite(url: string, at: unknown): PublishedSite {
+  let ms = at == null || at === '' ? NaN : Number(at);
+  return {
+    url,
+    host: hostOf(url),
+    when: Number.isFinite(ms) ? relativeTime(ms) : undefined,
+  };
+}
+
 // published sites, read synchronously off meta.realmInfo (source-realm
 // shape: lastPublishedAt is a map of publishedRealmURL → epoch-ms string)
-function publishedSitesOf(
-  model: Partial<Workspace>,
-): { url: string; host: string; when?: string }[] {
+function publishedSitesOf(model: Partial<Workspace>): PublishedSite[] {
   let info = model[realmInfo];
   let published = info?.lastPublishedAt;
   if (!published || typeof published !== 'object') {
     return [];
   }
-  return Object.entries(published).map(([url, at]) => {
-    let host: string;
-    try {
-      host = new URL(url).host;
-    } catch {
-      host = url;
-    }
-    let ms = Number(at);
-    return {
-      url,
-      host,
-      when: Number.isFinite(ms) ? relativeTime(ms) : undefined,
-    };
-  });
+  return Object.entries(published).map(([url, at]) => publishedSite(url, at));
 }
 
 // Types that are machinery rather than content — the Home inventory folds
@@ -3406,13 +3425,50 @@ export class Workspace extends CardDef {
       return this.args.model.pinnedSize === 'compact' ? 'compact' : 'regular';
     }
 
-    // Hosting: present published sites (free on realmInfo) and mutate via the
-    // registered publish-realm / unpublish-realm host tools. First-time publish
-    // (domain choice) stays in the host submode's publish flow; this format
-    // acts on destinations that already exist.
-    get publishedSites() {
-      return publishedSitesOf(this.args.model);
+    // Hosting: present published sites and mutate them via the registered
+    // publish-realm / unpublish-realm host tools. First-time publish (domain
+    // choice) stays in the host submode's publish flow; this format acts on
+    // destinations that already exist.
+    //
+    // The list starts from `meta.realmInfo`, which is a snapshot taken when the
+    // card was (de)serialized — a mutation here changes hosting state without
+    // changing that snapshot, and unpublish triggers no reindex, so nothing
+    // would rebuild it in-session. Once a mutation lands, re-read the list
+    // through the get-published-realms tool and prefer its answer from then on;
+    // otherwise an unpublished site would keep being listed as live until the
+    // card was reloaded. `TrackedObject` rather than `@tracked` fields because
+    // this is a class expression, where decorators aren't allowed.
+    private hosting = new TrackedObject<{
+      sites: PublishedSite[] | undefined;
+      error: string | undefined;
+    }>({ sites: undefined, error: undefined });
+
+    get publishedSites(): PublishedSite[] {
+      return this.hosting.sites ?? publishedSitesOf(this.args.model);
     }
+
+    get hostingError() {
+      return this.hosting.error;
+    }
+
+    // Re-reads the authoritative list. The tool reports RealmService's own
+    // hosting state, which both mutations write through, so this reflects what
+    // actually happened server-side rather than what was requested.
+    private reloadPublishedSites = async () => {
+      let commandContext = this.args.context?.commandContext;
+      let realm = this.args.model[realmURL]?.href;
+      if (!commandContext || !realm) {
+        return;
+      }
+      let { results } = await new GetPublishedRealmsTool(
+        commandContext,
+      ).execute(new GetPublishedRealmsInput({ realmURL: realm }));
+      // Annotated because this module is also compiled by projects that don't
+      // map `@cardstack/boxel-host/tools/*` and so see the tool as `any`.
+      this.hosting.sites = (results ?? []).map((site: PublishedRealmInfo) =>
+        publishedSite(site.publishedRealmURL, site.lastPublishedAt),
+      );
+    };
 
     get isPublishable() {
       return this.args.model[realmInfo]?.publishable === true;
@@ -3429,12 +3485,25 @@ export class Workspace extends CardDef {
       if (!commandContext || !realm || !urls.length) {
         return;
       }
-      await new PublishRealmTool(commandContext).execute(
+      this.hosting.error = undefined;
+      let { results } = await new PublishRealmTool(commandContext).execute(
         new PublishRealmInput({
           realmURL: realm,
           publishedRealmURLs: urls,
         }),
       );
+      // Per-destination outcomes come back on the result rather than as a
+      // rejection, so a publish that didn't happen is only visible here.
+      let failure = (results ?? []).find(
+        (result: PublishTargetResult) => result.status === 'error',
+      );
+      if (failure) {
+        this.hosting.error = `Could not republish ${hostOf(
+          failure.publishedRealmURL,
+        )}: ${failure.error || 'unknown error'}`;
+      }
+      // Refresh either way: with the publish timestamps of whatever did land.
+      await this.reloadPublishedSites();
     });
 
     get publishBusy() {
@@ -3446,9 +3515,7 @@ export class Workspace extends CardDef {
     };
 
     // Which site is in flight, so one row can label itself while the others
-    // stay idle — `unpublishTask.isRunning` is true for all of them. A
-    // TrackedSet rather than a `@tracked` field because this is a class
-    // expression, where decorators aren't allowed.
+    // stay idle — `unpublishTask.isRunning` is true for all of them.
     private unpublishing = new TrackedSet<string>();
 
     private unpublishTask = restartableTask(
@@ -3458,14 +3525,24 @@ export class Workspace extends CardDef {
         if (!commandContext || !realm) {
           return;
         }
+        this.hosting.error = undefined;
         this.unpublishing.add(publishedRealmURL);
         try {
-          await new UnpublishRealmTool(commandContext).execute(
+          let result = await new UnpublishRealmTool(commandContext).execute(
             new UnpublishRealmInput({
               realmURL: realm,
               publishedRealmURL,
             }),
           );
+          // The tool maps a rejected request onto an error result instead of
+          // throwing, so leaving the row in place depends on reading it.
+          if (result.status === 'error') {
+            this.hosting.error = `Could not unpublish ${hostOf(
+              publishedRealmURL,
+            )}: ${result.error || 'unknown error'}`;
+            return;
+          }
+          await this.reloadPublishedSites();
         } finally {
           this.unpublishing.delete(publishedRealmURL);
         }
@@ -3477,6 +3554,14 @@ export class Workspace extends CardDef {
 
     get unpublishBusy() {
       return this.unpublishTask.isRunning;
+    }
+
+    // Either mutation blocks both controls: Republish acts on the whole list,
+    // so republishing a destination that is mid-unpublish would put the site
+    // back up. Matches the host submode's modal, which disables its publish
+    // controls whenever an unpublish is running.
+    get hostingBusy() {
+      return this.publishBusy || this.unpublishBusy;
     }
 
     <template>
@@ -3737,6 +3822,17 @@ export class Workspace extends CardDef {
               </div>
               <div class='setting-control'><@fields.workspace /></div>
             </div>
+            {{#if this.hostingError}}
+              <div class='setting'>
+                <div class='setting-text'>
+                  <span class='setting-label'>Hosting</span>
+                  <p
+                    class='setting-help hosting-error'
+                    data-test-hosting-error
+                  >{{this.hostingError}}</p>
+                </div>
+              </div>
+            {{/if}}
             {{#if this.publishedSites.length}}
               {{#each this.publishedSites as |site|}}
                 <div class='setting'>
@@ -3752,7 +3848,7 @@ export class Workspace extends CardDef {
                     <button
                       type='button'
                       class='publish-btn unpublish-btn'
-                      disabled={{this.unpublishBusy}}
+                      disabled={{this.hostingBusy}}
                       data-test-unpublish-site={{site.url}}
                       {{on 'click' (this.unpublish site.url)}}
                     >{{if
@@ -3773,7 +3869,8 @@ export class Workspace extends CardDef {
                   <button
                     type='button'
                     class='publish-btn'
-                    disabled={{this.publishBusy}}
+                    disabled={{this.hostingBusy}}
+                    data-test-republish
                     {{on 'click' this.republish}}
                   >{{if this.publishBusy 'Publishing…' 'Republish'}}</button>
                 </div>
@@ -3782,8 +3879,8 @@ export class Workspace extends CardDef {
               <div class='setting'>
                 <div class='setting-text'>
                   <span class='setting-label'>Publishing</span>
-                  <p class='setting-help'>Not published. Use Publish in the
-                    Host submode toolbar to put this space on the web.</p>
+                  <p class='setting-help'>Not published. Use Publish in the Host
+                    submode toolbar to put this space on the web.</p>
                 </div>
               </div>
             {{else}}
@@ -4004,6 +4101,9 @@ export class Workspace extends CardDef {
         }
         .unpublish-btn:hover:not(:disabled) {
           border-color: var(--grid-broken);
+          color: var(--grid-broken);
+        }
+        .hosting-error {
           color: var(--grid-broken);
         }
         .choice-opt:focus-visible,

--- a/packages/host/tests/acceptance/workspace-hosting-test.gts
+++ b/packages/host/tests/acceptance/workspace-hosting-test.gts
@@ -1,0 +1,148 @@
+import { click, waitFor, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import {
+  realmConfigCardJSON,
+  setupAcceptanceTestRealm,
+  setupLocalIndexing,
+  setupRealmCacheTeardown,
+  setupUserSubscription,
+  testRealmInfo,
+  testRealmURL,
+  visitOperatorMode,
+} from '../helpers';
+import { setupBaseRealm } from '../helpers/base-realm';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+// The Workspace edit format drives hosting through the registered
+// publish-realm / unpublish-realm host tools, imported from card code as
+// `@cardstack/boxel-host/tools/*`. These tests are the end-to-end check on that
+// wiring: a click in a base-realm card has to reach the realm-server service.
+const publishedRealmURL = 'https://testuser.localhost/published-workspace/';
+
+const workspaceIndex = {
+  data: {
+    type: 'card',
+    meta: {
+      adoptsFrom: {
+        module: '@cardstack/base/workspace',
+        name: 'Workspace',
+      },
+    },
+  },
+};
+
+module('Acceptance | workspace hosting', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupRealmCacheTeardown(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+  });
+
+  setupBaseRealm(hooks);
+
+  let publishCalls: { sourceRealmURL: string; publishedRealmURL: string }[];
+  let unpublishCalls: string[];
+
+  hooks.beforeEach(async function () {
+    setupUserSubscription();
+    publishCalls = [];
+    unpublishCalls = [];
+
+    let { realm } = await setupAcceptanceTestRealm({
+      realmURL: testRealmURL,
+      mockMatrixUtils,
+      permissions: {
+        '@testuser:localhost': ['read', 'write', 'realm-owner'],
+      },
+      contents: {
+        'realm.json': realmConfigCardJSON({ name: 'Hosted Workspace' }),
+        'index.json': workspaceIndex,
+      },
+    });
+
+    // `publishedSites` reads the card's own `meta.realmInfo`, which the realm
+    // injects at request time from the realm_registry publish rows. There are
+    // none in this harness, so serve the published state directly.
+    realm.getRealmInfo = async () => ({
+      ...testRealmInfo,
+      name: 'Hosted Workspace',
+      publishable: true,
+      lastPublishedAt: { [publishedRealmURL]: String(Date.now()) },
+    });
+
+    let realmServer = getService('realm-server');
+    realmServer.publishRealm = async (
+      sourceRealmURL: string,
+      publishedURL: string,
+    ) => {
+      publishCalls.push({ sourceRealmURL, publishedRealmURL: publishedURL });
+      return {
+        sourceRealmURL,
+        publishedRealmURL: publishedURL,
+        publishedRealmId: '1',
+        lastPublishedAt: String(Date.now()),
+        status: 'published',
+      };
+    };
+    realmServer.unpublishRealm = async (publishedURL: string) => {
+      unpublishCalls.push(publishedURL);
+      return {
+        sourceRealmURL: null,
+        publishedRealmURL: publishedURL,
+        lastPublishedAt: null,
+      };
+    };
+    // publish() polls readiness after the 202; nothing here depends on the
+    // wait, so report ready immediately.
+    realmServer.waitForRealmReady = async () => {};
+  });
+
+  async function visitWorkspaceSettings() {
+    await visitOperatorMode({
+      stacks: [[{ id: `${testRealmURL}index`, format: 'edit' }]],
+    });
+    await waitFor('.settings-title');
+  }
+
+  test('the hosting section lists each published site', async function (assert) {
+    await visitWorkspaceSettings();
+
+    assert
+      .dom(`[data-test-unpublish-site="${publishedRealmURL}"]`)
+      .exists('the published site offers an unpublish action')
+      .hasText('Unpublish');
+  });
+
+  test('Unpublish reaches the unpublish-realm tool', async function (assert) {
+    await visitWorkspaceSettings();
+
+    await click(`[data-test-unpublish-site="${publishedRealmURL}"]`);
+    await waitUntil(() => unpublishCalls.length > 0);
+
+    assert.deepEqual(
+      unpublishCalls,
+      [publishedRealmURL],
+      'the tool unpublished exactly the clicked destination',
+    );
+  });
+
+  test('Republish reaches the publish-realm tool', async function (assert) {
+    await visitWorkspaceSettings();
+
+    await click('.publish-btn:not(.unpublish-btn)');
+    await waitUntil(() => publishCalls.length > 0);
+
+    assert.deepEqual(
+      publishCalls,
+      [{ sourceRealmURL: testRealmURL, publishedRealmURL }],
+      'the tool republished the existing destination',
+    );
+  });
+});

--- a/packages/host/tests/acceptance/workspace-hosting-test.gts
+++ b/packages/host/tests/acceptance/workspace-hosting-test.gts
@@ -133,16 +133,94 @@ module('Acceptance | workspace hosting', function (hooks) {
     );
   });
 
+  test('a site that is unpublished stops being listed as live', async function (assert) {
+    await visitWorkspaceSettings();
+
+    await click(`[data-test-unpublish-site="${publishedRealmURL}"]`);
+
+    assert
+      .dom(`[data-test-unpublish-site="${publishedRealmURL}"]`)
+      .doesNotExist('the row for the unpublished destination is gone');
+    assert
+      .dom('[data-test-republish]')
+      .doesNotExist('Republish goes away with the last destination');
+    assert
+      .dom('[data-test-hosting-error]')
+      .doesNotExist('no error is reported');
+    assert
+      .dom('.settings')
+      .containsText(
+        'Not published',
+        'the section falls back to its not-published copy',
+      );
+  });
+
+  test('an unpublish the server rejects keeps the row and says so', async function (assert) {
+    let realmServer = getService('realm-server');
+    realmServer.unpublishRealm = async () => {
+      throw new Error('destination is locked');
+    };
+
+    await visitWorkspaceSettings();
+    await click(`[data-test-unpublish-site="${publishedRealmURL}"]`);
+
+    assert
+      .dom('[data-test-hosting-error]')
+      .hasText(
+        'Could not unpublish testuser.localhost: destination is locked',
+        'the failure the tool reported is surfaced',
+      );
+    assert
+      .dom(`[data-test-unpublish-site="${publishedRealmURL}"]`)
+      .exists('the site is still listed, because it is still published');
+  });
+
   test('Republish reaches the publish-realm tool', async function (assert) {
     await visitWorkspaceSettings();
 
-    await click('.publish-btn:not(.unpublish-btn)');
+    await click('[data-test-republish]');
     await waitUntil(() => publishCalls.length > 0);
 
     assert.deepEqual(
       publishCalls,
       [{ sourceRealmURL: testRealmURL, publishedRealmURL }],
       'the tool republished the existing destination',
+    );
+    assert
+      .dom(`[data-test-unpublish-site="${publishedRealmURL}"]`)
+      .exists('the destination is still listed after a republish');
+  });
+
+  test('either hosting action disables the other while it runs', async function (assert) {
+    let releaseUnpublish: (() => void) | undefined;
+    let realmServer = getService('realm-server');
+    let stalledUnpublish = realmServer.unpublishRealm;
+    realmServer.unpublishRealm = async (publishedURL: string) => {
+      await new Promise<void>((resolve) => (releaseUnpublish = resolve));
+      return stalledUnpublish.call(realmServer, publishedURL);
+    };
+
+    await visitWorkspaceSettings();
+
+    // Not awaited yet: the buttons have to be inspected while the request is
+    // still in flight, which is exactly what settling would wait past.
+    let clicked = click(`[data-test-unpublish-site="${publishedRealmURL}"]`);
+    await waitUntil(() => releaseUnpublish !== undefined);
+    await waitFor('[data-test-republish]:disabled');
+
+    assert
+      .dom('[data-test-republish]')
+      .isDisabled('Republish cannot put the site back mid-unpublish');
+    assert
+      .dom(`[data-test-unpublish-site="${publishedRealmURL}"]`)
+      .isDisabled('the in-flight destination cannot be unpublished twice');
+
+    releaseUnpublish!();
+    await clicked;
+    assert.deepEqual(
+      unpublishCalls,
+      [publishedRealmURL],
+      'the unpublish completed once released',
     );
   });
 });

--- a/packages/host/tests/integration/modifiers/persist-scroll-position-test.gts
+++ b/packages/host/tests/integration/modifiers/persist-scroll-position-test.gts
@@ -18,20 +18,6 @@ async function waitForScrollTop(el: HTMLElement, expected: number) {
   }
 }
 
-// Assigning `scrollTop` queues a *native* scroll event that the browser
-// dispatches on a later rendering update, not before the assignment returns —
-// and `settled()` doesn't await it. Pump real frames so that event lands while
-// the state it was produced under still holds. Without this, a scroll queued
-// before a gesture can be delivered after it, and the modifier reads the live
-// offset at delivery time, so it reads as user scrolling to wherever the
-// element has since been moved.
-async function drainNativeScrollEvents() {
-  for (let i = 0; i < 2; i++) {
-    // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- test must await the browser's own scroll-event dispatch
-    await new Promise((resolve) => requestAnimationFrame(resolve));
-  }
-}
-
 module('Integration | modifier | persist-scroll-position', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -137,12 +123,9 @@ module('Integration | modifier | persist-scroll-position', function (hooks) {
     let scroller = document.querySelector('.scroller') as HTMLElement;
 
     // A scroll with no preceding gesture (a programmatic move or a layout
-    // reset) must not be recorded — including the browser's own event for this
-    // write, which has to be drained here rather than left to arrive after the
-    // gesture below.
+    // reset) must not be recorded.
     scroller.scrollTop = 90;
     await triggerEvent(scroller, 'scroll');
-    await drainNativeScrollEvents();
     assert.deepEqual(recorded, [], 'a gesture-less scroll is ignored');
 
     // After a real gesture, the user's scrolling is recorded. (A single move
@@ -151,7 +134,6 @@ module('Integration | modifier | persist-scroll-position', function (hooks) {
     await triggerEvent(scroller, 'wheel');
     scroller.scrollTop = 120;
     await triggerEvent(scroller, 'scroll');
-    await drainNativeScrollEvents();
     let recordedOnlyTheUserOffset =
       recorded.length >= 1 && recorded.every((v) => v === 120);
     assert.ok(

--- a/packages/host/tests/integration/modifiers/persist-scroll-position-test.gts
+++ b/packages/host/tests/integration/modifiers/persist-scroll-position-test.gts
@@ -18,6 +18,20 @@ async function waitForScrollTop(el: HTMLElement, expected: number) {
   }
 }
 
+// Assigning `scrollTop` queues a *native* scroll event that the browser
+// dispatches on a later rendering update, not before the assignment returns —
+// and `settled()` doesn't await it. Pump real frames so that event lands while
+// the state it was produced under still holds. Without this, a scroll queued
+// before a gesture can be delivered after it, and the modifier reads the live
+// offset at delivery time, so it reads as user scrolling to wherever the
+// element has since been moved.
+async function drainNativeScrollEvents() {
+  for (let i = 0; i < 2; i++) {
+    // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- test must await the browser's own scroll-event dispatch
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+  }
+}
+
 module('Integration | modifier | persist-scroll-position', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -123,9 +137,12 @@ module('Integration | modifier | persist-scroll-position', function (hooks) {
     let scroller = document.querySelector('.scroller') as HTMLElement;
 
     // A scroll with no preceding gesture (a programmatic move or a layout
-    // reset) must not be recorded.
+    // reset) must not be recorded — including the browser's own event for this
+    // write, which has to be drained here rather than left to arrive after the
+    // gesture below.
     scroller.scrollTop = 90;
     await triggerEvent(scroller, 'scroll');
+    await drainNativeScrollEvents();
     assert.deepEqual(recorded, [], 'a gesture-less scroll is ignored');
 
     // After a real gesture, the user's scrolling is recorded. (A single move
@@ -134,6 +151,7 @@ module('Integration | modifier | persist-scroll-position', function (hooks) {
     await triggerEvent(scroller, 'wheel');
     scroller.scrollTop = 120;
     await triggerEvent(scroller, 'scroll');
+    await drainNativeScrollEvents();
     let recordedOnlyTheUserOffset =
       recorded.length >= 1 && recorded.every((v) => v === 120);
     assert.ok(


### PR DESCRIPTION
## What

The hosting section of the Workspace edit format could republish an existing destination but had no way to take one down. Each published site now carries an Unpublish button backed by the registered `unpublish-realm` host tool, invoked with a typed `UnpublishRealmInput` exactly like the existing republish path.

Both mutations report what they actually got back. Neither tool signals failure by rejecting: `UnpublishRealmTool` maps a rejected request onto `UnpublishRealmResult({ status: 'error', error })`, and publish reports per-destination outcomes as `PublishTargetResult`s — so an action that didn't happen is only visible to a caller that inspects the result, and previously nothing did.

- **On success**, the list is re-read through the registered `get-published-realms` tool, which reports the `RealmService` state both mutations write through (`RealmResource.unpublish` deletes the key; `RealmResource.publish` merges fresh timestamps). `meta.realmInfo` remains the initial view — it is a snapshot taken when the card was (de)serialized, and unpublish triggers no reindex, so nothing would otherwise rebuild it in-session and an unpublished site would keep being listed as live until the card was reloaded.
- **On failure**, the row stays and the reason is rendered. This is where re-reading beats optimistic removal: an unpublish the server rejects leaves the list exactly as it was.

Republish and Unpublish also disable each other while either runs. Republish acts on the whole list, so republishing a destination that was mid-unpublish would put the site back up — the same race the host submode's modal closes with `isUnpublishingAnyRealms`.

Two smaller corrections alongside it:

- The local binding for the publish tool is renamed to its post-rename export name, `PublishRealmTool` (the module's default export; `PublishRealmCommand` survives only as a back-compat alias).
- The not-yet-published help text said "Use Publish in the workspace menu". There is no workspace-menu publish item — `data-test-publish-realm-button` lives in the Host submode top bar, so the text now points there.

Hosting state lives in a `TrackedObject` bag (`{ sites, error }`) and the in-flight row in a `TrackedSet`, rather than `@tracked` fields: the edit format is a class *expression*, where decorators are rejected (`TS1206`), which is why that class carries no tracked fields today. The task's own `isRunning` is true for every row at once, so it can't label just the row being unpublished.

## Why this needed verifying, not just reading

`workspace.gts` is currently the only card-side importer of a host tool, so `@cardstack/boxel-host/tools/*` from base-realm card code had no prior traffic. Two things had to hold, and one of them was not obvious:

**Runtime.** These specifiers are not a package export. They resolve because `shimHostTools` registers the tool modules on the loader's virtual network, and `shimExternals` (called by the `network` service) runs that — which is what makes them available in operator mode *and* under prerender.

**Types.** `packages/base/types/@cardstack/boxel-host/index.d.ts` declares the wildcard as:

```ts
declare module '@cardstack/boxel-host/tools/*' { const mod: any; export default mod }
```

Had that ambient declaration won over the tsconfig `paths` mapping, the import would be `any`, the tool construction would be entirely unchecked, and "no `as any` at the call site" would mean nothing. It does not win under the host's project — probing with a deliberate bad member access reports `Property '__nope__' does not exist on type 'typeof PublishRealmTool'`, and likewise for `UnpublishRealmTool`. Both imports carry their real types.

It *does* win elsewhere, which is worth recording: `packages/base` is also compiled by `packages/realm-server`'s project (`lint:types`, part of the Lint job), whose tsconfig has no such `paths` entry. There the tools resolve to the ambient `any`, so the two result callbacks are annotated explicitly rather than left to inference — otherwise `noImplicitAny` fails there while the host project stays clean.

## Test plan

`Acceptance | workspace hosting` (6 tests, 14 assertions): renders a realm whose index card is a `Workspace` in edit format, then pins the hop this change is about — base-realm card code → shimmed tool module → `RealmService` → realm-server — end to end in the app.

- Republish reaches `realm-server.publishRealm` and Unpublish reaches `realm-server.unpublishRealm` with exactly the clicked destination.
- A successful unpublish drops the row, takes Republish with the last destination, reports no error, and falls back to the not-published copy.
- An unpublish the server rejects keeps the row and renders the reported reason.
- A republish leaves the destination listed.
- While an unpublish is in flight, Republish and the row's own button are both disabled — asserted mid-flight against a stub that blocks on a promise the test releases, rather than after settling.

Shard 5 of an earlier run failed on `Integration | modifier | persist-scroll-position: records the offset only after a genuine user scroll gesture`, unrelated to this work. That flake is already fixed on `main` by #5607, which this branch now has merged in; no change to that test is carried here.

Local verification: `ember-tsc --noEmit` clean for both the host and realm-server projects; eslint, ember-template-lint, and prettier clean on the changed files; `Integration | Card | workspace` 19/19.

The realm-server's own `_unpublish-realm` HTTP handler is stubbed at the service boundary, matching the existing host-submode publish tests; it has its own realm-server coverage. A live publish→unpublish round trip wasn't possible in this dev stack — no realm is published locally, and host submode never finished loading for an unpublished dev realm (a CardsGrid-index realm hangs identically, so that is environmental rather than anything to do with the Workspace card).

Note: this touches `packages/base/workspace.gts`, as does #5610, in a different region of the file — whichever lands second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
