### PR TITLE
Drop qunit-testing.md from the pending boxel references

### DIFF
--- a/packages/software-factory/src/factory-skill-loader.ts
+++ b/packages/software-factory/src/factory-skill-loader.ts
@@ -165,7 +165,7 @@ export const ALWAYS_LOAD_REFERENCES: readonly string[] = [
  * and the validation test uses this set strictly: once a name ships in the
  * built skill, the test fails until it is removed from here.
  */
-export const PENDING_BOXEL_REFERENCES: readonly string[] = ['qunit-testing.md'];
+export const PENDING_BOXEL_REFERENCES: readonly string[] = [];
 
 // ---------------------------------------------------------------------------
 // Internal types for tracking reference metadata

--- a/packages/software-factory/tests/factory-skill-loader.test.ts
+++ b/packages/software-factory/tests/factory-skill-loader.test.ts
@@ -1006,12 +1006,15 @@ module('factory-skill-loader > curated boxel references', function () {
   test('pending references are still pending', function (assert) {
     // Strict on purpose: once a pending name ships in the built skill,
     // remove it from PENDING_BOXEL_REFERENCES (and any transitional notes
-    // that reference it).
-    for (let name of PENDING_BOXEL_REFERENCES) {
-      assert.false(
+    // that reference it). Asserted as one comparison over the whole set so
+    // the test still carries an assertion when nothing is pending, and names
+    // every offender at once when something is.
+    assert.deepEqual(
+      PENDING_BOXEL_REFERENCES.filter((name) =>
         existsSync(join(builtRefsDir, name)),
-        `${name} has shipped in the built boxel skill — remove it from PENDING_BOXEL_REFERENCES`,
-      );
-    }
+      ),
+      [],
+      'no pending reference has shipped in the built boxel skill yet — once one does, remove it from PENDING_BOXEL_REFERENCES',
+    );
   });
 });


### PR DESCRIPTION
## What

`Software Factory Tests (shard 1/3)` is red on `main`, and has been since `qunit-testing.md` landed in the built boxel skill:

```
not ok 131 factory-skill-loader > curated boxel references > pending references are still pending
  message: qunit-testing.md has shipped in the built boxel skill — remove it from PENDING_BOXEL_REFERENCES
```

`PENDING_BOXEL_REFERENCES` lists curated reference names that have **not** shipped yet, and the guard test is strict by design: a name that ships fails the test until it's removed. `packages/boxel-cli/plugin/skills/boxel/references/qunit-testing.md` is present, so the list empties.

Nothing changes at runtime — the list is test-only bookkeeping (`filterBoxelRefs` already filters to what's on disk), and `qunit-testing.md` stays in `ALWAYS_LOAD_REFERENCES`, where the sibling test now asserts it resolves.

## The guard test needed a small change too

It asserted once per pending name, so with the list empty it would have asserted nothing — passing whether or not the mechanism still worked. It now compares the shipped subset against an empty array: one assertion either way, and it names every offender at once rather than one per iteration when the list refills.

## Test plan

`node tests/index.ts` in `packages/software-factory`: 474 passing, up from 473, with `pending references are still pending` and `every curated reference name resolves in the built boxel skill` both green. `ember-tsc --noEmit`, eslint, and prettier clean.

One unrelated failure reproduces locally and is untouched here: `port-allocator > IPv4 holder blocks a default (dual-stack) bind on the same port` fails on macOS but passes on Linux CI (shard 1 reported exactly one failure, the skill-loader one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
