### PR TITLE
Refresh the realm list when a realm is created outside the session

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -8,6 +8,7 @@ import { isTesting } from '@embroider/macros';
 import { cached, tracked } from '@glimmer/tracking';
 
 import {
+  didCancel,
   dropTask,
   rawTimeout,
   restartableTask,
@@ -218,12 +219,6 @@ export default class MatrixService extends Service {
   // gains content at runtime. Login-related side effects (`loginToRealms`,
   // `loadMoreAuthRooms`) still run regardless.
   private trustedRealmServersAuthoritative = false;
-  // The trusted server list backing the authoritative assembly, kept
-  // current by boot and by the realm-servers listener. Needed at
-  // `app.boxel.realms` event time: a realm created mid-session announces
-  // itself only through that legacy event, and re-running the trusted
-  // assembly requires the server list.
-  private trustedRealmServers: string[] = [];
   // Sticky for the lifetime of this instance once a boot assembles from the
   // legacy `app.boxel.realms` list. Keeps later start() calls on the legacy
   // path even after the lazy migration writes `app.boxel.realm-servers`, so
@@ -480,12 +475,14 @@ export default class MatrixService extends Service {
                 // like the realm-servers listener: a reconcile failure must
                 // not crash the app from an async event handler.
                 try {
-                  await this.reconcileRealmsWithAnnouncedList(legacyRealms);
+                  await this.reconcileRealmsTask.perform(legacyRealms);
                 } catch (err) {
-                  console.error(
-                    'Failed to reconcile realms after app.boxel.realms account-data event',
-                    err,
-                  );
+                  if (!didCancel(err)) {
+                    console.error(
+                      'Failed to reconcile realms after app.boxel.realms account-data event',
+                      err,
+                    );
+                  }
                 }
               }
               // Only do this after we've completed our overall login
@@ -510,9 +507,6 @@ export default class MatrixService extends Service {
               }
               let realmServers = e.event.content.realmServers as string[];
               this.trustedRealmServersAuthoritative = realmServers.length > 0;
-              if (this.trustedRealmServersAuthoritative) {
-                this.trustedRealmServers = realmServers;
-              }
               if (this.trustedRealmServersAuthoritative) {
                 // A server-pushed account-data event must not crash the app:
                 // assembly can reject (e.g. fetchUserRealmsFromTrustedServers
@@ -1104,9 +1098,6 @@ export default class MatrixService extends Service {
         // this flag here makes that re-emission a no-op for the available-
         // realms list — the realm-servers path is the authoritative source.
         this.trustedRealmServersAuthoritative = useTrustedServers;
-        if (useTrustedServers) {
-          this.trustedRealmServers = trustedServers;
-        }
         let userRealmURLs: string[];
         if (useTrustedServers) {
           if (isTesting())
@@ -1404,7 +1395,13 @@ export default class MatrixService extends Service {
   //   advertises is dropped on the first pass. If the announced list
   //   still disagrees after the budget, the trusted result stands — the
   //   next signal or boot converges it.
-  async reconcileRealmsWithAnnouncedList(announced: string[]): Promise<void> {
+  //
+  // Restartable on purpose: a newer signal supersedes an in-flight
+  // reconcile (its retry waits are cancelled and the latest announced
+  // list wins), so back-to-back realm creations coalesce instead of
+  // interleaving assemblies — and destroying the service cancels any
+  // pending retry outright.
+  reconcileRealmsTask = restartableTask(async (announced: string[]) => {
     let announcedSet = new Set(announced.map((u) => ensureTrailingSlash(u)));
     let currentSet = () =>
       new Set<string>(
@@ -1420,13 +1417,17 @@ export default class MatrixService extends Service {
     if (setsEqual(announcedSet, currentSet())) {
       return;
     }
-    await this.applyTrustedRealmServersAccountData(this.trustedRealmServers);
+    let trustedServers = await this.getRealmServersFromAccountData();
+    if (trustedServers.length === 0) {
+      return;
+    }
+    await this.applyTrustedRealmServersAccountData(trustedServers);
     for (let delayMs of MatrixService.RECONCILE_CATCHUP_DELAYS_MS) {
       if (missingAnnounced().length === 0) {
         return;
       }
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-      await this.applyTrustedRealmServersAccountData(this.trustedRealmServers);
+      await timeout(delayMs);
+      await this.applyTrustedRealmServersAccountData(trustedServers);
     }
     let missing = missingAnnounced();
     if (missing.length > 0) {
@@ -1434,7 +1435,7 @@ export default class MatrixService extends Service {
         `Announced realm(s) still absent from the trusted-servers assembly after retries: ${missing.join(', ')} — keeping the trusted result`,
       );
     }
-  }
+  });
 
   // Re-assemble the available-realms list from a runtime
   // `app.boxel.realm-servers` account-data event. Unlike the fail-loud boot
@@ -2218,7 +2219,6 @@ export default class MatrixService extends Service {
     }
     this.setPostLoginCompleted(false, 'resetState');
     this.bootedFromLegacyRealmsList = false;
-    this.trustedRealmServers = [];
     this._isLoadingMoreAIRooms = false;
     this.messagesToSend.clear();
     this.cardsToSend.clear();

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -516,7 +516,7 @@ export default class MatrixService extends Service {
                 // start(); here we log and leave the available-realms list as
                 // it was.
                 try {
-                  await this.applyTrustedRealmServersAccountData(realmServers);
+                  await this.assembleRealmsFromTrustedServers(realmServers);
                 } catch (err) {
                   console.error(
                     'Failed to assemble realms from trusted servers in app.boxel.realm-servers account data',
@@ -1409,11 +1409,15 @@ export default class MatrixService extends Service {
     if (trustedServers.length === 0) {
       return;
     }
-    await this.applyTrustedRealmServersAccountData(trustedServers);
+    await this.assembleRealmsFromTrustedServers(trustedServers);
   });
 
-  // Re-assemble the available-realms list from a runtime
-  // `app.boxel.realm-servers` account-data event. Unlike the fail-loud boot
+  // The one procedure that builds the available-realms list: ask each
+  // trusted realm server via `_realm-auth` which realms this user has
+  // (the answer carries the realm URLs AND a JWT per realm), then
+  // replace the user entries and log in. Boot runs this, the
+  // `app.boxel.realm-servers` listener runs it, and the reconcile task
+  // re-runs it when a change signal arrives. Unlike the fail-loud boot
   // assembly, an event-time refresh must be conservative: because
   // `fetchUserRealmsFromTrustedServers` now returns a partial list when a
   // trusted server is unreachable (rather than throwing), replacing the list
@@ -1422,7 +1426,7 @@ export default class MatrixService extends Service {
   // merge (add newly-discovered realms, never remove) and let the retry
   // reconcile; only a fully reachable assembly is authoritative enough to
   // remove realms. Called by the AccountData listener and directly by tests.
-  async applyTrustedRealmServersAccountData(realmServers: string[]) {
+  async assembleRealmsFromTrustedServers(realmServers: string[]) {
     let realmURLs =
       await this.realmServer.fetchUserRealmsFromTrustedServers(realmServers);
     if (this.realmServer.unreachableRealmServers.length > 0) {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1430,7 +1430,6 @@ export default class MatrixService extends Service {
   reconcileRealmsTask = restartableTask(async (announced: string[]) => {
     let announcedSet = new Set(announced.map((u) => ensureTrailingSlash(u)));
     let previous = this.lastAnnouncedRealms;
-    this.lastAnnouncedRealms = announcedSet;
     if (
       previous !== undefined &&
       previous.size === announcedSet.size &&
@@ -1443,6 +1442,13 @@ export default class MatrixService extends Service {
       return;
     }
     await this.assembleRealmsFromTrustedServers(trustedServers);
+    // Committed only after the assembly lands: this task is restartable,
+    // so a redelivery of the SAME content could cancel a run mid-await.
+    // Recording the baseline up front would let that superseded run mark
+    // the change as seen without ever applying it; recording it here means
+    // a cancelled (or thrown, or no-trusted-servers) run leaves the
+    // baseline untouched and the next signal retries.
+    this.lastAnnouncedRealms = announcedSet;
   });
 
   // The one procedure that builds the available-realms list: ask each
@@ -2231,6 +2237,10 @@ export default class MatrixService extends Service {
     }
     this.setPostLoginCompleted(false, 'resetState');
     this.bootedFromLegacyRealmsList = false;
+    // This service outlives the session, so owner-destruction cancellation
+    // never fires at logout — cancel explicitly or an in-flight reconcile
+    // resumes after the reset and writes the previous user's realms back.
+    this.reconcileRealmsTask.cancelAll();
     this.lastAnnouncedRealms = undefined;
     this._isLoadingMoreAIRooms = false;
     this.messagesToSend.clear();

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -217,6 +217,12 @@ export default class MatrixService extends Service {
   // gains content at runtime. Login-related side effects (`loginToRealms`,
   // `loadMoreAuthRooms`) still run regardless.
   private trustedRealmServersAuthoritative = false;
+  // The trusted server list backing the authoritative assembly, kept
+  // current by boot and by the realm-servers listener. Needed at
+  // `app.boxel.realms` event time: a realm created mid-session announces
+  // itself only through that legacy event, and re-running the trusted
+  // assembly requires the server list.
+  private trustedRealmServers: string[] = [];
   // Sticky for the lifetime of this instance once a boot assembles from the
   // legacy `app.boxel.realms` list. Keeps later start() calls on the legacy
   // path even after the lazy migration writes `app.boxel.realm-servers`, so
@@ -458,6 +464,35 @@ export default class MatrixService extends Service {
                 await this.realmServer.setAvailableRealmIdentifiers(
                   legacyRealms.map(ri),
                 );
+              } else if (
+                legacyRealms.some(
+                  (url) =>
+                    !this.realmServer.availableRealmIdentifiers.includes(
+                      ri(url),
+                    ),
+                )
+              ) {
+                // A realm created mid-session (boxel-cli, the software
+                // factory, another tab) announces itself ONLY through this
+                // legacy event — `app.boxel.realm-servers` doesn't change
+                // when a realm is added to an already-trusted server. An
+                // event naming a realm we don't have yet is that signal:
+                // re-run the authoritative assembly so the workspace
+                // chooser picks it up without a reload. Initial-sync echoes
+                // carry no new URLs and stay no-ops, preserving the
+                // don't-clobber-boot guarantee above. Best-effort, like the
+                // realm-servers listener: assembly failure must not crash
+                // the app from an async event handler.
+                try {
+                  await this.applyTrustedRealmServersAccountData(
+                    this.trustedRealmServers,
+                  );
+                } catch (err) {
+                  console.error(
+                    'Failed to refresh realms after app.boxel.realms account-data event',
+                    err,
+                  );
+                }
               }
               // Only do this after we've completed our overall login
               if (this.session.isAuthenticated) {
@@ -481,6 +516,9 @@ export default class MatrixService extends Service {
               }
               let realmServers = e.event.content.realmServers as string[];
               this.trustedRealmServersAuthoritative = realmServers.length > 0;
+              if (this.trustedRealmServersAuthoritative) {
+                this.trustedRealmServers = realmServers;
+              }
               if (this.trustedRealmServersAuthoritative) {
                 // A server-pushed account-data event must not crash the app:
                 // assembly can reject (e.g. fetchUserRealmsFromTrustedServers
@@ -1072,6 +1110,9 @@ export default class MatrixService extends Service {
         // this flag here makes that re-emission a no-op for the available-
         // realms list — the realm-servers path is the authoritative source.
         this.trustedRealmServersAuthoritative = useTrustedServers;
+        if (useTrustedServers) {
+          this.trustedRealmServers = trustedServers;
+        }
         let userRealmURLs: string[];
         if (useTrustedServers) {
           if (isTesting())
@@ -2131,6 +2172,7 @@ export default class MatrixService extends Service {
     }
     this.setPostLoginCompleted(false, 'resetState');
     this.bootedFromLegacyRealmsList = false;
+    this.trustedRealmServers = [];
     this._isLoadingMoreAIRooms = false;
     this.messagesToSend.clear();
     this.cardsToSend.clear();

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -38,6 +38,7 @@ import {
   submissionBotUsername,
   logger,
   Deferred,
+  ensureTrailingSlash,
   ri,
   SEARCH_MARKER,
   REPLACE_MARKER,
@@ -464,32 +465,25 @@ export default class MatrixService extends Service {
                 await this.realmServer.setAvailableRealmIdentifiers(
                   legacyRealms.map(ri),
                 );
-              } else if (
-                legacyRealms.some(
-                  (url) =>
-                    !this.realmServer.availableRealmIdentifiers.includes(
-                      ri(url),
-                    ),
-                )
-              ) {
-                // A realm created mid-session (boxel-cli, the software
-                // factory, another tab) announces itself ONLY through this
-                // legacy event — `app.boxel.realm-servers` doesn't change
-                // when a realm is added to an already-trusted server. An
-                // event naming a realm we don't have yet is that signal:
-                // re-run the authoritative assembly so the workspace
-                // chooser picks it up without a reload. Initial-sync echoes
-                // carry no new URLs and stay no-ops, preserving the
-                // don't-clobber-boot guarantee above. Best-effort, like the
-                // realm-servers listener: assembly failure must not crash
-                // the app from an async event handler.
+              } else {
+                // Under the trusted-servers assembly this key is demoted
+                // from STATE to CHANGE SIGNAL: its payload is never applied
+                // to the available-realms list (only the authoritative
+                // assembly writes that), but the event is the one live
+                // signal that the user's realm membership changed — the
+                // realm server updates `app.boxel.realms` on membership
+                // changes (e.g. a realm created from boxel-cli, the
+                // software factory, or another tab), while
+                // `app.boxel.realm-servers` doesn't change when the server
+                // was already trusted. Do not remove the server-side write
+                // of this key without replacing this signal. Best-effort,
+                // like the realm-servers listener: a reconcile failure must
+                // not crash the app from an async event handler.
                 try {
-                  await this.applyTrustedRealmServersAccountData(
-                    this.trustedRealmServers,
-                  );
+                  await this.reconcileRealmsWithAnnouncedList(legacyRealms);
                 } catch (err) {
                   console.error(
-                    'Failed to refresh realms after app.boxel.realms account-data event',
+                    'Failed to reconcile realms after app.boxel.realms account-data event',
                     err,
                   );
                 }
@@ -1388,6 +1382,58 @@ export default class MatrixService extends Service {
         }
       }),
     );
+  }
+
+  // How long to wait between catch-up attempts when a change signal
+  // announces a realm that `_realm-auth` doesn't return yet (the realm
+  // server appends to `app.boxel.realms` after creating the realm, but
+  // the enumeration can lag the account-data write).
+  private static RECONCILE_CATCHUP_DELAYS_MS = [1_000, 3_000];
+
+  // Bring the available-realms list back in line with server truth after
+  // an `app.boxel.realms` change signal. The announced list is used only
+  // to DECIDE — never applied as state:
+  //
+  // - announced set equals the current user-realm set → an initial-sync
+  //   echo; no-op. This is what preserves the boot assembly.
+  // - sets differ (in either direction — additions AND removals) → re-run
+  //   the authoritative trusted-servers assembly.
+  // - an announced realm is still missing after assembly → `_realm-auth`
+  //   lagged the signal; retry on a short bounded backoff. Removals need
+  //   no retry: the assembly is authoritative, so anything it no longer
+  //   advertises is dropped on the first pass. If the announced list
+  //   still disagrees after the budget, the trusted result stands — the
+  //   next signal or boot converges it.
+  async reconcileRealmsWithAnnouncedList(announced: string[]): Promise<void> {
+    let announcedSet = new Set(announced.map((u) => ensureTrailingSlash(u)));
+    let currentSet = () =>
+      new Set<string>(
+        this.realmServer.userRealmIdentifiers.map((u) =>
+          ensureTrailingSlash(u),
+        ),
+      );
+    let setsEqual = (a: Set<string>, b: Set<string>) =>
+      a.size === b.size && [...a].every((x) => b.has(x));
+    let missingAnnounced = () =>
+      [...announcedSet].filter((u) => !currentSet().has(u));
+
+    if (setsEqual(announcedSet, currentSet())) {
+      return;
+    }
+    await this.applyTrustedRealmServersAccountData(this.trustedRealmServers);
+    for (let delayMs of MatrixService.RECONCILE_CATCHUP_DELAYS_MS) {
+      if (missingAnnounced().length === 0) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      await this.applyTrustedRealmServersAccountData(this.trustedRealmServers);
+    }
+    let missing = missingAnnounced();
+    if (missing.length > 0) {
+      console.warn(
+        `Announced realm(s) still absent from the trusted-servers assembly after retries: ${missing.join(', ')} — keeping the trusted result`,
+      );
+    }
   }
 
   // Re-assemble the available-realms list from a runtime

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1375,12 +1375,6 @@ export default class MatrixService extends Service {
     );
   }
 
-  // How long to wait between catch-up attempts when a change signal
-  // announces a realm that `_realm-auth` doesn't return yet (the realm
-  // server appends to `app.boxel.realms` after creating the realm, but
-  // the enumeration can lag the account-data write).
-  private static RECONCILE_CATCHUP_DELAYS_MS = [1_000, 3_000];
-
   // Bring the available-realms list back in line with server truth after
   // an `app.boxel.realms` change signal. The announced list is used only
   // to DECIDE — never applied as state:
@@ -1388,33 +1382,27 @@ export default class MatrixService extends Service {
   // - announced set equals the current user-realm set → an initial-sync
   //   echo; no-op. This is what preserves the boot assembly.
   // - sets differ (in either direction — additions AND removals) → re-run
-  //   the authoritative trusted-servers assembly.
-  // - an announced realm is still missing after assembly → `_realm-auth`
-  //   lagged the signal; retry on a short bounded backoff. Removals need
-  //   no retry: the assembly is authoritative, so anything it no longer
-  //   advertises is dropped on the first pass. If the announced list
-  //   still disagrees after the budget, the trusted result stands — the
-  //   next signal or boot converges it.
+  //   the authoritative trusted-servers assembly, once.
+  //
+  // One pass is enough because the realm server commits the permission
+  // rows `_realm-auth` reads BEFORE it writes `app.boxel.realms` (see
+  // handle-upsert-realm-user-permission), and the event can't arrive
+  // before the write that caused it — so by signal time the enumeration
+  // is consistent. If that ordering is ever violated, the trusted result
+  // stands and the next signal or boot converges it.
   //
   // Restartable on purpose: a newer signal supersedes an in-flight
-  // reconcile (its retry waits are cancelled and the latest announced
-  // list wins), so back-to-back realm creations coalesce instead of
-  // interleaving assemblies — and destroying the service cancels any
-  // pending retry outright.
+  // reconcile with the latest announced list, and destroying the service
+  // cancels any run in progress.
   reconcileRealmsTask = restartableTask(async (announced: string[]) => {
     let announcedSet = new Set(announced.map((u) => ensureTrailingSlash(u)));
-    let currentSet = () =>
-      new Set<string>(
-        this.realmServer.userRealmIdentifiers.map((u) =>
-          ensureTrailingSlash(u),
-        ),
-      );
-    let setsEqual = (a: Set<string>, b: Set<string>) =>
-      a.size === b.size && [...a].every((x) => b.has(x));
-    let missingAnnounced = () =>
-      [...announcedSet].filter((u) => !currentSet().has(u));
-
-    if (setsEqual(announcedSet, currentSet())) {
+    let currentSet = new Set<string>(
+      this.realmServer.userRealmIdentifiers.map((u) => ensureTrailingSlash(u)),
+    );
+    let setsEqual =
+      announcedSet.size === currentSet.size &&
+      [...announcedSet].every((x) => currentSet.has(x));
+    if (setsEqual) {
       return;
     }
     let trustedServers = await this.getRealmServersFromAccountData();
@@ -1422,19 +1410,6 @@ export default class MatrixService extends Service {
       return;
     }
     await this.applyTrustedRealmServersAccountData(trustedServers);
-    for (let delayMs of MatrixService.RECONCILE_CATCHUP_DELAYS_MS) {
-      if (missingAnnounced().length === 0) {
-        return;
-      }
-      await timeout(delayMs);
-      await this.applyTrustedRealmServersAccountData(trustedServers);
-    }
-    let missing = missingAnnounced();
-    if (missing.length > 0) {
-      console.warn(
-        `Announced realm(s) still absent from the trusted-servers assembly after retries: ${missing.join(', ')} — keeping the trusted result`,
-      );
-    }
   });
 
   // Re-assemble the available-realms list from a runtime

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -460,6 +460,11 @@ export default class MatrixService extends Service {
                 await this.realmServer.setAvailableRealmIdentifiers(
                   legacyRealms.map(ri),
                 );
+                // Only do this after we've completed our overall login
+                if (this.session.isAuthenticated) {
+                  await this.loginToRealms();
+                  await this.loadMoreAuthRooms(legacyRealms);
+                }
               } else {
                 // Under the trusted-servers assembly this key is demoted
                 // from STATE to CHANGE SIGNAL: its payload is never applied
@@ -474,6 +479,11 @@ export default class MatrixService extends Service {
                 // of this key without replacing this signal. Best-effort,
                 // like the realm-servers listener: a reconcile failure must
                 // not crash the app from an async event handler.
+                // No login side effects here: when the reconcile decides
+                // a re-assembly is needed, assembleRealmsFromTrustedServers
+                // performs loginToRealms/loadMoreAuthRooms itself; when it
+                // decides the event is an echo, nothing changed and there
+                // is nothing to log in to.
                 try {
                   await this.reconcileRealmsTask.perform(legacyRealms);
                 } catch (err) {
@@ -484,11 +494,6 @@ export default class MatrixService extends Service {
                     );
                   }
                 }
-              }
-              // Only do this after we've completed our overall login
-              if (this.session.isAuthenticated) {
-                await this.loginToRealms();
-                await this.loadMoreAuthRooms(legacyRealms);
               }
               break;
             }
@@ -1106,6 +1111,23 @@ export default class MatrixService extends Service {
             await this.realmServer.fetchUserRealmsFromTrustedServers(
               trustedServers,
             );
+          // Seed echo detection: the initial sync re-emits the CURRENT
+          // `app.boxel.realms` content, and the reconcile must recognize
+          // that re-emission as an echo rather than a change.
+          try {
+            let legacyRealmsData = (await this.client.getAccountDataFromServer(
+              APP_BOXEL_REALMS_EVENT_TYPE,
+            )) as { realms: string[] } | null;
+            this.lastAnnouncedRealms = new Set(
+              (legacyRealmsData?.realms ?? []).map((u) =>
+                ensureTrailingSlash(u),
+              ),
+            );
+          } catch (err) {
+            // Unseeded means the first event reconciles once against boot
+            // state — harmless; the assembly is idempotent.
+            console.warn('Failed to seed app.boxel.realms echo baseline', err);
+          }
         } else {
           this.bootedFromLegacyRealmsList = true;
           if (isTesting())
@@ -1375,14 +1397,25 @@ export default class MatrixService extends Service {
     );
   }
 
+  // The `app.boxel.realms` set from the most recent signal (seeded at
+  // boot from account data). Echo detection compares announcement to
+  // PREVIOUS announcement — never to the assembled list, which can
+  // legitimately differ from the legacy key in steady state (the
+  // assembly may hold `_realm-auth`-granted realms the legacy list
+  // never contained; see appendRealmToAccountData). Comparing against
+  // the assembly would make every echo look like a change and re-fetch
+  // for nothing.
+  private lastAnnouncedRealms: Set<string> | undefined;
+
   // Bring the available-realms list back in line with server truth after
   // an `app.boxel.realms` change signal. The announced list is used only
   // to DECIDE — never applied as state:
   //
-  // - announced set equals the current user-realm set → an initial-sync
+  // - announcement equals the previous announcement → an initial-sync
   //   echo; no-op. This is what preserves the boot assembly.
-  // - sets differ (in either direction — additions AND removals) → re-run
-  //   the authoritative trusted-servers assembly, once.
+  // - announcement changed (in either direction — additions AND
+  //   removals) → re-run the authoritative trusted-servers assembly,
+  //   once.
   //
   // One pass is enough because the realm server commits the permission
   // rows `_realm-auth` reads BEFORE it writes `app.boxel.realms` (see
@@ -1396,13 +1429,13 @@ export default class MatrixService extends Service {
   // cancels any run in progress.
   reconcileRealmsTask = restartableTask(async (announced: string[]) => {
     let announcedSet = new Set(announced.map((u) => ensureTrailingSlash(u)));
-    let currentSet = new Set<string>(
-      this.realmServer.userRealmIdentifiers.map((u) => ensureTrailingSlash(u)),
-    );
-    let setsEqual =
-      announcedSet.size === currentSet.size &&
-      [...announcedSet].every((x) => currentSet.has(x));
-    if (setsEqual) {
+    let previous = this.lastAnnouncedRealms;
+    this.lastAnnouncedRealms = announcedSet;
+    if (
+      previous !== undefined &&
+      previous.size === announcedSet.size &&
+      [...announcedSet].every((x) => previous.has(x))
+    ) {
       return;
     }
     let trustedServers = await this.getRealmServersFromAccountData();
@@ -2198,6 +2231,7 @@ export default class MatrixService extends Service {
     }
     this.setPostLoginCompleted(false, 'resetState');
     this.bootedFromLegacyRealmsList = false;
+    this.lastAnnouncedRealms = undefined;
     this._isLoadingMoreAIRooms = false;
     this.messagesToSend.clear();
     this.cardsToSend.clear();

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -88,8 +88,8 @@ export {
 export { createJWT, testRealmSecretSeed } from './test-auth';
 export {
   registerRealmAuthSessionRoomEnsurer,
+  removeRealmPermissions,
   resetCatalogRealmURL,
-  setRealmArchived,
   setRealmAuthFailure,
   setupAuthEndpoints,
   setCatalogRealmURL,

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -89,6 +89,7 @@ export { createJWT, testRealmSecretSeed } from './test-auth';
 export {
   registerRealmAuthSessionRoomEnsurer,
   resetCatalogRealmURL,
+  setRealmArchived,
   setRealmAuthFailure,
   setupAuthEndpoints,
   setCatalogRealmURL,

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -773,6 +773,20 @@ export class MockClient implements ExtendedClient {
     }
   }
 
+  // Dispatch an AccountData event as if the homeserver pushed updated
+  // account data — e.g. a realm server appending a freshly-created realm
+  // to `app.boxel.realms` from outside this session (boxel-cli, the
+  // software factory, another tab). Keeps sdkOpts in sync for the known
+  // keys so later reads agree with what the event announced.
+  simulateAccountDataEvent(type: string, content: Record<string, any>) {
+    if (type === APP_BOXEL_REALMS_EVENT_TYPE) {
+      this.sdkOpts.activeRealms = (content as any).realms;
+    } else if (type === APP_BOXEL_REALM_SERVERS_EVENT_TYPE) {
+      this.sdkOpts.activeRealmServers = (content as any).realmServers;
+    }
+    this.emitEvent(new MatrixEvent({ type, content }));
+  }
+
   private emitLocalEchoUpdated(event: MatrixEvent, oldEventId?: string) {
     let handlers = this.listeners[this.sdk.RoomEvent.LocalEchoUpdated];
     if (handlers) {

--- a/packages/host/tests/helpers/mock-matrix/_utils.ts
+++ b/packages/host/tests/helpers/mock-matrix/_utils.ts
@@ -106,6 +106,10 @@ export class MockUtils {
     this.testState.sdk!.client!.simulateToDeviceEvent(type, content, sender);
   };
 
+  simulateAccountDataEvent = (type: string, content: Record<string, any>) => {
+    this.testState.sdk!.client!.simulateAccountDataEvent(type, content);
+  };
+
   setReadReceipt = (roomId: string, eventId: string, reader: string) => {
     return this.testState.sdk!.serverState.addReceiptEvent(
       roomId,

--- a/packages/host/tests/helpers/realm-server-mock/index.ts
+++ b/packages/host/tests/helpers/realm-server-mock/index.ts
@@ -87,21 +87,13 @@ export function setupAuthEndpoints(
   }
 }
 
-// Archive (or restore) a realm directly in the mock server state, so
-// external-lifecycle flows can be exercised without driving the archive
-// HTTP route: an archived realm is omitted from `_realm-auth` enumeration,
-// matching the real server.
-export function setRealmArchived(realmURL: string, archived: boolean) {
+// Drop a realm's permission rows from the mock server state, as deleting
+// the realm does on the real server: `_realm-auth` enumerates from the
+// permission rows, so a realm with none disappears from its answer.
+export function removeRealmPermissions(realmURL: string) {
   let network = getService('network') as NetworkService;
   let state = ensureRealmServerMockState(network);
-  let normalized = ensureTrailingSlash(realmURL);
-  if (archived) {
-    state.archivedRealms.set(normalized, {
-      archivedAt: new Date().toISOString(),
-    });
-  } else {
-    state.archivedRealms.delete(normalized);
-  }
+  state.realmPermissions.delete(ensureTrailingSlash(realmURL));
 }
 
 // Simulate a trusted realm server going unreachable (or recovering) at its

--- a/packages/host/tests/helpers/realm-server-mock/index.ts
+++ b/packages/host/tests/helpers/realm-server-mock/index.ts
@@ -87,6 +87,23 @@ export function setupAuthEndpoints(
   }
 }
 
+// Archive (or restore) a realm directly in the mock server state, so
+// external-lifecycle flows can be exercised without driving the archive
+// HTTP route: an archived realm is omitted from `_realm-auth` enumeration,
+// matching the real server.
+export function setRealmArchived(realmURL: string, archived: boolean) {
+  let network = getService('network') as NetworkService;
+  let state = ensureRealmServerMockState(network);
+  let normalized = ensureTrailingSlash(realmURL);
+  if (archived) {
+    state.archivedRealms.set(normalized, {
+      archivedAt: new Date().toISOString(),
+    });
+  } else {
+    state.archivedRealms.delete(normalized);
+  }
+}
+
 // Simulate a trusted realm server going unreachable (or recovering) at its
 // `_realm-auth` endpoint, so boot-assembly graceful-degradation and retry can
 // be exercised deterministically.

--- a/packages/host/tests/integration/matrix-service-boot-assembly-test.ts
+++ b/packages/host/tests/integration/matrix-service-boot-assembly-test.ts
@@ -1,9 +1,10 @@
-import type { RenderingTestContext } from '@ember/test-helpers';
+import { waitUntil, type RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm, ensureTrailingSlash, ri } from '@cardstack/runtime-common';
+import { APP_BOXEL_REALMS_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 
 import ENV from '@cardstack/host/config/environment';
 import type MatrixService from '@cardstack/host/services/matrix-service';
@@ -14,6 +15,7 @@ import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setRealmAuthFailure,
+  setupAuthEndpoints,
 } from '../helpers';
 
 import { setupBaseRealm } from '../helpers/base-realm';
@@ -145,6 +147,80 @@ module(
       assert.ok(
         realmServer.availableRealmIdentifiers.includes(ri(testRealmURL)),
         'testRealmURL from _realm-auth survives the legacy event',
+      );
+    });
+  },
+);
+
+// A realm created OUTSIDE this session (boxel-cli, the software factory,
+// another tab) announces itself only through the legacy `app.boxel.realms`
+// account-data event — `app.boxel.realm-servers` doesn't change when a
+// realm is added to an already-trusted server. When such an event names a
+// realm the session doesn't have, the trusted-servers assembly re-runs so
+// the workspace chooser picks the realm up without a reload; echoes that
+// carry no new realms stay no-ops (previous module).
+module(
+  'Integration | matrix-service | realm created mid-session appears without a reload',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupBaseRealm(hooks);
+    setupLocalIndexing(hooks);
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [],
+      activeRealmServers: [testRealmServerURL],
+    });
+
+    hooks.beforeEach(async function (this: RenderingTestContext) {
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {},
+        startMatrix: false,
+      });
+      let realmServer = getService('realm-server') as RealmServerService;
+      await realmServer.setAvailableRealmIdentifiers([]);
+      let matrixService = getService('matrix-service') as MatrixService;
+      await matrixService.ready;
+      await matrixService.start();
+    });
+
+    test('a legacy realms event naming a new realm re-runs the trusted assembly', async function (assert) {
+      let realmServer = getService('realm-server') as RealmServerService;
+      let newRealmURL = ensureTrailingSlash(
+        new URL('./new-workspace/', testRealmURL).href,
+      );
+      assert.ok(
+        realmServer.availableRealmIdentifiers.includes(ri(testRealmURL)),
+        'precondition: boot assembled the trusted-servers realm list',
+      );
+      assert.notOk(
+        realmServer.availableRealmIdentifiers.includes(ri(newRealmURL)),
+        'precondition: the new realm is not known yet',
+      );
+
+      // The realm now exists server-side: `_realm-auth` starts advertising
+      // it alongside the original realm…
+      setupAuthEndpoints({
+        [testRealmURL]: ['read', 'write'],
+        [newRealmURL]: ['read', 'write'],
+      });
+      // …and the realm server appends it to the user's `app.boxel.realms`
+      // account data, which matrix pushes to this session.
+      mockMatrixUtils.simulateAccountDataEvent(APP_BOXEL_REALMS_EVENT_TYPE, {
+        realms: [testRealmURL, newRealmURL],
+      });
+
+      await waitUntil(() =>
+        realmServer.availableRealmIdentifiers.includes(ri(newRealmURL)),
+      );
+      assert.ok(
+        realmServer.availableRealmIdentifiers.includes(ri(newRealmURL)),
+        'the new realm appears in the available list without a reload',
+      );
+      assert.ok(
+        realmServer.availableRealmIdentifiers.includes(ri(testRealmURL)),
+        'the original realm is still present',
       );
     });
   },

--- a/packages/host/tests/integration/matrix-service-boot-assembly-test.ts
+++ b/packages/host/tests/integration/matrix-service-boot-assembly-test.ts
@@ -14,6 +14,7 @@ import {
   testRealmURL,
   setupIntegrationTestRealm,
   setupLocalIndexing,
+  setRealmArchived,
   setRealmAuthFailure,
   setupAuthEndpoints,
 } from '../helpers';
@@ -185,7 +186,7 @@ module(
       await matrixService.start();
     });
 
-    test('a legacy realms event naming a new realm re-runs the trusted assembly', async function (assert) {
+    test('realms events reconcile the list in both directions (create, then archive)', async function (assert) {
       let realmServer = getService('realm-server') as RealmServerService;
       let newRealmURL = ensureTrailingSlash(
         new URL('./new-workspace/', testRealmURL).href,
@@ -221,6 +222,28 @@ module(
       assert.ok(
         realmServer.availableRealmIdentifiers.includes(ri(testRealmURL)),
         'the original realm is still present',
+      );
+
+      // …and the reverse: the realm is archived externally. `_realm-auth`
+      // stops advertising it and the server rewrites `app.boxel.realms`
+      // without it. The signal set differs from ours (a removal), so the
+      // assembly re-runs and drops it — no retry needed, the assembly is
+      // authoritative.
+      setRealmArchived(newRealmURL, true);
+      mockMatrixUtils.simulateAccountDataEvent(APP_BOXEL_REALMS_EVENT_TYPE, {
+        realms: [testRealmURL],
+      });
+
+      await waitUntil(
+        () => !realmServer.availableRealmIdentifiers.includes(ri(newRealmURL)),
+      );
+      assert.notOk(
+        realmServer.availableRealmIdentifiers.includes(ri(newRealmURL)),
+        'the archived realm disappears from the available list without a reload',
+      );
+      assert.ok(
+        realmServer.availableRealmIdentifiers.includes(ri(testRealmURL)),
+        'the original realm survives the removal reconcile',
       );
     });
   },

--- a/packages/host/tests/integration/matrix-service-boot-assembly-test.ts
+++ b/packages/host/tests/integration/matrix-service-boot-assembly-test.ts
@@ -514,7 +514,7 @@ module(
 
       // The server goes down; a runtime account-data refresh arrives.
       setRealmAuthFailure(true);
-      await matrixService.applyTrustedRealmServersAccountData([
+      await matrixService.assembleRealmsFromTrustedServers([
         testRealmServerURL,
       ]);
 

--- a/packages/host/tests/integration/matrix-service-boot-assembly-test.ts
+++ b/packages/host/tests/integration/matrix-service-boot-assembly-test.ts
@@ -12,9 +12,9 @@ import type RealmServerService from '@cardstack/host/services/realm-server';
 
 import {
   testRealmURL,
+  removeRealmPermissions,
   setupIntegrationTestRealm,
   setupLocalIndexing,
-  setRealmArchived,
   setRealmAuthFailure,
   setupAuthEndpoints,
 } from '../helpers';
@@ -186,7 +186,7 @@ module(
       await matrixService.start();
     });
 
-    test('realms events reconcile the list in both directions (create, then archive)', async function (assert) {
+    test('realms events reconcile the list in both directions (create, then delete)', async function (assert) {
       let realmServer = getService('realm-server') as RealmServerService;
       let newRealmURL = ensureTrailingSlash(
         new URL('./new-workspace/', testRealmURL).href,
@@ -224,12 +224,14 @@ module(
         'the original realm is still present',
       );
 
-      // …and the reverse: the realm is archived externally. `_realm-auth`
-      // stops advertising it and the server rewrites `app.boxel.realms`
-      // without it. The signal set differs from ours (a removal), so the
-      // assembly re-runs and drops it — no retry needed, the assembly is
-      // authoritative.
-      setRealmArchived(newRealmURL, true);
+      // …and the reverse: the realm is deleted from another session.
+      // Deleting removes the realm's permission rows, so `_realm-auth`
+      // stops advertising it, and the deleting session rewrites
+      // `app.boxel.realms` without it (removeRealmFromAccountData) — the
+      // production flow that shrinks the announced list. The signal set
+      // differs from ours (a removal), so the assembly re-runs and drops
+      // it — no retry needed, the assembly is authoritative.
+      removeRealmPermissions(newRealmURL);
       mockMatrixUtils.simulateAccountDataEvent(APP_BOXEL_REALMS_EVENT_TYPE, {
         realms: [testRealmURL],
       });
@@ -239,7 +241,7 @@ module(
       );
       assert.notOk(
         realmServer.availableRealmIdentifiers.includes(ri(newRealmURL)),
-        'the archived realm disappears from the available list without a reload',
+        'the deleted realm disappears from the available list without a reload',
       );
       assert.ok(
         realmServer.availableRealmIdentifiers.includes(ri(testRealmURL)),


### PR DESCRIPTION
Realms created or deleted outside the session (boxel-cli, the software factory, another tab) don't show up — or linger — in an open session's workspace chooser until you reload. (Archiving doesn't write `app.boxel.realms` today, so an external archive still needs a reload; wiring that signal is a follow-up.)

Cause: the `app.boxel.realms` matrix event used to both carry the realm list and announce changes. Copying the carried list caused a stale-echo bug on page load, which was fixed by ignoring the event entirely — silently discarding the only live change signal along with it.

Fix: never copy the event's contents, only compare them. Same realms as shown → echo, ignore. Different → re-fetch the authoritative list from the realm server.

```mermaid
flowchart LR
    A["realm changed<br/>outside the session"] --> B["app.boxel.realms<br/>event pushed"]
    B --> C{"list actually<br/>changed?"}
    C -- "no (echo)" --> D["ignore"]
    C -- yes --> E["re-fetch from<br/>realm server"]
    E --> F["chooser updates,<br/>no reload"]
```

One re-fetch per genuine change is sufficient — the server commits permissions before writing the event, so the answer is always fresh. The re-fetch runs as a `restartableTask` so rapid changes coalesce and logout cancels in-flight work. The assembly is renamed `assembleRealmsFromTrustedServers`; the listener documents that the server-side write of `app.boxel.realms` must not be removed without replacing this signal.

- New integration test: external create appears / external delete disappears, no reload; existing coverage keeps the echo case pinned.
- Test helpers: `simulateAccountDataEvent` (mock matrix), `removeRealmPermissions` (realm-server mock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

