### PR TITLE
fix(skills): resolve run-command linksTo inputs given a card ID string

### DIFF
--- a/packages/boxel-cli/plugin/skills/boxel-command/SKILL.md
+++ b/packages/boxel-cli/plugin/skills/boxel-command/SKILL.md
@@ -24,7 +24,7 @@ boxel run-command <command-specifier> --realm <realm-url> [--input '<json>'] [--
 
 - `<command-specifier>` — the module path of the command (e.g. `@cardstack/boxel-host/commands/get-card-type-schema/default`).
 - `--realm` — the realm URL the command runs against. Required.
-- `--input` — JSON string passed as the command's input. Optional; some commands take no input.
+- `--input` — JSON string passed as the command's input. Optional; some commands take no input. Keys map to the input card's field names. A `linksTo` field is given the target card's **ID string**, and a `linksToMany` field an **array of ID strings** — the host resolves each ID to the actual card before running the command.
 - `--json` — emit the raw response instead of the formatted summary.
 
 ### Example
@@ -33,6 +33,14 @@ boxel run-command <command-specifier> --realm <realm-url> [--input '<json>'] [--
 boxel run-command @cardstack/boxel-host/commands/get-card-type-schema/default \
   --realm http://localhost:4201/my-realm/ \
   --input '{"codeRef":{"module":"http://localhost:4201/my-realm/sticky-note","name":"StickyNote"}}'
+```
+
+A command whose input has a `linksTo(CardDef)` field (here named `card`) takes that card's ID string:
+
+```
+boxel run-command @cardstack/boxel-host/commands/screenshot-card/default \
+  --realm http://localhost:4201/my-realm/ \
+  --input '{"card":"http://localhost:4201/my-realm/Author/1","format":"isolated"}'
 ```
 
 ## Programmatic

--- a/packages/host/app/routes/command-runner.ts
+++ b/packages/host/app/routes/command-runner.ts
@@ -15,6 +15,7 @@ import type {
 import {
   ToolContextStamp,
   getClass,
+  isCardInstance,
   parseBoxelHostCommandSpecifier,
   rri,
 } from '@cardstack/runtime-common';
@@ -24,6 +25,7 @@ import { registerBoxelTransitionTo } from '../utils/register-boxel-transition';
 import type CardService from '../services/card-service';
 import type LoaderService from '../services/loader-service';
 import type RealmService from '../services/realm';
+import type StoreService from '../services/store';
 import type { CardDef, CardDefConstructor } from '@cardstack/base/card-api';
 
 const commandRequestStorageKeyPrefix = 'boxel-command-request:';
@@ -78,6 +80,7 @@ export default class CommandRunnerRoute extends Route<CommandRunnerModel> {
   @service declare loaderService: LoaderService;
   @service declare cardService: CardService;
   @service declare realm: RealmService;
+  @service declare store: StoreService;
 
   async beforeModel() {
     registerBoxelTransitionTo(this.router, this);
@@ -140,7 +143,11 @@ export default class CommandRunnerRoute extends Route<CommandRunnerModel> {
       let toolInstance = new ToolConstructor(this.toolContext);
       let resultCard: CardDef | undefined;
       if (toolInput) {
-        resultCard = await toolInstance.execute(toolInput);
+        let InputType = await toolInstance.getInputType();
+        let resolvedInput = InputType
+          ? await this.#resolveLinkedInputs(InputType, toolInput)
+          : toolInput;
+        resultCard = await toolInstance.execute(resolvedInput);
       } else {
         resultCard = await toolInstance.execute();
       }
@@ -161,6 +168,53 @@ export default class CommandRunnerRoute extends Route<CommandRunnerModel> {
       model.error = error instanceof Error ? error : new Error(String(error));
       model.status = 'error';
     }
+  }
+
+  // The stored input arrives as raw JSON (e.g. from `run-command --input`), so
+  // a `linksTo`/`linksToMany` field is expressed as a card ID string (or array
+  // of them) rather than a card instance. `Tool.execute` assigns each value
+  // straight onto its field via `new InputType(...)`, which can't turn an ID
+  // into a card — so we resolve those IDs to instances here first, matching how
+  // `LinksTo.deserialize` resolves a relationship through the store.
+  async #resolveLinkedInputs(
+    InputType: CardDefConstructor,
+    toolInput: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    let cardApi = await this.cardService.getAPI();
+    let fields = cardApi.getFields(InputType, {
+      usedLinksToFieldsOnly: false,
+      includeComputeds: false,
+    });
+    let resolved: Record<string, unknown> = { ...toolInput };
+    for (let [fieldName, value] of Object.entries(toolInput)) {
+      let field = fields[fieldName];
+      if (!field) {
+        continue;
+      }
+      if (field.fieldType === 'linksTo' && typeof value === 'string') {
+        resolved[fieldName] = await this.#resolveCardId(value, fieldName);
+      } else if (
+        field.fieldType === 'linksToMany' &&
+        Array.isArray(value) &&
+        value.every((entry) => typeof entry === 'string')
+      ) {
+        resolved[fieldName] = await Promise.all(
+          (value as string[]).map((id) => this.#resolveCardId(id, fieldName)),
+        );
+      }
+    }
+    return resolved;
+  }
+
+  async #resolveCardId(id: string, fieldName: string): Promise<CardDef> {
+    let instance = await this.store.get(id);
+    if (!instance || !isCardInstance<CardDef>(instance)) {
+      let detail = instance ? ` (${instance.status}: ${instance.message})` : '';
+      throw new Error(
+        `Could not resolve card "${id}" for input field "${fieldName}"${detail}`,
+      );
+    }
+    return instance;
   }
 
   #consumeStoredCommandRequest(

--- a/packages/host/tests/acceptance/tools-test.gts
+++ b/packages/host/tests/acceptance/tools-test.gts
@@ -380,6 +380,30 @@ module('Acceptance | Tools tests', function (hooks) {
         </template>
       };
     }
+    class LinkEchoInput extends CardDef {
+      @field pet = linksTo(Pet);
+      @field friends = linksToMany(Pet);
+    }
+
+    class LinkEchoCommand extends Command<
+      typeof LinkEchoInput,
+      typeof GreetingCard
+    > {
+      static displayName = 'LinkEchoCommand';
+      async getInputType() {
+        return LinkEchoInput;
+      }
+      protected async run(input: LinkEchoInput): Promise<GreetingCard> {
+        let petName = input.pet?.name ?? 'none';
+        let friendNames = (input.friends ?? [])
+          .map((friend) => friend.name)
+          .join(', ');
+        return new GreetingCard({
+          message: `pet=${petName}; friends=${friendNames}`,
+        });
+      }
+    }
+
     let mangoPet = new Pet({ name: 'Mango' });
 
     await setupAcceptanceTestRealm({
@@ -420,6 +444,10 @@ module('Acceptance | Tools tests', function (hooks) {
         'command-runner-hello-command.ts': {
           GreetingCard,
           default: HelloCommand,
+        },
+        'link-echo-command.ts': {
+          LinkEchoInput,
+          default: LinkEchoCommand,
         },
         'search-and-open-card-command.ts': {
           default: SearchAndOpenCardCommand,
@@ -579,6 +607,45 @@ module('Acceptance | Tools tests', function (hooks) {
 
       await waitFor('[data-prerender][data-prerender-status="error"]');
       assert.dom('[data-prerender-error]').includesText('Boom!');
+      assert.dom('[data-test-command-runner-greeting]').doesNotExist();
+    });
+
+    test('resolves linksTo and linksToMany inputs specified by card id', async function (assert) {
+      let requestId = 'command-runner-test-linksto';
+      let nonce = '3';
+      setCommandRunnerRequest(
+        requestId,
+        nonce,
+        `${testRealmURL}link-echo-command/default`,
+        {
+          pet: `${testRealmURL}Pet/ringo`,
+          friends: [`${testRealmURL}Pet/mango`, `${testRealmURL}Pet/vangogh`],
+        },
+      );
+      await visit(`/command-runner/${requestId}/${nonce}`);
+
+      await waitFor('[data-prerender][data-prerender-status="ready"]');
+      assert
+        .dom('[data-test-command-runner-greeting]')
+        .includesText('pet=Ringo');
+      assert
+        .dom('[data-test-command-runner-greeting]')
+        .includesText('friends=Mango, Van Gogh');
+    });
+
+    test('captures an error when a linksTo input id cannot be resolved', async function (assert) {
+      let requestId = 'command-runner-test-linksto-missing';
+      let nonce = '4';
+      setCommandRunnerRequest(
+        requestId,
+        nonce,
+        `${testRealmURL}link-echo-command/default`,
+        { pet: `${testRealmURL}Pet/does-not-exist` },
+      );
+      await visit(`/command-runner/${requestId}/${nonce}`);
+
+      await waitFor('[data-prerender][data-prerender-status="error"]');
+      assert.dom('[data-prerender-error]').includesText('Pet/does-not-exist');
       assert.dom('[data-test-command-runner-greeting]').doesNotExist();
     });
   });


### PR DESCRIPTION
## What

`boxel run-command --input '<json>'` can now specify a `linksTo(CardDef)` (or `linksToMany(CardDef)`) command input using the target card's **ID string** — e.g. `--input '{ "card": "https://realm/Author/1" }'`, or an array of IDs for a `linksToMany` field.

## Why

The `--input` JSON is forwarded verbatim to the host command runner, which builds the command's input card with `new InputType(input)`. That is a plain field assignment: a `linksTo` field can only accept a card *instance*, so a string ID was assigned as-is and never resolved to a card. There was no way to reference a linked card from the CLI.

## How

`command-runner.ts` now resolves linked inputs before the command executes:

- Introspect the input card's fields (`getFields`).
- For a `linksTo` field whose value is a string, or a `linksToMany` field whose value is a string array, load each card via `store.get(id)` — the same store resolution `LinksTo.deserialize` uses — and substitute the resolved instance.
- An unresolvable ID throws `Could not resolve card "<id>" for input field "<field>"`, carrying the store's error status and message (e.g. 404 vs 403), surfaced as a normal command error.

All `linksTo(<subtype>)` fields (including `linksTo(Skill)`) are covered, since resolution keys off `fieldType`. The shared `Tool.execute` / AI command path is untouched.

## Tests

Two acceptance tests in `tools-test.gts` (command-runner module):
- a command with `linksTo(Pet)` + `linksToMany(Pet)` inputs resolves `{ pet: "<id>", friends: ["<id>", "<id>"] }` to the linked cards;
- an unresolvable ID surfaces as a command error.

The `boxel-command` skill doc is updated to describe the ID-string convention. The `fix(skills):` title bumps the plugin version so the updated doc ships to installed plugins — the marketplace cache is keyed on `plugin.json` version. The npm CLI surface is untouched, so no npm version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)