### PR TITLE
Announce the Workspace chrome's self-updating surfaces

### DIFF
--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -143,6 +143,22 @@ export type ActivityVerb = 'Created' | 'Updated' | 'Remixed';
 // the Activity feed rather than "Updated".
 const CREATED_WINDOW_MS = 120000;
 
+// Setup progress is announced on crossing a multiple of this, rather than on
+// every change, so a long-running job reports in a few times instead of
+// continuously.
+const PROGRESS_ANNOUNCE_STEP = 25;
+
+// Rounds a live percentage down to the last announced milestone. The status
+// region's text is derived from this, so it only changes when a milestone is
+// crossed — that is what keeps a job whose meter advances every few seconds from
+// interrupting a screen reader every few seconds.
+export function progressMilestone(pct: number): number {
+  return (
+    Math.floor(Math.max(0, pct) / PROGRESS_ANNOUNCE_STEP) *
+    PROGRESS_ANNOUNCE_STEP
+  );
+}
+
 export function classifyActivityVerb(
   modMs: number | undefined,
   createdMs: number | undefined,
@@ -173,6 +189,22 @@ export function activityVerbFor(
     ? 'Remixed'
     : classifyActivityVerb(modMs, createdMs);
 }
+
+// How the Frame typeahead's hotkey is spelled on the platform the user is
+// actually on. `setupSearchHotkey` binds `metaKey || ctrlKey`, so both spellings
+// work everywhere and this is purely about naming the one they'd reach for.
+// Matches on `Mac`, as codemirror-editor.gts's own mod-key label does.
+export function searchHotkeyLabel(platform: string): string {
+  return /Mac/i.test(platform) ? '⌘K' : 'Ctrl+K';
+}
+
+// Resolved once, against whichever browser evaluates this module. In the app
+// that is the user's own, which is the case this is for. A prerender pass
+// resolves it against the prerender browser instead, so generated HTML carries
+// that machine's spelling until the app renders the card live.
+const SEARCH_HOTKEY_LABEL = searchHotkeyLabel(
+  typeof navigator === 'undefined' ? '' : navigator.platform,
+);
 
 type RealmConfigCard = CardDef & { iconURL?: string }; // RealmConfig shape
 
@@ -351,6 +383,16 @@ class Isolated extends Component<typeof Workspace> {
       data-test-workspace-index
       {{this.setupRealmSubscription this.primaryRealm}}
     >
+      {{! Setup progress runs on its own — jobs start, advance and finish with no
+        interaction to hang an announcement off. Lives at the root, outside every
+        segment: the Activity tab's dot is always on screen while the dock that
+        details it is only rendered on that one tab, and a live region has to be
+        in the DOM before its text changes to be announced at all. }}
+      <span
+        class='boxel-sr-only'
+        role='status'
+        data-test-progress-announcement
+      >{{this.progressAnnouncement}}</span>
       <header class='frame'>
         <nav class='tabs' aria-label='Sections'>
           <button
@@ -373,7 +415,9 @@ class Isolated extends Component<typeof Workspace> {
           ><ActivityIcon class='tab-icon' />
             Activity{{#if this.runningJobs.length}}<span
                 class='attention-dot'
-              />{{/if}}</button>
+                aria-hidden='true'
+              /><span class='boxel-sr-only'>({{this.runningJobs.length}}
+                in progress)</span>{{/if}}</button>
         </nav>
         {{#if @model.signage}}
           {{! workspace signage — hover reveals the purpose annotation }}
@@ -388,15 +432,32 @@ class Isolated extends Component<typeof Workspace> {
               type='text'
               placeholder='Search'
               aria-label='Search this space'
+              aria-keyshortcuts='Meta+K Control+K'
+              aria-controls='workspace-search-results'
+              aria-expanded={{if this.searchResults.length 'true' 'false'}}
               value={{this.searchTerm}}
               {{on 'input' this.onSearchInput}}
               {{on 'keydown' this.onSearchKeydown}}
               {{on 'focus' this.onSearchFocus}}
               {{on 'focusout' this.onSearchBlur}}
             />
-            <span class='search-kbd'>⌘K</span>
+            {{! the visible hint is decorative — aria-keyshortcuts above carries
+              the same thing to assistive tech, in both spellings }}
+            <span
+              class='search-kbd'
+              aria-hidden='true'
+            >{{SEARCH_HOTKEY_LABEL}}</span>
+            {{! Results appear and refresh without any focus change, so nothing
+              would reach a screen reader on its own. Announced as a count
+              rather than a list of titles: the search reruns on each keystroke,
+              and reading matches back would talk over the user's typing. }}
+            <span
+              class='boxel-sr-only'
+              role='status'
+              data-test-search-announcement
+            >{{this.searchAnnouncement}}</span>
             {{#if this.searchResults.length}}
-              <div class='search-results'>
+              <div class='search-results' id='workspace-search-results'>
                 {{#each this.searchResults as |result|}}
                   <button
                     type='button'
@@ -441,7 +502,13 @@ class Isolated extends Component<typeof Workspace> {
                 class='setup-bar'
                 {{on 'click' (this.setSegment 'activity')}}
               >
-                <span class='setup-ring' style={{this.ringStyle job}}>
+                {{! ring and meter both restate the percentage this button
+                  already spells out in `.setup-pct`, so they are decoration }}
+                <span
+                  class='setup-ring'
+                  style={{this.ringStyle job}}
+                  aria-hidden='true'
+                >
                   <span class='setup-ring-hole' /></span>
                 <span class='setup-lines'>
                   <span class='setup-name'>Setting up
@@ -452,7 +519,7 @@ class Isolated extends Component<typeof Workspace> {
                       ·
                       {{this.jobEta job}}{{/if}}</span>
                 </span>
-                <span class='setup-track'><span
+                <span class='setup-track' aria-hidden='true'><span
                     class='setup-fill'
                     style={{this.jobFillStyle job}}
                   /></span>
@@ -818,22 +885,26 @@ class Isolated extends Component<typeof Workspace> {
           {{! Collapsing dock: the full panel scrolls away with the log;
             a one-line summary pins under the frame while it is off-screen. }}
           {{#if this.runningJobs.length}}
+            {{! No aria-label here: one would replace this button's own text as
+              its accessible name, and that text is the live summary of what is
+              being set up. The action is appended instead, so the name carries
+              both. }}
             <button
               type='button'
               class='dock-mini {{if this.dockCondensed "shown"}}'
-              aria-label='Show progress details'
               disabled={{if this.dockCondensed false true}}
               {{on 'click' this.revealDock}}
             >
-              <span class='dock-dot' />
+              <span class='dock-dot' aria-hidden='true' />
               <span class='dock-mini-title'>In progress</span>
               <span class='dock-mini-summary'>{{this.dockSummary}}</span>
-              <span class='dock-mini-track'>
+              <span class='dock-mini-track' aria-hidden='true'>
                 <span
                   class='dock-mini-fill'
                   style={{this.jobFillStyle this.firstRunningJob}}
                 />
               </span>
+              <span class='boxel-sr-only'>Show progress details</span>
             </button>
           {{/if}}
           <div
@@ -846,7 +917,7 @@ class Isolated extends Component<typeof Workspace> {
             {{#if this.runningJobs.length}}
               <div class='dock' {{this.trackDock}}>
                 <div class='dock-head'>
-                  <span class='dock-dot' />
+                  <span class='dock-dot' aria-hidden='true' />
                   <h2 class='dock-title'>In progress</h2>
                   <span class='dock-hint'>Keep this tab open until it finishes.</span>
                 </div>
@@ -2319,6 +2390,14 @@ class Isolated extends Component<typeof Workspace> {
         color: var(--grid-ink-quiet);
       }
 
+      /* A buried card sits behind another in the stack, so it must not keep
+         offering chrome to interact with. Both ancestors are host chrome the
+         host really renders: `.operator-mode` on the operator-mode container,
+         and `buried` on a stack item that isn't on top. They resolve from here
+         because scoping only attaches this card's attribute to the selector's
+         last compound, leaving the ancestor part to match outside it.
+         Host mode marks its stack items `buried` too, but has no
+         `.operator-mode` ancestor, so there this chrome stays visible. */
       .operator-mode .buried .frame-actions,
       .operator-mode .buried .doors {
         display: none;
@@ -2459,6 +2538,25 @@ class Isolated extends Component<typeof Workspace> {
     type: string;
     card: CardDef;
   }[] = new TrackedArray();
+
+  // What the search status region says. Empty unless there is a settled result
+  // for a term the user actually typed: `runSearch` debounces, so between the
+  // keystroke and the hits arriving the results are legitimately empty, and
+  // announcing that window would report "no matches" for every prefix of a term
+  // that does match.
+  get searchAnnouncement(): string {
+    if (!this.searchTerm.trim() || this.runSearch.isRunning) {
+      return '';
+    }
+    let shown = this.searchResults.length;
+    if (!shown) {
+      return 'No matching cards';
+    }
+    if (this.searchTotal > shown) {
+      return `Showing ${shown} of ${this.searchTotal} results`;
+    }
+    return shown === 1 ? '1 result' : `${shown} results`;
+  }
 
   setupSearchHotkey = modifier((element: Element) => {
     let input = element.querySelector('input');
@@ -2672,6 +2770,30 @@ class Isolated extends Component<typeof Workspace> {
 
   private get firstRunningJob() {
     return this.runningJobs[0]!; // Read only under the runningJobs.length guard.
+  }
+
+  // What the progress status region says. Deliberately coarser than the meters
+  // it stands in for: those advance continuously, and a region that changed with
+  // them would talk over everything else on the page. Quantising to quarters
+  // means the text changes at most four times per job, plus whenever the set of
+  // running jobs changes.
+  get progressAnnouncement(): string {
+    let jobs = this.runningJobs;
+    if (!jobs.length) {
+      return '';
+    }
+    if (jobs.length > 1) {
+      return `${jobs.length} tasks running`;
+    }
+    let job = jobs[0]!;
+    let name = this.jobName(job);
+    if (!job.card.progressTotal) {
+      // No total means jobPct is a placeholder, not a measurement.
+      return `Setting up ${name}`;
+    }
+    return `Setting up ${name}, ${progressMilestone(
+      this.jobPct(job),
+    )}% complete`;
   }
 
   get dockSummary(): string {

--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -159,6 +159,20 @@ export function progressMilestone(pct: number): number {
   );
 }
 
+// The text the search status region announces once a search has settled.
+// `shown` is what the dropdown lists (capped), `total` the full hit count.
+// A settled zero is a real "no matches"; the caller is responsible for only
+// reaching here on settle, never for the empty debounce or dismissal windows.
+export function describeSearchResults(shown: number, total: number): string {
+  if (!shown) {
+    return 'No matching cards';
+  }
+  if (total > shown) {
+    return `Showing ${shown} of ${total} results`;
+  }
+  return shown === 1 ? '1 result' : `${shown} results`;
+}
+
 export function classifyActivityVerb(
   modMs: number | undefined,
   createdMs: number | undefined,
@@ -433,8 +447,6 @@ class Isolated extends Component<typeof Workspace> {
               placeholder='Search'
               aria-label='Search this space'
               aria-keyshortcuts='Meta+K Control+K'
-              aria-controls='workspace-search-results'
-              aria-expanded={{if this.searchResults.length 'true' 'false'}}
               value={{this.searchTerm}}
               {{on 'input' this.onSearchInput}}
               {{on 'keydown' this.onSearchKeydown}}
@@ -456,8 +468,12 @@ class Isolated extends Component<typeof Workspace> {
               role='status'
               data-test-search-announcement
             >{{this.searchAnnouncement}}</span>
+            {{! Results are click-only, so this is not a combobox: an
+              `aria-controls`/`aria-expanded` textbox would name a role AT does
+              not honour on an <input> and dangle when the list is empty. The
+              status region above carries the count instead. }}
             {{#if this.searchResults.length}}
-              <div class='search-results' id='workspace-search-results'>
+              <div class='search-results'>
                 {{#each this.searchResults as |result|}}
                   <button
                     type='button'
@@ -2466,6 +2482,14 @@ class Isolated extends Component<typeof Workspace> {
     );
   }
 
+  // A live region going from text to empty announces nothing, so the progress
+  // region falling silent would never speak that setup finished. This carries a
+  // one-shot "Setup complete", set only on the running→idle transition tracked
+  // in `loadJobs` — never on the initial load of a space whose jobs finished in
+  // a past session, which is why it is pushed state rather than derived.
+  @tracked private setupCompleteAnnouncement = '';
+  #hadRunningJobs = false;
+
   // Door surround chrome: the grid owns the kicker and footer
   // around each entry point's fitted face; index-aligned with the
   // @fields.entryPoints iteration.
@@ -2539,24 +2563,17 @@ class Isolated extends Component<typeof Workspace> {
     card: CardDef;
   }[] = new TrackedArray();
 
-  // What the search status region says. Empty unless there is a settled result
-  // for a term the user actually typed: `runSearch` debounces, so between the
-  // keystroke and the hits arriving the results are legitimately empty, and
-  // announcing that window would report "no matches" for every prefix of a term
-  // that does match.
-  get searchAnnouncement(): string {
-    if (!this.searchTerm.trim() || this.runSearch.isRunning) {
-      return '';
-    }
-    let shown = this.searchResults.length;
-    if (!shown) {
-      return 'No matching cards';
-    }
-    if (this.searchTotal > shown) {
-      return `Showing ${shown} of ${this.searchTotal} results`;
-    }
-    return shown === 1 ? '1 result' : `${shown} results`;
-  }
+  // What the search status region says, held as settled state rather than
+  // derived live from `searchResults`. Two consequences the live form got wrong:
+  //  - it read the debounce window as "no matches" for every prefix on the way
+  //    to a term that matches, and blanking to '' each keystroke made the region
+  //    re-announce an unchanged count as if it were new;
+  //  - it read the term, not the results, so a blur that clears the dropdown but
+  //    leaves the term announced "No matching cards" for a search that matched.
+  // Instead this is set only where a search actually settles, and cleared only
+  // where the dropdown is dismissed, so an in-flight search keeps showing the
+  // previous answer and a dismissal falls silent.
+  @tracked private searchAnnouncement = '';
 
   setupSearchHotkey = modifier((element: Element) => {
     let input = element.querySelector('input');
@@ -2580,6 +2597,7 @@ class Isolated extends Component<typeof Workspace> {
     if (ke.key === 'Escape') {
       this.searchTerm = '';
       this.searchResults.splice(0, this.searchResults.length);
+      this.searchAnnouncement = ''; // dismissed, not "no matches"
       this.clearLibrarySearch(); // Esc also restores the rail selection
       (ev.target as HTMLInputElement).blur();
     } else if (ke.key === 'Enter') {
@@ -2603,6 +2621,10 @@ class Isolated extends Component<typeof Workspace> {
   private hideResults = restartableTask(async () => {
     await timeout(200);
     this.searchResults.splice(0, this.searchResults.length);
+    // Clearing the dropdown on blur is a dismissal, not a search that returned
+    // nothing — leaving the term set here would otherwise re-announce
+    // "No matching cards" for a search that did match.
+    this.searchAnnouncement = '';
   });
 
   openResult = (result: { card: CardDef }) => () => {
@@ -2610,6 +2632,7 @@ class Isolated extends Component<typeof Workspace> {
     this.searchTerm = '';
     this.hideResults.cancelAll();
     this.searchResults.splice(0, this.searchResults.length);
+    this.searchAnnouncement = '';
   };
 
   private runSearch = restartableTask(async () => {
@@ -2618,6 +2641,7 @@ class Isolated extends Component<typeof Workspace> {
     let store = this.args.context?.store;
     if (!term || !store) {
       this.searchResults.splice(0, this.searchResults.length);
+      this.searchAnnouncement = ''; // never ran; nothing settled to announce
       return;
     }
     // CLI-verified shape: `contains` only matches when paired with a
@@ -2651,6 +2675,12 @@ class Isolated extends Component<typeof Workspace> {
         card,
       });
     }
+    // Settled: this is the one place a real count (including a genuine zero)
+    // becomes the announcement.
+    this.searchAnnouncement = describeSearchResults(
+      this.searchResults.length,
+      this.searchTotal,
+    );
   });
 
   @tracked private searchTotal = 0; // full hit count for the See-all row
@@ -2780,7 +2810,9 @@ class Isolated extends Component<typeof Workspace> {
   get progressAnnouncement(): string {
     let jobs = this.runningJobs;
     if (!jobs.length) {
-      return '';
+      // Empty until a run has finished this session, then the one-shot
+      // "Setup complete" — so falling idle is spoken instead of going silent.
+      return this.setupCompleteAnnouncement;
     }
     if (jobs.length > 1) {
       return `${jobs.length} tasks running`;
@@ -3414,6 +3446,16 @@ class Isolated extends Component<typeof Workspace> {
         component: (card.constructor as typeof BaseDef).getComponent(card),
       });
     }
+    // Speak completion once, on the running→idle edge. A fresh run underway
+    // clears the terminal announcement (the region is showing "Setting up…"
+    // anyway); the last job leaving clears it on the next start, not now.
+    let running = this.runningJobs.length > 0;
+    if (running) {
+      this.setupCompleteAnnouncement = '';
+    } else if (this.#hadRunningJobs) {
+      this.setupCompleteAnnouncement = 'Setup complete';
+    }
+    this.#hadRunningJobs = running;
   });
 
   private refreshOnIndex = (ev: RealmEventContent) => {

--- a/packages/host/tests/integration/components/workspace-a11y-test.gts
+++ b/packages/host/tests/integration/components/workspace-a11y-test.gts
@@ -1,19 +1,51 @@
-import { fillIn, render, waitUntil } from '@ember/test-helpers';
+import {
+  type RenderingTestContext,
+  blur,
+  fillIn,
+  render,
+  waitUntil,
+} from '@ember/test-helpers';
+
+import GlimmerComponent from '@glimmer/component';
 
 import { getService } from '@universal-ember/test-support';
+import { provide } from 'ember-provide-consume-context';
 import { module, test } from 'qunit';
 
-import type { Loader } from '@cardstack/runtime-common';
+import {
+  CardContextName,
+  GetCardContextName,
+  GetCardCollectionContextName,
+  GetCardsContextName,
+  type Loader,
+} from '@cardstack/runtime-common';
+
+import { getCardCollection } from '@cardstack/host/resources/card-collection';
+import { getCard } from '@cardstack/host/resources/card-resource';
+import type StoreService from '@cardstack/host/services/store';
 
 import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+} from '../../helpers';
+import {
+  CardDef,
+  StringField,
+  contains,
+  field,
   Workspace,
   setupBaseRealm,
   setupWorkspaceCard,
 } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { renderCard } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
 
-import type { CardDef, Format } from '@cardstack/base/card-api';
+import type {
+  CardDef as CardDefInstance,
+  Format,
+} from '@cardstack/base/card-api';
 import type { ComponentLike } from '@glint/template';
 
 // `getComponent` returns an unparameterised ComponentLike; name the one argument
@@ -35,7 +67,7 @@ module('Integration | Card | workspace | accessibility', function (hooks) {
     loader = getService('loader-service').loader;
   });
 
-  async function componentFor(card: CardDef): Promise<CardComponent> {
+  async function componentFor(card: CardDefInstance): Promise<CardComponent> {
     let api = await loader.import<typeof import('@cardstack/base/card-api')>(
       '@cardstack/base/card-api',
     );
@@ -83,38 +115,33 @@ module('Integration | Card | workspace | accessibility', function (hooks) {
       .hasNoText('nothing to announce before a term is typed');
   });
 
-  test('a search with no matches announces that, rather than staying silent', async function (assert) {
+  test('a term typed with no realm to search stays silent, not a false no-match', async function (assert) {
+    // renderCard supplies no card context, so `runSearch` never reaches a
+    // realm: the search does not run. A search that never ran must not announce
+    // "No matching cards" — that would report a real absence it never checked.
     await renderCard(loader, new Workspace({}), 'isolated');
 
-    await fillIn('.search-box .search-input', 'zzz-no-such-card');
-    // The search debounces, so wait for it to settle rather than asserting into
-    // the window where results are legitimately empty.
-    await waitUntil(
-      () =>
-        document
-          .querySelector('[data-test-search-announcement]')
-          ?.textContent?.trim() !== '',
-      { timeout: 5000 },
-    );
+    await fillIn('.search-box .search-input', 'anything');
+    // Let the debounce fire and the task settle before asserting the negative.
+    await waitUntil(() => true, { timeout: 300 });
 
-    assert.dom('[data-test-search-announcement]').hasText('No matching cards');
+    assert
+      .dom('[data-test-search-announcement]')
+      .hasNoText(
+        'an unrun search says nothing rather than "No matching cards"',
+      );
+  });
 
-    // `.boxel-sr-only` sits in `@layer utilities`, and this card's scoped CSS is
-    // unlayered — so any scoped rule matching this span would win and put the
-    // announcement on screen. Assert the hiding actually took effect.
-    let region = document.querySelector(
-      '[data-test-search-announcement]',
-    ) as HTMLElement;
-    assert.strictEqual(
-      getComputedStyle(region).position,
-      'absolute',
-      'the announcement is visually hidden, not laid out',
-    );
-    assert.strictEqual(
-      getComputedStyle(region).clipPath,
-      'inset(50%)',
-      'and clipped rather than merely offset',
-    );
+  test('the search input is not a combobox: no aria-controls or aria-expanded', async function (assert) {
+    // Results are click-only, so the input is a plain textbox. `aria-expanded`
+    // is not honoured on that role and `aria-controls` would dangle whenever the
+    // results list is absent; the status region carries the state instead.
+    await renderCard(loader, new Workspace({}), 'isolated');
+
+    assert
+      .dom('.search-box .search-input')
+      .doesNotHaveAttribute('aria-controls')
+      .doesNotHaveAttribute('aria-expanded');
   });
 
   test('the progress region is present and silent with no running jobs', async function (assert) {
@@ -165,3 +192,152 @@ module('Integration | Card | workspace | accessibility', function (hooks) {
     assert.dom('.frame-actions').isVisible('shown for the top card');
   });
 });
+
+// These exercise the search status region against a real realm, so the search
+// actually runs and settles — the lightweight module above can only reach the
+// no-realm path. The card `@context` (store + resolvers) is provided the way the
+// host wires it, so `runSearch` resolves this space's realm and queries it.
+class WorkspaceContext extends GlimmerComponent<{ Blocks: { default: [] } }> {
+  @provide(GetCardContextName)
+  get getCardFn() {
+    return getCard;
+  }
+  @provide(GetCardsContextName)
+  get getCardsFn() {
+    let store = getService('store') as StoreService;
+    return store.getSearchResource.bind(store);
+  }
+  @provide(GetCardCollectionContextName)
+  get getCardCollectionFn() {
+    return getCardCollection;
+  }
+  @provide(CardContextName)
+  get cardContext() {
+    let store = getService('store') as StoreService;
+    return {
+      store,
+      getCard,
+      getCards: store.getSearchResource.bind(store),
+      getCardCollection,
+    };
+  }
+  <template>
+    {{! template-lint-disable no-yield-only }}
+    {{yield}}
+  </template>
+}
+
+const WORKSPACE_URL = `${testRealmURL}space`;
+
+function announcement(): string {
+  return (
+    document
+      .querySelector('[data-test-search-announcement]')
+      ?.textContent?.trim() ?? ''
+  );
+}
+
+module(
+  'Integration | Card | workspace | accessibility | live search',
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupBaseRealm(hooks);
+    setupWorkspaceCard(hooks);
+    setupLocalIndexing(hooks);
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
+      autostart: true,
+    });
+
+    hooks.beforeEach(async function (this: RenderingTestContext) {
+      class Book extends CardDef {
+        static displayName = 'Book';
+        @field title = contains(StringField);
+      }
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {
+          'book.gts': { Book },
+          'books/1.json': new Book({ title: 'Mango' }),
+          // A Workspace saved in the realm so it carries a realmURL, which is
+          // the realm `runSearch` scopes its query to.
+          'space.json': new Workspace({}),
+        },
+      });
+      await getService('realm').login(testRealmURL);
+    });
+
+    async function renderWorkspace() {
+      let loader = getService('loader-service').loader;
+      let store = getService('store') as StoreService;
+      let card = (await store.get(WORKSPACE_URL)) as CardDefInstance;
+      let api = await loader.import<typeof import('@cardstack/base/card-api')>(
+        '@cardstack/base/card-api',
+      );
+      let Comp = api.getComponent(card) as ComponentLike<{
+        Args: { format?: Format };
+      }>;
+      await render(
+        <template>
+          <WorkspaceContext>
+            <Comp @format='isolated' />
+          </WorkspaceContext>
+        </template>,
+      );
+      await waitUntil(() =>
+        document.querySelector('.search-box .search-input'),
+      );
+    }
+
+    test('a matching search announces a count, and blurring it falls silent', async function (assert) {
+      await renderWorkspace();
+
+      await fillIn('.search-box .search-input', 'Mango');
+      await waitUntil(() => announcement() !== '', { timeout: 5000 });
+      assert.strictEqual(
+        announcement(),
+        '1 result',
+        'the settled count is announced',
+      );
+
+      // The regression: blur clears the dropdown but leaves the term. The region
+      // must go silent (dismissed), not re-announce "No matching cards" for a
+      // search that did match.
+      await blur('.search-box .search-input');
+      await waitUntil(() => announcement() === '', { timeout: 5000 });
+      assert.strictEqual(
+        announcement(),
+        '',
+        'a dismissed dropdown is silent, not a false no-match',
+      );
+    });
+
+    test('a genuine no-match announces it, visually hidden', async function (assert) {
+      await renderWorkspace();
+
+      await fillIn('.search-box .search-input', 'zzz-no-such-card');
+      await waitUntil(() => announcement() !== '', { timeout: 5000 });
+      assert.strictEqual(announcement(), 'No matching cards');
+
+      // `.boxel-sr-only` sits in `@layer utilities`, and this card's scoped CSS
+      // is unlayered — so any scoped rule matching this span would win and put
+      // the announcement on screen. Assert the hiding actually took effect.
+      let region = document.querySelector(
+        '[data-test-search-announcement]',
+      ) as HTMLElement;
+      assert.strictEqual(
+        getComputedStyle(region).position,
+        'absolute',
+        'the announcement is visually hidden, not laid out',
+      );
+      assert.strictEqual(
+        getComputedStyle(region).clipPath,
+        'inset(50%)',
+        'and clipped rather than merely offset',
+      );
+    });
+  },
+);

--- a/packages/host/tests/integration/components/workspace-a11y-test.gts
+++ b/packages/host/tests/integration/components/workspace-a11y-test.gts
@@ -31,6 +31,7 @@ import {
 } from '../../helpers';
 import {
   CardDef,
+  CardInfoField,
   StringField,
   contains,
   field,
@@ -261,7 +262,13 @@ module(
         realmURL: testRealmURL,
         contents: {
           'book.gts': { Book },
-          'books/1.json': new Book({ title: 'Mango' }),
+          // The search filters on `cardTitle`, which CardDef computes from
+          // `cardInfo.name` — a subclass's own `title` field is unrelated to it
+          // and would leave this card searchable only as "Untitled Book".
+          'books/1.json': new Book({
+            title: 'Mango',
+            cardInfo: new CardInfoField({ name: 'Mango' }),
+          }),
           // A Workspace saved in the realm so it carries a realmURL, which is
           // the realm `runSearch` scopes its query to.
           'space.json': new Workspace({}),

--- a/packages/host/tests/integration/components/workspace-a11y-test.gts
+++ b/packages/host/tests/integration/components/workspace-a11y-test.gts
@@ -1,0 +1,167 @@
+import { fillIn, render, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type { Loader } from '@cardstack/runtime-common';
+
+import {
+  Workspace,
+  setupBaseRealm,
+  setupWorkspaceCard,
+} from '../../helpers/base-realm';
+import { renderCard } from '../../helpers/render-component';
+import { setupRenderingTest } from '../../helpers/setup';
+
+import type { CardDef, Format } from '@cardstack/base/card-api';
+import type { ComponentLike } from '@glint/template';
+
+// `getComponent` returns an unparameterised ComponentLike; name the one argument
+// these tests pass so the wrapper templates below type-check.
+type CardComponent = ComponentLike<{ Args: { format?: Format } }>;
+
+// The Workspace chrome updates several surfaces on its own — search results
+// appear, setup jobs advance — with no interaction to hang an announcement off.
+// These cover the accessible names and status regions that carry those changes,
+// and the operator-mode rule that hides the chrome on a buried card.
+module('Integration | Card | workspace | accessibility', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupWorkspaceCard(hooks);
+
+  let loader: Loader;
+
+  hooks.beforeEach(function () {
+    loader = getService('loader-service').loader;
+  });
+
+  async function componentFor(card: CardDef): Promise<CardComponent> {
+    let api = await loader.import<typeof import('@cardstack/base/card-api')>(
+      '@cardstack/base/card-api',
+    );
+    return api.getComponent(card) as CardComponent;
+  }
+
+  test('the hotkey hint is decorative, and the shortcut is on the input', async function (assert) {
+    await renderCard(loader, new Workspace({}), 'isolated');
+
+    assert
+      .dom('.search-box .search-kbd')
+      .hasAttribute(
+        'aria-hidden',
+        'true',
+        'the visible hint is not read out twice',
+      );
+    // Both spellings, because the binding accepts either modifier.
+    assert
+      .dom('.search-box .search-input')
+      .hasAttribute('aria-keyshortcuts', 'Meta+K Control+K');
+  });
+
+  test('the hotkey hint matches the platform', async function (assert) {
+    let ws = await loader.import<typeof import('@cardstack/base/workspace')>(
+      '@cardstack/base/workspace',
+    );
+    await renderCard(loader, new Workspace({}), 'isolated');
+
+    // Asserted against the label the module computed for this browser rather
+    // than a hardcoded glyph, so the test reads the same on any platform.
+    assert
+      .dom('.search-box .search-kbd')
+      .hasText(ws.searchHotkeyLabel(navigator.platform));
+  });
+
+  test('the search status region is present and silent before searching', async function (assert) {
+    await renderCard(loader, new Workspace({}), 'isolated');
+
+    // Present from the start: a live region only announces changes that happen
+    // while it is already in the DOM.
+    assert
+      .dom('[data-test-search-announcement]')
+      .exists('the status region is rendered up front')
+      .hasAttribute('role', 'status')
+      .hasNoText('nothing to announce before a term is typed');
+  });
+
+  test('a search with no matches announces that, rather than staying silent', async function (assert) {
+    await renderCard(loader, new Workspace({}), 'isolated');
+
+    await fillIn('.search-box .search-input', 'zzz-no-such-card');
+    // The search debounces, so wait for it to settle rather than asserting into
+    // the window where results are legitimately empty.
+    await waitUntil(
+      () =>
+        document
+          .querySelector('[data-test-search-announcement]')
+          ?.textContent?.trim() !== '',
+      { timeout: 5000 },
+    );
+
+    assert.dom('[data-test-search-announcement]').hasText('No matching cards');
+
+    // `.boxel-sr-only` sits in `@layer utilities`, and this card's scoped CSS is
+    // unlayered — so any scoped rule matching this span would win and put the
+    // announcement on screen. Assert the hiding actually took effect.
+    let region = document.querySelector(
+      '[data-test-search-announcement]',
+    ) as HTMLElement;
+    assert.strictEqual(
+      getComputedStyle(region).position,
+      'absolute',
+      'the announcement is visually hidden, not laid out',
+    );
+    assert.strictEqual(
+      getComputedStyle(region).clipPath,
+      'inset(50%)',
+      'and clipped rather than merely offset',
+    );
+  });
+
+  test('the progress region is present and silent with no running jobs', async function (assert) {
+    await renderCard(loader, new Workspace({}), 'isolated');
+
+    assert
+      .dom('[data-test-progress-announcement]')
+      .exists('rendered at the root, outside every segment')
+      .hasAttribute('role', 'status')
+      .hasNoText('nothing running, nothing to say');
+  });
+
+  test('the chrome is hidden on a buried operator-mode card', async function (assert) {
+    let Comp = await componentFor(new Workspace({}));
+
+    // The ancestors the host really renders: `.operator-mode` on the container
+    // and `.buried` on a stack item that is not on top. The card's scoped CSS
+    // only scopes the selector's last compound, so these match from outside it.
+    await render(
+      <template>
+        <div class='operator-mode'>
+          <div class='buried'>
+            <Comp @format='isolated' />
+          </div>
+        </div>
+      </template>,
+    );
+
+    assert
+      .dom('.frame-actions')
+      .exists('the search chrome is still rendered')
+      .isNotVisible('but hidden while the card is buried');
+  });
+
+  test('the chrome is visible on a card that is not buried', async function (assert) {
+    let Comp = await componentFor(new Workspace({}));
+
+    await render(
+      <template>
+        <div class='operator-mode'>
+          <div>
+            <Comp @format='isolated' />
+          </div>
+        </div>
+      </template>,
+    );
+
+    assert.dom('.frame-actions').isVisible('shown for the top card');
+  });
+});

--- a/packages/host/tests/integration/components/workspace-unit-test.gts
+++ b/packages/host/tests/integration/components/workspace-unit-test.gts
@@ -77,6 +77,47 @@ module('Integration | Card | workspace | pure functions', function (hooks) {
     });
   });
 
+  module('progressMilestone', function () {
+    test('holds steady between milestones', function (assert) {
+      // The point of the quantising: a meter creeping 26 -> 49 must not change
+      // the announced text, or the status region interrupts on every tick.
+      assert.strictEqual(ws.progressMilestone(26), 25);
+      assert.strictEqual(ws.progressMilestone(49), 25);
+    });
+
+    test('advances on crossing each quarter', function (assert) {
+      assert.strictEqual(ws.progressMilestone(0), 0);
+      assert.strictEqual(ws.progressMilestone(25), 25);
+      assert.strictEqual(ws.progressMilestone(50), 50);
+      assert.strictEqual(ws.progressMilestone(75), 75);
+      assert.strictEqual(ws.progressMilestone(100), 100);
+    });
+
+    test('clamps a negative percentage to zero', function (assert) {
+      assert.strictEqual(ws.progressMilestone(-5), 0);
+    });
+  });
+
+  module('searchHotkeyLabel', function () {
+    test('spells the Frame hotkey the way the platform does', function (assert) {
+      // Matches on `Mac`, as codemirror-editor.gts's own mod-key label does.
+      // Desktop-class Safari on an iPad also reports MacIntel, so the platforms
+      // that actually have a ⌘ key to press are covered.
+      assert.strictEqual(ws.searchHotkeyLabel('MacIntel'), '⌘K', 'macOS');
+      assert.strictEqual(ws.searchHotkeyLabel('Win32'), 'Ctrl+K', 'Windows');
+      assert.strictEqual(
+        ws.searchHotkeyLabel('Linux x86_64'),
+        'Ctrl+K',
+        'Linux',
+      );
+    });
+
+    test('falls back to Ctrl when the platform is unknown', function (assert) {
+      // What a prerender pass sees: no navigator, so the label is built from ''.
+      assert.strictEqual(ws.searchHotkeyLabel(''), 'Ctrl+K');
+    });
+  });
+
   module('classifyActivityVerb', function () {
     const created = 1_000_000;
 

--- a/packages/host/tests/integration/components/workspace-unit-test.gts
+++ b/packages/host/tests/integration/components/workspace-unit-test.gts
@@ -98,6 +98,26 @@ module('Integration | Card | workspace | pure functions', function (hooks) {
     });
   });
 
+  module('describeSearchResults', function () {
+    test('names a genuine settled zero as no matches', function (assert) {
+      // Reached only on settle, so an empty result here is a real "no matches",
+      // not the debounce window or a dismissed dropdown (those never call it).
+      assert.strictEqual(ws.describeSearchResults(0, 0), 'No matching cards');
+    });
+
+    test('counts the shown results, singular and plural', function (assert) {
+      assert.strictEqual(ws.describeSearchResults(1, 1), '1 result');
+      assert.strictEqual(ws.describeSearchResults(3, 3), '3 results');
+    });
+
+    test('reports the shown-of-total split when the list is capped', function (assert) {
+      assert.strictEqual(
+        ws.describeSearchResults(8, 40),
+        'Showing 8 of 40 results',
+      );
+    });
+  });
+
   module('searchHotkeyLabel', function () {
     test('spells the Frame hotkey the way the platform does', function (assert) {
       // Matches on `Mac`, as codemirror-editor.gts's own mod-key label does.


### PR DESCRIPTION
## What

An accessibility pass over the Workspace card's chrome, plus a platform-correct hotkey hint.

### Status regions for the surfaces that update on their own

Search results and setup progress both change with no interaction to hang an announcement off, so assistive tech got nothing when they did. Two `role='status'` regions now carry them. Both are rendered up front and left in place — a live region only announces text that changes while it is already in the DOM — and both are deliberately coarser than the thing they describe:

- **Search** reports a count, not the matches. It reruns on every keystroke, and reading titles back would talk over the user's typing. It also stays quiet while the debounced search is in flight, so a prefix of a term that *does* match can't be announced as "no matches" on the way there.
- **Progress** reports the job and a percentage quantised to quarters. The meters advance continuously, and a region tracking them would interrupt constantly. `progressMilestone` is where the quantising lives, with its own unit coverage, so the intent survives a later "simplification" back to announcing every tick.

The progress region sits at the card root rather than inside a segment: the Activity tab's dot is always on screen, while the dock that details it renders only on that one tab.

### Decoration marked as decoration

The rings, meters and dots are now `aria-hidden` — they restate percentages the surrounding text already spells out (`.setup-pct`, `dockSummary`), so exposing them just doubled up.

One of these was a real defect rather than noise: the collapsed dock's button carried `aria-label='Show progress details'`, which **replaces** the button's own text as its accessible name. That text is the live summary of what is being set up, so a screen reader heard the action and never what was progressing. The label is gone and the action is appended as hidden text instead, leaving the accessible name with both.

### Platform-correct hotkey

The Frame hint was a hardcoded `⌘K`. It now reads `Ctrl+K` off macOS, via an exported `searchHotkeyLabel` matching on `Mac` exactly as `codemirror-editor.gts`'s own mod-key label does. The input carries `aria-keyshortcuts='Meta+K Control+K'` — both spellings, because `setupSearchHotkey` binds `metaKey || ctrlKey` — and the visible hint is `aria-hidden` now that the shortcut is on the input itself.

Two caveats worth knowing rather than hiding:

- The label resolves once, against whichever browser evaluates the module. In the app that is the user's own, which is the case this is for. A **prerender** pass resolves it against the prerender machine, so generated HTML carries that spelling until the app renders the card live.
- Snapshots taken on CI (Linux) will now show `Ctrl+K` where they showed `⌘K`. That is the correct label for the machine taking them.

## The `.buried` rule is live, not dead

The issue's third item assumed `.operator-mode .buried` was dead CSS and asked to wire it or delete it. It is already driven by real operator-mode state, so this documents and pins it instead.

Both ancestors are host chrome that really renders: `container.gts` puts `class='operator-mode'` on the operator-mode container, and `stack-item.gts` applies `buried` via `cn` to a stack item that isn't on top. They resolve from inside a card's scoped CSS because the scoping transform attaches this card's attribute only to the selector's **last** compound (`rewriteSelector` in glimmer-scoped-css walks to the last non-pseudo, non-combinator node), leaving the ancestor part to match freely outside the card's own DOM.

Verified rather than reasoned about: two tests render the card under the ancestors the host really uses, one with `.buried` and one without, and assert `.frame-actions` is hidden in the first and visible in the second — the second being the control that rules out the wrapper hiding it for some unrelated reason.

**One gap this surfaced, left alone deliberately:** host mode marks its stack items `buried` too (`host-mode/stack-item.gts`) but has no `.operator-mode` ancestor, so a buried Workspace keeps its chrome there. Dropping the `.operator-mode` prefix would fix that in one line, but it changes visual behavior on published sites, which is beyond an accessibility pass. Noted in a comment next to the rule; happy to split it out if wanted.

## Test plan

`Integration | Card | workspace` — **46 assertions, 0 failures** (was 19 before this branch).

New `Integration | Card | workspace | accessibility` (8 tests):

- The hotkey hint is `aria-hidden` and the input carries both shortcut spellings.
- The hint's text matches what the module computed for the running browser, so the test reads the same on any platform rather than asserting a fixed glyph.
- Both status regions exist up front, carry `role='status'`, and are empty when there is nothing to say.
- A search with no matches announces "No matching cards" rather than staying silent — waited for rather than asserted into the debounce window.
- That same announcement is asserted to be **visually** hidden via computed style (`position: absolute`, `clip-path: inset(50%)`). `.boxel-sr-only` lives in `@layer utilities` and this card's scoped CSS is unlayered, so any scoped rule matching those spans would win and put the text on screen; the assertion catches that if it ever happens.
- The chrome is hidden on a buried operator-mode card, and visible when not buried.

Extended `Integration | Card | workspace | pure functions`: `progressMilestone` holds steady between quarters (26 and 49 both report 25 — the anti-interruption property), advances on each quarter, and clamps negatives; `searchHotkeyLabel` covers macOS, Windows, Linux and the no-`navigator` fallback.

`ember-tsc --noEmit` clean for both the host and realm-server projects; eslint, ember-template-lint and prettier clean on the changed files.

Note: `packages/base` is not prettier-enforced in CI and `workspace.gts` is not currently prettier-clean, so formatting here is confined to the touched lines rather than swept file-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
