### PR TITLE
Workspace: surface remixes as first-class Activity events

### DIFF
--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -120,6 +120,11 @@ export function etaMinutes(
   return mins > 30 ? undefined : mins;
 }
 
+// The verbs the Activity feed labels an event with. A card save is classified
+// as Created/Updated by timing; a RemixCard instance is a first-class Remixed
+// event regardless of when it was written.
+export type ActivityVerb = 'Created' | 'Updated' | 'Remixed';
+
 // A card modified within this window of its creation reads as "Created" in
 // the Activity feed rather than "Updated".
 const CREATED_WINDOW_MS = 120000;
@@ -133,6 +138,26 @@ export function classifyActivityVerb(
     Math.abs(modMs - createdMs) < CREATED_WINDOW_MS
     ? 'Created'
     : 'Updated';
+}
+
+// RemixCard's displayName. The feed recognizes a remix structurally (by
+// displayName, like SYSTEM_TYPE_NAMES) so this module keeps compiling without a
+// static RemixCard import — matching how loadJobs references it via codeRef.
+const REMIX_TYPE_NAME = 'Remix';
+// The subset of RemixCard the feed reads: the source it was cloned from.
+type RemixCardLike = CardDef & { remixedFrom?: CardDef };
+
+// The Activity feed verb for a card. A RemixCard instance is the record of a
+// clone, so it is a first-class "Remixed" event regardless of write timing;
+// every other card is Created/Updated by how close its save is to its creation.
+export function activityVerbFor(
+  displayName: string | undefined,
+  modMs: number | undefined,
+  createdMs: number | undefined,
+): ActivityVerb {
+  return displayName === REMIX_TYPE_NAME
+    ? 'Remixed'
+    : classifyActivityVerb(modMs, createdMs);
 }
 
 type RealmConfigCard = CardDef & { iconURL?: string }; // RealmConfig shape
@@ -185,7 +210,7 @@ function publishedSitesOf(
 const SYSTEM_TYPE_NAMES = new Set([
   'Theme',
   'Realm Config',
-  'Remix',
+  REMIX_TYPE_NAME,
   'Spec',
   'Skill',
   'Process',
@@ -632,10 +657,7 @@ class Isolated extends Component<typeof Workspace> {
                 <button
                   type='button'
                   class='rail-row
-                    {{if
-                      (eq option.id this.activeFilter.id)
-                      "selected"
-                    }}'
+                    {{if (eq option.id this.activeFilter.id) "selected"}}'
                   {{on 'click' (this.selectFilter option)}}
                 >
                   {{#let (this.iconComponent option) as |Icon|}}
@@ -656,10 +678,7 @@ class Isolated extends Component<typeof Workspace> {
                     <button
                       type='button'
                       class='rail-row type
-                        {{if
-                          (eq option.id this.activeFilter.id)
-                          "selected"
-                        }}'
+                        {{if (eq option.id this.activeFilter.id) "selected"}}'
                       {{on 'click' (this.selectFilter option)}}
                     >
                       {{#if (this.iconHtml option)}}
@@ -696,10 +715,7 @@ class Isolated extends Component<typeof Workspace> {
                   <button
                     type='button'
                     class='rail-row type
-                      {{if
-                        (eq option.id this.activeFilter.id)
-                        "selected"
-                      }}'
+                      {{if (eq option.id this.activeFilter.id) "selected"}}'
                     {{on 'click' (this.selectFilter option)}}
                   >
                     {{#if (this.iconHtml option)}}
@@ -867,7 +883,8 @@ class Isolated extends Component<typeof Workspace> {
                       <div class='feed-meta'>
                         <span
                           class='feed-verb
-                            {{if (eq item.verb "Created") "created"}}'
+                            {{if (eq item.verb "Created") "created"}}
+                            {{if (eq item.verb "Remixed") "remixed"}}'
                         >{{item.verb}}</span>
                         <span class='feed-type'>
                           <item.typeIcon class='feed-type-icon' />
@@ -876,6 +893,11 @@ class Isolated extends Component<typeof Workspace> {
                       {{#if item.title}}
                         <p class='feed-title'>{{item.title}}</p>
                       {{/if}}
+                      {{#let (this.remixSourceTitle item) as |source|}}
+                        {{#if source}}
+                          <p class='feed-remix-source'>from {{source}}</p>
+                        {{/if}}
+                      {{/let}}
                       {{#if item.note}}
                         <p class='feed-note-text'>{{item.note}}</p>
                       {{/if}}
@@ -951,6 +973,7 @@ class Isolated extends Component<typeof Workspace> {
         --grid-quick: 0.12s;
         --grid-soft: 0.18s;
         --grid-created: #00893a;
+        --grid-remixed: #7c3aed;
 
         display: flex;
         flex-direction: column;
@@ -1927,6 +1950,9 @@ class Isolated extends Component<typeof Workspace> {
       .feed-verb.created {
         color: var(--grid-created);
       }
+      .feed-verb.remixed {
+        color: var(--grid-remixed);
+      }
       .feed-type {
         display: inline-flex;
         align-items: center;
@@ -1948,6 +1974,14 @@ class Isolated extends Component<typeof Workspace> {
         margin: 0;
         font: 600 12.5px/1.35 var(--grid-sans);
         color: var(--grid-ink);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+      .feed-remix-source {
+        margin: 0;
+        font: 500 11px/1.35 var(--grid-sans);
+        color: var(--grid-ink-meta);
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
@@ -3139,9 +3173,8 @@ class Isolated extends Component<typeof Workspace> {
     this.fileTotal = fileTotal;
 
     this.activeFilter =
-      this.filterOptions.find(
-        (filter) => filter.id === this.activeFilter.id,
-      ) ?? this.filterOptions[0];
+      this.filterOptions.find((filter) => filter.id === this.activeFilter.id) ??
+      this.filterOptions[0];
   });
 
   private loadJobs = restartableTask(async () => {
@@ -3219,7 +3252,7 @@ class Isolated extends Component<typeof Workspace> {
     when: string | undefined;
     absolute: string | undefined;
     note: string | undefined;
-    verb: 'Created' | 'Updated';
+    verb: ActivityVerb;
     dayLabel: string;
     showDay: boolean;
     title: string | undefined; // card identity for the log line
@@ -3242,6 +3275,19 @@ class Isolated extends Component<typeof Workspace> {
   private get feedAtCap() {
     return this.feedItems.length >= 100;
   }
+
+  // The source a remix was cloned from, read live off the card so it fills in
+  // when the linked instance finishes loading (the linksTo getter lazily loads
+  // and tracks). Undefined for non-remix rows and remixes with no source set.
+  remixSourceTitle = (item: {
+    verb: ActivityVerb;
+    card: CardDef;
+  }): string | undefined => {
+    if (item.verb !== 'Remixed') {
+      return undefined;
+    }
+    return (item.card as RemixCardLike).remixedFrom?.cardTitle ?? undefined;
+  };
 
   watchFeedEnd = modifier((element: Element) => {
     let root = element.closest('.scroll-container');
@@ -3290,9 +3336,9 @@ class Isolated extends Component<typeof Workspace> {
       let card = instance as CardDef;
       let modMs = toMs(getCardMeta(card, 'lastModified'));
       let createdMs = toMs(getCardMeta(card, 'resourceCreatedAt'));
-      let verb = classifyActivityVerb(modMs, createdMs);
-      let day = modMs !== undefined ? dayLabelFor(modMs) : '';
       let ctor = card.constructor as typeof CardDef; // type identity for the log line
+      let verb = activityVerbFor(ctor.displayName, modMs, createdMs);
+      let day = modMs !== undefined ? dayLabelFor(modMs) : '';
       this.feedItems.push({
         id: card.id!,
         component: (card.constructor as typeof BaseDef).getComponent(card),

--- a/packages/host/tests/acceptance/workspace-test.gts
+++ b/packages/host/tests/acceptance/workspace-test.gts
@@ -59,6 +59,22 @@ module('Acceptance | workspace card', function (hooks) {
         'note.gts': { Note },
         'index.json': new Workspace(),
         'Note/1.json': new Note({ cardTitle: 'First Note' }),
+        // A remix cloned from Note/1 — its own indexed instance is the record
+        // of the clone that the Activity feed surfaces as a "Remixed" event.
+        'Remix/1.json': {
+          data: {
+            attributes: { listingName: 'Remixed Space' },
+            relationships: {
+              remixedFrom: { links: { self: '../Note/1' } },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/remix-card',
+                name: 'RemixCard',
+              },
+            },
+          },
+        },
       },
     });
   });
@@ -81,5 +97,25 @@ module('Acceptance | workspace card', function (hooks) {
 
     await click(`${STACK} nav.tabs .tab:nth-child(3)`);
     assert.dom(`${STACK} .activity-pane`).exists('Activity pane renders');
+  });
+
+  test('a remix surfaces in the Activity feed as a first-class event', async function (assert) {
+    await visit('/');
+    await click('[data-test-workspace-button="Unnamed Workspace"]');
+    await waitFor(`${STACK} nav.tabs`);
+
+    await click(`${STACK} nav.tabs .tab:nth-child(3)`); // Activity
+    await waitFor(`${STACK} .feed-verb.remixed`);
+    assert
+      .dom(`${STACK} .feed-verb.remixed`)
+      .hasText('Remixed', 'the remix reads as a Remixed event, not a save');
+
+    await waitFor(`${STACK} .feed-remix-source`);
+    assert
+      .dom(`${STACK} .feed-remix-source`)
+      .hasText(
+        'from First Note',
+        'the event names the source it was cloned from',
+      );
   });
 });

--- a/packages/host/tests/integration/components/workspace-unit-test.gts
+++ b/packages/host/tests/integration/components/workspace-unit-test.gts
@@ -105,4 +105,36 @@ module('Integration | Card | workspace | pure functions', function (hooks) {
       );
     });
   });
+
+  module('activityVerbFor', function () {
+    const created = 1_000_000;
+
+    test('a RemixCard is a first-class "Remixed" event regardless of timing', function (assert) {
+      // The remix verb wins even when the save timing would otherwise read as a
+      // fresh "Created" — the RemixCard instance IS the record of the clone.
+      assert.strictEqual(
+        ws.activityVerbFor('Remix', created + 60_000, created),
+        'Remixed',
+      );
+      assert.strictEqual(
+        ws.activityVerbFor('Remix', created + 300_000, created),
+        'Remixed',
+      );
+    });
+
+    test('a non-remix card falls back to the Created/Updated timing rule', function (assert) {
+      assert.strictEqual(
+        ws.activityVerbFor('Note', created + 60_000, created),
+        'Created',
+      );
+      assert.strictEqual(
+        ws.activityVerbFor('Note', created + 300_000, created),
+        'Updated',
+      );
+      assert.strictEqual(
+        ws.activityVerbFor(undefined, created + 60_000, created),
+        'Created',
+      );
+    });
+  });
 });


### PR DESCRIPTION
Surfaces **remix** events in the Workspace **Activity** feed as first-class events rather than generic card saves. (CS-12123; depends on the Workspace card and `RemixCard`, both on `main`.)

## What changed

The Activity feed already listed `RemixCard` instances — but as ordinary "Created/Updated" rows like any other card. A remix is its own kind of event, so it now reads as one:

- **New `Remixed` verb.** `activityVerbFor(displayName, modMs, createdMs)` returns `Remixed` for a `RemixCard` instance and otherwise falls back to the existing `classifyActivityVerb` Created/Updated timing rule. The remix is recognized structurally by `displayName` (like `SYSTEM_TYPE_NAMES`), so `workspace.gts` keeps compiling without a static `RemixCard` import — matching how `loadJobs` already references it via `codeRef`.
- **Source attribution.** Each remix row renders "from `<source>`", read live off the card's `remixedFrom` link via a template helper, so it fills in reactively when the linked instance finishes loading. Omitted for remixes with no source set.
- **Distinct styling** for the Remixed verb.

### Event-source decision
Per the ticket, the event source was the open question. This uses the **RemixCard instance itself as the record of the clone** — the cheapest reliable source, reusing the existing realm-local feed query and view-model. No new subscription plumbing. (Same precedent applies to the sibling CS-12121 indexing-activity work.)

### Preserved behavior
Reverse-chron ordering, day headers, the 20-item reveal, and the 100-item cap are untouched — the remix event flows through the same feed view-model as every other row, and the feed still defers loading until the Activity tab is opened.

## Tests
- **Unit** (`workspace-unit-test`): `activityVerbFor` returns `Remixed` for a remix regardless of write timing, and falls back to the timing rule otherwise.
- **Acceptance** (`workspace-test`): indexes a `RemixCard` cloned from a card, opens Activity, and asserts the row renders as a `Remixed` event naming its source.

## Verification
- glint (`ember-tsc --noEmit`): 0 errors
- `ember-template-lint`: clean
- `prettier --check`: clean

The host acceptance/integration suites need the env-mode realm+matrix stack, which wasn't run locally — CI exercises them. (A few unrelated `{{if}}` lines in `workspace.gts` reformatted due to a prettier-plugin version bump; `packages/base` has no CI prettier check, and the pre-commit hook reformats them regardless.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)