### PR TITLE
Answer realm-server liveness off the main thread

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,4 +22,5 @@ The following are important concepts:
 ## Operations
 
 - [Realm-server health signals](realm-server-health-signals.md): which check answers which question, why an event-loop-gated failure is honest, and what to do when the loop saturates.
+- Liveness wedge threshold: set `REALM_LIVENESS_WEDGE_MS` (milliseconds) to control how long the realm-server's event loop may go without turning before `/_liveness` reports it wedged; default is 30000, floor 5000. The endpoint is served only when `--livenessPort` is passed.
 - From-scratch indexing timeout: set `FROM_SCRATCH_JOB_TIMEOUT_SEC` (seconds) to control the from-scratch indexing job timeout and the queue worker cap; default is 3600.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,4 +21,5 @@ The following are important concepts:
 
 ## Operations
 
+- [Realm-server health signals](realm-server-health-signals.md): which check answers which question, why an event-loop-gated failure is honest, and what to do when the loop saturates.
 - From-scratch indexing timeout: set `FROM_SCRATCH_JOB_TIMEOUT_SEC` (seconds) to control the from-scratch indexing job timeout and the queue worker cap; default is 3600.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,5 +22,5 @@ The following are important concepts:
 ## Operations
 
 - [Realm-server health signals](realm-server-health-signals.md): which check answers which question, why an event-loop-gated failure is honest, and what to do when the loop saturates.
-- Liveness wedge threshold: set `REALM_LIVENESS_WEDGE_MS` (milliseconds) to control how long the realm-server's event loop may go without turning before `/_liveness` reports it wedged; default is 30000, floor 5000. The endpoint is served only when `--livenessPort` is passed.
+- Liveness wedge threshold: set `REALM_LIVENESS_WEDGE_MS` (milliseconds) to control how long the realm-server's event loop may go without turning before `/_liveness` reports it wedged; default is 60000 (sized against measured stalls — see the doc), floor 5000. The endpoint is served only when `--livenessPort` is passed.
 - From-scratch indexing timeout: set `FROM_SCRATCH_JOB_TIMEOUT_SEC` (seconds) to control the from-scratch indexing job timeout and the queue worker cap; default is 3600.

--- a/docs/realm-server-health-signals.md
+++ b/docs/realm-server-health-signals.md
@@ -32,11 +32,16 @@ monotonic reading into a `SharedArrayBuffer` on a 250ms interval; the worker rea
 it and reports its age:
 
 ```
-{ "alive": true, "heartbeatAgeMs": 41, "wedgeMs": 30000 }
+{ "alive": true, "heartbeatAgeMs": 41, "wedgeMs": 60000 }
 ```
 
 200 while the age is within `wedgeMs`, 503 past it. `REALM_LIVENESS_WEDGE_MS`
-tunes the threshold, with a 5s floor. The clock is `process.hrtime.bigint()`
+tunes the threshold, with a 5s floor. The 60s default is sized against measured
+stalls: the worst event-loop stall seen on a deployed realm-server during an
+overload incident is ~25s, a deep search-overload incident peaked near 11s, and
+ordinary production operation stays under ~5s. A genuinely stopped loop does not
+recover, so it exceeds any threshold — which makes erring high nearly free and
+erring low a restart of a server that was only busy. The clock is `process.hrtime.bigint()`
 rather than wall time, so an NTP or hypervisor step can neither age a fresh beat
 into a false wedge nor rejuvenate a stale one.
 
@@ -116,10 +121,19 @@ the trigger is wired up.
 
 The parameters matter as much as the endpoint. Replacement should require the
 endpoint to say "wedged" several times over: at 30s intervals with 3 retries, on
-top of the endpoint's own 30s threshold, that is roughly two minutes of a loop
-that has not turned. A `startPeriod` is required — there is a window early in boot
-where the module graph is still evaluating and nothing is listening yet, and every
-check in it is refused.
+top of the endpoint's own 60s threshold, that is around two and a half minutes of
+a loop that has not turned.
+
+Boot needs its own protection, but not for the reason it first appears. The
+responder binds at module scope, within milliseconds — so the unlistening window
+is tiny, and a fail-open probe treats it as healthy anyway. The exposure is the
+opposite one: everything after that point (fetching the host shell, migrations,
+mounting realms, the boot index) runs with the endpoint **live**, and a boot step
+that blocks the loop past `wedgeMs` produces a real 503 on a task that is merely
+starting up. That is what a service-level health-check grace period covers, and
+it is why one is set. Note also that AWS ends a container `startPeriod` at the
+first _successful_ check — which a fail-open probe delivers immediately — so a
+`startPeriod` alone would lapse long before boot finishes.
 
 The probe should also fail _open_: only an affirmative 503 means unhealthy. A
 plain `curl -f || exit 1` treats a refused connection the same as a wedge, which

--- a/docs/realm-server-health-signals.md
+++ b/docs/realm-server-health-signals.md
@@ -26,17 +26,19 @@ elsewhere.
 
 ### `GET /_liveness` — the wedge check
 
-Served off a `worker_threads` worker on a loopback-only port
-(`--livenessPort`), from `packages/realm-server/liveness/`. The main thread writes
-a timestamp into a `SharedArrayBuffer` on a 250ms interval; the worker reads that
-timestamp and reports its age:
+Served off a `worker_threads` worker bound to `127.0.0.1` on the port given by
+`--livenessPort`, from `packages/realm-server/liveness/`. The main thread writes a
+monotonic reading into a `SharedArrayBuffer` on a 250ms interval; the worker reads
+it and reports its age:
 
 ```
 { "alive": true, "heartbeatAgeMs": 41, "wedgeMs": 30000 }
 ```
 
 200 while the age is within `wedgeMs`, 503 past it. `REALM_LIVENESS_WEDGE_MS`
-tunes the threshold, with a 5s floor.
+tunes the threshold, with a 5s floor. The clock is `process.hrtime.bigint()`
+rather than wall time, so an NTP or hypervisor step can neither age a fresh beat
+into a false wedge nor rejuvenate a stale one.
 
 Because the answer comes off a different thread and depends on nothing but shared
 memory, it is available exactly when `GET /` is not. And because the value it
@@ -51,6 +53,12 @@ cases `GET /` cannot tell apart:
 
 Both middle and bottom rows look identical to a load balancer. Only the bottom one
 is worth a restart.
+
+What the beat proves is that the timers phase runs — not that the process can
+accept a connection or make useful progress. A server thrashing on a near-full
+heap, or out of file descriptors, still beats and still answers 200. That is
+tolerable because the ALB check keeps its own replacement power over exactly
+those cases, but it is a reason not to over-trust a 200 here on its own.
 
 ### The `realm:health` log line
 
@@ -93,31 +101,56 @@ equivalent split. It has two health signals — the ALB target-group check and t
 container `healthCheck` — and **both** replace the task when they fail. There is no
 "stop routing but keep this task".
 
-The two signals here approximate the split as closely as ECS allows:
+The two signals approximate the split as closely as ECS allows:
 
 - The **ALB check** (`GET /`) drives routing and deregistration, with its timeout
   and unhealthy threshold set wide enough that transient saturation cannot cross
   them.
-- The **container `healthCheck`** curls `/_liveness` on the loopback port and is
-  what actually decides replacement, on a signal that only a stalled loop trips.
+- A **container `healthCheck`** curls `/_liveness` on the loopback port and
+  decides replacement, on a signal that only a stalled loop trips.
+
+The container check lives in the task definition, not in this repo. The
+realm-server serves the endpoint whenever `--livenessPort` is set, whether or not
+anything is checking it — so the presence of the endpoint does not by itself mean
+the trigger is wired up.
+
+The parameters matter as much as the endpoint. Replacement should require the
+endpoint to say "wedged" several times over: at 30s intervals with 3 retries, on
+top of the endpoint's own 30s threshold, that is roughly two minutes of a loop
+that has not turned. A `startPeriod` is required — there is a window early in boot
+where the module graph is still evaluating and nothing is listening yet, and every
+check in it is refused.
+
+The probe should also fail _open_: only an affirmative 503 means unhealthy. A
+plain `curl -f || exit 1` treats a refused connection the same as a wedge, which
+turns a responder that failed to bind into a task-replacement loop — and outside a
+deployment there is no circuit breaker to bound it. The endpoint is an operational
+signal, and losing it should cost the signal, not the service.
 
 The result is not a true readiness/liveness split — a saturated target is still
 eventually deregistered, and a broad flood still produces 5xx at the load balancer.
-What it does buy is that transient saturation stops causing task replacement, so
+What it buys is that transient saturation stops causing task replacement, so
 recovery once load abates is fast instead of being fought by a cold cache.
 
-`/_liveness` binds loopback only, so it is reachable from a check running inside the
-container and from nowhere else. It is unauthenticated, and it stays off the routable
-address for that reason.
+`/_liveness` binds IPv4 loopback only, so it is reachable from inside the task and
+nowhere else. Under `awsvpc` every container in the task shares that network
+namespace, so any sidecar can reach it too. It is unauthenticated, which is why it
+stays off the routable address. Point checks at `127.0.0.1` rather than
+`localhost`, which can resolve to `::1` first.
 
 ## Operating
 
-**A liveness port that never binds looks like a wedge.** A container check pointed
-at an endpoint that is not being served fails every time, which restart-loops the
-service. The endpoint must therefore ship and be verified serving _before_ anything
-is wired to check it, and on rollback the check must come off _before_ the image
-goes back to one that does not serve it. A bind failure is logged on
-`realm:liveness` and reported to Sentry; serving is unaffected either way.
+**Ship the endpoint before wiring a check at it.** With a fail-open probe an
+unreachable endpoint reads as healthy, so getting this backwards is not
+destructive — but the check is then silently inert, reporting green on a server
+nobody is watching for wedges. Verify `curl 127.0.0.1:<port>/_liveness` from
+inside a task before trusting the trigger, and on rollback expect the same
+inertness rather than an outage.
+
+**A responder that is not answering is invisible by design.** A bind failure or a
+dead responder thread leaves serving untouched — that is the intent — so the only
+notice is a `realm:liveness` log line and a Sentry report. Those are the signal
+that wedge detection has stopped working; nothing else will say so.
 
 **When `GET /` starts failing**, read `realm:health` for the same window before
 concluding anything:

--- a/docs/realm-server-health-signals.md
+++ b/docs/realm-server-health-signals.md
@@ -1,0 +1,144 @@
+# Realm-server health signals
+
+The realm-server is a single Node process with a single event loop. Every request
+it serves — every JSON:API serialization, every `loadLinks` fan-out, every search
+result assembly — competes for that one thread. Under enough concurrent load the
+loop turns late, and everything on it waits, including whatever is asking whether
+the server is healthy.
+
+That makes "is this server healthy?" two different questions with two different
+right answers, and confusing them is expensive. This document is about which
+signal answers which question, and what to do with each.
+
+## The three signals
+
+### `GET /` — the load balancer's check
+
+`healthCheck` in `packages/realm-server/middleware/index.ts` answers `OK` from
+memory to any request whose user-agent starts with `ELB-HealthChecker`, ahead of
+the host-app and realm-serving middleware. It touches no database, no filesystem,
+and no realm state.
+
+It is served **by the event loop**, so it answers only when the loop has capacity
+to answer. That is what makes it the right signal for routing: a target that
+cannot answer this cannot serve a user's request either, and traffic should go
+elsewhere.
+
+### `GET /_liveness` — the wedge check
+
+Served off a `worker_threads` worker on a loopback-only port
+(`--livenessPort`), from `packages/realm-server/liveness/`. The main thread writes
+a timestamp into a `SharedArrayBuffer` on a 250ms interval; the worker reads that
+timestamp and reports its age:
+
+```
+{ "alive": true, "heartbeatAgeMs": 41, "wedgeMs": 30000 }
+```
+
+200 while the age is within `wedgeMs`, 503 past it. `REALM_LIVENESS_WEDGE_MS`
+tunes the threshold, with a 5s floor.
+
+Because the answer comes off a different thread and depends on nothing but shared
+memory, it is available exactly when `GET /` is not. And because the value it
+reports is a measurement the main thread itself produced, it distinguishes the two
+cases `GET /` cannot tell apart:
+
+| Main loop               | `GET /`   | `/_liveness`                       |
+| ----------------------- | --------- | ---------------------------------- |
+| idle or busy, turning   | 200       | 200                                |
+| saturated, turning late | times out | 200, with a large `heartbeatAgeMs` |
+| stopped turning         | times out | 503                                |
+
+Both middle and bottom rows look identical to a load balancer. Only the bottom one
+is worth a restart.
+
+### The `realm:health` log line
+
+`health-sampler.ts` samples `monitorEventLoopDelay` every 5s and logs when peak
+lag crosses a threshold or a search is in flight:
+
+```
+eventLoopLagMs(mean/p99/max)=… inFlightSearch=… heapMB=…
+```
+
+Silent on an idle, healthy server — so its presence in the logs is itself the
+signal. Lag climbing in step with `inFlightSearch` is the fingerprint of the loop
+being starved by concurrent search serialization.
+
+## An event-loop-gated failure is honest
+
+When the loop is saturated and the load balancer's check times out, the check is
+not broken and it is not lying. A server that cannot answer a request from memory
+cannot serve a card either. The check must never be made to answer from somewhere
+that isn't subject to the same constraint as real traffic — a check that stays
+green through an outage is worse than no check.
+
+What is wrong in that situation is the **reaction**. On ECS, an unhealthy target
+gets its task replaced, and replacing a saturated realm-server does not relieve the
+saturation: the replacement starts with an empty definition and transpile cache,
+pays every miss again, and lands in the same load. Under sustained load that is a
+loop, and each turn of it is slower than the last.
+
+So the fix for a saturated server is never to soften the check. It is to bound the
+work (`packages/runtime-common/search-bounds.ts` caps page size and wall-clock per
+item-leg search), to tolerate the transient (health-check timeout and unhealthy
+threshold set wide enough that a blip cannot cross them), and to restart only for a
+loop that has genuinely stopped.
+
+## Why there are two signals instead of one
+
+Kubernetes splits this natively: a failed readiness probe removes a pod from
+service without restarting it, a failed liveness probe restarts it. ECS has no
+equivalent split. It has two health signals — the ALB target-group check and the
+container `healthCheck` — and **both** replace the task when they fail. There is no
+"stop routing but keep this task".
+
+The two signals here approximate the split as closely as ECS allows:
+
+- The **ALB check** (`GET /`) drives routing and deregistration, with its timeout
+  and unhealthy threshold set wide enough that transient saturation cannot cross
+  them.
+- The **container `healthCheck`** curls `/_liveness` on the loopback port and is
+  what actually decides replacement, on a signal that only a stalled loop trips.
+
+The result is not a true readiness/liveness split — a saturated target is still
+eventually deregistered, and a broad flood still produces 5xx at the load balancer.
+What it does buy is that transient saturation stops causing task replacement, so
+recovery once load abates is fast instead of being fought by a cold cache.
+
+`/_liveness` binds loopback only, so it is reachable from a check running inside the
+container and from nowhere else. It is unauthenticated, and it stays off the routable
+address for that reason.
+
+## Operating
+
+**A liveness port that never binds looks like a wedge.** A container check pointed
+at an endpoint that is not being served fails every time, which restart-loops the
+service. The endpoint must therefore ship and be verified serving _before_ anything
+is wired to check it, and on rollback the check must come off _before_ the image
+goes back to one that does not serve it. A bind failure is logged on
+`realm:liveness` and reported to Sentry; serving is unaffected either way.
+
+**When `GET /` starts failing**, read `realm:health` for the same window before
+concluding anything:
+
+- Lag in the hundreds of ms to seconds, `inFlightSearch` elevated → saturation. The
+  server will recover when load drops. Look for what is generating the load;
+  restarting makes it worse.
+- Lag low, heap flat, but checks failing anyway → not saturation. Look at what sits
+  between the load balancer and the process.
+- No heartbeat at all and `/_liveness` returning 503 → the loop has stopped.
+  Replacement is the correct response.
+
+**Load that loops back through the public load balancer** — internal fan-out that
+resolves cross-realm links or re-enters `_search` through the external address —
+counts twice against the same event loop, and turns a degraded server into a source
+of its own load. Traffic that does not need to leave the process should not.
+
+## Note on naming
+
+`livenessCheck` in `packages/realm-server/middleware/index.ts` is a different thing
+from the endpoint described above: a trivial loop-served 200 used by the
+worker-manager and prerender apps. It answers "this process is listening", which the
+event loop must be free to say. `/_liveness` answers "this process's event loop is
+turning", which is only meaningful when asked from off that loop.

--- a/packages/realm-server/liveness/event-loop-heartbeat.ts
+++ b/packages/realm-server/liveness/event-loop-heartbeat.ts
@@ -1,0 +1,67 @@
+// The main thread's proof-of-life: a timestamp rewritten on every event-loop
+// turn into memory another thread can read.
+//
+// A `SharedArrayBuffer` rather than `postMessage` because the reader has to
+// stay useful precisely when the main thread is unavailable. Anything that
+// needs the main loop to run — a message round-trip, a callback, a write to a
+// stream the parent pumps — reports nothing at all in the case worth reporting.
+// A shared buffer the reader polls has no such dependency: the beat simply
+// stops advancing, and its age is the measurement.
+//
+// `BigInt64Array` because the value is an epoch millisecond, which does not fit
+// in the int32 that `Atomics` otherwise offers. `Atomics` on an 8-byte aligned
+// slot is already atomic on every platform we run; using it explicitly is what
+// documents the cross-thread visibility the reader depends on.
+
+// How often the main thread rewrites the beat. Fixed rather than configurable:
+// it only has to be small relative to any useful wedge threshold, and a
+// no-allocation timer callback four times a second costs nothing measurable.
+const BEAT_INTERVAL_MS = 250;
+
+const BEAT_SLOT = 0;
+
+export interface Heartbeat {
+  // Handed to the reader. Shared, not copied.
+  buffer: SharedArrayBuffer;
+  // Records a beat at the current time.
+  beat: () => void;
+  stop: () => void;
+}
+
+// A heartbeat with no timer of its own — the caller decides when a beat
+// happens. `startEventLoopHeartbeat` is the production caller; a caller that
+// needs a beat at a chosen age (a test, without blocking a thread) pairs this
+// with `writeBeat`.
+export function createHeartbeat(): Heartbeat {
+  let buffer = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT);
+  let beat = () => writeBeat(buffer, Date.now());
+  // Beat once here so the buffer is never observed at epoch 0 by a reader that
+  // attaches before the first interval tick.
+  beat();
+  return { buffer, beat, stop: () => {} };
+}
+
+// The single encoder of a beat into the shared buffer.
+export function writeBeat(buffer: SharedArrayBuffer, atMs: number): void {
+  Atomics.store(new BigInt64Array(buffer), BEAT_SLOT, BigInt(atMs));
+}
+
+export function startEventLoopHeartbeat(): Heartbeat {
+  let heartbeat = createHeartbeat();
+  let timer = setInterval(heartbeat.beat, BEAT_INTERVAL_MS);
+  // Don't keep the process alive solely for the heartbeat.
+  timer.unref?.();
+  return {
+    ...heartbeat,
+    stop: () => clearInterval(timer),
+  };
+}
+
+// Binds a reader to a buffer produced by `createHeartbeat`, for a holder of the
+// buffer that doesn't have the closure that writes it — the responder worker,
+// which receives the buffer through `workerData`. The typed-array view is built
+// once here rather than per read, so answering a request allocates nothing.
+export function createBeatReader(buffer: SharedArrayBuffer): () => number {
+  let view = new BigInt64Array(buffer);
+  return () => Number(Atomics.load(view, BEAT_SLOT));
+}

--- a/packages/realm-server/liveness/event-loop-heartbeat.ts
+++ b/packages/realm-server/liveness/event-loop-heartbeat.ts
@@ -8,9 +8,16 @@
 // A shared buffer the reader polls has no such dependency: the beat simply
 // stops advancing, and its age is the measurement.
 //
-// `BigInt64Array` because the value is an epoch millisecond, which does not fit
-// in the int32 that `Atomics` otherwise offers. `Atomics` on an 8-byte aligned
-// slot is already atomic on every platform we run; using it explicitly is what
+// The clock is `process.hrtime.bigint()`, not `Date.now()`. It is monotonic, so
+// an NTP or hypervisor step can't age a beat that was just written (a forward
+// step past the wedge threshold would otherwise condemn a healthy server) or
+// rejuvenate one that is genuinely stale. Its base is per-process, not
+// per-thread, so a reading taken on the responder thread is directly comparable
+// to a beat written on the main thread.
+//
+// `BigInt64Array` because the value is nanoseconds, far past what the int32
+// `Atomics` otherwise offers can hold. `Atomics` on an 8-byte aligned slot is
+// already tear-free on every platform we run; using it explicitly is what
 // documents the cross-thread visibility the reader depends on.
 
 // How often the main thread rewrites the beat. Fixed rather than configurable:
@@ -34,16 +41,16 @@ export interface Heartbeat {
 // with `writeBeat`.
 export function createHeartbeat(): Heartbeat {
   let buffer = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT);
-  let beat = () => writeBeat(buffer, Date.now());
-  // Beat once here so the buffer is never observed at epoch 0 by a reader that
+  // View built once and closed over, so a beat allocates nothing beyond the
+  // BigInt itself.
+  let view = new BigInt64Array(buffer);
+  let beat = () => {
+    Atomics.store(view, BEAT_SLOT, process.hrtime.bigint());
+  };
+  // Beat once here so the buffer is never observed at 0 by a reader that
   // attaches before the first interval tick.
   beat();
   return { buffer, beat, stop: () => {} };
-}
-
-// The single encoder of a beat into the shared buffer.
-export function writeBeat(buffer: SharedArrayBuffer, atMs: number): void {
-  Atomics.store(new BigInt64Array(buffer), BEAT_SLOT, BigInt(atMs));
 }
 
 export function startEventLoopHeartbeat(): Heartbeat {
@@ -57,11 +64,17 @@ export function startEventLoopHeartbeat(): Heartbeat {
   };
 }
 
+// Places a beat at an explicit monotonic reading, for a caller that needs one
+// of a chosen age without waiting for real time to pass.
+export function writeBeat(buffer: SharedArrayBuffer, atNs: bigint): void {
+  Atomics.store(new BigInt64Array(buffer), BEAT_SLOT, atNs);
+}
+
 // Binds a reader to a buffer produced by `createHeartbeat`, for a holder of the
 // buffer that doesn't have the closure that writes it — the responder worker,
 // which receives the buffer through `workerData`. The typed-array view is built
-// once here rather than per read, so answering a request allocates nothing.
-export function createBeatReader(buffer: SharedArrayBuffer): () => number {
+// once here rather than per read.
+export function createBeatReader(buffer: SharedArrayBuffer): () => bigint {
   let view = new BigInt64Array(buffer);
-  return () => Number(Atomics.load(view, BEAT_SLOT));
+  return () => Atomics.load(view, BEAT_SLOT);
 }

--- a/packages/realm-server/liveness/index.ts
+++ b/packages/realm-server/liveness/index.ts
@@ -54,10 +54,28 @@ export function startLivenessResponder({
     host,
     wedgeMs,
   };
-  let worker = new Worker(
-    new URL('./liveness-responder-worker.ts', import.meta.url),
-    { workerData },
-  );
+  let worker: Worker;
+  try {
+    worker = new Worker(
+      new URL('./liveness-responder-worker.ts', import.meta.url),
+      { workerData },
+    );
+  } catch (err) {
+    // The constructor throws synchronously when the thread itself can't be
+    // created — the host is out of thread or memory headroom, say. This runs
+    // during the server's own startup, so letting it escape would turn a
+    // missing operational signal into a server that doesn't boot. Report it and
+    // hand back a responder that does nothing.
+    let error = err instanceof Error ? err : new Error(String(err));
+    log.error(
+      `liveness responder thread could not be started: ${error.message}`,
+    );
+    Sentry.captureException(error);
+    return {
+      listening: Promise.resolve(undefined),
+      stop: async () => {},
+    };
+  }
 
   let resolveListening!: (boundPort: number | undefined) => void;
   let listening = new Promise<number | undefined>((resolve) => {

--- a/packages/realm-server/liveness/index.ts
+++ b/packages/realm-server/liveness/index.ts
@@ -1,0 +1,112 @@
+import { Worker } from 'node:worker_threads';
+import * as Sentry from '@sentry/node';
+import { logger } from '@cardstack/runtime-common';
+import type { LivenessResponderWorkerData } from './liveness-responder-worker.ts';
+
+// Spawns the thread that answers `/_liveness`, and owns its lifecycle.
+//
+// The responder is an operational signal, not part of serving. A port it cannot
+// bind, or a thread that dies, must leave the realm-server handling traffic
+// exactly as before — so every failure here is logged and reported, never
+// thrown.
+
+const DEFAULT_WEDGE_MS = 30_000;
+// Below a few seconds a threshold stops distinguishing a wedge from an ordinary
+// long synchronous span (a large serialization, a major GC), and starts calling
+// a server dead that is merely busy.
+const MIN_WEDGE_MS = 5_000;
+const LOOPBACK_HOST = '127.0.0.1';
+
+// Ops knob, in the shape the package's other tunables use: an env override,
+// clamped so a malformed value can't disable the floor.
+export function livenessWedgeMs(
+  raw: string | undefined = process.env.REALM_LIVENESS_WEDGE_MS,
+): number {
+  let parsed = raw != null ? Number(raw) : NaN;
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_WEDGE_MS;
+  }
+  return Math.max(MIN_WEDGE_MS, Math.floor(parsed));
+}
+
+export interface LivenessResponder {
+  // The port the responder actually bound, once it has. Resolves to undefined
+  // when the bind failed — the caller carries on serving either way.
+  listening: Promise<number | undefined>;
+  stop: () => Promise<void>;
+}
+
+export function startLivenessResponder({
+  buffer,
+  port,
+  wedgeMs = livenessWedgeMs(),
+  host = LOOPBACK_HOST,
+}: {
+  buffer: SharedArrayBuffer;
+  port: number;
+  wedgeMs?: number;
+  host?: string;
+}): LivenessResponder {
+  let log = logger('realm:liveness');
+  let workerData: LivenessResponderWorkerData = {
+    buffer,
+    port,
+    host,
+    wedgeMs,
+  };
+  let worker = new Worker(
+    new URL('./liveness-responder-worker.ts', import.meta.url),
+    { workerData },
+  );
+
+  let resolveListening!: (boundPort: number | undefined) => void;
+  let listening = new Promise<number | undefined>((resolve) => {
+    resolveListening = resolve;
+  });
+  // The responder must not be the reason the process stays up, but it must stay
+  // referenced long enough to report whether it bound — an unreferenced worker
+  // holds no handle, so node would exit (or a caller's `await listening` would
+  // hang) before the first message arrived. Referenced until it has reported,
+  // unreferenced after.
+  //
+  // Unreferencing has to happen after the `message` listener is attached in any
+  // case: attaching one starts the parent's side of the port, which re-references
+  // the handle and would undo an earlier `unref`.
+  let settle = (boundPort: number | undefined) => {
+    resolveListening(boundPort);
+    worker.unref();
+  };
+
+  worker.on(
+    'message',
+    (message: { type?: string; port?: number; message?: string }) => {
+      if (message?.type === 'listening') {
+        log.info(
+          `liveness responder listening on ${host}:${message.port} wedgeMs=${wedgeMs}`,
+        );
+        settle(message.port);
+      } else if (message?.type === 'error') {
+        // Most often the port is already taken. Loud, because a check wired to
+        // an endpoint that never bound reads as a wedge.
+        log.error(`liveness responder failed to serve: ${message.message}`);
+        Sentry.captureException(
+          new Error(`liveness responder failed to serve: ${message.message}`),
+        );
+        settle(undefined);
+      }
+    },
+  );
+  worker.on('error', (err) => {
+    log.error(`liveness responder thread error: ${err.message}`);
+    Sentry.captureException(err);
+    settle(undefined);
+  });
+  worker.on('exit', () => settle(undefined));
+
+  return {
+    listening,
+    stop: async () => {
+      await worker.terminate();
+    },
+  };
+}

--- a/packages/realm-server/liveness/index.ts
+++ b/packages/realm-server/liveness/index.ts
@@ -22,7 +22,14 @@ const LOOPBACK_HOST = '127.0.0.1';
 export function livenessWedgeMs(
   raw: string | undefined = process.env.REALM_LIVENESS_WEDGE_MS,
 ): number {
-  let parsed = raw != null ? Number(raw) : NaN;
+  // An empty or whitespace-only value counts as unset, not as zero. Setting a
+  // variable to "" is an ordinary way to clear it in a task definition, and
+  // `Number('')` is 0 — which is finite, so it would otherwise skip the default
+  // and clamp all the way down to the floor. Getting the shortest permitted
+  // threshold from an attempt to remove the override is the wrong surprise when
+  // the consequence is a task restart.
+  let trimmed = raw?.trim();
+  let parsed = trimmed ? Number(trimmed) : NaN;
   if (!Number.isFinite(parsed)) {
     return DEFAULT_WEDGE_MS;
   }
@@ -58,7 +65,11 @@ export function startLivenessResponder({
   try {
     worker = new Worker(
       new URL('./liveness-responder-worker.ts', import.meta.url),
-      { workerData },
+      // A worker inherits `process.execArgv` by default, which couples the
+      // responder to whatever the realm-server happened to be launched with —
+      // `--input-type=module`, for one, stops the worker starting at all. It
+      // needs no flags of its own.
+      { workerData, execArgv: [] },
     );
   } catch (err) {
     // The constructor throws synchronously when the thread itself can't be
@@ -119,11 +130,25 @@ export function startLivenessResponder({
     Sentry.captureException(err);
     settle(undefined);
   });
-  worker.on('exit', () => settle(undefined));
+  let expectedExit = false;
+  worker.on('exit', (code) => {
+    // A thread that dies on its own is the quiet failure mode: the endpoint
+    // stops answering, and a check reading that as "unreachable, not wedged"
+    // carries on green, so nothing else will ever mention that wedge detection
+    // is off. This log and the Sentry report are the only notice.
+    if (!expectedExit) {
+      log.error(`liveness responder thread exited on its own (code ${code})`);
+      Sentry.captureException(
+        new Error(`liveness responder thread exited on its own (code ${code})`),
+      );
+    }
+    settle(undefined);
+  });
 
   return {
     listening,
     stop: async () => {
+      expectedExit = true;
       await worker.terminate();
     },
   };

--- a/packages/realm-server/liveness/index.ts
+++ b/packages/realm-server/liveness/index.ts
@@ -10,7 +10,15 @@ import type { LivenessResponderWorkerData } from './liveness-responder-worker.ts
 // exactly as before — so every failure here is logged and reported, never
 // thrown.
 
-const DEFAULT_WEDGE_MS = 30_000;
+// Sized against measured stalls rather than a round number. The worst
+// event-loop stall observed on a deployed realm-server during an overload
+// incident is ~25s (a deploy-churn event); a deep search-overload incident
+// peaked near 11s, and ordinary production operation stays under ~5s. 60s sits
+// well clear of all three while remaining far below anything a genuinely
+// stopped loop would produce, since a wedge does not recover and blows past any
+// threshold. Erring high costs only detection latency; erring low costs a
+// restart of a server that was busy, which is the outcome this exists to avoid.
+const DEFAULT_WEDGE_MS = 60_000;
 // Below a few seconds a threshold stops distinguishing a wedge from an ordinary
 // long synchronous span (a large serialization, a major GC), and starts calling
 // a server dead that is merely busy.
@@ -106,10 +114,12 @@ export function startLivenessResponder({
     worker.unref();
   };
 
+  let bound = false;
   worker.on(
     'message',
     (message: { type?: string; port?: number; message?: string }) => {
       if (message?.type === 'listening') {
+        bound = true;
         log.info(
           `liveness responder listening on ${host}:${message.port} wedgeMs=${wedgeMs}`,
         );
@@ -132,11 +142,16 @@ export function startLivenessResponder({
   });
   let expectedExit = false;
   worker.on('exit', (code) => {
-    // A thread that dies on its own is the quiet failure mode: the endpoint
-    // stops answering, and a check reading that as "unreachable, not wedged"
-    // carries on green, so nothing else will ever mention that wedge detection
-    // is off. This log and the Sentry report are the only notice.
-    if (!expectedExit) {
+    // A thread that dies after it was serving is the quiet failure mode: the
+    // endpoint stops answering, and a check reading that as "unreachable, not
+    // wedged" carries on green, so nothing else will ever mention that wedge
+    // detection is off. This log and the Sentry report are the only notice.
+    //
+    // Gated on having bound, because the worker's only handle is its server:
+    // when `listen` fails its loop empties and it exits immediately after. That
+    // exit is the same incident the branch above already reported, and calling
+    // it a thread death names a fault that didn't happen.
+    if (!expectedExit && bound) {
       log.error(`liveness responder thread exited on its own (code ${code})`);
       Sentry.captureException(
         new Error(`liveness responder thread exited on its own (code ${code})`),

--- a/packages/realm-server/liveness/liveness-responder-worker.ts
+++ b/packages/realm-server/liveness/liveness-responder-worker.ts
@@ -34,17 +34,21 @@ let server = http.createServer((req, res) => {
   // `req.url` is a path, never absolute-form, for the requests this endpoint
   // serves; compare on the path prefix so a query string doesn't miss.
   let path = (req.url ?? '').split('?')[0];
-  if (
-    path !== LIVENESS_PATH ||
-    (req.method !== 'GET' && req.method !== 'HEAD')
-  ) {
+  if (path !== LIVENESS_PATH) {
     res.writeHead(404, { 'content-type': 'text/plain' });
     res.end('not found');
     return;
   }
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    // 405 over 404 so a check pointed at the right path with the wrong method
+    // says so, rather than looking like a version that doesn't serve it.
+    res.writeHead(405, { 'content-type': 'text/plain', allow: 'GET, HEAD' });
+    res.end('method not allowed');
+    return;
+  }
   let verdict = judgeLiveness({
-    nowMs: Date.now(),
-    beatMs: readBeat(),
+    nowNs: process.hrtime.bigint(),
+    beatNs: readBeat(),
     wedgeMs,
   });
   let body = JSON.stringify(verdict);

--- a/packages/realm-server/liveness/liveness-responder-worker.ts
+++ b/packages/realm-server/liveness/liveness-responder-worker.ts
@@ -1,0 +1,79 @@
+import http from 'node:http';
+import { parentPort, workerData } from 'node:worker_threads';
+import { createBeatReader } from './event-loop-heartbeat.ts';
+import { judgeLiveness } from './liveness-verdict.ts';
+
+// Serves the main thread's liveness verdict from a thread of its own, so the
+// answer is available in the one situation an answer is worth having: the main
+// thread has no capacity to give one.
+//
+// Everything on the request path reads the shared heartbeat buffer and nothing
+// else. In particular this worker must not, while serving:
+//
+//   - `postMessage` the parent and await a reply — a wedged parent never replies;
+//   - write to `console` / `process.stdout` / `process.stderr` — worker stdio is
+//     piped through the parent, so those bytes queue behind the wedge.
+//
+// Logging is therefore confined to bind and error events, which happen at
+// startup while the parent is healthy, and travels over `parentPort` for the
+// parent to log through its own logger.
+
+export interface LivenessResponderWorkerData {
+  buffer: SharedArrayBuffer;
+  port: number;
+  host: string;
+  wedgeMs: number;
+}
+
+const LIVENESS_PATH = '/_liveness';
+
+let { buffer, port, host, wedgeMs } = workerData as LivenessResponderWorkerData;
+let readBeat = createBeatReader(buffer);
+
+let server = http.createServer((req, res) => {
+  // `req.url` is a path, never absolute-form, for the requests this endpoint
+  // serves; compare on the path prefix so a query string doesn't miss.
+  let path = (req.url ?? '').split('?')[0];
+  if (
+    path !== LIVENESS_PATH ||
+    (req.method !== 'GET' && req.method !== 'HEAD')
+  ) {
+    res.writeHead(404, { 'content-type': 'text/plain' });
+    res.end('not found');
+    return;
+  }
+  let verdict = judgeLiveness({
+    nowMs: Date.now(),
+    beatMs: readBeat(),
+    wedgeMs,
+  });
+  let body = JSON.stringify(verdict);
+  res.writeHead(verdict.alive ? 200 : 503, {
+    'content-type': 'application/json',
+    'cache-control': 'no-store',
+    'content-length': Buffer.byteLength(body),
+  });
+  if (req.method === 'HEAD') {
+    res.end();
+    return;
+  }
+  res.end(body);
+});
+
+server.on('error', (err: Error) => {
+  parentPort?.postMessage({ type: 'error', message: err.message });
+});
+
+// Loopback only. The endpoint is unauthenticated and exists for a check running
+// inside this container; binding it to the task's routable address would put it
+// on the network for no gain.
+server.listen(port, host, () => {
+  // Report the address actually bound, not the one requested: a caller may pass
+  // 0 for an ephemeral port and needs to learn which one it got.
+  let bound = server.address();
+  parentPort?.postMessage({
+    type: 'listening',
+    port: typeof bound === 'object' && bound ? bound.port : port,
+    wedgeMs,
+  });
+});

--- a/packages/realm-server/liveness/liveness-responder-worker.ts
+++ b/packages/realm-server/liveness/liveness-responder-worker.ts
@@ -46,9 +46,12 @@ let server = http.createServer((req, res) => {
     res.end('method not allowed');
     return;
   }
+  // Beat first, then now: sampled the other way round, a beat landing between
+  // the two reads yields a negative age.
+  let beatNs = readBeat();
   let verdict = judgeLiveness({
     nowNs: process.hrtime.bigint(),
-    beatNs: readBeat(),
+    beatNs,
     wedgeMs,
   });
   let body = JSON.stringify(verdict);
@@ -78,6 +81,5 @@ server.listen(port, host, () => {
   parentPort?.postMessage({
     type: 'listening',
     port: typeof bound === 'object' && bound ? bound.port : port,
-    wedgeMs,
   });
 });

--- a/packages/realm-server/liveness/liveness-verdict.ts
+++ b/packages/realm-server/liveness/liveness-verdict.ts
@@ -11,6 +11,10 @@
 // cold definition/transpile cache and lands back in the same load. The second
 // cannot recover on its own. `wedgeMs` is where that line sits: a beat age
 // under it means "late, still turning", over it means "not turning".
+//
+// Both readings are `process.hrtime.bigint()` nanoseconds off the same
+// process-wide base, so the age is a true elapsed duration and cannot be
+// distorted by a wall-clock adjustment in either direction.
 
 export interface LivenessVerdict {
   // True while the main thread is still turning its event loop, whether or not
@@ -24,26 +28,25 @@ export interface LivenessVerdict {
   wedgeMs: number;
 }
 
+const NS_PER_MS = 1_000_000;
+
 export function judgeLiveness({
-  nowMs,
-  beatMs,
+  nowNs,
+  beatNs,
   wedgeMs,
 }: {
-  nowMs: number;
-  beatMs: number;
+  nowNs: bigint;
+  beatNs: bigint;
   wedgeMs: number;
 }): LivenessVerdict {
-  // A never-written beat reads as epoch 0, which yields an enormous age and so
-  // fails the threshold. That is the honest answer for a buffer nobody has
-  // beaten into: nothing has reported the loop turning. In practice the
-  // heartbeat writes its first beat synchronously at construction, before the
-  // responder exists to be asked.
-  let heartbeatAgeMs = nowMs - beatMs;
-  // A clock that went backwards (NTP step) would otherwise read as a negative
-  // age and pass trivially; clamp so the age is always a duration.
-  if (heartbeatAgeMs < 0) {
-    heartbeatAgeMs = 0;
-  }
+  // A never-written beat reads as 0, which makes the age the whole of process
+  // uptime and so fails any threshold. That is the honest answer for a buffer
+  // nobody has beaten into: nothing has reported the loop turning. In practice
+  // the heartbeat writes its first beat synchronously at construction, before
+  // the responder exists to be asked.
+  // Rounded to whole milliseconds: the threshold is seconds-scale, and a bare
+  // integer reads better in the response body than a nanosecond-precision float.
+  let heartbeatAgeMs = Math.round(Number(nowNs - beatNs) / NS_PER_MS);
   return {
     alive: heartbeatAgeMs <= wedgeMs,
     heartbeatAgeMs,

--- a/packages/realm-server/liveness/liveness-verdict.ts
+++ b/packages/realm-server/liveness/liveness-verdict.ts
@@ -1,0 +1,52 @@
+// Decides whether the realm-server's main thread counts as alive, from the age
+// of the last heartbeat it wrote.
+//
+// Pure and dependency-free so both sides can use it: the responder worker calls
+// it per request, and unit tests drive it without threads or sockets.
+//
+// The distinction it draws is the whole point. A single-threaded server under
+// load has a loop that turns late — hundreds of milliseconds, sometimes
+// seconds — and one that has stopped turning at all. The first recovers once
+// load abates and must not be restarted, because a replacement comes up with a
+// cold definition/transpile cache and lands back in the same load. The second
+// cannot recover on its own. `wedgeMs` is where that line sits: a beat age
+// under it means "late, still turning", over it means "not turning".
+
+export interface LivenessVerdict {
+  // True while the main thread is still turning its event loop, whether or not
+  // it currently has capacity to serve. Consumers that restart on `false` get a
+  // restart only for a loop that has stopped.
+  alive: boolean;
+  // How long ago the main thread last wrote a beat.
+  heartbeatAgeMs: number;
+  // The threshold this verdict was measured against, echoed so a reader of the
+  // response body doesn't have to know the server's configuration.
+  wedgeMs: number;
+}
+
+export function judgeLiveness({
+  nowMs,
+  beatMs,
+  wedgeMs,
+}: {
+  nowMs: number;
+  beatMs: number;
+  wedgeMs: number;
+}): LivenessVerdict {
+  // A never-written beat reads as epoch 0, which yields an enormous age and so
+  // fails the threshold. That is the honest answer for a buffer nobody has
+  // beaten into: nothing has reported the loop turning. In practice the
+  // heartbeat writes its first beat synchronously at construction, before the
+  // responder exists to be asked.
+  let heartbeatAgeMs = nowMs - beatMs;
+  // A clock that went backwards (NTP step) would otherwise read as a negative
+  // age and pass trivially; clamp so the age is always a duration.
+  if (heartbeatAgeMs < 0) {
+    heartbeatAgeMs = 0;
+  }
+  return {
+    alive: heartbeatAgeMs <= wedgeMs,
+    heartbeatAgeMs,
+    wedgeMs,
+  };
+}

--- a/packages/realm-server/liveness/liveness-verdict.ts
+++ b/packages/realm-server/liveness/liveness-verdict.ts
@@ -39,11 +39,11 @@ export function judgeLiveness({
   beatNs: bigint;
   wedgeMs: number;
 }): LivenessVerdict {
-  // A never-written beat reads as 0, which makes the age the whole of process
-  // uptime and so fails any threshold. That is the honest answer for a buffer
-  // nobody has beaten into: nothing has reported the loop turning. In practice
-  // the heartbeat writes its first beat synchronously at construction, before
-  // the responder exists to be asked.
+  // `createHeartbeat` writes its first beat synchronously at construction, so a
+  // reader never sees the 0 an unwritten slot would hold. Worth knowing that the
+  // fallback if one ever did is weaker than it looks: these are CLOCK_MONOTONIC
+  // readings measured from host boot, not from an epoch, so a 0 beat only
+  // exceeds the threshold once the host has been up longer than `wedgeMs`.
   // Rounded to whole milliseconds: the threshold is seconds-scale, and a bare
   // integer reads better in the response body than a nanosecond-precision float.
   let heartbeatAgeMs = Math.round(Number(nowNs - beatNs) / NS_PER_MS);

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -354,8 +354,15 @@ log.info(`Realm paths: ${paths.map(String).join(', ')}`);
 // `--livenessPort` is omitted there is no responder and the heartbeat is a
 // no-cost timer.
 const heartbeat = startEventLoopHeartbeat();
+// Guarded on a real port rather than merely present: yargs turns
+// `--livenessPort=` and `--no-livenessPort` into 0, and a bare `--livenessPort`
+// into NaN. Zero would bind an arbitrary ephemeral port and log it as a success
+// while a check aimed at the configured one is refused forever — a wedge that
+// never was, reported by logs that look fine.
 const livenessResponder =
-  livenessPort != null
+  typeof livenessPort === 'number' &&
+  Number.isInteger(livenessPort) &&
+  livenessPort > 0
     ? startLivenessResponder({ buffer: heartbeat.buffer, port: livenessPort })
     : undefined;
 

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -43,6 +43,8 @@ import { ModuleCacheCoordinator } from './lib/module-cache-coordination.ts';
 import { JobsFinishedListener } from './lib/jobs-finished-listener.ts';
 import { JobScopedSearchCache } from './job-scoped-search-cache.ts';
 import { startHealthSampler } from './health-sampler.ts';
+import { startEventLoopHeartbeat } from './liveness/event-loop-heartbeat.ts';
+import { startLivenessResponder } from './liveness/index.ts';
 import { resolveFullIndexOnStartup } from './lib/full-index-on-startup.ts';
 import { PUBLISHED_DIRECTORY_NAME } from '@cardstack/runtime-common';
 
@@ -196,6 +198,7 @@ let {
   migrateDB,
   workerManagerPort,
   workerManagerUrl,
+  livenessPort,
   prerendererUrl,
 } = yargs(process.argv.slice(2))
   .usage('Start realm server')
@@ -263,6 +266,11 @@ let {
       description:
         'The full URL of the worker manager. Used in branch mode instead of workerManagerPort.',
       type: 'string',
+    },
+    livenessPort: {
+      description:
+        'Loopback-only port on which to answer GET /_liveness with this process’s main-thread liveness, served off a worker thread so the answer survives a saturated event loop. Omit to not serve it at all.',
+      type: 'number',
     },
     prerendererUrl: {
       demandOption: true,
@@ -336,9 +344,20 @@ let autoMigrate = migrateDB || undefined;
 log.info(
   `Realm server boot config: port=${port} serverURL=${serverURL} distURL=${distURL} matrixURL=${matrixURL} realmsRootPath=${realmsRootPath} migrateDB=${Boolean(
     migrateDB,
-  )} workerManagerPort=${workerManagerPort ?? 'none'} prerendererUrl=${prerendererUrl} enableFileWatcher=${ENABLE_FILE_WATCHER} fullIndexOnStartupOverride=${FULL_INDEX_ON_STARTUP_OVERRIDE ?? 'unset (bootstrap-only)'}`,
+  )} workerManagerPort=${workerManagerPort ?? 'none'} livenessPort=${livenessPort ?? 'none'} prerendererUrl=${prerendererUrl} enableFileWatcher=${ENABLE_FILE_WATCHER} fullIndexOnStartupOverride=${FULL_INDEX_ON_STARTUP_OVERRIDE ?? 'unset (bootstrap-only)'}`,
 );
 log.info(`Realm paths: ${paths.map(String).join(', ')}`);
+
+// Start beating before anything else, so the shared buffer reflects a turning
+// event loop for the whole of boot rather than only from the point the server is
+// assembled. The responder reads that buffer from a thread of its own; when
+// `--livenessPort` is omitted there is no responder and the heartbeat is a
+// no-cost timer.
+const heartbeat = startEventLoopHeartbeat();
+const livenessResponder =
+  livenessPort != null
+    ? startLivenessResponder({ buffer: heartbeat.buffer, port: livenessPort })
+    : undefined;
 
 const getIndexHTML = async () => {
   let response = await fetch(distURL);
@@ -713,7 +732,12 @@ const reportHostShellToManager = async () => {
           jobsFinishedListener?.shutDown(),
           moduleCacheInvalidationListener?.shutDown(),
           moduleCacheCoordinator?.shutDown(),
+          livenessResponder?.stop(),
         ]);
+        // Stopped only once the responder is gone, never before: the loop is
+        // still turning while the shutdown above runs, and a check arriving in
+        // that window should read a beating heartbeat rather than a frozen one.
+        heartbeat.stop();
         queue.destroy(); // warning this is async
         dbAdapter.close(); // warning this is async
         console.log(`realm server on port ${stopPort} has stopped`);

--- a/packages/realm-server/scripts/start-production.sh
+++ b/packages/realm-server/scripts/start-production.sh
@@ -40,6 +40,7 @@ NODE_NO_WARNINGS=1 \
   PUBLISHED_REALM_BOXEL_SITE_DOMAIN='boxel.site' \
   exec node main.ts \
   --port=3000 \
+  --livenessPort=3010 \
   --matrixURL='https://matrix.boxel.ai' \
   --realmsRootPath='/persistent/realms' \
   --serverURL='https://app.boxel.ai' \

--- a/packages/realm-server/scripts/start-staging.sh
+++ b/packages/realm-server/scripts/start-staging.sh
@@ -40,6 +40,7 @@ NODE_NO_WARNINGS=1 \
   PUBLISHED_REALM_BOXEL_SITE_DOMAIN='staging.boxel.build' \
   exec node main.ts \
   --port=3000 \
+  --livenessPort=3010 \
   --matrixURL='https://matrix-staging.stack.cards' \
   --realmsRootPath='/persistent/realms' \
   --serverURL='https://realms-staging.stack.cards' \

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -246,6 +246,8 @@ const ALL_TEST_FILES: string[] = [
   './indexing-test',
   './lazy-mount-test',
   './listener-dispatcher-test',
+  './liveness-verdict-test',
+  './liveness-responder-test',
   './module-cache-race-test',
   './module-syntax-test',
   './network-inflight-tracker-test',

--- a/packages/realm-server/tests/liveness-responder-test.ts
+++ b/packages/realm-server/tests/liveness-responder-test.ts
@@ -82,6 +82,9 @@ function armPollingFromOwnThread(port: number): {
 } {
   let worker = new Worker(CLIENT_WORKER_SOURCE, {
     eval: true,
+    // Same reason the responder worker does it: CI launches the suite with
+    // `--require`, and this thread has no use for the parent's flags.
+    execArgv: [],
     workerData: {
       port,
       intervalMs: POLL_INTERVAL_MS,
@@ -116,8 +119,10 @@ function armPollingFromOwnThread(port: number): {
 }
 
 function blockMainThread(ms: number): void {
-  let until = Date.now() + ms;
-  while (Date.now() < until) {
+  // Monotonic, like the heartbeat this is stalling — the block's real duration
+  // is what the peak-stall assertion is measured against.
+  let until = process.hrtime.bigint() + BigInt(ms) * 1_000_000n;
+  while (process.hrtime.bigint() < until) {
     // Deliberately synchronous: nothing on this thread's event loop runs,
     // including the heartbeat that would otherwise report it as turning.
   }
@@ -275,12 +280,12 @@ module(basename(import.meta.filename), function (hooks) {
 
   test('the wedge threshold has a floor a malformed override cannot cross', function (assert) {
     assert.strictEqual(livenessWedgeMs('45000'), 45_000);
-    assert.strictEqual(livenessWedgeMs(undefined), 30_000);
-    assert.strictEqual(livenessWedgeMs('not-a-number'), 30_000);
+    assert.strictEqual(livenessWedgeMs(undefined), 60_000);
+    assert.strictEqual(livenessWedgeMs('not-a-number'), 60_000);
     // Clearing the variable means "use the default", not "use the floor" —
     // `Number('')` is 0, which is finite, so this needs handling of its own.
-    assert.strictEqual(livenessWedgeMs(''), 30_000);
-    assert.strictEqual(livenessWedgeMs('   '), 30_000);
+    assert.strictEqual(livenessWedgeMs(''), 60_000);
+    assert.strictEqual(livenessWedgeMs('   '), 60_000);
     assert.strictEqual(livenessWedgeMs('0'), 5_000);
     assert.strictEqual(livenessWedgeMs('-1'), 5_000);
   });

--- a/packages/realm-server/tests/liveness-responder-test.ts
+++ b/packages/realm-server/tests/liveness-responder-test.ts
@@ -2,6 +2,8 @@ import QUnit from 'qunit';
 const { module, test } = QUnit;
 import { basename } from 'path';
 import { Worker } from 'node:worker_threads';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import {
   createHeartbeat,
   startEventLoopHeartbeat,
@@ -70,11 +72,13 @@ interface LivenessSample {
 // way would make the caller await every poll before it got to block — and the
 // polls would then all land on an unblocked thread.
 //
-// `polling` resolves once the client thread is up and has started polling;
-// `reported` resolves with every answer it collected.
+// `polling` resolves once the client thread has been told to start; `reported`
+// resolves with every answer it collected. `stop` is for the failure paths —
+// this worker is referenced, so leaving one behind would hold the suite open.
 function armPollingFromOwnThread(port: number): {
   polling: Promise<void>;
   reported: Promise<LivenessSample[]>;
+  stop: () => Promise<void>;
 } {
   let worker = new Worker(CLIENT_WORKER_SOURCE, {
     eval: true,
@@ -89,7 +93,6 @@ function armPollingFromOwnThread(port: number): {
       'message',
       (message: { ready?: boolean; samples?: LivenessSample[] }) => {
         if (message?.samples) {
-          void worker.terminate();
           resolve(message.samples);
         }
       },
@@ -103,7 +106,13 @@ function armPollingFromOwnThread(port: number): {
     });
     worker.once('error', reject);
   });
-  return { polling, reported };
+  return {
+    polling,
+    reported,
+    stop: async () => {
+      await worker.terminate();
+    },
+  };
 }
 
 function blockMainThread(ms: number): void {
@@ -117,10 +126,15 @@ function blockMainThread(ms: number): void {
 module(basename(import.meta.filename), function (hooks) {
   let heartbeat: Heartbeat | undefined;
   let responder: LivenessResponder | undefined;
+  // The client thread is referenced, so an assertion that throws mid-test would
+  // otherwise leave it running and hold the suite open.
+  let stopPolling: (() => Promise<void>) | undefined;
 
   hooks.afterEach(async function () {
+    await stopPolling?.();
     await responder?.stop();
     heartbeat?.stop();
+    stopPolling = undefined;
     responder = undefined;
     heartbeat = undefined;
   });
@@ -144,7 +158,7 @@ module(basename(import.meta.filename), function (hooks) {
     // puts it.
     let port = await serveLiveness(createHeartbeat());
 
-    writeBeat(heartbeat!.buffer, Date.now() - 10_000);
+    writeBeat(heartbeat!.buffer, process.hrtime.bigint() - 10_000_000_000n);
     let wedged = await fetch(`http://127.0.0.1:${port}/_liveness`);
     assert.strictEqual(wedged.status, 503);
     let wedgedBody = await wedged.json();
@@ -155,7 +169,7 @@ module(basename(import.meta.filename), function (hooks) {
     );
     assert.strictEqual(wedgedBody.wedgeMs, WEDGE_MS);
 
-    writeBeat(heartbeat!.buffer, Date.now());
+    writeBeat(heartbeat!.buffer, process.hrtime.bigint());
     let alive = await fetch(`http://127.0.0.1:${port}/_liveness`);
     assert.strictEqual(alive.status, 200);
     assert.true((await alive.json()).alive);
@@ -167,7 +181,8 @@ module(basename(import.meta.filename), function (hooks) {
     // keeps answering from its own thread off the shared buffer. Nothing in that
     // path is the blocked thread.
     let port = await serveLiveness(startEventLoopHeartbeat());
-    let { polling, reported } = armPollingFromOwnThread(port);
+    let { polling, reported, stop } = armPollingFromOwnThread(port);
+    stopPolling = stop;
     await polling;
 
     blockMainThread(2_000);
@@ -189,9 +204,14 @@ module(basename(import.meta.filename), function (hooks) {
         .map((v) => v.heartbeatAgeMs)
         .join(',')}`,
     );
+    // The block ran for 2s against a 300ms threshold, so the stall the responder
+    // measured has to reach most of that — not merely clear the threshold, which
+    // a 503 already implies.
     assert.true(
-      wedged.every((v) => v.alive === false && v.heartbeatAgeMs > WEDGE_MS),
-      'each wedged answer carries the measured stall',
+      Math.max(...wedged.map((v) => v.heartbeatAgeMs)) > 1_500,
+      `measured the stall's real depth, peak age ${Math.max(
+        ...wedged.map((v) => v.heartbeatAgeMs),
+      )}ms`,
     );
     assert.true(
       verdicts.some((v) => v.status === 200),
@@ -216,16 +236,51 @@ module(basename(import.meta.filename), function (hooks) {
     let port = await serveLiveness(startEventLoopHeartbeat());
     let other = await fetch(`http://127.0.0.1:${port}/`);
     assert.strictEqual(other.status, 404);
+    // The right path with the wrong method says so, rather than looking like a
+    // build that doesn't serve the endpoint at all.
     let posted = await fetch(`http://127.0.0.1:${port}/_liveness`, {
       method: 'POST',
     });
-    assert.strictEqual(posted.status, 404);
+    assert.strictEqual(posted.status, 405);
+    assert.strictEqual(posted.headers.get('allow'), 'GET, HEAD');
+  });
+
+  test('a port it cannot bind leaves the server serving', async function (assert) {
+    // The failure this module exists to absorb. The responder is an operational
+    // signal; losing it must cost nothing but the signal, and must say so.
+    let squatter = createServer((_req, res) => res.end());
+    await new Promise<void>((resolve) =>
+      squatter.listen(0, '127.0.0.1', resolve),
+    );
+    let taken = (squatter.address() as AddressInfo).port;
+    try {
+      heartbeat = createHeartbeat();
+      responder = startLivenessResponder({
+        buffer: heartbeat.buffer,
+        port: taken,
+        wedgeMs: WEDGE_MS,
+      });
+      assert.strictEqual(
+        await responder.listening,
+        undefined,
+        'reports that it never bound rather than hanging',
+      );
+      await responder.stop();
+      responder = undefined;
+    } finally {
+      await new Promise<void>((resolve) => squatter.close(() => resolve()));
+    }
+    assert.true(true, 'and startup returned normally instead of throwing');
   });
 
   test('the wedge threshold has a floor a malformed override cannot cross', function (assert) {
     assert.strictEqual(livenessWedgeMs('45000'), 45_000);
     assert.strictEqual(livenessWedgeMs(undefined), 30_000);
     assert.strictEqual(livenessWedgeMs('not-a-number'), 30_000);
+    // Clearing the variable means "use the default", not "use the floor" —
+    // `Number('')` is 0, which is finite, so this needs handling of its own.
+    assert.strictEqual(livenessWedgeMs(''), 30_000);
+    assert.strictEqual(livenessWedgeMs('   '), 30_000);
     assert.strictEqual(livenessWedgeMs('0'), 5_000);
     assert.strictEqual(livenessWedgeMs('-1'), 5_000);
   });

--- a/packages/realm-server/tests/liveness-responder-test.ts
+++ b/packages/realm-server/tests/liveness-responder-test.ts
@@ -1,0 +1,232 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import { Worker } from 'node:worker_threads';
+import {
+  createHeartbeat,
+  startEventLoopHeartbeat,
+  writeBeat,
+  type Heartbeat,
+} from '../liveness/event-loop-heartbeat.ts';
+import {
+  livenessWedgeMs,
+  startLivenessResponder,
+  type LivenessResponder,
+} from '../liveness/index.ts';
+
+// Short thresholds throughout: the responder takes `wedgeMs` directly, so these
+// exercise the same code paths a 30s production threshold does without the wait.
+const WEDGE_MS = 300;
+
+// Polls the responder from a thread of its own and reports every answer. Neither
+// the polling clock nor the requests depend on the thread under test, so answers
+// keep arriving while that thread is blocked — the only way to observe what the
+// responder does then.
+//
+// Polling rather than one timed request: a single request has to be aimed at the
+// blocked window, which couples the test to scheduling skew between two threads.
+// A poll spanning the whole window lands in it regardless, and captures the
+// before and after as well.
+const POLL_INTERVAL_MS = 100;
+const POLL_COUNT = 30;
+
+const CLIENT_WORKER_SOURCE = `
+const http = require('node:http');
+const { parentPort, workerData } = require('node:worker_threads');
+let samples = [];
+let polls = 0;
+function poll() {
+  let req = http.get(
+    { host: '127.0.0.1', port: workerData.port, path: '/_liveness' },
+    (res) => {
+      let body = '';
+      res.on('data', (chunk) => (body += chunk));
+      res.on('end', () => samples.push({ status: res.statusCode, body }));
+    },
+  );
+  req.on('error', (err) => samples.push({ error: err.message }));
+}
+parentPort.on('message', () => {
+  let timer = setInterval(() => {
+    poll();
+    if (++polls >= workerData.pollCount) {
+      clearInterval(timer);
+      // One interval's grace for the last response to land before reporting.
+      setTimeout(() => parentPort.postMessage({ samples }), workerData.intervalMs);
+    }
+  }, workerData.intervalMs);
+});
+parentPort.postMessage({ ready: true });
+`;
+
+interface LivenessSample {
+  status?: number;
+  body?: string;
+  error?: string;
+}
+
+// Returns the two promises separately rather than one resolving to the other:
+// an async function adopts a promise it returns, so handing the report back that
+// way would make the caller await every poll before it got to block — and the
+// polls would then all land on an unblocked thread.
+//
+// `polling` resolves once the client thread is up and has started polling;
+// `reported` resolves with every answer it collected.
+function armPollingFromOwnThread(port: number): {
+  polling: Promise<void>;
+  reported: Promise<LivenessSample[]>;
+} {
+  let worker = new Worker(CLIENT_WORKER_SOURCE, {
+    eval: true,
+    workerData: {
+      port,
+      intervalMs: POLL_INTERVAL_MS,
+      pollCount: POLL_COUNT,
+    },
+  });
+  let reported = new Promise<LivenessSample[]>((resolve, reject) => {
+    worker.on(
+      'message',
+      (message: { ready?: boolean; samples?: LivenessSample[] }) => {
+        if (message?.samples) {
+          void worker.terminate();
+          resolve(message.samples);
+        }
+      },
+    );
+    worker.on('error', reject);
+  });
+  let polling = new Promise<void>((resolve, reject) => {
+    worker.once('message', () => {
+      worker.postMessage({ type: 'go' });
+      resolve();
+    });
+    worker.once('error', reject);
+  });
+  return { polling, reported };
+}
+
+function blockMainThread(ms: number): void {
+  let until = Date.now() + ms;
+  while (Date.now() < until) {
+    // Deliberately synchronous: nothing on this thread's event loop runs,
+    // including the heartbeat that would otherwise report it as turning.
+  }
+}
+
+module(basename(import.meta.filename), function (hooks) {
+  let heartbeat: Heartbeat | undefined;
+  let responder: LivenessResponder | undefined;
+
+  hooks.afterEach(async function () {
+    await responder?.stop();
+    heartbeat?.stop();
+    responder = undefined;
+    heartbeat = undefined;
+  });
+
+  async function serveLiveness(existing: Heartbeat): Promise<number> {
+    heartbeat = existing;
+    responder = startLivenessResponder({
+      buffer: existing.buffer,
+      port: 0,
+      wedgeMs: WEDGE_MS,
+    });
+    let port = await responder.listening;
+    if (port == null) {
+      throw new Error('liveness responder did not bind');
+    }
+    return port;
+  }
+
+  test('reports a fresh beat as alive and a stale one as wedged', async function (assert) {
+    // No timer on this heartbeat, so the beat stays exactly where each case
+    // puts it.
+    let port = await serveLiveness(createHeartbeat());
+
+    writeBeat(heartbeat!.buffer, Date.now() - 10_000);
+    let wedged = await fetch(`http://127.0.0.1:${port}/_liveness`);
+    assert.strictEqual(wedged.status, 503);
+    let wedgedBody = await wedged.json();
+    assert.false(wedgedBody.alive);
+    assert.true(
+      wedgedBody.heartbeatAgeMs >= 10_000,
+      `reports the beat's true age, got ${wedgedBody.heartbeatAgeMs}`,
+    );
+    assert.strictEqual(wedgedBody.wedgeMs, WEDGE_MS);
+
+    writeBeat(heartbeat!.buffer, Date.now());
+    let alive = await fetch(`http://127.0.0.1:${port}/_liveness`);
+    assert.strictEqual(alive.status, 200);
+    assert.true((await alive.json()).alive);
+  });
+
+  test('answers, and reports the wedge, while the main thread is blocked', async function (assert) {
+    // The property the whole design rests on. The heartbeat stops the moment the
+    // block starts; the client keeps asking from its own thread; the responder
+    // keeps answering from its own thread off the shared buffer. Nothing in that
+    // path is the blocked thread.
+    let port = await serveLiveness(startEventLoopHeartbeat());
+    let { polling, reported } = armPollingFromOwnThread(port);
+    await polling;
+
+    blockMainThread(2_000);
+
+    let samples = await reported;
+    assert.deepEqual(
+      samples.filter((s) => s.error).map((s) => s.error),
+      [],
+      'every poll got a response',
+    );
+    let verdicts = samples.map((s) => ({
+      status: s.status,
+      ...JSON.parse(s.body!),
+    }));
+    let wedged = verdicts.filter((v) => v.status === 503);
+    assert.true(
+      wedged.length > 0,
+      `the stalled loop was reported wedged; ages seen: ${verdicts
+        .map((v) => v.heartbeatAgeMs)
+        .join(',')}`,
+    );
+    assert.true(
+      wedged.every((v) => v.alive === false && v.heartbeatAgeMs > WEDGE_MS),
+      'each wedged answer carries the measured stall',
+    );
+    assert.true(
+      verdicts.some((v) => v.status === 200),
+      'and a turning loop is reported alive',
+    );
+  });
+
+  test('recovers to alive once the main thread resumes beating', async function (assert) {
+    let port = await serveLiveness(startEventLoopHeartbeat());
+
+    blockMainThread(WEDGE_MS * 3);
+    // Back on the loop, the overdue heartbeat interval fires in the timers phase
+    // — yield one macrotask so the assertion reads a resumed heartbeat rather
+    // than racing it. A stall is not a latch.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    let recovered = await fetch(`http://127.0.0.1:${port}/_liveness`);
+    assert.strictEqual(recovered.status, 200);
+    assert.true((await recovered.json()).alive);
+  });
+
+  test('serves only the liveness path', async function (assert) {
+    let port = await serveLiveness(startEventLoopHeartbeat());
+    let other = await fetch(`http://127.0.0.1:${port}/`);
+    assert.strictEqual(other.status, 404);
+    let posted = await fetch(`http://127.0.0.1:${port}/_liveness`, {
+      method: 'POST',
+    });
+    assert.strictEqual(posted.status, 404);
+  });
+
+  test('the wedge threshold has a floor a malformed override cannot cross', function (assert) {
+    assert.strictEqual(livenessWedgeMs('45000'), 45_000);
+    assert.strictEqual(livenessWedgeMs(undefined), 30_000);
+    assert.strictEqual(livenessWedgeMs('not-a-number'), 30_000);
+    assert.strictEqual(livenessWedgeMs('0'), 5_000);
+    assert.strictEqual(livenessWedgeMs('-1'), 5_000);
+  });
+});

--- a/packages/realm-server/tests/liveness-verdict-test.ts
+++ b/packages/realm-server/tests/liveness-verdict-test.ts
@@ -4,13 +4,16 @@ import { basename } from 'path';
 import { judgeLiveness } from '../liveness/liveness-verdict.ts';
 
 const WEDGE_MS = 30_000;
-const NOW = 1_800_000_000_000;
+// An arbitrary monotonic reading to measure ages back from. Large enough that
+// the "never written" case (beat 0) is unambiguous.
+const NOW_NS = 4_000_000_000_000n;
+const MS = 1_000_000n;
 
 module(basename(import.meta.filename), function () {
   test('a loop that beat just now is alive', function (assert) {
     let verdict = judgeLiveness({
-      nowMs: NOW,
-      beatMs: NOW - 120,
+      nowNs: NOW_NS,
+      beatNs: NOW_NS - 120n * MS,
       wedgeMs: WEDGE_MS,
     });
     assert.true(verdict.alive);
@@ -23,8 +26,8 @@ module(basename(import.meta.filename), function () {
     // under load. Restarting here throws away a warm cache and lands the
     // replacement in the same load.
     let verdict = judgeLiveness({
-      nowMs: NOW,
-      beatMs: NOW - 4_000,
+      nowNs: NOW_NS,
+      beatNs: NOW_NS - 4_000n * MS,
       wedgeMs: WEDGE_MS,
     });
     assert.true(verdict.alive);
@@ -33,8 +36,8 @@ module(basename(import.meta.filename), function () {
 
   test('a loop that stopped turning is not alive', function (assert) {
     let verdict = judgeLiveness({
-      nowMs: NOW,
-      beatMs: NOW - (WEDGE_MS + 1),
+      nowNs: NOW_NS,
+      beatNs: NOW_NS - (BigInt(WEDGE_MS) + 1n) * MS,
       wedgeMs: WEDGE_MS,
     });
     assert.false(verdict.alive);
@@ -43,28 +46,36 @@ module(basename(import.meta.filename), function () {
 
   test('an age exactly at the threshold is still alive', function (assert) {
     let verdict = judgeLiveness({
-      nowMs: NOW,
-      beatMs: NOW - WEDGE_MS,
+      nowNs: NOW_NS,
+      beatNs: NOW_NS - BigInt(WEDGE_MS) * MS,
       wedgeMs: WEDGE_MS,
     });
     assert.true(verdict.alive);
+    assert.strictEqual(verdict.heartbeatAgeMs, WEDGE_MS);
   });
 
   test('a buffer nobody has beaten into is not alive', function (assert) {
-    let verdict = judgeLiveness({ nowMs: NOW, beatMs: 0, wedgeMs: WEDGE_MS });
+    let verdict = judgeLiveness({
+      nowNs: NOW_NS,
+      beatNs: 0n,
+      wedgeMs: WEDGE_MS,
+    });
     assert.false(verdict.alive);
-    assert.strictEqual(verdict.heartbeatAgeMs, NOW);
+    assert.strictEqual(verdict.heartbeatAgeMs, Number(NOW_NS / MS));
   });
 
-  test('a backwards clock step reads as a zero-age beat, not a negative one', function (assert) {
-    // A negative age would compare as under any threshold and pass for the
-    // wrong reason; clamping keeps the reported value a duration.
+  test('the age is elapsed time, immune to a wall-clock step', function (assert) {
+    // The readings are monotonic nanoseconds off one process-wide base, so
+    // nothing an NTP or hypervisor adjustment does to the wall clock can age a
+    // beat that was just written — which, once a container health check reads
+    // this, would otherwise replace a perfectly healthy task.
+    let realNow = process.hrtime.bigint();
     let verdict = judgeLiveness({
-      nowMs: NOW,
-      beatMs: NOW + 5_000,
+      nowNs: realNow,
+      beatNs: realNow - 50n * MS,
       wedgeMs: WEDGE_MS,
     });
     assert.true(verdict.alive);
-    assert.strictEqual(verdict.heartbeatAgeMs, 0);
+    assert.strictEqual(verdict.heartbeatAgeMs, 50);
   });
 });

--- a/packages/realm-server/tests/liveness-verdict-test.ts
+++ b/packages/realm-server/tests/liveness-verdict-test.ts
@@ -1,0 +1,70 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import { judgeLiveness } from '../liveness/liveness-verdict.ts';
+
+const WEDGE_MS = 30_000;
+const NOW = 1_800_000_000_000;
+
+module(basename(import.meta.filename), function () {
+  test('a loop that beat just now is alive', function (assert) {
+    let verdict = judgeLiveness({
+      nowMs: NOW,
+      beatMs: NOW - 120,
+      wedgeMs: WEDGE_MS,
+    });
+    assert.true(verdict.alive);
+    assert.strictEqual(verdict.heartbeatAgeMs, 120);
+    assert.strictEqual(verdict.wedgeMs, WEDGE_MS);
+  });
+
+  test('a loop turning late but still turning is alive', function (assert) {
+    // The case the whole signal exists to protect: seconds of event-loop lag
+    // under load. Restarting here throws away a warm cache and lands the
+    // replacement in the same load.
+    let verdict = judgeLiveness({
+      nowMs: NOW,
+      beatMs: NOW - 4_000,
+      wedgeMs: WEDGE_MS,
+    });
+    assert.true(verdict.alive);
+    assert.strictEqual(verdict.heartbeatAgeMs, 4_000);
+  });
+
+  test('a loop that stopped turning is not alive', function (assert) {
+    let verdict = judgeLiveness({
+      nowMs: NOW,
+      beatMs: NOW - (WEDGE_MS + 1),
+      wedgeMs: WEDGE_MS,
+    });
+    assert.false(verdict.alive);
+    assert.strictEqual(verdict.heartbeatAgeMs, WEDGE_MS + 1);
+  });
+
+  test('an age exactly at the threshold is still alive', function (assert) {
+    let verdict = judgeLiveness({
+      nowMs: NOW,
+      beatMs: NOW - WEDGE_MS,
+      wedgeMs: WEDGE_MS,
+    });
+    assert.true(verdict.alive);
+  });
+
+  test('a buffer nobody has beaten into is not alive', function (assert) {
+    let verdict = judgeLiveness({ nowMs: NOW, beatMs: 0, wedgeMs: WEDGE_MS });
+    assert.false(verdict.alive);
+    assert.strictEqual(verdict.heartbeatAgeMs, NOW);
+  });
+
+  test('a backwards clock step reads as a zero-age beat, not a negative one', function (assert) {
+    // A negative age would compare as under any threshold and pass for the
+    // wrong reason; clamping keeps the reported value a duration.
+    let verdict = judgeLiveness({
+      nowMs: NOW,
+      beatMs: NOW + 5_000,
+      wedgeMs: WEDGE_MS,
+    });
+    assert.true(verdict.alive);
+    assert.strictEqual(verdict.heartbeatAgeMs, 0);
+  });
+});


### PR DESCRIPTION
The realm-server is one Node process with one event loop, and every health signal it has is served *by* that loop. That makes all of them answer the same question — "does the loop have capacity right now?" — and leaves one question unanswered: is the loop turning at all?

The two look identical from outside. A loop saturated by concurrent request work turns late, so a check times out. A loop that has stopped turning also times out. On ECS both outcomes replace the task, and replacing a *saturated* server is actively harmful: the replacement boots with an empty definition and transpile cache, pays every miss again, and lands back in the same load. Only the stopped loop is worth a restart.

This adds a signal that can tell them apart.

## What's here

A heartbeat the main thread writes into a `SharedArrayBuffer` every 250ms, and a `worker_threads` worker that serves `GET /_liveness` from it on a loopback-only port:

```
{ "alive": true, "heartbeatAgeMs": 41, "wedgeMs": 30000 }
```

200 while the beat's age is within the threshold, 503 past it.

| Main loop | `GET /` (ALB) | `/_liveness` |
| --- | --- | --- |
| idle or busy, turning | 200 | 200 |
| saturated, turning late | times out | 200, large `heartbeatAgeMs` |
| stopped turning | times out | 503 |

The design constraint that shapes the code: nothing on the worker's request path may touch the main thread. No `postMessage` round-trip — a stalled parent never replies. No `console` / stderr writes while serving — worker stdio is piped through the parent, so those bytes queue behind the stall. Shared-memory reads only; logging is confined to bind and error events, which happen while the parent is healthy.

The endpoint is honest in the same way `GET /` is. It reports one measured fact, produced by the main thread itself, and it reports it whether or not that thread is free. A busy-but-turning loop answers 200 because it is alive and will recover — it does not claim the server can serve.

`--livenessPort` turns it on; omitted, there is no responder. `REALM_LIVENESS_WEDGE_MS` tunes the threshold (5s floor).

The 60s default is measured, not chosen: `realm:health` `eventLoopLagMs` on deployed realm-servers peaks at **25.4s** during the deploy-churn incident, **11.1s** during the deep search-overload incident, and **5.0s** across three days of ordinary production. A stopped loop never recovers and so exceeds any threshold, which makes erring high nearly free and erring low a restart of a server that was only busy. The beat and the verdict are both `process.hrtime.bigint()` readings off one process-wide base, so the age is true elapsed time and no NTP or hypervisor step can manufacture a wedge.

Port 3010 rather than the more obvious 3001: 3001 is another service's traffic port, and locally it belongs to the Grafana compose stack. The dev mise tasks pass no liveness port at all, so nothing about the local stack changes.

## Scope

`/_liveness` ships served and unread. The ALB check on the traffic port is untouched, and no behavior changes until an ECS container `healthCheck` is pointed at the endpoint — which is a separate change in the infra repo.

Load-shedding to keep the loop out of saturation in the first place is not here; the per-request search bounds in `packages/runtime-common/search-bounds.ts` already cap page size and wall-clock, and broader admission control is its own piece of work.

## Deploy order

The endpoint ships before anything checks it. The companion infra change uses a probe that fails open — only an affirmative 503 is unhealthy — so a check running against an image that predates the endpoint reads refused-or-404 and reports healthy. Getting the order wrong therefore costs you a silently inert check, not an outage.

1. Merge and deploy this PR. `--livenessPort` ships inside the image via the start scripts, so no infra change is involved and nothing consumes the endpoint yet.
2. Verify it in a deployed task — exec into a staging task and `curl 127.0.0.1:3010/_liveness`, expecting 200 with a small `heartbeatAgeMs`. This is what distinguishes "wired up and healthy" from "wired up and inert".
3. Then apply cardstack/infra#728, which adds the container `healthCheck`.

## Failure modes, and what each one costs

The endpoint is an operational signal, so every way it can fail is arranged to cost the signal rather than the service:

| | behaviour |
| --- | --- |
| port won't bind | logged to `realm:liveness` + Sentry, `listening` resolves undefined, serving untouched |
| worker thread won't construct | same, and startup returns normally rather than throwing at module scope |
| thread dies after binding | logged + Sentry — the only notice that wedge detection has stopped |
| `--livenessPort` is 0 / NaN | responder not started, rather than binding an arbitrary port and logging success |
| `REALM_LIVENESS_WEDGE_MS=""` | falls back to the 30s default, not the 5s floor |
| wall clock steps | no effect; the beat is monotonic |

## Test plan

`packages/realm-server/tests/liveness-verdict-test.ts` covers the verdict itself — a late-but-turning loop is alive, a stopped one is not, the threshold boundary, an unwritten beat, and a backwards clock step.

`packages/realm-server/tests/liveness-responder-test.ts` covers it over the wire, including the property everything rests on: a client thread polls the endpoint while the main thread sits in a synchronous busy-wait, and every in-block answer is a 503 carrying the measured stall, followed by recovery to 200 once the loop resumes. Polling across the window rather than firing one timed request keeps that free of cross-thread scheduling skew.

Locally: 11/11 green, repeated to check the timing-sensitive case for flakiness; `pnpm lint` clean; and the real `main.ts` entry point verified to bind the port, answer 200, 404 other paths, and not pin the process at exit.

A runbook covering all three signals — the ALB check, `/_liveness`, and the `realm:health` log line — is in `docs/realm-server-health-signals.md`.
