### PR TITLE
Add a migration for realm index cards still on the legacy default index

### DIFF
--- a/packages/realm-server/scripts/migrate-index-to-workspace.ts
+++ b/packages/realm-server/scripts/migrate-index-to-workspace.ts
@@ -72,7 +72,7 @@
  *     --rollback ./migrate-index-to-workspace-manifest.json
  */
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
-import { join, resolve, sep } from 'path';
+import { join, relative, resolve, sep } from 'path';
 import { fileURLToPath } from 'url';
 import { PUBLISHED_DIRECTORY_NAME } from '@cardstack/runtime-common/constants';
 
@@ -250,6 +250,13 @@ type RealmReport = {
   forced: boolean;
   willMigrate: boolean;
   extras: string[];
+  /**
+   * The realm's path relative to the realms root it was discovered under —
+   * `<user>/<realm>`, which is what `/_grafana-reindex?realm=` wants. Absent
+   * for a realm named as an explicit directory argument, where the disk path
+   * says nothing about the URL the realm is served at.
+   */
+  reindexPath?: string;
 };
 
 type ManifestEntry = { path: string; original: string };
@@ -301,56 +308,42 @@ export function discoverPublishedRealms(realmsRoot: string): string[] {
   return childDirs(publishedRoot).map((diskId) => join(publishedRoot, diskId));
 }
 
-function classifyRealm(realmDir: string): RealmReport {
+function classifyRealm(
+  realmDir: string,
+  reindexPath: string | undefined,
+): RealmReport {
   let indexPath = join(realmDir, 'index.json');
+  let base = {
+    realmDir,
+    indexPath,
+    forced: false,
+    willMigrate: false,
+    extras: [] as string[],
+    reindexPath,
+  };
+  let unusable = (reason: string): RealmReport => ({
+    ...base,
+    classification: { kind: 'unusable', reason },
+  });
+
   if (!existsSync(indexPath)) {
-    return {
-      realmDir,
-      indexPath,
-      classification: { kind: 'unusable', reason: 'no index.json' },
-      forced: false,
-      willMigrate: false,
-      extras: [],
-    };
+    return unusable('no index.json');
   }
   let source: string;
   try {
     source = readFileSync(indexPath, 'utf8');
   } catch (err) {
-    return {
-      realmDir,
-      indexPath,
-      classification: {
-        kind: 'unusable',
-        reason: `unreadable: ${(err as Error).message}`,
-      },
-      forced: false,
-      willMigrate: false,
-      extras: [],
-    };
+    return unusable(`unreadable: ${(err as Error).message}`);
   }
   let doc: any;
   try {
     doc = JSON.parse(source);
   } catch (err) {
-    return {
-      realmDir,
-      indexPath,
-      classification: {
-        kind: 'unusable',
-        reason: `invalid JSON: ${(err as Error).message}`,
-      },
-      forced: false,
-      willMigrate: false,
-      extras: [],
-    };
+    return unusable(`invalid JSON: ${(err as Error).message}`);
   }
   return {
-    realmDir,
-    indexPath,
+    ...base,
     classification: classify(doc?.data?.meta?.adoptsFrom),
-    forced: false,
-    willMigrate: false,
     extras: extraKeys(source),
   };
 }
@@ -479,14 +472,29 @@ export function main(argv: string[]): number {
     return rollback(args.rollback);
   }
 
-  let realmDirs = [...args.dirs];
+  // Each discovered realm remembers the realms root it came from, so its
+  // `<user>/<realm>` path — the value `/_grafana-reindex?realm=` takes — can be
+  // printed alongside the disk path. An explicit directory argument gets none:
+  // its disk path implies nothing about the URL the realm is served at.
+  let discovered = new Map<string, string | undefined>();
+  for (let dir of args.dirs) {
+    discovered.set(dir, undefined);
+  }
   for (let root of args.realmsRoots) {
-    realmDirs.push(...discoverUserRealms(root));
-    if (args.published) {
-      realmDirs.push(...discoverPublishedRealms(root));
+    let fromRoot = [
+      ...discoverUserRealms(root),
+      ...(args.published ? discoverPublishedRealms(root) : []),
+    ];
+    for (let dir of fromRoot) {
+      if (!discovered.has(dir)) {
+        discovered.set(dir, relative(root, dir));
+      }
     }
   }
-  realmDirs = [...new Set(realmDirs)].filter((dir) => isDirectory(dir)).sort();
+
+  let realmDirs = [...discovered.keys()]
+    .filter((dir) => isDirectory(dir))
+    .sort();
 
   if (realmDirs.length === 0) {
     console.error(
@@ -495,7 +503,7 @@ export function main(argv: string[]): number {
     return 1;
   }
 
-  let reports = realmDirs.map(classifyRealm);
+  let reports = realmDirs.map((dir) => classifyRealm(dir, discovered.get(dir)));
   let unmatchedIncludes = new Set(args.include);
   for (let report of reports) {
     let hit = args.include.find((include) =>
@@ -547,6 +555,7 @@ export function main(argv: string[]): number {
           manifest: args.dryRun || manifest.length === 0 ? null : args.manifest,
           realms: reports.map((report) => ({
             realmDir: report.realmDir,
+            reindexPath: report.reindexPath ?? null,
             classification: report.classification,
             forced: report.forced,
             willMigrate: report.willMigrate,
@@ -588,10 +597,21 @@ export function main(argv: string[]): number {
       );
     }
     if (migrating.length > 0) {
-      console.log('\nReindex these realms (they were changed on disk):');
+      console.log(
+        `\nReindex these ${migrating.length} realm(s) — the server does not watch the filesystem,\nso the change is invisible to the index until one runs:`,
+      );
       for (let report of migrating) {
-        console.log(`  ${report.realmDir}`);
+        console.log(`  ${report.reindexPath ?? report.realmDir}`);
       }
+      console.log(
+        '\nAs a realm= list for /_grafana-reindex (one per line, pipe into a loop):',
+      );
+      console.log(
+        migrating
+          .map((report) => report.reindexPath)
+          .filter(Boolean)
+          .join('\n'),
+      );
     }
   }
 

--- a/packages/realm-server/scripts/migrate-index-to-workspace.ts
+++ b/packages/realm-server/scripts/migrate-index-to-workspace.ts
@@ -1,0 +1,607 @@
+/**
+ * migrate-index-to-workspace — switch realm index cards from the legacy
+ * default index (`CardsGrid`, or its `IndexCard` alias) to `Workspace`.
+ *
+ * A realm's index card is the `index.json` at its root. `Workspace` bundles the
+ * whole CardsGrid experience under its Library tab, so a realm that never
+ * customized its index can move across without losing anything. A realm that
+ * adopts something bespoke is left alone unless it is named with `--include`.
+ *
+ * Only `data.meta.adoptsFrom` is rewritten. Attributes and relationships are
+ * carried over untouched, and anything a file carries beyond `adoptsFrom` is
+ * called out in the report so it can be eyeballed before the run is applied.
+ * The module form each realm already uses is preserved — `@cardstack/base/…`
+ * stays a prefix, an absolute base-realm URL stays absolute — because the
+ * publish handler and the prerender fast path recognize both
+ * (`DEFAULT_REALM_INDEX_ADOPTIONS` in `handlers/handle-publish-realm.ts`).
+ *
+ * Every applied run writes a rollback manifest holding each file's original
+ * bytes; `--rollback <manifest>` restores them. The manifest is plain JSON
+ * read and written by node, so a rollback needs nothing installed in the
+ * container beyond the runtime that produced it.
+ *
+ * Migrated realms need a reindex — the deployed server does not watch EFS, so
+ * an on-disk edit is invisible to the index until one is triggered. The report
+ * ends with the realm paths to feed `/_grafana-reindex?realm=<path>`.
+ *
+ * Usage:
+ *   node scripts/migrate-index-to-workspace.ts [flags] <realm-dir> [<realm-dir> …]
+ *   node scripts/migrate-index-to-workspace.ts [flags] --persistent <root>
+ *   node scripts/migrate-index-to-workspace.ts [flags] --realms-root <dir>
+ *   node scripts/migrate-index-to-workspace.ts --rollback <manifest>
+ *
+ * Flags:
+ *   --dry-run              Report what would change; write nothing. Default is
+ *                          to apply, so a first pass should always be a dry run.
+ *   --persistent <root>    Scan the realm trees the deployed server mounts: the
+ *                          public realms directly under <root> (see
+ *                          PUBLIC_REALM_DIRS) plus every <root>/realms/<user>/<realm>.
+ *   --realms-root <dir>    Scan every <dir>/<user>/<realm> as a realm root.
+ *                          Repeatable; this is the user-realms half of --persistent.
+ *   --published            Also scan the published snapshots under
+ *                          <realms-root>/_published/<disk-id>. Off by default:
+ *                          a snapshot is regenerated from its source realm on
+ *                          the next publish, so migrating the source and
+ *                          republishing is the path that keeps the two in step.
+ *   --include <realm-dir>  Migrate this realm even though its index adopts a
+ *                          bespoke card — the hand-rolled-workspace case.
+ *                          Repeatable. Matches a scanned realm by path suffix,
+ *                          so `--include buck/mar10` names /persistent/realms/buck/mar10.
+ *   --manifest <file>      Where to write the rollback manifest
+ *                          (default ./migrate-index-to-workspace-manifest.json).
+ *   --json                 Emit the full report as JSON instead of a table.
+ *   --rollback <file>      Restore every file recorded in a manifest and exit.
+ *
+ * Examples:
+ *   # Preview every realm the deployed server mounts
+ *   node scripts/migrate-index-to-workspace.ts --dry-run --persistent /persistent
+ *
+ *   # Apply, also migrating two realms whose index is a hand-rolled workspace
+ *   node scripts/migrate-index-to-workspace.ts --persistent /persistent \
+ *     --include ctse/demo --include buck/mar10
+ *
+ *   # Undo
+ *   node scripts/migrate-index-to-workspace.ts \
+ *     --rollback ./migrate-index-to-workspace-manifest.json
+ */
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
+import { join, resolve, sep } from 'path';
+import { fileURLToPath } from 'url';
+import { PUBLISHED_DIRECTORY_NAME } from '@cardstack/runtime-common/constants';
+
+// The realms mounted by name in scripts/start-staging.sh and
+// scripts/start-production.sh. KEEP IN SYNC with those --path arguments.
+// `submissions` is passed there as ${SUBMISSION_REALM_PATH}, which resolves
+// under the same root.
+const PUBLIC_REALM_DIRS = [
+  'base',
+  'boxel-homepage',
+  'catalog',
+  'experiments',
+  'openrouter',
+  'skills',
+  'software-factory',
+  'submissions',
+];
+
+// The base-realm exports recognized as a realm's *default* index — the ones a
+// realm gets without customizing anything, and so the ones safe to move to
+// Workspace wholesale. `IndexCard` is here because `packages/base/index.gts` is
+// a one-line re-export of CardsGrid under its historical name, so a realm
+// adopting it is on CardsGrid too.
+const LEGACY_INDEX_EXPORTS: { module: string; name: string }[] = [
+  { module: 'cards-grid', name: 'CardsGrid' },
+  { module: 'index', name: 'IndexCard' },
+];
+
+const WORKSPACE_EXPORT = { module: 'workspace', name: 'Workspace' };
+
+export type AdoptsFrom = { module: string; name: string };
+
+export type Classification =
+  | { kind: 'legacy'; adoptsFrom: AdoptsFrom; target: AdoptsFrom }
+  | { kind: 'workspace'; adoptsFrom: AdoptsFrom }
+  | { kind: 'bespoke'; adoptsFrom: AdoptsFrom }
+  | { kind: 'relative'; adoptsFrom: AdoptsFrom }
+  | { kind: 'unusable'; reason: string };
+
+/**
+ * Split a base-realm module specifier into its prefix and last segment, or
+ * return undefined when it doesn't address the base realm at all.
+ *
+ * Both live forms are accepted: the `@cardstack/base/` prefix and an absolute
+ * URL whose path ends in `/base/<export>` — which covers the canonical
+ * `https://cardstack.com/base/…` as well as the deployment-URL spellings
+ * (`https://realms-staging.stack.cards/base/…`, `https://app.boxel.ai/base/…`)
+ * that predate the RRI migration and may still sit in an untouched realm.
+ */
+export function splitBaseModule(
+  module: string,
+): { prefix: string; segment: string } | undefined {
+  let prefixMatch = /^(@cardstack\/base\/)([^/]+)$/.exec(module);
+  if (prefixMatch) {
+    return { prefix: prefixMatch[1], segment: prefixMatch[2] };
+  }
+  let urlMatch = /^(https?:\/\/.*\/base\/)([^/]+)$/.exec(module);
+  if (urlMatch) {
+    return { prefix: urlMatch[1], segment: urlMatch[2] };
+  }
+  return undefined;
+}
+
+/**
+ * Decide what to do with one index card's adoption.
+ *
+ * A relative specifier gets its own verdict rather than being folded into
+ * `bespoke`: inside the base realm `./cards-grid` *is* the default index, but
+ * in a user realm it names that realm's own module. Nothing on disk
+ * distinguishes the two, so the script reports relative adoptions and rewrites
+ * none of them.
+ */
+export function classify(adoptsFrom: unknown): Classification {
+  if (
+    !adoptsFrom ||
+    typeof adoptsFrom !== 'object' ||
+    typeof (adoptsFrom as AdoptsFrom).module !== 'string' ||
+    typeof (adoptsFrom as AdoptsFrom).name !== 'string'
+  ) {
+    return { kind: 'unusable', reason: 'no data.meta.adoptsFrom' };
+  }
+  let from = adoptsFrom as AdoptsFrom;
+  if (from.module.startsWith('.')) {
+    return { kind: 'relative', adoptsFrom: from };
+  }
+  let split = splitBaseModule(from.module);
+  if (!split) {
+    return { kind: 'bespoke', adoptsFrom: from };
+  }
+  if (
+    split.segment === WORKSPACE_EXPORT.module &&
+    from.name === WORKSPACE_EXPORT.name
+  ) {
+    return { kind: 'workspace', adoptsFrom: from };
+  }
+  let legacy = LEGACY_INDEX_EXPORTS.find(
+    (candidate) =>
+      candidate.module === split.segment && candidate.name === from.name,
+  );
+  if (!legacy) {
+    return { kind: 'bespoke', adoptsFrom: from };
+  }
+  return {
+    kind: 'legacy',
+    adoptsFrom: from,
+    target: {
+      module: `${split.prefix}${WORKSPACE_EXPORT.module}`,
+      name: WORKSPACE_EXPORT.name,
+    },
+  };
+}
+
+/**
+ * The Workspace adoption to write into a realm whose index adopts a bespoke
+ * card. There is no existing base-realm specifier to take a form from, so this
+ * picks the `@cardstack/base/` prefix — the form new realms are created with
+ * (`handlers/create-realm.ts`).
+ */
+export function forcedTarget(): AdoptsFrom {
+  return {
+    module: `@cardstack/base/${WORKSPACE_EXPORT.module}`,
+    name: WORKSPACE_EXPORT.name,
+  };
+}
+
+/**
+ * Rewrite an index card's adoption, preserving the file's own formatting.
+ *
+ * Card JSON on disk comes in two shapes — the compact single line the realm
+ * server writes, and the pretty-printed form used by realms authored in the
+ * repo. Matching whichever the file already uses keeps the change to the one
+ * line that actually differs, which is what makes a `diff` of the run readable.
+ */
+export function rewriteIndexJson(source: string, target: AdoptsFrom): string {
+  let doc = JSON.parse(source);
+  doc.data.meta.adoptsFrom = { module: target.module, name: target.name };
+  // `trimEnd` first: the realm server writes card JSON as one line plus a
+  // trailing newline, and counting that newline would read the file as
+  // pretty-printed and reflow the whole thing.
+  let pretty = source.trimEnd().includes('\n');
+  let out = pretty ? JSON.stringify(doc, null, 2) : JSON.stringify(doc);
+  return source.endsWith('\n') ? `${out}\n` : out;
+}
+
+/** Keys a legacy index card carries beyond `meta.adoptsFrom`. */
+export function extraKeys(source: string): string[] {
+  let doc;
+  try {
+    doc = JSON.parse(source);
+  } catch {
+    return [];
+  }
+  let data = doc?.data ?? {};
+  let extras: string[] = [];
+  for (let key of Object.keys(data)) {
+    if (key === 'type' || key === 'meta') {
+      continue;
+    }
+    extras.push(`data.${key}`);
+  }
+  for (let key of Object.keys(data.meta ?? {})) {
+    if (key === 'adoptsFrom') {
+      continue;
+    }
+    extras.push(`data.meta.${key}`);
+  }
+  return extras.sort();
+}
+
+type RealmReport = {
+  realmDir: string;
+  indexPath: string;
+  classification: Classification;
+  /** Set when --include named this realm and its index is bespoke/relative. */
+  forced: boolean;
+  willMigrate: boolean;
+  extras: string[];
+};
+
+type ManifestEntry = { path: string; original: string };
+
+function isDirectory(path: string): boolean {
+  try {
+    return readdirSync(path, { withFileTypes: true }) !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+function childDirs(path: string): string[] {
+  try {
+    return readdirSync(path, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
+      .map((entry) => entry.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Every `<root>/<user>/<realm>` two levels under a realms root.
+ *
+ * `_published` is skipped for the same reason `lib/realm-registry-backfill.ts`
+ * skips it when walking owners: it is not a username, it is the flat
+ * `_published/<disk-id>` tree of publish snapshots. `discoverPublishedRealms`
+ * covers that tree, and only when it is asked for.
+ */
+export function discoverUserRealms(realmsRoot: string): string[] {
+  let found: string[] = [];
+  for (let user of childDirs(realmsRoot)) {
+    if (user === PUBLISHED_DIRECTORY_NAME) {
+      continue;
+    }
+    let userDir = join(realmsRoot, user);
+    for (let realm of childDirs(userDir)) {
+      found.push(join(userDir, realm));
+    }
+  }
+  return found;
+}
+
+/** Every `<root>/_published/<disk-id>` — one level, unlike the owner tree. */
+export function discoverPublishedRealms(realmsRoot: string): string[] {
+  let publishedRoot = join(realmsRoot, PUBLISHED_DIRECTORY_NAME);
+  return childDirs(publishedRoot).map((diskId) => join(publishedRoot, diskId));
+}
+
+function classifyRealm(realmDir: string): RealmReport {
+  let indexPath = join(realmDir, 'index.json');
+  if (!existsSync(indexPath)) {
+    return {
+      realmDir,
+      indexPath,
+      classification: { kind: 'unusable', reason: 'no index.json' },
+      forced: false,
+      willMigrate: false,
+      extras: [],
+    };
+  }
+  let source: string;
+  try {
+    source = readFileSync(indexPath, 'utf8');
+  } catch (err) {
+    return {
+      realmDir,
+      indexPath,
+      classification: {
+        kind: 'unusable',
+        reason: `unreadable: ${(err as Error).message}`,
+      },
+      forced: false,
+      willMigrate: false,
+      extras: [],
+    };
+  }
+  let doc: any;
+  try {
+    doc = JSON.parse(source);
+  } catch (err) {
+    return {
+      realmDir,
+      indexPath,
+      classification: {
+        kind: 'unusable',
+        reason: `invalid JSON: ${(err as Error).message}`,
+      },
+      forced: false,
+      willMigrate: false,
+      extras: [],
+    };
+  }
+  return {
+    realmDir,
+    indexPath,
+    classification: classify(doc?.data?.meta?.adoptsFrom),
+    forced: false,
+    willMigrate: false,
+    extras: extraKeys(source),
+  };
+}
+
+/** `--include buck/mar10` names /persistent/realms/buck/mar10. */
+function matchesInclude(realmDir: string, include: string): boolean {
+  let normalized = include.replace(/\/+$/, '');
+  return (
+    realmDir === resolve(normalized) ||
+    realmDir === normalized ||
+    realmDir.endsWith(`${sep}${normalized}`)
+  );
+}
+
+function parseArgs(argv: string[]) {
+  let args = {
+    dryRun: false,
+    json: false,
+    published: false,
+    dirs: [] as string[],
+    realmsRoots: [] as string[],
+    include: [] as string[],
+    manifest: './migrate-index-to-workspace-manifest.json',
+    rollback: undefined as string | undefined,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    let arg = argv[i];
+    switch (arg) {
+      case '--dry-run':
+        args.dryRun = true;
+        break;
+      case '--json':
+        args.json = true;
+        break;
+      case '--published':
+        args.published = true;
+        break;
+      case '--persistent': {
+        let root = argv[++i];
+        if (!root) {
+          throw new Error('--persistent requires a directory');
+        }
+        for (let name of PUBLIC_REALM_DIRS) {
+          args.dirs.push(join(root, name));
+        }
+        args.realmsRoots.push(join(root, 'realms'));
+        break;
+      }
+      case '--realms-root': {
+        let root = argv[++i];
+        if (!root) {
+          throw new Error('--realms-root requires a directory');
+        }
+        args.realmsRoots.push(root);
+        break;
+      }
+      case '--include': {
+        let realm = argv[++i];
+        if (!realm) {
+          throw new Error('--include requires a realm directory');
+        }
+        args.include.push(realm);
+        break;
+      }
+      case '--manifest': {
+        let file = argv[++i];
+        if (!file) {
+          throw new Error('--manifest requires a file path');
+        }
+        args.manifest = file;
+        break;
+      }
+      case '--rollback': {
+        let file = argv[++i];
+        if (!file) {
+          throw new Error('--rollback requires a manifest path');
+        }
+        args.rollback = file;
+        break;
+      }
+      default:
+        if (arg.startsWith('-')) {
+          throw new Error(`Unknown flag: ${arg}`);
+        }
+        args.dirs.push(arg);
+    }
+  }
+  return args;
+}
+
+function rollback(manifestPath: string): number {
+  let entries: ManifestEntry[] = JSON.parse(
+    readFileSync(manifestPath, 'utf8'),
+  ).files;
+  for (let entry of entries) {
+    writeFileSync(entry.path, entry.original);
+    console.log(`restored ${entry.path}`);
+  }
+  console.log(`\nRestored ${entries.length} file(s) from ${manifestPath}.`);
+  return 0;
+}
+
+function describe(report: RealmReport): string {
+  let { classification: c } = report;
+  switch (c.kind) {
+    case 'legacy':
+      return `${c.adoptsFrom.name} (${c.adoptsFrom.module}) -> ${c.target.name} (${c.target.module})`;
+    case 'workspace':
+      return `already Workspace`;
+    case 'bespoke':
+      return report.forced
+        ? `${c.adoptsFrom.name} (${c.adoptsFrom.module}) -> Workspace [--include]`
+        : `bespoke: ${c.adoptsFrom.name} (${c.adoptsFrom.module})`;
+    case 'relative':
+      return report.forced
+        ? `${c.adoptsFrom.name} (${c.adoptsFrom.module}) -> Workspace [--include]`
+        : `relative: ${c.adoptsFrom.name} (${c.adoptsFrom.module})`;
+    case 'unusable':
+      return `skipped: ${c.reason}`;
+  }
+}
+
+export function main(argv: string[]): number {
+  let args = parseArgs(argv);
+  if (args.rollback) {
+    return rollback(args.rollback);
+  }
+
+  let realmDirs = [...args.dirs];
+  for (let root of args.realmsRoots) {
+    realmDirs.push(...discoverUserRealms(root));
+    if (args.published) {
+      realmDirs.push(...discoverPublishedRealms(root));
+    }
+  }
+  realmDirs = [...new Set(realmDirs)].filter((dir) => isDirectory(dir)).sort();
+
+  if (realmDirs.length === 0) {
+    console.error(
+      'No realm directories to scan. Pass realm directories, --persistent <root>, or --realms-root <dir>.',
+    );
+    return 1;
+  }
+
+  let reports = realmDirs.map(classifyRealm);
+  let unmatchedIncludes = new Set(args.include);
+  for (let report of reports) {
+    let hit = args.include.find((include) =>
+      matchesInclude(report.realmDir, include),
+    );
+    if (hit) {
+      unmatchedIncludes.delete(hit);
+      if (
+        report.classification.kind === 'bespoke' ||
+        report.classification.kind === 'relative'
+      ) {
+        report.forced = true;
+      }
+    }
+    report.willMigrate =
+      report.classification.kind === 'legacy' || report.forced;
+  }
+
+  let migrating = reports.filter((report) => report.willMigrate);
+  let manifest: ManifestEntry[] = [];
+  if (!args.dryRun) {
+    for (let report of migrating) {
+      let source = readFileSync(report.indexPath, 'utf8');
+      let target =
+        report.classification.kind === 'legacy'
+          ? report.classification.target
+          : forcedTarget();
+      let rewritten = rewriteIndexJson(source, target);
+      // Re-parse before committing to disk. A malformed write here would
+      // error-index the realm's index card, which is the one card whose
+      // absence is most visible.
+      JSON.parse(rewritten);
+      manifest.push({ path: report.indexPath, original: source });
+      writeFileSync(report.indexPath, rewritten);
+    }
+    if (manifest.length > 0) {
+      writeFileSync(
+        args.manifest,
+        `${JSON.stringify({ files: manifest }, null, 2)}\n`,
+      );
+    }
+  }
+
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: args.dryRun,
+          manifest: args.dryRun || manifest.length === 0 ? null : args.manifest,
+          realms: reports.map((report) => ({
+            realmDir: report.realmDir,
+            classification: report.classification,
+            forced: report.forced,
+            willMigrate: report.willMigrate,
+            extras: report.extras,
+          })),
+          unmatchedIncludes: [...unmatchedIncludes],
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(
+      args.dryRun
+        ? `Dry run over ${reports.length} realm(s):\n`
+        : `Migrated ${migrating.length} of ${reports.length} realm(s):\n`,
+    );
+    for (let report of reports) {
+      let mark = report.willMigrate ? '*' : ' ';
+      console.log(`${mark} ${report.realmDir}\n    ${describe(report)}`);
+      if (report.extras.length > 0) {
+        console.log(`    carries: ${report.extras.join(', ')}`);
+      }
+    }
+    let counts = new Map<string, number>();
+    for (let report of reports) {
+      let key = report.willMigrate
+        ? 'migrate'
+        : `leave (${report.classification.kind})`;
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    console.log('');
+    for (let [key, count] of [...counts].sort()) {
+      console.log(`  ${count} ${key}`);
+    }
+    if (!args.dryRun && manifest.length > 0) {
+      console.log(
+        `\nRollback manifest: ${args.manifest}\n  node scripts/migrate-index-to-workspace.ts --rollback ${args.manifest}`,
+      );
+    }
+    if (migrating.length > 0) {
+      console.log('\nReindex these realms (they were changed on disk):');
+      for (let report of migrating) {
+        console.log(`  ${report.realmDir}`);
+      }
+    }
+  }
+
+  if (unmatchedIncludes.size > 0) {
+    console.error(
+      `\n--include named ${unmatchedIncludes.size} realm(s) that were not scanned: ${[...unmatchedIncludes].join(', ')}`,
+    );
+    return 1;
+  }
+  return 0;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    process.exit(main(process.argv.slice(2)));
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+}

--- a/packages/realm-server/scripts/migrate-index-to-workspace.ts
+++ b/packages/realm-server/scripts/migrate-index-to-workspace.ts
@@ -33,11 +33,18 @@
  * Flags:
  *   --dry-run              Report what would change; write nothing. Default is
  *                          to apply, so a first pass should always be a dry run.
- *   --persistent <root>    Scan the realm trees the deployed server mounts: the
- *                          public realms directly under <root> (see
- *                          PUBLIC_REALM_DIRS) plus every <root>/realms/<user>/<realm>.
  *   --realms-root <dir>    Scan every <dir>/<user>/<realm> as a realm root.
- *                          Repeatable; this is the user-realms half of --persistent.
+ *                          Repeatable. This is the flag to reach for: user
+ *                          realms are the ones that only exist on a realm
+ *                          server's disk, so this migration is their only path.
+ *   --persistent <root>    Also scan the public realms directly under <root>
+ *                          (see PUBLIC_REALM_DIRS) alongside <root>/realms.
+ *                          Those realms are deploy-managed — their contents
+ *                          come from this repo — so migrating them on disk
+ *                          duplicates what a deploy already carries, and for a
+ *                          realm the repo has deliberately left on CardsGrid it
+ *                          contradicts that decision. Prefer --realms-root
+ *                          unless a realm server has drifted from its deploy.
  *   --published            Also scan the published snapshots under
  *                          <realms-root>/_published/<disk-id>. Off by default:
  *                          a snapshot is regenerated from its source realm on
@@ -53,11 +60,11 @@
  *   --rollback <file>      Restore every file recorded in a manifest and exit.
  *
  * Examples:
- *   # Preview every realm the deployed server mounts
- *   node scripts/migrate-index-to-workspace.ts --dry-run --persistent /persistent
+ *   # Preview every user realm
+ *   node scripts/migrate-index-to-workspace.ts --dry-run --realms-root /persistent/realms
  *
  *   # Apply, also migrating two realms whose index is a hand-rolled workspace
- *   node scripts/migrate-index-to-workspace.ts --persistent /persistent \
+ *   node scripts/migrate-index-to-workspace.ts --realms-root /persistent/realms \
  *     --include ctse/demo --include buck/mar10
  *
  *   # Undo

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -239,6 +239,7 @@ const ALL_TEST_FILES: string[] = [
   './cpu-profiler-affinity-gate-test',
   './definition-lookup-test',
   './searchable-parity-diff-test',
+  './migrate-index-to-workspace-test',
   './file-watcher-events-test',
   './full-index-on-startup-test',
   './full-reindex-test',

--- a/packages/realm-server/tests/migrate-index-to-workspace-test.ts
+++ b/packages/realm-server/tests/migrate-index-to-workspace-test.ts
@@ -9,7 +9,7 @@ import {
   rmSync,
 } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { basename, join } from 'path';
 
 import {
   classify,
@@ -65,7 +65,11 @@ function captureLogs(fn: () => number): { code: number; out: string } {
   }
 }
 
-module('Unit | migrate-index-to-workspace', function () {
+// The outermost module must be the file's basename: CI shards this suite by
+// setting TEST_MODULES, which becomes a QUnit filter anchored on each file's
+// own name. A module named anything else matches nothing and the whole file is
+// silently skipped in CI while still passing locally.
+module(basename(import.meta.filename), function () {
   module('splitBaseModule', function () {
     test('recognizes the prefix form and every deployment-URL spelling', function (assert) {
       assert.deepEqual(splitBaseModule('@cardstack/base/cards-grid'), {

--- a/packages/realm-server/tests/migrate-index-to-workspace-test.ts
+++ b/packages/realm-server/tests/migrate-index-to-workspace-test.ts
@@ -1,0 +1,491 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  classify,
+  discoverPublishedRealms,
+  discoverUserRealms,
+  extraKeys,
+  forcedTarget,
+  main,
+  rewriteIndexJson,
+  splitBaseModule,
+} from '../scripts/migrate-index-to-workspace.ts';
+
+// Unit coverage for the realm index-card migration
+// (`scripts/migrate-index-to-workspace.ts`), which switches a realm's
+// `index.json` from the legacy default index — `CardsGrid`, or its `IndexCard`
+// alias — to `Workspace`. The costly mistakes it has to avoid are rewriting a
+// realm that customized its index, and losing data the file carries alongside
+// the adoption, so both get direct tests.
+
+function indexCard(module: string, name: string, extra: object = {}) {
+  return JSON.stringify({
+    data: { type: 'card', meta: { adoptsFrom: { module, name } }, ...extra },
+  });
+}
+
+function withTempDir(fn: (dir: string) => void) {
+  let dir = mkdtempSync(join(tmpdir(), 'migrate-index-'));
+  try {
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function makeRealm(root: string, path: string, contents: string) {
+  let dir = join(root, path);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'index.json'), contents);
+  return dir;
+}
+
+function captureLogs(fn: () => number): { code: number; out: string } {
+  let out: string[] = [];
+  let log = console.log;
+  let error = console.error;
+  console.log = (...args: unknown[]) => out.push(args.join(' '));
+  console.error = (...args: unknown[]) => out.push(args.join(' '));
+  try {
+    return { code: fn(), out: out.join('\n') };
+  } finally {
+    console.log = log;
+    console.error = error;
+  }
+}
+
+module('Unit | migrate-index-to-workspace', function () {
+  module('splitBaseModule', function () {
+    test('recognizes the prefix form and every deployment-URL spelling', function (assert) {
+      assert.deepEqual(splitBaseModule('@cardstack/base/cards-grid'), {
+        prefix: '@cardstack/base/',
+        segment: 'cards-grid',
+      });
+      assert.deepEqual(
+        splitBaseModule('https://cardstack.com/base/cards-grid'),
+        { prefix: 'https://cardstack.com/base/', segment: 'cards-grid' },
+      );
+      assert.deepEqual(
+        splitBaseModule('https://realms-staging.stack.cards/base/index'),
+        {
+          prefix: 'https://realms-staging.stack.cards/base/',
+          segment: 'index',
+        },
+      );
+    });
+
+    test('a module outside the base realm is not a base module', function (assert) {
+      assert.strictEqual(
+        splitBaseModule('@cardstack/catalog/cards-grid'),
+        undefined,
+        'another realm prefix',
+      );
+      assert.strictEqual(
+        splitBaseModule('https://example.com/mine/cards-grid'),
+        undefined,
+        'a URL with no /base/ segment',
+      );
+      assert.strictEqual(
+        splitBaseModule('./cards-grid'),
+        undefined,
+        'relative',
+      );
+    });
+  });
+
+  module('classify', function () {
+    test('CardsGrid is legacy in both module forms, and keeps the form it had', function (assert) {
+      let prefix = classify({
+        module: '@cardstack/base/cards-grid',
+        name: 'CardsGrid',
+      });
+      assert.strictEqual(prefix.kind, 'legacy');
+      assert.deepEqual(prefix.kind === 'legacy' ? prefix.target : undefined, {
+        module: '@cardstack/base/workspace',
+        name: 'Workspace',
+      });
+
+      let url = classify({
+        module: 'https://cardstack.com/base/cards-grid',
+        name: 'CardsGrid',
+      });
+      assert.strictEqual(url.kind, 'legacy');
+      assert.deepEqual(url.kind === 'legacy' ? url.target : undefined, {
+        module: 'https://cardstack.com/base/workspace',
+        name: 'Workspace',
+      });
+    });
+
+    test('IndexCard is legacy too — base/index re-exports CardsGrid under that name', function (assert) {
+      let result = classify({
+        module: 'https://cardstack.com/base/index',
+        name: 'IndexCard',
+      });
+      assert.strictEqual(result.kind, 'legacy');
+      assert.deepEqual(result.kind === 'legacy' ? result.target : undefined, {
+        module: 'https://cardstack.com/base/workspace',
+        name: 'Workspace',
+      });
+    });
+
+    test('an already-migrated realm is left alone', function (assert) {
+      assert.strictEqual(
+        classify({ module: '@cardstack/base/workspace', name: 'Workspace' })
+          .kind,
+        'workspace',
+      );
+    });
+
+    test('a bespoke index card is not migrated', function (assert) {
+      assert.strictEqual(
+        classify({
+          module: './boxel-ai-website/boxel-home-layout',
+          name: 'HomeLayoutCard',
+        }).kind,
+        'relative',
+        'a realm-local module is reported separately, never rewritten',
+      );
+      assert.strictEqual(
+        classify({ module: '@cardstack/catalog/blog', name: 'Blog' }).kind,
+        'bespoke',
+      );
+    });
+
+    test('a base-realm export that is not an index card is bespoke', function (assert) {
+      assert.strictEqual(
+        classify({ module: '@cardstack/base/cards-grid', name: 'Renderer' })
+          .kind,
+        'bespoke',
+        'right module, wrong export name',
+      );
+      assert.strictEqual(
+        classify({ module: '@cardstack/base/skill', name: 'Skill' }).kind,
+        'bespoke',
+      );
+    });
+
+    test('a file with no usable adoption is reported, not guessed at', function (assert) {
+      assert.strictEqual(classify(undefined).kind, 'unusable');
+      assert.strictEqual(classify({ module: 'x' }).kind, 'unusable');
+    });
+  });
+
+  module('rewriteIndexJson', function () {
+    test('only the adoption changes; attributes and relationships survive', function (assert) {
+      let source = indexCard('https://cardstack.com/base/index', 'IndexCard', {
+        attributes: { title: 'My Realm' },
+        relationships: { cardsGrid: { links: { self: './cards-grid' } } },
+      });
+      let result = JSON.parse(
+        rewriteIndexJson(source, {
+          module: 'https://cardstack.com/base/workspace',
+          name: 'Workspace',
+        }),
+      );
+      assert.deepEqual(result.data.meta.adoptsFrom, {
+        module: 'https://cardstack.com/base/workspace',
+        name: 'Workspace',
+      });
+      assert.deepEqual(result.data.attributes, { title: 'My Realm' });
+      assert.deepEqual(result.data.relationships, {
+        cardsGrid: { links: { self: './cards-grid' } },
+      });
+    });
+
+    test('the file keeps whichever formatting it already used', function (assert) {
+      let compact = indexCard('@cardstack/base/cards-grid', 'CardsGrid');
+      let rewrittenCompact = rewriteIndexJson(compact, forcedTarget());
+      assert.notOk(
+        rewrittenCompact.includes('\n'),
+        'a single-line file stays a single line',
+      );
+
+      let rewrittenTerminated = rewriteIndexJson(
+        `${compact}\n`,
+        forcedTarget(),
+      );
+      assert.false(
+        rewrittenTerminated.trimEnd().includes('\n'),
+        'a single line plus a trailing newline — what the realm server writes — is not reflowed',
+      );
+      assert.ok(rewrittenTerminated.endsWith('\n'), 'and keeps its newline');
+
+      let pretty = `${JSON.stringify(JSON.parse(compact), null, 2)}\n`;
+      let rewrittenPretty = rewriteIndexJson(pretty, forcedTarget());
+      assert.ok(
+        rewrittenPretty.includes('\n  "data"'),
+        'a pretty-printed file stays pretty-printed',
+      );
+      assert.ok(
+        rewrittenPretty.endsWith('\n'),
+        'a trailing newline is preserved',
+      );
+    });
+  });
+
+  test('extraKeys names what a file carries beyond the adoption', function (assert) {
+    assert.deepEqual(
+      extraKeys(indexCard('@cardstack/base/cards-grid', 'CardsGrid')),
+      [],
+      'a plain index card carries nothing',
+    );
+    assert.deepEqual(
+      extraKeys(
+        indexCard('@cardstack/base/cards-grid', 'CardsGrid', {
+          attributes: { title: 'x' },
+          relationships: {},
+        }),
+      ),
+      ['data.attributes', 'data.relationships'],
+    );
+  });
+
+  test('discoverUserRealms walks exactly two levels, and skips _published', function (assert) {
+    withTempDir((dir) => {
+      makeRealm(dir, 'buck/mar10', '{}');
+      makeRealm(dir, 'buck/other', '{}');
+      makeRealm(dir, 'tintin/notes', '{}');
+      // A card living inside a realm must not be mistaken for a realm.
+      mkdirSync(join(dir, 'buck/mar10/Author'), { recursive: true });
+      // _published is a flat <disk-id> tree, not an owner.
+      makeRealm(dir, '_published/e3271e35', '{}');
+
+      assert.deepEqual(discoverUserRealms(dir), [
+        join(dir, 'buck', 'mar10'),
+        join(dir, 'buck', 'other'),
+        join(dir, 'tintin', 'notes'),
+      ]);
+    });
+  });
+
+  test('discoverPublishedRealms walks the flat snapshot tree', function (assert) {
+    withTempDir((dir) => {
+      makeRealm(dir, 'buck/mar10', '{}');
+      makeRealm(dir, '_published/e3271e35', '{}');
+      makeRealm(dir, '_published/9b0c1d2e', '{}');
+
+      assert.deepEqual(discoverPublishedRealms(dir), [
+        join(dir, '_published', '9b0c1d2e'),
+        join(dir, '_published', 'e3271e35'),
+      ]);
+    });
+  });
+
+  test('publish snapshots are migrated only when --published asks for them', function (assert) {
+    withTempDir((dir) => {
+      let snapshot = makeRealm(
+        dir,
+        '_published/e3271e35',
+        indexCard('@cardstack/base/cards-grid', 'CardsGrid'),
+      );
+      let before = readFileSync(join(snapshot, 'index.json'), 'utf8');
+
+      captureLogs(() =>
+        main(['--realms-root', dir, '--manifest', join(dir, 'm1.json')]),
+      );
+      assert.strictEqual(
+        readFileSync(join(snapshot, 'index.json'), 'utf8'),
+        before,
+        'skipped by default — a republish regenerates it from its source realm',
+      );
+
+      captureLogs(() =>
+        main([
+          '--realms-root',
+          dir,
+          '--published',
+          '--manifest',
+          join(dir, 'm2.json'),
+        ]),
+      );
+      assert.deepEqual(
+        JSON.parse(readFileSync(join(snapshot, 'index.json'), 'utf8')).data.meta
+          .adoptsFrom,
+        { module: '@cardstack/base/workspace', name: 'Workspace' },
+        'migrated when explicitly asked for',
+      );
+    });
+  });
+
+  module('main', function () {
+    test('a dry run reports the plan and writes nothing', function (assert) {
+      withTempDir((dir) => {
+        let realm = makeRealm(
+          dir,
+          'buck/mar10',
+          indexCard('@cardstack/base/cards-grid', 'CardsGrid'),
+        );
+        let before = readFileSync(join(realm, 'index.json'), 'utf8');
+
+        let { code, out } = captureLogs(() =>
+          main(['--dry-run', '--realms-root', dir]),
+        );
+
+        assert.strictEqual(code, 0);
+        assert.ok(out.includes('Dry run over 1 realm'), out);
+        assert.strictEqual(
+          readFileSync(join(realm, 'index.json'), 'utf8'),
+          before,
+          'the file on disk is untouched',
+        );
+      });
+    });
+
+    test('an applied run migrates only the legacy realms and can be rolled back', function (assert) {
+      withTempDir((dir) => {
+        let legacy = makeRealm(
+          dir,
+          'buck/mar10',
+          indexCard('https://cardstack.com/base/cards-grid', 'CardsGrid'),
+        );
+        let alias = makeRealm(
+          dir,
+          'buck/notes',
+          indexCard('@cardstack/base/index', 'IndexCard'),
+        );
+        let bespoke = makeRealm(
+          dir,
+          'tintin/site',
+          indexCard('@cardstack/catalog/blog', 'Blog'),
+        );
+        let done = makeRealm(
+          dir,
+          'tintin/already',
+          indexCard('@cardstack/base/workspace', 'Workspace'),
+        );
+        let bespokeBefore = readFileSync(join(bespoke, 'index.json'), 'utf8');
+        let manifest = join(dir, 'manifest.json');
+
+        let { code } = captureLogs(() =>
+          main(['--realms-root', dir, '--manifest', manifest]),
+        );
+        assert.strictEqual(code, 0);
+
+        let adoption = (realm: string) =>
+          JSON.parse(readFileSync(join(realm, 'index.json'), 'utf8')).data.meta
+            .adoptsFrom;
+        assert.deepEqual(
+          adoption(legacy),
+          {
+            module: 'https://cardstack.com/base/workspace',
+            name: 'Workspace',
+          },
+          'CardsGrid migrated, absolute form preserved',
+        );
+        assert.deepEqual(
+          adoption(alias),
+          { module: '@cardstack/base/workspace', name: 'Workspace' },
+          'IndexCard migrated, prefix form preserved',
+        );
+        assert.strictEqual(
+          readFileSync(join(bespoke, 'index.json'), 'utf8'),
+          bespokeBefore,
+          'the customized realm is untouched',
+        );
+        assert.deepEqual(
+          adoption(done),
+          { module: '@cardstack/base/workspace', name: 'Workspace' },
+          'the already-migrated realm is unchanged',
+        );
+
+        let restored = captureLogs(() => main(['--rollback', manifest]));
+        assert.strictEqual(restored.code, 0);
+        assert.deepEqual(
+          adoption(legacy),
+          {
+            module: 'https://cardstack.com/base/cards-grid',
+            name: 'CardsGrid',
+          },
+          'rollback restores the original adoption',
+        );
+      });
+    });
+
+    test('--include migrates a realm whose index is a hand-rolled workspace', function (assert) {
+      withTempDir((dir) => {
+        let handRolled = makeRealm(
+          dir,
+          'ctse/demo',
+          indexCard('./workspace', 'Workspace'),
+        );
+        let otherBespoke = makeRealm(
+          dir,
+          'ctse/other',
+          indexCard('./workspace', 'Workspace'),
+        );
+
+        let { code } = captureLogs(() =>
+          main([
+            '--realms-root',
+            dir,
+            '--include',
+            'ctse/demo',
+            '--manifest',
+            join(dir, 'manifest.json'),
+          ]),
+        );
+        assert.strictEqual(code, 0);
+
+        assert.deepEqual(
+          JSON.parse(readFileSync(join(handRolled, 'index.json'), 'utf8')).data
+            .meta.adoptsFrom,
+          { module: '@cardstack/base/workspace', name: 'Workspace' },
+          'the named realm moves to the base Workspace',
+        );
+        assert.deepEqual(
+          JSON.parse(readFileSync(join(otherBespoke, 'index.json'), 'utf8'))
+            .data.meta.adoptsFrom,
+          { module: './workspace', name: 'Workspace' },
+          'an identical realm that was not named is left alone',
+        );
+      });
+    });
+
+    test('an --include that matches no scanned realm fails the run', function (assert) {
+      withTempDir((dir) => {
+        makeRealm(
+          dir,
+          'buck/mar10',
+          indexCard('@cardstack/base/cards-grid', 'CardsGrid'),
+        );
+        let { code, out } = captureLogs(() =>
+          main([
+            '--dry-run',
+            '--realms-root',
+            dir,
+            '--include',
+            'nobody/nothing',
+          ]),
+        );
+        assert.strictEqual(code, 1, 'a typo in --include is not silent');
+        assert.ok(out.includes('nobody/nothing'), out);
+      });
+    });
+
+    test('a realm with unreadable or missing index JSON is reported, not rewritten', function (assert) {
+      withTempDir((dir) => {
+        makeRealm(dir, 'buck/broken', '{ not json');
+        mkdirSync(join(dir, 'buck/empty'), { recursive: true });
+
+        let { code, out } = captureLogs(() =>
+          main(['--dry-run', '--realms-root', dir]),
+        );
+        assert.strictEqual(code, 0);
+        assert.ok(out.includes('invalid JSON'), out);
+        assert.ok(out.includes('no index.json'), out);
+        assert.notOk(out.includes('* '), 'nothing is marked for migration');
+      });
+    });
+  });
+});

--- a/packages/realm-server/tests/migrate-index-to-workspace-test.ts
+++ b/packages/realm-server/tests/migrate-index-to-workspace-test.ts
@@ -412,6 +412,37 @@ module('Unit | migrate-index-to-workspace', function () {
       });
     });
 
+    test('the report gives each migrated realm as a reindex realm= path', function (assert) {
+      withTempDir((dir) => {
+        makeRealm(
+          dir,
+          'buck/mar10',
+          indexCard('@cardstack/base/cards-grid', 'CardsGrid'),
+        );
+        // Three levels deep, so the two-level owner walk does not reach it and
+        // it is only in scope as an explicit argument.
+        let explicit = makeRealm(
+          dir,
+          'deep/deeper/deepest/thing',
+          indexCard('@cardstack/base/cards-grid', 'CardsGrid'),
+        );
+
+        let { out } = captureLogs(() =>
+          main(['--dry-run', '--realms-root', dir, explicit]),
+        );
+
+        let realmList = out.slice(out.indexOf('As a realm= list'));
+        assert.ok(
+          realmList.includes(join('buck', 'mar10')),
+          'a realm found under a realms root is listed as <user>/<realm>',
+        );
+        assert.notOk(
+          realmList.includes('thing'),
+          'an explicitly named directory is omitted — its disk path implies no URL',
+        );
+      });
+    });
+
     test('--include migrates a realm whose index is a hand-rolled workspace', function (assert) {
       withTempDir((dir) => {
         let handRolled = makeRealm(

--- a/packages/realm-server/tests/searchable-parity-diff-test.ts
+++ b/packages/realm-server/tests/searchable-parity-diff-test.ts
@@ -1,6 +1,8 @@
 import QUnit from 'qunit';
 const { module, test } = QUnit;
 
+import { basename } from 'path';
+
 import { diffDoc, isShallowLink, shallowIds } from '@cardstack/runtime-common';
 
 // Unit coverage for the parity comparison logic shared by the realm-scale
@@ -10,7 +12,7 @@ import { diffDoc, isShallowLink, shallowIds } from '@cardstack/runtime-common';
 // --ignore-shallow-links) treats the store-driven omit-vs-keep-`{id}` difference
 // as equivalent — at any nesting depth — while still catching a CHANGED
 // reference or any real contained-data delta.
-module('Unit | searchable-parity-diff', function () {
+module(basename(import.meta.filename), function () {
   module('isShallowLink', function () {
     test('null / a bare { id } / an array of bare { id } are shallow', function (assert) {
       assert.true(isShallowLink(null), 'null');


### PR DESCRIPTION
## What

`packages/realm-server/scripts/migrate-index-to-workspace.ts` moves a realm's index card off the legacy default index and onto `Workspace`. The committed realms in this repo were migrated by hand in #5610; this is the tool for the realms that only exist on a realm server's disk.

A realm's index card is the `index.json` at its root. Three adoptions are treated as the legacy default:

- `CardsGrid`, as `@cardstack/base/cards-grid` or an absolute `…/base/cards-grid` URL.
- `IndexCard`, as `@cardstack/base/index` or an absolute `…/base/index` URL — `packages/base/index.gts` is a one-line re-export of `CardsGrid` under that historical name, so a realm adopting it is on CardsGrid too.

Absolute URLs are matched on the `/base/<export>` path rather than a fixed host, so the deployment-URL spellings that predate the RRI migration are caught alongside `https://cardstack.com/base/…`.

Anything else is reported and left alone. Relative specifiers get their own verdict rather than being folded in with the rest: inside the base realm `./cards-grid` *is* the default index, but in a user realm it names that realm's own module, and nothing on disk distinguishes the two.

## What it preserves

Only `data.meta.adoptsFrom` is rewritten. Attributes and relationships carry over untouched, and anything a file holds beyond the adoption is named in the report so it can be eyeballed before the run is applied.

Each realm keeps whichever module form it already used — the publish handler's `DEFAULT_REALM_INDEX_ADOPTIONS` recognizes both the `@cardstack/base/` prefix and the absolute base-realm URL, so normalizing them would be churn.

Formatting is preserved too, which matters more than it sounds: card JSON on disk is one line plus a trailing newline, and a naive "does this file contain a newline" check reads that as pretty-printed and reflows the whole file. The rewrite reflows nothing.

## Rollback

An applied run writes a manifest holding each changed file's original bytes; `--rollback <manifest>` restores them. It is plain JSON read and written by node, so undoing a run needs nothing installed in the container beyond the runtime that produced it.

## Publish snapshots

`_published/<disk-id>` is skipped by default, the way `lib/realm-registry-backfill.ts` skips that directory when walking owners — it is a flat snapshot tree, not a username. A snapshot is regenerated from its source realm on the next publish, so migrating the source and republishing is what keeps the two in step. `--published` opts into them for the case where that isn't wanted.

## Hand-rolled workspaces

Some realms have an index card that is a copy of the Workspace card living in the realm itself. Those adopt a realm-local module, so no rule distinguishes them from a genuinely bespoke index — `--include <realm>` names them explicitly, and an `--include` that matches no scanned realm fails the run rather than passing silently.

## Reindex

The deployed server does not watch EFS, so an on-disk edit is invisible to the index until a reindex runs. Every report ends with the realm paths to feed `/_grafana-reindex?realm=<path>`.

## Test plan

`Unit | migrate-index-to-workspace` — 19 passed, 0 failed. Covers module-form recognition, each classification, the preserved-data and preserved-formatting guarantees, the two-level owner walk vs. the flat `_published` walk, apply/rollback round-trip, `--include`, and unreadable or missing index JSON.

Verified end-to-end against a live `dev-all` stack on two local realms — one plain `CardsGrid`, one `IndexCard` carrying a leftover `cardsGrid` relationship for a field neither card defines, which was the case most likely to error-index. Both reindexed with 0 file errors and 0 instance errors, landed in `boxel_index` with `_cardType` `Workspace`, and produced isolated and fitted prerendered HTML with no error doc. Rolling back and reindexing restored both to `Cards Grid`, and the restored files were byte-identical to the originals.

eslint, prettier and `tsc --noEmit` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
