### PR TITLE
Add ThreeMfDef FileDef subclass for 3MF (3D printing) files

### DIFF
--- a/packages/base/3mf-file-def.gts
+++ b/packages/base/3mf-file-def.gts
@@ -1,0 +1,210 @@
+import { byteStreamToUint8Array } from '@cardstack/runtime-common';
+import Cube3dSphereIcon from '@cardstack/boxel-icons/cube-3d-sphere';
+import {
+  BaseDefComponent,
+  Component,
+  StringField,
+  contains,
+  field,
+} from './card-api';
+import BooleanField from './boolean';
+import {
+  FileDef,
+  type ByteStream,
+  type SerializedFile,
+} from './file-api';
+import { extract3mfMetadata } from './3mf-meta-extractor';
+
+type ThreeMfExtra = {
+  title?: string;
+  designer?: string;
+  description?: string;
+  license?: string;
+  unit?: string;
+  hasThumbnail: boolean;
+};
+
+function threeMfTitle(
+  model: { title?: string | null; name?: string | null } | null | undefined,
+): string {
+  return model?.title ?? model?.name ?? 'Untitled 3MF model';
+}
+
+class Isolated extends Component<typeof ThreeMfDef> {
+  get title() {
+    return threeMfTitle(this.args.model);
+  }
+  <template>
+    <article class='threemf-isolated' data-test-threemf-isolated>
+      <header class='threemf-isolated__header'>
+        <Cube3dSphereIcon
+          class='threemf-isolated__icon'
+          width='32'
+          height='32'
+        />
+        <div class='threemf-isolated__heading'>
+          <div class='threemf-isolated__title'>{{this.title}}</div>
+          {{#if @model.designer}}
+            <div class='threemf-isolated__designer'>by {{@model.designer}}</div>
+          {{/if}}
+        </div>
+      </header>
+      {{#if @model.description}}
+        <p class='threemf-isolated__description'>{{@model.description}}</p>
+      {{/if}}
+      <dl class='threemf-isolated__facts'>
+        {{#if @model.unit}}
+          <div class='threemf-isolated__fact'>
+            <dt>Units</dt>
+            <dd>{{@model.unit}}</dd>
+          </div>
+        {{/if}}
+        {{#if @model.license}}
+          <div class='threemf-isolated__fact'>
+            <dt>License</dt>
+            <dd>{{@model.license}}</dd>
+          </div>
+        {{/if}}
+      </dl>
+    </article>
+    <style scoped>
+      .threemf-isolated {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp);
+        padding: var(--boxel-sp-lg);
+        max-width: 100%;
+      }
+      .threemf-isolated__header {
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp);
+      }
+      .threemf-isolated__icon {
+        color: var(--boxel-600);
+        flex-shrink: 0;
+      }
+      .threemf-isolated__heading {
+        min-width: 0;
+        flex: 1;
+      }
+      .threemf-isolated__title {
+        font-weight: 600;
+        color: var(--boxel-900);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .threemf-isolated__designer {
+        color: var(--boxel-600);
+        font-size: var(--boxel-font-sm);
+      }
+      .threemf-isolated__description {
+        color: var(--boxel-700);
+        margin: 0;
+      }
+      .threemf-isolated__facts {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--boxel-sp) var(--boxel-sp-lg);
+        margin: 0;
+      }
+      .threemf-isolated__fact {
+        display: flex;
+        flex-direction: column;
+      }
+      .threemf-isolated__fact dt {
+        color: var(--boxel-500);
+        font-size: var(--boxel-font-xs);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .threemf-isolated__fact dd {
+        color: var(--boxel-900);
+        margin: 0;
+      }
+    </style>
+  </template>
+}
+
+class Embedded extends Component<typeof ThreeMfDef> {
+  get title() {
+    return threeMfTitle(this.args.model);
+  }
+  <template>
+    <div class='threemf-embedded' data-test-threemf-embedded>
+      <Cube3dSphereIcon
+        class='threemf-embedded__icon'
+        width='20'
+        height='20'
+      />
+      <div class='threemf-embedded__meta'>
+        <div class='threemf-embedded__title'>{{this.title}}</div>
+        {{#if @model.designer}}
+          <div class='threemf-embedded__designer'>by {{@model.designer}}</div>
+        {{/if}}
+      </div>
+    </div>
+    <style scoped>
+      .threemf-embedded {
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp-xs);
+        min-width: 0;
+      }
+      .threemf-embedded__icon {
+        color: var(--boxel-600);
+        flex-shrink: 0;
+      }
+      .threemf-embedded__meta {
+        min-width: 0;
+      }
+      .threemf-embedded__title {
+        font-weight: 600;
+        color: var(--boxel-900);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .threemf-embedded__designer {
+        color: var(--boxel-600);
+        font-size: var(--boxel-font-sm);
+      }
+    </style>
+  </template>
+}
+
+// 3MF (3D Manufacturing Format) — the ZIP+XML successor to STL used for 3D
+// printing. Unlike STL, it self-describes with title/designer/description/
+// license text that is not in the filename, so extracting it delivers real
+// full-text search value. See `3mf-meta-extractor.ts` for the bounded parse.
+export class ThreeMfDef extends FileDef {
+  static displayName = '3MF Model';
+  static icon = Cube3dSphereIcon;
+  static acceptTypes = '.3mf,model/3mf';
+
+  @field title = contains(StringField);
+  @field designer = contains(StringField);
+  @field description = contains(StringField);
+  @field license = contains(StringField);
+  @field unit = contains(StringField);
+  @field hasThumbnail = contains(BooleanField);
+
+  static isolated: BaseDefComponent = Isolated;
+  static embedded: BaseDefComponent = Embedded;
+
+  static async extractAttributes(
+    url: string,
+    getStream: () => Promise<ByteStream>,
+    options: { contentHash?: string; contentSize?: number } = {},
+  ): Promise<SerializedFile<ThreeMfExtra>> {
+    let base = await super.extractAttributes(url, getStream, options);
+    // 3MF is a ZIP container, so we need the whole file in memory to unzip it;
+    // `extract3mfMetadata` then bounds the XML parse to the model header.
+    let bytes = await byteStreamToUint8Array(await getStream());
+    let metadata = extract3mfMetadata(bytes);
+    return { ...base, ...metadata };
+  }
+}
+
+export default ThreeMfDef;

--- a/packages/base/3mf-meta-extractor.ts
+++ b/packages/base/3mf-meta-extractor.ts
@@ -1,0 +1,127 @@
+import { unzipSync, strFromU8 } from 'fflate';
+import { FileContentMismatchError } from './file-api';
+
+// A 3MF file is an OPC package: a ZIP archive of XML parts. The part we read is
+// the 3D model (conventionally `3D/3dmodel.model`), whose `<model>` root carries
+// a `unit` attribute and a `<metadata>` block — both sitting *above* the
+// `<resources>` geometry. Everything a user searches for (title, designer,
+// description, license) lives in that header block and is absent from the
+// filename, which is why 3MF earns its own FileDef.
+
+export interface ThreeMfMetadata {
+  title?: string;
+  designer?: string;
+  description?: string;
+  license?: string;
+  unit?: string;
+  hasThumbnail: boolean;
+}
+
+// The model part holds all the geometry, so it can be large. We only need the
+// header, which is small and at the top — decode at most this many bytes before
+// parsing so the work stays bounded on the indexing hot path regardless of mesh
+// size.
+const MODEL_HEADER_MAX_BYTES = 262_144; // 256 KB
+
+// Case-insensitive, namespace-prefix tolerant (`<m:model …>`) matchers. These
+// live in a plain `.ts` module (not `.gts`) so regex literals are safe from the
+// content-tag lexer quirks that affect `.gts` files.
+const MODEL_PART_RE = /\.model$/i;
+const GEOMETRY_START_RE = /<(?:\w+:)?(?:resources|build)\b/i;
+const MODEL_UNIT_RE =
+  /<(?:\w+:)?model\b[^>]*\bunit\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
+const METADATA_RE =
+  /<(?:\w+:)?metadata\b[^>]*\bname\s*=\s*(?:"([^"]*)"|'([^']*)')[^>]*>([\s\S]*?)<\/(?:\w+:)?metadata>/gi;
+const THUMBNAIL_RE = /thumbnail/i;
+const IMAGE_EXT_RE = /\.(?:png|jpe?g)$/i;
+
+// 3MF's default unit when the `<model>` element omits it (spec §the model
+// element): millimeter. We fill it in so the field is always meaningful.
+const DEFAULT_UNIT = 'millimeter';
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) =>
+      String.fromCodePoint(parseInt(hex, 16)),
+    )
+    .replace(/&amp;/g, '&');
+}
+
+function firstMatch(...values: (string | undefined)[]): string | undefined {
+  for (let value of values) {
+    if (value != null && value.trim() !== '') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+export function extract3mfMetadata(bytes: Uint8Array): ThreeMfMetadata {
+  // Collect every entry name via the filter callback (called for all entries)
+  // while only inflating the model part — the thumbnail/texture parts stay
+  // compressed. The names give us the thumbnail signal for free.
+  let names: string[] = [];
+  let files: Record<string, Uint8Array>;
+  try {
+    files = unzipSync(bytes, {
+      filter: (file) => {
+        names.push(file.name);
+        return MODEL_PART_RE.test(file.name);
+      },
+    });
+  } catch {
+    throw new FileContentMismatchError('3MF file is not a valid ZIP archive');
+  }
+
+  let modelName =
+    Object.keys(files).find((name) => name === '3D/3dmodel.model') ??
+    Object.keys(files).find((name) => MODEL_PART_RE.test(name));
+  if (!modelName) {
+    throw new FileContentMismatchError(
+      '3MF archive has no 3D model part (no *.model entry)',
+    );
+  }
+
+  let modelBytes = files[modelName];
+  let header = strFromU8(modelBytes.subarray(0, MODEL_HEADER_MAX_BYTES));
+  let geometryStart = header.search(GEOMETRY_START_RE);
+  if (geometryStart >= 0) {
+    header = header.slice(0, geometryStart);
+  }
+
+  let unitMatch = header.match(MODEL_UNIT_RE);
+  let unit = firstMatch(unitMatch?.[1], unitMatch?.[2]) ?? DEFAULT_UNIT;
+
+  let metadata: Record<string, string> = {};
+  let match: RegExpExecArray | null;
+  while ((match = METADATA_RE.exec(header))) {
+    let name = firstMatch(match[1], match[2]);
+    if (!name) {
+      continue;
+    }
+    let value = decodeXmlEntities((match[3] ?? '').trim());
+    if (value !== '') {
+      metadata[name] = value;
+    }
+  }
+  // Reset lastIndex so the shared /g regex is safe on the next call.
+  METADATA_RE.lastIndex = 0;
+
+  let hasThumbnail = names.some(
+    (name) => THUMBNAIL_RE.test(name) && IMAGE_EXT_RE.test(name),
+  );
+
+  return {
+    title: metadata['Title'],
+    designer: metadata['Designer'],
+    description: metadata['Description'],
+    license: firstMatch(metadata['LicenseTerms'], metadata['Copyright']),
+    unit,
+    hasThumbnail,
+  };
+}

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -21,6 +21,7 @@
     "ember-modifier": "^3.2.1",
     "ember-resources": "catalog:",
     "ember-template-lint": "catalog:",
+    "fflate": "catalog:",
     "matrix-js-sdk": "catalog:",
     "super-fast-md5": "catalog:",
     "@floating-ui/dom": "catalog:",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -152,6 +152,7 @@
     "ethers": "catalog:",
     "eventemitter3": "catalog:",
     "fast-json-stable-stringify": "catalog:",
+    "fflate": "catalog:",
     "filesize": "catalog:",
     "flat": "catalog:",
     "glimmer-scoped-css": "catalog:",

--- a/packages/host/tests/acceptance/3mf-file-def-test.gts
+++ b/packages/host/tests/acceptance/3mf-file-def-test.gts
@@ -1,0 +1,328 @@
+import { visit, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { zipSync, strToU8 } from 'fflate';
+
+import { module, test } from 'qunit';
+
+import {
+  baseRealmRRI,
+  type FileExtractResponse,
+  type RenderRouteOptions,
+  type ResolvedCodeRef,
+  SupportedMimeType,
+  type RealmResourceIdentifier,
+} from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common/realm';
+
+import type NetworkService from '@cardstack/host/services/network';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  setupRealmCacheTeardown,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  capturePrerenderResult,
+  withCachedRealmSetup,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+import { setupTestRealmServiceWorker } from '../helpers/test-realm-service-worker';
+
+// A minimal but realistic 3MF: an OPC package (ZIP) whose `3D/3dmodel.model`
+// XML carries the searchable metadata and a tiny mesh, plus a thumbnail part.
+function makeMinimal3mf(): Uint8Array {
+  let model = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <metadata name="Title">Benchy Boat</metadata>
+  <metadata name="Designer">Creative Tools &amp; Co</metadata>
+  <metadata name="Description">A calibration boat for testing 3D printers.</metadata>
+  <metadata name="LicenseTerms">CC BY 4.0</metadata>
+  <metadata name="Application">PrusaSlicer 2.7</metadata>
+  <resources>
+    <object id="1" type="model">
+      <mesh>
+        <vertices><vertex x="0" y="0" z="0"/><vertex x="1" y="0" z="0"/><vertex x="0" y="1" z="0"/></vertices>
+        <triangles><triangle v1="0" v2="1" v3="2"/></triangles>
+      </mesh>
+    </object>
+  </resources>
+  <build><item objectid="1"/></build>
+</model>`;
+  let contentTypes = `<?xml version="1.0" encoding="UTF-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml"/><Default Extension="png" ContentType="image/png"/></Types>`;
+  let rels = `<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Target="/3D/3dmodel.model" Id="rel0" Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel"/><Relationship Target="/Metadata/thumbnail.png" Id="rel1" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail"/></Relationships>`;
+  return zipSync({
+    '[Content_Types].xml': strToU8(contentTypes),
+    '_rels/.rels': strToU8(rels),
+    '3D/3dmodel.model': strToU8(model),
+    'Metadata/thumbnail.png': new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+  });
+}
+
+// A ZIP that is a valid archive but has no `*.model` part.
+function makeZipWithoutModel(): Uint8Array {
+  return zipSync({ 'readme.txt': strToU8('not a 3mf model') });
+}
+
+module('Acceptance | 3mf file def', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+  setupRealmCacheTeardown(hooks);
+  setupTestRealmServiceWorker(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+  let realm: Realm;
+
+  const fileExtractPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/file-extract`;
+
+  const fileRenderPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    format = 'isolated',
+    ancestorLevel = 0,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/html/${format}/${ancestorLevel}`;
+
+  const makeFileURL = (path: string) => new URL(path, testRealmURL).href;
+
+  const threeMfDefCodeRef = (): ResolvedCodeRef => ({
+    module: `${baseRealmRRI}3mf-file-def` as RealmResourceIdentifier,
+    name: 'ThreeMfDef',
+  });
+
+  async function captureFileExtractResult(
+    expectedStatus?: 'ready' | 'error',
+  ): Promise<FileExtractResponse> {
+    await waitUntil(
+      () => {
+        let container = document.querySelector(
+          '[data-prerender-file-extract]',
+        ) as HTMLElement | null;
+        if (!container) {
+          return false;
+        }
+        let status = container.getAttribute(
+          'data-prerender-file-extract-status',
+        );
+        if (!status) {
+          return false;
+        }
+        if (expectedStatus && status !== expectedStatus) {
+          return false;
+        }
+        return status === 'ready' || status === 'error';
+      },
+      { timeout: 5000 },
+    );
+
+    let container = document.querySelector(
+      '[data-prerender-file-extract]',
+    ) as HTMLElement | null;
+    if (!container) {
+      throw new Error(
+        'captureFileExtractResult: missing [data-prerender-file-extract] container after wait',
+      );
+    }
+    let pre = container.querySelector('pre');
+    let text = pre?.textContent?.trim() ?? '';
+    return JSON.parse(text) as FileExtractResponse;
+  }
+
+  hooks.beforeEach(async function () {
+    ({ realm } = await withCachedRealmSetup(async () =>
+      setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'model.3mf': makeMinimal3mf(),
+          'not-a-3mf.3mf': 'This is plain text, not a ZIP archive.',
+          'no-model.3mf': makeZipWithoutModel(),
+        },
+      }),
+    ));
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any).__renderModel;
+    delete (globalThis as any).__boxelFileRenderData;
+  });
+
+  test('extracts metadata from 3mf', async function (assert) {
+    let url = makeFileURL('model.3mf');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: threeMfDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(
+      result.searchDoc?.title,
+      'Benchy Boat',
+      'extracts title',
+    );
+    assert.strictEqual(
+      result.searchDoc?.designer,
+      'Creative Tools & Co',
+      'extracts designer and decodes entities',
+    );
+    assert.strictEqual(
+      result.searchDoc?.description,
+      'A calibration boat for testing 3D printers.',
+      'extracts description',
+    );
+    assert.strictEqual(
+      result.searchDoc?.license,
+      'CC BY 4.0',
+      'extracts license',
+    );
+    assert.strictEqual(result.searchDoc?.unit, 'millimeter', 'extracts unit');
+    assert.true(result.searchDoc?.hasThumbnail, 'detects thumbnail');
+    assert.strictEqual(result.searchDoc?.name, 'model.3mf');
+    assert.strictEqual(
+      result.searchDoc?.contentType,
+      'model/3mf',
+      'sets 3mf content type',
+    );
+  });
+
+  test('falls back when ThreeMfDef is used for non-ZIP content', async function (assert) {
+    let url = makeFileURL('not-a-3mf.3mf');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: threeMfDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.true(result.mismatch, 'marks mismatch when content is not a ZIP');
+    assert.strictEqual(result.searchDoc?.name, 'not-a-3mf.3mf');
+  });
+
+  test('falls back when the ZIP has no model part', async function (assert) {
+    let url = makeFileURL('no-model.3mf');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: threeMfDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.true(result.mismatch, 'marks mismatch when there is no model part');
+    assert.strictEqual(result.searchDoc?.name, 'no-model.3mf');
+  });
+
+  test('isolated template renders the title and designer', async function (assert) {
+    let url = makeFileURL('model.3mf');
+
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: threeMfDefCodeRef(),
+      }),
+    );
+    let result = await captureFileExtractResult('ready');
+    assert.ok(result.resource, 'extraction produced a resource');
+
+    (globalThis as any).__boxelFileRenderData = {
+      resource: result.resource,
+      fileDefCodeRef: threeMfDefCodeRef(),
+    };
+
+    await visit(
+      fileRenderPath(url, {
+        fileRender: true,
+        fileDefCodeRef: threeMfDefCodeRef(),
+      }),
+    );
+
+    let { status } = await capturePrerenderResult('innerHTML');
+    assert.strictEqual(status, 'ready', 'render completed');
+
+    let title = document.querySelector(
+      '[data-prerender] .threemf-isolated__title',
+    );
+    assert.strictEqual(
+      title?.textContent?.trim(),
+      'Benchy Boat',
+      'renders the extracted title',
+    );
+    let designer = document.querySelector(
+      '[data-prerender] .threemf-isolated__designer',
+    );
+    assert.strictEqual(
+      designer?.textContent?.trim(),
+      'by Creative Tools & Co',
+      'renders the designer',
+    );
+  });
+
+  test('indexing stores 3mf metadata and file meta uses it', async function (assert) {
+    let fileURL = new URL('model.3mf', testRealmURL);
+    let fileEntry = await realm.realmIndexQueryEngine.file(fileURL);
+
+    assert.ok(fileEntry, 'file entry exists');
+    assert.strictEqual(
+      fileEntry?.searchDoc?.title,
+      'Benchy Boat',
+      'index stores 3mf title',
+    );
+    assert.strictEqual(
+      fileEntry?.searchDoc?.designer,
+      'Creative Tools & Co',
+      'index stores 3mf designer',
+    );
+
+    let network = getService('network') as NetworkService;
+    let response = await network.virtualNetwork.fetch(fileURL, {
+      headers: { Accept: SupportedMimeType.FileMeta },
+    });
+
+    assert.true(response.ok, 'file meta request succeeds');
+
+    let body = await response.json();
+    assert.strictEqual(body?.data?.type, 'file-meta');
+    assert.strictEqual(
+      body?.data?.attributes?.contentType,
+      'model/3mf',
+      'file meta uses 3mf content type',
+    );
+    assert.strictEqual(
+      body?.data?.attributes?.title,
+      'Benchy Boat',
+      'file meta includes 3mf title',
+    );
+    assert.strictEqual(
+      body?.data?.attributes?.designer,
+      'Creative Tools & Co',
+      'file meta includes 3mf designer',
+    );
+    assert.deepEqual(
+      body?.data?.meta?.adoptsFrom,
+      threeMfDefCodeRef(),
+      'file meta uses 3mf def',
+    );
+  });
+});

--- a/packages/host/tests/unit/file-def-code-ref-test.ts
+++ b/packages/host/tests/unit/file-def-code-ref-test.ts
@@ -5,6 +5,10 @@ import {
   baseRealm,
   baseRRI,
   isFileDefCodeRef,
+  urlNamesFile,
+  resolveFileDefCodeRef,
+  inferContentType,
+  isBinaryFilename,
 } from '@cardstack/runtime-common';
 import type { RealmResourceIdentifier } from '@cardstack/runtime-common';
 
@@ -59,6 +63,13 @@ module('Unit | isFileDefCodeRef', function (hooks) {
       ),
       'PngDef',
     );
+    assert.true(
+      isFileDefCodeRef(
+        { module: baseRRI('3mf-file-def'), name: 'ThreeMfDef' },
+        virtualNetwork,
+      ),
+      'ThreeMfDef',
+    );
   });
 
   test('rejects a non-FileDef card ref', function (assert) {
@@ -90,6 +101,44 @@ module('Unit | isFileDefCodeRef', function (hooks) {
         virtualNetwork,
       ),
       'a structured (non-module/name) ref is not treated as a FileDef ref',
+    );
+  });
+});
+
+module('Unit | 3mf file def wiring', function (hooks) {
+  let virtualNetwork: VirtualNetwork;
+
+  hooks.beforeEach(function () {
+    virtualNetwork = new VirtualNetwork();
+    virtualNetwork.addURLMapping(
+      new URL(baseRealm.url),
+      new URL(resolvedBaseRealmURL),
+    );
+    virtualNetwork.addRealmMapping('@cardstack/base/', resolvedBaseRealmURL);
+  });
+
+  test('urlNamesFile recognizes a .3mf URL', function (assert) {
+    assert.true(urlNamesFile(new URL('http://test-realm/test/widget.3mf')));
+    assert.false(urlNamesFile(new URL('http://test-realm/test/Widget/config')));
+  });
+
+  test('resolveFileDefCodeRef maps .3mf to ThreeMfDef', function (assert) {
+    let ref = resolveFileDefCodeRef(
+      new URL('http://test-realm/test/widget.3mf'),
+      virtualNetwork,
+    );
+    assert.strictEqual(ref.name, 'ThreeMfDef', 'resolves to ThreeMfDef');
+    assert.true(
+      ref.module.endsWith('3mf-file-def'),
+      'resolves the 3mf-file-def module',
+    );
+  });
+
+  test('.3mf infers the model/3mf content type and is binary', function (assert) {
+    assert.strictEqual(inferContentType('widget.3mf'), 'model/3mf');
+    assert.true(
+      isBinaryFilename('widget.3mf'),
+      '3mf is a binary ZIP container',
     );
   });
 });

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -39,6 +39,7 @@ const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
   '.opus': { module: baseModule('ogg-audio-def'), name: 'OggDef' },
   '.m4a': { module: baseModule('m4a-audio-def'), name: 'M4aDef' },
   '.flac': { module: baseModule('flac-audio-def'), name: 'FlacDef' },
+  '.3mf': { module: baseModule('3mf-file-def'), name: 'ThreeMfDef' },
   '.mismatch': {
     module: './filedef-mismatch' as RealmResourceIdentifier,
     name: 'FileDef',

--- a/packages/runtime-common/infer-content-type.ts
+++ b/packages/runtime-common/infer-content-type.ts
@@ -4,6 +4,8 @@ const DEFAULT_FILE_CONTENT_TYPE = 'application/octet-stream';
 const CONTENT_TYPE_OVERRIDES: Record<string, string> = {
   '.gts': 'text/typescript+glimmer',
   '.ts': 'text/typescript',
+  // 3MF (3D printing) — IANA-registered `model/3mf`; mime-db has no entry.
+  '.3mf': 'model/3mf',
 };
 
 export function inferContentType(filename: string): string {
@@ -29,6 +31,7 @@ export function isBinaryFilename(filename: string): boolean {
     mimeType.startsWith('font/') ||
     mimeType.startsWith('audio/') ||
     mimeType === 'application/pdf' ||
-    mimeType === 'application/vnd.ms-fontobject' // .eot legacy font
+    mimeType === 'application/vnd.ms-fontobject' || // .eot legacy font
+    mimeType === 'model/3mf' // 3MF is a binary ZIP container
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ catalogs:
     fast-json-stable-stringify:
       specifier: ^2.1.0
       version: 2.1.0
+    fflate:
+      specifier: ^0.8.3
+      version: 0.8.3
     file-loader:
       specifier: ^6.2.0
       version: 6.2.0
@@ -940,6 +943,9 @@ importers:
       ember-template-lint:
         specifier: 'catalog:'
         version: 7.9.3
+      fflate:
+        specifier: 'catalog:'
+        version: 0.8.3
       matrix-js-sdk:
         specifier: 'catalog:'
         version: 38.3.0(patch_hash=cee0baf579283943dc5a6b48977e8ed40a13fc111b5de9c91814893f9a4989fb)
@@ -1221,7 +1227,7 @@ importers:
         version: 5.5.6(@types/eslint@8.56.5)(eslint-config-prettier@9.1.2(eslint@8.57.1))(eslint@8.57.1)(prettier@3.8.4)
       http-server:
         specifier: ^14.1.1
-        version: 14.1.1(debug@4.3.4)
+        version: 14.1.1
       lucide-static:
         specifier: ^0.447.0
         version: 0.447.0
@@ -2309,6 +2315,9 @@ importers:
       fast-json-stable-stringify:
         specifier: 'catalog:'
         version: 2.1.0
+      fflate:
+        specifier: 'catalog:'
+        version: 0.8.3
       filesize:
         specifier: 'catalog:'
         version: 10.1.6
@@ -2741,7 +2750,7 @@ importers:
         version: 11.1.0
       http-server:
         specifier: 'catalog:'
-        version: 14.1.1(debug@4.3.4)
+        version: 14.1.1
       js-yaml:
         specifier: 'catalog:'
         version: 4.2.0
@@ -2834,7 +2843,7 @@ importers:
         version: 3.2.0
       wait-on:
         specifier: ^9.0.4
-        version: 9.0.10(debug@4.3.4)
+        version: 9.0.10
       wtfnode:
         specifier: ^0.10.1
         version: 0.10.1
@@ -10312,6 +10321,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -20612,7 +20624,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.18.0(debug@4.3.4):
+  axios@1.18.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.3.4)
       form-data: 4.0.6
@@ -22884,7 +22896,7 @@ snapshots:
       heimdalljs-fs-monitor: 1.1.2
       heimdalljs-graph: 1.0.0
       heimdalljs-logger: 0.1.10
-      http-proxy: 1.18.1(debug@4.3.4)
+      http-proxy: 1.18.1
       inflection: 2.0.1
       inquirer: 9.3.8(@types/node@24.13.2)
       is-git-url: 1.0.0
@@ -23026,7 +23038,7 @@ snapshots:
       heimdalljs-fs-monitor: 1.1.2
       heimdalljs-graph: 1.0.0
       heimdalljs-logger: 0.1.10
-      http-proxy: 1.18.1(debug@4.3.4)
+      http-proxy: 1.18.1
       inflection: 3.0.2
       inquirer: 13.4.3(@types/node@25.9.3)
       is-git-url: 1.0.0
@@ -24576,6 +24588,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.8.3: {}
+
   figures@2.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -25387,7 +25401,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy@1.18.1(debug@4.3.4):
+  http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
       follow-redirects: 1.16.0(debug@4.3.4)
@@ -25395,14 +25409,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-server@14.1.1(debug@4.3.4):
+  http-server@14.1.1:
     dependencies:
       basic-auth: 2.0.1
       chalk: 4.1.2
       corser: 2.0.1
       he: 1.2.0
       html-encoding-sniffer: 3.0.0
-      http-proxy: 1.18.1(debug@4.3.4)
+      http-proxy: 1.18.1
       mime: 1.6.0
       minimist: 1.2.8
       opener: 1.5.2
@@ -26158,7 +26172,7 @@ snapshots:
 
   koa-proxies@0.12.4(koa@2.16.4):
     dependencies:
-      http-proxy: 1.18.1(debug@4.3.4)
+      http-proxy: 1.18.1
       koa: 2.16.4
       path-match: 1.2.4
       uuid: 8.3.2
@@ -29220,7 +29234,7 @@ snapshots:
       execa: 9.6.1
       express: 5.2.1
       glob: 13.0.6
-      http-proxy: 1.18.1(debug@4.3.4)
+      http-proxy: 1.18.1
       js-yaml: 4.2.0
       lodash: 4.18.1
       minimatch: 10.2.5
@@ -30020,9 +30034,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  wait-on@9.0.10(debug@4.3.4):
+  wait-on@9.0.10:
     dependencies:
-      axios: 1.18.0(debug@4.3.4)
+      axios: 1.18.0
       joi: 18.2.1
       lodash: 4.18.1
       minimist: 1.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -162,6 +162,7 @@ catalog:
   ethers: ^6.6.2
   eventemitter3: ^5.0.1
   fast-json-stable-stringify: ^2.1.0
+  fflate: ^0.8.3
   file-loader: ^6.2.0
   filesize: ^10.0.12
   flat: ^5.0.2


### PR DESCRIPTION
## Background and Goal

Adds `ThreeMfDef`, a `FileDef` subclass for `.3mf` (3D Manufacturing Format / 3D printing) files, so they index as a first-class file type. A `.3mf` is an OPC package (a ZIP) whose `3D/3dmodel.model` XML carries `title` / `designer` / `description` / `license` and a `unit` — searchable text that is **not** present in the filename — so the subclass extracts it and feeds it into full-text search. Distinct icon + light metadata templates; no 3D viewer.

Resolves CS-12054.

## Where to start

- **`packages/base/3mf-meta-extractor.ts`** — the parse. `fflate.unzipSync` with a `filter` that records every entry name (→ `hasThumbnail`) while inflating only the `*.model` part; then decodes ≤256 KB of the model, cuts at `<resources>`/`<build>`, and regex-extracts the metadata + `unit`. Throws `FileContentMismatchError` on a non-ZIP or a ZIP with no model part.
- **`packages/base/3mf-file-def.gts`** — `ThreeMfDef extends FileDef`: the six searchable fields, `extractAttributes` (`super` + `extract3mfMetadata`), `cube-3d-sphere` icon, `acceptTypes`, and metadata-display `isolated`/`embedded` templates.
- **`packages/runtime-common/file-def-code-ref.ts`** — the one-line registry entry that maps `.3mf → ThreeMfDef` and lights up `urlNamesFile` / `isFileDefCodeRef`.

## Key decisions and non-obvious mechanics

- **Bounded on the indexing hot path.** `extractAttributes` runs for every file during the index/prerender visit and 3MF files can be large, so we inflate only the model part and cap the XML parse at the header (metadata lives above `<resources>`; geometry lives below). Counting objects/triangles or reading the bounding box would require scanning past all vertices, so those are deferred.
- **Graceful fallback.** A malformed/non-3MF file throws `FileContentMismatchError`, so the extractor falls back to a bare `FileDef` and the file still indexes — same pattern as `Mp3Def`/`PngDef`.
- **New dependency: `fflate`** (~8 KB, isomorphic, added to the catalog + `base`). No ZIP/deflate library existed in the repo; `base` already imports npm runtime deps this way (`super-fast-md5`, `awesome-phonenumber`). Also added to `host` so the acceptance test can build fixtures.
- **MIME + binary.** `.3mf → model/3mf` (IANA-registered; `mime-db` has no entry) and classified binary, so the CLI/bot don't treat the ZIP as text.
- **Deferred to follow-ups:** a WebGL/three.js viewer (greenfield + prerender-render risk), the expensive geometry fields (triangle/vertex counts, bounding box, volume, object count), and surfacing the embedded thumbnail as the preview image.