### PR TITLE
Make the catalog install planner RRI-native

### DIFF
--- a/packages/host/tests/live-test.js
+++ b/packages/host/tests/live-test.js
@@ -67,6 +67,13 @@ export async function loadRealmTests(application) {
     import('@cardstack/host/config/environment'),
   ]);
 
+  // Mutate the shared config module object directly (not just the copy
+  // handed to loaderInstance's shim below) so every app instance created
+  // later by individual tests' setupApplicationTest — which import
+  // '@cardstack/host/config/environment' as a normal static import, not
+  // through this loader — also sees the real catalog realm address.
+  hostConfigEnvironment.default.resolvedCatalogRealmURL = realmURL;
+
   const loaderInstance = application.buildInstance({
     rootElement: '#ember-testing-loader',
   });

--- a/packages/host/tests/live-test.js
+++ b/packages/host/tests/live-test.js
@@ -67,12 +67,22 @@ export async function loadRealmTests(application) {
     import('@cardstack/host/config/environment'),
   ]);
 
-  // Mutate the shared config module object directly (not just the copy
-  // handed to loaderInstance's shim below) so every app instance created
-  // later by individual tests' setupApplicationTest — which import
-  // '@cardstack/host/config/environment' as a normal static import, not
-  // through this loader — also sees the real catalog realm address.
-  hostConfigEnvironment.default.resolvedCatalogRealmURL = realmURL;
+  // The catalog live suites need the app to resolve `@cardstack/catalog/` to the
+  // realm actually under test, which in environment mode is not the build-time
+  // default. Only override when that realm really is a catalog realm: this
+  // runner also drives non-catalog realms — the skills realm is both the default
+  // above and what boxel's own CI passes — and pointing the catalog prefix at
+  // one of those would have `network.ts` resolve catalog imports and ids against
+  // the wrong realm.
+  const catalogRealmURL = new URL(realmURL).pathname.endsWith('/catalog/')
+    ? realmURL
+    : hostConfigEnvironment.default?.resolvedCatalogRealmURL;
+
+  // Mutate the shared config module object directly, not just the copy handed to
+  // loaderInstance's shim below, so app instances that individual tests create
+  // via setupApplicationTest — importing this config as a normal static import
+  // rather than through this loader — see it too.
+  hostConfigEnvironment.default.resolvedCatalogRealmURL = catalogRealmURL;
 
   const loaderInstance = application.buildInstance({
     rootElement: '#ember-testing-loader',
@@ -96,7 +106,7 @@ export async function loadRealmTests(application) {
     ...hostConfigEnvironment,
     default: {
       ...(hostConfigEnvironment.default ?? {}),
-      resolvedCatalogRealmURL: realmURL,
+      resolvedCatalogRealmURL: catalogRealmURL,
     },
   });
 

--- a/packages/host/tests/unit/plan-install-test.ts
+++ b/packages/host/tests/unit/plan-install-test.ts
@@ -328,6 +328,39 @@ module('Unit | Catalog | Install Plan Builder', function () {
         },
       ]);
     });
+
+    // The copy step reads `sourceModule` with `new URL`, so a prefix that
+    // resolves to nothing has to fail here rather than being handed onward as an
+    // unusable identifier.
+    test('spec whose realm prefix has no mapping fails during planning', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'Some Ref Name', module: '@nobody/nowhere/some' },
+          [realmURL]: sourceRealmURL,
+        },
+      ] as unknown as Spec[];
+      const listing = {
+        name: 'Some Listing',
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      assert.throws(
+        () =>
+          planModuleInstall(
+            specs,
+            new ListingPathResolver(
+              targetRealmURL.href,
+              listing,
+              'xyz',
+              virtualNetwork,
+            ),
+            virtualNetwork,
+          ),
+        /Cannot resolve module "@nobody\/nowhere\/some" to a fetchable URL/,
+      );
+    });
   });
 
   module('planInstanceInstall()', function () {

--- a/packages/host/tests/unit/plan-install-test.ts
+++ b/packages/host/tests/unit/plan-install-test.ts
@@ -17,16 +17,29 @@ import type { Spec } from '@cardstack/base/spec';
 
 const sourceRealmURL = new URL('https://localhost:4201/catalog/');
 const targetRealmURL = new URL('https://localhost:4201/experiments/');
+// The symbolic alias base is still served under, and the real URL backing it.
 const baseRealmURL = new URL('https://cardstack.com/base/');
+const resolvedBaseRealmURL = new URL('https://localhost:4201/base/');
+const baseRealmRRI = '@cardstack/base/';
 const foreignRealmURL = new URL('https://localhost:4201/user1/personal-realm/');
 
+// Register the base realm the same way the host's network service does at
+// construction (see `packages/host/app/services/network.ts`) — a URL mapping for
+// the `cardstack.com` alias plus the scoped prefix. Without both, a bare
+// VirtualNetwork can't recognize the real backing URL or the alias as base, and
+// the planner's canonicalization has nothing to fold onto.
 const virtualNetwork = new VirtualNetwork();
+virtualNetwork.addURLMapping(baseRealmURL, resolvedBaseRealmURL);
+virtualNetwork.addRealmMapping(baseRealmRRI, resolvedBaseRealmURL.href);
 
 module('Unit | Catalog | Install Plan Builder', function () {
   test('when listing name is not provided, just provides uuid (in this case uuid="xyz")', function (assert) {
     const specs = [
       {
-        ref: { name: 'Some Ref Name' },
+        ref: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder/some`,
+        },
         moduleHref: `${sourceRealmURL.href}some-folder/some`,
         [realmURL]: sourceRealmURL,
       },
@@ -73,12 +86,18 @@ module('Unit | Catalog | Install Plan Builder', function () {
     test('can execute plan for modules', function (assert) {
       const specs = [
         {
-          ref: { name: 'Some Ref Name' },
+          ref: {
+            name: 'Some Ref Name',
+            module: `${sourceRealmURL.href}some-folder/some`,
+          },
           moduleHref: `${sourceRealmURL.href}some-folder/some`,
           [realmURL]: sourceRealmURL,
         },
         {
-          ref: { name: 'Some Ref Name 2' },
+          ref: {
+            name: 'Some Ref Name 2',
+            module: `${sourceRealmURL.href}some-folder-2/some-2`,
+          },
           moduleHref: `${sourceRealmURL.href}some-folder-2/some-2`,
           [realmURL]: sourceRealmURL,
         },
@@ -137,12 +156,18 @@ module('Unit | Catalog | Install Plan Builder', function () {
     test('can execute plan for modules when all code exists inside root of realm', function (assert) {
       const specs = [
         {
-          ref: { name: 'Some Ref Name' },
+          ref: {
+            name: 'Some Ref Name',
+            module: `${sourceRealmURL.href}some`,
+          },
           moduleHref: `${sourceRealmURL.href}some`,
           [realmURL]: sourceRealmURL,
         },
         {
-          ref: { name: 'Some Ref Name 2' },
+          ref: {
+            name: 'Some Ref Name 2',
+            module: `${sourceRealmURL.href}some-2`,
+          },
           moduleHref: `${sourceRealmURL.href}some-2`,
           [realmURL]: sourceRealmURL,
         },
@@ -196,6 +221,110 @@ module('Unit | Catalog | Install Plan Builder', function () {
         {
           sourceModule: `${sourceRealmURL.href}some-2`,
           targetModule: `${targetRealmURL}some-listing-xyz/some-2`,
+        },
+      ]);
+    });
+
+    // `Spec.moduleHref` is deliberately a resolved real URL (readers like the
+    // source-file reader can't take an RRI), so it is the wrong input for
+    // planning: a base-realm spec's `moduleHref` is the environment-specific
+    // backing URL, which no base-realm check should have to recognize. The
+    // canonical ref lives on `spec.ref`. (CS-12078)
+    test('base-realm spec is not copied, and ref takes precedence over moduleHref', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'Skill', module: `${baseRealmRRI}skill` },
+          moduleHref: `${resolvedBaseRealmURL}skill`,
+          [realmURL]: sourceRealmURL,
+        },
+      ] as Spec[];
+      const listing = {
+        name: 'Some Listing',
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      const { modulesCopy, modulesToInstall } = planModuleInstall(
+        specs,
+        new ListingPathResolver(
+          targetRealmURL.href,
+          listing,
+          'xyz',
+          virtualNetwork,
+        ),
+        virtualNetwork,
+      );
+      assert.deepEqual(modulesCopy, []);
+      assert.deepEqual(modulesToInstall, []);
+    });
+
+    test('spec with no ref module is skipped rather than planned as undefined', function (assert) {
+      const specs = [
+        { ref: { name: 'Some Ref Name' }, [realmURL]: sourceRealmURL },
+      ] as unknown as Spec[];
+      const listing = {
+        name: 'Some Listing',
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      const { modulesCopy, modulesToInstall } = planModuleInstall(
+        specs,
+        new ListingPathResolver(
+          targetRealmURL.href,
+          listing,
+          'xyz',
+          virtualNetwork,
+        ),
+        virtualNetwork,
+      );
+      assert.deepEqual(modulesCopy, []);
+      assert.deepEqual(modulesToInstall, []);
+    });
+
+    // The catalog is a prefix-mapped realm in production, so a listing's own
+    // specs canonicalize to `@cardstack/catalog/…`. The plan must still resolve
+    // in-realm paths correctly and still hand the copy step a fetchable URL.
+    test('spec in a prefix-mapped (non-base) source realm still copies correctly', function (assert) {
+      let mappedNetwork = new VirtualNetwork();
+      mappedNetwork.addURLMapping(baseRealmURL, resolvedBaseRealmURL);
+      mappedNetwork.addRealmMapping(baseRealmRRI, resolvedBaseRealmURL.href);
+      mappedNetwork.addRealmMapping('@cardstack/catalog/', sourceRealmURL.href);
+
+      const specs = [
+        {
+          ref: {
+            name: 'Some Ref Name',
+            module: '@cardstack/catalog/some-folder/some',
+          },
+          moduleHref: `${sourceRealmURL.href}some-folder/some`,
+          [realmURL]: sourceRealmURL,
+        },
+      ] as Spec[];
+      const listing = {
+        name: 'Some Listing',
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      const { modulesToInstall } = planModuleInstall(
+        specs,
+        new ListingPathResolver(
+          targetRealmURL.href,
+          listing,
+          'xyz',
+          mappedNetwork,
+        ),
+        mappedNetwork,
+      );
+      assert.deepEqual(modulesToInstall, [
+        {
+          // Fetchable: the copy step reads this with `new URL`.
+          sourceModule: `${sourceRealmURL.href}some-folder/some`,
+          targetModule: `${targetRealmURL}some-listing-xyz/some-folder/some`,
         },
       ]);
     });
@@ -261,48 +390,104 @@ module('Unit | Catalog | Install Plan Builder', function () {
         module: `${targetRealmURL}some-listing-xyz/some-folder-2/some`,
       });
     });
-    test('can execute plan for instances when instance adoptsFrom from code inside base realm', function (assert) {
-      const instances = [
-        {
-          id: `${sourceRealmURL.href}some-folder/Example/1`,
-          [meta]: {
-            adoptsFrom: {
-              name: 'Some Ref Name',
-              module: `${baseRealmURL}skill`,
+    // A base-realm module ref reaches the planner in three spellings: the
+    // canonical prefix, the symbolic `cardstack.com` alias, and the real backing
+    // URL the alias resolves to. All three name the same module, so all three
+    // must be recognized as base — i.e. left alone rather than copied into the
+    // install destination, which would leave `adoptsFrom` pointing at a module
+    // that never gets written. (CS-12078)
+    const baseRealmSpellings = {
+      'canonical RRI prefix': `${baseRealmRRI}skill`,
+      'symbolic cardstack.com alias': `${baseRealmURL}skill`,
+      'real backing URL': `${resolvedBaseRealmURL}skill`,
+    };
+    for (let [spelling, module] of Object.entries(baseRealmSpellings)) {
+      test(`instance adoptsFrom base realm is not copied — ${spelling}`, function (assert) {
+        const instances = [
+          {
+            id: `${sourceRealmURL.href}some-folder/Example/1`,
+            [meta]: {
+              adoptsFrom: { name: 'Some Ref Name', module },
             },
+            [realmURL]: sourceRealmURL,
           },
+        ] as CardDef[];
+        const listing = {
+          name: 'Some Listing',
+          specs: [],
+          examples: instances,
+          skills: [],
           [realmURL]: sourceRealmURL,
-        },
-      ] as CardDef[];
-      const listing = {
-        name: 'Some Listing',
-        specs: [],
-        examples: instances,
-        skills: [],
-        [realmURL]: sourceRealmURL,
-      } as any;
-      let { modulesCopy, instancesCopy, modulesToInstall } =
-        planInstanceInstall(
-          instances,
-          new ListingPathResolver(
-            targetRealmURL.href,
-            listing,
-            'xyz',
+        } as any;
+        let { modulesCopy, instancesCopy, modulesToInstall } =
+          planInstanceInstall(
+            instances,
+            new ListingPathResolver(
+              targetRealmURL.href,
+              listing,
+              'xyz',
+              virtualNetwork,
+            ),
             virtualNetwork,
-          ),
-          virtualNetwork,
+          );
+        assert.deepEqual(modulesCopy, [], 'no base module is copied');
+        assert.deepEqual(modulesToInstall, []);
+        assert.strictEqual(instancesCopy.length, 1);
+        assert.strictEqual(
+          instancesCopy[0].lid,
+          'some-listing-xyz/some-folder/Example/1',
         );
-      assert.deepEqual(modulesCopy, []);
-      assert.deepEqual(modulesToInstall, []);
-      assert.strictEqual(instancesCopy.length, 1);
-      assert.strictEqual(
-        instancesCopy[0].lid,
-        'some-listing-xyz/some-folder/Example/1',
-      );
-      assert.deepEqual(instancesCopy[0].targetCodeRef, {
-        module: `${baseRealmURL}skill`,
-        name: 'Some Ref Name',
+        // Canonical prefix form regardless of how it arrived: this ref is
+        // written into the installed card's `meta.adoptsFrom`, so an
+        // environment-specific URL would not be portable.
+        assert.deepEqual(instancesCopy[0].targetCodeRef, {
+          module: `${baseRealmRRI}skill`,
+          name: 'Some Ref Name',
+        });
       });
+    }
+
+    test('throws when the instance itself lives in the base realm, in any spelling', function (assert) {
+      for (let id of [
+        `${baseRealmRRI}Skill/example`,
+        `${baseRealmURL}Skill/example`,
+        `${resolvedBaseRealmURL}Skill/example`,
+      ]) {
+        const instances = [
+          {
+            id,
+            [meta]: {
+              adoptsFrom: {
+                name: 'Skill',
+                module: `${baseRealmRRI}skill`,
+              },
+            },
+            [realmURL]: baseRealmURL,
+          },
+        ] as CardDef[];
+        const listing = {
+          name: 'Some Listing',
+          specs: [],
+          examples: instances,
+          skills: [],
+          [realmURL]: sourceRealmURL,
+        } as any;
+        assert.throws(
+          () =>
+            planInstanceInstall(
+              instances,
+              new ListingPathResolver(
+                targetRealmURL.href,
+                listing,
+                'xyz',
+                virtualNetwork,
+              ),
+              virtualNetwork,
+            ),
+          /Cannot install instance from base realm/,
+          `rejects ${id}`,
+        );
+      }
     });
   });
 
@@ -325,13 +510,13 @@ module('Unit | Catalog | Install Plan Builder', function () {
 
       // Same-realm URL resolves as before
       let sameRealmLocal = resolver.local(
-        `${sourceRealmURL.href}some-folder/Example/1`,
+        rri(`${sourceRealmURL.href}some-folder/Example/1`),
       );
       assert.strictEqual(sameRealmLocal, 'some-folder/Example/1');
 
       // Cross-realm URL with registered realm strips the foreign realm prefix
       let crossRealmLocal = resolver.local(
-        `${foreignRealmURL.href}CyclingMileageLog/abc`,
+        rri(`${foreignRealmURL.href}CyclingMileageLog/abc`),
       );
       assert.strictEqual(crossRealmLocal, 'CyclingMileageLog/abc');
     });
@@ -352,7 +537,7 @@ module('Unit | Catalog | Install Plan Builder', function () {
       );
 
       let crossRealmLocal = resolver.local(
-        `${foreignRealmURL.href}CyclingMileageLog/abc`,
+        rri(`${foreignRealmURL.href}CyclingMileageLog/abc`),
       );
       assert.strictEqual(
         crossRealmLocal,
@@ -377,7 +562,7 @@ module('Unit | Catalog | Install Plan Builder', function () {
       resolver.addKnownRealmURL(foreignRealmURL);
 
       let target = resolver.target(
-        `${foreignRealmURL.href}CyclingMileageLog/abc`,
+        rri(`${foreignRealmURL.href}CyclingMileageLog/abc`),
       );
       assert.strictEqual(
         target,
@@ -433,7 +618,10 @@ module('Unit | Catalog | Install Plan Builder', function () {
     test('planModuleInstall handles specs from a foreign realm', function (assert) {
       const specs = [
         {
-          ref: { name: 'CyclingMileageLog' },
+          ref: {
+            name: 'CyclingMileageLog',
+            module: `${foreignRealmURL.href}cycling-mileage-log`,
+          },
           moduleHref: `${foreignRealmURL.href}cycling-mileage-log`,
           [realmURL]: foreignRealmURL,
         },

--- a/packages/runtime-common/catalog.ts
+++ b/packages/runtime-common/catalog.ts
@@ -54,14 +54,20 @@ function fetchableRef(
   codeRef: ResolvedCodeRef,
   virtualNetwork: VirtualNetwork,
 ): ResolvedCodeRef {
+  let module: string;
   try {
-    return {
-      ...codeRef,
-      module: rri(virtualNetwork.toURLHref(codeRef.module)),
-    };
-  } catch {
-    return codeRef;
+    module = virtualNetwork.toURLHref(codeRef.module);
+  } catch (e) {
+    // Fail while planning rather than handing an unresolvable identifier to the
+    // copy step, where it would surface as a bare `Invalid URL` far from its
+    // cause.
+    let error = new Error(
+      `Cannot resolve module "${codeRef.module}" to a fetchable URL; no realm mapping is registered for it`,
+    );
+    (error as any).cause = e;
+    throw error;
   }
+  return { ...codeRef, module: rri(module) };
 }
 
 // sourceCodeRef -- (installs module) --> targetCodeRef
@@ -346,7 +352,12 @@ export function planInstanceInstall(
     // arrives canonical rather than as a materialized URL.
     let adopted = resolveAdoptsFrom(instance);
     if (!adopted) {
-      throw new Error('code ref is not resolved');
+      // Covers both halves of the contract, which the caller cannot tell apart
+      // from the return value: no `adoptsFrom` at all, or one that does not
+      // resolve to a concrete module.
+      throw new Error(
+        `Cannot resolve adoptsFrom for instance "${instance.id}"; it is missing or does not resolve to a concrete module`,
+      );
     }
     let sourceCodeRef = canonicalRef(adopted, virtualNetwork);
     if (!instance.id) {

--- a/packages/runtime-common/catalog.ts
+++ b/packages/runtime-common/catalog.ts
@@ -6,12 +6,13 @@ import type { Spec } from '@cardstack/base/spec';
 import type { CardDef } from '@cardstack/base/card-api';
 import { RealmPaths, join } from './paths.ts';
 import type { ResolvedCodeRef } from './code-ref.ts';
-import { resolveAdoptedCodeRef } from './code-ref.ts';
-import { realmURL } from './constants.ts';
+import { canonicalModuleKey, resolveAdoptsFrom } from './code-ref.ts';
+import { baseRealmRRI, realmURL } from './constants.ts';
 import { logger } from './log.ts';
 import type { LocalPath } from './paths.ts';
-import { rri } from './realm-identifiers.ts';
+import { ri, rri } from './realm-identifiers.ts';
 import type { RealmResourceIdentifier } from './realm-identifiers.ts';
+import { resolveRRIReference } from './url.ts';
 import type { VirtualNetwork } from './virtual-network.ts';
 
 // Local mirror of the boxel-catalog Listing shape — that repo isn't cloned in boxel CI. (CS-11166)
@@ -23,7 +24,45 @@ export interface Listing extends CardDef {
   skills: any[];
 }
 
-const baseRealmPath = new RealmPaths(new URL('https://cardstack.com/base/'));
+// Fold a module reference onto one canonical spelling. Callers do this once,
+// where a ref enters the planner, so every decision below is a plain prefix
+// test rather than a per-check sniff at the three forms a base-realm ref can
+// arrive in (`@cardstack/base/x`, the `cardstack.com` alias, the real backing
+// URL).
+function canonicalRef(
+  codeRef: ResolvedCodeRef,
+  virtualNetwork: VirtualNetwork,
+): ResolvedCodeRef {
+  return {
+    ...codeRef,
+    module: rri(canonicalModuleKey(codeRef.module, virtualNetwork)),
+  };
+}
+
+function isInBaseRealm(module: RealmResourceIdentifier): boolean {
+  return module.startsWith(baseRealmRRI);
+}
+
+// The one place a canonical ref is resolved to a real URL. `sourceCodeRef`
+// feeds the copy step's source read (`ReadSourceCommand`), which parses it with
+// `new URL` and so cannot take a prefix RRI. Nothing else in the plan is
+// materialized — in particular a base-realm `targetCodeRef` stays prefix form,
+// because it is written into the installed card's `meta.adoptsFrom`, where an
+// environment-specific URL would defeat the portability RRI exists to provide.
+// CS-12198 tracks making that consumer RRI-aware, retiring this.
+function fetchableRef(
+  codeRef: ResolvedCodeRef,
+  virtualNetwork: VirtualNetwork,
+): ResolvedCodeRef {
+  try {
+    return {
+      ...codeRef,
+      module: rri(virtualNetwork.toURLHref(codeRef.module)),
+    };
+  } catch {
+    return codeRef;
+  }
+}
 
 // sourceCodeRef -- (installs module) --> targetCodeRef
 // sourceCodeRef: code ref of the code from the source realm
@@ -119,15 +158,28 @@ export class ListingPathResolver {
       throw new Error('Cannot derive realm from listing');
     }
 
-    this.sourceRealmPath = new RealmPaths(sourceRealmURL, virtualNetwork);
+    this.sourceRealmPath = this.canonicalRealmPath(sourceRealmURL);
     this.targetDirectoryPath = new RealmPaths(
       new URL(join(this.targetRealmPath.url, this.targetDirectoryName)),
       virtualNetwork,
     );
   }
 
+  // The realms we measure ids against must be in the same form as the ids
+  // themselves: `RealmPaths.local` slices the id by `realm.url.length`, which
+  // silently yields garbage when one side is a prefix RRI and the other its
+  // real URL. Canonicalizing here keeps that slice honest for mapped realms
+  // (the catalog, which is exactly the source realm in production). Unmapped
+  // realms canonicalize to themselves, so this is a no-op for them.
+  private canonicalRealmPath(realm: URL): RealmPaths {
+    return new RealmPaths(
+      ri(canonicalModuleKey(realm.href, this.virtualNetwork)),
+      this.virtualNetwork,
+    );
+  }
+
   addKnownRealmURL(url: URL): void {
-    let realmPath = new RealmPaths(url, this.virtualNetwork);
+    let realmPath = this.canonicalRealmPath(url);
     if (
       realmPath.url !== this.sourceRealmPath.url &&
       !this.foreignRealmPaths.some((p) => p.url === realmPath.url)
@@ -136,11 +188,13 @@ export class ListingPathResolver {
     }
   }
 
-  local(href: string): LocalPath {
-    let url = new URL(href, this.sourceRealmPath.url);
-    let id = rri(url.href);
+  // Takes a canonical identifier, not an href: `RealmPaths.local`/`inRealm`
+  // work on either form directly, so there is no round-trip through `new URL`
+  // — which would silently mis-join a prefix RRI onto the source realm
+  // (`@cardstack/base/skill` → `<sourceRealm>/@cardstack/base/skill`).
+  local(id: RealmResourceIdentifier): LocalPath {
     if (this.sourceRealmPath.inRealm(id)) {
-      return this.sourceRealmPath.local(url);
+      return this.sourceRealmPath.local(id);
     }
     // Try known foreign realm paths (longest URL first to handle nested realms)
     let sorted = [...this.foreignRealmPaths].sort(
@@ -148,22 +202,33 @@ export class ListingPathResolver {
     );
     for (let foreignPath of sorted) {
       if (foreignPath.inRealm(id)) {
-        return foreignPath.local(url);
+        return foreignPath.local(id);
       }
     }
-    // Fallback: strip only the origin, preserving full path for safety
-    let path = decodeURI(url.pathname).replace(/^\//, '').replace(/\/+$/, '');
-    return path;
+    return this.localFallback(id);
   }
 
-  targetLid(href: string): string {
-    let local = this.local(href);
-    return join(this.targetDirectoryName, local);
+  // No known realm contains this id: strip just the realm-identifying prefix
+  // and keep the rest of the path. That prefix is the origin for a URL, and the
+  // `@scope/name` namespace for a prefix RRI.
+  private localFallback(id: RealmResourceIdentifier): LocalPath {
+    if (id.startsWith('@')) {
+      return id.split('/').slice(2).join('/').replace(/\/+$/, '');
+    }
+    try {
+      let { pathname } = new URL(id);
+      return decodeURI(pathname).replace(/^\//, '').replace(/\/+$/, '');
+    } catch {
+      return id.replace(/^\//, '').replace(/\/+$/, '');
+    }
   }
 
-  target(href: string): string {
-    let local = this.local(href);
-    return join(this.targetDirectoryPath.url, local);
+  targetLid(id: RealmResourceIdentifier): string {
+    return join(this.targetDirectoryName, this.local(id));
+  }
+
+  target(id: RealmResourceIdentifier): RealmResourceIdentifier {
+    return this.targetDirectoryPath.fileRRI(this.local(id));
   }
 }
 
@@ -217,21 +282,18 @@ export class PlanBuilder {
   }
 }
 
+// `codeRef` must already be canonical (see `canonicalRef`).
 function resolveTargetCodeRef(
   codeRef: ResolvedCodeRef,
   resolver: ListingPathResolver,
-  virtualNetwork: VirtualNetwork,
 ): ResolvedCodeRef {
-  if (baseRealmPath.inRealm(codeRef.module)) {
+  if (isInBaseRealm(codeRef.module)) {
     return codeRef;
-  } else {
-    let moduleURL = virtualNetwork.toURL(codeRef.module);
-    let targetModule = resolver.target(moduleURL.href);
-    return {
-      name: codeRef.name,
-      module: targetModule as RealmResourceIdentifier,
-    };
   }
+  return {
+    name: codeRef.name,
+    module: resolver.target(codeRef.module),
+  };
 }
 
 export function planModuleInstall(
@@ -242,24 +304,30 @@ export function planModuleInstall(
   if (specs.length == 0) {
     return new InstallPlan([], []);
   }
-  let codeRefs: ResolvedCodeRef[] = specs.map((s) => {
-    return {
-      module: s.moduleHref as RealmResourceIdentifier,
-      name: s.ref.name,
-    };
-  });
-  let modulesCopy = codeRefs.flatMap((sourceCodeRef: ResolvedCodeRef) => {
-    if (baseRealmPath.inRealm(sourceCodeRef.module)) {
+  // `spec.ref` is the canonical code ref; `spec.moduleHref` is deliberately a
+  // resolved real URL for readers that cannot take an RRI (see its computeVia),
+  // so it is not the right input for install planning.
+  let codeRefs: ResolvedCodeRef[] = specs.flatMap((s) => {
+    if (!s.ref?.module) {
       return [];
     }
-    let targetCodeRef = resolveTargetCodeRef(
-      sourceCodeRef,
-      resolver,
-      virtualNetwork,
-    );
+    return [
+      canonicalRef(
+        {
+          module: rri(resolveRRIReference(s.ref.module, s.id)),
+          name: s.ref.name,
+        },
+        virtualNetwork,
+      ),
+    ];
+  });
+  let modulesCopy = codeRefs.flatMap((sourceCodeRef: ResolvedCodeRef) => {
+    if (isInBaseRealm(sourceCodeRef.module)) {
+      return [];
+    }
     let copyMeta = {
-      sourceCodeRef,
-      targetCodeRef,
+      sourceCodeRef: fetchableRef(sourceCodeRef, virtualNetwork),
+      targetCodeRef: resolveTargetCodeRef(sourceCodeRef, resolver),
     };
     return [copyMeta];
   });
@@ -274,31 +342,37 @@ export function planInstanceInstall(
   let instancesCopy: CopyInstanceMeta[] = [];
   let modulesCopy: CopyMeta[] = [];
   for (let instance of instances) {
-    let sourceCodeRef = resolveAdoptedCodeRef(instance, virtualNetwork);
-    let lid = resolver.local(virtualNetwork.toURL(instance.id).href);
-    if (baseRealmPath.inRealm(rri(instance.id))) {
+    // Omitting the VirtualNetwork resolves in RRI space, so the adopted ref
+    // arrives canonical rather than as a materialized URL.
+    let adopted = resolveAdoptsFrom(instance);
+    if (!adopted) {
+      throw new Error('code ref is not resolved');
+    }
+    let sourceCodeRef = canonicalRef(adopted, virtualNetwork);
+    if (!instance.id) {
+      throw new Error('Cannot install an instance that has not been saved');
+    }
+    let instanceId = rri(canonicalModuleKey(instance.id, virtualNetwork));
+    if (isInBaseRealm(instanceId)) {
       throw new Error('Cannot install instance from base realm');
     }
-    if (!baseRealmPath.inRealm(sourceCodeRef.module)) {
-      let targetCodeRef = resolveTargetCodeRef(
-        sourceCodeRef,
-        resolver,
-        virtualNetwork,
-      );
+    let lid = resolver.targetLid(instanceId);
+    if (!isInBaseRealm(sourceCodeRef.module)) {
+      let targetCodeRef = resolveTargetCodeRef(sourceCodeRef, resolver);
       modulesCopy.push({
-        sourceCodeRef,
+        sourceCodeRef: fetchableRef(sourceCodeRef, virtualNetwork),
         targetCodeRef,
       });
       instancesCopy.push({
         sourceCard: instance,
-        lid: resolver.targetLid(lid),
+        lid,
         targetCodeRef,
       });
     } else {
       instancesCopy.push({
         sourceCard: instance,
         targetCodeRef: sourceCodeRef,
-        lid: resolver.targetLid(lid),
+        lid,
       });
     }
   }


### PR DESCRIPTION
Closes CS-12078.

## Why

The install planner decided whether an adopted module lives in the base realm using a VirtualNetwork-less `RealmPaths(new URL('https://cardstack.com/base/'))`, which prefix-matches exactly one spelling. Base-realm refs reach this layer in three:

1. `@cardstack/base/skill` — canonical RRI prefix
2. `https://cardstack.com/base/skill` — the symbolic alias
3. `https://localhost:4201/base/skill` — the real backing URL (environment-specific)

An unrecognized spelling was misclassified as "needs copying", so the installed card's `adoptsFrom.module` ended up pointing at a module that never got written.

The earlier stopgap (#5478) taught the check to recognize the missing forms. Per @habdelra's review there — *"this makes me feel like we are papering over a bug… the actual materialized base realm URL is only visible in the virtual network layer, the fact that it leaks out is probably not good"* — this instead stops the non-canonical forms from arriving.

## What changed

**Canonicalize once, decide on a prefix.** Refs are folded to one spelling where they enter the planner, reusing the existing `canonicalModuleKey` (`code-ref.ts:412`). Base detection is now `module.startsWith(baseRealmRRI)` — no `RealmPaths`, no VirtualNetwork, no per-check form sniffing.

**Both in-planner materializations are gone.**
- `planModuleInstall` read `Spec.moduleHref`, which is *deliberately* a resolved real URL for readers that can't take an RRI (see its `computeVia` at `spec.gts:938-941`). It now reads the canonical `spec.ref` — this was the form-3 leak.
- `planInstanceInstall` used `resolveAdoptedCodeRef`, which always resolves through the VirtualNetwork. Replaced with `resolveAdoptsFrom` with the VirtualNetwork **omitted**, its existing RRI-space mode.

**`toURL` is confined to the copy boundary.** It survives only in `fetchableRef`, applied to `sourceCodeRef` alone — the value handed to `ReadSourceCommand`, which parses it with `new URL`. A base-realm `targetCodeRef` deliberately stays in prefix form, because it is written into the installed card's `meta.adoptsFrom`, where an environment-specific URL would defeat the portability RRI exists to provide. (`read-source.ts` becoming RRI-aware is CS-12198; that would retire `fetchableRef`.)

**Realm paths are canonicalized alongside the ids measured against them.** `RealmPaths.local` slices an id by `realm.url.length`, which silently yields garbage when one side is a prefix RRI and the other its real URL. Reachable in production because the catalog is a prefix-mapped realm, so this is a real fix rather than defensive tidying — covered by a new test.

Incidental fixes found in passing: a double `local()` application on the lid; specs with no `ref.module` were casting `undefined` through into `inRealm`/`toURL`; an unsaved instance produced an incidental `TypeError` instead of a named error.

## ⚠️ This is inert until the boxel-catalog companion lands

boxel-catalog's `buildInstanceOperation` computes the planner's `targetCodeRef` and then **discards** it — it never assigns `cardResource.meta.adoptsFrom`. So the misclassification this PR fixes is currently *latent*, and this PR changes no user-visible behavior on its own. The companion PR adds that assignment and un-skips the 9 parked live suites, which are the only coverage of the `adoptsFrom` write.

## Testing

- **19/19** `Unit | Catalog | Install Plan Builder` (13 pre-existing + 6 new), **926/926** host unit tests, 0 skips
- **Bisect proof:** reverting `catalog.ts` to `main` with the new tests in place fails exactly the 6 new tests and passes all 13 pre-existing ones — they are genuine regression tests, not just descriptions of new behavior
- New coverage: all three base-realm spellings for an adopting instance; base-realm instance ids in all three spellings; a base-realm *spec* (proving `ref` beats `moduleHref`); a prefix-mapped non-base source realm; a spec with no `ref.module`

One pre-existing assertion changed deliberately: the base-realm instance test asserted `targetCodeRef.module === 'https://cardstack.com/base/skill'` and now asserts `@cardstack/base/skill`. That ref is written into `meta.adoptsFrom`, and the canonical prefix is the portable form (`serializers/code-ref.ts:134-151` preserves it verbatim); the old value was the legacy alias.

The `live-test.js` commit is a prerequisite for the companion PR's live suites — without it those tests can't reach the live catalog realm at all.

## Note for the RRI project

CS-12078's "Dependency / sequencing" section is stale: CS-10753, CS-10754, CS-10757 and CS-12048 have all shipped, so there is no data-migration blocker. Separately, `scripts/start-{staging,production}.sh` still boot base with `--fromUrl='https://cardstack.com/base/'` despite CS-12048 being marked Shipped (its PR #5473 was the code-ref/lint change, not the boot flip) (cc the base-realm RRI owners). Neither affects this PR, which canonicalizes rather than assumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

