### PR TITLE
Add memoisation for `VirtualNetwork#unresolveURL`

### DIFF
--- a/packages/realm-server/tests/virtual-network-test.ts
+++ b/packages/realm-server/tests/virtual-network-test.ts
@@ -122,6 +122,75 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('unresolveURL memo is invalidated when a realm mapping is added', function (assert) {
+      let virtualNetwork = new VirtualNetwork();
+      let url = 'https://localhost:4201/skills/Skill/foo';
+      // No matching prefix yet: the url is returned unchanged, and that
+      // passthrough is memoized.
+      assert.strictEqual(
+        virtualNetwork.unresolveURL(url),
+        url,
+        'with no matching prefix the url is returned as-is',
+      );
+      virtualNetwork.addRealmMapping(
+        '@cardstack/skills/',
+        'https://localhost:4201/skills/',
+      );
+      assert.strictEqual(
+        virtualNetwork.unresolveURL(url),
+        '@cardstack/skills/Skill/foo',
+        'the newly-added prefix takes effect instead of the cached passthrough',
+      );
+    });
+
+    test('unresolveURL memo is invalidated when a realm mapping is removed', function (assert) {
+      let virtualNetwork = new VirtualNetwork();
+      virtualNetwork.addRealmMapping(
+        '@cardstack/skills/',
+        'https://localhost:4201/skills/',
+      );
+      let url = 'https://localhost:4201/skills/Skill/foo';
+      assert.strictEqual(
+        virtualNetwork.unresolveURL(url),
+        '@cardstack/skills/Skill/foo',
+        'a mapped url unresolves to its RRI form',
+      );
+      virtualNetwork.removeRealmMapping('@cardstack/skills/');
+      assert.strictEqual(
+        virtualNetwork.unresolveURL(url),
+        url,
+        'removing the prefix drops the cached RRI and returns the url as-is',
+      );
+    });
+
+    test('unresolveURL memo is invalidated when a URL mapping is added', function (assert) {
+      let virtualNetwork = new VirtualNetwork();
+      virtualNetwork.addRealmMapping(
+        '@cardstack/base/',
+        'http://localhost:4201/base/',
+      );
+      let virtualURL = 'https://cardstack.com/base/card-api';
+      // The real target is registered, but the virtual alias has no URL
+      // mapping yet, so it cannot be chased to the real form and passes
+      // through unchanged (and is memoized as such).
+      assert.strictEqual(
+        virtualNetwork.unresolveURL(virtualURL),
+        virtualURL,
+        'without a URL mapping the virtual alias is returned as-is',
+      );
+      virtualNetwork.addURLMapping(
+        new URL('https://cardstack.com/base/'),
+        new URL('http://localhost:4201/base/'),
+      );
+      // unresolveURL chases urlMappings, so the new mapping must invalidate
+      // the memo and let the virtual alias resolve to its RRI form.
+      assert.strictEqual(
+        virtualNetwork.unresolveURL(virtualURL),
+        '@cardstack/base/card-api',
+        'the virtual alias now chases through the URL mapping to its RRI form',
+      );
+    });
+
     test('resolveURL: root-relative ref joins against the mapped URL of a prefix-form base', function (assert) {
       let virtualNetwork = new VirtualNetwork();
       virtualNetwork.addRealmMapping(

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -34,6 +34,11 @@ export class VirtualNetwork {
   // a pure function of the realm mappings, so entries stay valid until a
   // mapping is added or removed (both clear the cache).
   private toURLHrefCache = new Map<string, string>();
+  // Memo for unresolveURL, the inverse of toURLHref. It runs on hot store and
+  // indexing paths and each miss pays a native `new URL()` in the virtual→real
+  // mapping chase. Same pure-function-of-mappings contract as toURLHrefCache:
+  // entries stay valid until a realm or URL mapping changes.
+  private unresolveURLCache = new Map<string, RealmResourceIdentifier>();
 
   // Notified whenever a realm-prefix mapping changes — added, removed, or
   // re-registered against a new target. Consumers that key caches by the RRI
@@ -88,6 +93,10 @@ export class VirtualNetwork {
 
   addURLMapping(from: URL, to: URL) {
     this.urlMappings.push([from.href, to.href]);
+    // Both memos resolve through urlMappings (toURLHref via toURL, unresolveURL
+    // via its virtual→real chase), so a new URL mapping invalidates them.
+    this.toURLHrefCache.clear();
+    this.unresolveURLCache.clear();
   }
 
   mapURL(
@@ -118,6 +127,7 @@ export class VirtualNetwork {
     let normalizedTarget = ensureTrailingSlash(targetURL);
     this.realmMappings.set(normalizedId, normalizedTarget);
     this.toURLHrefCache.clear();
+    this.unresolveURLCache.clear();
     this.addImportMap(
       normalizedId,
       (rest) => new URL(rest, normalizedTarget).href,
@@ -136,6 +146,7 @@ export class VirtualNetwork {
     this.realmMappings.delete(normalizedId);
     this.importMap.delete(normalizedId);
     this.toURLHrefCache.clear();
+    this.unresolveURLCache.clear();
     this.notifyMappingChange();
   }
 
@@ -171,6 +182,16 @@ export class VirtualNetwork {
    * Inputs that match no prefix and no URL mapping are returned as-is.
    */
   unresolveURL(url: string): RealmResourceIdentifier {
+    let cached = this.unresolveURLCache.get(url);
+    if (cached !== undefined) {
+      return cached;
+    }
+    let result = this.computeUnresolveURL(url);
+    this.unresolveURLCache.set(url, result);
+    return result;
+  }
+
+  private computeUnresolveURL(url: string): RealmResourceIdentifier {
     for (let [prefix, target] of this.realmMappings) {
       if (url.startsWith(target)) {
         return (prefix + url.slice(target.length)) as RealmResourceIdentifier;

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -39,6 +39,24 @@ export class VirtualNetwork {
   // mapping chase. Same pure-function-of-mappings contract as toURLHrefCache:
   // entries stay valid until a realm or URL mapping changes.
   private unresolveURLCache = new Map<string, RealmResourceIdentifier>();
+  // Cap on the URL memos above. A VirtualNetwork is process-long-lived (notably
+  // in the realm server), and toURLHref/unresolveURL are called with distinct
+  // card, index, and request URLs — unique or nonexistent inputs would
+  // otherwise accumulate for the lifetime of the process. On overflow the
+  // oldest entry is evicted (Map preserves insertion order), which suits the
+  // "same identifiers resolved repeatedly" pattern these memos target.
+  private static readonly MAX_URL_CACHE = 20_000;
+
+  private setBoundedCache<V>(cache: Map<string, V>, key: string, value: V): V {
+    if (cache.size >= VirtualNetwork.MAX_URL_CACHE) {
+      let oldest = cache.keys().next().value;
+      if (oldest !== undefined) {
+        cache.delete(oldest);
+      }
+    }
+    cache.set(key, value);
+    return value;
+  }
 
   // Notified whenever a realm-prefix mapping changes — added, removed, or
   // re-registered against a new target. Consumers that key caches by the RRI
@@ -187,8 +205,7 @@ export class VirtualNetwork {
       return cached;
     }
     let result = this.computeUnresolveURL(url);
-    this.unresolveURLCache.set(url, result);
-    return result;
+    return this.setBoundedCache(this.unresolveURLCache, url, result);
   }
 
   private computeUnresolveURL(url: string): RealmResourceIdentifier {
@@ -317,8 +334,7 @@ export class VirtualNetwork {
       return cached;
     }
     let href = this.toURL(rri).href;
-    this.toURLHrefCache.set(rri, href);
-    return href;
+    return this.setBoundedCache(this.toURLHrefCache, rri, href);
   }
 
   /**

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -111,8 +111,9 @@ export class VirtualNetwork {
 
   addURLMapping(from: URL, to: URL) {
     this.urlMappings.push([from.href, to.href]);
-    // Both memos resolve through urlMappings (toURLHref via toURL, unresolveURL
-    // via its virtual→real chase), so a new URL mapping invalidates them.
+    // unresolveURL chases through urlMappings (via resolveURLMapping), so a new
+    // URL mapping invalidates its memo. toURLHref resolves only through
+    // realmMappings, so clearing its cache here is purely defensive.
     this.toURLHrefCache.clear();
     this.unresolveURLCache.clear();
   }


### PR DESCRIPTION
This is used a lot and can be cached until the mappings change.