### PR TITLE
Ellipsize long card-type names in the workspace.gts Library rail

### DIFF
--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -1311,6 +1311,12 @@ class Isolated extends Component<typeof Workspace> {
         font: 500 13px var(--grid-sans);
         color: var(--grid-nav-ink);
         cursor: pointer;
+        /* Without this the row keeps its max-content width instead of the
+           rail's, so a long type name pushes the count and the + past the
+           rail's right edge rather than ellipsizing. The ellipsis on
+           .rail-name only engages once the row itself is allowed to be
+           narrower than its content. */
+        min-width: 0;
       }
       .rail-row.type {
         padding: 5px 10px;


### PR DESCRIPTION
## The bug

In the Workspace Library's left rail, a long card-type name pushed the row's count and its hover `+` past the rail's right edge, where they were clipped away entirely. `.rail-name` already carried `overflow: hidden; white-space: nowrap; text-overflow: ellipsis`, but the ellipsis never engaged.

## Why the existing ellipsis did nothing

Card-type rows are the only rail rows wrapped in `.rail-row-wrap`, the extra grid level that positions the hover `+`. Nested in that column, `.rail-row` kept its automatic minimum width, so the row sized to its content rather than to the rail. Text can only ellipsize once something forces it to give up space; nothing did, because the row was free to grow.

Measured on an isolated reproduction of the rail's markup and CSS, with a 214px rail (`clientWidth` 213):

| | before | after |
|---|---|---|
| row width | 320px | 193px |
| rail `scrollWidth` | 330px | 213px |
| name ellipsized | no | yes |
| count right edge | 300px | 173px |
| `+` right edge | 325px | 198px |

Everything past 214px was invisible, which is why both the count and the `+` disappeared — including on short rows, since the whole grid column had taken the widest row's width.

## The fix

`min-width: 0` on `.rail-row`. That lets the row take the rail's width instead of its content's, which is the condition the existing ellipsis was waiting on.

Worth noting what did *not* work: `min-width: 0` on `.rail-name` changes nothing, because `overflow: hidden` already zeroes that element's automatic minimum. The constraint has to be on the row.

This is a containment fix rather than a fixed `max-width` on the name, so it holds at any rail width and adapts to the count: the name shrinks further when the count is several digits wide, keeping the count and `+` inside the rail. A hard `max-width` would need re-tuning whenever the rail width, icon size, or count width changed.

## Scope

The rail's other two groups — Library filters and File types — render `.rail-row` directly with no wrapper, and already ellipsized correctly. Measured before and after: unchanged at 193px and ellipsizing in both cases, so the added property is a no-op there. It's on `.rail-row` rather than scoped to `.rail-row-wrap` so a future wrapped group can't reintroduce this.

## Test plan

Verified in Chrome against an isolated page built from this file's actual rail CSS — extracted from the edited source, not hand-copied — across four rows: a short name, two long names, and a long name paired with a five-digit count. In every case there is no horizontal overflow, long names ellipsize, and the count and `+` are fully within the rail with no overlap between them. Before/after screenshots confirm it visually.

No automated regression test. Card-type rows only render once `cardTypeFilters` is populated from the realm's `_types` endpoint, and the host test helpers don't serve it — `Integration | Card | workspace | segments` exercises only the unwrapped rows, which don't reproduce this. Adding one means stubbing `_types` in the host helpers, which is test-infrastructure work rather than part of a one-line CSS fix; it fits better alongside the broader Workspace coverage work. Happy to add it here if preferred.

`ember-template-lint` and `prettier` clean. `packages/base/workspace.gts` trips an eslint parse error at line 348 — verified identical on an untouched copy of `main`, roughly 950 lines from this change, and `packages/base` is template-lint-only in CI.
