### PR TITLE
docs: describe a workspace's root card by its role, not as CardsGrid

### DIFF
--- a/.claude/skills/aws-access/SKILL.md
+++ b/.claude/skills/aws-access/SKILL.md
@@ -352,7 +352,7 @@ kill $TUNNEL_PID
 ### When this is useful
 
 - Confirming a `.gts` or `.json` file actually exists at a particular path before chasing why indexing skipped it.
-- Looking at `index.json` / `cards-grid.json` for a realm.
+- Reading a realm's `index.json` to see which card its root adopts — `Workspace` for realms on the default index card, `CardsGrid` (or its `IndexCard` alias) for older ones, or something bespoke.
 - Verifying file mtimes / sizes for a realm where the user reports "X is missing".
 - Cross-referencing what the indexer saw against what actually landed on disk.
 

--- a/.claude/skills/aws-access/SKILL.md
+++ b/.claude/skills/aws-access/SKILL.md
@@ -352,7 +352,7 @@ kill $TUNNEL_PID
 ### When this is useful
 
 - Confirming a `.gts` or `.json` file actually exists at a particular path before chasing why indexing skipped it.
-- Reading a realm's `index.json` to see which card its root adopts — `Workspace` for realms on the default index card, `CardsGrid` (or its `IndexCard` alias) for older ones, or something bespoke.
+- Reading a realm's `index.json` to see which card its root adopts — `Workspace` when it adopts the default index card, `CardsGrid` (or its `IndexCard` alias) when it adopts that card, or something bespoke.
 - Verifying file mtimes / sizes for a realm where the user reports "X is missing".
 - Cross-referencing what the indexer saw against what actually landed on disk.
 

--- a/packages/boxel-cli/plugin/skills/boxel-file-structure/SKILL.md
+++ b/packages/boxel-cli/plugin/skills/boxel-file-structure/SKILL.md
@@ -26,8 +26,7 @@ Example: https://app.boxel.ai/sarah/pet-rescue/animals/dog.gts
 ```
 workspace/
 ├── realm.json            # Workspace config (RealmConfig card)
-├── index.json            # Workspace index
-├── cards-grid.json       # Default cards grid
+├── index.json            # The workspace's default index card
 ├── blog-post.gts         # Card definition (kebab-case)
 ├── BlogPost/             # Instance directory (PascalCase)
 │   ├── my-first-post.json
@@ -36,6 +35,17 @@ workspace/
 └── Author/
     └── jane-doe.json
 ```
+
+A new workspace is seeded with exactly two files, `realm.json` and
+`index.json`; everything else is yours. `index.json` adopts `Workspace` from
+`@cardstack/base/workspace` (`workspace.gts`), which gives the workspace its
+Home, Library, and Activity views. Replace that adoption to put your own card
+on the workspace root instead.
+
+Workspaces created before that became the default adopt `CardsGrid`, and some
+also carry a separate `cards-grid.json` instance at the root. Both still work —
+`CardsGrid` remains available — so don't treat either as something to clean up
+unless you're deliberately migrating.
 
 ## Module Paths in JSON (CRITICAL)
 

--- a/packages/boxel-cli/plugin/skills/boxel-file-structure/SKILL.md
+++ b/packages/boxel-cli/plugin/skills/boxel-file-structure/SKILL.md
@@ -42,10 +42,9 @@ A new workspace is seeded with exactly two files, `realm.json` and
 Home, Library, and Activity views. Replace that adoption to put your own card
 on the workspace root instead.
 
-Workspaces created before that became the default adopt `CardsGrid`, and some
-also carry a separate `cards-grid.json` instance at the root. Both still work —
-`CardsGrid` remains available — so don't treat either as something to clean up
-unless you're deliberately migrating.
+Some workspaces adopt `CardsGrid` as their root card, and some also carry a separate
+`cards-grid.json` instance at the root. Both shapes are supported — `CardsGrid`
+remains available — so treat either as valid unless you're deliberately migrating.
 
 ## Module Paths in JSON (CRITICAL)
 


### PR DESCRIPTION
## Terminology

"workspace" already means *a realm* throughout this guidance — `boxel-file-structure` roots its directory tree at `workspace/`, and the word appears ~67 times across the skills corpus in that sense. The glossary defines **realm** and has no entry for **workspace** at all.

So the card at a workspace's root is named by what it does — **the default index card** — or by its module, `workspace.gts`. `Workspace` stays a class name in code (`adoptsFrom`, imports) and doesn't appear as a proper noun in prose. Without that split, "the workspace card in your workspace" is a sentence someone would have had to write.

## `boxel-file-structure`

Its directory tree listed:

```
├── cards-grid.json       # Default cards grid
```

`create-realm.ts:185` seeds exactly two files — `realm.json` and `index.json` — so that line described a file no new workspace has. Whether it was ever accurate, it isn't now.

Replaced with what the two seeded files actually are, plus a note that workspaces predating the change adopt `CardsGrid` and some carry a root `cards-grid.json`. Both remain supported, so the note says explicitly that neither is cleanup — otherwise the natural reading of a doc that only describes the new shape is "delete the old one."

## Why this file is edited here and not in boxel-skills

`packages/boxel-cli/plugin/skills/` is generated: `scripts/build-skills.ts` copies `skills/` and `commands/` verbatim from a pinned `boxel-skills` tag, and the publish workflow commits the regenerated diff. Hand-editing a synced entry would be reverted on the next build.

`boxel-file-structure` is not a synced entry — it is absent from `scripts/.boxel-skills-manifest.json`, and the script's stale-entry sweep only touches names it previously wrote. So it is CLI-authored, lives only in this repo, and this is the correct place to change it.

## `aws-access`

The read-only EFS section suggested "Looking at `index.json` / `cards-grid.json` for a realm." Rewritten to say what reading `index.json` actually tells you — which card the realm's root adopts, across the three cases now in the wild (`Workspace`, `CardsGrid` or its `IndexCard` alias, or something bespoke). That's the question the file is opened to answer.

## Not in scope here

The shared corpus in `boxel-skills` has more of these — the `app-card-home-with-search` and `link-host-mode-paths` patterns both give advice built on the old default, `icons.md`, `glossary.md`, and `container-query-fitted-layout.md` mention CardsGrid in passing, and nothing documents the default index card's `entryPoints` / tabs at all. Those need a `boxel-skills` PR, authored into both its `skills/` and `Skill/` trees, and are tracked separately.

Deliberately untouched: `cardsgrid-tile` / "CardsGrid Tile" is one of the 16 fixed fitted size names and must keep its name; the `show-card-list-with-views` pattern defines its own local `CardsGrid` component unrelated to the base card; and `docs/spec.md` uses `CardsGrid` as a generic example of a component spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
