### PR TITLE
host: Remove noisy diff editor Percy snapshot

### DIFF
--- a/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
@@ -651,8 +651,6 @@ Above code blocks are now complete`;
     assert.dom('.code-block-diff .editor.original').exists();
     assert.dom('.code-block-diff .editor.modified').exists();
     assert.dom('[data-test-apply-code-button]').exists();
-
-    await percySnapshot(assert);
   });
 
   test('it will render diff editor for a blank file', async function (assert) {


### PR DESCRIPTION
This produces a lot of Percy noise:

<img width="2438" height="1120" alt="s 2026-07-28 at 15 36 31@2x" src="https://github.com/user-attachments/assets/69dcec04-f19f-45bd-98db-257d536e35e5" />

While it would be nice to have visual diffs for this, it’s too unreliable.