### PR TITLE
Name the focused account on the client-performance board and click through to it from the session history

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/client-performance.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/client-performance.json
@@ -31,7 +31,7 @@
     "links": [],
     "panels": [
       {
-        "description": "Which account every panel below is scoped to. The User variable filters each query, so a name here means the whole board shows one client's events \u2014 grey 'All users' means nothing is filtered. Rendered from the focused_user and focused_user_color variables, which derive the label and its colour from the User selection; a dashboard title cannot interpolate a variable, so the name lives in a panel.",
+        "description": "Which account every panel below is scoped to. The User variable filters each query, so a name here means the whole board shows one client's events, and \"All\" means nothing is filtered. A dashboard title cannot interpolate a variable, so the name lives in a panel. The name is the User variable's own display text; the colour comes from the focused_user_color variable.",
         "gridPos": {
           "h": 3,
           "w": 24,
@@ -45,7 +45,7 @@
             "showLineNumbers": false,
             "showMiniMap": false
           },
-          "content": "<div style=\"display:flex;align-items:center;justify-content:center;gap:14px;height:100%;width:100%;overflow:hidden;font-family:Inter,system-ui,sans-serif\"><span style=\"font-size:13px;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--text-secondary)\">scoped to</span><span style=\"font-size:32px;font-weight:700;letter-spacing:1px;color:${focused_user_color}\">${focused_user}</span></div>",
+          "content": "<div style=\"display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:14px;height:100%;width:100%;padding:0 12px;box-sizing:border-box;text-align:center;font-family:Inter,system-ui,sans-serif\"><span style=\"font-size:13px;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:#8e8e8e\">scoped to</span><span style=\"font-size:32px;font-weight:700;letter-spacing:1px;min-width:0;word-break:break-all;color:${focused_user_color}\">${matrix_user_id:text}</span></div>",
           "mode": "html"
         },
         "pluginVersion": "12.4.3",
@@ -500,7 +500,7 @@
           "type": "loki",
           "uid": "loki"
         },
-        "description": "Active sessions over the selected time range, stacked by account: at each point, how many sessions each user had active in the preceding 5m. Total stack height is concurrency, the colours are who, and the legend doubles as the current-user list. The grey \"build in use\" legend rows name the host build(s) the active sessions run (from the app_version every beacon stamps): one row means every session is on that build; a second row right after a deploy is a tab that has not reloaded and still runs the previous code. Hovering the chart names which user is on which build. One session is one browser tab. The hover attribution is a third query byte-identical to the bands query, differing only in display name \u2014 Grafana cannot vary legend and tooltip names independently, so deleting the \"duplicate\" removes the user \u2192 build hover.",
+        "description": "Active sessions over the selected time range, stacked by account: at each point, how many sessions each user had active in the preceding 5m. Total stack height is concurrency, the colours are who, and the legend doubles as the current-user list. The grey \"build in use\" legend rows name the host build(s) the active sessions run (from the app_version every beacon stamps): one row means every session is on that build; a second row right after a deploy is a tab that has not reloaded and still runs the previous code. Hovering the chart names which user is on which build. One session is one browser tab. The hover attribution is a third query byte-identical to the bands query, differing only in display name \u2014 Grafana cannot vary legend and tooltip names independently, so deleting the \"duplicate\" removes the user \u2192 build hover. Clicking inside a band offers a link that scopes the whole board to that band's account; the link follows the series nearest the click, so click within the user you want.",
         "fieldConfig": {
           "defaults": {
             "color": {
@@ -766,7 +766,7 @@
               "h": 8,
               "w": 12,
               "x": 0,
-              "y": 23
+              "y": 26
             },
             "id": 9,
             "options": {
@@ -880,7 +880,7 @@
               "h": 8,
               "w": 12,
               "x": 12,
-              "y": 23
+              "y": 26
             },
             "id": 10,
             "options": {
@@ -976,7 +976,7 @@
               "h": 9,
               "w": 12,
               "x": 0,
-              "y": 31
+              "y": 34
             },
             "id": 11,
             "options": {
@@ -1091,7 +1091,7 @@
               "h": 9,
               "w": 12,
               "x": 12,
-              "y": 31
+              "y": 34
             },
             "id": 12,
             "options": {
@@ -1208,7 +1208,7 @@
               "h": 8,
               "w": 12,
               "x": 0,
-              "y": 33
+              "y": 36
             },
             "id": 14,
             "options": {
@@ -1300,7 +1300,7 @@
               "h": 8,
               "w": 12,
               "x": 12,
-              "y": 33
+              "y": 36
             },
             "id": 15,
             "options": {
@@ -1414,7 +1414,7 @@
               "h": 8,
               "w": 12,
               "x": 0,
-              "y": 41
+              "y": 44
             },
             "id": 16,
             "options": {
@@ -1488,7 +1488,7 @@
               "h": 8,
               "w": 12,
               "x": 12,
-              "y": 41
+              "y": 44
             },
             "id": 17,
             "options": {
@@ -1564,7 +1564,7 @@
               "h": 10,
               "w": 24,
               "x": 0,
-              "y": 49
+              "y": 52
             },
             "id": 18,
             "options": {
@@ -1663,7 +1663,7 @@
               "h": 8,
               "w": 12,
               "x": 0,
-              "y": 51
+              "y": 54
             },
             "id": 20,
             "options": {
@@ -1737,7 +1737,7 @@
               "h": 8,
               "w": 12,
               "x": 12,
-              "y": 51
+              "y": 54
             },
             "id": 21,
             "options": {
@@ -1902,7 +1902,7 @@
               "h": 8,
               "w": 24,
               "x": 0,
-              "y": 53
+              "y": 56
             },
             "id": 23,
             "options": {
@@ -1958,7 +1958,7 @@
               "h": 12,
               "w": 24,
               "x": 0,
-              "y": 61
+              "y": 64
             },
             "id": 24,
             "options": {
@@ -2025,7 +2025,7 @@
               "h": 9,
               "w": 24,
               "x": 0,
-              "y": 73
+              "y": 76
             },
             "id": 38,
             "options": {
@@ -2092,7 +2092,7 @@
               "h": 10,
               "w": 24,
               "x": 0,
-              "y": 128
+              "y": 131
             },
             "id": 39,
             "options": {
@@ -2210,7 +2210,7 @@
               "h": 8,
               "w": 12,
               "x": 0,
-              "y": 55
+              "y": 58
             },
             "id": 26,
             "options": {
@@ -2295,7 +2295,7 @@
               "h": 8,
               "w": 12,
               "x": 12,
-              "y": 55
+              "y": 58
             },
             "id": 27,
             "options": {
@@ -2443,7 +2443,7 @@
               "h": 8,
               "w": 8,
               "x": 0,
-              "y": 57
+              "y": 60
             },
             "id": 29,
             "options": {
@@ -2546,7 +2546,7 @@
               "h": 8,
               "w": 8,
               "x": 8,
-              "y": 57
+              "y": 60
             },
             "id": 30,
             "options": {
@@ -2638,7 +2638,7 @@
               "h": 8,
               "w": 8,
               "x": 16,
-              "y": 57
+              "y": 60
             },
             "id": 31,
             "options": {
@@ -2755,7 +2755,7 @@
               "h": 8,
               "w": 24,
               "x": 0,
-              "y": 59
+              "y": 62
             },
             "id": 33,
             "options": {
@@ -2825,7 +2825,7 @@
               "h": 12,
               "w": 24,
               "x": 0,
-              "y": 61
+              "y": 64
             },
             "id": 35,
             "options": {
@@ -2863,7 +2863,7 @@
               "h": 12,
               "w": 24,
               "x": 0,
-              "y": 73
+              "y": 76
             },
             "id": 36,
             "options": {
@@ -2946,7 +2946,7 @@
               "h": 9,
               "w": 8,
               "x": 0,
-              "y": 63
+              "y": 66
             },
             "id": 41,
             "options": {
@@ -3066,7 +3066,7 @@
               "h": 9,
               "w": 8,
               "x": 8,
-              "y": 63
+              "y": 66
             },
             "id": 42,
             "options": {
@@ -3174,7 +3174,7 @@
               "h": 9,
               "w": 8,
               "x": 16,
-              "y": 63
+              "y": 66
             },
             "id": 43,
             "options": {
@@ -3300,28 +3300,8 @@
             "type": "grafana-postgresql-datasource",
             "uid": "cef5v5sl9k7i8f"
           },
-          "definition": "SELECT CASE WHEN '$matrix_user_id' = '.*' THEN 'All users' ELSE '$matrix_user_id' END AS focused_user;",
-          "description": "Label the header panel renders: the account the board is scoped to, or 'All users' when the User variable is on All. Derived in SQL because a text panel interpolates a variable but cannot branch on it, and the All selection interpolates as its allValue regex '.*' rather than a readable name.",
-          "hide": 2,
-          "includeAll": false,
-          "label": "focused_user",
-          "multi": false,
-          "name": "focused_user",
-          "options": [],
-          "query": "SELECT CASE WHEN '$matrix_user_id' = '.*' THEN 'All users' ELSE '$matrix_user_id' END AS focused_user;",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": true,
-          "sort": 0,
-          "type": "query"
-        },
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "cef5v5sl9k7i8f"
-          },
           "definition": "SELECT CASE WHEN '$matrix_user_id' = '.*' THEN '#8e8e8e' ELSE '#ff66c4' END AS focused_user_color;",
-          "description": "Colour the header panel renders focused_user in \u2014 the pink this stack uses for a matrix user id elsewhere when one account is selected, grey when the board covers everyone. Carries the scoped-vs-platform-wide distinction at a glance, which the name alone does not.",
+          "description": "Colour the header panel renders the scoped account in \u2014 the pink this stack uses for a matrix user id elsewhere when one account is selected, grey when the board covers everyone. Carries the scoped-vs-platform-wide distinction at a glance, which the name alone does not. Derived in SQL because a text panel interpolates a variable but cannot branch on its value; the comparison is against '.*' because that is the User variable's allValue. An empty result drops the colour declaration, so the name still renders.",
           "hide": 2,
           "includeAll": false,
           "label": "focused_user_color",

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/client-performance.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/client-performance.json
@@ -31,12 +31,35 @@
     "links": [],
     "panels": [
       {
+        "description": "Which account every panel below is scoped to. The User variable filters each query, so a name here means the whole board shows one client's events \u2014 grey 'All users' means nothing is filtered. Rendered from the focused_user and focused_user_color variables, which derive the label and its colour from the User selection; a dashboard title cannot interpolate a variable, so the name lives in a panel.",
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 93,
+        "options": {
+          "code": {
+            "language": "plaintext",
+            "showLineNumbers": false,
+            "showMiniMap": false
+          },
+          "content": "<div style=\"display:flex;align-items:center;justify-content:center;gap:14px;height:100%;width:100%;overflow:hidden;font-family:Inter,system-ui,sans-serif\"><span style=\"font-size:13px;font-weight:600;letter-spacing:2px;text-transform:uppercase;color:var(--text-secondary)\">scoped to</span><span style=\"font-size:32px;font-weight:700;letter-spacing:1px;color:${focused_user_color}\">${focused_user}</span></div>",
+          "mode": "html"
+        },
+        "pluginVersion": "12.4.3",
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
         "collapsed": false,
         "gridPos": {
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 0
+          "y": 3
         },
         "id": 2,
         "panels": [],
@@ -71,7 +94,7 @@
           "h": 4,
           "w": 8,
           "x": 0,
-          "y": 1
+          "y": 4
         },
         "id": 4,
         "options": {
@@ -142,7 +165,7 @@
           "h": 4,
           "w": 8,
           "x": 8,
-          "y": 1
+          "y": 4
         },
         "id": 5,
         "options": {
@@ -209,7 +232,7 @@
           "h": 4,
           "w": 8,
           "x": 16,
-          "y": 1
+          "y": 4
         },
         "id": 6,
         "options": {
@@ -301,7 +324,7 @@
           "h": 8,
           "w": 12,
           "x": 0,
-          "y": 5
+          "y": 8
         },
         "id": 7,
         "options": {
@@ -404,7 +427,7 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 5
+          "y": 8
         },
         "id": 8,
         "options": {
@@ -543,6 +566,16 @@
                     "legend": false,
                     "tooltip": true
                   }
+                },
+                {
+                  "id": "links",
+                  "value": [
+                    {
+                      "title": "Focus this dashboard on ${__field.labels.matrix_user_id}",
+                      "url": "/d/${__dashboard.uid}?${__url_time_range}&var-matrix_user_id=${__field.labels.matrix_user_id:percentencode}",
+                      "targetBlank": false
+                    }
+                  ]
                 }
               ]
             },
@@ -605,7 +638,7 @@
           "h": 8,
           "w": 24,
           "x": 0,
-          "y": 13
+          "y": 16
         },
         "id": 92,
         "options": {
@@ -672,7 +705,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 22
+          "y": 25
         },
         "id": 13,
         "panels": [
@@ -1114,7 +1147,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 32
+          "y": 35
         },
         "id": 19,
         "panels": [
@@ -1569,7 +1602,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 50
+          "y": 53
         },
         "id": 22,
         "panels": [
@@ -1791,7 +1824,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 52
+          "y": 55
         },
         "id": 25,
         "panels": [
@@ -2099,7 +2132,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 54
+          "y": 57
         },
         "id": 28,
         "panels": [
@@ -2349,7 +2382,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 56
+          "y": 59
         },
         "id": 32,
         "panels": [
@@ -2661,7 +2694,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 58
+          "y": 61
         },
         "id": 34,
         "panels": [
@@ -2778,7 +2811,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 60
+          "y": 63
         },
         "id": 37,
         "panels": [
@@ -2868,7 +2901,7 @@
           "h": 1,
           "w": 24,
           "x": 0,
-          "y": 62
+          "y": 65
         },
         "id": 40,
         "title": "By user \u2014 who is hitting issues",
@@ -3261,6 +3294,46 @@
           "query": "",
           "skipUrlSync": false,
           "type": "textbox"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "cef5v5sl9k7i8f"
+          },
+          "definition": "SELECT CASE WHEN '$matrix_user_id' = '.*' THEN 'All users' ELSE '$matrix_user_id' END AS focused_user;",
+          "description": "Label the header panel renders: the account the board is scoped to, or 'All users' when the User variable is on All. Derived in SQL because a text panel interpolates a variable but cannot branch on it, and the All selection interpolates as its allValue regex '.*' rather than a readable name.",
+          "hide": 2,
+          "includeAll": false,
+          "label": "focused_user",
+          "multi": false,
+          "name": "focused_user",
+          "options": [],
+          "query": "SELECT CASE WHEN '$matrix_user_id' = '.*' THEN 'All users' ELSE '$matrix_user_id' END AS focused_user;",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": true,
+          "sort": 0,
+          "type": "query"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "cef5v5sl9k7i8f"
+          },
+          "definition": "SELECT CASE WHEN '$matrix_user_id' = '.*' THEN '#8e8e8e' ELSE '#ff66c4' END AS focused_user_color;",
+          "description": "Colour the header panel renders focused_user in \u2014 the pink this stack uses for a matrix user id elsewhere when one account is selected, grey when the board covers everyone. Carries the scoped-vs-platform-wide distinction at a glance, which the name alone does not.",
+          "hide": 2,
+          "includeAll": false,
+          "label": "focused_user_color",
+          "multi": false,
+          "name": "focused_user_color",
+          "options": [],
+          "query": "SELECT CASE WHEN '$matrix_user_id' = '.*' THEN '#8e8e8e' ELSE '#ff66c4' END AS focused_user_color;",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": true,
+          "sort": 0,
+          "type": "query"
         }
       ]
     },


### PR DESCRIPTION
The Host App Client Performance board scopes every panel to one account through the `matrix_user_id` template variable — each query carries `| matrix_user_id=~"$matrix_user_id"` inside the range selector it aggregates over, so a p50/p95/p99, a rate, or a table row is computed from that account's lines alone. Two things were missing around that mechanism: no way to reach it from the board's own session history, and nothing on the board saying the board was filtered. A board silently showing one account reads as platform-wide.

## Naming the focused account

A text panel at the top of the board renders the scoped account in the pink this stack uses for a matrix user id elsewhere, or a grey "All" when the User variable is on All.

A dashboard *title* cannot interpolate a variable, so the name has to live in a panel. The name itself is `${matrix_user_id:text}` — the User variable's own display text, which reads "All" for the All option and the account id otherwise — so it needs no database round-trip and cannot blank out or go stale behind the Loki panels. The colour does need a conditional, and a text panel cannot branch on a variable's value, so one hidden query variable (`focused_user_color`) does that in SQL, comparing against `.*` because that is the User variable's `allValue`. That is the same shape the Users board uses for its `permission_label`. An empty result there only drops the colour declaration, leaving the name intact.

Grafana's text-panel sanitiser strips `overflow`, so the panel wraps rather than clips: `flex-wrap` plus `word-break` keeps the label and a long account id complete and inside the panel at any width. Colours are literals — Grafana 12 declares no CSS custom properties on the root element, so a `var(--text-*)` reference never resolves.

## Click-through from the session history

The bands on *Active sessions over time by user* carry a data link that reloads the board with `var-matrix_user_id` set to the band's account. Grafana offers a timeseries data link in the pinned tooltip for the series nearest the cursor, so a click inside a user's band focuses that user.

The link lives on the band frame (`refId A`). The tooltip-only frame `C` never surfaces one — the link is resolved from the series under the cursor, and `C` is not rendered.

The link resolves its target through `${__dashboard.uid}` rather than a literal uid, so it stays on whichever copy of the board is open, including a per-PR preview copy whose uid the preview workflow rewrites. A relative URL is not an option here: Grafana serves `<base href="/">`, so a bare `?var-…` resolves against the Grafana root and drops the dashboard path.

## Left alone: the Users board

The Users board already reaches a user's client-performance view in one click. Its `tags: ["forensics"]` dashboard link runs with `includeVars: true`, and this board carries the `forensics` tag, so the Users link bar already renders a **Host App Client Performance** button carrying the selected `var-matrix_user_id`. Verified by clicking it: the board lands scoped to that account. An explicit link would put a second button to the same board next to the one that already works.

## Verification

Local Grafana 12.4.3 with this board applied and synthetic `boxel:client-perf` lines in Loki for three accounts:

- The header reads a grey "All" with the User variable on All, and the account in pink when one is selected.
- Clicking a band pins the tooltip and offers **Focus this dashboard on `<account>`**; the click lands on the board with the User variable set to that account, and the aggregates move with it — in the seeded fixture, card-settle p95 mean 1.48 s across all accounts against 601 ms for the focused one.
- The link names the band under the cursor rather than a fixed series: the same click point resolved to a different account once the stack composition changed.
- Rendered the per-PR preview tree with `render-preview.sh` and pushed it locally. On the preview copy (uid `pr…-boxel-client-perf`) the header renders and the link resolves to the preview copy, not the canonical board.

Also verified against the deployed staging preview copy: the header resolves there, and the stored data link is still the uid-free template on the `A` frame.

Layout: expanding all nine collapsed rows yields zero overlapping grid items. Grafana normalises nested panel positions on expand, so the nested `gridPos.y` values are not load-bearing at runtime; they are shifted with their row headers anyway to keep every row at `firstChild.y == row.y + 1`, so a `pull.sh` round-trip after someone expands and saves a row does not renumber all 26 of them.

Known limitation: the accent `#ff66c4` measures 7.08:1 on the dark theme background but 2.55:1 on the light theme's, below the 3:1 WCAG AA minimum for large text. The colour is this stack's established accent for a matrix user id, so it is kept rather than diverged from; no single hex clears AA for small text against both theme backgrounds.

Checks:

- All 56 query targets on the board carry the user filter inside the range selector they aggregate over, so no panel aggregates across accounts while the board is focused.
- `packages/observability/scripts/lint.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
