### PR TITLE
Fix host mode stack navbar overflow on mobile

### DIFF
--- a/packages/boxel-ui/addon/src/styles/variables.css
+++ b/packages/boxel-ui/addon/src/styles/variables.css
@@ -195,6 +195,8 @@
   --boxel-light: #fff;
   --boxel-dark: #000;
   --boxel-light-35: rgba(255, 255, 255, 0.35);
+  --boxel-light-60: rgba(255, 255, 255, 0.6);
+  --boxel-light-70: rgba(255, 255, 255, 0.7);
   --boxel-dark-10: rgba(0, 0, 0, 0.1);
   --boxel-dark-50: rgba(0, 0, 0, 0.5);
   --boxel-dark-80: rgba(0, 0, 0, 0.8);

--- a/packages/host/app/components/host-mode/breadcrumb-item.gts
+++ b/packages/host/app/components/host-mode/breadcrumb-item.gts
@@ -1,3 +1,4 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 
@@ -19,6 +20,65 @@ interface Signature {
     onClick?: (cardId: string) => void;
   };
 }
+
+interface BreadcrumbItemContentSignature {
+  Args: {
+    icon?: ComponentLike<{ Element: SVGSVGElement }>;
+    hasCard: boolean;
+    isLoading: boolean;
+    label: string;
+  };
+}
+
+const BreadcrumbItemContent: TemplateOnlyComponent<BreadcrumbItemContentSignature> =
+  <template>
+    {{#if @hasCard}}
+      {{#if @icon}}
+        <@icon
+          class='breadcrumb-item-icon'
+          width='18'
+          height='18'
+          aria-hidden='true'
+        />
+      {{/if}}
+      <span class='label'>{{@label}}</span>
+    {{else if @isLoading}}
+      <span class='label muted'>
+        Loading…
+      </span>
+    {{else}}
+      <span class='label'>{{@label}}</span>
+    {{/if}}
+
+    <style scoped>
+      .breadcrumb-item-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        color: var(--boxel-highlight);
+      }
+
+      @media (max-width: 30rem) {
+        .breadcrumb-item-icon {
+          width: 0.75rem;
+          height: 0.75rem;
+        }
+      }
+
+      .label {
+        font: 500 var(--boxel-font-sm);
+        color: var(--boxel-light);
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .muted {
+        opacity: 0.7;
+        font-weight: 500;
+      }
+    </style>
+  </template>;
 
 export default class HostModeBreadcrumbItem extends Component<Signature> {
   @cached
@@ -43,12 +103,18 @@ export default class HostModeBreadcrumbItem extends Component<Signature> {
     return Boolean(this.args.cardId) && !this.card && !this.cardError;
   }
 
-  private get iconComponent(): ComponentLike | undefined {
+  private get iconComponent():
+    | ComponentLike<{
+        Element: SVGSVGElement;
+      }>
+    | undefined {
     if (!this.card) {
       return undefined;
     }
 
-    return cardTypeIcon(this.card) as ComponentLike | undefined;
+    return cardTypeIcon(this.card) as
+      | ComponentLike<{ Element: SVGSVGElement }>
+      | undefined;
   }
 
   private get label() {
@@ -87,23 +153,12 @@ export default class HostModeBreadcrumbItem extends Component<Signature> {
           title={{this.label}}
           data-test-host-mode-breadcrumb={{@cardId}}
         >
-          {{#if this.card}}
-            {{#if Icon}}
-              <Icon
-                class='breadcrumb-item-icon'
-                width='18'
-                height='18'
-                aria-hidden='true'
-              />
-            {{/if}}
-            <span class='label'>{{this.label}}</span>
-          {{else if this.isLoading}}
-            <span class='label muted'>
-              Loading…
-            </span>
-          {{else}}
-            <span class='label'>{{this.label}}</span>
-          {{/if}}
+          <BreadcrumbItemContent
+            @icon={{Icon}}
+            @hasCard={{if this.card true false}}
+            @isLoading={{this.isLoading}}
+            @label={{this.label}}
+          />
         </span>
       {{else}}
         <button
@@ -114,23 +169,12 @@ export default class HostModeBreadcrumbItem extends Component<Signature> {
           data-test-host-mode-breadcrumb={{@cardId}}
           {{on 'click' this.handleClick}}
         >
-          {{#if this.card}}
-            {{#if Icon}}
-              <Icon
-                class='breadcrumb-item-icon'
-                width='18'
-                height='18'
-                aria-hidden='true'
-              />
-            {{/if}}
-            <span class='label'>{{this.label}}</span>
-          {{else if this.isLoading}}
-            <span class='label muted'>
-              Loading…
-            </span>
-          {{else}}
-            <span class='label'>{{this.label}}</span>
-          {{/if}}
+          <BreadcrumbItemContent
+            @icon={{Icon}}
+            @hasCard={{if this.card true false}}
+            @isLoading={{this.isLoading}}
+            @label={{this.label}}
+          />
         </button>
       {{/if}}
     {{/let}}
@@ -157,33 +201,6 @@ export default class HostModeBreadcrumbItem extends Component<Signature> {
       button.breadcrumb-item:focus-visible {
         outline: 1px solid var(--boxel-light-60);
         border-radius: var(--boxel-border-radius-lg);
-      }
-
-      .breadcrumb-item-icon {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        flex-shrink: 0;
-        color: var(--boxel-highlight);
-      }
-
-      @media (max-width: 30rem) {
-        .breadcrumb-item-icon {
-          width: 0.75rem;
-          height: 0.75rem;
-        }
-      }
-
-      .label {
-        font: 500 var(--boxel-font-sm);
-        color: var(--boxel-light);
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-
-      .muted {
-        opacity: 0.7;
-        font-weight: 500;
       }
     </style>
   </template>

--- a/packages/host/app/components/host-mode/breadcrumb-item.gts
+++ b/packages/host/app/components/host-mode/breadcrumb-item.gts
@@ -15,6 +15,7 @@ interface Signature {
   Args: {
     cardId: string;
     disabled?: boolean;
+    isCurrent?: boolean;
     onClick?: (cardId: string) => void;
   };
 }
@@ -83,15 +84,19 @@ export default class HostModeBreadcrumbItem extends Component<Signature> {
       class='breadcrumb-item'
       disabled={{this.isDisabled}}
       title={{this.label}}
+      aria-current={{if @isCurrent 'page'}}
       data-test-host-mode-breadcrumb={{@cardId}}
       {{on 'click' this.handleClick}}
     >
       {{#if this.card}}
         {{#if this.iconComponent}}
           {{#let this.iconComponent as |Icon|}}
-            <span class='icon' aria-hidden='true'>
-              <Icon />
-            </span>
+            <Icon
+              class='breadcrumb-item-icon'
+              width='18'
+              height='18'
+              aria-hidden='true'
+            />
           {{/let}}
         {{/if}}
         <span class='label'>{{this.label}}</span>
@@ -108,7 +113,7 @@ export default class HostModeBreadcrumbItem extends Component<Signature> {
       .breadcrumb-item {
         display: inline-flex;
         align-items: center;
-        gap: var(--boxel-sp-xxs);
+        gap: var(--boxel-sp-2xs);
         max-width: 16rem;
         background: none;
         border: none;
@@ -121,17 +126,23 @@ export default class HostModeBreadcrumbItem extends Component<Signature> {
       }
 
       .breadcrumb-item:focus-visible {
-        outline: 1px solid rgba(255, 255, 255, 0.6);
+        outline: 1px solid var(--boxel-light-60);
         border-radius: var(--boxel-border-radius-lg);
       }
 
-      .icon {
+      .breadcrumb-item-icon {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: 18px;
-        height: 18px;
-        color: var(--boxel-teal);
+        flex-shrink: 0;
+        color: var(--boxel-highlight);
+      }
+
+      @media (max-width: 30rem) {
+        .breadcrumb-item-icon {
+          width: 0.75rem;
+          height: 0.75rem;
+        }
       }
 
       .label {

--- a/packages/host/app/components/host-mode/breadcrumb-item.gts
+++ b/packages/host/app/components/host-mode/breadcrumb-item.gts
@@ -11,7 +11,7 @@ import { getCard } from '@cardstack/host/resources/card-resource';
 import type { ComponentLike } from '@glint/template';
 
 interface Signature {
-  Element: HTMLButtonElement;
+  Element: HTMLButtonElement | HTMLSpanElement;
   Args: {
     cardId: string;
     disabled?: boolean;
@@ -79,35 +79,61 @@ export default class HostModeBreadcrumbItem extends Component<Signature> {
   }
 
   <template>
-    <button
-      type='button'
-      class='breadcrumb-item'
-      disabled={{this.isDisabled}}
-      title={{this.label}}
-      aria-current={{if @isCurrent 'page'}}
-      data-test-host-mode-breadcrumb={{@cardId}}
-      {{on 'click' this.handleClick}}
-    >
-      {{#if this.card}}
-        {{#if this.iconComponent}}
-          {{#let this.iconComponent as |Icon|}}
-            <Icon
-              class='breadcrumb-item-icon'
-              width='18'
-              height='18'
-              aria-hidden='true'
-            />
-          {{/let}}
-        {{/if}}
-        <span class='label'>{{this.label}}</span>
-      {{else if this.isLoading}}
-        <span class='label muted'>
-          Loading…
+    {{#let this.iconComponent as |Icon|}}
+      {{#if @isCurrent}}
+        <span
+          class='breadcrumb-item'
+          aria-current='page'
+          title={{this.label}}
+          data-test-host-mode-breadcrumb={{@cardId}}
+        >
+          {{#if this.card}}
+            {{#if Icon}}
+              <Icon
+                class='breadcrumb-item-icon'
+                width='18'
+                height='18'
+                aria-hidden='true'
+              />
+            {{/if}}
+            <span class='label'>{{this.label}}</span>
+          {{else if this.isLoading}}
+            <span class='label muted'>
+              Loading…
+            </span>
+          {{else}}
+            <span class='label'>{{this.label}}</span>
+          {{/if}}
         </span>
       {{else}}
-        <span class='label'>{{this.label}}</span>
+        <button
+          type='button'
+          class='breadcrumb-item'
+          disabled={{this.isDisabled}}
+          title={{this.label}}
+          data-test-host-mode-breadcrumb={{@cardId}}
+          {{on 'click' this.handleClick}}
+        >
+          {{#if this.card}}
+            {{#if Icon}}
+              <Icon
+                class='breadcrumb-item-icon'
+                width='18'
+                height='18'
+                aria-hidden='true'
+              />
+            {{/if}}
+            <span class='label'>{{this.label}}</span>
+          {{else if this.isLoading}}
+            <span class='label muted'>
+              Loading…
+            </span>
+          {{else}}
+            <span class='label'>{{this.label}}</span>
+          {{/if}}
+        </button>
       {{/if}}
-    </button>
+    {{/let}}
 
     <style scoped>
       .breadcrumb-item {
@@ -115,9 +141,12 @@ export default class HostModeBreadcrumbItem extends Component<Signature> {
         align-items: center;
         gap: var(--boxel-sp-2xs);
         max-width: 16rem;
+        min-height: 1.5rem;
+        box-sizing: border-box;
         background: none;
         border: none;
-        padding: 0;
+        padding-block: var(--boxel-sp-4xs);
+        padding-inline: 0;
         margin: 0;
         color: inherit;
         white-space: nowrap;
@@ -125,7 +154,7 @@ export default class HostModeBreadcrumbItem extends Component<Signature> {
         overflow: hidden;
       }
 
-      .breadcrumb-item:focus-visible {
+      button.breadcrumb-item:focus-visible {
         outline: 1px solid var(--boxel-light-60);
         border-radius: var(--boxel-border-radius-lg);
       }

--- a/packages/host/app/components/host-mode/breadcrumb-item.gts
+++ b/packages/host/app/components/host-mode/breadcrumb-item.gts
@@ -17,7 +17,7 @@ interface Signature {
     cardId: string;
     disabled?: boolean;
     isCurrent?: boolean;
-    onClick?: (cardId: string) => void;
+    onClick?: () => void;
   };
 }
 
@@ -139,9 +139,7 @@ export default class HostModeBreadcrumbItem extends Component<Signature> {
       return;
     }
 
-    if (this.args.onClick) {
-      this.args.onClick(this.args.cardId);
-    }
+    this.args.onClick?.();
   }
 
   <template>

--- a/packages/host/app/components/host-mode/breadcrumbs.gts
+++ b/packages/host/app/components/host-mode/breadcrumbs.gts
@@ -2,6 +2,8 @@ import { action } from '@ember/object';
 
 import Component from '@glimmer/component';
 
+import { modifier } from 'ember-modifier';
+
 import { not } from '@cardstack/boxel-ui/helpers';
 
 import HostModeBreadcrumbItem from './breadcrumb-item';
@@ -13,6 +15,19 @@ interface Signature {
     close?: (cardId: string) => void;
   };
 }
+
+// The current-page crumb is always the rightmost one. When the trail
+// overflows the pill and scrolls, keep it in view instead of leaving it
+// stranded off-screen behind a hidden scrollbar — both on mount (a
+// deep-linked stack can already overflow) and whenever the trail changes.
+let scrollToCurrentCrumb = modifier(
+  (element: HTMLElement, [cardCount]: [number]) => {
+    if (cardCount === 0) {
+      return;
+    }
+    element.scrollLeft = element.scrollWidth;
+  },
+);
 
 export default class HostModeBreadcrumbs extends Component<Signature> {
   private get cardIds() {
@@ -72,7 +87,7 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
       ...attributes
     >
       {{#if this.hasCards}}
-        <ol class='list'>
+        <ol class='list' {{scrollToCurrentCrumb this.cardIds.length}}>
           {{#each this.cardIds key='@identity' as |cardId index|}}
             <li class='item'>
               <HostModeBreadcrumbItem

--- a/packages/host/app/components/host-mode/breadcrumbs.gts
+++ b/packages/host/app/components/host-mode/breadcrumbs.gts
@@ -78,6 +78,7 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
               <HostModeBreadcrumbItem
                 @cardId={{cardId}}
                 @disabled={{not (this.canNavigate cardId)}}
+                @isCurrent={{this.isLast index}}
                 @onClick={{this.handleBreadcrumbClick}}
               />
               {{#unless (this.isLast index)}}
@@ -95,10 +96,14 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
       .host-mode-breadcrumbs {
         display: inline-flex;
         align-items: center;
+        max-width: 100%;
+        box-sizing: border-box;
         background-color: var(--boxel-700);
         box-shadow: var(--boxel-deep-box-shadow);
-        border: solid 1px rgba(255, 255, 255, 0.35);
-        padding: var(--boxel-sp-xxs) var(--boxel-sp-xs);
+        border: 1px solid var(--boxel-light-35);
+        min-height: 2.25rem;
+        padding-block: 0;
+        padding-inline: var(--boxel-sp-xs);
         border-radius: 7px;
       }
 
@@ -113,18 +118,44 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
         margin: 0;
         padding: 0;
         align-items: center;
+        max-width: 100%;
       }
 
       .item {
         display: inline-flex;
         align-items: center;
-        gap: var(--boxel-sp-xxs);
+        gap: var(--boxel-sp-2xs);
+        flex-shrink: 0;
+      }
+
+      .item:first-child {
+        flex-shrink: 1;
+        min-width: 2.5rem;
+      }
+
+      .item:first-child :deep(.breadcrumb-item) {
+        min-width: 2.5rem;
+      }
+
+      .item:last-child {
+        flex-shrink: 2;
+        min-width: 2.5rem;
+      }
+
+      .item:last-child :deep(.breadcrumb-item) {
+        min-width: 2.5rem;
       }
 
       .separator {
-        color: rgba(255, 255, 255, 0.7);
+        color: var(--boxel-light-70);
         font-size: var(--boxel-font-size);
         line-height: 1;
+      }
+
+      @media (max-width: 30rem) {
+        .host-mode-breadcrumbs {
+          padding-inline: var(--boxel-sp-3xs);
+        }
       }
     </style>
   </template>

--- a/packages/host/app/components/host-mode/breadcrumbs.gts
+++ b/packages/host/app/components/host-mode/breadcrumbs.gts
@@ -115,29 +115,29 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
         padding: 0;
         align-items: center;
         max-width: 100%;
+        overflow-x: auto;
+        scrollbar-width: none;
+      }
+
+      .list::-webkit-scrollbar {
+        display: none;
       }
 
       .item {
         display: inline-flex;
         align-items: center;
         gap: var(--boxel-sp-2xs);
-        flex-shrink: 0;
-      }
-
-      .item:first-child {
         flex-shrink: 1;
-        min-width: 4rem;
+        min-width: 2.5rem;
       }
 
-      .item:first-child :deep(.breadcrumb-item) {
-        min-width: 4rem;
-      }
-
+      .item:first-child,
       .item:last-child {
-        flex-shrink: 2;
+        flex-shrink: 0;
         min-width: 4rem;
       }
 
+      .item:first-child :deep(.breadcrumb-item),
       .item:last-child :deep(.breadcrumb-item) {
         min-width: 4rem;
       }

--- a/packages/host/app/components/host-mode/breadcrumbs.gts
+++ b/packages/host/app/components/host-mode/breadcrumbs.gts
@@ -64,7 +64,7 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
 
   <template>
     <nav
-      class='host-mode-breadcrumbs {{unless this.hasCards "empty"}}'
+      class='host-mode-breadcrumbs'
       aria-label='Card stack navigation'
       hidden={{not this.hasCards}}
       data-host-mode-breadcrumbs
@@ -73,7 +73,7 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
     >
       {{#if this.hasCards}}
         <ol class='list'>
-          {{#each this.cardIds as |cardId index|}}
+          {{#each this.cardIds key='@identity' as |cardId index|}}
             <li class='item'>
               <HostModeBreadcrumbItem
                 @cardId={{cardId}}
@@ -107,10 +107,6 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
         border-radius: 7px;
       }
 
-      .empty {
-        display: none;
-      }
-
       .list {
         display: inline-flex;
         list-style: none;
@@ -130,20 +126,20 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
 
       .item:first-child {
         flex-shrink: 1;
-        min-width: 2.5rem;
+        min-width: 4rem;
       }
 
       .item:first-child :deep(.breadcrumb-item) {
-        min-width: 2.5rem;
+        min-width: 4rem;
       }
 
       .item:last-child {
         flex-shrink: 2;
-        min-width: 2.5rem;
+        min-width: 4rem;
       }
 
       .item:last-child :deep(.breadcrumb-item) {
-        min-width: 2.5rem;
+        min-width: 4rem;
       }
 
       .separator {

--- a/packages/host/app/components/host-mode/breadcrumbs.gts
+++ b/packages/host/app/components/host-mode/breadcrumbs.gts
@@ -1,3 +1,4 @@
+import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 
 import Component from '@glimmer/component';
@@ -42,31 +43,32 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
     return index === this.cardIds.length - 1;
   };
 
-  private cardsAboveCard(cardId: string) {
-    let cardIndex = this.cardIds.indexOf(cardId);
-
-    if (cardIndex < 0) {
+  // Crumbs are located by index rather than card id: the same card can
+  // appear more than once in the trail, so an id lookup could close the
+  // wrong cards.
+  private cardsAboveIndex(index: number) {
+    if (index < 0) {
       return [] as string[];
     }
 
-    return this.cardIds.slice(cardIndex + 1, this.cardIds.length);
+    return this.cardIds.slice(index + 1, this.cardIds.length);
   }
 
-  private canNavigate = (cardId: string) => {
+  private canNavigate = (index: number) => {
     if (!this.args.close) {
       return false;
     }
 
-    return this.cardsAboveCard(cardId).length > 0;
+    return this.cardsAboveIndex(index).length > 0;
   };
 
   @action
-  private handleBreadcrumbClick(cardId: string) {
+  private handleBreadcrumbClick(index: number) {
     if (!this.args.close) {
       return;
     }
 
-    let cardsToClose = this.cardsAboveCard(cardId);
+    let cardsToClose = this.cardsAboveIndex(index);
 
     if (cardsToClose.length === 0) {
       return;
@@ -92,9 +94,9 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
             <li class='item'>
               <HostModeBreadcrumbItem
                 @cardId={{cardId}}
-                @disabled={{not (this.canNavigate cardId)}}
+                @disabled={{not (this.canNavigate index)}}
                 @isCurrent={{this.isLast index}}
-                @onClick={{this.handleBreadcrumbClick}}
+                @onClick={{fn this.handleBreadcrumbClick index}}
               />
               {{#unless (this.isLast index)}}
                 <span class='separator' aria-hidden='true'>

--- a/packages/host/app/components/host-mode/content.gts
+++ b/packages/host/app/components/host-mode/content.gts
@@ -156,6 +156,7 @@ export default class HostModeContent extends Component<Signature> {
         top: var(--boxel-sp);
         left: var(--boxel-sp);
         z-index: 2;
+        max-width: calc(100% - 2 * var(--boxel-sp));
       }
 
       .host-mode-content.is-wide {
@@ -176,6 +177,16 @@ export default class HostModeContent extends Component<Signature> {
       .host-mode-content.is-wide .breadcrumb-container {
         top: var(--boxel-sp-lg);
         left: var(--boxel-sp-lg);
+        max-width: calc(100% - 2 * var(--boxel-sp-lg));
+      }
+
+      @media (max-width: 30rem) {
+        .breadcrumb-container,
+        .host-mode-content.is-wide .breadcrumb-container {
+          top: var(--boxel-sp-3xs);
+          left: var(--boxel-sp-3xs);
+          max-width: calc(100% - 2 * var(--boxel-sp-3xs));
+        }
       }
     </style>
   </template>


### PR DESCRIPTION
## Summary
- Cap the host-mode breadcrumb pill to the available content width; middle crumbs shrink first (first and last are protected with a wider floor), and trails too long to fit fall back to a horizontal scroller that keeps the current crumb in view.
- Tighten pill padding and icon size at narrow widths.
- Render the current-page crumb as a non-interactive `span[aria-current="page"]` instead of a disabled button, and enlarge the touch target toward the WCAG 2.5.8 minimum.
- Key the crumb list by card id for stable identity across re-renders.
- Resolve breadcrumb clicks by index rather than card id, so a trail that contains the same card twice closes the correct cards (the stack allows duplicate ids).

Fixes CS-12375.

Follow-up: CS-12395 tracks replacing the scroll fallback with the standard breadcrumb collapse pattern (`First › … › Current` with the buried crumbs in an ellipsis menu).

## Test plan
- [x] In host submode at a phone-width viewport, open stacks of 2–3 and 4+ cards: the pill stays within the viewport, and the current crumb is visible when the trail scrolls
- [x] Host acceptance suites (`host-submode-test.gts`, `host-mode-test.gts`) pass
- [x] Screen reader announces the current crumb via `aria-current="page"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


----

Before:
<img width="403" height="718" alt="stacknav-before" src="https://github.com/user-attachments/assets/e12e9de7-01c3-43c3-821a-8eea7c9801a8" />

After: (fallback case for long title that scrolls)
<img width="395" height="662" alt="stacknav-after" src="https://github.com/user-attachments/assets/1c6a6344-dba6-4036-99f0-f67345ce5290" />

