### PR TITLE
host: Fix routing use of full URL in scoped chooser

### DIFF
--- a/packages/host/app/components/search/panel-content.gts
+++ b/packages/host/app/components/search/panel-content.gts
@@ -476,6 +476,7 @@ export default class PanelContent extends Component<Signature> {
                 @resolvedCard={{this.resolvedCard}}
                 @isCardResourceLoaded={{this.isCardResourceLoaded}}
                 @realms={{this.realms}}
+                @realmsLocked={{@realmFilter.locked}}
                 @baseFilter={{@baseFilter}}
                 @offerToCreate={{@offerToCreate}}
                 @recentCardBareIds={{this.recentCardBareIds}}

--- a/packages/host/app/components/search/sheet-results.gts
+++ b/packages/host/app/components/search/sheet-results.gts
@@ -239,8 +239,17 @@ export default class SheetResults extends Component<Signature> {
     this.args.pagination.showMore(sectionId, totalCount);
   }
 
-  @action isSectionCollapsed(sectionId: string): boolean {
-    return this.args.pagination.isCollapsed(sectionId);
+  @action isSectionCollapsed(section: SearchSheetSection): boolean {
+    // A pasted URL is an explicit ask for that one card. A focused
+    // ("show only") realm section — including the one seeded when the
+    // chooser is scoped to a consuming realm — must not hide it: during a
+    // URL paste the realm query sections aren't rendered at all, so
+    // collapsing the URL section would leave the result count with
+    // nothing visible under it.
+    if (section.type === 'url') {
+      return false;
+    }
+    return this.args.pagination.isCollapsed(section.sid);
   }
 
   <template>
@@ -294,7 +303,7 @@ export default class SheetResults extends Component<Signature> {
           @variant={{@variant}}
           @handleSelect={{@handleSelect}}
           @isFocused={{eq @pagination.focusedSection section.sid}}
-          @isCollapsed={{this.isSectionCollapsed section.sid}}
+          @isCollapsed={{this.isSectionCollapsed section}}
           @onFocusSection={{this.onFocusSection}}
           @getDisplayedCount={{this.getDisplayedCount}}
           @onShowMore={{this.onShowMore}}

--- a/packages/host/app/components/search/sheet-results.gts
+++ b/packages/host/app/components/search/sheet-results.gts
@@ -25,6 +25,7 @@ import {
   buildUrlSection,
   type RecentsSection,
   type SearchSheetSection,
+  type UrlSection,
 } from '@cardstack/host/utils/search/sections';
 import type { NewCardArgs } from '@cardstack/host/utils/search/types';
 
@@ -62,6 +63,10 @@ interface Signature {
     resolvedCard: CardDef | undefined;
     isCardResourceLoaded: boolean;
     realms: string[];
+    // True when `realms` is a hard scope (the chooser's realm picker is
+    // locked). A pasted URL that resolves outside the scope is then
+    // suppressed rather than offered.
+    realmsLocked?: boolean;
     baseFilter?: Filter;
     offerToCreate?: { ref: CodeRef; relativeTo: URL | undefined };
     // The recent card ids stripped of any `.json`, for most-recent-first
@@ -129,16 +134,34 @@ export default class SheetResults extends Component<Signature> {
     return buildRecentsSection([...entries]);
   }
 
+  // The URL-paste section. When the realm scope is locked (the chooser is
+  // hard-scoped to a consuming realm), a pasted URL that resolves to a card
+  // outside the scope is suppressed — otherwise the tile would be
+  // selectable and Go could return a cross-realm card. `buildUrlSection`
+  // resolves `realmUrl` against `realms` (normalizing id forms), so an
+  // in-scope card always yields one of the `realms` entries verbatim.
+  private get urlSection(): UrlSection | undefined {
+    let section = buildUrlSection(
+      this.args.resolvedCard,
+      this.args.searchKeyIsURL,
+      this.args.realms,
+      this.realm,
+      (url) => this.network.virtualNetwork.unresolveURL(url),
+    );
+    if (
+      section &&
+      this.args.realmsLocked &&
+      !this.args.realms.includes(section.realmUrl)
+    ) {
+      return undefined;
+    }
+    return section;
+  }
+
   private get sections(): SearchSheetSection[] {
     return assembleSections(
       this.recentsSection,
-      buildUrlSection(
-        this.args.resolvedCard,
-        this.args.searchKeyIsURL,
-        this.args.realms,
-        this.realm,
-        (url) => this.network.virtualNetwork.unresolveURL(url),
-      ),
+      this.urlSection,
       buildQuerySections(this.args.mainResults.entries, {
         isURL: this.args.searchKeyIsURL,
         isSearchKeyEmpty: this.args.isSearchKeyEmpty,
@@ -162,7 +185,9 @@ export default class SheetResults extends Component<Signature> {
       if (!this.args.isCardResourceLoaded) {
         return 'Searching…';
       }
-      return this.args.resolvedCard ? '1 result from 1 realm' : '0 results';
+      // Count the section, not the resolved card — a card suppressed by the
+      // locked realm scope must not be reported as a result.
+      return this.urlSection ? '1 result from 1 realm' : '0 results';
     }
     const total = this.args.mainResults.meta.page?.total ?? 0;
     // The mini variant compresses the summary to "X results" — the design puts
@@ -199,8 +224,8 @@ export default class SheetResults extends Component<Signature> {
         urls.push(entry.id.replace(/\.json$/, ''));
       }
     }
-    if (this.args.resolvedCard?.id) {
-      urls.push(this.args.resolvedCard.id.replace(/\.json$/, ''));
+    if (this.urlSection?.card.id) {
+      urls.push(this.urlSection.card.id.replace(/\.json$/, ''));
     }
     return [...new Set(urls)];
   }
@@ -274,10 +299,19 @@ export default class SheetResults extends Component<Signature> {
     {{! Handle empty URL search state — only after loading completes }}
     {{#if @searchKeyIsURL}}
       {{#if @isCardResourceLoaded}}
-        {{#unless @resolvedCard}}
+        {{#unless this.urlSection}}
           <div class='empty-state' data-test-search-sheet-empty>
-            No card found at
-            {{@searchKey}}
+            {{#if @resolvedCard}}
+              {{! The card exists but the locked realm scope excludes it —
+                  saying "no card found" here would be untrue and send the
+                  user hunting for a typo. }}
+              Card at
+              {{@searchKey}}
+              is not in the realms this chooser is limited to
+            {{else}}
+              No card found at
+              {{@searchKey}}
+            {{/if}}
           </div>
         {{/unless}}
       {{/if}}

--- a/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
+++ b/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
@@ -167,6 +167,50 @@ module(
         .doesNotExist('cross-realm candidates are excluded by the lock');
     });
 
+    test('pasting a full card URL from the consuming realm shows the result', async function (assert) {
+      await renderRealmConfigEdit([{ path: '/docs' }]);
+
+      await click('[data-test-add-new="instance"]');
+      await waitFor('[data-test-card-chooser-modal]');
+
+      // Paste the full URL of a card that lives in the consuming realm —
+      // exactly the card the locked chooser is scoped to.
+      await fillIn(
+        '[data-test-card-chooser-modal] [data-test-search-field]',
+        `${testRealmURL}Pet/mango`,
+      );
+
+      // The URL-paste result section renders once the card resolves.
+      await waitFor(
+        '[data-test-card-chooser-modal] [data-section-sid^="url:"]',
+      );
+
+      // The chooser opens with the consuming realm's section focused
+      // ("show only"), which collapses every other section — but a pasted
+      // URL is an explicit ask, so its section must not be collapsed
+      // (collapse hides the result tile via display: none while the
+      // summary still reports "1 result").
+      assert
+        .dom('[data-test-card-chooser-modal] [data-section-sid^="url:"]')
+        .doesNotHaveClass(
+          'search-result-block--collapsed',
+          'the URL-paste section is not collapsed by the seeded realm focus',
+        );
+      assert
+        .dom(
+          '[data-test-card-chooser-modal] [data-section-sid^="url:"] [data-test-item-button]',
+        )
+        .isVisible('the pasted card result tile is visible');
+
+      // The visible tile is actually usable: selecting it enables Go.
+      await click(
+        '[data-test-card-chooser-modal] [data-section-sid^="url:"] [data-test-item-button]',
+      );
+      assert
+        .dom('[data-test-card-chooser-go-button]')
+        .isNotDisabled('the pasted card can be chosen');
+    });
+
     test('renders a per-rule warning when a path is malformed', async function (assert) {
       await renderRealmConfigEdit([
         { path: 'docs' }, // missing leading slash

--- a/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
+++ b/packages/host/tests/integration/components/realm-config-routing-rule-edit-test.gts
@@ -211,6 +211,47 @@ module(
         .isNotDisabled('the pasted card can be chosen');
     });
 
+    test('pasting a card URL from outside the consuming realm offers no result', async function (assert) {
+      await renderRealmConfigEdit([{ path: '/docs' }]);
+
+      await click('[data-test-add-new="instance"]');
+      await waitFor('[data-test-card-chooser-modal]');
+
+      // A real card, but in the base realm — outside the consuming realm
+      // the chooser is locked to. The chooser's hard scope applies to
+      // pasted URLs too: revealing this card would let Go return a
+      // cross-realm selection.
+      await fillIn(
+        '[data-test-card-chooser-modal] [data-test-search-field]',
+        `${baseRealm.url}types/card`,
+      );
+
+      await waitFor(
+        '[data-test-card-chooser-modal] [data-test-search-sheet-empty]',
+        { timeout: 10000 },
+      );
+      assert
+        .dom('[data-test-card-chooser-modal] [data-section-sid^="url:"]')
+        .doesNotExist(
+          'no URL-paste section is offered for an out-of-scope card',
+        );
+      assert
+        .dom('[data-test-card-chooser-modal] [data-test-search-sheet-empty]')
+        .containsText(
+          'is not in the realms this chooser is limited to',
+          'the empty state explains the card is out of scope, not missing',
+        );
+      assert
+        .dom('[data-test-card-chooser-modal] [data-test-search-label]')
+        .containsText('0 results', 'the summary does not count the card');
+      assert
+        .dom('[data-test-card-chooser-modal] [data-test-item-button]')
+        .doesNotExist('there is no tile to select');
+      assert
+        .dom('[data-test-card-chooser-go-button]')
+        .isDisabled('a cross-realm card cannot be returned by the chooser');
+    });
+
     test('renders a per-rule warning when a path is malformed', async function (assert) {
       await renderRealmConfigEdit([
         { path: 'docs' }, // missing leading slash


### PR DESCRIPTION
It says “1 result” but doesn’t show it:

<img width="2098" height="834" alt="image" src="https://github.com/user-attachments/assets/010565f5-1ab6-483c-9bcc-79fb1425e3d3" />

but finding it with a substring does work:

<img width="2112" height="1102" alt="image" src="https://github.com/user-attachments/assets/e40fc678-9246-487b-8bdf-bbbf09cd5803" />

The new test failed [here](https://github.com/cardstack/boxel/runs/90918239100) before the fix was added.

With this PR:

<img width="2130" height="1124" alt="s 2026-07-30 at 15 11 52@2x" src="https://github.com/user-attachments/assets/3b4415a4-fdc3-4f34-be8e-b0414a47c36b" />
