### PR TITLE
Record dotted card ids as instance deps, not file deps

### DIFF
--- a/packages/realm-server/tests/dependency-normalization-test.ts
+++ b/packages/realm-server/tests/dependency-normalization-test.ts
@@ -84,7 +84,24 @@ module(basename(import.meta.filename), function () {
       assert.deepEqual(
         forms('http://test/realm/report.pdf', network),
         ['http://test/realm/report.pdf', 'http://test/realm/report.pdf.json'],
-        'a file outside the FileDef registry keeps its own URL',
+        'a file the FileDef registry does not name keeps its own URL alongside the card-id form',
+      );
+      assert.deepEqual(
+        forms('http://test/realm/.gitignore', network),
+        ['http://test/realm/.gitignore', 'http://test/realm/.gitignore.json'],
+        'a leading dot is a name, not an extension, so it settles nothing either',
+      );
+    });
+
+    test('reads a registered extension as a file however it is cased', function (assert) {
+      let network = makeStubNetwork();
+      assert.deepEqual(forms('http://test/realm/LOGO.PNG', network), [
+        'http://test/realm/LOGO.PNG',
+      ]);
+      assert.deepEqual(
+        forms('http://test/realm/types.d.ts', network),
+        ['http://test/realm/types.d.ts'],
+        'a declaration file is a file, not a card id',
       );
     });
 

--- a/packages/realm-server/tests/dependency-normalization-test.ts
+++ b/packages/realm-server/tests/dependency-normalization-test.ts
@@ -1,0 +1,157 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import type { VirtualNetwork } from '@cardstack/runtime-common/virtual-network';
+import {
+  canTraverseRelationshipDependency,
+  relationshipDependencyForms,
+} from '@cardstack/runtime-common/index-runner/dependency-normalization';
+
+const realmURL = new URL('http://test/realm/');
+const relativeTo = new URL('http://test/realm/consumer.json');
+const prefix = '@cardstack/test-realm/';
+
+// A VirtualNetwork stand-in that resolves relative references with the platform
+// URL parser and maps one registered prefix onto the realm under test, so both
+// branches of `relationshipDependencyForms` (prefix-form and URL-form) are
+// reachable without standing up a network.
+function makeStubNetwork(): VirtualNetwork {
+  return {
+    isRegisteredPrefix(reference: string) {
+      return reference.startsWith(prefix);
+    },
+    toURL(reference: string) {
+      return new URL(reference.slice(prefix.length), realmURL);
+    },
+    resolveURL(reference: string, base: URL | string | undefined) {
+      return new URL(reference, base ?? undefined);
+    },
+    unresolveURL(url: string) {
+      return url;
+    },
+  } as unknown as VirtualNetwork;
+}
+
+function forms(dep: string, network = makeStubNetwork()): string[] {
+  return relationshipDependencyForms(dep, relativeTo, realmURL, network);
+}
+
+module(basename(import.meta.filename), function () {
+  module('relationshipDependencyForms', function () {
+    test('resolves an extensionless in-realm card id to its `.json` row', function (assert) {
+      assert.deepEqual(forms('http://test/realm/Person/mango'), [
+        'http://test/realm/Person/mango.json',
+      ]);
+    });
+
+    test('resolves a relative dep against the consuming resource', function (assert) {
+      assert.deepEqual(forms('./Person/mango'), [
+        'http://test/realm/Person/mango.json',
+      ]);
+    });
+
+    test('leaves an in-realm file dep at its own URL', function (assert) {
+      let network = makeStubNetwork();
+      for (let dep of [
+        'http://test/realm/logo.png',
+        'http://test/realm/notes.md',
+        'http://test/realm/song.mp3',
+        'http://test/realm/hello.test.gts',
+        'http://test/realm/bundled.js',
+        'http://test/realm/person.json',
+      ]) {
+        assert.deepEqual(forms(dep, network), [dep], dep);
+      }
+    });
+
+    test('records both forms for a dotted name no extension settles', function (assert) {
+      let network = makeStubNetwork();
+      assert.deepEqual(
+        forms('http://test/realm/hello.test', network),
+        ['http://test/realm/hello.test', 'http://test/realm/hello.test.json'],
+        'a `hello.test` card id keeps the `.json` form invalidation matches on',
+      );
+      assert.deepEqual(
+        forms(
+          'http://test/realm/ModelConfiguration/claude-sonnet-4.6',
+          network,
+        ),
+        [
+          'http://test/realm/ModelConfiguration/claude-sonnet-4.6',
+          'http://test/realm/ModelConfiguration/claude-sonnet-4.6.json',
+        ],
+      );
+      assert.deepEqual(
+        forms('http://test/realm/report.pdf', network),
+        ['http://test/realm/report.pdf', 'http://test/realm/report.pdf.json'],
+        'a file outside the FileDef registry keeps its own URL',
+      );
+    });
+
+    test('leaves an out-of-realm dep alone', function (assert) {
+      let network = makeStubNetwork();
+      assert.deepEqual(forms('http://other/realm/hello.test', network), [
+        'http://other/realm/hello.test',
+      ]);
+      assert.deepEqual(forms('http://other/realm/person', network), [
+        'http://other/realm/person',
+      ]);
+    });
+
+    test('keeps a prefix-form dep in prefix form', function (assert) {
+      let network = makeStubNetwork();
+      assert.deepEqual(forms('@cardstack/test-realm/Person/mango', network), [
+        '@cardstack/test-realm/Person/mango.json',
+      ]);
+      assert.deepEqual(forms('@cardstack/test-realm/logo.png', network), [
+        '@cardstack/test-realm/logo.png',
+      ]);
+      assert.deepEqual(forms('@cardstack/test-realm/hello.test', network), [
+        '@cardstack/test-realm/hello.test',
+        '@cardstack/test-realm/hello.test.json',
+      ]);
+    });
+  });
+
+  module('canTraverseRelationshipDependency', function () {
+    test('traverses in-realm deps that could name an index row', function (assert) {
+      let network = makeStubNetwork();
+      for (let dep of [
+        'http://test/realm/person.json',
+        'http://test/realm/hello.test.json',
+        'http://test/realm/logo.png',
+        'http://test/realm/hello.test.gts',
+        'http://test/realm/report.pdf',
+        '@cardstack/test-realm/person.json',
+      ]) {
+        assert.true(
+          canTraverseRelationshipDependency(dep, realmURL, network),
+          dep,
+        );
+      }
+    });
+
+    test('skips extensionless in-realm deps', function (assert) {
+      let network = makeStubNetwork();
+      for (let dep of [
+        'http://test/realm/person',
+        '@cardstack/test-realm/person',
+      ]) {
+        assert.false(
+          canTraverseRelationshipDependency(dep, realmURL, network),
+          `${dep} names no row of its own`,
+        );
+      }
+    });
+
+    test('skips deps outside the realm', function (assert) {
+      assert.false(
+        canTraverseRelationshipDependency(
+          'http://other/realm/person.json',
+          realmURL,
+          makeStubNetwork(),
+        ),
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/dependency-normalization-test.ts
+++ b/packages/realm-server/tests/dependency-normalization-test.ts
@@ -23,6 +23,9 @@ function makeStubNetwork(): VirtualNetwork {
     toURL(reference: string) {
       return new URL(reference.slice(prefix.length), realmURL);
     },
+    toURLHref(reference: string) {
+      return new URL(reference.slice(prefix.length), realmURL).href;
+    },
     resolveURL(reference: string, base: URL | string | undefined) {
       return new URL(reference, base ?? undefined);
     },
@@ -168,6 +171,36 @@ module(basename(import.meta.filename), function () {
           realmURL,
           makeStubNetwork(),
         ),
+      );
+    });
+
+    test('rejects a dep that is not a URL at all', function (assert) {
+      let network = makeStubNetwork();
+      for (let dep of ['not a url', './relative/person.json', '']) {
+        assert.false(
+          canTraverseRelationshipDependency(dep, realmURL, network),
+          JSON.stringify(dep),
+        );
+      }
+    });
+
+    test('classifies by the path alone when a query or hash is present', function (assert) {
+      let network = makeStubNetwork();
+      assert.true(
+        canTraverseRelationshipDependency(
+          'http://test/realm/logo.png?cache=1',
+          realmURL,
+          network,
+        ),
+        'query string does not hide the file extension',
+      );
+      assert.false(
+        canTraverseRelationshipDependency(
+          'http://test/realm/person?v=1.2',
+          realmURL,
+          network,
+        ),
+        'a dotted query string does not make an instance id look dotted',
       );
     });
   });

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -369,6 +369,7 @@ const ALL_TEST_FILES: string[] = [
   './search-bounds-test',
   './coerce-error-message-test',
   './canonical-url-memo-test',
+  './dependency-normalization-test',
   './realm-operations-test',
   './resolve-published-realm-url-test',
   './fallback-models-test',

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -3348,6 +3348,10 @@ module(basename(import.meta.filename), function () {
             deps,
           )})`,
         );
+        assert.notOk(
+          deps.includes(`${testRealm}hello.test`),
+          'the dotted target is recorded at its row URL rather than its bare id',
+        );
 
         let beforeInvalidation = await indexedAtFor(
           `${testRealm}dotted-consumer.json`,

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -3249,6 +3249,120 @@ module(basename(import.meta.filename), function () {
         );
       });
 
+      test('invalidates a consumer when the dotted-id instance it links to is written', async function (assert) {
+        await realm.write(
+          'dotted-link.gts',
+          `
+          import { CardDef, Component, contains, field, linksTo } from "@cardstack/base/card-api";
+          import StringField from "@cardstack/base/string";
+
+          export class DottedTarget extends CardDef {
+            @field name = contains(StringField);
+
+            static atom = class Atom extends Component<typeof this> {
+              <template>
+                <p><@fields.name /></p>
+              </template>
+            }
+            static embedded = class Embedded extends Component<typeof this> {
+              <template>
+                <p><@fields.name /></p>
+              </template>
+            }
+            static fitted = class Fitted extends Component<typeof this> {
+              <template>
+                <p><@fields.name /></p>
+              </template>
+            }
+            static isolated = class Isolated extends Component<typeof this> {
+              <template>
+                <p><@fields.name /></p>
+              </template>
+            }
+          }
+
+          export class DottedConsumer extends CardDef {
+            @field target = linksTo(() => DottedTarget);
+
+            static atom = class Atom extends Component<typeof this> {
+              <template>
+                <@fields.target />
+              </template>
+            }
+            static embedded = class Embedded extends Component<typeof this> {
+              <template>
+                <@fields.target />
+              </template>
+            }
+            static fitted = class Fitted extends Component<typeof this> {
+              <template>
+                <@fields.target />
+              </template>
+            }
+            static isolated = class Isolated extends Component<typeof this> {
+              <template>
+                <@fields.target />
+              </template>
+            }
+          }
+        `,
+        );
+
+        // A dot in a card id is part of the name: this instance's id is
+        // `hello.test`, and its index row is keyed on `hello.test.json`.
+        let dottedTarget = (name: string) =>
+          JSON.stringify({
+            data: {
+              attributes: { name },
+              meta: {
+                adoptsFrom: {
+                  module: rri('./dotted-link'),
+                  name: 'DottedTarget',
+                },
+              },
+            },
+          } as LooseSingleCardDocument);
+
+        await realm.write('hello.test.json', dottedTarget('Dotted Target'));
+        await realm.write(
+          'dotted-consumer.json',
+          JSON.stringify({
+            data: {
+              relationships: {
+                target: { links: { self: './hello.test' } },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: rri('./dotted-link'),
+                  name: 'DottedConsumer',
+                },
+              },
+            },
+          } as LooseSingleCardDocument),
+        );
+
+        let deps = await depsFor(`${testRealm}dotted-consumer.json`);
+        assert.ok(
+          deps.includes(`${testRealm}hello.test.json`),
+          `deps include the dotted target's row URL (deps: ${JSON.stringify(
+            deps,
+          )})`,
+        );
+
+        let beforeInvalidation = await indexedAtFor(
+          `${testRealm}dotted-consumer.json`,
+        );
+        await realm.write(
+          'hello.test.json',
+          dottedTarget('Dotted Target Updated'),
+        );
+        assert.notStrictEqual(
+          await indexedAtFor(`${testRealm}dotted-consumer.json`),
+          beforeInvalidation,
+          'writing the dotted-id instance invalidates the consumer linking to it',
+        );
+      });
+
       // remove this once we have a query based relationship invalidation strategy
       test('does not capture deps from query-backed relationships', async function (assert) {
         await realm.write(

--- a/packages/realm-server/tests/runtime-dependency-tracker-test.ts
+++ b/packages/realm-server/tests/runtime-dependency-tracker-test.ts
@@ -207,6 +207,50 @@ module(basename(import.meta.filename), function (hooks) {
     );
   });
 
+  test('records instance deps at their .json URL, dotted card ids included', async function (assert) {
+    beginRuntimeDependencyTrackingSession({
+      sessionKey: 'dotted-instance-ids',
+      rootURL: 'https://example.com/root.json',
+      rootKind: 'instance',
+    });
+
+    await withRuntimeDependencyTrackingContext(
+      {
+        mode: 'non-query',
+        source: 'test:dotted-instance-ids',
+        consumer: 'https://example.com/root.json',
+        consumerKind: 'instance',
+      },
+      async () => {
+        trackRuntimeInstanceDependency('https://example.com/hello.test');
+        trackRuntimeInstanceDependency(
+          'https://example.com/ModelConfiguration/claude-sonnet-4.6',
+        );
+        trackRuntimeInstanceDependency('https://example.com/already.json');
+      },
+    );
+
+    let snapshot = snapshotRuntimeDependencies({ excludeQueryOnly: true });
+    assert.true(
+      snapshot.deps.includes('https://example.com/hello.test.json'),
+      'a dotted card id gets the .json suffix its index row carries',
+    );
+    assert.true(
+      snapshot.deps.includes(
+        'https://example.com/ModelConfiguration/claude-sonnet-4.6.json',
+      ),
+      'a card id whose last segment ends in digits after a dot is not read as a file',
+    );
+    assert.true(
+      snapshot.deps.includes('https://example.com/already.json'),
+      'a reference already in .json form is recorded as-is',
+    );
+    assert.notOk(
+      snapshot.deps.includes('https://example.com/already.json.json'),
+      '.json is not appended twice',
+    );
+  });
+
   test('excludes file root across extensionless and .json aliases', async function (assert) {
     beginRuntimeDependencyTrackingSession({
       sessionKey: 'file-root-alias-exclusion',

--- a/packages/runtime-common/dependency-tracker.ts
+++ b/packages/runtime-common/dependency-tracker.ts
@@ -79,8 +79,10 @@ function normalizeModuleURL(url: string): string | undefined {
 // legitimately contain dots (a `ModelConfiguration/claude-sonnet-4.6`
 // instance, a `hello.test` instance). Reading such a dot as an extension would
 // leave the dep at a URL no index row carries, so changing the instance would
-// never invalidate this consumer. Files are tracked through `trackFile`, so an
-// instance reference here is never a file path.
+// never invalidate this consumer. Two conventions make the suffix sufficient on
+// its own: files are tracked through `trackFile`, so an instance reference here
+// is never a file path, and a card id never ends in `.json` — that suffix
+// belongs to the row, not to the id.
 function normalizeInstanceURL(url: string): string | undefined {
   let canonical = canonicalURL(url);
   if (!canonical) {

--- a/packages/runtime-common/dependency-tracker.ts
+++ b/packages/runtime-common/dependency-tracker.ts
@@ -60,12 +60,6 @@ function canonicalURL(url: string): string | undefined {
   return url;
 }
 
-function hasPathExtension(url: string): boolean {
-  let lastSlash = url.lastIndexOf('/');
-  let segment = lastSlash !== -1 ? url.slice(lastSlash + 1) : url;
-  return segment.length > 0 && segment.includes('.');
-}
-
 function normalizeModuleURL(url: string): string | undefined {
   let canonical = canonicalURL(url);
   if (!canonical) {
@@ -79,12 +73,20 @@ function normalizeModuleURL(url: string): string | undefined {
   return canonical;
 }
 
+// An instance dependency is recorded in the form the index carries it: the
+// instance's `.json` URL. The `.json` suffix — not "the last path segment has a
+// dot" — is what says a reference already has that form, because card ids can
+// legitimately contain dots (a `ModelConfiguration/claude-sonnet-4.6`
+// instance, a `hello.test` instance). Reading such a dot as an extension would
+// leave the dep at a URL no index row carries, so changing the instance would
+// never invalidate this consumer. Files are tracked through `trackFile`, so an
+// instance reference here is never a file path.
 function normalizeInstanceURL(url: string): string | undefined {
   let canonical = canonicalURL(url);
   if (!canonical) {
     return undefined;
   }
-  if (!hasPathExtension(canonical)) {
+  if (!canonical.endsWith('.json')) {
     return `${canonical}.json`;
   }
   return canonical;

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -82,10 +82,13 @@ export function isFileDefCodeRef(
   return false;
 }
 
-function extensionOf(url: URL): string {
-  let name = url.pathname.split('/').pop() ?? '';
+function extensionOfName(name: string): string {
   let dot = name.lastIndexOf('.');
   return dot <= 0 ? '' : name.slice(dot).toLowerCase();
+}
+
+function extensionOf(url: URL): string {
+  return extensionOfName(url.pathname.split('/').pop() ?? '');
 }
 
 // Whether a URL names a file rather than a card, judged by a known FileDef
@@ -96,6 +99,13 @@ function extensionOf(url: URL): string {
 // file extensions count.
 export function urlNamesFile(url: URL): boolean {
   return extensionOf(url) in FILEDEF_CODE_REF_BY_EXTENSION;
+}
+
+// Last-path-segment form of `urlNamesFile`, for callers that already hold the
+// segment as a string — the index runner's per-dep classifier stays off URL
+// construction entirely.
+export function segmentNamesFile(name: string): boolean {
+  return extensionOfName(name) in FILEDEF_CODE_REF_BY_EXTENSION;
 }
 
 export function resolveFileDefCodeRef(

--- a/packages/runtime-common/index-runner/dependency-normalization.ts
+++ b/packages/runtime-common/index-runner/dependency-normalization.ts
@@ -20,6 +20,10 @@ function isExtensionlessPath(url: URL): boolean {
 // beside the `hello.test.gts` module, a `ModelConfiguration/claude-sonnet-4.6`
 // instance) as readily as a file whose extension is outside the FileDef
 // registry (a `report.pdf` attachment), so those come back as 'either'.
+//
+// `.json` is itself a registered extension, which is what leaves a dep already
+// in an instance's stored form alone. The one id shape that reads wrong is a
+// card id ending in `.json`, whose row is at `<id>.json.json`.
 type NamedResource = 'file' | 'instance' | 'either';
 
 function namedResource(url: URL): NamedResource {
@@ -93,11 +97,12 @@ export function relationshipDependencyForms(
 }
 
 // Traversal follows a dep to the index row named by that exact URL, so it takes
-// every dep that could name one. An extensionless dep never does: it is a module
-// reference in node-resolution form, whose errors reach a consumer through the
-// definition cache instead. A dep that turns out to name no row is read as a
-// miss and traversal stops there, so admitting one costs a lookup — which is why
-// the ambiguous dotted names `namedResource` won't classify are admitted here.
+// every dep that could name one. A dep reading as a bare instance id never
+// does — no row is keyed on that form — and such a dep is a module reference in
+// node-resolution form, whose errors reach a consumer through the definition
+// cache instead. Everything else is admitted, undecidable dotted names
+// included: a dep naming no row reads as a miss, so admitting one costs a
+// lookup rather than correctness.
 export function canTraverseRelationshipDependency(
   dep: string,
   realmURL: URL,
@@ -111,7 +116,7 @@ export function canTraverseRelationshipDependency(
     if (!parsed.href.startsWith(realmURL.href)) {
       return false;
     }
-    return !isExtensionlessPath(parsed);
+    return namedResource(parsed) !== 'instance';
   } catch (_err) {
     return false;
   }

--- a/packages/runtime-common/index-runner/dependency-normalization.ts
+++ b/packages/runtime-common/index-runner/dependency-normalization.ts
@@ -1,11 +1,32 @@
 import { rri } from '../realm-identifiers.ts';
-import { trimExecutableExtension } from '../index.ts';
+import { hasExecutableExtension, trimExecutableExtension } from '../index.ts';
+import { urlNamesFile } from '../file-def-code-ref.ts';
 import type { VirtualNetwork } from '../virtual-network.ts';
 import { canonicalURL, type CanonicalURLMemo } from './dependency-url.ts';
 
-export function isExtensionlessPath(url: URL): boolean {
+function isExtensionlessPath(url: URL): boolean {
   let lastSegment = url.pathname.split('/').pop() ?? '';
   return !lastSegment.includes('.');
+}
+
+// Which resource a dependency URL names: a card instance, whose index row lives
+// at `<id>.json`, or a file, whose row lives at the file's own URL. A known
+// extension — one a file link resolves a FileDef subtype through, or an
+// executable extension a module is served under — settles it, and a last
+// segment with no dot at all settles it the other way, because an instance's
+// `.json` is stripped from its id.
+//
+// Nothing settles the rest. A dotted last segment is a card id (`hello.test`
+// beside the `hello.test.gts` module, a `ModelConfiguration/claude-sonnet-4.6`
+// instance) as readily as a file whose extension is outside the FileDef
+// registry (a `report.pdf` attachment), so those come back as 'either'.
+type NamedResource = 'file' | 'instance' | 'either';
+
+function namedResource(url: URL): NamedResource {
+  if (urlNamesFile(url) || hasExecutableExtension(url.pathname)) {
+    return 'file';
+  }
+  return isExtensionlessPath(url) ? 'instance' : 'either';
 }
 
 export function normalizeStoredDependency(
@@ -17,13 +38,19 @@ export function normalizeStoredDependency(
   return canonicalURL(dep, relativeTo.href, virtualNetwork, memo);
 }
 
-export function normalizeRelationshipDependency(
+// Every stored form an in-realm relationship dependency can take. Invalidation
+// matches a dep against a row URL by exact string, so a dep recorded in the
+// wrong form matches nothing and writing the target never invalidates this
+// consumer. Where `namedResource` can't tell a card id from a file, both
+// candidate forms are recorded rather than one guessed: an unmatched dep costs
+// a string, a missing one costs the consumer its invalidation.
+export function relationshipDependencyForms(
   dep: string,
   relativeTo: URL,
   realmURL: URL,
   virtualNetwork: VirtualNetwork,
   memo?: CanonicalURLMemo,
-): string {
+): string[] {
   let canonical = canonicalURL(dep, relativeTo.href, virtualNetwork, memo);
   // Prefix-form deps (e.g. @cardstack/catalog/foo) are already canonical.
   // Resolve to check realm membership and add .json if needed.
@@ -31,31 +58,52 @@ export function normalizeRelationshipDependency(
     let resolved = virtualNetwork.toURL(canonical).href;
     try {
       let parsed = new URL(resolved);
-      if (
-        parsed.href.startsWith(realmURL.href) &&
-        isExtensionlessPath(parsed)
-      ) {
-        return `${canonical}.json`;
+      if (parsed.href.startsWith(realmURL.href)) {
+        return formsFor(canonical, `${canonical}.json`, namedResource(parsed));
       }
     } catch (_err) {
       // fall through
     }
-    return canonical;
+    return [canonical];
   }
   try {
     let normalized = new URL(canonical);
-    if (
-      normalized.href.startsWith(realmURL.href) &&
-      isExtensionlessPath(normalized)
-    ) {
-      normalized.pathname = `${normalized.pathname}.json`;
+    if (normalized.href.startsWith(realmURL.href)) {
+      let instance = new URL(normalized.href);
+      instance.pathname = `${instance.pathname}.json`;
+      return formsFor(
+        normalized.href,
+        instance.href,
+        namedResource(normalized),
+      );
     }
-    return normalized.href;
+    return [normalized.href];
   } catch (_err) {
-    return canonical;
+    return [canonical];
   }
 }
 
+function formsFor(
+  fileForm: string,
+  instanceForm: string,
+  named: NamedResource,
+): string[] {
+  switch (named) {
+    case 'file':
+      return [fileForm];
+    case 'instance':
+      return [instanceForm];
+    case 'either':
+      return [fileForm, instanceForm];
+  }
+}
+
+// Traversal follows a dep to the index row named by that exact URL, so it takes
+// every dep that could name one. An extensionless dep never does: it is a module
+// reference in node-resolution form, whose errors reach a consumer through the
+// definition cache instead. A dep that turns out to name no row is read as a
+// miss and traversal stops there, so admitting one costs a lookup — which is why
+// the ambiguous dotted names `namedResource` won't classify are admitted here.
 export function canTraverseRelationshipDependency(
   dep: string,
   realmURL: URL,

--- a/packages/runtime-common/index-runner/dependency-normalization.ts
+++ b/packages/runtime-common/index-runner/dependency-normalization.ts
@@ -4,11 +4,6 @@ import { urlNamesFile } from '../file-def-code-ref.ts';
 import type { VirtualNetwork } from '../virtual-network.ts';
 import { canonicalURL, type CanonicalURLMemo } from './dependency-url.ts';
 
-function isExtensionlessPath(url: URL): boolean {
-  let lastSegment = url.pathname.split('/').pop() ?? '';
-  return !lastSegment.includes('.');
-}
-
 // Which resource a dependency URL names: a card instance, whose index row lives
 // at `<id>.json`, or a file, whose row lives at the file's own URL. A known
 // extension — one a file link resolves a FileDef subtype through, or an
@@ -26,11 +21,22 @@ function isExtensionlessPath(url: URL): boolean {
 // card id ending in `.json`, whose row is at `<id>.json.json`.
 type NamedResource = 'file' | 'instance' | 'either';
 
+// The dotless test runs first: it alone settles the dominant case (module deps
+// are stored with their executable extension stripped, so most deps are
+// dotless), and this classifier sits on the per-dep loop of every index visit
+// — including successful ones, via the index-backed dependency-error scan — so
+// the registry walk must stay off that path. Ordering is free: the registry
+// and executable tests can only match a segment that has a dot.
 function namedResource(url: URL): NamedResource {
-  if (urlNamesFile(url) || hasExecutableExtension(url.pathname)) {
+  let pathname = url.pathname;
+  let lastSegment = pathname.slice(pathname.lastIndexOf('/') + 1);
+  if (!lastSegment.includes('.')) {
+    return 'instance';
+  }
+  if (urlNamesFile(url) || hasExecutableExtension(pathname)) {
     return 'file';
   }
-  return isExtensionlessPath(url) ? 'instance' : 'either';
+  return 'either';
 }
 
 export function normalizeStoredDependency(

--- a/packages/runtime-common/index-runner/dependency-normalization.ts
+++ b/packages/runtime-common/index-runner/dependency-normalization.ts
@@ -59,7 +59,14 @@ export function relationshipDependencyForms(
     try {
       let parsed = new URL(resolved);
       if (parsed.href.startsWith(realmURL.href)) {
-        return formsFor(canonical, `${canonical}.json`, namedResource(parsed));
+        let named = namedResource(parsed);
+        if (named === 'file') {
+          return [canonical];
+        }
+        let instanceForm = `${canonical}.json`;
+        return named === 'instance'
+          ? [instanceForm]
+          : [canonical, instanceForm];
       }
     } catch (_err) {
       // fall through
@@ -68,33 +75,20 @@ export function relationshipDependencyForms(
   }
   try {
     let normalized = new URL(canonical);
-    if (normalized.href.startsWith(realmURL.href)) {
-      let instance = new URL(normalized.href);
-      instance.pathname = `${instance.pathname}.json`;
-      return formsFor(
-        normalized.href,
-        instance.href,
-        namedResource(normalized),
-      );
+    if (!normalized.href.startsWith(realmURL.href)) {
+      return [normalized.href];
     }
-    return [normalized.href];
+    let named = namedResource(normalized);
+    if (named === 'file') {
+      return [normalized.href];
+    }
+    let fileForm = normalized.href;
+    normalized.pathname = `${normalized.pathname}.json`;
+    return named === 'instance'
+      ? [normalized.href]
+      : [fileForm, normalized.href];
   } catch (_err) {
     return [canonical];
-  }
-}
-
-function formsFor(
-  fileForm: string,
-  instanceForm: string,
-  named: NamedResource,
-): string[] {
-  switch (named) {
-    case 'file':
-      return [fileForm];
-    case 'instance':
-      return [instanceForm];
-    case 'either':
-      return [fileForm, instanceForm];
   }
 }
 

--- a/packages/runtime-common/index-runner/dependency-normalization.ts
+++ b/packages/runtime-common/index-runner/dependency-normalization.ts
@@ -1,6 +1,6 @@
 import { rri } from '../realm-identifiers.ts';
 import { hasExecutableExtension, trimExecutableExtension } from '../index.ts';
-import { urlNamesFile } from '../file-def-code-ref.ts';
+import { segmentNamesFile } from '../file-def-code-ref.ts';
 import type { VirtualNetwork } from '../virtual-network.ts';
 import { canonicalURL, type CanonicalURLMemo } from './dependency-url.ts';
 
@@ -27,16 +27,23 @@ type NamedResource = 'file' | 'instance' | 'either';
 // — including successful ones, via the index-backed dependency-error scan — so
 // the registry walk must stay off that path. Ordering is free: the registry
 // and executable tests can only match a segment that has a dot.
-function namedResource(url: URL): NamedResource {
-  let pathname = url.pathname;
-  let lastSegment = pathname.slice(pathname.lastIndexOf('/') + 1);
+//
+// String-based for the same reason: `path` may be a pathname or a whole
+// canonical href — any query and hash must already be stripped — so the
+// per-dep loop never constructs a URL.
+function namedResourceForPath(path: string): NamedResource {
+  let lastSegment = path.slice(path.lastIndexOf('/') + 1);
   if (!lastSegment.includes('.')) {
     return 'instance';
   }
-  if (urlNamesFile(url) || hasExecutableExtension(pathname)) {
+  if (segmentNamesFile(lastSegment) || hasExecutableExtension(path)) {
     return 'file';
   }
   return 'either';
+}
+
+function namedResource(url: URL): NamedResource {
+  return namedResourceForPath(url.pathname);
 }
 
 export function normalizeStoredDependency(
@@ -109,23 +116,39 @@ export function relationshipDependencyForms(
 // cache instead. Everything else is admitted, undecidable dotted names
 // included: a dep naming no row reads as a miss, so admitting one costs a
 // lookup rather than correctness.
+// String-only on the same per-visit-per-dep grounds as `namedResourceForPath`.
+// Both callers hand this `normalizeStoredDependency` output — a canonical href
+// (already a parsed URL's `.href`, query and hash stripped) or a prefix form
+// the memoized `toURLHref` converts to one — so parsing through `new URL`
+// would only re-derive the same string. The realm gate keeps that safe for
+// any other input too: a string that isn't a canonical URL fails `startsWith`
+// and is rejected, exactly as URL-parsing would reject it. The query/hash
+// strip is belt-and-braces for direct callers, at two indexOf calls.
 export function canTraverseRelationshipDependency(
   dep: string,
   realmURL: URL,
   virtualNetwork: VirtualNetwork,
 ): boolean {
-  try {
-    let resolved = virtualNetwork.isRegisteredPrefix(dep)
-      ? virtualNetwork.toURL(dep).href
-      : dep;
-    let parsed = new URL(resolved);
-    if (!parsed.href.startsWith(realmURL.href)) {
+  let resolved = dep;
+  if (virtualNetwork.isRegisteredPrefix(dep)) {
+    try {
+      resolved = virtualNetwork.toURLHref(dep);
+    } catch (_err) {
       return false;
     }
-    return namedResource(parsed) !== 'instance';
-  } catch (_err) {
+  }
+  if (!resolved.startsWith(realmURL.href)) {
     return false;
   }
+  let hashIdx = resolved.indexOf('#');
+  if (hashIdx !== -1) {
+    resolved = resolved.slice(0, hashIdx);
+  }
+  let searchIdx = resolved.indexOf('?');
+  if (searchIdx !== -1) {
+    resolved = resolved.slice(0, searchIdx);
+  }
+  return namedResourceForPath(resolved) !== 'instance';
 }
 
 export function normalizeDependencyForLookup(

--- a/packages/runtime-common/index-runner/relationship-dependency-extractor.ts
+++ b/packages/runtime-common/index-runner/relationship-dependency-extractor.ts
@@ -6,7 +6,7 @@ import {
 } from '../index.ts';
 import type { VirtualNetwork } from '../virtual-network.ts';
 import { canonicalURL, type CanonicalURLMemo } from './dependency-url.ts';
-import { normalizeRelationshipDependency } from './dependency-normalization.ts';
+import { relationshipDependencyForms } from './dependency-normalization.ts';
 
 export type RelationshipSource =
   | Pick<CardResource, 'relationships'>
@@ -79,15 +79,15 @@ export class RelationshipDependencyExtractor {
       this.#canonicalURLMemo,
     );
     selfUrls.add(canonicalSelf);
-    selfUrls.add(
-      normalizeRelationshipDependency(
-        canonicalSelf,
-        relativeTo,
-        this.#realmURL,
-        this.#virtualNetwork,
-        this.#canonicalURLMemo,
-      ),
-    );
+    for (let form of relationshipDependencyForms(
+      canonicalSelf,
+      relativeTo,
+      this.#realmURL,
+      this.#virtualNetwork,
+      this.#canonicalURLMemo,
+    )) {
+      selfUrls.add(form);
+    }
     if (canonicalSelf.endsWith('.json')) {
       selfUrls.add(canonicalSelf.replace(/\.json$/, ''));
     } else {
@@ -113,15 +113,16 @@ export class RelationshipDependencyExtractor {
 
       let maybeId = (value as { id?: unknown }).id;
       if (typeof maybeId === 'string') {
-        let normalized = normalizeRelationshipDependency(
+        for (let form of relationshipDependencyForms(
           maybeId,
           relativeTo,
           this.#realmURL,
           this.#virtualNetwork,
           this.#canonicalURLMemo,
-        );
-        if (normalized && !selfUrls.has(normalized)) {
-          deps.add(normalized);
+        )) {
+          if (form && !selfUrls.has(form)) {
+            deps.add(form);
+          }
         }
       }
 
@@ -191,28 +192,30 @@ export class RelationshipDependencyExtractor {
       relativeTo.href,
       this.#virtualNetwork,
     )) {
-      let normalized = normalizeRelationshipDependency(
+      for (let form of relationshipDependencyForms(
         id,
         relativeTo,
         this.#realmURL,
         this.#virtualNetwork,
         this.#canonicalURLMemo,
-      );
-      if (normalized) {
-        deps.add(normalized);
+      )) {
+        if (form) {
+          deps.add(form);
+        }
       }
     }
     let selfLink = relationship.links?.self;
     if (typeof selfLink === 'string' && selfLink.length > 0) {
-      let normalized = normalizeRelationshipDependency(
+      for (let form of relationshipDependencyForms(
         selfLink,
         relativeTo,
         this.#realmURL,
         this.#virtualNetwork,
         this.#canonicalURLMemo,
-      );
-      if (normalized) {
-        deps.add(normalized);
+      )) {
+        if (form) {
+          deps.add(form);
+        }
       }
     }
   }

--- a/packages/runtime-common/index-runner/relationship-dependency-extractor.ts
+++ b/packages/runtime-common/index-runner/relationship-dependency-extractor.ts
@@ -120,7 +120,7 @@ export class RelationshipDependencyExtractor {
           this.#virtualNetwork,
           this.#canonicalURLMemo,
         )) {
-          if (form && !selfUrls.has(form)) {
+          if (!selfUrls.has(form)) {
             deps.add(form);
           }
         }
@@ -199,9 +199,7 @@ export class RelationshipDependencyExtractor {
         this.#virtualNetwork,
         this.#canonicalURLMemo,
       )) {
-        if (form) {
-          deps.add(form);
-        }
+        deps.add(form);
       }
     }
     let selfLink = relationship.links?.self;
@@ -213,9 +211,7 @@ export class RelationshipDependencyExtractor {
         this.#virtualNetwork,
         this.#canonicalURLMemo,
       )) {
-        if (form) {
-          deps.add(form);
-        }
+        deps.add(form);
       }
     }
   }


### PR DESCRIPTION
## Background

Every card the indexer processes records a list of **dependencies** — the other resources whose contents its own index row was built from. That list is what makes invalidation work: when something in a realm is written, the indexer looks for rows whose deps mention the written URL and re-indexes those consumers.

The match is an exact string comparison against the written resource's row URL (`itemsThatReference`), and the two kinds of resource are addressed differently:

- a **card instance** has its row at `<id>.json` — the `.json` is part of the row URL but stripped from the card's id
- a **file** has its row at the file's own URL, extension and all

So a dep pointing at a card instance has to be recorded with `.json` appended, and a dep pointing at a file has to be recorded without. Record one in the other's form and it matches nothing: writing the target finds no consumers, and they go on serving stale index data until something else happens to invalidate them.

Two functions decide which kind a dep URL names, and both ask "does the last path segment contain a dot?":

```ts
// dependency-tracker.ts — the runtime tracker, recording deps as a card renders
return segment.length > 0 && segment.includes('.');

// index-runner/dependency-normalization.ts — relationship deps, from serialized data
return !lastSegment.includes('.');
```

Card ids carry dots freely, though. A `ModelConfiguration/claude-sonnet-4.6` instance has one; so does a `hello.test` instance sitting beside the `hello.test.gts` module it exercises. Every such id reads as already carrying an extension, so it never picks up the `.json` its row is keyed on, and consumers linking to it stop being invalidated when it changes.

`urlNamesFile` in `file-def-code-ref.ts` already draws this line the other way round for precisely this reason — only an extension in the FileDef registry counts as naming a file, so a dotted card id isn't mistaken for one. This lines the two dependency paths up with that.

## Instance deps in the runtime tracker

Here the question doesn't arise: file targets reach the tracker through `trackFile`, so a reference passed to `trackInstance` is always a card id. `normalizeInstanceURL` appends `.json` unless the reference already ends in it, which is also what `card-api` does when it turns a link reference into its stored form.

This normalization runs on every field-getter access during a render, so it stays a suffix compare on a string rather than a URL parse.

## Relationship deps in the index runner

Here it does arise: the same URL can be either kind, and only the two ends of the range are decidable.

- a FileDef-registry extension, or an executable extension a module is served under → a **file**
- a last segment with no dot at all → a **card instance**, since an instance's `.json` is stripped from its id
- a dotted suffix in neither set → **undecidable**. `hello.test` is as plausibly a card id as `report.pdf` is a file whose extension the registry doesn't happen to name.

For that middle case `relationshipDependencyForms` returns both candidate forms rather than guessing. Deps are a match set, so the form that turns out wrong simply never matches anything, while guessing wrong costs the consumer its invalidation entirely. Callers already collect deps into a `Set`, so this is a loop instead of an assignment at four call sites in `relationship-dependency-extractor.ts`.

Worth knowing where this output actually lands: relationship-derived deps reach a persisted row only on the error paths — `card-indexer.ts` builds them inside its `!renderResult || 'error' in renderResult` branch, and `file-indexer.ts` inside its `extractResult.status === 'error'` branch. A successful index takes its deps from the runtime tracker snapshot alone. So the extra string is confined to error rows, and the tracker change above is what carries invalidation for healthy rows.

Relationship-error traversal (`canTraverseRelationshipDependency`) admits every dep that *could* name a row, undecidable ones included, on the same asymmetry: a dep that names no row reads as a miss and traversal stops there, so admitting one costs a lookup rather than correctness. What it excludes is the dep that reads as a bare instance id — a module reference in node-resolution form, which has no row under that URL and whose errors reach a consumer through the definition cache instead. It asks the shared classifier (`namedResourceForPath`) rather than testing for a dot itself, so the two can't drift apart; the classifier can only answer "file" when the last segment has a dot, which makes "not an instance id" and "has a dotted last segment" the same test.

That predicate is not confined to error rows: the index-backed dependency-error scan runs it once per dep on every visit, successful ones included, so both the predicate and the classifier are built for that loop. The whole path is string-only — no `new URL()` per dep. Both call sites hand the predicate `normalizeStoredDependency` output, which is already a canonical href (or a prefix form the memoized `VirtualNetwork#toURLHref` converts to one), so parsing it again would only re-derive the same string; a dep that isn't a canonical URL fails the realm-prefix gate, the same rejection URL-parsing produces. Inside the classifier the dotless test — one `lastIndexOf` and one `includes`, no `split` allocation — runs first and alone settles the dominant case (module deps are stored with their executable extension stripped, so most deps are dotless); the FileDef-registry and executable-extension walks only run for the dotted minority. Measured over a representative dep mix, the string-only predicate costs ~218ns/call against ~703ns for a `new URL`-per-dep spelling, and the classifier ordering is what keeps the dominant case from paying for the registry walk (registry-first ordering measures 2.6× the dotless-first form). The render-side tracker keeps its string-only fast path too: the `.json` suffix compare is a plain `endsWith` with no allocation, and it sits behind the tracker's normalize memo besides.

## Scope

The FileDef extension registry is the one place that decides "file" for the decidable end of the range: it drives the FileDef subtype a file link adopts, the mime a cross-realm file link is fetched with, and the dep form here. Extensions it doesn't name are undecidable and get both forms — correct, at the cost of one extra dep string per such link. Naming them in the registry moves them to the decidable end, here and everywhere else that consults it.

One id shape stays wrong, in both paths and by the same amount as before: a card id that itself ends in `.json` (an instance file `config.json.json`) reads as already being in stored form, so its dep lands at `config.json` while its row is at `config.json.json`. Both the registry test and the tracker's suffix test rely on `.json` belonging to the row rather than the id.

## Testing

`packages/realm-server/tests/dependency-normalization-test.ts` (new) drives `relationshipDependencyForms` and `canTraverseRelationshipDependency` against a stub virtual network: extensionless card ids, relative references, files whose extension the registry names, dotted names it doesn't (`hello.test`, `claude-sonnet-4.6`, `report.pdf`, `.gitignore`), casing and `.d.ts`, prefix-form deps in each of those shapes, out-of-realm deps, deps that are not URLs at all, and deps carrying a query or hash (classified by path alone, so a dotted query string neither hides an extension nor invents one).

`runtime-dependency-tracker-test.ts` adds a case for instance deps landing at their `.json` URL with dotted card ids included, and for a reference already in `.json` form not picking up a second suffix.

`indexing-test.ts` adds the end-to-end case the unit tests stand in for: a consumer links to a `hello.test` instance, its deps carry `hello.test.json`, and writing that instance invalidates the consumer.

Run locally against the `test-services:realm-server` stack, alongside the rest of `indexing-test.ts`, `card-dependencies-endpoint-test.ts`, and `realm-index-updater-test.ts` — the modules that assert dep contents end to end, including the existing checks that instance relationship deps use the concrete `.json` form, that glimmer scoped CSS deps survive, that relationship cycles still resolve, and that FileDef `linksTo`/`linksToMany` deps are tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
