### PR TITLE
Fix flaky ai-assistant reupload tests: wait for mock homeserver delivery

### DIFF
--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -53,6 +53,7 @@ import {
   internalKeyFor,
   isCardInstance,
   resolveFileDefCodeRef,
+  stringifyErrorForLog,
   SupportedMimeType,
 } from '@cardstack/runtime-common';
 import { DEFAULT_FALLBACK_MODELS } from '@cardstack/runtime-common/matrix-constants';
@@ -1722,7 +1723,14 @@ export default class Room extends Component<Signature> {
           context,
         );
       } catch (e) {
-        console.error(e);
+        // Console sinks stringify a thrown plain object as "[object Object]",
+        // which hides the actual failure; serialize it so the reason survives
+        // into captured browser logs.
+        console.error(
+          `message send pipeline threw (clientGeneratedId=${clientGeneratedId}): ${stringifyErrorForLog(
+            e,
+          )}`,
+        );
 
         // Inverse delivery race: client.sendEvent may have already handed the
         // event to matrix (status === 'sent') before a downstream throw escaped

--- a/packages/host/tests/helpers/mock-matrix/_utils.ts
+++ b/packages/host/tests/helpers/mock-matrix/_utils.ts
@@ -1,4 +1,5 @@
 import type Owner from '@ember/owner';
+import { waitUntil } from '@ember/test-helpers';
 
 import type { RealmAction } from '@cardstack/runtime-common';
 import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
@@ -22,6 +23,37 @@ export class MockUtils {
   ) {}
   getRoomEvents = (roomId: string) => {
     return this.testState.sdk!.getRoomEvents(roomId);
+  };
+  // Wait until the mock homeserver holds at least `count` m.room.message
+  // events for the room, then return them. Sending a message renders an
+  // optimistic bubble at click-time while the pre-send pipeline (context
+  // summary, card/file serialization, media uploads) continues past
+  // `settled()` — those legs run outside any test waiter, and only the final
+  // sendEvent dispatch is waiter-tracked via the room mutex. DOM-based waits
+  // therefore prove nothing about server-side delivery; assertions on
+  // `getRoomEvents` must wait on the server state itself.
+  waitForRoomMessages = async (roomId: string, count: number) => {
+    let messages = () =>
+      this.getRoomEvents(roomId).filter((e) => e.type === 'm.room.message');
+    try {
+      await waitUntil(() => messages().length >= count, { timeout: 10_000 });
+    } catch (e) {
+      // Dump the room's actual events so a send that failed (its optimistic
+      // bubble stays client-side and never reaches the mock homeserver) is
+      // distinguishable from a send that is merely slow.
+      let events = this.getRoomEvents(roomId);
+      throw new Error(
+        `timed out waiting for ${count} m.room.message event(s) in ${roomId}; ` +
+          `mock homeserver has ${events.length} event(s): ` +
+          JSON.stringify(
+            events.map((event) => ({
+              type: event.type,
+              event_id: event.event_id,
+            })),
+          ),
+      );
+    }
+    return messages();
   };
   getRoomIds = () => {
     // A realm can fire a deferred `broadcastRealmEvent` (the trailing `index`

--- a/packages/host/tests/helpers/mock-matrix/_utils.ts
+++ b/packages/host/tests/helpers/mock-matrix/_utils.ts
@@ -28,10 +28,10 @@ export class MockUtils {
   // events for the room, then return them. Sending a message renders an
   // optimistic bubble at click-time while the pre-send pipeline (context
   // summary, card/file serialization, media uploads) continues past
-  // `settled()` — those legs run outside any test waiter, and only the final
-  // sendEvent dispatch is waiter-tracked via the room mutex. DOM-based waits
-  // therefore prove nothing about server-side delivery; assertions on
-  // `getRoomEvents` must wait on the server state itself.
+  // `settled()` — those legs run outside any test waiter; only the mutex
+  // dispatches (the sendEvent and room-state legs) are waiter-tracked.
+  // DOM-based waits therefore prove nothing about server-side delivery;
+  // assertions on `getRoomEvents` must wait on the server state itself.
   waitForRoomMessages = async (roomId: string, count: number) => {
     let messages = () =>
       this.getRoomEvents(roomId).filter((e) => e.type === 'm.room.message');

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -1301,6 +1301,10 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
       'First message with card',
     );
     await click('[data-test-send-message-btn]');
+    // Wait out each send before clicking the next: while a send pipeline is
+    // in flight the send button is a no-op, so a premature click would drop
+    // the message instead of queueing it.
+    await waitForRoomMessages(roomId, 1);
 
     // Send second message with the same card
     await fillIn(
@@ -1389,6 +1393,10 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
       'First message with file',
     );
     await click('[data-test-send-message-btn]');
+    // Wait out each send before clicking the next: while a send pipeline is
+    // in flight the send button is a no-op, so a premature click would drop
+    // the message instead of queueing it.
+    await waitForRoomMessages(roomId, 1);
 
     // Send second message with the same file
     await fillIn(
@@ -1443,7 +1451,6 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
       'Third message with modified file',
     );
     await click('[data-test-send-message-btn]');
-    await waitFor('[data-test-message-idx="2"]');
 
     // Get the third message event
     messageEvents = await waitForRoomMessages(roomId, 3);

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -97,7 +97,7 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
     createAndJoinRoom,
     simulateRemoteMessage,
     setReadReceipt,
-    getRoomEvents,
+    waitForRoomMessages,
   } = mockMatrixUtils;
 
   // Setup realm server endpoints for summarization tests
@@ -1310,9 +1310,7 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
     await click('[data-test-send-message-btn]');
 
     // Get the first two message events
-    let messageEvents = getRoomEvents(roomId).filter(
-      (e) => e.type === 'm.room.message',
-    );
+    let messageEvents = await waitForRoomMessages(roomId, 2);
     let firstMessageEvent = messageEvents[0];
     let secondMessageEvent = messageEvents[1];
     let firstMessageData = firstMessageEvent.content.data
@@ -1354,9 +1352,7 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
     await click('[data-test-send-message-btn]');
 
     // Get the third message event
-    messageEvents = getRoomEvents(roomId).filter(
-      (e) => e.type === 'm.room.message',
-    );
+    messageEvents = await waitForRoomMessages(roomId, 3);
     let thirdMessageEvent = messageEvents[2];
     let thirdMessageData = thirdMessageEvent.content.data
       ? JSON.parse(thirdMessageEvent.content.data)
@@ -1402,9 +1398,7 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
     await click('[data-test-send-message-btn]');
 
     // Get the first two message events
-    let messageEvents = getRoomEvents(roomId).filter(
-      (e) => e.type === 'm.room.message',
-    );
+    let messageEvents = await waitForRoomMessages(roomId, 2);
     let firstMessageEvent = messageEvents[0];
     let secondMessageEvent = messageEvents[1];
     let firstMessageData = firstMessageEvent.content.data
@@ -1452,9 +1446,7 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
     await waitFor('[data-test-message-idx="2"]');
 
     // Get the third message event
-    messageEvents = getRoomEvents(roomId).filter(
-      (e) => e.type === 'm.room.message',
-    );
+    messageEvents = await waitForRoomMessages(roomId, 3);
     let thirdMessageEvent = messageEvents[2];
     let thirdMessageData = thirdMessageEvent.content.data
       ? JSON.parse(thirdMessageEvent.content.data)


### PR DESCRIPTION
Host CI intermittently fails `Integration | ai-assistant-panel | general: ensures files are reuploaded only when content changes` with:

```
TypeError: Cannot read properties of undefined (reading 'content')
```

(e.g. [this run](https://github.com/cardstack/boxel/actions/runs/30579835323/job/91017660678)).

The AI assistant renders the user's message bubble optimistically at click-time, before the pre-send pipeline (context summary, card/file serialization, media uploads) runs. Only the final `sendEvent` dispatch is tracked by a test waiter (through the room mutex); the upload legs cross `settled()` untracked. So neither `await click('[data-test-send-message-btn]')` nor a DOM wait like `waitFor('[data-test-message-idx="2"]')` proves the message reached the mock homeserver — the optimistic bubble satisfies the DOM condition while `getRoomEvents()` can still be one event short, and indexing one past the recorded events throws the `TypeError` above. The files variant of the reupload test is the most exposed because its third send re-uploads the changed file while the code editor's auto-save and reindex churn in the background, but the cards variant shares the same read-after-click shape.

Changes:

- `MockUtils.waitForRoomMessages(roomId, count)`: waits until the mock homeserver holds at least `count` `m.room.message` events and returns them. On timeout it throws with a dump of the room's recorded events, so a send that failed outright (its optimistic bubble never converts into a server event) is distinguishable from one that is merely slow.
- The two reupload tests (cards and files) read room events through the helper instead of immediately after the click.
- `doSendMessage`'s catch serializes the thrown value via `stringifyErrorForLog` and tags it with the `clientGeneratedId`. Captured CI browser logs render a thrown plain object as `[object Object]`, which hides the failure reason; the serialized form keeps send-pipeline failures diagnosable from test artifacts.

Other ai-assistant-panel tests (e.g. binary-upload-dedupe, file-attachment) share the read-after-click pattern and can adopt the helper if they flake; this PR fixes the failing test and its structural twin.

Test plan:

- With an untracked 150ms delay injected into the mock's `uploadContent` before the third send, the unfixed files test fails with the exact CI signature; with the fix in place it passes under the same delay.
- Both reupload tests pass 8/8 consecutive `ember test --path dist` runs against the local stack.
- `ember-tsc` and eslint are clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
