### PR TITLE
Fix .json wrongly appended when opening a file search result in code submode

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -49,7 +49,6 @@ import CodeSubmodeEditorIndicator from '@cardstack/host/components/operator-mode
 import ModuleInspector from '@cardstack/host/components/operator-mode/code-submode/module-inspector';
 
 import consumeContext from '@cardstack/host/helpers/consume-context';
-import { knownFileMetaUrls } from '@cardstack/host/lib/known-file-meta-urls';
 import type { FileResource } from '@cardstack/host/resources/file';
 import type {
   ModuleDeclaration,
@@ -65,6 +64,7 @@ import type RealmService from '@cardstack/host/services/realm';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 import type SpecPanelService from '@cardstack/host/services/spec-panel-service';
 import type StoreService from '@cardstack/host/services/store';
+import type { SearchResultKind } from '@cardstack/host/utils/search/types';
 
 import {
   CodeModePanelWidths,
@@ -646,16 +646,20 @@ export default class CodeSubmode extends Component<Signature> {
     this.updateCursorByName = updateCursorByName;
   };
 
-  @action private async openSearchResultInEditor(cardId: string) {
+  @action private async openSearchResultInEditor(
+    cardId: string,
+    kind?: SearchResultKind,
+  ) {
     // A card instance's id is the URL without `.json`, so its source file is
-    // `<id>.json`. A file result's id is already the real file URL and must be
-    // opened as-is. Prerendered search delivers file rows HTML-only, so the
-    // file-meta resource may not be in the Store yet — consult the same
-    // `knownFileMetaUrls` registry the interact-mode click paths rely on.
+    // `<id>.json`; a file result's id is already the real file URL and opens
+    // as-is. The search result carries its own card/file `kind`, so the target
+    // is resolved from that rather than guessed from the id string. `kind` is
+    // absent only for a selection that never came from a search entry — fall
+    // back to the id's own `.json` shape there.
     let codePath =
-      knownFileMetaUrls.has(cardId) || cardId.endsWith('.json')
+      kind === 'file'
         ? rri(cardId)
-        : rri(`${cardId}.json`);
+        : rri(cardId.endsWith('.json') ? cardId : `${cardId}.json`);
     await this.operatorModeStateService.updateCodePath(codePath);
   }
 

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -49,6 +49,7 @@ import CodeSubmodeEditorIndicator from '@cardstack/host/components/operator-mode
 import ModuleInspector from '@cardstack/host/components/operator-mode/code-submode/module-inspector';
 
 import consumeContext from '@cardstack/host/helpers/consume-context';
+import { knownFileMetaUrls } from '@cardstack/host/lib/known-file-meta-urls';
 import type { FileResource } from '@cardstack/host/resources/file';
 import type {
   ModuleDeclaration,
@@ -646,9 +647,15 @@ export default class CodeSubmode extends Component<Signature> {
   };
 
   @action private async openSearchResultInEditor(cardId: string) {
-    let codePath = cardId.endsWith('.json')
-      ? rri(cardId)
-      : rri(`${cardId}.json`);
+    // A card instance's id is the URL without `.json`, so its source file is
+    // `<id>.json`. A file result's id is already the real file URL and must be
+    // opened as-is. Prerendered search delivers file rows HTML-only, so the
+    // file-meta resource may not be in the Store yet — consult the same
+    // `knownFileMetaUrls` registry the interact-mode click paths rely on.
+    let codePath =
+      knownFileMetaUrls.has(cardId) || cardId.endsWith('.json')
+        ? rri(cardId)
+        : rri(`${cardId}.json`);
     await this.operatorModeStateService.updateCodePath(codePath);
   }
 

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -61,7 +61,10 @@ import { idFromCardOrURL } from '@cardstack/host/utils/id-from-card-or-url';
 
 import consumeContext from '../../helpers/consume-context';
 
-import { removeCardJsonExtension } from '../../utils/search/types';
+import {
+  removeCardJsonExtension,
+  type SearchResultKind,
+} from '../../utils/search/types';
 
 import CopyButton from './copy-button';
 import DeleteModal from './delete-modal';
@@ -624,10 +627,14 @@ export default class InteractSubmode extends Component {
   }
 
   private openSelectedSearchResultInStack = restartableTask(
-    async (cardId: string) => {
+    async (cardId: string, kind?: SearchResultKind) => {
       let waiterToken = waiter.beginAsync();
       try {
         let searchSheetTrigger = this.searchSheetTrigger; // Will be set by showSearchWithTrigger
+        // The selected result carries its own card/file `kind`; honor it so the
+        // stack item opens as the right type without re-deriving it. Absent
+        // `kind` falls back to the existing detection (`getStackItemType` /
+        // `viewCard`).
 
         // In case the left button was clicked, whatever is currently in stack with index 0 will be moved to stack with index 1,
         // and the card will be added to stack with index 0. shiftStack executes this logic.
@@ -639,7 +646,7 @@ export default class InteractSubmode extends Component {
             id: cardId,
             format: 'isolated',
             stackIndex: 0,
-            type: this.getStackItemType(cardId, cardId),
+            type: kind ?? this.getStackItemType(cardId, cardId),
           });
           // it's important that we await the stack item readiness _before_
           // we mutate the stack, otherwise there are very odd visual artifacts
@@ -660,7 +667,9 @@ export default class InteractSubmode extends Component {
           searchSheetTrigger ===
           SearchSheetTriggers.DropCardToRightNeighborStackButton
         ) {
-          await this.viewCard(this.stacks.length, cardId, 'isolated');
+          await this.viewCard(this.stacks.length, cardId, 'isolated', {
+            type: kind,
+          });
         } else {
           // In case, that the search was accessed directly without clicking right and left buttons,
           // the rightmost stack will be REPLACED by the selection
@@ -672,7 +681,7 @@ export default class InteractSubmode extends Component {
             numberOfStacks === 0 ||
             this.operatorModeStateService.stackIsEmpty(stackIndex)
           ) {
-            await this.viewCard(0, cardId, 'isolated');
+            await this.viewCard(0, cardId, 'isolated', { type: kind });
           } else {
             stack = this.operatorModeStateService.rightMostStack();
             if (stack) {
@@ -682,7 +691,7 @@ export default class InteractSubmode extends Component {
                   id: cardId,
                   format: 'isolated',
                   stackIndex,
-                  type: this.getStackItemType(cardId, cardId),
+                  type: kind ?? this.getStackItemType(cardId, cardId),
                 });
                 // await stackItem.ready();
                 this.operatorModeStateService.clearStackAndAdd(

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -37,6 +37,7 @@ import type IndexController from '@cardstack/host/controllers';
 
 import { assertNever } from '@cardstack/host/utils/assert-never';
 import { AiAssistantPanelWidth } from '@cardstack/host/utils/local-storage-keys';
+import type { SearchResultKind } from '@cardstack/host/utils/search/types';
 
 import SearchSheet, { SearchSheetModes } from '../search-sheet';
 
@@ -61,7 +62,7 @@ interface Signature {
   Args: {
     onSearchSheetOpened?: () => void;
     onSearchSheetClosed?: () => void;
-    onCardSelectFromSearch?: (cardId: string) => void;
+    onCardSelectFromSearch?: (cardId: string, kind?: SearchResultKind) => void;
     selectedCardRef?: ResolvedCodeRef | undefined;
     newFileOptions?: NewFileOptions;
   };
@@ -364,8 +365,11 @@ export default class SubmodeLayout extends Component<Signature> {
     this.args.onSearchSheetOpened?.();
   }
 
-  @action private async handleCardSelectFromSearch(cardId: string) {
-    this.args.onCardSelectFromSearch?.(cardId);
+  @action private async handleCardSelectFromSearch(
+    cardId: string,
+    kind?: SearchResultKind,
+  ) {
+    this.args.onCardSelectFromSearch?.(cardId, kind);
     this.closeSearchSheet();
   }
 

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -25,6 +25,7 @@ import type { ResolvedCodeRef } from '@cardstack/runtime-common';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 import type SearchSheetStateService from '@cardstack/host/services/search-sheet-state';
 import { SEARCH_SHEET_BASE_FILTER } from '@cardstack/host/services/search-sheet-state';
+import type { SearchResultKind } from '@cardstack/host/utils/search/types';
 import {
   isURLSearchKey,
   resolveSearchKeyAsURL,
@@ -57,7 +58,7 @@ interface Signature {
     onFocus: () => void;
     onBlur: () => void;
     onSearch: (term: string) => void;
-    onCardSelect: (cardId: string) => void;
+    onCardSelect: (cardId: string, kind?: SearchResultKind) => void;
     onInputInsertion?: (element: HTMLElement) => void;
     onFilterChange?: () => void;
   };
@@ -158,12 +159,17 @@ export default class SearchSheet extends Component<Signature> {
     this.args.onBlur();
   }
 
-  @action private handleCardSelect(selection: string | { realmURL: string }) {
+  @action private handleCardSelect(
+    selection: string | { realmURL: string },
+    kind?: SearchResultKind,
+  ) {
     if (typeof selection !== 'string') {
       return;
     }
-    // Selecting a result keeps the search, so reopening returns to it.
-    this.args.onCardSelect(selection);
+    // Selecting a result keeps the search, so reopening returns to it. `kind`
+    // carries the result's card/file classification so the consumer opens the
+    // right URL without re-deriving it from the id.
+    this.args.onCardSelect(selection, kind);
   }
 
   @action

--- a/packages/host/app/components/search/panel-content.gts
+++ b/packages/host/app/components/search/panel-content.gts
@@ -36,7 +36,10 @@ import {
   shouldSkipSearchQuery,
 } from '@cardstack/host/utils/search/query-builder';
 import { SectionPagination } from '@cardstack/host/utils/search/section-pagination';
-import type { NewCardArgs } from '@cardstack/host/utils/search/types';
+import type {
+  NewCardArgs,
+  SearchResultKind,
+} from '@cardstack/host/utils/search/types';
 import {
   isURLSearchKey,
   resolveSearchKeyAsURL,
@@ -119,7 +122,10 @@ interface Signature {
     // by default; the card choosers set this so file rows never surface.
     cardsOnly?: boolean;
     isCompact: boolean;
-    handleSelect: (selection: string | NewCardArgs) => void;
+    handleSelect: (
+      selection: string | NewCardArgs,
+      kind?: SearchResultKind,
+    ) => void;
     selectedCards?: (string | NewCardArgs)[];
     multiSelect?: boolean;
     onSelectAll?: (cards: string[]) => void;
@@ -128,7 +134,10 @@ interface Signature {
       ref: CodeRef;
       relativeTo: URL | undefined;
     };
-    onSubmit?: (selection: string | NewCardArgs) => void;
+    onSubmit?: (
+      selection: string | NewCardArgs,
+      kind?: SearchResultKind,
+    ) => void;
     showHeader?: boolean;
     activeSort: SortOption;
     onSortChange: (sort: SortOption) => void;

--- a/packages/host/app/components/search/result-section.gts
+++ b/packages/host/app/components/search/result-section.gts
@@ -28,6 +28,7 @@ import type {
 import {
   removeCardJsonExtension,
   type NewCardArgs,
+  type SearchResultKind,
 } from '@cardstack/host/utils/search/types';
 
 import { SECTION_SHOW_MORE_INCREMENT } from './constants';
@@ -69,7 +70,10 @@ interface Signature {
     section: SearchSheetSection;
     viewOption?: string;
     isCompact?: boolean;
-    handleSelect: (selection: string | NewCardArgs) => void;
+    handleSelect: (
+      selection: string | NewCardArgs,
+      kind?: SearchResultKind,
+    ) => void;
     isFocused?: boolean;
     isCollapsed?: boolean;
     onFocusSection?: (sectionId: string | null) => void;
@@ -81,7 +85,10 @@ interface Signature {
       ref: CodeRef;
       relativeTo: URL | undefined;
     };
-    onSubmit?: (selection: string | NewCardArgs) => void;
+    onSubmit?: (
+      selection: string | NewCardArgs,
+      kind?: SearchResultKind,
+    ) => void;
     // When true, the tiles render the Adorn visual treatment (teal hover
     // type-label tab + selection chip) rather than the plain grey
     // hover/selection visuals.

--- a/packages/host/app/components/search/result-tile.gts
+++ b/packages/host/app/components/search/result-tile.gts
@@ -24,6 +24,7 @@ import { htmlComponent } from '@cardstack/host/lib/html-component';
 import {
   removeCardJsonExtension,
   type NewCardArgs,
+  type SearchResultKind,
 } from '@cardstack/host/utils/search/types';
 
 import CardRenderer from '../card-renderer';
@@ -54,8 +55,18 @@ interface Signature {
     newCard?: NewCardArgs;
     isSelected: boolean;
     multiSelect?: boolean;
-    onSelect: (selection: string | NewCardArgs) => void;
-    onSubmit?: (selection: string | NewCardArgs) => void;
+    // `kind` carries the selected result's card/file classification (absent for
+    // the "Create New" affordance) so the open handler resolves the right URL
+    // without re-parsing the id. Intermediate components forward these callbacks
+    // by reference, so the arg reaches the consumer untouched.
+    onSelect: (
+      selection: string | NewCardArgs,
+      kind?: SearchResultKind,
+    ) => void;
+    onSubmit?: (
+      selection: string | NewCardArgs,
+      kind?: SearchResultKind,
+    ) => void;
     // When true, render the Adorn visual treatment: a teal hover type-label
     // tab, teal hover/selection outline, and a teal selection chip in place of
     // the plain grey selection circle.
@@ -156,34 +167,47 @@ export default class SearchResultTile extends Component<Signature> {
     return this.resolvedItemId as string;
   }
 
+  // The card/file kind travelling with the payload. An entry row carries its
+  // own classification; the URL-paste live card is always a card; the "Create
+  // New" affordance has no id, so it carries no kind.
+  private get selectionKind(): SearchResultKind | undefined {
+    if (this.args.newCard) {
+      return undefined;
+    }
+    if (this.args.entry) {
+      return this.args.entry.type === 'file-meta' ? 'file' : 'card';
+    }
+    return this.args.card ? 'card' : undefined;
+  }
+
   @action handleClick() {
     if (this.isNewCard) {
       // "Create New" always submits immediately, even in multi-select mode.
-      this.args.onSelect(this.selectPayload);
-      this.args.onSubmit?.(this.selectPayload);
+      this.args.onSelect(this.selectPayload, this.selectionKind);
+      this.args.onSubmit?.(this.selectPayload, this.selectionKind);
       return;
     }
-    this.args.onSelect(this.selectPayload);
+    this.args.onSelect(this.selectPayload, this.selectionKind);
   }
 
   @action handleDblClick() {
     if (this.args.multiSelect && !this.isNewCard) {
       // In multi-select, double-click just toggles for existing cards.
-      this.args.onSelect(this.selectPayload);
+      this.args.onSelect(this.selectPayload, this.selectionKind);
       return;
     }
-    this.args.onSelect(this.selectPayload);
-    this.args.onSubmit?.(this.selectPayload);
+    this.args.onSelect(this.selectPayload, this.selectionKind);
+    this.args.onSubmit?.(this.selectPayload, this.selectionKind);
   }
 
   @action handleKeydown(event: Event) {
     if ((event as KeyboardEvent).key === 'Enter') {
       if (this.args.multiSelect && !this.isNewCard) {
-        this.args.onSelect(this.selectPayload);
+        this.args.onSelect(this.selectPayload, this.selectionKind);
         return;
       }
-      this.args.onSelect(this.selectPayload);
-      this.args.onSubmit?.(this.selectPayload);
+      this.args.onSelect(this.selectPayload, this.selectionKind);
+      this.args.onSubmit?.(this.selectPayload, this.selectionKind);
     }
   }
 

--- a/packages/host/app/components/search/sheet-results.gts
+++ b/packages/host/app/components/search/sheet-results.gts
@@ -26,7 +26,10 @@ import {
   type RecentsSection,
   type SearchSheetSection,
 } from '@cardstack/host/utils/search/sections';
-import type { NewCardArgs } from '@cardstack/host/utils/search/types';
+import type {
+  NewCardArgs,
+  SearchResultKind,
+} from '@cardstack/host/utils/search/types';
 
 import { SORT_OPTIONS, VIEW_OPTIONS, type SortOption } from './constants';
 import ResultSection from './result-section';
@@ -77,8 +80,14 @@ interface Signature {
     onChangeSort: (option: SortOption) => void;
 
     // Selection + submit.
-    handleSelect: (selection: string | NewCardArgs) => void;
-    onSubmit?: (selection: string | NewCardArgs) => void;
+    handleSelect: (
+      selection: string | NewCardArgs,
+      kind?: SearchResultKind,
+    ) => void;
+    onSubmit?: (
+      selection: string | NewCardArgs,
+      kind?: SearchResultKind,
+    ) => void;
     multiSelect?: boolean;
     selectedCards?: (string | NewCardArgs)[];
     onSelectAll?: (cards: string[]) => void;

--- a/packages/host/app/utils/search/types.ts
+++ b/packages/host/app/utils/search/types.ts
@@ -6,6 +6,14 @@ export interface NewCardArgs {
   realmURL: string;
 }
 
+// A selected search result's card/file classification, threaded alongside the
+// selected id so the consumer opens the right URL — a card's source file is
+// `<id>.json`, a file's id already is its URL — without re-deriving the type
+// from the id string (or a stale side registry). Maps directly onto
+// `StackItemType`. Absent when a selection did not originate from a search
+// entry (e.g. a "Create New" affordance).
+export type SearchResultKind = 'card' | 'file';
+
 // Normalizes an id that may carry the card `.json` file convention down to the
 // canonical extensionless card id. Only `.json` is stripped: a file entry's id
 // (`….md`, `….gts`, …) IS its canonical id, and stripping its extension would

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -718,6 +718,7 @@ module('Acceptance | code submode tests', function (_hooks) {
               },
             },
             'not-json.json': 'I am not JSON.',
+            'care-guide.md': '# Care Guide\n\nWater weekly.\n',
             'Person/fadhlan.json': {
               data: {
                 attributes: {
@@ -1827,6 +1828,39 @@ module('Acceptance | code submode tests', function (_hooks) {
           },
         },
       });
+    });
+
+    test('Clicking a file in search panel opens the file itself (no .json appended)', async function (assert) {
+      await visitOperatorMode({
+        submode: 'code',
+        codePath: `${testRealmURL}employee.gts`,
+      });
+
+      await click('[data-test-open-search-field]');
+      await fillIn('[data-test-search-field]', 'care-guide');
+
+      await waitFor(
+        `[data-test-search-result="${testRealmURL}care-guide.md"]`,
+        {
+          timeout: 2000,
+        },
+      );
+
+      // Click on the file result
+      await click(`[data-test-search-result="${testRealmURL}care-guide.md"]`);
+
+      assert.dom('[data-test-search-sheet]').doesNotHaveClass('results'); // Search sheet is closed
+      await waitFor('[data-test-card-url-bar-input]');
+      assert
+        .dom('[data-test-card-url-bar-input]')
+        .hasValue(
+          `${testRealmURL}care-guide.md`,
+          'the file opens at its own URL, without a .json extension appended',
+        );
+      assert.true(
+        getMonacoContent().includes('Care Guide'),
+        'the markdown file content is loaded in the editor',
+      );
     });
 
     test('clicking a linksTo field in card renderer panel opens the linked card JSON', async function (assert) {

--- a/packages/host/tests/integration/components/search-adorn-test.gts
+++ b/packages/host/tests/integration/components/search-adorn-test.gts
@@ -25,6 +25,7 @@ function entry(
 ): RenderableSearchEntryLike {
   return {
     id: 'http://test/Foo/1',
+    type: 'card',
     realmUrl: 'http://test/',
     name: 'Foo/1',
     isError: false,

--- a/packages/runtime-common/search-results-component.ts
+++ b/packages/runtime-common/search-results-component.ts
@@ -42,6 +42,11 @@ export interface SearchEntryRendering {
 export interface RenderableSearchEntryLike {
   // The card/file identity URL.
   id: string;
+  // The result's card/file classification, resolved when the entry is built.
+  // Consumers thread this alongside `id` to open the right URL (a card's source
+  // is `<id>.json`; a file's `id` already is its URL) instead of re-deriving it
+  // from the string. Kept in sync with `StoreReadType`.
+  type: 'card' | 'file-meta';
   // The URL of the realm hosting this result — used to group results by realm.
   realmUrl: string;
   // The result's realm-local path (e.g. `Person/error`) — a readable label a


### PR DESCRIPTION
## Background and Goal

Clicking a search result in the search sheet while in **code submode** should open that item in the code editor. For a **card instance** this means opening `<id>.json` (the instance's id is the URL without the extension, and its source file is the `.json`). But since search now also returns **files** (`scope: 'all'`), a file result's id is already the real file URL — appending `.json` produced a non-existent `<file>.json` path.

The fix gates the `.json` append on the existing `knownFileMetaUrls` registry (`packages/host/app/lib/known-file-meta-urls.ts`), which records which search results are files as entries are built. This is the same registry the interact-mode click paths (`operator-mode-overlays.gts`, `lib/stack-item.ts`) already consult for exactly this "the file-meta resource isn't in the Store yet" situation — the code-submode search handler was the one click path that never learned about it. Card-instance behavior is unchanged.

Adds a code-submode acceptance test asserting a file result opens at its own URL with no `.json` appended.

Fixes CS-12402.