### PR TITLE
feat: add Realm Script notebooks and live activity

### DIFF
--- a/docs/realm-script-notebooks.md
+++ b/docs/realm-script-notebooks.md
@@ -1,0 +1,214 @@
+# Realm Script Notebooks
+
+Realm Script Notebooks let an LLM alternate between reasoning and isolated
+Realm Script cells without repeating expensive work or relying on a long-lived
+JavaScript heap. The same protocol is used by a Matrix room, `boxel realm
+script`, and the workspace `run-realm-script` tool.
+
+## What we borrow from Jupyter
+
+| Jupyter concept         | Realm Notebook equivalent                                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Notebook document       | A durable session containing named cell definitions                                                                      |
+| Code cell source        | Saved Realm Script source, mode, and input bindings                                                                      |
+| Cell output             | An immutable execution record and output reference                                                                       |
+| Execution count         | A monotonically increasing cell revision                                                                                 |
+| Run cell                | Execute saved or supplied source as a new revision                                                                       |
+| Run all / run from here | A client can replay saved cells in dependency order; a server-side batch replay command is a later orchestration feature |
+| Restart kernel          | Start a new session or clear aliases without changing saved source                                                       |
+| Clear output            | The model separates definitions from executions; a user-facing clear-history operation is still to be added              |
+| Autosave/checkpoint     | Storage-adapter writes after definition and execution transitions                                                        |
+| Parameterized notebook  | Explicit `realm.input` bindings sourced from earlier cells or caller JSON                                                |
+
+We deliberately do **not** borrow Jupyter's implicit mutable kernel heap.
+Every Realm Script still runs in a fresh QuickJS context. Cross-cell state is
+JSON data with recorded lineage, which avoids execution-order bugs and works
+after a server restart.
+
+The implemented MVP covers saved source, stable cell ordering, immutable output
+history, explicit input lineage, retry reuse, explicit rerun, stale-output
+status, TTL sessions, and encrypted durable storage. Batch "run all/from here"
+and clear-history controls belong in a subsequent orchestration/UI layer; they
+do not require a change to the storage or execution model below.
+
+## Data model
+
+A notebook has two distinct layers.
+
+### Cell definition (mutable, saved)
+
+```ts
+interface RealmNotebookCellDefinition {
+  cellId: string;
+  code: string;
+  mode: 'preview' | 'commit';
+  inputs: Record<string, RealmNotebookInputReference>;
+}
+```
+
+Editing a cell replaces its saved definition. A failed cell still retains its
+definition so it can be fixed or rerun.
+
+### Cell execution (immutable)
+
+```ts
+interface RealmNotebookExecution {
+  executionId: string;
+  cellId: string;
+  revision: number;
+  codeHash: string;
+  resolvedInputs: Record<string, { executionId: string; pointer: string }>;
+  status: 'pending' | 'succeeded' | 'failed' | 'indeterminate';
+  result?: RealmProgramResult;
+}
+```
+
+Input aliases such as `{ cellId: "search" }` are resolved to concrete
+execution IDs before the cell runs. The immutable execution stores those IDs,
+so its provenance never changes when an upstream cell is rerun.
+
+## Run versus retry
+
+These are different operations:
+
+- A transport retry or repeated LLM tool call reuses an already-succeeded
+  execution with the same code, mode, and resolved input references.
+- An explicit rerun (`force: true` or CLI `--rerun`) creates a new revision,
+  even when its definition is unchanged. This is how a search cell refreshes
+  data from a changing Realm index.
+- A saved run (`runSaved: true` or CLI `--saved`) loads source and bindings
+  from the notebook instead of requiring the LLM to reproduce the script.
+- A downstream saved run resolves cell aliases again. If an upstream cell has
+  a newer successful execution, the changed concrete input reference produces
+  a new downstream revision automatically.
+
+An indeterminate commit execution is never retried implicitly. The caller must
+inspect its effects and explicitly create a new revision.
+
+## Example: search, inspect, grep, transform
+
+First save and run a federated search cell:
+
+```json
+{
+  "sessionId": "!room:matrix.example",
+  "cellId": "search",
+  "persistence": "ephemeral"
+}
+```
+
+```js
+const candidates = await realm.search(query, { realms: 'all' });
+return { candidates };
+```
+
+The grep cell records a declarative binding:
+
+```json
+{
+  "sessionId": "!room:matrix.example",
+  "cellId": "grep",
+  "inputs": {
+    "candidates": {
+      "cellId": "search",
+      "pointer": "/result/value/candidates"
+    }
+  }
+}
+```
+
+```js
+return realm.fs.grep(/three(?:\.js)?/i, {
+  files: realm.input.candidates,
+  glob: '**/*.gts',
+});
+```
+
+Later, rerun `search`, then rerun the saved `grep` cell. The second operation
+uses the new search execution without issuing another search itself.
+
+## Persistence adapters
+
+`MemoryNotebookStorage` is the default for room and ad-hoc sessions. Records
+have a sliding TTL (one hour by default, bounded to one minute through 24
+hours) and disappear on Realm Server restart.
+
+`RealmFileNotebookStorage` persists records beneath
+`.boxel/realm-notebooks/`. It is opt-in and requires write permission. The
+server wraps it with authenticated AES-GCM encryption because a federated
+output may contain data from a Realm whose readers differ from the storage
+Realm's readers. The Realm secret is never exposed to QuickJS or clients.
+
+Storage adapters implement the small async contract:
+
+```ts
+interface NotebookStorageAdapter {
+  get(key: string): Promise<unknown | undefined>;
+  set(
+    key: string,
+    value: unknown,
+    options?: { expiresAt?: number | null },
+  ): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+```
+
+Notebook references are data, not authority. Each execution still uses the
+caller's current authenticated Realm capabilities.
+
+## LLM interleaving and status
+
+Every successful cell response includes a bounded `notebook.snapshot`. It is
+the handoff to the next LLM turn and contains, in stable cell order:
+
+- saved source (with an explicit truncation flag), mode, and input bindings;
+- latest successful revision, execution ID, and output reference;
+- the status of the last attempt (`pending`, `succeeded`, `failed`, or
+  `indeterminate`); and
+- a `stale` flag when a referenced upstream cell has advanced since this
+  cell's latest execution.
+
+Failures attach the same snapshot to structured error details. An LLM edits a
+later step by supplying revised source with the same `cellId`; the definition
+is updated and a new immutable revision is recorded. It can instead set
+`runSaved: true` to replay the existing definition unchanged.
+
+Inside a running cell, `realm.notebook` exposes the current session, cell,
+revision, execution ID, and persistence kind. Runtime discovery reports
+`realm.apiVersion === "2"` and `realm.features.notebooks === true`, so an agent
+can distinguish a deployed notebook build from the legacy one-shot runtime.
+
+Live progress is separate from cell output. `realm.activity()` and automatic
+capability instrumentation flow through the activity stream without becoming
+part of the immutable result. This keeps “what is it doing?” visible to CLI
+agents without copying code, queries, paths, or results into logs.
+
+## CLI
+
+Save and run a cell:
+
+```sh
+boxel realm script --realm @cardstack/my-workspace/ \
+  --file search.js --session research --cell search
+```
+
+Run a dependent cell:
+
+```sh
+boxel realm script --realm @cardstack/my-workspace/ \
+  --file grep.js --session research --cell grep \
+  --input-ref 'candidates=cell:search#/result/value/candidates'
+```
+
+Refresh the saved search and replay saved grep source:
+
+```sh
+boxel realm script --realm @cardstack/my-workspace/ \
+  --saved --rerun --session research --cell search
+
+boxel realm script --realm @cardstack/my-workspace/ \
+  --saved --session research --cell grep
+```
+
+Use `--persistence realm` to make a session survive process restarts. Omit the
+notebook flags entirely for a one-shot workspace command.

--- a/packages/base/Skill/boxel-environment.json
+++ b/packages/base/Skill/boxel-environment.json
@@ -59,6 +59,13 @@
             "module": "@cardstack/boxel-host/commands/set-active-llm"
           },
           "requiresApproval": false
+        },
+        {
+          "codeRef": {
+            "name": "default",
+            "module": "@cardstack/boxel-host/commands/run-realm-script"
+          },
+          "requiresApproval": true
         }
       ],
       "cardTitle": "Boxel Environment",

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -627,6 +627,18 @@ export class ExecuteAtomicOperationsResult extends CardDef {
   @field results = containsMany(JsonField);
 }
 
+export class RunRealmScriptInput extends CardDef {
+  @field realmIdentifier = contains(StringField);
+  @field code = contains(StringField);
+  @field mode = contains(StringField);
+  @field input = contains(JsonField);
+  @field notebook = contains(JsonField);
+}
+
+export class RunRealmScriptResult extends CardDef {
+  @field output = contains(JsonField);
+}
+
 // A publish destination for a realm. 'type' is 'subdirectory' (a Boxel Space
 // under the user's space domain, where 'name' is the realm-name path segment)
 // or 'custom' (a claimed custom domain, where 'name' is the full hostname).

--- a/packages/boxel-cli/README.md
+++ b/packages/boxel-cli/README.md
@@ -33,6 +33,33 @@ boxel --help
 boxel --version
 ```
 
+### Realm Scripts and notebooks
+
+Run a one-shot Realm Script:
+
+```bash
+boxel realm script --realm @cardstack/my-workspace/ \
+  --code 'return await realm.help();'
+```
+
+The command streams sanitized activity to `stderr` while preserving the final
+JSON result on `stdout`. Use `await realm.activity('Phase description')` for
+semantic checkpoints and `--no-activity` to request the legacy single-response
+transport.
+
+Notebook cells add `--session` and `--cell`; `--saved` reuses saved source,
+`--rerun` creates a new revision, and `--input-ref` binds immutable output from
+an earlier cell. Use `--persistence realm` for encrypted durable storage.
+
+```bash
+boxel realm script --realm @cardstack/my-workspace/ \
+  --file search.js --session research --cell search
+
+boxel realm script --realm @cardstack/my-workspace/ \
+  --file grep.js --session research --cell grep \
+  --input-ref 'candidates=cell:search#/result/value/candidates'
+```
+
 ### Environment variables
 
 These are read by `boxel profile add`:

--- a/packages/boxel-cli/src/commands/realm/index.ts
+++ b/packages/boxel-cli/src/commands/realm/index.ts
@@ -12,6 +12,7 @@ import { registerPullCommand } from './pull.ts';
 import { registerPushCommand } from './push.ts';
 import { registerRemoveCommand } from './remove.ts';
 import { registerRestoreCommand } from './restore.ts';
+import { registerRealmScriptCommand } from './script.ts';
 import { registerStatusCommand } from './status.ts';
 import { registerSyncCommand } from './sync.ts';
 import { registerUnpublishCommand } from './unpublish.ts';
@@ -36,6 +37,7 @@ export function registerRealmCommand(program: Command): void {
   registerPushCommand(realm);
   registerRemoveCommand(realm);
   registerRestoreCommand(realm);
+  registerRealmScriptCommand(realm);
   const sync = registerSyncCommand(realm);
   registerStatusCommand(sync);
   registerUnpublishCommand(realm);

--- a/packages/boxel-cli/src/commands/realm/script.ts
+++ b/packages/boxel-cli/src/commands/realm/script.ts
@@ -1,0 +1,398 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import type { Command } from 'commander';
+
+import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
+
+import { resolveRealmAuthenticator } from '../../lib/auth-resolver.ts';
+import { cliLog } from '../../lib/cli-log.ts';
+import { FG_RED, RESET } from '../../lib/colors.ts';
+import type { ProfileManager } from '../../lib/profile-manager.ts';
+import { resolveRealmSecretSeed } from '../../lib/prompt.ts';
+import type { RealmAuthenticator } from '../../lib/realm-authenticator.ts';
+import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
+
+export interface NotebookInputReference {
+  cellId?: string;
+  executionId?: string;
+  pointer?: string;
+}
+
+export interface RealmProgramActivity {
+  sequence: number;
+  timestamp: number;
+  source: 'runtime' | 'script';
+  status: 'running' | 'completed' | 'failed';
+  phase: string;
+  message: string;
+  operation?: string;
+  current?: number;
+  total?: number;
+}
+
+export interface ExecuteRealmScriptOptions {
+  mode?: 'preview' | 'commit';
+  input?: unknown;
+  notebook?: {
+    sessionId: string;
+    cellId: string;
+    persistence?: 'ephemeral' | 'realm';
+    ttlMs?: number;
+    inputs?: Record<string, NotebookInputReference>;
+    force?: boolean;
+    runSaved?: boolean;
+  };
+  profileManager?: ProfileManager;
+  realmSecretSeed?: string;
+  authenticator?: RealmAuthenticator;
+  onActivity?: (activity: RealmProgramActivity) => void | Promise<void>;
+}
+
+export type ExecuteRealmScriptResult =
+  | { ok: true; output: unknown }
+  | { ok: false; status?: number; error: string; output?: unknown };
+
+interface RealmScriptCliOptions {
+  realm: string;
+  code?: string;
+  file?: string;
+  saved?: boolean;
+  mode: 'preview' | 'commit';
+  inputJson?: string;
+  session?: string;
+  cell?: string;
+  persistence: 'ephemeral' | 'realm';
+  ttlMs?: number;
+  inputRef: string[];
+  rerun?: boolean;
+  activity: boolean;
+  realmSecretSeed?: boolean;
+}
+
+function collect(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+function parseInteger(value: string): number {
+  let parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${value} is not an integer`);
+  }
+  return parsed;
+}
+
+export function parseNotebookInputRefs(
+  specs: string[],
+): Record<string, NotebookInputReference> {
+  let result: Record<string, NotebookInputReference> = {};
+  for (let spec of specs) {
+    let equals = spec.indexOf('=');
+    if (equals <= 0 || equals === spec.length - 1) {
+      throw new Error(
+        `Invalid --input-ref ${JSON.stringify(spec)}; expected name=cell:<cell-id>#/pointer or name=exec:<execution-id>#/pointer`,
+      );
+    }
+    let name = spec.slice(0, equals);
+    if (!/^[A-Za-z_$][A-Za-z0-9_$-]*$/.test(name)) {
+      throw new Error(`Invalid Realm Notebook input name ${name}`);
+    }
+    if (result[name]) {
+      throw new Error(`Duplicate Realm Notebook input name ${name}`);
+    }
+    let sourceAndPointer = spec.slice(equals + 1);
+    let hash = sourceAndPointer.indexOf('#');
+    let source =
+      hash === -1 ? sourceAndPointer : sourceAndPointer.slice(0, hash);
+    let pointer =
+      hash === -1 ? undefined : sourceAndPointer.slice(hash + 1) || '';
+    if (pointer !== undefined && pointer !== '' && !pointer.startsWith('/')) {
+      throw new Error(`Input pointer for ${name} must start with /`);
+    }
+    if (source.startsWith('cell:') && source.length > 5) {
+      result[name] = {
+        cellId: source.slice(5),
+        ...(pointer === undefined ? {} : { pointer }),
+      };
+    } else if (
+      source.startsWith('exec:') &&
+      /^[a-f0-9]{64}$/.test(source.slice(5))
+    ) {
+      result[name] = {
+        executionId: source.slice(5),
+        ...(pointer === undefined ? {} : { pointer }),
+      };
+    } else {
+      throw new Error(
+        `Input source for ${name} must be cell:<cell-id> or exec:<64-character-execution-id>`,
+      );
+    }
+  }
+  return result;
+}
+
+export async function executeRealmScript(
+  realmIdentifier: string,
+  code: string | undefined,
+  options: ExecuteRealmScriptOptions = {},
+): Promise<ExecuteRealmScriptResult> {
+  let resolvedRealm = resolveRealmIdentifier(realmIdentifier, {
+    profileManager: options.profileManager,
+  });
+  if (!resolvedRealm.ok) return { ok: false, error: resolvedRealm.error };
+  let realmUrl = resolvedRealm.url;
+  let resolution = resolveRealmAuthenticator({
+    realmUrl,
+    profileManager: options.profileManager,
+    realmSecretSeed: options.realmSecretSeed,
+    authenticator: options.authenticator,
+  });
+  if (!resolution.ok) return { ok: false, error: resolution.error };
+
+  let mode = options.mode ?? 'preview';
+  let endpoint = new URL('_realm-program', realmUrl).href;
+  let response;
+  try {
+    response = await resolution.authenticator.authedRealmFetch(endpoint, {
+      method: mode === 'preview' ? 'QUERY' : 'POST',
+      headers: {
+        Accept: SupportedMimeType.JSON,
+        'Content-Type': SupportedMimeType.JSON,
+        ...(options.onActivity === undefined
+          ? {}
+          : { 'X-Boxel-Realm-Program-Stream': 'activity-v1' }),
+      },
+      body: JSON.stringify({
+        ...(code === undefined ? {} : { code }),
+        mode,
+        ...(options.input === undefined ? {} : { input: options.input }),
+        ...(options.notebook === undefined
+          ? {}
+          : { notebook: options.notebook }),
+      }),
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  if (
+    response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .includes('application/x-ndjson')
+  ) {
+    if (!response.body) {
+      return {
+        ok: false,
+        status: response.status,
+        error: 'Realm Script activity stream has no response body',
+      };
+    }
+    let decoder = new TextDecoder();
+    let reader = response.body.getReader();
+    let buffer = '';
+    let terminal: ExecuteRealmScriptResult | undefined;
+    let consumeLine = async (line: string) => {
+      if (line.trim().length === 0) return;
+      let event: unknown;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        throw new Error('Realm Script activity stream contained invalid JSON');
+      }
+      if (!event || typeof event !== 'object' || !('type' in event)) {
+        throw new Error('Realm Script activity stream event is malformed');
+      }
+      if (event.type === 'activity' && 'activity' in event) {
+        try {
+          await options.onActivity?.(event.activity as RealmProgramActivity);
+        } catch {
+          // Rendering progress must not change the underlying Realm run.
+        }
+      } else if (event.type === 'result' && 'result' in event) {
+        terminal = { ok: true, output: event.result };
+      } else if (event.type === 'error' && 'error' in event) {
+        let streamError = event.error;
+        let message =
+          streamError &&
+          typeof streamError === 'object' &&
+          'message' in streamError &&
+          typeof streamError.message === 'string'
+            ? streamError.message
+            : 'Realm Script failed';
+        terminal = {
+          ok: false,
+          error: message,
+          output: { ok: false, error: streamError },
+        };
+      }
+    };
+    try {
+      for (;;) {
+        let { done, value } = await reader.read();
+        buffer += decoder.decode(value, { stream: !done });
+        let newline;
+        while ((newline = buffer.indexOf('\n')) !== -1) {
+          await consumeLine(buffer.slice(0, newline));
+          buffer = buffer.slice(newline + 1);
+        }
+        if (done) break;
+      }
+      await consumeLine(buffer);
+    } catch (error) {
+      return {
+        ok: false,
+        status: response.status,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      reader.releaseLock();
+    }
+    return (
+      terminal ?? {
+        ok: false,
+        status: response.status,
+        error: 'Realm Script activity stream ended without a result',
+      }
+    );
+  }
+
+  let text = await response.text();
+  let output: unknown;
+  try {
+    output = text.length === 0 ? null : JSON.parse(text);
+  } catch {
+    return {
+      ok: false,
+      status: response.status,
+      error: `Realm Script returned non-JSON output (HTTP ${response.status})`,
+    };
+  }
+  if (!response.ok) {
+    let message =
+      output &&
+      typeof output === 'object' &&
+      'error' in output &&
+      output.error &&
+      typeof output.error === 'object' &&
+      'message' in output.error &&
+      typeof output.error.message === 'string'
+        ? output.error.message
+        : `Realm Script failed (HTTP ${response.status})`;
+    return { ok: false, status: response.status, error: message, output };
+  }
+  return { ok: true, output };
+}
+
+export function registerRealmScriptCommand(realm: Command): void {
+  realm
+    .command('script')
+    .description(
+      'Run an ad-hoc Realm Script or a resumable Realm Notebook cell',
+    )
+    .requiredOption('--realm <realm-url>', 'Realm URL or identifier')
+    .option('--code <javascript>', 'Inline Realm Script source')
+    .option('--file <path>', 'Read Realm Script source from a local file')
+    .option('--saved', 'Run the source saved for this notebook cell')
+    .option('--mode <mode>', 'preview or commit', 'preview')
+    .option('--input-json <json>', 'JSON value exposed as realm.input')
+    .option('--session <id>', 'Realm Notebook session or Matrix room id')
+    .option('--cell <id>', 'Realm Notebook cell id')
+    .option(
+      '--persistence <kind>',
+      'ephemeral (TTL session) or realm (encrypted durable files)',
+      'ephemeral',
+    )
+    .option('--ttl-ms <milliseconds>', 'Ephemeral session TTL', parseInteger)
+    .option(
+      '--input-ref <binding>',
+      'Cell input: name=cell:<cell-id>#/result/value/path or name=exec:<execution-id>#/result/value/path',
+      collect,
+      [],
+    )
+    .option('--rerun', 'Run a new revision instead of reusing a completed cell')
+    .option('--no-activity', 'Disable live Realm Script activity on stderr')
+    .option(
+      '--realm-secret-seed',
+      'Use administrative seed auth (env: BOXEL_REALM_SECRET_SEED)',
+    )
+    .action(async (opts: RealmScriptCliOptions) => {
+      try {
+        let sourceChoices = [
+          opts.code,
+          opts.file,
+          opts.saved ? true : undefined,
+        ].filter((value) => value !== undefined).length;
+        if (sourceChoices !== 1) {
+          throw new Error('Pass exactly one of --code, --file, or --saved');
+        }
+        if ((opts.session === undefined) !== (opts.cell === undefined)) {
+          throw new Error('--session and --cell must be provided together');
+        }
+        if (opts.saved && opts.session === undefined) {
+          throw new Error('--saved requires --session and --cell');
+        }
+        if (opts.mode !== 'preview' && opts.mode !== 'commit') {
+          throw new Error('--mode must be preview or commit');
+        }
+        if (opts.persistence !== 'ephemeral' && opts.persistence !== 'realm') {
+          throw new Error('--persistence must be ephemeral or realm');
+        }
+        let code =
+          opts.code ??
+          (opts.file === undefined
+            ? undefined
+            : await readFile(resolve(opts.file), 'utf8'));
+        let input =
+          opts.inputJson === undefined ? undefined : JSON.parse(opts.inputJson);
+        let inputRefs = parseNotebookInputRefs(opts.inputRef);
+        let notebook =
+          opts.session === undefined
+            ? undefined
+            : {
+                sessionId: opts.session,
+                cellId: opts.cell!,
+                persistence: opts.persistence,
+                ...(opts.ttlMs === undefined ? {} : { ttlMs: opts.ttlMs }),
+                ...(opts.inputRef.length === 0 ? {} : { inputs: inputRefs }),
+                force: opts.rerun === true,
+                runSaved: opts.saved === true,
+              };
+        let realmSecretSeed = await resolveRealmSecretSeed(
+          opts.realmSecretSeed === true,
+        );
+        let result = await executeRealmScript(opts.realm, code, {
+          mode: opts.mode,
+          input,
+          notebook,
+          realmSecretSeed,
+          ...(opts.activity === false
+            ? {}
+            : {
+                onActivity(activity) {
+                  let progress =
+                    activity.current === undefined
+                      ? ''
+                      : activity.total === undefined
+                        ? ` (${activity.current})`
+                        : ` (${activity.current}/${activity.total})`;
+                  cliLog.info(`[realm] ${activity.message}${progress}`);
+                },
+              }),
+        });
+        cliLog.output(JSON.stringify(result, null, 2));
+        if (!result.ok) {
+          console.error(`${FG_RED}Error:${RESET} ${result.error}`);
+          process.exitCode = 1;
+        }
+      } catch (error) {
+        console.error(
+          `${FG_RED}Error:${RESET} ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exitCode = 1;
+      }
+    });
+}

--- a/packages/boxel-cli/tests/commands/realm-script.test.ts
+++ b/packages/boxel-cli/tests/commands/realm-script.test.ts
@@ -1,0 +1,196 @@
+import { Command } from 'commander';
+import { describe, expect, it } from 'vitest';
+
+import {
+  executeRealmScript,
+  parseNotebookInputRefs,
+  registerRealmScriptCommand,
+} from '../../src/commands/realm/script.ts';
+import type { RealmAuthenticator } from '../../src/lib/realm-authenticator.ts';
+
+describe('Realm Notebook CLI inputs', () => {
+  it('parses cell and immutable execution references', () => {
+    let executionId = 'a'.repeat(64);
+    expect(
+      parseNotebookInputRefs([
+        'candidates=cell:search#/result/value/candidates',
+        `matches=exec:${executionId}#/result/value`,
+      ]),
+    ).toEqual({
+      candidates: {
+        cellId: 'search',
+        pointer: '/result/value/candidates',
+      },
+      matches: { executionId, pointer: '/result/value' },
+    });
+  });
+
+  it('rejects ambiguous or malformed references', () => {
+    expect(() => parseNotebookInputRefs(['missing-equals'])).toThrow(
+      /expected name=/,
+    );
+    expect(() =>
+      parseNotebookInputRefs(['value=cell:search#not-a-pointer']),
+    ).toThrow(/must start with/);
+  });
+
+  it('registers notebook lifecycle flags for agent use', () => {
+    let program = new Command().exitOverride();
+    let realm = program.command('realm');
+    registerRealmScriptCommand(realm);
+    let script = realm.commands.find((command) => command.name() === 'script');
+    if (!script) throw new Error('script command was not registered');
+    let names = script.options.map((option) => option.long);
+
+    expect(names).toContain('--session');
+    expect(names).toContain('--cell');
+    expect(names).toContain('--persistence');
+    expect(names).toContain('--ttl-ms');
+    expect(names).toContain('--input-ref');
+    expect(names).toContain('--saved');
+    expect(names).toContain('--rerun');
+    expect(names).toContain('--no-activity');
+  });
+});
+
+describe('executeRealmScript', () => {
+  it('sends a notebook cell through the same Realm endpoint used by Matrix', async () => {
+    let request: { input: string | URL | Request; init?: RequestInit } | null =
+      null;
+    let authenticator: RealmAuthenticator = {
+      async authedRealmFetch(input, init) {
+        request = { input, init };
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            value: ['module.gts'],
+            notebook: { reused: false },
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        );
+      },
+    };
+    let result = await executeRealmScript(
+      'https://example.test/workspace/',
+      'return realm.input;',
+      {
+        mode: 'preview',
+        authenticator,
+        notebook: {
+          sessionId: '!room:example.test',
+          cellId: 'grep',
+          persistence: 'ephemeral',
+          inputs: { candidates: { cellId: 'search' } },
+        },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(String(request!.input)).toBe(
+      'https://example.test/workspace/_realm-program',
+    );
+    expect(request!.init?.method).toBe('QUERY');
+    expect(JSON.parse(String(request!.init?.body))).toEqual({
+      code: 'return realm.input;',
+      mode: 'preview',
+      notebook: {
+        sessionId: '!room:example.test',
+        cellId: 'grep',
+        persistence: 'ephemeral',
+        inputs: { candidates: { cellId: 'search' } },
+      },
+    });
+  });
+
+  it('can invoke saved cell source without resending its code', async () => {
+    let body: unknown;
+    let authenticator: RealmAuthenticator = {
+      async authedRealmFetch(_input, init) {
+        body = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ ok: true, value: 1 }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    };
+
+    await executeRealmScript('https://example.test/workspace/', undefined, {
+      authenticator,
+      notebook: {
+        sessionId: 'research',
+        cellId: 'search',
+        runSaved: true,
+        force: true,
+      },
+    });
+
+    expect(body).toEqual({
+      mode: 'preview',
+      notebook: {
+        sessionId: 'research',
+        cellId: 'search',
+        runSaved: true,
+        force: true,
+      },
+    });
+  });
+
+  it('consumes live activity while preserving the final JSON result', async () => {
+    let requestHeaders: HeadersInit | undefined;
+    let activity: unknown[] = [];
+    let encoder = new TextEncoder();
+    let authenticator: RealmAuthenticator = {
+      async authedRealmFetch(_input, init) {
+        requestHeaders = init?.headers;
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  '{"type":"activity","activity":{"sequence":1,"timestamp":1,"source":"runtime","status":"running","phase":"search",',
+                ),
+              );
+              controller.enqueue(
+                encoder.encode(
+                  '"message":"Searching readable realms"}}\n{"type":"result","result":{"ok":true,"value":42}}\n',
+                ),
+              );
+              controller.close();
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/x-ndjson' },
+          },
+        );
+      },
+    };
+
+    let result = await executeRealmScript(
+      'https://example.test/workspace/',
+      'return 42;',
+      {
+        authenticator,
+        onActivity(event) {
+          activity.push(event);
+        },
+      },
+    );
+
+    expect(
+      new Headers(requestHeaders).get('X-Boxel-Realm-Program-Stream'),
+    ).toBe('activity-v1');
+    expect(activity).toHaveLength(1);
+    expect(activity[0]).toMatchObject({
+      phase: 'search',
+      message: 'Searching readable realms',
+    });
+    expect(result).toEqual({
+      ok: true,
+      output: { ok: true, value: 42 },
+    });
+  });
+});

--- a/packages/host/app/tools/index.ts
+++ b/packages/host/app/tools/index.ts
@@ -66,6 +66,7 @@ import * as ReadTextFileToolModule from './read-text-file';
 import * as RegisterBotToolModule from './register-bot';
 import * as ReindexRealmToolModule from './reindex-realm';
 import * as RetrySubmissionWorkflowToolModule from './retry-submission-workflow';
+import * as RunRealmScriptToolModule from './run-realm-script';
 import * as SanitizeModuleListToolModule from './sanitize-module-list';
 import * as SaveCardToolModule from './save-card';
 import * as ScreenshotCardToolModule from './screenshot-card';
@@ -267,6 +268,11 @@ export function shimHostTools(virtualNetwork: VirtualNetwork) {
   shimHostToolModule(virtualNetwork, 'read-source', ReadSourceToolModule);
   shimHostToolModule(virtualNetwork, 'read-text-file', ReadTextFileToolModule);
   shimHostToolModule(virtualNetwork, 'reindex-realm', ReindexRealmToolModule);
+  shimHostToolModule(
+    virtualNetwork,
+    'run-realm-script',
+    RunRealmScriptToolModule,
+  );
   shimHostToolModule(virtualNetwork, 'register-bot', RegisterBotToolModule);
   shimHostToolModule(virtualNetwork, 'save-card', SaveCardToolModule);
   shimHostToolModule(virtualNetwork, 'serialize-card', SerializeCardToolModule);
@@ -516,6 +522,7 @@ export const HostToolClasses: (typeof HostBaseTool<any, any>)[] = [
   ReadTextFileToolModule.default,
   RegisterBotToolModule.default,
   ReindexRealmToolModule.default,
+  RunRealmScriptToolModule.default,
   SaveCardToolModule.default,
   SanitizeModuleListToolModule.default,
   StoreAddToolModule.default,

--- a/packages/host/app/tools/run-realm-script.ts
+++ b/packages/host/app/tools/run-realm-script.ts
@@ -1,0 +1,124 @@
+import { service } from '@ember/service';
+
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+
+import HostBaseTool from '../lib/host-base-tool';
+
+import type NetworkService from '../services/network';
+import type * as BaseToolModule from '@cardstack/base/command';
+
+type RealmScriptMode = 'preview' | 'commit';
+
+export default class RunRealmScriptTool extends HostBaseTool<
+  typeof BaseToolModule.RunRealmScriptInput,
+  typeof BaseToolModule.RunRealmScriptResult
+> {
+  @service declare private network: NetworkService;
+
+  static actionVerb = 'Run Realm Script';
+  description =
+    'Run one capability-scoped QuickJS program against Boxel. It supports federated index search, cross-Realm reads, BXL/jq, staged Realm file operations, and the authenticated Realm/server API. For long scripts, insert awaited realm.activity messages before semantic phases; describe only the action and never interpolate code, paths, queries, arguments, or results. Pass input for ad-hoc realm.input data, or notebook { sessionId, cellId, persistence?, ttlMs?, inputs?, runSaved?, force? } for an interleaved notebook. Each result includes notebook.snapshot: inspect it for ordered saved source, run status, output references, and stale dependencies before writing the next cell. Bind earlier outputs through inputs, edit a later cell by supplying new code with the same cellId, use runSaved to load its saved code, and force to create a fresh revision; an exact retry otherwise reuses its result. Ephemeral notebooks expire; realm notebooks are encrypted durable workspace files. Preview mode is read-only apart from explicit notebook persistence and returns staged diffs. Commit mode applies staged text changes atomically and permits immediate raw API mutations, which are reported in output.effects.';
+
+  async getInputType() {
+    let commandModule = await this.loadToolModule();
+    return commandModule.RunRealmScriptInput;
+  }
+
+  requireInputFields = ['realmIdentifier', 'mode'];
+
+  protected async run(
+    input: BaseToolModule.RunRealmScriptInput,
+  ): Promise<BaseToolModule.RunRealmScriptResult> {
+    let mode = input.mode as RealmScriptMode;
+    if (mode !== 'preview' && mode !== 'commit') {
+      throw new Error('Realm Script mode must be "preview" or "commit"');
+    }
+    let runSaved =
+      input.notebook &&
+      typeof input.notebook === 'object' &&
+      'runSaved' in input.notebook &&
+      input.notebook.runSaved === true;
+    if (!runSaved && (!input.code || input.code.trim().length === 0)) {
+      throw new Error(
+        'Realm Script code is required unless notebook.runSaved is true',
+      );
+    }
+
+    let endpoint = new URL(
+      '_realm-program',
+      ensureTrailingSlash(input.realmIdentifier),
+    ).href;
+    let response = await this.network.authedFetch(endpoint, {
+      method: mode === 'preview' ? 'QUERY' : 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ...(input.code === undefined ? {} : { code: input.code }),
+        mode,
+        ...(input.input === undefined ? {} : { input: input.input }),
+        ...(input.notebook === undefined ? {} : { notebook: input.notebook }),
+      }),
+    });
+    let text = await response.text();
+    let output: unknown;
+    try {
+      output = text.length > 0 ? JSON.parse(text) : null;
+    } catch {
+      throw new Error(
+        `Realm Script returned a non-JSON response (HTTP ${response.status})`,
+      );
+    }
+
+    if (!response.ok) {
+      let message =
+        output &&
+        typeof output === 'object' &&
+        'error' in output &&
+        output.error &&
+        typeof output.error === 'object' &&
+        'message' in output.error &&
+        typeof output.error.message === 'string'
+          ? output.error.message
+          : `Realm Script failed (HTTP ${response.status})`;
+      let effects =
+        output &&
+        typeof output === 'object' &&
+        'error' in output &&
+        output.error &&
+        typeof output.error === 'object' &&
+        'details' in output.error &&
+        output.error.details &&
+        typeof output.error.details === 'object' &&
+        'effects' in output.error.details &&
+        Array.isArray(output.error.details.effects)
+          ? output.error.details.effects
+          : undefined;
+      let notebook =
+        output &&
+        typeof output === 'object' &&
+        'error' in output &&
+        output.error &&
+        typeof output.error === 'object' &&
+        'details' in output.error &&
+        output.error.details &&
+        typeof output.error.details === 'object' &&
+        'notebook' in output.error.details
+          ? output.error.details.notebook
+          : undefined;
+      if (effects?.length) {
+        message += `; raw API effects before failure: ${JSON.stringify(effects)}`;
+      }
+      if (notebook !== undefined) {
+        message += `; notebook state: ${JSON.stringify(notebook)}`;
+      }
+      throw new Error(message);
+    }
+
+    let commandModule = await this.loadToolModule();
+    return new commandModule.RunRealmScriptResult({ output });
+  }
+}
+
+export { RunRealmScriptTool as RunRealmScriptCommand };

--- a/packages/host/tests/integration/tools/run-realm-script-test.gts
+++ b/packages/host/tests/integration/tools/run-realm-script-test.gts
@@ -1,0 +1,234 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type NetworkService from '@cardstack/host/services/network';
+import RunRealmScriptTool from '@cardstack/host/tools/run-realm-script';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmCacheTeardown,
+  testRealmURL,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+import type * as BaseToolModule from '@cardstack/base/command';
+
+let mockResponse: {
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+};
+let requests: { url: string; options?: RequestInit }[];
+
+class TestRealmScriptResult {
+  declare output: unknown;
+
+  constructor({ output }: { output: unknown }) {
+    this.output = output;
+  }
+}
+
+class TestableRunRealmScriptTool extends RunRealmScriptTool {
+  protected override async loadToolModule(): Promise<typeof BaseToolModule> {
+    return {
+      RunRealmScriptResult: TestRealmScriptResult,
+    } as unknown as typeof BaseToolModule;
+  }
+
+  callRun(input: {
+    realmIdentifier: string;
+    code: string;
+    mode: string;
+    input?: unknown;
+    notebook?: unknown;
+  }) {
+    return this.run(input as BaseToolModule.RunRealmScriptInput);
+  }
+}
+
+module('Integration | tools | run-realm-script', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function () {
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {},
+      }),
+    );
+  });
+
+  hooks.beforeEach(function () {
+    requests = [];
+    let network = getService('network') as NetworkService;
+    Object.defineProperty(network, 'authedFetch', {
+      get() {
+        return async (url: string, options?: RequestInit) => {
+          requests.push({ url, options });
+          return mockResponse;
+        };
+      },
+      configurable: true,
+    });
+  });
+
+  test('uses the authenticated read boundary for preview mode', async function (assert) {
+    mockResponse = {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ scanned: 12, matches: ['a.gts'] }),
+    };
+    let toolService = getService('tool-service');
+    let tool = new TestableRunRealmScriptTool(toolService.toolContext);
+    let result = await tool.callRun({
+      realmIdentifier: testRealmURL.slice(0, -1),
+      code: 'return await realm.fs.glob("**/*.gts");',
+      mode: 'preview',
+    });
+
+    assert.deepEqual(result.output, {
+      scanned: 12,
+      matches: ['a.gts'],
+    });
+    assert.strictEqual(
+      requests[0].url,
+      `${testRealmURL}_realm-program`,
+      'targets the Realm-specific endpoint',
+    );
+    assert.strictEqual(
+      requests[0].options?.method,
+      'QUERY',
+      'preview uses the read permission boundary',
+    );
+    assert.deepEqual(JSON.parse(requests[0].options?.body as string), {
+      code: 'return await realm.fs.glob("**/*.gts");',
+      mode: 'preview',
+    });
+  });
+
+  test('uses the authenticated write boundary for commit mode', async function (assert) {
+    mockResponse = {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ committed: true }),
+    };
+    let toolService = getService('tool-service');
+    let tool = new TestableRunRealmScriptTool(toolService.toolContext);
+    await tool.callRun({
+      realmIdentifier: testRealmURL,
+      code: 'realm.fs.writeText("hello.txt", "hi");',
+      mode: 'commit',
+    });
+
+    assert.strictEqual(
+      requests[0].options?.method,
+      'POST',
+      'commit uses the write permission boundary',
+    );
+  });
+
+  test('forwards Matrix-room notebook state and explicit inputs', async function (assert) {
+    mockResponse = {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ notebook: { reused: false } }),
+    };
+    let toolService = getService('tool-service');
+    let tool = new TestableRunRealmScriptTool(toolService.toolContext);
+    let notebook = {
+      sessionId: '!room:localhost',
+      cellId: 'grep',
+      persistence: 'ephemeral',
+      inputs: {
+        candidates: {
+          cellId: 'search',
+          pointer: '/result/value/candidates',
+        },
+      },
+    };
+    await tool.callRun({
+      realmIdentifier: testRealmURL,
+      code: 'return realm.input.candidates;',
+      mode: 'preview',
+      input: { direct: 'value' },
+      notebook,
+    });
+
+    assert.deepEqual(JSON.parse(requests[0].options?.body as string), {
+      code: 'return realm.input.candidates;',
+      mode: 'preview',
+      input: { direct: 'value' },
+      notebook,
+    });
+  });
+
+  test('surfaces structured Realm Program errors', async function (assert) {
+    mockResponse = {
+      ok: false,
+      status: 501,
+      text: async () =>
+        JSON.stringify({
+          error: {
+            message: 'Realm Program failed after a write',
+            details: {
+              effects: [
+                {
+                  scope: 'realm',
+                  method: 'POST',
+                  path: 'partial.json',
+                  status: 201,
+                  ok: true,
+                },
+              ],
+              notebook: {
+                sessionId: '!room:localhost',
+                cellId: 'commit-cell',
+                snapshot: {
+                  cells: [{ cellId: 'commit-cell', status: 'indeterminate' }],
+                },
+              },
+            },
+          },
+        }),
+    };
+    let toolService = getService('tool-service');
+    let tool = new TestableRunRealmScriptTool(toolService.toolContext);
+
+    await assert.rejects(
+      tool.callRun({
+        realmIdentifier: testRealmURL,
+        code: 'return 1;',
+        mode: 'preview',
+      }),
+      /Realm Program failed after a write; raw API effects before failure:.*partial\.json.*notebook state:.*indeterminate/,
+    );
+  });
+
+  test('rejects unknown modes before making a request', async function (assert) {
+    let toolService = getService('tool-service');
+    let tool = new TestableRunRealmScriptTool(toolService.toolContext);
+
+    await assert.rejects(
+      tool.callRun({
+        realmIdentifier: testRealmURL,
+        code: 'return 1;',
+        mode: 'unsafe',
+      }),
+      /must be "preview" or "commit"/,
+    );
+    assert.strictEqual(requests.length, 0, 'does not make a request');
+  });
+});

--- a/packages/realm-runner/.eslintrc.cjs
+++ b/packages/realm-runner/.eslintrc.cjs
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  env: {
+    browser: true,
+    es2022: true,
+    node: true,
+  },
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+};

--- a/packages/realm-runner/README.md
+++ b/packages/realm-runner/README.md
@@ -1,0 +1,248 @@
+# Realm Runner
+
+`@cardstack/realm-runner` executes capability-scoped JavaScript programs in
+QuickJS. A program has no ambient Node.js, filesystem, process, or network
+authority. All Realm access goes through the authenticated Realm server API.
+
+The public guest API is available as the global `realm` object. Call
+`await realm.help()` from a program for the current operation list.
+
+Runtime discovery is explicit. Notebook and live-activity builds report
+`realm.apiVersion === "2"` and expose:
+
+```js
+return {
+  apiVersion: realm.apiVersion,
+  features: realm.features,
+  notebook: realm.notebook,
+  help: await realm.help(),
+};
+```
+
+`realm.notebook` is `null` for one-shot scripts and contains the current
+session, cell, revision, execution, and persistence identifiers for notebook
+cells.
+
+## Execution modes
+
+- `preview` permits reads and stages mutations. The result includes diffs, but
+  does not write them.
+- `commit` applies all staged text changes through one `/_atomic` request after
+  the program finishes successfully. Immediately before that request, the
+  runner re-reads every baseline and aborts with `WRITE_CONFLICT` if another
+  actor changed one.
+
+Commit mode also enables authenticated raw `POST`, `PUT`, `PATCH`, and `DELETE`
+requests through `realm.api.request` and `realm.server.request`. Raw mutations
+run when called so the program can inspect their responses; unlike staged file
+changes, separate HTTP operations cannot be rolled back if a later step fails.
+Every attempted raw mutation is returned in `effects`, including its scope,
+method, path, Realm URL (when applicable), and HTTP outcome. A null outcome
+means the transport failed and whether the remote operation completed is
+unknown.
+
+Writes, copies, replacements, JSON updates, and removals share the same staged
+overlay. The current Realm server has an [open bug for `remove` operations in
+`/_atomic`](https://github.com/cardstack/boxel/issues/5665); Realm Runner already
+emits the documented operation so removal will work when that server defect is
+corrected. Until then, commit-mode `realm.api.request('DELETE', path)` provides
+the non-atomic equivalent.
+
+Binary reads are available through `realm.fs.readBase64`. Binary writes are
+available in commit mode through `realm.api.request` with `bodyType: 'base64'`.
+They remain non-atomic with text changes because of [the Realm server's binary
+`/_atomic` limitation](https://github.com/cardstack/boxel/issues/5666).
+
+The Realm endpoint is `/_realm-program`: send a `QUERY` request for preview or
+a `POST` request for commit. Both accept `{ "code": "...", "mode": "..." }`.
+
+## Live activity
+
+Realm Runner emits sanitized phase events automatically for capability calls
+such as Realm discovery, federated search, grep, reads, BXL, API access, staged
+writes, and commit. Events describe the operation but never include its
+arguments, paths, source, query, or result.
+
+A Realm Script writer can add semantic phase boundaries with:
+
+```js
+await realm.activity('Searching readable realms');
+const candidates = await realm.search(query, { realms: 'all' });
+
+await realm.activity({
+  phase: 'inspect',
+  message: 'Inspecting candidates',
+  current: 0,
+  total: candidates.length,
+});
+const matches = await realm.fs.grep(pattern, { files: candidates });
+
+await realm.activity('Transforming matches');
+return realm.bxl.jq(expression, matches);
+```
+
+Writer rules:
+
+- add checkpoints before expensive semantic phases, not before every line;
+- use progress counts only for throttled batches, not per-file messages;
+- never interpolate source, paths, query terms, URLs, arguments, or results;
+- keep messages stable and action-oriented; and
+- always `await` the activity call.
+
+To receive events before completion, add
+`X-Boxel-Realm-Program-Stream: activity-v1`. The response is newline-delimited
+JSON (`application/x-ndjson`) containing `activity` events followed by exactly
+one `result` or `error` event. Without the header, the existing JSON response
+is unchanged. `boxel realm script` enables the stream by default and writes
+activity to `stderr`, preserving final JSON on `stdout`; pass `--no-activity`
+to disable it.
+
+## Resumable Realm Notebooks
+
+Add a `notebook` descriptor to save a named cell, reuse an exact completed
+execution, and pass JSON output into later scripts without rerunning the
+upstream search:
+
+```json
+{
+  "code": "return realm.fs.grep(/three/i, { files: realm.input.candidates });",
+  "mode": "preview",
+  "notebook": {
+    "sessionId": "!room:matrix.example",
+    "cellId": "grep",
+    "inputs": {
+      "candidates": {
+        "cellId": "search",
+        "pointer": "/result/value/candidates"
+      }
+    }
+  }
+}
+```
+
+Each response includes a bounded notebook snapshot with saved cell source,
+execution status, output references, and stale dependency flags for the next
+LLM turn. `runSaved: true` reruns saved source without resending it;
+`force: true` creates a new revision. The default `ephemeral` persistence has
+a sliding session TTL. `persistence: "realm"` stores encrypted records under
+`.boxel/realm-notebooks/` and requires write access. See
+[`docs/realm-script-notebooks.md`](../../docs/realm-script-notebooks.md) for
+the protocol and Jupyter model.
+
+## Search the current Realm
+
+Prefer the full-text index to narrow candidates, then inspect the matching
+files. `fs.grep` is available for exact source-level matching when needed.
+
+```js
+const indexed = await realm.search({
+  filter: { any: [{ matches: 'bxl' }, { matches: 'BXL' }] },
+});
+const matches = [];
+
+for (const hit of indexed) {
+  if (!hit.id.startsWith(realm.current.url) || !hit.id.endsWith('.gts'))
+    continue;
+  const path = hit.id.slice(realm.current.url.length);
+  const source = await realm.fs.readText(path);
+  if (/bxl/i.test(source)) matches.push(path);
+}
+
+return { candidates: indexed.length, matches };
+```
+
+## Federated search and cross-Realm reads
+
+`realms: 'all'` discovers every Realm for which the current user has read
+permission, batches a federated full-text query, and de-duplicates its results.
+An authorized result can then be inspected through a read-only Realm handle.
+
+```js
+const hits = await realm.search(
+  {
+    filter: {
+      any: [
+        { matches: 'three' },
+        { matches: 'three.js' },
+        { matches: 'threejs' },
+      ],
+    },
+  },
+  { realms: 'all' },
+);
+
+const grants = await realm.listRealms({ permission: 'read' });
+const sources = [];
+for (const hit of hits) {
+  if (!hit.id.endsWith('.gts')) continue;
+  const realmURL = grants
+    .map((grant) => grant.url)
+    .filter((url) => hit.id.startsWith(url))
+    .sort((a, b) => b.length - a.length)[0];
+  if (!realmURL) continue;
+  const path = hit.id.slice(realmURL.length);
+  sources.push({
+    id: hit.id,
+    source: await realm.open(realmURL).fs.readText(path),
+  });
+}
+
+return { hits: hits.length, sources };
+```
+
+## Data transforms
+
+BXL is the jq-like transformation layer:
+
+```js
+return await realm.bxl.jq('.items | map(.price) | add', input);
+```
+
+The package ships with a commit-pinned `@cardstack/bxl` runtime. `BXL_API` can
+override it with a local `dist/runtime-bare.js` build while developing BXL.
+
+## Full Realm and Realm-server API
+
+The stable helpers cover common reads. `realm.api.request` targets the current
+Realm; `realm.server.request` targets the Realm server. Both accept every HTTP
+method used by Boxel: `GET`, `HEAD`, `QUERY`, `POST`, `PUT`, `PATCH`, and
+`DELETE`.
+
+```js
+const info = await realm.api.request('GET', '_info', {
+  accept: 'application/vnd.api+json',
+});
+
+const binary = await realm.api.request('GET', 'document.pdf', {
+  accept: 'application/octet-stream',
+  responseType: 'base64',
+});
+
+// commit mode only
+const written = await realm.api.request('POST', 'copy.pdf', {
+  body: binary.body,
+  bodyType: 'base64',
+  accept: 'application/octet-stream',
+  contentType: 'application/octet-stream',
+});
+
+return { info, written };
+```
+
+Request options are `{ body, bodyType, responseType, headers, accept,
+contentType }`. `bodyType` is `none`, `json`, `text`, or `base64`;
+`responseType` is `auto`, `text`, or `base64`. Authorization is always supplied
+by the capability host and cannot be overridden. Absolute/escaping paths,
+credential-minting endpoints, recursive Realm Programs, hop-by-hop headers,
+and internal/impersonation/routing headers are blocked. Cross-Realm handles remain
+read-only by default. In commit mode, an explicit
+`realm.open(url, { write: true })` handle can issue raw mutations when the
+active profile has a write grant for that Realm.
+Boxel routes handlers by `Accept`, so source and binary writes must set
+`accept` to `application/vnd.card+source` or `application/octet-stream`
+respectively; `contentType` describes the request body.
+
+Each raw request and response is stream-bounded, and cumulative request and
+response budgets apply to the entire program. Realm HTTP calls have their own
+timeout. The QuickJS CPU deadline excludes time suspended on Realm I/O, while
+a separate five-minute wall-clock deadline includes both execution and I/O.

--- a/packages/realm-runner/package.json
+++ b/packages/realm-runner/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@cardstack/realm-runner",
+  "version": "0.1.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./core": {
+      "types": "./types/core.d.ts",
+      "default": "./src/core.js"
+    }
+  },
+  "dependencies": {
+    "@cardstack/bxl": "github:cardstack/bxl#eb9addc714e0111aa7bee5cf373a87cae11506e7",
+    "@cardstack/runtime-common": "workspace:*",
+    "diff": "catalog:",
+    "minimatch": "^10.0.3",
+    "quickjs-emscripten": "0.32.0"
+  },
+  "scripts": {
+    "test": "node --test",
+    "lint": "eslint ."
+  }
+}

--- a/packages/realm-runner/src/bxl-adapter.js
+++ b/packages/realm-runner/src/bxl-adapter.js
@@ -1,0 +1,65 @@
+import { access } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { RealmRunnerError } from './errors.js';
+
+async function loadBxlModule() {
+  if (process.env.BXL_API) {
+    return import(pathToFileURL(resolve(process.env.BXL_API)).href);
+  }
+
+  try {
+    return await import('@cardstack/bxl/runtime-bare');
+  } catch (packageError) {
+    let here = dirname(fileURLToPath(import.meta.url));
+    let adjacent = resolve(here, '../../bxl/dist/runtime-bare.js');
+    try {
+      await access(adjacent);
+      return await import(pathToFileURL(adjacent).href);
+    } catch {
+      throw new RealmRunnerError(
+        'BXL_NOT_FOUND',
+        'Could not load @cardstack/bxl/runtime-bare. Build an adjacent BXL checkout or set BXL_API to dist/runtime-bare.js.',
+        {
+          cause:
+            packageError instanceof Error
+              ? packageError.message
+              : String(packageError),
+        },
+      );
+    }
+  }
+}
+
+export class BxlAdapter {
+  constructor(evaluate) {
+    if (typeof evaluate !== 'function') {
+      throw new TypeError('BXL evaluator is required');
+    }
+    this.evaluateFn = evaluate;
+  }
+
+  static async create() {
+    let bxl = await loadBxlModule();
+    return new BxlAdapter(bxl.evaluateBxlBare);
+  }
+
+  evaluate(expression, input, options = {}) {
+    let readableSyntax;
+    if (options.syntax === 'jq') {
+      readableSyntax = false;
+    } else if (options.syntax === 'readable') {
+      readableSyntax = true;
+    }
+    return this.evaluateFn(expression, input, {
+      readableSyntax,
+      runtimeLimits: {
+        maxSteps: 250_000,
+        maxOutputs: 1_000,
+        maxOutputBytes: 1 * 1024 * 1024,
+        maxMillis: 2_000,
+      },
+    });
+  }
+}

--- a/packages/realm-runner/src/capability.js
+++ b/packages/realm-runner/src/capability.js
@@ -1,0 +1,1667 @@
+import { createTwoFilesPatch } from 'diff';
+import { minimatch } from 'minimatch';
+
+import { RealmRunnerError } from './errors.js';
+import { globPattern, realmPath } from './path.js';
+
+const DEFAULT_LIMITS = Object.freeze({
+  capabilityCalls: 1_000,
+  filesListed: 10_000,
+  globResults: 2_000,
+  grepMatches: 2_000,
+  grepContextLines: 10,
+  searchResults: 500,
+  searchRealms: 1_000,
+  searchRealmBatchSize: 2,
+  searchConcurrency: 16,
+  bxlSourceBytes: 64 * 1024,
+  base64ReadBytes: 3 * 1024 * 1024,
+  bytesRead: 16 * 1024 * 1024,
+  bytesWritten: 8 * 1024 * 1024,
+  filesChanged: 200,
+  logs: 200,
+  logBytes: 64 * 1024,
+  resultBytes: 512 * 1024,
+  rpcResultBytes: 4 * 1024 * 1024,
+  apiRequestBytes: 4 * 1024 * 1024,
+  apiResponseBytes: 4 * 1024 * 1024,
+  apiTotalRequestBytes: 16 * 1024 * 1024,
+  apiTotalResponseBytes: 32 * 1024 * 1024,
+  apiHeaderBytes: 16 * 1024,
+  diffBytes: 256 * 1024,
+});
+
+const textEncoder = new TextEncoder();
+const REMOVED = Symbol('removed');
+const MAX_ACTIVITY_MESSAGE_CHARS = 160;
+const API_METHODS = new Set([
+  'GET',
+  'HEAD',
+  'QUERY',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+]);
+const MUTATING_API_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const FORBIDDEN_API_HEADERS = new Set([
+  'authorization',
+  'connection',
+  'content-length',
+  'cookie',
+  'forwarded',
+  'host',
+  'proxy-authorization',
+  'set-cookie',
+  'transfer-encoding',
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-proto',
+  'x-http-method-override',
+  'x-boxel-assume-user',
+]);
+
+function byteLength(value) {
+  return textEncoder.encode(value).byteLength;
+}
+
+async function sha256(value) {
+  let digest = await crypto.subtle.digest('SHA-256', textEncoder.encode(value));
+  let hex = [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+  return `sha256:${hex}`;
+}
+
+function bytesToBase64(bytes) {
+  let binary = '';
+  let chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(offset, offset + chunkSize),
+    );
+  }
+  return btoa(binary);
+}
+
+function base64ByteLength(value) {
+  let padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0;
+  return Math.floor((value.length * 3) / 4) - padding;
+}
+
+function jsonClone(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+export class RealmCapabilityHost {
+  constructor({ adapter, bxl, realmUrl, mode = 'preview', limits = {} }) {
+    if (!adapter) throw new TypeError('adapter is required');
+    if (!realmUrl) throw new TypeError('realmUrl is required');
+    if (!['preview', 'commit'].includes(mode)) {
+      throw new TypeError(`Unsupported mode: ${mode}`);
+    }
+    this.adapter = adapter;
+    this.bxl = bxl;
+    this.realmUrl = realmUrl;
+    this.mode = mode;
+    this.limits = Object.freeze({ ...DEFAULT_LIMITS, ...limits });
+    this.overlay = new Map();
+    this.baseline = new Map();
+    this.fileList = undefined;
+    this.scopedFileLists = new Map();
+    this.scopedReads = new Map();
+    this.base64Reads = new Map();
+    this.readableRealmUrls = undefined;
+    this.writableRealmUrls = undefined;
+    this.logs = [];
+    this.effects = [];
+    this.logBytes = 0;
+    this.stats = {
+      capabilityCalls: 0,
+      filesRead: 0,
+      filesChanged: 0,
+      bytesRead: 0,
+      bytesWritten: 0,
+      apiRequests: 0,
+      apiBytesSent: 0,
+      apiBytesReceived: 0,
+    };
+  }
+
+  countCall() {
+    this.stats.capabilityCalls += 1;
+    if (this.stats.capabilityCalls > this.limits.capabilityCalls) {
+      throw new RealmRunnerError(
+        'OPERATION_LIMIT',
+        'Realm capability-call limit exceeded',
+      );
+    }
+  }
+
+  countRead(content) {
+    this.stats.filesRead += 1;
+    this.countReadBytes(content);
+  }
+
+  countReadBytes(content) {
+    this.countReadByteCount(byteLength(content));
+  }
+
+  countReadByteCount(bytes) {
+    this.stats.bytesRead += bytes;
+    if (this.stats.bytesRead > this.limits.bytesRead) {
+      throw new RealmRunnerError(
+        'BYTE_LIMIT',
+        'Realm read-byte limit exceeded',
+      );
+    }
+  }
+
+  invalidateRawMutationCaches(scope, targetRealm) {
+    this.readableRealmUrls = undefined;
+    this.writableRealmUrls = undefined;
+
+    let preserveStagedBaselines = () => {
+      for (let filePath of this.baseline.keys()) {
+        if (!this.overlay.has(filePath)) this.baseline.delete(filePath);
+      }
+    };
+    let clearScopedRealm = (realmUrl) => {
+      this.scopedFileLists.delete(realmUrl);
+      for (let key of this.scopedReads.keys()) {
+        if (key.startsWith(`${realmUrl}\u0000`)) this.scopedReads.delete(key);
+      }
+      for (let key of this.base64Reads.keys()) {
+        if (key.startsWith(`${realmUrl}\u0000`)) this.base64Reads.delete(key);
+      }
+    };
+
+    if (scope === 'server') {
+      this.fileList = undefined;
+      preserveStagedBaselines();
+      this.scopedFileLists.clear();
+      this.scopedReads.clear();
+      this.base64Reads.clear();
+    } else if (targetRealm === this.realmUrl) {
+      this.fileList = undefined;
+      preserveStagedBaselines();
+      clearScopedRealm(this.realmUrl);
+    } else if (targetRealm) {
+      clearScopedRealm(targetRealm);
+    }
+  }
+
+  async loadFileList() {
+    if (!this.fileList) {
+      let paths = await this.adapter.listFiles(
+        this.realmUrl,
+        this.limits.apiResponseBytes,
+      );
+      if (paths.length > this.limits.filesListed) {
+        throw new RealmRunnerError(
+          'RESULT_LIMIT',
+          `Realm contains more than ${this.limits.filesListed} files`,
+        );
+      }
+      this.fileList = new Set(paths.map(realmPath));
+    }
+    return this.fileList;
+  }
+
+  isCurrentRealm(realmUrl) {
+    return realmUrl === undefined || realmUrl === this.realmUrl;
+  }
+
+  async authorizeReadableRealm(realmUrl) {
+    if (this.isCurrentRealm(realmUrl)) return this.realmUrl;
+    if (typeof realmUrl !== 'string' || realmUrl.length === 0) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'Scoped Realm URL must be a non-empty string',
+      );
+    }
+    let canonical;
+    try {
+      let url = new URL(realmUrl);
+      if (!['http:', 'https:'].includes(url.protocol)) throw new Error();
+      canonical = url.href.endsWith('/') ? url.href : `${url.href}/`;
+    } catch {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'Scoped Realm reads require an absolute HTTP(S) Realm URL',
+      );
+    }
+    if (!this.readableRealmUrls) {
+      let grants = await this.listRealms({ permission: 'read' });
+      this.readableRealmUrls = new Set(grants.map((grant) => grant.url));
+    }
+    if (!this.readableRealmUrls.has(canonical)) {
+      throw new RealmRunnerError(
+        'CAPABILITY_DENIED',
+        `Active Boxel profile has no read grant for Realm ${canonical}`,
+      );
+    }
+    return canonical;
+  }
+
+  async authorizeWritableRealm(realmUrl) {
+    if (this.isCurrentRealm(realmUrl)) return this.realmUrl;
+    let canonical = await this.authorizeReadableRealm(realmUrl);
+    if (!this.writableRealmUrls) {
+      let grants = await this.listRealms({ permission: 'write' });
+      this.writableRealmUrls = new Set(grants.map((grant) => grant.url));
+    }
+    if (!this.writableRealmUrls.has(canonical)) {
+      throw new RealmRunnerError(
+        'CAPABILITY_DENIED',
+        `Active Boxel profile has no write grant for Realm ${canonical}`,
+      );
+    }
+    return canonical;
+  }
+
+  async listFor(realmUrl) {
+    if (this.isCurrentRealm(realmUrl)) return this.list();
+    realmUrl = await this.authorizeReadableRealm(realmUrl);
+    let cached = this.scopedFileLists.get(realmUrl);
+    if (cached) return [...cached];
+    let paths = await this.adapter.listFiles(
+      realmUrl,
+      this.limits.apiResponseBytes,
+    );
+    if (paths.length > this.limits.filesListed) {
+      throw new RealmRunnerError(
+        'RESULT_LIMIT',
+        `Realm contains more than ${this.limits.filesListed} files`,
+      );
+    }
+    let files = paths.map(realmPath).sort();
+    this.scopedFileLists.set(realmUrl, files);
+    return [...files];
+  }
+
+  async baselineFor(filePath) {
+    if (this.baseline.has(filePath)) return this.baseline.get(filePath);
+    let content = await this.adapter.readText(
+      this.realmUrl,
+      filePath,
+      this.limits.bytesRead - this.stats.bytesRead,
+    );
+    this.baseline.set(filePath, content);
+    if (content !== undefined) this.countRead(content);
+    return content;
+  }
+
+  async readText(filePath, realmUrl) {
+    filePath = realmPath(filePath);
+    if (!this.isCurrentRealm(realmUrl)) {
+      realmUrl = await this.authorizeReadableRealm(realmUrl);
+      let key = `${realmUrl}\u0000${filePath}`;
+      if (this.scopedReads.has(key)) {
+        let cached = this.scopedReads.get(key);
+        if (cached === undefined) {
+          throw new RealmRunnerError(
+            'NOT_FOUND',
+            `Realm file not found: ${filePath}`,
+          );
+        }
+        return cached;
+      }
+      let content = await this.adapter.readText(
+        realmUrl,
+        filePath,
+        this.limits.bytesRead - this.stats.bytesRead,
+      );
+      this.scopedReads.set(key, content);
+      if (content === undefined) {
+        throw new RealmRunnerError(
+          'NOT_FOUND',
+          `Realm file not found: ${filePath}`,
+        );
+      }
+      this.countRead(content);
+      return content;
+    }
+    if (this.overlay.has(filePath)) {
+      let staged = this.overlay.get(filePath);
+      if (staged === REMOVED) {
+        throw new RealmRunnerError(
+          'NOT_FOUND',
+          `Realm file not found: ${filePath}`,
+        );
+      }
+      return staged;
+    }
+    let content = await this.baselineFor(filePath);
+    if (content === undefined) {
+      throw new RealmRunnerError(
+        'NOT_FOUND',
+        `Realm file not found: ${filePath}`,
+      );
+    }
+    return content;
+  }
+
+  async readBase64(filePath, realmUrl) {
+    filePath = realmPath(filePath);
+    if (this.isCurrentRealm(realmUrl) && this.overlay.has(filePath)) {
+      let content = this.overlay.get(filePath);
+      if (content === REMOVED) {
+        throw new RealmRunnerError(
+          'NOT_FOUND',
+          `Realm file not found: ${filePath}`,
+        );
+      }
+      return bytesToBase64(textEncoder.encode(content));
+    }
+    let targetRealm = this.realmUrl;
+    if (!this.isCurrentRealm(realmUrl)) {
+      targetRealm = await this.authorizeReadableRealm(realmUrl);
+    }
+    let key = `${targetRealm}\u0000${filePath}`;
+    if (this.base64Reads.has(key)) return this.base64Reads.get(key);
+    let base64 = await this.adapter.readBase64(
+      targetRealm,
+      filePath,
+      Math.min(
+        this.limits.base64ReadBytes,
+        this.limits.bytesRead - this.stats.bytesRead,
+      ),
+    );
+    if (base64 === undefined) {
+      throw new RealmRunnerError(
+        'NOT_FOUND',
+        `Realm file not found: ${filePath}`,
+      );
+    }
+    let bytes = base64ByteLength(base64);
+    if (bytes > this.limits.base64ReadBytes) {
+      throw new RealmRunnerError(
+        'BYTE_LIMIT',
+        `Binary read exceeds ${this.limits.base64ReadBytes} bytes`,
+      );
+    }
+    this.stats.filesRead += 1;
+    this.countReadByteCount(bytes);
+    this.base64Reads.set(key, base64);
+    return base64;
+  }
+
+  async exists(filePath, realmUrl) {
+    filePath = realmPath(filePath);
+    if (!this.isCurrentRealm(realmUrl)) {
+      return (await this.listFor(realmUrl)).includes(filePath);
+    }
+    if (this.overlay.has(filePath)) {
+      return this.overlay.get(filePath) !== REMOVED;
+    }
+    if (this.baseline.has(filePath))
+      return this.baseline.get(filePath) !== undefined;
+    let files = await this.loadFileList();
+    return files.has(filePath);
+  }
+
+  async list() {
+    let files = new Set(await this.loadFileList());
+    for (let [filePath, content] of this.overlay) {
+      if (content === REMOVED) files.delete(filePath);
+      else files.add(filePath);
+    }
+    return [...files].sort();
+  }
+
+  async glob(pattern, options = {}, realmUrl) {
+    options ??= {};
+    pattern = globPattern(pattern);
+    let ignores = options.ignore ?? [];
+    ignores = Array.isArray(ignores) ? ignores : [ignores];
+    if (!ignores.every((ignore) => typeof ignore === 'string')) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'glob ignore must be a string or array of strings',
+      );
+    }
+    ignores = ignores.map(globPattern);
+    let files = await this.listFor(realmUrl);
+    let matchOptions = {
+      dot: options.dot === true,
+      nocase: false,
+      nonegate: true,
+      noext: false,
+    };
+    let matches = files.filter(
+      (filePath) =>
+        minimatch(filePath, pattern, matchOptions) &&
+        !ignores.some((ignore) => minimatch(filePath, ignore, matchOptions)),
+    );
+    let max = options.maxResults ?? this.limits.globResults;
+    if (
+      !Number.isSafeInteger(max) ||
+      max < 1 ||
+      max > this.limits.globResults
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        `maxResults must be between 1 and ${this.limits.globResults}`,
+      );
+    }
+    if (matches.length > max) {
+      throw new RealmRunnerError(
+        'RESULT_LIMIT',
+        `Glob matched ${matches.length} files; limit is ${max}`,
+      );
+    }
+    return matches;
+  }
+
+  async stat(filePath, realmUrl) {
+    filePath = realmPath(filePath);
+    if (!(await this.exists(filePath, realmUrl))) {
+      throw new RealmRunnerError(
+        'NOT_FOUND',
+        `Realm file not found: ${filePath}`,
+      );
+    }
+    let content = await this.readText(filePath, realmUrl);
+    return {
+      path: filePath,
+      type: 'file',
+      size: byteLength(content),
+      hash: await sha256(content),
+      staged: this.isCurrentRealm(realmUrl) && this.overlay.has(filePath),
+    };
+  }
+
+  async grep(pattern, options = {}, realmUrl) {
+    options ??= {};
+    if (typeof options !== 'object' || Array.isArray(options)) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'grep options must be an object',
+      );
+    }
+
+    let isSerializedRegex =
+      pattern &&
+      typeof pattern === 'object' &&
+      pattern.kind === 'regex' &&
+      typeof pattern.source === 'string';
+    if (typeof pattern !== 'string' && !isSerializedRegex) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'grep pattern must be a string or RegExp',
+      );
+    }
+    if (typeof pattern === 'string' && pattern.length === 0) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'grep pattern must not be empty',
+      );
+    }
+
+    let maxMatches = options.maxMatches ?? this.limits.grepMatches;
+    if (
+      !Number.isSafeInteger(maxMatches) ||
+      maxMatches < 1 ||
+      maxMatches > this.limits.grepMatches
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        `maxMatches must be between 1 and ${this.limits.grepMatches}`,
+      );
+    }
+    let contextLines = options.contextLines ?? 0;
+    if (
+      !Number.isSafeInteger(contextLines) ||
+      contextLines < 0 ||
+      contextLines > this.limits.grepContextLines
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        `contextLines must be between 0 and ${this.limits.grepContextLines}`,
+      );
+    }
+
+    let globs = options.glob ?? '**/*';
+    globs = Array.isArray(globs) ? globs : [globs];
+    if (!globs.every((pattern) => typeof pattern === 'string')) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'grep glob must be a string or array of strings',
+      );
+    }
+    let ignores = options.ignore ?? [];
+    ignores = Array.isArray(ignores) ? ignores : [ignores];
+    if (!ignores.every((pattern) => typeof pattern === 'string')) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'grep ignore must be a string or array of strings',
+      );
+    }
+    let candidates;
+    if (options.files !== undefined) {
+      if (!Array.isArray(options.files)) {
+        throw new RealmRunnerError(
+          'INVALID_ARGUMENT',
+          'grep files must be an array of paths, URLs, or search hits',
+        );
+      }
+      if (options.files.length > this.limits.globResults) {
+        throw new RealmRunnerError(
+          'RESULT_LIMIT',
+          `grep files contains more than ${this.limits.globResults} candidates`,
+        );
+      }
+      let grants = await this.listRealms({ permission: 'read' });
+      let realmUrls = grants
+        .map((grant) => grant.url)
+        .sort((a, b) => b.length - a.length);
+      candidates = [];
+      for (let candidate of options.files) {
+        let raw =
+          typeof candidate === 'string'
+            ? candidate
+            : candidate && typeof candidate.id === 'string'
+              ? candidate.id
+              : candidate && typeof candidate.path === 'string'
+                ? candidate.path
+                : undefined;
+        if (raw === undefined) {
+          throw new RealmRunnerError(
+            'INVALID_ARGUMENT',
+            'grep files entries must be paths, URLs, or objects with an id/path string',
+          );
+        }
+        let targetRealm = realmUrl;
+        let path = raw;
+        let id;
+        if (/^https?:\/\//i.test(raw)) {
+          targetRealm = realmUrls.find((url) => raw.startsWith(url));
+          if (!targetRealm) {
+            throw new RealmRunnerError(
+              'CAPABILITY_DENIED',
+              `grep candidate is outside the active profile's readable Realms: ${raw}`,
+            );
+          }
+          path = raw.slice(targetRealm.length);
+          id = raw;
+        }
+        path = realmPath(path);
+        if (
+          !globs.some((pattern) =>
+            minimatch(path, pattern, { dot: true, nonegate: true }),
+          ) ||
+          ignores.some((pattern) =>
+            minimatch(path, pattern, { dot: true, nonegate: true }),
+          )
+        ) {
+          continue;
+        }
+        candidates.push({ path, realmUrl: targetRealm, id });
+      }
+      candidates.sort((a, b) => (a.id ?? a.path).localeCompare(b.id ?? b.path));
+    } else {
+      let paths = new Set();
+      for (let pattern of globs) {
+        for (let path of await this.glob(pattern, undefined, realmUrl))
+          paths.add(path);
+      }
+      candidates = [...paths]
+        .filter(
+          (path) =>
+            !ignores.some((pattern) =>
+              minimatch(path, pattern, { dot: true, nonegate: true }),
+            ),
+        )
+        .sort()
+        .map((path) => ({ path, realmUrl }));
+    }
+
+    let caseSensitive = options.caseSensitive !== false;
+    let literal = options.literal === true || typeof pattern === 'string';
+    let expression;
+    let needle;
+    if (literal) {
+      needle = String(typeof pattern === 'string' ? pattern : pattern.source);
+      if (!caseSensitive) needle = needle.toLowerCase();
+    } else {
+      let flags = String(pattern.flags ?? '').replace(/[gy]/g, '');
+      if (!caseSensitive && !flags.includes('i')) flags += 'i';
+      if (pattern.source.length > 2_048) {
+        throw new RealmRunnerError(
+          'INVALID_ARGUMENT',
+          'grep RegExp source exceeds 2048 characters',
+        );
+      }
+      expression = new RegExp(pattern.source, `${flags}g`);
+    }
+
+    let matches = [];
+    for (let candidate of candidates) {
+      let { path } = candidate;
+      let content;
+      try {
+        content = await this.readText(path, candidate.realmUrl);
+      } catch (error) {
+        if (error?.code === 'BINARY_FILE') continue;
+        throw error;
+      }
+      let lines = content.split(/\r?\n/);
+      for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+        let line = lines[lineIndex];
+        let columns = [];
+        if (literal) {
+          let haystack = caseSensitive ? line : line.toLowerCase();
+          let offset = 0;
+          while (offset <= haystack.length) {
+            let index = haystack.indexOf(needle, offset);
+            if (index === -1) break;
+            columns.push(index);
+            offset = index + Math.max(needle.length, 1);
+          }
+        } else {
+          expression.lastIndex = 0;
+          let match;
+          while ((match = expression.exec(line))) {
+            columns.push(match.index);
+            if (match[0].length === 0) expression.lastIndex += 1;
+          }
+        }
+        for (let column of columns) {
+          let entry = {
+            path,
+            ...(candidate.id === undefined ? {} : { id: candidate.id }),
+            line: lineIndex + 1,
+            column: column + 1,
+            text: line,
+          };
+          if (contextLines > 0) {
+            entry.before = lines.slice(
+              Math.max(0, lineIndex - contextLines),
+              lineIndex,
+            );
+            entry.after = lines.slice(
+              lineIndex + 1,
+              lineIndex + 1 + contextLines,
+            );
+          }
+          matches.push(entry);
+          if (matches.length >= maxMatches) return matches;
+        }
+      }
+    }
+    return matches;
+  }
+
+  async stageWrite(filePath, content) {
+    filePath = realmPath(filePath);
+    if (typeof content !== 'string') {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'writeText content must be a string',
+      );
+    }
+    if (!this.baseline.has(filePath)) await this.baselineFor(filePath);
+    let previous = this.overlay.get(filePath);
+    let priorBytes =
+      previous === undefined || previous === REMOVED ? 0 : byteLength(previous);
+    this.stats.bytesWritten += byteLength(content) - priorBytes;
+    if (this.stats.bytesWritten > this.limits.bytesWritten) {
+      throw new RealmRunnerError(
+        'BYTE_LIMIT',
+        'Realm write-byte limit exceeded',
+      );
+    }
+    if (
+      !this.overlay.has(filePath) &&
+      this.overlay.size >= this.limits.filesChanged
+    ) {
+      throw new RealmRunnerError(
+        'OPERATION_LIMIT',
+        'Realm changed-file limit exceeded',
+      );
+    }
+    this.overlay.set(filePath, content);
+    this.stats.filesChanged = this.overlay.size;
+    return { path: filePath, staged: true };
+  }
+
+  async remove(filePath) {
+    filePath = realmPath(filePath);
+    let before = await this.baselineFor(filePath);
+    if (before === undefined) {
+      if (
+        this.overlay.has(filePath) &&
+        this.overlay.get(filePath) !== REMOVED
+      ) {
+        this.overlay.delete(filePath);
+        this.stats.filesChanged = this.overlay.size;
+        return { path: filePath, staged: false };
+      }
+      throw new RealmRunnerError(
+        'NOT_FOUND',
+        `Realm file not found: ${filePath}`,
+      );
+    }
+    if (
+      !this.overlay.has(filePath) &&
+      this.overlay.size >= this.limits.filesChanged
+    ) {
+      throw new RealmRunnerError(
+        'OPERATION_LIMIT',
+        'Realm changed-file limit exceeded',
+      );
+    }
+    this.overlay.set(filePath, REMOVED);
+    this.stats.filesChanged = this.overlay.size;
+    return { path: filePath, staged: true };
+  }
+
+  async replace(filePath, search, replacement, options = {}) {
+    options ??= {};
+    if (
+      typeof search !== 'string' ||
+      search.length === 0 ||
+      typeof replacement !== 'string'
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'replace requires non-empty string search and string replacement',
+      );
+    }
+    let content = await this.readText(filePath);
+    let parts = content.split(search);
+    let matches = parts.length - 1;
+    let expected = options.expectedMatches;
+    if (expected !== undefined && matches !== expected) {
+      throw new RealmRunnerError(
+        'MATCH_COUNT_MISMATCH',
+        `Expected ${expected} matches in ${filePath}; found ${matches}`,
+      );
+    }
+    if (matches === 0) {
+      throw new RealmRunnerError(
+        'MATCH_COUNT_MISMATCH',
+        `No matches found in ${filePath}`,
+      );
+    }
+    await this.stageWrite(filePath, parts.join(replacement));
+    return { path: realmPath(filePath), matches };
+  }
+
+  async appendText(filePath, content) {
+    filePath = realmPath(filePath);
+    if (typeof content !== 'string') {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'appendText content must be a string',
+      );
+    }
+    let before = (await this.exists(filePath))
+      ? await this.readText(filePath)
+      : '';
+    return this.stageWrite(filePath, before + content);
+  }
+
+  async lint(filePath, realmUrl) {
+    filePath = realmPath(filePath);
+    let source = await this.readText(filePath, realmUrl);
+    return this.adapter.lint(realmUrl ?? this.realmUrl, filePath, source);
+  }
+
+  async readTranspiled(filePath, realmUrl) {
+    filePath = realmPath(filePath);
+    if (!this.isCurrentRealm(realmUrl)) {
+      realmUrl = await this.authorizeReadableRealm(realmUrl);
+    }
+    let content = await this.adapter.readTranspiled(
+      realmUrl ?? this.realmUrl,
+      filePath,
+      this.limits.bytesRead - this.stats.bytesRead,
+    );
+    this.countReadBytes(content);
+    return content;
+  }
+
+  async apiRead(scope, method, path, body, options = {}, realmUrl) {
+    options ??= {};
+    if (
+      typeof options !== 'object' ||
+      Array.isArray(options) ||
+      (options.accept !== undefined && typeof options.accept !== 'string') ||
+      (options.contentType !== undefined &&
+        typeof options.contentType !== 'string')
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'API read accept and contentType options must be strings',
+      );
+    }
+    if (
+      (options.accept && byteLength(options.accept) > 512) ||
+      (options.contentType && byteLength(options.contentType) > 512)
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'API content type header exceeds 512 bytes',
+      );
+    }
+    if (method === 'Query') {
+      let encoded;
+      try {
+        encoded = JSON.stringify(body ?? null);
+      } catch (error) {
+        throw new RealmRunnerError(
+          'INVALID_ARGUMENT',
+          `API query body must be JSON-serializable: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      if (byteLength(encoded) > 256 * 1024) {
+        throw new RealmRunnerError(
+          'BYTE_LIMIT',
+          'API query body exceeds 256 KiB',
+        );
+      }
+    }
+    let adapterMethod = `${scope}${method}`;
+    let targetRealm =
+      scope === 'realm'
+        ? realmUrl
+          ? await this.authorizeReadableRealm(realmUrl)
+          : this.realmUrl
+        : undefined;
+    let result =
+      scope === 'realm'
+        ? await this.adapter[adapterMethod](
+            targetRealm,
+            path,
+            ...(method === 'Query' ? [body, options] : [options]),
+          )
+        : await this.adapter[adapterMethod](
+            path,
+            ...(method === 'Query' ? [body, options] : [options]),
+          );
+    if (Number.isSafeInteger(result.bodyBytes)) {
+      this.countReadByteCount(result.bodyBytes);
+    } else {
+      this.countReadBytes(JSON.stringify(result.body ?? null));
+    }
+    let publicResult = { ...result };
+    delete publicResult.bodyBytes;
+    return publicResult;
+  }
+
+  async apiRequest(
+    scope,
+    method,
+    path,
+    options = {},
+    realmUrl,
+    allowCrossRealmWrite = false,
+  ) {
+    options ??= {};
+    if (typeof method !== 'string' || !API_METHODS.has(method.toUpperCase())) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'API method must be GET, HEAD, QUERY, POST, PUT, PATCH, or DELETE',
+      );
+    }
+    method = method.toUpperCase();
+    if (MUTATING_API_METHODS.has(method)) {
+      if (realmUrl && !allowCrossRealmWrite) {
+        throw new RealmRunnerError(
+          'CAPABILITY_DENIED',
+          'Cross-Realm writes require realm.open(url, { write: true })',
+        );
+      }
+      if (this.mode !== 'commit') {
+        throw new RealmRunnerError(
+          'CAPABILITY_DENIED',
+          `API ${method} requests require Realm Script commit mode`,
+        );
+      }
+    }
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'API request options must be an object',
+      );
+    }
+
+    let responseType = options.responseType ?? 'auto';
+    if (!['auto', 'text', 'base64'].includes(responseType)) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        "API responseType must be 'auto', 'text', or 'base64'",
+      );
+    }
+    let bodyType = options.bodyType;
+    if (bodyType === undefined) {
+      bodyType =
+        options.body === undefined
+          ? 'none'
+          : typeof options.body === 'string'
+            ? 'text'
+            : 'json';
+    }
+    if (!['none', 'json', 'text', 'base64'].includes(bodyType)) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        "API bodyType must be 'none', 'json', 'text', or 'base64'",
+      );
+    }
+    if (['GET', 'HEAD'].includes(method) && bodyType !== 'none') {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        `${method} API requests cannot include a body`,
+      );
+    }
+    if (
+      (bodyType === 'text' || bodyType === 'base64') &&
+      typeof options.body !== 'string'
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        `API ${bodyType} body must be a string`,
+      );
+    }
+
+    let headers = options.headers ?? {};
+    if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'API headers must be an object of string values',
+      );
+    }
+    let headerBytes = 0;
+    let safeHeaders = {};
+    for (let [name, value] of Object.entries(headers)) {
+      let lowerName = name.toLowerCase();
+      if (
+        !/^[!#$%&'*+.^_`|~0-9a-z-]+$/i.test(name) ||
+        typeof value !== 'string' ||
+        /[\r\n]/.test(value)
+      ) {
+        throw new RealmRunnerError(
+          'INVALID_ARGUMENT',
+          'API headers must contain valid names and single-line string values',
+        );
+      }
+      if (
+        FORBIDDEN_API_HEADERS.has(lowerName) ||
+        (lowerName.startsWith('x-boxel-') &&
+          lowerName !== 'x-boxel-client-request-id')
+      ) {
+        throw new RealmRunnerError(
+          'CAPABILITY_DENIED',
+          `Realm Script cannot set the ${name} header`,
+        );
+      }
+      headerBytes += byteLength(name) + byteLength(value);
+      safeHeaders[name] = value;
+    }
+    if (headerBytes > this.limits.apiHeaderBytes) {
+      throw new RealmRunnerError(
+        'BYTE_LIMIT',
+        'API request headers exceed the configured byte limit',
+      );
+    }
+
+    for (let optionName of ['accept', 'contentType']) {
+      if (
+        options[optionName] !== undefined &&
+        (typeof options[optionName] !== 'string' ||
+          byteLength(options[optionName]) > 512 ||
+          /[\r\n]/.test(options[optionName]))
+      ) {
+        throw new RealmRunnerError(
+          'INVALID_ARGUMENT',
+          `API ${optionName} must be a single-line string no larger than 512 bytes`,
+        );
+      }
+    }
+
+    let requestBytes = 0;
+    if (bodyType === 'json') {
+      let encoded;
+      try {
+        encoded = JSON.stringify(options.body ?? null);
+      } catch (error) {
+        throw new RealmRunnerError(
+          'INVALID_ARGUMENT',
+          `API JSON body must be serializable: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      requestBytes = byteLength(encoded);
+    } else if (bodyType === 'text') {
+      requestBytes = byteLength(options.body);
+    } else if (bodyType === 'base64') {
+      try {
+        atob(options.body);
+      } catch {
+        throw new RealmRunnerError(
+          'INVALID_ARGUMENT',
+          'API base64 body is not valid base64',
+        );
+      }
+      requestBytes = base64ByteLength(options.body);
+    }
+    if (requestBytes > this.limits.apiRequestBytes) {
+      throw new RealmRunnerError(
+        'BYTE_LIMIT',
+        'API request body exceeds the configured byte limit',
+      );
+    }
+    if (
+      this.stats.apiBytesSent + requestBytes >
+      this.limits.apiTotalRequestBytes
+    ) {
+      throw new RealmRunnerError(
+        'BYTE_LIMIT',
+        'Cumulative API request bodies exceed the configured byte limit',
+      );
+    }
+
+    let responseBudget = Math.min(
+      this.limits.apiResponseBytes,
+      this.limits.apiTotalResponseBytes - this.stats.apiBytesReceived,
+    );
+    if (responseBudget < 0) {
+      throw new RealmRunnerError(
+        'BYTE_LIMIT',
+        'Cumulative API responses exceed the configured byte limit',
+      );
+    }
+
+    let targetRealm =
+      scope === 'realm'
+        ? realmUrl
+          ? MUTATING_API_METHODS.has(method)
+            ? await this.authorizeWritableRealm(realmUrl)
+            : await this.authorizeReadableRealm(realmUrl)
+          : this.realmUrl
+        : undefined;
+    let normalizedOptions = {
+      body: options.body,
+      bodyType,
+      responseType,
+      maxResponseBytes: responseBudget,
+      headers: safeHeaders,
+      ...(options.accept === undefined ? {} : { accept: options.accept }),
+      ...(options.contentType === undefined
+        ? {}
+        : { contentType: options.contentType }),
+    };
+    this.stats.apiRequests += 1;
+    this.stats.apiBytesSent += requestBytes;
+    let effect;
+    if (MUTATING_API_METHODS.has(method)) {
+      effect = {
+        scope,
+        ...(scope === 'realm' ? { realm: targetRealm } : {}),
+        method,
+        path,
+        status: null,
+        ok: null,
+      };
+      this.effects.push(effect);
+    }
+    let result;
+    // If this throws, the effect keeps a null outcome: a transport failure
+    // cannot prove whether the remote mutation completed.
+    try {
+      result =
+        scope === 'realm'
+          ? await this.adapter.realmRequest(
+              targetRealm,
+              method,
+              path,
+              normalizedOptions,
+            )
+          : await this.adapter.serverRequest(method, path, normalizedOptions);
+    } finally {
+      if (MUTATING_API_METHODS.has(method)) {
+        this.invalidateRawMutationCaches(scope, targetRealm);
+      }
+    }
+    if (effect) {
+      effect.status = result.status;
+      effect.ok = result.ok;
+    }
+    let responseBytes = Number.isSafeInteger(result.bodyBytes)
+      ? result.bodyBytes
+      : responseType === 'base64' && typeof result.body === 'string'
+        ? base64ByteLength(result.body)
+        : byteLength(
+            typeof result.body === 'string'
+              ? result.body
+              : JSON.stringify(result.body ?? null),
+          );
+    if (responseBytes > this.limits.apiResponseBytes) {
+      throw new RealmRunnerError(
+        'BYTE_LIMIT',
+        'API response body exceeds the configured byte limit',
+      );
+    }
+    if (
+      this.stats.apiBytesReceived + responseBytes >
+      this.limits.apiTotalResponseBytes
+    ) {
+      throw new RealmRunnerError(
+        'BYTE_LIMIT',
+        'Cumulative API responses exceed the configured byte limit',
+      );
+    }
+    this.stats.apiBytesReceived += responseBytes;
+    let publicResult = { ...result };
+    delete publicResult.bodyBytes;
+    return publicResult;
+  }
+
+  async listRealms(options = {}) {
+    options ??= {};
+    if (
+      typeof options !== 'object' ||
+      Array.isArray(options) ||
+      ![undefined, 'read', 'write'].includes(options.permission)
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        "listRealms permission must be 'read' or 'write'",
+      );
+    }
+    let grants = await this.adapter.listRealms();
+    if (options.permission === 'read') {
+      grants = grants.filter((grant) => grant.canRead);
+    } else if (options.permission === 'write') {
+      grants = grants.filter((grant) => grant.canWrite);
+    }
+    if (grants.length > this.limits.searchRealms) {
+      throw new RealmRunnerError(
+        'RESULT_LIMIT',
+        `Realm discovery returned ${grants.length} realms; limit is ${this.limits.searchRealms}`,
+      );
+    }
+    return grants;
+  }
+
+  async search(query = {}, options = {}) {
+    query ??= {};
+    options ??= {};
+    if (
+      typeof query !== 'object' ||
+      Array.isArray(query) ||
+      typeof options !== 'object' ||
+      Array.isArray(options)
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'search requires a query object and an options object',
+      );
+    }
+
+    let requestedRealms = options.realms;
+    let realmUrls;
+    if (requestedRealms === undefined || requestedRealms === 'current') {
+      realmUrls = [this.realmUrl];
+    } else if (requestedRealms === 'all') {
+      realmUrls = (await this.listRealms({ permission: 'read' })).map(
+        (grant) => grant.url,
+      );
+    } else if (typeof requestedRealms === 'string') {
+      realmUrls = [requestedRealms];
+    } else if (
+      Array.isArray(requestedRealms) &&
+      requestedRealms.every(
+        (realmUrl) => typeof realmUrl === 'string' && realmUrl.length > 0,
+      )
+    ) {
+      realmUrls = [...requestedRealms];
+    } else {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        "search options.realms must be 'current', 'all', a Realm URL, or an array of Realm URLs",
+      );
+    }
+
+    realmUrls = [...new Set(realmUrls)];
+    if (realmUrls.length === 0) return [];
+    if (realmUrls.length > this.limits.searchRealms) {
+      throw new RealmRunnerError(
+        'RESULT_LIMIT',
+        `Search spans ${realmUrls.length} realms; limit is ${this.limits.searchRealms}`,
+      );
+    }
+    realmUrls = await Promise.all(
+      realmUrls.map((realmUrl) => this.authorizeReadableRealm(realmUrl)),
+    );
+
+    let batches = [];
+    for (
+      let offset = 0;
+      offset < realmUrls.length;
+      offset += this.limits.searchRealmBatchSize
+    ) {
+      batches.push(
+        realmUrls.slice(offset, offset + this.limits.searchRealmBatchSize),
+      );
+    }
+
+    let resultsByBatch = new Array(batches.length);
+    let nextBatch = 0;
+    let searchWorker = async () => {
+      while (nextBatch < batches.length) {
+        let index = nextBatch++;
+        resultsByBatch[index] = await this.adapter.search(
+          batches[index],
+          query,
+        );
+      }
+    };
+    await Promise.all(
+      Array.from(
+        { length: Math.min(this.limits.searchConcurrency, batches.length) },
+        searchWorker,
+      ),
+    );
+
+    let results = [];
+    let seen = new Set();
+    for (let batchResults of resultsByBatch) {
+      for (let item of batchResults) {
+        let key =
+          item && typeof item === 'object' && item.id
+            ? `${item.type ?? ''}\u0000${item.id}`
+            : JSON.stringify(item);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        results.push(item);
+        if (results.length > this.limits.searchResults) {
+          throw new RealmRunnerError(
+            'RESULT_LIMIT',
+            `Search returned more than ${this.limits.searchResults} items`,
+          );
+        }
+      }
+    }
+    return results;
+  }
+
+  evaluateBxl(expression, input, options = {}) {
+    if (!this.bxl) {
+      throw new RealmRunnerError(
+        'BXL_NOT_FOUND',
+        'BXL is not configured for this Realm Runner',
+      );
+    }
+    if (
+      typeof expression !== 'string' ||
+      expression.length === 0 ||
+      byteLength(expression) > this.limits.bxlSourceBytes
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        `BXL source must be a non-empty string no larger than ${this.limits.bxlSourceBytes} bytes`,
+      );
+    }
+    options ??= {};
+    if (
+      typeof options !== 'object' ||
+      Array.isArray(options) ||
+      ![undefined, 'auto', 'jq', 'readable'].includes(options.syntax)
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        "BXL syntax must be 'auto', 'jq', or 'readable'",
+      );
+    }
+    try {
+      return this.bxl.evaluate(expression, input, options);
+    } catch (error) {
+      throw new RealmRunnerError(
+        'BXL_ERROR',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  captureLog(level, args) {
+    if (this.logs.length >= this.limits.logs) return;
+    let entry = { level, args: jsonClone(args) };
+    let size = byteLength(JSON.stringify(entry));
+    if (this.logBytes + size > this.limits.logBytes) return;
+    this.logBytes += size;
+    this.logs.push(entry);
+  }
+
+  activityDetails(value) {
+    let details = typeof value === 'string' ? { message: value } : value;
+    if (!details || typeof details !== 'object' || Array.isArray(details)) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'realm.activity requires a message string or activity object',
+      );
+    }
+    let message = details.message;
+    if (typeof message !== 'string') {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'Realm activity message must be a string',
+      );
+    }
+    message = [...message]
+      .map((character) => {
+        let code = character.charCodeAt(0);
+        return code < 32 || code === 127 ? ' ' : character;
+      })
+      .join('')
+      .trim();
+    if (message.length === 0 || message.length > MAX_ACTIVITY_MESSAGE_CHARS) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        `Realm activity message must be 1-${MAX_ACTIVITY_MESSAGE_CHARS} characters`,
+      );
+    }
+    let phase = details.phase;
+    if (
+      phase !== undefined &&
+      (typeof phase !== 'string' || !/^[a-z][a-z0-9-]{0,63}$/.test(phase))
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'Realm activity phase must be a lowercase identifier',
+      );
+    }
+    let current = details.current;
+    let total = details.total;
+    for (let [name, number] of [
+      ['current', current],
+      ['total', total],
+    ]) {
+      if (
+        number !== undefined &&
+        (!Number.isSafeInteger(number) || number < 0 || number > 1_000_000_000)
+      ) {
+        throw new RealmRunnerError(
+          'INVALID_ARGUMENT',
+          `Realm activity ${name} must be a non-negative safe integer`,
+        );
+      }
+    }
+    if (current !== undefined && total !== undefined && current > total) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'Realm activity current cannot exceed total',
+      );
+    }
+    return {
+      message,
+      ...(phase === undefined ? {} : { phase }),
+      ...(current === undefined ? {} : { current }),
+      ...(total === undefined ? {} : { total }),
+    };
+  }
+
+  async dispatch(operation, args) {
+    this.countCall();
+    switch (operation) {
+      case 'current':
+        return { url: this.realmUrl, mode: this.mode };
+      case 'activity':
+        return this.activityDetails(args[0]);
+      case 'realms.list':
+        return this.listRealms(args[0]);
+      case 'bxl.evaluate':
+        return this.evaluateBxl(args[0], args[1], args[2]);
+      case 'fs.list':
+        return this.list();
+      case 'fs.glob':
+        return this.glob(args[0], args[1]);
+      case 'fs.grep':
+        return this.grep(args[0], args[1]);
+      case 'fs.stat':
+        return this.stat(args[0]);
+      case 'fs.exists':
+        return this.exists(args[0]);
+      case 'fs.readText':
+        return this.readText(args[0]);
+      case 'fs.readJSON':
+        return JSON.parse(await this.readText(args[0]));
+      case 'fs.readBase64':
+        return this.readBase64(args[0]);
+      case 'fs.writeText':
+        return this.stageWrite(args[0], args[1]);
+      case 'fs.writeJSON':
+        return this.stageWrite(
+          args[0],
+          `${JSON.stringify(args[1], null, args[2]?.space ?? 2)}\n`,
+        );
+      case 'fs.appendText':
+        return this.appendText(args[0], args[1]);
+      case 'fs.replace':
+        return this.replace(args[0], args[1], args[2], args[3]);
+      case 'fs.copy':
+        return this.stageWrite(args[1], await this.readText(args[0]));
+      case 'fs.remove':
+        return this.remove(args[0]);
+      case 'fs.diff': {
+        let path = args[0] == null ? undefined : realmPath(args[0]);
+        return (await this.changes()).filter(
+          (change) => path === undefined || change.path === path,
+        );
+      }
+      case 'fs.lint':
+        return this.lint(args[0]);
+      case 'fs.readTranspiled':
+        return this.readTranspiled(args[0]);
+      case 'indexingErrors':
+        return this.adapter.indexingErrors(this.realmUrl);
+      case 'api.get':
+        return this.apiRead('realm', 'Get', args[0], undefined, args[1]);
+      case 'api.head':
+        return this.apiRead('realm', 'Head', args[0], undefined, args[1]);
+      case 'api.query':
+        return this.apiRead('realm', 'Query', args[0], args[1], args[2]);
+      case 'api.request':
+        return this.apiRequest('realm', args[0], args[1], args[2]);
+      case 'server.get':
+        return this.apiRead('server', 'Get', args[0], undefined, args[1]);
+      case 'server.head':
+        return this.apiRead('server', 'Head', args[0], undefined, args[1]);
+      case 'server.query':
+        return this.apiRead('server', 'Query', args[0], args[1], args[2]);
+      case 'server.request':
+        return this.apiRequest('server', args[0], args[1], args[2]);
+      case 'scoped.fs.list':
+        return this.listFor(args[0]);
+      case 'scoped.fs.glob':
+        return this.glob(args[1], args[2], args[0]);
+      case 'scoped.fs.grep':
+        return this.grep(args[1], args[2], args[0]);
+      case 'scoped.fs.stat':
+        return this.stat(args[1], args[0]);
+      case 'scoped.fs.exists':
+        return this.exists(args[1], args[0]);
+      case 'scoped.fs.readText':
+        return this.readText(args[1], args[0]);
+      case 'scoped.fs.readJSON':
+        return JSON.parse(await this.readText(args[1], args[0]));
+      case 'scoped.fs.readBase64':
+        return this.readBase64(args[1], args[0]);
+      case 'scoped.fs.lint':
+        return this.lint(args[1], args[0]);
+      case 'scoped.fs.readTranspiled':
+        return this.readTranspiled(args[1], args[0]);
+      case 'scoped.api.get':
+        return this.apiRead(
+          'realm',
+          'Get',
+          args[1],
+          undefined,
+          args[2],
+          args[0],
+        );
+      case 'scoped.api.head':
+        return this.apiRead(
+          'realm',
+          'Head',
+          args[1],
+          undefined,
+          args[2],
+          args[0],
+        );
+      case 'scoped.api.query':
+        return this.apiRead(
+          'realm',
+          'Query',
+          args[1],
+          args[2],
+          args[3],
+          args[0],
+        );
+      case 'scoped.api.request':
+        return this.apiRequest(
+          'realm',
+          args[1],
+          args[2],
+          args[3],
+          args[0],
+          args[4] === true,
+        );
+      case 'scoped.indexingErrors':
+        return this.adapter.indexingErrors(
+          await this.authorizeReadableRealm(args[0]),
+        );
+      case 'search':
+        return this.search(args[0], args[1]);
+      case 'help':
+        return {
+          apiVersion: '2',
+          features: {
+            notebooks: true,
+            activity: true,
+            streamingActivity: true,
+          },
+          methods: [
+            'realm.current',
+            'realm.input',
+            'realm.notebook',
+            'realm.activity(messageOrDetails)',
+            'realm.listRealms(options?)',
+            'realm.search(query, options?)',
+            'realm.bxl.evaluate(expression, input, options?)',
+            'realm.bxl.jq(expression, input)',
+            'realm.indexingErrors()',
+            'realm.api.get(path, options?)',
+            'realm.api.head(path, options?)',
+            'realm.api.query(path, body, options?)',
+            'realm.api.request(method, path, options?)',
+            'realm.server.get(path, options?)',
+            'realm.server.head(path, options?)',
+            'realm.server.query(path, body, options?)',
+            'realm.server.request(method, path, options?)',
+            'realm.open(url, options?).fs.* (read-only)',
+            'realm.open(url).search(query)',
+            'realm.open(url).api.get(path, options?)',
+            'realm.open(url).api.head(path, options?)',
+            'realm.open(url).api.query(path, body, options?)',
+            'realm.open(url).api.request(method, path, options?) (read-only)',
+            'realm.open(url, { write: true }).api.request(method, path, options?) (commit + write grant)',
+            'realm.open(url).indexingErrors()',
+            'realm.fs.list()',
+            'realm.fs.glob(pattern, options?)',
+            'realm.fs.grep(pattern, { glob?, files?, ignore?, contextLines?, maxMatches? })',
+            'realm.fs.stat(path)',
+            'realm.fs.exists(path)',
+            'realm.fs.readText(path)',
+            'realm.fs.readJSON(path)',
+            'realm.fs.readBase64(path)',
+            'realm.fs.writeText(path, content)',
+            'realm.fs.writeJSON(path, value, options?)',
+            'realm.fs.appendText(path, content)',
+            'realm.fs.replace(path, search, replacement, options?)',
+            'realm.fs.copy(from, to)',
+            'realm.fs.remove(path)',
+            'realm.fs.diff(path?)',
+            'realm.fs.lint(path)',
+            'realm.fs.readTranspiled(path)',
+          ],
+        };
+      default:
+        throw new RealmRunnerError(
+          'CAPABILITY_DENIED',
+          `Unknown Realm capability operation: ${operation}`,
+        );
+    }
+  }
+
+  async changes() {
+    let changes = [];
+    for (let [filePath, after] of this.overlay) {
+      let before = this.baseline.get(filePath);
+      if (before === after) continue;
+      if (before === undefined && after === REMOVED) continue;
+      let diff = createTwoFilesPatch(
+        before === undefined ? '/dev/null' : `a/${filePath}`,
+        after === REMOVED ? '/dev/null' : `b/${filePath}`,
+        before ?? '',
+        after === REMOVED ? '' : after,
+        '',
+        '',
+        { context: 3 },
+      );
+      if (byteLength(diff) > this.limits.diffBytes) {
+        diff = `${diff.slice(0, this.limits.diffBytes)}\n... diff truncated ...\n`;
+      }
+      changes.push({
+        operation:
+          after === REMOVED
+            ? 'remove'
+            : before === undefined
+              ? 'create'
+              : 'update',
+        path: filePath,
+        beforeHash: before === undefined ? null : await sha256(before),
+        afterHash: after === REMOVED ? null : await sha256(after),
+        diff,
+      });
+    }
+    return changes;
+  }
+
+  async finish() {
+    let changes = await this.changes();
+    if (this.mode === 'commit' && changes.length > 0) {
+      for (let change of changes) {
+        let latest = await this.adapter.readText(this.realmUrl, change.path);
+        if (latest !== this.baseline.get(change.path)) {
+          throw new RealmRunnerError(
+            'WRITE_CONFLICT',
+            `Realm file changed while the program was running: ${change.path}`,
+          );
+        }
+      }
+      await this.adapter.atomicWrite(
+        this.realmUrl,
+        changes.map((change) => ({
+          operation: change.operation,
+          path: change.path,
+          content:
+            this.overlay.get(change.path) === REMOVED
+              ? undefined
+              : this.overlay.get(change.path),
+          exists: this.baseline.get(change.path) !== undefined,
+        })),
+      );
+    }
+    return {
+      changes,
+      effects: this.effects.map((effect) => ({ ...effect })),
+      logs: this.logs,
+      stats: { ...this.stats },
+    };
+  }
+}
+
+export { DEFAULT_LIMITS };

--- a/packages/realm-runner/src/core.js
+++ b/packages/realm-runner/src/core.js
@@ -1,0 +1,9 @@
+export { RealmCapabilityHost, DEFAULT_LIMITS } from './capability.js';
+export { RealmRunnerError, errorDetails } from './errors.js';
+export { RealmNotebookCoordinator } from './notebook.js';
+export {
+  EncryptedNotebookStorage,
+  MemoryNotebookStorage,
+  RealmFileNotebookStorage,
+} from './notebook-storage.js';
+export { runRealmScript, DEFAULT_RUNTIME_LIMITS } from './runner.js';

--- a/packages/realm-runner/src/errors.js
+++ b/packages/realm-runner/src/errors.js
@@ -1,0 +1,24 @@
+export class RealmRunnerError extends Error {
+  constructor(code, message, details) {
+    super(message);
+    this.name = 'RealmRunnerError';
+    this.code = code;
+    if (details !== undefined) {
+      this.details = details;
+    }
+  }
+}
+
+export function errorDetails(error) {
+  if (error instanceof RealmRunnerError) {
+    return {
+      code: error.code,
+      message: error.message,
+      ...(error.details === undefined ? {} : { details: error.details }),
+    };
+  }
+  return {
+    code: 'RUNTIME_ERROR',
+    message: error instanceof Error ? error.message : String(error),
+  };
+}

--- a/packages/realm-runner/src/http-adapter.js
+++ b/packages/realm-runner/src/http-adapter.js
@@ -1,0 +1,559 @@
+import { isBinaryFilename } from '@cardstack/runtime-common/infer-content-type';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+import { searchEntryWireQueryFromQuery } from '@cardstack/runtime-common/search-entry';
+import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
+
+import { RealmRunnerError } from './errors.js';
+
+function scopedUrl(base, path) {
+  if (typeof path !== 'string' || path.length === 0 || path.includes('\\')) {
+    throw new RealmRunnerError(
+      'INVALID_ARGUMENT',
+      'API path must be a non-empty Realm-relative path',
+    );
+  }
+  if (/^[a-z][a-z0-9+.-]*:/i.test(path) || path.startsWith('//')) {
+    throw new RealmRunnerError(
+      'CAPABILITY_DENIED',
+      'Realm API reads cannot target an absolute URL',
+    );
+  }
+  let target = new URL(path.replace(/^\/+/, ''), base);
+  let baseUrl = new URL(base);
+  if (
+    target.origin !== baseUrl.origin ||
+    !target.pathname.startsWith(baseUrl.pathname)
+  ) {
+    throw new RealmRunnerError(
+      'CAPABILITY_DENIED',
+      'Realm API path escapes the authorized scope',
+    );
+  }
+  return target.href;
+}
+
+async function readResponseBytes(
+  response,
+  maxBytes = Number.POSITIVE_INFINITY,
+) {
+  let declaredLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    throw new RealmRunnerError(
+      'BYTE_LIMIT',
+      'Realm API response exceeds the configured byte limit',
+    );
+  }
+  if (!response.body) return new Uint8Array();
+
+  let reader = response.body.getReader();
+  let chunks = [];
+  let total = 0;
+  try {
+    for (;;) {
+      let { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new RealmRunnerError(
+          'BYTE_LIMIT',
+          'Realm API response exceeds the configured byte limit',
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  let bytes = new Uint8Array(total);
+  let offset = 0;
+  for (let chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function responseValue(
+  response,
+  responseType = 'auto',
+  maxBytes = Number.POSITIVE_INFINITY,
+) {
+  let headers = {};
+  for (let name of ['content-type', 'etag', 'last-modified', 'location']) {
+    let value = response.headers.get(name);
+    if (value !== null) headers[name] = value;
+  }
+  let bytes = await readResponseBytes(response, maxBytes);
+  let body;
+  if (responseType === 'base64') {
+    body = bytesToBase64(bytes);
+  } else {
+    let contentType = response.headers.get('content-type') ?? '';
+    let text = new TextDecoder().decode(bytes);
+    body = text;
+    if (
+      responseType === 'auto' &&
+      /\bjson\b|\+json\b/i.test(contentType) &&
+      text.length > 0
+    ) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        // Preserve malformed or non-standard JSON bodies as text.
+      }
+    }
+  }
+  return {
+    ok: response.ok,
+    status: response.status,
+    headers,
+    body,
+    bodyBytes: bytes.byteLength,
+  };
+}
+
+async function jsonResponseBody(response, maxBytes) {
+  let text = new TextDecoder().decode(
+    await readResponseBytes(response, maxBytes),
+  );
+  return JSON.parse(text);
+}
+
+async function errorSnippet(response, maxBytes = 4 * 1024) {
+  return new TextDecoder()
+    .decode(await readResponseBytes(response, maxBytes))
+    .slice(0, 300);
+}
+
+function jwtClaims(authorization) {
+  try {
+    let token = authorization.replace(/^Bearer\s+/i, '');
+    let payload = token.split('.')[1];
+    if (!payload) return {};
+    let base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+    base64 += '='.repeat((4 - (base64.length % 4)) % 4);
+    let bytes = Uint8Array.from(atob(base64), (character) =>
+      character.charCodeAt(0),
+    );
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    return {};
+  }
+}
+
+function bytesToBase64(bytes) {
+  let binary = '';
+  let chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(offset, offset + chunkSize),
+    );
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(value) {
+  let binary;
+  try {
+    binary = atob(value);
+  } catch {
+    throw new RealmRunnerError(
+      'INVALID_ARGUMENT',
+      'API base64 body is not valid base64',
+    );
+  }
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+const BLOCKED_RAW_ENDPOINTS = new Set([
+  '_delegate-session',
+  '_realm-auth',
+  '_realm-program',
+  '_server-session',
+  '_session',
+]);
+
+function assertRawEndpointAllowed(url) {
+  let endpoint = new URL(url).pathname.split('/').filter(Boolean).at(-1);
+  if (endpoint && BLOCKED_RAW_ENDPOINTS.has(endpoint)) {
+    throw new RealmRunnerError(
+      'CAPABILITY_DENIED',
+      `Raw Realm API access to ${endpoint} is reserved by the capability host`,
+    );
+  }
+}
+
+function resourceIdentity(type, id) {
+  return `${type}\u0000${id}`;
+}
+
+function itemsFromEntryDocument(document) {
+  let included = new Map();
+  for (let resource of document.included ?? []) {
+    if (resource?.type && resource?.id) {
+      included.set(resourceIdentity(resource.type, resource.id), resource);
+    }
+  }
+  let items = [];
+  for (let entry of document.data ?? []) {
+    let ref = entry?.relationships?.item?.data;
+    let item = ref && included.get(resourceIdentity(ref.type, ref.id));
+    if (item) items.push(item);
+  }
+  return items;
+}
+
+export class BoxelHttpAdapter {
+  constructor({
+    fetch,
+    authorization,
+    realmServerUrl,
+    requestTimeoutMs = 120_000,
+    responseLimitBytes = 4 * 1024 * 1024,
+  }) {
+    if (typeof fetch !== 'function') throw new TypeError('fetch is required');
+    if (typeof authorization !== 'string' || authorization.length === 0) {
+      throw new RealmRunnerError(
+        'AUTHORIZATION_REQUIRED',
+        'Realm Program execution requires an Authorization header',
+      );
+    }
+    this.fetch = fetch;
+    this.authorization = authorization;
+    this.realmServerUrl = ensureTrailingSlash(realmServerUrl);
+    this.requestTimeoutMs = requestTimeoutMs;
+    this.responseLimitBytes = responseLimitBytes;
+  }
+
+  setProgramSignal(signal) {
+    this.programSignal = signal;
+  }
+
+  async request(url, init = {}) {
+    let headers = new Headers(init.headers);
+    headers.set('Authorization', this.authorization);
+    try {
+      let timeoutSignal = AbortSignal.timeout(this.requestTimeoutMs);
+      return await this.fetch(url, {
+        ...init,
+        headers,
+        signal: this.programSignal
+          ? AbortSignal.any([timeoutSignal, this.programSignal])
+          : timeoutSignal,
+      });
+    } catch (error) {
+      if (error?.name === 'TimeoutError' || error?.name === 'AbortError') {
+        if (this.programSignal?.aborted) {
+          throw new RealmRunnerError(
+            'TIME_LIMIT',
+            'Realm Script wall-clock execution timed out',
+          );
+        }
+        throw new RealmRunnerError(
+          'REALM_API_TIMEOUT',
+          `Realm API request timed out after ${this.requestTimeoutMs}ms`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  async listFiles(realmUrl, maxBytes = this.responseLimitBytes) {
+    realmUrl = ensureTrailingSlash(realmUrl);
+    let response = await this.request(`${realmUrl}_mtimes`, {
+      headers: { Accept: SupportedMimeType.Mtimes },
+    });
+    if (!response.ok) {
+      throw new RealmRunnerError(
+        'REALM_API_ERROR',
+        `_mtimes returned HTTP ${response.status}: ${await errorSnippet(response)}`,
+      );
+    }
+    let document = await jsonResponseBody(response, maxBytes);
+    let mtimes = document?.data?.attributes?.mtimes ?? document;
+    return Object.keys(mtimes)
+      .filter((url) => url.startsWith(realmUrl))
+      .map((url) => url.slice(realmUrl.length))
+      .filter((path) => path.length > 0 && !path.endsWith('/'))
+      .sort();
+  }
+
+  async readText(realmUrl, filePath, maxBytes = this.responseLimitBytes) {
+    if (isBinaryFilename(filePath)) {
+      throw new RealmRunnerError('BINARY_FILE', `${filePath} is binary`);
+    }
+    let response = await this.request(
+      new URL(filePath, ensureTrailingSlash(realmUrl)).href,
+      { headers: { Accept: SupportedMimeType.CardSource } },
+    );
+    if (response.status === 404) return undefined;
+    if (!response.ok) {
+      throw new RealmRunnerError(
+        'REALM_API_ERROR',
+        `Unable to read ${filePath}: HTTP ${response.status}`,
+      );
+    }
+    return new TextDecoder().decode(
+      await readResponseBytes(response, maxBytes),
+    );
+  }
+
+  async readBase64(realmUrl, filePath, maxBytes = this.responseLimitBytes) {
+    let response = await this.request(
+      new URL(filePath, ensureTrailingSlash(realmUrl)).href,
+      { headers: { Accept: SupportedMimeType.CardSource } },
+    );
+    if (response.status === 404) return undefined;
+    if (!response.ok) {
+      throw new RealmRunnerError(
+        'REALM_API_ERROR',
+        `Unable to read ${filePath}: HTTP ${response.status}`,
+      );
+    }
+    return bytesToBase64(await readResponseBytes(response, maxBytes));
+  }
+
+  async readTranspiled(realmUrl, filePath, maxBytes = this.responseLimitBytes) {
+    let response = await this.request(
+      new URL(filePath, ensureTrailingSlash(realmUrl)).href,
+      { headers: { Accept: '*/*' } },
+    );
+    if (!response.ok) {
+      throw new RealmRunnerError(
+        'REALM_API_ERROR',
+        `Unable to read transpiled module ${filePath}: HTTP ${response.status}`,
+      );
+    }
+    return new TextDecoder().decode(
+      await readResponseBytes(response, maxBytes),
+    );
+  }
+
+  async lint(realmUrl, filePath, source) {
+    let response = await this.request(
+      new URL('_lint', ensureTrailingSlash(realmUrl)).href,
+      {
+        method: 'QUERY',
+        headers: {
+          Accept: SupportedMimeType.JSON,
+          'Content-Type': 'text/plain',
+          'X-Filename': filePath,
+        },
+        body: source,
+      },
+    );
+    if (!response.ok) {
+      throw new RealmRunnerError(
+        'REALM_API_ERROR',
+        `Unable to lint ${filePath}: HTTP ${response.status}`,
+      );
+    }
+    return jsonResponseBody(response, this.responseLimitBytes);
+  }
+
+  async listRealms() {
+    let response = await this.request(
+      new URL('_realm-auth', this.realmServerUrl).href,
+      {
+        method: 'POST',
+        headers: { Accept: SupportedMimeType.JSON },
+      },
+    );
+    if (!response.ok) {
+      throw new RealmRunnerError(
+        'REALM_API_ERROR',
+        `Realm discovery failed: HTTP ${response.status}`,
+      );
+    }
+    let sessions = await jsonResponseBody(response, this.responseLimitBytes);
+    return Object.entries(sessions)
+      .map(([url, token]) => {
+        let permissions = jwtClaims(`Bearer ${token}`).permissions ?? [];
+        return {
+          id: ensureTrailingSlash(url),
+          url: ensureTrailingSlash(url),
+          canRead: permissions.includes('read'),
+          canWrite:
+            permissions.includes('read') && permissions.includes('write'),
+        };
+      })
+      .sort((a, b) => a.url.localeCompare(b.url));
+  }
+
+  async search(realmUrls, query) {
+    let { cardUrls, scope, ...cardQuery } = query;
+    let body = {
+      ...searchEntryWireQueryFromQuery(cardQuery, {
+        fields: ['item'],
+        ...(scope ? { scope } : {}),
+      }),
+      realms: realmUrls.map(ensureTrailingSlash),
+      ...(cardUrls ? { cardUrls } : {}),
+    };
+    let response = await this.request(
+      new URL('_federated-search', this.realmServerUrl).href,
+      {
+        method: 'QUERY',
+        headers: {
+          Accept: 'application/vnd.card+json',
+          'Content-Type': SupportedMimeType.JSON,
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!response.ok) {
+      throw new RealmRunnerError(
+        'REALM_API_ERROR',
+        `Federated search failed: HTTP ${response.status}: ${await errorSnippet(response)}`,
+      );
+    }
+    return itemsFromEntryDocument(
+      await jsonResponseBody(response, this.responseLimitBytes),
+    );
+  }
+
+  async indexingErrors(realmUrl) {
+    let response = await this.request(
+      new URL('_indexing-errors', ensureTrailingSlash(realmUrl)).href,
+      { headers: { Accept: SupportedMimeType.JSONAPI } },
+    );
+    if (!response.ok) {
+      throw new RealmRunnerError(
+        'REALM_API_ERROR',
+        `Unable to read indexing errors: HTTP ${response.status}`,
+      );
+    }
+    return jsonResponseBody(response, this.responseLimitBytes);
+  }
+
+  realmGet(realmUrl, path, options = {}) {
+    return this.realmRead(realmUrl, 'GET', path, undefined, options);
+  }
+
+  realmHead(realmUrl, path, options = {}) {
+    return this.realmRead(realmUrl, 'HEAD', path, undefined, options);
+  }
+
+  realmQuery(realmUrl, path, body, options = {}) {
+    return this.realmRead(realmUrl, 'QUERY', path, body, options);
+  }
+
+  async realmRead(realmUrl, method, path, body, options) {
+    return this.readApi(
+      scopedUrl(ensureTrailingSlash(realmUrl), path),
+      method,
+      body,
+      options,
+    );
+  }
+
+  serverGet(path, options = {}) {
+    return this.serverRead('GET', path, undefined, options);
+  }
+
+  serverHead(path, options = {}) {
+    return this.serverRead('HEAD', path, undefined, options);
+  }
+
+  serverQuery(path, body, options = {}) {
+    return this.serverRead('QUERY', path, body, options);
+  }
+
+  async serverRead(method, path, body, options) {
+    return this.readApi(
+      scopedUrl(this.realmServerUrl, path),
+      method,
+      body,
+      options,
+    );
+  }
+
+  async readApi(url, method, body, options = {}) {
+    let headers = { Accept: options.accept ?? SupportedMimeType.JSON };
+    let init = { method, headers };
+    if (method === 'QUERY') {
+      headers['Content-Type'] = options.contentType ?? SupportedMimeType.JSON;
+      init.body = JSON.stringify(body ?? null);
+    }
+    return responseValue(
+      await this.request(url, init),
+      'auto',
+      this.responseLimitBytes,
+    );
+  }
+
+  realmRequest(realmUrl, method, path, options = {}) {
+    return this.rawApiRequest(
+      scopedUrl(ensureTrailingSlash(realmUrl), path),
+      method,
+      options,
+    );
+  }
+
+  serverRequest(method, path, options = {}) {
+    return this.rawApiRequest(
+      scopedUrl(this.realmServerUrl, path),
+      method,
+      options,
+    );
+  }
+
+  async rawApiRequest(url, method, options = {}) {
+    assertRawEndpointAllowed(url);
+    let headers = new Headers(options.headers);
+    if (options.accept !== undefined) headers.set('Accept', options.accept);
+
+    let body;
+    if (options.bodyType === 'base64') {
+      body = base64ToBytes(options.body);
+    } else if (options.bodyType === 'json') {
+      body = JSON.stringify(options.body ?? null);
+    } else if (options.bodyType === 'text') {
+      body = options.body;
+    }
+    if (body !== undefined && options.contentType !== undefined) {
+      headers.set('Content-Type', options.contentType);
+    }
+
+    return responseValue(
+      await this.request(url, { method, headers, body }),
+      options.responseType,
+      options.maxResponseBytes ?? this.responseLimitBytes,
+    );
+  }
+
+  async atomicWrite(realmUrl, changes) {
+    let operations = changes.map((change) =>
+      change.operation === 'remove'
+        ? { op: 'remove', href: change.path }
+        : {
+            op: change.exists ? 'update' : 'add',
+            href: change.path,
+            data: {
+              type: 'source',
+              attributes: { content: change.content },
+              meta: {},
+            },
+          },
+    );
+    let response = await this.request(
+      new URL('_atomic', ensureTrailingSlash(realmUrl)).href,
+      {
+        method: 'POST',
+        headers: {
+          Accept: SupportedMimeType.JSONAPI,
+          'Content-Type': SupportedMimeType.JSONAPI,
+        },
+        body: JSON.stringify({ 'atomic:operations': operations }),
+      },
+    );
+    if (!response.ok) {
+      throw new RealmRunnerError(
+        'COMMIT_FAILED',
+        `Atomic Realm write failed: HTTP ${response.status}: ${await errorSnippet(response)}`,
+      );
+    }
+    return jsonResponseBody(response, this.responseLimitBytes);
+  }
+}

--- a/packages/realm-runner/src/index.js
+++ b/packages/realm-runner/src/index.js
@@ -1,0 +1,15 @@
+export { BxlAdapter } from './bxl-adapter.js';
+export { RealmCapabilityHost, DEFAULT_LIMITS } from './capability.js';
+export { RealmRunnerError, errorDetails } from './errors.js';
+export { BoxelHttpAdapter } from './http-adapter.js';
+export { RealmNotebookCoordinator } from './notebook.js';
+export {
+  EncryptedNotebookStorage,
+  MemoryNotebookStorage,
+  RealmFileNotebookStorage,
+} from './notebook-storage.js';
+export {
+  QuickJSRealmProgramExecutor,
+  createRealmProgramExecutor,
+} from './realm-program-executor.js';
+export { runRealmScript, DEFAULT_RUNTIME_LIMITS } from './runner.js';

--- a/packages/realm-runner/src/notebook-storage.js
+++ b/packages/realm-runner/src/notebook-storage.js
@@ -1,0 +1,304 @@
+import { RealmRunnerError } from './errors.js';
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+function clone(value) {
+  return value === undefined ? undefined : structuredClone(value);
+}
+
+function byteLength(value) {
+  return textEncoder.encode(JSON.stringify(value)).byteLength;
+}
+
+function bytesToBase64(bytes) {
+  let binary = '';
+  let chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(offset, offset + chunkSize),
+    );
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(value) {
+  let binary;
+  try {
+    binary = atob(value);
+  } catch {
+    throw new RealmRunnerError(
+      'NOTEBOOK_CORRUPT',
+      'Realm Notebook encrypted data is not valid base64',
+    );
+  }
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+function assertStorageKey(key) {
+  if (
+    typeof key !== 'string' ||
+    key.length === 0 ||
+    key.length > 512 ||
+    !/^[a-z0-9][a-z0-9/_.-]*$/i.test(key) ||
+    key.includes('..') ||
+    key.startsWith('/') ||
+    key.endsWith('/')
+  ) {
+    throw new RealmRunnerError(
+      'INVALID_ARGUMENT',
+      'Realm Notebook storage key is invalid',
+    );
+  }
+}
+
+/**
+ * Process-local notebook storage with sliding TTL. It is suitable for Matrix
+ * room turns and ad-hoc agent sessions where durability beyond the active
+ * Realm Server process is not wanted.
+ */
+export class MemoryNotebookStorage {
+  constructor({ now = () => Date.now(), maxEntries = 2_000 } = {}) {
+    this.now = now;
+    this.maxEntries = maxEntries;
+    this.entries = new Map();
+  }
+
+  prune() {
+    let now = this.now();
+    for (let [key, entry] of this.entries) {
+      if (entry.expiresAt !== null && entry.expiresAt <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  async get(key) {
+    assertStorageKey(key);
+    this.prune();
+    return clone(this.entries.get(key)?.value);
+  }
+
+  async set(key, value, { expiresAt = null } = {}) {
+    assertStorageKey(key);
+    this.prune();
+    if (!this.entries.has(key) && this.entries.size >= this.maxEntries) {
+      throw new RealmRunnerError(
+        'NOTEBOOK_STORAGE_LIMIT',
+        `Ephemeral Realm Notebook storage is limited to ${this.maxEntries} records`,
+      );
+    }
+    this.entries.set(key, { value: clone(value), expiresAt });
+  }
+
+  async delete(key) {
+    assertStorageKey(key);
+    this.entries.delete(key);
+  }
+
+  async touchPrefix(prefix, expiresAt) {
+    assertStorageKey(prefix);
+    this.prune();
+    let keyPrefix = `${prefix}/`;
+    for (let [key, entry] of this.entries) {
+      if (key === prefix || key.startsWith(keyPrefix)) {
+        entry.expiresAt = expiresAt;
+      }
+    }
+  }
+}
+
+/**
+ * Stores notebook records as ordinary, non-executable Realm files. Callers
+ * should wrap this adapter in EncryptedNotebookStorage because notebook
+ * outputs can contain material read from Realms other than the storage Realm.
+ */
+export class RealmFileNotebookStorage {
+  constructor({
+    adapter,
+    realmUrl,
+    prefix = '.boxel/realm-notebooks',
+    maxRecordBytes = 2 * 1024 * 1024,
+    now = () => Date.now(),
+  }) {
+    if (!adapter) throw new TypeError('adapter is required');
+    if (!realmUrl) throw new TypeError('realmUrl is required');
+    this.adapter = adapter;
+    this.realmUrl = realmUrl;
+    this.prefix = prefix.replace(/^\/+|\/+$/g, '');
+    this.maxRecordBytes = maxRecordBytes;
+    this.now = now;
+  }
+
+  pathFor(key) {
+    assertStorageKey(key);
+    return `${this.prefix}/${key}.realm-notebook`;
+  }
+
+  async get(key) {
+    let path = this.pathFor(key);
+    let source = await this.adapter.readText(
+      this.realmUrl,
+      path,
+      this.maxRecordBytes,
+    );
+    if (source === undefined) return undefined;
+    let envelope;
+    try {
+      envelope = JSON.parse(source);
+    } catch {
+      throw new RealmRunnerError(
+        'NOTEBOOK_CORRUPT',
+        `Realm Notebook record ${key} is not valid JSON`,
+      );
+    }
+    if (
+      !envelope ||
+      typeof envelope !== 'object' ||
+      envelope.version !== 1 ||
+      !('value' in envelope)
+    ) {
+      throw new RealmRunnerError(
+        'NOTEBOOK_CORRUPT',
+        `Realm Notebook record ${key} has an unsupported format`,
+      );
+    }
+    if (
+      envelope.expiresAt !== null &&
+      (!Number.isFinite(envelope.expiresAt) || envelope.expiresAt <= this.now())
+    ) {
+      return undefined;
+    }
+    return envelope.value;
+  }
+
+  async set(key, value, { expiresAt = null } = {}) {
+    let path = this.pathFor(key);
+    let envelope = { version: 1, expiresAt, value };
+    let source = `${JSON.stringify(envelope)}\n`;
+    if (byteLength(envelope) > this.maxRecordBytes) {
+      throw new RealmRunnerError(
+        'NOTEBOOK_STORAGE_LIMIT',
+        `Realm Notebook record exceeds ${this.maxRecordBytes} bytes`,
+      );
+    }
+    let before = await this.adapter.readText(
+      this.realmUrl,
+      path,
+      this.maxRecordBytes,
+    );
+    await this.adapter.atomicWrite(this.realmUrl, [
+      {
+        operation: before === undefined ? 'create' : 'update',
+        path,
+        content: source,
+        exists: before !== undefined,
+      },
+    ]);
+  }
+
+  async delete(key) {
+    let path = this.pathFor(key);
+    let before = await this.adapter.readText(
+      this.realmUrl,
+      path,
+      this.maxRecordBytes,
+    );
+    if (before === undefined) return;
+    await this.adapter.atomicWrite(this.realmUrl, [
+      { operation: 'remove', path, exists: true },
+    ]);
+  }
+}
+
+/**
+ * Authenticated encryption decorator for durable notebook records. The
+ * storage key is included as AES-GCM additional authenticated data so records
+ * cannot be swapped between cells without detection.
+ */
+export class EncryptedNotebookStorage {
+  constructor({ storage, keyMaterial }) {
+    if (!storage) throw new TypeError('storage is required');
+    if (typeof keyMaterial !== 'string' || keyMaterial.length < 16) {
+      throw new TypeError(
+        'Realm Notebook encryption key material must be at least 16 characters',
+      );
+    }
+    this.storage = storage;
+    this.keyPromise = this.deriveKey(keyMaterial);
+  }
+
+  async deriveKey(keyMaterial) {
+    let digest = await crypto.subtle.digest(
+      'SHA-256',
+      textEncoder.encode(keyMaterial),
+    );
+    return crypto.subtle.importKey('raw', digest, 'AES-GCM', false, [
+      'encrypt',
+      'decrypt',
+    ]);
+  }
+
+  async get(key) {
+    let encrypted = await this.storage.get(key);
+    if (encrypted === undefined) return undefined;
+    if (
+      !encrypted ||
+      typeof encrypted !== 'object' ||
+      encrypted.version !== 1 ||
+      encrypted.algorithm !== 'A256GCM' ||
+      typeof encrypted.iv !== 'string' ||
+      typeof encrypted.ciphertext !== 'string'
+    ) {
+      throw new RealmRunnerError(
+        'NOTEBOOK_CORRUPT',
+        `Realm Notebook record ${key} is not encrypted`,
+      );
+    }
+    try {
+      let plaintext = await crypto.subtle.decrypt(
+        {
+          name: 'AES-GCM',
+          iv: base64ToBytes(encrypted.iv),
+          additionalData: textEncoder.encode(key),
+        },
+        await this.keyPromise,
+        base64ToBytes(encrypted.ciphertext),
+      );
+      return JSON.parse(textDecoder.decode(plaintext));
+    } catch (error) {
+      if (error instanceof RealmRunnerError) throw error;
+      throw new RealmRunnerError(
+        'NOTEBOOK_CORRUPT',
+        `Realm Notebook record ${key} failed authentication`,
+      );
+    }
+  }
+
+  async set(key, value, options) {
+    let iv = crypto.getRandomValues(new Uint8Array(12));
+    let ciphertext = await crypto.subtle.encrypt(
+      {
+        name: 'AES-GCM',
+        iv,
+        additionalData: textEncoder.encode(key),
+      },
+      await this.keyPromise,
+      textEncoder.encode(JSON.stringify(value)),
+    );
+    await this.storage.set(
+      key,
+      {
+        version: 1,
+        algorithm: 'A256GCM',
+        iv: bytesToBase64(iv),
+        ciphertext: bytesToBase64(new Uint8Array(ciphertext)),
+      },
+      options,
+    );
+  }
+
+  async delete(key) {
+    return this.storage.delete(key);
+  }
+}

--- a/packages/realm-runner/src/notebook.js
+++ b/packages/realm-runner/src/notebook.js
@@ -1,0 +1,644 @@
+import { errorDetails, RealmRunnerError } from './errors.js';
+import {
+  EncryptedNotebookStorage,
+  MemoryNotebookStorage,
+  RealmFileNotebookStorage,
+} from './notebook-storage.js';
+
+const textEncoder = new TextEncoder();
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
+const MIN_TTL_MS = 60 * 1000;
+const MAX_TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_INPUT_BYTES = 4 * 1024 * 1024;
+const MAX_INPUTS = 64;
+const MAX_CELLS = 128;
+const MAX_CELL_SOURCE_PREVIEW_CHARS = 8 * 1024;
+const MAX_NOTEBOOK_SOURCE_PREVIEW_CHARS = 64 * 1024;
+
+function clone(value) {
+  return value === undefined ? undefined : structuredClone(value);
+}
+
+function byteLength(value) {
+  return textEncoder.encode(JSON.stringify(value)).byteLength;
+}
+
+async function sha256(value) {
+  let digest = await crypto.subtle.digest('SHA-256', textEncoder.encode(value));
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function jwtUser(authorization) {
+  if (typeof authorization !== 'string') return 'anonymous';
+  try {
+    let token = authorization.replace(/^Bearer\s+/i, '');
+    let payload = token.split('.')[1];
+    if (!payload) return 'anonymous';
+    let base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+    base64 += '='.repeat((4 - (base64.length % 4)) % 4);
+    let claims = JSON.parse(
+      new TextDecoder().decode(
+        Uint8Array.from(atob(base64), (character) => character.charCodeAt(0)),
+      ),
+    );
+    return typeof claims.user === 'string' && claims.user.length > 0
+      ? claims.user
+      : 'anonymous';
+  } catch {
+    return 'anonymous';
+  }
+}
+
+function validateIdentifier(value, name) {
+  if (
+    typeof value !== 'string' ||
+    value.trim().length === 0 ||
+    value.length > 256
+  ) {
+    throw new RealmRunnerError(
+      'INVALID_ARGUMENT',
+      `Realm Notebook ${name} must be a non-empty string no longer than 256 characters`,
+    );
+  }
+  return value;
+}
+
+function validateDescriptor(notebook) {
+  if (!notebook || typeof notebook !== 'object' || Array.isArray(notebook)) {
+    throw new RealmRunnerError(
+      'INVALID_ARGUMENT',
+      'Realm Notebook settings must be an object',
+    );
+  }
+  let persistence = notebook.persistence ?? 'ephemeral';
+  if (persistence !== 'ephemeral' && persistence !== 'realm') {
+    throw new RealmRunnerError(
+      'INVALID_ARGUMENT',
+      'Realm Notebook persistence must be "ephemeral" or "realm"',
+    );
+  }
+  let ttlMs = notebook.ttlMs ?? DEFAULT_TTL_MS;
+  if (
+    persistence === 'ephemeral' &&
+    (!Number.isSafeInteger(ttlMs) || ttlMs < MIN_TTL_MS || ttlMs > MAX_TTL_MS)
+  ) {
+    throw new RealmRunnerError(
+      'INVALID_ARGUMENT',
+      `Ephemeral Realm Notebook ttlMs must be between ${MIN_TTL_MS} and ${MAX_TTL_MS}`,
+    );
+  }
+  let inputs = notebook.inputs ?? {};
+  if (!inputs || typeof inputs !== 'object' || Array.isArray(inputs)) {
+    throw new RealmRunnerError(
+      'INVALID_ARGUMENT',
+      'Realm Notebook inputs must be an object',
+    );
+  }
+  if (Object.keys(inputs).length > MAX_INPUTS) {
+    throw new RealmRunnerError(
+      'NOTEBOOK_INPUT_LIMIT',
+      `Realm Notebook cells accept at most ${MAX_INPUTS} inputs`,
+    );
+  }
+  return {
+    sessionId: validateIdentifier(notebook.sessionId, 'sessionId'),
+    cellId: validateIdentifier(notebook.cellId, 'cellId'),
+    persistence,
+    ttlMs,
+    inputs: notebook.inputs === undefined ? undefined : inputs,
+    force: notebook.force === true,
+    runSaved: notebook.runSaved === true,
+  };
+}
+
+function resolveJsonPointer(value, pointer) {
+  if (pointer === '') return value;
+  if (typeof pointer !== 'string' || !pointer.startsWith('/')) {
+    throw new RealmRunnerError(
+      'INVALID_ARGUMENT',
+      'Realm Notebook input pointer must be an RFC 6901 JSON pointer',
+    );
+  }
+  let current = value;
+  for (let rawToken of pointer.slice(1).split('/')) {
+    let token = rawToken.replace(/~1/g, '/').replace(/~0/g, '~');
+    if (
+      current === null ||
+      typeof current !== 'object' ||
+      !(token in current)
+    ) {
+      throw new RealmRunnerError(
+        'NOTEBOOK_INPUT_NOT_FOUND',
+        `Realm Notebook input pointer ${pointer} does not exist`,
+      );
+    }
+    current = current[token];
+  }
+  return current;
+}
+
+function executionKey(scope, executionId) {
+  return `${scope}/executions/${executionId}`;
+}
+
+function notebookSnapshot(manifest) {
+  let remainingSourceChars = MAX_NOTEBOOK_SOURCE_PREVIEW_CHARS;
+  return {
+    createdAt: manifest.createdAt,
+    updatedAt: manifest.updatedAt,
+    cells: Object.entries(manifest.cells).map(([cellId, cell], position) => {
+      let definition = cell.definition ?? {};
+      let source = String(definition.code ?? '');
+      let sourceChars = Math.min(
+        source.length,
+        MAX_CELL_SOURCE_PREVIEW_CHARS,
+        remainingSourceChars,
+      );
+      let sourcePreview = source.slice(0, sourceChars);
+      remainingSourceChars -= sourceChars;
+      let stale = Object.entries(definition.inputs ?? {}).some(
+        ([name, inputRef]) =>
+          inputRef?.cellId &&
+          manifest.cells[inputRef.cellId]?.executionId !==
+            cell.resolvedInputs?.[name]?.executionId,
+      );
+      return {
+        cellId,
+        position,
+        source: sourcePreview,
+        sourceTruncated: sourcePreview.length < source.length,
+        mode: definition.mode,
+        inputs: clone(definition.inputs ?? {}),
+        literalInputKeys: Object.keys(definition.input ?? {}),
+        revision: cell.revision ?? null,
+        lastRevision: cell.lastRevision ?? cell.revision ?? null,
+        executionId: cell.executionId ?? null,
+        outputRef:
+          cell.executionId === undefined
+            ? null
+            : { executionId: cell.executionId, pointer: '/result/value' },
+        status: cell.lastAttempt?.status ?? cell.status ?? 'saved',
+        stale,
+      };
+    }),
+  };
+}
+
+function notebookMetadata({
+  descriptor,
+  revision,
+  executionId,
+  reused,
+  expiresAt,
+  manifest,
+}) {
+  return {
+    sessionId: descriptor.sessionId,
+    cellId: descriptor.cellId,
+    revision,
+    executionId,
+    persistence: descriptor.persistence,
+    expiresAt,
+    reused,
+    outputRef: { executionId, pointer: '/result/value' },
+    snapshot: notebookSnapshot(manifest),
+  };
+}
+
+export class RealmNotebookCoordinator {
+  constructor({
+    ephemeralStorage = new MemoryNotebookStorage(),
+    encryptionKey,
+    now = () => Date.now(),
+  } = {}) {
+    this.ephemeralStorage = ephemeralStorage;
+    this.encryptionKey = encryptionKey;
+    this.now = now;
+    this.locks = new Map();
+  }
+
+  persistentStorage(adapter, realmUrl) {
+    if (typeof this.encryptionKey !== 'string') {
+      throw new RealmRunnerError(
+        'NOTEBOOK_PERSISTENCE_UNAVAILABLE',
+        'Durable Realm Notebook storage is not configured on this server',
+      );
+    }
+    return new EncryptedNotebookStorage({
+      storage: new RealmFileNotebookStorage({
+        adapter,
+        realmUrl,
+        now: this.now,
+      }),
+      keyMaterial: this.encryptionKey,
+    });
+  }
+
+  async withLock(key, callback) {
+    let previous = this.locks.get(key) ?? Promise.resolve();
+    let release;
+    let current = new Promise((resolve) => (release = resolve));
+    this.locks.set(key, current);
+    await previous;
+    try {
+      return await callback();
+    } finally {
+      release();
+      if (this.locks.get(key) === current) this.locks.delete(key);
+    }
+  }
+
+  async execute({
+    notebook,
+    input,
+    code,
+    mode,
+    realmURL,
+    authorization,
+    adapter,
+    run,
+  }) {
+    let descriptor = validateDescriptor(notebook);
+    let owner = jwtUser(authorization);
+    let scope = await sha256(
+      JSON.stringify([owner, realmURL, descriptor.sessionId]),
+    );
+    let storage =
+      descriptor.persistence === 'realm'
+        ? this.persistentStorage(adapter, realmURL)
+        : this.ephemeralStorage;
+    return this.withLock(scope, async () => {
+      return this.executeLocked({
+        descriptor,
+        scope,
+        owner,
+        storage,
+        directInput: input,
+        code,
+        mode,
+        realmURL,
+        run,
+      });
+    });
+  }
+
+  async executeLocked({
+    descriptor,
+    scope,
+    owner,
+    storage,
+    directInput,
+    code,
+    mode,
+    realmURL,
+    run,
+  }) {
+    let now = this.now();
+    let expiresAt =
+      descriptor.persistence === 'ephemeral' ? now + descriptor.ttlMs : null;
+    let manifestKey = `${scope}/manifest`;
+    let manifest = await storage.get(manifestKey);
+    if (
+      manifest &&
+      descriptor.persistence === 'ephemeral' &&
+      typeof storage.touchPrefix === 'function'
+    ) {
+      await storage.touchPrefix(scope, expiresAt);
+    }
+    if (manifest && manifest.sessionId !== descriptor.sessionId) {
+      throw new RealmRunnerError(
+        'NOTEBOOK_CORRUPT',
+        'Realm Notebook manifest does not match the requested session',
+      );
+    }
+    manifest ??= {
+      version: 1,
+      sessionId: descriptor.sessionId,
+      owner,
+      realmURL,
+      persistence: descriptor.persistence,
+      createdAt: now,
+      updatedAt: now,
+      expiresAt,
+      cells: {},
+    };
+
+    let previousCell = manifest.cells[descriptor.cellId];
+    if (descriptor.runSaved) {
+      if (!previousCell?.definition) {
+        throw new RealmRunnerError(
+          'NOTEBOOK_CELL_NOT_FOUND',
+          `Realm Notebook cell ${descriptor.cellId} has no saved definition`,
+        );
+      }
+      if (previousCell.definition.mode !== mode) {
+        throw new RealmRunnerError(
+          'NOTEBOOK_MODE_MISMATCH',
+          `Saved Realm Notebook cell ${descriptor.cellId} uses mode ${previousCell.definition.mode}, not ${mode}`,
+        );
+      }
+      code = previousCell.definition.code;
+      descriptor.inputs = clone(previousCell.definition.inputs ?? {});
+      if (directInput === undefined) {
+        directInput = clone(previousCell.definition.input ?? {});
+      }
+    }
+    if (typeof code !== 'string' || code.trim().length === 0) {
+      throw new RealmRunnerError(
+        'EMPTY_SCRIPT',
+        'Realm Notebook cell source is empty',
+      );
+    }
+    descriptor.inputs ??= {};
+    directInput ??= {};
+    if (
+      !directInput ||
+      typeof directInput !== 'object' ||
+      Array.isArray(directInput)
+    ) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        'Realm Notebook literal input must be a JSON object',
+      );
+    }
+
+    let { values: referencedInput, refs: inputRefs } = await this.resolveInputs(
+      {
+        descriptor,
+        manifest,
+        scope,
+        storage,
+        expiresAt,
+      },
+    );
+    let duplicateInput = Object.keys(referencedInput).find((name) =>
+      Object.hasOwn(directInput, name),
+    );
+    if (duplicateInput) {
+      throw new RealmRunnerError(
+        'INVALID_ARGUMENT',
+        `Realm Notebook input ${duplicateInput} is supplied as both a literal value and a cell reference`,
+      );
+    }
+    let input = { ...clone(directInput), ...referencedInput };
+    if (byteLength(input) > MAX_INPUT_BYTES) {
+      throw new RealmRunnerError(
+        'NOTEBOOK_INPUT_LIMIT',
+        `Resolved Realm Notebook inputs exceed ${MAX_INPUT_BYTES} bytes`,
+      );
+    }
+
+    let codeHash = await sha256(code);
+    let inputValueHash = await sha256(JSON.stringify(directInput));
+    let specHash = await sha256(
+      JSON.stringify({ codeHash, mode, inputRefs, inputValueHash }),
+    );
+    let sameSpec = previousCell?.specHash === specHash;
+    let revision = previousCell
+      ? (previousCell.lastRevision ?? previousCell.revision) + 1
+      : 1;
+    if (sameSpec && !descriptor.force) revision = previousCell.revision;
+    let executionId = await sha256(
+      JSON.stringify([scope, descriptor.cellId, revision, specHash]),
+    );
+    let recordKey = executionKey(scope, executionId);
+    let existing = await storage.get(recordKey);
+
+    if (existing?.status === 'succeeded' && !descriptor.force) {
+      manifest.cells[descriptor.cellId] = {
+        ...previousCell,
+        revision,
+        lastRevision: Math.max(previousCell?.lastRevision ?? 0, revision),
+        executionId,
+        specHash,
+        status: 'succeeded',
+        updatedAt: now,
+        resolvedInputs: clone(inputRefs),
+        definition: {
+          code,
+          mode,
+          input: clone(directInput),
+          inputs: clone(descriptor.inputs),
+        },
+        lastAttempt: { executionId, specHash, status: 'succeeded' },
+      };
+      manifest.updatedAt = now;
+      manifest.expiresAt = expiresAt;
+      await storage.set(manifestKey, manifest, { expiresAt });
+      await storage.set(recordKey, existing, { expiresAt });
+      return {
+        ...clone(existing.result),
+        notebook: notebookMetadata({
+          descriptor,
+          revision,
+          executionId,
+          reused: true,
+          expiresAt,
+          manifest,
+        }),
+      };
+    }
+    if (
+      existing?.status === 'pending' ||
+      existing?.status === 'indeterminate'
+    ) {
+      throw new RealmRunnerError(
+        'NOTEBOOK_EXECUTION_INDETERMINATE',
+        `Realm Notebook cell ${descriptor.cellId} may already have executed; use a new cell revision instead of retrying it`,
+        { executionId, status: existing.status },
+      );
+    }
+    if (
+      !descriptor.force &&
+      previousCell?.lastAttempt?.specHash === specHash &&
+      ['pending', 'indeterminate'].includes(previousCell.lastAttempt.status)
+    ) {
+      throw new RealmRunnerError(
+        'NOTEBOOK_EXECUTION_INDETERMINATE',
+        `Realm Notebook cell ${descriptor.cellId} may already have executed; rerun it explicitly to create a new revision`,
+        {
+          executionId: previousCell.lastAttempt.executionId,
+          status: previousCell.lastAttempt.status,
+        },
+      );
+    }
+
+    if (!previousCell && Object.keys(manifest.cells).length >= MAX_CELLS) {
+      throw new RealmRunnerError(
+        'NOTEBOOK_STORAGE_LIMIT',
+        `Realm Notebook sessions are limited to ${MAX_CELLS} cells`,
+      );
+    }
+
+    let pending = {
+      version: 1,
+      executionId,
+      sessionId: descriptor.sessionId,
+      cellId: descriptor.cellId,
+      revision,
+      specHash,
+      codeHash,
+      code,
+      mode,
+      input: clone(directInput),
+      inputRefs,
+      status: 'pending',
+      startedAt: now,
+    };
+    await storage.set(recordKey, pending, { expiresAt });
+    manifest.cells[descriptor.cellId] = {
+      ...previousCell,
+      lastRevision: revision,
+      definition: {
+        code,
+        mode,
+        input: clone(directInput),
+        inputs: clone(descriptor.inputs),
+      },
+      lastAttempt: { executionId, specHash, status: 'pending' },
+      updatedAt: now,
+    };
+    manifest.updatedAt = now;
+    manifest.expiresAt = expiresAt;
+    await storage.set(manifestKey, manifest, { expiresAt });
+
+    let result;
+    try {
+      result = await run(input, code, {
+        sessionId: descriptor.sessionId,
+        cellId: descriptor.cellId,
+        revision,
+        executionId,
+        persistence: descriptor.persistence,
+      });
+    } catch (error) {
+      let failureStatus = mode === 'commit' ? 'indeterminate' : 'failed';
+      let failed = {
+        ...pending,
+        status: failureStatus,
+        finishedAt: this.now(),
+        error: errorDetails(error),
+      };
+      try {
+        await storage.set(recordKey, failed, { expiresAt });
+        manifest.cells[descriptor.cellId].lastAttempt = {
+          executionId,
+          specHash,
+          status: failureStatus,
+        };
+        manifest.cells[descriptor.cellId].updatedAt = this.now();
+        manifest.updatedAt = this.now();
+        await storage.set(manifestKey, manifest, { expiresAt });
+      } catch {
+        // Preserve the execution error. A leftover pending record is the safe
+        // retry posture because it prevents a possibly-effectful rerun.
+      }
+      let failureNotebook = notebookMetadata({
+        descriptor,
+        revision,
+        executionId,
+        reused: false,
+        expiresAt,
+        manifest,
+      });
+      if (error instanceof RealmRunnerError) {
+        error.details = {
+          ...(error.details &&
+          typeof error.details === 'object' &&
+          !Array.isArray(error.details)
+            ? error.details
+            : {}),
+          notebook: failureNotebook,
+        };
+        throw error;
+      }
+      throw new RealmRunnerError(
+        'RUNTIME_ERROR',
+        error instanceof Error ? error.message : String(error),
+        { notebook: failureNotebook },
+      );
+    }
+
+    let finishedAt = this.now();
+    let succeeded = {
+      ...pending,
+      status: 'succeeded',
+      finishedAt,
+      result: clone(result),
+    };
+    await storage.set(recordKey, succeeded, { expiresAt });
+    manifest.cells[descriptor.cellId] = {
+      ...manifest.cells[descriptor.cellId],
+      revision,
+      lastRevision: revision,
+      executionId,
+      specHash,
+      status: 'succeeded',
+      updatedAt: finishedAt,
+      resolvedInputs: clone(inputRefs),
+      lastAttempt: { executionId, specHash, status: 'succeeded' },
+    };
+    manifest.updatedAt = finishedAt;
+    manifest.expiresAt = expiresAt;
+    await storage.set(manifestKey, manifest, { expiresAt });
+    return {
+      ...result,
+      notebook: notebookMetadata({
+        descriptor,
+        revision,
+        executionId,
+        reused: false,
+        expiresAt,
+        manifest,
+      }),
+    };
+  }
+
+  async resolveInputs({ descriptor, manifest, scope, storage, expiresAt }) {
+    let values = {};
+    let refs = {};
+    for (let [name, inputRef] of Object.entries(descriptor.inputs)) {
+      if (
+        !inputRef ||
+        typeof inputRef !== 'object' ||
+        Array.isArray(inputRef)
+      ) {
+        throw new RealmRunnerError(
+          'INVALID_ARGUMENT',
+          `Realm Notebook input ${name} must be a cell or execution reference`,
+        );
+      }
+      let sourceExecutionId = inputRef.executionId;
+      if (sourceExecutionId === undefined && inputRef.cellId !== undefined) {
+        validateIdentifier(inputRef.cellId, `input ${name} cellId`);
+        sourceExecutionId = manifest.cells[inputRef.cellId]?.executionId;
+      }
+      if (
+        typeof sourceExecutionId !== 'string' ||
+        !/^[a-f0-9]{64}$/.test(sourceExecutionId)
+      ) {
+        throw new RealmRunnerError(
+          'NOTEBOOK_INPUT_NOT_FOUND',
+          `Realm Notebook input ${name} does not reference a completed cell`,
+        );
+      }
+      let pointer = inputRef.pointer ?? '/result/value';
+      let sourceKey = executionKey(scope, sourceExecutionId);
+      let execution = await storage.get(sourceKey);
+      if (!execution || execution.status !== 'succeeded') {
+        throw new RealmRunnerError(
+          'NOTEBOOK_INPUT_NOT_FOUND',
+          `Realm Notebook input ${name} references an unavailable execution`,
+        );
+      }
+      values[name] = clone(resolveJsonPointer(execution, pointer));
+      refs[name] = { executionId: sourceExecutionId, pointer };
+      await storage.set(sourceKey, execution, { expiresAt });
+    }
+    return { values, refs };
+  }
+}
+
+export { DEFAULT_TTL_MS, MAX_TTL_MS, MIN_TTL_MS, resolveJsonPointer };

--- a/packages/realm-runner/src/path.js
+++ b/packages/realm-runner/src/path.js
@@ -1,0 +1,84 @@
+import { RealmRunnerError } from './errors.js';
+
+export function realmPath(input) {
+  if (typeof input !== 'string' || input.length === 0) {
+    throw new RealmRunnerError(
+      'INVALID_PATH',
+      'Realm path must be a non-empty string',
+    );
+  }
+  if (
+    input.includes('\\') ||
+    input.includes('\0') ||
+    input.includes('?') ||
+    input.includes('#')
+  ) {
+    throw new RealmRunnerError('INVALID_PATH', `Invalid Realm path: ${input}`);
+  }
+  if (input.startsWith('/') || /^[a-z][a-z0-9+.-]*:/i.test(input)) {
+    throw new RealmRunnerError(
+      'PATH_OUTSIDE_REALM',
+      `Realm path must be relative: ${input}`,
+    );
+  }
+  let segments = input.split('/');
+  let decodedSegments;
+  try {
+    decodedSegments = segments.map((segment) => decodeURIComponent(segment));
+  } catch {
+    throw new RealmRunnerError(
+      'INVALID_PATH',
+      `Realm path contains malformed percent encoding: ${input}`,
+    );
+  }
+  if (
+    decodedSegments.some(
+      (segment) =>
+        segment === '..' ||
+        segment.includes('/') ||
+        segment.includes('\\') ||
+        segment.includes('\0'),
+    )
+  ) {
+    throw new RealmRunnerError(
+      'PATH_OUTSIDE_REALM',
+      `Realm path escapes the Realm: ${input}`,
+    );
+  }
+  let normalized = input
+    .split('/')
+    .filter((segment) => segment !== '' && segment !== '.')
+    .join('/');
+  if (
+    normalized === '' ||
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.startsWith('../')
+  ) {
+    throw new RealmRunnerError(
+      'PATH_OUTSIDE_REALM',
+      `Realm path escapes the Realm: ${input}`,
+    );
+  }
+  return normalized;
+}
+
+export function globPattern(input) {
+  if (typeof input !== 'string' || input.length === 0 || input.length > 1024) {
+    throw new RealmRunnerError(
+      'INVALID_GLOB',
+      'Glob must be a non-empty string of at most 1024 characters',
+    );
+  }
+  if (
+    input.includes('\\') ||
+    input.startsWith('/') ||
+    input.split('/').includes('..')
+  ) {
+    throw new RealmRunnerError(
+      'PATH_OUTSIDE_REALM',
+      `Glob must stay inside the Realm: ${input}`,
+    );
+  }
+  return input.replace(/^\.\//, '');
+}

--- a/packages/realm-runner/src/realm-program-executor.js
+++ b/packages/realm-runner/src/realm-program-executor.js
@@ -1,0 +1,75 @@
+import { BxlAdapter } from './bxl-adapter.js';
+import { BoxelHttpAdapter } from './http-adapter.js';
+import { RealmNotebookCoordinator } from './notebook.js';
+import { runRealmScript } from './runner.js';
+
+export class QuickJSRealmProgramExecutor {
+  constructor({
+    fetch = globalThis.fetch,
+    bxl,
+    realmServerUrl,
+    notebookEncryptionKey,
+    notebookStorage,
+    now,
+  } = {}) {
+    this.fetch = fetch;
+    this.bxl = bxl;
+    this.realmServerUrl = realmServerUrl;
+    this.notebook = new RealmNotebookCoordinator({
+      encryptionKey: notebookEncryptionKey,
+      ephemeralStorage: notebookStorage,
+      now,
+    });
+  }
+
+  async execute({
+    code,
+    mode,
+    realmURL,
+    authorization,
+    input,
+    notebook,
+    onActivity,
+  }) {
+    let realmServerUrl = this.realmServerUrl ?? new URL('/', realmURL).href;
+    let adapter = new BoxelHttpAdapter({
+      fetch: this.fetch,
+      authorization,
+      realmServerUrl,
+    });
+    let run = (resolvedInput, resolvedCode = code, notebookContext = null) =>
+      runRealmScript({
+        code: resolvedCode,
+        realm: realmURL,
+        mode,
+        input: resolvedInput,
+        notebook: notebookContext,
+        adapter,
+        bxl: this.bxl,
+        onActivity,
+      });
+    if (notebook === undefined) return run(input ?? {});
+    return this.notebook.execute({
+      notebook,
+      input,
+      code,
+      mode,
+      realmURL,
+      authorization,
+      adapter,
+      run,
+    });
+  }
+}
+
+export async function createRealmProgramExecutor(options = {}) {
+  let bxl = options.bxl;
+  if (bxl === undefined) {
+    try {
+      bxl = await BxlAdapter.create();
+    } catch (error) {
+      options.onBxlUnavailable?.(error);
+    }
+  }
+  return new QuickJSRealmProgramExecutor({ ...options, bxl });
+}

--- a/packages/realm-runner/src/runner.js
+++ b/packages/realm-runner/src/runner.js
@@ -1,0 +1,652 @@
+import { getQuickJS } from 'quickjs-emscripten';
+
+import { RealmCapabilityHost } from './capability.js';
+import { errorDetails, RealmRunnerError } from './errors.js';
+
+const DEFAULT_RUNTIME_LIMITS = Object.freeze({
+  timeoutMs: 5_000,
+  wallTimeoutMs: 5 * 60_000,
+  memoryBytes: 64 * 1024 * 1024,
+  stackBytes: 1 * 1024 * 1024,
+  inputBytes: 4 * 1024 * 1024,
+});
+
+const textEncoder = new TextEncoder();
+const REALM_API_VERSION = '2';
+const REALM_FEATURES = Object.freeze({
+  notebooks: true,
+  activity: true,
+  streamingActivity: true,
+});
+
+const AUTOMATIC_ACTIVITY = Object.freeze({
+  'realms.list': ['discover', 'Discovering readable realms'],
+  search: ['search', 'Searching readable realms'],
+  'bxl.evaluate': ['transform', 'Transforming data with BXL'],
+  'fs.list': ['list', 'Listing Realm files'],
+  'fs.glob': ['list', 'Finding candidate files'],
+  'fs.grep': ['grep', 'Inspecting candidate files'],
+  'fs.readText': ['read', 'Reading Realm data'],
+  'fs.readJSON': ['read', 'Reading Realm data'],
+  'fs.readBase64': ['read', 'Reading Realm data'],
+  'fs.readTranspiled': ['read', 'Reading transpiled Realm data'],
+  'fs.lint': ['diagnose', 'Checking Realm source'],
+  'fs.writeText': ['stage', 'Staging Realm changes'],
+  'fs.writeJSON': ['stage', 'Staging Realm changes'],
+  'fs.appendText': ['stage', 'Staging Realm changes'],
+  'fs.replace': ['stage', 'Staging Realm changes'],
+  'fs.copy': ['stage', 'Staging Realm changes'],
+  'fs.remove': ['stage', 'Staging Realm changes'],
+  'fs.diff': ['preview', 'Preparing Realm change preview'],
+  indexingErrors: ['diagnose', 'Checking Realm indexing diagnostics'],
+});
+
+function automaticActivity(operation) {
+  let direct = AUTOMATIC_ACTIVITY[operation];
+  if (direct) return { phase: direct[0], message: direct[1] };
+  if (operation === 'scoped.fs.grep') {
+    return { phase: 'grep', message: 'Inspecting cross-Realm candidates' };
+  }
+  if (operation.startsWith('scoped.fs.')) {
+    return { phase: 'read', message: 'Reading authorized Realm data' };
+  }
+  if (
+    operation.startsWith('api.') ||
+    operation.startsWith('server.') ||
+    operation.startsWith('scoped.api.')
+  ) {
+    return { phase: 'api', message: 'Calling the authenticated Realm API' };
+  }
+  return undefined;
+}
+
+function createActivityReporter(onActivity) {
+  let sequence = 0;
+  let lastAutomaticPhase;
+  return async (
+    activity,
+    { automatic = false, source = automatic ? 'runtime' : 'script' } = {},
+  ) => {
+    if (typeof onActivity !== 'function') return;
+    if (automatic && activity.phase === lastAutomaticPhase) return;
+    if (automatic) lastAutomaticPhase = activity.phase;
+    try {
+      await onActivity({
+        sequence: ++sequence,
+        timestamp: Date.now(),
+        source,
+        status: activity.status ?? 'running',
+        ...activity,
+      });
+    } catch {
+      // Observability is best-effort and must never change script behavior.
+    }
+  };
+}
+
+function byteLength(value) {
+  return textEncoder.encode(value).byteLength;
+}
+
+const GUEST_BOOTSTRAP = String.raw`
+(() => {
+  'use strict';
+  const hostCall = globalThis.__realmHostCall;
+  const hostLog = globalThis.__realmHostLog;
+
+  const deepFreeze = (value) => {
+    if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+      for (const key of Object.keys(value)) deepFreeze(value[key]);
+      Object.freeze(value);
+    }
+    return value;
+  };
+  const input = deepFreeze(JSON.parse(globalThis.__realmInputJSON));
+  const notebook = deepFreeze(JSON.parse(globalThis.__realmNotebookJSON));
+  const features = deepFreeze(JSON.parse(globalThis.__realmFeaturesJSON));
+
+  const call = async (operation, args = []) => {
+    const envelope = JSON.parse(await hostCall(operation, JSON.stringify(args)));
+    if (!envelope.ok) {
+      const error = new Error('[realm:' + envelope.error.code + '] ' + envelope.error.message);
+      error.code = envelope.error.code;
+      error.details = envelope.error.details;
+      throw error;
+    }
+    return envelope.value;
+  };
+
+  const encodePattern = (pattern) => {
+    if (pattern instanceof RegExp) {
+      return { kind: 'regex', source: pattern.source, flags: pattern.flags };
+    }
+    return pattern;
+  };
+
+  const fs = Object.freeze({
+    list: () => call('fs.list'),
+    glob: (pattern, options) => call('fs.glob', [pattern, options]),
+    grep: (pattern, options) => call('fs.grep', [encodePattern(pattern), options]),
+    stat: (path) => call('fs.stat', [path]),
+    exists: (path) => call('fs.exists', [path]),
+    readText: (path) => call('fs.readText', [path]),
+    readJSON: (path) => call('fs.readJSON', [path]),
+    readBase64: (path) => call('fs.readBase64', [path]),
+    readTranspiled: (path) => call('fs.readTranspiled', [path]),
+    lint: (path) => call('fs.lint', [path]),
+    writeText: (path, content) => call('fs.writeText', [path, content]),
+    writeJSON: (path, value, options) => call('fs.writeJSON', [path, value, options]),
+    appendText: (path, content) => call('fs.appendText', [path, content]),
+    replace: (path, search, replacement, options) =>
+      call('fs.replace', [path, search, replacement, options]),
+    copy: (from, to) => call('fs.copy', [from, to]),
+    remove: (path) => call('fs.remove', [path]),
+    diff: (path) => call('fs.diff', [path]),
+  });
+
+  const bxl = Object.freeze({
+    evaluate: (expression, input, options) =>
+      call('bxl.evaluate', [expression, input, options]),
+    jq: (expression, input) =>
+      call('bxl.evaluate', [expression, input, { syntax: 'jq' }]),
+  });
+
+  const api = Object.freeze({
+    get: (path, options) => call('api.get', [path, options]),
+    head: (path, options) => call('api.head', [path, options]),
+    query: (path, body, options) => call('api.query', [path, body, options]),
+    request: (method, path, options) =>
+      call('api.request', [method, path, options]),
+  });
+
+  const server = Object.freeze({
+    get: (path, options) => call('server.get', [path, options]),
+    head: (path, options) => call('server.head', [path, options]),
+    query: (path, body, options) =>
+      call('server.query', [path, body, options]),
+    request: (method, path, options) =>
+      call('server.request', [method, path, options]),
+  });
+
+  const openRealm = (url, options = {}) => {
+    const writable = options && options.write === true;
+    const scopedFs = Object.freeze({
+      list: () => call('scoped.fs.list', [url]),
+      glob: (pattern, options) =>
+        call('scoped.fs.glob', [url, pattern, options]),
+      grep: (pattern, options) =>
+        call('scoped.fs.grep', [url, encodePattern(pattern), options]),
+      stat: (path) => call('scoped.fs.stat', [url, path]),
+      exists: (path) => call('scoped.fs.exists', [url, path]),
+      readText: (path) => call('scoped.fs.readText', [url, path]),
+      readJSON: (path) => call('scoped.fs.readJSON', [url, path]),
+      readBase64: (path) => call('scoped.fs.readBase64', [url, path]),
+      readTranspiled: (path) =>
+        call('scoped.fs.readTranspiled', [url, path]),
+      lint: (path) => call('scoped.fs.lint', [url, path]),
+    });
+    return Object.freeze({
+      current: Object.freeze({ url, mode: writable ? 'commit' : 'read-only' }),
+      fs: scopedFs,
+      bxl,
+      api: Object.freeze({
+        get: (path, options) => call('scoped.api.get', [url, path, options]),
+        head: (path, options) =>
+          call('scoped.api.head', [url, path, options]),
+        query: (path, body, options) =>
+          call('scoped.api.query', [url, path, body, options]),
+        request: (method, path, options) =>
+          call('scoped.api.request', [url, method, path, options, writable]),
+      }),
+      search: (query) => call('search', [query, { realms: [url] }]),
+      indexingErrors: () => call('scoped.indexingErrors', [url]),
+    });
+  };
+
+  const realm = Object.freeze({
+    apiVersion: '${REALM_API_VERSION}',
+    features,
+    current: Object.freeze(globalThis.__realmCurrent),
+    input,
+    notebook,
+    fs,
+    bxl,
+    api,
+    server,
+    listRealms: (options) => call('realms.list', [options]),
+    search: (query, options) => call('search', [query, options]),
+    open: openRealm,
+    indexingErrors: () => call('indexingErrors'),
+    activity: (messageOrDetails) => call('activity', [messageOrDetails]),
+    help: () => call('help'),
+  });
+
+  const console = Object.freeze({
+    debug: (...args) => hostLog('debug', JSON.stringify(args)),
+    log: (...args) => hostLog('log', JSON.stringify(args)),
+    info: (...args) => hostLog('info', JSON.stringify(args)),
+    warn: (...args) => hostLog('warn', JSON.stringify(args)),
+    error: (...args) => hostLog('error', JSON.stringify(args)),
+  });
+
+  Object.defineProperties(globalThis, {
+    realm: { value: realm, writable: false, configurable: false },
+    console: { value: console, writable: false, configurable: false },
+  });
+  delete globalThis.__realmHostCall;
+  delete globalThis.__realmHostLog;
+  delete globalThis.__realmCurrent;
+  delete globalThis.__realmInputJSON;
+  delete globalThis.__realmNotebookJSON;
+  delete globalThis.__realmFeaturesJSON;
+})();
+`;
+
+function resultSize(value) {
+  let serialized;
+  try {
+    serialized = JSON.stringify(value);
+  } catch (error) {
+    throw new RealmRunnerError(
+      'RESULT_NOT_SERIALIZABLE',
+      `Realm Script result must be JSON-serializable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return byteLength(serialized ?? 'null');
+}
+
+function dumpQuickJSError(context, errorHandle) {
+  let dumped = context.dump(errorHandle);
+  if (dumped && typeof dumped === 'object') {
+    let message = dumped.message ? String(dumped.message) : '';
+    let stack = dumped.stack ? String(dumped.stack) : '';
+    if (message && stack && !stack.includes(message))
+      return `${message}\n${stack}`;
+    return stack || message || JSON.stringify(dumped);
+  }
+  return String(dumped);
+}
+
+function quickJSError(message, deadline) {
+  let capabilityCode = message.match(/\[realm:([A-Z][A-Z0-9_]*)\]/)?.[1];
+  let code =
+    capabilityCode ??
+    (performance.now() >= deadline || message.includes('interrupted')
+      ? 'TIME_LIMIT'
+      : 'RUNTIME_ERROR');
+  return new RealmRunnerError(code, message);
+}
+
+async function beforeWallDeadline(promise, wallDeadline) {
+  let remaining = wallDeadline - performance.now();
+  if (remaining <= 0) {
+    throw new RealmRunnerError(
+      'TIME_LIMIT',
+      'Realm Script wall-clock execution timed out',
+    );
+  }
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new RealmRunnerError(
+                'TIME_LIMIT',
+                'Realm Script wall-clock execution timed out',
+              ),
+            ),
+          remaining,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function runRealmScript({
+  code,
+  realm,
+  mode = 'preview',
+  input = {},
+  notebook = null,
+  adapter,
+  bxl,
+  limits = {},
+  onActivity,
+}) {
+  if (typeof code !== 'string' || code.trim().length === 0) {
+    throw new RealmRunnerError(
+      'EMPTY_SCRIPT',
+      'Realm Script code must be a non-empty string',
+    );
+  }
+  if (byteLength(code) > 256 * 1024) {
+    throw new RealmRunnerError(
+      'SOURCE_LIMIT',
+      'Realm Script source exceeds 256 KiB',
+    );
+  }
+
+  let started = performance.now();
+  let reportActivity = createActivityReporter(onActivity);
+  await reportActivity(
+    {
+      phase: 'start',
+      message: 'Starting Realm Script',
+      status: 'running',
+    },
+    { source: 'runtime' },
+  );
+  let runtimeLimits = { ...DEFAULT_RUNTIME_LIMITS, ...limits };
+  let inputJSON;
+  try {
+    inputJSON = JSON.stringify(input ?? {});
+  } catch (error) {
+    throw new RealmRunnerError(
+      'INVALID_ARGUMENT',
+      `Realm Script input must be JSON-serializable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (byteLength(inputJSON) > runtimeLimits.inputBytes) {
+    throw new RealmRunnerError(
+      'NOTEBOOK_INPUT_LIMIT',
+      `Realm Script input exceeds ${runtimeLimits.inputBytes} bytes`,
+    );
+  }
+  let capability = new RealmCapabilityHost({
+    adapter,
+    bxl,
+    realmUrl: realm,
+    mode,
+    limits,
+  });
+  let QuickJS = await getQuickJS();
+  let context = QuickJS.newContext();
+  let runtime = context.runtime;
+  let requests = [];
+  let pendingDeferreds = new Set();
+  // The bootstrap is fixed, trusted runner code. Start the guest CPU clock
+  // only after it is installed so cold WASM/JIT startup cannot consume a
+  // user's script budget.
+  let deadline = Number.POSITIVE_INFINITY;
+  let wallDeadline = Number.POSITIVE_INFINITY;
+  let wallAbortController;
+  let wallAbortTimer;
+  runtime.setMemoryLimit(runtimeLimits.memoryBytes);
+  runtime.setMaxStackSize(runtimeLimits.stackBytes);
+  runtime.setInterruptHandler(
+    () => performance.now() > deadline || performance.now() > wallDeadline,
+  );
+
+  try {
+    let hostCall = context.newFunction(
+      '__realmHostCall',
+      (operationHandle, argsHandle) => {
+        let operation = context.getString(operationHandle);
+        let argsText = context.getString(argsHandle);
+        let deferred = context.newPromise();
+        pendingDeferreds.add(deferred);
+        requests.push({
+          operation,
+          args: JSON.parse(argsText),
+          deferred,
+        });
+        return deferred.handle;
+      },
+    );
+    context.setProp(context.global, '__realmHostCall', hostCall);
+    hostCall.dispose();
+
+    let hostLog = context.newFunction(
+      '__realmHostLog',
+      (levelHandle, argsHandle) => {
+        let level = context.getString(levelHandle);
+        let args;
+        try {
+          args = JSON.parse(context.getString(argsHandle));
+        } catch {
+          args = ['[unserializable console arguments]'];
+        }
+        capability.captureLog(level, args);
+        return context.undefined;
+      },
+    );
+    context.setProp(context.global, '__realmHostLog', hostLog);
+    hostLog.dispose();
+
+    let current = context.newObject();
+    let realmUrl = context.newString(realm);
+    let runtimeMode = context.newString(mode);
+    context.setProp(current, 'url', realmUrl);
+    context.setProp(current, 'mode', runtimeMode);
+    realmUrl.dispose();
+    runtimeMode.dispose();
+    context.setProp(context.global, '__realmCurrent', current);
+    current.dispose();
+
+    let inputJSONHandle = context.newString(inputJSON);
+    context.setProp(context.global, '__realmInputJSON', inputJSONHandle);
+    inputJSONHandle.dispose();
+
+    let notebookJSONHandle = context.newString(JSON.stringify(notebook));
+    context.setProp(context.global, '__realmNotebookJSON', notebookJSONHandle);
+    notebookJSONHandle.dispose();
+
+    let featuresJSONHandle = context.newString(JSON.stringify(REALM_FEATURES));
+    context.setProp(context.global, '__realmFeaturesJSON', featuresJSONHandle);
+    featuresJSONHandle.dispose();
+
+    let bootstrap = context.evalCode(GUEST_BOOTSTRAP, 'realm-bootstrap.js');
+    if (bootstrap.error) {
+      let message = dumpQuickJSError(context, bootstrap.error);
+      bootstrap.error.dispose();
+      throw new RealmRunnerError('BOOTSTRAP_ERROR', message);
+    }
+    bootstrap.value.dispose();
+
+    deadline = performance.now() + runtimeLimits.timeoutMs;
+    wallDeadline = performance.now() + runtimeLimits.wallTimeoutMs;
+    wallAbortController = new AbortController();
+    adapter.setProgramSignal?.(wallAbortController.signal);
+    wallAbortTimer = setTimeout(
+      () => wallAbortController.abort(),
+      runtimeLimits.wallTimeoutMs,
+    );
+
+    let wrapped = `(async function __runRealmScript(realm, console) {\n'use strict';\n${code}\n})(realm, console)`;
+    let evaluated = context.evalCode(wrapped, 'realm-script.js');
+    if (evaluated.error) {
+      let message = dumpQuickJSError(context, evaluated.error);
+      evaluated.error.dispose();
+      throw quickJSError(message, deadline);
+    }
+
+    let promiseHandle = evaluated.value;
+    let value;
+    for (;;) {
+      if (performance.now() >= wallDeadline) {
+        promiseHandle.dispose();
+        throw new RealmRunnerError(
+          'TIME_LIMIT',
+          'Realm Script wall-clock execution timed out',
+        );
+      }
+      let jobs = runtime.executePendingJobs();
+      if (jobs.error) {
+        let message = dumpQuickJSError(context, jobs.error);
+        jobs.error.dispose();
+        promiseHandle.dispose();
+        throw new RealmRunnerError('RUNTIME_ERROR', message);
+      }
+
+      let state = context.getPromiseState(promiseHandle);
+      if (state.type === 'fulfilled') {
+        value = context.dump(state.value);
+        state.value.dispose();
+        break;
+      }
+      if (state.type === 'rejected') {
+        let message = dumpQuickJSError(context, state.error);
+        state.error.dispose();
+        promiseHandle.dispose();
+        throw quickJSError(message, deadline);
+      }
+
+      if (performance.now() >= deadline) {
+        promiseHandle.dispose();
+        throw new RealmRunnerError(
+          'TIME_LIMIT',
+          'Realm Script execution timed out',
+        );
+      }
+      if (requests.length === 0) {
+        promiseHandle.dispose();
+        throw new RealmRunnerError(
+          'DEADLOCK',
+          'Realm Script is waiting on a promise that the runner cannot resolve',
+        );
+      }
+
+      let batch = requests.splice(0);
+      for (let request of batch) {
+        if (performance.now() >= wallDeadline) {
+          promiseHandle.dispose();
+          throw new RealmRunnerError(
+            'TIME_LIMIT',
+            'Realm Script wall-clock execution timed out',
+          );
+        }
+        let envelope;
+        let capabilityStarted = performance.now();
+        try {
+          let activity = automaticActivity(request.operation);
+          if (activity) {
+            await reportActivity(
+              { ...activity, operation: request.operation },
+              { automatic: true },
+            );
+          }
+          let requestValue = await beforeWallDeadline(
+            capability.dispatch(request.operation, request.args),
+            wallDeadline,
+          );
+          if (request.operation === 'activity') {
+            await reportActivity({ ...requestValue, operation: 'activity' });
+            requestValue = null;
+          }
+          envelope = {
+            ok: true,
+            value: requestValue === undefined ? null : requestValue,
+          };
+        } catch (error) {
+          envelope = { ok: false, error: errorDetails(error) };
+        } finally {
+          // The interrupt deadline bounds guest QuickJS execution, not Realm
+          // HTTP latency. A federated search or file read can legitimately
+          // take longer than the guest CPU budget while QuickJS is suspended
+          // awaiting its capability promise.
+          deadline += performance.now() - capabilityStarted;
+        }
+        if (performance.now() >= wallDeadline) {
+          promiseHandle.dispose();
+          throw new RealmRunnerError(
+            'TIME_LIMIT',
+            'Realm Script wall-clock execution timed out',
+          );
+        }
+        let responseText = JSON.stringify(envelope);
+        if (byteLength(responseText) > capability.limits.rpcResultBytes) {
+          responseText = JSON.stringify({
+            ok: false,
+            error: {
+              code: 'RESULT_LIMIT',
+              message: `Realm capability response exceeds ${capability.limits.rpcResultBytes} bytes`,
+            },
+          });
+        }
+        let responseHandle = context.newString(responseText);
+        request.deferred.resolve(responseHandle);
+        responseHandle.dispose();
+        pendingDeferreds.delete(request.deferred);
+      }
+    }
+    promiseHandle.dispose();
+    if (resultSize(value) > capability.limits.resultBytes) {
+      throw new RealmRunnerError(
+        'RESULT_LIMIT',
+        'Realm Script result exceeds the configured byte limit',
+      );
+    }
+
+    await reportActivity(
+      {
+        phase: mode === 'commit' ? 'commit' : 'finalize',
+        message:
+          mode === 'commit'
+            ? 'Committing staged Realm changes'
+            : 'Finalizing Realm Script preview',
+        operation: 'finish',
+      },
+      { automatic: true },
+    );
+    let finished = await capability.finish();
+    await reportActivity(
+      {
+        phase: 'complete',
+        message: 'Realm Script complete',
+        status: 'completed',
+      },
+      { source: 'runtime' },
+    );
+    return {
+      ok: true,
+      mode,
+      value: value === undefined ? null : value,
+      ...finished,
+      stats: {
+        ...finished.stats,
+        durationMs: Math.round((performance.now() - started) * 100) / 100,
+      },
+    };
+  } catch (error) {
+    await reportActivity(
+      {
+        phase: 'failed',
+        message: 'Realm Script failed',
+        status: 'failed',
+      },
+      { source: 'runtime' },
+    );
+    if (capability.effects.length === 0) throw error;
+    let details = {
+      ...(error instanceof RealmRunnerError &&
+      error.details &&
+      typeof error.details === 'object' &&
+      !Array.isArray(error.details)
+        ? error.details
+        : {}),
+      effects: capability.effects.map((effect) => ({ ...effect })),
+    };
+    if (error instanceof RealmRunnerError) {
+      error.details = details;
+      throw error;
+    }
+    throw new RealmRunnerError(
+      'RUNTIME_ERROR',
+      error instanceof Error ? error.message : String(error),
+      details,
+    );
+  } finally {
+    clearTimeout(wallAbortTimer);
+    wallAbortController?.abort();
+    adapter.setProgramSignal?.(undefined);
+    for (let deferred of pendingDeferreds) deferred.dispose();
+    context.dispose();
+  }
+}
+
+export { DEFAULT_RUNTIME_LIMITS };

--- a/packages/realm-runner/test/bxl-adapter.test.js
+++ b/packages/realm-runner/test/bxl-adapter.test.js
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { BxlAdapter } from '../src/bxl-adapter.js';
+
+test('loads the shipped BXL runtime and evaluates jq syntax', async () => {
+  let bxl = await BxlAdapter.create();
+  let result = await bxl.evaluate(
+    '.items | length',
+    { items: [1, 2, 3, 4, 5] },
+    { syntax: 'jq' },
+  );
+
+  assert.equal(result, 5);
+});

--- a/packages/realm-runner/test/capability.test.js
+++ b/packages/realm-runner/test/capability.test.js
@@ -1,0 +1,715 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { RealmCapabilityHost } from '../src/capability.js';
+import { realmPath } from '../src/path.js';
+
+class FakeAdapter {
+  constructor() {
+    this.searchCalls = [];
+    this.readCalls = [];
+    this.atomicWrites = [];
+    this.rawRequests = [];
+    this.files = new Map([
+      ['a.txt', 'alpha\nbeta\nALPHA\n'],
+      ['src/card.gts', "import Component from '@glimmer/component';\n"],
+    ]);
+  }
+
+  async listRealms() {
+    return [
+      {
+        id: 'https://example.test/a/',
+        url: 'https://example.test/a/',
+        canRead: true,
+        canWrite: true,
+      },
+      {
+        id: 'https://example.test/b/',
+        url: 'https://example.test/b/',
+        canRead: true,
+        canWrite: false,
+      },
+      {
+        id: 'https://example.test/denied/',
+        url: 'https://example.test/denied/',
+        canRead: false,
+        canWrite: false,
+      },
+    ];
+  }
+  async listFiles() {
+    return [...this.files.keys()];
+  }
+  async readText(_realm, path) {
+    this.readCalls.push({ realm: _realm, path });
+    return this.files.get(path);
+  }
+  async readBase64(_realm, path) {
+    let content = this.files.get(path);
+    return content === undefined
+      ? undefined
+      : Buffer.from(content).toString('base64');
+  }
+  async readTranspiled(_realm, path) {
+    return `transpiled:${path}`;
+  }
+  async lint(_realm, path, source) {
+    return { ok: true, path, sourceBytes: Buffer.byteLength(source) };
+  }
+  async indexingErrors() {
+    return { data: [] };
+  }
+  async realmGet(_realm, path, options) {
+    return { ok: true, status: 200, headers: {}, body: { path, options } };
+  }
+  async realmHead(_realm, path, options) {
+    return { ok: true, status: 200, headers: {}, body: { path, options } };
+  }
+  async realmQuery(_realm, path, body, options) {
+    return {
+      ok: true,
+      status: 200,
+      headers: {},
+      body: { path, queryBody: body, options },
+    };
+  }
+  async serverGet(path, options) {
+    return { ok: true, status: 200, headers: {}, body: { path, options } };
+  }
+  async serverHead(path, options) {
+    return { ok: true, status: 200, headers: {}, body: { path, options } };
+  }
+  async serverQuery(path, body, options) {
+    return {
+      ok: true,
+      status: 200,
+      headers: {},
+      body: { path, queryBody: body, options },
+    };
+  }
+  async realmRequest(realm, method, path, options) {
+    this.rawRequests.push({ scope: 'realm', realm, method, path, options });
+    return {
+      ok: true,
+      status: 200,
+      headers: {},
+      body:
+        options.responseType === 'base64'
+          ? Buffer.from('binary-response').toString('base64')
+          : { method, path },
+    };
+  }
+  async serverRequest(method, path, options) {
+    this.rawRequests.push({ scope: 'server', method, path, options });
+    return {
+      ok: true,
+      status: 202,
+      headers: {},
+      body: { method, path },
+    };
+  }
+  async search(realms) {
+    this.searchCalls.push(realms);
+    return realms.map((realm) => ({
+      type: 'file-meta',
+      id: `${realm}file.gts`,
+    }));
+  }
+  async atomicWrite(_realm, changes) {
+    this.atomicWrites.push(changes);
+  }
+}
+
+test('normalizes Realm-relative paths and rejects escape attempts', () => {
+  assert.equal(realmPath('./cards/a.json'), 'cards/a.json');
+  assert.throws(() => realmPath('../secret'), { code: 'PATH_OUTSIDE_REALM' });
+  assert.throws(() => realmPath('%2e%2e/secret'), {
+    code: 'PATH_OUTSIDE_REALM',
+  });
+  assert.throws(() => realmPath('folder/%2fsecret'), {
+    code: 'PATH_OUTSIDE_REALM',
+  });
+  assert.throws(() => realmPath('/etc/passwd'), { code: 'PATH_OUTSIDE_REALM' });
+  assert.throws(() => realmPath('https://example.test/file'), {
+    code: 'PATH_OUTSIDE_REALM',
+  });
+  assert.throws(() => realmPath('./'), { code: 'PATH_OUTSIDE_REALM' });
+  assert.throws(() => realmPath('file.gts?raw'), { code: 'INVALID_PATH' });
+});
+
+test('rejects replace when match cardinality differs', async () => {
+  let host = new RealmCapabilityHost({
+    adapter: new FakeAdapter(),
+    realmUrl: 'https://example.test/demo/',
+  });
+  await assert.rejects(
+    host.dispatch('fs.replace', [
+      'a.txt',
+      'alpha',
+      'b',
+      { expectedMatches: 2 },
+    ]),
+    { code: 'MATCH_COUNT_MISMATCH' },
+  );
+});
+
+test('greps selected Realm files with line context', async () => {
+  let host = new RealmCapabilityHost({
+    adapter: new FakeAdapter(),
+    realmUrl: 'https://example.test/demo/',
+  });
+
+  let matches = await host.dispatch('fs.grep', [
+    'alpha',
+    {
+      glob: '**/*.txt',
+      caseSensitive: false,
+      contextLines: 1,
+    },
+  ]);
+
+  assert.deepEqual(matches, [
+    {
+      path: 'a.txt',
+      line: 1,
+      column: 1,
+      text: 'alpha',
+      before: [],
+      after: ['beta'],
+    },
+    {
+      path: 'a.txt',
+      line: 3,
+      column: 1,
+      text: 'ALPHA',
+      before: ['beta'],
+      after: [''],
+    },
+  ]);
+});
+
+test('globs with one or more ignored patterns', async () => {
+  let host = new RealmCapabilityHost({
+    adapter: new FakeAdapter(),
+    realmUrl: 'https://example.test/demo/',
+  });
+
+  assert.deepEqual(
+    await host.dispatch('fs.glob', ['**/*', { ignore: 'src/**' }]),
+    ['a.txt'],
+  );
+});
+
+test('reads bounded base64 bytes in current and authorized Realms', async () => {
+  let host = new RealmCapabilityHost({
+    adapter: new FakeAdapter(),
+    realmUrl: 'https://example.test/a/',
+  });
+
+  assert.equal(
+    Buffer.from(
+      await host.dispatch('fs.readBase64', ['a.txt']),
+      'base64',
+    ).toString(),
+    'alpha\nbeta\nALPHA\n',
+  );
+  assert.equal(
+    Buffer.from(
+      await host.dispatch('scoped.fs.readBase64', [
+        'https://example.test/b/',
+        'a.txt',
+      ]),
+      'base64',
+    ).toString(),
+    'alpha\nbeta\nALPHA\n',
+  );
+});
+
+test('stats staged content and exposes preview diffs', async () => {
+  let host = new RealmCapabilityHost({
+    adapter: new FakeAdapter(),
+    realmUrl: 'https://example.test/demo/',
+  });
+
+  await host.dispatch('fs.appendText', ['a.txt', 'omega\n']);
+  let stat = await host.dispatch('fs.stat', ['a.txt']);
+  let changes = await host.dispatch('fs.diff', ['a.txt']);
+
+  assert.equal(stat.staged, true);
+  assert.equal(stat.size, Buffer.byteLength('alpha\nbeta\nALPHA\nomega\n'));
+  assert.equal(changes.length, 1);
+  assert.match(changes[0].diff, /\+omega/);
+});
+
+test('stages removals in the overlay', async () => {
+  let host = new RealmCapabilityHost({
+    adapter: new FakeAdapter(),
+    realmUrl: 'https://example.test/demo/',
+  });
+
+  await host.dispatch('fs.remove', ['a.txt']);
+  let changes = await host.dispatch('fs.diff', ['a.txt']);
+
+  assert.equal(await host.dispatch('fs.exists', ['a.txt']), false);
+  assert.equal((await host.dispatch('fs.list', [])).includes('a.txt'), false);
+  await assert.rejects(host.dispatch('fs.readText', ['a.txt']), {
+    code: 'NOT_FOUND',
+  });
+  assert.equal(changes[0].operation, 'remove');
+  assert.equal(changes[0].afterHash, null);
+  assert.match(changes[0].diff, /-alpha/);
+});
+
+test('rejects a commit when a staged file changed concurrently', async () => {
+  let adapter = new FakeAdapter();
+  let host = new RealmCapabilityHost({
+    adapter,
+    realmUrl: 'https://example.test/demo/',
+    mode: 'commit',
+  });
+
+  await host.dispatch('fs.appendText', ['a.txt', 'staged\n']);
+  adapter.files.set('a.txt', 'changed elsewhere\n');
+
+  await assert.rejects(host.finish(), { code: 'WRITE_CONFLICT' });
+  assert.equal(adapter.atomicWrites.length, 0);
+});
+
+test('uses Boxel-backed transpile, lint, and indexing diagnostics', async () => {
+  let host = new RealmCapabilityHost({
+    adapter: new FakeAdapter(),
+    realmUrl: 'https://example.test/demo/',
+  });
+
+  assert.equal(
+    await host.dispatch('fs.readTranspiled', ['src/card.gts']),
+    'transpiled:src/card.gts',
+  );
+  assert.deepEqual(await host.dispatch('fs.lint', ['src/card.gts']), {
+    ok: true,
+    path: 'src/card.gts',
+    sourceBytes: 44,
+  });
+  assert.deepEqual(await host.dispatch('indexingErrors', []), { data: [] });
+});
+
+test('exposes bounded read-only Realm and server API access', async () => {
+  let host = new RealmCapabilityHost({
+    adapter: new FakeAdapter(),
+    realmUrl: 'https://example.test/demo/',
+  });
+
+  let info = await host.dispatch('api.get', [
+    '_info',
+    {
+      accept: 'application/vnd.card+json',
+    },
+  ]);
+  let status = await host.dispatch('server.get', ['_queue-status']);
+  let query = await host.dispatch('api.query', [
+    '_search',
+    { filter: { matches: 'three' } },
+    { accept: 'application/vnd.card+json' },
+  ]);
+
+  assert.deepEqual(info.body, {
+    path: '_info',
+    options: { accept: 'application/vnd.card+json' },
+  });
+  assert.equal(status.body.path, '_queue-status');
+  assert.deepEqual(query.body, {
+    path: '_search',
+    queryBody: { filter: { matches: 'three' } },
+    options: { accept: 'application/vnd.card+json' },
+  });
+});
+
+test('gates raw API mutations to commit mode and preserves caller auth', async () => {
+  let previewAdapter = new FakeAdapter();
+  let preview = new RealmCapabilityHost({
+    adapter: previewAdapter,
+    realmUrl: 'https://example.test/demo/',
+  });
+
+  await assert.rejects(
+    preview.dispatch('api.request', [
+      'PATCH',
+      '_permissions',
+      { body: { add: ['read'] }, bodyType: 'json' },
+    ]),
+    { code: 'CAPABILITY_DENIED' },
+  );
+  assert.equal(previewAdapter.rawRequests.length, 0);
+
+  let adapter = new FakeAdapter();
+  let commit = new RealmCapabilityHost({
+    adapter,
+    realmUrl: 'https://example.test/demo/',
+    mode: 'commit',
+  });
+  let response = await commit.dispatch('api.request', [
+    'PATCH',
+    '_permissions',
+    {
+      body: { add: ['read'] },
+      bodyType: 'json',
+      contentType: 'application/json',
+      headers: { 'If-Match': 'current' },
+    },
+  ]);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(adapter.rawRequests[0], {
+    scope: 'realm',
+    realm: 'https://example.test/demo/',
+    method: 'PATCH',
+    path: '_permissions',
+    options: {
+      body: { add: ['read'] },
+      bodyType: 'json',
+      responseType: 'auto',
+      maxResponseBytes: 4 * 1024 * 1024,
+      headers: { 'If-Match': 'current' },
+      contentType: 'application/json',
+    },
+  });
+  assert.equal(commit.stats.apiRequests, 1);
+  assert.ok(commit.stats.apiBytesSent > 0);
+  assert.ok(commit.stats.apiBytesReceived > 0);
+});
+
+test('supports binary API bodies and responses within configured budgets', async () => {
+  let adapter = new FakeAdapter();
+  let host = new RealmCapabilityHost({
+    adapter,
+    realmUrl: 'https://example.test/demo/',
+    mode: 'commit',
+  });
+  let body = Buffer.from([0, 1, 2, 255]).toString('base64');
+  let response = await host.dispatch('api.request', [
+    'POST',
+    'asset.bin',
+    {
+      body,
+      bodyType: 'base64',
+      contentType: 'application/octet-stream',
+      responseType: 'base64',
+    },
+  ]);
+
+  assert.equal(
+    Buffer.from(response.body, 'base64').toString(),
+    'binary-response',
+  );
+  assert.equal(adapter.rawRequests[0].options.body, body);
+});
+
+test('supports every HTTP method used by Realm and Realm-server routes', async () => {
+  let adapter = new FakeAdapter();
+  let host = new RealmCapabilityHost({
+    adapter,
+    realmUrl: 'https://example.test/demo/',
+    mode: 'commit',
+  });
+
+  for (let method of [
+    'GET',
+    'HEAD',
+    'QUERY',
+    'POST',
+    'PUT',
+    'PATCH',
+    'DELETE',
+  ]) {
+    await host.dispatch('api.request', [method, '_operation']);
+  }
+
+  assert.deepEqual(
+    adapter.rawRequests.map(({ method }) => method),
+    ['GET', 'HEAD', 'QUERY', 'POST', 'PUT', 'PATCH', 'DELETE'],
+  );
+});
+
+test('invalidates file helper caches after an immediate raw mutation', async () => {
+  let adapter = new FakeAdapter();
+  adapter.files.set('mutable.txt', 'before');
+  adapter.realmRequest = async (realm, method, path, options) => {
+    adapter.rawRequests.push({ scope: 'realm', realm, method, path, options });
+    adapter.files.set(path, options.body);
+    return { ok: true, status: 204, headers: {}, body: '' };
+  };
+  let host = new RealmCapabilityHost({
+    adapter,
+    realmUrl: 'https://example.test/demo/',
+    mode: 'commit',
+  });
+
+  assert.equal(await host.dispatch('fs.readText', ['mutable.txt']), 'before');
+  await host.dispatch('api.request', [
+    'POST',
+    'mutable.txt',
+    { body: 'after', bodyType: 'text' },
+  ]);
+  assert.equal(await host.dispatch('fs.readText', ['mutable.txt']), 'after');
+});
+
+test('keeps cross-Realm raw API handles read-only', async () => {
+  let adapter = new FakeAdapter();
+  let host = new RealmCapabilityHost({
+    adapter,
+    realmUrl: 'https://example.test/a/',
+    mode: 'commit',
+  });
+
+  await host.dispatch('scoped.api.request', [
+    'https://example.test/b/',
+    'GET',
+    '_info',
+    {},
+  ]);
+  await assert.rejects(
+    host.dispatch('scoped.api.request', [
+      'https://example.test/b/',
+      'DELETE',
+      'card',
+      {},
+    ]),
+    { code: 'CAPABILITY_DENIED' },
+  );
+  assert.equal(adapter.rawRequests.length, 1);
+});
+
+test('permits explicit cross-Realm writes only with a discovered write grant', async () => {
+  let adapter = new FakeAdapter();
+  adapter.listRealms = async () => [
+    {
+      id: 'https://example.test/a/',
+      url: 'https://example.test/a/',
+      canRead: true,
+      canWrite: true,
+    },
+    {
+      id: 'https://example.test/b/',
+      url: 'https://example.test/b/',
+      canRead: true,
+      canWrite: true,
+    },
+    {
+      id: 'https://example.test/c/',
+      url: 'https://example.test/c/',
+      canRead: true,
+      canWrite: false,
+    },
+  ];
+  let host = new RealmCapabilityHost({
+    adapter,
+    realmUrl: 'https://example.test/a/',
+    mode: 'commit',
+  });
+
+  await host.dispatch('scoped.api.request', [
+    'https://example.test/b/',
+    'DELETE',
+    'old.json',
+    {},
+    true,
+  ]);
+  await assert.rejects(
+    host.dispatch('scoped.api.request', [
+      'https://example.test/c/',
+      'DELETE',
+      'old.json',
+      {},
+      true,
+    ]),
+    { code: 'CAPABILITY_DENIED' },
+  );
+
+  assert.equal(adapter.rawRequests.length, 1);
+  assert.equal(adapter.rawRequests[0].realm, 'https://example.test/b/');
+});
+
+test('blocks credential overrides and oversized raw API bodies', async () => {
+  let host = new RealmCapabilityHost({
+    adapter: new FakeAdapter(),
+    realmUrl: 'https://example.test/demo/',
+    mode: 'commit',
+    limits: { apiRequestBytes: 3 },
+  });
+
+  await assert.rejects(
+    host.dispatch('server.request', [
+      'POST',
+      '_create-realm',
+      { headers: { Authorization: 'Bearer forged' } },
+    ]),
+    { code: 'CAPABILITY_DENIED' },
+  );
+  await assert.rejects(
+    host.dispatch('api.request', [
+      'GET',
+      '_info',
+      { headers: { 'X-Boxel-Job-Id': 'internal' } },
+    ]),
+    { code: 'CAPABILITY_DENIED' },
+  );
+  await assert.rejects(
+    host.dispatch('api.request', [
+      'POST',
+      'file.txt',
+      { body: 'four', bodyType: 'text' },
+    ]),
+    { code: 'BYTE_LIMIT' },
+  );
+});
+
+test('enforces cumulative raw API request and response budgets', async () => {
+  let requestAdapter = new FakeAdapter();
+  let requestHost = new RealmCapabilityHost({
+    adapter: requestAdapter,
+    realmUrl: 'https://example.test/demo/',
+    mode: 'commit',
+    limits: { apiTotalRequestBytes: 5 },
+  });
+
+  await requestHost.dispatch('api.request', [
+    'POST',
+    'one.txt',
+    { body: 'abc', bodyType: 'text' },
+  ]);
+  await assert.rejects(
+    requestHost.dispatch('api.request', [
+      'POST',
+      'two.txt',
+      { body: 'def', bodyType: 'text' },
+    ]),
+    { code: 'BYTE_LIMIT' },
+  );
+  assert.equal(requestAdapter.rawRequests.length, 1);
+
+  let responseAdapter = new FakeAdapter();
+  let responseHost = new RealmCapabilityHost({
+    adapter: responseAdapter,
+    realmUrl: 'https://example.test/demo/',
+    limits: { apiTotalResponseBytes: 35 },
+  });
+  await responseHost.dispatch('api.request', ['GET', 'a', {}]);
+  await assert.rejects(responseHost.dispatch('api.request', ['GET', 'b', {}]), {
+    code: 'BYTE_LIMIT',
+  });
+  assert.ok(responseAdapter.rawRequests[1].options.maxResponseBytes < 35);
+});
+
+test('lists effective Realm grants and filters by permission', async () => {
+  let host = new RealmCapabilityHost({
+    adapter: new FakeAdapter(),
+    realmUrl: 'https://example.test/a/',
+  });
+
+  let readable = await host.dispatch('realms.list', [{ permission: 'read' }]);
+  let writable = await host.dispatch('realms.list', [{ permission: 'write' }]);
+
+  assert.deepEqual(
+    readable.map((grant) => grant.url),
+    ['https://example.test/a/', 'https://example.test/b/'],
+  );
+  assert.deepEqual(
+    writable.map((grant) => grant.url),
+    ['https://example.test/a/'],
+  );
+});
+
+test('federates explicit Realm searches in bounded batches', async () => {
+  let adapter = new FakeAdapter();
+  adapter.listRealms = async () =>
+    ['a', 'b', 'c'].map((name) => ({
+      id: `https://example.test/${name}/`,
+      url: `https://example.test/${name}/`,
+      canRead: true,
+      canWrite: name === 'a',
+    }));
+  let host = new RealmCapabilityHost({
+    adapter,
+    realmUrl: 'https://example.test/a/',
+    limits: { searchRealmBatchSize: 2 },
+  });
+  let realms = [
+    'https://example.test/a/',
+    'https://example.test/b/',
+    'https://example.test/c/',
+  ];
+
+  let results = await host.dispatch('search', [
+    { filter: { matches: 'three' } },
+    { realms },
+  ]);
+
+  assert.deepEqual(adapter.searchCalls, [realms.slice(0, 2), realms.slice(2)]);
+  assert.deepEqual(
+    results.map((item) => item.id),
+    realms.map((realm) => `${realm}file.gts`),
+  );
+});
+
+test('denies explicit federated searches outside discovered read grants', async () => {
+  let adapter = new FakeAdapter();
+  let host = new RealmCapabilityHost({
+    adapter,
+    realmUrl: 'https://example.test/a/',
+  });
+
+  await assert.rejects(
+    host.dispatch('search', [
+      { filter: { matches: 'secret' } },
+      { realms: ['https://example.test/denied/'] },
+    ]),
+    { code: 'CAPABILITY_DENIED' },
+  );
+  assert.equal(adapter.searchCalls.length, 0);
+});
+
+test('searches every readable Realm with realms all', async () => {
+  let adapter = new FakeAdapter();
+  let host = new RealmCapabilityHost({
+    adapter,
+    realmUrl: 'https://example.test/a/',
+  });
+
+  await host.dispatch('search', [{}, { realms: 'all' }]);
+
+  assert.deepEqual(adapter.searchCalls, [
+    ['https://example.test/a/', 'https://example.test/b/'],
+  ]);
+});
+
+test('reads a federated-search hit through an authorized Realm scope', async () => {
+  let adapter = new FakeAdapter();
+  let host = new RealmCapabilityHost({
+    adapter,
+    realmUrl: 'https://example.test/a/',
+  });
+
+  let content = await host.dispatch('scoped.fs.readText', [
+    'https://example.test/b/',
+    'src/card.gts',
+  ]);
+
+  assert.match(content, /@glimmer\/component/);
+  assert.deepEqual(adapter.readCalls.at(-1), {
+    realm: 'https://example.test/b/',
+    path: 'src/card.gts',
+  });
+});
+
+test('denies scoped reads outside discovered Realm grants', async () => {
+  let host = new RealmCapabilityHost({
+    adapter: new FakeAdapter(),
+    realmUrl: 'https://example.test/a/',
+  });
+
+  await assert.rejects(
+    host.dispatch('scoped.fs.readText', ['https://evil.test/realm/', 'a.txt']),
+    { code: 'CAPABILITY_DENIED' },
+  );
+});

--- a/packages/realm-runner/test/http-adapter.test.js
+++ b/packages/realm-runner/test/http-adapter.test.js
@@ -1,0 +1,312 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { BoxelHttpAdapter } from '../src/http-adapter.js';
+
+function jwt(claims) {
+  return `x.${Buffer.from(JSON.stringify(claims)).toString('base64url')}.x`;
+}
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { 'content-type': 'application/json', ...init.headers },
+  });
+}
+
+test('discovers effective Realm grants with the calling Realm JWT', async () => {
+  let requests = [];
+  let adapter = new BoxelHttpAdapter({
+    authorization: 'Bearer current-realm-token',
+    realmServerUrl: 'https://example.test/',
+    async fetch(url, init) {
+      requests.push({ url, init });
+      return jsonResponse({
+        'https://example.test/one/': jwt({
+          permissions: ['read', 'write'],
+        }),
+        'https://example.test/two/': jwt({ permissions: ['read'] }),
+      });
+    },
+  });
+
+  let grants = await adapter.listRealms();
+
+  assert.deepEqual(grants, [
+    {
+      id: 'https://example.test/one/',
+      url: 'https://example.test/one/',
+      canRead: true,
+      canWrite: true,
+    },
+    {
+      id: 'https://example.test/two/',
+      url: 'https://example.test/two/',
+      canRead: true,
+      canWrite: false,
+    },
+  ]);
+  assert.equal(requests[0].url, 'https://example.test/_realm-auth');
+  assert.equal(
+    requests[0].init.headers.get('Authorization'),
+    'Bearer current-realm-token',
+  );
+});
+
+test('uses the federated full-text index and returns item resources', async () => {
+  let captured;
+  let adapter = new BoxelHttpAdapter({
+    authorization: 'Bearer current-realm-token',
+    realmServerUrl: 'https://example.test/',
+    async fetch(url, init) {
+      captured = { url, init };
+      return jsonResponse({
+        data: [
+          {
+            relationships: {
+              item: {
+                data: {
+                  type: 'file-meta',
+                  id: 'https://example.test/two/card.gts',
+                },
+              },
+            },
+          },
+        ],
+        included: [
+          {
+            type: 'file-meta',
+            id: 'https://example.test/two/card.gts',
+            attributes: { name: 'card.gts' },
+          },
+        ],
+      });
+    },
+  });
+
+  let results = await adapter.search(
+    ['https://example.test/one/', 'https://example.test/two/'],
+    { filter: { any: [{ matches: 'three' }, { matches: 'threejs' }] } },
+  );
+
+  assert.equal(captured.url, 'https://example.test/_federated-search');
+  assert.equal(captured.init.method, 'QUERY');
+  assert.deepEqual(JSON.parse(captured.init.body), {
+    realms: ['https://example.test/one/', 'https://example.test/two/'],
+    fields: { entry: ['item'] },
+    filter: { any: [{ matches: 'three' }, { matches: 'threejs' }] },
+  });
+  assert.deepEqual(results, [
+    {
+      type: 'file-meta',
+      id: 'https://example.test/two/card.gts',
+      attributes: { name: 'card.gts' },
+    },
+  ]);
+});
+
+test('commits every staged text change in one atomic request', async () => {
+  let captured;
+  let adapter = new BoxelHttpAdapter({
+    authorization: 'Bearer current-realm-token',
+    realmServerUrl: 'https://example.test/',
+    async fetch(url, init) {
+      captured = { url, init };
+      return jsonResponse({ 'atomic:results': [] });
+    },
+  });
+
+  await adapter.atomicWrite('https://example.test/one/', [
+    {
+      operation: 'update',
+      path: 'existing.gts',
+      content: 'updated',
+      exists: true,
+    },
+    {
+      operation: 'create',
+      path: 'new.gts',
+      content: 'created',
+      exists: false,
+    },
+    { operation: 'remove', path: 'old.gts', exists: true },
+  ]);
+
+  assert.equal(captured.url, 'https://example.test/one/_atomic');
+  let body = JSON.parse(captured.init.body);
+  assert.deepEqual(
+    body['atomic:operations'].map(({ op, href }) => ({ op, href })),
+    [
+      { op: 'update', href: 'existing.gts' },
+      { op: 'add', href: 'new.gts' },
+      { op: 'remove', href: 'old.gts' },
+    ],
+  );
+});
+
+test('executes scoped raw Realm API requests with host-controlled auth', async () => {
+  let captured;
+  let adapter = new BoxelHttpAdapter({
+    authorization: 'Bearer current-realm-token',
+    realmServerUrl: 'https://example.test/',
+    async fetch(url, init) {
+      captured = { url, init };
+      return jsonResponse({ updated: true }, { status: 202 });
+    },
+  });
+
+  let result = await adapter.realmRequest(
+    'https://example.test/one/',
+    'PATCH',
+    '_permissions',
+    {
+      body: { add: ['read'] },
+      bodyType: 'json',
+      contentType: 'application/json',
+      headers: { 'If-Match': 'current' },
+      responseType: 'auto',
+    },
+  );
+
+  assert.equal(captured.url, 'https://example.test/one/_permissions');
+  assert.equal(captured.init.method, 'PATCH');
+  assert.equal(
+    captured.init.headers.get('Authorization'),
+    'Bearer current-realm-token',
+  );
+  assert.equal(captured.init.headers.get('If-Match'), 'current');
+  assert.deepEqual(JSON.parse(captured.init.body), { add: ['read'] });
+  assert.equal(result.status, 202);
+  assert.deepEqual(result.body, { updated: true });
+});
+
+test('transports binary raw API bodies and responses as base64', async () => {
+  let captured;
+  let adapter = new BoxelHttpAdapter({
+    authorization: 'Bearer current-realm-token',
+    realmServerUrl: 'https://example.test/',
+    async fetch(url, init) {
+      captured = { url, init };
+      return new Response(Uint8Array.from([9, 8, 7]), {
+        headers: { 'content-type': 'application/octet-stream' },
+      });
+    },
+  });
+  let requestBytes = Uint8Array.from([0, 1, 2, 255]);
+
+  let result = await adapter.realmRequest(
+    'https://example.test/one/',
+    'POST',
+    'asset.bin',
+    {
+      body: Buffer.from(requestBytes).toString('base64'),
+      bodyType: 'base64',
+      contentType: 'application/octet-stream',
+      responseType: 'base64',
+    },
+  );
+
+  assert.deepEqual(new Uint8Array(captured.init.body), requestBytes);
+  assert.deepEqual(Buffer.from(result.body, 'base64'), Buffer.from([9, 8, 7]));
+});
+
+test('blocks raw access to credential-minting and recursive endpoints', async () => {
+  let adapter = new BoxelHttpAdapter({
+    authorization: 'Bearer current-realm-token',
+    realmServerUrl: 'https://example.test/',
+    async fetch() {
+      throw new Error('must not fetch');
+    },
+  });
+
+  await assert.rejects(adapter.serverRequest('POST', '_realm-auth', {}), {
+    code: 'CAPABILITY_DENIED',
+  });
+  await assert.rejects(
+    adapter.realmRequest(
+      'https://example.test/one/',
+      'QUERY',
+      '_realm-program',
+      { body: { code: 'return 1' }, bodyType: 'json' },
+    ),
+    { code: 'CAPABILITY_DENIED' },
+  );
+});
+
+test('stops streaming a raw API response at the host byte limit', async () => {
+  let adapter = new BoxelHttpAdapter({
+    authorization: 'Bearer current-realm-token',
+    realmServerUrl: 'https://example.test/',
+    async fetch() {
+      return new Response('response is too large');
+    },
+  });
+
+  await assert.rejects(
+    adapter.realmRequest('https://example.test/one/', 'GET', 'large.txt', {
+      responseType: 'text',
+      maxResponseBytes: 4,
+    }),
+    { code: 'BYTE_LIMIT' },
+  );
+});
+
+test('stops streaming file helper responses at the host byte limit', async () => {
+  let adapter = new BoxelHttpAdapter({
+    authorization: 'Bearer current-realm-token',
+    realmServerUrl: 'https://example.test/',
+    async fetch() {
+      return new Response('file is too large');
+    },
+  });
+
+  await assert.rejects(
+    adapter.readText('https://example.test/one/', 'large.txt', 4),
+    { code: 'BYTE_LIMIT' },
+  );
+  await assert.rejects(
+    adapter.readBase64('https://example.test/one/', 'large.bin', 4),
+    { code: 'BYTE_LIMIT' },
+  );
+});
+
+test('turns request aborts into a stable Realm API timeout error', async () => {
+  let adapter = new BoxelHttpAdapter({
+    authorization: 'Bearer current-realm-token',
+    realmServerUrl: 'https://example.test/',
+    requestTimeoutMs: 5,
+    async fetch() {
+      throw new DOMException('timed out', 'TimeoutError');
+    },
+  });
+
+  await assert.rejects(
+    adapter.realmRequest('https://example.test/one/', 'GET', '_info'),
+    { code: 'REALM_API_TIMEOUT' },
+  );
+});
+
+test('aborts in-flight HTTP when the Realm Program deadline expires', async () => {
+  let controller = new AbortController();
+  let adapter = new BoxelHttpAdapter({
+    authorization: 'Bearer current-realm-token',
+    realmServerUrl: 'https://example.test/',
+    async fetch(_url, init) {
+      return new Promise((_resolve, reject) => {
+        init.signal.addEventListener('abort', () => {
+          reject(new DOMException('aborted', 'AbortError'));
+        });
+      });
+    },
+  });
+  adapter.setProgramSignal(controller.signal);
+
+  let pending = adapter.realmRequest(
+    'https://example.test/one/',
+    'GET',
+    '_info',
+  );
+  controller.abort();
+
+  await assert.rejects(pending, { code: 'TIME_LIMIT' });
+});

--- a/packages/realm-runner/test/notebook.test.js
+++ b/packages/realm-runner/test/notebook.test.js
@@ -1,0 +1,320 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { RealmNotebookCoordinator } from '../src/notebook.js';
+import {
+  EncryptedNotebookStorage,
+  MemoryNotebookStorage,
+  RealmFileNotebookStorage,
+} from '../src/notebook-storage.js';
+
+function authorizationFor(user) {
+  let encode = (value) =>
+    Buffer.from(JSON.stringify(value)).toString('base64url');
+  return `Bearer ${encode({ alg: 'none' })}.${encode({ user })}.signature`;
+}
+
+class FakeRealmAdapter {
+  constructor() {
+    this.files = new Map();
+  }
+
+  async readText(_realmUrl, path) {
+    return this.files.get(path);
+  }
+
+  async atomicWrite(_realmUrl, changes) {
+    for (let change of changes) {
+      if (change.operation === 'remove') this.files.delete(change.path);
+      else this.files.set(change.path, change.content);
+    }
+  }
+}
+
+test('ephemeral notebook storage expires records', async () => {
+  let now = 1_000;
+  let storage = new MemoryNotebookStorage({ now: () => now });
+  await storage.set('session/record', { answer: 42 }, { expiresAt: 2_000 });
+
+  assert.deepEqual(await storage.get('session/record'), { answer: 42 });
+  now = 2_001;
+  assert.equal(await storage.get('session/record'), undefined);
+});
+
+test('touching an ephemeral notebook extends every record in the session', async () => {
+  let now = 1_000;
+  let storage = new MemoryNotebookStorage({ now: () => now });
+  await storage.set('session/manifest', { cells: {} }, { expiresAt: 2_000 });
+  await storage.set(
+    'session/executions/old',
+    { value: 1 },
+    { expiresAt: 2_000 },
+  );
+
+  now = 1_900;
+  await storage.touchPrefix('session', 2_900);
+  now = 2_100;
+
+  assert.deepEqual(await storage.get('session/executions/old'), { value: 1 });
+});
+
+test('durable Realm notebook records are encrypted at rest', async () => {
+  let adapter = new FakeRealmAdapter();
+  let underlying = new RealmFileNotebookStorage({
+    adapter,
+    realmUrl: 'https://example.test/workspace/',
+  });
+  let storage = new EncryptedNotebookStorage({
+    storage: underlying,
+    keyMaterial: 'test-realm-secret-seed-that-is-long-enough',
+  });
+
+  await storage.set('scope/executions/abc', {
+    privateSource: 'do not expose this federated source',
+  });
+
+  let persisted = [...adapter.files.values()][0];
+  assert.equal(persisted.includes('do not expose'), false);
+  assert.deepEqual(await storage.get('scope/executions/abc'), {
+    privateSource: 'do not expose this federated source',
+  });
+});
+
+test('notebook cells reuse completed work and pass immutable outputs forward', async () => {
+  let coordinator = new RealmNotebookCoordinator();
+  let calls = [];
+  let common = {
+    mode: 'preview',
+    realmURL: 'https://example.test/workspace/',
+    authorization: authorizationFor('@user:example.test'),
+    adapter: {},
+  };
+
+  let search = await coordinator.execute({
+    ...common,
+    notebook: { sessionId: 'room-1', cellId: 'search' },
+    code: 'return search();',
+    run: async (input) => {
+      calls.push({ cell: 'search', input });
+      return {
+        ok: true,
+        mode: 'preview',
+        value: { candidates: ['one.gts', 'two.gts'] },
+        changes: [],
+        effects: [],
+        logs: [],
+        stats: {},
+      };
+    },
+  });
+
+  let grep = await coordinator.execute({
+    ...common,
+    notebook: {
+      sessionId: 'room-1',
+      cellId: 'grep',
+      inputs: {
+        candidates: { cellId: 'search', pointer: '/result/value/candidates' },
+      },
+    },
+    code: 'return grep(realm.input.candidates);',
+    run: async (input) => {
+      calls.push({ cell: 'grep', input });
+      return {
+        ok: true,
+        mode: 'preview',
+        value: input.candidates.filter((path) => path.startsWith('two')),
+        changes: [],
+        effects: [],
+        logs: [],
+        stats: {},
+      };
+    },
+  });
+
+  let repeatedSearch = await coordinator.execute({
+    ...common,
+    notebook: { sessionId: 'room-1', cellId: 'search' },
+    code: 'return search();',
+    run: async () => {
+      throw new Error('completed cell must not execute again');
+    },
+  });
+
+  assert.deepEqual(calls, [
+    { cell: 'search', input: {} },
+    {
+      cell: 'grep',
+      input: { candidates: ['one.gts', 'two.gts'] },
+    },
+  ]);
+  assert.deepEqual(grep.value, ['two.gts']);
+  assert.equal(search.notebook.reused, false);
+  assert.equal(repeatedSearch.notebook.reused, true);
+  assert.equal(
+    repeatedSearch.notebook.executionId,
+    search.notebook.executionId,
+  );
+});
+
+test('notebook ownership isolates identical session ids', async () => {
+  let coordinator = new RealmNotebookCoordinator();
+  let execute = (user, value) =>
+    coordinator.execute({
+      notebook: { sessionId: 'same-room', cellId: 'cell' },
+      code: 'return value;',
+      mode: 'preview',
+      realmURL: 'https://example.test/workspace/',
+      authorization: authorizationFor(user),
+      adapter: {},
+      run: async () => ({ ok: true, value }),
+    });
+
+  let first = await execute('@one:example.test', 1);
+  let second = await execute('@two:example.test', 2);
+
+  assert.equal(first.value, 1);
+  assert.equal(second.value, 2);
+  assert.notEqual(first.notebook.executionId, second.notebook.executionId);
+});
+
+test('saved cell source can be rerun and downstream cells consume its latest output', async () => {
+  let coordinator = new RealmNotebookCoordinator();
+  let upstreamValue = 1;
+  let common = {
+    mode: 'preview',
+    realmURL: 'https://example.test/workspace/',
+    authorization: authorizationFor('@user:example.test'),
+    adapter: {},
+  };
+  let runUpstream = async (_input, savedCode) => ({
+    ok: true,
+    value: { number: upstreamValue, savedCode },
+  });
+
+  await coordinator.execute({
+    ...common,
+    notebook: { sessionId: 'jupyter', cellId: 'source' },
+    code: 'return loadCurrentData();',
+    run: runUpstream,
+  });
+  let firstDownstream = await coordinator.execute({
+    ...common,
+    notebook: {
+      sessionId: 'jupyter',
+      cellId: 'transform',
+      inputs: {
+        source: { cellId: 'source', pointer: '/result/value/number' },
+      },
+    },
+    code: 'return realm.input.source * 10;',
+    run: async (input) => ({ ok: true, value: input.source * 10 }),
+  });
+
+  upstreamValue = 2;
+  let rerunUpstream = await coordinator.execute({
+    ...common,
+    notebook: {
+      sessionId: 'jupyter',
+      cellId: 'source',
+      runSaved: true,
+      force: true,
+    },
+    code: undefined,
+    run: runUpstream,
+  });
+  let secondDownstream = await coordinator.execute({
+    ...common,
+    notebook: {
+      sessionId: 'jupyter',
+      cellId: 'transform',
+      runSaved: true,
+      // Some clients naturally serialize an empty input-ref collection. A
+      // saved run must still use the cell's saved bindings.
+      inputs: {},
+    },
+    code: undefined,
+    run: async (input, savedCode) => ({
+      ok: true,
+      value: { result: input.source * 10, savedCode },
+    }),
+  });
+  let editedDownstream = await coordinator.execute({
+    ...common,
+    notebook: {
+      sessionId: 'jupyter',
+      cellId: 'transform',
+      inputs: {
+        source: { cellId: 'source', pointer: '/result/value/number' },
+      },
+    },
+    code: 'return realm.input.source * 100;',
+    run: async (input) => ({ ok: true, value: input.source * 100 }),
+  });
+
+  assert.equal(firstDownstream.value, 10);
+  assert.equal(rerunUpstream.value.number, 2);
+  assert.equal(rerunUpstream.value.savedCode, 'return loadCurrentData();');
+  assert.deepEqual(secondDownstream.value, {
+    result: 20,
+    savedCode: 'return realm.input.source * 10;',
+  });
+  assert.equal(rerunUpstream.notebook.revision, 2);
+  assert.equal(secondDownstream.notebook.revision, 2);
+  assert.equal(
+    rerunUpstream.notebook.snapshot.cells.find(
+      (cell) => cell.cellId === 'transform',
+    ).stale,
+    true,
+  );
+  assert.equal(
+    secondDownstream.notebook.snapshot.cells.find(
+      (cell) => cell.cellId === 'transform',
+    ).stale,
+    false,
+  );
+  assert.equal(editedDownstream.value, 200);
+  assert.equal(editedDownstream.notebook.revision, 3);
+  assert.equal(
+    editedDownstream.notebook.snapshot.cells.find(
+      (cell) => cell.cellId === 'transform',
+    ).source,
+    'return realm.input.source * 100;',
+  );
+});
+
+test('saved cells can be parameterized with new literal realm.input data', async () => {
+  let coordinator = new RealmNotebookCoordinator();
+  let common = {
+    mode: 'preview',
+    realmURL: 'https://example.test/workspace/',
+    authorization: authorizationFor('@user:example.test'),
+    adapter: {},
+    run: async (input, savedCode) => ({
+      ok: true,
+      value: { product: input.value * 2, savedCode },
+    }),
+  };
+  await coordinator.execute({
+    ...common,
+    notebook: { sessionId: 'parameters', cellId: 'double' },
+    input: { value: 2 },
+    code: 'return realm.input.value * 2;',
+  });
+  let rerun = await coordinator.execute({
+    ...common,
+    notebook: {
+      sessionId: 'parameters',
+      cellId: 'double',
+      runSaved: true,
+      force: true,
+    },
+    input: { value: 5 },
+    code: undefined,
+  });
+
+  assert.deepEqual(rerun.value, {
+    product: 10,
+    savedCode: 'return realm.input.value * 2;',
+  });
+});

--- a/packages/realm-runner/test/realm-program-executor.test.js
+++ b/packages/realm-runner/test/realm-program-executor.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { QuickJSRealmProgramExecutor } from '../src/realm-program-executor.js';
+
+test('targets the configured Realm-server origin for server API calls', async () => {
+  let requestedUrl;
+  let executor = new QuickJSRealmProgramExecutor({
+    realmServerUrl: 'https://realm-server.example.test/',
+    async fetch(url) {
+      requestedUrl = url;
+      return new Response(JSON.stringify({ queued: 0 }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  let result = await executor.execute({
+    code: `return await realm.server.request('GET', '_queue');`,
+    mode: 'preview',
+    realmURL: 'https://custom-realm.example/space/',
+    authorization: 'Bearer current-realm-token',
+  });
+
+  assert.equal(requestedUrl, 'https://realm-server.example.test/_queue');
+  assert.equal(result.value.status, 200);
+});

--- a/packages/realm-runner/test/runner.test.js
+++ b/packages/realm-runner/test/runner.test.js
@@ -1,0 +1,594 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { runRealmScript } from '../src/runner.js';
+
+class FakeAdapter {
+  constructor(files = {}, searchResults = []) {
+    this.files = new Map(Object.entries(files));
+    this.searchResults = searchResults;
+    this.commits = [];
+    this.searchCalls = [];
+    this.rawRequests = [];
+  }
+
+  async listRealms() {
+    return [
+      {
+        id: 'https://example.test/one/',
+        url: 'https://example.test/one/',
+        canRead: true,
+        canWrite: true,
+      },
+      {
+        id: 'https://example.test/two/',
+        url: 'https://example.test/two/',
+        canRead: true,
+        canWrite: false,
+      },
+    ];
+  }
+
+  async listFiles() {
+    return [...this.files.keys()];
+  }
+
+  async readText(_realm, path) {
+    return this.files.get(path);
+  }
+
+  async indexingErrors() {
+    return { data: [] };
+  }
+
+  async search(realms) {
+    this.searchCalls.push(structuredClone(realms));
+    return structuredClone(this.searchResults);
+  }
+
+  async atomicWrite(_realm, changes) {
+    this.commits.push(structuredClone(changes));
+    for (let change of changes) {
+      if (change.operation === 'remove') this.files.delete(change.path);
+      else this.files.set(change.path, change.content);
+    }
+    return { committed: changes.length };
+  }
+
+  async realmRequest(realm, method, path, options) {
+    this.rawRequests.push({ scope: 'realm', realm, method, path, options });
+    return { ok: true, status: 201, headers: {}, body: { created: true } };
+  }
+
+  async serverRequest(method, path, options) {
+    this.rawRequests.push({ scope: 'server', method, path, options });
+    return { ok: true, status: 202, headers: {}, body: { queued: true } };
+  }
+}
+
+class FakeBxl {
+  evaluate(expression, input, options) {
+    return { expression, input, syntax: options?.syntax ?? 'auto' };
+  }
+}
+
+test('runs a Realm Script with no ambient Node authority', async () => {
+  let result = await runRealmScript({
+    code: `return {
+      current: realm.current,
+      processType: typeof process,
+      requireType: typeof require,
+      fetchType: typeof fetch,
+    };`,
+    realm: 'https://example.test/demo/',
+    adapter: new FakeAdapter(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.value, {
+    current: { url: 'https://example.test/demo/', mode: 'preview' },
+    processType: 'undefined',
+    requireType: 'undefined',
+    fetchType: 'undefined',
+  });
+});
+
+test('advertises notebook and activity support in Realm API v2', async () => {
+  let notebook = {
+    sessionId: 'research',
+    cellId: 'search',
+    revision: 2,
+    executionId: 'a'.repeat(64),
+    persistence: 'ephemeral',
+  };
+  let result = await runRealmScript({
+    code: `return {
+      apiVersion: realm.apiVersion,
+      features: realm.features,
+      notebook: realm.notebook,
+      help: await realm.help(),
+    };`,
+    realm: 'https://example.test/demo/',
+    notebook,
+    adapter: new FakeAdapter(),
+  });
+
+  assert.equal(result.value.apiVersion, '2');
+  assert.deepEqual(result.value.features, {
+    notebooks: true,
+    activity: true,
+    streamingActivity: true,
+  });
+  assert.deepEqual(result.value.notebook, notebook);
+  assert.equal(result.value.help.apiVersion, '2');
+  assert.equal(result.value.help.features.notebooks, true);
+  assert.equal(
+    result.value.help.methods.includes('realm.activity(messageOrDetails)'),
+    true,
+  );
+});
+
+test('emits sanitized semantic and automatic activity without arguments or results', async () => {
+  let activity = [];
+  await runRealmScript({
+    code: `
+      await realm.activity({
+        phase: 'narrow',
+        message: 'Narrowing candidates',
+        current: 1,
+        total: 2,
+      });
+      await realm.fs.glob('private/**/*.gts');
+      return 'secret-result';
+    `,
+    realm: 'https://example.test/demo/',
+    adapter: new FakeAdapter({ 'private/secret.gts': 'secret source' }),
+    onActivity(event) {
+      activity.push(event);
+    },
+  });
+
+  assert.deepEqual(
+    activity.map(({ phase, message, source, status }) => ({
+      phase,
+      message,
+      source,
+      status,
+    })),
+    [
+      {
+        phase: 'start',
+        message: 'Starting Realm Script',
+        source: 'runtime',
+        status: 'running',
+      },
+      {
+        phase: 'narrow',
+        message: 'Narrowing candidates',
+        source: 'script',
+        status: 'running',
+      },
+      {
+        phase: 'list',
+        message: 'Finding candidate files',
+        source: 'runtime',
+        status: 'running',
+      },
+      {
+        phase: 'finalize',
+        message: 'Finalizing Realm Script preview',
+        source: 'runtime',
+        status: 'running',
+      },
+      {
+        phase: 'complete',
+        message: 'Realm Script complete',
+        source: 'runtime',
+        status: 'completed',
+      },
+    ],
+  );
+  assert.equal(JSON.stringify(activity).includes('private/secret.gts'), false);
+  assert.equal(JSON.stringify(activity).includes('secret-result'), false);
+});
+
+test('provides deeply frozen JSON input to an isolated Realm Script', async () => {
+  let result = await runRealmScript({
+    code: `
+      const before = realm.input.nested.count;
+      try { realm.input.nested.count = 99; } catch {}
+      return {
+        before,
+        after: realm.input.nested.count,
+        frozen: Object.isFrozen(realm.input) && Object.isFrozen(realm.input.nested),
+      };
+    `,
+    realm: 'https://example.test/demo/',
+    input: { nested: { count: 3 } },
+    adapter: new FakeAdapter(),
+  });
+
+  assert.deepEqual(result.value, { before: 3, after: 3, frozen: true });
+});
+
+test('globs, reads, transforms, and previews JSON writes', async () => {
+  let adapter = new FakeAdapter({
+    'data/a.json': '{"count":1}\n',
+    'data/b.json': '{"count":2}\n',
+    'notes/readme.md': 'hello\n',
+  });
+  let result = await runRealmScript({
+    code: `
+      const paths = await realm.fs.glob('data/*.json');
+      for (const path of paths) {
+        const value = await realm.fs.readJSON(path);
+        value.count += 10;
+        await realm.fs.writeJSON(path, value);
+      }
+      return { paths };
+    `,
+    realm: 'https://example.test/demo/',
+    adapter,
+  });
+
+  assert.deepEqual(result.value.paths, ['data/a.json', 'data/b.json']);
+  assert.equal(result.changes.length, 2);
+  assert.equal(adapter.commits.length, 0);
+  assert.equal(adapter.files.get('data/a.json'), '{"count":1}\n');
+});
+
+test('commits staged writes once through the atomic adapter', async () => {
+  let adapter = new FakeAdapter({
+    'hello.txt': 'hello\n',
+    'obsolete.txt': 'remove me\n',
+  });
+  let result = await runRealmScript({
+    code: `
+      await realm.fs.replace('hello.txt', 'hello', 'goodbye', { expectedMatches: 1 });
+      await realm.fs.writeText('new.txt', 'created\\n');
+      await realm.fs.remove('obsolete.txt');
+      return 'done';
+    `,
+    realm: 'https://example.test/demo/',
+    mode: 'commit',
+    adapter,
+  });
+
+  assert.equal(result.value, 'done');
+  assert.equal(adapter.commits.length, 1);
+  assert.equal(adapter.commits[0].length, 3);
+  assert.equal(adapter.files.get('hello.txt'), 'goodbye\n');
+  assert.equal(adapter.files.get('new.txt'), 'created\n');
+  assert.equal(adapter.files.has('obsolete.txt'), false);
+});
+
+test('captures bounded console output', async () => {
+  let result = await runRealmScript({
+    code: `console.log('found', 3); return true;`,
+    realm: 'https://example.test/demo/',
+    adapter: new FakeAdapter(),
+  });
+
+  assert.deepEqual(result.logs, [{ level: 'log', args: ['found', 3] }]);
+});
+
+test('exposes Realm discovery and federated search to guest programs', async () => {
+  let adapter = new FakeAdapter({}, [
+    { type: 'file-meta', id: 'https://example.test/one/module.gts' },
+  ]);
+  let result = await runRealmScript({
+    code: `
+      const grants = await realm.listRealms({ permission: 'read' });
+      const found = await realm.search(
+        { filter: { any: [{ matches: 'three' }, { matches: 'threejs' }] } },
+        { realms: grants.map((grant) => grant.url) },
+      );
+      return { grants, found };
+    `,
+    realm: 'https://example.test/one/',
+    adapter,
+  });
+
+  assert.deepEqual(adapter.searchCalls, [
+    ['https://example.test/one/', 'https://example.test/two/'],
+  ]);
+  assert.equal(result.value.grants.length, 2);
+  assert.equal(result.value.found[0].id.endsWith('module.gts'), true);
+});
+
+test('greps an exact federated candidate list passed through realm.input', async () => {
+  let adapter = new FakeAdapter({
+    'module.gts': `import * as THREE from 'three';\n`,
+    'other.gts': `export const unrelated = true;\n`,
+  });
+  let result = await runRealmScript({
+    code: `
+      return await realm.fs.grep(/from\\s+['"]three/i, {
+        files: realm.input.candidates,
+        glob: '**/*.gts',
+      });
+    `,
+    realm: 'https://example.test/one/',
+    input: {
+      candidates: [
+        { id: 'https://example.test/two/module.gts' },
+        { id: 'https://example.test/two/other.gts' },
+      ],
+    },
+    adapter,
+  });
+
+  assert.deepEqual(result.value, [
+    {
+      id: 'https://example.test/two/module.gts',
+      path: 'module.gts',
+      line: 1,
+      column: 19,
+      text: `import * as THREE from 'three';`,
+    },
+  ]);
+});
+
+test('opens an authorized federated Realm as a read-only handle', async () => {
+  let adapter = new FakeAdapter({
+    'remote.gts': 'export const remote = true;\n',
+  });
+  let result = await runRealmScript({
+    code: `
+      const remote = realm.open('https://example.test/two/');
+      return {
+        current: remote.current,
+        source: await remote.fs.readText('remote.gts'),
+        writeType: typeof remote.fs.writeText,
+      };
+    `,
+    realm: 'https://example.test/one/',
+    adapter,
+  });
+
+  assert.deepEqual(result.value, {
+    current: { url: 'https://example.test/two/', mode: 'read-only' },
+    source: 'export const remote = true;\n',
+    writeType: 'undefined',
+  });
+});
+
+test('opens an explicitly writable cross-Realm API handle in commit mode', async () => {
+  let adapter = new FakeAdapter();
+  adapter.listRealms = async () => [
+    {
+      id: 'https://example.test/one/',
+      url: 'https://example.test/one/',
+      canRead: true,
+      canWrite: true,
+    },
+    {
+      id: 'https://example.test/two/',
+      url: 'https://example.test/two/',
+      canRead: true,
+      canWrite: true,
+    },
+  ];
+
+  let result = await runRealmScript({
+    code: `
+      const remote = realm.open('https://example.test/two/', { write: true });
+      const response = await remote.api.request('DELETE', 'obsolete.json');
+      return { current: remote.current, response };
+    `,
+    realm: 'https://example.test/one/',
+    mode: 'commit',
+    adapter,
+  });
+
+  assert.equal(result.value.current.mode, 'commit');
+  assert.equal(adapter.rawRequests[0].realm, 'https://example.test/two/');
+  assert.equal(result.effects[0].realm, 'https://example.test/two/');
+});
+
+test('exposes BXL as the jq-like data transformation layer', async () => {
+  let result = await runRealmScript({
+    code: `return {
+      jq: await realm.bxl.jq('.items | length', { items: [1, 2, 3] }),
+      readable: await realm.bxl.evaluate('Score + 1', { Score: 4 }, { syntax: 'readable' }),
+    };`,
+    realm: 'https://example.test/demo/',
+    adapter: new FakeAdapter(),
+    bxl: new FakeBxl(),
+  });
+
+  assert.deepEqual(result.value, {
+    jq: {
+      expression: '.items | length',
+      input: { items: [1, 2, 3] },
+      syntax: 'jq',
+    },
+    readable: {
+      expression: 'Score + 1',
+      input: { Score: 4 },
+      syntax: 'readable',
+    },
+  });
+});
+
+test('exposes the full authenticated Realm API through one guest tool', async () => {
+  let adapter = new FakeAdapter();
+  let result = await runRealmScript({
+    code: `
+      const created = await realm.api.request('POST', 'Card', {
+        body: { data: { type: 'card', attributes: { title: 'Created' } } },
+        bodyType: 'json',
+        contentType: 'application/vnd.card+json',
+      });
+      const queued = await realm.server.request('POST', '_publish-realm', {
+        body: { sourceRealmURL: realm.current.url },
+        bodyType: 'json',
+        contentType: 'application/json',
+      });
+      return { created, queued };
+    `,
+    realm: 'https://example.test/demo/',
+    mode: 'commit',
+    adapter,
+  });
+
+  assert.equal(result.value.created.status, 201);
+  assert.equal(result.value.queued.status, 202);
+  assert.deepEqual(result.effects, [
+    {
+      scope: 'realm',
+      realm: 'https://example.test/demo/',
+      method: 'POST',
+      path: 'Card',
+      status: 201,
+      ok: true,
+    },
+    {
+      scope: 'server',
+      method: 'POST',
+      path: '_publish-realm',
+      status: 202,
+      ok: true,
+    },
+  ]);
+  assert.deepEqual(
+    adapter.rawRequests.map(({ scope, method, path }) => ({
+      scope,
+      method,
+      path,
+    })),
+    [
+      { scope: 'realm', method: 'POST', path: 'Card' },
+      { scope: 'server', method: 'POST', path: '_publish-realm' },
+    ],
+  );
+});
+
+test('reports raw API effects when a later guest operation fails', async () => {
+  let adapter = new FakeAdapter();
+
+  await assert.rejects(
+    runRealmScript({
+      code: `
+        await realm.api.request('POST', 'created-before-error.json');
+        throw new Error('later failure');
+      `,
+      realm: 'https://example.test/demo/',
+      mode: 'commit',
+      adapter,
+    }),
+    (error) => {
+      assert.equal(error.code, 'RUNTIME_ERROR');
+      assert.deepEqual(error.details.effects, [
+        {
+          scope: 'realm',
+          realm: 'https://example.test/demo/',
+          method: 'POST',
+          path: 'created-before-error.json',
+          status: 201,
+          ok: true,
+        },
+      ]);
+      return true;
+    },
+  );
+});
+
+test('transports RegExp grep patterns without exposing host RegExp objects', async () => {
+  let adapter = new FakeAdapter({
+    'src/a.gts': "import Three from 'three';\n",
+    'src/b.gts': 'const unrelated = true;\n',
+  });
+  let result = await runRealmScript({
+    code: `return await realm.fs.grep(/from\\s+['"]three/i, { glob: '**/*.gts' });`,
+    realm: 'https://example.test/demo/',
+    adapter,
+  });
+
+  assert.deepEqual(
+    result.value.map(({ path, line, column }) => ({ path, line, column })),
+    [{ path: 'src/a.gts', line: 1, column: 14 }],
+  );
+});
+
+test('interrupts an infinite loop', async () => {
+  await assert.rejects(
+    runRealmScript({
+      code: 'while (true) {}',
+      realm: 'https://example.test/demo/',
+      adapter: new FakeAdapter(),
+      limits: { timeoutMs: 25 },
+    }),
+    (error) => error.code === 'TIME_LIMIT',
+  );
+});
+
+test('does not charge Realm I/O latency against the QuickJS CPU deadline', async () => {
+  let adapter = new FakeAdapter({ 'slow.txt': 'eventually\n' });
+  let originalReadText = adapter.readText.bind(adapter);
+  adapter.readText = async (...args) => {
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    return originalReadText(...args);
+  };
+
+  let result = await runRealmScript({
+    code: `return await realm.fs.readText('slow.txt');`,
+    realm: 'https://example.test/demo/',
+    adapter,
+    limits: { timeoutMs: 10 },
+  });
+
+  assert.equal(result.value, 'eventually\n');
+});
+
+test('bounds total wall-clock time including Realm I/O', async () => {
+  let adapter = new FakeAdapter({ 'slow.txt': 'too late\n' });
+  let originalReadText = adapter.readText.bind(adapter);
+  adapter.readText = async (...args) => {
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    return originalReadText(...args);
+  };
+
+  await assert.rejects(
+    runRealmScript({
+      code: `return await realm.fs.readText('slow.txt');`,
+      realm: 'https://example.test/demo/',
+      adapter,
+      limits: { timeoutMs: 100, wallTimeoutMs: 10 },
+    }),
+    (error) =>
+      error.code === 'TIME_LIMIT' && error.message.includes('wall-clock'),
+  );
+});
+
+test('reports an unknown raw-mutation outcome when the wall deadline wins', async () => {
+  let adapter = new FakeAdapter();
+  adapter.realmRequest = async (...args) => {
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    return FakeAdapter.prototype.realmRequest.call(adapter, ...args);
+  };
+
+  await assert.rejects(
+    runRealmScript({
+      code: `await realm.api.request('POST', 'possibly-created.json');`,
+      realm: 'https://example.test/demo/',
+      mode: 'commit',
+      adapter,
+      limits: { timeoutMs: 100, wallTimeoutMs: 10 },
+    }),
+    (error) => {
+      assert.equal(error.code, 'TIME_LIMIT');
+      assert.deepEqual(error.details.effects, [
+        {
+          scope: 'realm',
+          realm: 'https://example.test/demo/',
+          method: 'POST',
+          path: 'possibly-created.json',
+          status: null,
+          ok: null,
+        },
+      ]);
+      return true;
+    },
+  );
+});

--- a/packages/realm-runner/types/core.d.ts
+++ b/packages/realm-runner/types/core.d.ts
@@ -1,0 +1,24 @@
+export {
+  DEFAULT_LIMITS,
+  DEFAULT_RUNTIME_LIMITS,
+  EncryptedNotebookStorage,
+  MemoryNotebookStorage,
+  RealmCapabilityHost,
+  RealmFileNotebookStorage,
+  RealmNotebookCoordinator,
+  RealmRunnerError,
+  errorDetails,
+  runRealmScript,
+} from './index.js';
+
+export type {
+  BxlEvaluator,
+  NotebookStorageAdapter,
+  RealmNotebookInputReference,
+  RealmNotebookMetadata,
+  RealmNotebookRequest,
+  RealmProgramActivity,
+  RealmProgramChange,
+  RealmProgramEffect,
+  RealmProgramResult,
+} from './index.js';

--- a/packages/realm-runner/types/index.d.ts
+++ b/packages/realm-runner/types/index.d.ts
@@ -1,0 +1,240 @@
+import type {
+  RealmNotebookInputReference,
+  RealmNotebookRequest,
+  RealmProgramActivity,
+  RealmProgramExecutor,
+  RealmProgramMode,
+} from '@cardstack/runtime-common';
+
+export type {
+  RealmNotebookInputReference,
+  RealmNotebookRequest,
+  RealmProgramActivity,
+} from '@cardstack/runtime-common';
+
+export interface BxlEvaluator {
+  evaluate(
+    expression: string,
+    input: unknown,
+    options?: object,
+  ): unknown | Promise<unknown>;
+}
+
+export interface RealmProgramChange {
+  operation: 'create' | 'update' | 'remove';
+  path: string;
+  beforeHash: string | null;
+  afterHash: string | null;
+  diff: string;
+}
+
+export interface RealmProgramEffect {
+  scope: 'realm' | 'server';
+  realm?: string;
+  method: 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  path: string;
+  status: number | null;
+  ok: boolean | null;
+}
+
+export interface RealmProgramResult {
+  ok: true;
+  mode: RealmProgramMode;
+  value: unknown;
+  changes: RealmProgramChange[];
+  effects: RealmProgramEffect[];
+  logs: Array<{ level: string; args: unknown[] }>;
+  stats: {
+    capabilityCalls: number;
+    filesRead: number;
+    filesChanged: number;
+    bytesRead: number;
+    bytesWritten: number;
+    apiRequests: number;
+    apiBytesSent: number;
+    apiBytesReceived: number;
+    durationMs: number;
+  };
+}
+
+export interface RealmNotebookMetadata {
+  sessionId: string;
+  cellId: string;
+  revision: number;
+  executionId: string;
+  persistence: 'ephemeral' | 'realm';
+  expiresAt: number | null;
+  reused: boolean;
+  outputRef: { executionId: string; pointer: string };
+  snapshot: {
+    createdAt: number;
+    updatedAt: number;
+    cells: Array<{
+      cellId: string;
+      position: number;
+      source: string;
+      sourceTruncated: boolean;
+      mode: RealmProgramMode;
+      inputs: Record<string, RealmNotebookInputReference>;
+      literalInputKeys: string[];
+      revision: number | null;
+      lastRevision: number | null;
+      executionId: string | null;
+      outputRef: { executionId: string; pointer: string } | null;
+      status: 'saved' | 'pending' | 'succeeded' | 'failed' | 'indeterminate';
+      stale: boolean;
+    }>;
+  };
+}
+
+export class RealmRunnerError extends Error {
+  code: string;
+  details?: unknown;
+}
+
+export function errorDetails(error: unknown): {
+  code: string;
+  message: string;
+  details?: unknown;
+};
+
+export class BxlAdapter implements BxlEvaluator {
+  constructor(evaluate: BxlEvaluator['evaluate']);
+  static create(): Promise<BxlAdapter>;
+  evaluate(
+    expression: string,
+    input: unknown,
+    options?: object,
+  ): unknown | Promise<unknown>;
+}
+
+export class RealmCapabilityHost {
+  constructor(options: {
+    adapter: object;
+    bxl?: BxlEvaluator;
+    realmUrl: string;
+    mode?: RealmProgramMode;
+    limits?: Record<string, number>;
+  });
+  dispatch(operation: string, args: unknown[]): Promise<unknown>;
+  finish(): Promise<{
+    changes: RealmProgramChange[];
+    effects: RealmProgramEffect[];
+    logs: RealmProgramResult['logs'];
+    stats: Omit<RealmProgramResult['stats'], 'durationMs'>;
+  }>;
+}
+
+export class BoxelHttpAdapter {
+  constructor(options: {
+    fetch: typeof globalThis.fetch;
+    authorization: string;
+    realmServerUrl: string;
+    requestTimeoutMs?: number;
+    responseLimitBytes?: number;
+  });
+}
+
+export const DEFAULT_LIMITS: Readonly<Record<string, number>>;
+export const DEFAULT_RUNTIME_LIMITS: Readonly<Record<string, number>>;
+
+export interface RealmProgramExecutorOptions {
+  fetch?: typeof globalThis.fetch;
+  bxl?: BxlEvaluator;
+  realmServerUrl?: string;
+  onBxlUnavailable?: (error: unknown) => void;
+  notebookEncryptionKey?: string;
+  notebookStorage?: MemoryNotebookStorage;
+  now?: () => number;
+}
+
+export class QuickJSRealmProgramExecutor implements RealmProgramExecutor {
+  constructor(options?: RealmProgramExecutorOptions);
+  execute(input: {
+    code?: string;
+    mode: RealmProgramMode;
+    realmURL: string;
+    authorization: string | null;
+    input?: unknown;
+    notebook?: RealmNotebookRequest;
+    onActivity?: (activity: RealmProgramActivity) => void | Promise<void>;
+  }): Promise<RealmProgramResult & { notebook?: RealmNotebookMetadata }>;
+}
+
+export function createRealmProgramExecutor(
+  options?: RealmProgramExecutorOptions,
+): Promise<QuickJSRealmProgramExecutor>;
+
+export function runRealmScript(options: {
+  code: string;
+  realm: string;
+  mode?: RealmProgramMode;
+  input?: unknown;
+  notebook?: object | null;
+  adapter: object;
+  bxl?: BxlEvaluator;
+  limits?: object;
+  onActivity?: (activity: RealmProgramActivity) => void | Promise<void>;
+}): Promise<RealmProgramResult>;
+
+export interface NotebookStorageAdapter {
+  get(key: string): Promise<unknown | undefined>;
+  set(
+    key: string,
+    value: unknown,
+    options?: { expiresAt?: number | null },
+  ): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export class MemoryNotebookStorage implements NotebookStorageAdapter {
+  constructor(options?: { now?: () => number; maxEntries?: number });
+  get(key: string): Promise<unknown | undefined>;
+  set(
+    key: string,
+    value: unknown,
+    options?: { expiresAt?: number | null },
+  ): Promise<void>;
+  delete(key: string): Promise<void>;
+  touchPrefix(prefix: string, expiresAt: number | null): Promise<void>;
+  prune(): void;
+}
+
+export class RealmFileNotebookStorage implements NotebookStorageAdapter {
+  constructor(options: {
+    adapter: object;
+    realmUrl: string;
+    prefix?: string;
+    maxRecordBytes?: number;
+    now?: () => number;
+  });
+  get(key: string): Promise<unknown | undefined>;
+  set(
+    key: string,
+    value: unknown,
+    options?: { expiresAt?: number | null },
+  ): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export class EncryptedNotebookStorage implements NotebookStorageAdapter {
+  constructor(options: {
+    storage: NotebookStorageAdapter;
+    keyMaterial: string;
+  });
+  get(key: string): Promise<unknown | undefined>;
+  set(
+    key: string,
+    value: unknown,
+    options?: { expiresAt?: number | null },
+  ): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export class RealmNotebookCoordinator {
+  constructor(options?: {
+    ephemeralStorage?: MemoryNotebookStorage;
+    encryptionKey?: string;
+    now?: () => number;
+  });
+}

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -18,6 +18,7 @@ import { RealmServer } from './server.ts';
 import { join } from 'path';
 import * as Sentry from '@sentry/node';
 import { PgAdapter, PgQueuePublisher } from '@cardstack/postgres';
+import { createRealmProgramExecutor } from '@cardstack/realm-runner';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 
 import 'decorator-transforms/globals';
@@ -516,6 +517,16 @@ const reportHostShellToManager = async () => {
     moduleCacheCoordinator,
   );
 
+  let realmProgramExecutor = await createRealmProgramExecutor({
+    realmServerUrl: serverURL,
+    notebookEncryptionKey: REALM_SECRET_SEED,
+    onBxlUnavailable(error) {
+      log.warn(
+        `Realm Program started without BXL; set BXL_API or install @cardstack/bxl to enable realm.bxl: ${error}`,
+      );
+    },
+  });
+
   if (SKIP_MODULES_CACHE_CLEAR_ON_STARTUP) {
     log.info('Skipping modules cache clear on startup (opted out via env)');
   } else {
@@ -619,6 +630,7 @@ const reportHostShellToManager = async () => {
           fileSizeLimitBytes: Number(
             process.env.FILE_SIZE_LIMIT_BYTES ?? DEFAULT_FILE_SIZE_LIMIT_BYTES,
           ),
+          realmProgramExecutor,
         },
         {
           ...(fullIndexOnStartup ? { fullIndexOnStartup: true as const } : {}),

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -147,6 +147,7 @@
     "stripe": "docker run --rm --add-host=host.docker.internal:host-gateway -it stripe/stripe-cli:latest"
   },
   "dependencies": {
+    "@cardstack/realm-runner": "workspace:*",
     "@aws-sdk/client-s3": "^3.1065.0",
     "@aws-sdk/lib-storage": "^3.1065.0",
     "morphdom": "^2.7.8",

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -22,6 +22,7 @@ import type {
   CardResource,
   FileMetaResource,
   QueryResultsMeta,
+  RealmProgramExecutor,
 } from '@cardstack/runtime-common';
 import {
   Realm,
@@ -1181,6 +1182,7 @@ export async function createRealm({
   fileSizeLimitBytes,
   transpileCoordinator,
   fullIndexOnStartup,
+  realmProgramExecutor,
 }: {
   dir: string;
   definitionLookup: DefinitionLookup;
@@ -1209,6 +1211,7 @@ export async function createRealm({
   // Production sets this via `resolveFullIndexOnStartup`; tests opt in
   // explicitly because `createRealm` has no realm-registry row to read.
   fullIndexOnStartup?: true;
+  realmProgramExecutor?: RealmProgramExecutor;
   // if you are creating a realm  to test it directly without a server, you can
   // also specify `withWorker: true` to also include a worker with your realm
   withWorker?: true;
@@ -1278,6 +1281,7 @@ export async function createRealm({
           process.env.FILE_SIZE_LIMIT_BYTES ?? DEFAULT_FILE_SIZE_LIMIT_BYTES,
         ),
       transpileCoordinator,
+      realmProgramExecutor,
     },
     fullIndexOnStartup ? { fullIndexOnStartup: true as const } : undefined,
   );
@@ -1320,6 +1324,7 @@ export async function runTestRealmServer({
   enableFileWatcher = false,
   cardSizeLimitBytes,
   fileSizeLimitBytes,
+  realmProgramExecutor,
   domainsForPublishedRealms = {
     boxelSpace: 'localhost',
     boxelSite: 'localhost',
@@ -1340,6 +1345,7 @@ export async function runTestRealmServer({
   enableFileWatcher?: boolean;
   cardSizeLimitBytes?: number;
   fileSizeLimitBytes?: number;
+  realmProgramExecutor?: RealmProgramExecutor;
   domainsForPublishedRealms?: {
     boxelSpace?: string;
     boxelSite?: string;
@@ -1380,6 +1386,7 @@ export async function runTestRealmServer({
     definitionLookup,
     cardSizeLimitBytes,
     fileSizeLimitBytes,
+    realmProgramExecutor,
   });
 
   await testRealm.logInToMatrix();
@@ -2034,6 +2041,7 @@ type InternalPermissionedRealmSetupOptions = {
   published?: boolean;
   cardSizeLimitBytes?: number;
   fileSizeLimitBytes?: number;
+  realmProgramExecutor?: RealmProgramExecutor;
 };
 
 async function startPermissionedRealmFixture(
@@ -2050,6 +2058,7 @@ async function startPermissionedRealmFixture(
     published = false,
     cardSizeLimitBytes,
     fileSizeLimitBytes,
+    realmProgramExecutor,
   }: InternalPermissionedRealmSetupOptions,
 ): Promise<{
   testRealmServer: Awaited<ReturnType<typeof runTestRealmServer>>;
@@ -2116,6 +2125,7 @@ async function startPermissionedRealmFixture(
     enableFileWatcher: subscribeToRealmEvents,
     cardSizeLimitBytes,
     fileSizeLimitBytes,
+    realmProgramExecutor,
     prerenderer,
   });
 
@@ -2183,6 +2193,7 @@ export function setupPermissionedRealm(
     published = false,
     cardSizeLimitBytes,
     fileSizeLimitBytes,
+    realmProgramExecutor,
   }: {
     permissions: RealmPermissions;
     realmURL?: URL;
@@ -2209,6 +2220,7 @@ export function setupPermissionedRealm(
     published?: boolean;
     cardSizeLimitBytes?: number;
     fileSizeLimitBytes?: number;
+    realmProgramExecutor?: RealmProgramExecutor;
   },
 ) {
   let testRealmServer: Awaited<ReturnType<typeof runTestRealmServer>>;
@@ -2236,6 +2248,7 @@ export function setupPermissionedRealm(
         published,
         cardSizeLimitBytes,
         fileSizeLimitBytes,
+        realmProgramExecutor,
       });
       testRealmServer = server;
 

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -316,6 +316,7 @@ const ALL_TEST_FILES: string[] = [
   './realm-endpoints/cancel-indexing-job-test',
   './realm-endpoints/publishability-test',
   './realm-endpoints/reindex-test',
+  './realm-endpoints/realm-program-test',
   './realm-endpoints/search-test',
   './realm-endpoints/user-test',
   './server-endpoints/archive-realm-test',

--- a/packages/realm-server/tests/realm-endpoints/realm-program-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/realm-program-test.ts
@@ -1,0 +1,512 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import type {
+  Realm,
+  RealmNotebookRequest,
+  RealmProgramExecutor,
+} from '@cardstack/runtime-common';
+import { SupportedMimeType } from '@cardstack/runtime-common';
+import { createRealmProgramExecutor } from '@cardstack/realm-runner';
+import type { SuperTest, Test } from 'supertest';
+
+import { createJWT, setupPermissionedRealmCached } from '../helpers/index.ts';
+
+module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
+  module('Realm-specific Endpoints | _realm-program', function (hooks) {
+    let testRealm: Realm;
+    let request: SuperTest<Test>;
+    let calls: Parameters<RealmProgramExecutor['execute']>[0][] = [];
+    let executor: RealmProgramExecutor = {
+      async execute(input) {
+        calls.push(input);
+        return { value: 42 };
+      },
+    };
+
+    setupPermissionedRealmCached(hooks, {
+      fixture: 'blank',
+      permissions: {
+        reader: ['read'],
+        writer: ['read', 'write'],
+      },
+      realmProgramExecutor: executor,
+      onRealmSetup(args) {
+        testRealm = args.testRealm;
+        request = args.request;
+        calls = [];
+      },
+    });
+
+    test('executes preview programs through the read permission boundary', async function (assert) {
+      let authorization = `Bearer ${createJWT(testRealm, 'reader', ['read'])}`;
+      let response = await request
+        .post('/_realm-program')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set('Authorization', authorization)
+        .send({ code: 'return 6 * 7;', mode: 'preview' });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.deepEqual(response.body, { value: 42 }, 'returns executor output');
+      assert.deepEqual(
+        calls,
+        [
+          {
+            code: 'return 6 * 7;',
+            mode: 'preview',
+            realmURL: testRealm.url,
+            authorization,
+          },
+        ],
+        'forwards the scoped execution context',
+      );
+    });
+
+    test('executes commit programs through the write permission boundary', async function (assert) {
+      let authorization = `Bearer ${createJWT(testRealm, 'writer', [
+        'read',
+        'write',
+      ])}`;
+      let response = await request
+        .post('/_realm-program')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set('Authorization', authorization)
+        .send({
+          code: 'realm.fs.writeText("hello.txt", "hi");',
+          mode: 'commit',
+        });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.strictEqual(calls.length, 1, 'executor is called once');
+      assert.strictEqual(calls[0].mode, 'commit', 'commit mode is forwarded');
+    });
+
+    test('forwards ad-hoc input and notebook cell settings', async function (assert) {
+      let authorization = `Bearer ${createJWT(testRealm, 'reader', ['read'])}`;
+      let notebook = {
+        sessionId: '!room:example.test',
+        cellId: 'grep',
+        persistence: 'ephemeral',
+        inputs: { candidates: { cellId: 'search' } },
+      } satisfies RealmNotebookRequest;
+      let response = await request
+        .post('/_realm-program')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set('Authorization', authorization)
+        .send({
+          code: 'return realm.input;',
+          mode: 'preview',
+          input: { direct: true },
+          notebook,
+        });
+
+      assert.strictEqual(response.status, 200);
+      assert.deepEqual(calls[0].input, { direct: true });
+      assert.deepEqual(calls[0].notebook, notebook);
+    });
+
+    test('does not let a read-only user execute commit programs', async function (assert) {
+      let response = await request
+        .post('/_realm-program')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'reader', ['read'])}`,
+        )
+        .send({ code: 'return 1;', mode: 'commit' });
+
+      assert.strictEqual(response.status, 403, 'HTTP 403 status');
+      assert.strictEqual(calls.length, 0, 'executor is not called');
+    });
+
+    test('rejects a mode that does not match the HTTP permission boundary', async function (assert) {
+      let response = await request
+        .post('/_realm-program')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'writer', ['read', 'write'])}`,
+        )
+        .send({ code: 'return 1;', mode: 'commit' });
+
+      assert.strictEqual(response.status, 400, 'HTTP 400 status');
+      assert.strictEqual(
+        response.body.error.code,
+        'INVALID_ARGUMENT',
+        'returns a structured error',
+      );
+      assert.strictEqual(calls.length, 0, 'executor is not called');
+    });
+  });
+
+  module('when Realm Program execution is not configured', function (hooks) {
+    let testRealm: Realm;
+    let request: SuperTest<Test>;
+
+    setupPermissionedRealmCached(hooks, {
+      fixture: 'blank',
+      permissions: { reader: ['read'] },
+      onRealmSetup(args) {
+        testRealm = args.testRealm;
+        request = args.request;
+      },
+    });
+
+    test('reports that the capability is unavailable', async function (assert) {
+      let response = await request
+        .post('/_realm-program')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'reader', ['read'])}`,
+        )
+        .send({ code: 'return 1;', mode: 'preview' });
+
+      assert.strictEqual(response.status, 501, 'HTTP 501 status');
+      assert.strictEqual(
+        response.body.error.code,
+        'REALM_PROGRAM_UNAVAILABLE',
+        'returns a structured error',
+      );
+    });
+  });
+
+  module('with the QuickJS Realm Program executor', function (hooks) {
+    let testRealm: Realm;
+    let request: SuperTest<Test>;
+    let executorPromise:
+      | ReturnType<typeof createRealmProgramExecutor>
+      | undefined;
+    let executor: RealmProgramExecutor = {
+      async execute(input) {
+        executorPromise ??= createRealmProgramExecutor({
+          notebookEncryptionKey:
+            'realm-program-test-notebook-encryption-key-material',
+        });
+        return (await executorPromise).execute(input);
+      },
+    };
+
+    setupPermissionedRealmCached(hooks, {
+      fixture: 'blank',
+      permissions: {
+        reader: ['read'],
+        writer: ['read', 'write'],
+      },
+      realmProgramExecutor: executor,
+      onRealmSetup(args) {
+        testRealm = args.testRealm;
+        request = args.request;
+      },
+    });
+
+    test('runs a capability-scoped program through the authenticated Realm API', async function (assert) {
+      let response = await request
+        .post('/_realm-program')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'reader', ['read'])}`,
+        )
+        .send({
+          code: `
+            const paths = await realm.fs.list();
+            const bxl = await realm.bxl.jq('.items | length', {
+              items: [1, 2, 3, 4, 5],
+            });
+            return { paths, processType: typeof process, bxl };
+          `,
+          mode: 'preview',
+        });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.deepEqual(response.body.value, {
+        paths: ['.gitkeep'],
+        processType: 'undefined',
+        bxl: 5,
+      });
+      assert.strictEqual(response.body.mode, 'preview');
+      assert.deepEqual(response.body.changes, []);
+    });
+
+    test('streams sanitized activity before the final result', async function (assert) {
+      let response = await request
+        .post('/_realm-program')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('X-Boxel-Realm-Program-Stream', 'activity-v1')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'reader', ['read'])}`,
+        )
+        .send({
+          code: `
+            await realm.activity('Inspecting candidates');
+            return {
+              apiVersion: realm.apiVersion,
+              features: realm.features,
+              notebook: realm.notebook,
+            };
+          `,
+          mode: 'preview',
+        });
+
+      assert.strictEqual(response.status, 200);
+      assert.true(
+        response.headers['content-type'].startsWith('application/x-ndjson'),
+      );
+      let events = response.text
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      assert.true(
+        events.some(
+          (event) =>
+            event.type === 'activity' &&
+            event.activity.message === 'Inspecting candidates',
+        ),
+        'semantic activity is streamed',
+      );
+      let result = events.find((event) => event.type === 'result').result;
+      assert.deepEqual(result.value, {
+        apiVersion: '2',
+        features: {
+          notebooks: true,
+          activity: true,
+          streamingActivity: true,
+        },
+        notebook: null,
+      });
+      assert.strictEqual(events.at(-1).type, 'result');
+    });
+
+    test('persists encrypted notebook cells and reuses them after executor restart', async function (assert) {
+      let authorization = `Bearer ${createJWT(testRealm, 'writer', [
+        'read',
+        'write',
+      ])}`;
+      let payload = {
+        code: `return { candidates: ['private-search-result.gts'] };`,
+        mode: 'preview',
+        notebook: {
+          sessionId: '!persistent-room:example.test',
+          cellId: 'federated-search',
+          persistence: 'realm',
+        },
+      };
+
+      let first = await request
+        .post('/_realm-program')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set('Authorization', authorization)
+        .send(payload);
+
+      assert.strictEqual(first.status, 200, 'first cell succeeds');
+      assert.false(first.body.notebook.reused, 'first cell executed');
+      executorPromise = undefined;
+
+      let second = await request
+        .post('/_realm-program')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set('Authorization', authorization)
+        .send(payload);
+
+      assert.strictEqual(second.status, 200, 'restored cell succeeds');
+      assert.true(second.body.notebook.reused, 'stored result was reused');
+      assert.strictEqual(
+        second.body.notebook.executionId,
+        first.body.notebook.executionId,
+        'the immutable execution is preserved',
+      );
+      assert.deepEqual(second.body.value, first.body.value);
+
+      let rerun = await request
+        .post('/_realm-program')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set('Authorization', authorization)
+        .send({
+          mode: 'preview',
+          notebook: {
+            sessionId: '!persistent-room:example.test',
+            cellId: 'federated-search',
+            persistence: 'realm',
+            runSaved: true,
+            force: true,
+          },
+        });
+      assert.strictEqual(rerun.status, 200, 'saved source reruns');
+      assert.false(rerun.body.notebook.reused, 'rerun creates an execution');
+      assert.strictEqual(rerun.body.notebook.revision, 2);
+      assert.deepEqual(rerun.body.value, first.body.value);
+
+      let inspection = await request
+        .post('/_realm-program')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set('Authorization', authorization)
+        .send({
+          code: `
+            const files = await realm.fs.glob('.boxel/realm-notebooks/**/*', { dot: true });
+            const contents = [];
+            for (const path of files) contents.push(await realm.fs.readText(path));
+            return { files, contents };
+          `,
+          mode: 'preview',
+        });
+      assert.strictEqual(inspection.status, 200);
+      assert.true(
+        inspection.body.value.files.length >= 2,
+        'manifest and execution records are durable Realm files',
+      );
+      assert.false(
+        inspection.body.value.contents.some((source: string) =>
+          source.includes('private-search-result.gts'),
+        ),
+        'federated output is encrypted at rest',
+      );
+    });
+
+    test('uses the raw authenticated API for endpoints and source writes', async function (assert) {
+      let authorization = `Bearer ${createJWT(testRealm, 'writer', [
+        'read',
+        'write',
+      ])}`;
+      let response = await request
+        .post('/_realm-program')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set('Authorization', authorization)
+        .send({
+          code: `
+            const info = await realm.api.request('GET', '_info', {
+              accept: '${SupportedMimeType.RealmInfo}',
+            });
+            const written = await realm.api.request('POST', 'agent-note.txt', {
+              body: 'created by Realm Script\\n',
+              bodyType: 'text',
+              contentType: '${SupportedMimeType.CardSource}',
+              accept: '${SupportedMimeType.CardSource}',
+            });
+            const binaryWritten = await realm.api.request('POST', 'agent.bin', {
+              body: 'AAEC/w==',
+              bodyType: 'base64',
+              contentType: '${SupportedMimeType.OctetStream}',
+              accept: '${SupportedMimeType.OctetStream}',
+            });
+            return {
+              infoStatus: info.status,
+              writeStatus: written.status,
+              binaryWriteStatus: binaryWritten.status,
+            };
+          `,
+          mode: 'commit',
+        });
+
+      assert.strictEqual(response.status, 200, 'Realm Program succeeds');
+      assert.strictEqual(response.body.value.infoStatus, 200, 'GET succeeds');
+      assert.true(
+        [200, 201, 204].includes(response.body.value.writeStatus),
+        'source write succeeds',
+      );
+      assert.true(
+        [200, 201, 204].includes(response.body.value.binaryWriteStatus),
+        'binary write succeeds',
+      );
+
+      let readback = await request
+        .get('/agent-note.txt')
+        .set('Accept', SupportedMimeType.CardSource)
+        .set('Authorization', authorization);
+      assert.strictEqual(readback.status, 200, 'written source is readable');
+      assert.strictEqual(readback.text, 'created by Realm Script\n');
+
+      let binaryReadback = await request
+        .get('/agent.bin')
+        .set('Accept', SupportedMimeType.OctetStream)
+        .set('Authorization', authorization)
+        .buffer(true);
+      assert.strictEqual(
+        binaryReadback.status,
+        200,
+        'written binary is readable',
+      );
+      assert.deepEqual(
+        [...(binaryReadback.body as Buffer)],
+        [0, 1, 2, 255],
+        'binary bytes round-trip exactly',
+      );
+    });
+
+    test('reports a raw side effect when the guest fails afterward', async function (assert) {
+      let authorization = `Bearer ${createJWT(testRealm, 'writer', [
+        'read',
+        'write',
+      ])}`;
+      let response = await request
+        .post('/_realm-program')
+        .set('Accept', SupportedMimeType.JSON)
+        .set('Content-Type', SupportedMimeType.JSON)
+        .set('Authorization', authorization)
+        .send({
+          code: `
+            await realm.api.request('POST', 'partial-effect.txt', {
+              body: 'persisted before failure\\n',
+              bodyType: 'text',
+              contentType: '${SupportedMimeType.CardSource}',
+              accept: '${SupportedMimeType.CardSource}',
+            });
+            throw new Error('failure after write');
+          `,
+          mode: 'commit',
+        });
+
+      assert.strictEqual(response.status, 500, 'program failure is reported');
+      assert.strictEqual(response.body.error.code, 'RUNTIME_ERROR');
+      let [effect] = response.body.error.details.effects;
+      assert.deepEqual(
+        {
+          scope: effect.scope,
+          realm: effect.realm,
+          method: effect.method,
+          path: effect.path,
+          ok: effect.ok,
+        },
+        {
+          scope: 'realm',
+          realm: testRealm.url,
+          method: 'POST',
+          path: 'partial-effect.txt',
+          ok: true,
+        },
+      );
+      assert.true([200, 201, 204].includes(effect.status));
+
+      let readback = await request
+        .get('/partial-effect.txt')
+        .set('Accept', SupportedMimeType.CardSource)
+        .set('Authorization', authorization);
+      assert.strictEqual(readback.status, 200, 'side effect persisted');
+      assert.strictEqual(readback.text, 'persisted before failure\n');
+    });
+  });
+});

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -768,6 +768,48 @@ export interface MatrixConfig {
 
 export type RequestContext = { realm: Realm; permissions: RealmPermissions };
 
+export type RealmProgramMode = 'preview' | 'commit';
+
+export interface RealmNotebookInputReference {
+  cellId?: string;
+  executionId?: string;
+  pointer?: string;
+}
+
+export interface RealmNotebookRequest {
+  sessionId: string;
+  cellId: string;
+  persistence?: 'ephemeral' | 'realm';
+  ttlMs?: number;
+  inputs?: Record<string, RealmNotebookInputReference>;
+  force?: boolean;
+  runSaved?: boolean;
+}
+
+export interface RealmProgramActivity {
+  sequence: number;
+  timestamp: number;
+  source: 'runtime' | 'script';
+  status: 'running' | 'completed' | 'failed';
+  phase: string;
+  message: string;
+  operation?: string;
+  current?: number;
+  total?: number;
+}
+
+export interface RealmProgramExecutor {
+  execute(input: {
+    code?: string;
+    mode: RealmProgramMode;
+    realmURL: string;
+    authorization: string | null;
+    input?: unknown;
+    notebook?: RealmNotebookRequest;
+    onActivity?: (activity: RealmProgramActivity) => void | Promise<void>;
+  }): Promise<unknown>;
+}
+
 export class Realm {
   #startedUp = new Deferred<void>();
   #matrixClient: MatrixClient;
@@ -856,6 +898,7 @@ export class Realm {
   #transpileCoordinator?: PopulateCoordinator;
   #cardSizeLimitBytes: number;
   #fileSizeLimitBytes: number;
+  #realmProgramExecutor: RealmProgramExecutor | undefined;
 
   #publicEndpoints: RouteTable<true> = new Map([
     [
@@ -923,6 +966,7 @@ export class Realm {
       cardSizeLimitBytes,
       fileSizeLimitBytes,
       transpileCoordinator,
+      realmProgramExecutor,
     }: {
       url: string;
       adapter: RealmAdapter;
@@ -942,6 +986,9 @@ export class Realm {
       // in-memory deployments leave this undefined and the uncoordinated
       // CS-11029 in-process dedup is the only sharing layer.
       transpileCoordinator?: PopulateCoordinator;
+      // Optional portable QuickJS+BXL program engine. Injection keeps the
+      // Realm HTTP/auth boundary independent from the execution runtime.
+      realmProgramExecutor?: RealmProgramExecutor;
     },
     opts?: Options,
   ) {
@@ -966,6 +1013,7 @@ export class Realm {
       cardSizeLimitBytes ?? DEFAULT_CARD_SIZE_LIMIT_BYTES;
     this.#fileSizeLimitBytes =
       fileSizeLimitBytes ?? DEFAULT_FILE_SIZE_LIMIT_BYTES;
+    this.#realmProgramExecutor = realmProgramExecutor;
     this.#disableModuleCaching = Boolean(opts?.disableModuleCaching);
     this.#copiedFromRealm = opts?.copiedFromRealm;
     let owner: string | undefined;
@@ -1079,6 +1127,16 @@ export class Realm {
         '/_readiness-check',
         SupportedMimeType.RealmInfo,
         this.readinessCheck.bind(this),
+      )
+      .query(
+        '/_realm-program',
+        SupportedMimeType.JSON,
+        this.realmProgram.bind(this),
+      )
+      .post(
+        '/_realm-program',
+        SupportedMimeType.JSON,
+        this.realmProgram.bind(this),
       )
       .post(
         '/_atomic',
@@ -5914,6 +5972,199 @@ export class Realm {
       },
       requestContext,
     });
+  }
+
+  private async realmProgram(
+    request: Request,
+    requestContext: RequestContext,
+  ): Promise<Response> {
+    let expectedMode: RealmProgramMode =
+      request.method === 'QUERY' ? 'preview' : 'commit';
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return createResponse({
+        body: JSON.stringify({
+          ok: false,
+          error: {
+            code: 'INVALID_ARGUMENT',
+            message: 'Realm Program request body must be valid JSON',
+          },
+        }),
+        init: {
+          status: 400,
+          headers: { 'content-type': SupportedMimeType.JSON },
+        },
+        requestContext,
+      });
+    }
+
+    let code =
+      body && typeof body === 'object' && 'code' in body
+        ? (body as { code?: unknown }).code
+        : undefined;
+    let mode =
+      body && typeof body === 'object' && 'mode' in body
+        ? (body as { mode?: unknown }).mode
+        : undefined;
+    let input =
+      body && typeof body === 'object' && 'input' in body
+        ? (body as { input?: unknown }).input
+        : undefined;
+    let notebook =
+      body && typeof body === 'object' && 'notebook' in body
+        ? (body as { notebook?: unknown }).notebook
+        : undefined;
+    let runSaved =
+      notebook &&
+      typeof notebook === 'object' &&
+      'runSaved' in notebook &&
+      (notebook as { runSaved?: unknown }).runSaved === true;
+    let invalidCode =
+      code !== undefined &&
+      (typeof code !== 'string' ||
+        code.trim().length === 0 ||
+        new TextEncoder().encode(code).byteLength > 256 * 1024);
+    if (
+      (!runSaved && code === undefined) ||
+      invalidCode ||
+      mode !== expectedMode
+    ) {
+      return createResponse({
+        body: JSON.stringify({
+          ok: false,
+          error: {
+            code: 'INVALID_ARGUMENT',
+            message:
+              `Realm Program requires non-empty code no larger than 256 KiB ` +
+              `(unless notebook.runSaved is true) ` +
+              `and mode "${expectedMode}" for HTTP ${request.method}`,
+          },
+        }),
+        init: {
+          status: 400,
+          headers: { 'content-type': SupportedMimeType.JSON },
+        },
+        requestContext,
+      });
+    }
+
+    if (!this.#realmProgramExecutor) {
+      return createResponse({
+        body: JSON.stringify({
+          ok: false,
+          error: {
+            code: 'REALM_PROGRAM_UNAVAILABLE',
+            message: 'Realm Program execution is not configured on this server',
+          },
+        }),
+        init: {
+          status: 501,
+          headers: { 'content-type': SupportedMimeType.JSON },
+        },
+        requestContext,
+      });
+    }
+
+    let executorInput: Parameters<RealmProgramExecutor['execute']>[0] = {
+      ...(code === undefined ? {} : { code: code as string }),
+      mode: expectedMode,
+      realmURL: this.url,
+      authorization: request.headers.get('Authorization'),
+      ...(input === undefined ? {} : { input }),
+      ...(notebook === undefined
+        ? {}
+        : { notebook: notebook as RealmNotebookRequest }),
+    };
+    let structuredRealmProgramError = (error: unknown) => {
+      let structuredError =
+        error && typeof error === 'object'
+          ? (error as { code?: unknown; message?: unknown; details?: unknown })
+          : undefined;
+      return {
+        code:
+          typeof structuredError?.code === 'string'
+            ? structuredError.code
+            : 'REALM_PROGRAM_ERROR',
+        message:
+          typeof structuredError?.message === 'string'
+            ? structuredError.message
+            : 'Realm Program failed',
+        ...(structuredError?.details === undefined
+          ? {}
+          : { details: structuredError.details }),
+      };
+    };
+
+    if (request.headers.get('X-Boxel-Realm-Program-Stream') === 'activity-v1') {
+      let encoder = new TextEncoder();
+      let cancelled = false;
+      let stream = new ReadableStream<Uint8Array>({
+        start: (controller) => {
+          let write = (event: unknown) => {
+            if (cancelled) return;
+            try {
+              controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
+            } catch {
+              cancelled = true;
+            }
+          };
+          void this.#realmProgramExecutor!.execute({
+            ...executorInput,
+            onActivity(activity) {
+              write({ type: 'activity', activity });
+            },
+          })
+            .then((result) => write({ type: 'result', result }))
+            .catch((error) => {
+              this.#log.error(`Realm Program execution failed`, error);
+              write({
+                type: 'error',
+                error: structuredRealmProgramError(error),
+              });
+            })
+            .finally(() => {
+              if (!cancelled) controller.close();
+            });
+        },
+        cancel: () => {
+          cancelled = true;
+        },
+      });
+      return createResponse({
+        body: stream,
+        init: {
+          headers: {
+            'content-type': 'application/x-ndjson',
+            'cache-control': 'no-store',
+          },
+        },
+        requestContext,
+      });
+    }
+
+    try {
+      let result = await this.#realmProgramExecutor.execute(executorInput);
+      return createResponse({
+        body: JSON.stringify(result),
+        init: { headers: { 'content-type': SupportedMimeType.JSON } },
+        requestContext,
+      });
+    } catch (error) {
+      this.#log.error(`Realm Program execution failed`, error);
+      return createResponse({
+        body: JSON.stringify({
+          ok: false,
+          error: structuredRealmProgramError(error),
+        }),
+        init: {
+          status: 500,
+          headers: { 'content-type': SupportedMimeType.JSON },
+        },
+        requestContext,
+      });
+    }
   }
 
   private async fetchCardTypeSummary(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2568,6 +2568,24 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/realm-runner:
+    dependencies:
+      '@cardstack/bxl':
+        specifier: github:cardstack/bxl#eb9addc714e0111aa7bee5cf373a87cae11506e7
+        version: git+https://github.com/cardstack/bxl.git#eb9addc714e0111aa7bee5cf373a87cae11506e7
+      '@cardstack/runtime-common':
+        specifier: workspace:*
+        version: link:../runtime-common
+      diff:
+        specifier: 'catalog:'
+        version: 5.2.2
+      minimatch:
+        specifier: ^10.0.3
+        version: 10.2.5
+      quickjs-emscripten:
+        specifier: 0.32.0
+        version: 0.32.0
+
   packages/realm-server:
     dependencies:
       '@aws-sdk/client-s3':
@@ -2576,6 +2594,9 @@ importers:
       '@aws-sdk/lib-storage':
         specifier: ^3.1065.0
         version: 3.1069.0(@aws-sdk/client-s3@3.1069.0)
+      '@cardstack/realm-runner':
+        specifier: workspace:*
+        version: link:../realm-runner
       morphdom:
         specifier: ^2.7.8
         version: 2.7.8
@@ -4237,6 +4258,12 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@cardstack/bxl@git+https://github.com/cardstack/bxl.git#eb9addc714e0111aa7bee5cf373a87cae11506e7':
+    resolution: {commit: eb9addc714e0111aa7bee5cf373a87cae11506e7, repo: https://github.com/cardstack/bxl.git, type: git}
+    version: 0.3.0
+    engines: {node: '>=18.17'}
+    hasBin: true
+
   '@cardstack/logger@0.2.1':
     resolution: {integrity: sha512-xT8NWm9OYz15Qf7U/y9EQmCiGgZMTJaUbmyh/RxfMupmnBaM/KHMSI1iRuJa2mJ5crY5rcO3rzth+nVk34+jag==}
     engines: {node: '>= 8'}
@@ -5442,6 +5469,21 @@ packages:
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jitl/quickjs-ffi-types@0.32.0':
+    resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    resolution: {integrity: sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==}
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    resolution: {integrity: sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==}
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    resolution: {integrity: sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==}
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    resolution: {integrity: sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==}
 
   '@joplin/turndown-plugin-gfm@1.0.67':
     resolution: {integrity: sha512-FZfW5EZfidhzd1IaY1uxHnIZPTVOxAdleMZ4/1U6Nt5b7+Qj5JThDnaIomuJtetnUBzuRNbe9FWMuqD4B3dlWA==}
@@ -7961,6 +8003,10 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  bessel@1.0.2:
+    resolution: {integrity: sha512-Al3nHGQGqDYqqinXhQzmwmcRToe/3WyBv4N8aZc5Pef8xw2neZlR9VPi84Sa23JtgWcucu18HxVZrnI0fn2etw==}
+    engines: {node: '>=0.8'}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -11745,6 +11791,9 @@ packages:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
+  jstat@1.9.6:
+    resolution: {integrity: sha512-rPBkJbK2TnA8pzs93QcDDPlKcrtZWuuCo2dVR0TFLOJSxhqfWOVCSp8aV3/oSbn+4uY4yw1URtLpHQedtmXfug==}
+
   just-extend@6.2.0:
     resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
 
@@ -13425,6 +13474,13 @@ packages:
   quick-temp@0.1.9:
     resolution: {integrity: sha512-yI0h7tIhKVObn03kD+Ln9JFi4OljD28lfaOsTdfpTR0xzrhGOod+q66CjGafUqYX2juUfT9oHIGrTBBo22mkRA==}
 
+  quickjs-emscripten-core@0.32.0:
+    resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
+
+  quickjs-emscripten@0.32.0:
+    resolution: {integrity: sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==}
+    engines: {node: '>=16.0.0'}
+
   qunit-dom@3.5.1:
     resolution: {integrity: sha512-ZnvTADVXASdjLxrUDuS/8NaOzadhxN+fZgafjuQV1EOMFd3dJqLkP0RqsGdAxQBxZ7KzKg57AAJO20dM6/PxkA==}
 
@@ -15048,6 +15104,10 @@ packages:
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
+    engines: {node: '>= 0.10'}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -16873,6 +16933,12 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@cardstack/bxl@git+https://github.com/cardstack/bxl.git#eb9addc714e0111aa7bee5cf373a87cae11506e7':
+    dependencies:
+      bessel: 1.0.2
+      jstat: 1.9.6
+      validator: 13.15.35
+
   '@cardstack/logger@0.2.1':
     dependencies:
       '@types/ms': 0.7.34
@@ -18203,6 +18269,24 @@ snapshots:
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.10
+
+  '@jitl/quickjs-ffi-types@0.32.0': {}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
 
   '@joplin/turndown-plugin-gfm@1.0.67': {}
 
@@ -21174,6 +21258,8 @@ snapshots:
   before-after-hook@2.2.3: {}
 
   before-after-hook@4.0.0: {}
+
+  bessel@1.0.2: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -26650,6 +26736,8 @@ snapshots:
       ms: 2.1.3
       semver: 7.8.4
 
+  jstat@1.9.6: {}
+
   just-extend@6.2.0: {}
 
   jwa@2.0.1:
@@ -28364,6 +28452,18 @@ snapshots:
       mktemp: 2.0.3
       rimraf: 5.0.10
       underscore.string: 3.3.6
+
+  quickjs-emscripten-core@0.32.0:
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  quickjs-emscripten@0.32.0:
+    dependencies:
+      '@jitl/quickjs-wasmfile-debug-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-debug-sync': 0.32.0
+      '@jitl/quickjs-wasmfile-release-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-release-sync': 0.32.0
+      quickjs-emscripten-core: 0.32.0
 
   qunit-dom@3.5.1:
     dependencies:
@@ -30322,6 +30422,8 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   validate-npm-package-name@7.0.2: {}
+
+  validator@13.15.35: {}
 
   vary@1.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -283,6 +283,7 @@ patchedDependencies:
   ember-source: patches/ember-source.patch
   object-inspect: patches/object-inspect.patch
 allowBuilds:
+  "@cardstack/bxl": true
   "@percy/core": true
   "@vscode/vsce-sign": true
   aws-sdk: true


### PR DESCRIPTION
## Background and Goal

Realm Scripts were one-shot and opaque while running, which forced agents to repeat federated searches and left shell clients with no indication of current work. This adds a capability-scoped QuickJS Realm Runner, resumable notebook cells with explicit output lineage, and sanitized live activity streaming for CLI agents.

## Where to start

- packages/realm-runner/src/runner.js defines the isolated guest API v2 and activity emission.
- packages/realm-runner/src/notebook.js defines saved cells, immutable executions, rerun semantics, and snapshots.
- packages/runtime-common/realm.ts exposes the authenticated Realm endpoint and compatible NDJSON stream.
- packages/boxel-cli/src/commands/realm/script.ts consumes live activity on stderr while keeping final JSON on stdout.

## Key decisions and non-obvious mechanics

- Exact retries reuse successful executions; explicit reruns create new immutable revisions.
- Cross-cell state is JSON with execution lineage, never a mutable shared JavaScript heap.
- Durable notebook records are AES-GCM encrypted because federated outputs can contain data from other Realms.
- Automatic activity contains phase names only and never capability arguments, paths, queries, source, or results.
- The existing JSON endpoint remains compatible; activity streaming is opt-in through a request header.