### PR TITLE
Push submission files to GitHub from memory instead of via the PrCard

### DIFF
--- a/packages/bot-runner/lib/github.ts
+++ b/packages/bot-runner/lib/github.ts
@@ -46,6 +46,11 @@ export interface WriteFilesToBranchParams {
   branch: string;
   files: { path: string; content: string; isBinary?: boolean }[];
   message: string;
+  // When set, the commit makes this folder mirror `files` exactly: any blob
+  // already on the branch under the folder whose path isn't among `files` is
+  // deleted in the same commit. Without it, a rewrite of an existing branch
+  // layers onto the previous tree and stale paths survive.
+  syncFolder?: string;
 }
 
 export interface WriteFilesToBranchResult {
@@ -199,7 +204,12 @@ export class OctokitGitHubClient implements GitHubClient {
     });
     let baseTreeSha = parentCommit.tree.sha;
 
-    let tree = await Promise.all(
+    let tree: {
+      path: string;
+      mode: '100644';
+      type: 'blob';
+      sha: string | null;
+    }[] = await Promise.all(
       normalizedFiles.map(async (file) => {
         let blob = await this.request<{ sha: string }>({
           action: 'create blob',
@@ -219,6 +229,22 @@ export class OctokitGitHubClient implements GitHubClient {
         };
       }),
     );
+
+    if (params.syncFolder) {
+      let keptPaths = new Set(normalizedFiles.map((file) => file.path));
+      let existingPaths = await this.listBlobPathsUnder(
+        params.owner,
+        params.repo,
+        baseTreeSha,
+        params.syncFolder,
+      );
+      for (let path of existingPaths) {
+        if (!keptPaths.has(path)) {
+          // a null sha is the Git Data API's deletion entry
+          tree.push({ path, mode: '100644', type: 'blob', sha: null });
+        }
+      }
+    }
 
     let createdTree = await this.request<{
       sha: string;
@@ -256,6 +282,51 @@ export class OctokitGitHubClient implements GitHubClient {
     });
 
     return { commitSha: createdCommit.sha };
+  }
+
+  // Walks segment-by-segment to the folder's own tree before listing it
+  // recursively, so only the folder's subtree — never the whole repo — is
+  // subject to the recursive listing (and its truncation limit). Returns []
+  // when the folder doesn't exist on the branch yet.
+  private async listBlobPathsUnder(
+    owner: string,
+    repo: string,
+    rootTreeSha: string,
+    folder: string,
+  ): Promise<string[]> {
+    let segments = folder.split('/').filter(Boolean);
+    let treeSha = rootTreeSha;
+    for (let segment of segments) {
+      let { tree } = await this.request<{
+        tree: { path: string; type: string; sha: string }[];
+      }>({
+        action: 'get tree',
+        method: 'GET',
+        path: `/repos/${owner}/${repo}/git/trees/${treeSha}`,
+      });
+      let entry = tree.find((e) => e.path === segment && e.type === 'tree');
+      if (!entry) {
+        return [];
+      }
+      treeSha = entry.sha;
+    }
+    let { tree, truncated } = await this.request<{
+      tree: { path: string; type: string }[];
+      truncated?: boolean;
+    }>({
+      action: 'get folder tree',
+      method: 'GET',
+      path: `/repos/${owner}/${repo}/git/trees/${treeSha}?recursive=1`,
+    });
+    if (truncated) {
+      throw new Error(
+        `tree listing for "${folder}" was truncated; refusing to compute deletions from an incomplete listing`,
+      );
+    }
+    let prefix = segments.join('/');
+    return tree
+      .filter((e) => e.type === 'blob')
+      .map((e) => `${prefix}/${e.path}`);
   }
 
   private getToken(): string {

--- a/packages/bot-runner/lib/pr-listing/create-listing-pr-handler.ts
+++ b/packages/bot-runner/lib/pr-listing/create-listing-pr-handler.ts
@@ -144,6 +144,10 @@ export class CreateListingPRHandler {
       branch: context.head,
       files: allFiles,
       message: `add ${context.listingDisplayName} changes [boxel-content-hash:${hash}]`,
+      // A retry rewrites an existing branch; syncing the submission folder
+      // drops paths that fell out of the fresh collection (deleted or
+      // renamed files) instead of layering onto the previous tree.
+      syncFolder: folderName,
     });
   }
 

--- a/packages/bot-runner/lib/pr-listing/create-listing-pr-handler.ts
+++ b/packages/bot-runner/lib/pr-listing/create-listing-pr-handler.ts
@@ -1,8 +1,4 @@
-import {
-  logger,
-  toBranchName,
-  type RunCommandResponse,
-} from '@cardstack/runtime-common';
+import { logger, toBranchName } from '@cardstack/runtime-common';
 import type { BotTriggerContent } from '@cardstack/base/matrix-event';
 import { createHash } from 'node:crypto';
 import type { GitHubClient, OpenPullRequestResult } from '../github.ts';
@@ -119,18 +115,15 @@ export class CreateListingPRHandler {
 
   async addContentsToCommit(
     eventContent: BotTriggerEventContent,
-    runCommandResult?: RunCommandResponse | null,
+    files?: { path: string; content: string }[],
     binaryFiles?: { path: string; content: string }[],
   ): Promise<void> {
     let context = getCreateListingPRContext(eventContent);
     if (!context) {
       return;
     }
-    let rawFiles = await getContentsFromRealm(
-      runCommandResult?.cardResultString,
-    );
     let folderName = buildSubmissionFolderName(context);
-    let textFiles = rawFiles.map((file) => ({
+    let textFiles = (files ?? []).map((file) => ({
       ...file,
       path: `${folderName}/${file.path}`,
       isBinary: false as const,
@@ -157,7 +150,7 @@ export class CreateListingPRHandler {
   async openCreateListingPR(
     eventContent: BotTriggerEventContent,
     runAs: string,
-    runCommandResult?: RunCommandResponse | null,
+    fileCount: number,
     workflowCardUrl?: string | null,
   ): Promise<CreatedListingPRResult | null> {
     let context = getCreateListingPRContext(eventContent);
@@ -167,10 +160,10 @@ export class CreateListingPRHandler {
     let { owner, repoName, repo, head, title, listingDisplayName } = context;
 
     try {
-      let summary = await this.getSubmissionSummary(
+      let summary = this.getSubmissionSummary(
         eventContent,
         runAs,
-        runCommandResult,
+        fileCount,
         workflowCardUrl,
       );
       let prParams = {
@@ -222,12 +215,12 @@ export class CreateListingPRHandler {
     }
   }
 
-  async getSubmissionSummary(
+  getSubmissionSummary(
     eventContent: BotTriggerEventContent,
     runAs: string,
-    runCommandResult?: RunCommandResponse | null,
+    fileCount: number,
     workflowCardUrl?: string | null,
-  ): Promise<string | null> {
+  ): string | null {
     let context = getCreateListingPRContext(eventContent);
     if (!context) {
       return null;
@@ -240,7 +233,6 @@ export class CreateListingPRHandler {
       typeof input.listingSummary === 'string'
         ? input.listingSummary.trim()
         : '';
-    let files = await getContentsFromRealm(runCommandResult?.cardResultString);
 
     return [
       '## Summary',
@@ -248,7 +240,7 @@ export class CreateListingPRHandler {
       `- Listing Name: ${context.listingDisplayName}`,
       `- Room ID: \`${context.roomId}\``,
       `- User ID: \`${runAs}\``,
-      `- Number of Files: ${files.length}`,
+      `- Number of Files: ${fileCount}`,
       ...(workflowCardUrl
         ? [`- Workflow Card: [${workflowCardUrl}](${workflowCardUrl})`]
         : []),
@@ -273,88 +265,6 @@ function mapOpenPullRequestResult(
     branchName,
     summary,
   };
-}
-
-async function getContentsFromRealm(
-  cardResultString?: string | null,
-): Promise<{ path: string; content: string }[]> {
-  if (!cardResultString || !cardResultString.trim()) {
-    return [];
-  }
-  let parsed = parseJSONLike(cardResultString);
-  if (parsed === undefined) {
-    return [];
-  }
-  return extractFileContents(parsed);
-}
-
-function parseJSONLike(value: string): unknown | undefined {
-  let current: unknown = value;
-  for (let i = 0; i < 3; i++) {
-    if (typeof current !== 'string') {
-      return current;
-    }
-    let text = current.trim();
-    if (!text) {
-      return undefined;
-    }
-    try {
-      current = JSON.parse(text);
-      continue;
-    } catch {
-      try {
-        current = JSON.parse(decodeURIComponent(text));
-        continue;
-      } catch {
-        return undefined;
-      }
-    }
-  }
-  return current;
-}
-
-function extractFileContents(
-  doc: unknown,
-): { path: string; content: string }[] {
-  if (!doc || typeof doc !== 'object') {
-    return [];
-  }
-  let root = doc as Record<string, unknown>;
-  let attributes = (root.data as Record<string, unknown> | undefined)
-    ?.attributes as Record<string, unknown> | undefined;
-  let items = attributes?.allFileContents;
-  if (!Array.isArray(items)) {
-    items = attributes?.filesWithContent;
-  }
-  if (!Array.isArray(items)) {
-    return [];
-  }
-  let dedupe = new Map<string, { path: string; content: string }>();
-  for (let item of items) {
-    let normalized =
-      typeof item === 'string' ? parseJSONLike(item) : (item as unknown);
-    if (!normalized || typeof normalized !== 'object') {
-      continue;
-    }
-    let record = normalized as Record<string, unknown>;
-    let path =
-      typeof record.filename === 'string'
-        ? record.filename.trim()
-        : typeof record.path === 'string'
-          ? record.path.trim()
-          : '';
-    let content =
-      typeof record.contents === 'string'
-        ? record.contents
-        : typeof record.content === 'string'
-          ? record.content
-          : '';
-    if (!path) {
-      continue;
-    }
-    dedupe.set(path, { path, content });
-  }
-  return [...dedupe.values()];
 }
 
 function hashFiles(files: { path: string; content: string }[]): string {

--- a/packages/bot-runner/lib/pr-listing/pr-listing-workflow-handler.ts
+++ b/packages/bot-runner/lib/pr-listing/pr-listing-workflow-handler.ts
@@ -40,6 +40,7 @@ type FileContent = { filename: string; contents: string };
 interface PrCardData {
   prCardResult: RunCommandResponse;
   prCardUrl: string | null;
+  textFiles: FileContent[];
   binaryFiles: FileContent[];
 }
 
@@ -249,9 +250,7 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
       if (ctx.isRetry) {
         await this.clearStaleWorkflowError(ctx);
       }
-      let prCardData = ctx.existingPrCardUrl
-        ? await runStep('create-pr-card', () => this.loadExistingPrCard(ctx))
-        : await this.runFreshPrCardFlow(ctx);
+      let prCardData = await this.runFreshPrCardFlow(ctx);
 
       await runStep('github-pr', () => this.pushToGitHub(ctx, prCardData));
       await runStep('github-pr', () =>
@@ -274,12 +273,12 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
       this.applyLint(ctx, textFiles),
     );
     let { prCardResult, prCardUrl } = await runStep('create-pr-card', () =>
-      this.createPrCard(ctx, lintedFiles, totalCount),
+      this.createPrCard(ctx, lintedFiles, binaryFiles, totalCount),
     );
     await runStep('create-pr-card', () =>
       this.linkPrCardOnWorkflow(ctx, prCardUrl),
     );
-    return { prCardResult, prCardUrl, binaryFiles };
+    return { prCardResult, prCardUrl, textFiles: lintedFiles, binaryFiles };
   }
 
   // ── Steps ──
@@ -376,9 +375,22 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
   private async createPrCard(
     ctx: WorkflowContext,
     textFiles: FileContent[],
+    binaryFiles: FileContent[],
     totalFileCount: number,
   ): Promise<{ prCardResult: RunCommandResponse; prCardUrl: string | null }> {
+    // Retry reuses the PrCard linked by the prior attempt; the files pushed
+    // to GitHub always come from this run's fresh collection.
+    if (ctx.existingPrCardUrl) {
+      log.info('pr-listing-retry: reusing existing PrCard', {
+        existingPrCardUrl: ctx.existingPrCardUrl,
+      });
+      return {
+        prCardResult: { status: 'ready', cardResultString: null },
+        prCardUrl: ctx.existingPrCardUrl,
+      };
+    }
     let prSummary = buildPrSummary(ctx, totalFileCount);
+    let fileManifest = buildFileManifest(textFiles, binaryFiles);
     let prCardResult = await this.enqueueRunCommand({
       runAs: this.submissionBotUserId,
       realmURL: ctx.submissionRealm,
@@ -388,7 +400,7 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
         branchName: ctx.branchName,
         submittedBy: ctx.runAs,
         prSummary,
-        allFileContents: textFiles,
+        fileManifest,
       },
     });
     if (prCardResult.status !== 'ready') {
@@ -401,7 +413,7 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
         error: prCardResult.error,
         cardResultString: prCardResult.cardResultString ?? null,
         fileCount: textFiles.length,
-        inputPayloadSize: JSON.stringify(textFiles).length,
+        inputPayloadSize: JSON.stringify(fileManifest).length,
       });
       throw new Error(
         prCardResult.error?.trim() ||
@@ -413,41 +425,6 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
     return { prCardResult, prCardUrl };
   }
 
-  private async loadExistingPrCard(ctx: WorkflowContext): Promise<PrCardData> {
-    log.info('pr-listing-retry: reusing existing PrCard', {
-      existingPrCardUrl: ctx.existingPrCardUrl,
-    });
-    let result = await this.enqueueRunCommand({
-      runAs: this.submissionBotUserId,
-      realmURL: ctx.submissionRealm,
-      command: FETCH_CARD_JSON_COMMAND,
-      commandInput: { cardIdentifier: ctx.existingPrCardUrl },
-    });
-    requireReady(result, 'fetch-card-json (existing PrCard)');
-
-    let prCardDoc = extractFetchedDocument(result.cardResultString);
-    let allFileContents = extractFileContents(
-      prCardDoc ? JSON.stringify(prCardDoc) : null,
-    );
-    if (!prCardDoc || allFileContents.length === 0) {
-      throw new Error(
-        `existing PrCard at ${ctx.existingPrCardUrl} has no allFileContents — refusing to open an empty PR`,
-      );
-    }
-    let prCardResult: RunCommandResponse = {
-      ...result,
-      cardResultString: JSON.stringify(prCardDoc),
-    };
-    // Binary files aren't stored on the PrCard; addContentsToCommit dedupes
-    // by content-hash so re-running with empty binaries is safe when the
-    // prior attempt already committed them.
-    return {
-      prCardResult,
-      prCardUrl: ctx.existingPrCardUrl,
-      binaryFiles: [],
-    };
-  }
-
   private async pushToGitHub(
     ctx: WorkflowContext,
     prCardData: PrCardData,
@@ -457,7 +434,10 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
     );
     await this.createListingPRHandler.addContentsToCommit(
       ctx.syntheticCreateEvent,
-      prCardData.prCardResult,
+      prCardData.textFiles.map((f) => ({
+        path: f.filename,
+        content: f.contents,
+      })),
       prCardData.binaryFiles.map((f) => ({
         path: f.filename,
         content: f.contents,
@@ -466,7 +446,7 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
     let prResult = await this.createListingPRHandler.openCreateListingPR(
       ctx.syntheticCreateEvent,
       ctx.runAs,
-      prCardData.prCardResult,
+      prCardData.textFiles.length + prCardData.binaryFiles.length,
       ctx.workflowCardUrl,
     );
     log.info('pr-listing-create: PR created', {
@@ -697,6 +677,31 @@ function extractFetchedDocument(cardResultString?: string | null): any | null {
   } catch {
     return null;
   }
+}
+
+function buildFileManifest(
+  textFiles: FileContent[],
+  binaryFiles: FileContent[],
+): { filename: string; size: number; kind: 'text' | 'binary' }[] {
+  return [
+    ...textFiles.map((f) => ({
+      filename: f.filename,
+      size: Buffer.byteLength(f.contents, 'utf8'),
+      kind: 'text' as const,
+    })),
+    ...binaryFiles.map((f) => ({
+      filename: f.filename,
+      size: base64DecodedLength(f.contents),
+      kind: 'binary' as const,
+    })),
+  ];
+}
+
+function base64DecodedLength(base64: string): number {
+  let length = base64.length;
+  if (length === 0) return 0;
+  let padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+  return Math.floor((length * 3) / 4) - padding;
 }
 
 function extractFileContents(cardResultString?: string | null): FileContent[] {

--- a/packages/bot-runner/lib/pr-listing/pr-listing-workflow-handler.ts
+++ b/packages/bot-runner/lib/pr-listing/pr-listing-workflow-handler.ts
@@ -35,7 +35,7 @@ const PR_LISTING_CREATE = 'pr-listing-create';
 const PR_LISTING_RETRY = 'pr-listing-retry';
 
 type FailedStep = 'collect-files' | 'lint' | 'create-pr-card' | 'github-pr';
-type FileContent = { filename: string; contents: string };
+type FileContent = { filename: string; contents: string; isBinary?: boolean };
 
 interface PrCardData {
   prCardResult: RunCommandResponse;
@@ -303,11 +303,15 @@ export class PrListingWorkflowHandler implements BotCommandHandler {
     });
     requireReady(result, 'collect-submission-files');
 
-    // Binary files bypass the PrCard 512KB size limit; they're committed to
-    // GitHub directly via addContentsToCommit's binaryFiles arg.
+    // Binaries skip lint and are committed to GitHub as base64 blobs. The
+    // collector's isBinary flag says how each file was actually read — a
+    // text-extension FileDef (e.g. a generated .js) still carries base64;
+    // the extension check is only a fallback for pre-flag collect results.
     let allFiles = extractFileContents(result.cardResultString);
-    let binaryFiles = allFiles.filter((f) => isBinaryFilename(f.filename));
-    let textFiles = allFiles.filter((f) => !isBinaryFilename(f.filename));
+    let isBinaryFile = (f: FileContent) =>
+      f.isBinary ?? isBinaryFilename(f.filename);
+    let binaryFiles = allFiles.filter((f) => isBinaryFile(f));
+    let textFiles = allFiles.filter((f) => !isBinaryFile(f));
     log.info('pr-listing-create: files collected', {
       fileCount: allFiles.length,
       binaryCount: binaryFiles.length,
@@ -714,12 +718,20 @@ function extractFileContents(cardResultString?: string | null): FileContent[] {
     if (!Array.isArray(items)) {
       return [];
     }
-    return items.filter(
-      (item: any) =>
-        item &&
-        typeof item.filename === 'string' &&
-        typeof item.contents === 'string',
-    );
+    return items
+      .filter(
+        (item: any) =>
+          item &&
+          typeof item.filename === 'string' &&
+          typeof item.contents === 'string',
+      )
+      .map((item: any) => ({
+        filename: item.filename,
+        contents: item.contents,
+        ...(typeof item.isBinary === 'boolean'
+          ? { isBinary: item.isBinary }
+          : {}),
+      }));
   } catch {
     return [];
   }

--- a/packages/bot-runner/tests/command-runner-test.ts
+++ b/packages/bot-runner/tests/command-runner-test.ts
@@ -364,15 +364,16 @@ module('command runner', () => {
           branchName: 'a1b2c3-my-listing-name',
           submittedBy: '@alice:localhost',
           prSummary: `## Summary\nMy listing Summary\n\n---\n- Listing Name: My Listing Name\n- Room ID: \`!abc123:localhost\`\n- User ID: \`@alice:localhost\`\n- Number of Files: 1\n- Workflow Card: [${submissionCardUrl}](${submissionCardUrl})`,
-          allFileContents: [
+          fileManifest: [
             {
               filename: 'catalog/MyListing/listing.json',
-              contents: '{"data":{"type":"card"}}',
+              size: Buffer.byteLength('{"data":{"type":"card"}}', 'utf8'),
+              kind: 'text',
             },
           ],
         },
       },
-      'enqueues PR card creation in submissions realm',
+      'enqueues PR card creation in submissions realm with a manifest instead of file contents',
     );
     assert.deepEqual(
       (publishedJobs[4] as { args: Record<string, unknown> }).args,
@@ -812,7 +813,7 @@ module('command runner', () => {
     );
   });
 
-  test('pr-listing-retry with existing PrCard skips collect-files + create-pr-card', async (assert) => {
+  test('pr-listing-retry with existing PrCard re-collects but skips create-pr-card', async (assert) => {
     let workflowCardUrl =
       'http://localhost:4201/test/SubmissionWorkflowCard/abc-123';
     let prCardUrl = 'http://localhost:4201/submissions/PrCard/pr-1';
@@ -862,35 +863,28 @@ module('command runner', () => {
               }),
             } as any;
           }
-          if (url === prCardUrl) {
-            return {
-              id: publishedJobs.length,
-              done: Promise.resolve({
-                status: 'ready',
-                cardResultString: JSON.stringify({
-                  data: {
-                    attributes: {
-                      document: {
-                        data: {
-                          id: prCardUrl,
-                          attributes: {
-                            allFileContents: [
-                              {
-                                filename: 'catalog/MyListing/listing.json',
-                                contents: '{"data":{"type":"card"}}',
-                              },
-                            ],
-                          },
-                        },
-                      },
-                    },
-                  },
-                }),
-              }),
-            } as any;
-          }
         }
-        // patch-card-instance — final link/clear patch
+        if (command.endsWith('/collect-submission-files/default')) {
+          return {
+            id: publishedJobs.length,
+            done: Promise.resolve({
+              status: 'ready',
+              cardResultString: JSON.stringify({
+                data: {
+                  attributes: {
+                    allFileContents: [
+                      {
+                        filename: 'catalog/MyListing/listing.json',
+                        contents: '{"data":{"type":"card"}}',
+                      },
+                    ],
+                  },
+                },
+              }),
+            }),
+          } as any;
+        }
+        // patch-card-instance — lint status, link, and clear patches
         return {
           id: publishedJobs.length,
           done: Promise.resolve({ status: 'ready', cardResultString: null }),
@@ -971,21 +965,21 @@ module('command runner', () => {
     );
 
     let commands = publishedJobs.map((j) => j.args.command);
-    assert.notOk(
+    assert.ok(
       commands.some((c: string) =>
         c.endsWith('/collect-submission-files/default'),
       ),
-      'retry skips collect-submission-files',
+      'retry re-collects submission files from the source realm',
     );
     assert.notOk(
       commands.some((c: string) => c.endsWith('/create-pr-card/default')),
-      'retry skips create-pr-card',
+      'retry skips create-pr-card and reuses the linked PrCard',
     );
     assert.strictEqual(
       commands.filter((c: string) => c.endsWith('/fetch-card-json/default'))
         .length,
-      2,
-      'retry fetches workflow card AND existing PrCard',
+      1,
+      'retry fetches only the workflow card, never the PrCard contents',
     );
     let patchAttrs = publishedJobs
       .filter((j) =>
@@ -1001,6 +995,18 @@ module('command runner', () => {
     );
     assert.strictEqual(createdBranches.length, 1, 'creates GitHub branch');
     assert.strictEqual(branchWrites.length, 1, 'writes files to branch');
+    assert.deepEqual(
+      (
+        branchWrites[0] as { files: { path: string; content: string }[] }
+      ).files.map((f) => ({ path: f.path, content: f.content })),
+      [
+        {
+          path: 'a1b2c3-my-listing/catalog/MyListing/listing.json',
+          content: '{"data":{"type":"card"}}',
+        },
+      ],
+      'pushed files come from the fresh collection, not the PrCard',
+    );
     assert.strictEqual(openedPRs.length, 1, 'opens pull request');
     // Regression: retry must reuse the *persisted* branchName, not recompute
     // from the workflow card's display-formatted title. Without this guard,
@@ -1301,7 +1307,7 @@ module('command runner', () => {
     );
   });
 
-  test('lint auto-fixes are forwarded to create-pr-card', async (assert) => {
+  test('lint auto-fixes are forwarded to the GitHub commit and the PrCard manifest', async (assert) => {
     let workflowCardUrl =
       'http://localhost:4201/test/SubmissionWorkflowCard/abc-123';
     let prCardUrl = 'http://localhost:4201/submissions/PrCard/pr-1';
@@ -1350,17 +1356,7 @@ module('command runner', () => {
             done: Promise.resolve({
               status: 'ready',
               cardResultString: JSON.stringify({
-                data: {
-                  id: prCardUrl,
-                  attributes: {
-                    allFileContents: [
-                      {
-                        filename: 'catalog/MyListing/component.gts',
-                        contents: 'export const x = 1; // fixed',
-                      },
-                    ],
-                  },
-                },
+                data: { id: prCardUrl, attributes: {} },
               }),
             }),
           } as any;
@@ -1373,10 +1369,14 @@ module('command runner', () => {
       destroy: async () => {},
     };
 
+    let branchWrites: unknown[] = [];
     let githubClient: GitHubClient = {
       createBranch: async () => ({ ref: 'refs/heads/test', sha: 'abc123' }),
       writeFileToBranch: async () => ({ commitSha: 'def456' }),
-      writeFilesToBranch: async () => ({ commitSha: 'def456' }),
+      writeFilesToBranch: async (params) => {
+        branchWrites.push(params);
+        return { commitSha: 'def456' };
+      },
       openPullRequest: async () => ({
         number: 1,
         html_url: 'https://example/pr/1',
@@ -1450,14 +1450,22 @@ module('command runner', () => {
     );
     assert.ok(createPrCardJob, 'create-pr-card job is enqueued');
     assert.deepEqual(
-      createPrCardJob!.args.commandInput.allFileContents,
+      createPrCardJob!.args.commandInput.fileManifest,
       [
         {
           filename: 'catalog/MyListing/component.gts',
-          contents: 'export const x = 1; // fixed',
+          size: Buffer.byteLength('export const x = 1; // fixed', 'utf8'),
+          kind: 'text',
         },
       ],
-      'auto-fixed contents (not originals) are sent to create-pr-card',
+      'manifest reflects the auto-fixed contents, not the originals',
+    );
+    assert.deepEqual(
+      (
+        branchWrites[0] as { files: { path: string; content: string }[] }
+      ).files.map((f) => f.content),
+      ['export const x = 1; // fixed'],
+      'auto-fixed contents (not originals) are committed to GitHub',
     );
 
     let passedPatch = publishedJobs

--- a/packages/bot-runner/tests/command-runner-test.ts
+++ b/packages/bot-runner/tests/command-runner-test.ts
@@ -1307,6 +1307,200 @@ module('command runner', () => {
     );
   });
 
+  test('a binary-flagged text-extension file skips lint and commits as binary', async (assert) => {
+    let workflowCardUrl =
+      'http://localhost:4201/test/SubmissionWorkflowCard/abc-123';
+    let base64Js = Buffer.from('export const model = 1;').toString('base64');
+    let lintedFilenames: string[] = [];
+    let capturingLint: LintSubmissionFilesFn = async (files) => {
+      lintedFilenames.push(...files.map((f) => f.filename));
+      return {
+        passed: true,
+        fixedFiles: files.map((f) => ({
+          filename: f.filename,
+          contents: f.contents ?? '',
+        })),
+        lintErrors: [],
+        fixedFileCount: 0,
+      };
+    };
+
+    let publishedJobs: Array<{
+      args: Record<string, any>;
+      concurrencyGroup: string;
+    }> = [];
+    let queuePublisher: QueuePublisher = {
+      publish: async (job: any) => {
+        publishedJobs.push(job);
+        let command = (job.args.command as string | undefined) ?? '';
+        if (command.endsWith('/collect-submission-files/default')) {
+          return {
+            id: publishedJobs.length,
+            done: Promise.resolve({
+              status: 'ready',
+              cardResultString: JSON.stringify({
+                data: {
+                  attributes: {
+                    allFileContents: [
+                      {
+                        filename: 'catalog/MyListing/listing.json',
+                        contents: '{"data":{"type":"card"}}',
+                        isBinary: false,
+                      },
+                      {
+                        filename: 'catalog/MyListing/exports/model.js',
+                        contents: base64Js,
+                        isBinary: true,
+                      },
+                    ],
+                  },
+                },
+              }),
+            }),
+          } as any;
+        }
+        if (command.endsWith('/create-pr-card/default')) {
+          return {
+            id: publishedJobs.length,
+            done: Promise.resolve({
+              status: 'ready',
+              cardResultString: JSON.stringify({
+                data: {
+                  id: 'http://localhost:4201/submissions/PrCard/pr-1',
+                  attributes: {},
+                },
+              }),
+            }),
+          } as any;
+        }
+        return {
+          id: publishedJobs.length,
+          done: Promise.resolve({ status: 'ready', cardResultString: null }),
+        } as any;
+      },
+      destroy: async () => {},
+    };
+
+    let branchWrites: {
+      files: { path: string; content: string; isBinary?: boolean }[];
+    }[] = [];
+    let githubClient: GitHubClient = {
+      createBranch: async () => ({ ref: 'refs/heads/test', sha: 'abc123' }),
+      writeFileToBranch: async () => ({ commitSha: 'def456' }),
+      writeFilesToBranch: async (params) => {
+        branchWrites.push({ files: params.files });
+        return { commitSha: 'def456' };
+      },
+      openPullRequest: async () => ({
+        number: 1,
+        html_url: 'https://example/pr/1',
+      }),
+    };
+
+    let commandsByRegistrationId = new Map<
+      string,
+      Record<string, PgPrimitive>[]
+    >([
+      [
+        'bot-registration-binary-flag',
+        [
+          {
+            command_filter: {
+              type: 'matrix-event',
+              event_type: 'app.boxel.bot-trigger',
+              content_type: 'pr-listing-create',
+            },
+            command:
+              '@cardstack/catalog/commands/collect-submission-files/default',
+          },
+        ],
+      ],
+    ]);
+    let dbAdapter = {
+      kind: 'pg',
+      notify: async () => {},
+      isClosed: false,
+      execute: async (sql: string, opts?: ExecuteOptions) => {
+        if (sql.includes('FROM bot_commands WHERE bot_id =')) {
+          let registrationId = opts?.bind?.[0];
+          if (typeof registrationId !== 'string') {
+            return [];
+          }
+          return commandsByRegistrationId.get(registrationId) ?? [];
+        }
+        return [];
+      },
+      close: async () => {},
+      getColumnNames: async () => [],
+      withWriteLock: async (_url, fn) => fn(undefined),
+      withUserCostLock: async (_userId, fn) => fn(),
+    } as DBAdapter;
+
+    let commandRunner = makeRunner(
+      dbAdapter,
+      queuePublisher,
+      githubClient,
+      capturingLint,
+    );
+
+    await commandRunner.maybeEnqueueCommand(
+      '@alice:localhost',
+      {
+        type: 'pr-listing-create',
+        realm: 'http://localhost:4201/test/',
+        userId: '@alice:localhost',
+        input: {
+          roomId: '!abc123:localhost',
+          listingId: 'http://localhost:4201/test/Listing/1',
+          listingName: 'My Listing',
+          branchName: 'a1b2c3-my-listing',
+          workflowCardUrl,
+        },
+      },
+      'bot-registration-binary-flag',
+    );
+
+    assert.deepEqual(
+      lintedFilenames,
+      ['catalog/MyListing/listing.json'],
+      'the binary-flagged .js never reaches lint',
+    );
+
+    let createPrCardJob = publishedJobs.find((j) =>
+      (j.args.command as string).endsWith('/create-pr-card/default'),
+    );
+    assert.deepEqual(
+      createPrCardJob!.args.commandInput.fileManifest,
+      [
+        {
+          filename: 'catalog/MyListing/listing.json',
+          size: Buffer.byteLength('{"data":{"type":"card"}}', 'utf8'),
+          kind: 'text',
+        },
+        {
+          filename: 'catalog/MyListing/exports/model.js',
+          size: Buffer.byteLength('export const model = 1;', 'utf8'),
+          kind: 'binary',
+        },
+      ],
+      'manifest records the .js as binary with its decoded byte size',
+    );
+
+    let written = branchWrites[0].files.find((f) =>
+      f.path.endsWith('exports/model.js'),
+    );
+    assert.strictEqual(
+      written?.isBinary,
+      true,
+      'the .js is committed through the binary path (base64 blob), not as text',
+    );
+    assert.strictEqual(
+      written?.content,
+      base64Js,
+      'the committed payload is the untouched base64',
+    );
+  });
+
   test('lint auto-fixes are forwarded to the GitHub commit and the PrCard manifest', async (assert) => {
     let workflowCardUrl =
       'http://localhost:4201/test/SubmissionWorkflowCard/abc-123';

--- a/packages/bot-runner/tests/create-listing-pr-handler-test.ts
+++ b/packages/bot-runner/tests/create-listing-pr-handler-test.ts
@@ -181,13 +181,18 @@ module('create-listing-pr handler', () => {
     let writeCalls: {
       files: { path: string; content: string }[];
       message: string;
+      syncFolder?: string;
     }[] = [];
     let githubClient: GitHubClient = {
       openPullRequest: async () => ({ number: 1, html_url: 'x' }),
       createBranch: async () => ({ ref: 'refs/heads/test', sha: 'abc123' }),
       writeFileToBranch: async () => ({ commitSha: 'def456' }),
       writeFilesToBranch: async (params) => {
-        writeCalls.push({ files: params.files, message: params.message });
+        writeCalls.push({
+          files: params.files,
+          message: params.message,
+          syncFolder: params.syncFolder,
+        });
         return { commitSha: 'def456' };
       },
     };
@@ -220,6 +225,11 @@ module('create-listing-pr handler', () => {
         `${branchName}/Spec/def.json`,
       ],
       'every file is prefixed with the branch-name folder, inner layout preserved',
+    );
+    assert.strictEqual(
+      writeCalls[0].syncFolder,
+      branchName,
+      'the write syncs the submission folder so a retry drops paths missing from the fresh collection',
     );
   });
 

--- a/packages/bot-runner/tests/create-listing-pr-handler-test.ts
+++ b/packages/bot-runner/tests/create-listing-pr-handler-test.ts
@@ -36,19 +36,7 @@ module('create-listing-pr handler', () => {
     let result = await handler.openCreateListingPR(
       eventContent,
       '@alice:localhost',
-      {
-        status: 'ready',
-        cardResultString: JSON.stringify({
-          data: {
-            attributes: {
-              allFileContents: [
-                { filename: 'catalog/Listing/listing.json', contents: '{}' },
-                { filename: 'catalog/Listing/readme.md', contents: '# readme' },
-              ],
-            },
-          },
-        }),
-      },
+      2,
     );
 
     assert.strictEqual(result?.prNumber, 1, 'returns PR number');
@@ -138,19 +126,7 @@ module('create-listing-pr handler', () => {
     let result = await handler.openCreateListingPR(
       eventContent,
       '@alice:localhost',
-      {
-        status: 'ready',
-        cardResultString: JSON.stringify({
-          data: {
-            id: workflowCardUrl,
-            attributes: {
-              allFileContents: [
-                { filename: 'catalog/Listing/listing.json', contents: '{}' },
-              ],
-            },
-          },
-        }),
-      },
+      1,
       workflowCardUrl,
     );
     assert.strictEqual(result?.prNumber, 2, 'returns PR metadata when opened');
@@ -195,6 +171,7 @@ module('create-listing-pr handler', () => {
     let result = await handler.openCreateListingPR(
       eventContent,
       '@alice:localhost',
+      0,
     );
 
     assert.strictEqual(result, null, 'returns null when PR already exists');
@@ -228,20 +205,11 @@ module('create-listing-pr handler', () => {
     };
 
     let handler = new CreateListingPRHandler(githubClient);
-    await handler.addContentsToCommit(eventContent, {
-      status: 'ready',
-      cardResultString: JSON.stringify({
-        data: {
-          attributes: {
-            allFileContents: [
-              { filename: 'CardListing/abc.json', contents: '{}' },
-              { filename: 'Spec/def.json', contents: '{}' },
-              { filename: 'Recipe.gts', contents: 'export const x = 1;' },
-            ],
-          },
-        },
-      }),
-    });
+    await handler.addContentsToCommit(eventContent, [
+      { path: 'CardListing/abc.json', content: '{}' },
+      { path: 'Spec/def.json', content: '{}' },
+      { path: 'Recipe.gts', content: 'export const x = 1;' },
+    ]);
 
     assert.strictEqual(writeCalls.length, 1, 'writes once');
     assert.deepEqual(
@@ -279,18 +247,9 @@ module('create-listing-pr handler', () => {
     };
 
     let handler = new CreateListingPRHandler(githubClient);
-    let runResult = {
-      status: 'ready' as const,
-      cardResultString: JSON.stringify({
-        data: {
-          attributes: {
-            allFileContents: [{ filename: 'Recipe.gts', contents: 'x' }],
-          },
-        },
-      }),
-    };
-    await handler.addContentsToCommit(eventContent, runResult);
-    await handler.addContentsToCommit(eventContent, runResult);
+    let files = [{ path: 'Recipe.gts', content: 'x' }];
+    await handler.addContentsToCommit(eventContent, files);
+    await handler.addContentsToCommit(eventContent, files);
 
     assert.strictEqual(writeCalls.length, 2, 'writes twice');
     assert.deepEqual(
@@ -313,16 +272,7 @@ module('create-listing-pr handler', () => {
     };
 
     let handler = new CreateListingPRHandler(githubClient);
-    let runResult = {
-      status: 'ready' as const,
-      cardResultString: JSON.stringify({
-        data: {
-          attributes: {
-            allFileContents: [{ filename: 'Recipe.gts', contents: 'x' }],
-          },
-        },
-      }),
-    };
+    let files = [{ path: 'Recipe.gts', content: 'x' }];
 
     await handler.addContentsToCommit(
       {
@@ -331,7 +281,7 @@ module('create-listing-pr handler', () => {
         userId: '@alice:localhost',
         input: { roomId: '!room-a:localhost', listingName: 'My Listing' },
       },
-      runResult,
+      files,
     );
 
     assert.strictEqual(folders.length, 1, 'wrote once');
@@ -369,6 +319,7 @@ module('create-listing-pr handler', () => {
     let result = await handler.openCreateListingPR(
       eventContent,
       '@alice:localhost',
+      0,
     );
 
     assert.strictEqual(result, null, 'returns null when no PR can be opened');

--- a/packages/bot-runner/tests/github-test.ts
+++ b/packages/bot-runner/tests/github-test.ts
@@ -72,6 +72,8 @@ module('github client', (hooks) => {
     assert.strictEqual(createdTreeBodies.length, 1, 'creates one tree');
     let entries = createdTreeBodies[0].tree as {
       path: string;
+      mode: string;
+      type: string;
       sha: string | null;
     }[];
     assert.deepEqual(

--- a/packages/bot-runner/tests/github-test.ts
+++ b/packages/bot-runner/tests/github-test.ts
@@ -1,0 +1,141 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { OctokitGitHubClient } from '../lib/github.ts';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+module('github client', (hooks) => {
+  let originalFetch: typeof fetch;
+  hooks.beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  hooks.afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('writeFilesToBranch with syncFolder deletes stale blobs under the folder', async (assert) => {
+    let createdTreeBodies: any[] = [];
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      let url = typeof input === 'string' ? input : input.toString();
+      let method = init?.method ?? 'GET';
+      if (url.includes('/git/ref/heads/')) {
+        return jsonResponse({ object: { sha: 'commit-sha' } });
+      }
+      if (url.includes('/git/commits/commit-sha')) {
+        return jsonResponse({ tree: { sha: 'root-tree-sha' } });
+      }
+      if (url.includes('/git/blobs') && method === 'POST') {
+        return jsonResponse({ sha: 'blob-sha' });
+      }
+      if (url.includes('/git/trees/root-tree-sha') && method === 'GET') {
+        return jsonResponse({
+          tree: [{ path: 'a1b2c3-listing', type: 'tree', sha: 'folder-sha' }],
+        });
+      }
+      if (url.includes('/git/trees/folder-sha?recursive=1')) {
+        return jsonResponse({
+          tree: [
+            { path: 'kept.json', type: 'blob' },
+            { path: 'nested/stale.json', type: 'blob' },
+            { path: 'nested', type: 'tree' },
+          ],
+        });
+      }
+      if (url.endsWith('/git/trees') && method === 'POST') {
+        createdTreeBodies.push(JSON.parse(init?.body as string));
+        return jsonResponse({ sha: 'new-tree-sha' });
+      }
+      if (url.endsWith('/git/commits') && method === 'POST') {
+        return jsonResponse({ sha: 'new-commit-sha' });
+      }
+      if (url.includes('/git/refs/heads/') && method === 'PATCH') {
+        return jsonResponse({});
+      }
+      throw new Error(`unexpected request: ${method} ${url}`);
+    };
+
+    let client = new OctokitGitHubClient('test-token');
+    await client.writeFilesToBranch({
+      owner: 'cardstack',
+      repo: 'boxel-catalog',
+      branch: 'a1b2c3-listing',
+      files: [{ path: 'a1b2c3-listing/kept.json', content: '{}' }],
+      message: 'update listing',
+      syncFolder: 'a1b2c3-listing',
+    });
+
+    assert.strictEqual(createdTreeBodies.length, 1, 'creates one tree');
+    let entries = createdTreeBodies[0].tree as {
+      path: string;
+      sha: string | null;
+    }[];
+    assert.deepEqual(
+      entries.find((e) => e.path === 'a1b2c3-listing/nested/stale.json'),
+      {
+        path: 'a1b2c3-listing/nested/stale.json',
+        mode: '100644',
+        type: 'blob',
+        sha: null,
+      },
+      'the blob missing from the fresh file set gets a deletion entry',
+    );
+    assert.notOk(
+      entries.some((e) => e.path === 'a1b2c3-listing/kept.json' && !e.sha),
+      'the kept blob is written, not deleted',
+    );
+  });
+
+  test('writeFilesToBranch with syncFolder is a no-op deletion-wise when the folder is new', async (assert) => {
+    let createdTreeBodies: any[] = [];
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      let url = typeof input === 'string' ? input : input.toString();
+      let method = init?.method ?? 'GET';
+      if (url.includes('/git/ref/heads/')) {
+        return jsonResponse({ object: { sha: 'commit-sha' } });
+      }
+      if (url.includes('/git/commits/commit-sha')) {
+        return jsonResponse({ tree: { sha: 'root-tree-sha' } });
+      }
+      if (url.includes('/git/blobs') && method === 'POST') {
+        return jsonResponse({ sha: 'blob-sha' });
+      }
+      if (url.includes('/git/trees/root-tree-sha') && method === 'GET') {
+        return jsonResponse({
+          tree: [{ path: 'other', type: 'tree', sha: 'x' }],
+        });
+      }
+      if (url.endsWith('/git/trees') && method === 'POST') {
+        createdTreeBodies.push(JSON.parse(init?.body as string));
+        return jsonResponse({ sha: 'new-tree-sha' });
+      }
+      if (url.endsWith('/git/commits') && method === 'POST') {
+        return jsonResponse({ sha: 'new-commit-sha' });
+      }
+      if (url.includes('/git/refs/heads/') && method === 'PATCH') {
+        return jsonResponse({});
+      }
+      throw new Error(`unexpected request: ${method} ${url}`);
+    };
+
+    let client = new OctokitGitHubClient('test-token');
+    await client.writeFilesToBranch({
+      owner: 'cardstack',
+      repo: 'boxel-catalog',
+      branch: 'a1b2c3-listing',
+      files: [{ path: 'a1b2c3-listing/new.json', content: '{}' }],
+      message: 'add listing',
+      syncFolder: 'a1b2c3-listing',
+    });
+
+    let entries = createdTreeBodies[0].tree as { sha: string | null }[];
+    assert.notOk(
+      entries.some((e) => e.sha === null),
+      'no deletion entries on a first write',
+    );
+  });
+});

--- a/packages/bot-runner/tests/index.ts
+++ b/packages/bot-runner/tests/index.ts
@@ -4,6 +4,7 @@ import '../setup-logger.ts';
 import './bot-runner-test.ts';
 import './command-runner-test.ts';
 import './create-listing-pr-handler-test.ts';
+import './github-test.ts';
 import './lint-submission-files-test.ts';
 
 QUnit.start();


### PR DESCRIPTION
## Problem

The listing-PR workflow wrote every collected text file onto the PrCard (`allFileContents`) and then parsed them back out of the saved card document to commit to GitHub. The PrCard save is subject to the realm's 512KB card size limit, so a listing whose collected sources approach that limit can never be submitted — even though the workflow already holds all the files in memory from the collect step, and binary files already bypass the card entirely.

## Changes

`packages/bot-runner/lib/pr-listing/` (plus `lib/github.ts`):

- **Manifest instead of contents**: `create-pr-card` is invoked with a lightweight `fileManifest` (filename, byte size, kind); the GitHub commit and PR summary are fed directly from the in-memory (post-lint-fix) files. The PrCard stays a few KB regardless of listing size. The triple-JSON-unwrap machinery (`getContentsFromRealm`/`parseJSONLike`/`extractFileContents`) in `create-listing-pr-handler.ts` is deleted.
- **Retry re-collects**: retry re-runs collection and lint instead of replaying contents off the existing PrCard, so it stays gated on lint and no longer needs the card to carry file bodies. It still reuses the linked PrCard and the persisted `branchName`, so the same branch/PR is targeted.
- **Submission folder sync on branch rewrites**: `writeFilesToBranch` takes a `syncFolder` — blobs on the branch under the submission folder that aren't in the incoming file set get null-sha deletion entries in the same commit, so a retry makes the folder mirror the fresh collection (deleted/renamed files converge). The folder's subtree is resolved segment-by-segment so only it is subject to the recursive-listing truncation limit; a truncated listing throws rather than computing deletions from an incomplete view.
- **Binary split on the collector's flag**: the text/binary split trusts the collector's `isBinary` stamp (how the file was actually read) over the filename extension, with the extension heuristic kept as fallback for pre-flag collect results. Fixes text-extension FileDefs (e.g. generated `.js` model exports) being fed to lint as base64 and committed to GitHub corrupted.

## Compatibility

The catalog-side counterparts are both merged: cardstack/boxel-catalog#684 (`fileManifest` input on `create-pr-card`, still honors `allFileContents`) and cardstack/boxel-catalog#686 (collector stamps `isBinary`). This PR is safe to merge now; all fallbacks for pre-flag data are in place.

## Testing

- `pnpm test` in `packages/bot-runner` — 28/28. Covers: manifest (not contents) in the create-pr-card enqueue, retry re-collection with create-pr-card skipped, pushed files sourced from the fresh collection, lint autofixes landing in both the commit and the manifest, binary-flagged `.js` skipping lint and committing through the base64 path, and syncFolder deletion entries (stale blob deleted; no deletions on first write).
- `pnpm lint` (ember-tsc) clean.
- Manual end-to-end on a local stack with the exact listing that failed in production — see the evidence comment below (result: cardstack/boxel-catalog#689, 124 files intact, ~14KB PrCard, remix from preview verified).