### PR TITLE
Reduce rounded corner radius for markdown dropdown bars and atom cards

### DIFF
--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -1649,7 +1649,8 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           gap: 4px;
           background-color: var(--boxel-100, #f0f0f0);
           border: 1px solid var(--boxel-border-color, #c4c4c4);
-          border-radius: var(--boxel-border-radius, 4px);
+          /* 2px less rounded than the default: the atom pill read too round. */
+          border-radius: calc(var(--boxel-border-radius, 4px) - 2px);
           padding: 1px 6px;
           font-size: 0.85em;
           cursor: pointer;

--- a/packages/base/components/markdown-editor-mode-select.gts
+++ b/packages/base/components/markdown-editor-mode-select.gts
@@ -64,6 +64,11 @@ export default class MarkdownEditorModeSelect extends GlimmerComponent<Signature
 
     <style scoped>
       .markdown-editor-mode-select {
+        /* Trim the trigger's corners: the default form-control radius reads a
+           touch too rounded here, so drop it 2px (scoped to this select). */
+        --boxel-form-control-border-radius: calc(
+          var(--boxel-border-radius) - 2px
+        );
         /* Compact the trigger: tight padding and a small label↔caret gap,
            via the BoxelSelect trigger tokens. */
         --boxel-select-trigger-padding: var(--boxel-sp-5xs) var(--boxel-sp-xxs);
@@ -91,8 +96,19 @@ export default class MarkdownEditorModeSelect extends GlimmerComponent<Signature
     {{! template-lint-disable require-scoped-style }}
     <style>
       .boxel-select__dropdown.markdown-editor-mode-select-dropdown {
+        /* Match the trigger: 2px less rounded than the default menu radius. */
+        --boxel-form-control-border-radius: calc(
+          var(--boxel-border-radius) - 2px
+        );
         width: max-content;
         min-width: 7rem;
+      }
+      /* Shorter rows: tighten the vertical padding so the menu reads less tall.
+         (0,3,0) specificity wins over BoxelSelect's own row rules regardless of
+         stylesheet order. */
+      .boxel-select__dropdown.markdown-editor-mode-select-dropdown
+        .boxel-select-option-item {
+        padding-block: var(--boxel-sp-3xs);
       }
       .markdown-editor-mode-select-dropdown .boxel-select-option-text {
         white-space: nowrap;


### PR DESCRIPTION
Reduces the corner radius by 2px on the RichMarkdown editing UI surfaces that read a touch too rounded, and tightens the mode-switcher menu row height.

## Changes (CSS-only)
- **Mode-switcher dropdown** (`markdown-editor-mode-select.gts`) — trigger bar and open menu corners 10px → 8px, via a locally-scoped `--boxel-form-control-border-radius` override that cascades to `BoxelSelect`'s trigger/menu rules.
- **Menu rows** — reduced vertical padding (`--boxel-sp-xxs` → `--boxel-sp-3xs`) so the dropdown reads less tall.
- **Atom card pill** (`codemirror-editor.gts`, `.codemirror-card-slot--inline`) — corners 10px → 8px.

## Scope
Everything is scoped to the Markdown editing UI. No global tokens change, so other selects, buttons, and inputs keep their current radius.

## Testing
- Existing `rich-markdown-field-test.gts` integration tests assert class/attribute presence and interactions (not computed styles), so they're unaffected.
- Visual confirmation against the ticket mocks still pending.

Closes CS-11696