### PR TITLE
Don't insert stray markers when formatting with no selection (CS-11697)

### DIFF
--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -7,7 +7,7 @@ import { on } from '@ember/modifier';
 import { scheduleOnce } from '@ember/runloop';
 import { htmlSafe } from '@ember/template';
 import { Tooltip } from '@cardstack/boxel-ui/components';
-import { eq, not } from '@cardstack/boxel-ui/helpers';
+import { eq } from '@cardstack/boxel-ui/helpers';
 
 import {
   baseRRI,
@@ -199,6 +199,13 @@ interface ToolbarItem {
   // binding in the CodeMirror keymap (bold/italic/code); absent items render a
   // label-only tooltip.
   shortcut?: string;
+  // Inline-format toggles (bold/italic/etc.) wrap the current selection, so they
+  // only make sense when text is highlighted. Set for those buttons so they
+  // disable when the selection is collapsed. Line-based buttons omit it.
+  requiresSelection?: boolean;
+  // Computed enablement for this button, folding in focus and (for
+  // selection-requiring buttons) whether text is highlighted.
+  disabled?: boolean;
 }
 
 const EMPTY_FORMATS: SelectionFormats = Object.freeze({
@@ -212,6 +219,9 @@ const EMPTY_FORMATS: SelectionFormats = Object.freeze({
 function sameToolbarState(a: SelectionInfo, b: SelectionInfo): boolean {
   return (
     a.hasFocus === b.hasFocus &&
+    // Selection presence gates the inline-format buttons' enablement, so a
+    // collapse/expand must refresh the toolbar even when nothing else changed.
+    a.hasSelection === b.hasSelection &&
     a.formats.bold === b.formats.bold &&
     a.formats.italic === b.formats.italic &&
     a.formats.code === b.formats.code &&
@@ -467,7 +477,13 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
   get toolbarButtons(): ToolbarItem[] {
     let f = this.toolbarFormats;
     let pressed = (active: boolean) => (active ? 'true' : 'false');
-    return [
+    let enabled = this.toolbarEnabled;
+    let hasSelection = this._selectionInfo?.hasSelection ?? false;
+    // Inline-format toggles additionally require a highlighted selection;
+    // line-based buttons only require focus.
+    let disabledFor = (requiresSelection?: boolean) =>
+      !enabled || (!!requiresSelection && !hasSelection);
+    let items: ToolbarItem[] = [
       {
         testId: 'bold',
         label: 'Bold',
@@ -476,6 +492,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         active: f.bold,
         ariaPressed: pressed(f.bold),
         shortcut: `${modKey}B`,
+        requiresSelection: true,
       },
       {
         testId: 'italic',
@@ -485,6 +502,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         active: f.italic,
         ariaPressed: pressed(f.italic),
         shortcut: `${modKey}I`,
+        requiresSelection: true,
       },
       {
         testId: 'strikethrough',
@@ -493,6 +511,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         action: this._wrapStrikethrough,
         active: f.strikethrough,
         ariaPressed: pressed(f.strikethrough),
+        requiresSelection: true,
       },
       {
         testId: 'code',
@@ -502,6 +521,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         active: f.code,
         ariaPressed: pressed(f.code),
         shortcut: `${modKey}\``,
+        requiresSelection: true,
       },
       {
         testId: 'link',
@@ -510,6 +530,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         action: this._toggleLink,
         active: f.link,
         ariaPressed: pressed(f.link),
+        requiresSelection: true,
       },
       { divider: true },
       {
@@ -550,6 +571,12 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         action: this._toggleBlockquote,
       },
     ];
+    for (let item of items) {
+      if (!item.divider) {
+        item.disabled = disabledFor(item.requiresSelection);
+      }
+    }
+    return items;
   }
 
   /** Prevent mousedown on toolbar/popup buttons from stealing editor focus/selection */
@@ -1212,7 +1239,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
                   is suppressed while the control is disabled. }}
               <Tooltip
                 @placement='top'
-                @disabled={{not this.toolbarEnabled}}
+                @disabled={{btn.disabled}}
                 data-test-toolbar-tooltip={{btn.testId}}
               >
                 <:trigger>
@@ -1222,7 +1249,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
                     type='button'
                     aria-label={{btn.label}}
                     aria-pressed={{btn.ariaPressed}}
-                    disabled={{not this.toolbarEnabled}}
+                    disabled={{btn.disabled}}
                     {{on 'mousedown' this._preventFocusLoss}}
                     {{on 'click' btn.action}}
                   >{{#let btn.icon as |Icon|}}<Icon

--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -201,7 +201,9 @@ interface ToolbarItem {
   shortcut?: string;
   // Inline-format toggles (bold/italic/etc.) wrap the current selection, so they
   // only make sense when text is highlighted. Set for those buttons so they
-  // disable when the selection is collapsed. Line-based buttons omit it.
+  // disable when the selection is collapsed — unless the toggle is active
+  // (e.g. the caret sits inside a link), since untoggling works at a bare
+  // caret. Line-based buttons omit it.
   requiresSelection?: boolean;
   // Computed enablement for this button, folding in focus and (for
   // selection-requiring buttons) whether text is highlighted.
@@ -479,10 +481,12 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
     let pressed = (active: boolean) => (active ? 'true' : 'false');
     let enabled = this.toolbarEnabled;
     let hasSelection = this._selectionInfo?.hasSelection ?? false;
-    // Inline-format toggles additionally require a highlighted selection;
-    // line-based buttons only require focus.
-    let disabledFor = (requiresSelection?: boolean) =>
-      !enabled || (!!requiresSelection && !hasSelection);
+    // Inline-format toggles additionally require a highlighted selection,
+    // except when already active — an active toggle can always be untoggled
+    // (unlink works from a bare caret inside the link). Line-based buttons
+    // only require focus.
+    let disabledFor = (item: ToolbarItem) =>
+      !enabled || (!!item.requiresSelection && !hasSelection && !item.active);
     let items: ToolbarItem[] = [
       {
         testId: 'bold',
@@ -573,7 +577,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
     ];
     for (let item of items) {
       if (!item.divider) {
-        item.disabled = disabledFor(item.requiresSelection);
+        item.disabled = disabledFor(item);
       }
     }
     return items;

--- a/packages/host/app/lib/codemirror-context.ts
+++ b/packages/host/app/lib/codemirror-context.ts
@@ -1064,21 +1064,32 @@ function wrapWith(marker: string) {
   };
 }
 
-// Toggle a markdown link around the selection. Uses the syntax tree to detect
-// an enclosing [text](url) — a string scan can match across unrelated brackets
-// and delete text the user never selected.
+// Find the markdown Link syntax node enclosing the given range, if any. Uses
+// the syntax tree — a string scan can match across unrelated brackets and
+// claim text the user never selected. Shared by toggleLink's unlink branch and
+// the selection-info emitter, so the toolbar's Link-button state can't drift
+// from what the command actually supports.
+function findEnclosingLink(
+  state: EditorState,
+  from: number,
+  to: number,
+): any | null {
+  let node: any = syntaxTree(state).resolveInner(from, 1);
+  for (let n: any = node; n; n = n.parent) {
+    if (n.name === 'Link' && from >= n.from && to <= n.to) {
+      return n;
+    }
+  }
+  return null;
+}
+
+// Toggle a markdown link around the selection. A caret or selection inside an
+// existing [text](url) unlinks it; a selection elsewhere wraps as a link.
 function toggleLink(view: EditorView): boolean {
   let { from, to } = view.state.selection.main;
 
-  let node: any = syntaxTree(view.state).resolveInner(from, 1);
-  let link: any = null;
-  for (let n: any = node; n; n = n.parent) {
-    if (n.name === 'Link') {
-      link = n;
-      break;
-    }
-  }
-  if (link && from >= link.from && to <= link.to) {
+  let link = findEnclosingLink(view.state, from, to);
+  if (link) {
     // Unlink: replace the whole node with just its text (between [ and ]).
     let marks: { from: number; to: number }[] = [];
     let c = link.cursor();
@@ -1097,8 +1108,9 @@ function toggleLink(view: EditorView): boolean {
   }
 
   if (from === to) {
-    // No selection: do nothing. Inserting empty link syntax leaves a stray
-    // [](url) in the document. Linking applies to selected text only.
+    // Caret outside any link: nothing to unlink, and inserting empty link
+    // syntax would leave a stray [](url) in the document. The wrap direction
+    // needs a selection.
     return true;
   }
 
@@ -1252,11 +1264,15 @@ function createEditorState(options: CreateEditorStateOptions): EditorState {
             formats: hasSelection
               ? detectFormats(update.state, from, to)
               : {
+                  // The wrap toggles no-op at a caret, so they read inactive.
+                  // Link is the exception: toggleLink can still unlink an
+                  // enclosing [text](url) from a bare caret, so report it
+                  // active — the toolbar keeps an active toggle clickable.
                   bold: false,
                   italic: false,
                   code: false,
                   strikethrough: false,
-                  link: false,
+                  link: !!findEnclosingLink(update.state, from, to),
                 },
             currentRef,
           });

--- a/packages/host/app/lib/codemirror-context.ts
+++ b/packages/host/app/lib/codemirror-context.ts
@@ -1011,13 +1011,11 @@ function wrapWith(marker: string) {
     let { from, to } = view.state.selection.main;
     let len = marker.length;
 
-    // No selection: insert an empty pair of markers and drop the cursor
-    // between them so the user can type the content (e.g. **|**).
+    // No selection: do nothing. Inserting an empty marker pair here leaves
+    // stray markers (e.g. **) visible in source and preview. Inline formatting
+    // applies to selected text only — the toolbar disables these buttons and
+    // the keyboard shortcut is a no-op until the user highlights something.
     if (from === to) {
-      view.dispatch({
-        changes: { from, insert: marker + marker },
-        selection: { anchor: from + len },
-      });
       return true;
     }
 
@@ -1099,12 +1097,8 @@ function toggleLink(view: EditorView): boolean {
   }
 
   if (from === to) {
-    // No selection: insert empty link syntax with the cursor inside the
-    // brackets so the user can type the link text — [|](url).
-    view.dispatch({
-      changes: { from, insert: '[](url)' },
-      selection: { anchor: from + 1 },
-    });
+    // No selection: do nothing. Inserting empty link syntax leaves a stray
+    // [](url) in the document. Linking applies to selected text only.
     return true;
   }
 

--- a/packages/host/tests/integration/components/codemirror-editor-test.gts
+++ b/packages/host/tests/integration/components/codemirror-editor-test.gts
@@ -1478,6 +1478,57 @@ module('Integration | codemirror-context', function (hooks) {
     }
   });
 
+  test('onSelectionChange reports link active at a bare caret inside a link', async function (assert) {
+    let element = document.createElement('div');
+    document.body.appendChild(element);
+
+    try {
+      let selectionInfo: {
+        hasSelection: boolean;
+        formats: { link: boolean; bold: boolean };
+      } | null = null;
+      let state = cmContext.createEditorState({
+        content: 'Click [here](https://example.com) for details',
+        onDocChange: () => {},
+        onCardTargetsChange: () => {},
+        onOpenCardSearch: () => {},
+        onSelectionChange: (info) => {
+          selectionInfo = info;
+        },
+      });
+
+      let view = new cmContext.EditorView({
+        state,
+        parent: element,
+      });
+
+      // Collapsed caret inside the link text "here"
+      view.dispatch({ selection: { anchor: 9, head: 9 } });
+
+      assert.ok(selectionInfo, 'onSelectionChange was called');
+      assert.false(selectionInfo!.hasSelection, 'no selection at a caret');
+      assert.true(
+        selectionInfo!.formats.link,
+        'link reads active — toggleLink can unlink from this caret, so the toolbar keeps the Link toggle clickable',
+      );
+      assert.false(
+        selectionInfo!.formats.bold,
+        'wrap toggles read inactive at a caret (they no-op there)',
+      );
+
+      // Caret outside the link
+      view.dispatch({ selection: { anchor: 2, head: 2 } });
+      assert.false(
+        selectionInfo!.formats.link,
+        'link reads inactive once the caret leaves the link',
+      );
+
+      view.destroy();
+    } finally {
+      element.remove();
+    }
+  });
+
   // ── Heading insertion (same logic as component's _insertHeading) ──
 
   test('heading prefix is added to line', async function (assert) {
@@ -1925,22 +1976,9 @@ module('Integration | codemirror-context', function (hooks) {
       // as a user would in live preview where [ and ](url) are hidden
       view.dispatch({ selection: { anchor: 7, head: 11 } });
 
-      // Simulate _toggleLink: scan for enclosing [text](url)
-      let doc = view.state.doc.toString();
-      let { from, to } = view.state.selection.main;
-      let bracketOpen = doc.lastIndexOf('[', from);
-      let parenClose = doc.indexOf(')', to - 1);
-      let between = doc.slice(bracketOpen, parenClose + 1);
-      let linkMatch = between.match(/^\[(.+)\]\(.*\)$/);
-      assert.ok(linkMatch, 'enclosing link pattern found');
-      view.dispatch({
-        changes: {
-          from: bracketOpen,
-          to: parenClose + 1,
-          insert: linkMatch![1],
-        },
-      });
+      let result = cmContext.toggleLink(view);
 
+      assert.true(result, 'returns true after unlinking');
       assert.strictEqual(
         view.state.doc.toString(),
         'Click here for details',
@@ -1953,7 +1991,7 @@ module('Integration | codemirror-context', function (hooks) {
     }
   });
 
-  test('toggleLink does nothing when there is no selection', async function (assert) {
+  test('toggleLink does nothing at a caret outside any link', async function (assert) {
     let element = document.createElement('div');
     document.body.appendChild(element);
 
@@ -1970,7 +2008,7 @@ module('Integration | codemirror-context', function (hooks) {
         parent: element,
       });
 
-      // Cursor at position 6, no selection
+      // Cursor at position 6, no selection, no enclosing link
       view.dispatch({ selection: { anchor: 6, head: 6 } });
       let result = cmContext.toggleLink(view);
 
@@ -1983,6 +2021,40 @@ module('Integration | codemirror-context', function (hooks) {
       let sel = view.state.selection.main;
       assert.true(sel.empty, 'cursor is collapsed (no selection)');
       assert.strictEqual(sel.from, 6, 'cursor stays where it was');
+
+      view.destroy();
+    } finally {
+      element.remove();
+    }
+  });
+
+  test('toggleLink unlinks from a bare caret inside a link', async function (assert) {
+    let element = document.createElement('div');
+    document.body.appendChild(element);
+
+    try {
+      let state = cmContext.createEditorState({
+        content: 'Click [here](https://example.com) for details',
+        onDocChange: () => {},
+        onCardTargetsChange: () => {},
+        onOpenCardSearch: () => {},
+      });
+
+      let view = new cmContext.EditorView({
+        state,
+        parent: element,
+      });
+
+      // Collapsed caret inside the link text "here" — no selection
+      view.dispatch({ selection: { anchor: 9, head: 9 } });
+      let result = cmContext.toggleLink(view);
+
+      assert.true(result, 'returns true after unlinking');
+      assert.strictEqual(
+        view.state.doc.toString(),
+        'Click here for details',
+        'the enclosing link is unwrapped, leaving just its text',
+      );
 
       view.destroy();
     } finally {

--- a/packages/host/tests/integration/components/codemirror-editor-test.gts
+++ b/packages/host/tests/integration/components/codemirror-editor-test.gts
@@ -1327,7 +1327,7 @@ module('Integration | codemirror-context', function (hooks) {
     }
   });
 
-  test('wrapWith inserts empty markers with cursor centered when no selection', async function (assert) {
+  test('wrapWith does nothing when there is no selection', async function (assert) {
     let element = document.createElement('div');
     document.body.appendChild(element);
 
@@ -1348,19 +1348,15 @@ module('Integration | codemirror-context', function (hooks) {
       view.dispatch({ selection: { anchor: 6, head: 6 } });
       let result = cmContext.wrapWith('**')(view);
 
-      assert.true(result, 'returns true after inserting markers');
+      assert.true(result, 'returns true (shortcut consumed) without editing');
       assert.strictEqual(
         view.state.doc.toString(),
-        'Hello ****World',
-        'an empty pair of bold markers is inserted at the cursor',
+        'Hello World',
+        'no stray markers are inserted when nothing is selected',
       );
       let sel = view.state.selection.main;
       assert.true(sel.empty, 'cursor is collapsed (no selection)');
-      assert.strictEqual(
-        sel.from,
-        8,
-        'cursor sits between the two pairs of markers',
-      );
+      assert.strictEqual(sel.from, 6, 'cursor stays where it was');
 
       view.destroy();
     } finally {
@@ -1950,6 +1946,43 @@ module('Integration | codemirror-context', function (hooks) {
         'Click here for details',
         'link syntax is removed, leaving just the text',
       );
+
+      view.destroy();
+    } finally {
+      element.remove();
+    }
+  });
+
+  test('toggleLink does nothing when there is no selection', async function (assert) {
+    let element = document.createElement('div');
+    document.body.appendChild(element);
+
+    try {
+      let state = cmContext.createEditorState({
+        content: 'Hello World',
+        onDocChange: () => {},
+        onCardTargetsChange: () => {},
+        onOpenCardSearch: () => {},
+      });
+
+      let view = new cmContext.EditorView({
+        state,
+        parent: element,
+      });
+
+      // Cursor at position 6, no selection
+      view.dispatch({ selection: { anchor: 6, head: 6 } });
+      let result = cmContext.toggleLink(view);
+
+      assert.true(result, 'returns true without editing');
+      assert.strictEqual(
+        view.state.doc.toString(),
+        'Hello World',
+        'no stray [](url) is inserted when nothing is selected',
+      );
+      let sel = view.state.selection.main;
+      assert.true(sel.empty, 'cursor is collapsed (no selection)');
+      assert.strictEqual(sel.from, 6, 'cursor stays where it was');
 
       view.destroy();
     } finally {

--- a/packages/host/tests/integration/components/rich-markdown-field-test.gts
+++ b/packages/host/tests/integration/components/rich-markdown-field-test.gts
@@ -3,6 +3,7 @@ import type { RenderingTestContext } from '@ember/test-helpers';
 import {
   click,
   render,
+  settled,
   triggerEvent,
   waitFor,
   waitUntil,
@@ -1625,6 +1626,70 @@ module('Integration | RichMarkdownField', function (hooks) {
       .dom('[data-test-markdown-mode-option="source"]')
       .exists('view selector opens without editor focus');
     await click('[data-test-markdown-mode-option="compose"]');
+  });
+
+  test('the Link toggle reads active when the caret sits inside a link', async function (assert) {
+    // Enablement can't be asserted headless (document.hasFocus() is false —
+    // see the note in the "formatting controls start disabled" test), but the
+    // active-state wiring can: a bare caret inside a link marks the Link
+    // toggle pressed, since unlinking works from a caret. This pins the path
+    // from CodeMirror's selection-info emitter through the toolbar's
+    // change-detection to the button's aria-pressed.
+    class TestCard extends CardDef {
+      @field body = contains(RichMarkdownField);
+      static edit = class Edit extends Component<typeof this> {
+        <template><@fields.body /></template>
+      };
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'test-card.gts': { TestCard },
+      },
+    });
+
+    let card = new TestCard({
+      body: new RichMarkdownField({
+        content: 'Click [here](https://example.com) now',
+      }),
+    });
+    await renderCard(loader, card, 'edit');
+    await waitFor('[data-test-toolbar="link"]');
+
+    let editorEl = document.querySelector('.cm-editor') as HTMLElement;
+    assert.ok(editorEl, 'editor is rendered');
+    let view = cmContext.EditorView.findFromDOM(editorEl);
+    assert.ok(view, 'live EditorView is reachable from the DOM');
+
+    // Collapsed caret inside the link text "here" — no selection
+    view!.dispatch({ selection: { anchor: 9, head: 9 } });
+    await settled();
+    assert
+      .dom('[data-test-toolbar="link"]')
+      .hasAttribute(
+        'aria-pressed',
+        'true',
+        'Link toggle reads active at a caret inside a link',
+      );
+    assert
+      .dom('[data-test-toolbar="bold"]')
+      .hasAttribute(
+        'aria-pressed',
+        'false',
+        'wrap toggles stay inactive at a caret',
+      );
+
+    // Caret outside the link
+    view!.dispatch({ selection: { anchor: 2, head: 2 } });
+    await settled();
+    assert
+      .dom('[data-test-toolbar="link"]')
+      .hasAttribute(
+        'aria-pressed',
+        'false',
+        'Link toggle deactivates once the caret leaves the link',
+      );
   });
 
   test('toolbar items are wrapped in tooltips whose hint is suppressed while the control is disabled', async function (assert) {

--- a/packages/host/tests/integration/components/rich-markdown-field-test.gts
+++ b/packages/host/tests/integration/components/rich-markdown-field-test.gts
@@ -1607,6 +1607,13 @@ module('Integration | RichMarkdownField', function (hooks) {
     assert
       .dom('[data-test-toolbar="bold"]')
       .isDisabled('Bold is disabled before the editor gains focus');
+    // The inline-format toggles wrap a selection, so they stay disabled with no
+    // focus (and, once focused, until text is highlighted — see the note above).
+    for (let testId of ['italic', 'strikethrough', 'code', 'link']) {
+      assert
+        .dom(`[data-test-toolbar="${testId}"]`)
+        .isDisabled(`${testId} is disabled before the editor gains focus`);
+    }
     assert
       .dom('[data-test-toolbar="blockquote"]')
       .isDisabled('all formatting controls start disabled');


### PR DESCRIPTION
## Background and Goal

In the markdown editor, triggering an inline format with **no text selected** (cursor merely placed in the field) inserted a stray empty marker pair — `**`/`*`/`~~`/`` ` `` via `wrapWith`, or `[](url)` via `toggleLink` — that stayed visible in both source and preview. Fixes [CS-11697](https://linear.app/cardstack/issue/CS-11697).

The defect had two layers, and both are fixed:

1. **Command layer** (`packages/host/app/lib/codemirror-context.ts`) — `wrapWith` and `toggleLink` inserted the empty marker pair whenever the selection was collapsed. This fired the same for the toolbar button *and* the `Mod-B`/`Mod-I`/`Mod-\`` keyboard shortcut, so it was wrong regardless of trigger. Both now do nothing (no dispatch) when nothing is selected. The keymap is untouched — the shortcut simply no-ops on a bare cursor instead of producing `****`. One exception is preserved: `toggleLink` still **unlinks** from a bare caret inside an existing `[text](url)` (its syntax-tree unlink branch runs before the collapsed-cursor check).
2. **Toolbar layer** (`packages/base/codemirror-editor.gts`) — the inline-format buttons (Bold, Italic, Strikethrough, Code, Link) now carry `requiresSelection: true` and disable until text is highlighted, so a click can't reach the command and the UI signals inapplicability. An **active** toggle stays clickable without a selection, since untoggling works at a bare caret — concretely, a caret inside a link marks the Link button pressed and keeps it enabled so it can unlink. The link-at-caret signal comes from `findEnclosingLink`, the same syntax-tree check `toggleLink`'s unlink branch uses, so button state can't drift from command behavior. Line-based buttons (headings, lists, blockquote) act on a bare cursor and stay enabled. `hasSelection` was added to `sameToolbarState` so the toolbar re-renders when the selection collapses/expands.

## Tests

- `codemirror-editor-test.gts` — rewrote the `wrapWith` empty-selection test to assert *no change*; added a `toggleLink` no-op test for a caret outside any link and an unlink test for a bare caret inside a link; the selection-based unlink test now calls the real `toggleLink` (it previously simulated the command with a string scan); added a selection-info test pinning `formats.link` at a caret inside vs. outside a link.
- `rich-markdown-field-test.gts` — extended the "controls start disabled" test to cover all five inline-format toggles, and added a test driving the live editor's caret into and out of a link to assert the Link button's `aria-pressed` wiring.

Note: the focused-*with*-selection → enabled transition can't be asserted in headless CI because `view.hasFocus` ANDs `document.hasFocus()` (pre-existing, documented limitation); the disabled side, the active-state wiring, and the command-level behavior are covered.

## Screen Recording

https://github.com/user-attachments/assets/93577fb3-fff7-4c6d-8978-20e9623fda7b



