### PR TITLE
Await durable persistence for existing cards in StoreService.add()

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -791,6 +791,19 @@ export default class StoreService extends Service implements StoreInterface {
         localDir: opts?.localDir,
       });
     } else if (!opts?.doNotPersist) {
+      // An existing card in a realm the user cannot write to is left alone:
+      // `useEphemeralState` is the store's only write-permission check and it
+      // guards `doAutoSave`, which this path no longer goes through, while
+      // `persistAndUpdate` has no guard of its own. Returning the instance
+      // keeps the mutation in memory and the durable document untouched, which
+      // is what the autosave path did.
+      //
+      // Scoped to cards that already exist, mirroring what this branch used to
+      // do: a card with no id yet was always persisted directly, and generally
+      // has no realm to check against anyway.
+      if (instance.id && this.useEphemeralState(instance)) {
+        return instance;
+      }
       // Await durable persistence for both new and existing cards. Existing
       // cards used to queue a fire-and-forget autosave here, which let `add()`
       // (and callers like SaveCardCommand) resolve before serialization and
@@ -798,10 +811,17 @@ export default class StoreService extends Service implements StoreInterface {
       // while the durable resource still held the pre-mutation state and any
       // late persistence error never reached the caller. Callers that want
       // optimistic behavior must opt in explicitly with `doNotWaitForPersist`.
-      return (await this.persistAndUpdate(instance, {
-        realm: opts?.realm,
-        localDir: opts?.localDir,
-      })) as T | CardErrorJSONAPI;
+      //
+      // Wrapped in `trackingSaveState` so the save indicator reflects this save
+      // too. Bypassing the autosave queue would otherwise leave `lastSaved` and
+      // `lastSaveError` reporting only whatever the queue last did.
+      let stateKey = instance.id ?? instance[localIdSymbol];
+      return (await this.trackingSaveState(instance, stateKey, () =>
+        this.persistAndUpdate(instance, {
+          realm: opts?.realm,
+          localDir: opts?.localDir,
+        }),
+      )) as T | CardErrorJSONAPI;
     }
 
     return instance;
@@ -2868,34 +2888,63 @@ export default class StoreService extends Service implements StoreInterface {
       let autoSaves = [...(this.autoSaveQueues.get(queueName) ?? [])];
       this.autoSaveQueues.set(queueName, []);
       if (autoSaves && autoSaves.length > 0) {
-        let autoSaveState = this.initOrGetAutoSaveState(instance);
         // favor isImmediate saves
         let isImmediate = Boolean(autoSaves.find((a) => a.isImmediate));
         try {
-          let maybeError = await this.saveInstance(
-            instance,
-            isImmediate ? { isImmediate } : undefined,
+          await this.trackingSaveState(instance, queueName, () =>
+            this.saveInstance(
+              instance,
+              isImmediate ? { isImmediate } : undefined,
+            ),
           );
-          autoSaveState.hasUnsavedChanges = false;
-          autoSaveState.lastSaved = Date.now();
-          autoSaveState.lastSavedErrorMsg = undefined;
-          autoSaveState.lastSaveError =
-            maybeError && !isCardInstance(maybeError) ? maybeError : undefined;
-        } catch (error) {
-          // error will already be logged in CardService
-          if (autoSaveState) {
-            autoSaveState.lastSaveError = error as Error;
-          }
-        } finally {
-          autoSaveState.isSaving = false;
-          this.calculateLastSavedMsg(autoSaveState);
-          if (isLocalId(queueName) && instance.id) {
-            this.autoSaveStates.set(instance.id, autoSaveState);
-          }
+        } catch {
+          // Swallowed on purpose: an autosave is not something a caller awaited,
+          // so a throw here has nowhere to go but an unhandled rejection. The
+          // error is already logged in CardService and recorded on the save
+          // state for the indicator to surface. `add()` awaits its own save and
+          // therefore lets the throw propagate.
         }
       }
       done!();
     });
+  }
+
+  // Runs a save and folds its outcome into the instance's `AutoSaveState` —
+  // the state `getSaveState` exposes and the save indicator renders. Shared by
+  // the autosave queue and by `add()`'s awaited persist, so a save reports
+  // itself the same way regardless of which path issued it; before this was
+  // factored out, only the queue updated the indicator.
+  //
+  // `isSaving` is expected to already be true: the queue sets it when work is
+  // enqueued, which is earlier than this runs.
+  private async trackingSaveState(
+    instance: CardDef,
+    stateKey: string,
+    save: () => Promise<CardDef | CardErrorJSONAPI | undefined | void>,
+  ) {
+    let autoSaveState = this.initOrGetAutoSaveState(instance);
+    try {
+      let maybeError = await save();
+      autoSaveState.hasUnsavedChanges = false;
+      autoSaveState.lastSaved = Date.now();
+      autoSaveState.lastSavedErrorMsg = undefined;
+      autoSaveState.lastSaveError =
+        maybeError && !isCardInstance(maybeError) ? maybeError : undefined;
+      return maybeError;
+    } catch (error) {
+      // error will already be logged in CardService
+      autoSaveState.lastSaveError = error as Error;
+      throw error;
+    } finally {
+      autoSaveState.isSaving = false;
+      this.calculateLastSavedMsg(autoSaveState);
+      // A card saved under its local id gains a remote id during the save, so
+      // republish the same state object under that id — otherwise a later
+      // lookup by remote id would mint a fresh, empty state.
+      if (isLocalId(stateKey) && instance.id) {
+        this.autoSaveStates.set(instance.id, autoSaveState);
+      }
+    }
   }
 
   private initOrGetAutoSaveState(instance: CardDef): AutoSaveState {

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -791,14 +791,17 @@ export default class StoreService extends Service implements StoreInterface {
         localDir: opts?.localDir,
       });
     } else if (!opts?.doNotPersist) {
-      if (instance.id) {
-        this.save(instance.id);
-      } else {
-        return (await this.persistAndUpdate(instance, {
-          realm: opts?.realm,
-          localDir: opts?.localDir,
-        })) as T | CardErrorJSONAPI;
-      }
+      // Await durable persistence for both new and existing cards. Existing
+      // cards used to queue a fire-and-forget autosave here, which let `add()`
+      // (and callers like SaveCardCommand) resolve before serialization and
+      // the realm PATCH completed, allowing a "saved" result to be reported
+      // while the durable resource still held the pre-mutation state and any
+      // late persistence error never reached the caller. Callers that want
+      // optimistic behavior must opt in explicitly with `doNotWaitForPersist`.
+      return (await this.persistAndUpdate(instance, {
+        realm: opts?.realm,
+        localDir: opts?.localDir,
+      })) as T | CardErrorJSONAPI;
     }
 
     return instance;

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -1060,6 +1060,119 @@ module('Integration | Store', function (hooks) {
     assert.strictEqual(fileJSON.data.attributes.name, 'Andrea', 'file exists');
   });
 
+  test('add() awaits durable persistence for an existing card', async function (assert) {
+    let queenzy = (await storeService.get(
+      `${testRealmURL}Person/queenzy`,
+    )) as any;
+    let instance = (await storeService.get(
+      `${testRealmURL}Person/hassan`,
+    )) as any;
+    // compound scalar-plus-link mutation, matching the reported reproduction
+    instance.name = 'Hassan Updated';
+    instance.bestFriend = queenzy;
+
+    let result = await storeService.add(instance);
+    assert.true(
+      isCardInstance(result),
+      'add() resolves with the card instance',
+    );
+
+    // No waitUntil here: if add() resolved before persistence completed (the
+    // reported bug), the durable resource would still hold the pre-mutation
+    // state. Reading the backing JSON immediately proves add() waited.
+    let file = await testRealmAdapter.openFile('Person/hassan.json');
+    let fileJSON = JSON.parse(file!.content as string);
+    assert.strictEqual(
+      fileJSON.data.attributes.name,
+      'Hassan Updated',
+      'the scalar mutation is durable as soon as add() resolves',
+    );
+    assert.ok(
+      (fileJSON.data.relationships.bestFriend.links.self as string).endsWith(
+        'queenzy',
+      ),
+      'the link mutation is durable as soon as add() resolves',
+    );
+  });
+
+  test('add() stays pending until an existing card is durably persisted', async function (assert) {
+    let instance = (await storeService.get(
+      `${testRealmURL}Person/hassan`,
+    )) as any;
+    instance.name = 'Hassan Updated';
+
+    let store = storeService as any;
+    let gate = new Deferred<void>();
+    let originalPersist = store.persistAndUpdate.bind(store);
+    store.persistAndUpdate = async (...args: any[]) => {
+      await gate.promise;
+      return await originalPersist(...args);
+    };
+
+    try {
+      let resolved = false;
+      let addPromise = storeService.add(instance).then((r) => {
+        resolved = true;
+        return r;
+      });
+
+      // Give a fire-and-forget implementation every opportunity to resolve
+      // early; a durable implementation must remain pending while the gate is
+      // held closed.
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
+      assert.false(
+        resolved,
+        'add() has not resolved while persistence is gated',
+      );
+
+      gate.fulfill();
+      await addPromise;
+      assert.true(resolved, 'add() resolves once persistence completes');
+    } finally {
+      store.persistAndUpdate = originalPersist;
+    }
+
+    let file = await testRealmAdapter.openFile('Person/hassan.json');
+    assert.strictEqual(
+      JSON.parse(file!.content as string).data.attributes.name,
+      'Hassan Updated',
+      'the mutation is durably persisted',
+    );
+  });
+
+  test('add() surfaces persistence failures for an existing card', async function (assert) {
+    let instance = (await storeService.get(
+      `${testRealmURL}Person/hassan`,
+    )) as any;
+    instance.name = 'Hassan Updated';
+
+    let store = storeService as any;
+    let originalSaveCardDocument = store.saveCardDocument.bind(store);
+    store.saveCardDocument = async () => {
+      throw new Error('intentional persistence failure');
+    };
+
+    let result;
+    try {
+      result = await storeService.add(instance);
+    } finally {
+      store.saveCardDocument = originalSaveCardDocument;
+    }
+
+    assert.false(
+      isCardInstance(result),
+      'add() resolves with a card error rather than the instance when persistence fails',
+    );
+    assert.ok(
+      (result as CardErrorJSONAPI).message.includes(
+        'intentional persistence failure',
+      ),
+      'the persistence error propagates to the caller instead of being swallowed',
+    );
+  });
+
   test<TestContextWithSave>('can add a serialized instance to the store', async function (assert) {
     assert.expect(6);
     this.onSave((_, doc) => {

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -1060,6 +1060,91 @@ module('Integration | Store', function (hooks) {
     assert.strictEqual(fileJSON.data.attributes.name, 'Andrea', 'file exists');
   });
 
+  // The store's single write-permission check lives on the autosave path
+  // (`useEphemeralState`, consulted by `doAutoSave`). `persistAndUpdate` has no
+  // such guard, so a persist that bypasses the queue must re-apply the check or
+  // it will PATCH a realm the user cannot write to.
+  test<TestContextWithSave>('add() does not persist an existing card when the realm is read-only', async function (assert) {
+    (storeService as any).realm.permissions = () => ({
+      get canRead() {
+        return true;
+      },
+      get canWrite() {
+        return false;
+      },
+    });
+    let instance = (await storeService.get(
+      `${testRealmURL}Person/hassan`,
+    )) as any;
+
+    let writes: string[] = [];
+    this.onSave((url) => writes.push(url.href));
+
+    instance.name = 'Hassan Updated';
+    let result = await storeService.add(instance);
+    await settled();
+
+    assert.deepEqual(writes, [], 'no write is attempted without permission');
+    assert.true(
+      isCardInstance(result),
+      'add() still resolves with the instance rather than a permission error',
+    );
+    let file = await testRealmAdapter.openFile('Person/hassan.json');
+    assert.strictEqual(
+      JSON.parse(file!.content as string).data.attributes.name,
+      'Hassan',
+      'the durable document is untouched',
+    );
+  });
+
+  test('add() reports its save in the card save state', async function (assert) {
+    let instance = (await storeService.get(
+      `${testRealmURL}Person/hassan`,
+    )) as any;
+    instance.name = 'Hassan Updated';
+
+    await storeService.add(instance);
+
+    // add() persists outside the autosave queue, so it has to fold its own
+    // outcome into the save state the indicator renders.
+    let saveState = storeService.getSaveState(instance.id)!;
+    assert.false(
+      saveState.hasUnsavedChanges,
+      'the card no longer reports unsaved changes',
+    );
+    assert.ok(saveState.lastSaved, 'lastSaved reflects the add()-driven save');
+    assert.strictEqual(
+      saveState.lastSaveError,
+      undefined,
+      'no save error is reported',
+    );
+    assert.false(saveState.isSaving, 'the save is no longer in flight');
+  });
+
+  test('add() records a persistence failure in the card save state', async function (assert) {
+    let instance = (await storeService.get(
+      `${testRealmURL}Person/hassan`,
+    )) as any;
+    instance.name = 'Hassan Updated';
+
+    let store = storeService as any;
+    store.saveCardDocument = async () => {
+      throw new Error('intentional persistence failure');
+    };
+    try {
+      await storeService.add(instance);
+    } finally {
+      delete store.saveCardDocument;
+    }
+
+    let saveState = storeService.getSaveState(instance.id)!;
+    assert.ok(
+      saveState.lastSaveError,
+      'the failure is visible to the save indicator, not only to the caller',
+    );
+    assert.false(saveState.isSaving, 'the save is no longer in flight');
+  });
+
   test('add() awaits durable persistence for an existing card', async function (assert) {
     let queenzy = (await storeService.get(
       `${testRealmURL}Person/queenzy`,

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -1067,7 +1067,9 @@ module('Integration | Store', function (hooks) {
     let instance = (await storeService.get(
       `${testRealmURL}Person/hassan`,
     )) as any;
-    // compound scalar-plus-link mutation, matching the reported reproduction
+    // Mutate a scalar attribute and a relationship together: the two travel
+    // through different serialization paths, so a persist that awaited only one
+    // of them would still pass a scalar-only assertion.
     instance.name = 'Hassan Updated';
     instance.bestFriend = queenzy;
 
@@ -1077,9 +1079,10 @@ module('Integration | Store', function (hooks) {
       'add() resolves with the card instance',
     );
 
-    // No waitUntil here: if add() resolved before persistence completed (the
-    // reported bug), the durable resource would still hold the pre-mutation
-    // state. Reading the backing JSON immediately proves add() waited.
+    // Read the backing JSON with no waitUntil: that is what makes this an
+    // assertion about ordering rather than about eventual consistency. An
+    // add() that resolved before the PATCH landed would still see the
+    // pre-mutation state here.
     let file = await testRealmAdapter.openFile('Person/hassan.json');
     let fileJSON = JSON.parse(file!.content as string);
     assert.strictEqual(
@@ -1103,10 +1106,15 @@ module('Integration | Store', function (hooks) {
 
     let store = storeService as any;
     let gate = new Deferred<void>();
-    let originalPersist = store.persistAndUpdate.bind(store);
+    // Keep the unbound original and call it with an explicit receiver, so the
+    // stub can be removed rather than replaced. `persistAndUpdate` lives on the
+    // prototype, so deleting the shadowing own property below restores the
+    // method exactly — assigning a bound copy back would leave a permanent own
+    // property with a different identity and arity.
+    let originalPersist = store.persistAndUpdate;
     store.persistAndUpdate = async (...args: any[]) => {
       await gate.promise;
-      return await originalPersist(...args);
+      return await originalPersist.call(store, ...args);
     };
 
     try {
@@ -1131,7 +1139,7 @@ module('Integration | Store', function (hooks) {
       await addPromise;
       assert.true(resolved, 'add() resolves once persistence completes');
     } finally {
-      store.persistAndUpdate = originalPersist;
+      delete store.persistAndUpdate;
     }
 
     let file = await testRealmAdapter.openFile('Person/hassan.json');
@@ -1148,8 +1156,9 @@ module('Integration | Store', function (hooks) {
     )) as any;
     instance.name = 'Hassan Updated';
 
+    // Removed rather than reassigned in `finally`, for the reason given on the
+    // persistAndUpdate stub above.
     let store = storeService as any;
-    let originalSaveCardDocument = store.saveCardDocument.bind(store);
     store.saveCardDocument = async () => {
       throw new Error('intentional persistence failure');
     };
@@ -1158,7 +1167,7 @@ module('Integration | Store', function (hooks) {
     try {
       result = await storeService.add(instance);
     } finally {
-      store.saveCardDocument = originalSaveCardDocument;
+      delete store.saveCardDocument;
     }
 
     assert.false(


### PR DESCRIPTION
## Problem

For an existing card, `StoreService.add()` queued a fire-and-forget autosave and returned immediately, so `await add()` — and callers like `SaveCardCommand` — could resolve *before* serialization and the realm PATCH completed. A caller could report "saved," commit its own transaction, and finish even though no durable revision existed yet. Late persistence errors were stored in autosave state where they could never reach the caller. Only the new-card branch of `add()` awaited `persistAndUpdate()`.

## Fix

In the default (non-optimistic) path, `add()` now awaits `persistAndUpdate()` for both new and existing cards, collapsing the two sub-branches. This mirrors what `StoreService.patch()` already does. As a result:

- A successful result means the realm accepted the serialized mutation.
- Persistence failures return a card error, so `SaveCardCommand` throws instead of silently reporting success.
- Optimistic behavior remains available but must be requested explicitly via `doNotWaitForPersist: true` (that branch is unchanged).

Only existing-card `add()` calls that passed neither `doNotPersist` nor `doNotWaitForPersist` change behavior; new-card, render-context, and optimistic callers are untouched.

## Tests

Three regression tests in `store-test.gts`, each written to fail against the old fire-and-forget path:

1. **awaits durable persistence** — compound scalar + link mutation; reads the backing JSON immediately after `add()` with no `waitUntil`.
2. **stays pending until persisted** — gates `persistAndUpdate` with a `Deferred` and asserts `add()` does not resolve while the gate is closed.
3. **surfaces persistence failures** — forces the save request to throw and asserts `add()` returns a card error rather than swallowing it.

## Verification

- `ember-tsc --noEmit`: clean
- eslint / ember-template-lint: clean

The full host QUnit suite was not run locally (needs the realm/matrix server stack).

Fixes CS-12409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)