### PR TITLE
Guard default card/field templates against a transiently undefined model

### DIFF
--- a/packages/base/default-templates/field-edit.gts
+++ b/packages/base/default-templates/field-edit.gts
@@ -1,5 +1,5 @@
 import GlimmerComponent from '@glimmer/component';
-import type { FieldDef } from '../card-api';
+import type { BaseDef, FieldDef } from '../card-api';
 import { FieldContainer } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 import { startCase } from 'lodash-es';
@@ -7,12 +7,17 @@ import { getField } from '@cardstack/runtime-common';
 
 export default class FieldDefEditTemplate extends GlimmerComponent<{
   Args: {
+    cardOrField: typeof BaseDef;
     model: FieldDef;
     fields: Record<string, new () => GlimmerComponent>;
   };
 }> {
   getFieldIcon = (key: string) => {
-    return getField(this.args.model.constructor, key)?.card?.icon;
+    // Read the field off the field class (@cardOrField), not
+    // @model.constructor: the host can invoke this template for a tick while
+    // the model instance is still resolving, and dereferencing the undefined
+    // model there crashes the render.
+    return getField(this.args.cardOrField, key)?.card?.icon;
   };
   <template>
     <div class='field-def-edit-template'>

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -79,7 +79,7 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
               @cardTitle={{@model.cardTitle}}
               @cardDescription={{@model.cardDescription}}
               @cardThumbnailURL={{@model.cardThumbnailURL}}
-              @icon={{@model.constructor.icon}}
+              @icon={{@cardOrField.icon}}
             />
           {{else if @fields.cardInfo}}
             <CardInfoTemplates.edit

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -1,5 +1,5 @@
 import GlimmerComponent from '@glimmer/component';
-import type { CardDef, FieldsTypeFor, Format } from '../card-api';
+import type { BaseDef, CardDef, FieldsTypeFor, Format } from '../card-api';
 import { FieldContainer, Header } from '@cardstack/boxel-ui/components';
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
 import { startCase } from 'lodash-es';
@@ -12,6 +12,7 @@ import CardInfoTemplates from './card-info';
 
 export default class DefaultCardDefTemplate extends GlimmerComponent<{
   Args: {
+    cardOrField: typeof BaseDef;
     model: CardDef;
     fields: FieldsTypeFor<CardDef>;
     format: Format;
@@ -29,7 +30,12 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
   // then display its edit format alongside other top-level fields.
   private get cardInfoFieldDisplayNames(): string[] | undefined {
     let fieldNames = this.standardComputedFields.filter((fieldName) => {
-      const field = getField(this.args.model.constructor, fieldName);
+      // Read the field off the card class (@cardOrField), not
+      // @model.constructor: the host can invoke this template for a tick while
+      // the model instance is still resolving (initial load, or a store
+      // re-resolve when an incremental index invalidation lands under an open
+      // card), and dereferencing the undefined model there crashes the render.
+      const field = getField(this.args.cardOrField, fieldName);
       return field?.computeVia == undefined;
     });
 
@@ -38,6 +44,9 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
 
   // Fields to display in between the cardInfo header and notes footer
   private get displayFields(): FieldsTypeFor<CardDef> | undefined {
+    if (!this.args.fields) {
+      return undefined;
+    }
     let excludedFields = this.excludedFields.filter(
       (name) => !this.cardInfoFieldDisplayNames?.includes(name),
     );
@@ -52,7 +61,9 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
 
   private get isThemeCard() {
     return Boolean(
-      Object.entries(this.args.fields).find(([key]) => key === 'cssVariables'),
+      Object.entries(this.args.fields ?? {}).find(
+        ([key]) => key === 'cssVariables',
+      ),
     );
   }
 
@@ -70,7 +81,7 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
               @cardThumbnailURL={{@model.cardThumbnailURL}}
               @icon={{@model.constructor.icon}}
             />
-          {{else}}
+          {{else if @fields.cardInfo}}
             <CardInfoTemplates.edit
               @fields={{@fields}}
               @model={{@model}}
@@ -91,15 +102,17 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
             {{/each-in}}
           </section>
         {{/if}}
-        <footer class='notes-footer'>
-          <FieldContainer
-            @label='Notes'
-            @icon={{getFieldIcon @model.cardInfo 'notes'}}
-            data-test-field='cardInfo-notes'
-          >
-            <@fields.cardInfo.notes />
-          </FieldContainer>
-        </footer>
+        {{#if @fields.cardInfo.notes}}
+          <footer class='notes-footer'>
+            <FieldContainer
+              @label='Notes'
+              @icon={{getFieldIcon @model.cardInfo 'notes'}}
+              data-test-field='cardInfo-notes'
+            >
+              <@fields.cardInfo.notes />
+            </FieldContainer>
+          </footer>
+        {{/if}}
       </div>
     </div>
     <style scoped>


### PR DESCRIPTION
## Problem

The production host intermittently crashes while rendering a card:

```
TypeError: Cannot read properties of undefined (reading 'constructor')
    at get cardInfoFieldDisplayNames (.../default-templates/isolated-and-edit)
    at get displayFields (.../default-templates/isolated-and-edit)
```

The default isolated/edit and field-edit templates derive the card/field class from `this.args.model.constructor` inside tracked getters, and dereference `this.args.fields` unguarded. The host can invoke a format component for a tick while the model instance is still resolving — on initial load, and on a store re-resolve when an incremental index invalidation lands under an open card — so the first tracked getter throws and takes down the render. Glimmer templates are null-safe on undefined paths; JS getters are not.

## Fix

Read the field definitions off the card/field **class** instead of the model instance. The render path already threads the class in as `@cardOrField` — a stable value independent of the model: `getBoxComponent` receives it, `field-component.gts` passes it to every `CardOrFieldFormatComponent`, and `BaseDefComponent` already declares it in its `Args`. `getField()` accepts a class directly, so `getField(this.args.cardOrField, …)` is a drop-in for `getField(this.args.model.constructor, …)` that never touches the transient model.

The `@fields`-dependent paths are guarded too:

- `displayFields` returns early when `@fields` is absent
- `isThemeCard` coalesces to `{}`
- the CardInfo edit header renders only when `@fields.cardInfo` exists
- the notes footer is wrapped in `{{#if @fields.cardInfo.notes}}` — invoking `<@fields.cardInfo.notes />` with undefined `@fields` throws "attempted to invoke undefined component"

Behavior is unchanged when the model and fields are present.

This supersedes the earlier #5608, which was closed because it was authored alongside unrelated userland work; this reapplies the `@cardOrField` approach cleanly on current `main`.

## Notes

- `atom.gts` has the same `model.constructor` shape but already guards with an early `if (!this.args.model) return;`, so it is not vulnerable and is left unchanged.
- The crash is a transient-resolution race that only reproduces under live invalidation in production, so there is no deterministic unit test for the timing window (the tracking issue's own render-suite investigation reached the same conclusion). Verified via `ember-template-lint` (clean) and host `lint:types` (no errors); behavior-preserving for the normal load path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)