### PR TITLE
Show the Home Browse pills by default on Workspace

### DIFF
--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -2909,8 +2909,9 @@ class Isolated extends Component<typeof Workspace> {
   // Settings gates. About and Browse show by default and are opt-out: an unset
   // `hideAbout`/`hideBrowse` (BooleanField `emptyValue` is `false`) reads as
   // "not hidden", so both surfaces appear until the administrator turns them
-  // off. (A "default-on" `showAbout`/`showBrowse` boolean could not express
-  // this — unset and explicit-off would both read as `false`.)
+  // off. The negative naming is load-bearing, not a style choice — a
+  // `show`-prefixed boolean cannot express a default-on setting here, because
+  // an unset field and an explicitly-disabled one both read as `false`.
   private get aboutVisible() {
     return Boolean(this.args.model.readme) && !this.args.model.hideAbout;
   }

--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -674,7 +674,7 @@ class Isolated extends Component<typeof Workspace> {
               {{/if}}
             {{else if (eq mod 'browse')}}
               {{#if this.browseVisible}}
-                <section class='zone'>
+                <section class='zone' data-test-browse>
                   <div class='section-head'>
                     <h2 class='section-title'>Browse</h2>
                     <p class='section-hint'>All cards and files in this space.</p>
@@ -688,6 +688,7 @@ class Isolated extends Component<typeof Workspace> {
                             <button
                               type='button'
                               class='type-chip'
+                              data-test-type-chip={{option.id}}
                               {{on 'click' (this.jumpToFilter option)}}
                             >
                               {{#if (this.iconHtml option)}}
@@ -696,9 +697,10 @@ class Isolated extends Component<typeof Workspace> {
                                   }}</span>
                               {{/if}}
                               {{option.displayName}}
-                              <span class='type-chip-count'>{{this.countFor
-                                  option
-                                }}</span>
+                              <span
+                                class='type-chip-count'
+                                data-test-type-chip-count
+                              >{{this.countFor option}}</span>
                             </button>
                           {{/each}}
                         </div>
@@ -712,6 +714,7 @@ class Isolated extends Component<typeof Workspace> {
                             <button
                               type='button'
                               class='type-chip'
+                              data-test-type-chip={{option.id}}
                               {{on 'click' (this.jumpToFilter option)}}
                             >
                               {{#if (this.iconHtml option)}}
@@ -720,9 +723,10 @@ class Isolated extends Component<typeof Workspace> {
                                   }}</span>
                               {{/if}}
                               {{option.displayName}}
-                              <span class='type-chip-count'>{{this.countFor
-                                  option
-                                }}</span>
+                              <span
+                                class='type-chip-count'
+                                data-test-type-chip-count
+                              >{{this.countFor option}}</span>
                             </button>
                           {{/each}}
                         </div>
@@ -2902,15 +2906,17 @@ class Isolated extends Component<typeof Workspace> {
     return htmlSafe(`--door-h: ${height}px`);
   }
 
-  // settings gates: unset booleans read as their defaults
+  // Settings gates. About and Browse show by default and are opt-out: an unset
+  // `hideAbout`/`hideBrowse` (BooleanField `emptyValue` is `false`) reads as
+  // "not hidden", so both surfaces appear until the administrator turns them
+  // off. (A "default-on" `showAbout`/`showBrowse` boolean could not express
+  // this — unset and explicit-off would both read as `false`.)
   private get aboutVisible() {
-    return (
-      Boolean(this.args.model.readme) && this.args.model.showReadme !== false
-    );
+    return Boolean(this.args.model.readme) && !this.args.model.hideAbout;
   }
 
   private get browseVisible() {
-    return this.hasInventory && this.args.model.showBrowse !== false;
+    return this.hasInventory && !this.args.model.hideBrowse;
   }
 
   @tracked private latest: { title: string; when?: string } | undefined;
@@ -3904,19 +3910,20 @@ export class Workspace extends CardDef {
             </div>
             <div class='setting'>
               <div class='setting-text'>
-                <span class='setting-label'>Show About</span>
-                <p class='setting-help'>Keep the About section visible below the
-                  pins. Turn off to keep Home to cards only.</p>
+                <span class='setting-label'>Hide About</span>
+                <p class='setting-help'>The About section shows below the pins by
+                  default. Turn on to keep Home to cards only.</p>
               </div>
-              <div class='setting-control'><@fields.showReadme /></div>
+              <div class='setting-control'><@fields.hideAbout /></div>
             </div>
             <div class='setting'>
               <div class='setting-text'>
-                <span class='setting-label'>Show Browse</span>
-                <p class='setting-help'>The inventory of card and file types,
-                  with counts, linking into the Library.</p>
+                <span class='setting-label'>Hide Browse</span>
+                <p class='setting-help'>Browse shows the inventory of card and
+                  file types, with counts, linking into the Library. Turn on to
+                  hide it.</p>
               </div>
-              <div class='setting-control'><@fields.showBrowse /></div>
+              <div class='setting-control'><@fields.hideBrowse /></div>
             </div>
             <div class='setting stack'>
               <div class='setting-text'>
@@ -4392,11 +4399,12 @@ export class Workspace extends CardDef {
 
   @field entryPoints = linksToMany(CardDef);
   @field readme = linksTo(MarkdownDef); // realm README shown on Home
-  // settings — every field wires to live behavior. Booleans
-  // read unset as their default (showReadme/showBrowse default ON,
-  // searchIncludesSystem defaults OFF).
-  @field showReadme = contains(BooleanField);
-  @field showBrowse = contains(BooleanField);
+  // settings — every field wires to live behavior. Booleans read unset as
+  // `false` (BooleanField `emptyValue`), so each is framed to make that the
+  // intended default: About and Browse are opt-out (hide*, default shown),
+  // system cards in search are opt-in (searchIncludesSystem, default off).
+  @field hideAbout = contains(BooleanField);
+  @field hideBrowse = contains(BooleanField);
   @field searchIncludesSystem = contains(BooleanField);
   @field defaultView = contains(StringField); // 'grid' | 'strip'
   @field workspace = linksTo(CardDef); // the realm's config card

--- a/packages/host/tests/acceptance/workspace-test.gts
+++ b/packages/host/tests/acceptance/workspace-test.gts
@@ -99,6 +99,75 @@ module('Acceptance | workspace card', function (hooks) {
     assert.dom(`${STACK} .activity-pane`).exists('Activity pane renders');
   });
 
+  // The Home "Browse" module renders one pill per realm card/file type with
+  // that type's instance count, and clicking a pill opens the Library filtered
+  // to that type. It only renders once `_types` has reported inventory, so it
+  // needs a realm with real indexed instances — hence acceptance, not the bare
+  // isolated-render integration tests.
+  test('Home Browse lists a pill per card type with its instance count', async function (assert) {
+    await visit('/');
+    await click('[data-test-workspace-button="Unnamed Workspace"]');
+    await waitFor(`${STACK} nav.tabs`);
+
+    await waitFor(`${STACK} [data-test-browse]`);
+    assert
+      .dom(`${STACK} [data-test-browse]`)
+      .exists(
+        'the Home Browse module renders once the realm reports inventory',
+      );
+
+    let noteChip = [
+      ...document.querySelectorAll(`${STACK} [data-test-type-chip]`),
+    ].find((el) => el.textContent?.includes('Note')) as HTMLElement | undefined;
+    assert.ok(noteChip, 'a pill for the Note card type is present');
+    assert
+      .dom(noteChip!.querySelector('[data-test-type-chip-count]'))
+      .hasText('1', 'the Note pill shows its single-instance count');
+  });
+
+  test('clicking a Home Browse pill opens the Library filtered to that type', async function (assert) {
+    await visit('/');
+    await click('[data-test-workspace-button="Unnamed Workspace"]');
+    await waitFor(`${STACK} [data-test-browse]`);
+
+    let noteChip = [
+      ...document.querySelectorAll(`${STACK} [data-test-type-chip]`),
+    ].find((el) => el.textContent?.includes('Note')) as HTMLElement | undefined;
+    let noteTypeId = noteChip!.getAttribute('data-test-type-chip');
+
+    await click(noteChip!);
+
+    assert
+      .dom(`${STACK} nav.tabs .tab.active`)
+      .hasText('Library', 'the pill switches to the Library segment');
+    assert
+      .dom(`${STACK} [data-test-workspace-filter="${noteTypeId}"]`)
+      .hasClass(
+        'selected',
+        'the Library opens with the clicked type pre-selected',
+      );
+  });
+
+  // The Library rail lists a row per realm card type (sourced from the same
+  // `_types` inventory that feeds the Home pills), each with its instance count
+  // — not just the base Everything / Cards / Files filters.
+  test('the Library rail lists a row per card type with its count', async function (assert) {
+    await visit('/');
+    await click('[data-test-workspace-button="Unnamed Workspace"]');
+    await waitFor(`${STACK} nav.tabs`);
+
+    await click(`${STACK} nav.tabs .tab:nth-child(2)`); // Library
+    await waitFor(`${STACK} .rail-group`);
+
+    let noteRow = [
+      ...document.querySelectorAll(`${STACK} .rail-row.type`),
+    ].find((el) => el.textContent?.includes('Note')) as HTMLElement | undefined;
+    assert.ok(noteRow, 'the Library rail lists a Note card-type row');
+    assert
+      .dom(noteRow!.querySelector('.rail-count'))
+      .hasText('1', 'the Note rail row shows its single-instance count');
+  });
+
   test('a remix surfaces in the Activity feed as a first-class event', async function (assert) {
     await visit('/');
     await click('[data-test-workspace-button="Unnamed Workspace"]');

--- a/packages/host/tests/acceptance/workspace-test.gts
+++ b/packages/host/tests/acceptance/workspace-test.gts
@@ -99,6 +99,21 @@ module('Acceptance | workspace card', function (hooks) {
     assert.dom(`${STACK} .activity-pane`).exists('Activity pane renders');
   });
 
+  // Pills are matched by their visible label rather than by index, since the
+  // order of `_types` inventory isn't part of the contract. Asserts and then
+  // throws on a miss so a fixture that stops producing the type fails as a
+  // named assertion instead of a null dereference further down.
+  function findTypeChip(assert: Assert, label: string): HTMLElement {
+    let chip = [
+      ...document.querySelectorAll(`${STACK} [data-test-type-chip]`),
+    ].find((el) => el.textContent?.includes(label));
+    assert.ok(chip, `a pill for the ${label} card type is present`);
+    if (!(chip instanceof HTMLElement)) {
+      throw new Error(`no Browse pill labelled "${label}" was rendered`);
+    }
+    return chip;
+  }
+
   // The Home "Browse" module renders one pill per realm card/file type with
   // that type's instance count, and clicking a pill opens the Library filtered
   // to that type. It only renders once `_types` has reported inventory, so it
@@ -116,12 +131,9 @@ module('Acceptance | workspace card', function (hooks) {
         'the Home Browse module renders once the realm reports inventory',
       );
 
-    let noteChip = [
-      ...document.querySelectorAll(`${STACK} [data-test-type-chip]`),
-    ].find((el) => el.textContent?.includes('Note')) as HTMLElement | undefined;
-    assert.ok(noteChip, 'a pill for the Note card type is present');
+    let noteChip = findTypeChip(assert, 'Note');
     assert
-      .dom(noteChip!.querySelector('[data-test-type-chip-count]'))
+      .dom(noteChip.querySelector('[data-test-type-chip-count]'))
       .hasText('1', 'the Note pill shows its single-instance count');
   });
 
@@ -130,12 +142,14 @@ module('Acceptance | workspace card', function (hooks) {
     await click('[data-test-workspace-button="Unnamed Workspace"]');
     await waitFor(`${STACK} [data-test-browse]`);
 
-    let noteChip = [
-      ...document.querySelectorAll(`${STACK} [data-test-type-chip]`),
-    ].find((el) => el.textContent?.includes('Note')) as HTMLElement | undefined;
-    let noteTypeId = noteChip!.getAttribute('data-test-type-chip');
+    let noteChip = findTypeChip(assert, 'Note');
+    let noteTypeId = noteChip.getAttribute('data-test-type-chip');
+    // Without this the filter selector below interpolates to
+    // `[data-test-workspace-filter="null"]` and reports a missing element
+    // rather than a pill that carries no type id.
+    assert.ok(noteTypeId, 'the Note pill carries the type id it filters on');
 
-    await click(noteChip!);
+    await click(noteChip);
 
     assert
       .dom(`${STACK} nav.tabs .tab.active`)

--- a/packages/host/tests/integration/components/workspace-test.gts
+++ b/packages/host/tests/integration/components/workspace-test.gts
@@ -38,6 +38,22 @@ module('Integration | Card | workspace', function (hooks) {
       .hasText('Home', 'Home is the default active segment');
   });
 
+  // The Home "Browse" module is gated on `hasInventory`: with no realm bound
+  // (and thus no `_types` inventory) it must stay hidden rather than render an
+  // empty shell. The populated case — one pill per card type with counts — is
+  // covered in the acceptance suite, which has a real indexed realm.
+  test('Home omits the Browse module when the realm has no inventory', async function (assert) {
+    let card = new Workspace({});
+    await renderCard(loader, card, 'isolated');
+
+    assert
+      .dom('nav.tabs .tab.active')
+      .hasText('Home', 'Home is the active segment');
+    assert
+      .dom('[data-test-browse]')
+      .doesNotExist('Browse stays hidden until the realm reports inventory');
+  });
+
   test('edit format renders workspace settings', async function (assert) {
     let card = new Workspace({});
     await renderCard(loader, card, 'edit');


### PR DESCRIPTION
## Problem

The Workspace Home tab has a **Browse** module — a pill per realm card/file type showing that type's instance count, each linking into the Library filtered to that type (ported from Chris's POC). It never rendered for anyone.

## Root cause

`browseVisible` gated on `this.args.model.showBrowse !== false`, written for a *default-on, opt-out* setting. But `BooleanField`'s `emptyValue` is `false`, so an **unset** `showBrowse` resolves to `false`, not `undefined`. A plain boolean can't distinguish "never set" from "explicitly off" — both read as `false` — so the gate was never satisfied and Browse stayed hidden on every workspace regardless of inventory. The Home **About** section (`showReadme`) had the identical latent bug.

Confirmed at runtime: with a realm containing indexed instances, `hasInventory=true` and the pill data was fully populated, yet `showBrowse=false` (unset) forced `browseVisible=false`.

## Fix

Reframe both surfaces as **opt-out** fields — `hideBrowse` / `hideAbout`, default `false` = shown — so the unset default is correct and the Settings toggles turn each surface off. `searchIncludesSystem` is unchanged (it's genuinely opt-in, so its default-off already matched the boolean's empty value).

## Tests

Added test hooks (`data-test-browse`, `data-test-type-chip`, `data-test-type-chip-count`) and coverage that was entirely missing for this feature:

- **Acceptance** — Home Browse renders a pill per card type with its instance count
- **Acceptance** — clicking a Browse pill opens the Library pre-filtered to that type
- **Acceptance** — the Library rail lists a per-card-type row with its count
- **Integration** — Home omits the Browse module when the realm reports no inventory

Verified locally against the running stack: acceptance workspace suite 6/6 (18/18 assertions), integration workspace suite 37/37 (71/71 assertions).

## Note

Field rename is a schema change but needs no migration: the default flips to "shown" (the intent), and since Browse was effectively always hidden before, no existing workspace could have relied on the old `showBrowse` value.