### PR TITLE
host: Fix `realmOf` to handle prefix RRIs

### DIFF
--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -1585,7 +1585,13 @@ export default class Workspace extends Component<Signature> {
     this.archiveError = undefined;
 
     try {
-      let realmPath = new RealmPaths(this.args.realmIdentifier);
+      // The VN lets this match a prefix-form card id against a URL-form realm
+      // identifier (or vice versa); without it an open card in a mapped realm
+      // never reads as belonging to this workspace.
+      let realmPath = new RealmPaths(
+        this.args.realmIdentifier,
+        this.network.virtualNetwork,
+      );
       let isActiveWorkspace =
         this.operatorModeStateService.realmURL === this.args.realmIdentifier ||
         this.operatorModeStateService
@@ -1693,7 +1699,13 @@ export default class Workspace extends Component<Signature> {
     this.deleteError = undefined;
 
     try {
-      let realmPath = new RealmPaths(this.args.realmIdentifier);
+      // The VN lets this match a prefix-form card id against a URL-form realm
+      // identifier (or vice versa); without it an open card in a mapped realm
+      // never reads as belonging to this workspace.
+      let realmPath = new RealmPaths(
+        this.args.realmIdentifier,
+        this.network.virtualNetwork,
+      );
       let isActiveWorkspace =
         this.operatorModeStateService.realmURL === this.args.realmIdentifier ||
         this.operatorModeStateService

--- a/packages/host/app/resources/search-entries.ts
+++ b/packages/host/app/resources/search-entries.ts
@@ -726,9 +726,13 @@ export class SearchEntriesResource extends Resource<Args> {
       }
     }
 
-    // One RealmPaths per searched realm per build — not per entry.
+    // One RealmPaths per searched realm per build — not per entry. Each needs
+    // the VN: an entry's id is prefix form for a mapped realm while the realms
+    // are URL-form, and RealmPaths only compares across those forms when it can
+    // normalize with the VN. Without it no realm ever claims the id and the
+    // fallback below returns the entry's own url as if it were a realm url.
     let realmPaths = this.realmsToSearch.map(
-      (realm) => new RealmPaths(new URL(realm)),
+      (realm) => new RealmPaths(new URL(realm), this.network.virtualNetwork),
     );
     let realmUrlFor = (id: string): string => {
       let idRRI = rri(id);

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -641,7 +641,11 @@ export class SearchResource<
 
   private isInTargetRealm(id: RealmResourceIdentifier): boolean {
     return this.realmsToSearch.some((realm) =>
-      new RealmPaths(realm).inRealm(id),
+      // The VN is required, not optional: an instance in a mapped realm has a
+      // prefix-form id while the realms are URL-form, and RealmPaths only
+      // compares across those forms when it can normalize with the VN.
+      // Without it every such instance reads as outside the target realm.
+      new RealmPaths(realm, this.network.virtualNetwork).inRealm(id),
     );
   }
 
@@ -649,7 +653,10 @@ export class SearchResource<
   get instancesByRealm() {
     return this.realmsToSearch
       .map((realm) => {
-        let realmPath = new RealmPaths(realm);
+        // Same cross-form requirement as isInTargetRealm: `card.id` is prefix
+        // form for a mapped realm, so without the VN no card is ever grouped
+        // under its realm and the group is dropped as empty.
+        let realmPath = new RealmPaths(realm, this.network.virtualNetwork);
         let cards = this.instances.filter((card) => realmPath.inRealm(card.id));
         return { realm, cards };
       })

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -404,7 +404,13 @@ export default class OperatorModeStateService extends Service {
     for (let item of items) {
       this.trimItemsFromStack(item);
     }
-    let realmPaths = new RealmPaths(new URL(cardRealmUrl));
+    // The VN is required here: `local` throws when the id doesn't read as
+    // inside the realm, and a mapped realm's card id is prefix form against a
+    // URL-form realm — a comparison RealmPaths can only make with the VN.
+    let realmPaths = new RealmPaths(
+      new URL(cardRealmUrl),
+      this.network.virtualNetwork,
+    );
     let cardPath = realmPaths.local(rri(`${cardId}.json`));
     this.recentFilesService.removeRecentFile(cardPath);
     this.recentCardsService.remove(cardId);

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -1057,7 +1057,13 @@ export default class RealmService extends Service {
     for (const realm of this.realms.keys()) {
       let paths = this.realmPathsCache.get(realm);
       if (!paths) {
-        paths = new RealmPaths(new URL(realm));
+        // `realm` keys are URL-form while an id may be prefix form (a mapped
+        // realm's card ids are), and `inRealm` only matches across those two
+        // forms when it has a VirtualNetwork — without one it reports false and
+        // the id resolves to no realm at all. Caching stays safe because
+        // RealmPaths consults the VN's mappings at call time, so an entry built
+        // before a mapping registered still sees it.
+        paths = new RealmPaths(new URL(realm), this.network.virtualNetwork);
         this.realmPathsCache.set(realm, paths);
       }
       if (paths.inRealm(id)) {

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -295,6 +295,29 @@ module('Integration | Store', function (hooks) {
     assert.strictEqual(instance, undefined, 'instance is undefined');
   });
 
+  // A mapped realm's card ids are in prefix form, while the realm service keys
+  // its realms by URL. Resolving one against the other is cross-form, which
+  // only works when RealmPaths has the VirtualNetwork to normalize with —
+  // otherwise the id belongs to no realm, and callers that fall back to a
+  // default realm (or to undefined) degrade silently rather than erroring.
+  test('realmOf resolves a prefix-form id to its realm', async function (assert) {
+    getService('network').virtualNetwork.addRealmMapping(
+      '@test-prefix/',
+      testRealmURL,
+    );
+
+    assert.strictEqual(
+      realmService.realmOf(rri('@test-prefix/Person/hassan')),
+      testRealmURL,
+      'a prefix-form id resolves to the mapped realm',
+    );
+    assert.strictEqual(
+      realmService.realmOf(new URL(`${testRealmURL}Person/hassan`)),
+      testRealmURL,
+      'the URL form still resolves to the same realm',
+    );
+  });
+
   test<TestContextWithSave>('can use registered prefix ids across store APIs', async function (assert) {
     getService('network').virtualNetwork.addRealmMapping(
       '@test-prefix/',


### PR DESCRIPTION
The function signature indicates it accepts RRIs but it previously couldn’t identify across the prefix/URL spellings.