### PR TITLE
Unwind the host-mode stack when navigating to a page you are already inside

### DIFF
--- a/packages/host/app/components/host-mode/breadcrumbs.gts
+++ b/packages/host/app/components/host-mode/breadcrumbs.gts
@@ -84,7 +84,6 @@ export default class HostModeBreadcrumbs extends Component<Signature> {
       class='host-mode-breadcrumbs'
       aria-label='Card stack navigation'
       hidden={{not this.hasCards}}
-      data-host-mode-breadcrumbs
       data-test-host-mode-breadcrumbs
       ...attributes
     >

--- a/packages/host/app/components/host-mode/stack-item.gts
+++ b/packages/host/app/components/host-mode/stack-item.gts
@@ -149,9 +149,10 @@ export default class HostModeStackItem extends Component<Signature> {
         {{if this.doMovingForwardAnimation "move-forward-animation"}}
         {{if this.isItemFullWidth "full-width"}}
         {{if this.isTesting "testing"}}'
+      style={{this.styleForStackedCard}}
+      data-host-mode-stack-item
       data-test-host-mode-stack-item-index={{@index}}
       data-test-host-mode-stack-item={{@cardId}}
-      style={{this.styleForStackedCard}}
     >
       <div class='stack-item-card'>
         <HostModeCard

--- a/packages/host/app/components/host-mode/stack.gts
+++ b/packages/host/app/components/host-mode/stack.gts
@@ -1,7 +1,6 @@
+import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-
-import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
 
 import HostModeStackItem from './stack-item';
 
@@ -23,17 +22,32 @@ export default class HostModeStack extends Component<Signature> {
     }
   }
 
+  // Dismiss is scoped to the scrim, not "anywhere but the stack": click-outside
+  // also closed the card an unwinding navigation had just opened (CS-12434).
+  @action
+  onScrimClick(event: Event) {
+    let target = event.target;
+    if (
+      target instanceof Element &&
+      target.closest('.host-mode-stack-item') !== null
+    ) {
+      return;
+    }
+    this.closeTopCard();
+  }
+
   <template>
-    <div class='host-mode-stack' data-test-host-mode-stack ...attributes>
+    {{! The scrim is a shortcut for the top card's close button, not the only
+    way out, so it stays a plain element rather than gaining a button role. }}
+    {{! template-lint-disable no-invalid-interactive }}
+    <div
+      class='host-mode-stack'
+      {{on 'click' this.onScrimClick}}
+      data-test-host-mode-stack
+      ...attributes
+    >
       <div class='inner' tabindex='-1'>
-        <div
-          class='stack-items'
-          {{onClickOutside
-            this.closeTopCard
-            exceptSelector='[data-host-mode-breadcrumbs]'
-          }}
-          data-test-host-mode-stack-items
-        >
+        <div class='stack-items' data-test-host-mode-stack-items>
           {{#each @stackItemCardIds key='cardId' as |cardId index|}}
             <HostModeStackItem
               @cardId={{cardId}}

--- a/packages/host/app/components/host-mode/stack.gts
+++ b/packages/host/app/components/host-mode/stack.gts
@@ -22,14 +22,16 @@ export default class HostModeStack extends Component<Signature> {
     }
   }
 
-  // Dismiss is scoped to the scrim, not "anywhere but the stack": click-outside
-  // also closed the card an unwinding navigation had just opened (CS-12434).
+  // Dismiss belongs to the scrim alone: a document-wide click-outside also
+  // fires for the click that navigated the stack, closing the card it just
+  // opened. Tests for a click inside a card rather than target ===
+  // currentTarget, since `.inner` fills the scrim and takes background clicks.
   @action
   onScrimClick(event: Event) {
     let target = event.target;
     if (
       target instanceof Element &&
-      target.closest('.host-mode-stack-item') !== null
+      target.closest('[data-host-mode-stack-item]') !== null
     ) {
       return;
     }

--- a/packages/host/app/services/host-mode-state-service.ts
+++ b/packages/host/app/services/host-mode-state-service.ts
@@ -94,8 +94,22 @@ export default class HostModeStateService extends Service {
     this.schedulePersist();
   }
 
+  // Opening a card that is already behind you in the trail is a navigation
+  // *back* to it — an in-page "up" link, or a second visit to the same page —
+  // so unwind to it rather than stacking another copy of a page the user is
+  // already inside. Pushing is only right for a card not yet on the trail.
   pushCard(cardId: string) {
-    this.stackCardItems.push(cardId);
+    if (cardId === this.primaryCardItem) {
+      // the root: everything above it closes
+      this.stackCardItems.splice(0, this.stackCardItems.length);
+    } else {
+      let index = this.stackCardItems.indexOf(cardId);
+      if (index === -1) {
+        this.stackCardItems.push(cardId);
+      } else {
+        this.stackCardItems.splice(index + 1);
+      }
+    }
     this.schedulePersist();
   }
 

--- a/packages/host/app/services/host-mode-state-service.ts
+++ b/packages/host/app/services/host-mode-state-service.ts
@@ -9,6 +9,8 @@ import stringify from 'safe-stable-stringify';
 
 import { TrackedArray } from 'tracked-built-ins';
 
+import { unwindOrPush } from '../utils/host-mode-stack';
+
 import type RealmService from './realm';
 import type SessionService from './session';
 
@@ -94,22 +96,8 @@ export default class HostModeStateService extends Service {
     this.schedulePersist();
   }
 
-  // Opening a card that is already behind you in the trail is a navigation
-  // *back* to it — an in-page "up" link, or a second visit to the same page —
-  // so unwind to it rather than stacking another copy of a page the user is
-  // already inside. Pushing is only right for a card not yet on the trail.
   pushCard(cardId: string) {
-    if (cardId === this.primaryCardItem) {
-      // the root: everything above it closes
-      this.stackCardItems.splice(0, this.stackCardItems.length);
-    } else {
-      let index = this.stackCardItems.indexOf(cardId);
-      if (index === -1) {
-        this.stackCardItems.push(cardId);
-      } else {
-        this.stackCardItems.splice(index + 1);
-      }
-    }
+    unwindOrPush(this.stackCardItems, cardId, this.primaryCardItem);
     this.schedulePersist();
   }
 

--- a/packages/host/app/services/host-mode-state-service.ts
+++ b/packages/host/app/services/host-mode-state-service.ts
@@ -9,7 +9,7 @@ import stringify from 'safe-stable-stringify';
 
 import { TrackedArray } from 'tracked-built-ins';
 
-import { unwindOrPush } from '../utils/host-mode-stack';
+import { removeTopmost, unwindOrPush } from '../utils/host-mode-stack';
 
 import type RealmService from './realm';
 import type SessionService from './session';
@@ -102,10 +102,7 @@ export default class HostModeStateService extends Service {
   }
 
   removeCardFromStack(cardId: string) {
-    let index = this.stackCardItems.findIndex((item) => item === cardId);
-
-    if (index !== -1) {
-      this.stackCardItems.splice(index, 1);
+    if (removeTopmost(this.stackCardItems, cardId)) {
       this.schedulePersist();
     }
   }

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -50,6 +50,7 @@ import type RealmServer from '@cardstack/host/services/realm-server';
 import type RecentCardsService from '@cardstack/host/services/recent-cards-service';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 
+import { unwindOrPush } from '../utils/host-mode-stack';
 import {
   AiAssistantOpen,
   ModuleInspectorSelections,
@@ -158,7 +159,9 @@ export default class OperatorModeStateService extends Service {
     submode: Submodes.Interact,
     codePath: null,
     hostModePrimaryCard: null,
-    hostModeStack: [],
+    // TrackedArray like the ones restoreState installs, so mutations before the
+    // first restore are reactive too
+    hostModeStack: new TrackedArray<string>([]),
     openDirs: new TrackedMap<string, string[]>(),
     aiAssistantOpen: readPersistedAiAssistantOpen(),
     newFileDropdownOpen: false,
@@ -624,17 +627,11 @@ export default class OperatorModeStateService extends Service {
   // so unwind to it rather than stacking another copy of a page the user is
   // already inside. Pushing is only right for a card not yet on the trail.
   addToHostModeStack(cardId: string) {
-    if (cardId === this._state.hostModePrimaryCard) {
-      // the root: everything above it closes
-      this._state.hostModeStack.splice(0, this._state.hostModeStack.length);
-    } else {
-      let index = this._state.hostModeStack.indexOf(cardId);
-      if (index === -1) {
-        this._state.hostModeStack.push(cardId);
-      } else {
-        this._state.hostModeStack.splice(index + 1);
-      }
-    }
+    unwindOrPush(
+      this._state.hostModeStack,
+      cardId,
+      this._state.hostModePrimaryCard,
+    );
     this.schedulePersist();
   }
 

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -619,8 +619,22 @@ export default class OperatorModeStateService extends Service {
       .map((stack) => stack[stack.length - 1]);
   }
 
+  // Opening a card that is already behind you in the trail is a navigation
+  // *back* to it — an in-page "up" link, or a second visit to the same page —
+  // so unwind to it rather than stacking another copy of a page the user is
+  // already inside. Pushing is only right for a card not yet on the trail.
   addToHostModeStack(cardId: string) {
-    this._state.hostModeStack.push(cardId);
+    if (cardId === this._state.hostModePrimaryCard) {
+      // the root: everything above it closes
+      this._state.hostModeStack.splice(0, this._state.hostModeStack.length);
+    } else {
+      let index = this._state.hostModeStack.indexOf(cardId);
+      if (index === -1) {
+        this._state.hostModeStack.push(cardId);
+      } else {
+        this._state.hostModeStack.splice(index + 1);
+      }
+    }
     this.schedulePersist();
   }
 

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -50,7 +50,7 @@ import type RealmServer from '@cardstack/host/services/realm-server';
 import type RecentCardsService from '@cardstack/host/services/recent-cards-service';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 
-import { unwindOrPush } from '../utils/host-mode-stack';
+import { removeTopmost, unwindOrPush } from '../utils/host-mode-stack';
 import {
   AiAssistantOpen,
   ModuleInspectorSelections,
@@ -636,9 +636,7 @@ export default class OperatorModeStateService extends Service {
   }
 
   removeFromHostModeStack(cardId: string) {
-    let index = this._state.hostModeStack.findIndex((item) => item === cardId);
-    if (index !== -1) {
-      this._state.hostModeStack.splice(index, 1);
+    if (removeTopmost(this._state.hostModeStack, cardId)) {
       this.schedulePersist();
     }
   }

--- a/packages/host/app/utils/host-mode-stack.ts
+++ b/packages/host/app/utils/host-mode-stack.ts
@@ -1,11 +1,15 @@
+// The trail can hold the same card more than once — `hostModeStack` is accepted
+// from the URL verbatim — so every lookup here resolves to the *topmost*
+// occurrence, the copy the user can actually see and act on.
+//
+// Both functions mutate `stack` in place so callers can pass their TrackedArray
+// directly and keep the mutation reactive. Host mode and the host submode share
+// them so the two trails cannot drift apart.
+
 // Opening a card that is already behind you in the trail is a navigation *back*
 // to it — an in-page "up" link, or a second visit to the same page — so unwind
 // to it rather than stacking another copy of a page the user is already inside.
 // Pushing is only right for a card not yet on the trail.
-//
-// Mutates `stack` in place so callers can pass their TrackedArray directly and
-// keep the mutation reactive. Host mode and the host submode share this so the
-// two trails cannot drift apart.
 export function unwindOrPush(
   stack: string[],
   cardId: string,
@@ -17,12 +21,25 @@ export function unwindOrPush(
     return;
   }
 
-  // lastIndexOf, not indexOf: a hand-crafted or stale `hostModeStack` param can
-  // carry the same card twice, and "go back" means the nearest occurrence.
+  // "Go back" means the nearest occurrence, so unwind to the topmost copy.
   let index = stack.lastIndexOf(cardId);
   if (index === -1) {
     stack.push(cardId);
   } else {
     stack.splice(index + 1);
   }
+}
+
+// Close removes the topmost copy of a card, since that is the one on screen: a
+// close button renders only on the stack's top card, and a breadcrumb click
+// closes the crumbs above it from the top down. Returns whether the trail
+// changed, so callers only persist when it did.
+export function removeTopmost(stack: string[], cardId: string): boolean {
+  let index = stack.lastIndexOf(cardId);
+  if (index === -1) {
+    return false;
+  }
+
+  stack.splice(index, 1);
+  return true;
 }

--- a/packages/host/app/utils/host-mode-stack.ts
+++ b/packages/host/app/utils/host-mode-stack.ts
@@ -1,0 +1,28 @@
+// Opening a card that is already behind you in the trail is a navigation *back*
+// to it — an in-page "up" link, or a second visit to the same page — so unwind
+// to it rather than stacking another copy of a page the user is already inside.
+// Pushing is only right for a card not yet on the trail.
+//
+// Mutates `stack` in place so callers can pass their TrackedArray directly and
+// keep the mutation reactive. Host mode and the host submode share this so the
+// two trails cannot drift apart.
+export function unwindOrPush(
+  stack: string[],
+  cardId: string,
+  primaryCardId: string | null,
+): void {
+  if (cardId === primaryCardId) {
+    // the root: everything above it closes
+    stack.splice(0, stack.length);
+    return;
+  }
+
+  // lastIndexOf, not indexOf: a hand-crafted or stale `hostModeStack` param can
+  // carry the same card twice, and "go back" means the nearest occurrence.
+  let index = stack.lastIndexOf(cardId);
+  if (index === -1) {
+    stack.push(cardId);
+  } else {
+    stack.splice(index + 1);
+  }
+}

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -815,6 +815,66 @@ module('Acceptance | host mode tests', function (hooks) {
       .exists('unwinds to the card, leaving it on top of the trail');
   });
 
+  // The unwind by the route a visitor can take: the scrim covers the primary
+  // card, so only a stack item's own button is genuinely clickable.
+  test('viewing a card below it in the trail unwinds to that card', async function (assert) {
+    let belowCardId = `${testHostModeRealmURL}ViewCardDemo/secondary`;
+    // index sits above secondary in the trail and targets it
+    let topCardId = `${testHostModeRealmURL}ViewCardDemo/index`;
+    let hostModeStackValue = encodeURIComponent(
+      JSON.stringify([belowCardId, topCardId]),
+    );
+
+    // tertiary as primary keeps both stack cards off the root, so this takes the
+    // unwind branch rather than the close-everything one.
+    await visit(
+      `/test/ViewCardDemo/tertiary.json?hostModeStack=${hostModeStackValue}`,
+    );
+
+    let topSelector = `[data-test-host-mode-stack-item="${topCardId}"]`;
+    let belowSelector = `[data-test-host-mode-stack-item="${belowCardId}"]`;
+    await waitFor(`${topSelector} [data-test-view-card-demo-button]`);
+
+    await click(`${topSelector} [data-test-view-card-demo-button]`);
+
+    await waitUntil(() => !document.querySelector(topSelector));
+    assert
+      .dom(belowSelector)
+      .exists('unwinds to the targeted card rather than stacking a copy');
+    // currentURL, not window.location: the latter is the test runner's own URL
+    // and never carries the app's query params.
+    assert.strictEqual(
+      new URL(currentURL()!, 'http://localhost').searchParams.get(
+        'hostModeStack',
+      ),
+      JSON.stringify([belowCardId]),
+      'the unwound trail is what persists to the query param',
+    );
+  });
+
+  // Regression cover for scoping dismiss to the scrim (CS-12434).
+  test('clicking the scrim closes the top card of the trail', async function (assert) {
+    let firstStackCardId = `${testHostModeRealmURL}ViewCardDemo/secondary`;
+    let secondStackCardId = `${testHostModeRealmURL}ViewCardDemo/tertiary`;
+    let hostModeStackValue = encodeURIComponent(
+      JSON.stringify([firstStackCardId, secondStackCardId]),
+    );
+
+    await visit(
+      `/test/ViewCardDemo/index.json?hostModeStack=${hostModeStackValue}`,
+    );
+
+    let secondStackSelector = `[data-test-host-mode-stack-item="${secondStackCardId}"]`;
+    await waitFor(secondStackSelector);
+
+    await click('[data-test-host-mode-stack]');
+
+    await waitUntil(() => !document.querySelector(secondStackSelector));
+    assert
+      .dom(`[data-test-host-mode-stack-item="${firstStackCardId}"]`)
+      .exists('only the top card closes');
+  });
+
   test('stack state persists in query parameter', async function (assert) {
     let hostModeStackValue = encodeURIComponent(
       JSON.stringify([`${testHostModeRealmURL}index`]),

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -783,8 +783,13 @@ module('Acceptance | host mode tests', function (hooks) {
         'the whole trail unwinds to the root rather than stacking the primary card again',
       );
     assert.dom(primaryCardSelector).exists();
+    // currentURL, not window.location: the latter is the test runner's own URL
+    // and never carries the app's query params, so asserting null against it
+    // would pass whether or not the param was cleared.
     assert.strictEqual(
-      new URL(window.location.href).searchParams.get('hostModeStack'),
+      new URL(currentURL()!, 'http://localhost').searchParams.get(
+        'hostModeStack',
+      ),
       null,
       'the emptied stack drops out of the query param',
     );
@@ -841,8 +846,6 @@ module('Acceptance | host mode tests', function (hooks) {
     assert
       .dom(belowSelector)
       .exists('unwinds to the targeted card rather than stacking a copy');
-    // currentURL, not window.location: the latter is the test runner's own URL
-    // and never carries the app's query params.
     assert.strictEqual(
       new URL(currentURL()!, 'http://localhost').searchParams.get(
         'hostModeStack',
@@ -867,7 +870,9 @@ module('Acceptance | host mode tests', function (hooks) {
     let secondStackSelector = `[data-test-host-mode-stack-item="${secondStackCardId}"]`;
     await waitFor(secondStackSelector);
 
-    await click('[data-test-host-mode-stack]');
+    // `.inner` fills the scrim, so this — not the scrim element itself — is what
+    // a real background click in a browser actually targets.
+    await click('[data-test-host-mode-stack] .inner');
 
     await waitUntil(() => !document.querySelector(secondStackSelector));
     assert
@@ -891,39 +896,11 @@ module('Acceptance | host mode tests', function (hooks) {
 
     assert.strictEqual(currentURL(), '/test/Pet/mango.json');
     assert.strictEqual(
-      new URL(window.location.href).searchParams.get('hostModeStack'),
+      new URL(currentURL()!, 'http://localhost').searchParams.get(
+        'hostModeStack',
+      ),
       null,
     );
-  });
-
-  test('clicking the stack backdrop closes the top card', async function (assert) {
-    let hostModeStackValue = encodeURIComponent(
-      JSON.stringify([`${testHostModeRealmURL}index`]),
-    );
-    await visit(`/test/Pet/mango.json?hostModeStack=${hostModeStackValue}`);
-
-    // Wait for stack item to appear
-    await waitFor(
-      `[data-test-host-mode-stack-item="${testHostModeRealmURL}index"]`,
-    );
-
-    // Verify stack item exists
-    assert
-      .dom(`[data-test-host-mode-stack-item="${testHostModeRealmURL}index"]`)
-      .exists();
-
-    // Click outside the stack items (on the stack backdrop area)
-    await click('[data-test-host-mode-stack]');
-
-    // Stack item should be removed
-    await waitUntil(() => {
-      return !document.querySelector(
-        `[data-test-host-mode-stack-item="${testHostModeRealmURL}index"]`,
-      );
-    });
-    assert
-      .dom(`[data-test-host-mode-stack-item="${testHostModeRealmURL}index"]`)
-      .doesNotExist();
   });
 
   test('clicking on a stack card does not close it', async function (assert) {

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -756,6 +756,65 @@ module('Acceptance | host mode tests', function (hooks) {
       .hasAttribute('data-test-view-card-demo-active-tab', 'details');
   });
 
+  // The ViewCardDemo instances form a cycle — index → secondary → tertiary →
+  // index — so tertiary's button is an "up" link back to the page the user is
+  // already inside. Viewing a card already on the trail must unwind to it,
+  // not stack a second copy of it.
+  test('viewing the primary card from deeper in the trail closes the stack', async function (assert) {
+    let primaryCardSelector = `[data-test-host-mode-card="${testHostModeRealmURL}ViewCardDemo/index"]`;
+    let firstStackSelector = `[data-test-host-mode-stack-item="${testHostModeRealmURL}ViewCardDemo/secondary"]`;
+    let secondStackSelector = `[data-test-host-mode-stack-item="${testHostModeRealmURL}ViewCardDemo/tertiary"]`;
+
+    await visit('/test/ViewCardDemo/index.json');
+
+    await waitFor(`${primaryCardSelector} [data-test-view-card-demo-button]`);
+    await click(`${primaryCardSelector} [data-test-view-card-demo-button]`);
+    await waitFor(`${firstStackSelector} [data-test-view-card-demo-button]`);
+    await click(`${firstStackSelector} [data-test-view-card-demo-button]`);
+    await waitFor(`${secondStackSelector} [data-test-view-card-demo-button]`);
+
+    // tertiary targets the primary card
+    await click(`${secondStackSelector} [data-test-view-card-demo-button]`);
+
+    await waitUntil(() => !document.querySelector(secondStackSelector));
+    assert
+      .dom(firstStackSelector)
+      .doesNotExist(
+        'the whole trail unwinds to the root rather than stacking the primary card again',
+      );
+    assert.dom(primaryCardSelector).exists();
+    assert.strictEqual(
+      new URL(window.location.href).searchParams.get('hostModeStack'),
+      null,
+      'the emptied stack drops out of the query param',
+    );
+  });
+
+  test('viewing a card already in the trail unwinds to it', async function (assert) {
+    let firstStackCardId = `${testHostModeRealmURL}ViewCardDemo/secondary`;
+    let secondStackCardId = `${testHostModeRealmURL}ViewCardDemo/tertiary`;
+    let hostModeStackValue = encodeURIComponent(
+      JSON.stringify([firstStackCardId, secondStackCardId]),
+    );
+
+    await visit(
+      `/test/ViewCardDemo/index.json?hostModeStack=${hostModeStackValue}`,
+    );
+
+    let primaryCardSelector = `[data-test-host-mode-card="${testHostModeRealmURL}ViewCardDemo/index"]`;
+    let secondStackSelector = `[data-test-host-mode-stack-item="${secondStackCardId}"]`;
+    await waitFor(secondStackSelector);
+    await waitFor(`${primaryCardSelector} [data-test-view-card-demo-button]`);
+
+    // the primary card targets secondary, which is already below tertiary
+    await click(`${primaryCardSelector} [data-test-view-card-demo-button]`);
+
+    await waitUntil(() => !document.querySelector(secondStackSelector));
+    assert
+      .dom(`[data-test-host-mode-stack-item="${firstStackCardId}"]`)
+      .exists('unwinds to the card, leaving it on top of the trail');
+  });
+
   test('stack state persists in query parameter', async function (assert) {
     let hostModeStackValue = encodeURIComponent(
       JSON.stringify([`${testHostModeRealmURL}index`]),

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -795,31 +795,6 @@ module('Acceptance | host mode tests', function (hooks) {
     );
   });
 
-  test('viewing a card already in the trail unwinds to it', async function (assert) {
-    let firstStackCardId = `${testHostModeRealmURL}ViewCardDemo/secondary`;
-    let secondStackCardId = `${testHostModeRealmURL}ViewCardDemo/tertiary`;
-    let hostModeStackValue = encodeURIComponent(
-      JSON.stringify([firstStackCardId, secondStackCardId]),
-    );
-
-    await visit(
-      `/test/ViewCardDemo/index.json?hostModeStack=${hostModeStackValue}`,
-    );
-
-    let primaryCardSelector = `[data-test-host-mode-card="${testHostModeRealmURL}ViewCardDemo/index"]`;
-    let secondStackSelector = `[data-test-host-mode-stack-item="${secondStackCardId}"]`;
-    await waitFor(secondStackSelector);
-    await waitFor(`${primaryCardSelector} [data-test-view-card-demo-button]`);
-
-    // the primary card targets secondary, which is already below tertiary
-    await click(`${primaryCardSelector} [data-test-view-card-demo-button]`);
-
-    await waitUntil(() => !document.querySelector(secondStackSelector));
-    assert
-      .dom(`[data-test-host-mode-stack-item="${firstStackCardId}"]`)
-      .exists('unwinds to the card, leaving it on top of the trail');
-  });
-
   // The unwind by the route a visitor can take: the scrim covers the primary
   // card, so only a stack item's own button is genuinely clickable.
   test('viewing a card below it in the trail unwinds to that card', async function (assert) {
@@ -855,7 +830,6 @@ module('Acceptance | host mode tests', function (hooks) {
     );
   });
 
-  // Regression cover for scoping dismiss to the scrim (CS-12434).
   test('clicking the scrim closes the top card of the trail', async function (assert) {
     let firstStackCardId = `${testHostModeRealmURL}ViewCardDemo/secondary`;
     let secondStackCardId = `${testHostModeRealmURL}ViewCardDemo/tertiary`;
@@ -878,6 +852,51 @@ module('Acceptance | host mode tests', function (hooks) {
     assert
       .dom(`[data-test-host-mode-stack-item="${firstStackCardId}"]`)
       .exists('only the top card closes');
+  });
+
+  // `hostModeStack` is taken from the URL verbatim, so the same card can appear
+  // twice in one trail. Closing has to act on the copy on screen — the top card
+  // — or the click appears to do nothing while a buried card disappears.
+  test('closing a card that appears twice in the trail closes the visible copy', async function (assert) {
+    let repeatedCardId = `${testHostModeRealmURL}ViewCardDemo/secondary`;
+    let middleCardId = `${testHostModeRealmURL}ViewCardDemo/tertiary`;
+    let hostModeStackValue = encodeURIComponent(
+      JSON.stringify([repeatedCardId, middleCardId, repeatedCardId]),
+    );
+
+    await visit(
+      `/test/ViewCardDemo/index.json?hostModeStack=${hostModeStackValue}`,
+    );
+
+    await waitFor('[data-test-host-mode-stack-item-index="2"]');
+
+    await click('[data-test-host-mode-stack] .inner');
+
+    await waitUntil(
+      () =>
+        !document.querySelector('[data-test-host-mode-stack-item-index="2"]'),
+    );
+    assert
+      .dom('[data-test-host-mode-stack-item-index="1"]')
+      .hasAttribute(
+        'data-test-host-mode-stack-item',
+        middleCardId,
+        'the card below the closed copy becomes the top of the trail',
+      );
+    assert
+      .dom('[data-test-host-mode-stack-item-index="0"]')
+      .hasAttribute(
+        'data-test-host-mode-stack-item',
+        repeatedCardId,
+        'the buried copy survives',
+      );
+    assert.strictEqual(
+      new URL(currentURL()!, 'http://localhost').searchParams.get(
+        'hostModeStack',
+      ),
+      JSON.stringify([repeatedCardId, middleCardId]),
+      'the persisted trail lost the top copy, not the bottom one',
+    );
   });
 
   test('stack state persists in query parameter', async function (assert) {

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -538,6 +538,59 @@ module('Acceptance | host submode', function (hooks) {
         .hasAttribute('data-test-view-card-demo-active-tab', 'details');
     });
 
+    // Submode counterpart, through operator-mode-state-service. ViewCardDemo
+    // cycles 1 → 2 → 3 → 1, so 1 above 2 is an "up" link (CS-12434).
+    test('viewing a card already in the trail unwinds to it', async function (assert) {
+      let belowCardId = `${testRealmURL}ViewCardDemo/2`;
+      let topCardId = `${testRealmURL}ViewCardDemo/1`;
+
+      // 3 as primary keeps both stack cards off the root, so this takes the
+      // unwind branch rather than the close-everything one.
+      await visitOperatorMode({
+        submode: 'host',
+        trail: [
+          `${testRealmURL}ViewCardDemo/3.json`,
+          `${belowCardId}.json`,
+          `${topCardId}.json`,
+        ],
+      });
+
+      let topSelector = `[data-test-host-mode-stack-item="${topCardId}"]`;
+      let belowSelector = `[data-test-host-mode-stack-item="${belowCardId}"]`;
+      await waitFor(`${topSelector} [data-test-view-card-demo-button]`);
+
+      await click(`${topSelector} [data-test-view-card-demo-button]`);
+
+      await waitUntil(() => !document.querySelector(topSelector));
+      assert
+        .dom(belowSelector)
+        .exists('unwinds to the targeted card rather than stacking a copy');
+    });
+
+    test('clicking the scrim closes the top card of the trail', async function (assert) {
+      let belowCardId = `${testRealmURL}ViewCardDemo/2`;
+      let topCardId = `${testRealmURL}ViewCardDemo/3`;
+
+      await visitOperatorMode({
+        submode: 'host',
+        trail: [
+          `${testRealmURL}ViewCardDemo/1.json`,
+          `${belowCardId}.json`,
+          `${topCardId}.json`,
+        ],
+      });
+
+      let topSelector = `[data-test-host-mode-stack-item="${topCardId}"]`;
+      await waitFor(topSelector);
+
+      await click('[data-test-host-mode-stack]');
+
+      await waitUntil(() => !document.querySelector(topSelector));
+      assert
+        .dom(`[data-test-host-mode-stack-item="${belowCardId}"]`)
+        .exists('only the top card closes');
+    });
+
     test('breadcrumbs can close stacked cards', async function (assert) {
       let card1Id = `${testRealmURL}Person/1`;
       let card2Id = `${testRealmURL}index`;

--- a/packages/host/tests/unit/host-mode-stack-test.ts
+++ b/packages/host/tests/unit/host-mode-stack-test.ts
@@ -1,6 +1,9 @@
 import { module, test } from 'qunit';
 
-import { unwindOrPush } from '@cardstack/host/utils/host-mode-stack';
+import {
+  removeTopmost,
+  unwindOrPush,
+} from '@cardstack/host/utils/host-mode-stack';
 
 module('Unit | host-mode-stack | unwindOrPush', function () {
   test('pushes a card that is not on the trail', function (assert) {
@@ -49,5 +52,38 @@ module('Unit | host-mode-stack | unwindOrPush', function () {
     let stack = ['b'];
     unwindOrPush(stack, 'c', null);
     assert.deepEqual(stack, ['b', 'c']);
+  });
+});
+
+module('Unit | host-mode-stack | removeTopmost', function () {
+  test('removes the card and reports the change', function (assert) {
+    let stack = ['b', 'c'];
+    assert.true(removeTopmost(stack, 'b'));
+    assert.deepEqual(stack, ['c']);
+  });
+
+  test('reports no change when the card is absent', function (assert) {
+    let stack = ['b'];
+    assert.false(removeTopmost(stack, 'c'));
+    assert.deepEqual(stack, ['b'], 'the trail is untouched');
+  });
+
+  test('removes the topmost copy of a duplicated card', function (assert) {
+    // Closing targets the copy on screen — the stack's top card. Removing the
+    // first copy instead would leave the visible card in place and silently
+    // drop one the user was not acting on.
+    let stack = ['a', 'b', 'a'];
+    assert.true(removeTopmost(stack, 'a'));
+    assert.deepEqual(stack, ['a', 'b']);
+  });
+
+  test('closing a whole trail of duplicates from the top down empties it', function (assert) {
+    // What a breadcrumb click does: close every card above the crumb, lowest
+    // id first, one call each.
+    let stack = ['a', 'b', 'a', 'b'];
+    for (let cardId of ['b', 'a', 'b']) {
+      removeTopmost(stack, cardId);
+    }
+    assert.deepEqual(stack, ['a'], 'unwinds to the clicked crumb');
   });
 });

--- a/packages/host/tests/unit/host-mode-stack-test.ts
+++ b/packages/host/tests/unit/host-mode-stack-test.ts
@@ -1,0 +1,53 @@
+import { module, test } from 'qunit';
+
+import { unwindOrPush } from '@cardstack/host/utils/host-mode-stack';
+
+module('Unit | host-mode-stack | unwindOrPush', function () {
+  test('pushes a card that is not on the trail', function (assert) {
+    let stack = ['b'];
+    unwindOrPush(stack, 'c', 'a');
+    assert.deepEqual(stack, ['b', 'c']);
+  });
+
+  test('pushes onto an empty trail', function (assert) {
+    let stack: string[] = [];
+    unwindOrPush(stack, 'b', 'a');
+    assert.deepEqual(stack, ['b']);
+  });
+
+  test('clears the trail when the target is the primary card', function (assert) {
+    let stack = ['b', 'c'];
+    unwindOrPush(stack, 'a', 'a');
+    assert.deepEqual(stack, [], 'everything above the root closes');
+  });
+
+  test('truncates above a card already mid-trail', function (assert) {
+    let stack = ['b', 'c', 'd'];
+    unwindOrPush(stack, 'b', 'a');
+    assert.deepEqual(stack, ['b'], 'unwinds to the target, leaving it on top');
+  });
+
+  test('leaves the trail alone when the target is already on top', function (assert) {
+    let stack = ['b', 'c'];
+    unwindOrPush(stack, 'c', 'a');
+    assert.deepEqual(stack, ['b', 'c']);
+  });
+
+  test('unwinds to the nearest occurrence of a duplicated card', function (assert) {
+    // A hand-crafted or stale hostModeStack param is accepted verbatim, so
+    // duplicates can still reach this even though pushing never creates them.
+    let stack = ['a', 'b', 'a', 'c'];
+    unwindOrPush(stack, 'a', 'primary');
+    assert.deepEqual(
+      stack,
+      ['a', 'b', 'a'],
+      'going back lands on the nearest copy, not the first one',
+    );
+  });
+
+  test('a null primary card does not swallow the push', function (assert) {
+    let stack = ['b'];
+    unwindOrPush(stack, 'c', null);
+    assert.deepEqual(stack, ['b', 'c']);
+  });
+});


### PR DESCRIPTION
[CS-12434](https://linear.app/cardstack/issue/CS-12434/host-mode-stacks-a-duplicate-page-instead-of-unwinding-when-you)

## Why

Host mode only ever pushes onto its stack, so following an in-page link *back* to a page you are already inside stacks a second copy instead of unwinding to it.

Found on the boxel.ai blog: opening a post from the index pushes it correctly, but the post's "← Back to Boxel Blog" link then pushes the index *on top of* the post — index → post → index. It applies to any host-mode realm with an "up" link, and cards are only ever handed `viewCard`, so realm content cannot work around it.

## What

Opening a card already behind you in the trail is a navigation back to it, so unwind rather than push:

- the primary card → close the whole stack
- somewhere in the stack → truncate everything above it
- otherwise → push

Both stacks need this and were separate implementations, so the branch table now lives in `app/utils/host-mode-stack.ts`, called by `HostModeStateService#pushCard` (the published site) and `OperatorModeStateService#addToHostModeStack` (host submode).

**Duplicate trails.** `hostModeStack` comes off the URL verbatim, so `?hostModeStack=["a","b","a"]` is a trail the app has to handle. Every lookup resolves to the topmost occurrence — the copy the visitor can see. That also fixes close, which removed the *first* copy: the visible card stayed put while a buried one silently disappeared, on every close path (scrim, close button, breadcrumbs).

**Dismiss had to move with it.** The stack closed its top card on any click outside itself, which undid the unwind — the same click that unwound to a card also read as an outside-click and closed it, emptying the trail and unmounting the stack. Dismiss is now scoped to the scrim and ignores clicks inside a stack item, matched by a `data-host-mode-stack-item` attribute that exists for that purpose (not a `data-test-` one, which production builds strip). The breadcrumbs `exceptSelector` and its `data-host-mode-breadcrumbs` hook drop out, since breadcrumbs render outside the scrim.

One intentional behaviour change: the old `onClickOutside` was document-wide, so in submode clicking the workbench chrome closed the top card. It no longer does — clicking the surrounding app furniture isn't a request to close a card, and the close button and breadcrumbs remain.

## Testing

Local dev stack: **host mode 25/25, host submode 40/40, unit 11/11.** `lint:hbs`, `lint:types`, eslint, prettier clean.

New `tests/unit/host-mode-stack-test.ts` covers the branch table directly instead of only through two acceptance suites. Acceptance tests cover unwinding to the root, unwinding by the route a visitor can take, scrim dismissal, and closing a card that appears twice — that last one checked against a reverted fix, where it fails. The submode side had no unwind coverage at all, so `addToHostModeStack` was shipping untested.

Two query-param assertions read `window.location`, which in an acceptance test is the test runner's URL and never carries app params — so asserting `null` passed regardless of behaviour. One arrived with this PR's own new test; the other predates it on `main`. Both now read `currentURL()`.

Two tests came out: one duplicated the new scrim test, and one clicked the primary card's button with a stack open, which the scrim covers — `@ember/test-helpers`' `click` does no hit-testing, so it asserted a path no visitor can take.

## Notes

Unrelated oddity left alone: `stack.gts` iterates with `key='cardId'` over an array of strings, so the key resolves to `undefined` for every item. Changing it shifts DOM reuse, which the stack animations depend on, so it wants its own change with Percy on it. --> Created ticket:  CS-12452 — Host-mode stack's {{#each}} key resolves to undefined for every item

🤖 Generated with [Claude Code](https://claude.com/claude-code)
