### PR TITLE
ci: Change host tests to use cached test realm index

### DIFF
--- a/mise-tasks/ci/import-index
+++ b/mise-tasks/ci/import-index
@@ -2,10 +2,38 @@
 #MISE description="Seed this environment's index tables from the cached CI index"
 #MISE dir="packages/realm-server"
 
-set -euo pipefail
+# No `-e`: everything this task does is an optimization. Seeding the index makes
+# a shard boot faster, and failing to seed it only means the realms index from
+# scratch the way they always did — so a problem here must degrade rather than
+# take the shard down with it. Failures are reported and the task still exits 0.
+set -uo pipefail
 
 export PATH="./node_modules/.bin:$PATH"
 REPO_ROOT="$(cd "../.." && pwd)"
+
+skip() {
+  echo "::warning title=Index cache skipped::$1"
+  exit 0
+}
+
+# Wait for Postgres over TCP, not the default unix socket. The postgres image's
+# entrypoint initializes a new data directory by starting a *temporary* server
+# that listens on the socket only, running init, then shutting it down before
+# the real server comes up. A socket probe answers "ready" during that window,
+# and the next command lands mid-shutdown on `FATAL: the database system is
+# shutting down`. Only the real server listens on TCP, so this waits for the
+# one that is going to stay.
+wait_for_pg() {
+  _wfp_tries=60
+  while [ "$_wfp_tries" -gt 0 ]; do
+    if docker exec boxel-pg pg_isready -U postgres -h 127.0.0.1 >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+    _wfp_tries=$((_wfp_tries - 1))
+  done
+  return 1
+}
 
 # Brings the database up to the point where scripts/import-cached-index.sh can
 # load a snapshot into it: Postgres running, the per-environment database
@@ -20,11 +48,11 @@ REPO_ROOT="$(cd "../.." && pwd)"
 # fixed budget. Keeping the import in its own step means the services start
 # promptly once it is done, and its cost shows up as its own line in the CI
 # timing rather than hiding inside service startup.
-./scripts/start-pg.sh
+./scripts/start-pg.sh || skip "Postgres would not start; realms will index from scratch."
 echo "Waiting for Postgres to accept connections…"
-until docker exec boxel-pg pg_isready -U postgres >/dev/null 2>&1; do sleep 1; done
-"$REPO_ROOT/scripts/ensure-branch-db.sh"
-pnpm migrate
+wait_for_pg || skip "Postgres did not accept TCP connections within 60s; realms will index from scratch."
+"$REPO_ROOT/scripts/ensure-branch-db.sh" || skip "Could not create the environment database; realms will index from scratch."
+pnpm migrate || skip "Migrations failed against ${PGDATABASE:-boxel}; realms will index from scratch."
 
 # Ask for the host-scoped snapshot: a test stack serves base, skills and
 # openrouter, and the full snapshot's other realms are a few hundred MB this
@@ -56,10 +84,11 @@ TEST_DB="${PGDATABASE_TEST:-boxel_test}"
 if docker exec boxel-pg psql -U postgres -lqt | cut -d '|' -f 1 | grep -qw "$TEST_DB"; then
   echo "[ci:import-index] database '${TEST_DB}' already exists"
 else
-  docker exec boxel-pg createdb -U postgres "$TEST_DB"
+  docker exec boxel-pg createdb -U postgres "$TEST_DB" \
+    || skip "Could not create ${TEST_DB}; the test realms will index from scratch."
   echo "[ci:import-index] created database '${TEST_DB}'"
 fi
-PGDATABASE="$TEST_DB" pnpm migrate
+PGDATABASE="$TEST_DB" pnpm migrate || skip "Migrations failed against ${TEST_DB}; the test realms will index from scratch."
 
 if INDEX_CACHE_ARTIFACT=boxel-index-cache-test INDEX_CACHE_DB="$TEST_DB" \
   "$REPO_ROOT/scripts/import-cached-index.sh"; then

--- a/mise-tasks/ci/import-index
+++ b/mise-tasks/ci/import-index
@@ -30,12 +30,40 @@ pnpm migrate
 # openrouter, and the full snapshot's other realms are a few hundred MB this
 # job would download and replay for rows it never reads. The import falls back
 # to the full snapshot when the scoped one is missing or expired.
-export INDEX_CACHE_ARTIFACT="${INDEX_CACHE_ARTIFACT:-boxel-index-cache-host}"
-
+#
 # A cache miss is not a failure: the realms simply index from scratch, which
 # is what they did before this task existed.
-if "$REPO_ROOT/scripts/import-cached-index.sh"; then
+if INDEX_CACHE_ARTIFACT="${INDEX_CACHE_ARTIFACT:-boxel-index-cache-host}" \
+  "$REPO_ROOT/scripts/import-cached-index.sh"; then
   echo "[ci:import-index] index cache imported — the boot index will reconcile only what this checkout changed"
 else
   echo "[ci:import-index] no index cache available — realms will index from scratch"
+fi
+
+# The live test realms (`/test/`, `/node-test/`) index into their own database,
+# which a shard waits on just as it waits on base and skills. Seed that one too,
+# or it stays the whole remaining cost of the boot.
+#
+# Its schema has to exist before the snapshot can load, and the test
+# realm-server's own `--migrateDB` runs far too late for that — hence creating
+# and migrating it here. `services/test-realms` creates the same database on its
+# way up, and both are idempotent.
+# Created by name rather than through ensure-branch-db.sh: that helper derives a
+# database name from a slug, and this is the one place that already knows the
+# exact name it is about to migrate and import into. Deriving it twice is how the
+# two drift apart.
+TEST_DB="${PGDATABASE_TEST:-boxel_test}"
+if docker exec boxel-pg psql -U postgres -lqt | cut -d '|' -f 1 | grep -qw "$TEST_DB"; then
+  echo "[ci:import-index] database '${TEST_DB}' already exists"
+else
+  docker exec boxel-pg createdb -U postgres "$TEST_DB"
+  echo "[ci:import-index] created database '${TEST_DB}'"
+fi
+PGDATABASE="$TEST_DB" pnpm migrate
+
+if INDEX_CACHE_ARTIFACT=boxel-index-cache-test INDEX_CACHE_DB="$TEST_DB" \
+  "$REPO_ROOT/scripts/import-cached-index.sh"; then
+  echo "[ci:import-index] test-realm index cache imported"
+else
+  echo "[ci:import-index] no test-realm index cache available — the test realms will index from scratch"
 fi

--- a/scripts/import-cached-index.sh
+++ b/scripts/import-cached-index.sh
@@ -9,7 +9,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/env-slug.sh"
 
-DB_NAME="${PGDATABASE:-boxel}"
+# The database to load into. Defaults to the dev realms' database; the live
+# test realms keep their index in a separate one, so a caller importing that
+# snapshot passes INDEX_CACHE_DB=$PGDATABASE_TEST.
+DB_NAME="${INDEX_CACHE_DB:-${PGDATABASE:-boxel}}"
 REPO="cardstack/boxel"
 # Artifacts to try, in order. `boxel-index-cache` carries every realm the
 # export job indexes; `boxel-index-cache-host` carries only the realms a host
@@ -18,11 +21,17 @@ REPO="cardstack/boxel"
 # fallback: a caller that wants the scoped one still works when it is missing
 # or expired, just with more rows than it needs. Each artifact holds a single
 # `<artifact-name>.sql.gz`.
+#
+# `boxel-index-cache-test` (the live test realms) is deliberately NOT given
+# that fallback: it targets a different database, and loading the dev realms'
+# rows there would be wrong rather than merely wasteful. A caller naming it
+# gets it or gets nothing.
 DEFAULT_ARTIFACT="boxel-index-cache"
 ARTIFACT_NAMES="${INDEX_CACHE_ARTIFACT:-$DEFAULT_ARTIFACT}"
-if [ "$ARTIFACT_NAMES" != "$DEFAULT_ARTIFACT" ]; then
-  ARTIFACT_NAMES="$ARTIFACT_NAMES $DEFAULT_ARTIFACT"
-fi
+case "$ARTIFACT_NAMES" in
+  "$DEFAULT_ARTIFACT" | boxel-index-cache-test) ;;
+  *) ARTIFACT_NAMES="$ARTIFACT_NAMES $DEFAULT_ARTIFACT" ;;
+esac
 DOWNLOAD_DIR="/tmp/boxel-index-cache-$$"
 
 cleanup() {
@@ -110,9 +119,14 @@ if [ -n "${BOXEL_ENVIRONMENT:-}" ]; then
   # the env-mode realm server and icons host register their realms and
   # URLs under https://<service>.<slug>.localhost, so http-form rows
   # would never match a served realm and the cache would be ignored.
+  #
+  # 4202 is the live test realms' port. Their snapshot also carries base-realm
+  # references pointing at the dev server (4201) and icon URLs (4206), so every
+  # rule applies to every snapshot; a rule that matches nothing is a no-op.
   gunzip -c "$CACHE_FILE" \
     | sed -E \
       -e "s|https?://localhost:4201|https://realm-server.${SLUG}.localhost|g" \
+      -e "s|https?://localhost:4202|https://realm-test.${SLUG}.localhost|g" \
       -e "s|https?://localhost:4206|https://icons.${SLUG}.localhost|g" \
     | docker exec -i boxel-pg psql $PSQL_OPTS
 else


### PR DESCRIPTION
This changes host test cache setup to use the new test realm index cache from #5689.

Here’s an overview of how these caching steps have affected test startup. Caching isn’t free but it’s worth it IMO:

| Phase | A. no cache | B. host cache | C. + test cache | C vs A |
|---|---|---|---|---|
| Import cached index | — | 14s (13–36) | 22s (17–25) | +22s |
| Wait for realms | 152s (129–161) | 35s (20–54) | **1s (0–23)** | **−151s (−99%)** |
| Job start → tests begin | 310s (289–373) | 212s (194–255) | **187s (157–244)** | **−123s (−40%)** |