### PR TITLE
Keep the logging correlation id off Matrix requests

### DIFF
--- a/packages/host/app/services/client-telemetry.ts
+++ b/packages/host/app/services/client-telemetry.ts
@@ -1344,6 +1344,16 @@ export default class ClientTelemetryService
 // attempts.
 const requestAttemptCounts = new WeakMap<Request, number>();
 
+// A Matrix client-server API call, which is served by Synapse rather than the
+// realm server. Recognized by path, so it holds for any homeserver origin.
+function isMatrixRequest(req: Request): boolean {
+  try {
+    return new URL(req.url).pathname.startsWith('/_matrix/');
+  } catch {
+    return false;
+  }
+}
+
 export function createServerRequestTimingMiddleware(
   owner: Owner,
 ): FetcherMiddlewareHandler {
@@ -1371,7 +1381,14 @@ export function createServerRequestTimingMiddleware(
     // the server is the same one recorded on the event below.
     let attempt = (requestAttemptCounts.get(req) ?? 0) + 1;
     requestAttemptCounts.set(req, attempt);
-    if (!req.headers.get(X_BOXEL_LOGGING_CORRELATION_ID_HEADER)) {
+    // Only the realm server reads this id back out. Synapse ignores it, and its
+    // CORS allow-list is a fixed set that a custom header is not in — so
+    // stamping a Matrix request makes the browser reject the preflight and the
+    // request never leaves.
+    if (
+      !isMatrixRequest(req) &&
+      !req.headers.get(X_BOXEL_LOGGING_CORRELATION_ID_HEADER)
+    ) {
       try {
         req.headers.set(X_BOXEL_LOGGING_CORRELATION_ID_HEADER, uuidv4());
       } catch {

--- a/packages/host/tests/integration/client-telemetry-test.ts
+++ b/packages/host/tests/integration/client-telemetry-test.ts
@@ -1,5 +1,11 @@
+import { getOwner } from '@ember/owner';
+
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
+
+import { X_BOXEL_LOGGING_CORRELATION_ID_HEADER } from '@cardstack/runtime-common/prerender-headers';
+
+import { createServerRequestTimingMiddleware } from '@cardstack/host/services/client-telemetry';
 
 import type ClientTelemetryService from '@cardstack/host/services/client-telemetry';
 import type { ClientErrorEvent } from '@cardstack/host/services/client-telemetry';
@@ -521,5 +527,44 @@ module('Integration | Service | client-telemetry', function (hooks) {
       0,
       'the window error listeners are released with everything else',
     );
+  });
+
+  // Synapse's CORS allow-list is a fixed set, with no configuration knob and no
+  // Boxel header in it, so a Matrix request carrying one is rejected by the
+  // browser at preflight and never leaves the tab. Only the realm server reads
+  // the correlation id back out, so a Matrix request has nothing to gain by
+  // carrying it. Armed telemetry is the only state where the stamp happens at
+  // all, and no other suite runs in it — which is how stamping every request
+  // silently broke email registration everywhere while every test passed.
+  module('the correlation id stamp', function () {
+    async function stampedHeader(url: string): Promise<string | null> {
+      let svc = telemetry();
+      svc.enableForTest();
+      let middleware = createServerRequestTimingMiddleware(getOwner(svc)!);
+      let seen: string | null = null;
+      await middleware(new Request(url, { method: 'POST' }), async (req) => {
+        seen = req.headers.get(X_BOXEL_LOGGING_CORRELATION_ID_HEADER);
+        return new Response('{}', { status: 200 });
+      });
+      return seen;
+    }
+
+    test('is put on a realm-server request', async function (assert) {
+      assert.notStrictEqual(
+        await stampedHeader('https://realm.example/my-realm/_search'),
+        null,
+        'the realm server gets an id to join its logs on',
+      );
+    });
+
+    test('is kept off a Matrix request', async function (assert) {
+      assert.strictEqual(
+        await stampedHeader(
+          'https://matrix.example/_matrix/client/v3/register/email/requestToken',
+        ),
+        null,
+        'no custom header for Synapse to reject at preflight',
+      );
+    });
   });
 });

--- a/packages/host/tests/integration/client-telemetry-test.ts
+++ b/packages/host/tests/integration/client-telemetry-test.ts
@@ -533,9 +533,9 @@ module('Integration | Service | client-telemetry', function (hooks) {
   // Boxel header in it, so a Matrix request carrying one is rejected by the
   // browser at preflight and never leaves the tab. Only the realm server reads
   // the correlation id back out, so a Matrix request has nothing to gain by
-  // carrying it. Armed telemetry is the only state where the stamp happens at
-  // all, and no other suite runs in it — which is how stamping every request
-  // silently broke email registration everywhere while every test passed.
+  // carrying it.
+  // These tests explicitly arm telemetry and assert the header is stamped only
+  // on realm-server requests, not Synapse requests.
   module('the correlation id stamp', function () {
     async function stampedHeader(url: string): Promise<string | null> {
       let svc = telemetry();

--- a/packages/host/tests/integration/client-telemetry-test.ts
+++ b/packages/host/tests/integration/client-telemetry-test.ts
@@ -535,7 +535,9 @@ module('Integration | Service | client-telemetry', function (hooks) {
   // the correlation id back out, so a Matrix request has nothing to gain by
   // carrying it.
   // These tests explicitly arm telemetry and assert the header is stamped only
-  // on realm-server requests, not Synapse requests.
+  // on realm-server requests, not Synapse requests. Arming is what makes the
+  // boundary observable at all — a dormant instrument stamps nothing, so these
+  // assertions pass vacuously without it.
   module('the correlation id stamp', function () {
     async function stampedHeader(url: string): Promise<string | null> {
       let svc = telemetry();


### PR DESCRIPTION
Email/password registration fails in every real browser — local dev, staging, and production — with "There was an error registering: Could not connect to server". Resolves CS-12436.

## What happens

The client-perf telemetry middleware stamps `x-boxel-logging-correlation-id` on every request passing through the fetcher chain (`client-telemetry.ts`), and two host-side `ExtendedClient` overrides use that chain to talk to Synapse rather than the realm server:

- `requestEmailToken` — registration's email step, and adding a 3pid
- `loginWithEmail` — the email-address fallback in `MatrixService.login`

Synapse's `Access-Control-Allow-Headers` is a fixed set with no configuration knob, and no Boxel header is in it. Every homeserver we run answers identically:

```
$ curl -i -X OPTIONS "$HOMESERVER/_matrix/client/v3/register/email/requestToken" \
    -H "Origin: https://app.boxel.ai" \
    -H "Access-Control-Request-Method: POST" \
    -H "Access-Control-Request-Headers: content-type,x-boxel-logging-correlation-id"

access-control-allow-headers: X-Requested-With, Content-Type, Authorization, Date
```

So the browser rejects the preflight and the request never leaves the tab. Registration surfaces that as a connection error. Email-address *login* fails more quietly: `login()` catches the CORS failure and rethrows the original password-login error, so it reads as bad credentials.

## The fix

Only the realm server reads the correlation id back out — Synapse neither reads nor logs it, so a Matrix request has nothing to gain by carrying it and a preflight to lose. The stamp now skips the client-server API, matched by path so it holds for any homeserver origin and for the next override that fetches Synapse. Timing events are still recorded for those requests; only the header is withheld.

## Why no test caught this

The stamp only happens when telemetry is armed, and `#isAllowed()` returns false under `isTesting()`. No suite runs in the state where this breaks, so every registration test — including the matrix e2e that walks the whole email round-trip — passed throughout. The two tests added here arm the instrument explicitly and assert the header reaches a realm-server request and not a Matrix one. Verified they fail with the guard removed.

Full investigation, including how it was found and the blast radius, is in CS-12436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)