### PR TITLE
Expose isolated as a queryable prerendered HTML format

### DIFF
--- a/packages/realm-server/tests/card-html-endpoints-test.ts
+++ b/packages/realm-server/tests/card-html-endpoints-test.ts
@@ -46,6 +46,11 @@ module(basename(import.meta.filename), function () {
 
           export class Person extends CardDef {
             @field firstName = contains(StringField);
+            static isolated = class Isolated extends Component<typeof this> {
+              <template>
+                <h1>Isolated Card Person: <@fields.firstName/></h1>
+              </template>
+            }
             static embedded = class Embedded extends Component<typeof this> {
               <template>
                 Embedded Card Person: <@fields.firstName/>
@@ -227,6 +232,23 @@ module(basename(import.meta.filename), function () {
           .replace(/\s+/g, ' ')
           .includes('Embedded Card Person: John'),
         'the embedded markup is served',
+      );
+    });
+
+    test('?format=isolated serves the isolated rendering', async function (assert) {
+      let response = await cardHtml('/john?format=isolated');
+      assert.strictEqual(response.status, 200);
+      let { data } = bodyOf(response);
+      let html = htmlResourceIn(
+        bodyOf(response),
+        data.relationships.html.data[0].id,
+      );
+      assert.strictEqual(html!.attributes.format, 'isolated');
+      assert.true(
+        (html!.attributes.html ?? '')
+          .replace(/\s+/g, ' ')
+          .includes('Isolated Card Person: John'),
+        'the isolated markup is served',
       );
     });
 

--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -347,6 +347,31 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('html.format: isolated selects the isolated rendering', async function (assert) {
+      let doc = await testRealm.realmIndexQueryEngine.searchEntries(
+        personQuery({
+          filterEq: { htmlQuery: { eq: { format: 'isolated' } } },
+          fields: { entry: ['html'] },
+        }),
+      );
+      assert.deepEqual(doc.meta.htmlQuery, { eq: { format: 'isolated' } });
+      // `isolated` is a scalar column rendered at the row's own native type, so
+      // its composite id carries the native key like the other scalar formats.
+      let htmlId = `${johnId}#isolated#${personKey}`;
+      assert.deepEqual(htmlIdsOf(entryFor(doc, johnId)!), [htmlId]);
+      let html = htmlIn(doc, htmlId)!;
+      assert.strictEqual(html.attributes.format, 'isolated');
+      let markup = normalizedHtml(html);
+      assert.true(
+        markup.includes('<h1'),
+        `isolated rendering carries the card's isolated <h1> markup: ${html.attributes.html}`,
+      );
+      assert.true(
+        markup.includes('John'),
+        `isolated rendering carries the card's field value: ${html.attributes.html}`,
+      );
+    });
+
     test('html.format: head selects the document head rendering', async function (assert) {
       let doc = await testRealm.realmIndexQueryEngine.searchEntries(
         personQuery({

--- a/packages/realm-server/tests/search-entry-test.ts
+++ b/packages/realm-server/tests/search-entry-test.ts
@@ -245,6 +245,13 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('accepts format: isolated as a queryable prerendered format', function (assert) {
+      let parsed = parseSearchEntryQueryFromPayload({
+        filter: { eq: { htmlQuery: { eq: { format: 'isolated' } } } },
+      });
+      assert.deepEqual(parsed.htmlQuery, { eq: { format: 'isolated' } });
+    });
+
     test('sort entries may carry their own item.on anchor', function (assert) {
       let parsed = parseSearchEntryQueryFromPayload({
         sort: [

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -861,11 +861,11 @@ export class IndexQueryEngine {
     // File-only columns the assembly loop reads to build a `file` row's
     // resource + native renderings. Each is gated on `i.type = 'file'` so a
     // mixed query never drags a card row's (potentially multi-megabyte)
-    // `search_doc` / `isolated_html` / `markdown`: within a `(url, type)`
-    // group the type is constant, so the CASE yields the value for a file
-    // group and NULL for an instance group (which the assembly loop ignores
-    // — it only calls `fileEntryFromResult` on `file` rows). Appended to
-    // either projection only when file rows are in scope.
+    // `search_doc` — the only large column in this fragment: within a
+    // `(url, type)` group the type is constant, so the CASE yields the value
+    // for a file group and NULL for an instance group (which the assembly loop
+    // ignores — it only calls `fileEntryFromResult` on `file` rows). Appended
+    // to either projection only when file rows are in scope.
     let fileOnly = (col: string) =>
       `ANY_VALUE(CASE WHEN i.type = 'file' THEN ${col} END)`;
     // Only the columns the file-row assembly actually reads

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -870,10 +870,13 @@ export class IndexQueryEngine {
       `ANY_VALUE(CASE WHEN i.type = 'file' THEN ${col} END)`;
     // Only the columns the file-row assembly actually reads
     // (`fileResourceFromIndex` + `fileEntryFromResult`): the row's search_doc,
-    // timestamps, realm, and index generation. `markdown` and `isolated_html`
-    // are deliberately NOT here — neither the file-meta resource nor its
-    // renderings read them, and `markdown` can be multi-megabyte. The standalone
-    // `searchFiles` projection (below) still carries them for its own consumers.
+    // timestamps, realm, and index generation. `markdown` is deliberately NOT
+    // here — nothing in the file-meta resource or its renderings reads it, and
+    // it can be multi-megabyte. `isolated_html` is a rendering column served to
+    // file renderings too (`enumerateFileRenderings`), so it rides the shared
+    // `renderSet` projection alongside the other per-format HTML columns rather
+    // than this file-only fragment. The standalone `searchFiles` projection
+    // (below) still carries both for its own consumers.
     let fileColumns = `, ${fileOnly('i.search_doc')} as search_doc, ${fileOnly(
       'i.last_modified',
     )} as last_modified, ${fileOnly(
@@ -898,13 +901,13 @@ export class IndexQueryEngine {
     } else {
       // The full rendering set: every per-format HTML column whole (the
       // fitted/embedded JSONB maps keyed by render type, the scalar
-      // atom/head columns), plus the live serialization on every row. The
-      // caller enumerates candidate renderings and selects from the set.
+      // atom/head/isolated columns), plus the live serialization on every row.
+      // The caller enumerates candidate renderings and selects from the set.
       // HTML, the deps that carry its scoped-CSS URLs, and the rendering
       // generation all come from the prerendered_html channel (`ph`); a row
       // with no prerendered row reads them as NULL and falls back to its
       // `item` serialization.
-      let renderSet = `SELECT i.url AS url, ANY_VALUE(i.type) as type, ANY_VALUE(${effectiveHasError()}) as has_error, ANY_VALUE(i.file_alias) as file_alias, ANY_VALUE(ph.fitted_html) as fitted_html, ANY_VALUE(ph.embedded_html) as embedded_html, ANY_VALUE(ph.atom_html) as atom_html, ANY_VALUE(ph.head_html) as head_html, ANY_VALUE(i.types) as types, ANY_VALUE(ph.deps) as deps, ANY_VALUE(i.display_names) as display_names, ANY_VALUE(i.icon_html) as icon_html, ANY_VALUE(${effectiveErrorDoc()}) as error_doc, ANY_VALUE(i.pristine_doc) as pristine_doc, ANY_VALUE(i.generation) as generation, ANY_VALUE(ph.generation) as html_generation`;
+      let renderSet = `SELECT i.url AS url, ANY_VALUE(i.type) as type, ANY_VALUE(${effectiveHasError()}) as has_error, ANY_VALUE(i.file_alias) as file_alias, ANY_VALUE(ph.fitted_html) as fitted_html, ANY_VALUE(ph.embedded_html) as embedded_html, ANY_VALUE(ph.atom_html) as atom_html, ANY_VALUE(ph.head_html) as head_html, ANY_VALUE(ph.isolated_html) as isolated_html, ANY_VALUE(i.types) as types, ANY_VALUE(ph.deps) as deps, ANY_VALUE(i.display_names) as display_names, ANY_VALUE(i.icon_html) as icon_html, ANY_VALUE(${effectiveErrorDoc()}) as error_doc, ANY_VALUE(i.pristine_doc) as pristine_doc, ANY_VALUE(i.generation) as generation, ANY_VALUE(ph.generation) as html_generation`;
       selectClauseExpression =
         entryType !== 'instance' ? [`${renderSet}${fileColumns}`] : [renderSet];
     }

--- a/packages/runtime-common/prerendered-html-format.ts
+++ b/packages/runtime-common/prerendered-html-format.ts
@@ -3,6 +3,7 @@ export const PRERENDERED_HTML_FORMATS = [
   'fitted',
   'atom',
   'head',
+  'isolated',
 ] as const;
 
 export type PrerenderedHtmlFormat = (typeof PRERENDERED_HTML_FORMATS)[number];

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -2063,8 +2063,8 @@ function collectIconId(
 // One candidate rendering of a row, with its markup: a (format, renderType)
 // point in the rendering set the renderSet projection selects. The
 // fitted/embedded JSONB maps contribute one candidate per render-type key;
-// the scalar atom/head columns contribute one candidate at the row's own
-// native type.
+// the scalar atom/head/isolated columns contribute one candidate at the row's
+// own native type.
 type RowRendering = RenderingCandidate & { html: string };
 
 function enumerateRowRenderings(row: {
@@ -2072,6 +2072,7 @@ function enumerateRowRenderings(row: {
   embedded_html?: Record<string, string> | null;
   atom_html?: string | null;
   head_html?: string | null;
+  isolated_html?: string | null;
   types?: string[] | null;
 }): RowRendering[] {
   let candidates: RowRendering[] = [];
@@ -2100,6 +2101,13 @@ function enumerateRowRenderings(row: {
       html: row.head_html,
     });
   }
+  if (row.isolated_html != null) {
+    candidates.push({
+      format: 'isolated',
+      ...(nativeKey ? { renderTypeKey: nativeKey } : {}),
+      html: row.isolated_html,
+    });
+  }
   return candidates;
 }
 
@@ -2124,6 +2132,9 @@ function enumerateFileRenderings(file: IndexedFile): RowRendering[] {
   }
   if (file.headHtml != null) {
     candidates.push({ format: 'head', html: file.headHtml });
+  }
+  if (file.isolatedHtml != null) {
+    candidates.push({ format: 'isolated', html: file.isolatedHtml });
   }
   return candidates;
 }


### PR DESCRIPTION
## Summary

`isolated` HTML is rendered and stored on `prerendered_html.isolated_html` during indexing, but it was **not queryable** through the entry / search APIs. `store.fetchCardEntry(cardId, { format: 'isolated', fields: 'html' })` returned nothing (and didn't even typecheck), while `format: 'embedded'` worked. This makes `isolated` a first-class queryable prerendered format.

The gap was in three places:

- `PRERENDERED_HTML_FORMATS` was `['embedded', 'fitted', 'atom', 'head']` — `isolated` absent, so `assertHtmlQuery` rejected `format=isolated` with a 400 and `store.fetchCardEntry`'s `format` param wouldn't typecheck.
- The `renderSet` SQL projection that feeds `searchEntries` (and therefore `/_search` and `/_federated-search`, plus the single-entry `card+html` GET) selected `fitted/embedded/atom/head` but not `isolated_html`.
- `enumerateRowRenderings` / `enumerateFileRenderings` never emitted an `isolated` candidate.

## Changes

- Add `'isolated'` to `PRERENDERED_HTML_FORMATS`. Validation, the query-param path, the error message, `RenderingCandidate.format`, and `store.fetchCardEntry`'s param type all key off this and pick it up automatically.
- Select `ph.isolated_html` in the `renderSet` projection. Federated search is a pure fan-out over each realm's `searchEntries`, so this one projection change covers `/_search` and `/_federated-search` as well as the single-instance `card+html` GET.
- Emit an `isolated` candidate from `enumerateRowRenderings` and `enumerateFileRenderings`. `isolated` is a scalar column rendered at the row's native type, so it behaves exactly like `atom`/`head`.

## Notes

- The default realm-index card (`CardsGrid`/`Workspace`) stores a boilerplate placeholder in `isolated_html` unless the realm sets `includePrerenderedDefaultRealmIndex: true`. Regular cards return real isolated HTML immediately; index cards need that per-realm opt-in. Not affected by this change.
- `renderSet` pulls the whole rendering set regardless of the requested format (it enumerates candidates then filters), so every html search now also reads the `isolated_html` column — consistent with how the other per-format columns already work, and only material when the `html` fieldset is requested.
- This is complementary to CS-12386 (which is being revisited now that we've decided to keep prerendered isolated).

## Testing

Added tests mirroring the existing `embedded`/`head` coverage:

- `search-entries-engine-test.ts` — `searchEntries` with `format: 'isolated'` returns the isolated rendering at the row's native type.
- `card-html-endpoints-test.ts` — the content-negotiated `GET /john?format=isolated` (the `fetchCardEntry` path) serves the isolated markup.
- `search-entry-test.ts` — `format: 'isolated'` now parses/validates instead of being rejected.

Typecheck (`ember-tsc`) and eslint pass for `runtime-common` and `realm-server`.

Fixes CS-12437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)