### PR TITLE
Support a LIVE_TEST_FILTER env in the live-test testem config

### DIFF
--- a/packages/host/testem-live.js
+++ b/packages/host/testem-live.js
@@ -12,10 +12,17 @@ const realmURLs = process.env.REALM_URL
   ? [process.env.REALM_URL]
   : DEFAULT_REALM_URLS;
 
+// Optional QUnit filter (plain substring or /regex/) so a caller can run a
+// subset of the realm's tests — e.g. content-only catalog PRs run just the
+// real-catalog-app smoke test.
+const filterParam = process.env.LIVE_TEST_FILTER
+  ? `&filter=${encodeURIComponent(process.env.LIVE_TEST_FILTER)}`
+  : '';
+
 const config = {
   test_page: realmURLs.map(
     (url) =>
-      `tests/index.html?liveTest=true&realmURL=${encodeURIComponent(url)}&hidepassed`,
+      `tests/index.html?liveTest=true&realmURL=${encodeURIComponent(url)}&hidepassed${filterParam}`,
   ),
   disable_watching: true,
   browser_timeout: 120,


### PR DESCRIPTION
Adds an optional `LIVE_TEST_FILTER` env to `packages/host/testem-live.js`: when set, its value is appended to the live-test page URL as QUnit's `filter=` param (plain substring or `/regex/`), so a caller can run a subset of the realm's discovered tests.

The consumer is boxel-catalog's CI: its live-test job (~28 min) spends ~17 min on acceptance suites that only exercise catalog-app source against mock realms, so content-only listing PRs there will set this to run just the real-catalog-app smoke test. Unset, behavior is unchanged — the full suite runs.

Verified by evaluating the config with and without the env:

- with: `…&hidepassed&filter=real%20catalog%20app`
- without: `…&hidepassed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)