### PR TITLE
Make the OIDC mapping provider's get_remote_user_id synchronous

### DIFF
--- a/packages/matrix/support/synapse/modules/boxel_oidc_mapping_provider.py
+++ b/packages/matrix/support/synapse/modules/boxel_oidc_mapping_provider.py
@@ -56,7 +56,20 @@ class BoxelOidcMappingProvider:
     def parse_config(config: JsonDict) -> dict:
         return dict(config or {})
 
-    async def get_remote_user_id(self, userinfo: JsonDict) -> str:
+    # MUST stay synchronous. Synapse calls this without awaiting it (see
+    # `synapse.handlers.oidc`, which does
+    # `subject = self._user_mapping_provider.get_remote_user_id(user)`) and
+    # stores the result as the `external_id` it matches Google identities
+    # against. Declaring it `async` makes the stored id the *coroutine's*
+    # repr — a string embedding `id()`, i.e. a heap address. Because the
+    # coroutine is never awaited it is freed immediately and the allocator
+    # reuses the block, so those addresses recur across sign-ins: a later
+    # sign-in whose repr collides with an existing `user_external_ids` row is
+    # logged in as that row's owner, and `map_user_attributes` — with all of
+    # the verified-email, ambiguity and collision checks below — is skipped
+    # entirely. `map_user_attributes` and `get_extra_attributes` are awaited
+    # by Synapse and must stay `async`; this one must not.
+    def get_remote_user_id(self, userinfo: JsonDict) -> str:
         return userinfo["sub"]
 
     async def map_user_attributes(

--- a/packages/matrix/support/synapse/modules/test_boxel_oidc_mapping_provider.py
+++ b/packages/matrix/support/synapse/modules/test_boxel_oidc_mapping_provider.py
@@ -7,6 +7,7 @@ relies on. They import the real `synapse.*` types, so they must run inside the
 pinned Synapse image (see scripts/test-oidc-mapping-provider.sh).
 """
 
+import inspect
 import unittest
 from unittest.mock import AsyncMock, Mock
 
@@ -90,6 +91,41 @@ class MapUserAttributesTests(unittest.IsolatedAsyncioTestCase):
         provider = make_provider(existing_users=["alice", "alice1", "alice2"])
         result = await provider.map_user_attributes(userinfo(), {}, 0)
         self.assertEqual(result["localpart"], "alice3")
+
+
+class InterfaceShapeTests(unittest.TestCase):
+    """Guards on which methods Synapse awaits and which it does not.
+
+    Synapse calls `get_remote_user_id` without awaiting it and uses the return
+    value as the `external_id` that Google identities are matched against. If
+    it is a coroutine function, the stored id becomes the coroutine's repr —
+    which embeds a reused heap address — and colliding reprs log a signing-in
+    user into somebody else's account, skipping `map_user_attributes` and every
+    check it performs. `map_user_attributes` and `get_extra_attributes` are
+    awaited, so they must stay `async`.
+    """
+
+    def test_get_remote_user_id_is_not_a_coroutine_function(self):
+        self.assertFalse(
+            inspect.iscoroutinefunction(
+                BoxelOidcMappingProvider.get_remote_user_id
+            )
+        )
+
+    def test_get_remote_user_id_returns_the_sub_as_a_plain_string(self):
+        provider = make_provider()
+        result = provider.get_remote_user_id(userinfo(sub="google-oauth2|42"))
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, "google-oauth2|42")
+
+    def test_awaited_methods_stay_coroutine_functions(self):
+        for name in ("map_user_attributes", "get_extra_attributes"):
+            with self.subTest(method=name):
+                self.assertTrue(
+                    inspect.iscoroutinefunction(
+                        getattr(BoxelOidcMappingProvider, name)
+                    )
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Synapse's `OidcMappingProvider` interface declares `get_remote_user_id` as synchronous, and Synapse calls it without awaiting it. Our provider declared it `async`, so the value Synapse stored as the identity's `external_id` was the coroutine's repr rather than the subject claim.

That repr embeds `id()`, a heap address. Because the coroutine is never awaited it is freed immediately and the allocator reuses the block, so those addresses recur between sign-ins. A sign-in whose repr matched a previously stored row was treated as a known identity and authenticated as that row's owner. That path short-circuits before `map_user_attributes`, so none of this provider's verified-email, ambiguity or derived-localpart collision checks ran — every safeguard in the module was bypassed rather than failing.

Removing `async` restores the interface contract, so the stored id is the `sub` claim again. `map_user_attributes` and `get_extra_attributes` are awaited by Synapse and stay `async`; the comment on the method records which of the three Synapse awaits, since the asymmetry is the whole trap.

The existing tests only drove `map_user_attributes`, so nothing covered the shape of the interface itself and the defect was invisible to them. This adds three guards: `get_remote_user_id` is not a coroutine function, it returns the subject as a plain string, and the two awaited methods remain coroutine functions so the opposite mistake is caught too. I verified the guards fail when `async` is reintroduced, and that the failure reproduces the coroutine repr rather than a subject id.

Two things this PR does not do. The deployed homeserver loads this module from outside the repo, so merging this does not by itself change a running deployment. And there is no end-to-end sign-in test — the guards here are unit-level, so a browser-level test covering two accounts signing in remains worth adding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)