### PR TITLE
Assert each Google identity is stored under its own subject claim

### DIFF
--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -4,6 +4,7 @@ import {
   loginUser,
   getAllRoomEvents,
   getJoinedRooms,
+  getUserExternalIds,
   registerUser,
   type SynapseInstance,
   sync,
@@ -93,6 +94,20 @@ export async function updateSynapseUser(
 ) {
   let { adminAccessToken } = getMatrixTestContext();
   await updateUser(adminAccessToken, userId, options);
+}
+
+// The SSO identities linked to an account, narrowed to one IdP. Returns the
+// bare external ids, which for an OIDC provider are the values its mapping
+// provider derived from the `sub` claim.
+export async function getExternalIdsForIdp(
+  userId: string,
+  authProvider: string,
+): Promise<string[]> {
+  let { adminAccessToken } = getMatrixTestContext();
+  let externalIds = await getUserExternalIds(adminAccessToken, userId);
+  return externalIds
+    .filter((entry) => entry.auth_provider === authProvider)
+    .map((entry) => entry.external_id);
 }
 
 async function registerRealmRedirect(

--- a/packages/matrix/support/synapse/index.ts
+++ b/packages/matrix/support/synapse/index.ts
@@ -613,6 +613,36 @@ export async function updateUser(
   }
 }
 
+export interface SynapseExternalId {
+  auth_provider: string;
+  external_id: string;
+}
+
+// Reads the admin API's view of an account, whose payload includes the
+// `external_ids` rows linking it to SSO identities. That linkage is otherwise
+// invisible from the client API, and it is the value an OIDC sign-in is matched
+// against — so it is what a test has to inspect to know *which* identity a
+// session was established for, rather than merely that some session was.
+export async function getUserExternalIds(
+  adminAccessToken: string,
+  userId: string,
+  matrixURL?: string,
+): Promise<SynapseExternalId[]> {
+  let url = `${matrixURL ?? getSynapseURL()}/_synapse/admin/v2/users/${userId}`;
+  let res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${adminAccessToken}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`could not get user: ${res.status} - ${await res.text()}`);
+  }
+  let { external_ids: externalIds } = (await res.json()) as {
+    external_ids?: SynapseExternalId[];
+  };
+  return externalIds ?? [];
+}
+
 export async function updateAccountData(
   userId: string,
   accessToken: string,

--- a/packages/matrix/tests/google-sso.spec.ts
+++ b/packages/matrix/tests/google-sso.spec.ts
@@ -20,6 +20,17 @@ interface GoogleIdentity {
   name: string;
 }
 
+// A subject claim has to be unique per test *attempt*, not just per test. One
+// Synapse instance serves the whole run and CI retries twice, so a subject that
+// signed in on an earlier attempt is already in `user_external_ids` — and
+// Synapse short-circuits on that row, logging the retry into the previous
+// attempt's account before the email-linking path runs. Deriving it from the
+// generated (UUID-suffixed) username keeps every attempt a fresh identity, so a
+// retry can actually recover from a flake instead of failing on stale state.
+function subjectFor(username: string): string {
+  return `google-oauth2|${username}`;
+}
+
 // Drives one sign-in from the host's Google button through the mock IdP's
 // interactive login form and back. `sub` is what the mock echoes as the subject
 // claim, so each caller controls the identity being presented.
@@ -81,7 +92,7 @@ test.describe('Google sign-in (mock OIDC)', () => {
     // Synapse advertises the oidc-google IdP, so signing in through it already
     // exercises the login-flow detection.
     await signInWithGoogle(page, {
-      sub: 'google-oauth2|returning',
+      sub: subjectFor(username),
       email: userEmail,
       name: 'Returning Google User',
     });
@@ -110,8 +121,8 @@ test.describe('Google sign-in (mock OIDC)', () => {
     });
     await setupPermissions(other.credentials.userId, `${appURL}/`);
 
-    let sub = 'google-oauth2|first-identity';
-    let otherSub = 'google-oauth2|second-identity';
+    let sub = subjectFor(username);
+    let otherSub = subjectFor(other.username);
 
     await signInWithGoogle(page, { sub, email: userEmail, name: 'First User' });
     await expectSignedInAs(page, `@${username}:localhost`);

--- a/packages/matrix/tests/google-sso.spec.ts
+++ b/packages/matrix/tests/google-sso.spec.ts
@@ -1,11 +1,52 @@
 import { expect, test } from './fixtures.ts';
+import type { Page } from '@playwright/test';
 import type { Credentials } from '../support/synapse/index.ts';
 import { appURL } from '../support/isolated-realm-server.ts';
 import {
   createSubscribedUser,
+  getExternalIdsForIdp,
+  setRealmRedirects,
   setupPermissions,
   updateSynapseUser,
 } from '../helpers/index.ts';
+
+// Synapse surfaces the `google` provider to clients — and stores its
+// `user_external_ids` rows — as `oidc-google`.
+const GOOGLE_IDP = 'oidc-google';
+
+interface GoogleIdentity {
+  sub: string;
+  email: string;
+  name: string;
+}
+
+// Drives one sign-in from the host's Google button through the mock IdP's
+// interactive login form and back. `sub` is what the mock echoes as the subject
+// claim, so each caller controls the identity being presented.
+async function signInWithGoogle(
+  page: Page,
+  { sub, email, name }: GoogleIdentity,
+) {
+  await page.goto(appURL);
+  await page.locator('[data-test-google-login-btn]').click();
+  await page.locator('input[name="username"]').fill(sub);
+  await page
+    .locator('textarea[name="claims"]')
+    .fill(JSON.stringify({ email, email_verified: true, name }));
+  await page.locator('input[type="submit"]').click();
+}
+
+async function expectSignedInAs(page: Page, userId: string) {
+  // The operator-mode stack confirms a successful session start.
+  await expect(page.locator('[data-test-operator-mode-stack="0"]')).toHaveCount(
+    1,
+  );
+  await page.locator('[data-test-profile-icon-button]').click();
+  await expect(page.locator('[data-test-profile-icon-handle]')).toContainText(
+    userId,
+  );
+  await page.keyboard.press('Escape');
+}
 
 // Drives the full Google sign-in round-trip through the real host UI against
 // navikt/mock-oauth2-server (wired up in tests/global.setup.ts):
@@ -36,39 +77,68 @@ test.describe('Google sign-in (mock OIDC)', () => {
   test('a returning user with a matching verified email is linked to their existing account', async ({
     page,
   }) => {
-    await page.goto(appURL);
-
-    // The button only renders when the flag is on (host dev build) AND Synapse
-    // advertises the oidc-google IdP, so its presence already exercises the
-    // login-flow detection.
-    await page.locator('[data-test-google-login-btn]').click();
-
-    // Synapse redirects to the mock's interactive login form. `username`
-    // becomes the `sub`; the claims textarea carries the verified email the
-    // mapping provider keys on.
-    await page
-      .locator('input[name="username"]')
-      .fill('google-oauth2|returning');
-    await page.locator('textarea[name="claims"]').fill(
-      JSON.stringify({
-        email: userEmail,
-        email_verified: true,
-        name: 'Returning Google User',
-      }),
-    );
-    await page.locator('input[type="submit"]').click();
-
-    // Back on the host with a loginToken, signed in. The operator-mode stack
-    // confirms a successful session start.
-    await expect(
-      page.locator('[data-test-operator-mode-stack="0"]'),
-    ).toHaveCount(1);
+    // The Google button only renders when the flag is on (host dev build) AND
+    // Synapse advertises the oidc-google IdP, so signing in through it already
+    // exercises the login-flow detection.
+    await signInWithGoogle(page, {
+      sub: 'google-oauth2|returning',
+      email: userEmail,
+      name: 'Returning Google User',
+    });
 
     // The crucial assertion: we are signed in as the *existing* mxid, not a
     // freshly-created duplicate.
-    await page.locator('[data-test-profile-icon-button]').click();
-    await expect(page.locator('[data-test-profile-icon-handle]')).toContainText(
-      `@${username}:localhost`,
-    );
+    await expectSignedInAs(page, `@${username}:localhost`);
+  });
+
+  // Two people signing in from two devices, which is the shape the wrong-account
+  // incident took. Landing in the right account is necessary but not sufficient
+  // as an assertion: the identity Synapse *stored* for each of them is what a
+  // later sign-in gets matched against, so a session that looks correct here can
+  // still have written a row that hands the account to somebody else next time.
+  // Hence the external-id assertions — they are what fail when
+  // `get_remote_user_id` is a coroutine function and the stored id is a repr
+  // carrying a heap address rather than the subject claim.
+  test('each Google identity signs in to its own account and is stored under its own subject claim', async ({
+    browser,
+    page,
+  }) => {
+    let other = await createSubscribedUser('google-sso-other');
+    let otherEmail = `${other.username}@example.com`;
+    await updateSynapseUser(other.credentials.userId, {
+      emailAddresses: [otherEmail],
+    });
+    await setupPermissions(other.credentials.userId, `${appURL}/`);
+
+    let sub = 'google-oauth2|first-identity';
+    let otherSub = 'google-oauth2|second-identity';
+
+    await signInWithGoogle(page, { sub, email: userEmail, name: 'First User' });
+    await expectSignedInAs(page, `@${username}:localhost`);
+
+    // A separate context is the second device: its own cookie jar, so the mock
+    // IdP prompts again instead of reusing the first sign-in's session, and the
+    // host cannot carry over any client-side state.
+    let context = await browser.newContext();
+    let otherPage = await context.newPage();
+    try {
+      await setRealmRedirects(otherPage);
+      await signInWithGoogle(otherPage, {
+        sub: otherSub,
+        email: otherEmail,
+        name: 'Second User',
+      });
+      await expectSignedInAs(otherPage, `@${other.username}:localhost`);
+    } finally {
+      await context.close().catch(() => {});
+    }
+
+    // Each account is linked to exactly the subject claim it presented.
+    expect(await getExternalIdsForIdp(credentials.userId, GOOGLE_IDP)).toEqual([
+      sub,
+    ]);
+    expect(
+      await getExternalIdsForIdp(other.credentials.userId, GOOGLE_IDP),
+    ).toEqual([otherSub]);
   });
 });


### PR DESCRIPTION
Follow-up to #5695. That PR made `get_remote_user_id` synchronous and added unit tests guarding the method's shape. It noted an end-to-end sign-in test was still missing — this is that test.

### Why the old test didn't catch the bug

There are two different things a sign-in test can check:

1. **Did this person end up in the right account?** — what the existing test checked.
2. **Which Google identity did Synapse record for that account?** — what nothing checked.

The second one is what matters, because that recorded identity (the `external_id`) is what the *next* sign-in gets matched against. With the bug, Synapse recorded a meaningless string containing a memory address instead of the user's Google subject id. Every sign-in still worked, because the provider fell back to matching on verified email — so check 1 passed. But those bad rows were left behind, and when a later sign-in produced the same recycled memory address, it matched an existing row and logged that person into someone else's account.

So the old test could pass while the system was actively writing the rows that cause the incident.

### What this test does

Two users sign in with two different Google identities. The second uses a separate browser context, so the mock identity provider asks for login again and no state carries over from the first — the two-device situation the real incident involved.

Then, for each account, it reads back the Google identity Synapse actually stored (via the Synapse admin API) and asserts it is exactly the subject id that was presented. That assertion is the one that fails on the old code, because the stored value was the memory-address string rather than the subject id.

Each subject claim is derived from the generated username rather than hard-coded. One Synapse instance serves the whole Playwright run and CI retries twice, so a fixed subject would already be linked to the previous attempt's account — and Synapse short-circuits on that existing row before the email-linking path runs, which would make a retry fail deterministically instead of recovering from the original flake. Deriving the subject keeps every attempt a fresh identity. The pre-existing sign-in test had the same hazard; it was latent while the stored ids were meaningless strings and became live once #5695 started storing real subject ids.

### Supporting change

`getUserExternalIds` is new in the Synapse support module — an account's linked SSO identities aren't visible through the normal client API, only the admin API. `getExternalIdsForIdp` narrows the result to a single provider.

### Checks I ran

- Confirmed the pinned Synapse image's admin API returns `external_ids`, so the test needs no direct database access.
- Ran the pinned mock identity provider on its own through the authorize/token exchange to confirm it uses the submitted username as the `sub` claim verbatim, `|` included. The new assertion depends on that, so it was worth proving rather than assuming.

### Not verified

I haven't run the Playwright suite locally — it needs ports and container names a running dev stack already occupies, and the host build fails for unrelated reasons under a dotted worktree path. CI will be the first real run of this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
