### PR TITLE
Give each Google sign-in test attempt its own OIDC subject claim

### DIFF
--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -105,9 +105,21 @@ export async function getExternalIdsForIdp(
 ): Promise<string[]> {
   let { adminAccessToken } = getMatrixTestContext();
   let externalIds = await getUserExternalIds(adminAccessToken, userId);
+  // Sorted: the admin API reports rows in database order, so an account with
+  // more than one linked identity would make assertions order-dependent.
   return externalIds
     .filter((entry) => entry.auth_provider === authProvider)
-    .map((entry) => entry.external_id);
+    .map((entry) => entry.external_id)
+    .sort();
+}
+
+// The subject claim to present to the mock identity provider. One Synapse
+// instance serves the whole run, so a subject reused across attempts matches the
+// `user_external_ids` row an earlier attempt left behind and signs the retry
+// into that account. Deriving it from the UUID-suffixed username keeps every
+// attempt a fresh identity.
+export function subjectFor(username: string): string {
+  return `google-oauth2|${username}`;
 }
 
 async function registerRealmRedirect(

--- a/packages/matrix/tests/cli-sso.spec.ts
+++ b/packages/matrix/tests/cli-sso.spec.ts
@@ -1,7 +1,11 @@
 import { expect, test } from './fixtures.ts';
-import { getMatrixTestContext } from '../helpers/index.ts';
+import {
+  createSubscribedUser,
+  getMatrixTestContext,
+  subjectFor,
+  updateSynapseUser,
+} from '../helpers/index.ts';
 import { appURL } from '../support/isolated-realm-server.ts';
-import { createSubscribedUser, updateSynapseUser } from '../helpers/index.ts';
 import { browserLogin } from '../../boxel-cli/src/lib/sso-login.ts';
 
 // The realm server serves the host app, so /cli-auth lives at its root. Taken
@@ -76,9 +80,10 @@ test.describe('boxel-cli browser authorization', () => {
       openBrowserFn: async (authUrl) => {
         await page.goto(authUrl);
         await page.locator('[data-test-cli-auth-google]').click();
-        // The mock OIDC provider's interactive login form: `username` becomes
-        // the sub, and `claims` carries the verified email.
-        await page.locator('input[name="username"]').fill('google-oauth2|cli');
+        // The mock provider's login form: its `username` field becomes the sub,
+        // and `claims` carries the verified email. See `subjectFor` for why the
+        // sub is derived rather than fixed.
+        await page.locator('input[name="username"]').fill(subjectFor(username));
         await page.locator('textarea[name="claims"]').fill(
           JSON.stringify({
             email: userEmail,

--- a/packages/matrix/tests/google-sso.spec.ts
+++ b/packages/matrix/tests/google-sso.spec.ts
@@ -7,6 +7,7 @@ import {
   getExternalIdsForIdp,
   setRealmRedirects,
   setupPermissions,
+  subjectFor,
   updateSynapseUser,
 } from '../helpers/index.ts';
 
@@ -18,17 +19,6 @@ interface GoogleIdentity {
   sub: string;
   email: string;
   name: string;
-}
-
-// A subject claim has to be unique per test *attempt*, not just per test. One
-// Synapse instance serves the whole run and CI retries twice, so a subject that
-// signed in on an earlier attempt is already in `user_external_ids` — and
-// Synapse short-circuits on that row, logging the retry into the previous
-// attempt's account before the email-linking path runs. Deriving it from the
-// generated (UUID-suffixed) username keeps every attempt a fresh identity, so a
-// retry can actually recover from a flake instead of failing on stale state.
-function subjectFor(username: string): string {
-  return `google-oauth2|${username}`;
 }
 
 // Drives one sign-in from the host's Google button through the mock IdP's
@@ -102,14 +92,11 @@ test.describe('Google sign-in (mock OIDC)', () => {
     await expectSignedInAs(page, `@${username}:localhost`);
   });
 
-  // Two people signing in from two devices, which is the shape the wrong-account
-  // incident took. Landing in the right account is necessary but not sufficient
-  // as an assertion: the identity Synapse *stored* for each of them is what a
-  // later sign-in gets matched against, so a session that looks correct here can
-  // still have written a row that hands the account to somebody else next time.
-  // Hence the external-id assertions — they are what fail when
-  // `get_remote_user_id` is a coroutine function and the stored id is a repr
-  // carrying a heap address rather than the subject claim.
+  // Two people signing in from two devices. The identity Synapse *stores* is what
+  // the next sign-in gets matched against, so landing in the right account is not
+  // enough — a correct-looking session can still write a row that hands the
+  // account to somebody else. Hence assertions on the stored external ids rather
+  // than on the session alone.
   test('each Google identity signs in to its own account and is stored under its own subject claim', async ({
     browser,
     page,


### PR DESCRIPTION
**Summary:** Fixes a hard-coded OIDC subject claim in `cli-sso.spec.ts` that made the test fail deterministically on any CI retry, hoisting `subjectFor` into the shared test helpers so all three call sites derive a fresh identity per attempt.

- Hoist `subjectFor` into helpers, use it in `cli-sso.spec.ts` *(fixes a live failure)*
- Sort in `getExternalIdsForIdp`
- Evergreen pass on the two-identity test's comment

### Details

`cli-sso.spec.ts` presented a fixed subject claim, `google-oauth2|cli`, to the mock identity provider. One Synapse instance serves the whole Playwright run, so the first attempt's sign-in leaves a `user_external_ids` row behind. A retry creates a fresh account but presents the same subject, matches that row, and short-circuits to the first attempt's mxid before the email-linking path runs — so the assertion on `auth.userId` compares the earlier account against the retry's username and fails. Either the first attempt passes or the job fails; a retry cannot recover from a flake.

The subject is now derived from the account's UUID-suffixed username, regenerated per attempt, so every attempt presents an identity Synapse has not seen before. `subjectFor` moves into the test helpers as the third call site to need it. A fixed subject was harmless while `get_remote_user_id` was `async` and the stored id was the coroutine object's string form — which embeds a reused memory address rather than the subject claim, so no sign-in ever matched a prior row. Storing real subject ids is what made a fixed subject a guaranteed collision.

### Additional Fixes

- `getExternalIdsForIdp` sorts its result. The admin API reports `external_ids` in whatever order the database returns them, so an account with more than one linked identity would make a caller's assertion order-dependent.
- The comment above the two-identity test described the assertion in terms of a bug that has since been fixed, and referred to an event a future reader cannot look up. It now states what the assertion enforces as a standing property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
