### PR TITLE
Trace hand-rolled browser contexts so their failures leave an artifact

### DIFF
--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from '@playwright/test';
+import { expect, test, type Browser, type Page } from '@playwright/test';
 import type { Credentials } from '../support/synapse/index.ts';
 import {
   loginUser,
@@ -134,6 +134,57 @@ export async function setRealmRedirects(page: Page) {
     'http://localhost:4201/base/',
     'https://localhost:4205/base/',
   );
+}
+
+// Runs `body` against a page in a context built by hand, rather than the one the
+// `page` fixture provides. Two situations need that: a second browser identity
+// inside one test, and `beforeAll`, which only sees worker-scoped fixtures.
+//
+// Playwright attaches traces, video and screenshots in its own `context`
+// fixture, so a context from `browser.newContext()` records nothing — a failure
+// in one is reported with no artifact to open. This starts a trace and keeps it
+// when there is something to explain, so the failing run carries the same
+// evidence a fixture-backed page would.
+//
+// The trace is kept in two cases. When `body` throws, obviously. And on any
+// retry, whatever `body` does — because the context has to close when `body`
+// returns, so a failure *after* that point (an assertion about what the session
+// persisted, say) can no longer be traced from here. Keeping the trace for the
+// whole of a retried attempt covers that, and mirrors the suite's
+// `trace: 'retry-with-trace'`: a first attempt stays cheap, and the attempt that
+// runs because something already failed records everything.
+//
+// Closing is best-effort on every path: a context that has wedged can fail or
+// hang on close, and that must not replace the real error, nor turn a completed
+// body into a failure.
+export async function withTracedContext<T>(
+  browser: Browser,
+  name: string,
+  body: (page: Page) => Promise<T>,
+): Promise<T> {
+  let context = await browser.newContext();
+  await context.tracing.start({ screenshots: true, snapshots: true });
+  let keepTrace = test.info().retry > 0;
+  try {
+    let page = await context.newPage();
+    await setRealmRedirects(page);
+    return await body(page);
+  } catch (e) {
+    keepTrace = true;
+    throw e;
+  } finally {
+    if (keepTrace) {
+      let tracePath = test.info().outputPath(`${name}-trace.zip`);
+      await context.tracing.stop({ path: tracePath }).catch(() => {});
+      await test
+        .info()
+        .attach(`${name}-trace`, { path: tracePath })
+        .catch(() => {});
+    } else {
+      await context.tracing.stop().catch(() => {});
+    }
+    await context.close().catch(() => {});
+  }
 }
 
 export async function registerRealmUsers(synapse: SynapseInstance) {

--- a/packages/matrix/tests/google-sso.spec.ts
+++ b/packages/matrix/tests/google-sso.spec.ts
@@ -5,9 +5,9 @@ import { appURL } from '../support/isolated-realm-server.ts';
 import {
   createSubscribedUser,
   getExternalIdsForIdp,
-  setRealmRedirects,
   setupPermissions,
   updateSynapseUser,
+  withTracedContext,
 } from '../helpers/index.ts';
 
 // Synapse surfaces the `google` provider to clients — and stores its
@@ -130,19 +130,14 @@ test.describe('Google sign-in (mock OIDC)', () => {
     // A separate context is the second device: its own cookie jar, so the mock
     // IdP prompts again instead of reusing the first sign-in's session, and the
     // host cannot carry over any client-side state.
-    let context = await browser.newContext();
-    let otherPage = await context.newPage();
-    try {
-      await setRealmRedirects(otherPage);
+    await withTracedContext(browser, 'second-device', async (otherPage) => {
       await signInWithGoogle(otherPage, {
         sub: otherSub,
         email: otherEmail,
         name: 'Second User',
       });
       await expectSignedInAs(otherPage, `@${other.username}:localhost`);
-    } finally {
-      await context.close().catch(() => {});
-    }
+    });
 
     // Each account is linked to exactly the subject claim it presented.
     expect(await getExternalIdsForIdp(credentials.userId, GOOGLE_IDP)).toEqual([

--- a/packages/matrix/tests/host-mode.spec.ts
+++ b/packages/matrix/tests/host-mode.spec.ts
@@ -4,9 +4,9 @@ import {
   createSubscribedUserAndLogin,
   logout,
   postCardSource,
-  setRealmRedirects,
   waitForPublishedMarker,
   waitUntil,
+  withTracedContext,
 } from '../helpers/index.ts';
 import { appURL } from '../support/isolated-realm-server.ts';
 import { randomUUID } from 'crypto';
@@ -89,8 +89,8 @@ async function publishRealm(
 
 // Create a fresh source realm, seed it with the host-mode fixture cards, and
 // publish it. Leaves the page logged out. The `page` must already have realm
-// redirects registered (the per-test `page` fixture does this; a hand-rolled
-// context page must call `setRealmRedirects` first).
+// redirects registered — the per-test `page` fixture and `withTracedContext`
+// both do this.
 //
 // `options.routingRulePath` seeds a `realm.json` host routing rule (mapping
 // that path to the white-paper card) BEFORE the single publish — so routing
@@ -337,16 +337,16 @@ test.describe('Host mode', () => {
     test.setTimeout(180_000);
     let lastError: unknown;
     for (let attempt = 1; attempt <= 3; attempt++) {
-      // `beforeAll` only has access to worker-scoped fixtures, so build a
-      // throwaway context by hand. Publishing is server-side state that
-      // outlives this context, so we close it once setup is done.
-      const context = await browser.newContext();
-      const page = await context.newPage();
+      // `beforeAll` only has access to worker-scoped fixtures, so the context is
+      // built by hand. Publishing is server-side state that outlives it, so it
+      // closes once setup is done. Each attempt traces separately — the trace of
+      // the attempt that failed is what explains why setup never took.
       try {
-        await setRealmRedirects(page);
-        realm = await createAndPublishHostModeRealm(page);
-        // Don't let a wedged context's close error mask a successful setup.
-        await context.close().catch(() => {});
+        realm = await withTracedContext(
+          browser,
+          `host-mode-setup-attempt-${attempt}`,
+          (page) => createAndPublishHostModeRealm(page),
+        );
         return;
       } catch (e) {
         lastError = e;
@@ -355,7 +355,6 @@ test.describe('Host mode', () => {
             (e as Error)?.message
           }`,
         );
-        await context.close().catch(() => {});
       }
     }
     throw lastError;


### PR DESCRIPTION
**Summary:** Adds tracing to the two Playwright tests that build their own browser context, so a CI failure in either leaves a trace to open instead of nothing.

--

Playwright wires trace, video and screenshot capture into its own `context` fixture, so a context created by `browser.newContext()` records nothing. Two places build one by hand — the second device in the Google sign-in test, and the shared publish in host mode's `beforeAll`, which only sees worker-scoped fixtures. Both failed with no artifact to open, while the fixture-backed `page` in the same run had one. With `trace: 'retry-with-trace'`, a retry produced a trace for the wrong half of the test.

`withTracedContext(browser, name, body)` takes over creating the context, registering realm redirects, and closing it. It starts a trace and keeps it when there is something to explain: when `body` throws, and on any retry whatever `body` does. That second case matters because the context has to close when `body` returns, so a failure *after* that point — an assertion about what the session persisted, say — cannot be traced from inside the helper; keeping the trace for the whole of a retried attempt covers it, and mirrors `trace: 'retry-with-trace'` in leaving first attempts cheap. Closing stays best-effort on every path, so a context that has wedged can neither replace the real error nor turn a completed body into a failure — the property the previous inline code was careful about, now in one place.

Host mode traces each setup attempt under its own name. That loop retries three times, and the attempt that failed is the one worth reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
