### PR TITLE
Extract EXIF and color facts from raster image files

### DIFF
--- a/packages/base/avif-image-def.gts
+++ b/packages/base/avif-image-def.gts
@@ -1,13 +1,20 @@
 import { readFirstBytes } from '@cardstack/runtime-common';
-import ImageDef from './image-file-def';
-import { type ByteStream, type SerializedFile } from './file-api';
-import { extractAvifDimensions } from './avif-meta-extractor';
+import {
+  RasterImageDef,
+  rasterImageAttributes,
+  type RasterImageAttributes,
+} from './image-file-def';
+import type { ByteStream, SerializedFile } from './file-api';
+import {
+  extractAvifColorProfile,
+  extractAvifDimensions,
+} from './avif-meta-extractor';
 
 // The AVIF ispe box is typically within the first few KB, but can follow
 // other ISOBMFF boxes. 64 KB covers virtually all real-world files.
 const AVIF_MAX_HEADER_BYTES = 65_536;
 
-export class AvifDef extends ImageDef {
+export class AvifDef extends RasterImageDef {
   static displayName = 'AVIF Image';
   static acceptTypes = '.avif,image/avif';
 
@@ -15,7 +22,9 @@ export class AvifDef extends ImageDef {
     url: string,
     getStream: () => Promise<ByteStream>,
     options: { contentHash?: string } = {},
-  ): Promise<SerializedFile<{ width: number; height: number }>> {
+  ): Promise<
+    SerializedFile<{ width: number; height: number } & RasterImageAttributes>
+  > {
     let base = await super.extractAttributes(url, getStream, options);
     let bytes = await readFirstBytes(await getStream(), AVIF_MAX_HEADER_BYTES);
     let { width, height } = extractAvifDimensions(bytes);
@@ -24,6 +33,9 @@ export class AvifDef extends ImageDef {
       ...base,
       width,
       height,
+      // AVIF stores EXIF as a separate metadata item elsewhere in the box tree;
+      // the item-location walk that reaches it isn't part of this pass.
+      ...rasterImageAttributes(undefined, extractAvifColorProfile(bytes)),
     };
   }
 }

--- a/packages/base/avif-meta-extractor.ts
+++ b/packages/base/avif-meta-extractor.ts
@@ -11,6 +11,10 @@ const FTYP_MARKER = new Uint8Array([0x66, 0x74, 0x79, 0x70]); // "ftyp"
 const AVIF_BRAND = new Uint8Array([0x61, 0x76, 0x69, 0x66]); // "avif"
 const AVIS_BRAND = new Uint8Array([0x61, 0x76, 0x69, 0x73]); // "avis"
 
+// Reused across every auxC box inspected, rather than allocating a decoder per
+// box while scanning — mirrors the module-level decoder in the EXIF extractor.
+const LATIN1 = new TextDecoder('latin1');
+
 // Minimum: ftyp box header (8) + major brand (4) = 12 bytes
 const MIN_BYTES = 12;
 
@@ -276,7 +280,7 @@ export function extractAvifColorProfile(
       if (start >= auxC.end) {
         return false;
       }
-      let text = new TextDecoder('latin1').decode(
+      let text = LATIN1.decode(
         bytes.subarray(start, Math.min(auxC.end, bytes.length)),
       );
       return text.startsWith(ALPHA_AUX_TYPE);

--- a/packages/base/avif-meta-extractor.ts
+++ b/packages/base/avif-meta-extractor.ts
@@ -1,4 +1,8 @@
 import { FileContentMismatchError } from './file-api';
+import {
+  prunedColorProfile,
+  type ImageColorProfile,
+} from './image-color-profile';
 
 // AVIF uses ISO Base Media File Format (ISOBMFF).
 // The file starts with a "ftyp" box whose brand is "avif" or "avis".
@@ -64,6 +68,33 @@ function findBox(
   return undefined;
 }
 
+// Every sibling box of a given type within a region. `findBox` returns only the
+// first, which is right for the single `ispe` that carries dimensions but wrong
+// for `auxC`: an alpha plane is one of several item properties and need not come
+// first.
+function findAllBoxes(
+  view: DataView,
+  bytes: Uint8Array,
+  start: number,
+  end: number,
+  targetType: string,
+): { start: number; end: number }[] {
+  let found: { start: number; end: number }[] = [];
+  let offset = start;
+  while (offset + 8 <= end) {
+    let size = view.getUint32(offset);
+    let boxEnd = size === 0 ? end : offset + size;
+    if ((size !== 0 && size < 8) || boxEnd > end) {
+      break;
+    }
+    if (readBoxType(bytes, offset + 4) === targetType) {
+      found.push({ start: offset, end: boxEnd });
+    }
+    offset = boxEnd;
+  }
+  return found;
+}
+
 function validateAvifSignature(bytes: Uint8Array): void {
   if (bytes.length < MIN_BYTES) {
     throw new FileContentMismatchError(
@@ -119,9 +150,7 @@ export function extractAvifDimensions(bytes: Uint8Array): {
   // Walk the ISOBMFF box tree: top-level → meta → iprp → ipco → ispe
   let meta = findBox(view, bytes, 0, bytes.length, 'meta');
   if (!meta) {
-    throw new FileContentMismatchError(
-      'AVIF file does not contain a meta box',
-    );
+    throw new FileContentMismatchError('AVIF file does not contain a meta box');
   }
 
   // meta is a "full box": 8-byte header + 4-byte version/flags before children
@@ -161,4 +190,106 @@ export function extractAvifDimensions(bytes: Uint8Array): {
   }
 
   return { width, height };
+}
+
+// The URN an `auxC` box carries when the auxiliary image it describes is an
+// alpha plane. AVIF stores transparency as a separate coded image rather than a
+// fourth channel of the primary one, so this is the only reliable signal.
+const ALPHA_AUX_TYPE = 'urn:mpeg:mpegB:cicp:systems:auxiliary:alpha';
+
+// CICP colour primaries, from the `colr`/`nclx` box. These are the four an
+// encoder realistically writes; anything else is left unnamed rather than
+// guessed at.
+const CICP_PRIMARIES: Record<number, string> = {
+  1: 'srgb', // BT.709
+  9: 'rec2020',
+  11: 'display-p3', // DCI-P3
+  12: 'display-p3', // Display P3 (P3-D65)
+};
+
+// AVIF states its encoding across three item-property boxes rather than one
+// header: `pixi` for bit depth and channel count, `colr` for the color space,
+// and `auxC` for whether a separate alpha plane exists. All three sit under
+// meta > iprp > ipco, so one walk collects them.
+//
+// Returns undefined when the box tree isn't reachable — the dimension reader is
+// what decides whether that constitutes a content mismatch.
+export function extractAvifColorProfile(
+  bytes: Uint8Array,
+): ImageColorProfile | undefined {
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let meta = findBox(view, bytes, 0, bytes.length, 'meta');
+  if (!meta) {
+    return undefined;
+  }
+  // meta is a "full box": 8-byte header plus 4 bytes of version/flags.
+  let iprp = findBox(view, bytes, meta.start + 12, meta.end, 'iprp');
+  let ipco = iprp
+    ? findBox(view, bytes, iprp.start + 8, iprp.end, 'ipco')
+    : undefined;
+  if (!ipco) {
+    return undefined;
+  }
+  let properties = ipco.start + 8;
+
+  // pixi: [size:4] [type:4] [version+flags:4] [num_channels:1] [depth × n]
+  let bitDepth: number | undefined;
+  let channels: number | undefined;
+  let pixi = findBox(view, bytes, properties, ipco.end, 'pixi');
+  if (pixi && pixi.end - pixi.start >= 14) {
+    let channelCount = view.getUint8(pixi.start + 12);
+    if (
+      channelCount > 0 &&
+      pixi.start + 13 + channelCount <= pixi.end &&
+      pixi.start + 13 + channelCount <= bytes.length
+    ) {
+      channels = channelCount;
+      // Every channel carries its own depth; they agree in every real encoder
+      // output, so the first is representative.
+      bitDepth = view.getUint8(pixi.start + 13);
+    }
+  }
+
+  // colr: [size:4] [type:4] [colour_type:4] then, for 'nclx',
+  // [primaries:2] [transfer:2] [matrix:2] [full_range:1]
+  let colorSpace: string | undefined;
+  let iccProfile: string | undefined;
+  for (let colr of findAllBoxes(view, bytes, properties, ipco.end, 'colr')) {
+    if (colr.end - colr.start < 12) {
+      continue;
+    }
+    let colourType = readBoxType(bytes, colr.start + 8);
+    if (colourType === 'nclx' && colr.end - colr.start >= 14) {
+      colorSpace ??= CICP_PRIMARIES[view.getUint16(colr.start + 12)];
+    } else if (colourType === 'rICC' || colourType === 'prof') {
+      // The profile bytes themselves are here, but naming the profile means
+      // parsing an ICC header; recording that one is embedded is the honest
+      // summary.
+      iccProfile ??= 'embedded';
+    }
+  }
+
+  let hasAlpha = findAllBoxes(view, bytes, properties, ipco.end, 'auxC').some(
+    (auxC) => {
+      // auxC: [size:4] [type:4] [version+flags:4] [aux_type: NUL-terminated]
+      let start = auxC.start + 12;
+      if (start >= auxC.end) {
+        return false;
+      }
+      let text = new TextDecoder('latin1').decode(
+        bytes.subarray(start, Math.min(auxC.end, bytes.length)),
+      );
+      return text.startsWith(ALPHA_AUX_TYPE);
+    },
+  );
+
+  return prunedColorProfile({
+    colorSpace: colorSpace ?? (channels === 1 ? 'grayscale' : undefined),
+    bitDepth,
+    channels,
+    // An `auxC` alpha plane is positive evidence; its absence within a header
+    // window that may have been truncated is not, so only report the positive.
+    hasAlpha: hasAlpha ? true : undefined,
+    iccProfile,
+  });
 }

--- a/packages/base/exif-meta-extractor.ts
+++ b/packages/base/exif-meta-extractor.ts
@@ -1,0 +1,622 @@
+// Portable EXIF reader. Pure `DataView`/`TextDecoder` — no DOM, no host APIs —
+// so the same function runs in the prerenderer's extract pass, in the host app,
+// and in a future server-side extraction worker without change.
+//
+// The unit of work is a TIFF block, not a JPEG: EXIF is a TIFF structure that
+// several containers embed verbatim (JPEG in an APP1 segment, PNG in an `eXIf`
+// chunk, WebP in an `EXIF` RIFF chunk, HEIF/AVIF in an item property). Only
+// `extractExifFromJpeg` knows about JPEG framing; `parseExifTiffBlock` is the
+// piece the other containers reuse as they land.
+//
+// Absent EXIF is not an error — most PNGs and every generated image lack it —
+// so a missing or unreadable block returns `undefined` rather than throwing.
+// Only the container's own signature check (in the `*-meta-extractor` that owns
+// the format) should reject a file.
+
+export interface ExifCapture {
+  make?: string;
+  cameraModel?: string;
+  lensModel?: string;
+  focalLength?: { value: number; unit: string; displayText?: string };
+  aperture?: { value: number; unit?: string; displayText?: string };
+  exposureTime?: { value: number; unit: string; displayText?: string };
+  iso?: number;
+  flash?: { code: string; scheme: string };
+  orientation?: { code: string; scheme: string };
+  capturedAt?: string;
+  software?: string;
+}
+
+export interface ExifLocation {
+  latitude?: number;
+  longitude?: number;
+  altitude?: { value: number; unit: string };
+  source?: { code: string; scheme: string };
+}
+
+export interface ExifMetadata {
+  capture?: ExifCapture;
+  location?: ExifLocation;
+  // A slug from the shared `color-space` vocabulary, not EXIF's raw number.
+  // The container's own header is the better authority on how pixels are
+  // encoded, so this is offered as a fallback for color space alone and is
+  // merged into the family's single `colorProfile` field rather than forming a
+  // second, competing one.
+  colorSpace?: string;
+}
+
+// TIFF field types, by their numeric code. Only the ones EXIF actually uses for
+// the tags below are named; the size table covers the rest so an unexpected
+// type still advances the cursor correctly instead of desynchronizing the walk.
+const TYPE_BYTE = 1;
+const TYPE_ASCII = 2;
+const TYPE_SHORT = 3;
+const TYPE_LONG = 4;
+const TYPE_RATIONAL = 5;
+const TYPE_SLONG = 9;
+const TYPE_SRATIONAL = 10;
+
+const TYPE_SIZES: Record<number, number> = {
+  1: 1, // BYTE
+  2: 1, // ASCII
+  3: 2, // SHORT
+  4: 4, // LONG
+  5: 8, // RATIONAL
+  6: 1, // SBYTE
+  7: 1, // UNDEFINED
+  8: 2, // SSHORT
+  9: 4, // SLONG
+  10: 8, // SRATIONAL
+  11: 4, // FLOAT
+  12: 8, // DOUBLE
+};
+
+// IFD0 (the primary image directory)
+const TAG_MAKE = 0x010f;
+const TAG_MODEL = 0x0110;
+const TAG_ORIENTATION = 0x0112;
+const TAG_SOFTWARE = 0x0131;
+const TAG_DATETIME = 0x0132;
+const TAG_EXIF_IFD_POINTER = 0x8769;
+const TAG_GPS_IFD_POINTER = 0x8825;
+
+// Exif sub-IFD
+const TAG_EXPOSURE_TIME = 0x829a;
+const TAG_F_NUMBER = 0x829d;
+const TAG_ISO_SPEED_RATINGS = 0x8827;
+const TAG_PHOTOGRAPHIC_SENSITIVITY = 0x8833;
+const TAG_DATETIME_ORIGINAL = 0x9003;
+const TAG_OFFSET_TIME_ORIGINAL = 0x9011;
+const TAG_FLASH = 0x9209;
+const TAG_FOCAL_LENGTH = 0x920a;
+const TAG_COLOR_SPACE = 0xa001;
+const TAG_LENS_MODEL = 0xa434;
+
+// GPS sub-IFD
+const TAG_GPS_LATITUDE_REF = 0x0001;
+const TAG_GPS_LATITUDE = 0x0002;
+const TAG_GPS_LONGITUDE_REF = 0x0003;
+const TAG_GPS_LONGITUDE = 0x0004;
+const TAG_GPS_ALTITUDE_REF = 0x0005;
+const TAG_GPS_ALTITUDE = 0x0006;
+
+// A directory with more entries than this is corrupt or hostile, not a photo.
+// Real IFD0/Exif directories run well under a hundred entries.
+const MAX_IFD_ENTRIES = 512;
+
+// EXIF strings are nominally ASCII; in practice makers write Latin-1 and
+// occasionally UTF-8. Latin-1 never throws and leaves ASCII untouched, so it's
+// the safe decode for short identifier strings.
+const LATIN1 = new TextDecoder('latin1');
+
+const TIFF_MAGIC = 0x002a;
+const BYTE_ORDER_LITTLE = 0x4949; // 'II'
+const BYTE_ORDER_BIG = 0x4d4d; // 'MM'
+
+// One parsed 12-byte directory entry, with its payload still unread: `count`
+// and `type` are what decide how to interpret `valueOffset`.
+interface IfdEntry {
+  type: number;
+  count: number;
+  // Either the value itself (when it fits in four bytes) or an offset from the
+  // start of the TIFF block. Resolved by `payloadOffset`.
+  valueOffset: number;
+  // Absolute offset of the entry's own 4-byte value field, needed because a
+  // value that fits inline lives there rather than at `valueOffset`.
+  inlineOffset: number;
+}
+
+// A bounds-checked cursor over one TIFF block. Every read returns `undefined`
+// rather than throwing when it would run past the end, so a truncated block
+// degrades to partial metadata instead of losing the whole extract.
+class TiffReader {
+  #view: DataView;
+  #length: number;
+  #littleEndian: boolean;
+  // Offsets inside a TIFF block are relative to the block's own start, which
+  // is not the start of the file.
+  #base: number;
+
+  constructor(bytes: Uint8Array, base: number, littleEndian: boolean) {
+    this.#view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    this.#length = bytes.byteLength;
+    this.#littleEndian = littleEndian;
+    this.#base = base;
+  }
+
+  #inBounds(absolute: number, size: number): boolean {
+    return absolute >= 0 && absolute + size <= this.#length;
+  }
+
+  absolute(relative: number): number {
+    return this.#base + relative;
+  }
+
+  uint16(absolute: number): number | undefined {
+    return this.#inBounds(absolute, 2)
+      ? this.#view.getUint16(absolute, this.#littleEndian)
+      : undefined;
+  }
+
+  uint32(absolute: number): number | undefined {
+    return this.#inBounds(absolute, 4)
+      ? this.#view.getUint32(absolute, this.#littleEndian)
+      : undefined;
+  }
+
+  int32(absolute: number): number | undefined {
+    return this.#inBounds(absolute, 4)
+      ? this.#view.getInt32(absolute, this.#littleEndian)
+      : undefined;
+  }
+
+  uint8(absolute: number): number | undefined {
+    return this.#inBounds(absolute, 1)
+      ? this.#view.getUint8(absolute)
+      : undefined;
+  }
+
+  ascii(absolute: number, length: number): string | undefined {
+    if (!this.#inBounds(absolute, length)) {
+      return undefined;
+    }
+    let bytes = new Uint8Array(
+      this.#view.buffer,
+      this.#view.byteOffset + absolute,
+      length,
+    );
+    // EXIF ASCII fields are NUL-terminated and often NUL- or space-padded to a
+    // fixed width, so trim to the first NUL before decoding.
+    let end = bytes.indexOf(0);
+    let text = LATIN1.decode(end === -1 ? bytes : bytes.subarray(0, end));
+    let trimmed = text.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  // Walk a directory into a tag→entry map. Unknown tags are kept: the cost is
+  // a map entry, and it means adding a tag later needs no re-walk.
+  readIfd(relativeOffset: number): Map<number, IfdEntry> | undefined {
+    let directory = this.absolute(relativeOffset);
+    let count = this.uint16(directory);
+    if (count === undefined || count === 0 || count > MAX_IFD_ENTRIES) {
+      return undefined;
+    }
+    let entries = new Map<number, IfdEntry>();
+    for (let index = 0; index < count; index++) {
+      let entryOffset = directory + 2 + index * 12;
+      let tag = this.uint16(entryOffset);
+      let type = this.uint16(entryOffset + 2);
+      let valueCount = this.uint32(entryOffset + 4);
+      let valueOffset = this.uint32(entryOffset + 8);
+      if (
+        tag === undefined ||
+        type === undefined ||
+        valueCount === undefined ||
+        valueOffset === undefined
+      ) {
+        break;
+      }
+      entries.set(tag, {
+        type,
+        count: valueCount,
+        valueOffset,
+        inlineOffset: entryOffset + 8,
+      });
+    }
+    return entries.size > 0 ? entries : undefined;
+  }
+
+  // Where an entry's payload actually starts. A payload of four bytes or fewer
+  // is stored in the entry itself; anything larger is stored elsewhere in the
+  // block and the entry holds a relative offset to it.
+  #payloadOffset(entry: IfdEntry): number {
+    let size = (TYPE_SIZES[entry.type] ?? 1) * entry.count;
+    return size <= 4 ? entry.inlineOffset : this.absolute(entry.valueOffset);
+  }
+
+  string(entry: IfdEntry | undefined): string | undefined {
+    if (!entry || entry.type !== TYPE_ASCII || entry.count === 0) {
+      return undefined;
+    }
+    return this.ascii(this.#payloadOffset(entry), entry.count);
+  }
+
+  integer(entry: IfdEntry | undefined): number | undefined {
+    if (!entry || entry.count === 0) {
+      return undefined;
+    }
+    let offset = this.#payloadOffset(entry);
+    switch (entry.type) {
+      case TYPE_BYTE:
+        return this.uint8(offset);
+      case TYPE_SHORT:
+        return this.uint16(offset);
+      case TYPE_LONG:
+        return this.uint32(offset);
+      case TYPE_SLONG:
+        return this.int32(offset);
+      default:
+        return undefined;
+    }
+  }
+
+  // A TIFF rational is a numerator/denominator pair of 4-byte integers.
+  #rationalAt(offset: number, signed: boolean): number | undefined {
+    let numerator = signed ? this.int32(offset) : this.uint32(offset);
+    let denominator = signed ? this.int32(offset + 4) : this.uint32(offset + 4);
+    if (numerator === undefined || !denominator) {
+      return undefined;
+    }
+    let value = numerator / denominator;
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  rational(entry: IfdEntry | undefined): number | undefined {
+    if (
+      !entry ||
+      entry.count === 0 ||
+      (entry.type !== TYPE_RATIONAL && entry.type !== TYPE_SRATIONAL)
+    ) {
+      return undefined;
+    }
+    return this.#rationalAt(
+      this.#payloadOffset(entry),
+      entry.type === TYPE_SRATIONAL,
+    );
+  }
+
+  rationals(entry: IfdEntry | undefined, wanted: number): number[] | undefined {
+    if (
+      !entry ||
+      entry.count < wanted ||
+      (entry.type !== TYPE_RATIONAL && entry.type !== TYPE_SRATIONAL)
+    ) {
+      return undefined;
+    }
+    let start = this.#payloadOffset(entry);
+    let signed = entry.type === TYPE_SRATIONAL;
+    let values: number[] = [];
+    for (let index = 0; index < wanted; index++) {
+      let value = this.#rationalAt(start + index * 8, signed);
+      if (value === undefined) {
+        return undefined;
+      }
+      values.push(value);
+    }
+    return values;
+  }
+}
+
+// EXIF writes `YYYY:MM:DD HH:MM:SS`, which no `Date` parser accepts. Convert to
+// ISO 8601 so the value round-trips through DateTimeField's `parseISO`.
+//
+// The timestamp carries no zone unless a matching `OffsetTime*` tag is present.
+// When it isn't, the naive form is emitted deliberately: it is the wall-clock
+// time the camera recorded, and inventing UTC would silently shift every photo
+// by the reader's own offset.
+function exifTimestampToIso(
+  value: string | undefined,
+  utcOffset?: string,
+): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  let match = value.match(
+    /^(\d{4}):(\d{2}):(\d{2})[ T](\d{2}):(\d{2}):(\d{2})/,
+  );
+  if (!match) {
+    return undefined;
+  }
+  let [, year, month, day, hour, minute, second] = match;
+  let base = `${year}-${month}-${day}T${hour}:${minute}:${second}`;
+  let offset = utcOffset?.trim();
+  return offset && /^([+-]\d{2}:\d{2}|Z)$/.test(offset)
+    ? `${base}${offset}`
+    : base;
+}
+
+// Shutter speeds are read as fractions, not decimals — "1/250 s" is the number
+// a photographer recognizes, "0.004 s" is not.
+function exposureDisplay(seconds: number): string {
+  if (seconds >= 1) {
+    return `${Math.round(seconds * 100) / 100} s`;
+  }
+  let denominator = Math.round(1 / seconds);
+  return denominator > 0 ? `1/${denominator} s` : `${seconds} s`;
+}
+
+// Degrees/minutes/seconds triple plus a hemisphere letter into signed decimal
+// degrees. Anything outside the valid range is dropped rather than clamped: an
+// out-of-range coordinate is a parse failure, not a place.
+function gpsToDecimal(
+  parts: number[] | undefined,
+  reference: string | undefined,
+  limit: number,
+): number | undefined {
+  if (!parts || parts.length < 3) {
+    return undefined;
+  }
+  let [degrees, minutes, seconds] = parts as [number, number, number];
+  let decimal = degrees + minutes / 60 + seconds / 3600;
+  if (!Number.isFinite(decimal) || Math.abs(decimal) > limit) {
+    return undefined;
+  }
+  let negative = /^[SW]/i.test(reference ?? '');
+  // Round at ~1 cm of precision; further digits are noise from the DMS divide.
+  let signed = negative ? -decimal : decimal;
+  return Math.round(signed * 1e7) / 1e7;
+}
+
+// Drop a branch whose every value came back undefined, so an image with no
+// EXIF at all produces no attributes rather than a nest of empty objects.
+function pruned<T extends object>(candidate: T): T | undefined {
+  let entries = Object.entries(candidate).filter(
+    ([, value]) => value !== undefined,
+  );
+  return entries.length > 0 ? (Object.fromEntries(entries) as T) : undefined;
+}
+
+function readCapture(
+  reader: TiffReader,
+  ifd0: Map<number, IfdEntry> | undefined,
+  exifIfd: Map<number, IfdEntry> | undefined,
+): ExifCapture | undefined {
+  let focalLength = reader.rational(exifIfd?.get(TAG_FOCAL_LENGTH));
+  let aperture = reader.rational(exifIfd?.get(TAG_F_NUMBER));
+  let exposure = reader.rational(exifIfd?.get(TAG_EXPOSURE_TIME));
+  let orientation = reader.integer(ifd0?.get(TAG_ORIENTATION));
+  let flash = reader.integer(exifIfd?.get(TAG_FLASH));
+  // `ISOSpeedRatings` was renamed `PhotographicSensitivity` in EXIF 2.3; files
+  // in the wild carry either, so accept both.
+  let iso =
+    reader.integer(exifIfd?.get(TAG_ISO_SPEED_RATINGS)) ??
+    reader.integer(exifIfd?.get(TAG_PHOTOGRAPHIC_SENSITIVITY));
+  let capturedAt = exifTimestampToIso(
+    reader.string(exifIfd?.get(TAG_DATETIME_ORIGINAL)) ??
+      reader.string(ifd0?.get(TAG_DATETIME)),
+    reader.string(exifIfd?.get(TAG_OFFSET_TIME_ORIGINAL)),
+  );
+
+  return pruned<ExifCapture>({
+    make: reader.string(ifd0?.get(TAG_MAKE)),
+    cameraModel: reader.string(ifd0?.get(TAG_MODEL)),
+    lensModel: reader.string(exifIfd?.get(TAG_LENS_MODEL)),
+    focalLength:
+      focalLength === undefined
+        ? undefined
+        : {
+            value: Math.round(focalLength * 100) / 100,
+            unit: 'mm',
+          },
+    aperture:
+      aperture === undefined
+        ? undefined
+        : {
+            value: Math.round(aperture * 100) / 100,
+            displayText: `ƒ/${Math.round(aperture * 100) / 100}`,
+          },
+    exposureTime:
+      exposure === undefined || exposure <= 0
+        ? undefined
+        : {
+            value: exposure,
+            unit: 's',
+            displayText: exposureDisplay(exposure),
+          },
+    iso,
+    flash:
+      flash === undefined
+        ? undefined
+        : { code: String(flash), scheme: 'exif-flash' },
+    orientation:
+      orientation === undefined
+        ? undefined
+        : { code: String(orientation), scheme: 'exif-orientation' },
+    capturedAt,
+    software: reader.string(ifd0?.get(TAG_SOFTWARE)),
+  });
+}
+
+function readLocation(
+  reader: TiffReader,
+  gpsIfd: Map<number, IfdEntry> | undefined,
+): ExifLocation | undefined {
+  if (!gpsIfd) {
+    return undefined;
+  }
+  let latitude = gpsToDecimal(
+    reader.rationals(gpsIfd.get(TAG_GPS_LATITUDE), 3),
+    reader.string(gpsIfd.get(TAG_GPS_LATITUDE_REF)),
+    90,
+  );
+  let longitude = gpsToDecimal(
+    reader.rationals(gpsIfd.get(TAG_GPS_LONGITUDE), 3),
+    reader.string(gpsIfd.get(TAG_GPS_LONGITUDE_REF)),
+    180,
+  );
+  let altitude = reader.rational(gpsIfd.get(TAG_GPS_ALTITUDE));
+  // `GPSAltitudeRef` of 1 means the altitude is measured *below* sea level, so
+  // the stored magnitude has to be negated to mean anything.
+  let belowSeaLevel = reader.integer(gpsIfd.get(TAG_GPS_ALTITUDE_REF)) === 1;
+
+  // A coordinate needs both halves to be a place. Dropping a lone latitude
+  // avoids persisting a point on the prime meridian that the camera never saw.
+  if (latitude === undefined || longitude === undefined) {
+    return pruned<ExifLocation>({
+      altitude:
+        altitude === undefined
+          ? undefined
+          : {
+              value:
+                Math.round((belowSeaLevel ? -altitude : altitude) * 100) / 100,
+              unit: 'm',
+            },
+    });
+  }
+
+  return {
+    latitude,
+    longitude,
+    ...(altitude === undefined
+      ? {}
+      : {
+          altitude: {
+            value:
+              Math.round((belowSeaLevel ? -altitude : altitude) * 100) / 100,
+            unit: 'm',
+          },
+        }),
+    source: { code: 'exif-gps', scheme: 'geo-source' },
+  };
+}
+
+// EXIF only ever names three color spaces: sRGB, Adobe RGB (as the
+// unregistered-but-universal 2), and "uncalibrated" for everything else —
+// which is what a wide-gamut file gets, with the real profile living in an
+// attached ICC chunk. Mapped onto the shared vocabulary so the persisted value
+// doesn't depend on which container the tag arrived in.
+const EXIF_COLOR_SPACE_SLUGS: Record<number, string> = {
+  1: 'srgb',
+  2: 'adobe-rgb',
+  65535: 'uncalibrated',
+};
+
+function readColorSpace(
+  reader: TiffReader,
+  exifIfd: Map<number, IfdEntry> | undefined,
+): string | undefined {
+  let colorSpace = reader.integer(exifIfd?.get(TAG_COLOR_SPACE));
+  return colorSpace === undefined
+    ? undefined
+    : EXIF_COLOR_SPACE_SLUGS[colorSpace];
+}
+
+// Parse a TIFF/EXIF block that begins at `tiffStart` within `bytes`. Callers
+// pass the offset of the byte-order marker, i.e. past any container-specific
+// prefix such as JPEG's `Exif\0\0`.
+export function parseExifTiffBlock(
+  bytes: Uint8Array,
+  tiffStart: number,
+): ExifMetadata | undefined {
+  if (tiffStart < 0 || tiffStart + 8 > bytes.byteLength) {
+    return undefined;
+  }
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let byteOrder = view.getUint16(tiffStart);
+  if (byteOrder !== BYTE_ORDER_LITTLE && byteOrder !== BYTE_ORDER_BIG) {
+    return undefined;
+  }
+  let littleEndian = byteOrder === BYTE_ORDER_LITTLE;
+  if (view.getUint16(tiffStart + 2, littleEndian) !== TIFF_MAGIC) {
+    return undefined;
+  }
+  let ifd0Offset = view.getUint32(tiffStart + 4, littleEndian);
+
+  let reader = new TiffReader(bytes, tiffStart, littleEndian);
+  let ifd0 = reader.readIfd(ifd0Offset);
+  // The Exif and GPS directories are reached through pointer tags in IFD0. A
+  // file may carry either, both, or neither.
+  let exifPointer = reader.integer(ifd0?.get(TAG_EXIF_IFD_POINTER));
+  let gpsPointer = reader.integer(ifd0?.get(TAG_GPS_IFD_POINTER));
+  let exifIfd =
+    exifPointer === undefined ? undefined : reader.readIfd(exifPointer);
+  let gpsIfd =
+    gpsPointer === undefined ? undefined : reader.readIfd(gpsPointer);
+
+  return pruned<ExifMetadata>({
+    capture: readCapture(reader, ifd0, exifIfd),
+    location: readLocation(reader, gpsIfd),
+    colorSpace: readColorSpace(reader, exifIfd),
+  });
+}
+
+// `Exif\0\0`, the six-byte identifier that distinguishes the EXIF APP1 segment
+// from the XMP one (which shares the same marker).
+const EXIF_APP1_IDENTIFIER = [0x45, 0x78, 0x69, 0x66, 0x00, 0x00];
+
+const MARKER_SOI = 0xd8;
+const MARKER_EOI = 0xd9;
+const MARKER_SOS = 0xda;
+const MARKER_APP1 = 0xe1;
+
+function hasExifIdentifier(bytes: Uint8Array, offset: number): boolean {
+  if (offset + EXIF_APP1_IDENTIFIER.length > bytes.byteLength) {
+    return false;
+  }
+  return EXIF_APP1_IDENTIFIER.every(
+    (expected, index) => bytes[offset + index] === expected,
+  );
+}
+
+// Find and parse the EXIF APP1 segment of a JPEG. Returns `undefined` when the
+// file carries none, which is the common case for generated images.
+export function extractExifFromJpeg(
+  bytes: Uint8Array,
+): ExifMetadata | undefined {
+  if (bytes.byteLength < 4 || bytes[0] !== 0xff || bytes[1] !== MARKER_SOI) {
+    return undefined;
+  }
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let offset = 2;
+  while (offset + 3 < bytes.byteLength) {
+    if (bytes[offset] !== 0xff) {
+      // Marker structure has desynchronized. Dimension extraction treats this
+      // as a malformed file; here it only means no EXIF is reachable.
+      return undefined;
+    }
+    // Fill bytes: a run of 0xFF before the marker code is legal padding.
+    while (offset + 1 < bytes.byteLength && bytes[offset + 1] === 0xff) {
+      offset++;
+    }
+    let marker = bytes[offset + 1]!;
+    offset += 2;
+
+    // Entropy-coded data begins at SOS; no further metadata segments follow.
+    if (marker === MARKER_SOS || marker === MARKER_EOI) {
+      return undefined;
+    }
+    // Standalone markers (SOI, RSTn) carry no length field.
+    if (marker === MARKER_SOI || (marker >= 0xd0 && marker <= 0xd7)) {
+      continue;
+    }
+    if (offset + 2 > bytes.byteLength) {
+      return undefined;
+    }
+    let segmentLength = view.getUint16(offset);
+    // The length field counts itself, so anything under two bytes is corrupt
+    // and would make the walk spin in place.
+    if (segmentLength < 2) {
+      return undefined;
+    }
+    if (marker === MARKER_APP1 && hasExifIdentifier(bytes, offset + 2)) {
+      // The TIFF block starts immediately after the identifier, and every
+      // offset inside it is relative to that point.
+      return parseExifTiffBlock(
+        bytes,
+        offset + 2 + EXIF_APP1_IDENTIFIER.length,
+      );
+    }
+    offset += segmentLength;
+  }
+  return undefined;
+}

--- a/packages/base/file-formats/index.ts
+++ b/packages/base/file-formats/index.ts
@@ -52,6 +52,22 @@ export {
   type FilePreviewSignature,
 } from './file-preview-stage';
 
+// The compound metadata shapes an extractor writes into. Shared per metadata
+// family rather than per file extension, so a camera or a color profile reads
+// the same wherever the bytes came from. A family that only needs the shapes
+// should import this module directly rather than through this barrel, which also
+// pulls in the four shells.
+export {
+  CameraCaptureField,
+  CodedValueField,
+  ColorProfileField,
+  ExifMetadataField,
+  GeoLocationField,
+  METADATA_VOCABULARIES,
+  QuantityField,
+  labelForCode,
+} from './metadata-fields';
+
 export { FileAtomShell } from './file-shell-atom';
 export { FileEmbeddedShell } from './file-shell-embedded';
 export { FileFittedShell } from './file-shell-fitted';

--- a/packages/base/file-formats/metadata-fields.gts
+++ b/packages/base/file-formats/metadata-fields.gts
@@ -371,6 +371,19 @@ export class ColorProfileField extends FieldDef {
   @field hasAlpha = contains(BooleanField);
   @field iccProfile = contains(StringField);
 
+  // A plain `{{#if @model.hasAlpha}}` would hide a genuine `false` alongside an
+  // unset value, collapsing the "no alpha channel" fact this field is careful to
+  // record. Projecting to a non-empty string keeps the two distinguishable in
+  // the template while still rendering nothing when we never learned either way.
+  @field hasAlphaLabel = contains(StringField, {
+    computeVia: function (this: ColorProfileField) {
+      if (this.hasAlpha == null) {
+        return '';
+      }
+      return this.hasAlpha ? 'Yes' : 'No';
+    },
+  });
+
   static embedded = class Embedded extends Component<typeof ColorProfileField> {
     <template>
       <dl class='metadata-rows'>
@@ -383,6 +396,9 @@ export class ColorProfileField extends FieldDef {
         {{/if}}
         {{#if @model.channels}}
           <div class='row'><dt>Channels</dt><dd>{{@model.channels}}</dd></div>
+        {{/if}}
+        {{#if @model.hasAlphaLabel}}
+          <div class='row'><dt>Alpha</dt><dd>{{@model.hasAlphaLabel}}</dd></div>
         {{/if}}
         {{#if @model.iccProfile}}
           <div class='row'><dt>ICC profile</dt><dd>{{@model.iccProfile}}</dd></div>

--- a/packages/base/file-formats/metadata-fields.gts
+++ b/packages/base/file-formats/metadata-fields.gts
@@ -1,0 +1,451 @@
+// Shared metadata FieldDefs: one shape per metadata *family*, reused by every
+// file type that carries it. A GPS block reads identically on a photo and on a
+// video; a camera block is the same shape whether the bytes came from a JPEG's
+// EXIF IFD or a HEIF item property. Keeping the shape shared — rather than
+// giving each extension its own flat spray of columns — is what lets a query
+// or a renderer treat "where was this captured" as one question.
+//
+// Every value here is written by an extractor during the index pass and is an
+// ordinary persisted field, so it stays inspectable and correctable through
+// Boxel's generated editor. Nothing in this module parses bytes; see the
+// `*-meta-extractor` modules for that.
+//
+// These fields deliberately live outside `card-api`'s import graph. `card-api`
+// statically imports FileDef's format templates, so anything those reach lands
+// in the deps of every card in every realm. A family attaches its metadata on
+// its own subclass module instead, so only realms holding that file type pay.
+
+import CameraIcon from '@cardstack/boxel-icons/camera';
+import MapPinIcon from '@cardstack/boxel-icons/map-pin';
+import PaletteIcon from '@cardstack/boxel-icons/palette';
+import RulerIcon from '@cardstack/boxel-icons/ruler';
+import TagIcon from '@cardstack/boxel-icons/tag';
+
+import FileInfoIcon from '@cardstack/boxel-icons/file-info';
+
+import {
+  Component,
+  FieldDef,
+  NumberField,
+  StringField,
+  contains,
+  field,
+} from '../card-api';
+import BooleanField from '../boolean';
+import DateTimeField from '../datetime';
+
+// Coded values keep the file's own number — a `flash` of 25 stays 25 — while
+// still reading as English. Persisting the label instead would throw away the
+// only thing that survives a vocabulary correction, and persisting the code
+// alone would make every consumer re-implement the lookup.
+export const METADATA_VOCABULARIES: Record<
+  string,
+  Record<string, string>
+> = Object.freeze({
+  'exif-orientation': {
+    '1': 'Normal',
+    '2': 'Mirror horizontal',
+    '3': 'Rotate 180',
+    '4': 'Mirror vertical',
+    '5': 'Mirror + rotate 270',
+    '6': 'Rotate 90 CW',
+    '7': 'Mirror + rotate 90',
+    '8': 'Rotate 270 CW',
+  },
+  'exif-flash': {
+    '0': 'No flash',
+    '1': 'Fired',
+    '5': 'Fired, no return',
+    '7': 'Fired, return detected',
+    '16': 'Off, did not fire',
+    '24': 'Auto, did not fire',
+    '25': 'Auto, fired',
+  },
+  'geo-source': {
+    'exif-gps': 'EXIF GPS IFD',
+    'ios-photos': 'iOS Photos convention',
+    'android-photos': 'Android Photos convention',
+  },
+  'color-space': {
+    srgb: 'sRGB',
+    'display-p3': 'Display P3',
+    'adobe-rgb': 'Adobe RGB',
+    rec2020: 'Rec. 2020',
+    grayscale: 'Grayscale',
+    'grayscale-alpha': 'Grayscale + alpha',
+    indexed: 'Indexed color',
+    ycbcr: 'YCbCr',
+    cmyk: 'CMYK',
+    uncalibrated: 'Uncalibrated',
+  },
+});
+
+// An unrecognized code renders as itself rather than disappearing: a file
+// carrying a vendor extension we don't have a word for is still evidence.
+export function labelForCode(scheme?: string, code?: string): string {
+  if (!scheme || code === undefined || code === null || code === '') {
+    return '';
+  }
+  return METADATA_VOCABULARIES[scheme]?.[String(code)] ?? String(code);
+}
+
+// A measured number and the unit it was measured in. Extractors that can
+// produce a better human string than a bare number/unit join — a shutter speed
+// is conventionally "1/250 s", not "0.004 s" — supply `displayText`, and it
+// wins.
+export class QuantityField extends FieldDef {
+  static displayName = 'Quantity';
+  static icon = RulerIcon;
+
+  @field value = contains(NumberField);
+  @field unit = contains(StringField);
+  @field displayText = contains(StringField);
+
+  @field display = contains(StringField, {
+    computeVia: function (this: QuantityField) {
+      if (this.displayText) {
+        return this.displayText;
+      }
+      if (this.value == null) {
+        return '';
+      }
+      // Thousands separators help at scale (a 48000 Hz sample rate); below
+      // that, trailing float noise hurts more than precision helps, so round
+      // to three decimals.
+      let magnitude =
+        Math.abs(this.value) >= 1000
+          ? this.value.toLocaleString()
+          : String(Math.round(this.value * 1000) / 1000);
+      return this.unit ? `${magnitude} ${this.unit}` : magnitude;
+    },
+  });
+
+  static embedded = class Embedded extends Component<typeof QuantityField> {
+    <template>
+      <span class='quantity'>{{@model.display}}</span>
+      <style scoped>
+        .quantity {
+          font-variant-numeric: tabular-nums;
+        }
+      </style>
+    </template>
+  };
+
+  static atom = this.embedded;
+}
+
+// A value the format defines as an enumerated code, paired with the vocabulary
+// that names it.
+export class CodedValueField extends FieldDef {
+  static displayName = 'Coded Value';
+  static icon = TagIcon;
+
+  @field code = contains(StringField);
+  @field scheme = contains(StringField);
+
+  @field label = contains(StringField, {
+    computeVia: function (this: CodedValueField) {
+      return labelForCode(this.scheme, this.code);
+    },
+  });
+
+  static embedded = class Embedded extends Component<typeof CodedValueField> {
+    <template>
+      {{#if @model.label}}
+        <span
+          class='coded-value'
+          title='{{@model.scheme}} · code {{@model.code}}'
+        >{{@model.label}}</span>
+      {{/if}}
+      <style scoped>
+        .coded-value {
+          border-bottom: 0.0625rem dotted var(--muted-foreground);
+          cursor: help;
+        }
+      </style>
+    </template>
+  };
+
+  static atom = this.embedded;
+}
+
+// How the frame was taken. Shared by stills and video: a camera is a camera.
+export class CameraCaptureField extends FieldDef {
+  static displayName = 'Camera Capture';
+  static icon = CameraIcon;
+
+  @field make = contains(StringField);
+  // Not `model`: a field named `model` would collide with the `@model` a
+  // template receives, making every reference in this file ambiguous to read.
+  @field cameraModel = contains(StringField);
+  @field lensModel = contains(StringField);
+  @field focalLength = contains(QuantityField);
+  @field aperture = contains(QuantityField);
+  @field exposureTime = contains(QuantityField);
+  @field iso = contains(NumberField);
+  @field flash = contains(CodedValueField);
+  @field orientation = contains(CodedValueField);
+  @field capturedAt = contains(DateTimeField);
+  @field software = contains(StringField);
+
+  @field cameraName = contains(StringField, {
+    computeVia: function (this: CameraCaptureField) {
+      // Makers vary on whether the model string already carries the make
+      // ("Canon EOS R5" vs. a bare "X-T4"), so only prepend when it doesn't.
+      let make = this.make?.trim() ?? '';
+      let cameraModel = this.cameraModel?.trim() ?? '';
+      if (!cameraModel) {
+        return make;
+      }
+      if (!make || cameraModel.toLowerCase().startsWith(make.toLowerCase())) {
+        return cameraModel;
+      }
+      return `${make} ${cameraModel}`;
+    },
+  });
+
+  static embedded = class Embedded extends Component<typeof CameraCaptureField> {
+    <template>
+      <dl class='metadata-rows'>
+        {{#if @model.cameraName}}
+          <div class='row'><dt>Camera</dt><dd>{{@model.cameraName}}</dd></div>
+        {{/if}}
+        {{#if @model.lensModel}}
+          <div class='row'><dt>Lens</dt><dd>{{@model.lensModel}}</dd></div>
+        {{/if}}
+        {{#if @model.focalLength.display}}
+          <div class='row'><dt>Focal length</dt><dd><@fields.focalLength
+              /></dd></div>
+        {{/if}}
+        {{#if @model.aperture.display}}
+          <div class='row'><dt>Aperture</dt><dd><@fields.aperture /></dd></div>
+        {{/if}}
+        {{#if @model.exposureTime.display}}
+          <div class='row'><dt>Exposure</dt><dd><@fields.exposureTime
+              /></dd></div>
+        {{/if}}
+        {{#if @model.iso}}
+          <div class='row'><dt>ISO</dt><dd>{{@model.iso}}</dd></div>
+        {{/if}}
+        {{#if @model.flash.label}}
+          <div class='row'><dt>Flash</dt><dd><@fields.flash /></dd></div>
+        {{/if}}
+        {{#if @model.orientation.label}}
+          <div class='row'><dt>Orientation</dt><dd><@fields.orientation
+              /></dd></div>
+        {{/if}}
+        {{#if @model.software}}
+          <div class='row'><dt>Software</dt><dd>{{@model.software}}</dd></div>
+        {{/if}}
+      </dl>
+      <style scoped>
+        .metadata-rows {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.3125rem;
+          font-size: 0.75rem;
+        }
+        .row {
+          display: flex;
+          gap: 0.625rem;
+          align-items: baseline;
+        }
+        dt {
+          flex: 0 0 5.75rem;
+          font-family: var(--font-mono);
+          font-size: 0.5625rem;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: var(--muted-foreground);
+        }
+        dd {
+          margin: 0;
+          min-width: 0;
+        }
+      </style>
+    </template>
+  };
+}
+
+// Where the file was made. `latitude`/`longitude` stay plain numbers so they
+// remain range-queryable; the formatted forms are computed.
+export class GeoLocationField extends FieldDef {
+  static displayName = 'Geo Location';
+  static icon = MapPinIcon;
+
+  @field latitude = contains(NumberField);
+  @field longitude = contains(NumberField);
+  @field altitude = contains(QuantityField);
+  @field placeName = contains(StringField);
+  @field city = contains(StringField);
+  @field region = contains(StringField);
+  @field country = contains(StringField);
+  @field source = contains(CodedValueField);
+
+  @field coordinates = contains(StringField, {
+    computeVia: function (this: GeoLocationField) {
+      if (this.latitude == null || this.longitude == null) {
+        return '';
+      }
+      let latitude = `${Math.abs(this.latitude).toFixed(4)}° ${
+        this.latitude >= 0 ? 'N' : 'S'
+      }`;
+      let longitude = `${Math.abs(this.longitude).toFixed(4)}° ${
+        this.longitude >= 0 ? 'E' : 'W'
+      }`;
+      return `${latitude}, ${longitude}`;
+    },
+  });
+
+  @field place = contains(StringField, {
+    computeVia: function (this: GeoLocationField) {
+      return [this.placeName, this.city, this.region, this.country]
+        .filter(Boolean)
+        .join(' · ');
+    },
+  });
+
+  static embedded = class Embedded extends Component<typeof GeoLocationField> {
+    <template>
+      <dl class='metadata-rows'>
+        {{#if @model.coordinates}}
+          <div class='row'><dt>Coordinates</dt><dd
+              class='mono'
+            >{{@model.coordinates}}</dd></div>
+        {{/if}}
+        {{#if @model.altitude.display}}
+          <div class='row'><dt>Altitude</dt><dd><@fields.altitude /></dd></div>
+        {{/if}}
+        {{#if @model.place}}
+          <div class='row'><dt>Place</dt><dd>{{@model.place}}</dd></div>
+        {{/if}}
+        {{#if @model.source.label}}
+          <div class='row'><dt>Source</dt><dd><@fields.source /></dd></div>
+        {{/if}}
+      </dl>
+      <style scoped>
+        .metadata-rows {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.3125rem;
+          font-size: 0.75rem;
+        }
+        .row {
+          display: flex;
+          gap: 0.625rem;
+          align-items: baseline;
+        }
+        dt {
+          flex: 0 0 5.75rem;
+          font-family: var(--font-mono);
+          font-size: 0.5625rem;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: var(--muted-foreground);
+        }
+        dd {
+          margin: 0;
+          min-width: 0;
+        }
+        .mono {
+          font-family: var(--font-mono);
+          font-size: 0.6875rem;
+        }
+      </style>
+    </template>
+  };
+}
+
+// How the pixels are encoded. `hasAlpha` is nullable on purpose: "this format
+// has no alpha channel" and "we couldn't tell" are different answers, and a
+// default of `false` would launder the second into the first.
+export class ColorProfileField extends FieldDef {
+  static displayName = 'Color Profile';
+  static icon = PaletteIcon;
+
+  @field colorSpace = contains(CodedValueField);
+  @field bitDepth = contains(NumberField);
+  @field channels = contains(NumberField);
+  @field hasAlpha = contains(BooleanField);
+  @field iccProfile = contains(StringField);
+
+  static embedded = class Embedded extends Component<typeof ColorProfileField> {
+    <template>
+      <dl class='metadata-rows'>
+        {{#if @model.colorSpace.label}}
+          <div class='row'><dt>Color space</dt><dd><@fields.colorSpace
+              /></dd></div>
+        {{/if}}
+        {{#if @model.bitDepth}}
+          <div class='row'><dt>Bit depth</dt><dd>{{@model.bitDepth}}-bit</dd></div>
+        {{/if}}
+        {{#if @model.channels}}
+          <div class='row'><dt>Channels</dt><dd>{{@model.channels}}</dd></div>
+        {{/if}}
+        {{#if @model.iccProfile}}
+          <div class='row'><dt>ICC profile</dt><dd>{{@model.iccProfile}}</dd></div>
+        {{/if}}
+      </dl>
+      <style scoped>
+        .metadata-rows {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.3125rem;
+          font-size: 0.75rem;
+        }
+        .row {
+          display: flex;
+          gap: 0.625rem;
+          align-items: baseline;
+        }
+        dt {
+          flex: 0 0 5.75rem;
+          font-family: var(--font-mono);
+          font-size: 0.5625rem;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: var(--muted-foreground);
+        }
+        dd {
+          margin: 0;
+          min-width: 0;
+        }
+      </style>
+    </template>
+  };
+}
+
+// What the camera recorded about the moment, grouped so a family declares one
+// field rather than two and a consumer has one place to look.
+//
+// Color is deliberately *not* here. EXIF's `ColorSpace` tag is one weak signal
+// about the pixels, while the container's own header states bit depth, channel
+// count, and alpha outright. Keeping both would mean two `colorProfile` blocks
+// disagreeing about the same file, so the container wins and the family carries
+// a single `ColorProfileField` alongside this one — with the EXIF tag folded in
+// as a fallback for color space alone.
+export class ExifMetadataField extends FieldDef {
+  static displayName = 'EXIF Metadata';
+  static icon = FileInfoIcon;
+
+  @field capture = contains(CameraCaptureField);
+  @field location = contains(GeoLocationField);
+
+  static embedded = class Embedded extends Component<typeof ExifMetadataField> {
+    <template>
+      <section class='exif'>
+        <@fields.capture />
+        <@fields.location />
+      </section>
+      <style scoped>
+        .exif {
+          display: grid;
+          gap: 0.75rem;
+        }
+      </style>
+    </template>
+  };
+}

--- a/packages/base/gif-image-def.gts
+++ b/packages/base/gif-image-def.gts
@@ -1,10 +1,21 @@
 import { readFirstBytes } from '@cardstack/runtime-common';
 import GifIcon from '@cardstack/boxel-icons/gif';
-import ImageDef from './image-file-def';
-import { type ByteStream, type SerializedFile } from './file-api';
-import { extractGifDimensions } from './gif-meta-extractor';
+import {
+  RasterImageDef,
+  rasterImageAttributes,
+  type RasterImageAttributes,
+} from './image-file-def';
+import type { ByteStream, SerializedFile } from './file-api';
+import {
+  extractGifColorProfile,
+  extractGifDimensions,
+} from './gif-meta-extractor';
 
-export class GifDef extends ImageDef {
+// 6-byte signature plus the 7-byte logical screen descriptor, which holds the
+// dimensions and the global color table's size.
+const GIF_SCREEN_DESCRIPTOR_BYTES = 13;
+
+export class GifDef extends RasterImageDef {
   static displayName = 'GIF Image';
   static icon = GifIcon;
   static acceptTypes = '.gif,image/gif';
@@ -13,15 +24,22 @@ export class GifDef extends ImageDef {
     url: string,
     getStream: () => Promise<ByteStream>,
     options: { contentHash?: string } = {},
-  ): Promise<SerializedFile<{ width: number; height: number }>> {
+  ): Promise<
+    SerializedFile<{ width: number; height: number } & RasterImageAttributes>
+  > {
     let base = await super.extractAttributes(url, getStream, options);
-    let bytes = await readFirstBytes(await getStream(), 10);
+    let bytes = await readFirstBytes(
+      await getStream(),
+      GIF_SCREEN_DESCRIPTOR_BYTES,
+    );
     let { width, height } = extractGifDimensions(bytes);
 
     return {
       ...base,
       width,
       height,
+      // GIF has no EXIF.
+      ...rasterImageAttributes(undefined, extractGifColorProfile(bytes)),
     };
   }
 }

--- a/packages/base/gif-meta-extractor.ts
+++ b/packages/base/gif-meta-extractor.ts
@@ -1,4 +1,8 @@
 import { FileContentMismatchError } from './file-api';
+import {
+  prunedColorProfile,
+  type ImageColorProfile,
+} from './image-color-profile';
 
 // GIF files start with either "GIF87a" or "GIF89a" (6 bytes)
 const GIF87A_SIGNATURE = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x37, 0x61]);
@@ -42,4 +46,36 @@ export function extractGifDimensions(bytes: Uint8Array): {
   let height = view.getUint16(8, true);
 
   return { width, height };
+}
+
+// Byte 10 of the logical screen descriptor packs the global color table flag
+// (bit 7) and, in bits 0-2, the table's size as an exponent: N means 2^(N+1)
+// entries, so a value of 7 is the full 256-color table.
+const LOGICAL_SCREEN_PACKED_OFFSET = 10;
+const GLOBAL_COLOR_TABLE_FLAG = 0x80;
+const GLOBAL_COLOR_TABLE_SIZE_MASK = 0x07;
+
+// GIF is always palette-indexed 8-bit RGB. What the header reveals beyond that
+// is how many palette entries the image actually uses, which is the honest
+// answer to its bit depth — a 16-color GIF is 4-bit.
+//
+// Transparency is deliberately reported as unknown rather than false: a GIF's
+// transparent color is declared in a Graphic Control Extension well past this
+// header, so claiming `hasAlpha: false` here would be a guess dressed as a fact.
+// Callers must read at least 11 bytes.
+export function extractGifColorProfile(
+  bytes: Uint8Array,
+): ImageColorProfile | undefined {
+  if (bytes.length <= LOGICAL_SCREEN_PACKED_OFFSET) {
+    return undefined;
+  }
+  let packed = bytes[LOGICAL_SCREEN_PACKED_OFFSET]!;
+  let hasGlobalColorTable = (packed & GLOBAL_COLOR_TABLE_FLAG) !== 0;
+  return prunedColorProfile({
+    colorSpace: 'indexed',
+    bitDepth: hasGlobalColorTable
+      ? (packed & GLOBAL_COLOR_TABLE_SIZE_MASK) + 1
+      : undefined,
+    channels: 3,
+  });
 }

--- a/packages/base/image-color-profile.ts
+++ b/packages/base/image-color-profile.ts
@@ -1,0 +1,37 @@
+// How a raster image encodes its pixels, read from the container's own header.
+//
+// Each image format states this in its own way — PNG in IHDR, JPEG in the frame
+// header, GIF in the logical screen descriptor, WebP per bitstream flavor — so
+// the per-format reader lives in that format's `*-meta-extractor` module and
+// they all return this one shape. That's what lets a query ask "which images
+// have an alpha channel" without caring what encoded them.
+//
+// Every property is optional, and absence is meaningful: a format that cannot
+// tell us its bit depth leaves `bitDepth` unset rather than guessing 8, and a
+// format with no alpha concept leaves `hasAlpha` unset rather than reporting
+// `false` — "no alpha channel" and "we couldn't tell" are different answers.
+
+export interface ImageColorProfile {
+  // A slug from the shared `color-space` vocabulary in
+  // `file-formats/metadata-fields`, wrapped by the caller into a CodedValue.
+  colorSpace?: string;
+  // Bits per channel, not per pixel: a 24-bit RGB image is 8-bit here, which
+  // is how every image format and every color tool states it.
+  bitDepth?: number;
+  channels?: number;
+  hasAlpha?: boolean;
+  iccProfile?: string;
+}
+
+// Drop the keys that came back undefined so a format that learned nothing
+// yields no attribute at all rather than an empty object in the index row.
+export function prunedColorProfile(
+  candidate: ImageColorProfile,
+): ImageColorProfile | undefined {
+  let entries = Object.entries(candidate).filter(
+    ([, value]) => value !== undefined,
+  );
+  return entries.length > 0
+    ? (Object.fromEntries(entries) as ImageColorProfile)
+    : undefined;
+}

--- a/packages/base/image-file-def.gts
+++ b/packages/base/image-file-def.gts
@@ -1,1 +1,94 @@
-export { ImageDef, ImageDef as default } from './card-api';
+import { ImageDef, contains, field } from './card-api';
+import {
+  ColorProfileField,
+  ExifMetadataField,
+} from './file-formats/metadata-fields';
+import type { ExifCapture, ExifLocation } from './exif-meta-extractor';
+import type { ExifMetadata } from './exif-meta-extractor';
+import type { ImageColorProfile } from './image-color-profile';
+
+export { ImageDef };
+export default ImageDef;
+
+// Raster images, as distinct from vector ones. The split exists to make field
+// legality explicit rather than to add a rendering layer: encoded pixels have a
+// bit depth, a channel count, and possibly a camera behind them, while an SVG
+// has none of those — so `SvgDef` extends `ImageDef` directly and everything
+// that decodes to a pixel grid extends this.
+//
+// These fields live here, and not on `ImageDef` in `card-api`, on purpose.
+// `card-api` statically imports FileDef's format templates, so anything it
+// reaches lands in the dependency graph of every card in every realm. Attaching
+// image metadata one level down means only realms that actually hold image
+// files pay for the metadata field modules.
+export class RasterImageDef extends ImageDef {
+  static displayName = 'Raster Image';
+
+  // What the camera recorded: body, lens, exposure, and where the shutter was
+  // pressed. Empty for anything generated rather than photographed, which is
+  // most images in most realms.
+  @field exif = contains(ExifMetadataField);
+
+  // How the pixels are encoded, read from the container's own header. See
+  // `ExifMetadataField` for why this is a sibling of `exif` rather than nested
+  // inside it.
+  @field colorProfile = contains(ColorProfileField);
+}
+
+// A `CodedValueField` as it arrives over the wire: the format's own code plus
+// the vocabulary that names it.
+interface SerializedCodedValue {
+  code: string;
+  scheme: string;
+}
+
+// `ColorProfileField`'s wire shape. It differs from `ImageColorProfile` in one
+// place — a color space travels as a coded value, while the per-format readers
+// return the bare slug — so that the readers stay free of any knowledge about
+// how the field is modeled.
+export interface SerializedColorProfile extends Omit<
+  ImageColorProfile,
+  'colorSpace'
+> {
+  colorSpace?: SerializedCodedValue;
+}
+
+// The attributes a raster subclass's `extractAttributes` adds on top of the base
+// file identity and dimensions. Both are plain nested objects, which is how a
+// contained FieldDef arrives over the wire.
+export interface RasterImageAttributes {
+  exif?: { capture?: ExifCapture; location?: ExifLocation };
+  colorProfile?: SerializedColorProfile;
+}
+
+// Assemble the two metadata attributes from whatever the format's readers could
+// determine, and omit either one entirely when they determined nothing — an
+// image with no EXIF and an unreadable header should add no attributes rather
+// than empty ones.
+//
+// EXIF's `ColorSpace` tag is folded in only as a fallback: the container header
+// is the better authority, so it wins wherever it spoke.
+export function rasterImageAttributes(
+  exif: ExifMetadata | undefined,
+  colorProfile: ImageColorProfile | undefined,
+): RasterImageAttributes {
+  let { colorSpace: exifColorSpace, ...cameraFacts } = exif ?? {};
+  let { colorSpace: headerColorSpace, ...pixelFacts } = colorProfile ?? {};
+  let colorSpace = headerColorSpace ?? exifColorSpace;
+  let hasPixelFacts = Object.values(pixelFacts).some(
+    (value) => value !== undefined,
+  );
+  return {
+    ...(Object.keys(cameraFacts).length > 0 ? { exif: cameraFacts } : {}),
+    ...(hasPixelFacts || colorSpace
+      ? {
+          colorProfile: {
+            ...pixelFacts,
+            ...(colorSpace
+              ? { colorSpace: { code: colorSpace, scheme: 'color-space' } }
+              : {}),
+          },
+        }
+      : {}),
+  };
+}

--- a/packages/base/jpg-image-def.gts
+++ b/packages/base/jpg-image-def.gts
@@ -1,14 +1,26 @@
 import { readFirstBytes } from '@cardstack/runtime-common';
 import JpgIcon from '@cardstack/boxel-icons/file-type-jpg';
-import ImageDef from './image-file-def';
-import { type ByteStream, type SerializedFile } from './file-api';
-import { extractJpgDimensions } from './jpg-meta-extractor';
+import {
+  RasterImageDef,
+  rasterImageAttributes,
+  type RasterImageAttributes,
+} from './image-file-def';
+import type { ByteStream, SerializedFile } from './file-api';
+import { extractExifFromJpeg } from './exif-meta-extractor';
+import {
+  extractJpgColorProfile,
+  extractJpgDimensions,
+} from './jpg-meta-extractor';
 
 // JPEG SOF marker is typically within the first few KB, but can follow
 // large EXIF/ICC segments. 64 KB covers virtually all real-world files.
+//
+// The same window is what makes EXIF readable: its APP1 segment precedes the
+// frame header, so any file whose dimensions this pass can find has already had
+// its EXIF stream past.
 const JPEG_MAX_HEADER_BYTES = 65_536;
 
-export class JpgDef extends ImageDef {
+export class JpgDef extends RasterImageDef {
   static displayName = 'JPEG Image';
   static icon = JpgIcon;
   static acceptTypes = '.jpg,.jpeg,image/jpeg';
@@ -17,7 +29,9 @@ export class JpgDef extends ImageDef {
     url: string,
     getStream: () => Promise<ByteStream>,
     options: { contentHash?: string } = {},
-  ): Promise<SerializedFile<{ width: number; height: number }>> {
+  ): Promise<
+    SerializedFile<{ width: number; height: number } & RasterImageAttributes>
+  > {
     let base = await super.extractAttributes(url, getStream, options);
     let bytes = await readFirstBytes(await getStream(), JPEG_MAX_HEADER_BYTES);
     let { width, height } = extractJpgDimensions(bytes);
@@ -26,6 +40,10 @@ export class JpgDef extends ImageDef {
       ...base,
       width,
       height,
+      ...rasterImageAttributes(
+        extractExifFromJpeg(bytes),
+        extractJpgColorProfile(bytes),
+      ),
     };
   }
 }

--- a/packages/base/jpg-meta-extractor.ts
+++ b/packages/base/jpg-meta-extractor.ts
@@ -53,12 +53,15 @@ export interface JpegFrameInfo {
   components: number;
 }
 
-// Component counts map to the color model the encoder used. JPEG has no alpha
-// channel in any mode, so `hasAlpha` is a definite `false` rather than unknown.
+// The component count alone pins the color model only for a single channel:
+// one component is grayscale, unambiguously. Three components are RGB *or*
+// YCbCr and four are CMYK *or* YCCK, and which one is carried by an Adobe APP14
+// transform flag this frame-header read doesn't parse — so those cases leave
+// `colorSpace` unset rather than guess, while `channels` still records the count.
+// JPEG has no alpha channel in any mode, so `hasAlpha` is a definite `false`
+// rather than unknown.
 const JPEG_COLOR_SPACES: Record<number, string> = {
   1: 'grayscale',
-  3: 'ycbcr',
-  4: 'cmyk',
 };
 
 export function extractJpgColorProfile(

--- a/packages/base/jpg-meta-extractor.ts
+++ b/packages/base/jpg-meta-extractor.ts
@@ -1,4 +1,8 @@
 import { FileContentMismatchError } from './file-api';
+import {
+  prunedColorProfile,
+  type ImageColorProfile,
+} from './image-color-profile';
 
 // JPEG files start with SOI marker: FF D8
 const JPEG_SOI = new Uint8Array([0xff, 0xd8]);
@@ -36,10 +40,55 @@ function validateJpegSignature(bytes: Uint8Array): void {
   }
 }
 
+// A JPEG's frame header carries its encoding as well as its size, and both come
+// from the same scan for the SOF marker — so one pass reads them together and
+// the two exported readers project from it.
+export interface JpegFrameInfo {
+  width: number;
+  height: number;
+  // Bits per sample. Baseline JPEG is always 8; 12 and 16 appear in extended
+  // and lossless modes.
+  precision: number;
+  // 1 = grayscale, 3 = YCbCr (or RGB), 4 = CMYK/YCCK.
+  components: number;
+}
+
+// Component counts map to the color model the encoder used. JPEG has no alpha
+// channel in any mode, so `hasAlpha` is a definite `false` rather than unknown.
+const JPEG_COLOR_SPACES: Record<number, string> = {
+  1: 'grayscale',
+  3: 'ycbcr',
+  4: 'cmyk',
+};
+
+export function extractJpgColorProfile(
+  bytes: Uint8Array,
+): ImageColorProfile | undefined {
+  let frame: JpegFrameInfo;
+  try {
+    frame = extractJpgFrameInfo(bytes);
+  } catch {
+    // A file we can't find a frame header in has no color facts to report; the
+    // dimension reader is what decides whether that's a content mismatch.
+    return undefined;
+  }
+  return prunedColorProfile({
+    colorSpace: JPEG_COLOR_SPACES[frame.components],
+    bitDepth: frame.precision > 0 ? frame.precision : undefined,
+    channels: frame.components > 0 ? frame.components : undefined,
+    hasAlpha: false,
+  });
+}
+
 export function extractJpgDimensions(bytes: Uint8Array): {
   width: number;
   height: number;
 } {
+  let { width, height } = extractJpgFrameInfo(bytes);
+  return { width, height };
+}
+
+export function extractJpgFrameInfo(bytes: Uint8Array): JpegFrameInfo {
   validateJpegSignature(bytes);
 
   if (bytes.length < MIN_BYTES) {
@@ -74,7 +123,11 @@ export function extractJpgDimensions(bytes: Uint8Array): {
     }
 
     // Markers without a length field (standalone markers)
-    if (marker === 0xd8 || marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7)) {
+    if (
+      marker === 0xd8 ||
+      marker === 0xd9 ||
+      (marker >= 0xd0 && marker <= 0xd7)
+    ) {
       continue;
     }
 
@@ -89,14 +142,19 @@ export function extractJpgDimensions(bytes: Uint8Array): {
       //   1 byte  — precision
       //   2 bytes — height (big-endian)
       //   2 bytes — width  (big-endian)
+      //   1 byte  — number of components
       if (offset + 2 + 5 > bytes.length) {
-        throw new FileContentMismatchError(
-          'JPEG SOF segment is truncated',
-        );
+        throw new FileContentMismatchError('JPEG SOF segment is truncated');
       }
+      let precision = view.getUint8(offset + 2);
       let height = view.getUint16(offset + 2 + 1);
       let width = view.getUint16(offset + 2 + 3);
-      return { width, height };
+      // The component count sits one byte past the dimensions. A frame header
+      // truncated right after the size still yields usable dimensions, so
+      // report zero components rather than rejecting the file.
+      let components =
+        offset + 2 + 6 <= bytes.length ? view.getUint8(offset + 2 + 5) : 0;
+      return { width, height, precision, components };
     }
 
     // Skip to next marker

--- a/packages/base/png-image-def.gts
+++ b/packages/base/png-image-def.gts
@@ -1,10 +1,22 @@
 import { readFirstBytes } from '@cardstack/runtime-common';
 import PngIcon from '@cardstack/boxel-icons/file-type-png';
-import ImageDef from './image-file-def';
-import { type ByteStream, type SerializedFile } from './file-api';
-import { extractPngDimensions } from './png-meta-extractor';
+import {
+  RasterImageDef,
+  rasterImageAttributes,
+  type RasterImageAttributes,
+} from './image-file-def';
+import type { ByteStream, SerializedFile } from './file-api';
+import {
+  extractPngColorProfile,
+  extractPngDimensions,
+} from './png-meta-extractor';
 
-export class PngDef extends ImageDef {
+// IHDR is always PNG's first chunk and is fixed-length, so everything this
+// reads — dimensions, bit depth, color type — lives in the first 33 bytes:
+// 8-byte signature, 8-byte chunk header, 13 bytes of IHDR data, 4-byte CRC.
+const PNG_IHDR_BYTES = 33;
+
+export class PngDef extends RasterImageDef {
   static displayName = 'PNG Image';
   static icon = PngIcon;
   static acceptTypes = '.png,image/png';
@@ -13,15 +25,21 @@ export class PngDef extends ImageDef {
     url: string,
     getStream: () => Promise<ByteStream>,
     options: { contentHash?: string } = {},
-  ): Promise<SerializedFile<{ width: number; height: number }>> {
+  ): Promise<
+    SerializedFile<{ width: number; height: number } & RasterImageAttributes>
+  > {
     let base = await super.extractAttributes(url, getStream, options);
-    let bytes = await readFirstBytes(await getStream(), 24);
+    let bytes = await readFirstBytes(await getStream(), PNG_IHDR_BYTES);
     let { width, height } = extractPngDimensions(bytes);
 
     return {
       ...base,
       width,
       height,
+      // PNG carries no EXIF in IHDR. A `eXIf` chunk can appear later in the
+      // file; reading it means walking chunks, which this header-only pass
+      // deliberately doesn't do.
+      ...rasterImageAttributes(undefined, extractPngColorProfile(bytes)),
     };
   }
 }

--- a/packages/base/png-meta-extractor.ts
+++ b/packages/base/png-meta-extractor.ts
@@ -1,4 +1,8 @@
 import { FileContentMismatchError } from './file-api';
+import {
+  prunedColorProfile,
+  type ImageColorProfile,
+} from './image-color-profile';
 
 // PNG 8-byte magic signature
 const PNG_SIGNATURE = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
@@ -39,4 +43,49 @@ export function extractPngDimensions(bytes: Uint8Array): {
   let height = view.getUint32(20);
 
   return { width, height };
+}
+
+// IHDR color type is a bit field: 1 = palette used, 2 = color used, 4 = alpha
+// channel present. Only five of the eight combinations are legal, and each
+// fixes the channel count.
+const PNG_COLOR_TYPES: Record<
+  number,
+  { colorSpace: string; channels: number; hasAlpha: boolean }
+> = {
+  0: { colorSpace: 'grayscale', channels: 1, hasAlpha: false },
+  2: { colorSpace: 'srgb', channels: 3, hasAlpha: false },
+  // Palette entries are themselves RGB triples, so the samples are indices but
+  // the rendered color is three-channel.
+  3: { colorSpace: 'indexed', channels: 3, hasAlpha: false },
+  4: { colorSpace: 'grayscale-alpha', channels: 2, hasAlpha: true },
+  6: { colorSpace: 'srgb', channels: 4, hasAlpha: true },
+};
+
+// IHDR byte offsets, continuing past the dimensions read above.
+const IHDR_BIT_DEPTH_OFFSET = 24;
+const IHDR_COLOR_TYPE_OFFSET = 25;
+
+// PNG states its encoding outright in IHDR, which is always the first chunk, so
+// this needs no scanning — but callers must read at least 26 bytes.
+//
+// One deliberate omission: a `tRNS` chunk can make an indexed or truecolor PNG
+// transparent without the alpha bit being set in the color type. Finding it
+// means walking chunks past IHDR, so `hasAlpha` here reports the alpha
+// *channel*, and an image whose transparency comes from `tRNS` reads as false.
+export function extractPngColorProfile(
+  bytes: Uint8Array,
+): ImageColorProfile | undefined {
+  if (bytes.length <= IHDR_COLOR_TYPE_OFFSET) {
+    return undefined;
+  }
+  let bitDepth = bytes[IHDR_BIT_DEPTH_OFFSET]!;
+  let colorType = PNG_COLOR_TYPES[bytes[IHDR_COLOR_TYPE_OFFSET]!];
+  return prunedColorProfile({
+    colorSpace: colorType?.colorSpace,
+    // Legal PNG bit depths are 1, 2, 4, 8, and 16; anything else means we're
+    // not looking at a real IHDR.
+    bitDepth: [1, 2, 4, 8, 16].includes(bitDepth) ? bitDepth : undefined,
+    channels: colorType?.channels,
+    hasAlpha: colorType?.hasAlpha,
+  });
 }

--- a/packages/base/png-meta-extractor.ts
+++ b/packages/base/png-meta-extractor.ts
@@ -48,17 +48,24 @@ export function extractPngDimensions(bytes: Uint8Array): {
 // IHDR color type is a bit field: 1 = palette used, 2 = color used, 4 = alpha
 // channel present. Only five of the eight combinations are legal, and each
 // fixes the channel count.
+//
+// `colorSpace` here names the channel *model*, not a colorimetric profile.
+// IHDR proves grayscale/indexed outright, but for truecolor (2/6) it says only
+// "three or four channels of color" — sRGB versus Display P3 versus an embedded
+// ICC profile is stated in an `sRGB`/`iCCP`/`cICP` chunk past IHDR that this
+// header-only read never reaches. So truecolor leaves `colorSpace` unset rather
+// than guess `srgb`; `channels` already records that it's RGB(A).
 const PNG_COLOR_TYPES: Record<
   number,
-  { colorSpace: string; channels: number; hasAlpha: boolean }
+  { colorSpace?: string; channels: number; hasAlpha: boolean }
 > = {
   0: { colorSpace: 'grayscale', channels: 1, hasAlpha: false },
-  2: { colorSpace: 'srgb', channels: 3, hasAlpha: false },
+  2: { channels: 3, hasAlpha: false },
   // Palette entries are themselves RGB triples, so the samples are indices but
   // the rendered color is three-channel.
   3: { colorSpace: 'indexed', channels: 3, hasAlpha: false },
   4: { colorSpace: 'grayscale-alpha', channels: 2, hasAlpha: true },
-  6: { colorSpace: 'srgb', channels: 4, hasAlpha: true },
+  6: { channels: 4, hasAlpha: true },
 };
 
 // IHDR byte offsets, continuing past the dimensions read above.

--- a/packages/base/webp-image-def.gts
+++ b/packages/base/webp-image-def.gts
@@ -1,9 +1,20 @@
 import { readFirstBytes } from '@cardstack/runtime-common';
-import ImageDef from './image-file-def';
-import { type ByteStream, type SerializedFile } from './file-api';
-import { extractWebpDimensions } from './webp-meta-extractor';
+import {
+  RasterImageDef,
+  rasterImageAttributes,
+  type RasterImageAttributes,
+} from './image-file-def';
+import type { ByteStream, SerializedFile } from './file-api';
+import {
+  extractWebpColorProfile,
+  extractWebpDimensions,
+} from './webp-meta-extractor';
 
-export class WebpDef extends ImageDef {
+// The RIFF header plus the first chunk's own header, which is where every WebP
+// flavor states both its dimensions and whether it carries alpha.
+const WEBP_HEADER_BYTES = 30;
+
+export class WebpDef extends RasterImageDef {
   static displayName = 'WebP Image';
   static acceptTypes = '.webp,image/webp';
 
@@ -11,15 +22,20 @@ export class WebpDef extends ImageDef {
     url: string,
     getStream: () => Promise<ByteStream>,
     options: { contentHash?: string } = {},
-  ): Promise<SerializedFile<{ width: number; height: number }>> {
+  ): Promise<
+    SerializedFile<{ width: number; height: number } & RasterImageAttributes>
+  > {
     let base = await super.extractAttributes(url, getStream, options);
-    let bytes = await readFirstBytes(await getStream(), 30);
+    let bytes = await readFirstBytes(await getStream(), WEBP_HEADER_BYTES);
     let { width, height } = extractWebpDimensions(bytes);
 
     return {
       ...base,
       width,
       height,
+      // WebP can carry EXIF in a trailing `EXIF` chunk, past the window this
+      // header-only pass reads.
+      ...rasterImageAttributes(undefined, extractWebpColorProfile(bytes)),
     };
   }
 }

--- a/packages/base/webp-meta-extractor.ts
+++ b/packages/base/webp-meta-extractor.ts
@@ -1,4 +1,8 @@
 import { FileContentMismatchError } from './file-api';
+import {
+  prunedColorProfile,
+  type ImageColorProfile,
+} from './image-color-profile';
 
 // WebP files start with "RIFF" (4 bytes) + file size (4 bytes) + "WEBP" (4 bytes)
 const RIFF_SIGNATURE = new Uint8Array([0x52, 0x49, 0x46, 0x46]); // "RIFF"
@@ -95,14 +99,67 @@ export function extractWebpDimensions(bytes: Uint8Array): {
         'VP8X chunk is too small to contain dimensions',
       );
     }
-    let width =
-      (bytes[24]! | (bytes[25]! << 8) | (bytes[26]! << 16)) + 1;
-    let height =
-      (bytes[27]! | (bytes[28]! << 8) | (bytes[29]! << 16)) + 1;
+    let width = (bytes[24]! | (bytes[25]! << 8) | (bytes[26]! << 16)) + 1;
+    let height = (bytes[27]! | (bytes[28]! << 8) | (bytes[29]! << 16)) + 1;
     return { width, height };
   }
 
   throw new FileContentMismatchError(
     `WebP file has unrecognized chunk type: ${chunkFourCC}`,
   );
+}
+
+// Each WebP flavor declares alpha in its own place.
+//
+//   VP8   lossy — no alpha in the bitstream at all.
+//   VP8L  lossless — bit 28 of the 32-bit little-endian header word that
+//         follows the signature byte, the same word the dimensions come from.
+//   VP8X  extended — bit 4 of the flags byte, set when a separate ALPH chunk
+//         follows. This is also the flavor an animated or ICC-carrying file
+//         uses, so it's the one where the flag actually varies.
+//
+// WebP is 8 bits per channel in every mode, so bit depth is a constant rather
+// than something read from the file.
+const VP8X_FLAGS_OFFSET = 20;
+const VP8X_ALPHA_FLAG = 0x10;
+const VP8X_ICC_FLAG = 0x20;
+const VP8L_HEADER_OFFSET = 21;
+const VP8L_ALPHA_BIT = 28;
+
+export function extractWebpColorProfile(
+  bytes: Uint8Array,
+): ImageColorProfile | undefined {
+  if (bytes.length < 16) {
+    return undefined;
+  }
+  let chunkFourCC = String.fromCharCode(
+    bytes[12]!,
+    bytes[13]!,
+    bytes[14]!,
+    bytes[15]!,
+  );
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let hasAlpha: boolean;
+  let iccProfile: string | undefined;
+  if (chunkFourCC === 'VP8 ') {
+    hasAlpha = false;
+  } else if (chunkFourCC === 'VP8L' && bytes.length >= VP8L_HEADER_OFFSET + 4) {
+    let header = view.getUint32(VP8L_HEADER_OFFSET, true);
+    hasAlpha = ((header >>> VP8L_ALPHA_BIT) & 1) === 1;
+  } else if (chunkFourCC === 'VP8X' && bytes.length > VP8X_FLAGS_OFFSET) {
+    let flags = bytes[VP8X_FLAGS_OFFSET]!;
+    hasAlpha = (flags & VP8X_ALPHA_FLAG) !== 0;
+    // The flag says an ICC chunk is present but not which profile it holds;
+    // naming it would mean parsing the chunk itself.
+    iccProfile = (flags & VP8X_ICC_FLAG) !== 0 ? 'embedded' : undefined;
+  } else {
+    return undefined;
+  }
+  return prunedColorProfile({
+    colorSpace: 'srgb',
+    bitDepth: 8,
+    channels: hasAlpha ? 4 : 3,
+    hasAlpha,
+    iccProfile,
+  });
 }

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -1610,7 +1610,23 @@ export default class Room extends Component<Signature> {
       });
     }
 
-    return new FileDefKlass(attributes);
+    // Build the typed instance through the deserialize path rather than the raw
+    // `new FileDefKlass(attributes)` constructor. The constructor assigns every
+    // attribute through the field setter, which rejects a composite field's
+    // serialized (plain-object) value — e.g. a raster image's `colorProfile` /
+    // `exif`. `createFromSerialized` deserializes those nested objects into
+    // their FieldDef instances instead. No store is passed, so it deserializes
+    // into an isolated store and stays a standalone instance, as before.
+    let api = await this.cardService.getAPI();
+    let resource = {
+      ...extracted.resource,
+      attributes,
+    } as Parameters<typeof api.createFromSerialized>[0];
+    return (await api.createFromSerialized(
+      resource,
+      { data: resource } as Parameters<typeof api.createFromSerialized>[1],
+      new URL(sourceUrl),
+    )) as FileDef;
   }
 
   private doSendMessage = enqueueTask(

--- a/packages/host/tests/acceptance/image-def/jpg-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/jpg-image-def-test.gts
@@ -56,6 +56,34 @@ const VALID_JPEG_4x5 = new Uint8Array([
   0x00, 0x02, 0x11, 0x03, 0x11, 0x00, 0x3f, 0x00, 0x3a, 0x03, 0x15, 0x4d, 0xff, 0xd9,
 ]);
 
+// An EXIF APP1 segment declaring a Canon EOS R5, orientation 6, 1/250s at ƒ/1.4,
+// ISO 400, 50mm, sRGB. Spliced in after SOI below so the same JPEG exercises
+// both the dimension read and the metadata read. Byte-level parsing is covered
+// in `unit/image-metadata-extractor-test`; this fixture exists to prove the
+// values survive the whole extract → search_doc → file-meta path.
+// prettier-ignore
+const EXIF_APP1_SEGMENT = new Uint8Array([
+  0xff, 0xe1, 0x00, 0xb3, 0x45, 0x78, 0x69, 0x66, 0x00, 0x00, 0x49, 0x49, 0x2a, 0x00, 0x08, 0x00,
+  0x00, 0x00, 0x04, 0x00, 0x0f, 0x01, 0x02, 0x00, 0x06, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
+  0x10, 0x01, 0x02, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x86, 0x00, 0x00, 0x00, 0x12, 0x01, 0x03, 0x00,
+  0x01, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x69, 0x87, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00,
+  0x3e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x9a, 0x82, 0x05, 0x00, 0x01, 0x00,
+  0x00, 0x00, 0x93, 0x00, 0x00, 0x00, 0x9d, 0x82, 0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x9b, 0x00,
+  0x00, 0x00, 0x27, 0x88, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x90, 0x01, 0x00, 0x00, 0x0a, 0x92,
+  0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0xa3, 0x00, 0x00, 0x00, 0x01, 0xa0, 0x03, 0x00, 0x01, 0x00,
+  0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x43, 0x61, 0x6e, 0x6f, 0x6e, 0x00,
+  0x43, 0x61, 0x6e, 0x6f, 0x6e, 0x20, 0x45, 0x4f, 0x53, 0x20, 0x52, 0x35, 0x00, 0x01, 0x00, 0x00,
+  0x00, 0xfa, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x32, 0x00, 0x00,
+  0x00, 0x01, 0x00, 0x00, 0x00,
+]);
+
+// EXIF must precede the frame header, so the segment goes directly after SOI.
+const JPEG_WITH_EXIF_4x5 = new Uint8Array([
+  ...VALID_JPEG_4x5.subarray(0, 2),
+  ...EXIF_APP1_SEGMENT,
+  ...VALID_JPEG_4x5.subarray(2),
+]);
+
 module('Acceptance | jpg image def', function (hooks) {
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
@@ -141,6 +169,7 @@ module('Acceptance | jpg image def', function (hooks) {
           ...SYSTEM_CARD_FIXTURE_CONTENTS,
           'sample.jpg': VALID_JPEG_4x5,
           'renderable.jpg': VALID_JPEG_4x5,
+          'with-exif.jpg': JPEG_WITH_EXIF_4x5,
           'not-a-jpg.jpg': 'This is plain text, not a JPEG file.',
         },
       }),
@@ -169,6 +198,106 @@ module('Acceptance | jpg image def', function (hooks) {
     assert.ok(
       String(result.searchDoc?.contentType).includes('jpeg'),
       'sets jpeg content type',
+    );
+  });
+
+  test('carries EXIF and color facts through extract into the search doc', async function (assert) {
+    let url = makeFileURL('with-exif.jpg');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: jpgDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.notOk(
+      result.mismatch,
+      'an EXIF segment ahead of the frame header does not break the dimension read',
+    );
+    assert.strictEqual(result.searchDoc?.width, 4, 'still extracts the width');
+    assert.strictEqual(
+      result.searchDoc?.height,
+      5,
+      'still extracts the height',
+    );
+
+    let exif = result.searchDoc?.exif;
+    assert.strictEqual(exif?.capture?.make, 'Canon');
+    assert.strictEqual(exif?.capture?.cameraModel, 'Canon EOS R5');
+    assert.strictEqual(exif?.capture?.iso, 400);
+    assert.strictEqual(
+      exif?.capture?.exposureTime?.displayText,
+      '1/250 s',
+      'a nested compound value three levels deep survives the extract',
+    );
+    assert.strictEqual(exif?.capture?.focalLength?.value, 50);
+    assert.deepEqual(exif?.capture?.orientation, {
+      code: '6',
+      scheme: 'exif-orientation',
+    });
+
+    assert.deepEqual(
+      result.searchDoc?.colorProfile,
+      {
+        colorSpace: { code: 'ycbcr', scheme: 'color-space' },
+        bitDepth: 8,
+        channels: 3,
+        hasAlpha: false,
+      },
+      "the frame header's color model outranks the EXIF sRGB tag",
+    );
+  });
+
+  test('a JPEG with no EXIF gains no exif attribute at all', async function (assert) {
+    let url = makeFileURL('sample.jpg');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: jpgDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(
+      result.searchDoc?.exif,
+      undefined,
+      'an absent optional structure leaves no empty object in the index row',
+    );
+    assert.strictEqual(
+      result.searchDoc?.colorProfile?.bitDepth,
+      8,
+      'the color profile still comes from the frame header',
+    );
+  });
+
+  test('indexing stores the EXIF metadata and file meta serves it', async function (assert) {
+    let fileURL = new URL('with-exif.jpg', testRealmURL);
+    let fileEntry = await realm.realmIndexQueryEngine.file(fileURL);
+
+    assert.strictEqual(
+      fileEntry?.searchDoc?.exif?.capture?.make,
+      'Canon',
+      'the index row holds the extracted camera make',
+    );
+
+    let network = getService('network') as NetworkService;
+    let response = await network.virtualNetwork.fetch(fileURL, {
+      headers: { Accept: SupportedMimeType.FileMeta },
+    });
+    assert.true(response.ok, 'file meta request succeeds');
+
+    let body = await response.json();
+    assert.strictEqual(
+      body?.data?.attributes?.exif?.capture?.cameraModel,
+      'Canon EOS R5',
+      'file meta serves the nested compound attribute',
+    );
+    assert.strictEqual(
+      body?.data?.attributes?.colorProfile?.colorSpace?.code,
+      'ycbcr',
+      'file meta serves the coded color-space value',
     );
   });
 

--- a/packages/host/tests/acceptance/image-def/jpg-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/jpg-image-def-test.gts
@@ -241,12 +241,13 @@ module('Acceptance | jpg image def', function (hooks) {
     assert.deepEqual(
       result.searchDoc?.colorProfile,
       {
-        colorSpace: { code: 'ycbcr', scheme: 'color-space' },
+        colorSpace: { code: 'srgb', scheme: 'color-space' },
         bitDepth: 8,
         channels: 3,
         hasAlpha: false,
       },
-      "the frame header's color model outranks the EXIF sRGB tag",
+      "a 3-component frame is RGB or YCbCr and the header can't say which, so " +
+        'it declines to guess and the EXIF sRGB tag fills in as the fallback',
     );
   });
 
@@ -296,8 +297,8 @@ module('Acceptance | jpg image def', function (hooks) {
     );
     assert.strictEqual(
       body?.data?.attributes?.colorProfile?.colorSpace?.code,
-      'ycbcr',
-      'file meta serves the coded color-space value',
+      'srgb',
+      'file meta serves the coded color-space value the EXIF fallback supplied',
     );
   });
 

--- a/packages/host/tests/acceptance/image-def/png-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/png-image-def-test.gts
@@ -261,6 +261,33 @@ module('Acceptance | png image def', function (hooks) {
     );
   });
 
+  test('reads the color profile out of IHDR during extract', async function (assert) {
+    let url = makeFileURL('sample.png');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: pngDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.deepEqual(
+      result.searchDoc?.colorProfile,
+      {
+        colorSpace: { code: 'srgb', scheme: 'color-space' },
+        bitDepth: 8,
+        channels: 3,
+        hasAlpha: false,
+      },
+      'the fixture is 8-bit color type 2, so three channels and no alpha',
+    );
+    assert.strictEqual(
+      result.searchDoc?.exif,
+      undefined,
+      'PNG carries no EXIF in IHDR, so no exif attribute is produced',
+    );
+  });
+
   test('falls back when PngDef is used for non-PNG content', async function (assert) {
     let url = makeFileURL('not-a-png.png');
     await visit(

--- a/packages/host/tests/acceptance/image-def/png-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/png-image-def-test.gts
@@ -274,12 +274,12 @@ module('Acceptance | png image def', function (hooks) {
     assert.deepEqual(
       result.searchDoc?.colorProfile,
       {
-        colorSpace: { code: 'srgb', scheme: 'color-space' },
         bitDepth: 8,
         channels: 3,
         hasAlpha: false,
       },
-      'the fixture is 8-bit color type 2, so three channels and no alpha',
+      'the fixture is 8-bit color type 2, so three channels and no alpha; ' +
+        'IHDR proves the channel model but not colorimetry, so no color space is claimed',
     );
     assert.strictEqual(
       result.searchDoc?.exif,

--- a/packages/host/tests/unit/image-metadata-extractor-test.ts
+++ b/packages/host/tests/unit/image-metadata-extractor-test.ts
@@ -635,8 +635,9 @@ module('Unit | image metadata extractors', function (hooks) {
         channels: 1,
         hasAlpha: false,
       });
+      // Color type 2 is truecolor: IHDR proves three channels but not their
+      // colorimetry, so no `colorSpace` is claimed.
       assert.deepEqual(extractPngColorProfile(buildPng(8, 2)), {
-        colorSpace: 'srgb',
         bitDepth: 8,
         channels: 3,
         hasAlpha: false,
@@ -653,8 +654,8 @@ module('Unit | image metadata extractors', function (hooks) {
         channels: 2,
         hasAlpha: true,
       });
+      // Color type 6 is truecolor + alpha: again four channels, no colorimetry.
       assert.deepEqual(extractPngColorProfile(buildPng(8, 6)), {
-        colorSpace: 'srgb',
         bitDepth: 8,
         channels: 4,
         hasAlpha: true,
@@ -680,17 +681,21 @@ module('Unit | image metadata extractors', function (hooks) {
 
   module('JPEG color profile', function () {
     test('maps the frame component count onto a color model', function (assert) {
+      // One component is unambiguously grayscale.
       assert.deepEqual(
         extractJpgColorProfile(buildJpeg([], { components: 1 })),
         { colorSpace: 'grayscale', bitDepth: 8, channels: 1, hasAlpha: false },
       );
+      // Three components are RGB or YCbCr and four are CMYK or YCCK; the count
+      // alone can't tell which, so `colorSpace` is left unset while `channels`
+      // still records the count.
       assert.deepEqual(
         extractJpgColorProfile(buildJpeg([], { components: 3 })),
-        { colorSpace: 'ycbcr', bitDepth: 8, channels: 3, hasAlpha: false },
+        { bitDepth: 8, channels: 3, hasAlpha: false },
       );
       assert.deepEqual(
         extractJpgColorProfile(buildJpeg([], { components: 4 })),
-        { colorSpace: 'cmyk', bitDepth: 8, channels: 4, hasAlpha: false },
+        { bitDepth: 8, channels: 4, hasAlpha: false },
       );
     });
 

--- a/packages/host/tests/unit/image-metadata-extractor-test.ts
+++ b/packages/host/tests/unit/image-metadata-extractor-test.ts
@@ -1,0 +1,905 @@
+// Byte-level tests for the image metadata readers. These parsers run inside the
+// index pass against whatever bytes a realm happens to hold, so the contract
+// they have to keep is as much about malformed input as about well-formed input:
+// a truncated or hostile file must degrade to "no metadata" rather than throw
+// out of the extract, and an absent optional structure must not be invented.
+//
+// Fixtures are assembled here rather than committed as binaries so each test
+// names the exact bytes it depends on.
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type { Loader } from '@cardstack/runtime-common';
+
+import { setupRenderingTest } from '../helpers/setup';
+
+import type * as AvifModule from '@cardstack/base/avif-meta-extractor';
+import type * as ExifModule from '@cardstack/base/exif-meta-extractor';
+import type * as GifModule from '@cardstack/base/gif-meta-extractor';
+import type * as ImageFileDefModule from '@cardstack/base/image-file-def';
+import type * as JpgModule from '@cardstack/base/jpg-meta-extractor';
+import type * as PngModule from '@cardstack/base/png-meta-extractor';
+import type * as WebpModule from '@cardstack/base/webp-meta-extractor';
+
+// TIFF field type codes, as the EXIF fixtures below declare them.
+const ASCII = 2;
+const SHORT = 3;
+const LONG = 4;
+const RATIONAL = 5;
+
+interface EntrySpec {
+  tag: number;
+  type: number;
+  // A string for ASCII fields; for RATIONAL, a flat numerator/denominator run.
+  values: number[] | string;
+}
+
+interface ExifFixture {
+  littleEndian?: boolean;
+  ifd0?: EntrySpec[];
+  exif?: EntrySpec[];
+  gps?: EntrySpec[];
+}
+
+const TAG_EXIF_IFD_POINTER = 0x8769;
+const TAG_GPS_IFD_POINTER = 0x8825;
+
+function payloadFor(
+  spec: EntrySpec,
+  littleEndian: boolean,
+): { bytes: Uint8Array; count: number } {
+  if (typeof spec.values === 'string') {
+    // EXIF ASCII fields are NUL-terminated, and the terminator counts.
+    let text = spec.values;
+    let bytes = new Uint8Array(text.length + 1);
+    for (let index = 0; index < text.length; index++) {
+      bytes[index] = text.charCodeAt(index) & 0xff;
+    }
+    return { bytes, count: bytes.length };
+  }
+  let values = spec.values;
+  if (spec.type === SHORT) {
+    let bytes = new Uint8Array(values.length * 2);
+    let view = new DataView(bytes.buffer);
+    values.forEach((value, index) =>
+      view.setUint16(index * 2, value, littleEndian),
+    );
+    return { bytes, count: values.length };
+  }
+  if (spec.type === LONG) {
+    let bytes = new Uint8Array(values.length * 4);
+    let view = new DataView(bytes.buffer);
+    values.forEach((value, index) =>
+      view.setUint32(index * 4, value, littleEndian),
+    );
+    return { bytes, count: values.length };
+  }
+  if (spec.type === RATIONAL) {
+    let bytes = new Uint8Array(values.length * 4);
+    let view = new DataView(bytes.buffer);
+    values.forEach((value, index) =>
+      view.setUint32(index * 4, value, littleEndian),
+    );
+    // A rational is a numerator/denominator pair, so the count is half the
+    // number of 32-bit words written.
+    return { bytes, count: values.length / 2 };
+  }
+  throw new Error(`unsupported fixture field type ${spec.type}`);
+}
+
+// Build a TIFF/EXIF block: header, IFD0, the optional Exif and GPS sub-IFDs,
+// then a heap holding every payload too large to sit inline in its entry.
+function buildTiffBlock(fixture: ExifFixture): Uint8Array {
+  let littleEndian = fixture.littleEndian ?? true;
+  let ifd0 = [...(fixture.ifd0 ?? [])];
+  let hasExif = (fixture.exif?.length ?? 0) > 0;
+  let hasGps = (fixture.gps?.length ?? 0) > 0;
+
+  let directorySize = (count: number) => 2 + count * 12 + 4;
+  let ifd0Count = ifd0.length + (hasExif ? 1 : 0) + (hasGps ? 1 : 0);
+  let ifd0Offset = 8;
+  let exifOffset = ifd0Offset + directorySize(ifd0Count);
+  let gpsOffset =
+    exifOffset + (hasExif ? directorySize(fixture.exif!.length) : 0);
+  let heapOffset =
+    gpsOffset + (hasGps ? directorySize(fixture.gps!.length) : 0);
+
+  // The pointer tags are ordinary IFD0 entries; adding them here is what makes
+  // `ifd0Count` above correct.
+  if (hasExif) {
+    ifd0.push({ tag: TAG_EXIF_IFD_POINTER, type: LONG, values: [exifOffset] });
+  }
+  if (hasGps) {
+    ifd0.push({ tag: TAG_GPS_IFD_POINTER, type: LONG, values: [gpsOffset] });
+  }
+
+  let heap: number[] = [];
+  let writeDirectory = (target: number[], entries: EntrySpec[]) => {
+    let bytes = new Uint8Array(directorySize(entries.length));
+    let view = new DataView(bytes.buffer);
+    view.setUint16(0, entries.length, littleEndian);
+    entries.forEach((spec, index) => {
+      let { bytes: payload, count } = payloadFor(spec, littleEndian);
+      let entryStart = 2 + index * 12;
+      view.setUint16(entryStart, spec.tag, littleEndian);
+      view.setUint16(entryStart + 2, spec.type, littleEndian);
+      view.setUint32(entryStart + 4, count, littleEndian);
+      if (payload.length <= 4) {
+        // Small payloads live in the entry's own value field.
+        bytes.set(payload, entryStart + 8);
+      } else {
+        view.setUint32(entryStart + 8, heapOffset + heap.length, littleEndian);
+        heap.push(...payload);
+      }
+    });
+    // Terminating next-directory pointer of 0.
+    view.setUint32(2 + entries.length * 12, 0, littleEndian);
+    target.push(...bytes);
+  };
+
+  // Written in the same order the offsets above assume, so each out-of-line
+  // payload lands where its entry says it does.
+  let directories: number[] = [];
+  writeDirectory(directories, ifd0);
+  if (hasExif) {
+    writeDirectory(directories, fixture.exif!);
+  }
+  if (hasGps) {
+    writeDirectory(directories, fixture.gps!);
+  }
+
+  let header = new Uint8Array(8);
+  let headerView = new DataView(header.buffer);
+  headerView.setUint16(0, littleEndian ? 0x4949 : 0x4d4d);
+  headerView.setUint16(2, 0x002a, littleEndian);
+  headerView.setUint32(4, ifd0Offset, littleEndian);
+
+  return new Uint8Array([...header, ...directories, ...heap]);
+}
+
+// A JPEG carrying the given APP1 segments and one SOF0 frame header, so the
+// dimension reader and the EXIF reader both have something to find.
+function buildJpeg(
+  app1Segments: { identifier: string; body: Uint8Array }[],
+  frame: { precision?: number; components?: number } = {},
+): Uint8Array {
+  let out: number[] = [0xff, 0xd8];
+  for (let segment of app1Segments) {
+    let identifier = [...segment.identifier].map((c) => c.charCodeAt(0));
+    let length = 2 + identifier.length + segment.body.length;
+    out.push(0xff, 0xe1, (length >> 8) & 0xff, length & 0xff);
+    out.push(...identifier, ...segment.body);
+  }
+  let components = frame.components ?? 3;
+  // SOF0 payload: precision, height, width, component count, then three bytes
+  // of sampling/quantization spec per component.
+  let sofLength = 8 + components * 3;
+  out.push(0xff, 0xc0, (sofLength >> 8) & 0xff, sofLength & 0xff);
+  out.push(frame.precision ?? 8);
+  out.push(0x00, 0x40); // height 64
+  out.push(0x00, 0x20); // width 32
+  out.push(components);
+  for (let index = 0; index < components; index++) {
+    out.push(index + 1, 0x11, 0x00);
+  }
+  out.push(0xff, 0xd9);
+  return new Uint8Array(out);
+}
+
+function jpegWithExif(fixture: ExifFixture): Uint8Array {
+  return buildJpeg([
+    { identifier: 'Exif\u0000\u0000', body: buildTiffBlock(fixture) },
+  ]);
+}
+
+// PNG signature plus an IHDR chunk with the given encoding bytes. Only the
+// bytes the color reader looks at need to be right.
+function buildPng(bitDepth: number, colorType: number): Uint8Array {
+  let out = [137, 80, 78, 71, 13, 10, 26, 10];
+  out.push(0x00, 0x00, 0x00, 0x0d); // IHDR length
+  out.push(0x49, 0x48, 0x44, 0x52); // "IHDR"
+  out.push(0x00, 0x00, 0x00, 0x08); // width 8
+  out.push(0x00, 0x00, 0x00, 0x08); // height 8
+  out.push(bitDepth, colorType, 0, 0, 0);
+  out.push(0x00, 0x00, 0x00, 0x00); // CRC placeholder
+  return new Uint8Array(out);
+}
+
+function buildGif(
+  hasGlobalColorTable: boolean,
+  colorTableSizeExponent: number,
+): Uint8Array {
+  let out = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61]; // "GIF89a"
+  out.push(0x08, 0x00, 0x08, 0x00); // 8 × 8
+  out.push(
+    (hasGlobalColorTable ? 0x80 : 0x00) | (colorTableSizeExponent & 0x07),
+  );
+  out.push(0x00, 0x00); // background color index, pixel aspect ratio
+  return new Uint8Array(out);
+}
+
+// A RIFF/WEBP container whose first chunk is the given flavor. `payload` is
+// written at offset 20, where every flavor keeps the bits the reader wants.
+function buildWebp(fourCC: string, payload: number[]): Uint8Array {
+  let out = [0x52, 0x49, 0x46, 0x46]; // "RIFF"
+  out.push(0x00, 0x00, 0x00, 0x00); // file size (unread)
+  out.push(0x57, 0x45, 0x42, 0x50); // "WEBP"
+  out.push(...[...fourCC].map((c) => c.charCodeAt(0)));
+  out.push(0x00, 0x00, 0x00, 0x00); // chunk size (unread)
+  out.push(...payload);
+  while (out.length < 30) {
+    out.push(0x00);
+  }
+  return new Uint8Array(out);
+}
+
+function box(type: string, body: number[]): number[] {
+  let size = 8 + body.length;
+  return [
+    (size >>> 24) & 0xff,
+    (size >>> 16) & 0xff,
+    (size >>> 8) & 0xff,
+    size & 0xff,
+    ...[...type].map((c) => c.charCodeAt(0)),
+    ...body,
+  ];
+}
+
+// An AVIF box tree carrying the three item properties the color reader reads.
+function buildAvif(properties: {
+  pixi?: number[];
+  colr?: number[];
+  auxC?: string;
+}): Uint8Array {
+  let ftyp = box('ftyp', [
+    ...[...'avif'].map((c) => c.charCodeAt(0)),
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+  ]);
+  let ispe = box('ispe', [
+    0,
+    0,
+    0,
+    0, // version + flags
+    0,
+    0,
+    0,
+    32, // width
+    0,
+    0,
+    0,
+    32, // height
+  ]);
+  let ipcoBody = [...ispe];
+  if (properties.pixi) {
+    ipcoBody.push(
+      ...box('pixi', [0, 0, 0, 0, properties.pixi.length, ...properties.pixi]),
+    );
+  }
+  if (properties.colr) {
+    ipcoBody.push(...box('colr', properties.colr));
+  }
+  if (properties.auxC) {
+    ipcoBody.push(
+      ...box('auxC', [
+        0,
+        0,
+        0,
+        0,
+        ...[...properties.auxC].map((c) => c.charCodeAt(0)),
+        0,
+      ]),
+    );
+  }
+  let ipco = box('ipco', ipcoBody);
+  let iprp = box('iprp', ipco);
+  // meta is a full box: its 4 bytes of version/flags precede its children.
+  let meta = box('meta', [0, 0, 0, 0, ...iprp]);
+  return new Uint8Array([...ftyp, ...meta]);
+}
+
+module('Unit | image metadata extractors', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let loader: Loader;
+  let extractExifFromJpeg: typeof ExifModule.extractExifFromJpeg;
+  let parseExifTiffBlock: typeof ExifModule.parseExifTiffBlock;
+  let extractPngColorProfile: typeof PngModule.extractPngColorProfile;
+  let extractJpgColorProfile: typeof JpgModule.extractJpgColorProfile;
+  let extractGifColorProfile: typeof GifModule.extractGifColorProfile;
+  let extractWebpColorProfile: typeof WebpModule.extractWebpColorProfile;
+  let extractAvifColorProfile: typeof AvifModule.extractAvifColorProfile;
+  let rasterImageAttributes: typeof ImageFileDefModule.rasterImageAttributes;
+
+  hooks.beforeEach(async function () {
+    loader = getService('loader-service').loader;
+    ({ extractExifFromJpeg, parseExifTiffBlock } = await loader.import<
+      typeof ExifModule
+    >('@cardstack/base/exif-meta-extractor'));
+    ({ extractPngColorProfile } = await loader.import<typeof PngModule>(
+      '@cardstack/base/png-meta-extractor',
+    ));
+    ({ extractJpgColorProfile } = await loader.import<typeof JpgModule>(
+      '@cardstack/base/jpg-meta-extractor',
+    ));
+    ({ extractGifColorProfile } = await loader.import<typeof GifModule>(
+      '@cardstack/base/gif-meta-extractor',
+    ));
+    ({ extractWebpColorProfile } = await loader.import<typeof WebpModule>(
+      '@cardstack/base/webp-meta-extractor',
+    ));
+    ({ extractAvifColorProfile } = await loader.import<typeof AvifModule>(
+      '@cardstack/base/avif-meta-extractor',
+    ));
+    ({ rasterImageAttributes } = await loader.import<typeof ImageFileDefModule>(
+      '@cardstack/base/image-file-def',
+    ));
+  });
+
+  module('EXIF', function () {
+    test('reads the camera, lens, and exposure a photograph was taken with', function (assert) {
+      let exif = extractExifFromJpeg(
+        jpegWithExif({
+          ifd0: [
+            { tag: 0x010f, type: ASCII, values: 'Canon' },
+            { tag: 0x0110, type: ASCII, values: 'Canon EOS R5' },
+            { tag: 0x0131, type: ASCII, values: 'Darkroom 4.2' },
+            { tag: 0x0112, type: SHORT, values: [6] },
+          ],
+          exif: [
+            { tag: 0xa434, type: ASCII, values: 'RF 50mm F1.2 L USM' },
+            { tag: 0x920a, type: RATIONAL, values: [50, 1] },
+            { tag: 0x829d, type: RATIONAL, values: [14, 10] },
+            { tag: 0x829a, type: RATIONAL, values: [1, 250] },
+            { tag: 0x8827, type: SHORT, values: [400] },
+            { tag: 0x9209, type: SHORT, values: [25] },
+          ],
+        }),
+      );
+
+      assert.strictEqual(exif?.capture?.make, 'Canon');
+      assert.strictEqual(exif?.capture?.cameraModel, 'Canon EOS R5');
+      assert.strictEqual(exif?.capture?.lensModel, 'RF 50mm F1.2 L USM');
+      assert.strictEqual(exif?.capture?.software, 'Darkroom 4.2');
+      assert.strictEqual(exif?.capture?.iso, 400);
+      assert.deepEqual(exif?.capture?.focalLength, { value: 50, unit: 'mm' });
+      assert.deepEqual(exif?.capture?.aperture, {
+        value: 1.4,
+        displayText: 'ƒ/1.4',
+      });
+      assert.strictEqual(
+        exif?.capture?.exposureTime?.displayText,
+        '1/250 s',
+        'a sub-second shutter speed reads as the fraction a photographer recognizes',
+      );
+      assert.deepEqual(exif?.capture?.flash, {
+        code: '25',
+        scheme: 'exif-flash',
+      });
+      assert.deepEqual(exif?.capture?.orientation, {
+        code: '6',
+        scheme: 'exif-orientation',
+      });
+    });
+
+    test('a shutter speed of a second or longer reads as a decimal, not a fraction', function (assert) {
+      let exif = extractExifFromJpeg(
+        jpegWithExif({
+          exif: [{ tag: 0x829a, type: RATIONAL, values: [4, 1] }],
+        }),
+      );
+      assert.strictEqual(exif?.capture?.exposureTime?.displayText, '4 s');
+    });
+
+    test('converts an EXIF timestamp to ISO 8601 and honors a recorded UTC offset', function (assert) {
+      let naive = extractExifFromJpeg(
+        jpegWithExif({
+          exif: [{ tag: 0x9003, type: ASCII, values: '2024:03:15 14:22:08' }],
+        }),
+      );
+      assert.strictEqual(
+        naive?.capture?.capturedAt,
+        '2024-03-15T14:22:08',
+        'without an offset tag the wall-clock time is preserved rather than shifted to UTC',
+      );
+
+      let zoned = extractExifFromJpeg(
+        jpegWithExif({
+          exif: [
+            { tag: 0x9003, type: ASCII, values: '2024:03:15 14:22:08' },
+            { tag: 0x9011, type: ASCII, values: '-04:00' },
+          ],
+        }),
+      );
+      assert.strictEqual(
+        zoned?.capture?.capturedAt,
+        '2024-03-15T14:22:08-04:00',
+      );
+    });
+
+    test('falls back to IFD0 DateTime when the original-capture tag is absent', function (assert) {
+      let exif = extractExifFromJpeg(
+        jpegWithExif({
+          ifd0: [{ tag: 0x0132, type: ASCII, values: '2019:11:02 08:00:00' }],
+        }),
+      );
+      assert.strictEqual(exif?.capture?.capturedAt, '2019-11-02T08:00:00');
+    });
+
+    test('accepts either ISO-speed tag, since EXIF 2.3 renamed it', function (assert) {
+      let renamed = extractExifFromJpeg(
+        jpegWithExif({ exif: [{ tag: 0x8833, type: LONG, values: [3200] }] }),
+      );
+      assert.strictEqual(renamed?.capture?.iso, 3200);
+    });
+
+    test('a malformed timestamp is dropped rather than persisted unparsed', function (assert) {
+      let exif = extractExifFromJpeg(
+        jpegWithExif({
+          exif: [{ tag: 0x9003, type: ASCII, values: 'not a date' }],
+        }),
+      );
+      assert.strictEqual(exif?.capture?.capturedAt, undefined);
+    });
+
+    test('converts GPS coordinates to signed decimal degrees', function (assert) {
+      let exif = extractExifFromJpeg(
+        jpegWithExif({
+          gps: [
+            { tag: 0x0001, type: ASCII, values: 'N' },
+            { tag: 0x0002, type: RATIONAL, values: [40, 1, 44, 1, 5454, 100] },
+            { tag: 0x0003, type: ASCII, values: 'W' },
+            { tag: 0x0004, type: RATIONAL, values: [73, 1, 59, 1, 852, 100] },
+            { tag: 0x0006, type: RATIONAL, values: [1024, 10] },
+          ],
+        }),
+      );
+
+      assert.strictEqual(exif?.location?.latitude, 40.7484833);
+      assert.strictEqual(
+        exif?.location?.longitude,
+        -73.9857,
+        'a western hemisphere reference makes the longitude negative',
+      );
+      assert.deepEqual(exif?.location?.altitude, { value: 102.4, unit: 'm' });
+      assert.deepEqual(exif?.location?.source, {
+        code: 'exif-gps',
+        scheme: 'geo-source',
+      });
+    });
+
+    test('a below-sea-level altitude reference negates the stored magnitude', function (assert) {
+      let exif = extractExifFromJpeg(
+        jpegWithExif({
+          gps: [
+            { tag: 0x0005, type: SHORT, values: [1] },
+            { tag: 0x0006, type: RATIONAL, values: [430, 10] },
+          ],
+        }),
+      );
+      assert.deepEqual(exif?.location?.altitude, { value: -43, unit: 'm' });
+    });
+
+    test('drops a coordinate missing its other half instead of placing it on the prime meridian', function (assert) {
+      let exif = extractExifFromJpeg(
+        jpegWithExif({
+          gps: [
+            { tag: 0x0001, type: ASCII, values: 'N' },
+            { tag: 0x0002, type: RATIONAL, values: [40, 1, 44, 1, 0, 1] },
+          ],
+        }),
+      );
+      assert.strictEqual(exif?.location?.latitude, undefined);
+      assert.strictEqual(exif?.location?.longitude, undefined);
+    });
+
+    test('drops an out-of-range coordinate rather than clamping it', function (assert) {
+      let exif = extractExifFromJpeg(
+        jpegWithExif({
+          gps: [
+            { tag: 0x0001, type: ASCII, values: 'N' },
+            { tag: 0x0002, type: RATIONAL, values: [200, 1, 0, 1, 0, 1] },
+            { tag: 0x0003, type: ASCII, values: 'E' },
+            { tag: 0x0004, type: RATIONAL, values: [10, 1, 0, 1, 0, 1] },
+          ],
+        }),
+      );
+      assert.strictEqual(exif?.location?.latitude, undefined);
+    });
+
+    test('reads big-endian EXIF identically to little-endian', function (assert) {
+      let fixture: ExifFixture = {
+        ifd0: [{ tag: 0x0110, type: ASCII, values: 'X-T4' }],
+        exif: [{ tag: 0x920a, type: RATIONAL, values: [23, 1] }],
+      };
+      let little = extractExifFromJpeg(
+        jpegWithExif({ ...fixture, littleEndian: true }),
+      );
+      let big = extractExifFromJpeg(
+        jpegWithExif({ ...fixture, littleEndian: false }),
+      );
+      assert.deepEqual(big, little, 'byte order does not change the result');
+      assert.strictEqual(big?.capture?.cameraModel, 'X-T4');
+    });
+
+    test('normalizes the EXIF color-space code onto the shared vocabulary', function (assert) {
+      let srgb = extractExifFromJpeg(
+        jpegWithExif({ exif: [{ tag: 0xa001, type: SHORT, values: [1] }] }),
+      );
+      assert.strictEqual(srgb?.colorSpace, 'srgb');
+
+      let uncalibrated = extractExifFromJpeg(
+        jpegWithExif({ exif: [{ tag: 0xa001, type: SHORT, values: [65535] }] }),
+      );
+      assert.strictEqual(uncalibrated?.colorSpace, 'uncalibrated');
+
+      let unknownCode = extractExifFromJpeg(
+        jpegWithExif({ exif: [{ tag: 0xa001, type: SHORT, values: [42] }] }),
+      );
+      assert.strictEqual(
+        unknownCode?.colorSpace,
+        undefined,
+        'a code with no vocabulary entry is left unset rather than guessed at',
+      );
+    });
+
+    test('a JPEG with no EXIF yields no metadata rather than empty branches', function (assert) {
+      assert.strictEqual(extractExifFromJpeg(buildJpeg([])), undefined);
+    });
+
+    test('skips an APP1 segment that is XMP rather than EXIF', function (assert) {
+      let xmpOnly = buildJpeg([
+        {
+          identifier: 'http://ns.adobe.com/xap/1.0/\u0000',
+          body: new Uint8Array([0x3c, 0x78, 0x3a, 0x78]),
+        },
+      ]);
+      assert.strictEqual(extractExifFromJpeg(xmpOnly), undefined);
+    });
+
+    test('finds the EXIF segment when an XMP segment precedes it', function (assert) {
+      let bytes = buildJpeg([
+        {
+          identifier: 'http://ns.adobe.com/xap/1.0/\u0000',
+          body: new Uint8Array([0x3c, 0x78]),
+        },
+        {
+          identifier: 'Exif\u0000\u0000',
+          body: buildTiffBlock({
+            ifd0: [{ tag: 0x010f, type: ASCII, values: 'Nikon' }],
+          }),
+        },
+      ]);
+      assert.strictEqual(extractExifFromJpeg(bytes)?.capture?.make, 'Nikon');
+    });
+
+    test('a truncated EXIF block degrades to partial metadata without throwing', function (assert) {
+      let block = buildTiffBlock({
+        ifd0: [{ tag: 0x010f, type: ASCII, values: 'Panasonic' }],
+        exif: [{ tag: 0x920a, type: RATIONAL, values: [12, 1] }],
+      });
+      // The heap holds `Panasonic` (10 bytes) followed by the focal-length
+      // rational (8 bytes). Cutting six bytes leaves every directory intact and
+      // the string reachable, while the rational's payload runs off the end —
+      // which is the shape a partially-fetched file actually has.
+      let exif = parseExifTiffBlock(block.subarray(0, block.length - 6), 0);
+
+      assert.strictEqual(
+        exif?.capture?.make,
+        'Panasonic',
+        'a payload still inside the buffer is read',
+      );
+      assert.strictEqual(
+        exif?.capture?.focalLength,
+        undefined,
+        'a payload past the end is omitted rather than read from adjacent bytes',
+      );
+    });
+
+    test('a garbage TIFF block is rejected without throwing', function (assert) {
+      assert.strictEqual(
+        parseExifTiffBlock(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]), 0),
+        undefined,
+        'an invalid byte-order marker is not EXIF',
+      );
+      assert.strictEqual(
+        parseExifTiffBlock(new Uint8Array([0x49, 0x49]), 0),
+        undefined,
+        'a block too short to hold a header is rejected on bounds',
+      );
+      assert.strictEqual(
+        parseExifTiffBlock(new Uint8Array(64), 200),
+        undefined,
+        'an out-of-range start offset is rejected rather than read',
+      );
+    });
+
+    test('an implausible directory entry count is refused', function (assert) {
+      let bytes = buildTiffBlock({
+        ifd0: [{ tag: 0x010f, type: ASCII, values: 'Sony' }],
+      });
+      // Overwrite IFD0's entry count with a value no real directory carries.
+      new DataView(bytes.buffer).setUint16(8, 40000, true);
+      assert.strictEqual(parseExifTiffBlock(bytes, 0), undefined);
+    });
+  });
+
+  module('PNG color profile', function () {
+    test('reads bit depth, channels, and alpha from each legal color type', function (assert) {
+      assert.deepEqual(extractPngColorProfile(buildPng(8, 0)), {
+        colorSpace: 'grayscale',
+        bitDepth: 8,
+        channels: 1,
+        hasAlpha: false,
+      });
+      assert.deepEqual(extractPngColorProfile(buildPng(8, 2)), {
+        colorSpace: 'srgb',
+        bitDepth: 8,
+        channels: 3,
+        hasAlpha: false,
+      });
+      assert.deepEqual(extractPngColorProfile(buildPng(4, 3)), {
+        colorSpace: 'indexed',
+        bitDepth: 4,
+        channels: 3,
+        hasAlpha: false,
+      });
+      assert.deepEqual(extractPngColorProfile(buildPng(16, 4)), {
+        colorSpace: 'grayscale-alpha',
+        bitDepth: 16,
+        channels: 2,
+        hasAlpha: true,
+      });
+      assert.deepEqual(extractPngColorProfile(buildPng(8, 6)), {
+        colorSpace: 'srgb',
+        bitDepth: 8,
+        channels: 4,
+        hasAlpha: true,
+      });
+    });
+
+    test('drops an illegal bit depth and an undefined color type', function (assert) {
+      let profile = extractPngColorProfile(buildPng(7, 5));
+      assert.strictEqual(
+        profile,
+        undefined,
+        'neither 7-bit samples nor color type 5 exist in PNG, so nothing is reported',
+      );
+    });
+
+    test('a buffer too short to hold IHDR reports nothing', function (assert) {
+      assert.strictEqual(
+        extractPngColorProfile(buildPng(8, 6).subarray(0, 24)),
+        undefined,
+      );
+    });
+  });
+
+  module('JPEG color profile', function () {
+    test('maps the frame component count onto a color model', function (assert) {
+      assert.deepEqual(
+        extractJpgColorProfile(buildJpeg([], { components: 1 })),
+        { colorSpace: 'grayscale', bitDepth: 8, channels: 1, hasAlpha: false },
+      );
+      assert.deepEqual(
+        extractJpgColorProfile(buildJpeg([], { components: 3 })),
+        { colorSpace: 'ycbcr', bitDepth: 8, channels: 3, hasAlpha: false },
+      );
+      assert.deepEqual(
+        extractJpgColorProfile(buildJpeg([], { components: 4 })),
+        { colorSpace: 'cmyk', bitDepth: 8, channels: 4, hasAlpha: false },
+      );
+    });
+
+    test('reports a 12-bit extended-mode frame precision', function (assert) {
+      assert.strictEqual(
+        extractJpgColorProfile(buildJpeg([], { precision: 12 }))?.bitDepth,
+        12,
+      );
+    });
+
+    test('a file with no frame header reports nothing instead of throwing', function (assert) {
+      assert.strictEqual(
+        extractJpgColorProfile(new Uint8Array([0xff, 0xd8, 0xff, 0xd9])),
+        undefined,
+      );
+    });
+  });
+
+  module('GIF color profile', function () {
+    test('derives bit depth from the global color table size', function (assert) {
+      assert.deepEqual(extractGifColorProfile(buildGif(true, 7)), {
+        colorSpace: 'indexed',
+        bitDepth: 8,
+        channels: 3,
+      });
+      assert.deepEqual(extractGifColorProfile(buildGif(true, 3)), {
+        colorSpace: 'indexed',
+        bitDepth: 4,
+        channels: 3,
+      });
+    });
+
+    test('omits bit depth when there is no global color table', function (assert) {
+      assert.deepEqual(extractGifColorProfile(buildGif(false, 0)), {
+        colorSpace: 'indexed',
+        channels: 3,
+      });
+    });
+
+    test('never claims to know whether a GIF is transparent', function (assert) {
+      // Transparency is declared in a Graphic Control Extension well past this
+      // header, so reporting `false` here would be a guess dressed as a fact.
+      assert.strictEqual(
+        extractGifColorProfile(buildGif(true, 7))?.hasAlpha,
+        undefined,
+      );
+    });
+  });
+
+  module('WebP color profile', function () {
+    test('lossy WebP has no alpha channel', function (assert) {
+      let profile = extractWebpColorProfile(buildWebp('VP8 ', []));
+      assert.false(profile?.hasAlpha);
+      assert.strictEqual(profile?.channels, 3);
+    });
+
+    test('reads the lossless alpha bit out of the VP8L header word', function (assert) {
+      // The 32-bit little-endian word at offset 21 packs width, height, then
+      // the alpha flag at bit 28.
+      let withAlpha = new Uint8Array(4);
+      new DataView(withAlpha.buffer).setUint32(0, 1 << 28, true);
+      assert.true(
+        extractWebpColorProfile(buildWebp('VP8L', [0x2f, ...withAlpha]))
+          ?.hasAlpha,
+      );
+
+      let withoutAlpha = new Uint8Array(4);
+      new DataView(withoutAlpha.buffer).setUint32(0, 0, true);
+      assert.false(
+        extractWebpColorProfile(buildWebp('VP8L', [0x2f, ...withoutAlpha]))
+          ?.hasAlpha,
+      );
+    });
+
+    test('reads the extended-format alpha and ICC flags', function (assert) {
+      let alphaAndIcc = extractWebpColorProfile(buildWebp('VP8X', [0x30]));
+      assert.true(alphaAndIcc?.hasAlpha);
+      assert.strictEqual(alphaAndIcc?.channels, 4);
+      assert.strictEqual(alphaAndIcc?.iccProfile, 'embedded');
+
+      let plain = extractWebpColorProfile(buildWebp('VP8X', [0x00]));
+      assert.false(plain?.hasAlpha);
+      assert.strictEqual(plain?.iccProfile, undefined);
+    });
+
+    test('an unrecognized first chunk reports nothing', function (assert) {
+      assert.strictEqual(
+        extractWebpColorProfile(buildWebp('ANIM', [0x00])),
+        undefined,
+      );
+    });
+  });
+
+  module('AVIF color profile', function () {
+    test('reads bit depth and channel count from the pixi property', function (assert) {
+      let profile = extractAvifColorProfile(buildAvif({ pixi: [10, 10, 10] }));
+      assert.strictEqual(profile?.bitDepth, 10);
+      assert.strictEqual(profile?.channels, 3);
+    });
+
+    test('maps CICP colour primaries onto the shared vocabulary', function (assert) {
+      let p3 = extractAvifColorProfile(
+        // colr payload: 'nclx', then primaries, transfer, matrix, range.
+        buildAvif({ colr: [0x6e, 0x63, 0x6c, 0x78, 0, 12, 0, 13, 0, 1, 0x80] }),
+      );
+      assert.strictEqual(p3?.colorSpace, 'display-p3');
+
+      let rec709 = extractAvifColorProfile(
+        buildAvif({ colr: [0x6e, 0x63, 0x6c, 0x78, 0, 1, 0, 13, 0, 1, 0x80] }),
+      );
+      assert.strictEqual(rec709?.colorSpace, 'srgb');
+    });
+
+    test('records an embedded ICC profile without naming it', function (assert) {
+      let profile = extractAvifColorProfile(
+        buildAvif({ colr: [0x70, 0x72, 0x6f, 0x66, 0, 0, 0, 0] }),
+      );
+      assert.strictEqual(profile?.iccProfile, 'embedded');
+    });
+
+    test('detects alpha from an auxiliary-image property', function (assert) {
+      let profile = extractAvifColorProfile(
+        buildAvif({
+          pixi: [8, 8, 8],
+          auxC: 'urn:mpeg:mpegB:cicp:systems:auxiliary:alpha',
+        }),
+      );
+      assert.true(profile?.hasAlpha);
+    });
+
+    test('treats a non-alpha auxiliary image as no alpha evidence', function (assert) {
+      let profile = extractAvifColorProfile(
+        buildAvif({
+          pixi: [8, 8, 8],
+          auxC: 'urn:mpeg:mpegB:cicp:systems:auxiliary:depth',
+        }),
+      );
+      assert.strictEqual(profile?.hasAlpha, undefined);
+    });
+
+    test('a single-channel image with no colr box reads as grayscale', function (assert) {
+      assert.strictEqual(
+        extractAvifColorProfile(buildAvif({ pixi: [12] }))?.colorSpace,
+        'grayscale',
+      );
+    });
+
+    test('an unreachable box tree reports nothing', function (assert) {
+      assert.strictEqual(
+        extractAvifColorProfile(new Uint8Array(24)),
+        undefined,
+      );
+    });
+  });
+
+  module('attribute assembly', function () {
+    test('the container header outranks the EXIF color-space tag', function (assert) {
+      let attributes = rasterImageAttributes(
+        { colorSpace: 'srgb' },
+        { colorSpace: 'display-p3', bitDepth: 10 },
+      );
+      assert.deepEqual(attributes.colorProfile, {
+        bitDepth: 10,
+        colorSpace: { code: 'display-p3', scheme: 'color-space' },
+      });
+    });
+
+    test('the EXIF tag supplies a color space the header did not', function (assert) {
+      let attributes = rasterImageAttributes(
+        { colorSpace: 'adobe-rgb' },
+        { bitDepth: 8, channels: 3 },
+      );
+      assert.deepEqual(attributes.colorProfile, {
+        bitDepth: 8,
+        channels: 3,
+        colorSpace: { code: 'adobe-rgb', scheme: 'color-space' },
+      });
+    });
+
+    test('a color space is enough on its own to produce the field', function (assert) {
+      let attributes = rasterImageAttributes({ colorSpace: 'srgb' }, undefined);
+      assert.deepEqual(attributes.colorProfile, {
+        colorSpace: { code: 'srgb', scheme: 'color-space' },
+      });
+    });
+
+    test('an image that revealed nothing adds no attributes at all', function (assert) {
+      assert.deepEqual(
+        rasterImageAttributes(undefined, undefined),
+        {},
+        'no empty exif or colorProfile object reaches the index row',
+      );
+    });
+
+    test('the EXIF color-space tag never becomes part of the exif attribute', function (assert) {
+      let attributes = rasterImageAttributes(
+        { capture: { make: 'Leica' }, colorSpace: 'srgb' },
+        undefined,
+      );
+      assert.deepEqual(attributes.exif, { capture: { make: 'Leica' } });
+    });
+
+    test('a false alpha flag survives assembly rather than being pruned as empty', function (assert) {
+      let attributes = rasterImageAttributes(undefined, { hasAlpha: false });
+      assert.deepEqual(
+        attributes.colorProfile,
+        { hasAlpha: false },
+        'knowing a format has no alpha channel is a fact worth persisting',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Now scoped to the image family only. Audio, MIDI, and the extraction-efficiency work that had accumulated here moved to #5714, which stacks on this; video is #5713 behind that.

First slice of CS-12230, covering the metadata half of CS-12237.

## The gap

The image FileDefs recorded `width` and `height` and nothing else. A photograph in a realm indexed as anonymously as a generated placeholder — no camera, no capture time, no bit depth, and no way to answer "which of these images have an alpha channel".

## What's here

**`file-formats/metadata-fields.gts`** — the shared shapes. Two primitives (`QuantityField`, `CodedValueField`) plus `CameraCaptureField`, `GeoLocationField`, `ColorProfileField`, and `ExifMetadataField`. One shape per metadata *family* rather than per extension, so "where was this taken" stays one question whether the answer came from a JPEG's GPS IFD or, later, a video container. Later slices append their own shapes here.

**`exif-meta-extractor.ts`** — a TIFF/EXIF reader using nothing but `DataView` and `TextDecoder`. The unit of work is deliberately the TIFF block, not the JPEG: EXIF is a TIFF structure several containers embed verbatim, so PNG's `eXIf` chunk and WebP's `EXIF` chunk can reuse `parseExifTiffBlock` as they land, and only `extractExifFromJpeg` knows about APP1 framing.

**Color facts per container**, added to the `*-meta-extractor` that already owns each format: PNG's IHDR, JPEG's frame header, GIF's logical screen descriptor, WebP's per-flavor alpha bit, and AVIF's `pixi` / `colr` / `auxC` item properties.

## Two judgment calls

**`colorProfile` is a sibling of `exif`, not nested inside it.** The handoff nests it. EXIF's `ColorSpace` tag is one weak signal, while the container states bit depth, channels, and alpha outright — nesting both would mean two `colorProfile` blocks disagreeing about one file. The container wins, and the EXIF tag is folded in as a color-space fallback, normalized onto the same vocabulary so the persisted value doesn't depend on which container it arrived in.

**Absence stays distinguishable from ignorance.** A GIF's transparency is declared in a Graphic Control Extension well past the header this pass reads, so `hasAlpha` is left unset rather than reported `false`. JPEG, which has no alpha in any mode, reports `false` outright. Same discipline for an unrecognized code, an out-of-range coordinate, and a lone latitude with no longitude — dropped, not guessed at or clamped onto the prime meridian.

## Dependency graph

The fields attach to a new `RasterImageDef`, not to `ImageDef` in `card-api` — which every card in every realm carries in its dependency graph. Only realms holding image files pay for the metadata modules. `SvgDef` stays on `ImageDef`: a vector has no bit depth to record. The `realm indexing` dependency assertions #5701 added as the guard on graph growth are unchanged and passing.

This does add one level to the image prototype chain, so image file rows gain a `Raster Image` entry in `types` and `display_names`. Additive — `on:`/`type:` filters against `ImageDef` still match.

## Robustness

These parsers run during indexing against whatever bytes a realm happens to hold, so every payload read is bounds-checked and returns `undefined` rather than throwing. A truncated file yields partial metadata; it does not fail the extract. Directory entry counts are capped, and there's no recursion, so a malformed pointer can't loop.

## Testing

- `unit/image-metadata-extractor-test.ts` — 44 tests / 79 assertions over hand-assembled byte fixtures: both TIFF byte orders, GPS sign and altitude reference, the EXIF 2.3 ISO tag rename, timestamp conversion with and without a recorded UTC offset, XMP-vs-EXIF APP1 discrimination, and the malformed cases (truncated heap, garbage byte-order marker, implausible entry count, illegal PNG color type).
- `acceptance/image-def/jpg-image-def-test.gts` — an EXIF-bearing JPEG proves a value three levels deep (`exif.capture.exposureTime.displayText`) survives extract → `search_doc` → file-meta, and that a JPEG *without* EXIF gains no empty `exif` object.
- `acceptance/image-def/png-image-def-test.gts` — IHDR color profile end-to-end.

`ember-tsc` for host, ai-bot, bot-runner, and billing; `packages/base`'s own lint; and the full `realm indexing` module all pass.

The 6 `authenticated images display in browser` failures in the image-def suites are pre-existing — they reproduce identically on a stashed baseline, including in `svg image def`, which this PR doesn't touch.

## One thing to know

`packages/base` is template-lint-only in CI (its `lint` script runs `ember-template-lint`, and that passes). The pre-commit hook additionally runs the *root* eslint config over staged base files, where every base `.gts` already fails to parse on `<template>`. `image-file-def.gts` is now the only base `.gts` with decorators and no template, so it parses and trips the erasable-syntax decorator rule — a rule aimed at code Node runs under `--experimental-strip-types`, which base card modules never are. Non-blocking and CI-green; the real fix is scoping that rule away from card realms, which belongs in a config change rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)