### PR TITLE
AI assistant: fix a long answer killing the next turn — duplicate tool_use id, and a failed chunk reported as a cancellation

### DIFF
--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -146,9 +146,13 @@ export default class MatrixResponsePublisher {
           reasoningAndContent.content,
           this.currentResponseEventId,
           extraData,
-          responseStateSnapshot.toolCalls.map((toolCall) =>
-            toCommandRequest(toolCall as ChatCompletionMessageFunctionToolCall),
-          ),
+          // No tool calls on a continuation fragment. They belong to the answer,
+          // not to each piece it was cut into, and the reader joins the pieces
+          // back into one message — so repeating them here puts the same
+          // tool_use id in that message more than once, which Anthropic rejects
+          // outright ("tool_use ids must be unique"), failing the whole next
+          // request. The final part below carries them.
+          [],
           reasoningAndContent.reasoning,
         );
         this.roomEventsEmitted++;

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -722,11 +722,21 @@ Common issues are:
                   pendingFulfillAgentId = agentId;
                 }
               } catch (error) {
-                // When the cancel handler aborts the runner,
-                // finalChatCompletion() throws APIUserAbortError.
-                // Finalize the responder with the canceled flag and let
-                // the finally block handle credit tracking.
-                if (error instanceof APIUserAbortError) {
+                // Aborting the runner always surfaces as APIUserAbortError, but
+                // the user is not the only one who aborts it: the chunk handler
+                // does too when publishing a chunk fails, and that failure is
+                // the answer being cut off rather than withdrawn. Telling them
+                // apart by `chunkHandlingError` keeps a send failure from being
+                // recorded as a cancellation — which reads to the user as an
+                // answer that simply stops mid-sentence, with no error to act on
+                // and nothing in the log but "canceled by user".
+                if (error instanceof APIUserAbortError && chunkHandlingError) {
+                  log.error(
+                    `[${eventId}] Generation aborted after a chunk could not be published`,
+                  );
+                  log.error(chunkHandlingError);
+                  await responder.onError(chunkHandlingError); // E.g. MatrixError: [413] event too large
+                } else if (error instanceof APIUserAbortError) {
                   log.info(`[${eventId}] Generation was canceled by user`);
                   await responder.finalize({ isCanceled: true });
                 } else {

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -91,6 +91,15 @@ function snapshotWithToolCall(
   };
 }
 
+function snapshotWithContentAndToolCall(
+  content: string,
+  toolRequest: Partial<ToolRequest>,
+): ChatCompletionSnapshot {
+  let snapshot = snapshotWithToolCall(toolRequest);
+  snapshot.choices[0].message.content = content;
+  return snapshot;
+}
+
 module('Responding', (hooks) => {
   let fakeMatrixClient: FakeMatrixClient;
   let responder: Responder;
@@ -1646,6 +1655,42 @@ module('Responding', (hooks) => {
       sentEvents[3].content.errorMessage,
       'Error - All your base are belong to us',
       'Error message should be sent, replacing the original message',
+    );
+  });
+  test('a split answer carries its tool call only on the final event', async () => {
+    // The reader joins continuation events back into one message, so a tool
+    // call repeated across the pieces lands in that message twice. Anthropic
+    // rejects the whole request for it — "tool_use ids must be unique" — and
+    // the turn dies on the request after the one that split.
+    responder.matrixResponsePublisher.eventSizeMax = 1024; // 1KB max event size
+
+    await responder.ensureThinkingMessageSent();
+    await responder.onChunk(
+      {} as any,
+      snapshotWithContentAndToolCall('a'.repeat(3072), {
+        id: 'toolu_duplicated',
+        name: 'readRealmFile',
+        arguments: { urls: [] },
+      }),
+    );
+    await responder.finalize();
+
+    let sent = fakeMatrixClient.getSentEvents();
+    let continuedWithToolRequests = sent.filter(
+      (e: any) =>
+        e.content[APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY] &&
+        (e.content[APP_BOXEL_TOOL_REQUESTS_KEY] ?? []).length > 0,
+    );
+    assert.equal(
+      continuedWithToolRequests.length,
+      0,
+      'no piece that continues into another carries the tool call',
+    );
+    assert.ok(
+      sent.some(
+        (e: any) => (e.content[APP_BOXEL_TOOL_REQUESTS_KEY] ?? []).length > 0,
+      ),
+      'the tool call still reaches the room, on the final piece',
     );
   });
 });


### PR DESCRIPTION
_(Written by Claude on Matic's behalf.)_

## Problem

An answer stops in the middle of a sentence. The user sees no error. The log shows only that the user stopped the answer. But the user did not stop it.

Two conditions stop the runner. Both give the same `APIUserAbortError`:

- The user sends a new message, or the user clicks Stop. This is a true cancellation.
- The chunk handler finds an error when it sends a chunk. For example, the event is too large.

The program used the same procedure for the two conditions. It recorded the turn as cancelled. It also discarded the error, because it read `chunkHandlingError` only in the `else` part. An abort does not go to that part.

The second condition is different. The answer stops, but the user did not stop it. The user gets no message about the error.

## Example

The assistant made a card family. The answer stopped after these words:

```
Here's the Run card (the workout entry):
```

A large code block starts at this point. The event has `isCanceled: true`. The room has no record of a cancellation. A subsequent turn then used a file that the assistant did not make. That turn gave a 404 error.

## Change

The program now uses `chunkHandlingError` to identify the condition. If the chunk handler stopped the runner, the program shows the error. If the user stopped the answer, the behavior does not change.

## Limits

This change shows the error. It does not prevent the error. If large events are the cause, you must change how the program divides a long answer. That is a different change.