### PR TITLE
ci: Add floor for host test shard weights

### DIFF
--- a/packages/host/scripts/generate-test-module-timings.mjs
+++ b/packages/host/scripts/generate-test-module-timings.mjs
@@ -217,10 +217,32 @@ for (const { key } of testFiles) {
 // often the file is rewritten, never which shard a test runs on.
 // ---------------------------------------------------------------------------
 
+// Keep in step with MIN_MODULE_WEIGHT_SECONDS in tests/helpers/shard-modules.ts,
+// which explains why a floor is needed at all. Predicting with unfloored weights
+// would model the packing that helper no longer performs: zero-weight files —
+// there are dozens, since junit only clocks test callbacks — would all collect
+// in one bucket here while the real assignment spreads them.
+const MIN_MODULE_WEIGHT_SECONDS = 1;
+
+function weightLookup(timings) {
+  const known = Object.values(timings)
+    .map((weight) => Math.max(weight, MIN_MODULE_WEIGHT_SECONDS))
+    .sort((a, b) => a - b);
+  const defaultWeight = known.length
+    ? known[Math.floor(known.length / 2)]
+    : MIN_MODULE_WEIGHT_SECONDS;
+  return (id) => {
+    const measured = timings[id];
+    // `== null`, not `??` on a floored value: a file measured at 0 must take
+    // the floor, not the median a missing file gets.
+    return measured == null
+      ? defaultWeight
+      : Math.max(measured, MIN_MODULE_WEIGHT_SECONDS);
+  };
+}
+
 function pack(moduleIds, timings) {
-  const known = Object.values(timings).sort((a, b) => a - b);
-  const defaultWeight = known.length ? known[Math.floor(known.length / 2)] : 1;
-  const weightOf = (id) => timings[id] ?? defaultWeight;
+  const weightOf = weightLookup(timings);
   const ordered = [...moduleIds].sort((a, b) => {
     const diff = weightOf(b) - weightOf(a);
     if (diff !== 0) return diff;
@@ -242,12 +264,9 @@ function pack(moduleIds, timings) {
 }
 
 function slowestShardSeconds(assignment, trueTimings) {
-  const known = Object.values(trueTimings).sort((a, b) => a - b);
-  const defaultWeight = known.length ? known[Math.floor(known.length / 2)] : 1;
+  const weightOf = weightLookup(trueTimings);
   return Math.max(
-    ...assignment.map((ids) =>
-      ids.reduce((sum, id) => sum + (trueTimings[id] ?? defaultWeight), 0),
-    ),
+    ...assignment.map((ids) => ids.reduce((sum, id) => sum + weightOf(id), 0)),
   );
 }
 

--- a/packages/host/tests/helpers/shard-modules.ts
+++ b/packages/host/tests/helpers/shard-modules.ts
@@ -28,6 +28,11 @@
 // all land together. Floor every weight at a nominal per-file cost, which
 // both stands in for what the data can't see and keeps such files
 // distributed.
+//
+// scripts/generate-test-module-timings.mjs floors identically, because the
+// drift gate deciding whether to rewrite the timings file predicts the
+// slowest shard by replaying this pack. A floor here and not there would
+// gate regeneration on an assignment that never runs.
 const MIN_MODULE_WEIGHT_SECONDS = 1;
 
 export function selectShardModules(

--- a/packages/host/tests/helpers/shard-modules.ts
+++ b/packages/host/tests/helpers/shard-modules.ts
@@ -17,6 +17,19 @@
 // so a new test file runs — on exactly one shard — without the timings
 // file needing regeneration.
 
+// The timings record only what QUnit clocks per test — the test callbacks
+// themselves. Fetching and evaluating the file's module, registering it,
+// and running its hooks all cost real time that never appears there, so a
+// file of fast assertions can be recorded at (or rounded to) zero.
+//
+// Zero is also pathological for the pack below: adding it never changes a
+// bucket's running weight, so every zero-weight file is assigned to
+// whichever bucket is lightest — and that bucket stays lightest, so they
+// all land together. Floor every weight at a nominal per-file cost, which
+// both stands in for what the data can't see and keeps such files
+// distributed.
+const MIN_MODULE_WEIGHT_SECONDS = 1;
+
 export function selectShardModules(
   moduleIds: string[],
   shard: number,
@@ -34,11 +47,18 @@ export function selectShardModules(
     );
   }
 
-  let knownWeights = Object.values(timings).sort((a, b) => a - b);
+  let knownWeights = Object.values(timings)
+    .map((weight) => Math.max(weight, MIN_MODULE_WEIGHT_SECONDS))
+    .sort((a, b) => a - b);
   let defaultWeight = knownWeights.length
     ? knownWeights[Math.floor(knownWeights.length / 2)]
-    : 1;
-  let weightOf = (id: string) => timings[id] ?? defaultWeight;
+    : MIN_MODULE_WEIGHT_SECONDS;
+  let weightOf = (id: string) => {
+    let measured = timings[id];
+    return measured == null
+      ? defaultWeight
+      : Math.max(measured, MIN_MODULE_WEIGHT_SECONDS);
+  };
 
   let ordered = [...moduleIds].sort((a, b) => {
     let diff = weightOf(b) - weightOf(a);

--- a/packages/host/tests/unit/shard-modules-test.ts
+++ b/packages/host/tests/unit/shard-modules-test.ts
@@ -74,6 +74,37 @@ module('Unit | shard-modules', function () {
     assert.strictEqual(unknownShards.length, 1);
   });
 
+  test('files recorded at zero seconds are spread, not piled onto one shard', function (assert) {
+    // A weight of zero never changes a bucket's running total, so without a
+    // floor every such file is assigned to the lightest bucket — which stays
+    // lightest — and they all land together.
+    let moduleIds = Array.from({ length: 12 }, (_, i) => `./zero${i}-test.ts`);
+    let timings = Object.fromEntries(moduleIds.map((id) => [id, 0]));
+
+    let counts = [1, 2, 3, 4].map(
+      (shard) => selectShardModules(moduleIds, shard, 4, timings).length,
+    );
+
+    assert.deepEqual(
+      counts,
+      [3, 3, 3, 3],
+      `zero-weight files spread evenly, got ${counts.join('/')}`,
+    );
+  });
+
+  test('a zero-weight file is never treated as lighter than a floored one', function (assert) {
+    // Both files sit under the floor, so they weigh the same and the pack
+    // falls back to its path tiebreak rather than ordering by raw seconds.
+    let timings = { './a-test.ts': 0, './b-test.ts': 0.2 };
+    let moduleIds = ['./a-test.ts', './b-test.ts'];
+
+    let first = selectShardModules(moduleIds, 1, 2, timings);
+    let second = selectShardModules(moduleIds, 2, 2, timings);
+
+    assert.deepEqual(first, ['./a-test.ts']);
+    assert.deepEqual(second, ['./b-test.ts']);
+  });
+
   test('rejects out-of-range shard coordinates', function (assert) {
     assert.throws(() => selectShardModules([], 0, 2, {}));
     assert.throws(() => selectShardModules([], 3, 2, {}));


### PR DESCRIPTION
There are a bunch of unit tests that register as taking <1s in #5650’s change to balance tests across shards. That means they all clump together in one or two shards. This adds a minimum 1s time so they can be more evenly distributed.