### PR TITLE
host: Add caching for base realm between tests

### DIFF
--- a/packages/host/tests/test-helper.js
+++ b/packages/host/tests/test-helper.js
@@ -3,6 +3,7 @@ import config from '@cardstack/host/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import setupOperatorModeParametersMatchAssertion from '@cardstack/host/tests/helpers/operator-mode-parameters-match';
+import { trustBaseRealmFetchCache } from '@cardstack/runtime-common';
 import { start as examStart } from 'ember-exam/test-support';
 // eslint-disable-next-line ember/no-test-import-export
 import { loadRealmTests } from './live-test';
@@ -18,6 +19,11 @@ export async function start(examOptions) {
   });
 
   async function setupHostTests() {
+    // The base realm is read-only for the lifetime of this page, so its
+    // modules never need revalidating — while the loader is replaced per
+    // test, and each replacement otherwise re-requests the whole base
+    // module graph.
+    trustBaseRealmFetchCache();
     setApplication(application);
     setupQUnit();
     setupOperatorModeParametersMatchAssertion(QUnit.assert);

--- a/packages/host/tests/unit/cached-fetch-test.ts
+++ b/packages/host/tests/unit/cached-fetch-test.ts
@@ -1,6 +1,11 @@
 import { module, test } from 'qunit';
 
-import { cachedFetch, clearFetchCache } from '@cardstack/runtime-common';
+import {
+  baseRealm,
+  cachedFetch,
+  clearFetchCache,
+  type MaybeCachedResponse,
+} from '@cardstack/runtime-common';
 
 type FetchCall = {
   accept: string | null;
@@ -53,6 +58,43 @@ function createFetchStub() {
 }
 
 const TEST_URL = 'http://example.com/modules/example.js';
+
+// Trusted base-realm entries deliberately outlive the between-test clear, so
+// each test needs its own URL — and one nothing else in the suite requests, so
+// what this module leaves behind can't affect other tests.
+const canonicalPath = './__cached-fetch-canonical__';
+const source = 'export const x = 1;';
+
+function realmResponse(moduleHref: string): Response {
+  let response = new Response(source, {
+    headers: {
+      ETag: 'etag-1',
+      'X-boxel-realm-url': baseRealm.url,
+      'X-Boxel-Canonical-Path': canonicalPath,
+      'content-type': 'text/javascript',
+    },
+  });
+  // A constructed Response has an empty url; a fetched one doesn't, and the
+  // loader reads it, so the stand-in has to have one too.
+  Object.defineProperty(response, 'url', {
+    value: moduleHref,
+    configurable: true,
+  });
+  return response;
+}
+
+// Populates the cache the way Loader#fetchModule does: read the body, then hand
+// it back through cacheResponse.
+async function primeCache(
+  fetchImplementation: typeof globalThis.fetch,
+  moduleHref: string,
+) {
+  let response = (await cachedFetch(
+    fetchImplementation,
+    moduleHref,
+  )) as MaybeCachedResponse;
+  response.cacheResponse?.(await response.text());
+}
 
 module('Unit | cached-fetch', function (hooks) {
   hooks.afterEach(function () {
@@ -119,5 +161,123 @@ module('Unit | cached-fetch', function (hooks) {
       { accept: '*/*', ifNoneMatch: null },
       { accept: null, ifNoneMatch: 'etag-module' },
     ]);
+  });
+
+  test('a replayed base-realm response keeps the headers and url the realm sent', async function (assert) {
+    let moduleHref = `${baseRealm.url}__cached-fetch-replay-test__`;
+    let requests = 0;
+    let fetchImplementation = (async () => {
+      requests++;
+      return realmResponse(moduleHref);
+    }) as unknown as typeof globalThis.fetch;
+
+    await primeCache(fetchImplementation, moduleHref);
+    assert.strictEqual(requests, 1, 'the first fetch reaches the realm');
+
+    // Test suites mark the base realm trusted (see test-helper.js), which is
+    // what lets a hit skip revalidation — and so return a response the caller
+    // did not receive from the realm.
+    let replayed = await cachedFetch(fetchImplementation, moduleHref);
+    assert.strictEqual(requests, 1, 'a trusted hit makes no request');
+
+    // Loader#fetchModule derives a module's canonical identity from this
+    // header, falling back to response.url. Losing either registers the module
+    // under a second identity, which breaks instanceof and def lookup.
+    assert.strictEqual(
+      replayed.headers.get('X-Boxel-Canonical-Path'),
+      canonicalPath,
+      'the canonical-path header survives the replay',
+    );
+    assert.strictEqual(
+      replayed.url,
+      moduleHref,
+      'the response url survives the replay',
+    );
+    assert.strictEqual(
+      replayed.headers.get('X-boxel-realm-url'),
+      baseRealm.url,
+      'the realm-url header survives the replay',
+    );
+    assert.strictEqual(
+      replayed.headers.get('content-type'),
+      'text/javascript',
+      'the content type survives the replay',
+    );
+    assert.strictEqual(await replayed.text(), source, 'the body is the source');
+  });
+
+  test('clearFetchCache keeps trusted base-realm entries', async function (assert) {
+    let moduleHref = `${baseRealm.url}__cached-fetch-clear-test__`;
+    let requests = 0;
+    let fetchImplementation = (async () => {
+      requests++;
+      return realmResponse(moduleHref);
+    }) as unknown as typeof globalThis.fetch;
+
+    await primeCache(fetchImplementation, moduleHref);
+    clearFetchCache();
+
+    let replayed = await cachedFetch(fetchImplementation, moduleHref);
+    assert.strictEqual(
+      requests,
+      1,
+      'the entry outlives the between-test clear, so no second request',
+    );
+    assert.strictEqual(
+      replayed.headers.get('X-Boxel-Canonical-Path'),
+      canonicalPath,
+      'and it still carries its headers afterwards',
+    );
+  });
+
+  test('a 304 revalidation keeps the content type and takes the canonical path from the realm', async function (assert) {
+    // Not a base-realm URL, so it revalidates rather than being served from
+    // cache outright — the path every non-base realm still takes.
+    let moduleHref = 'http://test-realm/test/__cached-fetch-304-test__';
+    let movedCanonicalPath = './__cached-fetch-moved__';
+    let responses = [
+      () => {
+        let response = new Response(source, {
+          headers: {
+            ETag: 'etag-1',
+            'X-boxel-realm-url': 'http://test-realm/test/',
+            'X-Boxel-Canonical-Path': canonicalPath,
+            'content-type': 'text/javascript',
+          },
+        });
+        Object.defineProperty(response, 'url', {
+          value: moduleHref,
+          configurable: true,
+        });
+        return response;
+      },
+      // The realm sends the canonical path on a 304 but no content-type, so a
+      // faithful replay needs both sources.
+      () =>
+        new Response(null, {
+          status: 304,
+          headers: {
+            ETag: 'etag-1',
+            'X-Boxel-Canonical-Path': movedCanonicalPath,
+          },
+        }),
+    ];
+    let fetchImplementation = (async () =>
+      responses.shift()!()) as unknown as typeof globalThis.fetch;
+
+    await primeCache(fetchImplementation, moduleHref);
+    let replayed = await cachedFetch(fetchImplementation, moduleHref);
+
+    assert.strictEqual(
+      replayed.headers.get('X-Boxel-Canonical-Path'),
+      movedCanonicalPath,
+      "the 304's canonical path wins over the cached one",
+    );
+    assert.strictEqual(
+      replayed.headers.get('content-type'),
+      'text/javascript',
+      'while the content type comes from the cached entry',
+    );
+    assert.strictEqual(await replayed.text(), source, 'the body is the source');
   });
 });

--- a/packages/runtime-common/cached-fetch.ts
+++ b/packages/runtime-common/cached-fetch.ts
@@ -1,8 +1,40 @@
 import { merge } from 'lodash-es';
 
-import { isNode } from './index.ts';
+import { baseRealm, isNode } from './index.ts';
 
-const cache = new Map<string, { etag: string; body: string }>();
+const cache = new Map<
+  string,
+  { etag: string; body: string; realmURL: string }
+>();
+
+// When set, cached base-realm responses are served without revalidating, and
+// they survive `clearFetchCache`.
+//
+// Every entry here still costs a request otherwise: the cache is
+// revalidation-based (`If-None-Match` → 304), and the realm serves modules
+// `max-age=0`, so a cache hit saves the body but not the round trip. That is
+// the right default for the running app, where a realm's contents can change
+// under it. It is the wrong one for a test suite: the base realm is
+// read-only and fixed for the lifetime of the page, while the loader is
+// replaced constantly (per test, and on every reset), and each replacement
+// re-requests the whole base module graph — a single test can re-request
+// `base/card-api` ten times.
+//
+// Only the base realm qualifies, and only because it is world-readable: the
+// cache is cleared between tests so one test's realm contents can't leak
+// into another's, and keeping public, immutable modules doesn't weaken that.
+let serveBaseRealmFromCacheWithoutRevalidating = false;
+
+export function trustBaseRealmFetchCache(trusted = true) {
+  serveBaseRealmFromCacheWithoutRevalidating = trusted;
+}
+
+function isTrustedBaseRealmEntry(entry: { realmURL: string } | undefined) {
+  return (
+    serveBaseRealmFromCacheWithoutRevalidating &&
+    entry?.realmURL === baseRealm.url
+  );
+}
 
 // we need to be careful not to read the response stream before the intended
 // consumer has read it. so we use this callback to allow the consumer to set
@@ -46,6 +78,11 @@ export async function cachedFetch(
   let accept = getAcceptHeader(urlOrRequest, init).trim().toLowerCase();
   let cacheKey = `${key}::accept:${accept}`;
   let cached = cache.get(cacheKey);
+  if (cached && isTrustedBaseRealmEntry(cached)) {
+    // Same shape the 304 branch below returns, which every consumer of this
+    // function already handles.
+    return new Response(cached.body);
+  }
   if (cached?.etag) {
     if (urlOrRequest instanceof Request) {
       urlOrRequest.headers.set('If-None-Match', cached.etag);
@@ -73,8 +110,9 @@ export async function cachedFetch(
     let maybeRealmURL = response.headers.get('X-boxel-realm-url');
     if (maybeETag && maybeRealmURL) {
       let etag = maybeETag;
+      let realmURL = maybeRealmURL;
       response.cacheResponse = (body: string) => {
-        cache.set(cacheKey, { etag, body });
+        cache.set(cacheKey, { etag, body, realmURL });
       };
     }
   }
@@ -82,7 +120,13 @@ export async function cachedFetch(
 }
 
 // make sure to clear this between tests so that cache contents don't leak
-// outside each test
+// outside each test. Base-realm entries are kept when they have been marked
+// trusted (see trustBaseRealmFetchCache) — they are public and, for the
+// lifetime of that page, immutable.
 export function clearFetchCache() {
-  cache.clear();
+  for (let [key, entry] of cache) {
+    if (!isTrustedBaseRealmEntry(entry)) {
+      cache.delete(key);
+    }
+  }
 }

--- a/packages/runtime-common/cached-fetch.ts
+++ b/packages/runtime-common/cached-fetch.ts
@@ -2,10 +2,53 @@ import { merge } from 'lodash-es';
 
 import { baseRealm, isNode } from './index.ts';
 
-const cache = new Map<
-  string,
-  { etag: string; body: string; realmURL: string }
->();
+interface CacheEntry {
+  etag: string;
+  body: string;
+  realmURL: string;
+  headers: [string, string][];
+  url: string;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+// Headers that describe how the body was framed on the wire. The replayed body
+// is a decoded string, so carrying these over would describe it wrongly.
+const bodyFramingHeaders = new Set([
+  'content-encoding',
+  'content-length',
+  'transfer-encoding',
+]);
+
+// A cached body on its own is not a faithful stand-in for the response: the
+// loader derives a module's canonical identity from `X-Boxel-Canonical-Path`,
+// falling back to `response.url` (see Loader#fetchModule). A bare
+// `new Response(body)` has neither, so the module gets registered under the
+// URL that was requested rather than its canonical one — two identities for
+// one module, which breaks `instanceof`, def lookup, and serialization.
+function replayCachedResponse(entry: CacheEntry, live?: Response): Response {
+  let headers = new Headers();
+  let copy = (name: string, value: string) => {
+    if (!bodyFramingHeaders.has(name.toLowerCase())) {
+      headers.set(name, value);
+    }
+  };
+  for (let [name, value] of entry.headers) {
+    copy(name, value);
+  }
+  // A 304 carries the realm's current metadata for the module — including its
+  // canonical path — but no content-type, so it overlays the cached headers
+  // rather than replacing them.
+  live?.headers.forEach((value, name) => copy(name, value));
+
+  let response = new Response(entry.body, { headers });
+  let url = live?.url || entry.url;
+  if (url) {
+    // `url` is a read-only getter that the constructor can't populate.
+    Object.defineProperty(response, 'url', { value: url, configurable: true });
+  }
+  return response;
+}
 
 // When set, cached base-realm responses are served without revalidating, and
 // they survive `clearFetchCache`.
@@ -79,9 +122,7 @@ export async function cachedFetch(
   let cacheKey = `${key}::accept:${accept}`;
   let cached = cache.get(cacheKey);
   if (cached && isTrustedBaseRealmEntry(cached)) {
-    // Same shape the 304 branch below returns, which every consumer of this
-    // function already handles.
-    return new Response(cached.body);
+    return replayCachedResponse(cached);
   }
   if (cached?.etag) {
     if (urlOrRequest instanceof Request) {
@@ -104,15 +145,18 @@ export async function cachedFetch(
         `Received HTTP 304 "not modified" when we don't have cache for ${key} (Accept: ${accept})`,
       );
     }
-    return new Response(cached.body);
+    return replayCachedResponse(cached, response);
   } else if (response.ok) {
     let maybeETag = response.headers.get('ETag');
     let maybeRealmURL = response.headers.get('X-boxel-realm-url');
     if (maybeETag && maybeRealmURL) {
       let etag = maybeETag;
       let realmURL = maybeRealmURL;
+      let headers: [string, string][] = [];
+      response.headers.forEach((value, name) => headers.push([name, value]));
+      let url = response.url;
       response.cacheResponse = (body: string) => {
-        cache.set(cacheKey, { etag, body, realmURL });
+        cache.set(cacheKey, { etag, body, realmURL, headers, url });
       };
     }
   }


### PR DESCRIPTION
We know the base realm shouldn’t change between tests, so its modules don’t need to be refetched.