### PR TITLE
Extract `RealmPaths#inRealm` efficiencies

### DIFF
--- a/packages/host/tests/unit/realm-paths-test.ts
+++ b/packages/host/tests/unit/realm-paths-test.ts
@@ -71,4 +71,43 @@ module('Unit | RealmPaths', function (hooks) {
       realmPaths.inRealm(rri('https://cardstack.com/humans/éxample')),
     );
   });
+
+  test('#inRealm handles percent-encoding, query strings, and the realm root', function (assert) {
+    // Percent-escapes are decoded before comparing, so an encoded id inside
+    // the realm still matches while an encoded id outside it does not.
+    assert.true(
+      realmPaths.inRealm(rri('https://cardstack.com/h%C3%BCmans/example')),
+      'percent-encoded realm path is in realm',
+    );
+    assert.true(
+      realmPaths.inRealm(rri('https://cardstack.com/hümans/a%20b.json')),
+      'percent-encoded local path is in realm',
+    );
+    assert.false(
+      realmPaths.inRealm(rri('https://cardstack.com/h%C3%BCmans2/example')),
+      'a percent-encoded path outside the realm is not in realm',
+    );
+
+    // A malformed escape can't be decoded; that is a "not in realm" answer
+    // rather than a thrown error.
+    assert.false(
+      realmPaths.inRealm(rri('https://cardstack.com/hümans/bad%ZZ')),
+      'malformed percent-escape is not in realm',
+    );
+
+    // The realm root matches with or without its trailing slash, and a query
+    // string doesn't defeat the match.
+    assert.true(
+      realmPaths.inRealm(rri('https://cardstack.com/hümans')),
+      'realm root without trailing slash is in realm',
+    );
+    assert.true(
+      realmPaths.inRealm(rri('https://cardstack.com/hümans?foo=bar')),
+      'realm root with a query string is in realm',
+    );
+    assert.true(
+      realmPaths.inRealm(rri('https://cardstack.com/hümans/example?a=1&b=2')),
+      'local path with a query string is in realm',
+    );
+  });
 });

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -18,6 +18,10 @@ interface RealmPathsVirtualNetwork {
 
 export class RealmPaths {
   readonly url: string;
+  // `url` without its trailing slash. `inRealm` compares against this on
+  // every call and is hot enough to show up in a CPU profile of the test
+  // suite, so it is computed once here rather than per call.
+  private urlWithoutTrailingSlash: string;
   private virtualNetwork: RealmPathsVirtualNetwork | undefined;
 
   constructor(realmURL: URL, virtualNetwork?: RealmPathsVirtualNetwork);
@@ -34,6 +38,7 @@ export class RealmPaths {
     } else {
       this.url = ensureTrailingSlash(realmURLOrId);
     }
+    this.urlWithoutTrailingSlash = this.url.replace(/\/$/, '');
     this.virtualNetwork = virtualNetwork;
   }
 
@@ -109,7 +114,7 @@ export class RealmPaths {
     let inputStr = input instanceof URL ? input.href : input;
     let decoded: string;
     try {
-      decoded = decodeURI(inputStr);
+      decoded = decodeUriIfNeeded(inputStr);
     } catch {
       return false;
     }
@@ -117,7 +122,7 @@ export class RealmPaths {
     if (
       decoded.startsWith(this.url) ||
       // realm root with missing trailing slash, optionally with query string
-      decoded.split('?')[0] === this.url.replace(/\/$/, '')
+      beforeQuery(decoded) === this.urlWithoutTrailingSlash
     ) {
       return true;
     }
@@ -136,13 +141,13 @@ export class RealmPaths {
     }
     let decodedURL: string;
     try {
-      decodedURL = decodeURI(inputURL);
+      decodedURL = decodeUriIfNeeded(inputURL);
     } catch {
       return false;
     }
     return (
       decodedURL.startsWith(realmURL) ||
-      decodedURL.split('?')[0] === realmURL.replace(/\/$/, '')
+      beforeQuery(decodedURL) === realmURL.replace(/\/$/, '')
     );
   }
 
@@ -173,6 +178,22 @@ export function join(...pathParts: string[]): LocalPath {
 
 export function ensureTrailingSlash(url: string) {
   return url.endsWith('/') ? url : `${url}/`;
+}
+
+// `decodeURI` only rewrites percent-escapes, so a string without a '%' is
+// returned unchanged — and it can only throw on a malformed escape, which
+// likewise requires one. Skipping the call for the common case keeps
+// `inRealm` off `decodeURI` entirely for ordinary ids; it is hot enough for
+// that to be visible in a CPU profile of the test suite.
+function decodeUriIfNeeded(value: string): string {
+  return value.includes('%') ? decodeURI(value) : value;
+}
+
+// `s.split('?')[0]` allocates an array (and every subsequent segment) just to
+// read the part before the query string.
+function beforeQuery(value: string): string {
+  let queryStart = value.indexOf('?');
+  return queryStart === -1 ? value : value.slice(0, queryStart);
 }
 
 // Documenting that this represents a local path within realm, with no leading


### PR DESCRIPTION
This is a slight refactor for cleanliness, not speed.