### PR TITLE
Read encoding, tags, waveforms, and MIDI from audio files

### DIFF
--- a/packages/base/audio-file-def.gts
+++ b/packages/base/audio-file-def.gts
@@ -14,12 +14,9 @@ import {
   WaveformMetadataField,
 } from './file-formats/metadata-fields';
 import { markdownAudio } from './markdown-helpers';
-import {
-  WAVEFORM_MAX_ENCODED_BYTES,
-  extractAudioWaveform,
-} from './audio-waveform';
+import { decodeSkipReason, extractAudioWaveform } from './audio-waveform';
 import type { AudioEncoding, MediaTags } from './audio-metadata';
-import type { WaveformMetadata } from './audio-waveform';
+import type { DecodeBudget, WaveformMetadata } from './audio-waveform';
 import type { ByteStream } from './file-api';
 import AudioDefIsolatedTemplate from './default-templates/audio-def-isolated';
 import AudioDefEmbeddedTemplate from './default-templates/audio-def-embedded';
@@ -170,26 +167,22 @@ export function audioAttributes(
 
 // Produce a waveform, or an honest reason for not having one.
 //
-// This is the one audio fact that needs the whole file rather than a header
-// window, so it asks for a second stream — which the extract runner satisfies by
-// re-fetching and buffering. That is a real cost during indexing, so the size
-// check comes first and uses `contentSize` when the indexer supplied it: a file
-// over the ceiling never triggers the extra read at all, rather than being
-// fetched and then rejected.
+// This is the fallback path, for the formats that still need a real decoder:
+// FLAC, Ogg, and M4A. WAV reads its envelope straight from PCM and MP3 reads
+// quantizer gains out of frame side info, so neither comes through here.
+//
+// The decode needs the whole file rather than a header window, so it asks for a
+// second stream — which the extract runner satisfies by re-fetching and
+// buffering. That is a real cost, so the budget check comes first and a file
+// over it never triggers the extra read at all, rather than being fetched and
+// then rejected.
 export async function waveformFor(
   getStream: () => Promise<ByteStream>,
-  contentSize: number | undefined,
+  budget: DecodeBudget,
 ): Promise<WaveformMetadata> {
-  if (
-    contentSize !== undefined &&
-    contentSize > WAVEFORM_MAX_ENCODED_BYTES
-  ) {
-    return {
-      decodeStatus: 'skipped',
-      decodeError: `File exceeds the ${Math.floor(
-        WAVEFORM_MAX_ENCODED_BYTES / (1024 * 1024),
-      )} MB decode ceiling`,
-    };
+  let skip = decodeSkipReason(budget);
+  if (skip) {
+    return { decodeStatus: 'skipped', decodeError: skip };
   }
   try {
     let bytes = await byteStreamToUint8Array(await getStream());

--- a/packages/base/audio-file-def.gts
+++ b/packages/base/audio-file-def.gts
@@ -6,8 +6,21 @@ import {
   contains,
   field,
 } from './card-api';
+import { byteStreamToUint8Array } from '@cardstack/runtime-common';
 import { FileDef } from './file-api';
+import {
+  MediaEncodingField,
+  MediaTagsField,
+  WaveformMetadataField,
+} from './file-formats/metadata-fields';
 import { markdownAudio } from './markdown-helpers';
+import {
+  WAVEFORM_MAX_ENCODED_BYTES,
+  extractAudioWaveform,
+} from './audio-waveform';
+import type { AudioEncoding, MediaTags } from './audio-metadata';
+import type { WaveformMetadata } from './audio-waveform';
+import type { ByteStream } from './file-api';
 import AudioDefIsolatedTemplate from './default-templates/audio-def-isolated';
 import AudioDefEmbeddedTemplate from './default-templates/audio-def-embedded';
 import AudioDefFittedTemplate from './default-templates/audio-def-fitted';
@@ -19,6 +32,20 @@ export class AudioDef extends FileDef {
   static acceptTypes = 'audio/*';
 
   @field duration = contains(NumberField);
+
+  // How the stream is encoded, read from the container's own header.
+  @field encoding = contains(MediaEncodingField);
+
+  // What the track says about itself. Empty for anything untagged, which is most
+  // audio that wasn't ripped or published.
+  @field tags = contains(MediaTagsField);
+
+  // The decoded amplitude envelope. Unlike every other field here this requires
+  // a real decoder rather than a header read, so it carries its own status and
+  // is the one audio fact that can legitimately be missing. MIDI deliberately
+  // does not inherit it — a note sequence has no amplitude until something
+  // synthesizes it.
+  @field waveform = contains(WaveformMetadataField);
 
   static isolated: BaseDefComponent = AudioDefIsolatedTemplate;
   static embedded: BaseDefComponent = AudioDefEmbeddedTemplate;
@@ -49,3 +76,133 @@ export class AudioDef extends FileDef {
 }
 
 export default AudioDef;
+
+// A `CodedValueField` as it arrives over the wire.
+interface SerializedCodedValue {
+  code: string;
+  scheme: string;
+}
+
+// A `QuantityField` as it arrives over the wire.
+interface SerializedQuantity {
+  value: number;
+  unit?: string;
+  displayText?: string;
+}
+
+// `MediaEncodingField`'s wire shape. It differs from `AudioEncoding` in that a
+// rate travels as a Quantity and a channel mode as a CodedValue, so the per-format
+// readers stay free of any knowledge about how the fields are modeled.
+export interface SerializedMediaEncoding {
+  container?: string;
+  audioCodec?: string;
+  sampleRate?: SerializedQuantity;
+  bitrate?: SerializedQuantity;
+  bitDepth?: number;
+  channels?: number;
+  channelMode?: SerializedCodedValue;
+  isVariableBitrate?: boolean;
+}
+
+// `MediaTagsField`'s wire shape: as `MediaTags`, but with the scheme wrapped.
+export type SerializedMediaTags = Omit<MediaTags, 'scheme'> & {
+  scheme?: SerializedCodedValue;
+};
+
+// The attributes a sampled-audio subclass's `extractAttributes` adds on top of
+// the base file identity and duration.
+export interface AudioAttributes {
+  encoding?: SerializedMediaEncoding;
+  tags?: SerializedMediaTags;
+  waveform?: WaveformMetadata;
+}
+
+// Bitrates read in the thousands and sample rates in the tens of thousands, so
+// both get a unit and let QuantityField's own formatting add the separators.
+function kilo(value: number | undefined, unit: string) {
+  return value === undefined ? undefined : { value, unit };
+}
+
+// Assemble the audio metadata attributes from whatever a format's readers could
+// determine, omitting each one entirely when they determined nothing — an
+// untagged file should add no `tags` attribute rather than an empty object.
+export function audioAttributes(
+  encoding: AudioEncoding | undefined,
+  tags: MediaTags | undefined,
+  waveform?: WaveformMetadata,
+): AudioAttributes {
+  let serializedEncoding: SerializedMediaEncoding | undefined;
+  if (encoding) {
+    let { sampleRateHz, bitrateBps, channelMode, ...rest } = encoding;
+    serializedEncoding = {
+      ...rest,
+      ...(sampleRateHz === undefined
+        ? {}
+        : { sampleRate: kilo(sampleRateHz, 'Hz') }),
+      ...(bitrateBps === undefined
+        ? {}
+        : { bitrate: kilo(bitrateBps, 'bps') }),
+      ...(channelMode === undefined
+        ? {}
+        : { channelMode: { code: channelMode, scheme: 'channel-mode' } }),
+    };
+  }
+
+  let serializedTags: SerializedMediaTags | undefined;
+  if (tags) {
+    let { scheme, ...rest } = tags;
+    serializedTags = {
+      ...rest,
+      ...(scheme === undefined
+        ? {}
+        : { scheme: { code: scheme, scheme: 'tag-scheme' } }),
+    };
+  }
+
+  return {
+    ...(serializedEncoding ? { encoding: serializedEncoding } : {}),
+    ...(serializedTags ? { tags: serializedTags } : {}),
+    // A skipped or failed decode is still worth persisting: it's the difference
+    // between "no waveform yet" and "this file cannot produce one".
+    ...(waveform ? { waveform } : {}),
+  };
+}
+
+// Produce a waveform, or an honest reason for not having one.
+//
+// This is the one audio fact that needs the whole file rather than a header
+// window, so it asks for a second stream — which the extract runner satisfies by
+// re-fetching and buffering. That is a real cost during indexing, so the size
+// check comes first and uses `contentSize` when the indexer supplied it: a file
+// over the ceiling never triggers the extra read at all, rather than being
+// fetched and then rejected.
+export async function waveformFor(
+  getStream: () => Promise<ByteStream>,
+  contentSize: number | undefined,
+): Promise<WaveformMetadata> {
+  if (
+    contentSize !== undefined &&
+    contentSize > WAVEFORM_MAX_ENCODED_BYTES
+  ) {
+    return {
+      decodeStatus: 'skipped',
+      decodeError: `File exceeds the ${Math.floor(
+        WAVEFORM_MAX_ENCODED_BYTES / (1024 * 1024),
+      )} MB decode ceiling`,
+    };
+  }
+  try {
+    let bytes = await byteStreamToUint8Array(await getStream());
+    return await extractAudioWaveform(bytes);
+  } catch (error) {
+    // A stream that won't re-read is not a reason to fail the whole extract; the
+    // header-derived facts are already gathered.
+    return {
+      decodeStatus: 'failed',
+      decodeError:
+        error instanceof Error
+          ? error.message
+          : `Could not read audio bytes: ${String(error)}`,
+    };
+  }
+}

--- a/packages/base/audio-metadata.ts
+++ b/packages/base/audio-metadata.ts
@@ -1,0 +1,115 @@
+// The shapes every audio format's reader returns, so `MediaEncodingField` and
+// `MediaTagsField` can be populated identically from an MP3 frame header, a WAV
+// `fmt ` chunk, a FLAC STREAMINFO block, an Ogg identification header, or an
+// MP4 sample entry.
+//
+// Each format's reader lives in that format's `*-meta-extractor` module beside
+// the duration reader that already walks the same structures. This module holds
+// only the vocabulary they agree on.
+//
+// Every property is optional and absence is meaningful: MP3 has no bit-depth
+// concept at all, so `bitDepth` stays unset rather than being filled with a
+// plausible 16 the file never carried.
+
+// A slug from the shared `channel-mode` vocabulary. Wrapped into a CodedValue by
+// the caller, so readers stay free of any knowledge of how the field is modeled.
+export type ChannelMode =
+  | 'mono'
+  | 'stereo'
+  | 'joint-stereo'
+  | 'dual-mono'
+  | 'surround';
+
+export interface AudioEncoding {
+  container?: string;
+  audioCodec?: string;
+  sampleRateHz?: number;
+  // Bits per second for the whole stream where the container states it, or for
+  // the sampled frame where that's all there is — `isVariableBitrate` is what
+  // tells those apart.
+  bitrateBps?: number;
+  isVariableBitrate?: boolean;
+  bitDepth?: number;
+  channels?: number;
+  channelMode?: ChannelMode;
+}
+
+// A slug from the shared `tag-scheme` vocabulary, naming which convention
+// supplied the values below.
+export type TagScheme = 'id3v2' | 'riff-info' | 'mp4-atoms' | 'vorbis-comment';
+
+export interface MediaTags {
+  scheme?: TagScheme;
+  trackTitle?: string;
+  artist?: string;
+  album?: string;
+  albumArtist?: string;
+  composer?: string;
+  year?: number;
+  // Kept as authored ("4/12") rather than split: the total is part of what the
+  // file said, and coercing to a number would discard it.
+  track?: string;
+  disc?: string;
+  genre?: string;
+  comment?: string;
+}
+
+function pruned<T extends object>(candidate: T): T | undefined {
+  let entries = Object.entries(candidate).filter(
+    ([, value]) => value !== undefined && value !== '',
+  );
+  return entries.length > 0 ? (Object.fromEntries(entries) as T) : undefined;
+}
+
+// Drop keys a format couldn't determine, so a reader that learned nothing adds
+// no attribute at all rather than an empty object in the index row.
+export function prunedEncoding(
+  candidate: AudioEncoding,
+): AudioEncoding | undefined {
+  return pruned(candidate);
+}
+
+// As above, and additionally drops a tag block that carries only its `scheme`:
+// knowing a file has an empty ID3v2 tag is not worth an index row.
+export function prunedTags(candidate: MediaTags): MediaTags | undefined {
+  let result = pruned(candidate);
+  if (!result) {
+    return undefined;
+  }
+  let keys = Object.keys(result);
+  if (keys.length === 1 && keys[0] === 'scheme') {
+    return undefined;
+  }
+  return result;
+}
+
+// A year can arrive as a bare "1997", a full "1997-06-03" date, or an ISO
+// timestamp depending on the convention. Take the leading four digits and only
+// when they land in a range a recording could plausibly carry — a "year" of 3
+// or 20997 is a parse failure, not a date.
+export function parseTagYear(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  let match = value.trim().match(/^(\d{4})/);
+  if (!match) {
+    return undefined;
+  }
+  let year = Number(match[1]);
+  return year >= 1000 && year <= 9999 ? year : undefined;
+}
+
+// MPEG and MP4 state a channel count; only some formats also say how the
+// channels relate. Where they don't, infer the obvious cases and leave anything
+// richer unset rather than guessing at a surround layout.
+export function channelModeForCount(
+  channels: number | undefined,
+): ChannelMode | undefined {
+  if (channels === 1) {
+    return 'mono';
+  }
+  if (channels === 2) {
+    return 'stereo';
+  }
+  return channels !== undefined && channels > 2 ? 'surround' : undefined;
+}

--- a/packages/base/audio-waveform.ts
+++ b/packages/base/audio-waveform.ts
@@ -30,26 +30,84 @@ export const WAVEFORM_ALGORITHM = 'rms-peak-v1';
 // comparing two files can tell it apart from a decoded envelope.
 export const WAVEFORM_ALGORITHM_SIDE_INFO = 'mp3-side-info-v1';
 
-// Refuse to decode past this, measured on the *encoded* size because that is
-// what's known before committing to a decode.
+// What one file's decode may cost in memory.
 //
-// This applies to FLAC, Ogg, and M4A — the formats that still need a real
-// decoder. MP3 no longer does: it reads its envelope out of frame side info
-// (see `extractMp3Envelope`) and streams with flat memory, which is why it is
-// exempt. That matters because MP3 was by far the worst case here, at roughly
-// twenty times the encoded size once decoded to float PCM against four to six
-// for the rest.
+// The ceiling is on *decoded* bytes rather than encoded ones, because encoded
+// size predicts decoded size very badly. Float PCM costs
+// `duration x sampleRate x channels x 4`, so the expansion factor is
+// `(sampleRate x channels x 32) / bitrate` — which is about 4x for FLAC but 22x
+// for AAC and up to 48x for low-bitrate Opus. A single encoded ceiling that
+// looks reasonable against FLAC therefore admits a decode an order of magnitude
+// larger for a lossy stream: at 16 MB encoded, FLAC decodes to ~64 MB while
+// 64 kbps Opus decodes to ~768 MB.
 //
-// The number that matters is still the decoded one: float PCM costs
-// `duration x sampleRate x channels x 4` bytes. A 16 MB FLAC is around three
-// minutes, decoding to ~60 MB inside the shared prerender pool alongside every
-// other render — enough for ordinary music and speech while refusing masters
-// that would decode to gigabytes.
+// Predicting the decoded size costs nothing, because every caller has already
+// read the duration, sample rate, and channel count from the container's header
+// before it gets here. So the budget is applied to the figure that actually
+// matters, and each format lands wherever its own codec puts it.
 //
-// Over the ceiling is not a failure: the file still indexes with every
-// header-derived fact intact and records `skipped`, so a renderer can tell
-// "too large to analyze" from "decode failed".
-export const WAVEFORM_MAX_ENCODED_BYTES = 16 * 1024 * 1024;
+// 128 MB admits roughly five minutes of 44.1 kHz stereo — comfortably every
+// ordinary song — while refusing the long recordings that would dominate a
+// prerender page's memory alongside every other render sharing the pool.
+export const WAVEFORM_MAX_DECODED_BYTES = 128 * 1024 * 1024;
+
+// Decoded PCM is 32-bit float per sample per channel.
+const BYTES_PER_DECODED_SAMPLE = 4;
+
+// A backstop for the case the decoded size can't be predicted — a container that
+// stated no sample rate, say. Deliberately generous, because it is a proxy for
+// the real constraint rather than the constraint itself.
+export const WAVEFORM_MAX_ENCODED_BYTES = 32 * 1024 * 1024;
+
+// What the container says this file will cost once decoded, or undefined when it
+// didn't say enough to tell.
+export function predictedDecodedBytes(
+  budget: DecodeBudget,
+): number | undefined {
+  let { durationSeconds, sampleRateHz, channels } = budget;
+  if (
+    durationSeconds === undefined ||
+    sampleRateHz === undefined ||
+    channels === undefined ||
+    durationSeconds <= 0 ||
+    sampleRateHz <= 0 ||
+    channels <= 0
+  ) {
+    return undefined;
+  }
+  return durationSeconds * sampleRateHz * channels * BYTES_PER_DECODED_SAMPLE;
+}
+
+// What each caller knows before committing to a decode.
+export interface DecodeBudget {
+  durationSeconds?: number;
+  sampleRateHz?: number;
+  channels?: number;
+  contentSize?: number;
+}
+
+function megabytes(bytes: number): string {
+  return `${Math.round(bytes / (1024 * 1024))} MB`;
+}
+
+// Why this file shouldn't be decoded, or undefined to go ahead. Skipping is not
+// a failure: the file still indexes with every header-derived fact intact, and
+// `skipped` tells a renderer "too large to analyze" rather than "decode failed".
+export function decodeSkipReason(budget: DecodeBudget): string | undefined {
+  let predicted = predictedDecodedBytes(budget);
+  if (predicted !== undefined) {
+    return predicted > WAVEFORM_MAX_DECODED_BYTES
+      ? `Decoding would need about ${megabytes(predicted)}, over the ${megabytes(
+          WAVEFORM_MAX_DECODED_BYTES,
+        )} ceiling`
+      : undefined;
+  }
+  // Nothing to predict from, so fall back to the encoded proxy.
+  return budget.contentSize !== undefined &&
+    budget.contentSize > WAVEFORM_MAX_ENCODED_BYTES
+    ? `File exceeds the ${megabytes(WAVEFORM_MAX_ENCODED_BYTES)} ceiling for audio of unknown duration`
+    : undefined;
+}
 
 export interface WaveformMetadata {
   decodeStatus: 'ok' | 'unsupported' | 'failed' | 'skipped';
@@ -202,12 +260,15 @@ export async function extractAudioWaveform(
   if (bytes.byteLength === 0) {
     return { decodeStatus: 'skipped', decodeError: 'File is empty' };
   }
+  // A last-resort guard for a caller that skipped the budget check entirely.
+  // The real decision is `decodeSkipReason`, which reasons about decoded rather
+  // than encoded size.
   if (bytes.byteLength > WAVEFORM_MAX_ENCODED_BYTES) {
     return {
       decodeStatus: 'skipped',
-      decodeError: `File exceeds the ${Math.floor(
+      decodeError: `File exceeds the ${Math.round(
         WAVEFORM_MAX_ENCODED_BYTES / (1024 * 1024),
-      )} MB decode ceiling`,
+      )} MB unbudgeted ceiling`,
     };
   }
   let Decoder = audioDecoderConstructor();

--- a/packages/base/audio-waveform.ts
+++ b/packages/base/audio-waveform.ts
@@ -1,11 +1,15 @@
-// Browser-only enrichment: decode the audio and reduce it to a bounded
-// amplitude envelope.
+// Decode audio and reduce it to a bounded amplitude envelope.
 //
-// Unlike everything else in the `*-meta-extractor` modules, this cannot be done
-// by reading a header — it needs a real decoder, which means Web Audio. That is
-// available because the extract pass runs in the prerenderer's headless Chrome,
-// but it is the one audio fact that can legitimately be unavailable, so failure
-// is recorded on the field rather than thrown.
+// This is the fallback path, used by the formats that genuinely need a decoder:
+// FLAC, Ogg, and M4A. It relies on Web Audio, which is available because the
+// extract pass runs in the prerenderer's headless Chrome — but it is the one
+// audio fact that can legitimately be unavailable, so failure is recorded on the
+// field rather than thrown.
+//
+// MP3 does not come through here. Its envelope is read straight from quantizer
+// gains in each frame's side info, with no decoder and flat memory; see
+// `extractMp3Envelope`. The reduction below is still what defines what a bar
+// means, and both paths produce the same `WaveformMetadata` shape.
 //
 // The envelope is deliberately *not* a downsample of the opening seconds. It is
 // resampled across the whole signal, so a waveform drawn from it is recognizably
@@ -20,15 +24,27 @@ export const WAVEFORM_BAR_COUNT = 96;
 // algorithm changes so a consumer can tell an old envelope from a new one.
 export const WAVEFORM_ALGORITHM = 'rms-peak-v1';
 
+// The envelope MP3 produces by reading quantizer gains out of frame side info
+// rather than decoding. Recorded distinctly because its bars are normalized to
+// the track's own peak rather than being calibrated amplitudes, so a consumer
+// comparing two files can tell it apart from a decoded envelope.
+export const WAVEFORM_ALGORITHM_SIDE_INFO = 'mp3-side-info-v1';
+
 // Refuse to decode past this, measured on the *encoded* size because that is
 // what's known before committing to a decode.
 //
-// The number that matters is the decoded one, and it is much larger: float PCM
-// costs `duration × sampleRate × channels × 4` bytes, so a five-minute 44.1 kHz
-// stereo track is ~106 MB decoded from ~7 MB of MP3 — a factor of fifteen. This
-// runs inside the shared prerender pool during indexing, alongside every other
-// render, so the ceiling is set to admit ordinary music and speech while
-// refusing hour-long masters that would decode to gigabytes.
+// This applies to FLAC, Ogg, and M4A — the formats that still need a real
+// decoder. MP3 no longer does: it reads its envelope out of frame side info
+// (see `extractMp3Envelope`) and streams with flat memory, which is why it is
+// exempt. That matters because MP3 was by far the worst case here, at roughly
+// twenty times the encoded size once decoded to float PCM against four to six
+// for the rest.
+//
+// The number that matters is still the decoded one: float PCM costs
+// `duration x sampleRate x channels x 4` bytes. A 16 MB FLAC is around three
+// minutes, decoding to ~60 MB inside the shared prerender pool alongside every
+// other render — enough for ordinary music and speech while refusing masters
+// that would decode to gigabytes.
 //
 // Over the ceiling is not a failure: the file still indexes with every
 // header-derived fact intact and records `skipped`, so a renderer can tell

--- a/packages/base/audio-waveform.ts
+++ b/packages/base/audio-waveform.ts
@@ -1,0 +1,229 @@
+// Browser-only enrichment: decode the audio and reduce it to a bounded
+// amplitude envelope.
+//
+// Unlike everything else in the `*-meta-extractor` modules, this cannot be done
+// by reading a header — it needs a real decoder, which means Web Audio. That is
+// available because the extract pass runs in the prerenderer's headless Chrome,
+// but it is the one audio fact that can legitimately be unavailable, so failure
+// is recorded on the field rather than thrown.
+//
+// The envelope is deliberately *not* a downsample of the opening seconds. It is
+// resampled across the whole signal, so a waveform drawn from it is recognizably
+// the shape of the track rather than the shape of its intro.
+
+// Fixed bar count so the stored payload is bounded regardless of duration: a
+// three-hour recording costs the same as a three-second one. 96 is enough to
+// read as a waveform at collection-cell width without being wasteful.
+export const WAVEFORM_BAR_COUNT = 96;
+
+// Names the reduction so a stored envelope stays interpretable. Bump it when the
+// algorithm changes so a consumer can tell an old envelope from a new one.
+export const WAVEFORM_ALGORITHM = 'rms-peak-v1';
+
+// Refuse to decode past this, measured on the *encoded* size because that is
+// what's known before committing to a decode.
+//
+// The number that matters is the decoded one, and it is much larger: float PCM
+// costs `duration × sampleRate × channels × 4` bytes, so a five-minute 44.1 kHz
+// stereo track is ~106 MB decoded from ~7 MB of MP3 — a factor of fifteen. This
+// runs inside the shared prerender pool during indexing, alongside every other
+// render, so the ceiling is set to admit ordinary music and speech while
+// refusing hour-long masters that would decode to gigabytes.
+//
+// Over the ceiling is not a failure: the file still indexes with every
+// header-derived fact intact and records `skipped`, so a renderer can tell
+// "too large to analyze" from "decode failed".
+export const WAVEFORM_MAX_ENCODED_BYTES = 16 * 1024 * 1024;
+
+export interface WaveformMetadata {
+  decodeStatus: 'ok' | 'unsupported' | 'failed' | 'skipped';
+  decodeError?: string;
+  algorithm?: string;
+  barsJson?: string;
+  barCount?: number;
+  durationSeconds?: number;
+  sampleRateHz?: number;
+  channelCount?: number;
+  peakAmplitude?: number;
+  rmsAmplitude?: number;
+}
+
+// The slice of `AudioBuffer` this needs, declared structurally so the module has
+// no dependency on DOM lib types and stays testable with a plain object.
+export interface DecodedAudioLike {
+  duration: number;
+  sampleRate: number;
+  numberOfChannels: number;
+  length: number;
+  getChannelData(channel: number): Float32Array;
+}
+
+function rounded(value: number, digits = 5): number {
+  let factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+// Reduce decoded PCM to `barCount` amplitude values.
+//
+// Each bar is the RMS of its window, not the peak: RMS tracks perceived loudness,
+// so quiet passages stay visibly quiet, whereas a peak-per-bar envelope saturates
+// to a solid block on anything mastered loud. The overall peak is reported
+// separately for callers that need headroom.
+//
+// All channels contribute to every bar. Reading only channel 0 would silently
+// misrepresent a track whose content is panned.
+export function analyzeDecodedAudio(
+  audio: DecodedAudioLike,
+  barCount = WAVEFORM_BAR_COUNT,
+): WaveformMetadata {
+  let channels = Math.max(1, audio.numberOfChannels);
+  let totalSamples = audio.length;
+  if (totalSamples <= 0 || barCount <= 0) {
+    return {
+      decodeStatus: 'ok',
+      algorithm: WAVEFORM_ALGORITHM,
+      barsJson: '[]',
+      barCount: 0,
+      durationSeconds: rounded(audio.duration, 3),
+      sampleRateHz: audio.sampleRate,
+      channelCount: audio.numberOfChannels,
+      peakAmplitude: 0,
+      rmsAmplitude: 0,
+    };
+  }
+
+  let channelData: Float32Array[] = [];
+  for (let channel = 0; channel < channels; channel++) {
+    channelData.push(audio.getChannelData(channel));
+  }
+
+  // Window boundaries are computed from the sample index rather than accumulated,
+  // so rounding never drifts and the last window always reaches the final sample.
+  let bars: number[] = [];
+  let overallPeak = 0;
+  let overallSquareSum = 0;
+  let overallCount = 0;
+
+  for (let bar = 0; bar < barCount; bar++) {
+    let start = Math.floor((bar * totalSamples) / barCount);
+    let end = Math.floor(((bar + 1) * totalSamples) / barCount);
+    if (end <= start) {
+      end = Math.min(start + 1, totalSamples);
+    }
+    let squareSum = 0;
+    let count = 0;
+    for (let channel = 0; channel < channels; channel++) {
+      let samples = channelData[channel];
+      if (!samples) {
+        continue;
+      }
+      for (let index = start; index < end && index < samples.length; index++) {
+        let sample = samples[index]!;
+        squareSum += sample * sample;
+        count++;
+        let magnitude = Math.abs(sample);
+        if (magnitude > overallPeak) {
+          overallPeak = magnitude;
+        }
+      }
+    }
+    overallSquareSum += squareSum;
+    overallCount += count;
+    bars.push(count > 0 ? rounded(Math.sqrt(squareSum / count), 4) : 0);
+  }
+
+  return {
+    decodeStatus: 'ok',
+    algorithm: WAVEFORM_ALGORITHM,
+    barsJson: JSON.stringify(bars),
+    barCount: bars.length,
+    durationSeconds: rounded(audio.duration, 3),
+    sampleRateHz: audio.sampleRate,
+    channelCount: audio.numberOfChannels,
+    peakAmplitude: rounded(overallPeak, 4),
+    rmsAmplitude:
+      overallCount > 0
+        ? rounded(Math.sqrt(overallSquareSum / overallCount), 4)
+        : 0,
+  };
+}
+
+// The Web Audio surface this needs, declared structurally for the same reason as
+// `DecodedAudioLike`: reaching for the global `AudioContext` type would put a DOM
+// dependency in a module the non-browser paths also load.
+interface AudioDecoderLike {
+  decodeAudioData(buffer: ArrayBuffer): Promise<DecodedAudioLike>;
+  close?: () => Promise<void> | void;
+}
+
+type AudioDecoderConstructor = new (options?: {
+  sampleRate?: number;
+}) => AudioDecoderLike;
+
+function audioDecoderConstructor(): AudioDecoderConstructor | undefined {
+  let scope = globalThis as unknown as {
+    OfflineAudioContext?: unknown;
+    AudioContext?: unknown;
+    webkitAudioContext?: unknown;
+  };
+  // An OfflineAudioContext decodes without touching an output device, which is
+  // what a headless indexing pass wants — a live AudioContext would try to open
+  // hardware. Fall back to the real thing where offline isn't available.
+  let candidate =
+    scope.OfflineAudioContext ?? scope.AudioContext ?? scope.webkitAudioContext;
+  return typeof candidate === 'function'
+    ? (candidate as AudioDecoderConstructor)
+    : undefined;
+}
+
+// Decode `bytes` and reduce them to an envelope. Never throws: every failure
+// mode becomes a recorded status, because a file whose audio won't decode should
+// still index with its header-derived metadata intact.
+export async function extractAudioWaveform(
+  bytes: Uint8Array,
+  barCount = WAVEFORM_BAR_COUNT,
+): Promise<WaveformMetadata> {
+  if (bytes.byteLength === 0) {
+    return { decodeStatus: 'skipped', decodeError: 'File is empty' };
+  }
+  if (bytes.byteLength > WAVEFORM_MAX_ENCODED_BYTES) {
+    return {
+      decodeStatus: 'skipped',
+      decodeError: `File exceeds the ${Math.floor(
+        WAVEFORM_MAX_ENCODED_BYTES / (1024 * 1024),
+      )} MB decode ceiling`,
+    };
+  }
+  let Decoder = audioDecoderConstructor();
+  if (!Decoder) {
+    return {
+      decodeStatus: 'unsupported',
+      decodeError: 'Web Audio is not available in this environment',
+    };
+  }
+
+  let context: AudioDecoderLike | undefined;
+  try {
+    context = new Decoder();
+    // `decodeAudioData` detaches the buffer it is given, so hand it a copy —
+    // otherwise the caller's bytes, which other extractors still need to read,
+    // come back as a zero-length view.
+    let copy = bytes.slice().buffer;
+    let decoded = await context.decodeAudioData(copy);
+    return analyzeDecodedAudio(decoded, barCount);
+  } catch (error) {
+    return {
+      decodeStatus: 'failed',
+      decodeError:
+        error instanceof Error
+          ? error.message
+          : `Audio decode failed: ${String(error)}`,
+    };
+  } finally {
+    try {
+      await context?.close?.();
+    } catch {
+      // A context that won't close is not worth failing an index pass over.
+    }
+  }
+}

--- a/packages/base/file-formats/metadata-fields.gts
+++ b/packages/base/file-formats/metadata-fields.gts
@@ -22,6 +22,7 @@ import MapPinIcon from '@cardstack/boxel-icons/map-pin';
 import PaletteIcon from '@cardstack/boxel-icons/palette';
 import RulerIcon from '@cardstack/boxel-icons/ruler';
 import TagIcon from '@cardstack/boxel-icons/tag';
+import KeyboardMusicIcon from '@cardstack/boxel-icons/keyboard-music';
 import TagsIcon from '@cardstack/boxel-icons/tags';
 
 import FileInfoIcon from '@cardstack/boxel-icons/file-info';
@@ -33,6 +34,7 @@ import {
   StringField,
   TextAreaField,
   contains,
+  containsMany,
   field,
 } from '../card-api';
 import BooleanField from '../boolean';
@@ -761,6 +763,119 @@ export class WaveformMetadataField extends FieldDef {
         }
         .decode-error {
           color: var(--destructive, var(--foreground));
+        }
+      </style>
+    </template>
+  };
+}
+
+// What a MIDI file will play. Symbolic performance data, not encoded audio —
+// there is no sample rate or amplitude here, because a MIDI file has no sound
+// until a synthesizer gives it one. That's why it is a family of its own rather
+// than a variety of `MediaEncodingField`.
+export class MidiMetadataField extends FieldDef {
+  static displayName = 'MIDI Metadata';
+  static icon = KeyboardMusicIcon;
+
+  // 0 = single track, 1 = simultaneous tracks, 2 = independent sequences.
+  @field format = contains(NumberField);
+  // Ticks per quarter note. Unset for a file timed in SMPTE timecode instead,
+  // where ticks don't convert to musical time.
+  @field ppq = contains(NumberField);
+  @field durationSeconds = contains(NumberField);
+  // What the header declares, which is usually more than actually sound: a
+  // format 1 file's first track conventionally holds only tempo and meter.
+  @field fileTrackCount = contains(NumberField);
+  @field trackCount = contains(NumberField);
+  @field noteCount = contains(NumberField);
+  @field tempoMap = containsMany(StringField);
+  @field timeSignatures = containsMany(StringField);
+  @field keySignatures = containsMany(StringField);
+  // General MIDI program numbers, excluding the percussion channel where a
+  // program names a drum kit rather than an instrument.
+  @field programs = containsMany(NumberField);
+  @field channels = containsMany(NumberField);
+  @field pitchRange = contains(StringField);
+  @field hasPercussion = contains(BooleanField);
+
+  static embedded = class Embedded extends Component<
+    typeof MidiMetadataField
+  > {
+    <template>
+      <dl class='metadata-rows'>
+        {{#if @model.trackCount}}
+          <div class='row'><dt>Tracks</dt><dd>{{@model.trackCount}}{{#if
+                @model.fileTrackCount
+              }}
+                of
+                {{@model.fileTrackCount}}{{/if}}</dd></div>
+        {{/if}}
+        {{#if @model.noteCount}}
+          <div class='row'><dt>Notes</dt><dd>{{@model.noteCount}}</dd></div>
+        {{/if}}
+        {{#if @model.durationSeconds}}
+          <div class='row'><dt>Duration</dt><dd>{{@model.durationSeconds}} s</dd></div>
+        {{/if}}
+        {{#if @model.keySignatures.length}}
+          <div class='row'><dt>Key</dt><dd class='list'>{{#each
+                @model.keySignatures as |key|
+              }}<span>{{key}}</span>{{/each}}</dd></div>
+        {{/if}}
+        {{#if @model.timeSignatures.length}}
+          <div class='row'><dt>Meter</dt><dd class='list'>{{#each
+                @model.timeSignatures as |meter|
+              }}<span>{{meter}}</span>{{/each}}</dd></div>
+        {{/if}}
+        {{#if @model.pitchRange}}
+          <div class='row'><dt>Range</dt><dd>{{@model.pitchRange}}</dd></div>
+        {{/if}}
+        {{#if @model.tempoMap.length}}
+          <div class='row'><dt>Tempo</dt><dd class='list'>{{#each
+                @model.tempoMap as |tempo|
+              }}<span>{{tempo}}</span>{{/each}}</dd></div>
+        {{/if}}
+        {{#if @model.channels.length}}
+          <div class='row'><dt>Channels</dt><dd class='list'>{{#each
+                @model.channels as |channel|
+              }}<span>{{channel}}</span>{{/each}}</dd></div>
+        {{/if}}
+        <div class='row'><dt>Percussion</dt><dd>{{if
+              @model.hasPercussion
+              'Yes'
+              'No'
+            }}</dd></div>
+      </dl>
+      <style scoped>
+        .metadata-rows {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.3125rem;
+          font-size: 0.75rem;
+        }
+        .row {
+          display: flex;
+          gap: 0.625rem;
+          align-items: baseline;
+        }
+        dt {
+          flex: 0 0 5.75rem;
+          font-family: var(--font-mono);
+          font-size: 0.5625rem;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: var(--muted-foreground);
+        }
+        dd {
+          margin: 0;
+          min-width: 0;
+          overflow-wrap: anywhere;
+        }
+        /* Several values on one row read as a list, not a run-on string. */
+        .list {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.125rem 0.5rem;
         }
       </style>
     </template>

--- a/packages/base/file-formats/metadata-fields.gts
+++ b/packages/base/file-formats/metadata-fields.gts
@@ -15,11 +15,14 @@
 // in the deps of every card in every realm. A family attaches its metadata on
 // its own subclass module instead, so only realms holding that file type pay.
 
+import AudioWaveformIcon from '@cardstack/boxel-icons/audio-waveform';
 import CameraIcon from '@cardstack/boxel-icons/camera';
+import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
 import MapPinIcon from '@cardstack/boxel-icons/map-pin';
 import PaletteIcon from '@cardstack/boxel-icons/palette';
 import RulerIcon from '@cardstack/boxel-icons/ruler';
 import TagIcon from '@cardstack/boxel-icons/tag';
+import TagsIcon from '@cardstack/boxel-icons/tags';
 
 import FileInfoIcon from '@cardstack/boxel-icons/file-info';
 
@@ -28,6 +31,7 @@ import {
   FieldDef,
   NumberField,
   StringField,
+  TextAreaField,
   contains,
   field,
 } from '../card-api';
@@ -65,6 +69,24 @@ export const METADATA_VOCABULARIES: Record<
     'exif-gps': 'EXIF GPS IFD',
     'ios-photos': 'iOS Photos convention',
     'android-photos': 'Android Photos convention',
+  },
+  // Which tagging convention the track's descriptive metadata came from. Worth
+  // recording because the schemes disagree about what a field means — an ID3v2
+  // `TRCK` is "4/12" while an MP4 `trkn` atom is a pair of integers — so a
+  // consumer comparing two files needs to know which it is reading.
+  'tag-scheme': {
+    id3v2: 'ID3v2',
+    'riff-info': 'RIFF LIST-INFO',
+    'mp4-atoms': 'MP4 metadata atoms',
+    'vorbis-comment': 'Vorbis comment',
+    xmp: 'XMP',
+  },
+  'channel-mode': {
+    mono: 'Mono',
+    stereo: 'Stereo',
+    'joint-stereo': 'Joint stereo',
+    'dual-mono': 'Dual mono',
+    surround: 'Surround',
   },
   'color-space': {
     srgb: 'sRGB',
@@ -460,6 +482,285 @@ export class ExifMetadataField extends FieldDef {
         .exif {
           display: grid;
           gap: 0.75rem;
+        }
+      </style>
+    </template>
+  };
+}
+
+// How a media stream is encoded. Shared by sampled audio and, as that family
+// lands, video — a sample rate means the same thing in an MP3 and in an MP4's
+// audio track, so asking "what was this encoded at" shouldn't depend on the
+// container.
+//
+// Fields a given container cannot state are left unset. FLAC declares its bit
+// depth outright; MP3 has no such concept, and reporting a plausible 16 would
+// invent a fact the file never carried.
+export class MediaEncodingField extends FieldDef {
+  static displayName = 'Media Encoding';
+  static icon = FileAudioIcon;
+
+  @field container = contains(StringField);
+  @field audioCodec = contains(StringField);
+  @field sampleRate = contains(QuantityField);
+  @field bitrate = contains(QuantityField);
+  @field bitDepth = contains(NumberField);
+  @field channels = contains(NumberField);
+  @field channelMode = contains(CodedValueField);
+  // Whether the bitrate figure describes the whole stream or one frame of it.
+  // A VBR file's per-frame bitrate says almost nothing about the file, so a
+  // consumer comparing two numbers needs to know which kind it has.
+  @field isVariableBitrate = contains(BooleanField);
+
+  static embedded = class Embedded extends Component<
+    typeof MediaEncodingField
+  > {
+    <template>
+      <dl class='metadata-rows'>
+        {{#if @model.container}}
+          <div class='row'><dt>Container</dt><dd
+              class='mono'
+            >{{@model.container}}</dd></div>
+        {{/if}}
+        {{#if @model.audioCodec}}
+          <div class='row'><dt>Codec</dt><dd class='mono'>{{@model.audioCodec}}</dd></div>
+        {{/if}}
+        {{#if @model.sampleRate.display}}
+          <div class='row'><dt>Sample rate</dt><dd><@fields.sampleRate
+              /></dd></div>
+        {{/if}}
+        {{#if @model.bitrate.display}}
+          <div class='row'><dt>Bitrate</dt><dd><@fields.bitrate />{{#if
+                @model.isVariableBitrate
+              }}<span class='qualifier'>VBR</span>{{/if}}</dd></div>
+        {{/if}}
+        {{#if @model.bitDepth}}
+          <div class='row'><dt>Bit depth</dt><dd>{{@model.bitDepth}}-bit</dd></div>
+        {{/if}}
+        {{#if @model.channels}}
+          <div class='row'><dt>Channels</dt><dd>{{@model.channels}}{{#if
+                @model.channelMode.label
+              }}<span class='qualifier'><@fields.channelMode
+                /></span>{{/if}}</dd></div>
+        {{/if}}
+      </dl>
+      <style scoped>
+        .metadata-rows {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.3125rem;
+          font-size: 0.75rem;
+        }
+        .row {
+          display: flex;
+          gap: 0.625rem;
+          align-items: baseline;
+        }
+        dt {
+          flex: 0 0 5.75rem;
+          font-family: var(--font-mono);
+          font-size: 0.5625rem;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: var(--muted-foreground);
+        }
+        dd {
+          margin: 0;
+          min-width: 0;
+        }
+        .mono {
+          font-family: var(--font-mono);
+          font-size: 0.6875rem;
+        }
+        .qualifier {
+          margin-left: 0.375rem;
+          font-size: 0.6875rem;
+          color: var(--muted-foreground);
+        }
+      </style>
+    </template>
+  };
+}
+
+// What a track says about itself. One shape across every tagging convention;
+// `scheme` records which one supplied the values, because the conventions
+// disagree on meaning — an ID3v2 `TRCK` is the string "4/12" while an MP4 `trkn`
+// atom is a pair of integers — so `track` stays a string rather than being
+// coerced into a number that loses the total.
+export class MediaTagsField extends FieldDef {
+  static displayName = 'Media Tags';
+  static icon = TagsIcon;
+
+  @field scheme = contains(CodedValueField);
+  // Not `title`: FileDef's own name is the file's identity, and a field called
+  // `title` here would read as though it renamed the file.
+  @field trackTitle = contains(StringField);
+  @field artist = contains(StringField);
+  @field album = contains(StringField);
+  @field albumArtist = contains(StringField);
+  @field composer = contains(StringField);
+  @field year = contains(NumberField);
+  @field track = contains(StringField);
+  @field disc = contains(StringField);
+  @field genre = contains(StringField);
+  @field comment = contains(TextAreaField);
+
+  static embedded = class Embedded extends Component<typeof MediaTagsField> {
+    <template>
+      <dl class='metadata-rows'>
+        {{#if @model.trackTitle}}
+          <div class='row'><dt>Title</dt><dd>{{@model.trackTitle}}</dd></div>
+        {{/if}}
+        {{#if @model.artist}}
+          <div class='row'><dt>Artist</dt><dd>{{@model.artist}}</dd></div>
+        {{/if}}
+        {{#if @model.album}}
+          <div class='row'><dt>Album</dt><dd>{{@model.album}}</dd></div>
+        {{/if}}
+        {{#if @model.albumArtist}}
+          <div class='row'><dt>Album artist</dt><dd>{{@model.albumArtist}}</dd></div>
+        {{/if}}
+        {{#if @model.composer}}
+          <div class='row'><dt>Composer</dt><dd>{{@model.composer}}</dd></div>
+        {{/if}}
+        {{#if @model.year}}
+          <div class='row'><dt>Year</dt><dd>{{@model.year}}</dd></div>
+        {{/if}}
+        {{#if @model.track}}
+          <div class='row'><dt>Track</dt><dd>{{@model.track}}</dd></div>
+        {{/if}}
+        {{#if @model.disc}}
+          <div class='row'><dt>Disc</dt><dd>{{@model.disc}}</dd></div>
+        {{/if}}
+        {{#if @model.genre}}
+          <div class='row'><dt>Genre</dt><dd>{{@model.genre}}</dd></div>
+        {{/if}}
+        {{#if @model.comment}}
+          <div class='row'><dt>Comment</dt><dd>{{@model.comment}}</dd></div>
+        {{/if}}
+        {{#if @model.scheme.label}}
+          <div class='row'><dt>Scheme</dt><dd><@fields.scheme /></dd></div>
+        {{/if}}
+      </dl>
+      <style scoped>
+        .metadata-rows {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.3125rem;
+          font-size: 0.75rem;
+        }
+        .row {
+          display: flex;
+          gap: 0.625rem;
+          align-items: baseline;
+        }
+        dt {
+          flex: 0 0 5.75rem;
+          font-family: var(--font-mono);
+          font-size: 0.5625rem;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: var(--muted-foreground);
+        }
+        dd {
+          margin: 0;
+          min-width: 0;
+          overflow-wrap: anywhere;
+        }
+      </style>
+    </template>
+  };
+}
+
+// A decoded amplitude envelope, produced by actually decoding the audio rather
+// than by reading a header — so unlike every other field here it depends on Web
+// Audio being available, and records why it isn't when it fails.
+//
+// `bars` is the envelope itself, resampled at extract time to a fixed count so
+// the stored payload is bounded no matter how long the track is. It is stored as
+// a JSON string rather than a `containsMany(NumberField)` deliberately: a
+// hundred-odd separate field instances would cost far more to serialize, index,
+// and rehydrate than one short string, and nothing queries an individual bar.
+export class WaveformMetadataField extends FieldDef {
+  static displayName = 'Waveform Analysis';
+  static icon = AudioWaveformIcon;
+
+  // 'ok' | 'unsupported' | 'failed' — a renderer needs to tell "no waveform yet"
+  // from "this file cannot produce one", and an operator needs to know which.
+  @field decodeStatus = contains(StringField);
+  @field decodeError = contains(StringField);
+  // Names the resampling so a stored envelope stays interpretable if the
+  // algorithm changes; a consumer can tell an old envelope from a new one.
+  @field algorithm = contains(StringField);
+  @field barsJson = contains(TextAreaField);
+  @field barCount = contains(NumberField);
+  @field durationSeconds = contains(NumberField);
+  @field sampleRateHz = contains(NumberField);
+  @field channelCount = contains(NumberField);
+  @field peakAmplitude = contains(NumberField);
+  @field rmsAmplitude = contains(NumberField);
+
+  static embedded = class Embedded extends Component<
+    typeof WaveformMetadataField
+  > {
+    <template>
+      <dl class='metadata-rows'>
+        {{#if @model.decodeStatus}}
+          <div class='row'><dt>Status</dt><dd>{{@model.decodeStatus}}</dd></div>
+        {{/if}}
+        {{#if @model.barCount}}
+          <div class='row'><dt>Envelope</dt><dd>{{@model.barCount}} bars ·
+              {{@model.algorithm}}</dd></div>
+        {{/if}}
+        {{#if @model.durationSeconds}}
+          <div class='row'><dt>Duration</dt><dd>{{@model.durationSeconds}} s</dd></div>
+        {{/if}}
+        {{#if @model.sampleRateHz}}
+          <div class='row'><dt>Sample rate</dt><dd>{{@model.sampleRateHz}} Hz</dd></div>
+        {{/if}}
+        {{#if @model.channelCount}}
+          <div class='row'><dt>Channels</dt><dd>{{@model.channelCount}}</dd></div>
+        {{/if}}
+        {{#if @model.peakAmplitude}}
+          <div class='row'><dt>Peak</dt><dd>{{@model.peakAmplitude}}</dd></div>
+        {{/if}}
+        {{#if @model.rmsAmplitude}}
+          <div class='row'><dt>RMS</dt><dd>{{@model.rmsAmplitude}}</dd></div>
+        {{/if}}
+        {{#if @model.decodeError}}
+          <div class='row'><dt>Decode</dt><dd class='decode-error'>{{@model.decodeError}}</dd></div>
+        {{/if}}
+      </dl>
+      <style scoped>
+        .metadata-rows {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.3125rem;
+          font-size: 0.75rem;
+        }
+        .row {
+          display: flex;
+          gap: 0.625rem;
+          align-items: baseline;
+        }
+        dt {
+          flex: 0 0 5.75rem;
+          font-family: var(--font-mono);
+          font-size: 0.5625rem;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: var(--muted-foreground);
+        }
+        dd {
+          margin: 0;
+          min-width: 0;
+          overflow-wrap: anywhere;
+        }
+        .decode-error {
+          color: var(--destructive, var(--foreground));
         }
       </style>
     </template>

--- a/packages/base/flac-audio-def.gts
+++ b/packages/base/flac-audio-def.gts
@@ -7,14 +7,15 @@ import AudioDef, {
 } from './audio-file-def';
 import type { ByteStream, SerializedFile } from './file-api';
 import {
+  FLAC_METADATA_WINDOW_BYTES,
   extractFlacDuration,
   extractFlacEncoding,
   extractFlacTags,
 } from './flac-meta-extractor';
 
-// "fLaC" marker (4) + STREAMINFO block header (4) + STREAMINFO data (34) = 42.
-// Round up to leave room for stream-chunking artefacts.
-const FLAC_MAX_HEADER_BYTES = 256;
+// The encoding read needs only STREAMINFO, 42 bytes in — but the tag read needs
+// the VORBIS_COMMENT block, which sits behind whatever other metadata blocks the
+// encoder wrote. See `FLAC_METADATA_WINDOW_BYTES` for why that is much further.
 
 export class FlacDef extends AudioDef {
   static displayName = 'FLAC Audio';
@@ -27,7 +28,10 @@ export class FlacDef extends AudioDef {
     options: { contentHash?: string; contentSize?: number } = {},
   ): Promise<SerializedFile<{ duration: number } & AudioAttributes>> {
     let base = await super.extractAttributes(url, getStream, options);
-    let bytes = await readFirstBytes(await getStream(), FLAC_MAX_HEADER_BYTES);
+    let bytes = await readFirstBytes(
+      await getStream(),
+      FLAC_METADATA_WINDOW_BYTES,
+    );
     let { duration } = extractFlacDuration(bytes);
 
     return {

--- a/packages/base/flac-audio-def.gts
+++ b/packages/base/flac-audio-def.gts
@@ -34,13 +34,22 @@ export class FlacDef extends AudioDef {
     );
     let { duration } = extractFlacDuration(bytes);
 
+    // Bound before the waveform call so the decode budget can be predicted from
+    // the sample rate and channel count the container already stated.
+    let encoding = extractFlacEncoding(bytes);
+
     return {
       ...base,
       duration,
       ...audioAttributes(
-        extractFlacEncoding(bytes),
+        encoding,
         extractFlacTags(bytes),
-        await waveformFor(getStream, base.contentSize),
+        await waveformFor(getStream, {
+          durationSeconds: duration,
+          sampleRateHz: encoding?.sampleRateHz,
+          channels: encoding?.channels,
+          contentSize: base.contentSize,
+        }),
       ),
     };
   }

--- a/packages/base/flac-audio-def.gts
+++ b/packages/base/flac-audio-def.gts
@@ -1,8 +1,16 @@
 import { readFirstBytes } from '@cardstack/runtime-common';
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
-import AudioDef from './audio-file-def';
+import AudioDef, {
+  audioAttributes,
+  waveformFor,
+  type AudioAttributes,
+} from './audio-file-def';
 import type { ByteStream, SerializedFile } from './file-api';
-import { extractFlacDuration } from './flac-meta-extractor';
+import {
+  extractFlacDuration,
+  extractFlacEncoding,
+  extractFlacTags,
+} from './flac-meta-extractor';
 
 // "fLaC" marker (4) + STREAMINFO block header (4) + STREAMINFO data (34) = 42.
 // Round up to leave room for stream-chunking artefacts.
@@ -16,8 +24,8 @@ export class FlacDef extends AudioDef {
   static async extractAttributes(
     url: string,
     getStream: () => Promise<ByteStream>,
-    options: { contentHash?: string } = {},
-  ): Promise<SerializedFile<{ duration: number }>> {
+    options: { contentHash?: string; contentSize?: number } = {},
+  ): Promise<SerializedFile<{ duration: number } & AudioAttributes>> {
     let base = await super.extractAttributes(url, getStream, options);
     let bytes = await readFirstBytes(await getStream(), FLAC_MAX_HEADER_BYTES);
     let { duration } = extractFlacDuration(bytes);
@@ -25,6 +33,11 @@ export class FlacDef extends AudioDef {
     return {
       ...base,
       duration,
+      ...audioAttributes(
+        extractFlacEncoding(bytes),
+        extractFlacTags(bytes),
+        await waveformFor(getStream, base.contentSize),
+      ),
     };
   }
 }

--- a/packages/base/flac-meta-extractor.ts
+++ b/packages/base/flac-meta-extractor.ts
@@ -1,4 +1,11 @@
+import {
+  channelModeForCount,
+  prunedEncoding,
+  type AudioEncoding,
+  type MediaTags,
+} from './audio-metadata';
 import { FileContentMismatchError } from './file-api';
+import { parseVorbisComments } from './vorbis-comment-parser';
 
 // FLAC stream marker: "fLaC"
 const FLAC_MARKER = [0x66, 0x4c, 0x61, 0x43];
@@ -88,4 +95,89 @@ export function extractFlacDuration(bytes: Uint8Array): { duration: number } {
   }
 
   return { duration: totalSamples / sampleRate };
+}
+
+const VORBIS_COMMENT_BLOCK_TYPE = 4;
+
+// Guards the walk when a block length is garbage. A real file has a handful.
+const MAX_METADATA_BLOCKS = 128;
+
+// Walk FLAC's metadata blocks. Each header is four bytes: one flag bit marking
+// the last block, seven bits of block type, then a 24-bit big-endian length.
+//
+// Never throws — an absent or truncated block is ordinary, and the duration
+// reader is what decides whether a file is really FLAC.
+function walkFlacBlocks(
+  bytes: Uint8Array,
+  visit: (blockType: number, dataStart: number, dataLength: number) => void,
+): void {
+  if (!matchMarker(bytes)) {
+    return;
+  }
+  let cursor = FLAC_MARKER.length;
+  for (let block = 0; block < MAX_METADATA_BLOCKS; block++) {
+    if (cursor + METADATA_BLOCK_HEADER_BYTES > bytes.length) {
+      return;
+    }
+    let header = bytes[cursor]!;
+    let isLast = (header & 0x80) !== 0;
+    let blockType = header & 0x7f;
+    let length =
+      (bytes[cursor + 1]! << 16) |
+      (bytes[cursor + 2]! << 8) |
+      bytes[cursor + 3]!;
+    let dataStart = cursor + METADATA_BLOCK_HEADER_BYTES;
+    visit(blockType, dataStart, length);
+    if (isLast) {
+      return;
+    }
+    cursor = dataStart + length;
+  }
+}
+
+// STREAMINFO states the sample layout outright. FLAC is lossless, so there is no
+// meaningful constant bitrate to report — the compressed rate varies with the
+// signal, and the file never states it.
+export function extractFlacEncoding(
+  bytes: Uint8Array,
+): AudioEncoding | undefined {
+  if (
+    !matchMarker(bytes) ||
+    FLAC_MARKER.length + METADATA_BLOCK_HEADER_BYTES + STREAMINFO_BLOCK_BYTES >
+      bytes.length
+  ) {
+    return undefined;
+  }
+  if ((bytes[FLAC_MARKER.length]! & 0x7f) !== STREAMINFO_BLOCK_TYPE) {
+    return undefined;
+  }
+  let p =
+    FLAC_MARKER.length + METADATA_BLOCK_HEADER_BYTES + PACKED_FIELD_OFFSET;
+  // bits 0..19 sampleRate, 20..22 channels-1, 23..27 bitsPerSample-1
+  let sampleRate =
+    (bytes[p]! << 12) | (bytes[p + 1]! << 4) | (bytes[p + 2]! >> 4);
+  let channels = ((bytes[p + 2]! >> 1) & 0x07) + 1;
+  let bitsPerSample =
+    (((bytes[p + 2]! & 0x01) << 4) | (bytes[p + 3]! >> 4)) + 1;
+
+  return prunedEncoding({
+    container: 'FLAC',
+    audioCodec: 'FLAC',
+    sampleRateHz: sampleRate > 0 ? sampleRate : undefined,
+    isVariableBitrate: true,
+    bitDepth: bitsPerSample,
+    channels,
+    channelMode: channelModeForCount(channels),
+  });
+}
+
+export function extractFlacTags(bytes: Uint8Array): MediaTags | undefined {
+  let tags: MediaTags | undefined;
+  walkFlacBlocks(bytes, (blockType, dataStart, dataLength) => {
+    if (blockType !== VORBIS_COMMENT_BLOCK_TYPE || tags) {
+      return;
+    }
+    tags = parseVorbisComments(bytes, dataStart, dataStart + dataLength)?.tags;
+  });
+  return tags;
 }

--- a/packages/base/flac-meta-extractor.ts
+++ b/packages/base/flac-meta-extractor.ts
@@ -99,6 +99,21 @@ export function extractFlacDuration(bytes: Uint8Array): { duration: number } {
 
 const VORBIS_COMMENT_BLOCK_TYPE = 4;
 
+// How much of the file the tag read needs.
+//
+// STREAMINFO is only 42 bytes in, but VORBIS_COMMENT is not: metadata blocks
+// appear in whatever order the encoder wrote them, and a SEEKTABLE — which most
+// rippers emit — sits ahead of the comments at 18 bytes per seek point, putting
+// them tens of kilobytes deep. A realistic tag set is itself well over half a
+// kilobyte once a vendor string, MusicBrainz ids, and ReplayGain values are
+// counted.
+//
+// A window that falls short doesn't error, it just silently yields no tags, so
+// this is sized to clear an ordinary seek table and comment block by a wide
+// margin. A file with cover art ahead of its comments can still exceed it; the
+// cost of missing that is tags, not correctness.
+export const FLAC_METADATA_WINDOW_BYTES = 1_048_576;
+
 // Guards the walk when a block length is garbage. A real file has a handful.
 const MAX_METADATA_BLOCKS = 128;
 

--- a/packages/base/id3v2-parser.ts
+++ b/packages/base/id3v2-parser.ts
@@ -1,0 +1,251 @@
+// ID3v2 tags, as MP3 files carry them. The tag sits at the very start of the
+// file, ahead of the first MPEG frame, so `mp3-meta-extractor` already skips
+// past it to find the audio — this reads what it skips.
+//
+// Pure `DataView`/`TextDecoder`, no DOM.
+
+import { parseTagYear, prunedTags, type MediaTags } from './audio-metadata';
+
+const ID3_IDENTIFIER = [0x49, 0x44, 0x33]; // "ID3"
+const HEADER_BYTES = 10;
+
+// A frame larger than this is embedded artwork (`APIC`) or a corrupt length.
+// Descriptive text frames are far smaller.
+const MAX_FRAME_BYTES = 65_536;
+
+// Guards the walk when a size field is garbage. A real tag has a few dozen.
+const MAX_FRAMES = 256;
+
+// ID3v2 text frames declare their own encoding in a leading byte.
+const ENCODING_LATIN1 = 0;
+const ENCODING_UTF16_BOM = 1;
+const ENCODING_UTF16_BE = 2;
+const ENCODING_UTF8 = 3;
+
+// v2.3/v2.4 four-character frame IDs, mapped onto the shared tag shape.
+const FRAME_ALIASES: Record<string, keyof MediaTags> = {
+  TIT2: 'trackTitle',
+  TPE1: 'artist',
+  TPE2: 'albumArtist',
+  TALB: 'album',
+  TCOM: 'composer',
+  TRCK: 'track',
+  TPOS: 'disc',
+  TCON: 'genre',
+  COMM: 'comment',
+  // v2.4 replaced TYER with TDRC; files in the wild carry either.
+  TDRC: 'year',
+  TYER: 'year',
+};
+
+// The v2.2 equivalents, which use three-character IDs and a three-byte size.
+const FRAME_ALIASES_V2: Record<string, keyof MediaTags> = {
+  TT2: 'trackTitle',
+  TP1: 'artist',
+  TP2: 'albumArtist',
+  TAL: 'album',
+  TCM: 'composer',
+  TRK: 'track',
+  TPA: 'disc',
+  TCO: 'genre',
+  COM: 'comment',
+  TYE: 'year',
+};
+
+// UTF-16 text is terminated by a NUL *pair*, everything else by a single NUL.
+// Getting this wrong is what makes a UTF-16 tag read as one character.
+function isWideEncoding(encoding: number): boolean {
+  return encoding === ENCODING_UTF16_BOM || encoding === ENCODING_UTF16_BE;
+}
+
+function decoderLabelFor(encoding: number): string {
+  switch (encoding) {
+    case ENCODING_UTF16_BOM:
+      // The BOM decides byte order; TextDecoder consumes and honors it.
+      return 'utf-16';
+    case ENCODING_UTF16_BE:
+      return 'utf-16be';
+    case ENCODING_UTF8:
+      return 'utf-8';
+    case ENCODING_LATIN1:
+    default:
+      // An unknown encoding byte is treated as Latin-1, which never throws and
+      // leaves ASCII — what almost every such frame actually holds — intact.
+      return 'latin1';
+  }
+}
+
+// Decode one text run, stopping at its terminator. A v2.4 frame may hold several
+// NUL-separated values; the first is the one to show, because joining them would
+// invent a credit the file never stated.
+function decodeRun(encoding: number, payload: Uint8Array): string {
+  let end = payload.length;
+  if (isWideEncoding(encoding)) {
+    for (let index = 0; index + 1 < payload.length; index += 2) {
+      if (payload[index] === 0 && payload[index + 1] === 0) {
+        end = index;
+        break;
+      }
+    }
+  } else {
+    let terminator = payload.indexOf(0);
+    if (terminator !== -1) {
+      end = terminator;
+    }
+  }
+  let run = payload.subarray(0, end);
+  try {
+    return new TextDecoder(decoderLabelFor(encoding), { fatal: false })
+      .decode(run)
+      .trim();
+  } catch {
+    return new TextDecoder('latin1').decode(run).trim();
+  }
+}
+
+// A text frame is an encoding byte followed by the text itself.
+function decodeText(bytes: Uint8Array): string {
+  if (bytes.length < 2) {
+    return '';
+  }
+  return decodeRun(bytes[0]!, bytes.subarray(1));
+}
+
+// A COMM frame is an encoding byte, a three-byte language code, a terminated
+// short description, and then the comment. The description is stepped over in
+// bytes rather than in decoded text, so the terminator width is unambiguous.
+function decodeComment(bytes: Uint8Array): string {
+  if (bytes.length < 5) {
+    return '';
+  }
+  let encoding = bytes[0]!;
+  let cursor = 4;
+  if (isWideEncoding(encoding)) {
+    while (
+      cursor + 1 < bytes.length &&
+      !(bytes[cursor] === 0 && bytes[cursor + 1] === 0)
+    ) {
+      cursor += 2;
+    }
+    cursor += 2;
+  } else {
+    while (cursor < bytes.length && bytes[cursor] !== 0) {
+      cursor += 1;
+    }
+    cursor += 1;
+  }
+  if (cursor >= bytes.length) {
+    return '';
+  }
+  return decodeRun(encoding, bytes.subarray(cursor));
+}
+
+// Sizes in the v2.4 frame header and in every version's tag header are
+// "syncsafe": seven bits per byte, so the bytes can never look like a frame sync.
+function syncsafeSize(bytes: Uint8Array, offset: number): number {
+  return (
+    ((bytes[offset]! & 0x7f) << 21) |
+    ((bytes[offset + 1]! & 0x7f) << 14) |
+    ((bytes[offset + 2]! & 0x7f) << 7) |
+    (bytes[offset + 3]! & 0x7f)
+  );
+}
+
+// Read the ID3v2 tag at the start of `bytes`. Returns undefined when there is
+// none, which is ordinary for a stripped or freshly encoded file.
+export function parseId3v2Tags(bytes: Uint8Array): MediaTags | undefined {
+  if (bytes.byteLength < HEADER_BYTES) {
+    return undefined;
+  }
+  if (!ID3_IDENTIFIER.every((expected, index) => bytes[index] === expected)) {
+    return undefined;
+  }
+  let majorVersion = bytes[3]!;
+  let flags = bytes[5]!;
+  let tagSize = syncsafeSize(bytes, 6);
+  let tagEnd = Math.min(HEADER_BYTES + tagSize, bytes.byteLength);
+
+  let cursor = HEADER_BYTES;
+  // An extended header, when present, sits between the tag header and the first
+  // frame and declares its own size.
+  if ((flags & 0x40) !== 0) {
+    if (cursor + 4 > tagEnd) {
+      return undefined;
+    }
+    let extendedSize =
+      majorVersion >= 4
+        ? syncsafeSize(bytes, cursor)
+        : new DataView(
+            bytes.buffer,
+            bytes.byteOffset,
+            bytes.byteLength,
+          ).getUint32(cursor) + 4;
+    cursor += extendedSize;
+  }
+
+  let isV22 = majorVersion === 2;
+  let idLength = isV22 ? 3 : 4;
+  let headerLength = isV22 ? 6 : 10;
+  let aliases = isV22 ? FRAME_ALIASES_V2 : FRAME_ALIASES;
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+  let collected: MediaTags = {};
+  let years: string[] = [];
+  for (let frame = 0; frame < MAX_FRAMES; frame++) {
+    if (cursor + headerLength > tagEnd) {
+      break;
+    }
+    // A run of zero bytes is the tag's padding, not another frame.
+    if (bytes[cursor] === 0) {
+      break;
+    }
+    let id = String.fromCharCode(...bytes.subarray(cursor, cursor + idLength));
+    let frameSize: number;
+    if (isV22) {
+      frameSize =
+        (bytes[cursor + 3]! << 16) |
+        (bytes[cursor + 4]! << 8) |
+        bytes[cursor + 5]!;
+    } else if (majorVersion >= 4) {
+      frameSize = syncsafeSize(bytes, cursor + 4);
+    } else {
+      // v2.3 frame sizes are plain big-endian, not syncsafe.
+      frameSize = view.getUint32(cursor + 4);
+    }
+    let payloadStart = cursor + headerLength;
+    if (frameSize <= 0 || payloadStart + frameSize > tagEnd) {
+      break;
+    }
+    cursor = payloadStart + frameSize;
+
+    let target = aliases[id];
+    if (!target || frameSize > MAX_FRAME_BYTES) {
+      continue;
+    }
+    let payload = bytes.subarray(payloadStart, payloadStart + frameSize);
+    let value =
+      id === 'COMM' || id === 'COM'
+        ? decodeComment(payload)
+        : decodeText(payload);
+    if (!value) {
+      continue;
+    }
+    if (target === 'year') {
+      years.push(value);
+      continue;
+    }
+    if (collected[target] === undefined) {
+      (collected as Record<string, string>)[target] = value;
+    }
+  }
+
+  for (let candidate of years) {
+    let year = parseTagYear(candidate);
+    if (year !== undefined) {
+      collected.year = year;
+      break;
+    }
+  }
+
+  return prunedTags({ ...collected, scheme: 'id3v2' });
+}

--- a/packages/base/m4a-audio-def.gts
+++ b/packages/base/m4a-audio-def.gts
@@ -1,5 +1,4 @@
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
-import { readFirstBytes } from '@cardstack/runtime-common';
 import AudioDef, {
   audioAttributes,
   waveformFor,
@@ -11,12 +10,6 @@ import {
   extractM4aEncoding,
   extractM4aTags,
 } from './m4a-meta-extractor';
-
-// `moov` holds both the sample entry and the iTunes atoms, and in a
-// faststart-arranged file it precedes `mdat`. 256 KB covers a typical `moov`
-// including cover art. A file that interleaves `moov` after a large `mdat` simply
-// yields no metadata here rather than pulling the whole payload into memory.
-const M4A_METADATA_WINDOW_BYTES = 262_144;
 
 export class M4aDef extends AudioDef {
   static displayName = 'M4A Audio';
@@ -36,19 +29,18 @@ export class M4aDef extends AudioDef {
     // without re-reading, so when those are present the stream is consumed
     // exactly once — by this walk.
     let base = await super.extractAttributes(url, getStream, options);
-    let { duration } = await extractM4aDurationFromStream(await getStream());
-
-    let header = await readFirstBytes(
+    // The same walk hands back the `moov` box, which is all the encoding and tag
+    // readers need — so this costs one stream rather than two.
+    let { duration, moov } = await extractM4aDurationFromStream(
       await getStream(),
-      M4A_METADATA_WINDOW_BYTES,
     );
 
     return {
       ...base,
       duration,
       ...audioAttributes(
-        extractM4aEncoding(header),
-        extractM4aTags(header),
+        extractM4aEncoding(moov),
+        extractM4aTags(moov),
         await waveformFor(getStream, base.contentSize),
       ),
     };

--- a/packages/base/m4a-audio-def.gts
+++ b/packages/base/m4a-audio-def.gts
@@ -1,7 +1,22 @@
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
-import AudioDef from './audio-file-def';
+import { readFirstBytes } from '@cardstack/runtime-common';
+import AudioDef, {
+  audioAttributes,
+  waveformFor,
+  type AudioAttributes,
+} from './audio-file-def';
 import type { ByteStream, SerializedFile } from './file-api';
-import { extractM4aDurationFromStream } from './m4a-meta-extractor';
+import {
+  extractM4aDurationFromStream,
+  extractM4aEncoding,
+  extractM4aTags,
+} from './m4a-meta-extractor';
+
+// `moov` holds both the sample entry and the iTunes atoms, and in a
+// faststart-arranged file it precedes `mdat`. 256 KB covers a typical `moov`
+// including cover art. A file that interleaves `moov` after a large `mdat` simply
+// yields no metadata here rather than pulling the whole payload into memory.
+const M4A_METADATA_WINDOW_BYTES = 262_144;
 
 export class M4aDef extends AudioDef {
   static displayName = 'M4A Audio';
@@ -12,7 +27,7 @@ export class M4aDef extends AudioDef {
     url: string,
     getStream: () => Promise<ByteStream>,
     options: { contentHash?: string; contentSize?: number } = {},
-  ): Promise<SerializedFile<{ duration: number }>> {
+  ): Promise<SerializedFile<{ duration: number } & AudioAttributes>> {
     // Duration lives in the small `moov` box; the bulk of an M4A file is the
     // `mdat` media payload, which we never need. Walk the container off the
     // stream, retaining only `moov` and discarding `mdat`, so even a long
@@ -23,9 +38,19 @@ export class M4aDef extends AudioDef {
     let base = await super.extractAttributes(url, getStream, options);
     let { duration } = await extractM4aDurationFromStream(await getStream());
 
+    let header = await readFirstBytes(
+      await getStream(),
+      M4A_METADATA_WINDOW_BYTES,
+    );
+
     return {
       ...base,
       duration,
+      ...audioAttributes(
+        extractM4aEncoding(header),
+        extractM4aTags(header),
+        await waveformFor(getStream, base.contentSize),
+      ),
     };
   }
 }

--- a/packages/base/m4a-audio-def.gts
+++ b/packages/base/m4a-audio-def.gts
@@ -35,13 +35,22 @@ export class M4aDef extends AudioDef {
       await getStream(),
     );
 
+    // Bound before the waveform call so the decode budget can be predicted from
+    // the sample rate and channel count the container already stated.
+    let encoding = extractM4aEncoding(moov);
+
     return {
       ...base,
       duration,
       ...audioAttributes(
-        extractM4aEncoding(moov),
+        encoding,
         extractM4aTags(moov),
-        await waveformFor(getStream, base.contentSize),
+        await waveformFor(getStream, {
+          durationSeconds: duration,
+          sampleRateHz: encoding?.sampleRateHz,
+          channels: encoding?.channels,
+          contentSize: base.contentSize,
+        }),
       ),
     };
   }

--- a/packages/base/m4a-meta-extractor.ts
+++ b/packages/base/m4a-meta-extractor.ts
@@ -328,11 +328,16 @@ function durationFromMoovBox(moovBytes: Uint8Array): { duration: number } {
 // directly. Works for both fast-start files (`moov` near the start, where the
 // walk stops early) and iPhone / Voice Memo files (`moov` at the end, where
 // the preceding `mdat` is skipped chunk by chunk).
+// Returns the retained `moov` box alongside the duration. It is the only part of
+// the file the metadata readers need — `extractM4aEncoding` and
+// `extractM4aTags` scan for `moov` from offset zero, and a lone moov box is one
+// at offset zero — so one walk serves all three and the def needs no second
+// stream, which the extract runner would satisfy by re-fetching the whole file.
 export async function extractM4aDurationFromStream(
   stream: ReadableStream<Uint8Array> | Uint8Array,
-): Promise<{ duration: number }> {
+): Promise<{ duration: number; moov: Uint8Array }> {
   if (stream instanceof Uint8Array) {
-    return extractM4aDuration(stream);
+    return { ...extractM4aDuration(stream), moov: stream };
   }
 
   let reader = new ChunkReader(stream);
@@ -407,7 +412,7 @@ export async function extractM4aDurationFromStream(
           moovBytes.set(largeSize, BOX_HEADER_BYTES);
         }
         moovBytes.set(payload, headerSize);
-        return durationFromMoovBox(moovBytes);
+        return { ...durationFromMoovBox(moovBytes), moov: moovBytes };
       }
 
       if (size === 0) {

--- a/packages/base/m4a-meta-extractor.ts
+++ b/packages/base/m4a-meta-extractor.ts
@@ -1,3 +1,11 @@
+import {
+  channelModeForCount,
+  parseTagYear,
+  prunedEncoding,
+  prunedTags,
+  type AudioEncoding,
+  type MediaTags,
+} from './audio-metadata';
 import { FileContentMismatchError } from './file-api';
 
 // ISO BMFF box header: 4 bytes size + 4 bytes type. Special sizes:
@@ -415,4 +423,222 @@ export async function extractM4aDurationFromStream(
   } finally {
     await reader.cancel();
   }
+}
+
+// Follow a path of box types down from a container, e.g. moov → trak → mdia.
+// Returns undefined rather than throwing when any step is missing or the tree is
+// malformed: absent metadata is ordinary, and the duration reader is what decides
+// whether a file is really MP4.
+function descend(
+  bytes: Uint8Array,
+  view: DataView,
+  start: number,
+  end: number,
+  path: string[],
+): { payloadOffset: number; payloadEnd: number } | undefined {
+  let cursorStart = start;
+  let cursorEnd = end;
+  for (let type of path) {
+    let target = [...type].map((c) => c.charCodeAt(0));
+    let found: { payloadOffset: number; payloadEnd: number } | undefined;
+    try {
+      found = findChildBox(bytes, view, cursorStart, cursorEnd, target);
+    } catch {
+      return undefined;
+    }
+    if (!found) {
+      return undefined;
+    }
+    cursorStart = found.payloadOffset;
+    cursorEnd = found.payloadEnd;
+  }
+  return { payloadOffset: cursorStart, payloadEnd: cursorEnd };
+}
+
+function findMoov(
+  bytes: Uint8Array,
+  view: DataView,
+): { payloadOffset: number; payloadEnd: number } | undefined {
+  try {
+    return findChildBox(bytes, view, 0, bytes.length, MOOV);
+  } catch {
+    return undefined;
+  }
+}
+
+// Codec identity comes from the sample-entry box type itself: `mp4a` for
+// AAC/ALAC-in-MP4, `alac` for Apple Lossless. Only the ones an .m4a realistically
+// carries are named; anything else leaves the codec unset.
+const SAMPLE_ENTRY_CODECS: Record<string, string> = {
+  mp4a: 'AAC',
+  alac: 'ALAC (Apple Lossless)',
+};
+
+// The audio sample entry inside stsd states channel count, sample size, and
+// sample rate. Layout after the box header: 6 reserved, 2 data reference index,
+// 8 reserved, 2 channel count, 2 sample size, 2 pre-defined, 2 reserved, then
+// the sample rate as a 16.16 fixed-point value.
+const SAMPLE_ENTRY_CHANNELS_OFFSET = 16;
+const SAMPLE_ENTRY_SAMPLE_SIZE_OFFSET = 18;
+const SAMPLE_ENTRY_SAMPLE_RATE_OFFSET = 24;
+
+export function extractM4aEncoding(
+  bytes: Uint8Array,
+): AudioEncoding | undefined {
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let moov = findMoov(bytes, view);
+  if (!moov) {
+    return undefined;
+  }
+  let stsd = descend(bytes, view, moov.payloadOffset, moov.payloadEnd, [
+    'trak',
+    'mdia',
+    'minf',
+    'stbl',
+    'stsd',
+  ]);
+  if (!stsd) {
+    return undefined;
+  }
+  // stsd is a full box: 4 bytes version/flags, then a 4-byte entry count before
+  // the sample entries themselves.
+  let entryStart = stsd.payloadOffset + 8;
+  let entry: { type: string; payloadOffset: number } | undefined;
+  try {
+    let box = readBoxAt(bytes, view, entryStart, stsd.payloadEnd);
+    if (box) {
+      entry = { type: box.type, payloadOffset: box.payloadOffset };
+    }
+  } catch {
+    return undefined;
+  }
+  if (!entry) {
+    return undefined;
+  }
+  let base = entry.payloadOffset;
+  if (base + SAMPLE_ENTRY_SAMPLE_RATE_OFFSET + 4 > bytes.length) {
+    return undefined;
+  }
+  let channels = view.getUint16(base + SAMPLE_ENTRY_CHANNELS_OFFSET);
+  let sampleSize = view.getUint16(base + SAMPLE_ENTRY_SAMPLE_SIZE_OFFSET);
+  // 16.16 fixed point: the integer part is the upper 16 bits.
+  let sampleRate = view.getUint16(base + SAMPLE_ENTRY_SAMPLE_RATE_OFFSET);
+  let isLossless = entry.type === 'alac';
+
+  return prunedEncoding({
+    container: 'MP4',
+    audioCodec: SAMPLE_ENTRY_CODECS[entry.type],
+    sampleRateHz: sampleRate > 0 ? sampleRate : undefined,
+    isVariableBitrate: true,
+    // A lossy AAC stream has no stored sample width; the field is present in the
+    // box but describes nothing, so only report it for lossless.
+    bitDepth: isLossless && sampleSize > 0 ? sampleSize : undefined,
+    channels: channels > 0 ? channels : undefined,
+    channelMode: channelModeForCount(channels > 0 ? channels : undefined),
+  });
+}
+
+// iTunes-style metadata atoms, mapped onto the shared tag shape. The leading
+// byte of the four-character name is the © sign (0xa9) for the standard set.
+const ATOM_ALIASES: Record<string, keyof MediaTags> = {
+  '\u00a9nam': 'trackTitle',
+  '\u00a9ART': 'artist',
+  '\u00a9alb': 'album',
+  aART: 'albumArtist',
+  '\u00a9wrt': 'composer',
+  '\u00a9day': 'year',
+  '\u00a9gen': 'genre',
+  '\u00a9cmt': 'comment',
+  trkn: 'track',
+  disk: 'disc',
+};
+
+// The `data` box's type indicator: 1 means UTF-8 text, 0 means binary, and the
+// integer types are used by trkn/disk.
+const DATA_TYPE_UTF8 = 1;
+
+const MAX_ATOM_BYTES = 8192;
+
+export function extractM4aTags(bytes: Uint8Array): MediaTags | undefined {
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let moov = findMoov(bytes, view);
+  if (!moov) {
+    return undefined;
+  }
+  let meta = descend(bytes, view, moov.payloadOffset, moov.payloadEnd, [
+    'udta',
+    'meta',
+  ]);
+  if (!meta) {
+    return undefined;
+  }
+  // `meta` is a full box: skip its 4 bytes of version/flags before its children.
+  let ilst = descend(bytes, view, meta.payloadOffset + 4, meta.payloadEnd, [
+    'ilst',
+  ]);
+  if (!ilst) {
+    return undefined;
+  }
+
+  let utf8 = new TextDecoder('utf-8', { fatal: false });
+  let collected: MediaTags = {};
+  let yearText: string | undefined;
+  let cursor = ilst.payloadOffset;
+
+  while (cursor < ilst.payloadEnd) {
+    let atom: ReturnType<typeof readBoxAt>;
+    try {
+      atom = readBoxAt(bytes, view, cursor, ilst.payloadEnd);
+    } catch {
+      break;
+    }
+    if (!atom) {
+      break;
+    }
+    let name = typeAt(bytes, cursor + 4);
+    let target = ATOM_ALIASES[name];
+    if (target && atom.payloadEnd - atom.payloadOffset <= MAX_ATOM_BYTES) {
+      let data = descend(bytes, view, atom.payloadOffset, atom.payloadEnd, [
+        'data',
+      ]);
+      if (data && data.payloadOffset + 8 <= data.payloadEnd) {
+        // A data box holds 1 byte reserved + 3 bytes type indicator, then 4
+        // bytes of locale, before the value.
+        let typeIndicator = view.getUint32(data.payloadOffset) & 0x00ffffff;
+        let valueStart = data.payloadOffset + 8;
+        if (target === 'track' || target === 'disc') {
+          // trkn/disk are pairs of integers: a leading padding short, the
+          // number, then the total. Rendered as "n/total" to match how every
+          // other convention states it.
+          if (valueStart + 6 <= data.payloadEnd) {
+            let number = view.getUint16(valueStart + 2);
+            let total = view.getUint16(valueStart + 4);
+            if (number > 0 && collected[target] === undefined) {
+              collected[target] =
+                total > 0 ? `${number}/${total}` : `${number}`;
+            }
+          }
+        } else if (typeIndicator === DATA_TYPE_UTF8) {
+          let value = utf8
+            .decode(bytes.subarray(valueStart, data.payloadEnd))
+            .trim();
+          if (value) {
+            if (target === 'year') {
+              yearText ??= value;
+            } else if (collected[target] === undefined) {
+              (collected as Record<string, string>)[target] = value;
+            }
+          }
+        }
+      }
+    }
+    cursor = atom.nextBoxOffset;
+  }
+
+  let year = parseTagYear(yearText);
+  return prunedTags({
+    ...collected,
+    ...(year === undefined ? {} : { year }),
+    scheme: 'mp4-atoms',
+  });
 }

--- a/packages/base/midi-audio-def.gts
+++ b/packages/base/midi-audio-def.gts
@@ -1,0 +1,55 @@
+import { readFirstBytes } from '@cardstack/runtime-common';
+import KeyboardMusicIcon from '@cardstack/boxel-icons/keyboard-music';
+import { NumberField, contains, field } from './card-api';
+import { FileDef, type ByteStream, type SerializedFile } from './file-api';
+import { MidiMetadataField } from './file-formats/metadata-fields';
+import { extractMidiMetadata, type MidiMetadata } from './midi-meta-extractor';
+
+// MIDI files are small — note events, not samples — so the whole file fits well
+// inside a single bounded read. A megabyte is a very long sequence; anything
+// larger is padding or corruption, and the walk's own event cap bounds the rest.
+const MIDI_MAX_BYTES = 1_048_576;
+
+// MIDI extends `FileDef` rather than `AudioDef` on purpose.
+//
+// A Standard MIDI File is symbolic performance data: a list of which notes to
+// play and when, with no sound until a synthesizer renders it. It therefore has
+// none of what `AudioDef` declares — no sample rate, no bit depth, no channel
+// layout, and no amplitude envelope to decode. Inheriting those would make every
+// MIDI file advertise fields it can never fill.
+//
+// The taxonomy registry already models this as its own `music` family, distinct
+// from `audio`, and this is the class that realizes that distinction.
+export class MidiDef extends FileDef {
+  static displayName = 'MIDI Sequence';
+  static icon = KeyboardMusicIcon;
+  static acceptTypes = '.mid,.midi,audio/midi,audio/x-midi';
+
+  // Derived by walking the tempo map to the last event, so a piece that changes
+  // tempo reports the time it actually takes rather than an average.
+  @field duration = contains(NumberField);
+
+  @field midi = contains(MidiMetadataField);
+
+  static async extractAttributes(
+    url: string,
+    getStream: () => Promise<ByteStream>,
+    options: { contentHash?: string; contentSize?: number } = {},
+  ): Promise<SerializedFile<{ duration?: number; midi?: MidiMetadata }>> {
+    let base = await super.extractAttributes(url, getStream, options);
+    let bytes = await readFirstBytes(await getStream(), MIDI_MAX_BYTES);
+    // Throws FileContentMismatchError when the file isn't SMF, which is how the
+    // extractor knows to fall back to the base FileDef.
+    let midi = extractMidiMetadata(bytes);
+
+    return {
+      ...base,
+      ...(midi.durationSeconds === undefined
+        ? {}
+        : { duration: midi.durationSeconds }),
+      midi,
+    };
+  }
+}
+
+export default MidiDef;

--- a/packages/base/midi-meta-extractor.ts
+++ b/packages/base/midi-meta-extractor.ts
@@ -138,10 +138,6 @@ class TrackReader {
     return this.#cursor >= this.#end;
   }
 
-  get position(): number {
-    return this.#cursor;
-  }
-
   byte(): number | undefined {
     if (this.#cursor >= this.#end) {
       return undefined;

--- a/packages/base/midi-meta-extractor.ts
+++ b/packages/base/midi-meta-extractor.ts
@@ -1,0 +1,491 @@
+// Standard MIDI File (SMF) reader.
+//
+// MIDI is not sampled audio: it is a note sequence that only becomes sound
+// through a synthesizer, which is why it sits in its own family rather than
+// under `AudioDef`. There is no sample rate, no bit depth, and no amplitude
+// envelope to read — but there is a great deal the file states outright about
+// what it will play.
+//
+// Pure `DataView`/`TextDecoder`, no DOM.
+
+import { FileContentMismatchError } from './file-api';
+
+const MTHD = [0x4d, 0x54, 0x68, 0x64]; // "MThd"
+const MTRK = [0x4d, 0x54, 0x72, 0x6b]; // "MTrk"
+
+const HEADER_CHUNK_BYTES = 14;
+
+// Guards against a corrupt track count. Format 1 files with more than this are
+// not something a realm is indexing.
+const MAX_TRACKS = 256;
+
+// Per track. A dense orchestral file runs to tens of thousands; this is a
+// backstop against a corrupt length field spinning the event walk.
+const MAX_EVENTS_PER_TRACK = 200_000;
+
+// Bounded so a tempo-map-heavy file can't grow the index row without limit.
+const MAX_TEMPO_ENTRIES = 32;
+const MAX_SIGNATURE_ENTRIES = 16;
+
+// The default when a file states no tempo, per the MIDI specification.
+const DEFAULT_MICROSECONDS_PER_QUARTER = 500_000; // 120 BPM
+
+const META_EVENT = 0xff;
+const META_END_OF_TRACK = 0x2f;
+const META_SET_TEMPO = 0x51;
+const META_TIME_SIGNATURE = 0x58;
+const META_KEY_SIGNATURE = 0x59;
+
+const STATUS_NOTE_OFF = 0x80;
+const STATUS_NOTE_ON = 0x90;
+const STATUS_POLY_AFTERTOUCH = 0xa0;
+const STATUS_CONTROL_CHANGE = 0xb0;
+const STATUS_PROGRAM_CHANGE = 0xc0;
+const STATUS_CHANNEL_PRESSURE = 0xd0;
+const STATUS_PITCH_BEND = 0xe0;
+const STATUS_SYSEX = 0xf0;
+const STATUS_SYSEX_ESCAPE = 0xf7;
+
+// Channel 10 (index 9) is percussion by General MIDI convention, so a program
+// number there names a drum kit rather than an instrument.
+const PERCUSSION_CHANNEL = 9;
+
+const NOTE_NAMES = [
+  'C',
+  'C#',
+  'D',
+  'D#',
+  'E',
+  'F',
+  'F#',
+  'G',
+  'G#',
+  'A',
+  'A#',
+  'B',
+];
+
+// Key signatures are stated as a count of sharps (positive) or flats (negative)
+// plus a major/minor flag, rather than as a name.
+const MAJOR_KEYS: Record<number, string> = {
+  '-7': 'Cb major',
+  '-6': 'Gb major',
+  '-5': 'Db major',
+  '-4': 'Ab major',
+  '-3': 'Eb major',
+  '-2': 'Bb major',
+  '-1': 'F major',
+  0: 'C major',
+  1: 'G major',
+  2: 'D major',
+  3: 'A major',
+  4: 'E major',
+  5: 'B major',
+  6: 'F# major',
+  7: 'C# major',
+};
+
+const MINOR_KEYS: Record<number, string> = {
+  '-7': 'Ab minor',
+  '-6': 'Eb minor',
+  '-5': 'Bb minor',
+  '-4': 'F minor',
+  '-3': 'C minor',
+  '-2': 'G minor',
+  '-1': 'D minor',
+  0: 'A minor',
+  1: 'E minor',
+  2: 'B minor',
+  3: 'F# minor',
+  4: 'C# minor',
+  5: 'G# minor',
+  6: 'D# minor',
+  7: 'A# minor',
+};
+
+export interface MidiMetadata {
+  format?: number;
+  ppq?: number;
+  durationSeconds?: number;
+  fileTrackCount?: number;
+  // Tracks that actually sound a note, which is usually fewer than the file
+  // declares — a format 1 file's first track conventionally holds only tempo
+  // and time-signature data.
+  trackCount?: number;
+  noteCount?: number;
+  tempoMap?: string[];
+  timeSignatures?: string[];
+  keySignatures?: string[];
+  programs?: number[];
+  channels?: number[];
+  pitchRange?: string;
+  hasPercussion?: boolean;
+}
+
+// A bounds-checked cursor over one track chunk.
+class TrackReader {
+  #bytes: Uint8Array;
+  #cursor: number;
+  #end: number;
+
+  constructor(bytes: Uint8Array, start: number, end: number) {
+    this.#bytes = bytes;
+    this.#cursor = start;
+    this.#end = end;
+  }
+
+  get exhausted(): boolean {
+    return this.#cursor >= this.#end;
+  }
+
+  get position(): number {
+    return this.#cursor;
+  }
+
+  byte(): number | undefined {
+    if (this.#cursor >= this.#end) {
+      return undefined;
+    }
+    return this.#bytes[this.#cursor++];
+  }
+
+  peek(): number | undefined {
+    return this.#cursor < this.#end ? this.#bytes[this.#cursor] : undefined;
+  }
+
+  skip(count: number): void {
+    this.#cursor += count;
+  }
+
+  slice(count: number): Uint8Array | undefined {
+    if (count < 0 || this.#cursor + count > this.#end) {
+      return undefined;
+    }
+    let out = this.#bytes.subarray(this.#cursor, this.#cursor + count);
+    this.#cursor += count;
+    return out;
+  }
+
+  // MIDI's variable-length quantity: seven bits per byte, high bit set on every
+  // byte but the last. Capped at four bytes, which is the spec's own maximum.
+  variableLength(): number | undefined {
+    let value = 0;
+    for (let index = 0; index < 4; index++) {
+      let next = this.byte();
+      if (next === undefined) {
+        return undefined;
+      }
+      value = (value << 7) | (next & 0x7f);
+      if ((next & 0x80) === 0) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+}
+
+function matchChunk(
+  bytes: Uint8Array,
+  offset: number,
+  tag: readonly number[],
+): boolean {
+  if (offset + tag.length > bytes.length) {
+    return false;
+  }
+  return tag.every((expected, index) => bytes[offset + index] === expected);
+}
+
+function noteName(pitch: number): string {
+  // MIDI note 60 is middle C, conventionally written C4.
+  let octave = Math.floor(pitch / 12) - 1;
+  return `${NOTE_NAMES[pitch % 12]}${octave}`;
+}
+
+function unique(values: number[]): number[] {
+  return [...new Set(values)].sort((a, b) => a - b);
+}
+
+// One tempo change, as ticks-from-start plus the rate that takes effect there.
+interface TempoChange {
+  tick: number;
+  microsecondsPerQuarter: number;
+}
+
+// Convert a tick position to seconds by walking the tempo map, since a file may
+// change tempo any number of times and a single average would misreport a piece
+// that speeds up.
+function ticksToSeconds(
+  ticks: number,
+  ppq: number,
+  tempoChanges: TempoChange[],
+): number {
+  if (ppq <= 0) {
+    return 0;
+  }
+  let ordered = [...tempoChanges].sort((a, b) => a.tick - b.tick);
+  let seconds = 0;
+  let lastTick = 0;
+  let rate = DEFAULT_MICROSECONDS_PER_QUARTER;
+  for (let change of ordered) {
+    if (change.tick >= ticks) {
+      break;
+    }
+    seconds += ((change.tick - lastTick) / ppq) * (rate / 1_000_000);
+    lastTick = change.tick;
+    rate = change.microsecondsPerQuarter;
+  }
+  seconds += ((ticks - lastTick) / ppq) * (rate / 1_000_000);
+  return seconds;
+}
+
+// Read a Standard MIDI File's structure and what it will play.
+//
+// Throws `FileContentMismatchError` when the file isn't SMF at all, matching how
+// the other format readers signal a content mismatch so the extractor can fall
+// back to the base FileDef. Anything malformed *within* a valid header degrades
+// to partial metadata instead.
+export function extractMidiMetadata(bytes: Uint8Array): MidiMetadata {
+  if (!matchChunk(bytes, 0, MTHD)) {
+    throw new FileContentMismatchError(
+      'File does not begin with a MIDI "MThd" header chunk',
+    );
+  }
+  if (bytes.length < HEADER_CHUNK_BYTES) {
+    throw new FileContentMismatchError(
+      'MIDI file is too small to contain a header chunk',
+    );
+  }
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let headerLength = view.getUint32(4);
+  let format = view.getUint16(8);
+  let declaredTracks = view.getUint16(10);
+  let division = view.getUint16(12);
+
+  // A negative division is SMPTE timecode rather than ticks-per-quarter. The
+  // note data still reads; only the tick-to-seconds conversion doesn't apply,
+  // so `ppq` is left unset rather than filled with a meaningless number.
+  let isMetrical = (division & 0x8000) === 0;
+  let ppq = isMetrical ? division & 0x7fff : undefined;
+
+  let noteCount = 0;
+  let soundingTracks = 0;
+  let tempoChanges: TempoChange[] = [];
+  let timeSignatures: string[] = [];
+  let keySignatures: string[] = [];
+  let programs: number[] = [];
+  let channels: number[] = [];
+  let lowestPitch: number | undefined;
+  let highestPitch: number | undefined;
+  let longestTrackTicks = 0;
+  let hasPercussion = false;
+
+  // Track chunks follow the header, whose declared length lets a file carry
+  // header extensions this reader doesn't know about.
+  let offset = 8 + headerLength;
+  let trackIndex = 0;
+  while (
+    trackIndex < Math.min(declaredTracks || MAX_TRACKS, MAX_TRACKS) &&
+    offset + 8 <= bytes.length
+  ) {
+    if (!matchChunk(bytes, offset, MTRK)) {
+      // An unrecognized chunk type is legal and must be skipped by its length.
+      let unknownLength = view.getUint32(offset + 4);
+      offset += 8 + unknownLength;
+      continue;
+    }
+    let trackLength = view.getUint32(offset + 4);
+    let trackStart = offset + 8;
+    let trackEnd = Math.min(trackStart + trackLength, bytes.length);
+    offset = trackStart + trackLength;
+    trackIndex++;
+
+    let reader = new TrackReader(bytes, trackStart, trackEnd);
+    let ticks = 0;
+    let runningStatus: number | undefined;
+    let trackSounds = false;
+
+    for (let event = 0; event < MAX_EVENTS_PER_TRACK; event++) {
+      if (reader.exhausted) {
+        break;
+      }
+      let delta = reader.variableLength();
+      if (delta === undefined) {
+        break;
+      }
+      ticks += delta;
+
+      let statusByte = reader.peek();
+      if (statusByte === undefined) {
+        break;
+      }
+      let status: number;
+      if (statusByte >= 0x80) {
+        status = statusByte;
+        reader.skip(1);
+        // Running status persists only across channel messages.
+        if (status < STATUS_SYSEX) {
+          runningStatus = status;
+        }
+      } else if (runningStatus !== undefined) {
+        // A data byte where a status was expected means the previous status
+        // repeats — the compression every real MIDI file relies on.
+        status = runningStatus;
+      } else {
+        break;
+      }
+
+      if (status === META_EVENT) {
+        let type = reader.byte();
+        let length = reader.variableLength();
+        if (type === undefined || length === undefined) {
+          break;
+        }
+        let payload = reader.slice(length);
+        if (!payload) {
+          break;
+        }
+        if (type === META_END_OF_TRACK) {
+          break;
+        }
+        if (type === META_SET_TEMPO && payload.length >= 3) {
+          let microseconds =
+            (payload[0]! << 16) | (payload[1]! << 8) | payload[2]!;
+          if (microseconds > 0 && tempoChanges.length < MAX_TEMPO_ENTRIES) {
+            tempoChanges.push({
+              tick: ticks,
+              microsecondsPerQuarter: microseconds,
+            });
+          }
+        } else if (type === META_TIME_SIGNATURE && payload.length >= 2) {
+          // The denominator is stored as a power of two.
+          let signature = `${payload[0]}/${2 ** payload[1]!}`;
+          if (
+            !timeSignatures.includes(signature) &&
+            timeSignatures.length < MAX_SIGNATURE_ENTRIES
+          ) {
+            timeSignatures.push(signature);
+          }
+        } else if (type === META_KEY_SIGNATURE && payload.length >= 2) {
+          // A signed byte: negative counts flats, positive counts sharps.
+          let accidentals = (payload[0]! << 24) >> 24;
+          let isMinor = payload[1] === 1;
+          let key = (isMinor ? MINOR_KEYS : MAJOR_KEYS)[accidentals];
+          if (
+            key &&
+            !keySignatures.includes(key) &&
+            keySignatures.length < MAX_SIGNATURE_ENTRIES
+          ) {
+            keySignatures.push(key);
+          }
+        }
+        continue;
+      }
+
+      if (status === STATUS_SYSEX || status === STATUS_SYSEX_ESCAPE) {
+        let length = reader.variableLength();
+        if (length === undefined || !reader.slice(length)) {
+          break;
+        }
+        continue;
+      }
+
+      let command = status & 0xf0;
+      let channel = status & 0x0f;
+      if (
+        command === STATUS_PROGRAM_CHANGE ||
+        command === STATUS_CHANNEL_PRESSURE
+      ) {
+        // One data byte.
+        let value = reader.byte();
+        if (value === undefined) {
+          break;
+        }
+        if (
+          command === STATUS_PROGRAM_CHANGE &&
+          channel !== PERCUSSION_CHANNEL
+        ) {
+          if (!programs.includes(value)) {
+            programs.push(value);
+          }
+        }
+        continue;
+      }
+      if (
+        command === STATUS_NOTE_ON ||
+        command === STATUS_NOTE_OFF ||
+        command === STATUS_POLY_AFTERTOUCH ||
+        command === STATUS_CONTROL_CHANGE ||
+        command === STATUS_PITCH_BEND
+      ) {
+        // Two data bytes.
+        let first = reader.byte();
+        let second = reader.byte();
+        if (first === undefined || second === undefined) {
+          break;
+        }
+        // A note-on with zero velocity is the conventional note-off, and
+        // counting it would double every note in most files.
+        if (command === STATUS_NOTE_ON && second > 0) {
+          noteCount++;
+          trackSounds = true;
+          if (!channels.includes(channel)) {
+            channels.push(channel);
+          }
+          if (channel === PERCUSSION_CHANNEL) {
+            hasPercussion = true;
+          } else {
+            lowestPitch =
+              lowestPitch === undefined ? first : Math.min(lowestPitch, first);
+            highestPitch =
+              highestPitch === undefined
+                ? first
+                : Math.max(highestPitch, first);
+          }
+        }
+        continue;
+      }
+      // An unrecognized status means the walk has desynchronized; the metadata
+      // gathered so far still stands.
+      break;
+    }
+
+    if (trackSounds) {
+      soundingTracks++;
+    }
+    longestTrackTicks = Math.max(longestTrackTicks, ticks);
+  }
+
+  let durationSeconds =
+    ppq && longestTrackTicks > 0
+      ? Math.round(
+          ticksToSeconds(longestTrackTicks, ppq, tempoChanges) * 1000,
+        ) / 1000
+      : undefined;
+
+  let tempoMap = tempoChanges.map(
+    (change) =>
+      `${Math.round(60_000_000 / change.microsecondsPerQuarter)} BPM @ tick ${
+        change.tick
+      }`,
+  );
+
+  return {
+    format,
+    ppq,
+    durationSeconds,
+    fileTrackCount: declaredTracks,
+    trackCount: soundingTracks,
+    noteCount,
+    tempoMap: tempoMap.length > 0 ? tempoMap : undefined,
+    timeSignatures: timeSignatures.length > 0 ? timeSignatures : undefined,
+    keySignatures: keySignatures.length > 0 ? keySignatures : undefined,
+    programs: programs.length > 0 ? unique(programs) : undefined,
+    channels:
+      channels.length > 0 ? unique(channels).map((c) => c + 1) : undefined,
+    pitchRange:
+      lowestPitch !== undefined && highestPitch !== undefined
+        ? `${noteName(lowestPitch)}–${noteName(highestPitch)}`
+        : undefined,
+    hasPercussion,
+  };
+}

--- a/packages/base/mp3-audio-def.gts
+++ b/packages/base/mp3-audio-def.gts
@@ -1,8 +1,16 @@
 import { readFirstBytes } from '@cardstack/runtime-common';
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
-import AudioDef from './audio-file-def';
+import AudioDef, {
+  audioAttributes,
+  waveformFor,
+  type AudioAttributes,
+} from './audio-file-def';
 import type { ByteStream, SerializedFile } from './file-api';
-import { extractMp3Duration } from './mp3-meta-extractor';
+import {
+  extractMp3Duration,
+  extractMp3Encoding,
+  extractMp3Tags,
+} from './mp3-meta-extractor';
 
 // ID3v2 tags can be large (embedded artwork). 1 MB covers virtually all
 // real-world files while still bounding worst-case memory at extract time.
@@ -16,8 +24,8 @@ export class Mp3Def extends AudioDef {
   static async extractAttributes(
     url: string,
     getStream: () => Promise<ByteStream>,
-    options: { contentHash?: string } = {},
-  ): Promise<SerializedFile<{ duration: number }>> {
+    options: { contentHash?: string; contentSize?: number } = {},
+  ): Promise<SerializedFile<{ duration: number } & AudioAttributes>> {
     let base = await super.extractAttributes(url, getStream, options);
     let bytes = await readFirstBytes(await getStream(), MP3_MAX_HEADER_BYTES);
     let { duration } = extractMp3Duration(bytes);
@@ -25,6 +33,11 @@ export class Mp3Def extends AudioDef {
     return {
       ...base,
       duration,
+      ...audioAttributes(
+        extractMp3Encoding(bytes),
+        extractMp3Tags(bytes),
+        await waveformFor(getStream, base.contentSize),
+      ),
     };
   }
 }

--- a/packages/base/mp3-audio-def.gts
+++ b/packages/base/mp3-audio-def.gts
@@ -1,7 +1,4 @@
-import {
-  byteStreamToUint8Array,
-  readFirstBytes,
-} from '@cardstack/runtime-common';
+import { readFirstBytes } from '@cardstack/runtime-common';
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
 import AudioDef, {
   audioAttributes,
@@ -11,7 +8,7 @@ import type { ByteStream, SerializedFile } from './file-api';
 import {
   extractMp3Duration,
   extractMp3Encoding,
-  extractMp3Envelope,
+  extractMp3EnvelopeFromStream,
   extractMp3Tags,
 } from './mp3-meta-extractor';
 import {
@@ -51,8 +48,10 @@ export class Mp3Def extends AudioDef {
 
   // MP3 never needs a decoder for its envelope. Every frame's side info states
   // a quantizer gain per granule, which is an amplitude scale readable by
-  // walking frame headers — so the whole file streams through without any
-  // decoded audio ever being resident.
+  // walking frame headers — and because frames are self-delimiting, the walk
+  // streams: it keeps a rolling buffer of a few frames and discards what it has
+  // passed, so neither decoded audio nor the encoded file is ever fully
+  // resident.
   //
   // That matters most here: float PCM costs roughly twenty times the encoded
   // size for a 128 kbps stream, making MP3 the worst case for a full decode by a
@@ -66,8 +65,10 @@ export class Mp3Def extends AudioDef {
     getStream: () => Promise<ByteStream>,
   ): Promise<WaveformMetadata> {
     try {
-      let bytes = await byteStreamToUint8Array(await getStream());
-      let envelope = extractMp3Envelope(bytes, WAVEFORM_BAR_COUNT);
+      let envelope = await extractMp3EnvelopeFromStream(
+        await getStream(),
+        WAVEFORM_BAR_COUNT,
+      );
       if (!envelope) {
         return {
           decodeStatus: 'failed',

--- a/packages/base/mp3-audio-def.gts
+++ b/packages/base/mp3-audio-def.gts
@@ -1,16 +1,24 @@
-import { readFirstBytes } from '@cardstack/runtime-common';
+import {
+  byteStreamToUint8Array,
+  readFirstBytes,
+} from '@cardstack/runtime-common';
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
 import AudioDef, {
   audioAttributes,
-  waveformFor,
   type AudioAttributes,
 } from './audio-file-def';
 import type { ByteStream, SerializedFile } from './file-api';
 import {
   extractMp3Duration,
   extractMp3Encoding,
+  extractMp3Envelope,
   extractMp3Tags,
 } from './mp3-meta-extractor';
+import {
+  WAVEFORM_ALGORITHM_SIDE_INFO,
+  WAVEFORM_BAR_COUNT,
+} from './audio-waveform';
+import type { WaveformMetadata } from './audio-waveform';
 
 // ID3v2 tags can be large (embedded artwork). 1 MB covers virtually all
 // real-world files while still bounding worst-case memory at extract time.
@@ -36,8 +44,60 @@ export class Mp3Def extends AudioDef {
       ...audioAttributes(
         extractMp3Encoding(bytes),
         extractMp3Tags(bytes),
-        await waveformFor(getStream, base.contentSize),
+        await this.readWaveform(getStream),
       ),
     };
+  }
+
+  // MP3 never needs a decoder for its envelope. Every frame's side info states
+  // a quantizer gain per granule, which is an amplitude scale readable by
+  // walking frame headers — so the whole file streams through without any
+  // decoded audio ever being resident.
+  //
+  // That matters most here: float PCM costs roughly twenty times the encoded
+  // size for a 128 kbps stream, making MP3 the worst case for a full decode by a
+  // wide margin. This path is flat in memory regardless of duration, so it runs
+  // with no size ceiling at all.
+  //
+  // Falling back to a real decode when the side-info walk finds nothing would
+  // reintroduce exactly the cost this avoids, so a file that yields no frames
+  // reports the failure instead.
+  private static async readWaveform(
+    getStream: () => Promise<ByteStream>,
+  ): Promise<WaveformMetadata> {
+    try {
+      let bytes = await byteStreamToUint8Array(await getStream());
+      let envelope = extractMp3Envelope(bytes, WAVEFORM_BAR_COUNT);
+      if (!envelope) {
+        return {
+          decodeStatus: 'failed',
+          decodeError: 'No readable MPEG frames to derive an envelope from',
+        };
+      }
+      return {
+        decodeStatus: 'ok',
+        algorithm: WAVEFORM_ALGORITHM_SIDE_INFO,
+        barsJson: JSON.stringify(envelope.bars),
+        barCount: envelope.bars.length,
+        ...(envelope.durationSeconds === undefined
+          ? {}
+          : { durationSeconds: envelope.durationSeconds }),
+        ...(envelope.sampleRateHz === undefined
+          ? {}
+          : { sampleRateHz: envelope.sampleRateHz }),
+        // A quantizer scale carries no calibrated amplitude, so the envelope is
+        // normalized to the track's own peak and the absolute figures are left
+        // unset rather than reported on a scale that isn't comparable with a
+        // decoded one.
+      };
+    } catch (error) {
+      return {
+        decodeStatus: 'failed',
+        decodeError:
+          error instanceof Error
+            ? error.message
+            : `Could not read audio bytes: ${String(error)}`,
+      };
+    }
   }
 }

--- a/packages/base/mp3-meta-extractor.ts
+++ b/packages/base/mp3-meta-extractor.ts
@@ -6,6 +6,7 @@ import {
 } from './audio-metadata';
 import { FileContentMismatchError } from './file-api';
 import { parseId3v2Tags } from './id3v2-parser';
+import { StreamingEnvelope } from './streaming-envelope';
 
 // MPEG audio frame sync: 11 bits set (0xFFE..). In practice the next bits
 // disambiguate MPEG version / layer, so we match the first byte as 0xFF and
@@ -383,4 +384,258 @@ export function extractMp3Encoding(
 
 export function extractMp3Tags(bytes: Uint8Array): MediaTags | undefined {
   return parseId3v2Tags(bytes);
+}
+
+// ── Amplitude envelope from side info, without decoding ──────────────────────
+//
+// Every Layer III frame carries a side-info block before its main data, and each
+// granule/channel within it has an 8-bit `global_gain` — the quantizer step
+// exponent used to requantize that granule:
+//
+//   sample = sign(is) · |is|^(4/3) · 2^((global_gain − 210) / 4)
+//
+// So `2^((global_gain − 210)/4)` is that granule's amplitude scale, readable by
+// walking frame headers and picking 8 bits out of side info. No Huffman decode,
+// no IMDCT, no synthesis filterbank, and no need to hold decoded audio.
+//
+// That matters because MP3 is by far the worst case for a full decode: float PCM
+// costs `duration × sampleRate × channels × 4`, which for a 128 kbps stream is
+// roughly twenty times the encoded size. This path is O(1) in memory regardless
+// of duration.
+//
+// The tradeoff is that a quantizer scale is not calibrated amplitude. It tracks
+// loudness well enough to draw, but its absolute values aren't comparable with a
+// decoded RMS, so the envelope is normalized to the track's own peak and the
+// absolute amplitude fields are left unset rather than reported wrongly.
+
+// A granule is 576 samples; a Layer III frame holds two of them (one in MPEG-2).
+const SAMPLES_PER_GRANULE = 576;
+
+// The exponent offset in the requantization formula.
+const GLOBAL_GAIN_BIAS = 210;
+
+// `global_gain` sits 21 bits into each granule/channel side-info block, after
+// part2_3_length (12) and big_values (9). Same in both MPEG generations.
+const GLOBAL_GAIN_BIT_OFFSET = 21;
+
+// Per granule/channel side-info block width. MPEG-2/2.5 spends four more bits on
+// scalefac_compress and two fewer on the trailing flags.
+const SIDE_INFO_BLOCK_BITS_V1 = 59;
+const SIDE_INFO_BLOCK_BITS_V2 = 63;
+
+function readBits(
+  bytes: Uint8Array,
+  base: number,
+  bitOffset: number,
+  count: number,
+): number | undefined {
+  let value = 0;
+  for (let index = 0; index < count; index++) {
+    let bit = bitOffset + index;
+    let byteIndex = base + (bit >> 3);
+    if (byteIndex >= bytes.length) {
+      return undefined;
+    }
+    value = (value << 1) | ((bytes[byteIndex]! >> (7 - (bit & 7))) & 1);
+  }
+  return value;
+}
+
+// How long this frame is in bytes, which is what advances the walk to the next
+// sync. Layer III packs 1152 samples per frame in MPEG-1 and 576 in MPEG-2/2.5,
+// hence the different multipliers.
+function frameLengthBytes(
+  version: number,
+  layer: number,
+  bitrateKbps: number,
+  sampleRate: number,
+  hasPadding: boolean,
+): number | undefined {
+  if (bitrateKbps <= 0 || sampleRate <= 0 || layer !== LAYER_III) {
+    return undefined;
+  }
+  let multiplier = version === MPEG_VERSION_1 ? 144 : 72;
+  return (
+    Math.floor((multiplier * bitrateKbps * 1000) / sampleRate) +
+    (hasPadding ? 1 : 0)
+  );
+}
+
+// Read every granule's gain out of one frame's side info.
+function frameGlobalGains(
+  bytes: Uint8Array,
+  frameOffset: number,
+  version: number,
+  channelCount: number,
+  hasCrc: boolean,
+): number[] {
+  // Side info follows the 4-byte header, plus a 2-byte CRC when present.
+  let base = frameOffset + 4 + (hasCrc ? 2 : 0);
+  let isMono = channelCount === 1;
+  let gains: number[] = [];
+  if (version === MPEG_VERSION_1) {
+    // main_data_begin(9) + private_bits + scfsi(4 per channel)
+    let start = 9 + (isMono ? 5 : 3) + 4 * channelCount;
+    for (let granule = 0; granule < 2; granule++) {
+      for (let channel = 0; channel < channelCount; channel++) {
+        let block = granule * channelCount + channel;
+        let gain = readBits(
+          bytes,
+          base,
+          start + block * SIDE_INFO_BLOCK_BITS_V1 + GLOBAL_GAIN_BIT_OFFSET,
+          8,
+        );
+        if (gain === undefined) {
+          return gains;
+        }
+        gains.push(gain);
+      }
+    }
+  } else {
+    // MPEG-2/2.5 carries one granule and no scfsi.
+    let start = 8 + (isMono ? 1 : 2);
+    for (let channel = 0; channel < channelCount; channel++) {
+      let gain = readBits(
+        bytes,
+        base,
+        start + channel * SIDE_INFO_BLOCK_BITS_V2 + GLOBAL_GAIN_BIT_OFFSET,
+        8,
+      );
+      if (gain === undefined) {
+        return gains;
+      }
+      gains.push(gain);
+    }
+  }
+  return gains;
+}
+
+export interface Mp3Envelope {
+  bars: number[];
+  granuleCount: number;
+  frameCount: number;
+  sampleRateHz?: number;
+  durationSeconds?: number;
+}
+
+// Walk `bytes` frame by frame, folding each granule's gain into `envelope`.
+// Returns how many granules were read.
+function scanFrames(
+  bytes: Uint8Array,
+  startOffset: number,
+  envelope: StreamingEnvelope,
+): { granuleCount: number; sampleRate?: number; frameCount: number } {
+  let offset = startOffset;
+  let granuleCount = 0;
+  let frameCount = 0;
+  let sampleRate: number | undefined;
+
+  while (offset + 4 <= bytes.length) {
+    let atSync =
+      bytes[offset] === FRAME_SYNC_FIRST &&
+      (bytes[offset + 1]! & FRAME_SYNC_SECOND_MASK) === FRAME_SYNC_SECOND_MASK;
+    let header = atSync ? parseFrameHeader(bytes, offset) : undefined;
+    if (!header) {
+      // Lost sync. Step forward and look again rather than abandoning the rest
+      // of the file, which a single corrupt frame would otherwise cost.
+      let resync = findFrameSync(bytes, offset + 1);
+      if (resync === undefined) {
+        break;
+      }
+      offset = resync;
+      continue;
+    }
+    sampleRate ??= header.sampleRate;
+
+    let b1 = bytes[offset + 1]!;
+    let b2 = bytes[offset + 2]!;
+    let b3 = bytes[offset + 3]!;
+    let hasCrc = (b1 & 0x01) === 0;
+    let bitrateIndex = (b2 >> 4) & 0x0f;
+    let bitrateKbps =
+      BITRATE_KBPS[bitrateTableKey(header.version, header.layer)]?.[
+        bitrateIndex
+      ];
+    let hasPadding = ((b2 >> 1) & 0x01) === 1;
+    let channelCount = ((b3 >> 6) & 0x03) === 3 ? 1 : 2;
+
+    let length = frameLengthBytes(
+      header.version,
+      header.layer,
+      bitrateKbps ?? 0,
+      header.sampleRate,
+      hasPadding,
+    );
+    if (length === undefined || length < 4) {
+      break;
+    }
+
+    for (let gain of frameGlobalGains(
+      bytes,
+      offset,
+      header.version,
+      channelCount,
+      hasCrc,
+    )) {
+      // Convert the log-domain quantizer exponent to a linear scale, then push
+      // it as its own "RMS" so the shared accumulator's weighting applies.
+      let amplitude = 2 ** ((gain - GLOBAL_GAIN_BIAS) / 4);
+      envelope.push(amplitude * amplitude, 1, amplitude);
+      granuleCount++;
+    }
+
+    frameCount++;
+    offset += length;
+  }
+
+  return { granuleCount, sampleRate, frameCount };
+}
+
+// Build an amplitude envelope from a whole MP3 without decoding it.
+//
+// Bars are normalized to the track's own peak, because a quantizer scale has no
+// absolute meaning — a renderer wants relative heights, and the calibrated
+// figures a decoded envelope would carry are deliberately omitted rather than
+// filled with numbers that don't mean the same thing.
+export function extractMp3Envelope(
+  bytes: Uint8Array,
+  barCount: number,
+): Mp3Envelope | undefined {
+  let start = findFrameSync(bytes, id3v2TagSize(bytes));
+  if (start === undefined) {
+    return undefined;
+  }
+  let envelope = new StreamingEnvelope(barCount);
+  let { granuleCount, sampleRate, frameCount } = scanFrames(
+    bytes,
+    start,
+    envelope,
+  );
+  if (granuleCount === 0 || envelope.isEmpty) {
+    return undefined;
+  }
+
+  let peak = envelope.peak;
+  let bars = envelope.bars();
+  let normalized =
+    peak > 0
+      ? bars.map((bar) => Math.round((bar / peak) * 10000) / 10000)
+      : bars;
+
+  // Granules are a fixed 576 samples, so the count gives a duration that agrees
+  // with the frame walk without needing the Xing header the duration reader
+  // depends on.
+  let durationSeconds =
+    sampleRate && sampleRate > 0
+      ? Math.round(((granuleCount * SAMPLES_PER_GRANULE) / sampleRate) * 1000) /
+        1000
+      : undefined;
+
+  return {
+    bars: normalized,
+    granuleCount,
+    frameCount,
+    ...(sampleRate === undefined ? {} : { sampleRateHz: sampleRate }),
+    ...(durationSeconds === undefined ? {} : { durationSeconds }),
+  };
 }

--- a/packages/base/mp3-meta-extractor.ts
+++ b/packages/base/mp3-meta-extractor.ts
@@ -639,3 +639,200 @@ export function extractMp3Envelope(
     ...(durationSeconds === undefined ? {} : { durationSeconds }),
   };
 }
+
+// Scan an MP3 off the stream, so neither decoded audio nor the encoded file is
+// ever fully resident.
+//
+// The buffered `extractMp3Envelope` above removed the decode, which was the
+// large cost — but it still needed every byte at once. Frames are
+// self-delimiting (each header states its own length), so the walk only ever
+// needs the frame it is on: this keeps a rolling buffer of a few frames and
+// discards what it has passed.
+export async function extractMp3EnvelopeFromStream(
+  stream: ReadableStream<Uint8Array> | Uint8Array,
+  barCount: number,
+): Promise<Mp3Envelope | undefined> {
+  if (stream instanceof Uint8Array) {
+    return extractMp3Envelope(stream, barCount);
+  }
+
+  let envelope = new StreamingEnvelope(barCount);
+  // The largest a Layer III frame can be: 144 * 320000 / 32000 + 1.
+  const MAX_FRAME_BYTES = 1441;
+  // Enough to hold a frame plus whatever partial frame follows it.
+  const WINDOW_BYTES = MAX_FRAME_BYTES * 4;
+
+  let buffer: Uint8Array<ArrayBufferLike> = new Uint8Array(0);
+  let granuleCount = 0;
+  let frameCount = 0;
+  let sampleRate: number | undefined;
+  // An ID3v2 tag precedes the audio and can be megabytes with artwork, so it is
+  // skipped by count rather than buffered.
+  let tagBytesRemaining: number | undefined;
+  let started = false;
+
+  let reader = stream.getReader();
+  try {
+    for (;;) {
+      let { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value || value.length === 0) {
+        continue;
+      }
+
+      let incoming: Uint8Array<ArrayBufferLike> = value;
+      if (!started) {
+        // Determine the ID3v2 size from the first bytes, once.
+        buffer =
+          buffer.length === 0
+            ? incoming.slice()
+            : concatBytes(buffer, incoming);
+        if (buffer.length < 10) {
+          continue;
+        }
+        tagBytesRemaining = id3v2TagSize(buffer);
+        started = true;
+        incoming = buffer;
+        buffer = new Uint8Array(0);
+      }
+
+      if (tagBytesRemaining !== undefined && tagBytesRemaining > 0) {
+        let skip = Math.min(tagBytesRemaining, incoming.length);
+        tagBytesRemaining -= skip;
+        incoming = incoming.subarray(skip);
+        if (incoming.length === 0) {
+          continue;
+        }
+      }
+
+      buffer =
+        buffer.length === 0 ? incoming.slice() : concatBytes(buffer, incoming);
+
+      // Consume every frame fully contained in the buffer, then keep the
+      // remainder for the next chunk.
+      let consumed = 0;
+      for (;;) {
+        let progress = readOneFrame(buffer, consumed, envelope);
+        if (!progress) {
+          break;
+        }
+        consumed = progress.nextOffset;
+        granuleCount += progress.granules;
+        if (progress.granules > 0) {
+          frameCount++;
+        }
+        sampleRate ??= progress.sampleRate;
+      }
+      buffer = consumed > 0 ? buffer.slice(consumed) : buffer;
+      // A buffer that has grown past the window without yielding a frame is
+      // desynchronized garbage; keep only the tail so a later sync can be found.
+      if (buffer.length > WINDOW_BYTES) {
+        buffer = buffer.slice(buffer.length - MAX_FRAME_BYTES);
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => {
+      // Already drained or released; cancelling is a no-op.
+    });
+  }
+
+  if (granuleCount === 0 || envelope.isEmpty) {
+    return undefined;
+  }
+
+  let peak = envelope.peak;
+  let bars = envelope.bars();
+  let normalized =
+    peak > 0
+      ? bars.map((bar) => Math.round((bar / peak) * 10000) / 10000)
+      : bars;
+  let durationSeconds =
+    sampleRate && sampleRate > 0
+      ? Math.round(((granuleCount * SAMPLES_PER_GRANULE) / sampleRate) * 1000) /
+        1000
+      : undefined;
+
+  return {
+    bars: normalized,
+    granuleCount,
+    frameCount,
+    ...(sampleRate === undefined ? {} : { sampleRateHz: sampleRate }),
+    ...(durationSeconds === undefined ? {} : { durationSeconds }),
+  };
+}
+
+function concatBytes(left: Uint8Array, right: Uint8Array): Uint8Array {
+  let out = new Uint8Array(left.length + right.length);
+  out.set(left, 0);
+  out.set(right, left.length);
+  return out;
+}
+
+// Read the single frame at `offset`, folding its gains into `envelope`. Returns
+// undefined when the buffer doesn't yet hold a whole frame, which tells the
+// caller to wait for more bytes rather than resynchronize.
+function readOneFrame(
+  bytes: Uint8Array,
+  offset: number,
+  envelope: StreamingEnvelope,
+):
+  | { nextOffset: number; granules: number; sampleRate: number | undefined }
+  | undefined {
+  if (offset + 4 > bytes.length) {
+    return undefined;
+  }
+  let atSync =
+    bytes[offset] === FRAME_SYNC_FIRST &&
+    (bytes[offset + 1]! & FRAME_SYNC_SECOND_MASK) === FRAME_SYNC_SECOND_MASK;
+  let header = atSync ? parseFrameHeader(bytes, offset) : undefined;
+  if (!header) {
+    let resync = findFrameSync(bytes, offset + 1);
+    if (resync === undefined) {
+      return undefined;
+    }
+    return { nextOffset: resync, granules: 0, sampleRate: undefined };
+  }
+
+  let b1 = bytes[offset + 1]!;
+  let b2 = bytes[offset + 2]!;
+  let b3 = bytes[offset + 3]!;
+  let bitrateKbps =
+    BITRATE_KBPS[bitrateTableKey(header.version, header.layer)]?.[
+      (b2 >> 4) & 0x0f
+    ];
+  let length = frameLengthBytes(
+    header.version,
+    header.layer,
+    bitrateKbps ?? 0,
+    header.sampleRate,
+    ((b2 >> 1) & 0x01) === 1,
+  );
+  if (length === undefined || length < 4) {
+    return { nextOffset: offset + 1, granules: 0, sampleRate: undefined };
+  }
+  if (offset + length > bytes.length) {
+    // The frame straddles the end of what has arrived.
+    return undefined;
+  }
+
+  let channelCount = ((b3 >> 6) & 0x03) === 3 ? 1 : 2;
+  let granules = 0;
+  for (let gain of frameGlobalGains(
+    bytes,
+    offset,
+    header.version,
+    channelCount,
+    (b1 & 0x01) === 0,
+  )) {
+    let amplitude = 2 ** ((gain - GLOBAL_GAIN_BIAS) / 4);
+    envelope.push(amplitude * amplitude, 1, amplitude);
+    granules++;
+  }
+  return {
+    nextOffset: offset + length,
+    granules,
+    sampleRate: header.sampleRate,
+  };
+}

--- a/packages/base/mp3-meta-extractor.ts
+++ b/packages/base/mp3-meta-extractor.ts
@@ -1,4 +1,11 @@
+import {
+  prunedEncoding,
+  type AudioEncoding,
+  type ChannelMode,
+  type MediaTags,
+} from './audio-metadata';
 import { FileContentMismatchError } from './file-api';
+import { parseId3v2Tags } from './id3v2-parser';
 
 // MPEG audio frame sync: 11 bits set (0xFFE..). In practice the next bits
 // disambiguate MPEG version / layer, so we match the first byte as 0xFF and
@@ -201,4 +208,179 @@ export function extractMp3Duration(bytes: Uint8Array): { duration: number } {
   return {
     duration: (totalFrames * header.samplesPerFrame) / header.sampleRate,
   };
+}
+
+// Bitrate index → kbps, keyed by MPEG version and layer. Index 0 means "free
+// format" and 15 is reserved, so both are left as gaps rather than filled in.
+const BITRATE_KBPS: Record<string, (number | undefined)[]> = {
+  // MPEG 1
+  '3-3': [
+    undefined,
+    32,
+    64,
+    96,
+    128,
+    160,
+    192,
+    224,
+    256,
+    288,
+    320,
+    352,
+    384,
+    416,
+    448,
+    undefined,
+  ], // Layer I
+  '3-2': [
+    undefined,
+    32,
+    48,
+    56,
+    64,
+    80,
+    96,
+    112,
+    128,
+    160,
+    192,
+    224,
+    256,
+    320,
+    384,
+    undefined,
+  ], // Layer II
+  '3-1': [
+    undefined,
+    32,
+    40,
+    48,
+    56,
+    64,
+    80,
+    96,
+    112,
+    128,
+    160,
+    192,
+    224,
+    256,
+    320,
+    undefined,
+  ], // Layer III
+  // MPEG 2 and 2.5 share one table
+  '2-3': [
+    undefined,
+    32,
+    48,
+    56,
+    64,
+    80,
+    96,
+    112,
+    128,
+    144,
+    160,
+    176,
+    192,
+    224,
+    256,
+    undefined,
+  ],
+  '2-2': [
+    undefined,
+    8,
+    16,
+    24,
+    32,
+    40,
+    48,
+    56,
+    64,
+    80,
+    96,
+    112,
+    128,
+    144,
+    160,
+    undefined,
+  ],
+  '2-1': [
+    undefined,
+    8,
+    16,
+    24,
+    32,
+    40,
+    48,
+    56,
+    64,
+    80,
+    96,
+    112,
+    128,
+    144,
+    160,
+    undefined,
+  ],
+};
+
+const CHANNEL_MODES: Record<number, { mode: ChannelMode; channels: number }> = {
+  0: { mode: 'stereo', channels: 2 },
+  1: { mode: 'joint-stereo', channels: 2 },
+  2: { mode: 'dual-mono', channels: 2 },
+  3: { mode: 'mono', channels: 1 },
+};
+
+const LAYER_NAMES: Record<number, string> = {
+  [LAYER_I]: 'MPEG Layer I',
+  [LAYER_II]: 'MPEG Layer II',
+  [LAYER_III]: 'MP3 (MPEG Layer III)',
+};
+
+function bitrateTableKey(version: number, layer: number): string {
+  // MPEG 2.5 uses MPEG 2's bitrate table.
+  let versionKey = version === MPEG_VERSION_1 ? '3' : '2';
+  return `${versionKey}-${layer}`;
+}
+
+// The first MPEG frame header states the sample rate, channel mode, layer, and
+// that frame's bitrate. Whether the bitrate describes the file depends on
+// whether a Xing/Info/VBRI header is present — the same header the duration
+// reader looks for — so that determination is reported rather than assumed.
+export function extractMp3Encoding(
+  bytes: Uint8Array,
+): AudioEncoding | undefined {
+  let frameOffset = findFrameSync(bytes, id3v2TagSize(bytes));
+  if (frameOffset === undefined) {
+    return undefined;
+  }
+  let header = parseFrameHeader(bytes, frameOffset);
+  if (!header) {
+    return undefined;
+  }
+  let b2 = bytes[frameOffset + 2]!;
+  let b3 = bytes[frameOffset + 3]!;
+  let bitrateIndex = (b2 >> 4) & 0x0f;
+  let bitrateKbps =
+    BITRATE_KBPS[bitrateTableKey(header.version, header.layer)]?.[bitrateIndex];
+  let channelMode = CHANNEL_MODES[(b3 >> 6) & 0x03];
+  // A Xing/Info/VBRI header is what an encoder writes when the bitrate varies.
+  let isVariableBitrate = findVbrTotalFrames(bytes, frameOffset) !== undefined;
+
+  return prunedEncoding({
+    container: 'MPEG',
+    audioCodec: LAYER_NAMES[header.layer],
+    sampleRateHz: header.sampleRate,
+    bitrateBps: bitrateKbps === undefined ? undefined : bitrateKbps * 1000,
+    isVariableBitrate,
+    // MP3 is a lossy transform codec with no stored sample width, so bitDepth
+    // stays unset rather than being filled with a plausible 16.
+    channels: channelMode?.channels,
+    channelMode: channelMode?.mode,
+  });
+}
+
+export function extractMp3Tags(bytes: Uint8Array): MediaTags | undefined {
+  return parseId3v2Tags(bytes);
 }

--- a/packages/base/ogg-audio-def.gts
+++ b/packages/base/ogg-audio-def.gts
@@ -35,13 +35,22 @@ export class OggDef extends AudioDef {
       await getStream(),
     );
 
+    // Bound before the waveform call so the decode budget can be predicted from
+    // the sample rate and channel count the container already stated.
+    let encoding = extractOggEncoding(head);
+
     return {
       ...base,
       duration,
       ...audioAttributes(
-        extractOggEncoding(head),
+        encoding,
         extractOggTags(head),
-        await waveformFor(getStream, base.contentSize),
+        await waveformFor(getStream, {
+          durationSeconds: duration,
+          sampleRateHz: encoding?.sampleRateHz,
+          channels: encoding?.channels,
+          contentSize: base.contentSize,
+        }),
       ),
     };
   }

--- a/packages/base/ogg-audio-def.gts
+++ b/packages/base/ogg-audio-def.gts
@@ -1,7 +1,22 @@
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
-import AudioDef from './audio-file-def';
+import { readFirstBytes } from '@cardstack/runtime-common';
+import AudioDef, {
+  audioAttributes,
+  waveformFor,
+  type AudioAttributes,
+} from './audio-file-def';
 import type { ByteStream, SerializedFile } from './file-api';
-import { extractOggDurationFromStream } from './ogg-meta-extractor';
+import {
+  extractOggDurationFromStream,
+  extractOggEncoding,
+  extractOggTags,
+} from './ogg-meta-extractor';
+
+// The identification header sits on the first page and the comment block on the
+// next one or two, so a 64 KB window reaches both without touching the audio
+// payload. Read separately from the duration walk above, which streams and keeps
+// no such buffer.
+const OGG_METADATA_WINDOW_BYTES = 65_536;
 
 export class OggDef extends AudioDef {
   static displayName = 'OGG Audio';
@@ -12,7 +27,7 @@ export class OggDef extends AudioDef {
     url: string,
     getStream: () => Promise<ByteStream>,
     options: { contentHash?: string; contentSize?: number } = {},
-  ): Promise<SerializedFile<{ duration: number }>> {
+  ): Promise<SerializedFile<{ duration: number } & AudioAttributes>> {
     // OGG duration needs the first page (codec id / sample rate) and the final
     // page's granule position — the head and tail of the file, never the audio
     // payload in between. Stream the container keeping only a small head buffer
@@ -23,9 +38,19 @@ export class OggDef extends AudioDef {
     let base = await super.extractAttributes(url, getStream, options);
     let { duration } = await extractOggDurationFromStream(await getStream());
 
+    let header = await readFirstBytes(
+      await getStream(),
+      OGG_METADATA_WINDOW_BYTES,
+    );
+
     return {
       ...base,
       duration,
+      ...audioAttributes(
+        extractOggEncoding(header),
+        extractOggTags(header),
+        await waveformFor(getStream, base.contentSize),
+      ),
     };
   }
 }

--- a/packages/base/ogg-audio-def.gts
+++ b/packages/base/ogg-audio-def.gts
@@ -1,5 +1,4 @@
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
-import { readFirstBytes } from '@cardstack/runtime-common';
 import AudioDef, {
   audioAttributes,
   waveformFor,
@@ -11,12 +10,6 @@ import {
   extractOggEncoding,
   extractOggTags,
 } from './ogg-meta-extractor';
-
-// The identification header sits on the first page and the comment block on the
-// next one or two, so a 64 KB window reaches both without touching the audio
-// payload. Read separately from the duration walk above, which streams and keeps
-// no such buffer.
-const OGG_METADATA_WINDOW_BYTES = 65_536;
 
 export class OggDef extends AudioDef {
   static displayName = 'OGG Audio';
@@ -36,19 +29,18 @@ export class OggDef extends AudioDef {
     // from `options` (supplied by the indexer) without re-reading, so when
     // those are present the stream is consumed exactly once — by this walk.
     let base = await super.extractAttributes(url, getStream, options);
-    let { duration } = await extractOggDurationFromStream(await getStream());
-
-    let header = await readFirstBytes(
+    // One walk yields duration and the head the metadata readers need, so this
+    // costs a single stream rather than the two a separate header read would.
+    let { duration, head } = await extractOggDurationFromStream(
       await getStream(),
-      OGG_METADATA_WINDOW_BYTES,
     );
 
     return {
       ...base,
       duration,
       ...audioAttributes(
-        extractOggEncoding(header),
-        extractOggTags(header),
+        extractOggEncoding(head),
+        extractOggTags(head),
         await waveformFor(getStream, base.contentSize),
       ),
     };

--- a/packages/base/ogg-meta-extractor.ts
+++ b/packages/base/ogg-meta-extractor.ts
@@ -1,4 +1,11 @@
+import {
+  channelModeForCount,
+  prunedEncoding,
+  type AudioEncoding,
+  type MediaTags,
+} from './audio-metadata';
 import { FileContentMismatchError } from './file-api';
+import { parseVorbisComments } from './vorbis-comment-parser';
 
 // Ogg page capture pattern: "OggS"
 const OGGS = [0x4f, 0x67, 0x67, 0x53];
@@ -285,4 +292,94 @@ export async function extractOggDurationFromStream(
 
   let playable = Math.max(0, granule - preSkipSamples);
   return { duration: playable / outputSampleRate };
+}
+
+// Ogg carries its comment block in the second packet of the logical stream, on a
+// page after the identification header. Rather than reassemble packets, scan the
+// read window for the comment magic — both codecs prefix theirs distinctively,
+// and a scan is robust to the page boundaries a comment block may straddle.
+const VORBIS_COMMENT_MAGIC = [0x03, 0x76, 0x6f, 0x72, 0x62, 0x69, 0x73]; // "\x03vorbis"
+const OPUS_TAGS_MAGIC = [0x4f, 0x70, 0x75, 0x73, 0x54, 0x61, 0x67, 0x73]; // "OpusTags"
+
+function indexOfMagic(
+  bytes: Uint8Array,
+  magic: readonly number[],
+  from = 0,
+): number | undefined {
+  let limit = bytes.length - magic.length;
+  for (let offset = from; offset <= limit; offset++) {
+    if (matchBytes(bytes, offset, magic)) {
+      return offset;
+    }
+  }
+  return undefined;
+}
+
+// The identification header states the channel count and sample rate. Opus always
+// decodes to 48 kHz regardless of what it was captured at, so that is what gets
+// reported — it is the rate any consumer will actually receive.
+export function extractOggEncoding(
+  bytes: Uint8Array,
+): AudioEncoding | undefined {
+  if (!matchBytes(bytes, 0, OGGS)) {
+    return undefined;
+  }
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let dataOffset: number;
+  try {
+    dataOffset = firstPageDataOffset(bytes);
+  } catch {
+    return undefined;
+  }
+
+  if (matchBytes(bytes, dataOffset, VORBIS_ID_MAGIC)) {
+    // 7 bytes magic, 4 version, 1 channels, 4 sample rate, then three bitrate
+    // fields (maximum, nominal, minimum) as signed 32-bit little-endian.
+    if (dataOffset + 28 > bytes.length) {
+      return undefined;
+    }
+    let channels = bytes[dataOffset + 11]!;
+    let sampleRate = view.getUint32(dataOffset + 12, true);
+    let nominalBitrate = view.getInt32(dataOffset + 20, true);
+    return prunedEncoding({
+      container: 'Ogg',
+      audioCodec: 'Vorbis',
+      sampleRateHz: sampleRate > 0 ? sampleRate : undefined,
+      // Vorbis states a nominal rate; zero or negative means "not declared".
+      bitrateBps: nominalBitrate > 0 ? nominalBitrate : undefined,
+      isVariableBitrate: true,
+      channels: channels > 0 ? channels : undefined,
+      channelMode: channelModeForCount(channels > 0 ? channels : undefined),
+    });
+  }
+
+  if (matchBytes(bytes, dataOffset, OPUS_ID_MAGIC)) {
+    if (dataOffset + 10 > bytes.length) {
+      return undefined;
+    }
+    let channels = bytes[dataOffset + 9]!;
+    return prunedEncoding({
+      container: 'Ogg',
+      audioCodec: 'Opus',
+      sampleRateHz: OPUS_OUTPUT_SAMPLE_RATE,
+      isVariableBitrate: true,
+      channels: channels > 0 ? channels : undefined,
+      channelMode: channelModeForCount(channels > 0 ? channels : undefined),
+    });
+  }
+
+  return undefined;
+}
+
+export function extractOggTags(bytes: Uint8Array): MediaTags | undefined {
+  let vorbisAt = indexOfMagic(bytes, VORBIS_COMMENT_MAGIC);
+  if (vorbisAt !== undefined) {
+    return parseVorbisComments(bytes, vorbisAt + VORBIS_COMMENT_MAGIC.length)
+      ?.tags;
+  }
+  let opusAt = indexOfMagic(bytes, OPUS_TAGS_MAGIC);
+  if (opusAt !== undefined) {
+    return parseVorbisComments(bytes, opusAt + OPUS_TAGS_MAGIC.length)?.tags;
+  }
+  return undefined;
 }

--- a/packages/base/ogg-meta-extractor.ts
+++ b/packages/base/ogg-meta-extractor.ts
@@ -172,7 +172,12 @@ export function extractOggDuration(bytes: Uint8Array): { duration: number } {
 
 // Enough of the file's start to cover the first page header (27 bytes + up to
 // 255 lacing values) plus the Vorbis/Opus identification packet that follows.
-const OGG_HEAD_BYTES = 4096;
+// Sized for the metadata read rather than the duration read. Parsing the first
+// page needs only a few hundred bytes, but the comment block sits a page or two
+// further in — and retaining that much here means the def gets duration,
+// encoding, and tags from this single walk instead of taking a second stream,
+// which the extract runner would satisfy by re-fetching the whole file.
+const OGG_HEAD_BYTES = 65_536;
 
 // The final page's "OggS" sits at most one max-size Ogg page (27 + 255 +
 // 255*255 = 65307 bytes) before EOF in a well-formed stream. A tail window at
@@ -201,11 +206,16 @@ function concatParts(parts: Uint8Array[], length: number): Uint8Array {
 // tail window, letting the audio payload in between stream past without being
 // buffered, so peak memory is ~`OGG_TAIL_BYTES` rather than the whole file. A
 // `Uint8Array` input (already-buffered bytes) is parsed directly.
+// Returns the retained head alongside the duration so one pass serves every
+// reader: `extractOggEncoding` and `extractOggTags` both work off `head`.
 export async function extractOggDurationFromStream(
   stream: ReadableStream<Uint8Array> | Uint8Array,
-): Promise<{ duration: number }> {
+): Promise<{ duration: number; head: Uint8Array }> {
   if (stream instanceof Uint8Array) {
-    return extractOggDuration(stream);
+    return {
+      ...extractOggDuration(stream),
+      head: stream.subarray(0, Math.min(stream.length, OGG_HEAD_BYTES)),
+    };
   }
 
   let reader = stream.getReader();
@@ -291,7 +301,7 @@ export async function extractOggDurationFromStream(
   );
 
   let playable = Math.max(0, granule - preSkipSamples);
-  return { duration: playable / outputSampleRate };
+  return { duration: playable / outputSampleRate, head };
 }
 
 // Ogg carries its comment block in the second packet of the logical stream, on a

--- a/packages/base/streaming-envelope.ts
+++ b/packages/base/streaming-envelope.ts
@@ -1,0 +1,130 @@
+// A fixed-memory amplitude accumulator for producers that don't know how much
+// audio is coming.
+//
+// The batch reduction in `audio-waveform` can divide a known sample count into
+// equal windows. A streaming producer can't: it has to place a value into a bar
+// before it knows how many values there will be. Guessing the total from a
+// header estimate would put the whole tail of a longer-than-expected file into
+// the last bar.
+//
+// So this accumulates into far more buckets than it needs and halves the
+// resolution whenever it runs out — the standard doubling histogram. Each fold
+// merges adjacent pairs, so a bucket always covers an equal span of the signal
+// and memory never grows with duration.
+
+// How many fine buckets to keep per output bar. Higher costs nothing meaningful
+// and reduces the boundary error left over from the final fold; 16 puts each
+// bar's edge within a sixteenth of a bar of where an exact windowing would have
+// placed it.
+const OVERSAMPLE = 16;
+
+export class StreamingEnvelope {
+  #barCount: number;
+  #capacity: number;
+  #squareSums: Float64Array;
+  #counts: Float64Array;
+  // Buckets written so far, including the one currently filling.
+  #used = 0;
+  // How many units each bucket holds at the current resolution. Doubles on fold.
+  #unitsPerBucket = 1;
+  // Units already placed into the bucket at `#used - 1`.
+  #unitsInCurrent = 0;
+  #peak = 0;
+  #totalSquareSum = 0;
+  #totalCount = 0;
+
+  constructor(barCount: number) {
+    this.#barCount = Math.max(1, barCount);
+    this.#capacity = this.#barCount * OVERSAMPLE;
+    this.#squareSums = new Float64Array(this.#capacity);
+    this.#counts = new Float64Array(this.#capacity);
+  }
+
+  // Add one indivisible unit of signal: a granule, a fixed-size sample window,
+  // whatever the producer measures in. Producers must use a consistent unit, so
+  // every bucket covers the same span.
+  push(squareSum: number, count: number, peak?: number): void {
+    if (count <= 0) {
+      return;
+    }
+    if (this.#unitsInCurrent >= this.#unitsPerBucket || this.#used === 0) {
+      if (this.#used >= this.#capacity) {
+        this.#fold();
+      }
+      this.#used++;
+      this.#unitsInCurrent = 0;
+    }
+    let index = this.#used - 1;
+    this.#squareSums[index] += squareSum;
+    this.#counts[index] += count;
+    this.#unitsInCurrent++;
+    this.#totalSquareSum += squareSum;
+    this.#totalCount += count;
+    if (peak !== undefined && peak > this.#peak) {
+      this.#peak = peak;
+    }
+  }
+
+  // Halve the resolution by merging adjacent bucket pairs, so the accumulator
+  // can keep going without allocating.
+  #fold(): void {
+    let merged = Math.ceil(this.#used / 2);
+    for (let index = 0; index < merged; index++) {
+      let left = index * 2;
+      let right = left + 1;
+      this.#squareSums[index] =
+        this.#squareSums[left]! +
+        (right < this.#used ? this.#squareSums[right]! : 0);
+      this.#counts[index] =
+        this.#counts[left]! + (right < this.#used ? this.#counts[right]! : 0);
+    }
+    this.#squareSums.fill(0, merged);
+    this.#counts.fill(0, merged);
+    this.#used = merged;
+    this.#unitsPerBucket *= 2;
+    // The bucket that was filling is now merged into its partner, so treat the
+    // last bucket as full and let the next push open a fresh one.
+    this.#unitsInCurrent = this.#unitsPerBucket;
+  }
+
+  get peak(): number {
+    return this.#peak;
+  }
+
+  get overallRms(): number {
+    return this.#totalCount > 0
+      ? Math.sqrt(this.#totalSquareSum / this.#totalCount)
+      : 0;
+  }
+
+  get isEmpty(): boolean {
+    return this.#used === 0;
+  }
+
+  // Fold the fine buckets down to the requested bar count. A bar's value is the
+  // RMS across its buckets, weighted by how much signal each holds, so an
+  // uneven final bucket doesn't skew the last bar.
+  bars(digits = 4): number[] {
+    if (this.#used === 0) {
+      return [];
+    }
+    let factor = 10 ** digits;
+    let out: number[] = [];
+    for (let bar = 0; bar < this.#barCount; bar++) {
+      let start = Math.floor((bar * this.#used) / this.#barCount);
+      let end = Math.floor(((bar + 1) * this.#used) / this.#barCount);
+      if (end <= start) {
+        end = Math.min(start + 1, this.#used);
+      }
+      let squareSum = 0;
+      let count = 0;
+      for (let index = start; index < end; index++) {
+        squareSum += this.#squareSums[index]!;
+        count += this.#counts[index]!;
+      }
+      let value = count > 0 ? Math.sqrt(squareSum / count) : 0;
+      out.push(Math.round(value * factor) / factor);
+    }
+    return out;
+  }
+}

--- a/packages/base/vorbis-comment-parser.ts
+++ b/packages/base/vorbis-comment-parser.ts
@@ -1,0 +1,141 @@
+// Vorbis comments: the tagging convention FLAC and Ogg (Vorbis and Opus) share.
+//
+// The structure is a vendor string followed by a count and then that many
+// `FIELD=value` entries, each length-prefixed with a 32-bit little-endian count.
+// Field names are case-insensitive ASCII; values are UTF-8.
+//
+// Pure `DataView`/`TextDecoder`, no DOM — the same reason the rest of the
+// `*-meta-extractor` modules are.
+
+import { parseTagYear, prunedTags, type MediaTags } from './audio-metadata';
+
+// A tag block with more entries than this is corrupt or hostile. Real files run
+// to a few dozen; embedded artwork travels as a separate FLAC picture block or
+// an Ogg `METADATA_BLOCK_PICTURE` entry, which this deliberately skips.
+const MAX_COMMENT_ENTRIES = 512;
+
+// One entry longer than this is not a descriptive tag. Caps the worst case when
+// a length prefix is garbage, and skips base64 artwork rather than decoding it
+// into a string nobody reads.
+const MAX_ENTRY_BYTES = 16_384;
+
+const UTF8 = new TextDecoder('utf-8', { fatal: false });
+
+// The comment keys worth persisting, mapped onto the shared tag shape. Anything
+// else in the block is left alone: a realm's files carry all sorts of
+// application-specific keys, and hoovering them into fields nobody declared
+// would bloat every index row.
+const FIELD_ALIASES: Record<string, keyof MediaTags> = {
+  TITLE: 'trackTitle',
+  ARTIST: 'artist',
+  ALBUM: 'album',
+  ALBUMARTIST: 'albumArtist',
+  'ALBUM ARTIST': 'albumArtist',
+  COMPOSER: 'composer',
+  DATE: 'year',
+  YEAR: 'year',
+  ORIGINALDATE: 'year',
+  TRACKNUMBER: 'track',
+  TRACK: 'track',
+  DISCNUMBER: 'disc',
+  DISC: 'disc',
+  GENRE: 'genre',
+  COMMENT: 'comment',
+  DESCRIPTION: 'comment',
+};
+
+export interface VorbisComments {
+  vendor?: string;
+  tags?: MediaTags;
+}
+
+// Parse a Vorbis comment block starting at `offset`. Returns undefined when the
+// block isn't readable — a truncated or absent tag block is ordinary, not an
+// error, so nothing throws.
+export function parseVorbisComments(
+  bytes: Uint8Array,
+  offset: number,
+  // Where the block ends. FLAC knows this from its metadata block header; Ogg
+  // passes the end of the packet.
+  end: number = bytes.byteLength,
+): VorbisComments | undefined {
+  let limit = Math.min(end, bytes.byteLength);
+  if (offset < 0 || offset + 8 > limit) {
+    return undefined;
+  }
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+  let vendorLength = view.getUint32(offset, true);
+  let cursor = offset + 4;
+  if (vendorLength > MAX_ENTRY_BYTES || cursor + vendorLength + 4 > limit) {
+    return undefined;
+  }
+  let vendor = UTF8.decode(
+    bytes.subarray(cursor, cursor + vendorLength),
+  ).trim();
+  cursor += vendorLength;
+
+  let entryCount = view.getUint32(cursor, true);
+  cursor += 4;
+  if (entryCount > MAX_COMMENT_ENTRIES) {
+    return undefined;
+  }
+
+  let collected: MediaTags = {};
+  let years: string[] = [];
+  for (let index = 0; index < entryCount; index++) {
+    if (cursor + 4 > limit) {
+      break;
+    }
+    let entryLength = view.getUint32(cursor, true);
+    cursor += 4;
+    if (entryLength > MAX_ENTRY_BYTES) {
+      // Almost certainly embedded artwork or a corrupt length. Skipping the
+      // payload keeps the walk in sync when the length is merely large.
+      cursor += entryLength;
+      continue;
+    }
+    if (cursor + entryLength > limit) {
+      break;
+    }
+    let entry = UTF8.decode(bytes.subarray(cursor, cursor + entryLength));
+    cursor += entryLength;
+
+    let separator = entry.indexOf('=');
+    if (separator <= 0) {
+      continue;
+    }
+    let key = entry.slice(0, separator).trim().toUpperCase();
+    let value = entry.slice(separator + 1).trim();
+    if (!value) {
+      continue;
+    }
+    let target = FIELD_ALIASES[key];
+    if (!target) {
+      continue;
+    }
+    if (target === 'year') {
+      years.push(value);
+      continue;
+    }
+    // First occurrence wins. Vorbis permits repeated keys for genuinely
+    // multi-valued fields (two ARTISTs on a collaboration), and joining them
+    // into one string would invent a credit the file didn't state.
+    if (collected[target] === undefined) {
+      (collected as Record<string, string>)[target] = value;
+    }
+  }
+
+  for (let candidate of years) {
+    let year = parseTagYear(candidate);
+    if (year !== undefined) {
+      collected.year = year;
+      break;
+    }
+  }
+
+  let tags = prunedTags({ ...collected, scheme: 'vorbis-comment' });
+  return vendor || tags
+    ? { ...(vendor ? { vendor } : {}), ...(tags ? { tags } : {}) }
+    : undefined;
+}

--- a/packages/base/wav-audio-def.gts
+++ b/packages/base/wav-audio-def.gts
@@ -1,44 +1,76 @@
-import { readFirstBytes } from '@cardstack/runtime-common';
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
 import AudioDef, {
   audioAttributes,
-  waveformFor,
   type AudioAttributes,
 } from './audio-file-def';
+import { FileContentMismatchError } from './file-api';
 import type { ByteStream, SerializedFile } from './file-api';
-import {
-  extractWavDuration,
-  extractWavEncoding,
-  extractWavTags,
-} from './wav-meta-extractor';
-
-// A WAVE file's `fmt ` and `data` chunk headers normally sit within the first
-// few hundred bytes, but BWF metadata (bext, LIST/INFO, iXML) can push `data`
-// further in. 64 KB matches the JPEG header window and covers anything we'd
-// realistically encounter.
-const WAV_MAX_HEADER_BYTES = 65_536;
+import { WAVEFORM_ALGORITHM, WAVEFORM_BAR_COUNT } from './audio-waveform';
+import { extractWavFromStream } from './wav-meta-extractor';
 
 export class WavDef extends AudioDef {
   static displayName = 'WAV Audio';
   static icon = FileAudioIcon;
   static acceptTypes = '.wav,audio/wav,audio/wave,audio/x-wav';
 
+  // Everything comes from one pass over one stream.
+  //
+  // WAV is the only audio format here that needs no decoder at all: the `data`
+  // chunk already holds the samples. The buffered path used to read a header
+  // window, then take a second stream, buffer the entire file, and hand it to
+  // Web Audio — which allocated a float copy roughly twice the file's size to
+  // recover samples the file already contained.
+  //
+  // Streaming the container instead keeps only a bounded header buffer and one
+  // chunk of payload at a time, so memory is flat in the file's duration, and it
+  // costs one fetch rather than two. The envelope is true RMS over real samples,
+  // so unlike MP3's side-info proxy it needs no normalization and its peak and
+  // RMS figures mean what they say.
   static async extractAttributes(
     url: string,
     getStream: () => Promise<ByteStream>,
     options: { contentHash?: string; contentSize?: number } = {},
   ): Promise<SerializedFile<{ duration: number } & AudioAttributes>> {
     let base = await super.extractAttributes(url, getStream, options);
-    let bytes = await readFirstBytes(await getStream(), WAV_MAX_HEADER_BYTES);
-    let { duration } = extractWavDuration(bytes);
+    let result = await extractWavFromStream(
+      await getStream(),
+      WAVEFORM_BAR_COUNT,
+    );
+
+    if (result.duration === undefined) {
+      // No `fmt `/`data` pair means this isn't a WAVE container, which is how
+      // the extractor knows to fall back to the base FileDef.
+      throw new FileContentMismatchError(
+        'WAV file is missing a fmt chunk with a non-zero byte rate, or a data chunk',
+      );
+    }
 
     return {
       ...base,
-      duration,
+      duration: result.duration,
       ...audioAttributes(
-        extractWavEncoding(bytes),
-        extractWavTags(bytes),
-        await waveformFor(getStream, base.contentSize),
+        result.encoding,
+        result.tags,
+        result.envelope
+          ? {
+              decodeStatus: 'ok',
+              algorithm: WAVEFORM_ALGORITHM,
+              barsJson: JSON.stringify(result.envelope.bars),
+              barCount: result.envelope.bars.length,
+              durationSeconds: Math.round(result.duration * 1000) / 1000,
+              ...(result.encoding?.sampleRateHz === undefined
+                ? {}
+                : { sampleRateHz: result.encoding.sampleRateHz }),
+              ...(result.encoding?.channels === undefined
+                ? {}
+                : { channelCount: result.encoding.channels }),
+              peakAmplitude: result.envelope.peak,
+              rmsAmplitude: result.envelope.rms,
+            }
+          : {
+              decodeStatus: 'failed',
+              decodeError: 'No PCM payload to derive an envelope from',
+            },
       ),
     };
   }

--- a/packages/base/wav-audio-def.gts
+++ b/packages/base/wav-audio-def.gts
@@ -1,8 +1,16 @@
 import { readFirstBytes } from '@cardstack/runtime-common';
 import FileAudioIcon from '@cardstack/boxel-icons/file-audio';
-import AudioDef from './audio-file-def';
+import AudioDef, {
+  audioAttributes,
+  waveformFor,
+  type AudioAttributes,
+} from './audio-file-def';
 import type { ByteStream, SerializedFile } from './file-api';
-import { extractWavDuration } from './wav-meta-extractor';
+import {
+  extractWavDuration,
+  extractWavEncoding,
+  extractWavTags,
+} from './wav-meta-extractor';
 
 // A WAVE file's `fmt ` and `data` chunk headers normally sit within the first
 // few hundred bytes, but BWF metadata (bext, LIST/INFO, iXML) can push `data`
@@ -18,8 +26,8 @@ export class WavDef extends AudioDef {
   static async extractAttributes(
     url: string,
     getStream: () => Promise<ByteStream>,
-    options: { contentHash?: string } = {},
-  ): Promise<SerializedFile<{ duration: number }>> {
+    options: { contentHash?: string; contentSize?: number } = {},
+  ): Promise<SerializedFile<{ duration: number } & AudioAttributes>> {
     let base = await super.extractAttributes(url, getStream, options);
     let bytes = await readFirstBytes(await getStream(), WAV_MAX_HEADER_BYTES);
     let { duration } = extractWavDuration(bytes);
@@ -27,6 +35,11 @@ export class WavDef extends AudioDef {
     return {
       ...base,
       duration,
+      ...audioAttributes(
+        extractWavEncoding(bytes),
+        extractWavTags(bytes),
+        await waveformFor(getStream, base.contentSize),
+      ),
     };
   }
 }

--- a/packages/base/wav-meta-extractor.ts
+++ b/packages/base/wav-meta-extractor.ts
@@ -1,3 +1,11 @@
+import {
+  channelModeForCount,
+  parseTagYear,
+  prunedEncoding,
+  prunedTags,
+  type AudioEncoding,
+  type MediaTags,
+} from './audio-metadata';
 import { FileContentMismatchError } from './file-api';
 
 // RIFF/WAVE 4-byte ASCII tags
@@ -5,6 +13,7 @@ const RIFF = [0x52, 0x49, 0x46, 0x46]; // "RIFF"
 const WAVE = [0x57, 0x41, 0x56, 0x45]; // "WAVE"
 const FMT = [0x66, 0x6d, 0x74, 0x20]; // "fmt "
 const DATA = [0x64, 0x61, 0x74, 0x61]; // "data"
+const INFO = [0x49, 0x4e, 0x46, 0x4f]; // "INFO"
 
 // RIFF (4) + size (4) + WAVE (4)
 const RIFF_HEADER_BYTES = 12;
@@ -94,4 +103,156 @@ export function extractWavDuration(bytes: Uint8Array): { duration: number } {
   }
 
   return { duration: dataSize / byteRate };
+}
+
+// WAV format codes. Only the ones that describe how samples are stored matter
+// here; an unrecognized code leaves the codec unnamed rather than guessed at.
+const WAVE_FORMAT_PCM = 0x0001;
+const WAVE_FORMAT_IEEE_FLOAT = 0x0003;
+const WAVE_FORMAT_ALAW = 0x0006;
+const WAVE_FORMAT_MULAW = 0x0007;
+// An "extensible" fmt chunk defers the real format to a GUID in its extension,
+// but keeps the sample layout in the same place, so the layout still reads.
+const WAVE_FORMAT_EXTENSIBLE = 0xfffe;
+
+const WAVE_CODECS: Record<number, string> = {
+  [WAVE_FORMAT_PCM]: 'PCM',
+  [WAVE_FORMAT_IEEE_FLOAT]: 'IEEE float',
+  [WAVE_FORMAT_ALAW]: 'A-law',
+  [WAVE_FORMAT_MULAW]: 'μ-law',
+  [WAVE_FORMAT_EXTENSIBLE]: 'PCM (extensible)',
+};
+
+// LIST-INFO chunk ids, mapped onto the shared tag shape.
+const INFO_ALIASES: Record<string, keyof MediaTags> = {
+  INAM: 'trackTitle',
+  IART: 'artist',
+  IPRD: 'album',
+  IMUS: 'composer',
+  ICRD: 'year',
+  ITRK: 'track',
+  IPRT: 'track',
+  IGNR: 'genre',
+  ICMT: 'comment',
+};
+
+// A LIST-INFO entry longer than this is not a descriptive tag.
+const MAX_INFO_ENTRY_BYTES = 8192;
+
+// Walk the top-level RIFF chunks, handing each to `visit`. Shared by the readers
+// below so the word-alignment and malformed-size rules live in one place.
+//
+// Unlike the duration reader this never throws: a chunk walk that desynchronizes
+// partway through has still yielded whatever it saw, and absent metadata is
+// ordinary.
+function walkRiffChunks(
+  bytes: Uint8Array,
+  visit: (id: string, dataStart: number, dataSize: number) => void,
+): void {
+  if (bytes.length < RIFF_HEADER_BYTES) {
+    return;
+  }
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let offset = RIFF_HEADER_BYTES;
+  while (offset + CHUNK_HEADER_BYTES <= bytes.length) {
+    let chunkSize = view.getUint32(offset + 4, true);
+    let id = String.fromCharCode(...bytes.subarray(offset, offset + 4));
+    visit(id, offset + CHUNK_HEADER_BYTES, chunkSize);
+    // RIFF chunks are word-aligned: an odd-sized chunk carries a 1-byte pad.
+    let advance = CHUNK_HEADER_BYTES + chunkSize + (chunkSize & 1);
+    if (advance <= CHUNK_HEADER_BYTES) {
+      return;
+    }
+    offset += advance;
+  }
+}
+
+// The `fmt ` chunk states the sample layout outright, so WAV is the one audio
+// format where every encoding fact is directly declared rather than derived.
+export function extractWavEncoding(
+  bytes: Uint8Array,
+): AudioEncoding | undefined {
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let encoding: AudioEncoding | undefined;
+  walkRiffChunks(bytes, (id, dataStart, dataSize) => {
+    if (id !== 'fmt ' || encoding || dataSize < 16) {
+      return;
+    }
+    if (dataStart + 16 > bytes.length) {
+      return;
+    }
+    let formatCode = view.getUint16(dataStart, true);
+    let channels = view.getUint16(dataStart + 2, true);
+    let sampleRate = view.getUint32(dataStart + 4, true);
+    let byteRate = view.getUint32(dataStart + 8, true);
+    let bitsPerSample = view.getUint16(dataStart + 14, true);
+    encoding = prunedEncoding({
+      container: 'WAV',
+      audioCodec: WAVE_CODECS[formatCode],
+      sampleRateHz: sampleRate > 0 ? sampleRate : undefined,
+      // PCM is constant-rate by definition, so the byte rate is the whole
+      // stream's bitrate rather than one frame's.
+      bitrateBps: byteRate > 0 ? byteRate * 8 : undefined,
+      isVariableBitrate: byteRate > 0 ? false : undefined,
+      bitDepth: bitsPerSample > 0 ? bitsPerSample : undefined,
+      channels: channels > 0 ? channels : undefined,
+      channelMode: channelModeForCount(channels > 0 ? channels : undefined),
+    });
+  });
+  return encoding;
+}
+
+// WAV's optional LIST-INFO chunk. Each entry is a 4-character id, a
+// little-endian size, and NUL-padded Latin-1 text.
+export function extractWavTags(bytes: Uint8Array): MediaTags | undefined {
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let latin1 = new TextDecoder('latin1');
+  let collected: MediaTags = {};
+  let yearText: string | undefined;
+
+  walkRiffChunks(bytes, (id, dataStart, dataSize) => {
+    if (id !== 'LIST' || dataSize < 4) {
+      return;
+    }
+    let listEnd = Math.min(dataStart + dataSize, bytes.length);
+    if (
+      !INFO.every((expected, index) => bytes[dataStart + index] === expected)
+    ) {
+      // A LIST chunk can also hold cue labels or adtl data; only INFO carries
+      // descriptive tags.
+      return;
+    }
+    let cursor = dataStart + 4;
+    while (cursor + CHUNK_HEADER_BYTES <= listEnd) {
+      let entryId = String.fromCharCode(...bytes.subarray(cursor, cursor + 4));
+      let entrySize = view.getUint32(cursor + 4, true);
+      let valueStart = cursor + CHUNK_HEADER_BYTES;
+      if (entrySize <= 0 || valueStart + entrySize > listEnd) {
+        return;
+      }
+      if (entrySize <= MAX_INFO_ENTRY_BYTES) {
+        let raw = bytes.subarray(valueStart, valueStart + entrySize);
+        let terminator = raw.indexOf(0);
+        let value = latin1
+          .decode(terminator === -1 ? raw : raw.subarray(0, terminator))
+          .trim();
+        let target = INFO_ALIASES[entryId];
+        if (value && target) {
+          if (target === 'year') {
+            yearText ??= value;
+          } else if (collected[target] === undefined) {
+            (collected as Record<string, string>)[target] = value;
+          }
+        }
+      }
+      cursor = valueStart + entrySize + (entrySize & 1);
+    }
+  });
+
+  let year = parseTagYear(yearText);
+  return prunedTags({
+    ...collected,
+    ...(year === undefined ? {} : { year }),
+    scheme: 'riff-info',
+  });
 }

--- a/packages/base/wav-meta-extractor.ts
+++ b/packages/base/wav-meta-extractor.ts
@@ -7,6 +7,7 @@ import {
   type MediaTags,
 } from './audio-metadata';
 import { FileContentMismatchError } from './file-api';
+import { StreamingEnvelope } from './streaming-envelope';
 
 // RIFF/WAVE 4-byte ASCII tags
 const RIFF = [0x52, 0x49, 0x46, 0x46]; // "RIFF"
@@ -255,4 +256,360 @@ export function extractWavTags(bytes: Uint8Array): MediaTags | undefined {
     ...(year === undefined ? {} : { year }),
     scheme: 'riff-info',
   });
+}
+
+// ── Single-pass streaming read ───────────────────────────────────────────────
+//
+// WAV is the one audio format that needs no decoder for its envelope: the `data`
+// chunk *is* the PCM. Decoding it through Web Audio would buffer the whole file
+// and then allocate a second float copy of it, to arrive at samples the file
+// already contained.
+//
+// So this walks the container once, off the stream, keeping only a bounded
+// header buffer and one chunk of payload at a time. Duration, encoding, tags,
+// and the amplitude envelope all come out of that single pass — which also means
+// one fetch rather than the two the buffered path needed.
+//
+// Because these are real samples rather than a quantizer proxy, the envelope is
+// true RMS on the same scale a decoded one would produce, so `peakAmplitude` and
+// `rmsAmplitude` are meaningful and no normalization is needed.
+
+// How much header to buffer while looking for `fmt ` and `data`. Broadcast WAVE
+// metadata (bext, iXML) can push `data` a long way in, but a header past this is
+// not something to hold in memory during indexing.
+const WAV_STREAM_HEADER_LIMIT = 1_048_576;
+
+// Trailing chunks — a LIST-INFO block written after the audio, which some
+// encoders do — are captured up to this much. Bounded because it accumulates
+// while the payload streams past.
+const WAV_STREAM_TRAILER_LIMIT = 262_144;
+
+// Samples pushed per envelope unit. Small enough that a bar boundary lands
+// close to where an exact windowing would put it, large enough that the
+// per-push overhead disappears against the sample loop.
+const ENVELOPE_WINDOW_FRAMES = 1024;
+
+export interface WavStreamResult {
+  duration?: number;
+  encoding?: AudioEncoding;
+  tags?: MediaTags;
+  envelope?: {
+    bars: number[];
+    peak: number;
+    rms: number;
+    sampleCount: number;
+  };
+}
+
+interface PcmFormat {
+  formatCode: number;
+  channels: number;
+  sampleRate: number;
+  bitsPerSample: number;
+  blockAlign: number;
+}
+
+// Read one sample and return it as a float in [-1, 1]. Each PCM width has its
+// own convention: 8-bit is unsigned around a 128 midpoint, everything wider is
+// two's-complement signed, and format 3 is already float.
+function readSample(
+  view: DataView,
+  offset: number,
+  format: PcmFormat,
+): number | undefined {
+  if (format.formatCode === WAVE_FORMAT_IEEE_FLOAT) {
+    if (format.bitsPerSample === 32) {
+      return view.getFloat32(offset, true);
+    }
+    if (format.bitsPerSample === 64) {
+      return view.getFloat64(offset, true);
+    }
+    return undefined;
+  }
+  switch (format.bitsPerSample) {
+    case 8:
+      return (view.getUint8(offset) - 128) / 128;
+    case 16:
+      return view.getInt16(offset, true) / 32768;
+    case 24: {
+      // No getInt24, so assemble it and sign-extend the 24th bit.
+      let raw =
+        view.getUint8(offset) |
+        (view.getUint8(offset + 1) << 8) |
+        (view.getUint8(offset + 2) << 16);
+      let signed = (raw << 8) >> 8;
+      return signed / 8388608;
+    }
+    case 32:
+      return view.getInt32(offset, true) / 2147483648;
+    default:
+      return undefined;
+  }
+}
+
+// Fold a run of PCM bytes into the envelope. Returns how many bytes were
+// consumed; a trailing partial frame is left for the next call to prepend, so a
+// sample split across two stream chunks isn't dropped or misread.
+function consumePcm(
+  bytes: Uint8Array,
+  format: PcmFormat,
+  envelope: StreamingEnvelope,
+  carry: { squareSum: number; count: number; peak: number; frames: number },
+): number {
+  let bytesPerSample = format.bitsPerSample / 8;
+  let frameBytes = bytesPerSample * format.channels;
+  if (frameBytes <= 0) {
+    return bytes.length;
+  }
+  let wholeFrames = Math.floor(bytes.length / frameBytes);
+  if (wholeFrames === 0) {
+    return 0;
+  }
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+  for (let frame = 0; frame < wholeFrames; frame++) {
+    let base = frame * frameBytes;
+    for (let channel = 0; channel < format.channels; channel++) {
+      let sample = readSample(view, base + channel * bytesPerSample, format);
+      if (sample === undefined) {
+        return wholeFrames * frameBytes;
+      }
+      carry.squareSum += sample * sample;
+      carry.count++;
+      let magnitude = Math.abs(sample);
+      if (magnitude > carry.peak) {
+        carry.peak = magnitude;
+      }
+    }
+    carry.frames++;
+    if (carry.frames >= ENVELOPE_WINDOW_FRAMES) {
+      envelope.push(carry.squareSum, carry.count, carry.peak);
+      carry.squareSum = 0;
+      carry.count = 0;
+      carry.frames = 0;
+    }
+  }
+  return wholeFrames * frameBytes;
+}
+
+function formatFrom(bytes: Uint8Array, offset: number): PcmFormat | undefined {
+  if (offset + 16 > bytes.length) {
+    return undefined;
+  }
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let format: PcmFormat = {
+    formatCode: view.getUint16(offset, true),
+    channels: view.getUint16(offset + 2, true),
+    sampleRate: view.getUint32(offset + 4, true),
+    bitsPerSample: view.getUint16(offset + 14, true),
+    blockAlign: view.getUint16(offset + 12, true),
+  };
+  return format.channels > 0 && format.bitsPerSample > 0 ? format : undefined;
+}
+
+// Walk a WAVE container off the stream, producing everything in one pass.
+export async function extractWavFromStream(
+  stream: ReadableStream<Uint8Array> | Uint8Array,
+  barCount: number,
+): Promise<WavStreamResult> {
+  let envelope = new StreamingEnvelope(barCount);
+  let carry = { squareSum: 0, count: 0, peak: 0, frames: 0 };
+
+  // Everything before the `data` payload, held so the chunk walk can parse it
+  // once complete.
+  let headerParts: Uint8Array[] = [];
+  let headerLength = 0;
+  // Everything after it, for encoders that write LIST-INFO at the end.
+  let trailerParts: Uint8Array[] = [];
+  let trailerLength = 0;
+
+  let format: PcmFormat | undefined;
+  let dataBytesSeen = 0;
+  let declaredDataSize: number | undefined;
+  let inData = false;
+  // Bytes of an incomplete PCM frame carried across a stream-chunk boundary.
+  let partialFrame = new Uint8Array(0);
+
+  let concat = (parts: Uint8Array[], length: number) => {
+    let out = new Uint8Array(length);
+    let offset = 0;
+    for (let part of parts) {
+      out.set(part, offset);
+      offset += part.length;
+    }
+    return out;
+  };
+
+  // Once the header is complete, parse `fmt ` out of it so PCM can be folded as
+  // it arrives rather than buffered.
+  let resolveFormat = () => {
+    if (format) {
+      return;
+    }
+    let header = concat(headerParts, headerLength);
+    walkRiffChunks(header, (id, dataStart, dataSize) => {
+      if (id === 'fmt ' && !format && dataSize >= 16) {
+        format = formatFrom(header, dataStart);
+      }
+    });
+  };
+
+  let handle = (chunk: Uint8Array) => {
+    let cursor = 0;
+    while (cursor < chunk.length) {
+      if (!inData) {
+        // Still collecting the header. Look for the `data` chunk header inside
+        // what we have so far; until it appears, keep buffering.
+        if (headerLength >= WAV_STREAM_HEADER_LIMIT) {
+          return;
+        }
+        let take = Math.min(
+          chunk.length - cursor,
+          WAV_STREAM_HEADER_LIMIT - headerLength,
+        );
+        headerParts.push(chunk.slice(cursor, cursor + take));
+        headerLength += take;
+        cursor += take;
+
+        let header = concat(headerParts, headerLength);
+        let dataStart: number | undefined;
+        walkRiffChunks(header, (id, start, size) => {
+          if (id === 'data' && dataStart === undefined) {
+            dataStart = start;
+            declaredDataSize = size;
+          }
+        });
+        if (dataStart === undefined) {
+          continue;
+        }
+        // The payload begins inside what we just buffered. Trim the header to
+        // end there and replay the remainder as PCM.
+        inData = true;
+        headerParts = [header.slice(0, dataStart)];
+        headerLength = dataStart;
+        resolveFormat();
+        // Anything already buffered past the `data` header is payload — but only
+        // up to the size the chunk declares. A LIST-INFO block written after the
+        // audio sits in the same buffer, and folding it in would read a tag
+        // block as a burst of samples.
+        let buffered = header.subarray(dataStart);
+        let payloadRoom =
+          declaredDataSize === undefined
+            ? buffered.length
+            : Math.min(buffered.length, declaredDataSize);
+        let payload = buffered.subarray(0, payloadRoom);
+        let past = buffered.subarray(payloadRoom);
+        if (format && payload.length > 0) {
+          let consumed = consumePcm(payload, format, envelope, carry);
+          dataBytesSeen += consumed;
+          partialFrame = payload.slice(consumed);
+        }
+        if (past.length > 0 && trailerLength < WAV_STREAM_TRAILER_LIMIT) {
+          let take = Math.min(
+            past.length,
+            WAV_STREAM_TRAILER_LIMIT - trailerLength,
+          );
+          trailerParts.push(past.slice(0, take));
+          trailerLength += take;
+        }
+        continue;
+      }
+
+      // Streaming the payload.
+      let remaining = chunk.subarray(cursor);
+      cursor = chunk.length;
+      let payloadRoom =
+        declaredDataSize === undefined
+          ? remaining.length
+          : Math.max(0, declaredDataSize - dataBytesSeen - partialFrame.length);
+      let payloadPart = remaining.subarray(
+        0,
+        Math.min(remaining.length, payloadRoom),
+      );
+      let afterPayload = remaining.subarray(payloadPart.length);
+
+      if (payloadPart.length > 0 && format) {
+        let combined =
+          partialFrame.length > 0
+            ? new Uint8Array([...partialFrame, ...payloadPart])
+            : payloadPart;
+        let consumed = consumePcm(combined, format, envelope, carry);
+        dataBytesSeen += consumed;
+        partialFrame = combined.slice(consumed);
+      }
+
+      if (afterPayload.length > 0 && trailerLength < WAV_STREAM_TRAILER_LIMIT) {
+        let take = Math.min(
+          afterPayload.length,
+          WAV_STREAM_TRAILER_LIMIT - trailerLength,
+        );
+        trailerParts.push(afterPayload.slice(0, take));
+        trailerLength += take;
+      }
+    }
+  };
+
+  if (stream instanceof Uint8Array) {
+    handle(stream);
+  } else {
+    let reader = stream.getReader();
+    try {
+      for (;;) {
+        let { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        if (value && value.length > 0) {
+          handle(value);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  // Flush whatever the last window didn't fill.
+  if (carry.count > 0) {
+    envelope.push(carry.squareSum, carry.count, carry.peak);
+  }
+
+  resolveFormat();
+  let header = concat(headerParts, headerLength);
+  // Tags may sit before the payload or after it; parse both regions. A trailing
+  // block needs the RIFF preamble prepended so the chunk walk can start.
+  let tags = extractWavTags(header);
+  if (!tags && trailerLength > 0) {
+    let trailer = concat(trailerParts, trailerLength);
+    let synthetic = new Uint8Array(RIFF_HEADER_BYTES + trailer.length);
+    synthetic.set(
+      header.subarray(0, Math.min(RIFF_HEADER_BYTES, header.length)),
+    );
+    synthetic.set(trailer, RIFF_HEADER_BYTES);
+    tags = extractWavTags(synthetic);
+  }
+
+  let encoding = extractWavEncoding(header);
+  let byteRate =
+    format && format.sampleRate > 0
+      ? (format.sampleRate * format.channels * format.bitsPerSample) / 8
+      : undefined;
+  let totalDataBytes = declaredDataSize ?? dataBytesSeen;
+  let duration =
+    byteRate && byteRate > 0 ? totalDataBytes / byteRate : undefined;
+
+  return {
+    ...(duration === undefined ? {} : { duration }),
+    ...(encoding ? { encoding } : {}),
+    ...(tags ? { tags } : {}),
+    ...(envelope.isEmpty
+      ? {}
+      : {
+          envelope: {
+            bars: envelope.bars(),
+            peak: Math.round(envelope.peak * 10000) / 10000,
+            rms: Math.round(envelope.overallRms * 10000) / 10000,
+            sampleCount: carry.count,
+          },
+        }),
+  };
 }

--- a/packages/host/tests/unit/audio-metadata-extractor-test.ts
+++ b/packages/host/tests/unit/audio-metadata-extractor-test.ts
@@ -1,0 +1,879 @@
+// Byte-level tests for the audio encoding and tag readers, and for the waveform
+// reduction.
+//
+// Same contract as the image readers: these run during indexing against whatever
+// a realm holds, so a truncated or hostile file must degrade to "no metadata"
+// rather than throw out of the extract, and a fact the container never stated
+// must not be invented.
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type { Loader } from '@cardstack/runtime-common';
+
+import { setupRenderingTest } from '../helpers/setup';
+
+import type * as AudioFileDefModule from '@cardstack/base/audio-file-def';
+import type * as AudioWaveformModule from '@cardstack/base/audio-waveform';
+import type * as FlacModule from '@cardstack/base/flac-meta-extractor';
+import type * as Id3Module from '@cardstack/base/id3v2-parser';
+import type * as Mp3Module from '@cardstack/base/mp3-meta-extractor';
+import type * as OggModule from '@cardstack/base/ogg-meta-extractor';
+import type * as VorbisModule from '@cardstack/base/vorbis-comment-parser';
+import type * as WavModule from '@cardstack/base/wav-meta-extractor';
+
+function ascii(text: string): number[] {
+  return [...text].map((c) => c.charCodeAt(0));
+}
+
+function uint32le(value: number): number[] {
+  return [
+    value & 0xff,
+    (value >>> 8) & 0xff,
+    (value >>> 16) & 0xff,
+    (value >>> 24) & 0xff,
+  ];
+}
+
+function uint32be(value: number): number[] {
+  return [
+    (value >>> 24) & 0xff,
+    (value >>> 16) & 0xff,
+    (value >>> 8) & 0xff,
+    value & 0xff,
+  ];
+}
+
+function uint16le(value: number): number[] {
+  return [value & 0xff, (value >>> 8) & 0xff];
+}
+
+// ---- WAV ----
+
+function riffChunk(id: string, body: number[]): number[] {
+  // RIFF chunks are word-aligned, so an odd-sized body carries a pad byte.
+  let pad = body.length % 2 === 1 ? [0] : [];
+  return [...ascii(id), ...uint32le(body.length), ...body, ...pad];
+}
+
+function buildWav(
+  fmt: {
+    formatCode?: number;
+    channels?: number;
+    sampleRate?: number;
+    bitsPerSample?: number;
+  } = {},
+  infoEntries: [string, string][] = [],
+): Uint8Array {
+  let channels = fmt.channels ?? 2;
+  let sampleRate = fmt.sampleRate ?? 44100;
+  let bitsPerSample = fmt.bitsPerSample ?? 16;
+  let byteRate = (sampleRate * channels * bitsPerSample) / 8;
+  let blockAlign = (channels * bitsPerSample) / 8;
+  let fmtBody = [
+    ...uint16le(fmt.formatCode ?? 1),
+    ...uint16le(channels),
+    ...uint32le(sampleRate),
+    ...uint32le(byteRate),
+    ...uint16le(blockAlign),
+    ...uint16le(bitsPerSample),
+  ];
+  let chunks = [...riffChunk('fmt ', fmtBody)];
+  if (infoEntries.length > 0) {
+    let infoBody = [...ascii('INFO')];
+    for (let [id, value] of infoEntries) {
+      // LIST-INFO values are NUL-terminated Latin-1.
+      infoBody.push(...riffChunk(id, [...ascii(value), 0]));
+    }
+    chunks.push(...riffChunk('LIST', infoBody));
+  }
+  chunks.push(...riffChunk('data', new Array(64).fill(0)));
+  let payload = [...ascii('WAVE'), ...chunks];
+  return new Uint8Array([
+    ...ascii('RIFF'),
+    ...uint32le(payload.length),
+    ...payload,
+  ]);
+}
+
+// ---- FLAC ----
+
+function buildFlac(
+  streamInfo: {
+    sampleRate?: number;
+    channels?: number;
+    bitsPerSample?: number;
+  } = {},
+  comments?: [string, string][],
+): Uint8Array {
+  let sampleRate = streamInfo.sampleRate ?? 44100;
+  let channels = streamInfo.channels ?? 2;
+  let bitsPerSample = streamInfo.bitsPerSample ?? 16;
+  let totalSamples = 44100;
+
+  // STREAMINFO: 10 bytes of block sizes and frame sizes, then the packed field.
+  let block = new Array(34).fill(0);
+  // Packed across bytes 10..17: 20 bits sample rate, 3 bits channels-1,
+  // 5 bits bitsPerSample-1, 36 bits total samples.
+  block[10] = (sampleRate >>> 12) & 0xff;
+  block[11] = (sampleRate >>> 4) & 0xff;
+  block[12] =
+    ((sampleRate & 0x0f) << 4) |
+    (((channels - 1) & 0x07) << 1) |
+    (((bitsPerSample - 1) >>> 4) & 0x01);
+  block[13] =
+    (((bitsPerSample - 1) & 0x0f) << 4) | ((totalSamples >>> 32) & 0x0f);
+  block[14] = (totalSamples >>> 24) & 0xff;
+  block[15] = (totalSamples >>> 16) & 0xff;
+  block[16] = (totalSamples >>> 8) & 0xff;
+  block[17] = totalSamples & 0xff;
+
+  let hasComments = comments !== undefined;
+  let out = [
+    ...ascii('fLaC'),
+    // STREAMINFO header: type 0, not last when a comment block follows.
+    hasComments ? 0x00 : 0x80,
+    0x00,
+    0x00,
+    0x22,
+    ...block,
+  ];
+  if (comments) {
+    let body = vorbisCommentBody(comments);
+    out.push(
+      0x84, // last block, type 4 (VORBIS_COMMENT)
+      (body.length >>> 16) & 0xff,
+      (body.length >>> 8) & 0xff,
+      body.length & 0xff,
+      ...body,
+    );
+  }
+  return new Uint8Array(out);
+}
+
+function vorbisCommentBody(entries: [string, string][]): number[] {
+  let vendor = ascii('test-vendor');
+  let out = [
+    ...uint32le(vendor.length),
+    ...vendor,
+    ...uint32le(entries.length),
+  ];
+  for (let [key, value] of entries) {
+    let entry = ascii(`${key}=${value}`);
+    out.push(...uint32le(entry.length), ...entry);
+  }
+  return out;
+}
+
+// ---- Ogg ----
+
+function buildOggPage(payload: number[]): number[] {
+  // A 27-byte page header plus a one-byte segment table describing one segment.
+  return [
+    ...ascii('OggS'),
+    0, // version
+    2, // header type: first page of logical stream
+    ...new Array(8).fill(0), // granule position
+    ...uint32le(1), // serial
+    ...uint32le(0), // page sequence
+    ...uint32le(0), // checksum (unread)
+    1, // one segment
+    Math.min(payload.length, 255),
+    ...payload,
+  ];
+}
+
+function buildOggVorbis(
+  channels = 2,
+  sampleRate = 44100,
+  nominalBitrate = 128000,
+  comments?: [string, string][],
+): Uint8Array {
+  let id = [
+    0x01,
+    ...ascii('vorbis'),
+    ...uint32le(0), // version
+    channels,
+    ...uint32le(sampleRate),
+    ...uint32le(0), // max bitrate
+    ...uint32le(nominalBitrate),
+    ...uint32le(0), // min bitrate
+    0x00, // blocksizes
+    0x01, // framing
+  ];
+  let out = buildOggPage(id);
+  if (comments) {
+    out.push(
+      ...buildOggPage([
+        0x03,
+        ...ascii('vorbis'),
+        ...vorbisCommentBody(comments),
+      ]),
+    );
+  }
+  return new Uint8Array(out);
+}
+
+function buildOggOpus(channels = 2, comments?: [string, string][]): Uint8Array {
+  let id = [
+    ...ascii('OpusHead'),
+    1, // version
+    channels,
+    ...uint16le(312), // pre-skip
+    ...uint32le(48000), // input sample rate
+    ...uint16le(0), // output gain
+    0, // channel mapping family
+  ];
+  let out = buildOggPage(id);
+  if (comments) {
+    out.push(
+      ...buildOggPage([...ascii('OpusTags'), ...vorbisCommentBody(comments)]),
+    );
+  }
+  return new Uint8Array(out);
+}
+
+// ---- ID3v2 ----
+
+function syncsafe(value: number): number[] {
+  return [
+    (value >>> 21) & 0x7f,
+    (value >>> 14) & 0x7f,
+    (value >>> 7) & 0x7f,
+    value & 0x7f,
+  ];
+}
+
+// A v2.3 tag (plain big-endian frame sizes), the common case in the wild.
+function buildId3v2(
+  frames: [string, number[]][],
+  majorVersion = 3,
+): Uint8Array {
+  let body: number[] = [];
+  for (let [id, payload] of frames) {
+    body.push(
+      ...ascii(id),
+      ...(majorVersion >= 4
+        ? syncsafe(payload.length)
+        : uint32be(payload.length)),
+      0,
+      0, // frame flags
+      ...payload,
+    );
+  }
+  // Trailing padding, which the walk must treat as the end of the frames.
+  body.push(0, 0, 0, 0);
+  return new Uint8Array([
+    ...ascii('ID3'),
+    majorVersion,
+    0, // revision
+    0, // flags
+    ...syncsafe(body.length),
+    ...body,
+  ]);
+}
+
+// A Latin-1 text frame: encoding byte 0, then NUL-terminated text.
+function latin1Frame(text: string): number[] {
+  return [0, ...ascii(text), 0];
+}
+
+// ---- MP3 ----
+
+// A single MPEG-1 Layer III frame header: 44.1 kHz, 128 kbps, joint stereo.
+function buildMp3Frame(options: { withXing?: boolean } = {}): number[] {
+  let header = [
+    0xff,
+    0xfb, // MPEG-1, Layer III, no CRC
+    0x90, // bitrate index 9 (128 kbps), sample rate index 0 (44100)
+    0x40, // joint stereo
+  ];
+  let body: number[] = [];
+  if (options.withXing) {
+    // The duration reader scans a small window after the header for this tag.
+    body.push(
+      ...new Array(32).fill(0),
+      ...ascii('Xing'),
+      ...uint32be(0x0001), // flags: frame count present
+      ...uint32be(1000), // total frames
+    );
+  }
+  return [...header, ...body, ...new Array(64).fill(0)];
+}
+
+module('Unit | audio metadata extractors', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let loader: Loader;
+  let extractWavEncoding: typeof WavModule.extractWavEncoding;
+  let extractWavTags: typeof WavModule.extractWavTags;
+  let extractFlacEncoding: typeof FlacModule.extractFlacEncoding;
+  let extractFlacTags: typeof FlacModule.extractFlacTags;
+  let extractOggEncoding: typeof OggModule.extractOggEncoding;
+  let extractOggTags: typeof OggModule.extractOggTags;
+  let extractMp3Encoding: typeof Mp3Module.extractMp3Encoding;
+  let parseId3v2Tags: typeof Id3Module.parseId3v2Tags;
+  let parseVorbisComments: typeof VorbisModule.parseVorbisComments;
+  let analyzeDecodedAudio: typeof AudioWaveformModule.analyzeDecodedAudio;
+  let audioAttributes: typeof AudioFileDefModule.audioAttributes;
+
+  hooks.beforeEach(async function () {
+    loader = getService('loader-service').loader;
+    ({ extractWavEncoding, extractWavTags } = await loader.import<
+      typeof WavModule
+    >('@cardstack/base/wav-meta-extractor'));
+    ({ extractFlacEncoding, extractFlacTags } = await loader.import<
+      typeof FlacModule
+    >('@cardstack/base/flac-meta-extractor'));
+    ({ extractOggEncoding, extractOggTags } = await loader.import<
+      typeof OggModule
+    >('@cardstack/base/ogg-meta-extractor'));
+    ({ extractMp3Encoding } = await loader.import<typeof Mp3Module>(
+      '@cardstack/base/mp3-meta-extractor',
+    ));
+    ({ parseId3v2Tags } = await loader.import<typeof Id3Module>(
+      '@cardstack/base/id3v2-parser',
+    ));
+    ({ parseVorbisComments } = await loader.import<typeof VorbisModule>(
+      '@cardstack/base/vorbis-comment-parser',
+    ));
+    ({ analyzeDecodedAudio } = await loader.import<typeof AudioWaveformModule>(
+      '@cardstack/base/audio-waveform',
+    ));
+    ({ audioAttributes } = await loader.import<typeof AudioFileDefModule>(
+      '@cardstack/base/audio-file-def',
+    ));
+  });
+
+  module('WAV', function () {
+    test('reads the sample layout the fmt chunk states outright', function (assert) {
+      let encoding = extractWavEncoding(
+        buildWav({ channels: 2, sampleRate: 48000, bitsPerSample: 24 }),
+      );
+      assert.strictEqual(encoding?.container, 'WAV');
+      assert.strictEqual(encoding?.audioCodec, 'PCM');
+      assert.strictEqual(encoding?.sampleRateHz, 48000);
+      assert.strictEqual(encoding?.bitDepth, 24);
+      assert.strictEqual(encoding?.channels, 2);
+      assert.strictEqual(encoding?.channelMode, 'stereo');
+      assert.false(
+        encoding?.isVariableBitrate,
+        'PCM is constant-rate by definition',
+      );
+      // 48000 × 2 × 3 bytes × 8 bits
+      assert.strictEqual(encoding?.bitrateBps, 48000 * 2 * 3 * 8);
+    });
+
+    test('names the float and companded format codes', function (assert) {
+      assert.strictEqual(
+        extractWavEncoding(buildWav({ formatCode: 3 }))?.audioCodec,
+        'IEEE float',
+      );
+      assert.strictEqual(
+        extractWavEncoding(buildWav({ formatCode: 7 }))?.audioCodec,
+        'μ-law',
+      );
+    });
+
+    test('leaves an unrecognized format code unnamed rather than guessing', function (assert) {
+      let encoding = extractWavEncoding(buildWav({ formatCode: 0x1234 }));
+      assert.strictEqual(encoding?.audioCodec, undefined);
+      assert.strictEqual(
+        encoding?.sampleRateHz,
+        44100,
+        'the layout still reads even when the codec does not',
+      );
+    });
+
+    test('reads a mono file as mono', function (assert) {
+      assert.strictEqual(
+        extractWavEncoding(buildWav({ channels: 1 }))?.channelMode,
+        'mono',
+      );
+    });
+
+    test('reads LIST-INFO tags', function (assert) {
+      let tags = extractWavTags(
+        buildWav({}, [
+          ['INAM', 'Field Recording'],
+          ['IART', 'A Recordist'],
+          ['ICRD', '2021-07-04'],
+          ['IGNR', 'Ambient'],
+        ]),
+      );
+      assert.strictEqual(tags?.trackTitle, 'Field Recording');
+      assert.strictEqual(tags?.artist, 'A Recordist');
+      assert.strictEqual(
+        tags?.year,
+        2021,
+        'a full date yields just its leading year',
+      );
+      assert.strictEqual(tags?.genre, 'Ambient');
+      assert.deepEqual(tags?.scheme, 'riff-info');
+    });
+
+    test('a WAV with no LIST chunk produces no tags at all', function (assert) {
+      assert.strictEqual(
+        extractWavTags(buildWav()),
+        undefined,
+        'a tag block carrying only its scheme is not worth an index row',
+      );
+    });
+
+    test('a truncated file yields nothing rather than throwing', function (assert) {
+      let short = buildWav().subarray(0, 20);
+      assert.strictEqual(extractWavEncoding(short), undefined);
+      assert.strictEqual(extractWavTags(short), undefined);
+    });
+  });
+
+  module('FLAC', function () {
+    test('reads the sample layout from STREAMINFO', function (assert) {
+      let encoding = extractFlacEncoding(
+        buildFlac({ sampleRate: 96000, channels: 2, bitsPerSample: 24 }),
+      );
+      assert.strictEqual(encoding?.container, 'FLAC');
+      assert.strictEqual(encoding?.audioCodec, 'FLAC');
+      assert.strictEqual(encoding?.sampleRateHz, 96000);
+      assert.strictEqual(encoding?.bitDepth, 24);
+      assert.strictEqual(encoding?.channels, 2);
+      assert.true(
+        encoding?.isVariableBitrate,
+        'lossless compression has no constant rate to report',
+      );
+      assert.strictEqual(
+        encoding?.bitrateBps,
+        undefined,
+        'FLAC never states a bitrate, so none is invented',
+      );
+    });
+
+    test('reads a 16-bit mono stream', function (assert) {
+      let encoding = extractFlacEncoding(
+        buildFlac({ sampleRate: 22050, channels: 1, bitsPerSample: 16 }),
+      );
+      assert.strictEqual(encoding?.sampleRateHz, 22050);
+      assert.strictEqual(encoding?.channels, 1);
+      assert.strictEqual(encoding?.bitDepth, 16);
+      assert.strictEqual(encoding?.channelMode, 'mono');
+    });
+
+    test('reads Vorbis comments from the metadata block', function (assert) {
+      let tags = extractFlacTags(
+        buildFlac({}, [
+          ['TITLE', 'Nocturne'],
+          ['ARTIST', 'A Pianist'],
+          ['ALBUM', 'Night Pieces'],
+          ['DATE', '1994'],
+          ['TRACKNUMBER', '3'],
+        ]),
+      );
+      assert.strictEqual(tags?.trackTitle, 'Nocturne');
+      assert.strictEqual(tags?.artist, 'A Pianist');
+      assert.strictEqual(tags?.album, 'Night Pieces');
+      assert.strictEqual(tags?.year, 1994);
+      assert.strictEqual(tags?.track, '3');
+      assert.strictEqual(tags?.scheme, 'vorbis-comment');
+    });
+
+    test('a FLAC with no comment block produces no tags', function (assert) {
+      assert.strictEqual(extractFlacTags(buildFlac()), undefined);
+    });
+
+    test('a non-FLAC buffer yields nothing rather than throwing', function (assert) {
+      let notFlac = new Uint8Array(64).fill(0x41);
+      assert.strictEqual(extractFlacEncoding(notFlac), undefined);
+      assert.strictEqual(extractFlacTags(notFlac), undefined);
+    });
+  });
+
+  module('Ogg', function () {
+    test('reads the Vorbis identification header', function (assert) {
+      let encoding = extractOggEncoding(buildOggVorbis(2, 44100, 160000));
+      assert.strictEqual(encoding?.container, 'Ogg');
+      assert.strictEqual(encoding?.audioCodec, 'Vorbis');
+      assert.strictEqual(encoding?.sampleRateHz, 44100);
+      assert.strictEqual(encoding?.bitrateBps, 160000);
+      assert.strictEqual(encoding?.channels, 2);
+    });
+
+    test('an undeclared nominal bitrate is omitted, not reported as zero', function (assert) {
+      assert.strictEqual(
+        extractOggEncoding(buildOggVorbis(2, 44100, 0))?.bitrateBps,
+        undefined,
+      );
+    });
+
+    test('Opus reports the 48 kHz rate it actually decodes to', function (assert) {
+      let encoding = extractOggEncoding(buildOggOpus(2));
+      assert.strictEqual(encoding?.audioCodec, 'Opus');
+      assert.strictEqual(
+        encoding?.sampleRateHz,
+        48000,
+        'Opus always decodes to 48 kHz whatever it was captured at',
+      );
+      assert.strictEqual(encoding?.channels, 2);
+    });
+
+    test('reads Vorbis comments from a following page', function (assert) {
+      let tags = extractOggTags(
+        buildOggVorbis(2, 44100, 128000, [
+          ['TITLE', 'Tape Loop'],
+          ['ARTIST', 'A Composer'],
+        ]),
+      );
+      assert.strictEqual(tags?.trackTitle, 'Tape Loop');
+      assert.strictEqual(tags?.artist, 'A Composer');
+    });
+
+    test('reads OpusTags', function (assert) {
+      let tags = extractOggTags(buildOggOpus(1, [['TITLE', 'Voice Memo']]));
+      assert.strictEqual(tags?.trackTitle, 'Voice Memo');
+    });
+
+    test('a non-Ogg buffer yields nothing', function (assert) {
+      assert.strictEqual(
+        extractOggEncoding(new Uint8Array(64).fill(0x41)),
+        undefined,
+      );
+    });
+  });
+
+  module('MP3', function () {
+    test('reads the frame header and reports a constant rate as constant', function (assert) {
+      let encoding = extractMp3Encoding(new Uint8Array(buildMp3Frame()));
+      assert.strictEqual(encoding?.container, 'MPEG');
+      assert.strictEqual(encoding?.audioCodec, 'MP3 (MPEG Layer III)');
+      assert.strictEqual(encoding?.sampleRateHz, 44100);
+      assert.strictEqual(encoding?.bitrateBps, 128000);
+      assert.strictEqual(encoding?.channels, 2);
+      assert.strictEqual(encoding?.channelMode, 'joint-stereo');
+      assert.false(
+        encoding?.isVariableBitrate,
+        'no Xing header means the encoder wrote a constant rate',
+      );
+    });
+
+    test('a Xing header marks the bitrate as variable', function (assert) {
+      assert.true(
+        extractMp3Encoding(new Uint8Array(buildMp3Frame({ withXing: true })))
+          ?.isVariableBitrate,
+      );
+    });
+
+    test('never reports a bit depth, which MP3 has no concept of', function (assert) {
+      assert.strictEqual(
+        extractMp3Encoding(new Uint8Array(buildMp3Frame()))?.bitDepth,
+        undefined,
+      );
+    });
+
+    test('finds the frame past a leading ID3v2 tag', function (assert) {
+      let tag = buildId3v2([['TIT2', latin1Frame('Something')]]);
+      let bytes = new Uint8Array([...tag, ...buildMp3Frame()]);
+      assert.strictEqual(extractMp3Encoding(bytes)?.sampleRateHz, 44100);
+    });
+
+    test('a buffer with no frame sync yields nothing rather than throwing', function (assert) {
+      assert.strictEqual(
+        extractMp3Encoding(new Uint8Array(128).fill(0x41)),
+        undefined,
+      );
+    });
+  });
+
+  module('ID3v2', function () {
+    test('reads the common v2.3 text frames', function (assert) {
+      let tags = parseId3v2Tags(
+        buildId3v2([
+          ['TIT2', latin1Frame('Blue Monday')],
+          ['TPE1', latin1Frame('A Band')],
+          ['TALB', latin1Frame('Power')],
+          ['TRCK', latin1Frame('4/12')],
+          ['TYER', latin1Frame('1983')],
+          ['TCON', latin1Frame('Synthpop')],
+        ]),
+      );
+      assert.strictEqual(tags?.trackTitle, 'Blue Monday');
+      assert.strictEqual(tags?.artist, 'A Band');
+      assert.strictEqual(tags?.album, 'Power');
+      assert.strictEqual(
+        tags?.track,
+        '4/12',
+        'a track number keeps its total rather than being coerced to a number',
+      );
+      assert.strictEqual(tags?.year, 1983);
+      assert.strictEqual(tags?.genre, 'Synthpop');
+      assert.strictEqual(tags?.scheme, 'id3v2');
+    });
+
+    test('accepts the v2.4 recording-date frame', function (assert) {
+      let tags = parseId3v2Tags(
+        buildId3v2([['TDRC', latin1Frame('2008-05-13')]], 4),
+      );
+      assert.strictEqual(tags?.year, 2008);
+    });
+
+    test('decodes a UTF-16 frame with a byte-order mark', function (assert) {
+      // Encoding byte 1, BOM, then UTF-16LE code units, NUL-pair terminated.
+      let text = 'Ünicode';
+      let payload = [0x01, 0xff, 0xfe];
+      for (let index = 0; index < text.length; index++) {
+        let code = text.charCodeAt(index);
+        payload.push(code & 0xff, (code >>> 8) & 0xff);
+      }
+      payload.push(0, 0);
+      let tags = parseId3v2Tags(buildId3v2([['TIT2', payload]]));
+      assert.strictEqual(
+        tags?.trackTitle,
+        text,
+        'a UTF-16 tag reads in full rather than stopping at its first NUL byte',
+      );
+    });
+
+    test('a COMM frame skips its language code and description', function (assert) {
+      let payload = [
+        0, // Latin-1
+        ...ascii('eng'),
+        ...ascii('short'),
+        0, // description terminator
+        ...ascii('the actual comment'),
+        0,
+      ];
+      assert.strictEqual(
+        parseId3v2Tags(buildId3v2([['COMM', payload]]))?.comment,
+        'the actual comment',
+      );
+    });
+
+    test('a file with no ID3v2 tag yields nothing', function (assert) {
+      assert.strictEqual(
+        parseId3v2Tags(new Uint8Array(buildMp3Frame())),
+        undefined,
+      );
+    });
+
+    test('an empty tag produces no attribute despite being well-formed', function (assert) {
+      assert.strictEqual(parseId3v2Tags(buildId3v2([])), undefined);
+    });
+  });
+
+  module('Vorbis comments', function () {
+    test('is case-insensitive about field names', function (assert) {
+      let body = new Uint8Array(
+        vorbisCommentBody([
+          ['title', 'lowercase key'],
+          ['Artist', 'Mixed Case Key'],
+        ]),
+      );
+      let parsed = parseVorbisComments(body, 0);
+      assert.strictEqual(parsed?.tags?.trackTitle, 'lowercase key');
+      assert.strictEqual(parsed?.tags?.artist, 'Mixed Case Key');
+    });
+
+    test('keeps the first of a repeated key rather than joining them', function (assert) {
+      let body = new Uint8Array(
+        vorbisCommentBody([
+          ['ARTIST', 'First Artist'],
+          ['ARTIST', 'Second Artist'],
+        ]),
+      );
+      assert.strictEqual(
+        parseVorbisComments(body, 0)?.tags?.artist,
+        'First Artist',
+        'joining two ARTIST values would invent a credit the file never stated',
+      );
+    });
+
+    test('reports the vendor string', function (assert) {
+      let body = new Uint8Array(vorbisCommentBody([['TITLE', 'x']]));
+      assert.strictEqual(parseVorbisComments(body, 0)?.vendor, 'test-vendor');
+    });
+
+    test('ignores keys it has no field for', function (assert) {
+      let body = new Uint8Array(
+        vorbisCommentBody([['REPLAYGAIN_TRACK_GAIN', '-6.5 dB']]),
+      );
+      assert.strictEqual(
+        parseVorbisComments(body, 0)?.tags,
+        undefined,
+        'application-specific keys do not become fields nobody declared',
+      );
+    });
+
+    test('a truncated block yields nothing rather than throwing', function (assert) {
+      let body = new Uint8Array(vorbisCommentBody([['TITLE', 'Truncated']]));
+      assert.strictEqual(
+        parseVorbisComments(body.subarray(0, 6), 0),
+        undefined,
+      );
+    });
+
+    test('an implausible entry count is refused', function (assert) {
+      let body = new Uint8Array(vorbisCommentBody([['TITLE', 'x']]));
+      // Overwrite the entry count that follows the vendor string.
+      let vendorLength = new DataView(body.buffer).getUint32(0, true);
+      new DataView(body.buffer).setUint32(4 + vendorLength, 100000, true);
+      assert.strictEqual(parseVorbisComments(body, 0), undefined);
+    });
+  });
+
+  module('waveform reduction', function () {
+    // A decoded buffer standing in for Web Audio's, so the reduction is testable
+    // without a real decoder.
+    function fakeAudio(
+      channels: Float32Array[],
+      sampleRate = 44100,
+    ): AudioWaveformModule.DecodedAudioLike {
+      let length = channels[0]?.length ?? 0;
+      return {
+        duration: length / sampleRate,
+        sampleRate,
+        numberOfChannels: channels.length,
+        length,
+        getChannelData: (index: number) =>
+          channels[index] ?? new Float32Array(),
+      };
+    }
+
+    test('resamples across the whole signal, not just its opening', function (assert) {
+      // Silence for the first nine tenths, full amplitude for the last tenth.
+      // An envelope built from the opening would be entirely flat.
+      let samples = new Float32Array(1000);
+      samples.fill(0, 0, 900);
+      samples.fill(1, 900, 1000);
+      let result = analyzeDecodedAudio(fakeAudio([samples]), 10);
+      let bars = JSON.parse(result.barsJson!) as number[];
+
+      assert.strictEqual(bars.length, 10);
+      assert.strictEqual(bars[0], 0, 'the silent opening reads as silent');
+      assert.strictEqual(
+        bars[9],
+        1,
+        'the loud ending is represented, so the envelope is the shape of the whole track',
+      );
+    });
+
+    test('every channel contributes, so panned content is not misread', function (assert) {
+      // Left silent, right loud. Reading only channel 0 would report silence.
+      let left = new Float32Array(100);
+      let right = new Float32Array(100).fill(1);
+      let result = analyzeDecodedAudio(fakeAudio([left, right]), 4);
+      let bars = JSON.parse(result.barsJson!) as number[];
+      assert.true(
+        bars.every((bar) => bar > 0),
+        'a hard-panned track is not reported as silent',
+      );
+    });
+
+    test('reports RMS per bar rather than peak, so quiet stays quiet', function (assert) {
+      let quiet = new Float32Array(100).fill(0.1);
+      let result = analyzeDecodedAudio(fakeAudio([quiet]), 4);
+      let bars = JSON.parse(result.barsJson!) as number[];
+      assert.true(
+        bars.every((bar) => Math.abs(bar - 0.1) < 0.001),
+        'a bar tracks loudness rather than saturating to the peak',
+      );
+    });
+
+    test('reports the overall peak separately from the envelope', function (assert) {
+      let samples = new Float32Array(100).fill(0.2);
+      samples[50] = -0.95;
+      let result = analyzeDecodedAudio(fakeAudio([samples]), 4);
+      assert.strictEqual(
+        result.peakAmplitude,
+        0.95,
+        'peak is a magnitude, so a negative sample still counts',
+      );
+      assert.true(result.rmsAmplitude! < 0.4, 'RMS is not dragged to the peak');
+    });
+
+    test('the bar count is fixed regardless of duration', function (assert) {
+      let short = analyzeDecodedAudio(
+        fakeAudio([new Float32Array(200).fill(0.5)]),
+        32,
+      );
+      let long = analyzeDecodedAudio(
+        fakeAudio([new Float32Array(200_000).fill(0.5)]),
+        32,
+      );
+      assert.strictEqual(short.barCount, 32);
+      assert.strictEqual(
+        long.barCount,
+        32,
+        'a long recording costs no more stored payload than a short one',
+      );
+    });
+
+    test('a buffer with fewer samples than bars still produces a bar each', function (assert) {
+      let result = analyzeDecodedAudio(
+        fakeAudio([new Float32Array(3).fill(0.5)]),
+        8,
+      );
+      let bars = JSON.parse(result.barsJson!) as number[];
+      assert.strictEqual(bars.length, 8, 'no window is left empty');
+    });
+
+    test('an empty buffer is reported as an empty envelope, not a failure', function (assert) {
+      let result = analyzeDecodedAudio(fakeAudio([new Float32Array(0)]), 8);
+      assert.strictEqual(result.decodeStatus, 'ok');
+      assert.strictEqual(result.barsJson, '[]');
+      assert.strictEqual(result.barCount, 0);
+    });
+  });
+
+  module('attribute assembly', function () {
+    test('wraps rates as quantities and schemes as coded values', function (assert) {
+      let attributes = audioAttributes(
+        {
+          container: 'FLAC',
+          audioCodec: 'FLAC',
+          sampleRateHz: 44100,
+          bitrateBps: 900000,
+          bitDepth: 16,
+          channels: 2,
+          channelMode: 'stereo',
+          isVariableBitrate: true,
+        },
+        { scheme: 'vorbis-comment', trackTitle: 'Nocturne' },
+      );
+      assert.deepEqual(attributes.encoding?.sampleRate, {
+        value: 44100,
+        unit: 'Hz',
+      });
+      assert.deepEqual(attributes.encoding?.bitrate, {
+        value: 900000,
+        unit: 'bps',
+      });
+      assert.deepEqual(attributes.encoding?.channelMode, {
+        code: 'stereo',
+        scheme: 'channel-mode',
+      });
+      assert.deepEqual(attributes.tags?.scheme, {
+        code: 'vorbis-comment',
+        scheme: 'tag-scheme',
+      });
+      assert.strictEqual(attributes.tags?.trackTitle, 'Nocturne');
+    });
+
+    test('a file that revealed nothing adds no attributes at all', function (assert) {
+      assert.deepEqual(audioAttributes(undefined, undefined), {});
+    });
+
+    test('a skipped decode is still persisted, because it is not the same as absent', function (assert) {
+      let attributes = audioAttributes(undefined, undefined, {
+        decodeStatus: 'skipped',
+        decodeError: 'too big',
+      });
+      assert.strictEqual(attributes.waveform?.decodeStatus, 'skipped');
+    });
+
+    test('a false variable-bitrate flag survives assembly', function (assert) {
+      let attributes = audioAttributes({ isVariableBitrate: false }, undefined);
+      assert.false(
+        attributes.encoding?.isVariableBitrate,
+        'knowing a stream is constant-rate is a fact worth persisting',
+      );
+    });
+  });
+});

--- a/packages/host/tests/unit/audio-metadata-extractor-test.ts
+++ b/packages/host/tests/unit/audio-metadata-extractor-test.ts
@@ -17,6 +17,7 @@ import type * as AudioFileDefModule from '@cardstack/base/audio-file-def';
 import type * as AudioWaveformModule from '@cardstack/base/audio-waveform';
 import type * as FlacModule from '@cardstack/base/flac-meta-extractor';
 import type * as Id3Module from '@cardstack/base/id3v2-parser';
+import type * as MidiModule from '@cardstack/base/midi-meta-extractor';
 import type * as Mp3Module from '@cardstack/base/mp3-meta-extractor';
 import type * as OggModule from '@cardstack/base/ogg-meta-extractor';
 import type * as VorbisModule from '@cardstack/base/vorbis-comment-parser';
@@ -316,6 +317,7 @@ module('Unit | audio metadata extractors', function (hooks) {
   let parseVorbisComments: typeof VorbisModule.parseVorbisComments;
   let analyzeDecodedAudio: typeof AudioWaveformModule.analyzeDecodedAudio;
   let audioAttributes: typeof AudioFileDefModule.audioAttributes;
+  let extractMidiMetadata: typeof MidiModule.extractMidiMetadata;
 
   hooks.beforeEach(async function () {
     loader = getService('loader-service').loader;
@@ -342,6 +344,9 @@ module('Unit | audio metadata extractors', function (hooks) {
     ));
     ({ audioAttributes } = await loader.import<typeof AudioFileDefModule>(
       '@cardstack/base/audio-file-def',
+    ));
+    ({ extractMidiMetadata } = await loader.import<typeof MidiModule>(
+      '@cardstack/base/midi-meta-extractor',
     ));
   });
 
@@ -873,6 +878,280 @@ module('Unit | audio metadata extractors', function (hooks) {
       assert.false(
         attributes.encoding?.isVariableBitrate,
         'knowing a stream is constant-rate is a fact worth persisting',
+      );
+    });
+  });
+
+  module('MIDI', function () {
+    // ---- SMF fixtures ----
+
+    // MIDI's variable-length quantity: seven bits per byte, high bit set on all
+    // but the last.
+    function vlq(value: number): number[] {
+      let out = [value & 0x7f];
+      let rest = value >>> 7;
+      while (rest > 0) {
+        out.unshift((rest & 0x7f) | 0x80);
+        rest >>>= 7;
+      }
+      return out;
+    }
+
+    function trackChunk(events: number[]): number[] {
+      // Every track must end with an end-of-track meta event.
+      let body = [...events, 0x00, 0xff, 0x2f, 0x00];
+      return [...ascii('MTrk'), ...uint32be(body.length), ...body];
+    }
+
+    function buildMidi(
+      tracks: number[][],
+      options: { format?: number; division?: number } = {},
+    ): Uint8Array {
+      let chunks = tracks.flatMap((events) => trackChunk(events));
+      return new Uint8Array([
+        ...ascii('MThd'),
+        ...uint32be(6),
+        ...uint16le(0).reverse(), // placeholder, overwritten below
+        ...uint16le(0).reverse(),
+        ...uint16le(0).reverse(),
+        ...chunks,
+      ]).map((byte, index) => {
+        // Rewrite the three header fields big-endian.
+        let format = options.format ?? 1;
+        let division = options.division ?? 480;
+        if (index === 8) return (format >>> 8) & 0xff;
+        if (index === 9) return format & 0xff;
+        if (index === 10) return (tracks.length >>> 8) & 0xff;
+        if (index === 11) return tracks.length & 0xff;
+        if (index === 12) return (division >>> 8) & 0xff;
+        if (index === 13) return division & 0xff;
+        return byte;
+      });
+    }
+
+    // A note-on/note-off pair at the given tick offsets.
+    function note(
+      channel: number,
+      pitch: number,
+      velocity = 64,
+      deltaOn = 0,
+      deltaOff = 480,
+    ): number[] {
+      return [
+        ...vlq(deltaOn),
+        0x90 | channel,
+        pitch,
+        velocity,
+        ...vlq(deltaOff),
+        0x80 | channel,
+        pitch,
+        0,
+      ];
+    }
+
+    function tempoEvent(bpm: number, delta = 0): number[] {
+      let microseconds = Math.round(60_000_000 / bpm);
+      return [
+        ...vlq(delta),
+        0xff,
+        0x51,
+        0x03,
+        (microseconds >>> 16) & 0xff,
+        (microseconds >>> 8) & 0xff,
+        microseconds & 0xff,
+      ];
+    }
+
+    test('reads the header and counts the notes that actually sound', function (assert) {
+      let midi = extractMidiMetadata(
+        buildMidi([[...note(0, 60), ...note(0, 64), ...note(0, 67)]], {
+          format: 0,
+          division: 480,
+        }),
+      );
+      assert.strictEqual(midi.format, 0);
+      assert.strictEqual(midi.ppq, 480);
+      assert.strictEqual(midi.noteCount, 3);
+      assert.strictEqual(midi.fileTrackCount, 1);
+      assert.strictEqual(midi.trackCount, 1);
+    });
+
+    test('a note-on with zero velocity is a note-off, not a second note', function (assert) {
+      // The conventional note-off encoding. Counting it would double every note.
+      let events = [...vlq(0), 0x90, 60, 64, ...vlq(480), 0x90, 60, 0];
+      assert.strictEqual(extractMidiMetadata(buildMidi([events])).noteCount, 1);
+    });
+
+    test('distinguishes tracks that sound from tracks the header declares', function (assert) {
+      // A format 1 file conventionally opens with a conductor track carrying only
+      // tempo and meter, which should not be counted as sounding.
+      let midi = extractMidiMetadata(
+        buildMidi([tempoEvent(120), [...note(0, 60)]]),
+      );
+      assert.strictEqual(midi.fileTrackCount, 2);
+      assert.strictEqual(
+        midi.trackCount,
+        1,
+        'the conductor track declares no notes so it does not count as sounding',
+      );
+    });
+
+    test('derives duration by walking the tempo map, not by averaging', function (assert) {
+      // One quarter note at 480 ppq and 120 BPM is exactly half a second.
+      let midi = extractMidiMetadata(
+        buildMidi([[...tempoEvent(120), ...note(0, 60, 64, 0, 480)]], {
+          division: 480,
+        }),
+      );
+      assert.strictEqual(midi.durationSeconds, 0.5);
+    });
+
+    test('a tempo change partway through changes the derived duration', function (assert) {
+      // Half a second at 120 BPM, then a quarter note at 240 BPM (0.25 s).
+      let events = [
+        ...tempoEvent(120),
+        ...note(0, 60, 64, 0, 480),
+        ...tempoEvent(240),
+        ...note(0, 62, 64, 0, 480),
+      ];
+      let midi = extractMidiMetadata(buildMidi([events], { division: 480 }));
+      assert.strictEqual(
+        midi.durationSeconds,
+        0.75,
+        'a piece that speeds up is not reported at its opening tempo',
+      );
+      assert.strictEqual(midi.tempoMap?.length, 2);
+      assert.true(midi.tempoMap?.[0]?.startsWith('120 BPM'));
+      assert.true(midi.tempoMap?.[1]?.startsWith('240 BPM'));
+    });
+
+    test('reads time and key signatures', function (assert) {
+      let events = [
+        ...vlq(0),
+        0xff,
+        0x58,
+        0x04,
+        6,
+        3,
+        24,
+        8, // 6/8
+        ...vlq(0),
+        0xff,
+        0x59,
+        0x02,
+        0xfd,
+        1, // three flats, minor → C minor
+        ...note(0, 60),
+      ];
+      let midi = extractMidiMetadata(buildMidi([events]));
+      assert.deepEqual(midi.timeSignatures, ['6/8']);
+      assert.deepEqual(
+        midi.keySignatures,
+        ['C minor'],
+        'a signed accidental count and a minor flag name the key',
+      );
+    });
+
+    test('reports the pitch range in note names', function (assert) {
+      let midi = extractMidiMetadata(
+        buildMidi([[...note(0, 60), ...note(0, 72)]]),
+      );
+      assert.strictEqual(
+        midi.pitchRange,
+        'C4–C5',
+        'MIDI note 60 is middle C, conventionally written C4',
+      );
+    });
+
+    test('percussion is flagged and kept out of the pitch range', function (assert) {
+      // Channel 10 (index 9) is percussion, where a note number names a drum
+      // rather than a pitch — folding it into the range would be meaningless.
+      let midi = extractMidiMetadata(
+        buildMidi([[...note(0, 60), ...note(9, 35), ...note(9, 81)]]),
+      );
+      assert.true(midi.hasPercussion);
+      assert.strictEqual(midi.pitchRange, 'C4–C4');
+    });
+
+    test('collects program changes excluding the percussion channel', function (assert) {
+      let events = [
+        ...vlq(0),
+        0xc0,
+        40, // channel 1, violin
+        ...vlq(0),
+        0xc9,
+        16, // channel 10, a drum kit rather than an instrument
+        ...note(0, 60),
+      ];
+      let midi = extractMidiMetadata(buildMidi([events]));
+      assert.deepEqual(midi.programs, [40]);
+    });
+
+    test('reports channels as the numbers a musician uses, counting from one', function (assert) {
+      let midi = extractMidiMetadata(
+        buildMidi([[...note(0, 60), ...note(3, 64)]]),
+      );
+      assert.deepEqual(midi.channels, [1, 4]);
+    });
+
+    test('follows running status, which real files rely on', function (assert) {
+      // Three notes sharing one status byte — the compression every sequencer
+      // emits. Mishandling it would lose all but the first.
+      let events = [
+        ...vlq(0),
+        0x90,
+        60,
+        64, // explicit status
+        ...vlq(10),
+        62,
+        64, // running status
+        ...vlq(10),
+        64,
+        64, // running status
+      ];
+      assert.strictEqual(extractMidiMetadata(buildMidi([events])).noteCount, 3);
+    });
+
+    test('skips a SysEx event without desynchronizing the walk', function (assert) {
+      let events = [
+        ...vlq(0),
+        0xf0,
+        0x04,
+        0x7e,
+        0x7f,
+        0x09,
+        0x01, // a GM reset
+        ...note(0, 60),
+      ];
+      assert.strictEqual(extractMidiMetadata(buildMidi([events])).noteCount, 1);
+    });
+
+    test('a SMPTE-timed file reads its notes but declares no ppq', function (assert) {
+      // A negative division is timecode, where ticks do not convert to musical
+      // time — so reporting a ppq would be meaningless.
+      let midi = extractMidiMetadata(
+        buildMidi([[...note(0, 60)]], { division: 0xe728 }),
+      );
+      assert.strictEqual(midi.ppq, undefined);
+      assert.strictEqual(midi.durationSeconds, undefined);
+      assert.strictEqual(midi.noteCount, 1);
+    });
+
+    test('a non-MIDI file is reported as a content mismatch', function (assert) {
+      assert.throws(
+        () => extractMidiMetadata(new Uint8Array(64).fill(0x41)),
+        /MThd/,
+        'the extractor falls back to the base FileDef rather than inventing metadata',
+      );
+    });
+
+    test('a truncated track yields the events it did read', function (assert) {
+      let full = buildMidi([[...note(0, 60), ...note(0, 64)]]);
+      let truncated = full.subarray(0, full.length - 6);
+      let midi = extractMidiMetadata(truncated);
+      assert.true(
+        midi.noteCount! >= 1,
+        'a partial track still reports what was readable rather than throwing',
       );
     });
   });

--- a/packages/host/tests/unit/audio-metadata-extractor-test.ts
+++ b/packages/host/tests/unit/audio-metadata-extractor-test.ts
@@ -309,6 +309,7 @@ module('Unit | audio metadata extractors', function (hooks) {
   let loader: Loader;
   let extractWavEncoding: typeof WavModule.extractWavEncoding;
   let extractWavTags: typeof WavModule.extractWavTags;
+  let extractWavFromStream: typeof WavModule.extractWavFromStream;
   let extractFlacEncoding: typeof FlacModule.extractFlacEncoding;
   let extractFlacTags: typeof FlacModule.extractFlacTags;
   let extractOggEncoding: typeof OggModule.extractOggEncoding;
@@ -324,9 +325,10 @@ module('Unit | audio metadata extractors', function (hooks) {
 
   hooks.beforeEach(async function () {
     loader = getService('loader-service').loader;
-    ({ extractWavEncoding, extractWavTags } = await loader.import<
-      typeof WavModule
-    >('@cardstack/base/wav-meta-extractor'));
+    ({ extractWavEncoding, extractWavTags, extractWavFromStream } =
+      await loader.import<typeof WavModule>(
+        '@cardstack/base/wav-meta-extractor',
+      ));
     ({ extractFlacEncoding, extractFlacTags } = await loader.import<
       typeof FlacModule
     >('@cardstack/base/flac-meta-extractor'));
@@ -1332,6 +1334,183 @@ module('Unit | audio metadata extractors', function (hooks) {
         extractMp3Envelope(new Uint8Array(256).fill(0x41), 8),
         undefined,
       );
+    });
+  });
+
+  module('WAV single-pass streaming', function () {
+    // A WAVE file with real 16-bit PCM, so the envelope is computed from actual
+    // samples rather than a stand-in.
+    function buildWavWithPcm(
+      frames: number[][],
+      options: {
+        sampleRate?: number;
+        channels?: number;
+        infoEntries?: [string, string][];
+        trailingInfo?: boolean;
+      } = {},
+    ): Uint8Array {
+      let sampleRate = options.sampleRate ?? 8000;
+      let channels = options.channels ?? 1;
+      let bitsPerSample = 16;
+      let byteRate = (sampleRate * channels * bitsPerSample) / 8;
+      let fmtBody = [
+        ...uint16le(1),
+        ...uint16le(channels),
+        ...uint32le(sampleRate),
+        ...uint32le(byteRate),
+        ...uint16le((channels * bitsPerSample) / 8),
+        ...uint16le(bitsPerSample),
+      ];
+      let pcm: number[] = [];
+      for (let frame of frames) {
+        for (let sample of frame) {
+          let clamped = Math.max(-1, Math.min(1, sample));
+          let value = Math.round(clamped * 32767);
+          pcm.push(...uint16le(value < 0 ? value + 65536 : value));
+        }
+      }
+      let infoChunk: number[] = [];
+      if (options.infoEntries?.length) {
+        let infoBody = [...ascii('INFO')];
+        for (let [id, value] of options.infoEntries) {
+          infoBody.push(...riffChunk(id, [...ascii(value), 0]));
+        }
+        infoChunk = riffChunk('LIST', infoBody);
+      }
+      let chunks = [
+        ...riffChunk('fmt ', fmtBody),
+        ...(options.trailingInfo ? [] : infoChunk),
+        ...riffChunk('data', pcm),
+        ...(options.trailingInfo ? infoChunk : []),
+      ];
+      let payload = [...ascii('WAVE'), ...chunks];
+      return new Uint8Array([
+        ...ascii('RIFF'),
+        ...uint32le(payload.length),
+        ...payload,
+      ]);
+    }
+
+    // Hand the reader a stream that yields small chunks, so frames land across
+    // chunk boundaries — the case a buffered reader never exercises.
+    function chunkedStream(
+      bytes: Uint8Array,
+      chunkSize: number,
+    ): ReadableStream<Uint8Array> {
+      let offset = 0;
+      return new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (offset >= bytes.length) {
+            controller.close();
+            return;
+          }
+          let end = Math.min(offset + chunkSize, bytes.length);
+          controller.enqueue(bytes.slice(offset, end));
+          offset = end;
+        },
+      });
+    }
+
+    function silentThenLoud(total: number): number[][] {
+      return Array.from({ length: total }, (_, index) => [
+        index < total / 2 ? 0 : 1,
+      ]);
+    }
+
+    test('derives duration, encoding, and envelope from one pass', async function (assert) {
+      let bytes = buildWavWithPcm(silentThenLoud(8000), { sampleRate: 8000 });
+      let result = await extractWavFromStream(bytes, 8);
+
+      assert.strictEqual(
+        result.duration,
+        1,
+        '8000 mono frames at 8 kHz is 1 s',
+      );
+      assert.strictEqual(result.encoding?.sampleRateHz, 8000);
+      assert.strictEqual(result.encoding?.bitDepth, 16);
+      assert.strictEqual(result.envelope?.bars.length, 8);
+    });
+
+    test('the envelope tracks the real signal', async function (assert) {
+      let result = await extractWavFromStream(
+        buildWavWithPcm(silentThenLoud(8000)),
+        8,
+      );
+      let bars = result.envelope!.bars;
+      assert.strictEqual(bars[0], 0, 'the silent half reads as silent');
+      assert.true(bars[7]! > 0.99, 'the loud half reaches full scale');
+    });
+
+    test('peak and RMS are real amplitudes, needing no normalization', async function (assert) {
+      // A constant half-scale signal: RMS and peak should both be ~0.5, unlike
+      // MP3's side-info proxy where only relative height is meaningful.
+      let frames = Array.from({ length: 4000 }, () => [0.5]);
+      let result = await extractWavFromStream(buildWavWithPcm(frames), 8);
+      assert.true(Math.abs(result.envelope!.peak - 0.5) < 0.001);
+      assert.true(Math.abs(result.envelope!.rms - 0.5) < 0.001);
+    });
+
+    test('a frame split across stream chunks is not dropped or misread', async function (assert) {
+      let bytes = buildWavWithPcm(silentThenLoud(4000), { channels: 2 });
+      let whole = await extractWavFromStream(bytes, 8);
+      // 7 is deliberately coprime with the 4-byte stereo frame, so almost every
+      // chunk boundary falls inside a frame.
+      let chunked = await extractWavFromStream(chunkedStream(bytes, 7), 8);
+
+      assert.deepEqual(
+        chunked.envelope?.bars,
+        whole.envelope?.bars,
+        'chunking the stream does not change the envelope',
+      );
+      assert.strictEqual(chunked.duration, whole.duration);
+    });
+
+    test('reads LIST-INFO written before the payload', async function (assert) {
+      let result = await extractWavFromStream(
+        buildWavWithPcm(silentThenLoud(800), {
+          infoEntries: [['INAM', 'Leading Tag']],
+        }),
+        8,
+      );
+      assert.strictEqual(result.tags?.trackTitle, 'Leading Tag');
+    });
+
+    test('reads LIST-INFO written after the payload', async function (assert) {
+      // Some encoders put the tag block at the end, past the audio.
+      let result = await extractWavFromStream(
+        buildWavWithPcm(silentThenLoud(800), {
+          infoEntries: [['INAM', 'Trailing Tag']],
+          trailingInfo: true,
+        }),
+        8,
+      );
+      assert.strictEqual(result.tags?.trackTitle, 'Trailing Tag');
+    });
+
+    test('stops folding PCM at the declared data size', async function (assert) {
+      // Trailing bytes past `data` must not be read as samples, or a tag block
+      // at the end would show up as a burst of noise in the envelope.
+      let result = await extractWavFromStream(
+        buildWavWithPcm(
+          Array.from({ length: 800 }, () => [0]),
+          { infoEntries: [['INAM', 'x']], trailingInfo: true },
+        ),
+        4,
+      );
+      assert.deepEqual(
+        result.envelope?.bars,
+        [0, 0, 0, 0],
+        'a silent file stays silent despite trailing chunk bytes',
+      );
+    });
+
+    test('a non-WAVE buffer yields no duration rather than throwing', async function (assert) {
+      let result = await extractWavFromStream(
+        new Uint8Array(256).fill(0x41),
+        8,
+      );
+      assert.strictEqual(result.duration, undefined);
+      assert.strictEqual(result.envelope, undefined);
     });
   });
 });

--- a/packages/host/tests/unit/audio-metadata-extractor-test.ts
+++ b/packages/host/tests/unit/audio-metadata-extractor-test.ts
@@ -24,6 +24,26 @@ import type * as StreamingEnvelopeModule from '@cardstack/base/streaming-envelop
 import type * as VorbisModule from '@cardstack/base/vorbis-comment-parser';
 import type * as WavModule from '@cardstack/base/wav-meta-extractor';
 
+// Hand a reader a stream that yields small chunks, so a frame or sample lands
+// across chunk boundaries — the case a buffered reader never exercises.
+function chunkedStream(
+  bytes: Uint8Array,
+  chunkSize: number,
+): ReadableStream<Uint8Array> {
+  let offset = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (offset >= bytes.length) {
+        controller.close();
+        return;
+      }
+      let end = Math.min(offset + chunkSize, bytes.length);
+      controller.enqueue(bytes.slice(offset, end));
+      offset = end;
+    },
+  });
+}
+
 function ascii(text: string): number[] {
   return [...text].map((c) => c.charCodeAt(0));
 }
@@ -107,6 +127,7 @@ function buildFlac(
     bitsPerSample?: number;
   } = {},
   comments?: [string, string][],
+  seekPoints = 0,
 ): Uint8Array {
   let sampleRate = streamInfo.sampleRate ?? 44100;
   let channels = streamInfo.channels ?? 2;
@@ -133,13 +154,25 @@ function buildFlac(
   let hasComments = comments !== undefined;
   let out = [
     ...ascii('fLaC'),
-    // STREAMINFO header: type 0, not last when a comment block follows.
+    // STREAMINFO header: type 0, not last when another block follows.
     hasComments ? 0x00 : 0x80,
     0x00,
     0x00,
     0x22,
     ...block,
   ];
+  if (seekPoints > 0) {
+    // A SEEKTABLE (type 3) of 18 bytes per point, which most rippers write and
+    // which sits ahead of the comment block.
+    let length = seekPoints * 18;
+    out.push(
+      0x03,
+      (length >>> 16) & 0xff,
+      (length >>> 8) & 0xff,
+      length & 0xff,
+      ...new Array(length).fill(0),
+    );
+  }
   if (comments) {
     let body = vorbisCommentBody(comments);
     out.push(
@@ -252,16 +285,20 @@ function buildId3v2(
   majorVersion = 3,
 ): Uint8Array {
   let body: number[] = [];
+  // Appended rather than spread: a frame carrying artwork runs to hundreds of
+  // thousands of bytes, and `push(...payload)` exceeds the argument limit.
+  let append = (values: number[]) => {
+    for (let value of values) {
+      body.push(value);
+    }
+  };
   for (let [id, payload] of frames) {
-    body.push(
-      ...ascii(id),
-      ...(majorVersion >= 4
-        ? syncsafe(payload.length)
-        : uint32be(payload.length)),
-      0,
-      0, // frame flags
-      ...payload,
+    append(ascii(id));
+    append(
+      majorVersion >= 4 ? syncsafe(payload.length) : uint32be(payload.length),
     );
+    append([0, 0]); // frame flags
+    append(payload);
   }
   // Trailing padding, which the walk must treat as the end of the frames.
   body.push(0, 0, 0, 0);
@@ -312,10 +349,12 @@ module('Unit | audio metadata extractors', function (hooks) {
   let extractWavFromStream: typeof WavModule.extractWavFromStream;
   let extractFlacEncoding: typeof FlacModule.extractFlacEncoding;
   let extractFlacTags: typeof FlacModule.extractFlacTags;
+  let FLAC_METADATA_WINDOW_BYTES: number;
   let extractOggEncoding: typeof OggModule.extractOggEncoding;
   let extractOggTags: typeof OggModule.extractOggTags;
   let extractMp3Encoding: typeof Mp3Module.extractMp3Encoding;
   let extractMp3Envelope: typeof Mp3Module.extractMp3Envelope;
+  let extractMp3EnvelopeFromStream: typeof Mp3Module.extractMp3EnvelopeFromStream;
   let StreamingEnvelope: typeof StreamingEnvelopeModule.StreamingEnvelope;
   let parseId3v2Tags: typeof Id3Module.parseId3v2Tags;
   let parseVorbisComments: typeof VorbisModule.parseVorbisComments;
@@ -329,15 +368,17 @@ module('Unit | audio metadata extractors', function (hooks) {
       await loader.import<typeof WavModule>(
         '@cardstack/base/wav-meta-extractor',
       ));
-    ({ extractFlacEncoding, extractFlacTags } = await loader.import<
-      typeof FlacModule
-    >('@cardstack/base/flac-meta-extractor'));
+    ({ extractFlacEncoding, extractFlacTags, FLAC_METADATA_WINDOW_BYTES } =
+      await loader.import<typeof FlacModule>(
+        '@cardstack/base/flac-meta-extractor',
+      ));
     ({ extractOggEncoding, extractOggTags } = await loader.import<
       typeof OggModule
     >('@cardstack/base/ogg-meta-extractor'));
-    ({ extractMp3Encoding, extractMp3Envelope } = await loader.import<
-      typeof Mp3Module
-    >('@cardstack/base/mp3-meta-extractor'));
+    ({ extractMp3Encoding, extractMp3Envelope, extractMp3EnvelopeFromStream } =
+      await loader.import<typeof Mp3Module>(
+        '@cardstack/base/mp3-meta-extractor',
+      ));
     ({ StreamingEnvelope } = await loader.import<
       typeof StreamingEnvelopeModule
     >('@cardstack/base/streaming-envelope'));
@@ -487,6 +528,36 @@ module('Unit | audio metadata extractors', function (hooks) {
       assert.strictEqual(tags?.year, 1994);
       assert.strictEqual(tags?.track, '3');
       assert.strictEqual(tags?.scheme, 'vorbis-comment');
+    });
+
+    test('finds tags behind a seek table, which the old window truncated', function (assert) {
+      // A 1000-point SEEKTABLE puts the comment block ~18 KB into the file. The
+      // read window used to be 256 bytes, so tags on any ripper-written file
+      // silently came back empty — a short window yields no tags rather than an
+      // error, which is what made it invisible.
+      let bytes = buildFlac(
+        {},
+        [
+          ['TITLE', 'Behind A Seek Table'],
+          ['ARTIST', 'A Pianist'],
+        ],
+        1000,
+      );
+      assert.true(
+        bytes.length > 18_000,
+        'the fixture really does push the comment block deep',
+      );
+      let windowed = bytes.subarray(0, FLAC_METADATA_WINDOW_BYTES);
+      assert.strictEqual(
+        extractFlacTags(windowed)?.trackTitle,
+        'Behind A Seek Table',
+        'the window reaches the comment block',
+      );
+      assert.strictEqual(
+        extractFlacTags(bytes.subarray(0, 256)),
+        undefined,
+        'and the old 256-byte window demonstrably did not',
+      );
     });
 
     test('a FLAC with no comment block produces no tags', function (assert) {
@@ -1335,6 +1406,49 @@ module('Unit | audio metadata extractors', function (hooks) {
         undefined,
       );
     });
+
+    test('the streaming scan agrees with the buffered one', async function (assert) {
+      // The streaming walk keeps only a rolling few frames, so neither the
+      // decoded audio nor the encoded file is ever fully resident. It has to
+      // reach the same answer regardless of how the bytes are chunked, including
+      // when a frame straddles a boundary.
+      let bytes = new Uint8Array([
+        ...Array.from({ length: 6 }, () => frameWithGain(150)).flat(),
+        ...Array.from({ length: 6 }, () => frameWithGain(205)).flat(),
+      ]);
+      let buffered = extractMp3Envelope(bytes, 8);
+
+      for (let chunkSize of [13, 417, 1000]) {
+        let streamed = await extractMp3EnvelopeFromStream(
+          chunkedStream(bytes, chunkSize),
+          8,
+        );
+        assert.deepEqual(
+          streamed?.bars,
+          buffered?.bars,
+          `chunks of ${chunkSize} bytes produce the same envelope`,
+        );
+        assert.strictEqual(streamed?.granuleCount, buffered?.granuleCount);
+        assert.strictEqual(streamed?.frameCount, buffered?.frameCount);
+      }
+    });
+
+    test('the streaming scan skips a large ID3v2 tag without buffering it', async function (assert) {
+      // Artwork can make the tag megabytes; it is skipped by count rather than
+      // accumulated.
+      let artwork = new Array(200_000).fill(0x00);
+      let tag = buildId3v2([['APIC', artwork]]);
+      let bytes = new Uint8Array([
+        ...tag,
+        ...frameWithGain(190),
+        ...frameWithGain(190),
+      ]);
+      let streamed = await extractMp3EnvelopeFromStream(
+        chunkedStream(bytes, 4096),
+        4,
+      );
+      assert.strictEqual(streamed?.granuleCount, 8);
+    });
   });
 
   module('WAV single-pass streaming', function () {
@@ -1389,26 +1503,6 @@ module('Unit | audio metadata extractors', function (hooks) {
         ...uint32le(payload.length),
         ...payload,
       ]);
-    }
-
-    // Hand the reader a stream that yields small chunks, so frames land across
-    // chunk boundaries — the case a buffered reader never exercises.
-    function chunkedStream(
-      bytes: Uint8Array,
-      chunkSize: number,
-    ): ReadableStream<Uint8Array> {
-      let offset = 0;
-      return new ReadableStream<Uint8Array>({
-        pull(controller) {
-          if (offset >= bytes.length) {
-            controller.close();
-            return;
-          }
-          let end = Math.min(offset + chunkSize, bytes.length);
-          controller.enqueue(bytes.slice(offset, end));
-          offset = end;
-        },
-      });
     }
 
     function silentThenLoud(total: number): number[][] {

--- a/packages/host/tests/unit/audio-metadata-extractor-test.ts
+++ b/packages/host/tests/unit/audio-metadata-extractor-test.ts
@@ -359,6 +359,8 @@ module('Unit | audio metadata extractors', function (hooks) {
   let parseId3v2Tags: typeof Id3Module.parseId3v2Tags;
   let parseVorbisComments: typeof VorbisModule.parseVorbisComments;
   let analyzeDecodedAudio: typeof AudioWaveformModule.analyzeDecodedAudio;
+  let decodeSkipReason: typeof AudioWaveformModule.decodeSkipReason;
+  let predictedDecodedBytes: typeof AudioWaveformModule.predictedDecodedBytes;
   let audioAttributes: typeof AudioFileDefModule.audioAttributes;
   let extractMidiMetadata: typeof MidiModule.extractMidiMetadata;
 
@@ -388,9 +390,10 @@ module('Unit | audio metadata extractors', function (hooks) {
     ({ parseVorbisComments } = await loader.import<typeof VorbisModule>(
       '@cardstack/base/vorbis-comment-parser',
     ));
-    ({ analyzeDecodedAudio } = await loader.import<typeof AudioWaveformModule>(
-      '@cardstack/base/audio-waveform',
-    ));
+    ({ analyzeDecodedAudio, decodeSkipReason, predictedDecodedBytes } =
+      await loader.import<typeof AudioWaveformModule>(
+        '@cardstack/base/audio-waveform',
+      ));
     ({ audioAttributes } = await loader.import<typeof AudioFileDefModule>(
       '@cardstack/base/audio-file-def',
     ));
@@ -1605,6 +1608,134 @@ module('Unit | audio metadata extractors', function (hooks) {
       );
       assert.strictEqual(result.duration, undefined);
       assert.strictEqual(result.envelope, undefined);
+    });
+  });
+
+  module('decode budget', function () {
+    // The expansion factor from encoded to decoded is
+    // (sampleRate x channels x 32) / bitrate, so it varies by an order of
+    // magnitude across codecs. These are the real cases that made a single
+    // encoded-size ceiling wrong.
+    const MB = 1024 * 1024;
+
+    function forEncoded(
+      bitrateBps: number,
+      sampleRateHz: number,
+      channels: number,
+      encodedBytes: number,
+    ) {
+      let durationSeconds = (encodedBytes * 8) / bitrateBps;
+      return {
+        durationSeconds,
+        sampleRateHz,
+        channels,
+        contentSize: encodedBytes,
+      };
+    }
+
+    test('predicts decoded size from what the container already stated', function (assert) {
+      // Five minutes of 44.1 kHz stereo float.
+      assert.strictEqual(
+        predictedDecodedBytes({
+          durationSeconds: 300,
+          sampleRateHz: 44100,
+          channels: 2,
+        }),
+        300 * 44100 * 2 * 4,
+      );
+    });
+
+    test('admits an ordinary song', function (assert) {
+      // Four minutes of CD-rate stereo is ~85 MB decoded.
+      assert.strictEqual(
+        decodeSkipReason({
+          durationSeconds: 240,
+          sampleRateHz: 44100,
+          channels: 2,
+        }),
+        undefined,
+      );
+    });
+
+    test('refuses the low-bitrate Opus case the old ceiling admitted', function (assert) {
+      // 16 MB of 64 kbps Opus is 35 minutes, which decodes to ~768 MB — the
+      // case the flat 16 MB encoded ceiling let straight through.
+      let budget = forEncoded(64_000, 48_000, 2, 16 * MB);
+      assert.true(
+        budget.contentSize <= 16 * MB,
+        'the file is within what the old encoded ceiling allowed',
+      );
+      assert.ok(
+        decodeSkipReason(budget),
+        'but it is refused on the decoded size that actually matters',
+      );
+    });
+
+    test('still admits FLAC of the same encoded size', function (assert) {
+      // The same 16 MB as FLAC is only ~3 minutes, ~64 MB decoded. A per-codec
+      // outcome from one rule is the whole point.
+      let budget = forEncoded(705_600, 44_100, 2, 16 * MB);
+      assert.strictEqual(decodeSkipReason(budget), undefined);
+    });
+
+    test('mono costs half as much, so twice as long is allowed', function (assert) {
+      assert.strictEqual(
+        decodeSkipReason({
+          durationSeconds: 700,
+          sampleRateHz: 44100,
+          channels: 1,
+        }),
+        undefined,
+        'a long mono recording still fits',
+      );
+      assert.ok(
+        decodeSkipReason({
+          durationSeconds: 700,
+          sampleRateHz: 44100,
+          channels: 2,
+        }),
+        'the same duration in stereo does not',
+      );
+    });
+
+    test('the skip reason names the size that caused it', function (assert) {
+      let reason = decodeSkipReason({
+        durationSeconds: 3600,
+        sampleRateHz: 48000,
+        channels: 2,
+      });
+      assert.true(
+        /\d+ MB/.test(reason ?? ''),
+        'an operator can see how far over it was, not just that it was over',
+      );
+    });
+
+    test('falls back to encoded size when the container said too little', function (assert) {
+      assert.strictEqual(
+        predictedDecodedBytes({ contentSize: 999 * MB }),
+        undefined,
+        'nothing to predict from',
+      );
+      assert.ok(
+        decodeSkipReason({ contentSize: 999 * MB }),
+        'the encoded proxy still catches an enormous file',
+      );
+      assert.strictEqual(
+        decodeSkipReason({ contentSize: 4 * MB }),
+        undefined,
+        'and lets a small one through',
+      );
+    });
+
+    test('a zero or missing sample rate is not treated as a prediction', function (assert) {
+      assert.strictEqual(
+        predictedDecodedBytes({
+          durationSeconds: 300,
+          sampleRateHz: 0,
+          channels: 2,
+        }),
+        undefined,
+      );
     });
   });
 });

--- a/packages/host/tests/unit/audio-metadata-extractor-test.ts
+++ b/packages/host/tests/unit/audio-metadata-extractor-test.ts
@@ -20,6 +20,7 @@ import type * as Id3Module from '@cardstack/base/id3v2-parser';
 import type * as MidiModule from '@cardstack/base/midi-meta-extractor';
 import type * as Mp3Module from '@cardstack/base/mp3-meta-extractor';
 import type * as OggModule from '@cardstack/base/ogg-meta-extractor';
+import type * as StreamingEnvelopeModule from '@cardstack/base/streaming-envelope';
 import type * as VorbisModule from '@cardstack/base/vorbis-comment-parser';
 import type * as WavModule from '@cardstack/base/wav-meta-extractor';
 
@@ -313,6 +314,8 @@ module('Unit | audio metadata extractors', function (hooks) {
   let extractOggEncoding: typeof OggModule.extractOggEncoding;
   let extractOggTags: typeof OggModule.extractOggTags;
   let extractMp3Encoding: typeof Mp3Module.extractMp3Encoding;
+  let extractMp3Envelope: typeof Mp3Module.extractMp3Envelope;
+  let StreamingEnvelope: typeof StreamingEnvelopeModule.StreamingEnvelope;
   let parseId3v2Tags: typeof Id3Module.parseId3v2Tags;
   let parseVorbisComments: typeof VorbisModule.parseVorbisComments;
   let analyzeDecodedAudio: typeof AudioWaveformModule.analyzeDecodedAudio;
@@ -330,9 +333,12 @@ module('Unit | audio metadata extractors', function (hooks) {
     ({ extractOggEncoding, extractOggTags } = await loader.import<
       typeof OggModule
     >('@cardstack/base/ogg-meta-extractor'));
-    ({ extractMp3Encoding } = await loader.import<typeof Mp3Module>(
-      '@cardstack/base/mp3-meta-extractor',
-    ));
+    ({ extractMp3Encoding, extractMp3Envelope } = await loader.import<
+      typeof Mp3Module
+    >('@cardstack/base/mp3-meta-extractor'));
+    ({ StreamingEnvelope } = await loader.import<
+      typeof StreamingEnvelopeModule
+    >('@cardstack/base/streaming-envelope'));
     ({ parseId3v2Tags } = await loader.import<typeof Id3Module>(
       '@cardstack/base/id3v2-parser',
     ));
@@ -1152,6 +1158,179 @@ module('Unit | audio metadata extractors', function (hooks) {
       assert.true(
         midi.noteCount! >= 1,
         'a partial track still reports what was readable rather than throwing',
+      );
+    });
+  });
+
+  module('streaming envelope', function () {
+    test('holds its bar count however many units arrive', function (assert) {
+      // The point of the doubling accumulator: memory and output stay fixed even
+      // though the total is unknown while pushing.
+      for (let units of [4, 100, 10_000]) {
+        let envelope = new StreamingEnvelope(16);
+        for (let index = 0; index < units; index++) {
+          envelope.push(0.25, 1);
+        }
+        assert.strictEqual(
+          envelope.bars().length,
+          16,
+          `${units} units still reduce to 16 bars`,
+        );
+      }
+    });
+
+    test('places signal by position, not by arrival order', function (assert) {
+      // Silence for the first three quarters, then full amplitude. A producer
+      // that mis-tracked position would smear this across every bar.
+      let envelope = new StreamingEnvelope(8);
+      for (let index = 0; index < 3000; index++) {
+        envelope.push(0, 1);
+      }
+      for (let index = 0; index < 1000; index++) {
+        envelope.push(1, 1);
+      }
+      let bars = envelope.bars();
+      assert.strictEqual(bars[0], 0, 'the silent opening reads as silent');
+      assert.strictEqual(
+        bars[7],
+        1,
+        'the loud ending reaches the final bar rather than being folded away',
+      );
+    });
+
+    test('survives many folds without losing the shape', function (assert) {
+      // Far more units than the fine-bucket capacity, forcing repeated folds.
+      let envelope = new StreamingEnvelope(4);
+      let total = 100_000;
+      for (let index = 0; index < total; index++) {
+        envelope.push(index < total / 2 ? 0 : 1, 1);
+      }
+      let bars = envelope.bars();
+      assert.strictEqual(bars[0], 0);
+      assert.strictEqual(bars[1], 0);
+      assert.strictEqual(
+        bars[3],
+        1,
+        'the second half is still loud after folding',
+      );
+    });
+
+    test('reports the peak it was told about', function (assert) {
+      let envelope = new StreamingEnvelope(4);
+      envelope.push(0.01, 1, 0.1);
+      envelope.push(0.81, 1, 0.9);
+      envelope.push(0.04, 1, 0.2);
+      assert.strictEqual(envelope.peak, 0.9);
+    });
+
+    test('an accumulator nothing was pushed to is empty, not zero-filled', function (assert) {
+      let envelope = new StreamingEnvelope(8);
+      assert.true(envelope.isEmpty);
+      assert.deepEqual(envelope.bars(), []);
+    });
+  });
+
+  module('MP3 envelope from side info', function () {
+    // Build a frame whose side info carries a chosen global_gain in every
+    // granule, so the envelope has a known shape without any real audio.
+    function frameWithGain(gain: number): number[] {
+      // MPEG-1 Layer III, 128 kbps, 44.1 kHz, joint stereo, no CRC.
+      let header = [0xff, 0xfb, 0x90, 0x40];
+      // 144 * 128000 / 44100 = 417 bytes, no padding.
+      let length = 417;
+      let body = new Array(length - 4).fill(0);
+      // Stereo MPEG-1 side info: main_data_begin(9) + private(3) + scfsi(8) = 20
+      // bits, then four 59-bit granule/channel blocks with global_gain 21 bits in.
+      let base = 20;
+      for (let block = 0; block < 4; block++) {
+        let bitOffset = base + block * 59 + 21;
+        for (let bit = 0; bit < 8; bit++) {
+          let value = (gain >> (7 - bit)) & 1;
+          let absolute = bitOffset + bit;
+          let byteIndex = absolute >> 3;
+          if (value) {
+            body[byteIndex] |= 1 << (7 - (absolute & 7));
+          }
+        }
+      }
+      return [...header, ...body];
+    }
+
+    test('reads a gain out of every granule of every frame', function (assert) {
+      // Four frames, two granules x two channels each.
+      let bytes = new Uint8Array([
+        ...frameWithGain(200),
+        ...frameWithGain(200),
+        ...frameWithGain(200),
+        ...frameWithGain(200),
+      ]);
+      let envelope = extractMp3Envelope(bytes, 8);
+      assert.strictEqual(
+        envelope?.granuleCount,
+        16,
+        'four frames yield sixteen granule gains',
+      );
+      assert.strictEqual(envelope?.frameCount, 4);
+      assert.strictEqual(envelope?.sampleRateHz, 44100);
+    });
+
+    test('a louder passage produces taller bars than a quieter one', function (assert) {
+      // global_gain is logarithmic, so a higher value is a larger amplitude.
+      let quiet = Array.from({ length: 8 }, () => frameWithGain(150)).flat();
+      let loud = Array.from({ length: 8 }, () => frameWithGain(210)).flat();
+      let envelope = extractMp3Envelope(new Uint8Array([...quiet, ...loud]), 4);
+      let bars = envelope!.bars;
+      assert.true(
+        bars[0]! < bars[3]!,
+        'the quiet opening reads lower than the loud ending',
+      );
+      assert.strictEqual(
+        bars[3],
+        1,
+        'bars are normalized to the track peak, so the loudest reaches 1',
+      );
+    });
+
+    test('derives a duration from granule count without needing a Xing header', function (assert) {
+      // Each granule is 576 samples; 16 granules at 44.1 kHz is ~0.209 s.
+      let bytes = new Uint8Array(
+        Array.from({ length: 4 }, () => frameWithGain(180)).flat(),
+      );
+      let envelope = extractMp3Envelope(bytes, 8);
+      assert.strictEqual(
+        envelope?.durationSeconds,
+        Math.round((16 * 576 * 1000) / 44100) / 1000,
+      );
+    });
+
+    test('skips a leading ID3v2 tag', function (assert) {
+      let tag = buildId3v2([['TIT2', latin1Frame('Tagged')]]);
+      let bytes = new Uint8Array([
+        ...tag,
+        ...frameWithGain(190),
+        ...frameWithGain(190),
+      ]);
+      assert.strictEqual(extractMp3Envelope(bytes, 4)?.granuleCount, 8);
+    });
+
+    test('resynchronizes past a corrupt frame rather than stopping', function (assert) {
+      let bytes = new Uint8Array([
+        ...frameWithGain(190),
+        ...new Array(64).fill(0x41), // garbage between frames
+        ...frameWithGain(190),
+      ]);
+      let envelope = extractMp3Envelope(bytes, 4);
+      assert.strictEqual(
+        envelope?.frameCount,
+        2,
+        'a single corrupt run does not cost the rest of the file',
+      );
+    });
+
+    test('a file with no frames yields nothing rather than throwing', function (assert) {
+      assert.strictEqual(
+        extractMp3Envelope(new Uint8Array(256).fill(0x41), 8),
+        undefined,
       );
     });
   });

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -39,6 +39,10 @@ const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
   '.opus': { module: baseModule('ogg-audio-def'), name: 'OggDef' },
   '.m4a': { module: baseModule('m4a-audio-def'), name: 'M4aDef' },
   '.flac': { module: baseModule('flac-audio-def'), name: 'FlacDef' },
+  // Symbolic performance data rather than sampled audio, so `MidiDef` extends
+  // FileDef directly instead of AudioDef.
+  '.mid': { module: baseModule('midi-audio-def'), name: 'MidiDef' },
+  '.midi': { module: baseModule('midi-audio-def'), name: 'MidiDef' },
   '.mismatch': {
     module: './filedef-mismatch' as RealmResourceIdentifier,
     name: 'FileDef',


### PR DESCRIPTION
Split out of #5702, which had grown to cover three families. That PR is now image/EXIF only — the part jurgenwerk reviewed. This is everything after it, stacked on it; retarget to `main` once it lands.

Second slice of CS-12230, covering CS-12238's metadata half.

## The gap

Audio FileDefs recorded a `duration` and nothing else, so a tagged, mastered track indexed as anonymously as a voice memo. MIDI had no FileDef at all.

## What's here

Three shared shapes join the metadata module — `MediaEncodingField`, `MediaTagsField`, `WaveformMetadataField` — plus `MidiMetadataField`. Encoding facts come from headers each duration reader already walked, so they cost no extra I/O. Two tag conventions became shared modules because more than one format speaks them: `vorbis-comment-parser` (FLAC + both Ogg codecs) and `id3v2-parser` (what `mp3-meta-extractor` already skipped past).

**MIDI extends `FileDef`, not `AudioDef`.** A Standard MIDI File is symbolic performance data with no sound until a synthesizer renders it — no sample rate, no bit depth, no amplitude envelope. Inheriting `AudioDef` would make every MIDI file advertise fields it can never fill. The taxonomy registry already models it as its own `music` family.

## Waveforms without decoders

The envelope is the one audio fact a header can't give you, and it started as a full Web Audio decode. Two formats no longer need one:

- **MP3** reads quantizer gains out of each frame's side info — `2^((global_gain − 210)/4)` is the granule's amplitude scale — with no Huffman decode, no IMDCT, no filterbank. Frames are self-delimiting, so it streams on a rolling few-frame buffer. This mattered most: float PCM is ~22× the encoded size for a 128 kbps stream, so a 16 MB MP3 was ~350 MB decoded.
- **WAV** is already PCM. It now walks the container in one pass, folding samples straight into the envelope — one fetch instead of two, no decoder, and a true-RMS envelope on the same scale a decoded one produces.

`streaming-envelope.ts` is what makes both flat in memory: a producer must place a value into a bar before knowing how many are coming, so it over-buckets and halves resolution on overflow — a doubling histogram where each fold merges adjacent pairs.

FLAC, Ogg, and M4A still decode; none exposes an amplitude proxy.

## Efficiency pass, per format

| Format | Before | After |
|---|---|---|
| WAV | 2 fetches, buffer, decode | 1 fetch, streaming, no decoder |
| MP3 | 2 fetches, whole file buffered | 2 fetches, rolling frame buffer |
| FLAC | 2 fetches, **256-byte window losing tags** | window that reaches the comments |
| Ogg | **3 fetches** | 2 |
| M4A | **3 fetches** | 2 |

**FLAC was silently losing every tag.** Its window was sized for STREAMINFO at offset 42, but `VORBIS_COMMENT` sits behind whatever blocks the encoder wrote — a SEEKTABLE (most rippers emit one, 18 bytes per point) puts it ~18 KB in, and a realistic tag set alone runs past 500 bytes. A short window returns *no tags rather than an error*, which is why it went unnoticed. The regression test asserts both directions.

Ogg and M4A each made three fetches; both already streamed a walk retaining exactly what the metadata readers need (Ogg's head buffer, M4A's `moov`), so they now hand it back.

## The decode budget was measuring the wrong thing

The ceiling was 16 MB of *encoded* audio. But the expansion factor is `(sampleRate × channels × 32) / bitrate` — ~4× for FLAC, 22× for AAC, up to 48× for low-bitrate Opus. So one encoded ceiling meant wildly different decodes: 16 MB of FLAC is ~64 MB, but 16 MB of 64 kbps Opus is 35 minutes and **~768 MB**, and it passed the same check.

The budget now applies to the predicted *decoded* size, which costs nothing to compute — every caller has already read duration, sample rate, and channels before deciding. One rule, per-codec outcomes. 128 MB admits ~5 minutes of 44.1 kHz stereo; mono gets twice the duration, which falls out of measuring the right thing.

## Honest limits, recorded not hidden

MP3's quantizer scale isn't calibrated amplitude, so its bars are normalized to the track's own peak and `peakAmplitude`/`rmsAmplitude` are left unset rather than reported on an incomparable scale. `algorithm` distinguishes `mp3-side-info-v1` from `rms-peak-v1`. `decodeStatus` separates `skipped`, `unsupported`, and `failed`, so a renderer can tell "too large" from "cannot".

Facts a container never stated stay unset: MP3 has no bit-depth concept, FLAC states no bitrate, a lossy AAC sample entry's size field describes nothing. A track number keeps its total as authored (`4/12`).

## Testing

118 tests / 310 assertions over hand-built byte fixtures. Includes the cases that motivated each fix: the 64 kbps Opus file asserted to be *within* the old encoded ceiling and *refused* by the new one; FLAC tags found behind a 1000-point seek table and demonstrably not found by the old window; the MP3 streaming scan required to agree with the buffered one at 13, 417, and 1000-byte chunks; WAV driven at 7-byte chunks against 4-byte stereo frames so nearly every boundary falls mid-frame.

`realm indexing` 140/140, `ember-tsc` across host/ai-bot/bot-runner/billing, and base's own lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)