### PR TITLE
AI assistant: Fix Auto-apply a patch that was split across continuation events

### DIFF
--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -293,6 +293,33 @@ export class RoomResource extends Resource<Args> {
       .sort((a, b) => a.created.getTime() - b.created.getTime());
   }
 
+  /**
+   * The message an event belongs to, which for an answer long enough to have
+   * been split across continuation events is the head of that chain — the one
+   * `messages` exposes, and the only one whose `body` is the whole answer. A
+   * caller holding a raw event id cannot use `messages.find` for this: the
+   * continuations are filtered out of that list, so every id but the first
+   * looks like an event with no message.
+   */
+  messageForEventId(eventId: string): Message | undefined {
+    let message = this._messageCache.get(eventId);
+    if (!message) {
+      return undefined;
+    }
+    let seen = new Set<string>();
+    while (message?.continuationOf && !seen.has(message.continuationOf)) {
+      seen.add(message.continuationOf);
+      let parent = this._messageCache.get(message.continuationOf);
+      if (!parent) {
+        // The head has not arrived yet. Returning nothing lets the caller wait
+        // for a later event in the chain rather than act on a partial answer.
+        return undefined;
+      }
+      message = parent;
+    }
+    return message;
+  }
+
   @cached
   get members() {
     if (this.roomId == undefined) {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -3020,11 +3020,17 @@ export default class MatrixService extends Service {
       event.content?.body &&
       event.content?.isStreamingFinished
     ) {
-      // Check if the message contains code patches by looking for search/replace blocks
+      // Any marker is enough to queue. An answer too long for one event is
+      // split at a character count that knows nothing about what it is cutting
+      // through, so a SEARCH/REPLACE block routinely straddles the boundary and
+      // no single event holds all three markers — requiring all three here left
+      // exactly those patches unqueued, while the UI, which reads the joined
+      // message, still offered an apply button for them. Whether there is
+      // anything to apply is decided later against the whole answer.
       let body = event.content.body as string;
       if (
-        body.includes(SEARCH_MARKER) &&
-        body.includes(SEPARATOR_MARKER) &&
+        body.includes(SEARCH_MARKER) ||
+        body.includes(SEPARATOR_MARKER) ||
         body.includes(REPLACE_MARKER)
       ) {
         this.toolService.queueEventForCodePatchProcessing(event);

--- a/packages/host/app/services/tool-service.ts
+++ b/packages/host/app/services/tool-service.ts
@@ -617,7 +617,10 @@ export default class ToolService extends Service {
           );
           continue;
         }
-        let message = roomResource.messages.find((m) => m.eventId === eventId);
+        // Resolve through the continuation chain: a long answer arrives as
+        // several events, and only the head of the chain carries the joined
+        // body every patch was parsed from.
+        let message = roomResource.messageForEventId(eventId);
         if (!message) {
           // The event was queued for auto-apply but its message isn't in the
           // room timeline yet — room processing lagged or dropped it. The event

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -26,6 +26,8 @@ import {
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
   APP_BOXEL_TOOL_REQUESTS_KEY,
   APP_BOXEL_LLM_MODE,
+  APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
+  APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
 } from '@cardstack/runtime-common/matrix-constants';
 
 import {
@@ -1603,6 +1605,58 @@ ${REPLACE_MARKER}
       .doesNotExist(
         'Code patch sent before act mode is still not auto-applied',
       );
+  });
+
+  test('a patch split across continuation events is still auto-applied in act mode', async function (assert) {
+    // An answer too long for one event is cut at a character count that knows
+    // nothing about what it is cutting through, so a SEARCH/REPLACE block ends
+    // up straddling the boundary: no single event holds all three markers, and
+    // only the head of the chain carries the joined body the patch is parsed
+    // from. The UI reads that joined body and offers an apply button, so a
+    // patch that never reached the queue looks identical to one waiting to be
+    // applied — in act mode it should simply apply.
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}hello.txt`,
+    });
+    await click('[data-test-open-ai-assistant]');
+    let roomId = getRoomIds().pop()!;
+
+    await click('[data-test-llm-mode-selector]');
+    await click('[data-test-llm-mode-option="act"]');
+
+    let head = `\`\`\`
+http://test-realm/test/hello.txt
+${SEARCH_MARKER}
+Hello, world!
+`;
+    let tail = `${SEPARATOR_MARKER}
+Hi, from across the split!
+${REPLACE_MARKER}
+\`\`\``;
+
+    let agentId = getService('matrix-service').agentId;
+    let headEventId = simulateRemoteMessage(roomId, '@aibot:localhost', {
+      body: head,
+      msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+      format: 'org.matrix.custom.html',
+      isStreamingFinished: true,
+      [APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY]: true,
+      data: { context: { agentId } },
+    });
+    simulateRemoteMessage(roomId, '@aibot:localhost', {
+      body: tail,
+      msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+      format: 'org.matrix.custom.html',
+      isStreamingFinished: true,
+      [APP_BOXEL_CONTINUATION_OF_CONTENT_KEY]: headEventId,
+      data: { context: { agentId } },
+    });
+
+    await waitFor('[data-test-apply-state="applied"]', { timeout: 5000 });
+    assert
+      .dom('[data-test-apply-state="applied"]')
+      .exists('the patch applies even though it was split across two events');
   });
 
   test('LLM mode for a message is resolved by room order, not just timestamp', async function (assert) {

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -1622,7 +1622,6 @@ ${REPLACE_MARKER}
     await click('[data-test-open-ai-assistant]');
     let roomId = getRoomIds().pop()!;
 
-    await click('[data-test-llm-mode-selector]');
     await click('[data-test-llm-mode-option="act"]');
 
     let head = `\`\`\`


### PR DESCRIPTION
## Problem

There was a problem where the assistant offered multiple patches but didn't apply them automatically, even when the ASK/ACT toggle was set to ACT.

The program divided the answer into continuation events. The division occurs at a count of characters. The division does not examine the content. Thus a SEARCH/REPLACE block can start in one event and end in a different event.

This is the data from a session:

```
HAS-CONT   len= 3799   SEARCH=1  SEP=1  REPLACE=0
CONT-OF    len=16384   SEARCH=3  SEP=3  REPLACE=3
CONT-OF    len=  279   SEARCH=0  SEP=0  REPLACE=1
```

Two conditions caused the failure:

- The program asked each event if that event had all three markers. A block that starts in one event and ends in a different event has no event with all three markers. Thus the program did not put these blocks into the queue.
- The middle event had all three markers. But the program then discarded it. The program used `roomResource.messages` to find the message, and that list does not include continuations.

The result is that the program applied no patches.

The user interface shows the joined message, where each block is complete. Thus the interface showed an apply button for a patch that the program cannot apply.

## Change

The program now puts an event into the queue if the event has any marker. The program then finds the head of the continuation chain. The `body` of the head contains the full answer. The subsequent steps do not change.

## Alternative

You can divide the answer at the end of a block. This alternative is not correct. One card definition is frequently larger than the limit for one event. Then there is no position to divide the answer, and the problem occurs again.

## Test

The test divides a block into two events. The test then makes sure that the program applies the patch in act mode.