### PR TITLE
Deep link into profile subscription from a URL

### DIFF
--- a/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
@@ -138,8 +138,9 @@ export default class ProfileSettingsModal extends Component<Signature> {
             />
           {{/if}}
           <div
-            data-test-profile-subscription-section
+            class='profile-settings-subscription'
             {{scrollIntoViewIfRequested this.subscriptionRequested}}
+            data-test-profile-subscription-section
           >
             <ProfileSubscription />
           </div>
@@ -217,7 +218,8 @@ export default class ProfileSettingsModal extends Component<Signature> {
       .profile-field :deep(.invalid) {
         box-shadow: none;
       }
-      .profile-field + .profile-field {
+      .profile-field + .profile-field,
+      .profile-settings-subscription {
         margin-top: var(--boxel-sp-xl);
       }
     </style>

--- a/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
@@ -9,6 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout, all } from 'ember-concurrency';
 
 import perform from 'ember-concurrency/helpers/perform';
+import { modifier } from 'ember-modifier';
 
 import {
   BoxelButton,
@@ -24,11 +25,21 @@ import { ProfileInfo } from '@cardstack/host/components/operator-mode/profile-in
 import config from '@cardstack/host/config/environment';
 import { isValidPassword } from '@cardstack/host/lib/matrix-utils';
 import type MatrixService from '@cardstack/host/services/matrix-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import ProfileEmail from './profile-email';
 import ProfileSubscription from './profile-subscription';
 
 import type { IAuthData } from 'matrix-js-sdk';
+
+// Subscription sits below the fold in this 70vh modal
+const scrollIntoViewIfRequested = modifier(
+  (element: HTMLElement, [requested]: [boolean]) => {
+    if (requested) {
+      element.scrollIntoView({ block: 'start' });
+    }
+  },
+);
 
 interface Signature {
   Args: {
@@ -126,7 +137,12 @@ export default class ProfileSettingsModal extends Component<Signature> {
               @changeEmailComplete={{this.completeEmail}}
             />
           {{/if}}
-          <ProfileSubscription />
+          <div
+            data-test-profile-subscription-section
+            {{scrollIntoViewIfRequested this.subscriptionRequested}}
+          >
+            <ProfileSubscription />
+          </div>
         </form>
         {{#if (or (bool this.displayNameError) (bool this.error))}}
           <div class='error-message' data-test-profile-save-error>
@@ -208,6 +224,7 @@ export default class ProfileSettingsModal extends Component<Signature> {
   </template>
 
   @service declare private matrixService: MatrixService;
+  @service declare private operatorModeStateService: OperatorModeStateService;
   @tracked private displayName: string | undefined;
   @tracked private submode: 'email' | 'password' | undefined;
   @tracked private saveSuccessIndicatorShown = false;
@@ -227,6 +244,12 @@ export default class ProfileSettingsModal extends Component<Signature> {
   constructor(owner: Owner, args: any) {
     super(owner, args);
     this.setInitialValues.perform();
+  }
+
+  private get subscriptionRequested() {
+    return (
+      this.operatorModeStateService.profileSettingsSection === 'subscription'
+    );
   }
 
   private get title() {

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -1,6 +1,8 @@
 import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
+import { scheduleOnce } from '@ember/runloop';
 
 import { service } from '@ember/service';
 
@@ -141,6 +143,33 @@ export default class SubmodeLayout extends Component<Signature> {
   @service declare private recentCardsService: RecentCardsService;
   @service('search-sheet-state')
   declare private searchSheetState: SearchSheetStateService;
+
+  // `?openProfileSettings` deep link. Consumed here, not in the
+  // index route, because this component exists only once logged in — a
+  // logged-out arrival renders <Auth /> after the model hook has returned.
+  // afterRender: both writes touch state this render pass already read.
+  constructor(owner: Owner, args: Signature['Args']) {
+    super(owner, args);
+
+    if (
+      this.operatorModeStateService.operatorModeController.openProfileSettings
+    )
+      scheduleOnce('afterRender', this, this.consumeProfileSettingsDeepLink);
+  }
+
+  // Nulled like `sid` in matrix/auth.gts, so the modal does not reopen on
+  // the model refresh every schedulePersist() triggers.
+  private consumeProfileSettingsDeepLink = () => {
+    let controller = this.operatorModeStateService.operatorModeController;
+    let requested = controller.openProfileSettings;
+    if (!requested) {
+      return;
+    }
+    controller.openProfileSettings = null;
+    this.operatorModeStateService.openProfileSettings(
+      requested === 'subscription' ? 'subscription' : undefined,
+    );
+  };
 
   private searchElement: HTMLElement | null = null;
   private suppressSearchClose = false;

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -166,6 +166,9 @@ export default class SubmodeLayout extends Component<Signature> {
       return;
     }
     controller.openProfileSettings = null;
+    // An unrecognized value still opens settings: this param is linked from
+    // external pages, so a stale or mistyped link degrades to the modal's
+    // default view rather than doing nothing.
     this.operatorModeStateService.openProfileSettings(
       requested === 'subscription' ? 'subscription' : undefined,
     );

--- a/packages/host/app/controllers/index.ts
+++ b/packages/host/app/controllers/index.ts
@@ -17,4 +17,5 @@ export default class IndexController extends Controller {
   @tracked sid: string | null = null;
   @tracked clientSecret: string | null = null;
   @tracked debug = false;
+  @tracked openProfileSettings: string | null = null;
 }

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -177,7 +177,6 @@ export default class OperatorModeStateService extends Service {
   private moduleInspectorHistory: Record<string, ModuleInspectorView>;
 
   @tracked profileSettingsOpen = false;
-  // Section to reveal when the settings modal opens
   @tracked profileSettingsSection: ProfileSettingsSection | undefined;
   @tracked createListingModalPayload?: CreateListingModalPayload;
 

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -117,6 +117,8 @@ interface SerializedExpandedStackItem {
 
 export type FileView = 'inspector' | 'browser';
 
+export type ProfileSettingsSection = 'subscription';
+
 type SerializedItem = CardItem;
 type SerializedStack = SerializedItem[];
 
@@ -175,6 +177,8 @@ export default class OperatorModeStateService extends Service {
   private moduleInspectorHistory: Record<string, ModuleInspectorView>;
 
   @tracked profileSettingsOpen = false;
+  // Section to reveal when the settings modal opens
+  @tracked profileSettingsSection: ProfileSettingsSection | undefined;
   @tracked createListingModalPayload?: CreateListingModalPayload;
 
   // Per-card expanded-mode intent. Keyed by stack-item instance id so the
@@ -255,6 +259,14 @@ export default class OperatorModeStateService extends Service {
 
   toggleProfileSettings = () => {
     this.profileSettingsOpen = !this.profileSettingsOpen;
+    if (!this.profileSettingsOpen) {
+      this.profileSettingsSection = undefined;
+    }
+  };
+
+  openProfileSettings = (section?: ProfileSettingsSection) => {
+    this.profileSettingsSection = section;
+    this.profileSettingsOpen = true;
   };
 
   get state() {
@@ -330,6 +342,7 @@ export default class OperatorModeStateService extends Service {
     this.cardTitles = new TrackedMap();
     this.moduleInspectorHistory = {};
     this.profileSettingsOpen = false;
+    this.profileSettingsSection = undefined;
     this.createListingModalPayload = undefined;
     this.expandedStackItems.clear();
     window.localStorage.removeItem(ModuleInspectorSelections);

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -1196,6 +1196,30 @@ module('Acceptance | operator mode tests', function (hooks) {
       );
     });
 
+    test('the deep link opens the modal once the visitor logs in', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
+      })!;
+      await click('[data-test-profile-icon-button]');
+      await click('[data-test-signout-button]');
+
+      await visit('/?openProfileSettings=subscription');
+      assert.dom('[data-test-settings-modal]').doesNotExist();
+
+      await fillIn('[data-test-username-field]', 'testuser');
+      await fillIn('[data-test-password-field]', 'mock-password');
+      await click('[data-test-login-btn]');
+
+      // The route's model hook already ran and returned while logged out, so
+      // this only passes if the param is consumed after the post-login refresh.
+      assert.dom('[data-test-settings-modal]').exists();
+      assert.dom('[data-test-profile-subscription-section]').exists();
+      assert.notOk(
+        currentURL().includes('openProfileSettings'),
+        'the param is consumed on arrival',
+      );
+    });
+
     test('can access and save settings via profile info popover', async function (assert) {
       await visitOperatorMode({
         stacks: [

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -1178,7 +1178,7 @@ module('Acceptance | operator mode tests', function (hooks) {
       assert.dom('[data-test-settings-modal]').doesNotExist();
     });
 
-    test('an unauthenticated arrival keeps the deep link until after login', async function (assert) {
+    test('a deep link arriving logged out waits for login, then opens the modal', async function (assert) {
       await visitOperatorMode({
         stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
       })!;
@@ -1188,35 +1188,24 @@ module('Acceptance | operator mode tests', function (hooks) {
 
       await visit('/?openProfileSettings=subscription');
 
+      // The model hook returns before the login form renders, so consuming
+      // the param there would swallow it with no modal to show.
       assert.dom('[data-test-login-btn]').exists();
       assert.dom('[data-test-settings-modal]').doesNotExist();
       assert.ok(
         currentURL().includes('openProfileSettings=subscription'),
         'the param must outlive the login form',
       );
-    });
-
-    test('the deep link opens the modal once the visitor logs in', async function (assert) {
-      await visitOperatorMode({
-        stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
-      })!;
-      await click('[data-test-profile-icon-button]');
-      await click('[data-test-signout-button]');
-
-      await visit('/?openProfileSettings=subscription');
-      assert.dom('[data-test-settings-modal]').doesNotExist();
 
       await fillIn('[data-test-username-field]', 'testuser');
       await fillIn('[data-test-password-field]', 'mock-password');
       await click('[data-test-login-btn]');
 
-      // The route's model hook already ran and returned while logged out, so
-      // this only passes if the param is consumed after the post-login refresh.
       assert.dom('[data-test-settings-modal]').exists();
       assert.dom('[data-test-profile-subscription-section]').exists();
       assert.notOk(
         currentURL().includes('openProfileSettings'),
-        'the param is consumed on arrival',
+        'the param is consumed once it has been acted on',
       );
     });
 

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -1152,6 +1152,50 @@ module('Acceptance | operator mode tests', function (hooks) {
       },
     ]);
 
+    test('openProfileSettings deep link opens settings on the subscription section', async function (assert) {
+      await visit('/?openProfileSettings=subscription');
+
+      assert.dom('[data-test-settings-modal]').exists();
+      assert.dom('[data-test-profile-subscription-section]').exists();
+
+      assert.notOk(
+        currentURL().includes('openProfileSettings'),
+        'the param is consumed on arrival',
+      );
+    });
+
+    test('a closed settings modal stays closed when operator mode state persists', async function (assert) {
+      await visit('/?openProfileSettings=subscription');
+      assert.dom('[data-test-settings-modal]').exists();
+
+      await click('[data-test-confirm-cancel-button]');
+      assert.dom('[data-test-settings-modal]').doesNotExist();
+
+      // Persisting re-runs the route's model hook
+      getService('operator-mode-state-service').workspaceChooserOpened = true;
+      await settled();
+
+      assert.dom('[data-test-settings-modal]').doesNotExist();
+    });
+
+    test('an unauthenticated arrival keeps the deep link until after login', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
+      })!;
+      await click('[data-test-profile-icon-button]');
+      await click('[data-test-signout-button]');
+      assert.dom('[data-test-login-btn]').exists();
+
+      await visit('/?openProfileSettings=subscription');
+
+      assert.dom('[data-test-login-btn]').exists();
+      assert.dom('[data-test-settings-modal]').doesNotExist();
+      assert.ok(
+        currentURL().includes('openProfileSettings=subscription'),
+        'the param must outlive the login form',
+      );
+    });
+
     test('can access and save settings via profile info popover', async function (assert) {
       await visitOperatorMode({
         stacks: [

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -1156,7 +1156,11 @@ module('Acceptance | operator mode tests', function (hooks) {
       await visit('/?openProfileSettings=subscription');
 
       assert.dom('[data-test-settings-modal]').exists();
-      assert.dom('[data-test-profile-subscription-section]').exists();
+      assert.strictEqual(
+        getService('operator-mode-state-service').profileSettingsSection,
+        'subscription',
+        'the modal opened targeting the subscription section',
+      );
 
       assert.notOk(
         currentURL().includes('openProfileSettings'),
@@ -1202,7 +1206,11 @@ module('Acceptance | operator mode tests', function (hooks) {
       await click('[data-test-login-btn]');
 
       assert.dom('[data-test-settings-modal]').exists();
-      assert.dom('[data-test-profile-subscription-section]').exists();
+      assert.strictEqual(
+        getService('operator-mode-state-service').profileSettingsSection,
+        'subscription',
+        'the modal opened targeting the subscription section',
+      );
       assert.notOk(
         currentURL().includes('openProfileSettings'),
         'the param is consumed once it has been acted on',
@@ -1226,6 +1234,11 @@ module('Acceptance | operator mode tests', function (hooks) {
 
       assert.dom('[data-test-profile-popover]').doesNotExist();
       assert.dom('[data-test-settings-modal]').exists();
+      assert.strictEqual(
+        getService('operator-mode-state-service').profileSettingsSection,
+        undefined,
+        'a plain open does not target a section',
+      );
 
       assert.dom('[data-test-profile-icon]').hasText('T'); // "T", from first letter of: @testuser:localhost
       assert.dom('[data-test-profile-display-name]').hasText(''); // No display name set yet

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -431,11 +431,20 @@ export class MockClient implements ExtendedClient {
     } as unknown as MatrixSDK.Room);
   }
 
+  // Mirrors what `loggedInAs` bootstraps at setup, so a test can drive the
+  // real login form and get the post-login route refresh that follows it.
+  // Any password is accepted; these tests are not about credentials.
   loginWithPassword(
-    _user: string,
+    user: string,
     _password: string,
   ): Promise<MatrixSDK.LoginResponse> {
-    throw new Error('Method not implemented.');
+    let userId = user.startsWith('@') ? user : `@${user}:localhost`;
+    this.clientOpts.userId = userId;
+    return Promise.resolve({
+      access_token: 'mock-access-token',
+      device_id: 'mock-device-id',
+      user_id: userId,
+    } as MatrixSDK.LoginResponse);
   }
 
   loginFlows(): Promise<{ flows: MatrixSDK.LoginFlow[] }> {

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -223,8 +223,7 @@ export class MockClient implements ExtendedClient {
   }
 
   async getOpenIdToken() {
-    let accessToken =
-      this.sdkOpts.loggedInAs ?? this.clientOpts.userId ?? 'mock-matrix-user';
+    let accessToken = this.loggedInAs ?? 'mock-matrix-user';
     let baseUrl = this.baseUrl ?? 'http://localhost';
     let matrixServerName: string;
     try {

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -432,8 +432,7 @@ export class MockClient implements ExtendedClient {
   }
 
   // Mirrors what `loggedInAs` bootstraps at setup, so a test can drive the
-  // real login form and get the post-login route refresh that follows it.
-  // Any password is accepted; these tests are not about credentials.
+  // real login form. Any password is accepted.
   loginWithPassword(
     user: string,
     _password: string,

--- a/packages/runtime-common/host-routing-validation.ts
+++ b/packages/runtime-common/host-routing-validation.ts
@@ -37,6 +37,8 @@ export const HOST_APP_QUERY_PARAMS = [
   'card',
   'cardPath',
   'debug',
+  // Deep link into profile settings, consumed once on arrival
+  'openProfileSettings',
 ];
 
 /**


### PR DESCRIPTION
Closes [CS-12461](https://linear.app/cardstack/issue/CS-12461/deep-link-into-profile-subscription-from-a-url)

Adds `?openProfileSettings=subscription`, which opens the settings modal and brings the subscription section into view. This will be linked to from the boxel-home pricing page. The param is added to `HOST_APP_QUERY_PARAMS` in `runtime-common/host-routing-validation.ts` so it survives routing.

### Where it's consumed, and why not the route

In `SubmodeLayout`'s constructor rather than the index route. A visitor arriving from a marketing page is logged out: the route's model hook returns early to render `<Auth />`, and by the time login completes that hook has already run. `SubmodeLayout` is only constructed once logged in, and `start({ refreshRoutes: true })` re-enters the route after login, so the component naturally exists at exactly the right moment. No login-specific branching.

Two details worth knowing:

- **The param is nulled on consumption**, the way `matrix/auth.gts` does for `sid`. The index route's model hook re-runs on *every* `schedulePersist()`, so a param left in the URL would reopen the modal the user just dismissed. It also keeps it out of a URL someone might share.
- **Both writes are deferred to `afterRender`.** Doing them in the constructor throws a backtracking-rerender assertion, since they land on state the render pass has already read. `auth.gts` avoids this by nulling from an action; `stack-item.gts` uses the same `scheduleOnce` pattern.

Subscription renders after the name and email fields in a modal with a fixed height, so opening it alone would land the visitor with their target below the fold — hence the scroll.

### Tests

Three acceptance tests in the `account popover` module:

- the deep link opens settings on the subscription section, and the param does not survive into the URL
- a dismissed modal stays dismissed across a state persist — the `schedulePersist()` hazard above
- the full logged-out path: the param outlives the login form, then after logging in the modal opens on the subscription section and the param is consumed

The logged-out test needs the mock matrix client to accept a password login, so `tests/helpers/mock-matrix/_client.ts` grew that support.

25/25 in the full operator-mode acceptance file, types and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
