### PR TITLE
Make the profile settings modal usable in a narrow dialog

### DIFF
--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -131,6 +131,11 @@ export default class ModalContainer extends Component<Signature> {
           'footer';
         grid-template-rows: auto 1fr auto;
         box-shadow: var(--boxel-deep-box-shadow);
+        /* container-type applies layout containment, which makes .dialog-box
+           the containing block for position: fixed descendants. A nested
+           modal rendered inside :content gets trapped by it (sized and
+           positioned against this box instead of the viewport), so nested
+           modals must portal out to the app root via in-element. */
         container-type: inline-size;
         container-name: dialog-box;
       }

--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -131,6 +131,8 @@ export default class ModalContainer extends Component<Signature> {
           'footer';
         grid-template-rows: auto 1fr auto;
         box-shadow: var(--boxel-deep-box-shadow);
+        container-type: inline-size;
+        container-name: dialog-box;
       }
 
       .dialog-box--with-sidebar {
@@ -138,7 +140,7 @@ export default class ModalContainer extends Component<Signature> {
           'sidebar-header header'
           'sidebar content'
           'sidebar footer';
-        grid-template-columns: 300px 1fr;
+        grid-template-columns: auto 1fr;
       }
 
       .dialog-box__sidebar-header {
@@ -149,8 +151,8 @@ export default class ModalContainer extends Component<Signature> {
 
       .dialog-box__sidebar {
         grid-area: sidebar;
+        width: 18.75rem;
         background-color: var(--boxel-100);
-
         border-bottom-left-radius: var(--boxel-border-radius);
       }
 
@@ -239,6 +241,21 @@ export default class ModalContainer extends Component<Signature> {
         border-bottom-left-radius: var(--boxel-border-radius);
         border-bottom-right-radius: var(--boxel-border-radius);
         display: flex;
+      }
+
+      @container dialog-box (width <= 48rem) {
+        .dialog-box--with-sidebar > .dialog-box__sidebar,
+        .dialog-box--with-sidebar > .dialog-box__sidebar-header {
+          display: none;
+        }
+        .dialog-box--with-sidebar > .dialog-box__content {
+          padding-inline: var(--boxel-sp);
+        }
+        .dialog-box--with-sidebar > .dialog-box__footer {
+          height: auto;
+          min-height: var(--stack-card-footer-height);
+          padding-inline: var(--boxel-sp-2xs);
+        }
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/profile/profile-email.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-email.gts
@@ -1,7 +1,7 @@
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import type Owner from '@ember/owner';
+import { getOwner, type default as Owner } from '@ember/owner';
 import { service } from '@ember/service';
 
 import Component from '@glimmer/component';
@@ -309,12 +309,18 @@ export default class ProfileEmail extends Component<Signature> {
       </FieldContainer>
     {{/if}}
     {{#if this.showPasswordModal}}
-      <PasswordModal
-        @confirmPassword={{this.confirmPasswordForEmailChange}}
-        @clearPasswordError={{this.clearPasswordError}}
-        @togglePasswordModal={{this.cancelEmailChange}}
-        @passwordError={{this.passwordError}}
-      />
+      {{! The surrounding settings modal's .dialog-box has
+          container-type: inline-size, whose layout containment captures
+          position: fixed descendants. Portal this nested modal to the app
+          root so it positions and overlays against the viewport. }}
+      {{#in-element this.appRootElement insertBefore=null}}
+        <PasswordModal
+          @confirmPassword={{this.confirmPasswordForEmailChange}}
+          @clearPasswordError={{this.clearPasswordError}}
+          @togglePasswordModal={{this.cancelEmailChange}}
+          @passwordError={{this.passwordError}}
+        />
+      {{/in-element}}
     {{/if}}
 
     <style scoped>
@@ -479,6 +485,14 @@ export default class ProfileEmail extends Component<Signature> {
 
   private get emailValidationState() {
     return this.emailError ? 'invalid' : 'initial';
+  }
+
+  private get appRootElement(): HTMLElement {
+    // @ts-expect-error rootElement exists on the owner at runtime
+    let root = getOwner(this)?.rootElement ?? document.body;
+    return typeof root === 'string'
+      ? (document.querySelector(root) as HTMLElement)
+      : root;
   }
 
   private get showPasswordModal() {

--- a/packages/host/app/components/operator-mode/profile/profile-email.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-email.gts
@@ -333,9 +333,6 @@ export default class ProfileEmail extends Component<Signature> {
       .profile-field :deep(.invalid) {
         box-shadow: none;
       }
-      .profile-field + .profile-field {
-        margin-top: var(--boxel-sp-xl);
-      }
       .warning-box {
         margin-top: var(--boxel-sp-xl);
         border-radius: var(--boxel-border-radius);
@@ -408,6 +405,13 @@ export default class ProfileEmail extends Component<Signature> {
       .pending-email {
         display: flex;
         justify-content: space-between;
+      }
+
+      @container dialog-box (width <= 48rem) {
+        .profile-field {
+          grid-template-columns: 1fr;
+          gap: var(--boxel-sp-xs);
+        }
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
@@ -64,7 +64,7 @@ export default class ProfileSettingsModal extends Component<Signature> {
         <ProfileInfo />
       </:sidebar>
       <:content>
-        <form {{on 'submit' this.onSubmit}}>
+        <form class='settings-form' {{on 'submit' this.onSubmit}}>
           {{#unless (bool this.submode)}}
             <FieldContainer @label='Name' @tag='label' class='profile-field'>
               <BoxelInput
@@ -88,7 +88,7 @@ export default class ProfileSettingsModal extends Component<Signature> {
             <FieldContainer
               @label='Current Password'
               @tag='label'
-              class='profile-field'
+              class='profile-field password-settings-field'
             >
               <BoxelInput
                 data-test-current-password-field
@@ -102,7 +102,7 @@ export default class ProfileSettingsModal extends Component<Signature> {
             <FieldContainer
               @label='New Password'
               @tag='label'
-              class='profile-field'
+              class='profile-field password-settings-field'
             >
               <BoxelInput
                 data-test-new-password-field
@@ -117,7 +117,7 @@ export default class ProfileSettingsModal extends Component<Signature> {
             <FieldContainer
               @label='Confirm New Password'
               @tag='label'
-              class='profile-field'
+              class='profile-field password-settings-field'
             >
               <BoxelInput
                 data-test-confirm-password-field
@@ -159,10 +159,11 @@ export default class ProfileSettingsModal extends Component<Signature> {
         <div class='buttons'>
           {{#unless (eq this.submode 'password')}}
             <BoxelButton
-              data-test-change-password-button
+              class='profile-settings-change-pw-button'
               @size='tall'
               @kind='secondary-light'
               {{on 'click' this.changePassword}}
+              data-test-change-password-button
             >
               Change Password
             </BoxelButton>
@@ -209,7 +210,7 @@ export default class ProfileSettingsModal extends Component<Signature> {
         display: flex;
       }
       :deep(.profile-settings) {
-        height: 70vh;
+        height: 80vh;
       }
       .error-message {
         color: var(--boxel-error-100);
@@ -218,9 +219,46 @@ export default class ProfileSettingsModal extends Component<Signature> {
       .profile-field :deep(.invalid) {
         box-shadow: none;
       }
-      .profile-field + .profile-field,
+
+      .settings-form,
       .profile-settings-subscription {
-        margin-top: var(--boxel-sp-xl);
+        --settings-modal-gap: var(--boxel-sp-xl);
+        display: grid;
+        gap: var(--settings-modal-gap);
+      }
+
+      @container dialog-box (width <= 48rem) {
+        .settings-form,
+        .profile-settings-subscription {
+          --settings-modal-gap: var(--boxel-sp);
+        }
+        .password-settings-field {
+          grid-template-columns: 1fr;
+          gap: var(--boxel-sp-xs);
+        }
+        .profile-settings-change-pw-button {
+          margin-right: auto;
+          padding-inline: var(--boxel-sp-xs);
+          font-size: 0.8175rem;
+        }
+        .buttons {
+          gap: var(--boxel-sp-xs);
+        }
+        .right-buttons > :not(:first-child) {
+          margin-left: 0;
+        }
+        .right-buttons {
+          display: flex;
+          gap: var(--boxel-sp-xs);
+        }
+      }
+
+      /* FieldContainer's 8rem label column is 40% of a phone-width modal,
+         shredding the values beside it. Inherited from the form. */
+      @container dialog-box (width <= 28rem) {
+        .settings-form {
+          --boxel-field-label-size: 5.5rem;
+        }
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
@@ -32,7 +32,7 @@ import ProfileSubscription from './profile-subscription';
 
 import type { IAuthData } from 'matrix-js-sdk';
 
-// Subscription sits below the fold in this 70vh modal
+// Subscription sits below the fold in this fixed-height modal
 const scrollIntoViewIfRequested = modifier(
   (element: HTMLElement, [requested]: [boolean]) => {
     if (requested) {
@@ -239,7 +239,7 @@ export default class ProfileSettingsModal extends Component<Signature> {
         .profile-settings-change-pw-button {
           margin-right: auto;
           padding-inline: var(--boxel-sp-xs);
-          font-size: 0.8175rem;
+          font-size: 0.8125rem;
         }
         .buttons {
           gap: var(--boxel-sp-xs);

--- a/packages/host/app/components/operator-mode/profile/profile-subscription.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-subscription.gts
@@ -32,8 +32,11 @@ export default class ProfileSubscription extends Component<Signature> {
 
   <template>
     <WithSubscriptionData as |subscriptionData|>
-      <FieldContainer @label='Membership Tier' class='profile-field'>
-        <div class='profile-subscription'>
+      <FieldContainer
+        class='profile-field membership-tier-field'
+        @label='Membership Tier'
+      >
+        <div class='profile-subscription membership-tier-content'>
           <div class='monthly-credit'>
             <div class='plan-name'>{{subscriptionData.plan}}</div>
             <div class='credit-info'>
@@ -43,6 +46,7 @@ export default class ProfileSubscription extends Component<Signature> {
           </div>
           {{#if this.billingService.subscriptionData.plan}}
             <BoxelButton
+              class='membership-tier-button'
               @kind='secondary-light'
               @size='extra-small'
               {{on
@@ -97,9 +101,6 @@ export default class ProfileSubscription extends Component<Signature> {
       .profile-field :deep(.invalid) {
         box-shadow: none;
       }
-      .profile-field + .profile-field {
-        margin-top: var(--boxel-sp-xl);
-      }
       .profile-subscription {
         display: flex;
         justify-content: space-between;
@@ -112,6 +113,7 @@ export default class ProfileSubscription extends Component<Signature> {
       .credit-info {
         display: flex;
         flex-direction: column;
+        justify-content: center;
         gap: var(--boxel-sp-xs);
         padding-left: var(--boxel-sp-sm);
         border-left: 5px solid #c6c6c6;
@@ -148,22 +150,51 @@ export default class ProfileSubscription extends Component<Signature> {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        border-bottom: 1px solid var(--boxel-300);
-        padding: var(--boxel-sp-xxs);
+        padding: var(--boxel-sp-2xs);
+      }
+      .payment-link:not(:last-child) {
+        border-bottom: 1px solid var(--boxel-200);
       }
       .payment-link > span {
         color: var(--boxel-dark);
         font: 600 var(--boxel-font-sm);
         display: flex;
         align-items: center;
-        gap: var(--boxel-sp-4xs);
+        gap: var(--boxel-sp-3xs);
 
-        --icon-color: var(--boxel-teal);
+        --icon-color: var(--boxel-highlight);
         --boxel-loading-indicator-size: var(--boxel-icon-xs);
       }
       :deep(.buy-more-credits .boxel-loading-indicator) {
         width: 100%;
         text-align: center;
+      }
+
+      @container dialog-box (width <= 48rem) {
+        .profile-field {
+          grid-template-columns: 1fr;
+          gap: var(--boxel-sp-xs);
+        }
+        .payment-links {
+          padding-left: 0;
+        }
+        .payment-link {
+          padding-inline: 0;
+        }
+        .membership-tier-field {
+          position: relative;
+        }
+        .membership-tier-button {
+          position: absolute;
+          right: 0;
+          top: var(--boxel-sp-2xs);
+        }
+        .membership-tier-content,
+        .additional-credit {
+          background-color: var(--boxel-100);
+          padding: var(--boxel-sp-xs);
+          border-radius: var(--boxel-border-radius);
+        }
       }
     </style>
   </template>


### PR DESCRIPTION
Before & After (previously unusable due to sidebar):

<img width="1035" height="758" alt="settings-modal" src="https://github.com/user-attachments/assets/7f65501f-059f-4379-a9b0-052c83561ee9" />
