### PR TITLE
Catch fire-and-forget rejections on the post-login path

### DIFF
--- a/packages/host/app/components/with-subscription-data.gts
+++ b/packages/host/app/components/with-subscription-data.gts
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import { formatDistanceToNow } from 'date-fns';
-import { task } from 'ember-concurrency';
+import { didCancel, task } from 'ember-concurrency';
 
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 import { cn, formatNumber } from '@cardstack/boxel-ui/helpers';
@@ -90,7 +90,12 @@ export default class WithSubscriptionData extends Component<WithSubscriptionData
     super(...args);
     // Uncaught, a failed token fetch escapes instead of leaving the
     // component in its empty state. billing-service catches its own load.
+    // Chaining opts into cancelation too — the modal closing mid-load is
+    // teardown, not a failure.
     this.loadSubscriptionData.perform().catch((e: unknown) => {
+      if (didCancel(e)) {
+        return;
+      }
       console.error('Failed to load subscription data', e);
     });
   }

--- a/packages/host/app/components/with-subscription-data.gts
+++ b/packages/host/app/components/with-subscription-data.gts
@@ -88,7 +88,11 @@ export default class WithSubscriptionData extends Component<WithSubscriptionData
 
   constructor(...args: [any, any]) {
     super(...args);
-    this.loadSubscriptionData.perform();
+    // Uncaught, a failed token fetch escapes instead of leaving the
+    // component in its empty state. billing-service catches its own load.
+    this.loadSubscriptionData.perform().catch((e: unknown) => {
+      console.error('Failed to load subscription data', e);
+    });
   }
 
   private get isLoading() {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1258,7 +1258,18 @@ export default class MatrixService extends Service {
         );
         window.location.href = indexController.authRedirect;
       } else if (refreshRoutes) {
-        await this.router.refresh();
+        // The index route's model hook redirects when the URL carries no
+        // operatorModeState, aborting the refresh that ran it. Expected.
+        try {
+          await this.router.refresh();
+        } catch (error: any) {
+          if (
+            error?.name !== 'TransitionAborted' &&
+            error?.code !== 'TRANSITION_ABORTED'
+          ) {
+            throw error;
+          }
+        }
       }
     } else if (isTesting()) {
       // start() did nothing because the client wasn't logged in at this point,


### PR DESCRIPTION
Closes [CS-12469](https://linear.app/cardstack/issue/CS-12469/unhandled-rejections-escape-on-the-post-login-path)

Two async calls on the login path are started and never awaited, so their rejections escape as uncaught errors rather than leaving the UI in a degraded state. Both affect a normal post-login arrival; neither is test-only.

### `matrix-service` — aborted route refresh

`start({ refreshRoutes: true })` does `await this.router.refresh()`. The index route's `model()` redirects whenever the URL carries no `operatorModeState` — every deep link, and most bare arrivals — and that redirect aborts the very refresh that invoked it. The awaited promise then rejects as `TransitionAborted` with nothing to catch it.

A newer transition winning is the expected outcome here, not a failure, so only that error is swallowed. The check matches the one `routes/render.ts` already uses, testing both `error.name` and `error.code` since the two forms come from different layers of the router.

### `with-subscription-data` — unawaited subscription load

The constructor performs `loadSubscriptionData` with no catch, so a failed token fetch (`realmServer.login()` returning nothing) rejects uncaught. `billing-service` already wraps its own session-start call in exactly this catch; the component was the odd one out. Caught, it falls back to the empty state it already renders.

### How these were found

Writing a logged-out arrival test for the subscription deep link (CS-12461). That test drives sign-out → deep link → log in, which nothing in the suite had done before, and both rejections surfaced immediately as QUnit global failures.

**Stacked below #5718** — that PR's post-login test only runs clean once these land, so it is based on this branch and should merge after it.

### Verification

Types and lint clean. Behaviour verified through #5718's acceptance test, which goes from two global failures to none with these applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
