### PR TITLE
Publishing action appears to have failed even though publish has succeeded

### DIFF
--- a/packages/host/tests/unit/prerendered-html-read-test.ts
+++ b/packages/host/tests/unit/prerendered-html-read-test.ts
@@ -13,6 +13,7 @@ import {
   type RealmResourceIdentifier,
 } from '@cardstack/runtime-common';
 import { CachingDefinitionLookup } from '@cardstack/runtime-common/definition-lookup';
+import { awaitPublishedHtmlReady } from '@cardstack/runtime-common/jobs/prerender-html';
 import { VirtualNetwork } from '@cardstack/runtime-common/virtual-network';
 
 import type SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
@@ -337,6 +338,33 @@ module('Unit | prerendered-html read path', function (hooks) {
       vanGogh.isolatedHtml,
       `<div class="isolated">Van Gogh</div>`,
       'other rows keep serving their prerendered_html',
+    );
+  });
+
+  test('published HTML readiness uses the per-row predicate under SQLite', async function (assert) {
+    assert.false(
+      await awaitPublishedHtmlReady(adapter, testRealmURL, {
+        timeoutMs: 100,
+        pollIntervalMs: 20,
+      }),
+      'the missing prerendered_html row holds readiness',
+    );
+
+    await adapter.execute(`DELETE FROM boxel_index WHERE url = $1`, {
+      bind: [`${testRealmURL}3.json`],
+    });
+    await adapter.execute(
+      `UPDATE realm_generations SET current_generation = 9 WHERE realm_url = $1`,
+      { bind: [testRealmURL] },
+    );
+    await adapter.execute(
+      `UPDATE prerendered_html SET is_deleted = TRUE WHERE url = $1`,
+      { bind: [`${testRealmURL}1.json`] },
+    );
+
+    assert.true(
+      await awaitPublishedHtmlReady(adapter, testRealmURL, { timeoutMs: 100 }),
+      'row-level generations are caught up regardless of the realm watermark or a current tombstone',
     );
   });
 

--- a/packages/realm-server/tests/await-realm-index-settled-test.ts
+++ b/packages/realm-server/tests/await-realm-index-settled-test.ts
@@ -6,7 +6,10 @@ import {
   awaitRealmIndexSettled,
   indexingConcurrencyGroup,
 } from '@cardstack/runtime-common/jobs/indexing';
-import { prerenderHtmlConcurrencyGroup } from '@cardstack/runtime-common/jobs/prerender-html';
+import {
+  awaitPublishedHtmlReady,
+  prerenderHtmlConcurrencyGroup,
+} from '@cardstack/runtime-common/jobs/prerender-html';
 import { setupDB } from './helpers/index.ts';
 
 const realmURL = 'http://localhost:4201/test/';
@@ -32,6 +35,60 @@ async function enqueueIndexJob(
     },
   )) as { id: number }[];
   return id;
+}
+
+// A live `boxel_index` row at `generation`, or a tombstone / index-errored one.
+// Sets only the columns the HTML gate reads.
+async function insertIndexRow(
+  dbAdapter: PgAdapter,
+  realm: string,
+  name: string,
+  generation: number,
+  opts?: { isDeleted?: boolean; hasError?: boolean },
+): Promise<void> {
+  await dbAdapter.execute(
+    `INSERT INTO boxel_index
+       (url, file_alias, realm_url, type, generation, is_deleted, has_error, error_doc)
+     VALUES ($1, $2, $3, 'instance', $4, $5, $6, $7)`,
+    {
+      bind: [
+        `${realm}${name}`,
+        `${realm}${name}`,
+        realm,
+        generation,
+        opts?.isDeleted ?? false,
+        opts?.hasError ?? false,
+        opts?.hasError ? JSON.stringify({ message: 'boom' }) : null,
+      ],
+    },
+  );
+}
+
+// The matching `prerendered_html` row, whose `generation` the gate compares
+// against the index row's own. A tombstone (`isDeleted`) carries no HTML,
+// matching what `tombstonePrerenderedHtmlEntries` seeds.
+async function insertHtmlRow(
+  dbAdapter: PgAdapter,
+  realm: string,
+  name: string,
+  generation: number,
+  opts?: { isDeleted?: boolean },
+): Promise<void> {
+  await dbAdapter.execute(
+    `INSERT INTO prerendered_html
+       (url, file_alias, realm_url, type, generation, is_deleted, isolated_html)
+     VALUES ($1, $2, $3, 'instance', $4, $5, $6)`,
+    {
+      bind: [
+        `${realm}${name}`,
+        `${realm}${name}`,
+        realm,
+        generation,
+        opts?.isDeleted ?? false,
+        opts?.isDeleted ? null : '<div>rendered</div>',
+      ],
+    },
+  );
 }
 
 module(basename(import.meta.filename), function (hooks) {
@@ -163,6 +220,145 @@ module(basename(import.meta.filename), function (hooks) {
 
       await waiting;
       assert.true(settled, 'the gate releases once the lane drains');
+    });
+  });
+
+  module('awaitPublishedHtmlReady', function () {
+    test('a realm with no index rows is caught up', async function (assert) {
+      assert.true(
+        await awaitPublishedHtmlReady(dbAdapter, realmURL, { timeoutMs: 200 }),
+        'a realm that has never been indexed has no HTML to await',
+      );
+    });
+
+    test('a live row whose HTML is missing holds the gate', async function (assert) {
+      await insertIndexRow(dbAdapter, realmURL, 'card-1', 3);
+      assert.false(
+        await awaitPublishedHtmlReady(dbAdapter, realmURL, {
+          timeoutMs: 200,
+          pollIntervalMs: 50,
+        }),
+        'an unrendered row is not ready',
+      );
+    });
+
+    test('a live row whose HTML is behind its own generation holds the gate', async function (assert) {
+      await insertIndexRow(dbAdapter, realmURL, 'card-1', 3);
+      await insertHtmlRow(dbAdapter, realmURL, 'card-1', 2);
+      assert.false(
+        await awaitPublishedHtmlReady(dbAdapter, realmURL, {
+          timeoutMs: 200,
+          pollIntervalMs: 50,
+        }),
+        'HTML from an earlier generation is stale for this row',
+      );
+    });
+
+    test('HTML at the row generation is caught up', async function (assert) {
+      await insertIndexRow(dbAdapter, realmURL, 'card-1', 3);
+      await insertHtmlRow(dbAdapter, realmURL, 'card-1', 3);
+      assert.true(
+        await awaitPublishedHtmlReady(dbAdapter, realmURL, { timeoutMs: 200 }),
+        'a row rendered at its own generation is ready',
+      );
+    });
+
+    // `realm_generations.current_generation` advances on every index batch,
+    // while the prerender channel writes rows only at the generation its
+    // spawning pass anticipated — so the watermark can sit above every rendered
+    // row on a realm that is fully rendered. Readiness must not read it.
+    test('a current_generation ahead of every rendered row does not hold the gate', async function (assert) {
+      await insertIndexRow(dbAdapter, realmURL, 'card-1', 3);
+      await insertHtmlRow(dbAdapter, realmURL, 'card-1', 3);
+      await dbAdapter.execute(
+        `INSERT INTO realm_generations (realm_url, current_generation, loader_epoch)
+           VALUES ($1, 9, 'epoch')`,
+        { bind: [realmURL] },
+      );
+      assert.true(
+        await awaitPublishedHtmlReady(dbAdapter, realmURL, { timeoutMs: 200 }),
+        'every live row is rendered, so the realm is ready regardless of the watermark',
+      );
+    });
+
+    // Readiness is a whole-realm property: any single unrendered row holds it.
+    test('one rendered row does not vouch for an unrendered sibling', async function (assert) {
+      await insertIndexRow(dbAdapter, realmURL, 'card-1', 3);
+      await insertHtmlRow(dbAdapter, realmURL, 'card-1', 3);
+      await insertIndexRow(dbAdapter, realmURL, 'card-2', 3);
+      assert.false(
+        await awaitPublishedHtmlReady(dbAdapter, realmURL, {
+          timeoutMs: 200,
+          pollIntervalMs: 50,
+        }),
+        'the unrendered sibling still holds the gate',
+      );
+    });
+
+    // Preserve the established readiness behavior: a render visit that leaves
+    // a tombstone at the row's generation has completed, even though it
+    // produced no markup. Readiness reports completion rather than turning a
+    // terminal render outcome into a permanently blocked publish.
+    test('a prerendered_html tombstone at the row generation is caught up', async function (assert) {
+      await insertIndexRow(dbAdapter, realmURL, 'card-1', 3);
+      await insertHtmlRow(dbAdapter, realmURL, 'card-1', 3, {
+        isDeleted: true,
+      });
+      assert.true(
+        await awaitPublishedHtmlReady(dbAdapter, realmURL, { timeoutMs: 200 }),
+        'a current-generation tombstone is a completed render outcome',
+      );
+    });
+
+    // Neither has servable HTML to wait on, matching the exclusions in
+    // findStalePrerenderedHtmlRows.
+    test('tombstones and index-errored rows do not hold the gate', async function (assert) {
+      await insertIndexRow(dbAdapter, realmURL, 'deleted', 3, {
+        isDeleted: true,
+      });
+      await insertIndexRow(dbAdapter, realmURL, 'broken', 3, {
+        hasError: true,
+      });
+      assert.true(
+        await awaitPublishedHtmlReady(dbAdapter, realmURL, { timeoutMs: 200 }),
+        'a deletion and an index error leave the HTML gate clear',
+      );
+    });
+
+    test('the gate is scoped to one realm', async function (assert) {
+      await insertIndexRow(dbAdapter, otherRealmURL, 'card-1', 3);
+      assert.true(
+        await awaitPublishedHtmlReady(dbAdapter, realmURL, { timeoutMs: 200 }),
+        "another realm's unrendered row does not hold this realm's gate",
+      );
+      assert.false(
+        await awaitPublishedHtmlReady(dbAdapter, otherRealmURL, {
+          timeoutMs: 200,
+          pollIntervalMs: 50,
+        }),
+        'that realm holds its own gate',
+      );
+    });
+
+    test('the gate releases when the render lands', async function (assert) {
+      await insertIndexRow(dbAdapter, realmURL, 'card-1', 3);
+
+      let ready: boolean | undefined;
+      let waiting = awaitPublishedHtmlReady(dbAdapter, realmURL, {
+        timeoutMs: 30_000,
+        pollIntervalMs: 100,
+      }).then((result) => {
+        ready = result;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      assert.strictEqual(ready, undefined, 'still waiting while unrendered');
+
+      await insertHtmlRow(dbAdapter, realmURL, 'card-1', 3);
+      await dbAdapter.execute(`NOTIFY jobs_finished`);
+
+      await waiting;
+      assert.true(ready, 'the gate releases once the HTML lands');
     });
   });
 });

--- a/packages/realm-server/tests/server-endpoints/publish-progress-test.ts
+++ b/packages/realm-server/tests/server-endpoints/publish-progress-test.ts
@@ -41,7 +41,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
         },
       });
 
-      // Each test owns a distinct realm URL so the jobs, generations and
+      // Each test owns a distinct realm URL so the jobs, index rows and
       // rendered rows it seeds can't be read by another test in this module.
       let realmCounter = 0;
       async function ownedRealm(): Promise<string> {
@@ -77,13 +77,21 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
         return req;
       }
 
-      async function seedGeneration(realmURL: string, generation: number) {
+      // A live, non-errored index row — the unit the caught-up fallback
+      // checks: each such row must have HTML at or beyond its own generation.
+      async function seedIndexRow(realmURL: string, generation: number) {
         await query(dbAdapter, [
-          `INSERT INTO realm_generations (realm_url, current_generation) VALUES (`,
+          `INSERT INTO boxel_index (url, file_alias, realm_url, type, generation, is_deleted, has_error) VALUES (`,
+          param(`${realmURL}card`),
+          `,`,
+          param(`${realmURL}card`),
+          `,`,
           param(realmURL),
           `,`,
+          param('instance'),
+          `,`,
           param(generation),
-          `)`,
+          `, false, false)`,
         ] as Expression);
       }
 
@@ -314,12 +322,12 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       });
 
       // The index pass enqueues its render fire-and-forget, so there is a
-      // window with an empty lane and no rendered HTML for the current
-      // generation. Reporting `done` there would tell a publish it had finished
+      // window with an empty lane and an indexed row that has no rendered HTML
+      // yet. Reporting `done` there would tell a publish it had finished
       // before the page it published exists.
-      test('reports the render phase when the current generation has no rendered html yet', async function (assert) {
+      test('reports the render phase when an indexed row has no rendered html yet', async function (assert) {
         let realmURL = await ownedRealm();
-        await seedGeneration(realmURL, 3);
+        await seedIndexRow(realmURL, 3);
 
         let response = await getProgress(realmURL, { as: ownerUserId });
 
@@ -332,7 +340,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
 
       test('reports done once the lanes are clear and the html has landed', async function (assert) {
         let realmURL = await ownedRealm();
-        await seedGeneration(realmURL, 3);
+        await seedIndexRow(realmURL, 3);
         await seedRenderedHtml(realmURL, 3);
 
         let response = await getProgress(realmURL, { as: ownerUserId });
@@ -349,7 +357,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       // settled realm from reporting a stale pass.
       test('ignores the progress rows of jobs that have already finished', async function (assert) {
         let realmURL = await ownedRealm();
-        await seedGeneration(realmURL, 3);
+        await seedIndexRow(realmURL, 3);
         await seedRenderedHtml(realmURL, 3);
         let finishedJob = await insertJob(dbAdapter, {
           job_type: 'from-scratch-index',

--- a/packages/runtime-common/jobs/prerender-html.ts
+++ b/packages/runtime-common/jobs/prerender-html.ts
@@ -66,31 +66,35 @@ export function prerenderHtmlConcurrencyGroup(realmURL: string): string {
   return `prerender-html:${realmURL}`;
 }
 
-// Await the prerender-html channel having caught up to a realm's current
-// index generation. The index pass spawns the prerender-html job
-// fire-and-forget and completes without it, so "indexed" does not imply
-// "viewable" — a freshly published realm can be reachable and searchable
-// while still serving a shell without card markup. Publishing awaits this so a
-// published realm reports ready only once its current generation has been
-// rendered.
+// Await the prerender-html channel having caught up to a realm's index. The
+// index pass spawns the prerender-html job fire-and-forget and completes
+// without it, so "indexed" does not imply "viewable" — a freshly published
+// realm can be reachable and searchable while still serving a shell without
+// card markup. Publishing awaits this so a published realm reports ready only
+// once its content has been rendered.
 //
-// Signal: `prerendered_html` carrying any row at >= the realm's current
-// generation. `batch.done()` swaps a generation's rendered rows into the
-// production table atomically, so a row at the current generation means that
-// generation's render batch has landed (a successful render leaves the
-// isolated HTML on those rows; a failed one leaves error rows — either way the
-// async render work for this publish is done, and a genuine render failure
-// surfaces downstream as missing markup rather than hanging readiness). Gating
-// on `generation` (not job status) sidesteps the fire-and-forget enqueue race
-// and never settles on a prior publish's stale (lower-generation) rows.
+// Signal: every live, non-errored `boxel_index` row has HTML at or beyond its
+// OWN generation — the per-row predicate the read path
+// (`index-query-engine`'s RENDER_ERROR_IS_CURRENT) and the catch-up sweep
+// (`findStalePrerenderedHtmlRows`) also use. A row the latest pass did not
+// revisit keeps its own generation, and its HTML at that generation is fresh
+// for it.
+//
+// A realm-wide watermark (`realm_generations.current_generation`) is the wrong
+// signal here and must not be reintroduced: an index batch advances it
+// unconditionally, a prerender batch never does, and the prerender job writes
+// rows only for the URLs it was handed, at the generation its spawning pass
+// anticipated. A pass that advances the watermark without a matching render
+// therefore leaves it unreachable on a realm that is in fact fully rendered.
+//
 // Resolves true when caught up, false on timeout.
 //
 // Woken by NOTIFY rather than tight-polling: pg-queue emits `NOTIFY
-// jobs_finished` when a job's finalize transaction commits, and the
-// prerender-html batch's swap is already durable by then, so re-checking on
-// that signal catches the current generation landing near-instantly. The
-// periodic poll is a safety net for a missed notification and for adapters
-// without pub/sub (SQLite has no LISTEN), so it stays coarse.
+// jobs_finished` when a job's finalize transaction commits, by which point the
+// prerender-html batch's swap is durable, so re-checking on that signal catches
+// the render landing near-instantly. The periodic poll is a safety net for a
+// missed notification and for adapters without pub/sub (SQLite has no LISTEN),
+// so it stays coarse.
 export async function awaitPublishedHtmlReady(
   dbAdapter: DBAdapter,
   realmURL: string,
@@ -98,18 +102,7 @@ export async function awaitPublishedHtmlReady(
 ): Promise<boolean> {
   let timeoutMs = opts?.timeoutMs ?? 60_000;
   let pollIntervalMs = opts?.pollIntervalMs ?? 1000;
-  // `const`, and read once: this wait is for the generation that was current
-  // when it began. A later pass bumping the generation must not move the target
-  // out from under a caller already waiting on an earlier one — so only the
-  // landed-HTML predicate re-runs below, never the generation read.
-  const currentGeneration = await currentRealmGeneration(dbAdapter, realmURL);
-  if (currentGeneration == null) {
-    // The realm has never been indexed — there is no generation to await.
-    return true;
-  }
-
-  let hasCaughtUp = () =>
-    prerenderedHtmlHasLanded(dbAdapter, realmURL, currentGeneration);
+  let hasCaughtUp = () => publishedHtmlHasCaughtUp(dbAdapter, realmURL);
 
   if (await hasCaughtUp()) {
     return true;
@@ -178,61 +171,40 @@ export async function awaitPublishedHtmlReady(
   }
 }
 
-// The realm's current index generation, or undefined when it has never been
-// indexed.
-async function currentRealmGeneration(
-  dbAdapter: DBAdapter,
-  realmURL: string,
-): Promise<number | undefined> {
-  let [row] = (await query(dbAdapter, [
-    'SELECT current_generation FROM realm_generations WHERE realm_url =',
-    param(realmURL),
-  ])) as { current_generation: number }[];
-  return row?.current_generation ?? undefined;
-}
-
-// Whether the prerender channel has produced HTML for `generation` or later.
-// `batch.done()` swaps a generation's rendered rows into the production table
-// atomically, so one row at or beyond the generation means that generation's
-// render batch has landed.
+// Whether every live, non-errored index row has HTML at or beyond its own
+// generation.
 //
-// This comparison is the whole definition of "the realm's HTML is live", and it
+// This predicate is the whole definition of "the realm's HTML is live", and it
 // has exactly one home on purpose: `awaitPublishedHtmlReady` gates a publish's
-// readiness on it and `publishedHtmlHasCaughtUp` reports progress against it,
-// so a change to the semantics here can't leave the two disagreeing about
+// readiness on it and the publish-progress endpoint reports progress against
+// it, so a change to the semantics here can't leave the two disagreeing about
 // whether a publish has finished.
-async function prerenderedHtmlHasLanded(
-  dbAdapter: DBAdapter,
-  realmURL: string,
-  generation: number,
-): Promise<boolean> {
-  let rows = await query(dbAdapter, [
-    'SELECT 1 FROM prerendered_html WHERE realm_url =',
-    param(realmURL),
-    'AND generation >=',
-    param(generation),
-    'LIMIT 1',
-  ]);
-  return rows.length > 0;
-}
-
-// A point-in-time read of the same signal `awaitPublishedHtmlReady` waits on:
-// is the realm's published HTML live for the generation that is current *now*?
-// Unlike the wait, this pins nothing — a caller sampling it repeatedly (the
-// publish-progress endpoint) wants the latest generation on every read, not the
-// one that was current when it started sampling.
 //
-// A realm with no generation has never been indexed and has no render to wait
-// on, which reads as caught up.
+// A failed render still writes an error row at its generation, so readiness
+// settles instead of hanging on content that will never render. Likewise, a
+// prerender tombstone at the row's generation is a completed render outcome,
+// matching the existing published-realm readiness behavior.
 export async function publishedHtmlHasCaughtUp(
   dbAdapter: DBAdapter,
   realmURL: string,
 ): Promise<boolean> {
-  let currentGeneration = await currentRealmGeneration(dbAdapter, realmURL);
-  if (currentGeneration == null) {
-    return true;
-  }
-  return prerenderedHtmlHasLanded(dbAdapter, realmURL, currentGeneration);
+  let rows = await query(dbAdapter, [
+    `SELECT 1
+       FROM boxel_index i
+       LEFT JOIN prerendered_html ph
+         ON ph.url = i.url AND ph.realm_url = i.realm_url AND ph.type = i.type
+      WHERE i.realm_url =`,
+    param(realmURL),
+    `  AND (i.is_deleted = false OR i.is_deleted IS NULL)
+        AND i.has_error = false
+        AND i.error_doc IS NULL
+        AND (ph.url IS NULL
+          OR ph.generation < i.generation)
+      LIMIT 1`,
+  ]);
+  // No row behind its own generation — every live row is rendered. A realm
+  // with no index rows at all (never indexed) reads as caught up.
+  return rows.length === 0;
 }
 
 // Publish a `prerender_html` job through the normal queue-publish path. The

--- a/packages/runtime-common/realm-operations.ts
+++ b/packages/runtime-common/realm-operations.ts
@@ -428,9 +428,23 @@ export const waitForReady: RealmOperation<WaitForReadyInput, void> = async (
         if (response.ok) {
           return;
         }
-        lastError = `HTTP ${response.status}`;
+        // `X-Boxel-Not-Ready` names the outstanding stage (index vs
+        // prerender-html); it's a header because pollers discard the body.
+        let stage = response.headers.get('X-Boxel-Not-Ready');
+        lastError = `HTTP ${response.status}${stage ? ` (not ready: ${stage})` : ''}`;
       } catch (error) {
+        // Node's fetch reports transport failures as a bare "fetch failed" and
+        // puts the real reason (DNS, TLS, ECONNRESET) on `cause`, so the timeout
+        // message needs both to be attributable.
         lastError = error instanceof Error ? error.message : String(error);
+        // Cast: `cause` predates this package's lib target. `!= null` keeps
+        // falsy-but-defined causes.
+        let cause = (error as { cause?: unknown })?.cause;
+        if (cause != null) {
+          lastError += ` (cause: ${
+            cause instanceof Error ? cause.message : String(cause)
+          })`;
+        }
       }
       let remaining = timeoutMs - (Date.now() - startedAt);
       if (remaining <= 0) {


### PR DESCRIPTION
The error:
<img width="866" height="636" alt="err-1" src="https://github.com/user-attachments/assets/7962bd5d-757f-47cb-8a3f-67c9099fc651" />

<img width="527" height="169" alt="err-2" src="https://github.com/user-attachments/assets/0956333e-d04f-421c-97cb-be3b58728044" />

A published realm could report `X-Boxel-Not-Ready: prerender-html` forever while serving fully rendered HTML: readiness gated on a realm-wide generation watermark that no write is obligated to satisfy, so post-publish polls ran to their full timeout and surfaced as an unattributable `fetch failed`.

### Changes:
- Check each live, non-errored index row against its own generation instead. Readiness now waits for every row to have matching HTML at or beyond that generation, while preserving the established handling of current-generation tombstones and render errors as completed outcomes.
- Improve waitForReady timeout diagnostics with the outstanding stage and transport cause, and add focused PostgreSQL and SQLite coverage for the per-row readiness cases.

Fixes CS-12435.

🤖 Generated with [Claude Code](https://claude.com/claude-code) & Codex
