### PR TITLE
host: Add multi-realm support to in-test index cache

### DIFF
--- a/packages/host/tests/acceptance/file-chooser-test.gts
+++ b/packages/host/tests/acceptance/file-chooser-test.gts
@@ -20,6 +20,7 @@ import { setupInteractSubmodeTests } from '../helpers/interact-submode-setup';
 
 module('Acceptance | file chooser tests', function (hooks) {
   setupInteractSubmodeTests(hooks, {
+    reuseIndexAcrossTests: 'fileChooser',
     setRealm() {},
   });
 
@@ -441,6 +442,7 @@ module('Acceptance | file chooser tests', function (hooks) {
 
 module('Acceptance | file chooser keyboard tests', function (hooks) {
   setupInteractSubmodeTests(hooks, {
+    reuseIndexAcrossTests: 'fileChooserKeyboard',
     setRealm() {},
   });
 
@@ -1010,6 +1012,7 @@ module('Acceptance | file chooser tests | upload size limit', function (hooks) {
   let FILE_SIZE_LIMIT = 512;
 
   setupInteractSubmodeTests(hooks, {
+    reuseIndexAcrossTests: 'fileChooserUploadSizeLimit',
     setRealm() {},
     fileSizeLimitBytes: FILE_SIZE_LIMIT,
   });

--- a/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
@@ -39,6 +39,7 @@ module(
     let { setRealmPermissions, setActiveRealms } = setupInteractSubmodeTests(
       hooks,
       {
+        reuseIndexAcrossTests: 'interactCreationAndPermissions',
         setRealm() {},
       },
     );

--- a/packages/host/tests/acceptance/interact-submode/index-changes-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/index-changes-test.gts
@@ -22,6 +22,7 @@ module('Acceptance | interact submode | index changes tests', function (hooks) {
   let realm: Realm;
 
   setupInteractSubmodeTests(hooks, {
+    reuseIndexAcrossTests: 'interactIndexChanges',
     setRealm(value) {
       realm = value;
     },

--- a/packages/host/tests/acceptance/interact-submode/multiple-stacks-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/multiple-stacks-test.gts
@@ -19,6 +19,7 @@ module(
   'Acceptance | interact submode | multiple stacks tests',
   function (hooks) {
     let { setActiveRealms } = setupInteractSubmodeTests(hooks, {
+      reuseIndexAcrossTests: 'interactMultipleStacks',
       setRealm() {},
     });
 

--- a/packages/host/tests/acceptance/interact-submode/no-stacks-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/no-stacks-test.gts
@@ -7,6 +7,7 @@ import { setupInteractSubmodeTests } from '../../helpers/interact-submode-setup'
 
 module('Acceptance | interact submode | no stacks tests', function (hooks) {
   setupInteractSubmodeTests(hooks, {
+    reuseIndexAcrossTests: 'interactNoStacks',
     setRealm() {},
   });
 

--- a/packages/host/tests/acceptance/interact-submode/search-sheet-persistence-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/search-sheet-persistence-test.gts
@@ -19,6 +19,7 @@ module(
   'Acceptance | interact submode | search sheet persistence tests',
   function (hooks) {
     setupInteractSubmodeTests(hooks, {
+      reuseIndexAcrossTests: 'interactSearchSheetPersistence',
       setRealm() {},
     });
 

--- a/packages/host/tests/acceptance/interact-submode/single-stack-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/single-stack-test.gts
@@ -29,6 +29,7 @@ module('Acceptance | interact submode | single stack tests', function (hooks) {
   let realm: Realm;
 
   setupInteractSubmodeTests(hooks, {
+    reuseIndexAcrossTests: 'interactSingleStack',
     setRealm(value) {
       realm = value;
     },

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -991,7 +991,8 @@ export function setupLocalIndexing(
     // indexes for itself exactly as it did before opting in. Calling it too
     // early is the failure that matters, which is why it belongs immediately
     // after the last realm rather than being inferred from a realm count kept
-    // somewhere else.
+    // somewhere else — and why building a realm after the capture throws (see
+    // setupTestRealm) instead of quietly serving that realm unindexed.
     captureIndexManually?: boolean;
   },
 ) {
@@ -1395,6 +1396,25 @@ async function setupTestRealm({
     definitionLookup = owner.lookup(
       'definition-lookup:main',
     ) as DefinitionLookup;
+  }
+
+  // A realm built in the same test that captured the snapshot cannot be in it —
+  // the capture already happened. Later tests would restore an index missing
+  // this realm and, because they also skip the boot index, serve it with
+  // nothing indexed at all. That reads as "these cards don't exist": a search
+  // returns nothing, an assertion that a card is absent passes, a list renders
+  // short. Nothing looks broken, and the first test still passes, because the
+  // live database did hold both. So fail here, on the first test, naming what
+  // to do about it. `restored` distinguishes the capturing test (false) from
+  // every later one (true, where realms are expected to come from the
+  // snapshot).
+  if (reusableIndex?.captured && !reusableIndex.restored) {
+    throw new Error(
+      `reuseIndexAcrossTests ('${reusableIndex.snapshotName}'): a realm is being built after this module's index snapshot was captured, so the snapshot cannot contain it. ` +
+        (reusableIndex.manual
+          ? 'captureReusableIndex() ran too early — move it after the last realm this module builds.'
+          : 'This module builds more than one realm per test: pass captureIndexManually and call captureReusableIndex() once, after the last realm.'),
+    );
   }
   await insertPermissions(dbAdapter, new URL(realmURL), permissions);
   let worker = new Worker({

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -1025,7 +1025,16 @@ export function setupLocalIndexing(
   hooks.beforeEach(async function () {
     let dbAdapter = await getDbAdapter();
     if (reusableIndex?.captured) {
-      // Replaces every table from the snapshot, so this subsumes reset().
+      // Subsumes reset(), which is a precondition rather than a property:
+      // importSnapshot DELETEs and refills every table it finds in the
+      // *snapshot*, so it covers reset()'s list only because the snapshot was
+      // taken from `main` with the schema unchanged since. A table in `main`
+      // but missing from the snapshot would never be cleared, and that leak
+      // reads as one test seeing another's rows, with nothing to attribute it
+      // to. The systematic exception is `sqlite_%` names, which the copy skips
+      // — harmless while nothing in config/schema is AUTOINCREMENT, since then
+      // `sqlite_sequence` doesn't exist; a migration adding one would leave
+      // restored tests inheriting the previous test's id counter.
       await dbAdapter.importSnapshot(reusableIndex.snapshotName);
       reusableIndex.restored = true;
     } else {

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -953,6 +953,11 @@ let reusableIndex:
       captured: boolean;
       restored: boolean;
       manual: boolean;
+      // The realms the snapshot actually contains, recorded when it was taken.
+      // `restored` says whether this test restored; only this says *what* it
+      // restored, which is what a realm appearing for the first time in a later
+      // test has to be checked against.
+      realmURLs: Set<string>;
     }
   | undefined;
 
@@ -1003,6 +1008,7 @@ export function setupLocalIndexing(
           captured: false,
           restored: false,
           manual: opts.captureIndexManually ?? false,
+          realmURLs: new Set<string>(),
         }
       : undefined;
   });
@@ -1086,6 +1092,13 @@ export function setupLocalIndexing(
   });
 }
 
+// Registry keys come from RealmPaths, which stores `ensureTrailingSlash(decodeURI(href))`.
+// Compare against that exact form so a realm isn't reported missing over a
+// trailing slash or an encoded character.
+function normalizeRealmKey(url: string): string {
+  return ensureTrailingSlash(url.includes('%') ? decodeURI(url) : url);
+}
+
 // Capture the reusable index now, for a module that opted in with
 // `captureIndexManually` because it builds several realms per test. Call it
 // once, from wherever the last realm is built — a setup helper that builds them
@@ -1104,6 +1117,9 @@ export async function captureReusableIndex() {
   let dbAdapter = await getDbAdapter();
   await dbAdapter.exportSnapshot(reusableIndex.snapshotName);
   reusableIndex.captured = true;
+  reusableIndex.realmURLs = new Set(
+    [...getTestRealmRegistry().keys()].map(normalizeRealmKey),
+  );
 }
 
 export function setupOnSave(hooks: NestedHooks) {
@@ -1407,23 +1423,35 @@ async function setupTestRealm({
     ) as DefinitionLookup;
   }
 
-  // A realm built in the same test that captured the snapshot cannot be in it —
-  // the capture already happened. Later tests would restore an index missing
-  // this realm and, because they also skip the boot index, serve it with
-  // nothing indexed at all. That reads as "these cards don't exist": a search
-  // returns nothing, an assertion that a card is absent passes, a list renders
-  // short. Nothing looks broken, and the first test still passes, because the
-  // live database did hold both. So fail here, on the first test, naming what
-  // to do about it. `restored` distinguishes the capturing test (false) from
-  // every later one (true, where realms are expected to come from the
-  // snapshot).
-  if (reusableIndex?.captured && !reusableIndex.restored) {
-    throw new Error(
-      `reuseIndexAcrossTests ('${reusableIndex.snapshotName}'): a realm is being built after this module's index snapshot was captured, so the snapshot cannot contain it. ` +
-        (reusableIndex.manual
-          ? 'captureReusableIndex() ran too early — move it after the last realm this module builds.'
-          : 'This module builds more than one realm per test: pass captureIndexManually and call captureReusableIndex() once, after the last realm.'),
-    );
+  // A realm the snapshot doesn't contain, in a module that reuses one, is the
+  // failure this whole mechanism has to avoid: the realm mounts with
+  // `skipBootIndex` and is served with nothing indexed, which reads as "these
+  // cards don't exist" — a search returns nothing, an assertion that a card is
+  // absent passes, a list renders short. Nothing looks broken. So fail loudly
+  // instead, as early as the mistake is detectable, and say what to do.
+  //
+  // Two ways in, and they need different advice. Building a realm in the test
+  // that captured (`restored === false`) means the capture came too early —
+  // that test's own later realms are missing from it. Building one in a test
+  // that restored means this realm was never in the snapshot at all, which is
+  // what `realmURLs` is for: `restored` says whether this test restored, only
+  // the set says what it restored.
+  if (reusableIndex?.captured) {
+    let context = `reuseIndexAcrossTests ('${reusableIndex.snapshotName}'): `;
+    if (!reusableIndex.restored) {
+      throw new Error(
+        `${context}a realm is being built after this module's index snapshot was captured, so the snapshot cannot contain it. ` +
+          (reusableIndex.manual
+            ? 'captureReusableIndex() ran too early — move it after the last realm this module builds.'
+            : 'This module builds more than one realm per test: pass captureIndexManually and call captureReusableIndex() once, after the last realm.'),
+      );
+    }
+    if (!reusableIndex.realmURLs.has(normalizeRealmKey(realmURL))) {
+      throw new Error(
+        `${context}'${realmURL}' is not one of the realms the snapshot was taken from (${[...reusableIndex.realmURLs].join(', ')}), so it would be served with an empty index. ` +
+          'A module that builds a realm only some of its tests need cannot reuse an index; build it in the shared setup, or drop the option for this module.',
+      );
+    }
   }
   await insertPermissions(dbAdapter, new URL(realmURL), permissions);
   let worker = new Worker({
@@ -1496,6 +1524,9 @@ async function setupTestRealm({
     // realm, since capturing here would omit the realms still to come.
     await dbAdapter.exportSnapshot(reusableIndex.snapshotName);
     reusableIndex.captured = true;
+    reusableIndex.realmURLs = new Set(
+      [...getTestRealmRegistry().keys()].map(normalizeRealmKey),
+    );
   }
   if (startMatrix) {
     await mockMatrixUtils.start();

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -948,7 +948,12 @@ class MockLocalIndexer extends Service {
 // this test starts from a snapshot, and `setupTestRealm`, which skips the
 // boot index when it does and captures the snapshot when it doesn't.
 let reusableIndex:
-  | { snapshotName: string; captured: boolean; restored: boolean }
+  | {
+      snapshotName: string;
+      captured: boolean;
+      restored: boolean;
+      manual: boolean;
+    }
   | undefined;
 
 export function setupLocalIndexing(
@@ -965,19 +970,29 @@ export function setupLocalIndexing(
     // identical pristine index: the snapshot is *restored* (a full table
     // replace), not carried over, so one test's writes cannot reach another.
     //
-    // Not usable yet by a module that builds more than one realm per test:
-    // the snapshot is captured after the first realm finishes indexing, so
-    // later realms' rows would be missing from it.
-    //
-    // Also not usable by a module whose tests are *about* indexing. A test
-    // whose index was restored runs against a realm started with
-    // `skipBootIndex`, so anything the boot index does beyond populating those
-    // tables — evicting a module from the loader, recording that it was flushed
-    // — has not happened. `Integration | Store` is the worked example: 71 of
-    // its 73 tests are indifferent, while two assert on exactly that
-    // module-rebuild bookkeeping and fail. Identical fixtures are necessary but
-    // not sufficient; the module also has to not care how its index got there.
+    // Not usable by a module whose tests are *about* indexing. A test whose
+    // index was restored runs against a realm started with `skipBootIndex`, so
+    // anything the boot index does beyond populating those tables — evicting a
+    // module from the loader, recording that it was flushed — has not happened.
+    // `Integration | Store` is the worked example: 71 of its 73 tests are
+    // indifferent, while two assert on exactly that module-rebuild bookkeeping
+    // and fail. Identical fixtures are necessary but not sufficient; the module
+    // also has to not care how its index came to exist.
     reuseIndexAcrossTests?: string;
+
+    // Set by a module (or its setup helper) that builds more than one realm
+    // per test. By default the snapshot is captured as soon as the first realm
+    // finishes indexing, which for such a module would omit every later
+    // realm's rows; this suppresses that and hands the timing to
+    // `captureReusableIndex`, which the caller invokes once its last realm is
+    // built.
+    //
+    // Forgetting that call is safe: nothing is ever captured, so every test
+    // indexes for itself exactly as it did before opting in. Calling it too
+    // early is the failure that matters, which is why it belongs immediately
+    // after the last realm rather than being inferred from a realm count kept
+    // somewhere else.
+    captureIndexManually?: boolean;
   },
 ) {
   hooks.before(function () {
@@ -986,6 +1001,7 @@ export function setupLocalIndexing(
           snapshotName: opts.reuseIndexAcrossTests,
           captured: false,
           restored: false,
+          manual: opts.captureIndexManually ?? false,
         }
       : undefined;
   });
@@ -1058,6 +1074,26 @@ export function setupLocalIndexing(
     });
     getTestRealmRegistry().clear();
   });
+}
+
+// Capture the reusable index now, for a module that opted in with
+// `captureIndexManually` because it builds several realms per test. Call it
+// once, from wherever the last realm is built — a setup helper that builds them
+// all is the right home, since the call then can't drift out of step with the
+// number of realms the way a count declared elsewhere would.
+//
+// Must be called before the test body runs, so that what later tests restore is
+// the fixtures as indexed and nothing a test went on to write. A no-op unless
+// the module opted in, so a shared helper can call it unconditionally, and a
+// no-op after the first test, since the snapshot it captured is what every
+// later test restores.
+export async function captureReusableIndex() {
+  if (!reusableIndex || reusableIndex.captured || !reusableIndex.manual) {
+    return;
+  }
+  let dbAdapter = await getDbAdapter();
+  await dbAdapter.exportSnapshot(reusableIndex.snapshotName);
+  reusableIndex.captured = true;
 }
 
 export function setupOnSave(hooks: NestedHooks) {
@@ -1420,11 +1456,15 @@ async function setupTestRealm({
   await adapter.ready;
   await worker.run();
   await realm.start();
-  if (reusableIndex && !reusableIndex.captured) {
+  if (reusableIndex && !reusableIndex.captured && !reusableIndex.manual) {
     // First test of a module that reuses its index: this start() just did the
     // indexing, so keep the result for the rest of the module. Captured before
     // the test body runs, so what later tests restore is the fixtures as
     // indexed and nothing a test went on to write.
+    //
+    // A module building several realms per test opts out of this timing with
+    // `captureIndexManually` and calls `captureReusableIndex` after its last
+    // realm, since capturing here would omit the realms still to come.
     await dbAdapter.exportSnapshot(reusableIndex.snapshotName);
     reusableIndex.captured = true;
   }

--- a/packages/host/tests/helpers/interact-submode-setup.gts
+++ b/packages/host/tests/helpers/interact-submode-setup.gts
@@ -8,6 +8,7 @@ import type { Realm } from '@cardstack/runtime-common/realm';
 
 import {
   SYSTEM_CARD_FIXTURE_CONTENTS,
+  captureReusableIndex,
   makeMinimalPng,
   setupAcceptanceTestRealm,
   setupAuthEndpoints,
@@ -27,14 +28,32 @@ export const personalRealmURL = `http://test-realm/personal/`;
 type InteractSubmodeSetupOptions = {
   setRealm: (realm: Realm) => void;
   fileSizeLimitBytes?: number;
+  // Index these four realms once for the module and restore that index before
+  // each subsequent test, instead of re-indexing all four per test. Pass a name
+  // unique to the module (matching /^[A-Za-z][A-Za-z0-9_]*$/) — the fixtures are
+  // identical across the modules sharing this helper, but a snapshot alias can
+  // only be exported once, so each module keeps its own.
+  //
+  // Omit it and the module indexes per test as before.
+  reuseIndexAcrossTests?: string;
 };
 
 export function setupInteractSubmodeTests(
   hooks: NestedHooks,
-  { setRealm, fileSizeLimitBytes }: InteractSubmodeSetupOptions,
+  {
+    setRealm,
+    fileSizeLimitBytes,
+    reuseIndexAcrossTests,
+  }: InteractSubmodeSetupOptions,
 ) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+  // This helper builds four realms, so the default capture point — as soon as
+  // the first one finishes indexing — would omit the other three. It captures
+  // explicitly below instead, once all four are built.
+  setupLocalIndexing(hooks, {
+    reuseIndexAcrossTests,
+    captureIndexManually: true,
+  });
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
@@ -543,6 +562,10 @@ export function setupInteractSubmodeTests(
         }),
       },
     });
+
+    // All four realms are built and indexed, and the test body hasn't run yet,
+    // so this is the moment the module's reusable index has to be taken.
+    await captureReusableIndex();
 
     setRealm(realm);
   });


### PR DESCRIPTION
This is an extension of #5722, as some modules start more than one realm.