### PR TITLE
Polish AI Assistant panel and workspace chooser dropdown styling

### DIFF
--- a/packages/boxel-ui/src/components/dropdown/index.gts
+++ b/packages/boxel-ui/src/components/dropdown/index.gts
@@ -1,8 +1,6 @@
-import { registerDestructor } from '@ember/destroyable';
 import { concat, fn, hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
-import type Owner from '@ember/owner';
 import Component from '@glimmer/component';
 import BasicDropdown from 'ember-basic-dropdown/components/basic-dropdown';
 import type { Dropdown } from 'ember-basic-dropdown/types';
@@ -41,7 +39,6 @@ interface Signature {
     matchTriggerWidth?: boolean;
     onClose?: () => void;
     registerAPI?: (publicAPI: Dropdown) => void;
-    variant?: 'primary' | 'secondary' | 'default';
   };
   Blocks: {
     content: [{ close: () => void }];
@@ -62,13 +59,7 @@ interface Signature {
 
 // Needs to be class, BasicDropdown doesn't work with const
 class BoxelDropdown extends Component<Signature> {
-  private themeObserver?: MutationObserver | null = null;
   private dropdownId = guidFor(this);
-
-  constructor(owner: Owner, args: Signature['Args']) {
-    super(owner, args);
-    registerDestructor(this, () => this.stopObservingTheme());
-  }
 
   get dropdownEl(): HTMLElement | null {
     return document.getElementById(this.dropdownId);
@@ -124,24 +115,9 @@ class BoxelDropdown extends Component<Signature> {
 
     const hasThemeVariables = hasBackground || hasForeground || parentHasTheme;
 
-    const variant = this.args.variant || 'default';
-    const variantColors = {
-      default: {
-        bg: 'var(--background, var(--boxel-light))',
-        fg: 'var(--foreground, var(--boxel-dark))',
-      },
-      primary: {
-        bg: 'var(--primary, var(--boxel-600))',
-        fg: 'var(--primary-foreground, var(--boxel-light))',
-      },
-      secondary: {
-        bg: 'var(--secondary, var(--boxel-400))',
-        fg: 'var(--secondary-foreground, var(--boxel-dark))',
-      },
-    };
-
     if (hasThemeVariables) {
-      const { bg, fg } = variantColors[variant];
+      const bg = 'var(--background, var(--boxel-light))';
+      const fg = 'var(--foreground, var(--boxel-dark))';
       const themeVars = {
         '--theme-highlight': `color-mix(in oklch, ${bg} 92%, ${fg})`,
         '--theme-highlight-hover': `color-mix(in oklch, ${bg} 88%, ${fg})`,
@@ -159,29 +135,16 @@ class BoxelDropdown extends Component<Signature> {
     }
   }
 
-  private startObservingTheme() {
+  // One-shot copy of the trigger's computed theme onto the shared wormhole.
+  // Every open re-syncs before the content renders, so a theme that changes
+  // while the dropdown is open corrects itself on the next open — no
+  // mutation observation needed.
+  private syncTheme() {
     if (!this.dropdownEl) {
       return;
     }
-
     this.syncCustomProps();
     this.detectAndSetThemeColors();
-
-    this.stopObservingTheme();
-    this.themeObserver = new MutationObserver(() => {
-      this.syncCustomProps();
-      this.detectAndSetThemeColors();
-    });
-    this.themeObserver.observe(this.dropdownEl, {
-      attributes: true,
-      attributeFilter: ['style', 'class'],
-      subtree: false,
-    });
-  }
-
-  private stopObservingTheme() {
-    this.themeObserver?.disconnect();
-    this.themeObserver = null;
   }
 
   @action registerAPI(publicAPI: DropdownAPI | null) {
@@ -197,11 +160,10 @@ class BoxelDropdown extends Component<Signature> {
   }
 
   @action onOpen() {
-    this.startObservingTheme();
+    this.syncTheme();
   }
 
   @action onClose() {
-    this.stopObservingTheme();
     this.args.onClose?.();
   }
 
@@ -236,11 +198,7 @@ class BoxelDropdown extends Component<Signature> {
       <dd.Content
         @onMouseLeave={{fn this.onMouseLeave dd}}
         data-test-boxel-dropdown-content
-        class={{cn
-          'boxel-dropdown__content'
-          @contentClass
-          (if @variant (concat 'variant-' @variant) 'variant-default')
-        }}
+        class={{cn 'boxel-dropdown__content' @contentClass}}
         {{focusTrap
           isActive=dd.isOpen
           focusTrapOptions=(hash
@@ -273,8 +231,8 @@ class BoxelDropdown extends Component<Signature> {
             --boxel-dropdown-text-color,
             var(--foreground, var(--boxel-dark))
           );
-          /* Only the variants below override this; the fallback keeps the
-             hovered menu item from resolving an undefined var. */
+          /* The fallback keeps the hovered menu item from resolving an
+             undefined var. */
           --dropdown-selected-text-color: var(
             --boxel-dropdown-selected-text-color,
             var(--dropdown-text-color)
@@ -294,25 +252,25 @@ class BoxelDropdown extends Component<Signature> {
           border: 1px solid var(--dropdown-border-color);
           color: var(--dropdown-text-color);
           border-radius: var(--boxel-dropdown-content-border-radius);
-          box-shadow: 0 5px 15px 0 rgb(0 0 0 / 25%);
+          box-shadow: var(
+            --boxel-dropdown-box-shadow,
+            0 5px 15px 0 rgb(0 0 0 / 25%)
+          );
         }
 
         /* Menu styling cater for dropdown */
-        .boxel-dropdown__content :deep(.boxel-menu:not(.themeless)) {
-          --boxel-menu-color: var(--dropdown-background-color) !important;
-          --boxel-menu-text-color: var(--dropdown-text-color) !important;
-          --boxel-menu-hover-color: var(--dropdown-hover-color) !important;
-          --boxel-menu-current-color: var(--dropdown-hover-color) !important;
-          --boxel-menu-selected-font-color: var(
-            --dropdown-text-color
-          ) !important;
+        .boxel-dropdown__content :deep(.boxel-menu) {
+          --boxel-menu-color: var(--dropdown-background-color);
+          --boxel-menu-text-color: var(--dropdown-text-color);
+          --boxel-menu-current-color: var(--dropdown-hover-color);
+          --boxel-menu-selected-font-color: var(--dropdown-text-color);
         }
 
         /* Dangerous items keep their own destructive hover color, and
            header items keep their own inert header colors. */
         .boxel-dropdown__content
           :deep(
-            .boxel-menu:not(.themeless)
+            .boxel-menu
               .boxel-menu__item:not(
                 .boxel-menu__item--disabled,
                 .boxel-menu__item--dangerous,
@@ -322,58 +280,8 @@ class BoxelDropdown extends Component<Signature> {
           color: var(--dropdown-selected-text-color);
         }
 
-        .boxel-dropdown__content
-          :deep(.boxel-menu:not(.themeless) .boxel-menu__separator) {
-          border-bottom-color: var(--dropdown-border-color) !important;
-        }
-
-        .boxel-dropdown__content[class*='variant-'] {
-          --dropdown-highlight-color: var(
-            --boxel-dropdown-highlight-color,
-            var(--theme-highlight, var(--boxel-highlight))
-          );
-          --dropdown-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--theme-hover, var(--boxel-light-100))
-          );
-        }
-
-        .boxel-dropdown__content.variant-primary {
-          --dropdown-highlight-color: var(
-            --boxel-dropdown-highlight-color,
-            var(--primary, var(--boxel-600))
-          );
-          --dropdown-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--theme-hover, var(--boxel-500))
-          );
-          --dropdown-selected-text-color: var(
-            --primary-foreground,
-            var(--foreground, var(--boxel-light))
-          );
-          --dropdown-focus-border-color: var(
-            --primary,
-            var(--boxel-outline-color)
-          );
-        }
-
-        .boxel-dropdown__content.variant-secondary {
-          --dropdown-highlight-color: var(
-            --boxel-dropdown-highlight-color,
-            var(--secondary, var(--boxel-400))
-          );
-          --dropdown-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--theme-hover, var(--boxel-light-100))
-          );
-          --dropdown-selected-text-color: var(
-            --secondary-foreground,
-            var(--foreground, var(--boxel-dark))
-          );
-          --dropdown-focus-border-color: var(
-            --secondary,
-            var(--boxel-outline-color)
-          );
+        .boxel-dropdown__content :deep(.boxel-menu .boxel-menu__separator) {
+          border-bottom-color: var(--dropdown-border-color);
         }
 
         .ember-basic-dropdown-content--below.gap-above {

--- a/packages/boxel-ui/src/components/dropdown/usage.gts
+++ b/packages/boxel-ui/src/components/dropdown/usage.gts
@@ -11,10 +11,7 @@ import BoxelMenu from '../menu/index.gts';
 import BoxelDropdown from './index.gts';
 
 export default class BoxelDropdownUsage extends Component {
-  dropdownVariants = ['default', 'primary', 'secondary'];
-
   @tracked shouldDropdownAutoClose = false;
-  @tracked variant: undefined | 'primary' | 'secondary' | 'default' = undefined;
 
   @action log(string: string): void {
     console.log(string);
@@ -34,10 +31,7 @@ export default class BoxelDropdownUsage extends Component {
         open.
       </:description>
       <:example>
-        <BoxelDropdown
-          @autoClose={{this.shouldDropdownAutoClose}}
-          @variant={{this.variant}}
-        >
+        <BoxelDropdown @autoClose={{this.shouldDropdownAutoClose}}>
           <:trigger as |bindings|>
             <BoxelButton {{bindings}}>
               Trigger
@@ -84,14 +78,6 @@ export default class BoxelDropdownUsage extends Component {
           @description='CSS Class to apply to the dropdown content div'
           @hideControls={{true}}
         />
-        <Args.String
-          @name='variant'
-          @optional={{true}}
-          @description='Theme-based variant for consistent styling'
-          @options={{this.dropdownVariants}}
-          @onInput={{fn (mut this.variant)}}
-          @value={{this.variant}}
-        />
         <Args.Bool
           @name='matchTriggerWidth'
           @description='Whether to match the width of the trigger'
@@ -121,6 +107,23 @@ export default class BoxelDropdownUsage extends Component {
           @description='Content to show on dropdown. The provided block is rendered when trigger is triggered. Yields close action to close the dropdown'
         />
       </:api>
+      <:cssVars as |Css|>
+        <Css.Basic
+          @name='--boxel-dropdown-background-color'
+          @type='background-color'
+        />
+        <Css.Basic @name='--boxel-dropdown-text-color' @type='color' />
+        <Css.Basic @name='--boxel-dropdown-border-color' @type='color' />
+        <Css.Basic
+          @name='--boxel-dropdown-box-shadow'
+          @type='box-shadow'
+          @description='(css shorthand property)'
+        />
+        <Css.Basic
+          @name='--boxel-dropdown-content-border-radius'
+          @type='border-radius'
+        />
+      </:cssVars>
     </FreestyleUsage>
   </template>
 }

--- a/packages/boxel-ui/src/components/input/index.gts
+++ b/packages/boxel-ui/src/components/input/index.gts
@@ -292,7 +292,7 @@ export default class BoxelInput extends Component<Signature> {
             var(--border, var(--boxel-form-control-border-color));
           border-radius: var(--boxel-form-control-border-radius);
           box-shadow: var(--boxel-form-control-box-shadow);
-          outline: 1px solid transparent;
+          outline: var(--boxel-input-outline, 1px solid transparent);
           transition:
             var(--boxel-transition-properties),
             outline-color var(--boxel-transition);

--- a/packages/boxel-ui/src/components/input/usage.gts
+++ b/packages/boxel-ui/src/components/input/usage.gts
@@ -223,6 +223,11 @@ export default class InputUsage extends Component {
           @description='Used to set the min-height of the field'
         />
         <Css.Basic
+          @name='--boxel-input-outline'
+          @type='outline'
+          @description='Outline of the field (defaults to 1px solid transparent; the focused field sets its own outline color)'
+        />
+        <Css.Basic
           @name='--boxel-input-search-color'
           @type='color'
           @description='Search input text color'

--- a/packages/boxel-ui/src/components/menu/index.gts
+++ b/packages/boxel-ui/src/components/menu/index.gts
@@ -8,6 +8,7 @@ import cn from '../../helpers/cn.ts';
 import compact from '../../helpers/compact.ts';
 import type { MenuDivider } from '../../helpers/menu-divider.ts';
 import type { MenuAction, MenuItem } from '../../helpers/menu-item.ts';
+import { eq } from '../../helpers/truth-helpers.ts';
 import CheckMark from '../../icons/check-mark.gts';
 import LoadingIndicator from '../loading-indicator/index.gts';
 
@@ -35,6 +36,7 @@ interface Signature {
   Args: {
     class?: string;
     closeMenu?: () => void;
+    isRounded?: boolean;
     itemClass?: string;
     items: Array<MenuItem | MenuDivider>;
     loading?: boolean;
@@ -50,7 +52,15 @@ export default class Menu extends Component<Signature> {
   }
 
   <template>
-    <ul role='menu' class={{cn 'boxel-menu' @class}} ...attributes>
+    <ul
+      role='menu'
+      class={{cn
+        'boxel-menu'
+        @class
+        boxel-menu--rounded=(if (eq @isRounded false) false true)
+      }}
+      ...attributes
+    >
       {{#if @loading}}
         <li role='none' class='boxel-menu__item' data-test-boxel-menu-loading>
           <div class='boxel-menu__item__content'>
@@ -136,60 +146,78 @@ export default class Menu extends Component<Signature> {
     <style scoped>
       @layer boxelComponentL1 {
         .boxel-menu {
-          --boxel-menu-border-radius: var(--boxel-border-radius);
-          --boxel-menu-color: var(--boxel-light);
-          --boxel-menu-text-color: var(--boxel-dark);
-          --boxel-menu-current-color: var(--boxel-light-100);
-          --boxel-menu-selected-color: var(--boxel-highlight);
-          --boxel-menu-disabled-color: var(--boxel-highlight);
-          --boxel-menu-font: 500 var(--boxel-font-sm);
-          --boxel-menu-item-gap: var(--boxel-sp-xxs);
-          --boxel-menu-item-content-padding: var(--boxel-sp-xs) var(--boxel-sp);
+          --_menu-background: var(--boxel-menu-color, var(--background));
+          --_menu-foreground: var(--boxel-menu-text-color, var(--foreground));
+          --_menu-hover-background: var(
+            --boxel-menu-current-color,
+            var(--boxel-50)
+          );
+          --_menu-selected-background: var(
+            --boxel-menu-selected-color,
+            var(--primary)
+          );
+          --_menu-selected-foreground: var(
+            --boxel-menu-selected-font-color,
+            var(--primary-foreground)
+          );
+          --_menu-selected-hover-foreground: var(
+            --boxel-menu-selected-hover-font-color
+          );
+          --_menu-font: var(--boxel-menu-font, 500 var(--boxel-font-sm));
+          --_menu-radius: var(--boxel-menu-radius, var(--radius));
+          --_menu-item-gap: var(--boxel-menu-item-gap, var(--boxel-sp-2xs));
+          --_menu-item-padding: var(
+            --boxel-menu-item-content-padding,
+            var(--boxel-sp-xs) var(--boxel-sp)
+          );
+          --_menu-item-radius: var(--boxel-menu-item-border-radius);
+
           list-style-type: none;
           margin: 0;
           padding: 0;
-          color: var(--boxel-menu-text-color, inherit);
-          background-color: var(--boxel-menu-color);
-          border-radius: var(--boxel-menu-border-radius);
+          color: var(--_menu-foreground);
+          background-color: var(--_menu-background);
+        }
+        .boxel-menu--rounded {
+          border-radius: var(--_menu-radius);
         }
 
         .boxel-menu__item {
-          font: var(--boxel-menu-font);
+          font: var(--_menu-font);
           font-family: inherit;
           letter-spacing: var(--boxel-lsp-sm);
+          border-radius: var(--_menu-item-radius);
         }
 
         .boxel-menu__item--checked {
-          background-color: var(--boxel-menu-selected-background-color);
-          color: var(--boxel-menu-selected-font-color);
+          background-color: var(--_menu-selected-background);
+          color: var(--_menu-selected-foreground);
         }
 
         .boxel-menu__item--checked:not(.boxel-menu__item--disabled):hover {
-          color: var(--boxel-menu-selected-hover-font-color);
+          color: var(--_menu-selected-hover-foreground);
         }
 
         .boxel-menu__item:not(.boxel-menu__item--disabled):hover {
-          background-color: var(--boxel-menu-current-color);
+          background-color: var(--_menu-hover-background);
           cursor: pointer;
         }
 
-        .boxel-menu__item:first-child:hover {
+        .boxel-menu--rounded > .boxel-menu__item:first-child:hover {
           border-top-left-radius: inherit;
           border-top-right-radius: inherit;
         }
-
-        .boxel-menu__item:last-child:hover {
+        .boxel-menu--rounded > .boxel-menu__item:last-child:hover {
           border-bottom-left-radius: inherit;
           border-bottom-right-radius: inherit;
         }
-
-        .boxel-menu__item:only-child:hover {
+        .boxel-menu--rounded > .boxel-menu__item:only-child:hover {
           border-radius: inherit;
         }
 
         .boxel-menu__item > .boxel-menu__item__content {
           width: 100%;
-          padding: var(--boxel-menu-item-content-padding);
+          padding: var(--_menu-item-padding);
           display: flex;
           justify-content: space-between;
           align-items: center;
@@ -210,17 +238,17 @@ export default class Menu extends Component<Signature> {
         }
 
         .boxel-menu__item__content:focus-visible {
-          outline: var(--boxel-outline);
+          outline: 1px solid var(--ring);
         }
 
         .boxel-menu__item--dangerous {
           --icon-color: currentColor;
-          color: var(--destructive, var(--boxel-danger));
+          color: var(--destructive);
           fill: currentColor;
         }
         .boxel-menu__item--dangerous:not(:disabled):hover {
           background-color: color-mix(in oklab, currentColor 10%, transparent);
-          color: var(--destructive, var(--boxel-danger-hover));
+          color: var(--destructive);
         }
 
         .boxel-menu__item--disabled,
@@ -234,15 +262,15 @@ export default class Menu extends Component<Signature> {
            select chip). */
         .boxel-menu__item--header,
         .boxel-menu__item--header.boxel-menu__item:hover {
-          background-color: var(--boxel-teal);
-          color: var(--boxel-dark);
+          background-color: var(--primary);
+          color: var(--primary-foreground);
           cursor: default;
         }
-        .boxel-menu__item--header:first-child {
+        .boxel-menu--rounded > .boxel-menu__item--header:first-child {
           border-top-left-radius: inherit;
           border-top-right-radius: inherit;
         }
-        .boxel-menu__item--header:last-child {
+        .boxel-menu--rounded > .boxel-menu__item--header:last-child {
           border-bottom-left-radius: inherit;
           border-bottom-right-radius: inherit;
         }
@@ -258,14 +286,14 @@ export default class Menu extends Component<Signature> {
           margin: 0;
           border: 0;
           height: 0;
-          border-bottom: 1px solid var(--boxel-purple-300);
+          border-bottom: 1px solid var(--boxel-400);
         }
 
         .menu-item {
           width: 100%;
           display: flex;
           align-items: center;
-          gap: var(--boxel-menu-item-gap);
+          gap: var(--_menu-item-gap);
           text-transform: capitalize;
         }
         .menu-item__icon-url {
@@ -279,7 +307,7 @@ export default class Menu extends Component<Signature> {
         }
 
         .check-icon {
-          --icon-color: var(--boxel-highlight);
+          --icon-color: var(--primary);
           visibility: collapse;
           display: contents;
         }

--- a/packages/boxel-ui/src/components/menu/usage.gts
+++ b/packages/boxel-ui/src/components/menu/usage.gts
@@ -12,6 +12,7 @@ import BoxelMenu from './index.gts';
 
 export default class MenuUsage extends Component {
   @tracked isLoading = false;
+  @tracked isRounded = true;
   @tracked menuItems: any[] = [];
 
   @action log(message: string): void {
@@ -60,6 +61,7 @@ export default class MenuUsage extends Component {
             )
           }}
           @loading={{this.isLoading}}
+          @isRounded={{this.isRounded}}
         />
       </:example>
       <:api as |Args|>
@@ -81,7 +83,60 @@ export default class MenuUsage extends Component {
           @onInput={{fn (mut this.isLoading)}}
           @value={{this.isLoading}}
         />
+        <Args.Bool
+          @name='isRounded'
+          @optional={{true}}
+          @description='Rounds the menu and its first/last items (via --boxel-menu-radius). Pass false when the menu fills a container that handles its own rounding.'
+          @onInput={{fn (mut this.isRounded)}}
+          @value={{this.isRounded}}
+          @defaultValue={{true}}
+        />
       </:api>
+      <:cssVars as |Css|>
+        <Css.Basic @name='--boxel-menu-color' @type='background-color' />
+        <Css.Basic @name='--boxel-menu-text-color' @type='color' />
+        <Css.Basic
+          @name='--boxel-menu-current-color'
+          @type='background-color'
+          @description='hovered item'
+        />
+        <Css.Basic
+          @name='--boxel-menu-selected-color'
+          @type='background-color'
+          @description='selected (checked) item'
+        />
+        <Css.Basic
+          @name='--boxel-menu-selected-font-color'
+          @type='color'
+          @description='selected (checked) item'
+        />
+        <Css.Basic
+          @name='--boxel-menu-selected-hover-font-color'
+          @type='color'
+          @description='selected (checked) item on hover'
+        />
+        <Css.Basic
+          @name='--boxel-menu-font'
+          @type='font'
+          @description='(css shorthand property)'
+        />
+        <Css.Basic
+          @name='--boxel-menu-radius'
+          @type='border-radius'
+          @description='applies when @isRounded is true'
+        />
+        <Css.Basic
+          @name='--boxel-menu-item-border-radius'
+          @type='border-radius'
+          @description='per-item border-radius'
+        />
+        <Css.Basic
+          @name='--boxel-menu-item-gap'
+          @type='gap'
+          @description='between an item’s icon and text'
+        />
+        <Css.Basic @name='--boxel-menu-item-content-padding' @type='padding' />
+      </:cssVars>
     </FreestyleUsage>
     <FreestyleUsage @name='Menu (Fetch Use Case)'>
       <:example>

--- a/packages/boxel-ui/src/components/select/index.gts
+++ b/packages/boxel-ui/src/components/select/index.gts
@@ -1,13 +1,10 @@
 import Check from '@cardstack/boxel-icons/check';
 import { eq } from '@cardstack/boxel-ui/helpers';
-import { registerDestructor } from '@ember/destroyable';
-import { concat } from '@ember/helper';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { get } from '@ember/object';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
-import type Owner from '@ember/owner';
 import Component from '@glimmer/component';
 import type { ComponentLike } from '@glint/template';
 import PowerSelect, {
@@ -88,7 +85,6 @@ export interface BoxelSelectArgs<ItemT> extends Omit<
   ) => void;
   options: ItemT[];
   selected?: ItemT | Promise<ItemT | undefined> | null;
-  variant?: 'primary' | 'secondary' | 'muted' | 'destructive' | 'default';
 }
 
 interface Signature<ItemT = any> {
@@ -102,13 +98,7 @@ interface Signature<ItemT = any> {
 export default class BoxelSelect<ItemT = any> extends Component<
   Signature<ItemT>
 > {
-  private themeObserver?: MutationObserver | null = null;
   private selectId = `boxel-select-${guidFor(this)}`;
-
-  constructor(owner: Owner, args: Signature<ItemT>['Args']) {
-    super(owner, args);
-    registerDestructor(this, () => this.stopObservingTheme());
-  }
 
   get selectEl(): HTMLElement | null {
     return document.getElementById(this.selectId);
@@ -154,6 +144,8 @@ export default class BoxelSelect<ItemT = any> extends Component<
       '--boxel-dropdown-focus-border-color',
       '--boxel-dropdown-highlight-color',
       '--boxel-dropdown-highlight-hover-color',
+      '--boxel-dropdown-selected-highlighted-color',
+      '--boxel-dropdown-selected-hover-color',
       '--boxel-dropdown-hover-color',
       '--boxel-form-control-border-radius',
     ];
@@ -170,52 +162,45 @@ export default class BoxelSelect<ItemT = any> extends Component<
     });
   }
 
-  private startObservingTheme() {
-    if (!this.selectEl) {
+  // One-shot copy of the trigger's computed theme onto the shared wormhole.
+  // Every open re-syncs before the content's first paint, so a theme that
+  // changes while a dropdown is open corrects itself on the next open —
+  // no mutation observation needed. Skipped for renderInPlace, where the
+  // dropdown inherits the theme naturally through CSS.
+  private syncTheme() {
+    if (!this.selectEl || this.args.renderInPlace) {
       return;
     }
-
-    // Don't set up theme observation when renderInPlace is true
-    // as the dropdown will inherit styles naturally through CSS
-    if (this.args.renderInPlace) {
-      return;
-    }
-
     this.syncCustomProps();
     this.detectAndSetThemeColors();
-
-    this.stopObservingTheme();
-    this.themeObserver = new MutationObserver(() => {
-      this.syncCustomProps();
-      this.detectAndSetThemeColors();
-    });
-    this.themeObserver.observe(this.selectEl, {
-      attributes: true,
-      attributeFilter: ['style', 'class'],
-      subtree: false,
-    });
-  }
-
-  private stopObservingTheme() {
-    this.themeObserver?.disconnect();
-    this.themeObserver = null;
   }
 
   @action
-  onOpen() {
-    // Only start theme observation if not rendering in place
-    if (!this.args.renderInPlace) {
-      this.startObservingTheme();
-    }
-  }
-
-  @action
-  onClose(
-    select: Parameters<NonNullable<Signature<ItemT>['Args']['onClose']>>[0],
+  onOpen(
+    select: Parameters<NonNullable<Signature<ItemT>['Args']['onOpen']>>[0],
     event?: Event,
   ) {
-    this.stopObservingTheme();
-    return this.args.onClose?.(select, event);
+    if (this.args.onOpen?.(select, event as Event) === false) {
+      return false;
+    }
+    // Sync theme vars onto the shared wormhole now, before the dropdown
+    // content renders, so its first paint already carries the trigger's
+    // theme. The focus handler alone is not enough: opens that don't move
+    // focus (keyboard reopen, an already-focused trigger) never refire it.
+    this.syncTheme();
+    return true;
+  }
+
+  @action
+  onFocus(
+    select: Parameters<NonNullable<Signature<ItemT>['Args']['onFocus']>>[0],
+    event: FocusEvent,
+  ) {
+    // Fallback for focus without an open transition (e.g. tabbing to the
+    // trigger of an already-open select), and re-syncs after another
+    // dropdown's sync overwrote the shared wormhole vars.
+    this.syncTheme();
+    this.args.onFocus?.(select, event);
   }
 
   // null↔undefined translation for the no-selection value (see
@@ -255,32 +240,9 @@ export default class BoxelSelect<ItemT = any> extends Component<
 
     const hasThemeVariables = hasBackground || hasForeground || parentHasTheme;
 
-    const variant = this.args.variant || 'default';
-    const variantColors = {
-      default: {
-        bg: 'var(--background, var(--boxel-light))',
-        fg: 'var(--foreground, var(--boxel-dark))',
-      },
-      primary: {
-        bg: 'var(--primary, var(--boxel-600))',
-        fg: 'var(--primary-foreground, var(--boxel-dark))',
-      },
-      secondary: {
-        bg: 'var(--secondary, var(--boxel-400))',
-        fg: 'var(--secondary-foreground, var(--boxel-dark))',
-      },
-      muted: {
-        bg: 'var(--muted, var(--boxel-200))',
-        fg: 'var(--muted-foreground, var(--boxel-dark))',
-      },
-      destructive: {
-        bg: 'var(--destructive, var(--boxel-danger))',
-        fg: 'var(--destructive-foreground, var(--boxel-light))',
-      },
-    };
-
     if (hasThemeVariables) {
-      const { bg, fg } = variantColors[variant];
+      const bg = 'var(--background, var(--boxel-light))';
+      const fg = 'var(--foreground, var(--boxel-dark))';
       const themeVars = {
         '--theme-highlight': `color-mix(in oklch, ${bg} 92%, ${fg})`,
         '--theme-highlight-hover': `color-mix(in oklch, ${bg} 88%, ${fg})`,
@@ -302,10 +264,7 @@ export default class BoxelSelect<ItemT = any> extends Component<
     {{! template-lint-disable no-autofocus-attribute }}
     <PowerSelect
       id={{this.selectId}}
-      class={{cn
-        'boxel-select'
-        (if @variant (concat 'variant-' @variant) 'variant-default')
-      }}
+      class='boxel-select'
       @options={{@options}}
       @searchField={{@searchField}}
       @selected={{this.selectedForPowerSelect}}
@@ -313,16 +272,13 @@ export default class BoxelSelect<ItemT = any> extends Component<
       @placeholder={{@placeholder}}
       @onChange={{this.handleChange}}
       @onBlur={{@onBlur}}
-      @onClose={{this.onClose}}
+      @onClose={{@onClose}}
       @renderInPlace={{@renderInPlace}}
       @verticalPosition={{@verticalPosition}}
-      @dropdownClass={{cn
-        'boxel-select__dropdown'
-        @dropdownClass
-        (if @variant (concat 'variant-' @variant) 'variant-default')
-      }}
+      @dropdownClass={{cn 'boxel-select__dropdown' @dropdownClass}}
       @loadingMessage={{@loadingMessage}}
-      @onFocus={{this.onOpen}}
+      @onOpen={{this.onOpen}}
+      @onFocus={{this.onFocus}}
       @ariaLabel={{@ariaLabel}}
       @ariaLabelledBy={{@ariaLabelledBy}}
       @ariaDescribedBy={{@ariaDescribedBy}}
@@ -336,9 +292,7 @@ export default class BoxelSelect<ItemT = any> extends Component<
         @triggerComponent
         (toTriggerComponent
           (component
-            BoxelSelectDefaultTrigger
-            invertIcon=(eq @verticalPosition 'above')
-            variant=@variant
+            BoxelSelectDefaultTrigger invertIcon=(eq @verticalPosition 'above')
           )
         )
       }}
@@ -381,9 +335,10 @@ export default class BoxelSelect<ItemT = any> extends Component<
           --boxel-select-placeholder-color,
           var(--muted-foreground, var(--boxel-450))
         );
-        --select-focus-border-color: var(
+        /* "--boxel-select-focus-border-color" refers to the hover color, NOT focus color */
+        --select-hover-border-color: var(
           --boxel-select-focus-border-color,
-          var(--primary, var(--boxel-dark))
+          currentColor
         );
 
         position: relative;
@@ -405,112 +360,17 @@ export default class BoxelSelect<ItemT = any> extends Component<
 
       .boxel-select:not([aria-disabled='true']):hover {
         cursor: pointer;
-        border-color: var(--select-focus-border-color);
+        border-color: var(--select-hover-border-color);
       }
 
       .boxel-select:focus-visible {
-        outline: 2px solid var(--ring, var(--boxel-highlight-hover));
+        outline: 2px solid var(--ring);
       }
 
       .boxel-select :deep(.boxel-trigger) {
         padding: var(
           --boxel-select-trigger-padding,
           var(--boxel-sp-xs) calc(var(--boxel-sp-xxxs) + var(--boxel-sp-xxs))
-        );
-      }
-
-      .variant-default {
-        --select-background-color: var(
-          --boxel-select-background-color,
-          var(--background, var(--boxel-light))
-        );
-        --select-border-color: var(
-          --boxel-select-border-color,
-          var(--border, var(--boxel-border-color))
-        );
-        --select-text-color: var(
-          --boxel-select-text-color,
-          var(--foreground, var(--boxel-dark))
-        );
-        --select-focus-border-color: var(
-          --boxel-select-focus-border-color,
-          var(--primary, var(--boxel-dark))
-        );
-      }
-
-      .variant-primary {
-        --select-background-color: var(
-          --boxel-select-background-color,
-          var(--primary, var(--boxel-600))
-        );
-        --select-border-color: var(
-          --boxel-select-border-color,
-          var(--primary, var(--boxel-600))
-        );
-        --select-text-color: var(
-          --boxel-select-text-color,
-          var(--primary-foreground, var(--boxel-light))
-        );
-        --select-focus-border-color: var(
-          --boxel-select-focus-border-color,
-          var(--primary, var(--boxel-600))
-        );
-      }
-
-      .variant-secondary {
-        --select-background-color: var(
-          --boxel-select-background-color,
-          var(--secondary, var(--boxel-400))
-        );
-        --select-border-color: var(
-          --boxel-select-border-color,
-          var(--secondary, var(--boxel-400))
-        );
-        --select-text-color: var(
-          --boxel-select-text-color,
-          var(--secondary-foreground, var(--boxel-dark))
-        );
-        --select-focus-border-color: var(
-          --boxel-select-focus-border-color,
-          var(--secondary, var(--boxel-400))
-        );
-      }
-
-      .variant-muted {
-        --select-background-color: var(
-          --boxel-select-background-color,
-          var(--muted, var(--boxel-200))
-        );
-        --select-border-color: var(
-          --boxel-select-border-color,
-          var(--muted, var(--boxel-200))
-        );
-        --select-text-color: var(
-          --boxel-select-text-color,
-          var(--muted-foreground, var(--boxel-dark))
-        );
-        --select-focus-border-color: var(
-          --boxel-select-focus-border-color,
-          var(--muted, var(--boxel-200))
-        );
-      }
-
-      .variant-destructive {
-        --select-background-color: var(
-          --boxel-select-background-color,
-          var(--destructive, var(--boxel-600))
-        );
-        --select-border-color: var(
-          --boxel-select-border-color,
-          var(--destructive, var(--boxel-600))
-        );
-        --select-text-color: var(
-          --boxel-select-text-color,
-          var(--destructive-foreground, var(--boxel-light))
-        );
-        --select-focus-border-color: var(
-          --boxel-select-focus-border-color,
-          var(--destructive, var(--boxel-danger))
         );
       }
 
@@ -544,8 +404,11 @@ export default class BoxelSelect<ItemT = any> extends Component<
             var(--theme-highlight, var(--boxel-highlight))
           );
           --dropdown-highlight-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--theme-highlight-hover, var(--boxel-highlight))
+            --boxel-dropdown-highlight-hover-color,
+            var(
+              --boxel-dropdown-hover-color,
+              var(--theme-highlight-hover, var(--boxel-highlight-hover))
+            )
           );
           --dropdown-hover-color: var(
             --boxel-dropdown-hover-color,
@@ -558,6 +421,25 @@ export default class BoxelSelect<ItemT = any> extends Component<
           --dropdown-selected-text-color: var(
             --boxel-dropdown-selected-text-color,
             var(--foreground, var(--boxel-dark))
+          );
+          --dropdown-selected-highlighted-color: var(
+            --boxel-dropdown-selected-highlighted-color,
+            color-mix(
+              in oklab,
+              var(--dropdown-highlight-color) 95%,
+              var(--dropdown-selected-text-color)
+            )
+          );
+          --dropdown-selected-hover-color: var(
+            --boxel-dropdown-selected-hover-color,
+            var(
+              --boxel-dropdown-highlight-hover-color,
+              color-mix(
+                in oklab,
+                var(--dropdown-highlight-color) 95%,
+                var(--dropdown-selected-text-color)
+              )
+            )
           );
 
           box-shadow: var(--boxel-box-shadow);
@@ -659,137 +541,29 @@ export default class BoxelSelect<ItemT = any> extends Component<
           color: var(--dropdown-text-color);
           text-align: center;
         }
+      }
 
-        /* All variants use the same reusable theme variables */
-        .boxel-select__dropdown[class*='variant-'] {
-          --dropdown-highlight-color: var(
-            --boxel-dropdown-highlight-color,
-            var(--theme-highlight, var(--boxel-highlight))
-          );
-          --dropdown-highlight-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--theme-highlight-hover, var(--boxel-highlight-hover))
-          );
-          --dropdown-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--theme-hover, var(--boxel-light-100))
-          );
-        }
+      :global(#select-dropdown-overlay) {
+        position: absolute;
+        z-index: 10000;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+      }
 
-        .boxel-select__dropdown.variant-primary {
-          --dropdown-highlight-color: var(
-            --boxel-dropdown-highlight-color,
-            var(--primary, var(--boxel-600))
-          );
-          --dropdown-highlight-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--primary, var(--boxel-600))
-          );
-          --dropdown-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--theme-hover, var(--boxel-500))
-          );
-          --dropdown-selected-text-color: var(
-            --primary-foreground,
-            var(--foreground, var(--boxel-light))
-          );
-          --dropdown-focus-border-color: var(
-            --primary,
-            var(--boxel-outline-color)
-          );
-        }
-
-        .boxel-select__dropdown.variant-secondary {
-          --dropdown-highlight-color: var(
-            --boxel-dropdown-highlight-color,
-            var(--secondary, var(--boxel-400))
-          );
-          --dropdown-highlight-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--secondary, var(--boxel-400))
-          );
-          --dropdown-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--theme-hover, var(--boxel-light-100))
-          );
-          --dropdown-selected-text-color: var(
-            --secondary-foreground,
-            var(--foreground, var(--boxel-dark))
-          );
-          --dropdown-focus-border-color: var(
-            --secondary,
-            var(--boxel-outline-color)
-          );
-        }
-
-        .boxel-select__dropdown.variant-muted {
-          --dropdown-highlight-color: var(
-            --boxel-dropdown-highlight-color,
-            var(--muted, var(--boxel-200))
-          );
-          --dropdown-highlight-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--muted, var(--boxel-200))
-          );
-          --dropdown-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--theme-hover, var(--boxel-light-100))
-          );
-          --dropdown-selected-text-color: var(
-            --muted-foreground,
-            var(--foreground, var(--boxel-dark))
-          );
-          --dropdown-focus-border-color: var(
-            --muted,
-            var(--boxel-outline-color)
-          );
-        }
-
-        .boxel-select__dropdown.variant-destructive {
-          --dropdown-highlight-color: var(
-            --boxel-dropdown-highlight-color,
-            var(--destructive, var(--boxel-danger))
-          );
-          --dropdown-highlight-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--destructive, var(--boxel-danger))
-          );
-          --dropdown-hover-color: var(
-            --boxel-dropdown-hover-color,
-            var(--theme-hover, var(--boxel-light-100))
-          );
-          --dropdown-selected-text-color: var(
-            --destructive-foreground,
-            var(--foreground, var(--boxel-dark))
-          );
-          --dropdown-focus-border-color: var(
-            --destructive,
-            var(--boxel-outline-color)
-          );
-        }
-
-        :global(#select-dropdown-overlay) {
-          position: absolute;
-          z-index: 10000;
-          top: 0;
-          left: 0;
-          width: 100%;
-          height: 100%;
-          pointer-events: none;
-        }
-
-        /* Accessibility: Status announcement region */
-        .ember-power-select-visually-hidden {
-          position: absolute !important;
-          width: 1px !important;
-          height: 1px !important;
-          padding: 0 !important;
-          margin: -1px !important;
-          overflow: hidden !important;
-          clip: rect(0, 0, 0, 0) !important;
-          white-space: nowrap !important;
-          border: 0 !important;
-        }
+      /* Accessibility: Status announcement region */
+      .ember-power-select-visually-hidden {
+        position: absolute !important;
+        width: 1px !important;
+        height: 1px !important;
+        padding: 0 !important;
+        margin: -1px !important;
+        overflow: hidden !important;
+        clip: rect(0, 0, 0, 0) !important;
+        white-space: nowrap !important;
+        border: 0 !important;
       }
     </style>
   </template>
@@ -840,16 +614,14 @@ export class BoxelSelectOptions extends PowerSelectOptions {
     >
       {{#each @options as |option index|}}
         <li
+          {{! `ember-power-select-option` stays: the addon's stylesheet and its
+          `selectChoose` test helper both key off it. The selected/highlighted
+          state is ours to name — the addon never reads those modifiers. }}
           class={{cn
             'boxel-select-option-item'
             'ember-power-select-option'
-            (if
-              (eq option @select.selected) 'ember-power-select-option--selected'
-            )
-            (if
-              (eq option @select.highlighted)
-              'ember-power-select-option--highlighted'
-            )
+            is-selected=(eq option @select.selected)
+            is-highlighted=(eq option @select.highlighted)
           }}
           id='{{@select.uniqueId}}-{{@groupIndex}}{{index}}'
           data-option-index='{{@groupIndex}}{{index}}'
@@ -925,23 +697,24 @@ export class BoxelSelectOptions extends PowerSelectOptions {
         cursor: pointer;
       }
 
-      .boxel-select-option-item.ember-power-select-option--highlighted {
+      .boxel-select-option-item.is-highlighted {
         background-color: var(--dropdown-hover-color);
         color: var(--dropdown-selected-text-color);
       }
 
-      .boxel-select-option-item.ember-power-select-option--selected {
+      .boxel-select-option-item.is-selected {
         background-color: var(--dropdown-highlight-color);
         color: var(--dropdown-selected-text-color);
       }
 
-      .boxel-select-option-item.ember-power-select-option--selected.ember-power-select-option--highlighted,
-      .boxel-select-option-item.ember-power-select-option--selected:hover {
-        background-color: color-mix(
-          in oklab,
-          var(--dropdown-highlight-color) 95%,
-          var(--dropdown-selected-text-color)
-        );
+      .boxel-select-option-item.is-selected.is-highlighted {
+        background-color: var(--dropdown-selected-highlighted-color);
+      }
+
+      /* Pointer state is declared after the keyboard state so it wins when both
+         apply — hovering an option also highlights it. */
+      .boxel-select-option-item.is-selected:hover {
+        background-color: var(--dropdown-selected-hover-color);
       }
 
       .boxel-select-option-item[aria-disabled='true'] {

--- a/packages/boxel-ui/src/components/select/usage.gts
+++ b/packages/boxel-ui/src/components/select/usage.gts
@@ -26,15 +26,6 @@ interface SortOption {
 }
 
 export default class BoxelSelectUsage extends Component {
-  selectVariants = ['default', 'primary', 'secondary', 'muted', 'destructive'];
-  selectVariantDefault:
-    | undefined
-    | 'primary'
-    | 'secondary'
-    | 'muted'
-    | 'destructive'
-    | 'default' = undefined;
-
   @tracked items = [
     { name: 'United States' },
     { name: 'Spain' },
@@ -58,14 +49,6 @@ export default class BoxelSelectUsage extends Component {
   @tracked selectedItem2: SortOption | null = this.items2[0] ?? null;
   @tracked placeholder = 'Select Item';
   @tracked verticalPosition = 'auto' as const;
-  @tracked variant:
-    | undefined
-    | 'primary'
-    | 'secondary'
-    | 'muted'
-    | 'destructive'
-    | 'default' = undefined;
-
   @tracked renderInPlace = false;
   @tracked disabled = false;
   @tracked searchField = '';
@@ -97,6 +80,10 @@ export default class BoxelSelectUsage extends Component {
   @cssVariable({ cssClassName: 'header-freestyle-container' })
   declare boxelDropdownHighlightHoverColor: CSSVariableInfo;
   @cssVariable({ cssClassName: 'header-freestyle-container' })
+  declare boxelDropdownSelectedHighlightedColor: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'header-freestyle-container' })
+  declare boxelDropdownSelectedHoverColor: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'header-freestyle-container' })
   declare boxelDropdownHoverColor: CSSVariableInfo;
   @cssVariable({ cssClassName: 'header-freestyle-container' })
   declare boxelDropdownFocusBorderColor: CSSVariableInfo;
@@ -125,6 +112,8 @@ export default class BoxelSelectUsage extends Component {
         boxel-dropdown-text-color=this.boxelDropdownTextColor.value
         boxel-dropdown-highlight-color=this.boxelDropdownHighlightColor.value
         boxel-dropdown-highlight-hover-color=this.boxelDropdownHighlightHoverColor.value
+        boxel-dropdown-selected-highlighted-color=this.boxelDropdownSelectedHighlightedColor.value
+        boxel-dropdown-selected-hover-color=this.boxelDropdownSelectedHoverColor.value
         boxel-dropdown-hover-color=this.boxelDropdownHoverColor.value
         boxel-dropdown-focus-border-color=this.boxelDropdownFocusBorderColor.value
       }}
@@ -132,8 +121,7 @@ export default class BoxelSelectUsage extends Component {
       <FreestyleUsage @name='Select'>
         <:description>
           Select components allow users to choose from a list of options. They
-          support theme variants and customizable styling with search
-          functionality.
+          support customizable styling with search functionality.
         </:description>
         <:example>
           <BoxelSelect
@@ -146,7 +134,6 @@ export default class BoxelSelectUsage extends Component {
             @verticalPosition={{this.verticalPosition}}
             @renderInPlace={{this.renderInPlace}}
             @disabled={{this.disabled}}
-            @variant={{this.variant}}
             @dropdownClass='boxel-select-usage'
             @matchTriggerWidth={{this.matchTriggerWidth}}
             aria-label={{this.placeholder}}
@@ -182,15 +169,6 @@ export default class BoxelSelectUsage extends Component {
             @description='Placeholder for trigger component'
             @value={{this.placeholder}}
             @onInput={{fn (mut this.placeholder)}}
-          />
-          <Args.String
-            @name='variant'
-            @optional={{true}}
-            @description='Theme-based variant for consistent styling'
-            @defaultValue={{this.selectVariantDefault}}
-            @options={{this.selectVariants}}
-            @onInput={{fn (mut this.variant)}}
-            @value={{this.variant}}
           />
           <Args.String
             @name='verticalPosition'
@@ -313,6 +291,20 @@ export default class BoxelSelectUsage extends Component {
             @onInput={{this.boxelDropdownHighlightHoverColor.update}}
           />
           <Css.Basic
+            @name='boxel-dropdown-selected-highlighted-color'
+            @type='color'
+            @description='Background of the selected option while it is keyboard-highlighted'
+            @value={{this.boxelDropdownSelectedHighlightedColor.value}}
+            @onInput={{this.boxelDropdownSelectedHighlightedColor.update}}
+          />
+          <Css.Basic
+            @name='boxel-dropdown-selected-hover-color'
+            @type='color'
+            @description='Background of the selected option on pointer hover'
+            @value={{this.boxelDropdownSelectedHoverColor.value}}
+            @onInput={{this.boxelDropdownSelectedHoverColor.update}}
+          />
+          <Css.Basic
             @name='boxel-dropdown-hover-color'
             @type='color'
             @description='Global override for dropdown hover color (highest priority)'
@@ -343,7 +335,6 @@ export default class BoxelSelectUsage extends Component {
             @verticalPosition={{this.verticalPosition}}
             @renderInPlace={{this.renderInPlace}}
             @disabled={{this.disabled}}
-            @variant={{this.variant}}
             @dropdownClass='boxel-select-usage'
             @matchTriggerWidth={{this.matchTriggerWidth}}
             aria-label={{this.placeholder}}

--- a/packages/boxel-ui/src/styles/variables.css
+++ b/packages/boxel-ui/src/styles/variables.css
@@ -132,7 +132,7 @@
 
   /* outline */
   --boxel-outline-width: 2px;
-  --boxel-outline-color: var(--boxel-blue);
+  --boxel-outline-color: var(--primary, var(--boxel-highlight));
   --boxel-outline-style: solid;
   --boxel-outline: var(--boxel-outline-width) var(--boxel-outline-style)
     var(--boxel-outline-color);
@@ -167,6 +167,7 @@
   --boxel-450: #919191;
   --boxel-500: #5a586a;
   --boxel-550: #525252;
+  --boxel-575: #4f4b57;
   --boxel-600: #413e4e;
   --boxel-650: #3b394b;
   --boxel-700: #272330;
@@ -194,10 +195,14 @@
   /* Primary colors */
   --boxel-light: #fff;
   --boxel-dark: #000;
+  --boxel-light-10: rgba(255, 255, 255, 0.1);
+  --boxel-light-25: rgba(255, 255, 255, 0.25);
   --boxel-light-35: rgba(255, 255, 255, 0.35);
+  --boxel-light-50: rgba(255, 255, 255, 0.5);
   --boxel-light-60: rgba(255, 255, 255, 0.6);
   --boxel-light-70: rgba(255, 255, 255, 0.7);
   --boxel-dark-10: rgba(0, 0, 0, 0.1);
+  --boxel-dark-30: rgba(0, 0, 0, 0.3);
   --boxel-dark-40: rgba(0, 0, 0, 0.4);
   --boxel-dark-50: rgba(0, 0, 0, 0.5);
   --boxel-dark-80: rgba(0, 0, 0, 0.8);
@@ -227,7 +232,7 @@
   --boxel-purple-900: var(--boxel-700); /* Card Wallet bg */
 
   /* Boxel neutrals */
-  --boxel-light-100: #f4f4f4;
+  --boxel-light-100: var(--boxel-50); /* formerly: #f4f4f4; */
   --boxel-light-200: var(--boxel-200); /* formerly: #f0f0f0; */
   --boxel-light-300: var(--boxel-200); /* formerly: #efefef; */
   --boxel-light-400: var(--boxel-200);

--- a/packages/host/app/components/ai-assistant/code-block/diff-editor-header.gts
+++ b/packages/host/app/components/ai-assistant/code-block/diff-editor-header.gts
@@ -47,7 +47,7 @@ export default class CodeBlockDiffEditorHeader extends Component<CodeBlockDiffEd
             {{this.fileName}}
           </div>
 
-          <div class='dropdown-container'>
+          <div class='dropdown-container' data-theme='light'>
             <AttachedFileDropdownMenu
               @file={{this.file}}
               @isNewFile={{bool @codeData.isNewFile}}

--- a/packages/host/app/components/ai-assistant/message/attachments.gts
+++ b/packages/host/app/components/ai-assistant/message/attachments.gts
@@ -106,6 +106,7 @@ export default class Attachments extends Component<Signature> {
                   @showErrorIcon={{true}}
                   @urlForRealmLookup={{this.cardErrorRealm cardError}}
                   title={{cardError.id}}
+                  data-theme='light'
                   data-test-attached-card-error={{cardError.id}}
                 />
               </li>

--- a/packages/host/app/components/ai-assistant/message/user-message.gts
+++ b/packages/host/app/components/ai-assistant/message/user-message.gts
@@ -18,6 +18,7 @@ interface Signature {
 const UserMessage: TemplateOnlyComponent<Signature> = <template>
   <Message
     class={{cn 'user-message-bubble' is-pending=@isPending}}
+    data-theme='light'
     data-test-user-message
     ...attributes
   >

--- a/packages/host/app/components/ai-assistant/new-session-settings.gts
+++ b/packages/host/app/components/ai-assistant/new-session-settings.gts
@@ -93,15 +93,14 @@ export default class NewSessionSettings extends Component<Signature> {
     </div>
     <style scoped>
       .new-session-settings-menu {
-        --new-sessions-menu-foreground: #e0e0e0;
-
-        background: var(--ai-assistant-menu-background);
+        position: relative;
+        background-color: var(--ai-assistant-menu-background);
         border-radius: var(--boxel-border-radius);
         box-shadow: 0 10px 15px 0 rgba(0, 0, 0, 0.25);
-        border: solid 1px rgba(0, 0, 0, 0.25);
+        border: 1px solid var(--ai-assistant-menu-border);
         padding: 6.5px 11px 11px 11px;
         min-width: 13.75rem;
-        color: var(--new-sessions-menu-foreground);
+        color: var(--ai-assistant-menu-foreground);
       }
       .new-session-settings-header {
         display: flex;
@@ -110,11 +109,13 @@ export default class NewSessionSettings extends Component<Signature> {
         margin-bottom: 6.5px;
       }
       .new-session-settings-title {
-        font-weight: 600;
+        font: 700 var(--boxel-font-sm);
         letter-spacing: var(--boxel-lsp-sm);
       }
-      .new-session-settings-close-button:hover {
-        color: var(--boxel-light);
+      .new-session-settings-close-button {
+        position: absolute;
+        top: var(--boxel-sp-4xs);
+        right: var(--boxel-sp-4xs);
       }
       .new-session-settings-options {
         display: flex;

--- a/packages/host/app/components/ai-assistant/panel-popover.gts
+++ b/packages/host/app/components/ai-assistant/panel-popover.gts
@@ -17,14 +17,14 @@ const AiAssistantPanelPopover: TemplateOnlyComponent<Signature> = <template>
       position: absolute;
       top: 1.5rem;
       right: 1.875rem;
+      left: 1.875rem;
       margin-top: var(--boxel-sp-sm);
-      max-width: 20rem;
       min-height: 12.5rem;
       max-height: 75vh;
-      background: var(--ai-assistant-menu-background);
-      border: 1px solid var(--past-sessions-divider-color);
+      background-color: var(--ai-assistant-menu-background);
+      border: 1px solid var(--ai-assistant-menu-border);
       border-radius: var(--boxel-border-radius);
-      color: var(--boxel-light);
+      color: var(--ai-assistant-menu-foreground);
       box-shadow: 0 5px 15px 0 rgba(0, 0, 0, 0.5);
       z-index: var(--host-ai-panel-popover-z-index);
       display: flex;
@@ -51,9 +51,8 @@ const AiAssistantPanelPopover: TemplateOnlyComponent<Signature> = <template>
       position: relative;
       padding: var(--boxel-sp-xs);
       color: var(--boxel-200);
-      font-weight: 700;
-      letter-spacing: var(--boxel-lsp-xs);
-      line-height: 1.2;
+      font: 700 var(--boxel-font-sm);
+      letter-spacing: var(--boxel-lsp-sm);
 
       box-shadow: var(--box-shadow-start);
 
@@ -70,6 +69,7 @@ const AiAssistantPanelPopover: TemplateOnlyComponent<Signature> = <template>
     .body {
       overflow-y: auto;
       flex-grow: 1;
+      scroll-timeline: --past-sessions-scroll-timeline block;
     }
 
     @keyframes scroll-past-sessions {
@@ -93,7 +93,7 @@ const AiAssistantPanelPopover: TemplateOnlyComponent<Signature> = <template>
     <header class='header'>
       {{yield to='header'}}
     </header>
-    <div class='body' tabindex='0'>
+    <div class='body' tabindex='0' data-test-panel-popover-body>
       {{yield to='body'}}
     </div>
   </div>

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -208,9 +208,11 @@ export default class AiAssistantPanel extends Component<Signature> {
 
     <style scoped>
       :global(:root) {
-        --ai-assistant-menu-background: #4f4b57;
-        --past-sessions-divider-color: #75707e;
-        --ai-assistant-menu-hover-background: #797788;
+        --ai-assistant-menu-background: var(--boxel-650);
+        --ai-assistant-menu-foreground: var(--boxel-light);
+        --ai-assistant-menu-border: var(--boxel-light-25);
+        --ai-assistant-menu-divider: var(--boxel-575);
+        --ai-assistant-menu-hover-background: var(--boxel-700);
       }
 
       .left-border {

--- a/packages/host/app/components/ai-assistant/past-session-item.gts
+++ b/packages/host/app/components/ai-assistant/past-session-item.gts
@@ -9,6 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import ExternalLink from '@cardstack/boxel-icons/external-link';
 
 import { format as formatDate, isSameDay, isSameYear } from 'date-fns';
+import { modifier } from 'ember-modifier';
 
 import {
   BoxelDropdown,
@@ -45,6 +46,42 @@ interface Signature {
 
 export default class PastSessionItem extends Component<Signature> {
   @tracked private preventMenuClose = false;
+  private closeDropdownAction: (() => void) | null = null;
+  private closeDropdownTimer: ReturnType<typeof setTimeout> | null = null;
+  private triggerElement: HTMLElement | null = null;
+
+  private registerCloseAction = modifier(
+    (_element: HTMLElement, [closeFn]: [() => void]) => {
+      this.closeDropdownAction = closeFn;
+      return () => {
+        this.closeDropdownAction = null;
+      };
+    },
+  );
+
+  private registerTriggerElement = modifier((element: HTMLElement) => {
+    this.triggerElement = element;
+    return () => {
+      this.triggerElement = null;
+    };
+  });
+
+  @action
+  private scheduleCloseDropdown() {
+    this.cancelCloseDropdown();
+    this.closeDropdownTimer = setTimeout(() => {
+      this.closeDropdownAction?.();
+      this.triggerElement?.blur();
+    }, 200);
+  }
+
+  @action
+  private cancelCloseDropdown() {
+    if (this.closeDropdownTimer) {
+      clearTimeout(this.closeDropdownTimer);
+      this.closeDropdownTimer = null;
+    }
+  }
 
   <template>
     <li
@@ -52,6 +89,8 @@ export default class PastSessionItem extends Component<Signature> {
       data-test-joined-room={{@session.roomId}}
       data-room-id={{@session.roomId}}
       data-is-current-room={{@isCurrentRoom}}
+      {{on 'mouseenter' this.cancelCloseDropdown}}
+      {{on 'mouseleave' this.scheduleCloseDropdown}}
     >
       <button
         class='view-session-button'
@@ -87,7 +126,7 @@ export default class PastSessionItem extends Component<Signature> {
           {{/if}}
         </div>
       </button>
-      <BoxelDropdown>
+      <BoxelDropdown @contentClass='past-session-menu-dropdown'>
         <:trigger as |bindings|>
           <Tooltip @placement='top'>
             <:trigger>
@@ -98,6 +137,7 @@ export default class PastSessionItem extends Component<Signature> {
                 @label='past session options'
                 data-test-past-session-options-button={{@session.roomId}}
                 {{bindings}}
+                {{this.registerTriggerElement}}
               />
             </:trigger>
             <:content>
@@ -108,6 +148,9 @@ export default class PastSessionItem extends Component<Signature> {
         <:content as |dd|>
           <Menu
             class='menu past-session-menu themeless'
+            {{this.registerCloseAction dd.close}}
+            {{on 'mouseenter' this.cancelCloseDropdown}}
+            {{on 'mouseleave' this.scheduleCloseDropdown}}
             @closeMenu={{fn this.handleCloseMenu dd.close}}
             @items={{array
               (menuItem
@@ -139,37 +182,49 @@ export default class PastSessionItem extends Component<Signature> {
       }
 
       .session {
+        position: relative;
         display: flex;
         align-items: center;
         justify-content: space-between;
-        border-top: 1px solid var(--past-sessions-divider-color);
         padding: var(--boxel-sp) var(--boxel-sp-sm);
         margin-right: var(--boxel-sp-xs);
         margin-left: var(--boxel-sp-xs);
         border-radius: var(--boxel-border-radius-xs);
       }
 
-      .session:first-child {
-        border-top: none;
+      .session::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 1px;
+        background: #4f4b57;
       }
 
-      .session:hover {
+      .session:first-child::before {
+        display: none;
+      }
+
+      .session:hover,
+      .session:has(.menu-button[aria-expanded='true']) {
         background-color: var(--ai-assistant-menu-hover-background);
+        border-radius: calc(var(--boxel-border-radius-xs) + 2px);
         cursor: pointer;
       }
-      .session[data-is-current-room] {
-        border: 1px solid var(--past-sessions-divider-color);
-      }
-      .session:hover + .session:not([data-is-current-room]),
-      .session[data-is-current-room] + .session {
-        border-top-color: transparent;
+      .session:hover::before,
+      .session:has(.menu-button[aria-expanded='true'])::before,
+      .session:hover + .session::before,
+      .session:has(.menu-button[aria-expanded='true']) + .session::before {
+        background: transparent;
       }
       .name {
         font-weight: 600;
       }
       .date {
-        margin-top: var(--boxel-sp-xxs);
+        margin-top: calc(var(--boxel-sp-xxs) - 5px);
         color: var(--boxel-400);
+        font-size: 12px;
       }
       .view-session-button {
         color: var(--boxel-light);
@@ -195,12 +250,17 @@ export default class PastSessionItem extends Component<Signature> {
         visibility: visible;
       }
 
+      :global(.past-session-menu-dropdown) {
+        border: none;
+        box-shadow: none;
+      }
+
       .menu {
         --boxel-menu-item-content-padding: var(--boxel-sp-xxs)
           var(--boxel-sp-sm);
 
-        background: var(--ai-assistant-menu-background);
-        border: 1px solid var(--past-sessions-divider-color);
+        background: #3b394b;
+        border: 1px solid rgba(255, 255, 255, 0.25);
         color: var(--boxel-light);
         padding: var(--boxel-sp-xs);
         box-shadow: var(--boxel-deep-box-shadow);
@@ -218,7 +278,7 @@ export default class PastSessionItem extends Component<Signature> {
       }
 
       .menu :deep(.boxel-menu__item:hover) {
-        background-color: var(--ai-assistant-menu-hover-background);
+        background-color: #272330;
         border-radius: var(--boxel-border-radius-xs);
       }
 

--- a/packages/host/app/components/ai-assistant/past-session-item.gts
+++ b/packages/host/app/components/ai-assistant/past-session-item.gts
@@ -9,6 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import ExternalLink from '@cardstack/boxel-icons/external-link';
 
 import { format as formatDate, isSameDay, isSameYear } from 'date-fns';
+import { restartableTask, timeout } from 'ember-concurrency';
 import { modifier } from 'ember-modifier';
 
 import {
@@ -47,14 +48,16 @@ interface Signature {
 export default class PastSessionItem extends Component<Signature> {
   @tracked private preventMenuClose = false;
   private closeDropdownAction: (() => void) | null = null;
-  private closeDropdownTimer: ReturnType<typeof setTimeout> | null = null;
   private triggerElement: HTMLElement | null = null;
+  private menuElement: HTMLElement | null = null;
 
   private registerCloseAction = modifier(
-    (_element: HTMLElement, [closeFn]: [() => void]) => {
+    (element: HTMLElement, [closeFn]: [() => void]) => {
       this.closeDropdownAction = closeFn;
+      this.menuElement = element;
       return () => {
         this.closeDropdownAction = null;
+        this.menuElement = null;
       };
     },
   );
@@ -66,21 +69,35 @@ export default class PastSessionItem extends Component<Signature> {
     };
   });
 
+  private closeDropdownTask = restartableTask(async () => {
+    await timeout(200);
+    // Hover-close is a pointer affordance: a keyboard user's menu must not
+    // vanish (nor their focus drop to <body>) because the pointer happened
+    // to pass over the row. Keyboard use shows as :focus-visible on the
+    // trigger or as focus inside the menu itself.
+    if (
+      this.triggerElement?.matches(':focus-visible') ||
+      this.menuElement?.contains(document.activeElement)
+    ) {
+      return;
+    }
+    this.closeDropdownAction?.();
+    // A pointer-click leaves non-visible focus on the trigger, which would
+    // hold the row's :focus-within and keep the hidden-until-hover button
+    // visible after the pointer leaves.
+    if (document.activeElement === this.triggerElement) {
+      this.triggerElement?.blur();
+    }
+  });
+
   @action
   private scheduleCloseDropdown() {
-    this.cancelCloseDropdown();
-    this.closeDropdownTimer = setTimeout(() => {
-      this.closeDropdownAction?.();
-      this.triggerElement?.blur();
-    }, 200);
+    this.closeDropdownTask.perform();
   }
 
   @action
   private cancelCloseDropdown() {
-    if (this.closeDropdownTimer) {
-      clearTimeout(this.closeDropdownTimer);
-      this.closeDropdownTimer = null;
-    }
+    this.closeDropdownTask.cancelAll();
   }
 
   <template>
@@ -147,10 +164,11 @@ export default class PastSessionItem extends Component<Signature> {
         </:trigger>
         <:content as |dd|>
           <Menu
-            class='menu past-session-menu themeless'
+            class='menu past-session-menu'
             {{this.registerCloseAction dd.close}}
             {{on 'mouseenter' this.cancelCloseDropdown}}
             {{on 'mouseleave' this.scheduleCloseDropdown}}
+            @isRounded={{false}}
             @closeMenu={{fn this.handleCloseMenu dd.close}}
             @items={{array
               (menuItem
@@ -199,7 +217,7 @@ export default class PastSessionItem extends Component<Signature> {
         left: 0;
         right: 0;
         height: 1px;
-        background: #4f4b57;
+        background-color: var(--ai-assistant-menu-divider);
       }
 
       .session:first-child::before {
@@ -209,7 +227,7 @@ export default class PastSessionItem extends Component<Signature> {
       .session:hover,
       .session:has(.menu-button[aria-expanded='true']) {
         background-color: var(--ai-assistant-menu-hover-background);
-        border-radius: calc(var(--boxel-border-radius-xs) + 2px);
+        border-radius: var(--boxel-border-radius-sm);
         cursor: pointer;
       }
       .session:hover::before,
@@ -218,13 +236,21 @@ export default class PastSessionItem extends Component<Signature> {
       .session:has(.menu-button[aria-expanded='true']) + .session::before {
         background: transparent;
       }
+      .session[data-is-current-room] {
+        background-color: var(--ai-assistant-menu-hover-background);
+        border-radius: var(--boxel-border-radius-sm);
+      }
+      .session[data-is-current-room]::before,
+      .session[data-is-current-room] + .session::before {
+        background: transparent;
+      }
       .name {
         font-weight: 600;
       }
       .date {
-        margin-top: calc(var(--boxel-sp-xxs) - 5px);
+        margin-top: var(--boxel-sp-6xs);
         color: var(--boxel-400);
-        font-size: 12px;
+        font-size: var(--boxel-font-size-xs);
       }
       .view-session-button {
         color: var(--boxel-light);
@@ -240,6 +266,7 @@ export default class PastSessionItem extends Component<Signature> {
       }
 
       .menu-button {
+        --host-outline-offset: 2px;
         visibility: hidden;
       }
       .session:hover .menu-button,
@@ -251,35 +278,30 @@ export default class PastSessionItem extends Component<Signature> {
       }
 
       :global(.past-session-menu-dropdown) {
-        border: none;
-        box-shadow: none;
+        --boxel-dropdown-background-color: var(--ai-assistant-menu-background);
+        --boxel-dropdown-border-color: var(--ai-assistant-menu-border);
+        --boxel-dropdown-text-color: var(--ai-assistant-menu-foreground);
+        --boxel-dropdown-hover-color: var(--ai-assistant-menu-hover-background);
+        --boxel-dropdown-box-shadow: var(--boxel-deep-box-shadow);
+        --boxel-menu-item-border-radius: var(--boxel-border-radius-xs);
+        overflow: hidden;
       }
 
       .menu {
-        --boxel-menu-item-content-padding: var(--boxel-sp-xxs)
+        --boxel-menu-item-content-padding: var(--boxel-sp-2xs)
           var(--boxel-sp-sm);
-
-        background: #3b394b;
-        border: 1px solid rgba(255, 255, 255, 0.25);
-        color: var(--boxel-light);
         padding: var(--boxel-sp-xs);
-        box-shadow: var(--boxel-deep-box-shadow);
       }
 
       .menu :deep(svg) {
         --icon-stroke-width: 1.5px;
-        --icon-color: var(--boxel-light);
+        --icon-color: currentColor;
 
         margin-right: var(--boxel-sp-xs);
       }
 
       .menu :deep(.boxel-menu__item:nth-child(2) svg) {
         --icon-stroke-width: 0.5px;
-      }
-
-      .menu :deep(.boxel-menu__item:hover) {
-        background-color: #272330;
-        border-radius: var(--boxel-border-radius-xs);
       }
 
       .icon-recency-indicator {
@@ -325,11 +347,14 @@ export default class PastSessionItem extends Component<Signature> {
   private handleCopyRoomId(roomId: string) {
     this.preventMenuClose = true;
     this.args.actions.copyRoomId(roomId);
-    // Reset the flag after a short delay to allow normal closing for other actions
-    setTimeout(() => {
-      this.preventMenuClose = false;
-    }, 200);
+    this.resetPreventMenuCloseTask.perform();
   }
+
+  // Reset the flag after a short delay to allow normal closing for other actions
+  private resetPreventMenuCloseTask = restartableTask(async () => {
+    await timeout(200);
+    this.preventMenuClose = false;
+  });
 
   @action
   private handleCloseMenu(originalClose: () => void) {

--- a/packages/host/app/components/ai-assistant/past-sessions.gts
+++ b/packages/host/app/components/ai-assistant/past-sessions.gts
@@ -47,53 +47,71 @@ export default class AiAssistantPastSessionsList extends Component<Signature> {
   });
 
   <template>
-    <AiAssistantPanelPopover
-      @onClose={{@onClose}}
-      data-test-past-sessions
-      ...attributes
-    >
-      <:header>
-        Past Sessions
-      </:header>
-      <:body>
-        {{#if @sessions}}
-          <ul class='past-sessions' {{this.checkScroll}}>
-            {{#each @sessions key='roomId' as |session|}}
-              <PastSessionItem
-                @session={{session}}
-                @isCurrentRoom={{eq session.roomId @currentRoomId}}
-                @actions={{@roomActions}}
-              />
-            {{/each}}
-            {{#if this.matrixService.isLoadingMoreAIRooms}}
-              <li
-                class='loading-indicator-container'
-                data-test-loading-more-rooms
-              >
-                <LoadingIndicator
-                  @color='var(--boxel-dark)'
-                  class='loading-indicator'
+    <div class='past-sessions-menu'>
+      <AiAssistantPanelPopover
+        @onClose={{@onClose}}
+        data-test-past-sessions
+        ...attributes
+      >
+        <:header>
+          Past Sessions
+        </:header>
+        <:body>
+          {{#if @sessions}}
+            <ul class='past-sessions' {{this.checkScroll}}>
+              {{#each @sessions key='roomId' as |session|}}
+                <PastSessionItem
+                  @session={{session}}
+                  @isCurrentRoom={{eq session.roomId @currentRoomId}}
+                  @actions={{@roomActions}}
                 />
-              </li>
-            {{/if}}
-          </ul>
-        {{else}}
-          <div class='empty-collection'>
-            No past sessions to show.
-          </div>
-        {{/if}}
-      </:body>
-    </AiAssistantPanelPopover>
+              {{/each}}
+              {{#if this.matrixService.isLoadingMoreAIRooms}}
+                <li
+                  class='loading-indicator-container'
+                  data-test-loading-more-rooms
+                >
+                  <LoadingIndicator
+                    @color='var(--boxel-dark)'
+                    class='loading-indicator'
+                  />
+                </li>
+              {{/if}}
+            </ul>
+          {{else}}
+            <div class='empty-collection'>
+              No past sessions to show.
+            </div>
+          {{/if}}
+        </:body>
+      </AiAssistantPanelPopover>
+    </div>
 
     <style scoped>
+      .past-sessions-menu :deep(.panel-popover) {
+        left: 30px;
+        right: 30px;
+        max-width: none;
+        background: #3b394b;
+        border: 1px solid rgba(255, 255, 255, 0.25);
+      }
+      .past-sessions-menu :deep(.header) {
+        font: 700 var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp-sm);
+      }
+      .past-sessions-menu :deep(.session:hover),
+      .past-sessions-menu
+        :deep(.session:has(.menu-button[aria-expanded='true'])) {
+        background-color: #272330;
+      }
+      .past-sessions-menu :deep(.body) {
+        scroll-timeline: --past-sessions-scroll-timeline block;
+      }
       .past-sessions {
         list-style-type: none;
         padding: 0;
         margin: 0;
         margin-bottom: var(--boxel-sp-xs);
-        max-height: 400px;
-        overflow-y: auto;
-        scroll-timeline: --past-sessions-scroll-timeline block;
       }
       .empty-collection {
         padding: var(--boxel-sp-sm);

--- a/packages/host/app/components/ai-assistant/past-sessions.gts
+++ b/packages/host/app/components/ai-assistant/past-sessions.gts
@@ -13,6 +13,18 @@ import type { SessionRoomData } from '../../services/ai-assistant-panel-service'
 
 import type MatrixService from '../../services/matrix-service';
 
+function findScrollContainer(element: HTMLElement): HTMLElement {
+  let candidate: HTMLElement | null = element;
+  while (candidate) {
+    let { overflowY } = getComputedStyle(candidate);
+    if (overflowY === 'auto' || overflowY === 'scroll') {
+      return candidate;
+    }
+    candidate = candidate.parentElement;
+  }
+  return element;
+}
+
 interface Signature {
   Args: {
     sessions: SessionRoomData[];
@@ -27,8 +39,12 @@ export default class AiAssistantPastSessionsList extends Component<Signature> {
   @service declare matrixService: MatrixService;
 
   checkScroll = modifier((element: HTMLElement) => {
+    // The list itself does not scroll — the popover's body clips it, and
+    // scroll events do not bubble, so listen on whichever element actually
+    // scrolls.
+    let scroller = findScrollContainer(element);
     let checkScrollPosition = () => {
-      let { scrollHeight, scrollTop, clientHeight } = element;
+      let { scrollHeight, scrollTop, clientHeight } = scroller;
       let isAtBottom = Math.abs(scrollHeight - scrollTop - clientHeight) <= 1;
       let hasNoScroll = scrollHeight <= clientHeight;
 
@@ -39,74 +55,53 @@ export default class AiAssistantPastSessionsList extends Component<Signature> {
 
     checkScrollPosition();
 
-    element.addEventListener('scroll', checkScrollPosition);
+    scroller.addEventListener('scroll', checkScrollPosition);
 
     return () => {
-      element.removeEventListener('scroll', checkScrollPosition);
+      scroller.removeEventListener('scroll', checkScrollPosition);
     };
   });
 
   <template>
-    <div class='past-sessions-menu'>
-      <AiAssistantPanelPopover
-        @onClose={{@onClose}}
-        data-test-past-sessions
-        ...attributes
-      >
-        <:header>
-          Past Sessions
-        </:header>
-        <:body>
-          {{#if @sessions}}
-            <ul class='past-sessions' {{this.checkScroll}}>
-              {{#each @sessions key='roomId' as |session|}}
-                <PastSessionItem
-                  @session={{session}}
-                  @isCurrentRoom={{eq session.roomId @currentRoomId}}
-                  @actions={{@roomActions}}
+    <AiAssistantPanelPopover
+      @onClose={{@onClose}}
+      data-test-past-sessions
+      ...attributes
+    >
+      <:header>
+        Past Sessions
+      </:header>
+      <:body>
+        {{#if @sessions}}
+          <ul class='past-sessions' {{this.checkScroll}}>
+            {{#each @sessions key='roomId' as |session|}}
+              <PastSessionItem
+                @session={{session}}
+                @isCurrentRoom={{eq session.roomId @currentRoomId}}
+                @actions={{@roomActions}}
+              />
+            {{/each}}
+            {{#if this.matrixService.isLoadingMoreAIRooms}}
+              <li
+                class='loading-indicator-container'
+                data-test-loading-more-rooms
+              >
+                <LoadingIndicator
+                  @color='var(--boxel-dark)'
+                  class='loading-indicator'
                 />
-              {{/each}}
-              {{#if this.matrixService.isLoadingMoreAIRooms}}
-                <li
-                  class='loading-indicator-container'
-                  data-test-loading-more-rooms
-                >
-                  <LoadingIndicator
-                    @color='var(--boxel-dark)'
-                    class='loading-indicator'
-                  />
-                </li>
-              {{/if}}
-            </ul>
-          {{else}}
-            <div class='empty-collection'>
-              No past sessions to show.
-            </div>
-          {{/if}}
-        </:body>
-      </AiAssistantPanelPopover>
-    </div>
+              </li>
+            {{/if}}
+          </ul>
+        {{else}}
+          <div class='empty-collection'>
+            No past sessions to show.
+          </div>
+        {{/if}}
+      </:body>
+    </AiAssistantPanelPopover>
 
     <style scoped>
-      .past-sessions-menu :deep(.panel-popover) {
-        left: 30px;
-        right: 30px;
-        max-width: none;
-        background: #3b394b;
-        border: 1px solid rgba(255, 255, 255, 0.25);
-      }
-      .past-sessions-menu :deep(.header) {
-        font: 700 var(--boxel-font-sm);
-        letter-spacing: var(--boxel-lsp-sm);
-      }
-      .past-sessions-menu :deep(.session:hover),
-      .past-sessions-menu
-        :deep(.session:has(.menu-button[aria-expanded='true'])) {
-        background-color: #272330;
-      }
-      .past-sessions-menu :deep(.body) {
-        scroll-timeline: --past-sessions-scroll-timeline block;
-      }
       .past-sessions {
         list-style-type: none;
         padding: 0;

--- a/packages/host/app/components/ai-assistant/rename-session.gts
+++ b/packages/host/app/components/ai-assistant/rename-session.gts
@@ -70,11 +70,9 @@ export default class RenameSession extends Component<Signature> {
 
     <style scoped>
       .rename-session {
-        --boxel-button-color: var(--boxel-light);
-
+        --boxel-input-outline: none;
         min-height: unset;
       }
-
       .rename-field {
         padding: 0 var(--boxel-sp-xs);
       }
@@ -86,9 +84,6 @@ export default class RenameSession extends Component<Signature> {
         justify-content: flex-end;
         gap: var(--boxel-sp-xs);
         padding: var(--boxel-sp-xs);
-      }
-      .footer :deep(.boxel-button:not(:disabled)) {
-        --boxel-button-text-color: var(--boxel-dark);
       }
     </style>
   </template>

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -278,6 +278,7 @@ export default class Room extends Component<Signature> {
               {{on 'dragenter' this.handleChatInputDragEnter}}
               {{on 'dragleave' this.handleChatInputDragLeave}}
               {{on 'drop' this.handleChatInputDrop}}
+              data-theme='light'
             >
               {{#if this.isDropZoneActive}}
                 <div

--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -708,7 +708,6 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
         flex-wrap: wrap;
         gap: var(--boxel-sp-xs);
         padding: var(--boxel-sp-xs);
-        border-bottom: var(--boxel-border);
         background-color: transparent;
       }
 

--- a/packages/host/app/components/operator-mode/code-submode/toggle-button.gts
+++ b/packages/host/app/components/operator-mode/code-submode/toggle-button.gts
@@ -22,7 +22,8 @@ const ToggleButton: TemplateOnlyComponent<ToggleButtonSignature> = <template>
   <Button
     @disabled={{@disabled}}
     @kind={{if @isActive 'primary-dark'}}
-    @size='extra-small'
+    @size='small'
+    @rectangular={{true}}
     class={{cn 'toggle-button' active=@isActive}}
     ...attributes
   >
@@ -44,7 +45,7 @@ const ToggleButton: TemplateOnlyComponent<ToggleButtonSignature> = <template>
       --boxel-button-letter-spacing: var(--boxel-lsp-xs);
       --boxel-button-min-width: 6rem;
       --boxel-button-padding: 0;
-      border-radius: var(--boxel-border-radius-sm);
+
       flex: 1;
       justify-content: space-between;
       white-space: nowrap;

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -219,7 +219,7 @@ export default class OperatorModeContainer extends Component<Signature> {
           --boxel-header-text-color,
           var(--ring, var(--boxel-highlight))
         );
-        outline-offset: var(--host-outline-offset, -2px);
+        outline-offset: var(--host-outline-offset, 2px);
       }
       :global(button:focus:not(:focus-visible)) {
         outline-color: transparent;

--- a/packages/host/app/components/operator-mode/delete-modal.gts
+++ b/packages/host/app/components/operator-mode/delete-modal.gts
@@ -35,6 +35,7 @@ let component: TemplateOnlyComponent<Signature> = <template>
     @isOpen={{true}}
     @onClose={{@onCancel}}
     style={{cssVar boxel-modal-offset-top='40vh'}}
+    data-theme='light'
   >
     <section class='delete {{@containerClass}}'>
       <div class='content' data-test-delete-msg>

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -501,6 +501,7 @@ export default class SubmodeLayout extends Component<Signature> {
                 workspace-button--chooser-open=this.workspaceChooserOpened
               }}
               {{on 'click' this.toggleWorkspaceChooser}}
+              data-workspace-chooser-toggle
               data-test-workspace-chooser-toggle
             />
             {{#if this.workspaceChooserOpened}}
@@ -614,6 +615,7 @@ export default class SubmodeLayout extends Component<Signature> {
             @defaultSize={{this.aiPanelWidths.defaultWidth}}
             @minSize={{this.aiPanelWidths.minWidth}}
             @collapsible={{false}}
+            data-theme='dark'
           >
             <AiAssistantPanel
               @onClose={{this.aiAssistantPanelService.closePanel}}

--- a/packages/host/app/components/operator-mode/workspace-chooser/focus-when-selected.ts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/focus-when-selected.ts
@@ -7,6 +7,26 @@ import { modifier } from 'ember-modifier';
 // button), since those controls live outside the tile element.
 const wasSelected = new WeakMap<HTMLElement, boolean>();
 
+// The WeakMap is keyed per element, so a re-render that recreates the tile
+// (async realm info/counts arriving, the sort filter re-rendering the list)
+// makes the still-selected tile look "just selected" again. Focus may only
+// move to the tile when it isn't actively engaged elsewhere: on nothing/body
+// (the chooser just opened), on the toggle button that opens the chooser
+// (which keeps focus after activation, and hands it off to the default tile
+// so arrow-key navigation works immediately), or on another tile (arrow-key
+// navigation). Otherwise a tile recreation would steal focus mid-interaction
+// from a control like the sort select — turning its next Enter into a click
+// on the workspace tile.
+function focusIsAvailable(): boolean {
+  let active = document.activeElement;
+  return (
+    !active ||
+    active === document.body ||
+    active.hasAttribute('data-workspace-chooser-toggle') ||
+    !!active.closest('[data-nav-index]')
+  );
+}
+
 // When a workspace-chooser tile becomes the keyboard-selected item, move DOM
 // focus to it and scroll it into view, so the selection is visible and the
 // tile is reachable as arrow-key navigation walks the list.
@@ -15,7 +35,11 @@ export default modifier(
     let selected = !!isSelected;
     let justSelected = selected && !wasSelected.get(element);
     wasSelected.set(element, selected);
-    if (justSelected && document.activeElement !== element) {
+    if (
+      justSelected &&
+      document.activeElement !== element &&
+      focusIsAvailable()
+    ) {
       element.focus();
       element.scrollIntoView({ block: 'nearest' });
     }

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -760,36 +760,25 @@ export default class WorkspaceChooser extends Component<Signature> {
       .sort-select {
         flex-shrink: 0;
         --boxel-select-background-color: var(--boxel-800);
-        --boxel-select-border-color: rgba(255 255 255 / 25%);
         --boxel-select-text-color: var(--boxel-light);
-        --boxel-select-focus-border-color: rgba(255 255 255 / 50%);
+        --boxel-select-border-color: var(--boxel-light-25);
+        --boxel-select-focus-border-color: var(--boxel-light-50);
         --icon-color: var(--boxel-light);
-        font: 400 var(--boxel-font-sm);
-        letter-spacing: var(--boxel-lsp);
       }
       :global(.boxel-select__dropdown.workspace-chooser-sort-dropdown) {
-        --boxel-dropdown-background-color: #3b394b;
-        --boxel-dropdown-border-color: rgba(255, 255, 255, 0.25);
-        --boxel-dropdown-text-color: #fff;
-        --boxel-dropdown-selected-text-color: #fff;
-        --boxel-dropdown-hover-color: #272330;
-        --boxel-dropdown-highlight-color: #3b394b;
-      }
-      :global(
-        .workspace-chooser-sort-dropdown
-          .boxel-select-option-item.ember-power-select-option--selected.ember-power-select-option--highlighted
-      ) {
-        background-color: #3b394b;
-      }
-      :global(
-        .workspace-chooser-sort-dropdown
-          .boxel-select-option-item.ember-power-select-option--selected:hover
-      ) {
-        background-color: #272330;
+        --boxel-dropdown-background-color: var(--boxel-650);
+        --boxel-dropdown-border-color: var(--boxel-light-25);
+        --boxel-dropdown-text-color: var(--boxel-light);
+        --boxel-dropdown-selected-text-color: var(--boxel-light);
+        --boxel-dropdown-hover-color: var(--boxel-700);
+        --boxel-dropdown-highlight-color: var(--boxel-650);
+        --boxel-dropdown-highlight-hover-color: var(--boxel-700);
+        --boxel-dropdown-selected-highlighted-color: var(--boxel-700);
+        --boxel-dropdown-selected-hover-color: var(--boxel-700);
       }
       :global(.workspace-chooser-sort-dropdown .boxel-select-option-checkmark) {
-        --icon-color: #00ffba;
-        color: #00ffba;
+        --icon-color: var(--boxel-highlight);
+        color: var(--boxel-highlight);
       }
       .workspace-chooser__content {
         display: flex;
@@ -864,7 +853,7 @@ export default class WorkspaceChooser extends Component<Signature> {
         max-width: 40rem;
         padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
         border-radius: var(--boxel-border-radius);
-        background-color: rgba(255 255 255 / 10%);
+        background-color: var(--boxel-light-10);
         color: var(--boxel-light);
         font: 400 var(--boxel-font-sm);
         letter-spacing: var(--boxel-lsp-xs);

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -558,6 +558,7 @@ export default class WorkspaceChooser extends Component<Signature> {
           <div class='sort-controls'>
             <BoxelSelect
               class='sort-select'
+              @dropdownClass='workspace-chooser-sort-dropdown'
               @options={{this.sortOptions}}
               @selected={{this.selectedSortOption}}
               @onChange={{this.onSortChange}}
@@ -758,13 +759,37 @@ export default class WorkspaceChooser extends Component<Signature> {
       }
       .sort-select {
         flex-shrink: 0;
-        --boxel-select-background-color: rgb(42 32 64 / 90%);
+        --boxel-select-background-color: var(--boxel-800);
         --boxel-select-border-color: rgba(255 255 255 / 25%);
         --boxel-select-text-color: var(--boxel-light);
         --boxel-select-focus-border-color: rgba(255 255 255 / 50%);
         --icon-color: var(--boxel-light);
         font: 400 var(--boxel-font-sm);
         letter-spacing: var(--boxel-lsp);
+      }
+      :global(.boxel-select__dropdown.workspace-chooser-sort-dropdown) {
+        --boxel-dropdown-background-color: #3b394b;
+        --boxel-dropdown-border-color: rgba(255, 255, 255, 0.25);
+        --boxel-dropdown-text-color: #fff;
+        --boxel-dropdown-selected-text-color: #fff;
+        --boxel-dropdown-hover-color: #272330;
+        --boxel-dropdown-highlight-color: #3b394b;
+      }
+      :global(
+        .workspace-chooser-sort-dropdown
+          .boxel-select-option-item.ember-power-select-option--selected.ember-power-select-option--highlighted
+      ) {
+        background-color: #3b394b;
+      }
+      :global(
+        .workspace-chooser-sort-dropdown
+          .boxel-select-option-item.ember-power-select-option--selected:hover
+      ) {
+        background-color: #272330;
+      }
+      :global(.workspace-chooser-sort-dropdown .boxel-select-option-checkmark) {
+        --icon-color: #00ffba;
+        color: #00ffba;
       }
       .workspace-chooser__content {
         display: flex;

--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -87,9 +87,10 @@ export default class Workspace extends Component<Signature> {
           {{if this.showSelectionRing "is-selected"}}
           {{if @isFavoritesSection "is-enlarged"}}'
         style={{cssVar favorite-tile-width=@enlargedWidth}}
+        data-theme='dark'
+        {{on 'mouseleave' this.closeHostDropdown}}
         data-test-workspace={{this.name}}
         data-test-workspace-selected={{if @isSelected this.name}}
-        {{on 'mouseleave' this.closeHostDropdown}}
         ...attributes
       >
         {{#if this.reindexError}}
@@ -1165,7 +1166,7 @@ export default class Workspace extends Component<Signature> {
         left: 10px;
         right: 10px;
         height: 1px;
-        background: var(--boxel-200);
+        background: var(--boxel-light-25);
         opacity: 0.75;
       }
       /* The last menu item normally rounds its bottom corners to match the

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -308,7 +308,7 @@ export default class SearchSheet extends Component<Signature> {
       {{repositionDropdownsOnTransitionEnd}}
       {{onClickOutside
         this.onBlur
-        exceptSelector='.add-card-to-neighbor-stack,.boxel-picker__dropdown,.picker-before-options-with-search,.picker-option-row,.search-sheet-header,.search-sheet-section-header,.variant-default'
+        exceptSelector='.add-card-to-neighbor-stack,.boxel-dropdown__content,.boxel-picker__dropdown,.boxel-select__dropdown,.picker-before-options-with-search,.picker-option-row,.search-sheet-header,.search-sheet-section-header'
       }}
     >
       {{#if (eq @mode 'closed')}}

--- a/packages/host/app/components/submode-switcher.gts
+++ b/packages/host/app/components/submode-switcher.gts
@@ -126,7 +126,11 @@ interface Signature {
 
 export default class SubmodeSwitcher extends Component<Signature> {
   <template>
-    <div data-test-submode-switcher={{@submode}} ...attributes>
+    <div
+      data-theme='dark'
+      data-test-submode-switcher={{@submode}}
+      ...attributes
+    >
       <BoxelDropdown
         @contentClass={{if
           @isCollapsed
@@ -163,7 +167,8 @@ export default class SubmodeSwitcher extends Component<Signature> {
         </:trigger>
         <:content as |dd|>
           <Menu
-            class='submode-switcher-dropdown-menu themeless'
+            class='submode-switcher-dropdown-menu'
+            @isRounded={{false}}
             @closeMenu={{dd.close}}
             @items={{this.buildMenuItems}}
           />
@@ -172,17 +177,21 @@ export default class SubmodeSwitcher extends Component<Signature> {
     </div>
     <style scoped>
       :global(:root) {
-        --submode-switcher-dropdown-content-border-radius: 0 0
-          var(--boxel-border-radius) var(--boxel-border-radius);
-        --submode-switcher-dropdown-content-bg-color: rgba(0, 0, 0, 0.5);
         --submode-switcher-width: 10.5rem; /* 168px */
         --submode-switcher-height: var(--container-button-size);
+        --submode-switcher-dropdown-content-border-radius: 0 0
+          var(--boxel-border-radius) var(--boxel-border-radius);
       }
       :global(.submode-switcher-dropdown) {
+        --boxel-dropdown-background-color: var(--boxel-dark-50);
+        --boxel-dropdown-text-color: var(--boxel-light);
+        --boxel-dropdown-hover-color: var(--boxel-dark-30);
         --boxel-dropdown-content-border-radius: var(
           --submode-switcher-dropdown-content-border-radius
         );
-        background-color: var(--submode-switcher-dropdown-content-bg-color);
+        --host-outline-offset: -2px;
+        border: none;
+        overflow: hidden;
       }
       :global(.submode-switcher-dropdown--detached) {
         --submode-switcher-dropdown-content-border-radius: var(
@@ -190,16 +199,9 @@ export default class SubmodeSwitcher extends Component<Signature> {
         );
       }
       .submode-switcher-dropdown-menu {
+        --icon-color: currentColor;
         width: var(--submode-switcher-width);
-        color: var(--boxel-light);
         font: 500 var(--boxel-font-sm);
-
-        --icon-color: var(--boxel-light);
-        --boxel-menu-border-radius: var(
-          --submode-switcher-dropdown-content-border-radius
-        );
-        --boxel-menu-color: var(--submode-switcher-dropdown-content-bg-color);
-        --boxel-menu-current-color: rgba(0, 0, 0, 0.3);
         --boxel-menu-item-gap: var(--boxel-sp-sm);
         --boxel-menu-item-content-padding: var(--boxel-sp-xs);
       }

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1454,12 +1454,11 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       `Expected at least 10 rooms, got ${initialRoomCount}`,
     );
 
-    let pastSessionsElement = document.querySelector(
-      '[data-test-past-sessions] .body ul',
-    );
-    if (pastSessionsElement) {
-      pastSessionsElement.scrollTop = pastSessionsElement.scrollHeight;
-    }
+    let pastSessionsElement = (await waitFor(
+      '[data-test-past-sessions] [data-test-panel-popover-body]',
+    )) as HTMLElement;
+    pastSessionsElement.scrollTop = pastSessionsElement.scrollHeight;
+    await triggerEvent(pastSessionsElement, 'scroll');
     await waitUntil(() => {
       return (
         document.querySelectorAll('[data-test-joined-room]').length >=


### PR DESCRIPTION
## Summary
- Resized the Past Sessions popover to inset 30px from both panel edges, matched its header font to the panel title, restyled its background/border/dividers/hover colors, and fixed a double-height list caused by two nested scroll containers
- The "more options" dropdown now auto-closes on mouse-out via a hover-intent debounce instead of requiring a click elsewhere, and clears lingering keyboard-focus styling on its trigger button
- The active session row keeps its hover background while its own options menu is open
- Restyled the workspace chooser's "View All" sort dropdown: default (closed) state now matches the chooser's own background; open state uses a dark platter with a white 25%-opacity stroke, white text, and a teal checkmark on the active item

## Additional Fixes
- Remove redundant mutation observer from boxel-ui dropdown and select
- Fix bug where selecting "View All" via keyboard on workspace-chooser dropdown opens a random workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)