### PR TITLE
host: Tolerate detached card elements in operator-mode overlays

### DIFF
--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -184,7 +184,15 @@ export default class Overlays extends Component<OverlaySignature> {
   // listeners for elements that are no longer present. A pure getter would leak stale listeners here.
   /* eslint-disable ember/no-side-effects */
   protected get renderedCardsForOverlayActionsWithEvents() {
-    let renderedCards = this.args.renderedCardsForOverlayActions;
+    // The element tracker reconciles its entries in an afterRender pass, so
+    // when a card's rendered DOM node is replaced (e.g. a hot update of the
+    // card's source while it is open in a stack), this getter can recompute
+    // while the incoming array still references the old, now-detached
+    // element. Prune those entries: a detached element has no parent to
+    // measure z-index from and no geometry to anchor an overlay to.
+    let renderedCards = this.args.renderedCardsForOverlayActions.filter(
+      (renderedCard) => renderedCard.element.isConnected,
+    );
     let currentElements = new Set(renderedCards.map((card) => card.element));
     for (let [element, handlers] of this.boundRenderedCardElements) {
       if (!currentElements.has(element)) {
@@ -398,7 +406,12 @@ export default class Overlays extends Component<OverlaySignature> {
       return overlayZIndexStyle;
     }
 
-    let parentElement = element.parentElement!;
+    let parentElement = element.parentElement;
+    if (!parentElement) {
+      // A detached element has no parent to measure; fall back to the
+      // default stacking behavior instead of crashing the render.
+      return htmlSafe('z-index: auto');
+    }
     let zIndexParentElement = window
       .getComputedStyle(parentElement)
       .getPropertyValue('z-index');

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -408,8 +408,9 @@ export default class Overlays extends Component<OverlaySignature> {
 
     let parentElement = element.parentElement;
     if (!parentElement) {
-      // A detached element has no parent to measure; fall back to the
-      // default stacking behavior instead of crashing the render.
+      // An element with no parent element — a document element, or a direct
+      // child of a shadow root — has nothing to measure against, and default
+      // stacking is the only meaningful answer for it.
       return htmlSafe('z-index: auto');
     }
     let zIndexParentElement = window

--- a/packages/host/tests/integration/components/overlays-detached-element-test.gts
+++ b/packages/host/tests/integration/components/overlays-detached-element-test.gts
@@ -27,12 +27,11 @@ function renderedCardEntry(
 module('Integration | overlays detached elements', function (hooks) {
   setupRenderingTest(hooks);
 
-  // The element tracker reconciles its entries in an afterRender pass, so
-  // when a card's rendered DOM node is replaced (e.g. a hot update of the
-  // card's source while it is open in a stack), the overlay getters can
-  // recompute while the tracker still lists the old, now-detached element.
-  // Overlays must tolerate such entries: a detached element has no parent to
-  // measure z-index from and no geometry to anchor an overlay to.
+  // Overlays must tolerate a tracked entry whose element is already detached:
+  // such an element has no geometry to anchor an overlay to and no parent to
+  // measure a z-index from. Binding is the observable signal that an entry
+  // reached the overlay machinery, since it sets `cursor: pointer` on the
+  // card element it binds.
   test('a tracked card element that is detached mid-update does not crash the render', async function (assert) {
     let renderedCards = new TrackedArray<RenderedCardForOverlayActions>([]);
     await renderComponent(
@@ -71,5 +70,15 @@ module('Integration | overlays detached elements', function (hooks) {
         { count: 1 },
         'detached entry is pruned while the connected overlay still renders',
       );
+    assert.strictEqual(
+      detachedElement.style.cursor,
+      '',
+      'the detached element is never bound',
+    );
+    assert.strictEqual(
+      attachedElement.style.cursor,
+      'pointer',
+      'the connected element alongside it is still bound',
+    );
   });
 });

--- a/packages/host/tests/integration/components/overlays-detached-element-test.gts
+++ b/packages/host/tests/integration/components/overlays-detached-element-test.gts
@@ -1,0 +1,75 @@
+import { find, settled, triggerEvent } from '@ember/test-helpers';
+import GlimmerComponent from '@glimmer/component';
+
+import { module, test } from 'qunit';
+import { TrackedArray } from 'tracked-built-ins';
+
+import Overlays from '@cardstack/host/components/operator-mode/overlays';
+
+import type { RenderedCardForOverlayActions } from '@cardstack/host/resources/element-tracker';
+
+import { renderComponent } from '../../helpers/render-component';
+import { setupRenderingTest } from '../../helpers/setup';
+
+function renderedCardEntry(
+  element: HTMLElement,
+  id: string,
+): RenderedCardForOverlayActions {
+  return {
+    element,
+    cardDefOrId: id,
+    fieldType: undefined,
+    fieldName: undefined,
+    format: 'isolated',
+  };
+}
+
+module('Integration | overlays detached elements', function (hooks) {
+  setupRenderingTest(hooks);
+
+  // The element tracker reconciles its entries in an afterRender pass, so
+  // when a card's rendered DOM node is replaced (e.g. a hot update of the
+  // card's source while it is open in a stack), the overlay getters can
+  // recompute while the tracker still lists the old, now-detached element.
+  // Overlays must tolerate such entries: a detached element has no parent to
+  // measure z-index from and no geometry to anchor an overlay to.
+  test('a tracked card element that is detached mid-update does not crash the render', async function (assert) {
+    let renderedCards = new TrackedArray<RenderedCardForOverlayActions>([]);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template>
+          <div id='overlay-test-host'></div>
+          <Overlays @renderedCardsForOverlayActions={{renderedCards}} />
+        </template>
+      },
+    );
+
+    let host = find('#overlay-test-host') as HTMLElement;
+    let attachedElement = document.createElement('div');
+    host.appendChild(attachedElement);
+    renderedCards.push(
+      renderedCardEntry(attachedElement, 'http://test-realm/test/Card/1'),
+    );
+    await settled();
+
+    await triggerEvent(attachedElement, 'mouseenter');
+    assert
+      .dom('[data-test-card-overlay]')
+      .exists({ count: 1 }, 'overlay renders for a connected card element');
+
+    let detachedElement = document.createElement('div');
+    host.appendChild(detachedElement);
+    detachedElement.remove();
+    renderedCards.push(
+      renderedCardEntry(detachedElement, 'http://test-realm/test/Card/2'),
+    );
+    await settled();
+
+    assert
+      .dom('[data-test-card-overlay]')
+      .exists(
+        { count: 1 },
+        'detached entry is pruned while the connected overlay still renders',
+      );
+  });
+});


### PR DESCRIPTION
While a card is open in an Interact-submode stack, editing that card's source (the realm pushes a hot update into the workbench) replaces the card's rendered DOM node. The operator-mode overlay layer tracks rendered card elements through `ElementTracker`, which reconciles its entries in an `afterRender` pass — so the render pass triggered by the card update can recompute the overlay getters while the tracker still lists the old, now-detached element. `Overlays.zIndexStyle` dereferenced that element's `parentElement` with a non-null assertion and passed the resulting `null` to `getComputedStyle`, which throws:

```
TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
    at OperatorModeOverlays.zIndexStyle (overlays.gts)
    at get renderedCardsForOverlayActionsWithEvents (overlays.gts)
```

An error thrown mid-render is unrecoverable in Ember — the app is dead until a page reload, and every live timer that pokes the renderer afterwards spams "Attempted to rerender, but the Ember application has had an unrecoverable error".

This change makes the overlay layer tolerate detached entries:

- `renderedCardsForOverlayActionsWithEvents` prunes entries whose element is no longer connected to the document. A detached element has no geometry to anchor an overlay to and no parent to measure z-index from; once the tracker's `afterRender` reconciliation lands, the getter recomputes with the replacement element and overlays resume as normal. Pruning also unbinds the stale element's mouse listeners through the existing reconciliation in that getter.
- `zIndexStyle` drops the `parentElement!` non-null assertion and falls back to `z-index: auto` when there is no parent to measure, so no caller can crash the render with a detached element.

The race is intermittent in the app (overlay recompute vs. card DOM replacement), so the regression test drives the base `Overlays` component directly with a tracked entry whose element is detached: without the guards it fails with the exact `getComputedStyle` TypeError above; with them the detached entry is pruned while overlays for connected elements keep rendering.

## Testing

- New integration test: `Integration | overlays detached elements` (fails with the production TypeError before the fix, passes after)
- Overlay-related host test modules pass locally; `pnpm lint` (eslint, template-lint, ember-tsc) green in `packages/host`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
