### PR TITLE
fix: classify unknown file types as binary so bytes survive the CLI

### DIFF
--- a/packages/boxel-cli/src/commands/file/read.ts
+++ b/packages/boxel-cli/src/commands/file/read.ts
@@ -9,7 +9,10 @@ import { resolveRealmSecretSeed } from '../../lib/prompt.ts';
 import type { RealmAuthenticator } from '../../lib/realm-authenticator.ts';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
-import { isBinaryFilename } from '@cardstack/runtime-common/infer-content-type';
+import {
+  isBinaryContentType,
+  isBinaryFilename,
+} from '@cardstack/runtime-common/infer-content-type';
 import { FG_RED, DIM, RESET } from '../../lib/colors.ts';
 import { cliLog } from '../../lib/cli-log.ts';
 
@@ -19,9 +22,9 @@ export interface ReadResult {
   /** Raw text content of the file. Populated for non-binary paths. */
   content?: string;
   /**
-   * Raw bytes. Populated when the requested path is a binary filename
-   * (PNG, PDF, font, etc.) — see `isBinaryFilename`. Mutually exclusive
-   * with `content`.
+   * Raw bytes. Populated when the realm serves a binary content type —
+   * anything not known to be textual, which includes unrecognized types.
+   * Mutually exclusive with `content`.
    */
   bytes?: Uint8Array;
   error?: string;
@@ -76,10 +79,9 @@ export function resolveReadTarget(
 }
 
 /**
- * Read a file from a realm. Returns raw text in `content` for text files;
- * returns raw bytes in `bytes` for binary files (PNG / PDF / font / etc.,
- * per `isBinaryFilename`). Callers should parse the content themselves
- * if needed (e.g. JSON).
+ * Read a file from a realm. Returns raw text in `content` when the realm
+ * serves a textual content type, and raw bytes in `bytes` otherwise.
+ * Callers should parse the content themselves if needed (e.g. JSON).
  *
  * Auth is resolved via `resolveRealmAuthenticator`: a realm secret seed (when
  * supplied) mints a JWT locally as the realm-server bot; otherwise the active
@@ -132,7 +134,17 @@ export async function read(
     };
   }
 
-  if (isBinaryFilename(path)) {
+  // The served content type describes the bytes that actually arrived, so it
+  // beats the requested path: the realm resolves extension fallbacks, and a
+  // card id (`Cards/my-card`) or a dotted name (`hello.test`) carries no
+  // usable extension of its own. Fall back to the path only when the response
+  // omits the header.
+  let servedContentType = response.headers.get('content-type');
+  let isBinary = servedContentType
+    ? isBinaryContentType(servedContentType)
+    : isBinaryFilename(path);
+
+  if (isBinary) {
     let bytes = new Uint8Array(await response.arrayBuffer());
     return { ok: true, status: response.status, bytes };
   }

--- a/packages/boxel-cli/src/commands/file/write.ts
+++ b/packages/boxel-cli/src/commands/file/write.ts
@@ -34,10 +34,11 @@ interface WriteCliOptions {
 /**
  * Write a file to a realm. Path should include the file extension.
  *
- * String content is sent with the card+source MIME type (the text path
- * .gts / .json / .md / etc. always took). Binary content (a `Uint8Array`,
- * including the `Buffer` subclass) is sent with `application/octet-stream`,
- * which the realm-server routes to `upsertBinaryFile` and writes verbatim.
+ * Content bound for a path that is textual by extension (.gts / .json / .md
+ * / etc.) is sent with the card+source MIME type. Everything else — raw
+ * `Uint8Array` content, and strings bound for a path that is not textual —
+ * is sent with `application/octet-stream`, which the realm-server routes to
+ * `upsertBinaryFile` and writes verbatim.
  *
  * Auth is resolved via `resolveRealmAuthenticator`: a realm secret seed (when
  * supplied) mints a JWT locally as the realm-server bot; otherwise the active
@@ -68,24 +69,32 @@ export async function write(
   let authenticator = resolution.authenticator;
 
   let url = new URL(path, ensureTrailingSlash(realmUrl)).href;
-  let isBinary = typeof content !== 'string';
+  let pathIsBinary = isBinaryFilename(path);
 
   // Defense-in-depth for programmatic callers (BoxelClient.write, tests).
   // The CLI wrapper has an earlier guard against `--file image.png` →
   // `notes.md` style misuse, but the library function is also reachable
-  // without going through that branch. Reject the mismatch here so raw
-  // bytes never land at a text extension (corrupt-on-read) and a UTF-8
-  // string never lands at a binary extension (corrupt-on-write).
-  let pathIsBinary = isBinaryFilename(path);
-  if (pathIsBinary !== isBinary) {
+  // without going through that branch. Raw bytes at a text extension are
+  // refused: the realm would serve them back as text and the UTF-8 decode
+  // would corrupt them.
+  if (typeof content !== 'string' && !pathIsBinary) {
     return {
       ok: false,
       error:
-        `Path ${path} is ${pathIsBinary ? 'binary' : 'text'} by extension ` +
-        `but content is ${isBinary ? 'bytes' : 'a string'}. ` +
+        `Path ${path} is text by extension but content is bytes. ` +
         `Refusing to write to avoid silent corruption.`,
     };
   }
+
+  // The mirror case is safe and stays allowed: a string bound for a path that
+  // is binary by extension (or has no extension at all) is UTF-8 encoded and
+  // sent down the byte path, which stores it verbatim. Encoding a string is
+  // lossless, so nothing is corrupted by taking this route.
+  let body: string | Uint8Array =
+    typeof content === 'string' && pathIsBinary
+      ? new TextEncoder().encode(content)
+      : content;
+  let isBinary = typeof body !== 'string';
 
   try {
     let response = await authenticator.authedRealmFetch(url, {
@@ -96,10 +105,10 @@ export async function write(
             Accept: SupportedMimeType.CardSource,
             'Content-Type': SupportedMimeType.CardSource,
           },
-      // Both branches of `content: string | Uint8Array` are valid
-      // BodyInit values, but TS narrows them as a union that doesn't
-      // unify against the fetch signature without a hint.
-      body: content as BodyInit,
+      // Both branches of `body: string | Uint8Array` are valid BodyInit
+      // values, but TS narrows them as a union that doesn't unify against
+      // the fetch signature without a hint.
+      body: body as BodyInit,
     });
 
     if (!response.ok) {
@@ -168,25 +177,25 @@ export function registerWriteCommand(parent: Command): void {
 
       let content: string | Uint8Array;
       if (opts.file) {
-        // Refuse a source/destination binary-classification mismatch
-        // (e.g., `write notes.md --file image.png`) — otherwise raw
-        // bytes would land at a text extension and corrupt-on-read.
+        // Refuse a binary source bound for a text destination (e.g.
+        // `write notes.md --file image.png`) — the realm would serve those
+        // bytes back as text and the UTF-8 decode would corrupt them. The
+        // mirror case (a text source at a binary destination) is lossless,
+        // so it is allowed and rides the byte path.
         const srcIsBinary = isBinaryFilename(opts.file);
         const dstIsBinary = isBinaryFilename(filePath);
-        if (srcIsBinary !== dstIsBinary) {
+        if (srcIsBinary && !dstIsBinary) {
           stderr(
-            `${FG_RED}Error:${RESET} source file ${opts.file} is ${
-              srcIsBinary ? 'binary' : 'text'
-            } but destination path ${filePath} is ${
-              dstIsBinary ? 'binary' : 'text'
-            }. Refusing to write to avoid silent corruption — rename the destination to match.`,
+            `${FG_RED}Error:${RESET} source file ${opts.file} is binary but ` +
+              `destination path ${filePath} is text. Refusing to write to ` +
+              `avoid silent corruption — rename the destination to match.`,
           );
           process.exit(1);
         }
         try {
           // Binary source files are read as raw bytes so write() can
           // hand them to the realm unchanged; forcing utf-8 would
-          // corrupt PNG / PDF / font / etc. payloads silently.
+          // corrupt their payloads silently.
           content = srcIsBinary
             ? readFileSync(opts.file)
             : readFileSync(opts.file, 'utf-8');

--- a/packages/boxel-cli/src/lib/realm-sync-base.ts
+++ b/packages/boxel-cli/src/lib/realm-sync-base.ts
@@ -3,7 +3,10 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import ignoreModule from 'ignore';
 import pLimit from 'p-limit';
-import { isBinaryFilename } from '@cardstack/runtime-common/infer-content-type';
+import {
+  isBinaryContentType,
+  isBinaryFilename,
+} from '@cardstack/runtime-common/infer-content-type';
 
 const ignore = (ignoreModule as any).default || ignoreModule;
 type Ignore = ReturnType<typeof ignoreModule>;
@@ -455,7 +458,7 @@ export abstract class RealmSyncBase {
     console.log(`  Uploaded: ${relativePath}`);
   }
 
-  // Uploads a single binary file (PNG, PDF, font, etc.) per the host
+  // Uploads a single binary file per the host
   // pattern: a per-file POST with Content-Type: application/octet-stream
   // and the raw bytes as the body. The realm-server routes octet-stream
   // POSTs to upsertBinaryFile, which writes the bytes verbatim without
@@ -763,7 +766,15 @@ export abstract class RealmSyncBase {
     const localDir = path.dirname(localPath);
     await fs.mkdir(localDir, { recursive: true });
 
-    if (isBinaryFilename(relativePath)) {
+    // Classify by what the realm served rather than by the requested name, so
+    // this agrees with `file read` on paths whose extension is absent or does
+    // not describe the bytes. Falls back to the name when the header is absent.
+    const servedContentType = response.headers.get('content-type');
+    const isBinary = servedContentType
+      ? isBinaryContentType(servedContentType)
+      : isBinaryFilename(relativePath);
+
+    if (isBinary) {
       const buffer = Buffer.from(await response.arrayBuffer());
       await fs.writeFile(localPath, buffer);
     } else {

--- a/packages/boxel-cli/tests/helpers/binary-fixtures.ts
+++ b/packages/boxel-cli/tests/helpers/binary-fixtures.ts
@@ -23,6 +23,17 @@ export const TINY_PDF_BYTES = new Uint8Array([
   0x0a, 0x25, 0x25, 0x45, 0x4f, 0x46, 0x0a,
 ]);
 
+// Byte blob built from sequences that are invalid UTF-8: nulls, 0xFF/0xFE,
+// a lone continuation byte (0x80), an overlong encoding (0xC0 0x80), and a
+// truncated multi-byte sequence (0xE0 0x28). Extension — not payload
+// validity — drives binary classification, so this one blob stands in for
+// any format (.zip, .bin, .mp4, extensionless) whose byte-for-byte
+// round-trip fidelity is under test.
+export const NON_UTF8_BYTES = new Uint8Array([
+  0x50, 0x4b, 0x03, 0x04, 0x00, 0x00, 0xff, 0xfe, 0x80, 0xc0, 0x80, 0xe0, 0x28,
+  0x00, 0xff, 0x00, 0x9f, 0x92, 0x96, 0xff, 0xd8, 0xff, 0xe0, 0x00,
+]);
+
 // Tiny MP3-shaped byte blob: ID3v2.4 tag header (`ID3 04 00 …`) followed
 // by an MPEG-1 Layer III frame sync (`FF FB …`). Like `TINY_PDF_BYTES`,
 // the realm-server treats `.mp3` as binary purely based on the

--- a/packages/boxel-cli/tests/integration/file-read.test.ts
+++ b/packages/boxel-cli/tests/integration/file-read.test.ts
@@ -211,6 +211,47 @@ describe('file read (integration)', () => {
     expect(bytes.equals(Buffer.from(NON_UTF8_BYTES))).toBe(true);
   });
 
+  it('reads a card by its extensionless id as text, not bytes', async () => {
+    // Card ids carry no extension — the realm resolves `test-card` to
+    // `test-card.json` and serves it as JSON. Classifying by the requested
+    // name would call it binary and hand back base64, so this pins that the
+    // served content type is what decides.
+    let res = await runBoxel(
+      ['file', 'read', 'test-card', '--realm', realmUrl, '--json'],
+      { home },
+    );
+    let result = res.json<ReadJson>();
+
+    expect(result.ok, `read failed: ${JSON.stringify(result)}`).toBe(true);
+    expect(result.bytesBase64).toBeUndefined();
+    expect(result.content).toBeTruthy();
+    expect(JSON.parse(result.content!)).toHaveProperty('data');
+  });
+
+  it('reads a module by a dotted extensionless name as text', async () => {
+    // `hello.test` resolves through the executable-extension fallback to
+    // `hello.test.gts`; `.test` is not a textual extension on its own.
+    let seed = await reloadProfile(home).authedRealmFetch(
+      `${realmUrl}hello.test.gts`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/vnd.card+source' },
+        body: 'export const hello = "world";\n',
+      },
+    );
+    expect(seed.ok, `seed POST failed: ${seed.status}`).toBe(true);
+
+    let res = await runBoxel(
+      ['file', 'read', 'hello.test', '--realm', realmUrl, '--json'],
+      { home },
+    );
+    let result = res.json<ReadJson>();
+
+    expect(result.ok, `read failed: ${JSON.stringify(result)}`).toBe(true);
+    expect(result.bytesBase64).toBeUndefined();
+    expect(result.content).toContain('hello');
+  });
+
   it('returns error result when no active profile', async () => {
     let emptyHome = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     try {

--- a/packages/boxel-cli/tests/integration/file-read.test.ts
+++ b/packages/boxel-cli/tests/integration/file-read.test.ts
@@ -12,7 +12,7 @@ import {
   TEST_REALM_SERVER_URL,
 } from '../helpers/integration.ts';
 import { runBoxel } from '../helpers/run-boxel.ts';
-import { TINY_PNG_BYTES } from '../helpers/binary-fixtures.ts';
+import { TINY_PNG_BYTES, NON_UTF8_BYTES } from '../helpers/binary-fixtures.ts';
 
 // `boxel file read <path> [--realm <url>] --json` prints
 // `{ ok, status, error?, content?, bytesBase64? }` on stdout. We drive the
@@ -185,6 +185,30 @@ describe('file read (integration)', () => {
     expect(result.bytesBase64).toBeDefined();
     let bytes = Buffer.from(result.bytesBase64!, 'base64');
     expect(bytes.equals(Buffer.from(TINY_PNG_BYTES))).toBe(true);
+  });
+
+  it('reads a .zip byte-identically (returns bytes, not content)', async () => {
+    // application/zip is not a media MIME type, so this pins that binary
+    // classification doesn't hinge on being one — a text-path read would
+    // UTF-8-decode the payload and mangle its invalid sequences into U+FFFD.
+    let zipUrl = `${realmUrl}archive.zip`;
+    let seed = await reloadProfile(home).authedRealmFetch(zipUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: NON_UTF8_BYTES,
+    });
+    expect(seed.ok, `seed POST failed: ${seed.status}`).toBe(true);
+
+    let res = await runBoxel(
+      ['file', 'read', 'archive.zip', '--realm', realmUrl, '--json'],
+      { home },
+    );
+    let result = res.json<ReadJson>();
+    expect(result.ok).toBe(true);
+    expect(result.content).toBeUndefined();
+    expect(result.bytesBase64).toBeDefined();
+    let bytes = Buffer.from(result.bytesBase64!, 'base64');
+    expect(bytes.equals(Buffer.from(NON_UTF8_BYTES))).toBe(true);
   });
 
   it('returns error result when no active profile', async () => {

--- a/packages/boxel-cli/tests/integration/file-read.test.ts
+++ b/packages/boxel-cli/tests/integration/file-read.test.ts
@@ -188,9 +188,9 @@ describe('file read (integration)', () => {
   });
 
   it('reads a .zip byte-identically (returns bytes, not content)', async () => {
-    // application/zip is not a media MIME type, so this pins that binary
-    // classification doesn't hinge on being one — a text-path read would
-    // UTF-8-decode the payload and mangle its invalid sequences into U+FFFD.
+    // A text-path read would UTF-8-decode the payload and mangle its invalid
+    // sequences into U+FFFD, so recovering the bytes intact is the proof that
+    // application/zip is read as bytes.
     let zipUrl = `${realmUrl}archive.zip`;
     let seed = await reloadProfile(home).authedRealmFetch(zipUrl, {
       method: 'POST',

--- a/packages/boxel-cli/tests/integration/file-write.test.ts
+++ b/packages/boxel-cli/tests/integration/file-write.test.ts
@@ -12,7 +12,11 @@ import {
   createTestRealmViaCli,
 } from '../helpers/integration.ts';
 import { runBoxel } from '../helpers/run-boxel.ts';
-import { TINY_PNG_BYTES, TINY_PDF_BYTES } from '../helpers/binary-fixtures.ts';
+import {
+  TINY_PNG_BYTES,
+  TINY_PDF_BYTES,
+  NON_UTF8_BYTES,
+} from '../helpers/binary-fixtures.ts';
 
 // `boxel file write <path> --realm <url>` reads content from STDIN (text)
 // or `--file <local>` (binary). We drive the installed binary and verify
@@ -124,6 +128,47 @@ describe('file write (integration)', () => {
     let response = await readBack('doc.pdf');
     let remote = Buffer.from(await response.arrayBuffer());
     expect(remote.equals(Buffer.from(TINY_PDF_BYTES))).toBe(true);
+  });
+
+  it('writes a .bin file byte-identically', async () => {
+    // .bin maps to application/octet-stream, the default for unknown
+    // extensions — the payload's invalid UTF-8 sequences survive only if
+    // that classification routes the upload through the binary path.
+    let src = path.join(os.tmpdir(), `boxel-write-${Date.now()}.bin`);
+    fs.writeFileSync(src, Buffer.from(NON_UTF8_BYTES));
+    try {
+      let res = await runBoxel(
+        ['file', 'write', 'blob.bin', '--realm', realmUrl, '--file', src],
+        { home },
+      );
+      expect(res.ok, res.stderr).toBe(true);
+    } finally {
+      fs.rmSync(src, { force: true });
+    }
+
+    let response = await readBack('blob.bin');
+    expect(response.ok).toBe(true);
+    let remote = Buffer.from(await response.arrayBuffer());
+    expect(remote.equals(Buffer.from(NON_UTF8_BYTES))).toBe(true);
+  });
+
+  it('writes a .zip file byte-identically', async () => {
+    let src = path.join(os.tmpdir(), `boxel-write-${Date.now()}.zip`);
+    fs.writeFileSync(src, Buffer.from(NON_UTF8_BYTES));
+    try {
+      let res = await runBoxel(
+        ['file', 'write', 'archive.zip', '--realm', realmUrl, '--file', src],
+        { home },
+      );
+      expect(res.ok, res.stderr).toBe(true);
+    } finally {
+      fs.rmSync(src, { force: true });
+    }
+
+    let response = await readBack('archive.zip');
+    expect(response.ok).toBe(true);
+    let remote = Buffer.from(await response.arrayBuffer());
+    expect(remote.equals(Buffer.from(NON_UTF8_BYTES))).toBe(true);
   });
 
   it('exits non-zero with a clear error when there is no active profile', async () => {

--- a/packages/boxel-cli/tests/integration/file-write.test.ts
+++ b/packages/boxel-cli/tests/integration/file-write.test.ts
@@ -171,6 +171,40 @@ describe('file write (integration)', () => {
     expect(remote.equals(Buffer.from(NON_UTF8_BYTES))).toBe(true);
   });
 
+  it('writes string content from STDIN to a non-textual path', async () => {
+    // STDIN can only produce a string, so refusing string content at a path
+    // that is binary by extension would make such paths unwritable. The
+    // string is UTF-8 encoded onto the byte path instead, which is lossless.
+    let script = '#!/usr/bin/env python3\nprint("hi")\n';
+    let res = await runBoxel(
+      ['file', 'write', 'scripts/hello.py', '--realm', realmUrl],
+      { home, input: script },
+    );
+    expect(res.ok, res.stderr).toBe(true);
+
+    let response = await readBack('scripts/hello.py');
+    expect(response.ok).toBe(true);
+    let remote = Buffer.from(await response.arrayBuffer());
+    expect(remote.toString('utf8')).toBe(script);
+  });
+
+  it('refuses binary source content at a text destination', async () => {
+    // The destructive direction stays blocked: raw bytes at a text extension
+    // would be served back as text and mangled by the UTF-8 decode.
+    let src = path.join(os.tmpdir(), `boxel-write-${Date.now()}-guard.png`);
+    fs.writeFileSync(src, Buffer.from(TINY_PNG_BYTES));
+    try {
+      let res = await runBoxel(
+        ['file', 'write', 'notes.md', '--realm', realmUrl, '--file', src],
+        { home },
+      );
+      expect(res.exitCode).toBe(1);
+      expect(res.stderr).toContain('Refusing to write');
+    } finally {
+      fs.rmSync(src, { force: true });
+    }
+  });
+
   it('exits non-zero with a clear error when there is no active profile', async () => {
     let emptyHome = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-empty-'));
     try {

--- a/packages/boxel-cli/tests/integration/realm-push.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-push.test.ts
@@ -18,6 +18,7 @@ import {
   TINY_PNG_BYTES,
   TINY_PDF_BYTES,
   TINY_MP3_BYTES,
+  NON_UTF8_BYTES,
 } from '../helpers/binary-fixtures.ts';
 
 // `boxel realm push <local-dir> <realm-url>` is driven as a subprocess. The
@@ -809,6 +810,45 @@ describe('realm push (integration)', () => {
       'doc.pdf',
       'image.png',
     ]);
+  });
+
+  it('pushes .zip, .bin, and .mp4 files byte-identically', async () => {
+    // None of these MIME types (application/zip, application/octet-stream,
+    // video/mp4) are media types, so this pins that binary classification
+    // doesn't hinge on being one — a text-pipeline round-trip would replace
+    // the payload's invalid UTF-8 sequences with U+FFFD.
+    let realmUrl = await createTestRealm();
+    let localDir = makeLocalDir();
+
+    writeLocalBytes(localDir, 'archive.zip', NON_UTF8_BYTES);
+    writeLocalBytes(localDir, 'blob.bin', NON_UTF8_BYTES);
+    writeLocalBytes(localDir, 'clip.mp4', NON_UTF8_BYTES);
+
+    let res = await runPush(localDir, realmUrl);
+    expect(res.ok, res.stderr).toBe(true);
+
+    for (let relPath of ['archive.zip', 'blob.bin', 'clip.mp4']) {
+      let remote = await fetchRemoteBytes(realmUrl, relPath);
+      expect(
+        remote.equals(Buffer.from(NON_UTF8_BYTES)),
+        `${relPath} should round-trip byte-identically`,
+      ).toBe(true);
+    }
+  });
+
+  it('pushes an extensionless file byte-identically via the binary path', async () => {
+    // No extension means no MIME mapping, which defaults to
+    // application/octet-stream — the binary side of the classification.
+    let realmUrl = await createTestRealm();
+    let localDir = makeLocalDir();
+
+    writeLocalBytes(localDir, 'LICENSE', NON_UTF8_BYTES);
+
+    let res = await runPush(localDir, realmUrl);
+    expect(res.ok, res.stderr).toBe(true);
+
+    let remote = await fetchRemoteBytes(realmUrl, 'LICENSE');
+    expect(remote.equals(Buffer.from(NON_UTF8_BYTES))).toBe(true);
   });
 
   it('treats SVG as text — round-trips through /_atomic without corruption', async () => {

--- a/packages/boxel-cli/tests/integration/realm-push.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-push.test.ts
@@ -813,10 +813,11 @@ describe('realm push (integration)', () => {
   });
 
   it('pushes .zip, .bin, and .mp4 files byte-identically', async () => {
-    // None of these MIME types (application/zip, application/octet-stream,
-    // video/mp4) are media types, so this pins that binary classification
-    // doesn't hinge on being one — a text-pipeline round-trip would replace
-    // the payload's invalid UTF-8 sequences with U+FFFD.
+    // These three span the range that has to reach the byte path: an archive
+    // type, a video type, and application/octet-stream — the type unknown
+    // extensions resolve to. A text-pipeline round-trip would replace the
+    // payload's invalid UTF-8 sequences with U+FFFD, so recovering the bytes
+    // intact is the proof that each one stayed on the byte path.
     let realmUrl = await createTestRealm();
     let localDir = makeLocalDir();
 

--- a/packages/boxel-cli/tests/lib/binary-filename.test.ts
+++ b/packages/boxel-cli/tests/lib/binary-filename.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { isBinaryFilename } from '@cardstack/runtime-common/infer-content-type';
+
+// `isBinaryFilename` decides which wire format the CLI uses: binary paths
+// move raw bytes (octet-stream upload, arrayBuffer download) while text
+// paths UTF-8-decode, replacing invalid sequences with U+FFFD. Classifying
+// text as binary still preserves bytes; classifying binary as text corrupts
+// them — so anything not affirmatively textual must land on the binary side.
+describe('isBinaryFilename', () => {
+  const binary = [
+    // media / fonts / documents
+    'photo.jpg',
+    'image.png',
+    'anim.gif',
+    'font.woff2',
+    'legacy-font.eot',
+    'doc.pdf',
+    'sound.mp3',
+    'sound.wav',
+    // container / video / archive formats
+    'archive.zip',
+    'blob.bin',
+    'video.mp4',
+    'video.mov',
+    'video.webm',
+    'bundle.tar',
+    'bundle.gz',
+    'module.wasm',
+    'report.docx',
+    // unknown or missing extensions default to application/octet-stream
+    'LICENSE',
+    'Dockerfile',
+    'data.unknownext',
+  ];
+
+  const text = [
+    // text/* (including the .gts/.ts content-type overrides)
+    'card.gts',
+    'card.ts',
+    'notes.md',
+    'style.css',
+    'page.html',
+    'plain.txt',
+    'data.csv',
+    'config.yaml',
+    // structured-syntax suffixes (+json / +xml)
+    'icon.svg',
+    'app.webmanifest',
+    // textual application/* types
+    'instance.json',
+    'bundle.map',
+    'script.js',
+    'script.mjs',
+    'script.cjs',
+    'feed.xml',
+    'setup.sh',
+    'schema.sql',
+    'settings.toml',
+  ];
+
+  for (let filename of binary) {
+    it(`classifies ${filename} as binary`, () => {
+      expect(isBinaryFilename(filename)).toBe(true);
+    });
+  }
+
+  for (let filename of text) {
+    it(`classifies ${filename} as text`, () => {
+      expect(isBinaryFilename(filename)).toBe(false);
+    });
+  }
+});

--- a/packages/boxel-cli/tests/lib/binary-filename.test.ts
+++ b/packages/boxel-cli/tests/lib/binary-filename.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { isBinaryFilename } from '@cardstack/runtime-common/infer-content-type';
+import {
+  isBinaryContentType,
+  isBinaryFilename,
+} from '@cardstack/runtime-common/infer-content-type';
 
 // `isBinaryFilename` decides which wire format the CLI uses: binary paths
 // move raw bytes (octet-stream upload, arrayBuffer download) while text
@@ -34,9 +37,14 @@ describe('isBinaryFilename', () => {
   ];
 
   const text = [
-    // text/* (including the .gts/.ts content-type overrides)
+    // text/* (including the .gts/.gjs/.ts content-type overrides). The
+    // overrides matter: mime-types maps none of these three to a textual
+    // type on its own — .ts resolves to video/mp2t, and .gts/.gjs to
+    // nothing at all — yet all three are card module source.
     'card.gts',
+    'card.gjs',
     'card.ts',
+    'types.d.ts',
     'notes.md',
     'style.css',
     'page.html',
@@ -69,4 +77,58 @@ describe('isBinaryFilename', () => {
       expect(isBinaryFilename(filename)).toBe(false);
     });
   }
+});
+
+// Callers holding a response classify on the served content type instead of
+// the requested name, so the two entry points must agree on the same
+// taxonomy — and the content-type form has to tolerate header syntax.
+describe('isBinaryContentType', () => {
+  it('ignores content-type parameters', () => {
+    expect(isBinaryContentType('text/plain; charset=utf-8')).toBe(false);
+    expect(isBinaryContentType('application/json;charset=UTF-8')).toBe(false);
+    expect(isBinaryContentType('application/octet-stream; name=x')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isBinaryContentType('TEXT/PLAIN')).toBe(false);
+    expect(isBinaryContentType('Application/JSON')).toBe(false);
+  });
+
+  it('classifies every textual mime type the platform speaks as text', () => {
+    // A card id resolves to its .json source, and module source is served
+    // under the glimmer/typescript types. The vnd.card vendor types are
+    // textual too, so no surface that echoes one can trip the byte path.
+    expect(isBinaryContentType('application/json')).toBe(false);
+    expect(isBinaryContentType('text/typescript+glimmer')).toBe(false);
+    expect(isBinaryContentType('text/javascript+glimmer')).toBe(false);
+    expect(isBinaryContentType('application/vnd.card+json')).toBe(false);
+    expect(isBinaryContentType('application/vnd.card+source')).toBe(false);
+    expect(isBinaryContentType('application/vnd.card+html')).toBe(false);
+    expect(isBinaryContentType('application/vnd.card.file-meta+json')).toBe(
+      false,
+    );
+    expect(isBinaryContentType('application/vnd.api+json')).toBe(false);
+  });
+
+  it('treats unrecognized and media types as binary', () => {
+    expect(isBinaryContentType('application/octet-stream')).toBe(true);
+    expect(isBinaryContentType('application/zip')).toBe(true);
+    expect(isBinaryContentType('video/mp4')).toBe(true);
+    expect(isBinaryContentType('image/png')).toBe(true);
+    expect(isBinaryContentType('application/x-newly-invented')).toBe(true);
+  });
+
+  it('accepts both mime-db spellings of sql and yaml', () => {
+    // These types are spelled differently across mime-db releases; a lookup
+    // resolving to either spelling must land on the text side.
+    for (let type of [
+      'application/sql',
+      'application/x-sql',
+      'application/yaml',
+      'application/x-yaml',
+      'text/yaml',
+    ]) {
+      expect(isBinaryContentType(type), `${type} should be text`).toBe(false);
+    }
+  });
 });

--- a/packages/boxel-cli/tests/lib/binary-filename.test.ts
+++ b/packages/boxel-cli/tests/lib/binary-filename.test.ts
@@ -110,7 +110,7 @@ describe('isBinaryContentType', () => {
     expect(isBinaryContentType('application/vnd.api+json')).toBe(false);
   });
 
-  it('treats unrecognized and media types as binary', () => {
+  it('treats unrecognized, archive, and audiovisual types as binary', () => {
     expect(isBinaryContentType('application/octet-stream')).toBe(true);
     expect(isBinaryContentType('application/zip')).toBe(true);
     expect(isBinaryContentType('video/mp4')).toBe(true);

--- a/packages/runtime-common/infer-content-type.ts
+++ b/packages/runtime-common/infer-content-type.ts
@@ -3,6 +3,7 @@ import { lookup as lookupMimeType } from 'mime-types';
 const DEFAULT_FILE_CONTENT_TYPE = 'application/octet-stream';
 const CONTENT_TYPE_OVERRIDES: Record<string, string> = {
   '.gts': 'text/typescript+glimmer',
+  '.gjs': 'text/javascript+glimmer',
   '.ts': 'text/typescript',
 };
 
@@ -21,7 +22,10 @@ export function inferContentType(filename: string): string {
 }
 
 // Textual application/* MIME types that carry neither a text/ prefix nor a
-// +json / +xml structured-syntax suffix.
+// +json / +xml structured-syntax suffix. Some formats are spelled differently
+// across mime-db releases (.sql is application/x-sql in mime-db 1.52 and the
+// IANA-registered application/sql in 1.54), so both spellings are listed:
+// a lookup that resolves to either must land on the same side.
 const TEXTUAL_APPLICATION_TYPES = new Set([
   'application/json',
   'application/javascript', // .js, .mjs
@@ -29,25 +33,43 @@ const TEXTUAL_APPLICATION_TYPES = new Set([
   'application/node', // .cjs
   'application/xml',
   'application/x-sh',
+  'application/sql',
   'application/x-sql',
+  'application/yaml',
+  'application/x-yaml',
   'application/toml',
 ]);
 
-// A filename is binary unless its MIME type is known to be textual. Unknown
-// extensions resolve to application/octet-stream and therefore land on the
+const TEXTUAL_SUFFIXES = ['+json', '+xml', '+html', '+source'];
+
+// A content type is binary unless it is known to be textual. Anything
+// unrecognized resolves to application/octet-stream and therefore lands on the
 // binary side, which is the byte-preserving default: binary handling moves
 // bytes verbatim, while text handling UTF-8-decodes content and replaces
 // invalid sequences with U+FFFD. Misclassifying text as binary keeps the
 // bytes intact; misclassifying binary as text corrupts them.
-export function isBinaryFilename(filename: string): boolean {
-  let mimeType = inferContentType(filename);
+export function isBinaryContentType(contentType: string): boolean {
+  // Strip any parameters (e.g. `text/plain; charset=utf-8`) so a header value
+  // classifies the same as the bare type.
+  let mimeType = contentType.split(';')[0].trim().toLowerCase();
   if (mimeType.startsWith('text/')) {
     return false;
   }
-  // Structured-syntax suffixes mark XML/JSON-based formats that happen to
-  // live under other top-level types, e.g. image/svg+xml.
-  if (mimeType.endsWith('+json') || mimeType.endsWith('+xml')) {
+  // Structured-syntax suffixes mark text-based formats that happen to live
+  // under other top-level types: image/svg+xml is XML, and the platform's own
+  // vendor types (application/vnd.card+source, application/vnd.card+html)
+  // carry card source and rendered markup.
+  if (TEXTUAL_SUFFIXES.some((suffix) => mimeType.endsWith(suffix))) {
     return false;
   }
   return !TEXTUAL_APPLICATION_TYPES.has(mimeType);
+}
+
+// Classify by filename. Callers holding a response should prefer
+// `isBinaryContentType` with the served content type: the realm resolves
+// extension fallbacks (a card id like `Cards/my-card` is served from
+// `Cards/my-card.json`), so the served type describes the bytes that actually
+// arrived while the requested name may carry no extension at all.
+export function isBinaryFilename(filename: string): boolean {
+  return isBinaryContentType(inferContentType(filename));
 }

--- a/packages/runtime-common/infer-content-type.ts
+++ b/packages/runtime-common/infer-content-type.ts
@@ -20,15 +20,34 @@ export function inferContentType(filename: string): string {
   return mimeType ? mimeType : DEFAULT_FILE_CONTENT_TYPE;
 }
 
+// Textual application/* MIME types that carry neither a text/ prefix nor a
+// +json / +xml structured-syntax suffix.
+const TEXTUAL_APPLICATION_TYPES = new Set([
+  'application/json',
+  'application/javascript', // .js, .mjs
+  'application/ecmascript',
+  'application/node', // .cjs
+  'application/xml',
+  'application/x-sh',
+  'application/x-sql',
+  'application/toml',
+]);
+
+// A filename is binary unless its MIME type is known to be textual. Unknown
+// extensions resolve to application/octet-stream and therefore land on the
+// binary side, which is the byte-preserving default: binary handling moves
+// bytes verbatim, while text handling UTF-8-decodes content and replaces
+// invalid sequences with U+FFFD. Misclassifying text as binary keeps the
+// bytes intact; misclassifying binary as text corrupts them.
 export function isBinaryFilename(filename: string): boolean {
   let mimeType = inferContentType(filename);
-  // SVG is image/* but is XML-based text
-  if (mimeType === 'image/svg+xml') return false;
-  return (
-    mimeType.startsWith('image/') ||
-    mimeType.startsWith('font/') ||
-    mimeType.startsWith('audio/') ||
-    mimeType === 'application/pdf' ||
-    mimeType === 'application/vnd.ms-fontobject' // .eot legacy font
-  );
+  if (mimeType.startsWith('text/')) {
+    return false;
+  }
+  // Structured-syntax suffixes mark XML/JSON-based formats that happen to
+  // live under other top-level types, e.g. image/svg+xml.
+  if (mimeType.endsWith('+json') || mimeType.endsWith('+xml')) {
+    return false;
+  }
+  return !TEXTUAL_APPLICATION_TYPES.has(mimeType);
 }


### PR DESCRIPTION
`boxel file write`, `boxel file read`, and `boxel realm push`/`pull` choose between a byte-verbatim pipeline and a UTF-8 string pipeline. That choice was driven by a media allowlist in `isBinaryFilename` (`image/*`, `font/*`, `audio/*`, PDF, EOT), so `application/zip`, `video/mp4`, and even `application/octet-stream` itself — the MIME default for `.bin` and for any unknown extension — fell through to the text pipeline, which UTF-8-decodes content and replaces invalid byte sequences with U+FFFD. A `.zip` / `.bin` / `.mp4` upload landed corrupted with its size inflated 1.4–1.8×, the command reported success, and a read-back "verification" applied the same mangling on the way down and confirmed the corrupt bytes.

## What decides text vs. binary

Two predicates now share one taxonomy in `runtime-common/infer-content-type.ts`:

- `isBinaryContentType(contentType)` — a content type is text only when it is affirmatively textual: a `text/*` type, a textual structured-syntax suffix (`+json`, `+xml`, `+html`, `+source`, which covers SVG, web manifests, and the platform's own `application/vnd.card+*` types), or one of a small set of textual `application/*` types. Everything else, including the octet-stream default, is binary. Header parameters and case are normalized, so a raw `Content-Type` value classifies the same as a bare type.
- `isBinaryFilename(name)` — the same predicate applied to `inferContentType(name)`.

This direction is safe by construction: the binary pipeline moves bytes verbatim, so a text file misclassified as binary still round-trips intact, while the reverse destroys data. Unknown types therefore default to binary.

**Reads classify on the served content type, not the requested name.** The realm resolves extension fallbacks — a card id (`Cards/my-card`) is served from `Cards/my-card.json`, and a dotted module name (`hello.test`) from `hello.test.gts` — so the requested path frequently carries no usable extension while the response always describes the bytes that actually arrived. `file read` and `realm pull` both consult the response and fall back to the filename only when the header is absent. Writes keep using the filename, since there is no response to consult and guessing wrong is the destructive direction.

**`.gjs` joins `.gts` and `.ts` in `CONTENT_TYPE_OVERRIDES`.** mime-types maps none of the three to a textual type on its own (`.ts` resolves to `video/mp2t`; `.gts` and `.gjs` to nothing), yet all three are card module source. `.gjs` previously had no override and so was served and indexed as `application/octet-stream`.

**`.sql` and `.yaml` are listed under both of their mime-db spellings.** mime-db renamed `application/x-sql` to the IANA-registered `application/sql` between 1.52 and 1.54, and the repo currently resolves both majors; a lookup landing on either spelling must classify the same.

## Write-side guard

Raw bytes bound for a textual path are still refused — the realm would serve them back as text and the decode would corrupt them. The mirror case is now allowed rather than refused: a string bound for a path that is binary by extension (or has no extension) is UTF-8 encoded onto the byte path, which is lossless. Since STDIN can only produce a string, refusing it would otherwise leave such paths unwritable.

## Scope

The realm server needs no change and got none: octet-stream request bodies are buffered without decoding and routed to `upsertBinaryFile`, which writes them verbatim, and reads of non-JSON, non-executable paths stream straight from disk. The host does not use these predicates — it detects binary content after download by looking for U+FFFD in the decoded text. bot-runner consults `isBinaryFilename` only as a fallback when a collected file carries no `isBinary` flag.

One consequence worth calling out: extensionless files and unrecognized extensions now ride the binary path. They round-trip byte-identically, but `file read --json` reports them as `bytesBase64` rather than `content`, and `realm push` sends them as per-file octet-stream POSTs instead of batching them into `/_atomic`. Teaching `inferContentType` about specific unmapped-but-textual extensions (`.py` and friends) would move them back to the text side in both the CLI and the server at once; that is deliberately not part of this change.

## Tests

A classification table pinning both predicates across the text/binary boundary — including the override-dependent module extensions and every textual MIME type the platform speaks — plus integration coverage that `.zip`, `.bin`, `.mp4`, and extensionless files survive `realm push`, `file write --file`, and `file read` byte-identically, that a card read by its extensionless id and a module read by a dotted name come back as text, that string content from STDIN lands at a non-textual path, and that a binary source at a text destination is still refused.
