### PR TITLE
Isolate the custom-subdomain publish test's retries with a unique subdomain

### DIFF
--- a/packages/matrix/tests/publish-realm.spec.ts
+++ b/packages/matrix/tests/publish-realm.spec.ts
@@ -113,6 +113,16 @@ test.describe('Publish realm', () => {
   }) => {
     await openPublishRealmModal(page);
 
+    // Use a unique subdomain per attempt. The claim persists on the
+    // realm-server, and a partial first attempt leaves a fixed name already
+    // taken, so every Playwright retry in the same run would then fail the
+    // "no error message" assertion on re-claim. A fresh name each attempt
+    // keeps retries isolated (CS-12428). The extra hyphens keep it clear of
+    // the single-hyphen reserved patterns, and it stays well under 63 chars.
+    let subdomain = `acceptable-subdomain-${Date.now().toString(36)}${Math.random()
+      .toString(36)
+      .slice(2, 6)}`;
+
     await page.locator('[data-test-custom-subdomain-setup-button]').click();
 
     let customSubdomainInput = page.locator(
@@ -128,7 +138,7 @@ test.describe('Publish realm', () => {
       page.locator('[data-test-boxel-input-group-error-message]'),
     ).toHaveText('Punycode domains are not allowed for security reasons');
 
-    await customSubdomainField.fill('acceptable-subdomain');
+    await customSubdomainField.fill(subdomain);
     await claimButton.click();
 
     await expect(
@@ -155,12 +165,10 @@ test.describe('Publish realm', () => {
     let newTab = await newTabPromise;
     await newTab.waitForLoadState();
 
-    await expect(newTab).toHaveURL(
-      'https://acceptable-subdomain.localhost:4205/',
-    );
+    await expect(newTab).toHaveURL(`https://${subdomain}.localhost:4205/`);
     await expect(
       newTab.locator(
-        '[data-test-card="https://acceptable-subdomain.localhost:4205/index"]',
+        `[data-test-card="https://${subdomain}.localhost:4205/index"]`,
       ),
     ).toBeVisible();
     await newTab.close();


### PR DESCRIPTION
## Summary

Fixes the flaky `Publish realm › it validates, claims, and publishes to a custom subdomain` test (`packages/matrix/tests/publish-realm.spec.ts`).

The test claimed a **fixed** subdomain (`acceptable-subdomain`). The claim persists on the realm-server, so a partial first attempt — e.g. one that got through the claim and then timed out at the popup wait under prerender pressure — left the name already taken. Every Playwright retry in the same run then failed the `toHaveCount(0)` "no error message" assertion on re-claim. Once the first attempt leaked that state, no retry could pass: the test poisoned its own retries.

## Fix

Mint a **unique subdomain per attempt** so retries (and parallel workers) can never collide:

```ts
let subdomain = `acceptable-subdomain-${Date.now().toString(36)}${Math.random()
  .toString(36)
  .slice(2, 6)}`;
```

Each retry re-runs the test body and gets a fresh name, so a leaked claim from a prior attempt is irrelevant. Downstream URL assertions interpolate the generated name.

This was the first of the three options in CS-12428; it's the most robust (no teardown to maintain, safe under parallelism) and needs no server-side change.

## Why the generated name stays valid

Checked against `packages/realm-server/lib/user-subdomain-validation.ts`:

- only `[a-z0-9-]` (base-36 output) ✓
- doesn't start/end with a hyphen ✓
- ~35 chars, within 2–63 ✓
- multiple hyphens, so it can't match a single-hyphen reserved pattern (e.g. `^[a-z]+-\d+$`) ✓

## Testing

`prettier --check` and `eslint` pass. Not run against the full matrix e2e stack locally — it's a test-only isolation change, the generated name is verified valid, and `*.localhost` wildcard resolution is identical to the existing (passing) `acceptable-subdomain.localhost:4205` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)