### PR TITLE
host: Add test caching for `host-submode` and `card-copy`

### DIFF
--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -227,13 +227,9 @@ module('Acceptance | host submode', function (hooks) {
 
   module('with a dangling host routing rule', function (hooks) {
     // Each snapshot this module's tests create stays attached until it is
-
     // deleted, and SQLite caps attached databases per connection. The prefix is
-
     // derived from the running module's name, and nested modules have distinct
-
     // names, so every scope that runs tests registers its own teardown.
-
     setupRealmCacheTeardown(hooks);
 
     hooks.beforeEach(async function () {
@@ -309,13 +305,9 @@ module('Acceptance | host submode', function (hooks) {
 
   module('with a realm that is not publishable', function (hooks) {
     // Each snapshot this module's tests create stays attached until it is
-
     // deleted, and SQLite caps attached databases per connection. The prefix is
-
     // derived from the running module's name, and nested modules have distinct
-
     // names, so every scope that runs tests registers its own teardown.
-
     setupRealmCacheTeardown(hooks);
 
     hooks.beforeEach(async function () {
@@ -362,13 +354,9 @@ module('Acceptance | host submode', function (hooks) {
 
   module('with a realm that is publishable', function (hooks) {
     // Each snapshot this module's tests create stays attached until it is
-
     // deleted, and SQLite caps attached databases per connection. The prefix is
-
     // derived from the running module's name, and nested modules have distinct
-
     // names, so every scope that runs tests registers its own teardown.
-
     setupRealmCacheTeardown(hooks);
 
     hooks.beforeEach(async function () {
@@ -782,13 +770,9 @@ module('Acceptance | host submode', function (hooks) {
 
     module('publish and unpublish realm', function (hooks) {
       // Each snapshot this module's tests create stays attached until it is
-
       // deleted, and SQLite caps attached databases per connection. The prefix is
-
       // derived from the running module's name, and nested modules have distinct
-
       // names, so every scope that runs tests registers its own teardown.
-
       setupRealmCacheTeardown(hooks);
 
       let publishDeferred: Deferred<void>;

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -769,10 +769,25 @@ module('Acceptance | host submode', function (hooks) {
     });
 
     module('publish and unpublish realm', function (hooks) {
-      // Each snapshot this module's tests create stays attached until it is
-      // deleted, and SQLite caps attached databases per connection. The prefix is
-      // derived from the running module's name, and nested modules have distinct
-      // names, so every scope that runs tests registers its own teardown.
+      // This module calls no caching helper of its own, so the registration below
+      // looks superfluous. It isn't. The parent's beforeEach runs for these tests
+      // too and caches the realm it builds under a key from
+      // `getCurrentModuleCacheKey()`, which reads the *running test's* module
+      // name — for a test in here that is the composed
+      // "… > with a realm that is publishable > publish and unpublish realm". So
+      // the parent exports a snapshot under this module's name and leaves it
+      // attached.
+      //
+      // Teardown deletes by `snapshot_${simpleHash(moduleName)}_`, and the hash
+      // of the parent's name is not the hash of this one, so the parent's
+      // registration cannot reach these. Without this line one snapshot database
+      // stays attached for the rest of the shard, against SQLite's per-connection
+      // cap on attached databases.
+      //
+      // A consequence, not a defect: the parent's own tests and these cache the
+      // same realm under two keys, so it is indexed once per scope rather than
+      // shared. That is inherent to keying by module name — don't "deduplicate"
+      // it by dropping a registration.
       setupRealmCacheTeardown(hooks);
 
       let publishDeferred: Deferred<void>;

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -16,6 +16,7 @@ import { Deferred, baseRealm, param, query } from '@cardstack/runtime-common';
 import ENV from '@cardstack/host/config/environment';
 
 import {
+  withCachedRealmSetup,
   getDbAdapter,
   setupLocalIndexing,
   setupOnSave,
@@ -254,9 +255,15 @@ module('Acceptance | host submode', function (hooks) {
           },
         },
       };
-      await setupAcceptanceTestRealm({
-        mockMatrixUtils,
-        contents: realmContents,
+      // Each of these nested modules builds the same realm for every one of its
+      // tests, so the indexed result is cached per module and restored instead
+      // of being rebuilt. The seeded realm_metadata row above is part of what
+      // the snapshot captures, so a restored test starts from the same state.
+      await withCachedRealmSetup(async () => {
+        await setupAcceptanceTestRealm({
+          mockMatrixUtils,
+          contents: realmContents,
+        });
       });
     });
 
@@ -283,9 +290,15 @@ module('Acceptance | host submode', function (hooks) {
 
   module('with a realm that is not publishable', function (hooks) {
     hooks.beforeEach(async function () {
-      await setupAcceptanceTestRealm({
-        mockMatrixUtils,
-        contents: realmContents,
+      // Each of these nested modules builds the same realm for every one of its
+      // tests, so the indexed result is cached per module and restored instead
+      // of being rebuilt. The seeded realm_metadata row above is part of what
+      // the snapshot captures, so a restored test starts from the same state.
+      await withCachedRealmSetup(async () => {
+        await setupAcceptanceTestRealm({
+          mockMatrixUtils,
+          contents: realmContents,
+        });
       });
     });
 
@@ -324,9 +337,15 @@ module('Acceptance | host submode', function (hooks) {
         param(true),
         `) ON CONFLICT (url) DO UPDATE SET publishable = true`,
       ]);
-      await setupAcceptanceTestRealm({
-        mockMatrixUtils,
-        contents: realmContents,
+      // Each of these nested modules builds the same realm for every one of its
+      // tests, so the indexed result is cached per module and restored instead
+      // of being rebuilt. The seeded realm_metadata row above is part of what
+      // the snapshot captures, so a restored test starts from the same state.
+      await withCachedRealmSetup(async () => {
+        await setupAcceptanceTestRealm({
+          mockMatrixUtils,
+          contents: realmContents,
+        });
       });
     });
 

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -14,6 +14,7 @@ import { TrackedObject } from 'tracked-built-ins';
 import { Deferred, baseRealm, param, query } from '@cardstack/runtime-common';
 
 import ENV from '@cardstack/host/config/environment';
+import type RealmService from '@cardstack/host/services/realm';
 
 import {
   withCachedRealmSetup,
@@ -265,6 +266,13 @@ module('Acceptance | host submode', function (hooks) {
           contents: realmContents,
         });
       });
+
+      // `withUpdatedTestRealmInfo` reads the realm service's resource for this
+      // realm, and some tests read it before their own visit. Nothing in the
+      // harness registers it — app components do, incidentally, while rendering
+      // during setup — so ask for it here rather than depend on what the setup
+      // visit happened to render.
+      await (getService('realm') as RealmService).ensureRealmMeta(testRealmURL);
     });
 
     test('publish modal warns that a routing rule points to a missing card', async function (assert) {
@@ -300,6 +308,13 @@ module('Acceptance | host submode', function (hooks) {
           contents: realmContents,
         });
       });
+
+      // `withUpdatedTestRealmInfo` reads the realm service's resource for this
+      // realm, and some tests read it before their own visit. Nothing in the
+      // harness registers it — app components do, incidentally, while rendering
+      // during setup — so ask for it here rather than depend on what the setup
+      // visit happened to render.
+      await (getService('realm') as RealmService).ensureRealmMeta(testRealmURL);
     });
 
     test('host submode is not available', async function (assert) {
@@ -347,6 +362,13 @@ module('Acceptance | host submode', function (hooks) {
           contents: realmContents,
         });
       });
+
+      // `withUpdatedTestRealmInfo` reads the realm service's resource for this
+      // realm, and some tests read it before their own visit. Nothing in the
+      // harness registers it — app components do, incidentally, while rendering
+      // during setup — so ask for it here rather than depend on what the setup
+      // visit happened to render.
+      await (getService('realm') as RealmService).ensureRealmMeta(testRealmURL);
     });
 
     test('host submode is available', async function (assert) {

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -17,6 +17,7 @@ import ENV from '@cardstack/host/config/environment';
 import type RealmService from '@cardstack/host/services/realm';
 
 import {
+  setupRealmCacheTeardown,
   withCachedRealmSetup,
   getDbAdapter,
   setupLocalIndexing,
@@ -225,6 +226,16 @@ module('Acceptance | host submode', function (hooks) {
   });
 
   module('with a dangling host routing rule', function (hooks) {
+    // Each snapshot this module's tests create stays attached until it is
+
+    // deleted, and SQLite caps attached databases per connection. The prefix is
+
+    // derived from the running module's name, and nested modules have distinct
+
+    // names, so every scope that runs tests registers its own teardown.
+
+    setupRealmCacheTeardown(hooks);
+
     hooks.beforeEach(async function () {
       let dbAdapter = await getDbAdapter();
       await query(dbAdapter, [
@@ -297,6 +308,16 @@ module('Acceptance | host submode', function (hooks) {
   });
 
   module('with a realm that is not publishable', function (hooks) {
+    // Each snapshot this module's tests create stays attached until it is
+
+    // deleted, and SQLite caps attached databases per connection. The prefix is
+
+    // derived from the running module's name, and nested modules have distinct
+
+    // names, so every scope that runs tests registers its own teardown.
+
+    setupRealmCacheTeardown(hooks);
+
     hooks.beforeEach(async function () {
       // Each of these nested modules builds the same realm for every one of its
       // tests, so the indexed result is cached per module and restored instead
@@ -340,6 +361,16 @@ module('Acceptance | host submode', function (hooks) {
   });
 
   module('with a realm that is publishable', function (hooks) {
+    // Each snapshot this module's tests create stays attached until it is
+
+    // deleted, and SQLite caps attached databases per connection. The prefix is
+
+    // derived from the running module's name, and nested modules have distinct
+
+    // names, so every scope that runs tests registers its own teardown.
+
+    setupRealmCacheTeardown(hooks);
+
     hooks.beforeEach(async function () {
       // CS-10053: publishable lives in realm_metadata now. Seed the row
       // BEFORE setupAcceptanceTestRealm so parseRealmInfo's first read
@@ -750,6 +781,16 @@ module('Acceptance | host submode', function (hooks) {
     });
 
     module('publish and unpublish realm', function (hooks) {
+      // Each snapshot this module's tests create stays attached until it is
+
+      // deleted, and SQLite caps attached databases per connection. The prefix is
+
+      // derived from the running module's name, and nested modules have distinct
+
+      // names, so every scope that runs tests registers its own teardown.
+
+      setupRealmCacheTeardown(hooks);
+
       let publishDeferred: Deferred<void>;
       let unpublishDeferred: Deferred<void>;
 

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -20,6 +20,7 @@ import type { Realm } from '@cardstack/runtime-common/realm';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
 import {
+  withCachedRealmSetup,
   SYSTEM_CARD_FIXTURE_CONTENTS,
   percySnapshot,
   testRealmURL,
@@ -167,147 +168,154 @@ module('Integration | card-copy', function (hooks) {
 
     // Defer matrix startup until all test realms (including read-only) are
     // registered to avoid _info fetch races during matrix boot.
-    ({ realm: realm1 } = await setupIntegrationTestRealm({
-      mockMatrixUtils,
-      contents: {
-        ...SYSTEM_CARD_FIXTURE_CONTENTS,
-        'person.gts': { Person },
-        'pet.gts': { Pet },
-        'index.json': {
-          data: {
-            type: 'card',
-            meta: {
-              adoptsFrom: {
-                module: '@cardstack/base/cards-grid',
-                name: 'CardsGrid',
-              },
-            },
-          },
-        },
-        'Person/hassan.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              firstName: 'Hassan',
-            },
-            relationships: {
-              pet: {
-                links: {
-                  self: '../Pet/mango',
+    // These three realms are the same for every test in this module, so the
+    // indexed result is cached and restored rather than rebuilt. The fourth
+    // realm one test builds for itself stays outside this: a cache hit
+    // replaces every table, which would discard the realms that test already
+    // has.
+    await withCachedRealmSetup(async () => {
+      ({ realm: realm1 } = await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'person.gts': { Person },
+          'pet.gts': { Pet },
+          'index.json': {
+            data: {
+              type: 'card',
+              meta: {
+                adoptsFrom: {
+                  module: '@cardstack/base/cards-grid',
+                  name: 'CardsGrid',
                 },
               },
             },
-            meta: {
-              adoptsFrom: {
-                module: `../person`,
-                name: 'Person',
+          },
+          'Person/hassan.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                firstName: 'Hassan',
+              },
+              relationships: {
+                pet: {
+                  links: {
+                    self: '../Pet/mango',
+                  },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `../person`,
+                  name: 'Person',
+                },
               },
             },
           },
-        },
-        'Pet/mango.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              firstName: 'Mango',
-            },
-            meta: {
-              adoptsFrom: {
-                module: '../pet',
-                name: 'Pet',
+          'Pet/mango.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                firstName: 'Mango',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: '../pet',
+                  name: 'Pet',
+                },
               },
             },
           },
-        },
-        'Pet/vangogh.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              firstName: 'Van Gogh',
-            },
-            meta: {
-              adoptsFrom: {
-                module: '../pet',
-                name: 'Pet',
+          'Pet/vangogh.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                firstName: 'Van Gogh',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: '../pet',
+                  name: 'Pet',
+                },
               },
             },
           },
+          'realm.json': realmConfigCardJSON({
+            name: 'Test Workspace 1',
+            backgroundURL:
+              'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+            iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+          }),
         },
-        'realm.json': realmConfigCardJSON({
-          name: 'Test Workspace 1',
-          backgroundURL:
-            'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
-          iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
-        }),
-      },
-      startMatrix: false,
-    }));
+        startMatrix: false,
+      }));
 
-    await setupIntegrationTestRealm({
-      mockMatrixUtils,
-      realmURL: testRealm2URL,
-      contents: {
-        ...SYSTEM_CARD_FIXTURE_CONTENTS,
-        'index.json': {
-          data: {
-            type: 'card',
-            meta: {
-              adoptsFrom: {
-                module: '@cardstack/base/cards-grid',
-                name: 'CardsGrid',
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealm2URL,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'index.json': {
+            data: {
+              type: 'card',
+              meta: {
+                adoptsFrom: {
+                  module: '@cardstack/base/cards-grid',
+                  name: 'CardsGrid',
+                },
               },
             },
           },
-        },
-        'Pet/paper.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              firstName: 'Paper',
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}pet`,
-                name: 'Pet',
+          'Pet/paper.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                firstName: 'Paper',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}pet`,
+                  name: 'Pet',
+                },
               },
             },
           },
+          'realm.json': realmConfigCardJSON({
+            name: 'Test Workspace 2',
+            backgroundURL:
+              'https://i.postimg.cc/tgRHRV8C/pawel-czerwinski-h-Nrd99q5pe-I-unsplash.jpg',
+            iconURL: 'https://boxel-images.boxel.ai/icons/cardstack.png',
+          }),
         },
-        'realm.json': realmConfigCardJSON({
-          name: 'Test Workspace 2',
-          backgroundURL:
-            'https://i.postimg.cc/tgRHRV8C/pawel-czerwinski-h-Nrd99q5pe-I-unsplash.jpg',
-          iconURL: 'https://boxel-images.boxel.ai/icons/cardstack.png',
-        }),
-      },
-      startMatrix: false,
-    });
+        startMatrix: false,
+      });
 
-    await setupIntegrationTestRealm({
-      mockMatrixUtils,
-      realmURL: readOnlyRealmURL,
-      permissions: { '@testuser:localhost': ['read'] },
-      contents: {
-        ...SYSTEM_CARD_FIXTURE_CONTENTS,
-        'index.json': {
-          data: {
-            type: 'card',
-            meta: {
-              adoptsFrom: {
-                module: '@cardstack/base/cards-grid',
-                name: 'CardsGrid',
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: readOnlyRealmURL,
+        permissions: { '@testuser:localhost': ['read'] },
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'index.json': {
+            data: {
+              type: 'card',
+              meta: {
+                adoptsFrom: {
+                  module: '@cardstack/base/cards-grid',
+                  name: 'CardsGrid',
+                },
               },
             },
           },
+          'realm.json': realmConfigCardJSON({
+            name: 'Read Only Workspace',
+            backgroundURL:
+              'https://i.postimg.cc/4xyCDpGq/pawel-czerwinski-5n-L-IMto-KEw-unsplash.jpg',
+            iconURL: 'https://i.postimg.cc/W4fZgT3j/icon.png',
+          }),
         },
-        'realm.json': realmConfigCardJSON({
-          name: 'Read Only Workspace',
-          backgroundURL:
-            'https://i.postimg.cc/4xyCDpGq/pawel-czerwinski-5n-L-IMto-KEw-unsplash.jpg',
-          iconURL: 'https://i.postimg.cc/W4fZgT3j/icon.png',
-        }),
-      },
-      startMatrix: false,
+        startMatrix: false,
+      });
     });
 
     await mockMatrixUtils.start();

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -20,6 +20,7 @@ import type { Realm } from '@cardstack/runtime-common/realm';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
 import {
+  setupRealmCacheTeardown,
   withCachedRealmSetup,
   SYSTEM_CARD_FIXTURE_CONTENTS,
   percySnapshot,
@@ -58,6 +59,11 @@ function getDestinationCardCount(): number {
 }
 
 module('Integration | card-copy', function (hooks) {
+  // The snapshot this module caches stays attached until it is deleted, and
+  // SQLite caps attached databases per connection, so register the teardown
+  // that removes it when the module finishes.
+  setupRealmCacheTeardown(hooks);
+
   let realm1: Realm;
   let noop = () => {};
 

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -175,10 +175,11 @@ module('Integration | card-copy', function (hooks) {
     // Defer matrix startup until all test realms (including read-only) are
     // registered to avoid _info fetch races during matrix boot.
     // These three realms are the same for every test in this module, so the
-    // indexed result is cached and restored rather than rebuilt. The fourth
-    // realm one test builds for itself stays outside this: a cache hit
-    // replaces every table, which would discard the realms that test already
-    // has.
+    // indexed result is cached and restored rather than rebuilt. One test
+    // re-provisions the read-only realm for itself, with wider permissions and
+    // an extra card, and that has to stay outside this block: a cache hit
+    // deletes and refills every table, which would discard the three realms it
+    // had just restored.
     await withCachedRealmSetup(async () => {
       ({ realm: realm1 } = await setupIntegrationTestRealm({
         mockMatrixUtils,


### PR DESCRIPTION
This is in the same vein as many host test indexing caching PRs, but uses the older `withCachedRealmSetup` which we may use to entirely replace the recent `setupLocalIndexing` addition.