### PR TITLE
Bound the readiness check's in-process gates so a stall answers instead of hanging

### DIFF
--- a/packages/matrix/support/isolated-realm-server.ts
+++ b/packages/matrix/support/isolated-realm-server.ts
@@ -208,14 +208,14 @@ async function waitForHttpReady(url: string, timeoutMs = 60_000) {
 }
 
 // Wait for a realm's `_readiness-check` to succeed. Unlike waitForHttpReady
-// (which only proves a port answers), the probe blocks server-side until the
-// realm's first from-scratch index and any in-flight index settle, so a success
-// means that realm is fully indexed and safe to create/publish against. The
-// server holds each request open until indexing settles, so a single `fetch`
-// could block past the budget (up to undici's default header timeout) and never
-// return to the loop condition — abort it at the remaining budget so the
-// configured timeout is actually enforced and the caller can stop the child
-// processes and emit diagnostics instead of leaving global setup to hang.
+// (which only proves a port answers), the probe gates server-side on the
+// realm's first from-scratch index and any in-flight index, so a success means
+// that realm is fully indexed and safe to create/publish against. The server
+// holds each request open while those settle — bounded, but a single `fetch`
+// can still outlast the remaining budget and never return to the loop
+// condition — so abort it at the remaining budget, keeping the configured
+// timeout enforced and letting the caller stop the child processes and emit
+// diagnostics instead of leaving global setup to hang.
 async function waitForRealmIndexed(url: string, timeoutMs: number) {
   let start = Date.now();
   let lastError: string | undefined;

--- a/packages/matrix/tests/publish-realm.spec.ts
+++ b/packages/matrix/tests/publish-realm.spec.ts
@@ -144,22 +144,21 @@ test.describe('Publish realm', () => {
     ).toBeChecked();
     await page.locator('[data-test-publish-button]').click();
 
-    // Gate on the publish finishing before reaching for the button it reveals.
-    // Publishing a brand-new realm runs a from-scratch index plus a prerender
-    // pass server-side, and the modal only swaps in the open/unpublish controls
-    // once the realm passes its readiness check. Waiting on that transition
-    // explicitly means a publish that stalls fails here, naming the stage that
-    // stalled — rather than surfacing as whichever later step happened to be
-    // in flight when the test's overall budget ran out.
-    await page.waitForSelector('[data-test-unpublish-button]');
+    // Wait for the publish to finish as its own step, before arming the popup
+    // listener. Publishing a brand-new realm runs a from-scratch index plus a
+    // prerender pass server-side, and this control only renders once the
+    // claimed domain reports published. Waiting explicitly means a stalled
+    // publish fails on the wait — naming the stage that stalled — instead of
+    // reporting a popup that never arrived alongside a click that was still
+    // waiting for its target.
+    let openPublishedSiteButton = page.locator(
+      '[data-test-publish-realm-modal] [data-test-open-custom-subdomain-button]',
+    );
+    await openPublishedSiteButton.waitFor({ state: 'visible' });
 
     let newTabPromise = page.waitForEvent('popup');
 
-    await page
-      .locator(
-        '[data-test-publish-realm-modal] [data-test-open-custom-subdomain-button]',
-      )
-      .click();
+    await openPublishedSiteButton.click();
 
     let newTab = await newTabPromise;
     await newTab.waitForLoadState();

--- a/packages/matrix/tests/publish-realm.spec.ts
+++ b/packages/matrix/tests/publish-realm.spec.ts
@@ -144,6 +144,15 @@ test.describe('Publish realm', () => {
     ).toBeChecked();
     await page.locator('[data-test-publish-button]').click();
 
+    // Gate on the publish finishing before reaching for the button it reveals.
+    // Publishing a brand-new realm runs a from-scratch index plus a prerender
+    // pass server-side, and the modal only swaps in the open/unpublish controls
+    // once the realm passes its readiness check. Waiting on that transition
+    // explicitly means a publish that stalls fails here, naming the stage that
+    // stalled — rather than surfacing as whichever later step happened to be
+    // in flight when the test's overall budget ran out.
+    await page.waitForSelector('[data-test-unpublish-button]');
+
     let newTabPromise = page.waitForEvent('popup');
 
     await page

--- a/packages/realm-server/lib/realm-registry-reconciler.ts
+++ b/packages/realm-server/lib/realm-registry-reconciler.ts
@@ -200,8 +200,9 @@ export class RealmRegistryReconciler {
     // realms' indexing — requests to /skills/_readiness-check would
     // 404 while /base/ is still indexing. Publishing all realms up
     // front means every URL routes through the realm immediately;
-    // requests block on the realm's #startedUp gate (e.g.,
-    // readinessCheck awaits #startedUp.promise) but don't 404.
+    // requests wait on the realm's #startedUp gate (readinessCheck
+    // waits on it for a bounded budget, then reports not-ready) but
+    // don't 404.
     //
     // Why sequential start() rather than Promise.all: indexing has
     // cross-realm dependencies and parallel fullIndex jobs queue up

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -372,6 +372,7 @@ const ALL_TEST_FILES: string[] = [
   './search-entries-engine-test',
   './search-bounds-test',
   './coerce-error-message-test',
+  './settled-by-test',
   './canonical-url-memo-test',
   './dependency-normalization-test',
   './realm-operations-test',

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -1452,16 +1452,29 @@ module(basename(import.meta.filename), function () {
           'cold republish accepted',
         );
 
-        // _readiness-check must block on the in-flight reindex, so by the time
-        // it returns 200 the published index already reflects the update. (The
-        // route only matches the RealmInfo mime, so set Accept accordingly.)
-        let readinessResponse = await request
-          .get(`${publishedRealmPath}_readiness-check`)
-          .set('Host', publishedRealmHost)
-          .set('Accept', 'application/vnd.api+json');
-        assert.strictEqual(
-          readinessResponse.status,
-          200,
+        // _readiness-check gates on the in-flight reindex, so by the time it
+        // reports ready the published index already reflects the update. Poll
+        // for that rather than asking once: readiness bounds how long it holds
+        // a single request and answers 503 with `Retry-After` once the budget
+        // is spent, so a reindex longer than the budget takes more than one
+        // request to observe. (The route only matches the RealmInfo mime, so
+        // set Accept accordingly.)
+        assert.true(
+          await waitUntil(
+            async () =>
+              (
+                await request
+                  .get(`${publishedRealmPath}_readiness-check`)
+                  .set('Host', publishedRealmHost)
+                  .set('Accept', 'application/vnd.api+json')
+              ).status === 200,
+            {
+              timeout: 120_000,
+              interval: 1000,
+              timeoutMessage:
+                'republished realm never passed its readiness check',
+            },
+          ),
           'readiness check reports ready',
         );
 

--- a/packages/realm-server/tests/realm-endpoints/readiness-check-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/readiness-check-test.ts
@@ -1,11 +1,28 @@
 import QUnit from 'qunit';
 const { module, test } = QUnit;
 import type { Test, SuperTest } from 'supertest';
-import { basename } from 'path';
-import type { Realm } from '@cardstack/runtime-common';
-import { SupportedMimeType } from '@cardstack/runtime-common';
+import { basename, join } from 'path';
+import fsExtra from 'fs-extra';
+const { ensureDirSync, writeJSONSync } = fsExtra;
+import { dirSync } from 'tmp';
+import type {
+  Realm,
+  QueuePublisher,
+  QueueRunner,
+} from '@cardstack/runtime-common';
+import {
+  CachingDefinitionLookup,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
 import { indexingConcurrencyGroup } from '@cardstack/runtime-common/jobs/indexing';
-import { setupPermissionedRealmCached } from '../helpers/index.ts';
+import {
+  createRealm,
+  createVirtualNetwork,
+  getTestPrerenderer,
+  setupDB,
+  setupPermissionedRealmCached,
+  testCreatePrerenderAuth,
+} from '../helpers/index.ts';
 import type { PgAdapter } from '@cardstack/postgres';
 
 // `_readiness-check` answers whether one realm's content is ready, not whether
@@ -95,6 +112,100 @@ module(`realm-endpoints/${basename(import.meta.filename)}`, function () {
           'Retry-After',
         ),
         'the retry hint is readable cross-origin',
+      );
+    });
+  });
+
+  // A realm that is mounted but whose start() has not completed. The gate in
+  // front of that state is the one a publish poll sits behind: a brand-new
+  // published realm is mounted and serving before its from-scratch index
+  // finishes. The realm here is deliberately never started, which is the
+  // never-settles end of that spectrum — a startup that hangs rather than one
+  // that is merely slow. The endpoint must still answer.
+  module('startup that has not completed', function (hooks) {
+    let dbAdapter: PgAdapter;
+    let publisher: QueuePublisher;
+    let runner: QueueRunner;
+
+    setupDB(hooks, {
+      beforeEach: async (adapter, pub, run) => {
+        dbAdapter = adapter;
+        publisher = pub;
+        runner = run;
+      },
+    });
+
+    const unstartedRealmURL = 'http://127.0.0.1:6677/unstarted/';
+
+    async function buildUnstartedRealm(): Promise<Realm> {
+      let dir = join(dirSync().name, 'unstarted-realm');
+      ensureDirSync(dir);
+      writeJSONSync(join(dir, 'realm.json'), {
+        data: {
+          type: 'card',
+          attributes: { cardInfo: { name: 'Unstarted Realm' } },
+          meta: {
+            adoptsFrom: {
+              module: '@cardstack/base/realm-config',
+              name: 'RealmConfig',
+            },
+          },
+        },
+      });
+      let virtualNetwork = createVirtualNetwork();
+      let definitionLookup = new CachingDefinitionLookup(
+        dbAdapter,
+        await getTestPrerenderer(),
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      // createRealm constructs without starting, so #startedUp stays pending
+      // for as long as this realm exists.
+      let { realm } = await createRealm({
+        dir,
+        definitionLookup,
+        realmURL: unstartedRealmURL,
+        permissions: { '*': ['read'] },
+        virtualNetwork,
+        publisher,
+        runner,
+        dbAdapter,
+      });
+      return realm;
+    }
+
+    test('answers 503 naming the startup stage instead of holding the request open', async function (assert) {
+      let realm = await buildUnstartedRealm();
+      let startedAt = Date.now();
+      let response = await realm.handle(
+        new Request(`${unstartedRealmURL}_readiness-check`, {
+          headers: { Accept: SupportedMimeType.RealmInfo },
+        }),
+      );
+      let elapsed = Date.now() - startedAt;
+
+      assert.ok(response, 'the realm handled the request');
+      assert.strictEqual(
+        response!.status,
+        503,
+        'reports not-ready rather than hanging until the caller gives up',
+      );
+      assert.strictEqual(
+        response!.headers.get('X-Boxel-Not-Ready'),
+        'startup',
+        'names startup — not the shared index lane — as the outstanding stage',
+      );
+      assert.strictEqual(
+        response!.headers.get('Retry-After'),
+        '1',
+        'tells the caller to poll again',
+      );
+      // The budget bounds one request; the assertion is that the request came
+      // back on its own rather than being released by something else. A
+      // generous ceiling keeps this from failing on a loaded CI box.
+      assert.true(
+        elapsed < 60_000,
+        `answered within the in-process budget (took ${elapsed}ms)`,
       );
     });
   });

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -1529,20 +1529,28 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
           }
 
           // `_publish-realm` returns 202 before indexing finishes. Drive a
-          // reconcile pass to mount the published realm, then hit its readiness
-          // check, which awaits start() + any in-flight index — so this blocks
-          // until the swapped files are indexed and the assertions below query
-          // indexed content.
+          // reconcile pass to mount the published realm, then poll its
+          // readiness check until it reports ready, so the assertions below
+          // query indexed content. Poll rather than asking once: readiness
+          // bounds how long it will hold a single request and answers 503 with
+          // `Retry-After` once that budget is spent, so a from-scratch index
+          // longer than the budget takes more than one request to observe.
           await testRealmServer.testingOnlyReconcile();
-          let readinessResponse = await request
-            .get(`${publishedRealmPath}_readiness-check`)
-            .set('Host', publishedRealmHost)
-            .set('Accept', 'application/vnd.api+json');
-          if (readinessResponse.status !== 200) {
-            throw new Error(
-              `Published realm not ready: ${readinessResponse.status} ${readinessResponse.text}`,
-            );
-          }
+          await waitUntil(
+            async () =>
+              (
+                await request
+                  .get(`${publishedRealmPath}_readiness-check`)
+                  .set('Host', publishedRealmHost)
+                  .set('Accept', 'application/vnd.api+json')
+              ).status === 200,
+            {
+              timeout: 120_000,
+              interval: 1000,
+              timeoutMessage:
+                'published realm never passed its readiness check',
+            },
+          );
           // Readiness drains the index channel only; head HTML lands via the
           // realm's prerender_html job, so settle that channel before the
           // assertions read it.

--- a/packages/realm-server/tests/settled-by-test.ts
+++ b/packages/realm-server/tests/settled-by-test.ts
@@ -1,0 +1,76 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import { Deferred } from '@cardstack/runtime-common/deferred';
+import { settledBy } from '@cardstack/runtime-common/settled-by';
+
+module(basename(import.meta.filename), function () {
+  module('settledBy', function () {
+    test('work that finishes inside the window reports settled', async function (assert) {
+      let deferred = new Deferred<void>();
+      setTimeout(() => deferred.fulfill(), 10);
+      assert.true(
+        await settledBy(deferred.promise, Date.now() + 1000),
+        'fulfilling before the deadline reports settled',
+      );
+    });
+
+    test('work still outstanding at the deadline reports unsettled rather than holding the caller', async function (assert) {
+      let neverSettles = new Deferred<void>();
+      let startedAt = Date.now();
+      assert.false(
+        await settledBy(neverSettles.promise, Date.now() + 100),
+        'the deadline decides the answer',
+      );
+      assert.true(
+        Date.now() - startedAt < 2000,
+        'the caller is released at the deadline instead of waiting on the work',
+      );
+    });
+
+    test('a deadline already in the past reports unsettled without waiting', async function (assert) {
+      let neverSettles = new Deferred<void>();
+      assert.false(
+        await settledBy(neverSettles.promise, Date.now() - 1000),
+        'a past deadline has already expired',
+      );
+    });
+
+    test('failed work propagates rather than reading as merely outstanding', async function (assert) {
+      let deferred = new Deferred<void>();
+      // Hand the promise to the gate before rejecting it, so the rejection is
+      // observed by the gate rather than by a bare promise nobody is watching.
+      let gate = settledBy(deferred.promise, Date.now() + 1000);
+      deferred.reject(new Error('startup blew up'));
+      await assert.rejects(
+        gate,
+        /startup blew up/,
+        'the rejection reaches the caller',
+      );
+    });
+
+    // A rejection landing after the deadline has already lost the race, so
+    // nothing is left to observe it. It must be handled internally: an
+    // unhandled rejection here would take down the process that called the
+    // gate, which is the opposite of what bounding the wait is for.
+    test('work that fails after the deadline does not surface as an unhandled rejection', async function (assert) {
+      let unhandled: unknown[] = [];
+      let onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+      try {
+        let deferred = new Deferred<void>();
+        assert.false(
+          await settledBy(deferred.promise, Date.now() + 50),
+          'the deadline expires first',
+        );
+        deferred.reject(new Error('late failure'));
+        // Let the rejection propagate through the microtask queue and past the
+        // turn on which node reports unhandled rejections.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        assert.deepEqual(unhandled, [], 'no unhandled rejection was reported');
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
+    });
+  });
+});

--- a/packages/realm-server/tests/settled-by-test.ts
+++ b/packages/realm-server/tests/settled-by-test.ts
@@ -1,8 +1,16 @@
 import QUnit from 'qunit';
 const { module, test } = QUnit;
 import { basename } from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { Deferred } from '@cardstack/runtime-common/deferred';
 import { settledBy } from '@cardstack/runtime-common/settled-by';
+
+const execFileAsync = promisify(execFile);
+const settledByModule = new URL(
+  '../../runtime-common/settled-by.ts',
+  import.meta.url,
+).href;
 
 module(basename(import.meta.filename), function () {
   module('settledBy', function () {
@@ -22,17 +30,37 @@ module(basename(import.meta.filename), function () {
         await settledBy(neverSettles.promise, Date.now() + 100),
         'the deadline decides the answer',
       );
+      let elapsed = Date.now() - startedAt;
+      // Both bounds matter: the lower one rules out an implementation that
+      // answers false immediately without honoring the window, the upper one
+      // rules out one that waits on the work regardless of the deadline.
       assert.true(
-        Date.now() - startedAt < 2000,
-        'the caller is released at the deadline instead of waiting on the work',
+        elapsed >= 90,
+        `waited for the window rather than answering immediately (took ${elapsed}ms)`,
+      );
+      assert.true(
+        elapsed < 2000,
+        `released at the deadline instead of waiting on the work (took ${elapsed}ms)`,
       );
     });
 
-    test('a deadline already in the past reports unsettled without waiting', async function (assert) {
+    test('a deadline already in the past releases outstanding work immediately', async function (assert) {
       let neverSettles = new Deferred<void>();
       assert.false(
         await settledBy(neverSettles.promise, Date.now() - 1000),
         'a past deadline has already expired',
+      );
+    });
+
+    // The tie-break the readiness gates depend on. Work that is demonstrably
+    // finished must never be reported as outstanding, so fulfilment observed on
+    // the microtask queue beats a deadline observed on a macrotask. Without
+    // this, a gate sharing a spent budget with an earlier gate would answer
+    // "not ready" about work that had already completed.
+    test('already-finished work reports settled even against an expired deadline', async function (assert) {
+      assert.true(
+        await settledBy(Promise.resolve(), Date.now() - 1000),
+        'fulfilment wins the tie against an expired deadline',
       );
     });
 
@@ -50,9 +78,10 @@ module(basename(import.meta.filename), function () {
     });
 
     // A rejection landing after the deadline has already lost the race, so
-    // nothing is left to observe it. It must be handled internally: an
-    // unhandled rejection here would take down the process that called the
-    // gate, which is the opposite of what bounding the wait is for.
+    // nothing is left to observe it. `Promise.race` attaches reactions to every
+    // input, which is what keeps this from surfacing as an unhandled rejection
+    // — and an unhandled rejection here would take down the process that called
+    // the gate, the opposite of what bounding the wait is for.
     test('work that fails after the deadline does not surface as an unhandled rejection', async function (assert) {
       let unhandled: unknown[] = [];
       let onUnhandled = (reason: unknown) => unhandled.push(reason);
@@ -71,6 +100,31 @@ module(basename(import.meta.filename), function () {
       } finally {
         process.off('unhandledRejection', onUnhandled);
       }
+    });
+
+    // Runs in a subprocess because this cannot be observed from inside the test
+    // harness: QUnit keeps its own work on the event loop, so the deadline timer
+    // is never the only thing holding the process open. A timer that does not
+    // hold the loop lets node exit while the gate is still pending — the caller
+    // never gets its answer, and a short-lived process (a CLI command, a
+    // migration, a worker draining at shutdown) exits 0 having silently skipped
+    // the work that depended on it.
+    test('the deadline holds the process open long enough to answer', async function (assert) {
+      let { stdout } = await execFileAsync(
+        process.execPath,
+        [
+          '--input-type=module',
+          '-e',
+          `const { settledBy } = await import(${JSON.stringify(settledByModule)});
+           console.log('RESULT:' + await settledBy(new Promise(() => {}), Date.now() + 100));`,
+        ],
+        { env: { ...process.env, NODE_NO_WARNINGS: '1' }, timeout: 30_000 },
+      );
+      assert.strictEqual(
+        stdout.trim(),
+        'RESULT:false',
+        'the gate answered instead of the process exiting with it still pending',
+      );
     });
   });
 });

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -4,6 +4,7 @@ import {
   indexingConcurrencyGroup,
 } from './jobs/indexing.ts';
 import { awaitPublishedHtmlReady } from './jobs/prerender-html.ts';
+import { settledBy } from './settled-by.ts';
 import type { RealmVisibility } from './realm-visibility.ts';
 import type { SearchOpts } from './search-utils.ts';
 import { buildSearchErrorBody, SearchRequestError } from './search-utils.ts';
@@ -328,6 +329,13 @@ const COALESCE_NOTIFY_WAIT_MS = 180_000;
 // so the exemption holds for header-less probes too. Keep in sync with
 // `#publicEndpoints`.
 const ARCHIVED_SEAL_EXEMPT_PATHS = new Set(['_readiness-check', '_session']);
+// How long `_readiness-check` holds a request while this process's own startup
+// and in-flight indexing settle, before answering not-ready instead. Matches
+// the budget the shared index-lane gate uses, and for the same reason: the hold
+// is a courtesy to the poller, `Retry-After` already tells it to come back, and
+// a hold longer than a caller's per-attempt deadline yields a connection
+// timeout instead of a status the loop can read.
+const IN_PROCESS_READINESS_BUDGET_MS = 10_000;
 const MODULE_ETAG_VARIANT = 'module';
 const SOURCE_ETAG_VARIANT = 'source';
 // Card+JSON ETag is `"<indexed_at>-<realmInfoHash>:card"` — quoted
@@ -1283,10 +1291,10 @@ export class Realm {
     // Report not-ready as a 503 with a retry hint rather than a false 200: a
     // poller keeps waiting, and a single-shot caller sees the failure instead
     // of treating the work it is waiting on as complete. `X-Boxel-Not-Ready`
-    // names which stage is outstanding — the two have different causes and
-    // different remedies, and the poll loops that consume this discard the
+    // names which stage is outstanding — each has a different cause and a
+    // different remedy, and the poll loops that consume this discard the
     // body, so the header is the only place an operator can read it from.
-    let notReady = (stage: 'index' | 'prerender-html') =>
+    let notReady = (stage: 'startup' | 'index' | 'prerender-html') =>
       createResponse({
         body: null,
         init: {
@@ -1300,16 +1308,39 @@ export class Realm {
         requestContext,
       });
 
-    await this.#startedUp.promise;
     // #startedUp is a one-time gate that resolves after the first start()'s
     // from-scratch index. On a republish the realm is already mounted with a
     // resolved #startedUp, so awaiting it alone would report ready before the
     // reindex of the swapped files completes. Also await any in-flight full or
     // incremental index so a publish poll only succeeds once the just-published
     // content is indexed.
+    //
+    // Both waits are budgeted for the same reason the shared-state gates below
+    // are: this endpoint's contract is that a not-yet answers, not that the
+    // connection is held until the answer is yes. An unbounded wait here is
+    // worse than no answer, because the canonical caller
+    // (`realm-operations.waitForReady`) polls serially with no per-request
+    // deadline and only re-checks its own overall budget between requests — so
+    // one held-open request parks the whole poll loop for as long as the gate
+    // stalls, and the client sees a hung connection rather than a status it can
+    // read. Returning 503 keeps the loop ticking against its own deadline, and
+    // a gate that clears later is picked up by the next poll.
+    //
+    // One budget spans both in-process waits, so adding the bound costs the
+    // request a single extra hold rather than one per gate.
+    let inProcessDeadline = Date.now() + IN_PROCESS_READINESS_BUDGET_MS;
+    if (!(await settledBy(this.#startedUp.promise, inProcessDeadline))) {
+      this.#log.warn(
+        `readiness check for ${this.url} is still waiting on realm startup after ${IN_PROCESS_READINESS_BUDGET_MS}ms`,
+      );
+      return notReady('startup');
+    }
     let inflight = this.indexing();
-    if (inflight) {
-      await inflight;
+    if (inflight && !(await settledBy(inflight, inProcessDeadline))) {
+      this.#log.warn(
+        `readiness check for ${this.url} is still waiting on in-flight indexing after ${IN_PROCESS_READINESS_BUDGET_MS}ms`,
+      );
+      return notReady('index');
     }
 
     // Both gates above read per-process state: they see only the indexing this

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -329,13 +329,16 @@ const COALESCE_NOTIFY_WAIT_MS = 180_000;
 // so the exemption holds for header-less probes too. Keep in sync with
 // `#publicEndpoints`.
 const ARCHIVED_SEAL_EXEMPT_PATHS = new Set(['_readiness-check', '_session']);
-// How long `_readiness-check` holds a request while this process's own startup
-// and in-flight indexing settle, before answering not-ready instead. Matches
-// the budget the shared index-lane gate uses, and for the same reason: the hold
-// is a courtesy to the poller, `Retry-After` already tells it to come back, and
-// a hold longer than a caller's per-attempt deadline yields a connection
-// timeout instead of a status the loop can read.
-const IN_PROCESS_READINESS_BUDGET_MS = 10_000;
+// How long one `_readiness-check` request holds while the gates it clears
+// settle, before answering not-ready instead. Shared across those gates rather
+// than granted per gate: the hold is a courtesy to the poller, `Retry-After`
+// already tells it to come back, and a hold longer than a caller's per-attempt
+// deadline yields a connection timeout instead of a status the loop can read.
+// Sized to the same per-attempt deadline the index-lane budget is sized to.
+// `awaitPrerenderHtml` readiness gates on rendered HTML after this budget and
+// carries its own, longer one — a published realm's HTML can take minutes and
+// its callers are pollers with deadlines to match.
+const READINESS_REQUEST_BUDGET_MS = 10_000;
 const MODULE_ETAG_VARIANT = 'module';
 const SOURCE_ETAG_VARIANT = 'source';
 // Card+JSON ETag is `"<indexed_at>-<realmInfoHash>:card"` — quoted
@@ -1326,19 +1329,26 @@ export class Realm {
     // read. Returning 503 keeps the loop ticking against its own deadline, and
     // a gate that clears later is picked up by the next poll.
     //
-    // One budget spans both in-process waits, so adding the bound costs the
-    // request a single extra hold rather than one per gate.
-    let inProcessDeadline = Date.now() + IN_PROCESS_READINESS_BUDGET_MS;
-    if (!(await settledBy(this.#startedUp.promise, inProcessDeadline))) {
+    // One deadline spans every gate below, so a request costs one hold no
+    // matter how many gates it clears. Each log line reports the time that gate
+    // actually spent, not the budget: when startup consumes most of it the
+    // later gates expire almost immediately, and a message naming the full
+    // budget would send an operator looking for a slow index that never
+    // happened.
+    let waitStartedAt = Date.now();
+    let requestDeadline = waitStartedAt + READINESS_REQUEST_BUDGET_MS;
+    if (!(await settledBy(this.#startedUp.promise, requestDeadline))) {
       this.#log.warn(
-        `readiness check for ${this.url} is still waiting on realm startup after ${IN_PROCESS_READINESS_BUDGET_MS}ms`,
+        `readiness check for ${this.url} is still waiting on realm startup after ${Date.now() - waitStartedAt}ms`,
       );
       return notReady('startup');
     }
+    let startupSettledAt = Date.now();
     let inflight = this.indexing();
-    if (inflight && !(await settledBy(inflight, inProcessDeadline))) {
+    if (inflight && !(await settledBy(inflight, requestDeadline))) {
       this.#log.warn(
-        `readiness check for ${this.url} is still waiting on in-flight indexing after ${IN_PROCESS_READINESS_BUDGET_MS}ms`,
+        `readiness check for ${this.url} is still waiting on in-flight indexing after ${Date.now() - startupSettledAt}ms ` +
+          `(realm startup used ${startupSettledAt - waitStartedAt}ms of the ${READINESS_REQUEST_BUDGET_MS}ms budget)`,
       );
       return notReady('index');
     }
@@ -1354,7 +1364,18 @@ export class Realm {
     // rows, so the realm's index lane holding no outstanding work is the same
     // answer everywhere. A realm with no server-side queue has no such lane and
     // reports settled without a query.
-    if (!(await awaitRealmIndexSettled(this.#dbAdapter, this.url))) {
+    // This gate shares the in-process gates' deadline rather than starting a
+    // fresh budget, so one request costs one hold no matter how many gates it
+    // clears. That keeps the endpoint inside the per-attempt deadline the
+    // budget is sized against — the CI readiness probes cap each attempt at
+    // `curl --max-time 15`, and a request that spent its budget on startup and
+    // then started another full budget here would blow past that and hand the
+    // probe a connection timeout instead of a status it can read.
+    if (
+      !(await awaitRealmIndexSettled(this.#dbAdapter, this.url, {
+        timeoutMs: Math.max(0, requestDeadline - Date.now()),
+      }))
+    ) {
       // The lane never drained within budget — a job queued behind a long
       // backlog, or one whose worker died and has yet to be reaped. Keep the
       // caller polling instead of reporting a realm ready whose index is

--- a/packages/runtime-common/settled-by.ts
+++ b/packages/runtime-common/settled-by.ts
@@ -18,7 +18,10 @@ export async function settledBy(
 ): Promise<boolean> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   let expired = new Promise<false>((resolve) => {
-    timer = setTimeout(() => resolve(false), Math.max(0, deadline - Date.now()));
+    timer = setTimeout(
+      () => resolve(false),
+      Math.max(0, deadline - Date.now()),
+    );
     // Never keep the process alive for this timer alone. Present on node,
     // absent on the browser's timer handles.
     timer.unref?.();

--- a/packages/runtime-common/settled-by.ts
+++ b/packages/runtime-common/settled-by.ts
@@ -12,6 +12,17 @@
 // deadline arrives first. A rejection that wins the race propagates, because
 // work having failed is a different answer from work still being outstanding
 // and callers generally need to tell them apart.
+//
+// `deadline` is an absolute `Date.now()`-style timestamp, not a duration, so
+// that several gates in one request can share a single deadline and the request
+// spends one budget rather than one per gate. Passing a duration yields a
+// deadline in 1970 — i.e. immediately expired.
+//
+// Ties go to the work: an already-fulfilled promise reports settled even when
+// the deadline has already passed, because the fulfilment is observed on the
+// microtask queue and the deadline on a macrotask. That ordering is relied on —
+// work that is demonstrably finished must never be reported as outstanding, or
+// a gate would answer "not ready" about something already done.
 export async function settledBy(
   promise: Promise<unknown>,
   deadline: number,
@@ -22,19 +33,17 @@ export async function settledBy(
       () => resolve(false),
       Math.max(0, deadline - Date.now()),
     );
-    // Never keep the process alive for this timer alone. Present on node,
-    // absent on the browser's timer handles.
-    timer.unref?.();
+    // Deliberately not `unref`'d. This timer is what makes the deadline
+    // binding: if the awaited work is the only other pending thing, an
+    // unref'd timer lets the process exit with this promise never settling,
+    // so the caller never gets its answer at all. The hold it adds is capped
+    // by the deadline and released below the moment the race settles.
   });
   let fulfilled = promise.then(() => true as const);
-  // A rejection arriving after the deadline has already lost the race, so no
-  // caller is left to observe it. Mark it handled rather than letting it
-  // surface as an unhandled rejection.
-  fulfilled.catch(() => {});
   try {
     return await Promise.race([fulfilled, expired]);
   } finally {
-    if (timer) {
+    if (timer !== undefined) {
       clearTimeout(timer);
     }
   }

--- a/packages/runtime-common/settled-by.ts
+++ b/packages/runtime-common/settled-by.ts
@@ -1,0 +1,38 @@
+// Bounded observation of work that is already in flight.
+//
+// Distinct from a timeout: nothing is cancelled and nothing is abandoned. The
+// caller learns whether the work finished inside the window and decides what to
+// report; the work itself keeps running and a later observation sees it done.
+// That fits gates in front of long-running background work, where holding a
+// request until the work finishes is worse than answering "not yet" — the
+// caller can act on an answer, but a held connection just consumes its deadline
+// somewhere it cannot see.
+//
+// Resolves true when `promise` fulfills before `deadline`, false when the
+// deadline arrives first. A rejection that wins the race propagates, because
+// work having failed is a different answer from work still being outstanding
+// and callers generally need to tell them apart.
+export async function settledBy(
+  promise: Promise<unknown>,
+  deadline: number,
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let expired = new Promise<false>((resolve) => {
+    timer = setTimeout(() => resolve(false), Math.max(0, deadline - Date.now()));
+    // Never keep the process alive for this timer alone. Present on node,
+    // absent on the browser's timer handles.
+    timer.unref?.();
+  });
+  let fulfilled = promise.then(() => true as const);
+  // A rejection arriving after the deadline has already lost the race, so no
+  // caller is left to observe it. Mark it handled rather than letting it
+  // surface as an unhandled rejection.
+  fulfilled.catch(() => {});
+  try {
+    return await Promise.race([fulfilled, expired]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}


### PR DESCRIPTION
## Background

`_readiness-check` is how a caller asks whether one realm's content is ready to be served. Publishing a realm leans on it hard: `POST /_publish-realm` returns `202` immediately and points the client at `<publishedRealmURL>_readiness-check?awaitPrerenderHtml=true` as the status monitor for the accepted-but-unfinished work. The publish UI polls that URL and only swaps the modal into its finished state — the unpublish control and the "open the published realm" buttons — once it answers ok.

The endpoint answers by clearing four gates in order:

1. `#startedUp` — this process's own mount for the realm, which for a brand-new publish includes its from-scratch index.
2. Any full or incremental index still in flight in this process.
3. The realm's index lane in the shared `jobs` table, so a poll landing on a replica that didn't handle the publish doesn't answer ready off another replica's work.
4. Optionally, the published HTML being live for the realm's current generation.

Gate 3 was budgeted at 10s and gate 4 at 60s, and when a budget expires the endpoint answers `503` with `Retry-After: 1` and an `X-Boxel-Not-Ready` header naming the stage. That design is deliberate: the endpoint's contract is that a not-yet is an *answer*, not a reason to keep the connection open.

## The problem

Gates 1 and 2 had no budget. `await this.#startedUp.promise` holds the request for as long as the realm's startup takes to settle, with no ceiling — and if startup never settles, forever.

That interacts badly with the shape of the canonical caller. `realm-operations.waitForReady` polls serially and has no per-request deadline; it re-checks its own overall budget only *between* requests. So a single held-open request parks the entire poll loop for as long as the gate stalls. The caller's 300s budget never gets consulted, because control never returns to the loop to consult it. From the client's side this is indistinguishable from the server having gone away: no status, no retry hint, no stage name — just a connection that never answers, until whatever deadline sits above the poller (a test timeout, a request timeout, a user closing the tab) fires and the socket is torn down. The realm-server then logs the abandoned request with the framework's default status, which describes nothing about what it was waiting on.

The stall this contains is real: a job whose completion never reaches the process awaiting it leaves `#startedUp` pending indefinitely, and a publish sitting behind that gate reports nothing at all for as long as anyone is willing to wait.

## What this changes

**One deadline now spans every gate, so a request costs one hold no matter how many gates it clears.** The two in-process gates are bounded by it, and the shared index-lane gate inherits what remains instead of starting a fresh budget of its own. When it expires the endpoint answers `503` the way the other gates already did, with `Retry-After: 1` and `X-Boxel-Not-Ready` naming either `startup` or `index`. The work is not cancelled — it keeps running, and a later poll observes it settled. What changes is that the caller gets an answer it can act on, its own deadline governs again, and a stall that clears is picked up by the next poll rather than being missed because the loop was parked on a dead request.

Sharing rather than stacking matters because the budget is sized to a per-attempt deadline: the CI readiness probes cap each attempt at `curl --max-time 15`. A request that spent its budget on startup and then started another full budget on the lane gate would blow past that and hand the probe a connection timeout instead of a readable status — the exact failure the bound exists to remove. `awaitPrerenderHtml` readiness still gates on rendered HTML after that budget with its own, longer one, since a published realm's HTML can take minutes and its callers are pollers with deadlines to match.

`startup` is a new value for the header. It is worth distinguishing from `index`: the two mean different things to an operator — this replica's mount for the realm never finished, versus indexing being outstanding — and they have different remedies.

Each expiry logs a line naming the realm and the gate, reporting the time that gate actually spent rather than the budget. When startup consumes most of the deadline the later gates expire almost immediately, and a message naming the full budget would send an operator looking for a slow index that never happened.

A rejected `#startedUp` still propagates as it did, rather than being flattened into "not ready": startup having *failed* is a different answer from startup being outstanding, and a caller needs to tell them apart.

**The bound lives in a small helper, `settledBy(promise, deadline)`.** It is deliberately not a timeout — nothing is cancelled or abandoned. It reports whether in-flight work finished inside a window and leaves the work running, which is the shape every gate in front of long-running background work wants. It takes an absolute deadline rather than a duration precisely so several gates can share one.

**Test call sites that asked once now poll.** Three tests drove `_readiness-check` with a single request and asserted `200`, relying on the endpoint blocking until ready — which is the behavior this removes. They now poll, matching the contract the endpoint documents with `Retry-After`.

**The custom-subdomain publish test waits for the publish to finish as its own step.** Publishing a brand-new realm runs a from-scratch index plus a prerender pass server-side, and the test previously walked straight from the publish click to a popup-triggering click on a control that only renders once the claimed domain reports published. A stall therefore surfaced as a popup that never arrived next to a click still hunting for its target. Waiting on that control explicitly makes a stalled publish fail on the wait, naming the stage that stalled.

## What this does not cover

The hold on the **cold-mount path** is unchanged and still unbounded. A request for a realm this process has never mounted resolves through `findOrMountRealm` → `lookupOrMount` → `ensureMounted`, whose promise awaits `realm.start()` — and that await happens before `readinessCheck` runs, so the budget here does not reach it. The first poll to a replica that has never seen the realm can still block for the whole from-scratch index, or indefinitely if startup never settles. From the second poll onward the realm is in `realms[]` and the request reaches the bounded gates. Bounding the routing layer is a separate change.

## Test plan

- `settled-by-test.ts` covers the helper: work finishing inside the window; work still outstanding at the deadline releasing the caller (asserted on both bounds, so neither an always-false nor a never-expiring implementation passes); an already-past deadline; the tie the gates depend on, where already-finished work reports settled even against an expired deadline; a rejection propagating; and a rejection arriving after the deadline not surfacing as an unhandled rejection. One case runs in a subprocess: a deadline timer that does not hold the event loop lets node exit with the gate still pending, and that is invisible from inside a test harness that keeps its own work on the loop. Green locally, and each of the two load-bearing cases fails when the behavior it pins is removed.
- `realm-endpoints/readiness-check-test.ts` gains a case that drives the endpoint on a realm that is mounted but never started — the never-settles end of the spectrum a publish poll sits on — and asserts it answers `503` with `X-Boxel-Not-Ready: startup` rather than holding the request. Green locally; it hangs against an unbounded gate.
- The module's existing cases still assert the contract this extends: an idle realm reports ready, which every gate falls through immediately to satisfy, and a job parked in the index lane behind a live reservation still yields `503` with `X-Boxel-Not-Ready: index`. Those need a matrix login the local sandbox could not supply, so they are covered here by CI.
