### PR TITLE
Add HtmlDef with sandboxed preview and structural metadata extraction

### DIFF
--- a/packages/base/file-formats/html-preview.gts
+++ b/packages/base/file-formats/html-preview.gts
@@ -1,0 +1,316 @@
+// The web family's renderer, projected into the format shells by
+// `FilePreviewStage`. A detailed view shows the document the way a browser
+// would — inside a sandboxed iframe in an opaque origin — with a source view
+// beside it, because an HTML file is both a rendered page and inspectable
+// markup. A fitted cell never mounts a frame: a collection of documents must
+// not each fetch and execute a page, so it gets a static prose summary built
+// from the extracted metadata.
+//
+// Sandbox posture: the source is fetched with the caller's session and handed
+// to the frame as `srcdoc`, so the document renders from an opaque origin with
+// no cookies, storage, or realm session. `allow-scripts` (without
+// `allow-same-origin`) lets authored behavior run inside that isolation;
+// powerful features are denied outright.
+import { on } from '@ember/modifier';
+import type Owner from '@ember/owner';
+import GlimmerComponent from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import { eq } from '@cardstack/boxel-ui/helpers';
+
+import type { FilePreviewSignature } from './file-preview-stage';
+
+// Preserve the canonical FileDef URL inside a generated `<base>` element.
+function escapeAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// Relative assets in the document resolve beside the file itself, not against
+// the opaque `srcdoc` origin's meaningless base.
+export function sourceWithBaseURL(source: string, sourceURL: string): string {
+  let base = `<base href="${escapeAttribute(sourceURL)}">`;
+  if (/<head(?:\s[^>]*)?>/i.test(source)) {
+    return source.replace(/<head(?:\s[^>]*)?>/i, (head) => `${head}${base}`);
+  }
+  if (/<html(?:\s[^>]*)?>/i.test(source)) {
+    return source.replace(
+      /<html(?:\s[^>]*)?>/i,
+      (html) => `${html}<head>${base}</head>`,
+    );
+  }
+  return `<head>${base}</head>${source}`;
+}
+
+const COPY_FEEDBACK_MS = 2000;
+
+export class HtmlPreview extends GlimmerComponent<FilePreviewSignature> {
+  @tracked view: 'rendered' | 'source' = 'rendered';
+  @tracked sourceText: string | undefined;
+  @tracked loadError = '';
+  @tracked copied = false;
+  copyFeedbackTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(owner: Owner, args: FilePreviewSignature['Args']) {
+    super(owner, args);
+    if (!this.isFitted && this.sourceUrl) {
+      void this.loadSource();
+    }
+  }
+
+  willDestroy() {
+    super.willDestroy();
+    if (this.copyFeedbackTimer) {
+      clearTimeout(this.copyFeedbackTimer);
+    }
+  }
+
+  get isFitted() {
+    return this.args.mode === 'fitted';
+  }
+
+  get sourceUrl() {
+    return String(this.args.model?.resourceUrl ?? this.args.model?.url ?? '');
+  }
+
+  get frameTitle() {
+    return `${
+      this.args.model?.baseName ?? this.args.model?.name ?? 'HTML document'
+    } preview`;
+  }
+
+  // One authenticated fetch serves both the rendered frame and the source
+  // view. `same-origin` rather than `include`: the realm answers with
+  // `Access-Control-Allow-Origin: *`, which a credentialed cross-origin
+  // request rejects; the auth service worker carries the session instead.
+  async loadSource() {
+    try {
+      let response = await fetch(this.sourceUrl, {
+        credentials: 'same-origin',
+      });
+      if (!response.ok) {
+        throw new Error(`HTML fetch failed with HTTP ${response.status}`);
+      }
+      let text = await response.text();
+      if (this.isDestroyed || this.isDestroying) {
+        return;
+      }
+      this.sourceText = text;
+    } catch (error) {
+      if (this.isDestroyed || this.isDestroying) {
+        return;
+      }
+      this.loadError =
+        error instanceof Error ? error.message : 'HTML preview unavailable';
+    }
+  }
+
+  get framedSource() {
+    if (this.sourceText == null) {
+      return undefined;
+    }
+    return sourceWithBaseURL(this.sourceText, this.sourceUrl);
+  }
+
+  // Reads the extracted fields off the FileDef itself; the shared projection
+  // doesn't carry an excerpt.
+  get summaryTitle() {
+    return (
+      this.args.model?.title ??
+      this.args.model?.htmlMetadata?.documentTitle ??
+      this.args.model?.baseName ??
+      ''
+    );
+  }
+
+  get summaryExcerpt() {
+    return String(this.args.model?.source?.excerpt ?? '');
+  }
+
+  showRendered = () => {
+    this.view = 'rendered';
+  };
+
+  showSource = () => {
+    this.view = 'source';
+  };
+
+  // Keep the clipboard write inside the gesture that asked for it.
+  copySource = async () => {
+    if (this.sourceText == null) {
+      return;
+    }
+    await navigator.clipboard.writeText(this.sourceText);
+    if (this.copyFeedbackTimer) {
+      clearTimeout(this.copyFeedbackTimer);
+    }
+    this.copied = true;
+    this.copyFeedbackTimer = setTimeout(() => {
+      this.copied = false;
+    }, COPY_FEEDBACK_MS);
+  };
+
+  <template>
+    <div class='html-preview' data-mode={{@mode}} data-test-html-preview>
+      {{#if this.isFitted}}
+        <div class='summary' data-test-html-summary>
+          {{#if this.summaryTitle}}
+            <strong class='summary-title'>{{this.summaryTitle}}</strong>
+          {{/if}}
+          {{#if this.summaryExcerpt}}
+            <p class='summary-excerpt'>{{this.summaryExcerpt}}</p>
+          {{/if}}
+        </div>
+      {{else if this.loadError}}
+        <div class='load-error' data-test-html-load-error>
+          <span>Preview unavailable</span>
+          <span class='error-detail'>{{this.loadError}}</span>
+        </div>
+      {{else}}
+        {{#if (eq this.view 'rendered')}}
+          <iframe
+            class='frame'
+            title={{this.frameTitle}}
+            sandbox='allow-scripts'
+            referrerpolicy='no-referrer'
+            allow="camera 'none'; microphone 'none'; geolocation 'none'"
+            srcdoc={{this.framedSource}}
+            data-test-html-frame
+          ></iframe>
+        {{else}}
+          <pre class='source' data-test-html-source>{{this.sourceText}}</pre>
+        {{/if}}
+        <div class='controls'>
+          <button
+            type='button'
+            class='control {{if (eq this.view "rendered") "active"}}'
+            data-test-html-view-rendered
+            {{on 'click' this.showRendered}}
+          >Rendered</button>
+          <button
+            type='button'
+            class='control {{if (eq this.view "source") "active"}}'
+            data-test-html-view-source
+            {{on 'click' this.showSource}}
+          >Source</button>
+          {{#if (eq this.view 'source')}}
+            <button
+              type='button'
+              class='control'
+              aria-live='polite'
+              data-test-html-copy-source
+              {{on 'click' this.copySource}}
+            >{{if this.copied 'Copied' 'Copy'}}</button>
+          {{/if}}
+        </div>
+      {{/if}}
+    </div>
+    <style scoped>
+      .html-preview {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        min-width: 0;
+        min-height: 0;
+        overflow: hidden;
+        isolation: isolate;
+        background: var(--card, #fff);
+      }
+      .frame {
+        display: block;
+        width: 100%;
+        height: 100%;
+        border: 0;
+        background: var(--card, #fff);
+      }
+      .source {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0.75rem;
+        overflow: auto;
+        font-family: var(--font-mono);
+        font-size: 0.6875rem;
+        line-height: 1.5;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+        color: var(--foreground);
+        background: var(--card, #fff);
+      }
+      .controls {
+        position: absolute;
+        z-index: 2;
+        top: 0.5rem;
+        right: 0.5rem;
+        display: flex;
+        gap: 0.25rem;
+      }
+      .control {
+        min-height: 1.75rem;
+        padding: 0 0.625rem;
+        border: 1px solid var(--border);
+        border-radius: 0.375rem;
+        background: color-mix(in srgb, var(--card, #fff) 92%, transparent);
+        color: var(--foreground);
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      .control.active {
+        background: var(--fd-slate, var(--foreground));
+        border-color: var(--fd-slate, var(--foreground));
+        color: var(--fd-paper, var(--card, #f7f7f5));
+      }
+      .summary {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+        padding: 0.625rem 0.75rem;
+        overflow: hidden;
+        text-align: left;
+        background: var(--fd-paper, var(--card, #f7f7f5));
+      }
+      .summary-title {
+        font-size: 0.75rem;
+        font-weight: 600;
+        line-height: 1.3;
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+        line-clamp: 2;
+      }
+      .summary-excerpt {
+        margin: 0;
+        font-size: 0.625rem;
+        line-height: 1.5;
+        color: var(--muted-foreground);
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 5;
+        line-clamp: 5;
+      }
+      .load-error {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.375rem;
+        padding: 0.625rem;
+        color: var(--muted-foreground);
+        font-size: 0.6875rem;
+      }
+      .error-detail {
+        font-family: var(--font-mono);
+        font-size: 0.5625rem;
+      }
+    </style>
+  </template>
+}

--- a/packages/base/file-formats/html-preview.gts
+++ b/packages/base/file-formats/html-preview.gts
@@ -51,7 +51,7 @@ export class HtmlPreview extends GlimmerComponent<FilePreviewSignature> {
   @tracked view: 'rendered' | 'source' = 'rendered';
   @tracked sourceText: string | undefined;
   @tracked loadError = '';
-  @tracked copied = false;
+  @tracked copyState: 'idle' | 'copied' | 'failed' = 'idle';
   copyFeedbackTimer?: ReturnType<typeof setTimeout>;
 
   constructor(owner: Owner, args: FilePreviewSignature['Args']) {
@@ -138,18 +138,34 @@ export class HtmlPreview extends GlimmerComponent<FilePreviewSignature> {
     this.view = 'source';
   };
 
-  // Keep the clipboard write inside the gesture that asked for it.
+  get copyLabel() {
+    if (this.copyState === 'copied') {
+      return 'Copied';
+    }
+    if (this.copyState === 'failed') {
+      return 'Copy failed';
+    }
+    return 'Copy';
+  }
+
+  // Keep the clipboard write inside the gesture that asked for it. The write
+  // can be refused (permissions, an unfocused document), and a refusal is
+  // feedback for the button, not an unhandled rejection.
   copySource = async () => {
     if (this.sourceText == null) {
       return;
     }
-    await navigator.clipboard.writeText(this.sourceText);
+    try {
+      await navigator.clipboard.writeText(this.sourceText);
+      this.copyState = 'copied';
+    } catch {
+      this.copyState = 'failed';
+    }
     if (this.copyFeedbackTimer) {
       clearTimeout(this.copyFeedbackTimer);
     }
-    this.copied = true;
     this.copyFeedbackTimer = setTimeout(() => {
-      this.copied = false;
+      this.copyState = 'idle';
     }, COPY_FEEDBACK_MS);
   };
 
@@ -203,7 +219,7 @@ export class HtmlPreview extends GlimmerComponent<FilePreviewSignature> {
               aria-live='polite'
               data-test-html-copy-source
               {{on 'click' this.copySource}}
-            >{{if this.copied 'Copied' 'Copy'}}</button>
+            >{{this.copyLabel}}</button>
           {{/if}}
         </div>
       {{/if}}

--- a/packages/base/file-formats/index.ts
+++ b/packages/base/file-formats/index.ts
@@ -65,6 +65,7 @@ export {
   ColorProfileField,
   ExifMetadataField,
   GeoLocationField,
+  HtmlMetadataField,
   METADATA_VOCABULARIES,
   QuantityField,
   labelForCode,

--- a/packages/base/file-formats/metadata-fields.gts
+++ b/packages/base/file-formats/metadata-fields.gts
@@ -25,6 +25,7 @@ import TagIcon from '@cardstack/boxel-icons/tag';
 import KeyboardMusicIcon from '@cardstack/boxel-icons/keyboard-music';
 import TagsIcon from '@cardstack/boxel-icons/tags';
 
+import FileCodeIcon from '@cardstack/boxel-icons/file-code';
 import FileInfoIcon from '@cardstack/boxel-icons/file-info';
 
 import {
@@ -228,7 +229,9 @@ export class CameraCaptureField extends FieldDef {
     },
   });
 
-  static embedded = class Embedded extends Component<typeof CameraCaptureField> {
+  static embedded = class Embedded extends Component<
+    typeof CameraCaptureField
+  > {
     <template>
       <dl class='metadata-rows'>
         {{#if @model.cameraName}}
@@ -416,7 +419,8 @@ export class ColorProfileField extends FieldDef {
               /></dd></div>
         {{/if}}
         {{#if @model.bitDepth}}
-          <div class='row'><dt>Bit depth</dt><dd>{{@model.bitDepth}}-bit</dd></div>
+          <div class='row'><dt>Bit depth</dt><dd
+            >{{@model.bitDepth}}-bit</dd></div>
         {{/if}}
         {{#if @model.channels}}
           <div class='row'><dt>Channels</dt><dd>{{@model.channels}}</dd></div>
@@ -425,7 +429,8 @@ export class ColorProfileField extends FieldDef {
           <div class='row'><dt>Alpha</dt><dd>{{@model.hasAlphaLabel}}</dd></div>
         {{/if}}
         {{#if @model.iccProfile}}
-          <div class='row'><dt>ICC profile</dt><dd>{{@model.iccProfile}}</dd></div>
+          <div class='row'><dt>ICC profile</dt><dd
+            >{{@model.iccProfile}}</dd></div>
         {{/if}}
       </dl>
       <style scoped>
@@ -549,13 +554,14 @@ export class MediaEncodingField extends FieldDef {
               }}<span class='qualifier'>VBR</span>{{/if}}</dd></div>
         {{/if}}
         {{#if @model.bitDepth}}
-          <div class='row'><dt>Bit depth</dt><dd>{{@model.bitDepth}}-bit</dd></div>
+          <div class='row'><dt>Bit depth</dt><dd
+            >{{@model.bitDepth}}-bit</dd></div>
         {{/if}}
         {{#if @model.channels}}
           <div class='row'><dt>Channels</dt><dd>{{@model.channels}}{{#if
                 @model.channelMode.label
               }}<span class='qualifier'><@fields.channelMode
-                /></span>{{/if}}</dd></div>
+                  /></span>{{/if}}</dd></div>
         {{/if}}
       </dl>
       <style scoped>
@@ -633,7 +639,8 @@ export class MediaTagsField extends FieldDef {
           <div class='row'><dt>Album</dt><dd>{{@model.album}}</dd></div>
         {{/if}}
         {{#if @model.albumArtist}}
-          <div class='row'><dt>Album artist</dt><dd>{{@model.albumArtist}}</dd></div>
+          <div class='row'><dt>Album artist</dt><dd
+            >{{@model.albumArtist}}</dd></div>
         {{/if}}
         {{#if @model.composer}}
           <div class='row'><dt>Composer</dt><dd>{{@model.composer}}</dd></div>
@@ -725,17 +732,21 @@ export class WaveformMetadataField extends FieldDef {
           <div class='row'><dt>Status</dt><dd>{{@model.decodeStatus}}</dd></div>
         {{/if}}
         {{#if @model.barCount}}
-          <div class='row'><dt>Envelope</dt><dd>{{@model.barCount}} bars ·
+          <div class='row'><dt>Envelope</dt><dd>{{@model.barCount}}
+              bars ·
               {{@model.algorithm}}</dd></div>
         {{/if}}
         {{#if @model.durationSeconds}}
-          <div class='row'><dt>Duration</dt><dd>{{@model.durationSeconds}} s</dd></div>
+          <div class='row'><dt>Duration</dt><dd>{{@model.durationSeconds}}
+              s</dd></div>
         {{/if}}
         {{#if @model.sampleRateHz}}
-          <div class='row'><dt>Sample rate</dt><dd>{{@model.sampleRateHz}} Hz</dd></div>
+          <div class='row'><dt>Sample rate</dt><dd>{{@model.sampleRateHz}}
+              Hz</dd></div>
         {{/if}}
         {{#if @model.channelCount}}
-          <div class='row'><dt>Channels</dt><dd>{{@model.channelCount}}</dd></div>
+          <div class='row'><dt>Channels</dt><dd
+            >{{@model.channelCount}}</dd></div>
         {{/if}}
         {{#if @model.peakAmplitude}}
           <div class='row'><dt>Peak</dt><dd>{{@model.peakAmplitude}}</dd></div>
@@ -744,7 +755,9 @@ export class WaveformMetadataField extends FieldDef {
           <div class='row'><dt>RMS</dt><dd>{{@model.rmsAmplitude}}</dd></div>
         {{/if}}
         {{#if @model.decodeError}}
-          <div class='row'><dt>Decode</dt><dd class='decode-error'>{{@model.decodeError}}</dd></div>
+          <div class='row'><dt>Decode</dt><dd
+              class='decode-error'
+            >{{@model.decodeError}}</dd></div>
         {{/if}}
       </dl>
       <style scoped>
@@ -810,9 +823,7 @@ export class MidiMetadataField extends FieldDef {
   @field pitchRange = contains(StringField);
   @field hasPercussion = contains(BooleanField);
 
-  static embedded = class Embedded extends Component<
-    typeof MidiMetadataField
-  > {
+  static embedded = class Embedded extends Component<typeof MidiMetadataField> {
     <template>
       <dl class='metadata-rows'>
         {{#if @model.trackCount}}
@@ -826,16 +837,19 @@ export class MidiMetadataField extends FieldDef {
           <div class='row'><dt>Notes</dt><dd>{{@model.noteCount}}</dd></div>
         {{/if}}
         {{#if @model.durationSeconds}}
-          <div class='row'><dt>Duration</dt><dd>{{@model.durationSeconds}} s</dd></div>
+          <div class='row'><dt>Duration</dt><dd>{{@model.durationSeconds}}
+              s</dd></div>
         {{/if}}
         {{#if @model.keySignatures.length}}
           <div class='row'><dt>Key</dt><dd class='list'>{{#each
-                @model.keySignatures as |key|
+                @model.keySignatures
+                as |key|
               }}<span>{{key}}</span>{{/each}}</dd></div>
         {{/if}}
         {{#if @model.timeSignatures.length}}
           <div class='row'><dt>Meter</dt><dd class='list'>{{#each
-                @model.timeSignatures as |meter|
+                @model.timeSignatures
+                as |meter|
               }}<span>{{meter}}</span>{{/each}}</dd></div>
         {{/if}}
         {{#if @model.pitchRange}}
@@ -843,12 +857,14 @@ export class MidiMetadataField extends FieldDef {
         {{/if}}
         {{#if @model.tempoMap.length}}
           <div class='row'><dt>Tempo</dt><dd class='list'>{{#each
-                @model.tempoMap as |tempo|
+                @model.tempoMap
+                as |tempo|
               }}<span>{{tempo}}</span>{{/each}}</dd></div>
         {{/if}}
         {{#if @model.channels.length}}
           <div class='row'><dt>Channels</dt><dd class='list'>{{#each
-                @model.channels as |channel|
+                @model.channels
+                as |channel|
               }}<span>{{channel}}</span>{{/each}}</dd></div>
         {{/if}}
         <div class='row'><dt>Percussion</dt><dd>{{if
@@ -888,6 +904,118 @@ export class MidiMetadataField extends FieldDef {
           display: flex;
           flex-wrap: wrap;
           gap: 0.125rem 0.5rem;
+        }
+      </style>
+    </template>
+  };
+}
+
+// The structural shape of an HTML document: what the markup contains, not what
+// the browser would paint. `isInteractive` is the one derived member —
+// authored scripts or form controls make a document interactive — and it is
+// persisted rather than recomputed so a query can ask for interactive
+// documents without re-reading every file.
+export class HtmlMetadataField extends FieldDef {
+  static displayName = 'HTML Metadata';
+  static icon = FileCodeIcon;
+
+  @field documentTitle = contains(StringField);
+  @field documentLanguage = contains(StringField);
+  @field elementCount = contains(NumberField);
+  @field wordCount = contains(NumberField);
+  @field headingCount = contains(NumberField);
+  @field linkCount = contains(NumberField);
+  @field imageCount = contains(NumberField);
+  @field formControlCount = contains(NumberField);
+  @field scriptCount = contains(NumberField);
+  @field styleSheetCount = contains(NumberField);
+  @field externalResourceCount = contains(NumberField);
+  @field hasDoctype = contains(BooleanField);
+  @field hasViewportMeta = contains(BooleanField);
+  @field hasInlineScript = contains(BooleanField);
+  @field hasModuleScript = contains(BooleanField);
+  @field isInteractive = contains(BooleanField);
+
+  // A genuine `false` ("static document") must render, while a never-extracted
+  // value must not — the same distinction `ColorProfileField.hasAlphaLabel`
+  // preserves for alpha channels.
+  @field interactivityLabel = contains(StringField, {
+    computeVia: function (this: HtmlMetadataField) {
+      if (this.isInteractive == null) {
+        return '';
+      }
+      return this.isInteractive ? 'Interactive' : 'Static document';
+    },
+  });
+
+  static embedded = class Embedded extends Component<typeof HtmlMetadataField> {
+    <template>
+      <dl class='metadata-rows'>
+        {{#if @model.documentLanguage}}
+          <div class='row'><dt>Language</dt><dd
+            >{{@model.documentLanguage}}</dd></div>
+        {{/if}}
+        {{#if @model.elementCount}}
+          <div class='row'><dt>Elements</dt><dd
+            >{{@model.elementCount}}</dd></div>
+        {{/if}}
+        {{#if @model.wordCount}}
+          <div class='row'><dt>Words</dt><dd>{{@model.wordCount}}</dd></div>
+        {{/if}}
+        {{#if @model.headingCount}}
+          <div class='row'><dt>Headings</dt><dd
+            >{{@model.headingCount}}</dd></div>
+        {{/if}}
+        {{#if @model.linkCount}}
+          <div class='row'><dt>Links</dt><dd>{{@model.linkCount}}</dd></div>
+        {{/if}}
+        {{#if @model.imageCount}}
+          <div class='row'><dt>Images</dt><dd>{{@model.imageCount}}</dd></div>
+        {{/if}}
+        {{#if @model.formControlCount}}
+          <div class='row'><dt>Form controls</dt><dd
+            >{{@model.formControlCount}}</dd></div>
+        {{/if}}
+        {{#if @model.scriptCount}}
+          <div class='row'><dt>Scripts</dt><dd>{{@model.scriptCount}}</dd></div>
+        {{/if}}
+        {{#if @model.styleSheetCount}}
+          <div class='row'><dt>Style sheets</dt><dd
+            >{{@model.styleSheetCount}}</dd></div>
+        {{/if}}
+        {{#if @model.externalResourceCount}}
+          <div class='row'><dt>External refs</dt><dd
+            >{{@model.externalResourceCount}}</dd></div>
+        {{/if}}
+        {{#if @model.interactivityLabel}}
+          <div class='row'><dt>Behavior</dt><dd
+            >{{@model.interactivityLabel}}</dd></div>
+        {{/if}}
+      </dl>
+      <style scoped>
+        .metadata-rows {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.3125rem;
+          font-size: 0.75rem;
+        }
+        .row {
+          display: flex;
+          gap: 0.625rem;
+          align-items: baseline;
+        }
+        dt {
+          flex: 0 0 5.75rem;
+          font-family: var(--font-mono);
+          font-size: 0.5625rem;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: var(--muted-foreground);
+        }
+        dd {
+          margin: 0;
+          min-width: 0;
         }
       </style>
     </template>

--- a/packages/base/html-file-def.gts
+++ b/packages/base/html-file-def.gts
@@ -1,0 +1,93 @@
+import { byteStreamToUint8Array } from '@cardstack/runtime-common';
+import FileCodeIcon from '@cardstack/boxel-icons/file-code';
+import { StringField, contains, field } from './card-api';
+import {
+  FileContentMismatchError,
+  FileDef,
+  type ByteStream,
+  type SerializedFile,
+} from './file-api';
+import { HtmlMetadataField } from './file-formats/metadata-fields';
+import { HtmlPreview } from './file-formats/html-preview';
+import {
+  extractHtmlExcerpt,
+  extractHtmlMetadata,
+  type HtmlDocumentMetadata,
+} from './html-meta-extractor';
+
+const HTML_EXTENSIONS = new Set(['.html', '.htm']);
+const EXCERPT_MAX_LENGTH = 500;
+
+function getExtension(url: string): string {
+  try {
+    let parsed = new URL(url);
+    let name = parsed.pathname.split('/').pop() ?? '';
+    let dot = name.lastIndexOf('.');
+    return dot === -1 ? '' : name.slice(dot).toLowerCase();
+  } catch {
+    let dot = url.lastIndexOf('.');
+    return dot === -1 ? '' : url.slice(dot).toLowerCase();
+  }
+}
+
+function fileNameWithoutExtension(name: string): string {
+  return name.replace(/\.[^/.]+$/, '');
+}
+
+// A browser document, not a code file or a prose file: it has a rendered form
+// (safe inside a sandboxed frame) and an inspectable source form, and its
+// metadata describes DOM shape rather than syntax. The four formats come from
+// FileDef's shared shells; this class supplies only its renderer and the
+// structural facts the extract persists — never a second copy of the source,
+// which the preview fetches at view time.
+export class HtmlDef extends FileDef {
+  static displayName = 'HTML File';
+  static icon = FileCodeIcon;
+  static acceptTypes = '.html,.htm,text/html';
+
+  @field title = contains(StringField);
+  @field excerpt = contains(StringField);
+  @field htmlMetadata = contains(HtmlMetadataField);
+
+  static previewComponent = HtmlPreview;
+
+  static async extractAttributes(
+    url: string,
+    getStream: () => Promise<ByteStream>,
+    options: { contentHash?: string } = {},
+  ): Promise<
+    SerializedFile<{
+      title: string;
+      excerpt: string;
+      htmlMetadata: HtmlDocumentMetadata;
+    }>
+  > {
+    let extension = getExtension(url);
+    if (!HTML_EXTENSIONS.has(extension)) {
+      throw new FileContentMismatchError(
+        `Expected HTML file extension, got "${extension || 'none'}"`,
+      );
+    }
+
+    let bytesPromise: Promise<Uint8Array> | undefined;
+    let memoizedStream = async () => {
+      bytesPromise ??= byteStreamToUint8Array(await getStream());
+      return bytesPromise;
+    };
+
+    let base = await super.extractAttributes(url, memoizedStream, options);
+    let bytes = await memoizedStream();
+    let text = new TextDecoder().decode(bytes);
+    let htmlMetadata = extractHtmlMetadata(text);
+    let fallbackTitle = fileNameWithoutExtension(base.name ?? '');
+
+    return {
+      ...base,
+      title: htmlMetadata.documentTitle ?? fallbackTitle ?? 'Untitled page',
+      excerpt: extractHtmlExcerpt(text, EXCERPT_MAX_LENGTH),
+      htmlMetadata,
+    };
+  }
+}
+
+export default HtmlDef;

--- a/packages/base/html-file-def.gts
+++ b/packages/base/html-file-def.gts
@@ -83,7 +83,9 @@ export class HtmlDef extends FileDef {
 
     return {
       ...base,
-      title: htmlMetadata.documentTitle ?? fallbackTitle ?? 'Untitled page',
+      // `||`, not `??`: a file named bare `.html` leaves an empty-string
+      // fallback title, which must not persist as the title.
+      title: (htmlMetadata.documentTitle ?? fallbackTitle) || 'Untitled page',
       excerpt: extractHtmlExcerpt(text, EXCERPT_MAX_LENGTH),
       htmlMetadata,
     };

--- a/packages/base/html-meta-extractor.ts
+++ b/packages/base/html-meta-extractor.ts
@@ -1,0 +1,111 @@
+// Header-free structural facts about an HTML document, computed with
+// dependency-free text scans so the same reader works in the browser, the CLI,
+// and the indexer. The extract persists bounded metadata only — never a second
+// copy of the source; a preview fetches the document itself at view time.
+
+export interface HtmlDocumentMetadata {
+  documentTitle?: string;
+  documentLanguage?: string;
+  elementCount: number;
+  wordCount: number;
+  headingCount: number;
+  linkCount: number;
+  imageCount: number;
+  formControlCount: number;
+  scriptCount: number;
+  styleSheetCount: number;
+  externalResourceCount: number;
+  hasDoctype: boolean;
+  hasViewportMeta: boolean;
+  hasInlineScript: boolean;
+  hasModuleScript: boolean;
+  isInteractive: boolean;
+}
+
+// Small metadata strings need common entity decoding, not a DOM dependency.
+function decodeHtmlText(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&#x([0-9a-f]+);/gi, (_match, code) =>
+      String.fromCodePoint(parseInt(code, 16)),
+    )
+    .replace(/&#(\d+);/g, (_match, code) => String.fromCodePoint(Number(code)));
+}
+
+// The document's readable prose with scripts, styles, and markup stripped.
+function visibleText(text: string): string {
+  return decodeHtmlText(
+    text
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' '),
+  )
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function extractHtmlMetadata(text: string): HtmlDocumentMetadata {
+  let titleMarkup = text.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? '';
+  let documentTitle = decodeHtmlText(
+    titleMarkup
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim(),
+  );
+  let documentLanguage =
+    text.match(/<html\b[^>]*\blang\s*=\s*["']([^"']+)["']/i)?.[1]?.trim() ?? '';
+  let scripts = [...text.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi)];
+  let styleBlocks = [...text.matchAll(/<style\b[^>]*>[\s\S]*?<\/style>/gi)]
+    .length;
+  let linkedStyleSheets = [
+    ...text.matchAll(
+      /<link\b[^>]*\brel\s*=\s*["'][^"']*stylesheet[^"']*["'][^>]*>/gi,
+    ),
+  ].length;
+  let formControlCount = [
+    ...text.matchAll(/<(?:button|input|select|textarea)\b[^>]*>/gi),
+  ].length;
+  let inlineScripts = scripts.filter(
+    (match) => !/\bsrc\s*=/.test(match[1] ?? '') && Boolean(match[2]?.trim()),
+  );
+
+  return {
+    ...(documentTitle ? { documentTitle } : {}),
+    ...(documentLanguage ? { documentLanguage } : {}),
+    elementCount: [...text.matchAll(/<([a-z][\w:-]*)\b[^>]*>/gi)].length,
+    wordCount: visibleText(text).split(/\s+/).filter(Boolean).length,
+    headingCount: [...text.matchAll(/<h[1-6]\b[^>]*>/gi)].length,
+    linkCount: [...text.matchAll(/<a\b[^>]*>/gi)].length,
+    imageCount: [...text.matchAll(/<img\b[^>]*>/gi)].length,
+    formControlCount,
+    scriptCount: scripts.length,
+    styleSheetCount: styleBlocks + linkedStyleSheets,
+    externalResourceCount: [
+      ...text.matchAll(/\b(?:src|href)\s*=\s*["']https?:\/\/[^"']+["']/gi),
+    ].length,
+    hasDoctype: /<!doctype\s+html\b/i.test(text),
+    hasViewportMeta: /<meta\b[^>]*\bname\s*=\s*["']viewport["'][^>]*>/i.test(
+      text,
+    ),
+    hasInlineScript: inlineScripts.length > 0,
+    hasModuleScript: scripts.some((match) =>
+      /\btype\s*=\s*["']module["']/.test(match[1] ?? ''),
+    ),
+    // Authored behavior or input affordances make a document interactive; prose
+    // with neither is a static page however elaborate its styling.
+    isInteractive: scripts.length > 0 || formControlCount > 0,
+  };
+}
+
+export function extractHtmlExcerpt(text: string, maxLength: number): string {
+  let prose = visibleText(text);
+  if (prose.length <= maxLength) {
+    return prose;
+  }
+  return `${prose.slice(0, maxLength - 3).trimEnd()}...`;
+}

--- a/packages/base/html-meta-extractor.ts
+++ b/packages/base/html-meta-extractor.ts
@@ -22,6 +22,15 @@ export interface HtmlDocumentMetadata {
   isInteractive: boolean;
 }
 
+// An entity above the Unicode range would make `fromCodePoint` throw, and this
+// decoder runs inside the index pass against hostile markup — so an invalid
+// reference stays as written rather than crashing the extract.
+function decodedCodePoint(raw: string, point: number): string {
+  return Number.isInteger(point) && point >= 0 && point <= 0x10ffff
+    ? String.fromCodePoint(point)
+    : raw;
+}
+
 // Small metadata strings need common entity decoding, not a DOM dependency.
 function decodeHtmlText(value: string): string {
   return value
@@ -31,10 +40,12 @@ function decodeHtmlText(value: string): string {
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
     .replace(/&#39;|&apos;/gi, "'")
-    .replace(/&#x([0-9a-f]+);/gi, (_match, code) =>
-      String.fromCodePoint(parseInt(code, 16)),
+    .replace(/&#x([0-9a-f]+);/gi, (match, code) =>
+      decodedCodePoint(match, parseInt(code, 16)),
     )
-    .replace(/&#(\d+);/g, (_match, code) => String.fromCodePoint(Number(code)));
+    .replace(/&#(\d+);/g, (match, code) =>
+      decodedCodePoint(match, Number(code)),
+    );
 }
 
 // The document's readable prose with scripts, styles, and markup stripped.

--- a/packages/host/tests/acceptance/html-def-test.gts
+++ b/packages/host/tests/acceptance/html-def-test.gts
@@ -1,0 +1,326 @@
+import { visit, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import {
+  baseRealmRRI,
+  type FileExtractResponse,
+  type RenderRouteOptions,
+  type ResolvedCodeRef,
+  SupportedMimeType,
+  type RealmResourceIdentifier,
+} from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common/realm';
+
+import type NetworkService from '@cardstack/host/services/network';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  setupRealmCacheTeardown,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  capturePrerenderResult,
+  withCachedRealmSetup,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+import { setupTestRealmServiceWorker } from '../helpers/test-realm-service-worker';
+
+const INTERACTIVE_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Release &amp; Dispatch Report</title>
+    <style>body { font-family: sans-serif; }</style>
+  </head>
+  <body>
+    <h1>Dispatch board</h1>
+    <p>Seven trucks left the depot before dawn.</p>
+    <a href="https://example.com/fleet">Fleet roster</a>
+    <img src="./depot.png" alt="Depot">
+    <form><input type="text"><button type="submit">Send</button></form>
+    <script type="module">document.title = 'Loaded';</script>
+  </body>
+</html>`;
+
+const STATIC_HTML = `<p>Just a paragraph, no head, no scripts.</p>`;
+
+module('Acceptance | html def', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+  setupRealmCacheTeardown(hooks);
+  setupTestRealmServiceWorker(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+  let realm: Realm;
+
+  const fileExtractPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/file-extract`;
+
+  const fileRenderPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    format = 'isolated',
+    ancestorLevel = 0,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/html/${format}/${ancestorLevel}`;
+
+  const makeFileURL = (path: string) => new URL(path, testRealmURL).href;
+
+  const htmlDefCodeRef = (): ResolvedCodeRef => ({
+    module: `${baseRealmRRI}html-file-def` as RealmResourceIdentifier,
+    name: 'HtmlDef',
+  });
+
+  async function captureFileExtractResult(
+    expectedStatus?: 'ready' | 'error',
+  ): Promise<FileExtractResponse> {
+    await waitUntil(
+      () => {
+        let container = document.querySelector(
+          '[data-prerender-file-extract]',
+        ) as HTMLElement | null;
+        if (!container) {
+          return false;
+        }
+        let status = container.getAttribute(
+          'data-prerender-file-extract-status',
+        );
+        if (!status) {
+          return false;
+        }
+        if (expectedStatus && status !== expectedStatus) {
+          return false;
+        }
+        return status === 'ready' || status === 'error';
+      },
+      { timeout: 5000 },
+    );
+
+    let container = document.querySelector(
+      '[data-prerender-file-extract]',
+    ) as HTMLElement | null;
+    if (!container) {
+      throw new Error(
+        'captureFileExtractResult: missing [data-prerender-file-extract] container after wait',
+      );
+    }
+    let pre = container.querySelector('pre');
+    let text = pre?.textContent?.trim() ?? '';
+    return JSON.parse(text) as FileExtractResponse;
+  }
+
+  async function renderHtmlFile(url: string, format = 'isolated') {
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: htmlDefCodeRef(),
+      }),
+    );
+    let result = await captureFileExtractResult('ready');
+
+    (globalThis as any).__boxelFileRenderData = {
+      resource: result.resource,
+      fileDefCodeRef: htmlDefCodeRef(),
+    };
+
+    await visit(
+      fileRenderPath(
+        url,
+        { fileRender: true, fileDefCodeRef: htmlDefCodeRef() },
+        format,
+      ),
+    );
+
+    return capturePrerenderResult('innerHTML');
+  }
+
+  hooks.beforeEach(async function () {
+    ({ realm } = await withCachedRealmSetup(async () =>
+      setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'dispatch.html': INTERACTIVE_HTML,
+          'plain.html': STATIC_HTML,
+        },
+      }),
+    ));
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any).__renderModel;
+    delete (globalThis as any).__boxelFileRenderData;
+  });
+
+  test('extracts document structure into the search doc', async function (assert) {
+    let url = makeFileURL('dispatch.html');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: htmlDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(
+      result.searchDoc?.title,
+      'Release & Dispatch Report',
+      'the decoded document title becomes the file title',
+    );
+    let html = result.searchDoc?.htmlMetadata;
+    assert.strictEqual(html?.documentTitle, 'Release & Dispatch Report');
+    assert.strictEqual(html?.documentLanguage, 'en');
+    assert.strictEqual(html?.scriptCount, 1);
+    assert.strictEqual(html?.headingCount, 1);
+    assert.strictEqual(html?.linkCount, 1);
+    assert.strictEqual(html?.imageCount, 1);
+    assert.strictEqual(html?.formControlCount, 2);
+    assert.strictEqual(html?.styleSheetCount, 1);
+    assert.strictEqual(html?.externalResourceCount, 1);
+    assert.true(html?.hasDoctype);
+    assert.true(html?.hasViewportMeta);
+    assert.true(html?.hasInlineScript);
+    assert.true(html?.hasModuleScript);
+    assert.true(html?.isInteractive);
+    assert.ok(
+      String(result.searchDoc?.excerpt).includes('Seven trucks left the depot'),
+      'the excerpt is visible prose, not markup',
+    );
+    assert.strictEqual(
+      result.searchDoc?.content,
+      undefined,
+      'the extract persists structural facts, never a second copy of the source',
+    );
+  });
+
+  test('a titleless fragment stays static and titles from its file name', async function (assert) {
+    let url = makeFileURL('plain.html');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: htmlDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(
+      result.searchDoc?.title,
+      'plain',
+      'file name fills in when the document declares no title',
+    );
+    let html = result.searchDoc?.htmlMetadata;
+    assert.strictEqual(html?.scriptCount, 0);
+    assert.false(html?.isInteractive);
+    assert.false(html?.hasDoctype);
+  });
+
+  test('indexing stores the HTML metadata and file meta serves it', async function (assert) {
+    let fileURL = new URL('dispatch.html', testRealmURL);
+    let fileEntry = await realm.realmIndexQueryEngine.file(fileURL);
+
+    assert.strictEqual(
+      fileEntry?.searchDoc?.htmlMetadata?.documentTitle,
+      'Release & Dispatch Report',
+      'the index row holds the extracted document title',
+    );
+
+    let network = getService('network') as NetworkService;
+    let response = await network.virtualNetwork.fetch(fileURL, {
+      headers: { Accept: SupportedMimeType.FileMeta },
+    });
+    assert.true(response.ok, 'file meta request succeeds');
+
+    let body = await response.json();
+    assert.true(
+      body?.data?.attributes?.htmlMetadata?.isInteractive,
+      'file meta serves the derived interactivity fact',
+    );
+    assert.deepEqual(
+      body?.data?.meta?.adoptsFrom,
+      htmlDefCodeRef(),
+      'file meta uses the HTML def',
+    );
+  });
+
+  test('isolated renders the document in a sandboxed frame inside the shared shell', async function (assert) {
+    let { status } = await renderHtmlFile(makeFileURL('dispatch.html'));
+    assert.strictEqual(status, 'ready', 'render completed');
+
+    assert.ok(
+      document.querySelector('[data-prerender] [data-test-file-isolated]'),
+      'the shared isolated shell hosts the preview',
+    );
+
+    let frame = document.querySelector(
+      '[data-prerender] [data-test-html-frame]',
+    ) as HTMLIFrameElement | null;
+    assert.ok(frame, 'the rendered view is an iframe');
+    assert.strictEqual(
+      frame?.getAttribute('sandbox'),
+      'allow-scripts',
+      'authored scripts run only inside the opaque-origin sandbox',
+    );
+    assert.strictEqual(
+      frame?.getAttribute('referrerpolicy'),
+      'no-referrer',
+      'the document cannot leak the realm URL as a referrer',
+    );
+
+    await waitUntil(() => frame?.getAttribute('srcdoc'), { timeout: 5000 });
+    let srcdoc = frame?.getAttribute('srcdoc') ?? '';
+    assert.ok(
+      srcdoc.includes('Dispatch board'),
+      'the fetched source reaches the frame as srcdoc',
+    );
+    assert.ok(
+      srcdoc.includes(`<base href="${makeFileURL('dispatch.html')}">`),
+      'a base element makes relative assets resolve beside the file',
+    );
+
+    assert.ok(
+      document.querySelector('[data-prerender] [data-test-html-view-source]'),
+      'a source view sits beside the rendered view',
+    );
+  });
+
+  test('fitted renders a static summary, never a frame', async function (assert) {
+    let { status } = await renderHtmlFile(
+      makeFileURL('dispatch.html'),
+      'fitted',
+    );
+    assert.strictEqual(status, 'ready', 'render completed');
+
+    let summary = document.querySelector(
+      '[data-prerender] [data-test-html-summary]',
+    );
+    assert.ok(summary, 'the fitted cell shows the extracted summary');
+    assert.ok(
+      summary?.textContent?.includes('Release & Dispatch Report'),
+      'the summary leads with the document title',
+    );
+    assert.notOk(
+      document.querySelector('[data-prerender] iframe'),
+      'a collection cell never mounts a frame',
+    );
+  });
+});

--- a/packages/host/tests/unit/html-meta-extractor-test.ts
+++ b/packages/host/tests/unit/html-meta-extractor-test.ts
@@ -34,6 +34,17 @@ module('Unit | html-meta-extractor', function (hooks) {
     assert.strictEqual(meta.documentTitle, 'Fish & Chips — menu');
   });
 
+  test('an out-of-range numeric entity stays as written rather than throwing', function (assert) {
+    let meta = extractHtmlMetadata(
+      `<title>bad &#9999999999; and &#x110000; but ok &#x1F600;</title>`,
+    );
+    assert.strictEqual(
+      meta.documentTitle,
+      'bad &#9999999999; and &#x110000; but ok 😀',
+      'invalid references survive verbatim while valid ones decode',
+    );
+  });
+
   test('a titleless fragment yields no documentTitle rather than inventing one', function (assert) {
     let meta = extractHtmlMetadata(`<p>hello</p>`);
     assert.strictEqual(meta.documentTitle, undefined);

--- a/packages/host/tests/unit/html-meta-extractor-test.ts
+++ b/packages/host/tests/unit/html-meta-extractor-test.ts
@@ -1,0 +1,91 @@
+// Text-level tests for the HTML structure reader. It runs inside the index
+// pass against whatever a realm holds, so the contract is as much about
+// fragments and hostile markup as about well-formed documents: a titleless
+// fragment must degrade to "no title" rather than invent one, and entity
+// decoding must not become an HTML parse.
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm, type Loader } from '@cardstack/runtime-common';
+
+import { setupRenderingTest } from '../helpers/setup';
+
+import type * as HtmlModule from '@cardstack/base/html-meta-extractor';
+
+module('Unit | html-meta-extractor', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let loader: Loader;
+  let extractHtmlMetadata: typeof HtmlModule.extractHtmlMetadata;
+  let extractHtmlExcerpt: typeof HtmlModule.extractHtmlExcerpt;
+
+  hooks.beforeEach(async function () {
+    loader = getService('loader-service').loader;
+    ({ extractHtmlMetadata, extractHtmlExcerpt } = await loader.import<
+      typeof HtmlModule
+    >(`${baseRealm.url}html-meta-extractor`));
+  });
+
+  test('decodes entities and strips markup from the title', function (assert) {
+    let meta = extractHtmlMetadata(
+      `<title>Fish &amp; Chips &#8212; <em>menu</em></title>`,
+    );
+    assert.strictEqual(meta.documentTitle, 'Fish & Chips — menu');
+  });
+
+  test('a titleless fragment yields no documentTitle rather than inventing one', function (assert) {
+    let meta = extractHtmlMetadata(`<p>hello</p>`);
+    assert.strictEqual(meta.documentTitle, undefined);
+    assert.strictEqual(meta.elementCount, 1);
+  });
+
+  test('interactivity derives from scripts or form controls, not styling', function (assert) {
+    let styledProse = extractHtmlMetadata(
+      `<style>p { color: red; }</style><p>prose</p>`,
+    );
+    assert.false(styledProse.isInteractive, 'styling alone is static');
+    assert.strictEqual(styledProse.styleSheetCount, 1);
+
+    let form = extractHtmlMetadata(`<form><input></form>`);
+    assert.true(form.isInteractive, 'a form control is interactive');
+    assert.strictEqual(form.formControlCount, 1);
+
+    let script = extractHtmlMetadata(`<script src="./app.js"></script>`);
+    assert.true(script.isInteractive, 'a script is interactive');
+    assert.false(
+      script.hasInlineScript,
+      'an external script is not an inline one',
+    );
+  });
+
+  test('module scripts are distinguished from classic ones', function (assert) {
+    let meta = extractHtmlMetadata(
+      `<script type="module">import './x.js';</script>`,
+    );
+    assert.true(meta.hasModuleScript);
+    assert.true(meta.hasInlineScript);
+    assert.strictEqual(meta.scriptCount, 1);
+  });
+
+  test('stylesheets count both style blocks and stylesheet links', function (assert) {
+    let meta = extractHtmlMetadata(
+      `<link rel="stylesheet" href="a.css"><style>b{}</style><link rel="icon" href="i.png">`,
+    );
+    assert.strictEqual(meta.styleSheetCount, 2, 'the icon link is not a sheet');
+  });
+
+  test('the excerpt is visible prose with scripts and styles removed', function (assert) {
+    let excerpt = extractHtmlExcerpt(
+      `<style>p{}</style><script>var x;</script><h1>Depot</h1><p>Seven &quot;trucks&quot; left.</p>`,
+      500,
+    );
+    assert.strictEqual(excerpt, 'Depot Seven "trucks" left.');
+  });
+
+  test('a long excerpt truncates with an ellipsis inside the budget', function (assert) {
+    let excerpt = extractHtmlExcerpt(`<p>${'word '.repeat(200)}</p>`, 50);
+    assert.strictEqual(excerpt.length, 50);
+    assert.true(excerpt.endsWith('...'));
+  });
+});

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -19,6 +19,8 @@ const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
   // TODO: Replace with realm metadata configuration.
   '.markdown': { module: baseModule('markdown-file-def'), name: 'MarkdownDef' },
   '.md': { module: baseModule('markdown-file-def'), name: 'MarkdownDef' },
+  '.html': { module: baseModule('html-file-def'), name: 'HtmlDef' },
+  '.htm': { module: baseModule('html-file-def'), name: 'HtmlDef' },
   '.png': { module: baseModule('png-image-def'), name: 'PngDef' },
   '.jpg': { module: baseModule('jpg-image-def'), name: 'JpgDef' },
   '.jpeg': { module: baseModule('jpg-image-def'), name: 'JpgDef' },


### PR DESCRIPTION
Closes [CS-12234](https://linear.app/cardstack/issue/CS-12234/document-format-html)

## What changed

`.html`/`.htm` files previously indexed as generic `FileDef` with no renderer. This adds the HTML family following the FileDef handoff architecture (shells + `previewComponent`, as in the image family PR #5745):

- **`HtmlDef`** (`packages/base/html-file-def.gts`), registered for `.html`/`.htm` in `file-def-code-ref.ts`. Its `extractAttributes` persists `title` (decoded `<title>`, falling back to the file name), a 500-char prose `excerpt`, and an `htmlMetadata` compound — never a second copy of the source, which the preview fetches at view time.
- **`html-meta-extractor.ts`**: dependency-free text scans for document title/language, element/word/heading/link/image/form-control/script/stylesheet/external-resource counts, doctype/viewport/inline-script/module-script flags, and derived `isInteractive` (scripts or form controls). `HtmlMetadataField` in `metadata-fields.gts` models it with an inspector pane, keeping a genuine `false` ("Static document") distinct from never-extracted.
- **`HtmlPreview`** (`file-formats/html-preview.gts`): detailed formats fetch the source once (session via the auth service worker) and render it as `iframe.srcdoc` with an injected `<base href>` so relative assets resolve beside the file. The frame is `sandbox="allow-scripts"` **without** `allow-same-origin` — authored behavior runs in an opaque origin with no cookies, storage, or realm session — plus `referrerpolicy="no-referrer"` and denied camera/microphone/geolocation. A Rendered/Source toggle exposes the raw markup with a copy control. **Fitted cells never mount a frame**: they render a static title + excerpt summary, so a collection of documents doesn't fetch and execute a page per cell.
- The shells' existing HTML affordances (the `html-document` embed shape, the full-width isolated stage, the `htmlMetadata` inspector pane, title/interactivity facts) light up through the `previewKind: 'html'` profile that was already in the registry.

## Testing

- New acceptance module `html def`: extraction facts through the search doc (including entity-decoded titles and the no-source-copy invariant), titleless-fragment fallback, indexing → file-meta round trip, isolated render asserting the sandbox posture (`allow-scripts`, `no-referrer`, `srcdoc` with the injected base), and fitted rendering a summary with no iframe.
- New unit module `html-meta-extractor`: entity decoding, no-invented-titles, interactivity derivation, module/inline script distinction, stylesheet counting, excerpt budget.
- Locally green: `html def` (acceptance), `Unit | html-meta-extractor`, `realm indexing`, `isFileDefCodeRef`; host type-check and base template-lint clean. `HtmlDef` lives outside card-api's universal graph (like the other family subclasses), so the realm-indexing deps guard is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)