### PR TITLE
Move the last two non-queue helpers out of pg-queue

### DIFF
--- a/.claude/skills/indexing-diagnostics/SKILL.md
+++ b/.claude/skills/indexing-diagnostics/SKILL.md
@@ -623,9 +623,9 @@ A short rubric for the most common shapes:
 - **High confidence the stall is at file X**: the bottom row of `boxel_index_working` (max `indexedAt` for the batch's `invalidationId`) is X **AND** the worker's last `begin fused visit of file X` line has no matching `completed fused visit of file X` line **AND** the bottom row's `recentModuleEvaluations[0].url` (or `currentlyEvaluatingModule` / `inFlightModuleImports[0]`) is a module under X. Treat the row's `diagnostics` as a Mode A capture and walk the [Classify in one pass](#classify-in-one-pass) table.
 - **Medium confidence**: only two of the three signals agree. Most often the worker log is the dropout — debug-level logging wasn't on. Promote `index-runner` to debug and trigger a follow-up reindex to validate.
 - **Low confidence — the runner stalled before any per-file work**: `boxel_index_working` has no rows for this batch's `invalidationId` (no row stamped with the batch UUID, no `is_deleted = TRUE` tombstones at the batch's `realm_version`). The worker is still in **invalidation discovery** — either the mtime walk (no `discovering invalidations in dir` line yet) or the consumer fan-out (the `discovering` line is there but no per-file visit-start lines). Look at the worker's `index-perf` `time to get file system mtimes` / `time to invalidate` lines — if those are missing too, you're stuck in the realm-server fetch (`reader.mtimes()` → `_mtimes` HTTP call) or in `Batch.invalidate`'s own jsonb-containment SQL (`itemsThatReference`). Then go look at what _should_ have been in the seed but wasn't — cross-check the EFS file listing against the realm's `boxel_index.last_modified` per step 3.
-- **Confirm a "rejected" job actually failed cleanly**: `jobs.status = 'rejected'` should pair with the matching reservation's `completed_at IS NOT NULL`. If `completed_at IS NULL`, the worker bailed before its finalize transaction (see `pg-queue.ts` lines 619-696); the reservation's `locked_until` will eventually expire and another worker can claim it.
+- **Confirm a "rejected" job actually failed cleanly**: `jobs.status = 'rejected'` should pair with the matching reservation's `completed_at IS NOT NULL`. If `completed_at IS NULL`, the worker bailed before its finalize transaction (see `attemptJobFinalize` in `packages/postgres/job-finalize.ts`); the reservation's `locked_until` will eventually expire and another worker can claim it.
 
-  The actual error is in **`jobs.result`** (jsonb). When the worker's `await job.run(...)` throws, `pg-queue.ts:627-628` does `result = serializableError(err); newStatus = 'rejected';` and the finalize UPDATE writes both into the row. Read it directly:
+  The actual error is in **`jobs.result`** (jsonb). When the worker's `await job.run(...)` throws, `pg-queue.ts` does `result = flattenErrorForJsonb(err); newStatus = 'rejected';` and the finalize UPDATE writes both into the row. Read it directly:
 
   ```sql
   SELECT id, job_type, status, finished_at,
@@ -637,7 +637,7 @@ A short rubric for the most common shapes:
   WHERE id = <job_id>;
   ```
 
-  `result` is the same shape `serializableError` produces: `{ message, name, stack, ... }`. For triage, `error_message` + `error_class` is usually enough; `stack_trace` is there when you need to find the throw site. Sentry has the same payload (and more breadcrumbs) but you don't need to leave the DB to get the rejection reason.
+  `result` is the same shape `flattenErrorForJsonb` produces: `{ message, name, stack, ... }`. For triage, `error_message` + `error_class` is usually enough; `stack_trace` is there when you need to find the throw site. Sentry has the same payload (and more breadcrumbs) but you don't need to leave the DB to get the rejection reason.
 
 ### 9. What this mode can't tell you
 

--- a/packages/postgres/flatten-error-for-jsonb.ts
+++ b/packages/postgres/flatten-error-for-jsonb.ts
@@ -1,0 +1,31 @@
+// Copy every own property of a thrown value onto a plain object, so
+// `jobs.result` can hold it as jsonb and the row still explains why the job
+// failed. A job handler can throw anything, including an Error whose useful
+// fields are all non-enumerable, so nothing is assumed about the shape.
+//
+// Deliberately not called `serializableError`: runtime-common exports a
+// function by that name which does something else — it is card-error aware and
+// returns anything that is not a card error untouched, leaving serialization to
+// pg. Swapping one for the other silently changes what lands in the row, so
+// they are named for what they do rather than for the problem they share.
+
+export function flattenErrorForJsonb(err: any): Record<string, any> {
+  try {
+    let result = Object.create(null);
+    for (let field of Object.getOwnPropertyNames(err)) {
+      result[field] = err[field];
+    }
+    return result;
+  } catch (megaError) {
+    let stringish: string | undefined;
+    try {
+      stringish = String(err);
+    } catch (_ignored) {
+      // ignoring
+    }
+    return {
+      failedToSerializeError: true,
+      string: stringish,
+    };
+  }
+}

--- a/packages/postgres/index.ts
+++ b/packages/postgres/index.ts
@@ -1,6 +1,7 @@
 export * from './pg-adapter.ts';
 export * from './pg-config.ts';
 export * from './job-concurrency-lock.ts';
+export * from './work-loop.ts';
 export * from './job-tables.ts';
 export * from './job-finalize.ts';
 export * from './pg-queue.ts';

--- a/packages/postgres/pg-queue.ts
+++ b/packages/postgres/pg-queue.ts
@@ -39,6 +39,8 @@ import '@cardstack/runtime-common/tasks/prerender-html-reconcile';
 import type { PgAdapter } from './pg-adapter.ts';
 import type { JobReservationsTable, JobsTable } from './job-tables.ts';
 import { acquireConcurrencyGroupLock } from './job-concurrency-lock.ts';
+import { flattenErrorForJsonb } from './flatten-error-for-jsonb.ts';
+import { WorkLoop } from './work-loop.ts';
 import { finalizeJobVerdict, releaseJobReservation } from './job-finalize.ts';
 import * as Sentry from '@sentry/node';
 
@@ -59,72 +61,6 @@ interface CoalesceCandidateRow extends Pick<
   JobsTable,
   'id' | 'job_type' | 'concurrency_group' | 'timeout' | 'priority' | 'args'
 > {}
-
-// Tracks a task that should loop with a timeout and an interruptible sleep.
-export class WorkLoop {
-  private internalWaker: Deferred<void> | undefined;
-  private timeout: NodeJS.Timeout | undefined;
-  private _shuttingDown = false;
-  private runnerPromise: Promise<void> | undefined;
-  private label: string;
-  private pollInterval: number;
-
-  constructor(label: string, pollInterval: number) {
-    this.label = label;
-    this.pollInterval = pollInterval;
-  }
-
-  // 1. Your fn should loop until workLoop.shuttingDown is true.
-  // 2. When it has no work to do, it should await workLoop.sleep().
-  // 3. It can be awoke with workLoop.wake().
-  // 4. Remember to await workLoop.shutdown() when you're done.
-  //
-  // This is separate from the constructor so you can store your WorkLoop first,
-  // *before* the runner starts doing things.
-  run(fn: (loop: WorkLoop) => Promise<void>) {
-    this.runnerPromise = fn(this);
-  }
-
-  async shutDown(): Promise<void> {
-    log.debug(`[workloop %s] shutting down`, this.label);
-    this._shuttingDown = true;
-    this.wake();
-    await this.runnerPromise;
-    log.debug(`[workloop %s] completed shutdown`, this.label);
-  }
-
-  get shuttingDown(): boolean {
-    return this._shuttingDown;
-  }
-
-  private get waker() {
-    if (!this.internalWaker) {
-      this.internalWaker = new Deferred();
-    }
-    return this.internalWaker;
-  }
-
-  wake() {
-    log.debug(`[workloop %s] waking up`, this.label);
-    this.waker.fulfill();
-  }
-
-  async sleep() {
-    if (this.shuttingDown) {
-      return;
-    }
-    let timerPromise = new Promise((resolve) => {
-      this.timeout = setTimeout(resolve, this.pollInterval).unref();
-    });
-    log.debug(`[workloop %s] entering promise race`, this.label);
-    await Promise.race([this.waker.promise, timerPromise]);
-    log.debug(`[workloop] leaving promise race`, this.label);
-    if (this.timeout != null) {
-      clearTimeout(this.timeout);
-    }
-    this.internalWaker = undefined;
-  }
-}
 
 export class PgQueuePublisher implements QueuePublisher {
   #isDestroyed = false;
@@ -788,7 +724,7 @@ export class PgQueueRunner implements QueueRunner {
                 err,
               );
             }
-            result = serializableError(err);
+            result = flattenErrorForJsonb(err);
             newStatus = 'rejected';
           }
           log.debug(
@@ -848,26 +784,5 @@ export class PgQueueRunner implements QueueRunner {
     if (this.#jobRunner) {
       await this.#jobRunner.shutDown();
     }
-  }
-}
-
-export function serializableError(err: any): Record<string, any> {
-  try {
-    let result = Object.create(null);
-    for (let field of Object.getOwnPropertyNames(err)) {
-      result[field] = err[field];
-    }
-    return result;
-  } catch (megaError) {
-    let stringish: string | undefined;
-    try {
-      stringish = String(err);
-    } catch (_ignored) {
-      // ignoring
-    }
-    return {
-      failedToSerializeError: true,
-      string: stringish,
-    };
   }
 }

--- a/packages/postgres/work-loop.ts
+++ b/packages/postgres/work-loop.ts
@@ -1,0 +1,70 @@
+import { logger } from '@cardstack/runtime-common';
+import { Deferred } from '@cardstack/runtime-common';
+
+const log = logger('queue');
+
+// Tracks a task that should loop with a timeout and an interruptible sleep.
+export class WorkLoop {
+  private internalWaker: Deferred<void> | undefined;
+  private timeout: NodeJS.Timeout | undefined;
+  private _shuttingDown = false;
+  private runnerPromise: Promise<void> | undefined;
+  private label: string;
+  private pollInterval: number;
+
+  constructor(label: string, pollInterval: number) {
+    this.label = label;
+    this.pollInterval = pollInterval;
+  }
+
+  // 1. Your fn should loop until workLoop.shuttingDown is true.
+  // 2. When it has no work to do, it should await workLoop.sleep().
+  // 3. It can be awoke with workLoop.wake().
+  // 4. Remember to await workLoop.shutdown() when you're done.
+  //
+  // This is separate from the constructor so you can store your WorkLoop first,
+  // *before* the runner starts doing things.
+  run(fn: (loop: WorkLoop) => Promise<void>) {
+    this.runnerPromise = fn(this);
+  }
+
+  async shutDown(): Promise<void> {
+    log.debug(`[workloop %s] shutting down`, this.label);
+    this._shuttingDown = true;
+    this.wake();
+    await this.runnerPromise;
+    log.debug(`[workloop %s] completed shutdown`, this.label);
+  }
+
+  get shuttingDown(): boolean {
+    return this._shuttingDown;
+  }
+
+  private get waker() {
+    if (!this.internalWaker) {
+      this.internalWaker = new Deferred();
+    }
+    return this.internalWaker;
+  }
+
+  wake() {
+    log.debug(`[workloop %s] waking up`, this.label);
+    this.waker.fulfill();
+  }
+
+  async sleep() {
+    if (this.shuttingDown) {
+      return;
+    }
+    let timerPromise = new Promise((resolve) => {
+      this.timeout = setTimeout(resolve, this.pollInterval).unref();
+    });
+    log.debug(`[workloop %s] entering promise race`, this.label);
+    await Promise.race([this.waker.promise, timerPromise]);
+    log.debug(`[workloop] leaving promise race`, this.label);
+    if (this.timeout != null) {
+      clearTimeout(this.timeout);
+    }
+    this.internalWaker = undefined;
+  }
+}

--- a/packages/postgres/work-loop.ts
+++ b/packages/postgres/work-loop.ts
@@ -62,7 +62,7 @@ export class WorkLoop {
     });
     log.debug(`[workloop %s] entering promise race`, this.label);
     await Promise.race([this.waker.promise, timerPromise]);
-    log.debug(`[workloop] leaving promise race`, this.label);
+    log.debug(`[workloop %s] leaving promise race`, this.label);
     if (this.timeout != null) {
       clearTimeout(this.timeout);
     }

--- a/packages/postgres/work-loop.ts
+++ b/packages/postgres/work-loop.ts
@@ -1,7 +1,7 @@
 import { Deferred, logger } from '@cardstack/runtime-common';
 
-// Same channel as the queue that used to host this, so existing log filters
-// keep working.
+// Logs on the `queue` channel, shared with pg-queue, so one LOG_LEVELS entry
+// covers both loops.
 const log = logger('queue');
 
 // Tracks a task that should loop with a timeout and an interruptible sleep.

--- a/packages/postgres/work-loop.ts
+++ b/packages/postgres/work-loop.ts
@@ -1,6 +1,7 @@
-import { logger } from '@cardstack/runtime-common';
-import { Deferred } from '@cardstack/runtime-common';
+import { Deferred, logger } from '@cardstack/runtime-common';
 
+// Same channel as the queue that used to host this, so existing log filters
+// keep working.
 const log = logger('queue');
 
 // Tracks a task that should loop with a timeout and an interruptible sleep.

--- a/packages/realm-server/lib/realm-registry-reconciler.ts
+++ b/packages/realm-server/lib/realm-registry-reconciler.ts
@@ -56,7 +56,7 @@ export interface ReconcilerDeps {
 //                    concurrent callers serialize per URL. Used by the
 //                    Phase 3 request path.
 //
-// The loop is driven by a WorkLoop (shared with pg-queue). Every mutation
+// The loop is driven by a WorkLoop. Every mutation
 // handler emits `NOTIFY realm_registry` after its DB write; the LISTEN
 // wakes the loop, which re-reads the registry and applies the diff. A 30s
 // poll is the safety net for missed notifications (pg_reconnect, LISTEN


### PR DESCRIPTION
## Background

`packages/postgres/pg-queue.ts` had accumulated everything that touches the job queue: the publisher and runner classes, the row types, the concurrency-group lock, the whole finalize path, a generic work loop, and an error serializer. The parent PR pulled the first group out. This finishes the job with the two that are not queue-specific at all.

## WorkLoop

A poll / wake / interruptible-sleep loop with no knowledge of jobs. It already had a consumer outside the queue — `realm-registry-reconciler` imports it from `@cardstack/postgres` — so living inside the queue module was already inaccurate. It moves to `work-loop.ts` and stays exported from the barrel, so nothing about that import changes.

## The error flattener, and why it gets a new name

This one is worth a closer look, because the move surfaced a name collision rather than just a layout problem.

`pg-queue.ts` exported a function called `serializableError`. `runtime-common` also exports a function called `serializableError`. They do different things:

- The queue's copies **every own property** of a thrown value onto a plain object, with a string fallback if even that fails. A job handler can throw anything, and an `Error`'s useful fields are non-enumerable, so a plain spread would produce `{}` and `jobs.result` would explain nothing.
- The runtime-common one is **card-error aware**: it returns anything that is not a card error untouched, on the reasoning that pg will make a best effort when it writes the value as jsonb.

Both were reachable as `serializableError` from packages the same callers import from, and swapping one for the other silently changes what lands in the row. So the queue's is now `flattenErrorForJsonb`, in `flatten-error-for-jsonb.ts` — named for the mechanism, not for the problem the two share.

It is deliberately **not** on the barrel. Nothing outside `@cardstack/postgres` imported it (checked across the monorepo — every existing `serializableError` call site resolves to runtime-common's), and re-exporting it would put the collision straight back. Dropping a public export is technically a surface change, which is why it is called out here rather than buried.

Worth being precise about how much that buys, though: `packages/postgres/package.json` declares `"./*": "./*.ts"`, so `@cardstack/postgres/flatten-error-for-jsonb` stays deep-importable and TS auto-import will still offer it. The **rename** is what actually prevents the mix-up; keeping it off the barrel is defence in depth, not a wall.

## Result

`pg-queue.ts` is 788 lines, down from 1151 before this decomposition began. What remains is the publisher and the runner — the queue itself. (The claim query is not a separate unit; it is SQL inline in `PgQueueRunner.processJobs`.)

Three follow-on commits fix prose the move invalidated rather than code: the runbook in `.claude/skills/indexing-diagnostics/SKILL.md` told an operator to read `serializableError` in `pg-queue.ts`, and `realm-registry-reconciler` described its loop as "shared with pg-queue", which now sends a reader to the wrong file. Both now name symbols rather than files and line numbers, since symbols survive the next move. One genuine one-character bug is also fixed separately, so the move commit stays byte-identical: the loop's sleep-exit `log.debug` omitted its `%s`, so the label landed as a trailing console argument and the line couldn't be attributed to a loop.

## Testing

The queue suite is unchanged and passes: 57 assertions across `queue-test`, `pg-queue-finalize-test`, `mark-failed-job-test`, `stuck-reservations-test` and `finalize-orphan-reservations-test`. `@cardstack/postgres`, `@cardstack/realm-server` and `@cardstack/host` all typecheck, which is what confirms the two moved symbols kept their consumers — `realm-registry-reconciler` for `WorkLoop`, and for the flattener, that host's `serializableError` call sites were always resolving to runtime-common's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
