### PR TITLE
Fix loader cycle race that fails host CI shards

### DIFF
--- a/packages/host/tests/unit/loader-concurrent-cycle-test.ts
+++ b/packages/host/tests/unit/loader-concurrent-cycle-test.ts
@@ -1,0 +1,62 @@
+import { module, test } from 'qunit';
+
+import { Deferred, Loader } from '@cardstack/runtime-common';
+
+// The loader records a `completing-dep` for a module that is mid-completion on
+// the recording task's own recursion stack — cycle handling. That leaves a
+// window where the dep is still 'registered': the recording task must resume
+// before the dep advances. A *concurrent* import root that reaches the
+// recorded module during that window used to treat the not-yet-advanced dep as
+// a broken invariant and throw
+// `expected <url> to be 'registered-completing-deps' but was 'registered'`;
+// it must instead complete the dep itself, since state transitions are
+// monotonic and re-entrant.
+module('Unit | loader concurrent cycle completion', function () {
+  test('a second import root completes a cycle participant that a suspended root left mid-completion', async function (assert) {
+    let releaseSlow = new Deferred<void>();
+    let slowRequested = new Deferred<void>();
+    let sources: Record<string, string> = {
+      '/a': `import './b'; import './slow'; export const a = 'a';`,
+      '/b': `import './a'; export const b = 'b';`,
+      '/slow': `export const slow = 'slow';`,
+    };
+    let fetchImpl: typeof globalThis.fetch = async (input) => {
+      let url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      let path = new URL(url).pathname;
+      if (path === '/slow') {
+        slowRequested.fulfill();
+        await releaseSlow.promise;
+      }
+      let source = sources[path];
+      if (!source) {
+        return new Response('not found', { status: 404 });
+      }
+      return new Response(source, {
+        status: 200,
+        headers: { 'content-type': 'text/javascript' },
+      });
+    };
+    let loader = new Loader(fetchImpl);
+
+    // Root 1 walks a → b (which cycles back to a, so b records a
+    // completing-dep on a) → slow, and suspends awaiting slow's bytes with
+    // `a` still in state 'registered'.
+    let root1 = loader.import<{ a: string }>('http://race.example/a');
+    await slowRequested.promise;
+
+    // Root 2 enters at `b` while root 1 is suspended: b's completing-dep `a`
+    // has not been advanced yet, which is exactly the interleaving that used
+    // to throw.
+    let root2 = loader.import<{ b: string }>('http://race.example/b');
+    releaseSlow.fulfill();
+
+    let [modA, modB] = await Promise.all([root1, root2]);
+    assert.strictEqual(modA.a, 'a', 'the suspended root still evaluates');
+    assert.strictEqual(modB.b, 'b', 'the concurrent root evaluates the cycle');
+  });
+});

--- a/packages/host/tests/unit/loader-concurrent-cycle-test.ts
+++ b/packages/host/tests/unit/loader-concurrent-cycle-test.ts
@@ -6,11 +6,10 @@ import { Deferred, Loader } from '@cardstack/runtime-common';
 // the recording task's own recursion stack — cycle handling. That leaves a
 // window where the dep is still 'registered': the recording task must resume
 // before the dep advances. A *concurrent* import root that reaches the
-// recorded module during that window used to treat the not-yet-advanced dep as
-// a broken invariant and throw
-// `expected <url> to be 'registered-completing-deps' but was 'registered'`;
-// it must instead complete the dep itself, since state transitions are
-// monotonic and re-entrant.
+// recorded module during that window completes the dep itself rather than
+// treating the not-yet-advanced dep as a broken invariant, since state
+// transitions are monotonic and re-entrant. Regression guard against
+// `expected <url> to be 'registered-completing-deps' but was 'registered'`.
 module('Unit | loader concurrent cycle completion', function () {
   test('a second import root completes a cycle participant that a suspended root left mid-completion', async function (assert) {
     let releaseSlow = new Deferred<void>();
@@ -50,11 +49,13 @@ module('Unit | loader concurrent cycle completion', function () {
     await slowRequested.promise;
 
     // Root 2 enters at `b` while root 1 is suspended: b's completing-dep `a`
-    // has not been advanced yet, which is exactly the interleaving that used
-    // to throw.
+    // has not been advanced yet, which is exactly the interleaving under test.
     let root2 = loader.import<{ b: string }>('http://race.example/b');
     releaseSlow.fulfill();
 
+    // Each module's own export is the strongest stable assertion here: what a
+    // module sees *through* the cycle depends on which end the cycle is
+    // entered from, which is exactly what the second root varies.
     let [modA, modB] = await Promise.all([root1, root2]);
     assert.strictEqual(modA.a, 'a', 'the suspended root still evaluates');
     assert.strictEqual(modB.b, 'b', 'the concurrent root evaluates the cycle');

--- a/packages/host/tests/unit/loader-concurrent-cycle-test.ts
+++ b/packages/host/tests/unit/loader-concurrent-cycle-test.ts
@@ -14,6 +14,13 @@ module('Unit | loader concurrent cycle completion', function () {
   test('a second import root completes a cycle participant that a suspended root left mid-completion', async function (assert) {
     let releaseSlow = new Deferred<void>();
     let slowRequested = new Deferred<void>();
+    // Every axis of this graph is load-bearing: the two-node cycle, `./b`
+    // preceding `./slow` (so root 1 suspends with `a` still 'registered'),
+    // and root 2 entering at `b` specifically. A longer chain closes the
+    // window on its own — the suspended root resumes and advances the dep
+    // before the second root arrives — and the interleaving pins nothing.
+    // Anyone restructuring this test must re-verify it fails with the
+    // loader's completing-dep recovery reverted to a throw.
     let sources: Record<string, string> = {
       '/a': `import './b'; import './slow'; export const a = 'a';`,
       '/b': `import './a'; export const b = 'b';`,

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -763,10 +763,30 @@ export class Loader {
             switch (depModule?.state) {
               case undefined:
               case 'fetching':
-              case 'registered':
-                throw new Error(
-                  `expected ${entry.moduleURL.href} to be 'registered-completing-deps' but was '${depModule?.state}'`,
+              case 'registered': {
+                // A `completing-dep` is recorded while the task completing it
+                // is still on its own recursion stack. A concurrent import
+                // root can reach this transition while that task is suspended
+                // at an await, so finding the dep not-yet-completed is a real
+                // interleaving, not a broken invariant. State transitions are
+                // monotonic and re-entrant, so do the pending work here and
+                // re-enter the state machine rather than asserting some other
+                // task already did it.
+                await this.advanceToState(
+                  entry.moduleURL,
+                  'registered-completing-deps',
+                  {
+                    ...stack,
+                    ...{
+                      'registered-completing-deps': [
+                        ...stack['registered-completing-deps'],
+                        resolvedURL.href,
+                      ],
+                    },
+                  },
                 );
+                break outer_switch;
+              }
               case 'registered-completing-deps': {
                 if (
                   !stack['registered-with-deps'].includes(entry.moduleURL.href)


### PR DESCRIPTION
Closes [CS-12494](https://linear.app/cardstack/issue/CS-12494/loader-cycle-race-expected-to-be-registered-completing-deps-but-was)

## Problem

Host CI shards 5/6 fail — on main as well as on open PRs, surviving `rerun --failed` — with a QUnit global error between tests:

```
Global error: Uncaught Error: expected https://…/base/default-templates/isolated-and-edit
to be 'registered-completing-deps' but was 'registered'
```

The frequency jumped after the FileDef family PRs reshaped the base realm module graph, and a red main run silently blocks staging deploys, so this stopped being ignorable flake.

## Mechanism

`Loader.advanceToState` records a `completing-dep` for a module that is mid-completion on the *recording task's own recursion stack* (cycle handling — `isolated-and-edit` sits in the `card-api ↔ default-templates` import cycle). That leaves a window where the dep is still `'registered'`: the recording task must resume from whatever `await` suspended it (e.g. an unrelated module fetch) before the dep advances. A **concurrent import root** that reaches the recorded module during that window found the not-yet-advanced dep and treated it as a broken invariant — the throw above.

## Fix

The `registered-completing-deps → registered-with-deps` transition now advances such a dep itself (to `registered-completing-deps`, with the current stack) and re-enters the state machine, instead of asserting some other task already did it. Module state transitions are monotonic and re-entrant — the suspended root finds the work done when it resumes and returns early — so doing the pending work from whichever root gets there first is safe and guarantees forward progress.

## Testing

New `Unit | loader concurrent cycle completion` test pins the interleaving deterministically with a hand-controlled fetch: root 1 walks `a → b` (which cycles back to `a`, recording the completing-dep) then suspends awaiting a gated `slow` module; root 2 then imports `b` directly. Against the unpatched loader this reproduces the exact CI error; with the fix both roots evaluate.

Also green locally: `Unit | loader fetch-failure caching` (6), `Unit | Loader transient 5xx retry` (28), `Unit | loader | missing boxel icon` (3), host type-check, prettier/eslint. The `Unit | loader` and `loader prefetch` modules don't run on the local dev test page (they detach the harness frame — pre-existing local limitation); CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)