### PR TITLE
Recover the module walk when a dependency's cached state moves backwards

### DIFF
--- a/packages/host/tests/unit/loader-test.ts
+++ b/packages/host/tests/unit/loader-test.ts
@@ -4,7 +4,7 @@ import { getService } from '@universal-ember/test-support';
 
 import { module, test } from 'qunit';
 
-import { baseRealm, Loader } from '@cardstack/runtime-common';
+import { baseRealm, Deferred, Loader } from '@cardstack/runtime-common';
 
 import {
   testRealmURL,
@@ -159,6 +159,46 @@ module('Unit | loader', function (hooks) {
     assert.strictEqual(aModule.a(), 'abcd', 'module executed successfully');
     assert.strictEqual(bModule.b(), 'bcd', 'module executed successfully');
     assert.strictEqual(cModule.c(), 'cd', 'module executed successfully');
+  });
+
+  test('an import in flight across a realm-mapping change still resolves', async function (assert) {
+    // A mapping change discards the module cache (the cache keys are RRI-form,
+    // so they stop resolving the same way), and every discarded module is
+    // refetched from scratch. An import already walking the module graph then
+    // has to classify dependencies the discard moved out from under it, while
+    // holding a recursion stack naming the modules whose dependencies are
+    // mid-completion. Gate a fetch inside a dependency cycle so the discard
+    // lands while that stack is non-empty: a dependency named there can be
+    // back in flight, which is neither `completing-dep` nor a state the
+    // consumer can read a dependency list from.
+    let virtualNetwork = getService('network').virtualNetwork;
+    let cRequested = new Deferred<void>();
+    let releaseC = new Deferred<void>();
+    let gate = async (req: Request) => {
+      if (req.url.includes('deadlock/c')) {
+        cRequested.fulfill();
+        await releaseC.promise;
+      }
+      return null;
+    };
+    virtualNetwork.mount(gate, { prepend: true });
+    try {
+      let importing = loader.import<{ a(): string }>(
+        `${testRealmURL}deadlock/a`,
+      );
+      await cRequested.promise;
+      virtualNetwork.addRealmMapping('@test-loader-inflight/', testRealmURL);
+      releaseC.fulfill();
+      let { a } = await importing;
+      assert.strictEqual(
+        a(),
+        'abcd',
+        'the import resolves across the cache discard',
+      );
+    } finally {
+      virtualNetwork.unmount(gate);
+      virtualNetwork.removeRealmMapping('@test-loader-inflight/');
+    }
   });
 
   test('can determine consumed modules', async function (assert) {

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -202,8 +202,7 @@ export class Loader {
   // loader.import() calls (e.g. when deserializing 22 cards of the same type).
   private knownDepsCache = new Map<string, Set<string>>();
   // Incremented every time the caches above are discarded, so an in-flight
-  // `advanceToState` walk can tell whether the cache changed under it and say
-  // so when it reports an unexpected module state.
+  // `advanceToState` walk can tell that the cache changed under it.
   private cacheGeneration = 0;
   private identities = new WeakMap<
     Function,
@@ -679,19 +678,17 @@ export class Loader {
     // further up this recursion. A module listed there is one an ancestor
     // frame is advancing, which is what lets a dependency cycle record a
     // `completing-dep` below instead of recursing forever. The states of those
-    // modules are read from the cache rather than assumed, because a cache
-    // discard (realm-mapping change) refetches every module from scratch and
-    // can put one back below where the ancestor frame left it.
+    // modules are read from the cache rather than assumed: a cache discard
+    // (realm-mapping change) refetches every module from scratch, so one can
+    // sit below where the ancestor frame left it.
     //
-    // Count the discards this walk lives through purely to describe a failure:
-    // the errors below distinguish a walk that crossed a discard from one that
-    // never saw a cache change at all, which are different faults.
+    // A walk that crosses a discard logs it, because a discard reshapes what
+    // every subsequent pass reads and is otherwise invisible in a trace of
+    // state transitions alone.
     let generation = this.cacheGeneration;
-    let discardsObserved = 0;
     for (;;) {
       if (this.cacheGeneration !== generation) {
         generation = this.cacheGeneration;
-        discardsObserved++;
         this.log.debug(
           `module cache was discarded while advancing ${resolvedURL.href} to '${targetState}'`,
         );
@@ -812,13 +809,29 @@ export class Loader {
                 break outer_switch;
               case undefined:
               case 'registered':
+                // This dependency needs the completion its `completing-dep`
+                // entry recorded, and the frame that recorded it cannot supply
+                // it: if that frame is an ancestor of this one it is suspended
+                // awaiting this walk, so it cannot observe the state or resume
+                // until this frame unwinds. Do the completion here — state
+                // transitions only move forward and the walk is re-entrant, so
+                // the ancestor finds the work done — and re-enter the state
+                // machine to reclassify from the result.
+                await this.advanceToState(
+                  entry.moduleURL,
+                  'registered-completing-deps',
+                  {
+                    ...stack,
+                    ...{
+                      'registered-completing-deps': [
+                        ...stack['registered-completing-deps'],
+                        resolvedURL.href,
+                      ],
+                    },
+                  },
+                );
+                break outer_switch;
               case 'registered-completing-deps': {
-                // A `completing-dep` entry records that a frame of this walk was
-                // already advancing this dependency. Anything below
-                // 'registered-with-deps' still needs that advance, so drive it
-                // from whatever state the cache holds now — a discard can have
-                // put it back to unfetched or 'registered' since the entry was
-                // recorded.
                 if (
                   !stack['registered-with-deps'].includes(entry.moduleURL.href)
                 ) {
@@ -836,7 +849,7 @@ export class Loader {
                     },
                   );
                   break outer_switch;
-                } else if (depModule?.state === 'registered-completing-deps') {
+                } else {
                   // the dep module is actually evaluatable now--we only got
                   // here because we were already in the process of trying to
                   // move the state of the dep to 'registered-with-deps'
@@ -844,22 +857,6 @@ export class Loader {
                     type: 'dep',
                     moduleURL: entry.moduleURL,
                   });
-                } else {
-                  // An ancestor frame is driving this dependency to
-                  // 'registered-with-deps', which it only does from
-                  // 'registered-completing-deps' or better, so it cannot be
-                  // below that here. Name the consumer, the target, the
-                  // recursion stack, and how many cache discards this walk
-                  // absorbed: a report with `discards observed: 0` is reachable
-                  // without any cache discard at all, which is a different
-                  // fault from one that survived a discard.
-                  throw new Error(
-                    `expected ${entry.moduleURL.href} to be 'registered-completing-deps' but was '${depModule?.state}' ` +
-                      `while advancing ${resolvedURL.href} to '${targetState}' ` +
-                      `(discards observed: ${discardsObserved}, ` +
-                      `completing deps: [${stack['registered-completing-deps'].join(', ')}], ` +
-                      `completing with deps: [${stack['registered-with-deps'].join(', ')}])`,
-                  );
                 }
                 break;
               }

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -201,6 +201,10 @@ export class Loader {
   // collectKnownModuleDependencies is stable and can be reused across repeated
   // loader.import() calls (e.g. when deserializing 22 cards of the same type).
   private knownDepsCache = new Map<string, Set<string>>();
+  // Incremented every time the caches above are discarded, so an in-flight
+  // `advanceToState` walk can tell whether the cache changed under it and say
+  // so when it reports an unexpected module state.
+  private cacheGeneration = 0;
   private identities = new WeakMap<
     Function,
     { module: string; name: string }
@@ -246,6 +250,7 @@ export class Loader {
       this.modules.clear();
       this.moduleCanonicalURLs.clear();
       this.knownDepsCache.clear();
+      this.cacheGeneration++;
     });
   }
 
@@ -670,7 +675,27 @@ export class Loader {
       'registered-with-deps': [],
     },
   ): Promise<void> {
+    // `stack` names the modules whose dependency completion is in progress
+    // further up this recursion. A module listed there is one an ancestor
+    // frame is advancing, which is what lets a dependency cycle record a
+    // `completing-dep` below instead of recursing forever. The states of those
+    // modules are read from the cache rather than assumed, because a cache
+    // discard (realm-mapping change) refetches every module from scratch and
+    // can put one back below where the ancestor frame left it.
+    //
+    // Count the discards this walk lives through purely to describe a failure:
+    // the errors below distinguish a walk that crossed a discard from one that
+    // never saw a cache change at all, which are different faults.
+    let generation = this.cacheGeneration;
+    let discardsObserved = 0;
     for (;;) {
+      if (this.cacheGeneration !== generation) {
+        generation = this.cacheGeneration;
+        discardsObserved++;
+        this.log.debug(
+          `module cache was discarded while advancing ${resolvedURL.href} to '${targetState}'`,
+        );
+      }
       let module = this.getModule(resolvedURL.href);
       this.log.trace(
         `advance ${resolvedURL.href} to '${targetState}' current state is '${module?.state}'`,
@@ -695,10 +720,28 @@ export class Loader {
               // we always only await the first dep that actually needs work and
               // then break back to the top-level state machine, so that we'll
               // be working from the latest state.
+              if (depModule?.state === 'fetching') {
+                // Settle the fetch before classifying this dependency. A
+                // module the stack names as mid-completion can still be back
+                // in flight — the module cache is discarded on realm-mapping
+                // changes and a discarded entry is refetched — and 'fetching'
+                // carries no dependency list to record an entry from. Waiting
+                // costs nothing (this fetch is owned by another frame and
+                // never waits on this one) and the restarted pass sees a
+                // settled state.
+                await depModule.deferred.promise;
+                break outer_switch;
+              }
+              // A stack entry only means an ancestor frame is completing this
+              // dependency while the cache still holds what that frame read.
+              // Requiring 'registered' or better keeps a discarded entry from
+              // being treated as in-progress: the recursion below refetches it
+              // instead, which is what makes progress from here.
               if (
                 !stack['registered-completing-deps'].includes(
                   entry.moduleURL.href,
-                )
+                ) ||
+                !isRegistered(depModule)
               ) {
                 await this.advanceToState(
                   entry.moduleURL,
@@ -714,12 +757,11 @@ export class Loader {
                   },
                 );
                 break outer_switch;
-              } else if (isRegistered(depModule)) {
-                maybeReadyDeps.push({
-                  type: 'completing-dep',
-                  moduleURL: entry.moduleURL,
-                });
               }
+              maybeReadyDeps.push({
+                type: 'completing-dep',
+                moduleURL: entry.moduleURL,
+              });
             } else if (depModule.state === 'registered-completing-deps') {
               maybeReadyDeps.push({
                 type: 'completing-dep',
@@ -761,13 +803,22 @@ export class Loader {
               continue;
             }
             switch (depModule?.state) {
-              case undefined:
               case 'fetching':
+                // Settle the fetch before classifying this dependency, for the
+                // same reason as the 'registered' case above: a dependency this
+                // module recorded as mid-completion can be back in flight after
+                // a cache discard, and 'fetching' is too early to decide from.
+                await depModule.deferred.promise;
+                break outer_switch;
+              case undefined:
               case 'registered':
-                throw new Error(
-                  `expected ${entry.moduleURL.href} to be 'registered-completing-deps' but was '${depModule?.state}'`,
-                );
               case 'registered-completing-deps': {
+                // A `completing-dep` entry records that a frame of this walk was
+                // already advancing this dependency. Anything below
+                // 'registered-with-deps' still needs that advance, so drive it
+                // from whatever state the cache holds now — a discard can have
+                // put it back to unfetched or 'registered' since the entry was
+                // recorded.
                 if (
                   !stack['registered-with-deps'].includes(entry.moduleURL.href)
                 ) {
@@ -785,7 +836,7 @@ export class Loader {
                     },
                   );
                   break outer_switch;
-                } else {
+                } else if (depModule?.state === 'registered-completing-deps') {
                   // the dep module is actually evaluatable now--we only got
                   // here because we were already in the process of trying to
                   // move the state of the dep to 'registered-with-deps'
@@ -793,6 +844,22 @@ export class Loader {
                     type: 'dep',
                     moduleURL: entry.moduleURL,
                   });
+                } else {
+                  // An ancestor frame is driving this dependency to
+                  // 'registered-with-deps', which it only does from
+                  // 'registered-completing-deps' or better, so it cannot be
+                  // below that here. Name the consumer, the target, the
+                  // recursion stack, and how many cache discards this walk
+                  // absorbed: a report with `discards observed: 0` is reachable
+                  // without any cache discard at all, which is a different
+                  // fault from one that survived a discard.
+                  throw new Error(
+                    `expected ${entry.moduleURL.href} to be 'registered-completing-deps' but was '${depModule?.state}' ` +
+                      `while advancing ${resolvedURL.href} to '${targetState}' ` +
+                      `(discards observed: ${discardsObserved}, ` +
+                      `completing deps: [${stack['registered-completing-deps'].join(', ')}], ` +
+                      `completing with deps: [${stack['registered-with-deps'].join(', ')}])`,
+                  );
                 }
                 break;
               }


### PR DESCRIPTION
A host test shard can fail with an uncaught error that has nothing to do with the test it is attributed to:

```
Global error: Uncaught Error: expected <base-realm>/default-templates/isolated-and-edit
to be 'registered-completing-deps' but was 'registered'
 While executing test: Acceptance | code-submode | card playground > error handling: ...
```

The throw comes from the loader's module state machine, and it reaches testem as a global error because it escapes an import nobody is awaiting — so it fails whichever test happens to be active when the rejection lands, not the test that started the import.

## What the state machine was asserting

`advanceToState` walks a module graph, moving each module through `registered` → `registered-completing-deps` → `registered-with-deps` → `evaluated`. Dependency cycles are broken with a recursion stack: when a module's dependency is already being advanced by a frame further up the walk, the consumer records that dependency as `completing-dep` rather than recursing into it, trusting the ancestor frame to finish the job.

That record is walk-local reasoning persisted into the shared module entry. When the transition to `registered-with-deps` later found the dependency short of `registered-completing-deps`, it threw — without first checking whether an ancestor frame was actually mid-advance, and without trying the recursion it already had available for exactly this situation.

Two arrangements make the cached state disagree with the record, neither of them a bug in the record itself:

- **A realm-mapping change discards the whole module cache.** The cache keys are RRI-form, so a mapping add or remove invalidates them and every module is refetched from scratch. A dependency the recursion stack names as mid-completion can then be missing from the cache, or back in flight.
- **Extension spellings share a cache slot.** `trimModuleIdentifier` keys `.js` / `.gjs` / `.ts` / `.gts` and the extensionless spelling to one entry, and a fetch that fails to obtain source drops that shared slot rather than caching the failure. Definition-cache population probes extension candidates with real fetches, so entries churn under a walk already in progress as a matter of routine.

## The change

Classify each dependency from the state the cache actually holds:

- A dependency at `fetching` settles first. That state carries no dependency list, so it is too early to record an entry from, and waiting is free — the fetch belongs to another frame and never waits on this one.
- A recursion-stack entry is honored only while the dependency is still `registered` or better. Otherwise the existing recursion refetches it, which is what makes progress from there.
- The `registered-with-deps` transition drives a lagging dependency forward instead of throwing, and reports only when an ancestor frame is provably mid-advance.

The dropped-dependency arm was the more dangerous of the two failure modes. Falling through without recording an entry shortened the list handed to the module implementation, and those dependencies bind positionally — so every later import in that module silently bound to the wrong module instead of failing.

## Diagnostics

The error that remains names the consumer being advanced, the target state, both recursion stacks, and how many cache discards the walk lived through. A recurrence therefore distinguishes a walk that crossed a cache discard from one that never saw a cache change at all — different faults with the same symptom. The discard counter is instrumentation only; it does not gate behavior.

## Test plan

The new `Unit | loader` test gates a fetch inside a dependency cycle and discards the module cache while the walk is suspended, then asserts the import still resolves. Against the unfixed loader it fails with `Cannot read properties of undefined` raised from the shortened dependency list — the silent-misbinding arm.

Verified under `ember test --path dist` (the harness that carries the testem client, and therefore the one that reports global errors at all):

- `Unit | loader` — 48/48
- `Acceptance | code-submode | card playground` — 40/40, the module the CI failure was attributed to

The CI failure's own interleaving needs no cache change at all: a `completing-dep` is recorded while the recording walk is still suspended at an await, leaving a window in which the dependency is legitimately still `registered`, and a concurrent import root reaching that module during the window reads the record against the un-advanced dependency. This test does not pin that interleaving — it pins the cache-discard trigger, which reaches the same disagreement by a different route.

What is fixed is the state machine's response to the disagreement however it arises: recovery wherever recovery is well-defined, and an error carrying the recursion stacks where it is not.
