### PR TITLE
Cache the conversation history so pulled skill content is not re-billed every turn

### DIFF
--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -64,6 +64,41 @@ function replaceCatalogRealmURL(value: string): string {
   return value.split(DEFAULT_CATALOG_REALM_URL).join(catalogRealmURL);
 }
 
+// The prompt marks the end of the stable conversation prefix with a
+// cache_control breakpoint, which turns that message's string content into a
+// content-part array. Tests that read a message's text must tolerate both
+// shapes, since which message carries the marker shifts with the history.
+function messageText(
+  message: { content: string | { type: string; text?: string }[] } | undefined,
+): string {
+  if (!message) {
+    return '';
+  }
+  let { content } = message;
+  if (typeof content === 'string') {
+    return content;
+  }
+  return content
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text ?? '')
+    .join('');
+}
+
+// Total cache_control markers across the whole prompt. Anthropic allows at
+// most 4 per request; the prompt is designed to emit exactly 2 (system +
+// end of stable history), or 1 on a first turn with no history.
+function countCacheBreakpoints(
+  messages: { content: string | { cache_control?: unknown }[] }[],
+): number {
+  let count = 0;
+  for (let message of messages) {
+    if (Array.isArray(message.content)) {
+      count += message.content.filter((part) => part.cache_control).length;
+    }
+  }
+  return count;
+}
+
 function oldPatchTool(card: CardDef, properties: any): Tool {
   return {
     type: 'function',
@@ -187,12 +222,14 @@ module('buildPromptForModel', (hooks) => {
     );
 
     // Should have a system prompt and a user prompt
-    assert.equal(result.length, 2);
+    assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
     assert.equal(result[1].role, 'user');
+    assert.equal(result[2].role, 'system');
 
+    assert.equal(messageText(result[1]), 'Hey');
     assert.equal(
-      result[1].content,
+      result[2].content,
       `The user is currently viewing the following user interface:
 Room ID: room1
 Submode: code
@@ -208,7 +245,7 @@ Errors display:
     Source URL: http://localhost:4201/experiments/author.gts
 
 Current date and time: 2025-06-11T11:43:00.533Z
-` + '\n\nHey',
+`,
     );
   });
 
@@ -284,12 +321,14 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
 
     // Should have a system prompt and a user prompt
-    assert.equal(result.length, 2);
+    assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
     assert.equal(result[1].role, 'user');
+    assert.equal(result[2].role, 'system');
 
+    assert.equal(messageText(result[1]), 'Hey');
     assert.equal(
-      result[1].content,
+      result[2].content,
       `The user is currently viewing the following user interface:
 Room ID: room1
 Submode: code
@@ -308,7 +347,7 @@ Viewing card instance: http://localhost:4201/experiments/Author/1
 In format: isolated
 
 Current date and time: 2025-06-11T11:43:00.533Z
-` + '\n\nHey',
+`,
     );
   });
 
@@ -367,12 +406,14 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
 
     // Should have a system prompt and a user prompt
-    assert.equal(result.length, 2);
+    assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
     assert.equal(result[1].role, 'user');
+    assert.equal(result[2].role, 'system');
 
+    assert.equal(messageText(result[1]), 'Hey');
     assert.equal(
-      result[1].content,
+      result[2].content,
       `The user is currently viewing the following user interface:
 Room ID: room1
 Submode: workspace-chooser
@@ -385,7 +426,7 @@ Available workspaces:
 The user has no open cards.
 
 Current date and time: 2025-06-11T11:43:00.533Z
-` + '\n\nHey',
+`,
     );
   });
 
@@ -437,12 +478,14 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
 
     // Should have a system prompt and a user prompt
-    assert.equal(result.length, 2);
+    assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
     assert.equal(result[1].role, 'user');
+    assert.equal(result[2].role, 'system');
 
+    assert.equal(messageText(result[1]), 'Hey');
     assert.equal(
-      result[1].content,
+      result[2].content,
       `The user is currently viewing the following user interface:
 Room ID: room1
 Submode: code
@@ -454,7 +497,7 @@ Module inspector panel: spec
 Active spec card: http://localhost:4201/experiments/Spec/author-spec-1
 
 Current date and time: 2025-06-11T11:43:00.533Z
-` + '\n\nHey',
+`,
     );
   });
 
@@ -522,11 +565,12 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
 
     // Should include the body as well as the card
-    assert.equal(result.length, 2);
+    assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
     assert.equal(result[1].role, 'user');
+    assert.equal(result[2].role, 'system');
     assert.true(
-      (result[1].content as string).includes('Hey'),
+      messageText(result[1]).includes('Hey'),
       'message body should be in the user prompt',
     );
     if (
@@ -534,32 +578,32 @@ Current date and time: 2025-06-11T11:43:00.533Z
       history[0].content.msgtype === APP_BOXEL_MESSAGE_MSGTYPE
     ) {
       assert.true(
-        (result[1].content as string).includes(`"firstName": "Terry"`),
+        messageText(result[1]).includes(`"firstName": "Terry"`),
         'attached card should be in the message that it was sent with 1',
       );
       assert.true(
-        (result[1].content as string).includes(`"lastName": "Pratchett"`),
+        messageText(result[1]).includes(`"lastName": "Pratchett"`),
         'attached card should be in the message that it was sent with 2',
       );
       assert.true(
-        (result[1].content as string).includes('Room ID: room1'),
-        'roomId should be in the context leading the user turn',
+        messageText(result[2]).includes('Room ID: room1'),
+        'roomId should be in the trailing context message',
       );
       assert.true(
-        (result[1].content as string).includes('Submode: interact'),
-        'submode should be in the context leading the user turn',
+        messageText(result[2]).includes('Submode: interact'),
+        'submode should be in the trailing context message',
       );
       assert.true(
-        (result[1].content as string).includes(
+        messageText(result[2]).includes(
           'Workspace: http://localhost:4201/experiments',
         ),
-        'workspace should be in the context leading the user turn',
+        'workspace should be in the trailing context message',
       );
       assert.true(
-        (result[1].content as string).includes(
+        messageText(result[2]).includes(
           'Open cards:\n - http://localhost:4201/experiments/Author/1\n',
         ),
-        'open card ids should be in the context leading the user turn',
+        'open card ids should be in the trailing context message',
       );
     } else {
       assert.true(
@@ -1025,7 +1069,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
 
     let userMessages = prompt.filter((message) => message.role === 'user');
     assert.ok(
-      (userMessages[0]?.content as string).includes(
+      messageText(userMessages[0]).includes(
         `
 Attached Files (files with newer versions don't show their content):
 [spaghetti-recipe.gts](http://test-realm-server/my-realm/spaghetti-recipe.gts)
@@ -1034,7 +1078,7 @@ Attached Files (files with newer versions don't show their content):
       ),
     );
     assert.ok(
-      (userMessages[1]?.content as string).includes(
+      messageText(userMessages[1]).includes(
         `
 Attached Files (files with newer versions don't show their content):
 [spaghetti-recipe.gts](http://test-realm-server/my-realm/spaghetti-recipe.gts)
@@ -1045,7 +1089,7 @@ Attached Files (files with newer versions don't show their content):
       ),
     );
     assert.ok(
-      (userMessages[2]?.content as string).includes(
+      messageText(userMessages[2]).includes(
         `
 Attached Files (files with newer versions don't show their content):
 [spaghetti-recipe.gts](http://test-realm-server/my-realm/spaghetti-recipe.gts):
@@ -1057,7 +1101,7 @@ Attached Files (files with newer versions don't show their content):
     );
 
     assert.ok(
-      (prompt[prompt.length - 1].content as string).includes(
+      messageText(prompt[prompt.length - 1]).includes(
         'File open in code editor: http://test-realm-server/my-realm/spaghetti-recipe.gts',
       ),
       'Context should include the URL of the file open in the code editor',
@@ -1360,26 +1404,24 @@ Attached Files (files with newer versions don't show their content):
       (message) => message.role === 'user',
     );
     assert.true(
-      (userMessages[0]?.content as string).includes(
+      messageText(userMessages[0]).includes(
         'http://localhost:4201/experiments/Author/1',
       ),
     );
     assert.false(
-      (userMessages[0]?.content as string).includes('"firstName": "Terry"'),
+      messageText(userMessages[0]).includes('"firstName": "Terry"'),
       'should not include the contents of the first version of the card in the first user message',
     );
     assert.true(
-      (userMessages[1]?.content as string).includes(
+      messageText(userMessages[1]).includes(
         'http://localhost:4201/experiments/Author/1',
       ),
     );
     assert.true(
-      (userMessages[1]?.content as string).includes(
-        '"firstName": "Newer Terry"',
-      ),
+      messageText(userMessages[1]).includes('"firstName": "Newer Terry"'),
     );
     assert.true(
-      (userMessages[1]?.content as string).includes(
+      messageText(userMessages[1]).includes(
         'http://localhost:4201/experiments/Author/2',
       ),
     );
@@ -1754,7 +1796,7 @@ Attached Files (files with newer versions don't show their content):
 
     let userContextMessage = messages?.[messages.length - 1];
     assert.ok(
-      (userContextMessage?.content as string).includes(nonEditableCardsMessage),
+      messageText(userContextMessage).includes(nonEditableCardsMessage),
       'The context leading the user turn should include the "unable to edit cards" message when there are attached cards and no tools, and no attached files, but was ' +
         userContextMessage?.content,
     );
@@ -1775,7 +1817,7 @@ Attached Files (files with newer versions don't show their content):
     );
 
     assert.ok(
-      !(messages2?.[messages2.length - 2].content as string).includes(
+      !messageText(messages2?.[messages2.length - 2]).includes(
         nonEditableCardsMessage,
       ),
       'System context message should not include the "unable to edit cards" message when there are attached cards and a tool',
@@ -1801,7 +1843,7 @@ Attached Files (files with newer versions don't show their content):
     );
 
     assert.ok(
-      !(messages3?.[messages3.length - 2].content as string).includes(
+      !messageText(messages3?.[messages3.length - 2]).includes(
         nonEditableCardsMessage,
       ),
       'System context message should not include the "unable to edit cards" message when there is an attached file',
@@ -1986,8 +2028,9 @@ Attached Files (files with newer versions don't show their content):
     const result = (
       await getPromptParts(eventList, '@aibot:localhost', fakeMatrixClient)
     ).messages!;
-    assert.equal(result.length, 2);
+    assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
+    assert.equal(result[2].role, 'system');
     const systemPromptText = (result[0].content as TextContent[])
       .map((c) => c.text)
       .join('\n');
@@ -2121,7 +2164,7 @@ Attached Files (files with newer versions don't show their content):
     );
     assert.equal(result[1].role, 'user');
     assert.true(
-      (result[1].content as string).includes(
+      messageText(result[1]).includes(
         '"appTitle": "Radio Episode Tracker for Nerds"',
       ),
       'attached card details included in the user message',
@@ -2357,8 +2400,9 @@ Attached Files (files with newer versions don't show their content):
       '@aibot:localhost',
       fakeMatrixClient,
     );
-    assert.equal(messages!.length, 2);
+    assert.equal(messages!.length, 3);
     assert.equal(messages![1].role, 'user');
+    assert.equal(messages![2].role, 'system');
     assert.true(tools!.length === 1);
     assert.deepEqual(toolChoice, {
       type: 'function',
@@ -2716,7 +2760,7 @@ Attached Files (files with newer versions don't show their content):
     assert.equal(result[5].tool_call_id, 'tool-call-id-1');
     const expected = `Tool call executed, with result card: {"data":{"type":"card","attributes":{"title":"Search Results","description":"Here are the search results","results":[{"data":{"type":"card","id":"http://localhost:4201/drafts/Author/1","attributes":{"firstName":"Alice","lastName":"Enwunder","photo":null,"body":"Alice is a software engineer at Google.","description":null,"thumbnailURL":null},"meta":{"adoptsFrom":{"module":"../author","name":"Author"}}}}]},"meta":{"adoptsFrom":{"module":"@cardstack/base/search-results","name":"SearchResults"}}}}.`;
 
-    assert.equal((result[5].content as string).trim(), expected.trim());
+    assert.equal(messageText(result[5]).trim(), expected.trim());
   });
 
   test('pairs a pre-rename request/result (legacy wire keys) with the same tool_call_id', async () => {
@@ -2920,7 +2964,7 @@ Attached Files (files with newer versions don't show their content):
     );
     assert.ok(toolCallMessage, 'Should have a tool call message');
     assert.ok(
-      (toolCallMessage!.content as string).includes('Cloudy'),
+      messageText(toolCallMessage!).includes('Cloudy'),
       'Tool call result should include "Cloudy"',
     );
   });
@@ -3045,7 +3089,7 @@ Attached Files (files with newer versions don't show their content):
       'Should have one tool call message',
     );
     assert.ok(
-      (toolCallMessages[0].content as string).includes('Tool call executed'),
+      messageText(toolCallMessages[0]).includes('Tool call executed'),
       'Tool call result should include "Tool call executed"',
     );
   });
@@ -3166,11 +3210,11 @@ Attached Files (files with newer versions don't show their content):
       'Should have two tool call messages',
     );
     assert.ok(
-      (toolCallMessages[0].content as string).includes('Cloudy'),
+      messageText(toolCallMessages[0]).includes('Cloudy'),
       'Tool call result should include "Cloudy"',
     );
     assert.ok(
-      (toolCallMessages[1].content as string).includes('Sunny'),
+      messageText(toolCallMessages[1]).includes('Sunny'),
       'Tool call result should include "Sunny"',
     );
   });
@@ -3338,8 +3382,9 @@ Attached Files (files with newer versions don't show their content):
     // we should not have any tools available
     assert.true(tools!.length == 0, 'Should not have tools available');
 
+    assert.equal(messageText(messages![1]), 'Command Definitions');
     assert.equal(
-      messages![1].content,
+      messages![2].content,
       `The user is currently viewing the following user interface:
 Room ID: !XuZQzeYAGZzFQFYUzQ:localhost
 Submode: interact
@@ -3347,7 +3392,7 @@ The user has no open cards.
 Disabled skills: http://boxel.ai/skills/skill_card_editing
 
 Current date and time: 2025-06-11T11:43:00.533Z
-` + '\n\nCommand Definitions',
+`,
     );
   });
 
@@ -3507,10 +3552,10 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
     assert.deepEqual(
       messages!.map((m) => m.role),
-      ['system', 'user', 'assistant'],
+      ['system', 'user', 'assistant', 'system'],
     );
     assert.equal(
-      messages![2].content,
+      messageText(messages![2]),
       'Updating the file...\n' +
         'http://test.com/spaghetti-recipe.gts\n' +
         '[Omitting previously suggested and applied code change]\n' +
@@ -3608,14 +3653,12 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
     assert.equal(messages![2].role, 'assistant');
     assert.equal(
-      messages![2].content,
+      messageText(messages![2]),
       'I see a card with the ID "http://localhost:4201/admin/personal/BusinessCard/business_card". It appears to be a business card for Jane Smith, a Senior Software Architect at Innovative Solutions Inc.',
     );
     assert.equal(messages![3].role, 'user');
     assert.true(
-      (messages![3].content as string).startsWith(
-        'change the name to stephanie',
-      ),
+      messageText(messages![3]).startsWith('change the name to stephanie'),
     );
     assert.equal(messages![4].role, 'assistant');
     assert.equal(
@@ -3629,7 +3672,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
       'patchCardInstance',
       'Should have patchCardInstance tool call',
     );
-    assert.true((messages![6].content as string).includes('Business Card V2'));
+    assert.true(messageText(messages![6]).includes('Business Card V2'));
   });
 
   test('Responds to successful completion of lone code patch', async function () {
@@ -3652,7 +3695,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.ok(userMessages.length >= 1, 'Should have user messages');
     assert.false(
       userMessages.some((message) =>
-        (message.content as string).includes(
+        messageText(message).includes(
           '(The user has successfully applied code patch',
         ),
       ),
@@ -3703,7 +3746,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.ok(userMessages.length >= 1, 'Should have user messages');
     assert.false(
       userMessages.some((message) =>
-        (message.content as string).includes('(The user has successfully'),
+        messageText(message).includes('(The user has successfully'),
       ),
       'Code patch result messages should be omitted',
     );
@@ -3778,7 +3821,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.strictEqual(userMessages.length, 1, 'Should have one user message');
     assert.false(
       userMessages.some((message) =>
-        (message.content as string).includes(
+        messageText(message).includes(
           '(The user has successfully applied code patch',
         ),
       ),
@@ -3793,7 +3836,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
       'Should have one tool result message',
     );
     assert.ok(
-      (toolResultMessages[0].content as string).includes('Cloudy'),
+      messageText(toolResultMessages[0]).includes('Cloudy'),
       'Tool call result should include "Cloudy"',
     );
   });
@@ -3845,7 +3888,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.strictEqual(userMessages.length, 1, 'Should have one user message');
     assert.false(
       userMessages.some((message) =>
-        (message.content as string).includes(
+        messageText(message).includes(
           '(The user has successfully applied code patch',
         ),
       ),
@@ -3860,7 +3903,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
       'Should have one tool result message',
     );
     assert.ok(
-      (toolResultMessages[0].content as string).includes('Cloudy'),
+      messageText(toolResultMessages[0]).includes('Cloudy'),
       'Tool call result should include "Cloudy"',
     );
   });
@@ -3885,15 +3928,13 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.ok(userMessages.length >= 1, 'Should have user messages');
     assert.false(
       userMessages.some((message) =>
-        (message.content as string).includes(
-          'The user tried to apply code patch',
-        ),
+        messageText(message).includes('The user tried to apply code patch'),
       ),
       'Code patch result messages should be omitted',
     );
   });
 
-  test('context leads the last user message when there is just one user message', async () => {
+  test('context trails as its own system message when there is just one user message', async () => {
     const eventList: DiscreteMatrixEvent[] = JSON.parse(
       readFileSync(
         path.join(
@@ -3911,15 +3952,18 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
     assert.equal(messages![0].role, 'system');
     assert.equal(messages![1].role, 'user');
+    assert.equal(messages![2].role, 'system');
     assert.ok(
-      (messages![1].content as string).startsWith(
-        'The user is currently viewing',
-      ),
-      'the context leads the user turn',
+      messageText(messages![2]).startsWith('The user is currently viewing'),
+      'the context trails the conversation as its own message',
+    );
+    assert.notOk(
+      messageText(messages![1]).includes('The user is currently viewing'),
+      'the user turn stays byte-stable across requests: no context is folded into it',
     );
   });
 
-  test('context leads the last user message when there are multiple user messages', async () => {
+  test('context trails as its own system message when there are multiple user messages', async () => {
     const eventList: DiscreteMatrixEvent[] = JSON.parse(
       readFileSync(
         path.join(
@@ -3939,11 +3983,14 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.equal(messages![1].role, 'user');
     assert.equal(messages![2].role, 'assistant');
     assert.equal(messages![3].role, 'user');
+    assert.equal(messages![4].role, 'system');
     assert.ok(
-      (messages![3].content as string).startsWith(
-        'The user is currently viewing',
-      ),
-      'the context leads the last user turn',
+      messageText(messages![4]).startsWith('The user is currently viewing'),
+      'the context trails the conversation as its own message',
+    );
+    assert.notOk(
+      messageText(messages![3]).includes('The user is currently viewing'),
+      'the last user turn stays byte-stable across requests: no context is folded into it',
     );
   });
 
@@ -3971,7 +4018,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.equal(messages![8].role, 'system');
   });
 
-  test('context leads the last user message when the last message is an assistant message', async () => {
+  test('context trails as its own system message when the last message is an assistant message', async () => {
     const eventList: DiscreteMatrixEvent[] = JSON.parse(
       readFileSync(
         path.join(
@@ -3989,13 +4036,12 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
     assert.equal(messages![0].role, 'system');
     assert.equal(messages![1].role, 'user');
-    assert.ok(
-      (messages![1].content as string).startsWith(
-        'The user is currently viewing',
-      ),
-      'the context leads the user turn it explains',
-    );
     assert.equal(messages![2].role, 'assistant');
+    assert.equal(messages![3].role, 'system');
+    assert.ok(
+      messageText(messages![3]).startsWith('The user is currently viewing'),
+      'the context trails the conversation as its own message',
+    );
   });
 
   test('no interstitial system message is followed by a user message', async () => {
@@ -4058,13 +4104,13 @@ Current date and time: 2025-06-11T11:43:00.533Z
       '@aibot:localhost',
       fakeMatrixClient,
     );
-    assert.equal(messages![3].role, 'user');
+    assert.equal(messages![4].role, 'system');
     assert.true(
-      !!(messages![3].content as string).match(
+      !!messageText(messages![4]).match(
         /Current date and time: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
       ),
       'Context message should contain the current date and time but was ' +
-        messages![3].content,
+        messages![4].content,
     );
   });
 
@@ -4092,11 +4138,11 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
     assert.ok(toolCallMessage, 'Should have a tool call message');
     assert.true(
-      (toolCallMessage!.content as string).includes('executed'),
+      messageText(toolCallMessage!).includes('executed'),
       'Tool call result should reflect that the tool was executed',
     );
     assert.true(
-      (toolCallMessage!.content as string).includes(
+      messageText(toolCallMessage!).includes(
         `
 Attached Files (files with newer versions don't show their content):
 [postcard.gts](http://test-realm-server/user/test-realm/postcard.gts):
@@ -4130,11 +4176,11 @@ Attached Files (files with newer versions don't show their content):
     );
     assert.ok(toolCallMessage, 'Should have a tool call message');
     assert.true(
-      (toolCallMessage!.content as string).includes('executed'),
+      messageText(toolCallMessage!).includes('executed'),
       'Tool call result should reflect that the tool was executed',
     );
     assert.true(
-      (toolCallMessage!.content as string).includes(
+      messageText(toolCallMessage!).includes(
         `
 Attached Cards (cards with newer versions don't show their content):
 [
@@ -4884,9 +4930,7 @@ new content
     let userMessages =
       messages?.filter((message) => message.role === 'user') ?? [];
     let retryMessages = userMessages.filter((message) =>
-      (message.content as string).includes(
-        'Propose fixes for the above errors',
-      ),
+      messageText(message).includes('Propose fixes for the above errors'),
     );
     assert.strictEqual(
       retryMessages.length,
@@ -4895,7 +4939,7 @@ new content
     );
 
     let failureLimitMessages = userMessages.filter((message) =>
-      (message.content as string).includes(
+      messageText(message).includes(
         'Automated correctness fixes have already been attempted 3 times',
       ),
     );
@@ -4906,7 +4950,7 @@ new content
     );
     let failureLimitMessage = failureLimitMessages[0];
     assert.notOk(
-      (failureLimitMessage?.content as string).includes(
+      messageText(failureLimitMessage).includes(
         'Propose fixes for the above errors',
       ),
       'The failure limit prompt should not ask for another round of fixes',
@@ -5081,9 +5125,7 @@ new content
     );
     assert.ok(secondToolMessage, 'Second correctness result should be present');
     assert.ok(
-      (secondToolMessage!.content as string).includes(
-        'attempts so far: 1 of 3',
-      ),
+      messageText(secondToolMessage!).includes('attempts so far: 1 of 3'),
       'Correctness attempts reset to the first attempt when a new patch event begins for the same target',
     );
   });
@@ -5231,16 +5273,14 @@ new
     let enabledUserMessages =
       promptParts.messages?.filter((message) => message.role === 'user') ?? [];
     assert.true(
-      enabledUserMessages.some(
-        (message) =>
-          typeof message.content === 'string' &&
-          message.content.endsWith(summaryMessage),
+      enabledUserMessages.some((message) =>
+        messageText(message).endsWith(summaryMessage),
       ),
       'Summary should be included',
     );
     assert.false(
       enabledUserMessages.some((message) =>
-        (message.content as string).includes(
+        messageText(message).includes(
           'The user has successfully applied code patch 1.',
         ),
       ),
@@ -5350,6 +5390,269 @@ new
       lastPart.cache_control,
       { type: 'ephemeral' },
       'cache_control should be set to ephemeral',
+    );
+  });
+
+  test('marks the last real message as cacheable and leaves the trailing context unmarked', async () => {
+    // Three-turn history ending in a user message. The context (which carries
+    // the current time, so it changes every request) trails as its own
+    // message; the cache breakpoint lands on the last real message, and the
+    // volatile trailing context must never carry one.
+    const userEvent = (
+      event_id: string,
+      ts: number,
+      body: string,
+    ): DiscreteMatrixEvent => ({
+      type: 'm.room.message',
+      event_id,
+      origin_server_ts: ts,
+      content: {
+        msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+        format: 'org.matrix.custom.html',
+        body,
+        isStreamingFinished: true,
+        data: { context: { tools: [], functions: [] } },
+      },
+      sender: '@user:localhost',
+      room_id: 'room1',
+      unsigned: { age: 1000, transaction_id: event_id },
+      status: EventStatus.SENT,
+    });
+    const history: DiscreteMatrixEvent[] = [
+      userEvent('1', 1000, 'First question'),
+      {
+        type: 'm.room.message',
+        event_id: '2',
+        origin_server_ts: 2000,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'First answer',
+          isStreamingFinished: true,
+          data: {},
+        },
+        sender: '@aibot:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '2' },
+        status: EventStatus.SENT,
+      },
+      userEvent('3', 3000, 'Second question'),
+    ];
+
+    const result = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      [],
+      [],
+      [],
+      fakeMatrixClient,
+    );
+
+    // [system, user, assistant, user, trailing context]
+    assert.deepEqual(
+      result.map((m) => m.role),
+      ['system', 'user', 'assistant', 'user', 'system'],
+    );
+    let lastUserMessage = result[3];
+    assert.ok(
+      Array.isArray(lastUserMessage.content) &&
+        (lastUserMessage.content.at(-1) as TextContent).cache_control?.type ===
+          'ephemeral',
+      'The last real message carries the history cache breakpoint',
+    );
+    assert.equal(
+      messageText(lastUserMessage),
+      'Second question',
+      'No context is folded into the user message — its bytes must not change between requests',
+    );
+    let contextMessage = result[4];
+    assert.notOk(
+      Array.isArray(contextMessage.content) &&
+        (contextMessage.content as TextContent[]).some(
+          (part) => part.cache_control,
+        ),
+      'The trailing context message carries no breakpoint — it changes every request',
+    );
+    assert.equal(
+      countCacheBreakpoints(result),
+      2,
+      'Exactly two breakpoints: system message + end of stable history',
+    );
+  });
+
+  test('marks the trailing tool result as cacheable when the history ends with one', async function () {
+    // Tool results are where pulled skill files land, so when the turn ends
+    // with one, the breakpoint must cover it — that content must not be
+    // re-billed fresh on every later request. The trailing system context
+    // message stays unmarked (it carries the current time).
+    const eventList: DiscreteMatrixEvent[] = JSON.parse(
+      readFileSync(
+        path.join(
+          import.meta.dirname,
+          'resources/chats/code-block-and-command-two-results-a.json',
+        ),
+        'utf-8',
+      ),
+    );
+    mockResponses.set('mxc://mock-server/weather-report-1', {
+      ok: true,
+      text: JSON.stringify({
+        data: {
+          type: 'card',
+          attributes: { temperature: '22°C', conditions: 'Cloudy' },
+          meta: {
+            adoptsFrom: {
+              module: 'http://localhost:4201/admin/onnx/commandexample',
+              name: 'WeatherReport',
+            },
+          },
+        },
+      }),
+    });
+
+    const { messages } = await getPromptParts(
+      eventList,
+      '@aibot:localhost',
+      fakeMatrixClient,
+    );
+    assert.deepEqual(
+      messages!.map((m) => m.role),
+      ['system', 'user', 'assistant', 'tool', 'system'],
+    );
+    let toolMessage = messages![3];
+    assert.ok(
+      Array.isArray(toolMessage.content) &&
+        (toolMessage.content.at(-1) as TextContent).cache_control?.type ===
+          'ephemeral',
+      'The trailing tool result carries the history cache breakpoint',
+    );
+    let contextMessage = messages![4];
+    assert.notOk(
+      Array.isArray(contextMessage.content) &&
+        (contextMessage.content as TextContent[]).some(
+          (part) => part.cache_control,
+        ),
+      'The trailing context message carries no breakpoint',
+    );
+    assert.equal(
+      countCacheBreakpoints(messages!),
+      2,
+      'Exactly two breakpoints: system message + trailing tool result',
+    );
+  });
+
+  test('the shared history serializes byte-identically across consecutive turns, apart from the moving marker', async () => {
+    // The invariant the prompt cache lives on: request N+1's messages must be
+    // an exact byte extension of request N's stable prefix. The cache marker
+    // moves forward each turn, so the marker property itself is excluded —
+    // but nothing else may differ, including the string-vs-parts shape of a
+    // message's content, which is why every history message is normalized to
+    // the parts form on every turn.
+    const makeEvent = (
+      event_id: string,
+      ts: number,
+      body: string,
+      sender = '@user:localhost',
+    ): DiscreteMatrixEvent => ({
+      type: 'm.room.message',
+      event_id,
+      origin_server_ts: ts,
+      content: {
+        msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+        format: 'org.matrix.custom.html',
+        body,
+        isStreamingFinished: true,
+        data:
+          sender === '@user:localhost'
+            ? { context: { tools: [], functions: [] } }
+            : {},
+      },
+      sender,
+      room_id: 'room1',
+      unsigned: { age: 1000, transaction_id: event_id },
+      status: EventStatus.SENT,
+    });
+    const turnOne: DiscreteMatrixEvent[] = [
+      makeEvent('1', 1000, 'First question'),
+    ];
+    const turnTwo: DiscreteMatrixEvent[] = [
+      ...turnOne,
+      makeEvent('2', 2000, 'First answer', '@aibot:localhost'),
+      makeEvent('3', 3000, 'Second question'),
+    ];
+
+    const promptOne = await buildPromptForModel(
+      turnOne,
+      '@aibot:localhost',
+      [],
+      [],
+      [],
+      fakeMatrixClient,
+    );
+    const promptTwo = await buildPromptForModel(
+      turnTwo,
+      '@aibot:localhost',
+      [],
+      [],
+      [],
+      fakeMatrixClient,
+    );
+
+    // Strip the marker (it is allowed to move) and each prompt's volatile
+    // trailing context message, then require an exact prefix match.
+    const stripMarkers = (message: (typeof promptOne)[number]) =>
+      JSON.stringify(message, (key, value) =>
+        key === 'cache_control' ? undefined : value,
+      );
+    const stableOne = promptOne.slice(0, -1).map(stripMarkers);
+    const stableTwo = promptTwo.slice(0, -1).map(stripMarkers);
+    for (let i = 0; i < stableOne.length; i++) {
+      assert.equal(
+        stableTwo[i],
+        stableOne[i],
+        `message ${i} must serialize identically on the next turn`,
+      );
+    }
+  });
+
+  test('a first-turn prompt marks the system prompt and the first user message', async () => {
+    // One user message and nothing before it: the user message is the whole
+    // stable history, so it carries the second breakpoint — the next request
+    // re-reads it from cache.
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: '1',
+        origin_server_ts: 1000,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Hello',
+          isStreamingFinished: true,
+          data: { context: { tools: [], functions: [] } },
+        },
+        sender: '@user:localhost',
+        room_id: 'room1',
+        unsigned: { age: 1000, transaction_id: '1' },
+        status: EventStatus.SENT,
+      },
+    ];
+    const result = await buildPromptForModel(
+      history,
+      '@aibot:localhost',
+      [],
+      [],
+      [],
+      fakeMatrixClient,
+    );
+    assert.deepEqual(
+      result.map((m) => m.role),
+      ['system', 'user', 'system'],
+    );
+    assert.equal(
+      countCacheBreakpoints(result),
+      2,
+      'System breakpoint plus the first user message',
     );
   });
 
@@ -5627,7 +5930,7 @@ new
       'Only the non-empty user message should be included',
     );
     assert.true(
-      (userMessages[0].content as string).endsWith('Hello'),
+      messageText(userMessages[0]).endsWith('Hello'),
       'the surviving user message keeps its body',
     );
   });
@@ -5733,17 +6036,17 @@ new
 
     // Older message's unique file (config.json) should show metadata only, not content
     assert.ok(
-      (userMessages[0]?.content as string).includes('[config.json]'),
+      messageText(userMessages[0]).includes('[config.json]'),
       'First message mentions config.json',
     );
     assert.notOk(
-      (userMessages[0]?.content as string).includes('"key": "value"'),
+      messageText(userMessages[0]).includes('"key": "value"'),
       'First message should NOT include config.json content (not the current message)',
     );
 
     // Most recent message's file (utils.ts) should include content
     assert.ok(
-      (userMessages[1]?.content as string).includes(
+      messageText(userMessages[1]).includes(
         'export function hello() { return "world"; }',
       ),
       'Most recent message should include utils.ts content',
@@ -5892,7 +6195,7 @@ new
     );
 
     let userMessages = prompt.filter((m) => m.role === 'user');
-    let content = userMessages[0]?.content as string;
+    let content = messageText(userMessages[0]);
 
     assert.ok(
       content.includes('"name":"Alice"'),
@@ -5988,7 +6291,7 @@ new
     );
 
     let userMessages = prompt.filter((m) => m.role === 'user');
-    let firstMessage = userMessages[0]?.content as string;
+    let firstMessage = messageText(userMessages[0]);
     assert.ok(
       firstMessage.includes('diagram.png'),
       'older image attachment should still be mentioned',
@@ -6690,7 +6993,7 @@ new
     // The command result for the unauthorized file should contain a rejection
     let toolMessages = prompt.filter((m) => m.role === 'tool');
     let rejectionMessage = toolMessages.find((m) =>
-      (m.content as string).includes('not-attached-file.ts'),
+      messageText(m).includes('not-attached-file.ts'),
     );
 
     assert.ok(
@@ -6699,7 +7002,7 @@ new
     );
 
     if (rejectionMessage) {
-      let rejectionContent = rejectionMessage.content as string;
+      let rejectionContent = messageText(rejectionMessage);
       assert.ok(
         rejectionContent.includes('not previously attached') ||
           rejectionContent.includes('not authorized') ||

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5552,12 +5552,9 @@ new
   });
 
   test('the shared history serializes byte-identically across consecutive turns, apart from the moving marker', async () => {
-    // The invariant the prompt cache lives on: request N+1's messages must be
-    // an exact byte extension of request N's stable prefix. The cache marker
-    // moves forward each turn, so the marker property itself is excluded —
-    // but nothing else may differ, including the string-vs-parts shape of a
-    // message's content, which is why every history message is normalized to
-    // the parts form on every turn.
+    // The invariant the prompt cache lives on: request N+1's messages must
+    // be an exact byte extension of request N's stable prefix, marker aside
+    // — including the string-vs-parts shape of each message's content.
     const makeEvent = (
       event_id: string,
       ts: number,

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -225,7 +225,7 @@ module('buildPromptForModel', (hooks) => {
     assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
     assert.equal(result[1].role, 'user');
-    assert.equal(result[2].role, 'system');
+    assert.equal(result[2].role, 'user');
 
     assert.equal(messageText(result[1]), 'Hey');
     assert.equal(
@@ -324,7 +324,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
     assert.equal(result[1].role, 'user');
-    assert.equal(result[2].role, 'system');
+    assert.equal(result[2].role, 'user');
 
     assert.equal(messageText(result[1]), 'Hey');
     assert.equal(
@@ -409,7 +409,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
     assert.equal(result[1].role, 'user');
-    assert.equal(result[2].role, 'system');
+    assert.equal(result[2].role, 'user');
 
     assert.equal(messageText(result[1]), 'Hey');
     assert.equal(
@@ -481,7 +481,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
     assert.equal(result[1].role, 'user');
-    assert.equal(result[2].role, 'system');
+    assert.equal(result[2].role, 'user');
 
     assert.equal(messageText(result[1]), 'Hey');
     assert.equal(
@@ -568,7 +568,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
     assert.equal(result[1].role, 'user');
-    assert.equal(result[2].role, 'system');
+    assert.equal(result[2].role, 'user');
     assert.true(
       messageText(result[1]).includes('Hey'),
       'message body should be in the user prompt',
@@ -2030,7 +2030,7 @@ Attached Files (files with newer versions don't show their content):
     ).messages!;
     assert.equal(result.length, 3);
     assert.equal(result[0].role, 'system');
-    assert.equal(result[2].role, 'system');
+    assert.equal(result[2].role, 'user');
     const systemPromptText = (result[0].content as TextContent[])
       .map((c) => c.text)
       .join('\n');
@@ -2402,7 +2402,7 @@ Attached Files (files with newer versions don't show their content):
     );
     assert.equal(messages!.length, 3);
     assert.equal(messages![1].role, 'user');
-    assert.equal(messages![2].role, 'system');
+    assert.equal(messages![2].role, 'user');
     assert.true(tools!.length === 1);
     assert.deepEqual(toolChoice, {
       type: 'function',
@@ -3552,7 +3552,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
     assert.deepEqual(
       messages!.map((m) => m.role),
-      ['system', 'user', 'assistant', 'system'],
+      ['system', 'user', 'assistant', 'user'],
     );
     assert.equal(
       messageText(messages![2]),
@@ -3815,10 +3815,14 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.strictEqual(shouldRespond, true, 'AiBot should solicit a response');
     assert.deepEqual(
       messages!.map((m) => m.role),
-      ['system', 'user', 'assistant', 'tool', 'system'],
+      ['system', 'user', 'assistant', 'tool', 'user'],
     );
     const userMessages = messages!.filter((message) => message.role === 'user');
-    assert.strictEqual(userMessages.length, 1, 'Should have one user message');
+    assert.strictEqual(
+      userMessages.length,
+      2,
+      'The question plus the trailing context message',
+    );
     assert.false(
       userMessages.some((message) =>
         messageText(message).includes(
@@ -3882,10 +3886,14 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.strictEqual(shouldRespond, true, 'AiBot should solicit a response');
     assert.deepEqual(
       messages!.map((m) => m.role),
-      ['system', 'user', 'assistant', 'tool', 'system'],
+      ['system', 'user', 'assistant', 'tool', 'user'],
     );
     const userMessages = messages!.filter((message) => message.role === 'user');
-    assert.strictEqual(userMessages.length, 1, 'Should have one user message');
+    assert.strictEqual(
+      userMessages.length,
+      2,
+      'The question plus the trailing context message',
+    );
     assert.false(
       userMessages.some((message) =>
         messageText(message).includes(
@@ -3934,7 +3942,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
   });
 
-  test('context trails as its own system message when there is just one user message', async () => {
+  test('context trails as its own user message when there is just one user message', async () => {
     const eventList: DiscreteMatrixEvent[] = JSON.parse(
       readFileSync(
         path.join(
@@ -3952,7 +3960,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
     assert.equal(messages![0].role, 'system');
     assert.equal(messages![1].role, 'user');
-    assert.equal(messages![2].role, 'system');
+    assert.equal(messages![2].role, 'user');
     assert.ok(
       messageText(messages![2]).startsWith('The user is currently viewing'),
       'the context trails the conversation as its own message',
@@ -3963,7 +3971,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
   });
 
-  test('context trails as its own system message when there are multiple user messages', async () => {
+  test('context trails as its own user message when there are multiple user messages', async () => {
     const eventList: DiscreteMatrixEvent[] = JSON.parse(
       readFileSync(
         path.join(
@@ -3983,7 +3991,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.equal(messages![1].role, 'user');
     assert.equal(messages![2].role, 'assistant');
     assert.equal(messages![3].role, 'user');
-    assert.equal(messages![4].role, 'system');
+    assert.equal(messages![4].role, 'user');
     assert.ok(
       messageText(messages![4]).startsWith('The user is currently viewing'),
       'the context trails the conversation as its own message',
@@ -4015,10 +4023,10 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.equal(messages![5].role, 'user');
     assert.equal(messages![6].role, 'assistant');
     assert.equal(messages![7].role, 'tool');
-    assert.equal(messages![8].role, 'system');
+    assert.equal(messages![8].role, 'user');
   });
 
-  test('context trails as its own system message when the last message is an assistant message', async () => {
+  test('context trails as its own user message when the last message is an assistant message', async () => {
     const eventList: DiscreteMatrixEvent[] = JSON.parse(
       readFileSync(
         path.join(
@@ -4037,19 +4045,19 @@ Current date and time: 2025-06-11T11:43:00.533Z
     assert.equal(messages![0].role, 'system');
     assert.equal(messages![1].role, 'user');
     assert.equal(messages![2].role, 'assistant');
-    assert.equal(messages![3].role, 'system');
+    assert.equal(messages![3].role, 'user');
     assert.ok(
       messageText(messages![3]).startsWith('The user is currently viewing'),
       'the context trails the conversation as its own message',
     );
   });
 
-  test('no interstitial system message is followed by a user message', async () => {
-    // Anthropic rejects the array outright when a `system` message is neither
-    // last nor immediately before an `assistant` message:
-    //   "role 'system' must precede an 'assistant' message or end the array"
-    // The leading system prompt is exempt — providers lift it out of the array
-    // into their own system parameter — so this checks every one after it.
+  test('the leading system prompt is the only system message', async () => {
+    // For models without a native mid-conversation system role, OpenRouter
+    // hoists every non-leading `system` message into the top-level system
+    // parameter. Volatile content hoisted that way lands in front of the
+    // whole conversation and defeats the prompt cache — so nothing after
+    // messages[0] may carry the system role.
     for (let fixture of [
       'user-message-last-single.json',
       'user-message-last-multiple.json',
@@ -4073,18 +4081,11 @@ Current date and time: 2025-06-11T11:43:00.533Z
         // A history the bot would not answer builds no message array.
         continue;
       }
-      for (let i = 1; i < messages!.length; i++) {
-        if (messages![i].role !== 'system') {
-          continue;
-        }
-        let next = messages![i + 1];
-        assert.true(
-          next === undefined || next.role === 'assistant',
-          `${fixture}: system message at ${i} is followed by ${
-            next?.role ?? 'nothing'
-          }, which Anthropic rejects`,
-        );
-      }
+      assert.equal(messages![0].role, 'system', `${fixture}: leading system`);
+      assert.false(
+        messages!.slice(1).some((message) => message.role === 'system'),
+        `${fixture}: no system message after the leading one`,
+      );
     }
   });
 
@@ -4104,7 +4105,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
       '@aibot:localhost',
       fakeMatrixClient,
     );
-    assert.equal(messages![4].role, 'system');
+    assert.equal(messages![4].role, 'user');
     assert.true(
       !!messageText(messages![4]).match(
         /Current date and time: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
@@ -5276,15 +5277,15 @@ new
     // volatile trailing context message rather than the history — a history
     // entry that vanishes on the next request would defeat the prompt cache.
     let trailingMessage = promptParts.messages?.at(-1);
-    assert.equal(trailingMessage?.role, 'system');
+    assert.equal(trailingMessage?.role, 'user');
     assert.true(
       messageText(trailingMessage).endsWith(summaryMessage),
       'Summary should be appended to the trailing context message',
     );
     assert.false(
-      enabledUserMessages.some((message) =>
-        messageText(message).includes(summaryMessage),
-      ),
+      promptParts.messages
+        ?.slice(0, -1)
+        .some((message) => messageText(message).includes(summaryMessage)),
       'Summary must not be a history entry — it vanishes on the next request',
     );
     assert.false(
@@ -5460,7 +5461,7 @@ new
     // [system, user, assistant, user, trailing context]
     assert.deepEqual(
       result.map((m) => m.role),
-      ['system', 'user', 'assistant', 'user', 'system'],
+      ['system', 'user', 'assistant', 'user', 'user'],
     );
     let lastUserMessage = result[3];
     assert.ok(
@@ -5526,7 +5527,7 @@ new
     );
     assert.deepEqual(
       messages!.map((m) => m.role),
-      ['system', 'user', 'assistant', 'tool', 'system'],
+      ['system', 'user', 'assistant', 'tool', 'user'],
     );
     let toolMessage = messages![3];
     assert.ok(
@@ -5656,7 +5657,7 @@ new
     );
     assert.deepEqual(
       result.map((m) => m.role),
-      ['system', 'user', 'system'],
+      ['system', 'user', 'user'],
     );
     assert.equal(
       countCacheBreakpoints(result),
@@ -5755,8 +5756,8 @@ new
     const userMessages = result.filter((message) => message.role === 'user');
     assert.equal(
       userMessages.length,
-      2,
-      'Both user messages should be included',
+      3,
+      'Both user messages plus the trailing context message',
     );
   });
 
@@ -5935,8 +5936,8 @@ new
     const userMessages = result.filter((message) => message.role === 'user');
     assert.equal(
       userMessages.length,
-      1,
-      'Only the non-empty user message should be included',
+      2,
+      'The non-empty user message plus the trailing context message',
     );
     assert.true(
       messageText(userMessages[0]).endsWith('Hello'),

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5272,11 +5272,20 @@ new
     );
     let enabledUserMessages =
       promptParts.messages?.filter((message) => message.role === 'user') ?? [];
+    // The instruction exists for this one request only, so it rides the
+    // volatile trailing context message rather than the history — a history
+    // entry that vanishes on the next request would defeat the prompt cache.
+    let trailingMessage = promptParts.messages?.at(-1);
+    assert.equal(trailingMessage?.role, 'system');
     assert.true(
+      messageText(trailingMessage).endsWith(summaryMessage),
+      'Summary should be appended to the trailing context message',
+    );
+    assert.false(
       enabledUserMessages.some((message) =>
-        messageText(message).endsWith(summaryMessage),
+        messageText(message).includes(summaryMessage),
       ),
-      'Summary should be included',
+      'Summary must not be a history entry — it vanishes on the next request',
     );
     assert.false(
       enabledUserMessages.some((message) =>

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -165,6 +165,22 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       getResponse: async (req: Request) => {
         const body = await req.json();
 
+        // Message content arrives as a plain string or as a parts array (the
+        // prompt serializes history messages in the parts form); read the
+        // text out of either shape, the way the real endpoint would.
+        const contentText = (content: any): string => {
+          if (typeof content === 'string') {
+            return content;
+          }
+          if (Array.isArray(content)) {
+            return content
+              .filter((part: any) => part.type === 'text')
+              .map((part: any) => part.text ?? '')
+              .join('');
+          }
+          return '';
+        };
+
         // Handle summarization requests
         if (body.url.includes('openrouter.ai/api/v1/chat/completions')) {
           const requestBody = JSON.parse(body.requestBody);
@@ -172,10 +188,10 @@ module('Acceptance | AI Assistant tests', function (hooks) {
           // Check if this is a summarization request
           if (
             requestBody.messages &&
-            requestBody.messages.some(
-              (msg: any) =>
-                msg.content &&
-                msg.content.includes('Please provide a concise summary'),
+            requestBody.messages.some((msg: any) =>
+              contentText(msg.content).includes(
+                'Please provide a concise summary',
+              ),
             )
           ) {
             // Return a mock summary based on the conversation content
@@ -183,9 +199,11 @@ module('Acceptance | AI Assistant tests', function (hooks) {
               .filter(
                 (msg: any) =>
                   msg.role === 'user' &&
-                  !msg.content.includes('Please provide a concise summary'),
+                  !contentText(msg.content).includes(
+                    'Please provide a concise summary',
+                  ),
               )
-              .map((msg: any) => msg.content)
+              .map((msg: any) => contentText(msg.content))
               .join(' ');
 
             let summary = 'This conversation focused on general discussion.';

--- a/packages/host/tests/integration/tools/summarize-session-test.gts
+++ b/packages/host/tests/integration/tools/summarize-session-test.gts
@@ -49,6 +49,22 @@ module('Integration | tools | summarize-session', function (hooks) {
       getResponse: async (req: Request) => {
         const body = await req.json();
 
+        // Message content arrives as a plain string or as a parts array (the
+        // prompt serializes history messages in the parts form); read the
+        // text out of either shape, the way the real endpoint would.
+        const contentText = (content: any): string => {
+          if (typeof content === 'string') {
+            return content;
+          }
+          if (Array.isArray(content)) {
+            return content
+              .filter((part: any) => part.type === 'text')
+              .map((part: any) => part.text ?? '')
+              .join('');
+          }
+          return '';
+        };
+
         // Handle summarization requests
         if (body.url.includes('openrouter.ai/api/v1/chat/completions')) {
           const requestBody = JSON.parse(body.requestBody);
@@ -56,10 +72,10 @@ module('Integration | tools | summarize-session', function (hooks) {
           // Check if this is a summarization request
           if (
             requestBody.messages &&
-            requestBody.messages.some(
-              (msg: any) =>
-                msg.content &&
-                msg.content.includes('Please provide a concise summary'),
+            requestBody.messages.some((msg: any) =>
+              contentText(msg.content).includes(
+                'Please provide a concise summary',
+              ),
             )
           ) {
             // Return a mock summary based on the conversation content
@@ -67,9 +83,11 @@ module('Integration | tools | summarize-session', function (hooks) {
               .filter(
                 (msg: any) =>
                   msg.role === 'user' &&
-                  !msg.content.includes('Please provide a concise summary'),
+                  !contentText(msg.content).includes(
+                    'Please provide a concise summary',
+                  ),
               )
-              .map((msg: any) => msg.content)
+              .map((msg: any) => contentText(msg.content))
               .join(' ');
 
             let summary = 'This conversation focused on general discussion.';

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1701,42 +1701,19 @@ export async function buildPromptForModel(
     tools,
     disabledSkillIds,
   );
-  // The context always trails the conversation as its own message, for two
-  // reasons that lock together:
-  //
-  // Caching. The context carries the current time, so its bytes change on
-  // every request, and prompt caching is an exact prefix match. Trailing it
-  // keeps every history message byte-stable across requests, which is what
-  // lets the cache breakpoint below actually get read back. Folding the
-  // context into the last user message instead — which this assembly used to
-  // do — rewrote that message's bytes on every request and on every new user
-  // turn, guaranteeing a cache miss for the entire history after it, every
-  // time.
-  //
-  // Role. The trailing message is `user`, not `system`, and this is
-  // load-bearing: for models without a native mid-conversation system role,
-  // OpenRouter hoists every non-leading `system` message into the top-level
-  // system parameter — which put this volatile, timestamped content in front
-  // of the entire conversation and made every request miss the cache for
-  // everything after the system prefix (verified empirically: an identical
-  // two-request exchange read the full history back with a trailing `user`
-  // context and only the system prefix with a trailing `system` one). A
-  // trailing `user` message is legal everywhere; when the turn also ends
-  // with a user message, providers merge the two, and the merged blocks land
-  // after the cache marker where their churn costs nothing.
-  //
-  // The breakpoint marks the last real message — the end of the stable
-  // history. When the turn ends with a tool result, that is where pulled
-  // skill files land, and they are exactly the content that must not be
-  // re-billed at full price on every later request.
+  // The context carries the current time, so its bytes change on every
+  // request. Prompt caching is an exact prefix match, so it trails the
+  // conversation as its own message, after the cache marker — never folded
+  // into a history message, whose bytes must stay stable across requests.
+  // Its role must be `user`: OpenRouter hoists non-leading `system`
+  // messages into the top-level system parameter, which would put this
+  // volatile content in front of the whole conversation and defeat the
+  // cache.
   normalizeHistoryContentShape(messages);
   addHistoryCacheBreakpoint(messages, messages.length - 1);
-  // The correctness-summary instruction exists for this one request only, so
-  // it rides the volatile trailing message. As its own history entry — how
-  // this used to work — it changed the history's byte layout between
-  // requests (present on this one, gone on the next) and drew the cache
-  // marker onto a message that would never exist again, wasting the turn's
-  // cache entry. Appending keeps it the last thing the model reads.
+  // The correctness-summary instruction applies to this request only, so it
+  // rides the volatile trailing message; a history entry that vanishes on
+  // the next request would both churn the history and waste the marker.
   let trailingContent = shouldPromptCheckCorrectnessSummary(
     history,
     aiBotUserId,
@@ -1748,16 +1725,12 @@ export async function buildPromptForModel(
   return messages;
 }
 
-// Serializes every history message's content in the parts-array form, every
-// turn, whether or not it carries the cache marker. The marker needs the
-// parts form, and it moves forward each turn — if only the marked message
-// were converted, each message would flip between the string shape and the
-// parts shape as the marker passed through it. String and parts-array
-// content are semantically the same message, but they are not the same bytes
-// on the wire, and prompt caching is an exact byte match: the flip made the
-// previous turn's cache entry unreadable at exactly the marked position,
-// every turn. A message with empty content (an assistant turn that is only
-// tool calls) stays as it is — an empty text part would be rejected.
+// Serializes every history message in the parts-array form, every turn.
+// The cache marker needs the parts form and moves forward each turn; if
+// only the marked message were converted, messages would flip between the
+// string and parts shapes as the marker passes through — different bytes on
+// the wire, so each flip is a cache miss at that position. Empty contents
+// stay untouched: an empty text part would be rejected.
 function normalizeHistoryContentShape(messages: OpenAIPromptMessage[]) {
   for (let i = 1; i < messages.length; i++) {
     let message = messages[i];
@@ -1767,18 +1740,12 @@ function normalizeHistoryContentShape(messages: OpenAIPromptMessage[]) {
   }
 }
 
-// Marks the end of the stable conversation prefix as cacheable, so the
-// provider re-reads the history at the cached-input price instead of
-// re-billing it fresh on every request. This is the second of the prompt's
-// two cache breakpoints — the first sits on the system message — and it is
-// what keeps skills pulled mid-conversation (readRealmFile results) from
-// costing full price on every turn for the rest of the session.
-//
-// Walks backward from `index` past messages that cannot carry a marker (an
-// empty body, e.g. an assistant turn that is only tool calls). Never marks
-// messages[0]: that is the system message, which has its own breakpoint. The
-// mutation is safe because every message here was freshly built by this
-// prompt assembly.
+// Marks the end of the stable history as cacheable — the second of the
+// prompt's two breakpoints (the first sits on the system message). This is
+// what keeps pulled skill files (readRealmFile results) from being
+// re-billed at full price on every later request. Walks backward past
+// unmarkable messages (empty content); never marks messages[0], the system
+// message.
 function addHistoryCacheBreakpoint(
   messages: OpenAIPromptMessage[],
   index: number,

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1311,6 +1311,14 @@ const CORRECTNESS_SUCCESS_SUMMARY_INSTRUCTION =
 
 const CORRECTNESS_FAILURE_LIMIT_INSTRUCTION = `Automated correctness fixes have already been attempted ${MAX_CORRECTNESS_FIX_ATTEMPTS} times and the target is still failing validation. Stop proposing further automated patches; instead, summarize the remaining errors and ask the user how they want to proceed. Do not mention correctness or automated checks or tool calls.`;
 
+// This lands mid-answer, right after a file is written, and it is the last
+// thing the model reads before replying — so an instruction that only asks
+// for a summary reads as the end of the work. It was: a build announced as
+// two cards delivered one, reported it was clean, and stopped, because
+// nothing resumes a plan across turns.
+const CHECK_CORRECTNESS_SUMMARY_INSTRUCTION =
+  'The automated correctness checks have finished. Summarize the results based on the tool output above in one short sentence. Do not mention: correctness, automated correctness checks, tool calls. If work you already described remains unfinished, carry straight on with it in the same reply — this is a note on what just landed, not a request to stop.';
+
 function extractCorrectnessResultCard(
   toolResult?: ToolResultEvent,
 ): CorrectnessResultSummary | undefined {
@@ -1653,18 +1661,6 @@ export async function buildPromptForModel(
       }
     }
   }
-  if (shouldPromptCheckCorrectnessSummary(history, aiBotUserId)) {
-    historicalMessages.push({
-      role: 'user',
-      content:
-        // This lands mid-answer, right after a file is written, and it is the
-        // last thing the model reads before replying — so an instruction that
-        // only asks for a summary reads as the end of the work. It was: a build
-        // announced as two cards delivered one, reported it was clean, and
-        // stopped, because nothing resumes a plan across turns.
-        'The automated correctness checks have finished. Summarize the results based on the tool output above in one short sentence. Do not mention: correctness, automated correctness checks, tool calls. If work you already described remains unfinished, carry straight on with it in the same reply — this is a note on what just landed, not a request to stop.',
-    });
-  }
   let systemMessageParts = [SYSTEM_MESSAGE];
 
   systemMessageParts.push(
@@ -1730,7 +1726,19 @@ export async function buildPromptForModel(
   // re-billed at full price on every later request.
   normalizeHistoryContentShape(messages);
   addHistoryCacheBreakpoint(messages, messages.length - 1);
-  messages.push({ role: 'system', content: contextContent });
+  // The correctness-summary instruction exists for this one request only, so
+  // it rides the volatile trailing message. As its own history entry — how
+  // this used to work — it changed the history's byte layout between
+  // requests (present on this one, gone on the next) and drew the cache
+  // marker onto a message that would never exist again, wasting the turn's
+  // cache entry. Appending keeps it the last thing the model reads.
+  let trailingContent = shouldPromptCheckCorrectnessSummary(
+    history,
+    aiBotUserId,
+  )
+    ? `${contextContent}\n\n${CHECK_CORRECTNESS_SUMMARY_INSTRUCTION}`
+    : contextContent;
+  messages.push({ role: 'system', content: trailingContent });
 
   return messages;
 }

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1713,12 +1713,17 @@ export async function buildPromptForModel(
   // turn, guaranteeing a cache miss for the entire history after it, every
   // time.
   //
-  // Placement. Providers disagree about where a `system` message may sit,
-  // and the array has to satisfy the strictest of them: OpenAI rejects one
-  // placed between an assistant and its tool messages, and Anthropic
-  // requires one to immediately precede an `assistant` message or end the
-  // array. A trailing `system` message ends the array, which is legal
-  // everywhere.
+  // Role. The trailing message is `user`, not `system`, and this is
+  // load-bearing: for models without a native mid-conversation system role,
+  // OpenRouter hoists every non-leading `system` message into the top-level
+  // system parameter — which put this volatile, timestamped content in front
+  // of the entire conversation and made every request miss the cache for
+  // everything after the system prefix (verified empirically: an identical
+  // two-request exchange read the full history back with a trailing `user`
+  // context and only the system prefix with a trailing `system` one). A
+  // trailing `user` message is legal everywhere; when the turn also ends
+  // with a user message, providers merge the two, and the merged blocks land
+  // after the cache marker where their churn costs nothing.
   //
   // The breakpoint marks the last real message — the end of the stable
   // history. When the turn ends with a tool result, that is where pulled
@@ -1738,7 +1743,7 @@ export async function buildPromptForModel(
   )
     ? `${contextContent}\n\n${CHECK_CORRECTNESS_SUMMARY_INSTRUCTION}`
     : contextContent;
-  messages.push({ role: 'system', content: trailingContent });
+  messages.push({ role: 'user', content: trailingContent });
 
   return messages;
 }

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1705,33 +1705,83 @@ export async function buildPromptForModel(
     tools,
     disabledSkillIds,
   );
-  // The context should be placed where it explains the state of the host.
-  // This is either:
-  // * After the last tool call message, if the last message was a tool call
-  // * At the front of the last user message otherwise
+  // The context always trails the conversation as its own message, for two
+  // reasons that lock together:
   //
-  // Providers disagree about where a `system` message may sit, and the array
-  // has to satisfy the strictest of them: OpenAI rejects one placed between an
-  // assistant and its tool messages, and Anthropic requires one to immediately
-  // precede an `assistant` message or end the array. A `system` message before
-  // the last user turn always has a `user` after it, so it can never satisfy
-  // Anthropic — the context is folded into that user turn instead of standing
-  // as its own message. Trailing it after a tool result keeps its own message,
-  // which is legal everywhere because it ends the array.
-  let lastMessage = messages[messages.length - 1];
-  if (lastMessage.role === 'tool') {
-    messages.push({ role: 'system', content: contextContent });
-  } else {
-    let lastUserIndex = findLastIndex(messages, (msg) => msg.role === 'user');
-    if (lastUserIndex !== -1) {
-      messages[lastUserIndex] = prependContextToMessage(
-        messages[lastUserIndex],
-        contextContent,
-      );
-    }
-  }
+  // Caching. The context carries the current time, so its bytes change on
+  // every request, and prompt caching is an exact prefix match. Trailing it
+  // keeps every history message byte-stable across requests, which is what
+  // lets the cache breakpoint below actually get read back. Folding the
+  // context into the last user message instead — which this assembly used to
+  // do — rewrote that message's bytes on every request and on every new user
+  // turn, guaranteeing a cache miss for the entire history after it, every
+  // time.
+  //
+  // Placement. Providers disagree about where a `system` message may sit,
+  // and the array has to satisfy the strictest of them: OpenAI rejects one
+  // placed between an assistant and its tool messages, and Anthropic
+  // requires one to immediately precede an `assistant` message or end the
+  // array. A trailing `system` message ends the array, which is legal
+  // everywhere.
+  //
+  // The breakpoint marks the last real message — the end of the stable
+  // history. When the turn ends with a tool result, that is where pulled
+  // skill files land, and they are exactly the content that must not be
+  // re-billed at full price on every later request.
+  normalizeHistoryContentShape(messages);
+  addHistoryCacheBreakpoint(messages, messages.length - 1);
+  messages.push({ role: 'system', content: contextContent });
 
   return messages;
+}
+
+// Serializes every history message's content in the parts-array form, every
+// turn, whether or not it carries the cache marker. The marker needs the
+// parts form, and it moves forward each turn — if only the marked message
+// were converted, each message would flip between the string shape and the
+// parts shape as the marker passed through it. String and parts-array
+// content are semantically the same message, but they are not the same bytes
+// on the wire, and prompt caching is an exact byte match: the flip made the
+// previous turn's cache entry unreadable at exactly the marked position,
+// every turn. A message with empty content (an assistant turn that is only
+// tool calls) stays as it is — an empty text part would be rejected.
+function normalizeHistoryContentShape(messages: OpenAIPromptMessage[]) {
+  for (let i = 1; i < messages.length; i++) {
+    let message = messages[i];
+    if (typeof message.content === 'string' && message.content) {
+      message.content = [{ type: 'text', text: message.content }];
+    }
+  }
+}
+
+// Marks the end of the stable conversation prefix as cacheable, so the
+// provider re-reads the history at the cached-input price instead of
+// re-billing it fresh on every request. This is the second of the prompt's
+// two cache breakpoints — the first sits on the system message — and it is
+// what keeps skills pulled mid-conversation (readRealmFile results) from
+// costing full price on every turn for the rest of the session.
+//
+// Walks backward from `index` past messages that cannot carry a marker (an
+// empty body, e.g. an assistant turn that is only tool calls). Never marks
+// messages[0]: that is the system message, which has its own breakpoint. The
+// mutation is safe because every message here was freshly built by this
+// prompt assembly.
+function addHistoryCacheBreakpoint(
+  messages: OpenAIPromptMessage[],
+  index: number,
+) {
+  for (let i = Math.min(index, messages.length - 1); i >= 1; i--) {
+    // Contents were normalized to the parts form before this runs; anything
+    // still a string is empty and cannot carry a marker.
+    let { content } = messages[i];
+    if (Array.isArray(content) && content.length > 0) {
+      content[content.length - 1] = {
+        ...content[content.length - 1],
+        cache_control: { type: 'ephemeral' },
+      };
+      return;
+    }
+  }
 }
 
 function collectPendingCodePatchCorrectnessCheck(
@@ -2290,29 +2340,6 @@ export const buildAttachmentsMessagePart = async (
   }
   return { text, mediaParts };
 };
-
-// Puts the host-state context at the front of a user turn, so it reads as the
-// setting for what the user then asks. String content stays a string; content
-// already split into parts gains one leading text part, which keeps any image,
-// file, or audio parts — and their `cache_control` — exactly as they were.
-function prependContextToMessage(
-  message: OpenAIPromptMessage,
-  contextContent: string,
-): OpenAIPromptMessage {
-  if (typeof message.content === 'string') {
-    return {
-      ...message,
-      content: `${contextContent}\n\n${message.content}`,
-    };
-  }
-  return {
-    ...message,
-    content: [
-      { type: 'text', text: contextContent } as TextContent,
-      ...message.content,
-    ],
-  };
-}
 
 export const buildContextMessage = async (
   client: MatrixClient,


### PR DESCRIPTION
There was an unexpected result after lading https://github.com/cardstack/boxel/pull/5676 - the AI responses in the AI asistant actually got more expensive while the mentioned feature was supposed to bring the cost down. It turns out we got prompt caching management issues. This PR fixes that.

I did benchmarks using https://github.com/cardstack/boxel/pull/5755 and working with AI assistant is now around 5% cheaper than before (when we loaded all skills upfront). 

claude summary:

The provider gives ~90% off any part of a request it has seen before, but only up to a cache marker and only if the bytes match the previous request exactly. We only marked the system prompt, so the whole conversation — including pulled skill files — was re-billed at full price on every turn.

This marks the end of the conversation history too, and fixes three things that broke the byte-match between turns:

- The context block (contains the current time) now always trails the conversation, after the marker — it used to be folded into the last user message, changing that message every request.
- All history messages are serialized in one shape (parts array) every turn — messages used to flip between string and parts form as the marker moved through them.
- The trailing context is a `user` message — OpenRouter moves `system` messages to the front, which put the changing timestamp ahead of the whole conversation.

Result on the benchmark task: cached input now grows with the conversation instead of staying flat, follow-up requests cost ~$0.01 instead of $0.05–0.20, and a session dropped from $0.40–1.00 to $0.18.

Tests pin the invariant: consecutive turns must serialize the shared history byte-identically, marker aside.

Known limitation (follow-up): applying a code patch still rewrites one past message, costing one cache miss per apply.

