### PR TITLE
Fix flaky Percy diff related to resizable panel widths

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -207,11 +207,16 @@ export default class CodeSubmode extends Component<Signature> {
         rightPanel: !this.codePath ? 0 : persistedDefaultPanelWidths.rightPanel,
       }) <= 100
         ? persistedDefaultPanelWidths
-        : defaultPanelWidths;
+        : // Copy rather than alias. The layout callbacks below mutate whichever
+          // object lands here, and `defaultPanelWidths` is module-level state
+          // shared by every instance that ever falls back to it — mutating it
+          // would make one instance's final layout the next one's starting
+          // point, with nothing but a page load to clear it.
+          { ...defaultPanelWidths };
     this.defaultPanelHeights =
       persistedDefaultPanelHeights && sum(persistedDefaultPanelHeights) <= 100
         ? persistedDefaultPanelHeights
-        : defaultPanelHeights;
+        : { ...defaultPanelHeights };
 
     registerDestructor(this, () => {
       this.operatorModeStateService.unsubscribeFromOpenFileStateChanges(this);

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1620,6 +1620,27 @@ module('Acceptance | code submode tests', function (_hooks) {
       let previewResizeHandle = handles.at(-1);
       assert.ok(previewResizeHandle, 'preview panel resize handle exists');
 
+      // The panels either side of the handle, in group order.
+      let editorPanel = previewResizeHandle!
+        .previousElementSibling as HTMLElement;
+      let previewPanel = previewResizeHandle!.nextElementSibling as HTMLElement;
+      assert
+        .dom(previewPanel)
+        .hasAttribute(
+          'data-boxel-panel-id',
+          /.+/,
+          'the handle sits between two resizable panels',
+        );
+
+      // Drag by a fraction of the preview panel's own width rather than a
+      // fixed pixel count. A drag wider than the panel is clamped where the
+      // panel runs out of room, so only part of it lands — and the reverse
+      // drag, which is not clamped, then gives back more than the first one
+      // took, leaving the group in a layout neither drag asked for.
+      let initialEditorWidth = editorPanel.getBoundingClientRect().width;
+      let initialPreviewWidth = previewPanel.getBoundingClientRect().width;
+      let dragDistance = Math.round(initialPreviewWidth * 0.75);
+
       let shrinkRect = previewResizeHandle!.getBoundingClientRect();
       await triggerEvent(previewResizeHandle!, 'pointerdown', {
         button: 0,
@@ -1630,12 +1651,12 @@ module('Acceptance | code submode tests', function (_hooks) {
       await triggerEvent(previewResizeHandle!, 'pointermove', {
         pointerId: 1,
         buttons: 1,
-        clientX: shrinkRect.x + shrinkRect.width / 2 + 320,
+        clientX: shrinkRect.x + shrinkRect.width / 2 + dragDistance,
         clientY: shrinkRect.y + shrinkRect.height / 2,
       });
       await triggerEvent(previewResizeHandle!, 'pointerup', {
         pointerId: 1,
-        clientX: shrinkRect.x + shrinkRect.width / 2 + 320,
+        clientX: shrinkRect.x + shrinkRect.width / 2 + dragDistance,
         clientY: shrinkRect.y + shrinkRect.height / 2,
       });
 
@@ -1680,12 +1701,12 @@ module('Acceptance | code submode tests', function (_hooks) {
       await triggerEvent(previewResizeHandle!, 'pointermove', {
         pointerId: 2,
         buttons: 1,
-        clientX: widenRect.x + widenRect.width / 2 - 320,
+        clientX: widenRect.x + widenRect.width / 2 - dragDistance,
         clientY: widenRect.y + widenRect.height / 2,
       });
       await triggerEvent(previewResizeHandle!, 'pointerup', {
         pointerId: 2,
-        clientX: widenRect.x + widenRect.width / 2 - 320,
+        clientX: widenRect.x + widenRect.width / 2 - dragDistance,
         clientY: widenRect.y + widenRect.height / 2,
       });
 
@@ -1707,6 +1728,23 @@ module('Acceptance | code submode tests', function (_hooks) {
       assert
         .dom('[data-test-format-chooser-pill-label]')
         .hasText('isolated', 'full chooser label is restored');
+
+      // The chooser reports full mode for any width above its threshold, so
+      // it can read as restored while the panels sit somewhere else entirely.
+      // Check the widths themselves to hold the widen drag to giving back
+      // exactly what the shrink drag took.
+      assert.ok(
+        Math.abs(
+          previewPanel.getBoundingClientRect().width - initialPreviewWidth,
+        ) <= 1,
+        'preview panel is back to the width it started at',
+      );
+      assert.ok(
+        Math.abs(
+          editorPanel.getBoundingClientRect().width - initialEditorWidth,
+        ) <= 1,
+        'code editor panel is back to the width it started at',
+      );
     });
 
     test('displays clear message when a schema-editor incompatible item is selected within a valid file type', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1625,11 +1625,18 @@ module('Acceptance | code submode tests', function (_hooks) {
         .previousElementSibling as HTMLElement;
       let previewPanel = previewResizeHandle!.nextElementSibling as HTMLElement;
       assert
+        .dom(editorPanel)
+        .hasAttribute(
+          'data-boxel-panel-id',
+          /.+/,
+          'the element before the handle is a resizable panel',
+        );
+      assert
         .dom(previewPanel)
         .hasAttribute(
           'data-boxel-panel-id',
           /.+/,
-          'the handle sits between two resizable panels',
+          'the element after the handle is a resizable panel',
         );
 
       // Drag by a fraction of the preview panel's own width rather than a


### PR DESCRIPTION
While Percy diffs are definitely reduced since the font fixes, I’ve seen this pattern occasionally:

<img width="1235" height="697" alt="image" src="https://github.com/user-attachments/assets/26e35fc5-f3a0-460f-87f5-0645958c69e4" />

This fixes it by:
* copying persisted panel widths instead of reusing, as that leads to bleed-through
* changing the test to drag by a fraction vs absolute amount