### PR TITLE
Clip adorn card overlays behind the rich-markdown compose toolbar

### DIFF
--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -929,7 +929,7 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           boundary the operator-mode overlay layer clips against: adorn overlays
           drawn over embedded compose-preview cards are cut off where a card
           scrolls behind the sticky toolbar, so the outline no longer paints on
-          top of it (CS-11699). Consumed by the `offset` middleware in
+          top of it. Consumed by the `offset` middleware in
           operator-mode/overlays.gts. }}
       <div
         class='codemirror-editor'

--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -926,11 +926,12 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
   <template>
     {{#if this.cm}}
       {{! `data-overlay-clip-container` / `data-overlay-clip-header` mark the
-          boundary the operator-mode overlay layer clips against: adorn overlays
-          drawn over embedded compose-preview cards are cut off where a card
-          scrolls behind the sticky toolbar, so the outline no longer paints on
-          top of it. Consumed by the `offset` middleware in
-          operator-mode/overlays.gts. }}
+          scroll scope and its sticky header so an overlay layer can clip a
+          decorated card's overlay behind the header: adorn overlays drawn over
+          embedded compose-preview cards are cut off where a card scrolls behind
+          the sticky toolbar, so the outline no longer paints on top of it. This
+          is a data-attribute contract — the consumer finds these markers by
+          attribute, not by importing this module. }}
       <div
         class='codemirror-editor'
         data-overlay-clip-container

--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -925,10 +925,25 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
 
   <template>
     {{#if this.cm}}
-      <div class='codemirror-editor' data-test-codemirror-editor ...attributes>
+      {{! `data-overlay-clip-container` / `data-overlay-clip-header` mark the
+          boundary the operator-mode overlay layer clips against: adorn overlays
+          drawn over embedded compose-preview cards are cut off where a card
+          scrolls behind the sticky toolbar, so the outline no longer paints on
+          top of it (CS-11699). Consumed by the `offset` middleware in
+          operator-mode/overlays.gts. }}
+      <div
+        class='codemirror-editor'
+        data-overlay-clip-container
+        data-test-codemirror-editor
+        ...attributes
+      >
         {{! ── Docked toolbar ── }}
         {{! template-lint-disable no-pointer-down-event-binding }}
-        <div class='codemirror-toolbar' data-test-markdown-toolbar>
+        <div
+          class='codemirror-toolbar'
+          data-overlay-clip-header
+          data-test-markdown-toolbar
+        >
           {{yield to='leadingControls'}}
           {{#if (has-block 'leadingControls')}}
             <span class='toolbar-divider'></span>

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -21,7 +21,7 @@ import type { CardDefOrId } from './stack-item';
 
 import type { RenderedCardForOverlayActions } from '../../resources/element-tracker';
 import type { CardDef, Format, ViewCardFn } from '@cardstack/base/card-api';
-import type { MiddlewareState } from '@floating-ui/dom';
+import type { MiddlewareState, ReferenceElement } from '@floating-ui/dom';
 
 interface OverlaySignature {
   Args: {
@@ -74,6 +74,29 @@ export function stickyClipHeaderFor(reference: Element): HTMLElement | null {
       .closest('[data-overlay-clip-container]')
       ?.querySelector<HTMLElement>('[data-overlay-clip-header]') ?? null
   );
+}
+
+// Reads the live rects of `reference` and its clip container's sticky header
+// and assigns the resulting clip to `floating.style.clipPath` — the glue that
+// turns the pure helpers above into the running fix. Both elements must be laid
+// out in the document. Clears to '' when the reference is not an HTMLElement,
+// sits in no marked container, or has scrolled clear of the header. Exported so
+// a test can drive it without standing up the floating-ui middleware.
+export function applyStickyHeaderClip(
+  reference: ReferenceElement,
+  floating: HTMLElement,
+): void {
+  let clipPath = '';
+  if (reference instanceof HTMLElement) {
+    let header = stickyClipHeaderFor(reference);
+    if (header) {
+      clipPath = stickyHeaderClipPath(
+        reference.getBoundingClientRect().top,
+        header.getBoundingClientRect().bottom,
+      );
+    }
+  }
+  floating.style.clipPath = clipPath;
 }
 
 export default class Overlays extends Component<OverlaySignature> {
@@ -182,17 +205,7 @@ export default class Overlays extends Component<OverlaySignature> {
       // the x/y offsets below we deliberately don't divide `clipTop` by the
       // parent scale — under the test runner's #ember-testing scale the clip
       // line is therefore only approximate, which doesn't affect real users.
-      let clipPath = '';
-      if (reference instanceof HTMLElement) {
-        let header = stickyClipHeaderFor(reference);
-        if (header) {
-          clipPath = stickyHeaderClipPath(
-            refRect.top,
-            header.getBoundingClientRect().bottom,
-          );
-        }
-      }
-      floating.style.clipPath = clipPath;
+      applyStickyHeaderClip(reference, floating);
 
       // Position the overlay from the live reference rect relative to the
       // floating element's own offset parent, rather than floating-ui's

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -52,13 +52,28 @@ interface OverlaySignature {
 // far the overlay's top has slid under the header. Negative side/bottom insets
 // keep the adorn box-shadow ring (≤0.25rem spread) visible on the un-clipped
 // edges; '' fully restores the overlay (and its top-overhanging type-label) when
-// nothing occludes it. Exported for unit testing. See CS-11699.
+// nothing occludes it. Exported for unit testing.
 export function stickyHeaderClipPath(
   refTop: number,
   headerBottom: number,
 ): string {
   let clipTop = Math.max(0, headerBottom - refTop);
   return clipTop > 0 ? `inset(${clipTop}px -0.5rem -0.5rem -0.5rem)` : '';
+}
+
+// Finds the sticky header an overlay should clip against: the nearest
+// `[data-overlay-clip-header]` inside the reference card's enclosing
+// `[data-overlay-clip-container]` (the rich-markdown editor). Returns null for
+// cards outside a marked container — so the clip is a no-op for non-editor
+// overlay consumers (spec-preview, playground) and the `querySelector` never
+// runs for them. Scoped to the nearest container, so nested editors clip
+// against their own toolbar. Exported for unit testing.
+export function stickyClipHeaderFor(reference: Element): HTMLElement | null {
+  return (
+    reference
+      .closest('[data-overlay-clip-container]')
+      ?.querySelector<HTMLElement>('[data-overlay-clip-header]') ?? null
+  );
 }
 
 export default class Overlays extends Component<OverlaySignature> {
@@ -155,16 +170,21 @@ export default class Overlays extends Component<OverlaySignature> {
       // (the rich-markdown compose toolbar) — otherwise the adorn outline paints
       // on top of the toolbar, because the overlay is a positioned sibling above
       // the card's stacking-context-sealed subtree and z-index can't arbitrate
-      // it (CS-11699). Mirrors the overflow-occlusion the stack-item header
-      // already relies on, but at the toolbar's dynamic bottom edge. A no-op for
-      // cards outside a marked clip container (the `closest` returns null), so
-      // the `querySelector` never runs for non-editor overlay consumers. Always
-      // assigned so the clip clears as the card scrolls back into the clear.
+      // it. Mirrors the overflow-occlusion the stack-item header
+      // already relies on, but at the toolbar's dynamic bottom edge. `stickyClipHeaderFor`
+      // is a no-op outside a marked clip container, so this stays inert for
+      // non-editor overlay consumers. Always assigned so the clip clears as the
+      // card scrolls back into the clear.
+      //
+      // The inset is measured in viewport px and applied to the floating
+      // element's own (pre-transform) box. In production the offset parent is
+      // unscaled, so the clip lands exactly at the header's bottom edge. Unlike
+      // the x/y offsets below we deliberately don't divide `clipTop` by the
+      // parent scale — under the test runner's #ember-testing scale the clip
+      // line is therefore only approximate, which doesn't affect real users.
       let clipPath = '';
       if (reference instanceof HTMLElement) {
-        let header = reference
-          .closest('[data-overlay-clip-container]')
-          ?.querySelector<HTMLElement>('[data-overlay-clip-header]');
+        let header = stickyClipHeaderFor(reference);
         if (header) {
           clipPath = stickyHeaderClipPath(
             refRect.top,

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -45,6 +45,22 @@ interface OverlaySignature {
   };
 }
 
+// Returns the `clip-path` that hides the portion of an overlay scrolled behind
+// a sticky header (e.g. the rich-markdown compose toolbar), or '' when the card
+// is clear of the header. `refTop` is the decorated card's viewport top and
+// `headerBottom` the header's viewport bottom, so `headerBottom - refTop` is how
+// far the overlay's top has slid under the header. Negative side/bottom insets
+// keep the adorn box-shadow ring (≤0.25rem spread) visible on the un-clipped
+// edges; '' fully restores the overlay (and its top-overhanging type-label) when
+// nothing occludes it. Exported for unit testing. See CS-11699.
+export function stickyHeaderClipPath(
+  refTop: number,
+  headerBottom: number,
+): string {
+  let clipTop = Math.max(0, headerBottom - refTop);
+  return clipTop > 0 ? `inset(${clipTop}px -0.5rem -0.5rem -0.5rem)` : '';
+}
+
 export default class Overlays extends Component<OverlaySignature> {
   @tracked overlayClassName = this.args.overlayClassName ?? 'base-overlay';
   private boundRenderedCardElements = new Map<
@@ -134,6 +150,29 @@ export default class Overlays extends Component<OverlaySignature> {
         floating.style.borderRadius =
           window.getComputedStyle(reference).borderRadius;
       }
+
+      // Clip the overlay where a scrolled card slides behind a sticky header
+      // (the rich-markdown compose toolbar) — otherwise the adorn outline paints
+      // on top of the toolbar, because the overlay is a positioned sibling above
+      // the card's stacking-context-sealed subtree and z-index can't arbitrate
+      // it (CS-11699). Mirrors the overflow-occlusion the stack-item header
+      // already relies on, but at the toolbar's dynamic bottom edge. A no-op for
+      // cards outside a marked clip container (the `closest` returns null), so
+      // the `querySelector` never runs for non-editor overlay consumers. Always
+      // assigned so the clip clears as the card scrolls back into the clear.
+      let clipPath = '';
+      if (reference instanceof HTMLElement) {
+        let header = reference
+          .closest('[data-overlay-clip-container]')
+          ?.querySelector<HTMLElement>('[data-overlay-clip-header]');
+        if (header) {
+          clipPath = stickyHeaderClipPath(
+            refRect.top,
+            header.getBoundingClientRect().bottom,
+          );
+        }
+      }
+      floating.style.clipPath = clipPath;
 
       // Position the overlay from the live reference rect relative to the
       // floating element's own offset parent, rather than floating-ui's

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -45,20 +45,36 @@ interface OverlaySignature {
   };
 }
 
+// A per-edge inset large enough to leave that edge effectively unclipped — it
+// extends the clip region a full viewport past the box on that side, well
+// beyond any overlay chrome.
+const UNCLIPPED_EDGE = '-100vmax';
+
 // Returns the `clip-path` that hides the portion of an overlay scrolled behind
 // a sticky header (e.g. the rich-markdown compose toolbar), or '' when the card
 // is clear of the header. `refTop` is the decorated card's viewport top and
 // `headerBottom` the header's viewport bottom, so `headerBottom - refTop` is how
-// far the overlay's top has slid under the header. Negative side/bottom insets
-// keep the adorn box-shadow ring (≤0.25rem spread) visible on the un-clipped
-// edges; '' fully restores the overlay (and its top-overhanging type-label) when
+// far the overlay's top has slid under the header.
+//
+// Only the top edge is clipped; the other three are left unclipped. The header
+// is a horizontal top occluder, so the top clip line (anchored at
+// `headerBottom`) alone hides everything above it — regardless of which edge of
+// the overlay that content sits on. Clipping the sides/bottom would serve no
+// occlusion purpose and would crop chrome that legitimately hangs past the box:
+// the box-shadow ring, and above all a type-label that has flipped below the
+// card (which happens exactly when the card nears the top of its boundary — the
+// same moment this clip engages). A below-flipped label is still hidden while
+// it's above `headerBottom` (the top inset catches it) and shown once it clears
+// the header, which is the correct behavior. '' fully restores the overlay when
 // nothing occludes it. Exported for unit testing.
 export function stickyHeaderClipPath(
   refTop: number,
   headerBottom: number,
 ): string {
   let clipTop = Math.max(0, headerBottom - refTop);
-  return clipTop > 0 ? `inset(${clipTop}px -0.5rem -0.5rem -0.5rem)` : '';
+  return clipTop > 0
+    ? `inset(${clipTop}px ${UNCLIPPED_EDGE} ${UNCLIPPED_EDGE} ${UNCLIPPED_EDGE})`
+    : '';
 }
 
 // Finds the sticky header an overlay should clip against: the nearest

--- a/packages/host/tests/integration/components/codemirror-editor-test.gts
+++ b/packages/host/tests/integration/components/codemirror-editor-test.gts
@@ -1491,7 +1491,7 @@ module('Integration | codemirror-context', function (hooks) {
         content: 'Click [here](https://example.com) for details',
         onDocChange: () => {},
         onCardTargetsChange: () => {},
-        onOpenCardSearch: () => {},
+        onOpenEmbedChooser: () => {},
         onSelectionChange: (info) => {
           selectionInfo = info;
         },
@@ -2000,7 +2000,7 @@ module('Integration | codemirror-context', function (hooks) {
         content: 'Hello World',
         onDocChange: () => {},
         onCardTargetsChange: () => {},
-        onOpenCardSearch: () => {},
+        onOpenEmbedChooser: () => {},
       });
 
       let view = new cmContext.EditorView({
@@ -2037,7 +2037,7 @@ module('Integration | codemirror-context', function (hooks) {
         content: 'Click [here](https://example.com) for details',
         onDocChange: () => {},
         onCardTargetsChange: () => {},
-        onOpenCardSearch: () => {},
+        onOpenEmbedChooser: () => {},
       });
 
       let view = new cmContext.EditorView({

--- a/packages/host/tests/unit/overlays-clip-test.ts
+++ b/packages/host/tests/unit/overlays-clip-test.ts
@@ -17,12 +17,12 @@ module('Unit | overlays | stickyHeaderClipPath', function () {
   });
 
   test('clips the strip that has slid behind the header', function (assert) {
-    // Card top (20) is 30px above the header bottom (50): clip the top 30px,
-    // extending the other edges so the box-shadow ring survives on the
-    // still-visible portion.
+    // Card top (20) is 30px above the header bottom (50): clip the top 30px and
+    // leave the other three edges unclipped, so chrome that hangs past the box
+    // (the ring, a below-flipped type-label) survives on the visible portion.
     assert.strictEqual(
       stickyHeaderClipPath(20, 50),
-      'inset(30px -0.5rem -0.5rem -0.5rem)',
+      'inset(30px -100vmax -100vmax -100vmax)',
     );
   });
 
@@ -116,7 +116,7 @@ module('Unit | overlays | applyStickyHeaderClip', function (hooks) {
   test('clears the clip once the card scrolls clear of the header', function (assert) {
     let card = mountCard(100); // card top 100 is below the header bottom (50)
     let floating = document.createElement('div');
-    floating.style.clipPath = 'inset(30px -0.5rem -0.5rem -0.5rem)'; // stale clip
+    floating.style.clipPath = 'inset(30px -100vmax -100vmax -100vmax)'; // stale clip
 
     applyStickyHeaderClip(card, floating);
 
@@ -130,7 +130,7 @@ module('Unit | overlays | applyStickyHeaderClip', function (hooks) {
   test('clears the clip for a card outside any marked container', function (assert) {
     let card = document.createElement('div');
     let floating = document.createElement('div');
-    floating.style.clipPath = 'inset(30px -0.5rem -0.5rem -0.5rem)'; // stale clip
+    floating.style.clipPath = 'inset(30px -100vmax -100vmax -100vmax)'; // stale clip
 
     applyStickyHeaderClip(card, floating);
 

--- a/packages/host/tests/unit/overlays-clip-test.ts
+++ b/packages/host/tests/unit/overlays-clip-test.ts
@@ -1,6 +1,9 @@
 import { module, test } from 'qunit';
 
-import { stickyHeaderClipPath } from '@cardstack/host/components/operator-mode/overlays';
+import {
+  stickyClipHeaderFor,
+  stickyHeaderClipPath,
+} from '@cardstack/host/components/operator-mode/overlays';
 
 module('Unit | overlays | stickyHeaderClipPath', function () {
   test('no clip while the card sits below the sticky header', function (assert) {
@@ -24,5 +27,42 @@ module('Unit | overlays | stickyHeaderClipPath', function () {
 
   test('clamps to no clip when the card top is far below the header', function (assert) {
     assert.strictEqual(stickyHeaderClipPath(500, 50), '');
+  });
+});
+
+module('Unit | overlays | stickyClipHeaderFor', function () {
+  // Builds a detached clip container with its header and a card inside it —
+  // mirroring the `data-overlay-clip-*` markers the codemirror editor renders.
+  // closest()/querySelector() work on detached DOM, so no fixture is needed.
+  function makeContainer() {
+    let container = document.createElement('div');
+    container.setAttribute('data-overlay-clip-container', '');
+    let header = document.createElement('div');
+    header.setAttribute('data-overlay-clip-header', '');
+    let card = document.createElement('div');
+    container.append(header, card);
+    return { container, header, card };
+  }
+
+  test('finds the sticky header for a card inside a marked container', function (assert) {
+    let { header, card } = makeContainer();
+    assert.strictEqual(stickyClipHeaderFor(card), header);
+  });
+
+  test('returns null for a card outside any marked container', function (assert) {
+    let card = document.createElement('div');
+    assert.strictEqual(stickyClipHeaderFor(card), null);
+  });
+
+  test('scopes to the nearest container when editors are nested', function (assert) {
+    let outer = makeContainer();
+    let inner = makeContainer();
+    outer.container.append(inner.container);
+
+    // A card in the inner editor clips against the inner toolbar...
+    assert.strictEqual(stickyClipHeaderFor(inner.card), inner.header);
+    // ...while a card in the outer editor clips against the outer toolbar
+    // (the first `[data-overlay-clip-header]` in document order).
+    assert.strictEqual(stickyClipHeaderFor(outer.card), outer.header);
   });
 });

--- a/packages/host/tests/unit/overlays-clip-test.ts
+++ b/packages/host/tests/unit/overlays-clip-test.ts
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 
 import {
+  applyStickyHeaderClip,
   stickyClipHeaderFor,
   stickyHeaderClipPath,
 } from '@cardstack/host/components/operator-mode/overlays';
@@ -64,5 +65,75 @@ module('Unit | overlays | stickyClipHeaderFor', function () {
     // ...while a card in the outer editor clips against the outer toolbar
     // (the first `[data-overlay-clip-header]` in document order).
     assert.strictEqual(stickyClipHeaderFor(outer.card), outer.header);
+  });
+});
+
+module('Unit | overlays | applyStickyHeaderClip', function (hooks) {
+  // Exercises the middleware wiring end to end: it reads the live rects of the
+  // card and its sticky header and assigns `floating.style.clipPath`. That
+  // needs real layout, so the fixture is attached to `document.body` (outside
+  // `#ember-testing`, so no runner scale) and each element is `position: fixed`
+  // to pin its rect to a known viewport coordinate independent of scroll. The
+  // header bottom lands at 50px throughout.
+  let mounted: HTMLElement[] = [];
+
+  hooks.afterEach(function () {
+    mounted.forEach((el) => el.remove());
+    mounted = [];
+  });
+
+  function mountCard(cardTop: number) {
+    let container = document.createElement('div');
+    container.setAttribute('data-overlay-clip-container', '');
+
+    let header = document.createElement('div');
+    header.setAttribute('data-overlay-clip-header', '');
+    header.style.cssText =
+      'position: fixed; top: 0; left: 0; width: 200px; height: 50px;';
+
+    let card = document.createElement('div');
+    card.style.cssText = `position: fixed; left: 0; top: ${cardTop}px; width: 200px; height: 200px;`;
+
+    container.append(header, card);
+    document.body.append(container);
+    mounted.push(container);
+    return card;
+  }
+
+  test('clips the overlay while the card sits behind the sticky header', function (assert) {
+    let card = mountCard(20); // card top 20 is 30px above the header bottom (50)
+    let floating = document.createElement('div');
+
+    applyStickyHeaderClip(card, floating);
+
+    assert.notStrictEqual(floating.style.clipPath, '', 'a clip is applied');
+    assert.ok(
+      floating.style.clipPath.includes('30px'),
+      'the clip reads the live rects — the top 30px behind the header is cut',
+    );
+  });
+
+  test('clears the clip once the card scrolls clear of the header', function (assert) {
+    let card = mountCard(100); // card top 100 is below the header bottom (50)
+    let floating = document.createElement('div');
+    floating.style.clipPath = 'inset(30px -0.5rem -0.5rem -0.5rem)'; // stale clip
+
+    applyStickyHeaderClip(card, floating);
+
+    assert.strictEqual(
+      floating.style.clipPath,
+      '',
+      'the stale clip is cleared when nothing occludes the card',
+    );
+  });
+
+  test('clears the clip for a card outside any marked container', function (assert) {
+    let card = document.createElement('div');
+    let floating = document.createElement('div');
+    floating.style.clipPath = 'inset(30px -0.5rem -0.5rem -0.5rem)'; // stale clip
+
+    applyStickyHeaderClip(card, floating);
+
+    assert.strictEqual(floating.style.clipPath, '', 'no container, no clip');
   });
 });

--- a/packages/host/tests/unit/overlays-clip-test.ts
+++ b/packages/host/tests/unit/overlays-clip-test.ts
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+
+import { stickyHeaderClipPath } from '@cardstack/host/components/operator-mode/overlays';
+
+module('Unit | overlays | stickyHeaderClipPath', function () {
+  test('no clip while the card sits below the sticky header', function (assert) {
+    // Card top (100) is below the header bottom (50): nothing is occluded.
+    assert.strictEqual(stickyHeaderClipPath(100, 50), '');
+  });
+
+  test('no clip when the card top is flush with the header bottom', function (assert) {
+    assert.strictEqual(stickyHeaderClipPath(50, 50), '');
+  });
+
+  test('clips the strip that has slid behind the header', function (assert) {
+    // Card top (20) is 30px above the header bottom (50): clip the top 30px,
+    // extending the other edges so the box-shadow ring survives on the
+    // still-visible portion.
+    assert.strictEqual(
+      stickyHeaderClipPath(20, 50),
+      'inset(30px -0.5rem -0.5rem -0.5rem)',
+    );
+  });
+
+  test('clamps to no clip when the card top is far below the header', function (assert) {
+    assert.strictEqual(stickyHeaderClipPath(500, 50), '');
+  });
+});


### PR DESCRIPTION
## Problem

In the rich-markdown **Compose** editor, `:card[…]` references render as live embedded card previews. When you hover or select one, the operator-mode adorn treatment (green box-shadow outline + type-label tab) appears. Scrolling a decorated card up behind the sticky formatting toolbar made that green outline paint **on top of** the toolbar instead of disappearing underneath it.

## Root cause

The adorn treatment is the operator-mode overlay layer — an absolutely-positioned **later sibling** of the card renderer, so it paints above the card's entire subtree. The sticky toolbar's `z-index: 10` is sealed inside two stacking contexts it can't escape (`.boxel-card-container`'s `z-index: 0`, and `.default-card-template`'s `container-type` layout containment). So no z-index change can fix it: the overlay is one flat layer above the whole card, while the toolbar is a sub-region buried inside it.

The stack-item header already avoids this — but only because it sits in a grid row **outside** the `overflow: auto` scroll container that clips the overlays. This change reproduces that same overflow-occlusion, applied dynamically at the toolbar's bottom edge.

## Fix

- `operator-mode/overlays.gts`: the overlay's existing per-frame floating-ui `offset` middleware now sets `clip-path` on the overlay, cutting off the strip that has slid behind a marked sticky header. Two pure, unit-tested helpers: `stickyClipHeaderFor()` (find the header for a card's clip container) and `stickyHeaderClipPath()` (build the inset). Negative side/bottom insets preserve the box-shadow ring on the still-visible portion; the clip clears when the card is in the open. It's a no-op for overlays outside a marked container, so other overlay consumers (spec-preview, playground, preview-panel) are unaffected.
- `codemirror-editor.gts`: marks the compose editor scope with `data-overlay-clip-container` and its sticky toolbar with `data-overlay-clip-header` — the boundary contract, avoiding CSS-class coupling.

Cost is negligible: an overlay is rendered only for a hovered/selected card (0–1 during a scroll), and the layout read already happens each frame.

## Interactivity is preserved

The clip is purely visual. The overlay is `pointer-events: none`; hover and click-to-open are wired to listeners on the underlying **card element**, not the overlay. The only in-overlay controls (type-label menu, select chip) are clipped only where they sit behind the (opaque, unreachable) toolbar. Embedded preview cards remain fully interactive.

## Testing

- **Unit** (`tests/unit/overlays-clip-test.ts`): `stickyHeaderClipPath` (no clip below/flush with the header, correct top inset when the card slides under it) and `stickyClipHeaderFor` (finds the header, returns null outside a container, scopes to the nearest container when editors are nested).
- `ember-tsc` clean on the changed host file.
- **Pending**: manual visual check in the running app (outline cut cleanly at the toolbar edge, box-shadow ring intact on the visible sides, smooth on scroll, controls still work when clear). Scope is compose-only; the preview sub-mode bar is out of scope.

## Risk

The one behavioral dependency is `clip-path: inset()` with negative offsets (to keep the box-shadow ring on the un-clipped sides) — well-supported in the target Chromium. Fallback if it ever regresses: `inset(<top>px 0 0 0)`, accepting a slightly thinner side outline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)