### PR TITLE
Clip markdown editor toolbar corners to the rounded outline

### DIFF
--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -1176,10 +1176,11 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
            corners clip the toolbar's square bottom corners when it docks at
            the bottom on scroll. `overflow: clip` (not `hidden`) does this
            without establishing a scroll container, so the toolbar keeps
-           sticking to the outer scroll panel. The card-search / format-picker
-           popovers stay outside this wrapper so they can still overflow the
-           editor box. The radius is inset by the 1px border so it hugs the
-           border's inner curve. */
+           sticking to the outer scroll panel. The Add-embed dropdown lives
+           inside this wrapper with the toolbar and is intentionally clipped
+           to it: it drops down into the tall editor mount, so the clip is
+           invisible in practice. The radius is inset by the 1px border so it
+           hugs the border's inner curve. */
         .codemirror-body {
           display: flex;
           flex-direction: column;

--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -527,14 +527,53 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
   // ── Markdown embed chooser (toolbar) ────────────────────────────────────
 
   @tracked _embedPopoverOpen = false;
+  // Inline style pinning the popover under its trigger. The popover is
+  // `position: fixed` (see below) so it escapes the `.codemirror-body` corner
+  // clip, which means it needs explicit viewport coordinates rather than the
+  // `top: 100%` an in-flow absolute box would get for free.
+  @tracked _embedPopoverStyle = '';
+  _embedTriggerEl: HTMLElement | null = null;
 
   get _currentBfmRef(): BfmRefRange | undefined {
     return this._selectionInfo?.currentRef;
   }
 
-  _toggleEmbedPopover = () => {
-    this._embedPopoverOpen = !this._embedPopoverOpen;
+  // Pin the popover directly under the trigger, in viewport coordinates. The
+  // trigger is inside a sticky toolbar, so this is recomputed on scroll/resize
+  // (see `_trackEmbedPopover`) to keep the two glued together.
+  _positionEmbedPopover = () => {
+    let trigger = this._embedTriggerEl;
+    if (!trigger) return;
+    let r = trigger.getBoundingClientRect();
+    this._embedPopoverStyle = `position: fixed; top: ${r.bottom + 4}px; left: ${r.left}px;`;
   };
+
+  _toggleEmbedPopover = (e: Event) => {
+    if (this._embedPopoverOpen) {
+      this._embedPopoverOpen = false;
+      return;
+    }
+    this._embedTriggerEl = e.currentTarget as HTMLElement;
+    this._positionEmbedPopover();
+    this._embedPopoverOpen = true;
+  };
+
+  // While the popover is open, keep it pinned under the trigger as the outer
+  // panel scrolls or the window resizes. Installed on the popover element, so
+  // its lifecycle tracks the popover's presence in the DOM.
+  _trackEmbedPopover = modifier(() => {
+    this._positionEmbedPopover();
+    let reposition = () => this._positionEmbedPopover();
+    window.addEventListener('scroll', reposition, {
+      capture: true,
+      passive: true,
+    });
+    window.addEventListener('resize', reposition);
+    return () => {
+      window.removeEventListener('scroll', reposition, { capture: true });
+      window.removeEventListener('resize', reposition);
+    };
+  });
 
   _openEmbedChooser = async (defaultTab: 'card' | 'file') => {
     this._embedPopoverOpen = false;
@@ -993,7 +1032,9 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
                 {{#if this._embedPopoverOpen}}
                   <div
                     class='toolbar-embed-popover'
+                    style={{htmlSafe this._embedPopoverStyle}}
                     data-test-toolbar-embed-popover
+                    {{this._trackEmbedPopover}}
                   >
                     <button
                       type='button'
@@ -1176,11 +1217,16 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
            corners clip the toolbar's square bottom corners when it docks at
            the bottom on scroll. `overflow: clip` (not `hidden`) does this
            without establishing a scroll container, so the toolbar keeps
-           sticking to the outer scroll panel. The Add-embed dropdown lives
-           inside this wrapper with the toolbar and is intentionally clipped
-           to it: it drops down into the tall editor mount, so the clip is
-           invisible in practice. The radius is inset by the 1px border so it
-           hugs the border's inner curve. */
+           sticking to the outer scroll panel. The radius is inset by the 1px
+           border so it hugs the border's inner curve.
+
+           The toolbar's two menus must escape this clip: when the toolbar
+           docks at the bottom there is zero room below it inside the box, so a
+           menu rendered here would be swallowed while its trigger still looks
+           normal. Both are kept out — the mode selector wormholes out of place
+           (BoxelSelect without `renderInPlace`) and the Add-embed popover is
+           `position: fixed` (its containing block is the viewport, so this
+           clip can't reach it). */
         .codemirror-body {
           display: flex;
           flex-direction: column;
@@ -1504,11 +1550,13 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           position: relative;
           display: inline-flex;
         }
+        /* `position: fixed` (coordinates set inline from the trigger's rect)
+           so the popover escapes the `.codemirror-body` corner clip — its
+           containing block is the viewport, which that clip can't reach. An
+           absolute popover here would be swallowed once the toolbar docks at
+           the bottom, where there is no room left below it inside the clip. */
         .toolbar-embed-popover {
-          position: absolute;
-          top: 100%;
-          left: 0;
-          margin-top: 4px;
+          position: fixed;
           min-width: 140px;
           background: var(--boxel-light);
           color: var(--boxel-dark);

--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -6,7 +6,7 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { scheduleOnce } from '@ember/runloop';
 import { htmlSafe } from '@ember/template';
-import { Tooltip } from '@cardstack/boxel-ui/components';
+import { BoxelDropdown, Tooltip } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 
 import {
@@ -526,57 +526,20 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
 
   // ── Markdown embed chooser (toolbar) ────────────────────────────────────
 
-  @tracked _embedPopoverOpen = false;
-  // Inline style pinning the popover under its trigger. The popover is
-  // `position: fixed` (see below) so it escapes the `.codemirror-body` corner
-  // clip, which means it needs explicit viewport coordinates rather than the
-  // `top: 100%` an in-flow absolute box would get for free.
-  @tracked _embedPopoverStyle = '';
-  _embedTriggerEl: HTMLElement | null = null;
-
   get _currentBfmRef(): BfmRefRange | undefined {
     return this._selectionInfo?.currentRef;
   }
 
-  // Pin the popover directly under the trigger, in viewport coordinates. The
-  // trigger is inside a sticky toolbar, so this is recomputed on scroll/resize
-  // (see `_trackEmbedPopover`) to keep the two glued together.
-  _positionEmbedPopover = () => {
-    let trigger = this._embedTriggerEl;
-    if (!trigger) return;
-    let r = trigger.getBoundingClientRect();
-    this._embedPopoverStyle = `position: fixed; top: ${r.bottom + 4}px; left: ${r.left}px;`;
+  // Close the Add-embed dropdown, then open the chooser. The dropdown lives in
+  // BoxelDropdown's wormhole (outside the toolbar's corner-clip box), so its
+  // positioning, viewport-edge flipping, and outside-click dismissal are the
+  // dropdown's concern, not ours.
+  _chooseEmbed = (close: () => void, defaultTab: 'card' | 'file') => {
+    close();
+    this._openEmbedChooser(defaultTab);
   };
-
-  _toggleEmbedPopover = (e: Event) => {
-    if (this._embedPopoverOpen) {
-      this._embedPopoverOpen = false;
-      return;
-    }
-    this._embedTriggerEl = e.currentTarget as HTMLElement;
-    this._positionEmbedPopover();
-    this._embedPopoverOpen = true;
-  };
-
-  // While the popover is open, keep it pinned under the trigger as the outer
-  // panel scrolls or the window resizes. Installed on the popover element, so
-  // its lifecycle tracks the popover's presence in the DOM.
-  _trackEmbedPopover = modifier(() => {
-    this._positionEmbedPopover();
-    let reposition = () => this._positionEmbedPopover();
-    window.addEventListener('scroll', reposition, {
-      capture: true,
-      passive: true,
-    });
-    window.addEventListener('resize', reposition);
-    return () => {
-      window.removeEventListener('scroll', reposition, { capture: true });
-      window.removeEventListener('resize', reposition);
-    };
-  });
 
   _openEmbedChooser = async (defaultTab: 'card' | 'file') => {
-    this._embedPopoverOpen = false;
     let chooser = this.cardContext?.markdownEmbedChooser;
     if (!chooser) {
       // No chooser provided (e.g. card running outside the host) — warn and
@@ -1009,50 +972,52 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
                 </:content>
               </Tooltip>
             {{else}}
-              <div class='toolbar-embed-trigger'>
-                <Tooltip @placement='top' data-test-toolbar-tooltip='add-embed'>
-                  <:trigger>
-                    <button
-                      class='toolbar-btn
-                        {{if this._embedPopoverOpen "toolbar-btn--active"}}'
-                      data-test-toolbar='add-embed'
-                      type='button'
-                      aria-label='Add embed'
-                      aria-expanded={{if this._embedPopoverOpen 'true' 'false'}}
-                      {{on 'mousedown' this._preventFocusLoss}}
-                      {{on 'click' this._toggleEmbedPopover}}
-                    ><PlusIcon width='16' height='16' /></button>
-                  </:trigger>
-                  <:content>
-                    <span class='toolbar-tooltip'>
-                      <span class='toolbar-tooltip__label'>Add embed</span>
-                    </span>
-                  </:content>
-                </Tooltip>
-                {{#if this._embedPopoverOpen}}
+              {{! The dropdown renders in the shared wormhole (BoxelDropdown),
+                  so it escapes the toolbar's corner-clip box and handles its
+                  own viewport-edge flipping and outside-click dismissal. }}
+              <BoxelDropdown @contentClass='toolbar-embed-popover'>
+                <:trigger as |bindings|>
+                  <Tooltip
+                    @placement='top'
+                    data-test-toolbar-tooltip='add-embed'
+                  >
+                    <:trigger>
+                      <button
+                        class='toolbar-btn'
+                        data-test-toolbar='add-embed'
+                        type='button'
+                        aria-label='Add embed'
+                        {{on 'mousedown' this._preventFocusLoss}}
+                        {{bindings}}
+                      ><PlusIcon width='16' height='16' /></button>
+                    </:trigger>
+                    <:content>
+                      <span class='toolbar-tooltip'>
+                        <span class='toolbar-tooltip__label'>Add embed</span>
+                      </span>
+                    </:content>
+                  </Tooltip>
+                </:trigger>
+                <:content as |dd|>
                   <div
-                    class='toolbar-embed-popover'
-                    style={{htmlSafe this._embedPopoverStyle}}
+                    class='toolbar-embed-menu'
                     data-test-toolbar-embed-popover
-                    {{this._trackEmbedPopover}}
                   >
                     <button
                       type='button'
                       class='toolbar-embed-popover__item'
                       data-test-toolbar-embed='card'
-                      {{on 'mousedown' this._preventFocusLoss}}
-                      {{on 'click' (fn this._openEmbedChooser 'card')}}
+                      {{on 'click' (fn this._chooseEmbed dd.close 'card')}}
                     >Add a card</button>
                     <button
                       type='button'
                       class='toolbar-embed-popover__item'
                       data-test-toolbar-embed='file'
-                      {{on 'mousedown' this._preventFocusLoss}}
-                      {{on 'click' (fn this._openEmbedChooser 'file')}}
+                      {{on 'click' (fn this._chooseEmbed dd.close 'file')}}
                     >Add a file</button>
                   </div>
-                {{/if}}
-              </div>
+                </:content>
+              </BoxelDropdown>
             {{/if}}
             <span class='toolbar-divider'></span>
 
@@ -1223,10 +1188,10 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
            The toolbar's two menus must escape this clip: when the toolbar
            docks at the bottom there is zero room below it inside the box, so a
            menu rendered here would be swallowed while its trigger still looks
-           normal. Both are kept out — the mode selector wormholes out of place
-           (BoxelSelect without `renderInPlace`) and the Add-embed popover is
-           `position: fixed` (its containing block is the viewport, so this
-           clip can't reach it). */
+           normal. Both escape by rendering in the shared dropdown wormhole at
+           the app root, outside this subtree entirely — the mode selector via
+           BoxelSelect (without `renderInPlace`) and the Add-embed menu via
+           BoxelDropdown. */
         .codemirror-body {
           display: flex;
           flex-direction: column;
@@ -1508,7 +1473,11 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           background: color-mix(in oklab, currentColor 8%, transparent);
         }
 
-        .toolbar-btn--active:not(:disabled) {
+        /* `[aria-expanded='true']` covers the Add-embed trigger while its
+           dropdown is open — BoxelDropdown's trigger modifier sets that
+           attribute, so the button reads active without a tracked flag. */
+        .toolbar-btn--active:not(:disabled),
+        .toolbar-btn[aria-expanded='true']:not(:disabled) {
           background: var(--primary, var(--boxel-200));
           color: var(--primary-foreground, var(--boxel-700));
         }
@@ -1549,41 +1518,6 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           margin: 0 var(--boxel-sp-5xs);
         }
 
-        .toolbar-embed-trigger {
-          position: relative;
-          display: inline-flex;
-        }
-        /* `position: fixed` (coordinates set inline from the trigger's rect)
-           so the popover escapes the `.codemirror-body` corner clip — its
-           containing block is the viewport, which that clip can't reach. An
-           absolute popover here would be swallowed once the toolbar docks at
-           the bottom, where there is no room left below it inside the clip. */
-        .toolbar-embed-popover {
-          position: fixed;
-          min-width: 140px;
-          background: var(--boxel-light);
-          color: var(--boxel-dark);
-          border: 1px solid var(--boxel-300);
-          border-radius: var(--boxel-border-radius);
-          box-shadow: var(--boxel-deep-box-shadow);
-          padding: var(--boxel-sp-4xs) 0;
-          z-index: 5;
-          display: flex;
-          flex-direction: column;
-        }
-        .toolbar-embed-popover__item {
-          appearance: none;
-          background: none;
-          border: none;
-          text-align: left;
-          padding: var(--boxel-sp-4xs) var(--boxel-sp-xs);
-          font: var(--boxel-font-sm);
-          cursor: pointer;
-        }
-        .toolbar-embed-popover__item:hover {
-          background: var(--boxel-100);
-        }
-
         .codemirror-editor-loading {
           min-height: 120px;
           display: flex;
@@ -1592,6 +1526,35 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           color: var(--boxel-400, #999);
           font-style: italic;
         }
+      }
+    </style>
+    {{! The Add-embed dropdown content renders in the shared wormhole, outside
+        this component's scoped-style reach — so its rules are matched by the
+        @contentClass here rather than scoped. BoxelDropdown provides the
+        surface (background, border, radius, shadow); these add the menu's
+        padding and the item layout. }}
+    {{! template-lint-disable require-scoped-style }}
+    <style>
+      .boxel-dropdown__content.toolbar-embed-popover {
+        min-width: 140px;
+        padding: var(--boxel-sp-4xs) 0;
+      }
+      .toolbar-embed-popover .toolbar-embed-menu {
+        display: flex;
+        flex-direction: column;
+      }
+      .toolbar-embed-popover .toolbar-embed-popover__item {
+        appearance: none;
+        background: none;
+        border: none;
+        text-align: left;
+        padding: var(--boxel-sp-4xs) var(--boxel-sp-xs);
+        font: var(--boxel-font-sm);
+        color: inherit;
+        cursor: pointer;
+      }
+      .toolbar-embed-popover .toolbar-embed-popover__item:hover {
+        background: color-mix(in oklab, currentColor 8%, transparent);
       }
     </style>
   </template>

--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -938,129 +938,132 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         data-test-codemirror-editor
         ...attributes
       >
-        {{! ── Docked toolbar ── }}
-        {{! template-lint-disable no-pointer-down-event-binding }}
-        <div
-          class='codemirror-toolbar'
-          data-overlay-clip-header
-          data-test-markdown-toolbar
-        >
-          {{yield to='leadingControls'}}
-          {{#if (has-block 'leadingControls')}}
-            <span class='toolbar-divider'></span>
-          {{/if}}
+        <div class='codemirror-body' data-test-codemirror-body>
+          {{! ── Docked toolbar ── }}
+          {{! template-lint-disable no-pointer-down-event-binding }}
+          <div
+            class='codemirror-toolbar'
+            data-overlay-clip-header
+            data-test-markdown-toolbar
+          >
+            {{yield to='leadingControls'}}
+            {{#if (has-block 'leadingControls')}}
+              <span class='toolbar-divider'></span>
+            {{/if}}
 
-          {{#if this._currentBfmRef}}
-            <Tooltip @placement='top' data-test-toolbar-tooltip='edit-embed'>
-              <:trigger>
-                <button
-                  class='toolbar-btn'
-                  data-test-toolbar='edit-embed'
-                  type='button'
-                  aria-label='Edit embed'
-                  {{on 'mousedown' this._preventFocusLoss}}
-                  {{on 'click' this._openEditEmbed}}
-                ><PencilIcon width='16' height='16' /></button>
-              </:trigger>
-              <:content>
-                <span class='toolbar-tooltip'>
-                  <span class='toolbar-tooltip__label'>Edit embed</span>
-                </span>
-              </:content>
-            </Tooltip>
-          {{else}}
-            <div class='toolbar-embed-trigger'>
-              <Tooltip @placement='top' data-test-toolbar-tooltip='add-embed'>
+            {{#if this._currentBfmRef}}
+              <Tooltip @placement='top' data-test-toolbar-tooltip='edit-embed'>
                 <:trigger>
                   <button
-                    class='toolbar-btn
-                      {{if this._embedPopoverOpen "toolbar-btn--active"}}'
-                    data-test-toolbar='add-embed'
+                    class='toolbar-btn'
+                    data-test-toolbar='edit-embed'
                     type='button'
-                    aria-label='Add embed'
-                    aria-expanded={{if this._embedPopoverOpen 'true' 'false'}}
+                    aria-label='Edit embed'
                     {{on 'mousedown' this._preventFocusLoss}}
-                    {{on 'click' this._toggleEmbedPopover}}
-                  ><PlusIcon width='16' height='16' /></button>
+                    {{on 'click' this._openEditEmbed}}
+                  ><PencilIcon width='16' height='16' /></button>
                 </:trigger>
                 <:content>
                   <span class='toolbar-tooltip'>
-                    <span class='toolbar-tooltip__label'>Add embed</span>
+                    <span class='toolbar-tooltip__label'>Edit embed</span>
                   </span>
                 </:content>
               </Tooltip>
-              {{#if this._embedPopoverOpen}}
-                <div
-                  class='toolbar-embed-popover'
-                  data-test-toolbar-embed-popover
-                >
-                  <button
-                    type='button'
-                    class='toolbar-embed-popover__item'
-                    data-test-toolbar-embed='card'
-                    {{on 'mousedown' this._preventFocusLoss}}
-                    {{on 'click' (fn this._openEmbedChooser 'card')}}
-                  >Add a card</button>
-                  <button
-                    type='button'
-                    class='toolbar-embed-popover__item'
-                    data-test-toolbar-embed='file'
-                    {{on 'mousedown' this._preventFocusLoss}}
-                    {{on 'click' (fn this._openEmbedChooser 'file')}}
-                  >Add a file</button>
-                </div>
-              {{/if}}
-            </div>
-          {{/if}}
-          <span class='toolbar-divider'></span>
-
-          {{#each this.toolbarButtons as |btn|}}
-            {{#if btn.divider}}
-              <span class='toolbar-divider'></span>
             {{else}}
-              {{! Every item gets a styled tooltip — the label, plus a shortcut
+              <div class='toolbar-embed-trigger'>
+                <Tooltip @placement='top' data-test-toolbar-tooltip='add-embed'>
+                  <:trigger>
+                    <button
+                      class='toolbar-btn
+                        {{if this._embedPopoverOpen "toolbar-btn--active"}}'
+                      data-test-toolbar='add-embed'
+                      type='button'
+                      aria-label='Add embed'
+                      aria-expanded={{if this._embedPopoverOpen 'true' 'false'}}
+                      {{on 'mousedown' this._preventFocusLoss}}
+                      {{on 'click' this._toggleEmbedPopover}}
+                    ><PlusIcon width='16' height='16' /></button>
+                  </:trigger>
+                  <:content>
+                    <span class='toolbar-tooltip'>
+                      <span class='toolbar-tooltip__label'>Add embed</span>
+                    </span>
+                  </:content>
+                </Tooltip>
+                {{#if this._embedPopoverOpen}}
+                  <div
+                    class='toolbar-embed-popover'
+                    data-test-toolbar-embed-popover
+                  >
+                    <button
+                      type='button'
+                      class='toolbar-embed-popover__item'
+                      data-test-toolbar-embed='card'
+                      {{on 'mousedown' this._preventFocusLoss}}
+                      {{on 'click' (fn this._openEmbedChooser 'card')}}
+                    >Add a card</button>
+                    <button
+                      type='button'
+                      class='toolbar-embed-popover__item'
+                      data-test-toolbar-embed='file'
+                      {{on 'mousedown' this._preventFocusLoss}}
+                      {{on 'click' (fn this._openEmbedChooser 'file')}}
+                    >Add a file</button>
+                  </div>
+                {{/if}}
+              </div>
+            {{/if}}
+            <span class='toolbar-divider'></span>
+
+            {{#each this.toolbarButtons as |btn|}}
+              {{#if btn.divider}}
+                <span class='toolbar-divider'></span>
+              {{else}}
+                {{! Every item gets a styled tooltip — the label, plus a shortcut
                   key badge when the item has a CodeMirror binding. The tooltip
                   is suppressed while the control is disabled. }}
-              <Tooltip
-                @placement='top'
-                @disabled={{btn.disabled}}
-                data-test-toolbar-tooltip={{btn.testId}}
-              >
-                <:trigger>
-                  <button
-                    class='toolbar-btn {{if btn.active "toolbar-btn--active"}}'
-                    data-test-toolbar={{btn.testId}}
-                    type='button'
-                    aria-label={{btn.label}}
-                    aria-pressed={{btn.ariaPressed}}
-                    disabled={{btn.disabled}}
-                    {{on 'mousedown' this._preventFocusLoss}}
-                    {{on 'click' btn.action}}
-                  >{{#let btn.icon as |Icon|}}<Icon
-                        width='16'
-                        height='16'
-                      />{{/let}}</button>
-                </:trigger>
-                <:content>
-                  <span class='toolbar-tooltip'>
-                    <span class='toolbar-tooltip__label'>{{btn.label}}</span>
-                    {{#if btn.shortcut}}
-                      <kbd class='shortcut-key'>{{btn.shortcut}}</kbd>
-                    {{/if}}
-                  </span>
-                </:content>
-              </Tooltip>
-            {{/if}}
-          {{/each}}
-        </div>
+                <Tooltip
+                  @placement='top'
+                  @disabled={{btn.disabled}}
+                  data-test-toolbar-tooltip={{btn.testId}}
+                >
+                  <:trigger>
+                    <button
+                      class='toolbar-btn
+                        {{if btn.active "toolbar-btn--active"}}'
+                      data-test-toolbar={{btn.testId}}
+                      type='button'
+                      aria-label={{btn.label}}
+                      aria-pressed={{btn.ariaPressed}}
+                      disabled={{btn.disabled}}
+                      {{on 'mousedown' this._preventFocusLoss}}
+                      {{on 'click' btn.action}}
+                    >{{#let btn.icon as |Icon|}}<Icon
+                          width='16'
+                          height='16'
+                        />{{/let}}</button>
+                  </:trigger>
+                  <:content>
+                    <span class='toolbar-tooltip'>
+                      <span class='toolbar-tooltip__label'>{{btn.label}}</span>
+                      {{#if btn.shortcut}}
+                        <kbd class='shortcut-key'>{{btn.shortcut}}</kbd>
+                      {{/if}}
+                    </span>
+                  </:content>
+                </Tooltip>
+              {{/if}}
+            {{/each}}
+          </div>
 
-        {{! template-lint-disable no-invalid-interactive }}
-        <div
-          class='codemirror-mount'
-          data-test-codemirror-mount
-          {{on 'mousedown' this._focusEditorOnPointerDown}}
-          {{this.mountEditor this.cm @content @onUpdate this.livePreview}}
-        ></div>
+          {{! template-lint-disable no-invalid-interactive }}
+          <div
+            class='codemirror-mount'
+            data-test-codemirror-mount
+            {{on 'mousedown' this._focusEditorOnPointerDown}}
+            {{this.mountEditor this.cm @content @onUpdate this.livePreview}}
+          ></div>
+        </div>
       </div>
 
       {{#if this.livePreview}}
@@ -1167,6 +1170,23 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
         .codemirror-editor:focus-within {
           border-color: var(--ring, var(--boxel-highlight));
           outline-color: var(--ring, var(--boxel-highlight));
+        }
+
+        /* Wraps the sticky toolbar + editor mount so the editor's rounded
+           corners clip the toolbar's square bottom corners when it docks at
+           the bottom on scroll. `overflow: clip` (not `hidden`) does this
+           without establishing a scroll container, so the toolbar keeps
+           sticking to the outer scroll panel. The card-search / format-picker
+           popovers stay outside this wrapper so they can still overflow the
+           editor box. The radius is inset by the 1px border so it hugs the
+           border's inner curve. */
+        .codemirror-body {
+          display: flex;
+          flex-direction: column;
+          flex: 1;
+          min-height: 0;
+          border-radius: calc(var(--boxel-border-radius) - 1px);
+          overflow: clip;
         }
 
         /* Fill the field so clicking anywhere below the text focuses it. */

--- a/packages/base/codemirror-editor.gts
+++ b/packages/base/codemirror-editor.gts
@@ -1232,7 +1232,10 @@ export default class CodeMirrorEditor extends GlimmerComponent<CodeMirrorEditorS
           flex-direction: column;
           flex: 1;
           min-height: 0;
-          border-radius: calc(var(--boxel-border-radius) - 1px);
+          /* Inset by the 1px border; clamped at 0 so a card that themes
+             `--boxel-border-radius` below 1px doesn't drive the calc negative
+             (which would invalidate the declaration). */
+          border-radius: max(0px, calc(var(--boxel-border-radius) - 1px));
           overflow: clip;
         }
 

--- a/packages/base/components/markdown-editor-mode-select.gts
+++ b/packages/base/components/markdown-editor-mode-select.gts
@@ -50,7 +50,11 @@ export default class MarkdownEditorModeSelect extends GlimmerComponent<Signature
       @selected={{this.selectedOption}}
       @onChange={{this.handleChange}}
       @searchEnabled={{false}}
-      @renderInPlace={{true}}
+      {{! Render the menu in the shared dropdown wormhole, not in place: this
+          toolbar sits inside CodeMirrorEditor's `overflow: clip` corner-clip
+          box, and an in-place menu would be swallowed by it once the toolbar
+          docks at the bottom on scroll. BoxelSelect syncs the card theme onto
+          the wormhole on open, so the themed look is preserved. }}
       @matchTriggerWidth={{false}}
       @dropdownClass='markdown-editor-mode-select-dropdown'
       data-test-markdown-mode-select={{this.selectedOption.value}}

--- a/packages/base/components/markdown-editor-mode-select.gts
+++ b/packages/base/components/markdown-editor-mode-select.gts
@@ -100,10 +100,12 @@ export default class MarkdownEditorModeSelect extends GlimmerComponent<Signature
     {{! template-lint-disable require-scoped-style }}
     <style>
       .boxel-select__dropdown.markdown-editor-mode-select-dropdown {
-        /* Match the trigger: 2px less rounded than the default menu radius. */
-        --boxel-form-control-border-radius: calc(
-          var(--boxel-border-radius) - 2px
-        );
+        /* The trigger's 2px-tighter radius arrives on the wormhole via
+           BoxelSelect's `--boxel-form-control-border-radius` sync (resolved
+           against the card theme at the trigger). Don't re-declare it here:
+           this element sits at the app root, where the card's
+           `--boxel-border-radius` doesn't apply, so a local `calc()` would
+           override the synced value with the app default under a theme. */
         width: max-content;
         min-width: 7rem;
       }

--- a/packages/host/tests/integration/components/rich-markdown-field-test.gts
+++ b/packages/host/tests/integration/components/rich-markdown-field-test.gts
@@ -133,6 +133,55 @@ module('Integration | RichMarkdownField', function (hooks) {
     );
   });
 
+  test('docked toolbar and editor mount share an overflow-clipping wrapper so the sticky toolbar corners conform to the rounded editor outline', async function (assert) {
+    class TestCard extends CardDef {
+      @field body = contains(RichMarkdownField);
+      static edit = class Edit extends Component<typeof this> {
+        <template><@fields.body /></template>
+      };
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'test-card.gts': { TestCard },
+      },
+    });
+
+    let card = new TestCard({
+      body: new RichMarkdownField({ content: 'Edit me' }),
+    });
+    let root = await renderCard(loader, card, 'edit');
+    await waitFor('[data-test-codemirror-body]', { timeout: 5000 });
+
+    let wrapper = root.querySelector(
+      '[data-test-codemirror-body]',
+    ) as HTMLElement;
+    assert.dom(wrapper).exists('the clipping wrapper is rendered');
+    // The wrapper must clip (not scroll) so the toolbar's square bottom
+    // corners follow the editor's rounded outline when it docks at the
+    // bottom, while keeping position: sticky resolving to the outer panel.
+    assert.strictEqual(
+      getComputedStyle(wrapper).overflowY,
+      'clip',
+      'the wrapper clips its overflow',
+    );
+    // Toolbar + mount live inside the wrapper (so they get clipped)…
+    assert
+      .dom('[data-test-markdown-toolbar]', wrapper)
+      .exists('the toolbar is inside the clipping wrapper');
+    assert
+      .dom('[data-test-codemirror-mount]', wrapper)
+      .exists('the editor mount is inside the clipping wrapper');
+    // …but the wrapper is nested directly in the bordered/rounded editor.
+    assert
+      .dom(wrapper.parentElement)
+      .hasClass(
+        'codemirror-editor',
+        'the wrapper is a direct child of the editor container',
+      );
+  });
+
   test('renders with null content without error', async function (assert) {
     class TestCard extends CardDef {
       @field body = contains(RichMarkdownField);

--- a/packages/host/tests/integration/components/rich-markdown-field-test.gts
+++ b/packages/host/tests/integration/components/rich-markdown-field-test.gts
@@ -182,6 +182,41 @@ module('Integration | RichMarkdownField', function (hooks) {
       );
   });
 
+  test('the Add-embed dropdown opens inside the clipping wrapper (it is intentionally clipped to the editor)', async function (assert) {
+    class TestCard extends CardDef {
+      @field body = contains(RichMarkdownField);
+      static edit = class Edit extends Component<typeof this> {
+        <template><@fields.body /></template>
+      };
+    }
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'test-card.gts': { TestCard },
+      },
+    });
+
+    let card = new TestCard({
+      body: new RichMarkdownField({ content: 'Edit me' }),
+    });
+    let root = await renderCard(loader, card, 'edit');
+    await waitFor('[data-test-codemirror-body]', { timeout: 5000 });
+
+    let wrapper = root.querySelector(
+      '[data-test-codemirror-body]',
+    ) as HTMLElement;
+
+    // No embed is referenced yet, so the toolbar shows the Add-embed trigger.
+    await click('[data-test-toolbar="add-embed"]');
+    assert
+      .dom('[data-test-toolbar-embed-popover]', wrapper)
+      .exists(
+        'the Add-embed dropdown lives inside the clipping wrapper — it drops ' +
+          'into the tall editor mount so the clip is invisible in practice',
+      );
+  });
+
   test('renders with null content without error', async function (assert) {
     class TestCard extends CardDef {
       @field body = contains(RichMarkdownField);

--- a/packages/host/tests/integration/components/rich-markdown-field-test.gts
+++ b/packages/host/tests/integration/components/rich-markdown-field-test.gts
@@ -161,10 +161,19 @@ module('Integration | RichMarkdownField', function (hooks) {
     // The wrapper must clip (not scroll) so the toolbar's square bottom
     // corners follow the editor's rounded outline when it docks at the
     // bottom, while keeping position: sticky resolving to the outer panel.
+    // Assert both axes (the shorthand): the source sets `overflow: clip`, and
+    // it is both axes that must stay out of scroll-container territory — a
+    // stray `overflow-x: visible` would let the corners spill horizontally.
+    let overflow = getComputedStyle(wrapper);
     assert.strictEqual(
-      getComputedStyle(wrapper).overflowY,
+      overflow.overflowX,
       'clip',
-      'the wrapper clips its overflow',
+      'the wrapper clips overflow-x',
+    );
+    assert.strictEqual(
+      overflow.overflowY,
+      'clip',
+      'the wrapper clips overflow-y',
     );
     // The clip only rounds the toolbar's corners because the wrapper itself
     // carries a radius — delete that declaration and the clip has nothing to
@@ -215,19 +224,21 @@ module('Integration | RichMarkdownField', function (hooks) {
 
     // No embed is referenced yet, so the toolbar shows the Add-embed trigger.
     await click('[data-test-toolbar="add-embed"]');
-    let popover = root.querySelector(
-      '[data-test-toolbar-embed-popover]',
-    ) as HTMLElement;
-    assert.dom(popover).exists('the Add-embed dropdown opens');
-    // The dropdown must not be swallowed by `.codemirror-body`'s `overflow:
-    // clip`: when the toolbar docks at the bottom there is zero room below it
-    // inside that box. `position: fixed` roots the dropdown to the viewport —
-    // a box the clip cannot reach — so it stays visible and clickable. An
-    // absolute dropdown (its containing block inside the clip) would be cut off.
-    assert.strictEqual(
-      getComputedStyle(popover).position,
-      'fixed',
-      'the Add-embed dropdown is fixed-positioned so the corner clip cannot swallow it',
+    // BoxelDropdown renders the menu in the shared dropdown wormhole at the app
+    // root, so it lives outside `.codemirror-body` entirely — the `overflow:
+    // clip` corner box is not in its ancestor chain and cannot swallow it when
+    // the toolbar docks at the bottom, where an in-box menu would have zero
+    // room below it. Query the whole document since the menu is not under the
+    // card's render root.
+    let popover = document.querySelector('[data-test-toolbar-embed-popover]');
+    let clipBox = root.querySelector('[data-test-codemirror-body]');
+    assert.ok(popover, 'the Add-embed dropdown opens');
+    assert
+      .dom('[data-test-codemirror-body]')
+      .exists('the corner-clip box is present');
+    assert.notOk(
+      clipBox?.contains(popover),
+      'the Add-embed menu renders outside the corner-clip box, so the clip cannot swallow it',
     );
   });
 

--- a/packages/host/tests/integration/components/rich-markdown-field-test.gts
+++ b/packages/host/tests/integration/components/rich-markdown-field-test.gts
@@ -166,6 +166,16 @@ module('Integration | RichMarkdownField', function (hooks) {
       'clip',
       'the wrapper clips its overflow',
     );
+    // The clip only rounds the toolbar's corners because the wrapper itself
+    // carries a radius — delete that declaration and the clip has nothing to
+    // round off, and the reported square-corner bug returns with every other
+    // assertion here still green. Assert it is non-zero rather than a specific
+    // px, since the radius token is themeable per card.
+    assert.notStrictEqual(
+      getComputedStyle(wrapper).borderRadius,
+      '0px',
+      'the wrapper is rounded, so the clip has corners to round off',
+    );
     // Toolbar + mount live inside the wrapper (so they get clipped)…
     assert
       .dom('[data-test-markdown-toolbar]', wrapper)
@@ -182,7 +192,7 @@ module('Integration | RichMarkdownField', function (hooks) {
       );
   });
 
-  test('the Add-embed dropdown opens inside the clipping wrapper (it is intentionally clipped to the editor)', async function (assert) {
+  test('the Add-embed dropdown escapes the corner-clipping wrapper so it stays visible when the toolbar docks at the bottom', async function (assert) {
     class TestCard extends CardDef {
       @field body = contains(RichMarkdownField);
       static edit = class Edit extends Component<typeof this> {
@@ -203,18 +213,22 @@ module('Integration | RichMarkdownField', function (hooks) {
     let root = await renderCard(loader, card, 'edit');
     await waitFor('[data-test-codemirror-body]', { timeout: 5000 });
 
-    let wrapper = root.querySelector(
-      '[data-test-codemirror-body]',
-    ) as HTMLElement;
-
     // No embed is referenced yet, so the toolbar shows the Add-embed trigger.
     await click('[data-test-toolbar="add-embed"]');
-    assert
-      .dom('[data-test-toolbar-embed-popover]', wrapper)
-      .exists(
-        'the Add-embed dropdown lives inside the clipping wrapper — it drops ' +
-          'into the tall editor mount so the clip is invisible in practice',
-      );
+    let popover = root.querySelector(
+      '[data-test-toolbar-embed-popover]',
+    ) as HTMLElement;
+    assert.dom(popover).exists('the Add-embed dropdown opens');
+    // The dropdown must not be swallowed by `.codemirror-body`'s `overflow:
+    // clip`: when the toolbar docks at the bottom there is zero room below it
+    // inside that box. `position: fixed` roots the dropdown to the viewport —
+    // a box the clip cannot reach — so it stays visible and clickable. An
+    // absolute dropdown (its containing block inside the clip) would be cut off.
+    assert.strictEqual(
+      getComputedStyle(popover).position,
+      'fixed',
+      'the Add-embed dropdown is fixed-positioned so the corner clip cannot swallow it',
+    );
   });
 
   test('renders with null content without error', async function (assert) {


### PR DESCRIPTION
## Problem

In the rich-markdown editor, the docked toolbar (the grey "Compose / B / I / H1…" bar) is a `position: sticky` element with **square bottom corners**, living inside the editor's rounded, bordered container (`.codemirror-editor`). The container had a `border-radius` but did **not** clip its children.

When you scroll to the very bottom of the body field, the sticky toolbar is pushed down to the container's bottom edge, and its square grey corners spill past the rounded outline — the reported bug (CS-11700):

> when user scrolls to the very end of the body field the grey UI bar's bottom corners do not conform to the rounded corners of the body field boundary outline.

## Fix

Wrap the toolbar + editor mount in a new `.codemirror-body` element with `border-radius` + `overflow: clip`, so the editor's rounded corners clip the toolbar's square bottom corners when it docks at the bottom.

Key detail: **`overflow: clip`, not `hidden`**. `hidden` would establish a scroll container, which would break the toolbar's `position: sticky` (it would stick to the never-scrolling editor instead of the outer edit panel). `clip` rounds/clips the corners without creating a scroll container, preserving the sticky behavior.

The card-search (`/`) and format-picker popovers are intentionally left **outside** the clip wrapper (still positioned relative to `.codemirror-editor`), so they can continue to overflow the editor box — e.g. when you open the card search on the last line.

## Tests

- Adds an integration test in `rich-markdown-field-test.gts` asserting the toolbar + mount share the `overflow: clip` wrapper and that the wrapper nests directly in the bordered editor container.
- Existing `codemirror-embed-toolbar` / `markdown-embed-chooser` tests continue to guard the popovers.

## Verification note

Statically verified (template-lint, eslint, prettier). The corner-pixel conformance is best confirmed visually in the running app; happy to attach before/after screenshots — flag if you'd like them before this comes out of draft.

Linear: [CS-11700](https://linear.app/cardstack/issue/CS-11700)

## Screenshot

### Before


<img width="589" height="42" alt="Screenshot 2026-08-13 at 18 54 43" src="https://github.com/user-attachments/assets/e96cb9dc-de52-47d1-b438-be6cb6c1bb56" />

## After

<img width="581" height="37" alt="Screenshot 2026-08-13 at 18 54 53" src="https://github.com/user-attachments/assets/ae339ada-7104-49de-a9be-28181308740b" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)