### PR TITLE
Expose @cardstack/bxl to card code as a platform module, with real-card test suites

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2655,6 +2655,23 @@ export class BaseDef {
     }
   }
 }
+
+// @cardstack/bxl materializes `{ as: FieldDef }` expression results through
+// the platform's field metadata, but it cannot import this module — it also
+// loads outside a realm (node tooling, the realm-server), where `https:`
+// module specifiers are rejected at load time. The bridge is instance-carried:
+// every instance of this card-api copy inherits its own `getFields` under a
+// cross-realm symbol, so BXL always materializes through the copy that
+// created the instance it was handed — correct even when several loader
+// universes are alive at once. `globalThis.__cardstackGetFields` (registered
+// in field-support) remains as the fallback for consumers without an
+// instance in hand.
+Object.defineProperty(BaseDef.prototype, Symbol.for('cardstack.getFields'), {
+  value: getFields,
+  enumerable: false,
+  configurable: true,
+});
+
 export class Component<
   CardT extends BaseDefConstructor,
 > extends GlimmerComponent<SignatureFor<CardT>> {}

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -442,6 +442,16 @@ export function getFields(
   return fields;
 }
 
+// The ambient half of the @cardstack/bxl field-metadata bridge. BXL cannot
+// import this module — it also loads outside a realm (node tooling, the
+// realm-server), where `https:` module specifiers are rejected at load time —
+// so it reads `getFields` out-of-band. The primary bridge is instance-carried
+// (card-api stamps `getFields` onto `BaseDef.prototype` under a cross-realm
+// symbol, so each value resolves the card-api copy that created it); this
+// well-known global is the fallback for consumers that hold no instance,
+// e.g. BXL's mutation adapter resolving field metadata at plan time.
+(globalThis as any).__cardstackGetFields = getFields;
+
 function computeFields(
   cardInstanceOrClass: BaseDef | typeof BaseDef,
   opts?: { usedLinksToFieldsOnly?: boolean; includeComputeds?: boolean },

--- a/packages/bxl/CHANGELOG.md
+++ b/packages/bxl/CHANGELOG.md
@@ -10,7 +10,24 @@ versions may change syntax behavior until `1.0.0`.
 
 ## [Unreleased]
 
+### Added
+
+- **`loadAllFormulaExtensions()`.** Loads every lazy formula chunk
+  (statistical, Bessel, engineering/financial, validation) and folds it into
+  `DEFAULT_BUILTIN_LIBRARIES`, so hosts can serve the module to authors whose
+  synchronous `expression()` computeVia expressions may name any function.
+  A failed chunk load no longer sticks: the memo clears on rejection so the
+  next call retries.
+
 ### Changed
+
+- **`{ as: FieldDef }` field-metadata resolution is instance-carried
+  first.** Materialization reads the value's own bridge — card-api stamps
+  its `getFields` onto `BaseDef.prototype` under
+  `Symbol.for('cardstack.getFields')` — and only then falls back to the
+  ambient `globalThis.__cardstackGetFields`, which logs a one-time warning
+  when consulted for a card-api-marked value. This keeps materialization
+  correct when several card-api copies are loaded at once.
 
 - **The package ships raw erasable TypeScript from `src/`.** The `exports`
   map points at `.ts` sources; there is no build step and no `dist/`.

--- a/packages/bxl/src/bxl/bridge/lazy-formulas.ts
+++ b/packages/bxl/src/bxl/bridge/lazy-formulas.ts
@@ -65,43 +65,80 @@ function astUsesFilterSet(node: unknown, filters: Set<string>): boolean {
   return false;
 }
 
+// A rejected chunk load must not stick: the memo caches the in-flight
+// promise so concurrent callers share one import, but a failure (e.g. a
+// transient network error fetching the chunk) clears the slot so the next
+// caller retries — otherwise every later evaluation would re-reject off
+// the cached rejection and the family could never load.
+function memoizedLoad(
+  read: () => Promise<void> | undefined,
+  write: (value: Promise<void> | undefined) => void,
+  load: () => Promise<void>,
+): Promise<void> {
+  let pending = read();
+  if (!pending) {
+    pending = load().catch((error) => {
+      write(undefined);
+      throw error;
+    });
+    write(pending);
+  }
+  return pending;
+}
+
 async function ensureStatisticalLoaded() {
-  formulaStatisticalLoad ??= import('../registry/formula-statistical.ts').then(
-    ({ formulaStatisticalLibrary }) => {
-      registerBuiltinLibrary('formula-statistical', formulaStatisticalLibrary);
-    },
+  await memoizedLoad(
+    () => formulaStatisticalLoad,
+    (value) => (formulaStatisticalLoad = value),
+    () =>
+      import('../registry/formula-statistical.ts').then(
+        ({ formulaStatisticalLibrary }) => {
+          registerBuiltinLibrary(
+            'formula-statistical',
+            formulaStatisticalLibrary,
+          );
+        },
+      ),
   );
-  await formulaStatisticalLoad;
 }
 
 async function ensureBesselLoaded() {
-  formulaBesselLoad ??= import('../registry/formula-bessel.ts').then(
-    ({ formulaBesselLibrary }) => {
-      registerBuiltinLibrary('formula-bessel', formulaBesselLibrary);
-    },
+  await memoizedLoad(
+    () => formulaBesselLoad,
+    (value) => (formulaBesselLoad = value),
+    () =>
+      import('../registry/formula-bessel.ts').then(
+        ({ formulaBesselLibrary }) => {
+          registerBuiltinLibrary('formula-bessel', formulaBesselLibrary);
+        },
+      ),
   );
-  await formulaBesselLoad;
 }
 
 async function ensureExtrasBundleLoaded() {
-  formulaExtrasBundleLoad ??=
-    import('../registry/bundles/formula-extras.ts').then(
-      ({ formulaExtrasBundle }) => {
-        for (const [name, library] of Object.entries(formulaExtrasBundle)) {
-          registerBuiltinLibrary(name as BuiltinLibraryName, library);
-        }
-      },
-    );
-  await formulaExtrasBundleLoad;
+  await memoizedLoad(
+    () => formulaExtrasBundleLoad,
+    (value) => (formulaExtrasBundleLoad = value),
+    () =>
+      import('../registry/bundles/formula-extras.ts').then(
+        ({ formulaExtrasBundle }) => {
+          for (const [name, library] of Object.entries(formulaExtrasBundle)) {
+            registerBuiltinLibrary(name as BuiltinLibraryName, library);
+          }
+        },
+      ),
+  );
 }
 
 async function ensureValidationLoaded() {
-  validationLoad ??= import('../registry/validation.ts').then(
-    ({ validationLibrary }) => {
-      registerBuiltinLibrary('validation', validationLibrary);
-    },
+  await memoizedLoad(
+    () => validationLoad,
+    (value) => (validationLoad = value),
+    () =>
+      import('../registry/validation.ts').then(({ validationLibrary }) => {
+        registerBuiltinLibrary('validation', validationLibrary);
+      }),
   );
-  await validationLoad;
 }
 
 const EXTRAS_LIBRARIES: BuiltinLibraryName[] = [

--- a/packages/bxl/src/bxl/bridge/lazy-formulas.ts
+++ b/packages/bxl/src/bxl/bridge/lazy-formulas.ts
@@ -235,3 +235,39 @@ export async function resolveLazyBuiltinLibrariesForExpressions(
   );
   return next;
 }
+
+const ALL_LAZY_LIBRARIES: BuiltinLibraryName[] = [
+  'formula-statistical',
+  'formula-bessel',
+  ...EXTRAS_LIBRARIES,
+  'validation',
+];
+
+/**
+ * Load every lazy formula extension and fold it into
+ * `DEFAULT_BUILTIN_LIBRARIES`, so synchronous evaluation — most
+ * importantly the `bxl()` / `expression()` computeVia factory, which
+ * cannot await a chunk mid-compute — sees the full formula surface.
+ *
+ * A host that hands BXL to card authors (where any expression may name
+ * any Excel function) awaits this once before serving the module. The
+ * chunks still arrive via dynamic import, so bundlers keep them out of
+ * the initial graph; embeds that skip this call keep the smaller core
+ * and the per-program auto-loading of the async APIs.
+ *
+ * Idempotent and safe to call concurrently — each chunk load is
+ * memoized module-wide.
+ */
+export async function loadAllFormulaExtensions(): Promise<void> {
+  await Promise.all([
+    ensureStatisticalLoaded(),
+    ensureBesselLoaded(),
+    ensureExtrasBundleLoaded(),
+    ensureValidationLoaded(),
+  ]);
+  for (const name of ALL_LAZY_LIBRARIES) {
+    if (!DEFAULT_BUILTIN_LIBRARIES.includes(name)) {
+      DEFAULT_BUILTIN_LIBRARIES.push(name);
+    }
+  }
+}

--- a/packages/bxl/src/bxl/bridge/validation-native.ts
+++ b/packages/bxl/src/bxl/bridge/validation-native.ts
@@ -1,3 +1,7 @@
+// See formulajs/bessel.ts for why this is a reference rather than a
+// tsconfig include or an import.
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../../types/validator.d.ts" />
 import validatorPackage from 'validator';
 import type { BareNativeFilter } from '../../jqtools/evaluate/filters/lib/nativeFilter.ts';
 import { wrapBareNativeFilters } from '../../jqtools/evaluate/filters/lib/nativeFilter.ts';

--- a/packages/bxl/src/formulajs/bessel.ts
+++ b/packages/bxl/src/formulajs/bessel.ts
@@ -1,3 +1,10 @@
+// The reference (rather than tsconfig `include`) carries the ambient module
+// declaration into any project that reaches this file through its import
+// graph — the host type-checks these sources under its own tsconfig, which
+// never sees this package's include list. An `import` cannot do this job:
+// it would be executed at node runtime, where a .d.ts is not loadable.
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../types/bessel.d.ts" />
 import besselImport from 'bessel';
 
 import { parseExcelNumber } from './common.ts';

--- a/packages/bxl/src/formulajs/statistical.ts
+++ b/packages/bxl/src/formulajs/statistical.ts
@@ -1,3 +1,7 @@
+// See bessel.ts for why this is a reference rather than a tsconfig include
+// or an import.
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../types/jstat.d.ts" />
 import jStatImport from 'jstat';
 
 import {

--- a/packages/bxl/src/index.ts
+++ b/packages/bxl/src/index.ts
@@ -266,6 +266,8 @@ export type {
   BxlSafeResult,
 };
 
+export { loadAllFormulaExtensions } from './bxl/bridge/lazy-formulas.ts';
+
 export {
   BXL_AUTHORIZATION_IR_SCHEMA,
   BXL_AUTHORIZATION_SCHEMA,
@@ -825,13 +827,22 @@ function makeTagged(
   };
 }
 
-// Boxel's `getFields` arrives out-of-band: a host registers it on
-// `globalThis` and `safeFieldMap` picks it up from there. This module does not
-// import `https://cardstack.com/base/card-api` itself, because Node's ESM
-// loader rejects `https:` schemes at module-load time — a static import would
-// break every consumer that runs outside a realm (tests, tooling, the
-// realm-server). Absent a registration, the field-aware paths degrade rather
-// than throw.
+// Boxel's `getFields` arrives out-of-band. This module does not import
+// `https://cardstack.com/base/card-api` itself, because Node's ESM loader
+// rejects `https:` schemes at module-load time — a static import would break
+// every consumer that runs outside a realm (tests, tooling, the
+// realm-server). Two bridges exist, tried in order:
+//
+// 1. Instance-carried: card-api stamps its own `getFields` onto
+//    `BaseDef.prototype` under the cross-realm symbol below, so a value made
+//    by any card-api copy resolves the copy that created it — correct even
+//    when several loader universes are alive at once.
+// 2. `globalThis.__cardstackGetFields`: the ambient fallback a host
+//    registers, for values that carry no stamp. Falling back here is
+//    ambiguous — the ambient copy may not be the one that created the
+//    value — so it logs a one-time warning.
+//
+// Absent both, the field-aware paths degrade rather than throw.
 type GetFieldsFn = (
   instance: unknown,
   options?: { includeComputeds?: boolean },
@@ -845,15 +856,37 @@ type GetFieldsFn = (
 >;
 
 const GET_FIELDS_KEY = '__cardstackGetFields' as const;
+const GET_FIELDS_BRIDGE = Symbol.for('cardstack.getFields');
 
 function getCardstackGetFields(): GetFieldsFn | undefined {
   const fn = (globalThis as unknown as Record<string, unknown>)[GET_FIELDS_KEY];
   return typeof fn === 'function' ? (fn as GetFieldsFn) : undefined;
 }
 
+let warnedAmbientGetFields = false;
+
+function getFieldsFor(value: object): GetFieldsFn | undefined {
+  const fn = (value as Record<symbol, unknown>)[GET_FIELDS_BRIDGE];
+  if (typeof fn === 'function') {
+    return fn as GetFieldsFn;
+  }
+  const ambient = getCardstackGetFields();
+  if (ambient && !warnedAmbientGetFields) {
+    warnedAmbientGetFields = true;
+    console.warn(
+      '@cardstack/bxl: resolving field metadata through the ambient ' +
+        '__cardstackGetFields global because the value carries no ' +
+        'instance-scoped bridge. When more than one card-api copy is ' +
+        'loaded, the ambient copy may not be the one that created this ' +
+        'value, and field-aware materialization can silently degrade.',
+    );
+  }
+  return ambient;
+}
+
 function safeFieldMap(value: unknown) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const getFields = getCardstackGetFields();
+  const getFields = getFieldsFor(value);
   if (!getFields) return null;
   try {
     return getFields(value, { includeComputeds: false });
@@ -863,7 +896,6 @@ function safeFieldMap(value: unknown) {
 }
 
 function fieldMapForShape(shape: new () => unknown, instance: unknown) {
-  if (!getCardstackGetFields()) return null;
   for (const target of [instance, shape]) {
     const map = safeFieldMap(target);
     if (map && Object.keys(map).length > 0) return map;

--- a/packages/bxl/src/index.ts
+++ b/packages/bxl/src/index.ts
@@ -838,9 +838,12 @@ function makeTagged(
 //    by any card-api copy resolves the copy that created it — correct even
 //    when several loader universes are alive at once.
 // 2. `globalThis.__cardstackGetFields`: the ambient fallback a host
-//    registers, for values that carry no stamp. Falling back here is
+//    registers, for values that carry no stamp. For a card-api instance
+//    (marked with the registered `isBaseInstance` symbol) this fallback is
 //    ambiguous — the ambient copy may not be the one that created the
-//    value — so it logs a one-time warning.
+//    value — so that case logs a one-time warning. Plain classes resolve
+//    through the ambient copy silently: their field map is empty either
+//    way, and the plain-copy fallback is their intended behavior.
 //
 // Absent both, the field-aware paths degrade rather than throw.
 type GetFieldsFn = (
@@ -857,6 +860,7 @@ type GetFieldsFn = (
 
 const GET_FIELDS_KEY = '__cardstackGetFields' as const;
 const GET_FIELDS_BRIDGE = Symbol.for('cardstack.getFields');
+const IS_BASE_INSTANCE = Symbol.for('isBaseInstance');
 
 function getCardstackGetFields(): GetFieldsFn | undefined {
   const fn = (globalThis as unknown as Record<string, unknown>)[GET_FIELDS_KEY];
@@ -871,14 +875,15 @@ function getFieldsFor(value: object): GetFieldsFn | undefined {
     return fn as GetFieldsFn;
   }
   const ambient = getCardstackGetFields();
-  if (ambient && !warnedAmbientGetFields) {
+  if (ambient && !warnedAmbientGetFields && IS_BASE_INSTANCE in value) {
     warnedAmbientGetFields = true;
     console.warn(
-      '@cardstack/bxl: resolving field metadata through the ambient ' +
-        '__cardstackGetFields global because the value carries no ' +
-        'instance-scoped bridge. When more than one card-api copy is ' +
-        'loaded, the ambient copy may not be the one that created this ' +
-        'value, and field-aware materialization can silently degrade.',
+      '@cardstack/bxl: resolving field metadata for a card-api value ' +
+        'through the ambient __cardstackGetFields global because the ' +
+        'value carries no instance-scoped bridge. When more than one ' +
+        'card-api copy is loaded, the ambient copy may not be the one ' +
+        'that created this value, and field-aware materialization can ' +
+        'silently degrade.',
     );
   }
   return ambient;

--- a/packages/bxl/tests/boxel/materialize.ts
+++ b/packages/bxl/tests/boxel/materialize.ts
@@ -164,6 +164,85 @@ check(
   },
 );
 
+// ---------------------------------------------------------------- Instance-carried getFields bridge
+
+// Boxel's card-api stamps its own `getFields` onto its base prototype under
+// this cross-realm symbol, so materialization resolves the card-api copy
+// that created the shape it was handed — the ambient global is only the
+// fallback. These cases pin that resolution order with a stand-in card-api:
+// a base class carrying the stamp and a field map that declares one nested
+// `contains` shape.
+
+const GET_FIELDS_BRIDGE = Symbol.for('cardstack.getFields');
+const GET_FIELDS_GLOBAL = '__cardstackGetFields';
+
+class StampedBase {}
+class StampedBadge extends StampedBase {
+  text: string = '';
+}
+class StampedPanel extends StampedBase {
+  label: string = '';
+  badge: StampedBadge | null = null;
+}
+const stampedFieldMaps = new Map<unknown, Record<string, unknown>>([
+  [
+    StampedPanel,
+    {
+      label: { fieldType: 'contains' },
+      badge: { fieldType: 'contains', card: StampedBadge },
+    },
+  ],
+  [StampedBadge, { text: { fieldType: 'contains' } }],
+]);
+Object.defineProperty(StampedBase.prototype, GET_FIELDS_BRIDGE, {
+  value: (instance: object) => stampedFieldMaps.get(instance.constructor) ?? {},
+  enumerable: false,
+});
+
+function withGlobalGetFields(fn: unknown, body: () => void) {
+  const holder = globalThis as Record<string, unknown>;
+  const prior = holder[GET_FIELDS_GLOBAL];
+  holder[GET_FIELDS_GLOBAL] = fn;
+  try {
+    body();
+  } finally {
+    if (prior === undefined) {
+      delete holder[GET_FIELDS_GLOBAL];
+    } else {
+      holder[GET_FIELDS_GLOBAL] = prior;
+    }
+  }
+}
+
+check('the instance-carried stamp wins over the ambient global', () => {
+  withGlobalGetFields(
+    () => {
+      throw new Error('the ambient global must not be consulted');
+    },
+    () => {
+      const compute = expression(jq`{ label: "ok", badge: { text: "hot" } }`, {
+        as: StampedPanel,
+      });
+      const out = compute.call(baselinePatient) as StampedPanel;
+      ok(out instanceof StampedPanel);
+      ok(out.badge instanceof StampedBadge);
+      strictEqual(out.badge!.text, 'hot');
+    },
+  );
+});
+
+check('the stamp alone materializes nested contains shapes', () => {
+  // No global registered at all: the stamped prototype is sufficient.
+  const compute = expression(jq`{ label: "solo", badge: { text: "warm" } }`, {
+    as: StampedPanel,
+  });
+  const out = compute.call(baselinePatient) as StampedPanel;
+  ok(out instanceof StampedPanel);
+  strictEqual(out.label, 'solo');
+  ok(out.badge instanceof StampedBadge);
+  strictEqual(out.badge!.text, 'warm');
+});
+
 console.log(
   `BXL Boxel materialize-as fallback: ${pass}/${pass + fail} cases passed`,
 );

--- a/packages/bxl/tests/smoke/load-all-formula-extensions.ts
+++ b/packages/bxl/tests/smoke/load-all-formula-extensions.ts
@@ -36,9 +36,11 @@ approx(expression(fx`ERF(0.5)`).call({}), 0.5205); // engineering
 approx(expression(fx`ABS(PMT(0.005, 12, -12000))`).call({}), 1032.7972, 1e-3); // financial
 approx(expression(fx`BESSELI(1.5, 1)`).call({}), 0.981666); // bessel
 approx(expression(fx`NORM.S.DIST(1, TRUE)`).call({}), 0.841345); // statistical
+strictEqual(expression(fx`isEmail("team@example.com")`).call({}), true); // validation
+strictEqual(expression(fx`isEmail("not-an-email")`).call({}), false);
 
 // Idempotent: a second call must not double-register or throw.
 await loadAllFormulaExtensions();
 strictEqual(expression(fx`ERF(0.5)`).call({}) === null, false);
 
-console.log('BXL load-all formula extensions: 6/6 cases passed');
+console.log('BXL load-all formula extensions: 8/8 cases passed');

--- a/packages/bxl/tests/smoke/load-all-formula-extensions.ts
+++ b/packages/bxl/tests/smoke/load-all-formula-extensions.ts
@@ -1,0 +1,44 @@
+// `loadAllFormulaExtensions` is the hook a host calls before serving this
+// module to card authors: it loads every lazy formula chunk and folds it
+// into DEFAULT_BUILTIN_LIBRARIES, so the synchronous `expression()` factory
+// — which cannot await a chunk mid-compute — sees the full formula surface.
+
+import { ok, strictEqual } from 'node:assert';
+import {
+  evaluateBxl,
+  expression,
+  fx,
+  loadAllFormulaExtensions,
+} from '../../src/index.ts';
+
+// Synchronous evaluation does not auto-load lazy chunks; a lazy-family
+// function is unavailable until the host opts in.
+let syncFailed = false;
+try {
+  evaluateBxl('ERF(0.5)', {});
+} catch (error) {
+  syncFailed = String((error as Error).message).includes('ERF/1');
+}
+ok(syncFailed, 'lazy engineering family is absent before the load');
+
+await loadAllFormulaExtensions();
+
+function approx(actual: unknown, expected: number, tolerance = 1e-4) {
+  ok(typeof actual === 'number', `expected number, got ${typeof actual}`);
+  ok(
+    Math.abs(actual - expected) <= tolerance,
+    `expected ${expected} +/- ${tolerance}, got ${actual}`,
+  );
+}
+
+// One function from each lazy family, all through the synchronous factory.
+approx(expression(fx`ERF(0.5)`).call({}), 0.5205); // engineering
+approx(expression(fx`ABS(PMT(0.005, 12, -12000))`).call({}), 1032.7972, 1e-3); // financial
+approx(expression(fx`BESSELI(1.5, 1)`).call({}), 0.981666); // bessel
+approx(expression(fx`NORM.S.DIST(1, TRUE)`).call({}), 0.841345); // statistical
+
+// Idempotent: a second call must not double-register or throw.
+await loadAllFormulaExtensions();
+strictEqual(expression(fx`ERF(0.5)`).call({}) === null, false);
+
+console.log('BXL load-all formula extensions: 6/6 cases passed');

--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -186,6 +186,22 @@ export function shimExternals(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule('rsvp', rsvp);
   virtualNetwork.shimModule('super-fast-md5', superFastMD5);
   virtualNetwork.shimModule('tracked-built-ins', tracked);
+  // BXL is card-facing: any card module may `import { expression, fx, jq }
+  // from '@cardstack/bxl'` for computeVia formulas. The async shim keeps the
+  // library out of the host's initial chunk graph — it loads only when a card
+  // that uses it loads. `expression()` evaluates synchronously (computeVia
+  // cannot await), so the resolver folds in the lazy formula families
+  // (statistical, Bessel, engineering/financial, validation) before serving
+  // the module: cards get the full Excel-function surface without knowing
+  // about chunking.
+  virtualNetwork.shimAsyncModule({
+    id: '@cardstack/bxl',
+    resolve: async () => {
+      let bxl = await import('@cardstack/bxl');
+      await bxl.loadAllFormulaExtensions();
+      return bxl;
+    },
+  });
   virtualNetwork.shimAsyncModule({
     id: 'ethers',
     resolve: () => import('ethers'),

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -41,6 +41,7 @@
     "@cardstack/base": "workspace:*",
     "@cardstack/boxel-icons": "workspace:*",
     "@cardstack/boxel-ui": "workspace:*",
+    "@cardstack/bxl": "workspace:*",
     "@cardstack/eslint-plugin-boxel": "workspace:*",
     "@cardstack/eslint-plugin-host": "workspace:*",
     "@cardstack/local-types": "workspace:*",

--- a/packages/host/tests/helpers/cards/bxl-tracking.ts
+++ b/packages/host/tests/helpers/cards/bxl-tracking.ts
@@ -200,6 +200,36 @@ export const bxlTrackingCardSource = `
 // has neither amounts nor a policy: its own computeds fall back to Excel
 // blank semantics, its two-hop path yields null, and it stays out of both
 // policies' query-backed claims.
+//
+// Query-backed inverses (Policy.claims) resolve against the LIVE index at
+// visit time, while linksTo traversal loads targets from source. On a
+// realm's first-ever index pass the live index is empty, so POL-100's
+// claims aggregations bake in their empty-set values; the next visit of
+// the policy converges them. Tests that assert converged aggregations
+// re-write POL-100 with `bxlTrackingPol100Renewal` to trigger that visit.
+function pol100Doc(policyStatus: string) {
+  return {
+    data: {
+      type: 'card',
+      attributes: {
+        policyId: 'POL-100',
+        policyStatus,
+        annualPremium: 12000,
+        financingApr: 0.06,
+      },
+      relationships: {
+        customer: { links: { self: '../Customer/acme' } },
+        underwriter: { links: { self: '../Underwriter/dana' } },
+      },
+      meta: {
+        adoptsFrom: { module: '../tracking', name: 'Policy' },
+      },
+    },
+  };
+}
+
+export const bxlTrackingPol100Renewal = pol100Doc('Renewed');
+
 export const bxlTrackingRealmContents: Record<string, unknown> = {
   'tracking.gts': bxlTrackingCardSource,
   'Customer/acme.json': {
@@ -217,38 +247,6 @@ export const bxlTrackingRealmContents: Record<string, unknown> = {
       attributes: { name: 'Dana Reeve' },
       meta: {
         adoptsFrom: { module: '../tracking', name: 'Underwriter' },
-      },
-    },
-  },
-  'Policy/pol-100.json': {
-    data: {
-      type: 'card',
-      attributes: {
-        policyId: 'POL-100',
-        policyStatus: 'Active',
-        annualPremium: 12000,
-        financingApr: 0.06,
-      },
-      relationships: {
-        customer: { links: { self: '../Customer/acme' } },
-        underwriter: { links: { self: '../Underwriter/dana' } },
-      },
-      meta: {
-        adoptsFrom: { module: '../tracking', name: 'Policy' },
-      },
-    },
-  },
-  'Policy/pol-200.json': {
-    data: {
-      type: 'card',
-      attributes: {
-        policyId: 'POL-200',
-        policyStatus: 'Lapsed',
-        annualPremium: 8000,
-        financingApr: 0.05,
-      },
-      meta: {
-        adoptsFrom: { module: '../tracking', name: 'Policy' },
       },
     },
   },
@@ -295,6 +293,21 @@ export const bxlTrackingRealmContents: Record<string, unknown> = {
       },
       meta: {
         adoptsFrom: { module: '../tracking', name: 'Claim' },
+      },
+    },
+  },
+  'Policy/pol-100.json': pol100Doc('Active'),
+  'Policy/pol-200.json': {
+    data: {
+      type: 'card',
+      attributes: {
+        policyId: 'POL-200',
+        policyStatus: 'Lapsed',
+        annualPremium: 8000,
+        financingApr: 0.05,
+      },
+      meta: {
+        adoptsFrom: { module: '../tracking', name: 'Policy' },
       },
     },
   },

--- a/packages/host/tests/helpers/cards/bxl-tracking.ts
+++ b/packages/host/tests/helpers/cards/bxl-tracking.ts
@@ -1,0 +1,301 @@
+// An insurance-tracking domain — Policy linking to Customer / Underwriter
+// with a query-backed inverse of Claim.policy — whose computed fields are all
+// BXL expressions imported from the platform-provided '@cardstack/bxl'
+// module. Modeled on the crafted real-world BXL realms, simplified to the
+// smallest shape that still exercises every factory dimension:
+//
+//   - all three syntax modes (plain string / fx / jq) driving computeVia
+//   - linked-card traversal: linksTo, query-backed linksToMany, dotted
+//     paths across two links
+//   - null tolerance: fx arithmetic coerces blank numerics to 0 (Excel
+//     blank semantics); jq paths propagate null
+//   - Excel error sentinels (#N/A, #DIV/0!, …) surfaced as null
+//   - `{ as: FieldDef }` materialization, single instance and arrays
+//   - a lazy-chunk formula family (PMT is in the financial chunk), proving
+//     chunk loading works wherever the realm indexes or renders
+//
+// The realm contents are position-independent: instance links are relative
+// and the query filter derives its type ref from import.meta.url, so any
+// test can mount them at any realm URL. Intended to be shared by the BXL
+// host suites (function coverage, indexing, cycle regression) rather than
+// each test growing its own variant.
+
+export const bxlTrackingCardSource = `
+  import {
+    CardDef,
+    Component,
+    FieldDef,
+    field,
+    contains,
+    containsMany,
+    linksTo,
+    linksToMany,
+  } from '@cardstack/base/card-api';
+  import NumberField from '@cardstack/base/number';
+  import StringField from '@cardstack/base/string';
+  import { expression, fx, jq } from '@cardstack/bxl';
+
+  // Exercises { as: FieldDef }: BXL expressions yield plain JSON; the
+  // factory rebuilds that output as instances of this class through the
+  // platform's field metadata, so the serializer can identify the value
+  // instead of failing on an anonymous object.
+  export class RiskBandField extends FieldDef {
+    static displayName = 'RiskBand';
+    @field label = contains(StringField);
+    @field score = contains(NumberField);
+    @field flags = containsMany(StringField);
+  }
+
+  export class Customer extends CardDef {
+    static displayName = 'Customer';
+    @field name = contains(StringField);
+    @field tier = contains(StringField);
+    @field displayLabel = contains(StringField, {
+      computeVia: expression(fx\`Name & " (" & Tier & ")"\`),
+    });
+  }
+
+  export class Underwriter extends CardDef {
+    static displayName = 'Underwriter';
+    @field name = contains(StringField);
+  }
+
+  export class Claim extends CardDef {
+    static displayName = 'Claim';
+    @field claimId = contains(StringField);
+    @field claimStatus = contains(StringField);
+    @field paidAmount = contains(NumberField);
+    @field reserveAmount = contains(NumberField);
+    @field policy = linksTo(() => Policy);
+    // Blank amounts read as 0 under Excel blank semantics, so a claim with
+    // no amounts computes 0 here rather than crashing or going null.
+    @field incurredAmount = contains(NumberField, {
+      computeVia: expression(
+        fx\`ROUND((PaidAmount + ReserveAmount) * 100) / 100\`,
+      ),
+    });
+    @field severityBand = contains(StringField, {
+      computeVia: expression(
+        fx\`IFS(IncurredAmount < 1000, "Minor", IncurredAmount < 10000, "Standard", TRUE, "Large")\`,
+      ),
+    });
+    // A dotted path across two links: claim → policy → customer. A missing
+    // hop anywhere along the path yields null.
+    @field customerName = contains(StringField, {
+      computeVia: expression(jq\`.policy.customer.name\`),
+    });
+  }
+
+  export class Policy extends CardDef {
+    static displayName = 'Policy';
+    @field policyId = contains(StringField);
+    @field policyStatus = contains(StringField);
+    @field annualPremium = contains(NumberField);
+    @field financingApr = contains(NumberField);
+    @field customer = linksTo(() => Customer);
+    @field underwriter = linksTo(() => Underwriter);
+    // Query-backed inverse: every Claim whose policy link targets this
+    // card. Seed data only sets Claim.policy; this side is derived.
+    @field claims = linksToMany(() => Claim, {
+      query: {
+        filter: {
+          every: [
+            {
+              type: {
+                module: \`\${new URL('./tracking', import.meta.url).href}\`,
+                name: 'Claim',
+              },
+            },
+            { eq: { 'policy.id': '$this.id' } },
+          ],
+        },
+        sort: [{ by: 'claimId', direction: 'asc' }],
+      },
+    });
+
+    // The three syntax modes side by side. Plain strings compile as
+    // readable BXL (jq-style paths and Excel functions both allowed)…
+    @field premiumWithTax = contains(NumberField, {
+      computeVia: expression('ROUND(.annualPremium * 1.07 * 100) / 100'),
+    });
+    // …fx marks Excel-like readable syntax with PascalCase field labels —
+    // PMT also comes from the lazily-loaded financial formula family…
+    @field monthlyPayment = contains(NumberField, {
+      computeVia: expression(
+        fx\`ROUND(ABS(PMT(FinancingApr / 12, 12, -AnnualPremium)) * 100) / 100\`,
+      ),
+    });
+    // …and jq is handed straight to the jq engine, no readable-syntax
+    // compilation.
+    @field paidClaimsTotal = contains(NumberField, {
+      computeVia: expression(jq\`[.claims[] | .paidAmount] | add // 0\`),
+    });
+    @field reservedClaimsTotal = contains(NumberField, {
+      computeVia: expression(jq\`[.claims[] | .reserveAmount] | add // 0\`),
+    });
+    @field openClaimCount = contains(NumberField, {
+      computeVia: expression(
+        jq\`[.claims[] | select(.claimStatus == "Open")] | length\`,
+      ),
+    });
+    @field customerName = contains(StringField, {
+      computeVia: expression(jq\`.customer.name\`),
+    });
+    @field underwriterName = contains(StringField, {
+      computeVia: expression(jq\`.underwriter.name\`),
+    });
+    // Chained computeds: a BXL expression reading other BXL computeds.
+    @field lossRatio = contains(NumberField, {
+      computeVia: expression(
+        fx\`ROUND((PaidClaimsTotal + ReservedClaimsTotal) / AnnualPremium * 10000) / 10000\`,
+      ),
+    });
+
+    // Excel error sentinels are first-class spreadsheet values; the factory
+    // catches them at the boundary and surfaces null so the indexer never
+    // tears down the card.
+    @field notApplicable = contains(NumberField, {
+      computeVia: expression(fx\`NA()\`),
+    });
+    @field divByZero = contains(NumberField, {
+      computeVia: expression(fx\`AnnualPremium / 0\`),
+    });
+
+    // { as: FieldDef } — single instance…
+    @field riskBand = contains(RiskBandField, {
+      computeVia: expression(
+        jq\`{
+          label: (if .lossRatio >= 0.8 then "High" else "Low" end),
+          score: ((.lossRatio * 100) | round),
+          flags: (if .lossRatio >= 0.8 then ["review"] else [] end)
+        }\`,
+        { as: RiskBandField },
+      ),
+    });
+    // …and arrays: one materialized instance per element.
+    @field claimBands = containsMany(RiskBandField, {
+      computeVia: expression(
+        jq\`[.claims[] | { label: .severityBand, score: .paidAmount }]\`,
+        { as: RiskBandField },
+      ),
+    });
+
+    static embedded = class Embedded extends Component<typeof Policy> {
+      <template>
+        <div data-test-policy={{@model.policyId}}>
+          <span data-test-premium-with-tax>{{@model.premiumWithTax}}</span>
+          <span data-test-monthly-payment>{{@model.monthlyPayment}}</span>
+          <span data-test-paid-claims-total>{{@model.paidClaimsTotal}}</span>
+          <span data-test-customer-name>{{@model.customerName}}</span>
+          <span data-test-loss-ratio>{{@model.lossRatio}}</span>
+          <span data-test-risk-band>{{@model.riskBand.label}}</span>
+        </div>
+      </template>
+    };
+  }
+`;
+
+// Fixture data. POL-100 is fully linked with two claims; POL-200 has no
+// links and no claims, so it exercises every null-tolerance path. CLM-3
+// has neither amounts nor a policy: its own computeds fall back to Excel
+// blank semantics, its two-hop path yields null, and it stays out of both
+// policies' query-backed claims.
+export const bxlTrackingRealmContents: Record<string, unknown> = {
+  'tracking.gts': bxlTrackingCardSource,
+  'Customer/acme.json': {
+    data: {
+      type: 'card',
+      attributes: { name: 'Acme Freight', tier: 'Gold' },
+      meta: {
+        adoptsFrom: { module: '../tracking', name: 'Customer' },
+      },
+    },
+  },
+  'Underwriter/dana.json': {
+    data: {
+      type: 'card',
+      attributes: { name: 'Dana Reeve' },
+      meta: {
+        adoptsFrom: { module: '../tracking', name: 'Underwriter' },
+      },
+    },
+  },
+  'Policy/pol-100.json': {
+    data: {
+      type: 'card',
+      attributes: {
+        policyId: 'POL-100',
+        policyStatus: 'Active',
+        annualPremium: 12000,
+        financingApr: 0.06,
+      },
+      relationships: {
+        customer: { links: { self: '../Customer/acme' } },
+        underwriter: { links: { self: '../Underwriter/dana' } },
+      },
+      meta: {
+        adoptsFrom: { module: '../tracking', name: 'Policy' },
+      },
+    },
+  },
+  'Policy/pol-200.json': {
+    data: {
+      type: 'card',
+      attributes: {
+        policyId: 'POL-200',
+        policyStatus: 'Lapsed',
+        annualPremium: 8000,
+        financingApr: 0.05,
+      },
+      meta: {
+        adoptsFrom: { module: '../tracking', name: 'Policy' },
+      },
+    },
+  },
+  'Claim/clm-1.json': {
+    data: {
+      type: 'card',
+      attributes: {
+        claimId: 'CLM-1',
+        claimStatus: 'Open',
+        paidAmount: 3200.5,
+        reserveAmount: 1500,
+      },
+      relationships: {
+        policy: { links: { self: '../Policy/pol-100' } },
+      },
+      meta: {
+        adoptsFrom: { module: '../tracking', name: 'Claim' },
+      },
+    },
+  },
+  'Claim/clm-2.json': {
+    data: {
+      type: 'card',
+      attributes: {
+        claimId: 'CLM-2',
+        claimStatus: 'Closed',
+        paidAmount: 780.25,
+        reserveAmount: 0,
+      },
+      relationships: {
+        policy: { links: { self: '../Policy/pol-100' } },
+      },
+      meta: {
+        adoptsFrom: { module: '../tracking', name: 'Claim' },
+      },
+    },
+  },
+  'Claim/clm-3.json': {
+    data: {
+      type: 'card',
+      attributes: {
+        claimId: 'CLM-3',
+        claimStatus: 'Open',
+      },
+      meta: {
+        adoptsFrom: { module: '../tracking', name: 'Claim' },
+      },
+    },
+  },
+};

--- a/packages/host/tests/helpers/cards/bxl-tracking.ts
+++ b/packages/host/tests/helpers/cards/bxl-tracking.ts
@@ -230,7 +230,10 @@ function pol100Doc(policyStatus: string) {
 
 export const bxlTrackingPol100Renewal = pol100Doc('Renewed');
 
-export const bxlTrackingRealmContents: Record<string, unknown> = {
+export const bxlTrackingRealmContents: Record<
+  string,
+  string | Record<string, unknown>
+> = {
   'tracking.gts': bxlTrackingCardSource,
   'Customer/acme.json': {
     data: {

--- a/packages/host/tests/integration/bxl-expression-test.gts
+++ b/packages/host/tests/integration/bxl-expression-test.gts
@@ -1,0 +1,337 @@
+import { expression, fx, jq } from '@cardstack/bxl';
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type { Realm, IndexedInstance } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import {
+  testRealmURL,
+  setupCardLogs,
+  setupLocalIndexing,
+  setupIntegrationTestRealm,
+} from '../helpers';
+import {
+  CardDef,
+  FieldDef,
+  StringField,
+  NumberField,
+  contains,
+  containsMany,
+  field,
+  getFields,
+  setupBaseRealm,
+} from '../helpers/base-realm';
+import { bxlTrackingRealmContents } from '../helpers/cards/bxl-tracking';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupRenderingTest } from '../helpers/setup';
+
+// The core BXL-on-real-cards suite: the `expression()` factory driving
+// computeVia on actual CardDef instances through the real card-api — the
+// field metadata (`getFields`) that `{ as: FieldDef }` materialization
+// consults, the real link-loading machinery under jq path traversal, and the
+// real indexer generating search docs from BXL computeds. Plain-JSON inputs
+// are covered by the bxl package's own unit suite; everything here goes
+// through cards.
+//
+// The realm fixtures live in helpers/cards/bxl-tracking.ts and are shared
+// with the platform-module suite; the factory-level dimensions (metadata,
+// memoization, materialization shapes) use a purpose-built card class so
+// each assertion touches only its own dimension.
+module('Integration | bxl expressions on real cards', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  let loader: Loader;
+  let realm: Realm;
+
+  setupLocalIndexing(hooks, {
+    reuseIndexAcrossTests: 'bxlExpressionCore',
+  });
+  setupCardLogs(
+    hooks,
+    async () => await loader.import('@cardstack/base/card-api'),
+  );
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  hooks.beforeEach(async function () {
+    loader = getService('loader-service').loader;
+    ({ realm } = await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: bxlTrackingRealmContents,
+    }));
+  });
+
+  async function indexedSearchDoc(id: string) {
+    let entry = await realm.realmIndexQueryEngine.instance(new URL(id));
+    if (!entry || entry.type === 'instance-error') {
+      throw new Error(
+        `expected ${id} to index cleanly, got ${JSON.stringify(entry?.error?.errorDetail?.message)}`,
+      );
+    }
+    return (entry as IndexedInstance).searchDoc ?? {};
+  }
+
+  // ===========================================================================
+  // The three syntax modes
+  // ===========================================================================
+
+  test('all three syntax modes drive computeVia on real fields', async function (assert) {
+    let searchDoc = await indexedSearchDoc(`${testRealmURL}Policy/pol-100`);
+    assert.strictEqual(
+      searchDoc.premiumWithTax,
+      12840,
+      'plain string compiles as readable BXL',
+    );
+    assert.strictEqual(
+      searchDoc.monthlyPayment,
+      1032.8,
+      'fx compiles Excel-like readable syntax (PascalCase labels)',
+    );
+    assert.strictEqual(
+      searchDoc.paidClaimsTotal,
+      3980.75,
+      'jq is handed straight to the jq engine',
+    );
+  });
+
+  // ===========================================================================
+  // Linked-card traversal
+  // ===========================================================================
+
+  test('jq paths traverse linksTo targets', async function (assert) {
+    let searchDoc = await indexedSearchDoc(`${testRealmURL}Policy/pol-100`);
+    assert.strictEqual(searchDoc.customerName, 'Acme Freight');
+    assert.strictEqual(searchDoc.underwriterName, 'Dana Reeve');
+  });
+
+  test('a dotted path crosses two links', async function (assert) {
+    // claim → policy → customer
+    let searchDoc = await indexedSearchDoc(`${testRealmURL}Claim/clm-1`);
+    assert.strictEqual(searchDoc.customerName, 'Acme Freight');
+  });
+
+  test('aggregations run over the query-backed claims inverse', async function (assert) {
+    let searchDoc = await indexedSearchDoc(`${testRealmURL}Policy/pol-100`);
+    assert.strictEqual(searchDoc.paidClaimsTotal, 3980.75);
+    assert.strictEqual(searchDoc.reservedClaimsTotal, 1500);
+    assert.strictEqual(searchDoc.openClaimCount, 1);
+    assert.strictEqual(
+      searchDoc.lossRatio,
+      0.4567,
+      'chained computeds read other BXL computeds',
+    );
+  });
+
+  // ===========================================================================
+  // Null tolerance
+  // ===========================================================================
+
+  test('missing links propagate null through jq paths and the card still indexes', async function (assert) {
+    let searchDoc = await indexedSearchDoc(`${testRealmURL}Policy/pol-200`);
+    assert.strictEqual(searchDoc.customerName ?? null, null);
+    assert.strictEqual(searchDoc.underwriterName ?? null, null);
+    assert.strictEqual(
+      searchDoc.paidClaimsTotal,
+      0,
+      'aggregation over an empty claims inverse falls back to 0',
+    );
+    assert.strictEqual(searchDoc.lossRatio, 0);
+  });
+
+  test('blank numeric fields read as 0 under Excel blank semantics', async function (assert) {
+    // CLM-3 has no amounts and no policy link.
+    let searchDoc = await indexedSearchDoc(`${testRealmURL}Claim/clm-3`);
+    assert.strictEqual(searchDoc.incurredAmount, 0);
+    assert.strictEqual(searchDoc.severityBand, 'Minor');
+    assert.strictEqual(
+      searchDoc.customerName ?? null,
+      null,
+      'the two-hop path yields null when the first hop is missing',
+    );
+  });
+
+  // ===========================================================================
+  // Excel error sentinels
+  // ===========================================================================
+
+  test('Excel error sentinels surface as null, never a crashed compute', async function (assert) {
+    let searchDoc = await indexedSearchDoc(`${testRealmURL}Policy/pol-100`);
+    assert.strictEqual(searchDoc.notApplicable ?? null, null, '#N/A → null');
+    assert.strictEqual(searchDoc.divByZero ?? null, null, '#DIV/0! → null');
+  });
+
+  // ===========================================================================
+  // { as: FieldDef } materialization
+  // ===========================================================================
+
+  test('{ as: FieldDef } output lands in the search doc as structured field values', async function (assert) {
+    let searchDoc = await indexedSearchDoc(`${testRealmURL}Policy/pol-100`);
+    assert.strictEqual(searchDoc.riskBand?.label, 'Low');
+    assert.strictEqual(searchDoc.riskBand?.score, 46);
+    // Query sort orders the claims by claimId, so the bands are stable.
+    assert.deepEqual(
+      (searchDoc.claimBands ?? []).map((band: any) => band?.label),
+      ['Standard', 'Minor'],
+    );
+    assert.deepEqual(
+      (searchDoc.claimBands ?? []).map((band: any) => band?.score),
+      [3200.5, 780.25],
+    );
+  });
+
+  test('{ as: FieldDef } materializes real instances through getFields', async function (assert) {
+    class BadgeField extends FieldDef {
+      static displayName = 'Badge';
+      @field text = contains(StringField);
+    }
+    class PanelField extends FieldDef {
+      static displayName = 'Panel';
+      @field label = contains(StringField);
+      @field score = contains(NumberField);
+      @field flags = containsMany(StringField);
+      @field badge = contains(BadgeField);
+    }
+    class Quote extends CardDef {
+      static displayName = 'Quote';
+      @field subtotal = contains(NumberField);
+      @field statusPanel = contains(PanelField, {
+        computeVia: expression(
+          jq`{
+            label: (if .subtotal > 50 then "big" else "small" end),
+            score: .subtotal,
+            flags: ["checked"],
+            badge: { text: "hot" }
+          }`,
+          { as: PanelField },
+        ),
+      });
+      @field panels = containsMany(PanelField, {
+        computeVia: expression(
+          jq`[{ label: "a", score: 1 }, { label: "b", score: 2 }]`,
+          { as: PanelField },
+        ),
+      });
+    }
+
+    let quote = new Quote({ subtotal: 100 });
+    let panel = quote.statusPanel;
+    assert.true(
+      panel instanceof PanelField,
+      'the serializer-identifiable class, not an anonymous object',
+    );
+    assert.strictEqual(panel.label, 'big');
+    assert.strictEqual(panel.score, 100);
+    assert.deepEqual([...panel.flags], ['checked']);
+    // The nested shape is the discriminator between field-metadata
+    // materialization and BXL's plain-copy fallback (which it degrades to
+    // when no getFields bridge is registered): only the getFields walk
+    // rebuilds nested contains values as their own field-def instances.
+    assert.true(
+      panel.badge instanceof BadgeField,
+      'nested contains values materialize through the real getFields',
+    );
+    assert.strictEqual(panel.badge.text, 'hot');
+
+    let panels = quote.panels;
+    assert.strictEqual(panels.length, 2);
+    assert.true(
+      panels.every((entry: unknown) => entry instanceof PanelField),
+      'every array element is materialized',
+    );
+    assert.deepEqual(
+      panels.map((entry: PanelField & { label: string }) => entry.label),
+      ['a', 'b'],
+    );
+  });
+
+  // ===========================================================================
+  // Factory metadata + memoization
+  // ===========================================================================
+
+  test('factory metadata is reachable from the field definition', async function (assert) {
+    class Quote extends CardDef {
+      static displayName = 'Quote';
+      @field subtotal = contains(NumberField);
+      @field taxRate = contains(NumberField);
+      @field total = contains(NumberField, {
+        computeVia: expression('.subtotal * (1 + .taxRate)'),
+      });
+      @field rounded = contains(NumberField, {
+        computeVia: expression(fx`ROUND(Subtotal, 0)`),
+      });
+    }
+
+    let fields = getFields(Quote, { includeComputeds: true }) as Record<
+      string,
+      { computeVia?: unknown }
+    >;
+    let totalMeta = (fields.total.computeVia as any).bxl;
+    assert.strictEqual(totalMeta.source, '.subtotal * (1 + .taxRate)');
+    assert.deepEqual(totalMeta.deps.sort(), ['subtotal', 'taxRate']);
+    assert.strictEqual(totalMeta.memoize, 'microtask');
+
+    let roundedMeta = (fields.rounded.computeVia as any).bxl;
+    assert.strictEqual(roundedMeta.source, 'ROUND(Subtotal, 0)');
+    assert.strictEqual(
+      roundedMeta.compiledSource,
+      'ROUND(.subtotal; 0)',
+      'the compiled canonical jq is exposed alongside the source',
+    );
+  });
+
+  test('computeVia results are memoized per card instance within a microtask', async function (assert) {
+    class PanelField extends FieldDef {
+      static displayName = 'Panel';
+      @field label = contains(StringField);
+    }
+    class Quote extends CardDef {
+      static displayName = 'Quote';
+      @field subtotal = contains(NumberField);
+      @field panel = contains(PanelField, {
+        computeVia: expression(jq`{ label: "memoized" }`, { as: PanelField }),
+      });
+      @field freshPanel = contains(PanelField, {
+        computeVia: expression(jq`{ label: "fresh" }`, {
+          as: PanelField,
+          memoize: false,
+        }),
+      });
+    }
+
+    let quote = new Quote({ subtotal: 1 });
+    let fields = getFields(Quote, { includeComputeds: true }) as Record<
+      string,
+      { computeVia?: (this: object) => unknown }
+    >;
+    let computePanel = fields.panel.computeVia!;
+    let computeFresh = fields.freshPanel.computeVia!;
+
+    let first = computePanel.call(quote);
+    let second = computePanel.call(quote);
+    assert.strictEqual(
+      first,
+      second,
+      'synchronous re-reads within a microtask return the cached value',
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    let third = computePanel.call(quote);
+    assert.notStrictEqual(
+      third,
+      first,
+      'the cache expires with the microtask cycle',
+    );
+    assert.strictEqual((third as any).label, 'memoized');
+
+    assert.notStrictEqual(
+      computeFresh.call(quote),
+      computeFresh.call(quote),
+      'memoize: false disables the per-instance cache',
+    );
+  });
+});

--- a/packages/host/tests/integration/bxl-expression-test.gts
+++ b/packages/host/tests/integration/bxl-expression-test.gts
@@ -288,7 +288,7 @@ module('Integration | bxl expressions on real cards', function (hooks) {
     >;
     let totalMeta = (fields.total.computeVia as any).bxl;
     assert.strictEqual(totalMeta.source, '.subtotal * (1 + .taxRate)');
-    assert.deepEqual(totalMeta.deps.sort(), ['subtotal', 'taxRate']);
+    assert.deepEqual([...totalMeta.deps].sort(), ['subtotal', 'taxRate']);
     assert.strictEqual(totalMeta.memoize, 'microtask');
 
     let roundedMeta = (fields.rounded.computeVia as any).bxl;

--- a/packages/host/tests/integration/bxl-expression-test.gts
+++ b/packages/host/tests/integration/bxl-expression-test.gts
@@ -22,7 +22,10 @@ import {
   getFields,
   setupBaseRealm,
 } from '../helpers/base-realm';
-import { bxlTrackingRealmContents } from '../helpers/cards/bxl-tracking';
+import {
+  bxlTrackingPol100Renewal,
+  bxlTrackingRealmContents,
+} from '../helpers/cards/bxl-tracking';
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupRenderingTest } from '../helpers/setup';
 
@@ -44,9 +47,7 @@ module('Integration | bxl expressions on real cards', function (hooks) {
   let loader: Loader;
   let realm: Realm;
 
-  setupLocalIndexing(hooks, {
-    reuseIndexAcrossTests: 'bxlExpressionCore',
-  });
+  setupLocalIndexing(hooks);
   setupCardLogs(
     hooks,
     async () => await loader.import('@cardstack/base/card-api'),
@@ -64,6 +65,16 @@ module('Integration | bxl expressions on real cards', function (hooks) {
       mockMatrixUtils,
       contents: bxlTrackingRealmContents,
     }));
+    // Query-backed inverses resolve against the live index at visit time, and
+    // the from-scratch pass above ran with an empty live index — POL-100's
+    // claims aggregations baked in their empty-set values (that first-pass
+    // contract is pinned by the platform-module suite). Re-visiting the
+    // policy now that the claims are live converges them; the assertions in
+    // this suite are all against the converged state.
+    await realm.write(
+      'Policy/pol-100.json',
+      JSON.stringify(bxlTrackingPol100Renewal),
+    );
   });
 
   async function indexedSearchDoc(id: string) {

--- a/packages/host/tests/integration/bxl-expression-test.gts
+++ b/packages/host/tests/integration/bxl-expression-test.gts
@@ -81,7 +81,7 @@ module('Integration | bxl expressions on real cards', function (hooks) {
     let entry = await realm.realmIndexQueryEngine.instance(new URL(id));
     if (!entry || entry.type === 'instance-error') {
       throw new Error(
-        `expected ${id} to index cleanly, got ${JSON.stringify(entry?.error?.errorDetail?.message)}`,
+        `expected ${id} to index cleanly, got ${JSON.stringify(entry?.error)}`,
       );
     }
     return (entry as IndexedInstance).searchDoc ?? {};
@@ -144,8 +144,10 @@ module('Integration | bxl expressions on real cards', function (hooks) {
 
   test('missing links propagate null through jq paths and the card still indexes', async function (assert) {
     let searchDoc = await indexedSearchDoc(`${testRealmURL}Policy/pol-200`);
-    assert.strictEqual(searchDoc.customerName ?? null, null);
-    assert.strictEqual(searchDoc.underwriterName ?? null, null);
+    let customerName = searchDoc.customerName ?? null;
+    let underwriterName = searchDoc.underwriterName ?? null;
+    assert.strictEqual(customerName, null);
+    assert.strictEqual(underwriterName, null);
     assert.strictEqual(
       searchDoc.paidClaimsTotal,
       0,
@@ -159,8 +161,9 @@ module('Integration | bxl expressions on real cards', function (hooks) {
     let searchDoc = await indexedSearchDoc(`${testRealmURL}Claim/clm-3`);
     assert.strictEqual(searchDoc.incurredAmount, 0);
     assert.strictEqual(searchDoc.severityBand, 'Minor');
+    let customerName = searchDoc.customerName ?? null;
     assert.strictEqual(
-      searchDoc.customerName ?? null,
+      customerName,
       null,
       'the two-hop path yields null when the first hop is missing',
     );
@@ -172,8 +175,10 @@ module('Integration | bxl expressions on real cards', function (hooks) {
 
   test('Excel error sentinels surface as null, never a crashed compute', async function (assert) {
     let searchDoc = await indexedSearchDoc(`${testRealmURL}Policy/pol-100`);
-    assert.strictEqual(searchDoc.notApplicable ?? null, null, '#N/A → null');
-    assert.strictEqual(searchDoc.divByZero ?? null, null, '#DIV/0! → null');
+    let notApplicable = searchDoc.notApplicable ?? null;
+    let divByZero = searchDoc.divByZero ?? null;
+    assert.strictEqual(notApplicable, null, '#N/A → null');
+    assert.strictEqual(divByZero, null, '#DIV/0! → null');
   });
 
   // ===========================================================================

--- a/packages/host/tests/integration/bxl-platform-module-test.gts
+++ b/packages/host/tests/integration/bxl-platform-module-test.gts
@@ -15,7 +15,10 @@ import {
   setupIntegrationTestRealm,
 } from '../helpers';
 import { setupBaseRealm } from '../helpers/base-realm';
-import { bxlTrackingRealmContents } from '../helpers/cards/bxl-tracking';
+import {
+  bxlTrackingPol100Renewal,
+  bxlTrackingRealmContents,
+} from '../helpers/cards/bxl-tracking';
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { renderCard } from '../helpers/render-component';
 import { setupRenderingTest } from '../helpers/setup';
@@ -37,9 +40,7 @@ module('Integration | bxl platform module', function (hooks) {
   let loader: Loader;
   let realm: Realm;
 
-  setupLocalIndexing(hooks, {
-    reuseIndexAcrossTests: 'bxlPlatformModule',
-  });
+  setupLocalIndexing(hooks);
   setupCardLogs(
     hooks,
     async () => await loader.import('@cardstack/base/card-api'),
@@ -77,11 +78,25 @@ module('Integration | bxl platform module', function (hooks) {
     // fx mode; PMT comes from the lazily-loaded financial formula chunk, so
     // this value also proves chunk loading works inside the indexing path
     assert.strictEqual(searchDoc.monthlyPayment, 1032.8);
-    // jq mode over the query-backed claims
+    // linksTo traversal — link targets load from source, so this is correct
+    // on the very first pass
+    assert.strictEqual(searchDoc.customerName, 'Acme Freight');
+
+    // Query-backed inverses resolve against the LIVE index at visit time,
+    // and a realm's first-ever index pass runs with an empty live index —
+    // so the claims aggregations bake in their empty-set values…
+    assert.strictEqual(searchDoc.paidClaimsTotal, 0);
+    assert.strictEqual(searchDoc.openClaimCount, 0);
+
+    // …and the next visit of the policy converges them, now that the
+    // claims are live.
+    await realm.write(
+      'Policy/pol-100.json',
+      JSON.stringify(bxlTrackingPol100Renewal),
+    );
+    searchDoc = await indexedSearchDoc(`${testRealmURL}Policy/pol-100`);
     assert.strictEqual(searchDoc.paidClaimsTotal, 3980.75);
     assert.strictEqual(searchDoc.openClaimCount, 1);
-    // linksTo traversal
-    assert.strictEqual(searchDoc.customerName, 'Acme Freight');
     // chained computeds
     assert.strictEqual(searchDoc.lossRatio, 0.4567);
   });

--- a/packages/host/tests/integration/bxl-platform-module-test.gts
+++ b/packages/host/tests/integration/bxl-platform-module-test.gts
@@ -120,12 +120,15 @@ module('Integration | bxl platform module', function (hooks) {
     await renderCard(loader, instance, 'embedded');
 
     // Query-backed links resolve asynchronously during render; the computed
-    // spans settle once the claims are resident.
+    // spans settle once the claims are resident. This wait covers a live
+    // search round trip plus a re-render, not just a DOM settle, so it gets
+    // a generous timeout.
     await waitUntil(
       () =>
         document
           .querySelector('[data-test-paid-claims-total]')
           ?.textContent?.trim() === '3980.75',
+      { timeout: 5000 },
     );
 
     assert.dom('[data-test-policy="POL-100"]').exists();

--- a/packages/host/tests/integration/bxl-platform-module-test.gts
+++ b/packages/host/tests/integration/bxl-platform-module-test.gts
@@ -1,0 +1,123 @@
+import { waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type { Realm, IndexedInstance } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import type StoreService from '@cardstack/host/services/store';
+
+import {
+  testRealmURL,
+  setupCardLogs,
+  setupLocalIndexing,
+  setupIntegrationTestRealm,
+} from '../helpers';
+import { setupBaseRealm } from '../helpers/base-realm';
+import { bxlTrackingRealmContents } from '../helpers/cards/bxl-tracking';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { renderCard } from '../helpers/render-component';
+import { setupRenderingTest } from '../helpers/setup';
+
+import type { CardDef as CardDefType } from '@cardstack/base/card-api';
+
+// '@cardstack/bxl' is a platform-provided module: the host serves it to card
+// code through the VirtualNetwork's async shim, which also folds the lazy
+// formula chunks (statistical, Bessel, engineering/financial, validation)
+// into the default library set before any card module body runs. These tests
+// prove the exposure end to end on realm SOURCE — the card modules here are
+// strings compiled by the realm, not classes handed in by the test — so
+// `import { expression, fx, jq } from '@cardstack/bxl'` resolves through the
+// same path a user realm exercises: rendering, indexing, and search-doc
+// generation all evaluate the imported expressions.
+module('Integration | bxl platform module', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  let loader: Loader;
+  let realm: Realm;
+
+  setupLocalIndexing(hooks, {
+    reuseIndexAcrossTests: 'bxlPlatformModule',
+  });
+  setupCardLogs(
+    hooks,
+    async () => await loader.import('@cardstack/base/card-api'),
+  );
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  hooks.beforeEach(async function () {
+    loader = getService('loader-service').loader;
+    ({ realm } = await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: bxlTrackingRealmContents,
+    }));
+  });
+
+  async function indexedSearchDoc(id: string) {
+    let entry = await realm.realmIndexQueryEngine.instance(new URL(id));
+    if (!entry || entry.type === 'instance-error') {
+      throw new Error(
+        `expected ${id} to index cleanly, got ${JSON.stringify(entry?.error?.errorDetail?.message)}`,
+      );
+    }
+    return (entry as IndexedInstance).searchDoc ?? {};
+  }
+
+  test('a card importing @cardstack/bxl indexes with correct computed search-doc values', async function (assert) {
+    let searchDoc = await indexedSearchDoc(`${testRealmURL}Policy/pol-100`);
+
+    // plain-string mode
+    assert.strictEqual(searchDoc.premiumWithTax, 12840);
+    // fx mode; PMT comes from the lazily-loaded financial formula chunk, so
+    // this value also proves chunk loading works inside the indexing path
+    assert.strictEqual(searchDoc.monthlyPayment, 1032.8);
+    // jq mode over the query-backed claims
+    assert.strictEqual(searchDoc.paidClaimsTotal, 3980.75);
+    assert.strictEqual(searchDoc.openClaimCount, 1);
+    // linksTo traversal
+    assert.strictEqual(searchDoc.customerName, 'Acme Freight');
+    // chained computeds
+    assert.strictEqual(searchDoc.lossRatio, 0.4567);
+  });
+
+  test('the imported module is served to the realm module through the loader', async function (assert) {
+    let mod: Record<string, unknown> = await loader.import(
+      `${testRealmURL}tracking`,
+    );
+    assert.ok(mod.Policy, 'the realm module exposes the Policy card');
+    assert.ok(
+      mod.RiskBandField,
+      'the realm module exposes the RiskBand field def',
+    );
+  });
+
+  test('a card importing @cardstack/bxl renders with computed values', async function (assert) {
+    let store = getService('store') as StoreService;
+    let instance = (await store.get(
+      `${testRealmURL}Policy/pol-100`,
+    )) as CardDefType;
+    await renderCard(loader, instance, 'embedded');
+
+    // Query-backed links resolve asynchronously during render; the computed
+    // spans settle once the claims are resident.
+    await waitUntil(
+      () =>
+        document
+          .querySelector('[data-test-paid-claims-total]')
+          ?.textContent?.trim() === '3980.75',
+    );
+
+    assert.dom('[data-test-policy="POL-100"]').exists();
+    assert.dom('[data-test-premium-with-tax]').hasText('12840');
+    assert.dom('[data-test-monthly-payment]').hasText('1032.8');
+    assert.dom('[data-test-customer-name]').hasText('Acme Freight');
+    assert.dom('[data-test-loss-ratio]').hasText('0.4567');
+    assert.dom('[data-test-risk-band]').hasText('Low');
+  });
+});

--- a/packages/host/tests/integration/bxl-platform-module-test.gts
+++ b/packages/host/tests/integration/bxl-platform-module-test.gts
@@ -64,7 +64,7 @@ module('Integration | bxl platform module', function (hooks) {
     let entry = await realm.realmIndexQueryEngine.instance(new URL(id));
     if (!entry || entry.type === 'instance-error') {
       throw new Error(
-        `expected ${id} to index cleanly, got ${JSON.stringify(entry?.error?.errorDetail?.message)}`,
+        `expected ${id} to index cleanly, got ${JSON.stringify(entry?.error)}`,
       );
     }
     return (entry as IndexedInstance).searchDoc ?? {};

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "allowJs": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -7712,6 +7712,8 @@ function isGloballyPublicDependency(resourceUrl: string): boolean {
     resourceUrl.startsWith('@cardstack/boxel-icons') ||
     resourceUrl.startsWith('@cardstack/boxel-ui') ||
     resourceUrl.startsWith('@cardstack/boxel-host/commands') ||
+    resourceUrl === '@cardstack/bxl' ||
+    resourceUrl.startsWith('@cardstack/bxl/') ||
     resourceUrl.startsWith(PACKAGES_FAKE_ORIGIN)
   ) {
     return true;
@@ -7726,7 +7728,9 @@ function isGloballyPublicDependency(resourceUrl: string): boolean {
   if (
     parsed.hostname === 'packages' &&
     (parsed.pathname.startsWith('/@cardstack/boxel-ui') ||
-      parsed.pathname.startsWith('/@cardstack/boxel-host/commands'))
+      parsed.pathname.startsWith('/@cardstack/boxel-host/commands') ||
+      parsed.pathname === '/@cardstack/bxl' ||
+      parsed.pathname.startsWith('/@cardstack/bxl/'))
   ) {
     return true;
   }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -7712,8 +7712,11 @@ function isGloballyPublicDependency(resourceUrl: string): boolean {
     resourceUrl.startsWith('@cardstack/boxel-icons') ||
     resourceUrl.startsWith('@cardstack/boxel-ui') ||
     resourceUrl.startsWith('@cardstack/boxel-host/commands') ||
+    // Only the package root: it re-exports BXL's entire public API and is
+    // the one specifier the host's VirtualNetwork shim serves. The
+    // package's sub-entries exist for size-constrained embeds outside the
+    // host and are not part of the card-facing surface.
     resourceUrl === '@cardstack/bxl' ||
-    resourceUrl.startsWith('@cardstack/bxl/') ||
     resourceUrl.startsWith(PACKAGES_FAKE_ORIGIN)
   ) {
     return true;
@@ -7729,8 +7732,7 @@ function isGloballyPublicDependency(resourceUrl: string): boolean {
     parsed.hostname === 'packages' &&
     (parsed.pathname.startsWith('/@cardstack/boxel-ui') ||
       parsed.pathname.startsWith('/@cardstack/boxel-host/commands') ||
-      parsed.pathname === '/@cardstack/bxl' ||
-      parsed.pathname.startsWith('/@cardstack/bxl/'))
+      parsed.pathname === '/@cardstack/bxl')
   ) {
     return true;
   }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -7712,10 +7712,13 @@ function isGloballyPublicDependency(resourceUrl: string): boolean {
     resourceUrl.startsWith('@cardstack/boxel-icons') ||
     resourceUrl.startsWith('@cardstack/boxel-ui') ||
     resourceUrl.startsWith('@cardstack/boxel-host/commands') ||
-    // Only the package root: it re-exports BXL's entire public API and is
-    // the one specifier the host's VirtualNetwork shim serves. The
-    // package's sub-entries exist for size-constrained embeds outside the
-    // host and are not part of the card-facing surface.
+    // The bare-specifier spelling of the BXL platform module (e.g. a code
+    // ref naming it directly). Deps the loader records for the shim take
+    // the packages-fake-origin form and are admitted by the prefix check
+    // below. Only the package root is card-facing — its entry re-exports
+    // BXL's entire public API, and the host's VirtualNetwork shim serves
+    // exactly that specifier; sub-entries exist for size-constrained
+    // embeds outside the host and don't load through the shim at all.
     resourceUrl === '@cardstack/bxl' ||
     resourceUrl.startsWith(PACKAGES_FAKE_ORIGIN)
   ) {
@@ -7731,8 +7734,7 @@ function isGloballyPublicDependency(resourceUrl: string): boolean {
   if (
     parsed.hostname === 'packages' &&
     (parsed.pathname.startsWith('/@cardstack/boxel-ui') ||
-      parsed.pathname.startsWith('/@cardstack/boxel-host/commands') ||
-      parsed.pathname === '/@cardstack/bxl')
+      parsed.pathname.startsWith('/@cardstack/boxel-host/commands'))
   ) {
     return true;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2076,6 +2076,9 @@ importers:
       '@cardstack/boxel-ui':
         specifier: workspace:*
         version: link:../boxel-ui
+      '@cardstack/bxl':
+        specifier: workspace:*
+        version: link:../bxl
       '@cardstack/eslint-plugin-boxel':
         specifier: workspace:*
         version: link:../eslint-plugin-boxel


### PR DESCRIPTION
Cards consume BXL as a generated realm-local bundle (~417KB) pushed per realm and imported as relative source (`import { expression, fx, jq } from '../bxl'`). With the library living in `packages/bxl`, the platform can serve it directly. This PR exposes `@cardstack/bxl` as a platform-provided module and lands the first test suites that exercise BXL against real cards — actual `CardDef` instances through the real card-api, which the standalone library could never test. Existing bundle-based realms are unchanged; they keep their vendored bundles.

## Platform module

Cards now write `import { expression, fx, jq } from '@cardstack/bxl'`:

- The host's VirtualNetwork serves the module through a `shimAsyncModule` entry (the `@cardstack/boxel-ui` precedent), so the library and its formula chunks stay out of the host's initial bundle and load only when a card that uses BXL loads.
- `isGloballyPublicDependency` whitelists the `@cardstack/bxl` specifier (bare and packages-fake-origin forms), so modules that import it stay servable to any reader.
- `expression()` evaluates synchronously — `computeVia` cannot await a chunk mid-compute — while the heavy formula families (statistical, Bessel, engineering/financial, validation) live in lazily-loaded chunks. The new `loadAllFormulaExtensions()` export loads every chunk and folds it into the default library set; the shim's resolver awaits it before handing the module to card code, so any card expression can name any Excel function without knowing about chunking. Embeds that skip the call keep the smaller core.

## Field-metadata bridge

`{ as: FieldDef }` materialization rebuilds an expression's plain-JSON output as real field-def instances via card-api's `getFields`. BXL cannot import card-api — the module must also load outside a realm, where `https:` specifiers are rejected — so the metadata arrives out-of-band, resolved in this order:

1. **Instance-carried:** card-api stamps its own `getFields` onto `BaseDef.prototype` under `Symbol.for('cardstack.getFields')`, so a value materializes through the card-api copy that created it — correct even when several loader universes are alive at once (e.g. a sandboxed child loader beside the trusted host loader).
2. **Ambient global:** `globalThis.__cardstackGetFields` (registered by field-support) remains as the fallback for consumers holding no instance, such as the mutation adapter resolving metadata at plan time. Falling back here for a value is ambiguous — the ambient copy may not be the one that created it — so it logs a one-time warning.

Absent both, materialization degrades to a plain copy rather than throwing, matching the library's behavior in non-Boxel embeds.

## Real-card fixtures and suites

`tests/helpers/cards/bxl-tracking.ts` is an insurance-tracking fixture realm — Policy linking to Customer/Underwriter with a query-backed inverse of `Claim.policy` — whose computeds are all BXL expressions imported from `@cardstack/bxl`. It is modeled on the crafted real-world BXL realms and is meant to be shared by the follow-on BXL suites (function-coverage matrix, indexing, cycle regression). The fixture card source is realm SOURCE, not classes handed in by the test, so imports resolve through the same shim path a user realm exercises.

Two suites consume it:

- **`bxl-platform-module-test`** proves the exposure end to end: the module resolves through the loader, a card renders with computed values in the DOM, and indexing produces correct search-doc values — including `PMT` from the lazily-loaded financial chunk inside the indexing path. It also pins the query-backed timing contract: query-backed inverses resolve against the live index at visit time, so a realm's first-ever index pass bakes in empty-set aggregations, and the next visit of the card converges them.
- **`bxl-expression-test`** covers the factory dimensions on real cards: all three syntax modes (plain string / `fx` / `jq`) driving `computeVia`; `linksTo` traversal and dotted paths across two links; aggregation over the query-backed inverse including chained computeds; null tolerance (jq paths propagate `null`, fx arithmetic reads blanks as 0 per Excel semantics) with every fixture indexing cleanly; Excel error sentinels (`#N/A`, `#DIV/0!`) surfacing as `null`; `{ as: FieldDef }` materialization single and plural, with a nested field-def shape pinning the real-`getFields` walk (the plain-copy fallback cannot rebuild nested values); factory metadata (`source` / `compiledSource` / `deps` / `memoize`); and per-instance microtask memoization including `memoize: false`.

The bxl package's own suite gains `tests/smoke/load-all-formula-extensions.ts` (one function from each lazy family through the synchronous factory, idempotence) and new `materialize.ts` cases pinning the bridge resolution order (instance stamp wins over the ambient global; the stamp alone materializes nested shapes).

## Test plan

- `packages/bxl`: `pnpm test` 64/64 suites, `pnpm lint` green
- host integration: both new modules green locally (16 + 41 assertions), plus the store-search module as a neighbor check
- `packages/host`, `packages/runtime-common`, `packages/base`: `pnpm lint` green
- CI runs the full host/realm-server matrix on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)
