### PR TITLE
Add the font FileDef family with a live specimen and metadata

### DIFF
--- a/packages/base/file-formats/font-specimen.gts
+++ b/packages/base/file-formats/font-specimen.gts
@@ -1,0 +1,307 @@
+// The font family's renderer, projected into the four format shells by
+// `FilePreviewStage`. The browser is the decoder: `applyFileFont` loads the
+// linked face onto the specimen container and every sample below inherits it,
+// so what shows is the real typeface, not a description of it.
+//
+// Each mode gets a different amount of the specimen — a single showcase glyph in
+// a budgeted collection cell, a compact name-plus-pangram inline, and a full
+// waterfall with a character map when isolated — while all three share one
+// FontFace load.
+import GlimmerComponent from '@glimmer/component';
+
+import { eq } from '@cardstack/boxel-ui/helpers';
+
+import { applyFileFont } from './file-resources';
+import type { FilePreviewSignature } from './file-preview-stage';
+
+// A type-designer's pangram: every letter, and a shape mix that shows a face's
+// personality faster than "quick brown fox".
+const PANGRAM = 'Sphinx of black quartz, judge my vow';
+
+// The reading-size waterfall. Large enough at the top to read the letterforms,
+// small enough at the bottom to prove the face holds up as body text.
+const WATERFALL_SIZES = [64, 48, 36, 28, 22, 18, 15, 13];
+
+// The character map an isolated specimen lays out in the face itself.
+const UPPERCASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const LOWERCASE = 'abcdefghijklmnopqrstuvwxyz';
+const DIGITS = '0123456789';
+const PUNCTUATION = '&.,;:!?“”‘’()[]{}/@#$%*+=—';
+
+export class FontSpecimen extends GlimmerComponent<FilePreviewSignature> {
+  get metadata() {
+    return this.args.model?.fontMetadata;
+  }
+
+  // The face's own name is the natural showcase string; the file name is the
+  // honest fallback before extraction has run (or for a WOFF2, whose name table
+  // we can't read).
+  get displayName(): string {
+    return (
+      this.metadata?.familyName ||
+      this.metadata?.fullName ||
+      this.args.model?.baseName ||
+      this.args.model?.name ||
+      'Specimen'
+    );
+  }
+
+  get subfamily(): string {
+    return this.metadata?.subfamilyName ?? '';
+  }
+
+  // A short showcase glyph pair for the budgeted fitted cell — big enough to
+  // read the face's character at a glance without loading a whole waterfall.
+  get fittedGlyphs(): string {
+    return 'Ag';
+  }
+
+  get pangram(): string {
+    return PANGRAM;
+  }
+
+  get waterfallSizes(): number[] {
+    return WATERFALL_SIZES;
+  }
+
+  get characterRows(): { label: string; glyphs: string }[] {
+    return [
+      { label: 'Uppercase', glyphs: UPPERCASE },
+      { label: 'Lowercase', glyphs: LOWERCASE },
+      { label: 'Numerals', glyphs: DIGITS },
+      { label: 'Punctuation', glyphs: PUNCTUATION },
+    ];
+  }
+
+  // The URL the FontFace loads from. `resourceUrl` is the served file; the auth
+  // service worker injects the realm token on the native request.
+  get resourceUrl(): string {
+    return this.args.model?.resourceUrl ?? this.args.model?.url ?? '';
+  }
+
+  // A face family name unique to this file, so two specimens on one page each
+  // load their own face instead of colliding in the document's FontFace
+  // registry. The content hash is stable across renders of the same bytes.
+  get specimenFamily(): string {
+    let token =
+      this.args.model?.contentHash ||
+      this.args.model?.id ||
+      this.resourceUrl ||
+      this.displayName;
+    return `Boxel specimen ${token}`;
+  }
+
+  <template>
+    {{#if (eq @mode 'fitted')}}
+      <div
+        class='specimen specimen--fitted'
+        {{applyFileFont null this.resourceUrl this.specimenFamily}}
+        data-test-font-specimen='fitted'
+      >
+        <span class='fitted-glyphs'>{{this.fittedGlyphs}}</span>
+        <span class='fitted-name'>{{this.displayName}}</span>
+      </div>
+    {{else if (eq @mode 'embedded')}}
+      <div
+        class='specimen specimen--embedded'
+        {{applyFileFont null this.resourceUrl this.specimenFamily}}
+        data-test-font-specimen='embedded'
+      >
+        <div class='name-line' title={{this.displayName}}>{{this.displayName}}</div>
+        <div class='pangram pangram--embedded'>{{this.pangram}}</div>
+        <div class='mini-waterfall'>
+          <div class='waterfall-line wf-30'>{{this.pangram}}</div>
+          <div class='waterfall-line wf-18'>{{this.pangram}}</div>
+        </div>
+      </div>
+    {{else}}
+      <div
+        class='specimen specimen--isolated'
+        {{applyFileFont null this.resourceUrl this.specimenFamily}}
+        data-test-font-specimen='isolated'
+      >
+        <header class='specimen-head'>
+          <div class='hero' title={{this.displayName}}>{{this.displayName}}</div>
+          {{#if this.subfamily}}
+            <div class='hero-sub'>{{this.subfamily}}</div>
+          {{/if}}
+        </header>
+
+        <section class='waterfall' aria-label='Waterfall'>
+          {{#each this.waterfallSizes as |size|}}
+            <div class='waterfall-line wf-{{size}}'>{{this.pangram}}</div>
+          {{/each}}
+        </section>
+
+        <section class='charmap' aria-label='Character set'>
+          {{#each this.characterRows as |row|}}
+            <div class='charmap-row'>
+              <div class='charmap-label'>{{row.label}}</div>
+              <div class='charmap-glyphs'>{{row.glyphs}}</div>
+            </div>
+          {{/each}}
+        </section>
+      </div>
+    {{/if}}
+
+    <style scoped>
+      /* The specimen container carries the loaded face via `applyFileFont`, and
+         the samples inherit it. Chrome (labels, size markers) sets its own
+         family so only the actual specimen text renders in the linked font. */
+      .specimen {
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        box-sizing: border-box;
+        background: var(--card, #fff);
+        color: var(--foreground);
+        text-align: left;
+        /* Own the container context so the `cqw` sizing below scales the hero
+           and glyphs against the specimen's own width, not the viewport — a
+           narrow embedded cell gets a proportionally smaller showcase. */
+        container-type: inline-size;
+      }
+
+      /* Fitted: a budgeted collection cell. One showcase glyph pair plus the
+         family name, both in the face. */
+      .specimen--fitted {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 4px;
+        padding: 8px;
+        overflow: hidden;
+      }
+      .fitted-glyphs {
+        font-size: clamp(2.25rem, 34cqw, 5rem);
+        line-height: 1;
+      }
+      .fitted-name {
+        max-width: 100%;
+        font-family: var(--font-mono);
+        font-size: 0.5625rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--muted-foreground);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      /* Embedded: a compact plate — name, one pangram, a two-step waterfall. */
+      .specimen--embedded {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 16px;
+        overflow: hidden;
+      }
+      .name-line {
+        font-size: clamp(1.75rem, 8cqw, 2.75rem);
+        line-height: 1.1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .pangram--embedded {
+        font-size: 1.125rem;
+        line-height: 1.3;
+        color: var(--foreground);
+      }
+      .mini-waterfall {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      /* Isolated: the full specimen — hero name, waterfall, character map. */
+      .specimen--isolated {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-lg, 24px);
+        padding: var(--boxel-sp-xl, 32px);
+        overflow: auto;
+      }
+      .specimen-head {
+        border-bottom: 1px solid var(--border);
+        padding-bottom: var(--boxel-sp, 16px);
+      }
+      .hero {
+        font-size: clamp(2.5rem, 9cqw, 5rem);
+        line-height: 1.05;
+        word-break: break-word;
+      }
+      .hero-sub {
+        margin-top: 4px;
+        font-size: 1.25rem;
+        color: var(--muted-foreground);
+      }
+      .waterfall {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .waterfall-line {
+        line-height: 1.25;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      /* The waterfall steps through a fixed set of sizes; a class per step keeps
+         the size out of an inline style. */
+      .wf-64 {
+        font-size: 64px;
+      }
+      .wf-48 {
+        font-size: 48px;
+      }
+      .wf-36 {
+        font-size: 36px;
+      }
+      .wf-30 {
+        font-size: 30px;
+      }
+      .wf-28 {
+        font-size: 28px;
+      }
+      .wf-22 {
+        font-size: 22px;
+      }
+      .wf-18 {
+        font-size: 18px;
+      }
+      .wf-15 {
+        font-size: 15px;
+      }
+      .wf-13 {
+        font-size: 13px;
+      }
+      .charmap {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp, 16px);
+      }
+      .charmap-row {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .charmap-label {
+        font-family: var(--font-mono);
+        font-size: 0.5625rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted-foreground);
+      }
+      .charmap-glyphs {
+        font-size: 1.75rem;
+        line-height: 1.4;
+        letter-spacing: 0.08em;
+        word-break: break-word;
+      }
+    </style>
+  </template>
+}

--- a/packages/base/file-formats/index.ts
+++ b/packages/base/file-formats/index.ts
@@ -64,6 +64,7 @@ export {
   CodedValueField,
   ColorProfileField,
   ExifMetadataField,
+  FontMetadataField,
   GeoLocationField,
   HtmlMetadataField,
   METADATA_VOCABULARIES,

--- a/packages/base/file-formats/metadata-fields.gts
+++ b/packages/base/file-formats/metadata-fields.gts
@@ -24,6 +24,7 @@ import RulerIcon from '@cardstack/boxel-icons/ruler';
 import TagIcon from '@cardstack/boxel-icons/tag';
 import KeyboardMusicIcon from '@cardstack/boxel-icons/keyboard-music';
 import TagsIcon from '@cardstack/boxel-icons/tags';
+import TypographyIcon from '@cardstack/boxel-icons/typography';
 
 import FileCodeIcon from '@cardstack/boxel-icons/file-code';
 import FileInfoIcon from '@cardstack/boxel-icons/file-info';
@@ -900,6 +901,134 @@ export class MidiMetadataField extends FieldDef {
           overflow-wrap: anywhere;
         }
         /* Several values on one row read as a list, not a run-on string. */
+        .list {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.125rem 0.5rem;
+        }
+      </style>
+    </template>
+  };
+}
+
+// What a font file says about itself, read from its own sfnt tables — the name
+// table's identity strings, OS/2's weight/width/vendor, head's em grid, maxp's
+// glyph count, and fvar's variation axes. Shared across every font family
+// (WOFF2/WOFF/TTF/OTF) because the tables read identically regardless of how the
+// bytes were wrapped. Absent for a WOFF2, whose tables are Brotli-compressed and
+// unreadable in the browser extract pass; the live specimen renders anyway.
+export class FontMetadataField extends FieldDef {
+  static displayName = 'Font Metadata';
+  static icon = TypographyIcon;
+
+  @field familyName = contains(StringField);
+  // The named style within the family, e.g. "Bold Italic".
+  @field subfamilyName = contains(StringField);
+  @field fullName = contains(StringField);
+  @field postscriptName = contains(StringField);
+  @field versionName = contains(StringField);
+  // Manufacturer from the name table; `vendorId` is the OS/2 four-character
+  // fallback shown when the name table names no foundry.
+  @field foundry = contains(StringField);
+  @field vendorId = contains(StringField);
+  // OS/2 usWeightClass (100–900).
+  @field weightClass = contains(NumberField);
+  // Label derived from usWidthClass, set only when the face isn't normal width.
+  @field widthName = contains(StringField);
+  @field glyphCount = contains(NumberField);
+  @field unitsPerEm = contains(NumberField);
+  // 'TrueType' or 'PostScript/CFF'.
+  @field outlineType = contains(StringField);
+  @field isVariable = contains(BooleanField);
+  @field isItalic = contains(BooleanField);
+  @field isBold = contains(BooleanField);
+  // Variation axes as display labels, e.g. "Weight (wght) 100–900".
+  @field axes = containsMany(StringField);
+
+  static embedded = class Embedded extends Component<typeof FontMetadataField> {
+    // The em grid and the outline flavor read as one line — "TrueType ·
+    // variable · 2048 upm" — rather than three near-empty rows.
+    get technicalSummary() {
+      let parts: string[] = [];
+      if (this.args.model?.outlineType) {
+        parts.push(this.args.model.outlineType);
+      }
+      if (this.args.model?.isVariable) {
+        parts.push('variable');
+      }
+      if (this.args.model?.unitsPerEm) {
+        parts.push(`${this.args.model.unitsPerEm} upm`);
+      }
+      return parts.join(' · ');
+    }
+
+    // The name-table foundry is the better label; the OS/2 vendor tag is the
+    // honest fallback that at least identifies who stamped the file.
+    get vendor() {
+      return this.args.model?.foundry || this.args.model?.vendorId;
+    }
+
+    <template>
+      <dl class='metadata-rows'>
+        {{#if @model.familyName}}
+          <div class='row'><dt>Family</dt><dd>{{@model.familyName}}</dd></div>
+        {{/if}}
+        {{#if @model.subfamilyName}}
+          <div class='row'><dt>Style</dt><dd>{{@model.subfamilyName}}</dd></div>
+        {{/if}}
+        {{#if @model.weightClass}}
+          <div class='row'><dt>Weight</dt><dd>{{@model.weightClass}}</dd></div>
+        {{/if}}
+        {{#if @model.widthName}}
+          <div class='row'><dt>Width</dt><dd>{{@model.widthName}}</dd></div>
+        {{/if}}
+        {{#if @model.glyphCount}}
+          <div class='row'><dt>Glyphs</dt><dd>{{@model.glyphCount}}</dd></div>
+        {{/if}}
+        {{#if this.technicalSummary}}
+          <div class='row'><dt>Outline</dt><dd>{{this.technicalSummary}}</dd></div>
+        {{/if}}
+        {{#if @model.axes.length}}
+          <div class='row'><dt>Axes</dt><dd class='list'>{{#each
+                @model.axes as |axis|
+              }}<span>{{axis}}</span>{{/each}}</dd></div>
+        {{/if}}
+        {{#if @model.postscriptName}}
+          <div class='row'><dt>PostScript</dt><dd>{{@model.postscriptName}}</dd></div>
+        {{/if}}
+        {{#if this.vendor}}
+          <div class='row'><dt>Vendor</dt><dd>{{this.vendor}}</dd></div>
+        {{/if}}
+        {{#if @model.versionName}}
+          <div class='row'><dt>Version</dt><dd>{{@model.versionName}}</dd></div>
+        {{/if}}
+      </dl>
+      <style scoped>
+        .metadata-rows {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.3125rem;
+          font-size: 0.75rem;
+        }
+        .row {
+          display: flex;
+          gap: 0.625rem;
+          align-items: baseline;
+        }
+        dt {
+          flex: 0 0 5.75rem;
+          font-family: var(--font-mono);
+          font-size: 0.5625rem;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: var(--muted-foreground);
+        }
+        dd {
+          margin: 0;
+          min-width: 0;
+          overflow-wrap: anywhere;
+        }
         .list {
           display: flex;
           flex-wrap: wrap;

--- a/packages/base/file-formats/metadata-fields.gts
+++ b/packages/base/file-formats/metadata-fields.gts
@@ -940,6 +940,10 @@ export class FontMetadataField extends FieldDef {
   // 'TrueType' or 'PostScript/CFF'.
   @field outlineType = contains(StringField);
   @field isVariable = contains(BooleanField);
+  // Query-only style facets: persisted so a search can filter for italic or bold
+  // faces, but deliberately not rendered — the specimen and the isolated
+  // inspector already convey style through `subfamilyName · weightClass`, so
+  // surfacing the raw booleans too would only duplicate it.
   @field isItalic = contains(BooleanField);
   @field isBold = contains(BooleanField);
   // Variation axes as display labels, e.g. "Weight (wght) 100–900".

--- a/packages/base/font-file-def.gts
+++ b/packages/base/font-file-def.gts
@@ -1,0 +1,88 @@
+import { byteStreamToUint8Array } from '@cardstack/runtime-common';
+import TypeIcon from '@cardstack/boxel-icons/type';
+import { FileDef, contains, field } from './card-api';
+import type { ByteStream, SerializedFile } from './file-api';
+import { FontMetadataField } from './file-formats/metadata-fields';
+import { FontSpecimen } from './file-formats/font-specimen';
+import { extractFontMetadata, type FontMetadata } from './font-meta-extractor';
+import type { FilePreviewComponent } from './file-formats/file-preview-stage';
+
+// The font family. Web fonts (WOFF2/WOFF) and desktop fonts (TTF/OTF) share one
+// renderer and one metadata shape because, once the container is unwrapped, they
+// are the same sfnt tables — so the four shared shells mount a single live
+// specimen for every subclass, and only the labeled kind differs per extension.
+//
+// The metadata field and the specimen icon live here rather than in `card-api`
+// so only realms that actually hold fonts pay for the font modules, matching how
+// `ImageDef`/`AudioDef` keep their own fields off every card's dependency graph.
+
+// A font over this size is not read for metadata: the tables that carry
+// identity are tiny, but locating them can require buffering the whole file,
+// and a large CJK face's outline data can run to tens of megabytes. The live
+// specimen still renders — the browser streams the face itself — so the only
+// thing skipped is the inspector's name/glyph facts.
+const FONT_METADATA_MAX_BYTES = 24 * 1024 * 1024;
+
+export class FontDef extends FileDef {
+  static displayName = 'Font';
+  static icon = TypeIcon;
+  static acceptTypes = 'font/*';
+  // A font served without a useful content type would otherwise route to a
+  // generic profile by extension alone, so pin the family the four shells
+  // present rather than depending on every instance carrying a `font/*` type.
+  static fileFamily = 'font';
+
+  // What the face says about itself, read from its own sfnt tables during the
+  // extract pass. Empty for a WOFF2, whose tables are Brotli-compressed and
+  // can't be read in the browser extract environment; the specimen renders
+  // regardless. Surfaced by the shells as hero facts and the isolated
+  // inspector's font-metadata group.
+  @field fontMetadata = contains(FontMetadataField);
+
+  // The four formats come from FileDef's shared shells; the family supplies only
+  // the renderer that draws the type — a live FontFace specimen.
+  static previewComponent: FilePreviewComponent = FontSpecimen;
+
+  static async extractAttributes(
+    url: string,
+    getStream: () => Promise<ByteStream>,
+    options: { contentHash?: string; contentSize?: number } = {},
+  ): Promise<SerializedFile<{ fontMetadata?: FontMetadata }>> {
+    let base = await super.extractAttributes(url, getStream, options);
+
+    // A known oversize file skips the read entirely rather than buffering it to
+    // then reject it.
+    if (
+      options.contentSize !== undefined &&
+      options.contentSize > FONT_METADATA_MAX_BYTES
+    ) {
+      return base;
+    }
+
+    let bytes: Uint8Array;
+    try {
+      bytes = await byteStreamToUint8Array(await getStream());
+    } catch {
+      // A stream that won't read is not a reason to fail the whole extract; the
+      // base file identity is already gathered.
+      return base;
+    }
+
+    if (bytes.byteLength > FONT_METADATA_MAX_BYTES) {
+      return base;
+    }
+
+    // A non-font throws `FileContentMismatchError` here, which propagates so the
+    // extract framework falls back to a plain FileDef rather than indexing a
+    // broken font. A real font with unreadable tables (a WOFF2) returns an empty
+    // result instead, which adds no attribute rather than an empty object.
+    let parsed = await extractFontMetadata(bytes);
+
+    return {
+      ...base,
+      ...(Object.keys(parsed).length > 0 ? { fontMetadata: parsed } : {}),
+    };
+  }
+}
+
+export default FontDef;

--- a/packages/base/font-meta-extractor.ts
+++ b/packages/base/font-meta-extractor.ts
@@ -54,6 +54,22 @@ function asciiTag(view: DataView, offset: number): string {
   return out;
 }
 
+// Fixed-length name and tag fields (an OS/2 vendor tag, a padded name record)
+// pad with trailing spaces or NULs. Trim both ends by code point rather than
+// with a regex, so a legitimate trailing accented letter in a UTF-16 name
+// survives while the C0 padding does not.
+function trimPadding(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (end > start && value.charCodeAt(end - 1) <= 0x20) {
+    end--;
+  }
+  while (start < end && value.charCodeAt(start) <= 0x20) {
+    start++;
+  }
+  return value.slice(start, end);
+}
+
 // A face's tables, abstracted over the three containers so the metadata readers
 // don't care whether the bytes arrived bare, deflate-wrapped (WOFF), or
 // Brotli-wrapped (WOFF2). `flavor` is the sfnt version, which alone names the
@@ -245,10 +261,9 @@ function decodeNameString(
     platformID === 3 ||
     (platformID === 1 && encodingID !== 0);
   try {
-    return new TextDecoder(utf16 ? 'utf-16be' : 'latin1')
-      .decode(bytes)
-      .replace(/ +$/g, '')
-      .trim();
+    return trimPadding(
+      new TextDecoder(utf16 ? 'utf-16be' : 'latin1').decode(bytes),
+    );
   } catch {
     return '';
   }
@@ -331,7 +346,7 @@ function parseOs2Table(table: Uint8Array): {
   let view = new DataView(table.buffer, table.byteOffset, table.byteLength);
   let weightClass = view.getUint16(4);
   let widthClass = view.getUint16(6);
-  let vendorId = asciiTag(view, 58).replace(/ +$/g, '').trim();
+  let vendorId = trimPadding(asciiTag(view, 58));
   let fsSelection = view.getUint16(62);
   return {
     weightClass: weightClass > 0 ? weightClass : undefined,

--- a/packages/base/font-meta-extractor.ts
+++ b/packages/base/font-meta-extractor.ts
@@ -145,6 +145,13 @@ function sfntTableSource(bytes: Uint8Array, headerOffset = 0): TableSource {
 // compressed length equals its original length is stored raw; otherwise it is
 // zlib-compressed and inflated on demand.
 function woffTableSource(bytes: Uint8Array): TableSource {
+  // The 44-byte header carries the fields read below (flavor at 4, numTables at
+  // 12); a stream that starts `wOFF` but is shorter is truncated, and reading
+  // past its end would throw a RangeError that fails the whole extract. Reject
+  // it as a content mismatch instead, which degrades to the plain FileDef.
+  if (bytes.byteLength < 44) {
+    throw new FileContentMismatchError('WOFF header is truncated');
+  }
   let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   let flavor = view.getUint32(4);
   let numTables = view.getUint16(12);
@@ -200,6 +207,22 @@ function woff2TableSource(bytes: Uint8Array): TableSource {
   };
 }
 
+// A TrueType Collection packs several faces behind a `ttcf` header, which is not
+// an sfnt table directory — its bytes after the tag are a version and a face
+// count, not `numTables` and table records. As the container comment says, this
+// pass reports a collection as a font (the flavor names it) but does not walk
+// into a face, so it exposes no tables rather than misreading the TTC header as
+// one.
+function collectionTableSource(bytes: Uint8Array): TableSource {
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return {
+    flavor: view.getUint32(0),
+    container: 'sfnt',
+    hasTable: () => false,
+    getTable: async () => undefined,
+  };
+}
+
 function tableSourceFor(bytes: Uint8Array): TableSource {
   if (bytes.byteLength < 12) {
     throw new FileContentMismatchError('File is too small to be a font');
@@ -211,11 +234,12 @@ function tableSourceFor(bytes: Uint8Array): TableSource {
       return woffTableSource(bytes);
     case WOFF2_SIGNATURE:
       return woff2TableSource(bytes);
+    case SFNT_TTCF:
+      return collectionTableSource(bytes);
     case SFNT_TRUETYPE:
     case SFNT_TRUE:
     case SFNT_TYP1:
     case SFNT_OTTO:
-    case SFNT_TTCF:
       return sfntTableSource(bytes);
     default:
       throw new FileContentMismatchError(

--- a/packages/base/font-meta-extractor.ts
+++ b/packages/base/font-meta-extractor.ts
@@ -107,11 +107,13 @@ async function inflateZlib(bytes: Uint8Array): Promise<Uint8Array | undefined> {
   }
 }
 
-function sfntTableSource(bytes: Uint8Array, headerOffset = 0): TableSource {
+function sfntTableSource(bytes: Uint8Array): TableSource {
   let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-  let flavor = view.getUint32(headerOffset);
-  let numTables = view.getUint16(headerOffset + 4);
-  let directory = headerOffset + 12;
+  // A bare sfnt begins with a 12-byte offset table (version, table count, and
+  // three binary-search hints) followed by the table directory.
+  let flavor = view.getUint32(0);
+  let numTables = view.getUint16(4);
+  let directory = 12;
   let tables = new Map<string, SfntTableEntry>();
   for (let i = 0; i < numTables; i++) {
     let record = directory + i * 16;
@@ -210,13 +212,26 @@ function woff2TableSource(bytes: Uint8Array): TableSource {
 // A TrueType Collection packs several faces behind a `ttcf` header, which is not
 // an sfnt table directory — its bytes after the tag are a version and a face
 // count, not `numTables` and table records. As the container comment says, this
-// pass reports a collection as a font (the flavor names it) but does not walk
-// into a face, so it exposes no tables rather than misreading the TTC header as
-// one.
+// pass reports a collection as a font but does not walk into a face, so it
+// exposes no tables rather than misreading the TTC header as one.
+//
+// The `ttcf` signature itself carries no outline flavor, so to name the outline
+// type honestly (a collection may hold TrueType *or* CFF/PostScript faces — an
+// "OpenType Collection") the flavor is read from the first face's sfnt version.
+// The TTC header stores that face's offset at byte 12; reading the 4-byte
+// version there names the flavor without touching any table directory. Falls
+// back to the `ttcf` signature when the offset is out of range.
 function collectionTableSource(bytes: Uint8Array): TableSource {
   let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let flavor = view.getUint32(0);
+  if (bytes.byteLength >= 16) {
+    let firstFaceOffset = view.getUint32(12);
+    if (firstFaceOffset + 4 <= bytes.byteLength) {
+      flavor = view.getUint32(firstFaceOffset);
+    }
+  }
   return {
-    flavor: view.getUint32(0),
+    flavor,
     container: 'sfnt',
     hasTable: () => false,
     getTable: async () => undefined,

--- a/packages/base/font-meta-extractor.ts
+++ b/packages/base/font-meta-extractor.ts
@@ -1,0 +1,495 @@
+import { FileContentMismatchError } from './file-api';
+
+// Facts read from a font file's own tables. Every field is optional: a family
+// declares what it could parse, and the shells degrade to identity-only for a
+// font whose tables couldn't be read (see FontMetadataField / file-view-model).
+export interface FontMetadata {
+  // Name-table identity. `familyName`/`subfamilyName` prefer the typographic
+  // (WWS/preferred) names when present so a "Bold Italic" reads as one family
+  // rather than four, falling back to the legacy family/style pair.
+  familyName?: string;
+  subfamilyName?: string;
+  fullName?: string;
+  postscriptName?: string;
+  versionName?: string;
+  // Name-table manufacturer (ID 8). The OS/2 vendor tag is the coarser
+  // four-character fallback a consumer shows when this is absent.
+  foundry?: string;
+  vendorId?: string;
+  // OS/2 usWeightClass (100–900) and a label derived from usWidthClass, the
+  // latter only when it isn't the normal width.
+  weightClass?: number;
+  widthName?: string;
+  // maxp numGlyphs.
+  glyphCount?: number;
+  // head unitsPerEm — the coordinate grid the outlines are drawn on.
+  unitsPerEm?: number;
+  // Which outline technology the file carries: 'TrueType' (`glyf`) or
+  // 'PostScript/CFF' (`CFF `/`CFF2`).
+  outlineType?: string;
+  // Whether the face defines variation axes (`fvar`).
+  isVariable?: boolean;
+  isItalic?: boolean;
+  isBold?: boolean;
+  // Variation axes as short labels, e.g. `Weight (wght) 100–900`.
+  axes?: string[];
+}
+
+// Container magic. sfnt covers bare TrueType/OpenType; WOFF and WOFF2 wrap an
+// sfnt for the web. `ttcf` is a TrueType collection — several faces in one file
+// — which this header pass reports as a font but does not walk into.
+const SFNT_TRUETYPE = 0x00010000;
+const SFNT_TRUE = 0x74727565; // 'true'
+const SFNT_TYP1 = 0x74797031; // 'typ1'
+const SFNT_OTTO = 0x4f54544f; // 'OTTO'
+const SFNT_TTCF = 0x74746366; // 'ttcf'
+const WOFF_SIGNATURE = 0x774f4646; // 'wOFF'
+const WOFF2_SIGNATURE = 0x774f4632; // 'wOF2'
+
+function asciiTag(view: DataView, offset: number): string {
+  let out = '';
+  for (let i = 0; i < 4; i++) {
+    out += String.fromCharCode(view.getUint8(offset + i));
+  }
+  return out;
+}
+
+// A face's tables, abstracted over the three containers so the metadata readers
+// don't care whether the bytes arrived bare, deflate-wrapped (WOFF), or
+// Brotli-wrapped (WOFF2). `flavor` is the sfnt version, which alone names the
+// outline technology when no outline table is legible.
+interface TableSource {
+  flavor: number;
+  container: 'sfnt' | 'woff' | 'woff2';
+  hasTable(tag: string): boolean;
+  // Resolves to the decompressed table bytes, or undefined when the table is
+  // absent or its bytes can't be produced in this environment (a WOFF2 table,
+  // which is Brotli-compressed with no browser-native decoder).
+  getTable(tag: string): Promise<Uint8Array | undefined>;
+}
+
+interface SfntTableEntry {
+  offset: number;
+  compLength: number;
+  origLength: number;
+}
+
+// Inflate a zlib stream (WOFF per-table compression is RFC 1950). Returns
+// undefined when no decompressor is available rather than throwing, so a WOFF
+// still yields whatever tables happened to be stored uncompressed.
+async function inflateZlib(bytes: Uint8Array): Promise<Uint8Array | undefined> {
+  if (typeof DecompressionStream === 'undefined') {
+    return undefined;
+  }
+  try {
+    let stream = new Blob([bytes as BlobPart])
+      .stream()
+      .pipeThrough(new DecompressionStream('deflate'));
+    return new Uint8Array(await new Response(stream).arrayBuffer());
+  } catch {
+    return undefined;
+  }
+}
+
+function sfntTableSource(bytes: Uint8Array, headerOffset = 0): TableSource {
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let flavor = view.getUint32(headerOffset);
+  let numTables = view.getUint16(headerOffset + 4);
+  let directory = headerOffset + 12;
+  let tables = new Map<string, SfntTableEntry>();
+  for (let i = 0; i < numTables; i++) {
+    let record = directory + i * 16;
+    if (record + 16 > bytes.byteLength) {
+      break;
+    }
+    let tag = asciiTag(view, record);
+    let offset = view.getUint32(record + 8);
+    let length = view.getUint32(record + 12);
+    tables.set(tag, { offset, compLength: length, origLength: length });
+  }
+  return {
+    flavor,
+    container: 'sfnt',
+    hasTable: (tag) => tables.has(tag),
+    getTable: async (tag) => {
+      let entry = tables.get(tag);
+      if (!entry) {
+        return undefined;
+      }
+      let end = entry.offset + entry.origLength;
+      if (entry.offset > bytes.byteLength || end > bytes.byteLength) {
+        return undefined;
+      }
+      return bytes.subarray(entry.offset, end);
+    },
+  };
+}
+
+// WOFF header is 44 bytes; the table directory is 20-byte records. A table whose
+// compressed length equals its original length is stored raw; otherwise it is
+// zlib-compressed and inflated on demand.
+function woffTableSource(bytes: Uint8Array): TableSource {
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let flavor = view.getUint32(4);
+  let numTables = view.getUint16(12);
+  let directory = 44;
+  let tables = new Map<string, SfntTableEntry>();
+  for (let i = 0; i < numTables; i++) {
+    let record = directory + i * 20;
+    if (record + 20 > bytes.byteLength) {
+      break;
+    }
+    let tag = asciiTag(view, record);
+    tables.set(tag, {
+      offset: view.getUint32(record + 4),
+      compLength: view.getUint32(record + 8),
+      origLength: view.getUint32(record + 12),
+    });
+  }
+  return {
+    flavor,
+    container: 'woff',
+    hasTable: (tag) => tables.has(tag),
+    getTable: async (tag) => {
+      let entry = tables.get(tag);
+      if (!entry) {
+        return undefined;
+      }
+      let end = entry.offset + entry.compLength;
+      if (entry.offset > bytes.byteLength || end > bytes.byteLength) {
+        return undefined;
+      }
+      let slice = bytes.subarray(entry.offset, end);
+      if (entry.compLength >= entry.origLength) {
+        return slice;
+      }
+      return inflateZlib(slice);
+    },
+  };
+}
+
+// WOFF2 stores every table as one Brotli stream, which no browser exposes a
+// decoder for, so the table directory is unreadable here. Only the header's
+// flavor is legible — enough to name the outline technology and confirm the
+// file is a font. Everything the name/OS-2/maxp readers want lives inside the
+// compressed block and comes back undefined.
+function woff2TableSource(bytes: Uint8Array): TableSource {
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let flavor = view.getUint32(4);
+  return {
+    flavor,
+    container: 'woff2',
+    hasTable: () => false,
+    getTable: async () => undefined,
+  };
+}
+
+function tableSourceFor(bytes: Uint8Array): TableSource {
+  if (bytes.byteLength < 12) {
+    throw new FileContentMismatchError('File is too small to be a font');
+  }
+  let view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let signature = view.getUint32(0);
+  switch (signature) {
+    case WOFF_SIGNATURE:
+      return woffTableSource(bytes);
+    case WOFF2_SIGNATURE:
+      return woff2TableSource(bytes);
+    case SFNT_TRUETYPE:
+    case SFNT_TRUE:
+    case SFNT_TYP1:
+    case SFNT_OTTO:
+    case SFNT_TTCF:
+      return sfntTableSource(bytes);
+    default:
+      throw new FileContentMismatchError(
+        'File does not have a recognized font signature',
+      );
+  }
+}
+
+// Name IDs the specimen surfaces. The typographic pair (16/17) supersedes the
+// legacy family/style pair (1/2) when a face declares it.
+const NAME_FAMILY = 1;
+const NAME_SUBFAMILY = 2;
+const NAME_FULL = 4;
+const NAME_VERSION = 5;
+const NAME_POSTSCRIPT = 6;
+const NAME_MANUFACTURER = 8;
+const NAME_TYPO_FAMILY = 16;
+const NAME_TYPO_SUBFAMILY = 17;
+
+// How well a name record's platform/language matches what we want to display.
+// Higher wins. Windows-English is the canonical specimen string; a Windows
+// record in another language beats a Mac one; anything legible beats nothing.
+function nameRecordScore(platformID: number, languageID: number): number {
+  if (platformID === 3) {
+    return languageID === 0x0409 ? 4 : 3;
+  }
+  if (platformID === 1) {
+    return languageID === 0 ? 2 : 1;
+  }
+  return 0;
+}
+
+function decodeNameString(
+  bytes: Uint8Array,
+  platformID: number,
+  encodingID: number,
+): string {
+  // Windows (3) and Unicode (0) records are UTF-16BE. Mac (1) Roman is ASCII
+  // for the names that matter here, so Latin-1 decodes it without a Mac-Roman
+  // table.
+  let utf16 =
+    platformID === 0 ||
+    platformID === 3 ||
+    (platformID === 1 && encodingID !== 0);
+  try {
+    return new TextDecoder(utf16 ? 'utf-16be' : 'latin1')
+      .decode(bytes)
+      .replace(/ +$/g, '')
+      .trim();
+  } catch {
+    return '';
+  }
+}
+
+interface NameEntry {
+  score: number;
+  value: string;
+}
+
+// Read the name table into best-scoring strings per name ID.
+function parseNameTable(table: Uint8Array): Map<number, string> {
+  let out = new Map<number, string>();
+  if (table.byteLength < 6) {
+    return out;
+  }
+  let view = new DataView(table.buffer, table.byteOffset, table.byteLength);
+  let count = view.getUint16(2);
+  let storageOffset = view.getUint16(4);
+  let best = new Map<number, NameEntry>();
+  for (let i = 0; i < count; i++) {
+    let record = 6 + i * 12;
+    if (record + 12 > table.byteLength) {
+      break;
+    }
+    let platformID = view.getUint16(record);
+    let encodingID = view.getUint16(record + 2);
+    let languageID = view.getUint16(record + 4);
+    let nameID = view.getUint16(record + 6);
+    let length = view.getUint16(record + 8);
+    let offset = view.getUint16(record + 10);
+    let start = storageOffset + offset;
+    if (start + length > table.byteLength) {
+      continue;
+    }
+    let score = nameRecordScore(platformID, languageID);
+    let current = best.get(nameID);
+    if (current && current.score >= score) {
+      continue;
+    }
+    let value = decodeNameString(
+      table.subarray(start, start + length),
+      platformID,
+      encodingID,
+    );
+    if (value) {
+      best.set(nameID, { score, value });
+    }
+  }
+  for (let [nameID, entry] of best) {
+    out.set(nameID, entry.value);
+  }
+  return out;
+}
+
+// usWidthClass 1–9. 5 is normal and adds nothing worth a row, so it's omitted.
+const WIDTH_NAMES: Record<number, string> = {
+  1: 'Ultra-condensed',
+  2: 'Extra-condensed',
+  3: 'Condensed',
+  4: 'Semi-condensed',
+  6: 'Semi-expanded',
+  7: 'Expanded',
+  8: 'Extra-expanded',
+  9: 'Ultra-expanded',
+};
+
+// OS/2 field offsets. achVendID and fsSelection sit past the fixed-size PANOSE
+// and Unicode-range block, so their positions are the same across every table
+// version this reads.
+function parseOs2Table(table: Uint8Array): {
+  weightClass?: number;
+  widthName?: string;
+  vendorId?: string;
+  fsSelection?: number;
+} {
+  if (table.byteLength < 64) {
+    return {};
+  }
+  let view = new DataView(table.buffer, table.byteOffset, table.byteLength);
+  let weightClass = view.getUint16(4);
+  let widthClass = view.getUint16(6);
+  let vendorId = asciiTag(view, 58).replace(/ +$/g, '').trim();
+  let fsSelection = view.getUint16(62);
+  return {
+    weightClass: weightClass > 0 ? weightClass : undefined,
+    widthName: WIDTH_NAMES[widthClass],
+    vendorId: vendorId || undefined,
+    fsSelection,
+  };
+}
+
+const AXIS_LABELS: Record<string, string> = {
+  wght: 'Weight',
+  wdth: 'Width',
+  ital: 'Italic',
+  slnt: 'Slant',
+  opsz: 'Optical size',
+};
+
+// A Fixed (16.16) coordinate, rounded — axis ranges are whole numbers in
+// practice and the fractional noise only clutters the label.
+function fixedToNumber(view: DataView, offset: number): number {
+  return Math.round(view.getInt32(offset) / 65536);
+}
+
+// fvar variation axes as display labels. Absent for a static font (no `fvar`).
+function parseFvarAxes(table: Uint8Array): string[] {
+  if (table.byteLength < 16) {
+    return [];
+  }
+  let view = new DataView(table.buffer, table.byteOffset, table.byteLength);
+  let axesOffset = view.getUint16(4);
+  let axisCount = view.getUint16(8);
+  let axisSize = view.getUint16(10);
+  let axes: string[] = [];
+  for (let i = 0; i < axisCount; i++) {
+    let record = axesOffset + i * axisSize;
+    if (record + 20 > table.byteLength) {
+      break;
+    }
+    let tag = asciiTag(view, record);
+    let min = fixedToNumber(view, record + 4);
+    let max = fixedToNumber(view, record + 12);
+    let label = AXIS_LABELS[tag] ?? tag;
+    axes.push(`${label} (${tag}) ${min}–${max}`);
+  }
+  return axes;
+}
+
+// glyf/CFF presence names the outline technology outright; the sfnt flavor is
+// the fallback when neither table is legible (e.g. a WOFF2, or a truncated
+// header read).
+function outlineTypeFor(source: TableSource): string | undefined {
+  if (source.hasTable('CFF ') || source.hasTable('CFF2')) {
+    return 'PostScript/CFF';
+  }
+  if (source.hasTable('glyf')) {
+    return 'TrueType';
+  }
+  if (source.flavor === SFNT_OTTO) {
+    return 'PostScript/CFF';
+  }
+  if (
+    source.flavor === SFNT_TRUETYPE ||
+    source.flavor === SFNT_TRUE ||
+    source.flavor === SFNT_TTCF
+  ) {
+    return 'TrueType';
+  }
+  return undefined;
+}
+
+function pruneUndefined(metadata: FontMetadata): FontMetadata {
+  let out: FontMetadata = {};
+  for (let [key, value] of Object.entries(metadata)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (Array.isArray(value) && value.length === 0) {
+      continue;
+    }
+    (out as Record<string, unknown>)[key] = value;
+  }
+  return out;
+}
+
+// Read whatever font identity the container makes legible. Throws
+// `FileContentMismatchError` only when the bytes aren't a font at all; a font
+// whose individual tables are missing or (for WOFF2) compressed away yields a
+// partial result rather than an error, because the live specimen still renders
+// from the same bytes regardless of what the tables said.
+export async function extractFontMetadata(
+  bytes: Uint8Array,
+): Promise<FontMetadata> {
+  let source = tableSourceFor(bytes);
+
+  let [nameTable, os2Table, headTable, maxpTable, fvarTable] =
+    await Promise.all([
+      source.getTable('name'),
+      source.getTable('OS/2'),
+      source.getTable('head'),
+      source.getTable('maxp'),
+      source.getTable('fvar'),
+    ]);
+
+  let names = nameTable ? parseNameTable(nameTable) : new Map<number, string>();
+  let os2 = os2Table ? parseOs2Table(os2Table) : {};
+
+  let glyphCount: number | undefined;
+  if (maxpTable && maxpTable.byteLength >= 6) {
+    let maxpView = new DataView(
+      maxpTable.buffer,
+      maxpTable.byteOffset,
+      maxpTable.byteLength,
+    );
+    glyphCount = maxpView.getUint16(4);
+  }
+
+  let unitsPerEm: number | undefined;
+  let macStyle: number | undefined;
+  if (headTable && headTable.byteLength >= 46) {
+    let headView = new DataView(
+      headTable.buffer,
+      headTable.byteOffset,
+      headTable.byteLength,
+    );
+    unitsPerEm = headView.getUint16(18);
+    macStyle = headView.getUint16(44);
+  }
+
+  // Prefer OS/2 fsSelection (italic bit 0, bold bit 5); fall back to head
+  // macStyle (bold bit 0, italic bit 1) when OS/2 is absent.
+  let isItalic: boolean | undefined;
+  let isBold: boolean | undefined;
+  if (os2.fsSelection !== undefined) {
+    isItalic = (os2.fsSelection & 0x01) !== 0;
+    isBold = (os2.fsSelection & 0x20) !== 0;
+  } else if (macStyle !== undefined) {
+    isBold = (macStyle & 0x01) !== 0;
+    isItalic = (macStyle & 0x02) !== 0;
+  }
+
+  let axes = fvarTable ? parseFvarAxes(fvarTable) : [];
+
+  return pruneUndefined({
+    familyName: names.get(NAME_TYPO_FAMILY) ?? names.get(NAME_FAMILY),
+    subfamilyName: names.get(NAME_TYPO_SUBFAMILY) ?? names.get(NAME_SUBFAMILY),
+    fullName: names.get(NAME_FULL),
+    postscriptName: names.get(NAME_POSTSCRIPT),
+    versionName: names.get(NAME_VERSION),
+    foundry: names.get(NAME_MANUFACTURER),
+    vendorId: os2.vendorId,
+    weightClass: os2.weightClass,
+    widthName: os2.widthName,
+    glyphCount,
+    unitsPerEm,
+    outlineType: outlineTypeFor(source),
+    isVariable: source.hasTable('fvar') ? true : undefined,
+    isItalic,
+    isBold,
+    axes,
+  });
+}

--- a/packages/base/otf-font-def.gts
+++ b/packages/base/otf-font-def.gts
@@ -1,0 +1,11 @@
+import { FontDef } from './font-file-def';
+
+// OpenType: a bare sfnt with `CFF `/`CFF2` PostScript outlines (the `OTTO`
+// flavor). Same uncompressed tables as TrueType, so it too indexes with full
+// metadata; only the outline technology differs.
+export class OtfDef extends FontDef {
+  static displayName = 'OpenType Font';
+  static acceptTypes = '.otf,font/otf';
+}
+
+export default OtfDef;

--- a/packages/base/ttf-font-def.gts
+++ b/packages/base/ttf-font-def.gts
@@ -1,0 +1,10 @@
+import { FontDef } from './font-file-def';
+
+// TrueType: a bare sfnt with `glyf` outlines. Its tables are uncompressed, so it
+// indexes with the fullest metadata of the four families.
+export class TtfDef extends FontDef {
+  static displayName = 'TrueType Font';
+  static acceptTypes = '.ttf,font/ttf';
+}
+
+export default TtfDef;

--- a/packages/base/woff-font-def.gts
+++ b/packages/base/woff-font-def.gts
@@ -1,0 +1,11 @@
+import { FontDef } from './font-file-def';
+
+// WOFF wraps an sfnt for the web with per-table zlib compression, which the
+// browser extract pass inflates on demand — so unlike WOFF2, a WOFF indexes with
+// full name/OS-2/glyph metadata.
+export class WoffDef extends FontDef {
+  static displayName = 'WOFF Font';
+  static acceptTypes = '.woff,font/woff';
+}
+
+export default WoffDef;

--- a/packages/base/woff2-font-def.gts
+++ b/packages/base/woff2-font-def.gts
@@ -1,0 +1,13 @@
+import { FontDef } from './font-file-def';
+
+// WOFF2 wraps an sfnt in a Brotli-compressed container for the web. The browser
+// decodes and renders it natively, so the live specimen is unaffected — but the
+// tables are Brotli-compressed with no browser-native decoder, so this is the
+// one font family that indexes without name/glyph metadata. The shells degrade
+// to the specimen and file identity.
+export class Woff2Def extends FontDef {
+  static displayName = 'WOFF2 Font';
+  static acceptTypes = '.woff2,font/woff2';
+}
+
+export default Woff2Def;

--- a/packages/host/tests/acceptance/font-def/ttf-font-def-test.gts
+++ b/packages/host/tests/acceptance/font-def/ttf-font-def-test.gts
@@ -1,0 +1,332 @@
+import { visit, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import {
+  baseRealmRRI,
+  type FileExtractResponse,
+  type RenderRouteOptions,
+  type ResolvedCodeRef,
+  SupportedMimeType,
+  type RealmResourceIdentifier,
+} from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common/realm';
+
+import type NetworkService from '@cardstack/host/services/network';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  setupRealmCacheTeardown,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  capturePrerenderResult,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupApplicationTest } from '../../helpers/setup';
+import { setupTestRealmServiceWorker } from '../../helpers/test-realm-service-worker';
+
+// A minimal but parser-valid TrueType face: the four tables the metadata reader
+// reads (name/OS-2/head/maxp) plus an empty `glyf` to mark it TrueType. It is
+// not a renderable outline font — the specimen's FontFace load fails and falls
+// back to the theme font — which is exactly what lets the render test assert the
+// specimen chrome without shipping a real binary.
+function utf16be(text: string): Uint8Array {
+  let bytes = new Uint8Array(text.length * 2);
+  let view = new DataView(bytes.buffer);
+  for (let i = 0; i < text.length; i++) {
+    view.setUint16(i * 2, text.charCodeAt(i));
+  }
+  return bytes;
+}
+
+function nameTable(records: { nameID: number; value: string }[]): Uint8Array {
+  let strings = records.map((r) => utf16be(r.value));
+  let recordArea = 6 + records.length * 12;
+  let storage = strings.reduce((sum, s) => sum + s.length, 0);
+  let table = new Uint8Array(recordArea + storage);
+  let view = new DataView(table.buffer);
+  view.setUint16(2, records.length);
+  view.setUint16(4, recordArea);
+  let cursor = 0;
+  records.forEach((r, i) => {
+    let rec = 6 + i * 12;
+    view.setUint16(rec, 3); // Windows
+    view.setUint16(rec + 2, 1); // Unicode BMP
+    view.setUint16(rec + 4, 0x0409); // US-English
+    view.setUint16(rec + 6, r.nameID);
+    view.setUint16(rec + 8, strings[i]!.length);
+    view.setUint16(rec + 10, cursor);
+    table.set(strings[i]!, recordArea + cursor);
+    cursor += strings[i]!.length;
+  });
+  return table;
+}
+
+function os2Table(): Uint8Array {
+  let table = new Uint8Array(78);
+  let view = new DataView(table.buffer);
+  view.setUint16(4, 600); // usWeightClass
+  view.setUint16(6, 5); // usWidthClass (normal)
+  'BOXL'.split('').forEach((c, i) => view.setUint8(58 + i, c.charCodeAt(0)));
+  return table;
+}
+
+function headTable(): Uint8Array {
+  let table = new Uint8Array(54);
+  new DataView(table.buffer).setUint16(18, 1000); // unitsPerEm
+  return table;
+}
+
+function maxpTable(numGlyphs: number): Uint8Array {
+  let table = new Uint8Array(6);
+  let view = new DataView(table.buffer);
+  view.setUint32(0, 0x00010000);
+  view.setUint16(4, numGlyphs);
+  return table;
+}
+
+function makeMinimalTtf(): Uint8Array {
+  let tables = [
+    { tag: 'OS/2', data: os2Table() },
+    { tag: 'head', data: headTable() },
+    { tag: 'maxp', data: maxpTable(96) },
+    {
+      tag: 'name',
+      data: nameTable([
+        { nameID: 1, value: 'Boxel Test Sans' },
+        { nameID: 4, value: 'Boxel Test Sans Regular' },
+      ]),
+    },
+    { tag: 'glyf', data: new Uint8Array(4) },
+  ];
+  let headerSize = 12 + tables.length * 16;
+  let cursor = headerSize;
+  let placed = tables.map((t) => {
+    let offset = cursor;
+    cursor += Math.ceil(t.data.length / 4) * 4;
+    return { ...t, offset };
+  });
+  let out = new Uint8Array(cursor);
+  let view = new DataView(out.buffer);
+  view.setUint32(0, 0x00010000); // sfnt version (TrueType)
+  view.setUint16(4, tables.length);
+  placed.forEach((t, i) => {
+    let rec = 12 + i * 16;
+    for (let j = 0; j < 4; j++) {
+      view.setUint8(rec + j, t.tag.charCodeAt(j));
+    }
+    view.setUint32(rec + 8, t.offset);
+    view.setUint32(rec + 12, t.data.length);
+    out.set(t.data, t.offset);
+  });
+  return out;
+}
+
+module('Acceptance | ttf font def', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+  setupRealmCacheTeardown(hooks);
+  setupTestRealmServiceWorker(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+  let realm: Realm;
+
+  const fileExtractPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/file-extract`;
+
+  const fileRenderPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    format = 'isolated',
+    ancestorLevel = 0,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/html/${format}/${ancestorLevel}`;
+
+  const makeFileURL = (path: string) => new URL(path, testRealmURL).href;
+
+  const ttfDefCodeRef = (): ResolvedCodeRef => ({
+    module: `${baseRealmRRI}ttf-font-def` as RealmResourceIdentifier,
+    name: 'TtfDef',
+  });
+
+  async function captureFileExtractResult(
+    expectedStatus?: 'ready' | 'error',
+  ): Promise<FileExtractResponse> {
+    await waitUntil(
+      () => {
+        let container = document.querySelector(
+          '[data-prerender-file-extract]',
+        ) as HTMLElement | null;
+        let status = container?.getAttribute(
+          'data-prerender-file-extract-status',
+        );
+        if (!status) {
+          return false;
+        }
+        if (expectedStatus && status !== expectedStatus) {
+          return false;
+        }
+        return status === 'ready' || status === 'error';
+      },
+      { timeout: 5000 },
+    );
+
+    let container = document.querySelector(
+      '[data-prerender-file-extract]',
+    ) as HTMLElement | null;
+    let pre = container?.querySelector('pre');
+    return JSON.parse(pre?.textContent?.trim() ?? '') as FileExtractResponse;
+  }
+
+  hooks.beforeEach(async function () {
+    ({ realm } = await withCachedRealmSetup(async () =>
+      setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'sample.ttf': makeMinimalTtf(),
+          'not-a-font.ttf': 'This is plain text, not a font file.',
+        },
+      }),
+    ));
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any).__renderModel;
+    delete (globalThis as any).__boxelFileRenderData;
+  });
+
+  test('extracts name, glyph count, and outline type from a TTF', async function (assert) {
+    let url = makeFileURL('sample.ttf');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: ttfDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(
+      result.searchDoc?.fontMetadata?.familyName,
+      'Boxel Test Sans',
+      'extracts the family name',
+    );
+    assert.strictEqual(
+      result.searchDoc?.fontMetadata?.glyphCount,
+      96,
+      'extracts the glyph count',
+    );
+    assert.strictEqual(
+      result.searchDoc?.fontMetadata?.outlineType,
+      'TrueType',
+      'names the outline technology',
+    );
+    assert.strictEqual(
+      result.searchDoc?.fontMetadata?.weightClass,
+      600,
+      'extracts the weight class',
+    );
+  });
+
+  test('falls back when TtfDef is used for non-font content', async function (assert) {
+    let url = makeFileURL('not-a-font.ttf');
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: ttfDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.true(result.mismatch, 'marks mismatch when content is not a font');
+    assert.strictEqual(result.searchDoc?.name, 'not-a-font.ttf');
+  });
+
+  test('isolated template renders the live specimen with the family name', async function (assert) {
+    let url = makeFileURL('sample.ttf');
+
+    await visit(
+      fileExtractPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: ttfDefCodeRef(),
+      }),
+    );
+    let result = await captureFileExtractResult('ready');
+    assert.ok(result.resource, 'extraction produced a resource');
+
+    (globalThis as any).__boxelFileRenderData = {
+      resource: result.resource,
+      fileDefCodeRef: ttfDefCodeRef(),
+    };
+
+    await visit(
+      fileRenderPath(url, {
+        fileRender: true,
+        fileDefCodeRef: ttfDefCodeRef(),
+      }),
+    );
+
+    let { status } = await capturePrerenderResult('innerHTML');
+    assert.strictEqual(status, 'ready', 'render completed');
+
+    let specimen = document.querySelector(
+      '[data-prerender] [data-test-font-specimen="isolated"]',
+    );
+    assert.ok(specimen, 'the isolated specimen is rendered');
+    assert.ok(
+      specimen?.textContent?.includes('Boxel Test Sans'),
+      'the specimen shows the extracted family name',
+    );
+  });
+
+  test('indexing stores font metadata and file meta uses it', async function (assert) {
+    let fileURL = new URL('sample.ttf', testRealmURL);
+    let fileEntry = await realm.realmIndexQueryEngine.file(fileURL);
+
+    assert.ok(fileEntry, 'file entry exists');
+    assert.strictEqual(
+      fileEntry?.searchDoc?.fontMetadata?.familyName,
+      'Boxel Test Sans',
+      'index stores the font family name',
+    );
+
+    let network = getService('network') as NetworkService;
+    let response = await network.virtualNetwork.fetch(fileURL, {
+      headers: { Accept: SupportedMimeType.FileMeta },
+    });
+
+    assert.true(response.ok, 'file meta request succeeds');
+
+    let body = await response.json();
+    assert.strictEqual(body?.data?.type, 'file-meta');
+    assert.strictEqual(
+      body?.data?.attributes?.fontMetadata?.familyName,
+      'Boxel Test Sans',
+      'file meta includes the font family name',
+    );
+    assert.deepEqual(
+      body?.data?.meta?.adoptsFrom,
+      ttfDefCodeRef(),
+      'file meta uses the TTF def',
+    );
+  });
+});

--- a/packages/host/tests/unit/file-def-code-ref-test.ts
+++ b/packages/host/tests/unit/file-def-code-ref-test.ts
@@ -59,6 +59,13 @@ module('Unit | isFileDefCodeRef', function (hooks) {
       ),
       'PngDef',
     );
+    assert.true(
+      isFileDefCodeRef(
+        { module: baseRRI('woff2-font-def'), name: 'Woff2Def' },
+        virtualNetwork,
+      ),
+      'Woff2Def',
+    );
   });
 
   test('rejects a non-FileDef card ref', function (assert) {

--- a/packages/host/tests/unit/font-metadata-extractor-test.ts
+++ b/packages/host/tests/unit/font-metadata-extractor-test.ts
@@ -1,0 +1,412 @@
+// Byte-level tests for the font metadata reader. Like the other extract
+// parsers, this runs inside the index pass against whatever bytes a realm holds,
+// so the contract is as much about degrading on malformed or unreadable input as
+// about parsing a well-formed face: a non-font must throw `FileContentMismatch`
+// so the extract falls back to a plain FileDef, and a real font whose tables are
+// missing or (for WOFF2) compressed away must return a partial result rather
+// than an empty error.
+//
+// Fixtures are assembled here rather than committed as binaries so each test
+// names the exact tables and header fields it depends on.
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type { Loader } from '@cardstack/runtime-common';
+
+import { setupRenderingTest } from '../helpers/setup';
+
+import type * as FontModule from '@cardstack/base/font-meta-extractor';
+
+// A UTF-16BE name string, the encoding the Windows-platform name records use.
+function utf16be(text: string): Uint8Array {
+  let bytes = new Uint8Array(text.length * 2);
+  let view = new DataView(bytes.buffer);
+  for (let i = 0; i < text.length; i++) {
+    view.setUint16(i * 2, text.charCodeAt(i));
+  }
+  return bytes;
+}
+
+interface NameRecordSpec {
+  nameID: number;
+  value: string;
+}
+
+// A `name` table of Windows (platform 3) / Unicode BMP (encoding 1) / US-English
+// (0x0409) records — the canonical specimen strings the reader scores highest.
+function nameTable(records: NameRecordSpec[]): Uint8Array {
+  let strings = records.map((r) => utf16be(r.value));
+  let recordArea = 6 + records.length * 12;
+  let storage = strings.reduce((sum, s) => sum + s.length, 0);
+  let table = new Uint8Array(recordArea + storage);
+  let view = new DataView(table.buffer);
+  view.setUint16(0, 0); // format
+  view.setUint16(2, records.length);
+  view.setUint16(4, recordArea); // storageOffset
+  let stringCursor = 0;
+  records.forEach((r, i) => {
+    let rec = 6 + i * 12;
+    view.setUint16(rec, 3); // platformID (Windows)
+    view.setUint16(rec + 2, 1); // encodingID (Unicode BMP)
+    view.setUint16(rec + 4, 0x0409); // languageID (US-English)
+    view.setUint16(rec + 6, r.nameID);
+    view.setUint16(rec + 8, strings[i]!.length);
+    view.setUint16(rec + 10, stringCursor);
+    table.set(strings[i]!, recordArea + stringCursor);
+    stringCursor += strings[i]!.length;
+  });
+  return table;
+}
+
+interface Os2Spec {
+  weightClass: number;
+  widthClass: number;
+  vendorId: string;
+  fsSelection: number;
+}
+
+function os2Table(spec: Os2Spec): Uint8Array {
+  let table = new Uint8Array(78); // OS/2 version 0
+  let view = new DataView(table.buffer);
+  view.setUint16(0, 0); // version
+  view.setUint16(4, spec.weightClass);
+  view.setUint16(6, spec.widthClass);
+  for (let i = 0; i < 4; i++) {
+    view.setUint8(58 + i, spec.vendorId.charCodeAt(i));
+  }
+  view.setUint16(62, spec.fsSelection);
+  return table;
+}
+
+function headTable(unitsPerEm: number, macStyle: number): Uint8Array {
+  let table = new Uint8Array(54);
+  let view = new DataView(table.buffer);
+  view.setUint16(18, unitsPerEm);
+  view.setUint16(44, macStyle);
+  return table;
+}
+
+function maxpTable(numGlyphs: number): Uint8Array {
+  let table = new Uint8Array(6);
+  let view = new DataView(table.buffer);
+  view.setUint32(0, 0x00010000); // version
+  view.setUint16(4, numGlyphs);
+  return table;
+}
+
+interface AxisSpec {
+  tag: string;
+  min: number;
+  def: number;
+  max: number;
+}
+
+function fvarTable(axes: AxisSpec[]): Uint8Array {
+  let axesOffset = 16;
+  let table = new Uint8Array(axesOffset + axes.length * 20);
+  let view = new DataView(table.buffer);
+  view.setUint16(0, 1); // majorVersion
+  view.setUint16(4, axesOffset);
+  view.setUint16(8, axes.length); // axisCount
+  view.setUint16(10, 20); // axisSize
+  axes.forEach((axis, i) => {
+    let rec = axesOffset + i * 20;
+    for (let j = 0; j < 4; j++) {
+      view.setUint8(rec + j, axis.tag.charCodeAt(j));
+    }
+    view.setInt32(rec + 4, axis.min * 65536);
+    view.setInt32(rec + 8, axis.def * 65536);
+    view.setInt32(rec + 12, axis.max * 65536);
+    view.setUint16(rec + 16, 0); // flags
+    view.setUint16(rec + 18, 256 + i); // axisNameID
+  });
+  return table;
+}
+
+interface TableSpec {
+  tag: string;
+  data: Uint8Array;
+}
+
+// Assemble a bare sfnt (TTF/OTF) from a table map, 4-byte aligning each table's
+// data the way real fonts do.
+function sfnt(flavor: number, tables: TableSpec[]): Uint8Array {
+  let headerSize = 12 + tables.length * 16;
+  let cursor = headerSize;
+  let placed = tables.map((t) => {
+    let offset = cursor;
+    cursor += Math.ceil(t.data.length / 4) * 4;
+    return { ...t, offset };
+  });
+  let out = new Uint8Array(cursor);
+  let view = new DataView(out.buffer);
+  view.setUint32(0, flavor);
+  view.setUint16(4, tables.length);
+  placed.forEach((t, i) => {
+    let rec = 12 + i * 16;
+    for (let j = 0; j < 4; j++) {
+      view.setUint8(rec + j, t.tag.charCodeAt(j));
+    }
+    view.setUint32(rec + 8, t.offset);
+    view.setUint32(rec + 12, t.data.length);
+    out.set(t.data, t.offset);
+  });
+  return out;
+}
+
+async function deflate(bytes: Uint8Array): Promise<Uint8Array> {
+  let stream = new Blob([bytes as BlobPart])
+    .stream()
+    .pipeThrough(new CompressionStream('deflate'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+// Assemble a WOFF from a table map. Each table is stored uncompressed unless
+// `compressedTags` names it, in which case its data is zlib-deflated and the
+// directory records the smaller compressed length.
+async function woff(
+  flavor: number,
+  tables: TableSpec[],
+  compressedTags: Set<string> = new Set(),
+): Promise<Uint8Array> {
+  let headerSize = 44 + tables.length * 20;
+  let blobs = await Promise.all(
+    tables.map(async (t) => {
+      if (compressedTags.has(t.tag)) {
+        let comp = await deflate(t.data);
+        return { tag: t.tag, comp, origLength: t.data.length };
+      }
+      return { tag: t.tag, comp: t.data, origLength: t.data.length };
+    }),
+  );
+  let cursor = headerSize;
+  let placed = blobs.map((b) => {
+    let offset = cursor;
+    cursor += Math.ceil(b.comp.length / 4) * 4;
+    return { ...b, offset };
+  });
+  let out = new Uint8Array(cursor);
+  let view = new DataView(out.buffer);
+  view.setUint32(0, 0x774f4646); // 'wOFF'
+  view.setUint32(4, flavor);
+  view.setUint32(8, out.length);
+  view.setUint16(12, tables.length);
+  placed.forEach((b, i) => {
+    let rec = 44 + i * 20;
+    for (let j = 0; j < 4; j++) {
+      view.setUint8(rec + j, b.tag.charCodeAt(j));
+    }
+    view.setUint32(rec + 4, b.offset);
+    view.setUint32(rec + 8, b.comp.length); // compLength
+    view.setUint32(rec + 12, b.origLength);
+    out.set(b.comp, b.offset);
+  });
+  return out;
+}
+
+// A WOFF2 header with no legible table body — the shape the reader can extract
+// nothing but the outline flavor from.
+function woff2Header(flavor: number): Uint8Array {
+  let out = new Uint8Array(48);
+  let view = new DataView(out.buffer);
+  view.setUint32(0, 0x774f4632); // 'wOF2'
+  view.setUint32(4, flavor);
+  view.setUint16(12, 4); // numTables
+  return out;
+}
+
+const SFNT_TRUETYPE = 0x00010000;
+const SFNT_OTTO = 0x4f54544f;
+
+// fsSelection bit 5 (bold); macStyle in `head` uses a different bit order,
+// tested separately via a font with no OS/2.
+const FS_BOLD = 0x20;
+
+// A complete TrueType face with every table the reader knows how to read.
+function completeTruetype(): Uint8Array {
+  return sfnt(SFNT_TRUETYPE, [
+    {
+      tag: 'OS/2',
+      data: os2Table({
+        weightClass: 700,
+        widthClass: 3,
+        vendorId: 'ACME',
+        fsSelection: FS_BOLD,
+      }),
+    },
+    { tag: 'head', data: headTable(2048, 0) },
+    { tag: 'maxp', data: maxpTable(1234) },
+    {
+      tag: 'name',
+      data: nameTable([
+        { nameID: 1, value: 'Legacy Family' },
+        { nameID: 2, value: 'Legacy Style' },
+        { nameID: 4, value: 'Acme Sans Bold' },
+        { nameID: 6, value: 'AcmeSans-Bold' },
+        { nameID: 8, value: 'Acme Type Foundry' },
+        { nameID: 16, value: 'Acme Sans' },
+        { nameID: 17, value: 'Bold' },
+      ]),
+    },
+    { tag: 'glyf', data: new Uint8Array(4) },
+  ]);
+}
+
+module('Unit | font metadata extractor', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let loader: Loader;
+  let extractFontMetadata: typeof FontModule.extractFontMetadata;
+
+  hooks.beforeEach(async function () {
+    loader = getService('loader-service').loader;
+    ({ extractFontMetadata } = await loader.import<typeof FontModule>(
+      '@cardstack/base/font-meta-extractor',
+    ));
+  });
+
+  test('reads name, OS/2, head, and maxp facts from a TrueType face', async function (assert) {
+    let metadata = await extractFontMetadata(completeTruetype());
+    // Typographic names (16/17) win over the legacy family/style pair (1/2).
+    assert.strictEqual(metadata.familyName, 'Acme Sans');
+    assert.strictEqual(metadata.subfamilyName, 'Bold');
+    assert.strictEqual(metadata.fullName, 'Acme Sans Bold');
+    assert.strictEqual(metadata.postscriptName, 'AcmeSans-Bold');
+    assert.strictEqual(metadata.foundry, 'Acme Type Foundry');
+    assert.strictEqual(metadata.vendorId, 'ACME');
+    assert.strictEqual(metadata.weightClass, 700);
+    assert.strictEqual(metadata.widthName, 'Condensed');
+    assert.strictEqual(metadata.glyphCount, 1234);
+    assert.strictEqual(metadata.unitsPerEm, 2048);
+    assert.strictEqual(metadata.outlineType, 'TrueType');
+    assert.true(metadata.isBold);
+    assert.false(metadata.isItalic);
+  });
+
+  test('names CFF outlines as PostScript', async function (assert) {
+    let metadata = await extractFontMetadata(
+      sfnt(SFNT_OTTO, [
+        { tag: 'CFF ', data: new Uint8Array(4) },
+        { tag: 'maxp', data: maxpTable(50) },
+        { tag: 'name', data: nameTable([{ nameID: 1, value: 'Acme Serif' }]) },
+      ]),
+    );
+    assert.strictEqual(metadata.outlineType, 'PostScript/CFF');
+    assert.strictEqual(metadata.familyName, 'Acme Serif');
+  });
+
+  test('reports variation axes for a variable font', async function (assert) {
+    let metadata = await extractFontMetadata(
+      sfnt(SFNT_TRUETYPE, [
+        { tag: 'maxp', data: maxpTable(80) },
+        { tag: 'glyf', data: new Uint8Array(4) },
+        {
+          tag: 'fvar',
+          data: fvarTable([
+            { tag: 'wght', min: 100, def: 400, max: 900 },
+            { tag: 'wdth', min: 75, def: 100, max: 125 },
+          ]),
+        },
+      ]),
+    );
+    assert.true(metadata.isVariable);
+    assert.deepEqual(metadata.axes, [
+      'Weight (wght) 100–900',
+      'Width (wdth) 75–125',
+    ]);
+  });
+
+  test('falls back to the legacy family/style names when no typographic pair exists', async function (assert) {
+    let metadata = await extractFontMetadata(
+      sfnt(SFNT_TRUETYPE, [
+        { tag: 'glyf', data: new Uint8Array(4) },
+        {
+          tag: 'name',
+          data: nameTable([
+            { nameID: 1, value: 'Plain Family' },
+            { nameID: 2, value: 'Regular' },
+          ]),
+        },
+      ]),
+    );
+    assert.strictEqual(metadata.familyName, 'Plain Family');
+    assert.strictEqual(metadata.subfamilyName, 'Regular');
+  });
+
+  test('derives style from head macStyle when OS/2 is absent', async function (assert) {
+    // macStyle bit 0 is bold, bit 1 is italic — the opposite order from OS/2.
+    let metadata = await extractFontMetadata(
+      sfnt(SFNT_TRUETYPE, [
+        { tag: 'glyf', data: new Uint8Array(4) },
+        { tag: 'head', data: headTable(1000, 0x02) },
+      ]),
+    );
+    assert.true(metadata.isItalic);
+    assert.false(metadata.isBold);
+    assert.strictEqual(metadata.weightClass, undefined, 'no OS/2, no weight');
+  });
+
+  test('reads the same facts through an uncompressed WOFF wrapper', async function (assert) {
+    let bytes = await woff(SFNT_TRUETYPE, [
+      { tag: 'maxp', data: maxpTable(321) },
+      { tag: 'glyf', data: new Uint8Array(4) },
+      { tag: 'name', data: nameTable([{ nameID: 1, value: 'Woff Family' }]) },
+    ]);
+    let metadata = await extractFontMetadata(bytes);
+    assert.strictEqual(metadata.familyName, 'Woff Family');
+    assert.strictEqual(metadata.glyphCount, 321);
+    assert.strictEqual(metadata.outlineType, 'TrueType');
+  });
+
+  test('inflates a zlib-compressed WOFF table', async function (assert) {
+    // A well-formed WOFF only stores a table compressed when that actually
+    // shrinks it, so the fixture's name table carries a long repetitive filler
+    // record (an ID the reader ignores) to make it genuinely compressible.
+    let bytes = await woff(
+      SFNT_TRUETYPE,
+      [
+        { tag: 'glyf', data: new Uint8Array(4) },
+        {
+          tag: 'name',
+          data: nameTable([
+            { nameID: 1, value: 'Compressed Family' },
+            { nameID: 256, value: 'padding '.repeat(64) },
+          ]),
+        },
+      ],
+      new Set(['name']),
+    );
+    let metadata = await extractFontMetadata(bytes);
+    assert.strictEqual(metadata.familyName, 'Compressed Family');
+  });
+
+  test('reads only the outline flavor from a WOFF2, whose tables are Brotli-compressed', async function (assert) {
+    let metadata = await extractFontMetadata(woff2Header(SFNT_TRUETYPE));
+    assert.strictEqual(metadata.outlineType, 'TrueType');
+    assert.strictEqual(metadata.familyName, undefined, 'no legible name table');
+    assert.strictEqual(metadata.glyphCount, undefined, 'no legible maxp table');
+  });
+
+  test('throws a content mismatch on non-font bytes so the extract falls back', async function (assert) {
+    let notAFont = new Uint8Array([
+      0x25, 0x50, 0x44, 0x46, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+    await assert.rejects(
+      extractFontMetadata(notAFont),
+      /recognized font signature/,
+    );
+  });
+
+  test('degrades to a partial result when a declared table is out of bounds', async function (assert) {
+    // A directory that points a table past the end of the buffer must not throw
+    // out of the extract; the reader skips what it can't reach.
+    let bytes = completeTruetype();
+    let view = new DataView(bytes.buffer);
+    // Corrupt the first table's offset to point past the file.
+    view.setUint32(12 + 8, bytes.length + 1000);
+    let metadata = await extractFontMetadata(bytes);
+    // Other tables still read; the extract survives.
+    assert.strictEqual(metadata.outlineType, 'TrueType');
+  });
+});

--- a/packages/host/tests/unit/font-metadata-extractor-test.ts
+++ b/packages/host/tests/unit/font-metadata-extractor-test.ts
@@ -409,4 +409,41 @@ module('Unit | font metadata extractor', function (hooks) {
     // Other tables still read; the extract survives.
     assert.strictEqual(metadata.outlineType, 'TrueType');
   });
+
+  test('rejects a truncated WOFF header instead of throwing a RangeError', async function (assert) {
+    // A stream that starts `wOFF` but is shorter than the 44-byte header would
+    // read past its end; it must surface as a content mismatch — degrading to
+    // the plain FileDef — rather than a RangeError that fails the whole extract.
+    let truncated = new Uint8Array(20);
+    new DataView(truncated.buffer).setUint32(0, 0x774f4646); // 'wOFF'
+    await assert.rejects(
+      extractFontMetadata(truncated),
+      /WOFF header is truncated/,
+    );
+  });
+
+  test('reports a TrueType Collection as a font without walking into a face', async function (assert) {
+    // A `ttcf` header is not an sfnt table directory, so the reader recognizes
+    // the collection from its flavor but exposes no tables rather than misreading
+    // the TTC version and face count as `numTables` and a table record.
+    let ttc = new Uint8Array(16);
+    let view = new DataView(ttc.buffer);
+    view.setUint32(0, 0x74746366); // 'ttcf'
+    view.setUint16(4, 1); // majorVersion
+    view.setUint16(6, 0); // minorVersion
+    view.setUint32(8, 1); // numFonts
+    view.setUint32(12, 16); // offset to the first face
+    let metadata = await extractFontMetadata(ttc);
+    assert.strictEqual(
+      metadata.outlineType,
+      'TrueType',
+      'recognized as a font',
+    );
+    assert.strictEqual(
+      metadata.familyName,
+      undefined,
+      'no table is walked, so no name is invented',
+    );
+    assert.strictEqual(metadata.glyphCount, undefined, 'no maxp is read');
+  });
 });

--- a/packages/host/tests/unit/font-metadata-extractor-test.ts
+++ b/packages/host/tests/unit/font-metadata-extractor-test.ts
@@ -422,22 +422,30 @@ module('Unit | font metadata extractor', function (hooks) {
     );
   });
 
-  test('reports a TrueType Collection as a font without walking into a face', async function (assert) {
-    // A `ttcf` header is not an sfnt table directory, so the reader recognizes
-    // the collection from its flavor but exposes no tables rather than misreading
-    // the TTC version and face count as `numTables` and a table record.
-    let ttc = new Uint8Array(16);
+  // A `ttcf` header whose byte-12 offset points to a first face carrying the
+  // given sfnt version — enough to name the collection's outline flavor without
+  // any face's table directory.
+  function ttcFixture(faceVersion: number): Uint8Array {
+    let ttc = new Uint8Array(28);
     let view = new DataView(ttc.buffer);
     view.setUint32(0, 0x74746366); // 'ttcf'
     view.setUint16(4, 1); // majorVersion
     view.setUint16(6, 0); // minorVersion
     view.setUint32(8, 1); // numFonts
-    view.setUint32(12, 16); // offset to the first face
-    let metadata = await extractFontMetadata(ttc);
+    view.setUint32(12, 16); // offset to the first face's sfnt header
+    view.setUint32(16, faceVersion); // that face's sfnt version
+    return ttc;
+  }
+
+  test('reports a TrueType Collection as a font without walking into a face', async function (assert) {
+    // A `ttcf` header is not an sfnt table directory, so the reader recognizes
+    // the collection but exposes no tables rather than misreading the TTC version
+    // and face count as `numTables` and a table record.
+    let metadata = await extractFontMetadata(ttcFixture(SFNT_TRUETYPE));
     assert.strictEqual(
       metadata.outlineType,
       'TrueType',
-      'recognized as a font',
+      'flavor read from the first face',
     );
     assert.strictEqual(
       metadata.familyName,
@@ -445,5 +453,13 @@ module('Unit | font metadata extractor', function (hooks) {
       'no table is walked, so no name is invented',
     );
     assert.strictEqual(metadata.glyphCount, undefined, 'no maxp is read');
+  });
+
+  test('names an OpenType Collection by its first face rather than defaulting to TrueType', async function (assert) {
+    // The `ttcf` signature carries no outline flavor, so a collection of CFF
+    // faces must be read from the first face's `OTTO` version, not reported as
+    // TrueType by default.
+    let metadata = await extractFontMetadata(ttcFixture(SFNT_OTTO));
+    assert.strictEqual(metadata.outlineType, 'PostScript/CFF');
   });
 });

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -51,6 +51,10 @@ const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
   '.m4v': { module: baseModule('mp4-video-def'), name: 'Mp4Def' },
   '.mov': { module: baseModule('mov-video-def'), name: 'MovDef' },
   '.webm': { module: baseModule('webm-video-def'), name: 'WebmDef' },
+  '.woff2': { module: baseModule('woff2-font-def'), name: 'Woff2Def' },
+  '.woff': { module: baseModule('woff-font-def'), name: 'WoffDef' },
+  '.ttf': { module: baseModule('ttf-font-def'), name: 'TtfDef' },
+  '.otf': { module: baseModule('otf-font-def'), name: 'OtfDef' },
   '.mismatch': {
     module: './filedef-mismatch' as RealmResourceIdentifier,
     name: 'FileDef',


### PR DESCRIPTION
High-quality atom / fitted / embedded / isolated rendering for the font FileDef families — WOFF2, WOFF, TTF, OTF (CS-12242).

## What this adds
Web fonts (WOFF2/WOFF) and desktop fonts (TTF/OTF) share one renderer and one metadata shape, because once the container is unwrapped they are the same sfnt tables. The four shared shells mount a single live FontFace specimen for every subclass, and only the labeled kind differs per extension.

- **`font-meta-extractor.ts`** — reads name / OS-2 / head / maxp / fvar facts and outline technology (TrueType vs PostScript-CFF) from bare sfnt and from WOFF (per-table zlib via `DecompressionStream`), and the outline flavor from a WOFF2 header. A non-font throws `FileContentMismatchError` so the extract falls back to a plain FileDef.
- **`FontMetadataField`** — carries family / subfamily / full / PostScript names, foundry/vendor, weight, width, glyph count, em grid, outline type, and variation axes. The isolated inspector already mounts it via `<@fields.fontMetadata />`.
- **`FontSpecimen`** — renders the real linked face into each format: a showcase glyph pair (fitted), a name plus pangram (embedded), and a waterfall with a character map (isolated).
- **`Woff2Def` / `WoffDef` / `TtfDef` / `OtfDef`** — route `.woff2` / `.woff` / `.ttf` / `.otf` to the family.

## Metadata coverage
TTF, OTF, and WOFF index with full metadata. WOFF2 tables are Brotli-compressed and no browser exposes a Brotli decoder, so a WOFF2 indexes with the outline flavor only — but its **live specimen renders fully**, since the browser decodes WOFF2 natively.

## Tests
- Unit test builds synthetic sfnt / WOFF / WOFF2 fixtures and covers name/OS-2/head/maxp/fvar reads, the CFF-vs-TrueType split, WOFF zlib inflation, WOFF2 header-only reads, the non-font mismatch, and out-of-bounds degradation.
- Acceptance test drives extract → index → isolated render against a synthetic TTF and asserts the live specimen and stored metadata.
- The existing `experiments-realm` `FileDefFormatPreview` cards for the four extensions now resolve to these classes automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)