### PR TITLE
Harden two CI flakes: Synapse readiness gate and AI-assistant room helper

### DIFF
--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -2224,9 +2224,25 @@ export async function addSkillToAiAssistant(
   skillCardId: string,
   roomId?: string,
 ) {
-  let resolvedRoomId =
-    roomId ??
-    document.querySelector('[data-test-room]')?.getAttribute('data-test-room');
+  // The room element can lag the click that opened or created the room: room
+  // creation resolves through async matrix operations, so `[data-test-room]`
+  // may not carry the id yet in the runloop the caller reached. Waiting for it
+  // rather than reading a single snapshot is what removes the intermittent
+  // "Expected an active AI assistant room" failure; a genuine absence still
+  // surfaces the same message when the wait times out.
+  let resolvedRoomId = roomId;
+  if (!resolvedRoomId) {
+    resolvedRoomId = (await waitUntil(
+      () =>
+        document
+          .querySelector('[data-test-room]')
+          ?.getAttribute('data-test-room'),
+      {
+        timeout: 5000,
+        timeoutMessage: `Expected an active AI assistant room before adding skill "${skillCardId}"`,
+      },
+    )) as string;
+  }
 
   if (!resolvedRoomId) {
     throw new Error(

--- a/packages/matrix/scripts/register-matrix-users.ts
+++ b/packages/matrix/scripts/register-matrix-users.ts
@@ -67,20 +67,32 @@ const EXTRA_USERS: ExtraUser[] = [
 ];
 
 async function waitForSynapse(): Promise<void> {
-  const url = getSynapseURL();
-  const maxAttempts = 24;
+  const base = getSynapseURL().replace(/\/$/, '');
+  // `/_matrix/client/versions` returns 200 only once Synapse has finished
+  // booting and running its database migrations, so it is a truer readiness
+  // signal than a HEAD on the root (which can answer non-2xx while the server
+  // is still coming up, or 404 depending on config).
+  const url = `${base}/_matrix/client/versions`;
+  // The budget is deliberately generous. On a cold or loaded CI runner the
+  // image pull and migrations can take minutes, and a too-tight window took out
+  // the whole test shard before a single test ran rather than tolerating a slow
+  // start.
+  const maxAttempts = 60;
+  const intervalMs = 5000;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
-      const res = await fetch(url, { method: 'HEAD' });
+      const res = await fetch(url);
       if (res.ok) return;
     } catch {
       // fall through to retry
     }
     process.stdout.write('.');
-    await new Promise((r) => setTimeout(r, 5000));
+    await new Promise((r) => setTimeout(r, intervalMs));
   }
   throw new Error(
-    `Failed to reach Synapse at ${url} after ${maxAttempts} attempts.`,
+    `Failed to reach Synapse at ${url} after ${maxAttempts} attempts (~${Math.round(
+      (maxAttempts * intervalMs) / 1000,
+    )}s).`,
   );
 }
 


### PR DESCRIPTION
Two intermittent CI failures, both **timing races in the test harness** rather than product defects. Surfaced while investigating red checks on the FileDef PRs (#5774, #5775, #5777), where these flakes hit unrelated shards.

## Synapse readiness gate — `packages/matrix/scripts/register-matrix-users.ts`
`waitForSynapse` polled a `HEAD` on the homeserver root with a hard **24 × 5s = 120-second** budget. On a cold or loaded runner the image pull + DB migrations can take longer, and when they did the gate threw — taking out the **entire test shard before a single test ran** (this is what failed #5777: 0 tests executed).

- Polls **`/_matrix/client/versions`** instead — it returns 200 only once Synapse has finished migrating, a truer signal than a root `HEAD` that can answer non-2xx mid-boot.
- Widens the budget to **60 × 5s (~5 min)** so a slow start is tolerated rather than fatal.

## AI-assistant room helper — `packages/host/tests/helpers/index.gts`
`addSkillToAiAssistant` read `[data-test-room]` in a **single synchronous snapshot** and threw *"Expected an active AI assistant room"* if it was absent. But room creation resolves through async Matrix operations, so a caller that has just clicked "new room" can reach the helper a runloop before the element carries the new id (this is what failed #5774's Tools test).

- Now **waits** for the room element (up to 5s) instead of snapshotting it.
- A genuine absence still surfaces the same error message when the wait times out.
- Fixed at the helper, so **every caller benefits**, not just one test.

## Validation
- `ember-tsc --noEmit` on both `packages/host` and `packages/matrix`: **0 errors**.
- Neither change alters product code — both are test-harness timing hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)