### PR TITLE
Widen and correct the Synapse readiness gate in CI

### DIFF
--- a/packages/matrix/scripts/register-matrix-users.ts
+++ b/packages/matrix/scripts/register-matrix-users.ts
@@ -67,20 +67,32 @@ const EXTRA_USERS: ExtraUser[] = [
 ];
 
 async function waitForSynapse(): Promise<void> {
-  const url = getSynapseURL();
-  const maxAttempts = 24;
+  const base = getSynapseURL().replace(/\/$/, '');
+  // `/_matrix/client/versions` returns 200 only once Synapse has finished
+  // booting and running its database migrations, so it is a truer readiness
+  // signal than a HEAD on the root (which can answer non-2xx while the server
+  // is still coming up, or 404 depending on config).
+  const url = `${base}/_matrix/client/versions`;
+  // The budget is deliberately generous. On a cold or loaded CI runner the
+  // image pull and migrations can take minutes, and a too-tight window took out
+  // the whole test shard before a single test ran rather than tolerating a slow
+  // start.
+  const maxAttempts = 60;
+  const intervalMs = 5000;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
-      const res = await fetch(url, { method: 'HEAD' });
+      const res = await fetch(url);
       if (res.ok) return;
     } catch {
       // fall through to retry
     }
     process.stdout.write('.');
-    await new Promise((r) => setTimeout(r, 5000));
+    await new Promise((r) => setTimeout(r, intervalMs));
   }
   throw new Error(
-    `Failed to reach Synapse at ${url} after ${maxAttempts} attempts.`,
+    `Failed to reach Synapse at ${url} after ${maxAttempts} attempts (~${Math.round(
+      (maxAttempts * intervalMs) / 1000,
+    )}s).`,
   );
 }
 


### PR DESCRIPTION
`waitForSynapse` (in `packages/matrix/scripts/register-matrix-users.ts`) polled a `HEAD` on the homeserver root with a hard **24 × 5s = 120-second** budget and no backoff. On a cold or loaded CI runner the image pull + database migrations can take longer, and when they did the gate threw — taking out the **entire test shard before a single test ran**.

- Polls **`/_matrix/client/versions`** instead — it returns 200 only once Synapse has finished migrating, a truer readiness signal than a root `HEAD` that can answer non-2xx mid-boot.
- Widens the budget to **60 × 5s (~5 min)** so a slow start is tolerated rather than fatal.

Test-harness timing only; no product code. `ember-tsc --noEmit` on `packages/matrix`: 0 errors.

Split out of #5779 (paired with the AI-assistant room-helper fix, now its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)