### PR TITLE
Wait for the AI-assistant room element instead of snapshotting it

### DIFF
--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -2224,9 +2224,25 @@ export async function addSkillToAiAssistant(
   skillCardId: string,
   roomId?: string,
 ) {
-  let resolvedRoomId =
-    roomId ??
-    document.querySelector('[data-test-room]')?.getAttribute('data-test-room');
+  // The room element can lag the click that opened or created the room: room
+  // creation resolves through async matrix operations, so `[data-test-room]`
+  // may not carry the id yet in the runloop the caller reached. Waiting for it
+  // rather than reading a single snapshot is what removes the intermittent
+  // "Expected an active AI assistant room" failure; a genuine absence still
+  // surfaces the same message when the wait times out.
+  let resolvedRoomId = roomId;
+  if (!resolvedRoomId) {
+    resolvedRoomId = (await waitUntil(
+      () =>
+        document
+          .querySelector('[data-test-room]')
+          ?.getAttribute('data-test-room'),
+      {
+        timeout: 5000,
+        timeoutMessage: `Expected an active AI assistant room before adding skill "${skillCardId}"`,
+      },
+    )) as string;
+  }
 
   if (!resolvedRoomId) {
     throw new Error(


### PR DESCRIPTION
`addSkillToAiAssistant` (in `packages/host/tests/helpers/index.gts`) read `[data-test-room]` in a **single synchronous snapshot** and threw *"Expected an active AI assistant room"* if it was absent. But room creation resolves through async Matrix operations, so a caller that has just clicked "new room" can reach the helper a runloop before the element carries the new id — an intermittent failure rather than a real one.

- Now **waits** for the room element (up to 5s) instead of snapshotting it.
- A genuine absence still surfaces the same error message when the wait times out.
- Fixed at the helper, so **every caller benefits**, not just one test.

Test-harness timing only; no product code. `ember-tsc --noEmit` on `packages/host`: 0 errors.

Split out of #5779 (paired with the Synapse readiness-gate fix, now its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)