### PR TITLE
Single-source the fitted-format envelopes; pin boxel-ui's copy

### DIFF
--- a/packages/experiments-realm/filedef-fixtures/SOURCES.md
+++ b/packages/experiments-realm/filedef-fixtures/SOURCES.md
@@ -46,7 +46,7 @@ The three levels have different jobs:
 
 ## Integrity manifest
 
-Fixture bytes are committed to the repository and served by the realm directly from disk. The `samples/` tree is exempt from repository formatting tools so these bytes stay stable; any intentional change to a fixture must update its row here. A mismatch between this manifest and the file on disk means the fixture no longer matches its recorded provenance.
+Fixture bytes are committed to the repository and served by the realm directly from disk. The `samples/` tree is exempt from repository formatting tools so these bytes stay stable; any intentional change to a fixture must update its row here. Nothing recomputes these hashes automatically — the manifest is a reference for manual audits. To check a fixture's provenance, hash it (`shasum -a 256 samples/<file>`) and compare against its row; a mismatch means the fixture no longer matches its recorded provenance and should be re-verified against its listed source.
 
 | File                            | Bytes   | SHA-256                                                          |
 | ------------------------------- | ------- | ---------------------------------------------------------------- |

--- a/packages/experiments-realm/filedef-fixtures/format-preview.gts
+++ b/packages/experiments-realm/filedef-fixtures/format-preview.gts
@@ -11,49 +11,14 @@ import LayoutDashboardIcon from '@cardstack/boxel-icons/layout-dashboard';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 import { fn, get } from '@ember/helper';
+import { htmlSafe } from '@ember/template';
+import { FITTED_FORMATS } from '@cardstack/runtime-common';
 
-// The 16 host-owned fitted envelopes. These mirror FITTED_FORMATS in
-// runtime-common/formats.ts (which card modules cannot import), so the
-// dimensions here are the host's pixel specs, not layout choices — keep them
-// in px and keep them in sync with that list.
-const FORMAT_GROUPS = [
-  {
-    label: 'Badges',
-    formats: [
-      { key: 'badge-s', name: 'Small Badge', w: 150, h: 40 },
-      { key: 'badge-m', name: 'Medium Badge', w: 150, h: 65 },
-      { key: 'badge-l', name: 'Large Badge', w: 150, h: 105 },
-    ],
-  },
-  {
-    label: 'Strips',
-    formats: [
-      { key: 'strip-1', name: 'Single Strip', w: 250, h: 40 },
-      { key: 'strip-2', name: 'Double Strip', w: 250, h: 65 },
-      { key: 'strip-3', name: 'Triple Strip', w: 250, h: 105 },
-      { key: 'strip-wide-2', name: 'Double Wide Strip', w: 400, h: 65 },
-      { key: 'strip-wide-3', name: 'Triple Wide Strip', w: 400, h: 105 },
-    ],
-  },
-  {
-    label: 'Tiles',
-    formats: [
-      { key: 'tile-s', name: 'Small Tile', w: 150, h: 170 },
-      { key: 'tile-r', name: 'Regular Tile', w: 250, h: 170 },
-      { key: 'tile-grid', name: 'CardsGrid Tile', w: 170, h: 250 },
-      { key: 'tile-tall', name: 'Tall Tile', w: 150, h: 275 },
-      { key: 'tile-l', name: 'Large Tile', w: 250, h: 275 },
-    ],
-  },
-  {
-    label: 'Cards',
-    formats: [
-      { key: 'card-c', name: 'Compact Card', w: 400, h: 170 },
-      { key: 'card-f', name: 'Full Card', w: 400, h: 275 },
-      { key: 'card-x', name: 'Expanded Card', w: 400, h: 445 },
-    ],
-  },
-];
+// Each envelope frame gets the host's exact pixel spec inline, so the boxes
+// below are always the sizes the host actually renders fitted cards at.
+function frameSize({ width, height }: { width: number; height: number }) {
+  return htmlSafe(`width: ${width}px; height: ${height}px`);
+}
 
 type PreviewItem = {
   index: number;
@@ -258,17 +223,17 @@ class FormatPreviewIsolated extends Component<typeof FileDefFormatPreview> {
           </div>
 
           <div class='format-collage'>
-            {{#each FORMAT_GROUPS as |group|}}
+            {{#each FITTED_FORMATS as |group|}}
               <section class='format-group'>
-                <h3>{{group.label}}</h3>
+                <h3>{{group.name}}</h3>
                 <div class='format-list'>
-                  {{#each group.formats as |fmt|}}
+                  {{#each group.specs as |spec|}}
                     <article class='format-item'>
                       <div class='format-label'>
-                        <strong>{{fmt.name}}</strong>
-                        <span>{{fmt.w}} × {{fmt.h}}</span>
+                        <strong>{{spec.title}}</strong>
+                        <span>{{spec.width}} × {{spec.height}}</span>
                       </div>
-                      <div class='format-frame size-{{fmt.key}}'>
+                      <div class='format-frame' style={{frameSize spec}}>
                         {{#let
                           (get @fields.previewFiles this.selectedFieldIndex)
                           as |FileField|
@@ -522,71 +487,6 @@ class FormatPreviewIsolated extends Component<typeof FileDefFormatPreview> {
         min-height: 0;
         overflow: hidden;
         background: var(--card);
-      }
-      /* Envelope frames are the host's pixel specs (see FORMAT_GROUPS). */
-      .size-badge-s {
-        width: 150px;
-        height: 40px;
-      }
-      .size-badge-m {
-        width: 150px;
-        height: 65px;
-      }
-      .size-badge-l {
-        width: 150px;
-        height: 105px;
-      }
-      .size-strip-1 {
-        width: 250px;
-        height: 40px;
-      }
-      .size-strip-2 {
-        width: 250px;
-        height: 65px;
-      }
-      .size-strip-3 {
-        width: 250px;
-        height: 105px;
-      }
-      .size-strip-wide-2 {
-        width: 400px;
-        height: 65px;
-      }
-      .size-strip-wide-3 {
-        width: 400px;
-        height: 105px;
-      }
-      .size-tile-s {
-        width: 150px;
-        height: 170px;
-      }
-      .size-tile-r {
-        width: 250px;
-        height: 170px;
-      }
-      .size-tile-grid {
-        width: 170px;
-        height: 250px;
-      }
-      .size-tile-tall {
-        width: 150px;
-        height: 275px;
-      }
-      .size-tile-l {
-        width: 250px;
-        height: 275px;
-      }
-      .size-card-c {
-        width: 400px;
-        height: 170px;
-      }
-      .size-card-f {
-        width: 400px;
-        height: 275px;
-      }
-      .size-card-x {
-        width: 400px;
-        height: 445px;
       }
       .format-panel {
         display: grid;

--- a/packages/realm-server/tests/fitted-formats-parity-test.ts
+++ b/packages/realm-server/tests/fitted-formats-parity-test.ts
@@ -4,22 +4,11 @@ import { readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { FITTED_FORMATS } from '@cardstack/runtime-common';
 
-// Two places in the repo carry a hand-maintained copy of the fitted envelope
-// specs, because neither can import runtime-common's FITTED_FORMATS: the
-// filedef-fixtures format-preview harness (a card module, loaded through the
-// realm) and boxel-ui (which must not depend on runtime-common). These tests
-// pin both copies — and the harness's paired .size-* CSS blocks — to the
-// canonical list so an edit to any of them fails loudly instead of letting
-// the copies drift.
+// boxel-ui carries a hand-maintained copy of the fitted envelope specs,
+// because as a standalone design-system package it must not depend on
+// runtime-common. This test pins that copy to the canonical FITTED_FORMATS
+// so an edit to either list fails loudly instead of letting the two drift.
 
-const HARNESS_PATH = join(
-  import.meta.dirname,
-  '..',
-  '..',
-  'experiments-realm',
-  'filedef-fixtures',
-  'format-preview.gts',
-);
 const BOXEL_UI_PATH = join(
   import.meta.dirname,
   '..',
@@ -30,10 +19,10 @@ const BOXEL_UI_PATH = join(
   'fitted-formats.ts',
 );
 
-// The copies live in modules this suite cannot import (a .gts card module and
-// a v2-addon source file), so we lift the array literal out of the source
-// text and evaluate it. The literals are plain data — no identifiers — so the
-// evaluation cannot reach anything else.
+// The copy lives in a v2-addon source file this suite cannot import, so we
+// lift the array literal out of the source text and evaluate it. The literal
+// is plain data — no identifiers — so the evaluation cannot reach anything
+// else.
 function extractArrayLiteral(filePath: string, declaration: string): unknown {
   let source = readFileSync(filePath, 'utf8');
   let match = source.match(
@@ -51,63 +40,7 @@ function extractArrayLiteral(filePath: string, declaration: string): unknown {
   return new Function(`return ${match[1]};`)();
 }
 
-type HarnessGroup = {
-  label: string;
-  formats: { key: string; name: string; w: number; h: number }[];
-};
-
 module(basename(import.meta.filename), function () {
-  test('the format-preview harness envelopes match FITTED_FORMATS', function (assert) {
-    let harnessGroups = extractArrayLiteral(
-      HARNESS_PATH,
-      'FORMAT_GROUPS',
-    ) as HarnessGroup[];
-
-    // The harness uses its own short keys for CSS class names, so parity is
-    // asserted on everything except the key: group names, titles, and pixel
-    // dimensions, in order.
-    assert.deepEqual(
-      harnessGroups.map((group) => ({
-        label: group.label,
-        formats: group.formats.map(({ name, w, h }) => ({ name, w, h })),
-      })),
-      FITTED_FORMATS.map((group) => ({
-        label: group.name,
-        formats: group.specs.map((spec) => ({
-          name: spec.title,
-          w: spec.width,
-          h: spec.height,
-        })),
-      })),
-    );
-  });
-
-  test('the format-preview .size-* CSS blocks match the envelope dimensions', function (assert) {
-    let harnessGroups = extractArrayLiteral(
-      HARNESS_PATH,
-      'FORMAT_GROUPS',
-    ) as HarnessGroup[];
-    let source = readFileSync(HARNESS_PATH, 'utf8');
-
-    let cssSizes = new Map<string, { w: number; h: number }>();
-    for (let [, key, w, h] of source.matchAll(
-      /\.size-([a-z0-9-]+)\s*\{\s*width:\s*(\d+)px;\s*height:\s*(\d+)px;\s*\}/g,
-    )) {
-      cssSizes.set(key, { w: Number(w), h: Number(h) });
-    }
-
-    let envelopeSizes = new Map(
-      harnessGroups.flatMap((group) =>
-        group.formats.map(({ key, w, h }) => [key, { w, h }] as const),
-      ),
-    );
-    assert.deepEqual(
-      Object.fromEntries(cssSizes),
-      Object.fromEntries(envelopeSizes),
-      'every envelope has a .size-* block with the same dimensions, and no extras',
-    );
-  });
-
   test("boxel-ui's FITTED_FORMATS copy matches runtime-common's", function (assert) {
     assert.deepEqual(
       extractArrayLiteral(BOXEL_UI_PATH, 'FITTED_FORMATS'),

--- a/packages/realm-server/tests/fitted-formats-parity-test.ts
+++ b/packages/realm-server/tests/fitted-formats-parity-test.ts
@@ -36,7 +36,6 @@ function extractArrayLiteral(filePath: string, declaration: string): unknown {
       `could not find "const ${declaration} = [...]" in ${filePath}`,
     );
   }
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
   return new Function(`return ${match[1]};`)();
 }
 

--- a/packages/realm-server/tests/fitted-formats-parity-test.ts
+++ b/packages/realm-server/tests/fitted-formats-parity-test.ts
@@ -1,0 +1,117 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { FITTED_FORMATS } from '@cardstack/runtime-common';
+
+// Two places in the repo carry a hand-maintained copy of the fitted envelope
+// specs, because neither can import runtime-common's FITTED_FORMATS: the
+// filedef-fixtures format-preview harness (a card module, loaded through the
+// realm) and boxel-ui (which must not depend on runtime-common). These tests
+// pin both copies — and the harness's paired .size-* CSS blocks — to the
+// canonical list so an edit to any of them fails loudly instead of letting
+// the copies drift.
+
+const HARNESS_PATH = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'experiments-realm',
+  'filedef-fixtures',
+  'format-preview.gts',
+);
+const BOXEL_UI_PATH = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  'boxel-ui',
+  'src',
+  'utils',
+  'fitted-formats.ts',
+);
+
+// The copies live in modules this suite cannot import (a .gts card module and
+// a v2-addon source file), so we lift the array literal out of the source
+// text and evaluate it. The literals are plain data — no identifiers — so the
+// evaluation cannot reach anything else.
+function extractArrayLiteral(filePath: string, declaration: string): unknown {
+  let source = readFileSync(filePath, 'utf8');
+  let match = source.match(
+    new RegExp(
+      `^(?:export )?const ${declaration}[^=]*= (\\[[\\s\\S]*?^\\]);`,
+      'm',
+    ),
+  );
+  if (!match) {
+    throw new Error(
+      `could not find "const ${declaration} = [...]" in ${filePath}`,
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function(`return ${match[1]};`)();
+}
+
+type HarnessGroup = {
+  label: string;
+  formats: { key: string; name: string; w: number; h: number }[];
+};
+
+module(basename(import.meta.filename), function () {
+  test('the format-preview harness envelopes match FITTED_FORMATS', function (assert) {
+    let harnessGroups = extractArrayLiteral(
+      HARNESS_PATH,
+      'FORMAT_GROUPS',
+    ) as HarnessGroup[];
+
+    // The harness uses its own short keys for CSS class names, so parity is
+    // asserted on everything except the key: group names, titles, and pixel
+    // dimensions, in order.
+    assert.deepEqual(
+      harnessGroups.map((group) => ({
+        label: group.label,
+        formats: group.formats.map(({ name, w, h }) => ({ name, w, h })),
+      })),
+      FITTED_FORMATS.map((group) => ({
+        label: group.name,
+        formats: group.specs.map((spec) => ({
+          name: spec.title,
+          w: spec.width,
+          h: spec.height,
+        })),
+      })),
+    );
+  });
+
+  test('the format-preview .size-* CSS blocks match the envelope dimensions', function (assert) {
+    let harnessGroups = extractArrayLiteral(
+      HARNESS_PATH,
+      'FORMAT_GROUPS',
+    ) as HarnessGroup[];
+    let source = readFileSync(HARNESS_PATH, 'utf8');
+
+    let cssSizes = new Map<string, { w: number; h: number }>();
+    for (let [, key, w, h] of source.matchAll(
+      /\.size-([a-z0-9-]+)\s*\{\s*width:\s*(\d+)px;\s*height:\s*(\d+)px;\s*\}/g,
+    )) {
+      cssSizes.set(key, { w: Number(w), h: Number(h) });
+    }
+
+    let envelopeSizes = new Map(
+      harnessGroups.flatMap((group) =>
+        group.formats.map(({ key, w, h }) => [key, { w, h }] as const),
+      ),
+    );
+    assert.deepEqual(
+      Object.fromEntries(cssSizes),
+      Object.fromEntries(envelopeSizes),
+      'every envelope has a .size-* block with the same dimensions, and no extras',
+    );
+  });
+
+  test("boxel-ui's FITTED_FORMATS copy matches runtime-common's", function (assert) {
+    assert.deepEqual(
+      extractArrayLiteral(BOXEL_UI_PATH, 'FITTED_FORMATS'),
+      FITTED_FORMATS,
+    );
+  });
+});

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -282,6 +282,7 @@ const ALL_TEST_FILES: string[] = [
   './is-json-content-type-test',
   './file-size-limit-test',
   './content-hash-test',
+  './fitted-formats-parity-test',
   './prerender-diagnostics-persistence-test',
   './prerender-proxy-test',
   './prerender-v8-prof-test',


### PR DESCRIPTION
The filedef-fixtures `format-preview` harness rendered its fitted envelopes from a hand-copied list of the 16 specs plus 16 paired `.size-*` CSS blocks, and `boxel-ui` carries its own independent copy of the same data. Any edit to `FITTED_FORMATS` in runtime-common would silently drift both — the harness would render the wrong envelope boxes with no signal, which is worse than no harness because it gives false visual confidence.

Two fixes, matched to what each copy allows:

- **Harness: single-sourced.** Card code can import `@cardstack/runtime-common` — the host shims it as a platform module (`packages/host/app/lib/externals.ts`), and several experiments-realm cards already do. The harness now imports `FITTED_FORMATS` and sizes each envelope frame with an inline style derived from the spec (the same pattern as the host's fitted-format gallery), deleting the copied list and all 16 `.size-*` CSS blocks. Nothing is left to drift.
- **boxel-ui: parity-tested.** `boxel-ui/src/utils/fitted-formats.ts` stays a copy, because a standalone design-system package must not depend on runtime-common. `packages/realm-server/tests/fitted-formats-parity-test.ts` lifts that array literal out of the source text (the suite can't import a v2-addon source file) and asserts it deep-equals runtime-common's `FITTED_FORMATS`, so an edit to either list fails loudly.

Also rewords the SOURCES.md integrity-manifest note: the per-fixture hashes are a reference for manual audits (`shasum -a 256`), not something CI recomputes — the wording previously implied enforcement that does not exist.

## Test plan

- `TEST_FILES=./fitted-formats-parity-test pnpm test` in `packages/realm-server` — passing.
- `pnpm run lint` in `packages/experiments-realm` — passing.
- Verified via `content-tag` directly that the reworked `.gts` transpiles with all three `<template>` tags consumed, identical to the prior version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)