### PR TITLE
Import vendor CSS into a low-priority layer and name every boxel-ui layer

### DIFF
--- a/packages/boxel-ui/README.md
+++ b/packages/boxel-ui/README.md
@@ -4,7 +4,7 @@ Run these from `packages/boxel-ui`.
 
 ### `pnpm build`
 
-Runs the rollup build that produces the consumable v2 addon format in `dist/`.
+Runs the rollup build that produces the consumable v2 addon format in `dist/`. Only publishing uses it (`prepack` runs this build); in-repo consumers such as the host resolve to `src/` directly via the package exports.
 
 ### Or... `pnpm start`
 
@@ -12,7 +12,7 @@ Serves the QUnit suite in `tests/` — there is no app entry at `/`, so go to `/
 
 For a headless run instead, `pnpm test` builds and drives the same suite via testem on a free port.
 
-To browse components, run the ember-freestyle explorer: `cd docs-app && pnpm start`, then visit http://localhost:4220/. Note its `/tests` is a single acceptance test for the explorer itself — the 38 integration and unit files live in this package's `tests/`.
+To browse components, run the ember-freestyle explorer: `cd docs-app && pnpm start`, then visit http://localhost:4220/. Note its `/tests` covers the explorer itself — the integration and unit files live in this package's `tests/`.
 
 ## CSS layers
 
@@ -25,7 +25,28 @@ To browse components, run the ember-freestyle explorer: `cd docs-app && pnpm sta
 
 The contract is **consumer > boxel-ui > vendor**. A consuming app's own
 unlayered CSS beats every layer here, so apps override boxel-ui without
-fighting specificity.
+fighting specificity. A consumer's own *named* layers land above boxel-ui's
+too: a layer name absent from the order statement joins the order at its
+first appearance, which is after every declared layer — that is how
+`packages/base`'s `baseComponent` layer outranks all four component tiers.
+
+**The copy in `global.css` is not the one that takes effect.** Every app entry
+repeats the same statement in an inline `<style>` at the top of `<head>`, and
+that is the copy that decides the order — `packages/host/index.html`,
+`packages/host/tests/index.html`, `tests/index.html`,
+`docs-app/index.html`, and `docs-app/tests/index.html`. Change the order in one
+place and you have to change it in all of them.
+
+The duplication is not decorative. A layer's precedence is fixed by where its
+name *first* appears, and in a bundled build that is not the order the source
+files are written in: component `<style>` blocks are extracted into the CSS
+bundle in JS module-graph order, which routinely puts them ahead of
+`global.css`. esbuild then prunes any layer name from an order statement it has
+already seen declared earlier in the bundle, so a statement that lands
+mid-bundle is reduced to nothing and the layers keep whatever order they
+happened to fall into. That is how `vendor` ended up outranking all four
+component tiers. A statement in the document `<head>`, ahead of every
+stylesheet link, is outside the bundle and cannot be reordered or pruned.
 
 Three things to know when adding or editing component CSS:
 

--- a/packages/boxel-ui/README.md
+++ b/packages/boxel-ui/README.md
@@ -1,12 +1,69 @@
 ## How to build this addon
 
-### `pnpm build` in the addon/ dir
+Run these from `packages/boxel-ui`.
 
-This command runs the rollup build to create the consumable v2 addon format that is used by the test-app as well as the host package.
+### `pnpm build`
 
-### Or... `pnpm start` in the addon/ dir
+Runs the rollup build that produces the consumable v2 addon format in `dist/`.
 
-This command does the same thing as `pnpm build` but then watches for changes to the addon directory and re-runs the build when somethng changes.
+### Or... `pnpm start`
+
+Serves the QUnit suite in `tests/` — there is no app entry at `/`, so go to `/tests/`. It takes vite's default port 4200, the same one the host app uses; with `strictPort` unset vite walks up until it finds a free port, so read the terminal for the URL rather than assuming.
+
+For a headless run instead, `pnpm test` builds and drives the same suite via testem on a free port.
+
+To browse components, run the ember-freestyle explorer: `cd docs-app && pnpm start`, then visit http://localhost:4220/. Note its `/tests` is a single acceptance test for the explorer itself — the 38 integration and unit files live in this package's `tests/`.
+
+## CSS layers
+
+`src/styles/global.css` declares the cascade order, lowest priority first:
+
+```css
+@layer vendor, reset, utilities, boxelComponentL1, boxelComponentL2,
+  boxelComponentL3, boxelComponentL4;
+```
+
+The contract is **consumer > boxel-ui > vendor**. A consuming app's own
+unlayered CSS beats every layer here, so apps override boxel-ui without
+fighting specificity.
+
+Three things to know when adding or editing component CSS:
+
+**Pick a component tier by what you wrap: one tier above it, or L1 if you wrap
+nothing.** The tiers are load-bearing, not decorative. A component that wraps
+another and restyles it has to outrank it, because a wrapper passing its own
+class onto the wrapped component's root collapses them onto a single element —
+`CardHeader` renders `ContextButton` renders `IconButton` renders `BoxelButton`,
+so one DOM node carries all four classes. They are single-class selectors of
+equal specificity, so without the tiers they tie and source order decides, and
+the inner component wins arbitrarily. Hence `button` is L1, `icon-button` L2,
+`context-button` L3, `card-header` L4.
+
+Note this is not yet true across the board — roughly half the components have
+`<style>` blocks with no layer at all, and because unlayered styles win over
+layered ones those components currently outrank the layered ones. Layer
+anything you touch; the remaining sweep is tracked separately.
+
+**Never leave a `@layer` block anonymous.** `@layer { … }` creates an unnamed
+layer that can't appear in the order statement, and unnamed layers sort
+*above* all named ones — so an anonymous block silently outranks everything,
+which is the opposite of what the order above implies.
+
+**Third-party stylesheets must be imported into the `vendor` layer**, via a
+CSS `@import … layer(vendor)` in `global.css` — not a JS `import` in a
+component. Unlayered author styles beat layered ones regardless of
+specificity, so a vendor sheet that arrives unlayered can never be overridden
+by a component rule. That is what made `--boxel-dropdown-background-color`
+inert: `BoxelDropdown` set `background-color` inside a layer while
+ember-basic-dropdown set it unlayered, so the documented hook did nothing.
+
+A JS import such as `import 'ember-power-select/styles'` injects the CSS
+unlayered and cannot be given a layer, so those imports belong in
+`global.css` instead:
+
+```css
+@import url('ember-power-select/vendor/ember-power-select.css') layer(vendor);
+```
 
 ## Notes on rebuild scripts
 
@@ -14,12 +71,14 @@ These scripts do not run as part of the build steps above and should be run when
 
 ### `pnpm rebuild:icons`
 
-Icon components in addon/src/icons are code-generated from svg files using `pnpm rebuild:icons` from the addon project. This script also generates src/icons.ts, which is the module that re-exports the icons for consumers of this addon.
+Icon components in `src/icons/` are code-generated from the svg files in `raw-icons/`. This script also generates `src/icons.gts`, the module that re-exports the icons for consumers of this addon.
 
-This script should be run when an icon is added, removed, updated, or renamed.
+Run it when an icon is added, removed, updated, or renamed. Edit the svg in `raw-icons/` — never the generated `.gts`, which is overwritten.
+
+Icons follow the lucide grid that `@cardstack/boxel-icons` uses: a `0 0 24 24` viewBox with the drawing inset two units per side, so every icon reads at the same optical size for a given `width`/`height`. An icon drawn edge-to-edge on a smaller box renders visibly larger than its neighbours.
 
 ### `pnpm rebuild:usage`
 
-This script generates src/usage.ts, which is the module that re-exports the usage modules that the test-app uses to include in it's component explorer UI.
+This script generates `src/usage.gts`, the module that re-exports the usage modules `docs-app` lists in its component explorer.
 
-This script should be run when a usage file is added, removed, or renamed.
+Run it when a usage file is added, removed, or renamed.

--- a/packages/boxel-ui/README.md
+++ b/packages/boxel-ui/README.md
@@ -35,7 +35,9 @@ repeats the same statement in an inline `<style>` at the top of `<head>`, and
 that is the copy that decides the order — `packages/host/index.html`,
 `packages/host/tests/index.html`, `tests/index.html`,
 `docs-app/index.html`, and `docs-app/tests/index.html`. Change the order in one
-place and you have to change it in all of them.
+place and you have to change it in all of them —
+`bin/check-css-layer-order-sync.mjs` (run as part of `pnpm lint`) fails if any
+copy drifts from `global.css`.
 
 The duplication is not decorative. A layer's precedence is fixed by where its
 name *first* appears, and in a bundled build that is not the order the source

--- a/packages/boxel-ui/bin/check-css-layer-order-sync.mjs
+++ b/packages/boxel-ui/bin/check-css-layer-order-sync.mjs
@@ -1,0 +1,64 @@
+// The CSS cascade layer order is declared in src/styles/global.css and
+// repeated in the <head> of every app entry, because the copy in global.css
+// does not survive bundling (see the comment there). The copies decide the
+// cascade, so they must all agree. tests/unit/css-layer-order-test.ts can only
+// exercise the entry it runs under — this check covers every copy, including
+// the production host entry no test loads.
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+);
+
+const sourceOfTruth = 'packages/boxel-ui/src/styles/global.css';
+const copies = [
+  'packages/boxel-ui/tests/index.html',
+  'packages/boxel-ui/docs-app/index.html',
+  'packages/boxel-ui/docs-app/tests/index.html',
+  'packages/host/index.html',
+  'packages/host/tests/index.html',
+];
+
+// Matches only the order statement (`@layer a, b;`), not layer blocks
+// (`@layer a { … }`) or `@import … layer(…)`.
+const ORDER_STATEMENT = /@layer\s+([^;{]+);/g;
+
+function layerOrder(file) {
+  const content = readFileSync(join(repoRoot, file), 'utf8');
+  const statements = [...content.matchAll(ORDER_STATEMENT)];
+  if (statements.length !== 1) {
+    throw new Error(
+      `${file}: expected exactly one @layer order statement, found ${statements.length}`,
+    );
+  }
+  return statements[0][1]
+    .split(',')
+    .map((name) => name.trim())
+    .join(', ');
+}
+
+try {
+  const expected = layerOrder(sourceOfTruth);
+  const mismatches = copies
+    .map((file) => ({ file, order: layerOrder(file) }))
+    .filter(({ order }) => order !== expected);
+  if (mismatches.length > 0) {
+    console.error(`@layer order statements have drifted out of sync.`);
+    console.error(`${sourceOfTruth} declares:\n  ${expected}`);
+    for (const { file, order } of mismatches) {
+      console.error(`${file} declares:\n  ${order}`);
+    }
+    process.exit(1);
+  }
+  console.log(
+    `@layer order in sync across ${copies.length + 1} files: ${expected}`,
+  );
+} catch (error) {
+  console.error(String(error.message ?? error));
+  process.exit(1);
+}

--- a/packages/boxel-ui/docs-app/app/app.js
+++ b/packages/boxel-ui/docs-app/app/app.js
@@ -6,6 +6,8 @@ import '@cardstack/boxel-ui/styles/global.css';
 import '@cardstack/boxel-ui/styles/fonts.css';
 import '@cardstack/boxel-ui/styles/variables.css';
 import '@cardstack/boxel-ui/styles/theme.css';
+// After global.css, which declares the layer order this imports into.
+import './vendor.css';
 import './deprecation-workflow';
 
 import setupInspector from '@embroider/legacy-inspector-support/ember-source-4.12';

--- a/packages/boxel-ui/docs-app/app/app.js
+++ b/packages/boxel-ui/docs-app/app/app.js
@@ -6,7 +6,8 @@ import '@cardstack/boxel-ui/styles/global.css';
 import '@cardstack/boxel-ui/styles/fonts.css';
 import '@cardstack/boxel-ui/styles/variables.css';
 import '@cardstack/boxel-ui/styles/theme.css';
-// After global.css, which declares the layer order this imports into.
+// Imports into the `vendor` layer; the inline <style> in index.html
+// declares the layer order, so import position here doesn't matter.
 import './vendor.css';
 import './deprecation-workflow';
 

--- a/packages/boxel-ui/docs-app/app/vendor.css
+++ b/packages/boxel-ui/docs-app/app/vendor.css
@@ -1,0 +1,3 @@
+/* Freestyle's stylesheet, layered so boxel-ui's cascade wins in the explorer.
+   Its own injection is turned off in ember-cli-build.js. */
+@import url('ember-freestyle/vendor/ember-freestyle.css') layer(vendor);

--- a/packages/boxel-ui/docs-app/ember-cli-build.js
+++ b/packages/boxel-ui/docs-app/ember-cli-build.js
@@ -7,8 +7,8 @@ module.exports = async function (defaults) {
 
   const app = new EmberApp(defaults, {
     // Its `included` hook imports the CSS unlayered, which would outrank every
-    // boxel-ui layer (and redefine `--radius` inside usage blocks). Opted out
-    // here; app/vendor.css imports it into the `vendor` layer instead.
+    // boxel-ui layer. Opted out here; app/vendor.css imports it into the
+    // `vendor` layer instead.
     'ember-freestyle': {
       includeStyles: false,
     },

--- a/packages/boxel-ui/docs-app/ember-cli-build.js
+++ b/packages/boxel-ui/docs-app/ember-cli-build.js
@@ -5,7 +5,14 @@ const { compatBuild } = require('@embroider/compat');
 module.exports = async function (defaults) {
   const { buildOnce } = await import('@embroider/vite');
 
-  const app = new EmberApp(defaults, {});
+  const app = new EmberApp(defaults, {
+    // Its `included` hook imports the CSS unlayered, which would outrank every
+    // boxel-ui layer (and redefine `--radius` inside usage blocks). Opted out
+    // here; app/vendor.css imports it into the `vendor` layer instead.
+    'ember-freestyle': {
+      includeStyles: false,
+    },
+  });
 
   return compatBuild(app, buildOnce, {});
 };

--- a/packages/boxel-ui/docs-app/index.html
+++ b/packages/boxel-ui/docs-app/index.html
@@ -7,6 +7,15 @@
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
+    <!-- Declares the boxel-ui cascade layer order. It lives here, ahead of
+         every stylesheet, because a layer's first appearance is what fixes its
+         precedence and bundlers prune this statement out of global.css. Mirrors
+         @cardstack/boxel-ui/styles/global.css — keep the two in sync. -->
+    <style>
+      @layer vendor, reset, utilities, boxelComponentL1, boxelComponentL2,
+        boxelComponentL3, boxelComponentL4;
+    </style>
+
     {{content-for "head"}}
 
     <link

--- a/packages/boxel-ui/docs-app/tests/index.html
+++ b/packages/boxel-ui/docs-app/tests/index.html
@@ -7,6 +7,15 @@
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
+    <!-- Declares the boxel-ui cascade layer order. It lives here, ahead of
+         every stylesheet, because a layer's first appearance is what fixes its
+         precedence and bundlers prune this statement out of global.css. Mirrors
+         @cardstack/boxel-ui/styles/global.css — keep the two in sync. -->
+    <style>
+      @layer vendor, reset, utilities, boxelComponentL1, boxelComponentL2,
+        boxelComponentL3, boxelComponentL4;
+    </style>
+
     {{content-for "head"}} {{content-for "test-head"}}
 
     <link rel="stylesheet" href="/@embroider/virtual/vendor.css" />

--- a/packages/boxel-ui/package.json
+++ b/packages/boxel-ui/package.json
@@ -18,6 +18,7 @@
     "generate:component-specs": "node bin/generate-component-specs.mjs",
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"pnpm:lint:*:fix\" --names \"fix:\"",
+    "lint:css-layer-order": "node bin/check-css-layer-order-sync.mjs",
     "lint:format": "prettier . --cache --check",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",

--- a/packages/boxel-ui/src/components/card-header/index.gts
+++ b/packages/boxel-ui/src/components/card-header/index.gts
@@ -248,7 +248,7 @@ export default class CardHeader extends Component<Signature> {
       </header>
     {{/let}}
     <style scoped>
-      @layer {
+      @layer boxelComponentL4 {
         header {
           container-type: inline-size;
           container-name: card-header;

--- a/packages/boxel-ui/src/components/container/index.gts
+++ b/packages/boxel-ui/src/components/container/index.gts
@@ -36,7 +36,7 @@ const Container: TemplateOnlyComponent<Signature> = <template>
     </TagName>
   {{/let}}
   <style scoped>
-    @layer {
+    @layer boxelComponentL1 {
       .boxel-container {
         padding: var(--boxel-container-padding, var(--boxel-sp));
       }

--- a/packages/boxel-ui/src/components/context-button/index.gts
+++ b/packages/boxel-ui/src/components/context-button/index.gts
@@ -112,7 +112,7 @@ const DropdownButton: TemplateOnlyComponent<Signature> = <template>
     />
   {{/let}}
   <style scoped>
-    @layer boxelComponentL2 {
+    @layer boxelComponentL3 {
       .boxel-context-button {
         color: inherit;
         background-color: transparent;

--- a/packages/boxel-ui/src/components/date-range-picker/index.gts
+++ b/packages/boxel-ui/src/components/date-range-picker/index.gts
@@ -1,5 +1,3 @@
-import 'ember-power-calendar/styles';
-
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -201,16 +199,20 @@ export default class DateRangePicker extends Component<Signature> {
      }}
     {{! template-lint-disable require-scoped-style }}
     <style>
-      .ember-power-calendar {
-        --ember-power-calendar-cell-size: 35px;
-        --ember-power-calendar-row-spacing: var(--boxel-sp-sm);
-        width: 100%;
-      }
-      .ember-power-calendar-week {
-        padding-bottom: var(--ember-power-calendar-row-spacing);
-      }
-      .ember-power-calendar-weekday {
-        padding: var(--boxel-sp-4xs);
+      /* ember-power-calendar's stylesheet sits in the `vendor` layer, so these
+         overrides win from here. See "CSS layers" in ../../../README.md. */
+      @layer boxelComponentL1 {
+        .ember-power-calendar {
+          --ember-power-calendar-cell-size: 35px;
+          --ember-power-calendar-row-spacing: var(--boxel-sp-sm);
+          width: 100%;
+        }
+        .ember-power-calendar-week {
+          padding-bottom: var(--ember-power-calendar-row-spacing);
+        }
+        .ember-power-calendar-weekday {
+          padding: var(--boxel-sp-4xs);
+        }
       }
     </style>
   </template>

--- a/packages/boxel-ui/src/components/date-range-picker/index.gts
+++ b/packages/boxel-ui/src/components/date-range-picker/index.gts
@@ -213,6 +213,14 @@ export default class DateRangePicker extends Component<Signature> {
         .ember-power-calendar-weekday {
           padding: var(--boxel-sp-4xs);
         }
+
+        /* The vendor sheet sets this on <button> day cells, where the reset
+           layer's `button { font: inherit }` outranks it; restated here so
+           it survives. */
+        .ember-power-calendar-day--selected,
+        .ember-power-calendar-day--selected:not([disabled]):hover {
+          font-weight: bold;
+        }
       }
     </style>
   </template>

--- a/packages/boxel-ui/src/components/dropdown/index.gts
+++ b/packages/boxel-ui/src/components/dropdown/index.gts
@@ -308,10 +308,16 @@ class BoxelDropdown extends Component<Signature> {
           ) !important;
         }
 
+        /* Dangerous items keep their own destructive hover color, and
+           header items keep their own inert header colors. */
         .boxel-dropdown__content
           :deep(
             .boxel-menu:not(.themeless)
-              .boxel-menu__item:not(.boxel-menu__item--disabled):hover
+              .boxel-menu__item:not(
+                .boxel-menu__item--disabled,
+                .boxel-menu__item--dangerous,
+                .boxel-menu__item--header
+              ):hover
           ) {
           color: var(--dropdown-selected-text-color);
         }

--- a/packages/boxel-ui/src/components/dropdown/index.gts
+++ b/packages/boxel-ui/src/components/dropdown/index.gts
@@ -258,7 +258,7 @@ class BoxelDropdown extends Component<Signature> {
     </BasicDropdown>
 
     <style scoped>
-      @layer {
+      @layer boxelComponentL1 {
         .boxel-dropdown__content {
           --boxel-dropdown-content-border-radius: var(--boxel-border-radius);
           --dropdown-background-color: var(
@@ -272,6 +272,12 @@ class BoxelDropdown extends Component<Signature> {
           --dropdown-text-color: var(
             --boxel-dropdown-text-color,
             var(--foreground, var(--boxel-dark))
+          );
+          /* Only the variants below override this; the fallback keeps the
+             hovered menu item from resolving an undefined var. */
+          --dropdown-selected-text-color: var(
+            --boxel-dropdown-selected-text-color,
+            var(--dropdown-text-color)
           );
           --dropdown-shadow: 0 5px 15px 0 rgb(0 0 0 / 25%);
           --dropdown-highlight-color: var(

--- a/packages/boxel-ui/src/components/dropdown/trigger/index.gts
+++ b/packages/boxel-ui/src/components/dropdown/trigger/index.gts
@@ -37,7 +37,7 @@ const BoxelDropdownTrigger: TemplateOnlyComponent<Signature> = <template>
     />
   </BoxelButton>
   <style scoped>
-    @layer {
+    @layer boxelComponentL2 {
       .boxel-dropdown-trigger {
         border: 0;
         padding: 0;

--- a/packages/boxel-ui/src/components/dropdown/usage.gts
+++ b/packages/boxel-ui/src/components/dropdown/usage.gts
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
 import menuItem from '../../helpers/menu-item.ts';
+import IconTrash from '../../icons/icon-trash.gts';
 import BoxelButton from '../button/index.gts';
 import BoxelMenu from '../menu/index.gts';
 import BoxelDropdown from './index.gts';
@@ -50,6 +51,12 @@ export default class BoxelDropdownUsage extends Component {
                   'Duplicate' (fn this.log 'Duplicate menu item clicked')
                 )
                 (menuItem 'Share' (fn this.log 'Share menu item clicked'))
+                (menuItem
+                  'Delete'
+                  (fn this.log 'Delete menu item clicked')
+                  icon=IconTrash
+                  dangerous=true
+                )
               }}
             />
           </:content>

--- a/packages/boxel-ui/src/components/filter-list/index.gts
+++ b/packages/boxel-ui/src/components/filter-list/index.gts
@@ -38,7 +38,7 @@ const FilterList: TemplateOnlyComponent<Signature> = <template>
     {{/each}}
   </ul>
   <style scoped>
-    @layer boxelComponentL2 {
+    @layer boxelComponentL3 {
       .filter-list {
         display: flex;
         flex-direction: column;

--- a/packages/boxel-ui/src/components/header/index.gts
+++ b/packages/boxel-ui/src/components/header/index.gts
@@ -47,7 +47,7 @@ const Header: TemplateOnlyComponent<Signature> = <template>
     {{/if}}
   </header>
   <style scoped>
-    @layer {
+    @layer boxelComponentL1 {
       header {
         --_h-padding: var(--boxel-sp);
         --_h-min-height: 1.875rem; /* 30px */

--- a/packages/boxel-ui/src/components/menu/index.gts
+++ b/packages/boxel-ui/src/components/menu/index.gts
@@ -134,7 +134,7 @@ export default class Menu extends Component<Signature> {
       {{/if}}
     </ul>
     <style scoped>
-      @layer {
+      @layer boxelComponentL1 {
         .boxel-menu {
           --boxel-menu-border-radius: var(--boxel-border-radius);
           --boxel-menu-color: var(--boxel-light);

--- a/packages/boxel-ui/src/components/multi-select/index.gts
+++ b/packages/boxel-ui/src/components/multi-select/index.gts
@@ -1,5 +1,3 @@
-import 'ember-power-select/styles';
-
 import Component from '@glimmer/component';
 import type { ComponentLike } from '@glint/template';
 import type { PowerSelectArgs } from 'ember-power-select/components/power-select';

--- a/packages/boxel-ui/src/components/pill/index.gts
+++ b/packages/boxel-ui/src/components/pill/index.gts
@@ -87,7 +87,7 @@ const Pill: TemplateOnlyComponent<PillSignature> = <template>
   {{/let}}
 
   <style scoped>
-    @layer {
+    @layer boxelComponentL1 {
       .pill {
         /* internal properties */
         --pill-padding: var(--boxel-sp-5xs) var(--boxel-sp-xxxs);

--- a/packages/boxel-ui/src/components/progress-bar/index.gts
+++ b/packages/boxel-ui/src/components/progress-bar/index.gts
@@ -77,7 +77,7 @@ export default class ProgressBar extends Component<Signature> {
     </div>
 
     <style scoped>
-      @layer {
+      @layer boxelComponentL1 {
         .boxel-progress-bar {
           /* Track height. Defaults to the em-relative height this component
              has always had, so a caller that sets nothing is unaffected; a

--- a/packages/boxel-ui/src/components/progress-radial/index.gts
+++ b/packages/boxel-ui/src/components/progress-radial/index.gts
@@ -40,7 +40,7 @@ export default class ProgressRadial extends Component<Signature> {
     </div>
 
     <style scoped>
-      @layer {
+      @layer boxelComponentL1 {
         .boxel-progress-radial {
           --progress-radial-size: var(--boxel-progress-radial-size, 80px);
           --progress-radial-fill-color: var(

--- a/packages/boxel-ui/src/components/radio-input/index.gts
+++ b/packages/boxel-ui/src/components/radio-input/index.gts
@@ -54,7 +54,7 @@ export default class RadioInput extends Component<Signature> {
 
   <template>
     <style scoped>
-      @layer {
+      @layer boxelComponentL1 {
         .boxel-radio-fieldset {
           --boxel-radio-gap: var(--boxel-sp);
           --boxel-radio-input-option-padding: var(--boxel-sp);

--- a/packages/boxel-ui/src/components/radio-input/item.gts
+++ b/packages/boxel-ui/src/components/radio-input/item.gts
@@ -27,7 +27,7 @@ export interface Signature {
 
 const RadioInputItem: TemplateOnlyComponent<Signature> = <template>
   <style scoped>
-    @layer {
+    @layer boxelComponentL1 {
       .boxel-radio-option {
         --radio-border: 1.5px solid
           var(

--- a/packages/boxel-ui/src/components/realm-icon/index.gts
+++ b/packages/boxel-ui/src/components/realm-icon/index.gts
@@ -52,7 +52,7 @@ export default class RealmIcon extends Component<Signature> {
     />
 
     <style scoped>
-      @layer {
+      @layer boxelComponentL1 {
         .realm-icon-img {
           --border-radius: var(
             --boxel-realm-icon-border-radius,

--- a/packages/boxel-ui/src/components/select/index.gts
+++ b/packages/boxel-ui/src/components/select/index.gts
@@ -1,5 +1,3 @@
-import 'ember-power-select/styles';
-
 import Check from '@cardstack/boxel-icons/check';
 import { eq } from '@cardstack/boxel-ui/helpers';
 import { registerDestructor } from '@ember/destroyable';
@@ -525,265 +523,273 @@ export default class BoxelSelect<ItemT = any> extends Component<
     </style>
     {{! template-lint-disable require-scoped-style }}
     <style>
-      .boxel-select__dropdown.ember-power-select-dropdown {
-        --dropdown-background-color: var(
-          --boxel-dropdown-background-color,
-          var(--background, var(--boxel-light))
-        );
-        --dropdown-border-color: var(
-          --boxel-dropdown-border-color,
-          var(--border, var(--boxel-border-color))
-        );
-        --dropdown-text-color: var(
-          --boxel-dropdown-text-color,
-          var(--foreground, var(--boxel-dark))
-        );
-        --dropdown-highlight-color: var(
-          --boxel-dropdown-highlight-color,
-          var(--theme-highlight, var(--boxel-highlight))
-        );
-        --dropdown-highlight-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--theme-highlight-hover, var(--boxel-highlight))
-        );
-        --dropdown-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--theme-hover, var(--boxel-light-100))
-        );
-        --dropdown-focus-border-color: var(
-          --boxel-dropdown-focus-border-color,
-          var(--ring, var(--boxel-highlight-hover))
-        );
-        --dropdown-selected-text-color: var(
-          --boxel-dropdown-selected-text-color,
-          var(--foreground, var(--boxel-dark))
-        );
+      /* Unscoped because the dropdown renders in a wormhole outside this
+         component. See "CSS layers" in ../../../README.md. */
+      @layer boxelComponentL1 {
+        .boxel-select__dropdown.ember-power-select-dropdown {
+          --dropdown-background-color: var(
+            --boxel-dropdown-background-color,
+            var(--background, var(--boxel-light))
+          );
+          --dropdown-border-color: var(
+            --boxel-dropdown-border-color,
+            var(--border, var(--boxel-border-color))
+          );
+          --dropdown-text-color: var(
+            --boxel-dropdown-text-color,
+            var(--foreground, var(--boxel-dark))
+          );
+          --dropdown-highlight-color: var(
+            --boxel-dropdown-highlight-color,
+            var(--theme-highlight, var(--boxel-highlight))
+          );
+          --dropdown-highlight-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--theme-highlight-hover, var(--boxel-highlight))
+          );
+          --dropdown-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--theme-hover, var(--boxel-light-100))
+          );
+          --dropdown-focus-border-color: var(
+            --boxel-dropdown-focus-border-color,
+            var(--ring, var(--boxel-highlight-hover))
+          );
+          --dropdown-selected-text-color: var(
+            --boxel-dropdown-selected-text-color,
+            var(--foreground, var(--boxel-dark))
+          );
 
-        box-shadow: var(--boxel-box-shadow);
-        border-radius: var(--boxel-form-control-border-radius);
-        background-color: var(--dropdown-background-color);
-        border: 1px solid var(--dropdown-border-color);
-        z-index: var(--boxel-layer-modal-urgent);
-        max-height: var(--boxel-select-max-height, 12.5rem);
-        overflow: hidden;
-        font-family: inherit;
-      }
+          box-shadow: var(--boxel-box-shadow);
+          border-radius: var(--boxel-form-control-border-radius);
+          background-color: var(--dropdown-background-color);
+          border: 1px solid var(--dropdown-border-color);
+          z-index: var(--boxel-layer-modal-urgent);
+          max-height: var(--boxel-select-max-height, 12.5rem);
+          overflow: hidden;
+          font-family: inherit;
+        }
 
-      .boxel-select__dropdown:not(.ember-basic-dropdown-content--above) {
-        margin-top: 4px;
-        margin-bottom: 0;
-      }
+        .boxel-select__dropdown:not(.ember-basic-dropdown-content--above) {
+          margin-top: 4px;
+          margin-bottom: 0;
+        }
 
-      .boxel-select__dropdown ul {
-        list-style: none;
-        padding: var(--boxel-sp-xxxs);
-        margin: 0;
-        overflow: auto;
-        max-height: inherit;
-        font-family: inherit;
-      }
+        .boxel-select__dropdown ul {
+          list-style: none;
+          padding: var(--boxel-sp-xxxs);
+          margin: 0;
+          overflow: auto;
+          max-height: inherit;
+          font-family: inherit;
+        }
 
-      .boxel-select__dropdown .ember-power-select-option {
-        padding: var(--boxel-sp-xxs);
-        background-color: var(--dropdown-background-color);
-        color: var(--dropdown-text-color);
-        transition: background-color var(--boxel-transition);
-        border-radius: var(--boxel-border-radius-sm);
-        cursor: pointer;
-        border: none;
-        width: 100%;
-        text-align: left;
-        font-family: inherit;
-        font-size: var(--boxel-font-size-sm);
-        letter-spacing: var(--boxel-lsp-sm);
-        margin-bottom: 2px;
-      }
+        .boxel-select__dropdown .ember-power-select-option {
+          padding: var(--boxel-sp-xxs);
+          background-color: var(--dropdown-background-color);
+          color: var(--dropdown-text-color);
+          transition: background-color var(--boxel-transition);
+          border-radius: var(--boxel-border-radius-sm);
+          cursor: pointer;
+          border: none;
+          width: 100%;
+          text-align: left;
+          font-family: inherit;
+          font-size: var(--boxel-font-size-sm);
+          letter-spacing: var(--boxel-lsp-sm);
+          margin-bottom: 2px;
+        }
 
-      .boxel-select__dropdown .ember-power-select-option[aria-selected='true'] {
-        background-color: var(--dropdown-highlight-color);
-        color: var(--dropdown-selected-text-color);
-      }
+        .boxel-select__dropdown
+          .ember-power-select-option[aria-selected='true'] {
+          background-color: var(--dropdown-highlight-color);
+          color: var(--dropdown-selected-text-color);
+        }
 
-      .boxel-select__dropdown
-        .ember-power-select-option[aria-selected='true']:hover {
-        background-color: var(--dropdown-highlight-hover-color);
-        color: var(--dropdown-selected-text-color);
-      }
+        .boxel-select__dropdown
+          .ember-power-select-option[aria-selected='true']:hover {
+          background-color: var(--dropdown-highlight-hover-color);
+          color: var(--dropdown-selected-text-color);
+        }
 
-      .boxel-select__dropdown .ember-power-select-option:hover {
-        background-color: var(--dropdown-hover-color);
-        color: var(--dropdown-selected-text-color);
-      }
+        .boxel-select__dropdown .ember-power-select-option:hover {
+          background-color: var(--dropdown-hover-color);
+          color: var(--dropdown-selected-text-color);
+        }
 
-      .boxel-select__dropdown .ember-power-select-option:focus {
-        outline: none;
-        background-color: var(--dropdown-highlight-color);
-        color: var(--dropdown-selected-text-color);
-      }
+        .boxel-select__dropdown .ember-power-select-option:focus {
+          outline: none;
+          background-color: var(--dropdown-highlight-color);
+          color: var(--dropdown-selected-text-color);
+        }
 
-      .boxel-select__dropdown .ember-power-select-search {
-        padding: var(--boxel-sp-xs);
-        border-bottom: 1px solid var(--dropdown-border-color);
-      }
+        .boxel-select__dropdown .ember-power-select-search {
+          padding: var(--boxel-sp-xs);
+          border-bottom: 1px solid var(--dropdown-border-color);
+        }
 
-      .boxel-select__dropdown .ember-power-select-search-input {
-        background-color: var(--dropdown-background-color);
-        color: var(--dropdown-text-color);
-        border: 1px solid var(--dropdown-border-color);
-        border-radius: var(--boxel-border-radius-xs);
-        padding: var(--boxel-sp-5xs) var(--boxel-sp-xs);
-        font-family: inherit;
-        font-size: var(--boxel-font-size-sm);
-        letter-spacing: var(--boxel-lsp-sm);
-        width: 100%;
-        box-sizing: border-box;
-      }
+        .boxel-select__dropdown .ember-power-select-search-input {
+          background-color: var(--dropdown-background-color);
+          color: var(--dropdown-text-color);
+          border: 1px solid var(--dropdown-border-color);
+          border-radius: var(--boxel-border-radius-xs);
+          padding: var(--boxel-sp-5xs) var(--boxel-sp-xs);
+          font-family: inherit;
+          font-size: var(--boxel-font-size-sm);
+          letter-spacing: var(--boxel-lsp-sm);
+          width: 100%;
+          box-sizing: border-box;
+        }
 
-      .boxel-select__dropdown .ember-power-select-search-input:focus {
-        border: 1px solid var(--dropdown-focus-border-color);
-        box-shadow: 0 0 0 1px var(--dropdown-focus-border-color);
-        outline: none;
-      }
+        .boxel-select__dropdown .ember-power-select-search-input:focus {
+          border: 1px solid var(--dropdown-focus-border-color);
+          box-shadow: 0 0 0 1px var(--dropdown-focus-border-color);
+          outline: none;
+        }
 
-      .boxel-select__dropdown .ember-power-select-option--no-matches-message {
-        padding: var(--boxel-sp-sm);
-        color: var(--dropdown-text-color);
-        font-style: italic;
-        text-align: center;
-      }
+        .boxel-select__dropdown .ember-power-select-option--no-matches-message {
+          padding: var(--boxel-sp-sm);
+          color: var(--dropdown-text-color);
+          font-style: italic;
+          text-align: center;
+        }
 
-      .boxel-select__dropdown .ember-power-select-option--loading-message {
-        padding: var(--boxel-sp-sm);
-        color: var(--dropdown-text-color);
-        text-align: center;
-      }
+        .boxel-select__dropdown .ember-power-select-option--loading-message {
+          padding: var(--boxel-sp-sm);
+          color: var(--dropdown-text-color);
+          text-align: center;
+        }
 
-      /* All variants use the same reusable theme variables */
-      .boxel-select__dropdown[class*='variant-'] {
-        --dropdown-highlight-color: var(
-          --boxel-dropdown-highlight-color,
-          var(--theme-highlight, var(--boxel-highlight))
-        );
-        --dropdown-highlight-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--theme-highlight-hover, var(--boxel-highlight-hover))
-        );
-        --dropdown-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--theme-hover, var(--boxel-light-100))
-        );
-      }
+        /* All variants use the same reusable theme variables */
+        .boxel-select__dropdown[class*='variant-'] {
+          --dropdown-highlight-color: var(
+            --boxel-dropdown-highlight-color,
+            var(--theme-highlight, var(--boxel-highlight))
+          );
+          --dropdown-highlight-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--theme-highlight-hover, var(--boxel-highlight-hover))
+          );
+          --dropdown-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--theme-hover, var(--boxel-light-100))
+          );
+        }
 
-      .boxel-select__dropdown.variant-primary {
-        --dropdown-highlight-color: var(
-          --boxel-dropdown-highlight-color,
-          var(--primary, var(--boxel-600))
-        );
-        --dropdown-highlight-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--primary, var(--boxel-600))
-        );
-        --dropdown-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--theme-hover, var(--boxel-500))
-        );
-        --dropdown-selected-text-color: var(
-          --primary-foreground,
-          var(--foreground, var(--boxel-light))
-        );
-        --dropdown-focus-border-color: var(
-          --primary,
-          var(--boxel-outline-color)
-        );
-      }
+        .boxel-select__dropdown.variant-primary {
+          --dropdown-highlight-color: var(
+            --boxel-dropdown-highlight-color,
+            var(--primary, var(--boxel-600))
+          );
+          --dropdown-highlight-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--primary, var(--boxel-600))
+          );
+          --dropdown-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--theme-hover, var(--boxel-500))
+          );
+          --dropdown-selected-text-color: var(
+            --primary-foreground,
+            var(--foreground, var(--boxel-light))
+          );
+          --dropdown-focus-border-color: var(
+            --primary,
+            var(--boxel-outline-color)
+          );
+        }
 
-      .boxel-select__dropdown.variant-secondary {
-        --dropdown-highlight-color: var(
-          --boxel-dropdown-highlight-color,
-          var(--secondary, var(--boxel-400))
-        );
-        --dropdown-highlight-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--secondary, var(--boxel-400))
-        );
-        --dropdown-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--theme-hover, var(--boxel-light-100))
-        );
-        --dropdown-selected-text-color: var(
-          --secondary-foreground,
-          var(--foreground, var(--boxel-dark))
-        );
-        --dropdown-focus-border-color: var(
-          --secondary,
-          var(--boxel-outline-color)
-        );
-      }
+        .boxel-select__dropdown.variant-secondary {
+          --dropdown-highlight-color: var(
+            --boxel-dropdown-highlight-color,
+            var(--secondary, var(--boxel-400))
+          );
+          --dropdown-highlight-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--secondary, var(--boxel-400))
+          );
+          --dropdown-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--theme-hover, var(--boxel-light-100))
+          );
+          --dropdown-selected-text-color: var(
+            --secondary-foreground,
+            var(--foreground, var(--boxel-dark))
+          );
+          --dropdown-focus-border-color: var(
+            --secondary,
+            var(--boxel-outline-color)
+          );
+        }
 
-      .boxel-select__dropdown.variant-muted {
-        --dropdown-highlight-color: var(
-          --boxel-dropdown-highlight-color,
-          var(--muted, var(--boxel-200))
-        );
-        --dropdown-highlight-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--muted, var(--boxel-200))
-        );
-        --dropdown-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--theme-hover, var(--boxel-light-100))
-        );
-        --dropdown-selected-text-color: var(
-          --muted-foreground,
-          var(--foreground, var(--boxel-dark))
-        );
-        --dropdown-focus-border-color: var(--muted, var(--boxel-outline-color));
-      }
+        .boxel-select__dropdown.variant-muted {
+          --dropdown-highlight-color: var(
+            --boxel-dropdown-highlight-color,
+            var(--muted, var(--boxel-200))
+          );
+          --dropdown-highlight-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--muted, var(--boxel-200))
+          );
+          --dropdown-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--theme-hover, var(--boxel-light-100))
+          );
+          --dropdown-selected-text-color: var(
+            --muted-foreground,
+            var(--foreground, var(--boxel-dark))
+          );
+          --dropdown-focus-border-color: var(
+            --muted,
+            var(--boxel-outline-color)
+          );
+        }
 
-      .boxel-select__dropdown.variant-destructive {
-        --dropdown-highlight-color: var(
-          --boxel-dropdown-highlight-color,
-          var(--destructive, var(--boxel-danger))
-        );
-        --dropdown-highlight-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--destructive, var(--boxel-danger))
-        );
-        --dropdown-hover-color: var(
-          --boxel-dropdown-hover-color,
-          var(--theme-hover, var(--boxel-light-100))
-        );
-        --dropdown-selected-text-color: var(
-          --destructive-foreground,
-          var(--foreground, var(--boxel-dark))
-        );
-        --dropdown-focus-border-color: var(
-          --destructive,
-          var(--boxel-outline-color)
-        );
-      }
+        .boxel-select__dropdown.variant-destructive {
+          --dropdown-highlight-color: var(
+            --boxel-dropdown-highlight-color,
+            var(--destructive, var(--boxel-danger))
+          );
+          --dropdown-highlight-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--destructive, var(--boxel-danger))
+          );
+          --dropdown-hover-color: var(
+            --boxel-dropdown-hover-color,
+            var(--theme-hover, var(--boxel-light-100))
+          );
+          --dropdown-selected-text-color: var(
+            --destructive-foreground,
+            var(--foreground, var(--boxel-dark))
+          );
+          --dropdown-focus-border-color: var(
+            --destructive,
+            var(--boxel-outline-color)
+          );
+        }
 
-      :global(#select-dropdown-overlay) {
-        position: absolute;
-        z-index: 10000;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        pointer-events: none;
-      }
+        :global(#select-dropdown-overlay) {
+          position: absolute;
+          z-index: 10000;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          pointer-events: none;
+        }
 
-      /* Accessibility: Status announcement region */
-      .ember-power-select-visually-hidden {
-        position: absolute !important;
-        width: 1px !important;
-        height: 1px !important;
-        padding: 0 !important;
-        margin: -1px !important;
-        overflow: hidden !important;
-        clip: rect(0, 0, 0, 0) !important;
-        white-space: nowrap !important;
-        border: 0 !important;
+        /* Accessibility: Status announcement region */
+        .ember-power-select-visually-hidden {
+          position: absolute !important;
+          width: 1px !important;
+          height: 1px !important;
+          padding: 0 !important;
+          margin: -1px !important;
+          overflow: hidden !important;
+          clip: rect(0, 0, 0, 0) !important;
+          white-space: nowrap !important;
+          border: 0 !important;
+        }
       }
     </style>
   </template>

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -36,7 +36,7 @@ export default class Switch extends Component<SwitchSiganture> {
     </label>
 
     <style scoped>
-      @layer {
+      @layer boxelComponentL1 {
         .switch {
           --_switch-bg-color: var(--boxel-switch-background, var(--input));
           --_switch-active-color: var(

--- a/packages/boxel-ui/src/components/tag-list/index.gts
+++ b/packages/boxel-ui/src/components/tag-list/index.gts
@@ -45,7 +45,7 @@ export default class TagList extends Component<TagListSignature> {
     </div>
 
     <style scoped>
-      @layer {
+      @layer boxelComponentL2 {
         .tag-list {
           display: flex;
           flex-wrap: wrap;

--- a/packages/boxel-ui/src/components/tag/index.gts
+++ b/packages/boxel-ui/src/components/tag/index.gts
@@ -30,7 +30,7 @@ const Tag: TemplateOnlyComponent<TagSignature> = <template>
   </Pill>
 
   <style scoped>
-    @layer {
+    @layer boxelComponentL2 {
       .tag-pill {
         --pill-padding: var(--boxel-sp-5xs) var(--boxel-sp-xxxs);
         --pill-font: 500 var(--boxel-font-xs);

--- a/packages/boxel-ui/src/components/view-selector/index.gts
+++ b/packages/boxel-ui/src/components/view-selector/index.gts
@@ -76,7 +76,7 @@ export default class ViewSelector extends Component<Signature> {
       </RadioInput>
     </div>
     <style scoped>
-      @layer {
+      @layer boxelComponentL2 {
         .view-options-group {
           display: flex;
           flex-wrap: wrap;

--- a/packages/boxel-ui/src/styles/global.css
+++ b/packages/boxel-ui/src/styles/global.css
@@ -1,18 +1,22 @@
-/* Vendor stylesheets belong here, in the lowest layer. A JS `import` in a
-   component arrives unlayered and wins instead. See "CSS layers" in
-   ../../README.md. */
-@import url('./ember-basic-dropdown.css') layer(vendor);
-@import url('ember-power-select/vendor/ember-power-select.css') layer(vendor);
-@import url('ember-power-calendar/vendor/ember-power-calendar.css')
-layer(vendor);
-
 /* The tiers are load-bearing. A wrapper that passes its own class onto the
    wrapped component's root shares one element with it, so both are single-class
    selectors that tie on specificity — only the tier breaks it. Sit one tier
    above the highest component you pass a class to; L1 if none. Button L1 →
-   IconButton L2 → ContextButton L3 → CardHeader L4. */
+   IconButton L2 → ContextButton L3 → CardHeader L4.
+
+   This statement does not survive bundling — see "CSS layers" in
+   ../../README.md. Every app entry repeats it in an inline <style> at the top
+   of <head>, and that copy is the one that decides the order. Keep them in
+   sync. */
 @layer vendor, reset, utilities, boxelComponentL1, boxelComponentL2,
   boxelComponentL3, boxelComponentL4;
+
+/* Vendor stylesheets belong here, in the lowest layer. A JS `import` in a
+   component arrives unlayered and wins instead. */
+@import url('./ember-basic-dropdown.css') layer(vendor);
+@import url('ember-power-select/vendor/ember-power-select.css') layer(vendor);
+@import url('ember-power-calendar/vendor/ember-power-calendar.css')
+layer(vendor);
 
 @layer reset {
   * {

--- a/packages/boxel-ui/src/styles/global.css
+++ b/packages/boxel-ui/src/styles/global.css
@@ -1,17 +1,18 @@
-/* Note on css layers: css @layer rules are used to create a layering system for the css.
-   The order of the layers is important as it determines the precedence of the styles.
-   The layers are defined in the following order:
-   1. reset: for resetting default browser styles
-   2. utilities: for utility classes that can be used throughout the application
-   3. boxelComponentL1: for base component styles
-   4. boxelComponentL2: for component styles that build on top of base styles
-   5. boxelComponentL3: for component styles that build on top of L2 styles
-   This layering system allows for easier overrides and customizations of styles at different levels.
-   More info: https://developer.mozilla.org/en-US/docs/Web/CSS/@layer
-*/
-@import url('./ember-basic-dropdown.css');
+/* Vendor stylesheets belong here, in the lowest layer. A JS `import` in a
+   component arrives unlayered and wins instead. See "CSS layers" in
+   ../../README.md. */
+@import url('./ember-basic-dropdown.css') layer(vendor);
+@import url('ember-power-select/vendor/ember-power-select.css') layer(vendor);
+@import url('ember-power-calendar/vendor/ember-power-calendar.css')
+layer(vendor);
 
-@layer reset, utilities, boxelComponentL1, boxelComponentL2, boxelComponentL3;
+/* The tiers are load-bearing. A wrapper that passes its own class onto the
+   wrapped component's root shares one element with it, so both are single-class
+   selectors that tie on specificity — only the tier breaks it. Sit one tier
+   above the highest component you pass a class to; L1 if none. Button L1 →
+   IconButton L2 → ContextButton L3 → CardHeader L4. */
+@layer vendor, reset, utilities, boxelComponentL1, boxelComponentL2,
+  boxelComponentL3, boxelComponentL4;
 
 @layer reset {
   * {

--- a/packages/boxel-ui/tests/index.html
+++ b/packages/boxel-ui/tests/index.html
@@ -5,6 +5,15 @@
     <title>Boxel UI Tests</title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <!-- Declares the boxel-ui cascade layer order. It lives here, ahead of
+         every stylesheet, because a layer's first appearance is what fixes its
+         precedence and bundlers prune this statement out of global.css. Mirrors
+         ../src/styles/global.css — keep the two in sync. -->
+    <style>
+      @layer vendor, reset, utilities, boxelComponentL1, boxelComponentL2,
+        boxelComponentL3, boxelComponentL4;
+    </style>
   </head>
   <body>
     <div id="qunit"></div>

--- a/packages/boxel-ui/tests/integration/components/dropdown-test.gts
+++ b/packages/boxel-ui/tests/integration/components/dropdown-test.gts
@@ -79,4 +79,45 @@ module('Integration | Component | dropdown', function (hooks) {
       .dom('[data-test-boxel-dropdown-content-2]')
       .exists('dropdown should stay open when autoClose is false');
   });
+
+  test('--boxel-dropdown-background-color wins over ember-basic-dropdown', async function (assert) {
+    // ember-basic-dropdown paints .ember-basic-dropdown-content white. That
+    // rule is less specific than the scoped .boxel-dropdown__content rule, so
+    // it can only win by sitting in a higher cascade layer — which is what
+    // happens when the layer order statement is lost during bundling.
+    document.documentElement.style.setProperty(
+      '--boxel-dropdown-background-color',
+      'rgb(1, 2, 3)',
+    );
+    try {
+      await render(
+        <template>
+          <BoxelDropdown>
+            <:trigger as |dd|>
+              <button data-test-dropdown-trigger {{dd}}>Open</button>
+            </:trigger>
+            <:content>
+              <div>content</div>
+            </:content>
+          </BoxelDropdown>
+        </template>,
+      );
+
+      await click('[data-test-dropdown-trigger]');
+      await waitFor('[data-test-boxel-dropdown-content]');
+
+      const content = document.querySelector(
+        '[data-test-boxel-dropdown-content]',
+      )!;
+      assert.strictEqual(
+        getComputedStyle(content).backgroundColor,
+        'rgb(1, 2, 3)',
+        'the documented custom property paints the dropdown',
+      );
+    } finally {
+      document.documentElement.style.removeProperty(
+        '--boxel-dropdown-background-color',
+      );
+    }
+  });
 });

--- a/packages/boxel-ui/tests/unit/css-layer-order-test.ts
+++ b/packages/boxel-ui/tests/unit/css-layer-order-test.ts
@@ -1,0 +1,85 @@
+import { module, test } from 'qunit';
+
+// The order statement in src/styles/global.css does not survive bundling —
+// component <style> blocks are extracted ahead of it and esbuild then prunes
+// the names it has already seen, so each app entry repeats the statement in an
+// inline <style> at the top of <head>. These tests assert against the order the
+// running document actually resolved, which is the thing that matters.
+const LAYERS = [
+  'vendor',
+  'reset',
+  'utilities',
+  'boxelComponentL1',
+  'boxelComponentL2',
+  'boxelComponentL3',
+  'boxelComponentL4',
+];
+
+// Declares one rule per layer, all of equal specificity, in an order that is
+// the reverse of the expected cascade order — so source order and the layer
+// order disagree and only the layers can decide the winner.
+function probeCSS(className: string): string {
+  return [...LAYERS]
+    .reverse()
+    .map(
+      (layer, i) =>
+        `@layer ${layer} { .${className} { --probe: ${LAYERS.length - 1 - i}; } }`,
+    )
+    .join('\n');
+}
+
+function withProbe(className: string, css: string, fn: () => void): void {
+  const style = document.createElement('style');
+  style.textContent = css;
+  document.head.append(style);
+  const el = document.createElement('div');
+  el.className = className;
+  document.body.append(el);
+  try {
+    fn();
+  } finally {
+    style.remove();
+    el.remove();
+  }
+}
+
+module('Unit | css layer order', function () {
+  test('the highest declared layer wins regardless of source order', function (assert) {
+    withProbe('boxel-layer-probe', probeCSS('boxel-layer-probe'), () => {
+      const el = document.querySelector('.boxel-layer-probe')!;
+      assert.strictEqual(
+        getComputedStyle(el).getPropertyValue('--probe').trim(),
+        String(LAYERS.length - 1),
+        `${LAYERS[LAYERS.length - 1]} outranks every layer below it`,
+      );
+    });
+  });
+
+  test('every boxel-ui layer outranks vendor', function (assert) {
+    for (const layer of LAYERS.slice(1)) {
+      const css = `@layer ${layer} { .boxel-layer-probe { --probe: component; } }
+@layer vendor { .boxel-layer-probe { --probe: vendor; } }`;
+      withProbe('boxel-layer-probe', css, () => {
+        const el = document.querySelector('.boxel-layer-probe')!;
+        assert.strictEqual(
+          getComputedStyle(el).getPropertyValue('--probe').trim(),
+          'component',
+          `${layer} outranks vendor`,
+        );
+      });
+    }
+  });
+
+  test('unlayered author styles outrank every layer', function (assert) {
+    const css = `@layer boxelComponentL4 { .boxel-layer-probe { --probe: layered; } }
+.boxel-layer-probe { --probe: unlayered; }`;
+    withProbe('boxel-layer-probe', css, () => {
+      const el = document.querySelector('.boxel-layer-probe')!;
+      assert.strictEqual(
+        getComputedStyle(el).getPropertyValue('--probe').trim(),
+        'unlayered',
+        'a consuming app can override boxel-ui without fighting specificity',
+      );
+    });
+  });
+});

--- a/packages/host/app/components/ai-assistant/past-session-item.gts
+++ b/packages/host/app/components/ai-assistant/past-session-item.gts
@@ -107,7 +107,7 @@ export default class PastSessionItem extends Component<Signature> {
         </:trigger>
         <:content as |dd|>
           <Menu
-            class='menu past-session-menu'
+            class='menu past-session-menu themeless'
             @closeMenu={{fn this.handleCloseMenu dd.close}}
             @items={{array
               (menuItem

--- a/packages/host/index.html
+++ b/packages/host/index.html
@@ -5,6 +5,15 @@
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
+    <!-- Declares the boxel-ui cascade layer order. It lives here, ahead of
+         every stylesheet, because a layer's first appearance is what fixes its
+         precedence and bundlers prune this statement out of global.css. Mirrors
+         @cardstack/boxel-ui/styles/global.css — keep the two in sync. -->
+    <style>
+      @layer vendor, reset, utilities, boxelComponentL1, boxelComponentL2,
+        boxelComponentL3, boxelComponentL4;
+    </style>
+
     {{content-for "head"}}
 
     <script>

--- a/packages/host/tests/index.html
+++ b/packages/host/tests/index.html
@@ -6,6 +6,15 @@
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
+    <!-- Declares the boxel-ui cascade layer order. It lives here, ahead of
+         every stylesheet, because a layer's first appearance is what fixes its
+         precedence and bundlers prune this statement out of global.css. Mirrors
+         @cardstack/boxel-ui/styles/global.css — keep the two in sync. -->
+    <style>
+      @layer vendor, reset, utilities, boxelComponentL1, boxelComponentL2,
+        boxelComponentL3, boxelComponentL4;
+    </style>
+
     {{content-for "head"}} {{content-for "test-head"}}
 
     <link rel="stylesheet" href="/@embroider/virtual/vendor.css" />


### PR DESCRIPTION
Closes CS-12394.

## Problem

boxel-ui wraps component styles in `@layer`, but its vendor stylesheets arrived unlayered — and unlayered styles beat layered ones regardless of specificity, so a component rule could never override a vendor rule. Visible symptom: `--boxel-dropdown-background-color` was a dead API; every dropdown panel rendered on ember-basic-dropdown's `#fff`.

## What changed

- **All four vendor stylesheets enter through a `vendor` layer**, the lowest tier: ember-basic-dropdown, ember-power-select, and ember-power-calendar via `@import … layer(vendor)` in `global.css`; ember-freestyle (docs-app only) via `includeStyles: false` plus a layered import, since its classic `included` hook injects unlayered.
- **The layer order is declared in an inline `<style>` at the top of each app entry's `<head>`.** The statement in `global.css` does not survive bundling: component CSS is extracted ahead of it in module-graph order, and esbuild prunes already-seen names from order statements — leaving first-appearance order in effect, with `vendor` above the component tiers. A `<head>` declaration sits outside the bundle and can't be reordered. Unit tests assert the order the running document actually resolves, and an integration test pins the dropdown background var working end to end.
- **16 anonymous `@layer {` blocks are named into the tiers** (11 × L1, 4 × L2, card-header → L4) — unnamed layers sort above all named ones, so they were silently outranking every declared tier.
- **The `boxelComponentL1–L4` tiers are documented as load-bearing** in `global.css` and the README: wrappers pass their class onto the wrapped component's root, so one element carries several equal-specificity selectors and only the tier breaks the tie.
- **Fallout fixes:** power-calendar's selected-day bold (the reset layer's `button { font: inherit }` now outranks the vendor sheet) is restated in `DateRangePicker`; the past-session menu's hover text went dark-on-dark once `--dropdown-selected-text-color` started resolving, so that menu is now `themeless` like the submode-switcher's; and dangerous menu items are excluded from the dropdown's hover repaint so they keep their destructive color on hover (the dropdown usage example gains a Delete item that shows this).

**Out of scope:** 35 of 73 component files still have unlayered `<style>` blocks that outrank the layered ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
