### PR TITLE
Add StlDef and ThreeMfDef 3D-model FileDefs on the shared file-format shells

### DIFF
--- a/packages/base/file-formats/metadata-fields.gts
+++ b/packages/base/file-formats/metadata-fields.gts
@@ -27,6 +27,7 @@ import TagsIcon from '@cardstack/boxel-icons/tags';
 
 import FileCodeIcon from '@cardstack/boxel-icons/file-code';
 import FileInfoIcon from '@cardstack/boxel-icons/file-info';
+import CubeIcon from '@cardstack/boxel-icons/cube';
 
 import {
   Component,
@@ -534,7 +535,9 @@ export class MediaEncodingField extends FieldDef {
             >{{@model.container}}</dd></div>
         {{/if}}
         {{#if @model.videoCodec}}
-          <div class='row'><dt>Video</dt><dd class='mono'>{{@model.videoCodec}}</dd></div>
+          <div class='row'><dt>Video</dt><dd
+              class='mono'
+            >{{@model.videoCodec}}</dd></div>
         {{/if}}
         {{#if @model.audioCodec}}
           <div class='row'><dt>{{if @model.videoCodec 'Audio' 'Codec'}}</dt><dd
@@ -542,7 +545,8 @@ export class MediaEncodingField extends FieldDef {
             >{{@model.audioCodec}}</dd></div>
         {{/if}}
         {{#if @model.frameRate.display}}
-          <div class='row'><dt>Frame rate</dt><dd><@fields.frameRate /></dd></div>
+          <div class='row'><dt>Frame rate</dt><dd><@fields.frameRate
+              /></dd></div>
         {{/if}}
         {{#if @model.sampleRate.display}}
           <div class='row'><dt>Sample rate</dt><dd><@fields.sampleRate
@@ -1016,6 +1020,134 @@ export class HtmlMetadataField extends FieldDef {
         dd {
           margin: 0;
           min-width: 0;
+        }
+      </style>
+    </template>
+  };
+}
+
+// The 3D model family's metadata shape (STL, 3MF, and — once their leaves land —
+// glTF/GLB). One field for the whole family, projected onto the isolated shell's
+// `3D model` inspector section, the same way `encoding` serves audio and video.
+//
+// Every fact here is read from the file's HEAD at index time (see the
+// `*-meta-extractor` modules). The true geometry — transform-correct dimensions,
+// full triangle counts — is deliberately left to the live client-side viewer
+// (`Model3DPreview`), which already loads and measures the mesh; paying for a
+// full geometry scan at index time would duplicate that for no gain. So a value
+// is present here only when it sits cheaply in the header: a binary STL's facet
+// count, a slicer 3MF's configured face/part counts, the package's materials and
+// provenance.
+export class Model3dMetadataField extends FieldDef {
+  static displayName = '3D Model Metadata';
+  static icon = CubeIcon;
+
+  // Human label for the concrete format, e.g. `Binary STL` / `3MF package`.
+  @field format = contains(StringField);
+  // Mesh/object count. An STL is exactly one solid, so it reports 1; a slicer
+  // 3MF reports its configured print-part count. Read by the isolated shell's
+  // `hasModel3d` gate together with `triangles`.
+  @field meshes = contains(NumberField);
+  // Triangle/facet count where the header carries it (a binary STL's facet
+  // count, a slicer 3MF's summed configured face count); absent otherwise.
+  @field triangles = contains(NumberField);
+  @field materials = contains(NumberField);
+  @field materialNames = containsMany(StringField);
+  @field unit = contains(StringField);
+  // Authoring/slicer application (3MF) or the binary STL header string.
+  @field generator = contains(StringField);
+  @field solidName = contains(StringField);
+  @field designer = contains(StringField);
+  @field license = contains(StringField);
+  @field plateCount = contains(NumberField);
+  @field printPartCount = contains(NumberField);
+  @field extruderCount = contains(NumberField);
+  @field hasColorData = contains(BooleanField);
+
+  static embedded = class Embedded extends Component<
+    typeof Model3dMetadataField
+  > {
+    get materialList() {
+      return (this.args.model?.materialNames ?? []).join(', ');
+    }
+
+    <template>
+      <dl class='metadata-rows'>
+        {{#if @model.format}}
+          <div class='row'><dt>Format</dt><dd>{{@model.format}}</dd></div>
+        {{/if}}
+        {{#if @model.solidName}}
+          <div class='row'><dt>Solid</dt><dd>{{@model.solidName}}</dd></div>
+        {{/if}}
+        {{#if @model.meshes}}
+          <div class='row'><dt>Meshes</dt><dd>{{@model.meshes}}</dd></div>
+        {{/if}}
+        {{#if @model.triangles}}
+          <div class='row'><dt>Triangles</dt><dd>{{@model.triangles}}</dd></div>
+        {{/if}}
+        {{#if @model.unit}}
+          <div class='row'><dt>Units</dt><dd>{{@model.unit}}</dd></div>
+        {{/if}}
+        {{#if @model.materialNames.length}}
+          <div class='row'><dt>Materials</dt><dd
+            >{{this.materialList}}</dd></div>
+        {{else if @model.materials}}
+          <div class='row'><dt>Materials</dt><dd>{{@model.materials}}</dd></div>
+        {{/if}}
+        {{#if @model.plateCount}}
+          <div class='row'><dt>Plates</dt><dd>{{@model.plateCount}}</dd></div>
+        {{/if}}
+        {{#if @model.printPartCount}}
+          <div class='row'><dt>Print parts</dt><dd
+            >{{@model.printPartCount}}</dd></div>
+        {{/if}}
+        {{#if @model.extruderCount}}
+          <div class='row'><dt>Extruders</dt><dd
+            >{{@model.extruderCount}}</dd></div>
+        {{/if}}
+        {{#if @model.designer}}
+          <div class='row'><dt>Designer</dt><dd>{{@model.designer}}</dd></div>
+        {{/if}}
+        {{#if @model.generator}}
+          <div class='row'><dt>Generator</dt><dd
+              class='mono'
+            >{{@model.generator}}</dd></div>
+        {{/if}}
+        {{#if @model.license}}
+          <div class='row'><dt>License</dt><dd>{{@model.license}}</dd></div>
+        {{/if}}
+        {{#if @model.hasColorData}}
+          <div class='row'><dt>Vertex colors</dt><dd>Present</dd></div>
+        {{/if}}
+      </dl>
+      <style scoped>
+        .metadata-rows {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0.3125rem;
+          font-size: 0.75rem;
+        }
+        .row {
+          display: flex;
+          gap: 0.625rem;
+          align-items: baseline;
+        }
+        dt {
+          flex: 0 0 5.75rem;
+          font-family: var(--font-mono);
+          font-size: 0.5625rem;
+          letter-spacing: 0.05em;
+          text-transform: uppercase;
+          color: var(--muted-foreground);
+        }
+        dd {
+          margin: 0;
+          min-width: 0;
+          overflow-wrap: anywhere;
+        }
+        .mono {
+          font-family: var(--font-mono);
         }
       </style>
     </template>

--- a/packages/base/file-formats/model3d-preview.gts
+++ b/packages/base/file-formats/model3d-preview.gts
@@ -1,0 +1,491 @@
+// The 3D model family's renderer, projected into the format shells by
+// `FilePreviewStage`. Embedded and isolated mount a live WebGL orbit viewer;
+// fitted — a collection cell that a grid can show dozens of at once — never
+// boots a context and shows the static cube instead.
+//
+// Three.js is loaded from a CDN (esm.sh) only at live client render time, the
+// sanctioned Boxel pattern for external libraries (the loader resolves https://
+// specifiers). Two gates keep WebGL off the paths where it can't or shouldn't
+// run:
+//   - PRERENDER: server-side rendering (indexing/prerender) never boots WebGL or
+//     fetches the CDN engine; `isLiveRender()` is the deterministic gate. The
+//     static cube is the prerender representation.
+//   - VIEWPORT: the viewer boots only while on-screen and disposes its context
+//     when scrolled off, re-booting on re-entry — so a strip of embedded models
+//     keeps only the visible ones holding a context and never exhausts the
+//     browser's ~16-context budget.
+//
+// Any failure (no WebGL, offline, blocked CDN, unparseable geometry) is caught
+// and leaves the cube placeholder in place.
+import GlimmerComponent from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+import CubeIcon from '@cardstack/boxel-icons/cube';
+
+import type { FilePreviewSignature } from './file-preview-stage';
+
+// Static preview behind the live viewer and in fitted cells: a plain cube icon.
+// A shaded raster thumbnail (CS-12401) will later flow through the shell's own
+// thumbnail path rather than here.
+class ModelThumbnail extends GlimmerComponent<{
+  Args: { name?: string };
+  Element: HTMLElement;
+}> {
+  <template>
+    <div class='model-thumb' ...attributes>
+      <CubeIcon class='model-thumb__icon' role='img' aria-label={{@name}} />
+    </div>
+    <style scoped>
+      .model-thumb {
+        width: 100%;
+        height: 100%;
+        display: grid;
+        place-items: center;
+        overflow: hidden;
+      }
+      .model-thumb__icon {
+        width: 45%;
+        height: 45%;
+        max-width: 96px;
+        max-height: 96px;
+        color: var(--boxel-450);
+      }
+    </style>
+  </template>
+}
+
+// Release GPU resources held by a loaded model when the card leaves the DOM.
+function disposeObject(root: any) {
+  root?.traverse?.((node: any) => {
+    node.geometry?.dispose?.();
+    let materials = Array.isArray(node.material)
+      ? node.material
+      : [node.material];
+    for (let material of materials.filter(Boolean)) {
+      for (let value of Object.values(material)) {
+        if ((value as any)?.isTexture) {
+          (value as any).dispose();
+        }
+      }
+      material.dispose?.();
+    }
+  });
+}
+
+// Base cards read this global to tell a server-side prerender from a live
+// client render (same signal `query-field-support` / `links-to-many` use).
+function isLiveRender(): boolean {
+  return !(globalThis as { __boxelRenderContext?: unknown })
+    .__boxelRenderContext;
+}
+
+const renderModel = modifier(
+  (element: HTMLElement, [component, url]: [Model3DPreview, string]) => {
+    if (!url || !isLiveRender()) {
+      return;
+    }
+    let cancelled = false;
+    let frameId = 0;
+    // Model bytes are fetched once and reused across dispose/re-boot cycles, so
+    // scrolling a tile in and out doesn't re-download it.
+    let cachedBytes: ArrayBuffer | undefined;
+    let controller: AbortController | undefined;
+    let renderer: any;
+    let scene: any;
+    let camera: any;
+    let controls: any;
+    let modelRoot: any;
+    let frameModel: ((resetDirection?: boolean) => void) | undefined;
+    let booted = false;
+    let isThreeMf = /\.3mf(?:$|[?#])/i.test(url);
+    let isStl = /\.stl(?:$|[?#])/i.test(url);
+
+    let resize = () => {
+      if (!renderer || !camera) {
+        return;
+      }
+      let width = Math.max(1, element.clientWidth);
+      let height = Math.max(1, element.clientHeight);
+      renderer.setSize(width, height, false);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+      frameModel?.(false);
+    };
+    let resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(element);
+
+    let tick = () => {
+      if (cancelled || !renderer || !scene || !camera) {
+        return;
+      }
+      controls.update();
+      renderer.render(scene, camera);
+      // eslint-disable-next-line @cardstack/boxel/no-raf-for-state -- WebGL paint loop owns no Ember state
+      frameId = requestAnimationFrame(tick);
+    };
+
+    // Release the WebGL context and scene when the tile leaves the viewport (or
+    // on teardown). Re-entry calls `boot()` again, which rebuilds from the
+    // cached bytes.
+    let disposeGl = () => {
+      cancelAnimationFrame(frameId);
+      frameId = 0;
+      controller?.abort();
+      controls?.dispose?.();
+      disposeObject(modelRoot);
+      renderer?.dispose?.();
+      renderer?.forceContextLoss?.();
+      renderer?.domElement?.remove();
+      renderer = scene = camera = controls = modelRoot = undefined;
+      frameModel = undefined;
+      booted = false;
+      // Back to the thumbnail. Skip during teardown — the component is going
+      // away and must not have tracked state mutated mid-destroy.
+      if (!cancelled) {
+        component.setLoading();
+      }
+    };
+
+    let boot = () => {
+      if (booted || cancelled) {
+        return;
+      }
+      booted = true;
+      component.setLoading();
+      let localController = new AbortController();
+      controller = localController;
+      void (async () => {
+        try {
+          let [THREE, controlsModule, loaderModule] = await Promise.all([
+            // @ts-expect-error Pinned browser ESM import; the Boxel loader resolves https:// at runtime
+            import('https://esm.sh/three@0.160.0'),
+            // @ts-expect-error Pinned browser ESM import; the Boxel loader resolves https:// at runtime
+            import('https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js'),
+            isThreeMf
+              ? // @ts-expect-error Pinned browser ESM import; 3MFLoader brings its own fflate dependency
+                import('https://esm.sh/three@0.160.0/examples/jsm/loaders/3MFLoader.js')
+              : isStl
+                ? // @ts-expect-error Pinned browser ESM import; STLLoader handles ASCII and binary STL
+                  import('https://esm.sh/three@0.160.0/examples/jsm/loaders/STLLoader.js')
+                : // @ts-expect-error Pinned browser ESM import; the Boxel loader resolves https:// at runtime
+                  import('https://esm.sh/three@0.160.0/examples/jsm/loaders/GLTFLoader.js'),
+          ]);
+          let bytes = cachedBytes;
+          if (!bytes) {
+            // No `credentials: 'include'` — that makes a credentialed CORS
+            // request, illegal against the realm's wildcard
+            // `Access-Control-Allow-Origin`. The host auth service worker
+            // injects the realm `Authorization` header on this GET (same path
+            // that lets <img src> load realm images).
+            let response = await fetch(url, { signal: localController.signal });
+            if (!response.ok) {
+              throw new Error(
+                `Model fetch failed with HTTP ${response.status}`,
+              );
+            }
+            bytes = await response.arrayBuffer();
+            cachedBytes = bytes;
+          }
+          // Disposed (scrolled off) or torn down while loading — bail before
+          // creating a context.
+          if (cancelled || !booted) {
+            return;
+          }
+          renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+          scene = new THREE.Scene();
+          camera = new THREE.PerspectiveCamera(38, 1, 0.01, 100);
+          controls = new controlsModule.OrbitControls(
+            camera,
+            renderer.domElement,
+          );
+          renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+          renderer.outputColorSpace = THREE.SRGBColorSpace;
+          renderer.toneMapping = THREE.ACESFilmicToneMapping;
+          renderer.toneMappingExposure = 1.05;
+          renderer.domElement.setAttribute('aria-label', component.label);
+          renderer.domElement.setAttribute('role', 'img');
+          element.appendChild(renderer.domElement);
+          scene.add(new THREE.HemisphereLight(0xffffff, 0x697080, 2.1));
+          let key = new THREE.DirectionalLight(0xffffff, 2.4);
+          key.position.set(3, 5, 4);
+          scene.add(key);
+          let fill = new THREE.DirectionalLight(0xaec6ff, 1.1);
+          fill.position.set(-4, 1, -2);
+          scene.add(fill);
+          controls.enableDamping = true;
+          controls.dampingFactor = 0.07;
+          controls.enablePan = false;
+          controls.autoRotate = false;
+          resize();
+          tick();
+
+          let installModel = (root: any) => {
+            if (cancelled || !booted) {
+              disposeObject(root);
+              return;
+            }
+            modelRoot = root;
+            modelRoot.updateMatrixWorld(true);
+            let bounds = new THREE.Box3().setFromObject(modelRoot);
+            if (bounds.isEmpty()) {
+              throw new Error('Model contains no renderable geometry');
+            }
+            scene.add(modelRoot);
+            let size = bounds.getSize(new THREE.Vector3());
+            let center = bounds.getCenter(new THREE.Vector3());
+            // Report the true, transform-correct bounding box for display — the
+            // dimensions we don't extract at index time come from here.
+            component.setDimensions(size);
+            frameModel = (resetDirection = false) => {
+              let verticalFov = THREE.MathUtils.degToRad(camera.fov);
+              let horizontalFov =
+                2 * Math.atan(Math.tan(verticalFov / 2) * camera.aspect);
+              let heightDistance = size.y / (2 * Math.tan(verticalFov / 2));
+              let widthDistance = size.x / (2 * Math.tan(horizontalFov / 2));
+              let distance =
+                Math.max(heightDistance, widthDistance, 0.001) * 1.2 + size.z;
+              let isFlatPrint =
+                size.z < Math.max(0.001, Math.min(size.x, size.y) * 0.35);
+              let defaultDirection = isFlatPrint
+                ? new THREE.Vector3(0.08, -0.14, 1).normalize()
+                : new THREE.Vector3(0.72, 0.52, 1).normalize();
+              let direction = resetDirection
+                ? defaultDirection
+                : new THREE.Vector3()
+                    .subVectors(camera.position, controls.target)
+                    .normalize();
+              if (
+                !Number.isFinite(direction.lengthSq()) ||
+                direction.lengthSq() === 0
+              ) {
+                direction.copy(defaultDirection);
+              }
+              controls.target.copy(center);
+              camera.position
+                .copy(center)
+                .add(direction.multiplyScalar(distance));
+              camera.near = Math.max(0.001, distance / 1000);
+              camera.far = Math.max(distance * 10, size.length() * 12, 100);
+              camera.updateProjectionMatrix();
+              controls.minDistance = Math.max(0.001, distance * 0.18);
+              controls.maxDistance = Math.max(distance * 6, size.length() * 8);
+              controls.update();
+            };
+            frameModel(true);
+            renderer.render(scene, camera);
+            component.setReady();
+          };
+
+          if (isThreeMf) {
+            let loader = new loaderModule.ThreeMFLoader();
+            installModel(loader.parse(bytes));
+          } else if (isStl) {
+            let loader = new loaderModule.STLLoader();
+            let geometry = loader.parse(bytes);
+            geometry.computeVertexNormals();
+            let hasColors = Boolean(
+              (geometry as any).hasColors || geometry.getAttribute('color'),
+            );
+            let alpha = Number((geometry as any).alpha ?? 1);
+            let material = new THREE.MeshStandardMaterial({
+              color: hasColors ? 0xffffff : 0xb9c0cb,
+              vertexColors: hasColors,
+              roughness: 0.62,
+              metalness: 0.08,
+              opacity: alpha,
+              transparent: alpha < 1,
+              side: THREE.DoubleSide,
+            });
+            let mesh = new THREE.Mesh(geometry, material);
+            mesh.rotation.x = -Math.PI / 2;
+            installModel(mesh);
+          } else {
+            let loader = new loaderModule.GLTFLoader();
+            loader.parse(
+              bytes,
+              '',
+              (gltf: any) => installModel(gltf.scene),
+              (error: unknown) => component.setError(error),
+            );
+          }
+        } catch (error) {
+          if (!cancelled && booted) {
+            component.setError(error);
+          }
+        }
+      })();
+    };
+
+    // Boot while on-screen, dispose when scrolled off — so only visible viewers
+    // hold a WebGL context.
+    let visibilityObserver = new IntersectionObserver((entries) => {
+      if (cancelled) {
+        return;
+      }
+      if (entries.some((entry) => entry.isIntersecting)) {
+        boot();
+      } else {
+        disposeGl();
+      }
+    });
+    visibilityObserver.observe(element);
+
+    let stop = (event: Event) => event.stopPropagation();
+    let resetView = (event: Event) => {
+      event.stopPropagation();
+      frameModel?.(true);
+    };
+    for (let eventName of ['pointerdown', 'pointerup', 'click', 'wheel']) {
+      element.addEventListener(eventName, stop);
+    }
+    element.addEventListener('dblclick', resetView);
+
+    return () => {
+      cancelled = true;
+      visibilityObserver.disconnect();
+      resizeObserver.disconnect();
+      disposeGl();
+      for (let eventName of ['pointerdown', 'pointerup', 'click', 'wheel']) {
+        element.removeEventListener(eventName, stop);
+      }
+      element.removeEventListener('dblclick', resetView);
+    };
+  },
+);
+
+export class Model3DPreview extends GlimmerComponent<FilePreviewSignature> {
+  @tracked state: 'loading' | 'ready' | 'error' = 'loading';
+  @tracked dimensions: { x: number; y: number; z: number } | null = null;
+
+  get isFitted() {
+    return this.args.mode === 'fitted';
+  }
+  get url() {
+    return String(this.args.model?.resourceUrl ?? this.args.model?.url ?? '');
+  }
+  get name() {
+    return String(this.args.model?.name ?? 'model');
+  }
+  // The format's own unit labels the dimensions readout (3MF carries one; STL is
+  // unitless). Read off the projected `model3d` field.
+  get unit() {
+    return String(this.args.model?.model3d?.unit ?? '');
+  }
+  get label() {
+    return `Interactive 3D preview of ${this.name}`;
+  }
+  get isReady() {
+    return this.state === 'ready';
+  }
+  get showHint() {
+    return this.isReady;
+  }
+  // True, transform-correct dimensions from the loaded geometry, labeled with
+  // the format's unit when it has one.
+  get dimensionsLabel() {
+    if (!this.dimensions) {
+      return '';
+    }
+    let unit = this.unit ? ` ${this.unit}` : '';
+    return `${this.dimensions.x} × ${this.dimensions.y} × ${this.dimensions.z}${unit}`;
+  }
+  setLoading = () => {
+    this.state = 'loading';
+    this.dimensions = null;
+  };
+  setReady = () => {
+    this.state = 'ready';
+  };
+  setError = (_error: unknown) => {
+    this.state = 'error';
+  };
+  setDimensions = (size: { x: number; y: number; z: number }) => {
+    let round = (n: number) => Math.round(n * 100) / 100;
+    this.dimensions = { x: round(size.x), y: round(size.y), z: round(size.z) };
+  };
+
+  <template>
+    {{#if this.isFitted}}
+      <ModelThumbnail @name={{this.name}} data-test-model-preview='fitted' />
+    {{else}}
+      <div class='model-viewer' data-test-model-preview={{@mode}}>
+        {{#if this.url}}
+          <div class='model-viewer__host' {{renderModel this this.url}}></div>
+        {{/if}}
+        {{#unless this.isReady}}
+          <div class='model-viewer__placeholder'>
+            <ModelThumbnail @name={{this.name}} />
+          </div>
+        {{/unless}}
+        {{#if this.dimensionsLabel}}
+          <div class='model-viewer__dims'>{{this.dimensionsLabel}}</div>
+        {{/if}}
+        {{#if this.showHint}}
+          <div class='model-viewer__hint'>Drag to orbit · scroll to zoom</div>
+        {{/if}}
+      </div>
+    {{/if}}
+    <style scoped>
+      .model-viewer {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: radial-gradient(
+          120% 100% at 50% 12%,
+          var(--card),
+          var(--muted)
+        );
+      }
+      .model-viewer__host {
+        position: absolute;
+        inset: 0;
+      }
+      .model-viewer__host :deep(canvas) {
+        display: block;
+        width: 100%;
+        height: 100%;
+        cursor: grab;
+        touch-action: none;
+      }
+      .model-viewer__host :deep(canvas:active) {
+        cursor: grabbing;
+      }
+      .model-viewer__placeholder {
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        pointer-events: none;
+      }
+      .model-viewer__dims {
+        position: absolute;
+        left: 0.5rem;
+        bottom: 0.5rem;
+        padding: 0.25rem 0.4375rem;
+        border-radius: 0.1875rem;
+        font-family: var(--font-mono, var(--boxel-monospace-font-family));
+        font-size: 0.5625rem;
+        letter-spacing: 0.02em;
+        color: var(--muted-foreground);
+        background: color-mix(in srgb, var(--card) 84%, transparent);
+        pointer-events: none;
+      }
+      .model-viewer__hint {
+        position: absolute;
+        right: 0.5rem;
+        bottom: 0.5rem;
+        padding: 0.25rem 0.4375rem;
+        border-radius: 0.1875rem;
+        font-family: var(--font-mono, var(--boxel-monospace-font-family));
+        font-size: 0.5625rem;
+        letter-spacing: 0.04em;
+        color: var(--muted-foreground);
+        background: color-mix(in srgb, var(--card) 84%, transparent);
+        pointer-events: none;
+      }
+    </style>
+  </template>
+}
+
+export default Model3DPreview;

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -21,6 +21,7 @@
     "ember-modifier": "^3.2.1",
     "ember-resources": "catalog:",
     "ember-template-lint": "catalog:",
+    "fflate": "^0.8.2",
     "matrix-js-sdk": "catalog:",
     "super-fast-md5": "catalog:",
     "@floating-ui/dom": "catalog:",

--- a/packages/base/stl-meta-extractor.ts
+++ b/packages/base/stl-meta-extractor.ts
@@ -1,0 +1,92 @@
+// Header-only STL sniffer. Reads just enough to (a) confirm the bytes really are
+// STL geometry and (b) surface the cheap descriptive facts that live in the
+// file's head — it never scans the facet body. Binary STL carries its facet
+// count and an optional COLOR= tag in the fixed 84-byte header; ASCII STL
+// carries its solid name on the first line. The physical bounding box is
+// intentionally NOT computed here: it requires walking every facet, and the
+// live client-side viewer already derives true (transform-correct) dimensions
+// from the geometry it loads, so index-time never pays for the scan. Pure JS
+// (DataView/TextDecoder), kept in a plain `.ts` module (mirroring
+// `png-meta-extractor.ts`) so it is directly unit-testable. Returns `undefined`
+// for anything that isn't STL; the calling FileDef turns that into a
+// `FileContentMismatchError` so the extractor falls back to the base FileDef.
+
+export interface StlMetadata {
+  encoding: string;
+  solidName?: string;
+  binaryHeader?: string;
+  // Present for binary STL (read straight from the header's uint32). Absent for
+  // ASCII STL, where a count would require scanning the whole facet body.
+  facetCount?: number;
+  hasColorData: boolean;
+}
+
+// How many bytes off the top we decode to sniff an ASCII STL. The `solid` line
+// and the first `facet normal` always sit at the very start, so a small prefix
+// is enough to both validate and read the solid name.
+const ASCII_SNIFF_BYTES = 4096;
+
+// Turn the raw 80-byte binary header into a readable string: keep printable
+// ASCII, collapse control/hi bytes to spaces, trim. Empty → undefined.
+function decodeBinaryHeader(bytes: Uint8Array): string | undefined {
+  return (
+    new TextDecoder('latin1')
+      .decode(bytes.subarray(0, 80))
+      .split('')
+      .map((character) => {
+        let code = character.charCodeAt(0);
+        return code < 32 || code > 126 ? ' ' : character;
+      })
+      .join('')
+      .trim() || undefined
+  );
+}
+
+export function parseStl(
+  buf: ArrayBuffer,
+): { stlMetadata: StlMetadata } | undefined {
+  let bytes = new Uint8Array(buf);
+  let view = new DataView(buf);
+
+  // Binary detection first: a binary STL is exactly 84 + 50 × facetCount bytes
+  // (some writers append trailing data, hence `<=`). This must precede the
+  // ASCII check because a binary header can itself begin with the word "solid".
+  let declaredBinaryFacets = bytes.length >= 84 ? view.getUint32(80, true) : 0;
+  let isBinary =
+    declaredBinaryFacets > 0 && 84 + declaredBinaryFacets * 50 <= bytes.length;
+
+  if (isBinary) {
+    let binaryHeader = decodeBinaryHeader(bytes);
+    return {
+      stlMetadata: {
+        encoding: 'binary',
+        binaryHeader,
+        facetCount: declaredBinaryFacets,
+        // Materialise/other writers flag per-vertex color in the header; the
+        // reliable, header-only signal is a COLOR= token. (The per-facet
+        // attribute-byte heuristic needed a full scan and over-reported, so
+        // it's dropped.)
+        hasColorData: /COLOR=/i.test(binaryHeader ?? ''),
+      },
+    };
+  }
+
+  // ASCII STL: validate against a small prefix (the `solid` keyword plus the
+  // first `facet normal`, which always appear at the top) and read the solid
+  // name from the first line.
+  let head = new TextDecoder().decode(
+    bytes.subarray(0, Math.min(bytes.length, ASCII_SNIFF_BYTES)),
+  );
+  if (!/^\s*solid\b/i.test(head) || !/\bfacet\s+normal\b/i.test(head)) {
+    return undefined;
+  }
+  let solidName =
+    head.match(/^\s*solid(?:\s+([^\r\n]+))?/i)?.[1]?.trim() || undefined;
+  return {
+    stlMetadata: {
+      encoding: 'ASCII',
+      solidName,
+      hasColorData: false,
+    },
+  };
+}

--- a/packages/base/stl-model-def.gts
+++ b/packages/base/stl-model-def.gts
@@ -1,0 +1,92 @@
+import File3dIcon from '@cardstack/boxel-icons/file-3d';
+import { byteStreamToUint8Array } from '@cardstack/runtime-common';
+import { DEFAULT_FILE_SIZE_LIMIT_BYTES } from '@cardstack/runtime-common/constants';
+import {
+  FileContentMismatchError,
+  type ByteStream,
+  type SerializedFile,
+} from './file-api';
+import {
+  ThreeDModelDef,
+  getExtension,
+  model3dAttributes,
+  type SerializedModel3d,
+} from './three-d-model-def';
+import { parseStl, type StlMetadata } from './stl-meta-extractor';
+
+// Project the STL header sniff onto the shared `model3d` field. An STL file is
+// exactly one solid, so `meshes` is always 1 — which also keeps the isolated
+// shell's `3D model` section visible for ASCII STL, whose header carries no
+// facet count.
+function stlToModel3d(s: StlMetadata): SerializedModel3d {
+  return {
+    format: s.encoding === 'binary' ? 'Binary STL' : 'ASCII STL',
+    meshes: 1,
+    triangles: s.facetCount,
+    solidName: s.solidName,
+    generator: s.binaryHeader,
+    hasColorData: s.hasColorData ? true : undefined,
+  };
+}
+
+export class StlDef extends ThreeDModelDef {
+  static displayName = 'STL Mesh';
+  static icon = File3dIcon;
+  static acceptTypes = '.stl,model/stl,application/sla';
+
+  static async extractAttributes(
+    url: string,
+    getStream: () => Promise<ByteStream>,
+    options: {
+      contentHash?: string;
+      contentSize?: number;
+      // Backstop bound on the bytes we're willing to sniff at index time,
+      // threaded from the host (see `FileDefAttributesExtractor`); defaults to
+      // the realm's standard file-size limit (`DEFAULT_FILE_SIZE_LIMIT_BYTES`),
+      // the same ceiling the write path enforces, so the two stay in step.
+      fileSizeLimitBytes?: number;
+    } = {},
+  ): Promise<SerializedFile<Partial<{ model3d: SerializedModel3d }>>> {
+    let extension = getExtension(url);
+    if (extension !== '.stl') {
+      throw new FileContentMismatchError(
+        `Expected .stl file extension, got "${extension || 'none'}"`,
+      );
+    }
+
+    let bytesPromise: Promise<Uint8Array> | undefined;
+    let memoizedStream = async () => {
+      bytesPromise ??= byteStreamToUint8Array(await getStream());
+      return bytesPromise;
+    };
+
+    let base = await super.extractAttributes(url, memoizedStream, options);
+    let bytes = await memoizedStream();
+    // Over the size cap, skip the sniff but keep the StlDef type — the file
+    // still renders via the live client-side viewer (which parses its own
+    // geometry); it just has an empty inspector panel and the cube placeholder.
+    // Do NOT throw FileContentMismatchError here: that would demote the file to
+    // a plain FileDef and lose the 3D card entirely.
+    let sizeCap = options.fileSizeLimitBytes ?? DEFAULT_FILE_SIZE_LIMIT_BYTES;
+    if (bytes.byteLength > sizeCap) {
+      console.warn(
+        `[StlDef] skipping metadata extraction for ${url}: ${bytes.byteLength} bytes exceeds cap ${sizeCap}`,
+      );
+      return { ...base };
+    }
+    let parsed = parseStl(
+      bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      ) as ArrayBuffer,
+    );
+    if (!parsed) {
+      throw new FileContentMismatchError(
+        'File does not contain parseable STL geometry',
+      );
+    }
+    return { ...base, ...model3dAttributes(stlToModel3d(parsed.stlMetadata)) };
+  }
+}
+
+export default StlDef;

--- a/packages/base/three-d-model-def.gts
+++ b/packages/base/three-d-model-def.gts
@@ -1,0 +1,86 @@
+import File3dIcon from '@cardstack/boxel-icons/file-3d';
+import { FileDef, contains, field } from './card-api';
+import { Model3dMetadataField } from './file-formats/metadata-fields';
+import { Model3DPreview } from './file-formats/model3d-preview';
+
+// Extracted to a module const: a regex literal inline in a `.gts` (with `/`
+// inside a character class) can confuse the content-tag template lexer.
+const EXTENSION_RE = new RegExp('\\.[^/.]+$');
+
+// Lowercased file extension (including the leading dot) from a URL, e.g.
+// `.stl`. Shared by the leaf `extractAttributes` methods to reject a file whose
+// bytes don't match its extension. Falls back to a plain string scan when the
+// value isn't a parseable URL.
+export function getExtension(url: string): string {
+  try {
+    let parsed = new URL(url);
+    let name = parsed.pathname.split('/').pop() ?? '';
+    let dot = name.lastIndexOf('.');
+    return dot === -1 ? '' : name.slice(dot).toLowerCase();
+  } catch {
+    let dot = url.lastIndexOf('.');
+    return dot === -1 ? '' : url.slice(dot).toLowerCase();
+  }
+}
+
+// The wire shape a leaf's `extractAttributes` projects onto the shared `model3d`
+// field. Every key is optional: a leaf sets only what its header carries, and
+// `model3dAttributes` drops the rest so an absent fact never overwrites the
+// field with an empty value.
+export interface SerializedModel3d {
+  format?: string;
+  meshes?: number;
+  triangles?: number;
+  materials?: number;
+  materialNames?: string[];
+  unit?: string;
+  generator?: string;
+  solidName?: string;
+  designer?: string;
+  license?: string;
+  plateCount?: number;
+  printPartCount?: number;
+  extruderCount?: number;
+  hasColorData?: boolean;
+}
+
+// Prune undefined / empty facts, then wrap the result as the `model3d`
+// attribute — omitting it entirely when the leaf extracted nothing, so an
+// unparseable-but-still-3D file keeps identity-only rather than a blank panel.
+export function model3dAttributes(facts: SerializedModel3d): {
+  model3d?: SerializedModel3d;
+} {
+  let model3d: SerializedModel3d = {};
+  for (let [key, value] of Object.entries(facts)) {
+    if (value === undefined || value === null || value === '') {
+      continue;
+    }
+    if (Array.isArray(value) && value.length === 0) {
+      continue;
+    }
+    (model3d as Record<string, unknown>)[key] = value;
+  }
+  return Object.keys(model3d).length > 0 ? { model3d } : {};
+}
+
+// Re-exported for a leaf that wants to strip an extension off a file name.
+export { EXTENSION_RE };
+
+// The 3D model family. Like the audio/video families it sits directly under
+// `FileDef` and supplies just two things — its icon and its live renderer —
+// inheriting the four shared format shells (atom, fitted, embedded, isolated)
+// and their chrome. The family's metadata lands on the `model3d` field, which
+// the isolated shell renders in its `3D model` inspector section; the fitted
+// hero fact reads `model3d.triangles`. Leaves (StlDef, ThreeMfDef) add only
+// their `extractAttributes`, projecting each format's header facts onto that one
+// field via `model3dAttributes`.
+export class ThreeDModelDef extends FileDef {
+  static displayName = '3D Model';
+  static icon = File3dIcon;
+
+  static previewComponent = Model3DPreview;
+
+  @field model3d = contains(Model3dMetadataField);
+}
+
+export default ThreeDModelDef;

--- a/packages/base/three-mf-def.gts
+++ b/packages/base/three-mf-def.gts
@@ -1,0 +1,100 @@
+import PrinterIcon from '@cardstack/boxel-icons/printer';
+import { byteStreamToUint8Array } from '@cardstack/runtime-common';
+import { DEFAULT_FILE_SIZE_LIMIT_BYTES } from '@cardstack/runtime-common/constants';
+import {
+  FileContentMismatchError,
+  type ByteStream,
+  type SerializedFile,
+} from './file-api';
+import {
+  ThreeDModelDef,
+  getExtension,
+  model3dAttributes,
+  type SerializedModel3d,
+} from './three-d-model-def';
+import { parseThreeMf, type ThreeMfMetadata } from './three-mf-meta-extractor';
+
+// Project the 3MF package header + slicer config onto the shared `model3d`
+// field. Triangle and mesh counts come from the slicer config (`printParts` /
+// summed configured face count) when present; a package without one keeps its
+// material and provenance facts but reports no geometry counts, which is the
+// honest header-only answer.
+function threeMfToModel3d(t: ThreeMfMetadata): SerializedModel3d {
+  return {
+    format: '3MF package',
+    meshes: t.printPartCount,
+    triangles: t.configuredFaceCount,
+    materials: t.materialNames?.length || undefined,
+    materialNames: t.materialNames,
+    unit: t.unit,
+    generator: t.application,
+    designer: t.designer,
+    license: t.licenseTerms,
+    plateCount: t.plateCount,
+    printPartCount: t.printPartCount,
+    extruderCount: t.extruderCount,
+  };
+}
+
+export class ThreeMfDef extends ThreeDModelDef {
+  static displayName = '3MF Package';
+  static icon = PrinterIcon;
+  static acceptTypes = '.3mf,model/3mf,application/vnd.ms-3mfdocument';
+
+  static async extractAttributes(
+    url: string,
+    getStream: () => Promise<ByteStream>,
+    options: {
+      contentHash?: string;
+      contentSize?: number;
+      // Backstop bound on the bytes we're willing to read at index time,
+      // threaded from the host (see `FileDefAttributesExtractor`); defaults to
+      // the realm's standard file-size limit (`DEFAULT_FILE_SIZE_LIMIT_BYTES`),
+      // the same ceiling the write path enforces, so the two stay in step.
+      fileSizeLimitBytes?: number;
+    } = {},
+  ): Promise<SerializedFile<Partial<{ model3d: SerializedModel3d }>>> {
+    let extension = getExtension(url);
+    if (extension !== '.3mf') {
+      throw new FileContentMismatchError(
+        `Expected .3mf file extension, got "${extension || 'none'}"`,
+      );
+    }
+
+    let bytesPromise: Promise<Uint8Array> | undefined;
+    let memoizedStream = async () => {
+      bytesPromise ??= byteStreamToUint8Array(await getStream());
+      return bytesPromise;
+    };
+
+    let base = await super.extractAttributes(url, memoizedStream, options);
+    let bytes = await memoizedStream();
+    // Over the size cap, skip the read but keep the ThreeMfDef type — the file
+    // still renders via the live client-side viewer (which parses its own
+    // geometry); it just has an empty inspector panel and the cube placeholder.
+    // Do NOT throw FileContentMismatchError here: that would demote the file to
+    // a plain FileDef and lose the 3D card entirely.
+    let sizeCap = options.fileSizeLimitBytes ?? DEFAULT_FILE_SIZE_LIMIT_BYTES;
+    if (bytes.byteLength > sizeCap) {
+      console.warn(
+        `[ThreeMfDef] skipping metadata extraction for ${url}: ${bytes.byteLength} bytes exceeds cap ${sizeCap}`,
+      );
+      return { ...base };
+    }
+    let parsed = parseThreeMf(
+      bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      ) as ArrayBuffer,
+    );
+    if (!parsed) {
+      throw new FileContentMismatchError('File is not a parseable 3MF package');
+    }
+    return {
+      ...base,
+      ...model3dAttributes(threeMfToModel3d(parsed.threeMfMetadata)),
+    };
+  }
+}
+
+export default ThreeMfDef;

--- a/packages/base/three-mf-meta-extractor.ts
+++ b/packages/base/three-mf-meta-extractor.ts
@@ -1,0 +1,232 @@
+import { unzipSync, strFromU8 } from 'fflate';
+
+// Bounded, header-only 3MF (OPC ZIP) reader. A 3MF package's useful text
+// metadata lives at the TOP of the `*.model` part — the `<model>` root's
+// namespaces/unit, the `<metadata>` children, and the `<basematerials>` in
+// `<resources>` — all of which precede the geometry (`<object>`/`<mesh>`/
+// `<vertices>`). This reader exploits that layout to avoid paying for the
+// geometry:
+//   1. `unzipSync`'s `filter` runs BEFORE decompression, so we decompress only
+//      the `.model` and `model_settings.config` entries — every other package
+//      entry (embedded plate-thumbnail PNGs, textures, `.rels`) is skipped, and
+//      any entry declaring an implausibly large decompressed size is rejected
+//      as a ZIP-bomb backstop.
+//   2. We read metadata off the model part's PROLOGUE (everything up to the
+//      first `<object>`) with lightweight regex — no DOM parse of the vertex/
+//      triangle body, and no per-vertex bounding-box scan. Physical dimensions
+//      come from the live client-side viewer instead, which is both cheaper at
+//      index time and correct (it applies the build/component transforms this
+//      reader would have ignored).
+// Pure JS (`fflate` + regex, no DOM), so it is directly unit-testable. Returns
+// `undefined` for anything that isn't a 3MF core package — a non-ZIP payload, a
+// package with no `.model` part, or a `.model` whose root isn't the 3MF
+// `<model>` core element — and the calling FileDef turns that into a
+// `FileContentMismatchError`.
+
+// ZIP-bomb backstop: reject any entry that DECLARES a decompressed size beyond
+// this. A 3MF's model XML compresses well, so a legitimate part can be many
+// times the (write-capped) archive — but never hundreds of MB. Declared sizes
+// can be forged, so this stops the honest bomb, not an adversarial one; realm
+// files come from authenticated members, so this is hardening, not a hard DoS
+// guarantee.
+const MAX_DECOMPRESSED_BYTES = 128 * 1024 * 1024;
+const CORE_NS = '3dmanufacturing/core';
+
+const MODEL_PART_RE = /\.model$/i;
+const CONFIG_PART_RE = /(?:^|\/)model_settings\.config$/i;
+
+interface ThreeMfPrintPartData {
+  name?: string;
+  extruder?: number;
+  faceCount?: number;
+}
+
+export interface ThreeMfMetadata {
+  unit?: string;
+  language?: string;
+  modelPart?: string;
+  extensionCount?: number;
+  extensions?: string[];
+  title?: string;
+  designer?: string;
+  application?: string;
+  bambuStudioVersion?: string;
+  creationDate?: string;
+  licenseTerms?: string;
+  description?: string;
+  plateCount?: number;
+  printPartCount?: number;
+  configuredFaceCount?: number;
+  extruderCount?: number;
+  materialNames?: string[];
+  materialColors?: string[];
+  printParts?: ThreeMfPrintPartData[];
+}
+
+function decodeXmlEntities(value: string): string {
+  return (
+    value
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
+      .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
+        String.fromCodePoint(parseInt(hex, 16)),
+      )
+      // `&amp;` last so a literal `&amp;lt;` doesn't double-decode.
+      .replace(/&amp;/g, '&')
+  );
+}
+
+// Read a single `name="value"` attribute out of a raw start-tag string.
+function attr(tag: string, name: string): string | undefined {
+  let match = tag.match(new RegExp(`\\b${name}\\s*=\\s*"([^"]*)"`, 'i'));
+  return match ? decodeXmlEntities(match[1]) : undefined;
+}
+
+export function parseThreeMf(
+  buf: ArrayBuffer,
+): { threeMfMetadata: ThreeMfMetadata } | undefined {
+  let files: Record<string, Uint8Array>;
+  try {
+    files = unzipSync(new Uint8Array(buf), {
+      // Runs before decompression: only the entries we actually read are
+      // inflated, and an oversized declared entry is refused outright.
+      filter: (file) =>
+        (MODEL_PART_RE.test(file.name) || CONFIG_PART_RE.test(file.name)) &&
+        file.originalSize <= MAX_DECOMPRESSED_BYTES,
+    }) as Record<string, Uint8Array>;
+  } catch {
+    // Not a valid ZIP / OPC package.
+    return undefined;
+  }
+
+  let modelName = Object.keys(files).find((name) => MODEL_PART_RE.test(name));
+  if (!modelName) {
+    return undefined;
+  }
+  let modelText = strFromU8(files[modelName]);
+
+  // Require a real 3MF core `<model>` root — not merely a `.model`-named XML
+  // file. This rejects a mislabeled document (e.g. `<document/>`) that would
+  // otherwise be stamped as a 3MF and handed to a viewer that can't parse it.
+  let rootTag = modelText.match(/<model\b[^>]*>/i)?.[0];
+  if (!rootTag || !new RegExp(CORE_NS, 'i').test(rootTag)) {
+    return undefined;
+  }
+  if (
+    !/^\s*(?:<\?xml[^>]*\?>\s*)?(?:<!--[\s\S]*?-->\s*)*<model\b/i.test(
+      modelText,
+    )
+  ) {
+    return undefined;
+  }
+
+  // The metadata prologue: everything before the first geometry object. All the
+  // facts we read (metadata children, basematerials) live here.
+  let objectIndex = modelText.search(/<object\b/i);
+  let prologue =
+    objectIndex === -1 ? modelText : modelText.slice(0, objectIndex);
+
+  let metadata = new Map<string, string>();
+  let metadataRe = /<metadata\b([^>]*)>([\s\S]*?)<\/metadata>/gi;
+  for (let match; (match = metadataRe.exec(prologue)); ) {
+    let key = attr(match[1], 'name');
+    if (key) {
+      metadata.set(key.toLowerCase(), decodeXmlEntities(match[2].trim()));
+    }
+  }
+
+  let materialNames: string[] = [];
+  let materialColors: string[] = [];
+  let baseRe = /<base\b([^>]*?)\/?>/gi;
+  for (let match; (match = baseRe.exec(prologue)); ) {
+    let name = attr(match[1], 'name');
+    let color = attr(match[1], 'displaycolor');
+    if (name) {
+      materialNames.push(name);
+    }
+    if (color) {
+      materialColors.push(color);
+    }
+  }
+
+  let extensions: string[] = [];
+  let namespaceRe = /xmlns:([\w-]+)\s*=\s*"([^"]*)"/gi;
+  for (let match; (match = namespaceRe.exec(rootTag)); ) {
+    extensions.push(`${match[1]} · ${match[2]}`);
+  }
+
+  let application =
+    metadata.get('application') ??
+    metadata.get('producer') ??
+    metadata.get('generator');
+
+  // The slicer config is a separate, small entry — decompressed in full and
+  // parsed for the Bambu/PrusaSlicer print-part facts (plates, extruders,
+  // per-part face counts). Absent for non-slicer 3MFs, which simply omit these.
+  let configName = Object.keys(files).find((name) => CONFIG_PART_RE.test(name));
+  let printParts: ThreeMfPrintPartData[] = [];
+  let plateCount = 0;
+  let configuredFaceCount = 0;
+  let extruders = new Set<number>();
+  if (configName) {
+    let config = strFromU8(files[configName]);
+    plateCount = (config.match(/<plate\b/gi) ?? []).length;
+    let partRe = /<part\b([^>]*)>([\s\S]*?)<\/part>/gi;
+    for (let partMatch; (partMatch = partRe.exec(config)); ) {
+      let partAttrs = partMatch[1];
+      let body = partMatch[2];
+      let values = new Map<string, string>();
+      let kvRe = /<metadata\b([^>]*?)\/?>/gi;
+      for (let kv; (kv = kvRe.exec(body)); ) {
+        let key = attr(kv[1], 'key');
+        if (key) {
+          values.set(key, attr(kv[1], 'value') ?? '');
+        }
+      }
+      let faceCount = Number(
+        body.match(/<mesh_stat\b[^>]*\bface_count\s*=\s*"([^"]*)"/i)?.[1] ?? 0,
+      );
+      let extruder = Number(values.get('extruder') ?? 0);
+      if (extruder > 0) {
+        extruders.add(extruder);
+      }
+      if (Number.isFinite(faceCount)) {
+        configuredFaceCount += faceCount;
+      }
+      printParts.push({
+        name:
+          values.get('name') ||
+          `Part ${attr(partAttrs, 'id') ?? printParts.length + 1}`,
+        extruder: extruder || undefined,
+        faceCount: faceCount || undefined,
+      });
+    }
+  }
+
+  return {
+    threeMfMetadata: {
+      unit: attr(rootTag, 'unit') ?? 'millimeter',
+      language: attr(rootTag, 'xml:lang'),
+      modelPart: modelName,
+      extensionCount: extensions.length || undefined,
+      extensions,
+      title: metadata.get('title'),
+      designer: metadata.get('designer'),
+      application,
+      bambuStudioVersion: metadata.get('bambustudio:3mfversion'),
+      creationDate: metadata.get('creationdate'),
+      licenseTerms: metadata.get('licenseterms'),
+      description: metadata.get('description'),
+      plateCount: plateCount || undefined,
+      printPartCount: printParts.length || undefined,
+      configuredFaceCount: configuredFaceCount || undefined,
+      extruderCount: extruders.size || undefined,
+      materialNames,
+      materialColors,
+      printParts,
+    },
+  };
+}

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -1663,6 +1663,7 @@ export default class Room extends Component<Signature> {
       baseFileDefCodeRef: baseFileRef,
       contentHash: undefined,
       contentSize: bytes.byteLength,
+      fileSizeLimitBytes: ENV.fileSizeLimitBytes,
       fileBytes: bytes,
       buildError: (errorUrl, error) => {
         let errorJSONAPI = formattedError(errorUrl, error).errors[0];

--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -199,6 +199,14 @@ export function shimExternals(virtualNetwork: VirtualNetwork) {
     resolve: () => import('yaml'),
   });
   virtualNetwork.shimAsyncModule({
+    id: 'fflate',
+    resolve: () => import('fflate'),
+  });
+  virtualNetwork.shimAsyncModule({
+    id: '@cardstack/runtime-common/constants',
+    resolve: () => import('@cardstack/runtime-common/constants'),
+  });
+  virtualNetwork.shimAsyncModule({
     id: '@cardstack/runtime-common/marked-sync',
     resolve: () => import('@cardstack/runtime-common/marked-sync'),
   });

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -26,6 +26,7 @@ import {
 } from '@cardstack/runtime-common';
 
 import type CardService from '@cardstack/host/services/card-service';
+import type EnvironmentService from '@cardstack/host/services/environment-service';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import type NetworkService from '@cardstack/host/services/network';
 import type RenderStoreService from '@cardstack/host/services/render-store';
@@ -140,6 +141,8 @@ const SEARCHABLE_MODULE_URL = 'https://cardstack.com/base/searchable';
 
 export default class RenderMetaRoute extends Route<Model> {
   @service declare cardService: CardService;
+  @service('environment-service')
+  declare private environmentService: EnvironmentService;
   @service declare private loaderService: LoaderService;
   @service declare private network: NetworkService;
   @service('render-store') declare private store: RenderStoreService;
@@ -412,6 +415,7 @@ export default class RenderMetaRoute extends Route<Model> {
         network: this.network,
         authGuard: this.#authGuard,
         owner: getOwner(this)!,
+        fileSizeLimitBytes: this.environmentService.fileSizeLimitBytes,
       });
     } finally {
       this.#authGuard.unregister();

--- a/packages/host/app/utils/file-def-attributes-extractor.ts
+++ b/packages/host/app/utils/file-def-attributes-extractor.ts
@@ -37,6 +37,7 @@ export type FileDefExport = {
       contentHash?: string;
       contentSize?: number;
       toolContext?: ToolContext;
+      fileSizeLimitBytes?: number;
     },
   ) => Promise<any>;
 };
@@ -72,6 +73,7 @@ export class FileDefAttributesExtractor {
   #baseFileDefCodeRef: ResolvedCodeRef;
   #contentHash: string | undefined;
   #contentSize: number | undefined;
+  #fileSizeLimitBytes: number | undefined;
   #fileBytes: Uint8Array | undefined;
   #buildError: (url: string, error: unknown) => RenderError;
   #toolContext: ToolContext | undefined;
@@ -87,6 +89,7 @@ export class FileDefAttributesExtractor {
     baseFileDefCodeRef,
     contentHash,
     contentSize,
+    fileSizeLimitBytes,
     fileBytes,
     buildError,
     toolContext,
@@ -99,6 +102,11 @@ export class FileDefAttributesExtractor {
     baseFileDefCodeRef: ResolvedCodeRef;
     contentHash: string | undefined;
     contentSize: number | undefined;
+    // The realm's configured file-size ceiling. Threaded through to each leaf
+    // `extractAttributes` so a format that parses bytes at index time (the 3D
+    // model defs) caps that work at the same limit the write path enforces,
+    // rather than a hard-coded default.
+    fileSizeLimitBytes?: number;
     fileBytes?: Uint8Array;
     buildError: (url: string, error: unknown) => RenderError;
     // Owner-carrying context that index-time tool schema generation
@@ -117,6 +125,7 @@ export class FileDefAttributesExtractor {
     this.#baseFileDefCodeRef = baseFileDefCodeRef;
     this.#contentHash = contentHash;
     this.#contentSize = contentSize;
+    this.#fileSizeLimitBytes = fileSizeLimitBytes;
     this.#fileBytes = fileBytes;
     this.#buildError = buildError;
     this.#toolContext = toolContext;
@@ -176,6 +185,7 @@ export class FileDefAttributesExtractor {
           {
             contentHash: this.#contentHash,
             contentSize: this.#contentSize,
+            fileSizeLimitBytes: this.#fileSizeLimitBytes,
             toolContext: this.#toolContext,
           },
         );

--- a/packages/host/app/utils/file-extract-runner.ts
+++ b/packages/host/app/utils/file-extract-runner.ts
@@ -54,6 +54,7 @@ export async function runFileExtract({
   network,
   authGuard,
   owner,
+  fileSizeLimitBytes,
 }: {
   fileURL: string;
   renderOptions: RenderRouteOptions;
@@ -61,6 +62,7 @@ export async function runFileExtract({
   network: NetworkService;
   authGuard: AuthErrorGuard;
   owner: Owner;
+  fileSizeLimitBytes?: number;
 }): Promise<FileDefExtractResult> {
   let fileDefCodeRef = renderOptions.fileDefCodeRef ?? baseFileRef;
   let contentHash: string | undefined = renderOptions.fileContentHash;
@@ -82,6 +84,7 @@ export async function runFileExtract({
     baseFileDefCodeRef: baseFileRef,
     contentHash,
     contentSize,
+    fileSizeLimitBytes,
     buildError: buildFileExtractError,
     toolContext,
   });

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -151,6 +151,7 @@
     "ethers": "catalog:",
     "eventemitter3": "catalog:",
     "fast-json-stable-stringify": "catalog:",
+    "fflate": "^0.8.2",
     "filesize": "catalog:",
     "flat": "catalog:",
     "glimmer-scoped-css": "catalog:",

--- a/packages/host/tests/acceptance/model-file-extract-test.gts
+++ b/packages/host/tests/acceptance/model-file-extract-test.gts
@@ -1,0 +1,207 @@
+import { visit, waitUntil } from '@ember/test-helpers';
+
+import { zipSync, strToU8 } from 'fflate';
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  type FileExtractResponse,
+  type RenderRouteOptions,
+  type ResolvedCodeRef,
+  type RealmResourceIdentifier,
+} from '@cardstack/runtime-common';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  setupRealmCacheTeardown,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  withCachedRealmSetup,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+// End-to-end coverage of the StlDef / ThreeMfDef extract chain through the real
+// render/file-extract route (the path the indexer drives): a file is served
+// from the test realm, the route runs the leaf `extractAttributes`, and the
+// resulting file-meta search doc carries the parsed facts on the shared
+// `model3d` field. The pure parsers are unit-tested separately in
+// `unit/model-meta-extractor-test.ts`; this proves the full round-trip, the
+// base-realm code-ref resolution, and the projection onto `model3d`.
+
+// One ASCII STL facet — the realm serves it as text, StlDef parses it.
+const CUBE_STL = [
+  'solid testcube',
+  ' facet normal 0 0 1',
+  '  outer loop',
+  '   vertex 0 0 0',
+  '   vertex 2 0 0',
+  '   vertex 0 4 0',
+  '  endloop',
+  ' endfacet',
+  'endsolid testcube',
+].join('\n');
+
+const CUBE_MODEL_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <metadata name="Title">Round-trip Cube</metadata>
+  <metadata name="Designer">Test</metadata>
+  <resources>
+    <object id="1" type="model" name="Cube">
+      <mesh>
+        <vertices>
+          <vertex x="0" y="0" z="0"/>
+          <vertex x="10" y="0" z="0"/>
+          <vertex x="0" y="20" z="0"/>
+          <vertex x="0" y="0" z="30"/>
+        </vertices>
+        <triangles>
+          <triangle v1="0" v2="1" v3="2"/>
+          <triangle v1="0" v2="1" v3="3"/>
+        </triangles>
+      </mesh>
+    </object>
+  </resources>
+  <build><item objectid="1"/></build>
+</model>`;
+
+// A real OPC/3MF package (binary ZIP) stored as bytes in the realm.
+const CUBE_3MF = zipSync({ '3D/3dmodel.model': strToU8(CUBE_MODEL_XML) });
+
+module('Acceptance | model file-extract', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+  setupRealmCacheTeardown(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+
+  const renderPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/file-extract`;
+
+  const baseFileDefCodeRef = (name: string): ResolvedCodeRef => ({
+    module: `${baseRealm.url}${
+      name === 'StlDef' ? 'stl-model-def' : 'three-mf-def'
+    }` as RealmResourceIdentifier,
+    name,
+  });
+
+  const fileURL = (path: string) => new URL(path, testRealmURL).href;
+
+  async function captureFileExtractResult(
+    expectedStatus?: 'ready' | 'error',
+  ): Promise<FileExtractResponse> {
+    await waitUntil(
+      () => {
+        let container = document.querySelector(
+          '[data-prerender-file-extract]',
+        ) as HTMLElement | null;
+        let status = container?.getAttribute(
+          'data-prerender-file-extract-status',
+        );
+        if (!status) {
+          return false;
+        }
+        if (expectedStatus && status !== expectedStatus) {
+          return false;
+        }
+        return status === 'ready' || status === 'error';
+      },
+      { timeout: 5000 },
+    );
+    let container = document.querySelector(
+      '[data-prerender-file-extract]',
+    ) as HTMLElement | null;
+    let text = container?.querySelector('pre')?.textContent?.trim() ?? '';
+    return JSON.parse(text) as FileExtractResponse;
+  }
+
+  hooks.beforeEach(async function () {
+    await withCachedRealmSetup(async () => {
+      await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'cube.stl': CUBE_STL,
+          'cube.3mf': CUBE_3MF,
+          'notmodel.stl': 'this is not an STL file',
+        },
+      });
+    });
+  });
+
+  test('extracts STL facts onto model3d through the render route', async function (assert) {
+    await visit(
+      renderPath(fileURL('cube.stl'), {
+        fileExtract: true,
+        fileDefCodeRef: baseFileDefCodeRef('StlDef'),
+      }),
+    );
+    let result = await captureFileExtractResult('ready');
+    let doc = result.searchDoc as Record<string, any>;
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(doc?.model3d?.format, 'ASCII STL');
+    assert.strictEqual(doc?.model3d?.solidName, 'testcube');
+    // An STL is exactly one solid, so `meshes` is always 1 — this also keeps the
+    // isolated shell's `3D model` section visible for ASCII STL.
+    assert.strictEqual(doc?.model3d?.meshes, 1);
+    // Header-only sniff: an ASCII STL carries no facet count, and dimensions
+    // come from the client-side viewer, never the index.
+    assert.strictEqual(
+      doc?.model3d?.triangles,
+      undefined,
+      'no ASCII facet count',
+    );
+    assert.strictEqual(
+      doc?.model3d?.hasColorData,
+      undefined,
+      'no color data (false is pruned)',
+    );
+  });
+
+  test('extracts 3MF facts onto model3d through the render route', async function (assert) {
+    await visit(
+      renderPath(fileURL('cube.3mf'), {
+        fileExtract: true,
+        fileDefCodeRef: baseFileDefCodeRef('ThreeMfDef'),
+      }),
+    );
+    let result = await captureFileExtractResult('ready');
+    let doc = result.searchDoc as Record<string, any>;
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(doc?.model3d?.format, '3MF package');
+    assert.strictEqual(doc?.model3d?.unit, 'millimeter');
+    assert.strictEqual(doc?.model3d?.designer, 'Test');
+    // Bounded prologue read: geometry counts come only from a slicer config,
+    // which this minimal package has none of.
+    assert.strictEqual(
+      doc?.model3d?.triangles,
+      undefined,
+      'no geometry counts without slicer config',
+    );
+  });
+
+  test('a .stl whose bytes are not STL falls back and marks mismatch', async function (assert) {
+    await visit(
+      renderPath(fileURL('notmodel.stl'), {
+        fileExtract: true,
+        fileDefCodeRef: baseFileDefCodeRef('StlDef'),
+      }),
+    );
+    let result = await captureFileExtractResult('ready');
+    let doc = result.searchDoc as Record<string, any>;
+    assert.strictEqual(result.status, 'ready', 'still indexes as base file');
+    assert.true(result.mismatch, 'sets mismatch flag');
+    assert.strictEqual(doc?.model3d, undefined, 'no 3D metadata on fallback');
+  });
+});

--- a/packages/host/tests/unit/file-def-code-ref-test.ts
+++ b/packages/host/tests/unit/file-def-code-ref-test.ts
@@ -59,6 +59,20 @@ module('Unit | isFileDefCodeRef', function (hooks) {
       ),
       'PngDef',
     );
+    assert.true(
+      isFileDefCodeRef(
+        { module: baseRRI('stl-model-def'), name: 'StlDef' },
+        virtualNetwork,
+      ),
+      'StlDef',
+    );
+    assert.true(
+      isFileDefCodeRef(
+        { module: baseRRI('three-mf-def'), name: 'ThreeMfDef' },
+        virtualNetwork,
+      ),
+      'ThreeMfDef',
+    );
   });
 
   test('rejects a non-FileDef card ref', function (assert) {

--- a/packages/host/tests/unit/model-meta-extractor-test.ts
+++ b/packages/host/tests/unit/model-meta-extractor-test.ts
@@ -1,0 +1,240 @@
+import { parseStl } from '@cardstack/base/stl-meta-extractor';
+import { parseThreeMf } from '@cardstack/base/three-mf-meta-extractor';
+import { zipSync, strToU8 } from 'fflate';
+import { module, test } from 'qunit';
+
+// These exercise the pure, index-time metadata extractors directly (no
+// card-api/render harness needed) — they take an ArrayBuffer and return plain
+// data. Inputs are built programmatically so the tests carry no binary fixtures.
+//
+// Both extractors are deliberately header-only: STL reads the fixed binary
+// header (or the ASCII prologue) and 3MF reads the model part's metadata
+// prologue. Neither scans geometry, so neither reports a bounding box or vertex/
+// triangle counts — physical dimensions come from the live client-side viewer.
+
+function toArrayBuffer(u8: Uint8Array): ArrayBuffer {
+  return u8.buffer.slice(
+    u8.byteOffset,
+    u8.byteOffset + u8.byteLength,
+  ) as ArrayBuffer;
+}
+
+interface BinaryTriangle {
+  normal: [number, number, number];
+  vertices: [
+    [number, number, number],
+    [number, number, number],
+    [number, number, number],
+  ];
+  attributeByteCount?: number;
+}
+
+// Build a well-formed binary STL: 80-byte header, uint32 facet count, then
+// 50 bytes per facet (normal + 3 vertices + 2-byte attribute count).
+function buildBinaryStl(
+  triangles: BinaryTriangle[],
+  header = 'binary stl fixture',
+): ArrayBuffer {
+  let buf = new ArrayBuffer(84 + triangles.length * 50);
+  let view = new DataView(buf);
+  let bytes = new Uint8Array(buf);
+  bytes.set(new TextEncoder().encode(header).subarray(0, 80), 0);
+  view.setUint32(80, triangles.length, true);
+  let offset = 84;
+  for (let tri of triangles) {
+    view.setFloat32(offset, tri.normal[0], true);
+    view.setFloat32(offset + 4, tri.normal[1], true);
+    view.setFloat32(offset + 8, tri.normal[2], true);
+    for (let v = 0; v < 3; v++) {
+      let p = offset + 12 + v * 12;
+      view.setFloat32(p, tri.vertices[v][0], true);
+      view.setFloat32(p + 4, tri.vertices[v][1], true);
+      view.setFloat32(p + 8, tri.vertices[v][2], true);
+    }
+    view.setUint16(offset + 48, tri.attributeByteCount ?? 0, true);
+    offset += 50;
+  }
+  return buf;
+}
+
+const UNIT_TRIANGLE: BinaryTriangle = {
+  normal: [0, 0, 1],
+  vertices: [
+    [0, 0, 0],
+    [1, 0, 0],
+    [0, 1, 0],
+  ],
+};
+
+module('Unit | model metadata extractors | parseStl', function () {
+  test('reads the binary STL header: encoding and facet count', function (assert) {
+    let parsed = parseStl(buildBinaryStl([UNIT_TRIANGLE, UNIT_TRIANGLE]));
+    assert.ok(parsed, 'binary STL parses');
+    assert.strictEqual(parsed!.stlMetadata.encoding, 'binary');
+    // Facet count comes straight from the header's uint32 — no facet scan.
+    assert.strictEqual(parsed!.stlMetadata.facetCount, 2);
+    assert.false(parsed!.stlMetadata.hasColorData);
+    // No geometry scan → no bounding box on the extracted metadata.
+    assert.notOk(
+      (parsed!.stlMetadata as unknown as Record<string, unknown>).sizeX,
+      'no index-time size',
+    );
+  });
+
+  test('detects color via a COLOR= binary header', function (assert) {
+    let parsed = parseStl(buildBinaryStl([UNIT_TRIANGLE], 'COLOR=1.0 solid'));
+    assert.true(parsed!.stlMetadata.hasColorData, 'COLOR= header');
+  });
+
+  test('parses an ASCII STL: encoding and solid name', function (assert) {
+    let ascii = [
+      'solid mycube',
+      ' facet normal 0 0 1',
+      '  outer loop',
+      '   vertex 0 0 0',
+      '   vertex 2 0 0',
+      '   vertex 0 4 0',
+      '  endloop',
+      ' endfacet',
+      'endsolid mycube',
+    ].join('\n');
+    let parsed = parseStl(toArrayBuffer(new TextEncoder().encode(ascii)));
+    assert.ok(parsed, 'ASCII STL parses');
+    assert.strictEqual(parsed!.stlMetadata.encoding, 'ASCII');
+    assert.strictEqual(parsed!.stlMetadata.solidName, 'mycube');
+    // ASCII carries no facet count in its head, and we never scan the body.
+    assert.strictEqual(parsed!.stlMetadata.facetCount, undefined);
+  });
+
+  test('returns undefined for non-STL content', function (assert) {
+    assert.strictEqual(
+      parseStl(toArrayBuffer(new TextEncoder().encode('just some text'))),
+      undefined,
+    );
+    assert.strictEqual(parseStl(new ArrayBuffer(0)), undefined, 'empty buffer');
+  });
+});
+
+// Minimal OPC/3MF package builder: a ZIP whose entries are the model XML and
+// (optionally) a slicer config, produced with fflate — the same library the
+// parser uses to unzip.
+function buildThreeMf(entries: Record<string, string>): ArrayBuffer {
+  let files: Record<string, Uint8Array> = {};
+  for (let [path, text] of Object.entries(entries)) {
+    files[path] = strToU8(text);
+  }
+  return toArrayBuffer(zipSync(files));
+}
+
+const CUBE_MODEL_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" xmlns:slic3rpe="http://schemas.slic3r.org/3mf/2017/06">
+  <metadata name="Title">My Cube &amp; Co</metadata>
+  <metadata name="Designer">Alice</metadata>
+  <metadata name="Application">TestApp</metadata>
+  <resources>
+    <basematerials id="1">
+      <base name="PLA Black" displaycolor="#101010FF"/>
+      <base name="PLA Red" displaycolor="#FF0000FF"/>
+    </basematerials>
+    <object id="2" type="model" name="Cube">
+      <mesh>
+        <vertices>
+          <vertex x="0" y="0" z="0"/>
+          <vertex x="10" y="0" z="0"/>
+        </vertices>
+      </mesh>
+    </object>
+  </resources>
+  <build><item objectid="2"/></build>
+</model>`;
+
+module('Unit | model metadata extractors | parseThreeMf', function () {
+  test('reads the 3MF metadata prologue', function (assert) {
+    let parsed = parseThreeMf(
+      buildThreeMf({ '3D/3dmodel.model': CUBE_MODEL_XML }),
+    );
+    assert.ok(parsed, '3MF parses');
+    assert.strictEqual(parsed!.threeMfMetadata.unit, 'millimeter');
+    assert.strictEqual(parsed!.threeMfMetadata.language, 'en-US');
+    // Values are XML-entity-decoded.
+    assert.strictEqual(parsed!.threeMfMetadata.title, 'My Cube & Co');
+    assert.strictEqual(parsed!.threeMfMetadata.designer, 'Alice');
+    assert.strictEqual(parsed!.threeMfMetadata.application, 'TestApp');
+    assert.deepEqual(parsed!.threeMfMetadata.materialNames, [
+      'PLA Black',
+      'PLA Red',
+    ]);
+    assert.strictEqual(parsed!.threeMfMetadata.extensionCount, 1);
+    // No geometry parse → no bounding box, no object/vertex counts.
+    assert.notOk(
+      (parsed!.threeMfMetadata as Record<string, unknown>).sizeX,
+      'no index-time size',
+    );
+    assert.notOk(
+      (parsed!.threeMfMetadata as Record<string, unknown>).objectCount,
+      'no geometry counts',
+    );
+    // No slicer config → no print parts (we no longer fall back to geometry).
+    assert.strictEqual(parsed!.threeMfMetadata.printPartCount, undefined);
+  });
+
+  test('reads slicer config parts, plates, and extruders', function (assert) {
+    let config = `<?xml version="1.0"?>
+<config>
+  <plate><metadata key="plater_id" value="1"/></plate>
+  <part id="1">
+    <metadata key="name" value="Widget"/>
+    <metadata key="extruder" value="2"/>
+    <mesh_stat face_count="1234"/>
+  </part>
+</config>`;
+    let parsed = parseThreeMf(
+      buildThreeMf({
+        '3D/3dmodel.model': CUBE_MODEL_XML,
+        'Metadata/model_settings.config': config,
+      }),
+    );
+    assert.strictEqual(parsed!.threeMfMetadata.plateCount, 1);
+    assert.strictEqual(parsed!.threeMfMetadata.printPartCount, 1);
+    assert.strictEqual(parsed!.threeMfMetadata.extruderCount, 1);
+    assert.strictEqual(parsed!.threeMfMetadata.configuredFaceCount, 1234);
+    let part = parsed!.threeMfMetadata.printParts?.[0];
+    assert.strictEqual(part?.name, 'Widget');
+    assert.strictEqual(part?.extruder, 2);
+    assert.strictEqual(part?.faceCount, 1234);
+  });
+
+  test('rejects well-formed XML that is not a 3MF core model', function (assert) {
+    // The negative space around the format check: a `.model`-named XML file
+    // whose root is not the 3MF `<model>` core element must NOT be accepted.
+    assert.strictEqual(
+      parseThreeMf(buildThreeMf({ '3D/3dmodel.model': '<document/>' })),
+      undefined,
+      'unrelated root rejected',
+    );
+    assert.strictEqual(
+      parseThreeMf(
+        buildThreeMf({
+          '3D/3dmodel.model':
+            '<model xmlns="http://example.com/other"><resources/></model>',
+        }),
+      ),
+      undefined,
+      'wrong namespace rejected',
+    );
+  });
+
+  test('returns undefined for a package with no model part', function (assert) {
+    assert.strictEqual(
+      parseThreeMf(buildThreeMf({ 'random.txt': 'hello' })),
+      undefined,
+    );
+  });
+
+  test('returns undefined for a non-ZIP payload', function (assert) {
+    assert.strictEqual(
+      parseThreeMf(toArrayBuffer(new TextEncoder().encode('not a zip'))),
+      undefined,
+    );
+  });
+});

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -51,6 +51,10 @@ const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
   '.m4v': { module: baseModule('mp4-video-def'), name: 'Mp4Def' },
   '.mov': { module: baseModule('mov-video-def'), name: 'MovDef' },
   '.webm': { module: baseModule('webm-video-def'), name: 'WebmDef' },
+  // 3D model formats. STL is raw triangle geometry; 3MF is a zipped OPC package.
+  // Both extend ThreeDModelDef, which renders a live client-side WebGL viewer.
+  '.stl': { module: baseModule('stl-model-def'), name: 'StlDef' },
+  '.3mf': { module: baseModule('three-mf-def'), name: 'ThreeMfDef' },
   '.mismatch': {
     module: './filedef-mismatch' as RealmResourceIdentifier,
     name: 'FileDef',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -937,6 +937,9 @@ importers:
       ember-template-lint:
         specifier: 'catalog:'
         version: 7.9.3
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       matrix-js-sdk:
         specifier: 'catalog:'
         version: 38.3.0(patch_hash=cee0baf579283943dc5a6b48977e8ed40a13fc111b5de9c91814893f9a4989fb)
@@ -2354,6 +2357,9 @@ importers:
       fast-json-stable-stringify:
         specifier: 'catalog:'
         version: 2.1.0
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       filesize:
         specifier: 'catalog:'
         version: 10.1.6
@@ -10515,6 +10521,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -18949,13 +18958,19 @@ snapshots:
       '@percy/cli-command': 1.31.14(typescript@5.9.3)
       '@percy/cli-exec': 1.31.14(typescript@5.9.3)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-build@1.31.14(typescript@5.9.3)':
     dependencies:
       '@percy/cli-command': 1.31.14(typescript@5.9.3)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-command@1.31.14(typescript@5.9.3)':
     dependencies:
@@ -18972,7 +18987,10 @@ snapshots:
     dependencies:
       '@percy/cli-command': 1.31.14(typescript@5.9.3)
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-doctor@1.31.14(typescript@5.9.3)':
     dependencies:
@@ -18998,14 +19016,20 @@ snapshots:
       cross-spawn: 7.0.6
       which: 2.0.2
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-snapshot@1.31.14(typescript@5.9.3)':
     dependencies:
       '@percy/cli-command': 1.31.14(typescript@5.9.3)
       yaml: 2.9.0
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli-upload@1.31.14(typescript@5.9.3)':
     dependencies:
@@ -19013,7 +19037,10 @@ snapshots:
       fast-glob: 3.3.3
       image-size: 1.2.1
     transitivePeerDependencies:
+      - bufferutil
+      - supports-color
       - typescript
+      - utf-8-validate
 
   '@percy/cli@1.31.14(typescript@5.9.3)':
     dependencies:
@@ -25211,6 +25238,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.3: {}
 
   figures@2.0.0:
     dependencies:


### PR DESCRIPTION
## What

Adds `.stl` and `.3mf` support as base-realm `FileDef` subclasses, built on the shared file-format shells' `model` family.

- **`ThreeDModelDef`** — thin family base under `FileDef`: supplies `static previewComponent = Model3DPreview` (a live WebGL orbit viewer, loaded from a CDN at client render time) and the `model3d` metadata field the isolated shell already renders. Inherits all four shared format shells.
- **`Model3dMetadataField`** — the 3D family's metadata field in `file-formats/metadata-fields.gts`. The shells were already wired to render `<@fields.model3d />` and gate the fitted hero on `model3d.triangles`; this fills in the field they expected.
- **`StlDef` / `ThreeMfDef`** — leaves that add only their header-only `extractAttributes`, projecting each format's facts onto `model3d` via `model3dAttributes`. STL uses a bounded ASCII/binary sniffer; 3MF unzips the OPC package (`fflate`) and reads the model prologue + slicer config.
- Registers `.stl`/`.3mf` in the FileDef code-ref map; threads the realm file-size limit through the index-time extractor; adds `fflate`.

The `.stl`/`.3mf` fixtures already in `filedef-fixtures` now resolve to these subclasses instead of the generic `FileDef`.

Supersedes #5658 — that PR predated the shared file-format shells and rolled its own four format templates + per-format inspector fields; this rebuilds the same feature on the shells the rest of the FileDef families now use.

## Design notes

- **One `model3d` field (not per-format fields).** The isolated shell renders exactly one 3D slot and no family overrides `isolated`, so both formats project onto a single `Model3dMetadataField` — the shell-native shape.
- **Header-only extraction.** True geometry (transform-correct dimensions, full triangle counts) comes from the live viewer, not the index. A value is present only when it sits cheaply in the header: a binary STL's facet count, a slicer 3MF's configured face/part counts, materials, provenance.
- **Known limitation:** the isolated `3D model` section gates on `meshes || triangles`. An STL reports `meshes: 1` (a solid) so it always shows; a config-less 3MF reports no geometry counts, so its section hides (generic name/type/size rows still show).

## Test plan

- `ember-tsc` clean; prettier clean; template-lint clean.
- Unit tests for the pure parsers (`model-meta-extractor-test.ts`) and an end-to-end file-extract acceptance test (`model-file-extract-test.gts`) asserting the `model3d` projection.
- Pending on a dev stack: index the `filedef-fixtures` corpus and confirm the stl / three-mf FormatPreview pages render with zero error rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)