### PR TITLE
Skip decorative-bullet normalization inside fenced code blocks

### DIFF
--- a/packages/host/tests/unit/marked-sync-test.ts
+++ b/packages/host/tests/unit/marked-sync-test.ts
@@ -472,17 +472,17 @@ module('Unit | marked-sync', function () {
     );
   });
 
-  test('indented code blocks are left verbatim', function (assert) {
-    const markdown = 'Example:\n\n    🚧 SITE UNDER CONSTRUCTION 🚧\n\n🌟 tail';
+  test('a decorative bullet indented four spaces under a list item renders as a nested list', function (assert) {
+    const markdown = '- item one\n    🌟 nested point';
     const result = markdownToHtml(markdown, { sanitize: false });
 
-    assert.false(
-      result.includes('* 🚧'),
-      'no list marker is inserted into the indented code block',
+    assert.true(
+      result.includes('<li>🌟 nested point</li>'),
+      'the indented decorative bullet becomes its own list item',
     );
     assert.true(
-      result.includes('<li>🌟 tail</li>'),
-      'normalization still applies outside the indented block',
+      /<li>item one[\s\S]*<ul>[\s\S]*🌟 nested point/.test(result),
+      'the decorative bullet nests as a sub-list under the parent item',
     );
   });
 

--- a/packages/host/tests/unit/marked-sync-test.ts
+++ b/packages/host/tests/unit/marked-sync-test.ts
@@ -344,6 +344,45 @@ module('Unit | marked-sync', function () {
     );
   });
 
+  test('markdownToHtml prefixes decorative bullets with a list marker', function (assert) {
+    const markdown = '🌟 First point\n🌟 Second point';
+    const result = markdownToHtml(markdown);
+
+    assert.true(
+      result.includes('<li>🌟 First point</li>'),
+      'emoji-led lines become list items',
+    );
+    assert.true(
+      result.includes('<li>🌟 Second point</li>'),
+      'each emoji-led line is its own list item',
+    );
+  });
+
+  test('markdownToHtml leaves fenced code block content verbatim when lines start with decorative bullets', function (assert) {
+    const markdown = [
+      '🌟 A real list item',
+      '```gts',
+      "  <span class='marquee-text'>",
+      '    🚧 SITE UNDER CONSTRUCTION 🚧',
+      '  </span>',
+      '```',
+    ].join('\n');
+    const result = markdownToHtml(markdown, { sanitize: false });
+
+    assert.true(
+      result.includes('<li>🌟 A real list item</li>'),
+      'bullet normalization still applies outside the fence',
+    );
+    assert.true(
+      result.includes('    🚧 SITE UNDER CONSTRUCTION 🚧'),
+      'emoji-led line inside the fence is unchanged',
+    );
+    assert.false(
+      result.includes('* 🚧'),
+      'no list marker is inserted inside the fence',
+    );
+  });
+
   test('markdownToHtml preserves heading IDs through sanitization', function (assert) {
     const markdown = '## Test Heading';
     const result = markdownToHtml(markdown);

--- a/packages/host/tests/unit/marked-sync-test.ts
+++ b/packages/host/tests/unit/marked-sync-test.ts
@@ -1,9 +1,30 @@
 import { module, test } from 'qunit';
 
 import {
+  SEARCH_MARKER,
+  SEPARATOR_MARKER,
+  REPLACE_MARKER,
+} from '@cardstack/runtime-common';
+import { escapeHtmlOutsideCodeBlocks } from '@cardstack/runtime-common/helpers/html';
+import {
   markedSync,
   markdownToHtml,
 } from '@cardstack/runtime-common/marked-sync';
+
+import { parseHtmlContent } from '@cardstack/host/lib/formatted-message/utils';
+
+// The render path a bot message's code patch travels before the host applies
+// it: markdown body → bodyHTML (message.ts) → parseHtmlContent →
+// codeData.searchReplaceBlock. The patch must survive this byte-identical —
+// the applier matches it against the target file.
+function roundTripSearchReplaceBlock(body: string) {
+  let html = markdownToHtml(escapeHtmlOutsideCodeBlocks(body), {
+    sanitize: false,
+    escapeHtmlInCodeBlocks: true,
+  });
+  let parts = parseHtmlContent(html, 'room-1', 'event-1');
+  return parts.find((p) => p.type === 'pre_tag')?.codeData ?? null;
+}
 
 module('Unit | marked-sync', function () {
   test('markedSync converts markdown to HTML', function (assert) {
@@ -380,6 +401,88 @@ module('Unit | marked-sync', function () {
     assert.false(
       result.includes('* 🚧'),
       'no list marker is inserted inside the fence',
+    );
+  });
+
+  test('a code patch round-trips byte-identical through render and extraction', function (assert) {
+    const search = [
+      "        <div class='marquee-wrap'>",
+      '            🚧 SITE UNDER CONSTRUCTION 🚧 &nbsp;&nbsp;&nbsp; BEST VIEWED IN',
+      '        </div>',
+    ].join('\n');
+    const block = `${SEARCH_MARKER}\n${search}\n${SEPARATOR_MARKER}\nreplaced\n${REPLACE_MARKER}`;
+    const body = `Fixing the file now.\n\n\`\`\`gts\nhttps://example.test/hello-world.gts\n${block}\n\`\`\``;
+
+    const codeData = roundTripSearchReplaceBlock(body);
+    assert.ok(codeData, 'a code block was extracted');
+    assert.strictEqual(
+      codeData!.searchReplaceBlock,
+      block,
+      'the extracted patch is byte-identical to what the bot authored',
+    );
+  });
+
+  test('a code patch round-trips intact from CRLF input', function (assert) {
+    const search = '            🚧 SITE UNDER CONSTRUCTION 🚧';
+    const block = `${SEARCH_MARKER}\n${search}\n${SEPARATOR_MARKER}\nreplaced\n${REPLACE_MARKER}`;
+    const body =
+      `Fixing the file now.\n\n\`\`\`gts\nhttps://example.test/hello-world.gts\n${block}\n\`\`\``.replace(
+        /\n/g,
+        '\r\n',
+      );
+
+    const codeData = roundTripSearchReplaceBlock(body);
+    assert.ok(codeData, 'a code block was extracted from CRLF input');
+    assert.ok(
+      codeData!.searchReplaceBlock?.includes(search),
+      'the emoji-led search line survives unmutated',
+    );
+    assert.false(
+      (codeData!.searchReplaceBlock ?? '').includes('* 🚧'),
+      'no list marker was inserted into the CRLF fenced content',
+    );
+  });
+
+  test('a fence opened on a list-item line is respected and does not invert fence tracking', function (assert) {
+    const markdown = [
+      '- ```gts',
+      '  🚧 SITE UNDER CONSTRUCTION 🚧',
+      '  ```',
+      '',
+      '🌟 after the list',
+    ].join('\n');
+    const result = markdownToHtml(markdown, { sanitize: false });
+
+    assert.false(
+      result.includes('* 🚧'),
+      'content of the list-nested fence is unchanged',
+    );
+    assert.true(
+      result.includes('<li>🌟 after the list</li>'),
+      'normalization still applies after the fence closes (state did not invert)',
+    );
+  });
+
+  test('a decorative bullet alone on its line still becomes a list item', function (assert) {
+    const result = markdownToHtml('🌟\n\ntext after', { sanitize: false });
+
+    assert.true(
+      result.includes('<li>🌟</li>'),
+      'a bare decorative bullet line is normalized',
+    );
+  });
+
+  test('indented code blocks are left verbatim', function (assert) {
+    const markdown = 'Example:\n\n    🚧 SITE UNDER CONSTRUCTION 🚧\n\n🌟 tail';
+    const result = markdownToHtml(markdown, { sanitize: false });
+
+    assert.false(
+      result.includes('* 🚧'),
+      'no list marker is inserted into the indented code block',
+    );
+    assert.true(
+      result.includes('<li>🌟 tail</li>'),
+      'normalization still applies outside the indented block',
     );
   });
 

--- a/packages/runtime-common/marked-sync.ts
+++ b/packages/runtime-common/marked-sync.ts
@@ -88,18 +88,17 @@ const CODE_FENCE_PATTERN = /^(\s*)(`{3,}|~{3,})(.*)\r?$/;
 // list marker.
 const LIST_PREFIXED_CODE_FENCE_PATTERN =
   /^(\s*)(?:[-*+]|\d{1,9}[.)])\s+(`{3,}|~{3,})(.*)\r?$/;
-// A 4-space (or tab) indented line outside a fence is an indented code block
-// to marked, and the extraction side treats its <pre> exactly like a fenced
-// one — so rewriting it corrupts code the same way. The rewrite is cosmetic
-// when skipped wrongly and destructive when applied wrongly, so indented
-// lines are left alone.
-const INDENTED_CODE_PATTERN = /^(?: {4}|\t)/;
-
 // Prefix decorative bullets with a standard list marker so marked treats them
-// as list items — but never inside code blocks (fenced or indented). Code
-// content must survive rendering verbatim: search/replace patches are
-// extracted back out of the rendered HTML, and an inserted marker makes the
-// patch text no longer match the file it targets.
+// as list items — but never inside fenced code blocks. Fenced content must
+// survive rendering verbatim: search/replace patches are extracted back out
+// of the rendered HTML, and an inserted marker makes the patch text no longer
+// match the file it targets.
+//
+// Only *fenced* blocks are protected. A 4-space indented line is an indented
+// code block to marked in some contexts, but inside a list item the same
+// indentation is ordinary list content (a nested bullet); telling the two
+// apart needs block context that only the lexer has. Since the patch format
+// is always fenced, indented code blocks are left to the rewrite.
 function normalizeDecorativeBullets(markdown: string): string {
   let inFence = false;
   let fenceChar = '';
@@ -126,9 +125,6 @@ function normalizeDecorativeBullets(markdown: string): string {
         inFence = true;
         fenceChar = openMatch[2][0];
         fenceLength = openMatch[2].length;
-        return line;
-      }
-      if (INDENTED_CODE_PATTERN.test(line)) {
         return line;
       }
       return line.replace(

--- a/packages/runtime-common/marked-sync.ts
+++ b/packages/runtime-common/marked-sync.ts
@@ -70,17 +70,36 @@ bfmMarked.use({
   },
 });
 
+// The trailing `\s+|\r?$` alternation keeps a bullet that ends its line —
+// with or without trailing text — normalizable; split('\n') has already
+// consumed the newline the old whole-string pattern used to match.
 const DECORATIVE_BULLET_PATTERN =
   // eslint-disable-next-line no-misleading-character-class -- match pictographic symbols plus a few geometric glyphs not covered by the Unicode class
-  /^(\s*)([\p{Extended_Pictographic}★•▪●❖✦✧◉◦◾◽⬢⬡☑✔☑️➤➔➜➡→])(\s+)/u;
+  /^(\s*)([\p{Extended_Pictographic}★•▪●❖✦✧◉◦◾◽⬢⬡☑✔☑️➤➔➜➡→])(\s+|\r?$)/u;
 
-const CODE_FENCE_PATTERN = /^(\s*)(`{3,}|~{3,})(.*)$/;
+// `.` never matches `\r`, so on CRLF input the greedy group stops before a
+// trailing `\r`; the explicit `\r?` lets `$` still anchor. Without it no
+// fence line would ever match CRLF content and the tracker would rewrite
+// fenced code.
+const CODE_FENCE_PATTERN = /^(\s*)(`{3,}|~{3,})(.*)\r?$/;
+// Markdown can open a fence on the same line as a list marker (`- ```gts`);
+// marked treats that as fenced code, so the tracker must too. Only openers
+// take this form — a closing fence cannot carry an info string, let alone a
+// list marker.
+const LIST_PREFIXED_CODE_FENCE_PATTERN =
+  /^(\s*)(?:[-*+]|\d{1,9}[.)])\s+(`{3,}|~{3,})(.*)\r?$/;
+// A 4-space (or tab) indented line outside a fence is an indented code block
+// to marked, and the extraction side treats its <pre> exactly like a fenced
+// one — so rewriting it corrupts code the same way. The rewrite is cosmetic
+// when skipped wrongly and destructive when applied wrongly, so indented
+// lines are left alone.
+const INDENTED_CODE_PATTERN = /^(?: {4}|\t)/;
 
 // Prefix decorative bullets with a standard list marker so marked treats them
-// as list items — but never inside fenced code blocks. Code-block content must
-// survive rendering verbatim: search/replace patches are extracted back out of
-// the rendered HTML, and an inserted marker makes the patch text no longer
-// match the file it targets.
+// as list items — but never inside code blocks (fenced or indented). Code
+// content must survive rendering verbatim: search/replace patches are
+// extracted back out of the rendered HTML, and an inserted marker makes the
+// patch text no longer match the file it targets.
 function normalizeDecorativeBullets(markdown: string): string {
   let inFence = false;
   let fenceChar = '';
@@ -88,23 +107,28 @@ function normalizeDecorativeBullets(markdown: string): string {
   return markdown
     .split('\n')
     .map((line) => {
-      let fenceMatch = line.match(CODE_FENCE_PATTERN);
-      if (fenceMatch) {
-        let marker = fenceMatch[2];
-        if (!inFence) {
-          inFence = true;
-          fenceChar = marker[0];
-          fenceLength = marker.length;
-        } else if (
-          marker[0] === fenceChar &&
-          marker.length >= fenceLength &&
-          fenceMatch[3].trim() === ''
+      if (inFence) {
+        let closeMatch = line.match(CODE_FENCE_PATTERN);
+        if (
+          closeMatch &&
+          closeMatch[2][0] === fenceChar &&
+          closeMatch[2].length >= fenceLength &&
+          closeMatch[3].trim() === ''
         ) {
           inFence = false;
         }
         return line;
       }
-      if (inFence) {
+      let openMatch =
+        line.match(CODE_FENCE_PATTERN) ??
+        line.match(LIST_PREFIXED_CODE_FENCE_PATTERN);
+      if (openMatch) {
+        inFence = true;
+        fenceChar = openMatch[2][0];
+        fenceLength = openMatch[2].length;
+        return line;
+      }
+      if (INDENTED_CODE_PATTERN.test(line)) {
         return line;
       }
       return line.replace(

--- a/packages/runtime-common/marked-sync.ts
+++ b/packages/runtime-common/marked-sync.ts
@@ -72,7 +72,49 @@ bfmMarked.use({
 
 const DECORATIVE_BULLET_PATTERN =
   // eslint-disable-next-line no-misleading-character-class -- match pictographic symbols plus a few geometric glyphs not covered by the Unicode class
-  /(^|\n)(\s*)([\p{Extended_Pictographic}★•▪●❖✦✧◉◦◾◽⬢⬡☑✔☑️➤➔➜➡→])(\s+)/gu;
+  /^(\s*)([\p{Extended_Pictographic}★•▪●❖✦✧◉◦◾◽⬢⬡☑✔☑️➤➔➜➡→])(\s+)/u;
+
+const CODE_FENCE_PATTERN = /^(\s*)(`{3,}|~{3,})(.*)$/;
+
+// Prefix decorative bullets with a standard list marker so marked treats them
+// as list items — but never inside fenced code blocks. Code-block content must
+// survive rendering verbatim: search/replace patches are extracted back out of
+// the rendered HTML, and an inserted marker makes the patch text no longer
+// match the file it targets.
+function normalizeDecorativeBullets(markdown: string): string {
+  let inFence = false;
+  let fenceChar = '';
+  let fenceLength = 0;
+  return markdown
+    .split('\n')
+    .map((line) => {
+      let fenceMatch = line.match(CODE_FENCE_PATTERN);
+      if (fenceMatch) {
+        let marker = fenceMatch[2];
+        if (!inFence) {
+          inFence = true;
+          fenceChar = marker[0];
+          fenceLength = marker.length;
+        } else if (
+          marker[0] === fenceChar &&
+          marker.length >= fenceLength &&
+          fenceMatch[3].trim() === ''
+        ) {
+          inFence = false;
+        }
+        return line;
+      }
+      if (inFence) {
+        return line;
+      }
+      return line.replace(
+        DECORATIVE_BULLET_PATTERN,
+        (_match, indentation, bullet, whitespace) =>
+          `${indentation}* ${bullet}${whitespace}`,
+      );
+    })
+    .join('\n');
+}
 
 const DEFAULT_MARKED_SYNC_OPTIONS = {
   escapeHtmlInCodeBlocks: true,
@@ -187,11 +229,7 @@ export function markdownToHtml(
     return '';
   }
   // Marked only treats ASCII list markers, so prefix decorative bullets with a standard marker.
-  let normalizedMarkdown = markdown.replace(
-    DECORATIVE_BULLET_PATTERN,
-    (_match, boundary, indentation, bullet, whitespace) =>
-      `${boundary}${indentation}* ${bullet}${whitespace}`,
-  );
+  let normalizedMarkdown = normalizeDecorativeBullets(markdown);
   let html = markedSync(normalizedMarkdown, {
     escapeHtmlInCodeBlocks: opts.escapeHtmlInCodeBlocks,
     enableMonacoSyntaxHighlighting: opts.enableMonacoSyntaxHighlighting,


### PR DESCRIPTION
There was a case where ai assistant code patches were failing over and over even though it re-read the file multiple times. Here's an example:

<img width="525" height="1144" alt="image" src="https://github.com/user-attachments/assets/105a4244-61e9-4413-b382-d9489795dff4" />

Claude's summary:

The AI assistant's code patches could fail forever with "search pattern not found" even though the search block matched the target file exactly. The cause is in `markdownToHtml`: it prefixes emoji/star-led lines with a `* ` list marker so marked renders them as lists, and it applied that rewrite to the entire message — including the content of fenced code blocks. The host extracts search/replace patches from the rendered HTML, so a patch containing a line that starts with an emoji was mutated before matching:

```
bot message (markdown)                 file on disk
  ```gts                                 🚧 SITE UNDER ...
  ╔═══ SEARCH ════╗
  🚧 SITE UNDER ...
  ```
        │ markdownToHtml inserts "* " before 🚧
        ▼
  * 🚧 SITE UNDER ...   ──match──✗──►   🚧 SITE UNDER ...
```

The bot re-reads the file and resends a correct patch, the renderer corrupts it again, and the loop never converges. The same rewrite also corrupted patches that did apply: REPLACE content with emoji-led lines was written to the file with stray `* ` markers injected.

The normalization now walks the markdown line by line with code-fence tracking (``` and ~~~ fences) and leaves fenced content verbatim; lines outside fences are normalized exactly as before.