### PR TITLE
Correct the BXL functions that answered something other than their specification

### DIFF
--- a/packages/bxl/CHANGELOG.md
+++ b/packages/bxl/CHANGELOG.md
@@ -56,6 +56,30 @@ versions may change syntax behavior until `1.0.0`.
   TypeScript — `engines.node` is now `>=24`.
 - Relative import specifiers use `.ts` extensions throughout.
 
+### Fixed
+
+- **Twenty functions that answered something other than their specification.**
+  On the jq side: named captures now travel on a match, so `capture`, `sub` and
+  `gsub` can read them, and a group that did not participate reports an absent
+  capture rather than crashing; `round` ties away from zero; `isinfinite`
+  excludes NaN, and `isfinite` with it; `lgamma_r` returns its `[magnitude,
+  sign]` pair; `scalars_or_empty` keeps empty collections; `max_by` breaks ties
+  on the last maximum, as jq does; `inputs` yields an empty stream. On the Excel
+  side: `PROPER`, `TRIM`, `SEARCH` (wildcards), `SUBSTITUTE` (an occurrence at
+  position 0), `TEXT` (date format codes), `NUMBERVALUE` (percent signs and
+  spaces), `CHAR` (bounded to 1–255), `ISEVEN`/`ISODD` (truncation),
+  `WEEKDAY`/`WEEKNUM` (every return type), `ISOWEEKNUM`, `TIMEVALUE` (AM/PM),
+  `BASE`/`BIN2HEX`/`DEC2HEX`/`OCT2HEX` (upper-case digits), `COMPLEX` (`-i`),
+  `ERF`/`ERFC` (full double precision), `WEIBULL_DIST` (shape and scale),
+  `T_TEST` (Welch degrees of freedom), `IRR`/`IRR_BY`/`XIRR` (`#NUM!` for a
+  series with no root), the `TBILL` family (maturity within a year) and
+  `COUPDAYS` (a real coupon period under actual/actual). Each is pinned by a
+  case in the function-coverage suite; see `src/*/UPSTREAM-DIFFS.md`.
+
+- **Numeric literals accept an exponent.** `1e3`, `1E-3` and `5e-324` are
+  single numbers in both readable and canonical-jq syntax, where the tokenizer
+  previously ended the literal at the first digit and read the rest as a name.
+
 ### Removed
 
 - **`BXL_BUILD_INFO.buildTime`.** Only a bundling step ever set it; the const

--- a/packages/bxl/CHANGELOG.md
+++ b/packages/bxl/CHANGELOG.md
@@ -76,6 +76,15 @@ versions may change syntax behavior until `1.0.0`.
   `COUPDAYS` (a real coupon period under actual/actual). Each is pinned by a
   case in the function-coverage suite; see `src/*/UPSTREAM-DIFFS.md`.
 
+- **Excel wildcards are matched in linear time.** `SEARCH` and the `COUNTIF`
+  family of criteria share one matcher that walks the text once. Compiling `*`
+  to a regex's `.*` made a pattern carrying several stars exponential — a stray
+  run of asterisks over an ordinary text field took tens of seconds, blocking an
+  indexing worker or the browser's main thread.
+
+- **`max_by`/`min_by` on an empty array yield `null`**, as `max`/`min` already
+  did, rather than an empty stream.
+
 - **Numeric literals accept an exponent.** `1e3`, `1E-3` and `5e-324` are
   single numbers in both readable and canonical-jq syntax, where the tokenizer
   previously ended the literal at the first digit and read the rest as a name.

--- a/packages/bxl/docs/grammar.ebnf
+++ b/packages/bxl/docs/grammar.ebnf
@@ -122,7 +122,8 @@ CompareOp          = "==" | "!=" | "<" | "<=" | ">" | ">=" ;
 Identifier         = Letter, { Letter | Digit | "_" } ;
 QuotedLabel        = String ;
 String             = '"', { JsonStringChar }, '"' ;
-Number             = Digit, { Digit }, [ ".", Digit, { Digit } ] ;
+Number             = Digit, { Digit }, [ ".", Digit, { Digit } ],
+                     [ ("e" | "E"), [ "+" | "-" ], Digit, { Digit } ] ;
 
 NativeExpr         = (* Any expression accepted by the jqxl parser. *) ;
 Letter             = "A".."Z" | "a".."z" | "_" ;

--- a/packages/bxl/docs/syntax-reference.md
+++ b/packages/bxl/docs/syntax-reference.md
@@ -112,15 +112,19 @@ If you need log-Γ, use the unambiguous spellings — they compute the same thin
 
 jq has an `INDEX` of its own: `INDEX(stream; key_expr)` builds an object keyed
 by an expression, and `INDEX(key_expr)` is the same over `.[]`. Excel's
-`INDEX(array, row)` claims that name here, and it wins — spreadsheet authors are
-this surface's audience and the formula library loads by default for cards. jq's
-`INDEX` is therefore unreachable, in both arities, and calling it fails with
-`Cannot index array with string`.
+`INDEX(array, row)` claims the two-argument name here, and it wins — spreadsheet
+authors are this surface's audience and the formula library loads by default for
+cards. So the object-building `INDEX` is out of reach in both arities: the
+two-argument form resolves to Excel's positional lookup and fails with
+`Cannot index array with string`, and the one-argument form is jq's own
+`index` — index-of — in readable BXL, or a delegation to the shadowed
+two-argument form in canonical jq.
 
-The linter says so rather than leaving that message to explain itself: a one-
-argument `INDEX`, or a two-argument one written with jq's semicolon, reports
-`jq-index-shadowed-by-excel` at warning severity. The substitutes are ordinary
-jq:
+The linter says so rather than leaving that message to explain itself: a
+two-argument `INDEX` written with jq's semicolon reports
+`jq-index-shadowed-by-excel` at warning severity. One argument is not flagged,
+since index-of is a function in its own right, and jq has no three-argument
+`INDEX` to shadow. The substitutes are ordinary jq:
 
 ```text
 reduce Rows[] as $row ({}; .[$row.id] = $row)   -- key rows by a field

--- a/packages/bxl/docs/syntax-reference.md
+++ b/packages/bxl/docs/syntax-reference.md
@@ -108,6 +108,26 @@ If you need log-Γ, use the unambiguous spellings — they compute the same thin
 | true Γ(x) | `x \| gamma` (== `tgamma`) | `GAMMA(x)`     |
 | log Γ(x)  | `x \| lgamma`              | `GAMMALN(x)`   |
 
+#### `INDEX` — Excel's positional lookup takes the name
+
+jq has an `INDEX` of its own: `INDEX(stream; key_expr)` builds an object keyed
+by an expression, and `INDEX(key_expr)` is the same over `.[]`. Excel's
+`INDEX(array, row)` claims that name here, and it wins — spreadsheet authors are
+this surface's audience and the formula library loads by default for cards. jq's
+`INDEX` is therefore unreachable, in both arities, and calling it fails with
+`Cannot index array with string`.
+
+The linter says so rather than leaving that message to explain itself: a one-
+argument `INDEX`, or a two-argument one written with jq's semicolon, reports
+`jq-index-shadowed-by-excel` at warning severity. The substitutes are ordinary
+jq:
+
+```text
+reduce Rows[] as $row ({}; .[$row.id] = $row)   -- key rows by a field
+Rows | map({key: .id, value: .}) | from_entries -- the same, via pairs
+INDEX(.names, 2)                                -- Excel: second name
+```
+
 #### Quick reference: collisions and resolutions
 
 > Spelling reminder: prefer the **UPPERCASE** form for any name that ends up at an Excel function. Lowercase still resolves but the linter emits an info-level `excel-name-uppercase-preferred` nudge — see [Linter style nudges](#linter-style-nudges).
@@ -116,6 +136,7 @@ If you need log-Γ, use the unambiguous spellings — they compute the same thin
 | ------------------------------------------ | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `MATCH(value, array)` / `match(re; flags)` | Excel lookup with comma; jq regex with semicolon      | `match(re)` is jq by arity; `MATCH(value, array, 0)` is Excel by arity.                             |
 | `INDEX(array, row)` / `index(value)`       | Excel lookup with 2-3 args; jq index-of with 1 arg    | Excel rows are one-based; jq index result is zero-based.                                            |
+| `INDEX(array, row)` / `INDEX(stream; key)` | Excel lookup wins; jq's object-building INDEX is unreachable | Not a dispatch: both spell `INDEX/2`. The linter reports `jq-index-shadowed-by-excel`.        |
 | `TYPE(value)` / `type`                     | Excel numeric type code vs jq type string             | Parenthesized one-arg call is Excel; bare pipe filter is jq.                                        |
 | `LOG(x)` / `log`                           | Excel base-10 log vs jq natural log                   | Arity decides. `LOG(x, base)` is Excel.                                                             |
 | `NOW()` / `now`                            | Excel date serial vs jq epoch seconds                 | Call shape decides. `now()` is Excel and formats to `NOW()`. Bare `NOW` is jq and formats to `now`. |
@@ -271,7 +292,7 @@ BXL absorbs five Excel-specific idioms so a formula from a spreadsheet works ver
 | `&` string concat                 | Rewrite to `((a\|tostring) + (b\|tostring))` — Excel-style coercion.       | `"Invoice-" & "Invoice Number"` |
 | Unknown characters                | Caught by the linter as `untokenizable-character`; never crashes solidify. | —                               |
 
-> **Paste test:** Sampled FormulaJS cases across math/trig, text, logical, statistical, engineering, information, date/time, and financial formulas work unchanged in the async compatibility runtime. Known paste gap: `MODE` is not implemented. `AND` / `OR` / `XOR` use array-style arguments, and `DEC2HEX` returns lowercase.
+> **Paste test:** Sampled FormulaJS cases across math/trig, text, logical, statistical, engineering, information, date/time, and financial formulas work unchanged in the async compatibility runtime. Known paste gap: `MODE` is not implemented, and `AND` / `OR` / `XOR` use array-style arguments.
 
 ## Interesting Patterns
 

--- a/packages/bxl/docs/syntax-reference.md
+++ b/packages/bxl/docs/syntax-reference.md
@@ -1216,7 +1216,7 @@ INDEX(.names, MATCH("target", .ids, 0))
 
 | Function                      | Description                                                                                                                    | Example                                                        |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
-| `IF(test, then, else)`        | Excel-style conditional                                                                                                        | `IF(.score >= 90, "A", "B")`                                   |
+| `IF(test, then, else)`        | Excel-style conditional. The test is read with jq truthiness: only `null` and `false` are false, so `IF(0, …)` takes the true branch where Excel takes the false one. | `IF(.score >= 90, "A", "B")`   |
 | `IFERROR(val, fallback)`      | Catch any error                                                                                                                | `IFERROR(.x / .y, 0)`                                          |
 | `IFNA(val, fallback)`         | Catch only #N/A                                                                                                                | `IFNA(VLOOKUP(...), "missing")`                                |
 | `IFS(c1, v1, c2, v2, ...)`    | Multiple conditions (2--4 pairs)                                                                                               | `IFS(.x > 90, "A", .x > 80, "B", true, "C")`                   |
@@ -1341,7 +1341,7 @@ validation extension.
 | `isBase58`             | `isBase58(value)`                            | Base58 string.                                                                                                    |
 | `isBase64`             | `isBase64(value[, options])`                 | Base64 string.                                                                                                    |
 | `isBoolean`            | `isBoolean(value[, options])`                | Boolean string.                                                                                                   |
-| `isByteLength`         | `isByteLength(value[, options])`             | UTF-8 byte length range.                                                                                          |
+| `isByteLength`         | `isByteLength(value, options)`               | UTF-8 byte length range. Pass the options: upstream validator.js reads the minimum with no fallback, so the one-argument form compares against `undefined` and is false for every string. Its sibling `isLength` has the fallback. |
 | `isDecimal`            | `isDecimal(value[, options])`                | Decimal number string.                                                                                            |
 | `isDivisibleBy`        | `isDivisibleBy(value, number)`               | Numeric string divisible by number.                                                                               |
 | `isEmpty`              | `isEmpty(value[, options])`                  | Empty string.                                                                                                     |

--- a/packages/bxl/examples/bxl-formula-examples.ts
+++ b/packages/bxl/examples/bxl-formula-examples.ts
@@ -549,7 +549,7 @@ export const bxlFormulaExamples: BxlFormulaExample[] = [
     level: '06 date finance engineering',
     name: 'base conversion',
     expression: 'BASE(255, 16)',
-    expected: 'ff',
+    expected: 'FF',
   },
   {
     id: 76,

--- a/packages/bxl/src/bxl/bridge/formula-contrib-jq.ts
+++ b/packages/bxl/src/bxl/bridge/formula-contrib-jq.ts
@@ -6,6 +6,11 @@ def FALSE: false;
 def NA: "#N/A" | error;
 def INDEX(array; row): _EXCEL_INDEX(array; row);
 def INDEX(array; row; column): _EXCEL_INDEX(array; row; column);
+# IF and IFS carry a second implementation in the compiled-scalar fast path,
+# jqtools/evaluate/compiledScalar.ts, which answers any formula that compiles
+# wholly to scalars — so these definitions run only for the rest. Keep the two
+# in step. Both read a condition with jq truthiness: only null and false are
+# false, so the number 0 takes the true branch where Excel takes the false one.
 def IF(test; value_if_true; value_if_false):
   . as $xl_in
   | if ($xl_in | test)

--- a/packages/bxl/src/bxl/bridge/formula-contrib-native.ts
+++ b/packages/bxl/src/bxl/bridge/formula-contrib-native.ts
@@ -20,6 +20,7 @@ import {
 } from '../../formulajs/criteria.ts';
 import { EXCEL_ERROR, throwExcelError } from '../../formulajs/errors.ts';
 import { isoWeekNumber } from '../../formulajs/isoWeek.ts';
+import { excelWildcardSearch } from '../../formulajs/wildcard.ts';
 import { compare } from '../../jqtools/evaluate/compare.ts';
 import type { BareNativeFilter } from '../../jqtools/evaluate/filters/lib/nativeFilter.ts';
 import { wrapBareNativeFilters } from '../../jqtools/evaluate/filters/lib/nativeFilter.ts';
@@ -218,7 +219,12 @@ function nowSerial() {
 const SERIAL_EPOCH_UTC_MS = Date.UTC(1899, 11, 30);
 
 function serialToUtcDate(serial: number): Date {
-  return new Date(SERIAL_EPOCH_UTC_MS + serial * NOW_SERIAL_MS_PER_DAY);
+  // Rounded to the millisecond: a serial is a fraction that rarely lands on one
+  // exactly, and Date truncates toward zero, which would drop a second off a
+  // time of day below the 1970 epoch and not above it.
+  return new Date(
+    Math.round(SERIAL_EPOCH_UTC_MS + serial * NOW_SERIAL_MS_PER_DAY),
+  );
 }
 
 function weekdayValue(serialDateLike: unknown, returnTypeLike: unknown = 1) {
@@ -277,31 +283,6 @@ function replaceNth(
   return text;
 }
 
-/**
- * Excel's wildcards for the arguments that take them: `*` for any run of
- * characters, `?` for exactly one, and `~` escaping any of the three.
- */
-function excelWildcardPattern(pattern: string, flags: string): RegExp {
-  let source = '';
-  for (let index = 0; index < pattern.length; index++) {
-    const char = pattern[index];
-    if (char === '~' && '*?~'.includes(pattern[index + 1] ?? '')) {
-      source += escapeRegExpLiteral(pattern[++index]);
-    } else if (char === '*') {
-      source += '[\\s\\S]*';
-    } else if (char === '?') {
-      source += '[\\s\\S]';
-    } else {
-      source += escapeRegExpLiteral(char);
-    }
-  }
-  return new RegExp(source, flags);
-}
-
-function escapeRegExpLiteral(text: string) {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 function searchValue(
   findTextLike: unknown,
   withinTextLike: unknown,
@@ -318,9 +299,7 @@ function searchValue(
   }
   // SEARCH differs from FIND in two ways, not one: it ignores case and it
   // reads find_text as a wildcard pattern.
-  const found = withinText
-    .slice(startNum - 1)
-    .search(excelWildcardPattern(findText, 'i'));
+  const found = excelWildcardSearch(findText, withinText.slice(startNum - 1));
   if (found === -1) {
     throwExcelError(EXCEL_ERROR.value);
   }
@@ -398,12 +377,16 @@ const WEEKDAY_NAMES = [
 
 type DateFormatField =
   | 'literal'
+  | 'ignored'
   | 'year'
   | 'month'
   | 'day'
   | 'hour'
   | 'minute'
   | 'second'
+  | 'elapsedHour'
+  | 'elapsedMinute'
+  | 'elapsedSecond'
   | 'meridiem';
 
 interface DateFormatToken {
@@ -411,23 +394,50 @@ interface DateFormatToken {
   text: string;
 }
 
+// A bracketed run is a colour, a condition or a locale — none of them date
+// codes — unless it is one of the elapsed-time codes, which are.
+const ELAPSED_CODE = /^\[(h+|m+|s+)\]$/i;
+const NON_ELAPSED_BRACKET = /\[(?!(?:h+|m+|s+)\])[^\]]*\]/gi;
+// Everything a clock is allowed to be punctuated with, for reading whether an
+// `m` run sits next to an hour or a seconds run.
+const CLOCK_SEPARATOR = /^[\s:.,\-/]$/;
+
 /**
  * True when a format code addresses a date or a time rather than a number.
- * Quoted and escaped literals are excluded, since they may spell anything.
+ * Quoted, escaped and bracketed runs are excluded: they may spell anything,
+ * and `[Red]` carrying a `d` would otherwise make a currency format a date.
  */
 function isDateFormatCode(formatText: string) {
   return /[ymdhs]/i.test(
-    formatText.replace(/"[^"]*"/g, '').replace(/\\[\s\S]/g, ''),
+    formatText
+      .replace(/"[^"]*"/g, '')
+      .replace(/\\[\s\S]/g, '')
+      .replace(NON_ELAPSED_BRACKET, ''),
   );
 }
 
 function tokenizeDateFormat(formatText: string): DateFormatToken[] {
   const runs =
-    formatText.match(/AM\/PM|A\/P|y+|m+|d+|h+|s+|"[^"]*"|\\[\s\S]|[\s\S]/gi) ??
-    [];
+    formatText.match(
+      /AM\/PM|A\/P|\[[^\]]*\]|y+|m+|d+|h+|s+|"[^"]*"|\\[\s\S]|[\s\S]/gi,
+    ) ?? [];
   const tokens = runs.map((text): DateFormatToken => {
     const code = text.toLowerCase();
     if (code === 'am/pm' || code === 'a/p') return { field: 'meridiem', text };
+    const elapsed = ELAPSED_CODE.exec(code);
+    if (elapsed) {
+      const unit = elapsed[1][0];
+      return {
+        field:
+          unit === 'h'
+            ? 'elapsedHour'
+            : unit === 'm'
+              ? 'elapsedMinute'
+              : 'elapsedSecond',
+        text,
+      };
+    }
+    if (code.startsWith('[')) return { field: 'ignored', text };
     if (/^y+$/.test(code)) return { field: 'year', text };
     if (/^m+$/.test(code)) return { field: 'month', text };
     if (/^d+$/.test(code)) return { field: 'day', text };
@@ -436,21 +446,29 @@ function tokenizeDateFormat(formatText: string): DateFormatToken[] {
     return { field: 'literal', text };
   });
 
-  // An `m` run means minutes when it neighbours an hour or second run, and
-  // months everywhere else. Only separators may sit in between.
+  // An `m` run means minutes exactly where the clock puts it: directly after an
+  // hour run, or directly before a seconds run, with nothing but separators in
+  // between. Everywhere else it is the month — including before an hour, which
+  // is how `d mmm h:mm` keeps its month name.
   const neighbour = (from: number, step: number): DateFormatField => {
     for (let i = from + step; i >= 0 && i < tokens.length; i += step) {
-      if (tokens[i].field !== 'literal') return tokens[i].field;
-      if (!/^[\s:.,\-/]$/.test(tokens[i].text)) break;
+      const { field, text } = tokens[i];
+      if (field === 'ignored') continue;
+      if (field !== 'literal') return field;
+      if (!CLOCK_SEPARATOR.test(text)) break;
     }
     return 'literal';
   };
-  tokens.forEach((token, index) => {
-    if (token.field !== 'month') return;
-    const adjacent = [neighbour(index, -1), neighbour(index, 1)];
-    if (adjacent.includes('hour') || adjacent.includes('second')) {
-      token.field = 'minute';
-    }
+  // Decided against the original classification, then applied, so that one
+  // `m` run's reading cannot depend on another's having been rewritten first.
+  const readsAsMinutes = tokens.map(
+    (token, index) =>
+      token.field === 'month' &&
+      (['hour', 'elapsedHour'].includes(neighbour(index, -1)) ||
+        ['second', 'elapsedSecond'].includes(neighbour(index, 1))),
+  );
+  readsAsMinutes.forEach((isMinutes, index) => {
+    if (isMinutes) tokens[index].field = 'minute';
   });
 
   return tokens;
@@ -462,10 +480,16 @@ function renderDateFormat(serial: number, formatText: string) {
   const twelveHour = tokens.some((token) => token.field === 'meridiem');
   const pad = (value: number, width: number) =>
     String(value).padStart(width, '0');
+  // Elapsed totals come from the rounded millisecond rather than the raw
+  // serial, so a duration that is a whole number of seconds does not truncate
+  // to one less through the fraction that represents it.
+  const elapsedMs = Math.round(serial * NOW_SERIAL_MS_PER_DAY);
 
   return tokens
     .map(({ field, text }) => {
       const width = text.length;
+      // An elapsed code carries its width inside the brackets.
+      const bracketWidth = width - 2;
       switch (field) {
         case 'year':
           return width <= 2
@@ -493,6 +517,17 @@ function renderDateFormat(serial: number, formatText: string) {
           return pad(date.getUTCMinutes(), Math.min(width, 2));
         case 'second':
           return pad(date.getUTCSeconds(), Math.min(width, 2));
+        // Elapsed time is the whole duration, not a field of the clock, so
+        // `[h]:mm` on a day and a half is 36:00 rather than 12:00.
+        case 'elapsedHour':
+          return pad(Math.floor(elapsedMs / 3_600_000), bracketWidth);
+        case 'elapsedMinute':
+          return pad(Math.floor(elapsedMs / 60_000), bracketWidth);
+        case 'elapsedSecond':
+          return pad(Math.floor(elapsedMs / 1_000), bracketWidth);
+        // A colour, condition or locale code prints nothing.
+        case 'ignored':
+          return '';
         case 'meridiem': {
           const half = date.getUTCHours() < 12 ? 'AM' : 'PM';
           const shown = text.length === 3 ? half.slice(0, 1) : half;

--- a/packages/bxl/src/bxl/bridge/formula-contrib-native.ts
+++ b/packages/bxl/src/bxl/bridge/formula-contrib-native.ts
@@ -310,7 +310,10 @@ function searchValue(
   const findText = parseExcelString(findTextLike);
   const withinText = parseExcelString(withinTextLike);
   const startNum = Math.trunc(parseExcelNumber(startNumLike));
-  if (startNum < 1) {
+  // A start position outside the text is an error, not an empty haystack —
+  // otherwise a pattern that can match nothing, like `*`, would report a hit
+  // past the end of the string.
+  if (startNum < 1 || startNum > withinText.length) {
     throwExcelError(EXCEL_ERROR.value);
   }
   // SEARCH differs from FIND in two ways, not one: it ignores case and it
@@ -469,10 +472,12 @@ function renderDateFormat(serial: number, formatText: string) {
             ? pad(date.getUTCFullYear() % 100, 2)
             : pad(date.getUTCFullYear(), 4);
         case 'month': {
+          // Five m's is Excel's single-letter month, past four's full name.
           const name = MONTH_NAMES[date.getUTCMonth()];
-          if (width >= 4) return name;
+          if (width >= 5) return name.slice(0, 1);
+          if (width === 4) return name;
           if (width === 3) return name.slice(0, 3);
-          return pad(date.getUTCMonth() + 1, Math.min(width, 2));
+          return pad(date.getUTCMonth() + 1, width);
         }
         case 'day': {
           if (width >= 4) return WEEKDAY_NAMES[date.getUTCDay()];

--- a/packages/bxl/src/bxl/bridge/formula-contrib-native.ts
+++ b/packages/bxl/src/bxl/bridge/formula-contrib-native.ts
@@ -19,6 +19,7 @@ import {
   matchesCriteria,
 } from '../../formulajs/criteria.ts';
 import { EXCEL_ERROR, throwExcelError } from '../../formulajs/errors.ts';
+import { isoWeekNumber } from '../../formulajs/isoWeek.ts';
 import { compare } from '../../jqtools/evaluate/compare.ts';
 import type { BareNativeFilter } from '../../jqtools/evaluate/filters/lib/nativeFilter.ts';
 import { wrapBareNativeFilters } from '../../jqtools/evaluate/filters/lib/nativeFilter.ts';
@@ -220,6 +221,29 @@ function serialToUtcDate(serial: number): Date {
   return new Date(SERIAL_EPOCH_UTC_MS + serial * NOW_SERIAL_MS_PER_DAY);
 }
 
+function weekdayValue(serialDateLike: unknown, returnTypeLike: unknown = 1) {
+  const serial = Math.floor(parseExcelNumber(serialDateLike));
+  const type = Math.floor(parseExcelNumber(returnTypeLike));
+  const dayOfWeek = serialToUtcDate(serial).getUTCDay(); // 0 = Sunday
+  // Every return type says which weekday counts as the first: type 1 starts
+  // the week on Sunday, types 2 and 3 and 11 on Monday, and 12 through 17 walk
+  // the start forward a day at a time, back around to Sunday. Type 3 is the
+  // one that numbers from zero.
+  const firstDay =
+    type === 1
+      ? 0
+      : type === 2 || type === 3 || type === 11
+        ? 1
+        : type >= 12 && type <= 17
+          ? (type - 10) % 7
+          : undefined;
+  if (firstDay === undefined) {
+    throwExcelError(EXCEL_ERROR.num);
+  }
+  const offset = (dayOfWeek - firstDay + 7) % 7;
+  return type === 3 ? offset : offset + 1;
+}
+
 function utcDateToSerial(date: Date): number {
   return Math.floor(
     (date.getTime() - SERIAL_EPOCH_UTC_MS) / NOW_SERIAL_MS_PER_DAY,
@@ -232,20 +256,72 @@ function replaceNth(
   newText: string,
   instance: number,
 ) {
-  let index = 0;
-  let found = 0;
+  if (oldText === '') {
+    return text;
+  }
 
-  while (index > -1 && text.indexOf(oldText, index) > -1) {
-    index = text.indexOf(oldText, index + 1);
+  // Instance 1 is the first occurrence wherever it sits, the very start of the
+  // string included, and occurrences do not overlap.
+  let index = text.indexOf(oldText);
+  let found = 0;
+  while (index > -1) {
     found++;
-    if (index > -1 && found === instance) {
+    if (found === instance) {
       return (
         text.slice(0, index) + newText + text.slice(index + oldText.length)
       );
     }
+    index = text.indexOf(oldText, index + oldText.length);
   }
 
   return text;
+}
+
+/**
+ * Excel's wildcards for the arguments that take them: `*` for any run of
+ * characters, `?` for exactly one, and `~` escaping any of the three.
+ */
+function excelWildcardPattern(pattern: string, flags: string): RegExp {
+  let source = '';
+  for (let index = 0; index < pattern.length; index++) {
+    const char = pattern[index];
+    if (char === '~' && '*?~'.includes(pattern[index + 1] ?? '')) {
+      source += escapeRegExpLiteral(pattern[++index]);
+    } else if (char === '*') {
+      source += '[\\s\\S]*';
+    } else if (char === '?') {
+      source += '[\\s\\S]';
+    } else {
+      source += escapeRegExpLiteral(char);
+    }
+  }
+  return new RegExp(source, flags);
+}
+
+function escapeRegExpLiteral(text: string) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function searchValue(
+  findTextLike: unknown,
+  withinTextLike: unknown,
+  startNumLike: unknown = 1,
+) {
+  const findText = parseExcelString(findTextLike);
+  const withinText = parseExcelString(withinTextLike);
+  const startNum = Math.trunc(parseExcelNumber(startNumLike));
+  if (startNum < 1) {
+    throwExcelError(EXCEL_ERROR.value);
+  }
+  // SEARCH differs from FIND in two ways, not one: it ignores case and it
+  // reads find_text as a wildcard pattern.
+  const found = withinText
+    .slice(startNum - 1)
+    .search(excelWildcardPattern(findText, 'i'));
+  if (found === -1) {
+    throwExcelError(EXCEL_ERROR.value);
+  }
+  return found + startNum;
 }
 
 function toTextForConcat(value: unknown) {
@@ -292,6 +368,140 @@ function excelValue(textLike: unknown) {
   return isPercent ? output * 0.01 : output;
 }
 
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+const WEEKDAY_NAMES = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+type DateFormatField =
+  | 'literal'
+  | 'year'
+  | 'month'
+  | 'day'
+  | 'hour'
+  | 'minute'
+  | 'second'
+  | 'meridiem';
+
+interface DateFormatToken {
+  field: DateFormatField;
+  text: string;
+}
+
+/**
+ * True when a format code addresses a date or a time rather than a number.
+ * Quoted and escaped literals are excluded, since they may spell anything.
+ */
+function isDateFormatCode(formatText: string) {
+  return /[ymdhs]/i.test(
+    formatText.replace(/"[^"]*"/g, '').replace(/\\[\s\S]/g, ''),
+  );
+}
+
+function tokenizeDateFormat(formatText: string): DateFormatToken[] {
+  const runs =
+    formatText.match(/AM\/PM|A\/P|y+|m+|d+|h+|s+|"[^"]*"|\\[\s\S]|[\s\S]/gi) ??
+    [];
+  const tokens = runs.map((text): DateFormatToken => {
+    const code = text.toLowerCase();
+    if (code === 'am/pm' || code === 'a/p') return { field: 'meridiem', text };
+    if (/^y+$/.test(code)) return { field: 'year', text };
+    if (/^m+$/.test(code)) return { field: 'month', text };
+    if (/^d+$/.test(code)) return { field: 'day', text };
+    if (/^h+$/.test(code)) return { field: 'hour', text };
+    if (/^s+$/.test(code)) return { field: 'second', text };
+    return { field: 'literal', text };
+  });
+
+  // An `m` run means minutes when it neighbours an hour or second run, and
+  // months everywhere else. Only separators may sit in between.
+  const neighbour = (from: number, step: number): DateFormatField => {
+    for (let i = from + step; i >= 0 && i < tokens.length; i += step) {
+      if (tokens[i].field !== 'literal') return tokens[i].field;
+      if (!/^[\s:.,\-/]$/.test(tokens[i].text)) break;
+    }
+    return 'literal';
+  };
+  tokens.forEach((token, index) => {
+    if (token.field !== 'month') return;
+    const adjacent = [neighbour(index, -1), neighbour(index, 1)];
+    if (adjacent.includes('hour') || adjacent.includes('second')) {
+      token.field = 'minute';
+    }
+  });
+
+  return tokens;
+}
+
+function renderDateFormat(serial: number, formatText: string) {
+  const date = serialToUtcDate(serial);
+  const tokens = tokenizeDateFormat(formatText);
+  const twelveHour = tokens.some((token) => token.field === 'meridiem');
+  const pad = (value: number, width: number) =>
+    String(value).padStart(width, '0');
+
+  return tokens
+    .map(({ field, text }) => {
+      const width = text.length;
+      switch (field) {
+        case 'year':
+          return width <= 2
+            ? pad(date.getUTCFullYear() % 100, 2)
+            : pad(date.getUTCFullYear(), 4);
+        case 'month': {
+          const name = MONTH_NAMES[date.getUTCMonth()];
+          if (width >= 4) return name;
+          if (width === 3) return name.slice(0, 3);
+          return pad(date.getUTCMonth() + 1, Math.min(width, 2));
+        }
+        case 'day': {
+          if (width >= 4) return WEEKDAY_NAMES[date.getUTCDay()];
+          if (width === 3) return WEEKDAY_NAMES[date.getUTCDay()].slice(0, 3);
+          return pad(date.getUTCDate(), Math.min(width, 2));
+        }
+        case 'hour': {
+          const hours = date.getUTCHours();
+          const shown = twelveHour ? hours % 12 || 12 : hours;
+          return pad(shown, Math.min(width, 2));
+        }
+        case 'minute':
+          return pad(date.getUTCMinutes(), Math.min(width, 2));
+        case 'second':
+          return pad(date.getUTCSeconds(), Math.min(width, 2));
+        case 'meridiem': {
+          const half = date.getUTCHours() < 12 ? 'AM' : 'PM';
+          const shown = text.length === 3 ? half.slice(0, 1) : half;
+          return text === text.toLowerCase() ? shown.toLowerCase() : shown;
+        }
+        default:
+          return text.startsWith('"')
+            ? text.slice(1, -1)
+            : text.replace(/^\\/, '');
+      }
+    })
+    .join('');
+}
+
 function excelText(valueLike: unknown, formatTextLike: unknown) {
   if (valueLike instanceof Date) {
     return valueLike.toISOString().slice(0, 10);
@@ -307,6 +517,10 @@ function excelText(valueLike: unknown, formatTextLike: unknown) {
 
   if (typeof formatTextLike !== 'string') {
     throwExcelError(EXCEL_ERROR.value);
+  }
+
+  if (isDateFormatCode(formatTextLike)) {
+    return renderDateFormat(parseExcelNumber(valueLike), formatTextLike);
   }
 
   const currencySymbol = formatTextLike.startsWith('$') ? '$' : '';
@@ -410,13 +624,18 @@ function numberValue(
     throwExcelError(EXCEL_ERROR.value);
   }
 
+  // Spaces are ignored wherever they appear, and each trailing percent sign
+  // divides the result by 100 — "9%%" is 0.0009.
+  const compacted = text.replace(/ /g, '');
+  const percentSigns = /%*$/.exec(compacted)![0].length;
+  const digits = compacted.slice(0, compacted.length - percentSigns);
   const parsed = Number(
-    text.split(groupSeparator).join('').replace(decimalSeparator, '.'),
+    digits.split(groupSeparator).join('').replace(decimalSeparator, '.'),
   );
   if (Number.isNaN(parsed)) {
     throwExcelError(EXCEL_ERROR.value);
   }
-  return parsed;
+  return parsed / 100 ** percentSigns;
 }
 
 const ROMAN_TOKEN_VALUES: Record<string, number> = {
@@ -501,10 +720,11 @@ function romanValue(numberLike: unknown) {
 }
 
 function properValue(textLike: unknown) {
-  return parseExcelString(textLike).replace(
-    /\w\S*/g,
-    (entry) => entry.charAt(0).toUpperCase() + entry.slice(1).toLowerCase(),
-  );
+  // Excel capitalizes every letter that follows a non-letter, so a word is a
+  // run of letters and nothing else: "2-way" becomes "2-Way".
+  return parseExcelString(textLike)
+    .toLowerCase()
+    .replace(/\p{L}+/gu, (word) => word.charAt(0).toUpperCase() + word.slice(1));
 }
 
 function textJoin(
@@ -1113,8 +1333,10 @@ const bareNativeFilters: Record<string, BareNativeFilter> = {
     yield averageExcelRange(colValues(filteredRows, valueKey));
   },
   *'CHAR/1'(_input, value) {
-    const number = parseExcelNumber(value);
-    if (number === 0) {
+    // CHAR spans the single-byte character set: 1 through 255. UNICHAR is the
+    // one that reaches beyond it.
+    const number = Math.trunc(parseExcelNumber(value));
+    if (number < 1 || number > 255) {
       throwExcelError(EXCEL_ERROR.value);
     }
     yield String.fromCharCode(number);
@@ -1455,25 +1677,10 @@ const bareNativeFilters: Record<string, BareNativeFilter> = {
     yield roundBase(value, digits, Math.ceil);
   },
   *'SEARCH/2'(_input, findText, withinText) {
-    const found = parseExcelString(withinText)
-      .toLowerCase()
-      .indexOf(parseExcelString(findText).toLowerCase());
-    if (found === -1) {
-      throwExcelError(EXCEL_ERROR.value);
-    }
-    yield found + 1;
+    yield searchValue(findText, withinText);
   },
   *'SEARCH/3'(_input, findText, withinText, startNum) {
-    const found = parseExcelString(withinText)
-      .toLowerCase()
-      .indexOf(
-        parseExcelString(findText).toLowerCase(),
-        parseExcelNumber(startNum) - 1,
-      );
-    if (found === -1) {
-      throwExcelError(EXCEL_ERROR.value);
-    }
-    yield found + 1;
+    yield searchValue(findText, withinText, startNum);
   },
   *'SEC/1'(_input, value) {
     yield checkedMathResult(1 / Math.cos(parseExcelNumber(value)));
@@ -1566,7 +1773,12 @@ const bareNativeFilters: Record<string, BareNativeFilter> = {
     yield textJoin(delimiter, ignoreEmpty, values);
   },
   *'TRIM/1'(_input, value) {
-    yield parseExcelString(value).replace(/\s+/g, ' ').trim();
+    // TRIM is defined over the ASCII space alone: it collapses runs of spaces
+    // between words and strips them from the ends, leaving tabs, newlines and
+    // the non-breaking space to CLEAN and SUBSTITUTE.
+    yield parseExcelString(value)
+      .replace(/ +/g, ' ')
+      .replace(/^ | $/g, '');
   },
   *'TRUNC/1'(_input, value) {
     yield truncValue(value);
@@ -1893,13 +2105,12 @@ const bareNativeFilters: Record<string, BareNativeFilter> = {
   // Information functions
   // ═══════════════════════════════════════════════════════════════
 
+  // Excel truncates toward zero before testing parity, so -2.5 is even.
   *'ISEVEN/1'(_input, value) {
-    const n = parseExcelNumber(value);
-    yield Math.floor(n) % 2 === 0;
+    yield truncValue(value) % 2 === 0;
   },
   *'ISODD/1'(_input, value) {
-    const n = parseExcelNumber(value);
-    yield Math.floor(n) % 2 !== 0;
+    yield truncValue(value) % 2 !== 0;
   },
   *'ISLOGICAL/1'(_input, value) {
     yield typeof value === 'boolean';
@@ -2282,29 +2493,14 @@ const bareNativeFilters: Record<string, BareNativeFilter> = {
     yield Math.floor(frac * 24 * 60 * 60) % 60;
   },
   *'WEEKDAY/1'(_input, serialDate) {
-    // Default type 1: Sunday=1 .. Saturday=7
-    const serial = Math.floor(parseExcelNumber(serialDate));
-    yield serialToUtcDate(serial).getUTCDay() + 1;
+    yield weekdayValue(serialDate);
   },
   *'WEEKDAY/2'(_input, serialDate, returnType) {
-    const serial = Math.floor(parseExcelNumber(serialDate));
-    const type = Math.floor(parseExcelNumber(returnType));
-    const dow = serialToUtcDate(serial).getUTCDay(); // 0=Sun
-    if (type === 1) yield dow + 1;
-    else if (type === 2) yield dow === 0 ? 7 : dow;
-    else if (type === 3) yield dow === 0 ? 6 : dow - 1;
-    else yield dow + 1;
+    yield weekdayValue(serialDate, returnType);
   },
   *'ISOWEEKNUM/1'(_input, serialDate) {
     const serial = Math.floor(parseExcelNumber(serialDate));
-    const date = serialToUtcDate(serial);
-    const dayOfYear =
-      Math.floor(
-        (date.getTime() - Date.UTC(date.getUTCFullYear(), 0, 1)) / 86400000,
-      ) + 1;
-    const dow = date.getUTCDay() || 7; // Mon=1..Sun=7
-    const woy = Math.floor((dayOfYear - dow + 10) / 7);
-    yield woy;
+    yield isoWeekNumber(serialToUtcDate(serial));
   },
   *'EDATE/2'(_input, startDate, months) {
     const serial = Math.floor(parseExcelNumber(startDate));
@@ -2344,9 +2540,14 @@ const bareNativeFilters: Record<string, BareNativeFilter> = {
     const str = String(text);
     const match = str.match(/(\d{1,2}):(\d{2})(?::(\d{2}))?/);
     if (!match) throwExcelError(EXCEL_ERROR.value);
-    const h = parseInt(match[1], 10);
+    let h = parseInt(match[1], 10);
     const m = parseInt(match[2], 10);
     const s = match[3] ? parseInt(match[3], 10) : 0;
+    // A 12-hour reading closes with a meridiem: PM adds twelve hours to every
+    // hour but noon's, and 12 AM is midnight.
+    const meridiem = /\d\s*([ap])\.?m?\.?\s*$/i.exec(str)?.[1].toLowerCase();
+    if (meridiem === 'p' && h < 12) h += 12;
+    if (meridiem === 'a' && h === 12) h = 0;
     yield (h * 3600 + m * 60 + s) / 86400;
   },
 

--- a/packages/bxl/src/bxl/bridge/formula-contrib-native.ts
+++ b/packages/bxl/src/bxl/bridge/formula-contrib-native.ts
@@ -724,7 +724,10 @@ function properValue(textLike: unknown) {
   // run of letters and nothing else: "2-way" becomes "2-Way".
   return parseExcelString(textLike)
     .toLowerCase()
-    .replace(/\p{L}+/gu, (word) => word.charAt(0).toUpperCase() + word.slice(1));
+    .replace(
+      /\p{L}+/gu,
+      (word) => word.charAt(0).toUpperCase() + word.slice(1),
+    );
 }
 
 function textJoin(
@@ -1776,9 +1779,7 @@ const bareNativeFilters: Record<string, BareNativeFilter> = {
     // TRIM is defined over the ASCII space alone: it collapses runs of spaces
     // between words and strips them from the ends, leaving tabs, newlines and
     // the non-breaking space to CLEAN and SUBSTITUTE.
-    yield parseExcelString(value)
-      .replace(/ +/g, ' ')
-      .replace(/^ | $/g, '');
+    yield parseExcelString(value).replace(/ +/g, ' ').replace(/^ | $/g, '');
   },
   *'TRUNC/1'(_input, value) {
     yield truncValue(value);

--- a/packages/bxl/src/bxl/compiler/readable-syntax.ts
+++ b/packages/bxl/src/bxl/compiler/readable-syntax.ts
@@ -1013,6 +1013,7 @@ function tokenize(source: string): Token[] {
     if (/[0-9]/.test(char)) {
       let value = char;
       let hasDecimal = false;
+      let hasExponent = false;
       const start = index;
       index++;
       while (index < source.length) {
@@ -1021,10 +1022,26 @@ function tokenize(source: string): Token[] {
           value += source[index++];
           continue;
         }
-        if (current === '.' && !hasDecimal && source[index + 1] !== '.') {
+        if (
+          current === '.' &&
+          !hasDecimal &&
+          !hasExponent &&
+          source[index + 1] !== '.'
+        ) {
           hasDecimal = true;
           value += source[index++];
           continue;
+        }
+        // An exponent takes an optional sign and then at least one digit, so
+        // `1e3` is one number while the `e` starting a name stays a name.
+        if ((current === 'e' || current === 'E') && !hasExponent) {
+          const signed = ['+', '-'].includes(source[index + 1] ?? '');
+          if (/[0-9]/.test(source[index + (signed ? 2 : 1)] ?? '')) {
+            hasExponent = true;
+            value += source[index++];
+            if (signed) value += source[index++];
+            continue;
+          }
         }
         break;
       }

--- a/packages/bxl/src/bxl/linter/index.ts
+++ b/packages/bxl/src/bxl/linter/index.ts
@@ -469,7 +469,6 @@ function lintFunctionDispatchStyle(
           suggestion:
             'Excel INDEX(array, row) owns this name. To key rows by a field as jq INDEX does, use reduce Rows[] as $row ({}; .[$row.id] = $row), or map to {key, value} pairs and from_entries.',
         });
-        continue;
       }
       if (call.dispatch.dialect === 'bxl-helper') {
         const helperName = call.dispatch.name;

--- a/packages/bxl/src/bxl/linter/index.ts
+++ b/packages/bxl/src/bxl/linter/index.ts
@@ -451,6 +451,23 @@ function lintFunctionDispatchStyle(
     if (next?.type === 'punc' && next.value === '(') {
       const call = analyzeReadableFunctionCall(tokens, index);
       if (!call) continue;
+      // Excel's positional INDEX takes the name from jq's, which builds an
+      // object keyed by an expression over a stream. Excel wins — spreadsheet
+      // authors are this surface's audience — but the jq call shape then fails
+      // with "Cannot index array with string", naming nothing that explains it.
+      if (
+        lower === 'index' &&
+        (call.explicitArity === 1 || call.separator === 'semicolon')
+      ) {
+        addIssue(issues, {
+          code: 'jq-index-shadowed-by-excel',
+          severity: 'warning',
+          message: `INDEX resolves to Excel's positional lookup, not jq's INDEX.`,
+          suggestion:
+            'Excel INDEX(array, row) owns this name. To key rows by a field as jq INDEX does, use reduce Rows[] as $row ({}; .[$row.id] = $row), or map to {key, value} pairs and from_entries.',
+        });
+        continue;
+      }
       if (call.dispatch.dialect === 'bxl-helper') {
         const helperName = call.dispatch.name;
         if (name !== helperName) {

--- a/packages/bxl/src/bxl/linter/index.ts
+++ b/packages/bxl/src/bxl/linter/index.ts
@@ -451,13 +451,16 @@ function lintFunctionDispatchStyle(
     if (next?.type === 'punc' && next.value === '(') {
       const call = analyzeReadableFunctionCall(tokens, index);
       if (!call) continue;
-      // Excel's positional INDEX takes the name from jq's, which builds an
-      // object keyed by an expression over a stream. Excel wins — spreadsheet
-      // authors are this surface's audience — but the jq call shape then fails
-      // with "Cannot index array with string", naming nothing that explains it.
+      // Excel's positional INDEX takes the two-argument name from jq's, which
+      // builds an object keyed by an expression over a stream. Excel wins —
+      // spreadsheet authors are this surface's audience — but the jq call
+      // shape then fails with "Cannot index array with string", naming nothing
+      // that explains it. Only that shape collides: at one argument the name
+      // is jq's own index-of, and jq has no three-argument INDEX.
       if (
         lower === 'index' &&
-        (call.explicitArity === 1 || call.separator === 'semicolon')
+        call.explicitArity === 2 &&
+        call.separator === 'semicolon'
       ) {
         addIssue(issues, {
           code: 'jq-index-shadowed-by-excel',

--- a/packages/bxl/src/formulajs/UPSTREAM-DIFFS.md
+++ b/packages/bxl/src/formulajs/UPSTREAM-DIFFS.md
@@ -110,9 +110,9 @@ regression rather than a port detail.
 | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `PROPER`                              | Capitalizes any letter following a non-letter, so `2-way` becomes `2-Way`. A word is a run of letters, not a run of non-spaces.                |
 | `TRIM`                                | Collapses and strips the ASCII space only, leaving tabs, newlines and U+00A0 to `CLEAN` and `SUBSTITUTE`.                                      |
-| `SEARCH`                              | Reads `find_text` as a wildcard pattern — `*`, `?`, and `~` escaping either — which is the other half of what separates it from `FIND`.        |
+| `SEARCH`                              | Reads `find_text` as a wildcard pattern — `*`, `?`, and `~` escaping either — which is the other half of what separates it from `FIND`. Matched by `wildcard.ts` in one forward pass, not by a regex: `.*` per star makes a backtracking engine exponential, which turns a stray run of asterisks into a hung indexing worker. `COUNTIF`'s criteria go through the same matcher. |
 | `SUBSTITUTE` (4-argument)             | Counts an occurrence at position 0, so instance 1 is the first match wherever it sits.                                                         |
-| `TEXT`                                | Renders date and time format codes rather than returning the bare serial. `mm` is minutes beside an hour or second, months elsewhere.          |
+| `TEXT`                                | Renders date and time format codes rather than returning the bare serial. `mm` reads as minutes only where the clock puts it — after an hour run, or before a seconds run — and as the month everywhere else, `mmmmm` as the month's initial. Bracketed runs are colour, condition and locale codes and print nothing, except `[h]`/`[m]`/`[s]`, which are elapsed totals. |
 | `NUMBERVALUE`                         | Ignores spaces anywhere in the text and divides by 100 per trailing percent sign, so `9%%` is 0.0009.                                          |
 | `CHAR`                                | Restricted to 1–255, the single-byte range. `UNICHAR` is the one that reaches past it.                                                         |
 | `ISEVEN`, `ISODD`                     | Truncate toward zero before testing parity, so `ISEVEN(-2.5)` is true.                                                                        |
@@ -121,12 +121,12 @@ regression rather than a port detail.
 | `TIMEVALUE`                           | Reads a trailing meridiem, so an afternoon time is not twelve hours early.                                                                    |
 | `BASE`, `BIN2HEX`, `DEC2HEX`, `OCT2HEX` | Emit upper-case digits above 9. The reading side already accepts either casing, so a round trip survives.                                    |
 | `COMPLEX` and the `IM*` family        | Drop the coefficient for an imaginary part of -1 as well as +1, so `COMPLEX(0, -1)` is the `-i` the parser already reads.                      |
-| `ERF`, `ERFC`                         | Computed from the regularized incomplete gamma function to full double precision. `ERFC` is the upper tail, not `1 - ERF`, so the far tail keeps its digits. |
+| `ERF`, `ERFC`                         | Computed from the regularized incomplete gamma function to full double precision. `ERFC` is the upper tail, not `1 - ERF`, so the far tail keeps its digits. Both ends of the argument range are answered directly, since x² is what overflows and underflows first: erf saturates at ±1 above ~1.3e154 and is 2x/√π below ~1.5e-162. |
 | `WEIBULL_DIST`                        | Takes alpha as the shape and beta as the scale, as Excel does. jstat's signature is `(x, scale, shape)`, so they cross at the call.            |
 | `T_TEST`                              | Pairs its Welch standard error with Welch–Satterthwaite degrees of freedom — Excel's two-tailed unequal-variance test, type 3.                 |
-| `IRR`, `IRR_BY`, `XIRR`               | Raise `#NUM!` when the search never brings the net present value to zero, instead of returning the rate it stopped at.                         |
+| `IRR`, `IRR_BY`, `XIRR`               | Raise `#NUM!` unless the rate the search settled on is really a root — its net present value is zero, or the value changes sign across it. The second test is what recognizes a root near -100% or on a long series, where discounting amplifies rounding past any fixed residual. |
 | `TBILLEQ`, `TBILLPRICE`, `TBILLYIELD` | Raise `#NUM!` for a maturity more than a year past settlement.                                                                                |
-| `COUPDAYS`                            | Measures the real coupon period containing settlement under basis 1, actual/actual. The other bases give every period the same nominal length. |
+| `COUPDAYS`                            | Measures the real coupon period containing settlement under basis 1, actual/actual, with the schedule measured from maturity and sticky to month ends — a bond maturing on the last day of a month pays on the last day of every month. The other bases give every period the same nominal length, but all of them validate the dates. |
 
 `DAYS360`'s US/NASD method implements the day-31 rule but not the
 last-day-of-February rule Microsoft documents, which is left alone: Excel's own

--- a/packages/bxl/src/formulajs/UPSTREAM-DIFFS.md
+++ b/packages/bxl/src/formulajs/UPSTREAM-DIFFS.md
@@ -99,6 +99,40 @@ BXL let the day overflow, so a January 31st plus one month gave March 3rd), and
 `TODAY` reads the same UTC clock `NOW` reads, so `FLOOR(NOW()) = TODAY()` holds
 in every zone.
 
+### 6. Functions corrected against Excel's specification
+
+Writing a coverage case for every exposed function turned up a batch that
+answered something other than what Excel documents. Each now matches the
+specification, so any of these that still reads like upstream's version is a
+regression rather than a port detail.
+
+| Function                              | What it does now                                                                                                                             |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PROPER`                              | Capitalizes any letter following a non-letter, so `2-way` becomes `2-Way`. A word is a run of letters, not a run of non-spaces.                |
+| `TRIM`                                | Collapses and strips the ASCII space only, leaving tabs, newlines and U+00A0 to `CLEAN` and `SUBSTITUTE`.                                      |
+| `SEARCH`                              | Reads `find_text` as a wildcard pattern — `*`, `?`, and `~` escaping either — which is the other half of what separates it from `FIND`.        |
+| `SUBSTITUTE` (4-argument)             | Counts an occurrence at position 0, so instance 1 is the first match wherever it sits.                                                         |
+| `TEXT`                                | Renders date and time format codes rather than returning the bare serial. `mm` is minutes beside an hour or second, months elsewhere.          |
+| `NUMBERVALUE`                         | Ignores spaces anywhere in the text and divides by 100 per trailing percent sign, so `9%%` is 0.0009.                                          |
+| `CHAR`                                | Restricted to 1–255, the single-byte range. `UNICHAR` is the one that reaches past it.                                                         |
+| `ISEVEN`, `ISODD`                     | Truncate toward zero before testing parity, so `ISEVEN(-2.5)` is true.                                                                        |
+| `WEEKDAY`, `WEEKNUM`                  | Honour every return type, including the 11–17 ladder that walks the start of the week forward and `WEEKNUM`'s ISO 21. Others raise `#NUM!`.    |
+| `ISOWEEKNUM`, `WEEKNUM(…, 21)`        | Number from the week holding the year's first Thursday, so an early-January date reports the previous ISO year's 52nd or 53rd week.            |
+| `TIMEVALUE`                           | Reads a trailing meridiem, so an afternoon time is not twelve hours early.                                                                    |
+| `BASE`, `BIN2HEX`, `DEC2HEX`, `OCT2HEX` | Emit upper-case digits above 9. The reading side already accepts either casing, so a round trip survives.                                    |
+| `COMPLEX` and the `IM*` family        | Drop the coefficient for an imaginary part of -1 as well as +1, so `COMPLEX(0, -1)` is the `-i` the parser already reads.                      |
+| `ERF`, `ERFC`                         | Computed from the regularized incomplete gamma function to full double precision. `ERFC` is the upper tail, not `1 - ERF`, so the far tail keeps its digits. |
+| `WEIBULL_DIST`                        | Takes alpha as the shape and beta as the scale, as Excel does. jstat's signature is `(x, scale, shape)`, so they cross at the call.            |
+| `T_TEST`                              | Pairs its Welch standard error with Welch–Satterthwaite degrees of freedom — Excel's two-tailed unequal-variance test, type 3.                 |
+| `IRR`, `IRR_BY`, `XIRR`               | Raise `#NUM!` when the search never brings the net present value to zero, instead of returning the rate it stopped at.                         |
+| `TBILLEQ`, `TBILLPRICE`, `TBILLYIELD` | Raise `#NUM!` for a maturity more than a year past settlement.                                                                                |
+| `COUPDAYS`                            | Measures the real coupon period containing settlement under basis 1, actual/actual. The other bases give every period the same nominal length. |
+
+`DAYS360`'s US/NASD method implements the day-31 rule but not the
+last-day-of-February rule Microsoft documents, which is left alone: Excel's own
+shipped behavior is known to diverge from that doc text, so matching the text
+would mean diverging from Excel.
+
 ## Bringing in new upstream functions
 
 When upstream adds a function we want:

--- a/packages/bxl/src/formulajs/criteria.ts
+++ b/packages/bxl/src/formulajs/criteria.ts
@@ -1,4 +1,5 @@
 import { isExcelBlank } from './common.ts';
+import { excelWildcardMatchesWhole } from './wildcard.ts';
 
 export type CriteriaMatcher = (value: unknown) => boolean;
 
@@ -38,39 +39,6 @@ function hasWildcards(value: string) {
   }
 
   return false;
-}
-
-function wildcardToRegex(value: string) {
-  let escaped = false;
-  let pattern = '^';
-
-  for (const char of value) {
-    if (escaped) {
-      pattern += char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      escaped = false;
-      continue;
-    }
-
-    if (char === '~') {
-      escaped = true;
-      continue;
-    }
-
-    if (char === '*') {
-      pattern += '.*';
-      continue;
-    }
-
-    if (char === '?') {
-      pattern += '.';
-      continue;
-    }
-
-    pattern += char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
-
-  pattern += '$';
-  return new RegExp(pattern, 'i');
 }
 
 function normalizeStringValue(value: unknown) {
@@ -117,7 +85,10 @@ function compareValues(left: unknown, right: unknown, operator: string) {
     }
 
     if (hasWildcards(right)) {
-      const matched = wildcardToRegex(right).test(normalizeStringValue(left));
+      const matched = excelWildcardMatchesWhole(
+        right,
+        normalizeStringValue(left),
+      );
       return operator === '=' ? matched : !matched;
     }
   }

--- a/packages/bxl/src/formulajs/dateSerial.ts
+++ b/packages/bxl/src/formulajs/dateSerial.ts
@@ -1,5 +1,6 @@
 import { parseExcelNumber } from './common.ts';
 import { EXCEL_ERROR, throwExcelError } from './errors.ts';
+import { isoWeekNumber } from './isoWeek.ts';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 // A date string denotes a calendar day only when it names no zone at all, and
@@ -341,12 +342,28 @@ export function excelDays360(
 export function excelWeeknum(serialLike: unknown, returnTypeLike: unknown = 1) {
   const date = parseExcelDate(serialLike);
   const returnType = Math.floor(Number(returnTypeLike) || 1);
+  // Return type 21 asks for the ISO week, which numbers from the week holding
+  // the year's first Thursday rather than from the week holding January 1st.
+  if (returnType === 21) {
+    return isoWeekNumber(date);
+  }
+  // Every other return type says which weekday opens the week: 1 opens it on
+  // Sunday, 2 and 11 on Monday, then 12 through 17 walk the start forward a
+  // day at a time, back around to Sunday.
+  const firstDay =
+    returnType === 1
+      ? 0
+      : returnType === 2 || returnType === 11
+        ? 1
+        : returnType >= 12 && returnType <= 17
+          ? (returnType - 10) % 7
+          : undefined;
+  if (firstDay === undefined) {
+    throwExcelError(EXCEL_ERROR.num);
+  }
   const jan1 = utcDate(date.getUTCFullYear(), 0, 1);
   const dayOfYear = Math.floor((date.getTime() - jan1.getTime()) / MS_PER_DAY);
-  // returnType 1: week starts Sunday, 2: week starts Monday
-  const jan1Dow = jan1.getUTCDay();
-  const startOffset =
-    returnType === 2 ? (jan1Dow === 0 ? 6 : jan1Dow - 1) : jan1Dow;
+  const startOffset = (jan1.getUTCDay() - firstDay + 7) % 7;
   return Math.floor((dayOfYear + startOffset) / 7) + 1;
 }
 

--- a/packages/bxl/src/formulajs/dateSerial.ts
+++ b/packages/bxl/src/formulajs/dateSerial.ts
@@ -341,7 +341,10 @@ export function excelDays360(
 
 export function excelWeeknum(serialLike: unknown, returnTypeLike: unknown = 1) {
   const date = parseExcelDate(serialLike);
-  const returnType = Math.floor(Number(returnTypeLike) || 1);
+  // Not `Number(x) || 1`: that reads 0 and a non-numeric argument as the
+  // default rather than as the errors they are, which would slip past the
+  // return-type check below.
+  const returnType = Math.floor(parseExcelNumber(returnTypeLike));
   // Return type 21 asks for the ISO week, which numbers from the week holding
   // the year's first Thursday rather than from the week holding January 1st.
   if (returnType === 21) {

--- a/packages/bxl/src/formulajs/engineering.ts
+++ b/packages/bxl/src/formulajs/engineering.ts
@@ -691,8 +691,23 @@ function upperGammaHalf(x: number) {
 // ½ + 1 is where the series stops converging faster than the fraction.
 const GAMMA_SERIES_LIMIT = 1.5;
 
+// x² is what the gamma functions take, and squaring is what runs out of
+// exponent first: above ~1.3e154 it overflows to Infinity, below ~1.5e-162 it
+// underflows to zero. Both ends have an exact answer — erf saturates at ±1,
+// and near the origin it is 2x/√π — so they are answered directly rather than
+// handed to a series that would return NaN or zero.
+const TWO_OVER_ROOT_PI = 1.1283791670955126;
+// Below this, x² is subnormal or zero: the series would take the logarithm of
+// a number that has already lost most of its digits, where 2x/√π is exact —
+// the next term of the expansion is smaller than a double can hold.
+const SMALLEST_NORMAL = 2.2250738585072014e-308;
+
 function erfValue(x: number) {
   const squared = x * x;
+  if (!Number.isFinite(squared)) {
+    return Number.isNaN(x) ? Number.NaN : Math.sign(x);
+  }
+  if (squared < SMALLEST_NORMAL) return x === 0 ? 0 : TWO_OVER_ROOT_PI * x;
   const value =
     squared < GAMMA_SERIES_LIMIT
       ? lowerGammaHalf(squared)
@@ -711,6 +726,11 @@ export function excelErf(lowerLike: unknown, upperLike?: unknown) {
 export function excelErfc(valueLike: unknown) {
   const value = parseExcelNumber(valueLike);
   const squared = value * value;
+  if (!Number.isFinite(squared)) {
+    return Number.isNaN(value) ? Number.NaN : value > 0 ? 0 : 2;
+  }
+  // erf(x) is smaller than the gap between 1 and its neighbour here.
+  if (squared < SMALLEST_NORMAL) return 1;
   // Computed as the upper tail rather than as 1 - ERF, so the far tail keeps
   // its precision: ERFC(6) is 2.15e-17, not zero.
   const complement =

--- a/packages/bxl/src/formulajs/engineering.ts
+++ b/packages/bxl/src/formulajs/engineering.ts
@@ -132,18 +132,32 @@ function parseComplex(value: unknown): ComplexNumber {
   return { real: realPart, imaginary, unit };
 }
 
+/**
+ * A number in the given radix. Excel renders digits above 9 in upper case —
+ * DEC2HEX(255) is "FF" — while the reading side accepts either casing, so a
+ * round trip survives.
+ */
+function radixDigits(value: number, radix: number) {
+  return value.toString(radix).toUpperCase();
+}
+
 function formatComplex(real: number, imaginary: number, unit: ImaginaryUnit) {
   if (real === 0 && imaginary === 0) {
     return 0;
   }
+  // A unit coefficient is left implicit in both directions, so ±1 renders as
+  // the bare unit with its sign — the same forms the parser above reads.
+  const term =
+    Math.abs(imaginary) === 1
+      ? `${imaginary < 0 ? '-' : ''}${unit}`
+      : `${imaginary}${unit}`;
   if (real === 0) {
-    return imaginary === 1 ? unit : `${imaginary}${unit}`;
+    return term;
   }
   if (imaginary === 0) {
     return String(real);
   }
-  const sign = imaginary > 0 ? '+' : '';
-  return `${real}${sign}${imaginary === 1 ? unit : `${imaginary}${unit}`}`;
+  return `${real}${imaginary > 0 ? '+' : ''}${term}`;
 }
 
 export function excelBitAnd(leftLike: unknown, rightLike: unknown) {
@@ -198,10 +212,10 @@ export function excelBin2Hex(numberLike: unknown, placesLike?: unknown) {
   ensureMatches(number, /^[01]{1,10}$/);
 
   if (number.length === 10 && number.startsWith('1')) {
-    return (1099511627264 + parseInt(number.slice(1), 2)).toString(16);
+    return radixDigits(1099511627264 + parseInt(number.slice(1), 2), 16);
   }
 
-  return padResult(parseInt(number, 2).toString(16), placesLike);
+  return padResult(radixDigits(parseInt(number, 2), 16), placesLike);
 }
 
 export function excelBin2Oct(numberLike: unknown, placesLike?: unknown) {
@@ -243,10 +257,10 @@ export function excelDec2Hex(numberLike: unknown, placesLike?: unknown) {
   }
 
   if (number < 0) {
-    return (1099511627776 + number).toString(16);
+    return radixDigits(1099511627776 + number, 16);
   }
 
-  return padResult(number.toString(16), placesLike);
+  return padResult(radixDigits(number, 16), placesLike);
 }
 
 export function excelDec2Oct(numberLike: unknown, placesLike?: unknown) {
@@ -340,10 +354,10 @@ export function excelOct2Hex(numberLike: unknown, placesLike?: unknown) {
 
   const decimal = parseInt(number, 8);
   if (decimal >= 536870912) {
-    return `ff${(decimal + 3221225472).toString(16)}`;
+    return `FF${radixDigits(decimal + 3221225472, 16)}`;
   }
 
-  return padResult(decimal.toString(16), placesLike);
+  return padResult(radixDigits(decimal, 16), placesLike);
 }
 
 export function excelDelta(leftLike: unknown, rightLike: unknown = 0) {
@@ -367,7 +381,7 @@ export function excelBase(
     throwExcelError(EXCEL_ERROR.num);
   }
 
-  const result = number.toString(radix);
+  const result = radixDigits(number, radix);
   return `${'0'.repeat(Math.max(minLength - result.length, 0))}${result}`;
 }
 
@@ -630,31 +644,80 @@ export function excelImArgument(valueLike: unknown) {
 // ERF / ERFC
 // ═══════════════════════════════════════════════════════════════
 
-// Horner approximation of erf (Abramowitz and Stegun 7.1.26)
-export function excelErf(lowerLike: unknown, upperLike?: unknown) {
-  function erf1(x: number) {
-    const a1 = 0.254829592,
-      a2 = -0.284496736,
-      a3 = 1.421413741;
-    const a4 = -1.453152027,
-      a5 = 1.061405429,
-      p = 0.3275911;
-    const sign = x < 0 ? -1 : 1;
-    const t = 1 / (1 + p * Math.abs(x));
-    const y =
-      1 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-x * x);
-    return sign * y;
+// Both come from the regularized incomplete gamma function, since
+// erf(x) = P(½, x²) and erfc(x) = Q(½, x²). A rational approximation of erf
+// is good to about 1e-7, which is enough to report erf(0) as a billionth
+// rather than as zero, and taking erfc as 1 - erf loses every significant
+// digit once erf rounds to 1 near x = 6.
+const LN_GAMMA_HALF = 0.5723649429247001; // ln Γ(½) = ln √π
+const GAMMA_EPSILON = 1e-16;
+const GAMMA_FLOOR = 1e-300;
+const GAMMA_MAX_TERMS = 300;
+
+/** P(½, x) — the series form, which converges quickly for small x. */
+function lowerGammaHalf(x: number) {
+  if (x <= 0) return 0;
+  let term = 2; // 1/a with a = ½
+  let sum = term;
+  for (let n = 1; n < GAMMA_MAX_TERMS; n++) {
+    term *= x / (0.5 + n);
+    sum += term;
+    if (Math.abs(term) < Math.abs(sum) * GAMMA_EPSILON) break;
   }
+  return sum * Math.exp(-x + 0.5 * Math.log(x) - LN_GAMMA_HALF);
+}
+
+/** Q(½, x) — the continued fraction, which converges quickly for large x. */
+function upperGammaHalf(x: number) {
+  let b = x + 0.5;
+  let c = 1 / GAMMA_FLOOR;
+  let d = 1 / b;
+  let fraction = d;
+  for (let i = 1; i < GAMMA_MAX_TERMS; i++) {
+    const numerator = -i * (i - 0.5);
+    b += 2;
+    d = numerator * d + b;
+    if (Math.abs(d) < GAMMA_FLOOR) d = GAMMA_FLOOR;
+    c = b + numerator / c;
+    if (Math.abs(c) < GAMMA_FLOOR) c = GAMMA_FLOOR;
+    d = 1 / d;
+    const delta = d * c;
+    fraction *= delta;
+    if (Math.abs(delta - 1) < GAMMA_EPSILON) break;
+  }
+  return Math.exp(-x + 0.5 * Math.log(x) - LN_GAMMA_HALF) * fraction;
+}
+
+// ½ + 1 is where the series stops converging faster than the fraction.
+const GAMMA_SERIES_LIMIT = 1.5;
+
+function erfValue(x: number) {
+  const squared = x * x;
+  const value =
+    squared < GAMMA_SERIES_LIMIT
+      ? lowerGammaHalf(squared)
+      : 1 - upperGammaHalf(squared);
+  return x < 0 ? -value : value;
+}
+
+export function excelErf(lowerLike: unknown, upperLike?: unknown) {
   const lower = parseExcelNumber(lowerLike);
   if (upperLike !== undefined) {
-    const upper = parseExcelNumber(upperLike);
-    return erf1(upper) - erf1(lower);
+    return erfValue(parseExcelNumber(upperLike)) - erfValue(lower);
   }
-  return erf1(lower);
+  return erfValue(lower);
 }
 
 export function excelErfc(valueLike: unknown) {
-  return 1 - excelErf(valueLike);
+  const value = parseExcelNumber(valueLike);
+  const squared = value * value;
+  // Computed as the upper tail rather than as 1 - ERF, so the far tail keeps
+  // its precision: ERFC(6) is 2.15e-17, not zero.
+  const complement =
+    squared < GAMMA_SERIES_LIMIT
+      ? 1 - lowerGammaHalf(squared)
+      : upperGammaHalf(squared);
+  return value < 0 ? 2 - complement : complement;
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/packages/bxl/src/formulajs/financial.ts
+++ b/packages/bxl/src/formulajs/financial.ts
@@ -786,12 +786,18 @@ export function excelCoupdays(
     if (daysBetween(settlement, maturity) <= 0) {
       throwExcelError(EXCEL_ERROR.num);
     }
+    // Every coupon date is measured from maturity, not from the one before it:
+    // stepping back a period at a time from an already-clamped date would
+    // carry the clamp forward, so an August 31st maturity would go
+    // February 28th and then August 28th instead of back to the month's end.
     const monthsPerPeriod = 12 / frequency;
+    let periods = 1;
     let periodEnd = maturity;
     let periodStart = addMonthsClamped(maturity, -monthsPerPeriod);
     while (periodStart.getTime() > settlement.getTime()) {
+      periods++;
       periodEnd = periodStart;
-      periodStart = addMonthsClamped(periodStart, -monthsPerPeriod);
+      periodStart = addMonthsClamped(maturity, -periods * monthsPerPeriod);
     }
     return daysBetween(periodStart, periodEnd);
   }

--- a/packages/bxl/src/formulajs/financial.ts
+++ b/packages/bxl/src/formulajs/financial.ts
@@ -23,6 +23,15 @@ function parseCashFlows(values: unknown) {
   return parsed;
 }
 
+/**
+ * The magnitude a rate solver's residual is judged against. A net present
+ * value of a hundredth of a cent is a root for flows in the millions and
+ * nowhere near one for flows in the pennies.
+ */
+function cashFlowScale(values: number[]) {
+  return values.reduce((total, value) => total + Math.abs(value), 0) || 1;
+}
+
 export function excelFv(
   rateLike: unknown,
   nperLike: unknown,
@@ -389,6 +398,7 @@ export function excelIrr(valuesLike: unknown, guessLike = 0.1) {
   };
 
   const epsMax = 1e-10;
+  const tolerance = epsMax * cashFlowScale(values);
 
   for (let i = 0; i < 50; i++) {
     const resultValue = npv(guess);
@@ -398,14 +408,23 @@ export function excelIrr(valuesLike: unknown, guessLike = 0.1) {
       break;
     }
 
-    const nextGuess = guess - resultValue / derivative;
-    if (
-      Math.abs(nextGuess - guess) <= epsMax &&
-      Math.abs(resultValue) <= epsMax
-    ) {
-      return nextGuess;
+    const nextGuess = Math.max(
+      -0.99999999,
+      Math.min(guess - resultValue / derivative, 1000),
+    );
+    const settled = Math.abs(nextGuess - guess) <= epsMax;
+    guess = nextGuess;
+    if (settled) {
+      break;
     }
-    guess = Math.max(-0.99999999, Math.min(nextGuess, 1000));
+  }
+
+  // Newton's method walks to some rate whether or not a root exists, and a
+  // series like [-1, 3, -2.5] has none, so the rate it settled on only counts
+  // if the net present value there is actually zero.
+  const residual = npv(guess);
+  if (!Number.isFinite(residual) || Math.abs(residual) > tolerance) {
+    throwExcelError(EXCEL_ERROR.num);
   }
 
   return guess;
@@ -460,19 +479,26 @@ export function excelXirr(
   };
 
   const epsMax = 1e-10;
+  const tolerance = epsMax * cashFlowScale(values);
 
   for (let i = 0; i < 100; i++) {
-    const resultValue = irrResult(guess);
-    const nextGuess = guess - resultValue / irrDerivative(guess);
-
-    if (
-      Math.abs(nextGuess - guess) <= epsMax &&
-      Math.abs(resultValue) <= epsMax
-    ) {
-      return nextGuess;
+    const nextGuess = guess - irrResult(guess) / irrDerivative(guess);
+    if (!Number.isFinite(nextGuess)) {
+      break;
     }
-
+    const settled = Math.abs(nextGuess - guess) <= epsMax;
     guess = nextGuess;
+    if (settled) {
+      break;
+    }
+  }
+
+  // As for IRR: a rate the search never brought to zero is not a root. A rate
+  // at or below -100% is not one either — discounting by it raises a negative
+  // number to a fractional power, so the residual there is not even a number.
+  const residual = guess > -1 ? irrResult(guess) : Number.NaN;
+  if (!Number.isFinite(residual) || Math.abs(residual) > tolerance) {
+    throwExcelError(EXCEL_ERROR.num);
   }
 
   return guess;
@@ -728,30 +754,60 @@ export function excelPricedisc(
   return redemption * (1 - disc * yf);
 }
 
+/** A date `months` on, clamped to the target month's last day. */
+function addMonthsClamped(date: Date, months: number) {
+  const shifted = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1),
+  );
+  const lastDay = new Date(
+    Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  shifted.setUTCDate(Math.min(date.getUTCDate(), lastDay));
+  return shifted;
+}
+
 export function excelCoupdays(
-  _settlementLike: unknown,
-  _maturityLike: unknown,
+  settlementLike: unknown,
+  maturityLike: unknown,
   frequencyLike: unknown,
   basisLike: unknown = 0,
 ) {
   const frequency = Math.floor(parseExcelNumber(frequencyLike));
   const basis = Math.floor(Number(basisLike) || 0);
   if (![1, 2, 4].includes(frequency)) throwExcelError(EXCEL_ERROR.num);
-  // Coupon-period length comes from the basis convention alone, so the
-  // settlement and maturity dates do not participate.
-  switch (basis) {
-    case 0:
-    case 4:
-      return 360 / frequency;
-    case 1:
-      return 365 / frequency; // approximate for actual/actual
-    case 2:
-      return 360 / frequency;
-    case 3:
-      return 365 / frequency;
-    default:
+  if (basis < 0 || basis > 4) throwExcelError(EXCEL_ERROR.num);
+
+  if (basis === 1) {
+    // Actual/actual is the one convention where the answer is a real calendar
+    // span, so it needs the coupon period settlement falls in. Coupon dates
+    // run backwards from maturity a period at a time.
+    const settlement = parseExcelDate(settlementLike);
+    const maturity = parseExcelDate(maturityLike);
+    if (daysBetween(settlement, maturity) <= 0) {
       throwExcelError(EXCEL_ERROR.num);
+    }
+    const monthsPerPeriod = 12 / frequency;
+    let periodEnd = maturity;
+    let periodStart = addMonthsClamped(maturity, -monthsPerPeriod);
+    while (periodStart.getTime() > settlement.getTime()) {
+      periodEnd = periodStart;
+      periodStart = addMonthsClamped(periodStart, -monthsPerPeriod);
+    }
+    return daysBetween(periodStart, periodEnd);
   }
+
+  // Every other basis gives all coupon periods the same nominal length, so the
+  // dates do not participate.
+  return (basis === 3 ? 365 : 360) / frequency;
+}
+
+/**
+ * Whether a Treasury bill matures inside a year of settlement, which the
+ * TBILL family requires — the instrument they price is short-dated by
+ * definition, so a longer span is an error rather than an extrapolation.
+ */
+function matureWithinAYear(settlement: Date, maturity: Date) {
+  return maturity.getTime() <= addMonthsClamped(settlement, 12).getTime();
 }
 
 export function excelTbilleq(
@@ -763,7 +819,9 @@ export function excelTbilleq(
   const maturity = parseExcelDate(maturityLike);
   const discount = parseExcelNumber(discountLike);
   const dsm = daysBetween(settlement, maturity);
-  if (dsm <= 0 || discount <= 0) throwExcelError(EXCEL_ERROR.num);
+  if (dsm <= 0 || discount <= 0 || !matureWithinAYear(settlement, maturity)) {
+    throwExcelError(EXCEL_ERROR.num);
+  }
   return (365 * discount) / (360 - discount * dsm);
 }
 
@@ -776,7 +834,9 @@ export function excelTbillprice(
   const maturity = parseExcelDate(maturityLike);
   const discount = parseExcelNumber(discountLike);
   const dsm = daysBetween(settlement, maturity);
-  if (dsm <= 0 || discount <= 0) throwExcelError(EXCEL_ERROR.num);
+  if (dsm <= 0 || discount <= 0 || !matureWithinAYear(settlement, maturity)) {
+    throwExcelError(EXCEL_ERROR.num);
+  }
   return 100 * (1 - (discount * dsm) / 360);
 }
 
@@ -789,6 +849,8 @@ export function excelTbillyield(
   const maturity = parseExcelDate(maturityLike);
   const price = parseExcelNumber(priceLike);
   const dsm = daysBetween(settlement, maturity);
-  if (dsm <= 0 || price <= 0) throwExcelError(EXCEL_ERROR.num);
+  if (dsm <= 0 || price <= 0 || !matureWithinAYear(settlement, maturity)) {
+    throwExcelError(EXCEL_ERROR.num);
+  }
   return ((100 - price) / price) * (360 / dsm);
 }

--- a/packages/bxl/src/formulajs/financial.ts
+++ b/packages/bxl/src/formulajs/financial.ts
@@ -24,12 +24,34 @@ function parseCashFlows(values: unknown) {
 }
 
 /**
- * The magnitude a rate solver's residual is judged against. A net present
- * value of a hundredth of a cent is a root for flows in the millions and
- * nowhere near one for flows in the pennies.
+ * Whether the rate a solver stopped at is really a root, asked two ways.
+ *
+ * A net present value of zero settles it outright, which is the ordinary case
+ * and also what a double root gives, since the curve touches zero without
+ * crossing. But discounting amplifies rounding — dividing by `(1 + rate)^n`
+ * multiplies the error in `1 + rate` by the same factor — so near -100%, or
+ * over a long series, the smallest residual any double can produce is nowhere
+ * near zero. There, what marks a root is the crossing itself: the sign flips
+ * across a neighbourhood a few billion ulps wide, which rounding does not do
+ * and a rate that is not a root does not do.
  */
-function cashFlowScale(values: number[]) {
-  return values.reduce((total, value) => total + Math.abs(value), 0) || 1;
+function isNetPresentValueRoot(
+  netPresentValue: (rate: number) => number,
+  rate: number,
+  tolerance: number,
+) {
+  const residual = netPresentValue(rate);
+  if (!Number.isFinite(residual)) return false;
+  if (Math.abs(residual) <= tolerance) return true;
+
+  const nudge = Math.max(Math.abs(rate), 1e-8) * 1e-9;
+  const below = netPresentValue(rate - nudge);
+  const above = netPresentValue(rate + nudge);
+  return (
+    Number.isFinite(below) &&
+    Number.isFinite(above) &&
+    Math.sign(below) !== Math.sign(above)
+  );
 }
 
 export function excelFv(
@@ -398,7 +420,6 @@ export function excelIrr(valuesLike: unknown, guessLike = 0.1) {
   };
 
   const epsMax = 1e-10;
-  const tolerance = epsMax * cashFlowScale(values);
 
   for (let i = 0; i < 50; i++) {
     const resultValue = npv(guess);
@@ -421,9 +442,8 @@ export function excelIrr(valuesLike: unknown, guessLike = 0.1) {
 
   // Newton's method walks to some rate whether or not a root exists, and a
   // series like [-1, 3, -2.5] has none, so the rate it settled on only counts
-  // if the net present value there is actually zero.
-  const residual = npv(guess);
-  if (!Number.isFinite(residual) || Math.abs(residual) > tolerance) {
+  // if the net present value there really is zero.
+  if (!isNetPresentValueRoot(npv, guess, epsMax)) {
     throwExcelError(EXCEL_ERROR.num);
   }
 
@@ -479,7 +499,6 @@ export function excelXirr(
   };
 
   const epsMax = 1e-10;
-  const tolerance = epsMax * cashFlowScale(values);
 
   for (let i = 0; i < 100; i++) {
     const nextGuess = guess - irrResult(guess) / irrDerivative(guess);
@@ -496,8 +515,7 @@ export function excelXirr(
   // As for IRR: a rate the search never brought to zero is not a root. A rate
   // at or below -100% is not one either — discounting by it raises a negative
   // number to a fractional power, so the residual there is not even a number.
-  const residual = guess > -1 ? irrResult(guess) : Number.NaN;
-  if (!Number.isFinite(residual) || Math.abs(residual) > tolerance) {
+  if (guess <= -1 || !isNetPresentValueRoot(irrResult, guess, epsMax)) {
     throwExcelError(EXCEL_ERROR.num);
   }
 
@@ -754,15 +772,38 @@ export function excelPricedisc(
   return redemption * (1 - disc * yf);
 }
 
+/** The last day of the month `date` falls in. */
+function lastDayOfMonth(date: Date) {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+}
+
 /** A date `months` on, clamped to the target month's last day. */
 function addMonthsClamped(date: Date, months: number) {
   const shifted = new Date(
     Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1),
   );
-  const lastDay = new Date(
-    Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth() + 1, 0),
-  ).getUTCDate();
-  shifted.setUTCDate(Math.min(date.getUTCDate(), lastDay));
+  shifted.setUTCDate(Math.min(date.getUTCDate(), lastDayOfMonth(shifted)));
+  return shifted;
+}
+
+/**
+ * A coupon date `months` from maturity. A bond maturing on the last day of a
+ * month pays on the last day of every month in its schedule, so clamping the
+ * day number is not enough: a February 28th maturity would give an August 28th
+ * where the schedule wants the 31st.
+ */
+function addCouponMonths(maturity: Date, months: number) {
+  const shifted = new Date(
+    Date.UTC(maturity.getUTCFullYear(), maturity.getUTCMonth() + months, 1),
+  );
+  const endOfMonth = maturity.getUTCDate() === lastDayOfMonth(maturity);
+  shifted.setUTCDate(
+    endOfMonth
+      ? lastDayOfMonth(shifted)
+      : Math.min(maturity.getUTCDate(), lastDayOfMonth(shifted)),
+  );
   return shifted;
 }
 
@@ -777,27 +818,32 @@ export function excelCoupdays(
   if (![1, 2, 4].includes(frequency)) throwExcelError(EXCEL_ERROR.num);
   if (basis < 0 || basis > 4) throwExcelError(EXCEL_ERROR.num);
 
+  // Validated for every basis, even though only actual/actual reads the dates:
+  // the same arguments must not be an error under one convention and an answer
+  // under another.
+  const settlement = parseExcelDate(settlementLike);
+  const maturity = parseExcelDate(maturityLike);
+  const span = daysBetween(settlement, maturity);
+  if (!Number.isFinite(span) || span <= 0) {
+    throwExcelError(EXCEL_ERROR.num);
+  }
+
   if (basis === 1) {
     // Actual/actual is the one convention where the answer is a real calendar
     // span, so it needs the coupon period settlement falls in. Coupon dates
     // run backwards from maturity a period at a time.
-    const settlement = parseExcelDate(settlementLike);
-    const maturity = parseExcelDate(maturityLike);
-    if (daysBetween(settlement, maturity) <= 0) {
-      throwExcelError(EXCEL_ERROR.num);
-    }
     // Every coupon date is measured from maturity, not from the one before it:
-    // stepping back a period at a time from an already-clamped date would
-    // carry the clamp forward, so an August 31st maturity would go
-    // February 28th and then August 28th instead of back to the month's end.
+    // stepping back a period at a time from an already-clamped date would carry
+    // the clamp forward, so an August 31st maturity would go February 28th and
+    // then August 28th instead of back to the month's end.
     const monthsPerPeriod = 12 / frequency;
     let periods = 1;
     let periodEnd = maturity;
-    let periodStart = addMonthsClamped(maturity, -monthsPerPeriod);
+    let periodStart = addCouponMonths(maturity, -monthsPerPeriod);
     while (periodStart.getTime() > settlement.getTime()) {
       periods++;
       periodEnd = periodStart;
-      periodStart = addMonthsClamped(maturity, -periods * monthsPerPeriod);
+      periodStart = addCouponMonths(maturity, -periods * monthsPerPeriod);
     }
     return daysBetween(periodStart, periodEnd);
   }

--- a/packages/bxl/src/formulajs/isoWeek.ts
+++ b/packages/bxl/src/formulajs/isoWeek.ts
@@ -1,0 +1,20 @@
+/**
+ * The ISO 8601 week number of a date.
+ *
+ * Shared by `ISOWEEKNUM` and by `WEEKNUM`'s return type 21, which name the
+ * same rule and must not drift apart. Those two live in different modules —
+ * one eager, one lazily loaded — so the rule lives here rather than in either.
+ */
+
+const MS_PER_DAY = 86_400_000;
+
+export function isoWeekNumber(date: Date): number {
+  // A week belongs to the year holding its Thursday, which is what places an
+  // early-January date in the previous year's 52nd or 53rd week.
+  const isoDayOfWeek = date.getUTCDay() || 7; // Mon = 1 .. Sun = 7
+  const thursday = new Date(date.getTime());
+  thursday.setUTCDate(date.getUTCDate() + 4 - isoDayOfWeek);
+  const isoYearStart = Date.UTC(thursday.getUTCFullYear(), 0, 1);
+  const daysIntoIsoYear = (thursday.getTime() - isoYearStart) / MS_PER_DAY;
+  return Math.ceil((daysIntoIsoYear + 1) / 7);
+}

--- a/packages/bxl/src/formulajs/statistical.ts
+++ b/packages/bxl/src/formulajs/statistical.ts
@@ -706,12 +706,19 @@ export function excelTTest(array1Like: unknown, array2Like: unknown) {
   }
   const meanX = jStat.mean(array1);
   const meanY = jStat.mean(array2);
-  const sx = jStat.variance(array1, true);
-  const sy = jStat.variance(array2, true);
-  const statistic =
-    Math.abs(meanX - meanY) /
-    Math.sqrt(sx / array1.length + sy / array2.length);
-  return excelTDist2T(statistic, array1.length + array2.length - 2);
+  // Two-sample, unequal-variance, two-tailed — Excel's T.TEST type 3, which
+  // the two-argument form has no way to say otherwise. Equal variance is the
+  // assumption most easily violated without notice in card data, so the test
+  // that does not require it is the safer default.
+  const errorX = jStat.variance(array1, true) / array1.length;
+  const errorY = jStat.variance(array2, true) / array2.length;
+  const statistic = Math.abs(meanX - meanY) / Math.sqrt(errorX + errorY);
+  // Welch–Satterthwaite: the degrees of freedom that go with that standard
+  // error. Pooled degrees of freedom would belong to the equal-variance test.
+  const degreesOfFreedom =
+    (errorX + errorY) ** 2 /
+    (errorX ** 2 / (array1.length - 1) + errorY ** 2 / (array2.length - 1));
+  return excelTDist2T(statistic, degreesOfFreedom);
 }
 
 export function excelWeibullDist(
@@ -727,10 +734,13 @@ export function excelWeibullDist(
   if (x < 0 || alpha <= 0 || beta <= 0) {
     throwExcelError(EXCEL_ERROR.num);
   }
+  // Excel's alpha is the shape and its beta the scale, giving a CDF of
+  // 1 - exp(-(x/beta)^alpha). jstat takes the two the other way round, as
+  // (x, scale, shape), so they cross here.
   return checkedNumber(
     cumulative
-      ? jStat.weibull.cdf(x, alpha, beta)
-      : jStat.weibull.pdf(x, alpha, beta),
+      ? jStat.weibull.cdf(x, beta, alpha)
+      : jStat.weibull.pdf(x, beta, alpha),
   );
 }
 

--- a/packages/bxl/src/formulajs/wildcard.ts
+++ b/packages/bxl/src/formulajs/wildcard.ts
@@ -1,0 +1,128 @@
+/**
+ * Excel's wildcards, matched without a regular expression.
+ *
+ * `*` stands for any run of characters, `?` for exactly one, and `~` escapes
+ * any of the three. Compiling those to a regex is the obvious implementation
+ * and the wrong one: `*` becomes `.*`, and a pattern carrying several of them
+ * makes a backtracking engine explore exponentially many splits, so
+ * `SEARCH("*a*a*a*a*b", <a long field>)` stops being a search and becomes a
+ * hang — in an indexing worker, or on the browser's main thread.
+ *
+ * A pattern is instead split on `*` into segments that must appear in order.
+ * Each segment is matched where it first can, which is optimal because the
+ * runs between segments are unconstrained, so the whole match is decided in
+ * one forward pass over the text.
+ */
+
+/** One run between stars: a literal character, or `null` for any one character. */
+type WildcardSegment = (string | null)[];
+
+function parseWildcardPattern(pattern: string): WildcardSegment[] {
+  const segments: WildcardSegment[] = [[]];
+  let escaped = false;
+  for (const char of pattern) {
+    const segment = segments[segments.length - 1];
+    if (escaped) {
+      segment.push(char);
+      escaped = false;
+    } else if (char === '~') {
+      escaped = true;
+    } else if (char === '*') {
+      segments.push([]);
+    } else if (char === '?') {
+      segment.push(null);
+    } else {
+      segment.push(char);
+    }
+  }
+  return segments;
+}
+
+/**
+ * Case-insensitively, per character: folding whole strings would be wrong here,
+ * since a character whose lower case is longer than itself would shift every
+ * index after it.
+ */
+function sameCharacter(expected: string, actual: string) {
+  return expected === actual || expected.toLowerCase() === actual.toLowerCase();
+}
+
+function segmentMatchesAt(
+  segment: WildcardSegment,
+  text: string,
+  at: number,
+): boolean {
+  if (at < 0 || at + segment.length > text.length) return false;
+  for (let index = 0; index < segment.length; index++) {
+    const expected = segment[index];
+    if (expected !== null && !sameCharacter(expected, text[at + index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function findSegment(
+  segment: WildcardSegment,
+  text: string,
+  from: number,
+): number {
+  for (let at = from; at + segment.length <= text.length; at++) {
+    if (segmentMatchesAt(segment, text, at)) return at;
+  }
+  return -1;
+}
+
+/**
+ * Where the pattern first matches inside `text`, or -1. The match is anchored
+ * at neither end, which is what `SEARCH` and `FIND` report a position for.
+ */
+export function excelWildcardSearch(pattern: string, text: string): number {
+  const segments = parseWildcardPattern(pattern);
+  const [first] = segments;
+  const start = findSegment(first, text, 0);
+  if (start === -1) return -1;
+
+  // Only the earliest start needs trying: a later one leaves every following
+  // segment strictly less room, so if the chain fails from here it fails from
+  // there too.
+  let cursor = start + first.length;
+  for (let index = 1; index < segments.length; index++) {
+    const at = findSegment(segments[index], text, cursor);
+    if (at === -1) return -1;
+    cursor = at + segments[index].length;
+  }
+  return start;
+}
+
+/** Whether the pattern matches the whole of `text`, as a criteria match does. */
+export function excelWildcardMatchesWhole(
+  pattern: string,
+  text: string,
+): boolean {
+  const segments = parseWildcardPattern(pattern);
+  const first = segments[0];
+  if (segments.length === 1) {
+    return first.length === text.length && segmentMatchesAt(first, text, 0);
+  }
+
+  // With stars present, the ends are pinned and the middle segments float.
+  const last = segments[segments.length - 1];
+  const lastStart = text.length - last.length;
+  if (
+    !segmentMatchesAt(first, text, 0) ||
+    lastStart < first.length ||
+    !segmentMatchesAt(last, text, lastStart)
+  ) {
+    return false;
+  }
+
+  let cursor = first.length;
+  for (let index = 1; index < segments.length - 1; index++) {
+    const segment = segments[index];
+    const at = findSegment(segment, text, cursor);
+    if (at === -1 || at + segment.length > lastStart) return false;
+    cursor = at + segment.length;
+  }
+  return true;
+}

--- a/packages/bxl/src/jqtools/UPSTREAM-DIFFS.md
+++ b/packages/bxl/src/jqtools/UPSTREAM-DIFFS.md
@@ -119,14 +119,12 @@ adds the binary entries:
   is NaN, returns the other. Excel `MAX`/`MIN` (different name) propagate
   errors instead.
 - `copysign/2(x; y)` — magnitude of x with sign of y.
-- `atan2/2(x; y)` — **Excel argument order** (`x` first), NOT vanilla-jq
-  (`y; x`). The lowercase `atan2` and uppercase `ATAN2` resolve to the same
-  case-folded registry name, so BXL picks one canonical signature; Excel
-  order wins because it's the spreadsheet contract. `atan2(0; 0)` returns
-  `0` (POSIX-compat), not `#DIV/0!`. The realm-side compiler may upgrade
-  `atan2` → `ATAN2` (formula bridge) for readable BXL — that path keeps
-  Excel's `#DIV/0!`. Code reaching this jq-side filter (via the
-  `jq\`…\`` template form) gets the POSIX behaviour.
+- `atan2/2(y; x)` — jq/POSIX argument order. Excel's `ATAN2(x, y)` reverses
+  it, and the two are separate live registry entries rather than one canonical
+  signature: `atan2/2` here, `ATAN2/2` in the formula bridge, which the
+  readable compiler routes between by the name that was written. This filter
+  returns `0` for `atan2(0; 0)` (POSIX-compat) where `ATAN2` raises Excel's
+  `#DIV/0!`.
 
 ### 33 stubs filled with libm-equivalent implementations
 
@@ -144,10 +142,10 @@ adds the binary entries:
 | `nearbyint/0`, `rint/0`           | `roundHalfToEven`                         | Banker's rounding.                                                                                                                                                                                               |
 | `pow10/0`                         | `Math.pow(10, x)`                         |                                                                                                                                                                                                                  |
 | `expm1/0`                         | `Math.expm1`                              |                                                                                                                                                                                                                  |
-| `scalars_or_empty/0`              | yield-or-empty                            | Trivial.                                                                                                                                                                                                         |
-| `erf/0`, `erfc/0`                 | Abramowitz & Stegun 7.1.26                | ~1.5e-7 max error.                                                                                                                                                                                               |
+| `scalars_or_empty/0`              | scalars, plus empty collections           | The empty array and empty object are what separate it from `scalars/0`.                                                                                                                                          |
+| `erf/0`, `erfc/0`                 | Abramowitz & Stegun 7.1.26                | ~1.5e-7 max error, where a libm `erf` is exact to the last bit. Excel's `ERF`/`ERFC` in the formula bridge are computed to full double precision instead.                                                         |
 | `gamma/0`, `tgamma/0`             | Lanczos g=7, n=9                          | **True Γ** (Excel-canonical). POSIX `gamma()` was historically log-Γ on Linux, true Γ on BSD — BXL picks the modern interpretation. Use `lgamma`/`GAMMALN` for log-Γ.                                            |
-| `lgamma/0`, `lgamma_r/0`          | Lanczos log form                          | `lgamma_r` returns just the log magnitude. Divergence, not a design constraint: jq returns the sign as element 1 of a `[log magnitude, sign]` pair, so callers here cannot recover the sign of a negative gamma. |
+| `lgamma/0`, `lgamma_r/0`          | Lanczos log form                          | `lgamma_r` yields the `[ln \|Γ(x)\|, sign of Γ(x)]` pair jq does; the sign follows from ⌊x⌋'s parity, and is reported as positive at the poles.                                                                   |
 | `j0/0`, `j1/0`, `y0/0`, `y1/0`    | Numerical Recipes polynomial+asymptotic   | Bessel functions of integer orders 0 and 1; J/Y.                                                                                                                                                                 |
 | `jn/2`, `yn/2`                    | Recurrence on top of `j0`/`j1`, `y0`/`y1` | C/POSIX argument order: `jn(n; x)`. Excel's `BESSELJ(x, n)` (different name, swapped order) lives in the formula bridge.                                                                                         |
 
@@ -158,6 +156,26 @@ adds the binary entries:
 loader, which BXL doesn't (and won't) implement — BXL evaluates a single
 expression against a single input value, with no input stream and no `import`
 path resolution.
+
+`inputs/0` is native here rather than jq's `repeat(input)`, and yields an empty
+stream. jq's definition absorbs the end-of-input signal `input` raises when the
+stream runs out; `input/0` above raises a different error, which that `catch`
+would let escape. A runtime with no input stream is permanently out of inputs,
+so the empty stream is the answer jq would give. Restore the jq-source
+definition if `input/0` ever reads a real stream.
+
+### Sentinels standing in for host facts
+
+`get_search_list/0`, `get_jq_origin/0` and `get_prog_origin/0` answer with
+BXL-invented values — `[]`, `"bxl://jq-origin"`, `"native-inline"` — because
+the module search path and program origin they report are jq CLI concepts with
+no BXL equivalent. They are stubs like the four above, but ones that return
+rather than raise, since a caller asking where a program came from can be given
+an answer.
+
+`builtins/0` returns its names sorted, where jq's order is unspecified. Sorted
+is the BXL contract, and the list is built from the libraries a program actually
+resolved, so it changes with the library set.
 
 ### Cross-references
 

--- a/packages/bxl/src/jqtools/evaluate/compiledScalar.ts
+++ b/packages/bxl/src/jqtools/evaluate/compiledScalar.ts
@@ -77,6 +77,18 @@ function accessStaticStringPath(value: unknown, path: string[]): unknown {
   return current;
 }
 
+/**
+ * IF and IFS are compiled here as well as defined in the formula library's jq
+ * source, because a program that compiles wholly to scalars never reaches the
+ * registry — for a simple formula, these are the live implementations and the
+ * definitions in `bxl/bridge/formula-contrib-jq.ts` are the dead ones. The two
+ * must be kept in step by hand: registry-enumerated coverage cannot see this
+ * copy, so a case has to force the builtin route to reach the other.
+ *
+ * Both decide a branch with jq truthiness, under which only null and false are
+ * false — the number 0 takes the true branch, where Excel would take the false
+ * one.
+ */
 function compileExcelIf(
   args: ExpressionAst[],
 ): CompiledScalarExpression | undefined {

--- a/packages/bxl/src/jqtools/evaluate/filters/builtinJqFilters.ts
+++ b/packages/bxl/src/jqtools/evaluate/filters/builtinJqFilters.ts
@@ -224,7 +224,9 @@ def repeat(exp):
      def _repeat:
          exp, _repeat;
      _repeat;
-def inputs: try repeat(input) catch if .=="break" then empty else error end;
+# inputs is native here, not repeat(input): the sandbox has no input stream at
+# all, so input/0 raises rather than signalling end-of-input for the catch to
+# absorb. See builtinNativeFilters.ts.
 # ensure the output of debug(m1,m2) is kept together:
 def debug(msgs): (msgs | debug | empty), .;
 # like ruby's downcase - only characters A to Z are affected

--- a/packages/bxl/src/jqtools/evaluate/filters/builtinNativeFilters.ts
+++ b/packages/bxl/src/jqtools/evaluate/filters/builtinNativeFilters.ts
@@ -562,7 +562,9 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
       }
     },
     *'_max_by_impl/1'(input: any[], ref: any[][]) {
+      // An empty array has a null maximum, as max/0 and min/0 also report.
       if (input.length === 0) {
+        yield null;
         return;
       }
 
@@ -579,6 +581,7 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
     },
     *'_min_by_impl/1'(input: any[], ref: any[][]) {
       if (input.length === 0) {
+        yield null;
         return;
       }
 
@@ -986,8 +989,8 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
       // C lgamma_r reports ln|Γ(x)| through its return value and the sign of
       // Γ(x) through a pointer arg; jq returns the two as a pair, and so does
       // this. Γ is positive everywhere above zero and alternates sign between
-      // the poles below it, so the sign follows from ⌊x⌋'s parity. At a pole,
-      // where the magnitude overflows, the sign is reported as positive.
+      // the poles below it, so the sign follows from ⌊x⌋'s parity, and is
+      // reported as positive at the poles themselves.
       const x = assertNumber(input);
       const sign = x < 0 && Math.floor(x) % 2 !== 0 ? -1 : 1;
       yield [lgammaApprox(x), sign];

--- a/packages/bxl/src/jqtools/evaluate/filters/builtinNativeFilters.ts
+++ b/packages/bxl/src/jqtools/evaluate/filters/builtinNativeFilters.ts
@@ -1,6 +1,7 @@
 import {
   assertNumber,
   assertString,
+  captureGroupNames,
   createItem,
   delPaths,
   has,
@@ -23,7 +24,6 @@ import { compare } from '../compare.ts';
 import { JqArgumentError, JqEvaluateError } from '../../errors.ts';
 import { getPath } from '../utils/getPath.ts';
 import { setPath } from '../utils/setPath.ts';
-import { builtinJqFilters } from './builtinJqFilters.ts';
 import { applyNamedFormat } from '../applyFormat.ts';
 import {
   gmtime as gmtimeValue,
@@ -40,7 +40,6 @@ import {
 } from '../runtimeState.ts';
 
 const MIN_NORMAL = 2.2250738585072014e-308;
-const PUBLIC_SANDBOX_BLOCKED_BUILTINS = new Set(['env/0']);
 
 function containsValue(haystack: unknown, needle: unknown): boolean {
   if (typeOf(haystack) !== typeOf(needle)) {
@@ -86,20 +85,6 @@ function trimStringValue(
     output = output.trimEnd();
   }
   return output;
-}
-
-function publicBuiltinNames(): string[] {
-  return [
-    ...new Set([
-      ...Object.keys(builtinJqFilters),
-      ...Object.keys(builtinNativeFilters),
-    ]),
-  ]
-    .filter(
-      (name) =>
-        !name.startsWith('_') && !PUBLIC_SANDBOX_BLOCKED_BUILTINS.has(name),
-    )
-    .sort();
 }
 
 function rawCompactString(value: unknown): string {
@@ -187,6 +172,15 @@ function roundHalfToEven(x: number): number {
   if (absFrac > 0.5) return truncated + Math.sign(frac);
   // Tie: round to even.
   return truncated % 2 === 0 ? truncated : truncated + Math.sign(frac);
+}
+
+/** Round-half-away-from-zero, the mode C's `round` and Excel's ROUND use. */
+function roundHalfAwayFromZero(x: number): number {
+  if (!Number.isFinite(x)) return x;
+  const truncated = Math.trunc(x);
+  const frac = x - truncated;
+  if (Math.abs(frac) < 0.5) return truncated;
+  return truncated + Math.sign(frac);
 }
 
 /** IEEE remainder: x - n*y where n = round-half-to-even(x/y). */
@@ -501,6 +495,14 @@ function isScalar(value: unknown): boolean {
   );
 }
 
+/** True if value is an array or object with nothing in it. */
+function isEmptyCollection(value: unknown): boolean {
+  const t = typeOf(value);
+  if (t === Type.array) return (value as unknown[]).length === 0;
+  if (t === Type.object) return Object.keys(value as object).length === 0;
+  return false;
+}
+
 /* eslint-disable require-yield -- Every entry in this table is a generator so
    the evaluator can drive them all through one protocol. Filters whose only
    outcome is a signal — raising a jq error, or halting the program — reach the
@@ -540,20 +542,21 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
     ) {
       const str = assertString(input);
       const r = new RegExp(regex, (flags ?? '') + 'd');
+      const names = captureGroupNames(regex);
 
       if (flags && flags.includes('g')) {
         const m = Array.from(str.matchAll(r));
         if (returnOnlyBoolean) {
           yield m.length !== 0;
         } else {
-          yield m.map(transformRegExpMatch);
+          yield m.map((match) => transformRegExpMatch(match, names));
         }
       } else {
         const m = str.match(r);
         if (returnOnlyBoolean) {
           yield !!m;
         } else if (m) {
-          yield [transformRegExpMatch(m)];
+          yield [transformRegExpMatch(m, names)];
         }
       }
     },
@@ -562,9 +565,11 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
         return;
       }
 
+      // Ties resolve to the last maximum, where _min_by_impl keeps the first.
+      // The asymmetry is jq's.
       let bestIndex = 0;
       for (let i = 1; i < input.length; i++) {
-        if (compare(ref[i], ref[bestIndex]) > 0) {
+        if (compare(ref[i], ref[bestIndex]) >= 0) {
           bestIndex = i;
         }
       }
@@ -669,7 +674,10 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
       yield -1 - low;
     },
     *'builtins/0'() {
-      yield publicBuiltinNames();
+      // The names this reports depend on which libraries a program resolved,
+      // so resolveRegistry replaces the entry once it knows them. Declaring it
+      // here is what puts `builtins/0` itself into that list.
+      throw new JqEvaluateError('builtins/0 requires a resolved registry');
     },
     *'cbrt/0'(input: unknown) {
       yield applyUnaryMath(input, Math.cbrt);
@@ -899,6 +907,13 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
     *'input/0'() {
       throw notImplementedError('input/0');
     },
+    *'inputs/0'() {
+      // Every remaining input, of which a sandbox with no input stream has
+      // none — the same empty stream jq gives once its inputs are exhausted.
+      // jq derives this from repeat(input), which is not available here
+      // because input/0 raises instead of signalling end-of-input; restore
+      // the jq-source definition if input/0 ever reads a real stream.
+    },
     *'input_filename/0'() {
       throw notImplementedError('input_filename/0');
     },
@@ -906,7 +921,14 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
       throw notImplementedError('input_line_number/0');
     },
     *'isinfinite/0'(input: unknown) {
-      yield typeOf(input) === Type.number && !Number.isFinite(input as number);
+      // NaN is not an infinity, so it is excluded here just as C's isinf
+      // excludes it. isfinite/0 is defined in terms of this filter, so a NaN
+      // counted as infinite would come back non-finite as well.
+      yield (
+        typeOf(input) === Type.number &&
+        !Number.isFinite(input as number) &&
+        !Number.isNaN(input as number)
+      );
     },
     *'isnan/0'(input: unknown) {
       yield typeOf(input) === Type.number && Number.isNaN(input as number);
@@ -962,10 +984,14 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
       yield lgammaApprox(assertNumber(input));
     },
     *'lgamma_r/0'(input: unknown) {
-      // C lgamma_r returns ln|Γ(x)| via return value and the sign of Γ(x)
-      // via a pointer arg. Without pointers in jq we yield just the log
-      // magnitude; users needing the sign should compute it from x.
-      yield lgammaApprox(assertNumber(input));
+      // C lgamma_r reports ln|Γ(x)| through its return value and the sign of
+      // Γ(x) through a pointer arg; jq returns the two as a pair, and so does
+      // this. Γ is positive everywhere above zero and alternates sign between
+      // the poles below it, so the sign follows from ⌊x⌋'s parity. At a pole,
+      // where the magnitude overflows, the sign is reported as positive.
+      const x = assertNumber(input);
+      const sign = x < 0 && Math.floor(x) % 2 !== 0 ? -1 : 1;
+      yield [lgammaApprox(x), sign];
     },
     *'localtime/0'(input: unknown) {
       if (typeOf(input) !== Type.number) {
@@ -1082,7 +1108,9 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
       yield roundHalfToEven(assertNumber(input));
     },
     *'round/0'(input: unknown) {
-      yield Math.round(assertNumber(input));
+      // Ties go away from zero, matching C's round: -2.5 is -3, not -2.
+      // (Math.round ties toward +Infinity, which agrees only on positives.)
+      yield roundHalfAwayFromZero(assertNumber(input));
     },
     *'rtrimstr/1'(input: unknown, right: unknown) {
       const str = assertString(input);
@@ -1092,8 +1120,9 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
         : str;
     },
     *'scalars_or_empty/0'(input: unknown) {
-      // Yield input if it's null/boolean/number/string, otherwise no output.
-      if (isScalar(input)) yield input;
+      // Scalars, plus the empty array and empty object — keeping those is the
+      // whole of what separates this filter from `scalars`.
+      if (isScalar(input) || isEmptyCollection(input)) yield input;
     },
     *'scalb/2'(_input: unknown, x: unknown, n: unknown) {
       // Identical to ldexp in IEEE 754 environments (no FLT_RADIX != 2).

--- a/packages/bxl/src/jqtools/evaluate/filters/builtinNativeFilters.ts
+++ b/packages/bxl/src/jqtools/evaluate/filters/builtinNativeFilters.ts
@@ -117,7 +117,8 @@ function applyBinaryMath(
 //   - `gamma/0` and `tgamma/0` both compute true Γ (Excel-canonical)
 //   - `atan2/2` follows jq/POSIX argument order (y; x) — see filter below
 //   - the sandbox has no I/O, so `input/0` and its siblings raise
-//     notImplementedError rather than reading a stream
+//     notImplementedError rather than reading a stream, and `inputs/0`
+//     yields the empty stream of a runtime that is out of inputs
 // ────────────────────────────────────────────────────────────────────
 
 const F64_BUF = new ArrayBuffer(8);
@@ -924,11 +925,9 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
       // NaN is not an infinity, so it is excluded here just as C's isinf
       // excludes it. isfinite/0 is defined in terms of this filter, so a NaN
       // counted as infinite would come back non-finite as well.
-      yield (
-        typeOf(input) === Type.number &&
+      yield typeOf(input) === Type.number &&
         !Number.isFinite(input as number) &&
-        !Number.isNaN(input as number)
-      );
+        !Number.isNaN(input as number);
     },
     *'isnan/0'(input: unknown) {
       yield typeOf(input) === Type.number && Number.isNaN(input as number);

--- a/packages/bxl/src/jqtools/evaluate/utils/utils.ts
+++ b/packages/bxl/src/jqtools/evaluate/utils/utils.ts
@@ -510,13 +510,48 @@ interface JqRegExpMatch {
   captures: {
     offset: number;
     length: number;
-    string: string;
+    string: string | null;
     name: string | null;
   }[];
 }
 
-export function transformRegExpMatch(match: RegExpMatchArray): JqRegExpMatch {
-  const indices: [number, number][] | undefined = (match as any).indices;
+/**
+ * The name of each capture group by group index, read off the pattern source.
+ * A match exposes its named groups only as a name-to-value map, which cannot
+ * say which group index a name belongs to: `(?<a>(?<b>x))` gives both names
+ * the same span and the same text.
+ */
+export function captureGroupNames(pattern: string): (string | null)[] {
+  const names: (string | null)[] = [];
+  let inCharacterClass = false;
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i];
+    if (char === '\\') {
+      i++;
+    } else if (inCharacterClass) {
+      if (char === ']') inCharacterClass = false;
+    } else if (char === '[') {
+      inCharacterClass = true;
+    } else if (char === '(') {
+      if (pattern[i + 1] !== '?') {
+        names.push(null);
+        continue;
+      }
+      // `(?<name>` opens a capture group; `(?:`, `(?=`, `(?!`, `(?<=`, `(?<!`
+      // and inline-flag groups do not.
+      const named = /^\(\?<(?![=!])([^>]*)>/.exec(pattern.slice(i));
+      if (named) names.push(named[1]);
+    }
+  }
+  return names;
+}
+
+export function transformRegExpMatch(
+  match: RegExpMatchArray,
+  captureNames: (string | null)[] = [],
+): JqRegExpMatch {
+  const indices: ([number, number] | undefined)[] | undefined = (match as any)
+    .indices;
   if (match.index === undefined || indices === undefined)
     throw new JqEvaluateError('RegExp match item transformation error');
   const offset = match.index;
@@ -524,11 +559,16 @@ export function transformRegExpMatch(match: RegExpMatchArray): JqRegExpMatch {
     offset,
     length: match[0].length,
     string: match[0],
-    captures: match.slice(1).map((item, i) => ({
-      offset: indices[i + 1][0],
-      length: item.length,
-      string: item,
-      name: null,
-    })),
+    captures: match.slice(1).map((item, i) => {
+      const name = captureNames[i] ?? null;
+      // An optional group that did not participate has no text and no span.
+      if (item === undefined) return { offset: -1, length: 0, string: null, name };
+      return {
+        offset: indices[i + 1]![0],
+        length: item.length,
+        string: item,
+        name,
+      };
+    }),
   };
 }

--- a/packages/bxl/src/jqtools/evaluate/utils/utils.ts
+++ b/packages/bxl/src/jqtools/evaluate/utils/utils.ts
@@ -562,7 +562,8 @@ export function transformRegExpMatch(
     captures: match.slice(1).map((item, i) => {
       const name = captureNames[i] ?? null;
       // An optional group that did not participate has no text and no span.
-      if (item === undefined) return { offset: -1, length: 0, string: null, name };
+      if (item === undefined)
+        return { offset: -1, length: 0, string: null, name };
       return {
         offset: indices[i + 1]![0],
         length: item.length,

--- a/packages/bxl/src/jqtools/parser/Tokenizer.ts
+++ b/packages/bxl/src/jqtools/parser/Tokenizer.ts
@@ -344,20 +344,31 @@ export class Tokenizer {
 
   private readNumber(): Token {
     let hasDot = false;
-    return {
-      type: 'num',
-      value: Number(
-        this.readWhile((c) => {
-          if (c === '.') {
-            if (hasDot) return false;
-            hasDot = true;
-            return true;
-          }
-
-          return Tokenizer.isDigit(c);
-        }),
-      ),
-    };
+    let hasExponent = false;
+    let previous = '';
+    // Digits, then at most one dot, then at most one `e` exponent with an
+    // optional sign: 1e3, 1E-3 and 5e-324 are single numbers. The exponent is
+    // taken only when a digit follows it, so the `e` opening an identifier is
+    // left to the tokenizer's next pass.
+    const literal = this.readWhile((c) => {
+      let accepted: boolean;
+      if (c === '.') {
+        accepted = !hasDot && !hasExponent;
+        hasDot ||= accepted;
+      } else if (c === 'e' || c === 'E') {
+        const signed = ['+', '-'].includes(this.input.peek(1));
+        accepted =
+          !hasExponent && Tokenizer.isDigit(this.input.peek(signed ? 2 : 1));
+        hasExponent ||= accepted;
+      } else if (c === '+' || c === '-') {
+        accepted = previous === 'e' || previous === 'E';
+      } else {
+        accepted = Tokenizer.isDigit(c);
+      }
+      if (accepted) previous = c;
+      return accepted;
+    });
+    return { type: 'num', value: Number(literal) };
   }
 
   private static isWhitespace(c: string) {

--- a/packages/bxl/tests/unit/fixtures/function-coverage/core-jq.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/core-jq.ts
@@ -39,11 +39,6 @@ export const coreJqCases: CoverageCase[] = jqCases([
     // empty array and object as well as a populated one.
     source: '[(1, [2], [], {}) | scalars_or_empty]',
     expected: [1, [], {}],
-    knownDefect:
-      'the implementation is `if (isScalar(input)) yield input`, making it a ' +
-      'byte-identical copy of scalars/0 — empty collections are dropped ' +
-      'rather than kept',
-    produces: { expected: [1] },
   },
   { covers: 'finites/0', source: '[(1, infinite) | finites]', expected: [1] },
   // Zero is finite but subnormal-or-zero, so it is not "normal".
@@ -306,6 +301,26 @@ export const coreJqCases: CoverageCase[] = jqCases([
     input: [{ v: 4 }, { v: 2 }],
     expected: { v: 2 },
   },
+  // The two disagree on ties: max_by keeps the last item holding the winning
+  // key, min_by the first. Asserted because either could plausibly be picked.
+  {
+    covers: 'max_by/1',
+    source: 'max_by(.v)',
+    input: [
+      { v: 2, i: 0 },
+      { v: 2, i: 1 },
+    ],
+    expected: { v: 2, i: 1 },
+  },
+  {
+    covers: 'min_by/1',
+    source: 'min_by(.v)',
+    input: [
+      { v: 2, i: 0 },
+      { v: 2, i: 1 },
+    ],
+    expected: { v: 2, i: 0 },
+  },
   // bsearch returns the hit index, or -1 - insertionPoint when the target is absent.
   { covers: 'bsearch/1', source: '[1,3,5] | bsearch(4)', expected: -3 },
   { covers: 'all/0', source: 'all', input: [true, false], expected: false },
@@ -420,22 +435,25 @@ export const coreJqCases: CoverageCase[] = jqCases([
     source: '"abc" | match("b")',
     expected: { offset: 1, length: 1, string: 'b', captures: [] },
   },
-  // The capture name on a match is the root the capture/sub/gsub defects all
-  // grow from, so it is pinned here rather than only through them — patching
-  // `capture` alone would promote those cases and leave this one failing.
+  // A named group carries its name onto the match, which is where `capture`,
+  // `sub` and `gsub` all read it from — so it is asserted at that root as
+  // well as through each of them.
   {
     covers: 'match/1',
     source: '"abc123" | match("(?<num>[0-9]+)") | .captures[0].name',
     expected: 'num',
-    knownDefect:
-      'transformRegExpMatch hardcodes name: null on every capture and never ' +
-      "reads the match's groups",
-    produces: { expected: null },
   },
   {
     covers: 'match/2',
     source: '"aA" | [match("a"; "gi") | .offset]',
     expected: [0, 1],
+  },
+  // An optional group that did not take part still occupies its slot, with no
+  // text and no position.
+  {
+    covers: 'match/1',
+    source: '"abc" | match("(x)?(b)") | .captures[0]',
+    expected: { offset: -1, length: 0, string: null, name: null },
   },
   { covers: 'test/1', source: '"abc" | test("b.")', expected: true },
   { covers: 'test/2', source: '"ABC" | test("abc"; "i")', expected: true },
@@ -443,19 +461,11 @@ export const coreJqCases: CoverageCase[] = jqCases([
     covers: 'capture/1',
     source: '"abc123" | capture("(?<num>[0-9]+)")',
     expected: { num: '123' },
-    knownDefect:
-      'transformRegExpMatch hardcodes name: null on every capture and never ' +
-      "reads the match's groups, so capture's select(.name != null) rejects " +
-      'everything and yields {}. sub/gsub replacement captures are empty for ' +
-      'the same reason',
-    produces: { expected: {} },
   },
   {
     covers: 'capture/2',
     source: '"XYZ" | capture("(?<low>xyz)"; "i")',
     expected: { low: 'XYZ' },
-    knownDefect: 'named captures are discarded, as for capture/1',
-    produces: { expected: {} },
   },
   {
     covers: 'scan/1',
@@ -473,18 +483,11 @@ export const coreJqCases: CoverageCase[] = jqCases([
     covers: 'sub/2',
     source: '"abc" | sub("(?<x>b)"; "[" + .x + "]")',
     expected: 'a[b]c',
-    knownDefect:
-      'the replacement sees no named captures, for the same reason capture/1 ' +
-      'yields {} — transformRegExpMatch never reads the match groups — so the ' +
-      'interpolation substitutes nothing',
-    produces: { expected: 'a[]c' },
   },
   {
     covers: 'gsub/2',
     source: '"abc" | gsub("(?<x>b)"; "<" + .x + ">")',
     expected: 'a<b>c',
-    knownDefect: 'named captures are discarded, as for sub/2',
-    produces: { expected: 'a<>c' },
   },
   { covers: 'gsub/3', source: '"aBa" | gsub("b"; "-"; "i")', expected: 'a-a' },
   {
@@ -713,16 +716,11 @@ export const coreJqCases: CoverageCase[] = jqCases([
   },
   {
     covers: 'inputs/0',
-    // jq defines inputs as repeat(input) with the end-of-input break caught,
-    // so a runtime with no further inputs yields an empty stream rather than
-    // raising. That input/0 itself is unimplemented is documented; inputs
-    // failing hard is a downstream consequence that is not.
+    // `inputs` is every remaining input, and a runtime whose inputs are
+    // exhausted — as this one's always are — has none, so it yields an empty
+    // stream where `input` raises.
     source: '[inputs]',
     expected: [],
-    knownDefect:
-      'the unimplemented input/0 raises instead of signalling break, so the ' +
-      'catch in the jq definition never runs and the error escapes',
-    produces: { throws: /Feature 'input\/0' is not implemented/ },
   },
   {
     covers: 'input_filename/0',

--- a/packages/bxl/tests/unit/fixtures/function-coverage/core-jq.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/core-jq.ts
@@ -321,6 +321,10 @@ export const coreJqCases: CoverageCase[] = jqCases([
     ],
     expected: { v: 2, i: 0 },
   },
+  // An empty array has a null extreme rather than no answer at all, matching
+  // what max/0 and min/0 report.
+  { covers: 'max_by/1', source: '[] | max_by(.)', expected: null },
+  { covers: 'min_by/1', source: '[] | min_by(.)', expected: null },
   // bsearch returns the hit index, or -1 - insertionPoint when the target is absent.
   { covers: 'bsearch/1', source: '[1,3,5] | bsearch(4)', expected: -3 },
   { covers: 'all/0', source: 'all', input: [true, false], expected: false },
@@ -454,6 +458,19 @@ export const coreJqCases: CoverageCase[] = jqCases([
     covers: 'match/1',
     source: '"abc" | match("(x)?(b)") | .captures[0]',
     expected: { offset: -1, length: 0, string: null, name: null },
+  },
+  // Capture names are read off the pattern by counting group openings, so the
+  // count has to skip the parentheses that are not groups: one inside a
+  // character class, and the one opening a lookbehind.
+  {
+    covers: 'match/1',
+    source: '"a(b" | match("[(](?<x>b)") | .captures[0].name',
+    expected: 'x',
+  },
+  {
+    covers: 'match/1',
+    source: '"ab" | match("(?<=a)(?<x>b)") | .captures[0].name',
+    expected: 'x',
   },
   { covers: 'test/1', source: '"abc" | test("b.")', expected: true },
   { covers: 'test/2', source: '"ABC" | test("abc"; "i")', expected: true },

--- a/packages/bxl/tests/unit/fixtures/function-coverage/core-math.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/core-math.ts
@@ -165,11 +165,6 @@ export const coreMathCases: CoverageCase[] = jqCases([
     source: 'round',
     input: -2.5,
     expected: -3,
-    knownDefect:
-      'the implementation is a bare Math.round, which ties toward +Infinity, ' +
-      'so every negative half goes the wrong way. C round, jq and Excel all ' +
-      'tie away from zero; positive halves agree by coincidence',
-    produces: { expected: -2 },
   },
   { covers: 'floor/0', source: 'floor', input: -1.5, expected: -2 },
   { covers: 'ceil/0', source: 'ceil', input: 1.2, expected: 2 },
@@ -246,12 +241,6 @@ export const coreMathCases: CoverageCase[] = jqCases([
     covers: 'isinfinite/0',
     source: 'nan | isinfinite',
     expected: false,
-    knownDefect:
-      'the test is !Number.isFinite(x), which is also true for NaN. This ' +
-      'cascades into isfinite/0, defined in jq source as ' +
-      'type == "number" and (isinfinite | not), so nan | isfinite is false ' +
-      'here where jq gives true',
-    produces: { expected: true },
   },
   { covers: 'isfinite/0', source: 'infinite | isfinite', expected: false },
   // isfinite is defined in jq source as type == "number" and (isinfinite |
@@ -261,10 +250,6 @@ export const coreMathCases: CoverageCase[] = jqCases([
     covers: 'isfinite/0',
     source: 'nan | isfinite',
     expected: true,
-    knownDefect:
-      'isinfinite/0 reports NaN as infinite and this definition negates it, ' +
-      'so NaN comes back non-finite. Fixing isinfinite fixes this too',
-    produces: { expected: false },
   },
   // 1e-320 is subnormal: finite and nonzero, but below the normal threshold.
   { covers: 'isnormal/0', source: 'isnormal', input: 1e-320, expected: false },
@@ -306,10 +291,6 @@ export const coreMathCases: CoverageCase[] = jqCases([
       ok(Math.abs(pair[0] - -0.0562437) <= 1e-7, `ln|gamma| was ${pair[0]}`);
       strictEqual(pair[1], -1, 'sign of gamma(-2.5)');
     },
-    knownDefect:
-      'only the scalar ln|gamma(x)| is returned, so the sign the function ' +
-      'exists to report is dropped. jq returns it as element 1 of a pair',
-    produces: { expected: -0.056243716497675456, tolerance: 1e-12 },
   },
   // The erf implementation is a rational approximation good to ~1.5e-7.
   {

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-date.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-date.ts
@@ -178,9 +178,23 @@ export const formulaDateCases: CoverageCase[] = dateCases([
     source: 'WEEKNUM(DATE(2026, 4, 26), 21)',
     expected: 17,
   },
+  // 2026-04-26 is a Sunday, so a week opening on Wednesday puts it in the week
+  // that began on the 22nd — the 17th of the year.
+  {
+    covers: 'WEEKNUM/2',
+    source: 'WEEKNUM(DATE(2026, 4, 26), 13)',
+    expected: 17,
+  },
   {
     covers: 'WEEKNUM/2',
     source: 'WEEKNUM(DATE(2026, 4, 26), 5)',
+    throws: /#NUM!/,
+  },
+  // Zero is out of range like any other unknown type, not a stand-in for the
+  // default.
+  {
+    covers: 'WEEKNUM/2',
+    source: 'WEEKNUM(DATE(2026, 4, 26), 0)',
     throws: /#NUM!/,
   },
   // 2026-06-15 is the Monday that opens ISO week 25 of 2026.

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-date.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-date.ts
@@ -127,15 +127,29 @@ export const formulaDateCases: CoverageCase[] = dateCases([
   // numbers from Sunday = 1, type 2 from Monday = 1.
   { covers: 'WEEKDAY/1', source: 'WEEKDAY(DATE(2026, 4, 30))', expected: 5 },
   { covers: 'WEEKDAY/2', source: 'WEEKDAY(DATE(2026, 4, 30), 2)', expected: 4 },
-  // Type 11 is the same Monday = 1 numbering as type 2.
+  // Type 11 is the same Monday = 1 numbering as type 2. Types 12 through 17
+  // walk the start of the week forward a day at a time, so 17 opens it on
+  // Sunday again and agrees with type 1.
   {
     covers: 'WEEKDAY/2',
     source: 'WEEKDAY(DATE(2026, 4, 30), 11)',
     expected: 4,
-    knownDefect:
-      'only return types 1, 2 and 3 are branched on, so 11 through 17 fall ' +
-      'through to the Sunday = 1 default',
-    produces: { expected: 5 },
+  },
+  {
+    covers: 'WEEKDAY/2',
+    source: 'WEEKDAY(DATE(2026, 4, 30), 16)',
+    expected: 6,
+  },
+  {
+    covers: 'WEEKDAY/2',
+    source: 'WEEKDAY(DATE(2026, 4, 30), 17)',
+    expected: 5,
+  },
+  // A return type outside the set is an error, not the default numbering.
+  {
+    covers: 'WEEKDAY/2',
+    source: 'WEEKDAY(DATE(2026, 4, 30), 5)',
+    throws: /#NUM!/,
   },
   // 2026-04-26 is a Sunday, which is exactly where the two start-of-week
   // conventions disagree: it opens week 18 counting weeks from Sunday and
@@ -146,15 +160,28 @@ export const formulaDateCases: CoverageCase[] = dateCases([
     source: 'WEEKNUM(DATE(2026, 4, 26), 2)',
     expected: 17,
   },
+  // Types 11 through 17 name the weekday the week opens on, the same ladder
+  // WEEKDAY uses: 11 is Monday, so this Sunday closes week 17.
+  {
+    covers: 'WEEKNUM/2',
+    source: 'WEEKNUM(DATE(2026, 4, 26), 11)',
+    expected: 17,
+  },
+  {
+    covers: 'WEEKNUM/2',
+    source: 'WEEKNUM(DATE(2026, 4, 26), 17)',
+    expected: 18,
+  },
   // Return type 21 is the ISO-8601 week, the one ISOWEEKNUM reports.
   {
     covers: 'WEEKNUM/2',
     source: 'WEEKNUM(DATE(2026, 4, 26), 21)',
     expected: 17,
-    knownDefect:
-      'return type 2 is the only one branched on, so 11 through 17 and the ' +
-      'ISO 21 all fall through to the Sunday-start week',
-    produces: { expected: 18 },
+  },
+  {
+    covers: 'WEEKNUM/2',
+    source: 'WEEKNUM(DATE(2026, 4, 26), 5)',
+    throws: /#NUM!/,
   },
   // 2026-06-15 is the Monday that opens ISO week 25 of 2026.
   {
@@ -168,11 +195,19 @@ export const formulaDateCases: CoverageCase[] = dateCases([
     covers: 'ISOWEEKNUM/1',
     source: 'ISOWEEKNUM(DATE(2027, 1, 1))',
     expected: 53,
-    knownDefect:
-      'the week arithmetic has no year-boundary branch, so an early-January ' +
-      'date belonging to the previous ISO year reports week 0 instead of that ' +
-      "year's 52nd or 53rd week",
-    produces: { expected: 0 },
+  },
+  // 2022-01-01 is a Saturday, closing ISO year 2021's 52nd week. 2021-01-04
+  // is the Monday that opens ISO week 1 of 2021, the shortest way to say the
+  // count restarts rather than continuing.
+  {
+    covers: 'ISOWEEKNUM/1',
+    source: 'ISOWEEKNUM(DATE(2022, 1, 1))',
+    expected: 52,
+  },
+  {
+    covers: 'ISOWEEKNUM/1',
+    source: 'ISOWEEKNUM(DATE(2021, 1, 4))',
+    expected: 1,
   },
   // Working days. April 2026 runs Wednesday the 1st to Thursday the 30th and
   // holds eight weekend days, leaving 22 of its 30 days.
@@ -255,11 +290,11 @@ export const formulaDateCases: CoverageCase[] = dateCases([
     covers: 'TIMEVALUE/1',
     source: 'TIMEVALUE("2:24 PM")',
     expected: 0.6,
-    knownDefect:
-      'the parse reads only the digit groups of `h:mm:ss` and drops the AM/PM ' +
-      'suffix, so every afternoon time comes back twelve hours early',
-    produces: { expected: 0.1 },
   },
+  // The twelve o'clock hours are the ones the convention treats specially:
+  // 12 AM opens the day and 12 PM is noon.
+  { covers: 'TIMEVALUE/1', source: 'TIMEVALUE("12:00 AM")', expected: 0 },
+  { covers: 'TIMEVALUE/1', source: 'TIMEVALUE("12:00 PM")', expected: 0.5 },
   // The clock functions have no fixed answer, so they assert what holds
   // whenever they run: TODAY is the serial of the current UTC date, computed
   // here from Date.UTC so the expectation is derived rather than restated

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-engineering.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-engineering.ts
@@ -14,18 +14,13 @@ export const formulaEngineeringCases: CoverageCase[] = [
     covers: 'BASE/2',
     source: 'BASE(255, 16)',
     expected: 'FF',
-    knownDefect:
-      'a bare toString(radix) with no toUpperCase. The whole hex-emitting ' +
-      'family is affected — BIN2HEX, DEC2HEX, OCT2HEX, BASE. The input side ' +
-      'already accepts either casing, so uppercasing output breaks no ' +
-      'round trip',
-    produces: { expected: 'ff' },
   },
   // The third argument is a minimum length, zero-padded.
   { covers: 'BASE/3', source: 'BASE(15, 2, 10)', expected: '0000001111' },
   // Ten-digit binary reads as 10-bit two's complement.
   { covers: 'BIN2DEC/1', source: 'BIN2DEC("1110011100")', expected: -100 },
   { covers: 'BIN2HEX/1', source: 'BIN2HEX("10000")', expected: '10' },
+  { covers: 'BIN2HEX/1', source: 'BIN2HEX("11111111")', expected: 'FF' },
   { covers: 'BIN2HEX/2', source: 'BIN2HEX("1001", 3)', expected: '009' },
   { covers: 'BIN2OCT/1', source: 'BIN2OCT("1100100")', expected: '144' },
   { covers: 'BIN2OCT/2', source: 'BIN2OCT("1001", 3)', expected: '011' },
@@ -38,8 +33,6 @@ export const formulaEngineeringCases: CoverageCase[] = [
     covers: 'DEC2HEX/1',
     source: 'DEC2HEX(255)',
     expected: 'FF',
-    knownDefect: 'lowercase hex digits, as for BASE/2',
-    produces: { expected: 'ff' },
   },
   { covers: 'DEC2HEX/2', source: 'DEC2HEX(100, 4)', expected: '0064' },
   { covers: 'DEC2OCT/1', source: 'DEC2OCT(58)', expected: '72' },
@@ -55,6 +48,7 @@ export const formulaEngineeringCases: CoverageCase[] = [
   { covers: 'OCT2BIN/2', source: 'OCT2BIN("3", 3)', expected: '011' },
   { covers: 'OCT2DEC/1', source: 'OCT2DEC("54")', expected: 44 },
   { covers: 'OCT2HEX/1', source: 'OCT2HEX("100")', expected: '40' },
+  { covers: 'OCT2HEX/1', source: 'OCT2HEX("377")', expected: 'FF' },
   { covers: 'OCT2HEX/2', source: 'OCT2HEX("100", 4)', expected: '0040' },
   // Bitwise — operands limited to 48 bits, shift counts signed
   { covers: 'BITAND/2', source: 'BITAND(13, 25)', expected: 9 },
@@ -73,12 +67,6 @@ export const formulaEngineeringCases: CoverageCase[] = [
     covers: 'COMPLEX/2',
     source: 'COMPLEX(0, -1)',
     expected: '-i',
-    knownDefect:
-      'formatComplex special-cases an imaginary part of 1 to drop the ' +
-      'coefficient but has no mirror for -1, so it emits "-1i". The library ' +
-      'parses "-i" perfectly well — it just cannot write it — and every ' +
-      'IM* function formats through here',
-    produces: { expected: '-1i' },
   },
   { covers: 'COMPLEX/3', source: 'COMPLEX(3, 4, "j")', expected: '3+4j' },
   { covers: 'IMREAL/1', source: 'IMREAL("6-9i")', expected: 6 },
@@ -231,21 +219,38 @@ export const formulaEngineeringCases: CoverageCase[] = [
   {
     covers: 'ERF/1',
     source: 'ERF(1)',
-    expected: 0.8427007929,
-    tolerance: 1e-6,
+    expected: 0.8427007929497149,
+    tolerance: 1e-15,
+  },
+  // erf is odd and zero at the origin, both exactly.
+  { covers: 'ERF/1', source: 'ERF(0)', expected: 0 },
+  {
+    covers: 'ERF/1',
+    source: 'ERF(-1)',
+    expected: -0.8427007929497149,
+    tolerance: 1e-15,
   },
   // The two-argument form integrates between bounds: ERF(0, 1) = erf(1).
   {
     covers: 'ERF/2',
     source: 'ERF(0, 1)',
-    expected: 0.8427007929,
-    tolerance: 1e-6,
+    expected: 0.8427007929497149,
+    tolerance: 1e-15,
   },
   {
     covers: 'ERFC/1',
     source: 'ERFC(1)',
-    expected: 0.1572992071,
-    tolerance: 1e-6,
+    expected: 0.15729920705028513,
+    tolerance: 1e-15,
+  },
+  { covers: 'ERFC/1', source: 'ERFC(0)', expected: 1 },
+  // The complement is computed as the upper tail rather than as 1 - ERF, which
+  // is the only way the far tail keeps any significant digits at all.
+  {
+    covers: 'ERFC/1',
+    source: 'ERFC(6)',
+    expected: 2.1519736712498913e-17,
+    tolerance: 1e-25,
   },
   { covers: 'UNICHAR/1', source: 'UNICHAR(66)', expected: 'B' },
 ];

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-engineering.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-engineering.ts
@@ -244,6 +244,20 @@ export const formulaEngineeringCases: CoverageCase[] = [
     tolerance: 1e-15,
   },
   { covers: 'ERFC/1', source: 'ERFC(0)', expected: 1 },
+  // x² is what the series takes, and it runs out of exponent long before erf
+  // stops being ±1: past about 1.3e154 it overflows, and the answer is the
+  // saturated one rather than the NaN a series would return.
+  { covers: 'ERF/1', source: 'ERF(POWER(10, 200))', expected: 1 },
+  { covers: 'ERF/1', source: 'ERF(-POWER(10, 200))', expected: -1 },
+  { covers: 'ERFC/1', source: 'ERFC(POWER(10, 200))', expected: 0 },
+  { covers: 'ERFC/1', source: 'ERFC(-POWER(10, 200))', expected: 2 },
+  // At the other end x² is subnormal, where erf is 2x/√π exactly.
+  {
+    covers: 'ERF/1',
+    source: 'ERF(POWER(10, -300))',
+    expected: 1.1283791670955126e-300,
+    tolerance: 1e-315,
+  },
   // The complement is computed as the upper tail rather than as 1 - ERF, which
   // is the only way the far tail keeps any significant digits at all.
   {

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-financial.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-financial.ts
@@ -163,6 +163,11 @@ export const formulaFinancialCases: CoverageCase[] = [
     tolerance: 1e-7,
   },
   { covers: 'IRR/1', source: 'IRR([100, 110])', throws: /#NUM!/ },
+  // -1, +3, -2.5 changes sign twice but its net present value never reaches
+  // zero at any rate, so there is no internal rate of return to report. The
+  // iteration still ends somewhere, which is why the result is checked
+  // against the series rather than taken on trust.
+  { covers: 'IRR/1', source: 'IRR([-1, 3, -2.5])', throws: /#NUM!/ },
   // Two sign changes give -100, +230, -132 exact roots at 10% and 20%, so a
   // guess above the turning point returns the higher one. The same series
   // carries the guess arities of IRR_BY, XIRR and XIRR_BY.
@@ -210,6 +215,12 @@ export const formulaFinancialCases: CoverageCase[] = [
     ],
     expected: 10,
     tolerance: 1e-9,
+    zones: TIMEZONES,
+  },
+  {
+    covers: 'XIRR/2',
+    source: 'XIRR([-1, 3, -2.5], ["2020-01-01", "2021-01-01", "2022-01-01"])',
+    throws: /#NUM!/,
     zones: TIMEZONES,
   },
   {
@@ -349,6 +360,15 @@ export const formulaFinancialCases: CoverageCase[] = [
     expected: 182.5,
     zones: TIMEZONES,
   },
+  // Basis 1 is actual/actual, the one convention that measures a real calendar
+  // span: settlement falls in the period from 2010-11-15 to 2011-05-15, which
+  // is 181 days long.
+  {
+    covers: 'COUPDAYS/4',
+    source: 'COUPDAYS("2011-01-25", "2011-11-15", 2, 1)',
+    expected: 181,
+    zones: TIMEZONES,
+  },
   {
     covers: 'DISC/4',
     source: 'DISC("2023-01-01", "2023-07-01", 97.5, 100)',
@@ -382,6 +402,26 @@ export const formulaFinancialCases: CoverageCase[] = [
     source: 'TBILLEQ("2023-01-01", "2023-04-01", 0.04)',
     expected: 14.6 / 356.4,
     tolerance: 1e-9,
+    zones: TIMEZONES,
+  },
+  // A Treasury bill is short-dated by definition, so a maturity more than a
+  // year out is an error rather than an extrapolation.
+  {
+    covers: 'TBILLEQ/3',
+    source: 'TBILLEQ("2023-01-01", "2024-04-01", 0.04)',
+    throws: /#NUM!/,
+    zones: TIMEZONES,
+  },
+  {
+    covers: 'TBILLPRICE/3',
+    source: 'TBILLPRICE("2023-01-01", "2024-04-01", 0.04)',
+    throws: /#NUM!/,
+    zones: TIMEZONES,
+  },
+  {
+    covers: 'TBILLYIELD/3',
+    source: 'TBILLYIELD("2023-01-01", "2024-04-01", 98)',
+    throws: /#NUM!/,
     zones: TIMEZONES,
   },
   {

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-financial.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-financial.ts
@@ -369,6 +369,17 @@ export const formulaFinancialCases: CoverageCase[] = [
     expected: 181,
     zones: TIMEZONES,
   },
+  // A maturity on the last day of the month keeps the schedule on month ends:
+  // the coupon dates behind 2026-08-31 are 2026-02-28 and 2025-08-31, so
+  // settlement sits in a 181-day period. Measuring each date from the one
+  // before it would carry February's clamp forward to an August 28th and
+  // report 184.
+  {
+    covers: 'COUPDAYS/4',
+    source: 'COUPDAYS("2025-09-01", "2026-08-31", 2, 1)',
+    expected: 181,
+    zones: TIMEZONES,
+  },
   {
     covers: 'DISC/4',
     source: 'DISC("2023-01-01", "2023-07-01", 97.5, 100)',

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-financial.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-financial.ts
@@ -168,6 +168,24 @@ export const formulaFinancialCases: CoverageCase[] = [
   // iteration still ends somewhere, which is why the result is checked
   // against the series rather than taken on trust.
   { covers: 'IRR/1', source: 'IRR([-1, 3, -2.5])', throws: /#NUM!/ },
+  // A rate near -100% is a root the residual cannot show: dividing by a
+  // 1 + rate of a millionth multiplies rounding by the same factor, so the net
+  // present value at the exact root is a millionth rather than zero. What marks
+  // it is the crossing. 0.001 discounted at -99.9999% is exactly 1000.
+  {
+    covers: 'IRR/1',
+    source: 'IRR([-1000, 0.001])',
+    expected: -0.999999,
+    tolerance: 1e-9,
+  },
+  // A double root touches zero without crossing it, so this one is carried by
+  // the residual instead: 230 and -132.25 put both roots at 15%.
+  {
+    covers: 'IRR/1',
+    source: 'IRR([-100, 230, -132.25])',
+    expected: 0.15,
+    tolerance: 1e-6,
+  },
   // Two sign changes give -100, +230, -132 exact roots at 10% and 20%, so a
   // guess above the turning point returns the higher one. The same series
   // carries the guess arities of IRR_BY, XIRR and XIRR_BY.
@@ -378,6 +396,36 @@ export const formulaFinancialCases: CoverageCase[] = [
     covers: 'COUPDAYS/4',
     source: 'COUPDAYS("2025-09-01", "2026-08-31", 2, 1)',
     expected: 181,
+    zones: TIMEZONES,
+  },
+  // A maturity on the last day of a short month keeps the schedule on month
+  // ends too: the coupon date behind 2026-02-28 is 2025-08-31, not the 28th, so
+  // the period holding settlement is 181 days rather than 184.
+  {
+    covers: 'COUPDAYS/4',
+    source: 'COUPDAYS("2026-01-15", "2026-02-28", 2, 1)',
+    expected: 181,
+    zones: TIMEZONES,
+  },
+  {
+    covers: 'COUPDAYS/4',
+    source: 'COUPDAYS("2027-11-15", "2028-02-29", 2, 1)',
+    expected: 182,
+    zones: TIMEZONES,
+  },
+  // The dates are checked whatever the basis, even where the answer does not
+  // read them, so one argument list cannot be an error under one convention and
+  // an answer under another.
+  {
+    covers: 'COUPDAYS/4',
+    source: 'COUPDAYS("2024-01-01", "2023-01-01", 2, 0)',
+    throws: /#NUM!/,
+    zones: TIMEZONES,
+  },
+  {
+    covers: 'COUPDAYS/4',
+    source: 'COUPDAYS("2023-01-15", "2024-01-01", 2, 5)',
+    throws: /#NUM!/,
     zones: TIMEZONES,
   },
   {

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-logic.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-logic.ts
@@ -109,19 +109,12 @@ export const formulaLogicCases: CoverageCase[] = [
     covers: 'ISEVEN/1',
     source: 'ISEVEN(-2.5)',
     expected: true,
-    knownDefect:
-      'Math.floor instead of truncation toward zero, so every negative ' +
-      'non-integer is inverted. truncValue in the same module already ' +
-      'implements Excel truncation correctly',
-    produces: { expected: false },
   },
   { covers: 'ISODD/1', source: 'ISODD(3.5)', expected: true },
   {
     covers: 'ISODD/1',
     source: 'ISODD(-2.5)',
     expected: false,
-    knownDefect: 'floors instead of truncating, as for ISEVEN/1',
-    produces: { expected: true },
   },
   { covers: 'ISLOGICAL/1', source: 'ISLOGICAL(FALSE())', expected: true },
   // Numeric text is still text, never a number.

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-logic.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-logic.ts
@@ -24,6 +24,17 @@ export const formulaLogicCases: CoverageCase[] = [
     input: { nickname: 'Ada' },
     expected: false,
   },
+  // A condition is read with jq truthiness, not Excel's: only null and false
+  // are false, so the number 0 takes the true branch where Excel takes the
+  // false one. The compiled-scalar copy of IF reads truthiness the same way.
+  // The blank call in the branch that is not taken is what keeps this program
+  // off the fast path and on the builtin this case covers.
+  {
+    covers: 'IF/3',
+    source: 'IF(.count, "some", ISBLANK(.count))',
+    input: { count: 0 },
+    expected: 'some',
+  },
   // One grading ladder per IFS arity, each won by a different band.
   {
     covers: 'IFS/4',

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-statistical.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-statistical.ts
@@ -330,6 +330,15 @@ export const formulaStatisticalCases: CoverageCase[] = [
     expected: 0.9816843611112658,
     tolerance: 1e-9,
   },
+  // The density needs its own case with shape and scale far apart: at 2 and 1
+  // the cumulative form alone would pass with the two transposed. Microsoft
+  // documents WEIBULL.DIST(105, 20, 100, FALSE) as 0.035589.
+  {
+    covers: 'WEIBULL_DIST/4',
+    source: 'WEIBULL_DIST(105, 20, 100, false)',
+    expected: 0.03558886402450434,
+    tolerance: 1e-12,
+  },
   // One-tailed upper-tail test against the hypothesized mean. With x equal
   // to the sample mean, z = 0 and p is exactly 1/2; giving sigma = 2 with
   // n = 4 and a mean one unit above x makes z = 1, the upper normal tail.

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-statistical.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-statistical.ts
@@ -311,22 +311,24 @@ export const formulaStatisticalCases: CoverageCase[] = [
     expected: 0.16794970566215628,
     tolerance: 1e-9,
   },
+  // Unequal sizes and unequal variances, which is where the choice of test
+  // shows: this is Excel's T.TEST(...; 2; 3), the two-tailed unequal-variance
+  // form, whose degrees of freedom are Welch–Satterthwaite's 2.05 rather than
+  // the pooled 5. Pooling them would give 0.0159 instead.
+  {
+    covers: 'T_TEST/2',
+    source: 'T_TEST([1, 2, 3, 4], [10, 20, 30])',
+    expected: 0.0919893089522017,
+    tolerance: 1e-9,
+  },
   // Excel's WEIBULL.DIST(x, alpha, beta, ...) takes alpha as the shape and
   // beta as the scale: CDF = 1 - exp(-(x/beta)^alpha), so 1 - exp(-4) here.
-  // This case fails: the bridge hands alpha and beta to jstat in its
-  // (scale, shape) order, transposing the two.
+  // Transposing the two would give 1 - exp(-1) instead.
   {
     covers: 'WEIBULL_DIST/4',
     source: 'WEIBULL_DIST(2, 2, 1, true)',
     expected: 0.9816843611112658,
     tolerance: 1e-9,
-    knownDefect:
-      "alpha and beta reach jstat transposed — jstat's signature is " +
-      '(x, scale, shape) but the call passes (x, alpha, beta), and Excel ' +
-      'makes alpha the shape. The returned 1 - e^-1 is the transposed ' +
-      'evaluation. On realistic parameters it saturates to 0 or 1 rather ' +
-      'than merely being off',
-    produces: { expected: 0.6321205588285577, tolerance: 1e-15 },
   },
   // One-tailed upper-tail test against the hypothesized mean. With x equal
   // to the sample mean, z = 0 and p is exactly 1/2; giving sigma = 2 with

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-text.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-text.ts
@@ -5,6 +5,9 @@ export const formulaTextCases: CoverageCase[] = [
   // while UNICODE reads a whole code point — an astral character is two
   // UTF-16 units long but reports the code point, not the lead surrogate.
   { covers: 'CHAR/1', source: 'CHAR(65)', expected: 'A' },
+  // 255 is the top of that byte, so anything above it is out of range rather
+  // than the Unicode code point of the same number.
+  { covers: 'CHAR/1', source: 'CHAR(256)', throws: /#VALUE!/ },
   { covers: 'CODE/1', source: 'CODE("A")', expected: 65 },
   { covers: 'UNICODE/1', source: 'UNICODE(.)', input: '😀', expected: 128512 },
   {
@@ -31,10 +34,6 @@ export const formulaTextCases: CoverageCase[] = [
     covers: 'PROPER/1',
     source: 'PROPER("2-way street")',
     expected: '2-Way Street',
-    knownDefect:
-      'the /\\w\\S*/g tokenizer treats "2-way" as one word and uppercases ' +
-      'only its first character, so letters after a non-letter stay lower',
-    produces: { expected: '2-way Street' },
   },
   // TRIM collapses runs of spaces between words as well as stripping the
   // ends, which a plain JavaScript trim does not do.
@@ -50,10 +49,6 @@ export const formulaTextCases: CoverageCase[] = [
     source: 'TRIM(.)',
     input: 'Acme\u00a0Legal',
     expected: 'Acme\u00a0Legal',
-    knownDefect:
-      'the implementation collapses /\\s+/, whose character class includes ' +
-      'U+00A0 as well as tabs and newlines that Excel leaves for CLEAN',
-    produces: { expected: 'Acme Legal' },
   },
   { covers: 'LEN/1', source: 'LEN("Phoenix, AZ")', expected: 11 },
   { covers: 'REPT/2', source: 'REPT("*-", 3)', expected: '*-*-*-' },
@@ -83,12 +78,14 @@ export const formulaTextCases: CoverageCase[] = [
     covers: 'SEARCH/2',
     source: 'SEARCH("Mc*n", "Miriam McGovern")',
     expected: 8,
-    knownDefect:
-      'SEARCH is a lowercased indexOf, so only the case-insensitivity half ' +
-      'of the FIND/SEARCH distinction exists; wildcards match literally and ' +
-      'this raises #VALUE!. SEARCH/3 shares the code path',
-    produces: { throws: /#VALUE!/ },
   },
+  // `?` stands for exactly one character, and `~` makes a wildcard literal.
+  {
+    covers: 'SEARCH/3',
+    source: 'SEARCH("M?G", "Miriam McGovern", 3)',
+    expected: 8,
+  },
+  { covers: 'SEARCH/2', source: 'SEARCH("~*", "3 * 4")', expected: 3 },
   { covers: 'EXACT/2', source: 'EXACT("Word", "word")', expected: false },
   // Substitution. SUBSTITUTE matches text, REPLACE matches a position span,
   // and REPLACE's new text comes last, after the start and length.
@@ -108,11 +105,6 @@ export const formulaTextCases: CoverageCase[] = [
     covers: 'SUBSTITUTE/4',
     source: 'SUBSTITUTE("a-a-a", "a", "b", 1)',
     expected: 'b-a-a',
-    knownDefect:
-      'replaceNth searches from index + 1 starting at index 0, so a match at ' +
-      'position 0 is never counted and every instance number shifts by one ' +
-      'whenever the string opens with old_text',
-    produces: { expected: 'a-b-a' },
   },
   {
     covers: 'REPLACE/4',
@@ -149,11 +141,22 @@ export const formulaTextCases: CoverageCase[] = [
     source: 'TEXT(DATE(2026, 4, 30), "yyyy-mm-dd")',
     expected: '2026-04-30',
     zones: TIMEZONES,
-    knownDefect:
-      'only numeric format codes are implemented; a date code falls through ' +
-      'and TEXT returns the bare serial as a string ("46142"), so a card ' +
-      'formatting a date this way shows a five-digit number',
-    produces: { expected: '46142' },
+  },
+  // Month and weekday names come from the run length: three letters abbreviate,
+  // four or more spell it out.
+  {
+    covers: 'TEXT/2',
+    source: 'TEXT(DATE(2026, 4, 30), "dddd d mmm yy")',
+    expected: 'Thursday 30 Apr 26',
+    zones: TIMEZONES,
+  },
+  // `mm` is minutes next to an hour or a second, and months anywhere else, so
+  // one format code carries both readings.
+  {
+    covers: 'TEXT/2',
+    source: 'TEXT(DATE(2026, 4, 30) + TIME(14, 5, 9), "mm/dd h:mm:ss AM/PM")',
+    expected: '04/30 2:05:09 PM',
+    zones: TIMEZONES,
   },
   { covers: 'FIXED/1', source: 'FIXED(1234.567)', expected: '1,234.57' },
   // Negative decimals round to the left of the point.
@@ -171,10 +174,13 @@ export const formulaTextCases: CoverageCase[] = [
     covers: 'NUMBERVALUE/1',
     source: 'NUMBERVALUE("3.5%")',
     expected: 0.035,
-    knownDefect:
-      'only separators are stripped before Number(), so a percent sign — and ' +
-      'likewise the embedded spaces Excel ignores — yields NaN and #VALUE!',
-    produces: { throws: /#VALUE!/ },
+  },
+  // Percent signs stack, and spaces are ignored wherever they fall.
+  { covers: 'NUMBERVALUE/1', source: 'NUMBERVALUE("9%%")', expected: 0.0009 },
+  {
+    covers: 'NUMBERVALUE/1',
+    source: 'NUMBERVALUE(" 3 500 ")',
+    expected: 3500,
   },
   {
     covers: 'NUMBERVALUE/2',

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-text.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-text.ts
@@ -89,6 +89,14 @@ export const formulaTextCases: CoverageCase[] = [
   // A start position past the end of the text is an error, even for a pattern
   // that can match nothing.
   { covers: 'SEARCH/3', source: 'SEARCH("*", "abc", 5)', throws: /#VALUE!/ },
+  // Stars are matched by walking the text once, not by a backtracking regex, so
+  // a pattern full of them answers in linear time instead of exponential.
+  {
+    covers: 'SEARCH/2',
+    source:
+      'SEARCH("*a*a*a*a*a*a*a*a*b", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")',
+    throws: /#VALUE!/,
+  },
   { covers: 'EXACT/2', source: 'EXACT("Word", "word")', expected: false },
   // Substitution. SUBSTITUTE matches text, REPLACE matches a position span,
   // and REPLACE's new text comes last, after the start and length.
@@ -108,6 +116,13 @@ export const formulaTextCases: CoverageCase[] = [
     covers: 'SUBSTITUTE/4',
     source: 'SUBSTITUTE("a-a-a", "a", "b", 1)',
     expected: 'b-a-a',
+  },
+  // Occurrences do not overlap: "aaa" holds one "aa", not two, so there is no
+  // second instance to replace and the text comes back whole.
+  {
+    covers: 'SUBSTITUTE/4',
+    source: 'SUBSTITUTE("aaa", "aa", "X", 2)',
+    expected: 'aaa',
   },
   {
     covers: 'REPLACE/4',
@@ -166,6 +181,62 @@ export const formulaTextCases: CoverageCase[] = [
     covers: 'TEXT/2',
     source: 'TEXT(DATE(2026, 4, 30) + TIME(14, 5, 9), "mm/dd h:mm:ss AM/PM")',
     expected: '04/30 2:05:09 PM',
+    zones: TIMEZONES,
+  },
+  // Minutes only where the clock puts them — after an hour, or before seconds.
+  // A month run that merely precedes an hour is still a month.
+  {
+    covers: 'TEXT/2',
+    source: 'TEXT(DATE(2026, 4, 30) + TIME(14, 5, 9), "d mmm h:mm")',
+    expected: '30 Apr 14:05',
+    zones: TIMEZONES,
+  },
+  {
+    covers: 'TEXT/2',
+    source: 'TEXT(DATE(2026, 4, 30) + TIME(14, 5, 9), "mm hh")',
+    expected: '04 14',
+    zones: TIMEZONES,
+  },
+  // A bracketed run is a colour, a condition or a locale, so a `d` inside one
+  // does not make a number format a date format.
+  {
+    covers: 'TEXT/2',
+    source: 'TEXT(1234.5, "[Red]#,##0.0")',
+    expected: '1,234.5',
+  },
+  {
+    covers: 'TEXT/2',
+    source: 'TEXT(DATE(2026, 4, 30), "[$-409]yyyy-mm-dd")',
+    expected: '2026-04-30',
+    zones: TIMEZONES,
+  },
+  // The bracketed clock codes are the exception: they ask for elapsed time, so
+  // a day and a half is 36 hours and the minutes beside them are the clock's.
+  {
+    covers: 'TEXT/2',
+    source: 'TEXT(1.5, "[h]:mm")',
+    expected: '36:00',
+    zones: TIMEZONES,
+  },
+  {
+    covers: 'TEXT/2',
+    source: 'TEXT(1.5, "[mm]")',
+    expected: '2160',
+    zones: TIMEZONES,
+  },
+  // A time of day below the 1970 epoch reads the same as one above it: the
+  // serial is a fraction that lands a hair under the second it names, and
+  // truncating it would drop that second on one side of the epoch only.
+  {
+    covers: 'TEXT/2',
+    source: 'TEXT(TIME(12, 30, 0), "hh:mm:ss")',
+    expected: '12:30:00',
+    zones: TIMEZONES,
+  },
+  {
+    covers: 'TEXT/2',
+    source: 'TEXT(DATE(2023, 1, 1) + TIME(12, 30, 0), "hh:mm:ss")',
+    expected: '12:30:00',
     zones: TIMEZONES,
   },
   { covers: 'FIXED/1', source: 'FIXED(1234.567)', expected: '1,234.57' },

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-text.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-text.ts
@@ -86,6 +86,9 @@ export const formulaTextCases: CoverageCase[] = [
     expected: 8,
   },
   { covers: 'SEARCH/2', source: 'SEARCH("~*", "3 * 4")', expected: 3 },
+  // A start position past the end of the text is an error, even for a pattern
+  // that can match nothing.
+  { covers: 'SEARCH/3', source: 'SEARCH("*", "abc", 5)', throws: /#VALUE!/ },
   { covers: 'EXACT/2', source: 'EXACT("Word", "word")', expected: false },
   // Substitution. SUBSTITUTE matches text, REPLACE matches a position span,
   // and REPLACE's new text comes last, after the start and length.
@@ -148,6 +151,13 @@ export const formulaTextCases: CoverageCase[] = [
     covers: 'TEXT/2',
     source: 'TEXT(DATE(2026, 4, 30), "dddd d mmm yy")',
     expected: 'Thursday 30 Apr 26',
+    zones: TIMEZONES,
+  },
+  // Five m's is the single-letter month, one more than the full name.
+  {
+    covers: 'TEXT/2',
+    source: 'TEXT(DATE(2026, 4, 30), "mmmmm")',
+    expected: 'A',
     zones: TIMEZONES,
   },
   // `mm` is minutes next to an hour or a second, and months anywhere else, so

--- a/packages/bxl/tests/unit/fixtures/function-coverage/validation.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/validation.ts
@@ -44,8 +44,10 @@ export const validationCases: CoverageCase[] = [
     source: 'isLength("😀😀", {min: 3})',
     expected: false,
   },
-  // isByteLength with no options leaves its minimum unset, so no string can
-  // satisfy it; the non-string guard is the only assertion it supports.
+  // Upstream validator.js reads the minimum as `arguments[1]` with no `|| 0`
+  // fallback, so the one-argument form compares a length against `undefined`
+  // and no string can satisfy it. The bridge is faithful to that, which leaves
+  // the non-string guard as the only assertion this arity supports.
   { covers: 'isByteLength/1', source: 'isByteLength(42)', expected: false },
   // Byte length counts UTF-8 bytes: "héllo" is five characters, six bytes.
   {

--- a/packages/bxl/tests/unit/linter-cli.ts
+++ b/packages/bxl/tests/unit/linter-cli.ts
@@ -187,4 +187,23 @@ for (const lowerJq of [
   );
 }
 
+// Excel's positional INDEX shadows jq's two-argument object-building INDEX, so
+// only that call shape is flagged. One argument is jq's own index-of and three
+// is Excel's row-and-column lookup, neither of which collides with anything.
+for (const [expression, expected] of [
+  ['INDEX(.rows; .id)', true],
+  ['index(.rows; .id)', true],
+  ['INDEX(.names, 2)', false],
+  ['INDEX(.names, 2, 1)', false],
+  ['index("na")', false],
+  ['INDEX("na")', false],
+] as [string, boolean][]) {
+  const result = lintBxlExpression(expression);
+  strictEqual(
+    result.issues.some((issue) => issue.code === 'jq-index-shadowed-by-excel'),
+    expected,
+    `${expression} ${expected ? 'must' : 'must NOT'} report the shadowed INDEX`,
+  );
+}
+
 console.log('BXL linter: edge-case diagnostics passed');

--- a/packages/bxl/tests/unit/number-literal-cli.ts
+++ b/packages/bxl/tests/unit/number-literal-cli.ts
@@ -1,0 +1,67 @@
+// Numeric literals, asserted through both syntaxes.
+//
+// Readable syntax and canonical jq tokenize numbers separately, so every form
+// is checked twice: a literal accepted by one and not the other would break
+// authored expressions only after compilation, where it is hardest to read.
+// Scientific notation matters most — it is the only form whose tokenization
+// can collide with an identifier, since `e` is a letter.
+import { ok, strictEqual, throws } from 'node:assert';
+import { evaluateBxl } from '../../src/index.ts';
+
+interface LiteralCase {
+  /** Program, written so that it means the same thing in both syntaxes. */
+  source: string;
+  expected: unknown;
+}
+
+const cases: LiteralCase[] = [
+  { source: '1', expected: 1 },
+  { source: '1.5', expected: 1.5 },
+  { source: '1e3', expected: 1000 },
+  { source: '1E3', expected: 1000 },
+  { source: '1e-3', expected: 0.001 },
+  { source: '2e+3', expected: 2000 },
+  { source: '1.5e2', expected: 150 },
+  { source: '1.5E-2', expected: 0.015 },
+  // The smallest positive double is subnormal and has no decimal spelling
+  // short enough to write, so an exponent is the only way to name it.
+  { source: '5e-324', expected: 5e-324 },
+  // An exponent binds tighter than any operator around it.
+  { source: '1e3 + 1', expected: 1001 },
+  { source: '2 * 1e2', expected: 200 },
+];
+
+let checks = 0;
+for (const { source, expected } of cases) {
+  for (const readableSyntax of [true, false]) {
+    const { value } = evaluateBxl(source, null, { readableSyntax });
+    strictEqual(
+      value,
+      expected,
+      `${source} under ${readableSyntax ? 'readable' : 'jq'} syntax`,
+    );
+    checks++;
+  }
+}
+
+// An `e` with no digits after it is not an exponent, so the tokenizer leaves
+// it to be read as a name — which is what makes `1e` a failure rather than a
+// literal that quietly evaluates to NaN.
+for (const readableSyntax of [true, false]) {
+  throws(
+    () => evaluateBxl('1e', null, { readableSyntax }),
+    /Cannot index number with string/,
+    `1e is not a number under ${readableSyntax ? 'readable' : 'jq'} syntax`,
+  );
+  checks++;
+}
+
+// A name may open with the exponent letter without being read as one.
+const named = evaluateBxl('.e5 + .e', { e5: 2, e: 3 }, {
+  readableSyntax: false,
+});
+strictEqual(named.value, 5, 'a field name starting with e survives');
+checks++;
+
+ok(checks > 0);
+console.log(`BXL number literals: ${checks} checks passed`);

--- a/packages/bxl/tests/unit/number-literal-cli.ts
+++ b/packages/bxl/tests/unit/number-literal-cli.ts
@@ -57,9 +57,13 @@ for (const readableSyntax of [true, false]) {
 }
 
 // A name may open with the exponent letter without being read as one.
-const named = evaluateBxl('.e5 + .e', { e5: 2, e: 3 }, {
-  readableSyntax: false,
-});
+const named = evaluateBxl(
+  '.e5 + .e',
+  { e5: 2, e: 3 },
+  {
+    readableSyntax: false,
+  },
+);
 strictEqual(named.value, 5, 'a field name starting with e survives');
 checks++;
 

--- a/packages/bxl/tests/unit/wildcard-matching-cli.ts
+++ b/packages/bxl/tests/unit/wildcard-matching-cli.ts
@@ -1,0 +1,115 @@
+// Excel wildcard matching: what it answers, and how long it may take.
+//
+// The cost is part of the contract here, not a nicety. Compiling `*` to a
+// regex's `.*` makes a pattern carrying several stars explore exponentially
+// many ways to split the text, which turns a formula over an ordinary text
+// field into a hang — in an indexing worker, or on the browser's main thread.
+// A value assertion cannot catch that: the suite would stop rather than fail.
+// So the patterns below are the exponential shapes, and they are given a
+// deadline.
+import { ok, strictEqual } from 'node:assert';
+import {
+  excelWildcardMatchesWhole,
+  excelWildcardSearch,
+} from '../../src/formulajs/wildcard.ts';
+
+let checks = 0;
+
+// Where the pattern first matches, zero-based, or -1. SEARCH reports this + 1.
+const searchCases: [string, string, number][] = [
+  ['b', 'abc', 1],
+  ['B', 'abc', 1],
+  ['b', 'xyz', -1],
+  ['Mc*n', 'Miriam McGovern', 7],
+  ['M?G', 'Miriam McGovern', 7],
+  ['*', 'abc', 0],
+  ['', 'abc', 0],
+  ['*b', 'ab', 0],
+  ['a*', 'ab', 0],
+  ['a*c', 'abc', 0],
+  ['a*c', 'ac', 0],
+  ['~*', '3 * 4', 2],
+  ['~?', 'a?b', 1],
+  ['~~', 'a~b', 1],
+  // Regex metacharacters are literal text to a wildcard pattern.
+  ['[a]', 'x[a]y', 1],
+  ['.', 'a.b', 1],
+  ['a+', 'xa+y', 1],
+  ['(b)', 'a(b)c', 1],
+  // `?` spans any one character, newlines included.
+  ['a?b', 'a\nb', 0],
+  ['a*b', 'a\n\nb', 0],
+];
+for (const [pattern, text, expected] of searchCases) {
+  strictEqual(
+    excelWildcardSearch(pattern, text),
+    expected,
+    `search ${JSON.stringify(pattern)} in ${JSON.stringify(text)}`,
+  );
+  checks++;
+}
+
+// A criteria match is anchored at both ends instead.
+const wholeCases: [string, string, boolean][] = [
+  ['abc', 'abc', true],
+  ['abc', 'abcd', false],
+  ['ABC', 'abc', true],
+  ['a?c', 'abc', true],
+  ['a?c', 'ac', false],
+  ['a*', 'ab', true],
+  ['*b', 'ab', true],
+  ['*', '', true],
+  ['*', 'anything', true],
+  ['a*c', 'ac', true],
+  ['a*c', 'abbbc', true],
+  ['a*c', 'abbb', false],
+  ['*b*', 'abc', true],
+  ['~*', '*', true],
+  ['~*', 'x', false],
+  ['a*a*a', 'aaa', true],
+  ['a*a*a', 'aa', false],
+];
+for (const [pattern, text, expected] of wholeCases) {
+  strictEqual(
+    excelWildcardMatchesWhole(pattern, text),
+    expected,
+    `whole ${JSON.stringify(pattern)} against ${JSON.stringify(text)}`,
+  );
+  checks++;
+}
+
+// Every pattern here is one a backtracking engine takes exponential time on.
+// The text is deliberately the worst case: nothing but the character the
+// literal runs are made of, so every star has somewhere to go.
+const BUDGET_MS = 1000;
+const haystack = 'a'.repeat(400);
+const pathological = [
+  '********z',
+  '**********z',
+  '*a*a*a*a*a*a*a*a*a*a*a*ab',
+  '*a*a*a*a*b',
+  'a*a*a*a*a*a*a*a*a*a*a*a*z',
+  '?*?*?*?*?*?*?*?*z',
+];
+const started = process.hrtime.bigint();
+for (const pattern of pathological) {
+  strictEqual(
+    excelWildcardSearch(pattern, haystack),
+    -1,
+    `${pattern} cannot match a text with no z`,
+  );
+  strictEqual(
+    excelWildcardMatchesWhole(pattern, haystack),
+    false,
+    `${pattern} cannot match the whole of a text with no z`,
+  );
+  checks += 2;
+}
+const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+ok(
+  elapsedMs < BUDGET_MS,
+  `${pathological.length} star-heavy patterns over ${haystack.length} characters took ${elapsedMs.toFixed(1)}ms, over the ${BUDGET_MS}ms budget — matching has gone superlinear again`,
+);
+checks++;
+
+console.log(`BXL wildcard matching: ${checks} checks passed`);


### PR DESCRIPTION
Stacked on #5791 — review that one first; this branch's diff against it is the second commit onward.

The function-coverage matrix in #5791 wrote a case for every `NAME/arity` the BXL registry exposes, and twenty of them turned out to assert an answer the function does not give. Each was left holding a `knownDefect` note: the case asserts the correct value — Excel's, jq's, or validator.js's — and the suite inverts it, so the case must keep failing while the defect stands and reports itself the moment it starts passing.

This PR fixes the functions, so those twenty cases are now ordinary assertions and the suite reports `0 known defect(s)`. New cases cover what the fixes made reachable: return types that used to fall through, wildcards, exponents, the tie-break in `max_by`, a coupon period measured in real days.

## What each function does now

**jq builtins.** A named group carries its name onto the match, which is the root `capture`, `sub` and `gsub` all read from — patching `capture` alone would have left `match` wrong — and an optional group that did not participate reports jq's absent-capture triple instead of crashing on a missing index. `round` ties away from zero, so `-2.5` is `-3` as in C, jq and Excel. `isinfinite` excludes NaN, which takes `isfinite` with it, since that one is defined in jq source as `type == "number" and (isinfinite | not)`. `lgamma_r` returns the `[ln |Γ(x)|, sign]` pair it exists to report, the sign following from the parity of `⌊x⌋`. `scalars_or_empty` keeps the empty array and empty object that are the whole of what separates it from `scalars`. `max_by` breaks ties on the last maximum where `min_by` keeps the first — jq's asymmetry, now asserted in both directions. `inputs` yields the empty stream a runtime with no inputs has, rather than letting the unimplemented `input`'s error escape the `catch` in jq's definition.

**Numeric literals take an exponent.** `1e3`, `1E-3` and `5e-324` are single numbers in both readable and canonical-jq syntax; the tokenizer used to end the literal at the first digit and read `e3` as an index. The exponent is taken only when a digit follows it, so a name that opens with `e` is still a name. `docs/grammar.ebnf` grows the production and a new suite asserts every form through both syntaxes.

**Excel functions.** `PROPER` capitalizes any letter following a non-letter (`2-way` → `2-Way`). `TRIM` is defined over the ASCII space alone, leaving tabs, newlines and U+00A0 to `CLEAN` and `SUBSTITUTE`. `SEARCH` reads `find_text` as a wildcard pattern, which is the other half of what separates it from `FIND`. `SUBSTITUTE`'s instance number counts a match at position 0. `TEXT` renders date and time format codes instead of returning the bare serial as a string, with `mm` reading as minutes beside an hour or second and as months elsewhere. `NUMBERVALUE` ignores spaces anywhere in its text and divides by 100 per trailing percent sign. `CHAR` is bounded to its byte. `ISEVEN`/`ISODD` truncate toward zero. `WEEKDAY` and `WEEKNUM` honour every return type, including the 11–17 ladder that walks the start of the week forward, and reject the rest with `#NUM!` rather than silently falling through to the default. `ISOWEEKNUM` and `WEEKNUM(…, 21)` number from the week holding the year's first Thursday, so an early-January date reports the previous ISO year's 52nd or 53rd week; they share one implementation now, since they name one rule. `TIMEVALUE` reads a trailing meridiem. The hex emitters answer in upper case. `COMPLEX` writes the `-i` its own parser already reads. `ERF`/`ERFC` come from the regularized incomplete gamma function at full double precision, with `ERFC` computed as the upper tail so the far tail keeps its digits (`ERFC(6)` is 2.15e-17, not zero). `WEIBULL_DIST` takes alpha as the shape and beta as the scale, as Excel does — Microsoft's documented example now returns its documented 0.929581 rather than saturating to 1. `IRR`, `IRR_BY` and `XIRR` report `#NUM!` when the search never brings the net present value to zero; the residual is judged against the size of the cash flows, so a series in millions is not held to an absolute tenth of a nanodollar. The `TBILL` family rejects a maturity more than a year past settlement. `COUPDAYS` measures the real coupon period containing settlement under basis 1, actual/actual.

## Judgment calls

**`T_TEST/2` pairs Welch with Welch.** It computed an unequal-variance standard error and evaluated it against pooled degrees of freedom, matching neither Excel variant. It now uses Welch–Satterthwaite — Excel's two-tailed type 3. The standard error it already computed is the Welch one, so this corrects the degrees of freedom rather than rewriting the statistic; equal variance is the assumption most easily violated without notice in card data, which is why R's `t.test` defaults the same way; and two-tailed is the conservative reading of a signature with no way to say otherwise.

**Excel's `INDEX` keeps the name, and the collision stops being silent.** jq has an `INDEX` of its own — `INDEX(stream; key_expr)` builds an object keyed by an expression — and Excel's positional `INDEX` shadows it at the same arity, which also makes jq's `INDEX/1` unreachable since it delegates. Excel wins: spreadsheet authors are this surface's audience and the formula library loads by default for cards. What was wrong is that an author writing the jq idiom got `Cannot index array with string` with nothing pointing at the cause. The linter now reports `jq-index-shadowed-by-excel` on a one-argument `INDEX` or a semicolon-separated two-argument one, and the syntax reference says what to write instead.

**`DAYS360` is left alone.** Its US/NASD method implements the day-31 rule but not the last-day-of-February rule Microsoft documents. Excel's own shipped behavior is known to diverge from that doc text, so matching the text would mean diverging from Excel.

**`TBILLEQ` keeps the single formula.** Microsoft documents `(365 × rate) / (360 − rate × DSM)` with no branch past 182 days, and Excel compatibility is the contract here even where the bond-equivalent convention differs.

**`isByteLength/1` is upstream's bug, not ours.** validator.js reads the minimum with no fallback, so the one-argument form compares a length against `undefined` and no string can satisfy it; its sibling `isLength` has the fallback. The bridge is faithful, and the syntax reference now tells authors to pass the options.

## Second implementations and shadowed names

`IF` and `IFS` are implemented twice — once in the formula library's jq source, once in the compiled-scalar fast path, which answers any formula that compiles wholly to scalars and so is the live copy for simple formulas. Registry-enumerated coverage cannot see the fast-path copy, so the two have to be kept in step by hand; each site now names the other. Both read a condition with jq truthiness, under which the number `0` takes the true branch where Excel takes the false one — undocumented before, now stated in both places, in the syntax reference, and pinned by a case.

The `builtins/0` entry in `builtinNativeFilters.ts` was a second copy of the public-name computation that `resolveRegistry` unconditionally overwrites, since the list depends on which libraries resolved. The duplicate logic is gone; the declaration stays, because it is what puts `builtins/0` into its own output.

Both `UPSTREAM-DIFFS.md` files record the corrected behavior. The jq one also stops describing `atan2/2` backwards — it takes POSIX `(y; x)`, and `atan2/2` and `ATAN2/2` are two separate live entries rather than one case-folded signature — and now documents the sentinels `get_search_list`, `get_jq_origin` and `get_prog_origin` return, and that `builtins` sorts where jq's order is unspecified.

## Testing

`pnpm test` in `packages/bxl`: 67/67 suites, coverage at 814 of 815 exposed functions across 898 cases with 0 known defects. `pnpm lint` clean in `packages/bxl`, and `pnpm lint:types` clean in `packages/host`, which consumes the package. Values were checked against Microsoft's documented examples where they exist and against the real `jq 1.7` binary for the jq-side changes.
