### PR TITLE
host: Move the `interact-submode` tests to shared realm cache

### DIFF
--- a/packages/host/tests/acceptance/file-chooser-test.gts
+++ b/packages/host/tests/acceptance/file-chooser-test.gts
@@ -20,7 +20,6 @@ import { setupInteractSubmodeTests } from '../helpers/interact-submode-setup';
 
 module('Acceptance | file chooser tests', function (hooks) {
   setupInteractSubmodeTests(hooks, {
-    reuseIndexAcrossTests: 'fileChooser',
     setRealm() {},
   });
 
@@ -489,7 +488,6 @@ module('Acceptance | file chooser tests', function (hooks) {
 
 module('Acceptance | file chooser keyboard tests', function (hooks) {
   setupInteractSubmodeTests(hooks, {
-    reuseIndexAcrossTests: 'fileChooserKeyboard',
     setRealm() {},
   });
 
@@ -1061,7 +1059,6 @@ module('Acceptance | file chooser tests | upload size limit', function (hooks) {
   let AUDIO_SIZE_LIMIT = 4096;
 
   setupInteractSubmodeTests(hooks, {
-    reuseIndexAcrossTests: 'fileChooserUploadSizeLimit',
     setRealm() {},
     fileSizeLimitBytes: FILE_SIZE_LIMIT,
     audioSizeLimitBytes: AUDIO_SIZE_LIMIT,

--- a/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
@@ -20,6 +20,7 @@ import { claimsFromRawToken } from '@cardstack/host/services/realm';
 import { RecentCards } from '@cardstack/host/utils/local-storage-keys';
 
 import {
+  setupRealmCacheTeardown,
   assertMessages,
   percySnapshot,
   testRealmURL,
@@ -39,12 +40,15 @@ module(
     let { setRealmPermissions, setActiveRealms } = setupInteractSubmodeTests(
       hooks,
       {
-        reuseIndexAcrossTests: 'interactCreationAndPermissions',
         setRealm() {},
       },
     );
 
-    module('1 stack creation flows', function () {
+    module('1 stack creation flows', function (hooks) {
+      // The helper's realm-building beforeEach runs for these tests too, and
+      // caches under this module's name, which the outer prefix cannot match.
+      setupRealmCacheTeardown(hooks);
+
       test<TestContextWithSave>('can create a card from the index stack item', async function (assert) {
         assert.expect(7);
         await visitOperatorMode({
@@ -424,6 +428,10 @@ module(
     });
 
     module('1 stack, when the user lacks write permissions', function (hooks) {
+      // The helper's realm-building beforeEach runs for these tests too, and
+      // caches under this module's name, which the outer prefix cannot match.
+      setupRealmCacheTeardown(hooks);
+
       hooks.beforeEach(async function () {
         setRealmPermissions({
           [testRealmURL]: ['read'],
@@ -684,6 +692,10 @@ module(
     });
 
     module('2 stacks with differing permissions', function (hooks) {
+      // The helper's realm-building beforeEach runs for these tests too, and
+      // caches under this module's name, which the outer prefix cannot match.
+      setupRealmCacheTeardown(hooks);
+
       hooks.beforeEach(async function () {
         setRealmPermissions({
           [testRealmURL]: ['read'],
@@ -823,7 +835,11 @@ module(
       });
     });
 
-    module('workspace index card', function () {
+    module('workspace index card', function (hooks) {
+      // The helper's realm-building beforeEach runs for these tests too, and
+      // caches under this module's name, which the outer prefix cannot match.
+      setupRealmCacheTeardown(hooks);
+
       test('cannot be deleted', async function (assert) {
         await visitOperatorMode({
           stacks: [

--- a/packages/host/tests/acceptance/interact-submode/index-changes-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/index-changes-test.gts
@@ -10,7 +10,11 @@ import {
 } from '@cardstack/runtime-common';
 import type { Realm } from '@cardstack/runtime-common/realm';
 
-import { testRealmURL, visitOperatorMode } from '../../helpers';
+import {
+  setupRealmCacheTeardown,
+  testRealmURL,
+  visitOperatorMode,
+} from '../../helpers';
 import { setupInteractSubmodeTests } from '../../helpers/interact-submode-setup';
 
 import type {
@@ -22,13 +26,16 @@ module('Acceptance | interact submode | index changes tests', function (hooks) {
   let realm: Realm;
 
   setupInteractSubmodeTests(hooks, {
-    reuseIndexAcrossTests: 'interactIndexChanges',
     setRealm(value) {
       realm = value;
     },
   });
 
-  module('index changes', function () {
+  module('index changes', function (hooks) {
+    // The helper's realm-building beforeEach runs for these tests too, and
+    // caches under this module's name, which the outer prefix cannot match.
+    setupRealmCacheTeardown(hooks);
+
     test('stack item live updates when index changes', async function (assert) {
       await visitOperatorMode({
         stacks: [
@@ -427,7 +434,11 @@ module('Acceptance | interact submode | index changes tests', function (hooks) {
     });
   });
 
-  module('size limit errors', function () {
+  module('size limit errors', function (hooks) {
+    // The helper's realm-building beforeEach runs for these tests too, and
+    // caches under this module's name, which the outer prefix cannot match.
+    setupRealmCacheTeardown(hooks);
+
     test('edit view shows size limit error when save exceeds limit', async function (assert) {
       let environmentService = getService('environment-service') as any;
       let originalMaxSize = environmentService.cardSizeLimitBytes;

--- a/packages/host/tests/acceptance/interact-submode/multiple-stacks-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/multiple-stacks-test.gts
@@ -4,6 +4,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
+  setupRealmCacheTeardown,
   percySnapshot,
   testModuleRealm,
   testRealmURL,
@@ -19,11 +20,14 @@ module(
   'Acceptance | interact submode | multiple stacks tests',
   function (hooks) {
     let { setActiveRealms } = setupInteractSubmodeTests(hooks, {
-      reuseIndexAcrossTests: 'interactMultipleStacks',
       setRealm() {},
     });
 
-    module('2 stacks', function () {
+    module('2 stacks', function (hooks) {
+      // The helper's realm-building beforeEach runs for these tests too, and
+      // caches under this module's name, which the outer prefix cannot match.
+      setupRealmCacheTeardown(hooks);
+
       test('restoring the stacks from query param', async function (assert) {
         await visitOperatorMode({
           stacks: [
@@ -254,7 +258,11 @@ module(
       });
     });
 
-    module('expand to full width', function () {
+    module('expand to full width', function (hooks) {
+      // The helper's realm-building beforeEach runs for these tests too, and
+      // caches under this module's name, which the outer prefix cannot match.
+      setupRealmCacheTeardown(hooks);
+
       test('expanding a card in a two-stack layout hides the other stack', async function (assert) {
         let fadhlanId = `${testRealmURL}Person/fadhlan`;
         let mangoId = `${testRealmURL}Pet/mango`;

--- a/packages/host/tests/acceptance/interact-submode/no-stacks-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/no-stacks-test.gts
@@ -2,16 +2,23 @@ import { click, fillIn } from '@ember/test-helpers';
 
 import { module, test } from 'qunit';
 
-import { testRealmURL, visitOperatorMode } from '../../helpers';
+import {
+  setupRealmCacheTeardown,
+  testRealmURL,
+  visitOperatorMode,
+} from '../../helpers';
 import { setupInteractSubmodeTests } from '../../helpers/interact-submode-setup';
 
 module('Acceptance | interact submode | no stacks tests', function (hooks) {
   setupInteractSubmodeTests(hooks, {
-    reuseIndexAcrossTests: 'interactNoStacks',
     setRealm() {},
   });
 
-  module('0 stacks', function () {
+  module('0 stacks', function (hooks) {
+    // The helper's realm-building beforeEach runs for these tests too, and
+    // caches under this module's name, which the outer prefix cannot match.
+    setupRealmCacheTeardown(hooks);
+
     test('Clicking card in search panel opens card on a new stack', async function (assert) {
       await visitOperatorMode({});
 

--- a/packages/host/tests/acceptance/interact-submode/search-sheet-persistence-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/search-sheet-persistence-test.gts
@@ -12,18 +12,25 @@ import { module, test } from 'qunit';
 
 import { rri } from '@cardstack/runtime-common';
 
-import { testRealmURL, visitOperatorMode } from '../../helpers';
+import {
+  setupRealmCacheTeardown,
+  testRealmURL,
+  visitOperatorMode,
+} from '../../helpers';
 import { setupInteractSubmodeTests } from '../../helpers/interact-submode-setup';
 
 module(
   'Acceptance | interact submode | search sheet persistence tests',
   function (hooks) {
     setupInteractSubmodeTests(hooks, {
-      reuseIndexAcrossTests: 'interactSearchSheetPersistence',
       setRealm() {},
     });
 
-    module('search sheet persistence', function () {
+    module('search sheet persistence', function (hooks) {
+      // The helper's realm-building beforeEach runs for these tests too, and
+      // caches under this module's name, which the outer prefix cannot match.
+      setupRealmCacheTeardown(hooks);
+
       test('restores the query, view, and results after a close/reopen', async function (assert) {
         await visitOperatorMode({});
 

--- a/packages/host/tests/acceptance/interact-submode/single-stack-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/single-stack-test.gts
@@ -15,6 +15,7 @@ import { Deferred } from '@cardstack/runtime-common';
 import type { Realm } from '@cardstack/runtime-common/realm';
 
 import {
+  setupRealmCacheTeardown,
   percySnapshot,
   testRealmURL,
   visitOperatorMode,
@@ -29,13 +30,16 @@ module('Acceptance | interact submode | single stack tests', function (hooks) {
   let realm: Realm;
 
   setupInteractSubmodeTests(hooks, {
-    reuseIndexAcrossTests: 'interactSingleStack',
     setRealm(value) {
       realm = value;
     },
   });
 
-  module('1 stack', function (_hooks) {
+  module('1 stack', function (hooks) {
+    // The helper's realm-building beforeEach runs for these tests too, and
+    // caches under this module's name, which the outer prefix cannot match.
+    setupRealmCacheTeardown(hooks);
+
     test('restoring the stack from query param', async function (assert) {
       await visitOperatorMode({
         stacks: [

--- a/packages/host/tests/helpers/interact-submode-setup.gts
+++ b/packages/host/tests/helpers/interact-submode-setup.gts
@@ -8,7 +8,8 @@ import type { Realm } from '@cardstack/runtime-common/realm';
 
 import {
   SYSTEM_CARD_FIXTURE_CONTENTS,
-  captureReusableIndex,
+  withCachedRealmSetup,
+  setupRealmCacheTeardown,
   makeMinimalPng,
   setupAcceptanceTestRealm,
   setupAuthEndpoints,
@@ -30,14 +31,6 @@ type InteractSubmodeSetupOptions = {
   fileSizeLimitBytes?: number;
   audioSizeLimitBytes?: number;
   videoSizeLimitBytes?: number;
-  // Index these four realms once for the module and restore that index before
-  // each subsequent test, instead of re-indexing all four per test. Pass a name
-  // unique to the module (matching /^[A-Za-z][A-Za-z0-9_]*$/) — the fixtures are
-  // identical across the modules sharing this helper, but a snapshot alias can
-  // only be exported once, so each module keeps its own.
-  //
-  // Omit it and the module indexes per test as before.
-  reuseIndexAcrossTests?: string;
 };
 
 export function setupInteractSubmodeTests(
@@ -47,17 +40,15 @@ export function setupInteractSubmodeTests(
     fileSizeLimitBytes,
     audioSizeLimitBytes,
     videoSizeLimitBytes,
-    reuseIndexAcrossTests,
   }: InteractSubmodeSetupOptions,
 ) {
   setupApplicationTest(hooks);
-  // This helper builds four realms, so the default capture point — as soon as
-  // the first one finishes indexing — would omit the other three. It captures
-  // explicitly below instead, once all four are built.
-  setupLocalIndexing(hooks, {
-    reuseIndexAcrossTests,
-    captureIndexManually: true,
-  });
+  setupLocalIndexing(hooks);
+  // Registers for the scope this helper is called from. A consumer whose tests
+  // live in nested modules registers its own too: the delete prefix is fixed at
+  // registration from the module name, and a nested test's snapshot is keyed by
+  // its own composed name.
+  setupRealmCacheTeardown(hooks);
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
@@ -344,234 +335,236 @@ export function setupInteractSubmodeTests(
     let mangoPet = new Pet({ name: 'Mango' });
 
     let realm: Realm;
-    ({ realm } = await setupAcceptanceTestRealm({
-      mockMatrixUtils,
-      fileSizeLimitBytes,
-      audioSizeLimitBytes,
-      videoSizeLimitBytes,
-      contents: {
-        ...SYSTEM_CARD_FIXTURE_CONTENTS,
-        'address.gts': { Address },
-        'focus-test.gts': { FocusTest },
-        'focus-nested.gts': { FocusNested, FocusNestedItem },
-        'file-link-card.gts': { FileLinkCard },
-        'image-link-card.gts': { ImageLinkCard },
-        'person.gts': { Person },
-        'personnel.gts': { Personnel },
-        'pet.gts': { Pet, Puppy },
-        'shipping-info.gts': { ShippingInfo },
-        'README.txt': `Hello World`,
-        'test-image.png': makeMinimalPng(),
-        'FileLinkCard/notes.txt': 'Hello from a file link',
-        'person-entry.json': new Spec({
-          cardTitle: 'Person Card',
-          cardDescription: 'Spec for Person Card',
-          specType: 'card',
-          ref: {
-            module: `${testRealmURL}person`,
-            name: 'Person',
-          },
-        }),
-        'pet-entry.json': new Spec({
-          cardTitle: 'Pet Card',
-          cardDescription: 'Spec for Pet Card',
-          specType: 'card',
-          ref: {
-            module: `${testRealmURL}pet`,
-            name: 'Pet',
-          },
-        }),
-        ...catalogEntries,
-        'puppy-entry.json': new Spec({
-          cardTitle: 'Puppy Card',
-          cardDescription: 'Spec for Puppy Card',
-          specType: 'card',
-          ref: {
-            module: `${testRealmURL}pet`,
-            name: 'Puppy',
-          },
-        }),
-        'Pet/mango.json': mangoPet,
-        'Pet/vangogh.json': new Pet({ name: 'Van Gogh' }),
-        'FocusTest/1.json': new FocusTest({ names: [] }),
-        'FocusNested/1.json': new FocusNested({
-          items: [
-            new FocusNestedItem({ label: 'Plain', pets: [] }),
-            new FocusNestedItem({ label: 'With Pet', pets: [mangoPet] }),
-          ],
-        }),
-        'Person/fadhlan.json': new Person({
-          firstName: 'Fadhlan',
-          address: new Address({
-            city: 'Bandung',
-            country: 'Indonesia',
-            shippingInfo: new ShippingInfo({
-              preferredCarrier: 'DHL',
-              remarks: `Don't let bob deliver the package--he's always bringing it to the wrong address`,
-            }),
+    // The four realms are the same for every test in a module using this
+    // helper, so the indexed result is cached and restored rather than rebuilt.
+    // One block covers all four: the snapshot is taken after the callback
+    // resolves, so it cannot omit a realm the way a hand-placed capture could.
+    await withCachedRealmSetup(async () => {
+      ({ realm } = await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        fileSizeLimitBytes,
+        audioSizeLimitBytes,
+        videoSizeLimitBytes,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'address.gts': { Address },
+          'focus-test.gts': { FocusTest },
+          'focus-nested.gts': { FocusNested, FocusNestedItem },
+          'file-link-card.gts': { FileLinkCard },
+          'image-link-card.gts': { ImageLinkCard },
+          'person.gts': { Person },
+          'personnel.gts': { Personnel },
+          'pet.gts': { Pet, Puppy },
+          'shipping-info.gts': { ShippingInfo },
+          'README.txt': `Hello World`,
+          'test-image.png': makeMinimalPng(),
+          'FileLinkCard/notes.txt': 'Hello from a file link',
+          'person-entry.json': new Spec({
+            cardTitle: 'Person Card',
+            cardDescription: 'Spec for Person Card',
+            specType: 'card',
+            ref: {
+              module: `${testRealmURL}person`,
+              name: 'Person',
+            },
           }),
-          additionalAddresses: [
-            new Address({
-              city: 'Jakarta',
+          'pet-entry.json': new Spec({
+            cardTitle: 'Pet Card',
+            cardDescription: 'Spec for Pet Card',
+            specType: 'card',
+            ref: {
+              module: `${testRealmURL}pet`,
+              name: 'Pet',
+            },
+          }),
+          ...catalogEntries,
+          'puppy-entry.json': new Spec({
+            cardTitle: 'Puppy Card',
+            cardDescription: 'Spec for Puppy Card',
+            specType: 'card',
+            ref: {
+              module: `${testRealmURL}pet`,
+              name: 'Puppy',
+            },
+          }),
+          'Pet/mango.json': mangoPet,
+          'Pet/vangogh.json': new Pet({ name: 'Van Gogh' }),
+          'FocusTest/1.json': new FocusTest({ names: [] }),
+          'FocusNested/1.json': new FocusNested({
+            items: [
+              new FocusNestedItem({ label: 'Plain', pets: [] }),
+              new FocusNestedItem({ label: 'With Pet', pets: [mangoPet] }),
+            ],
+          }),
+          'Person/fadhlan.json': new Person({
+            firstName: 'Fadhlan',
+            address: new Address({
+              city: 'Bandung',
               country: 'Indonesia',
-              shippingInfo: new ShippingInfo({
-                preferredCarrier: 'FedEx',
-                remarks: `Make sure to deliver to the back door`,
-              }),
-            }),
-            new Address({
-              city: 'Bali',
-              country: 'Indonesia',
-              shippingInfo: new ShippingInfo({
-                preferredCarrier: 'UPS',
-                remarks: `Call ahead to make sure someone is home`,
-              }),
-            }),
-          ],
-          pet: mangoPet,
-          friends: [mangoPet],
-        }),
-        'FileLinkCard/empty.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              title: 'Empty linked file',
-            },
-            relationships: {
-              attachment: {
-                links: { self: null },
-                data: null,
-              },
-            },
-            meta: {
-              adoptsFrom: {
-                module: '../file-link-card',
-                name: 'FileLinkCard',
-              },
-            },
-          },
-        },
-        'FileLinkCard/with-file.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              title: 'Linked file example',
-            },
-            relationships: {
-              attachment: {
-                links: {
-                  self: './notes.txt',
-                },
-                data: {
-                  type: 'file-meta',
-                  id: './notes.txt',
-                },
-              },
-            },
-            meta: {
-              adoptsFrom: {
-                module: '../file-link-card',
-                name: 'FileLinkCard',
-              },
-            },
-          },
-        },
-        'ImageLinkCard/empty.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              title: 'Empty image link',
-            },
-            relationships: {
-              photo: {
-                links: { self: null },
-                data: null,
-              },
-            },
-            meta: {
-              adoptsFrom: {
-                module: '../image-link-card',
-                name: 'ImageLinkCard',
-              },
-            },
-          },
-        },
-        'Puppy/marco.json': new Puppy({ name: 'Marco', age: '5 months' }),
-        'grid.json': new CardsGrid(),
-        'index.json': new CardsGrid(),
-        'realm.json': realmConfigCardJSON({
-          name: 'Test Workspace B',
-          backgroundURL:
-            'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
-          iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
-        }),
-      },
-    }));
-
-    await setupAcceptanceTestRealm({
-      mockMatrixUtils,
-      realmURL: testRealm2URL,
-      contents: {
-        ...SYSTEM_CARD_FIXTURE_CONTENTS,
-        'index.json': new CardsGrid(),
-        'realm.json': realmConfigCardJSON({
-          name: 'Test Workspace A',
-          backgroundURL:
-            'https://i.postimg.cc/tgRHRV8C/pawel-czerwinski-h-Nrd99q5pe-I-unsplash.jpg',
-          iconURL: 'https://boxel-images.boxel.ai/icons/cardstack.png',
-        }),
-        'Pet/ringo.json': new Pet({ name: 'Ringo' }),
-        'Person/hassan.json': new Person({
-          firstName: 'Hassan',
-          pet: mangoPet,
-          additionalAddresses: [
-            new Address({
-              city: 'New York',
-              country: 'USA',
               shippingInfo: new ShippingInfo({
                 preferredCarrier: 'DHL',
                 remarks: `Don't let bob deliver the package--he's always bringing it to the wrong address`,
               }),
             }),
-          ],
-          friends: [mangoPet],
-        }),
-      },
-    });
+            additionalAddresses: [
+              new Address({
+                city: 'Jakarta',
+                country: 'Indonesia',
+                shippingInfo: new ShippingInfo({
+                  preferredCarrier: 'FedEx',
+                  remarks: `Make sure to deliver to the back door`,
+                }),
+              }),
+              new Address({
+                city: 'Bali',
+                country: 'Indonesia',
+                shippingInfo: new ShippingInfo({
+                  preferredCarrier: 'UPS',
+                  remarks: `Call ahead to make sure someone is home`,
+                }),
+              }),
+            ],
+            pet: mangoPet,
+            friends: [mangoPet],
+          }),
+          'FileLinkCard/empty.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                title: 'Empty linked file',
+              },
+              relationships: {
+                attachment: {
+                  links: { self: null },
+                  data: null,
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: '../file-link-card',
+                  name: 'FileLinkCard',
+                },
+              },
+            },
+          },
+          'FileLinkCard/with-file.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                title: 'Linked file example',
+              },
+              relationships: {
+                attachment: {
+                  links: {
+                    self: './notes.txt',
+                  },
+                  data: {
+                    type: 'file-meta',
+                    id: './notes.txt',
+                  },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: '../file-link-card',
+                  name: 'FileLinkCard',
+                },
+              },
+            },
+          },
+          'ImageLinkCard/empty.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                title: 'Empty image link',
+              },
+              relationships: {
+                photo: {
+                  links: { self: null },
+                  data: null,
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: '../image-link-card',
+                  name: 'ImageLinkCard',
+                },
+              },
+            },
+          },
+          'Puppy/marco.json': new Puppy({ name: 'Marco', age: '5 months' }),
+          'grid.json': new CardsGrid(),
+          'index.json': new CardsGrid(),
+          'realm.json': realmConfigCardJSON({
+            name: 'Test Workspace B',
+            backgroundURL:
+              'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+            iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+          }),
+        },
+      }));
 
-    await setupAcceptanceTestRealm({
-      mockMatrixUtils,
-      realmURL: testRealm3URL,
-      contents: {
-        ...SYSTEM_CARD_FIXTURE_CONTENTS,
-        'index.json': new CardsGrid(),
-        'realm.json': realmConfigCardJSON({
-          name: 'Test Workspace C',
-          backgroundURL:
-            'https://boxel-images.boxel.ai/background-images/4k-powder-puff.jpg',
-          iconURL: 'https://boxel-images.boxel.ai/icons/cardstack.png',
-        }),
-      },
-    });
+      await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealm2URL,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'index.json': new CardsGrid(),
+          'realm.json': realmConfigCardJSON({
+            name: 'Test Workspace A',
+            backgroundURL:
+              'https://i.postimg.cc/tgRHRV8C/pawel-czerwinski-h-Nrd99q5pe-I-unsplash.jpg',
+            iconURL: 'https://boxel-images.boxel.ai/icons/cardstack.png',
+          }),
+          'Pet/ringo.json': new Pet({ name: 'Ringo' }),
+          'Person/hassan.json': new Person({
+            firstName: 'Hassan',
+            pet: mangoPet,
+            additionalAddresses: [
+              new Address({
+                city: 'New York',
+                country: 'USA',
+                shippingInfo: new ShippingInfo({
+                  preferredCarrier: 'DHL',
+                  remarks: `Don't let bob deliver the package--he's always bringing it to the wrong address`,
+                }),
+              }),
+            ],
+            friends: [mangoPet],
+          }),
+        },
+      });
 
-    await setupAcceptanceTestRealm({
-      mockMatrixUtils,
-      realmURL: personalRealmURL,
-      contents: {
-        ...SYSTEM_CARD_FIXTURE_CONTENTS,
-        'index.json': new CardsGrid(),
-        'realm.json': realmConfigCardJSON({
-          name: 'Test Personal Workspace',
-          backgroundURL:
-            'https://boxel-images.boxel.ai/background-images/4k-origami-flock.jpg',
-          iconURL: 'https://boxel-images.boxel.ai/icons/cardstack.png',
-        }),
-      },
-    });
+      await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealm3URL,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'index.json': new CardsGrid(),
+          'realm.json': realmConfigCardJSON({
+            name: 'Test Workspace C',
+            backgroundURL:
+              'https://boxel-images.boxel.ai/background-images/4k-powder-puff.jpg',
+            iconURL: 'https://boxel-images.boxel.ai/icons/cardstack.png',
+          }),
+        },
+      });
 
-    // All four realms are built and indexed, and the test body hasn't run yet,
-    // so this is the moment the module's reusable index has to be taken.
-    await captureReusableIndex();
+      await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        realmURL: personalRealmURL,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'index.json': new CardsGrid(),
+          'realm.json': realmConfigCardJSON({
+            name: 'Test Personal Workspace',
+            backgroundURL:
+              'https://boxel-images.boxel.ai/background-images/4k-origami-flock.jpg',
+            iconURL: 'https://boxel-images.boxel.ai/icons/cardstack.png',
+          }),
+        },
+      });
+    });
 
     setRealm(realm);
   });

--- a/packages/host/tests/helpers/interact-submode-setup.gts
+++ b/packages/host/tests/helpers/interact-submode-setup.gts
@@ -334,13 +334,12 @@ export function setupInteractSubmodeTests(
 
     let mangoPet = new Pet({ name: 'Mango' });
 
-    let realm: Realm;
     // The four realms are the same for every test in a module using this
     // helper, so the indexed result is cached and restored rather than rebuilt.
     // One block covers all four: the snapshot is taken after the callback
     // resolves, so it cannot omit a realm the way a hand-placed capture could.
-    await withCachedRealmSetup(async () => {
-      ({ realm } = await setupAcceptanceTestRealm({
+    let realm = await withCachedRealmSetup(async () => {
+      let { realm } = await setupAcceptanceTestRealm({
         mockMatrixUtils,
         fileSizeLimitBytes,
         audioSizeLimitBytes,
@@ -502,7 +501,7 @@ export function setupInteractSubmodeTests(
             iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
           }),
         },
-      }));
+      });
 
       await setupAcceptanceTestRealm({
         mockMatrixUtils,
@@ -564,6 +563,8 @@ export function setupInteractSubmodeTests(
           }),
         },
       });
+
+      return realm;
     });
 
     setRealm(realm);


### PR DESCRIPTION
This continues the removal of `reuseIndexAcrossTests` in favour of `withCachedRealmSetup`.