### PR TITLE
Serve realm files with Content-Length and HTTP byte-range support

### DIFF
--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -252,6 +252,9 @@ export class NodeAdapter implements RealmAdapter {
         return lazyStream;
       },
       lastModified: unixTime(stat.mtime.getTime()),
+      size: stat.size,
+      createRangeStream: (start: number, end: number) =>
+        createReadStream(absolutePath, { start, end }),
     };
   }
 

--- a/packages/realm-server/tests/http-range-test.ts
+++ b/packages/realm-server/tests/http-range-test.ts
@@ -1,0 +1,112 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import { resolveRangeHeader } from '@cardstack/runtime-common';
+
+module(basename(import.meta.filename), function () {
+  test('no header resolves to the full representation', function (assert) {
+    assert.deepEqual(resolveRangeHeader(null, 100), { kind: 'full' });
+    assert.deepEqual(resolveRangeHeader(undefined, 100), { kind: 'full' });
+    assert.deepEqual(resolveRangeHeader('', 100), { kind: 'full' });
+  });
+
+  test('a bounded range resolves to its inclusive offsets', function (assert) {
+    assert.deepEqual(resolveRangeHeader('bytes=0-0', 100), {
+      kind: 'range',
+      start: 0,
+      end: 0,
+    });
+    assert.deepEqual(resolveRangeHeader('bytes=2-5', 100), {
+      kind: 'range',
+      start: 2,
+      end: 5,
+    });
+    assert.deepEqual(
+      resolveRangeHeader(' bytes=2-5 ', 100),
+      { kind: 'range', start: 2, end: 5 },
+      'surrounding whitespace is tolerated',
+    );
+  });
+
+  test('an open-ended range runs through the final byte', function (assert) {
+    assert.deepEqual(resolveRangeHeader('bytes=90-', 100), {
+      kind: 'range',
+      start: 90,
+      end: 99,
+    });
+    assert.deepEqual(resolveRangeHeader('bytes=0-', 100), {
+      kind: 'range',
+      start: 0,
+      end: 99,
+    });
+  });
+
+  test('a last-byte position past the end is clamped', function (assert) {
+    assert.deepEqual(resolveRangeHeader('bytes=90-1000', 100), {
+      kind: 'range',
+      start: 90,
+      end: 99,
+    });
+  });
+
+  test('a suffix range selects the final N bytes', function (assert) {
+    assert.deepEqual(resolveRangeHeader('bytes=-10', 100), {
+      kind: 'range',
+      start: 90,
+      end: 99,
+    });
+    assert.deepEqual(
+      resolveRangeHeader('bytes=-1000', 100),
+      { kind: 'range', start: 0, end: 99 },
+      'a suffix longer than the representation selects all of it',
+    );
+  });
+
+  test('ranges that select no bytes are unsatisfiable', function (assert) {
+    assert.deepEqual(resolveRangeHeader('bytes=100-', 100), {
+      kind: 'unsatisfiable',
+    });
+    assert.deepEqual(resolveRangeHeader('bytes=100-200', 100), {
+      kind: 'unsatisfiable',
+    });
+    assert.deepEqual(
+      resolveRangeHeader('bytes=-0', 100),
+      { kind: 'unsatisfiable' },
+      'a zero-length suffix selects nothing',
+    );
+    assert.deepEqual(
+      resolveRangeHeader('bytes=0-', 0),
+      { kind: 'unsatisfiable' },
+      'an empty representation has no bytes to select',
+    );
+    assert.deepEqual(resolveRangeHeader('bytes=-5', 0), {
+      kind: 'unsatisfiable',
+    });
+  });
+
+  test('anything but a well-formed single bytes range resolves to full', function (assert) {
+    assert.deepEqual(
+      resolveRangeHeader('bytes=0-1,4-5', 100),
+      { kind: 'full' },
+      'multi-range requests are answered with the full representation',
+    );
+    assert.deepEqual(
+      resolveRangeHeader('items=0-5', 100),
+      { kind: 'full' },
+      'non-bytes units are ignored',
+    );
+    assert.deepEqual(
+      resolveRangeHeader('bytes=5-2', 100),
+      { kind: 'full' },
+      'an inverted range is malformed',
+    );
+    assert.deepEqual(
+      resolveRangeHeader('bytes=-', 100),
+      { kind: 'full' },
+      'a range with no offsets is malformed',
+    );
+    assert.deepEqual(resolveRangeHeader('bytes=abc-def', 100), {
+      kind: 'full',
+    });
+  });
+});

--- a/packages/realm-server/tests/range-request-test.ts
+++ b/packages/realm-server/tests/range-request-test.ts
@@ -1,0 +1,227 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import {
+  setupPermissionedRealmCached,
+  withRealmPath,
+  type RealmRequest,
+} from './helpers/index.ts';
+
+// Byte-range serving of raw realm files (RFC 9110 §14): browsers will not
+// treat media as seekable — Safari refuses playback outright, Chromium
+// reports duration: Infinity for size-derived formats like PCM WAV — unless
+// file responses carry Content-Length, advertise Accept-Ranges, and honor
+// single byte ranges with a 206.
+module(basename(import.meta.filename), function () {
+  module('Realm-specific Endpoints | Range requests', function (hooks) {
+    let realmURL = new URL('http://127.0.0.1:4444/test/');
+    let request: RealmRequest;
+
+    setupPermissionedRealmCached(hooks, {
+      fixture: 'simple',
+      realmURL,
+      permissions: {
+        '*': ['read', 'write'],
+        '@node-test_realm:localhost': ['read', 'realm-owner'],
+      },
+      onRealmSetup: (args) => {
+        request = withRealmPath(args.request, realmURL);
+      },
+    });
+
+    const bytes = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+    // Collect the raw bytes rather than letting supertest pick a text/JSON
+    // parser from the content type — these assertions are about exact byte
+    // slices.
+    function binaryParser(
+      res: unknown,
+      callback: (err: Error | null, body: Buffer) => void,
+    ) {
+      let stream = res as NodeJS.ReadableStream;
+      let chunks: Buffer[] = [];
+      stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+      stream.on('end', () => callback(null, Buffer.concat(chunks)));
+    }
+
+    async function uploadSample(path: string) {
+      let response = await request
+        .post(path)
+        .set('Content-Type', 'application/octet-stream')
+        .send(Buffer.from(bytes));
+      QUnit.assert.strictEqual(response.status, 204, 'sample file uploaded');
+    }
+
+    function getSample(path: string) {
+      return request
+        .get(path)
+        .set('Accept', 'image/*')
+        .buffer(true)
+        .parse(binaryParser);
+    }
+
+    test('a full GET advertises range support and carries Content-Length', async function (assert) {
+      await uploadSample('/full.png');
+      let response = await getSample('/full.png');
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.strictEqual(
+        response.headers['accept-ranges'],
+        'bytes',
+        'Accept-Ranges advertises byte-range support',
+      );
+      assert.strictEqual(
+        response.headers['content-length'],
+        String(bytes.length),
+        'Content-Length reports the full file size',
+      );
+      assert.deepEqual(
+        new Uint8Array(response.body),
+        bytes,
+        'full body round-trips',
+      );
+    });
+
+    test('a bounded range returns a 206 with just those bytes', async function (assert) {
+      await uploadSample('/bounded.png');
+      let response = await getSample('/bounded.png').set('Range', 'bytes=2-5');
+
+      assert.strictEqual(response.status, 206, 'HTTP 206 status');
+      assert.strictEqual(
+        response.headers['content-range'],
+        `bytes 2-5/${bytes.length}`,
+        'Content-Range reports the slice and the total',
+      );
+      assert.strictEqual(
+        response.headers['content-length'],
+        '4',
+        'Content-Length matches the slice',
+      );
+      assert.deepEqual(
+        new Uint8Array(response.body),
+        new Uint8Array([2, 3, 4, 5]),
+        'body is exactly the requested bytes',
+      );
+    });
+
+    test('an open-ended range runs through the final byte', async function (assert) {
+      await uploadSample('/open-ended.png');
+      let response = await getSample('/open-ended.png').set(
+        'Range',
+        'bytes=6-',
+      );
+
+      assert.strictEqual(response.status, 206, 'HTTP 206 status');
+      assert.strictEqual(
+        response.headers['content-range'],
+        `bytes 6-9/${bytes.length}`,
+      );
+      assert.deepEqual(
+        new Uint8Array(response.body),
+        new Uint8Array([6, 7, 8, 9]),
+      );
+    });
+
+    test('a suffix range selects the final N bytes', async function (assert) {
+      await uploadSample('/suffix.png');
+      let response = await getSample('/suffix.png').set('Range', 'bytes=-3');
+
+      assert.strictEqual(response.status, 206, 'HTTP 206 status');
+      assert.strictEqual(
+        response.headers['content-range'],
+        `bytes 7-9/${bytes.length}`,
+      );
+      assert.deepEqual(
+        new Uint8Array(response.body),
+        new Uint8Array([7, 8, 9]),
+      );
+    });
+
+    test('a last-byte position past the end is clamped', async function (assert) {
+      await uploadSample('/clamped.png');
+      let response = await getSample('/clamped.png').set(
+        'Range',
+        'bytes=8-999',
+      );
+
+      assert.strictEqual(response.status, 206, 'HTTP 206 status');
+      assert.strictEqual(
+        response.headers['content-range'],
+        `bytes 8-9/${bytes.length}`,
+      );
+      assert.deepEqual(new Uint8Array(response.body), new Uint8Array([8, 9]));
+    });
+
+    test('a range past the end of the file is unsatisfiable', async function (assert) {
+      await uploadSample('/unsatisfiable.png');
+      let response = await getSample('/unsatisfiable.png').set(
+        'Range',
+        'bytes=10-',
+      );
+
+      assert.strictEqual(response.status, 416, 'HTTP 416 status');
+      assert.strictEqual(
+        response.headers['content-range'],
+        `bytes */${bytes.length}`,
+        'Content-Range reports the total size for the client to retry with',
+      );
+    });
+
+    test('a multi-range request is answered with the full representation', async function (assert) {
+      await uploadSample('/multi.png');
+      let response = await getSample('/multi.png').set(
+        'Range',
+        'bytes=0-1,4-5',
+      );
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.deepEqual(
+        new Uint8Array(response.body),
+        bytes,
+        'full body is served',
+      );
+    });
+
+    test('If-Range with a stale validator falls back to the full body', async function (assert) {
+      await uploadSample('/if-range.png');
+      let response = await getSample('/if-range.png')
+        .set('Range', 'bytes=2-5')
+        .set('If-Range', '"some-other-etag"');
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.deepEqual(
+        new Uint8Array(response.body),
+        bytes,
+        'the client’s offsets referred to a different representation, so the full body is served',
+      );
+    });
+
+    test('If-Range with the current ETag still yields the 206', async function (assert) {
+      await uploadSample('/if-range-match.png');
+      let etag = (await getSample('/if-range-match.png')).headers['etag'];
+      assert.ok(etag, 'file response carries an ETag');
+
+      let response = await getSample('/if-range-match.png')
+        .set('Range', 'bytes=2-5')
+        .set('If-Range', etag);
+
+      assert.strictEqual(response.status, 206, 'HTTP 206 status');
+      assert.deepEqual(
+        new Uint8Array(response.body),
+        new Uint8Array([2, 3, 4, 5]),
+      );
+    });
+
+    test('If-None-Match takes precedence over Range', async function (assert) {
+      await uploadSample('/revalidate.png');
+      let etag = (await getSample('/revalidate.png')).headers['etag'];
+      assert.ok(etag, 'file response carries an ETag');
+
+      let response = await getSample('/revalidate.png')
+        .set('Range', 'bytes=2-5')
+        .set('If-None-Match', etag);
+
+      assert.strictEqual(response.status, 304, 'HTTP 304 status');
+    });
+  });
+});

--- a/packages/runtime-common/http-range.ts
+++ b/packages/runtime-common/http-range.ts
@@ -1,0 +1,64 @@
+// Resolution of an HTTP `Range` request header (RFC 9110 §14) against a body
+// whose total byte size is known. Only single `bytes=` ranges resolve to a
+// slice: a server is permitted to ignore any Range it chooses not to satisfy
+// by answering with the full 200 representation, and multi-range responses
+// (multipart/byteranges) buy browsers nothing — media elements only ever ask
+// for one range — so everything except a well-formed single range resolves to
+// `full`.
+export type RangeResolution =
+  // Serve the complete representation as a 200: no Range header, a malformed
+  // one, a non-bytes unit, or a multi-range request.
+  | { kind: 'full' }
+  // Serve a 206 with these inclusive byte offsets.
+  | { kind: 'range'; start: number; end: number }
+  // Serve a 416: the range is syntactically valid but selects no bytes of
+  // this representation (start at or past the end, or a zero-length suffix).
+  | { kind: 'unsatisfiable' };
+
+const SINGLE_RANGE = /^bytes=(\d*)-(\d*)$/;
+
+export function resolveRangeHeader(
+  header: string | null | undefined,
+  totalSize: number,
+): RangeResolution {
+  if (!header) {
+    return { kind: 'full' };
+  }
+  let match = SINGLE_RANGE.exec(header.trim());
+  if (!match) {
+    return { kind: 'full' };
+  }
+  let [, startDigits, endDigits] = match;
+  if (startDigits === '' && endDigits === '') {
+    // "bytes=-" carries no offsets at all.
+    return { kind: 'full' };
+  }
+  if (startDigits === '') {
+    // Suffix range "bytes=-N": the final N bytes. A zero-length suffix
+    // selects nothing, which the spec defines as unsatisfiable.
+    let suffixLength = parseInt(endDigits, 10);
+    if (suffixLength === 0 || totalSize === 0) {
+      return { kind: 'unsatisfiable' };
+    }
+    return {
+      kind: 'range',
+      start: Math.max(0, totalSize - suffixLength),
+      end: totalSize - 1,
+    };
+  }
+  let start = parseInt(startDigits, 10);
+  if (start >= totalSize) {
+    return { kind: 'unsatisfiable' };
+  }
+  if (endDigits === '') {
+    // Open-ended "bytes=N-": from N through the final byte.
+    return { kind: 'range', start, end: totalSize - 1 };
+  }
+  let end = parseInt(endDigits, 10);
+  if (end < start) {
+    return { kind: 'full' };
+  }
+  // A last-byte position past the end of the representation is valid; it
+  // means "through the final byte".
+  return { kind: 'range', start, end: Math.min(end, totalSize - 1) };
+}

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1035,6 +1035,7 @@ import type { LocalPath } from './paths.ts';
 import type { CardTypeFilter, Query, EveryFilter } from './query.ts';
 import { Loader } from './loader.ts';
 export * from './frontmatter-parse.ts';
+export * from './http-range.ts';
 export * from './paths.ts';
 export * from './realm-client.ts';
 export * from './realm-operations.ts';

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1,4 +1,5 @@
 import { Deferred } from './deferred.ts';
+import { resolveRangeHeader } from './http-range.ts';
 import {
   awaitRealmIndexSettled,
   indexingConcurrencyGroup,
@@ -307,6 +308,19 @@ export interface FileRef {
   path: LocalPath;
   content: ReadableStream<Uint8Array> | Readable | Uint8Array | string;
   lastModified: number;
+  // Total byte size of `content`, when the adapter knows it without reading
+  // the bytes (e.g. from the stat it already performed). Lets streamed file
+  // responses carry a Content-Length, which browsers need before they will
+  // treat media as seekable / of known duration.
+  size?: number;
+  // Open a bounded byte range of the file, [start, end] inclusive, without
+  // materializing the rest. Present when the adapter can do this cheaply
+  // (e.g. a bounded fs read stream); together with `size` it enables HTTP
+  // Range (206) serving. Both offsets are within `size`.
+  createRangeStream?: (
+    start: number,
+    end: number,
+  ) => ReadableStream<Uint8Array> | Readable;
 
   [key: symbol]: object;
 }
@@ -4021,6 +4035,86 @@ export class Realm {
     if (createdFromDb != null) {
       headers['x-created'] = formatRFC7231(createdFromDb * 1000);
     }
+
+    // Byte size when knowable without reading the bytes. `ref.size` is
+    // consulted before `ref.content` because adapters expose `content` as a
+    // lazy getter that opens a real stream on first touch — a ranged or 416
+    // response must never pay for (and then strand) a full-file stream.
+    // String bodies are left to the HTTP layer, which measures and sets
+    // Content-Length for them itself.
+    let sliceableBytes =
+      ref.size == null && ref.content instanceof Uint8Array
+        ? ref.content
+        : undefined;
+    let totalSize = ref.size ?? sliceableBytes?.byteLength;
+    if (totalSize != null) {
+      headers['content-length'] = String(totalSize);
+    }
+    let rangeCapable =
+      totalSize != null &&
+      (sliceableBytes != null || typeof ref.createRangeStream === 'function');
+    if (rangeCapable) {
+      headers['accept-ranges'] = 'bytes';
+      let rangeHeader =
+        request.method === 'GET' ? request.headers.get('range') : null;
+      // A Range is conditional on If-Range when present: a validator that no
+      // longer matches means the client's byte offsets refer to a different
+      // representation, so the full body is the correct answer.
+      let ifRange = request.headers.get('if-range');
+      if (rangeHeader && (!ifRange || (etag && ifRange === etag))) {
+        let resolution = resolveRangeHeader(rangeHeader, totalSize!);
+        if (resolution.kind === 'unsatisfiable') {
+          return createResponse({
+            body: null,
+            init: {
+              status: 416,
+              headers: {
+                ...headers,
+                'content-range': `bytes */${totalSize}`,
+                'content-length': '0',
+              },
+            },
+            requestContext,
+          });
+        }
+        if (resolution.kind === 'range') {
+          let { start, end } = resolution;
+          let rangeHeaders = {
+            ...headers,
+            'content-range': `bytes ${start}-${end}/${totalSize}`,
+            'content-length': String(end - start + 1),
+          };
+          if (sliceableBytes) {
+            return createResponse({
+              body: sliceableBytes.subarray(start, end + 1) as BodyInit,
+              init: { status: 206, headers: rangeHeaders },
+              requestContext,
+            });
+          }
+          let rangeContent = ref.createRangeStream!(start, end);
+          if (rangeContent instanceof ReadableStream) {
+            return createResponse({
+              body: rangeContent,
+              init: { status: 206, headers: rangeHeaders },
+              requestContext,
+            });
+          }
+          if (!isNode) {
+            throw new Error(
+              `Cannot handle node stream in a non-node environment`,
+            );
+          }
+          let response = createResponse({
+            body: null,
+            init: { status: 206, headers: rangeHeaders },
+            requestContext,
+          }) as ResponseWithNodeStream;
+          response.nodeStream = rangeContent;
+          return response;
+        }
+      }
+    }
+
     if (
       ref.content instanceof ReadableStream ||
       ref.content instanceof Uint8Array ||


### PR DESCRIPTION
## What this does

Raw file responses streamed from disk carried no `Content-Length` and ignored the `Range` request header entirely — every request got a `200` with the full body and no `Accept-Ranges`. Browsers therefore treat realm-hosted media as an unseekable stream of unknown size: Safari's native player refuses playback without byte-range support, and Chromium reports `duration: Infinity` for formats whose duration derives from byte size (PCM WAV, plain MP3 without a Xing header). Container formats that embed their duration (M4A's `moov` atom) mask the gap, which is why some media appeared to work.

`serveLocalFile` now:

- emits `Content-Length` whenever the byte size is knowable without reading the body — the adapter's stat for streamed files, `byteLength` for in-memory bytes;
- advertises `Accept-Ranges: bytes` and answers a single satisfiable `bytes` range with a `206` + `Content-Range`, streamed bounded from disk (`fs.createReadStream(path, { start, end })`) rather than sliced in memory;
- answers an unsatisfiable range with a `416` carrying `Content-Range: bytes */<size>`;
- honors `If-Range`: a validator that doesn't match the current ETag means the client's offsets refer to a different representation, so the full body is served;
- keeps `If-None-Match` precedence — a `304` wins over any `Range`.

`FileRef` gains optional `size` and `createRangeStream` members, populated by the node adapter from the stat it already performs. The range paths never touch `FileRef.content`, which is a lazy getter that opens a full-file stream on first access — a `206`/`416` must not strand an unconsumed file handle. Multi-range and malformed `Range` headers are answered with the full `200` representation, which RFC 9110 permits; browsers only issue single ranges.

## Scope

Range support alone doesn't make protected-realm media play: the auth service worker rewrites media requests to `mode: 'cors'`, and `Range` isn't in the realm server's CORS allow-list, so those preflights still fail. That CORS change is a separate follow-up; this PR is the serving-path half and is fully exercisable on public realms.

## Test plan

- `packages/realm-server/tests/http-range-test.ts` — unit coverage of the range-header resolution (bounded/open-ended/suffix ranges, clamping, unsatisfiable cases, multi-range and malformed headers).
- `packages/realm-server/tests/range-request-test.ts` — integration coverage over a live realm server: `Content-Length`/`Accept-Ranges` on full GETs, exact byte slices on `206`s, `416`, `If-Range` both ways, and `If-None-Match` precedence.
- Existing file-serving suites pass locally through the card-source GET coverage (later modules in that suite hit a local test-pg disk limit unrelated to this change; CI runs them all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)