### PR TITLE
Give every FileDef subtype module a default export; name the field in thunk errors

### DIFF
--- a/packages/base/avif-image-def.gts
+++ b/packages/base/avif-image-def.gts
@@ -39,3 +39,5 @@ export class AvifDef extends RasterImageDef {
     };
   }
 }
+
+export default AvifDef;

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -4794,23 +4794,37 @@ function cardThunk<CardT extends BaseDefConstructor>(
   // value came from isn't knowable here — by the time the value reaches us
   // the import has already evaluated to undefined — so the message names the
   // two ways that happens instead.
-  fieldContext?: { fieldName: string; ownerPrototype: BaseDef },
+  fieldContext: { fieldName: string; ownerPrototype: BaseDef },
 ): () => CardT {
-  if (!cardOrThunk) {
-    let fieldDescription = fieldContext
-      ? `field '${fieldContext.fieldName}' on '${
-          fieldContext.ownerPrototype.constructor?.name ?? 'unknown card'
-        }'`
-      : 'a field';
-    throw new Error(
-      `The card class for ${fieldDescription} was ${cardOrThunk}. Two common causes:
+  // `||` rather than `??`: an anonymous class's `.name` is `''`, not nullish.
+  let fieldDescription = `field '${fieldContext.fieldName}' on '${
+    fieldContext.ownerPrototype.constructor?.name || 'unknown card'
+  }'`;
+  let causes = `Two common causes:
       (1) the import doesn't match the module's export shape — e.g. \`import X from '…'\` where the module only has a named export; use \`import { X } from '…'\`;
-      (2) a cyclic dependency between cards — use the thunk form in all cards in the cycle, e.g. '@field friend = linksTo(() => Person)'.`,
+      (2) a cyclic dependency between cards — use the thunk form in all cards in the cycle, e.g. '@field friend = linksTo(() => Person)'.`;
+  if (!cardOrThunk) {
+    throw new Error(
+      `The card class for ${fieldDescription} was ${cardOrThunk}. ${causes}`,
     );
   }
-  return (
-    'baseDef' in cardOrThunk ? () => cardOrThunk : cardOrThunk
-  ) as () => CardT;
+  if ('baseDef' in cardOrThunk) {
+    return () => cardOrThunk as CardT;
+  }
+  // The thunk form fails the same two ways the eager form does, just later —
+  // at the first `field.card` read instead of at decoration. The accessors
+  // re-invoke the thunk on every read (nothing is memoized), so this adds a
+  // truthiness check per read, not an extra call.
+  let thunk = cardOrThunk as () => CardT;
+  return () => {
+    let card = thunk();
+    if (!card) {
+      throw new Error(
+        `The card class thunk for ${fieldDescription} returned ${card}. ${causes}`,
+      );
+    }
+    return card;
+  };
 }
 
 export type SignatureFor<CardT extends BaseDefConstructor> = {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2397,10 +2397,10 @@ export function containsMany<FieldT extends FieldDefConstructor>(
   options?: Options,
 ): BaseInstanceType<FieldT>[] {
   return {
-    setupField(fieldName: string, _ownerPrototype: BaseDef) {
+    setupField(fieldName: string, ownerPrototype: BaseDef) {
       let { computeVia, searchable } = options ?? {};
       let instance = new ContainsMany({
-        cardThunk: cardThunk(field),
+        cardThunk: cardThunk(field, { fieldName, ownerPrototype }),
         computeVia,
         name: fieldName,
         searchable,
@@ -2417,10 +2417,10 @@ export function contains<FieldT extends FieldDefConstructor>(
   options?: Options,
 ): BaseInstanceType<FieldT> {
   return {
-    setupField(fieldName: string, _ownerPrototype: BaseDef) {
+    setupField(fieldName: string, ownerPrototype: BaseDef) {
       let { computeVia, searchable } = options ?? {};
       let instance = new Contains({
-        cardThunk: cardThunk(field),
+        cardThunk: cardThunk(field, { fieldName, ownerPrototype }),
         computeVia,
         name: fieldName,
         searchable,
@@ -2439,7 +2439,10 @@ export function linksTo<CardT extends LinkableDefConstructor>(
   return {
     setupField(fieldName: string, ownerPrototype: BaseDef) {
       let { computeVia, searchable, query } = options ?? {};
-      let fieldCardThunk = cardThunk(cardOrThunk);
+      let fieldCardThunk = cardThunk(cardOrThunk, {
+        fieldName,
+        ownerPrototype,
+      });
       if (query) {
         validateRelationshipQuery(ownerPrototype, fieldName, query);
       }
@@ -2465,7 +2468,10 @@ export function linksToMany<CardT extends LinkableDefConstructor>(
   return {
     setupField(fieldName: string, ownerPrototype: BaseDef) {
       let { computeVia, searchable, query } = options ?? {};
-      let fieldCardThunk = cardThunk(cardOrThunk);
+      let fieldCardThunk = cardThunk(cardOrThunk, {
+        fieldName,
+        ownerPrototype,
+      });
       if (query) {
         validateRelationshipQuery(ownerPrototype, fieldName, query);
       }
@@ -4783,12 +4789,23 @@ function notifySubscribers(
 
 function cardThunk<CardT extends BaseDefConstructor>(
   cardOrThunk: CardT | (() => CardT),
+  // Where the field lives, so the thrown error can name the exact field
+  // instead of leaving the author to bisect their schema. The module the bad
+  // value came from isn't knowable here — by the time the value reaches us
+  // the import has already evaluated to undefined — so the message names the
+  // two ways that happens instead.
+  fieldContext?: { fieldName: string; ownerPrototype: BaseDef },
 ): () => CardT {
   if (!cardOrThunk) {
+    let fieldDescription = fieldContext
+      ? `field '${fieldContext.fieldName}' on '${
+          fieldContext.ownerPrototype.constructor?.name ?? 'unknown card'
+        }'`
+      : 'a field';
     throw new Error(
-      `cardOrThunk was ${cardOrThunk}. There might be a cyclic dependency in one of your fields.
-      Use '() => CardName' format for the fields with the cycle in all related cards.
-      e.g.: '@field friend = linksTo(() => Person)'`,
+      `The card class for ${fieldDescription} was ${cardOrThunk}. Two common causes:
+      (1) the import doesn't match the module's export shape — e.g. \`import X from '…'\` where the module only has a named export; use \`import { X } from '…'\`;
+      (2) a cyclic dependency between cards — use the thunk form in all cards in the cycle, e.g. '@field friend = linksTo(() => Person)'.`,
     );
   }
   return (

--- a/packages/base/csv-file-def.gts
+++ b/packages/base/csv-file-def.gts
@@ -463,3 +463,5 @@ export class CsvFileDef extends FileDef {
     };
   }
 }
+
+export default CsvFileDef;

--- a/packages/base/flac-audio-def.gts
+++ b/packages/base/flac-audio-def.gts
@@ -54,3 +54,5 @@ export class FlacDef extends AudioDef {
     };
   }
 }
+
+export default FlacDef;

--- a/packages/base/gif-image-def.gts
+++ b/packages/base/gif-image-def.gts
@@ -43,3 +43,5 @@ export class GifDef extends RasterImageDef {
     };
   }
 }
+
+export default GifDef;

--- a/packages/base/gts-file-def.gts
+++ b/packages/base/gts-file-def.gts
@@ -12,3 +12,5 @@ export class GtsFileDef extends TsFileDef {
   // GTS adds, so the inherited CodePreview renders a `.gts` file correctly.
   static fileKind = 'Glimmer TS';
 }
+
+export default GtsFileDef;

--- a/packages/base/jpg-image-def.gts
+++ b/packages/base/jpg-image-def.gts
@@ -47,3 +47,5 @@ export class JpgDef extends RasterImageDef {
     };
   }
 }
+
+export default JpgDef;

--- a/packages/base/json-file-def.gts
+++ b/packages/base/json-file-def.gts
@@ -594,3 +594,5 @@ export class JsonFileDef extends FileDef {
     };
   }
 }
+
+export default JsonFileDef;

--- a/packages/base/m4a-audio-def.gts
+++ b/packages/base/m4a-audio-def.gts
@@ -55,3 +55,5 @@ export class M4aDef extends AudioDef {
     };
   }
 }
+
+export default M4aDef;

--- a/packages/base/markdown-file-def.gts
+++ b/packages/base/markdown-file-def.gts
@@ -558,3 +558,5 @@ export class MarkdownDef extends FileDef {
     return attributes;
   }
 }
+
+export default MarkdownDef;

--- a/packages/base/mp3-audio-def.gts
+++ b/packages/base/mp3-audio-def.gts
@@ -102,3 +102,5 @@ export class Mp3Def extends AudioDef {
     }
   }
 }
+
+export default Mp3Def;

--- a/packages/base/ogg-audio-def.gts
+++ b/packages/base/ogg-audio-def.gts
@@ -55,3 +55,5 @@ export class OggDef extends AudioDef {
     };
   }
 }
+
+export default OggDef;

--- a/packages/base/png-image-def.gts
+++ b/packages/base/png-image-def.gts
@@ -43,3 +43,5 @@ export class PngDef extends RasterImageDef {
     };
   }
 }
+
+export default PngDef;

--- a/packages/base/svg-image-def.gts
+++ b/packages/base/svg-image-def.gts
@@ -1,7 +1,7 @@
 import { byteStreamToUint8Array } from '@cardstack/runtime-common';
 import SvgIcon from '@cardstack/boxel-icons/file-type-svg';
 import ImageDef from './image-file-def';
-import { type ByteStream, type SerializedFile } from './file-api';
+import type { ByteStream, SerializedFile } from './file-api';
 import { extractSvgDimensions } from './svg-meta-extractor';
 
 export class SvgDef extends ImageDef {
@@ -25,3 +25,5 @@ export class SvgDef extends ImageDef {
     };
   }
 }
+
+export default SvgDef;

--- a/packages/base/text-file-def.gts
+++ b/packages/base/text-file-def.gts
@@ -243,3 +243,5 @@ export class TextFileDef extends FileDef {
     };
   }
 }
+
+export default TextFileDef;

--- a/packages/base/ts-file-def.gts
+++ b/packages/base/ts-file-def.gts
@@ -303,3 +303,5 @@ export class TsFileDef extends FileDef {
     };
   }
 }
+
+export default TsFileDef;

--- a/packages/base/wav-audio-def.gts
+++ b/packages/base/wav-audio-def.gts
@@ -75,3 +75,5 @@ export class WavDef extends AudioDef {
     };
   }
 }
+
+export default WavDef;

--- a/packages/base/webp-image-def.gts
+++ b/packages/base/webp-image-def.gts
@@ -39,3 +39,5 @@ export class WebpDef extends RasterImageDef {
     };
   }
 }
+
+export default WebpDef;

--- a/packages/host/tests/unit/card-thunk-error-test.ts
+++ b/packages/host/tests/unit/card-thunk-error-test.ts
@@ -1,0 +1,36 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../helpers/setup';
+
+// When a field's card class evaluates to undefined — most often a default
+// import of a module that only has named exports, or a genuine cycle — the
+// thrown error names the field and its owning card, so the author lands on
+// the exact declaration instead of bisecting the schema. These call the
+// `field` decorator the same way Babel's decorator transform does.
+module('Unit | card field thunk errors', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('an undefined field card class names the field and its owner', async function (assert) {
+    let loader = getService('loader-service').loader;
+    let api = (await loader.import('@cardstack/base/card-api')) as any;
+    class Broken extends api.CardDef {}
+
+    let cases: [string, string, (value: any) => unknown][] = [
+      ['linksTo', 'src', api.linksTo],
+      ['linksToMany', 'links', api.linksToMany],
+      ['contains', 'meta', api.contains],
+      ['containsMany', 'items', api.containsMany],
+    ];
+    for (let [label, fieldName, fieldFn] of cases) {
+      assert.throws(
+        () =>
+          api.field(Broken.prototype, fieldName, {
+            initializer: () => fieldFn(undefined),
+          }),
+        new RegExp(`field '${fieldName}' on 'Broken'`),
+        `${label} names the field and owner`,
+      );
+    }
+  });
+});

--- a/packages/host/tests/unit/card-thunk-error-test.ts
+++ b/packages/host/tests/unit/card-thunk-error-test.ts
@@ -5,31 +5,67 @@ import { setupRenderingTest } from '../helpers/setup';
 
 // When a field's card class evaluates to undefined — most often a default
 // import of a module that only has named exports, or a genuine cycle — the
-// thrown error names the field and its owning card, so the author lands on
-// the exact declaration instead of bisecting the schema. These call the
-// `field` decorator the same way Babel's decorator transform does.
+// thrown error names the field and its owning card and spells out both
+// causes, so the author lands on the exact declaration instead of bisecting
+// the schema. The eager form throws at decoration time; the thunk form
+// throws at the first `field.card` read. These call the `field` decorator
+// the same way Babel's decorator transform does.
 module('Unit | card field thunk errors', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('an undefined field card class names the field and its owner', async function (assert) {
+  let fieldKinds = (api: any): [string, string, (value: any) => unknown][] => [
+    ['linksTo', 'src', api.linksTo],
+    ['linksToMany', 'links', api.linksToMany],
+    ['contains', 'meta', api.contains],
+    ['containsMany', 'items', api.containsMany],
+  ];
+
+  test('an undefined field card class names the field, the owner, and both causes', async function (assert) {
     let loader = getService('loader-service').loader;
     let api = (await loader.import('@cardstack/base/card-api')) as any;
     class Broken extends api.CardDef {}
 
-    let cases: [string, string, (value: any) => unknown][] = [
-      ['linksTo', 'src', api.linksTo],
-      ['linksToMany', 'links', api.linksToMany],
-      ['contains', 'meta', api.contains],
-      ['containsMany', 'items', api.containsMany],
-    ];
-    for (let [label, fieldName, fieldFn] of cases) {
+    for (let [label, fieldName, fieldFn] of fieldKinds(api)) {
       assert.throws(
         () =>
           api.field(Broken.prototype, fieldName, {
             initializer: () => fieldFn(undefined),
           }),
-        new RegExp(`field '${fieldName}' on 'Broken'`),
-        `${label} names the field and owner`,
+        (err: Error) =>
+          new RegExp(`field '${fieldName}' on 'Broken'`).test(err.message) &&
+          /export shape/.test(err.message) &&
+          /cyclic dependency/.test(err.message),
+        `${label} names the field, the owner, and both causes`,
+      );
+    }
+  });
+
+  test('a thunk resolving to undefined names the field at first read', async function (assert) {
+    let loader = getService('loader-service').loader;
+    let api = (await loader.import('@cardstack/base/card-api')) as any;
+    let { isField } = (await loader.import('@cardstack/runtime-common')) as any;
+    class BrokenThunk extends api.CardDef {}
+
+    for (let [label, fieldName, fieldFn] of fieldKinds(api)) {
+      // The thunk defers evaluation, so decoration itself succeeds. The
+      // decorator returns the property descriptor whose getter carries the
+      // Field object; `field.card` is the accessor every consumer reads
+      // through.
+      let descriptor = api.field(BrokenThunk.prototype, fieldName, {
+        initializer: () => fieldFn(() => undefined),
+      });
+      let field = (descriptor?.get as any)?.[isField];
+      assert.ok(field, `${label} field is registered`);
+      // …and the named error surfaces the first time the class is needed.
+      assert.throws(
+        () => field.card,
+        (err: Error) =>
+          new RegExp(`field '${fieldName}' on 'BrokenThunk'`).test(
+            err.message,
+          ) &&
+          /export shape/.test(err.message) &&
+          /cyclic dependency/.test(err.message),
+        `${label} thunk form names the field and owner at first read`,
       );
     }
   });

--- a/packages/host/tests/unit/filedef-export-shape-test.ts
+++ b/packages/host/tests/unit/filedef-export-shape-test.ts
@@ -1,28 +1,39 @@
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { FILEDEF_CODE_REF_BY_EXTENSION } from '@cardstack/runtime-common';
+import {
+  FILEDEF_CODE_REF_BY_EXTENSION,
+  baseRealm,
+} from '@cardstack/runtime-common';
 
 import { setupRenderingTest } from '../helpers/setup';
 
-// Every FileDef subtype module exports its def class both named and as the
-// default, so `import X from '…'` and `import { X } from '…'` are equally
-// valid. A named-only module makes a default import silently evaluate to
-// undefined, which then fails far away at schema time; a consistent shape
-// removes the trap. Walking the extension registry keeps this guard covering
-// every registered subtype, including ones added later.
+// Every FileDef module exports its def class both named and as the default,
+// so `import X from '…'` and `import { X } from '…'` are equally valid. A
+// named-only module makes a default import silently evaluate to undefined,
+// which then fails far away at schema time; a consistent shape removes the
+// trap. Walking the extension registry keeps this guard covering every
+// registered subtype, including ones added later.
+//
+// What this pins is "a default import never yields undefined" — not "a
+// default import yields the class you named". A module carrying a second,
+// named-only class is the sharper trap: `import RasterImageDef from
+// './image-file-def'` evaluates to ImageDef (the default), a perfectly valid
+// class, so nothing throws and the field is silently wired to the wrong
+// class. image-file-def (RasterImageDef) and zip-file-def (ArchiveEntryField)
+// are the two such modules today; only their registered class is pinned to
+// the default below.
 module('Unit | FileDef subtype export shapes', function (hooks) {
   setupRenderingTest(hooks);
 
   test('every registered subtype module has matching named and default exports', async function (assert) {
     let loader = getService('loader-service').loader;
     let seen = new Set<string>();
-    for (let [extension, ref] of Object.entries(
-      FILEDEF_CODE_REF_BY_EXTENSION,
-    )) {
-      // `.mismatch` is a synthetic registry entry for a non-existent module,
-      // not a real subtype.
-      if (extension === '.mismatch') {
+    for (let ref of Object.values(FILEDEF_CODE_REF_BY_EXTENSION)) {
+      // Real entries are built by `baseModule()` in full-URL form; a bare
+      // relative specifier marks a synthetic test-only entry with no module
+      // behind it (`.mismatch` today).
+      if (!ref.module.includes('://')) {
         continue;
       }
       let key = `${ref.module}#${ref.name}`;
@@ -34,8 +45,10 @@ module('Unit | FileDef subtype export shapes', function (hooks) {
       assert.ok(ns[ref.name], `${ref.module} has named export ${ref.name}`);
       assert.ok(ns['default'], `${ref.module} has a default export`);
       // A module registered under exactly one class defaults to that class.
-      // Multi-leaf modules (e.g. gltf-model-def's GltfDef/GlbDef) default to
-      // one of their leaves; existence is all that's required there.
+      // A module that ever registers two leaf classes would default to one
+      // of them; there, existence of *a* default is all this walk can
+      // require (see the module comment for why that case is a trap of its
+      // own).
       let namesInModule = new Set(
         Object.values(FILEDEF_CODE_REF_BY_EXTENSION)
           .filter((r) => r.module === ref.module)
@@ -48,6 +61,34 @@ module('Unit | FileDef subtype export shapes', function (hooks) {
           `${ref.module} default export is ${ref.name}`,
         );
       }
+    }
+  });
+
+  // The registry maps extensions to leaf subtypes only, so the family's base
+  // modules — the ones a subtype author actually imports from — appear in no
+  // entry and the walk above never touches them. One of these defaults is
+  // already load-bearing in the shipped tree: svg-image-def default-imports
+  // image-file-def.
+  test('family base modules have matching named and default exports', async function (assert) {
+    let loader = getService('loader-service').loader;
+    let baseModules: { module: string; name: string }[] = [
+      { module: 'image-file-def', name: 'ImageDef' },
+      { module: 'audio-file-def', name: 'AudioDef' },
+      { module: 'video-file-def', name: 'VideoDef' },
+      { module: 'font-file-def', name: 'FontDef' },
+      { module: 'three-d-model-def', name: 'ThreeDModelDef' },
+      { module: 'file-api', name: 'FileDef' },
+    ];
+    for (let { module: moduleName, name } of baseModules) {
+      let moduleId = `${baseRealm.url}${moduleName}`;
+      let ns = (await loader.import(moduleId)) as Record<string, unknown>;
+      assert.ok(ns[name], `${moduleId} has named export ${name}`);
+      assert.ok(ns['default'], `${moduleId} has a default export`);
+      assert.strictEqual(
+        ns['default'],
+        ns[name],
+        `${moduleId} default export is ${name}`,
+      );
     }
   });
 });

--- a/packages/host/tests/unit/filedef-export-shape-test.ts
+++ b/packages/host/tests/unit/filedef-export-shape-test.ts
@@ -1,0 +1,53 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { FILEDEF_CODE_REF_BY_EXTENSION } from '@cardstack/runtime-common';
+
+import { setupRenderingTest } from '../helpers/setup';
+
+// Every FileDef subtype module exports its def class both named and as the
+// default, so `import X from '…'` and `import { X } from '…'` are equally
+// valid. A named-only module makes a default import silently evaluate to
+// undefined, which then fails far away at schema time; a consistent shape
+// removes the trap. Walking the extension registry keeps this guard covering
+// every registered subtype, including ones added later.
+module('Unit | FileDef subtype export shapes', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('every registered subtype module has matching named and default exports', async function (assert) {
+    let loader = getService('loader-service').loader;
+    let seen = new Set<string>();
+    for (let [extension, ref] of Object.entries(
+      FILEDEF_CODE_REF_BY_EXTENSION,
+    )) {
+      // `.mismatch` is a synthetic registry entry for a non-existent module,
+      // not a real subtype.
+      if (extension === '.mismatch') {
+        continue;
+      }
+      let key = `${ref.module}#${ref.name}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      let ns = (await loader.import(ref.module)) as Record<string, unknown>;
+      assert.ok(ns[ref.name], `${ref.module} has named export ${ref.name}`);
+      assert.ok(ns['default'], `${ref.module} has a default export`);
+      // A module registered under exactly one class defaults to that class.
+      // Multi-leaf modules (e.g. gltf-model-def's GltfDef/GlbDef) default to
+      // one of their leaves; existence is all that's required there.
+      let namesInModule = new Set(
+        Object.values(FILEDEF_CODE_REF_BY_EXTENSION)
+          .filter((r) => r.module === ref.module)
+          .map((r) => r.name),
+      );
+      if (namesInModule.size === 1) {
+        assert.strictEqual(
+          ns['default'],
+          ns[ref.name],
+          `${ref.module} default export is ${ref.name}`,
+        );
+      }
+    }
+  });
+});

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -15,7 +15,7 @@ function baseModule(name: string): RealmResourceIdentifier {
   return `${baseRealm.url}${name}` as RealmResourceIdentifier;
 }
 
-const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
+export const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
   // TODO: Replace with realm metadata configuration.
   '.markdown': { module: baseModule('markdown-file-def'), name: 'MarkdownDef' },
   '.md': { module: baseModule('markdown-file-def'), name: 'MarkdownDef' },

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -15,7 +15,9 @@ function baseModule(name: string): RealmResourceIdentifier {
   return `${baseRealm.url}${name}` as RealmResourceIdentifier;
 }
 
-export const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
+export const FILEDEF_CODE_REF_BY_EXTENSION: Readonly<
+  Record<string, ResolvedCodeRef>
+> = {
   // TODO: Replace with realm metadata configuration.
   '.markdown': { module: baseModule('markdown-file-def'), name: 'MarkdownDef' },
   '.md': { module: baseModule('markdown-file-def'), name: 'MarkdownDef' },


### PR DESCRIPTION
## What this does

The FileDef subtype family had two export conventions: the shell-based modules export their def class both named and as the default, while 17 older leaf modules (the text, image, and audio families — `markdown-file-def`, `png-image-def`, `mp3-audio-def`, …) were named-only. A default import of a named-only module silently evaluates to `undefined`, and `linksTo(TsFileDef)` then fails far from the import at schema time with an error blaming a cyclic dependency — naming neither the field, the module, nor the actual cause. Authors had to probe `Object.keys(ns)` to find out which import form a given module wanted.

- All 17 named-only subtype modules now also `export default` their primary class, matching the convention the rest of the family already follows, so both import forms work everywhere.
- `cardThunk` receives the field name and owning prototype from every field initializer (`contains`/`containsMany`/`linksTo`/`linksToMany`); the parameter is required, so a future call site can't silently degrade the message. An undefined field card class throws an error naming the exact declaration — `The card class for field 'src' on 'MyCard' was undefined` — and describes both real causes: an import that doesn't match the module's export shape, and a genuine cycle needing the thunk form. (The offending module itself isn't knowable at that point — the import has already evaluated to `undefined` by the time the value reaches the field machinery.)
- The thunk form gets the same guard: a thunk that resolves to `undefined` throws the same field-and-owner-named error at the first `field.card` read, instead of an anonymous `TypeError: Cannot use 'in' operator…` later in `getFieldDefinitions`. This matters because cause (2) of the message advises switching to the thunk form — that path now fails just as loudly and specifically.
- `FILEDEF_CODE_REF_BY_EXTENSION` is exported from runtime-common (as `Readonly` — every consumer is a read) so the export-shape guard test can walk the registry and automatically cover subtypes added later.

## Test plan

- `packages/host/tests/unit/filedef-export-shape-test.ts` — walks every registered subtype extension plus the six family base modules a subtype author imports from (`image-file-def`, `audio-file-def`, `video-file-def`, `font-file-def`, `three-d-model-def`, `file-api`), loads each module, and asserts the named export exists, a default export exists, and (for single-class modules) that the two are the same class. What this pins is "a default import never yields `undefined`"; for the two modules carrying a second named-only class (`image-file-def`, `zip-file-def`) only the registered class is pinned to the default. 117 assertions, passing locally against a full dev stack; the local base realm also completed a from-scratch index over the modified modules.
- `packages/host/tests/unit/card-thunk-error-test.ts` — drives the `field` decorator exactly as Babel's transform does through all four field types, asserting the error names the field, the owner, and both causes; covers the eager form (throws at decoration) and the thunk form (throws at first `field.card` read).
- Typechecks pass across runtime-common and host; template-lint clean on the touched `.gts` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)