### PR TITLE
Disable pnpm's implicit install-on-run in favor of explicit installs

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -16,6 +16,7 @@ on:
       - ".github/workflows/ci-host.yaml"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       # CI boot path: see comment on the equivalent block in ci.yaml.
       - ".mise.toml"
       - ".github/actions/**"
@@ -149,7 +150,7 @@ jobs:
           use_cache=true
           while IFS= read -r file; do
             case "$file" in
-              packages/realm-server/*|packages/runtime-common/*|packages/postgres/*|packages/boxel-ui/*|package.json|pnpm-lock.yaml)
+              packages/realm-server/*|packages/runtime-common/*|packages/postgres/*|packages/boxel-ui/*|package.json|pnpm-lock.yaml|pnpm-workspace.yaml)
                 use_cache=false
                 echo "Index-behavior change detected: $file"
                 break

--- a/.github/workflows/ci-software-factory.yaml
+++ b/.github/workflows/ci-software-factory.yaml
@@ -20,6 +20,7 @@ on:
       - "packages/software-factory/**"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       # CI boot path: see comment on the equivalent block in ci.yaml.
       - ".mise.toml"
       - ".github/actions/**"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,7 @@ jobs:
               - 'packages/runtime-common/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
               # CI boot path. Each gated suite runs `./.github/actions/init`
               # (which calls `jdx/mise-action`, sourcing `.mise.toml` for tool
               # versions) and then `mise run test-services:*` (which sources

--- a/.github/workflows/pr-boxel-ui.yml
+++ b/.github/workflows/pr-boxel-ui.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/pr-boxel-ui.yml"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/preview-host.yml"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
 
 concurrency:
   group: preview-host-${{ github.head_ref || github.run_id }}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -257,6 +257,15 @@ catalog:
   yaml: ^2.5.1
   yargs: ^17.5.1
 
+# pnpm 11 defaults this to `install`, making every `pnpm run` first check
+# node_modules freshness and silently run a full install when the check
+# fails. The check never passes in CI, so each of the ~9 services `run-p`
+# boots kicks off its own concurrent workspace-wide install into the same
+# node_modules; when they collide badly enough, start:matrix never reaches
+# `docker run` and the shard dies with "Failed to reach Synapse". Disabling
+# restores pnpm 10 behavior: scripts run against node_modules as-is.
+verifyDepsBeforeRun: false
+
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - "@glint/ember-tsc"


### PR DESCRIPTION
## What

1. Sets `verifyDepsBeforeRun: false` in `pnpm-workspace.yaml`. pnpm 11 defaults this setting to `install`, which makes every `pnpm run` / `pnpm exec` check node_modules freshness first and silently run a workspace-wide install when the check fails. With `false`, scripts run against node_modules as-is and installs happen only when explicitly requested — the pnpm 10 behavior this workspace ran on previously.
2. Adds `pnpm-workspace.yaml` to every workflow path filter that already lists `pnpm-lock.yaml` (and to ci-host's index-cache invalidation case). The file carries dependency-resolution settings (catalog, overrides, patchedDependencies, allowBuilds, verifyDepsBeforeRun), but a settings-only change that doesn't touch the lockfile previously ran zero suites.

## Why

The freshness check never passes in CI — not even immediately after the init action's `pnpm install --frozen-lockfile`, and not after one of the implicit installs itself completes — so every pnpm invocation in a CI job pays a redundant 4–16s install. Green host-shard logs show the sequence plainly: the explicit install finishes, then three more implicit installs run during setup, then several *concurrent* ones fire when `run-p` boots the test services.

That concurrency is the fatal case. `start:matrix`, `start:smtp`, `start:host-dist`, and the rest are each `pnpm run` invocations, so each spawns its own workspace-wide install into the same node_modules. They stomp each other's bin links (the `Failed to create bin … ENOENT` warnings visible even in passing shards) and occasionally wedge each other. When `start:matrix`'s install is the one that hangs, `start-matrix.sh` never reaches `pnpm assert-synapse-running`, the Synapse container is never created, and the shard fails with `Failed to reach Synapse at http://localhost:8008/_matrix/client/versions after 60 attempts (~300s)` — the recurring "Synapse startup" flake. Failing-shard logs show that install still running at teardown, killed by SIGTERM five minutes after it started, with `Error response from daemon: No such container: boxel-synapse-ci` in between.

The same mechanism slows local dev: every `pnpm <script>` pays the check, and `pnpm start:all` fans out the same concurrent implicit installs.

## Test plan

- `pnpm config get verify-deps-before-run` reports `false` with this change (previously unset, defaulting to `install`).
- With the path filters updated, CI on this PR exercises the fix directly: host-shard logs should show no `Done in Ns using pnpm` implicit-install output between the init action's install and the test run, and no `Failed to create bin … ENOENT` warnings during service boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)