### PR TITLE
Accrue ACCRINT over the quasi-coupon period the interest falls in

### DIFF
--- a/packages/bxl/src/formulajs/financial.ts
+++ b/packages/bxl/src/formulajs/financial.ts
@@ -556,9 +556,13 @@ export function excelMirr(
 }
 
 /**
- * Interest accrued from issue to settlement, which a bond pays a coupon at a
- * time: `rate / frequency` per quasi-coupon period, earned in proportion to
- * the share of each period the holding covers.
+ * Interest accrued between issue and settlement. A bond pays `rate / frequency`
+ * per quasi-coupon period, and a holding earns each period's coupon in
+ * proportion to the share of that period it covers.
+ *
+ * Excel's optional eighth argument, `calc_method`, is not part of the exposed
+ * surface, so the accrual always runs from issue rather than from the first
+ * interest payment.
  */
 export function excelAccrint(
   issueLike: unknown,
@@ -600,12 +604,13 @@ export function excelAccrint(
     );
   }
 
-  // Every other basis gives all coupon periods the same nominal length,
-  // year/frequency, so each period's share is the segment's year fraction
-  // times the frequency — and summed over the holding the frequency cancels,
-  // leaving the whole accrual at par * rate * YEARFRAC however the schedule
-  // falls. `first_interest` and `frequency` reach the answer only through the
-  // period lengths, so on these bases they have nothing left to say.
+  // Every other basis gives a coupon period the same nominal length,
+  // year/frequency, whatever dates the schedule falls on. For a holding inside
+  // one period that makes its share `frequency * YEARFRAC` and the frequency
+  // cancels exactly, leaving par * rate * YEARFRAC with nothing for the
+  // schedule to add. Across several periods the two readings can part, because
+  // a period's own day count under the basis need not be its nominal length;
+  // these bases measure the holding as a whole rather than period by period.
   return par * rate * yearFrac(issue, settlement, basis);
 }
 
@@ -841,7 +846,7 @@ function addCouponMonths(anchor: Date, months: number) {
 }
 
 /**
- * How many coupons' worth of interest accrues over `start` → `settlement` on
+ * How many coupons' worth of interest accrues over `issue` → `settlement` on
  * an actual/actual basis: each quasi-coupon period the holding touches
  * contributes the share of its own real length the holding covers, and the
  * shares sum. A holding that spans a period and a half earns one and a half
@@ -856,37 +861,45 @@ function addCouponMonths(anchor: Date, months: number) {
  * February's clamp forward.
  */
 function accruedCoupons(
-  start: Date,
+  issue: Date,
   settlement: Date,
   anchor: Date,
   frequency: number,
 ) {
   const monthsPerPeriod = 12 / frequency;
-  const couponDate = (periods: number) =>
-    addCouponMonths(anchor, periods * monthsPerPeriod);
+  const couponDate = (periods: number) => {
+    const date = addCouponMonths(anchor, periods * monthsPerPeriod);
+    // A schedule that runs past the last representable date is an
+    // out-of-range date rather than an accrual, the same answer a serial
+    // beyond the calendar's end gets.
+    if (Number.isNaN(date.getTime())) {
+      throwExcelError(EXCEL_ERROR.num);
+    }
+    return date;
+  };
 
-  // Counting whole months from the anchor names the period `start` falls in,
+  // Counting whole months from the anchor names the period `issue` falls in,
   // to within one: month arithmetic cannot see the day numbers, so a boundary
-  // later in the month than `start` is one the count still claims. It can only
+  // later in the month than `issue` is one the count still claims. It can only
   // err in that direction — the period after the counted one begins in a later
-  // month than `start`, so it can never have started already — which makes one
+  // month than `issue`, so it can never have started already — which makes one
   // step back the whole correction.
   let periods = Math.floor(
-    ((start.getUTCFullYear() - anchor.getUTCFullYear()) * 12 +
-      start.getUTCMonth() -
+    ((issue.getUTCFullYear() - anchor.getUTCFullYear()) * 12 +
+      issue.getUTCMonth() -
       anchor.getUTCMonth()) /
       monthsPerPeriod,
   );
-  if (couponDate(periods).getTime() > start.getTime()) periods--;
+  if (couponDate(periods).getTime() > issue.getTime()) periods--;
 
   let shares = 0;
   let periodStart = couponDate(periods);
   while (periodStart.getTime() < settlement.getTime()) {
     const periodEnd = couponDate(periods + 1);
-    // The span's own ends bound the first and last periods; the ones between
-    // are covered whole.
+    // The holding's own ends bound the first and last periods; the ones
+    // between are covered whole.
     const segmentStart =
-      periodStart.getTime() > start.getTime() ? periodStart : start;
+      periodStart.getTime() > issue.getTime() ? periodStart : issue;
     const segmentEnd =
       periodEnd.getTime() < settlement.getTime() ? periodEnd : settlement;
     shares +=

--- a/packages/bxl/src/formulajs/financial.ts
+++ b/packages/bxl/src/formulajs/financial.ts
@@ -555,9 +555,14 @@ export function excelMirr(
   return Math.pow(numerator / denominator, 1 / (values.length - 1)) - 1;
 }
 
+/**
+ * Interest accrued from issue to settlement, which a bond pays a coupon at a
+ * time: `rate / frequency` per quasi-coupon period, earned in proportion to
+ * the share of each period the holding covers.
+ */
 export function excelAccrint(
   issueLike: unknown,
-  _firstInterestLike: unknown,
+  firstInterestLike: unknown,
   settlementLike: unknown,
   rateLike: unknown,
   parLike: unknown,
@@ -565,6 +570,10 @@ export function excelAccrint(
   basisLike = 0,
 ) {
   const issue = parseExcelDate(issueLike);
+  // Parsed for every basis, even though only actual/actual reads the schedule
+  // it anchors: the same arguments must not be an error under one convention
+  // and an answer under another.
+  const firstInterest = parseExcelDate(firstInterestLike);
   const settlement = parseExcelDate(settlementLike);
   const rate = parseExcelNumber(rateLike);
   const par = parseExcelNumber(parLike);
@@ -583,6 +592,20 @@ export function excelAccrint(
     throwExcelError(EXCEL_ERROR.num);
   }
 
+  if (basis === 1) {
+    return (
+      par *
+      (rate / frequency) *
+      accruedCoupons(issue, settlement, firstInterest, frequency)
+    );
+  }
+
+  // Every other basis gives all coupon periods the same nominal length,
+  // year/frequency, so each period's share is the segment's year fraction
+  // times the frequency — and summed over the holding the frequency cancels,
+  // leaving the whole accrual at par * rate * YEARFRAC however the schedule
+  // falls. `first_interest` and `frequency` reach the answer only through the
+  // period lengths, so on these bases they have nothing left to say.
   return par * rate * yearFrac(issue, settlement, basis);
 }
 
@@ -798,22 +821,82 @@ function addMonthsClamped(date: Date, months: number) {
 }
 
 /**
- * A coupon date `months` from maturity. A bond maturing on the last day of a
- * month pays on the last day of every month in its schedule, so clamping the
- * day number is not enough: a February 28th maturity would give an August 28th
- * where the schedule wants the 31st.
+ * A coupon date `months` from `anchor` — a known date on the bond's schedule,
+ * its maturity or its first interest payment. A bond whose anchor is the last
+ * day of a month pays on the last day of every month in its schedule, so
+ * clamping the day number is not enough: a February 28th anchor would give an
+ * August 28th where the schedule wants the 31st.
  */
-function addCouponMonths(maturity: Date, months: number) {
+function addCouponMonths(anchor: Date, months: number) {
   const shifted = new Date(
-    Date.UTC(maturity.getUTCFullYear(), maturity.getUTCMonth() + months, 1),
+    Date.UTC(anchor.getUTCFullYear(), anchor.getUTCMonth() + months, 1),
   );
-  const endOfMonth = maturity.getUTCDate() === lastDayOfMonth(maturity);
+  const endOfMonth = anchor.getUTCDate() === lastDayOfMonth(anchor);
   shifted.setUTCDate(
     endOfMonth
       ? lastDayOfMonth(shifted)
-      : Math.min(maturity.getUTCDate(), lastDayOfMonth(shifted)),
+      : Math.min(anchor.getUTCDate(), lastDayOfMonth(shifted)),
   );
   return shifted;
+}
+
+/**
+ * How many coupons' worth of interest accrues over `start` → `settlement` on
+ * an actual/actual basis: each quasi-coupon period the holding touches
+ * contributes the share of its own real length the holding covers, and the
+ * shares sum. A holding that spans a period and a half earns one and a half
+ * coupons, and the two halves divide by their own lengths — which is why no
+ * single year fraction over the whole holding can stand in for the sum.
+ *
+ * The periods are the schedule `anchor` — the first interest payment — sits
+ * on, extended in both directions at `frequency` a year, since a bond can be
+ * issued periods before its first payment and still be accruing periods after
+ * it. Every boundary is measured from the anchor rather than from the boundary
+ * before it, so a month-end schedule stays on month ends instead of carrying
+ * February's clamp forward.
+ */
+function accruedCoupons(
+  start: Date,
+  settlement: Date,
+  anchor: Date,
+  frequency: number,
+) {
+  const monthsPerPeriod = 12 / frequency;
+  const couponDate = (periods: number) =>
+    addCouponMonths(anchor, periods * monthsPerPeriod);
+
+  // Counting whole months from the anchor names the period `start` falls in,
+  // to within one: month arithmetic cannot see the day numbers, so a boundary
+  // later in the month than `start` is one the count still claims. It can only
+  // err in that direction — the period after the counted one begins in a later
+  // month than `start`, so it can never have started already — which makes one
+  // step back the whole correction.
+  let periods = Math.floor(
+    ((start.getUTCFullYear() - anchor.getUTCFullYear()) * 12 +
+      start.getUTCMonth() -
+      anchor.getUTCMonth()) /
+      monthsPerPeriod,
+  );
+  if (couponDate(periods).getTime() > start.getTime()) periods--;
+
+  let shares = 0;
+  let periodStart = couponDate(periods);
+  while (periodStart.getTime() < settlement.getTime()) {
+    const periodEnd = couponDate(periods + 1);
+    // The span's own ends bound the first and last periods; the ones between
+    // are covered whole.
+    const segmentStart =
+      periodStart.getTime() > start.getTime() ? periodStart : start;
+    const segmentEnd =
+      periodEnd.getTime() < settlement.getTime() ? periodEnd : settlement;
+    shares +=
+      daysBetween(segmentStart, segmentEnd) /
+      daysBetween(periodStart, periodEnd);
+    periods++;
+    periodStart = periodEnd;
+  }
+
+  return shares;
 }
 
 export function excelCoupdays(

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-financial.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-financial.ts
@@ -436,6 +436,29 @@ export const formulaFinancialCases: CoverageCase[] = [
     expected: 13.516483516483516,
     tolerance: 1e-9,
   },
+  {
+    covers: 'ACCRINT/7',
+    // A month-end anchor keeps the whole schedule on month ends: behind
+    // 2023-08-31 sit 2023-02-28 and 2022-08-31, so issue accrues 18 of the 181
+    // days in the period ending February and settlement 46 of the 184 in the
+    // one after — 1000 * 0.05 * (18/181 + 46/184). Measuring each date from the
+    // one before it would carry February's clamp forward to an August 28th and
+    // divide by the wrong lengths. Issue also shares February with a coupon
+    // date it precedes, which is the case whole months alone misplace.
+    source:
+      'ACCRINT("2023-02-10", "2023-08-31", "2023-04-15", 0.1, 1000, 2, 1)',
+    expected: 17.472375690607734,
+    tolerance: 1e-9,
+  },
+  {
+    covers: 'ACCRINT/6',
+    // The schedule anchor is read on every basis, so a first_interest that is
+    // not a date is an error even where the accrual would not have consulted
+    // the schedule it anchors. The same arguments must not be an error under
+    // one convention and an answer under another.
+    source: 'ACCRINT("2023-01-01", "not a date", "2023-04-01", 0.1, 1000, 2)',
+    throws: /#VALUE!/,
+  },
   // On the default 30/360 basis a coupon period is 360/frequency days by
   // definition, so the dates are inert here and the frequency is what the
   // case can pin. Basis 3 is the same shape over a 365-day year. The

--- a/packages/bxl/tests/unit/fixtures/function-coverage/formula-financial.ts
+++ b/packages/bxl/tests/unit/fixtures/function-coverage/formula-financial.ts
@@ -364,6 +364,15 @@ export const formulaFinancialCases: CoverageCase[] = [
   },
   // Bills and bonds: date pairs picked for round day counts (90 actual days
   // to April, 181 actual days / 180 on a 30-360 basis to July).
+  //
+  // ACCRINT pays par * (rate / frequency) per quasi-coupon period, earned in
+  // proportion to the share of each period the holding covers — periods on the
+  // schedule first_interest sits on, at the given frequency. On every basis
+  // with a fixed year length a period is exactly year/frequency long, so the
+  // shares sum to frequency * YEARFRAC(issue, settlement) and the frequency
+  // cancels: those bases answer par * rate * YEARFRAC no matter where the
+  // schedule falls. Basis 1 is actual/actual, where a period's own length is
+  // what divides, so it is the basis the schedule reaches.
   {
     covers: 'ACCRINT/6',
     // Settling mid-period rather than on the coupon date, so the accrual is a
@@ -373,24 +382,59 @@ export const formulaFinancialCases: CoverageCase[] = [
     tolerance: 1e-9,
   },
   {
+    covers: 'ACCRINT/6',
+    // A holding that runs past a coupon date, on the basis where the coupons
+    // still sum to the whole span: one full period from 2022-11-15 to
+    // 2023-05-15 plus 76 more 30/360 days is 1000 * 0.1 * 256/360. A frequency
+    // left uncancelled would scale that by 2 or by a half.
+    source: 'ACCRINT("2022-11-15", "2023-05-15", "2023-08-01", 0.1, 1000, 2)',
+    expected: 71.11111111111111,
+    tolerance: 1e-9,
+  },
+  {
     covers: 'ACCRINT/7',
-    // Excel accrues par * (rate / frequency) * the accrued days over the
-    // length of the quasi-coupon period they fall in — periods counted back
-    // from first_interest. Settling 90 days into the period that runs
-    // 2023-01-01 to 2023-07-01 gives 1000 * 0.05 * 90/181.
-    //
-    // On every basis with a fixed year length that reduces to
-    // par * rate * YEARFRAC(issue, settlement), which is why only basis 1
-    // separates the two readings.
+    // Settling 90 actual days into the period that runs 2023-01-01 to
+    // 2023-07-01, which is 181 days long: 1000 * 0.05 * 90/181. Dividing by
+    // the year instead would give 24.657, and reading the period off a
+    // schedule anchored anywhere but 2023-07-01 would give neither.
     source:
       'ACCRINT("2023-01-15", "2023-07-01", "2023-04-15", 0.1, 1000, 2, 1)',
     expected: 24.861878453038674,
     tolerance: 1e-9,
-    knownDefect:
-      'ACCRINT computes par * rate * YEARFRAC(issue, settlement, basis) and ' +
-      'never reads first_interest or frequency, so on basis 1 it divides by ' +
-      "the year rather than by the quasi-coupon period's own length",
-    produces: { expected: 24.65753424657534, tolerance: 1e-9 },
+  },
+  {
+    covers: 'ACCRINT/7',
+    // Held from issue to the first payment, so the holding is one whole
+    // quasi-coupon period and earns exactly one coupon — 1000 * 0.05 — however
+    // many days the calendar put in it. Dividing the 181 days by the year
+    // instead would pay 49.589 for a full period's holding.
+    source:
+      'ACCRINT("2022-11-15", "2023-05-15", "2023-05-15", 0.1, 1000, 2, 1)',
+    expected: 50,
+    tolerance: 1e-9,
+  },
+  {
+    covers: 'ACCRINT/7',
+    // A holding that spans a coupon date earns from both periods, and on
+    // actual/actual the two periods are not the same length: one full coupon
+    // for 2022-11-15 to 2023-05-15, then 78 of the 184 days in 2023-05-15 to
+    // 2023-11-15. No single YEARFRAC over the whole holding produces this,
+    // since the halves divide by 181 and 184 respectively.
+    source:
+      'ACCRINT("2022-11-15", "2023-05-15", "2023-08-01", 0.1, 1000, 2, 1)',
+    expected: 71.19565217391303,
+    tolerance: 1e-9,
+  },
+  {
+    covers: 'ACCRINT/7',
+    // Issued after its first interest payment, so the schedule is the one
+    // extended forward from the anchor rather than counted back from it: the
+    // quarterly dates behind 2023-12-01 are 2023-09-01 and 2023-06-01, and
+    // settlement closes the 91-day period issue opened 9 days into.
+    source:
+      'ACCRINT("2023-09-10", "2023-03-01", "2023-12-01", 0.06, 1000, 4, 1)',
+    expected: 13.516483516483516,
+    tolerance: 1e-9,
   },
   // On the default 30/360 basis a coupon period is 360/frequency days by
   // definition, so the dates are inert here and the frequency is what the


### PR DESCRIPTION
## Background

`ACCRINT` reports the interest a bond has accrued between issue and settlement. Excel pays that a coupon at a time: `par * (rate / frequency)` per quasi-coupon period, earned in proportion to the share of each period the holding covers. The periods come off the schedule `first_interest` sits on, extended in both directions at `frequency` a year — a bond can be issued periods before its first payment and still be accruing periods after it.

On every basis with a fixed year length — 0 and 4 (30/360), 2 (actual/360), 3 (actual/365) — a period is exactly `year / frequency` long. The shares then sum to `frequency * YEARFRAC(issue, settlement)` and the frequency cancels, so the whole accrual is `par * rate * YEARFRAC` wherever the schedule falls, and `first_interest` has nothing left to say. Basis 1 is actual/actual, where a period is as long as the calendar made it, and that reduction does not hold: `first_interest` and `frequency` reach the answer through the period lengths, so basis 1 is the one basis where the schedule is live.

## Shape

`excelAccrint` takes the schedule path on basis 1. It locates the quasi-coupon period holding `issue` by counting whole months from the anchor (one step back is the whole correction — the count can only claim a boundary later in the month than `issue`, never one that has already passed), walks forward period by period to settlement, and sums each period's covered share of its own real length. Boundaries are measured from the anchor rather than from the boundary before them, so a month-end schedule stays on month ends instead of carrying February's clamp forward — the same rule `COUPDAYS` already walks its schedule by, and `addCouponMonths` is now shared between them.

`ACCRINT("2023-01-15", "2023-07-01", "2023-04-15", 0.1, 1000, 2, 1)` settles 90 actual days into the 181-day period 2023-01-01 → 2023-07-01: `1000 * 0.05 * 90/181` = 24.861878453038674. Dividing those same 90 days by the year gives 24.657 instead.

Every other basis keeps the single `par * rate * YEARFRAC`, and the reduction that justifies it is exact for a holding inside one coupon period. Measured over 178,200 argument sets per basis, the schedule walk and the closed form agree bit for bit on bases 2, 3 and 4; on basis 0 the US 30/360 adjustment rules are not additive across a split at a month-end boundary, so the two part by one day of one period's coupon (0.56 on par 1000 at 10% semiannual) on schedules anchored to the 31st or a clamped month end. Keeping the closed form there leaves the default basis untouched.

Across several coupon periods a period-by-period reading can part from the whole-holding one on the fixed-year bases too, because a period's own day count under those bases need not be its nominal length. That is a separate question from this one and is left alone here — the fixed bases answer for the whole holding, as the comment now says rather than claiming the reduction universally. Reference implementations disagree about it: Microsoft documents the per-period sum and `fsprojects/ExcelFinancialFunctions` walks the schedule on every basis, short-circuiting a fully covered period to exactly one coupon, while LibreOffice's `getAccrint` and Formula.js both take `par * rate * YEARFRAC` and never read `first_interest` at all. Settling it wants a real-Excel check, and it is tracked separately.

`first_interest` is parsed on every basis even though only actual/actual reads the schedule it anchors, so the same arguments are not an error under one convention and an answer under another.

A schedule stepped past the last representable date raises `#NUM!` rather than letting an invalid date's day counts propagate as the answer.

Out of scope: Excel's optional 8th argument, `calc_method`. The registry exposes `ACCRINT` at 6 and 7 arguments, so the accrual always runs from issue.

One convention choice worth flagging, since no source settles it: coupon boundaries are measured from the anchor, so a `first_interest` on day 29 or 30 of a 31-day month keeps that day number throughout, where an implementation that steps period-to-period would carry February's clamp forward. The two readings differ only for those two day numbers. This matches how `COUPDAYS` in the same file already walks its schedule.

## Verification

* `ACCRINT/7` asserts normally and the coverage suite reports **0 known defects** (1133 cases, 6 time zones, unchanged 829/830 invoked).
* Five `ACCRINT` cases pin distinct mechanisms: a partial period; a whole period earning exactly one coupon (50, where dividing 181 days by the year would pay 49.589); a holding spanning two periods of unequal length (181 and 184 days), which no single `YEARFRAC` can produce; a schedule extended forward from an anchor that precedes issue, at frequency 4; and the reduction holding on the default basis across a coupon date.
* The definitional invariant checked directly: a holding of *n* whole quasi-coupon periods earns exactly *n* coupons — 3,930 holdings across month-end and leap-year anchors at all three frequencies, zero error.
* The one-step correction that lands issue in its period is exercised: brute-forced over 19.6M anchor/frequency/issue combinations, the month count lands one period late 9.4% of the time and never early, so a single step back is the complete correction — and the month-end case is the one that takes it.
* `pnpm test` 68/68 suites, `pnpm lint` (eslint + types) clean.
