### PR TITLE
ci: Fix host shard Synapse wait

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -306,8 +306,11 @@ jobs:
       # realm-server logs in as. Without this the worker's `_mtimes`
       # request to the realm-server is unauthenticated and gets 404, so
       # the from-scratch index finishes with zero files and every later
-      # card fetch 404s. Script waits for Synapse to be reachable before
-      # registering, so the ordering with `Start test services` is safe.
+      # card fetch 404s. This step deliberately starts before Synapse does:
+      # the script polls for readiness, re-resolving Synapse's address on
+      # every attempt so it picks up the dynamically published host port as
+      # soon as the container appears. That is what makes the ordering with
+      # the backgrounded `Start test services` safe.
       - name: create realm users
         run: pnpm register-realm-users
         working-directory: packages/matrix
@@ -581,8 +584,11 @@ jobs:
       # realm-server logs in as. Without this the worker's `_mtimes`
       # request to the realm-server is unauthenticated and gets 404, so
       # the from-scratch index finishes with zero files and every later
-      # card fetch 404s. Script waits for Synapse to be reachable before
-      # registering, so the ordering with `Start test services` is safe.
+      # card fetch 404s. This step deliberately starts before Synapse does:
+      # the script polls for readiness, re-resolving Synapse's address on
+      # every attempt so it picks up the dynamically published host port as
+      # soon as the container appears. That is what makes the ordering with
+      # the backgrounded `Start test services` safe.
       - name: create realm users
         run: pnpm register-realm-users
         working-directory: packages/matrix

--- a/packages/matrix/scripts/register-matrix-users.ts
+++ b/packages/matrix/scripts/register-matrix-users.ts
@@ -7,7 +7,7 @@ import {
 import { ensureUserRecord } from '../helpers/ensure-user-record.ts';
 import {
   getSynapseContainerName,
-  getSynapseURL,
+  tryGetSynapseURL,
 } from '../support/environment-config.ts';
 import { realmPassword } from '../helpers/realm-credentials.ts';
 
@@ -67,30 +67,44 @@ const EXTRA_USERS: ExtraUser[] = [
 ];
 
 async function waitForSynapse(): Promise<void> {
-  const base = getSynapseURL().replace(/\/$/, '');
-  // `/_matrix/client/versions` returns 200 only once Synapse has finished
-  // booting and running its database migrations, so it is a truer readiness
-  // signal than a HEAD on the root (which can answer non-2xx while the server
-  // is still coming up, or 404 depending on config).
-  const url = `${base}/_matrix/client/versions`;
   // The budget is deliberately generous. On a cold or loaded CI runner the
   // image pull and migrations can take minutes, and a too-tight window took out
   // the whole test shard before a single test ran rather than tolerating a slow
   // start.
   const maxAttempts = 60;
   const intervalMs = 5000;
+  // Re-resolve the address on every attempt. This gate is expected to start
+  // before Synapse does, and in environment mode Synapse's host port is only
+  // discoverable once its container exists — so resolving once up front would
+  // capture "not knowable yet" and then poll that stale answer for the whole
+  // budget, never noticing the container that appeared a few seconds later.
+  let lastUrl: string | undefined;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    try {
-      const res = await fetch(url);
-      if (res.ok) return;
-    } catch {
-      // fall through to retry
+    const base = tryGetSynapseURL()?.replace(/\/$/, '');
+    if (base) {
+      // `/_matrix/client/versions` returns 200 only once Synapse has finished
+      // booting and running its database migrations, so it is a truer readiness
+      // signal than a HEAD on the root (which can answer non-2xx while the
+      // server is still coming up, or 404 depending on config).
+      lastUrl = `${base}/_matrix/client/versions`;
+      try {
+        const res = await fetch(lastUrl);
+        if (res.ok) return;
+      } catch {
+        // fall through to retry
+      }
     }
     process.stdout.write('.');
     await new Promise((r) => setTimeout(r, intervalMs));
   }
+  // Distinguish the two ways this wait runs out, because they point at
+  // different things: a container that never came up, versus one that came up
+  // but never finished booting.
+  const target =
+    lastUrl ??
+    `container ${getSynapseContainerName()}, which never started (no published port to poll)`;
   throw new Error(
-    `Failed to reach Synapse at ${url} after ${maxAttempts} attempts (~${Math.round(
+    `Failed to reach Synapse at ${target} after ${maxAttempts} attempts (~${Math.round(
       (maxAttempts * intervalMs) / 1000,
     )}s).`,
   );

--- a/packages/matrix/support/environment-config.ts
+++ b/packages/matrix/support/environment-config.ts
@@ -60,10 +60,19 @@ export function getSynapseContainerName(): string {
   return 'boxel-synapse';
 }
 
-export function getSynapseURL(synapse?: {
+// Resolve Synapse's base URL, or `undefined` when it is not yet knowable.
+//
+// Outside environment mode Synapse always binds the fixed host port 8008, so
+// the answer is a constant. Inside environment mode `synapseStart` publishes it
+// on a dynamically chosen free port so that concurrent environments do not
+// collide, and that port is only discoverable by asking Docker about a
+// container that has to already exist. Callers that may run before the
+// container is up — a readiness gate, most of all — need to tell "not yet" from
+// a real address, so this returns `undefined` rather than guessing.
+export function tryGetSynapseURL(synapse?: {
   baseUrl?: string;
   port?: number;
-}): string {
+}): string | undefined {
   if (synapse?.baseUrl) {
     return synapse.baseUrl;
   }
@@ -77,15 +86,36 @@ export function getSynapseURL(synapse?: {
   try {
     let output = execSync(`docker port ${containerName} 8008/tcp`, {
       encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     // Output is like "0.0.0.0:55123" or "[::]:55123" — take the first line
     let firstLine = output.split('\n')[0];
     let port = firstLine.split(':').pop();
+    if (!port) {
+      return undefined;
+    }
     return `http://localhost:${port}`;
   } catch {
-    // Fallback if container isn't running yet
-    return 'http://localhost:8008';
+    // The container does not exist yet (or has no published port). There is no
+    // correct URL to return here: in environment mode 8008 belongs to whatever
+    // else happens to be listening, never to this Synapse.
+    return undefined;
   }
+}
+
+export function getSynapseURL(synapse?: {
+  baseUrl?: string;
+  port?: number;
+}): string {
+  let url = tryGetSynapseURL(synapse);
+  if (!url) {
+    throw new Error(
+      `Cannot determine the Synapse URL: container ${getSynapseContainerName()} is not running, ` +
+        `so its dynamically published host port cannot be read. If you are waiting for Synapse ` +
+        `to come up, poll with tryGetSynapseURL() instead.`,
+    );
+  }
+  return url;
 }
 
 export function registerSynapseWithTraefik(hostPort: number): void {


### PR DESCRIPTION
¾ of host shard failures lately have been about Synapse seemingly not being ready, which looks like this:

<img width="1948" height="1276" alt="s 2026-08-18 at 11 29 24@2x" src="https://github.com/user-attachments/assets/1a458a3b-57e0-48f0-93e5-b4c7eeb117b5" />

But it turns out it’s been looking for Synapse at the wrong port! Host test shards use environment mode, so `localhost:8008` would never work.

More details on how popular this failure is:

| | Count | Share |
|---|---:|---:|
| Jobs run | 1,102 | — |
| **Failed jobs** | **114** | 10.3% of all jobs |
| ├ `create realm users` | 81 | **71% of failures**, 7.4% of all jobs |
| ├ `Wait for realms…parity` | 15 | 13% of failures |
| ├ actual `host test suite (shard N)` | 17 | 15% of failures |
| └ misc | 1 | — |


<details><summary>Claude explanation</summary>In environment mode Synapse is published on a dynamically chosen free host port so concurrent environments cannot collide, and that port is only discoverable by asking Docker about a container that has to already exist. `getSynapseURL` answered a failed lookup with the fixed `localhost:8008` — an address that in environment mode belongs to whatever else happens to be listening, never to this Synapse.

`waitForSynapse` resolved that address once, before its poll loop. The gate is deliberately scheduled to start before Synapse does, so the lookup ran against a container that did not exist yet, latched the wrong fallback, and then polled a port nothing would ever bind for the entire budget. It could not succeed, and widening the budget only lengthened the wait before it failed.

Resolution now happens on every attempt, so the real port is picked up as soon as the container appears, and `tryGetSynapseURL` reports "not knowable yet" as `undefined` instead of guessing. `getSynapseURL` keeps its string-returning contract for the callers that run once Synapse is up, but now throws a diagnostic instead of handing back a dead address. Outside environment mode Synapse still binds the fixed 8008 and nothing changes.

The timeout message now also distinguishes a container that never started from one that started but never finished booting.</details>