### PR TITLE
Remove the FileDef preview stage's floating provenance tag

### DIFF
--- a/packages/base/file-formats/file-preview-stage.gts
+++ b/packages/base/file-formats/file-preview-stage.gts
@@ -114,21 +114,6 @@ export class FilePreviewStage extends GlimmerComponent<StageSignature> {
     return this.showGenericDetail ? '44' : '30';
   }
 
-  get srcTag() {
-    return (this.model?.previewSource ?? '').toUpperCase();
-  }
-
-  // Provenance is only meaningful for the families that actually render
-  // something; a generic pane has nothing to attribute.
-  get showSrcTag() {
-    return (
-      this.showReal &&
-      Boolean(this.args.preview) &&
-      Boolean(this.model?.previewSource) &&
-      this.model?.previewSource !== 'fallback'
-    );
-  }
-
   <template>
     <div
       class='stage'
@@ -189,9 +174,10 @@ export class FilePreviewStage extends GlimmerComponent<StageSignature> {
         {{#if (eq this.state 'malformed')}}
           <div class='malformed-banner'>Partial · some content unreadable</div>
         {{/if}}
-        {{#if this.showSrcTag}}
-          <span class='src-tag'>{{this.srcTag}}</span>
-        {{/if}}
+        {{! No provenance overlay: a tag floated over the render lands on
+        whatever the family draws in that corner — a prose preview's title, an
+        archive tree's first row — and provenance already has a home in the
+        isolated shell's metadata chrome. }}
       {{else if (eq this.state 'loading')}}
         <div class='state-pane'>
           <div class='skeleton-bar'></div>
@@ -366,19 +352,6 @@ export class FilePreviewStage extends GlimmerComponent<StageSignature> {
         text-transform: uppercase;
         color: var(--fd-warn, #e8710a);
         text-align: left;
-      }
-      .src-tag {
-        position: absolute;
-        top: 8px;
-        left: 8px;
-        font-family: var(--font-mono);
-        font-size: 0.4375rem;
-        letter-spacing: 0.06em;
-        color: var(--muted-foreground);
-        background: rgb(255 255 255 / 62%);
-        padding: 2px 4px;
-        border-radius: 2px;
-        text-transform: uppercase;
       }
       @keyframes fd-shimmer {
         0% {

--- a/packages/host/tests/integration/components/file-def-format-templates-test.gts
+++ b/packages/host/tests/integration/components/file-def-format-templates-test.gts
@@ -184,6 +184,40 @@ module('Integration | FileDef format templates', function (hooks) {
     assert.dom('[data-test-file-no-preview]').doesNotExist();
   });
 
+  // The stage floats no chrome over the family's render: an overlay in the
+  // stage's corner lands on whatever the preview draws there — a prose
+  // preview's title, an archive tree's first row. Provenance lives in the
+  // isolated shell's metadata chrome instead.
+  test('the stage renders no provenance overlay in any format', async function (assert) {
+    const ReportPreview: TemplateOnlyComponent<FilePreviewSignature> =
+      <template>
+        <div data-test-report-preview>{{@model.name}}</div>
+      </template>;
+
+    class ReportDef extends FileDef {
+      static displayName = 'Report';
+      static previewComponent = ReportPreview;
+    }
+
+    let file = new ReportDef({
+      id: 'http://example.com/docs/report.pdf',
+      url: 'http://example.com/docs/report.pdf',
+      sourceUrl: 'http://example.com/docs/report.pdf',
+      name: 'report.pdf',
+      contentType: 'application/pdf',
+    });
+
+    for (let format of ['embedded', 'isolated', 'fitted'] as const) {
+      await renderCard(loader, file, format);
+      assert
+        .dom('[data-test-report-preview]')
+        .exists(`the preview mounts in ${format}`);
+      assert
+        .dom('[data-test-file-preview-stage] > span, .src-tag')
+        .doesNotExist(`${format} floats no tag over the render`);
+    }
+  });
+
   // The shells read the glyph from the class rather than from a family→glyph
   // map, which is what keeps each family's icon module out of card-api's
   // dependency graph — and so out of every card's. If a shell ever goes back to


### PR DESCRIPTION
## What this does

`FilePreviewStage` floated a provenance tag over every real preview — the profile's `previewSource` uppercased ("NATIVE" for the HTML/Markdown families, "EXTRACTED" for archives) — absolutely positioned at the stage's top-left with a translucent background. That corner is exactly where several families draw their own content: the HTML summary and Markdown snippet begin their document title there, and the zip family's archive tree starts its first row there. In all of those, the tag overprinted the content's first words into an unreadable jumble (observed on staging in the fixture gallery for HTML and Markdown fitted tiles, and in the zip embedded view).

The overlay is removed in every format. Provenance keeps a legible home where layout actually reserves space for it:

- the isolated shell's metadata chrome already describes the render source in prose ("The browser displays…", "Structured…", "Rendered by Boxel…"), and
- the fitted shell's metadata strip identifies the file.

## Test plan

- `packages/host/tests/integration/components/file-def-format-templates-test.gts`: a preview-bearing FileDef mounts its family renderer in embedded, isolated, and fitted with no floating tag over the stage in any of them. Full module: 16 tests, 57 assertions, passing locally against a full dev stack.
- Host typecheck and eslint clean.

Fixes CS-12551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)