### PR TITLE
Scale waveform bars from stored amplitudes to the renderer's range

### DIFF
--- a/packages/base/file-formats/file-view-model.ts
+++ b/packages/base/file-formats/file-view-model.ts
@@ -195,12 +195,18 @@ function waveformBarsFor(model: FileModelLike, format: FileFormat): number[] {
   if (!Array.isArray(values)) {
     return [];
   }
+  // Every producer persists bars as 0..1 amplitudes — decoded RMS of float
+  // samples, MP3's side-info envelope normalized to its own peak, the WAV
+  // streaming envelope — while the renderers draw bar heights from 0–100.
+  // The projection owns that scale conversion; a renderer given raw
+  // amplitudes would crush every bar to its minimum sliver height and draw
+  // silence.
   let normalized = values
     .filter(
       (value): value is number =>
         typeof value === 'number' && Number.isFinite(value),
     )
-    .map((value) => Math.max(0, Math.min(100, value)));
+    .map((value) => Math.max(0, Math.min(100, value * 100)));
   let budget =
     format === 'fitted'
       ? FITTED_WAVEFORM_BAR_BUDGET

--- a/packages/host/tests/unit/file-view-model-test.ts
+++ b/packages/host/tests/unit/file-view-model-test.ts
@@ -259,9 +259,12 @@ module('Unit | file-formats', function (hooks) {
     });
 
     // Resampling has to sample across the whole signal: returning the first N
-    // bars would show only the opening seconds of the waveform.
+    // bars would show only the opening seconds of the waveform. Stored bars
+    // are 0..1 amplitudes; the projection scales them to the 0–100 range the
+    // renderers draw from.
     test('resamples the waveform across the whole envelope', function (assert) {
-      let bars = Array.from({ length: 1000 }, (_, i) => i % 101);
+      // Quarter steps stay exact through the x100 scaling.
+      let bars = Array.from({ length: 1000 }, (_, i) => (i % 5) / 4);
       let model = {
         name: 'take.wav',
         waveform: { barsJson: JSON.stringify(bars) },
@@ -272,10 +275,10 @@ module('Unit | file-formats', function (hooks) {
         fitted.waveformBars.length,
         FITTED_WAVEFORM_BAR_BUDGET,
       );
-      assert.strictEqual(fitted.waveformBars[0], bars[0]);
+      assert.strictEqual(fitted.waveformBars[0], bars[0]! * 100);
       assert.strictEqual(
         fitted.waveformBars.at(-1),
-        bars.at(-1),
+        bars.at(-1)! * 100,
         'the last bar comes from the end of the signal, not from bar 64',
       );
 
@@ -285,13 +288,28 @@ module('Unit | file-formats', function (hooks) {
       );
     });
 
-    test('leaves a waveform shorter than the budget untouched', function (assert) {
-      let bars = [1, 2, 3, 4];
+    test('a waveform shorter than the budget is scaled but not resampled', function (assert) {
+      let bars = [0.25, 0.5, 0.75, 1];
       let vm = fileViewModel(
         { name: 'blip.wav', waveform: { barsJson: JSON.stringify(bars) } },
         'fitted',
       );
-      assert.deepEqual(vm.waveformBars, bars);
+      assert.deepEqual(vm.waveformBars, [25, 50, 75, 100]);
+    });
+
+    // The producers' contract is 0..1 (RMS amplitudes; MP3's peak-normalized
+    // envelope). A full-scale bar must project to full height — this is the
+    // difference between a waveform and a flat line of minimum-height slivers
+    // — and out-of-range values clamp rather than distort the scale.
+    test('amplitude bars project to the renderer percentage scale', function (assert) {
+      let vm = fileViewModel(
+        {
+          name: 'loud.mp3',
+          waveform: { barsJson: JSON.stringify([0, 0.5, 1, 1.2, -0.5]) },
+        },
+        'fitted',
+      );
+      assert.deepEqual(vm.waveformBars, [0, 50, 100, 100, 0]);
     });
 
     test('survives waveform data that is not parseable', function (assert) {


### PR DESCRIPTION
## What this does

Every audio waveform rendered as a flat dashed line of identical minimum-height slivers — indistinguishable from silence — regardless of the track's dynamics. The cause is a scale mismatch across the projection seam:

- Every envelope producer persists bars as **0..1 amplitudes**: the decoded path's RMS of float samples, MP3's side-info envelope normalized to its own peak, and the WAV streaming envelope.
- `AudioPreview` draws bar heights from **0–100 percentages** (`(v / 100) * 96`) with a 1.5 minimum sliver, so a full-scale 1.0 bar computes a 0.96 height — below the minimum — and every bar clamps to the identical sliver.
- The converting seam is `waveformBarsFor` in `file-view-model.ts`, whose contract (per `AudioPreview`'s own comment) is to deliver bars "already normalized to 0–100". It clamped into [0, 100] but never rescaled.

`waveformBarsFor` now scales by 100 before clamping. There is no compatibility concern: no producer ever emitted the 0–100 scale the clamp implied, so every persisted envelope is 0..1.

## Test plan

- `packages/host/tests/unit/file-view-model-test.ts`: new contract test — a full-scale 1.0 bar projects to 100 (full height rather than the minimum sliver), out-of-range values clamp to [0, 100]; the existing resample and under-budget tests now feed 0..1 amplitudes and assert the projected scale. Full `Unit | file-formats` module: 23 tests, 58 assertions, passing locally against a full dev stack.
- Host typecheck and eslint clean.

Fixes CS-12556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)