### PR TITLE
Give the catalog typecheck the ES2022 lib

### DIFF
--- a/packages/catalog/tsconfig.json
+++ b/packages/catalog/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "allowJs": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",


### PR DESCRIPTION
## Problem

`Lint` in the boxel-catalog repo fails its `lint:types` step with seven errors that are not in catalog content at all:

```
../bxl/src/authorization/errors.ts(35,7): error TS2554: Expected 0-1 arguments, but got 2.
../bxl/src/authorization/errors.ts(47,16): error TS2339: Property 'cause' does not exist on type 'AuthorizationError'.
../bxl/src/authorization/errors.ts(47,57): error TS2339: Property 'cause' does not exist on type 'AuthorizationError'.
../bxl/src/boxel-runtime.ts(1961,16): error TS2304: Cannot find name 'WeakRef'.
../bxl/src/boxel-runtime.ts(2962,14): error TS2304: Cannot find name 'WeakRef'.
../bxl/src/boxel-runtime.ts(2962,43): error TS2304: Cannot find name 'WeakRef'.
../bxl/src/mutation/types.ts(230,7): error TS2554: Expected 0-1 arguments, but got 2.
```

`@cardstack/bxl` maps its `exports` to raw TypeScript source (`"." : "./src/index.ts"`) rather than built declarations, so every consumer that resolves it typechecks bxl's sources under *its own* compilerOptions. `skipLibCheck` doesn't apply, because these are `.ts` sources and not `.d.ts`.

`packages/catalog/tsconfig.json` declared no `lib`, so it inherited the default for its `es2020` target. That lib has neither `WeakRef` (ES2021) nor the `Error(message, { cause })` overload and `.cause` property (ES2022), both of which bxl uses. bxl's own tsconfig sets `target: es2022` / `lib: ["ES2022", "DOM"]`, so it is clean on its own terms — it only fails when checked through catalog's options.

This became visible once bxl was reachable from card code, and it lands in the catalog repo rather than here because catalog CI checks out this repo's main unpinned, and nothing in this repo lints `packages/catalog`.

## Fix

Declare the lib, matching `packages/host/tsconfig.json`, which already carries `"lib": ["ES2022", "DOM", "DOM.Iterable"]` for exactly this reason — which is why the catalog CI run's "Lint Host" step passes while "Lint Catalog" fails on the same import surface.

Widening `lib` only adds globals, and with `noEmit: true` the emit target is unaffected.

## Verification

Ran `ember-tsc --noEmit` in `packages/catalog` against a populated `contents` before and after:

| | errors | bxl errors |
| --- | --- | --- |
| before | 32 | 7 |
| after | 25 | 0 |

The seven bxl errors are gone, all three bxl files drop out of the report entirely, and no new error or file appears. The remaining 25 are pre-existing catalog-content errors unrelated to this change.