### PR TITLE
ci: Add timeouts and retry-limiting for host jobs

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -198,6 +198,9 @@ jobs:
     name: Live Tests (realm)
     if: github.event.action != 'ready_for_review'
     runs-on: ubuntu-latest
+    # See the note on host-test's timeout. This job has never taken more than
+    # ~10 minutes when healthy.
+    timeout-minutes: 25
     needs: [test-web-assets, check-index-cache]
     concurrency:
       group: boxel-live-test-${{ github.head_ref || github.run_id }}
@@ -235,10 +238,15 @@ jobs:
       # the realm-server's prerender workers), which aborts every in-flight
       # h2 stream with ERR_NETWORK_CHANGED and leaves wait-for-host-standby
       # stuck waiting for #standby-ready that never lands.
+      # These packages are absent from the runner image, so this step has to
+      # reach Ubuntu's mirrors. Bound it: apt retries a degraded mirror with
+      # long internal timeouts, so without a ceiling an upstream archive
+      # outage hangs the job rather than failing it.
       - name: Install D-Bus helpers
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y dbus-x11 upower
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y -o Acquire::Retries=3 dbus-x11 upower
           sudo service dbus restart
           sudo service upower restart
 
@@ -432,6 +440,12 @@ jobs:
   host-test:
     name: Host Tests
     runs-on: ubuntu-latest
+    # Without this a wedged shard inherits GitHub's 360-minute default and
+    # holds a runner for six hours doing nothing, which starves the pool for
+    # every other PR in the repo. A healthy shard has never exceeded ~19
+    # minutes, so this fails a genuinely stuck one fast while leaving ample
+    # headroom for a slow-but-working run.
+    timeout-minutes: 35
     needs: [test-web-assets, check-percy, check-index-cache]
     strategy:
       fail-fast: false
@@ -493,10 +507,15 @@ jobs:
       # the realm-server's prerender workers), which aborts every in-flight
       # h2 stream with ERR_NETWORK_CHANGED and leaves wait-for-host-standby
       # stuck waiting for #standby-ready that never lands.
+      # These packages are absent from the runner image, so this step has to
+      # reach Ubuntu's mirrors. Bound it: apt retries a degraded mirror with
+      # long internal timeouts, so without a ceiling an upstream archive
+      # outage hangs the job rather than failing it.
       - name: Install D-Bus helpers
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y dbus-x11 upower
+          sudo apt-get update -o Acquire::Retries=3
+          sudo apt-get install -y -o Acquire::Retries=3 dbus-x11 upower
           sudo service dbus restart
           sudo service upower restart
 


### PR DESCRIPTION
We have a huge ongoing CI backlog, this is extracted from #5812 because I can’t confirm its `init` step changes actually work due to the backlog!

I’m going to merge this immediately.