### PR TITLE
Fix Switch keyboard activation, focus ring, and thumb geometry

### DIFF
--- a/.claude/skills/gts-component-conventions/SKILL.md
+++ b/.claude/skills/gts-component-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gts-component-conventions
-description: Styling and authoring conventions for `.gts` components and their CSS in the host and boxel-ui packages, plus the content-tag `<template>`-detection hazards that silently break `.gts` parsing. Use whenever writing, reviewing, or refactoring a `.gts` component, a `<style scoped>` block, or a glimmer template — especially component-styling review passes ("apply these design-review notes", "clean up this component's CSS") and when a `.gts` file mysteriously fails to type-check or lints with phantom unused-import errors. Triggers on editing component markup/CSS, adding SVG icons, writing conditional class names, choosing colors or units, and any cascading "Cannot find name 'template'" or template-was-dropped symptom.
+description: Styling and authoring conventions for `.gts` components and their CSS in the host and boxel-ui packages, plus the content-tag `<template>`-detection hazards that silently break `.gts` parsing. Use whenever writing, reviewing, or refactoring a `.gts` component, a `<style scoped>` block, or a glimmer template — especially component-styling review passes ("apply these design-review notes", "clean up this component's CSS") and when a `.gts` file mysteriously fails to type-check or lints with phantom unused-import errors. Triggers on editing component markup/CSS, adding SVG icons, writing conditional class names, choosing colors or units, improving or designing a boxel-ui component's API or behavior (benchmark against reference design systems), and any cascading "Cannot find name 'template'" or template-was-dropped symptom.
 ---
 
 # `.gts` Component Conventions
@@ -144,6 +144,19 @@ Before building a common UI primitive — progress bar, pill, button, avatar, ta
 {{! Right — the shared, themed component }}
 <ProgressBar @value={{this.percent}} @max={{100}} />
 ```
+
+### 9. Benchmark boxel-ui components against reference design systems
+
+When designing, extending, or reviewing a **boxel-ui** component (`packages/boxel-ui/src/components/**`), don't reason about its API and behavior from scratch — compare it against how the mature design systems solve the same control, and use the differences as a checklist. Each reference is authoritative for something different:
+
+- **React Aria (Adobe)** — behavior and accessibility contracts: keyboard support, focus management, controlled-state semantics, RTL. If React Aria handles an interaction (e.g. hit-target padding, direction-aware thumb travel), treat its absence here as a gap to justify, not a default.
+- **Radix / shadcn** — API shape: controlled vs. uncontrolled props, form participation (`name`/`value` reaching the real input), where `...attributes`-equivalents land, composition via slots/blocks.
+- **Material (Google)** — interaction polish and metrics: minimum touch targets, pressed/hover states, motion (including `prefers-reduced-motion`).
+- **WAI-ARIA APG** — the normative keyboard/ARIA contract for the role itself; check it before trusting any library's interpretation.
+
+The method: enumerate what the references do that the boxel-ui component doesn't, rank the differences (a11y/correctness first, API second, polish last), and adopt _patterns_, not wholesale code — everything still lands as boxel idiom (semantic tokens, `--boxel-*` override knobs, `<style scoped>`, native elements over ARIA re-implementations).
+
+Worked example: the Switch review that produced this section measured the component against those four references and yielded, in rank order — fully controlled state with the arg as single source of truth (Radix/React Aria's controlled contract), WCAG 2.5.8 hit-target extension and RTL thumb travel (React Aria), form participation and a visible-label block (Radix/React Aria API shape), reduced-motion guards, pressed-state affordance, and `cursor: not-allowed` (Material/shadcn polish). None of those came from intuition; all came from asking "what do the reference systems do here that we don't?"
 
 ---
 

--- a/packages/base/Theme/boxel-brand-guide.json
+++ b/packages/base/Theme/boxel-brand-guide.json
@@ -85,7 +85,7 @@
       "rootVariables": {
         "card": "var(--boxel-light, #FFFFFF)",
         "ring": "var(--boxel-teal, #00FFBA)",
-        "input": "var(--boxel-450, #919191)",
+        "input": "var(--boxel-400, #afafb7)",
         "muted": "#F5F5F5",
         "accent": "var(--cardstack-lime, #C3FC33)",
         "border": "#E2E8F0",

--- a/packages/base/Theme/boxel-brand-guide.json
+++ b/packages/base/Theme/boxel-brand-guide.json
@@ -10,12 +10,6 @@
     "attributes": {
       "spacing": "0.25rem",
       "version": "7.0",
-      "customCssVariables": [
-        {
-          "name": "boxelSwitchActiveThumb",
-          "value": "var(--boxel-dove, #F7F8FA)"
-        }
-      ],
       "cardInfo": {
         "notes": "v7.0 - Dense Modularity (UI Optimized)",
         "name": "Boxel Brand Guide",

--- a/packages/base/Theme/boxel-brand-guide.json
+++ b/packages/base/Theme/boxel-brand-guide.json
@@ -10,6 +10,12 @@
     "attributes": {
       "spacing": "0.25rem",
       "version": "7.0",
+      "customCssVariables": [
+        {
+          "name": "boxelSwitchActiveThumb",
+          "value": "var(--boxel-dove, #F7F8FA)"
+        }
+      ],
       "cardInfo": {
         "notes": "v7.0 - Dense Modularity (UI Optimized)",
         "name": "Boxel Brand Guide",
@@ -85,7 +91,7 @@
       "rootVariables": {
         "card": "var(--boxel-light, #FFFFFF)",
         "ring": "var(--boxel-teal, #00FFBA)",
-        "input": "var(--boxel-light, #FFFFFF)",
+        "input": "var(--boxel-450, #919191)",
         "muted": "#F5F5F5",
         "accent": "var(--cardstack-lime, #C3FC33)",
         "border": "#E2E8F0",
@@ -114,6 +120,7 @@
         "background": "var(--boxel-dove, #F7F8FA)",
         "foreground": "var(--boxel-slate, #272330)",
         "destructive": "var(--cardstack-red, #FF5050)",
+        "success": "var(--boxel-success, #00AC3D)",
         "sidebarRing": "var(--boxel-teal, #00FFBA)",
         "sidebarAccent": "var(--cardstack-lime, #C3FC33)",
         "sidebarBorder": "#E2E8F0",
@@ -185,7 +192,7 @@
       "darkModeVariables": {
         "card": "#1E1E1E",
         "ring": "var(--boxel-teal, #00FFBA)",
-        "input": "#27272A",
+        "input": "#52525B",
         "muted": "#27272A",
         "accent": "var(--cardstack-lime, #C3FC33)",
         "border": "#333333",
@@ -214,6 +221,7 @@
         "background": "var(--brand-dark, #272330)",
         "foreground": "var(--brand-light, #F7F8FA)",
         "destructive": "var(--cardstack-red, #FF5050)",
+        "success": "var(--boxel-success, #00AC3D)",
         "sidebarRing": "var(--boxel-teal, #00FFBA)",
         "sidebarAccent": "oklch(0.9338 0.1913 122.52)",
         "sidebarBorder": "#333333",

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -472,6 +472,11 @@ export default class ThemeVarField extends FieldDef {
   @field destructiveForeground = contains(ColorField, {
     description: describeColor('Text/icon color on destructive actions.'),
   });
+  @field success = contains(ColorField, {
+    description: describeColor(
+      'Success/positive feedback color. Not standard shadcn: consumers fall back to primary when unset. Do not use as foreground color.',
+    ),
+  });
   @field border = contains(ColorField, {
     description: describeColor('Specifies border-color.'),
   });
@@ -637,6 +642,7 @@ export default class ThemeVarField extends FieldDef {
     'ring',
     'destructive',
     'destructiveForeground',
+    'success',
   ];
   private chartColors = ['chart1', 'chart2', 'chart3', 'chart4', 'chart5'];
   private sidebarColors = [
@@ -849,6 +855,11 @@ export default class ThemeVarField extends FieldDef {
             </FieldContainer>
             <FieldContainer @label='Destructive Foreground' @vertical={{true}} data-test-field='destructiveForeground'>
               <@fields.destructiveForeground />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer @label='Success' @vertical={{true}} data-test-field='success'>
+              <@fields.success />
             </FieldContainer>
           </div>
         </section>

--- a/packages/boxel-ui/docs-app/app/themes/cs-themes.ts
+++ b/packages/boxel-ui/docs-app/app/themes/cs-themes.ts
@@ -16,7 +16,7 @@ export const BoxelBrandGuide = `:root {
   --font-sans: 'IBM Plex Sans', 'Helvetica Neue', Arial, ui-sans-serif, sans-serif, system-ui;
   --font-serif: 'IBM Plex Serif', 'Georgia', Times, serif;
   --foreground: var(--boxel-slate, #272330);
-  --input: var(--boxel-450, #919191);
+  --input: var(--boxel-400, #afafb7);
   --muted: #F5F5F5;
   --muted-foreground: #64748B;
   --popover: var(--boxel-light, #FFFFFF);

--- a/packages/boxel-ui/docs-app/app/themes/cs-themes.ts
+++ b/packages/boxel-ui/docs-app/app/themes/cs-themes.ts
@@ -16,7 +16,7 @@ export const BoxelBrandGuide = `:root {
   --font-sans: 'IBM Plex Sans', 'Helvetica Neue', Arial, ui-sans-serif, sans-serif, system-ui;
   --font-serif: 'IBM Plex Serif', 'Georgia', Times, serif;
   --foreground: var(--boxel-slate, #272330);
-  --input: var(--boxel-light, #FFFFFF);
+  --input: var(--boxel-450, #919191);
   --muted: #F5F5F5;
   --muted-foreground: #64748B;
   --popover: var(--boxel-light, #FFFFFF);
@@ -44,12 +44,14 @@ export const BoxelBrandGuide = `:root {
   --sidebar-primary-foreground: #0F172A;
   --sidebar-ring: var(--boxel-teal, #00FFBA);
   --spacing: 0.25rem;
+  --success: var(--boxel-success, #00AC3D);
   --tracking-normal: 0.01em;
   --brand-primary: var(--boxel-teal);
   --brand-secondary: var(--cardstack-purple);
   --brand-accent: var(--cardstack-lime);
   --brand-light: var(--boxel-dove, #F7F8FA);
   --brand-dark: var(--boxel-slate, #272330);
+  --boxel-switch-active-thumb: var(--boxel-dove, #F7F8FA);
   --boxel-teal: #00FFBA;
   --boxel-cyan: #00EBE5;
   --boxel-slate: #272330;
@@ -110,7 +112,7 @@ export const BoxelBrandGuide = `:root {
   --font-sans: 'IBM Plex Sans', 'Helvetica Neue', Arial, ui-sans-serif, sans-serif, system-ui;
   --font-serif: 'IBM Plex Serif', 'Georgia', Times, serif;
   --foreground: var(--brand-light, #F7F8FA);
-  --input: #27272A;
+  --input: #52525B;
   --muted: #27272A;
   --muted-foreground: #A1A1AA;
   --popover: #1E1E1E;
@@ -138,12 +140,14 @@ export const BoxelBrandGuide = `:root {
   --sidebar-primary-foreground: #0F172A;
   --sidebar-ring: var(--boxel-teal, #00FFBA);
   --spacing: 0.25rem;
+  --success: var(--boxel-success, #00AC3D);
   --tracking-normal: 0.01em;
   --brand-primary: var(--boxel-teal);
   --brand-secondary: var(--cardstack-purple);
   --brand-accent: var(--cardstack-lime);
   --brand-light: var(--boxel-dove, #F7F8FA);
   --brand-dark: var(--boxel-slate, #272330);
+  --boxel-switch-active-thumb: var(--boxel-dove, #F7F8FA);
   --boxel-teal: #00FFBA;
   --boxel-cyan: #00EBE5;
   --boxel-slate: #272330;

--- a/packages/boxel-ui/docs-app/app/themes/cs-themes.ts
+++ b/packages/boxel-ui/docs-app/app/themes/cs-themes.ts
@@ -51,7 +51,6 @@ export const BoxelBrandGuide = `:root {
   --brand-accent: var(--cardstack-lime);
   --brand-light: var(--boxel-dove, #F7F8FA);
   --brand-dark: var(--boxel-slate, #272330);
-  --boxel-switch-active-thumb: var(--boxel-dove, #F7F8FA);
   --boxel-teal: #00FFBA;
   --boxel-cyan: #00EBE5;
   --boxel-slate: #272330;
@@ -147,7 +146,6 @@ export const BoxelBrandGuide = `:root {
   --brand-accent: var(--cardstack-lime);
   --brand-light: var(--boxel-dove, #F7F8FA);
   --brand-dark: var(--boxel-slate, #272330);
-  --boxel-switch-active-thumb: var(--boxel-dove, #F7F8FA);
   --boxel-teal: #00FFBA;
   --boxel-cyan: #00EBE5;
   --boxel-slate: #272330;

--- a/packages/boxel-ui/src/components/card-container/index.gts
+++ b/packages/boxel-ui/src/components/card-container/index.gts
@@ -93,15 +93,18 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
        applies to every container — themed cards differ only in the knob
        values their scoped theme stylesheet provides. */
     :global(.boxel-card-container) {
-      /* setting boxel base css variable overrides, with boxel defaults as fallback */
-      --_boxel-scale: var(--theme-scale, var(--boxel-ratio));
-      --theme-spacing: calc(var(--spacing) * 4);
-      --boxel-spacing: var(--theme-spacing, var(--_boxel-spacing));
+      /* Setting boxel base css variable overrides. Every chain ends in a
+         literal: the calc()-derived scales below are invalid if any var()
+         in them fails to resolve, and variables.css is not guaranteed to
+         be in scope. Literals mirror its values. */
+      --_boxel-scale: var(--theme-scale, var(--boxel-ratio, 1.333));
+      --theme-spacing: calc(var(--spacing, 0.25rem) * 4);
+      --boxel-spacing: var(--theme-spacing, var(--_boxel-spacing, 1rem));
       --boxel-font-size: var(
         --theme-font-size,
-        var(--theme-body-font-size, var(--_boxel-font-size))
+        var(--theme-body-font-size, var(--_boxel-font-size, 1rem))
       );
-      --boxel-radius: var(--radius, var(--_boxel-radius));
+      --boxel-radius: var(--radius, var(--_boxel-radius, 0.625rem));
       --_boxel-ff: var(--font-sans, var(--boxel-font-family));
 
       /*** code below this line is from "variables.css". values will be recalculated based on theming variable values ***/

--- a/packages/boxel-ui/src/components/card-container/index.gts
+++ b/packages/boxel-ui/src/components/card-container/index.gts
@@ -93,10 +93,6 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
        applies to every container — themed cards differ only in the knob
        values their scoped theme stylesheet provides. */
     :global(.boxel-card-container) {
-      /* Setting boxel base css variable overrides. Every chain ends in a
-         literal: the calc()-derived scales below are invalid if any var()
-         in them fails to resolve, and variables.css is not guaranteed to
-         be in scope. Literals mirror its values. */
       --_boxel-scale: var(--theme-scale, var(--boxel-ratio, 1.333));
       --theme-spacing: calc(var(--spacing, 0.25rem) * 4);
       --boxel-spacing: var(--theme-spacing, var(--_boxel-spacing, 1rem));

--- a/packages/boxel-ui/src/components/field-container/index.gts
+++ b/packages/boxel-ui/src/components/field-container/index.gts
@@ -153,6 +153,9 @@ const FieldContainer: TemplateOnlyComponent<Signature> = <template>
 
       .horizontal.inline > .content {
         overflow: clip;
+        /* clears a focus ring (2px outline at 2px offset) while the row
+           still clips runaway content */
+        overflow-clip-margin: 0.25rem;
       }
 
       .vertical {

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -6,12 +6,17 @@ import { cn } from '../../helpers.gts';
 
 interface SwitchSignature {
   Args: SwitchArgs;
+  Blocks: {
+    default?: [];
+  };
   Element: HTMLLabelElement;
 }
 interface SwitchArgs {
   disabled?: boolean;
   isEnabled: boolean;
-  label: string;
+  /* names the switch for assistive technology when no block is given; a
+     yielded visible label names it instead, so pass one or the other */
+  label?: string;
   onChange: (isEnabled: boolean) => void;
 }
 
@@ -44,23 +49,34 @@ function toggleOnEnter(
 
 const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
   <label
-    class={{cn 'switch' checked=@isEnabled disabled=@disabled}}
+    class={{cn
+      'switch'
+      checked=@isEnabled
+      disabled=@disabled
+      has-label=(has-block)
+    }}
     data-test-switch-checked={{if @isEnabled 'on' 'off'}}
     ...attributes
   >
-    <span class='boxel-sr-only'>{{@label}}</span>
-    {{! a native checkbox's checkedness maps to aria-checked automatically;
-        an explicit binding could disagree with it }}
-    {{! template-lint-disable require-mandatory-role-attributes }}
-    <input
-      {{on 'click' (fn toggleOnClick @isEnabled @onChange)}}
-      {{on 'keydown' (fn toggleOnEnter @isEnabled @onChange)}}
-      class='switch-input'
-      type='checkbox'
-      checked={{@isEnabled}}
-      disabled={{@disabled}}
-      role='switch'
-    />
+    {{#if (has-block)}}
+      <span class='switch-label'>{{yield}}</span>
+    {{else}}
+      <span class='boxel-sr-only'>{{@label}}</span>
+    {{/if}}
+    <span class='switch-track'>
+      {{! a native checkbox's checkedness maps to aria-checked automatically;
+          an explicit binding could disagree with it }}
+      {{! template-lint-disable require-mandatory-role-attributes }}
+      <input
+        {{on 'click' (fn toggleOnClick @isEnabled @onChange)}}
+        {{on 'keydown' (fn toggleOnEnter @isEnabled @onChange)}}
+        class='switch-input'
+        type='checkbox'
+        checked={{@isEnabled}}
+        disabled={{@disabled}}
+        role='switch'
+      />
+    </span>
   </label>
 
   <style scoped>
@@ -83,16 +99,29 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
           color-mix(in oklch, var(--primary-foreground) 12%, transparent)
         );
 
+        display: inline-flex;
+        align-items: center;
+        position: relative;
+        color: var(--boxel-switch-foreground, var(--foreground));
+      }
+
+      .switch.has-label {
+        gap: var(--boxel-sp-xs);
+      }
+
+      /* With no visible label the wrapper has no other content, so it sizes
+         exactly to this track and consumer CSS on the label element keeps
+         behaving as if the label were the track itself. */
+      .switch-track {
         box-sizing: border-box;
+        flex: none;
         width: var(--_switch-width);
         height: var(--_switch-height);
         border-radius: var(--boxel-border-radius-pill);
         padding: 1px;
         display: inline-flex;
         align-items: center;
-        position: relative;
         background-color: var(--_switch-bg-color);
-        color: var(--boxel-switch-foreground, var(--foreground));
         border: 1px solid var(--border);
         box-shadow: var(--shadow-xs);
       }
@@ -113,14 +142,14 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
            foreground-derived color keeps the thumb visible in themes where
            --input and --background nearly coincide. */
         box-shadow: 0 0 0 1px var(--_switch-thumb-edge-color);
-        /* the control's ring is drawn on the label below; the UA ring here
+        /* the control's ring is drawn on the track below; the UA ring here
            would halo the thumb instead */
         outline: none;
       }
 
-      /* Extends the clickable surface past the drawn track so the control
-         meets the 24px minimum target size (WCAG 2.5.8) without growing
-         visually. Part of the label, so clicks here toggle as usual. */
+      /* Extends the clickable surface past the drawn control so it meets the
+         24px minimum target size (WCAG 2.5.8) without growing visually. Part
+         of the label, so clicks here toggle as usual. */
       .switch::before {
         content: '';
         position: absolute;
@@ -144,11 +173,11 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         );
       }
 
-      .switch.checked {
+      .switch.checked .switch-track {
         background-color: var(--_switch-active-color);
       }
 
-      .switch:has(:focus-visible) {
+      .switch:has(:focus-visible) .switch-track {
         outline: 2px solid var(--ring);
         outline-offset: 2px;
       }
@@ -161,7 +190,7 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
       }
 
       @media (prefers-reduced-motion: no-preference) {
-        .switch {
+        .switch-track {
           transition: background-color 0.1s ease-in;
         }
 

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -1,5 +1,4 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
-import { warn } from '@ember/debug';
 import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import type { ComponentLike } from '@glint/template';
@@ -21,29 +20,10 @@ interface SwitchArgs {
   checkedIcon?: ComponentLike<{ Element: Element }>;
   disabled?: boolean;
   isEnabled: boolean;
-  label?: string; /* Visually-hidden accessible name. Use default block instead to add a visible label. */
+  label?: string; /* Screen-reader-only name, rendered visually hidden. */
   onChange: (isEnabled: boolean) => void;
   size?: SwitchSize;
   uncheckedIcon?: ComponentLike<{ Element: Element }>;
-}
-
-function srOnlyLabel(label: string | undefined) {
-  warn(
-    'Switch has no accessible name: pass @label or a visible label block',
-    Boolean(label && label.trim()),
-    { id: 'boxel-ui.switch.missing-label' },
-  );
-  return label;
-}
-
-/* Warns rather than asserts so a mislabeled switch still renders */
-function warnOnRedundantLabel(label: string | undefined) {
-  warn(
-    'Switch ignores @label when a visible label block is given — the block names the control',
-    label === undefined,
-    { id: 'boxel-ui.switch.redundant-label' },
-  );
-  return '';
 }
 
 /* Intrinsic size, which prerendering needs. Tracks the @size presets
@@ -74,10 +54,10 @@ function toggleOnEnter(
   event: Event,
 ) {
   if (event instanceof KeyboardEvent && event.key === 'Enter') {
+    event.preventDefault();
     if (event.repeat) {
       return;
     }
-    event.preventDefault();
     onChange(!isEnabled);
   }
 }
@@ -95,9 +75,9 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
     ...attributes
   >
     {{#if (has-block)}}
-      <span class='switch-label'>{{warnOnRedundantLabel @label}}{{yield}}</span>
+      <span class='switch-label'>{{yield}}</span>
     {{else}}
-      <span class='boxel-sr-only'>{{srOnlyLabel @label}}</span>
+      <span class='boxel-sr-only'>{{@label}}</span>
     {{/if}}
     <span class='switch-track'>
       {{! aria-checked is derived from checked; binding it could disagree }}

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -1,5 +1,5 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
-import { assert } from '@ember/debug';
+import { assert, warn } from '@ember/debug';
 import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import type { ComponentLike } from '@glint/template';
@@ -17,44 +17,44 @@ interface SwitchSignature {
   Element: HTMLLabelElement;
 }
 interface SwitchArgs {
-  /* decorative glyph inside the thumb for the matching state; the label
-     still names the control. Skipped at size small — the thumb is too
-     small to carry a legible glyph there. */
+  /* decorative; skipped at size small, where no glyph stays legible */
   checkedIcon?: ComponentLike<{ Element: Element }>;
   disabled?: boolean;
   isEnabled: boolean;
-  /* names the switch for assistive technology when no block is given; a
-     yielded visible label names it instead, so pass one or the other.
-     Glint can't tie block presence to the args type, so the requirement
-     is asserted at render time rather than in the signature. */
-  label?: string;
+  label?: string; /* Visually-hidden accessible name. Use default block instead to add a visible label. */
   onChange: (isEnabled: boolean) => void;
   size?: SwitchSize;
   uncheckedIcon?: ComponentLike<{ Element: Element }>;
 }
 
-/* Only reached when no visible label block is given, so an empty @label
-   here means the switch would render with no accessible name at all.
-   assert is compiled out of production builds. */
+/* asserts are compiled out of production builds */
 function srOnlyLabel(label: string | undefined) {
   assert(
-    'Switch requires an accessible name: pass @label or provide a visible label block',
+    'Switch requires an accessible name: pass @label or a visible label block',
     Boolean(label && label.trim()),
   );
   return label;
 }
 
-/* explicit width/height attributes so icons carry intrinsic size (they
-   scale with the thumb per preset, not with ambient CSS) */
+/* Warns rather than asserts so a mislabeled switch still renders */
+function warnOnRedundantLabel(label: string | undefined) {
+  warn(
+    'Switch ignores @label when a visible label block is given — the block names the control',
+    label === undefined,
+    { id: 'boxel-ui.switch.redundant-label' },
+  );
+  return '';
+}
+
+/* Intrinsic size, which prerendering needs. Tracks the @size presets
+   only; .switch-thumb clamps glyphs when CSS sets the geometry. */
 function iconSize(size?: SwitchSize) {
   return size === 'touch' ? 14 : 10;
 }
 
-/* Fully controlled: preventDefault keeps the checkbox from toggling itself
-   (click covers pointer and Space alike), so the DOM checked property — and
-   the aria-checked the browser derives from it — only ever changes when
-   @isEnabled does. Without this, an @onChange that drops the value would
-   leave the native state disagreeing with the rendered one. */
+/* Fully controlled: preventDefault stops the checkbox toggling itself, so
+   checked — and the aria-checked derived from it — follows @isEnabled
+   alone, even when @onChange drops the value. Click covers Space too. */
 function toggleOnClick(
   isEnabled: boolean,
   onChange: SwitchArgs['onChange'],
@@ -64,11 +64,10 @@ function toggleOnClick(
   onChange(!isEnabled);
 }
 
-/* Enter is inert on checkboxes, listed in WAI-ARIA as optional for role=switch,
-   so it gets its own keydown path. https://www.w3.org/WAI/ARIA/apg/patterns/switch/
-   Held keys repeat keydown, and unlike Space — which reaches the click handler
-   only on keyup, once per press — nothing else throttles this path, so skip the
-   repeats and toggle once per press. */
+/* Checkboxes ignore Enter, which WAI-ARIA lists as optional for
+   role=switch, so it needs its own keydown path — and its own repeat
+   guard, since Space activates on keyup and cannot repeat.
+   https://www.w3.org/WAI/ARIA/apg/patterns/switch/ */
 function toggleOnEnter(
   isEnabled: boolean,
   onChange: SwitchArgs['onChange'],
@@ -96,13 +95,12 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
     ...attributes
   >
     {{#if (has-block)}}
-      <span class='switch-label'>{{yield}}</span>
+      <span class='switch-label'>{{warnOnRedundantLabel @label}}{{yield}}</span>
     {{else}}
       <span class='boxel-sr-only'>{{srOnlyLabel @label}}</span>
     {{/if}}
     <span class='switch-track'>
-      {{! a native checkbox's checkedness maps to aria-checked automatically;
-          an explicit binding could disagree with it }}
+      {{! aria-checked is derived from checked; binding it could disagree }}
       {{! template-lint-disable require-mandatory-role-attributes }}
       <input
         {{on 'click' (fn toggleOnClick @isEnabled @onChange)}}
@@ -113,7 +111,7 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         disabled={{@disabled}}
         role='switch'
       />
-      {{! presentational: the input above carries all semantics and state }}
+      {{! presentational: the input carries the semantics and state }}
       <span class='switch-thumb' aria-hidden='true'>
         {{#unless (eq @size 'small')}}
           {{#let (if @isEnabled @checkedIcon @uncheckedIcon) as |StateIcon|}}
@@ -143,7 +141,7 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         );
         --_switch-thumb-edge-color: var(
           --boxel-switch-thumb-edge,
-          color-mix(in oklch, var(--primary-foreground) 12%, transparent)
+          color-mix(in oklch, var(--foreground) 12%, transparent)
         );
         --_switch-thumb-icon-color: var(
           --boxel-switch-thumb-icon,
@@ -158,12 +156,8 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         display: inline-flex;
         align-items: center;
         color: var(--boxel-switch-foreground, var(--foreground));
-        /* Pads the label out to the 24px minimum target size (WCAG 2.5.8)
-           when the drawn track is smaller, without growing the track. The
-           padding is inside the element's own box, so the target never
-           overlaps a neighboring control the way an outset overlay would;
-           max() keeps it at zero once the track already clears the minimum.
-           align-items: center keeps the track centered in the padded box. */
+        /* Reaches the 24px minimum target (WCAG 2.5.8) inside the
+           element's own box, so it never covers a neighbor. */
         padding-block: max(
           0px,
           calc((var(--_switch-min-target) - var(--_switch-height)) / 2)
@@ -178,10 +172,8 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         gap: var(--boxel-sp-xs);
       }
 
-      /* Size presets set the same public knobs callers use, so all geometry
-         (thumb, travel, hit area) follows; an inline --boxel-switch-* on the
-         element still outranks them. size-base has no rule: it keeps the
-         defaults and lets ancestor-provided variables through. */
+      /* Presets set the public knobs, so all geometry follows; an inline
+         --boxel-switch-* still outranks them. */
       .switch.size-small {
         --boxel-switch-width: 1.75rem;
         --boxel-switch-height: 1rem;
@@ -193,8 +185,6 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         --boxel-switch-height: 1.625rem;
       }
 
-      /* With no visible label the wrapper has no other content, so it sizes
-         to this track plus whatever padding the minimum target size adds. */
       .switch-track {
         box-sizing: border-box;
         flex: none;
@@ -210,9 +200,8 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         box-shadow: var(--shadow-xs);
       }
 
-      /* Invisible semantic layer over the track: still the focusable,
-         checkable element and the :focus-visible source for the track's
-         ring; the sibling .switch-thumb draws what used to be here. */
+      /* Invisible, but still the focusable, checkable element and the
+         :focus-visible source for the track's ring. */
       .switch-input {
         -webkit-appearance: none;
         appearance: none;
@@ -220,8 +209,7 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         inset: 0;
         margin: 0;
         opacity: 0;
-        /* the UA gives disabled inputs their own cursor, which would
-           disagree with the control's */
+        /* the UA's disabled cursor would disagree with the control's */
         cursor: inherit;
       }
 
@@ -235,17 +223,22 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         /* icons draw with currentColor */
         color: var(--_switch-thumb-icon-color);
         border-radius: 50%;
-        /* a shadow ring, not a border: a border would add to the thumb's
-           border-box and break the height:100% + aspect-ratio square. The
-           foreground-derived color keeps the thumb visible in themes where
-           --input and --background nearly coincide. */
+        /* A shadow, not a border, which would grow the border-box and
+           break the aspect-ratio square. --foreground because it inverts:
+           this exists for themes where --input and --background meet. */
         box-shadow: 0 0 0 1px var(--_switch-thumb-edge-color);
       }
 
-      /* Thumb travel is width minus height: border and padding subtract
-         equally from the track's content box and the (square, track-height)
-         thumb, so the difference holds at any size or border/padding and the
-         thumb always lands flush against the far edge. */
+      /* The icon's intrinsic size follows @size only, so CSS-set geometry
+         could overflow the thumb. :deep: the svg is the caller's. */
+      .switch-thumb :deep(svg) {
+        max-width: 60%;
+        max-height: 60%;
+      }
+
+      /* Travel is width minus height: border and padding subtract equally
+         from the track's content box and the square thumb, so the thumb
+         lands flush against the far edge at any size. */
       .switch.checked .switch-thumb {
         background-color: var(--_switch-active-thumb-color);
         color: var(--_switch-active-thumb-icon-color);
@@ -269,9 +262,8 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         outline-offset: 2px;
       }
 
-      /* pressed-state affordance: the thumb swells slightly under the
-         pointer. `scale` composes with the checked-state translate, so it
-         works in both positions. */
+      /* scale composes with the checked translate, so the pressed thumb
+         swells in both positions */
       .switch:not(.disabled):active .switch-thumb {
         scale: 1.05;
       }

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -1,5 +1,5 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
-import { assert, warn } from '@ember/debug';
+import { warn } from '@ember/debug';
 import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import type { ComponentLike } from '@glint/template';
@@ -27,11 +27,11 @@ interface SwitchArgs {
   uncheckedIcon?: ComponentLike<{ Element: Element }>;
 }
 
-/* asserts are compiled out of production builds */
 function srOnlyLabel(label: string | undefined) {
-  assert(
-    'Switch requires an accessible name: pass @label or a visible label block',
+  warn(
+    'Switch has no accessible name: pass @label or a visible label block',
     Boolean(label && label.trim()),
+    { id: 'boxel-ui.switch.missing-label' },
   );
   return label;
 }
@@ -191,7 +191,8 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         position: relative;
         width: var(--_switch-width);
         height: var(--_switch-height);
-        border-radius: var(--boxel-border-radius-pill);
+        /* the one radius token CardContainer does not re-declare */
+        border-radius: var(--boxel-border-radius-pill, 9999px);
         padding: 1px;
         display: inline-flex;
         align-items: center;

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -1,8 +1,11 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
-import { fn } from '@ember/helper';
+import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 
 import { cn } from '../../helpers.gts';
+
+export type SwitchSize = 'small' | 'base' | 'touch';
+export const switchSizeOptions: SwitchSize[] = ['small', 'base', 'touch'];
 
 interface SwitchSignature {
   Args: SwitchArgs;
@@ -18,6 +21,7 @@ interface SwitchArgs {
      yielded visible label names it instead, so pass one or the other */
   label?: string;
   onChange: (isEnabled: boolean) => void;
+  size?: SwitchSize;
 }
 
 /* Fully controlled: preventDefault keeps the checkbox from toggling itself
@@ -51,6 +55,7 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
   <label
     class={{cn
       'switch'
+      (concat 'size-' (if @size @size 'base'))
       checked=@isEnabled
       disabled=@disabled
       has-label=(has-block)
@@ -107,6 +112,21 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
 
       .switch.has-label {
         gap: var(--boxel-sp-xs);
+      }
+
+      /* Size presets set the same public knobs callers use, so all geometry
+         (thumb, travel, hit area) follows; an inline --boxel-switch-* on the
+         element still outranks them. size-base has no rule: it keeps the
+         defaults and lets ancestor-provided variables through. */
+      .switch.size-small {
+        --boxel-switch-width: 1.75rem;
+        --boxel-switch-height: 1rem;
+      }
+
+      /* meets the 24px target size (WCAG 2.5.8) on its drawn size alone */
+      .switch.size-touch {
+        --boxel-switch-width: 2.75rem;
+        --boxel-switch-height: 1.625rem;
       }
 
       /* With no visible label the wrapper has no other content, so it sizes

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -1,9 +1,10 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
-import Component from '@glimmer/component';
 
 import { cn } from '../../helpers.gts';
 
-interface SwitchSiganture {
+interface SwitchSignature {
   Args: SwitchArgs;
   Element: HTMLLabelElement;
 }
@@ -11,90 +12,125 @@ interface SwitchArgs {
   disabled?: boolean;
   isEnabled: boolean;
   label: string;
-  onChange: () => void;
+  onChange: (isEnabled: boolean) => void;
 }
 
-// eslint-disable-next-line ember/no-empty-glimmer-component-classes
-export default class Switch extends Component<SwitchSiganture> {
-  <template>
-    <label
-      class={{cn 'switch' checked=@isEnabled disabled=@disabled}}
-      data-test-switch-checked={{if @isEnabled 'on' 'off'}}
-      ...attributes
-    >
-      <span class='boxel-sr-only'>{{@label}}</span>
-      <input
-        {{on 'click' @onChange}}
-        {{on 'keypress' @onChange}}
-        class='switch-input'
-        type='checkbox'
-        checked={{@isEnabled}}
-        disabled={{@disabled}}
-        aria-checked={{@isEnabled}}
-        role='switch'
-      />
-    </label>
+function announceChange(onChange: SwitchArgs['onChange'], event: Event) {
+  onChange((event.target as HTMLInputElement).checked);
+}
 
-    <style scoped>
-      @layer boxelComponentL1 {
-        .switch {
-          --_switch-bg-color: var(--boxel-switch-background, var(--input));
-          --_switch-active-color: var(
-            --boxel-switch-active-background,
-            var(--success, var(--primary))
-          );
-          --_switch-thumb-color: var(--boxel-switch-thumb, var(--background));
+/* Enter is inert on checkboxes, listed in WAI-ARIA as optional for role=switch,
+   so it gets its own keydown path. https://www.w3.org/WAI/ARIA/apg/patterns/switch/ */
+function toggleOnEnter(onChange: SwitchArgs['onChange'], event: KeyboardEvent) {
+  if (event.key === 'Enter') {
+    event.preventDefault();
+    onChange(!(event.target as HTMLInputElement).checked);
+  }
+}
 
-          width: var(--boxel-switch-width, 2.125rem);
-          height: var(--boxel-switch-height, 1.25rem);
-          border-radius: 1.25rem;
-          padding: 1px;
-          display: inline-flex;
-          align-items: center;
-          transition: background-color 0.1s ease-in;
-          position: relative;
-          background-color: var(--_switch-bg-color);
-          color: var(--boxel-switch-foreground, var(--foreground));
-          border: 1px solid var(--border);
-          box-shadow: var(--shadow-xs);
-        }
+const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
+  <label
+    class={{cn 'switch' checked=@isEnabled disabled=@disabled}}
+    data-test-switch-checked={{if @isEnabled 'on' 'off'}}
+    ...attributes
+  >
+    <span class='boxel-sr-only'>{{@label}}</span>
+    <input
+      {{on 'change' (fn announceChange @onChange)}}
+      {{on 'keydown' (fn toggleOnEnter @onChange)}}
+      class='switch-input'
+      type='checkbox'
+      checked={{@isEnabled}}
+      disabled={{@disabled}}
+      aria-checked={{if @isEnabled 'true' 'false'}}
+      role='switch'
+    />
+  </label>
 
-        input[type='checkbox'] {
-          appearance: none;
-        }
+  <style scoped>
+    @layer boxelComponentL1 {
+      .switch {
+        --_switch-width: var(--boxel-switch-width, 2.125rem);
+        --_switch-height: var(--boxel-switch-height, 1.25rem);
+        --_switch-bg-color: var(--boxel-switch-background, var(--input));
+        --_switch-active-color: var(
+          --boxel-switch-active-background,
+          var(--success, var(--primary))
+        );
+        --_switch-thumb-color: var(--boxel-switch-thumb, var(--background));
+        --_switch-active-thumb-color: var(
+          --boxel-switch-active-thumb,
+          var(--_switch-thumb-color)
+        );
+        --_switch-thumb-edge-color: var(
+          --boxel-switch-thumb-edge,
+          color-mix(in oklch, var(--foreground) 25%, transparent)
+        );
 
-        .switch-input {
-          margin: 0;
-          height: 100%;
-          aspect-ratio: 1;
-          background-color: var(--_switch-thumb-color);
-          border-radius: 50%;
-          margin-left: 0;
-          transition: margin-left 0.1s ease-in;
-        }
-
-        .switch.checked {
-          background-color: var(--_switch-active-color);
-        }
-
-        .switch.checked .switch-input {
-          margin-left: 49%;
-        }
-
-        .switch:hover,
-        .switch-input:hover {
-          cursor: pointer;
-        }
-
-        .switch.disabled {
-          opacity: 0.5;
-        }
-
-        .switch.disabled,
-        .switch.disabled .switch-input {
-          cursor: default;
-        }
+        box-sizing: border-box;
+        width: var(--_switch-width);
+        height: var(--_switch-height);
+        border-radius: var(--boxel-border-radius-pill);
+        padding: 1px;
+        display: inline-flex;
+        align-items: center;
+        transition: background-color 0.1s ease-in;
+        position: relative;
+        background-color: var(--_switch-bg-color);
+        color: var(--boxel-switch-foreground, var(--foreground));
+        border: 1px solid var(--border);
+        box-shadow: var(--shadow-xs);
       }
-    </style>
-  </template>
-}
+
+      .switch-input {
+        -webkit-appearance: none;
+        appearance: none;
+        margin: 0;
+        height: 100%;
+        aspect-ratio: 1;
+        background-color: var(--_switch-thumb-color);
+        border-radius: 50%;
+        /* a shadow ring, not a border: a border would add to the thumb's
+           border-box and break the height:100% + aspect-ratio square. The
+           foreground-derived color keeps the thumb visible in themes where
+           --input and --background nearly coincide. */
+        box-shadow: 0 0 0 1px var(--_switch-thumb-edge-color);
+        transition: transform 0.1s ease-in;
+        /* the control's ring is drawn on the label below; the UA ring here
+           would halo the thumb instead */
+        outline: none;
+      }
+
+      /* Thumb travel is width minus height: border and padding subtract
+         equally from the track's content box and the (square, track-height)
+         thumb, so the difference holds at any size or border/padding and the
+         thumb always lands flush right. */
+      .switch.checked .switch-input {
+        background-color: var(--_switch-active-thumb-color);
+        transform: translateX(
+          calc(var(--_switch-width) - var(--_switch-height))
+        );
+      }
+
+      .switch.checked {
+        background-color: var(--_switch-active-color);
+      }
+
+      .switch:has(:focus-visible) {
+        outline: 2px solid var(--ring);
+        outline-offset: 2px;
+      }
+
+      .switch:hover {
+        cursor: pointer;
+      }
+
+      .switch.disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+    }
+  </style>
+</template>;
+
+export default Switch;

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -147,11 +147,25 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
           --boxel-switch-active-thumb-icon,
           var(--_switch-thumb-icon-color)
         );
+        --_switch-min-target: var(--boxel-switch-min-target, 1.5rem);
 
         display: inline-flex;
         align-items: center;
-        position: relative;
         color: var(--boxel-switch-foreground, var(--foreground));
+        /* Pads the label out to the 24px minimum target size (WCAG 2.5.8)
+           when the drawn track is smaller, without growing the track. The
+           padding is inside the element's own box, so the target never
+           overlaps a neighboring control the way an outset overlay would;
+           max() keeps it at zero once the track already clears the minimum.
+           align-items: center keeps the track centered in the padded box. */
+        padding-block: max(
+          0px,
+          calc((var(--_switch-min-target) - var(--_switch-height)) / 2)
+        );
+        padding-inline: max(
+          0px,
+          calc((var(--_switch-min-target) - var(--_switch-width)) / 2)
+        );
       }
 
       .switch.has-label {
@@ -174,8 +188,7 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
       }
 
       /* With no visible label the wrapper has no other content, so it sizes
-         exactly to this track and consumer CSS on the label element keeps
-         behaving as if the label were the track itself. */
+         to this track plus whatever padding the minimum target size adds. */
       .switch-track {
         box-sizing: border-box;
         flex: none;
@@ -221,15 +234,6 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
            foreground-derived color keeps the thumb visible in themes where
            --input and --background nearly coincide. */
         box-shadow: 0 0 0 1px var(--_switch-thumb-edge-color);
-      }
-
-      /* Extends the clickable surface past the drawn control so it meets the
-         24px minimum target size (WCAG 2.5.8) without growing visually. Part
-         of the label, so clicks here toggle as usual. */
-      .switch::before {
-        content: '';
-        position: absolute;
-        inset: calc(-1 * var(--boxel-switch-hit-inset, 0.5rem));
       }
 
       /* Thumb travel is width minus height: border and padding subtract

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -15,16 +15,30 @@ interface SwitchArgs {
   onChange: (isEnabled: boolean) => void;
 }
 
-function announceChange(onChange: SwitchArgs['onChange'], event: Event) {
-  onChange((event.target as HTMLInputElement).checked);
+/* Fully controlled: preventDefault keeps the checkbox from toggling itself
+   (click covers pointer and Space alike), so the DOM checked property — and
+   the aria-checked the browser derives from it — only ever changes when
+   @isEnabled does. Without this, an @onChange that drops the value would
+   leave the native state disagreeing with the rendered one. */
+function toggleOnClick(
+  isEnabled: boolean,
+  onChange: SwitchArgs['onChange'],
+  event: Event,
+) {
+  event.preventDefault();
+  onChange(!isEnabled);
 }
 
 /* Enter is inert on checkboxes, listed in WAI-ARIA as optional for role=switch,
    so it gets its own keydown path. https://www.w3.org/WAI/ARIA/apg/patterns/switch/ */
-function toggleOnEnter(onChange: SwitchArgs['onChange'], event: KeyboardEvent) {
-  if (event.key === 'Enter') {
+function toggleOnEnter(
+  isEnabled: boolean,
+  onChange: SwitchArgs['onChange'],
+  event: Event,
+) {
+  if (event instanceof KeyboardEvent && event.key === 'Enter') {
     event.preventDefault();
-    onChange(!(event.target as HTMLInputElement).checked);
+    onChange(!isEnabled);
   }
 }
 
@@ -35,14 +49,16 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
     ...attributes
   >
     <span class='boxel-sr-only'>{{@label}}</span>
+    {{! a native checkbox's checkedness maps to aria-checked automatically;
+        an explicit binding could disagree with it }}
+    {{! template-lint-disable require-mandatory-role-attributes }}
     <input
-      {{on 'change' (fn announceChange @onChange)}}
-      {{on 'keydown' (fn toggleOnEnter @onChange)}}
+      {{on 'click' (fn toggleOnClick @isEnabled @onChange)}}
+      {{on 'keydown' (fn toggleOnEnter @isEnabled @onChange)}}
       class='switch-input'
       type='checkbox'
       checked={{@isEnabled}}
       disabled={{@disabled}}
-      aria-checked={{if @isEnabled 'true' 'false'}}
       role='switch'
     />
   </label>

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -80,7 +80,7 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         );
         --_switch-thumb-edge-color: var(
           --boxel-switch-thumb-edge,
-          color-mix(in oklch, var(--foreground) 12%, transparent)
+          color-mix(in oklch, var(--primary-foreground) 12%, transparent)
         );
 
         box-sizing: border-box;

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -132,18 +132,25 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
           var(--_switch-thumb-icon-color)
         );
         --_switch-min-target: var(--boxel-switch-min-target, 1.5rem);
+        --_switch-ring-width: 2px;
+        --_switch-ring-offset: 2px;
+        --_switch-ring-bleed: calc(
+          var(--_switch-ring-width) + var(--_switch-ring-offset)
+        );
 
         display: inline-flex;
         align-items: center;
         color: var(--boxel-switch-foreground, var(--foreground));
-        /* Reaches the 24px minimum target (WCAG 2.5.8) inside the
-           element's own box, so it never covers a neighbor. */
+        /* Reaches the 24px minimum target (WCAG 2.5.8) inside the element's
+           own box, so it never covers a neighbor — and never less than the
+           ring's bleed past the track, so a scrolling or clipping ancestor
+           cannot cut the focus ring. */
         padding-block: max(
-          0px,
+          var(--_switch-ring-bleed),
           calc((var(--_switch-min-target) - var(--_switch-height)) / 2)
         );
         padding-inline: max(
-          0px,
+          var(--_switch-ring-bleed),
           calc((var(--_switch-min-target) - var(--_switch-width)) / 2)
         );
       }
@@ -239,8 +246,8 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
       }
 
       .switch:has(:focus-visible) .switch-track {
-        outline: 2px solid var(--ring);
-        outline-offset: 2px;
+        outline: var(--_switch-ring-width) solid var(--ring);
+        outline-offset: var(--_switch-ring-offset);
       }
 
       /* scale composes with the checked translate, so the pressed thumb

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -1,8 +1,9 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
+import type { ComponentLike } from '@glint/template';
 
-import { cn } from '../../helpers.gts';
+import { cn, eq } from '../../helpers.gts';
 
 export type SwitchSize = 'small' | 'base' | 'touch';
 export const switchSizeOptions: SwitchSize[] = ['small', 'base', 'touch'];
@@ -15,6 +16,10 @@ interface SwitchSignature {
   Element: HTMLLabelElement;
 }
 interface SwitchArgs {
+  /* decorative glyph inside the thumb for the matching state; the label
+     still names the control. Skipped at size small — the thumb is too
+     small to carry a legible glyph there. */
+  checkedIcon?: ComponentLike<{ Element: Element }>;
   disabled?: boolean;
   isEnabled: boolean;
   /* names the switch for assistive technology when no block is given; a
@@ -22,6 +27,13 @@ interface SwitchArgs {
   label?: string;
   onChange: (isEnabled: boolean) => void;
   size?: SwitchSize;
+  uncheckedIcon?: ComponentLike<{ Element: Element }>;
+}
+
+/* explicit width/height attributes so icons carry intrinsic size (they
+   scale with the thumb per preset, not with ambient CSS) */
+function iconSize(size?: SwitchSize) {
+  return size === 'touch' ? 14 : 10;
 }
 
 /* Fully controlled: preventDefault keeps the checkbox from toggling itself
@@ -81,6 +93,16 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         disabled={{@disabled}}
         role='switch'
       />
+      {{! presentational: the input above carries all semantics and state }}
+      <span class='switch-thumb' aria-hidden='true'>
+        {{#unless (eq @size 'small')}}
+          {{#let (if @isEnabled @checkedIcon @uncheckedIcon) as |StateIcon|}}
+            {{#if StateIcon}}
+              <StateIcon width={{iconSize @size}} height={{iconSize @size}} />
+            {{/if}}
+          {{/let}}
+        {{/unless}}
+      </span>
     </span>
   </label>
 
@@ -102,6 +124,14 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         --_switch-thumb-edge-color: var(
           --boxel-switch-thumb-edge,
           color-mix(in oklch, var(--primary-foreground) 12%, transparent)
+        );
+        --_switch-thumb-icon-color: var(
+          --boxel-switch-thumb-icon,
+          var(--foreground)
+        );
+        --_switch-active-thumb-icon-color: var(
+          --boxel-switch-active-thumb-icon,
+          var(--_switch-thumb-icon-color)
         );
 
         display: inline-flex;
@@ -135,6 +165,7 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
       .switch-track {
         box-sizing: border-box;
         flex: none;
+        position: relative;
         width: var(--_switch-width);
         height: var(--_switch-height);
         border-radius: var(--boxel-border-radius-pill);
@@ -146,25 +177,36 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         box-shadow: var(--shadow-xs);
       }
 
+      /* Invisible semantic layer over the track: still the focusable,
+         checkable element and the :focus-visible source for the track's
+         ring; the sibling .switch-thumb draws what used to be here. */
       .switch-input {
         -webkit-appearance: none;
         appearance: none;
+        position: absolute;
+        inset: 0;
         margin: 0;
-        /* the UA gives disabled inputs their own cursor, which would make
-           the thumb disagree with the track */
+        opacity: 0;
+        /* the UA gives disabled inputs their own cursor, which would
+           disagree with the control's */
         cursor: inherit;
+      }
+
+      .switch-thumb {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         height: 100%;
         aspect-ratio: 1;
         background-color: var(--_switch-thumb-color);
+        /* icons draw with currentColor */
+        color: var(--_switch-thumb-icon-color);
         border-radius: 50%;
         /* a shadow ring, not a border: a border would add to the thumb's
            border-box and break the height:100% + aspect-ratio square. The
            foreground-derived color keeps the thumb visible in themes where
            --input and --background nearly coincide. */
         box-shadow: 0 0 0 1px var(--_switch-thumb-edge-color);
-        /* the control's ring is drawn on the track below; the UA ring here
-           would halo the thumb instead */
-        outline: none;
       }
 
       /* Extends the clickable surface past the drawn control so it meets the
@@ -180,14 +222,15 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
          equally from the track's content box and the (square, track-height)
          thumb, so the difference holds at any size or border/padding and the
          thumb always lands flush against the far edge. */
-      .switch.checked .switch-input {
+      .switch.checked .switch-thumb {
         background-color: var(--_switch-active-thumb-color);
+        color: var(--_switch-active-thumb-icon-color);
         transform: translateX(
           calc(var(--_switch-width) - var(--_switch-height))
         );
       }
 
-      .switch.checked:dir(rtl) .switch-input {
+      .switch.checked:dir(rtl) .switch-thumb {
         transform: translateX(
           calc(-1 * (var(--_switch-width) - var(--_switch-height)))
         );
@@ -205,8 +248,8 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
       /* pressed-state affordance: the thumb swells slightly under the
          pointer. `scale` composes with the checked-state translate, so it
          works in both positions. */
-      .switch:not(.disabled):active .switch-input {
-        scale: 1.15;
+      .switch:not(.disabled):active .switch-thumb {
+        scale: 1.05;
       }
 
       @media (prefers-reduced-motion: no-preference) {
@@ -214,7 +257,7 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
           transition: background-color 0.1s ease-in;
         }
 
-        .switch-input {
+        .switch-thumb {
           transition:
             transform 0.1s ease-in,
             scale 0.1s ease-in;

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -65,13 +65,19 @@ function toggleOnClick(
 }
 
 /* Enter is inert on checkboxes, listed in WAI-ARIA as optional for role=switch,
-   so it gets its own keydown path. https://www.w3.org/WAI/ARIA/apg/patterns/switch/ */
+   so it gets its own keydown path. https://www.w3.org/WAI/ARIA/apg/patterns/switch/
+   Held keys repeat keydown, and unlike Space — which reaches the click handler
+   only on keyup, once per press — nothing else throttles this path, so skip the
+   repeats and toggle once per press. */
 function toggleOnEnter(
   isEnabled: boolean,
   onChange: SwitchArgs['onChange'],
   event: Event,
 ) {
   if (event instanceof KeyboardEvent && event.key === 'Enter') {
+    if (event.repeat) {
+      return;
+    }
     event.preventDefault();
     onChange(!isEnabled);
   }

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -80,7 +80,7 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         );
         --_switch-thumb-edge-color: var(
           --boxel-switch-thumb-edge,
-          color-mix(in oklch, var(--foreground) 25%, transparent)
+          color-mix(in oklch, var(--foreground) 12%, transparent)
         );
 
         box-sizing: border-box;
@@ -90,7 +90,6 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         padding: 1px;
         display: inline-flex;
         align-items: center;
-        transition: background-color 0.1s ease-in;
         position: relative;
         background-color: var(--_switch-bg-color);
         color: var(--boxel-switch-foreground, var(--foreground));
@@ -102,6 +101,9 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         -webkit-appearance: none;
         appearance: none;
         margin: 0;
+        /* the UA gives disabled inputs their own cursor, which would make
+           the thumb disagree with the track */
+        cursor: inherit;
         height: 100%;
         aspect-ratio: 1;
         background-color: var(--_switch-thumb-color);
@@ -111,20 +113,34 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
            foreground-derived color keeps the thumb visible in themes where
            --input and --background nearly coincide. */
         box-shadow: 0 0 0 1px var(--_switch-thumb-edge-color);
-        transition: transform 0.1s ease-in;
         /* the control's ring is drawn on the label below; the UA ring here
            would halo the thumb instead */
         outline: none;
       }
 
+      /* Extends the clickable surface past the drawn track so the control
+         meets the 24px minimum target size (WCAG 2.5.8) without growing
+         visually. Part of the label, so clicks here toggle as usual. */
+      .switch::before {
+        content: '';
+        position: absolute;
+        inset: calc(-1 * var(--boxel-switch-hit-inset, 0.5rem));
+      }
+
       /* Thumb travel is width minus height: border and padding subtract
          equally from the track's content box and the (square, track-height)
          thumb, so the difference holds at any size or border/padding and the
-         thumb always lands flush right. */
+         thumb always lands flush against the far edge. */
       .switch.checked .switch-input {
         background-color: var(--_switch-active-thumb-color);
         transform: translateX(
           calc(var(--_switch-width) - var(--_switch-height))
+        );
+      }
+
+      .switch.checked:dir(rtl) .switch-input {
+        transform: translateX(
+          calc(-1 * (var(--_switch-width) - var(--_switch-height)))
         );
       }
 
@@ -137,13 +153,32 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
         outline-offset: 2px;
       }
 
+      /* pressed-state affordance: the thumb swells slightly under the
+         pointer. `scale` composes with the checked-state translate, so it
+         works in both positions. */
+      .switch:not(.disabled):active .switch-input {
+        scale: 1.15;
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+        .switch {
+          transition: background-color 0.1s ease-in;
+        }
+
+        .switch-input {
+          transition:
+            transform 0.1s ease-in,
+            scale 0.1s ease-in;
+        }
+      }
+
       .switch:hover {
         cursor: pointer;
       }
 
       .switch.disabled {
         opacity: 0.5;
-        cursor: default;
+        cursor: not-allowed;
       }
     }
   </style>

--- a/packages/boxel-ui/src/components/switch/index.gts
+++ b/packages/boxel-ui/src/components/switch/index.gts
@@ -1,4 +1,5 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { assert } from '@ember/debug';
 import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import type { ComponentLike } from '@glint/template';
@@ -23,11 +24,24 @@ interface SwitchArgs {
   disabled?: boolean;
   isEnabled: boolean;
   /* names the switch for assistive technology when no block is given; a
-     yielded visible label names it instead, so pass one or the other */
+     yielded visible label names it instead, so pass one or the other.
+     Glint can't tie block presence to the args type, so the requirement
+     is asserted at render time rather than in the signature. */
   label?: string;
   onChange: (isEnabled: boolean) => void;
   size?: SwitchSize;
   uncheckedIcon?: ComponentLike<{ Element: Element }>;
+}
+
+/* Only reached when no visible label block is given, so an empty @label
+   here means the switch would render with no accessible name at all.
+   assert is compiled out of production builds. */
+function srOnlyLabel(label: string | undefined) {
+  assert(
+    'Switch requires an accessible name: pass @label or provide a visible label block',
+    Boolean(label && label.trim()),
+  );
+  return label;
 }
 
 /* explicit width/height attributes so icons carry intrinsic size (they
@@ -78,7 +92,7 @@ const Switch: TemplateOnlyComponent<SwitchSignature> = <template>
     {{#if (has-block)}}
       <span class='switch-label'>{{yield}}</span>
     {{else}}
-      <span class='boxel-sr-only'>{{@label}}</span>
+      <span class='boxel-sr-only'>{{srOnlyLabel @label}}</span>
     {{/if}}
     <span class='switch-track'>
       {{! a native checkbox's checkedness maps to aria-checked automatically;

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -52,8 +52,10 @@ export default class SwitchUsage extends Component {
       <FreestyleUsage @name='Switch'>
         <:description>
           A switch is a component that allows the user to switch a setting on or
-          off. It toggles on click, Space, and Enter, and announces itself to
-          assistive technology as a switch.
+          off. It responds to click, Space, and Enter, and announces itself to
+          assistive technology as a switch. It is fully controlled: the switch
+          never changes state on its own — it calls onChange with the new value,
+          and only moves when isEnabled is updated to match.
         </:description>
         <:example>
           <Switch
@@ -72,7 +74,7 @@ export default class SwitchUsage extends Component {
           />
           <Args.Bool
             @name='isEnabled'
-            @description='Whether the switch is on'
+            @description='Whether the switch is on. The single source of truth: the switch only moves when this changes'
             @defaultValue={{false}}
             @value={{this.isEnabled}}
             @onInput={{fn (mut this.isEnabled)}}
@@ -87,7 +89,7 @@ export default class SwitchUsage extends Component {
           />
           <Args.Action
             @name='onChange'
-            @description='Called with the new on/off state when the user toggles the switch'
+            @description='Called with the requested on/off state when the user toggles the switch. Update isEnabled here to apply the change'
           />
         </:api>
         <:cssVars as |Css|>

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -14,54 +14,138 @@ import Switch from './index.gts';
 export default class SwitchUsage extends Component {
   @tracked isEnabled = false;
   @tracked isDisabled = false;
+  @tracked label = 'Switch';
 
   @action
-  handleChange() {
-    this.isEnabled = !this.isEnabled;
+  handleChange(isEnabled: boolean) {
+    this.isEnabled = isEnabled;
   }
 
   @cssVariable({ cssClassName: 'switch-freestyle-container' })
-  declare boxelSwitchColor: CSSVariableInfo;
+  declare boxelSwitchWidth: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'switch-freestyle-container' })
+  declare boxelSwitchHeight: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'switch-freestyle-container' })
+  declare boxelSwitchBackground: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'switch-freestyle-container' })
+  declare boxelSwitchActiveBackground: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'switch-freestyle-container' })
+  declare boxelSwitchThumb: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'switch-freestyle-container' })
+  declare boxelSwitchActiveThumb: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'switch-freestyle-container' })
+  declare boxelSwitchThumbEdge: CSSVariableInfo;
 
   <template>
     <div
-      class='header-freestyle-container'
-      style={{cssVar boxel-switch-color=this.boxelSwitchColor.value}}
+      class='switch-freestyle-container'
+      style={{cssVar
+        boxel-switch-width=this.boxelSwitchWidth.value
+        boxel-switch-height=this.boxelSwitchHeight.value
+        boxel-switch-background=this.boxelSwitchBackground.value
+        boxel-switch-active-background=this.boxelSwitchActiveBackground.value
+        boxel-switch-thumb=this.boxelSwitchThumb.value
+        boxel-switch-active-thumb=this.boxelSwitchActiveThumb.value
+        boxel-switch-thumb-edge=this.boxelSwitchThumbEdge.value
+      }}
     >
       <FreestyleUsage @name='Switch'>
         <:description>
           A switch is a component that allows the user to switch a setting on or
-          off.
+          off. It toggles on click, Space, and Enter, and announces itself to
+          assistive technology as a switch.
         </:description>
         <:example>
           <Switch
-            @label='Switch'
+            @label={{this.label}}
             @isEnabled={{this.isEnabled}}
             @onChange={{this.handleChange}}
             @disabled={{this.isDisabled}}
           />
         </:example>
         <:api as |Args|>
+          <Args.String
+            @name='label'
+            @description='Accessible label for the switch (visually hidden, read by screen readers)'
+            @value={{this.label}}
+            @onInput={{fn (mut this.label)}}
+          />
           <Args.Bool
             @name='isEnabled'
+            @description='Whether the switch is on'
             @defaultValue={{false}}
             @value={{this.isEnabled}}
             @onInput={{fn (mut this.isEnabled)}}
           />
           <Args.Bool
             @name='disabled'
+            @description='Whether the switch can be toggled'
             @defaultValue={{false}}
             @value={{this.isDisabled}}
             @onInput={{fn (mut this.isDisabled)}}
+            @optional={{true}}
+          />
+          <Args.Action
+            @name='onChange'
+            @description='Called with the new on/off state when the user toggles the switch'
           />
         </:api>
         <:cssVars as |Css|>
           <Css.Basic
-            @name='boxel-switch-color'
+            @name='boxel-switch-width'
+            @type='dimension'
+            @description='Width of the switch track'
+            @defaultValue={{this.boxelSwitchWidth.defaults}}
+            @value={{this.boxelSwitchWidth.value}}
+            @onInput={{this.boxelSwitchWidth.update}}
+          />
+          <Css.Basic
+            @name='boxel-switch-height'
+            @type='dimension'
+            @description='Height of the switch track (the thumb sizes to match)'
+            @defaultValue={{this.boxelSwitchHeight.defaults}}
+            @value={{this.boxelSwitchHeight.value}}
+            @onInput={{this.boxelSwitchHeight.update}}
+          />
+          <Css.Basic
+            @name='boxel-switch-background'
             @type='color'
-            @description='Color of the switch background (Only viewable when isEnabled=true)'
-            @value={{this.boxelSwitchColor.value}}
-            @onInput={{this.boxelSwitchColor.update}}
+            @description='Track color when the switch is off'
+            @defaultValue={{this.boxelSwitchBackground.defaults}}
+            @value={{this.boxelSwitchBackground.value}}
+            @onInput={{this.boxelSwitchBackground.update}}
+          />
+          <Css.Basic
+            @name='boxel-switch-active-background'
+            @type='color'
+            @description='Track color when the switch is on'
+            @defaultValue={{this.boxelSwitchActiveBackground.defaults}}
+            @value={{this.boxelSwitchActiveBackground.value}}
+            @onInput={{this.boxelSwitchActiveBackground.update}}
+          />
+          <Css.Basic
+            @name='boxel-switch-thumb'
+            @type='color'
+            @description='Color of the thumb'
+            @defaultValue={{this.boxelSwitchThumb.defaults}}
+            @value={{this.boxelSwitchThumb.value}}
+            @onInput={{this.boxelSwitchThumb.update}}
+          />
+          <Css.Basic
+            @name='boxel-switch-active-thumb'
+            @type='color'
+            @description='Color of the thumb when the switch is on (defaults to boxel-switch-thumb; themed light in dark mode)'
+            @defaultValue={{this.boxelSwitchActiveThumb.defaults}}
+            @value={{this.boxelSwitchActiveThumb.value}}
+            @onInput={{this.boxelSwitchActiveThumb.update}}
+          />
+          <Css.Basic
+            @name='boxel-switch-thumb-edge'
+            @type='color'
+            @description='Color of the 1px ring around the thumb (defaults to a translucent foreground mix so the thumb stays visible when track and thumb colors coincide)'
+            @defaultValue={{this.boxelSwitchThumbEdge.defaults}}
+            @value={{this.boxelSwitchThumbEdge.value}}
+            @onInput={{this.boxelSwitchThumbEdge.update}}
           />
         </:cssVars>
       </FreestyleUsage>

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -20,11 +20,6 @@ export default class SwitchUsage extends Component {
   @tracked label = 'Switch';
   @tracked size: SwitchSize = 'base';
 
-  /* Switch asserts without a label, so wait for the knob to name it */
-  get hasLabel() {
-    return Boolean(this.label && this.label.trim());
-  }
-
   @tracked isLabeledEnabled = false;
   @tracked isDarkModeEnabled = false;
 
@@ -104,34 +99,27 @@ export default class SwitchUsage extends Component {
     >
       <FreestyleUsage @name='Switch'>
         <:description>
-          A switch is a component that allows the user to switch a setting on or
-          off. It responds to click, Space, and Enter, and announces itself to
-          assistive technology as a switch. It is fully controlled: the switch
-          never changes state on its own — it calls onChange with the new value,
-          and only moves when isEnabled is updated to match. label is always
-          required — it is the accessible name. Yield a block to also render a
-          visible label beside the track, in which case label should repeat that
-          text.
+          <p>A component that allows the user to switch a setting on or off. It
+            responds to click, Space, and Enter.</p>
+
+          <p>To render with no visible label (screen-reader-only), use the
+            <code>@label</code>
+            arg. For a visible label, yield a block. Not both — the two join
+            into one announced name.</p>
         </:description>
         <:example>
-          {{#if this.hasLabel}}
-            <Switch
-              @label={{this.label}}
-              @isEnabled={{this.isEnabled}}
-              @onChange={{this.handleChange}}
-              @disabled={{this.isDisabled}}
-              @size={{this.size}}
-            />
-          {{else}}
-            <p>Set the label arg to render this example — without it (or a
-              visible label block) the switch would have no accessible name,
-              which Switch rejects in development.</p>
-          {{/if}}
+          <Switch
+            @label={{this.label}}
+            @isEnabled={{this.isEnabled}}
+            @onChange={{this.handleChange}}
+            @disabled={{this.isDisabled}}
+            @size={{this.size}}
+          />
         </:example>
         <:api as |Args|>
           <Args.String
             @name='label'
-            @description='Accessible label for the switch (visually hidden, read by screen readers). Required unless a block provides a visible label'
+            @description='Screen-reader-only name. Do not pass this and a block — the two join into one announced name'
             @value={{this.label}}
             @onInput={{fn (mut this.label)}}
             @optional={{true}}
@@ -282,9 +270,9 @@ export default class SwitchUsage extends Component {
       <FreestyleUsage @name='Switch with thumb icons'>
         <:description>
           checkedIcon and uncheckedIcon render inside the thumb for the matching
-          state. The icons are decorative — the label still names the control —
-          and they are skipped at size small, where the thumb is too small for a
-          legible glyph.
+          state. The icons are decorative — the name still comes from label or
+          the block — and they are skipped at size small, where the thumb is too
+          small for a legible glyph.
         </:description>
         <:example>
           <Switch

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -1,3 +1,5 @@
+import Moon from '@cardstack/boxel-icons/moon';
+import Sun from '@cardstack/boxel-icons/sun';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import type Owner from '@ember/owner';
@@ -19,6 +21,7 @@ export default class SwitchUsage extends Component {
   @tracked size: SwitchSize = 'base';
 
   @tracked isLabeledEnabled = false;
+  @tracked isDarkModeEnabled = false;
 
   @action
   handleChange(isEnabled: boolean) {
@@ -28,6 +31,11 @@ export default class SwitchUsage extends Component {
   @action
   handleLabeledChange(isEnabled: boolean) {
     this.isLabeledEnabled = isEnabled;
+  }
+
+  @action
+  handleDarkModeChange(isEnabled: boolean) {
+    this.isDarkModeEnabled = isEnabled;
   }
 
   @cssVariable({ cssClassName: 'switch-freestyle-container' })
@@ -44,6 +52,10 @@ export default class SwitchUsage extends Component {
   declare boxelSwitchActiveThumb: CSSVariableInfo;
   @cssVariable({ cssClassName: 'switch-freestyle-container' })
   declare boxelSwitchThumbEdge: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'switch-freestyle-container' })
+  declare boxelSwitchThumbIcon: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'switch-freestyle-container' })
+  declare boxelSwitchActiveThumbIcon: CSSVariableInfo;
 
   constructor(owner: Owner, args: Record<string, never>) {
     super(owner, args);
@@ -61,6 +73,9 @@ export default class SwitchUsage extends Component {
       this.boxelSwitchThumb,
       this.boxelSwitchActiveThumb,
       this.boxelSwitchThumbEdge,
+      this.boxelSwitchThumbIcon,
+      this.boxelSwitchActiveThumbIcon,
+      this.boxelSwitchHitInset,
     ]) {
       info.value = undefined;
     }
@@ -79,6 +94,8 @@ export default class SwitchUsage extends Component {
         boxel-switch-thumb=this.boxelSwitchThumb.value
         boxel-switch-active-thumb=this.boxelSwitchActiveThumb.value
         boxel-switch-thumb-edge=this.boxelSwitchThumbEdge.value
+        boxel-switch-thumb-icon=this.boxelSwitchThumbIcon.value
+        boxel-switch-active-thumb-icon=this.boxelSwitchActiveThumbIcon.value
         boxel-switch-hit-inset=this.boxelSwitchHitInset.value
       }}
     >
@@ -137,6 +154,16 @@ export default class SwitchUsage extends Component {
             @onInput={{fn (mut this.size)}}
             @optional={{true}}
           />
+          <Args.Component
+            @name='checkedIcon'
+            @description='Decorative icon rendered inside the thumb while the switch is on (e.g. a boxel-icons component). Skipped at size small'
+            @optional={{true}}
+          />
+          <Args.Component
+            @name='uncheckedIcon'
+            @description='Decorative icon rendered inside the thumb while the switch is off. Skipped at size small'
+            @optional={{true}}
+          />
           <Args.Action
             @name='onChange'
             @description='Called with the requested on/off state when the user toggles the switch. Update isEnabled here to apply the change'
@@ -186,7 +213,7 @@ export default class SwitchUsage extends Component {
           <Css.Basic
             @name='boxel-switch-active-thumb'
             @type='color'
-            @description='Color of the thumb when the switch is on (defaults to boxel-switch-thumb; themed light in dark mode)'
+            @description='Color of the thumb when the switch is on (defaults to boxel-switch-thumb)'
             @defaultValue={{this.boxelSwitchActiveThumb.defaults}}
             @value={{this.boxelSwitchActiveThumb.value}}
             @onInput={{this.boxelSwitchActiveThumb.update}}
@@ -194,10 +221,26 @@ export default class SwitchUsage extends Component {
           <Css.Basic
             @name='boxel-switch-thumb-edge'
             @type='color'
-            @description='Color of the 1px ring around the thumb (defaults to a translucent foreground mix so the thumb stays visible when track and thumb colors coincide)'
+            @description='Color of the 1px ring around the thumb (defaults to a translucent primary-foreground mix so the thumb stays visible when track and thumb colors coincide)'
             @defaultValue={{this.boxelSwitchThumbEdge.defaults}}
             @value={{this.boxelSwitchThumbEdge.value}}
             @onInput={{this.boxelSwitchThumbEdge.update}}
+          />
+          <Css.Basic
+            @name='boxel-switch-thumb-icon'
+            @type='color'
+            @description='Color of the thumb icon (defaults to the foreground color)'
+            @defaultValue={{this.boxelSwitchThumbIcon.defaults}}
+            @value={{this.boxelSwitchThumbIcon.value}}
+            @onInput={{this.boxelSwitchThumbIcon.update}}
+          />
+          <Css.Basic
+            @name='boxel-switch-active-thumb-icon'
+            @type='color'
+            @description='Color of the thumb icon when the switch is on (defaults to boxel-switch-thumb-icon)'
+            @defaultValue={{this.boxelSwitchActiveThumbIcon.defaults}}
+            @value={{this.boxelSwitchActiveThumbIcon.value}}
+            @onInput={{this.boxelSwitchActiveThumbIcon.update}}
           />
           <Css.Basic
             @name='boxel-switch-hit-inset'
@@ -222,6 +265,26 @@ export default class SwitchUsage extends Component {
             @onChange={{this.handleLabeledChange}}
           >
             Email notifications
+          </Switch>
+        </:example>
+      </FreestyleUsage>
+
+      <FreestyleUsage @name='Switch with thumb icons'>
+        <:description>
+          checkedIcon and uncheckedIcon render inside the thumb for the matching
+          state. The icons are decorative — the label still names the control —
+          and they are skipped at size small, where the thumb is too small for a
+          legible glyph.
+        </:description>
+        <:example>
+          <Switch
+            @isEnabled={{this.isDarkModeEnabled}}
+            @onChange={{this.handleDarkModeChange}}
+            @checkedIcon={{Moon}}
+            @uncheckedIcon={{Sun}}
+            @size='touch'
+          >
+            Dark mode
           </Switch>
         </:example>
       </FreestyleUsage>

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -17,9 +17,16 @@ export default class SwitchUsage extends Component {
   @tracked isDisabled = false;
   @tracked label = 'Switch';
 
+  @tracked isLabeledEnabled = false;
+
   @action
   handleChange(isEnabled: boolean) {
     this.isEnabled = isEnabled;
+  }
+
+  @action
+  handleLabeledChange(isEnabled: boolean) {
+    this.isLabeledEnabled = isEnabled;
   }
 
   @cssVariable({ cssClassName: 'switch-freestyle-container' })
@@ -80,7 +87,9 @@ export default class SwitchUsage extends Component {
           off. It responds to click, Space, and Enter, and announces itself to
           assistive technology as a switch. It is fully controlled: the switch
           never changes state on its own — it calls onChange with the new value,
-          and only moves when isEnabled is updated to match.
+          and only moves when isEnabled is updated to match. Pass label for a
+          visually-hidden accessible name, or yield a block to render a visible
+          label beside the track — one of the two is required.
         </:description>
         <:example>
           <Switch
@@ -93,9 +102,14 @@ export default class SwitchUsage extends Component {
         <:api as |Args|>
           <Args.String
             @name='label'
-            @description='Accessible label for the switch (visually hidden, read by screen readers)'
+            @description='Accessible label for the switch (visually hidden, read by screen readers). Not needed when a block provides a visible label'
             @value={{this.label}}
             @onInput={{fn (mut this.label)}}
+            @optional={{true}}
+          />
+          <Args.Yield
+            @description='Visible label rendered beside the track, programmatically associated with the switch'
+            @optional={{true}}
           />
           <Args.Bool
             @name='isEnabled'
@@ -183,6 +197,22 @@ export default class SwitchUsage extends Component {
             @onInput={{this.boxelSwitchHitInset.update}}
           />
         </:cssVars>
+      </FreestyleUsage>
+
+      <FreestyleUsage @name='Switch with a visible label'>
+        <:description>
+          Yielding a block renders it as a visible label beside the track;
+          clicking the text toggles the switch, and it names the control for
+          assistive technology, so no label arg is needed.
+        </:description>
+        <:example>
+          <Switch
+            @isEnabled={{this.isLabeledEnabled}}
+            @onChange={{this.handleLabeledChange}}
+          >
+            Email notifications
+          </Switch>
+        </:example>
       </FreestyleUsage>
     </div>
   </template>

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -231,7 +231,7 @@ export default class SwitchUsage extends Component {
           <Css.Basic
             @name='boxel-switch-thumb-edge'
             @type='color'
-            @description='Color of the 1px ring around the thumb (defaults to a translucent primary-foreground mix so the thumb stays visible when track and thumb colors coincide)'
+            @description='Color of the 1px ring around the thumb (defaults to a translucent foreground mix)'
             @defaultValue={{this.boxelSwitchThumbEdge.defaults}}
             @value={{this.boxelSwitchThumbEdge.value}}
             @onInput={{this.boxelSwitchThumbEdge.update}}

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -10,12 +10,13 @@ import {
 } from 'ember-freestyle/decorators/css-variable';
 
 import cssVar from '../../helpers/css-var.ts';
-import Switch from './index.gts';
+import Switch, { type SwitchSize, switchSizeOptions } from './index.gts';
 
 export default class SwitchUsage extends Component {
   @tracked isEnabled = false;
   @tracked isDisabled = false;
   @tracked label = 'Switch';
+  @tracked size: SwitchSize = 'base';
 
   @tracked isLabeledEnabled = false;
 
@@ -97,6 +98,7 @@ export default class SwitchUsage extends Component {
             @isEnabled={{this.isEnabled}}
             @onChange={{this.handleChange}}
             @disabled={{this.isDisabled}}
+            @size={{this.size}}
           />
         </:example>
         <:api as |Args|>
@@ -124,6 +126,15 @@ export default class SwitchUsage extends Component {
             @defaultValue={{false}}
             @value={{this.isDisabled}}
             @onInput={{fn (mut this.isDisabled)}}
+            @optional={{true}}
+          />
+          <Args.String
+            @name='size'
+            @description='Size preset for the track; thumb, travel, and hit area follow. Custom sizes remain available via the width/height CSS variables'
+            @defaultValue='base'
+            @options={{switchSizeOptions}}
+            @value={{this.size}}
+            @onInput={{fn (mut this.size)}}
             @optional={{true}}
           />
           <Args.Action

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -119,13 +119,13 @@ export default class SwitchUsage extends Component {
         <:api as |Args|>
           <Args.String
             @name='label'
-            @description='Screen-reader-only name. Do not pass this and a block — the two join into one announced name'
+            @description='Screen-reader-only name. Not needed if passing in a block as label'
             @value={{this.label}}
             @onInput={{fn (mut this.label)}}
             @optional={{true}}
           />
           <Args.Yield
-            @description='Visible label rendered beside the track, programmatically associated with the switch'
+            @description='Visible label rendered beside the track'
             @optional={{true}}
           />
           <Args.Bool
@@ -154,12 +154,12 @@ export default class SwitchUsage extends Component {
           />
           <Args.Component
             @name='checkedIcon'
-            @description='Decorative icon rendered inside the thumb while the switch is on (e.g. a boxel-icons component). Skipped at size small'
+            @description='Decorative icon for the "on" switch thumb. Skipped at size small'
             @optional={{true}}
           />
           <Args.Component
             @name='uncheckedIcon'
-            @description='Decorative icon rendered inside the thumb while the switch is off. Skipped at size small'
+            @description='Decorative icon for the "off" switch thumb. Skipped at size small'
             @optional={{true}}
           />
           <Args.Action
@@ -243,7 +243,7 @@ export default class SwitchUsage extends Component {
           <Css.Basic
             @name='boxel-switch-min-target'
             @type='dimension'
-            @description='Minimum clickable size of the control (default 1.5rem, the 24px minimum target size). The label pads itself out to this size when the drawn track is smaller; the padding stays inside the element, so it never overlaps neighbouring controls'
+            @description='Minimum clickable size (default 1.5rem, the WCAG 24px target), including padding for focus ring.'
             @defaultValue={{this.boxelSwitchMinTarget.defaults}}
             @value={{this.boxelSwitchMinTarget.value}}
             @onInput={{this.boxelSwitchMinTarget.update}}
@@ -281,9 +281,8 @@ export default class SwitchUsage extends Component {
             @checkedIcon={{Moon}}
             @uncheckedIcon={{Sun}}
             @size='touch'
-          >
-            Dark mode
-          </Switch>
+            @label='Dark Mode'
+          />
         </:example>
       </FreestyleUsage>
     </div>

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -81,13 +81,13 @@ export default class SwitchUsage extends Component {
       this.boxelSwitchThumbEdge,
       this.boxelSwitchThumbIcon,
       this.boxelSwitchActiveThumbIcon,
-      this.boxelSwitchHitInset,
+      this.boxelSwitchMinTarget,
     ]) {
       info.value = undefined;
     }
   }
   @cssVariable({ cssClassName: 'switch-freestyle-container' })
-  declare boxelSwitchHitInset: CSSVariableInfo;
+  declare boxelSwitchMinTarget: CSSVariableInfo;
 
   <template>
     <div
@@ -102,7 +102,7 @@ export default class SwitchUsage extends Component {
         boxel-switch-thumb-edge=this.boxelSwitchThumbEdge.value
         boxel-switch-thumb-icon=this.boxelSwitchThumbIcon.value
         boxel-switch-active-thumb-icon=this.boxelSwitchActiveThumbIcon.value
-        boxel-switch-hit-inset=this.boxelSwitchHitInset.value
+        boxel-switch-min-target=this.boxelSwitchMinTarget.value
       }}
     >
       <FreestyleUsage @name='Switch'>
@@ -255,12 +255,12 @@ export default class SwitchUsage extends Component {
             @onInput={{this.boxelSwitchActiveThumbIcon.update}}
           />
           <Css.Basic
-            @name='boxel-switch-hit-inset'
+            @name='boxel-switch-min-target'
             @type='dimension'
-            @description='How far the clickable area extends past the visible track on each side (default 0.5rem, meeting the 24px minimum target size). Reduce it if switches sit closer together than the default reach'
-            @defaultValue={{this.boxelSwitchHitInset.defaults}}
-            @value={{this.boxelSwitchHitInset.value}}
-            @onInput={{this.boxelSwitchHitInset.update}}
+            @description='Minimum clickable size of the control (default 1.5rem, the 24px minimum target size). The label pads itself out to this size when the drawn track is smaller; the padding stays inside the element, so it never overlaps neighbouring controls'
+            @defaultValue={{this.boxelSwitchMinTarget.defaults}}
+            @value={{this.boxelSwitchMinTarget.value}}
+            @onInput={{this.boxelSwitchMinTarget.update}}
           />
         </:cssVars>
       </FreestyleUsage>

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -20,6 +20,12 @@ export default class SwitchUsage extends Component {
   @tracked label = 'Switch';
   @tracked size: SwitchSize = 'base';
 
+  /* Switch asserts when it has neither a label nor a visible label block,
+     so the example only renders once the knob names it. */
+  get hasLabel() {
+    return Boolean(this.label && this.label.trim());
+  }
+
   @tracked isLabeledEnabled = false;
   @tracked isDarkModeEnabled = false;
 
@@ -110,18 +116,24 @@ export default class SwitchUsage extends Component {
           label beside the track — one of the two is required.
         </:description>
         <:example>
-          <Switch
-            @label={{this.label}}
-            @isEnabled={{this.isEnabled}}
-            @onChange={{this.handleChange}}
-            @disabled={{this.isDisabled}}
-            @size={{this.size}}
-          />
+          {{#if this.hasLabel}}
+            <Switch
+              @label={{this.label}}
+              @isEnabled={{this.isEnabled}}
+              @onChange={{this.handleChange}}
+              @disabled={{this.isDisabled}}
+              @size={{this.size}}
+            />
+          {{else}}
+            <p>Set the label arg to render this example — without it (or a
+              visible label block) the switch would have no accessible name,
+              which Switch rejects in development.</p>
+          {{/if}}
         </:example>
         <:api as |Args|>
           <Args.String
             @name='label'
-            @description='Accessible label for the switch (visually hidden, read by screen readers). Not needed when a block provides a visible label'
+            @description='Accessible label for the switch (visually hidden, read by screen readers). Required unless a block provides a visible label'
             @value={{this.label}}
             @onInput={{fn (mut this.label)}}
             @optional={{true}}

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -1,5 +1,6 @@
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
@@ -36,6 +37,29 @@ export default class SwitchUsage extends Component {
   @cssVariable({ cssClassName: 'switch-freestyle-container' })
   declare boxelSwitchThumbEdge: CSSVariableInfo;
 
+  constructor(owner: Owner, args: Record<string, never>) {
+    super(owner, args);
+    /* ember-freestyle seeds each CSSVariableInfo.value with the value computed
+       on a temp element at document.body — outside the themed docs container —
+       so the seed pins the chrome's :root values on the preview via inline
+       style and stops it from following theme cycling and dark mode. Clear the
+       seeds so the preview inherits the active theme until a control is
+       touched. */
+    for (let info of [
+      this.boxelSwitchWidth,
+      this.boxelSwitchHeight,
+      this.boxelSwitchBackground,
+      this.boxelSwitchActiveBackground,
+      this.boxelSwitchThumb,
+      this.boxelSwitchActiveThumb,
+      this.boxelSwitchThumbEdge,
+    ]) {
+      info.value = undefined;
+    }
+  }
+  @cssVariable({ cssClassName: 'switch-freestyle-container' })
+  declare boxelSwitchHitInset: CSSVariableInfo;
+
   <template>
     <div
       class='switch-freestyle-container'
@@ -47,6 +71,7 @@ export default class SwitchUsage extends Component {
         boxel-switch-thumb=this.boxelSwitchThumb.value
         boxel-switch-active-thumb=this.boxelSwitchActiveThumb.value
         boxel-switch-thumb-edge=this.boxelSwitchThumbEdge.value
+        boxel-switch-hit-inset=this.boxelSwitchHitInset.value
       }}
     >
       <FreestyleUsage @name='Switch'>
@@ -148,6 +173,14 @@ export default class SwitchUsage extends Component {
             @defaultValue={{this.boxelSwitchThumbEdge.defaults}}
             @value={{this.boxelSwitchThumbEdge.value}}
             @onInput={{this.boxelSwitchThumbEdge.update}}
+          />
+          <Css.Basic
+            @name='boxel-switch-hit-inset'
+            @type='dimension'
+            @description='How far the clickable area extends past the visible track on each side (default 0.5rem, meeting the 24px minimum target size). Reduce it if switches sit closer together than the default reach'
+            @defaultValue={{this.boxelSwitchHitInset.defaults}}
+            @value={{this.boxelSwitchHitInset.value}}
+            @onInput={{this.boxelSwitchHitInset.update}}
           />
         </:cssVars>
       </FreestyleUsage>

--- a/packages/boxel-ui/src/components/switch/usage.gts
+++ b/packages/boxel-ui/src/components/switch/usage.gts
@@ -20,8 +20,7 @@ export default class SwitchUsage extends Component {
   @tracked label = 'Switch';
   @tracked size: SwitchSize = 'base';
 
-  /* Switch asserts when it has neither a label nor a visible label block,
-     so the example only renders once the knob names it. */
+  /* Switch asserts without a label, so wait for the knob to name it */
   get hasLabel() {
     return Boolean(this.label && this.label.trim());
   }
@@ -65,12 +64,10 @@ export default class SwitchUsage extends Component {
 
   constructor(owner: Owner, args: Record<string, never>) {
     super(owner, args);
-    /* ember-freestyle seeds each CSSVariableInfo.value with the value computed
-       on a temp element at document.body — outside the themed docs container —
-       so the seed pins the chrome's :root values on the preview via inline
-       style and stops it from following theme cycling and dark mode. Clear the
-       seeds so the preview inherits the active theme until a control is
-       touched. */
+    /* ember-freestyle seeds each value from a temp element at
+       document.body, outside the themed docs container, pinning the
+       chrome's :root values on the preview via inline style. Clear the
+       seeds so it follows theme cycling until a control is touched. */
     for (let info of [
       this.boxelSwitchWidth,
       this.boxelSwitchHeight,
@@ -111,9 +108,10 @@ export default class SwitchUsage extends Component {
           off. It responds to click, Space, and Enter, and announces itself to
           assistive technology as a switch. It is fully controlled: the switch
           never changes state on its own — it calls onChange with the new value,
-          and only moves when isEnabled is updated to match. Pass label for a
-          visually-hidden accessible name, or yield a block to render a visible
-          label beside the track — one of the two is required.
+          and only moves when isEnabled is updated to match. label is always
+          required — it is the accessible name. Yield a block to also render a
+          visible label beside the track, in which case label should repeat that
+          text.
         </:description>
         <:example>
           {{#if this.hasLabel}}
@@ -269,7 +267,7 @@ export default class SwitchUsage extends Component {
         <:description>
           Yielding a block renders it as a visible label beside the track;
           clicking the text toggles the switch, and it names the control for
-          assistive technology, so no label arg is needed.
+          assistive technology, so no label arg is passed.
         </:description>
         <:example>
           <Switch

--- a/packages/boxel-ui/src/styles/theme.css
+++ b/packages/boxel-ui/src/styles/theme.css
@@ -60,7 +60,7 @@
 
   /* form + focus */
   --border: var(--boxel-border-color);
-  --input: var(--boxel-light);
+  --input: var(--boxel-300);
   --ring: var(--boxel-highlight);
 
   /* charts */
@@ -216,7 +216,7 @@
   --destructive: var(--boxel-danger);
   --destructive-foreground: var(--boxel-light-100);
   --border: var(--boxel-550);
-  --input: var(--boxel-dark);
+  --input: var(--boxel-550);
   --ring: var(--boxel-highlight);
   --sidebar: #555366;
   --sidebar-foreground: var(--boxel-light);

--- a/packages/boxel-ui/src/styles/theme.css
+++ b/packages/boxel-ui/src/styles/theme.css
@@ -165,6 +165,8 @@
   --theme-caption-font-size: initial;
   --theme-caption-font-weight: initial;
   --theme-caption-line-height: initial;
+  --boxel-switch-background: initial;
+  --boxel-switch-thumb: initial;
   --boxel-switch-active-thumb: initial;
   --boxel-switch-thumb-icon: initial;
   --boxel-switch-active-thumb-icon: initial;
@@ -226,6 +228,8 @@
   --sidebar-accent-foreground: var(--boxel-light);
   --sidebar-border: var(--boxel-550);
   --sidebar-ring: var(--boxel-highlight);
+  --boxel-switch-thumb: var(--boxel-light);
+  --boxel-switch-thumb-icon: var(--background);
   --boxel-button-default-border: var(--border);
   --boxel-button-default-active-background: var(--background);
   --boxel-button-default-active-foreground: var(--foreground);

--- a/packages/boxel-ui/src/styles/theme.css
+++ b/packages/boxel-ui/src/styles/theme.css
@@ -167,6 +167,7 @@
   --theme-caption-font-weight: initial;
   --theme-caption-line-height: initial;
   --boxel-switch-background: initial;
+  --boxel-switch-active-thumb: initial;
   --boxel-button-default-border: initial;
   --boxel-button-default-active-background: initial;
   --boxel-button-default-active-foreground: initial;
@@ -225,6 +226,10 @@
   --sidebar-accent-foreground: var(--boxel-light);
   --sidebar-border: var(--boxel-550);
   --sidebar-ring: var(--boxel-highlight);
+  /* the thumb's --background default is near-invisible on the checked track's
+     dark green; the unchecked track stays light gray, so only the checked
+     state needs a light thumb */
+  --boxel-switch-active-thumb: var(--foreground);
   --boxel-button-default-border: var(--border);
   --boxel-button-default-active-background: var(--background);
   --boxel-button-default-active-foreground: var(--foreground);

--- a/packages/boxel-ui/src/styles/theme.css
+++ b/packages/boxel-ui/src/styles/theme.css
@@ -60,7 +60,7 @@
 
   /* form + focus */
   --border: var(--boxel-border-color);
-  --input: var(--boxel-300);
+  --input: var(--boxel-400);
   --ring: var(--boxel-highlight);
 
   /* charts */
@@ -118,7 +118,6 @@
   --warning: var(--boxel-warning);
 
   /* other */
-  --boxel-switch-background: var(--boxel-400);
   --boxel-button-default-border: var(--boxel-button-border-color);
   --boxel-button-default-active-background: var(--background);
   --boxel-button-default-active-foreground: var(--foreground);
@@ -166,7 +165,6 @@
   --theme-caption-font-size: initial;
   --theme-caption-font-weight: initial;
   --theme-caption-line-height: initial;
-  --boxel-switch-background: initial;
   --boxel-switch-active-thumb: initial;
   --boxel-switch-thumb-icon: initial;
   --boxel-switch-active-thumb-icon: initial;

--- a/packages/boxel-ui/src/styles/theme.css
+++ b/packages/boxel-ui/src/styles/theme.css
@@ -168,6 +168,8 @@
   --theme-caption-line-height: initial;
   --boxel-switch-background: initial;
   --boxel-switch-active-thumb: initial;
+  --boxel-switch-thumb-icon: initial;
+  --boxel-switch-active-thumb-icon: initial;
   --boxel-button-default-border: initial;
   --boxel-button-default-active-background: initial;
   --boxel-button-default-active-foreground: initial;
@@ -226,10 +228,6 @@
   --sidebar-accent-foreground: var(--boxel-light);
   --sidebar-border: var(--boxel-550);
   --sidebar-ring: var(--boxel-highlight);
-  /* the thumb's --background default is near-invisible on the checked track's
-     dark green; the unchecked track stays light gray, so only the checked
-     state needs a light thumb */
-  --boxel-switch-active-thumb: var(--foreground);
   --boxel-button-default-border: var(--border);
   --boxel-button-default-active-background: var(--background);
   --boxel-button-default-active-foreground: var(--foreground);

--- a/packages/boxel-ui/tests/integration/components/switch-test.gts
+++ b/packages/boxel-ui/tests/integration/components/switch-test.gts
@@ -1,0 +1,165 @@
+import { Switch } from '@cardstack/boxel-ui/components';
+import { click, render, settled, triggerKeyEvent } from '@ember/test-helpers';
+import { tracked } from '@glimmer/tracking';
+import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../helpers';
+
+const SWITCH = '[data-test-switch-checked]';
+const INPUT = '[data-test-switch-checked] input';
+
+// triggerKeyEvent's modifiers do not include `repeat`, so the auto-repeat
+// keydown a held key produces has to be dispatched directly.
+async function pressEnter(repeat = false) {
+  let input = document.querySelector(INPUT);
+  if (!input) {
+    throw new Error(`expected to find ${INPUT}`);
+  }
+  input.dispatchEvent(
+    new KeyboardEvent('keydown', { bubbles: true, key: 'Enter', repeat }),
+  );
+  await settled();
+}
+
+class SwitchState {
+  @tracked isEnabled = false;
+  calls: boolean[] = [];
+
+  // Applies what the switch asks for, the way a normal caller would.
+  accept = (isEnabled: boolean) => {
+    this.calls.push(isEnabled);
+    this.isEnabled = isEnabled;
+  };
+
+  // Records the request and drops it, leaving @isEnabled where it was.
+  ignore = (isEnabled: boolean) => {
+    this.calls.push(isEnabled);
+  };
+}
+
+module('Integration | Component | switch', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('Space activation routes through click alone', async function (assert) {
+    let state = new SwitchState();
+    await render(
+      <template>
+        <Switch
+          @label='Notifications'
+          @isEnabled={{state.isEnabled}}
+          @onChange={{state.accept}}
+        />
+      </template>,
+    );
+
+    // The browser turns a Space press on a checkbox into a click, which
+    // test helpers do not synthesize — so drive the two halves separately.
+    // A keypress binding alongside the click one is what made Space fire
+    // twice; if any returns, the count here goes to 2.
+    await triggerKeyEvent(INPUT, 'keypress', ' ');
+    assert.deepEqual(state.calls, [], 'keypress alone does not toggle');
+
+    await click(INPUT);
+    assert.deepEqual(state.calls, [true], 'one onChange call for one press');
+    assert.dom(SWITCH).hasAttribute('data-test-switch-checked', 'on');
+  });
+
+  test('Enter toggles once and ignores auto-repeat', async function (assert) {
+    let state = new SwitchState();
+    await render(
+      <template>
+        <Switch
+          @label='Notifications'
+          @isEnabled={{state.isEnabled}}
+          @onChange={{state.accept}}
+        />
+      </template>,
+    );
+
+    await pressEnter();
+    assert.deepEqual(state.calls, [true], 'the first keydown toggles');
+
+    // Held keys repeat keydown; without the repeat guard each one would call
+    // @onChange, which for a realm-backed switch is a burst of writes.
+    for (let i = 0; i < 3; i++) {
+      await pressEnter(true);
+    }
+    assert.deepEqual(state.calls, [true], 'repeats are ignored');
+
+    await triggerKeyEvent(INPUT, 'keyup', 'Enter');
+    await pressEnter();
+    assert.deepEqual(state.calls, [true, false], 'a fresh press toggles again');
+  });
+
+  test('stays on @isEnabled when onChange drops the value', async function (assert) {
+    let state = new SwitchState();
+    await render(
+      <template>
+        <Switch
+          @label='Notifications'
+          @isEnabled={{state.isEnabled}}
+          @onChange={{state.ignore}}
+        />
+      </template>,
+    );
+
+    await click(INPUT);
+
+    assert.deepEqual(state.calls, [true], 'the switch requested the change');
+    // The native checkbox would have flipped itself here, leaving the DOM
+    // state — and the aria-checked derived from it — disagreeing with
+    // @isEnabled.
+    assert.dom(INPUT).isNotChecked();
+    assert.dom(SWITCH).hasAttribute('data-test-switch-checked', 'off');
+  });
+
+  test('a disabled switch does not report changes', async function (assert) {
+    let state = new SwitchState();
+    await render(
+      <template>
+        <Switch
+          @label='Notifications'
+          @isEnabled={{state.isEnabled}}
+          @onChange={{state.accept}}
+          @disabled={{true}}
+        />
+      </template>,
+    );
+
+    // Clicking the label is the only route left: a disabled input takes
+    // neither pointer nor keyboard events, and the test helpers refuse to
+    // fake them.
+    await click(SWITCH);
+
+    assert.deepEqual(state.calls, [], 'no onChange calls');
+  });
+
+  test('names the control from @label or a visible label block', async function (assert) {
+    let state = new SwitchState();
+    await render(
+      <template>
+        <Switch
+          @label='Notifications'
+          @isEnabled={{state.isEnabled}}
+          @onChange={{state.accept}}
+          data-test-hidden-label
+        />
+        <Switch
+          @isEnabled={{state.isEnabled}}
+          @onChange={{state.accept}}
+          data-test-visible-label
+        >Email notifications</Switch>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-hidden-label] .boxel-sr-only')
+      .hasText('Notifications');
+    assert
+      .dom('[data-test-visible-label] .switch-label')
+      .hasText('Email notifications');
+    // The block is the label element's own text, so it names the input
+    // without a second labeling mechanism.
+    assert.dom('[data-test-visible-label] .boxel-sr-only').doesNotExist();
+  });
+});

--- a/packages/boxel-ui/tests/integration/components/switch-test.gts
+++ b/packages/boxel-ui/tests/integration/components/switch-test.gts
@@ -15,10 +15,15 @@ async function pressEnter(repeat = false) {
   if (!input) {
     throw new Error(`expected to find ${INPUT}`);
   }
-  input.dispatchEvent(
-    new KeyboardEvent('keydown', { bubbles: true, key: 'Enter', repeat }),
-  );
+  let event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key: 'Enter',
+    repeat,
+  });
+  input.dispatchEvent(event);
   await settled();
+  return event;
 }
 
 class SwitchState {
@@ -132,6 +137,29 @@ module('Integration | Component | switch', function (hooks) {
     await click(SWITCH);
 
     assert.deepEqual(state.calls, [], 'no onChange calls');
+  });
+
+  test('every Enter keydown is prevented, auto-repeat included', async function (assert) {
+    let state = new SwitchState();
+    await render(
+      <template>
+        <Switch
+          @label='Notifications'
+          @isEnabled={{state.isEnabled}}
+          @onChange={{state.accept}}
+        />
+      </template>,
+    );
+
+    assert.true((await pressEnter()).defaultPrevented, 'the first press');
+    // A repeat that reaches the UA unprevented is an implicit submit for
+    // any switch inside a form — every card edit template. Asserted on the
+    // event because a synthetic keydown never submits a form on its own.
+    for (let i = 0; i < 3; i++) {
+      assert.true((await pressEnter(true)).defaultPrevented, `repeat ${i}`);
+    }
+
+    assert.deepEqual(state.calls, [true], 'still one toggle for one press');
   });
 
   test('names the control from @label or a visible label block', async function (assert) {


### PR DESCRIPTION
Overhauls the boxel-ui Switch per [CS-12328](https://linear.app/cardstack/issue/CS-12328/boxel-ui-switch-geometry-focus-sizing-and-api-fixes-shared-pill), benchmarked against React Aria, Radix/shadcn, Material, and the WAI-ARIA switch pattern.

**Behavior & accessibility**

- One `click` binding replaces the `click` + `keypress` pair that double-fired on Space; Enter gets its own keydown path, guarded against auto-repeat so a held key toggles once
- Fully controlled — the input's default toggle is prevented, so `checked` and the derived `aria-checked` change only when `@isEnabled` does
- `:focus-visible` ring on the track, UA halo on the inner input suppressed
- Padding on the label reaches the WCAG 2.5.8 24px minimum target inside the element's own box, so the target never covers a neighboring control (`--boxel-switch-min-target` to tune)
- Thumb travel is `translateX(width − height)`: flush at both ends at any size, direction-aware under RTL, `prefers-reduced-motion` guarded

**API**

- `@size` presets `small` / `base` / `touch`, driving the same public `--boxel-switch-width`/`-height` knobs callers use
- `@checkedIcon` / `@uncheckedIcon` render a decorative glyph in the thumb

**Also in boxel-ui**

- `FieldContainer`: inline rows allow enough bleed for a control's focus ring instead of clipping it
- `CardContainer`: the `--boxel-sp-*` / font-size / radius derivations terminate in literals, so one unresolved `var()` no longer collapses the whole scale

Usage page covers the label block, icons, and size presets, with knobs for every `--boxel-switch-*` variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
