### PR TITLE
Add Upload File to the interact-mode New menu

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -452,14 +452,18 @@ export default class CodeSubmode extends Component<Signature> {
         ];
       },
     );
-    items.push(new MenuDivider());
-    items.push(
-      new MenuItem({
-        label: 'Upload File…',
-        action: () => this.triggerUploadFile(),
-        icon: Upload,
-      }),
-    );
+    // An upload needs a destination realm, so the entry (and its divider)
+    // only appears once the current file's realm is known.
+    if (this.operatorModeStateService.realmURL) {
+      items.push(new MenuDivider());
+      items.push(
+        new MenuItem({
+          label: 'Upload File…',
+          action: () => this.triggerUploadFile(),
+          icon: Upload,
+        }),
+      );
+    }
     return items;
   }
 
@@ -595,9 +599,11 @@ export default class CodeSubmode extends Component<Signature> {
 
   @action
   private triggerUploadFile() {
+    // The menu omits this entry when no realm is known, so the guard is a
+    // no-op backstop rather than an error path.
     let realm = this.operatorModeStateService.realmURL;
     if (!realm) {
-      throw new Error('No realm available for upload');
+      return;
     }
     this.uploadFiles.perform(ri(realm)).catch((error) => {
       console.error('Unexpected error during file upload', error);
@@ -605,20 +611,7 @@ export default class CodeSubmode extends Component<Signature> {
   }
 
   private uploadFiles = dropTask(async (realm: RealmIdentifier) => {
-    let files = await this.fileUpload.pickLocalFiles({});
-    if (files.length === 0) {
-      return;
-    }
-    // Parallel POSTs are correct on the server: the realm advisory
-    // lock (packages/runtime-common/realm.ts:1746) serializes writes
-    // and each upload emits its own incremental-index event. A
-    // separate live file-tree refresh race (uploads AND deletes both
-    // leave the tree stale until the user refreshes / toggles views)
-    // is tracked in CS-11295.
-    let tasks = files.map((file) =>
-      this.fileUpload.uploadProvidedFile({ realm, file }),
-    );
-    let results = await Promise.all(tasks.map((task) => task.result));
+    let results = await this.fileUpload.pickAndUploadFiles(realm);
     let firstSuccess = results.find((fileDef) => fileDef?.url);
     if (firstSuccess?.url) {
       await this.operatorModeStateService.updateCodePath(

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -17,7 +17,12 @@ import { get } from 'lodash-es';
 import { TrackedWeakMap, TrackedSet } from 'tracked-built-ins';
 
 import { cn, gt, MenuItem, MenuDivider } from '@cardstack/boxel-ui/helpers';
-import { IconCode, IconSearch, type Icon } from '@cardstack/boxel-ui/icons';
+import {
+  IconCode,
+  IconSearch,
+  Upload,
+  type Icon,
+} from '@cardstack/boxel-ui/icons';
 
 import {
   chooseCard,
@@ -35,6 +40,7 @@ import {
   CardError,
   loadCardDef,
   localId as localIdSymbol,
+  ri,
   rri,
   specRef,
   type getCard,
@@ -43,6 +49,7 @@ import {
   type CodeRef,
   type LooseSingleCardDocument,
   type LocalPath,
+  type RealmIdentifier,
   type RealmResourceIdentifier,
   type ResolvedCodeRef,
   type Filter,
@@ -82,6 +89,7 @@ import type { CardDefOrId } from './stack-item';
 import type { StackItemComponentAPI } from './stack-item';
 
 import type CardService from '../../services/card-service';
+import type FileUploadService from '../../services/file-upload';
 import type LoaderService from '../../services/loader-service';
 import type NetworkService from '../../services/network';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
@@ -140,6 +148,7 @@ export default class InteractSubmode extends Component {
   @consume(CardContextName) declare private cardContext: CardContext;
 
   @service declare private cardService: CardService;
+  @service('file-upload') declare private fileUpload: FileUploadService;
   @service declare private toolService: ToolService;
   @service declare private operatorModeStateService: OperatorModeStateService;
   @service declare private store: StoreService;
@@ -799,6 +808,11 @@ export default class InteractSubmode extends Component {
         action: () => this.createCardInstance.perform(),
         icon: IconSearch,
       }),
+      new MenuItem({
+        label: 'Upload File…',
+        action: () => this.triggerUploadFile(),
+        icon: Upload,
+      }),
       new MenuDivider(),
       new MenuItem({
         label: 'Open Code Mode',
@@ -823,6 +837,39 @@ export default class InteractSubmode extends Component {
     this.operatorModeStateService.setNewFileDropdownOpen();
     this.operatorModeStateService.updateSubmode('code');
   };
+
+  @action
+  private triggerUploadFile() {
+    // Same destination convention as the other create actions in this
+    // menu: the current workspace when it is writable, otherwise the
+    // default writable realm.
+    let realm = this.operatorModeStateService.getWritableRealmURL();
+    if (!realm) {
+      throw new Error('No writable realm found');
+    }
+    this.uploadFiles.perform(ri(realm.href)).catch((error) => {
+      console.error('Unexpected error during file upload', error);
+    });
+  }
+
+  private uploadFiles = dropTask(async (realm: RealmIdentifier) => {
+    let files = await this.fileUpload.pickLocalFiles({});
+    if (files.length === 0) {
+      return;
+    }
+    // Parallel POSTs are safe: the realm advisory lock serializes
+    // writes server-side (packages/runtime-common/realm.ts).
+    let tasks = files.map((file) =>
+      this.fileUpload.uploadProvidedFile({ realm, file }),
+    );
+    let results = await Promise.all(tasks.map((task) => task.result));
+    let firstSuccess = results.find((fileDef) => fileDef?.url);
+    if (firstSuccess?.url) {
+      this.viewCard(this.rightMostStackIndex, firstSuccess.url, 'isolated', {
+        type: 'file',
+      });
+    }
+  });
 
   private createCardInstance = restartableTask(async () => {
     let specFilter: Filter = {

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -808,11 +808,19 @@ export default class InteractSubmode extends Component {
         action: () => this.createCardInstance.perform(),
         icon: IconSearch,
       }),
-      new MenuItem({
-        label: 'Upload File…',
-        action: () => this.triggerUploadFile(),
-        icon: Upload,
-      }),
+      // An upload needs a writable destination, so the entry only appears
+      // once one exists — which also covers the moment before realm info
+      // has populated. The sibling entries pass an undefined realm through
+      // to the store, which picks a default; an upload has no such path.
+      ...(this.operatorModeStateService.getWritableRealmURL()
+        ? [
+            new MenuItem({
+              label: 'Upload File…',
+              action: () => this.triggerUploadFile(),
+              icon: Upload,
+            }),
+          ]
+        : []),
       new MenuDivider(),
       new MenuItem({
         label: 'Open Code Mode',
@@ -842,10 +850,11 @@ export default class InteractSubmode extends Component {
   private triggerUploadFile() {
     // Same destination convention as the other create actions in this
     // menu: the current workspace when it is writable, otherwise the
-    // default writable realm.
+    // default writable realm. The menu omits this entry when neither
+    // exists, so the guard is a no-op backstop rather than an error path.
     let realm = this.operatorModeStateService.getWritableRealmURL();
     if (!realm) {
-      throw new Error('No writable realm found');
+      return;
     }
     this.uploadFiles.perform(ri(realm.href)).catch((error) => {
       console.error('Unexpected error during file upload', error);
@@ -853,16 +862,7 @@ export default class InteractSubmode extends Component {
   }
 
   private uploadFiles = dropTask(async (realm: RealmIdentifier) => {
-    let files = await this.fileUpload.pickLocalFiles({});
-    if (files.length === 0) {
-      return;
-    }
-    // Parallel POSTs are safe: the realm advisory lock serializes
-    // writes server-side (packages/runtime-common/realm.ts).
-    let tasks = files.map((file) =>
-      this.fileUpload.uploadProvidedFile({ realm, file }),
-    );
-    let results = await Promise.all(tasks.map((task) => task.result));
+    let results = await this.fileUpload.pickAndUploadFiles(realm);
     let firstSuccess = results.find((fileDef) => fileDef?.url);
     if (firstSuccess?.url) {
       this.viewCard(this.rightMostStackIndex, firstSuccess.url, 'isolated', {

--- a/packages/host/app/services/file-upload.ts
+++ b/packages/host/app/services/file-upload.ts
@@ -123,6 +123,19 @@ export default class FileUploadService extends Service {
     return this._openNativeFilePickerMulti(opts?.acceptTypes);
   }
 
+  // Opens the multi-file picker and uploads every chosen file to the realm.
+  // Parallel POSTs are safe: the realm advisory lock serializes writes
+  // server-side (packages/runtime-common/realm.ts). Each entry resolves to
+  // the uploaded FileDef, or undefined for a file whose upload failed — the
+  // per-file failure detail stays on the task in `activeUploads`.
+  async pickAndUploadFiles(
+    realm: RealmIdentifier,
+  ): Promise<(FileDef | undefined)[]> {
+    let files = await this.pickLocalFiles({});
+    let tasks = files.map((file) => this.uploadProvidedFile({ realm, file }));
+    return Promise.all(tasks.map((task) => task.result));
+  }
+
   // Test seam for local-file attachment flow
   __queueLocalFileForTesting(file: File | null) {
     this.queuedLocalFilesForTesting.push(file);

--- a/packages/host/tests/acceptance/interact-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/create-file-test.gts
@@ -627,6 +627,23 @@ module('Acceptance | interact submode | create-file tests', function (hooks) {
       .dom(`[data-test-stack-card="${testRealmURL}interact-multi-first.txt"]`)
       .exists('first uploaded file opened on the stack');
     assert.dom(`[data-test-stack-card-index]`).exists({ count: 2 });
+
+    // The second file never opens on the stack, and a settled upload task is
+    // removed from `activeUploads` whether it succeeded or failed — so the
+    // realm itself is the only place its upload can be verified.
+    let second = await getService('card-service').getSource(
+      new URL(`${testRealmURL}interact-multi-second.txt`),
+    );
+    assert.strictEqual(
+      second.status,
+      200,
+      'second uploaded file is served by the realm',
+    );
+    assert.strictEqual(
+      second.content,
+      'file two',
+      'second uploaded file holds its content',
+    );
   });
 
   test('uploads land in the default writable realm when the current realm is read-only', async function (assert) {

--- a/packages/host/tests/acceptance/interact-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/create-file-test.gts
@@ -1,9 +1,11 @@
-import { click, waitUntil } from '@ember/test-helpers';
+import { click, waitFor, waitUntil } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm, specRef } from '@cardstack/runtime-common';
+
+import type FileUploadService from '@cardstack/host/services/file-upload';
 
 import {
   setupLocalIndexing,
@@ -388,7 +390,7 @@ module('Acceptance | interact submode | create-file tests', function (hooks) {
       stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
     });
     await click('[data-test-new-file-button]');
-    assert.dom('[data-test-boxel-menu-item]').exists({ count: 4 });
+    assert.dom('[data-test-boxel-menu-item]').exists({ count: 5 });
     assert
       .dom(
         '[data-test-boxel-menu-item]:nth-of-type(1) [data-test-boxel-menu-item-text="Author"]',
@@ -459,7 +461,7 @@ module('Acceptance | interact submode | create-file tests', function (hooks) {
     });
     await click('[data-test-new-file-button]');
     // new cards will be created in test realm (has write-permission)
-    assert.dom('[data-test-boxel-menu-item]').exists({ count: 4 });
+    assert.dom('[data-test-boxel-menu-item]').exists({ count: 5 });
     assert
       .dom(
         '[data-test-boxel-menu-item]:nth-of-type(1) [data-test-boxel-menu-item-text="Garden"]',
@@ -494,7 +496,7 @@ module('Acceptance | interact submode | create-file tests', function (hooks) {
       stacks: [[{ id: `${baseRealm.url}index`, format: 'isolated' }]],
     });
     await click('[data-test-new-file-button]');
-    assert.dom('[data-test-boxel-menu-item]').exists({ count: 4 });
+    assert.dom('[data-test-boxel-menu-item]').exists({ count: 5 });
     assert
       .dom(
         '[data-test-boxel-menu-item]:nth-of-type(1) [data-test-boxel-menu-item-text="Spec"]',
@@ -537,7 +539,7 @@ module('Acceptance | interact submode | create-file tests', function (hooks) {
       ],
     });
     await click('[data-test-new-file-button]');
-    assert.dom('[data-test-boxel-menu-item]').exists({ count: 4 });
+    assert.dom('[data-test-boxel-menu-item]').exists({ count: 5 });
     assert
       .dom(
         '[data-test-boxel-menu-item]:nth-of-type(1) [data-test-boxel-menu-item-text="Garden"]',
@@ -565,5 +567,109 @@ module('Acceptance | interact submode | create-file tests', function (hooks) {
     assert
       .dom(`[data-test-operator-mode-stack="0"] [data-test-stack-card-index]`)
       .exists({ count: 2 });
+  });
+
+  test('can upload a file via the New menu', async function (assert) {
+    await visitOperatorMode({
+      submode: 'interact',
+      stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
+    });
+    await click('[data-test-new-file-button]');
+
+    let fileUpload = getService('file-upload') as FileUploadService;
+    fileUpload.__queueLocalFileBatchForTesting([
+      new File(['hello upload'], 'uploaded-in-interact.txt', {
+        type: 'text/plain',
+      }),
+    ]);
+
+    await click('[data-test-boxel-menu-item-text="Upload File…"]');
+
+    await waitFor(
+      `[data-test-stack-card="${testRealmURL}uploaded-in-interact.txt"]`,
+      { timeout: 10000 },
+    );
+    assert
+      .dom(`[data-test-stack-card="${testRealmURL}uploaded-in-interact.txt"]`)
+      .exists('uploaded file opened on the stack');
+    assert.dom(`[data-test-stack-card-index]`).exists({ count: 2 });
+  });
+
+  test('uploading multiple files opens the first uploaded file', async function (assert) {
+    await visitOperatorMode({
+      submode: 'interact',
+      stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
+    });
+    await click('[data-test-new-file-button]');
+
+    let fileUpload = getService('file-upload') as FileUploadService;
+    fileUpload.__queueLocalFileBatchForTesting([
+      new File(['file one'], 'interact-multi-first.txt', {
+        type: 'text/plain',
+      }),
+      new File(['file two'], 'interact-multi-second.txt', {
+        type: 'text/plain',
+      }),
+    ]);
+
+    await click('[data-test-boxel-menu-item-text="Upload File…"]');
+
+    await waitUntil(() => fileUpload.activeUploads.length === 0, {
+      timeout: 20000,
+      timeoutMessage: 'uploads did not all complete',
+    });
+
+    await waitFor(
+      `[data-test-stack-card="${testRealmURL}interact-multi-first.txt"]`,
+      { timeout: 10000 },
+    );
+    assert
+      .dom(`[data-test-stack-card="${testRealmURL}interact-multi-first.txt"]`)
+      .exists('first uploaded file opened on the stack');
+    assert.dom(`[data-test-stack-card-index]`).exists({ count: 2 });
+  });
+
+  test('uploads land in the default writable realm when the current realm is read-only', async function (assert) {
+    await visitOperatorMode({
+      submode: 'interact',
+      stacks: [[{ id: `${baseRealm.url}index`, format: 'isolated' }]],
+    });
+    await click('[data-test-new-file-button]');
+
+    let fileUpload = getService('file-upload') as FileUploadService;
+    fileUpload.__queueLocalFileBatchForTesting([
+      new File(['read-only realm upload'], 'interact-readonly-upload.txt', {
+        type: 'text/plain',
+      }),
+    ]);
+
+    await click('[data-test-boxel-menu-item-text="Upload File…"]');
+
+    await waitFor(
+      `[data-test-stack-card="${userRealm}interact-readonly-upload.txt"]`,
+      { timeout: 10000 },
+    );
+    assert
+      .dom(`[data-test-stack-card="${userRealm}interact-readonly-upload.txt"]`)
+      .exists('uploaded file landed in the writable realm');
+  });
+
+  test('cancelling upload file picker does not cause errors', async function (assert) {
+    await visitOperatorMode({
+      submode: 'interact',
+      stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
+    });
+    await click('[data-test-new-file-button]');
+
+    let fileUpload = getService('file-upload') as FileUploadService;
+    // Simulate cancelling the native file picker - empty batch
+    fileUpload.__queueLocalFileBatchForTesting([]);
+
+    await click('[data-test-boxel-menu-item-text="Upload File…"]');
+
+    assert.dom(`[data-test-stack-card-index]`).exists({ count: 1 });
+    assert
+      .dom(`[data-test-stack-card="${testRealmURL}index"]`)
+      .exists('stack still shows the original card');
   });
 });


### PR DESCRIPTION
Fixes [CS-12487](https://linear.app/cardstack/issue/CS-12487/allow-uploading-a-file-from-the-new-button-in-interact-mode)

Uploading a file was only reachable from code mode. The +New button's menu in interact mode now offers **Upload File…** as well, grouped with the menu's other content-creation entries.

## Behavior

- **Destination realm**: the current workspace when it is writable, otherwise the default writable realm — via `getWritableRealmURL()`, the same convention the menu's card-creation actions ("Choose a card type…", recent card types) already use. Files land at the realm root, matching code mode.
- **After upload**: the first successfully uploaded file opens on the right-most stack as a `file` stack item (interact mode's analogue of code mode navigating `codePath` to the uploaded file).
- Multiple files upload in parallel, same as code mode; cancelling the picker is a no-op.

## Out of scope (per the ticket's open questions)

- Drag-and-drop onto the interact-mode canvas — the menu item is the first pass.
- Routing uploads to a folder rather than the realm root — that decision affects code mode too and deserves its own change.

## Tests

Added acceptance tests covering single upload (opens on the stack), multi-file upload (first success opens), upload from a read-only realm (routes to the writable realm), and picker cancellation; updated the menu-count assertions for the new item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)