### PR TITLE
ci: Change Puppeteer to use already-installed Chrome

### DIFF
--- a/mise-tasks/lib/env-vars.sh
+++ b/mise-tasks/lib/env-vars.sh
@@ -234,21 +234,30 @@ else
   fi
   unset _BOXEL_DEV_CERT_DIR _BOXEL_DEV_CERT_FILE _BOXEL_DEV_KEY_FILE
 
-  # Puppeteer 24.35 (and the lockfile's tree) bundles Chrome 143, which
-  # has a known h2 stream-window bug that hangs the dev prerender forever
-  # on the first cold-start fetch of vite's large pre-optimized
-  # `indexeddb-crypto-store` chunk (matrix-js-sdk). Newer Chrome (148+)
-  # doesn't hit the bug. Both prerender's BrowserManager and the
-  # standby-warmup probe (`scripts/wait-for-host-standby.ts`) already
-  # honor `PUPPETEER_EXECUTABLE_PATH`, so just point them at the system
-  # chrome when one's installed. Devs without google-chrome installed
-  # keep the bundled puppeteer chromium — they'll see the hang stall
-  # longer until vite's optimizer cache warms up.
-  if [ -z "${PUPPETEER_EXECUTABLE_PATH:-}" ]; then
-    _boxel_chrome="$(_boxel_resolve_chrome)"
-    [ -n "$_boxel_chrome" ] && export PUPPETEER_EXECUTABLE_PATH="$_boxel_chrome"
-    unset _boxel_chrome
-  fi
+fi
+
+# Puppeteer bundles a Chrome and downloads it at install time, and the
+# lockfile's tree pins a build with a known h2 stream-window bug: it hangs the
+# dev prerender forever on the first cold-start fetch of vite's large
+# pre-optimized `indexeddb-crypto-store` chunk (matrix-js-sdk). Newer Chrome
+# does not hit it. Both prerender's BrowserManager and the standby-warmup probe
+# (`scripts/wait-for-host-standby.ts`) honor `PUPPETEER_EXECUTABLE_PATH`, so
+# point them at the system chrome when one is installed. Devs without
+# google-chrome keep the bundled puppeteer chromium.
+#
+# Setting it also stops the install-time download, because puppeteer reads the
+# variable as "a browser was supplied". That download is otherwise repeated by
+# every job in CI — two archives from Google's storage, on each of twenty-odd
+# shards — and a 403 there fails dependency installation, and the job with it.
+#
+# Like the Percy block below, this sits outside the env/standard branches
+# above. The host-test job runs in env mode (BOXEL_ENVIRONMENT set), whose
+# branch resolved no Chrome path, so CI was downloading a browser while Percy
+# beside it used the image's copy.
+if [ -z "${PUPPETEER_EXECUTABLE_PATH:-}" ]; then
+  _boxel_chrome="$(_boxel_resolve_chrome)"
+  [ -n "$_boxel_chrome" ] && export PUPPETEER_EXECUTABLE_PATH="$_boxel_chrome"
+  unset _boxel_chrome
 fi
 
 # Percy bundles its own Chromium and downloads + unzips it on first use


### PR DESCRIPTION
This was already the case for standard mode. This is meant to address shard init failures like [this](https://github.com/cardstack/boxel/actions/runs/32395562850/job/96512323118#step:3:307), we might as well use what’s present.

<details><summary>Claude explanation</summary>The block resolving PUPPETEER_EXECUTABLE_PATH sat inside the standard-mode branch, and the host-test job runs in env mode, so CI never reached it — the variable appears nowhere in a full job log. Every job therefore downloaded two Chrome archives from Google's storage while Percy, three lines further down, used /usr/bin/google-chrome from the image. The Percy block had already been moved out of the branches for exactly this reason; puppeteer's never followed.

Moving it out has two effects. Puppeteer uses the image's Chrome, which is what the surrounding comment says is wanted anyway — the pinned build has an h2 stream-window bug that hangs the prerender. And the install-time download stops happening at all, because puppeteer reads the variable as a supplied browser: that download is what failed a host shard on main with a 403 from Google's storage, taking dependency installation and the whole job with it.

Verified in both modes with the variable cleared: env mode now resolves a Chrome path where it previously resolved none, and standard mode is unchanged.</details>