### PR TITLE
Fill the isolated image preview to its stage frame

### DIFF
--- a/packages/base/file-formats/image-preview.gts
+++ b/packages/base/file-formats/image-preview.gts
@@ -60,10 +60,20 @@ export class ImagePreview extends GlimmerComponent<FilePreviewSignature> {
       data-test-image-preview
     />
     <style scoped>
+      /* Fill the stage frame like the stage's own thumbnail sibling does: an
+         absolute box against the relatively-positioned stage resolves both axes
+         to the frame. A plain height:100% grid child does not — the stage's auto
+         row leaves the percentage unresolved, so the browser falls back to the
+         intrinsic aspect ratio from the img's width/height attributes and
+         overflows a frame taller than it. object-fit then does the fitting
+         within a correctly sized box. */
       .image-preview {
-        display: block;
+        position: absolute;
+        inset: 0;
         width: 100%;
         height: 100%;
+        box-sizing: border-box;
+        display: block;
       }
       .image-preview[data-image-fit='cover'] {
         object-fit: cover;

--- a/packages/host/tests/integration/components/file-def-format-templates-test.gts
+++ b/packages/host/tests/integration/components/file-def-format-templates-test.gts
@@ -1,4 +1,5 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { find } from '@ember/test-helpers';
 import type { RenderingTestContext } from '@ember/test-helpers';
 
 import GlimmerComponent from '@glimmer/component';
@@ -281,5 +282,45 @@ module('Integration | FileDef format templates', function (hooks) {
     assert
       .dom('[data-test-file-embedded] img[data-test-image-preview]')
       .exists('the image family renders a native <img> inside the shell');
+  });
+
+  test('an isolated image fills its stage frame rather than overflowing it', async function (assert) {
+    // A small image carries its intrinsic pixel dimensions as the <img>'s
+    // width/height attributes. If the renderer's `height: 100%` fails to resolve
+    // against the stage's grid row, the browser falls back to the aspect ratio
+    // those attributes imply and sizes the box from its width — overflowing a
+    // frame taller than the stage and clipping the picture. The image must
+    // instead fill the stage exactly, letting object-fit do the fitting.
+    let image = new ImageDef({
+      id: 'http://example.com/img/tiny.png',
+      url: 'http://example.com/img/tiny.png',
+      sourceUrl: 'http://example.com/img/tiny.png',
+      name: 'tiny.png',
+      contentType: 'image/png',
+      width: 154,
+      height: 160,
+    });
+    await renderCard(loader, image, 'isolated');
+
+    let img = find('[data-test-file-isolated] img[data-test-image-preview]');
+    let stage = find(
+      '[data-test-file-isolated] [data-test-file-preview-stage]',
+    );
+    assert.ok(img, 'the isolated image renders a native <img>');
+    assert.ok(stage, 'the image sits inside the preview stage');
+
+    let imgHeight = img!.getBoundingClientRect().height;
+    let stageHeight = stage!.getBoundingClientRect().height;
+    assert.ok(
+      stageHeight > 0,
+      `the stage has a real height (${stageHeight}px)`,
+    );
+    // The box fills the frame; without the fix it would be sized from the
+    // width/height attributes' aspect ratio (~1.04x its width) and run past the
+    // stage's bottom edge.
+    assert.ok(
+      Math.abs(imgHeight - stageHeight) <= 1,
+      `the <img> height (${imgHeight}px) fills the stage (${stageHeight}px) instead of overflowing it`,
+    );
   });
 });


### PR DESCRIPTION
## Problem

In the isolated view of an image FileDef, a small image rendered as its top edge only, sitting at the bottom of a mostly-empty stage frame.

The `<img>` carries its intrinsic pixel dimensions as `width`/`height` HTML attributes. In `image-preview.gts` the renderer relied on `height: 100%`, but the image is a grid child of the preview stage (`display: grid; place-items: center`), whose implicit row is `auto`. In that layout the percentage height never resolves, so the browser derived the box height from `width: 100%` × the aspect ratio implied by those attributes — a box taller than the 380px stage. `object-fit: scale-down` then drew the picture at its natural size centered inside that oversized box, which placed it below the visible frame; `overflow: hidden` clipped everything but the top edge.

Reproduced in a browser: for a 154×160 image in a 740px-wide stage, the `<img>` box measured **740×769** — matching the reported symptom exactly.

## Fix

`.image-preview` now fills the frame the way the stage's own `.generated-thumbnail` sibling already does: an absolute box (`position: absolute; inset: 0`) against the relatively-positioned stage resolves both axes to the frame, and `object-fit` fits the pixels within a correctly-sized box. `box-sizing: border-box` keeps the `contain` mode's padding inside the frame.

After the fix the same image measures **740×380** (the stage box) across all three fit modes — scale-down (small image centered on the paper matte), cover (fills + crops), and contain (letterboxed).

## Test

Adds a regression test to `file-def-format-templates-test.gts` that renders an isolated `ImageDef` and asserts the rendered `<img>` height fills the stage rather than overflowing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)