### PR TITLE
Keep the background dark from sign-in through to the workspace chooser

### DIFF
--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -764,12 +764,10 @@ export default class WorkspaceChooser extends Component<Signature> {
         }
       }
       .workspace-chooser {
-        opacity: 0;
         position: absolute;
         background-color: var(--boxel-800);
         height: 100%;
         width: 100%;
-        animation: fadeIn 0.5s ease-in forwards;
         z-index: var(--host-workspace-chooser-z-index);
       }
       .sort-controls {
@@ -810,6 +808,11 @@ export default class WorkspaceChooser extends Component<Signature> {
         height: 100%;
         padding: calc(5rem + 3.75rem) 5rem 5rem;
         overflow: auto;
+        /* Fade in only the contents; the dark chooser background above
+           paints immediately so the grey operator-mode canvas never flashes
+           between the (dark) sign-in screen and the (dark) chooser. */
+        opacity: 0;
+        animation: fadeIn 0.5s ease-in forwards;
       }
       .sections-wrapper {
         display: flex;


### PR DESCRIPTION
## Problem

Signing in briefly flashed the grey/lavender operator-mode canvas between the (dark) sign-in screen and the (dark) dashboard.

The workspace chooser — the dashboard you land on after login — faded in from `opacity: 0` as a whole element, **its dark background included**. For that half-second fade the chooser was semi-transparent, so the grey operator-mode canvas behind it (`--operator-mode-bg-color: #686283`) showed through. That grey is intentional in interact mode (the desktop canvas behind card stacks), so the fade exposing it during login was the bug, not the colour itself.

## Fix

Keep `.workspace-chooser`'s dark background (`--boxel-800`) opaque from the first frame and move the `fadeIn` onto `.workspace-chooser__content`. The dark background now covers the grey canvas in the same paint as the swap away from the sign-in screen, so the transition stays dark throughout while the content still fades in.

Fixes CS-11771.

## Verification

- Lint passes; no tests asserted on the chooser's opacity/animation.
- Reproduced the exact layering (grey canvas behind, dark chooser fading in) old vs new and captured it mid-fade: the old version is fully grey during the fade (the reported flash); the new version is already dark with only the content fading in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)