### PR TITLE
Use the shared Button for the pinned-card Open action

### DIFF
--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -637,17 +637,17 @@ class Isolated extends Component<typeof Workspace> {
                       to create something for you.</p>
                   {{/if}}
                   <div class='welcome-actions'>
-                    <button
-                      type='button'
+                    <Button
+                      @kind='primary'
                       class='welcome-cta'
                       {{on 'click' (this.setSegment 'library')}}
-                    >Open Library</button>
+                    >Open Library</Button>
                     {{#if @canEdit}}
-                      <button
-                        type='button'
+                      <Button
+                        @kind='secondary'
                         class='welcome-alt'
                         {{on 'click' this.createNew}}
-                      >New card</button>
+                      >New card</Button>
                     {{/if}}
                   </div>
                 </section>
@@ -1325,23 +1325,6 @@ class Isolated extends Component<typeof Workspace> {
         text-transform: uppercase;
         color: var(--grid-ink-ghost);
       }
-      .new-button {
-        border: 0;
-        border-radius: 8px;
-        padding: 7px 13px;
-        background-color: var(--grid-accent);
-        color: var(--grid-accent-ink);
-        font: 600 12.5px var(--grid-sans);
-        cursor: pointer;
-        white-space: nowrap;
-        box-shadow:
-          inset 0 1px 0 rgba(255, 255, 255, 0.5),
-          0 1px 2px rgba(0, 0, 0, 0.1);
-      }
-      .new-button:hover {
-        background-color: var(--boxel-dark-teal, #00da9f);
-      }
-
       @keyframes softpulse {
         0%,
         100% {
@@ -2335,30 +2318,6 @@ class Isolated extends Component<typeof Workspace> {
         display: flex;
         align-items: center;
         gap: 10px;
-      }
-      .welcome-cta {
-        border: 0;
-        border-radius: 8px;
-        padding: 9px 16px;
-        background-color: var(--grid-accent);
-        color: var(--grid-accent-ink);
-        font: 600 13px var(--grid-sans);
-        cursor: pointer;
-        box-shadow:
-          inset 0 1px 0 rgba(255, 255, 255, 0.5),
-          0 1px 2px rgba(0, 0, 0, 0.1);
-      }
-      .welcome-alt {
-        border: 1px solid var(--grid-border);
-        border-radius: 8px;
-        padding: 8px 16px;
-        background-color: var(--grid-surface);
-        font: 600 13px var(--grid-sans);
-        color: var(--grid-nav-ink);
-        cursor: pointer;
-      }
-      .welcome-alt:hover {
-        border-color: var(--grid-hover-border);
       }
       .empty-note {
         margin: 0;

--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -7,7 +7,7 @@ import { restartableTask, timeout } from 'ember-concurrency';
 import { modifier } from 'ember-modifier';
 import { TrackedArray, TrackedObject, TrackedSet } from 'tracked-built-ins';
 
-import { BoxelInput } from '@cardstack/boxel-ui/components';
+import { BoxelInput, Button } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 import BooleanField from './boolean';
 // host-mode mutation: publish and unpublish are registered host tools
@@ -598,11 +598,13 @@ class Isolated extends Component<typeof Workspace> {
                           <span class='door-title'>{{this.doorTitle
                               index
                             }}</span>
-                          <button
-                            type='button'
+                          <Button
+                            @kind='primary'
+                            @size='extra-small'
+                            @rectangular={{true}}
                             class='door-open'
                             {{on 'click' (this.openDoor index)}}
-                          >Open</button>
+                          >Open</Button>
                         </div>
                       </article>
                     {{/each}}
@@ -1942,20 +1944,8 @@ class Isolated extends Component<typeof Workspace> {
       }
       .door-open {
         flex: 0 0 auto; /* Keep the action inside its tile while the label ellipsizes */
-        border: 0;
-        border-radius: 8px;
-        padding: 5px 12px;
-        background-color: var(--grid-accent);
-        color: var(--grid-accent-ink);
-        font: 600 12px var(--grid-sans);
-        cursor: pointer;
+        --boxel-button-min-width: 0; /* Stay as narrow as the label; the tile is tight */
         white-space: nowrap;
-        box-shadow:
-          inset 0 1px 0 rgba(255, 255, 255, 0.5),
-          0 1px 2px rgba(0, 0, 0, 0.1);
-      }
-      .door-open:hover {
-        background-color: var(--boxel-highlight-hover, #00da9f);
       }
 
       /* ── Inventory (Home): what lives here, grouped by kind ── */


### PR DESCRIPTION
## What

Follow-up to #5837 addressing [@burieberry's review](https://github.com/cardstack/boxel/pull/5837#pullrequestreview-4987616397): *"why not use a primary button? you can use one of the smaller sizes with rectangular arg."*

#5837 restyled the pinned-card **Open** control into an accent-filled button by hand-writing the fill, radius, inset highlight, and hover — all of which the shared `Button` component already provides. This PR replaces that bespoke CSS with the shared component, and applies the same treatment to the workspace card's other CTAs:

- **Open** (pinned card) → `<Button @kind='primary' @size='extra-small' @rectangular>`
- **Open Library** (welcome state) → `<Button @kind='primary'>`
- **New card** (welcome state) → `<Button @kind='secondary'>` (it was an outlined secondary button)
- Removes the `.new-button` CSS block, which was dead — no markup ever referenced it.

Each keeps only the layout concerns the component doesn't own (e.g. the pinned-card Open stays compact inside its tile), and the card's grid-themed focus ring still applies via the existing `:focus-visible` block.

## Test plan

- Markup/CSS-only change; no behavior change (same click handlers).
- `ember-template-lint` clean on the changed file.
- Note: eslint reports a pre-existing parsing error at `workspace.gts:394` (a content-tag detection quirk present on `main`) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)