### PR TITLE
GET screenshot URL DSL: canonicalized specs, capture gate, persisted-else-on-demand

### DIFF
--- a/packages/base/realm-config.gts
+++ b/packages/base/realm-config.gts
@@ -688,10 +688,10 @@ export class RealmConfig extends CardDef {
   // for arbitrary capture specs. Full captureSpec power on a GET is an
   // unbounded spec space reachable with only realm read, so it is off
   // unless the realm turns it on; the gate blocks Chrome work only, never
-  // serving — declared screenshots and already-captured specs (including
-  // ones a write-holder produced via POST) stream regardless. Read from the
-  // realm's indexed config at request time, so editing this takes effect
-  // with the index update, no restart.
+  // serving — any capture whose canonical spec already has a MediaCache
+  // ledger entry streams regardless. Read from the realm's indexed config
+  // at request time, so editing this takes effect with the index update,
+  // no restart.
   @field allowArbitraryScreenshots = contains(BooleanField);
 
   @field cardTitle = contains(StringField, {

--- a/packages/base/realm-config.gts
+++ b/packages/base/realm-config.gts
@@ -684,6 +684,15 @@ export class RealmConfig extends CardDef {
   // automatically in that case) or when an operator otherwise needs
   // the full isolated render present in the index.
   @field includePrerenderedDefaultRealmIndex = contains(BooleanField);
+  // Opt-in for the realm's GET `_screenshot/` route to trigger NEW captures
+  // for arbitrary capture specs. Full captureSpec power on a GET is an
+  // unbounded spec space reachable with only realm read, so it is off
+  // unless the realm turns it on; the gate blocks Chrome work only, never
+  // serving — declared screenshots and already-captured specs (including
+  // ones a write-holder produced via POST) stream regardless. Read from the
+  // realm's indexed config at request time, so editing this takes effect
+  // with the index update, no restart.
+  @field allowArbitraryScreenshots = contains(BooleanField);
 
   @field cardTitle = contains(StringField, {
     computeVia: function (this: RealmConfig) {

--- a/packages/postgres/pg-queue.ts
+++ b/packages/postgres/pg-queue.ts
@@ -32,6 +32,7 @@ import { FROM_SCRATCH_JOB_TIMEOUT_SEC } from '@cardstack/runtime-common/tasks/in
 // Side-effect imports: these modules call registerQueueJobDefinition() at
 // load time, so any process that constructs a PgQueuePublisher gets the
 // coalesce handlers registered before publish() is called.
+import '@cardstack/runtime-common/jobs/screenshot-card';
 import '@cardstack/runtime-common/tasks/copy';
 import '@cardstack/runtime-common/tasks/full-reindex';
 import '@cardstack/runtime-common/tasks/media-cache-gc';

--- a/packages/realm-server/handlers/handle-screenshot-card.ts
+++ b/packages/realm-server/handlers/handle-screenshot-card.ts
@@ -1,5 +1,6 @@
 import type Koa from 'koa';
 
+import { isCaptureFormat } from '@cardstack/runtime-common';
 import { enqueueScreenshotCardJob } from '@cardstack/runtime-common/jobs/screenshot-card';
 import { userInitiatedPriority } from '@cardstack/runtime-common/queue';
 
@@ -64,7 +65,9 @@ export default function handleScreenshotCard({
     if (!cardId || typeof cardId !== 'string') {
       return sendResponseForBadRequest(ctxt, 'cardId is required');
     }
-    if (format !== 'isolated' && format !== 'embedded') {
+    // Shared with the GET `_screenshot/` DSL so both surfaces accept exactly
+    // the same capture formats.
+    if (!isCaptureFormat(format)) {
       return sendResponseForBadRequest(
         ctxt,
         'format must be "isolated" or "embedded"',
@@ -88,6 +91,7 @@ export default function handleScreenshotCard({
           runAs: userId,
           cardId,
           format,
+          persist: null,
         },
         queue,
         dbAdapter,

--- a/packages/realm-server/tests/helpers/fake-media-cache-adapter.ts
+++ b/packages/realm-server/tests/helpers/fake-media-cache-adapter.ts
@@ -24,9 +24,15 @@ export class FakeMediaCacheAdapter implements MediaCacheAdapter {
     if (this.streamShape === 'readable') {
       return Readable.from(Buffer.from(bytes));
     }
+    // Yield in two chunks: a single-chunk generator can't distinguish an
+    // implementation that wraps the whole iterable from one that reads only
+    // its head, which is the bug the bare-async-iterable serving test exists
+    // to catch. Split at the midpoint (min 1) so a payload shorter than a
+    // fixed offset still crosses a real chunk boundary.
     return (async function* () {
-      yield bytes.slice(0, 3);
-      yield bytes.slice(3);
+      let mid = Math.max(1, Math.floor(bytes.length / 2));
+      yield bytes.slice(0, mid);
+      yield bytes.slice(mid);
     })();
   }
   async delete(key: string) {

--- a/packages/realm-server/tests/helpers/fake-media-cache-adapter.ts
+++ b/packages/realm-server/tests/helpers/fake-media-cache-adapter.ts
@@ -1,16 +1,21 @@
 import { Readable } from 'node:stream';
 import type { MediaCacheAdapter } from '@cardstack/runtime-common';
 
-// Minimal in-memory store: real bytes behind the MediaCacheAdapter
-// interface, with a switch between the two stream shapes the serving layer
-// handles (a node Readable, which passes through `toNodeStream`, and a bare
-// async iterable, which it wraps).
+// Shared in-memory MediaCacheAdapter for tests: real bytes behind the
+// interface, observable deletes, scriptable per-key delete failures, and a
+// switch between the two stream shapes the serving layer handles (a node
+// Readable, which passes through `toNodeStream`, and a bare async iterable,
+// which it wraps).
 export class FakeMediaCacheAdapter implements MediaCacheAdapter {
   objects = new Map<string, Uint8Array>();
+  deleted: string[] = [];
+  failDeletesFor = new Set<string>();
   streamShape: 'readable' | 'iterable' = 'readable';
 
   async put(key: string, bytes: Uint8Array, _opts: { contentType: string }) {
-    this.objects.set(key, bytes);
+    if (!this.objects.has(key)) {
+      this.objects.set(key, bytes);
+    }
   }
   async head(key: string) {
     let bytes = this.objects.get(key);
@@ -36,6 +41,10 @@ export class FakeMediaCacheAdapter implements MediaCacheAdapter {
     })();
   }
   async delete(key: string) {
+    if (this.failDeletesFor.has(key)) {
+      throw new Error(`simulated delete failure for ${key}`);
+    }
+    this.deleted.push(key);
     this.objects.delete(key);
   }
 }

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -1238,6 +1238,7 @@ export async function createRealm({
   transpileCoordinator,
   fullIndexOnStartup,
   mediaCacheAdapter,
+  screenshotSyncWaitMs,
 }: {
   dir: string;
   definitionLookup: DefinitionLookup;
@@ -1274,6 +1275,9 @@ export async function createRealm({
   // MediaCache object store for the realm's `_screenshot/` route; absent
   // means every screenshot request serves as an uncaptured miss.
   mediaCacheAdapter?: MediaCacheAdapter;
+  // Shrinks the `_screenshot/` route's on-demand sync-wait budget so tests
+  // can exercise the 503 + Retry-After path without holding real time.
+  screenshotSyncWaitMs?: number;
 }): Promise<{ realm: Realm; adapter: RealmAdapter }> {
   await insertPermissions(dbAdapter, new URL(realmURL), permissions);
 
@@ -1352,7 +1356,10 @@ export async function createRealm({
       transpileCoordinator,
       mediaCacheAdapter,
     },
-    fullIndexOnStartup ? { fullIndexOnStartup: true as const } : undefined,
+    {
+      ...(fullIndexOnStartup ? { fullIndexOnStartup: true as const } : {}),
+      ...(screenshotSyncWaitMs !== undefined ? { screenshotSyncWaitMs } : {}),
+    },
   );
   if (worker) {
     virtualNetwork.mount(realm.handle);
@@ -3071,6 +3078,7 @@ export function realmConfigCardJSON(
     iconURL?: string;
     backgroundURL?: string;
     includePrerenderedDefaultRealmIndex?: boolean;
+    allowArbitraryScreenshots?: boolean;
   } = {},
 ): string {
   let attrs: Record<string, unknown> = {};
@@ -3086,6 +3094,9 @@ export function realmConfigCardJSON(
   if (config.includePrerenderedDefaultRealmIndex !== undefined) {
     attrs.includePrerenderedDefaultRealmIndex =
       config.includePrerenderedDefaultRealmIndex;
+  }
+  if (config.allowArbitraryScreenshots !== undefined) {
+    attrs.allowArbitraryScreenshots = config.allowArbitraryScreenshots;
   }
   return JSON.stringify({
     data: {

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -264,6 +264,7 @@ const ALL_TEST_FILES: string[] = [
   './media-cache-adapter-test',
   './media-cache-gc-test',
   './media-cache-serving-test',
+  './media-cache-dsl-test',
   './prerender-server-test',
   './prerender-manager-test',
   './prerender-host-shell-recycle-test',

--- a/packages/realm-server/tests/media-cache-dsl-test.ts
+++ b/packages/realm-server/tests/media-cache-dsl-test.ts
@@ -391,6 +391,51 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('concurrent misses for one spec coalesce onto one capture', async function (assert) {
+      await seedInstanceRow('card-1');
+      await seedRealmConfigRow(true);
+      // Recent capture history keeps the congestion pre-check's estimate
+      // under the budget while the first capture is in flight, so the
+      // second request reaches the queue and can coalesce instead of
+      // failing fast.
+      let job = await insertJob(dbAdapter, {
+        job_type: 'screenshot-card',
+        concurrency_group: `screenshot:${REALM_URL}`,
+        status: 'resolved',
+        finished_at: new Date().toISOString(),
+        result: {},
+      });
+      await query(dbAdapter, [
+        `INSERT INTO job_reservations (job_id, created_at, locked_until, completed_at, worker_id)
+         VALUES (${Number(job.id)}, NOW() - INTERVAL '200 milliseconds', NOW(), NOW(), 'test-worker')`,
+      ]);
+      captureGate = new Deferred<void>();
+      await startWorker();
+
+      let first = get('_screenshot/card-1');
+      // Wait for the first capture to be claimed and parked on the gate so
+      // the second request's publish sees it as an in-flight twin.
+      let deadline = Date.now() + 5000;
+      while (captureCalls === 0 && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      let second = get('_screenshot/card-1');
+      // Give the second request time to publish (and coalesce) before the
+      // render completes.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      captureGate.fulfill();
+      captureGate = undefined;
+
+      let [firstResponse, secondResponse] = await Promise.all([first, second]);
+      assert.strictEqual(firstResponse.status, 200);
+      assert.strictEqual(secondResponse.status, 200);
+      assert.strictEqual(
+        captureCalls,
+        1,
+        'both requests were satisfied by one render',
+      );
+    });
+
     test('a congested lane fails fast with 503 + Retry-After', async function (assert) {
       await seedInstanceRow('card-1');
       await seedRealmConfigRow(true);

--- a/packages/realm-server/tests/media-cache-dsl-test.ts
+++ b/packages/realm-server/tests/media-cache-dsl-test.ts
@@ -1,0 +1,461 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PgAdapter } from '@cardstack/postgres';
+import type {
+  DefinitionLookup,
+  IndexWriter,
+  Prerenderer,
+  QueuePublisher,
+  QueueRunner,
+  Realm,
+  ScreenshotPrerenderResponse,
+  VirtualNetwork as VirtualNetworkType,
+} from '@cardstack/runtime-common';
+import {
+  Deferred,
+  VirtualNetwork,
+  asExpressions,
+  canonicalCaptureSpecString,
+  captureSpecHash,
+  findMediaCacheEntry,
+  insert,
+  logger,
+  parseCaptureSpecParams,
+  putMedia,
+  query,
+  screenshotCard,
+} from '@cardstack/runtime-common';
+
+import { FakeMediaCacheAdapter } from './helpers/fake-media-cache-adapter.ts';
+import { createRealm, insertJob, setupDB } from './helpers/index.ts';
+import { nodeStreamToBuffer } from '../stream.ts';
+
+const REALM_URL = 'http://test-dsl-realm/';
+const OWNER = '@node-test_realm:localhost';
+const PNG_BYTES = new TextEncoder().encode('stub-png-bytes');
+const PNG_BASE64 = Buffer.from(PNG_BYTES).toString('base64');
+// Long enough that a healthy queue round-trip never times out; short enough
+// that the deliberately-stalled timeout test doesn't drag the suite.
+const SYNC_WAIT_MS = 2000;
+
+function params(qs: string): URLSearchParams {
+  return new URL(`http://x/?${qs}`).searchParams;
+}
+
+module(basename(import.meta.filename), function () {
+  module('capture-spec canonicalization', function () {
+    test('the all-defaults spec canonicalizes to {} however it is spelled', async function (assert) {
+      let bare = parseCaptureSpecParams(params(''));
+      let explicit = parseCaptureSpecParams(params('format=isolated'));
+      assert.true('spec' in bare, 'the bare URL parses');
+      assert.true('spec' in explicit, 'the explicit-default URL parses');
+      if ('spec' in bare && 'spec' in explicit) {
+        assert.strictEqual(canonicalCaptureSpecString(bare.spec), '{}');
+        assert.strictEqual(
+          await captureSpecHash(bare.spec),
+          await captureSpecHash(explicit.spec),
+          'default-elision makes the two spellings one cache key',
+        );
+      }
+    });
+
+    test('a non-default format is its own cache key', async function (assert) {
+      let embedded = parseCaptureSpecParams(params('format=embedded'));
+      assert.true('spec' in embedded, 'format=embedded parses');
+      if ('spec' in embedded) {
+        assert.strictEqual(
+          canonicalCaptureSpecString(embedded.spec),
+          '{"format":"embedded"}',
+        );
+        assert.notStrictEqual(
+          await captureSpecHash(embedded.spec),
+          await captureSpecHash({ format: 'isolated' }),
+        );
+      }
+    });
+
+    test('errors name the offending field', function (assert) {
+      let unknown = parseCaptureSpecParams(params('sparkle=true'));
+      assert.deepEqual(unknown, {
+        error: { field: 'sparkle', message: 'unsupported parameter "sparkle"' },
+      });
+
+      let reserved = parseCaptureSpecParams(params('viewport=1280x800'));
+      assert.strictEqual(
+        'error' in reserved ? reserved.error.field : undefined,
+        'viewport',
+      );
+
+      let badFormat = parseCaptureSpecParams(params('format=fancy'));
+      assert.deepEqual(badFormat, {
+        error: {
+          field: 'format',
+          message: 'format must be "isolated" or "embedded"',
+        },
+      });
+
+      let repeated = parseCaptureSpecParams(
+        params('format=isolated&format=embedded'),
+      );
+      assert.strictEqual(
+        'error' in repeated ? repeated.error.field : undefined,
+        'format',
+      );
+    });
+  });
+
+  module('GET _screenshot capture flow', function (hooks) {
+    let dbAdapter: PgAdapter;
+    let publisher: QueuePublisher;
+    let runner: QueueRunner;
+    let realm: Realm;
+    let adapter: FakeMediaCacheAdapter;
+    let virtualNetwork: VirtualNetworkType;
+    let captureCalls: number;
+    // When set, in-flight captures park on it — the lever for the sync-wait
+    // timeout test.
+    let captureGate: Deferred<void> | undefined;
+
+    setupDB(hooks, {
+      beforeEach: async (
+        _dbAdapter: PgAdapter,
+        _publisher: QueuePublisher,
+        _runner: QueueRunner,
+      ): Promise<void> => {
+        dbAdapter = _dbAdapter;
+        publisher = _publisher;
+        runner = _runner;
+        adapter = new FakeMediaCacheAdapter();
+        captureCalls = 0;
+        captureGate = undefined;
+        virtualNetwork = new VirtualNetwork();
+        ({ realm } = await createRealm({
+          dir: await mkdtemp(join(tmpdir(), 'media-cache-dsl-test-')),
+          definitionLookup: {
+            forRealm() {
+              return this;
+            },
+          } as unknown as DefinitionLookup,
+          realmURL: REALM_URL,
+          permissions: {
+            '*': ['read'],
+            [OWNER]: ['read', 'write', 'realm-owner'],
+          },
+          virtualNetwork,
+          publisher,
+          dbAdapter,
+          mediaCacheAdapter: adapter,
+          screenshotSyncWaitMs: SYNC_WAIT_MS,
+        }));
+      },
+    });
+
+    // Registers the real screenshot-card task on the test runner, with a
+    // stub prerenderer standing in for the Chrome pool. Only tests that
+    // want a capture to complete start the worker; the rest leave enqueued
+    // jobs unclaimed on purpose.
+    async function startWorker() {
+      let prerenderer = {
+        prerenderScreenshot: async (): Promise<ScreenshotPrerenderResponse> => {
+          captureCalls++;
+          if (captureGate) {
+            await captureGate.promise;
+          }
+          return {
+            status: 'ready',
+            base64: PNG_BASE64,
+            width: 8,
+            height: 6,
+            contentType: 'image/png',
+          };
+        },
+      } as unknown as Prerenderer;
+      await runner.register(
+        'screenshot-card',
+        screenshotCard({
+          dbAdapter,
+          queuePublisher: publisher,
+          prerenderer,
+          mediaCacheAdapter: adapter,
+          log: logger('media-cache-dsl-test'),
+          reportStatus: () => {},
+          matrixURL: 'http://localhost:8008',
+          indexWriter: null as unknown as IndexWriter,
+          definitionLookup: null as unknown as DefinitionLookup,
+          virtualNetwork,
+          getReader: () => {
+            throw new Error('getReader is not used by screenshot-card');
+          },
+          getAuthedFetch: async () => globalThis.fetch,
+          createPrerenderAuth: () => 'test-auth',
+        }),
+      );
+      await runner.start();
+    }
+
+    async function seedInstanceRow(localPath: string, generation = 1) {
+      let { nameExpressions, valueExpressions } = asExpressions(
+        {
+          url: `${REALM_URL}${localPath}.json`,
+          file_alias: `${REALM_URL}${localPath}`,
+          realm_url: REALM_URL,
+          type: 'instance',
+          generation,
+          last_modified: Date.now(),
+          resource_created_at: Date.now(),
+          is_deleted: false,
+          pristine_doc: { attributes: {} },
+        },
+        { jsonFields: ['pristine_doc'] },
+      );
+      await query(
+        dbAdapter,
+        insert('boxel_index', nameExpressions, valueExpressions),
+      );
+    }
+
+    async function seedRealmConfigRow(allowArbitraryScreenshots: boolean) {
+      let { nameExpressions, valueExpressions } = asExpressions(
+        {
+          url: `${REALM_URL}realm.json`,
+          file_alias: `${REALM_URL}realm`,
+          realm_url: REALM_URL,
+          type: 'instance',
+          generation: 1,
+          last_modified: Date.now(),
+          resource_created_at: Date.now(),
+          is_deleted: false,
+          pristine_doc: { attributes: { allowArbitraryScreenshots } },
+        },
+        { jsonFields: ['pristine_doc'] },
+      );
+      await query(
+        dbAdapter,
+        insert('boxel_index', nameExpressions, valueExpressions),
+      );
+    }
+
+    async function get(pathAndQuery: string, method = 'GET') {
+      let response = await realm.handle(
+        new Request(`${REALM_URL}${pathAndQuery}`, { method }),
+      );
+      return response!;
+    }
+
+    test('an already-captured spec serves on a gated realm with zero capture work', async function (assert) {
+      await seedInstanceRow('card-1');
+      await putMedia(dbAdapter, adapter, {
+        realmURL: REALM_URL,
+        sourceURL: `${REALM_URL}card-1`,
+        captureSpecHash: await captureSpecHash({ format: 'isolated' }),
+        sourceGeneration: 1,
+        bytes: PNG_BYTES,
+        contentType: 'image/png',
+        lane: 'on-demand',
+      });
+
+      let response = await get('_screenshot/card-1');
+
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.headers.get('content-type'), 'image/png');
+      assert.deepEqual(
+        [...(await nodeStreamToBuffer(response.nodeStream!))],
+        [...PNG_BYTES],
+      );
+      assert.strictEqual(captureCalls, 0, 'no render work occurred');
+    });
+
+    test('a gated miss is a 403 naming the flag', async function (assert) {
+      await seedInstanceRow('card-1');
+
+      let response = await get('_screenshot/card-1');
+
+      assert.strictEqual(response.status, 403);
+      assert.true(
+        (await response.text()).includes('allowArbitraryScreenshots'),
+        'the refusal names the config flag',
+      );
+      assert.strictEqual(captureCalls, 0);
+    });
+
+    test('flipping the indexed config opens the gate with no restart', async function (assert) {
+      await seedInstanceRow('card-1');
+      await seedRealmConfigRow(false);
+
+      assert.strictEqual((await get('_screenshot/card-1')).status, 403);
+
+      // The flag is read from the indexed config on every request, so an
+      // index update is all it takes.
+      await query(dbAdapter, [
+        `UPDATE boxel_index SET pristine_doc = '{"attributes":{"allowArbitraryScreenshots":true}}'::jsonb
+         WHERE url = '${REALM_URL}realm.json'`,
+      ]);
+      await startWorker();
+
+      let response = await get('_screenshot/card-1');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(captureCalls, 1);
+    });
+
+    test('an open realm captures on demand, persists, and then serves hits', async function (assert) {
+      await seedInstanceRow('card-1');
+      await seedRealmConfigRow(true);
+      await startWorker();
+
+      let response = await get('_screenshot/card-1?format=embedded');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(response.headers.get('content-type'), 'image/png');
+      assert.deepEqual(
+        [...(await nodeStreamToBuffer(response.nodeStream!))],
+        [...PNG_BYTES],
+      );
+      assert.strictEqual(captureCalls, 1);
+
+      let entry = await findMediaCacheEntry(dbAdapter, {
+        realmURL: REALM_URL,
+        sourceURL: `${REALM_URL}card-1`,
+        captureSpecHash: await captureSpecHash({ format: 'embedded' }),
+        sourceGeneration: 1,
+      });
+      assert.strictEqual(entry?.lane, 'on-demand');
+
+      let second = await get('_screenshot/card-1?format=embedded');
+      assert.strictEqual(second.status, 200);
+      assert.strictEqual(captureCalls, 1, 'the second request is a pure hit');
+    });
+
+    test('an edited instance never serves a stale capture', async function (assert) {
+      await seedInstanceRow('card-1');
+      await seedRealmConfigRow(true);
+      await startWorker();
+
+      await get('_screenshot/card-1');
+      assert.strictEqual(captureCalls, 1);
+
+      // An edit bumps the instance's index generation, which is part of the
+      // cache key.
+      await query(dbAdapter, [
+        `UPDATE boxel_index SET generation = 2 WHERE url = '${REALM_URL}card-1.json'`,
+      ]);
+
+      let response = await get('_screenshot/card-1');
+      assert.strictEqual(response.status, 200);
+      assert.strictEqual(captureCalls, 2, 'the edited card re-captured');
+    });
+
+    test('a sync wait that outruns the budget answers 503, and the capture still lands', async function (assert) {
+      await seedInstanceRow('card-1');
+      await seedRealmConfigRow(true);
+      captureGate = new Deferred<void>();
+      await startWorker();
+
+      let response = await get('_screenshot/card-1');
+      assert.strictEqual(response.status, 503);
+      assert.ok(
+        Number(response.headers.get('retry-after')) >= 1,
+        'the 503 carries a Retry-After',
+      );
+
+      // The job kept running; once the render finishes it persists its own
+      // capture, so the client retry is a pure ledger hit.
+      captureGate.fulfill();
+      captureGate = undefined;
+      let entryKey = {
+        realmURL: REALM_URL,
+        sourceURL: `${REALM_URL}card-1`,
+        captureSpecHash: await captureSpecHash({ format: 'isolated' }),
+        sourceGeneration: 1,
+      };
+      let deadline = Date.now() + 10_000;
+      while (
+        !(await findMediaCacheEntry(dbAdapter, entryKey)) &&
+        Date.now() < deadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      assert.ok(
+        await findMediaCacheEntry(dbAdapter, entryKey),
+        'the timed-out capture persisted anyway',
+      );
+      let capturesSoFar = captureCalls;
+      let retry = await get('_screenshot/card-1');
+      assert.strictEqual(retry.status, 200);
+      assert.strictEqual(
+        captureCalls,
+        capturesSoFar,
+        'the retry re-rendered nothing',
+      );
+    });
+
+    test('a congested lane fails fast with 503 + Retry-After', async function (assert) {
+      await seedInstanceRow('card-1');
+      await seedRealmConfigRow(true);
+      // A queued capture already holds the realm's serialized lane; with no
+      // worker started it stays pending, and pending × the default capture
+      // estimate dwarfs the budget.
+      await insertJob(dbAdapter, {
+        job_type: 'screenshot-card',
+        concurrency_group: `screenshot:${REALM_URL}`,
+      });
+
+      let response = await get('_screenshot/card-1');
+
+      assert.strictEqual(response.status, 503);
+      assert.ok(Number(response.headers.get('retry-after')) >= 1);
+      assert.strictEqual(captureCalls, 0, 'nothing was enqueued or rendered');
+    });
+
+    test('HEAD never reaches the screenshot route, even for a captured spec', async function (assert) {
+      // checkPermission exempts HEAD from auth realm-wide; the GET-only
+      // dispatch is what keeps HEAD from becoming an unauthenticated
+      // existence/size/content-hash oracle. Even a spec with a live capture
+      // answers a HEAD from the generic handlers, not this route.
+      await seedInstanceRow('card-1');
+      await putMedia(dbAdapter, adapter, {
+        realmURL: REALM_URL,
+        sourceURL: `${REALM_URL}card-1`,
+        captureSpecHash: await captureSpecHash({ format: 'isolated' }),
+        sourceGeneration: 1,
+        bytes: PNG_BYTES,
+        contentType: 'image/png',
+        lane: 'on-demand',
+      });
+
+      let response = await get('_screenshot/card-1', 'HEAD');
+
+      assert.notStrictEqual(response.status, 200);
+      assert.strictEqual(
+        response.headers.get('etag'),
+        null,
+        'no content-hash validator leaks',
+      );
+      assert.strictEqual(captureCalls, 0);
+    });
+
+    test('parameter errors are 400s naming the field', async function (assert) {
+      await seedInstanceRow('card-1');
+
+      let unknown = await get('_screenshot/card-1?sparkle=true');
+      assert.strictEqual(unknown.status, 400);
+      assert.true((await unknown.text()).includes('sparkle'));
+
+      let mixed = await get('_screenshot/card-1?name=hero&format=embedded');
+      assert.strictEqual(mixed.status, 400);
+      assert.true((await mixed.text()).includes('name cannot be combined'));
+    });
+
+    test('a missing instance is an uncaptured miss, not a capture attempt', async function (assert) {
+      await seedRealmConfigRow(true);
+      await startWorker();
+
+      let response = await get('_screenshot/nope');
+
+      assert.strictEqual(response.status, 404);
+      assert.strictEqual(captureCalls, 0);
+    });
+  });
+});

--- a/packages/realm-server/tests/media-cache-gc-test.ts
+++ b/packages/realm-server/tests/media-cache-gc-test.ts
@@ -22,44 +22,11 @@ import {
   touchMediaCacheEntry,
 } from '@cardstack/runtime-common';
 
+import { FakeMediaCacheAdapter } from './helpers/fake-media-cache-adapter.ts';
 import { setupDB } from './helpers/index.ts';
 
 const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;
-
-// In-memory MediaCacheAdapter: enough store to observe what the sweep
-// deletes, plus scriptable per-key delete failures.
-class FakeMediaCacheAdapter implements MediaCacheAdapter {
-  objects = new Map<string, Uint8Array>();
-  deleted: string[] = [];
-  failDeletesFor = new Set<string>();
-
-  async put(key: string, bytes: Uint8Array, _opts: { contentType: string }) {
-    if (!this.objects.has(key)) {
-      this.objects.set(key, bytes);
-    }
-  }
-  async head(key: string) {
-    let bytes = this.objects.get(key);
-    return bytes ? { size: bytes.length } : undefined;
-  }
-  async getStream(key: string) {
-    let bytes = this.objects.get(key);
-    if (!bytes) {
-      return undefined;
-    }
-    return (async function* () {
-      yield bytes;
-    })();
-  }
-  async delete(key: string) {
-    if (this.failDeletesFor.has(key)) {
-      throw new Error(`simulated delete failure for ${key}`);
-    }
-    this.deleted.push(key);
-    this.objects.delete(key);
-  }
-}
 
 module(basename(import.meta.filename), function (hooks) {
   let dbAdapter: PgAdapter;

--- a/packages/realm-server/tests/screenshot-card-test.ts
+++ b/packages/realm-server/tests/screenshot-card-test.ts
@@ -150,6 +150,9 @@ module(basename(import.meta.filename), function () {
         runAs: '@someone:localhost',
         cardId,
         format: 'isolated',
+        // The POST surface returns the capture in its response body rather
+        // than recording it in the MediaCache ledger.
+        persist: null,
       });
     });
 

--- a/packages/runtime-common/capture-spec.ts
+++ b/packages/runtime-common/capture-spec.ts
@@ -1,0 +1,98 @@
+import { computeMediaCacheKey } from './media-cache.ts';
+
+// The capture spec: every way a screenshot capture can be parameterized,
+// shared by the POST /_screenshot-card body and the GET `_screenshot/` URL
+// DSL so the two surfaces validate identically and one capture satisfies
+// both. The spec's canonical form is what keys the MediaCache ledger, so
+// everything here is deliberately strict: two requests that mean the same
+// capture must canonicalize to the same string, and a parameter the engine
+// cannot honor is refused by name rather than ignored (ignoring would fold
+// different intents onto one cache key and serve the wrong image).
+
+export const CAPTURE_FORMATS = ['isolated', 'embedded'] as const;
+export type CaptureFormat = (typeof CAPTURE_FORMATS)[number];
+export const DEFAULT_CAPTURE_FORMAT: CaptureFormat = 'isolated';
+
+export function isCaptureFormat(value: unknown): value is CaptureFormat {
+  return (CAPTURE_FORMATS as readonly unknown[]).includes(value);
+}
+
+export interface CaptureSpec {
+  format: CaptureFormat;
+}
+
+// The DSL's parameter surface grows with the capture engine; these names are
+// reserved for the engine capabilities the project's URL grammar assigns
+// them, and refused (never ignored) while the engine lacks them.
+const RESERVED_CAPTURE_PARAMS = new Set([
+  'envelope',
+  'viewport',
+  'dsf',
+  'fullPage',
+  'clip',
+  'target',
+]);
+
+export type CaptureSpecParseResult =
+  | { spec: CaptureSpec }
+  | { error: { field: string; message: string } };
+
+// Parses the flat, unprefixed query params of a `_screenshot/` request into
+// a spec. Strict on principle (see the module comment): unknown and
+// reserved params, repeated params, and out-of-range values are each a 400
+// naming the offending field. `name=` addresses a declared screenshot, a
+// different addressing form entirely — the route splits it off before
+// calling this.
+export function parseCaptureSpecParams(
+  searchParams: URLSearchParams,
+): CaptureSpecParseResult {
+  for (let key of new Set(searchParams.keys())) {
+    if (key === 'format') {
+      continue;
+    }
+    let message = RESERVED_CAPTURE_PARAMS.has(key)
+      ? `parameter "${key}" is not supported by this capture engine`
+      : `unsupported parameter "${key}"`;
+    return { error: { field: key, message } };
+  }
+  if (searchParams.getAll('format').length > 1) {
+    return {
+      error: { field: 'format', message: 'format may only be given once' },
+    };
+  }
+  let format = searchParams.get('format') ?? DEFAULT_CAPTURE_FORMAT;
+  if (!isCaptureFormat(format)) {
+    // Same wording as the POST /_screenshot-card validation.
+    return {
+      error: {
+        field: 'format',
+        message: 'format must be "isolated" or "embedded"',
+      },
+    };
+  }
+  return { spec: { format } };
+}
+
+// The canonical serialization: keys sorted, default-valued fields elided —
+// so the all-defaults spec is `{}` however it was spelled, and any two
+// requests meaning the same capture hash identically.
+export function canonicalCaptureSpecString(spec: CaptureSpec): string {
+  let canonical: Record<string, unknown> = {};
+  if (spec.format !== DEFAULT_CAPTURE_FORMAT) {
+    canonical.format = spec.format;
+  }
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.entries(canonical).sort(([a], [b]) => a.localeCompare(b)),
+    ),
+  );
+}
+
+// The ledger key component for a spec: the hash of its canonical form (the
+// same sha256-hex the store uses for content addresses, though this one
+// keys intent rather than bytes).
+export async function captureSpecHash(spec: CaptureSpec): Promise<string> {
+  return await computeMediaCacheKey(
+    new TextEncoder().encode(canonicalCaptureSpecString(spec)),
+  );
+}

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -442,6 +442,34 @@ export class IndexQueryEngine {
     return rows.length > 0;
   }
 
+  // The index generation of a live instance, or undefined when none matches —
+  // the generation companion to `hasLiveInstance`, matching the same row
+  // predicate (including the effective-error channel) but selecting the one
+  // column the screenshot cache key needs, still without hydrating the row.
+  // Used where the caller needs both the liveness gate and the generation, so
+  // the two collapse into a single narrow read.
+  async liveInstanceGeneration(
+    url: URL,
+    opts?: GetEntryOptions,
+  ): Promise<number | undefined> {
+    let rows = (await this.#query([
+      'SELECT i.generation',
+      `FROM ${tableFromOpts(opts)} AS i ${prerenderedJoin(opts)}`,
+      'WHERE',
+      ...every([
+        any([
+          [`i.url =`, param(url.href)],
+          [`i.file_alias =`, param(url.href)],
+        ]),
+        ['i.type =', param('instance')],
+        any([['i.is_deleted = FALSE'], ['i.is_deleted IS NULL']]),
+        [`NOT ${effectiveHasError()}`],
+      ]),
+      'LIMIT 1',
+    ] as Expression)) as unknown as { generation: number }[];
+    return rows.length > 0 ? Number(rows[0].generation) : undefined;
+  }
+
   // Shared row → InstanceOrError mapping for getInstance / getInstances.
   // `lookupURL` is used only for error context and is optional in the batch path.
   #rowToInstanceOrError(

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1064,6 +1064,7 @@ export * from './job-utils.ts';
 export * from './prerender-html-reconcile.ts';
 export * from './media-cache.ts';
 export * from './media-cache-serving.ts';
+export * from './capture-spec.ts';
 export * from './expression.ts';
 export * from './searchable-parity.ts';
 export * from './infer-content-type.ts';

--- a/packages/runtime-common/jobs/screenshot-card.ts
+++ b/packages/runtime-common/jobs/screenshot-card.ts
@@ -21,12 +21,19 @@ export const SCREENSHOT_CARD_JOB_TIMEOUT_SEC = 60;
 // render identity, and persist target — since joining hands the incoming
 // caller the twin's result verbatim. Queued and in-flight twins both join;
 // an in-flight join just registers a late waiter on the running job.
+//
+// Only the ledger-backed GET lane coalesces. Its persist target pins the
+// source generation, so a joined caller can never be handed a capture of a
+// different revision. `POST /_screenshot-card` publishes with `persist: null`
+// — a render-now request whose identity carries no freshness axis, so an
+// in-flight twin could be up to a reservation-lease old and of a pre-edit
+// card; those always insert.
 function chooseScreenshotCardCoalesceDecision(
   context: QueueCoalesceContext,
 ): QueueCoalesceDecision {
   let { incoming, candidates, inFlightCandidates } = context;
   let incomingArgs = parseScreenshotCardArgs(incoming.args);
-  if (!incomingArgs) {
+  if (!incomingArgs || !incomingArgs.persist) {
     return { type: 'insert' };
   }
   let twin = [...candidates, ...inFlightCandidates].find((candidate) => {
@@ -116,6 +123,11 @@ export interface ScreenshotQueueEstimate {
   // behind the realm's serialized screenshot lane before its own capture
   // even starts.
   estimatedWaitMs: number;
+  // True when a queued or in-flight job already carries this exact capture
+  // identity: the incoming request would coalesce onto it and cost no new
+  // Chrome work, so the caller skips the congestion pre-check rather than
+  // 503-ing a request the lane is about to satisfy for free.
+  hasTwin: boolean;
 }
 
 // The fail-fast congestion pre-check for a capture-triggering request:
@@ -128,26 +140,67 @@ export interface ScreenshotQueueEstimate {
 export async function estimateScreenshotQueueWait(
   dbAdapter: DBAdapter,
   concurrencyGroup: string,
+  // The persist identity of the capture about to be requested. When a queued
+  // or in-flight job already matches it, the request coalesces rather than
+  // rendering, so `hasTwin` lets the caller bypass the congestion gate.
+  twinOf?: {
+    sourceURL: string;
+    captureSpecHash: string;
+    sourceGeneration: number;
+  },
 ): Promise<ScreenshotQueueEstimate> {
   if (dbAdapter.kind !== 'pg') {
-    return { pending: 0, avgCaptureMs: 0, estimatedWaitMs: 0 };
+    return { pending: 0, avgCaptureMs: 0, estimatedWaitMs: 0, hasTwin: false };
   }
-  let [pendingRows, durationRows] = await Promise.all([
+  let [pendingRows, durationRows, twinRows] = await Promise.all([
     query(dbAdapter, [
-      `SELECT COUNT(*) AS pending FROM jobs WHERE status = 'unfulfilled' AND concurrency_group =`,
+      `SELECT COUNT(*) AS pending FROM jobs
+        WHERE status = 'unfulfilled'
+          AND job_type = 'screenshot-card'
+          AND concurrency_group =`,
       param(concurrencyGroup),
     ] as Expression) as Promise<{ pending: number | string }[]>,
     // Execution time is reservation-claim → job-finish (there is no
-    // started_at column); resolved captures only, bounded lookback so the
-    // estimate tracks current conditions.
+    // started_at column). Aggregate per job and measure from the last
+    // (winning) claim: a lease-lapsed retry leaves an earlier abandoned
+    // reservation whose completed_at is also set, and its row spans the
+    // whole expired lease — averaging that in would drag the estimate toward
+    // the lease duration and 503 a healthy queue. Realm-scoped to match the
+    // per-realm `pending` count, resolved captures only, bounded lookback.
     query(dbAdapter, [
-      `SELECT AVG(EXTRACT(EPOCH FROM (j.finished_at - jr.created_at)) * 1000) AS avg_ms
-       FROM jobs j
-       JOIN job_reservations jr ON jr.job_id = j.id AND jr.completed_at IS NOT NULL
-       WHERE j.job_type = 'screenshot-card'
-         AND j.status = 'resolved'
-         AND j.finished_at > NOW() - INTERVAL '${CAPTURE_DURATION_LOOKBACK_HOURS} hours'`,
+      `SELECT AVG(ms) AS avg_ms FROM (
+         SELECT EXTRACT(EPOCH FROM (j.finished_at - MAX(jr.created_at))) * 1000 AS ms
+           FROM jobs j
+           JOIN job_reservations jr ON jr.job_id = j.id AND jr.completed_at IS NOT NULL
+          WHERE j.job_type = 'screenshot-card'
+            AND j.status = 'resolved'
+            AND j.finished_at > NOW() - INTERVAL '${CAPTURE_DURATION_LOOKBACK_HOURS} hours'
+            AND j.concurrency_group =`,
+      param(concurrencyGroup),
+      `GROUP BY j.id, j.finished_at
+       ) t`,
     ] as Expression) as Promise<{ avg_ms: number | string | null }[]>,
+    twinOf
+      ? (query(dbAdapter, [
+          // A pending/in-flight job carrying the same persist target (jsonb
+          // extraction, so the compares are text — sourceGeneration binds as
+          // a string to match). Confined to the GET lane's identity fields;
+          // POST jobs have no persist and never appear here.
+          `SELECT EXISTS (
+             SELECT 1 FROM jobs
+              WHERE status = 'unfulfilled'
+                AND job_type = 'screenshot-card'
+                AND concurrency_group =`,
+          param(concurrencyGroup),
+          `AND args->'persist'->>'sourceURL' =`,
+          param(twinOf.sourceURL),
+          `AND args->'persist'->>'captureSpecHash' =`,
+          param(twinOf.captureSpecHash),
+          `AND args->'persist'->>'sourceGeneration' =`,
+          param(String(twinOf.sourceGeneration)),
+          `) AS has_twin`,
+        ] as Expression) as Promise<{ has_twin: boolean }[]>)
+      : Promise.resolve([{ has_twin: false }]),
   ]);
   let pending = Number(pendingRows[0]?.pending ?? 0);
   let avgRaw = durationRows[0]?.avg_ms;
@@ -157,6 +210,7 @@ export async function estimateScreenshotQueueWait(
     pending,
     avgCaptureMs,
     estimatedWaitMs: pending * avgCaptureMs,
+    hasTwin: Boolean(twinRows[0]?.has_twin),
   };
 }
 

--- a/packages/runtime-common/jobs/screenshot-card.ts
+++ b/packages/runtime-common/jobs/screenshot-card.ts
@@ -1,8 +1,73 @@
+import { param, query, type Expression } from '../expression.ts';
 import type { QueuePublisher } from '../queue.ts';
 import type { ScreenshotPrerenderResponse, DBAdapter } from '../index.ts';
 import type { ScreenshotCardArgs } from '../tasks/screenshot-card.ts';
 
 export const SCREENSHOT_CARD_JOB_TIMEOUT_SEC = 60;
+
+// How long a GET `_screenshot/` request holds its connection waiting for an
+// on-demand capture before answering 503 + Retry-After. A cost-posture
+// bound, not a transport one (the realm-server ALB's idle timeout is far
+// above this): sync-wait callers are humans, agents, and scripts that honor
+// Retry-After — HTML and crawlers live on the never-waiting `name=` path —
+// so the hold is a courtesy and the Retry-After is the contract.
+export const SCREENSHOT_SYNC_WAIT_BUDGET_MS = 25_000;
+
+// The stand-in capture estimate while the jobs table holds no recent
+// screenshot history to average.
+const DEFAULT_CAPTURE_ESTIMATE_MS = 10_000;
+const CAPTURE_DURATION_LOOKBACK_HOURS = 1;
+
+export interface ScreenshotQueueEstimate {
+  pending: number;
+  avgCaptureMs: number;
+  // queue depth × average capture time: what a new arrival would wait
+  // behind the realm's serialized screenshot lane before its own capture
+  // even starts.
+  estimatedWaitMs: number;
+}
+
+// The fail-fast congestion pre-check for a capture-triggering request:
+// when the realm's serialized screenshot lane is already deep enough that a
+// new arrival's wait would blow the sync budget, the caller answers 503 +
+// Retry-After immediately instead of holding a doomed connection against
+// the queue. The jobs-table SQL is Postgres-shaped; on any other adapter
+// (an in-memory test realm) the estimate is zero, which simply skips the
+// pre-check.
+export async function estimateScreenshotQueueWait(
+  dbAdapter: DBAdapter,
+  concurrencyGroup: string,
+): Promise<ScreenshotQueueEstimate> {
+  if (dbAdapter.kind !== 'pg') {
+    return { pending: 0, avgCaptureMs: 0, estimatedWaitMs: 0 };
+  }
+  let [pendingRows, durationRows] = await Promise.all([
+    query(dbAdapter, [
+      `SELECT COUNT(*) AS pending FROM jobs WHERE status = 'unfulfilled' AND concurrency_group =`,
+      param(concurrencyGroup),
+    ] as Expression) as Promise<{ pending: number | string }[]>,
+    // Execution time is reservation-claim → job-finish (there is no
+    // started_at column); resolved captures only, bounded lookback so the
+    // estimate tracks current conditions.
+    query(dbAdapter, [
+      `SELECT AVG(EXTRACT(EPOCH FROM (j.finished_at - jr.created_at)) * 1000) AS avg_ms
+       FROM jobs j
+       JOIN job_reservations jr ON jr.job_id = j.id AND jr.completed_at IS NOT NULL
+       WHERE j.job_type = 'screenshot-card'
+         AND j.status = 'resolved'
+         AND j.finished_at > NOW() - INTERVAL '${CAPTURE_DURATION_LOOKBACK_HOURS} hours'`,
+    ] as Expression) as Promise<{ avg_ms: number | string | null }[]>,
+  ]);
+  let pending = Number(pendingRows[0]?.pending ?? 0);
+  let avgRaw = durationRows[0]?.avg_ms;
+  let avgCaptureMs =
+    avgRaw == null ? DEFAULT_CAPTURE_ESTIMATE_MS : Number(avgRaw);
+  return {
+    pending,
+    avgCaptureMs,
+    estimatedWaitMs: pending * avgCaptureMs,
+  };
+}
 
 export async function enqueueScreenshotCardJob(
   args: ScreenshotCardArgs,

--- a/packages/runtime-common/jobs/screenshot-card.ts
+++ b/packages/runtime-common/jobs/screenshot-card.ts
@@ -1,9 +1,100 @@
 import { param, query, type Expression } from '../expression.ts';
-import type { QueuePublisher } from '../queue.ts';
+import {
+  registerQueueJobDefinition,
+  type QueueCoalesceContext,
+  type QueueCoalesceDecision,
+  type QueuePublisher,
+} from '../queue.ts';
 import type { ScreenshotPrerenderResponse, DBAdapter } from '../index.ts';
-import type { ScreenshotCardArgs } from '../tasks/screenshot-card.ts';
+import type {
+  ScreenshotCardArgs,
+  ScreenshotPersistArgs,
+} from '../tasks/screenshot-card.ts';
 
 export const SCREENSHOT_CARD_JOB_TIMEOUT_SEC = 60;
+
+// Concurrent requests for one capture fold onto one job: the per-realm
+// concurrency group serializes execution but does not dedupe, so without
+// this two simultaneous misses for the same spec would each run a full
+// render (the store's dedupe-on-write only saves the second upload, not the
+// Chrome work). A twin must match the whole capture identity — card, format,
+// render identity, and persist target — since joining hands the incoming
+// caller the twin's result verbatim. Queued and in-flight twins both join;
+// an in-flight join just registers a late waiter on the running job.
+function chooseScreenshotCardCoalesceDecision(
+  context: QueueCoalesceContext,
+): QueueCoalesceDecision {
+  let { incoming, candidates, inFlightCandidates } = context;
+  let incomingArgs = parseScreenshotCardArgs(incoming.args);
+  if (!incomingArgs) {
+    return { type: 'insert' };
+  }
+  let twin = [...candidates, ...inFlightCandidates].find((candidate) => {
+    if (candidate.jobType !== incoming.jobType) {
+      return false;
+    }
+    let candidateArgs = parseScreenshotCardArgs(candidate.args);
+    return (
+      candidateArgs !== undefined &&
+      candidateArgs.cardId === incomingArgs.cardId &&
+      candidateArgs.format === incomingArgs.format &&
+      candidateArgs.runAs === incomingArgs.runAs &&
+      samePersist(candidateArgs.persist, incomingArgs.persist)
+    );
+  });
+  if (!twin) {
+    return { type: 'insert' };
+  }
+  return { type: 'join', jobId: twin.id };
+}
+
+function parseScreenshotCardArgs(
+  args: unknown,
+): ScreenshotCardArgs | undefined {
+  let obj: unknown = args;
+  if (typeof args === 'string') {
+    try {
+      obj = JSON.parse(args);
+    } catch {
+      return undefined;
+    }
+  }
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+    return undefined;
+  }
+  let { cardId, format, runAs } = obj as Record<string, unknown>;
+  if (
+    typeof cardId !== 'string' ||
+    typeof format !== 'string' ||
+    typeof runAs !== 'string'
+  ) {
+    return undefined;
+  }
+  return obj as ScreenshotCardArgs;
+}
+
+// Field-by-field rather than JSON.stringify: one side round-trips through
+// jsonb, which does not preserve key order.
+function samePersist(
+  a: ScreenshotPersistArgs | null | undefined,
+  b: ScreenshotPersistArgs | null | undefined,
+): boolean {
+  if (!a || !b) {
+    return !a && !b;
+  }
+  return (
+    a.realmURL === b.realmURL &&
+    a.sourceURL === b.sourceURL &&
+    a.captureSpecHash === b.captureSpecHash &&
+    a.sourceGeneration === b.sourceGeneration &&
+    a.lane === b.lane
+  );
+}
+
+registerQueueJobDefinition({
+  jobType: 'screenshot-card',
+  coalesce: chooseScreenshotCardCoalesceDecision,
+});
 
 // How long a GET `_screenshot/` request holds its connection waiting for an
 // on-demand capture before answering 503 + Retry-After. A cost-posture

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -783,6 +783,16 @@ export class RealmIndexQueryEngine {
     return await this.#indexQueryEngine.hasLiveInstance(url, opts);
   }
 
+  // The live instance's index generation (undefined when not live) — the
+  // liveness gate and the cache-key generation in one narrow read, without
+  // hydrating the row.
+  async liveInstanceGeneration(
+    url: URL,
+    opts?: QueryOptions,
+  ): Promise<number | undefined> {
+    return await this.#indexQueryEngine.liveInstanceGeneration(url, opts);
+  }
+
   async file(url: URL, opts?: QueryOptions): Promise<IndexedFile | undefined> {
     return await this.#indexQueryEngine.getFile(url, opts);
   }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -4068,9 +4068,10 @@ export class Realm {
   // parent instance must be live: this gives per-instance ACLs a place to
   // land, and captures of a deleted instance stop serving the moment its
   // index tombstone appears, ahead of GC reclaiming their artifacts. The
-  // gate is a narrow existence probe (`hasLiveInstance`), never an instance
-  // hydration — it runs on every request, 304 revalidations included. Any
-  // request that resolves to no capture — instance missing or errored,
+  // gate is a narrow index read (`liveInstanceGeneration`) that returns the
+  // live instance's generation for the cache key, never a full hydration — it
+  // runs on every request, 304 revalidations included. Any request that
+  // resolves to no capture — instance missing or errored,
   // store unconfigured, addressing unresolvable — is an uncaptured miss:
   // 404 with a short max-age so an `<img>` picks up a later capture on
   // revalidation, never a synchronous wait inside an image load.
@@ -4085,7 +4086,13 @@ export class Realm {
     let instanceURL = this.paths.fileURL(
       instanceLocalPath.replace(/\.json$/, ''),
     );
-    if (!(await this.#realmIndexQueryEngine.hasLiveInstance(instanceURL))) {
+    // One narrow read is both the liveness gate and the cache key's
+    // generation: undefined means the instance is missing, deleted, or
+    // errored — an uncaptured miss — and otherwise it pins the generation an
+    // edit bumps, without hydrating the row.
+    let sourceGeneration =
+      await this.#realmIndexQueryEngine.liveInstanceGeneration(instanceURL);
+    if (sourceGeneration === undefined) {
       return mediaCacheMissResponse({ requestContext });
     }
     let searchParams = new URL(request.url).searchParams;
@@ -4121,7 +4128,7 @@ export class Realm {
       realmURL: this.url,
       sourceURL: instanceURL.href,
       captureSpecHash: await captureSpecHash(parsed.spec),
-      sourceGeneration: Number(instance.generation),
+      sourceGeneration,
     };
     let entry = await findMediaCacheEntry(this.#dbAdapter, entryKey);
     if (entry) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -180,6 +180,8 @@ import {
 import {
   mediaCacheMissResponse,
   serveMediaCacheEntry,
+  mediaCacheVisibility,
+  MEDIA_CACHE_MAX_AGE_SECONDS,
 } from './media-cache-serving.ts';
 import {
   enqueueScreenshotCardJob,
@@ -4161,21 +4163,38 @@ export class Realm {
     spec: CaptureSpec,
   ): Promise<ResponseWithNodeStream> {
     if (!(await this.allowsArbitraryScreenshots())) {
-      return responseWithError(
-        new CardError(
-          `This realm does not allow arbitrary screenshot captures: set "allowArbitraryScreenshots" to true on the realm's config card to enable them. Captures that already exist still serve.`,
-          { status: 403 },
-        ),
+      // 403 isn't heuristically cacheable, so with no explicit freshness a
+      // browser re-requests on every `<img>` load — and absent-⇒-false means
+      // every realm is gated by default. Carry the same short window the miss
+      // uses so a gated realm's image loads stop hammering the origin (and so
+      // opting the realm in surfaces images within that same window).
+      return createResponse({
+        body: `This realm does not allow arbitrary screenshot captures: set "allowArbitraryScreenshots" to true on the realm's config card to enable them. Captures that already exist still serve.`,
+        init: {
+          status: 403,
+          headers: {
+            'cache-control': `${mediaCacheVisibility(requestContext)}, max-age=${MEDIA_CACHE_MAX_AGE_SECONDS}`,
+          },
+        },
         requestContext,
-      );
+      });
     }
 
     let concurrencyGroup = `screenshot:${this.url}`;
     let estimate = await estimateScreenshotQueueWait(
       this.#dbAdapter,
       concurrencyGroup,
+      entryKey,
     );
-    if (estimate.estimatedWaitMs > this.#screenshotSyncWaitMs) {
+    // A request whose capture is already queued or rendering coalesces onto
+    // that job (see `chooseScreenshotCardCoalesceDecision`) and costs no new
+    // Chrome work, so the lane's depth is not its wait — only a genuinely new
+    // capture faces the congestion gate. Without this, the second viewer of a
+    // card that is mid-render is 503'd against a wait it would never incur.
+    if (
+      !estimate.hasTwin &&
+      estimate.estimatedWaitMs > this.#screenshotSyncWaitMs
+    ) {
       return this.screenshotRetryLater(
         requestContext,
         estimate.estimatedWaitMs,
@@ -4268,12 +4287,16 @@ export class Realm {
     requestContext: RequestContext,
     estimatedWaitMs: number,
   ): Response {
+    let retryAfterSeconds = Math.max(1, Math.ceil(estimatedWaitMs / 1000));
     return createResponse({
-      body: null,
+      // Every other refusal on this route names its reason (the 400s name the
+      // field, the 403 names the flag); a sync-wait caller honoring
+      // Retry-After gets one too.
+      body: `Screenshot capture is queued; retry after ${retryAfterSeconds} seconds.`,
       init: {
         status: 503,
         headers: {
-          'retry-after': String(Math.max(1, Math.ceil(estimatedWaitMs / 1000))),
+          'retry-after': String(retryAfterSeconds),
         },
       },
       requestContext,
@@ -4281,7 +4304,7 @@ export class Realm {
   }
 
   // The per-realm opt-in for GET-triggered captures, read from the realm's
-  // indexed config card on every check — so a `.realm.json` edit takes
+  // indexed config card on every check — so a `realm.json` edit takes
   // effect with its own index update, with no restart and no cache to
   // invalidate. Absent, unindexed, or anything but `true` all read as
   // gated.

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -166,11 +166,26 @@ import {
 import { parseQuery } from './query.ts';
 import type { Readable } from 'stream';
 import { createResponse } from './create-response.ts';
-import type { MediaCacheAdapter, MediaCacheEntry } from './media-cache.ts';
+import {
+  captureSpecHash,
+  parseCaptureSpecParams,
+  type CaptureSpec,
+} from './capture-spec.ts';
+import {
+  findMediaCacheEntry,
+  putMedia,
+  type MediaCacheAdapter,
+  type MediaCacheEntryKey,
+} from './media-cache.ts';
 import {
   mediaCacheMissResponse,
   serveMediaCacheEntry,
 } from './media-cache-serving.ts';
+import {
+  enqueueScreenshotCardJob,
+  estimateScreenshotQueueWait,
+  SCREENSHOT_SYNC_WAIT_BUDGET_MS,
+} from './jobs/screenshot-card.ts';
 import { mergeRelationships } from './merge-relationships.ts';
 import { getCardDirectoryName } from './helpers/card-directory-name.ts';
 import {
@@ -846,6 +861,11 @@ interface Options {
   // removes both the startup wait and the prerender-pool contention it would
   // otherwise create with the tests.
   skipBootIndex?: true;
+  // How long a `_screenshot/` request holds its connection waiting for an
+  // on-demand capture before answering 503 + Retry-After. Defaults to
+  // SCREENSHOT_SYNC_WAIT_BUDGET_MS; tests shrink it to exercise the timeout
+  // path without holding real time.
+  screenshotSyncWaitMs?: number;
 }
 
 interface UpdateItem {
@@ -965,6 +985,7 @@ export class Realm {
   #queue: QueuePublisher;
   #virtualNetwork: VirtualNetwork;
   #mediaCacheAdapter: MediaCacheAdapter | undefined;
+  #screenshotSyncWaitMs: number;
   #cachedRealmInfo: RealmInfo | null = null;
   // md5 of the JSON-stringified `#cachedRealmInfo`. Folded into the
   // card+json ETag so any path that nulls `#cachedRealmInfo` (e.g.
@@ -1098,6 +1119,8 @@ export class Realm {
     this.#disableModuleCaching = Boolean(opts?.disableModuleCaching);
     this.#copiedFromRealm = opts?.copiedFromRealm;
     this.#mediaCacheAdapter = mediaCacheAdapter;
+    this.#screenshotSyncWaitMs =
+      opts?.screenshotSyncWaitMs ?? SCREENSHOT_SYNC_WAIT_BUDGET_MS;
     let owner: string | undefined;
     let _fetch = fetcher(
       virtualNetwork.fetch,
@@ -4063,32 +4086,214 @@ export class Realm {
     if (!(await this.#realmIndexQueryEngine.hasLiveInstance(instanceURL))) {
       return mediaCacheMissResponse({ requestContext });
     }
-    let entry = await this.resolveScreenshotEntry(
-      instanceURL,
-      new URL(request.url).searchParams,
-    );
-    if (!entry) {
+    let searchParams = new URL(request.url).searchParams;
+
+    // `name=` addresses a declared screenshot through the instance's
+    // manifest — a different addressing form from the capture-spec params,
+    // so mixing them is a request with two contradictory identities.
+    let name = searchParams.get('name');
+    if (name !== null) {
+      let extraParams = [...new Set(searchParams.keys())].filter(
+        (key) => key !== 'name',
+      );
+      if (extraParams.length > 0) {
+        return badRequest({
+          message: `name cannot be combined with capture parameters ("${extraParams[0]}")`,
+          requestContext,
+        });
+      }
+      // Declared-screenshot manifests are indexing-time artifacts; nothing
+      // publishes them, so every name is an uncaptured miss.
       return mediaCacheMissResponse({ requestContext });
     }
-    return await serveMediaCacheEntry({
+
+    let parsed = parseCaptureSpecParams(searchParams);
+    if ('error' in parsed) {
+      return badRequest({ message: parsed.error.message, requestContext });
+    }
+
+    // The cache key pins the instance's own index generation: an edit bumps
+    // it, so an edited card can never serve a stale capture, and an
+    // unchanged card is a pure ledger hit with zero Chrome work.
+    let entryKey: MediaCacheEntryKey = {
+      realmURL: this.url,
+      sourceURL: instanceURL.href,
+      captureSpecHash: await captureSpecHash(parsed.spec),
+      sourceGeneration: Number(instance.generation),
+    };
+    let entry = await findMediaCacheEntry(this.#dbAdapter, entryKey);
+    if (entry) {
+      // A hit costs zero Chrome work, so hits serve regardless of the
+      // realm's capture gate — including captures a write-holder published
+      // via POST on a gated realm.
+      return await serveMediaCacheEntry({
+        request,
+        requestContext,
+        entry,
+        mediaCacheAdapter: this.#mediaCacheAdapter,
+        dbAdapter: this.#dbAdapter,
+      });
+    }
+    return await this.captureScreenshotOnDemand(
       request,
       requestContext,
-      entry,
-      mediaCacheAdapter: this.#mediaCacheAdapter,
-      dbAdapter: this.#dbAdapter,
+      entryKey,
+      parsed.spec,
+    );
+  }
+
+  // The miss path: a capture no ledger entry satisfies. Full captureSpec
+  // power on an unauthenticated-reachable GET is an unbounded spec space, so
+  // new captures are per-realm opt-in (`allowArbitraryScreenshots` on the
+  // realm's config card — the gate blocks Chrome work, never serving), and
+  // an open realm's captures run through the same per-realm serialized
+  // screenshot queue as the POST endpoint, bounded by a sync-wait budget:
+  //   - lane already too deep for the budget → immediate 503 + Retry-After
+  //     (fail fast instead of holding a doomed connection);
+  //   - otherwise enqueue and wait up to the budget; the job persists its
+  //     capture to the MediaCache itself, so a wait that times out (503 +
+  //     Retry-After) still lands the capture and the client's retry is a
+  //     pure ledger hit.
+  private async captureScreenshotOnDemand(
+    request: Request,
+    requestContext: RequestContext,
+    entryKey: MediaCacheEntryKey,
+    spec: CaptureSpec,
+  ): Promise<ResponseWithNodeStream> {
+    if (!(await this.allowsArbitraryScreenshots())) {
+      return responseWithError(
+        new CardError(
+          `This realm does not allow arbitrary screenshot captures: set "allowArbitraryScreenshots" to true on the realm's config card to enable them. Captures that already exist still serve.`,
+          { status: 403 },
+        ),
+        requestContext,
+      );
+    }
+
+    let concurrencyGroup = `screenshot:${this.url}`;
+    let estimate = await estimateScreenshotQueueWait(
+      this.#dbAdapter,
+      concurrencyGroup,
+    );
+    if (estimate.estimatedWaitMs > this.#screenshotSyncWaitMs) {
+      return this.screenshotRetryLater(
+        requestContext,
+        estimate.estimatedWaitMs,
+      );
+    }
+
+    // Render as the realm's owner — the same identity an index pass renders
+    // under. The requester already proved realm read; the capture is a
+    // realm-derived artifact, not a per-user view.
+    let owner = await this.getRealmOwnerUserId();
+    let job = await enqueueScreenshotCardJob(
+      {
+        realmURL: this.url,
+        realmUsername: owner,
+        runAs: owner,
+        cardId: entryKey.sourceURL,
+        format: spec.format,
+        persist: { ...entryKey, lane: 'on-demand' },
+      },
+      this.#queue,
+      this.#dbAdapter,
+      userInitiatedPriority,
+    );
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    // `const` so the symbol gets a unique-symbol type and the race result
+    // narrows on comparison.
+    const timedOut = Symbol('sync-wait-timeout');
+    try {
+      let outcome = await Promise.race([
+        job.done,
+        new Promise<typeof timedOut>((resolve) => {
+          timeoutHandle = setTimeout(
+            () => resolve(timedOut),
+            this.#screenshotSyncWaitMs,
+          );
+          timeoutHandle.unref?.();
+        }),
+      ]);
+      if (outcome === timedOut) {
+        // The job keeps running and persists its own capture; the retry
+        // hint is one average capture, since this request is now at the
+        // front of the lane.
+        return this.screenshotRetryLater(
+          requestContext,
+          Math.max(estimate.avgCaptureMs, 1000),
+        );
+      }
+      // Prefer the ledger entry the job persisted; fall back to persisting
+      // here from the response for a worker that has no store configured.
+      let entry = await findMediaCacheEntry(this.#dbAdapter, entryKey);
+      if (!entry && outcome.status === 'ready' && outcome.base64) {
+        let binary = atob(outcome.base64);
+        let bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+          bytes[i] = binary.charCodeAt(i);
+        }
+        await putMedia(this.#dbAdapter, this.#mediaCacheAdapter!, {
+          ...entryKey,
+          bytes,
+          contentType: outcome.contentType ?? 'image/png',
+          lane: 'on-demand',
+        });
+        entry = await findMediaCacheEntry(this.#dbAdapter, entryKey);
+      }
+      if (!entry) {
+        return systemError({
+          requestContext,
+          message: `screenshot capture failed for ${entryKey.sourceURL}`,
+          additionalError: outcome.error
+            ? new Error(String(outcome.error))
+            : undefined,
+        });
+      }
+      return await serveMediaCacheEntry({
+        request,
+        requestContext,
+        entry,
+        mediaCacheAdapter: this.#mediaCacheAdapter!,
+        dbAdapter: this.#dbAdapter,
+      });
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
+  private screenshotRetryLater(
+    requestContext: RequestContext,
+    estimatedWaitMs: number,
+  ): Response {
+    return createResponse({
+      body: null,
+      init: {
+        status: 503,
+        headers: {
+          'retry-after': String(Math.max(1, Math.ceil(estimatedWaitMs / 1000))),
+        },
+      },
+      requestContext,
     });
   }
 
-  // Resolution seam for the route's addressing forms: `name=` resolves
-  // through the instance's declared-screenshot manifest, and capture-spec
-  // params resolve through canonicalization to a ledger entry (see
-  // `findMediaCacheEntry`). This method is where those resolvers plug in;
-  // with none available, every request is an uncaptured miss.
-  private async resolveScreenshotEntry(
-    _instanceURL: URL,
-    _searchParams: URLSearchParams,
-  ): Promise<MediaCacheEntry | undefined> {
-    return undefined;
+  // The per-realm opt-in for GET-triggered captures, read from the realm's
+  // indexed config card on every check — so a `.realm.json` edit takes
+  // effect with its own index update, with no restart and no cache to
+  // invalidate. Absent, unindexed, or anything but `true` all read as
+  // gated.
+  private async allowsArbitraryScreenshots(): Promise<boolean> {
+    let realmConfigCardURL = new URL(
+      this.paths.fileURL('realm.json').href.replace(/\.json$/, ''),
+    );
+    let entry = await this.#realmIndexQueryEngine.instance(realmConfigCardURL);
+    if (entry?.type !== 'instance') {
+      return false;
+    }
+    return entry.instance.attributes?.allowArbitraryScreenshots === true;
   }
 
   private async serveLocalFile(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -4124,8 +4124,8 @@ export class Realm {
     let entry = await findMediaCacheEntry(this.#dbAdapter, entryKey);
     if (entry) {
       // A hit costs zero Chrome work, so hits serve regardless of the
-      // realm's capture gate — including captures a write-holder published
-      // via POST on a gated realm.
+      // realm's capture gate — however the capture came to be in the
+      // ledger.
       return await serveMediaCacheEntry({
         request,
         requestContext,

--- a/packages/runtime-common/tasks/screenshot-card.ts
+++ b/packages/runtime-common/tasks/screenshot-card.ts
@@ -6,10 +6,22 @@ import {
   fetchRealmPermissions,
   fetchUserPermissions,
   jobIdentity,
+  putMedia,
+  type MediaCacheLane,
   type ScreenshotPrerenderResponse,
   ensureFullMatrixUserId,
   ensureTrailingSlash,
 } from '../index.ts';
+
+// The ledger identity a capture persists under (see
+// `ScreenshotCardArgs.persist`).
+export interface ScreenshotPersistArgs extends JSONTypes.Object {
+  realmURL: string;
+  sourceURL: string;
+  captureSpecHash: string;
+  sourceGeneration: number;
+  lane: MediaCacheLane;
+}
 
 export interface ScreenshotCardArgs extends JSONTypes.Object {
   realmURL: string;
@@ -17,6 +29,14 @@ export interface ScreenshotCardArgs extends JSONTypes.Object {
   runAs: string;
   cardId: string;
   format: 'isolated' | 'embedded';
+  // When non-null, a successful capture is persisted to the MediaCache under
+  // this ledger identity before the job resolves. This is what makes a
+  // bounded-wait caller (the GET `_screenshot/` route's sync wait) safe to
+  // give up on: the capture still lands durably, and the caller's retry is
+  // a pure ledger hit instead of a second render. Non-optional `| null`
+  // rather than `?:` because the args are a `JSONTypes.Object`, whose index
+  // signature rejects `undefined`.
+  persist: ScreenshotPersistArgs | null;
 }
 
 export { screenshotCard };
@@ -28,9 +48,10 @@ const screenshotCard: Task<ScreenshotCardArgs, ScreenshotPrerenderResponse> = ({
   prerenderer,
   createPrerenderAuth,
   matrixURL,
+  mediaCacheAdapter,
 }) =>
   async function (args) {
-    let { jobInfo, realmURL, runAs, cardId, format } = args;
+    let { jobInfo, realmURL, runAs, cardId, format, persist } = args;
     log.debug(
       `${jobIdentity(jobInfo)} starting screenshot-card for job: ${JSON.stringify(
         {
@@ -85,7 +106,40 @@ const screenshotCard: Task<ScreenshotCardArgs, ScreenshotPrerenderResponse> = ({
       format,
       priority: jobInfo?.priority,
     });
+    // The local (in-process) prerenderer resolves to `{response, timings,
+    // pool}` while the remote one resolves to the bare response; unwrap so
+    // the job result is one shape either way.
+    let response: ScreenshotPrerenderResponse =
+      (result as any)?.response ?? result;
+
+    if (persist && response.status === 'ready' && response.base64) {
+      if (!mediaCacheAdapter) {
+        log.warn(
+          `${jobIdentity(jobInfo)} screenshot-card asked to persist but this worker has no media cache adapter configured; skipping`,
+        );
+      } else {
+        // Persist failure must not fail the capture: the response still
+        // carries the bytes, so the caller can serve (or store) them itself.
+        try {
+          let binary = atob(response.base64);
+          let bytes = new Uint8Array(binary.length);
+          for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+          }
+          await putMedia(dbAdapter, mediaCacheAdapter, {
+            ...persist,
+            bytes,
+            contentType: response.contentType ?? 'image/png',
+          });
+        } catch (e: any) {
+          log.error(
+            `${jobIdentity(jobInfo)} screenshot-card failed to persist capture to the media cache`,
+            e,
+          );
+        }
+      }
+    }
 
     reportStatus(jobInfo, 'finish');
-    return result;
+    return response;
   };


### PR DESCRIPTION
Stacked on #5840 (serving internals), which stacks on #5838 (the MediaCache store). This PR makes the `_screenshot/` route real: hybrid persisted-else-on-demand serving with today's capture capabilities.

## What this adds

**Capture-spec canonicalization** (`packages/runtime-common/capture-spec.ts`, shared with POST): flat unprefixed params parse into a spec whose canonical form (sorted keys, defaults elided) hashes into the ledger key — `?format=isolated`, `?format=isolated&`-noise, and the bare URL are one cache key. Today's parameter surface is `format` (`isolated`/`embedded`, matching what the capture engine supports); the engine-reserved params (`envelope`, `viewport`, `dsf`, `fullPage`, `clip`, `target`) are refused by name, never ignored — ignoring would fold different capture intents onto one cache key. All parameter errors are 400s naming the offending field, with format validation shared verbatim with `POST /_screenshot-card`.

**Cache key = (instance URL, canonical spec hash, the instance's own index generation).** An edit bumps the generation, so an edited card can never serve a stale capture; an unchanged card is a pure ledger hit with zero Chrome work — and hits serve regardless of the gate, including captures a write-holder published via POST on a gated realm.

**The `allowArbitraryScreenshots` gate**: a new BooleanField on the base `RealmConfig` card (absent ⇒ false), read from the realm's *indexed* config on every gate check — editing `realm.json` takes effect with its own index update, no restart, no cache to invalidate (pinned by a test that flips the indexed value between requests). A gated miss is a 403 whose body names the flag; the gate blocks Chrome work only, never serving.

**The miss path on an opted-in realm**:
- *Fail-fast congestion pre-check*: pending jobs in the realm's serialized `screenshot:` lane × recent average capture duration (from the jobs table, 1h lookback, reservation-claim→finish); if that already exceeds the sync budget, immediate 503 + Retry-After computed from the same math — no doomed connection held against the queue.
- *Bounded sync wait*: the capture runs through the existing `screenshot-card` job (rendered as the realm's owner, the same identity an index pass renders under), waited on for up to 25s. The budget is cost posture, not transport: the realm-server ALB idle timeout is configured at 4000s, so the ticket's stay-well-under-the-ALB question is settled with margin.
- *The job persists its own capture* (new `persist` args on `screenshot-card`; the worker writes to the MediaCache before resolving): a wait that times out answers 503 + Retry-After while the render completes and lands durably, so the client's retry is a pure ledger hit — never a second render. The route also persists from the job response itself as a fallback for workers without a store configured.

`name=` (declared screenshots) still misses — manifests are indexing-time artifacts that don't exist yet — and mixing `name=` with spec params is a 400. HEAD keeps the GET-only posture from the serving layer: even a captured spec answers HEAD from the generic handlers, pinned by test.

## Test plan

`media-cache-dsl-test` (real Postgres + real queue runner + real `screenshot-card` task over a stub prerenderer — no Chrome, no HTTP server): canonicalization/hash identities and per-field 400s; gated-realm ledger hit with zero capture work; gated miss 403 naming the flag; indexed-config flip opening the gate with no restart; capture→persist→serve with hit dedupe on the second request; generation-bump re-capture; sync-wait timeout → 503 + Retry-After with the capture landing anyway and the retry re-rendering nothing; congested-lane fail-fast 503; HEAD exclusion; missing-instance miss. The POST handler suite pins `persist: null` on its published jobs; all media-cache and screenshot suites pass (44 tests); typechecks clean across runtime-common, realm-server, base (via host), host, ai-bot, billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
