### PR TITLE
Update `ember-eslint-parser` and `eslint-plugin-ember`

### DIFF
--- a/packages/boxel-icons/package.json
+++ b/packages/boxel-icons/package.json
@@ -57,6 +57,7 @@
     "@typescript-eslint/parser": "catalog:",
     "babel-plugin-ember-template-compilation": "catalog:",
     "concurrently": "catalog:",
+    "ember-eslint-parser": "catalog:",
     "ember-source": "catalog:",
     "ember-template-imports": "^4.1.1",
     "ember-template-lint": "catalog:",

--- a/packages/boxel-ui/docs-app/package.json
+++ b/packages/boxel-ui/docs-app/package.json
@@ -71,6 +71,7 @@
     "ember-cli-htmlbars": "^6.3.0",
     "ember-concurrency": "catalog:",
     "ember-css-url": "^1.0.0",
+    "ember-eslint-parser": "catalog:",
     "ember-freestyle": "catalog:",
     "ember-load-initializers": "^3.0.0",
     "ember-modifier": "^4.1.0",

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -18,7 +18,7 @@
     "@universal-ember/test-support": "catalog:",
     "concurrently": "catalog:",
     "ember-concurrency": "catalog:",
-    "ember-eslint-parser": "^0.13.0",
+    "ember-eslint-parser": "^0.14.6",
     "ember-modifier": "^4.1.0",
     "ember-resources": "catalog:",
     "ember-template-lint": "catalog:",

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -18,7 +18,7 @@
     "@universal-ember/test-support": "catalog:",
     "concurrently": "catalog:",
     "ember-concurrency": "catalog:",
-    "ember-eslint-parser": "^0.14.6",
+    "ember-eslint-parser": "catalog:",
     "ember-modifier": "^4.1.0",
     "ember-resources": "catalog:",
     "ember-template-lint": "catalog:",

--- a/packages/eslint-plugin-boxel/package.json
+++ b/packages/eslint-plugin-boxel/package.json
@@ -37,7 +37,7 @@
     "eslint": "catalog:"
   },
   "dependencies": {
-    "ember-eslint-parser": "^0.13.0",
+    "ember-eslint-parser": "^0.14.6",
     "requireindex": "catalog:"
   },
   "devDependencies": {

--- a/packages/eslint-plugin-boxel/package.json
+++ b/packages/eslint-plugin-boxel/package.json
@@ -37,7 +37,7 @@
     "eslint": "catalog:"
   },
   "dependencies": {
-    "ember-eslint-parser": "^0.14.6",
+    "ember-eslint-parser": "catalog:",
     "requireindex": "catalog:"
   },
   "devDependencies": {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -123,6 +123,7 @@
     "ember-concurrency": "catalog:",
     "ember-css-url": "^1.0.0",
     "ember-elsewhere": "catalog:",
+    "ember-eslint-parser": "catalog:",
     "ember-exam": "^10.1.0",
     "ember-focus-trap": "^1.0.1",
     "ember-freestyle": "catalog:",

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -51,7 +51,7 @@
     "cron": "catalog:",
     "date-fns": "catalog:",
     "decorator-transforms": "catalog:",
-    "ember-eslint-parser": "^0.14.6",
+    "ember-eslint-parser": "catalog:",
     "ember-template-recast": "^6.1.5",
     "eslint": "catalog:",
     "eslint-plugin-qunit": "catalog:",

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -51,7 +51,7 @@
     "cron": "catalog:",
     "date-fns": "catalog:",
     "decorator-transforms": "catalog:",
-    "ember-eslint-parser": "^0.13.0",
+    "ember-eslint-parser": "^0.14.6",
     "ember-template-recast": "^6.1.5",
     "eslint": "catalog:",
     "eslint-plugin-qunit": "catalog:",

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -60,7 +60,7 @@
     "decorator-transforms": "catalog:",
     "diff": "catalog:",
     "ember-concurrency-async-plugin": "workspace:*",
-    "ember-eslint-parser": "^0.13.0",
+    "ember-eslint-parser": "^0.14.6",
     "ember-source": "catalog:",
     "eslint": "catalog:",
     "ethers": "catalog:",

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -60,7 +60,7 @@
     "decorator-transforms": "catalog:",
     "diff": "catalog:",
     "ember-concurrency-async-plugin": "workspace:*",
-    "ember-eslint-parser": "^0.14.6",
+    "ember-eslint-parser": "catalog:",
     "ember-source": "catalog:",
     "eslint": "catalog:",
     "ethers": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ catalogs:
     ember-elsewhere:
       specifier: ^2.0.1
       version: 2.0.1
+    ember-eslint-parser:
+      specifier: ^0.14.6
+      version: 0.14.6
     ember-freestyle:
       specifier: ^0.24.0
       version: 0.24.0
@@ -1204,6 +1207,9 @@ importers:
       concurrently:
         specifier: 'catalog:'
         version: 8.2.2
+      ember-eslint-parser:
+        specifier: 'catalog:'
+        version: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       ember-source:
         specifier: 'catalog:'
         version: 6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5)
@@ -1662,6 +1668,9 @@ importers:
       ember-css-url:
         specifier: ^1.0.0
         version: 1.0.0(patch_hash=0e5253a008cc7bf02424d786e7a8fb2397bc48962f3cd1443f2c0fdd8200c96d)
+      ember-eslint-parser:
+        specifier: 'catalog:'
+        version: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       ember-freestyle:
         specifier: 'catalog:'
         version: 0.24.0(@babel/core@7.29.7)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.107.2(postcss@8.5.15))
@@ -1848,7 +1857,7 @@ importers:
         specifier: 'catalog:'
         version: 5.2.0(@babel/core@7.29.7)(@glint/template@1.7.7)
       ember-eslint-parser:
-        specifier: ^0.14.6
+        specifier: 'catalog:'
         version: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       ember-modifier:
         specifier: ^4.1.0
@@ -1899,7 +1908,7 @@ importers:
   packages/eslint-plugin-boxel:
     dependencies:
       ember-eslint-parser:
-        specifier: ^0.14.6
+        specifier: 'catalog:'
         version: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       requireindex:
         specifier: 'catalog:'
@@ -2331,6 +2340,9 @@ importers:
       ember-elsewhere:
         specifier: 'catalog:'
         version: 2.0.1(@babel/core@7.29.7)(@glint/template@1.7.7)(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))
+      ember-eslint-parser:
+        specifier: 'catalog:'
+        version: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       ember-exam:
         specifier: ^10.1.0
         version: 10.1.0(@glint/template@1.7.7)(ember-qunit@9.1.0(@ember/test-helpers@5.4.3(@babel/core@7.29.7))(qunit@2.26.0))(ember-source@6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.26.0)(webpack@5.107.2)
@@ -2840,7 +2852,7 @@ importers:
         specifier: 'catalog:'
         version: 2.3.2(@babel/core@7.29.7)
       ember-eslint-parser:
-        specifier: ^0.14.6
+        specifier: 'catalog:'
         version: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       ember-template-recast:
         specifier: ^6.1.5
@@ -3128,7 +3140,7 @@ importers:
         specifier: workspace:*
         version: link:../../vendor/ember-concurrency-async-plugin
       ember-eslint-parser:
-        specifier: ^0.14.6
+        specifier: 'catalog:'
         version: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       ember-source:
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,8 +400,8 @@ catalogs:
       specifier: ^1.7.1
       version: 1.7.1
     eslint-plugin-ember:
-      specifier: ^13.3.2
-      version: 13.3.2
+      specifier: ^13.5.0
+      version: 13.5.0
     eslint-plugin-eslint-comments:
       specifier: ^3.2.0
       version: 3.2.0
@@ -1224,7 +1224,7 @@ importers:
         version: 9.1.2(eslint@8.57.1)
       eslint-plugin-ember:
         specifier: 'catalog:'
-        version: 13.3.2(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+        version: 13.5.0(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 17.24.0(eslint@8.57.1)(typescript@5.9.3)
@@ -1462,7 +1462,7 @@ importers:
         version: 9.1.2(eslint@9.39.5)
       eslint-plugin-ember:
         specifier: 'catalog:'
-        version: 13.3.2(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@9.39.5))(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)
+        version: 13.5.0(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@9.39.5))(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)
       eslint-plugin-import:
         specifier: 'catalog:'
         version: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)
@@ -1706,7 +1706,7 @@ importers:
         version: 9.1.2(eslint@8.57.1)
       eslint-plugin-ember:
         specifier: 'catalog:'
-        version: 13.3.2(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+        version: 13.5.0(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       eslint-plugin-n:
         specifier: 'catalog:'
         version: 17.24.0(eslint@8.57.1)(typescript@5.9.3)
@@ -1848,8 +1848,8 @@ importers:
         specifier: 'catalog:'
         version: 5.2.0(@babel/core@7.29.7)(@glint/template@1.7.7)
       ember-eslint-parser:
-        specifier: ^0.13.0
-        version: 0.13.0(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
+        specifier: ^0.14.6
+        version: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       ember-modifier:
         specifier: ^4.1.0
         version: 4.3.0(@babel/core@7.29.7)
@@ -1867,7 +1867,7 @@ importers:
         version: 9.1.2(eslint@8.57.1)
       eslint-plugin-ember:
         specifier: 'catalog:'
-        version: 13.3.2(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+        version: 13.5.0(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       eslint-plugin-import:
         specifier: 'catalog:'
         version: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
@@ -1899,8 +1899,8 @@ importers:
   packages/eslint-plugin-boxel:
     dependencies:
       ember-eslint-parser:
-        specifier: ^0.13.0
-        version: 0.13.0(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
+        specifier: ^0.14.6
+        version: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       requireindex:
         specifier: 'catalog:'
         version: 1.2.0
@@ -2393,7 +2393,7 @@ importers:
         version: 9.1.2(eslint@8.57.1)
       eslint-plugin-ember:
         specifier: 'catalog:'
-        version: 13.3.2(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+        version: 13.5.0(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       eslint-plugin-import:
         specifier: 'catalog:'
         version: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
@@ -2840,8 +2840,8 @@ importers:
         specifier: 'catalog:'
         version: 2.3.2(@babel/core@7.29.7)
       ember-eslint-parser:
-        specifier: ^0.13.0
-        version: 0.13.0(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
+        specifier: ^0.14.6
+        version: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       ember-template-recast:
         specifier: ^6.1.5
         version: 6.1.5
@@ -3128,8 +3128,8 @@ importers:
         specifier: workspace:*
         version: link:../../vendor/ember-concurrency-async-plugin
       ember-eslint-parser:
-        specifier: ^0.13.0
-        version: 0.13.0(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
+        specifier: ^0.14.6
+        version: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       ember-source:
         specifier: 'catalog:'
         version: 6.10.1(patch_hash=ea945024993105fb6cc4ae5cb5e9ea8e0eff6cd5fe0b0033c43dd0cf9453eb0d)(@glimmer/component@2.1.1)(rsvp@4.8.5)
@@ -7266,12 +7266,6 @@ packages:
     resolution: {integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.61.1':
-    resolution: {integrity: sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/tsconfig-utils@8.67.0':
     resolution: {integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -9763,11 +9757,11 @@ packages:
     resolution: {integrity: sha512-Jy2UOM7H83yriKrhwGhEgnbdL5H0QECMSPg/2AsjCji6aNvSLlHDl8FjvadQ79O6nbYP1Cny30JlVnRQpyoC7w==}
     engines: {node: 12.* || 14.* || >= 16}
 
-  ember-eslint-parser@0.13.0:
-    resolution: {integrity: sha512-i8mt96+yxFQaTNcz/2+SAkwpeLYU+VOFyHBshRyNL3HOciZhPpX3WszJK0/9GhVi8hQVGNtt21Iv7tsui3x0cQ==}
+  ember-eslint-parser@0.14.6:
+    resolution: {integrity: sha512-Z4fA1E/3uGZeBLPcz5aCiic3OoZ9YVxQBkImgGXdtgHLLuF/51drGor/FCwT9cCs1XZqY8HWRy4aarl+MZCfwQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@babel/eslint-parser': ^7.28.6
+      '@babel/eslint-parser': ^7.28.6 || ^8.0.0
       '@typescript-eslint/parser': '*'
     peerDependenciesMeta:
       '@babel/eslint-parser':
@@ -9775,8 +9769,8 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
-  ember-estree@0.6.4:
-    resolution: {integrity: sha512-/0+JLFt200RB/gUfLfRALTFWby6fGS7Bu+NN985Y8gadEntX4KoiYHhOl2hkzvy+AmBi+PbHxBa9QVCV7K/PUg==}
+  ember-estree@0.6.11:
+    resolution: {integrity: sha512-aZyheQGUXyHu8GARPd1YyjbDMGkvqBYKzPj6RVp8qqMqA1L1MbkWKsljWE3K1CwiJcHwTPgm/O3oxS0TY1AX9Q==}
 
   ember-exam@10.1.0:
     resolution: {integrity: sha512-6jUftmu2zpmLZ35PCsZDbdsAXTm2GjCGT3SjRX+BkUr2yKYpbD9B2R7hqCUnqOOTkdp2lzhBcGZ+KwwLLdH7eg==}
@@ -10201,8 +10195,8 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
-  eslint-plugin-ember@13.3.2:
-    resolution: {integrity: sha512-A/Sy+rfwpqOYwinU6chNZjzOPcbxg0JI69cSnM6uxUfeLRYGp0eYd9SiVB/j2QWAltGF/HAC6r8UMV+qKxUV2A==}
+  eslint-plugin-ember@13.5.0:
+    resolution: {integrity: sha512-q1s/irrc2l1KeE1l5S1UiO7ZrvGF5aYm903CMQ7lHFc09F/78/uvgzvA4wPZ9TFMl07r2ttoIINrEOFy05RtGg==}
     engines: {node: '>= 20.19'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -20364,10 +20358,6 @@ snapshots:
       '@typescript-eslint/types': 8.67.0
       '@typescript-eslint/visitor-keys': 8.67.0
 
-  '@typescript-eslint/tsconfig-utils@8.61.1(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-
   '@typescript-eslint/tsconfig-utils@8.67.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
@@ -23749,12 +23739,12 @@ snapshots:
       - ember-source
       - supports-color
 
-  ember-eslint-parser@0.13.0(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3):
+  ember-eslint-parser@0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@glimmer/syntax': 0.95.0
-      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
       content-tag: 4.2.0
-      ember-estree: 0.6.4
+      ember-estree: 0.6.11
       eslint-scope: 9.1.2
       html-tags: 5.1.0
       mathml-tag-names: 4.0.0
@@ -23765,12 +23755,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  ember-eslint-parser@0.13.0(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@9.39.5))(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(typescript@5.9.3):
+  ember-eslint-parser@0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@9.39.5))(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@glimmer/syntax': 0.95.0
-      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
       content-tag: 4.2.0
-      ember-estree: 0.6.4
+      ember-estree: 0.6.11
       eslint-scope: 9.1.2
       html-tags: 5.1.0
       mathml-tag-names: 4.0.0
@@ -23781,7 +23771,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  ember-estree@0.6.4:
+  ember-estree@0.6.11:
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/syntax': 0.95.0
@@ -24588,14 +24578,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-ember@13.3.2(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3):
+  eslint-plugin-ember@13.5.0(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3):
     dependencies:
       '@ember-data/rfc395-data': 0.0.4
       aria-query: 5.3.2
       axobject-query: 4.1.0
       css-tree: 3.2.1
       editorconfig: 3.0.2
-      ember-eslint-parser: 0.13.0(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
+      ember-eslint-parser: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@8.57.1))(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(typescript@5.9.3)
       ember-rfc176-data: 0.3.18
       eslint: 8.57.1
       eslint-utils: 3.0.0(eslint@8.57.1)
@@ -24614,14 +24604,14 @@ snapshots:
       - '@babel/eslint-parser'
       - typescript
 
-  eslint-plugin-ember@13.3.2(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@9.39.5))(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3):
+  eslint-plugin-ember@13.5.0(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@9.39.5))(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3):
     dependencies:
       '@ember-data/rfc395-data': 0.0.4
       aria-query: 5.3.2
       axobject-query: 4.1.0
       css-tree: 3.2.1
       editorconfig: 3.0.2
-      ember-eslint-parser: 0.13.0(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@9.39.5))(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(typescript@5.9.3)
+      ember-eslint-parser: 0.14.6(patch_hash=364c7e71472801c87618bf2b2cdabd256358166bbe107f29d321ab35d0a53425)(@babel/eslint-parser@7.29.7(@babel/core@7.29.7)(eslint@9.39.5))(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(typescript@5.9.3)
       ember-rfc176-data: 0.3.18
       eslint: 9.39.5
       eslint-utils: 3.0.0(eslint@9.39.5)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -146,7 +146,7 @@ catalog:
   eslint: ^8.57.1
   eslint-config-prettier: ^9.1.2
   eslint-doc-generator: ^1.7.1
-  eslint-plugin-ember: ^13.3.2
+  eslint-plugin-ember: ^13.5.0
   eslint-plugin-eslint-comments: ^3.2.0
   eslint-plugin-eslint-plugin: ^5.5.1
   eslint-plugin-filenames: ^1.3.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -133,6 +133,7 @@ catalog:
   ember-concurrency: ^5.2.0
   ember-concurrency-ts: ^0.3.1
   ember-elsewhere: ^2.0.1
+  ember-eslint-parser: ^0.14.6
   ember-freestyle: ^0.24.0
   ember-keyboard: ^9.0.4
   ember-modify-based-class-resource: ^1.1.0


### PR DESCRIPTION
This is a step to make #5847 more useful.

<details><summary>Claude explanation</summary>

`ember-eslint-parser` 0.13.0 to 0.14.6, and `eslint-plugin-ember` 13.3.2 to 13.5.0. The two move together: 13.3.2 depends on the 0.13 line, so bumping only the parser leaves two copies in the tree, and the parser's own duplicate-version guard then fails every `.gts` file. 13.5.0 depends on `^0.14.2`, so the tree collapses to one parser again. The local patch applies to 0.14.6 unchanged.

Beyond keeping current, 0.14.6 fixes how `.gts` files enter a TypeScript program. That fix is not exercised by this branch: it only shows up under `parserOptions.project`, which no config here sets. Measured on a branch that does add it, linting host went from 974 files reporting that the tsconfig does not include them to zero, and from 337s to 49s. This PR is what makes that possible; expect no change to the Lint job's own timing.

The parser moves into the catalog rather than repeating `^0.14.6` across four manifests. Four hand-maintained ranges are how a tree acquires the two copies the guard trips on, and every neighbour — eslint, the `@typescript-eslint` pair, every other `eslint-plugin-*` — is catalogued already.

`packages/host`, `packages/boxel-icons` and `packages/boxel-ui/docs-app` now declare the parser their eslintrc already names. Without it, which of the lockfile's two peer variants they load is decided by hoisting; `noop.js` keeps `parsedFiles` in a module-level Set, so a parser and processor from different copies make every `.gts` file report the setup-guide error, which this repo's patch makes fatal.

</details>
