### PR TITLE
ci: Update Synapse to start alongside index import

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -595,6 +595,31 @@ jobs:
       - name: Warm test Docker images from the GHCR mirror
         continue-on-error: true
         uses: ./.github/actions/warm-test-images
+      # Synapse's boot is most of the `create realm users` wait a few steps
+      # below, and none of it depends on the index import that runs next, so
+      # start it here and let the two overlap. This is not the same trade as
+      # making a step before service start faster: those only move the moment
+      # the readiness clock starts, and the wait downstream absorbs the
+      # difference. Synapse is on the critical path — realm-server logs into
+      # it during boot — so starting it earlier shortens the chain itself.
+      #
+      # Backgrounded because `assert-synapse-running` blocks on Synapse's own
+      # healthcheck (`curl --retry 30` against /health); spending that wait
+      # during the import is the entire point.
+      #
+      # Safe against the later start: `assert-synapse-running` is idempotent,
+      # so when `test-services:host` reaches `start:matrix` it finds the
+      # container up and only re-registers its Traefik route. The container
+      # exists within seconds of this step, long before that, so the two
+      # cannot race to create it. Nothing waits on this — `create realm users`
+      # already polls for Synapse and fails loudly on its own if it never
+      # arrives. Output joins /tmp/server.log, which a later step prints and
+      # uploads.
+      - name: Start Synapse ahead of the index import
+        working-directory: packages/matrix
+        run: |
+          pnpm assert-synapse-running >> /tmp/server.log 2>&1 &
+          echo "Synapse is starting in the background; its output goes to /tmp/server.log"
       # Seed the index tables from a recent main boxel-index-cache artifact,
       # leaving the boot index to reconcile whatever this checkout changed
       # rather than indexing every realm from scratch. Runs before the


### PR DESCRIPTION
These aren’t interrelated, so might as well happen in parallel.

<details><summary>Claude explanation</summary>The shard waits ~34s in `create realm users` for Synapse to finish booting, then imports nothing from it — the 27s index import that runs just before is entirely independent. Overlap them.

This is a different trade from speeding up a step that precedes service start. Measured on #5849, pulling the mirrored images concurrently cut that step from 29s to 13s and the readiness wait grew from 1s to 38s across every shard: the services simply started earlier and the same wall remained. Synapse is on the critical path rather than in front of it — realm-server logs into it during boot — so moving its boot earlier shortens the chain instead of relocating the wait.

Backgrounded, because `assert-synapse-running` blocks on Synapse's own healthcheck. It is idempotent, so `test-services:host` finds the container up when it reaches `start:matrix` and only re-registers the Traefik route; the container exists within seconds, long before that step, so they cannot race to create it.

Expected: `create realm users` falls toward zero and the readiness wait does not absorb it. If the wait grows instead, the same wall applies here too and the readiness path itself is the only thing left to attack.</details>