### PR TITLE
ci: Add cache of Synapse migration setup

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -85,6 +85,55 @@ jobs:
             echo "Percy will be skipped — no UI-relevant changes"
           fi
 
+  # Bake a migrated Synapse database once, so shards do not each spend ~52s
+  # applying its schema to an empty SQLite file. Only the schema is baked: no
+  # users are registered here, so `create realm users` still runs on every
+  # shard and nothing about credentials is pinned into an artifact.
+  #
+  # The artifact name carries a key derived from the Synapse support tree, the
+  # docker helpers and the pinned image tag (see scripts/synapse-cache-key.sh).
+  # A checkout that changes any of them asks for a name that does not exist and
+  # boots from scratch, so there is no staleness gate to keep in step by hand.
+  # Those inputs moved 18 times in the last 7,246 commits, so in practice this
+  # is a hit.
+  cache-synapse-db:
+    name: Cache the migrated Synapse database
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # TEMPORARY (drop before merge): also runs on this branch, so the artifact
+    # exists to iterate against without merging first. The consumer below reads
+    # from the same branch under the same condition.
+    if: ${{ (github.event_name == 'push'""" + AND + """github.ref == 'refs/heads/main') || github.head_ref == '""" + BRANCH + """' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/init
+      - name: Compute the Synapse cache key
+        id: key
+        run: echo "key=$(scripts/synapse-cache-key.sh)" >> "$GITHUB_OUTPUT"
+      - name: Warm test Docker images from the GHCR mirror
+        continue-on-error: true
+        uses: ./.github/actions/warm-test-images
+      - name: Boot Synapse so it applies its migrations
+        working-directory: packages/matrix
+        run: pnpm assert-synapse-running
+      # Stopped rather than killed: SQLite has pages in the container's memory
+      # until the process exits cleanly, and a torn database is worse than none
+      # because a consumer would open it and fail as though Synapse were broken.
+      - name: Stop Synapse so SQLite flushes to disk
+        run: docker stop boxel-synapse
+      - name: Package the migrated database
+        run: |
+          set -euo pipefail
+          db=$(ls packages/matrix/synapse-data*/db/homeserver.db | head -1)
+          gzip -c "$db" > /tmp/homeserver.db.gz
+          echo "baked $(du -h "$db" | cut -f1) -> $(du -h /tmp/homeserver.db.gz | cut -f1) compressed"
+      - name: Upload the migrated database
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: boxel-synapse-db-${{ steps.key.outputs.key }}
+          path: /tmp/homeserver.db.gz
+          retention-days: 30
+
   check-index-cache:
     # The boxel-index-cache artifact (produced by main runs of ci.yaml)
     # snapshots the index tables, letting shards boot on it instead of
@@ -608,6 +657,26 @@ jobs:
         run: mise run ci:import-index
         env:
           GH_TOKEN: ${{ github.token }}
+
+      # Synapse spends ~52s of every shard applying its schema to a fresh
+      # SQLite file, and `create realm users` below does nothing but wait for
+      # it. Drop in the database baked by `cache-synapse-db` so Synapse opens
+      # one that is already migrated. Best-effort: on a miss the script says so
+      # and Synapse boots exactly as it did before.
+      #
+      # This reduces the work rather than moving it. Shard setup is bound by
+      # the runner's cores, not by latency — measured twice, by starting
+      # Synapse earlier and watching its own boot get slower as it competed
+      # with the rest of setup — so overlapping work does not help and removing
+      # it does.
+      - name: Import the cached Synapse database
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # TEMPORARY (drop before merge): consume this branch's own bake while
+          # iterating, since main has none until this merges.
+          SYNAPSE_CACHE_BRANCH: ${{ github.head_ref == '""" + BRANCH + """' && '""" + BRANCH + """' || 'main' }}
+        run: scripts/import-cached-synapse-db.sh
 
       - name: Start test services (icons + host dist + realm servers)
         run: mise run test-services:host | tee -a /tmp/server.log &

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -103,7 +103,7 @@ jobs:
     # TEMPORARY (drop before merge): also runs on this branch, so the artifact
     # exists to iterate against without merging first. The consumer below reads
     # from the same branch under the same condition.
-    if: ${{ (github.event_name == 'push'""" + AND + """github.ref == 'refs/heads/main') || github.head_ref == '""" + BRANCH + """' }}
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.head_ref == 'cs-12583-synapse-db-cache' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/init
@@ -124,7 +124,13 @@ jobs:
       - name: Package the migrated database
         run: |
           set -euo pipefail
-          db=$(ls packages/matrix/synapse-data*/db/homeserver.db | head -1)
+          shopt -s nullglob
+          dbs=(packages/matrix/synapse-data*/db/homeserver.db)
+          db="${dbs[0]:-}"
+          if [ -z "$db" ]; then
+            echo "::error::Synapse produced no database to bake"
+            exit 1
+          fi
           gzip -c "$db" > /tmp/homeserver.db.gz
           echo "baked $(du -h "$db" | cut -f1) -> $(du -h /tmp/homeserver.db.gz | cut -f1) compressed"
       - name: Upload the migrated database
@@ -675,7 +681,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           # TEMPORARY (drop before merge): consume this branch's own bake while
           # iterating, since main has none until this merges.
-          SYNAPSE_CACHE_BRANCH: ${{ github.head_ref == '""" + BRANCH + """' && '""" + BRANCH + """' || 'main' }}
+          SYNAPSE_CACHE_BRANCH: ${{ github.head_ref == 'cs-12583-synapse-db-cache' && 'cs-12583-synapse-db-cache' || 'main' }}
         run: scripts/import-cached-synapse-db.sh
 
       - name: Start test services (icons + host dist + realm servers)

--- a/scripts/import-cached-synapse-db.sh
+++ b/scripts/import-cached-synapse-db.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Drops an already-migrated Synapse database into this environment's data dir,
+# so Synapse boots by opening it instead of applying its schema from scratch.
+#
+# Measured on a host shard: Synapse takes ~52s from container start to
+# answering its healthcheck, and `create realm users` does nothing but wait for
+# that. Nearly all of it is first-run migrations against an empty SQLite file.
+#
+# No `set -e`: everything here is an optimization. A miss — no artifact, an
+# expired one, no gh CLI — must leave the shard booting Synapse exactly as it
+# did before, so failures are reported and the script still exits 0.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/env-slug.sh"
+
+REPO="cardstack/boxel"
+# Which branch's runs to take the bake from. Defaults to main, where the
+# producer runs; overridable so a branch iterating on this machinery can
+# consume its own artifact without merging first.
+BRANCH="${SYNAPSE_CACHE_BRANCH:-main}"
+
+skip() {
+  echo "[synapse-db-cache] $1 — Synapse will migrate from scratch"
+  exit 0
+}
+
+if [ -n "${BOXEL_ENVIRONMENT:-}" ]; then
+  DATA_DIR="$SCRIPT_DIR/../packages/matrix/synapse-data-$(resolve_env_slug)"
+else
+  DATA_DIR="$SCRIPT_DIR/../packages/matrix/synapse-data"
+fi
+DB_PATH="$DATA_DIR/db/homeserver.db"
+
+# `start-synapse.sh` creates the data dir on its way up, so finding a database
+# already here means Synapse has run in this workspace. Replacing it would
+# throw away state the caller may be relying on.
+if [ -s "$DB_PATH" ]; then
+  skip "a database is already present at $DB_PATH"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  skip "gh CLI not found"
+fi
+
+KEY=$("$SCRIPT_DIR/synapse-cache-key.sh") || skip "could not compute the cache key"
+ARTIFACT="boxel-synapse-db-${KEY}"
+
+# The key is in the artifact name, so a checkout whose Synapse config or image
+# tag differs simply finds nothing — no separate staleness gate to keep in
+# step with what actually affects the schema.
+RUN_IDS=$(gh run list -w ci-host.yaml -b "$BRANCH" -L 10 \
+  --json databaseId -q '.[].databaseId' -R "$REPO" 2>/dev/null) || RUN_IDS=""
+[ -n "$RUN_IDS" ] || skip "no recent CI Host runs on $BRANCH"
+
+DOWNLOAD_DIR="/tmp/synapse-db-cache-$$"
+trap 'rm -rf "$DOWNLOAD_DIR"' EXIT
+
+# Runs are walked rather than pinning to the newest, because the producer job
+# is skipped on runs that did not need it, and because a run can be red for
+# reasons that have nothing to do with whether it published this artifact.
+START=$(date +%s)
+FOUND=""
+for RUN_ID in $RUN_IDS; do
+  if gh run download "$RUN_ID" -n "$ARTIFACT" -D "$DOWNLOAD_DIR" -R "$REPO" 2>/dev/null; then
+    FOUND="$RUN_ID"
+    break
+  fi
+  rm -rf "$DOWNLOAD_DIR"
+done
+[ -n "$FOUND" ] || skip "no $ARTIFACT in the last 10 CI Host runs on $BRANCH"
+
+GZ="$DOWNLOAD_DIR/homeserver.db.gz"
+[ -f "$GZ" ] || skip "artifact $ARTIFACT did not contain homeserver.db.gz"
+
+mkdir -p "$DATA_DIR/db"
+if ! gunzip -c "$GZ" > "$DB_PATH"; then
+  # A half-written database is worse than none: Synapse would open it and fail
+  # in a way that reads as a Synapse bug rather than a bad cache.
+  rm -f "$DB_PATH"
+  skip "could not unpack the cached database"
+fi
+
+echo "[synapse-db-cache] restored $ARTIFACT from run $FOUND in $(( $(date +%s) - START ))s ($(du -h "$DB_PATH" | cut -f1))"

--- a/scripts/synapse-cache-key.sh
+++ b/scripts/synapse-cache-key.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Prints the cache key identifying a migrated Synapse database, so a producer
+# and a consumer agree on whether a baked database still describes this
+# checkout's Synapse.
+#
+# The key is the identity of everything that decides what Synapse's schema and
+# configuration are: its support tree, its docker helpers, and the pinned image
+# tag. Anything else in the repo can change freely without invalidating a bake,
+# which is the point — those inputs move about once a month against thousands
+# of commits.
+#
+# Content is read through `git ls-files -s`, whose output is (mode, blob sha,
+# stage, path) per tracked file, rather than by hashing files on disk: the
+# support tree gains generated files (a signing key, a rendered homeserver.yaml)
+# the first time Synapse boots, and hashing those would make the key depend on
+# whether the caller had already run Synapse.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+{
+  git ls-files -s packages/matrix/support/synapse packages/matrix/docker
+  # The image tag matters most of all: a Synapse version bump can change the
+  # schema, which is exactly when a baked database must not be reused.
+  grep -o 'matrixdotorg/synapse:[^ ]*' .github/actions/warm-test-images/action.yml | sort -u
+} | sha256sum | cut -c1-16


### PR DESCRIPTION
<details><summary>Claude explanation</summary>Synapse takes ~52s from container start to answering its healthcheck, and `create realm users` spends that time waiting: in a shard log all twelve realm users queue at 18:34:33 and the first registration goes out at 18:35:03. Almost all of it is first-run schema migration against an empty SQLite file, and every one of the 20 shards pays it.

Bake it once on main and drop the result in before the services start. This removes work rather than moving it, which is the only thing that helps here: shard setup is bound by the runner's cores, not by latency. Starting Synapse earlier was measured twice — its own boot stretched from 52s to 84s as it competed with the image warm and the index import, and setup did not move.

Schema only. No users are registered into the bake, so `create realm users` still runs and nothing about credentials is pinned into an artifact.

Staleness is handled by the artifact's name rather than a separate gate: the key hashes the Synapse support tree, the docker helpers and the pinned image tag, so a checkout that changes any of them asks for a name that does not exist and boots from scratch. Those inputs moved 18 times in the last 7,246 commits. The key reads content through `git ls-files -s` rather than hashing files, because the support tree gains a signing key and a rendered homeserver.yaml the first time Synapse runs, and hashing those would make the key depend on whether the caller had booted Synapse before.

Every failure path degrades: a missing artifact, an expired one, no gh CLI, or a half-unpacked database all leave Synapse migrating from scratch.</details>