### PR TITLE
ci: Change host shard count to 16

### DIFF
--- a/.claude/skills/host-test-memory-leak-hunting/SKILL.md
+++ b/.claude/skills/host-test-memory-leak-hunting/SKILL.md
@@ -126,6 +126,10 @@ A clean fix is one that:
 
 1. Makes the per-test slope flat in steady state (compare t=50→t=90, not t=10→t=50 — the early region warms up caches).
 2. Drops the leaked constructor count delta to zero (or single digits — V8 caching introduces a small floor).
-3. Still passes the full host-test shard 3 (the historical canary for memory pressure) under the original `shardTotal: 20` config.
+3. Still passes whichever host-test shard currently carries the most memory pressure, at the shard count `ci-host.yaml` ships.
 
-If you bumped CI shard count as a temporary mitigation, revert that bump in the same PR as the fix.
+Do not assume a fixed shard number for that last one. Peak heap tracks which modules a shard is dealt, not how long the shard runs: on a 16-shard run the worst shard peaked at 463 MB used heap, against 664 MB on a 20-shard main run of the same era. Identify the canary for the run you are working against — download that run's `memory-report-*` artifacts and take the highest peak.
+
+Nothing in CI gates per-shard peak heap: `check-memory-baseline.mjs` compares per-module deltas merged across shards, so the per-shard figure only exists in those artifacts.
+
+If you bumped the CI shard count as a temporary mitigation, revert that bump in the same PR as the fix.

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -459,31 +459,25 @@ jobs:
     needs: [test-web-assets, check-percy, check-index-cache]
     strategy:
       fail-fast: false
+      # Three places carry the shard count and must move together: this list,
+      # `shardTotal` below, and `--shard-count` on the timings generator, which
+      # decides whether a rebalance is worth committing by predicting the
+      # slowest shard.
+      #
+      # Fewer, longer shards rather than more, shorter ones. Setup is ~195s per
+      # shard and largely irreducible (it is bound by the runner's cores, not
+      # by latency — see the four experiments on CS-12583), so each added shard
+      # buys a shrinking slice of test time for a fixed ~3 minutes of machine
+      # time and one more slot held. With ~8,665s of test work: 20 shards is
+      # ~10.5 minutes and 3.49 machine-hours, 12 is ~15.3 minutes and 3.06.
+      #
+      # The modelled wall-clock cost overstates the real one, because it
+      # assumes every shard starts immediately. They do not: shards have been
+      # observed queueing up to 242s waiting for a runner, and 20 concurrent
+      # jobs per host run is a large share of the pool.
       matrix:
-        shardIndex:
-          [
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-          ]
-        shardTotal: [20]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        shardTotal: [12]
     concurrency:
       group: boxel-host-test${{ github.head_ref || github.run_id }}-shard${{ matrix.shardIndex }}
       cancel-in-progress: true
@@ -1243,7 +1237,7 @@ jobs:
             # job loudly rather than committing a degraded weights file.
             if [ -f merged-junit-report/host.xml ]; then
               node packages/host/scripts/generate-test-module-timings.mjs merged-junit-report/host.xml \
-                --min-drift-seconds 60 --shard-count 20
+                --min-drift-seconds 60 --shard-count 12
             else
               echo "No merged junit report available — leaving shard timings unchanged."
             fi

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -468,16 +468,18 @@ jobs:
       # shard and largely irreducible (it is bound by the runner's cores, not
       # by latency — see the four experiments on CS-12583), so each added shard
       # buys a shrinking slice of test time for a fixed ~3 minutes of machine
-      # time and one more slot held. With ~8,665s of test work: 20 shards is
-      # ~10.5 minutes and 3.49 machine-hours, 12 is ~15.3 minutes and 3.06.
+      # time and one more slot held. Measured on ~8,500s of test work: at 20
+      # shards the slowest shard took 13.1 minutes for 3.62 machine-hours, at
+      # 12 it took 18.0 for 3.08. Sixteen sits between them, keeping most of
+      # the wall clock while returning a fifth of the slots to the pool.
       #
       # The modelled wall-clock cost overstates the real one, because it
       # assumes every shard starts immediately. They do not: shards have been
       # observed queueing up to 242s waiting for a runner, and 20 concurrent
       # jobs per host run is a large share of the pool.
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-        shardTotal: [12]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        shardTotal: [16]
     concurrency:
       group: boxel-host-test${{ github.head_ref || github.run_id }}-shard${{ matrix.shardIndex }}
       cancel-in-progress: true
@@ -1237,7 +1239,7 @@ jobs:
             # job loudly rather than committing a degraded weights file.
             if [ -f merged-junit-report/host.xml ]; then
               node packages/host/scripts/generate-test-module-timings.mjs merged-junit-report/host.xml \
-                --min-drift-seconds 60 --shard-count 12
+                --min-drift-seconds 60 --shard-count 16
             else
               echo "No merged junit report available — leaving shard timings unchanged."
             fi

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -465,9 +465,10 @@ jobs:
       # slowest shard.
       #
       # Fewer, longer shards rather than more, shorter ones. Setup is ~195s per
-      # shard and largely irreducible (it is bound by the runner's cores, not
-      # by latency — see the four experiments on CS-12583), so each added shard
-      # buys a shrinking slice of test time for a fixed ~3 minutes of machine
+      # shard and largely irreducible — it is bound by the runner's cores, not
+      # by latency, so parallelising or pre-computing it moves the cost rather
+      # than removing it. Each added shard therefore buys a shrinking slice of
+      # test time for a fixed ~3 minutes of machine
       # time and one more slot held. Measured on ~8,500s of test work: at 20
       # shards the slowest shard took 13.1 minutes for 3.62 machine-hours, at
       # 12 it took 18.0 for 3.08. Sixteen sits between them, keeping most of

--- a/packages/host/scripts/generate-test-module-timings.mjs
+++ b/packages/host/scripts/generate-test-module-timings.mjs
@@ -31,8 +31,12 @@
 //                            at least n seconds (default 0: always write).
 //                            CI passes a threshold here so main runs don't
 //                            commit churn for balance-equivalent jitter.
-//   --shard-count <n>        Shard count used for the drift prediction
-//                            (default 20, matching ci-host.yaml).
+//   --shard-count <n>        Shard count the drift prediction packs into.
+//                            Required with --min-drift-seconds, and with no
+//                            default: the prediction is a slowest-shard time,
+//                            so a stale default would quietly answer for a
+//                            shard count nobody runs. ci-host.yaml passes both
+//                            and is the only place naming the number.
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative, dirname } from 'node:path';
@@ -43,7 +47,7 @@ const MIN_COVERAGE = 0.95;
 const args = process.argv.slice(2);
 let junitPath;
 let minDriftSeconds = 0;
-let shardCount = 20;
+let shardCount;
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--min-drift-seconds') {
     minDriftSeconds = Number(args[++i]);
@@ -54,9 +58,24 @@ for (let i = 0; i < args.length; i++) {
   }
 }
 
-if (!junitPath || isNaN(minDriftSeconds) || isNaN(shardCount)) {
+if (
+  !junitPath ||
+  isNaN(minDriftSeconds) ||
+  (shardCount !== undefined && isNaN(shardCount))
+) {
   console.error(
     'Usage: node scripts/generate-test-module-timings.mjs <merged-junit-xml> [--min-drift-seconds n] [--shard-count n]',
+  );
+  process.exit(1);
+}
+
+// Only the drift gate packs shards, so a plain regeneration needs no count.
+// A gate run without one, though, would compare slowest-shard times for an
+// invented shard count and decide whether to rewrite the file on that. Fail
+// rather than guess.
+if (minDriftSeconds > 0 && shardCount === undefined) {
+  console.error(
+    '--min-drift-seconds requires --shard-count: the drift prediction is a slowest-shard time, which depends on how many shards there are.',
   );
   process.exit(1);
 }


### PR DESCRIPTION
Twenty concurrent jobs per host run is a large share of the runner pool. During one congested window, 35 boxel workflow runs overlapped — five of them CI Host, so 100 shard jobs demanded at once, from four branches — and shards started staggered over eleven minutes.

Queueing is bimodal. Across eight recent CI Host runs, seven waited under a minute in total; the eighth had every shard waiting a median of 252s and burned 1.7 machine-hours idle. That tail is the thing worth cutting.

Measured on the same suite, no failures on either side:

| | 20 shards | 16 shards | 12 shards |
| -- | -- | -- | -- |
| slowest shard (gates the run) | 13.1m | 13.8m | 18.0m |
| machine time | 3.62h | 3.32h | 3.08h |

Sixteen takes the middle: most of the wall clock kept, a fifth of the slots returned to the pool. Twelve was measured too and costs nearly five minutes a run, which is too much for the same kind of relief.

Setup is ~195s per shard and largely irreducible — it is bound by the runner's cores rather than by latency, so parallelising or pre-computing it moves the cost rather than removing it. Each added shard therefore buys a shrinking slice of test time for a fixed ~3 minutes of machine time, and holds one more slot.

Two caveats worth carrying into the merge:

- If the concurrency cap is in the 40–60 range, five concurrent runs at 16 shards still exceed it. This reduces queueing rather than eliminating it.
- There is no same-window A/B. The 16-shard run happened to land in a congested window while the 20-shard runs did not, so the queue improvement is inferred from demand arithmetic, not measured. What would settle it is queue-delay distributions across a few weeks, split before and after.

Most of the benefit lands on whatever else is queued rather than on the run that gives up the slots, so it does not show up in this PR's own numbers.

Follow-up, not in this PR: the weights are still packed for 20, which shows as a wider spread across 16 shards (216s vs 182s). Rebalancing touches the same file as the shard-weight work in #5850.
