### PR TITLE
Export content-only FileDef preview components for markdown, image, and audio

### DIFF
--- a/packages/base/file-formats/audio-preview.gts
+++ b/packages/base/file-formats/audio-preview.gts
@@ -1,6 +1,9 @@
 // The sampled-audio family's renderer, projected into the four format shells by
-// `FilePreviewStage`. The browser is the decoder, so the reading formats mount
-// one native `<audio controls>` — but a sound file has no picture, so the visual
+// `FilePreviewStage` — and the content-only component an embedding author
+// imports from the `file-formats/index` barrel to render a waveform and player
+// without any shell chrome. The browser is the decoder, so the reading formats
+// mount one native `<audio controls>` — but a sound file has no picture, so the
+// visual
 // the shells hand their stage is the amplitude envelope the extract pass read
 // out of the bytes, drawn as a waveform.
 //
@@ -16,13 +19,18 @@
 // waveform and the running time, and the reading formats own playback.
 import { on } from '@ember/modifier';
 import GlimmerComponent from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+import { cached, tracked } from '@glimmer/tracking';
 
 import MusicIcon from '@cardstack/boxel-icons/music';
-import { cn, eq } from '@cardstack/boxel-ui/helpers';
+import { cn } from '@cardstack/boxel-ui/helpers';
 
 import { formatClock } from './file-presentation';
-import type { FilePreviewSignature } from './file-preview-stage';
+import type { ContentPreviewSignature } from './file-preview-stage';
+import {
+  ensureFileViewModel,
+  type FileFormat,
+  type FileViewModel,
+} from './file-view-model';
 
 // SVG clipPath ids are document-global, and a page can mount several audio
 // previews at once, so each instance takes its own serial.
@@ -38,11 +46,27 @@ interface WaveBar {
   h: number;
 }
 
-export class AudioPreview extends GlimmerComponent<FilePreviewSignature> {
+export class AudioPreview extends GlimmerComponent<ContentPreviewSignature> {
+  get mode(): FileFormat {
+    return this.args.mode ?? 'embedded';
+  }
+
+  get isFitted(): boolean {
+    return this.mode === 'fitted';
+  }
+
+  // `@model` is the FileDef instance in the content-only case and a prebuilt
+  // view model when a shell is rendering; either way the reads below see the
+  // shared projection.
+  @cached
+  get model(): FileViewModel {
+    return ensureFileViewModel(this.args.model, this.mode);
+  }
+
   // The resampled envelope, already normalized to 0–100 and capped to the
   // format's bar budget by the shared projection.
   get bars(): number[] {
-    return this.args.model?.waveformBars ?? [];
+    return this.model.waveformBars ?? [];
   }
 
   get hasWaveform(): boolean {
@@ -75,7 +99,7 @@ export class AudioPreview extends GlimmerComponent<FilePreviewSignature> {
   // Present for the `audio`/`music` families, where the shared projection routes
   // the file's own URL to the player.
   get mediaUrl(): string | undefined {
-    return this.args.model?.mediaUrl;
+    return this.model.mediaUrl;
   }
 
   // How much of the track has played, 0–1, mirrored from the mounted player.
@@ -109,7 +133,7 @@ export class AudioPreview extends GlimmerComponent<FilePreviewSignature> {
     let duration =
       Number.isFinite(el.duration) && el.duration > 0
         ? el.duration
-        : Number(this.args.model?.durationSeconds);
+        : Number(this.model.durationSeconds);
     if (!Number.isFinite(duration) || duration <= 0) {
       this.playedRatio = 0;
       return;
@@ -121,19 +145,19 @@ export class AudioPreview extends GlimmerComponent<FilePreviewSignature> {
   // loads, but that never happens in a headless prerender and may lag a slow
   // range fetch, so the figure the extractor already read is shown regardless.
   get duration(): string {
-    return formatClock(this.args.model?.durationSeconds);
+    return formatClock(this.model.durationSeconds);
   }
 
   get trackTitle(): string {
-    return this.args.model?.mediaTags?.trackTitle ?? '';
+    return this.model.mediaTags?.trackTitle ?? '';
   }
 
   get artist(): string {
-    return this.args.model?.mediaTags?.artist ?? '';
+    return this.model.mediaTags?.artist ?? '';
   }
 
   <template>
-    {{#if (eq @mode 'fitted')}}
+    {{#if this.isFitted}}
       <div class='wave-fitted' data-test-audio-fitted>
         {{#if this.hasWaveform}}
           <svg
@@ -157,7 +181,7 @@ export class AudioPreview extends GlimmerComponent<FilePreviewSignature> {
         {{/if}}
       </div>
     {{else}}
-      <div class='audio' data-mode={{@mode}} data-test-audio-preview>
+      <div class='audio' data-mode={{this.mode}} data-test-audio-preview>
         <div class='audio-visual'>
           {{#if this.hasWaveform}}
             <svg

--- a/packages/base/file-formats/audio-preview.gts
+++ b/packages/base/file-formats/audio-preview.gts
@@ -3,9 +3,8 @@
 // imports from the `file-formats/index` barrel to render a waveform and player
 // without any shell chrome. The browser is the decoder, so the reading formats
 // mount one native `<audio controls>` — but a sound file has no picture, so the
-// visual
-// the shells hand their stage is the amplitude envelope the extract pass read
-// out of the bytes, drawn as a waveform.
+// visual the shells hand their stage is the amplitude envelope the extract pass
+// read out of the bytes, drawn as a waveform.
 //
 // The envelope arrives already resampled and bounded by `fileViewModel`
 // (`waveformBars`, 64 bars in a fitted cell, 256 in the reading formats), so

--- a/packages/base/file-formats/file-preview-stage.gts
+++ b/packages/base/file-formats/file-preview-stage.gts
@@ -45,7 +45,12 @@ export type FilePreviewComponent = ComponentLike<FilePreviewSignature>;
 // itself in the common case (the component projects it through
 // `fileViewModel`), or a prebuilt FileViewModel (what the shells pass). `mode`
 // defaults to 'embedded', the complete-content rendition; 'fitted' selects the
-// budgeted snippet a collection cell draws. These components render content
+// budgeted snippet a collection cell draws. A prebuilt view model must have
+// been projected at the same format passed as `mode`: the fitted budgets are
+// applied at projection time, so a complete-content projection rendered at
+// 'fitted' would feed the whole file to the snippet branch. A consumer that
+// varies `mode` should pass the instance and let the component re-project.
+// These components render content
 // only — the loading/failure/staleness panes are `FilePreviewStage`'s job
 // inside the shells, so an embedding author owns those states.
 export interface ContentPreviewSignature {

--- a/packages/base/file-formats/file-preview-stage.gts
+++ b/packages/base/file-formats/file-preview-stage.gts
@@ -14,7 +14,11 @@ import { eq } from '@cardstack/boxel-ui/helpers';
 import { Warning } from '@cardstack/boxel-ui/icons';
 
 import { downloadNameFor, fileIconFor, humanSize } from './file-presentation';
-import type { FileFormat, FileViewModel } from './file-view-model';
+import type {
+  FileFormat,
+  FileModelLike,
+  FileViewModel,
+} from './file-view-model';
 
 import type { ComponentLike } from '@glint/template';
 
@@ -33,6 +37,25 @@ export interface FilePreviewSignature {
 }
 
 export type FilePreviewComponent = ComponentLike<FilePreviewSignature>;
+
+// The content-only face of a family renderer, for the components the
+// `file-formats/index` barrel exports (MarkdownPreview, ImagePreview,
+// AudioPreview): just the file's content, none of the shell chrome — no file
+// bar, no inspector, no Download/Copy-link. `model` is the FileDef instance
+// itself in the common case (the component projects it through
+// `fileViewModel`), or a prebuilt FileViewModel (what the shells pass). `mode`
+// defaults to 'embedded', the complete-content rendition; 'fitted' selects the
+// budgeted snippet a collection cell draws. These components render content
+// only — the loading/failure/staleness panes are `FilePreviewStage`'s job
+// inside the shells, so an embedding author owns those states.
+export interface ContentPreviewSignature {
+  Args: {
+    model: FileViewModel | FileModelLike | undefined | null;
+    mode?: FileFormat;
+    fields?: Record<string, any>;
+  };
+  Element: HTMLElement;
+}
 
 // The renderer a file's own class declares, if its family has landed one. Read
 // from the instance's constructor rather than the declared field class, since a

--- a/packages/base/file-formats/file-view-model.ts
+++ b/packages/base/file-formats/file-view-model.ts
@@ -590,3 +590,31 @@ export function fileViewModel(
     thumbnailMetadata: file.thumbnailMetadata,
   };
 }
+
+// A projection produced by `fileViewModel`, as opposed to a FileDef instance.
+// The projection is always a plain object literal, and a card instance never
+// is, so the constructor check can't be fooled by a family that happens to
+// declare fields with these names.
+export function isFileViewModel(value: unknown): value is FileViewModel {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    value.constructor === Object &&
+    'source' in value &&
+    'fileState' in value
+  );
+}
+
+// Accept either side of the projection. The format shells hand their preview
+// renderers a prebuilt FileViewModel; a content-only consumer passes the
+// FileDef instance itself and this projects it, including the profile axes the
+// instance's own class pins (`static fileFamily` and friends).
+export function ensureFileViewModel(
+  model: object | undefined | null,
+  format: FileFormat = 'embedded',
+): FileViewModel {
+  if (isFileViewModel(model)) {
+    return model;
+  }
+  return fileViewModel(model, format, fileProfileSource(model));
+}

--- a/packages/base/file-formats/image-preview.gts
+++ b/packages/base/file-formats/image-preview.gts
@@ -1,19 +1,39 @@
 // The image family's renderer, projected into the four format shells by
-// `FilePreviewStage`. The browser is the decoder, so this is one native
-// `<img>` via the `FileImage` primitive; the component's whole job is choosing
-// how the pixels meet the frame the shell hands it.
+// `FilePreviewStage` — and the content-only component an embedding author
+// imports from the `file-formats/index` barrel to render just the pixels. The
+// browser is the decoder, so this is one native `<img>` via the `FileImage`
+// primitive; the component's whole job is choosing how the pixels meet the
+// frame it is handed.
 import GlimmerComponent from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
 
 import { FileImage } from './file-image';
 import { letterboxImage } from './file-presentation';
-import type { FilePreviewSignature } from './file-preview-stage';
+import type { ContentPreviewSignature } from './file-preview-stage';
+import {
+  ensureFileViewModel,
+  type FileFormat,
+  type FileViewModel,
+} from './file-view-model';
 
-export class ImagePreview extends GlimmerComponent<FilePreviewSignature> {
+export class ImagePreview extends GlimmerComponent<ContentPreviewSignature> {
+  get mode(): FileFormat {
+    return this.args.mode ?? 'embedded';
+  }
+
+  // `@model` is the FileDef instance in the content-only case and a prebuilt
+  // view model when a shell is rendering; either way the reads below see the
+  // shared projection.
+  @cached
+  get model(): FileViewModel {
+    return ensureFileViewModel(this.args.model, this.mode);
+  }
+
   // A vector scales crisply at any size and is as likely to be a diagram as a
   // picture, so it always letterboxes at its own proportions — a center-crop
   // that a photograph tolerates would cut through an illustration's subject.
   get isSvg() {
-    return this.args.model?.previewKind === 'svg';
+    return this.model.previewKind === 'svg';
   }
 
   // How the pixels meet the frame. A fitted cell is a fixed collection tile:
@@ -26,11 +46,8 @@ export class ImagePreview extends GlimmerComponent<FilePreviewSignature> {
     if (this.isSvg) {
       return 'contain';
     }
-    if (this.args.mode === 'fitted') {
-      return letterboxImage(
-        this.args.model?.previewKind,
-        this.args.model?.aspectRatio,
-      )
+    if (this.mode === 'fitted') {
+      return letterboxImage(this.model.previewKind, this.model.aspectRatio)
         ? 'contain'
         : 'cover';
     }
@@ -40,22 +57,22 @@ export class ImagePreview extends GlimmerComponent<FilePreviewSignature> {
   // The fitted strip already announces the file name, so the cell's pixels are
   // decorative there; the reading formats describe the image themselves.
   get alt() {
-    return this.args.mode === 'fitted' ? '' : (this.args.model?.name ?? '');
+    return this.mode === 'fitted' ? '' : (this.model.name ?? '');
   }
 
   get loading(): 'eager' | 'lazy' {
-    return this.args.mode === 'fitted' ? 'lazy' : 'eager';
+    return this.mode === 'fitted' ? 'lazy' : 'eager';
   }
 
   <template>
     <FileImage
       class='image-preview'
-      @src={{@model.imageUrl}}
+      @src={{this.model.imageUrl}}
       @alt={{this.alt}}
       @loading={{this.loading}}
       @decoding='async'
-      width={{@model.width}}
-      height={{@model.height}}
+      width={{this.model.width}}
+      height={{this.model.height}}
       data-image-fit={{this.fit}}
       data-test-image-preview
     />

--- a/packages/base/file-formats/index.ts
+++ b/packages/base/file-formats/index.ts
@@ -26,8 +26,10 @@ export {
   FITTED_TEXT_CHARACTER_BUDGET,
   FITTED_TEXT_LINE_BUDGET,
   FITTED_WAVEFORM_BAR_BUDGET,
+  ensureFileViewModel,
   fileProfileSource,
   fileViewModel,
+  isFileViewModel,
   type FileFormat,
   type FileModelLike,
   type FileProfileSource,
@@ -48,11 +50,23 @@ export {
 
 export {
   FilePreviewStage,
+  filePreviewComponentFor,
+  type ContentPreviewSignature,
   type FilePreviewComponent,
   type FilePreviewSignature,
 } from './file-preview-stage';
 
+// The content-only family renderers: just the file's content, none of the
+// shell chrome (no file bar, no inspector, no Download/Copy-link). Pass the
+// FileDef instance as `@model` — or a prebuilt view model — and optionally a
+// `@mode`, which defaults to 'embedded' (see `ContentPreviewSignature`).
+// Loading/failure/staleness treatment belongs to the embedding author; inside
+// the default templates it is `FilePreviewStage`'s job. For kind-dispatching
+// consumers, `filePreviewComponentFor(file)` resolves the renderer the file's
+// own class declares.
+export { AudioPreview } from './audio-preview';
 export { ImagePreview } from './image-preview';
+export { MarkdownPreview } from './markdown-preview';
 
 // The compound metadata shapes an extractor writes into. Shared per metadata
 // family rather than per file extension, so a camera or a color profile reads

--- a/packages/base/file-formats/index.ts
+++ b/packages/base/file-formats/index.ts
@@ -63,7 +63,10 @@ export {
 // Loading/failure/staleness treatment belongs to the embedding author; inside
 // the default templates it is `FilePreviewStage`'s job. For kind-dispatching
 // consumers, `filePreviewComponentFor(file)` resolves the renderer the file's
-// own class declares.
+// own class declares — pass it `ensureFileViewModel(file, mode)` as `@model`,
+// since only the content-only components exported here project a bare
+// instance themselves; the other family renderers read projection-only fields
+// (the fitted budgets among them) straight off `@model`.
 export { AudioPreview } from './audio-preview';
 export { ImagePreview } from './image-preview';
 export { MarkdownPreview } from './markdown-preview';

--- a/packages/base/file-formats/markdown-preview.gts
+++ b/packages/base/file-formats/markdown-preview.gts
@@ -99,8 +99,8 @@ export class MarkdownPreview extends GlimmerComponent<ContentPreviewSignature> {
         height: 100%;
         min-height: 0;
         overflow: auto;
-        background: var(--card);
-        color: var(--foreground);
+        background: var(--md-preview-background, var(--card));
+        color: var(--md-preview-foreground, var(--card-foreground));
         text-align: left;
       }
       .md-preview--full {

--- a/packages/base/file-formats/markdown-preview.gts
+++ b/packages/base/file-formats/markdown-preview.gts
@@ -1,0 +1,171 @@
+// The markdown family's renderer, projected into the four format shells by
+// `FilePreviewStage` — and the content-only component an embedding author
+// imports from the `file-formats/index` barrel to render a markdown file's
+// content without any shell chrome.
+//
+// Embedded and isolated get the full Boxel-flavored-markdown render — rendered
+// markdown with the linked-card and linked-file slots resolved — while a fitted
+// collection cell gets a lighter, non-interactive rendition of the projection's
+// already-budgeted head snippet, so a grid tile never mounts the
+// slot-collection machinery over a truncated body.
+import GlimmerComponent from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+import { htmlSafe } from '@ember/template';
+
+import { markdownToHtml } from '@cardstack/runtime-common/marked-sync';
+
+import MarkdownTemplate from '../default-templates/markdown';
+import type { ContentPreviewSignature } from './file-preview-stage';
+import {
+  ensureFileViewModel,
+  type FileFormat,
+  type FileViewModel,
+} from './file-view-model';
+
+export class MarkdownPreview extends GlimmerComponent<ContentPreviewSignature> {
+  get mode(): FileFormat {
+    return this.args.mode ?? 'embedded';
+  }
+
+  // `@model` is the FileDef instance in the content-only case and a prebuilt
+  // view model when a shell is rendering; either way the reads below see the
+  // shared projection.
+  @cached
+  get model(): FileViewModel {
+    return ensureFileViewModel(this.args.model, this.mode);
+  }
+
+  // The FileDef instance behind the shared projection, reached for the fields
+  // the generic view model doesn't carry: the linked cards/files and the id the
+  // BFM renderer resolves relative references against.
+  get source(): any {
+    return this.model.source;
+  }
+
+  get content(): string {
+    if (this.isFitted) {
+      // Budgeted in `fileViewModel`; a fitted cell never touches the whole
+      // file — and the presence guard below judges the same bounded snippet
+      // the cell draws, so the two can't disagree.
+      return this.model.contentPreview ?? '';
+    }
+    return String(this.source?.content ?? '');
+  }
+
+  get hasContent(): boolean {
+    return Boolean(this.content.trim());
+  }
+
+  get isFitted(): boolean {
+    return this.mode === 'fitted';
+  }
+
+  // `contentPreview` is truncated to the fitted character/line budget in
+  // `fileViewModel`, so the snippet parse stays bounded no matter the file size.
+  get snippetHtml() {
+    return htmlSafe(markdownToHtml(this.model.contentPreview ?? ''));
+  }
+
+  <template>
+    {{#if this.isFitted}}
+      <div class='md-preview md-preview--fitted' data-test-markdown-preview>
+        {{#if this.hasContent}}
+          <div class='md-snippet'>{{this.snippetHtml}}</div>
+        {{else}}
+          <p class='md-preview__empty'>No content</p>
+        {{/if}}
+      </div>
+    {{else}}
+      <div
+        class='md-preview md-preview--full'
+        data-mode={{this.mode}}
+        data-test-markdown-preview
+      >
+        {{#if this.hasContent}}
+          <MarkdownTemplate
+            @content={{this.content}}
+            @linkedCards={{this.source.linkedCards}}
+            @linkedFiles={{this.source.linkedFiles}}
+            @cardReferenceBaseUrl={{this.source.id}}
+          />
+        {{else}}
+          <p class='md-preview__empty'>No content</p>
+        {{/if}}
+      </div>
+    {{/if}}
+    <style scoped>
+      .md-preview {
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        overflow: auto;
+        background: var(--card);
+        color: var(--foreground);
+        text-align: left;
+      }
+      .md-preview--full {
+        padding: var(--boxel-sp-lg);
+      }
+      /* Inside the embedded shell's bounded body, keep the first heading from
+         pushing a gap above the render. */
+      .md-preview--full :deep(h1:first-child),
+      .md-preview--full :deep(h2:first-child),
+      .md-preview--full :deep(h3:first-child),
+      .md-preview--full :deep(h4:first-child),
+      .md-preview--full :deep(h5:first-child),
+      .md-preview--full :deep(h6:first-child) {
+        margin-top: 0;
+      }
+      .md-preview__empty {
+        margin: 0;
+        padding: var(--boxel-sp);
+        color: var(--muted-foreground);
+        font-size: var(--boxel-font-sm);
+      }
+
+      /* Fitted: a glanceable mini-page. Rendered, but with its own compact type
+         scale and a fade so the clip reads as "more below". */
+      .md-preview--fitted {
+        overflow: hidden;
+        position: relative;
+        padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
+        -webkit-mask-image: linear-gradient(to bottom, black 74%, transparent);
+        mask-image: linear-gradient(to bottom, black 74%, transparent);
+      }
+      .md-snippet {
+        font-size: 0.6875rem;
+        line-height: 1.5;
+      }
+      .md-snippet :deep(h1),
+      .md-snippet :deep(h2),
+      .md-snippet :deep(h3),
+      .md-snippet :deep(h4) {
+        font-weight: 700;
+        font-size: 0.8125rem;
+        margin: 0 0 0.25em;
+        line-height: 1.25;
+      }
+      .md-snippet :deep(p),
+      .md-snippet :deep(ul),
+      .md-snippet :deep(ol) {
+        margin: 0 0 0.5em;
+      }
+      .md-snippet :deep(ul),
+      .md-snippet :deep(ol) {
+        padding-left: 1.2em;
+      }
+      .md-snippet :deep(pre),
+      .md-snippet :deep(code) {
+        font-family: var(--font-mono, monospace);
+        font-size: 0.625rem;
+      }
+      .md-snippet :deep(pre) {
+        white-space: pre-wrap;
+        overflow: hidden;
+      }
+      .md-snippet :deep(img) {
+        max-width: 100%;
+      }
+    </style>
+  </template>
+}

--- a/packages/base/markdown-file-def.gts
+++ b/packages/base/markdown-file-def.gts
@@ -10,9 +10,6 @@ import {
   type ToolContext,
 } from '@cardstack/runtime-common';
 import MarkdownIcon from '@cardstack/boxel-icons/align-box-left-middle';
-import GlimmerComponent from '@glimmer/component';
-import { htmlSafe } from '@ember/template';
-import { markdownToHtml } from '@cardstack/runtime-common/marked-sync';
 import {
   BaseDefComponent,
   CardDef,
@@ -24,14 +21,13 @@ import {
   field,
   linksToMany,
 } from './card-api';
-import MarkdownTemplate from './default-templates/markdown';
 import {
   FileContentMismatchError,
   FileDef,
   type ByteStream,
   type SerializedFile,
 } from './file-api';
-import type { FilePreviewSignature } from './file-formats/file-preview-stage';
+import { MarkdownPreview } from './file-formats/markdown-preview';
 import { FrontmatterField } from './frontmatter-field';
 import {
   frontmatterFieldForKind,
@@ -152,148 +148,6 @@ function markdownTitle(
   model: { title?: string | null; name?: string | null } | null | undefined,
 ): string {
   return model?.title ?? model?.name ?? 'Untitled markdown';
-}
-
-// The family renderer the four shared shells mount into. Embedded and isolated
-// get the full Boxel-flavored-markdown render — rendered markdown with the
-// linked-card and linked-file slots resolved — while a fitted collection cell
-// gets a lighter, non-interactive rendition of the projection's already-budgeted
-// head snippet, so a grid tile never mounts the slot-collection machinery over a
-// truncated body.
-class MarkdownPreview extends GlimmerComponent<FilePreviewSignature> {
-  // The FileDef instance behind the shared projection, reached for the fields
-  // the generic view model doesn't carry: the linked cards/files and the id the
-  // BFM renderer resolves relative references against.
-  get source(): any {
-    return this.args.model?.source;
-  }
-
-  get content(): string {
-    if (this.args.mode === 'fitted') {
-      // Budgeted in `fileViewModel`; a fitted cell never touches the whole
-      // file — and the presence guard below judges the same bounded snippet
-      // the cell draws, so the two can't disagree.
-      return this.args.model?.contentPreview ?? '';
-    }
-    return String(this.source?.content ?? '');
-  }
-
-  get hasContent(): boolean {
-    return Boolean(this.content.trim());
-  }
-
-  get isFitted(): boolean {
-    return this.args.mode === 'fitted';
-  }
-
-  // `contentPreview` is truncated to the fitted character/line budget in
-  // `fileViewModel`, so the snippet parse stays bounded no matter the file size.
-  get snippetHtml() {
-    return htmlSafe(markdownToHtml(this.args.model?.contentPreview ?? ''));
-  }
-
-  <template>
-    {{#if this.isFitted}}
-      <div class='md-preview md-preview--fitted' data-test-markdown-preview>
-        {{#if this.hasContent}}
-          <div class='md-snippet'>{{this.snippetHtml}}</div>
-        {{else}}
-          <p class='md-preview__empty'>No content</p>
-        {{/if}}
-      </div>
-    {{else}}
-      <div
-        class='md-preview md-preview--full'
-        data-mode={{@mode}}
-        data-test-markdown-preview
-      >
-        {{#if this.hasContent}}
-          <MarkdownTemplate
-            @content={{this.content}}
-            @linkedCards={{this.source.linkedCards}}
-            @linkedFiles={{this.source.linkedFiles}}
-            @cardReferenceBaseUrl={{this.source.id}}
-          />
-        {{else}}
-          <p class='md-preview__empty'>No content</p>
-        {{/if}}
-      </div>
-    {{/if}}
-    <style scoped>
-      .md-preview {
-        width: 100%;
-        height: 100%;
-        min-height: 0;
-        overflow: auto;
-        background: var(--card);
-        color: var(--foreground);
-        text-align: left;
-      }
-      .md-preview--full {
-        padding: var(--boxel-sp-lg);
-      }
-      /* Inside the embedded shell's bounded body, keep the first heading from
-         pushing a gap above the render. */
-      .md-preview--full :deep(h1:first-child),
-      .md-preview--full :deep(h2:first-child),
-      .md-preview--full :deep(h3:first-child),
-      .md-preview--full :deep(h4:first-child),
-      .md-preview--full :deep(h5:first-child),
-      .md-preview--full :deep(h6:first-child) {
-        margin-top: 0;
-      }
-      .md-preview__empty {
-        margin: 0;
-        padding: var(--boxel-sp);
-        color: var(--muted-foreground);
-        font-size: var(--boxel-font-sm);
-      }
-
-      /* Fitted: a glanceable mini-page. Rendered, but with its own compact type
-         scale and a fade so the clip reads as "more below". */
-      .md-preview--fitted {
-        overflow: hidden;
-        position: relative;
-        padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
-        -webkit-mask-image: linear-gradient(to bottom, black 74%, transparent);
-        mask-image: linear-gradient(to bottom, black 74%, transparent);
-      }
-      .md-snippet {
-        font-size: 0.6875rem;
-        line-height: 1.5;
-      }
-      .md-snippet :deep(h1),
-      .md-snippet :deep(h2),
-      .md-snippet :deep(h3),
-      .md-snippet :deep(h4) {
-        font-weight: 700;
-        font-size: 0.8125rem;
-        margin: 0 0 0.25em;
-        line-height: 1.25;
-      }
-      .md-snippet :deep(p),
-      .md-snippet :deep(ul),
-      .md-snippet :deep(ol) {
-        margin: 0 0 0.5em;
-      }
-      .md-snippet :deep(ul),
-      .md-snippet :deep(ol) {
-        padding-left: 1.2em;
-      }
-      .md-snippet :deep(pre),
-      .md-snippet :deep(code) {
-        font-family: var(--font-mono, monospace);
-        font-size: 0.625rem;
-      }
-      .md-snippet :deep(pre) {
-        white-space: pre-wrap;
-        overflow: hidden;
-      }
-      .md-snippet :deep(img) {
-        max-width: 100%;
-      }
-    </style>
-  </template>
 }
 
 class Head extends Component<typeof MarkdownDef> {

--- a/packages/host/tests/integration/components/content-preview-components-test.gts
+++ b/packages/host/tests/integration/components/content-preview-components-test.gts
@@ -137,8 +137,27 @@ module('Integration | content-only file preview components', function (hooks) {
   });
 
   test('MarkdownPreview in fitted mode renders the budgeted snippet rendition', async function (assert) {
-    let { MarkdownPreview } = fileFormats;
-    let file = makeMarkdownFile();
+    let { MarkdownPreview, FITTED_TEXT_LINE_BUDGET } = fileFormats;
+    // A fixture longer than the fitted line budget, so this test pins that
+    // `@mode` flows through `ensureFileViewModel` into the projection-time
+    // budget — not just the branch selection the class name reflects. The
+    // heading occupies line one, so items 1..(budget - 1) survive the cut.
+    let content = [
+      '# Field Notes',
+      ...Array.from(
+        { length: FITTED_TEXT_LINE_BUDGET + 6 },
+        (_, i) => `- budget line ${i + 1}`,
+      ),
+    ].join('\n');
+    let file = new MarkdownDef({
+      id: 'http://example.com/docs/notes.md',
+      url: 'http://example.com/docs/notes.md',
+      sourceUrl: 'http://example.com/docs/notes.md',
+      name: 'notes.md',
+      contentType: 'text/markdown',
+      title: 'Field Notes',
+      content,
+    });
     await renderComponent(
       <template><MarkdownPreview @model={{file}} @mode='fitted' /></template>,
     );
@@ -146,6 +165,18 @@ module('Integration | content-only file preview components', function (hooks) {
       .dom('[data-test-markdown-preview]')
       .hasClass('md-preview--fitted', 'the fitted rendition is selected');
     assert.dom('[data-test-markdown-preview] h1').hasText('Field Notes');
+    assert
+      .dom('[data-test-markdown-preview]')
+      .includesText(
+        `budget line ${FITTED_TEXT_LINE_BUDGET - 1}`,
+        'the last line inside the budget is rendered',
+      );
+    assert
+      .dom('[data-test-markdown-preview]')
+      .doesNotIncludeText(
+        `budget line ${FITTED_TEXT_LINE_BUDGET}`,
+        'lines beyond the fitted budget are cut at projection time',
+      );
   });
 
   test('ImagePreview renders a native <img> from a bare FileDef instance', async function (assert) {

--- a/packages/host/tests/integration/components/content-preview-components-test.gts
+++ b/packages/host/tests/integration/components/content-preview-components-test.gts
@@ -1,0 +1,214 @@
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm, type Loader } from '@cardstack/runtime-common';
+
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { renderComponent } from '../../helpers/render-component';
+import { setupRenderingTest } from '../../helpers/setup';
+
+import type * as AudioDefModule from '@cardstack/base/audio-file-def';
+import type * as CardApiModule from '@cardstack/base/card-api';
+import type * as FileFormatsModule from '@cardstack/base/file-formats/index';
+import type * as MetadataFieldsModule from '@cardstack/base/file-formats/metadata-fields';
+import type * as MarkdownDefModule from '@cardstack/base/markdown-file-def';
+
+// The content-only preview components: a card author imports one from the
+// `file-formats/index` barrel, passes the FileDef instance, and gets just the
+// file's content — no shell chrome (file bar, inspector, Download/Copy-link),
+// which stays with the default FileDef format templates.
+module('Integration | content-only file preview components', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  let loader: Loader;
+  let fileFormats: typeof FileFormatsModule;
+  let MarkdownDef: typeof MarkdownDefModule.MarkdownDef;
+  let ImageDef: typeof CardApiModule.ImageDef;
+  let AudioDef: typeof AudioDefModule.AudioDef;
+  let WaveformMetadataField: typeof MetadataFieldsModule.WaveformMetadataField;
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    loader = getService('loader-service').loader;
+    // The one stable import path for embedding authors:
+    // `https://cardstack.com/base/file-formats/index`.
+    fileFormats = await loader.import<typeof FileFormatsModule>(
+      `${baseRealm.url}file-formats/index`,
+    );
+    ({ MarkdownDef } = await loader.import<typeof MarkdownDefModule>(
+      `${baseRealm.url}markdown-file-def`,
+    ));
+    ({ ImageDef } = await loader.import<typeof CardApiModule>(
+      `${baseRealm.url}card-api`,
+    ));
+    ({ AudioDef } = await loader.import<typeof AudioDefModule>(
+      `${baseRealm.url}audio-file-def`,
+    ));
+    ({ WaveformMetadataField } = await loader.import<
+      typeof MetadataFieldsModule
+    >(`${baseRealm.url}file-formats/metadata-fields`));
+  });
+
+  function makeMarkdownFile() {
+    return new MarkdownDef({
+      id: 'http://example.com/docs/notes.md',
+      url: 'http://example.com/docs/notes.md',
+      sourceUrl: 'http://example.com/docs/notes.md',
+      name: 'notes.md',
+      contentType: 'text/markdown',
+      title: 'Field Notes',
+      content: '# Field Notes\n\nSome **important** prose.',
+    });
+  }
+
+  function assertNoShellChrome(assert: Assert) {
+    assert.dom('[data-test-file-atom]').doesNotExist('no atom shell');
+    assert.dom('[data-test-file-embedded]').doesNotExist('no embedded shell');
+    assert.dom('[data-test-file-fitted]').doesNotExist('no fitted shell');
+    assert.dom('[data-test-file-isolated]').doesNotExist('no isolated shell');
+    assert
+      .dom('[data-test-file-preview-stage]')
+      .doesNotExist('no preview stage');
+    assert.dom('[data-test-file-download]').doesNotExist('no download action');
+    assert
+      .dom('[data-test-file-copy-link]')
+      .doesNotExist('no copy-link action');
+  }
+
+  test('the barrel exports the content-only components and their helpers', async function (assert) {
+    assert.ok(fileFormats.MarkdownPreview, 'MarkdownPreview is exported');
+    assert.ok(fileFormats.ImagePreview, 'ImagePreview is exported');
+    assert.ok(fileFormats.AudioPreview, 'AudioPreview is exported');
+    assert.ok(
+      fileFormats.filePreviewComponentFor,
+      'filePreviewComponentFor is exported',
+    );
+    assert.ok(
+      fileFormats.ensureFileViewModel,
+      'ensureFileViewModel is exported',
+    );
+  });
+
+  test('filePreviewComponentFor dispatches to the renderer the file class declares', async function (assert) {
+    assert.strictEqual(
+      fileFormats.filePreviewComponentFor(makeMarkdownFile()),
+      fileFormats.MarkdownPreview,
+      'a markdown file dispatches to MarkdownPreview',
+    );
+    assert.strictEqual(
+      fileFormats.filePreviewComponentFor(
+        new ImageDef({ name: 'hero.png', contentType: 'image/png' }),
+      ),
+      fileFormats.ImagePreview,
+      'an image file dispatches to ImagePreview',
+    );
+  });
+
+  test('MarkdownPreview renders the file content from a bare FileDef instance', async function (assert) {
+    let { MarkdownPreview } = fileFormats;
+    let file = makeMarkdownFile();
+    await renderComponent(
+      <template><MarkdownPreview @model={{file}} /></template>,
+    );
+    assert.dom('[data-test-markdown-preview] h1').hasText('Field Notes');
+    assert.dom('[data-test-markdown-preview] strong').hasText('important');
+    assert
+      .dom('[data-test-markdown-preview]')
+      .hasAttribute('data-mode', 'embedded', "mode defaults to 'embedded'");
+    assertNoShellChrome(assert);
+  });
+
+  test('MarkdownPreview accepts a prebuilt view model', async function (assert) {
+    let { MarkdownPreview, fileProfileSource, fileViewModel } = fileFormats;
+    let file = makeMarkdownFile();
+    let viewModel = fileViewModel(file, 'isolated', fileProfileSource(file));
+    await renderComponent(
+      <template>
+        <MarkdownPreview @model={{viewModel}} @mode='isolated' />
+      </template>,
+    );
+    assert.dom('[data-test-markdown-preview] h1').hasText('Field Notes');
+    assert
+      .dom('[data-test-markdown-preview]')
+      .hasAttribute('data-mode', 'isolated');
+    assertNoShellChrome(assert);
+  });
+
+  test('MarkdownPreview in fitted mode renders the budgeted snippet rendition', async function (assert) {
+    let { MarkdownPreview } = fileFormats;
+    let file = makeMarkdownFile();
+    await renderComponent(
+      <template><MarkdownPreview @model={{file}} @mode='fitted' /></template>,
+    );
+    assert
+      .dom('[data-test-markdown-preview]')
+      .hasClass('md-preview--fitted', 'the fitted rendition is selected');
+    assert.dom('[data-test-markdown-preview] h1').hasText('Field Notes');
+  });
+
+  test('ImagePreview renders a native <img> from a bare FileDef instance', async function (assert) {
+    let { ImagePreview } = fileFormats;
+    let image = new ImageDef({
+      id: 'http://example.com/img/hero.png',
+      url: 'http://example.com/img/hero.png',
+      sourceUrl: 'http://example.com/img/hero.png',
+      name: 'hero.png',
+      contentType: 'image/png',
+      width: 640,
+      height: 480,
+    });
+    await renderComponent(
+      <template>
+        {{! The component fills its nearest positioned ancestor (the same
+        contract it has inside the shells' stage), so the embedding author
+        supplies the frame. }}
+        {{! template-lint-disable no-inline-styles }}
+        <div style='position: relative; width: 200px; height: 150px;'>
+          <ImagePreview @model={{image}} />
+        </div>
+      </template>,
+    );
+    assert.dom('img[data-test-image-preview]').exists();
+    assert
+      .dom('img[data-test-image-preview]')
+      .hasAttribute(
+        'data-image-fit',
+        'scale-down',
+        'the default embedded mode never crops or upscales',
+      );
+    assert
+      .dom('img[data-test-image-preview]')
+      .hasAttribute('alt', 'hero.png', 'reading formats describe the image');
+    assertNoShellChrome(assert);
+  });
+
+  test('AudioPreview renders the waveform and player from a bare FileDef instance', async function (assert) {
+    let { AudioPreview } = fileFormats;
+    let audio = new AudioDef({
+      id: 'http://example.com/audio/take.wav',
+      url: 'http://example.com/audio/take.wav',
+      sourceUrl: 'http://example.com/audio/take.wav',
+      name: 'take.wav',
+      contentType: 'audio/wav',
+      contentSize: 2_646_078,
+      duration: 10,
+      waveform: new WaveformMetadataField({
+        decodeStatus: 'ok',
+        barsJson: JSON.stringify(Array.from({ length: 32 }, () => 0.5)),
+        barCount: 32,
+      }),
+    });
+    await renderComponent(
+      <template><AudioPreview @model={{audio}} /></template>,
+    );
+    assert
+      .dom('[data-test-audio-preview]')
+      .hasAttribute('data-mode', 'embedded', "mode defaults to 'embedded'");
+    assert.dom('[data-test-audio-preview] .wave-svg').exists();
+    assert.dom('[data-test-audio-player]').exists();
+    assert.dom('[data-test-audio-duration]').hasText('0:10');
+    assertNoShellChrome(assert);
+  });
+});


### PR DESCRIPTION
## What this does

The \`file-formats/index\` barrel now exports **MarkdownPreview**, **ImagePreview**, and **AudioPreview** so card authors can render a file's content with no shell chrome — no file bar, no inspector metadata, no Download/Copy-link bar. The default wrapped FileDef templates are unchanged; authors wanting full control import a content-only component instead of fighting the shell with CSS.

## The settled component signature

The three components share \`ContentPreviewSignature\` (exported from the barrel alongside \`FilePreviewSignature\`):

- **\`@model\`** — the FileDef instance itself, the common case: the component projects it through the new \`ensureFileViewModel\` helper, which also picks up the profile axes the instance's class pins (\`static fileFamily\` and friends). A prebuilt \`FileViewModel\` (what the shells pass) is also accepted; \`isFileViewModel\` tells the two apart by the projection's plain-object shape.
- **\`@mode\`** — optional, defaulting to \`embedded\` (complete content). \`fitted\` selects the budgeted snippet rendition a collection cell draws.
- **\`@fields\`** — optional, only for renderers that delegate to a declared field's own component.

Loading/failure/staleness panes are deliberately *not* drawn by these components — inside the default templates that is \`FilePreviewStage\`'s job, and a content-only embedding author owns those states.

\`filePreviewComponentFor\` is also exported from the barrel, so a kind-dispatching consumer can resolve whichever renderer a file's own class declares.

## Where MarkdownPreview lives

Rather than exporting it from \`markdown-file-def.gts\`, the component moves to \`file-formats/markdown-preview.gts\`, matching the image/audio/html renderers. This keeps the barrel from pulling MarkdownDef's whole extraction graph (frontmatter parsing, file-api, card-api statics) into every barrel consumer, and it keeps card-api's guarded dependency-graph fixture in \`realm-indexing-test\` untouched — nothing new becomes reachable from \`card-api\`.

## Tests

New \`Integration | content-only file preview components\` module covers: importing each component (and the helpers) from the barrel via the loader, markdown/image/audio rendering from a bare FileDef instance with explicit no-shell-chrome assertions, the prebuilt-view-model path, the \`embedded\` mode default, and \`filePreviewComponentFor\` dispatch.

Ran locally via the dev test page: the new module plus \`FileDef format templates\` (68), \`markdown-preview\` (19), \`json/csv file def preview\` (39), \`markdown skill *\` (53), and \`realm indexing\` (145) — all green. Typechecks pass in host, ai-bot, bot-runner, and billing.

Linear: [CS-12587](https://linear.app/cardstack/issue/CS-12587)

🤖 Generated with [Claude Code](https://claude.com/claude-code)