### PR TITLE
feat: boxel browse opens the app pre-authenticated

### DIFF
--- a/packages/boxel-cli/src/build-program.ts
+++ b/packages/boxel-cli/src/build-program.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { profileCommand } from './commands/profile.ts';
+import { registerBrowseCommand } from './commands/browse.ts';
 import { registerConsolidateWorkspacesCommand } from './commands/consolidate-workspaces.ts';
 import { registerLintCommand } from './commands/lint.ts';
 import { registerParseCommand } from './commands/parse.ts';
@@ -127,6 +128,7 @@ Environment variables (for 'add'):
       },
     );
 
+  registerBrowseCommand(program);
   registerFileCommand(program);
   registerLintCommand(program);
   registerParseCommand(program);

--- a/packages/boxel-cli/src/commands/browse.ts
+++ b/packages/boxel-cli/src/commands/browse.ts
@@ -1,0 +1,183 @@
+import type { Command } from 'commander';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+import { describeDuration } from '@cardstack/runtime-common/cli-auth';
+import {
+  getProfileManager,
+  NO_ACTIVE_PROFILE_ERROR,
+  type Profile,
+  type ProfileManager,
+} from '../lib/profile-manager.ts';
+import {
+  requestLoginToken as defaultRequestLoginToken,
+  MatrixAuthError,
+} from '../lib/auth.ts';
+import { openBrowser } from '../lib/open-browser.ts';
+import { FG_RED, RESET } from '../lib/colors.ts';
+import { cliLog } from '../lib/cli-log.ts';
+
+// The standard local dev URLs. The realm server and the host app dev server run
+// on different ports, and the browser session lives in origin-scoped storage,
+// so the login token must be redeemed on the host app's origin (`4200`), not the
+// realm server's (`4201`). Deployed environments serve both from one origin, so
+// there the host app URL is just the realm server URL.
+const LOCAL_REALM_SERVER_URL = 'https://localhost:4201/';
+const LOCAL_HOST_APP_URL = 'https://localhost:4200/';
+
+/**
+ * Derive the origin that serves the host app for a profile.
+ *
+ * `--host-url` wins when given (the only way to reach env-slug `.localhost`
+ * environments, which store no host-URL convention). Otherwise: standard local
+ * dev maps the realm-server port to the host dev-server port; every other
+ * environment serves the app from the realm-server origin. Exported for unit
+ * testing.
+ */
+export function hostAppUrlForProfile(
+  profile: Pick<Profile, 'realmServerUrl'>,
+  hostUrlOverride?: string,
+): string {
+  if (hostUrlOverride) {
+    return ensureTrailingSlash(hostUrlOverride);
+  }
+  let realmServerUrl = ensureTrailingSlash(profile.realmServerUrl);
+  if (realmServerUrl === LOCAL_REALM_SERVER_URL) {
+    return LOCAL_HOST_APP_URL;
+  }
+  return realmServerUrl;
+}
+
+/**
+ * Build the authenticated host-app URL: the login token the host consumes on
+ * load, plus an optional `cardPath` to deep-link to a card once signed in.
+ * Exported for unit testing.
+ */
+export function buildBrowseUrl(
+  hostUrl: string,
+  loginToken: string,
+  cardPath?: string,
+): string {
+  let url = new URL(ensureTrailingSlash(hostUrl));
+  url.searchParams.set('loginToken', loginToken);
+  if (cardPath) {
+    url.searchParams.set('cardPath', cardPath);
+  }
+  return url.href;
+}
+
+export interface BrowseOptions {
+  profile?: string;
+  hostUrl?: string;
+  printUrl?: boolean;
+  // Injectable seams for testing.
+  profileManager?: ProfileManager;
+  requestLoginToken?: typeof defaultRequestLoginToken;
+  openBrowserFn?: (url: string) => Promise<boolean>;
+  log?: (message: string) => void;
+}
+
+// Resolve the target profile: the named one, or the active one.
+function resolveProfile(
+  pm: ProfileManager,
+  profileId: string | undefined,
+): { id: string; profile: Profile } {
+  if (profileId) {
+    let profile = pm.getProfile(profileId);
+    if (!profile) {
+      throw new Error(
+        `No profile named "${profileId}". Run \`boxel profile list\` to see your profiles.`,
+      );
+    }
+    return { id: profileId, profile };
+  }
+  let active = pm.getActiveProfile();
+  if (!active) {
+    throw new Error(NO_ACTIVE_PROFILE_ERROR);
+  }
+  return active;
+}
+
+export async function browse(
+  cardPath: string | undefined,
+  options: BrowseOptions = {},
+): Promise<void> {
+  let pm = options.profileManager ?? getProfileManager();
+  let requestLoginToken = options.requestLoginToken ?? defaultRequestLoginToken;
+  let openBrowserFn = options.openBrowserFn ?? openBrowser;
+  let log = options.log ?? ((message: string) => console.log(message));
+
+  let { id: profileId, profile } = resolveProfile(pm, options.profile);
+
+  // Mint the login token, recovering once from a rejected access token via the
+  // profile manager's interactive re-auth (same pattern as the other commands).
+  let token;
+  try {
+    token = await requestLoginToken(pm.getStoredMatrixAuth(profileId));
+  } catch (err) {
+    if (!(err instanceof MatrixAuthError)) {
+      throw err;
+    }
+    let freshAuth = await pm.reAuthenticate(profileId);
+    token = await requestLoginToken(freshAuth);
+  }
+
+  let hostUrl = hostAppUrlForProfile(profile, options.hostUrl);
+  let url = buildBrowseUrl(hostUrl, token.loginToken, cardPath);
+
+  // The URL carries a single-use login token, so it's a credential. Under
+  // `--print-url` it's the requested payload (stdout); otherwise it only ever
+  // reaches the browser or the failure fallback.
+  if (options.printUrl) {
+    cliLog.output(url);
+    return;
+  }
+
+  log(
+    `Opening ${hostUrl} as ${profile.matrixUserId} ` +
+      `(login token valid ${describeDuration(token.expiresInMs)}, single use)`,
+  );
+
+  let opened = await openBrowserFn(url);
+  if (!opened) {
+    cliLog.warn(
+      `Couldn't open a browser automatically. Open this URL to sign in ` +
+        `(single-use, expires soon):\n  ${url}`,
+    );
+  }
+}
+
+interface BrowseCliOptions {
+  profile?: string;
+  hostUrl?: string;
+  printUrl?: boolean;
+}
+
+export function registerBrowseCommand(program: Command): void {
+  program
+    .command('browse')
+    .description(
+      'Open the Boxel app in your browser, already signed in as your active profile',
+    )
+    .argument(
+      '[card-path]',
+      'Card path to deep-link to after signing in (e.g. a realm-relative path)',
+    )
+    .option('--profile <id>', 'Profile to use (default: the active profile)')
+    .option(
+      '--host-url <url>',
+      'Override the host app URL the token is redeemed against',
+    )
+    .option(
+      '--print-url',
+      'Print the authenticated URL instead of opening a browser (for remote shells / agents)',
+    )
+    .action(async (cardPath: string | undefined, opts: BrowseCliOptions) => {
+      try {
+        await browse(cardPath, opts);
+      } catch (err) {
+        console.error(
+          `${FG_RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+    });
+}

--- a/packages/boxel-cli/src/commands/browse.ts
+++ b/packages/boxel-cli/src/commands/browse.ts
@@ -131,10 +131,12 @@ export async function browse(
     return;
   }
 
-  log(
-    `Opening ${hostUrl} as ${profile.matrixUserId} ` +
-      `(login token valid ${describeDuration(token.expiresInMs)}, single use)`,
-  );
+  // The validity window is only stated when the server reported one.
+  let tokenNote =
+    token.expiresInMs !== undefined
+      ? `(login token valid ${describeDuration(token.expiresInMs)}, single use)`
+      : `(single-use login token)`;
+  log(`Opening ${hostUrl} as ${profile.matrixUserId} ${tokenNote}`);
 
   let opened = await openBrowserFn(url);
   if (!opened) {

--- a/packages/boxel-cli/src/lib/auth.ts
+++ b/packages/boxel-cli/src/lib/auth.ts
@@ -60,6 +60,104 @@ export async function matrixLogin(
   };
 }
 
+export interface LoginToken {
+  loginToken: string;
+  // How long the token is valid, in milliseconds, as reported by the server.
+  expiresInMs: number;
+}
+
+// Parse a Matrix error body, which is JSON `{ errcode, error, ... }` on a
+// standard error and additionally carries `flows` when the endpoint answers a
+// User-Interactive Auth (UIA) challenge. Tolerant of a non-JSON body.
+function parseMatrixError(text: string): {
+  errcode?: string;
+  flows?: unknown;
+} {
+  try {
+    let parsed = JSON.parse(text) as { errcode?: string; flows?: unknown };
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Mint a short-lived, single-use Matrix login token from an existing session
+ * (MSC3882 `POST /_matrix/client/v1/login/get_token`). The token can be handed
+ * to a browser to sign it in as the same user without re-entering credentials.
+ *
+ * Requires the homeserver to have `login_via_existing_session` enabled; when it
+ * doesn't, the endpoint is unrecognized and this throws a clear "not enabled"
+ * error naming the server. A rejected access token throws `MatrixAuthError`, so
+ * a caller can drive interactive re-auth and retry.
+ */
+export async function requestLoginToken(
+  matrixAuth: MatrixAuth,
+  fetchFn: typeof fetch = fetch,
+): Promise<LoginToken> {
+  let response = await fetchFn(
+    new URL('_matrix/client/v1/login/get_token', matrixAuth.matrixUrl).href,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${matrixAuth.accessToken}`,
+      },
+      body: '{}',
+    },
+  );
+
+  if (response.ok) {
+    let json = (await response.json()) as {
+      login_token?: string;
+      expires_in_ms?: number;
+    };
+    if (!json.login_token) {
+      throw new Error(
+        `Matrix login-token response from ${matrixAuth.matrixUrl} did not include a login_token`,
+      );
+    }
+    return {
+      loginToken: json.login_token,
+      expiresInMs: json.expires_in_ms ?? 0,
+    };
+  }
+
+  let text = await response.text();
+  let { errcode, flows } = parseMatrixError(text);
+
+  // A rejected access token — surface it as MatrixAuthError so the caller can
+  // re-authenticate and retry once, matching the other Matrix calls here.
+  if (response.status === 401 && errcode === 'M_UNKNOWN_TOKEN') {
+    throw new MatrixAuthError(
+      response.status,
+      `Matrix rejected the access token: ${response.status} ${text}`,
+    );
+  }
+
+  // The endpoint is unrecognized (feature off) or gated behind an interactive
+  // UIA challenge (require_ui_auth). Neither is something this non-interactive
+  // path can drive, and both mean the same thing to the user: the server isn't
+  // set up to mint login tokens from a session.
+  let featureUnavailable =
+    errcode === 'M_UNRECOGNIZED' ||
+    response.status === 404 ||
+    response.status === 400 ||
+    (response.status === 401 && Array.isArray(flows));
+  if (featureUnavailable) {
+    throw new Error(
+      `The Matrix server at ${matrixAuth.matrixUrl} does not have ` +
+        `login_via_existing_session enabled, so it cannot mint a login token ` +
+        `(${response.status} ${errcode ?? 'no errcode'}). This is expected ` +
+        `until that feature is turned on for this environment.`,
+    );
+  }
+
+  throw new Error(
+    `Matrix login-token request failed: ${response.status} ${text}`,
+  );
+}
+
 async function getOpenIdToken(
   matrixAuth: MatrixAuth,
 ): Promise<Record<string, unknown>> {

--- a/packages/boxel-cli/src/lib/auth.ts
+++ b/packages/boxel-cli/src/lib/auth.ts
@@ -63,7 +63,8 @@ export async function matrixLogin(
 export interface LoginToken {
   loginToken: string;
   // How long the token is valid, in milliseconds, as reported by the server.
-  expiresInMs: number;
+  // Absent when the server omits `expires_in_ms`.
+  expiresInMs?: number;
 }
 
 // Parse a Matrix error body, which is JSON `{ errcode, error, ... }` on a
@@ -119,7 +120,9 @@ export async function requestLoginToken(
     }
     return {
       loginToken: json.login_token,
-      expiresInMs: json.expires_in_ms ?? 0,
+      ...(json.expires_in_ms !== undefined
+        ? { expiresInMs: json.expires_in_ms }
+        : {}),
     };
   }
 
@@ -138,11 +141,13 @@ export async function requestLoginToken(
   // The endpoint is unrecognized (feature off) or gated behind an interactive
   // UIA challenge (require_ui_auth). Neither is something this non-interactive
   // path can drive, and both mean the same thing to the user: the server isn't
-  // set up to mint login tokens from a session.
+  // set up to mint login tokens from a session. `M_UNRECOGNIZED` covers both
+  // response shapes for an unknown endpoint (404 per spec, 400 from older
+  // Synapse); a 400 with any other errcode is a genuine bad request and falls
+  // through to the raw failure below.
   let featureUnavailable =
     errcode === 'M_UNRECOGNIZED' ||
     response.status === 404 ||
-    response.status === 400 ||
     (response.status === 401 && Array.isArray(flows));
   if (featureUnavailable) {
     throw new Error(

--- a/packages/boxel-cli/src/lib/open-browser.ts
+++ b/packages/boxel-cli/src/lib/open-browser.ts
@@ -1,18 +1,33 @@
 import { spawn } from 'node:child_process';
 
+// The platform launcher invocation for a URL. Exported for unit testing.
+export function browserLaunchCommand(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): [command: string, args: string[]] {
+  if (platform === 'darwin') {
+    return ['open', [url]];
+  }
+  if (platform === 'win32') {
+    // cmd.exe parses the `start` line itself, so shell metacharacters inside
+    // the URL — `&` between query params, redirection chars — would cut the
+    // command short and run the remainder as a separate command.
+    // Caret-escaping neutralizes them; `^` is escaped first so the carets
+    // this inserts aren't themselves re-escaped.
+    let escaped = url.replace(/\^/g, '^^').replace(/[&|<>]/g, '^$&');
+    return ['cmd', ['/c', 'start', '', escaped]];
+  }
+  return ['xdg-open', [url]];
+}
+
 // Best-effort: a detached launch whose failure is reported to the caller so it
 // can fall back to printing the URL. Never rejects.
 export function openBrowser(url: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const [command, args] =
-      process.platform === 'darwin'
-        ? ['open', [url]]
-        : process.platform === 'win32'
-          ? ['cmd', ['/c', 'start', '', url]]
-          : ['xdg-open', [url]];
+    const [command, args] = browserLaunchCommand(url);
 
     try {
-      const child = spawn(command as string, args as string[], {
+      const child = spawn(command, args, {
         stdio: 'ignore',
         detached: true,
       });

--- a/packages/boxel-cli/src/lib/open-browser.ts
+++ b/packages/boxel-cli/src/lib/open-browser.ts
@@ -1,0 +1,28 @@
+import { spawn } from 'node:child_process';
+
+// Best-effort: a detached launch whose failure is reported to the caller so it
+// can fall back to printing the URL. Never rejects.
+export function openBrowser(url: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const [command, args] =
+      process.platform === 'darwin'
+        ? ['open', [url]]
+        : process.platform === 'win32'
+          ? ['cmd', ['/c', 'start', '', url]]
+          : ['xdg-open', [url]];
+
+    try {
+      const child = spawn(command as string, args as string[], {
+        stdio: 'ignore',
+        detached: true,
+      });
+      child.once('error', () => resolve(false));
+      child.once('spawn', () => {
+        child.unref();
+        resolve(true);
+      });
+    } catch {
+      resolve(false);
+    }
+  });
+}

--- a/packages/boxel-cli/src/lib/sso-login.ts
+++ b/packages/boxel-cli/src/lib/sso-login.ts
@@ -11,6 +11,11 @@ import {
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 
 import type { MatrixAuth } from './auth.ts';
+import { openBrowser } from './open-browser.ts';
+
+// Re-exported so this module's long-standing public surface is unchanged now
+// that the browser opener lives in its own module (shared with `browse`).
+export { openBrowser };
 
 // The authorization page states this same window to the person waiting in it, so
 // the two read it from one place.
@@ -372,33 +377,6 @@ export async function redeemLoginToken(
     userId: json.user_id,
     matrixUrl,
   };
-}
-
-// Best-effort: a detached launch whose failure is reported to the caller so it
-// can fall back to printing the URL. Never rejects.
-export function openBrowser(url: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    const [command, args] =
-      process.platform === 'darwin'
-        ? ['open', [url]]
-        : process.platform === 'win32'
-          ? ['cmd', ['/c', 'start', '', url]]
-          : ['xdg-open', [url]];
-
-    try {
-      const child = spawn(command as string, args as string[], {
-        stdio: 'ignore',
-        detached: true,
-      });
-      child.once('error', () => resolve(false));
-      child.once('spawn', () => {
-        child.unref();
-        resolve(true);
-      });
-    } catch {
-      resolve(false);
-    }
-  });
 }
 
 // Copies text through the platform's clipboard tool. Best-effort in the same

--- a/packages/boxel-cli/tests/commands/browse.test.ts
+++ b/packages/boxel-cli/tests/commands/browse.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  hostAppUrlForProfile,
+  buildBrowseUrl,
+  browse,
+} from '../../src/commands/browse.js';
+import { requestLoginToken, MatrixAuthError } from '../../src/lib/auth.js';
+import type { ProfileManager } from '../../src/lib/profile-manager.js';
+
+const MATRIX_URL = 'https://matrix.example.com';
+const MATRIX_AUTH = {
+  accessToken: 'access-token',
+  userId: '@alice:example.com',
+  deviceId: 'DEVICE',
+  matrixUrl: MATRIX_URL,
+};
+
+// A minimal Response stand-in shaped to what requestLoginToken reads.
+function fakeResponse(status: number, body: unknown): Response {
+  let text = typeof body === 'string' ? body : JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => (typeof body === 'string' ? JSON.parse(text) : body),
+    text: async () => text,
+  } as unknown as Response;
+}
+
+describe('hostAppUrlForProfile', () => {
+  it('maps standard local dev to the host dev server origin', () => {
+    // The realm server (4201) and host app (4200) run on different origins in
+    // local dev; the token must be redeemed on the host app's.
+    expect(
+      hostAppUrlForProfile({ realmServerUrl: 'https://localhost:4201/' }),
+    ).toBe('https://localhost:4200/');
+  });
+
+  it('serves the app from the realm-server origin for staging', () => {
+    expect(
+      hostAppUrlForProfile({
+        realmServerUrl: 'https://realms-staging.stack.cards/',
+      }),
+    ).toBe('https://realms-staging.stack.cards/');
+  });
+
+  it('serves the app from the realm-server origin for production', () => {
+    expect(
+      hostAppUrlForProfile({ realmServerUrl: 'https://app.boxel.ai/' }),
+    ).toBe('https://app.boxel.ai/');
+  });
+
+  it('normalizes a missing trailing slash', () => {
+    expect(
+      hostAppUrlForProfile({ realmServerUrl: 'https://app.boxel.ai' }),
+    ).toBe('https://app.boxel.ai/');
+  });
+
+  it('lets --host-url override the derived URL (e.g. env-slug environments)', () => {
+    expect(
+      hostAppUrlForProfile(
+        { realmServerUrl: 'https://realm-server.my-slug.localhost/' },
+        'https://my-slug.localhost:4200',
+      ),
+    ).toBe('https://my-slug.localhost:4200/');
+  });
+});
+
+describe('buildBrowseUrl', () => {
+  it('appends the login token as a query param', () => {
+    expect(buildBrowseUrl('https://app.boxel.ai/', 'tok123')).toBe(
+      'https://app.boxel.ai/?loginToken=tok123',
+    );
+  });
+
+  it('adds an encoded cardPath when given', () => {
+    expect(
+      buildBrowseUrl('https://app.boxel.ai/', 'tok123', 'my realm/card.json'),
+    ).toBe(
+      'https://app.boxel.ai/?loginToken=tok123&cardPath=my+realm%2Fcard.json',
+    );
+  });
+
+  it('omits cardPath when not given', () => {
+    expect(buildBrowseUrl('https://localhost:4200/', 'tok')).not.toContain(
+      'cardPath',
+    );
+  });
+});
+
+describe('requestLoginToken', () => {
+  it('returns the login token and expiry on success', async () => {
+    let fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        fakeResponse(200, { login_token: 'lt_abc', expires_in_ms: 120000 }),
+      );
+
+    await expect(requestLoginToken(MATRIX_AUTH, fetchFn)).resolves.toEqual({
+      loginToken: 'lt_abc',
+      expiresInMs: 120000,
+    });
+
+    let [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe(`${MATRIX_URL}/_matrix/client/v1/login/get_token`);
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer access-token');
+  });
+
+  it('throws MatrixAuthError on a rejected access token (M_UNKNOWN_TOKEN)', async () => {
+    let fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        fakeResponse(401, { errcode: 'M_UNKNOWN_TOKEN', error: 'bad token' }),
+      );
+
+    await expect(
+      requestLoginToken(MATRIX_AUTH, fetchFn),
+    ).rejects.toBeInstanceOf(MatrixAuthError);
+  });
+
+  it('gives a clear "not enabled" error when the endpoint is unrecognized', async () => {
+    let fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        fakeResponse(404, { errcode: 'M_UNRECOGNIZED', error: 'Unknown' }),
+      );
+
+    await expect(requestLoginToken(MATRIX_AUTH, fetchFn)).rejects.toThrow(
+      /login_via_existing_session enabled/,
+    );
+  });
+
+  it('treats a UIA-gated 401 (require_ui_auth) as "not enabled"', async () => {
+    let fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        fakeResponse(401, { flows: [{ stages: ['m.login.password'] }] }),
+      );
+
+    await expect(requestLoginToken(MATRIX_AUTH, fetchFn)).rejects.toThrow(
+      /login_via_existing_session enabled/,
+    );
+  });
+});
+
+describe('browse', () => {
+  function fakeProfileManager(): ProfileManager {
+    return {
+      getActiveProfile: () => ({
+        id: '@alice:localhost',
+        profile: {
+          displayName: 'Alice',
+          matrixUrl: 'http://localhost:8008',
+          realmServerUrl: 'https://localhost:4201/',
+          matrixAccessToken: 'access-token',
+          matrixUserId: '@alice:localhost',
+          matrixDeviceId: 'DEVICE',
+        },
+      }),
+      getProfile: () => undefined,
+      getStoredMatrixAuth: () => ({
+        accessToken: 'access-token',
+        userId: '@alice:localhost',
+        deviceId: 'DEVICE',
+        matrixUrl: 'http://localhost:8008',
+      }),
+      reAuthenticate: async () => ({
+        accessToken: 'fresh-token',
+        userId: '@alice:localhost',
+        deviceId: 'DEVICE',
+        matrixUrl: 'http://localhost:8008',
+      }),
+    } as unknown as ProfileManager;
+  }
+
+  it('opens the derived host URL with a login token', async () => {
+    let openBrowserFn = vi.fn().mockResolvedValue(true);
+    let requestLoginTokenFn = vi
+      .fn()
+      .mockResolvedValue({ loginToken: 'lt_abc', expiresInMs: 120000 });
+
+    await browse(undefined, {
+      profileManager: fakeProfileManager(),
+      requestLoginToken: requestLoginTokenFn,
+      openBrowserFn,
+      log: () => {},
+    });
+
+    expect(openBrowserFn).toHaveBeenCalledWith(
+      'https://localhost:4200/?loginToken=lt_abc',
+    );
+  });
+
+  it('deep-links to a card path when the positional arg is given', async () => {
+    let openBrowserFn = vi.fn().mockResolvedValue(true);
+    let requestLoginTokenFn = vi
+      .fn()
+      .mockResolvedValue({ loginToken: 'lt_abc', expiresInMs: 120000 });
+
+    await browse('cards/1.json', {
+      profileManager: fakeProfileManager(),
+      requestLoginToken: requestLoginTokenFn,
+      openBrowserFn,
+      log: () => {},
+    });
+
+    expect(openBrowserFn).toHaveBeenCalledWith(
+      'https://localhost:4200/?loginToken=lt_abc&cardPath=cards%2F1.json',
+    );
+  });
+
+  it('prints the URL and does not open a browser under --print-url', async () => {
+    let openBrowserFn = vi.fn().mockResolvedValue(true);
+    let requestLoginTokenFn = vi
+      .fn()
+      .mockResolvedValue({ loginToken: 'lt_abc', expiresInMs: 120000 });
+    let stdout = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    await browse(undefined, {
+      printUrl: true,
+      profileManager: fakeProfileManager(),
+      requestLoginToken: requestLoginTokenFn,
+      openBrowserFn,
+      log: () => {},
+    });
+
+    expect(openBrowserFn).not.toHaveBeenCalled();
+    expect(stdout).toHaveBeenCalledWith(
+      'https://localhost:4200/?loginToken=lt_abc\n',
+    );
+    stdout.mockRestore();
+  });
+
+  it('re-authenticates once and retries when the access token is rejected', async () => {
+    let openBrowserFn = vi.fn().mockResolvedValue(true);
+    let requestLoginTokenFn = vi
+      .fn()
+      .mockRejectedValueOnce(new MatrixAuthError(401, 'rejected'))
+      .mockResolvedValueOnce({ loginToken: 'lt_fresh', expiresInMs: 120000 });
+
+    await browse(undefined, {
+      profileManager: fakeProfileManager(),
+      requestLoginToken: requestLoginTokenFn,
+      openBrowserFn,
+      log: () => {},
+    });
+
+    expect(requestLoginTokenFn).toHaveBeenCalledTimes(2);
+    // The retry used the freshly re-authenticated session.
+    expect(requestLoginTokenFn.mock.calls[1][0]).toMatchObject({
+      accessToken: 'fresh-token',
+    });
+    expect(openBrowserFn).toHaveBeenCalledWith(
+      'https://localhost:4200/?loginToken=lt_fresh',
+    );
+  });
+});

--- a/packages/boxel-cli/tests/commands/browse.test.ts
+++ b/packages/boxel-cli/tests/commands/browse.test.ts
@@ -142,6 +142,50 @@ describe('requestLoginToken', () => {
       /login_via_existing_session enabled/,
     );
   });
+
+  it('treats an old-Synapse 400 M_UNRECOGNIZED as "not enabled"', async () => {
+    let fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        fakeResponse(400, { errcode: 'M_UNRECOGNIZED', error: 'Unrecognized' }),
+      );
+
+    await expect(requestLoginToken(MATRIX_AUTH, fetchFn)).rejects.toThrow(
+      /login_via_existing_session enabled/,
+    );
+  });
+
+  it('reports a 400 with another errcode as a raw failure, not "not enabled"', async () => {
+    let fetchFn = vi
+      .fn()
+      .mockResolvedValue(
+        fakeResponse(400, { errcode: 'M_NOT_JSON', error: 'Bad request' }),
+      );
+
+    await expect(requestLoginToken(MATRIX_AUTH, fetchFn)).rejects.toThrow(
+      /login-token request failed: 400/,
+    );
+  });
+
+  it('errors when a 200 response has no login_token', async () => {
+    let fetchFn = vi
+      .fn()
+      .mockResolvedValue(fakeResponse(200, { expires_in_ms: 120000 }));
+
+    await expect(requestLoginToken(MATRIX_AUTH, fetchFn)).rejects.toThrow(
+      /did not include a login_token/,
+    );
+  });
+
+  it('omits expiresInMs when the server does not report one', async () => {
+    let fetchFn = vi
+      .fn()
+      .mockResolvedValue(fakeResponse(200, { login_token: 'lt_abc' }));
+
+    await expect(requestLoginToken(MATRIX_AUTH, fetchFn)).resolves.toEqual({
+      loginToken: 'lt_abc',
+    });
+  });
 });
 
 describe('browse', () => {
@@ -262,6 +306,32 @@ describe('browse', () => {
     expect(openBrowserFn).toHaveBeenCalledWith(
       'https://localhost:4200/?loginToken=lt_fresh',
     );
+  });
+
+  it('propagates a second auth rejection instead of re-authenticating again', async () => {
+    let openBrowserFn = vi.fn().mockResolvedValue(true);
+    let reAuthenticate = vi.fn().mockResolvedValue({
+      accessToken: 'fresh-token',
+      userId: '@alice:localhost',
+      deviceId: 'DEVICE',
+      matrixUrl: 'http://localhost:8008',
+    });
+    let requestLoginTokenFn = vi
+      .fn()
+      .mockRejectedValue(new MatrixAuthError(401, 'still rejected'));
+
+    await expect(
+      browse(undefined, {
+        profileManager: fakeProfileManager({ reAuthenticate }),
+        requestLoginToken: requestLoginTokenFn,
+        openBrowserFn,
+        log: () => {},
+      }),
+    ).rejects.toBeInstanceOf(MatrixAuthError);
+
+    expect(reAuthenticate).toHaveBeenCalledTimes(1);
+    expect(requestLoginTokenFn).toHaveBeenCalledTimes(2);
+    expect(openBrowserFn).not.toHaveBeenCalled();
   });
 
   it('uses a named --profile via getProfile', async () => {

--- a/packages/boxel-cli/tests/commands/browse.test.ts
+++ b/packages/boxel-cli/tests/commands/browse.test.ts
@@ -145,18 +145,23 @@ describe('requestLoginToken', () => {
 });
 
 describe('browse', () => {
-  function fakeProfileManager(): ProfileManager {
+  const ALICE_PROFILE = {
+    displayName: 'Alice',
+    matrixUrl: 'http://localhost:8008',
+    realmServerUrl: 'https://localhost:4201/',
+    matrixAccessToken: 'access-token',
+    matrixUserId: '@alice:localhost',
+    matrixDeviceId: 'DEVICE',
+  };
+
+  // A ProfileManager stub whose relevant methods can be overridden per test.
+  function fakeProfileManager(
+    overrides: Partial<Record<string, unknown>> = {},
+  ): ProfileManager {
     return {
       getActiveProfile: () => ({
         id: '@alice:localhost',
-        profile: {
-          displayName: 'Alice',
-          matrixUrl: 'http://localhost:8008',
-          realmServerUrl: 'https://localhost:4201/',
-          matrixAccessToken: 'access-token',
-          matrixUserId: '@alice:localhost',
-          matrixDeviceId: 'DEVICE',
-        },
+        profile: ALICE_PROFILE,
       }),
       getProfile: () => undefined,
       getStoredMatrixAuth: () => ({
@@ -171,6 +176,7 @@ describe('browse', () => {
         deviceId: 'DEVICE',
         matrixUrl: 'http://localhost:8008',
       }),
+      ...overrides,
     } as unknown as ProfileManager;
   }
 
@@ -256,5 +262,102 @@ describe('browse', () => {
     expect(openBrowserFn).toHaveBeenCalledWith(
       'https://localhost:4200/?loginToken=lt_fresh',
     );
+  });
+
+  it('uses a named --profile via getProfile', async () => {
+    let openBrowserFn = vi.fn().mockResolvedValue(true);
+    let getStoredMatrixAuth = vi.fn().mockReturnValue({
+      accessToken: 'access-token',
+      userId: '@bob:boxel.ai',
+      deviceId: 'DEVICE',
+      matrixUrl: 'https://matrix.boxel.ai',
+    });
+    let pm = fakeProfileManager({
+      // A named profile shouldn't fall back to the active one.
+      getActiveProfile: () => null,
+      getProfile: (id: string) =>
+        id === '@bob:boxel.ai'
+          ? { ...ALICE_PROFILE, realmServerUrl: 'https://app.boxel.ai/' }
+          : undefined,
+      getStoredMatrixAuth,
+    });
+
+    await browse(undefined, {
+      profile: '@bob:boxel.ai',
+      profileManager: pm,
+      requestLoginToken: vi
+        .fn()
+        .mockResolvedValue({ loginToken: 'lt_abc', expiresInMs: 120000 }),
+      openBrowserFn,
+      log: () => {},
+    });
+
+    expect(getStoredMatrixAuth).toHaveBeenCalledWith('@bob:boxel.ai');
+    expect(openBrowserFn).toHaveBeenCalledWith(
+      'https://app.boxel.ai/?loginToken=lt_abc',
+    );
+  });
+
+  it('errors when the named --profile does not exist', async () => {
+    await expect(
+      browse(undefined, {
+        profile: '@nobody:boxel.ai',
+        profileManager: fakeProfileManager({ getProfile: () => undefined }),
+        requestLoginToken: vi.fn(),
+        openBrowserFn: vi.fn(),
+        log: () => {},
+      }),
+    ).rejects.toThrow(/No profile named "@nobody:boxel.ai"/);
+  });
+
+  it('errors when there is no active profile', async () => {
+    await expect(
+      browse(undefined, {
+        profileManager: fakeProfileManager({ getActiveProfile: () => null }),
+        requestLoginToken: vi.fn(),
+        openBrowserFn: vi.fn(),
+        log: () => {},
+      }),
+    ).rejects.toThrow(/No active profile/);
+  });
+
+  it('honors --host-url over the derived URL', async () => {
+    let openBrowserFn = vi.fn().mockResolvedValue(true);
+
+    await browse(undefined, {
+      hostUrl: 'https://cs-123.localhost:4200',
+      profileManager: fakeProfileManager(),
+      requestLoginToken: vi
+        .fn()
+        .mockResolvedValue({ loginToken: 'lt_abc', expiresInMs: 120000 }),
+      openBrowserFn,
+      log: () => {},
+    });
+
+    expect(openBrowserFn).toHaveBeenCalledWith(
+      'https://cs-123.localhost:4200/?loginToken=lt_abc',
+    );
+  });
+
+  it('warns with the URL when the browser cannot be opened', async () => {
+    // spawn failed → the URL (a live single-use credential) is surfaced on
+    // stderr so the user can finish by hand.
+    let openBrowserFn = vi.fn().mockResolvedValue(false);
+    let stderr = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    await browse(undefined, {
+      profileManager: fakeProfileManager(),
+      requestLoginToken: vi
+        .fn()
+        .mockResolvedValue({ loginToken: 'lt_abc', expiresInMs: 120000 }),
+      openBrowserFn,
+      log: () => {},
+    });
+
+    let written = stderr.mock.calls.map((c) => String(c[0])).join('');
+    expect(written).toContain('https://localhost:4200/?loginToken=lt_abc');
+    stderr.mockRestore();
   });
 });

--- a/packages/boxel-cli/tests/lib/open-browser.test.ts
+++ b/packages/boxel-cli/tests/lib/open-browser.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+
+import { browserLaunchCommand } from '../../src/lib/open-browser.js';
+
+describe('browserLaunchCommand', () => {
+  it('passes the URL straight through on darwin', () => {
+    expect(
+      browserLaunchCommand('https://app.boxel.ai/?a=1&b=2', 'darwin'),
+    ).toEqual(['open', ['https://app.boxel.ai/?a=1&b=2']]);
+  });
+
+  it('passes the URL straight through on linux', () => {
+    expect(
+      browserLaunchCommand('https://app.boxel.ai/?a=1&b=2', 'linux'),
+    ).toEqual(['xdg-open', ['https://app.boxel.ai/?a=1&b=2']]);
+  });
+
+  it('caret-escapes cmd metacharacters on win32', () => {
+    // Unescaped, cmd.exe would cut the `start` line at the `&` and run the
+    // rest (`cardPath=...`) as a separate command.
+    expect(
+      browserLaunchCommand(
+        'https://localhost:4200/?loginToken=tok&cardPath=cards%2F1.json',
+        'win32',
+      ),
+    ).toEqual([
+      'cmd',
+      [
+        '/c',
+        'start',
+        '',
+        'https://localhost:4200/?loginToken=tok^&cardPath=cards%2F1.json',
+      ],
+    ]);
+  });
+
+  it('escapes a literal caret before the other metacharacters on win32', () => {
+    expect(browserLaunchCommand('https://x.test/?a=^&b=|', 'win32')).toEqual([
+      'cmd',
+      ['/c', 'start', '', 'https://x.test/?a=^^^&b=^|'],
+    ]);
+  });
+});


### PR DESCRIPTION
## Background and Goal

Part 3 of the `boxel browse` project. Adds `boxel browse [card-path]`, which mints a short-lived, single-use Matrix login token from the active profile's stored session and opens the host app in the system browser at `?loginToken=<token>`. The host login component already consumes that param (`consumeSsoLoginToken`), so the browser lands signed in with no credentials typed.

```
boxel browse [card-path]
  --profile <id>     profile to use (default: active profile)
  --host-url <url>   override the derived host app URL
  --print-url        print the authenticated URL instead of opening a browser
```

> Stacked on #5830 (CS-12157) — this PR's base is `cs-12157-…`, so the diff is only the CLI command. Merge #5830 first. The `login_via_existing_session` Synapse config from #5830 is what makes the token endpoint available; against a server without it, `browse` prints a clear "not enabled" error and exits non-zero.

## Where to start

- `src/lib/auth.ts` — `requestLoginToken()`: `POST /_matrix/client/v1/login/get_token`. Maps `M_UNKNOWN_TOKEN` → `MatrixAuthError` (drives the existing re-auth + retry), and an unrecognized / UIA-gated endpoint → a clear "feature not enabled" error naming the server.
- `src/commands/browse.ts` — the command. Exported pure helpers `hostAppUrlForProfile` / `buildBrowseUrl` and an injectable `browse()` orchestrator (the seams the unit tests drive).

## Key decisions and non-obvious mechanics

- **Reused the browser opener instead of duplicating it.** The `spawn`-detached `open`/`cmd start`/`xdg-open` logic already lived in `sso-login.ts`; extracted it into `src/lib/open-browser.ts` and `sso-login.ts` now imports + re-exports it. No duplicate platform logic.
- **Host app URL is derived, not stored.** Profiles persist only `matrixUrl` / `realmServerUrl`. `hostAppUrlForProfile` maps standard local dev (`https://localhost:4201/` → `https://localhost:4200/`, host dev server on the local cert) and otherwise uses the realm-server origin (staging/prod serve the app there). `--host-url` overrides — the only way to reach env-slug `.localhost` environments, which store no host-URL convention.
- **The URL is a live credential.** It carries a single-use ~2-minute token, so it only ever reaches the browser, the `--print-url` stdout payload (the parseable contract, for remote shells / agents), or a spawn-failure fallback on stderr. The human status line goes to `console.log` (silenced under `-q`).
- **`cardPath` deep-links.** `consumeSsoLoginToken` strips only `loginToken` and preserves the rest of the query, so `?loginToken=…&cardPath=…` lands on the card after sign-in.