### PR TITLE
prerenderer: Add memory cleanup after render

### DIFF
--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -92,7 +92,14 @@ type DrainSubscription = {
   promise: Promise<{ draining: true }>;
   dispose: () => void;
 };
+// What a caller needs in order to wait: `raceAgainstDrain` only calls this, so
+// it asks for nothing more.
 type SubscribeToDrain = () => DrainSubscription;
+
+// What `createDrainSubscriber` hands back. `waiterCount` is the one thing it
+// exposes beyond subscribing, so the release property can be asserted against
+// this implementation rather than against a stand-in that reimplements it.
+type DrainSubscriber = SubscribeToDrain & { waiterCount: () => number };
 
 // Fans one settlement of the shutdown promise out to per-request subscribers.
 //
@@ -108,17 +115,22 @@ type SubscribeToDrain = () => DrainSubscription;
 // subscription.
 export function createDrainSubscriber(
   drainingPromise: Promise<void>,
-): SubscribeToDrain {
+): DrainSubscriber {
   let waiters = new Set<() => void>();
   let drained = false;
-  drainingPromise.then(() => {
+  let settle = () => {
     drained = true;
     for (let notify of waiters) {
       notify();
     }
     waiters.clear();
-  });
-  return () => {
+  };
+  // Both settlements latch. Nothing rejects the deferred the server wires in,
+  // but this is exported and takes any promise, and an unhandled rejection
+  // here reaches the handler that exits the process. A shutdown signal that
+  // errored is still a shutdown signal.
+  drainingPromise.then(settle, settle);
+  let subscribe = (() => {
     if (drained) {
       return {
         promise: Promise.resolve({ draining: true as const }),
@@ -131,19 +143,27 @@ export function createDrainSubscriber(
     });
     waiters.add(notify);
     return { promise, dispose: () => waiters.delete(notify) };
-  };
+  }) as DrainSubscriber;
+  subscribe.waiterCount = () => waiters.size;
+  return subscribe;
 }
 
 // Run `execPromise`, giving up early if the server starts draining.
 //
 // The subscription is released in `finally` because the alternative — each
 // request calling `.then()` on a promise that only settles at shutdown —
-// leaks. A pending promise keeps every reaction ever attached to it, a
-// reaction keeps its closure, and here that closure captures the request
-// context: the request, its response, and the rendered HTML it produced stay
-// reachable for the life of the process. Nothing detaches a reaction when the
-// render it was racing wins, so the retained set grows by one request's worth
-// of output per request, indefinitely.
+// leaks far more than the reaction itself. The shutdown promise holds that
+// reaction forever; the reaction holds the promise `.then()` derived from it;
+// that derived promise never settles either. `Promise.race` chains onto it,
+// so it holds the race's resolve capability, which holds the race promise —
+// and the race promise is fulfilled with this request's render output. One
+// render's worth of HTML therefore stays reachable per render, for the life
+// of the process. Taking a waiter and dropping it leaves nothing behind.
+//
+// The handler passed to `.then()` captured nothing, so blaming the closure
+// would point at a rule that already held: measured over 2000 renders, that
+// shape alone costs ~0.4 MB, while the same shape fed into a race costs the
+// full ~196 MB of payload.
 export async function raceAgainstDrain<T>(
   execPromise: Promise<T>,
   subscribeToDrain: SubscribeToDrain | undefined,
@@ -451,7 +471,6 @@ export function buildPrerenderApp(options: {
       afterResponse?: (target: string, response: R) => void;
       parseAttributes: (attrs: any) => RouteParseResult<A>;
       errorMessage?: string | ((err: any) => string);
-      subscribeToDrain?: SubscribeToDrain;
     },
   ) {
     router.post(path, async (ctxt: Koa.Context) => {
@@ -543,10 +562,7 @@ export function buildPrerenderApp(options: {
         let execPromise = options
           .execute(routeArgs, { signal: ac.signal })
           .then((result) => ({ result }));
-        let raceResult = await raceAgainstDrain(
-          execPromise,
-          options.subscribeToDrain,
-        );
+        let raceResult = await raceAgainstDrain(execPromise, subscribeToDrain);
         if ('draining' in raceResult) {
           // Ensure execute completion does not raise unhandled rejections after we respond.
           execPromise.catch((e) =>
@@ -666,7 +682,6 @@ export function buildPrerenderApp(options: {
     parseAttributes: parseDefaultPrerenderAttributes,
     execute: (args, { signal }) =>
       prerenderer.prerenderModule({ ...args, signal }),
-    subscribeToDrain,
     afterResponse: (url, response) => {
       const moduleResponse = response as ModuleRenderResponse;
       if (moduleResponse.status === 'error' && moduleResponse.error) {
@@ -696,7 +711,6 @@ export function buildPrerenderApp(options: {
           ...(args.priority !== undefined ? { priority: args.priority } : {}),
           signal,
         }),
-      subscribeToDrain,
     },
   );
 
@@ -718,7 +732,6 @@ export function buildPrerenderApp(options: {
           priority: args.priority,
           signal,
         }),
-      subscribeToDrain,
     },
   );
 

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -94,6 +94,46 @@ type DrainSubscription = {
 };
 type SubscribeToDrain = () => DrainSubscription;
 
+// Fans one settlement of the shutdown promise out to per-request subscribers.
+//
+// Latched rather than only broadcast: a subscriber taken after the broadcast
+// has happened would otherwise join a set nobody iterates again, leaving its
+// promise pending forever. The race in `raceAgainstDrain` would then quietly
+// degrade to a plain await, and the request would render on instead of
+// reporting that the server is going away — which can hold `server.close()`
+// open for the length of a render. Requests do arrive after draining starts:
+// the guard ahead of the routes only turns away POSTs to `/prerender-*`, so
+// `/run-command` and `/release-batch` reach their handlers regardless, and
+// even a guarded path can cross the line between that check and its
+// subscription.
+export function createDrainSubscriber(
+  drainingPromise: Promise<void>,
+): SubscribeToDrain {
+  let waiters = new Set<() => void>();
+  let drained = false;
+  drainingPromise.then(() => {
+    drained = true;
+    for (let notify of waiters) {
+      notify();
+    }
+    waiters.clear();
+  });
+  return () => {
+    if (drained) {
+      return {
+        promise: Promise.resolve({ draining: true as const }),
+        dispose: () => {},
+      };
+    }
+    let notify!: () => void;
+    let promise = new Promise<{ draining: true }>((resolve) => {
+      notify = () => resolve({ draining: true });
+    });
+    waiters.add(notify);
+    return { promise, dispose: () => waiters.delete(notify) };
+  };
+}
+
 // Run `execPromise`, giving up early if the server starts draining.
 //
 // The subscription is released in `finally` because the alternative — each
@@ -137,25 +177,10 @@ export function buildPrerenderApp(options: {
   });
 
   // One reaction on the shutdown promise for the whole process. Requests take
-  // a waiter from this set and drop it when they finish, so what accumulates
-  // is bounded by the number of renders in flight rather than by the number
-  // ever served.
-  let drainWaiters = new Set<() => void>();
-  options.drainingPromise?.then(() => {
-    for (let notify of drainWaiters) {
-      notify();
-    }
-    drainWaiters.clear();
-  });
+  // a waiter and drop it when they finish, so what accumulates is bounded by
+  // the number of renders in flight rather than by the number ever served.
   let subscribeToDrain: SubscribeToDrain | undefined = options.drainingPromise
-    ? () => {
-        let notify!: () => void;
-        let promise = new Promise<{ draining: true }>((resolve) => {
-          notify = () => resolve({ draining: true });
-        });
-        drainWaiters.add(notify);
-        return { promise, dispose: () => drainWaiters.delete(notify) };
-      }
+    ? createDrainSubscriber(options.drainingPromise)
     : undefined;
 
   router.head('/', (ctxt: Koa.Context) => {

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -86,6 +86,39 @@ export function decideHostShellRecycle(
   return { recycle: true, nextWarmed: reported };
 }
 
+// A one-shot notification that shutdown has begun, which the holder releases
+// when it no longer needs it.
+type DrainSubscription = {
+  promise: Promise<{ draining: true }>;
+  dispose: () => void;
+};
+type SubscribeToDrain = () => DrainSubscription;
+
+// Run `execPromise`, giving up early if the server starts draining.
+//
+// The subscription is released in `finally` because the alternative — each
+// request calling `.then()` on a promise that only settles at shutdown —
+// leaks. A pending promise keeps every reaction ever attached to it, a
+// reaction keeps its closure, and here that closure captures the request
+// context: the request, its response, and the rendered HTML it produced stay
+// reachable for the life of the process. Nothing detaches a reaction when the
+// render it was racing wins, so the retained set grows by one request's worth
+// of output per request, indefinitely.
+export async function raceAgainstDrain<T>(
+  execPromise: Promise<T>,
+  subscribeToDrain: SubscribeToDrain | undefined,
+): Promise<T | { draining: true }> {
+  if (!subscribeToDrain) {
+    return await execPromise;
+  }
+  let drain = subscribeToDrain();
+  try {
+    return await Promise.race([execPromise, drain.promise]);
+  } finally {
+    drain.dispose();
+  }
+}
+
 export function buildPrerenderApp(options: {
   serverURL: string;
   maxPages?: number;
@@ -102,6 +135,28 @@ export function buildPrerenderApp(options: {
     maxPages,
     serverURL: options.serverURL,
   });
+
+  // One reaction on the shutdown promise for the whole process. Requests take
+  // a waiter from this set and drop it when they finish, so what accumulates
+  // is bounded by the number of renders in flight rather than by the number
+  // ever served.
+  let drainWaiters = new Set<() => void>();
+  options.drainingPromise?.then(() => {
+    for (let notify of drainWaiters) {
+      notify();
+    }
+    drainWaiters.clear();
+  });
+  let subscribeToDrain: SubscribeToDrain | undefined = options.drainingPromise
+    ? () => {
+        let notify!: () => void;
+        let promise = new Promise<{ draining: true }>((resolve) => {
+          notify = () => resolve({ draining: true });
+        });
+        drainWaiters.add(notify);
+        return { promise, dispose: () => drainWaiters.delete(notify) };
+      }
+    : undefined;
 
   router.head('/', (ctxt: Koa.Context) => {
     if (options.isDraining?.()) {
@@ -371,7 +426,7 @@ export function buildPrerenderApp(options: {
       afterResponse?: (target: string, response: R) => void;
       parseAttributes: (attrs: any) => RouteParseResult<A>;
       errorMessage?: string | ((err: any) => string);
-      drainingPromise?: Promise<void>;
+      subscribeToDrain?: SubscribeToDrain;
     },
   ) {
     router.post(path, async (ctxt: Koa.Context) => {
@@ -463,12 +518,10 @@ export function buildPrerenderApp(options: {
         let execPromise = options
           .execute(routeArgs, { signal: ac.signal })
           .then((result) => ({ result }));
-        let drainPromise = options.drainingPromise
-          ? options.drainingPromise.then(() => ({ draining: true as const }))
-          : null;
-        let raceResult = drainPromise
-          ? await Promise.race([execPromise, drainPromise])
-          : await execPromise;
+        let raceResult = await raceAgainstDrain(
+          execPromise,
+          options.subscribeToDrain,
+        );
         if ('draining' in raceResult) {
           // Ensure execute completion does not raise unhandled rejections after we respond.
           execPromise.catch((e) =>
@@ -588,7 +641,7 @@ export function buildPrerenderApp(options: {
     parseAttributes: parseDefaultPrerenderAttributes,
     execute: (args, { signal }) =>
       prerenderer.prerenderModule({ ...args, signal }),
-    drainingPromise: options.drainingPromise,
+    subscribeToDrain,
     afterResponse: (url, response) => {
       const moduleResponse = response as ModuleRenderResponse;
       if (moduleResponse.status === 'error' && moduleResponse.error) {
@@ -618,7 +671,7 @@ export function buildPrerenderApp(options: {
           ...(args.priority !== undefined ? { priority: args.priority } : {}),
           signal,
         }),
-      drainingPromise: options.drainingPromise,
+      subscribeToDrain,
     },
   );
 
@@ -640,7 +693,7 @@ export function buildPrerenderApp(options: {
           priority: args.priority,
           signal,
         }),
-      drainingPromise: options.drainingPromise,
+      subscribeToDrain,
     },
   );
 
@@ -818,12 +871,7 @@ export function buildPrerenderApp(options: {
           signal: ac.signal,
         })
         .then((result) => ({ result }));
-      let drainPromise = options.drainingPromise
-        ? options.drainingPromise.then(() => ({ draining: true as const }))
-        : null;
-      let raceResult = drainPromise
-        ? await Promise.race([execPromise, drainPromise])
-        : await execPromise;
+      let raceResult = await raceAgainstDrain(execPromise, subscribeToDrain);
       if ('draining' in raceResult) {
         execPromise.catch((e) =>
           log.debug(

--- a/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
+++ b/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
@@ -171,16 +171,48 @@ module(basename(import.meta.filename), function () {
       drain.fulfil();
       await drain.promise;
 
-      let settled = false;
-      let raced = raceAgainstDrain(
-        new Promise<{ result: string }>(() => {}),
-        subscribe,
-      ).then((r) => {
-        settled = true;
-        return r;
-      });
-      assert.deepEqual(await raced, { draining: true });
-      assert.true(settled, 'resolved rather than hanging');
+      // Raced against a timer so the failure being guarded against — the
+      // subscription never settling — reports as this assertion rather than
+      // as a suite timeout.
+      let result = await Promise.race([
+        raceAgainstDrain(new Promise<{ result: string }>(() => {}), subscribe),
+        new Promise((resolve) => setTimeout(() => resolve('hung'), 250)),
+      ]);
+      assert.deepEqual(result, { draining: true }, 'settled rather than hung');
+    });
+
+    // The regression this PR exists to prevent, asserted against the shipping
+    // subscriber rather than the stand-in above: a render that finishes must
+    // leave nothing behind, because what it would leave behind holds that
+    // render's output for the life of the process.
+    test('a completed render leaves nothing on the subscriber', async function (assert) {
+      let subscribe = createDrainSubscriber(new Promise<void>(() => {}));
+      for (let i = 0; i < 50; i++) {
+        await raceAgainstDrain(Promise.resolve({ result: i }), subscribe);
+      }
+      assert.strictEqual(subscribe.waiterCount(), 0, 'no waiters retained');
+    });
+
+    test('a failed render leaves nothing on the subscriber', async function (assert) {
+      let subscribe = createDrainSubscriber(new Promise<void>(() => {}));
+      await assert.rejects(
+        raceAgainstDrain(Promise.reject(new Error('boom')), subscribe),
+        /boom/,
+      );
+      assert.strictEqual(subscribe.waiterCount(), 0, 'no waiters retained');
+    });
+
+    test('a rejected shutdown signal still latches', async function (assert) {
+      let rejected = Promise.reject(new Error('shutdown failed'));
+      let subscribe = createDrainSubscriber(rejected);
+      await rejected.catch(() => undefined);
+      assert.deepEqual(
+        await raceAgainstDrain(
+          new Promise<{ result: string }>(() => {}),
+          subscribe,
+        ),
+        { draining: true },
+      );
     });
 
     test('every later render also reports draining', async function (assert) {

--- a/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
+++ b/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
@@ -1,7 +1,10 @@
 import QUnit from 'qunit';
 const { module, test } = QUnit;
 import { basename } from 'path';
-import { decideHostShellRecycle } from '../prerender/prerender-app.ts';
+import {
+  decideHostShellRecycle,
+  raceAgainstDrain,
+} from '../prerender/prerender-app.ts';
 
 // Unit tests for the host-shell recycle decision a prerender server makes on
 // every heartbeat: the manager echoes the current host-shell token, and the
@@ -39,6 +42,88 @@ module(basename(import.meta.filename), function () {
         recycle: true,
         nextWarmed: 'bbb',
       });
+    });
+  });
+
+  module('raceAgainstDrain', function () {
+    // Stands in for the server's drain subscription, counting how many are
+    // outstanding. The count is the whole point: a subscription that survives
+    // its request keeps the request's context, response and rendered HTML
+    // reachable, so anything that leaves one behind grows the heap by a
+    // render's worth per render.
+    function fakeSubscriber() {
+      let live = 0;
+      let notifiers = new Set<() => void>();
+      return {
+        get live() {
+          return live;
+        },
+        drain() {
+          for (let notify of notifiers) {
+            notify();
+          }
+        },
+        subscribe: () => {
+          live++;
+          let notify!: () => void;
+          let promise = new Promise<{ draining: true }>((resolve) => {
+            notify = () => resolve({ draining: true });
+          });
+          notifiers.add(notify);
+          return {
+            promise,
+            dispose: () => {
+              live--;
+              notifiers.delete(notify);
+            },
+          };
+        },
+      };
+    }
+
+    test('a completed render leaves no subscription behind', async function (assert) {
+      let subscriber = fakeSubscriber();
+      for (let i = 0; i < 50; i++) {
+        let result = await raceAgainstDrain(
+          Promise.resolve({ result: i }),
+          subscriber.subscribe,
+        );
+        assert.deepEqual(result, { result: i }, `render ${i} returned`);
+      }
+      assert.strictEqual(
+        subscriber.live,
+        0,
+        'no subscriptions outstanding after 50 renders',
+      );
+    });
+
+    test('a failed render leaves no subscription behind', async function (assert) {
+      let subscriber = fakeSubscriber();
+      await assert.rejects(
+        raceAgainstDrain(
+          Promise.reject(new Error('boom')),
+          subscriber.subscribe,
+        ),
+        /boom/,
+        'the render error propagates',
+      );
+      assert.strictEqual(subscriber.live, 0, 'subscription released');
+    });
+
+    test('draining wins the race and still releases', async function (assert) {
+      let subscriber = fakeSubscriber();
+      let never = new Promise<{ result: string }>(() => {});
+      let raced = raceAgainstDrain(never, subscriber.subscribe);
+      subscriber.drain();
+      assert.deepEqual(await raced, { draining: true }, 'reports draining');
+      assert.strictEqual(subscriber.live, 0, 'subscription released');
+    });
+
+    test('with no subscriber it just awaits the render', async function (assert) {
+      assert.deepEqual(
+        await raceAgainstDrain(Promise.resolve({ result: 'ok' }), undefined),
+        { result: 'ok' },
+      );
     });
   });
 });

--- a/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
+++ b/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
@@ -2,6 +2,7 @@ import QUnit from 'qunit';
 const { module, test } = QUnit;
 import { basename } from 'path';
 import {
+  createDrainSubscriber,
   decideHostShellRecycle,
   raceAgainstDrain,
 } from '../prerender/prerender-app.ts';
@@ -124,6 +125,79 @@ module(basename(import.meta.filename), function () {
         await raceAgainstDrain(Promise.resolve({ result: 'ok' }), undefined),
         { result: 'ok' },
       );
+    });
+  });
+
+  module('createDrainSubscriber', function () {
+    function deferred() {
+      let fulfil!: () => void;
+      let promise = new Promise<void>((resolve) => {
+        fulfil = resolve;
+      });
+      return { promise, fulfil };
+    }
+
+    test('a render started before draining runs to completion', async function (assert) {
+      let drain = deferred();
+      let subscribe = createDrainSubscriber(drain.promise);
+      assert.deepEqual(
+        await raceAgainstDrain(
+          Promise.resolve({ result: 'rendered' }),
+          subscribe,
+        ),
+        { result: 'rendered' },
+      );
+    });
+
+    test('a render in flight when draining begins reports draining', async function (assert) {
+      let drain = deferred();
+      let subscribe = createDrainSubscriber(drain.promise);
+      let raced = raceAgainstDrain(
+        new Promise<{ result: string }>(() => {}),
+        subscribe,
+      );
+      drain.fulfil();
+      assert.deepEqual(await raced, { draining: true });
+    });
+
+    // The regression this guards: subscribing after the notification has
+    // already gone out. A subscriber that only broadcast would hand back a
+    // promise nobody ever settles, the race would decay into a plain await,
+    // and the request would render on instead of reporting that the server is
+    // leaving — holding shutdown open for the length of that render.
+    test('a render arriving after draining reports draining rather than hanging', async function (assert) {
+      let drain = deferred();
+      let subscribe = createDrainSubscriber(drain.promise);
+      drain.fulfil();
+      await drain.promise;
+
+      let settled = false;
+      let raced = raceAgainstDrain(
+        new Promise<{ result: string }>(() => {}),
+        subscribe,
+      ).then((r) => {
+        settled = true;
+        return r;
+      });
+      assert.deepEqual(await raced, { draining: true });
+      assert.true(settled, 'resolved rather than hanging');
+    });
+
+    test('every later render also reports draining', async function (assert) {
+      let drain = deferred();
+      let subscribe = createDrainSubscriber(drain.promise);
+      drain.fulfil();
+      await drain.promise;
+      for (let i = 0; i < 3; i++) {
+        assert.deepEqual(
+          await raceAgainstDrain(
+            new Promise<{ result: number }>(() => {}),
+            subscribe,
+          ),
+          { draining: true },
+          `render ${i}`,
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
The Checkly publish check failure exposed a memory leak in the prerenderer, where the render promise closure retains the request, response, and rendered HTML forever, until server shutdown.

<details><summary>Claude explanation</summary>Every render raced its work against the shutdown promise by calling `.then()` on it. That promise only settles when the process is asked to stop, and a pending promise keeps every reaction ever attached to it — so each request left one behind. A reaction keeps its closure, and this closure captured the request context, which meant the request, its response and the rendered HTML all stayed reachable for as long as the server ran. Nothing detached the reaction when the render won the race, so the retained set grew by a render's worth of output per render and never shrank.

Subscribe to the shutdown promise once for the process instead, and give each render a waiter it releases in `finally`. What accumulates is now bounded by the renders in flight rather than by the renders ever served.

A heap snapshot from a staging instance shows what this looked like: 1,564 MB, of which 94.5% was strings, holding a response, request and url object for each of the 4,163 requests that instance had served, all of them hanging off a single promise via a chain of 4,090 reactions.</details>