### PR TITLE
Hide "Open in Code Mode" in the playground's context menu

### DIFF
--- a/packages/base/file-menu-items.ts
+++ b/packages/base/file-menu-items.ts
@@ -116,17 +116,8 @@ export function getDefaultFileMenuItems(
       icon: Eye,
     });
   }
-  if (params.menuContext === 'code-mode-playground') {
-    menuItems.push({
-      label: 'Open in Code Mode',
-      action: async () => {
-        await new SwitchSubmodeTool(params.toolContext).execute({
-          submode: 'code',
-          codePath: fileDefInstanceId,
-        });
-      },
-      icon: CodeIcon,
-    });
-  }
+  // No "Open in Code Mode" for the code-mode-playground context: that panel
+  // already lives inside code submode, so the entry would be a no-op switch to
+  // the mode we're in.
   return menuItems;
 }

--- a/packages/base/menu-items.ts
+++ b/packages/base/menu-items.ts
@@ -11,7 +11,6 @@ import OpenCreateListingModalTool from '@cardstack/boxel-host/commands/open-crea
 import OpenInInteractModeTool from '@cardstack/boxel-host/commands/open-in-interact-mode';
 import PopulateWithSampleDataTool from '@cardstack/boxel-host/commands/populate-with-sample-data';
 import ShowCardTool from '@cardstack/boxel-host/commands/show-card';
-import SwitchSubmodeTool from '@cardstack/boxel-host/commands/switch-submode';
 import type {
   ToolContext,
   Format,
@@ -26,7 +25,6 @@ import {
 } from '@cardstack/runtime-common';
 import { resolveAdoptsFrom } from '@cardstack/runtime-common';
 
-import CodeIcon from '@cardstack/boxel-icons/code';
 import ArrowLeft from '@cardstack/boxel-icons/arrow-left';
 import ClipboardCopy from '@cardstack/boxel-icons/clipboard-copy';
 import Eye from '@cardstack/boxel-icons/eye';
@@ -200,17 +198,8 @@ export function getDefaultCardMenuItems(
     });
   }
   if (params.menuContext === 'code-mode-playground') {
-    menuItems.push({
-      label: 'Open in Code Mode',
-      action: async () => {
-        await new SwitchSubmodeTool(params.toolContext).execute({
-          submode: 'code',
-          codePath: cardId,
-        });
-      },
-      icon: CodeIcon,
-      disabled: !cardId,
-    });
+    // No "Open in Code Mode" here: the playground panel already lives inside
+    // code submode, so the entry would be a no-op switch to the mode we're in.
     menuItems = [...menuItems, ...getSampleDataMenuItems(card, params)];
     if (cardId && !isRealmIndexCard(card)) {
       menuItems.push({

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -827,22 +827,17 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
       assert.dom('[data-option-index="0"]').containsText('Jane Doe');
     });
 
-    test('can use the header context menu to open instance in code mode', async function (assert) {
+    test('header context menu omits "Open in Code Mode" (already in code submode)', async function (assert) {
       await openFileInPlayground('author.gts', testRealmURL, {
         declaration: 'Author',
       });
       await click('[data-test-more-options-button]');
       assert
         .dom('[data-test-boxel-dropdown-content] [data-test-boxel-menu-item]')
-        .exists({ count: 6 });
-
-      await click('[data-test-boxel-menu-item-text="Open in Code Mode"]');
+        .exists({ count: 5 });
       assert
-        .dom(
-          `[data-test-code-mode-card-renderer-header="${testRealmURL}Author/jane-doe"]`,
-        )
-        .exists();
-      assert.dom('[data-test-module-inspector-view="preview"]').doesNotExist();
+        .dom('[data-test-boxel-menu-item-text="Open in Code Mode"]')
+        .doesNotExist();
     });
 
     test('can use the header context menu to open instance in interact mode', async function (assert) {

--- a/packages/host/tests/unit/card-def-menu-items-test.ts
+++ b/packages/host/tests/unit/card-def-menu-items-test.ts
@@ -236,7 +236,7 @@ module('Unit | CardDef menu items', function (hooks) {
     );
   });
 
-  test('code-mode-playground includes sample-data tagged items and Open in Code Mode', function (assert: Assert) {
+  test('code-mode-playground includes sample-data tagged items and omits Open in Code Mode', function (assert: Assert) {
     let card = new DummyCard(
       'https://example.com/realm/card-3',
       'Three',
@@ -255,11 +255,18 @@ module('Unit | CardDef menu items', function (hooks) {
     let hasSampleDataTagged = items.some((i: MenuItemOptions) =>
       (i.tags || []).includes('playground-sample-data'),
     );
+    let hasOpenInCodeMode = items.some(
+      (i: MenuItemOptions) => i.label === 'Open in Code Mode',
+    );
 
     assert.ok(hasCreateListing, 'contains Create Listing');
     assert.ok(
       hasSampleDataTagged,
       'contains items tagged playground-sample-data',
+    );
+    assert.notOk(
+      hasOpenInCodeMode,
+      'does not contain Open in Code Mode (already in code submode)',
     );
   });
 

--- a/packages/host/tests/unit/file-def-menu-items-test.ts
+++ b/packages/host/tests/unit/file-def-menu-items-test.ts
@@ -163,7 +163,7 @@ module('Unit | FileDef menu items', function (hooks) {
     );
   });
 
-  test('code-mode-playground includes Open in Code Mode', function (assert: Assert) {
+  test('code-mode-playground omits Open in Code Mode (already in code submode)', function (assert: Assert) {
     let file = new DummyFile(
       'https://example.com/realm/file-4.txt',
     ) as unknown as FileDef;
@@ -181,9 +181,9 @@ module('Unit | FileDef menu items', function (hooks) {
       texts.includes('Open in Interact Mode'),
       'contains Open in Interact Mode',
     );
-    assert.ok(
+    assert.notOk(
       texts.includes('Open in Code Mode'),
-      'contains Open in Code Mode',
+      'does not contain Open in Code Mode',
     );
   });
 });


### PR DESCRIPTION
## Problem

CS-12511: The playground panel lives inside **code submode**, yet its "..." (more-options) context menu offered an **"Open in Code Mode"** entry — a redundant no-op switch to the mode the user is already in.

## Fix

Both menu builders in `packages/base` appended "Open in Code Mode" for the `code-mode-playground` menu context (the context `playground-panel.gts` uses):

- `menu-items.ts` (`getDefaultCardMenuItems`) — the actual source of the bug, since the playground renders a `CardDef`. Removed the entry; sample-data items and Create Listing stay. Dropped the now-unused `SwitchSubmodeTool` / `CodeIcon` imports.
- `file-menu-items.ts` (`getDefaultFileMenuItems`) — removed the same entry for consistency. This branch was actually unreachable from the app (the playground always calls `[getMenuItems]` on a `CardDef`, and file-def mode suppresses the context menu entirely), but it mirrored the same mistake, so it's cleaned up to keep the rule uniform.

The `interact`-context "Open in Code Mode" (files opened via CardsGrid's All Files group, and the AI-assistant attached-file menu) is untouched — those surfaces aren't in code submode.

## Tests

- `card-def-menu-items-test.ts` / `file-def-menu-items-test.ts` unit tests now assert the entry is absent in `code-mode-playground`.
- `card-playground-test.gts` acceptance test converted from "open instance in code mode" into a regression test asserting the item does not appear (menu count 6 → 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)