### PR TITLE
Host service worker absorbs _screenshot 503 + Retry-After for in-app image retry

### DIFF
--- a/packages/host/public/auth-service-worker.js
+++ b/packages/host/public/auth-service-worker.js
@@ -9,6 +9,11 @@
 // localStorage write happening just before the SW message round-trip lands,
 // etc.), the SW asks the controlling page for a token via MessageChannel and
 // retries once before falling through.
+//
+// The SW also absorbs 503 + Retry-After answers from the realm's
+// `_screenshot/` route, re-fetching at the server's suggested pace within a
+// bounded budget so an in-app <img> waits out an in-flight capture instead
+// of showing a broken image. See the SCREENSHOT_* constants below.
 
 // Map of realm URL prefix → JWT token
 const realmTokens = new Map();
@@ -23,6 +28,77 @@ const inflightTokenRequests = new Map();
 // Common-case budget. Refresh path posts `{type:'pending'}` to extend.
 const TOKEN_REQUEST_TIMEOUT_MS = 200;
 const TOKEN_REQUEST_REFRESH_TIMEOUT_MS = 3000;
+
+// The realm's `_screenshot/` route answers 503 + Retry-After when a capture
+// can't complete within its bounded sync wait (capture still rendering, or
+// the on-demand lane is congested). <img> has no retry logic, so without
+// help a broken image sticks until a manual reload. For requests on that
+// route — and only that route — the SW absorbs the 503 and re-fetches at
+// the server's suggested pace, so the fetch event resolves late instead of
+// failing and the image pops in when the capture lands.
+//
+// The match is deliberately tight (GET + known realm origin + `_screenshot/`
+// path segment + status exactly 503 + a numeric Retry-After): a blanket SW
+// 503-retry would mask real outages and hammer a struggling realm-server.
+// Uncaptured-`name=` 404s are never retried — a typo'd name in a fitted
+// template across a large grid would otherwise become that many synchronized
+// retry loops; the 404's short max-age already covers the brief uncaptured
+// window.
+const SCREENSHOT_PATH_SEGMENT = '/_screenshot/';
+// Total absorption budget across all retries. On exhaustion the 503 is let
+// through so the <img> errors visibly rather than hiding a permanently
+// failing capture.
+const SCREENSHOT_RETRY_BUDGET_MS = 90000;
+
+// A request is on the screenshot route when a `_screenshot/` path segment
+// appears under a realm URL. Only GET absorbs: the route itself is GET-only,
+// and HEAD/other methods keep the plain single-fetch behavior.
+function isScreenshotRoute(request) {
+  if (request.method !== 'GET') {
+    return false;
+  }
+  try {
+    return new URL(request.url).pathname.includes(SCREENSHOT_PATH_SEGMENT);
+  } catch {
+    return false;
+  }
+}
+
+// Returns the retry delay in ms for a response the SW should absorb, or
+// undefined for any response that must be returned to the page as-is.
+// Retry-After is the contract: a 503 without one (or with an unparseable
+// value, e.g. an HTTP-date) is a real error, not a capture-pending signal.
+function screenshotRetryDelayMs(response) {
+  if (response.status !== 503) {
+    return undefined;
+  }
+  let retryAfter = response.headers.get('Retry-After');
+  if (retryAfter === null) {
+    return undefined;
+  }
+  let seconds = Number(retryAfter);
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return undefined;
+  }
+  return Math.max(1000, seconds * 1000);
+}
+
+// Fetch loop for `_screenshot/` requests. buildRequest is invoked per
+// attempt so each retry picks up the freshest token from the realmTokens
+// map. When the next server-suggested pause would overrun the budget, the
+// 503 is returned immediately — waiting out a pause we can't follow with a
+// retry would only delay the visible error.
+async function fetchScreenshotAbsorbing503s(buildRequest) {
+  let deadline = Date.now() + SCREENSHOT_RETRY_BUDGET_MS;
+  for (;;) {
+    let response = await fetch(buildRequest());
+    let delayMs = screenshotRetryDelayMs(response);
+    if (delayMs === undefined || Date.now() + delayMs > deadline) {
+      return response;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}
 
 function recordRealmHost(realmURL) {
   try {
@@ -168,7 +244,7 @@ async function requestTokenFromClient(requestURL, initiatingClientId) {
   return promise;
 }
 
-function buildAuthedRequest(request, token) {
+function buildRealmRequest(request, token) {
   // Cross-origin <img> and CSS background-image requests arrive with
   // mode: 'no-cors', which silently strips non-safelisted headers like
   // Authorization. We must upgrade to mode: 'cors' so the header is
@@ -179,8 +255,15 @@ function buildAuthedRequest(request, token) {
   // <img> requests default to 'include', and credentials: 'include' with
   // mode: 'cors' requires the server to send a specific origin in
   // Access-Control-Allow-Origin (not '*'), which the realm server doesn't do.
+  //
+  // The cors upgrade also matters without a token: a no-cors response is
+  // opaque (status reads as 0), so the screenshot 503-absorption path
+  // rebuilds tokenless requests to public realms as cors too, to be able to
+  // read the status and Retry-After.
   let headers = new Headers(request.headers);
-  headers.set('Authorization', `Bearer ${token}`);
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
   return new Request(request, {
     headers,
     mode: 'cors',
@@ -207,7 +290,15 @@ self.addEventListener('fetch', (event) => {
   let matchedToken = lookupToken(url);
 
   if (matchedToken) {
-    event.respondWith(fetch(buildAuthedRequest(request, matchedToken)));
+    if (isScreenshotRoute(request)) {
+      event.respondWith(
+        fetchScreenshotAbsorbing503s(() =>
+          buildRealmRequest(request, lookupToken(url) ?? matchedToken),
+        ),
+      );
+    } else {
+      event.respondWith(fetch(buildRealmRequest(request, matchedToken)));
+    }
     return;
   }
 
@@ -232,7 +323,20 @@ self.addEventListener('fetch', (event) => {
     (async () => {
       let token = await requestTokenFromClient(url, event.clientId);
       if (token) {
-        return fetch(buildAuthedRequest(request, token));
+        if (isScreenshotRoute(request)) {
+          return fetchScreenshotAbsorbing503s(() =>
+            buildRealmRequest(request, lookupToken(url) ?? token),
+          );
+        }
+        return fetch(buildRealmRequest(request, token));
+      }
+      // Tokenless screenshot requests to a known realm origin (a public
+      // realm the page holds no session for) still get 503 absorption. The
+      // request is rebuilt as cors so the status is readable cross-origin.
+      if (isScreenshotRoute(request) && realmHosts.has(requestOrigin)) {
+        return fetchScreenshotAbsorbing503s(() =>
+          buildRealmRequest(request, lookupToken(url)),
+        );
       }
       // No token available; preserve existing behavior (let it pass through
       // and 401, rather than synthesizing a response).

--- a/packages/host/public/auth-service-worker.js
+++ b/packages/host/public/auth-service-worker.js
@@ -37,22 +37,30 @@ const TOKEN_REQUEST_REFRESH_TIMEOUT_MS = 3000;
 // the server's suggested pace, so the fetch event resolves late instead of
 // failing and the image pops in when the capture lands.
 //
-// The match is deliberately tight (GET + known realm origin + `_screenshot/`
-// path segment + status exactly 503 + a numeric Retry-After): a blanket SW
-// 503-retry would mask real outages and hammer a struggling realm-server.
+// The match is deliberately tight (GET + a `_screenshot/` path segment on a
+// request already scoped to a realm — a realm-token prefix match on the token
+// branches, a known realm origin on the tokenless branch — + status exactly
+// 503 + a numeric Retry-After): a blanket SW 503-retry would mask real
+// outages and hammer a struggling realm-server.
 // Uncaptured-`name=` 404s are never retried — a typo'd name in a fitted
 // template across a large grid would otherwise become that many synchronized
 // retry loops; the 404's short max-age already covers the brief uncaptured
 // window.
 const SCREENSHOT_PATH_SEGMENT = '/_screenshot/';
-// Total absorption budget across all retries. On exhaustion the 503 is let
-// through so the <img> errors visibly rather than hiding a permanently
-// failing capture.
+// Bounds when re-fetches may start: retry sleeps are clamped to this window,
+// and a 503 arriving after it closes is let through so the <img> errors
+// visibly rather than hiding a permanently failing capture. The final
+// re-fetch can itself hold up to the server's sync wait, so worst-case wall
+// time is this budget plus one sync wait.
 const SCREENSHOT_RETRY_BUDGET_MS = 90000;
 
-// A request is on the screenshot route when a `_screenshot/` path segment
-// appears under a realm URL. Only GET absorbs: the route itself is GET-only,
-// and HEAD/other methods keep the plain single-fetch behavior.
+// A request is on the screenshot route when it is a GET with a
+// `_screenshot/` path segment. Origin/realm scoping is the call sites' job
+// (see the engagement-gate comment above); position within the realm is
+// not checked — the realm serves the subtree only at its root, so a nested
+// segment on a plain file engages the loop harmlessly (plain files never
+// answer 503 + Retry-After). Only GET absorbs: the route itself is
+// GET-only, and HEAD/other methods keep the plain single-fetch behavior.
 function isScreenshotRoute(request) {
   if (request.method !== 'GET') {
     return false;
@@ -85,18 +93,27 @@ function screenshotRetryDelayMs(response) {
 
 // Fetch loop for `_screenshot/` requests. buildRequest is invoked per
 // attempt so each retry picks up the freshest token from the realmTokens
-// map. When the next server-suggested pause would overrun the budget, the
-// 503 is returned immediately — waiting out a pause we can't follow with a
-// retry would only delay the visible error.
+// map. A server-suggested pause longer than the remaining budget is clamped
+// to it rather than abandoned: the congested lane's Retry-After is
+// `pending × avgCaptureMs` with a coarse stand-in average when there is no
+// history, so the estimate can far overshoot the real wait — one retry at
+// the deadline is worth more than an immediate visible error. A 503
+// arriving once the window is closed is returned as-is.
 async function fetchScreenshotAbsorbing503s(buildRequest) {
   let deadline = Date.now() + SCREENSHOT_RETRY_BUDGET_MS;
   for (;;) {
     let response = await fetch(buildRequest());
     let delayMs = screenshotRetryDelayMs(response);
-    if (delayMs === undefined || Date.now() + delayMs > deadline) {
+    if (delayMs === undefined) {
       return response;
     }
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    let remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return response;
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(delayMs, remainingMs)),
+    );
   }
 }
 
@@ -291,9 +308,14 @@ self.addEventListener('fetch', (event) => {
 
   if (matchedToken) {
     if (isScreenshotRoute(request)) {
+      // Each attempt re-reads the token map: rotation is picked up, and a
+      // removal (logout clears the map) makes the next attempt tokenless —
+      // a private realm then answers 401, which is not absorbable, so the
+      // loop ends instead of presenting the pre-logout JWT for the rest of
+      // the budget.
       event.respondWith(
         fetchScreenshotAbsorbing503s(() =>
-          buildRealmRequest(request, lookupToken(url) ?? matchedToken),
+          buildRealmRequest(request, lookupToken(url)),
         ),
       );
     } else {
@@ -324,6 +346,10 @@ self.addEventListener('fetch', (event) => {
       let token = await requestTokenFromClient(url, event.clientId);
       if (token) {
         if (isScreenshotRoute(request)) {
+          // Unlike the matched-token branch, `?? token` is load-bearing
+          // here: the client's reply lands in the map keyed by its own
+          // realmURL, which may not prefix this request's URL, so the map
+          // lookup can miss forever while the token stays valid.
           return fetchScreenshotAbsorbing503s(() =>
             buildRealmRequest(request, lookupToken(url) ?? token),
           );

--- a/packages/host/tests/unit/auth-service-worker-test.ts
+++ b/packages/host/tests/unit/auth-service-worker-test.ts
@@ -9,8 +9,8 @@ import { SessionLocalStorageKey } from '@cardstack/host/utils/local-storage-keys
 // the SW environment. The actual SW is at public/auth-service-worker.js.
 //
 // We duplicate the core logic here (token matching, fetch interception,
-// on-miss client fallback) to test it in a standard QUnit context where
-// service workers aren't available.
+// on-miss client fallback, `_screenshot/` 503 absorption) to test it in a
+// standard QUnit context where service workers aren't available.
 
 function createServiceWorkerEnv(
   opts: {
@@ -35,6 +35,11 @@ function createServiceWorkerEnv(
     // Mirrors TOKEN_REQUEST_REFRESH_TIMEOUT_MS — the extended budget
     // applied after the client posts `{type:'pending'}`.
     tokenRequestRefreshTimeoutMs?: number;
+    // Network stub for the `_screenshot/` 503-absorption loop. Receives the
+    // Request the SW would fetch on each attempt. Absorption paths require
+    // it; leaving it unset makes any unexpected engagement of the loop fail
+    // loudly.
+    screenshotFetch?: (request: Request) => Promise<Response>;
   } = {},
 ) {
   const realmTokens = new Map<string, string>();
@@ -153,20 +158,85 @@ function createServiceWorkerEnv(
     return promise;
   }
 
-  function buildAuthedRequest(request: Request, token: string): Request {
+  function buildRealmRequest(request: Request, token?: string): Request {
     let headers = new Headers(request.headers);
-    headers.set('Authorization', `Bearer ${token}`);
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
     return new Request(request, { headers, mode: 'cors' });
+  }
+
+  // Mirrors the SCREENSHOT_* constants and helpers in auth-service-worker.js.
+  const SCREENSHOT_PATH_SEGMENT = '/_screenshot/';
+  const SCREENSHOT_RETRY_BUDGET_MS = 90000;
+
+  function isScreenshotRoute(request: Request): boolean {
+    if (request.method !== 'GET') {
+      return false;
+    }
+    try {
+      return new URL(request.url).pathname.includes(SCREENSHOT_PATH_SEGMENT);
+    } catch {
+      return false;
+    }
+  }
+
+  function screenshotRetryDelayMs(response: Response): number | undefined {
+    if (response.status !== 503) {
+      return undefined;
+    }
+    let retryAfter = response.headers.get('Retry-After');
+    if (retryAfter === null) {
+      return undefined;
+    }
+    let seconds = Number(retryAfter);
+    if (!Number.isFinite(seconds) || seconds < 0) {
+      return undefined;
+    }
+    return Math.max(1000, seconds * 1000);
+  }
+
+  // Virtual clock for the absorption loop: sleeps advance it instantly and
+  // are recorded so tests can assert on the server-suggested pacing without
+  // holding real time.
+  let clock = 0;
+  let sleeps: number[] = [];
+  let now = () => clock;
+  let sleep = async (ms: number) => {
+    sleeps.push(ms);
+    clock += ms;
+  };
+
+  async function fetchScreenshotAbsorbing503s(
+    buildRequest: () => Request,
+  ): Promise<Response> {
+    let doFetch = opts.screenshotFetch;
+    if (!doFetch) {
+      throw new Error(
+        'screenshot absorption engaged but no screenshotFetch was configured',
+      );
+    }
+    let deadline = now() + SCREENSHOT_RETRY_BUDGET_MS;
+    for (;;) {
+      let response = await doFetch(buildRequest());
+      let delayMs = screenshotRetryDelayMs(response);
+      if (delayMs === undefined || now() + delayMs > deadline) {
+        return response;
+      }
+      await sleep(delayMs);
+    }
   }
 
   // Returns:
   //   - Request: the SW would respondWith fetch of this authed Request
+  //   - Response: the `_screenshot/` absorption loop ran the network via
+  //     opts.screenshotFetch and this is what the page would receive
   //   - 'pass-through': the SW would not intercept (returns from fetch handler)
   //   - 'fallthrough-fetch': the SW called respondWith but with the original
   //     request (client had no token); will hit the network unauth'd
   let processFetch = async (
     request: Request,
-  ): Promise<Request | 'pass-through' | 'fallthrough-fetch'> => {
+  ): Promise<Request | Response | 'pass-through' | 'fallthrough-fetch'> => {
     if (request.method !== 'GET' && request.method !== 'HEAD') {
       return 'pass-through';
     }
@@ -177,7 +247,12 @@ function createServiceWorkerEnv(
     let url = request.url;
     let matchedToken = lookupToken(url);
     if (matchedToken) {
-      return buildAuthedRequest(request, matchedToken);
+      if (isScreenshotRoute(request)) {
+        return fetchScreenshotAbsorbing503s(() =>
+          buildRealmRequest(request, lookupToken(url) ?? matchedToken),
+        );
+      }
+      return buildRealmRequest(request, matchedToken);
     }
 
     let origin: string;
@@ -192,7 +267,17 @@ function createServiceWorkerEnv(
 
     let token = await requestTokenFromClient(url);
     if (token) {
-      return buildAuthedRequest(request, token);
+      if (isScreenshotRoute(request)) {
+        return fetchScreenshotAbsorbing503s(() =>
+          buildRealmRequest(request, lookupToken(url) ?? token),
+        );
+      }
+      return buildRealmRequest(request, token);
+    }
+    if (isScreenshotRoute(request) && realmHosts.has(origin)) {
+      return fetchScreenshotAbsorbing503s(() =>
+        buildRealmRequest(request, lookupToken(url)),
+      );
     }
     return 'fallthrough-fetch';
   };
@@ -203,6 +288,7 @@ function createServiceWorkerEnv(
     realmTokens,
     realmHosts,
     inflightTokenRequests,
+    sleeps,
   };
 }
 
@@ -672,6 +758,249 @@ module('Unit | auth-service-worker', function () {
         new Request('http://localhost:4201/r/image.png'),
       );
       assert.strictEqual(result, 'fallthrough-fetch');
+    });
+  });
+
+  module('_screenshot/ 503 absorption', function () {
+    const REALM_URL = 'http://localhost:4201/user/realm/';
+    const SCREENSHOT_URL = `${REALM_URL}_screenshot/Card/1.png?w=800&h=600`;
+
+    function response(status: number, retryAfter?: string) {
+      return new Response(null, {
+        status,
+        headers: retryAfter !== undefined ? { 'Retry-After': retryAfter } : {},
+      });
+    }
+
+    // Builds a SW env whose network answers the given responses in order,
+    // recording each Request the absorption loop actually sent.
+    function makeSw(responses: Response[], extraOpts = {}) {
+      let fetched: Request[] = [];
+      let sw = createServiceWorkerEnv({
+        screenshotFetch: async (request) => {
+          fetched.push(request);
+          let next = responses.shift();
+          if (!next) {
+            throw new Error('screenshotFetch called more times than expected');
+          }
+          return next;
+        },
+        ...extraOpts,
+      });
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: REALM_URL,
+        token: 'realm-token',
+      });
+      return { sw, fetched };
+    }
+
+    test('injects Authorization on query-param _screenshot URLs and resolves with the eventual 200 after absorbing 503s', async function (assert) {
+      let { sw, fetched } = makeSw([
+        response(503, '2'),
+        response(503, '3'),
+        response(200),
+      ]);
+
+      let result = await sw.processFetch(new Request(SCREENSHOT_URL));
+
+      assert.ok(result instanceof Response, 'the page receives a Response');
+      assert.strictEqual((result as Response).status, 200);
+      assert.strictEqual(fetched.length, 3, 'fetched until the capture landed');
+      for (let request of fetched) {
+        assert.strictEqual(
+          request.headers.get('Authorization'),
+          'Bearer realm-token',
+          'every attempt carries the realm JWT',
+        );
+        assert.strictEqual(request.mode, 'cors');
+      }
+      assert.deepEqual(
+        sw.sleeps,
+        [2000, 3000],
+        'retries pace at the server-suggested Retry-After',
+      );
+    });
+
+    test('a 503 without Retry-After is let through untouched', async function (assert) {
+      let { sw, fetched } = makeSw([response(503)]);
+
+      let result = await sw.processFetch(new Request(SCREENSHOT_URL));
+
+      assert.strictEqual((result as Response).status, 503);
+      assert.strictEqual(fetched.length, 1, 'no retry');
+    });
+
+    test('a 503 with an unparseable Retry-After is let through untouched', async function (assert) {
+      let { sw, fetched } = makeSw([
+        response(503, 'Wed, 21 Oct 2026 07:28:00 GMT'),
+      ]);
+
+      let result = await sw.processFetch(new Request(SCREENSHOT_URL));
+
+      assert.strictEqual((result as Response).status, 503);
+      assert.strictEqual(fetched.length, 1, 'no retry');
+    });
+
+    test('404s are never retried', async function (assert) {
+      // An uncaptured `name=` miss answers 404; retrying it from a fitted
+      // template rendered across a large grid would multiply into that many
+      // synchronized poll loops.
+      let { sw, fetched } = makeSw([response(404, '1')]);
+
+      let result = await sw.processFetch(new Request(SCREENSHOT_URL));
+
+      assert.strictEqual((result as Response).status, 404);
+      assert.strictEqual(fetched.length, 1, 'no retry');
+    });
+
+    test('the 503 is let through once the absorption budget is exhausted', async function (assert) {
+      // Budget is 90s; each 503 asks for a 30s pause. Attempts at t=0, 30s,
+      // 60s, 90s absorb; the pause after the t=90s attempt would overrun,
+      // so its 503 goes to the page.
+      let { sw, fetched } = makeSw([
+        response(503, '30'),
+        response(503, '30'),
+        response(503, '30'),
+        response(503, '30'),
+      ]);
+
+      let result = await sw.processFetch(new Request(SCREENSHOT_URL));
+
+      assert.strictEqual(
+        (result as Response).status,
+        503,
+        'exhaustion surfaces the 503 so the <img> errors visibly',
+      );
+      assert.strictEqual(fetched.length, 4);
+    });
+
+    test('a Retry-After beyond the whole budget passes the 503 through at once', async function (assert) {
+      let { sw, fetched } = makeSw([response(503, '600')]);
+
+      let result = await sw.processFetch(new Request(SCREENSHOT_URL));
+
+      assert.strictEqual((result as Response).status, 503);
+      assert.strictEqual(
+        fetched.length,
+        1,
+        'no pointless wait before erroring',
+      );
+    });
+
+    test('sub-second Retry-After values are clamped to a 1s pause', async function (assert) {
+      let { sw } = makeSw([response(503, '0'), response(200)]);
+
+      await sw.processFetch(new Request(SCREENSHOT_URL));
+
+      assert.deepEqual(sw.sleeps, [1000]);
+    });
+
+    test('each retry rebuilds the request with the freshest token', async function (assert) {
+      let swRef: { sw?: ReturnType<typeof createServiceWorkerEnv> } = {};
+      let fetched: Request[] = [];
+      let responses = [response(503, '1'), response(200)];
+      let sw = createServiceWorkerEnv({
+        screenshotFetch: async (request) => {
+          fetched.push(request);
+          if (fetched.length === 1) {
+            // Token rotates while the first attempt is being absorbed.
+            swRef.sw!.processMessage({
+              type: 'set-realm-token',
+              realmURL: REALM_URL,
+              token: 'rotated-token',
+            });
+          }
+          return responses.shift()!;
+        },
+      });
+      swRef.sw = sw;
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: REALM_URL,
+        token: 'original-token',
+      });
+
+      await sw.processFetch(new Request(SCREENSHOT_URL));
+
+      assert.deepEqual(
+        fetched.map((r) => r.headers.get('Authorization')),
+        ['Bearer original-token', 'Bearer rotated-token'],
+      );
+    });
+
+    test('non-_screenshot GETs never engage absorption', async function (assert) {
+      // The screenshotFetch stub would throw if invoked with no responses
+      // queued; a plain image URL must instead come back as an authed
+      // Request for the ordinary single-fetch path.
+      let { sw } = makeSw([]);
+
+      let result = await sw.processFetch(
+        new Request(`${REALM_URL}images/photo.png`),
+      );
+
+      assert.ok(
+        result instanceof Request,
+        'ordinary single-fetch interception',
+      );
+    });
+
+    test('HEAD requests to _screenshot URLs keep single-fetch behavior', async function (assert) {
+      let { sw } = makeSw([]);
+
+      let result = await sw.processFetch(
+        new Request(SCREENSHOT_URL, { method: 'HEAD' }),
+      );
+
+      assert.ok(
+        result instanceof Request,
+        'ordinary single-fetch interception',
+      );
+    });
+
+    test('tokenless _screenshot requests on a known realm origin absorb via a cors request without Authorization', async function (assert) {
+      // A public realm the page holds no session for: the client lookup
+      // yields nothing, but the origin is a known realm host. The request
+      // is rebuilt as cors (a no-cors response would be opaque, hiding the
+      // 503) with no auth header.
+      let fetched: Request[] = [];
+      let responses = [response(503, '1'), response(200)];
+      let sw = createServiceWorkerEnv({
+        clientTokenLookup: async () => undefined,
+        screenshotFetch: async (request) => {
+          fetched.push(request);
+          return responses.shift()!;
+        },
+      });
+      // Seed realmHosts via a different realm on the same origin.
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/other/realm/',
+        token: 'other-token',
+      });
+
+      let result = await sw.processFetch(
+        new Request(
+          'http://localhost:4201/public/realm/_screenshot/Card/1.png?w=800',
+        ),
+      );
+
+      assert.strictEqual((result as Response).status, 200);
+      assert.strictEqual(fetched.length, 2);
+      for (let request of fetched) {
+        assert.strictEqual(request.headers.get('Authorization'), null);
+        assert.strictEqual(request.mode, 'cors');
+      }
+    });
+
+    test('_screenshot requests on unknown origins pass through untouched', async function (assert) {
+      let { sw } = makeSw([]);
+
+      let result = await sw.processFetch(
+        new Request('https://unrelated.example.com/x/_screenshot/Card/1.png'),
+      );
+
+      assert.strictEqual(result, 'pass-through');
     });
   });
 });

--- a/packages/host/tests/unit/auth-service-worker-test.ts
+++ b/packages/host/tests/unit/auth-service-worker-test.ts
@@ -10,7 +10,11 @@ import { SessionLocalStorageKey } from '@cardstack/host/utils/local-storage-keys
 //
 // We duplicate the core logic here (token matching, fetch interception,
 // on-miss client fallback, `_screenshot/` 503 absorption) to test it in a
-// standard QUnit context where service workers aren't available.
+// standard QUnit context where service workers aren't available. The
+// mirrored logic can drift from the shipped file, so the "shipped worker"
+// module at the bottom evaluates the real public/auth-service-worker.js
+// bytes and exercises the same behavior against them — a change to the
+// shipped constants or helpers that the mirror misses fails there.
 
 function createServiceWorkerEnv(
   opts: {
@@ -1174,3 +1178,194 @@ module(
     });
   },
 );
+
+// Evaluates the REAL public/auth-service-worker.js — the bytes the browser
+// registers — inside a stubbed SW global scope, so the shipped constants and
+// helpers are what these assertions run against. The scaffold modules above
+// exercise a mirror of the worker's logic; this module is the drift guard:
+// an edit to the shipped parse/clamp/loop that the mirror misses fails here.
+module('Unit | auth-service-worker | shipped worker', function () {
+  interface ShippedWorker {
+    isScreenshotRoute: (request: Request) => boolean;
+    screenshotRetryDelayMs: (response: Response) => number | undefined;
+    dispatchMessage: (data: unknown) => void;
+    // Drives the shipped fetch listener; resolves with the Response the SW
+    // would respondWith, or 'pass-through' when the listener declined to
+    // intercept.
+    dispatchFetch: (request: Request) => Promise<Response | 'pass-through'>;
+    fetched: Request[];
+  }
+
+  async function loadShippedWorker(
+    networkResponses: Response[],
+  ): Promise<ShippedWorker> {
+    let source = await (await fetch('/auth-service-worker.js')).text();
+    let listeners = new Map<string, ((event: unknown) => void)[]>();
+    let selfStub = {
+      addEventListener: (type: string, fn: (event: unknown) => void) => {
+        let list = listeners.get(type) ?? [];
+        list.push(fn);
+        listeners.set(type, list);
+      },
+      skipWaiting: () => {},
+      clients: {
+        claim: async () => {},
+        get: async () => undefined,
+        matchAll: async () => [],
+      },
+    };
+    let fetched: Request[] = [];
+    // Bound over the worker source's free `fetch` identifier, so the shipped
+    // absorption loop fetches from this queue.
+    let fetchStub = async (request: Request) => {
+      fetched.push(request);
+      let next = networkResponses.shift();
+      if (!next) {
+        throw new Error('network stub called more times than expected');
+      }
+      return next;
+    };
+    // The worker source declares its helpers at (function-body) top level, so
+    // appending a return statement exposes them without any module plumbing —
+    // a classic `public/` SW cannot be imported as ESM.
+    let factory = new Function(
+      'self',
+      'fetch',
+      `${source}
+      ;return { isScreenshotRoute, screenshotRetryDelayMs };`,
+    );
+    let exported = factory(selfStub, fetchStub) as Pick<
+      ShippedWorker,
+      'isScreenshotRoute' | 'screenshotRetryDelayMs'
+    >;
+    return {
+      ...exported,
+      fetched,
+      dispatchMessage: (data: unknown) => {
+        for (let fn of listeners.get('message') ?? []) {
+          fn({ data });
+        }
+      },
+      dispatchFetch: async (request: Request) => {
+        let responded: Promise<Response> | undefined;
+        let event = {
+          request,
+          clientId: '',
+          respondWith: (promise: Promise<Response>) => {
+            responded = promise;
+          },
+          waitUntil: () => {},
+        };
+        for (let fn of listeners.get('fetch') ?? []) {
+          fn(event);
+        }
+        return responded ? await responded : 'pass-through';
+      },
+    };
+  }
+
+  test('shipped screenshotRetryDelayMs implements the 503 + numeric Retry-After contract', async function (assert) {
+    let sw = await loadShippedWorker([]);
+    let response = (status: number, retryAfter?: string) =>
+      new Response(null, {
+        status,
+        headers: retryAfter !== undefined ? { 'Retry-After': retryAfter } : {},
+      });
+
+    assert.strictEqual(sw.screenshotRetryDelayMs(response(503, '2')), 2000);
+    assert.strictEqual(
+      sw.screenshotRetryDelayMs(response(503, '0')),
+      1000,
+      'sub-second values clamp to 1s',
+    );
+    assert.strictEqual(
+      sw.screenshotRetryDelayMs(response(503)),
+      undefined,
+      'a 503 without Retry-After is not absorbable',
+    );
+    assert.strictEqual(
+      sw.screenshotRetryDelayMs(response(503, 'Wed, 21 Oct 2026 07:28:00 GMT')),
+      undefined,
+      'an HTTP-date Retry-After is not absorbable',
+    );
+    assert.strictEqual(
+      sw.screenshotRetryDelayMs(response(404, '1')),
+      undefined,
+      'only status 503 absorbs',
+    );
+  });
+
+  test('shipped isScreenshotRoute matches GET _screenshot/ requests only', async function (assert) {
+    let sw = await loadShippedWorker([]);
+
+    assert.true(
+      sw.isScreenshotRoute(
+        new Request(
+          'http://localhost:4201/user/realm/_screenshot/Card/1.png?w=800',
+        ),
+      ),
+    );
+    assert.false(
+      sw.isScreenshotRoute(
+        new Request('http://localhost:4201/user/realm/_screenshot/Card/1.png', {
+          method: 'HEAD',
+        }),
+      ),
+    );
+    assert.false(
+      sw.isScreenshotRoute(
+        new Request('http://localhost:4201/user/realm/images/photo.png'),
+      ),
+    );
+  });
+
+  test('shipped fetch listener absorbs a 503 end-to-end and resolves with the 200', async function (assert) {
+    let sw = await loadShippedWorker([
+      new Response(null, { status: 503, headers: { 'Retry-After': '0' } }),
+      new Response(null, { status: 200 }),
+    ]);
+    sw.dispatchMessage({
+      type: 'set-realm-token',
+      realmURL: 'http://localhost:4201/user/realm/',
+      token: 'shipped-token',
+    });
+
+    let result = await sw.dispatchFetch(
+      new Request(
+        'http://localhost:4201/user/realm/_screenshot/Card/1.png?w=800&h=600',
+      ),
+    );
+
+    assert.ok(result instanceof Response, 'the listener intercepted');
+    assert.strictEqual((result as Response).status, 200);
+    assert.strictEqual(sw.fetched.length, 2, 'retried once, per Retry-After');
+    for (let request of sw.fetched) {
+      assert.strictEqual(
+        request.headers.get('Authorization'),
+        'Bearer shipped-token',
+      );
+    }
+  });
+
+  test('shipped fetch listener leaves non-screenshot requests on the single-fetch path', async function (assert) {
+    let sw = await loadShippedWorker([
+      new Response(null, { status: 503, headers: { 'Retry-After': '1' } }),
+    ]);
+    sw.dispatchMessage({
+      type: 'set-realm-token',
+      realmURL: 'http://localhost:4201/user/realm/',
+      token: 'shipped-token',
+    });
+
+    let result = await sw.dispatchFetch(
+      new Request('http://localhost:4201/user/realm/images/photo.png'),
+    );
+
+    assert.strictEqual(
+      (result as Response).status,
+      503,
+      'the 503 reaches the page unabsorbed',
+    );
+    assert.strictEqual(sw.fetched.length, 1, 'no retry outside _screenshot/');
+  });
+});

--- a/packages/host/tests/unit/auth-service-worker-test.ts
+++ b/packages/host/tests/unit/auth-service-worker-test.ts
@@ -224,10 +224,14 @@ function createServiceWorkerEnv(
     for (;;) {
       let response = await doFetch(buildRequest());
       let delayMs = screenshotRetryDelayMs(response);
-      if (delayMs === undefined || now() + delayMs > deadline) {
+      if (delayMs === undefined) {
         return response;
       }
-      await sleep(delayMs);
+      let remainingMs = deadline - now();
+      if (remainingMs <= 0) {
+        return response;
+      }
+      await sleep(Math.min(delayMs, remainingMs));
     }
   }
 
@@ -253,7 +257,7 @@ function createServiceWorkerEnv(
     if (matchedToken) {
       if (isScreenshotRoute(request)) {
         return fetchScreenshotAbsorbing503s(() =>
-          buildRealmRequest(request, lookupToken(url) ?? matchedToken),
+          buildRealmRequest(request, lookupToken(url)),
         );
       }
       return buildRealmRequest(request, matchedToken);
@@ -860,8 +864,8 @@ module('Unit | auth-service-worker', function () {
 
     test('the 503 is let through once the absorption budget is exhausted', async function (assert) {
       // Budget is 90s; each 503 asks for a 30s pause. Attempts at t=0, 30s,
-      // 60s, 90s absorb; the pause after the t=90s attempt would overrun,
-      // so its 503 goes to the page.
+      // 60s, 90s; the window is closed after the t=90s attempt, so its 503
+      // goes to the page.
       let { sw, fetched } = makeSw([
         response(503, '30'),
         response(503, '30'),
@@ -879,17 +883,31 @@ module('Unit | auth-service-worker', function () {
       assert.strictEqual(fetched.length, 4);
     });
 
-    test('a Retry-After beyond the whole budget passes the 503 through at once', async function (assert) {
-      let { sw, fetched } = makeSw([response(503, '600')]);
+    test('a Retry-After beyond the whole budget clamps to one deadline retry', async function (assert) {
+      // The congestion 503's Retry-After can far overshoot the real wait
+      // (it is pending × a coarse capture-time average), so the pause is
+      // clamped to the remaining budget and retried once at the deadline
+      // rather than surfacing the 503 immediately.
+      let { sw, fetched } = makeSw([response(503, '600'), response(200)]);
+
+      let result = await sw.processFetch(new Request(SCREENSHOT_URL));
+
+      assert.strictEqual((result as Response).status, 200);
+      assert.strictEqual(fetched.length, 2, 'exactly one deadline retry');
+      assert.deepEqual(
+        sw.sleeps,
+        [90000],
+        'the pause is clamped to the remaining budget',
+      );
+    });
+
+    test('a 503 on the deadline retry is let through', async function (assert) {
+      let { sw, fetched } = makeSw([response(503, '600'), response(503, '30')]);
 
       let result = await sw.processFetch(new Request(SCREENSHOT_URL));
 
       assert.strictEqual((result as Response).status, 503);
-      assert.strictEqual(
-        fetched.length,
-        1,
-        'no pointless wait before erroring',
-      );
+      assert.strictEqual(fetched.length, 2, 'no retries past the deadline');
     });
 
     test('sub-second Retry-After values are clamped to a 1s pause', async function (assert) {
@@ -930,6 +948,44 @@ module('Unit | auth-service-worker', function () {
       assert.deepEqual(
         fetched.map((r) => r.headers.get('Authorization')),
         ['Bearer original-token', 'Bearer rotated-token'],
+      );
+    });
+
+    test('a token removal mid-loop stops presenting the old JWT', async function (assert) {
+      // Logout clears the token map while a grid may still be absorbing.
+      // The next attempt must go out tokenless — a private realm then
+      // answers an unabsorbable 401 and the loop ends — rather than keep
+      // sending the pre-logout session token for the rest of the budget.
+      let swRef: { sw?: ReturnType<typeof createServiceWorkerEnv> } = {};
+      let fetched: Request[] = [];
+      let responses = [response(503, '1'), response(401)];
+      let sw = createServiceWorkerEnv({
+        screenshotFetch: async (request) => {
+          fetched.push(request);
+          if (fetched.length === 1) {
+            swRef.sw!.processMessage({ type: 'clear-tokens' });
+          }
+          return responses.shift()!;
+        },
+      });
+      swRef.sw = sw;
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: REALM_URL,
+        token: 'original-token',
+      });
+
+      let result = await sw.processFetch(new Request(SCREENSHOT_URL));
+
+      assert.deepEqual(
+        fetched.map((r) => r.headers.get('Authorization')),
+        ['Bearer original-token', null],
+        'the attempt after removal carries no Authorization header',
+      );
+      assert.strictEqual(
+        (result as Response).status,
+        401,
+        'the unabsorbable 401 ends the loop and reaches the page',
       );
     });
 
@@ -1188,12 +1244,20 @@ module('Unit | auth-service-worker | shipped worker', function () {
   interface ShippedWorker {
     isScreenshotRoute: (request: Request) => boolean;
     screenshotRetryDelayMs: (response: Response) => number | undefined;
+    fetchScreenshotAbsorbing503s: (
+      buildRequest: () => Request,
+    ) => Promise<Response>;
+    SCREENSHOT_RETRY_BUDGET_MS: number;
     dispatchMessage: (data: unknown) => void;
     // Drives the shipped fetch listener; resolves with the Response the SW
     // would respondWith, or 'pass-through' when the listener declined to
     // intercept.
     dispatchFetch: (request: Request) => Promise<Response | 'pass-through'>;
     fetched: Request[];
+    // Virtual-clock sleep log: the worker's `setTimeout`/`Date` are bound to
+    // a clock that sleeps advance instantly, so budget arithmetic runs
+    // against shipped bytes without holding real time.
+    sleeps: number[];
   }
 
   async function loadShippedWorker(
@@ -1225,22 +1289,46 @@ module('Unit | auth-service-worker | shipped worker', function () {
       }
       return next;
     };
+    // Virtual clock: the worker's free `Date` and `setTimeout` identifiers
+    // bind to these stubs, so retry sleeps advance the clock instantly and
+    // the shipped budget arithmetic is testable without real waits.
+    let clock = 0;
+    let sleeps: number[] = [];
+    let setTimeoutStub = ((fn: () => void, ms?: number) => {
+      sleeps.push(ms ?? 0);
+      clock += ms ?? 0;
+      fn();
+      return 0;
+    }) as unknown as typeof setTimeout;
+    let dateStub = { now: () => clock };
     // The worker source declares its helpers at (function-body) top level, so
     // appending a return statement exposes them without any module plumbing —
     // a classic `public/` SW cannot be imported as ESM.
     let factory = new Function(
       'self',
       'fetch',
+      'setTimeout',
+      'Date',
       `${source}
-      ;return { isScreenshotRoute, screenshotRetryDelayMs };`,
+      ;return { isScreenshotRoute, screenshotRetryDelayMs,
+        fetchScreenshotAbsorbing503s, SCREENSHOT_RETRY_BUDGET_MS };`,
     );
-    let exported = factory(selfStub, fetchStub) as Pick<
+    let exported = factory(
+      selfStub,
+      fetchStub,
+      setTimeoutStub,
+      dateStub,
+    ) as Pick<
       ShippedWorker,
-      'isScreenshotRoute' | 'screenshotRetryDelayMs'
+      | 'isScreenshotRoute'
+      | 'screenshotRetryDelayMs'
+      | 'fetchScreenshotAbsorbing503s'
+      | 'SCREENSHOT_RETRY_BUDGET_MS'
     >;
     return {
       ...exported,
       fetched,
+      sleeps,
       dispatchMessage: (data: unknown) => {
         for (let fn of listeners.get('message') ?? []) {
           fn({ data });
@@ -1316,6 +1404,51 @@ module('Unit | auth-service-worker | shipped worker', function () {
       sw.isScreenshotRoute(
         new Request('http://localhost:4201/user/realm/images/photo.png'),
       ),
+    );
+  });
+
+  test('shipped absorption loop exhausts the budget at the shipped constant', async function (assert) {
+    // Budget is 90s; each 503 asks for a 30s pause. Attempts at t=0, 30s,
+    // 60s, 90s; the window is closed after the t=90s attempt, so its 503
+    // goes to the page. Runs against the shipped loop and constant — a
+    // change to either that the mirror module misses fails here.
+    let retryAfter30 = () =>
+      new Response(null, { status: 503, headers: { 'Retry-After': '30' } });
+    let sw = await loadShippedWorker([
+      retryAfter30(),
+      retryAfter30(),
+      retryAfter30(),
+      retryAfter30(),
+    ]);
+
+    let result = await sw.fetchScreenshotAbsorbing503s(
+      () =>
+        new Request('http://localhost:4201/user/realm/_screenshot/Card/1.png'),
+    );
+
+    assert.strictEqual(sw.SCREENSHOT_RETRY_BUDGET_MS, 90000);
+    assert.strictEqual(result.status, 503, 'exhaustion surfaces the 503');
+    assert.strictEqual(sw.fetched.length, 4);
+    assert.deepEqual(sw.sleeps, [30000, 30000, 30000]);
+  });
+
+  test('shipped absorption loop clamps an oversized Retry-After to one deadline retry', async function (assert) {
+    let sw = await loadShippedWorker([
+      new Response(null, { status: 503, headers: { 'Retry-After': '600' } }),
+      new Response(null, { status: 200 }),
+    ]);
+
+    let result = await sw.fetchScreenshotAbsorbing503s(
+      () =>
+        new Request('http://localhost:4201/user/realm/_screenshot/Card/1.png'),
+    );
+
+    assert.strictEqual(result.status, 200);
+    assert.strictEqual(sw.fetched.length, 2, 'exactly one deadline retry');
+    assert.deepEqual(
+      sw.sleeps,
+      [90000],
+      'the pause is clamped to the remaining budget',
     );
   });
 


### PR DESCRIPTION
## What this does

The realm's `_screenshot/` route answers **503 + Retry-After** when a capture can't complete within its bounded sync wait (capture still rendering, or the on-demand lane is congested). `<img>` has no retry logic, so an in-app screenshot image would stick as a broken image until a manual reload.

The host's auth service worker — which already intercepts these requests to inject the realm JWT — now absorbs exactly those 503s and re-fetches at the server's suggested pace, so the fetch event resolves late instead of failing and the image pops in when the capture lands. The server stays connection-cheap (fail-fast + bounded sync wait); the SW is the poll loop, paced by the server's own `Retry-After` estimates.

## Guardrails

- **Tight match, never generalized**: absorption engages only for GET requests with a `_screenshot/` path segment on a request already scoped to a realm (a realm-token prefix match on the token branches, a known realm origin on the tokenless branch), and only for status exactly 503 with a numeric `Retry-After`. A blanket SW 503-retry would mask real outages and hammer a struggling realm-server. Position within the realm is not checked — the realm serves the subtree only at its root, so a nested segment on a plain file engages the loop harmlessly (plain files never answer 503 + Retry-After).
- **Retry budget (90s), not a retry count**: the budget bounds when re-fetches may start. A server-suggested pause longer than the remaining budget is clamped to it rather than abandoned — the congestion 503's `Retry-After` is `pending × avgCaptureMs` with a coarse stand-in average when there is no history, so the estimate can far overshoot the real wait, and one retry at the deadline is worth more than an immediate visible error. A 503 arriving once the window is closed passes through so the `<img>` errors visibly rather than hiding a permanently failing capture. The final re-fetch can itself hold up to the server's sync wait, so worst-case wall time is the budget plus one sync wait.
- **Logout ends absorption**: each attempt re-reads the token map with no stale-token fallback, so a token removal mid-loop (logout clears the map) makes the next attempt tokenless — a private realm then answers an unabsorbable 401 and the loop ends, rather than presenting the pre-logout JWT for the rest of the budget.
- **404s are never retried**: an uncaptured-`name=` miss in a fitted template rendered across a large grid would otherwise become that many synchronized retry loops; eager indexing capture plus the 404's short `max-age` already covers the brief uncaptured window.
- **Inert for everything else**: non-`_screenshot` requests, HEAD, and unknown origins take the exact pre-existing code paths, with dedicated tests proving the absorption loop never engages.

## Details

- Each retry rebuilds the request via the token map, so a token rotated mid-loop is picked up on the next attempt. The client-fallback branch keeps a fallback to the client-supplied token: the reply lands in the map keyed by its own realmURL, which may not prefix the request URL, so the map lookup can miss forever while the token stays valid.
- JWT injection already covers the query-param `_screenshot/` DSL URLs via realm-URL prefix matching; a test pins that.
- Tokenless requests to a public realm on a known realm origin are rebuilt as `mode: 'cors'` (no Authorization header): a no-cors response is opaque (status reads as 0), which would hide the 503 from the absorption loop. The realm server exposes `Retry-After` in its CORS headers.

## Test plan

- `ember test --path dist --filter "auth-service-worker"`: 48 passing, covering absorption to eventual 200, server-paced sleeps, budget exhaustion, the deadline clamp for oversized `Retry-After`, missing/unparseable `Retry-After`, 404 non-retry, sub-second clamping, token rotation mid-loop, logout mid-loop ending the loop tokenless, tokenless public-realm cors absorption, and inertness for non-matching requests.
- A "shipped worker" module evaluates the real `public/auth-service-worker.js` bytes in a stubbed SW scope with a virtual `Date`/`setTimeout`, asserting the Retry-After parse contract, route matching, budget exhaustion, and the deadline clamp against the shipped loop and constants — a change the mirrored scaffold misses fails there, with no real sleeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)