### PR TITLE
ci: Update Actions to move off Node 20

### DIFF
--- a/.github/workflows/boxel-cli-pr-title.yml
+++ b/.github/workflows/boxel-cli-pr-title.yml
@@ -46,7 +46,7 @@ jobs:
             echo '__EOF__'
           } >> "$GITHUB_OUTPUT"
 
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/bxl-pr-title.yml
+++ b/.github/workflows/bxl-pr-title.yml
@@ -44,7 +44,7 @@ jobs:
             echo '__EOF__'
           } >> "$GITHUB_OUTPUT"
 
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/manual-vscode-boxel-tools.yml
+++ b/.github/workflows/manual-vscode-boxel-tools.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
       - name: Install vsce

--- a/.github/workflows/pr-boxel-ui.yml
+++ b/.github/workflows/pr-boxel-ui.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get boxel-ui files that changed
         id: boxel-ui-files-that-changed
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # 46.0.1
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             packages/boxel-ui/**

--- a/.github/workflows/pr-status-comment.yml
+++ b/.github/workflows/pr-status-comment.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upsert sticky comment
         if: steps.pr.outputs.skip != 'true' && steps.body.outputs.empty != 'true'
-        uses: marocchino/sticky-pull-request-comment@5060d4700a91de252c87eeddd2da026382d9298a # 2.9.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: pr-status
           number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get boxel-host files that changed
         id: boxel-host-files-that-changed
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # 46.0.1
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             .github/workflows/build-host.yml


### PR DESCRIPTION
This addresses deprecations like [this](https://github.com/cardstack/boxel/actions/runs/32766137641/job/97555915318?pr=5865).