### PR TITLE
Thread screenshot captureSpec (viewport, deviceScaleFactor, fullPage, clip)

### DIFF
--- a/packages/realm-server/handlers/handle-screenshot-card.ts
+++ b/packages/realm-server/handlers/handle-screenshot-card.ts
@@ -543,6 +543,13 @@ export default function handleScreenshotCard({
         // The job keeps running and (when persisting) lands its capture in
         // the MediaCache, so the client's retry answers from the ledger
         // with no second render. The retry hint is one average capture.
+        //
+        // That resume applies only to canonical captures. A custom
+        // captureSpec's job is capture-only (persist: null, never
+        // coalesced), so its timed-out render is discarded and each retry
+        // is a full re-render — the Retry-After here is pacing, not a
+        // cheap-resume promise, until the ledger identity learns these
+        // specs.
         let estimate = await estimateScreenshotQueueWait(
           dbAdapter,
           `screenshot:${normalizedRealmURL}`,

--- a/packages/realm-server/handlers/handle-screenshot-card.ts
+++ b/packages/realm-server/handlers/handle-screenshot-card.ts
@@ -7,13 +7,13 @@ import {
   findLiveInstanceGeneration,
   findMediaCacheEntry,
   isCaptureFormat,
+  parseScreenshotCaptureSpec,
   screenshotURLFor,
   touchMediaCacheEntryOnHit,
   type CaptureSpec,
   type DBAdapter,
   type MediaCacheEntry,
   type MediaCacheEntryKey,
-  type ScreenshotCaptureSpec,
   type ScreenshotPrerenderResponse,
 } from '@cardstack/runtime-common';
 import RealmPermissionChecker from '@cardstack/runtime-common/realm-permission-checker';
@@ -98,16 +98,19 @@ interface CaptureResult {
  * }
  * ```
  *
- * `captureSpec` is optional; every field within it is optional. It is validated
- * here (viewport ≤ 4096×16384, deviceScaleFactor ≤ 3, clip bounded by the same
- * caps as the viewport and within the viewport when one is given, physical
- * pixels per edge ≤ the Chromium texture cap, `fullPage` and `clip` mutually
- * exclusive) so the worker/prerenderer downstream can treat it as trusted. The
- * parse is strict per the capture-spec contract (`capture-spec.ts`): a field
- * the engine cannot honor is refused by name — never ignored — and
- * default-valued fields (`fullPage: false`, `deviceScaleFactor: 1`) are elided
- * so equal capture intents classify identically. Invalid specs return a 400
- * naming the offending field.
+ * `captureSpec` is optional; every field within it is optional. It is
+ * validated by the shared strict parse in `capture-spec.ts` (viewport ≤
+ * 4096×16384, deviceScaleFactor ≤ 3, clip bounded by the same caps as the
+ * viewport and within the viewport when one is given, physical pixels per
+ * edge ≤ the Chromium texture cap, `fullPage` and `clip` mutually exclusive
+ * — the prerender server's screenshot route runs the identical parse), so
+ * the worker downstream can treat it as trusted. The parse is strict: a
+ * field the engine cannot honor is refused by name — never ignored — and
+ * default-valued fields (`fullPage: false`, `deviceScaleFactor: 1`) are
+ * elided so equal capture intents classify identically. Invalid specs
+ * return a 400 naming the offending field. The one bound no request-time
+ * parse can enforce — a fullPage capture's document extent — is checked
+ * against the same physical-pixel cap at capture time.
  * A spec with overrides is capture-only: the ledger's canonical capture
  * identity cannot represent it yet (the GET DSL reserves those params), so it
  * always renders fresh and returns raw bytes — no ledger fast path, no
@@ -116,240 +119,9 @@ interface CaptureResult {
  * The `runAs` user is derived from the authenticated JWT.
  */
 
-// Chromium caps a single texture at 16384px; a viewport wider than 4096px is
-// well past any real card layout and mostly a way to force a huge capture.
-export const SCREENSHOT_MAX_VIEWPORT_WIDTH = 4096;
-export const SCREENSHOT_MAX_VIEWPORT_HEIGHT = 16384;
-// A 3× scale already covers retina/hi-dpi; higher just multiplies pixel cost.
-export const SCREENSHOT_MAX_DEVICE_SCALE_FACTOR = 3;
-// The Chromium single-texture cap the viewport bounds are derived from,
-// enforced on *physical* pixels: CSS dimension × deviceScaleFactor. The CSS
-// caps alone would admit e.g. a 16384-tall viewport at 3× (~49k physical px).
-export const SCREENSHOT_MAX_PHYSICAL_EDGE_PX = 16384;
-
-// Result of validating the request's `captureSpec` attribute. On success
-// `captureSpec` is the normalized spec — null when the attribute was absent
-// or carried no overrides (default-valued fields are elided), so `null`
-// exactly means "the canonical capture"; on failure `error` names the
-// offending field for a 400.
-type CaptureSpecParse =
-  | { captureSpec: ScreenshotCaptureSpec | null; error?: undefined }
-  | { captureSpec?: undefined; error: string };
-
-const CAPTURE_SPEC_FIELDS = new Set([
-  'viewport',
-  'deviceScaleFactor',
-  'fullPage',
-  'clip',
-]);
-const CAPTURE_SPEC_VIEWPORT_FIELDS = new Set(['width', 'height']);
-const CAPTURE_SPEC_CLIP_FIELDS = new Set(['x', 'y', 'width', 'height']);
-
-function isPositiveInteger(value: unknown): value is number {
-  return typeof value === 'number' && Number.isInteger(value) && value > 0;
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function parseCaptureSpec(raw: unknown): CaptureSpecParse {
-  if (raw === undefined || raw === null) {
-    return { captureSpec: null };
-  }
-  if (!isPlainObject(raw)) {
-    return { error: 'captureSpec must be an object' };
-  }
-
-  // Strict per the capture-spec contract: an unrecognized field is refused by
-  // name rather than dropped — silently dropping a typo'd `fullpage: true`
-  // would classify the request as canonical and serve (or persist) the wrong
-  // image.
-  for (let key of Object.keys(raw)) {
-    if (!CAPTURE_SPEC_FIELDS.has(key)) {
-      return { error: `captureSpec.${key} is not a supported field` };
-    }
-  }
-
-  let spec: ScreenshotCaptureSpec = {};
-
-  if (raw.viewport !== undefined) {
-    let viewport = raw.viewport;
-    if (!isPlainObject(viewport)) {
-      return {
-        error:
-          'captureSpec.viewport must have positive integer width and height',
-      };
-    }
-    for (let key of Object.keys(viewport)) {
-      if (!CAPTURE_SPEC_VIEWPORT_FIELDS.has(key)) {
-        return {
-          error: `captureSpec.viewport.${key} is not a supported field`,
-        };
-      }
-    }
-    if (
-      !isPositiveInteger(viewport.width) ||
-      !isPositiveInteger(viewport.height)
-    ) {
-      return {
-        error:
-          'captureSpec.viewport must have positive integer width and height',
-      };
-    }
-    if (viewport.width > SCREENSHOT_MAX_VIEWPORT_WIDTH) {
-      return {
-        error: `captureSpec.viewport.width must be <= ${SCREENSHOT_MAX_VIEWPORT_WIDTH}`,
-      };
-    }
-    if (viewport.height > SCREENSHOT_MAX_VIEWPORT_HEIGHT) {
-      return {
-        error: `captureSpec.viewport.height must be <= ${SCREENSHOT_MAX_VIEWPORT_HEIGHT}`,
-      };
-    }
-    spec.viewport = { width: viewport.width, height: viewport.height };
-  }
-
-  if (raw.deviceScaleFactor !== undefined) {
-    let scale = raw.deviceScaleFactor;
-    if (typeof scale !== 'number' || !Number.isFinite(scale) || scale <= 0) {
-      return {
-        error: 'captureSpec.deviceScaleFactor must be a positive number',
-      };
-    }
-    if (scale > SCREENSHOT_MAX_DEVICE_SCALE_FACTOR) {
-      return {
-        error: `captureSpec.deviceScaleFactor must be <= ${SCREENSHOT_MAX_DEVICE_SCALE_FACTOR}`,
-      };
-    }
-    // 1 is the engine default: elide it so `{ deviceScaleFactor: 1 }` means
-    // the same capture as no spec at all and keeps the canonical fast path.
-    if (scale !== 1) {
-      spec.deviceScaleFactor = scale;
-    }
-  }
-
-  if (raw.fullPage !== undefined) {
-    if (typeof raw.fullPage !== 'boolean') {
-      return { error: 'captureSpec.fullPage must be a boolean' };
-    }
-    // false is the engine default: elide it (see deviceScaleFactor above).
-    if (raw.fullPage) {
-      spec.fullPage = true;
-    }
-  }
-
-  if (raw.clip !== undefined) {
-    let clip = raw.clip;
-    if (!isPlainObject(clip)) {
-      return {
-        error:
-          'captureSpec.clip must have non-negative x/y and positive integer width/height',
-      };
-    }
-    for (let key of Object.keys(clip)) {
-      if (!CAPTURE_SPEC_CLIP_FIELDS.has(key)) {
-        return { error: `captureSpec.clip.${key} is not a supported field` };
-      }
-    }
-    if (
-      typeof clip.x !== 'number' ||
-      typeof clip.y !== 'number' ||
-      !Number.isFinite(clip.x) ||
-      !Number.isFinite(clip.y) ||
-      clip.x < 0 ||
-      clip.y < 0 ||
-      !isPositiveInteger(clip.width) ||
-      !isPositiveInteger(clip.height)
-    ) {
-      return {
-        error:
-          'captureSpec.clip must have non-negative x/y and positive integer width/height',
-      };
-    }
-    // The clip's extent is bounded by the same caps as the viewport whether
-    // or not one was sent: Puppeteer captures beyond the viewport by default
-    // (`captureBeyondViewport`), so an unbounded clip would be a way around
-    // the viewport cost caps.
-    if (clip.x + clip.width > SCREENSHOT_MAX_VIEWPORT_WIDTH) {
-      return {
-        error: `captureSpec.clip x + width must be <= ${SCREENSHOT_MAX_VIEWPORT_WIDTH}`,
-      };
-    }
-    if (clip.y + clip.height > SCREENSHOT_MAX_VIEWPORT_HEIGHT) {
-      return {
-        error: `captureSpec.clip y + height must be <= ${SCREENSHOT_MAX_VIEWPORT_HEIGHT}`,
-      };
-    }
-    spec.clip = {
-      x: clip.x,
-      y: clip.y,
-      width: clip.width,
-      height: clip.height,
-    };
-  }
-
-  if (spec.fullPage && spec.clip) {
-    return {
-      error: 'captureSpec cannot set both fullPage and clip',
-    };
-  }
-
-  // Tighter containment when the caller declared a viewport: the layout was
-  // requested at that size, so a clip past its edge is caller error — the
-  // region would be unstyled overflow or blank area past the document edge.
-  if (spec.clip && spec.viewport) {
-    if (spec.clip.x + spec.clip.width > spec.viewport.width) {
-      return {
-        error: 'captureSpec.clip exceeds captureSpec.viewport.width',
-      };
-    }
-    if (spec.clip.y + spec.clip.height > spec.viewport.height) {
-      return {
-        error: 'captureSpec.clip exceeds captureSpec.viewport.height',
-      };
-    }
-  }
-
-  // The CSS caps compose with the scale factor: what Chromium renders is
-  // physical pixels, and each capture edge must stay under the texture cap.
-  let effectiveScale = spec.deviceScaleFactor ?? 1;
-  if (spec.viewport) {
-    if (
-      spec.viewport.width * effectiveScale >
-      SCREENSHOT_MAX_PHYSICAL_EDGE_PX
-    ) {
-      return {
-        error: `captureSpec.viewport.width × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
-      };
-    }
-    if (
-      spec.viewport.height * effectiveScale >
-      SCREENSHOT_MAX_PHYSICAL_EDGE_PX
-    ) {
-      return {
-        error: `captureSpec.viewport.height × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
-      };
-    }
-  }
-  if (spec.clip) {
-    if (spec.clip.width * effectiveScale > SCREENSHOT_MAX_PHYSICAL_EDGE_PX) {
-      return {
-        error: `captureSpec.clip.width × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
-      };
-    }
-    if (spec.clip.height * effectiveScale > SCREENSHOT_MAX_PHYSICAL_EDGE_PX) {
-      return {
-        error: `captureSpec.clip.height × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
-      };
-    }
-  }
-
-  // A spec whose every field matched an engine default normalizes to null:
-  // it means the canonical capture, and null is what the rest of the handler
-  // (and the job args) key that classification on.
-  return { captureSpec: Object.keys(spec).length > 0 ? spec : null };
-}
+// The captureSpec bounds and strict parse live in `capture-spec.ts`
+// (runtime-common) so this handler and the prerender server's screenshot
+// route validate identically; see the constants and rules there.
 
 export default function handleScreenshotCard({
   dbAdapter,
@@ -420,7 +192,7 @@ export default function handleScreenshotCard({
     let sourceURL = normalizedCardId.replace(/\.json$/, '');
     let instanceLocalPath = sourceURL.slice(normalizedRealmURL.length);
 
-    let captureSpecParse = parseCaptureSpec(attrs.captureSpec);
+    let captureSpecParse = parseScreenshotCaptureSpec(attrs.captureSpec);
     if (captureSpecParse.error) {
       return sendResponseForBadRequest(ctxt, captureSpecParse.error);
     }

--- a/packages/realm-server/handlers/handle-screenshot-card.ts
+++ b/packages/realm-server/handlers/handle-screenshot-card.ts
@@ -99,10 +99,16 @@ interface CaptureResult {
  * ```
  *
  * `captureSpec` is optional; every field within it is optional. It is validated
- * here (viewport ≤ 4096×16384, deviceScaleFactor ≤ 3, clip within the viewport,
- * `fullPage` and `clip` mutually exclusive) so the worker/prerenderer downstream
- * can treat it as trusted. Invalid specs return a 400 naming the offending field.
- * A non-empty `captureSpec` is capture-only: the ledger's canonical capture
+ * here (viewport ≤ 4096×16384, deviceScaleFactor ≤ 3, clip bounded by the same
+ * caps as the viewport and within the viewport when one is given, physical
+ * pixels per edge ≤ the Chromium texture cap, `fullPage` and `clip` mutually
+ * exclusive) so the worker/prerenderer downstream can treat it as trusted. The
+ * parse is strict per the capture-spec contract (`capture-spec.ts`): a field
+ * the engine cannot honor is refused by name — never ignored — and
+ * default-valued fields (`fullPage: false`, `deviceScaleFactor: 1`) are elided
+ * so equal capture intents classify identically. Invalid specs return a 400
+ * naming the offending field.
+ * A spec with overrides is capture-only: the ledger's canonical capture
  * identity cannot represent it yet (the GET DSL reserves those params), so it
  * always renders fresh and returns raw bytes — no ledger fast path, no
  * MediaCache persist, no `captures` URL.
@@ -116,13 +122,28 @@ export const SCREENSHOT_MAX_VIEWPORT_WIDTH = 4096;
 export const SCREENSHOT_MAX_VIEWPORT_HEIGHT = 16384;
 // A 3× scale already covers retina/hi-dpi; higher just multiplies pixel cost.
 export const SCREENSHOT_MAX_DEVICE_SCALE_FACTOR = 3;
+// The Chromium single-texture cap the viewport bounds are derived from,
+// enforced on *physical* pixels: CSS dimension × deviceScaleFactor. The CSS
+// caps alone would admit e.g. a 16384-tall viewport at 3× (~49k physical px).
+export const SCREENSHOT_MAX_PHYSICAL_EDGE_PX = 16384;
 
 // Result of validating the request's `captureSpec` attribute. On success
-// `captureSpec` is the normalized spec (or null when the attribute was absent);
-// on failure `error` names the offending field for a 400.
+// `captureSpec` is the normalized spec — null when the attribute was absent
+// or carried no overrides (default-valued fields are elided), so `null`
+// exactly means "the canonical capture"; on failure `error` names the
+// offending field for a 400.
 type CaptureSpecParse =
   | { captureSpec: ScreenshotCaptureSpec | null; error?: undefined }
   | { captureSpec?: undefined; error: string };
+
+const CAPTURE_SPEC_FIELDS = new Set([
+  'viewport',
+  'deviceScaleFactor',
+  'fullPage',
+  'clip',
+]);
+const CAPTURE_SPEC_VIEWPORT_FIELDS = new Set(['width', 'height']);
+const CAPTURE_SPEC_CLIP_FIELDS = new Set(['x', 'y', 'width', 'height']);
 
 function isPositiveInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && value > 0;
@@ -140,12 +161,34 @@ function parseCaptureSpec(raw: unknown): CaptureSpecParse {
     return { error: 'captureSpec must be an object' };
   }
 
+  // Strict per the capture-spec contract: an unrecognized field is refused by
+  // name rather than dropped — silently dropping a typo'd `fullpage: true`
+  // would classify the request as canonical and serve (or persist) the wrong
+  // image.
+  for (let key of Object.keys(raw)) {
+    if (!CAPTURE_SPEC_FIELDS.has(key)) {
+      return { error: `captureSpec.${key} is not a supported field` };
+    }
+  }
+
   let spec: ScreenshotCaptureSpec = {};
 
   if (raw.viewport !== undefined) {
     let viewport = raw.viewport;
+    if (!isPlainObject(viewport)) {
+      return {
+        error:
+          'captureSpec.viewport must have positive integer width and height',
+      };
+    }
+    for (let key of Object.keys(viewport)) {
+      if (!CAPTURE_SPEC_VIEWPORT_FIELDS.has(key)) {
+        return {
+          error: `captureSpec.viewport.${key} is not a supported field`,
+        };
+      }
+    }
     if (
-      !isPlainObject(viewport) ||
       !isPositiveInteger(viewport.width) ||
       !isPositiveInteger(viewport.height)
     ) {
@@ -179,20 +222,37 @@ function parseCaptureSpec(raw: unknown): CaptureSpecParse {
         error: `captureSpec.deviceScaleFactor must be <= ${SCREENSHOT_MAX_DEVICE_SCALE_FACTOR}`,
       };
     }
-    spec.deviceScaleFactor = scale;
+    // 1 is the engine default: elide it so `{ deviceScaleFactor: 1 }` means
+    // the same capture as no spec at all and keeps the canonical fast path.
+    if (scale !== 1) {
+      spec.deviceScaleFactor = scale;
+    }
   }
 
   if (raw.fullPage !== undefined) {
     if (typeof raw.fullPage !== 'boolean') {
       return { error: 'captureSpec.fullPage must be a boolean' };
     }
-    spec.fullPage = raw.fullPage;
+    // false is the engine default: elide it (see deviceScaleFactor above).
+    if (raw.fullPage) {
+      spec.fullPage = true;
+    }
   }
 
   if (raw.clip !== undefined) {
     let clip = raw.clip;
+    if (!isPlainObject(clip)) {
+      return {
+        error:
+          'captureSpec.clip must have non-negative x/y and positive integer width/height',
+      };
+    }
+    for (let key of Object.keys(clip)) {
+      if (!CAPTURE_SPEC_CLIP_FIELDS.has(key)) {
+        return { error: `captureSpec.clip.${key} is not a supported field` };
+      }
+    }
     if (
-      !isPlainObject(clip) ||
       typeof clip.x !== 'number' ||
       typeof clip.y !== 'number' ||
       !Number.isFinite(clip.x) ||
@@ -205,6 +265,20 @@ function parseCaptureSpec(raw: unknown): CaptureSpecParse {
       return {
         error:
           'captureSpec.clip must have non-negative x/y and positive integer width/height',
+      };
+    }
+    // The clip's extent is bounded by the same caps as the viewport whether
+    // or not one was sent: Puppeteer captures beyond the viewport by default
+    // (`captureBeyondViewport`), so an unbounded clip would be a way around
+    // the viewport cost caps.
+    if (clip.x + clip.width > SCREENSHOT_MAX_VIEWPORT_WIDTH) {
+      return {
+        error: `captureSpec.clip x + width must be <= ${SCREENSHOT_MAX_VIEWPORT_WIDTH}`,
+      };
+    }
+    if (clip.y + clip.height > SCREENSHOT_MAX_VIEWPORT_HEIGHT) {
+      return {
+        error: `captureSpec.clip y + height must be <= ${SCREENSHOT_MAX_VIEWPORT_HEIGHT}`,
       };
     }
     spec.clip = {
@@ -221,8 +295,9 @@ function parseCaptureSpec(raw: unknown): CaptureSpecParse {
     };
   }
 
-  // Clip must sit within the viewport when the caller specified both; a clip
-  // beyond the viewport would otherwise capture blank/scrolled area.
+  // Tighter containment when the caller declared a viewport: the layout was
+  // requested at that size, so a clip past its edge is caller error — the
+  // region would be unstyled overflow or blank area past the document edge.
   if (spec.clip && spec.viewport) {
     if (spec.clip.x + spec.clip.width > spec.viewport.width) {
       return {
@@ -236,7 +311,44 @@ function parseCaptureSpec(raw: unknown): CaptureSpecParse {
     }
   }
 
-  return { captureSpec: spec };
+  // The CSS caps compose with the scale factor: what Chromium renders is
+  // physical pixels, and each capture edge must stay under the texture cap.
+  let effectiveScale = spec.deviceScaleFactor ?? 1;
+  if (spec.viewport) {
+    if (
+      spec.viewport.width * effectiveScale >
+      SCREENSHOT_MAX_PHYSICAL_EDGE_PX
+    ) {
+      return {
+        error: `captureSpec.viewport.width × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
+      };
+    }
+    if (
+      spec.viewport.height * effectiveScale >
+      SCREENSHOT_MAX_PHYSICAL_EDGE_PX
+    ) {
+      return {
+        error: `captureSpec.viewport.height × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
+      };
+    }
+  }
+  if (spec.clip) {
+    if (spec.clip.width * effectiveScale > SCREENSHOT_MAX_PHYSICAL_EDGE_PX) {
+      return {
+        error: `captureSpec.clip.width × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
+      };
+    }
+    if (spec.clip.height * effectiveScale > SCREENSHOT_MAX_PHYSICAL_EDGE_PX) {
+      return {
+        error: `captureSpec.clip.height × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
+      };
+    }
+  }
+
+  // A spec whose every field matched an engine default normalizes to null:
+  // it means the canonical capture, and null is what the rest of the handler
+  // (and the job args) key that classification on.
+  return { captureSpec: Object.keys(spec).length > 0 ? spec : null };
 }
 
 export default function handleScreenshotCard({
@@ -334,9 +446,9 @@ export default function handleScreenshotCard({
       // `viewport`/`dsf`/`fullPage`/`clip` — so persisting one under the
       // format-only key would let a custom render serve on the canonical
       // URL. Custom captures render fresh and return bytes only: no ledger
-      // fast path, no persist, no served URL.
-      let isCanonicalCapture =
-        !captureSpec || Object.keys(captureSpec).length === 0;
+      // fast path, no persist, no served URL. The parse normalizes an
+      // all-defaults spec to null, so null exactly means canonical.
+      let isCanonicalCapture = captureSpec === null;
       if (mediaCacheAdapter && isCanonicalCapture) {
         // The ledger fast path and the generation probe feeding it answer
         // from the store before any job exists, so the worker task's

--- a/packages/realm-server/handlers/handle-screenshot-card.ts
+++ b/packages/realm-server/handlers/handle-screenshot-card.ts
@@ -13,6 +13,7 @@ import {
   type DBAdapter,
   type MediaCacheEntry,
   type MediaCacheEntryKey,
+  type ScreenshotCaptureSpec,
   type ScreenshotPrerenderResponse,
 } from '@cardstack/runtime-common';
 import RealmPermissionChecker from '@cardstack/runtime-common/realm-permission-checker';
@@ -85,14 +86,159 @@ interface CaptureResult {
  *       "realmURL": "https://realm.example/user/workspace/",
  *       "cardId": "https://realm.example/user/workspace/Person/fadhlan",
  *       "format": "isolated",
- *       "includeBase64": true
+ *       "includeBase64": true,
+ *       "captureSpec": {
+ *         "viewport": { "width": 1280, "height": 800 },
+ *         "deviceScaleFactor": 2,
+ *         "fullPage": true,
+ *         "clip": { "x": 0, "y": 0, "width": 400, "height": 300 }
+ *       }
  *     }
  *   }
  * }
  * ```
  *
+ * `captureSpec` is optional; every field within it is optional. It is validated
+ * here (viewport ≤ 4096×16384, deviceScaleFactor ≤ 3, clip within the viewport,
+ * `fullPage` and `clip` mutually exclusive) so the worker/prerenderer downstream
+ * can treat it as trusted. Invalid specs return a 400 naming the offending field.
+ * A non-empty `captureSpec` is capture-only: the ledger's canonical capture
+ * identity cannot represent it yet (the GET DSL reserves those params), so it
+ * always renders fresh and returns raw bytes — no ledger fast path, no
+ * MediaCache persist, no `captures` URL.
+ *
  * The `runAs` user is derived from the authenticated JWT.
  */
+
+// Chromium caps a single texture at 16384px; a viewport wider than 4096px is
+// well past any real card layout and mostly a way to force a huge capture.
+export const SCREENSHOT_MAX_VIEWPORT_WIDTH = 4096;
+export const SCREENSHOT_MAX_VIEWPORT_HEIGHT = 16384;
+// A 3× scale already covers retina/hi-dpi; higher just multiplies pixel cost.
+export const SCREENSHOT_MAX_DEVICE_SCALE_FACTOR = 3;
+
+// Result of validating the request's `captureSpec` attribute. On success
+// `captureSpec` is the normalized spec (or null when the attribute was absent);
+// on failure `error` names the offending field for a 400.
+type CaptureSpecParse =
+  | { captureSpec: ScreenshotCaptureSpec | null; error?: undefined }
+  | { captureSpec?: undefined; error: string };
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseCaptureSpec(raw: unknown): CaptureSpecParse {
+  if (raw === undefined || raw === null) {
+    return { captureSpec: null };
+  }
+  if (!isPlainObject(raw)) {
+    return { error: 'captureSpec must be an object' };
+  }
+
+  let spec: ScreenshotCaptureSpec = {};
+
+  if (raw.viewport !== undefined) {
+    let viewport = raw.viewport;
+    if (
+      !isPlainObject(viewport) ||
+      !isPositiveInteger(viewport.width) ||
+      !isPositiveInteger(viewport.height)
+    ) {
+      return {
+        error:
+          'captureSpec.viewport must have positive integer width and height',
+      };
+    }
+    if (viewport.width > SCREENSHOT_MAX_VIEWPORT_WIDTH) {
+      return {
+        error: `captureSpec.viewport.width must be <= ${SCREENSHOT_MAX_VIEWPORT_WIDTH}`,
+      };
+    }
+    if (viewport.height > SCREENSHOT_MAX_VIEWPORT_HEIGHT) {
+      return {
+        error: `captureSpec.viewport.height must be <= ${SCREENSHOT_MAX_VIEWPORT_HEIGHT}`,
+      };
+    }
+    spec.viewport = { width: viewport.width, height: viewport.height };
+  }
+
+  if (raw.deviceScaleFactor !== undefined) {
+    let scale = raw.deviceScaleFactor;
+    if (typeof scale !== 'number' || !Number.isFinite(scale) || scale <= 0) {
+      return {
+        error: 'captureSpec.deviceScaleFactor must be a positive number',
+      };
+    }
+    if (scale > SCREENSHOT_MAX_DEVICE_SCALE_FACTOR) {
+      return {
+        error: `captureSpec.deviceScaleFactor must be <= ${SCREENSHOT_MAX_DEVICE_SCALE_FACTOR}`,
+      };
+    }
+    spec.deviceScaleFactor = scale;
+  }
+
+  if (raw.fullPage !== undefined) {
+    if (typeof raw.fullPage !== 'boolean') {
+      return { error: 'captureSpec.fullPage must be a boolean' };
+    }
+    spec.fullPage = raw.fullPage;
+  }
+
+  if (raw.clip !== undefined) {
+    let clip = raw.clip;
+    if (
+      !isPlainObject(clip) ||
+      typeof clip.x !== 'number' ||
+      typeof clip.y !== 'number' ||
+      !Number.isFinite(clip.x) ||
+      !Number.isFinite(clip.y) ||
+      clip.x < 0 ||
+      clip.y < 0 ||
+      !isPositiveInteger(clip.width) ||
+      !isPositiveInteger(clip.height)
+    ) {
+      return {
+        error:
+          'captureSpec.clip must have non-negative x/y and positive integer width/height',
+      };
+    }
+    spec.clip = {
+      x: clip.x,
+      y: clip.y,
+      width: clip.width,
+      height: clip.height,
+    };
+  }
+
+  if (spec.fullPage && spec.clip) {
+    return {
+      error: 'captureSpec cannot set both fullPage and clip',
+    };
+  }
+
+  // Clip must sit within the viewport when the caller specified both; a clip
+  // beyond the viewport would otherwise capture blank/scrolled area.
+  if (spec.clip && spec.viewport) {
+    if (spec.clip.x + spec.clip.width > spec.viewport.width) {
+      return {
+        error: 'captureSpec.clip exceeds captureSpec.viewport.width',
+      };
+    }
+    if (spec.clip.y + spec.clip.height > spec.viewport.height) {
+      return {
+        error: 'captureSpec.clip exceeds captureSpec.viewport.height',
+      };
+    }
+  }
+
+  return { captureSpec: spec };
+}
+
 export default function handleScreenshotCard({
   dbAdapter,
   queue,
@@ -162,6 +308,12 @@ export default function handleScreenshotCard({
     let sourceURL = normalizedCardId.replace(/\.json$/, '');
     let instanceLocalPath = sourceURL.slice(normalizedRealmURL.length);
 
+    let captureSpecParse = parseCaptureSpec(attrs.captureSpec);
+    if (captureSpecParse.error) {
+      return sendResponseForBadRequest(ctxt, captureSpecParse.error);
+    }
+    let captureSpec = captureSpecParse.captureSpec ?? null;
+
     let token = ctxt.state.token as RealmServerTokenClaim;
     if (!token?.user) {
       return sendResponseForBadRequest(
@@ -177,7 +329,15 @@ export default function handleScreenshotCard({
       // a store. Without either, the capture still runs; it just isn't
       // persisted and the response carries no served URL.
       let entryKey: MediaCacheEntryKey | undefined;
-      if (mediaCacheAdapter) {
+      // A custom `captureSpec` has no representation in the ledger's
+      // canonical capture identity yet — the GET `_screenshot/` DSL reserves
+      // `viewport`/`dsf`/`fullPage`/`clip` — so persisting one under the
+      // format-only key would let a custom render serve on the canonical
+      // URL. Custom captures render fresh and return bytes only: no ledger
+      // fast path, no persist, no served URL.
+      let isCanonicalCapture =
+        !captureSpec || Object.keys(captureSpec).length === 0;
+      if (mediaCacheAdapter && isCanonicalCapture) {
         // The ledger fast path and the generation probe feeding it answer
         // from the store before any job exists, so the worker task's
         // permission check never covers them — realm read is enforced here
@@ -240,6 +400,7 @@ export default function handleScreenshotCard({
           runAs: userId,
           cardId: normalizedCardId,
           format,
+          captureSpec,
           persist: entryKey ? { ...entryKey, lane: 'on-demand' } : null,
         },
         queue,

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -11,6 +11,7 @@ import {
   type RenderRouteOptions,
   type ModuleRenderResponse,
   type RunCommandResponse,
+  type ScreenshotCaptureSpec,
   type ScreenshotPrerenderResponse,
 } from '@cardstack/runtime-common';
 import {
@@ -303,6 +304,10 @@ export function buildPrerenderApp(options: {
     realm: string;
     url: string;
     format: 'isolated' | 'embedded';
+    // Pass-through of the caller's per-capture overrides. Already validated by
+    // the realm-server handler; the capture path guards the one hard invariant
+    // (fullPage + clip) defensively.
+    captureSpec?: ScreenshotCaptureSpec;
   };
 
   type RouteParseResult<A extends RouteBaseArgs> = {
@@ -451,6 +456,7 @@ export function buildPrerenderApp(options: {
     let rawAffinityType = attrs.affinityType;
     let rawAffinityValue = attrs.affinityValue;
     let rawFormat = attrs.format;
+    let rawCaptureSpec = attrs.captureSpec;
     let renderOptions = parseRenderOptions(attrs);
     let priority = parsePriority(attrs);
     let formatIsValid = rawFormat === 'isolated' || rawFormat === 'embedded';
@@ -480,6 +486,9 @@ export function buildPrerenderApp(options: {
               auth: rawAuth as string,
               format: rawFormat as 'isolated' | 'embedded',
               renderOptions,
+              ...(rawCaptureSpec
+                ? { captureSpec: rawCaptureSpec as ScreenshotCaptureSpec }
+                : {}),
               ...(priority !== undefined ? { priority } : {}),
             },
       missing,
@@ -772,6 +781,7 @@ export function buildPrerenderApp(options: {
           url: args.url,
           auth: args.auth,
           format: args.format,
+          ...(args.captureSpec ? { captureSpec: args.captureSpec } : {}),
           priority: args.priority,
           signal,
         }),

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -7,6 +7,7 @@ import {
   Deferred,
   type AffinityType,
   logger,
+  parseScreenshotCaptureSpec,
   type PrerenderVisitType,
   type RenderRouteOptions,
   type ModuleRenderResponse,
@@ -456,10 +457,16 @@ export function buildPrerenderApp(options: {
     let rawAffinityType = attrs.affinityType;
     let rawAffinityValue = attrs.affinityValue;
     let rawFormat = attrs.format;
-    let rawCaptureSpec = attrs.captureSpec;
     let renderOptions = parseRenderOptions(attrs);
     let priority = parsePriority(attrs);
     let formatIsValid = rawFormat === 'isolated' || rawFormat === 'embedded';
+    // Same strict parse + bounds as the realm-server's POST /_screenshot-card
+    // body: this route is its own HTTP surface, and an unvalidated spec here
+    // would reach `page.setViewport` on a pooled page with none of the cost
+    // caps applied. The parse also normalizes (defaults elided, empty spec
+    // -> null), so the capture path sees one canonical shape from every
+    // caller.
+    let captureSpecParse = parseScreenshotCaptureSpec(attrs.captureSpec);
     let missing = missingAttrs([
       { value: rawUrl, name: 'url' },
       { value: rawRealm, name: 'realm' },
@@ -474,6 +481,9 @@ export function buildPrerenderApp(options: {
         name: 'format',
       },
     ]);
+    if (captureSpecParse.error !== undefined) {
+      missing = [...missing, 'captureSpec'];
+    }
     return {
       args:
         missing.length > 0
@@ -486,14 +496,16 @@ export function buildPrerenderApp(options: {
               auth: rawAuth as string,
               format: rawFormat as 'isolated' | 'embedded',
               renderOptions,
-              ...(rawCaptureSpec
-                ? { captureSpec: rawCaptureSpec as ScreenshotCaptureSpec }
+              ...(captureSpecParse.captureSpec
+                ? { captureSpec: captureSpecParse.captureSpec }
                 : {}),
               ...(priority !== undefined ? { priority } : {}),
             },
       missing,
       missingMessage:
-        'Missing or invalid required attributes: url, auth, realm, affinityType, affinityValue, format (isolated|embedded)',
+        captureSpecParse.error !== undefined
+          ? captureSpecParse.error
+          : 'Missing or invalid required attributes: url, auth, realm, affinityType, affinityValue, format (isolated|embedded)',
       logTarget: (rawUrl as string | undefined) ?? '<missing>',
       responseId: (rawUrl as string | undefined) ?? 'unknown',
       rejectionLogDetails: `affinityType=${

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -7,6 +7,7 @@ import {
   type RenderVisitResponse,
   logger,
   type RunCommandResponse,
+  type ScreenshotCaptureSpec,
   type ScreenshotPrerenderResponse,
 } from '@cardstack/runtime-common';
 import { BrowserManager } from './browser-manager.ts';
@@ -625,6 +626,7 @@ export class Prerenderer {
     url,
     auth,
     format,
+    captureSpec,
     priority,
     opts,
     signal,
@@ -633,6 +635,7 @@ export class Prerenderer {
     url: string;
     auth: string;
     format: 'isolated' | 'embedded';
+    captureSpec?: ScreenshotCaptureSpec;
     priority?: number;
     opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
     signal?: AbortSignal;
@@ -657,6 +660,7 @@ export class Prerenderer {
         url,
         auth,
         format,
+        ...(captureSpec ? { captureSpec } : {}),
         priority,
         opts,
         signal,

--- a/packages/realm-server/prerender/remote-prerenderer.ts
+++ b/packages/realm-server/prerender/remote-prerenderer.ts
@@ -274,7 +274,14 @@ export function createRemotePrerenderer(
         },
       );
     },
-    async prerenderScreenshot({ realm, url, auth, format, priority }) {
+    async prerenderScreenshot({
+      realm,
+      url,
+      auth,
+      format,
+      captureSpec,
+      priority,
+    }) {
       return await requestWithRetry<ScreenshotPrerenderResponse>(
         'prerender-screenshot',
         'screenshot-request',
@@ -285,6 +292,7 @@ export function createRemotePrerenderer(
           url,
           auth,
           format,
+          ...(captureSpec ? { captureSpec } : {}),
           ...(priority !== undefined ? { priority } : {}),
         },
       );

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -10,6 +10,7 @@ import {
   type FileRenderResponse,
   type RenderRouteOptions,
   type RunCommandResponse,
+  type ScreenshotCaptureSpec,
   type ScreenshotPrerenderResponse,
   type AffinityType,
   type PrerenderQueue,
@@ -520,6 +521,7 @@ export class RenderRunner {
     url,
     auth,
     format,
+    captureSpec,
     opts,
     priority,
     signal,
@@ -530,6 +532,7 @@ export class RenderRunner {
     url: string;
     auth: string;
     format: 'isolated' | 'embedded';
+    captureSpec?: ScreenshotCaptureSpec;
     opts?: { timeoutMs?: number; simulateTimeoutMs?: number };
     priority?: number;
     signal?: AbortSignal;
@@ -587,6 +590,7 @@ export class RenderRunner {
         expectedNonce: nonce,
         simulateTimeoutMs: opts?.simulateTimeoutMs,
         timeoutMs: opts?.timeoutMs,
+        ...(captureSpec ? { captureSpec } : {}),
       };
 
       let capture = await withTimeout(

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -2,6 +2,7 @@ import {
   cleanCapturedHTML,
   delay,
   logger,
+  SCREENSHOT_MAX_PHYSICAL_EDGE_PX,
   type PrerenderMeta,
   type PrerenderTypes,
   type RenderError,
@@ -1379,16 +1380,33 @@ export async function captureScreenshot(
     // produces empty avatars / missing thumbnails. Bounded by an internal
     // timeout so a slow / 401-looping image can't hang the capture.
     await waitForImagePaint(page);
-    // Reported CSS dimensions of the capture. `fullPage` reports the full
-    // scrollable document; `clip` reports its own region; otherwise the
-    // viewport. Device scale multiplies the PNG's physical pixels but not these
-    // CSS dims.
+    // Reported CSS dimensions of the capture. `fullPage` reports the
+    // captured document (derived from the PNG itself below, so report and
+    // bytes cannot disagree); `clip` reports its own region; otherwise the
+    // viewport. Device scale multiplies the PNG's physical pixels but not
+    // these CSS dims.
+    let effectiveScale = page.viewport()?.deviceScaleFactor ?? 1;
     let dims: { width: number; height: number };
     if (captureSpec?.fullPage) {
+      // A fullPage capture's extent is the document's scroll size — a bound
+      // no request-time validation can know, so the physical-pixel cap the
+      // parse enforces for viewport/clip is enforced here. Chromium cannot
+      // produce a texture past the cap anyway; failing by name beats
+      // returning silently truncated bytes.
       dims = await page.evaluate(() => ({
         width: document.documentElement.scrollWidth,
         height: document.documentElement.scrollHeight,
       }));
+      if (
+        dims.width * effectiveScale > SCREENSHOT_MAX_PHYSICAL_EDGE_PX ||
+        dims.height * effectiveScale > SCREENSHOT_MAX_PHYSICAL_EDGE_PX
+      ) {
+        return buildInvalidRenderResponseError(
+          page,
+          `fullPage capture of ${dims.width}x${dims.height} CSS px at ${effectiveScale}x exceeds ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels per edge`,
+          { title: 'Screenshot capture too large' },
+        );
+      }
     } else if (captureSpec?.clip) {
       dims = {
         width: captureSpec.clip.width,
@@ -1406,6 +1424,17 @@ export async function captureScreenshot(
       ...(captureSpec?.fullPage ? { fullPage: true } : {}),
       ...(captureSpec?.clip ? { clip: captureSpec.clip } : {}),
     })) as string;
+    if (captureSpec?.fullPage) {
+      // The scroll-size read above and the capture are two separate
+      // measurements (Chromium sizes fullPage from its own layout metrics),
+      // so the reported dims come from the PNG's IHDR: physical pixels at
+      // bytes 16..23, divided back to CSS px by the scale in effect.
+      let header = Buffer.from(base64.slice(0, 48), 'base64');
+      dims = {
+        width: Math.round(header.readUInt32BE(16) / effectiveScale),
+        height: Math.round(header.readUInt32BE(20) / effectiveScale),
+      };
+    }
     let pngBytes = Buffer.byteLength(base64, 'base64');
     log.debug(
       `captureScreenshot success format=${format} ancestorLevel=${ancestorLevel} bytes=${pngBytes} base64Chars=${base64.length} ${dims.width}x${dims.height}`,

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -6,6 +6,7 @@ import {
   type PrerenderTypes,
   type RenderError,
   type RenderTimeoutDiagnostics,
+  type ScreenshotCaptureSpec,
 } from '@cardstack/runtime-common';
 import { prerenderRenderTimeoutMs } from './prerender-constants.ts';
 import { getPendingNetworkRequests } from './network-inflight-tracker.ts';
@@ -92,6 +93,9 @@ export interface CaptureOptions {
   expectedNonce?: string;
   simulateTimeoutMs?: number;
   timeoutMs?: number;
+  // Screenshot-only: per-capture viewport / scale / fullPage / clip overrides.
+  // Ignored by the HTML/meta/module capture paths.
+  captureSpec?: ScreenshotCaptureSpec;
 }
 
 export interface ModuleCapture {
@@ -1262,76 +1266,162 @@ async function waitForImagePaint(page: Page): Promise<void> {
   );
 }
 
+// Puppeteer's default launch viewport (no `defaultViewport` override). Used to
+// restore a pooled page when we can't read its prior viewport — the canonical
+// size the indexing HTML-capture path expects.
+const DEFAULT_SCREENSHOT_VIEWPORT = {
+  width: 800,
+  height: 600,
+  deviceScaleFactor: 1,
+};
+
 export async function captureScreenshot(
   page: Page,
   format: 'isolated' | 'embedded',
   ancestorLevel: number,
   opts?: CaptureOptions,
 ): Promise<ScreenshotCapture | RenderError> {
+  let captureSpec = opts?.captureSpec;
   log.debug(
-    `captureScreenshot start format=${format} ancestorLevel=${ancestorLevel} url=${page.url()}`,
+    `captureScreenshot start format=${format} ancestorLevel=${ancestorLevel} url=${page.url()} captureSpec=${
+      captureSpec ? JSON.stringify(captureSpec) : 'none'
+    }`,
   );
-  await transitionTo(page, 'render.html', format, String(ancestorLevel));
-  await waitForRoutePathSuffix(page, `/html/${format}/${ancestorLevel}`, opts);
-  await waitForPrerenderSettle(page);
-  // After settle, surface any terminal prerender error rather than
-  // screenshotting a skeleton/error frame. Reuses the same data-attribute
-  // signaling as the HTML capture path.
-  let terminal = await page.evaluate(() => {
-    let elements = Array.from(
-      document.querySelectorAll('[data-prerender]'),
-    ) as HTMLElement[];
-    for (let element of elements) {
-      let status = element.dataset.prerenderStatus ?? '';
-      if (status === 'error' || status === 'unusable') {
-        let errorElement = element.querySelector(
-          '[data-prerender-error]',
-        ) as HTMLElement | null;
-        let raw = (
-          errorElement?.textContent ??
-          errorElement?.innerHTML ??
-          ''
-        ).trim();
-        return { status: status as 'error' | 'unusable', raw };
-      }
-    }
-    let stray = document.querySelector(
-      '[data-prerender-error]',
-    ) as HTMLElement | null;
-    if (stray) {
-      let raw = (stray.textContent ?? stray.innerHTML ?? '').trim();
-      if (raw.length > 0) {
-        return { status: 'error' as const, raw };
-      }
-    }
-    return null;
-  });
-  if (terminal) {
-    let capture: RenderCapture = {
-      status: terminal.status,
-      value: terminal.raw,
-    };
-    return renderCaptureToError(page, capture, 'render.screenshot');
+
+  // Defensive: `fullPage` and `clip` are mutually exclusive (Puppeteer ignores
+  // clip under fullPage). The realm-server handler already 400s this, but a
+  // direct prerender-server caller could still send it — fail cleanly rather
+  // than return a silently-wrong screenshot.
+  if (captureSpec?.fullPage && captureSpec?.clip) {
+    return buildInvalidRenderResponseError(
+      page,
+      'captureSpec cannot set both fullPage and clip',
+      { title: 'Invalid screenshot capture spec' },
+    );
   }
-  // Settle hook only tracks store/loader generation + animation frames; it
-  // does NOT wait for `<img>` element loads, CSS background-image fetches, or
-  // fonts. Without this extra wait the screenshot races those resources and
-  // produces empty avatars / missing thumbnails. Bounded by an internal
-  // timeout so a slow / 401-looping image can't hang the capture.
-  await waitForImagePaint(page);
-  let dims = await page.evaluate(() => ({
-    width: window.innerWidth,
-    height: window.innerHeight,
-  }));
-  let base64 = (await page.screenshot({
-    encoding: 'base64',
-    type: 'png',
-  })) as string;
-  let pngBytes = Buffer.byteLength(base64, 'base64');
-  log.debug(
-    `captureScreenshot success format=${format} ancestorLevel=${ancestorLevel} bytes=${pngBytes} base64Chars=${base64.length} ${dims.width}x${dims.height}`,
-  );
-  return { base64, width: dims.width, height: dims.height };
+
+  // Pooled pages are reused by the indexing HTML-capture path; a viewport left
+  // at a caller-specified size (or 2× scale) would silently change subsequent
+  // index prerenders. Snapshot the current viewport before overriding and
+  // restore it in `finally`. Set the viewport BEFORE the render transition so
+  // the card lays out at the target size before we settle + capture.
+  let wantsViewportOverride =
+    captureSpec?.viewport != null || captureSpec?.deviceScaleFactor != null;
+  let originalViewport = wantsViewportOverride ? page.viewport() : null;
+  let viewportOverridden = false;
+  try {
+    if (wantsViewportOverride) {
+      let width =
+        captureSpec!.viewport?.width ??
+        originalViewport?.width ??
+        DEFAULT_SCREENSHOT_VIEWPORT.width;
+      let height =
+        captureSpec!.viewport?.height ??
+        originalViewport?.height ??
+        DEFAULT_SCREENSHOT_VIEWPORT.height;
+      let deviceScaleFactor =
+        captureSpec!.deviceScaleFactor ??
+        originalViewport?.deviceScaleFactor ??
+        DEFAULT_SCREENSHOT_VIEWPORT.deviceScaleFactor;
+      await page.setViewport({ width, height, deviceScaleFactor });
+      viewportOverridden = true;
+    }
+
+    await transitionTo(page, 'render.html', format, String(ancestorLevel));
+    await waitForRoutePathSuffix(
+      page,
+      `/html/${format}/${ancestorLevel}`,
+      opts,
+    );
+    await waitForPrerenderSettle(page);
+    // After settle, surface any terminal prerender error rather than
+    // screenshotting a skeleton/error frame. Reuses the same data-attribute
+    // signaling as the HTML capture path.
+    let terminal = await page.evaluate(() => {
+      let elements = Array.from(
+        document.querySelectorAll('[data-prerender]'),
+      ) as HTMLElement[];
+      for (let element of elements) {
+        let status = element.dataset.prerenderStatus ?? '';
+        if (status === 'error' || status === 'unusable') {
+          let errorElement = element.querySelector(
+            '[data-prerender-error]',
+          ) as HTMLElement | null;
+          let raw = (
+            errorElement?.textContent ??
+            errorElement?.innerHTML ??
+            ''
+          ).trim();
+          return { status: status as 'error' | 'unusable', raw };
+        }
+      }
+      let stray = document.querySelector(
+        '[data-prerender-error]',
+      ) as HTMLElement | null;
+      if (stray) {
+        let raw = (stray.textContent ?? stray.innerHTML ?? '').trim();
+        if (raw.length > 0) {
+          return { status: 'error' as const, raw };
+        }
+      }
+      return null;
+    });
+    if (terminal) {
+      let capture: RenderCapture = {
+        status: terminal.status,
+        value: terminal.raw,
+      };
+      return renderCaptureToError(page, capture, 'render.screenshot');
+    }
+    // Settle hook only tracks store/loader generation + animation frames; it
+    // does NOT wait for `<img>` element loads, CSS background-image fetches, or
+    // fonts. Without this extra wait the screenshot races those resources and
+    // produces empty avatars / missing thumbnails. Bounded by an internal
+    // timeout so a slow / 401-looping image can't hang the capture.
+    await waitForImagePaint(page);
+    // Reported CSS dimensions of the capture. `fullPage` reports the full
+    // scrollable document; `clip` reports its own region; otherwise the
+    // viewport. Device scale multiplies the PNG's physical pixels but not these
+    // CSS dims.
+    let dims: { width: number; height: number };
+    if (captureSpec?.fullPage) {
+      dims = await page.evaluate(() => ({
+        width: document.documentElement.scrollWidth,
+        height: document.documentElement.scrollHeight,
+      }));
+    } else if (captureSpec?.clip) {
+      dims = {
+        width: captureSpec.clip.width,
+        height: captureSpec.clip.height,
+      };
+    } else {
+      dims = await page.evaluate(() => ({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      }));
+    }
+    let base64 = (await page.screenshot({
+      encoding: 'base64',
+      type: 'png',
+      ...(captureSpec?.fullPage ? { fullPage: true } : {}),
+      ...(captureSpec?.clip ? { clip: captureSpec.clip } : {}),
+    })) as string;
+    let pngBytes = Buffer.byteLength(base64, 'base64');
+    log.debug(
+      `captureScreenshot success format=${format} ancestorLevel=${ancestorLevel} bytes=${pngBytes} base64Chars=${base64.length} ${dims.width}x${dims.height}`,
+    );
+    return { base64, width: dims.width, height: dims.height };
+  } finally {
+    if (viewportOverridden) {
+      // Restore so the next reuse of this pooled page (including the indexing
+      // HTML-capture path) sees the original viewport, not the caller's.
+      try {
+        await page.setViewport(originalViewport ?? DEFAULT_SCREENSHOT_VIEWPORT);
+      } catch {
+        // Page may be closing/evicted; a best-effort restore is enough.
+      }
+    }
+  }
 }
 
 // Best-effort CPU / heap capture via the CDP `Performance` domain. Runs

--- a/packages/realm-server/tests/media-cache-dsl-test.ts
+++ b/packages/realm-server/tests/media-cache-dsl-test.ts
@@ -391,6 +391,51 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('a job carrying both a persist target and captureSpec overrides never persists', async function (assert) {
+      // No producer publishes this pairing — the POST handler sets
+      // `persist: null` whenever a spec has overrides — but the task is the
+      // last line of defense: the persist identity is the canonical
+      // capture's, so persisting an override render under it would serve
+      // that render on the canonical `_screenshot/` URL.
+      await seedInstanceRow('card-1');
+      await startWorker();
+
+      let entryKey = {
+        realmURL: REALM_URL,
+        sourceURL: `${REALM_URL}card-1`,
+        captureSpecHash: await captureSpecHash({ format: 'isolated' }),
+        sourceGeneration: 1,
+      };
+      let job = await publisher.publish<ScreenshotPrerenderResponse>({
+        jobType: 'screenshot-card',
+        concurrencyGroup: `screenshot:${REALM_URL}`,
+        timeout: 60,
+        priority: 0,
+        args: {
+          realmURL: REALM_URL,
+          realmUsername: OWNER,
+          runAs: OWNER,
+          cardId: `${REALM_URL}card-1`,
+          format: 'isolated',
+          captureSpec: { viewport: { width: 1280, height: 800 } },
+          persist: { ...entryKey, lane: 'on-demand' },
+        },
+      });
+      let result = await job.done;
+
+      assert.strictEqual(result.status, 'ready', 'the capture itself ran');
+      assert.strictEqual(
+        result.base64,
+        PNG_BASE64,
+        'the bytes still reach the caller',
+      );
+      assert.strictEqual(
+        await findMediaCacheEntry(dbAdapter, entryKey),
+        undefined,
+        'nothing was persisted under the canonical ledger identity',
+      );
+    });
+
     test('concurrent misses for one spec coalesce onto one capture', async function (assert) {
       await seedInstanceRow('card-1');
       await seedRealmConfigRow(true);

--- a/packages/realm-server/tests/prerender-server-test.ts
+++ b/packages/realm-server/tests/prerender-server-test.ts
@@ -127,6 +127,57 @@ module(basename(import.meta.filename), function () {
       await prerenderer.stop();
     });
 
+    test('screenshot route rejects an out-of-bounds captureSpec by field name', async function (assert) {
+      // This route is its own HTTP surface: without the shared bounds check
+      // an oversize viewport would reach page.setViewport on a pooled page
+      // with none of the realm-server's cost caps applied.
+      let res = await request
+        .post('/prerender-screenshot')
+        .send({
+          data: {
+            attributes: {
+              url: 'http://example.test/card',
+              realm: 'http://example.test/',
+              auth: '{}',
+              affinityType: 'realm',
+              affinityValue: 'http://example.test/',
+              format: 'isolated',
+              captureSpec: { viewport: { width: 1_000_000, height: 600 } },
+            },
+          },
+        })
+        .set('Accept', 'application/json');
+      assert.strictEqual(res.status, 400, 'rejected before any render work');
+      assert.true(
+        res.body.errors?.[0]?.message?.includes('captureSpec.viewport.width'),
+        `names the offending field: ${JSON.stringify(res.body)}`,
+      );
+    });
+
+    test('screenshot route rejects an unknown captureSpec field by name', async function (assert) {
+      let res = await request
+        .post('/prerender-screenshot')
+        .send({
+          data: {
+            attributes: {
+              url: 'http://example.test/card',
+              realm: 'http://example.test/',
+              auth: '{}',
+              affinityType: 'realm',
+              affinityValue: 'http://example.test/',
+              format: 'isolated',
+              captureSpec: { fullpage: true },
+            },
+          },
+        })
+        .set('Accept', 'application/json');
+      assert.strictEqual(res.status, 400, 'rejected before any render work');
+      assert.true(
+        res.body.errors?.[0]?.message?.includes('captureSpec.fullpage'),
+        `names the offending field: ${JSON.stringify(res.body)}`,
+      );
+    });
+
     test('liveness', async function (assert) {
       let res = await request.get('/').set('Accept', 'application/json');
       assert.strictEqual(res.status, 200, 'HTTP 200');

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -744,7 +744,12 @@ module(basename(import.meta.filename), function () {
                 },
               },
             },
-            'long.json': {
+            // Named `tall`, not `long`: an instance sharing its extensionless
+            // alias with `long.gts` would make the render route's
+            // extensionless card id ambiguous — the module source wins the
+            // lookup and the render errors trying to parse it as JSON, even
+            // though indexing (which uses full URLs) stays clean.
+            'tall.json': {
               data: {
                 attributes: { name: 'Tall Card' },
                 meta: {
@@ -788,7 +793,7 @@ module(basename(import.meta.filename), function () {
     });
 
     test('fullPage captures beyond the viewport height for a long card', async function (assert) {
-      let { response } = await screenshot(`${realmURL}long`, {
+      let { response } = await screenshot(`${realmURL}tall`, {
         fullPage: true,
       });
       assert.strictEqual(response.status, 'ready', 'screenshot succeeded');
@@ -807,7 +812,7 @@ module(basename(import.meta.filename), function () {
     });
 
     test('clip captures exactly the requested region', async function (assert) {
-      let { response } = await screenshot(`${realmURL}long`, {
+      let { response } = await screenshot(`${realmURL}tall`, {
         clip: { x: 0, y: 0, width: 400, height: 300 },
       });
       assert.strictEqual(response.status, 'ready', 'screenshot succeeded');

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -744,6 +744,18 @@ module(basename(import.meta.filename), function () {
                 },
               },
             },
+            'giant.gts': `
+              import { CardDef, field, contains, StringField, Component } from '@cardstack/base/card-api';
+              export class Giant extends CardDef {
+                static displayName = "Giant";
+                @field name = contains(StringField);
+                static isolated = class extends Component<typeof this> {
+                  <template>
+                    <div style="height: 6000px; background: linear-gradient(#fff, #000);">{{@model.name}}</div>
+                  </template>
+                }
+              }
+            `,
             // Named `tall`, not `long`: an instance sharing its extensionless
             // alias with `long.gts` would make the render route's
             // extensionless card id ambiguous — the module source wins the
@@ -754,6 +766,14 @@ module(basename(import.meta.filename), function () {
                 attributes: { name: 'Tall Card' },
                 meta: {
                   adoptsFrom: { module: rri('./long'), name: 'Long' },
+                },
+              },
+            },
+            'huge.json': {
+              data: {
+                attributes: { name: 'Huge Card' },
+                meta: {
+                  adoptsFrom: { module: rri('./giant'), name: 'Giant' },
                 },
               },
             },
@@ -822,6 +842,41 @@ module(basename(import.meta.filename), function () {
       assert.strictEqual(png.height, 300, 'PNG matches the clip height');
       assert.strictEqual(response.width, 400, 'reports the clip width');
       assert.strictEqual(response.height, 300, 'reports the clip height');
+    });
+
+    test('fullPage rejects a document past the physical-pixel cap', async function (assert) {
+      // The parse cannot bound a fullPage capture's extent (the document's
+      // scroll size), so the capture path enforces the physical-pixel cap:
+      // a 6000px-tall document at 3× is ~18k physical px, past the 16384
+      // Chromium texture cap.
+      let { response } = await screenshot(`${realmURL}huge`, {
+        fullPage: true,
+        deviceScaleFactor: 3,
+      });
+      assert.strictEqual(response.status, 'error', 'capture is refused');
+      assert.true(
+        (response.error ?? '').includes('physical pixels'),
+        `error names the cap: ${response.error}`,
+      );
+    });
+
+    test('fullPage within the cap still captures at scale', async function (assert) {
+      // The same document is fine at 1× (6000 < 16384) — the cap composes
+      // with the scale factor rather than banning tall documents outright.
+      let { response } = await screenshot(`${realmURL}huge`, {
+        fullPage: true,
+      });
+      assert.strictEqual(response.status, 'ready', 'screenshot succeeded');
+      let png = decodePng(response.base64!);
+      assert.true(
+        png.height > 5000,
+        `captures the full document (got ${png.height})`,
+      );
+      assert.strictEqual(
+        png.height,
+        response.height,
+        'reported height matches the captured PNG height',
+      );
     });
 
     test('viewport override is restored on the pooled page between captures', async function (assert) {

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -8,6 +8,7 @@ import type {
   ModuleRenderResponse,
   FileExtractResponse,
   RenderRouteOptions,
+  ScreenshotCaptureSpec,
 } from '@cardstack/runtime-common';
 import type { Realm as RuntimeRealm } from '@cardstack/runtime-common';
 import type { Prerenderer } from '../prerender/index.ts';
@@ -226,6 +227,24 @@ function makeStubPagePool(opts: StubPagePoolOptions) {
       }),
   );
   return { pool, contextsCreated, contextsClosed };
+}
+
+// Decode a base64 PNG's signature + IHDR dimensions without an image library.
+// The 8-byte PNG signature is followed by the IHDR chunk, whose big-endian
+// width/height live at byte offsets 16 and 20.
+function decodePng(base64: string): {
+  isPng: boolean;
+  width: number;
+  height: number;
+} {
+  let buf = Buffer.from(base64, 'base64');
+  let signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  let isPng = buf.length >= 24 && signature.every((byte, i) => buf[i] === byte);
+  return {
+    isPng,
+    width: isPng ? buf.readUInt32BE(16) : 0,
+    height: isPng ? buf.readUInt32BE(20) : 0,
+  };
 }
 
 module(basename(import.meta.filename), function () {
@@ -636,6 +655,238 @@ module(basename(import.meta.filename), function () {
       } finally {
         await flakyPatch.restore();
       }
+    });
+  });
+
+  module('prerender - screenshot capture', function (hooks) {
+    let realmURL = 'http://127.0.0.1:4461/test/';
+    let prerenderServerURL = new URL(realmURL).origin;
+    let testUserId = '@user1:localhost';
+    let permissions: RealmPermissions = {
+      [realmURL]: ['read', 'write', 'realm-owner'],
+    };
+    let prerenderer: Prerenderer;
+    let realm: RuntimeRealm;
+    let auth = () => {
+      let sessions = JSON.parse(
+        testCreatePrerenderAuth(testUserId, permissions),
+      ) as Record<string, string>;
+      let token = sessions[realmURL];
+      if (token) {
+        sessions[new URL(realmURL).origin + '/'] = token;
+      }
+      return JSON.stringify(sessions);
+    };
+
+    let screenshot = (cardURL: string, captureSpec?: ScreenshotCaptureSpec) =>
+      prerenderer.prerenderScreenshot({
+        realm: realmURL,
+        url: cardURL,
+        auth: auth(),
+        format: 'isolated',
+        ...(captureSpec ? { captureSpec } : {}),
+      });
+
+    hooks.before(async () => {
+      prerenderer = getPrerendererForTesting({
+        maxPages: 2,
+        serverURL: prerenderServerURL,
+      });
+    });
+
+    hooks.after(async () => {
+      await prerenderer.stop();
+    });
+
+    hooks.afterEach(async () => {
+      await prerenderer.disposeAffinity({
+        affinityType: 'realm',
+        affinityValue: realmURL,
+      });
+    });
+
+    setupPermissionedRealmsCached(hooks, {
+      realms: [
+        {
+          realmURL,
+          permissions: {
+            '*': ['read'],
+            [testUserId]: ['read', 'write', 'realm-owner'],
+          },
+          fileSystem: {
+            'person.gts': `
+              import { CardDef, field, contains, StringField, Component } from '@cardstack/base/card-api';
+              export class Person extends CardDef {
+                static displayName = "Person";
+                @field name = contains(StringField);
+                static isolated = class extends Component<typeof this> {
+                  <template>{{@model.name}}</template>
+                }
+              }
+            `,
+            'long.gts': `
+              import { CardDef, field, contains, StringField, Component } from '@cardstack/base/card-api';
+              export class Long extends CardDef {
+                static displayName = "Long";
+                @field name = contains(StringField);
+                static isolated = class extends Component<typeof this> {
+                  <template>
+                    <div style="height: 1500px; background: linear-gradient(#fff, #000);">{{@model.name}}</div>
+                  </template>
+                }
+              }
+            `,
+            '1.json': {
+              data: {
+                attributes: { name: 'Maple' },
+                meta: {
+                  adoptsFrom: { module: rri('./person'), name: 'Person' },
+                },
+              },
+            },
+            'long.json': {
+              data: {
+                attributes: { name: 'Tall Card' },
+                meta: {
+                  adoptsFrom: { module: rri('./long'), name: 'Long' },
+                },
+              },
+            },
+          },
+        },
+      ],
+      onRealmSetup({ realms: setupRealms }) {
+        ({ realm } = setupRealms[0]);
+        permissions = {
+          [realmURL]: ['read', 'write', 'realm-owner'],
+        };
+      },
+    });
+
+    test('default capture is a PNG at the 800x600 viewport', async function (assert) {
+      let { response } = await screenshot(`${realmURL}1`);
+      assert.strictEqual(response.status, 'ready', 'screenshot succeeded');
+      assert.ok(response.base64, 'returns base64 image data');
+      let png = decodePng(response.base64!);
+      assert.true(png.isPng, 'payload is a PNG (magic bytes)');
+      assert.strictEqual(png.width, 800, 'PNG is 800px wide');
+      assert.strictEqual(png.height, 600, 'PNG is 600px tall');
+      assert.strictEqual(response.width, 800, 'reports 800 CSS px wide');
+      assert.strictEqual(response.height, 600, 'reports 600 CSS px tall');
+    });
+
+    test('viewport override widens the capture to 1280', async function (assert) {
+      let { response } = await screenshot(`${realmURL}1`, {
+        viewport: { width: 1280, height: 720 },
+      });
+      assert.strictEqual(response.status, 'ready', 'screenshot succeeded');
+      let png = decodePng(response.base64!);
+      assert.true(png.isPng, 'payload is a PNG');
+      assert.strictEqual(png.width, 1280, 'PNG is 1280px wide');
+      assert.strictEqual(png.height, 720, 'PNG is 720px tall');
+      assert.strictEqual(response.width, 1280, 'reports 1280 CSS px wide');
+    });
+
+    test('fullPage captures beyond the viewport height for a long card', async function (assert) {
+      let { response } = await screenshot(`${realmURL}long`, {
+        fullPage: true,
+      });
+      assert.strictEqual(response.status, 'ready', 'screenshot succeeded');
+      let png = decodePng(response.base64!);
+      assert.true(png.isPng, 'payload is a PNG');
+      assert.strictEqual(png.width, 800, 'PNG keeps the 800px viewport width');
+      assert.true(
+        png.height > 600,
+        `fullPage is taller than the 600px viewport (got ${png.height})`,
+      );
+      assert.strictEqual(
+        png.height,
+        response.height,
+        'reported height matches the captured PNG height',
+      );
+    });
+
+    test('clip captures exactly the requested region', async function (assert) {
+      let { response } = await screenshot(`${realmURL}long`, {
+        clip: { x: 0, y: 0, width: 400, height: 300 },
+      });
+      assert.strictEqual(response.status, 'ready', 'screenshot succeeded');
+      let png = decodePng(response.base64!);
+      assert.true(png.isPng, 'payload is a PNG');
+      assert.strictEqual(png.width, 400, 'PNG matches the clip width');
+      assert.strictEqual(png.height, 300, 'PNG matches the clip height');
+      assert.strictEqual(response.width, 400, 'reports the clip width');
+      assert.strictEqual(response.height, 300, 'reports the clip height');
+    });
+
+    test('viewport override is restored on the pooled page between captures', async function (assert) {
+      // A leaked viewport would silently resize the next capture (and any index
+      // prerender) reusing this pooled page. Custom capture in the middle, plain
+      // captures on either side must both stay at the default viewport.
+      let before = decodePng(
+        (await screenshot(`${realmURL}1`)).response.base64!,
+      );
+      assert.strictEqual(before.width, 800, 'first plain capture is 800 wide');
+
+      let custom = decodePng(
+        (
+          await screenshot(`${realmURL}1`, {
+            viewport: { width: 1280, height: 900 },
+            deviceScaleFactor: 2,
+          })
+        ).response.base64!,
+      );
+      assert.strictEqual(
+        custom.width,
+        2560,
+        'custom capture is 1280 * 2x wide',
+      );
+
+      let after = decodePng(
+        (await screenshot(`${realmURL}1`)).response.base64!,
+      );
+      assert.strictEqual(
+        after.width,
+        800,
+        'viewport restored: later plain capture is back to 800 wide',
+      );
+      assert.strictEqual(after.height, 600, 'restored height is 600');
+    });
+
+    test('a custom-viewport capture leaves indexed HTML unchanged', async function (assert) {
+      let cardURL = `${realmURL}1`;
+      await realm.realmIndexUpdater.fullIndex();
+      realm.__testOnlyClearCaches();
+      let baseline = await prerenderCard(prerenderer, {
+        affinityType: 'realm',
+        affinityValue: realmURL,
+        realm: realmURL,
+        url: cardURL,
+        auth: auth(),
+      });
+
+      // Capture at a large custom viewport + 2x scale on the same affinity's
+      // pooled page.
+      await screenshot(cardURL, {
+        viewport: { width: 1440, height: 2000 },
+        deviceScaleFactor: 2,
+      });
+
+      await realm.realmIndexUpdater.fullIndex();
+      realm.__testOnlyClearCaches();
+      let after = await prerenderCard(prerenderer, {
+        affinityType: 'realm',
+        affinityValue: realmURL,
+        realm: realmURL,
+        url: cardURL,
+        auth: auth(),
+      });
+
+      assert.strictEqual(
+        cleanWhiteSpace(after.response.isolatedHTML ?? ''),
+        cleanWhiteSpace(baseline.response.isolatedHTML ?? ''),
+        'indexed isolated HTML is identical before and after the screenshot',
+      );
     });
   });
 

--- a/packages/realm-server/tests/screenshot-card-test.ts
+++ b/packages/realm-server/tests/screenshot-card-test.ts
@@ -14,7 +14,10 @@ import {
   putMedia,
   query,
 } from '@cardstack/runtime-common';
-import { estimateScreenshotQueueWait } from '@cardstack/runtime-common/jobs/screenshot-card';
+import {
+  chooseScreenshotCardCoalesceDecision,
+  estimateScreenshotQueueWait,
+} from '@cardstack/runtime-common/jobs/screenshot-card';
 import type {
   DBAdapter,
   QueuePublisher,
@@ -23,6 +26,7 @@ import type {
   PgPrimitive,
   ScreenshotPrerenderResponse,
 } from '@cardstack/runtime-common';
+import type { QueueJobSpec } from '@cardstack/runtime-common/queue';
 import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import type { PgAdapter } from '@cardstack/postgres';
 
@@ -207,6 +211,46 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('a default-valued captureSpec normalizes to null', async function (assert) {
+      // `{ fullPage: false, deviceScaleFactor: 1 }` means the same capture
+      // as no spec at all; eliding the defaults keeps it classified as
+      // canonical (ledger fast path, persistence, served URL).
+      let dbAdapter = makeDbAdapter();
+      let { queue, published } = makeQueue({
+        status: 'ready',
+      } as unknown as PgPrimitive);
+      let app = buildApp(buildArgs(dbAdapter, queue));
+      let token = createJWT(
+        { user: '@someone:localhost', sessionRoom: '!room:localhost' },
+        realmSecretSeed,
+      );
+      let realmURL = 'http://example.test/';
+      let cardId = `${realmURL}Person/fadhlan`;
+
+      await supertest(app.callback())
+        .post('/_screenshot-card')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          data: {
+            type: 'screenshot-card',
+            attributes: {
+              realmURL,
+              cardId,
+              format: 'isolated',
+              captureSpec: { fullPage: false, deviceScaleFactor: 1 },
+            },
+          },
+        })
+        .expect(201);
+
+      assert.strictEqual(published.length, 1, 'published exactly one job');
+      assert.strictEqual(
+        (published[0]?.args as Record<string, unknown>)?.captureSpec,
+        null,
+        'default-valued spec reaches the job as null',
+      );
+    });
+
     async function expectCaptureSpecRejected(
       assert: Assert,
       captureSpec: unknown,
@@ -282,6 +326,58 @@ module(basename(import.meta.filename), function () {
           clip: { x: 100, y: 0, width: 400, height: 100 },
         },
         'clip',
+      );
+    });
+
+    test('rejects clip extent beyond the viewport caps even without a viewport', async function (assert) {
+      // Puppeteer captures beyond the viewport by default, so an unbounded
+      // clip would be a way around the viewport cost caps.
+      await expectCaptureSpecRejected(
+        assert,
+        { clip: { x: 0, y: 0, width: 1_000_000_000, height: 100 } },
+        'clip x + width',
+      );
+      await expectCaptureSpecRejected(
+        assert,
+        { clip: { x: 0, y: 16_000, width: 100, height: 1_000 } },
+        'clip y + height',
+      );
+    });
+
+    test('rejects an unknown captureSpec field by name', async function (assert) {
+      // A dropped typo would silently classify the request as canonical and
+      // serve the wrong image.
+      await expectCaptureSpecRejected(assert, { fullpage: true }, 'fullpage');
+    });
+
+    test('rejects an unknown nested captureSpec field by name', async function (assert) {
+      await expectCaptureSpecRejected(
+        assert,
+        { clip: { x: 0, y: 0, width: 100, height: 100, scale: 2 } },
+        'clip.scale',
+      );
+      await expectCaptureSpecRejected(
+        assert,
+        { viewport: { width: 800, height: 600, dsf: 2 } },
+        'viewport.dsf',
+      );
+    });
+
+    test('rejects physical pixels per edge beyond the texture cap', async function (assert) {
+      // Each CSS cap alone passes; the product with deviceScaleFactor is
+      // what exceeds the Chromium texture limit.
+      await expectCaptureSpecRejected(
+        assert,
+        { viewport: { width: 800, height: 6_000 }, deviceScaleFactor: 3 },
+        'viewport.height × deviceScaleFactor',
+      );
+      await expectCaptureSpecRejected(
+        assert,
+        {
+          clip: { x: 0, y: 0, width: 100, height: 6_000 },
+          deviceScaleFactor: 3,
+        },
+        'clip.height × deviceScaleFactor',
       );
     });
 
@@ -636,6 +732,39 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('a default-valued captureSpec still answers from the ledger', async function (assert) {
+      // `{ fullPage: false, deviceScaleFactor: 1 }` is the canonical capture
+      // spelled explicitly — it must keep the ledger fast path rather than
+      // classify as a custom capture.
+      await seedInstanceRow();
+      await putMedia(dbAdapter, adapter, {
+        realmURL: REALM_URL,
+        sourceURL: CARD_ID,
+        captureSpecHash: await captureSpecHash({ format: 'isolated' }),
+        sourceGeneration: 1,
+        bytes: PNG_BYTES,
+        contentType: 'image/png',
+        lane: 'on-demand',
+        width: 800,
+        height: 600,
+      });
+      let { queue, published } = makePersistQueue('ready');
+
+      let response = await post(persistApp(queue), {
+        realmURL: REALM_URL,
+        cardId: CARD_ID,
+        format: 'isolated',
+        captureSpec: { fullPage: false, deviceScaleFactor: 1 },
+      }).expect(201);
+
+      assert.deepEqual(published, [], 'no job was enqueued');
+      assert.strictEqual(
+        response.body.data.attributes.captures[0].url,
+        `${REALM_URL}_screenshot/Person/fadhlan`,
+        'the canonical served URL is returned',
+      );
+    });
+
     test('a custom captureSpec bypasses the ledger and never persists', async function (assert) {
       await seedInstanceRow();
       // A canonical (format-only) capture exists; the custom-spec request
@@ -917,6 +1046,76 @@ module(basename(import.meta.filename), function () {
         differentRunAs.hasTwin,
         'a different-runAs job is not a twin',
       );
+    });
+  });
+
+  module('screenshot-card coalesce decision', function () {
+    const PERSIST = {
+      realmURL: 'http://example.test/',
+      sourceURL: 'http://example.test/Person/fadhlan',
+      captureSpecHash: 'abc123',
+      sourceGeneration: 1,
+      lane: 'on-demand',
+    };
+
+    function jobSpec(args: Record<string, unknown>): QueueJobSpec {
+      return {
+        jobType: 'screenshot-card',
+        concurrencyGroup: 'screenshot:http://example.test/',
+        timeout: 60,
+        priority: 0,
+        args: args as PgPrimitive,
+      };
+    }
+
+    function canonicalArgs(): Record<string, unknown> {
+      return {
+        cardId: PERSIST.sourceURL,
+        format: 'isolated',
+        runAs: '@owner:localhost',
+        captureSpec: null,
+        persist: PERSIST,
+      };
+    }
+
+    test('canonical persist-carrying twins join', function (assert) {
+      let decision = chooseScreenshotCardCoalesceDecision({
+        incoming: jobSpec(canonicalArgs()),
+        candidates: [{ ...jobSpec(canonicalArgs()), id: 7 }],
+        inFlightCandidates: [],
+      });
+      assert.deepEqual(decision, { type: 'join', jobId: 7 });
+    });
+
+    test('an incoming job with captureSpec overrides always inserts', function (assert) {
+      // The persist identity cannot represent the overrides, so joining a
+      // canonical twin would hand this caller the wrong image.
+      let decision = chooseScreenshotCardCoalesceDecision({
+        incoming: jobSpec({
+          ...canonicalArgs(),
+          captureSpec: { viewport: { width: 1280, height: 800 } },
+        }),
+        candidates: [{ ...jobSpec(canonicalArgs()), id: 7 }],
+        inFlightCandidates: [],
+      });
+      assert.deepEqual(decision, { type: 'insert' });
+    });
+
+    test('a candidate with captureSpec overrides is never a twin', function (assert) {
+      let decision = chooseScreenshotCardCoalesceDecision({
+        incoming: jobSpec(canonicalArgs()),
+        candidates: [
+          {
+            ...jobSpec({
+              ...canonicalArgs(),
+              captureSpec: { deviceScaleFactor: 2 },
+            }),
+            id: 7,
+          },
+        ],
+        inFlightCandidates: [],
+      });
+      assert.deepEqual(decision, { type: 'insert' });
     });
   });
 });

--- a/packages/realm-server/tests/screenshot-card-test.ts
+++ b/packages/realm-server/tests/screenshot-card-test.ts
@@ -163,10 +163,126 @@ module(basename(import.meta.filename), function () {
         runAs: '@someone:localhost',
         cardId,
         format: 'isolated',
+        captureSpec: null,
         // The POST surface returns the capture in its response body rather
         // than recording it in the MediaCache ledger.
         persist: null,
       });
+    });
+
+    test('threads a valid captureSpec into the enqueued job', async function (assert) {
+      let dbAdapter = makeDbAdapter();
+      let { queue, published } = makeQueue({
+        status: 'ready',
+      } as unknown as PgPrimitive);
+      let app = buildApp(buildArgs(dbAdapter, queue));
+      let token = createJWT(
+        { user: '@someone:localhost', sessionRoom: '!room:localhost' },
+        realmSecretSeed,
+      );
+      let realmURL = 'http://example.test/';
+      let cardId = `${realmURL}Person/fadhlan`;
+      let captureSpec = {
+        viewport: { width: 1280, height: 800 },
+        deviceScaleFactor: 2,
+        clip: { x: 0, y: 0, width: 400, height: 300 },
+      };
+
+      await supertest(app.callback())
+        .post('/_screenshot-card')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          data: {
+            type: 'screenshot-card',
+            attributes: { realmURL, cardId, format: 'isolated', captureSpec },
+          },
+        })
+        .expect(201);
+
+      assert.strictEqual(published.length, 1, 'published exactly one job');
+      assert.deepEqual(
+        (published[0]?.args as Record<string, unknown>)?.captureSpec,
+        captureSpec,
+        'captureSpec forwarded verbatim into the job args',
+      );
+    });
+
+    async function expectCaptureSpecRejected(
+      assert: Assert,
+      captureSpec: unknown,
+      offendingField: string,
+    ) {
+      let { queue, published } = makeQueue({ status: 'ready' });
+      let app = buildApp(buildArgs(makeDbAdapter(), queue));
+      let token = createJWT(
+        { user: '@someone:localhost', sessionRoom: '!room:localhost' },
+        realmSecretSeed,
+      );
+
+      let response = await supertest(app.callback())
+        .post('/_screenshot-card')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          data: {
+            type: 'screenshot-card',
+            attributes: {
+              realmURL: 'http://example.test/',
+              cardId: 'http://example.test/Person/fadhlan',
+              format: 'isolated',
+              captureSpec,
+            },
+          },
+        });
+
+      assert.strictEqual(response.status, 400, '400 for invalid captureSpec');
+      assert.ok(
+        response.text.includes(offendingField),
+        `names the offending field (${offendingField}) in the error: ${response.text}`,
+      );
+      assert.deepEqual(published, [], 'does not enqueue any job');
+    }
+
+    test('rejects oversize viewport width', async function (assert) {
+      await expectCaptureSpecRejected(
+        assert,
+        { viewport: { width: 5000, height: 800 } },
+        'viewport.width',
+      );
+    });
+
+    test('rejects oversize viewport height', async function (assert) {
+      await expectCaptureSpecRejected(
+        assert,
+        { viewport: { width: 800, height: 20000 } },
+        'viewport.height',
+      );
+    });
+
+    test('rejects deviceScaleFactor above the cap', async function (assert) {
+      await expectCaptureSpecRejected(
+        assert,
+        { deviceScaleFactor: 4 },
+        'deviceScaleFactor',
+      );
+    });
+
+    test('rejects fullPage combined with clip', async function (assert) {
+      await expectCaptureSpecRejected(
+        assert,
+        { fullPage: true, clip: { x: 0, y: 0, width: 100, height: 100 } },
+        'fullPage',
+      );
+    });
+
+    test('rejects clip that exceeds the viewport', async function (assert) {
+      await expectCaptureSpecRejected(
+        assert,
+        {
+          viewport: { width: 400, height: 300 },
+          clip: { x: 100, y: 0, width: 400, height: 100 },
+        },
+        'clip',
+      );
     });
 
     test('rejects without auth', async function (assert) {
@@ -517,6 +633,55 @@ module(basename(import.meta.filename), function () {
       assert.strictEqual(
         attrs.captures[0].url,
         `${REALM_URL}_screenshot/Person/fadhlan`,
+      );
+    });
+
+    test('a custom captureSpec bypasses the ledger and never persists', async function (assert) {
+      await seedInstanceRow();
+      // A canonical (format-only) capture exists; the custom-spec request
+      // must not serve it — the ledger identity cannot represent viewport /
+      // scale / clip overrides, so a canonical entry is the wrong image for
+      // this request, and persisting the custom render under that identity
+      // would poison the canonical `_screenshot/` URL.
+      await putMedia(dbAdapter, adapter, {
+        realmURL: REALM_URL,
+        sourceURL: CARD_ID,
+        captureSpecHash: await captureSpecHash({ format: 'isolated' }),
+        sourceGeneration: 1,
+        bytes: PNG_BYTES,
+        contentType: 'image/png',
+        lane: 'on-demand',
+        width: 800,
+        height: 600,
+      });
+      let { queue, published } = makePersistQueue('ready');
+      let captureSpec = { viewport: { width: 1280, height: 800 } };
+
+      let response = await post(persistApp(queue), {
+        realmURL: REALM_URL,
+        cardId: CARD_ID,
+        format: 'isolated',
+        captureSpec,
+      }).expect(201);
+
+      assert.strictEqual(
+        published.length,
+        1,
+        'renders fresh instead of answering from the canonical ledger entry',
+      );
+      assert.deepEqual(
+        (published[0]?.args as any)?.captureSpec,
+        captureSpec,
+        'the custom spec reaches the job',
+      );
+      assert.strictEqual(
+        (published[0]?.args as any)?.persist,
+        null,
+        'the custom capture is never persisted',
+      );
+      assert.false(
+        'captures' in response.body.data.attributes,
+        'no served URL for a capture the ledger cannot key',
       );
     });
 

--- a/packages/runtime-common/capture-spec.ts
+++ b/packages/runtime-common/capture-spec.ts
@@ -35,6 +35,254 @@ export function hasCaptureSpecOverrides(
   return !!captureSpec && Object.keys(captureSpec).length > 0;
 }
 
+// ---------------------------------------------------------------------------
+// ScreenshotCaptureSpec bounds + strict parse — one enforcement point for
+// every surface that accepts a spec off the wire (the realm-server's POST
+// /_screenshot-card body and the prerender server's /prerender-screenshot
+// route), and the home of the caps the capture path itself enforces for the
+// extents only it can know (a fullPage capture's document size).
+// ---------------------------------------------------------------------------
+
+// Chromium caps a single texture at 16384px; a viewport wider than 4096px is
+// well past any real card layout and mostly a way to force a huge capture.
+export const SCREENSHOT_MAX_VIEWPORT_WIDTH = 4096;
+export const SCREENSHOT_MAX_VIEWPORT_HEIGHT = 16384;
+// A 3× scale already covers retina/hi-dpi; higher just multiplies pixel cost.
+export const SCREENSHOT_MAX_DEVICE_SCALE_FACTOR = 3;
+// The Chromium single-texture cap the viewport bounds are derived from,
+// enforced on *physical* pixels: CSS dimension × deviceScaleFactor. The CSS
+// caps alone would admit e.g. a 16384-tall viewport at 3× (~49k physical px).
+// A fullPage capture's extent (the document's scroll size) is unknowable at
+// parse time, so the capture path checks it against this cap itself.
+export const SCREENSHOT_MAX_PHYSICAL_EDGE_PX = 16384;
+
+// Result of validating a raw `captureSpec` value. On success `captureSpec`
+// is the normalized spec — null when the value was absent or carried no
+// overrides (default-valued fields are elided), so `null` exactly means
+// "the canonical capture"; on failure `error` names the offending field.
+export type ScreenshotCaptureSpecParse =
+  | { captureSpec: ScreenshotCaptureSpec | null; error?: undefined }
+  | { captureSpec?: undefined; error: string };
+
+const CAPTURE_SPEC_FIELDS = new Set([
+  'viewport',
+  'deviceScaleFactor',
+  'fullPage',
+  'clip',
+]);
+const CAPTURE_SPEC_VIEWPORT_FIELDS = new Set(['width', 'height']);
+const CAPTURE_SPEC_CLIP_FIELDS = new Set(['x', 'y', 'width', 'height']);
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function parseScreenshotCaptureSpec(
+  raw: unknown,
+): ScreenshotCaptureSpecParse {
+  if (raw === undefined || raw === null) {
+    return { captureSpec: null };
+  }
+  if (!isPlainObject(raw)) {
+    return { error: 'captureSpec must be an object' };
+  }
+
+  // Strict per the capture-spec contract: an unrecognized field is refused by
+  // name rather than dropped — silently dropping a typo'd `fullpage: true`
+  // would classify the request as canonical and serve (or persist) the wrong
+  // image.
+  for (let key of Object.keys(raw)) {
+    if (!CAPTURE_SPEC_FIELDS.has(key)) {
+      return { error: `captureSpec.${key} is not a supported field` };
+    }
+  }
+
+  let spec: ScreenshotCaptureSpec = {};
+
+  if (raw.viewport !== undefined) {
+    let viewport = raw.viewport;
+    if (!isPlainObject(viewport)) {
+      return {
+        error:
+          'captureSpec.viewport must have positive integer width and height',
+      };
+    }
+    for (let key of Object.keys(viewport)) {
+      if (!CAPTURE_SPEC_VIEWPORT_FIELDS.has(key)) {
+        return {
+          error: `captureSpec.viewport.${key} is not a supported field`,
+        };
+      }
+    }
+    if (
+      !isPositiveInteger(viewport.width) ||
+      !isPositiveInteger(viewport.height)
+    ) {
+      return {
+        error:
+          'captureSpec.viewport must have positive integer width and height',
+      };
+    }
+    if (viewport.width > SCREENSHOT_MAX_VIEWPORT_WIDTH) {
+      return {
+        error: `captureSpec.viewport.width must be <= ${SCREENSHOT_MAX_VIEWPORT_WIDTH}`,
+      };
+    }
+    if (viewport.height > SCREENSHOT_MAX_VIEWPORT_HEIGHT) {
+      return {
+        error: `captureSpec.viewport.height must be <= ${SCREENSHOT_MAX_VIEWPORT_HEIGHT}`,
+      };
+    }
+    spec.viewport = { width: viewport.width, height: viewport.height };
+  }
+
+  if (raw.deviceScaleFactor !== undefined) {
+    let scale = raw.deviceScaleFactor;
+    if (typeof scale !== 'number' || !Number.isFinite(scale) || scale <= 0) {
+      return {
+        error: 'captureSpec.deviceScaleFactor must be a positive number',
+      };
+    }
+    if (scale > SCREENSHOT_MAX_DEVICE_SCALE_FACTOR) {
+      return {
+        error: `captureSpec.deviceScaleFactor must be <= ${SCREENSHOT_MAX_DEVICE_SCALE_FACTOR}`,
+      };
+    }
+    // 1 is the engine default: elide it so `{ deviceScaleFactor: 1 }` means
+    // the same capture as no spec at all and keeps the canonical fast path.
+    if (scale !== 1) {
+      spec.deviceScaleFactor = scale;
+    }
+  }
+
+  if (raw.fullPage !== undefined) {
+    if (typeof raw.fullPage !== 'boolean') {
+      return { error: 'captureSpec.fullPage must be a boolean' };
+    }
+    // false is the engine default: elide it (see deviceScaleFactor above).
+    if (raw.fullPage) {
+      spec.fullPage = true;
+    }
+  }
+
+  if (raw.clip !== undefined) {
+    let clip = raw.clip;
+    if (!isPlainObject(clip)) {
+      return {
+        error:
+          'captureSpec.clip must have non-negative x/y and positive integer width/height',
+      };
+    }
+    for (let key of Object.keys(clip)) {
+      if (!CAPTURE_SPEC_CLIP_FIELDS.has(key)) {
+        return { error: `captureSpec.clip.${key} is not a supported field` };
+      }
+    }
+    if (
+      typeof clip.x !== 'number' ||
+      typeof clip.y !== 'number' ||
+      !Number.isFinite(clip.x) ||
+      !Number.isFinite(clip.y) ||
+      clip.x < 0 ||
+      clip.y < 0 ||
+      !isPositiveInteger(clip.width) ||
+      !isPositiveInteger(clip.height)
+    ) {
+      return {
+        error:
+          'captureSpec.clip must have non-negative x/y and positive integer width/height',
+      };
+    }
+    // The clip's extent is bounded by the same caps as the viewport whether
+    // or not one was sent: Puppeteer captures beyond the viewport by default
+    // (`captureBeyondViewport`), so an unbounded clip would be a way around
+    // the viewport cost caps.
+    if (clip.x + clip.width > SCREENSHOT_MAX_VIEWPORT_WIDTH) {
+      return {
+        error: `captureSpec.clip x + width must be <= ${SCREENSHOT_MAX_VIEWPORT_WIDTH}`,
+      };
+    }
+    if (clip.y + clip.height > SCREENSHOT_MAX_VIEWPORT_HEIGHT) {
+      return {
+        error: `captureSpec.clip y + height must be <= ${SCREENSHOT_MAX_VIEWPORT_HEIGHT}`,
+      };
+    }
+    spec.clip = {
+      x: clip.x,
+      y: clip.y,
+      width: clip.width,
+      height: clip.height,
+    };
+  }
+
+  if (spec.fullPage && spec.clip) {
+    return {
+      error: 'captureSpec cannot set both fullPage and clip',
+    };
+  }
+
+  // Tighter containment when the caller declared a viewport: the layout was
+  // requested at that size, so a clip past its edge is caller error — the
+  // region would be unstyled overflow or blank area past the document edge.
+  if (spec.clip && spec.viewport) {
+    if (spec.clip.x + spec.clip.width > spec.viewport.width) {
+      return {
+        error: 'captureSpec.clip exceeds captureSpec.viewport.width',
+      };
+    }
+    if (spec.clip.y + spec.clip.height > spec.viewport.height) {
+      return {
+        error: 'captureSpec.clip exceeds captureSpec.viewport.height',
+      };
+    }
+  }
+
+  // The CSS caps compose with the scale factor: what Chromium renders is
+  // physical pixels, and each capture edge must stay under the texture cap.
+  // fullPage's extent (the document scroll size) isn't knowable here; the
+  // capture path enforces the same cap on it at capture time.
+  let effectiveScale = spec.deviceScaleFactor ?? 1;
+  if (spec.viewport) {
+    if (
+      spec.viewport.width * effectiveScale >
+      SCREENSHOT_MAX_PHYSICAL_EDGE_PX
+    ) {
+      return {
+        error: `captureSpec.viewport.width × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
+      };
+    }
+    if (
+      spec.viewport.height * effectiveScale >
+      SCREENSHOT_MAX_PHYSICAL_EDGE_PX
+    ) {
+      return {
+        error: `captureSpec.viewport.height × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
+      };
+    }
+  }
+  if (spec.clip) {
+    if (spec.clip.width * effectiveScale > SCREENSHOT_MAX_PHYSICAL_EDGE_PX) {
+      return {
+        error: `captureSpec.clip.width × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
+      };
+    }
+    if (spec.clip.height * effectiveScale > SCREENSHOT_MAX_PHYSICAL_EDGE_PX) {
+      return {
+        error: `captureSpec.clip.height × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels`,
+      };
+    }
+  }
+
+  // A spec whose every field matched an engine default normalizes to null:
+  // it means the canonical capture, and null is what consumers key that
+  // classification on.
+  return { captureSpec: Object.keys(spec).length > 0 ? spec : null };
+}
+
 // The DSL's parameter surface grows with the capture engine; these names are
 // reserved for the engine capabilities the project's URL grammar assigns
 // them, and refused (never ignored) while the engine lacks them.

--- a/packages/runtime-common/capture-spec.ts
+++ b/packages/runtime-common/capture-spec.ts
@@ -1,5 +1,7 @@
 import { computeMediaCacheKey } from './media-cache.ts';
 
+import type { ScreenshotCaptureSpec } from './index.ts';
+
 // The capture spec: every way a screenshot capture can be parameterized,
 // shared by the POST /_screenshot-card body and the GET `_screenshot/` URL
 // DSL so the two surfaces validate identically and one capture satisfies
@@ -19,6 +21,18 @@ export function isCaptureFormat(value: unknown): value is CaptureFormat {
 
 export interface CaptureSpec {
   format: CaptureFormat;
+}
+
+// Whether a screenshot job's per-capture overrides (viewport / scale /
+// fullPage / clip) make it a non-canonical render. The canonical capture
+// identity (and thus the MediaCache ledger and job coalescing) cannot
+// represent these overrides, so everything keyed on that identity must treat
+// an override-carrying capture as outside it: never persisted under a ledger
+// key, never joined to (or by) a canonical twin.
+export function hasCaptureSpecOverrides(
+  captureSpec: ScreenshotCaptureSpec | null | undefined,
+): boolean {
+  return !!captureSpec && Object.keys(captureSpec).length > 0;
 }
 
 // The DSL's parameter surface grows with the capture engine; these names are

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -933,8 +933,9 @@ export type ScreenshotCaptureSpec = {
   // Capture the full scrollable document rather than just the viewport. Mutually
   // exclusive with `clip`.
   fullPage?: boolean;
-  // CSS-pixel region to capture, passed straight to `page.screenshot`. Must sit
-  // within the viewport. Mutually exclusive with `fullPage`.
+  // CSS-pixel region to capture, passed straight to `page.screenshot`. Its
+  // extent is bounded by the same caps as the viewport (and must sit within
+  // the viewport when one is given). Mutually exclusive with `fullPage`.
   clip?: { x: number; y: number; width: number; height: number };
 };
 

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -916,11 +916,35 @@ export type RunCommandResponse = {
   meta?: PrerenderResponseMeta;
 };
 
+// Optional per-capture overrides for a screenshot render. All fields are
+// JSON-serializable so this rides through the worker queue on
+// `ScreenshotCardArgs`. Bounds are enforced by the realm-server handler
+// (`handle-screenshot-card.ts`) before the job is enqueued; the capture path
+// (`captureScreenshot`) treats these as already-validated but still rejects the
+// mutually-exclusive `fullPage` + `clip` combination defensively.
+export type ScreenshotCaptureSpec = {
+  // CSS-pixel render viewport applied via `page.setViewport` before the render
+  // settles, then restored so pooled pages don't leak the size into later index
+  // prerenders.
+  viewport?: { width: number; height: number };
+  // Puppeteer device scale factor (1 = CSS px, 2 = retina). Multiplies the
+  // PNG's physical pixel dimensions without changing the reported CSS dims.
+  deviceScaleFactor?: number;
+  // Capture the full scrollable document rather than just the viewport. Mutually
+  // exclusive with `clip`.
+  fullPage?: boolean;
+  // CSS-pixel region to capture, passed straight to `page.screenshot`. Must sit
+  // within the viewport. Mutually exclusive with `fullPage`.
+  clip?: { x: number; y: number; width: number; height: number };
+};
+
 export type ScreenshotPrerenderArgs = {
   realm: string;
   url: string;
   auth: string;
   format: 'isolated' | 'embedded';
+  // Optional per-capture overrides (viewport, scale, fullPage, clip).
+  captureSpec?: ScreenshotCaptureSpec;
   // Worker-job priority threaded through from the producer side. See
   // ModulePrerenderArgs for the contract.
   priority?: number;

--- a/packages/runtime-common/jobs/screenshot-card.ts
+++ b/packages/runtime-common/jobs/screenshot-card.ts
@@ -5,7 +5,11 @@ import {
   type QueueCoalesceDecision,
   type QueuePublisher,
 } from '../queue.ts';
-import type { ScreenshotPrerenderResponse, DBAdapter } from '../index.ts';
+import {
+  hasCaptureSpecOverrides,
+  type ScreenshotPrerenderResponse,
+  type DBAdapter,
+} from '../index.ts';
 import type {
   ScreenshotCardArgs,
   ScreenshotPersistArgs,
@@ -18,9 +22,10 @@ export const SCREENSHOT_CARD_JOB_TIMEOUT_SEC = 60;
 // this two simultaneous misses for the same spec would each run a full
 // render (the store's dedupe-on-write only saves the second upload, not the
 // Chrome work). A twin must match the whole capture identity — card, format,
-// render identity, and persist target — since joining hands the incoming
-// caller the twin's result verbatim. Queued and in-flight twins both join;
-// an in-flight join just registers a late waiter on the running job.
+// render identity, captureSpec, and persist target — since joining hands the
+// incoming caller the twin's result verbatim. Queued and in-flight twins
+// both join; an in-flight join just registers a late waiter on the running
+// job.
 //
 // Only persist-carrying jobs coalesce — both surfaces publish them: the GET
 // `_screenshot/` lane always, `POST /_screenshot-card` whenever the instance
@@ -29,16 +34,25 @@ export const SCREENSHOT_CARD_JOB_TIMEOUT_SEC = 60;
 // different revision. A `persist: null` job (unindexed card, or a server
 // with no MediaCache) is a render-now request whose identity carries no
 // freshness axis — an in-flight twin could be up to a reservation-lease old
-// and of a pre-edit card — so those always insert. The `runAs` equality
-// below keeps joins within one render identity: the GET lane renders as the
-// realm owner and the POST lane as the requester, so cross-surface twins
-// never join even when their persist targets match.
-function chooseScreenshotCardCoalesceDecision(
+// and of a pre-edit card — so those always insert. A job with captureSpec
+// overrides also always inserts, on both the incoming and candidate sides:
+// the persist identity cannot represent the overrides, so an override job
+// is never a canonical job's twin (the producers uphold that pairing by
+// setting `persist: null` on override jobs, and the task refuses the
+// persist if one slips through — this predicate must not depend on it).
+// The `runAs` equality below keeps joins within one render identity: the
+// GET lane renders as the realm owner and the POST lane as the requester,
+// so cross-surface twins never join even when their persist targets match.
+export function chooseScreenshotCardCoalesceDecision(
   context: QueueCoalesceContext,
 ): QueueCoalesceDecision {
   let { incoming, candidates, inFlightCandidates } = context;
   let incomingArgs = parseScreenshotCardArgs(incoming.args);
-  if (!incomingArgs || !incomingArgs.persist) {
+  if (
+    !incomingArgs ||
+    !incomingArgs.persist ||
+    hasCaptureSpecOverrides(incomingArgs.captureSpec)
+  ) {
     return { type: 'insert' };
   }
   let twin = [...candidates, ...inFlightCandidates].find((candidate) => {
@@ -48,6 +62,7 @@ function chooseScreenshotCardCoalesceDecision(
     let candidateArgs = parseScreenshotCardArgs(candidate.args);
     return (
       candidateArgs !== undefined &&
+      !hasCaptureSpecOverrides(candidateArgs.captureSpec) &&
       candidateArgs.cardId === incomingArgs.cardId &&
       candidateArgs.format === incomingArgs.format &&
       candidateArgs.runAs === incomingArgs.runAs &&

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -4221,6 +4221,10 @@ export class Realm {
         runAs: owner,
         cardId: entryKey.sourceURL,
         format: spec.format,
+        // The GET DSL's spec is canonical by construction (viewport / scale /
+        // clip params are reserved), so there are never capture overrides on
+        // this lane.
+        captureSpec: null,
         persist: { ...entryKey, lane: 'on-demand' },
       },
       this.#queue,

--- a/packages/runtime-common/tasks/screenshot-card.ts
+++ b/packages/runtime-common/tasks/screenshot-card.ts
@@ -5,6 +5,7 @@ import type { Task } from './index.ts';
 import {
   fetchRealmPermissions,
   fetchUserPermissions,
+  hasCaptureSpecOverrides,
   jobIdentity,
   putMedia,
   type MediaCacheLane,
@@ -39,9 +40,11 @@ export interface ScreenshotCardArgs extends JSONTypes.Object {
   // this ledger identity before the job resolves. This is what makes a
   // bounded-wait caller (the GET `_screenshot/` route's sync wait) safe to
   // give up on: the capture still lands durably, and the caller's retry is
-  // a pure ledger hit instead of a second render. Non-optional `| null`
-  // rather than `?:` because the args are a `JSONTypes.Object`, whose index
-  // signature rejects `undefined`.
+  // a pure ledger hit instead of a second render. Mutually exclusive with
+  // captureSpec overrides: the ledger identity is the canonical capture's,
+  // so the task refuses to persist an override-carrying job's render.
+  // Non-optional `| null` rather than `?:` because the args are a
+  // `JSONTypes.Object`, whose index signature rejects `undefined`.
   persist: ScreenshotPersistArgs | null;
 }
 
@@ -122,7 +125,16 @@ const screenshotCard: Task<ScreenshotCardArgs, ScreenshotPrerenderResponse> = ({
       (result as any)?.response ?? result;
 
     if (persist && response.status === 'ready' && response.base64) {
-      if (!mediaCacheAdapter) {
+      if (hasCaptureSpecOverrides(captureSpec)) {
+        // The ledger identity in `persist` is the canonical capture's; it
+        // cannot represent viewport / scale / fullPage / clip overrides.
+        // Persisting an override render under it would serve that render on
+        // the canonical `_screenshot/` URL, so the persist is refused — the
+        // response still carries the bytes for the caller.
+        log.error(
+          `${jobIdentity(jobInfo)} screenshot-card job carries both a persist target and captureSpec overrides; refusing to persist a non-canonical capture under the canonical ledger identity`,
+        );
+      } else if (!mediaCacheAdapter) {
         log.warn(
           `${jobIdentity(jobInfo)} screenshot-card asked to persist but this worker has no media cache adapter configured; skipping`,
         );

--- a/packages/runtime-common/tasks/screenshot-card.ts
+++ b/packages/runtime-common/tasks/screenshot-card.ts
@@ -8,6 +8,7 @@ import {
   jobIdentity,
   putMedia,
   type MediaCacheLane,
+  type ScreenshotCaptureSpec,
   type ScreenshotPrerenderResponse,
   ensureFullMatrixUserId,
   ensureTrailingSlash,
@@ -29,6 +30,11 @@ export interface ScreenshotCardArgs extends JSONTypes.Object {
   runAs: string;
   cardId: string;
   format: 'isolated' | 'embedded';
+  // Optional per-capture overrides (viewport, scale, fullPage, clip). Typed as
+  // `| null` rather than `?:` because `JSONTypes.Object`'s index signature
+  // rejects `undefined`; the handler always sets it (to the parsed spec or
+  // null).
+  captureSpec: ScreenshotCaptureSpec | null;
   // When non-null, a successful capture is persisted to the MediaCache under
   // this ledger identity before the job resolves. This is what makes a
   // bounded-wait caller (the GET `_screenshot/` route's sync wait) safe to
@@ -51,7 +57,8 @@ const screenshotCard: Task<ScreenshotCardArgs, ScreenshotPrerenderResponse> = ({
   mediaCacheAdapter,
 }) =>
   async function (args) {
-    let { jobInfo, realmURL, runAs, cardId, format, persist } = args;
+    let { jobInfo, realmURL, runAs, cardId, format, captureSpec, persist } =
+      args;
     log.debug(
       `${jobIdentity(jobInfo)} starting screenshot-card for job: ${JSON.stringify(
         {
@@ -59,6 +66,7 @@ const screenshotCard: Task<ScreenshotCardArgs, ScreenshotPrerenderResponse> = ({
           runAs,
           cardId,
           format,
+          captureSpec,
         },
       )}`,
     );
@@ -104,6 +112,7 @@ const screenshotCard: Task<ScreenshotCardArgs, ScreenshotPrerenderResponse> = ({
       url: cardId,
       auth,
       format,
+      ...(captureSpec ? { captureSpec } : {}),
       priority: jobInfo?.priority,
     });
     // The local (in-process) prerenderer resolves to `{response, timings,


### PR DESCRIPTION
## What

Adds an optional `captureSpec` to the `POST /_screenshot-card` flow so callers can control a card screenshot's **viewport size**, **device scale factor**, **fullPage** capture, and a **clip** region. It's a single JSON-serializable object threaded through the whole chain (server-only; no host change):

`ScreenshotCardArgs` → screenshot-card worker task → `prerenderScreenshot` (local + remote) → `captureScreenshotAttempt` → `captureScreenshot`.

## Validation (shared, in `capture-spec.ts`)

The bounds and strict parse live in `capture-spec.ts` so every surface that accepts a spec off the wire enforces them identically: the realm-server's POST body and the prerender server's `/prerender-screenshot` route (its own HTTP surface) both 400 naming the offending field before any render work.

- `viewport` ≤ 4096 × 16384, positive integers
- `deviceScaleFactor` ≤ 3, positive
- `clip` extent bounded by the viewport caps whether or not a viewport is sent (Puppeteer captures beyond the viewport by default, so an unbounded clip would be a way around the viewport cost caps), plus the tighter within-viewport containment when both are given
- physical pixels per edge — CSS dimension × `deviceScaleFactor`, for viewport and clip — ≤ 16384 (the Chromium texture cap)
- `fullPage` and `clip` are mutually exclusive
- unknown fields, top-level and nested, are 400s naming the field
- default-valued fields (`fullPage: false`, `deviceScaleFactor: 1`) are elided, so an all-defaults spec normalizes to `null` and classifies as the canonical capture

The one bound no request-time parse can enforce — a fullPage capture's document extent — is checked at capture time: a document whose scroll size × the effective scale exceeds the physical-pixel cap is refused by name instead of captured.

## Interaction with MediaCache persistence

The MediaCache ledger's canonical capture identity cannot represent viewport / scale / fullPage / clip overrides (the GET `_screenshot/` DSL reserves those params), so a request with captureSpec overrides is capture-only: it skips the ledger fast path, renders fresh, is never persisted, and returns raw bytes with no `captures` served URL. This keeps a custom render from ever serving on (or being keyed under) the canonical `_screenshot/` URL. Requests without overrides behave exactly as before.

The invariant is enforced executably, not just by producer convention:

- the handler sets `persist: null` on override-carrying jobs (which also keeps them out of job coalescing — only persist-carrying jobs join twins)
- the worker task refuses to persist a render whose job carries captureSpec overrides, even if a future producer passes both
- the coalesce predicate treats an override-carrying job as insert-always on both the incoming and candidate sides (shared `hasCaptureSpecOverrides` helper in `capture-spec.ts`)

Capture-only requests that outrun the sync wait still get 503 + `Retry-After`, but the hint is pacing, not a cheap-resume promise — each retry is a full re-render (stated in the handler doc comment; the repair belongs to the follow-up that teaches the ledger identity these specs).

## Capture behavior (`captureScreenshot`)

- The viewport is applied via `page.setViewport` **before** the render transition and **restored in a `finally`** — pooled pages are reused by the indexing HTML-capture path, so a leaked viewport/scale would silently change later index prerenders.
- `fullPage` reports its dimensions from the captured PNG's IHDR (divided back to CSS px by the scale in effect), so the response describes exactly the image the caller received; `clip` reports its own region; both pass through to `page.screenshot`.
- `fullPage` documents past the physical-pixel cap are refused by name at capture time.
- `fullPage` + `clip` is also rejected defensively at the capture layer for direct prerender-server callers.
- The terminal-error check and `waitForImagePaint` are unchanged and stay where they were.

## Tests

- **Shared parse via the handler** (`screenshot-card-test.ts`): valid spec forwarded verbatim into the job; 400s for oversize viewport width/height, `deviceScaleFactor` over the cap, `fullPage`+`clip`, clip beyond the viewport, clip extent beyond the caps without a viewport, unknown top-level and nested fields, and physical-pixel-per-edge overruns; a default-valued spec normalizes to `null` and still answers from the ledger; a custom captureSpec bypasses an existing canonical ledger entry, enqueues with `persist: null`, and returns no served URL; coalesce-predicate unit tests (canonical twins join, override jobs insert on either side). ✅ passing locally.
- **Prerender route** (`prerender-server-test.ts`): `/prerender-screenshot` 400s an out-of-bounds and an unknown-field captureSpec by name before any render work. ✅ passing locally.
- **Task** (`media-cache-dsl-test.ts`): a job carrying both a persist target and captureSpec overrides still captures and returns bytes but writes no ledger row. ✅ passing locally.
- **Capture** (`prerendering-test.ts`): default 800×600, viewport override to 1280, fullPage taller than the viewport for a long card, fullPage cap rejection at 3× and a within-cap fullPage whose reported dims equal the PNG's, clip exact dims, viewport-restore across reused pooled pages, and indexed HTML unchanged after a custom-viewport capture (via PNG magic-byte + IHDR dimension asserts). ✅ the new cap/dims cases verified against a live local prerender stack; the shared-fixture module remains CI-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)