### PR TITLE
End HTTP/2 responses on their final DATA frame

### DIFF
--- a/.devcontainer/claude-web-h2-preload.cjs
+++ b/.devcontainer/claude-web-h2-preload.cjs
@@ -20,6 +20,12 @@
 // Nothing in this repo sends HTTP trailers, so forcing waitForTrailers off
 // is behavior-preserving: the last DATA frame simply carries END_STREAM
 // itself, eliminating the droppable-trailers window while keeping HTTP/2.
+//
+// The realm-server declines the trailers itself (see
+// `endStreamOnFinalDataFrame` in packages/realm-server/server.ts), so what
+// this preload still covers is the rest of the stack's node servers on this
+// VM — chiefly the host app's vite dev server, which serves the
+// module graph behind the /_standby page.
 'use strict';
 const http2 = require('http2');
 

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -316,7 +316,10 @@ class RealmResource {
             case 'incremental-index-initiation':
               this.info.isIndexing = true;
               if (!this.indexingWaiterToken) {
-                this.indexingWaiterToken = indexingWaiter.beginAsync();
+                this.indexingWaiterToken = indexingWaiter.beginAsync(
+                  undefined,
+                  this.realmURL,
+                );
               }
               break;
             case 'full':

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -711,7 +711,8 @@ export default class StoreService extends Service implements StoreInterface {
     doc: LooseSingleCardDocument,
     opts?: TrackedCreateOptions,
   ): Promise<string | CardErrorJSONAPI> {
-    return await this.withTestWaiters(async () => {
+    let waiterLabel = `create ${opts?.realm ?? '<default realm>'}`;
+    return await this.withTestWaiters(waiterLabel, async () => {
       if (opts?.realm) {
         doc.data.meta = {
           ...(doc.data.meta ?? {}),
@@ -1757,7 +1758,8 @@ export default class StoreService extends Service implements StoreInterface {
     readType: StoreReadType = 'card',
   ) {
     let deferred = new Deferred<void>();
-    await this.withTestWaiters(async () => {
+    let waiterLabel = `wireUpNewReference ${url}`;
+    await this.withTestWaiters(waiterLabel, async () => {
       this.newReferencePromises.push(deferred.promise);
       try {
         await this.ready;
@@ -2371,7 +2373,8 @@ export default class StoreService extends Service implements StoreInterface {
   });
 
   private reloadFileMetaTask = task(async (url: string) => {
-    await this.withTestWaiters(async () => {
+    let waiterLabel = `reloadFileMeta ${url}`;
+    await this.withTestWaiters(waiterLabel, async () => {
       let instanceOrError = await this.getFileMetaInstance<FileDef>({
         idOrDoc: url,
         opts: { noCache: true },
@@ -2898,7 +2901,8 @@ export default class StoreService extends Service implements StoreInterface {
   }
 
   private async drainAutoSaveQueue(queueName: string) {
-    return await this.withTestWaiters(async () => {
+    let waiterLabel = `drainAutoSaveQueue ${queueName}`;
+    return await this.withTestWaiters(waiterLabel, async () => {
       await this.autoSavePromises.get(queueName);
 
       let instance = this.peek(queueName);
@@ -3076,7 +3080,8 @@ export default class StoreService extends Service implements StoreInterface {
     instance: CardDef,
     opts?: PersistOptions,
   ): Promise<CardDef | CardErrorJSONAPI> {
-    return await this.withTestWaiters(async () => {
+    let waiterLabel = `persistAndUpdate ${instance.id ?? instance[localIdSymbol]}`;
+    return await this.withTestWaiters(waiterLabel, async () => {
       let isNew = !instance.id;
       let inflightMutation = this.inflightCardMutations.get(
         instance[localIdSymbol],
@@ -3196,7 +3201,8 @@ export default class StoreService extends Service implements StoreInterface {
   private async reloadInstance(instance: CardDef): Promise<CardDef> {
     // we don't await this in the realm subscription callback, so this test
     // waiter should catch otherwise leaky async in the tests
-    return await this.withTestWaiters(async () => {
+    let waiterLabel = `reloadInstance ${instance.id}`;
+    return await this.withTestWaiters(waiterLabel, async () => {
       let api = await this.cardService.getAPI();
       let incomingDoc: SingleCardDocument = (await this.cardService.fetchJSON(
         instance.id,
@@ -3345,8 +3351,13 @@ export default class StoreService extends Service implements StoreInterface {
     return isCardInstance(instance) ? instance : undefined;
   }
 
-  private async withTestWaiters<T>(cb: () => Promise<T>) {
-    let token = waiter.beginAsync();
+  // `label` names the individual store operation the token stands for. Every
+  // store operation opens its token on the one `store-service` waiter from
+  // this one call site, so without a label a `settled()` that never resolves
+  // reports only that some store work is outstanding — with a stack that is
+  // this method for all of them.
+  private async withTestWaiters<T>(label: string, cb: () => Promise<T>) {
+    let token = waiter.beginAsync(undefined, label);
     try {
       let result = await cb();
       // only do this in test env--this makes sure that we also wait for any

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -89,6 +89,7 @@ import {
   isEntrySingleDocument,
   type PrerenderedHtmlFormat,
   type ResolvedCodeRef,
+  humanReadable,
   type RealmIdentifier,
   type RealmResourceIdentifier,
   type Saved,
@@ -711,7 +712,10 @@ export default class StoreService extends Service implements StoreInterface {
     doc: LooseSingleCardDocument,
     opts?: TrackedCreateOptions,
   ): Promise<string | CardErrorJSONAPI> {
-    let waiterLabel = `create ${opts?.realm ?? '<default realm>'}`;
+    let adoptsFrom = doc.data.meta?.adoptsFrom;
+    let waiterLabel = `create ${
+      adoptsFrom ? humanReadable(adoptsFrom) : '<unknown type>'
+    } in ${opts?.realm ?? '<default realm>'}`;
     return await this.withTestWaiters(waiterLabel, async () => {
       if (opts?.realm) {
         doc.data.meta = {

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -297,7 +297,7 @@ function buildHttp2SecureServer(
   try {
     tlsServer = http2.createSecureServer(
       { cert, key, allowHTTP1: true },
-      app.callback(),
+      endStreamOnFinalDataFrame(app.callback()),
     );
   } catch (e) {
     throw new Error(
@@ -312,6 +312,54 @@ function buildHttp2SecureServer(
     installHttp2Diagnostics(tlsServer, log, liveness);
   }
   return tlsServer;
+}
+
+// End every HTTP/2 response with END_STREAM on its final DATA frame rather
+// than through node's trailers mechanism.
+//
+// Node's http2 compat layer — the half that turns an `Http2Stream` into the
+// `(req, res)` pair Koa is written against — responds with
+// `waitForTrailers: true` unconditionally, and then emits the (empty)
+// trailers HEADERS frame, the frame that actually carries END_STREAM, from a
+// `setImmediate` (`finishSendTrailers` in `lib/internal/http2/core.js`). When
+// a batch of streams finishes in one event-loop turn, a stream can be
+// destroyed before its `setImmediate` runs; `finishSendTrailers` then drops
+// the trailers silently and the stream terminates as RST_STREAM(NO_ERROR)
+// with a truncated body. Chromium treats such a response as neither complete
+// nor failed and leaves the load pending forever — no error, no retry — which
+// is what a browser-side hang with a clean, promptly-closed server-side
+// stream looks like.
+//
+// Nothing here sends HTTP trailers, so declining them is behavior-preserving:
+// the last DATA frame carries END_STREAM itself and the droppable-trailers
+// window closes.
+//
+// Applied by wrapping the request listener rather than the `stream` event,
+// because the compat listener registered by `createSecureServer(..., handler)`
+// runs first and responds synchronously for a request the app answers without
+// awaiting — a `stream` listener added afterwards would miss exactly those.
+// `allowHTTP1` means this also sees HTTP/1.1 requests, whose `res` has no
+// backing stream; those are passed through untouched.
+function endStreamOnFinalDataFrame(
+  requestListener: ReturnType<Koa['callback']>,
+): ReturnType<Koa['callback']> {
+  return function (req, res) {
+    let stream = (res as unknown as { stream?: http2.ServerHttp2Stream })
+      .stream;
+    if (stream) {
+      let respond = stream.respond;
+      stream.respond = function (
+        headers?: http2.OutgoingHttpHeaders,
+        options?: http2.ServerStreamResponseOptions,
+      ) {
+        if (options?.waitForTrailers) {
+          options = { ...options, waitForTrailers: false };
+        }
+        return respond.call(this, headers, options);
+      };
+    }
+    return requestListener(req, res);
+  };
 }
 
 // Wire the HTTP/2 PING keepalive onto every session the secure server

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -319,20 +319,19 @@ function buildHttp2SecureServer(
 //
 // Node's http2 compat layer — the half that turns an `Http2Stream` into the
 // `(req, res)` pair Koa is written against — responds with
-// `waitForTrailers: true` unconditionally, and then emits the (empty)
-// trailers HEADERS frame, the frame that actually carries END_STREAM, from a
-// `setImmediate` (`finishSendTrailers` in `lib/internal/http2/core.js`). When
-// a batch of streams finishes in one event-loop turn, a stream can be
-// destroyed before its `setImmediate` runs; `finishSendTrailers` then drops
-// the trailers silently and the stream terminates as RST_STREAM(NO_ERROR)
-// with a truncated body. Chromium treats such a response as neither complete
-// nor failed and leaves the load pending forever — no error, no retry — which
-// is what a browser-side hang with a clean, promptly-closed server-side
-// stream looks like.
+// `waitForTrailers: true` unconditionally. That moves END_STREAM off the final
+// DATA frame and onto an empty trailers HEADERS frame emitted from a
+// `setImmediate` (`finishSendTrailers` in `lib/internal/http2/core.js`), which
+// drops that frame when the stream is already destroyed. A response whose
+// END_STREAM never arrives leaves its peer holding a body it can neither
+// complete nor fail.
 //
-// Nothing here sends HTTP trailers, so declining them is behavior-preserving:
-// the last DATA frame carries END_STREAM itself and the droppable-trailers
-// window closes.
+// Whether this server can reach that state is not established — no sequence
+// here is known to destroy a stream inside the window. What is established is
+// that the deferral buys nothing: nothing in this repo sends HTTP trailers, so
+// declining them is behavior-preserving and removes the window rather than
+// reasoning about its reachability. The last DATA frame carries END_STREAM
+// itself.
 //
 // Applied by wrapping the request listener rather than the `stream` event,
 // because the compat listener registered by `createSecureServer(..., handler)`

--- a/packages/realm-server/tests/listener-dispatcher-test.ts
+++ b/packages/realm-server/tests/listener-dispatcher-test.ts
@@ -68,10 +68,30 @@ function makeApp(): Koa {
   return app;
 }
 
+// Same responses as `makeApp`, plus a record of whether the h2 stream ever
+// asked for trailing headers. Node emits `wantTrailers` only for a response
+// that was told to wait for trailers, so this reads whether the response took
+// that path — see the test that uses it.
+function makeTrailerProbeApp(probe: { wantTrailers: boolean }): Koa {
+  let app = new Koa();
+  app.use(async (ctx) => {
+    let stream = (ctx.res as unknown as { stream?: http2.ServerHttp2Stream })
+      .stream;
+    stream?.once('wantTrailers', () => {
+      probe.wantTrailers = true;
+    });
+    ctx.status = 200;
+    ctx.set('content-type', 'text/plain');
+    ctx.body = `ok via ${ctx.req.httpVersion}`;
+  });
+  return app;
+}
+
 async function startListener(opts: {
   cert?: string | null;
   key?: string | null;
   boxelEnvironment?: string | null;
+  app?: Koa;
 }): Promise<{
   port: number;
   server: RealmHttpServer;
@@ -99,7 +119,10 @@ async function startListener(opts: {
   } else {
     process.env.BOXEL_ENVIRONMENT = opts.boxelEnvironment;
   }
-  let { server, proto } = createListener(logger('test:dispatcher'), makeApp());
+  let { server, proto } = createListener(
+    logger('test:dispatcher'),
+    opts.app ?? makeApp(),
+  );
   let isHttp2 = proto === 'https/h2';
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   let port = (server.address() as AddressInfo).port;
@@ -314,6 +337,45 @@ module(basename(import.meta.filename), function (hooks) {
         res.responseHeaders['content-length'],
         String(Buffer.byteLength('ok via 2.0')),
         'h2 HEAD reports the GET body length via content-length',
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  test('h2 responses end with END_STREAM on their final DATA frame', async function (assert) {
+    // Node's http2 compat layer responds with `waitForTrailers: true` on
+    // every response, which moves END_STREAM off the last DATA frame and onto
+    // an empty trailers HEADERS frame sent from a setImmediate — a frame a
+    // stream destroyed in the same event-loop turn never sends, leaving the
+    // peer holding a body it can neither complete nor fail.
+    // `endStreamOnFinalDataFrame` (applied inside `createListener` when an h2
+    // listener is constructed) declines those trailers, so `wantTrailers`,
+    // which node emits only for a response that took the trailers path, must
+    // never fire. Without it this assertion fails while the response body
+    // still arrives intact — which is the whole point: the difference is
+    // invisible in the response and only shows up as a peer that hangs.
+    let probe = { wantTrailers: false };
+    let { port, isHttp2, close } = await startListener({
+      cert: certFile,
+      key: keyFile,
+      app: makeTrailerProbeApp(probe),
+    });
+    try {
+      assert.true(isHttp2, 'listener advertises h2 mode');
+      let res = await h2Request({ port, path: '/_alive', timeoutMs: 2000 });
+      assert.strictEqual(res.status, 200, 'h2 GET returns 200');
+      assert.true(
+        res.body.includes('ok via 2.0'),
+        `body arrives intact — got "${res.body}"`,
+      );
+      // The trailers frame goes out from a setImmediate, so yield one turn
+      // before reading the probe rather than relying on it having fired by
+      // the time the client saw the end of the body.
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.false(
+        probe.wantTrailers,
+        'response did not defer END_STREAM to a trailers frame',
       );
     } finally {
       await close();

--- a/packages/runtime-common/fetcher.ts
+++ b/packages/runtime-common/fetcher.ts
@@ -48,10 +48,7 @@ export function fetcher(
     // Labeled with the request it stands for: this waiter holds `settled()`
     // open for every fetch the app makes, so a hung one is only actionable if
     // the pending token says which request it is.
-    let token = fetcherWaiter.beginAsync(
-      undefined,
-      `${request.method} ${request.url}`,
-    );
+    let token = fetcherWaiter.beginAsync(undefined, describeRequest(request));
     try {
       return responseWithWaiters(await buildNext(middlewareStack)(request));
     } finally {
@@ -59,6 +56,29 @@ export function fetcher(
     }
   };
   return instance;
+}
+
+// Method and target of a request, for a waiter label. Query values are
+// replaced with a placeholder because a diagnostic that prints this label ends
+// up in a log — a query string can carry a credential (a Matrix OpenID
+// exchange puts an access token in one), and knowing which request is
+// outstanding needs its shape, never its values.
+function describeRequest(request: Request): string {
+  let target: string;
+  try {
+    let url = new URL(request.url);
+    let keys = Array.from(new Set(url.searchParams.keys()));
+    url.search = '';
+    url.hash = '';
+    target = url.href;
+    if (keys.length > 0) {
+      target += `?${keys.map((key) => `${key}=[redacted]`).join('&')}`;
+    }
+  } catch {
+    // A URL the parser rejects still must not carry its query into the log.
+    target = request.url.split('?')[0];
+  }
+  return `${request.method} ${target}`;
 }
 
 async function simulateNetworkBehaviors(

--- a/packages/runtime-common/fetcher.ts
+++ b/packages/runtime-common/fetcher.ts
@@ -58,11 +58,14 @@ export function fetcher(
   return instance;
 }
 
-// Method and target of a request, for a waiter label. Query values are
-// replaced with a placeholder because a diagnostic that prints this label ends
-// up in a log — a query string can carry a credential (a Matrix OpenID
-// exchange puts an access token in one), and knowing which request is
-// outstanding needs its shape, never its values.
+// Method and target of a request, for a waiter label. This waiter labels every
+// request the app's network layer makes, and a diagnostic that prints the label
+// ends up in a log, so query values are replaced with a placeholder: knowing
+// which request is outstanding needs the request's shape, never its values.
+//
+// The host's own fetch-debugging helper (`describeFetchRequest` in
+// `host/tests/helpers/setup.ts`) prints into the same dump without redacting,
+// so the two do not yet agree on policy.
 function describeRequest(request: Request): string {
   let target: string;
   try {

--- a/packages/runtime-common/fetcher.ts
+++ b/packages/runtime-common/fetcher.ts
@@ -45,7 +45,13 @@ export function fetcher(
         ? urlOrRequest
         : new Request(urlOrRequest, init);
 
-    let token = fetcherWaiter.beginAsync();
+    // Labeled with the request it stands for: this waiter holds `settled()`
+    // open for every fetch the app makes, so a hung one is only actionable if
+    // the pending token says which request it is.
+    let token = fetcherWaiter.beginAsync(
+      undefined,
+      `${request.method} ${request.url}`,
+    );
     try {
       return responseWithWaiters(await buildNext(middlewareStack)(request));
     } finally {

--- a/packages/runtime-common/test-waiters.ts
+++ b/packages/runtime-common/test-waiters.ts
@@ -6,7 +6,7 @@
 
 export interface Waiters {
   buildWaiter(label: string): {
-    beginAsync(): unknown;
+    beginAsync(token?: unknown, itemLabel?: string): unknown;
     endAsync(token: unknown): void;
   };
   waitForPromise<T>(promise: Promise<T>, label?: string): Promise<T>;
@@ -19,7 +19,12 @@ export function useTestWaiters(w: Waiters) {
 }
 
 export interface TestWaiter {
-  beginAsync(): unknown;
+  // `itemLabel` describes the individual pending operation rather than the
+  // waiter as a whole. The host's moment-of-timeout diagnostic prints it in
+  // place of a stack frame (see `describePendingWaiter` in
+  // `host/tests/helpers/setup.ts`), so a waiter whose call site serves many
+  // concurrent operations should pass whatever tells them apart.
+  beginAsync(token?: unknown, itemLabel?: string): unknown;
   endAsync(token: unknown): void;
 }
 
@@ -36,8 +41,8 @@ export function buildWaiter(label: string): TestWaiter {
     return real;
   };
   return {
-    beginAsync() {
-      return resolve()?.beginAsync();
+    beginAsync(token?: unknown, itemLabel?: string) {
+      return resolve()?.beginAsync(token, itemLabel);
     },
     endAsync(token: unknown) {
       if (token === undefined) {


### PR DESCRIPTION
Node's http2 compat layer — the half that turns an `Http2Stream` into the `(req, res)` pair Koa is written against — responds with `waitForTrailers: true` unconditionally. That moves END_STREAM off the final DATA frame and onto an empty trailers HEADERS frame emitted from a `setImmediate` (`finishSendTrailers` in `lib/internal/http2/core.js`), which drops that frame when the stream is already destroyed. A response whose END_STREAM never arrives leaves its peer holding a body it can neither complete nor fail.

Nothing in this repo sends HTTP trailers, so the deferral buys nothing. `endStreamOnFinalDataFrame` wraps the request listener `createSecureServer` is given and declines it, so the last DATA frame carries END_STREAM itself. Response bytes are unchanged.

It wraps the request listener rather than the `stream` event because the compat listener node registers runs first and responds synchronously for a request the app answers without awaiting — a `stream` listener added afterwards misses exactly those. `allowHTTP1` means it also sees HTTP/1.1 requests, whose `res` has no backing stream; those pass through untouched.

## What this does and does not claim

This started as a fix for the 60s host-test timeouts on shard 16 of [run 32796026625](https://github.com/cardstack/boxel/actions/runs/32796026625/job/97647940651). It should not be read that way, and the code comment no longer says so:

- **The deferral is real and checkable.** Every compat response goes out as `{endStream: false, waitForTrailers: true, sendDate: true}` on node 24, and the new test pins that declining it works.
- **The bridge to a hung peer is not established.** 600 responses finishing in one event-loop turn fire `wantTrailers` 600 times, flush 600 trailers frames, and deliver 600 complete responses — nothing destroyed early. Forcing the window (destroying the stream from a `wantTrailers` listener registered after the compat layer's) still gives the peer `end` plus `close rst=0`. Two independent attempts have failed to reach the state that would strand a peer.
- **The peer is not the browser where the flake happens.** Under `BOXEL_ENVIRONMENT` — `ci` on the host-test shards — Traefik fronts the realm server and negotiates h2 by ALPN to an `https://host.docker.internal:<port>` upstream (`registerService(..., { http2: true })`); `server.ts` says as much, "Traefik is the only client". A truncated response would land on Traefik's Go client first, and whether it forwards a stream it can neither complete nor fail is an open question.

So: this removes a window rather than reasoning about its reachability, at no behavioral cost. Whether it moves the timeouts is unproven.

## Diagnostics

Independent of the above, and the part most likely to help next time. `describePendingWaiter` in `host/tests/helpers/setup.ts` prefers a token's label over its stack frame, but no call site passed one, so a moment-of-timeout dump repeated the same frame once per pending token. Labelled now:

- `fetcher` → the method and target of the request in flight, query values replaced with `[redacted]`
- `store-service` → the store operation and its subject (`persistAndUpdate <id>`, `create <type> in <realm>`, …)
- `realm:incremental-indexing` → the realm whose index event has not landed

If a 60s timeout recurs, the dump names the stuck request instead of pointing at `fetcher.ts`.

## Known gaps

- `describeFetchRequest` in `host/tests/helpers/setup.ts` prints full URLs with query values into the same dump, so the two lines still disagree on redaction policy. Its `url` is load-bearing for test-realm routing, not only logging, so redacting it is a separate change; noted in the comment rather than done here.
- `monaco-test-waiter.ts` already receives an `operation` string per token and drops it at `beginAsync()` — the same one-call-site-many-operations case, label already in hand. Not touched here.

## Verification

- New case in `listener-dispatcher-test.ts` drives the real `createListener` and asserts `wantTrailers` — which node emits only for a response that took the trailers path — never fires. All 12 tests in that module pass; with the wrapper removed only the new one fails, while the response body still arrives intact.
- `lint` and `lint:types` clean for `realm-server`, `host`, and `runtime-common`.
- Host and realm-server suites green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ooR7A4u4BpLufmYBzPnJe