### PR TITLE
Don't display stale live store card instance when there are historic card-related tool results in the assistant room

### DIFF
--- a/packages/host/app/components/matrix/room-message-tool.gts
+++ b/packages/host/app/components/matrix/room-message-tool.gts
@@ -35,6 +35,7 @@ import type MatrixService from '@cardstack/host/services/matrix-service';
 import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
+import type StoreService from '@cardstack/host/services/store';
 import type ToolService from '@cardstack/host/services/tool-service';
 
 import CodeBlock from '../ai-assistant/code-block';
@@ -63,6 +64,7 @@ export default class RoomMessageTool extends Component<Signature> {
   @service declare private matrixService: MatrixService;
   @service declare private realm: RealmService;
   @service declare private operatorModeStateService: OperatorModeStateService;
+  @service declare private store: StoreService;
 
   private get previewCommandCode() {
     let { name, arguments: payload } = this.args.messageTool;
@@ -106,11 +108,31 @@ export default class RoomMessageTool extends Component<Signature> {
     );
   }
 
-  @use private toolResultCard = resource(() => {
+  // The result card is the live store instance when the result doc names a
+  // saved card. Holding a store reference for as long as this component
+  // renders it keeps the instance out of the store's GC sweep and subscribed
+  // to realm invalidation; otherwise a sweep could evict it mid-render and the
+  // next `store.get` would mint a second instance for the same id.
+  @use private toolResultCard = resource(({ on }) => {
     let initialState = { card: undefined } as { card: CardDef | undefined };
     let state = new TrackedObject(initialState);
+    let referencedId: string | undefined;
+    let isTornDown = false;
+    on.cleanup(() => {
+      isTornDown = true;
+      if (referencedId) {
+        this.store.dropReference(referencedId);
+      }
+    });
     if (this.args.messageTool.toolResultFileDef) {
       this.args.messageTool.getCommandResultCard().then((card) => {
+        if (isTornDown) {
+          return;
+        }
+        if (card?.id) {
+          referencedId = card.id;
+          this.store.addReference(card.id);
+        }
         state.card = card;
       });
     }

--- a/packages/host/app/lib/matrix-classes/message-tool.ts
+++ b/packages/host/app/lib/matrix-classes/message-tool.ts
@@ -4,7 +4,11 @@ import { service } from '@ember/service';
 
 import { tracked } from '@glimmer/tracking';
 
-import type { ResolvedCodeRef } from '@cardstack/runtime-common';
+import {
+  isCardInstance,
+  type LooseSingleCardDocument,
+  type ResolvedCodeRef,
+} from '@cardstack/runtime-common';
 import {
   AI_BOT_EXECUTOR,
   type ToolRequest,
@@ -115,12 +119,30 @@ export default class MessageTool {
     }
   }
 
+  // The result doc stored in the room is a snapshot of the card as it was when
+  // the tool ran. When that card lives in a realm (the doc carries its id), the
+  // snapshot must never be installed in the store under that id: the store
+  // holds one instance per id, so adding the snapshot would replace the live
+  // instance everywhere it is rendered, and its autosave would then write the
+  // stale state back over the newer file. Render the live instance instead,
+  // and fall back to an id-less ephemeral copy only when the live card can no
+  // longer be loaded (for example, it was deleted since).
   async getCommandResultCard(): Promise<CardDef | undefined> {
     let cardDoc = await this.commandResultCardDoc();
-    let card: CardDef | undefined;
-    if (cardDoc) {
-      card = (await this.store.add(cardDoc, { doNotPersist: true })) as CardDef;
+    if (!cardDoc) {
+      return undefined;
     }
-    return card;
+    let id = cardDoc.data.id;
+    if (id) {
+      let live = await this.store.get<CardDef>(id);
+      if (isCardInstance(live)) {
+        return live;
+      }
+    }
+    let { id: _id, ...resource } = cardDoc.data;
+    let ephemeralDoc: LooseSingleCardDocument = { ...cardDoc, data: resource };
+    return (await this.store.add(ephemeralDoc, {
+      doNotPersist: true,
+    })) as CardDef;
   }
 }

--- a/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
@@ -8,6 +8,7 @@ import { module, skip, test } from 'qunit';
 
 import {
   buildToolFunctionNameFromResolvedRef,
+  isCardInstance,
   skillCardRef,
 } from '@cardstack/runtime-common';
 import type { LooseSingleCardDocument } from '@cardstack/runtime-common';
@@ -2282,12 +2283,16 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
   // card's id, so the store must not adopt it: one instance per id means the
   // snapshot would replace the live instance and its autosave would write the
   // stale state back over the newer file.
-  function simulateShowCardResult(roomId: string, snapshotFirstName: string) {
+  function simulateShowCardResult(
+    roomId: string,
+    snapshotFirstName: string,
+    cardId = `${testRealmURL}Person/fadhlan`,
+  ) {
     let matrixService = getService('matrix-service');
     matrixService.downloadCardFileDef = async () =>
       ({
         data: {
-          id: `${testRealmURL}Person/fadhlan`,
+          id: cardId,
           type: 'card',
           attributes: { firstName: snapshotFirstName },
           meta: {
@@ -2306,7 +2311,7 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
           id: commandRequestId,
           name: 'showCard',
           arguments: JSON.stringify({
-            attributes: { cardId: `${testRealmURL}Person/fadhlan` },
+            attributes: { cardId },
           }),
         },
       ],
@@ -2325,7 +2330,7 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
         data: {
           card: {
             url: 'mxc://mock-server/fadhlan-snapshot',
-            sourceUrl: `${testRealmURL}Person/fadhlan`,
+            sourceUrl: cardId,
             name: 'Fadhlan',
             contentType: 'application/vnd.card+json',
           },
@@ -2387,5 +2392,30 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
     assert
       .dom('[data-test-boxel-tool-call-result]')
       .containsText('Fadhlan', 'the tool result renders the live card');
+  });
+
+  test<TestContextWithSave>('rendering a tool result whose live card no longer exists renders the snapshot without installing it under the card id', async function (assert) {
+    let roomId = await renderAiAssistantPanel();
+    this.onSave(() => {
+      assert.ok(false, 'rendering a tool result must not trigger a save');
+    });
+    let deletedId = `${testRealmURL}Person/deleted`;
+
+    simulateShowCardResult(roomId, 'Snapshot', deletedId);
+
+    await waitFor('[data-test-boxel-tool-call-result]');
+    await settled();
+
+    assert
+      .dom('[data-test-boxel-tool-call-result]')
+      .containsText(
+        'Snapshot',
+        'the tool result falls back to rendering the snapshot',
+      );
+    let store = getService('store');
+    assert.false(
+      isCardInstance(store.peek(deletedId)),
+      'the snapshot is not installed in the store under the realm id',
+    );
   });
 });

--- a/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
@@ -10,6 +10,7 @@ import {
   buildToolFunctionNameFromResolvedRef,
   skillCardRef,
 } from '@cardstack/runtime-common';
+import type { LooseSingleCardDocument } from '@cardstack/runtime-common';
 import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
@@ -17,6 +18,7 @@ import {
   APP_BOXEL_TOOL_RESULT_EVENT_TYPE,
   APP_BOXEL_TOOL_RESULT_REL_TYPE,
   APP_BOXEL_TOOL_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+  APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
@@ -2273,5 +2275,117 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
       .exists(
         'manual approval bar still renders for commands that need user approval',
       );
+  });
+
+  // A tool that returns the target card itself (show-card, get-card, ...)
+  // stores a snapshot of that card in the room. The snapshot carries the live
+  // card's id, so the store must not adopt it: one instance per id means the
+  // snapshot would replace the live instance and its autosave would write the
+  // stale state back over the newer file.
+  function simulateShowCardResult(roomId: string, snapshotFirstName: string) {
+    let matrixService = getService('matrix-service');
+    matrixService.downloadCardFileDef = async () =>
+      ({
+        data: {
+          id: `${testRealmURL}Person/fadhlan`,
+          type: 'card',
+          attributes: { firstName: snapshotFirstName },
+          meta: {
+            adoptsFrom: { module: `${testRealmURL}person`, name: 'Person' },
+          },
+        },
+      }) as unknown as LooseSingleCardDocument;
+    let commandRequestId = 'show-card-request-id';
+    simulateRemoteMessage(roomId, '@aibot:localhost', {
+      msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+      body: 'Showing the card',
+      format: 'org.matrix.custom.html',
+      isStreamingFinished: true,
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
+        {
+          id: commandRequestId,
+          name: 'showCard',
+          arguments: JSON.stringify({
+            attributes: { cardId: `${testRealmURL}Person/fadhlan` },
+          }),
+        },
+      ],
+    });
+    simulateRemoteMessage(
+      roomId,
+      '@aibot:localhost',
+      {
+        msgtype: APP_BOXEL_TOOL_RESULT_WITH_OUTPUT_MSGTYPE,
+        commandRequestId,
+        'm.relates_to': {
+          rel_type: APP_BOXEL_TOOL_RESULT_REL_TYPE,
+          key: 'applied',
+          event_id: 'bot-message-event-id',
+        },
+        data: {
+          card: {
+            url: 'mxc://mock-server/fadhlan-snapshot',
+            sourceUrl: `${testRealmURL}Person/fadhlan`,
+            name: 'Fadhlan',
+            contentType: 'application/vnd.card+json',
+          },
+        },
+      },
+      { type: APP_BOXEL_TOOL_RESULT_EVENT_TYPE },
+    );
+  }
+
+  test<TestContextWithSave>('rendering a tool result that snapshots a card already in the store leaves the live instance untouched', async function (assert) {
+    let roomId = await renderAiAssistantPanel(`${testRealmURL}Person/fadhlan`);
+    await waitFor('[data-test-person="Fadhlan"]');
+    this.onSave(() => {
+      assert.ok(false, 'rendering a tool result must not trigger a save');
+    });
+
+    simulateShowCardResult(roomId, 'Stale');
+
+    await waitFor('[data-test-boxel-tool-call-result]');
+    await settled();
+
+    assert
+      .dom('[data-test-person]')
+      .hasText('Fadhlan', 'the card in the stack still shows the live data');
+    let store = getService('store');
+    let live = store.peek(`${testRealmURL}Person/fadhlan`) as
+      | { firstName?: string }
+      | undefined;
+    assert.strictEqual(
+      live?.firstName,
+      'Fadhlan',
+      'the resident instance keeps its live fields',
+    );
+    assert
+      .dom('[data-test-boxel-tool-call-result]')
+      .containsText('Fadhlan', 'the tool result renders the live card');
+  });
+
+  test<TestContextWithSave>('rendering a tool result that snapshots a card not yet in the store loads the live card instead of the snapshot', async function (assert) {
+    let roomId = await renderAiAssistantPanel();
+    this.onSave(() => {
+      assert.ok(false, 'rendering a tool result must not trigger a save');
+    });
+
+    simulateShowCardResult(roomId, 'Stale');
+
+    await waitFor('[data-test-boxel-tool-call-result]');
+    await settled();
+
+    let store = getService('store');
+    let live = store.peek(`${testRealmURL}Person/fadhlan`) as
+      | { firstName?: string }
+      | undefined;
+    assert.strictEqual(
+      live?.firstName,
+      'Fadhlan',
+      'the store holds the live card, not the room snapshot',
+    );
+    assert
+      .dom('[data-test-boxel-tool-call-result]')
+      .containsText('Fadhlan', 'the tool result renders the live card');
   });
 });

--- a/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
@@ -2288,9 +2288,15 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
     snapshotFirstName: string,
     cardId = `${testRealmURL}Person/fadhlan`,
   ) {
+    let snapshotUrl = 'mxc://mock-server/fadhlan-snapshot';
     let matrixService = getService('matrix-service');
-    matrixService.downloadCardFileDef = async () =>
-      ({
+    let originalDownload =
+      matrixService.downloadCardFileDef.bind(matrixService);
+    matrixService.downloadCardFileDef = async (serializedFile) => {
+      if (serializedFile.url !== snapshotUrl) {
+        return originalDownload(serializedFile);
+      }
+      return {
         data: {
           id: cardId,
           type: 'card',
@@ -2299,7 +2305,8 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
             adoptsFrom: { module: `${testRealmURL}person`, name: 'Person' },
           },
         },
-      }) as unknown as LooseSingleCardDocument;
+      } as unknown as LooseSingleCardDocument;
+    };
     let commandRequestId = 'show-card-request-id';
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
@@ -2329,7 +2336,7 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
         },
         data: {
           card: {
-            url: 'mxc://mock-server/fadhlan-snapshot',
+            url: snapshotUrl,
             sourceUrl: cardId,
             name: 'Fadhlan',
             contentType: 'application/vnd.card+json',
@@ -2343,8 +2350,12 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
   test<TestContextWithSave>('rendering a tool result that snapshots a card already in the store leaves the live instance untouched', async function (assert) {
     let roomId = await renderAiAssistantPanel(`${testRealmURL}Person/fadhlan`);
     await waitFor('[data-test-person="Fadhlan"]');
-    this.onSave(() => {
-      assert.ok(false, 'rendering a tool result must not trigger a save');
+    let savedFirstNames: string[] = [];
+    this.onSave((_, json) => {
+      if (typeof json === 'string') {
+        throw new Error('expected JSON save data');
+      }
+      savedFirstNames.push(json.data.attributes?.firstName);
     });
 
     simulateShowCardResult(roomId, 'Stale');
@@ -2367,6 +2378,29 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
     assert
       .dom('[data-test-boxel-tool-call-result]')
       .containsText('Fadhlan', 'the tool result renders the live card');
+    assert.deepEqual(
+      savedFirstNames,
+      [],
+      'rendering the tool result does not save anything',
+    );
+
+    // Mutating the resident instance must show up in the tool result, which
+    // pins that the result renders the store's instance and not a copy, and
+    // the autosave that follows must carry the live value, not the snapshot.
+    live!.firstName = 'Fadhlan Updated';
+    await settled();
+
+    assert
+      .dom('[data-test-boxel-tool-call-result]')
+      .containsText(
+        'Fadhlan Updated',
+        'the tool result follows the resident instance',
+      );
+    assert.deepEqual(
+      savedFirstNames,
+      ['Fadhlan Updated'],
+      'the autosave writes the live value',
+    );
   });
 
   test<TestContextWithSave>('rendering a tool result that snapshots a card not yet in the store loads the live card instead of the snapshot', async function (assert) {


### PR DESCRIPTION
When testing generating cards using the AI assistant, I ran into issues where the live card I was working on and looking at. The problem was that the card was not showing the updated data values (card's json) that the assistant was manipulating over time. It turns out the assistant was overwriting the live instance with its historic snapshot.

Claude's summary:

Opening a room whose history holds a tool result with a serialized card (from show-card, get-card, copy-card and similar tools whose result is the target card itself) replaced the live instance of that card in the store with the historical snapshot. `store.add(doc, { doNotPersist: true })` skips the initial write but still installs the instance under the doc's id, so the resident card flipped to stale data wherever it was rendered, and the next autosave wrote that stale state over the newer file.

`MessageTool.getCommandResultCard()` now renders the live card instead:

- Doc has an id: `store.get(id)` returns the resident instance, or loads the live card from the realm when nothing is resident yet (so opening the room before the card is also safe).
- Live card cannot be loaded (for example, deleted since): the snapshot is added as an id-less ephemeral copy, so it never aliases a realm id.
- Doc has no id (output-only result cards such as patch-fields): unchanged ephemeral path, no extra request.

Message attachments need no change; they stay `FileDef`s and never enter the store.

Two integration tests cover the resident and not-resident cases: the store instance keeps its live fields, the result renders the live data, and no save fires. Run against the previous `getCommandResultCard()`, both tests fail with the reported symptom: the card in the stack and the store instance flip to the snapshot's `firstName` ("Stale"), and the not-resident case leaves the snapshot in the store instead of the live card.
