### PR TITLE
Add the cross-tier record diff and its parity harness

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -55,6 +55,13 @@ jobs:
       - name: Check the execution protocol's runtime import closure
         if: ${{ !cancelled() }}
         run: pnpm run lint:protocol-closure
+      - name: Check every execution tier is registered for record parity
+        # RP-14.4: the parity harness compares the tiers it is handed, so an
+        # adapter nobody registered is not a failing comparison but an absent
+        # one. This holds the set of BoxelRuntime implementations equal to the
+        # set the harness knows about.
+        if: ${{ !cancelled() }}
+        run: pnpm run lint:tier-registry
       - name: Lint Boxel Icons
         if: ${{ !cancelled() }}
         run: pnpm run lint

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "openrouter:sync": "OPENROUTER_REALM_URL=${OPENROUTER_REALM_URL:-https://localhost:4201/openrouter/} pnpm --filter @cardstack/realm-server sync-openrouter-models",
     "prepare-worktree-types": "pnpm --filter @cardstack/boxel-icons build && pnpm --filter @cardstack/boxel-ui build",
     "prepare": "husky",
-    "lint:protocol-closure": "node ./scripts/check-protocol-import-closure.mts"
+    "lint:protocol-closure": "node ./scripts/check-protocol-import-closure.mts",
+    "lint:tier-registry": "node ./scripts/check-execution-tier-registry.mts"
   },
   "devDependencies": {
     "@actions/core": "catalog:",

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -598,12 +598,16 @@ function getFields(card: typeof CardDef): {
 
 // The child-format cascade (RP-2.6). `childFieldFormatsFor` in
 // `@cardstack/runtime-common/boxel-execution-protocol/child-formats` is the
-// same table for every consumer outside this file, and a conformance suite
-// holds that one to it — so an edit here that is not made there renders nested
-// cards in one format inside the Host and another wherever authored code is
-// caged, which neither side's own tests can see. This copy stays because a
-// realm module can only import what the host's virtual network shims, and
-// widening that surface is not this function's call to make.
+// same table for every consumer outside this file, so an edit here that is not
+// made there renders nested cards in one format inside the Host and another
+// wherever authored code is caged.
+//
+// Nothing checks that the two agree. This function is module-private, so a
+// conformance suite cannot reach it; the suite holds `childFieldFormatsFor` to
+// a table written out longhand, and this copy is held to nothing. Keeping them
+// aligned is a matter of editing both. The copy exists because a realm module
+// can only import what the host's virtual network shims, and widening that
+// surface is not this function's call to make.
 function defaultFieldFormats(containingFormat: Format): FieldFormats {
   switch (containingFormat) {
     case 'edit':

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -596,6 +596,14 @@ function getFields(card: typeof CardDef): {
   return fields;
 }
 
+// The child-format cascade (RP-2.6). `childFieldFormatsFor` in
+// `@cardstack/runtime-common/boxel-execution-protocol/child-formats` is the
+// same table for every consumer outside this file, and a conformance suite
+// holds that one to it — so an edit here that is not made there renders nested
+// cards in one format inside the Host and another wherever authored code is
+// caged, which neither side's own tests can see. This copy stays because a
+// realm module can only import what the host's virtual network shims, and
+// widening that surface is not this function's call to make.
 function defaultFieldFormats(containingFormat: Format): FieldFormats {
   switch (containingFormat) {
     case 'edit':

--- a/packages/host/tests/unit/rp-14-4-record-parity-test.ts
+++ b/packages/host/tests/unit/rp-14-4-record-parity-test.ts
@@ -751,16 +751,39 @@ module('Unit | rendering protocol | cross-tier record parity', function () {
     }
   });
 
-  test('RP-14.4: an exemption covering no path is reported rather than read as satisfied', function (assert) {
-    let diff = diffRecords(description(), description(), {
-      exemptPaths: ['presentaton.displayName'],
+  test('RP-14.4: an empty exemption exempts nothing rather than everything', function (assert) {
+    // Coverage is prefix-closed, and the empty path is a prefix of every path,
+    // so honoring one would silence the whole record and report parity. Nothing
+    // legitimately names it: the root of a record is not a member.
+    let reference = description();
+    let diff = diffRecords(
+      reference,
+      description({ boxelKind: 'field', ancestors: [] }),
+      { exemptPaths: [''] },
+    );
+    assert.strictEqual(diff.divergences.length, 2);
+    assert.false(recordsAgree(diff), describeRecordDiff(diff));
+  });
+
+  test('RP-14.4: a record this protocol cannot use is not compared against a peer', function (assert) {
+    // The fault says the record declares a version this consumer does not
+    // implement. Comparing it anyway would report divergences beneath a record
+    // the run has just declared unusable, and count the pair as checked.
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        tier('direct'),
+        tier('capsule', {
+          description: { ...description(), protocolVersion: 2 },
+        }),
+      ],
+      registeredModes: ['direct', 'capsule'],
     });
-    assert.deepEqual(diff.divergences, []);
-    assert.deepEqual(diff.exemptionsUnused, ['presentaton.displayName']);
-    // An exemption is a claim that a member legitimately differs between
-    // tiers. One matching nothing is a claim about a member that is not there.
-    assert.false(recordsAgree(diff));
-    assert.true(describeRecordDiff(diff).includes('covered no path'));
+    let faults = findingsOfKind(report, 'fault');
+    assert.strictEqual(faults.length, 1);
+    assert.strictEqual(faults[0].code, 'BOXEL_PROTOCOL_VERSION_UNSUPPORTED');
+    assert.strictEqual(findingsOfKind(report, 'divergence').length, 0);
+    assert.strictEqual(report.comparisons, 1);
   });
 
   test('RP-14.4: a concrete array index in an exemption names that member of every element', function (assert) {

--- a/packages/host/tests/unit/rp-14-4-record-parity-test.ts
+++ b/packages/host/tests/unit/rp-14-4-record-parity-test.ts
@@ -532,9 +532,9 @@ module('Unit | rendering protocol | cross-tier record parity', function () {
   });
 
   test('RP-14.4: the spec declares no tier-specific record paths, so the diff is total', function (assert) {
-    // RP-14.4's "modulo fields this spec explicitly declares tier-specific
-    // (currently: none)". An entry appearing here without a statement declaring
-    // it means a member stopped being compared and nothing said so.
+    // RP-14.4's "modulo fields this spec explicitly declares tier-specific".
+    // An entry here without a statement declaring it means a member is not
+    // compared and nothing says so.
     assert.deepEqual([...TIER_SPECIFIC_RECORD_PATHS], []);
   });
 
@@ -692,7 +692,7 @@ module('Unit | rendering protocol | cross-tier record parity', function () {
     assert.strictEqual(absent[0].mode, 'capsule');
   });
 
-  test('RP-14.4: the harness honors the declared tier-specific paths by default', function (assert) {
+  test('RP-14.4: an exemption suppresses a divergence the harness would otherwise report', function (assert) {
     let reference = projection();
     let report = checkRecordParity({
       fixture: 'person/1',
@@ -723,6 +723,153 @@ module('Unit | rendering protocol | cross-tier record parity', function () {
       registeredModes: ['direct', 'capsule'],
     });
     assert.strictEqual(findingsOfKind(unexempted, 'divergence').length, 1);
+  });
+
+  test('RP-14.4: an exemption does not silence a divergence at a path it does not cover', function (assert) {
+    // `personRef` is one object reached from `ref`, from `fields[1].type` and
+    // from `formats[0].provider.ref`, so a memo entered on behalf of an exempt
+    // path would mark that object compared and skip every other path to it —
+    // exempting one member silencing divergences at unrelated ones, with visit
+    // order deciding which.
+    let wrongRef = { module: personRef.module, name: 'PERSON' };
+    let reference = description();
+    let candidate = description({
+      ref: wrongRef,
+      fields: [reference.fields[0], { ...reference.fields[1], type: wrongRef }],
+      formats: [
+        { format: 'isolated', provider: { kind: 'authored', ref: wrongRef } },
+      ],
+    });
+    for (let exemption of ['ref', 'fields[].type', 'formats']) {
+      let diff = diffRecords(reference, candidate, {
+        exemptPaths: [exemption],
+      });
+      assert.false(
+        recordsAgree(diff),
+        `exempting ${exemption} — ${describeRecordDiff(diff)}`,
+      );
+    }
+  });
+
+  test('RP-14.4: an exemption covering no path is reported rather than read as satisfied', function (assert) {
+    let diff = diffRecords(description(), description(), {
+      exemptPaths: ['presentaton.displayName'],
+    });
+    assert.deepEqual(diff.divergences, []);
+    assert.deepEqual(diff.exemptionsUnused, ['presentaton.displayName']);
+    // An exemption is a claim that a member legitimately differs between
+    // tiers. One matching nothing is a claim about a member that is not there.
+    assert.false(recordsAgree(diff));
+    assert.true(describeRecordDiff(diff).includes('covered no path'));
+  });
+
+  test('RP-14.4: a concrete array index in an exemption names that member of every element', function (assert) {
+    let reference = description();
+    let diff = diffRecords(
+      reference,
+      description({
+        fields: [
+          { ...reference.fields[0], isComputed: true },
+          reference.fields[1],
+        ],
+      }),
+      { exemptPaths: ['fields[0].isComputed'] },
+    );
+    // Wildcarded on both sides, so an index names the shape rather than one
+    // position — an exemption that matched no position would be a rule doing
+    // nothing while reading as satisfied.
+    assert.true(recordsAgree(diff), describeRecordDiff(diff));
+  });
+
+  test('RP-14.4: a record carrying no envelope is not a usable record of this protocol', function (assert) {
+    // `{}` is inert data and it is a record, and it is not a description: it
+    // carries no protocol version, so RP-14.3's gate refuses it. Two tiers that
+    // each produced one agree at every path, which is the same false green as
+    // two tiers that each produced nothing.
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        { mode: 'direct', description: {}, projection: {} },
+        { mode: 'capsule', description: {}, projection: {} },
+      ],
+      registeredModes: ['direct', 'capsule'],
+    });
+    assert.false(reportsParity(report), describeParityReport(report));
+    assert.strictEqual(findingsOfKind(report, 'fault').length, 4);
+  });
+
+  test('RP-14.4: a tier whose mode the protocol does not declare is inspected, not skipped', function (assert) {
+    // A tier's mode is data, and a Sandbox tier's arrives across the boundary
+    // this module exists to distrust. Iterating only the declared modes would
+    // leave a typo'd or forged one uninspected, uncompared and unreported while
+    // the run reports no findings.
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        tier('direct'),
+        {
+          mode: 'capsule-next' as BoxelExecutionMode,
+          description: null,
+          projection: projection(),
+        },
+      ],
+      registeredModes: ['direct'],
+    });
+    assert.false(reportsParity(report), describeParityReport(report));
+    assert.deepEqual(
+      findingsOfKind(report, 'mode-unregistered').map(
+        (finding) => finding.mode,
+      ),
+      ['capsule-next' as BoxelExecutionMode],
+    );
+    assert.strictEqual(findingsOfKind(report, 'fault').length, 1);
+    assert.strictEqual(report.inspections, 2 * PARITY_RECORD_KINDS.length);
+  });
+
+  test('RP-14.4: two tiers handed the same record are reported rather than agreeing for free', function (assert) {
+    let records = { description: description(), projection: projection() };
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        { mode: 'direct', ...records },
+        { mode: 'capsule', ...records },
+      ],
+      registeredModes: ['direct', 'capsule'],
+    });
+    assert.false(reportsParity(report), describeParityReport(report));
+    assert.deepEqual(
+      findingsOfKind(report, 'records-shared').map((finding) => finding.record),
+      [...PARITY_RECORD_KINDS],
+    );
+  });
+
+  test('RP-14.4: the comparison count names the pairs actually compared', function (assert) {
+    let liveDescription: Record<string, unknown> = { ...description() };
+    Object.defineProperty(liveDescription, 'boxelKind', {
+      get: () => 'card',
+      enumerable: true,
+      configurable: true,
+    });
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        {
+          mode: 'direct',
+          description: liveDescription,
+          projection: projection(),
+        },
+        tier('capsule'),
+      ],
+      registeredModes: ['direct', 'capsule'],
+    });
+    // The description pair was never compared — one side is not a record — so
+    // counting it would have the coverage line claim a check that did not run.
+    assert.strictEqual(report.comparisons, 1);
+    assert.strictEqual(findingsOfKind(report, 'fault').length, 1);
+    assert.true(
+      describeParityReport(report).includes('1 record comparison(s)'),
+      describeParityReport(report),
+    );
   });
 
   test('RP-14.4: a divergence past the report limit is carried into the parity report', function (assert) {

--- a/packages/host/tests/unit/rp-14-4-record-parity-test.ts
+++ b/packages/host/tests/unit/rp-14-4-record-parity-test.ts
@@ -320,12 +320,26 @@ module('Unit | rendering protocol | cross-tier record parity', function () {
     );
   });
 
-  test('RP-14.4: a divergence at the record itself is reported at the root', function (assert) {
+  test('RP-14.4: a side that is not a record at all is a fault about that side', function (assert) {
     let diff = diffRecords(description(), 'a description');
-    assert.strictEqual(diff.divergences.length, 1);
-    assert.strictEqual(diff.divergences[0].path, '');
-    assert.strictEqual(diff.divergences[0].reason, 'shape');
-    assert.true(describeRecordDiff(diff).startsWith('(the record)'));
+    assert.strictEqual(diff.faults.length, 1);
+    assert.strictEqual(diff.faults[0].side, 'candidate');
+    assert.strictEqual(diff.faults[0].code, 'BOXEL_RECORD_MALFORMED');
+    assert.strictEqual(diff.divergences.length, 0);
+  });
+
+  test('RP-14.4: two producers that both answered with no record do not agree', function (assert) {
+    // `null`, a string and an empty array are all inert data, so two producers
+    // that answered with the same one of them agree at every path. Requiring
+    // the root to be a record is what keeps "both tiers produced nothing" from
+    // reading as "the tiers agree" — the false green this harness exists for.
+    for (let answered of [null, 'a description', 42, [], undefined]) {
+      let diff = diffRecords(answered, answered);
+      assert.false(
+        recordsAgree(diff),
+        `${describeRecordDiff(diff)} for ${JSON.stringify(answered) ?? 'undefined'}`,
+      );
+    }
   });
 
   test('RP-14.4: sharing on one side and duplication on the other is not a divergence', function (assert) {
@@ -560,6 +574,26 @@ module('Unit | rendering protocol | cross-tier record parity', function () {
     assert.strictEqual(faults.length, 1);
     assert.strictEqual(faults[0].mode, PARITY_REFERENCE_MODE);
     assert.strictEqual(faults[0].record, 'projection');
+  });
+
+  test('RP-14.4: tiers that all answered with nothing are not at parity', function (assert) {
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        { mode: 'direct', description: null, projection: null },
+        { mode: 'capsule', description: null, projection: null },
+      ],
+      registeredModes: ['direct', 'capsule'],
+    });
+    assert.false(reportsParity(report), describeParityReport(report));
+    // One per tier per record kind: the claim is about each record on its own,
+    // so neither tier is excused by its peer having done the same thing.
+    let faults = findingsOfKind(report, 'fault');
+    assert.strictEqual(faults.length, 4);
+    assert.deepEqual(
+      [...new Set(faults.map((fault) => fault.mode))],
+      ['direct', 'capsule'],
+    );
   });
 
   test('RP-14.4: a candidate tier diverging from Direct is attributed to that tier and record', function (assert) {

--- a/packages/host/tests/unit/rp-14-4-record-parity-test.ts
+++ b/packages/host/tests/unit/rp-14-4-record-parity-test.ts
@@ -1,0 +1,714 @@
+import { module, test } from 'qunit';
+
+import {
+  PARITY_RECORD_KINDS,
+  PARITY_REFERENCE_MODE,
+  REPORTED_DIVERGENCE_LIMIT,
+  TIER_SPECIFIC_RECORD_PATHS,
+  checkRecordParity,
+  describeParityReport,
+  describeRecordDiff,
+  diffRecords,
+  recordsAgree,
+  reportsParity,
+} from '@cardstack/runtime-common/boxel-execution-conformance';
+import type {
+  ParityFinding,
+  ParityReport,
+  RecordDiff,
+  RecordDivergence,
+  TierRecords,
+} from '@cardstack/runtime-common/boxel-execution-conformance';
+import { BOXEL_EXECUTION_PROTOCOL_VERSION } from '@cardstack/runtime-common/boxel-execution-protocol';
+import type {
+  BoxelDescription,
+  BoxelExecutionMode,
+  InstanceProjection,
+} from '@cardstack/runtime-common/boxel-execution-protocol';
+import { rri } from '@cardstack/runtime-common/realm-identifiers';
+
+const personRef = { module: rri('http://test/person'), name: 'Person' };
+const stringRef = { module: rri('@cardstack/base/string'), name: 'default' };
+const cardDefRef = { module: rri('@cardstack/base/card-api'), name: 'CardDef' };
+
+function description(
+  overrides: Partial<BoxelDescription> = {},
+): BoxelDescription {
+  return {
+    protocolVersion: BOXEL_EXECUTION_PROTOCOL_VERSION,
+    requiredFeatures: [],
+    ref: personRef,
+    boxelKind: 'card',
+    ancestors: [cardDefRef],
+    fields: [
+      {
+        fieldName: 'title',
+        type: stringRef,
+        kind: 'contains',
+        isComputed: false,
+      },
+      {
+        fieldName: 'vendor',
+        type: personRef,
+        kind: 'linksTo',
+        isComputed: false,
+      },
+    ],
+    formats: [
+      { format: 'isolated', provider: { kind: 'authored', ref: personRef } },
+    ],
+    presentation: {
+      displayName: 'Person',
+      headerColor: null,
+      prefersWideFormat: false,
+    },
+    executionHints: { prefersFullSandbox: false },
+    ...overrides,
+  };
+}
+
+function projection(
+  overrides: Partial<InstanceProjection> = {},
+): InstanceProjection {
+  return {
+    protocolVersion: BOXEL_EXECUTION_PROTOCOL_VERSION,
+    requiredFeatures: [],
+    id: rri('http://test/people/1'),
+    type: personRef,
+    revision: 3,
+    model: {
+      title: 'Ada',
+      vendor: { $boxel: { id: 'http://test/vendors/1', type: personRef } },
+    },
+    presentation: {
+      title: 'Ada',
+      summary: null,
+      thumbnailURL: null,
+      isThemed: true,
+      theme: { $boxel: { id: rri('http://test/themes/1'), type: personRef } },
+      themeScope: 'http://test/themes/1-9f2c1a',
+      themeCss: '--boxel-accent: rebeccapurple;',
+      cssImports: ['https://fonts.example/inter.css'],
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * A description with whatever a producer actually sent in place of a member,
+ * including the things `Cloneable` forbids and `any` lets through anyway.
+ */
+function descriptionWith(overrides: Record<string, unknown>): unknown {
+  return { ...description(), ...overrides };
+}
+
+/**
+ * A projection whose model is whatever a producer actually sent, including the
+ * things `Cloneable` forbids and `any` lets through anyway.
+ */
+function projectionWithModel(model: Record<string, unknown>): unknown {
+  return { ...projection(), model };
+}
+
+function tier(
+  mode: BoxelExecutionMode,
+  overrides: Partial<Omit<TierRecords, 'mode'>> = {},
+): TierRecords {
+  return {
+    mode,
+    description: description(),
+    projection: projection(),
+    ...overrides,
+  };
+}
+
+function divergenceAt(
+  diff: RecordDiff,
+  path: string,
+): RecordDivergence | undefined {
+  return diff.divergences.find((divergence) => divergence.path === path);
+}
+
+function findingsOfKind<Kind extends ParityFinding['kind']>(
+  report: ParityReport,
+  kind: Kind,
+): Extract<ParityFinding, { kind: Kind }>[] {
+  return report.findings.filter(
+    (finding): finding is Extract<ParityFinding, { kind: Kind }> =>
+      finding.kind === kind,
+  );
+}
+
+module('Unit | rendering protocol | cross-tier record parity', function () {
+  test('RP-14.4: two tiers that built the same records from one input agree', function (assert) {
+    let diff = diffRecords(description(), structuredClone(description()));
+    assert.true(recordsAgree(diff), describeRecordDiff(diff));
+    assert.strictEqual(describeRecordDiff(diff), 'the records agree');
+    let projectionDiff = diffRecords(
+      projection(),
+      structuredClone(projection()),
+    );
+    assert.true(
+      recordsAgree(projectionDiff),
+      describeRecordDiff(projectionDiff),
+    );
+  });
+
+  test('RP-14.4: member order is not part of a record', function (assert) {
+    let reference = description();
+    // The same members, assigned in the opposite order — which is what two
+    // producers building one record through different code produce.
+    let reordered: Record<string, unknown> = {};
+    for (let name of Object.keys(reference).reverse()) {
+      reordered[name] = (reference as Record<string, unknown>)[name];
+    }
+    let diff = diffRecords(reference, reordered);
+    assert.true(recordsAgree(diff), describeRecordDiff(diff));
+  });
+
+  test('RP-14.4: the report reads the same whichever producer laid its keys out first', function (assert) {
+    // Reported in sorted member order rather than in the order either producer
+    // happened to write. Following one side's key order makes the same pair of
+    // records produce a different report depending on which one is the
+    // reference, which is not a thing a CI log should have to explain.
+    let diff = diffRecords(
+      projectionWithModel({ zeta: 1, alpha: 2 }),
+      projectionWithModel({ zeta: 9, alpha: 9 }),
+    );
+    assert.deepEqual(
+      diff.divergences.map((divergence) => divergence.path),
+      ['model.alpha', 'model.zeta'],
+    );
+  });
+
+  test('RP-14.4: element order is part of a record', function (assert) {
+    let reference = description();
+    let swapped = description({
+      fields: [reference.fields[1], reference.fields[0]],
+    });
+    let diff = diffRecords(reference, swapped);
+    assert.strictEqual(
+      divergenceAt(diff, 'fields[0].fieldName')?.reference,
+      '"title"',
+    );
+    assert.strictEqual(
+      divergenceAt(diff, 'fields[1].fieldName')?.candidate,
+      '"title"',
+    );
+  });
+
+  test('RP-14.4: a scalar divergence names the path that reaches it', function (assert) {
+    let diff = diffRecords(
+      description(),
+      description({
+        presentation: {
+          displayName: 'Human',
+          headerColor: null,
+          prefersWideFormat: false,
+        },
+      }),
+    );
+    assert.strictEqual(diff.divergences.length, 1);
+    assert.deepEqual(diff.divergences[0], {
+      path: 'presentation.displayName',
+      reason: 'value',
+      reference: '"Person"',
+      candidate: '"Human"',
+    });
+  });
+
+  test('RP-14.4: a divergence inside an array names the element it is in', function (assert) {
+    let reference = description();
+    let candidate = description({
+      fields: [
+        { ...reference.fields[0], kind: 'containsMany' },
+        reference.fields[1],
+      ],
+    });
+    let diff = diffRecords(reference, candidate);
+    assert.strictEqual(diff.divergences.length, 1);
+    assert.strictEqual(diff.divergences[0].path, 'fields[0].kind');
+    assert.strictEqual(diff.divergences[0].reason, 'value');
+  });
+
+  test('RP-14.4: an absent member and a member whose value is undefined are different', function (assert) {
+    let absent = diffRecords(
+      projectionWithModel({ title: 'Ada', note: undefined }),
+      projectionWithModel({ title: 'Ada' }),
+    );
+    assert.strictEqual(divergenceAt(absent, 'model.note')?.reason, 'absent');
+    assert.strictEqual(
+      divergenceAt(absent, 'model.note')?.reference,
+      'undefined',
+    );
+    assert.strictEqual(divergenceAt(absent, 'model.note')?.candidate, 'absent');
+
+    let nulled = diffRecords(
+      projectionWithModel({ note: undefined }),
+      projectionWithModel({ note: null }),
+    );
+    assert.strictEqual(divergenceAt(nulled, 'model.note')?.reason, 'value');
+    assert.strictEqual(divergenceAt(nulled, 'model.note')?.candidate, 'null');
+  });
+
+  test('RP-14.4: -0 and 0 are different values, and a report that renders both as 0 would hide it', function (assert) {
+    let diff = diffRecords(
+      projectionWithModel({ balance: 0 }),
+      projectionWithModel({ balance: -0 }),
+    );
+    assert.strictEqual(divergenceAt(diff, 'model.balance')?.reason, 'value');
+    assert.strictEqual(divergenceAt(diff, 'model.balance')?.reference, '0');
+    assert.strictEqual(divergenceAt(diff, 'model.balance')?.candidate, '-0');
+  });
+
+  test('RP-14.4: NaN on both sides is agreement, and a report names it', function (assert) {
+    let agree = diffRecords(
+      projectionWithModel({ total: NaN }),
+      projectionWithModel({ total: NaN }),
+    );
+    assert.true(recordsAgree(agree), describeRecordDiff(agree));
+
+    let diverge = diffRecords(
+      projectionWithModel({ total: NaN }),
+      projectionWithModel({ total: null }),
+    );
+    assert.strictEqual(divergenceAt(diverge, 'model.total')?.reference, 'NaN');
+  });
+
+  test('RP-14.4: an array of a different length reports the lengths', function (assert) {
+    let reference = description();
+    let diff = diffRecords(
+      reference,
+      description({ fields: [reference.fields[0]] }),
+    );
+    let divergence = divergenceAt(diff, 'fields');
+    assert.strictEqual(divergence?.reason, 'length');
+    assert.strictEqual(divergence?.reference, '2');
+    assert.strictEqual(divergence?.candidate, '1');
+    // The elements the two share are still compared, and they still agree, so
+    // the length is the only thing reported.
+    assert.strictEqual(diff.divergences.length, 1);
+  });
+
+  test('RP-14.4: a container where the other side has a scalar is a shape divergence', function (assert) {
+    let diff = diffRecords(
+      description(),
+      descriptionWith({ ancestors: 'CardDef' }),
+    );
+    assert.strictEqual(divergenceAt(diff, 'ancestors')?.reason, 'shape');
+  });
+
+  test('RP-14.4: a tier that expanded a link where the reference carried a reference diverges', function (assert) {
+    // The projection is one instance deep: a linked value crosses as
+    // `{$boxel:{id,type}}` and never as the linked card's own data (RP-14.1).
+    // A tier that walked the graph instead disagrees with Direct here.
+    let diff = diffRecords(
+      projection(),
+      projectionWithModel({
+        title: 'Ada',
+        vendor: { id: 'http://test/vendors/1', title: 'Analytical Engines' },
+      }),
+    );
+    assert.strictEqual(
+      divergenceAt(diff, 'model.vendor.$boxel')?.reason,
+      'absent',
+    );
+    assert.strictEqual(divergenceAt(diff, 'model.vendor.id')?.reason, 'absent');
+    assert.strictEqual(
+      divergenceAt(diff, 'model.vendor.title')?.reason,
+      'absent',
+    );
+  });
+
+  test('RP-14.4: a divergence at the record itself is reported at the root', function (assert) {
+    let diff = diffRecords(description(), 'a description');
+    assert.strictEqual(diff.divergences.length, 1);
+    assert.strictEqual(diff.divergences[0].path, '');
+    assert.strictEqual(diff.divergences[0].reason, 'shape');
+    assert.true(describeRecordDiff(diff).startsWith('(the record)'));
+  });
+
+  test('RP-14.4: sharing on one side and duplication on the other is not a divergence', function (assert) {
+    let shared: BoxelDescription['formats'][number] = {
+      format: 'isolated',
+      provider: { kind: 'authored', ref: personRef },
+    };
+    let reference = description({ formats: [shared, shared] });
+    let candidate = description({
+      formats: [structuredClone(shared), structuredClone(shared)],
+    });
+    let diff = diffRecords(reference, candidate);
+    assert.true(recordsAgree(diff), describeRecordDiff(diff));
+  });
+
+  test('RP-14.4: a subgraph two records share is compared once, not once per path', function (assert) {
+    // Forty levels of a node with two parents is forty values and 2^40 paths.
+    // A diff that walks paths never answers on a record the boundary accepts.
+    let deep: unknown = { leaf: true };
+    for (let level = 0; level < 40; level++) {
+      deep = { left: deep, right: deep };
+    }
+    let diff = diffRecords(deep, structuredClone(deep));
+    assert.true(recordsAgree(diff), describeRecordDiff(diff));
+  });
+
+  test('RP-14.4: a record carrying an accessor is a fault naming the member, not a divergence', function (assert) {
+    let live: Record<string, unknown> = {};
+    Object.defineProperty(live, 'title', {
+      get: () => 'Ada',
+      enumerable: true,
+      configurable: true,
+    });
+    let diff = diffRecords(projectionWithModel(live), projection());
+    assert.strictEqual(diff.faults.length, 1);
+    assert.strictEqual(diff.faults[0].side, 'reference');
+    assert.strictEqual(diff.faults[0].code, 'BOXEL_RECORD_MALFORMED');
+    assert.true(diff.faults[0].message.includes('"title" is an accessor'));
+    assert.true(
+      describeRecordDiff(diff).startsWith('reference is not a record:'),
+      describeRecordDiff(diff),
+    );
+    // Nothing is compared against a value that is not a record: reporting a
+    // divergence at every path would say nothing the fault has not.
+    assert.strictEqual(diff.divergences.length, 0);
+    assert.false(recordsAgree(diff));
+  });
+
+  test('RP-14.4: a record carrying a function is a fault', function (assert) {
+    let diff = diffRecords(
+      projection(),
+      projectionWithModel({ recompute: () => 'Ada' }),
+    );
+    assert.strictEqual(diff.faults.length, 1);
+    assert.strictEqual(diff.faults[0].side, 'candidate');
+    assert.true(diff.faults[0].message.includes('not data: function'));
+  });
+
+  test('RP-14.4: a record whose member has a prototype of its own is a fault', function (assert) {
+    class LiveModel {
+      title = 'Ada';
+    }
+    let diff = diffRecords(
+      projection(),
+      projectionWithModel({ nested: new LiveModel() }),
+    );
+    assert.strictEqual(diff.faults.length, 1);
+    assert.true(
+      diff.faults[0].message.includes('a prototype of its own'),
+      diff.faults[0].message,
+    );
+  });
+
+  test('RP-14.4: a symbol-keyed member is a fault', function (assert) {
+    let diff = diffRecords(
+      projection(),
+      projectionWithModel({ nested: { title: 'Ada', [Symbol('hidden')]: 1 } }),
+    );
+    assert.strictEqual(diff.faults.length, 1);
+    assert.true(
+      diff.faults[0].message.includes('symbol-keyed'),
+      diff.faults[0].message,
+    );
+  });
+
+  test('RP-14.4: a record that contains itself is a fault rather than a harness that never answers', function (assert) {
+    let cyclic: Record<string, unknown> = { title: 'Ada' };
+    cyclic.self = cyclic;
+    let diff = diffRecords(projectionWithModel(cyclic), projection());
+    assert.strictEqual(diff.faults.length, 1);
+    assert.true(
+      diff.faults[0].message.includes('contains itself'),
+      diff.faults[0].message,
+    );
+  });
+
+  test('RP-14.4: a value that throws from its own trap leaves the diff as a fault', function (assert) {
+    let hostile = new Proxy({} as Record<string, unknown>, {
+      ownKeys: () => ['title'],
+      getOwnPropertyDescriptor: () => {
+        throw new Error('trap');
+      },
+    });
+    let diff = diffRecords(
+      projection(),
+      projectionWithModel({ nested: hostile }),
+    );
+    assert.strictEqual(diff.faults.length, 1);
+    assert.strictEqual(diff.faults[0].code, 'BOXEL_RECORD_MALFORMED');
+    assert.true(
+      diff.faults[0].message.includes('raised an error'),
+      diff.faults[0].message,
+    );
+  });
+
+  test('RP-14.4: the report is bounded in count and states the number it found', function (assert) {
+    let reference: Record<string, unknown> = {};
+    let candidate: Record<string, unknown> = {};
+    let divergent = REPORTED_DIVERGENCE_LIMIT + 15;
+    for (let index = 0; index < divergent; index++) {
+      reference[`field${index}`] = 'reference';
+      candidate[`field${index}`] = 'candidate';
+    }
+    let diff = diffRecords(
+      projectionWithModel(reference),
+      projectionWithModel(candidate),
+    );
+    assert.strictEqual(diff.divergences.length, REPORTED_DIVERGENCE_LIMIT);
+    // The count it found, not the count it printed: a tier developer told they
+    // have twenty-five when they have forty fixes twenty-five and re-runs.
+    assert.strictEqual(diff.withheld, divergent - REPORTED_DIVERGENCE_LIMIT);
+    assert.true(
+      describeRecordDiff(diff).includes(
+        `and ${divergent - REPORTED_DIVERGENCE_LIMIT} more`,
+      ),
+    );
+  });
+
+  test('RP-14.4: a divergent value is bounded in size', function (assert) {
+    let diff = diffRecords(
+      projectionWithModel({ body: 'a'.repeat(5000) }),
+      projectionWithModel({ body: 'b'.repeat(5000) }),
+    );
+    let rendered = divergenceAt(diff, 'model.body')?.reference ?? '';
+    assert.true(
+      rendered.length < 200,
+      `rendered ${rendered.length} characters`,
+    );
+    assert.true(rendered.endsWith('…'));
+  });
+
+  test('RP-14.4: an exempt path is not compared, and neither is anything under it', function (assert) {
+    let reference = projection();
+    let candidate = projection({
+      presentation: { ...reference.presentation, themeScope: 'other-scope' },
+    });
+    let compared = diffRecords(reference, candidate);
+    assert.strictEqual(compared.divergences.length, 1);
+
+    let exempted = diffRecords(reference, candidate, {
+      exemptPaths: ['presentation'],
+    });
+    assert.true(recordsAgree(exempted), describeRecordDiff(exempted));
+  });
+
+  test('RP-14.4: an exemption names a member of the record shape, not one element position', function (assert) {
+    let reference = description();
+    let candidate = description({
+      fields: [
+        { ...reference.fields[0], isComputed: true },
+        { ...reference.fields[1], isComputed: true },
+      ],
+    });
+    let diff = diffRecords(reference, candidate, {
+      exemptPaths: ['fields[].isComputed'],
+    });
+    assert.true(recordsAgree(diff), describeRecordDiff(diff));
+    // The exemption is that member and no other.
+    let neighbour = diffRecords(
+      reference,
+      description({
+        fields: [
+          { ...reference.fields[0], kind: 'containsMany' },
+          reference.fields[1],
+        ],
+      }),
+      { exemptPaths: ['fields[].isComputed'] },
+    );
+    assert.strictEqual(neighbour.divergences.length, 1);
+  });
+
+  test('RP-14.4: the spec declares no tier-specific record paths, so the diff is total', function (assert) {
+    // RP-14.4's "modulo fields this spec explicitly declares tier-specific
+    // (currently: none)". An entry appearing here without a statement declaring
+    // it means a member stopped being compared and nothing said so.
+    assert.deepEqual([...TIER_SPECIFIC_RECORD_PATHS], []);
+  });
+
+  test('RP-14.4: one tier is still held to its records being data, with nothing to compare', function (assert) {
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [tier(PARITY_REFERENCE_MODE)],
+      registeredModes: [PARITY_REFERENCE_MODE],
+    });
+    assert.true(reportsParity(report), describeParityReport(report));
+    assert.strictEqual(report.comparisons, 0);
+    assert.strictEqual(report.inspections, PARITY_RECORD_KINDS.length);
+    // The coverage is in the message whether or not anything failed, so a green
+    // run cannot read as "the tiers agree" when it means "there was one tier".
+    assert.true(
+      describeParityReport(report).includes('0 record comparison(s)'),
+      describeParityReport(report),
+    );
+  });
+
+  test('RP-14.4: a lone tier answering with something that is not a record still fails', function (assert) {
+    let live: Record<string, unknown> = {};
+    Object.defineProperty(live, 'title', {
+      get: () => 'Ada',
+      enumerable: true,
+      configurable: true,
+    });
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        tier(PARITY_REFERENCE_MODE, { projection: projectionWithModel(live) }),
+      ],
+      registeredModes: [PARITY_REFERENCE_MODE],
+    });
+    assert.false(reportsParity(report));
+    let faults = findingsOfKind(report, 'fault');
+    assert.strictEqual(faults.length, 1);
+    assert.strictEqual(faults[0].mode, PARITY_REFERENCE_MODE);
+    assert.strictEqual(faults[0].record, 'projection');
+  });
+
+  test('RP-14.4: a candidate tier diverging from Direct is attributed to that tier and record', function (assert) {
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        tier('direct'),
+        tier('capsule', { projection: projection({ revision: 4 }) }),
+      ],
+      registeredModes: ['direct', 'capsule'],
+    });
+    assert.false(reportsParity(report));
+    let divergences = findingsOfKind(report, 'divergence');
+    assert.strictEqual(divergences.length, 1);
+    assert.strictEqual(divergences[0].mode, 'capsule');
+    assert.strictEqual(divergences[0].record, 'projection');
+    assert.strictEqual(divergences[0].divergence.path, 'revision');
+    assert.true(
+      describeParityReport(report).includes('reference=3 capsule=4'),
+      describeParityReport(report),
+    );
+  });
+
+  test('RP-14.4: three tiers agreeing on both records report parity across every comparison', function (assert) {
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [tier('direct'), tier('capsule'), tier('sandbox')],
+      registeredModes: ['direct', 'capsule', 'sandbox'],
+    });
+    assert.true(reportsParity(report), describeParityReport(report));
+    assert.deepEqual(report.comparedModes, ['capsule', 'sandbox']);
+    assert.strictEqual(report.comparisons, 2 * PARITY_RECORD_KINDS.length);
+    assert.strictEqual(report.inspections, 3 * PARITY_RECORD_KINDS.length);
+  });
+
+  test('RP-14.4: tiers are compared in tier order however the caller listed them', function (assert) {
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [tier('sandbox'), tier('capsule'), tier('direct')],
+      registeredModes: ['direct', 'capsule', 'sandbox'],
+    });
+    assert.deepEqual(report.comparedModes, ['capsule', 'sandbox']);
+  });
+
+  test('RP-14.4: no reference tier is a finding, not a comparison between candidates', function (assert) {
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [tier('capsule'), tier('sandbox')],
+      registeredModes: ['capsule', 'sandbox'],
+    });
+    assert.false(reportsParity(report));
+    assert.strictEqual(findingsOfKind(report, 'reference-missing').length, 1);
+    assert.strictEqual(report.comparisons, 0);
+    // The records are still read as data, so a malformed one is not excused by
+    // the missing reference.
+    assert.strictEqual(report.inspections, 2 * PARITY_RECORD_KINDS.length);
+  });
+
+  test('RP-14.4: two tiers claiming one mode is a finding, because one of them went unchecked', function (assert) {
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        tier('direct'),
+        tier('capsule'),
+        tier('capsule', { projection: projection({ revision: 9 }) }),
+      ],
+      registeredModes: ['direct', 'capsule'],
+    });
+    assert.false(reportsParity(report));
+    let repeated = findingsOfKind(report, 'mode-repeated');
+    assert.strictEqual(repeated.length, 1);
+    assert.strictEqual(repeated[0].mode, 'capsule');
+  });
+
+  test('RP-14.4: a tier the harness was not told about is a finding', function (assert) {
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [tier('direct'), tier('sandbox')],
+      registeredModes: ['direct'],
+    });
+    assert.false(reportsParity(report));
+    let unregistered = findingsOfKind(report, 'mode-unregistered');
+    assert.strictEqual(unregistered.length, 1);
+    assert.strictEqual(unregistered[0].mode, 'sandbox');
+  });
+
+  test('RP-14.4: a registered tier that produced no records is a finding, not a silent pass', function (assert) {
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [tier('direct')],
+      registeredModes: ['direct', 'capsule'],
+    });
+    assert.false(reportsParity(report));
+    let absent = findingsOfKind(report, 'mode-absent');
+    assert.strictEqual(absent.length, 1);
+    assert.strictEqual(absent[0].mode, 'capsule');
+  });
+
+  test('RP-14.4: the harness honors the declared tier-specific paths by default', function (assert) {
+    let reference = projection();
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        tier('direct'),
+        tier('capsule', {
+          projection: projection({
+            presentation: { ...reference.presentation, themeScope: 'other' },
+          }),
+        }),
+      ],
+      registeredModes: ['direct', 'capsule'],
+      exemptPaths: ['presentation.themeScope'],
+    });
+    assert.true(reportsParity(report), describeParityReport(report));
+    // Without the exemption the same pair diverges, so the exemption is what
+    // suppressed it rather than the records happening to agree.
+    let unexempted = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        tier('direct'),
+        tier('capsule', {
+          projection: projection({
+            presentation: { ...reference.presentation, themeScope: 'other' },
+          }),
+        }),
+      ],
+      registeredModes: ['direct', 'capsule'],
+    });
+    assert.strictEqual(findingsOfKind(unexempted, 'divergence').length, 1);
+  });
+
+  test('RP-14.4: a divergence past the report limit is carried into the parity report', function (assert) {
+    let reference: Record<string, unknown> = {};
+    let candidate: Record<string, unknown> = {};
+    for (let index = 0; index < REPORTED_DIVERGENCE_LIMIT + 4; index++) {
+      reference[`field${index}`] = 'reference';
+      candidate[`field${index}`] = 'candidate';
+    }
+    let report = checkRecordParity({
+      fixture: 'person/1',
+      tiers: [
+        tier('direct', { projection: projectionWithModel(reference) }),
+        tier('capsule', { projection: projectionWithModel(candidate) }),
+      ],
+      registeredModes: ['direct', 'capsule'],
+    });
+    let withheld = findingsOfKind(report, 'withheld');
+    assert.strictEqual(withheld.length, 1);
+    assert.strictEqual(withheld[0].count, 4);
+    assert.strictEqual(withheld[0].mode, 'capsule');
+  });
+});

--- a/packages/host/tests/unit/rp-14-4-record-parity-test.ts
+++ b/packages/host/tests/unit/rp-14-4-record-parity-test.ts
@@ -751,18 +751,28 @@ module('Unit | rendering protocol | cross-tier record parity', function () {
     }
   });
 
-  test('RP-14.4: an empty exemption exempts nothing rather than everything', function (assert) {
-    // Coverage is prefix-closed, and the empty path is a prefix of every path,
-    // so honoring one would silence the whole record and report parity. Nothing
-    // legitimately names it: the root of a record is not a member.
-    let reference = description();
-    let diff = diffRecords(
-      reference,
-      description({ boxelKind: 'field', ancestors: [] }),
-      { exemptPaths: [''] },
+  test('RP-14.4: an empty exemption is refused rather than exempting everything', function (assert) {
+    // Coverage is prefix-closed and the empty path is a prefix of every path, so
+    // honoring one silences the whole record and reports parity. Nothing
+    // legitimately names it — the root of a record is not a member — which
+    // makes it the one exemption that can be refused without guessing, and
+    // dropping it quietly would be a rule reading as satisfied while doing
+    // nothing.
+    assert.throws(
+      () =>
+        diffRecords(description(), description({ boxelKind: 'field' }), {
+          exemptPaths: [''],
+        }),
+      /must name a member/,
     );
-    assert.strictEqual(diff.divergences.length, 2);
-    assert.false(recordsAgree(diff), describeRecordDiff(diff));
+    // Mixed in with a real one, so the refusal is not conditional on being alone.
+    assert.throws(
+      () =>
+        diffRecords(description(), description({ boxelKind: 'field' }), {
+          exemptPaths: ['presentation', ''],
+        }),
+      /must name a member/,
+    );
   });
 
   test('RP-14.4: a record this protocol cannot use is not compared against a peer', function (assert) {

--- a/packages/host/tests/unit/rp-14-execution-protocol-test.ts
+++ b/packages/host/tests/unit/rp-14-execution-protocol-test.ts
@@ -2137,6 +2137,76 @@ module('Unit | rendering protocol | records and operations', function () {
     );
   });
 
+  test('RP-14.1, RP-14.3: a bounded diagnostic reports the offenders a producer sent, not the ones it printed', function (assert) {
+    // Bounding the list and reporting its length are two different things. A
+    // gate that names ten offenders and reports ten tells a tier developer
+    // with forty that they have ten — they fix those and re-run into the same
+    // refusal. Forty is deliberate: past the record's value ceiling the budget
+    // refuses first and the list never fills, which is why the bound tests do
+    // not reach this.
+    let refusalFor = (run: () => void): string => {
+      try {
+        run();
+        return '(no refusal)';
+      } catch (error) {
+        return (error as Error).message;
+      }
+    };
+    let forty = (build: (index: number) => unknown): unknown[] =>
+      Array.from({ length: 40 }, (_unused, index) => build(index));
+
+    let carried = bundle();
+    let kinds = refusalFor(() =>
+      acceptTemplateBundle(
+        {
+          ...carried,
+          templates: {
+            'template-0': {
+              ...carried.templates['template-0'],
+              scope: forty((index) => ({
+                kind: `not-a-kind-${index}`,
+              })) as unknown as TemplateDependency[],
+            },
+          },
+        },
+        support,
+      ),
+    );
+    let effects = refusalFor(() =>
+      acceptComponentUpdate(
+        update({
+          effects: forty((index) => ({
+            kind: `not-an-effect-${index}`,
+          })) as unknown as ComponentUpdate['effects'],
+        }),
+        support,
+      ),
+    );
+    let features = refusalFor(() =>
+      assertUsableExecutionRecord(
+        description({
+          requiredFeatures: forty((index) => `feature-${index}`) as string[],
+        }),
+        support,
+      ),
+    );
+
+    for (let [site, message] of [
+      ['a scope of unrecognized dependency kinds', kinds],
+      ['an update of unrecognized effect kinds', effects],
+      ['an envelope of unrecognized required features', features],
+    ]) {
+      assert.true(
+        message.includes('(and 30 more)'),
+        `${site} names the thirty it withheld — ${message}`,
+      );
+      assert.true(
+        message.length < 1000,
+        `${site} still renders a bounded diagnostic`,
+      );
+    }
+  });
+
   test('RP-14.3: every code the catalog declares is reachable, and every reachable refusal is declared', function (assert) {
     let thrown = new Set<string>();
     let attempts: (() => void)[] = [

--- a/packages/host/tests/unit/rp-14-execution-protocol-test.ts
+++ b/packages/host/tests/unit/rp-14-execution-protocol-test.ts
@@ -2144,6 +2144,12 @@ module('Unit | rendering protocol | records and operations', function () {
     // refusal. Forty is deliberate: past the record's value ceiling the budget
     // refuses first and the list never fills, which is why the bound tests do
     // not reach this.
+    //
+    // What this pins is the shared count, not any one site's container:
+    // `joinTokens` reads a plain array's length as its total, so an array and
+    // an offender list render the same message at the same count. The
+    // difference between them is retention, which no assertion on a message
+    // can see.
     let refusalFor = (run: () => void): string => {
       try {
         run();

--- a/packages/runtime-common/boxel-execution-conformance.ts
+++ b/packages/runtime-common/boxel-execution-conformance.ts
@@ -4,10 +4,10 @@
  * RP-15.4 names three pieces of conformance machinery. This module is the
  * third — the **record diff** (RP-14.4): for one input, every tier must
  * produce deep-equal `BoxelDescription` and `InstanceProjection` records,
- * modulo the members the spec declares tier-specific, of which there are
- * currently none. The other two, the main-equivalence oracle and the
- * cross-tier render suite, compare rendered behavior rather than records, and
- * are not here.
+ * modulo the members the spec declares tier-specific, which are enumerated in
+ * `TIER_SPECIFIC_RECORD_PATHS`. The other two, the main-equivalence oracle and
+ * the cross-tier render suite, compare rendered behavior rather than records,
+ * and are not here.
  *
  * Why this lives beside the protocol module rather than inside it: the two have
  * opposite constraints. The protocol module's runtime closure is held equal to
@@ -17,15 +17,15 @@
  * make the guard on that closure mean less rather than more. It reads the
  * protocol's own normalizer by path and adds nothing to what a cage carries.
  *
- * Why it lives in `runtime-common` rather than in a test suite: judging parity
- * is one rule, and more than one caller needs it. Today the caller is a host
- * conformance suite; the equivalence oracle will diff main's records against
- * Direct's with no tier notion at all, and a realm-server prerender assertion
- * will ask the same question of records built server-side. A rule that lives in
- * one suite gets a second copy the first time a second caller needs it, and
- * two parity rules is how the answer starts depending on who asked. The
- * precedent is `searchable-parity.ts`, which is shared between a
- * realm-server script and its tests for exactly that reason.
+ * Why it lives in `runtime-common` rather than in a test suite: what counts as
+ * record equality has to be one rule, and it is asked from more than one
+ * package — a harness comparing one tier's record against an expected one, a
+ * harness comparing two tiers, and a server-side assertion about records built
+ * in another process all ask it. A rule that lives inside one suite gets a
+ * second copy the first time a caller outside that suite needs it, and two
+ * parity rules is how the answer starts depending on who asked.
+ * `searchable-parity.ts` is the precedent: one diff rule here, imported by a
+ * realm-server script and by its tests.
  *
  * Deliberately absent from `index.ts`. Nothing on a render path calls this, so
  * a consumer names the file:

--- a/packages/runtime-common/boxel-execution-conformance.ts
+++ b/packages/runtime-common/boxel-execution-conformance.ts
@@ -17,13 +17,12 @@
  * make the guard on that closure mean less rather than more. It reads the
  * protocol's own normalizer by path and adds nothing to what a cage carries.
  *
- * Why it lives in `runtime-common` rather than in a test suite: what counts as
- * record equality has to be one rule, and it is asked from more than one
- * package — a harness comparing one tier's record against an expected one, a
- * harness comparing two tiers, and a server-side assertion about records built
- * in another process all ask it. A rule that lives inside one suite gets a
- * second copy the first time a caller outside that suite needs it, and two
- * parity rules is how the answer starts depending on who asked.
+ * Why it lives in `runtime-common` rather than in a test suite: record equality
+ * is a rule, not a fixture. The same question is asked of one tier's record
+ * against an expected one, of two tiers against each other, and of records
+ * built in another process — askers that do not share a package, so a rule
+ * living inside one suite would be copied the first time it was asked from
+ * outside. Two parity rules is how the answer starts depending on who asked.
  * `searchable-parity.ts` is the precedent: one diff rule here, imported by a
  * realm-server script and by its tests.
  *

--- a/packages/runtime-common/boxel-execution-conformance.ts
+++ b/packages/runtime-common/boxel-execution-conformance.ts
@@ -1,0 +1,36 @@
+/**
+ * The machinery that holds the execution tiers to the protocol they share.
+ *
+ * RP-15.4 names three pieces of conformance machinery. This module is the
+ * third — the **record diff** (RP-14.4): for one input, every tier must
+ * produce deep-equal `BoxelDescription` and `InstanceProjection` records,
+ * modulo the members the spec declares tier-specific, of which there are
+ * currently none. The other two, the main-equivalence oracle and the
+ * cross-tier render suite, compare rendered behavior rather than records, and
+ * are not here.
+ *
+ * Why this lives beside the protocol module rather than inside it: the two have
+ * opposite constraints. The protocol module's runtime closure is held equal to
+ * its own directory, because it is evaluated where the Host's module graph is
+ * absent — inside a SES Compartment and inside an iframe child. A conformance
+ * harness never crosses into either, and paying for it in every cage would
+ * make the guard on that closure mean less rather than more. It reads the
+ * protocol's own normalizer by path and adds nothing to what a cage carries.
+ *
+ * Why it lives in `runtime-common` rather than in a test suite: judging parity
+ * is one rule, and more than one caller needs it. Today the caller is a host
+ * conformance suite; the equivalence oracle will diff main's records against
+ * Direct's with no tier notion at all, and a realm-server prerender assertion
+ * will ask the same question of records built server-side. A rule that lives in
+ * one suite gets a second copy the first time a second caller needs it, and
+ * two parity rules is how the answer starts depending on who asked. The
+ * precedent is `searchable-parity.ts`, which is shared between a
+ * realm-server script and its tests for exactly that reason.
+ *
+ * Deliberately absent from `index.ts`. Nothing on a render path calls this, so
+ * a consumer names the file:
+ * `@cardstack/runtime-common/boxel-execution-conformance`.
+ */
+
+export * from './boxel-execution-conformance/record-diff.ts';
+export * from './boxel-execution-conformance/tier-parity.ts';

--- a/packages/runtime-common/boxel-execution-conformance/record-diff.ts
+++ b/packages/runtime-common/boxel-execution-conformance/record-diff.ts
@@ -124,7 +124,7 @@ export interface RecordDiffOptions {
    * tier-specific member is a property of the record shape rather than of one
    * element's position, and an exemption that matched no position at all would
    * be a rule that reads as satisfied while doing nothing. An empty entry is
-   * dropped: it would cover every path and silence the whole record.
+   * refused: it would cover every path and silence the whole record.
    */
   exemptPaths?: readonly string[];
 }
@@ -161,19 +161,32 @@ export function diffRecords(
  * The exemptions that can cover a path, wildcarded so an index names the
  * record's shape rather than one position.
  *
- * An empty entry is dropped rather than honored. Coverage is prefix-closed —
- * an exemption covers the path it names and everything under it — and the
- * empty path is a prefix of every path, so honoring one would silence the
- * whole record and report parity. Nothing legitimately names it: the root of a
- * record is not a member, and a member that differs is always named by a
- * non-empty path.
+ * An empty entry is refused rather than dropped. Coverage is prefix-closed — an
+ * exemption covers the path it names and everything under it — and the empty
+ * path is a prefix of every path, so honoring one silences the whole record and
+ * reports parity. Nothing legitimately names it: the root of a record is not a
+ * member, and a member that differs is always named by a non-empty path. That
+ * makes it the one exemption provably incapable of meaning anything, so it is
+ * the one this can refuse without guessing — and dropping it quietly would be
+ * the thing the exemption rules exist to prevent, a rule that reads as
+ * satisfied while doing nothing.
+ *
+ * This throws where the rest of the module reports, and the difference is whose
+ * data it is: a record comes from a producer across a trust boundary and must
+ * never be able to raise, while an exemption list is written by the caller
+ * beside the assertion it serves.
  */
 function activeExemptions(
   exemptPaths: readonly string[] | undefined,
 ): string[] {
-  return [...(exemptPaths ?? [])]
-    .map(wildcardIndices)
-    .filter((exemption) => exemption !== '');
+  let exemptions = [...(exemptPaths ?? [])].map(wildcardIndices);
+  if (exemptions.includes('')) {
+    throw new TypeError(
+      'an exempt path must name a member; the empty path names the record ' +
+        'itself and would exempt every member of it',
+    );
+  }
+  return exemptions;
 }
 
 /** Whether a diff found nothing to report. */

--- a/packages/runtime-common/boxel-execution-conformance/record-diff.ts
+++ b/packages/runtime-common/boxel-execution-conformance/record-diff.ts
@@ -44,7 +44,10 @@
 import stringify from 'safe-stable-stringify';
 
 import type { ProtocolRefusalCode } from '../boxel-execution-protocol/refusal.ts';
-import { isProtocolRefusal } from '../boxel-execution-protocol/refusal.ts';
+import {
+  isProtocolRefusal,
+  quoteToken,
+} from '../boxel-execution-protocol/refusal.ts';
 import {
   asRefusal,
   normalizeJsonRecord,
@@ -113,15 +116,29 @@ export interface RecordDiff {
   /** Divergences found past `REPORTED_DIVERGENCE_LIMIT` and not listed. */
   withheld: number;
   faults: RecordFault[];
+  /**
+   * Exemptions that covered no path in either record.
+   *
+   * An exemption is a claim that a member legitimately differs between tiers.
+   * One that matches nothing is a claim about a member neither record has —
+   * a typo, or a member that was renamed out from under it — and it reads as
+   * satisfied rather than as wrong unless something says so.
+   */
+  exemptionsUnused: string[];
 }
 
 export interface RecordDiffOptions {
   /**
    * Paths the spec declares tier-specific, which are therefore not compared
    * (RP-14.4). An exemption covers the path it names and everything under it,
-   * and array indices are wildcarded — `fields[].kind` exempts that member of
-   * every element, since a tier-specific member is a property of the record
-   * shape rather than of one element's position.
+   * and array indices are wildcarded on both sides — `fields[].kind` and
+   * `fields[0].kind` both exempt that member of every element, since a
+   * tier-specific member is a property of the record shape rather than of one
+   * element's position, and an exemption that matched no position at all would
+   * be a rule that reads as satisfied while doing nothing.
+   *
+   * An exemption covering no path in either record comes back in
+   * `exemptionsUnused`.
    */
   exemptPaths?: readonly string[];
 }
@@ -142,24 +159,46 @@ export function diffRecords(
   let referenceData = readAsData(reference, 'reference', faults);
   let candidateData = readAsData(candidate, 'candidate', faults);
   if (faults.length > 0) {
-    return { divergences: [], withheld: 0, faults };
+    return {
+      divergences: [],
+      withheld: 0,
+      faults,
+      exemptionsUnused: [],
+    };
   }
+  let exemptions = [...(options.exemptPaths ?? [])].map(wildcardIndices);
   let walk: Walk = {
     divergences: [],
     withheld: 0,
     compared: new Map(),
-    exemptions: [...(options.exemptPaths ?? [])],
+    exemptions,
+    exempted: new Set(),
   };
   compareValue(walk, '', referenceData, candidateData);
-  return { divergences: walk.divergences, withheld: walk.withheld, faults };
+  return {
+    divergences: walk.divergences,
+    withheld: walk.withheld,
+    faults,
+    exemptionsUnused: exemptions.filter(
+      (exemption) => !walk.exempted.has(exemption),
+    ),
+  };
 }
 
-/** Whether a diff found nothing to report. */
+/**
+ * Whether a diff found nothing to report.
+ *
+ * An unused exemption counts as something to report: it is a rule about a
+ * member neither record has, and a diff that answers "they agree" while
+ * carrying one is agreeing partly by a rule that applies to
+ * nothing.
+ */
 export function recordsAgree(diff: RecordDiff): boolean {
   return (
     diff.faults.length === 0 &&
     diff.divergences.length === 0 &&
-    diff.withheld === 0
+    diff.withheld === 0 &&
+    diff.exemptionsUnused.length === 0
   );
 }
 
@@ -193,13 +232,15 @@ export function describeRecordDiff(diff: RecordDiff): string {
   );
   for (let divergence of diff.divergences) {
     lines.push(
-      `${divergence.path === '' ? '(the record)' : divergence.path} ` +
-        `[${divergence.reason}] reference=${divergence.reference} ` +
-        `candidate=${divergence.candidate}`,
+      `${divergence.path} [${divergence.reason}] ` +
+        `reference=${divergence.reference} candidate=${divergence.candidate}`,
     );
   }
   if (diff.withheld > 0) {
     lines.push(`(and ${diff.withheld} more divergences not listed)`);
+  }
+  for (let exemption of diff.exemptionsUnused) {
+    lines.push(`the exemption ${quoteToken(exemption)} covered no path`);
   }
   return lines.length === 0 ? 'the records agree' : lines.join('\n');
 }
@@ -215,11 +256,15 @@ interface Walk {
    * parents has a number of *paths* exponential in its depth. Without this the
    * harness stops answering on a record it accepted.
    *
-   * The consequence to know: a divergence inside a shared subgraph is reported
-   * at the first path that reaches it, not at every path.
+   * Two consequences to know. A divergence inside a shared subgraph is
+   * reported at the first path that reaches it, not at every path. And the
+   * memo must never be reached for an exempt path, or exempting one member
+   * silences divergences at unrelated ones — which is why exemption prunes the
+   * descent in `compareValue` rather than filtering in `report`.
    */
   compared: Map<object, Set<object>>;
   exemptions: string[];
+  exempted: Set<string>;
 }
 
 /**
@@ -258,6 +303,16 @@ function compareValue(
   reference: Compared,
   candidate: Compared,
 ): void {
+  // Exemption prunes the descent rather than filtering the report, and that
+  // ordering is the whole of its correctness. Filtering at the report meant an
+  // exempt path still walked its subtree and still entered the compared-pair
+  // memo — so a subgraph two records share, reached first through an exempt
+  // path, was recorded as compared and every later non-exempt path to it was
+  // skipped. Exempting one member silenced divergences at unrelated members,
+  // and which ones depended on visit order.
+  if (isExempt(walk, path)) {
+    return;
+  }
   if (reference === ABSENT || candidate === ABSENT) {
     report(walk, path, 'absent', reference, candidate);
     return;
@@ -365,9 +420,6 @@ function report(
   reference: Compared,
   candidate: Compared,
 ): void {
-  if (isExempt(walk.exemptions, path)) {
-    return;
-  }
   if (walk.divergences.length >= REPORTED_DIVERGENCE_LIMIT) {
     walk.withheld += 1;
     return;
@@ -382,20 +434,38 @@ function report(
 
 /**
  * Whether a path is covered by an exemption: the exact path, or anything
- * beneath it. Compared with array indices removed, so an exemption describes
- * the record's shape rather than one element's position.
+ * beneath it.
+ *
+ * Both sides have their array indices removed, so an exemption describes the
+ * record's shape rather than one element's position — and one written with a
+ * concrete index means the member of every element rather than silently
+ * matching nothing.
+ *
+ * Which exemptions fired is recorded, because an exemption is a claim that a
+ * member legitimately differs between tiers, and one that matches nothing is
+ * a claim about a member that does not exist. Without this it reads as
+ * satisfied.
  */
-function isExempt(exemptions: string[], path: string): boolean {
-  if (exemptions.length === 0) {
+function isExempt(walk: Walk, path: string): boolean {
+  if (walk.exemptions.length === 0) {
     return false;
   }
-  let wildcarded = path.replace(/\[\d+\]/g, '[]');
-  return exemptions.some(
+  let wildcarded = wildcardIndices(path);
+  let covering = walk.exemptions.find(
     (exemption) =>
       wildcarded === exemption ||
       wildcarded.startsWith(`${exemption}.`) ||
       wildcarded.startsWith(`${exemption}[`),
   );
+  if (covering === undefined) {
+    return false;
+  }
+  walk.exempted.add(covering);
+  return true;
+}
+
+function wildcardIndices(path: string): string {
+  return path.replace(/\[\d+\]/g, '[]');
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/runtime-common/boxel-execution-conformance/record-diff.ts
+++ b/packages/runtime-common/boxel-execution-conformance/record-diff.ts
@@ -32,6 +32,13 @@
  * to itself is not compared at all. It is reported as a fault, naming the
  * member and the refusal code, because "these two records differ at every
  * path" says nothing that "this record is not data" has not already said.
+ *
+ * The root itself must be a record, and that is load-bearing rather than
+ * tidy. `null`, a string and an empty array are all inert data, so two
+ * producers that answered with the same one of them agree at every path — and
+ * a harness reporting parity over two tiers that each produced no record is
+ * exactly the false green this exists to prevent. A root that is not a record
+ * is a fault about that side.
  */
 
 import stringify from 'safe-stable-stringify';
@@ -40,7 +47,7 @@ import type { ProtocolRefusalCode } from '../boxel-execution-protocol/refusal.ts
 import { isProtocolRefusal } from '../boxel-execution-protocol/refusal.ts';
 import {
   asRefusal,
-  normalizeJsonData,
+  normalizeJsonRecord,
 } from '../boxel-execution-protocol/untrusted-input.ts';
 
 /**
@@ -157,10 +164,11 @@ export function recordsAgree(diff: RecordDiff): boolean {
 }
 
 /**
- * Why one record is not inert data, or `undefined` when it is.
+ * Why one value is not a record of inert data, or `undefined` when it is.
  *
  * Worth asking on its own: a harness with a single tier has nothing to diff,
- * and "the one record we have is data" is still a claim about it that can fail.
+ * and "the one record we have is a record" is still a claim about it that can
+ * fail — and it is the claim that fails when a producer answered with `null`.
  */
 export function faultInRecord(
   value: unknown,
@@ -232,7 +240,7 @@ function readAsData(
   faults: RecordFault[],
 ): unknown {
   try {
-    return asRefusal(() => normalizeJsonData(value));
+    return asRefusal(() => normalizeJsonRecord(value, 'a protocol record'));
   } catch (error) {
     // `asRefusal` is what makes the other branch unreachable; the check is
     // here because it is also what narrows `error` to something with a `code`.

--- a/packages/runtime-common/boxel-execution-conformance/record-diff.ts
+++ b/packages/runtime-common/boxel-execution-conformance/record-diff.ts
@@ -1,0 +1,423 @@
+/**
+ * Whether two producers built the same record, and where they parted (RP-14.4).
+ *
+ * Part of the cross-boundary execution conformance harness; see
+ * `../boxel-execution-conformance.ts` for what the harness is and what it is
+ * not.
+ *
+ * The equality this implements is equality *as a record*, which is narrower
+ * than `===` and wider than `JSON.stringify` on both sides:
+ *
+ * - **Member order is not part of a record.** Two producers that build the
+ *   same description through different code order their keys differently, and
+ *   a stringified comparison calls that a divergence. Members are compared by
+ *   name.
+ * - **Element order is.** `ancestors`, `fields` and `formats` are sequences a
+ *   consumer renders in order, so a tier that enumerates them differently has
+ *   diverged.
+ * - **Absent, `undefined` and `null` are three states, not one.** A member
+ *   with an `undefined` value survives `structuredClone` with its name intact,
+ *   so `'x' in record` distinguishes it from an absent one, and a consumer
+ *   reading it distinguishes both from `null`.
+ * - **`Object.is`, not `===`, compares scalars.** `NaN` and `-0` both cross a
+ *   boundary intact, so two producers can genuinely differ by `0` vs `-0` —
+ *   which is what a lane that JSON round-trips where it claims to
+ *   `structuredClone` looks like from here.
+ *
+ * Before anything is compared, each side is reduced to inert data by the
+ * protocol's own normalizer — the same call every gate makes. That is
+ * deliberate: a diff judging records by a looser rule than the boundary would
+ * call two records equal that the boundary then refuses. So a value carrying
+ * an accessor, a symbol-keyed member, a prototype of its own, or a reference
+ * to itself is not compared at all. It is reported as a fault, naming the
+ * member and the refusal code, because "these two records differ at every
+ * path" says nothing that "this record is not data" has not already said.
+ */
+
+import stringify from 'safe-stable-stringify';
+
+import type { ProtocolRefusalCode } from '../boxel-execution-protocol/refusal.ts';
+import { isProtocolRefusal } from '../boxel-execution-protocol/refusal.ts';
+import {
+  asRefusal,
+  normalizeJsonData,
+} from '../boxel-execution-protocol/untrusted-input.ts';
+
+/**
+ * How many divergences one comparison names before counting the rest.
+ *
+ * Two wholly unrelated records diverge at every leaf, and a producer chooses
+ * how many leaves it sent. A report is read by a person, so it is bounded in
+ * count the way the protocol's own diagnostics are — and, like those, it
+ * reports the number it *found* rather than the number it printed. A tier
+ * developer told they have twenty-five divergences when they have four hundred
+ * fixes twenty-five of them and re-runs.
+ */
+export const REPORTED_DIVERGENCE_LIMIT = 25;
+
+/**
+ * How much of a divergent value a report repeats. The value is chosen by the
+ * producer under test, so a single string field can otherwise put a megabyte
+ * into a CI log.
+ */
+const RENDERED_VALUE_LIMIT = 160;
+
+export type DivergenceReason =
+  /** Both sides carry a scalar at this path and the scalars differ. */
+  | 'value'
+  /** One side carries a record, an array, or a scalar where the other does not. */
+  | 'shape'
+  /** One side has no member of this name at all. */
+  | 'absent'
+  /** Both sides carry an array here and the arrays are different lengths. */
+  | 'length';
+
+/** One place two records disagree, named by the path that reaches it. */
+export interface RecordDivergence {
+  /**
+   * Where the disagreement is, as a reader would address it: `''` for the
+   * record itself, then `fields[2].kind`, `presentation.themeScope`,
+   * `model.summary`.
+   */
+  path: string;
+  reason: DivergenceReason;
+  /** The reference side's value, rendered and bounded. */
+  reference: string;
+  /** The candidate side's value, rendered and bounded. */
+  candidate: string;
+}
+
+/**
+ * A record that is not inert data, so nothing about it can be compared.
+ *
+ * Distinct from a divergence on purpose. A divergence is a claim about two
+ * records; this is a claim about one, and it holds whether or not there is
+ * another record to compare it to.
+ */
+export interface RecordFault {
+  side: 'reference' | 'candidate';
+  code: ProtocolRefusalCode;
+  /** The refusal's own message, which names the offending member. */
+  message: string;
+}
+
+export interface RecordDiff {
+  divergences: RecordDivergence[];
+  /** Divergences found past `REPORTED_DIVERGENCE_LIMIT` and not listed. */
+  withheld: number;
+  faults: RecordFault[];
+}
+
+export interface RecordDiffOptions {
+  /**
+   * Paths the spec declares tier-specific, which are therefore not compared
+   * (RP-14.4). An exemption covers the path it names and everything under it,
+   * and array indices are wildcarded — `fields[].kind` exempts that member of
+   * every element, since a tier-specific member is a property of the record
+   * shape rather than of one element's position.
+   */
+  exemptPaths?: readonly string[];
+}
+
+/**
+ * Compares two records built for the same input, and reports where they part.
+ *
+ * `reference` is the side the contract is written against — Direct, where a
+ * tier is under test (RP-0.5) — so a divergence reads as "the candidate did
+ * this instead".
+ */
+export function diffRecords(
+  reference: unknown,
+  candidate: unknown,
+  options: RecordDiffOptions = {},
+): RecordDiff {
+  let faults: RecordFault[] = [];
+  let referenceData = readAsData(reference, 'reference', faults);
+  let candidateData = readAsData(candidate, 'candidate', faults);
+  if (faults.length > 0) {
+    return { divergences: [], withheld: 0, faults };
+  }
+  let walk: Walk = {
+    divergences: [],
+    withheld: 0,
+    compared: new Map(),
+    exemptions: [...(options.exemptPaths ?? [])],
+  };
+  compareValue(walk, '', referenceData, candidateData);
+  return { divergences: walk.divergences, withheld: walk.withheld, faults };
+}
+
+/** Whether a diff found nothing to report. */
+export function recordsAgree(diff: RecordDiff): boolean {
+  return (
+    diff.faults.length === 0 &&
+    diff.divergences.length === 0 &&
+    diff.withheld === 0
+  );
+}
+
+/**
+ * Why one record is not inert data, or `undefined` when it is.
+ *
+ * Worth asking on its own: a harness with a single tier has nothing to diff,
+ * and "the one record we have is data" is still a claim about it that can fail.
+ */
+export function faultInRecord(
+  value: unknown,
+): Omit<RecordFault, 'side'> | undefined {
+  let faults: RecordFault[] = [];
+  readAsData(value, 'reference', faults);
+  let [fault] = faults;
+  return fault === undefined
+    ? undefined
+    : { code: fault.code, message: fault.message };
+}
+
+/**
+ * Renders a diff as the message an assertion fails with.
+ *
+ * One line per finding, each self-contained: a path with no value beside it
+ * sends the reader back to the two records to work out what changed.
+ */
+export function describeRecordDiff(diff: RecordDiff): string {
+  let lines = diff.faults.map(
+    (fault) => `${fault.side} is not a record: ${fault.message}`,
+  );
+  for (let divergence of diff.divergences) {
+    lines.push(
+      `${divergence.path === '' ? '(the record)' : divergence.path} ` +
+        `[${divergence.reason}] reference=${divergence.reference} ` +
+        `candidate=${divergence.candidate}`,
+    );
+  }
+  if (diff.withheld > 0) {
+    lines.push(`(and ${diff.withheld} more divergences not listed)`);
+  }
+  return lines.length === 0 ? 'the records agree' : lines.join('\n');
+}
+
+interface Walk {
+  divergences: RecordDivergence[];
+  withheld: number;
+  /**
+   * Pairs already compared, so a subgraph both records share is walked once.
+   *
+   * `structuredClone` preserves sharing, so a normalized record is a directed
+   * acyclic graph rather than a tree, and a graph whose every node has two
+   * parents has a number of *paths* exponential in its depth. Without this the
+   * harness stops answering on a record it accepted.
+   *
+   * The consequence to know: a divergence inside a shared subgraph is reported
+   * at the first path that reaches it, not at every path.
+   */
+  compared: Map<object, Set<object>>;
+  exemptions: string[];
+}
+
+/**
+ * A member that is not there, kept distinct from one whose value is
+ * `undefined` — `structuredClone` carries the second with its name, so a
+ * consumer can tell them apart and so must this.
+ */
+const ABSENT = Symbol('absent');
+
+// Resolves to `unknown`, so it constrains nothing. It is here to say which
+// parameters may be handed the sentinel, since that is not visible from the
+// type.
+type Compared = unknown | typeof ABSENT;
+
+function readAsData(
+  value: unknown,
+  side: RecordFault['side'],
+  faults: RecordFault[],
+): unknown {
+  try {
+    return asRefusal(() => normalizeJsonData(value));
+  } catch (error) {
+    // `asRefusal` is what makes the other branch unreachable; the check is
+    // here because it is also what narrows `error` to something with a `code`.
+    if (!isProtocolRefusal(error)) {
+      throw error;
+    }
+    faults.push({ side, code: error.code, message: error.message });
+    return undefined;
+  }
+}
+
+function compareValue(
+  walk: Walk,
+  path: string,
+  reference: Compared,
+  candidate: Compared,
+): void {
+  if (reference === ABSENT || candidate === ABSENT) {
+    report(walk, path, 'absent', reference, candidate);
+    return;
+  }
+  // One branch per container kind, each asking about both sides, rather than
+  // four booleans compared pairwise: a shape divergence and a recursion into
+  // the same shape are the same question asked once.
+  if (Array.isArray(reference) || Array.isArray(candidate)) {
+    if (!Array.isArray(reference) || !Array.isArray(candidate)) {
+      report(walk, path, 'shape', reference, candidate);
+      return;
+    }
+    compareArray(walk, path, reference, candidate);
+    return;
+  }
+  if (isRecord(reference) || isRecord(candidate)) {
+    if (!isRecord(reference) || !isRecord(candidate)) {
+      report(walk, path, 'shape', reference, candidate);
+      return;
+    }
+    compareRecord(walk, path, reference, candidate);
+    return;
+  }
+  if (!Object.is(reference, candidate)) {
+    report(walk, path, 'value', reference, candidate);
+  }
+}
+
+function compareArray(
+  walk: Walk,
+  path: string,
+  reference: unknown[],
+  candidate: unknown[],
+): void {
+  if (alreadyCompared(walk, reference, candidate)) {
+    return;
+  }
+  if (reference.length !== candidate.length) {
+    report(walk, path, 'length', reference.length, candidate.length);
+  }
+  // The shared prefix, rather than the union: a longer array would otherwise
+  // report the length once and then once more per element the other side never
+  // had, which is the same fact told N times. An element *inserted* in the
+  // middle still shifts everything after it and reports per position — that is
+  // two records genuinely disagreeing at those positions, and the report limit
+  // is what keeps it readable.
+  let shared = Math.min(reference.length, candidate.length);
+  for (let index = 0; index < shared; index++) {
+    compareValue(walk, `${path}[${index}]`, reference[index], candidate[index]);
+  }
+}
+
+function compareRecord(
+  walk: Walk,
+  path: string,
+  reference: Record<string, unknown>,
+  candidate: Record<string, unknown>,
+): void {
+  if (alreadyCompared(walk, reference, candidate)) {
+    return;
+  }
+  // Sorted, so the report reads the same however the two producers happened to
+  // lay their keys out. Unsorted, the same pair of records yields a different
+  // report depending on which side is the reference.
+  let names = [
+    ...new Set([...Object.keys(reference), ...Object.keys(candidate)]),
+  ].sort();
+  for (let name of names) {
+    compareValue(
+      walk,
+      path === '' ? name : `${path}.${name}`,
+      ownValue(reference, name),
+      ownValue(candidate, name),
+    );
+  }
+}
+
+function ownValue(source: Record<string, unknown>, name: string): Compared {
+  return Object.prototype.hasOwnProperty.call(source, name)
+    ? source[name]
+    : ABSENT;
+}
+
+function alreadyCompared(
+  walk: Walk,
+  reference: object,
+  candidate: object,
+): boolean {
+  let against = walk.compared.get(reference);
+  if (against === undefined) {
+    walk.compared.set(reference, new Set([candidate]));
+    return false;
+  }
+  if (against.has(candidate)) {
+    return true;
+  }
+  against.add(candidate);
+  return false;
+}
+
+function report(
+  walk: Walk,
+  path: string,
+  reason: DivergenceReason,
+  reference: Compared,
+  candidate: Compared,
+): void {
+  if (isExempt(walk.exemptions, path)) {
+    return;
+  }
+  if (walk.divergences.length >= REPORTED_DIVERGENCE_LIMIT) {
+    walk.withheld += 1;
+    return;
+  }
+  walk.divergences.push({
+    path,
+    reason,
+    reference: render(reference),
+    candidate: render(candidate),
+  });
+}
+
+/**
+ * Whether a path is covered by an exemption: the exact path, or anything
+ * beneath it. Compared with array indices removed, so an exemption describes
+ * the record's shape rather than one element's position.
+ */
+function isExempt(exemptions: string[], path: string): boolean {
+  if (exemptions.length === 0) {
+    return false;
+  }
+  let wildcarded = path.replace(/\[\d+\]/g, '[]');
+  return exemptions.some(
+    (exemption) =>
+      wildcarded === exemption ||
+      wildcarded.startsWith(`${exemption}.`) ||
+      wildcarded.startsWith(`${exemption}[`),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Renders one side of a divergence.
+ *
+ * Numbers go through `String` rather than JSON, and `-0` is spelled out: JSON
+ * writes `NaN` and both infinities as `null` and `-0` as `0`, so a report of
+ * the very divergences `Object.is` exists to catch would read
+ * `reference=0 candidate=0`. Everything else is stable-stringified, so member
+ * order in a rendered subtree does not depend on which producer built it.
+ */
+function render(value: Compared): string {
+  if (value === ABSENT) {
+    return 'absent';
+  }
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (typeof value === 'number') {
+    return Object.is(value, -0) ? '-0' : String(value);
+  }
+  return bound(stringify(value) ?? String(value));
+}
+
+function bound(rendered: string): string {
+  return rendered.length > RENDERED_VALUE_LIMIT
+    ? `${rendered.slice(0, RENDERED_VALUE_LIMIT)}…`
+    : rendered;
+}

--- a/packages/runtime-common/boxel-execution-conformance/record-diff.ts
+++ b/packages/runtime-common/boxel-execution-conformance/record-diff.ts
@@ -44,10 +44,7 @@
 import stringify from 'safe-stable-stringify';
 
 import type { ProtocolRefusalCode } from '../boxel-execution-protocol/refusal.ts';
-import {
-  isProtocolRefusal,
-  quoteToken,
-} from '../boxel-execution-protocol/refusal.ts';
+import { isProtocolRefusal } from '../boxel-execution-protocol/refusal.ts';
 import {
   asRefusal,
   normalizeJsonRecord,
@@ -116,15 +113,6 @@ export interface RecordDiff {
   /** Divergences found past `REPORTED_DIVERGENCE_LIMIT` and not listed. */
   withheld: number;
   faults: RecordFault[];
-  /**
-   * Exemptions that covered no path in either record.
-   *
-   * An exemption is a claim that a member legitimately differs between tiers.
-   * One that matches nothing is a claim about a member neither record has —
-   * a typo, or a member that was renamed out from under it — and it reads as
-   * satisfied rather than as wrong unless something says so.
-   */
-  exemptionsUnused: string[];
 }
 
 export interface RecordDiffOptions {
@@ -135,10 +123,8 @@ export interface RecordDiffOptions {
    * `fields[0].kind` both exempt that member of every element, since a
    * tier-specific member is a property of the record shape rather than of one
    * element's position, and an exemption that matched no position at all would
-   * be a rule that reads as satisfied while doing nothing.
-   *
-   * An exemption covering no path in either record comes back in
-   * `exemptionsUnused`.
+   * be a rule that reads as satisfied while doing nothing. An empty entry is
+   * dropped: it would cover every path and silence the whole record.
    */
   exemptPaths?: readonly string[];
 }
@@ -159,46 +145,43 @@ export function diffRecords(
   let referenceData = readAsData(reference, 'reference', faults);
   let candidateData = readAsData(candidate, 'candidate', faults);
   if (faults.length > 0) {
-    return {
-      divergences: [],
-      withheld: 0,
-      faults,
-      exemptionsUnused: [],
-    };
+    return { divergences: [], withheld: 0, faults };
   }
-  let exemptions = [...(options.exemptPaths ?? [])].map(wildcardIndices);
   let walk: Walk = {
     divergences: [],
     withheld: 0,
     compared: new Map(),
-    exemptions,
-    exempted: new Set(),
+    exemptions: activeExemptions(options.exemptPaths),
   };
   compareValue(walk, '', referenceData, candidateData);
-  return {
-    divergences: walk.divergences,
-    withheld: walk.withheld,
-    faults,
-    exemptionsUnused: exemptions.filter(
-      (exemption) => !walk.exempted.has(exemption),
-    ),
-  };
+  return { divergences: walk.divergences, withheld: walk.withheld, faults };
 }
 
 /**
- * Whether a diff found nothing to report.
+ * The exemptions that can cover a path, wildcarded so an index names the
+ * record's shape rather than one position.
  *
- * An unused exemption counts as something to report: it is a rule about a
- * member neither record has, and a diff that answers "they agree" while
- * carrying one is agreeing partly by a rule that applies to
- * nothing.
+ * An empty entry is dropped rather than honored. Coverage is prefix-closed —
+ * an exemption covers the path it names and everything under it — and the
+ * empty path is a prefix of every path, so honoring one would silence the
+ * whole record and report parity. Nothing legitimately names it: the root of a
+ * record is not a member, and a member that differs is always named by a
+ * non-empty path.
  */
+function activeExemptions(
+  exemptPaths: readonly string[] | undefined,
+): string[] {
+  return [...(exemptPaths ?? [])]
+    .map(wildcardIndices)
+    .filter((exemption) => exemption !== '');
+}
+
+/** Whether a diff found nothing to report. */
 export function recordsAgree(diff: RecordDiff): boolean {
   return (
     diff.faults.length === 0 &&
     diff.divergences.length === 0 &&
-    diff.withheld === 0 &&
-    diff.exemptionsUnused.length === 0
+    diff.withheld === 0
   );
 }
 
@@ -239,9 +222,6 @@ export function describeRecordDiff(diff: RecordDiff): string {
   if (diff.withheld > 0) {
     lines.push(`(and ${diff.withheld} more divergences not listed)`);
   }
-  for (let exemption of diff.exemptionsUnused) {
-    lines.push(`the exemption ${quoteToken(exemption)} covered no path`);
-  }
   return lines.length === 0 ? 'the records agree' : lines.join('\n');
 }
 
@@ -264,7 +244,6 @@ interface Walk {
    */
   compared: Map<object, Set<object>>;
   exemptions: string[];
-  exempted: Set<string>;
 }
 
 /**
@@ -440,28 +419,18 @@ function report(
  * record's shape rather than one element's position — and one written with a
  * concrete index means the member of every element rather than silently
  * matching nothing.
- *
- * Which exemptions fired is recorded, because an exemption is a claim that a
- * member legitimately differs between tiers, and one that matches nothing is
- * a claim about a member that does not exist. Without this it reads as
- * satisfied.
  */
 function isExempt(walk: Walk, path: string): boolean {
   if (walk.exemptions.length === 0) {
     return false;
   }
   let wildcarded = wildcardIndices(path);
-  let covering = walk.exemptions.find(
+  return walk.exemptions.some(
     (exemption) =>
       wildcarded === exemption ||
       wildcarded.startsWith(`${exemption}.`) ||
       wildcarded.startsWith(`${exemption}[`),
   );
-  if (covering === undefined) {
-    return false;
-  }
-  walk.exempted.add(covering);
-  return true;
 }
 
 function wildcardIndices(path: string): string {

--- a/packages/runtime-common/boxel-execution-conformance/tier-parity.ts
+++ b/packages/runtime-common/boxel-execution-conformance/tier-parity.ts
@@ -85,7 +85,16 @@ export type ParityFinding =
   | { kind: 'mode-unregistered'; mode: BoxelExecutionMode }
   /** The registry names a tier that produced nothing to check. */
   | { kind: 'mode-absent'; mode: BoxelExecutionMode }
-  /** A tier's record is not inert data, so it cannot be compared at all. */
+  /**
+   * A tier's record is not one this protocol can use, so it is not compared.
+   *
+   * Two questions collapse into one finding because they have one consequence.
+   * The record may not be inert data — an accessor, a function, a prototype of
+   * its own, a value containing itself. Or it may be data and still not a
+   * record of this protocol: `{}` carries no envelope, and a record declaring
+   * a version the comparing consumer does not implement is refused by RP-14.3's
+   * own gate. Either way there is nothing to hold a peer to.
+   */
   | {
       kind: 'fault';
       mode: BoxelExecutionMode;
@@ -116,17 +125,7 @@ export type ParityFinding =
       kind: 'records-shared';
       mode: BoxelExecutionMode;
       record: ParityRecordKind;
-    }
-  /**
-   * An exemption covered no path in any comparison, so it is a rule about a
-   * member no record has.
-   *
-   * Aggregated across every comparison rather than reported per comparison,
-   * because one list serves both record kinds and every tier: an exemption
-   * naming a projection member is legitimately unused by a description
-   * comparison, and reporting that would make the check fire on correct input.
-   */
-  | { kind: 'exemption-unused'; exemption: string };
+    };
 
 export interface ParityReport {
   /** What the tiers were given, so a finding can be reproduced. */
@@ -134,7 +133,10 @@ export interface ParityReport {
   referenceMode: BoxelExecutionMode;
   /** The non-reference tiers that were compared, in tier order. */
   comparedModes: BoxelExecutionMode[];
-  /** Records diffed against the reference: compared modes × record kinds. */
+  /**
+   * Record pairs actually diffed against the reference. A pair where either
+   * side is not a usable record is not counted, because it was not compared.
+   */
   comparisons: number;
   /** Records read as inert data, the reference tier's included. */
   inspections: number;
@@ -203,6 +205,7 @@ export function checkRecordParity(input: ParityInput): ParityReport {
   }
 
   let inspections = 0;
+  let unusable = new Set<string>();
   for (let mode of modes) {
     let tier = byMode.get(mode);
     if (tier === undefined) {
@@ -212,6 +215,7 @@ export function checkRecordParity(input: ParityInput): ParityReport {
       inspections += 1;
       let fault = faultInParityRecord(tier[record], support);
       if (fault !== undefined) {
+        unusable.add(`${mode}/${record}`);
         findings.push({ kind: 'fault', mode, record, ...fault });
       }
     }
@@ -232,7 +236,6 @@ export function checkRecordParity(input: ParityInput): ParityReport {
 
   let comparedModes: BoxelExecutionMode[] = [];
   let comparisons = 0;
-  let usedExemptions = new Set<string>();
   for (let mode of modes) {
     let candidate = byMode.get(mode);
     if (candidate === undefined || mode === PARITY_REFERENCE_MODE) {
@@ -243,17 +246,20 @@ export function checkRecordParity(input: ParityInput): ParityReport {
       if (isSameObject(reference[record], candidate[record])) {
         findings.push({ kind: 'records-shared', mode, record });
       }
+      // A record this protocol cannot use is not compared, and the fault above
+      // already says why. Comparing it anyway would report divergences beneath
+      // a record the run has just declared unusable, and count the pair as
+      // checked.
+      if (
+        unusable.has(`${PARITY_REFERENCE_MODE}/${record}`) ||
+        unusable.has(`${mode}/${record}`)
+      ) {
+        continue;
+      }
+      comparisons += 1;
       let diff = diffRecords(reference[record], candidate[record], {
         exemptPaths,
       });
-      // Counted per pair actually compared. A pair where either side is not a
-      // record was never compared, and a coverage line that counts it says the
-      // run checked something it did not.
-      if (diff.faults.length === 0) {
-        comparisons += 1;
-      }
-      // The faults themselves were reported per tier above; repeating them per
-      // comparison would say the same thing once per peer.
       for (let divergence of diff.divergences) {
         findings.push({ kind: 'divergence', mode, record, divergence });
       }
@@ -264,22 +270,6 @@ export function checkRecordParity(input: ParityInput): ParityReport {
           record,
           count: diff.withheld,
         });
-      }
-      for (let exemption of exemptPaths) {
-        if (!diff.exemptionsUnused.includes(exemption)) {
-          usedExemptions.add(exemption);
-        }
-      }
-    }
-  }
-
-  // Only once every comparison has had its chance to use one. An exemption no
-  // comparison used is a rule about a member no record carries, which reads as
-  // satisfied unless something says otherwise.
-  if (comparisons > 0) {
-    for (let exemption of exemptPaths) {
-      if (!usedExemptions.has(exemption)) {
-        findings.push({ kind: 'exemption-unused', exemption });
       }
     }
   }
@@ -396,7 +386,7 @@ function describeFinding(finding: ParityFinding): string {
     case 'mode-absent':
       return `the ${finding.mode} tier is registered but produced no records`;
     case 'fault':
-      return `${finding.mode} ${finding.record} is not a record: ${finding.message}`;
+      return `${finding.mode} ${finding.record} is not a usable record: ${finding.message}`;
     case 'divergence': {
       let { path, reason, reference, candidate } = finding.divergence;
       return (
@@ -408,7 +398,5 @@ function describeFinding(finding: ParityFinding): string {
       return `${finding.mode} ${finding.record}: and ${finding.count} more divergences not listed`;
     case 'records-shared':
       return `${finding.mode} was handed the reference tier's own ${finding.record}, so the comparison compared it with itself`;
-    case 'exemption-unused':
-      return `the exemption ${finding.exemption} covered no path in any comparison`;
   }
 }

--- a/packages/runtime-common/boxel-execution-conformance/tier-parity.ts
+++ b/packages/runtime-common/boxel-execution-conformance/tier-parity.ts
@@ -86,14 +86,24 @@ export type ParityFinding =
   /** The registry names a tier that produced nothing to check. */
   | { kind: 'mode-absent'; mode: BoxelExecutionMode }
   /**
-   * A tier's record is not one this protocol can use, so it is not compared.
+   * A tier's record is not one this protocol can use, so it is not compared
+   * against a peer.
    *
-   * Two questions collapse into one finding because they have one consequence.
-   * The record may not be inert data — an accessor, a function, a prototype of
-   * its own, a value containing itself. Or it may be data and still not a
-   * record of this protocol: `{}` carries no envelope, and a record declaring
-   * a version the comparing consumer does not implement is refused by RP-14.3's
-   * own gate. Either way there is nothing to hold a peer to.
+   * Two conditions reported as one finding, because a consumer's response to
+   * both is the same — read no member of it. The record may not be inert data:
+   * an accessor, a function, a prototype of its own, a value containing itself.
+   * Or it may be data and still not a record of this protocol: `{}` carries no
+   * envelope, and one declaring a version the comparing consumer does not
+   * implement is refused by RP-14.3's own gate.
+   *
+   * What the two do not share is what the skip costs. A record that is not data
+   * could not have been compared anyway, so skipping it loses nothing. A record
+   * refused for its envelope could have been compared member by member, and
+   * skipping it means every content divergence in that pair goes unreported —
+   * for every candidate at once, when it is the reference tier's record that was
+   * refused. That is the intended trade: RP-14.3 exists so a consumer reads no
+   * member of a record it has rejected, and a differ is a consumer. It costs a
+   * version fixed and a re-run, not a divergence that stays hidden.
    */
   | {
       kind: 'fault';
@@ -131,14 +141,22 @@ export interface ParityReport {
   /** What the tiers were given, so a finding can be reproduced. */
   fixture: string;
   referenceMode: BoxelExecutionMode;
-  /** The non-reference tiers that were compared, in tier order. */
+  /**
+   * The non-reference tiers this report covers, in tier order. A tier appears
+   * here even when none of its records could be compared, so `comparisons` is
+   * what says how much was actually checked.
+   */
   comparedModes: BoxelExecutionMode[];
   /**
    * Record pairs actually diffed against the reference. A pair where either
    * side is not a usable record is not counted, because it was not compared.
    */
   comparisons: number;
-  /** Records read as inert data, the reference tier's included. */
+  /**
+   * Records offered for reading as a usable record, the reference tier's
+   * included — attempts rather than successes, so a run where every record is
+   * `null` still reports one per tier per record kind.
+   */
   inspections: number;
   findings: ParityFinding[];
 }

--- a/packages/runtime-common/boxel-execution-conformance/tier-parity.ts
+++ b/packages/runtime-common/boxel-execution-conformance/tier-parity.ts
@@ -16,8 +16,17 @@
  */
 
 import type { ProtocolRefusalCode } from '../boxel-execution-protocol/refusal.ts';
+import { isProtocolRefusal } from '../boxel-execution-protocol/refusal.ts';
 import type { BoxelExecutionMode } from '../boxel-execution-protocol/runtime.ts';
 import { BOXEL_EXECUTION_MODES } from '../boxel-execution-protocol/runtime.ts';
+import type {
+  ProtocolEnvelope,
+  ProtocolSupport,
+} from '../boxel-execution-protocol/version.ts';
+import {
+  BOXEL_EXECUTION_PROTOCOL_VERSION,
+  assertUsableExecutionRecord,
+} from '../boxel-execution-protocol/version.ts';
 import type { RecordDivergence } from './record-diff.ts';
 import { diffRecords, faultInRecord } from './record-diff.ts';
 
@@ -46,12 +55,11 @@ export const PARITY_REFERENCE_MODE: BoxelExecutionMode = 'direct';
  * Record paths the spec declares tier-specific, and therefore does not
  * compare.
  *
- * Empty, because RP-14.4 currently declares none — so the diff is total. An
- * entry here is a statement that a member legitimately differs between tiers,
- * which is a spec change: it needs the statement declaring it, in the same
- * change that adds the path. Left as a list rather than left out so that the
- * "modulo" clause in RP-14.4 has somewhere to be, and so the fact that it is
- * empty is something a test can hold.
+ * Empty, which makes the diff total. An entry is a statement that a member
+ * legitimately differs between tiers, and that is a spec change: it needs the
+ * statement declaring it, in the change that adds the path. The list exists
+ * rather than being left out so RP-14.4's "modulo" clause has somewhere to
+ * live, and so a test can hold it to whatever the spec declares.
  */
 export const TIER_SPECIFIC_RECORD_PATHS: readonly string[] = [];
 
@@ -98,7 +106,27 @@ export type ParityFinding =
       mode: BoxelExecutionMode;
       record: ParityRecordKind;
       count: number;
-    };
+    }
+  /**
+   * Two tiers were handed the same object, so the comparison compared a record
+   * with itself. Nothing a real pair of tiers can do — the caller wired one
+   * tier's output in twice, and every comparison after it agrees for free.
+   */
+  | {
+      kind: 'records-shared';
+      mode: BoxelExecutionMode;
+      record: ParityRecordKind;
+    }
+  /**
+   * An exemption covered no path in any comparison, so it is a rule about a
+   * member no record has.
+   *
+   * Aggregated across every comparison rather than reported per comparison,
+   * because one list serves both record kinds and every tier: an exemption
+   * naming a projection member is legitimately unused by a description
+   * comparison, and reporting that would make the check fire on correct input.
+   */
+  | { kind: 'exemption-unused'; exemption: string };
 
 export interface ParityReport {
   /** What the tiers were given, so a finding can be reproduced. */
@@ -125,6 +153,12 @@ export interface ParityInput {
   registeredModes: readonly BoxelExecutionMode[];
   /** Defaults to `TIER_SPECIFIC_RECORD_PATHS`. */
   exemptPaths?: readonly string[];
+  /**
+   * What the comparing consumer implements. Defaults to this module's own
+   * protocol version and no optional features, which is what a conformance run
+   * of the current protocol wants.
+   */
+  support?: ProtocolSupport;
 }
 
 /**
@@ -138,6 +172,10 @@ export interface ParityInput {
 export function checkRecordParity(input: ParityInput): ParityReport {
   let { fixture, tiers, registeredModes } = input;
   let exemptPaths = input.exemptPaths ?? TIER_SPECIFIC_RECORD_PATHS;
+  let support = input.support ?? {
+    protocolVersion: BOXEL_EXECUTION_PROTOCOL_VERSION,
+    features: new Set<string>(),
+  };
   let findings: ParityFinding[] = [];
   let byMode = new Map<BoxelExecutionMode, TierRecords>();
   for (let tier of tiers) {
@@ -148,9 +186,14 @@ export function checkRecordParity(input: ParityInput): ParityReport {
     byMode.set(tier.mode, tier);
   }
   let registered = new Set(registeredModes);
-  // Walked in tier order rather than call order, so two callers listing the
-  // same tiers differently get the same report.
-  for (let mode of BOXEL_EXECUTION_MODES) {
+  // Every mode anyone named, not only the ones the protocol declares. A tier's
+  // mode is data — a Sandbox child's arrives across the boundary this module
+  // exists to distrust — so iterating the declared list alone lets a typo'd or
+  // forged mode go uninspected, uncompared and unreported while the run says
+  // it found nothing.
+  let modes = modesInPlay(byMode, registered);
+
+  for (let mode of modes) {
     if (byMode.has(mode) && !registered.has(mode)) {
       findings.push({ kind: 'mode-unregistered', mode });
     }
@@ -160,14 +203,14 @@ export function checkRecordParity(input: ParityInput): ParityReport {
   }
 
   let inspections = 0;
-  for (let mode of BOXEL_EXECUTION_MODES) {
+  for (let mode of modes) {
     let tier = byMode.get(mode);
     if (tier === undefined) {
       continue;
     }
     for (let record of PARITY_RECORD_KINDS) {
       inspections += 1;
-      let fault = faultInRecord(tier[record]);
+      let fault = faultInParityRecord(tier[record], support);
       if (fault !== undefined) {
         findings.push({ kind: 'fault', mode, record, ...fault });
       }
@@ -188,17 +231,28 @@ export function checkRecordParity(input: ParityInput): ParityReport {
   }
 
   let comparedModes: BoxelExecutionMode[] = [];
-  for (let mode of BOXEL_EXECUTION_MODES) {
+  let comparisons = 0;
+  let usedExemptions = new Set<string>();
+  for (let mode of modes) {
     let candidate = byMode.get(mode);
     if (candidate === undefined || mode === PARITY_REFERENCE_MODE) {
       continue;
     }
     comparedModes.push(mode);
     for (let record of PARITY_RECORD_KINDS) {
+      if (isSameObject(reference[record], candidate[record])) {
+        findings.push({ kind: 'records-shared', mode, record });
+      }
       let diff = diffRecords(reference[record], candidate[record], {
         exemptPaths,
       });
-      // Faults were already reported per tier above; repeating them per
+      // Counted per pair actually compared. A pair where either side is not a
+      // record was never compared, and a coverage line that counts it says the
+      // run checked something it did not.
+      if (diff.faults.length === 0) {
+        comparisons += 1;
+      }
+      // The faults themselves were reported per tier above; repeating them per
       // comparison would say the same thing once per peer.
       for (let divergence of diff.divergences) {
         findings.push({ kind: 'divergence', mode, record, divergence });
@@ -211,6 +265,22 @@ export function checkRecordParity(input: ParityInput): ParityReport {
           count: diff.withheld,
         });
       }
+      for (let exemption of exemptPaths) {
+        if (!diff.exemptionsUnused.includes(exemption)) {
+          usedExemptions.add(exemption);
+        }
+      }
+    }
+  }
+
+  // Only once every comparison has had its chance to use one. An exemption no
+  // comparison used is a rule about a member no record carries, which reads as
+  // satisfied unless something says otherwise.
+  if (comparisons > 0) {
+    for (let exemption of exemptPaths) {
+      if (!usedExemptions.has(exemption)) {
+        findings.push({ kind: 'exemption-unused', exemption });
+      }
     }
   }
 
@@ -218,10 +288,73 @@ export function checkRecordParity(input: ParityInput): ParityReport {
     fixture,
     referenceMode: PARITY_REFERENCE_MODE,
     comparedModes,
-    comparisons: comparedModes.length * PARITY_RECORD_KINDS.length,
+    comparisons,
     inspections,
     findings,
   };
+}
+
+/**
+ * Every mode named by a tier or by the registry, the protocol's own order
+ * first and anything else after it, so one report does not depend on the order
+ * a caller listed its tiers in.
+ */
+function modesInPlay(
+  byMode: Map<BoxelExecutionMode, TierRecords>,
+  registered: Set<BoxelExecutionMode>,
+): BoxelExecutionMode[] {
+  let declared = new Set<string>(BOXEL_EXECUTION_MODES);
+  let named = [...new Set([...byMode.keys(), ...registered])];
+  return [
+    ...BOXEL_EXECUTION_MODES.filter(
+      (mode) => byMode.has(mode) || registered.has(mode),
+    ),
+    ...named.filter((mode) => !declared.has(mode)).sort(),
+  ];
+}
+
+/**
+ * Why a value is not a usable record of this protocol, or `undefined` when it
+ * is.
+ *
+ * Two questions, because a value can pass one and fail the other. `{}` is
+ * inert data and a record, and it is not a `BoxelDescription` — it carries no
+ * envelope, so RP-14.3's gate refuses it. Without the second question two
+ * tiers that each produced `{}` agree at every path, which is the same false
+ * green as two tiers that each produced `null`.
+ */
+function faultInParityRecord(
+  value: unknown,
+  support: ProtocolSupport,
+): { code: ProtocolRefusalCode; message: string } | undefined {
+  let fault = faultInRecord(value);
+  if (fault !== undefined) {
+    return fault;
+  }
+  try {
+    assertUsableExecutionRecord(value as ProtocolEnvelope, support);
+    return undefined;
+  } catch (error) {
+    // `assertUsableExecutionRecord` wraps whatever it meets in a refusal; the
+    // check is what narrows the caught value to one carrying a code.
+    if (!isProtocolRefusal(error)) {
+      throw error;
+    }
+    return { code: error.code, message: error.message };
+  }
+}
+
+/**
+ * Whether two tiers were handed the very same object. No pair of real tiers
+ * can be — each builds its own record — so this is a caller that wired one
+ * tier's output in twice, and every comparison of it agrees for free.
+ */
+function isSameObject(reference: unknown, candidate: unknown): boolean {
+  return (
+    typeof reference === 'object' &&
+    reference !== null &&
+    reference === candidate
+  );
 }
 
 /** Whether a report found nothing. */
@@ -267,12 +400,15 @@ function describeFinding(finding: ParityFinding): string {
     case 'divergence': {
       let { path, reason, reference, candidate } = finding.divergence;
       return (
-        `${finding.mode} ${finding.record} ` +
-        `${path === '' ? '(the record)' : path} [${reason}] ` +
+        `${finding.mode} ${finding.record} ${path} [${reason}] ` +
         `reference=${reference} ${finding.mode}=${candidate}`
       );
     }
     case 'withheld':
       return `${finding.mode} ${finding.record}: and ${finding.count} more divergences not listed`;
+    case 'records-shared':
+      return `${finding.mode} was handed the reference tier's own ${finding.record}, so the comparison compared it with itself`;
+    case 'exemption-unused':
+      return `the exemption ${finding.exemption} covered no path in any comparison`;
   }
 }

--- a/packages/runtime-common/boxel-execution-conformance/tier-parity.ts
+++ b/packages/runtime-common/boxel-execution-conformance/tier-parity.ts
@@ -1,0 +1,278 @@
+/**
+ * Holding every tier to one set of records (RP-14.4).
+ *
+ * Part of the cross-boundary execution conformance harness; see
+ * `../boxel-execution-conformance.ts` for what the harness is and what it is
+ * not.
+ *
+ * RP-14.4 is a claim about agreement, and the project's own case for it is
+ * that the tiers "conform to the same spec, so they are at parity by
+ * construction". This is what turns that from an assertion into a check. It
+ * runs over whatever tiers were handed to it, so the Direct↔Capsule half
+ * stands up the moment a second adapter exists rather than waiting for a
+ * third — and it says, in every report it produces, how much it actually
+ * compared, because a harness with one tier has nothing to diff and a green
+ * result that does not admit that is worse than no harness at all.
+ */
+
+import type { ProtocolRefusalCode } from '../boxel-execution-protocol/refusal.ts';
+import type { BoxelExecutionMode } from '../boxel-execution-protocol/runtime.ts';
+import { BOXEL_EXECUTION_MODES } from '../boxel-execution-protocol/runtime.ts';
+import type { RecordDivergence } from './record-diff.ts';
+import { diffRecords, faultInRecord } from './record-diff.ts';
+
+/**
+ * The records RP-14.4 requires every tier to agree on.
+ *
+ * Both are enveloped records a tier produces from an input it was given, which
+ * is what makes them comparable across tiers. A `TemplateBundle` is not here:
+ * only Capsule produces one, so there is nothing to hold it against.
+ */
+export const PARITY_RECORD_KINDS = ['description', 'projection'] as const;
+
+export type ParityRecordKind = (typeof PARITY_RECORD_KINDS)[number];
+
+/**
+ * The tier every other tier is compared against.
+ *
+ * Direct is the reference implementation: where the spec is silent, main's
+ * Direct behavior is the contract (RP-0.5). So a divergence is always reported
+ * as the candidate's, and a run with no Direct tier is a fault rather than a
+ * comparison between two candidates.
+ */
+export const PARITY_REFERENCE_MODE: BoxelExecutionMode = 'direct';
+
+/**
+ * Record paths the spec declares tier-specific, and therefore does not
+ * compare.
+ *
+ * Empty, because RP-14.4 currently declares none — so the diff is total. An
+ * entry here is a statement that a member legitimately differs between tiers,
+ * which is a spec change: it needs the statement declaring it, in the same
+ * change that adds the path. Left as a list rather than left out so that the
+ * "modulo" clause in RP-14.4 has somewhere to be, and so the fact that it is
+ * empty is something a test can hold.
+ */
+export const TIER_SPECIFIC_RECORD_PATHS: readonly string[] = [];
+
+/**
+ * One tier's answers for one input.
+ *
+ * Typed `unknown` rather than `BoxelDescription` / `InstanceProjection` on
+ * purpose: whether a tier produced a well-formed record is the question, and a
+ * parameter typed as the answer cannot ask it.
+ */
+export interface TierRecords {
+  mode: BoxelExecutionMode;
+  description: unknown;
+  projection: unknown;
+}
+
+export type ParityFinding =
+  /** No tier answered for the reference mode, so nothing can be held to it. */
+  | { kind: 'reference-missing'; mode: BoxelExecutionMode }
+  /** Two tiers claimed one mode; whichever lost the tie went unchecked. */
+  | { kind: 'mode-repeated'; mode: BoxelExecutionMode }
+  /** A tier answered that the registry does not know about. */
+  | { kind: 'mode-unregistered'; mode: BoxelExecutionMode }
+  /** The registry names a tier that produced nothing to check. */
+  | { kind: 'mode-absent'; mode: BoxelExecutionMode }
+  /** A tier's record is not inert data, so it cannot be compared at all. */
+  | {
+      kind: 'fault';
+      mode: BoxelExecutionMode;
+      record: ParityRecordKind;
+      code: ProtocolRefusalCode;
+      message: string;
+    }
+  /** A tier's record differs from the reference tier's. */
+  | {
+      kind: 'divergence';
+      mode: BoxelExecutionMode;
+      record: ParityRecordKind;
+      divergence: RecordDivergence;
+    }
+  /** Divergences past the diff's report limit, counted but not listed. */
+  | {
+      kind: 'withheld';
+      mode: BoxelExecutionMode;
+      record: ParityRecordKind;
+      count: number;
+    };
+
+export interface ParityReport {
+  /** What the tiers were given, so a finding can be reproduced. */
+  fixture: string;
+  referenceMode: BoxelExecutionMode;
+  /** The non-reference tiers that were compared, in tier order. */
+  comparedModes: BoxelExecutionMode[];
+  /** Records diffed against the reference: compared modes × record kinds. */
+  comparisons: number;
+  /** Records read as inert data, the reference tier's included. */
+  inspections: number;
+  findings: ParityFinding[];
+}
+
+export interface ParityInput {
+  fixture: string;
+  tiers: readonly TierRecords[];
+  /**
+   * The modes the caller expects to be answering. A tier missing from this
+   * list, or named by it and missing from `tiers`, is a finding — the harness
+   * cannot tell "this tier agrees" from "this tier never ran", and only the
+   * caller knows which was meant.
+   */
+  registeredModes: readonly BoxelExecutionMode[];
+  /** Defaults to `TIER_SPECIFIC_RECORD_PATHS`. */
+  exemptPaths?: readonly string[];
+}
+
+/**
+ * Checks every tier's records against the reference tier's.
+ *
+ * With one tier there is nothing to diff, and the check that remains is still
+ * a real one: every record is read as inert data by the same rule the boundary
+ * uses, so a tier answering with a live object fails here whether or not it
+ * has a peer to disagree with.
+ */
+export function checkRecordParity(input: ParityInput): ParityReport {
+  let { fixture, tiers, registeredModes } = input;
+  let exemptPaths = input.exemptPaths ?? TIER_SPECIFIC_RECORD_PATHS;
+  let findings: ParityFinding[] = [];
+  let byMode = new Map<BoxelExecutionMode, TierRecords>();
+  for (let tier of tiers) {
+    if (byMode.has(tier.mode)) {
+      findings.push({ kind: 'mode-repeated', mode: tier.mode });
+      continue;
+    }
+    byMode.set(tier.mode, tier);
+  }
+  let registered = new Set(registeredModes);
+  // Walked in tier order rather than call order, so two callers listing the
+  // same tiers differently get the same report.
+  for (let mode of BOXEL_EXECUTION_MODES) {
+    if (byMode.has(mode) && !registered.has(mode)) {
+      findings.push({ kind: 'mode-unregistered', mode });
+    }
+    if (registered.has(mode) && !byMode.has(mode)) {
+      findings.push({ kind: 'mode-absent', mode });
+    }
+  }
+
+  let inspections = 0;
+  for (let mode of BOXEL_EXECUTION_MODES) {
+    let tier = byMode.get(mode);
+    if (tier === undefined) {
+      continue;
+    }
+    for (let record of PARITY_RECORD_KINDS) {
+      inspections += 1;
+      let fault = faultInRecord(tier[record]);
+      if (fault !== undefined) {
+        findings.push({ kind: 'fault', mode, record, ...fault });
+      }
+    }
+  }
+
+  let reference = byMode.get(PARITY_REFERENCE_MODE);
+  if (reference === undefined) {
+    findings.push({ kind: 'reference-missing', mode: PARITY_REFERENCE_MODE });
+    return {
+      fixture,
+      referenceMode: PARITY_REFERENCE_MODE,
+      comparedModes: [],
+      comparisons: 0,
+      inspections,
+      findings,
+    };
+  }
+
+  let comparedModes: BoxelExecutionMode[] = [];
+  for (let mode of BOXEL_EXECUTION_MODES) {
+    let candidate = byMode.get(mode);
+    if (candidate === undefined || mode === PARITY_REFERENCE_MODE) {
+      continue;
+    }
+    comparedModes.push(mode);
+    for (let record of PARITY_RECORD_KINDS) {
+      let diff = diffRecords(reference[record], candidate[record], {
+        exemptPaths,
+      });
+      // Faults were already reported per tier above; repeating them per
+      // comparison would say the same thing once per peer.
+      for (let divergence of diff.divergences) {
+        findings.push({ kind: 'divergence', mode, record, divergence });
+      }
+      if (diff.withheld > 0) {
+        findings.push({
+          kind: 'withheld',
+          mode,
+          record,
+          count: diff.withheld,
+        });
+      }
+    }
+  }
+
+  return {
+    fixture,
+    referenceMode: PARITY_REFERENCE_MODE,
+    comparedModes,
+    comparisons: comparedModes.length * PARITY_RECORD_KINDS.length,
+    inspections,
+    findings,
+  };
+}
+
+/** Whether a report found nothing. */
+export function reportsParity(report: ParityReport): boolean {
+  return report.findings.length === 0;
+}
+
+/**
+ * Renders a report as the message an assertion carries, passing or failing.
+ *
+ * The coverage line is there in both cases and on purpose. A report saying
+ * only "no findings" reads as "the tiers agree" when it may mean "there was
+ * one tier"; the two have to be distinguishable in a CI log without reading
+ * the harness.
+ */
+export function describeParityReport(report: ParityReport): string {
+  let against =
+    report.comparedModes.length === 0
+      ? 'no other tier'
+      : report.comparedModes.join(', ');
+  let coverage =
+    `${report.fixture}: ${report.referenceMode} vs ${against} — ` +
+    `${report.comparisons} record comparison(s), ` +
+    `${report.inspections} record(s) read as data`;
+  if (report.findings.length === 0) {
+    return `${coverage}; no findings`;
+  }
+  return [coverage, ...report.findings.map(describeFinding)].join('\n');
+}
+
+function describeFinding(finding: ParityFinding): string {
+  switch (finding.kind) {
+    case 'reference-missing':
+      return `no ${finding.mode} tier answered, so nothing was held to the reference`;
+    case 'mode-repeated':
+      return `two tiers claimed the ${finding.mode} mode`;
+    case 'mode-unregistered':
+      return `the ${finding.mode} tier answered but is not registered with the harness`;
+    case 'mode-absent':
+      return `the ${finding.mode} tier is registered but produced no records`;
+    case 'fault':
+      return `${finding.mode} ${finding.record} is not a record: ${finding.message}`;
+    case 'divergence': {
+      let { path, reason, reference, candidate } = finding.divergence;
+      return (
+        `${finding.mode} ${finding.record} ` +
+        `${path === '' ? '(the record)' : path} [${reason}] ` +
+        `reference=${reference} ${finding.mode}=${candidate}`
+      );
+    }
+    case 'withheld':
+      return `${finding.mode} ${finding.record}: and ${finding.count} more divergences not listed`;
+  }
+}

--- a/packages/runtime-common/boxel-execution-protocol/version.ts
+++ b/packages/runtime-common/boxel-execution-protocol/version.ts
@@ -7,7 +7,13 @@
  */
 
 import type { Cloneable } from './cloneable.ts';
-import { ProtocolRefusal, describeValue, joinTokens } from './refusal.ts';
+import {
+  ProtocolRefusal,
+  describeValue,
+  joinTokens,
+  newOffenderList,
+  recordOffender,
+} from './refusal.ts';
 import {
   asRefusal,
   newNormalizationBudget,
@@ -89,14 +95,23 @@ function gateEnvelope(
       `record declares protocol version ${protocolVersion}; this consumer implements ${support.protocolVersion}`,
     );
   }
-  let unsupported = requiredFeatures.filter(
-    (feature) => !support.features.has(feature),
-  );
-  if (unsupported.length > 0) {
+  // Collected into a bounded list rather than filtered into a full one. The
+  // feature array itself is charged against the record's budget, so this is no
+  // longer where a producer buys unbounded work — but a filter builds one
+  // string per unrecognized feature, each through `JSON.stringify`, to render
+  // ten of them, and the count a diagnostic reports has to be the count the
+  // producer sent rather than the count it printed.
+  let unsupported = newOffenderList();
+  for (let feature of requiredFeatures) {
+    if (!support.features.has(feature)) {
+      recordOffender(unsupported, describeValue(feature));
+    }
+  }
+  if (unsupported.total > 0) {
     throw new ProtocolRefusal(
       'BOXEL_PROTOCOL_FEATURE_UNSUPPORTED',
       `record requires features this consumer does not implement: ${joinTokens(
-        unsupported.map((feature) => describeValue(feature)),
+        unsupported,
       )}`,
     );
   }

--- a/packages/runtime-common/boxel-execution-protocol/version.ts
+++ b/packages/runtime-common/boxel-execution-protocol/version.ts
@@ -96,11 +96,13 @@ function gateEnvelope(
     );
   }
   // Collected into a bounded list rather than filtered into a full one. The
-  // feature array itself is charged against the record's budget, so this is no
-  // longer where a producer buys unbounded work — but a filter builds one
-  // string per unrecognized feature, each through `JSON.stringify`, to render
-  // ten of them, and the count a diagnostic reports has to be the count the
-  // producer sent rather than the count it printed.
+  // feature array is charged against the record's budget, so a producer cannot
+  // buy unbounded work here; what this bounds is retention — a filter holds one
+  // rendered string per unrecognized feature in order to print ten of them. The
+  // rendering cost per offender is the same either way, and so is the message:
+  // `joinTokens` reads a plain array's length as its total, so the count is
+  // right in both shapes. What the list buys is one collect-and-report idiom
+  // across the three sites that have one.
   let unsupported = newOffenderList();
   for (let feature of requiredFeatures) {
     if (!support.features.has(feature)) {

--- a/scripts/check-execution-tier-registry.mts
+++ b/scripts/check-execution-tier-registry.mts
@@ -1,0 +1,131 @@
+#!/usr/bin/env -S node
+// Makes a tier adapter landing visible to the record-parity harness (RP-14.4).
+//
+// The harness compares the records every tier produces, but it can only
+// compare tiers it was handed. Nothing about writing a second `BoxelRuntime`
+// implementation wires it in, and nothing about forgetting to fails: the
+// harness reports parity across the tiers it knows, so an unregistered adapter
+// is not a red test, it is an absent one. That is the failure this project
+// already paid for once — the spike grew three record builders, and nearly
+// every parity bug traced to two of the three disagreeing with no check
+// watching.
+//
+// So the set of `BoxelRuntime` implementations in the repo is held EQUAL to the
+// list recorded below. An adapter appearing fails the build until someone
+// records it here, which is the moment to hand it to `checkRecordParity` as a
+// registered mode. An adapter disappearing fails too, because a harness still
+// listing a mode that no longer exists reports a tier absent forever.
+//
+// What this cannot see, and does not claim to: an implementation that satisfies
+// the interface structurally, with no `implements` / `satisfies` / annotated
+// declaration naming it, and one that inherits the interface from a base class
+// that names it. This is a tripwire on the ways an adapter is actually written,
+// not a proof that none exists. Comment detection is line-local, for the
+// reasons `check-rp-bijection.mts` gives at length.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const scanRoot = join(repoRoot, 'packages');
+
+// Every file declaring a tier runtime, and nothing else. Empty because no
+// adapter exists yet: the interface is declared (CS-12599) and the first
+// implementation is still ahead. Each entry here should be a mode passed to
+// `checkRecordParity` as registered.
+const registered = new Set<string>([]);
+
+// Directories with no source of ours in them, or with a copy of it that is not
+// the one that ships.
+const skipDirectories = new Set([
+  'node_modules',
+  'dist',
+  'tmp',
+  'coverage',
+  '.git',
+  'declarations',
+]);
+
+const SOURCE = /\.(ts|gts|mts)$/;
+
+// `implements` may list more than one interface, so the match runs to the class
+// body rather than to the next identifier. `satisfies` covers an object literal
+// adapter, and the annotated-declaration form covers one built by a factory. A
+// parameter or field annotation deliberately does not match: taking a
+// `BoxelRuntime` is what a consumer does.
+const DECLARES_RUNTIME = [
+  /\bimplements\b[^{;]*\bBoxelRuntime\b/,
+  /\bsatisfies\s+BoxelRuntime\b/,
+  /\b(?:const|let|var)\s+\w+\s*:\s*BoxelRuntime\b/,
+];
+
+function* walk(dir: string): Generator<string> {
+  for (let entry of readdirSync(dir)) {
+    if (skipDirectories.has(entry)) {
+      continue;
+    }
+    let full = join(dir, entry);
+    let stat = statSync(full, { throwIfNoEntry: false });
+    if (!stat) {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      yield* walk(full);
+    } else if (SOURCE.test(entry)) {
+      yield full;
+    }
+  }
+}
+
+function withoutComments(source: string): string {
+  return source
+    .split('\n')
+    .map((line) => {
+      let withoutSpans = line.replace(/\/\*.*?\*\//g, ' ');
+      return /^\s*(\/\/|\*|\/\*|\{\{!)/.test(withoutSpans) ? '' : withoutSpans;
+    })
+    .join('\n');
+}
+
+let found: string[] = [];
+for (let file of walk(scanRoot)) {
+  let raw = readFileSync(file, 'utf8');
+  // The name is what makes a file worth parsing at all, and most of the repo
+  // does not carry it.
+  if (!raw.includes('BoxelRuntime')) {
+    continue;
+  }
+  let source = withoutComments(raw);
+  if (DECLARES_RUNTIME.some((pattern) => pattern.test(source))) {
+    found.push(relative(repoRoot, file));
+  }
+}
+found.sort();
+
+const unexpected = found.filter((file) => !registered.has(file));
+const missing = [...registered].sort().filter((file) => !found.includes(file));
+
+console.log(
+  `execution tier adapters: ${found.length} — ${found.length === 0 ? 'none yet' : found.join(', ')}`,
+);
+
+if (unexpected.length > 0) {
+  console.error(
+    `\nThese files declare a BoxelRuntime the record-parity harness does not know about:\n` +
+      unexpected.map((file) => `  ${file}`).join('\n') +
+      `\n\nA tier the harness is not handed is a tier RP-14.4 does not hold to\n` +
+      `anything. Pass its mode to checkRecordParity as a registered mode, and\n` +
+      `record the file here in the same change.`,
+  );
+}
+if (missing.length > 0) {
+  console.error(
+    `\nRecorded as a tier adapter but no longer declaring a BoxelRuntime:\n` +
+      missing.map((file) => `  ${file}`).join('\n') +
+      `\n\nA harness still expecting that mode reports it absent on every run.\n` +
+      `Drop it from the registered modes and from this script together.`,
+  );
+}
+
+process.exit(unexpected.length + missing.length > 0 ? 1 : 0);

--- a/scripts/check-execution-tier-registry.mts
+++ b/scripts/check-execution-tier-registry.mts
@@ -40,12 +40,26 @@
 // until it stopped meaning anything. An adapter built by a factory is caught by
 // signal 2 instead, in whichever file defines the operations.
 //
-// What this cannot see, and does not claim to: an implementation that both
-// names the interface nowhere AND defines few operations of its own because it
-// inherits them, and anything under a `tests` directory, which is skipped so a
-// test double is not mistaken for a tier. What it over-reads: a wrapper that
-// forwards most of the interface to an inner runtime looks like an
-// implementation by signal 2, because textually it is one.
+// What this cannot see, and does not claim to:
+//
+//   - an implementation that both names the interface nowhere AND defines few
+//     operations of its own, because it inherits them;
+//   - one that defines its operations *dynamically* — assigning them in a loop
+//     over `BOXEL_RUNTIME_OPERATIONS`, or dispatching by name in a `switch` —
+//     which names none of them textually. The protocol exports that list for
+//     dispatch by name, so this is a shape it invites, and a transport-backed
+//     adapter is the likeliest place for it;
+//   - anything under a `tests` directory, skipped so a test double is not
+//     mistaken for a tier.
+//
+// What it over-reads, all by signal 2 and all because textually they define the
+// operations: a wrapper forwarding most of the interface to an inner runtime; a
+// consumer that destructures the operations out of a runtime under the same
+// names, or calls them bare rather than through a member access; a type-only
+// structural mirror of the interface; and a stub outside a `tests` directory.
+// The lookbehind separates a member-access call from a definition —
+// `runtime.projectInstance(handle)` is a consumer — and does not separate a
+// bare call or a renamed destructure.
 //
 // It is a tripwire on how an adapter is actually written, not a proof that none
 // exists — and it holds files rather than behavior: recording an entry says
@@ -78,7 +92,12 @@ const skipDirectories = new Set([
   'tests',
 ]);
 
+// A declaration file declares types and implements nothing, and generated
+// mirrors of this repo's own source are declaration files — `bundled-types`
+// holds a copy of the protocol module's own `runtime.ts`, which declares all
+// eight operations and sits outside the exclusion below.
 const SOURCE = /\.(ts|gts|mts)$/;
+const DECLARATION_FILE = /\.d\.(ts|mts)$/;
 
 // The module that declares the interface, which is therefore not an
 // implementation of it: its own body defines all eight operations, and its
@@ -146,7 +165,7 @@ function* walk(dir: string): Generator<string> {
     }
     if (stat.isDirectory()) {
       yield* walk(full);
-    } else if (SOURCE.test(entry)) {
+    } else if (SOURCE.test(entry) && !DECLARATION_FILE.test(entry)) {
       yield full;
     }
   }

--- a/scripts/check-execution-tier-registry.mts
+++ b/scripts/check-execution-tier-registry.mts
@@ -21,10 +21,14 @@
 //
 //   1. `implements` / `satisfies` naming the interface. Neither has a reading
 //      other than "this is an implementation".
-//   2. A file that names the interface and defines most of its operations as
-//      its own members. No syntax is involved, so this covers a class
-//      expression, a decorated class, an object literal built by a factory, and
-//      whatever the next form is.
+//   2. A file defining most of the interface's operations as its own members.
+//      No syntax is involved and the interface need not be named, so this
+//      covers a class expression, a decorated class, an object literal a
+//      factory in another file returns, and whatever the next form is. Every
+//      source file is read for it rather than only those mentioning the
+//      interface: an adapter assembled by a factory elsewhere never mentions
+//      it, and skipping those files is what made the claim below false the
+//      first time it was written.
 //
 // A bare type annotation — `const x: BoxelRuntime`, or a return type — is
 // deliberately NOT a signal. Those forms read identically on an implementation
@@ -34,17 +38,20 @@
 // remedy such a failure prints — register this mode with the harness — is
 // meaningless for them, so the list would accumulate entries that are not tiers
 // until it stopped meaning anything. An adapter built by a factory is caught by
-// signal 2 instead, in the file that defines the operations.
+// signal 2 instead, in whichever file defines the operations.
 //
-// What this cannot see, and does not claim to: an implementation naming the
-// interface nowhere at all; one defining few operations of its own because it
-// inherits them from a base class that does not name the interface either; and
-// anything under a `tests` directory, which is skipped so a test double
-// implementing the interface is not mistaken for a tier. It is a tripwire on
-// how an adapter is actually written, not a proof that none exists. It also
-// holds files rather than behavior: recording an entry says someone looked, not
-// that the mode reached `checkRecordParity`. Comment detection is line-local,
-// for the reasons `check-rp-bijection.mts` gives at length.
+// What this cannot see, and does not claim to: an implementation that both
+// names the interface nowhere AND defines few operations of its own because it
+// inherits them, and anything under a `tests` directory, which is skipped so a
+// test double is not mistaken for a tier. What it over-reads: a wrapper that
+// forwards most of the interface to an inner runtime looks like an
+// implementation by signal 2, because textually it is one.
+//
+// It is a tripwire on how an adapter is actually written, not a proof that none
+// exists — and it holds files rather than behavior: recording an entry says
+// someone looked, not that the mode reached `checkRecordParity`. Comment
+// detection is line-local, for the reasons `check-rp-bijection.mts` gives at
+// length.
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
@@ -175,11 +182,6 @@ for (let file of walk(scanRoot)) {
     continue;
   }
   let raw = readFileSync(file, 'utf8');
-  // The name is what makes a file worth parsing at all, and most of the repo
-  // does not carry it.
-  if (!raw.includes('BoxelRuntime')) {
-    continue;
-  }
   if (implementsRuntime(withoutComments(raw))) {
     found.push(path);
   }

--- a/scripts/check-execution-tier-registry.mts
+++ b/scripts/check-execution-tier-registry.mts
@@ -1,50 +1,66 @@
 #!/usr/bin/env -S node
-// Makes a tier adapter landing visible to the record-parity harness (RP-14.4).
+// Makes a tier adapter visible to the record-parity harness (RP-14.4).
 //
-// The harness compares the records every tier produces, but it can only
-// compare tiers it was handed. Nothing about writing a second `BoxelRuntime`
-// implementation wires it in, and nothing about forgetting to fails: the
-// harness reports parity across the tiers it knows, so an unregistered adapter
-// is not a red test, it is an absent one. That is the failure this project
-// already paid for once — the spike grew three record builders, and nearly
-// every parity bug traced to two of the three disagreeing with no check
-// watching.
+// The harness compares the records every tier produces, and it can only compare
+// tiers it was handed. Writing a second `BoxelRuntime` implementation does not
+// wire it in, and omitting that step fails nothing: the harness reports parity
+// across the tiers it knows, so an unregistered adapter is not a red test but an
+// absent one. Competing record builders that each agree with themselves and not
+// with each other is the failure this guards, and it is invisible to every
+// per-tier suite, because each of those agrees with its own builder.
 //
-// So the set of `BoxelRuntime` implementations in the repo is held EQUAL to the
-// list recorded below. An adapter appearing fails the build until someone
-// records it here, which is the moment to hand it to `checkRecordParity` as a
-// registered mode. An adapter disappearing fails too, because a harness still
-// listing a mode that no longer exists reports a tier absent forever.
+// So the set of `BoxelRuntime` implementations under `packages/` is held EQUAL
+// to the list recorded below, each entry naming the mode it implements. An
+// implementation appearing fails the build until someone records it, which is
+// the moment to hand that mode to `checkRecordParity`. One disappearing fails
+// too, because a harness expecting a mode nothing implements reports that tier
+// absent on every run.
 //
-// Two independent signals, because enumerating syntaxes is how a check like
-// this quietly stops working. The first is the keyword forms an adapter is
-// declared through. The second needs no syntax at all: a file that names the
-// interface and defines most of its operations as its own members is
-// implementing it, however it was declared — which covers the factory forms,
-// a class expression, a decorated class, and whatever the next one is.
+// Two independent signals, because a check that enumerates syntaxes stops
+// working the first time someone writes a form it does not list:
 //
-// What this cannot see, and does not claim to: an implementation that names
-// the interface nowhere at all, satisfying it structurally, and one that
-// defines few operations itself because it delegates them to a mixin AND is
-// declared through none of the keyword forms. This is a tripwire on how an
-// adapter is actually written, not a proof that none exists. Comment detection
-// is line-local, for the reasons `check-rp-bijection.mts` gives at length.
+//   1. `implements` / `satisfies` naming the interface. Neither has a reading
+//      other than "this is an implementation".
+//   2. A file that names the interface and defines most of its operations as
+//      its own members. No syntax is involved, so this covers a class
+//      expression, a decorated class, an object literal built by a factory, and
+//      whatever the next form is.
+//
+// A bare type annotation — `const x: BoxelRuntime`, or a return type — is
+// deliberately NOT a signal. Those forms read identically on an implementation
+// and on a consumer: a wrapper takes and returns one, a service exposes one
+// through a getter, an interface declares a factory method producing one.
+// Treating them as implementations fails the build for all three, and the
+// remedy such a failure prints — register this mode with the harness — is
+// meaningless for them, so the list would accumulate entries that are not tiers
+// until it stopped meaning anything. An adapter built by a factory is caught by
+// signal 2 instead, in the file that defines the operations.
+//
+// What this cannot see, and does not claim to: an implementation naming the
+// interface nowhere at all; one defining few operations of its own because it
+// inherits them from a base class that does not name the interface either; and
+// anything under a `tests` directory, which is skipped so a test double
+// implementing the interface is not mistaken for a tier. It is a tripwire on
+// how an adapter is actually written, not a proof that none exists. It also
+// holds files rather than behavior: recording an entry says someone looked, not
+// that the mode reached `checkRecordParity`. Comment detection is line-local,
+// for the reasons `check-rp-bijection.mts` gives at length.
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const scanRoot = join(repoRoot, 'packages');
 
-// Every file declaring a tier runtime, and nothing else. Empty because no
-// adapter exists yet: the interface is declared (CS-12599) and the first
-// implementation is still ahead. Each entry here should be a mode passed to
-// `checkRecordParity` as registered.
-const registered = new Set<string>([]);
+// Every file implementing a tier runtime, and the mode each one implements.
+// Empty because the interface is declared and nothing implements it. Each entry
+// should be a mode `checkRecordParity` is given as registered.
+const registered = new Map<string, string>([]);
 
-// Directories with no source of ours in them, or with a copy of it that is not
-// the one that ships.
+// Directories with no source of ours in them, a copy of it that is not the one
+// that ships, or — for `tests` — implementations that stand in for a tier
+// rather than being one.
 const skipDirectories = new Set([
   'node_modules',
   'dist',
@@ -52,32 +68,28 @@ const skipDirectories = new Set([
   'coverage',
   '.git',
   'declarations',
+  'tests',
 ]);
 
 const SOURCE = /\.(ts|gts|mts)$/;
 
-// `implements` may list more than one interface, so the match runs to the class
-// body rather than to the next identifier. `satisfies` covers an object literal
-// adapter. The two annotation forms are a bound name (`const runtime:
-// BoxelRuntime = …`) and a return type (`function create(): BoxelRuntime`,
-// `(): Promise<BoxelRuntime> =>`), which is how a factory-built adapter is
-// declared. A parameter or field annotation deliberately does not match:
-// taking a `BoxelRuntime` is what a consumer does.
-const DECLARES_RUNTIME = [
-  /\bimplements\b[^{;]*\bBoxelRuntime\b/,
-  /\bsatisfies\s+BoxelRuntime\b/,
-  /\b(?:const|let|var)\s+\w+\s*:\s*BoxelRuntime\b/,
-  /\)\s*:\s*(?:Promise\s*<\s*)?BoxelRuntime\b/,
-];
-
-// The module that declares the interface, which is therefore never an
+// The module that declares the interface, which is therefore not an
 // implementation of it: its own body defines all eight operations, and its
-// operation list names them again.
+// operation list names them again. Compared with a separator, so a sibling whose
+// name merely begins with the same characters is still scanned — the directory
+// beside the protocol module is exactly where an adapter would sit.
 const declaringDirectory = join(
   'packages',
   'runtime-common',
   'boxel-execution-protocol',
 );
+
+// `implements` may list more than one interface, so the match runs to the class
+// body rather than to the next identifier.
+const DECLARES_RUNTIME = [
+  /\bimplements\b[^{;]*\bBoxelRuntime\b/,
+  /\bsatisfies\s+BoxelRuntime\b/,
+];
 
 /**
  * The operations an implementation has to define, read out of the protocol's
@@ -106,10 +118,10 @@ function runtimeOperations(): string[] {
 
 const operations = runtimeOperations();
 
-// Two thirds of the interface. Not all of it: an adapter part-way through
-// being written, or one inheriting a couple of operations, is exactly what
-// this should catch. The lookbehind is what separates defining an operation
-// from calling one — `runtime.projectInstance(handle)` is a consumer.
+// Two thirds of the interface. Not all of it: an adapter part-way through being
+// written, or one inheriting a couple of operations, is exactly what this should
+// catch. The lookbehind is what separates defining an operation from calling
+// one — `runtime.projectInstance(handle)` is a consumer.
 const operationThreshold = Math.ceil((operations.length * 2) / 3);
 const DEFINES_OPERATION = operations.map(
   (name) => new RegExp(`(?<![.\\w$])${name}\\s*[(:=]`),
@@ -143,10 +155,23 @@ function withoutComments(source: string): string {
     .join('\n');
 }
 
+function implementsRuntime(source: string): boolean {
+  if (DECLARES_RUNTIME.some((pattern) => pattern.test(source))) {
+    return true;
+  }
+  return (
+    DEFINES_OPERATION.filter((pattern) => pattern.test(source)).length >=
+    operationThreshold
+  );
+}
+
 let found: string[] = [];
 for (let file of walk(scanRoot)) {
   let path = relative(repoRoot, file);
-  if (path.startsWith(declaringDirectory)) {
+  if (
+    path === `${declaringDirectory}.ts` ||
+    path.startsWith(`${declaringDirectory}${sep}`)
+  ) {
     continue;
   }
   let raw = readFileSync(file, 'utf8');
@@ -155,39 +180,39 @@ for (let file of walk(scanRoot)) {
   if (!raw.includes('BoxelRuntime')) {
     continue;
   }
-  let source = withoutComments(raw);
-  let declared = DECLARES_RUNTIME.some((pattern) => pattern.test(source));
-  let defined =
-    DEFINES_OPERATION.filter((pattern) => pattern.test(source)).length >=
-    operationThreshold;
-  if (declared || defined) {
+  if (implementsRuntime(withoutComments(raw))) {
     found.push(path);
   }
 }
 found.sort();
 
 const unexpected = found.filter((file) => !registered.has(file));
-const missing = [...registered].sort().filter((file) => !found.includes(file));
+const missing = [...registered.keys()]
+  .sort()
+  .filter((file) => !found.includes(file));
 
 console.log(
-  `execution tier adapters: ${found.length} — ${found.length === 0 ? 'none yet' : found.join(', ')}`,
+  `execution tier adapters: ${found.length}${found.length === 0 ? '' : ` — ${found.join(', ')}`}`,
 );
 
 if (unexpected.length > 0) {
   console.error(
-    `\nThese files declare a BoxelRuntime the record-parity harness does not know about:\n` +
+    `\nThese files implement a BoxelRuntime the record-parity harness does not know about:\n` +
       unexpected.map((file) => `  ${file}`).join('\n') +
       `\n\nA tier the harness is not handed is a tier RP-14.4 does not hold to\n` +
       `anything. Pass its mode to checkRecordParity as a registered mode, and\n` +
-      `record the file here in the same change.`,
+      `record the file here against that mode in the same change.\n` +
+      `If it implements no tier, the signal that matched it is too broad —\n` +
+      `narrow the signal rather than recording a file that is not an adapter.`,
   );
 }
 if (missing.length > 0) {
   console.error(
-    `\nRecorded as a tier adapter but no longer declaring a BoxelRuntime:\n` +
-      missing.map((file) => `  ${file}`).join('\n') +
-      `\n\nA harness still expecting that mode reports it absent on every run.\n` +
-      `Drop it from the registered modes and from this script together.`,
+    `\nRecorded as a tier adapter but not implementing a BoxelRuntime:\n` +
+      missing.map((file) => `  ${file} (${registered.get(file)})`).join('\n') +
+      `\n\nA harness expecting a mode nothing implements reports that tier\n` +
+      `absent on every run. Drop it from the registered modes and from this\n` +
+      `script together.`,
   );
 }
 

--- a/scripts/check-execution-tier-registry.mts
+++ b/scripts/check-execution-tier-registry.mts
@@ -16,12 +16,19 @@
 // registered mode. An adapter disappearing fails too, because a harness still
 // listing a mode that no longer exists reports a tier absent forever.
 //
-// What this cannot see, and does not claim to: an implementation that satisfies
-// the interface structurally, with no `implements` / `satisfies` / annotated
-// declaration naming it, and one that inherits the interface from a base class
-// that names it. This is a tripwire on the ways an adapter is actually written,
-// not a proof that none exists. Comment detection is line-local, for the
-// reasons `check-rp-bijection.mts` gives at length.
+// Two independent signals, because enumerating syntaxes is how a check like
+// this quietly stops working. The first is the keyword forms an adapter is
+// declared through. The second needs no syntax at all: a file that names the
+// interface and defines most of its operations as its own members is
+// implementing it, however it was declared — which covers the factory forms,
+// a class expression, a decorated class, and whatever the next one is.
+//
+// What this cannot see, and does not claim to: an implementation that names
+// the interface nowhere at all, satisfying it structurally, and one that
+// defines few operations itself because it delegates them to a mixin AND is
+// declared through none of the keyword forms. This is a tripwire on how an
+// adapter is actually written, not a proof that none exists. Comment detection
+// is line-local, for the reasons `check-rp-bijection.mts` gives at length.
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
@@ -51,14 +58,62 @@ const SOURCE = /\.(ts|gts|mts)$/;
 
 // `implements` may list more than one interface, so the match runs to the class
 // body rather than to the next identifier. `satisfies` covers an object literal
-// adapter, and the annotated-declaration form covers one built by a factory. A
-// parameter or field annotation deliberately does not match: taking a
-// `BoxelRuntime` is what a consumer does.
+// adapter. The two annotation forms are a bound name (`const runtime:
+// BoxelRuntime = …`) and a return type (`function create(): BoxelRuntime`,
+// `(): Promise<BoxelRuntime> =>`), which is how a factory-built adapter is
+// declared. A parameter or field annotation deliberately does not match:
+// taking a `BoxelRuntime` is what a consumer does.
 const DECLARES_RUNTIME = [
   /\bimplements\b[^{;]*\bBoxelRuntime\b/,
   /\bsatisfies\s+BoxelRuntime\b/,
   /\b(?:const|let|var)\s+\w+\s*:\s*BoxelRuntime\b/,
+  /\)\s*:\s*(?:Promise\s*<\s*)?BoxelRuntime\b/,
 ];
+
+// The module that declares the interface, which is therefore never an
+// implementation of it: its own body defines all eight operations, and its
+// operation list names them again.
+const declaringDirectory = join(
+  'packages',
+  'runtime-common',
+  'boxel-execution-protocol',
+);
+
+/**
+ * The operations an implementation has to define, read out of the protocol's
+ * own list rather than repeated here — a copy would drift, and a drifted copy
+ * lowers the bar silently.
+ */
+function runtimeOperations(): string[] {
+  let source = readFileSync(
+    join(repoRoot, declaringDirectory, 'runtime.ts'),
+    'utf8',
+  );
+  let list = /BOXEL_RUNTIME_OPERATIONS\s*=\s*\[([^\]]*)\]/.exec(source);
+  let names = list
+    ? [...list[1].matchAll(/'([^']+)'/g)].map((match) => match[1])
+    : [];
+  if (names.length === 0) {
+    console.error(
+      `Could not read BOXEL_RUNTIME_OPERATIONS out of ${declaringDirectory}/runtime.ts.\n` +
+        `The operation-shape signal is inert without it; fix the reader rather ` +
+        `than leaving the check running on one signal.`,
+    );
+    process.exit(1);
+  }
+  return names;
+}
+
+const operations = runtimeOperations();
+
+// Two thirds of the interface. Not all of it: an adapter part-way through
+// being written, or one inheriting a couple of operations, is exactly what
+// this should catch. The lookbehind is what separates defining an operation
+// from calling one — `runtime.projectInstance(handle)` is a consumer.
+const operationThreshold = Math.ceil((operations.length * 2) / 3);
+const DEFINES_OPERATION = operations.map(
+  (name) => new RegExp(`(?<![.\\w$])${name}\\s*[(:=]`),
+);
 
 function* walk(dir: string): Generator<string> {
   for (let entry of readdirSync(dir)) {
@@ -90,6 +145,10 @@ function withoutComments(source: string): string {
 
 let found: string[] = [];
 for (let file of walk(scanRoot)) {
+  let path = relative(repoRoot, file);
+  if (path.startsWith(declaringDirectory)) {
+    continue;
+  }
   let raw = readFileSync(file, 'utf8');
   // The name is what makes a file worth parsing at all, and most of the repo
   // does not carry it.
@@ -97,8 +156,12 @@ for (let file of walk(scanRoot)) {
     continue;
   }
   let source = withoutComments(raw);
-  if (DECLARES_RUNTIME.some((pattern) => pattern.test(source))) {
-    found.push(relative(repoRoot, file));
+  let declared = DECLARES_RUNTIME.some((pattern) => pattern.test(source));
+  let defined =
+    DEFINES_OPERATION.filter((pattern) => pattern.test(source)).length >=
+    operationThreshold;
+  if (declared || defined) {
+    found.push(path);
   }
 }
 found.sort();

--- a/scripts/check-rp-bijection.mts
+++ b/scripts/check-rp-bijection.mts
@@ -48,7 +48,7 @@ const strict = process.argv.includes('--strict');
 // The count of coverable statements with no citing test. Direction 2 holds the
 // real count equal to this, so it changes only in a commit that deliberately
 // lands coverage or edits the statement inventory.
-const expectedUncovered = 105;
+const expectedUncovered = 104;
 const exemptStatements = new Set([
   'RP-0.1',
   'RP-0.2',


### PR DESCRIPTION
The protocol module declares the records that cross a trust boundary and the interface every tier answers through. What it cannot do on its own is check that the tiers agree. The case the whole design rests on is that Capsule and Sandbox conform to the same spec and are therefore at parity by construction; RP-14.4 is where that is written down, and until something compares records, "by construction" is an assertion rather than a check. Competing record builders that each agree with themselves and not with each other is a failure this design has already produced, and it is invisible to every per-tier suite, because each of those agrees with its own builder.

This is the comparison, landed ahead of the tiers it will compare. `@cardstack/runtime-common/boxel-execution-conformance` has two entry points: `diffRecords(reference, candidate)`, which answers where two records part, and `checkRecordParity({fixture, tiers, registeredModes})`, which runs that over whatever tiers it was handed, with Direct as the reference (RP-0.5).

## What equality means here

The interesting part is not the recursion, it is the definition. Record equality is narrower than `===` and wider than comparing two stringifications, and every one of these rules is a case where the obvious implementation is wrong:

- **Member order is not part of a record; element order is.** Two producers building one description through different code order their keys differently, and a stringified comparison calls that a divergence. `ancestors` / `fields` / `formats` are sequences a consumer renders in order, so a tier enumerating them differently has diverged.
- **Absent, `undefined` and `null` are three states.** A member with an `undefined` value survives `structuredClone` with its name intact, so `'x' in record` tells it from an absent one and a consumer reading it tells both from `null`. A sentinel keeps them apart; without it the first two collapse.
- **`Object.is`, not `===`.** `NaN` and `-0` both cross a boundary intact, so two tiers can genuinely differ by `0` against `-0` — which is what a lane that JSON round-trips where it claims to `structuredClone` looks like from the outside. Rendering follows: JSON writes `NaN` and both infinities as `null` and `-0` as `0`, so a report of exactly the divergences `Object.is` exists to catch would read `reference=0 candidate=0`.
- **A subgraph two records share is compared once.** `structuredClone` preserves sharing, so a normalized record is a DAG, and a DAG whose every node has two parents has a number of *paths* exponential in its depth. Forty such levels is 82 values — comfortably inside the boundary's own ceiling — and 2^40 paths, so without the compared-pair memo the harness does not answer on a record the boundary accepts.
- **Two arrays are compared over their shared prefix.** Reporting the length and then one absent element per position past it is the same fact told N times.

## Faults are about one record, not two

Each side is first reduced through the protocol's own normalizer, and then past RP-14.3's envelope gate — the same calls a consumer makes. That is deliberate: a diff judging records by a looser rule than the boundary would call two records equal that the boundary then refuses. Two conditions produce a **fault**, and a faulted record is not compared against a peer:

- **Not inert data** — an accessor, a function, a prototype of its own, a symbol-keyed member, a reference to itself, a trap that throws, or a root that is not a record. `structuredClone` accepts three of those, so "it cloned" is not evidence.
- **Data, but not a record of this protocol** — `{}` carries no envelope, and one declaring a version the comparing consumer does not implement is refused by the gate.

The two differ in what the skip costs, which the code says out loud. A record that is not data could not have been compared anyway. One refused for its envelope could have been compared member by member, so a version mismatch hides that pair's content divergences until the version is fixed — for every candidate at once when it is Direct's record that was refused. That is RP-14.3's rule applied to a differ, which is a consumer like any other.

This is also the runtime half of a compile-time check with a known hole: `Cloneable<T>` proves a declared record is inert data, and `any` satisfies it at any depth, including through `Record<string, any>`. JSON:API attribute bags are exactly that shape, so those members get no compile-time check and are caught only here.

## How it avoids reporting success while enforcing nothing

There is one tier today, so there is nothing to diff, and a harness that returns green on that is worse than no harness:

- **Every report states its own coverage, passing or failing** — `0 record comparison(s), 2 record(s) read as data`. A CI log cannot read "the tiers agree" when it means "there was one tier". `comparisons` counts pairs actually compared, so a faulted pair is never counted as checked.
- **One tier is still held to something real.** Every record is read as a usable record whether or not there is a peer, so a Direct adapter answering with a live object, with `null`, or with `{}` fails on its own.
- **Every mode named by a tier or by the registry is walked**, not only the three the protocol declares. A tier's mode is data, and a Sandbox tier's arrives across the boundary this module exists to distrust, so a typo'd or forged mode is inspected and reported rather than skipped while the run says it found nothing.
- **Two tiers handed the same object are reported.** No real pair of tiers can be — each builds its own record — so that is a caller that wired one tier's output in twice, and every comparison of it agrees for free.
- **`lint:tier-registry`** holds the set of `BoxelRuntime` implementations under `packages/` equal to a recorded list, each entry naming the mode it implements, empty while nothing implements the interface. One appearing fails the build until it is recorded, which is the moment to hand that mode to `checkRecordParity`; one disappearing fails too, since a harness expecting a mode nothing implements reports that tier absent forever. Two signals: `implements` / `satisfies` naming the interface, and — needing no syntax and no mention of the interface — a file defining two thirds of its operations as its own members, with the names read out of `BOXEL_RUNTIME_OPERATIONS` rather than copied. A bare type annotation is deliberately not a signal: a wrapper, a service getter and an interface's factory method all read the same as an implementation through one, and the remedy such a failure prints is meaningless for them.

## Exemptions

`TIER_SPECIFIC_RECORD_PATHS` is RP-14.4's "modulo" clause as a list, empty and held empty by a test. An entry is a statement that a member legitimately differs between tiers, which is a spec change.

The rules matter more than the list, because the list is where the first real caller starts. Coverage is prefix-closed — an exemption covers the path it names and everything under it. Indices are wildcarded on both sides, so `fields[].kind` and `fields[0].kind` both name that member of every element. Exemption prunes the descent rather than filtering the report, which is what keeps an exempt subtree out of the compared-pair memo: filter at the report instead, and a shared subgraph first reached through an exempt path is recorded as compared, so exempting one member silences divergences at unrelated ones. An empty entry is refused rather than dropped — the empty path is a prefix of every path, so honoring one silences the whole record, and it is the one exemption provably incapable of naming a member.

## Also in this change

Three fixes in the protocol module, all behavioral rather than cosmetic:

- **An offender list's count is enforced.** `OffenderList` splits what a diagnostic *shows* from how many it *saw*, and nothing pinned the second half, because every test reaching one used more entries than a record may carry — so the budget refused first and the list never filled. Forty offenders at each of the three sites is inside the ceiling, so the list fills and the count is the assertion. A bundle with forty unknown kinds that names ten and implies that is all of them is the falsehood the split exists to prevent.
- **`gateEnvelope` collects rather than filters.** It is the third collect-and-report site, and it built one rendered string per unrecognized feature in order to print ten. The feature array is budget-charged, so this bounds retention rather than exposure, and it makes one idiom of the three sites that have one.
- **Base's child-format cascade points back at the shared one.** `childFieldFormatsFor` names `defaultFieldFormats`; that function is module-private, so a conformance suite cannot reach it and nothing holds Base's copy to anything. The comment says exactly that, rather than implying coverage that does not exist.

## Where it lives, and why not in the protocol module

Beside the protocol module rather than inside it. The protocol's runtime closure is held *equal* to its own directory because it is evaluated where the Host's module graph is absent, and paying for a conformance harness in every Compartment and iframe child would make that guard mean less rather than more. The closure is still 13 modules.

In `runtime-common` rather than in a test suite because record equality is a rule, not a fixture: the same question is asked of one tier's record against an expected one, of two tiers against each other, and of records built in another process — askers that do not share a package, so a rule living inside one suite would be copied the first time it was asked from outside. `searchable-parity.ts` is the precedent: one diff rule there, imported by a realm-server script and by its tests.

Being precise about the bet, since it is the one placement decision here that could go the other way: the module has exactly one caller, a host conformance suite. If the next consumer turns out not to fit, the move is a rename plus imports in one file — much cheaper now than once two packages depend on it. Push back if you would rather not carry that.

## What is deliberately not here

**The cross-tier render suite (RP-15.4b).** It is each fixture × applicable tier through the render entry in a real DOM, Sandbox in a real iframe, asserting mounted tier, visible output, interaction results and boundary negatives. There is no render entry and no second tier to mount, so this would be fiction. RP-15.4 is one statement covering the oracle, the render suite and the record diff, so it is **not** cited: citing it would mark all three covered while two do not exist.

**The fixture axis inventory.** RP-15.5 wants formats × field kinds × computed/config × links × broken/loading × edit generated rather than hand-picked, and the record diff does not need it — it takes records, not fixtures. It belongs with the corpus port and the oracle that consumes it, and inventing its shape here would mean the fixtures arrive and change it.

So the bijection figure moves 105 → 104: RP-14.4 only.

## Known limits, stated because the first caller will meet them

**Every exemption path here is unexercised by anything that ships.** `TIER_SPECIFIC_RECORD_PATHS` is empty, and the only caller passing `exemptPaths` is the conformance suite. So the commit that first declares a tier-specific path is the one that first runs this in earnest, and it is the least likely to suspect the harness. An exemption naming a member no record carries is silent, so the rules above are worth reading before adding an entry.

**The tier-registry check is a tripwire, not a proof, and its header enumerates both directions.** It over-reads a forwarding wrapper, a consumer that destructures the operations or calls them bare, a type-only structural mirror, and a stub outside a `tests` directory — all loud, all resolved by narrowing the signal rather than padding the list. It is blind to an adapter that assigns its operations in a loop over `BOXEL_RUNTIME_OPERATIONS`, a shape the protocol invites by exporting that list for dispatch by name. The highest score across the files it scans is 3 of 8 against a threshold of 6.

## Verification

- `Unit | rendering protocol | cross-tier record parity`: 47 tests. With the protocol suite: 98 tests, 356 assertions, green at `:4200/tests?filter=rendering protocol`.
- Randomized differential testing over generated record pairs and exemption lists finds no input on which the harness reports parity for records that diverge — 0 false greens in 16,089 generated parity inputs — and `comparisons` equals the number of pairs where neither side faulted in every one of them.
- Each load-bearing rule is held by a case that fails when the rule is removed: `Object.is` (NaN and `-0`), the absent sentinel, sorted report order, the shared array prefix, the compared-pair memo (31ms with it, no answer inside 45s without), the `asRefusal` wrap, the faulted-side skip, tier-order iteration, inspections counting the reference, each of the four registry findings, and the offender count at all three sites — where nothing else in the suite fails under that last change, which is what made it a gap.
- A 13-shape probe holds the registry detector to five adapter forms caught — including a builder in a sibling file that never names the interface, and one in a directory whose name begins with the protocol module's — and eight consumer forms ignored.
- `ember-tsc --noEmit` clean in `runtime-common` and `host`; `eslint` clean; `pnpm lint` in `packages/base` clean; `lint:scripts`, `lint:rp-bijection`, `lint:protocol-closure` and `lint:tier-registry` all pass.
