### PR TITLE
host: Fix duplicate Percy snapshot name and add lint prevention

### DIFF
--- a/packages/eslint-plugin-cardstack-host/README.md
+++ b/packages/eslint-plugin-cardstack-host/README.md
@@ -30,12 +30,13 @@ Then configure the rules you want to use under the rules section:
 ✅ Set in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                                   | Description                                                                                          | 💼 | 🔧 |
-| :--------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- | :- | :- |
-| [host-tools-registered](docs/rules/host-tools-registered.md)           | Ensure every host tool module is imported, shimmed, and exported                                     | ✅  |    |
-| [mock-window-only](docs/rules/mock-window-only.md)                     | Enforce use of window mock localStorage                                                              | ✅  | 🔧 |
-| [no-percy-direct-import](docs/rules/no-percy-direct-import.md)         | Forbid importing percySnapshot directly from @percy/ember; use @cardstack/host/tests/helpers instead | ✅  | 🔧 |
-| [wrapped-setup-helpers-only](docs/rules/wrapped-setup-helpers-only.md) | Enforce use of wrapped setup helpers that use ember-window-mock                                      | ✅  |    |
+| Name                                                                     | Description                                                                                          | 💼  | 🔧  |
+| :----------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- | :-- | :-- |
+| [host-tools-registered](docs/rules/host-tools-registered.md)             | Ensure every host tool module is imported, shimmed, and exported                                     | ✅  |     |
+| [mock-window-only](docs/rules/mock-window-only.md)                       | Enforce use of window mock localStorage                                                              | ✅  | 🔧  |
+| [no-percy-direct-import](docs/rules/no-percy-direct-import.md)           | Forbid importing percySnapshot directly from @percy/ember; use @cardstack/host/tests/helpers instead | ✅  | 🔧  |
+| [unique-percy-snapshot-names](docs/rules/unique-percy-snapshot-names.md) | Require every Percy snapshot within a test to have a distinct name                                   | ✅  |     |
+| [wrapped-setup-helpers-only](docs/rules/wrapped-setup-helpers-only.md)   | Enforce use of wrapped setup helpers that use ember-window-mock                                      | ✅  |     |
 
 <!-- end auto-generated rules list -->
 

--- a/packages/eslint-plugin-cardstack-host/docs/rules/unique-percy-snapshot-names.md
+++ b/packages/eslint-plugin-cardstack-host/docs/rules/unique-percy-snapshot-names.md
@@ -1,0 +1,27 @@
+# Require every Percy snapshot within a test to have a distinct name (`@cardstack/host/unique-percy-snapshot-names`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+
+`percySnapshot(assert)` derives its snapshot name from the QUnit module name
+and the test name and nothing else, so every bare call inside one test uploads
+under the same name. Percy stores one snapshot per name per build and which of
+the colliding uploads it keeps is not stable from build to build, so one of the
+two intended snapshots silently goes unreviewed and the name flips between two
+unrelated frames — a near-total diff appearing on branches that changed
+neither.
+
+A test that snapshots more than once needs an explicit distinct name for each
+call after the first:
+
+```js
+test('visiting operator mode', async function (assert) {
+  await percySnapshot(assert);
+
+  await click(cardSelector);
+  await percySnapshot(
+    'Acceptance | operator mode tests | visiting operator mode - card opened in stack',
+  );
+});
+```

--- a/packages/eslint-plugin-cardstack-host/lib/recommended-rules.js
+++ b/packages/eslint-plugin-cardstack-host/lib/recommended-rules.js
@@ -5,8 +5,9 @@
  * definitions, execute "pnpm run update"
  */
 module.exports = {
-  "@cardstack/host/host-tools-registered": "error",
-  "@cardstack/host/mock-window-only": "error",
-  "@cardstack/host/no-percy-direct-import": "error",
-  "@cardstack/host/wrapped-setup-helpers-only": "error"
-}
+  '@cardstack/host/host-tools-registered': 'error',
+  '@cardstack/host/mock-window-only': 'error',
+  '@cardstack/host/no-percy-direct-import': 'error',
+  '@cardstack/host/unique-percy-snapshot-names': 'error',
+  '@cardstack/host/wrapped-setup-helpers-only': 'error',
+};

--- a/packages/eslint-plugin-cardstack-host/lib/rules/unique-percy-snapshot-names.js
+++ b/packages/eslint-plugin-cardstack-host/lib/rules/unique-percy-snapshot-names.js
@@ -7,17 +7,24 @@
 // `test`, and the QUnit variants that also take a test body.
 const TEST_CALLEES = new Set(['test', 'skip', 'todo', 'only']);
 
-// Stands in for the name `percySnapshot(assert)` produces, which is the QUnit
-// module name plus the test name and nothing else — identical for every bare
-// call within one test.
-const DERIVED_NAME = Symbol('derived from module and test name');
+// Stands in for the name Percy will derive when this file doesn't spell out
+// enough of it to reconstruct — a module or test named by something other than
+// a static string. Two bare calls in such a test still collide with each other,
+// which this catches; they just can't be compared against a written-out name.
+const DERIVED = Symbol('derived from module and test name');
 
-function testCalleeName(node) {
-  let callee = node.callee;
+// A name that cannot be known statically. Never compared, never recorded — a
+// call the rule has no opinion about is not a call it may report.
+const UNKNOWN = Symbol('not statically known');
+
+// `test(...)`, `test.only(...)`, `module(...)` all answer with the leading
+// identifier. `re.test(s)` answers 're', so a method call named `test` on some
+// other object is not mistaken for a QUnit test.
+function calleeRootName(node) {
+  const callee = node.callee;
   if (callee.type === 'Identifier') {
     return callee.name;
   }
-  // test.only(...), test.skip(...)
   if (
     callee.type === 'MemberExpression' &&
     callee.object.type === 'Identifier'
@@ -27,23 +34,24 @@ function testCalleeName(node) {
   return null;
 }
 
-function isTestCall(node) {
-  return TEST_CALLEES.has(testCalleeName(node));
-}
-
-// The explicit name a call passes, or null when Percy will derive one.
-function explicitName(node) {
-  let [arg] = node.arguments;
-  if (!arg) {
+function staticString(node) {
+  if (!node) {
     return null;
   }
-  if (arg.type === 'Literal' && typeof arg.value === 'string') {
-    return arg.value;
+  if (node.type === 'Literal' && typeof node.value === 'string') {
+    return node.value;
   }
-  if (arg.type === 'TemplateLiteral' && arg.expressions.length === 0) {
-    return arg.quasis[0].value.cooked;
+  if (node.type === 'TemplateLiteral' && node.expressions.length === 0) {
+    return node.quasis[0].value.cooked;
   }
   return null;
+}
+
+function callbackOf(node) {
+  return node.arguments.find(
+    (a) =>
+      a.type === 'FunctionExpression' || a.type === 'ArrowFunctionExpression',
+  );
 }
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -59,49 +67,113 @@ module.exports = {
     schema: [],
     messages: {
       duplicateDerivedName:
-        'This test already takes a Percy snapshot under the name derived from its module and test name, and Percy keeps one snapshot per name per build. Pass an explicit distinct name here so both snapshots are reviewed.',
+        'This test already takes a Percy snapshot under the name Percy derives from its module and test name, and Percy keeps one snapshot per name per build. Pass an explicit distinct name here so both snapshots are reviewed.',
       duplicateExplicitName:
-        "Another Percy snapshot in this test is already named '{{name}}', and Percy keeps one snapshot per name per build. Give this one a distinct name so both snapshots are reviewed.",
+        "Another Percy snapshot in this test already takes the name '{{name}}', and Percy keeps one snapshot per name per build. Give this one a distinct name so both snapshots are reviewed.",
     },
   },
 
   create(context) {
-    // One entry per enclosing test call, holding the names taken so far.
+    // Enclosing `module()` names, outermost first. QUnit joins nested module
+    // names with ' > ' to form the module name Percy reads.
+    let moduleNames = [];
+    // One frame per enclosing test call: the names taken so far, the name
+    // Percy will derive for it, and what its callback calls the assert object.
     let testStack = [];
+
+    function derivedNameFor(testName) {
+      if (testName === null || moduleNames.length === 0) {
+        return null;
+      }
+      if (moduleNames.some((m) => m === null)) {
+        return null;
+      }
+      return `${moduleNames.join(' > ')} | ${testName}`;
+    }
+
+    // Whether this call lets Percy derive its name rather than spelling one out.
+    function letsPercyDerive(node, frame) {
+      const [arg] = node.arguments;
+      return (
+        !arg ||
+        (arg.type === 'Identifier' &&
+          (arg.name === frame.assertParam || arg.name === 'assert'))
+      );
+    }
+
+    // What name this call will upload under: a written-out string, the name
+    // Percy derives for the enclosing test, or UNKNOWN when the argument is
+    // computed. Both spellings of the derived name land on the same key, so
+    // `percySnapshot(assert)` and a literal equal to that derived name are
+    // recognised as the collision they are.
+    function keyFor(node, frame) {
+      if (letsPercyDerive(node, frame)) {
+        return frame.derived === null ? DERIVED : frame.derived;
+      }
+      const written = staticString(node.arguments[0]);
+      return written === null ? UNKNOWN : written;
+    }
 
     return {
       CallExpression(node) {
-        if (isTestCall(node)) {
-          testStack.push(new Map());
+        const root = calleeRootName(node);
+
+        if (root === 'module') {
+          moduleNames.push(staticString(node.arguments[0]));
           return;
         }
+
+        if (TEST_CALLEES.has(root)) {
+          const callback = callbackOf(node);
+          const firstParam = callback && callback.params[0];
+          testStack.push({
+            taken: new Map(),
+            derived: derivedNameFor(staticString(node.arguments[0])),
+            assertParam:
+              firstParam && firstParam.type === 'Identifier'
+                ? firstParam.name
+                : null,
+          });
+          return;
+        }
+
         if (
           node.callee.type !== 'Identifier' ||
           node.callee.name !== 'percySnapshot'
         ) {
           return;
         }
-        let taken = testStack[testStack.length - 1];
+
+        const frame = testStack[testStack.length - 1];
         // A call outside any test can't collide with a sibling call.
-        if (!taken) {
+        if (!frame) {
           return;
         }
-        let name = explicitName(node);
-        let key = name === null ? DERIVED_NAME : name;
-        if (taken.has(key)) {
+
+        const key = keyFor(node, frame);
+        if (key === UNKNOWN) {
+          return;
+        }
+
+        if (frame.taken.has(key)) {
           context.report({
             node,
-            messageId:
-              name === null ? 'duplicateDerivedName' : 'duplicateExplicitName',
-            data: { name },
+            messageId: letsPercyDerive(node, frame)
+              ? 'duplicateDerivedName'
+              : 'duplicateExplicitName',
+            data: { name: typeof key === 'string' ? key : '' },
           });
           return;
         }
-        taken.set(key, node);
+
+        frame.taken.set(key, node);
       },
 
       'CallExpression:exit'(node) {
-        if (isTestCall(node)) {
+        const root = calleeRootName(node);
+        if (root === 'module') {
+          moduleNames.pop();
+        } else if (TEST_CALLEES.has(root)) {
           testStack.pop();
         }
       },

--- a/packages/eslint-plugin-cardstack-host/lib/rules/unique-percy-snapshot-names.js
+++ b/packages/eslint-plugin-cardstack-host/lib/rules/unique-percy-snapshot-names.js
@@ -1,0 +1,110 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+// `test`, and the QUnit variants that also take a test body.
+const TEST_CALLEES = new Set(['test', 'skip', 'todo', 'only']);
+
+// Stands in for the name `percySnapshot(assert)` produces, which is the QUnit
+// module name plus the test name and nothing else — identical for every bare
+// call within one test.
+const DERIVED_NAME = Symbol('derived from module and test name');
+
+function testCalleeName(node) {
+  let callee = node.callee;
+  if (callee.type === 'Identifier') {
+    return callee.name;
+  }
+  // test.only(...), test.skip(...)
+  if (
+    callee.type === 'MemberExpression' &&
+    callee.object.type === 'Identifier'
+  ) {
+    return callee.object.name;
+  }
+  return null;
+}
+
+function isTestCall(node) {
+  return TEST_CALLEES.has(testCalleeName(node));
+}
+
+// The explicit name a call passes, or null when Percy will derive one.
+function explicitName(node) {
+  let [arg] = node.arguments;
+  if (!arg) {
+    return null;
+  }
+  if (arg.type === 'Literal' && typeof arg.value === 'string') {
+    return arg.value;
+  }
+  if (arg.type === 'TemplateLiteral' && arg.expressions.length === 0) {
+    return arg.quasis[0].value.cooked;
+  }
+  return null;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require every Percy snapshot within a test to have a distinct name',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      duplicateDerivedName:
+        'This test already takes a Percy snapshot under the name derived from its module and test name, and Percy keeps one snapshot per name per build. Pass an explicit distinct name here so both snapshots are reviewed.',
+      duplicateExplicitName:
+        "Another Percy snapshot in this test is already named '{{name}}', and Percy keeps one snapshot per name per build. Give this one a distinct name so both snapshots are reviewed.",
+    },
+  },
+
+  create(context) {
+    // One entry per enclosing test call, holding the names taken so far.
+    let testStack = [];
+
+    return {
+      CallExpression(node) {
+        if (isTestCall(node)) {
+          testStack.push(new Map());
+          return;
+        }
+        if (
+          node.callee.type !== 'Identifier' ||
+          node.callee.name !== 'percySnapshot'
+        ) {
+          return;
+        }
+        let taken = testStack[testStack.length - 1];
+        // A call outside any test can't collide with a sibling call.
+        if (!taken) {
+          return;
+        }
+        let name = explicitName(node);
+        let key = name === null ? DERIVED_NAME : name;
+        if (taken.has(key)) {
+          context.report({
+            node,
+            messageId:
+              name === null ? 'duplicateDerivedName' : 'duplicateExplicitName',
+            data: { name },
+          });
+          return;
+        }
+        taken.set(key, node);
+      },
+
+      'CallExpression:exit'(node) {
+        if (isTestCall(node)) {
+          testStack.pop();
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-cardstack-host/package.json
+++ b/packages/eslint-plugin-cardstack-host/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "vitest run",
     "update:eslint-docs": "eslint-doc-generator",
-    "update": "node ./scripts/update-rules.js && pnpm run update:eslint-docs"
+    "update:format": "prettier --write README.md docs lib/recommended-rules.js",
+    "update": "node ./scripts/update-rules.js && pnpm run update:eslint-docs && pnpm run update:format"
   },
   "keywords": [],
   "author": "Cardstack",

--- a/packages/eslint-plugin-cardstack-host/tests/lib/rules/unique-percy-snapshot-names-test.js
+++ b/packages/eslint-plugin-cardstack-host/tests/lib/rules/unique-percy-snapshot-names-test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/unique-percy-snapshot-names');
+const RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('unique-percy-snapshot-names', rule, {
+  valid: [
+    {
+      name: 'one derived name per test',
+      code: `
+        test('a', async function (assert) {
+          await percySnapshot(assert);
+        });
+        test('b', async function (assert) {
+          await percySnapshot(assert);
+        });
+      `,
+    },
+    {
+      name: 'a second snapshot with an explicit name',
+      code: `
+        test('a', async function (assert) {
+          await percySnapshot(assert);
+          await percySnapshot('Module | a - after opening the card');
+        });
+      `,
+    },
+    {
+      name: 'two distinct explicit names',
+      code: `
+        test('a', async function (assert) {
+          await percySnapshot('Module | a - error state');
+          await percySnapshot(\`Module | a - new room state\`);
+        });
+      `,
+    },
+    {
+      name: 'a snapshot outside any test',
+      code: `
+        async function snapshotBoth() {
+          await percySnapshot('one');
+          await percySnapshot(assert);
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'two bare snapshots in one test',
+      code: `
+        test('a', async function (assert) {
+          await percySnapshot(assert);
+          await percySnapshot(assert);
+        });
+      `,
+      errors: [{ messageId: 'duplicateDerivedName' }],
+    },
+    {
+      name: 'two bare snapshots in a skipped test',
+      code: `
+        skip('a', async function (assert) {
+          await percySnapshot(assert);
+          await percySnapshot(assert);
+        });
+      `,
+      errors: [{ messageId: 'duplicateDerivedName' }],
+    },
+    {
+      name: 'two bare snapshots in test.only',
+      code: `
+        test.only('a', async function (assert) {
+          await percySnapshot(assert);
+          await percySnapshot(assert);
+        });
+      `,
+      errors: [{ messageId: 'duplicateDerivedName' }],
+    },
+    {
+      name: 'three bare snapshots report twice',
+      code: `
+        test('a', async function (assert) {
+          await percySnapshot(assert);
+          await percySnapshot(assert);
+          await percySnapshot(assert);
+        });
+      `,
+      errors: [
+        { messageId: 'duplicateDerivedName' },
+        { messageId: 'duplicateDerivedName' },
+      ],
+    },
+    {
+      name: 'the same explicit name twice',
+      code: `
+        test('a', async function (assert) {
+          await percySnapshot('Module | a - error state');
+          await percySnapshot('Module | a - error state');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'duplicateExplicitName',
+          data: { name: 'Module | a - error state' },
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-cardstack-host/tests/lib/rules/unique-percy-snapshot-names-test.js
+++ b/packages/eslint-plugin-cardstack-host/tests/lib/rules/unique-percy-snapshot-names-test.js
@@ -58,6 +58,47 @@ ruleTester.run('unique-percy-snapshot-names', rule, {
         }
       `,
     },
+    {
+      name: 'a computed name is not comparable, so not a duplicate',
+      code: `
+        test('a', async function (assert) {
+          await percySnapshot(assert);
+          await percySnapshot(\`Module | a - \${state}\`);
+        });
+      `,
+    },
+    {
+      name: 'an identifier name is not comparable either',
+      code: `
+        test('a', async function (assert) {
+          await percySnapshot(assert);
+          await percySnapshot(snapshotName);
+        });
+      `,
+    },
+    {
+      name: 'a literal that differs from the derived name',
+      code: `
+        module('Module', function () {
+          test('a test', async function (assert) {
+            await percySnapshot(assert);
+            await percySnapshot('Module | a test - after opening');
+          });
+        });
+      `,
+    },
+    {
+      name: 'a method call named test is not a QUnit test',
+      code: `
+        module('Module', function () {
+          test('a test', async function (assert) {
+            if (/x/.test(value)) {
+              await percySnapshot(assert);
+            }
+          });
+        });
+      `,
+    },
   ],
   invalid: [
     {
@@ -118,6 +159,64 @@ ruleTester.run('unique-percy-snapshot-names', rule, {
           data: { name: 'Module | a - error state' },
         },
       ],
+    },
+    {
+      name: 'an explicit name equal to the name Percy would derive',
+      code: `
+        module('Module', function () {
+          test('a test', async function (assert) {
+            await percySnapshot(assert);
+            await percySnapshot('Module | a test');
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'duplicateExplicitName',
+          data: { name: 'Module | a test' },
+        },
+      ],
+    },
+    {
+      name: 'the derived name written out first, then a bare call',
+      code: `
+        module('Module', function () {
+          test('a test', async function (assert) {
+            await percySnapshot('Module | a test');
+            await percySnapshot(assert);
+          });
+        });
+      `,
+      errors: [{ messageId: 'duplicateDerivedName' }],
+    },
+    {
+      name: 'nested modules join with > to form the derived name',
+      code: `
+        module('Outer', function () {
+          module('Inner', function () {
+            test('a test', async function (assert) {
+              await percySnapshot(assert);
+              await percySnapshot('Outer > Inner | a test');
+            });
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'duplicateExplicitName',
+          data: { name: 'Outer > Inner | a test' },
+        },
+      ],
+    },
+    {
+      name: 'an assert parameter under another name still counts as derived',
+      code: `
+        test('a', async function (a) {
+          await percySnapshot(a);
+          await percySnapshot(a);
+        });
+      `,
+      errors: [{ messageId: 'duplicateDerivedName' }],
     },
   ],
 });

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -550,7 +550,14 @@ module('Acceptance | operator mode tests', function (hooks) {
     );
     await waitFor(`[data-test-stack-card="${testRealmURL}Pet/mango"]`);
 
-    await percySnapshot(assert); /* snapshot for special styling */
+    // This second snapshot covers the opened card's own isolated styling. Its
+    // name is spelled out because `percySnapshot(assert)` derives a name from
+    // the module and test name alone, so a second bare call would upload under
+    // the same name as the snapshot above and Percy would keep only one of the
+    // two.
+    await percySnapshot(
+      'Acceptance | operator mode tests | visiting operator mode - pet card opened in stack',
+    );
     assert.operatorModeParametersMatch(currentURL(), {
       stacks: [
         [


### PR DESCRIPTION
I’ve been seeing a diff like this regularly:

<img width="1214" height="688" alt="image" src="https://github.com/user-attachments/assets/327b8932-644e-4432-a6ea-33bf890cc0c2" />

It’s because the `percySnapshot` helper is used twice in the test, so two snapshots share the same name. This adds a unique name and a lint rule to prevent this.