### PR TITLE
host: Remove search result counts from Percy

### DIFF
--- a/packages/host/app/components/search/search-result-header.gts
+++ b/packages/host/app/components/search/search-result-header.gts
@@ -85,7 +85,14 @@ export default class SearchResultHeader extends Component<Signature> {
 
   <template>
     <header class='search-result-header' data-test-search-result-header>
-      <div class='summary' data-test-search-label>{{@summaryText}}</div>
+      {{! Carries a total result count, which moves whenever a realm gains a
+      card — see the note on the section count in ./section-header.gts for why
+      that is hidden from Percy rather than compared. }}
+      <div
+        class='summary'
+        data-test-search-label
+        data-test-percy-hide
+      >{{@summaryText}}</div>
       <div class='controls'>
         {{#if this.showSelectionMenu}}
           <SelectionMenu

--- a/packages/host/app/components/search/section-header.gts
+++ b/packages/host/app/components/search/section-header.gts
@@ -46,10 +46,18 @@ export default class SearchSheetSectionHeader extends Component<Signature> {
       </div>
       <div class='title'>{{@title}}</div>
       {{#unless @hideCount}}
+        {{! A section's result count reflects how many cards the realm holds,
+        so in a Percy snapshot it changes every time someone adds a card to
+        the base realm — a diff to approve on unrelated PRs, reporting a
+        number no screenshot is the right place to verify. `.percy.js` hides
+        this with `visibility: hidden`, so the row's layout is still compared;
+        only the digits stop being. Note the box keeps its natural width, so a
+        change in digit *count* (99 -> 100) can still shift siblings. }}
         <div
           class='count'
           data-test-search-sheet-section-count
           data-test-results-count
+          data-test-percy-hide
         >
           {{#if (eq @totalCount 0)}}
             No results


### PR DESCRIPTION
Here’s an example before and after:

<img width="2452" height="982" alt="s 2026-08-25 at 14 37 22@2x" src="https://github.com/user-attachments/assets/bf5b02b1-b0d0-4aaa-8346-279331f060be" />


Claude: The search sheet's summary line and each section's count report how many cards a realm holds, so a Percy snapshot containing them changes every time someone adds a card to the base realm. That is a diff to approve on PRs that had nothing to do with the search sheet, reporting a number a screenshot is the wrong place to verify — 32 existing assertions already check these counts, and an exact number belongs in an assertion.

`.percy.js` hides `data-test-percy-hide` elements with `visibility: hidden`, so the rows keep their boxes and the surrounding layout is still compared; only the digits stop being. The hidden box keeps its natural width, so a change in digit count (99 -> 100) can still shift siblings.