### PR TITLE
Surface uploaded files in the Workspace Activity feed

### DIFF
--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -38,7 +38,10 @@ import {
   codeRef,
   specRef,
   baseCardRef,
+  baseFileRef,
   baseRealmRRI,
+  executableExtensions,
+  inferContentType,
   isCardInstance,
   isFileDefInstance,
   excludeCardInstanceFileRows,
@@ -302,6 +305,28 @@ function excludeSelfReferentialCards(on?: CodeRef): Filter[] {
   return SELF_REFERENTIAL_CARD_TYPES.map((_cardType) =>
     on ? { not: { on, eq: { _cardType } } } : { not: { eq: { _cardType } } },
   );
+}
+
+// Source modules (.gts, .ts, …) index as `file` rows just like uploaded
+// assets, but the Activity feed is a content stream — cards and uploaded
+// files, not code edits. The exclusion must live in the query rather than the
+// render loop: the server-side row budget is shared across both kinds, so a
+// realm under active code editing would otherwise fill the window with module
+// saves and evict every card. Deriving the content types from
+// `executableExtensions` through the same `inferContentType` the file indexer
+// stamps rows with keeps the filter and the index in lockstep. The negation is
+// qualified with `on: baseFileRef` so it wraps a type gate card rows fail — a
+// bare negated match on a key card rows lack is SQL NULL, which would drop
+// them all.
+function excludeExecutableFiles(): Filter {
+  return {
+    not: {
+      on: baseFileRef,
+      any: executableExtensions.map((extension) => ({
+        eq: { contentType: inferContentType(`module${extension}`) },
+      })),
+    },
+  };
 }
 
 // Debounce window for the post-index refresh. Active editing (e.g. an AI setup
@@ -3509,13 +3534,12 @@ class Isolated extends Component<typeof Workspace> {
     verb: ActivityVerb;
     card: CardDef | FileDef;
   }): string | undefined => {
-    if (item.verb !== 'Remixed') {
+    if (item.verb !== 'Remixed' || !isCardInstance(item.card)) {
+      // Only a card is ever classified 'Remixed'; the guard also narrows the
+      // card/file union so the cast below starts from CardDef.
       return undefined;
     }
-    // Only a card is ever classified 'Remixed', so the cast is safe here.
-    return (
-      (item.card as unknown as RemixCardLike).remixedFrom?.cardTitle ?? undefined
-    );
+    return (item.card as RemixCardLike).remixedFrom?.cardTitle ?? undefined;
   };
 
   watchFeedEnd = modifier((element: Element) => {
@@ -3556,11 +3580,13 @@ class Isolated extends Component<typeof Workspace> {
         // the negation wraps a type gate a file row fails, so files survive.
         // `excludeCardInstanceFileRows()` drops a card's dual-indexed `.json`
         // file row so each card shows once (via its instance row) — still
-        // required alongside `scope: 'all'`.
+        // required alongside `scope: 'all'`. `excludeExecutableFiles()` keeps
+        // source-module saves from consuming the shared row budget.
         filter: {
           every: [
             ...excludeSelfReferentialCards(baseCardRef),
             excludeCardInstanceFileRows(),
+            excludeExecutableFiles(),
           ],
         },
         sort: [{ by: 'lastModified', direction: 'desc' }],
@@ -3584,10 +3610,12 @@ class Isolated extends Component<typeof Workspace> {
         continue;
       }
       seen.add(entry.id);
-      // A single malformed row (a file whose preview can't build, a card
-      // missing metadata) must not blank the whole feed — skip it and keep
-      // going. The restartable task would otherwise swallow the throw and leave
-      // the log truncated at the failing row.
+      // A single malformed row (a throwing `cardTitle`/`name` getter, an
+      // unreadable timestamp) must not cost the rows after it — skip it and
+      // keep going. The restartable task would otherwise swallow the throw and
+      // truncate the feed at the failing row. This guards only the row build:
+      // `getComponent` just returns the component, so a preview that throws
+      // does so later, when Glimmer renders it in the template.
       try {
         // Timestamps read the same way for both kinds: a file carries its
         // `lastModified` / `resourceCreatedAt` on `meta` from the serialization
@@ -3616,7 +3644,9 @@ class Isolated extends Component<typeof Workspace> {
           verb,
           dayLabel: day,
           showDay: Boolean(day) && day !== prevDay,
-          title: card ? (card.cardTitle ?? undefined) : (file!.name ?? undefined),
+          title: card
+            ? (card.cardTitle ?? undefined)
+            : (file!.name ?? undefined),
           typeName: (ctor as typeof CardDef).displayName,
           typeIcon: (ctor as typeof CardDef).icon,
           card: entry,
@@ -3930,8 +3960,8 @@ export class Workspace extends CardDef {
             <div class='setting'>
               <div class='setting-text'>
                 <span class='setting-label'>Hide About</span>
-                <p class='setting-help'>The About section shows below the pins by
-                  default. Turn on to keep Home to cards only.</p>
+                <p class='setting-help'>The About section shows below the pins
+                  by default. Turn on to keep Home to cards only.</p>
               </div>
               <div class='setting-control'><@fields.hideAbout /></div>
             </div>

--- a/packages/base/workspace.gts
+++ b/packages/base/workspace.gts
@@ -40,6 +40,8 @@ import {
   baseCardRef,
   baseRealmRRI,
   isCardInstance,
+  isFileDefInstance,
+  excludeCardInstanceFileRows,
   SupportedMimeType,
   subscribeToRealm,
   codeRefFromInternalKey,
@@ -70,6 +72,7 @@ import {
   StringField,
   type BaseDef,
   type BoxComponent,
+  type FileDef,
 } from './card-api';
 import { MarkdownDef } from './markdown-file-def'; // realm README
 import type { RealmEventContent } from './matrix-event';
@@ -1026,7 +1029,7 @@ class Isolated extends Component<typeof Workspace> {
                         type='button'
                         class='tile-open'
                         aria-label='Open {{if item.title item.title "card"}}'
-                        {{on 'click' (this.openCard item.card)}}
+                        {{on 'click' (this.openFeedItem item)}}
                       ></button>
                     </div>
                     <div class='feed-note'>
@@ -2962,6 +2965,19 @@ class Isolated extends Component<typeof Workspace> {
     }
   };
 
+  // The feed mixes cards and files; a file opens through `viewCard`'s
+  // `type: 'file'` path (keyed by its URL) rather than as a card on the stack.
+  openFeedItem =
+    (item: { card: CardDef | FileDef; kind: 'card' | 'file' }) => () => {
+      if (item.kind === 'file') {
+        this.args.viewCard?.((item.card as FileDef).id, undefined, {
+          type: 'file',
+        });
+      } else {
+        this.args.viewCard?.(item.card as CardDef);
+      }
+    };
+
   moreSites = (sites: unknown[]) => (sites.length > 1 ? sites.length - 1 : 0);
 
   jumpToFilter = (option: FilterOption | undefined) => () => {
@@ -3447,10 +3463,11 @@ class Isolated extends Component<typeof Workspace> {
     }
   });
 
-  // The Activity log: everything in the realm, reverse-chron by
-  // lastModified. Each row carries when / what / why: timestamp rail,
-  // the card, and a change note (`cardInfo.notes` — the convention slot a
-  // human or AI fills in when saving a change).
+  // The Activity log: everything in the realm — cards and uploaded files —
+  // reverse-chron by lastModified. Each row carries when / what / why:
+  // timestamp rail, the card or file preview, and a change note
+  // (`cardInfo.notes` — the convention slot a human or AI fills in when saving
+  // a change; files carry none).
   private feedItems: {
     id: string;
     component: BoxComponent;
@@ -3460,10 +3477,13 @@ class Isolated extends Component<typeof Workspace> {
     verb: ActivityVerb;
     dayLabel: string;
     showDay: boolean;
-    title: string | undefined; // card identity for the log line
+    title: string | undefined; // card / file identity for the log line
     typeName: string;
     typeIcon: typeof CardDef.icon;
-    card: CardDef; // for the tile-open overlay
+    // The instance behind the tile-open overlay. A file row opens through
+    // `viewCard`'s `type: 'file'` path, so the two kinds are distinguished.
+    card: CardDef | FileDef;
+    kind: 'card' | 'file';
   }[] = new TrackedArray();
 
   // Reveal-on-scroll pagination over the fetched window.
@@ -3487,12 +3507,15 @@ class Isolated extends Component<typeof Workspace> {
   // and tracks). Undefined for non-remix rows and remixes with no source set.
   remixSourceTitle = (item: {
     verb: ActivityVerb;
-    card: CardDef;
+    card: CardDef | FileDef;
   }): string | undefined => {
     if (item.verb !== 'Remixed') {
       return undefined;
     }
-    return (item.card as RemixCardLike).remixedFrom?.cardTitle ?? undefined;
+    // Only a card is ever classified 'Remixed', so the cast is safe here.
+    return (
+      (item.card as unknown as RemixCardLike).remixedFrom?.cardTitle ?? undefined
+    );
   };
 
   watchFeedEnd = modifier((element: Element) => {
@@ -3525,46 +3548,88 @@ class Isolated extends Component<typeof Workspace> {
     }
     let instances = await store.search(
       {
+        // The feed mixes cards and uploaded files. The self-referential
+        // exclusion is qualified to card rows (`on: baseCardRef`) on purpose:
+        // it filters on `_cardType`, a search-doc key only card rows carry, and
+        // a top-level negated match against a key a file row lacks is SQL NULL
+        // (not true), which would silently drop every file. Qualified by `on`,
+        // the negation wraps a type gate a file row fails, so files survive.
+        // `excludeCardInstanceFileRows()` drops a card's dual-indexed `.json`
+        // file row so each card shows once (via its instance row) — still
+        // required alongside `scope: 'all'`.
         filter: {
-          every: [...excludeSelfReferentialCards()],
+          every: [
+            ...excludeSelfReferentialCards(baseCardRef),
+            excludeCardInstanceFileRows(),
+          ],
         },
         sort: [{ by: 'lastModified', direction: 'desc' }],
         // Bound server results before instance hydration.
         page: { size: ACTIVITY_FEED_CAP },
       } as Query,
       [realm],
+      // Opt into the mixed instance + file scope; the loop discriminates each
+      // row by kind. An untyped query would otherwise be pinned to cards only.
+      { scope: 'all' },
     ); // Search only the Card Grid instance's realm.
     this.feedItems.splice(0, this.feedItems.length);
     let seen = new Set<string>();
     let prevDay: string | undefined;
     for (let instance of instances ?? []) {
       // build the full fetched window (≤100); the template reveals in 20s
-      if (!isCardInstance(instance) || !instance.id || seen.has(instance.id)) {
+      let card = isCardInstance(instance) ? instance : undefined;
+      let file = !card && isFileDefInstance(instance) ? instance : undefined;
+      let entry = card ?? file;
+      if (!entry || !entry.id || seen.has(entry.id)) {
         continue;
       }
-      seen.add(instance.id);
-      let card = instance as CardDef;
-      let modMs = toMs(getCardMeta(card, 'lastModified'));
-      let createdMs = toMs(getCardMeta(card, 'resourceCreatedAt'));
-      let ctor = card.constructor as typeof CardDef; // type identity for the log line
-      let verb = activityVerbFor(ctor.displayName, modMs, createdMs);
-      let day = modMs !== undefined ? dayLabelFor(modMs) : '';
-      this.feedItems.push({
-        id: card.id!,
-        component: (card.constructor as typeof BaseDef).getComponent(card),
-        when: modMs !== undefined ? relativeTime(modMs) : undefined,
-        absolute:
-          modMs !== undefined ? new Date(modMs).toLocaleString() : undefined,
-        note: card.cardInfo?.notes ?? undefined,
-        verb,
-        dayLabel: day,
-        showDay: Boolean(day) && day !== prevDay,
-        title: card.cardTitle ?? undefined,
-        typeName: ctor.displayName,
-        typeIcon: ctor.icon,
-        card,
-      });
-      prevDay = day || prevDay;
+      seen.add(entry.id);
+      // A single malformed row (a file whose preview can't build, a card
+      // missing metadata) must not blank the whole feed — skip it and keep
+      // going. The restartable task would otherwise swallow the throw and leave
+      // the log truncated at the failing row.
+      try {
+        // Timestamps read the same way for both kinds: a file carries its
+        // `lastModified` / `resourceCreatedAt` on `meta` from the serialization
+        // source (FileDef's first-class getters), so `getCardMeta` answers
+        // uniformly for cards and files.
+        let modMs = toMs(getCardMeta(entry, 'lastModified'));
+        let createdMs = toMs(getCardMeta(entry, 'resourceCreatedAt'));
+        let ctor = entry.constructor as typeof BaseDef; // type identity for the log line
+        // A file is a Created/Updated event by write timing; only a card can be
+        // a first-class Remix.
+        let verb = card
+          ? activityVerbFor(
+              (ctor as typeof CardDef).displayName,
+              modMs,
+              createdMs,
+            )
+          : classifyActivityVerb(modMs, createdMs);
+        let day = modMs !== undefined ? dayLabelFor(modMs) : '';
+        this.feedItems.push({
+          id: entry.id,
+          component: ctor.getComponent(entry),
+          when: modMs !== undefined ? relativeTime(modMs) : undefined,
+          absolute:
+            modMs !== undefined ? new Date(modMs).toLocaleString() : undefined,
+          note: card?.cardInfo?.notes ?? undefined,
+          verb,
+          dayLabel: day,
+          showDay: Boolean(day) && day !== prevDay,
+          title: card ? (card.cardTitle ?? undefined) : (file!.name ?? undefined),
+          typeName: (ctor as typeof CardDef).displayName,
+          typeIcon: (ctor as typeof CardDef).icon,
+          card: entry,
+          kind: card ? 'card' : 'file',
+        });
+        prevDay = day || prevDay;
+      } catch (err) {
+        console.warn(
+          `workspace activity feed: skipping ${entry.id} — ${
+            (err as Error)?.message ?? err
+          }`,
+        );
+      }
     }
   });
 }

--- a/packages/host/tests/acceptance/workspace-test.gts
+++ b/packages/host/tests/acceptance/workspace-test.gts
@@ -63,7 +63,7 @@ module('Acceptance | workspace card', function (hooks) {
         'Note/1.json': new Note({ cardTitle: 'First Note' }),
         // A plain uploaded file (not a card). It indexes as a `file` row, so it
         // only reaches the Activity feed if the feed query surfaces files
-        // alongside cards (CS-12476).
+        // alongside cards.
         'welcome-song.mp3': 'ID3 fake audio bytes',
         // A remix cloned from Note/1 — its own indexed instance is the record
         // of the clone that the Activity feed surfaces as a "Remixed" event.
@@ -240,12 +240,50 @@ module('Acceptance | workspace card', function (hooks) {
     await click(`${STACK} nav.tabs .tab:nth-child(3)`); // Activity
     await waitFor(`${STACK} .feed-row`);
 
-    let titles = [...document.querySelectorAll(`${STACK} .feed-title`)].map(
-      (el) => el.textContent?.trim(),
-    );
+    let rows = [...document.querySelectorAll(`${STACK} .feed-row`)];
+    let titleOf = (row: Element) =>
+      row.querySelector('.feed-title')?.textContent?.trim();
+    let fileRow = rows.find((row) => titleOf(row) === 'welcome-song.mp3');
     assert.ok(
-      titles.includes('welcome-song.mp3'),
-      `the uploaded audio file appears in the feed (saw: ${titles.join(', ')})`,
+      fileRow,
+      `the uploaded audio file appears in the feed (saw: ${rows
+        .map(titleOf)
+        .join(', ')})`,
     );
+
+    // A file row must be dated, not merely present: '—' is the placeholder
+    // rendered when the file's `lastModified` meta fails to reach the client,
+    // and the title alone would still render in that case.
+    let when = fileRow!.querySelector('.feed-when')?.textContent?.trim() ?? '';
+    assert.notStrictEqual(
+      when,
+      '—',
+      'the file row carries a real timestamp, not the missing-date placeholder',
+    );
+    assert.notStrictEqual(when, '', 'the file row renders its timestamp rail');
+
+    // Source modules index as file rows too, but the feed's query excludes
+    // code edits so they cannot crowd cards out of the shared row budget.
+    assert.notOk(
+      rows.some((row) => titleOf(row) === 'note.gts'),
+      'a source module does not appear in the feed',
+    );
+  });
+
+  test('opening a file feed row opens the file, not a card', async function (assert) {
+    await visit('/');
+    await click('[data-test-workspace-button="Unnamed Workspace"]');
+    await waitFor(`${STACK} nav.tabs`);
+
+    await click(`${STACK} nav.tabs .tab:nth-child(3)`); // Activity
+    await waitFor(`${STACK} .feed-row`);
+
+    // A file feed row routes through the file stack-item path, keyed by the
+    // file's URL — not the card path a card row takes.
+    await click(`${STACK} [aria-label="Open welcome-song.mp3"]`);
+    await waitFor(`[data-test-stack-card="${testRealmURL}welcome-song.mp3"]`);
+    assert
+      .dom(`[data-test-stack-card="${testRealmURL}welcome-song.mp3"]`)
+      .exists('the file opens as a file stack item');
   });
 });

--- a/packages/host/tests/acceptance/workspace-test.gts
+++ b/packages/host/tests/acceptance/workspace-test.gts
@@ -61,6 +61,10 @@ module('Acceptance | workspace card', function (hooks) {
         'note.gts': { Note },
         'index.json': new Workspace(),
         'Note/1.json': new Note({ cardTitle: 'First Note' }),
+        // A plain uploaded file (not a card). It indexes as a `file` row, so it
+        // only reaches the Activity feed if the feed query surfaces files
+        // alongside cards (CS-12476).
+        'welcome-song.mp3': 'ID3 fake audio bytes',
         // A remix cloned from Note/1 — its own indexed instance is the record
         // of the clone that the Activity feed surfaces as a "Remixed" event.
         'Remix/1.json': {
@@ -226,5 +230,22 @@ module('Acceptance | workspace card', function (hooks) {
         'from First Note',
         'the event names the source it was cloned from',
       );
+  });
+
+  test('an uploaded file surfaces in the Activity feed alongside cards', async function (assert) {
+    await visit('/');
+    await click('[data-test-workspace-button="Unnamed Workspace"]');
+    await waitFor(`${STACK} nav.tabs`);
+
+    await click(`${STACK} nav.tabs .tab:nth-child(3)`); // Activity
+    await waitFor(`${STACK} .feed-row`);
+
+    let titles = [...document.querySelectorAll(`${STACK} .feed-title`)].map(
+      (el) => el.textContent?.trim(),
+    );
+    assert.ok(
+      titles.includes('welcome-song.mp3'),
+      `the uploaded audio file appears in the feed (saw: ${titles.join(', ')})`,
+    );
   });
 });


### PR DESCRIPTION
Surfaces uploaded files in the Workspace Activity feed — a newly uploaded audio file did not appear in the `workspace.gts` Activity list.

## Root cause
The Workspace "Activity" feed (`packages/base/workspace.gts`, `loadFeed`) queried `store.search` with an untyped filter. The store pins an untyped query to card-instance scope, so an uploaded file (a `file`-type index row) was never returned — even though the feed's own hint reads "Changes to cards **and files**". The feed loop also only handled `isCardInstance`, so files couldn't render even if returned.

## Changes
**`packages/base/workspace.gts`**
- The feed query passes the explicit `{ scope: 'all' }` option to opt into the mixed instance + file scope. That argument selects the `Store.search` overload returning `Promise<(CardDef | FileDef)[]>`, so the result is union-typed without caller-side casts.
- **The feed's scope is cards + uploaded assets, not everything in the realm.** Source modules (`.gts`, `.ts`, …) index as `file` rows too, and the server-side row budget (`LIMIT` over the union, sorted by `lastModified`) is shared across both kinds — a realm under active code editing would otherwise fill the window with module saves and evict every card. The query therefore excludes executable content types (`excludeExecutableFiles()`), deriving them from `executableExtensions` through the same `inferContentType` the file indexer stamps rows with, keeping filter and index in lockstep. The exclusion lives in the query, not the render loop, because the budget is spent server-side.
- The loop renders a file via its own embedded component, name, type, icon, and timestamps. A file row opens through `viewCard`'s `type: 'file'` path (`openFeedItem` discriminates by the row's `kind`). Each per-row build is wrapped so a single malformed row (a throwing title getter, unreadable metadata) skips that row instead of truncating the feed; a preview that throws does so later, at Glimmer render, outside that guard.

## Query-shape pitfall worth calling out
A negated match on a search-doc key only one row kind carries must be qualified with `on:` — in SQL a top-level `NOT (NULL = x)` is `NULL` (not `true`), silently dropping every row that lacks the key. So the self-referential exclusion is qualified `on: baseCardRef` (file rows lack `_cardType`) and the executable exclusion `on: baseFileRef` (card rows lack `contentType`). `excludeCardInstanceFileRows()` drops a card's dual-indexed `.json` file row so each card shows once.

## Testing
`packages/host/tests/acceptance/workspace-test.gts`:
- The file-feed test asserts the uploaded `.mp3` surfaces **with a real timestamp** (not the missing-date placeholder rendered when meta hydration dies) and that source modules (`note.gts`) stay out of the feed.
- A second test clicks the file row's open overlay and asserts a file stack item keyed by the file's URL appears — covering `openFeedItem`'s `type: 'file'` branch.
- Full "Acceptance | workspace card" module: 8 tests, 23/23 assertions green against the dev stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)