### PR TITLE
store.search: explicit card/file/all scope, with element type keyed to it

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -138,7 +138,7 @@ export default class PlaygroundPanel extends Component<Signature> {
   @service declare private store: StoreService;
 
   @tracked private cardResource: ReturnType<getCard> | undefined;
-  @tracked private fileSearchResults: ReturnType<getCards> | undefined;
+  @tracked private fileSearchResults: ReturnType<getCards<FileDef>> | undefined;
   @tracked private fieldChooserIsOpen = false;
   @tracked private newCardNonce = 0;
 
@@ -368,7 +368,7 @@ export default class PlaygroundPanel extends Component<Signature> {
     }
     // Host code-submode UI searches the store directly (uncapped); the card
     // caps live on the `@context` surfaces this component does not consume.
-    this.fileSearchResults = this.store.getSearchResource(
+    this.fileSearchResults = this.store.getSearchResource<FileDef>(
       this,
       () => this.fileMetaQuery,
       () => this.realmServer.availableRealmIdentifiers,
@@ -389,7 +389,7 @@ export default class PlaygroundPanel extends Component<Signature> {
   static FILE_META_DROPDOWN_LIMIT = 20;
 
   private get fileMetaInstances(): FileDef[] | undefined {
-    return this.fileSearchResults?.instances as FileDef[] | undefined;
+    return this.fileSearchResults?.instances;
   }
 
   private get fileMetaDropdownOptions(): FileDef[] | undefined {

--- a/packages/host/app/lib/search-cache-key.ts
+++ b/packages/host/app/lib/search-cache-key.ts
@@ -1,6 +1,7 @@
 import {
   normalizeQueryForSignature,
   type Query,
+  type SearchEntryScope,
 } from '@cardstack/runtime-common';
 
 // Stable digest key for the store-side resolved-doc search cache.
@@ -20,9 +21,11 @@ export function searchCacheKey(
   jobId: string,
   consumingRealm: string,
   query: Query,
-  // Two otherwise-identical queries that differ only by scope resolve to
-  // different result sets, so scope is part of the key.
-  scope?: string,
+  // The *resolved* wire scope (see `StoreService.resolveWireScope`), not the
+  // caller's raw scope, so two spellings of a byte-identical request share a
+  // key. Two requests that differ by wire scope are different result sets, so
+  // scope is part of the key.
+  scope?: SearchEntryScope,
 ): string | undefined {
   try {
     return JSON.stringify([

--- a/packages/host/app/lib/search-cache-key.ts
+++ b/packages/host/app/lib/search-cache-key.ts
@@ -20,12 +20,16 @@ export function searchCacheKey(
   jobId: string,
   consumingRealm: string,
   query: Query,
+  // Two otherwise-identical queries that differ only by scope resolve to
+  // different result sets, so scope is part of the key.
+  scope?: string,
 ): string | undefined {
   try {
     return JSON.stringify([
       jobId,
       consumingRealm,
       normalizeQueryForSignature(query),
+      scope ?? null,
     ]);
   } catch {
     return undefined;

--- a/packages/host/app/lib/search-in-flight-key.ts
+++ b/packages/host/app/lib/search-in-flight-key.ts
@@ -1,6 +1,7 @@
 import {
   normalizeQueryForSignature,
   type Query,
+  type SearchEntryScope,
 } from '@cardstack/runtime-common';
 
 // Stable digest key for store-side `_federated-search` in-flight dedup.
@@ -19,9 +20,11 @@ import {
 export function searchInFlightKey(
   realms: string[],
   query: Query,
-  // Two otherwise-identical requests that differ only by scope resolve to
-  // different result sets, so scope is part of the key.
-  scope?: string,
+  // The *resolved* wire scope (see `StoreService.resolveWireScope`), not the
+  // caller's raw scope, so two spellings of a byte-identical request share a
+  // key. Two requests that differ by wire scope are different result sets, so
+  // scope is part of the key.
+  scope?: SearchEntryScope,
 ): string | undefined {
   try {
     return JSON.stringify([

--- a/packages/host/app/lib/search-in-flight-key.ts
+++ b/packages/host/app/lib/search-in-flight-key.ts
@@ -19,9 +19,16 @@ import {
 export function searchInFlightKey(
   realms: string[],
   query: Query,
+  // Two otherwise-identical requests that differ only by scope resolve to
+  // different result sets, so scope is part of the key.
+  scope?: string,
 ): string | undefined {
   try {
-    return JSON.stringify([realms, normalizeQueryForSignature(query)]);
+    return JSON.stringify([
+      realms,
+      normalizeQueryForSignature(query),
+      scope ?? null,
+    ]);
   } catch {
     return undefined;
   }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1416,6 +1416,14 @@ export default class StoreService extends Service implements StoreInterface {
       this.searchCacheGeneration++;
     }
 
+    // Resolve to the scope that actually goes on the wire *before* keying, so
+    // the cache and in-flight coalescer key on the request we send rather than
+    // the caller's spelling of it. `{ type: ref }` and `{ type: ref, scope:
+    // 'all' }` are a byte-identical `_federated-search` body — both resolve to
+    // the undefined wire default — and so must share one key; keying on the raw
+    // `scope` would split them and defeat the dedup.
+    let wireScope = this.resolveWireScope(query, scope);
+
     // Resolved-doc cache eligibility: prerender + jobId + same-realm.
     // Cross-realm reads bypass — see field comment.
     let cacheKey: string | undefined;
@@ -1426,7 +1434,7 @@ export default class StoreService extends Service implements StoreInterface {
       realms.length === 1 &&
       realms[0] === consumingRealm
     ) {
-      cacheKey = searchCacheKey(jobId, consumingRealm, query, scope);
+      cacheKey = searchCacheKey(jobId, consumingRealm, query, wireScope);
       if (cacheKey !== undefined) {
         let cached = this.searchCache.get(cacheKey);
         if (cached !== undefined) {
@@ -1441,7 +1449,7 @@ export default class StoreService extends Service implements StoreInterface {
     let captureGeneration = this.searchCacheGeneration;
 
     let inflightKey = inPrerender
-      ? searchInFlightKey(realms, query, scope)
+      ? searchInFlightKey(realms, query, wireScope)
       : undefined;
     let doc: SearchEntryResults;
     if (inflightKey !== undefined) {
@@ -1452,7 +1460,7 @@ export default class StoreService extends Service implements StoreInterface {
         let pending = this.fetchSearchDocUncoalesced(
           query,
           realms,
-          scope,
+          wireScope,
         ).finally(() => {
           // Identity-check before deletion: a concurrent
           // `clearInFlightSearch()` could in principle have removed
@@ -1467,7 +1475,7 @@ export default class StoreService extends Service implements StoreInterface {
         doc = await pending;
       }
     } else {
-      doc = await this.fetchSearchDocUncoalesced(query, realms, scope);
+      doc = await this.fetchSearchDocUncoalesced(query, realms, wireScope);
     }
 
     // Populate only if the cache generation hasn't moved under us. A
@@ -1485,49 +1493,62 @@ export default class StoreService extends Service implements StoreInterface {
     return doc;
   }
 
-  private async fetchSearchDocUncoalesced(
+  // Resolve the caller's optional explicit scope + the query's filter shape to
+  // the single scope that goes on the wire. A pure function of
+  // `(query, explicitScope)`, so `fetchSearchDoc` can call it above the caching
+  // layer and key on the result — see the note there.
+  //
+  // An explicit scope from the caller always wins — it is the sanctioned way to
+  // ask for cards, files, or both, rather than shaping the filter to coax the
+  // inference below.
+  //
+  // Search spans card instances and files. A query with a positive *concrete*
+  // type ref already selects a kind (a card type -> instances, a FileDef type
+  // -> files), so it passes through with the default 'all' scope and its filter
+  // discriminates. An otherwise-unscoped query is pinned to 'cards' so the
+  // common "search for cards" case doesn't surface a card's dual-indexed
+  // `.json` file row (or plain files) — the choke point that replaces the
+  // former per-call-site card anchor, while leaving file/typed searches (e.g.
+  // SearchResource's file-meta queries) untouched.
+  //
+  // A BaseDef ref is *not* kind-selecting — it terminates both kinds' type
+  // chains, so it matches every row — and is pinned to 'cards' like an untyped
+  // query. Known gap: a mixed `any:` whose one branch is card-typed and another
+  // untyped counts as positively typed, so its untyped branch can still match
+  // file rows in 'all' scope; no caller composes that shape today.
+  //
+  // 'all' is the wire default (undefined scope), so an explicit 'all' maps to
+  // undefined just like the inferred positive-type case — which is what lets
+  // `{ type: ref }` and `{ type: ref, scope: 'all' }` share one cache key.
+  private resolveWireScope(
     query: Query,
-    realms: string[],
     explicitScope?: SearchEntryScope,
-  ): Promise<SearchEntryResults> {
-    // An explicit scope from the caller always wins — it is the sanctioned way
-    // to ask for cards, files, or both, rather than shaping the filter to coax
-    // the inference below.
-    //
-    // Search spans card instances and files. A query with a positive
-    // *concrete* type ref already selects a kind (a card type -> instances, a
-    // FileDef type -> files), so it passes through with the default 'all'
-    // scope and its filter discriminates. An otherwise-unscoped query is
-    // pinned to 'cards' so the common "search for cards" case doesn't surface
-    // a card's dual-indexed `.json` file row (or plain files) — the choke
-    // point that replaces the former per-call-site card anchor, while leaving
-    // file/typed searches (e.g. SearchResource's file-meta queries) untouched.
-    //
-    // A BaseDef ref is *not* kind-selecting — it terminates both kinds' type
-    // chains, so it matches every row — and is pinned to 'cards' like an
-    // untyped query. Known gap: a mixed `any:` whose one branch is card-typed
-    // and another untyped counts as positively typed, so its untyped branch
-    // can still match file rows in 'all' scope; no caller composes that shape
-    // today.
+  ): SearchEntryScope | undefined {
     let typeRefs = query.filter
       ? getTypeRefsFromFilter(query.filter)
       : undefined;
     let hasPositiveType =
       typeRefs?.some((r) => !r.negated && !isEqual(r.ref, baseRef)) ?? false;
-    // 'all' is the wire default (undefined scope), so an explicit 'all' maps to
-    // undefined just like the inferred positive-type case.
-    let scope: SearchEntryScope | undefined =
-      explicitScope !== undefined
-        ? explicitScope === 'all'
-          ? undefined
-          : explicitScope
-        : hasPositiveType
-          ? undefined
-          : 'cards';
+    return explicitScope !== undefined
+      ? explicitScope === 'all'
+        ? undefined
+        : explicitScope
+      : hasPositiveType
+        ? undefined
+        : 'cards';
+  }
+
+  private async fetchSearchDocUncoalesced(
+    query: Query,
+    realms: string[],
+    // Already resolved to the wire scope by `fetchSearchDoc` (via
+    // `resolveWireScope`) so the value keyed on and the value sent match.
+    wireScope?: SearchEntryScope,
+  ): Promise<SearchEntryResults> {
     return await this.fetchSearchEntryDoc(
       searchEntryWireQueryFromQuery(query, {
         fields: ['item'],
-        ...(scope ? { scope } : {}),
+        ...(wireScope ? { scope: wireScope } : {}),
       }),
       realms,
     );

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1152,6 +1152,7 @@ export default class StoreService extends Service implements StoreInterface {
       includeMeta?: false;
       dependencyTrackingContext?: RuntimeDependencyTrackingContext;
       cardInitiated?: boolean;
+      scope?: SearchEntryScope;
     },
   ): Promise<T[]>;
   async search<T extends CardDef | FileDef = CardDef>(
@@ -1161,6 +1162,7 @@ export default class StoreService extends Service implements StoreInterface {
       includeMeta: true;
       dependencyTrackingContext?: RuntimeDependencyTrackingContext;
       cardInitiated?: boolean;
+      scope?: SearchEntryScope;
     },
   ): Promise<{ instances: T[]; meta: QueryResultsMeta }>;
   async search<T extends CardDef | FileDef = CardDef>(
@@ -1174,6 +1176,11 @@ export default class StoreService extends Service implements StoreInterface {
       // page size, realms fan-out, and the concurrency throttle — none of which
       // constrain the host app's own direct search calls.
       cardInitiated?: boolean;
+      // Pin which index rows the search returns: 'cards' (instance rows),
+      // 'files' (FileDef rows), or 'all' (both). When omitted, the scope is
+      // inferred from the filter — an untyped query defaults to 'cards'. Prefer
+      // passing this explicitly over shaping the filter to coax a scope.
+      scope?: SearchEntryScope;
     },
   ): Promise<T[] | { instances: T[]; meta: QueryResultsMeta }> {
     if ('asData' in query && query.asData) {
@@ -1207,6 +1214,7 @@ export default class StoreService extends Service implements StoreInterface {
         query,
         searchRealms,
         opts?.dependencyTrackingContext,
+        opts?.scope,
       );
     let result = opts?.cardInitiated
       ? await this.performThrottledSearch(run)
@@ -1308,10 +1316,17 @@ export default class StoreService extends Service implements StoreInterface {
     return new Proxy(store, {
       get(target, prop) {
         if (prop === 'search') {
-          return (query: Query, realmURLs?: string[]) => {
+          return (
+            query: Query,
+            realmURLs?: string[],
+            opts?: { scope?: SearchEntryScope },
+          ) => {
             let current = getCurrentRealm();
             let realms = realmURLs ?? (current ? [current] : ([] as string[]));
-            return target.search(query, realms, { cardInitiated: true });
+            return target.search(query, realms, {
+              cardInitiated: true,
+              scope: opts?.scope,
+            });
           };
         }
         let value = Reflect.get(target, prop, target);
@@ -1326,8 +1341,9 @@ export default class StoreService extends Service implements StoreInterface {
     query: Query,
     realms: string[],
     dependencyTrackingContext?: RuntimeDependencyTrackingContext,
+    scope?: SearchEntryScope,
   ): Promise<{ instances: T[]; meta: QueryResultsMeta }> {
-    let collectionDoc = await this.fetchSearchDoc(query, realms);
+    let collectionDoc = await this.fetchSearchDoc(query, realms, scope);
 
     // Hydrate each result into the store. The data-only entry doc
     // carries one full `item` (`card`/`file-meta`) serialization per entry in
@@ -1378,6 +1394,7 @@ export default class StoreService extends Service implements StoreInterface {
   private async fetchSearchDoc(
     query: Query,
     realms: string[],
+    scope?: SearchEntryScope,
   ): Promise<SearchEntryResults> {
     let inPrerender = Boolean((globalThis as any).__boxelRenderContext);
     let jobId = inPrerender
@@ -1406,7 +1423,7 @@ export default class StoreService extends Service implements StoreInterface {
       realms.length === 1 &&
       realms[0] === consumingRealm
     ) {
-      cacheKey = searchCacheKey(jobId, consumingRealm, query);
+      cacheKey = searchCacheKey(jobId, consumingRealm, query, scope);
       if (cacheKey !== undefined) {
         let cached = this.searchCache.get(cacheKey);
         if (cached !== undefined) {
@@ -1421,7 +1438,7 @@ export default class StoreService extends Service implements StoreInterface {
     let captureGeneration = this.searchCacheGeneration;
 
     let inflightKey = inPrerender
-      ? searchInFlightKey(realms, query)
+      ? searchInFlightKey(realms, query, scope)
       : undefined;
     let doc: SearchEntryResults;
     if (inflightKey !== undefined) {
@@ -1429,23 +1446,25 @@ export default class StoreService extends Service implements StoreInterface {
       if (existing) {
         doc = await existing;
       } else {
-        let pending = this.fetchSearchDocUncoalesced(query, realms).finally(
-          () => {
-            // Identity-check before deletion: a concurrent
-            // `clearInFlightSearch()` could in principle have removed
-            // (and a later caller re-set) this slot while we were
-            // in-flight. Only clean up if the map still points at *this*
-            // pending promise.
-            if (this.inflightSearch.get(inflightKey) === pending) {
-              this.inflightSearch.delete(inflightKey);
-            }
-          },
-        );
+        let pending = this.fetchSearchDocUncoalesced(
+          query,
+          realms,
+          scope,
+        ).finally(() => {
+          // Identity-check before deletion: a concurrent
+          // `clearInFlightSearch()` could in principle have removed
+          // (and a later caller re-set) this slot while we were
+          // in-flight. Only clean up if the map still points at *this*
+          // pending promise.
+          if (this.inflightSearch.get(inflightKey) === pending) {
+            this.inflightSearch.delete(inflightKey);
+          }
+        });
         this.inflightSearch.set(inflightKey, pending);
         doc = await pending;
       }
     } else {
-      doc = await this.fetchSearchDocUncoalesced(query, realms);
+      doc = await this.fetchSearchDocUncoalesced(query, realms, scope);
     }
 
     // Populate only if the cache generation hasn't moved under us. A
@@ -1466,7 +1485,12 @@ export default class StoreService extends Service implements StoreInterface {
   private async fetchSearchDocUncoalesced(
     query: Query,
     realms: string[],
+    explicitScope?: SearchEntryScope,
   ): Promise<SearchEntryResults> {
+    // An explicit scope from the caller always wins — it is the sanctioned way
+    // to ask for cards, files, or both, rather than shaping the filter to coax
+    // the inference below.
+    //
     // Search spans card instances and files. A query with a positive
     // *concrete* type ref already selects a kind (a card type -> instances, a
     // FileDef type -> files), so it passes through with the default 'all'
@@ -1487,9 +1511,16 @@ export default class StoreService extends Service implements StoreInterface {
       : undefined;
     let hasPositiveType =
       typeRefs?.some((r) => !r.negated && !isEqual(r.ref, baseRef)) ?? false;
-    let scope: SearchEntryScope | undefined = hasPositiveType
-      ? undefined
-      : 'cards';
+    // 'all' is the wire default (undefined scope), so an explicit 'all' maps to
+    // undefined just like the inferred positive-type case.
+    let scope: SearchEntryScope | undefined =
+      explicitScope !== undefined
+        ? explicitScope === 'all'
+          ? undefined
+          : explicitScope
+        : hasPositiveType
+          ? undefined
+          : 'cards';
     return await this.fetchSearchEntryDoc(
       searchEntryWireQueryFromQuery(query, {
         fields: ['item'],

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1180,6 +1180,9 @@ export default class StoreService extends Service implements StoreInterface {
       // 'files' (FileDef rows), or 'all' (both). When omitted, the scope is
       // inferred from the filter — an untyped query defaults to 'cards'. Prefer
       // passing this explicitly over shaping the filter to coax a scope.
+      // Note: 'all' returns a card's instance row *and* its dual-indexed
+      // `.json` file row, so an untyped `scope: 'all'` search yields each card
+      // twice unless the caller dedups (e.g. `excludeCardInstanceFileRows()`).
       scope?: SearchEntryScope;
     },
   ): Promise<T[] | { instances: T[]; meta: QueryResultsMeta }> {

--- a/packages/host/tests/unit/lib/search-cache-key-test.ts
+++ b/packages/host/tests/unit/lib/search-cache-key-test.ts
@@ -78,6 +78,23 @@ module('Unit | Utility | searchCacheKey', function () {
     );
   });
 
+  test('different wire scopes produce different keys', function (assert) {
+    assert.notStrictEqual(
+      searchCacheKey(jobA, realmA, baseQuery, 'cards'),
+      searchCacheKey(jobA, realmA, baseQuery, 'files'),
+    );
+  });
+
+  test('an explicit wire scope is distinct from omitted', function (assert) {
+    // The store keys on the *resolved* wire scope, so a resolved 'cards' must
+    // not collide with the undefined wire default (a positive-type / 'all'
+    // request) — otherwise the two would share a cache entry.
+    assert.notStrictEqual(
+      searchCacheKey(jobA, realmA, baseQuery),
+      searchCacheKey(jobA, realmA, baseQuery, 'cards'),
+    );
+  });
+
   test('pagination differences produce different keys', function (assert) {
     let p1: Query = { ...baseQuery, page: { number: 0, size: 10 } };
     let p2: Query = { ...baseQuery, page: { number: 1, size: 10 } };

--- a/packages/host/tests/unit/lib/search-in-flight-key-test.ts
+++ b/packages/host/tests/unit/lib/search-in-flight-key-test.ts
@@ -86,6 +86,23 @@ module('Unit | Utility | searchInFlightKey (host)', function () {
     );
   });
 
+  test('different wire scopes produce different keys', function (assert) {
+    assert.notStrictEqual(
+      searchInFlightKey([realmA], baseQuery, 'cards'),
+      searchInFlightKey([realmA], baseQuery, 'files'),
+    );
+  });
+
+  test('an explicit wire scope is distinct from omitted', function (assert) {
+    // The store keys on the *resolved* wire scope, so a resolved 'cards' must
+    // not collide with the undefined wire default (a positive-type / 'all'
+    // request) — otherwise the two would coalesce into one in-flight fetch.
+    assert.notStrictEqual(
+      searchInFlightKey([realmA], baseQuery),
+      searchInFlightKey([realmA], baseQuery, 'cards'),
+    );
+  });
+
   test('pagination differences produce different keys', function (assert) {
     let p1: Query = { ...baseQuery, page: { number: 0, size: 10 } };
     let p2: Query = { ...baseQuery, page: { number: 1, size: 10 } };

--- a/packages/host/tests/unit/store-card-boundary-test.ts
+++ b/packages/host/tests/unit/store-card-boundary-test.ts
@@ -5,6 +5,7 @@ import type { Query, Store } from '@cardstack/runtime-common';
 import type StoreService from '@cardstack/host/services/store';
 
 import type { CardDef } from '@cardstack/base/card-api';
+import type { FileDef } from '@cardstack/base/file-api';
 
 // The card boundary, codified at the type level: the `Store` interface cards
 // receive via `@context.store` exposes instances-level search only. The raw
@@ -19,6 +20,30 @@ type CardStoreExposesInstancesSearch = Assert<
     query: Query,
     realmURLs?: string[],
   ) => Promise<CardDef[]>
+    ? true
+    : false
+>;
+
+// The element type follows the runtime `scope` argument: a file-scoped search
+// is `FileDef`-typed and a mixed-scope search is `(CardDef | FileDef)`-typed,
+// both without a caller cast. These pin the scope→element mapping — reverting
+// `search` to a flat `Promise<CardDef[]>` breaks the two assertions below.
+type CardStoreSearchFilesNarrows = Assert<
+  Store['search'] extends (
+    query: Query,
+    realmURLs: string[] | undefined,
+    opts: { scope: 'files' },
+  ) => Promise<FileDef[]>
+    ? true
+    : false
+>;
+
+type CardStoreSearchAllNarrows = Assert<
+  Store['search'] extends (
+    query: Query,
+    realmURLs: string[] | undefined,
+    opts: { scope: 'all' },
+  ) => Promise<(CardDef | FileDef)[]>
     ? true
     : false
 >;
@@ -42,10 +67,12 @@ module('Unit | store card boundary', function () {
     // the real assertions are the compile-time types above
     let witnesses: [
       CardStoreExposesInstancesSearch,
+      CardStoreSearchFilesNarrows,
+      CardStoreSearchAllNarrows,
       CardStoreLacksSearchEntries,
       HostStoreServiceCarriesSearchEntries,
       HostStoreServiceSatisfiesCardStore,
-    ] = [true, true, true, true];
-    assert.deepEqual(witnesses, [true, true, true, true]);
+    ] = [true, true, true, true, true, true];
+    assert.deepEqual(witnesses, [true, true, true, true, true, true]);
   });
 });

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1443,7 +1443,10 @@ export interface Store {
   // `scope` pins which rows the search returns: 'cards' (instance rows),
   // 'files' (FileDef rows), or 'all' (both). When omitted the scope is inferred
   // from the filter — an untyped query defaults to 'cards'. Prefer passing it
-  // explicitly over shaping the filter to coax a scope.
+  // explicitly over shaping the filter to coax a scope. Note: 'all' returns a
+  // card's instance row *and* its dual-indexed `.json` file row, so an untyped
+  // `scope: 'all'` search yields each card twice unless the caller dedups
+  // (e.g. `excludeCardInstanceFileRows()`).
   search(
     query: Query,
     realmURLs?: string[],

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1033,7 +1033,6 @@ export interface RealmCards {
 export { v4 as uuidv4 } from '@lukeed/uuid'; // isomorphic UUID's using Math.random
 import type { LocalPath } from './paths.ts';
 import type { CardTypeFilter, Query, EveryFilter } from './query.ts';
-import type { SearchEntryScope } from './search-entry.ts';
 import { Loader } from './loader.ts';
 export * from './frontmatter-parse.ts';
 export * from './http-range.ts';
@@ -1366,7 +1365,12 @@ export type getCardCollection<T extends CardDef = CardDef> = (
   cardErrors: CardErrorJSONAPI[];
   isLoaded: boolean;
 };
-export type getCards<T extends CardDef = CardDef> = (
+// Generic over `CardDef | FileDef` (defaulting to `CardDef`) to match the
+// resource backing it — `StoreService.getSearchResource`, `SearchResource`, and
+// `getSearch` are all `<T extends CardDef | FileDef = CardDef>`. A file-typed
+// search (`getCards<FileDef>(...)`) is then `FileDef`-typed end to end instead
+// of a `CardDef[]` the caller has to cast.
+export type getCards<T extends CardDef | FileDef = CardDef> = (
   parent: object,
   getQuery: () => Query | undefined,
   getRealms?: () => string[] | undefined,
@@ -1440,18 +1444,33 @@ export interface Store {
     patchData: PatchData,
     opts?: { doNotPersist?: boolean; clientRequestId?: string },
   ): Promise<T | CardErrorJSONAPI | undefined>;
-  // `scope` pins which rows the search returns: 'cards' (instance rows),
-  // 'files' (FileDef rows), or 'all' (both). When omitted the scope is inferred
-  // from the filter — an untyped query defaults to 'cards'. Prefer passing it
-  // explicitly over shaping the filter to coax a scope. Note: 'all' returns a
-  // card's instance row *and* its dual-indexed `.json` file row, so an untyped
-  // `scope: 'all'` search yields each card twice unless the caller dedups
+  // `scope` pins which rows the search returns and drives the element type:
+  // 'files' → `FileDef[]`, 'all' → `(CardDef | FileDef)[]`, and 'cards' (or
+  // omitted) → `CardDef[]`. When omitted the scope is inferred from the filter —
+  // an untyped query defaults to 'cards'. Prefer passing it explicitly over
+  // shaping the filter to coax a scope. Note: 'all' returns a card's instance
+  // row *and* its dual-indexed `.json` file row, so an untyped `scope: 'all'`
+  // search yields each card twice unless the caller dedups
   // (e.g. `excludeCardInstanceFileRows()`).
+  //
+  // The element type follows the runtime `scope` argument rather than a free
+  // caller-supplied type parameter, so a file-scoped search is `FileDef`-typed
+  // without a cast and a card-scoped search cannot be mis-asserted as files.
   search(
     query: Query,
+    realmURLs: string[] | undefined,
+    opts: { scope: 'files' },
+  ): Promise<FileDef[]>;
+  search(
+    query: Query,
+    realmURLs: string[] | undefined,
+    opts: { scope: 'all' },
+  ): Promise<(CardDef | FileDef)[]>;
+  search<T extends CardDef = CardDef>(
+    query: Query,
     realmURLs?: string[],
-    opts?: { scope?: SearchEntryScope },
-  ): Promise<CardDef[]>;
+    opts?: { scope?: 'cards' },
+  ): Promise<T[]>;
   getSaveState(id: string): AutoSaveState | undefined;
 }
 

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1033,6 +1033,7 @@ export interface RealmCards {
 export { v4 as uuidv4 } from '@lukeed/uuid'; // isomorphic UUID's using Math.random
 import type { LocalPath } from './paths.ts';
 import type { CardTypeFilter, Query, EveryFilter } from './query.ts';
+import type { SearchEntryScope } from './search-entry.ts';
 import { Loader } from './loader.ts';
 export * from './frontmatter-parse.ts';
 export * from './http-range.ts';
@@ -1439,7 +1440,15 @@ export interface Store {
     patchData: PatchData,
     opts?: { doNotPersist?: boolean; clientRequestId?: string },
   ): Promise<T | CardErrorJSONAPI | undefined>;
-  search(query: Query, realmURLs?: string[]): Promise<CardDef[]>;
+  // `scope` pins which rows the search returns: 'cards' (instance rows),
+  // 'files' (FileDef rows), or 'all' (both). When omitted the scope is inferred
+  // from the filter — an untyped query defaults to 'cards'. Prefer passing it
+  // explicitly over shaping the filter to coax a scope.
+  search(
+    query: Query,
+    realmURLs?: string[],
+    opts?: { scope?: SearchEntryScope },
+  ): Promise<CardDef[]>;
   getSaveState(id: string): AutoSaveState | undefined;
 }
 


### PR DESCRIPTION
## Problem
`store.search` inferred its card/file/all scope from the filter shape: an untyped query pinned to `'cards'`, a positive type ref opened `'all'`. To search cards **and** files together, a caller had to name both base refs and add the `_isCardInstanceFile` dedup key purely to coax the store into `'all'` scope — and the card-facing `Store` interface exposed no scope at all, so a mixed feed silently returned cards only.

Separately, the card-facing `Store.search` return type was a lie: it declared `Promise<CardDef[]>`, but a file-typed or mixed-scope search returns `FileDef` instances too, forcing consumers to cast (`instances as FileDef[]`) and runtime-discriminate every element.

## Change
**Explicit scope.** Add a `scope?: 'cards' | 'files' | 'all'` option to `store.search` and the card-facing `Store` interface, threaded through `fetchAndHydrateSearchResults` → `fetchSearchDoc` → `fetchSearchDocUncoalesced`, and folded into the prerender resolved-doc cache key and the in-flight-dedup key (a query that differs only by scope is a different result set). An explicit scope **wins**; when omitted, the existing filter-derived default is preserved, so **no existing call site changes behavior**.

**Element type keyed to scope.** The card-facing `Store.search` element type now follows the runtime `scope` argument via overloads: `'files'` → `FileDef[]`, `'all'` → `(CardDef | FileDef)[]`, `'cards'`/omitted → `CardDef[]`. This drops the caller-side cast and makes a card-scoped search un-mis-assertable as files (a free type parameter could assert `<FileDef>` on a card query and compile). The sibling `getCards` `@context` surface is widened to `<T extends CardDef | FileDef = CardDef>` to match its backing resource (`getSearchResource` / `SearchResource` / `getSearch`), removing the `as FileDef[]` cast in the playground panel. `store-card-boundary-test` gains narrowing witnesses that pin the scope→element mapping, so a reversion to a flat `CardDef[]` return fails the type-check.

## Follow-up
The mixed workspace feed query can drop the `baseCardRef` / `baseFileRef` + `excludeCardInstanceFileRows()` incantation in favor of `scope: 'all'` + a plain self-referential exclusion.

## Notes
- Subsumes #5888, which proposed the generic return type independently; that change is folded in here as scope-keyed overloads, and #5888 is closed.
- `ember-tsc --noEmit`: 0 errors across `host` and `runtime-common`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
