### PR TITLE
Make card-facing Store.search generic over CardDef | FileDef

### DIFF
--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1439,7 +1439,16 @@ export interface Store {
     patchData: PatchData,
     opts?: { doNotPersist?: boolean; clientRequestId?: string },
   ): Promise<T | CardErrorJSONAPI | undefined>;
-  search(query: Query, realmURLs?: string[]): Promise<CardDef[]>;
+  // Generic over the element type because a search can return `FileDef`
+  // instances (file-meta rows), not just cards — e.g. a file-typed query, or a
+  // mixed card+file scope. Defaults to `CardDef` so existing call sites are
+  // unaffected; a caller that expects files narrows with the type argument
+  // (`store.search<FileDef>(...)`) and gets a correctly-typed result instead of
+  // a `CardDef[]` it has to cast and runtime-discriminate.
+  search<T extends CardDef | FileDef = CardDef>(
+    query: Query,
+    realmURLs?: string[],
+  ): Promise<T[]>;
   getSaveState(id: string): AutoSaveState | undefined;
 }
 


### PR DESCRIPTION
Addresses CS-12645 (surfaced during review of #5886 / CS-12476).

## Problem
The card-facing `Store` interface (`packages/runtime-common/index.ts`) declared:

```ts
search(query: Query, realmURLs?: string[]): Promise<CardDef[]>;
```

but at runtime a file-typed or mixed-scope search returns `FileDef` instances too. The type was a lie — consumers had to cast (`raw as BaseDef`) and runtime-discriminate every element with `isCardInstance` / `isFileDefInstance` (exactly what the CS-12476 feed loop does).

## Change
Make `Store.search` generic over `CardDef | FileDef`, defaulting to `CardDef` so **existing call sites are unaffected**. A caller expecting files narrows with `store.search<FileDef>(...)` and gets a correctly-typed result. The host `StoreService.search` is already generic; this just aligns the interface it implements.

## Status — draft
- `ember-tsc --noEmit`: 0 errors (type-only change).
- Pairs naturally with CS-12644 (explicit scope) — ideally the element type follows the requested scope. Opening as draft to decide how far to take that coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)