### PR TITLE
Give FileDef first-class lastModified / resourceCreatedAt getters

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3117,6 +3117,19 @@ export class FileDef extends BaseDef {
   @field contentHash = contains(StringField);
   @field contentSize = contains(NumberField);
 
+  // Server-managed timestamps (epoch seconds), read off the resource `meta` the
+  // store stamps at hydration — not `@field`s, so they never round-trip on a
+  // write. These mirror the names a card exposes through `getCardMeta`, so a
+  // consumer reads a file's timestamps the same way it reads a card's without
+  // reaching for `getCardMeta` on a FileDef.
+  get lastModified(): number | undefined {
+    return this[meta]?.lastModified;
+  }
+
+  get resourceCreatedAt(): number | undefined {
+    return this[meta]?.resourceCreatedAt;
+  }
+
   // The four shared format shells own identity, facts, budgets, and state for
   // every file family. What they can't know is how to draw the file itself — a
   // waveform, a page, a 3D scene — so a family supplies that one renderer here

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3117,11 +3117,12 @@ export class FileDef extends BaseDef {
   @field contentHash = contains(StringField);
   @field contentSize = contains(NumberField);
 
-  // Server-managed timestamps (epoch seconds), read off the resource `meta` the
-  // store stamps at hydration — not `@field`s, so they never round-trip on a
-  // write. These mirror the names a card exposes through `getCardMeta`, so a
-  // consumer reads a file's timestamps the same way it reads a card's without
-  // reaching for `getCardMeta` on a FileDef.
+  // Server-managed timestamps (epoch seconds), read off the resource `meta`
+  // (stamped at serialization under the same key names a card uses, so
+  // `createFromSerialized` carries them onto `this[meta]`) — not `@field`s, so
+  // they never round-trip on a write. These mirror the names a card exposes
+  // through `getCardMeta`, so a consumer reads a file's timestamps the same way
+  // it reads a card's without reaching for `getCardMeta` on a FileDef.
   get lastModified(): number | undefined {
     return this[meta]?.lastModified;
   }

--- a/packages/base/file-formats/file-presentation.gts
+++ b/packages/base/file-formats/file-presentation.gts
@@ -99,12 +99,27 @@ export function downloadNameFor(
   return model?.name || undefined;
 }
 
-export function shortDate(value?: Date | string | null): string {
-  if (!value) {
-    return '';
+// Coerce a timestamp to a Date. A bare number is epoch time, but the server
+// stamps a file's `lastModified` / `resourceCreatedAt` in epoch *seconds* — a
+// value `new Date` would otherwise read as milliseconds and render as 1970 —
+// so seconds are promoted to ms below the year-2001 ms floor. Mirrors
+// `workspace.gts`'s `toMs`.
+function toDate(value?: Date | string | number | null): Date | undefined {
+  if (value == null || value === '') {
+    return undefined;
   }
-  let d = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(d.getTime())) {
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return new Date(value < 1e12 ? value * 1000 : value);
+  }
+  return new Date(value);
+}
+
+export function shortDate(value?: Date | string | number | null): string {
+  let d = toDate(value);
+  if (!d || Number.isNaN(d.getTime())) {
     return '';
   }
   return d.toLocaleDateString('en-US', {
@@ -114,12 +129,9 @@ export function shortDate(value?: Date | string | null): string {
   });
 }
 
-export function relativeDate(value?: Date | string | null): string {
-  if (!value) {
-    return '';
-  }
-  let d = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(d.getTime())) {
+export function relativeDate(value?: Date | string | number | null): string {
+  let d = toDate(value);
+  if (!d || Number.isNaN(d.getTime())) {
     return '';
   }
   let days = Math.floor((Date.now() - d.getTime()) / 86400000);

--- a/packages/base/file-formats/file-view-model.ts
+++ b/packages/base/file-formats/file-view-model.ts
@@ -114,8 +114,8 @@ export interface FileViewModel {
   contentPreview: string;
   previewTruncated: boolean;
   durationSeconds?: number;
-  lastModified?: string | Date;
-  createdAt?: string | Date;
+  lastModified?: string | Date | number;
+  createdAt?: string | Date | number;
   realmPath?: string;
   width?: number;
   height?: number;
@@ -540,7 +540,10 @@ export function fileViewModel(
         archiveEntries.length < completeArchiveEntries.length),
     durationSeconds: durationOf(file),
     lastModified: file.lastModified,
-    createdAt: file.createdAt,
+    // A FileDef exposes its created timestamp as `resourceCreatedAt` (the card
+    // key name); `createdAt` is the legacy attribute spelling a plain wire
+    // object may still carry. Prefer the explicit field, fall back to the getter.
+    createdAt: file.createdAt ?? file.resourceCreatedAt,
     realmPath: file.realmPath,
     width,
     height,

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -2442,25 +2442,10 @@ export default class StoreService extends Service implements StoreInterface {
       store: this.store,
       dependencyTrackingContext,
     })) as unknown as FileDef;
-    // A file-meta resource carries its timestamps as `attributes.lastModified`
-    // / `attributes.createdAt` — a different location and a different "created"
-    // key than a card resource, which puts `lastModified` / `resourceCreatedAt`
-    // in `meta`. FileDef declares neither as a field, so they'd be dropped on
-    // hydration. Normalize them onto `meta` under the card key names so
-    // FileDef's `lastModified` / `resourceCreatedAt` getters (and `getCardMeta`)
-    // answer uniformly for cards and files.
-    let lastModified = resource.attributes?.lastModified;
-    let resourceCreatedAt = resource.attributes?.createdAt;
-    if (
-      typeof lastModified === 'number' ||
-      typeof resourceCreatedAt === 'number'
-    ) {
-      (instance as any)[meta] = {
-        ...(instance as any)[meta],
-        ...(typeof lastModified === 'number' ? { lastModified } : {}),
-        ...(typeof resourceCreatedAt === 'number' ? { resourceCreatedAt } : {}),
-      };
-    }
+    // The file's timestamps ride in the resource `meta` (stamped at
+    // serialization, mirroring a card), so `createFromSerialized` copies them
+    // onto `instance[meta]` — FileDef's `lastModified` / `resourceCreatedAt`
+    // getters and `getCardMeta` read them with no store-side normalization.
     this.setIdentityContext(instance, 'file-meta');
     return instance;
   }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -2442,6 +2442,25 @@ export default class StoreService extends Service implements StoreInterface {
       store: this.store,
       dependencyTrackingContext,
     })) as unknown as FileDef;
+    // A file-meta resource carries its timestamps as `attributes.lastModified`
+    // / `attributes.createdAt` — a different location and a different "created"
+    // key than a card resource, which puts `lastModified` / `resourceCreatedAt`
+    // in `meta`. FileDef declares neither as a field, so they'd be dropped on
+    // hydration. Normalize them onto `meta` under the card key names so
+    // FileDef's `lastModified` / `resourceCreatedAt` getters (and `getCardMeta`)
+    // answer uniformly for cards and files.
+    let lastModified = resource.attributes?.lastModified;
+    let resourceCreatedAt = resource.attributes?.createdAt;
+    if (
+      typeof lastModified === 'number' ||
+      typeof resourceCreatedAt === 'number'
+    ) {
+      (instance as any)[meta] = {
+        ...(instance as any)[meta],
+        ...(typeof lastModified === 'number' ? { lastModified } : {}),
+        ...(typeof resourceCreatedAt === 'number' ? { resourceCreatedAt } : {}),
+      };
+    }
     this.setIdentityContext(instance, 'file-meta');
     return instance;
   }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -2442,10 +2442,6 @@ export default class StoreService extends Service implements StoreInterface {
       store: this.store,
       dependencyTrackingContext,
     })) as unknown as FileDef;
-    // The file's timestamps ride in the resource `meta` (stamped at
-    // serialization, mirroring a card), so `createFromSerialized` copies them
-    // onto `instance[meta]` — FileDef's `lastModified` / `resourceCreatedAt`
-    // getters and `getCardMeta` read them with no store-side normalization.
     this.setIdentityContext(instance, 'file-meta');
     return instance;
   }

--- a/packages/host/tests/unit/file-view-model-test.ts
+++ b/packages/host/tests/unit/file-view-model-test.ts
@@ -10,6 +10,7 @@ import type { Loader } from '@cardstack/runtime-common';
 
 import { setupRenderingTest } from '../helpers/setup';
 
+import type * as FilePresentationModule from '@cardstack/base/file-formats/file-presentation';
 import type * as FileTypeProfileModule from '@cardstack/base/file-formats/file-type-profile';
 import type * as FileViewModelModule from '@cardstack/base/file-formats/file-view-model';
 
@@ -21,6 +22,8 @@ module('Unit | file-formats', function (hooks) {
   let extensionOfFile: typeof FileTypeProfileModule.extensionOfFile;
   let contentTypeForFile: typeof FileTypeProfileModule.contentTypeForFile;
   let fileViewModel: typeof FileViewModelModule.fileViewModel;
+  let shortDate: typeof FilePresentationModule.shortDate;
+  let relativeDate: typeof FilePresentationModule.relativeDate;
   let FITTED_TEXT_CHARACTER_BUDGET: number;
   let FITTED_TEXT_LINE_BUDGET: number;
   let FITTED_WAVEFORM_BAR_BUDGET: number;
@@ -33,7 +36,11 @@ module('Unit | file-formats', function (hooks) {
     let viewModelModule = await loader.import<typeof FileViewModelModule>(
       '@cardstack/base/file-formats/file-view-model',
     );
+    let presentationModule = await loader.import<typeof FilePresentationModule>(
+      '@cardstack/base/file-formats/file-presentation',
+    );
     ({ profileForFile, contentTypeForFile, extensionOfFile } = profileModule);
+    ({ shortDate, relativeDate } = presentationModule);
     ({
       fileViewModel,
       FITTED_TEXT_CHARACTER_BUDGET,
@@ -346,6 +353,49 @@ module('Unit | file-formats', function (hooks) {
     test('describes an oddly-shaped image with a ratio rather than a fraction', function (assert) {
       let vm = fileViewModel({ name: 'pano.jpg', width: 4001, height: 1000 });
       assert.strictEqual(vm.aspectLabel, '4.00:1');
+    });
+  });
+
+  module('timestamps', function () {
+    // A FileDef exposes its created timestamp as `resourceCreatedAt` (the card
+    // key name), not the legacy `createdAt` attribute. The projection has to
+    // resolve the created slot off the getter, or the isolated shell's "Created"
+    // line reads blank for every hydrated file.
+    test('resolves the created slot from resourceCreatedAt', function (assert) {
+      let vm = fileViewModel({
+        name: 'note.txt',
+        url: 'http://test.com/note.txt',
+        lastModified: 1_700_000_500,
+        resourceCreatedAt: 1_699_000_000,
+      });
+      assert.strictEqual(vm.createdAt, 1_699_000_000);
+      assert.strictEqual(vm.lastModified, 1_700_000_500);
+    });
+
+    // The server stamps a file's timestamps in epoch *seconds*, and the shells
+    // hand them straight to these formatters. A bare number read as milliseconds
+    // renders as 1970 — the regression this guards.
+    test('formats epoch-seconds timestamps to the right era, not 1970', function (assert) {
+      // 1_700_000_000s = 2023-11-14T22:13:20Z — far enough into that UTC day
+      // that no local timezone shifts it off the year.
+      assert.true(
+        shortDate(1_700_000_000).includes('2023'),
+        `epoch seconds format to their real year, got: ${shortDate(1_700_000_000)}`,
+      );
+      assert.notOk(
+        shortDate(1_700_000_000).includes('1970'),
+        'a seconds timestamp is not misread as milliseconds',
+      );
+      // Milliseconds already above the seconds floor pass through unchanged.
+      assert.true(
+        shortDate(1_700_000_000_000).includes('2023'),
+        'a millisecond timestamp still formats correctly',
+      );
+      // A recent seconds timestamp reads as a recent relative date, not "56y ago".
+      assert.notOk(
+        relativeDate(1_700_000_000).includes('56y'),
+        'a seconds timestamp is not misread as a 1970 relative date',
+      );
     });
   });
 });

--- a/packages/host/tests/unit/instance-filter-matcher-test.ts
+++ b/packages/host/tests/unit/instance-filter-matcher-test.ts
@@ -662,6 +662,95 @@ module('Unit | instance-filter-matcher', function (hooks) {
     );
   });
 
+  // -- file timestamps (meta parity with cards) -------------------------------
+  // A file's `lastModified` / `resourceCreatedAt` ride in the resource `meta`
+  // (stamped at serialization, mirroring a card), so `createFromSerialized`
+  // carries them onto `instance[meta]` and both the FileDef getters and the
+  // client-side comparator read them the same way they do for a card.
+
+  async function hydrateFile(
+    name: string,
+    timestamps: { lastModified: number; resourceCreatedAt: number },
+  ): Promise<FileDef> {
+    let cardApi = await loader.import<any>('@cardstack/base/card-api');
+    let url = `${testRealmURL}files/${name}`;
+    let doc = {
+      data: {
+        id: url,
+        type: 'file-meta' as const,
+        attributes: { name, url, contentType: 'text/markdown' },
+        meta: {
+          adoptsFrom: { module: `${baseRealm.url}card-api`, name: 'FileDef' },
+          lastModified: timestamps.lastModified,
+          resourceCreatedAt: timestamps.resourceCreatedAt,
+        },
+      },
+    };
+    return (await cardApi.createFromSerialized(
+      doc.data,
+      doc,
+      new URL(testRealmURL),
+    )) as FileDef;
+  }
+
+  test('a hydrated FileDef exposes its meta timestamps through the getters', async function (assert) {
+    let cardApi = await loader.import<any>('@cardstack/base/card-api');
+    let file = await hydrateFile('report.md', {
+      lastModified: 1_700_000_500,
+      resourceCreatedAt: 1_700_000_000,
+    });
+    assert.strictEqual(
+      file.lastModified,
+      1_700_000_500,
+      'lastModified getter reads off meta',
+    );
+    assert.strictEqual(
+      file.resourceCreatedAt,
+      1_700_000_000,
+      'resourceCreatedAt getter reads off meta',
+    );
+    assert.strictEqual(
+      cardApi.getCardMeta(file, 'lastModified'),
+      1_700_000_500,
+      'getCardMeta answers for a file the same way it does for a card',
+    );
+    assert.strictEqual(
+      cardApi.getCardMeta(file, 'resourceCreatedAt'),
+      1_700_000_000,
+      'getCardMeta resolves resourceCreatedAt for a file',
+    );
+  });
+
+  test('comparator orders files by their meta lastModified / createdAt', async function (assert) {
+    let older = await hydrateFile('older.md', {
+      lastModified: 100,
+      resourceCreatedAt: 10,
+    });
+    let newer = await hydrateFile('newer.md', {
+      lastModified: 200,
+      resourceCreatedAt: 20,
+    });
+    let files = [older, newer] as unknown as CardDef[];
+
+    let byModifiedDesc: Sort = [{ by: 'lastModified', direction: 'desc' }];
+    assert.deepEqual(
+      [...files]
+        .sort(makeInstanceComparator(byModifiedDesc, api))
+        .map((f) => (f as any).name),
+      ['newer.md', 'older.md'],
+      'newest lastModified first',
+    );
+
+    let byCreatedAsc: Sort = [{ by: 'createdAt', direction: 'asc' }];
+    assert.deepEqual(
+      [...files]
+        .sort(makeInstanceComparator(byCreatedAsc, api))
+        .map((f) => (f as any).name),
+      ['older.md', 'newer.md'],
+      'oldest createdAt first',
+    );
+  });
+
   // -- synthetic search-doc keys (server parity) ------------------------------
   // The engine lets filters/sorts address `_title`, `_cardType`, and
   // `_isCardInstanceFile` even though they are stamped into the search doc, not

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1354,6 +1354,30 @@ module(basename(import.meta.filename), function () {
         doc.data.attributes?.lastModified,
         'lastModified sourced from response attributes',
       );
+      // Timestamps also ride in `meta` (mirroring a card), the canonical home a
+      // hydrated FileDef reads through `getCardMeta` / its getters. They are
+      // stamped from the index columns and agree with the legacy attributes.
+      assert.strictEqual(
+        typeof doc.data.meta?.lastModified,
+        'number',
+        'file-meta GET carries meta.lastModified',
+      );
+      assert.strictEqual(
+        typeof (doc.data.meta as { resourceCreatedAt?: unknown })
+          ?.resourceCreatedAt,
+        'number',
+        'file-meta GET carries meta.resourceCreatedAt',
+      );
+      assert.strictEqual(
+        doc.data.meta?.lastModified,
+        doc.data.attributes?.lastModified,
+        'meta.lastModified agrees with the legacy attributes spelling',
+      );
+      assert.strictEqual(
+        (doc.data.meta as { resourceCreatedAt?: unknown })?.resourceCreatedAt,
+        doc.data.attributes?.createdAt,
+        'meta.resourceCreatedAt agrees with the legacy attributes.createdAt',
+      );
     });
 
     test('file meta adoptsFrom prefers index types', async function (assert) {

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1380,6 +1380,45 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('serves FileMeta with meta timestamps from the filesystem fallback', async function (assert) {
+      // Drop the index row so getFileMeta finds no entry and falls through to
+      // the filesystem fallback (fileMetaDocument), which builds the doc from
+      // disk metadata. The timestamps must land in `meta` there too, so a
+      // hydrated FileDef reads them the same way it does for an indexed file —
+      // the value must not hinge on whether the row is in the index yet.
+      await realm.write('unindexed-note.txt', 'not yet indexed');
+      await testDbAdapter.execute(
+        `DELETE FROM boxel_index WHERE url = '${testRealm}unindexed-note.txt'`,
+      );
+      let response = await fetch(`${testRealm}unindexed-note.txt`, {
+        headers: { Accept: SupportedMimeType.FileMeta },
+      });
+      assert.strictEqual(response.status, 200, 'file meta response is ok');
+      let doc = (await response.json()) as LooseSingleCardDocument;
+      assert.strictEqual(doc.data.type, 'file-meta');
+      assert.strictEqual(
+        typeof doc.data.meta?.lastModified,
+        'number',
+        'fallback file-meta GET carries meta.lastModified',
+      );
+      assert.strictEqual(
+        typeof (doc.data.meta as { resourceCreatedAt?: unknown })
+          ?.resourceCreatedAt,
+        'number',
+        'fallback file-meta GET carries meta.resourceCreatedAt',
+      );
+      assert.strictEqual(
+        doc.data.meta?.lastModified,
+        doc.data.attributes?.lastModified,
+        'meta.lastModified agrees with the legacy attributes spelling',
+      );
+      assert.strictEqual(
+        (doc.data.meta as { resourceCreatedAt?: unknown })?.resourceCreatedAt,
+        doc.data.attributes?.createdAt,
+        'meta.resourceCreatedAt agrees with the legacy attributes.createdAt',
+      );
+    });
+
     test('file meta adoptsFrom prefers index types', async function (assert) {
       let fileDefModule = new URL('filedef-mismatch', testRealm).href;
       let fileDefKey = internalKeyFor(

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1363,8 +1363,7 @@ module(basename(import.meta.filename), function () {
         'file-meta GET carries meta.lastModified',
       );
       assert.strictEqual(
-        typeof (doc.data.meta as { resourceCreatedAt?: unknown })
-          ?.resourceCreatedAt,
+        typeof doc.data.meta?.resourceCreatedAt,
         'number',
         'file-meta GET carries meta.resourceCreatedAt',
       );
@@ -1374,7 +1373,7 @@ module(basename(import.meta.filename), function () {
         'meta.lastModified agrees with the legacy attributes spelling',
       );
       assert.strictEqual(
-        (doc.data.meta as { resourceCreatedAt?: unknown })?.resourceCreatedAt,
+        doc.data.meta?.resourceCreatedAt,
         doc.data.attributes?.createdAt,
         'meta.resourceCreatedAt agrees with the legacy attributes.createdAt',
       );
@@ -1390,6 +1389,18 @@ module(basename(import.meta.filename), function () {
       await testDbAdapter.execute(
         `DELETE FROM boxel_index WHERE url = '${testRealm}unindexed-note.txt'`,
       );
+      // Assert the discriminator: with no index row, getFileMeta must take the
+      // filesystem fallback. Without this the test still passes if a row exists
+      // when the fetch runs (both GET branches now stamp the same meta keys), so
+      // it would silently stop covering the fallback it names.
+      let [{ count: indexRowCount }] = (await testDbAdapter.execute(
+        `SELECT count(*)::int AS count FROM boxel_index WHERE url = '${testRealm}unindexed-note.txt'`,
+      )) as { count: number }[];
+      assert.strictEqual(
+        indexRowCount,
+        0,
+        'no index row remains, so the GET must take the filesystem fallback',
+      );
       let response = await fetch(`${testRealm}unindexed-note.txt`, {
         headers: { Accept: SupportedMimeType.FileMeta },
       });
@@ -1402,8 +1413,7 @@ module(basename(import.meta.filename), function () {
         'fallback file-meta GET carries meta.lastModified',
       );
       assert.strictEqual(
-        typeof (doc.data.meta as { resourceCreatedAt?: unknown })
-          ?.resourceCreatedAt,
+        typeof doc.data.meta?.resourceCreatedAt,
         'number',
         'fallback file-meta GET carries meta.resourceCreatedAt',
       );
@@ -1413,7 +1423,7 @@ module(basename(import.meta.filename), function () {
         'meta.lastModified agrees with the legacy attributes spelling',
       );
       assert.strictEqual(
-        (doc.data.meta as { resourceCreatedAt?: unknown })?.resourceCreatedAt,
+        doc.data.meta?.resourceCreatedAt,
         doc.data.attributes?.createdAt,
         'meta.resourceCreatedAt agrees with the legacy attributes.createdAt',
       );

--- a/packages/realm-server/tests/search-entries-engine-test.ts
+++ b/packages/realm-server/tests/search-entries-engine-test.ts
@@ -684,6 +684,29 @@ module(basename(import.meta.filename), function () {
       let item = itemIn(doc, fileUrl)!;
       assert.strictEqual(item.type, 'file-meta');
       assert.strictEqual(item.attributes?.name, 'hello.md');
+      // A file's timestamps ride in `meta` (mirroring a card), so a hydrated
+      // FileDef reads them through `getCardMeta` / its getters — not just in the
+      // legacy `attributes` spelling.
+      assert.strictEqual(
+        typeof item.meta?.lastModified,
+        'number',
+        'file item carries meta.lastModified',
+      );
+      assert.strictEqual(
+        typeof item.meta?.resourceCreatedAt,
+        'number',
+        'file item carries meta.resourceCreatedAt',
+      );
+      assert.strictEqual(
+        item.meta?.lastModified,
+        item.attributes?.lastModified,
+        'meta.lastModified agrees with the legacy attributes spelling',
+      );
+      assert.strictEqual(
+        item.meta?.resourceCreatedAt,
+        item.attributes?.createdAt,
+        'meta.resourceCreatedAt agrees with the legacy attributes.createdAt',
+      );
 
       // default fieldset: a file's rendering is its own (no renderType in
       // the composite id — files render natively)

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -66,6 +66,7 @@ import type {
   Saved,
   EntryResource,
 } from './resource-types.ts';
+import { fileMetaTimestamps } from './resource-types.ts';
 import {
   buildCssResource,
   parseUsedRenderType,
@@ -2256,11 +2257,7 @@ function fileResourceFromIndex(
     meta: {
       adoptsFrom: adoptsFrom as CodeRef,
       realmURL: fileEntry.realmURL as RealmIdentifier,
-      // Canonical home for the file's timestamps, mirroring a card's `meta`, so
-      // a hydrated FileDef exposes them through `getCardMeta` / its getters (the
-      // wire also carries the legacy `attributes.lastModified`/`createdAt`).
-      lastModified,
-      resourceCreatedAt: createdAt,
+      ...fileMetaTimestamps(lastModified, createdAt),
     },
     links: { self: fileURL.href },
   };

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -2256,6 +2256,11 @@ function fileResourceFromIndex(
     meta: {
       adoptsFrom: adoptsFrom as CodeRef,
       realmURL: fileEntry.realmURL as RealmIdentifier,
+      // Canonical home for the file's timestamps, mirroring a card's `meta`, so
+      // a hydrated FileDef exposes them through `getCardMeta` / its getters (the
+      // wire also carries the legacy `attributes.lastModified`/`createdAt`).
+      lastModified,
+      resourceCreatedAt: createdAt,
     },
     links: { self: fileURL.href },
   };

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -5190,6 +5190,12 @@ export class Realm {
           adoptsFrom,
           realmInfo,
           realmURL: this.url as RealmIdentifier,
+          // Canonical home for the file's timestamps, mirroring a card's `meta`,
+          // so a hydrated FileDef exposes them through `getCardMeta` / its
+          // getters (the wire also carries the legacy
+          // `attributes.lastModified`/`createdAt`).
+          lastModified: baseAttributes.lastModified,
+          resourceCreatedAt: baseAttributes.createdAt,
           // Per-field subclass overrides for nested polymorphic fields (e.g.
           // `frontmatter` → SkillFrontmatterField). Without this the field
           // rehydrates as its declared base type when the document is read.

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -134,6 +134,7 @@ import {
   isCardDocumentString,
   isBrowserTestEnv,
   unresolveResourceInstanceURLs,
+  fileMetaTimestamps,
   type IndexedFile,
   type LooseCardResource,
   type FileMetaResource,
@@ -5095,14 +5096,12 @@ export class Realm {
           adoptsFrom: fileDefCodeRef,
           realmInfo,
           realmURL: this.url as RealmIdentifier,
-          // Canonical home for the file's timestamps, mirroring a card's `meta`,
-          // so a hydrated FileDef exposes them through `getCardMeta` / its
-          // getters (the wire also carries the legacy
-          // `attributes.lastModified`/`createdAt`). This un-indexed fallback
-          // must stamp them too, so a file's `meta` timestamps don't hinge on
-          // whether the row is in the index yet.
-          lastModified: fileRef.lastModified,
-          resourceCreatedAt: createdAt ?? fileRef.lastModified,
+          // This un-indexed fallback must stamp the timestamps too, so a file's
+          // `meta` timestamps don't hinge on whether the row is in the index yet.
+          ...fileMetaTimestamps(
+            fileRef.lastModified,
+            createdAt ?? fileRef.lastModified,
+          ),
         },
         links: { self: fileURL },
       },
@@ -5198,12 +5197,10 @@ export class Realm {
           adoptsFrom,
           realmInfo,
           realmURL: this.url as RealmIdentifier,
-          // Canonical home for the file's timestamps, mirroring a card's `meta`,
-          // so a hydrated FileDef exposes them through `getCardMeta` / its
-          // getters (the wire also carries the legacy
-          // `attributes.lastModified`/`createdAt`).
-          lastModified: baseAttributes.lastModified,
-          resourceCreatedAt: baseAttributes.createdAt,
+          ...fileMetaTimestamps(
+            baseAttributes.lastModified,
+            baseAttributes.createdAt,
+          ),
           // Per-field subclass overrides for nested polymorphic fields (e.g.
           // `frontmatter` → SkillFrontmatterField). Without this the field
           // rehydrates as its declared base type when the document is read.

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -5095,6 +5095,14 @@ export class Realm {
           adoptsFrom: fileDefCodeRef,
           realmInfo,
           realmURL: this.url as RealmIdentifier,
+          // Canonical home for the file's timestamps, mirroring a card's `meta`,
+          // so a hydrated FileDef exposes them through `getCardMeta` / its
+          // getters (the wire also carries the legacy
+          // `attributes.lastModified`/`createdAt`). This un-indexed fallback
+          // must stamp them too, so a file's `meta` timestamps don't hinge on
+          // whether the row is in the index yet.
+          lastModified: fileRef.lastModified,
+          resourceCreatedAt: createdAt ?? fileRef.lastModified,
         },
         links: { self: fileURL },
       },

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -107,6 +107,13 @@ export type CardResourceMeta = Meta & {
 };
 
 export type FileMetaResourceResourceMeta = Meta & {
+  // A file's server-managed timestamps (epoch seconds), stamped here at
+  // serialization under the same key names a card uses (see CardResourceMeta),
+  // so `getCardMeta` / FileDef's getters read them uniformly for both kinds.
+  // The legacy `attributes.lastModified` / `attributes.createdAt` spelling is
+  // still carried on the wire for back-compat; `meta` is the canonical home.
+  lastModified?: number;
+  resourceCreatedAt?: number;
   realmInfo?: RealmInfo;
   realmURL?: RealmIdentifier;
   queryFieldDefs?: Record<string, QueryFieldMeta>;

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -125,6 +125,20 @@ export type FileMetaResourceResourceMeta = Meta & {
   error?: ErrorEntry;
 };
 
+// The single home for how a file's timestamps land in `meta`: the card key
+// names (`resourceCreatedAt`, not the legacy `attributes.createdAt` spelling),
+// mapped once. Every producer of a file-meta resource — the two indexed
+// builders and the filesystem fallback — spreads this so a hydrated FileDef
+// exposes them through `getCardMeta` / its getters, and a fourth producer can't
+// silently reintroduce the mapping omission. Callers resolve their own defaults
+// (the source values differ per path) and pass the two resolved values here.
+export function fileMetaTimestamps(
+  lastModified: number | undefined,
+  createdAt: number | undefined,
+): Pick<FileMetaResourceResourceMeta, 'lastModified' | 'resourceCreatedAt'> {
+  return { lastModified, resourceCreatedAt: createdAt };
+}
+
 export interface CardResource<Identity extends Unsaved = Saved> {
   id?: Identity;
   lid?: string;


### PR DESCRIPTION
Addresses CS-12646 (surfaced during review of #5886 / CS-12476).

## Problem
Card and file resources carry timestamps differently:
- **Card**: `lastModified` / `resourceCreatedAt` in `meta`.
- **File-meta**: `lastModified` / **`createdAt`** in `attributes` — different location *and* a different "created" key.

`FileDef` declares neither as a field, so a hydrated file dropped both, and callers had to reach for `getCardMeta` on a `FileDef` — which only worked via a hydration hack. The same gap also meant client-side sort (`instance-filter-matcher`'s `sortValue` → `getCardMeta`) resolved a file's `lastModified` / `createdAt` to `null`.

## Change
Unify the timestamp contract at the **serialization source** rather than lifting it per-hydration:

- `FileMetaResourceResourceMeta` now declares `lastModified?` / `resourceCreatedAt?`, mirroring `CardResourceMeta`.
- The two places that build a file-meta resource off the index row — `fileResourceFromIndex` (search `item`s) and the file-meta GET in `realm.ts` — stamp those timestamps onto the resource `meta` under the card key names.
- `createFromSerialized` already copies `resource.meta` onto `instance[meta]` (`card-api.gts` `updateFromSerialized`), so `FileDef.lastModified` / `FileDef.resourceCreatedAt` and `getCardMeta` read a file's timestamps uniformly with a card's — and client-side file sort now resolves them instead of `null`.

The `FileDef` getters stay; the store-side normalization is **removed** (nothing re-derives the `createdAt → resourceCreatedAt` mapping, so there's no twin to drift — and no overlap left with the CS-12476 branch's store hunk).

The legacy `attributes.lastModified` / `attributes.createdAt` spelling is still carried on the wire for back-compat. No reader of it was found, but dropping it is a wire-contract change left to a follow-up; `meta` is the canonical home.

## Tests
All passing locally:
- **realm-server** — the file-meta search `item` (`fileResourceFromIndex`) and the file-meta GET both carry `lastModified` / `resourceCreatedAt` in `meta`, agreeing with the legacy `attributes` spelling.
- **host** — a `FileDef` hydrated via `createFromSerialized` exposes `.lastModified` / `.resourceCreatedAt` (and `getCardMeta`) off `meta`; the client-side comparator orders files by their `meta` `lastModified` / `createdAt` (previously `null` for files).
- `ember-tsc --noEmit` (host + runtime-common): 0 errors from these changes.

## Follow-up
Drop the legacy `attributes.lastModified` / `attributes.createdAt` once no external consumer is confirmed; optionally promote the getters to `BaseDef` so cards expose `.lastModified` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
