### PR TITLE
Loader seams: injectable module evaluator and surgical module invalidation

### DIFF
--- a/packages/host/tests/unit/loader-seams-test.ts
+++ b/packages/host/tests/unit/loader-seams-test.ts
@@ -272,6 +272,12 @@ module('Unit | loader seams', function (hooks) {
         dependencyList: [],
         implementation: 'not callable',
       },
+      // Passes `Array.isArray`, so only an element check refuses it before
+      // the loader tries to resolve 42 as a module identifier.
+      'a dependency that is not an identifier': {
+        dependencyList: ['exports', 42],
+        implementation: () => {},
+      },
     };
 
     for (let [description, registration] of Object.entries(unusable)) {
@@ -762,6 +768,75 @@ module('Unit | loader seams', function (hooks) {
     assert.false(
       loader.isModuleLoaded(server.url('throws-on-eval.js')),
       'the failure is not pinned past the replacement of its dependency',
+    );
+  });
+
+  test('a dependency walk taken while a module is evicted is not memoized', async function (assert) {
+    await loader.import(server.url('top.js'));
+    assert.deepEqual(
+      loader.getKnownConsumedModules(server.url('top.js')).sort(),
+      [server.url('leaf'), server.url('middle')],
+      'the dependency set is cached off the first walk',
+    );
+
+    loader.invalidateModule(server.url('leaf'));
+    assert.deepEqual(
+      loader.getKnownConsumedModules(server.url('top.js')),
+      [],
+      'a walk taken while the module is gone reports what is loaded, which is nothing',
+    );
+
+    await loader.import(server.url('top.js'));
+    assert.deepEqual(
+      loader.getKnownConsumedModules(server.url('top.js')).sort(),
+      [server.url('leaf'), server.url('middle')],
+      'that walk did not outlive the gap it was taken in',
+    );
+  });
+
+  test('an eviction landing after the graph is walked re-enters instead of failing the import', async function (assert) {
+    // The read this covers happens after the walk has resolved, so no fetch
+    // can reach it — driving the interleaving means stepping in where the
+    // import awaits. Counting microtasks instead would pin nothing stable.
+    let prototype = Object.getPrototypeOf(loader) as Record<string, unknown>;
+    let walk = prototype.advanceToState as (
+      ...args: unknown[]
+    ) => Promise<void>;
+    assert.strictEqual(
+      typeof walk,
+      'function',
+      'the walk this test steps into still exists',
+    );
+
+    let evictions = 0;
+    prototype.advanceToState = async function (
+      this: Loader,
+      ...args: unknown[]
+    ) {
+      let result = await walk.apply(this, args);
+      if (evictions === 0) {
+        evictions++;
+        this.invalidateModule(server.url('leaf'));
+      }
+      return result;
+    };
+
+    try {
+      let module = await loader.import<{ leaf(): string }>(
+        server.url('leaf.js'),
+      );
+      assert.strictEqual(
+        module.leaf(),
+        'leaf',
+        'the import resolves against the module that replaced the evicted one',
+      );
+    } finally {
+      prototype.advanceToState = walk;
+    }
+    assert.strictEqual(
+      evictions,
+      1,
+      'the eviction fired in the window under test',
     );
   });
 

--- a/packages/host/tests/unit/loader-seams-test.ts
+++ b/packages/host/tests/unit/loader-seams-test.ts
@@ -15,6 +15,9 @@ const origin = 'https://loader-seams.test/';
 class SourceServer {
   sources: Map<string, string>;
   fetchCounts = new Map<string, number>();
+  // Path a realm names a module by when it differs from the one requested,
+  // served as `X-Boxel-Canonical-Path`.
+  canonicalPaths = new Map<string, string>();
   #parkedURLs = new Set<string>();
   #parked: Array<{ url: string; release: (fail: boolean) => void }> = [];
 
@@ -54,8 +57,12 @@ class SourceServer {
     if (source == null) {
       return new Response(`no such module ${url}`, { status: 404 });
     }
+    let canonicalPath = this.canonicalPaths.get(url);
     return new Response(source, {
-      headers: { 'content-type': 'text/javascript' },
+      headers: {
+        'content-type': 'text/javascript',
+        ...(canonicalPath ? { 'X-Boxel-Canonical-Path': canonicalPath } : {}),
+      },
     });
   };
 
@@ -114,6 +121,11 @@ const fixtures = {
     export function metaLoader() { return import.meta.loader; }
   `,
   'gen.js': `export function value() { return 'v1'; }`,
+  'throws-on-eval.js': `
+    import { leaf } from './leaf';
+    export const usesLeaf = leaf;
+    throw new Error('intentional evaluation failure');
+  `,
   // `./race-b` before `./race-slow`, and a two-module cycle through race-b,
   // is what leaves race-a's dependency list frozen with both edges still
   // completing — see the concurrent-completion test below.
@@ -250,7 +262,12 @@ module('Unit | loader seams', function (hooks) {
   test('a registration the loader cannot use fails the module by name', async function (assert) {
     let unusable: Record<string, unknown> = {
       'nothing at all': undefined,
-      'a dependency list that is not a list': { dependencyList: 'not a list' },
+      // Carries a usable implementation, so only the dependency-list arm can
+      // refuse it.
+      'a dependency list that is not a list': {
+        dependencyList: 'not a list',
+        implementation: () => {},
+      },
       'an implementation that is not callable': {
         dependencyList: [],
         implementation: 'not callable',
@@ -333,12 +350,16 @@ module('Unit | loader seams', function (hooks) {
   });
 
   test('moduleMeta decides what import.meta exposes to a module', async function (assert) {
+    // Served under a canonical path that differs from the URL it was reached
+    // by, so "the module's URL" and "the identifier the caller used" are two
+    // distinguishable strings here.
+    server.canonicalPaths.set(server.url('meta.js'), '/canonical-meta.js');
     let denial = { denied: 'the real loader never crosses this boundary' };
     let seen: string[] = [];
     let stubLoader = makeLoader({
-      moduleMeta: (moduleIdentifier) => {
-        seen.push(moduleIdentifier);
-        return { url: moduleIdentifier, loader: denial };
+      moduleMeta: (moduleURL) => {
+        seen.push(moduleURL);
+        return { url: moduleURL, loader: denial };
       },
     });
 
@@ -349,10 +370,10 @@ module('Unit | loader seams', function (hooks) {
 
     assert.deepEqual(
       seen,
-      [server.url('meta.js')],
-      'moduleMeta is asked for the module by its canonical URL',
+      [server.url('canonical-meta.js')],
+      'moduleMeta is asked by the URL the module is canonically known by',
     );
-    assert.strictEqual(module.metaURL(), server.url('meta.js'));
+    assert.strictEqual(module.metaURL(), server.url('canonical-meta.js'));
     assert.strictEqual(
       module.metaLoader(),
       denial,
@@ -712,18 +733,35 @@ module('Unit | loader seams', function (hooks) {
   });
 
   test('invalidateModule accepts the spellings a caller can hold', async function (assert) {
-    await loader.import(server.url('leaf.js'));
+    let spellings = {
+      'an extensionless identifier': server.url('leaf'),
+      'the identifier with its extension': server.url('leaf.js'),
+      'a path that only resolves once normalized': server.url('sub/../leaf.js'),
+      'a URL carrying its default port': `https://loader-seams.test:443/leaf.js`,
+    };
+
+    for (let [description, spelling] of Object.entries(spellings)) {
+      await loader.import(server.url('leaf.js'));
+      assert.strictEqual(
+        loader.invalidateModule(spelling),
+        1,
+        `${description} names the module`,
+      );
+    }
+  });
+
+  test('invalidateModule evicts an importer that broke while evaluating', async function (assert) {
+    await assert.rejects(loader.import(server.url('throws-on-eval.js')));
+    assert.true(loader.isModuleLoaded(server.url('throws-on-eval.js')));
+
     assert.strictEqual(
       loader.invalidateModule(server.url('leaf')),
-      1,
-      'an extensionless identifier names the module',
+      2,
+      'a module cached broken still names what it imported',
     );
-
-    await loader.import(server.url('leaf.js'));
-    assert.strictEqual(
-      loader.invalidateModule(server.url('leaf.js')),
-      1,
-      'so does the identifier with its extension',
+    assert.false(
+      loader.isModuleLoaded(server.url('throws-on-eval.js')),
+      'the failure is not pinned past the replacement of its dependency',
     );
   });
 

--- a/packages/host/tests/unit/loader-seams-test.ts
+++ b/packages/host/tests/unit/loader-seams-test.ts
@@ -1,0 +1,572 @@
+import { module, test } from 'qunit';
+
+import {
+  Loader,
+  type ModuleEvaluator,
+  type ModuleRegistration,
+} from '@cardstack/runtime-common/loader';
+
+const origin = 'https://loader-seams.test/';
+
+// Stands in for a realm serving module source: the tests own what each URL
+// answers with and, where an interleaving is the thing under test, when the
+// answer arrives.
+class SourceServer {
+  sources: Map<string, string>;
+  fetchCounts = new Map<string, number>();
+  #parkedURLs = new Set<string>();
+  #parked: Array<{ url: string; release: (fail: boolean) => void }> = [];
+
+  constructor(sources: Record<string, string>) {
+    this.sources = new Map(
+      Object.entries(sources).map(([path, source]) => [
+        `${origin}${path}`,
+        source,
+      ]),
+    );
+  }
+
+  url(path: string): string {
+    return `${origin}${path}`;
+  }
+
+  fetch: typeof globalThis.fetch = async (urlOrRequest, init) => {
+    let url = new Request(urlOrRequest as RequestInfo, init).url;
+    this.fetchCounts.set(url, (this.fetchCounts.get(url) ?? 0) + 1);
+    // A realm resolves an extensionless import to the file that backs it; the
+    // loader emits dependency URLs without an extension, so answer both. Read
+    // before parking, so a held fetch answers with the source that was current
+    // when it was issued — a response in flight carries the bytes the server
+    // already sent.
+    let source =
+      this.sources.get(url) ??
+      this.sources.get(`${url}.js`) ??
+      this.sources.get(`${url}.gts`);
+    if (this.#parkedURLs.has(url)) {
+      let failed = await new Promise<boolean>((resolve) => {
+        this.#parked.push({ url, release: resolve });
+      });
+      if (failed) {
+        return new Response('server error', { status: 500 });
+      }
+    }
+    if (source == null) {
+      return new Response(`no such module ${url}`, { status: 404 });
+    }
+    return new Response(source, {
+      headers: { 'content-type': 'text/javascript' },
+    });
+  };
+
+  // Hold every subsequent fetch of `url` until the test releases it, so a
+  // second generation of the same module can be started while the first is
+  // still in flight.
+  park(path: string) {
+    this.#parkedURLs.add(this.url(path));
+  }
+
+  parkedCount(path: string): number {
+    let url = this.url(path);
+    return this.#parked.filter((entry) => entry.url === url).length;
+  }
+
+  // Releases one parked fetch by its arrival position, so a test can choose
+  // the order two generations of a module complete in.
+  release(path: string, arrival: number, outcome: 'source' | 'failure') {
+    let url = this.url(path);
+    let parked = this.#parked.filter((entry) => entry.url === url);
+    if (!parked[arrival]) {
+      throw new Error(
+        `no fetch of ${url} has arrived at position ${arrival} (${parked.length} parked)`,
+      );
+    }
+    parked[arrival].release(outcome === 'failure');
+  }
+}
+
+const fixtures = {
+  'leaf.js': `export function leaf() { return 'leaf'; }`,
+  'middle.js': `
+    import { leaf } from './leaf';
+    export function middle() { return 'middle-' + leaf(); }
+  `,
+  'top.js': `
+    import { middle } from './middle';
+    export function top() { return 'top-' + middle(); }
+  `,
+  'unrelated.js': `export function unrelated() { return 'unrelated'; }`,
+  'cycle-a.js': `
+    import { b } from './cycle-b';
+    export function a() { return 'a' + b(); }
+  `,
+  'cycle-b.js': `
+    import { a } from './cycle-a';
+    export function b() { return 'b'; }
+    export function both() { return a(); }
+  `,
+  'meta.js': `
+    export function metaURL() { return import.meta.url; }
+    export function metaLoader() { return import.meta.loader; }
+  `,
+  'gen.js': `export function value() { return 'v1'; }`,
+};
+
+async function waitFor(condition: () => boolean, description: string) {
+  let deadline = Date.now() + 3000;
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+module('Unit | loader seams', function (hooks) {
+  let server: SourceServer;
+  let loader: Loader;
+
+  hooks.beforeEach(function () {
+    server = new SourceServer(fixtures);
+    loader = makeLoader();
+  });
+
+  function makeLoader(options?: {
+    moduleEvaluator?: ModuleEvaluator;
+    moduleMeta?: (moduleIdentifier: string) => object;
+  }): Loader {
+    return new Loader(server.fetch, undefined, options);
+  }
+
+  // A registration the loader can use, synthesized rather than evaluated, so
+  // an evaluator's answer is distinguishable from the module's own source.
+  function stubRegistration(value: string): ModuleRegistration {
+    return {
+      dependencyList: ['exports'],
+      implementation: (exports: Record<string, unknown>) => {
+        exports.leaf = () => value;
+        exports.evaluatedBy = () => 'stub';
+      },
+    };
+  }
+
+  test('a module evaluator supplied at construction replaces evaluation of the source', async function (assert) {
+    let evaluated: string[] = [];
+    let stubLoader = makeLoader({
+      moduleEvaluator: (_source, moduleIdentifier) => {
+        evaluated.push(moduleIdentifier);
+        return stubRegistration('from the injected evaluator');
+      },
+    });
+
+    let module = await stubLoader.import<{
+      leaf(): string;
+      evaluatedBy(): string;
+    }>(server.url('leaf.js'));
+
+    assert.deepEqual(
+      evaluated,
+      [server.url('leaf.js')],
+      'the evaluator was asked for exactly this module',
+    );
+    assert.strictEqual(module.leaf(), 'from the injected evaluator');
+    assert.strictEqual(
+      module.evaluatedBy(),
+      'stub',
+      "the module's own source was never evaluated",
+    );
+  });
+
+  test('an evaluator receives the transpiled AMD registration wrapper', async function (assert) {
+    let sources: string[] = [];
+    let stubLoader = makeLoader({
+      moduleEvaluator: (source) => {
+        sources.push(source);
+        return stubRegistration('stubbed');
+      },
+    });
+
+    await stubLoader.import(server.url('leaf.js'));
+
+    assert.strictEqual(sources.length, 1);
+    assert.true(
+      sources[0].includes('define('),
+      'the source is the AMD registration wrapper, not the original module',
+    );
+    assert.true(
+      sources[0].includes(`//# sourceURL=${server.url('leaf.js')}`),
+      'the source names the module it came from',
+    );
+  });
+
+  test('the loader resolves the dependencies an injected evaluator names', async function (assert) {
+    let stubLoader = makeLoader({
+      moduleEvaluator: (_source, moduleIdentifier) => {
+        if (moduleIdentifier !== server.url('middle.js')) {
+          return {
+            dependencyList: ['exports'],
+            implementation: (exports: Record<string, unknown>) => {
+              exports.leaf = () => 'the real leaf';
+            },
+          };
+        }
+        return {
+          dependencyList: ['exports', './leaf'],
+          implementation: (
+            exports: Record<string, unknown>,
+            leafModule: { leaf(): string },
+          ) => {
+            exports.middle = () => `middle sees ${leafModule.leaf()}`;
+          },
+        };
+      },
+    });
+
+    let module = await stubLoader.import<{ middle(): string }>(
+      server.url('middle.js'),
+    );
+
+    assert.strictEqual(module.middle(), 'middle sees the real leaf');
+  });
+
+  test('a registration the loader cannot use fails the module by name', async function (assert) {
+    let calls = 0;
+    let stubLoader = makeLoader({
+      moduleEvaluator: () => {
+        calls++;
+        return {
+          dependencyList: 'not a list',
+        } as unknown as ModuleRegistration;
+      },
+    });
+
+    for (let attempt of ['first', 'second']) {
+      await assert.rejects(
+        stubLoader.import(server.url('leaf.js')),
+        (err: Error) =>
+          err.message.includes(
+            `Module evaluator returned an invalid registration for ${server.url(
+              'leaf.js',
+            )}`,
+          ),
+        `the ${attempt} import fails with the named registration error`,
+      );
+    }
+    assert.strictEqual(
+      calls,
+      1,
+      'the failure is cached, so the evaluator is not asked again',
+    );
+  });
+
+  test('an injected evaluator is never asked about a shimmed module', async function (assert) {
+    let calls = 0;
+    let stubLoader = makeLoader({
+      moduleEvaluator: () => {
+        calls++;
+        return stubRegistration('stubbed');
+      },
+    });
+    stubLoader.shimModule(server.url('leaf.js'), { leaf: () => 'shimmed' });
+
+    let module = await stubLoader.import<{ leaf(): string }>(
+      server.url('leaf.js'),
+    );
+
+    assert.strictEqual(module.leaf(), 'shimmed');
+    assert.strictEqual(calls, 0, 'a shim has no source to evaluate');
+  });
+
+  test("omitting the evaluator evaluates the module in the loader's own realm", async function (assert) {
+    let module = await loader.import<{ top(): string }>(server.url('top.js'));
+    assert.strictEqual(module.top(), 'top-middle-leaf');
+  });
+
+  test('moduleMeta decides what import.meta exposes to a module', async function (assert) {
+    let denial = { denied: 'the real loader never crosses this boundary' };
+    let seen: string[] = [];
+    let stubLoader = makeLoader({
+      moduleMeta: (moduleIdentifier) => {
+        seen.push(moduleIdentifier);
+        return { url: moduleIdentifier, loader: denial };
+      },
+    });
+
+    let module = await stubLoader.import<{
+      metaURL(): string;
+      metaLoader(): unknown;
+    }>(server.url('meta.js'));
+
+    assert.deepEqual(
+      seen,
+      [server.url('meta.js')],
+      'moduleMeta is asked for the module by its canonical URL',
+    );
+    assert.strictEqual(module.metaURL(), server.url('meta.js'));
+    assert.strictEqual(
+      module.metaLoader(),
+      denial,
+      'the module sees what moduleMeta supplied, not the loader',
+    );
+  });
+
+  test('omitting moduleMeta exposes the loader itself', async function (assert) {
+    let module = await loader.import<{
+      metaURL(): string;
+      metaLoader(): unknown;
+    }>(server.url('meta.js'));
+
+    assert.strictEqual(module.metaURL(), server.url('meta.js'));
+    assert.strictEqual(module.metaLoader(), loader);
+  });
+
+  test('cloneLoader carries the evaluator and moduleMeta', async function (assert) {
+    let denial = { denied: true };
+    let evaluated: string[] = [];
+    let stubLoader = makeLoader({
+      moduleEvaluator: (_source, moduleIdentifier) => {
+        evaluated.push(moduleIdentifier);
+        return {
+          dependencyList: ['exports', '__import_meta__'],
+          implementation: (
+            exports: Record<string, unknown>,
+            meta: { loader: unknown },
+          ) => {
+            exports.metaLoader = () => meta.loader;
+          },
+        };
+      },
+      moduleMeta: (moduleIdentifier) => ({
+        url: moduleIdentifier,
+        loader: denial,
+      }),
+    });
+
+    let clone = Loader.cloneLoader(stubLoader);
+    let module = await clone.import<{ metaLoader(): unknown }>(
+      server.url('meta.js'),
+    );
+
+    assert.deepEqual(
+      evaluated,
+      [server.url('meta.js')],
+      'the clone evaluates through the same evaluator',
+    );
+    assert.strictEqual(
+      module.metaLoader(),
+      denial,
+      'the clone exposes the same import.meta',
+    );
+  });
+
+  test('isShimmedModule recognizes a shim under any spelling of the same module', async function (assert) {
+    loader.shimModule(server.url('shimmed.gts'), { shimmed: true });
+
+    for (let spelling of ['shimmed.gts', 'shimmed', 'shimmed.ts']) {
+      assert.true(
+        loader.isShimmedModule(server.url(spelling)),
+        `${spelling} names the shimmed module`,
+      );
+    }
+  });
+
+  test('isShimmedModule is false for a module with fetchable source', async function (assert) {
+    assert.false(loader.isShimmedModule(server.url('leaf.js')));
+    await loader.import(server.url('leaf.js'));
+    assert.false(
+      loader.isShimmedModule(server.url('leaf.js')),
+      'importing source does not make a module a shim',
+    );
+  });
+
+  test('isShimmedModule recognizes a shim that arrived from the fetch response', async function (assert) {
+    let shim = { fromTheNetwork: () => 'shimmed' };
+    let shimServingLoader = new Loader(async () => {
+      let response = new Response();
+      (response as any)[Symbol.for('shimmed-module')] = shim;
+      return response;
+    });
+
+    assert.false(
+      shimServingLoader.isShimmedModule(server.url('served-shim.gts')),
+      'nothing is known about the module before it is loaded',
+    );
+    await shimServingLoader.import(server.url('served-shim.gts'));
+    assert.true(
+      shimServingLoader.isShimmedModule(server.url('served-shim')),
+      'a shim discovered over the network is a shim under every spelling',
+    );
+  });
+
+  test('invalidateModule evicts the module and the modules that import it', async function (assert) {
+    await loader.import(server.url('top.js'));
+    await loader.import(server.url('unrelated.js'));
+
+    assert.strictEqual(
+      loader.invalidateModule(server.url('middle.js')),
+      2,
+      'the module and its one importer are removed',
+    );
+    assert.false(loader.isModuleLoaded(server.url('middle.js')));
+    assert.false(
+      loader.isModuleLoaded(server.url('top.js')),
+      'an importer closed over the replaced exports, so it goes too',
+    );
+    assert.true(
+      loader.isModuleLoaded(server.url('leaf.js')),
+      'a dependency of the invalidated module is untouched',
+    );
+    assert.true(
+      loader.isModuleLoaded(server.url('unrelated.js')),
+      'an unrelated module is untouched',
+    );
+  });
+
+  test('invalidateModule fans in through an import cycle', async function (assert) {
+    await loader.import(server.url('cycle-a.js'));
+
+    assert.strictEqual(
+      loader.invalidateModule(server.url('cycle-b.js')),
+      2,
+      'the module that closed the cycle is a dependent too',
+    );
+    assert.false(loader.isModuleLoaded(server.url('cycle-a.js')));
+    assert.false(loader.isModuleLoaded(server.url('cycle-b.js')));
+  });
+
+  test('an invalidated module and its importers re-import the new source', async function (assert) {
+    let first = await loader.import<{ top(): string }>(server.url('top.js'));
+    assert.strictEqual(first.top(), 'top-middle-leaf');
+    let unrelatedFetches = server.fetchCounts.get(server.url('unrelated.js'));
+
+    server.sources.set(
+      server.url('leaf.js'),
+      `export function leaf() { return 'leaf-v2'; }`,
+    );
+    assert.strictEqual(loader.invalidateModule(server.url('leaf.js')), 3);
+
+    let second = await loader.import<{ top(): string }>(server.url('top.js'));
+    assert.strictEqual(
+      second.top(),
+      'top-middle-leaf-v2',
+      'every module that consumed the replaced one is rebuilt on it',
+    );
+    assert.strictEqual(
+      server.fetchCounts.get(server.url('unrelated.js')),
+      unrelatedFetches,
+      'nothing outside the dependent set was refetched',
+    );
+  });
+
+  test('invalidating a module discards the cached dependency sets that reached it', async function (assert) {
+    await loader.import(server.url('top.js'));
+    assert.deepEqual(
+      loader.getKnownConsumedModules(server.url('top.js')).sort(),
+      [server.url('leaf'), server.url('middle')],
+      'the dependency set is cached off the first walk',
+    );
+
+    server.sources.set(
+      server.url('middle.js'),
+      `import { leaf } from './leaf';
+       import { unrelated } from './unrelated';
+       export function middle() { return 'middle-' + leaf() + unrelated(); }`,
+    );
+    loader.invalidateModule(server.url('middle.js'));
+    await loader.import(server.url('top.js'));
+
+    assert.deepEqual(
+      loader.getKnownConsumedModules(server.url('top.js')).sort(),
+      [server.url('leaf'), server.url('middle'), server.url('unrelated')],
+      'the dependency set is rebuilt on the replaced module',
+    );
+  });
+
+  test('invalidateModule accepts the spellings a caller can hold', async function (assert) {
+    await loader.import(server.url('leaf.js'));
+    assert.strictEqual(
+      loader.invalidateModule(server.url('leaf')),
+      1,
+      'an extensionless identifier names the module',
+    );
+
+    await loader.import(server.url('leaf.js'));
+    assert.strictEqual(
+      loader.invalidateModule(server.url('leaf.js')),
+      1,
+      'so does the identifier with its extension',
+    );
+  });
+
+  test('invalidateModule reports nothing removed for a module this loader never loaded', async function (assert) {
+    await loader.import(server.url('leaf.js'));
+    assert.strictEqual(loader.invalidateModule(server.url('absent.js')), 0);
+    assert.strictEqual(
+      loader.invalidateModule('not-a-url'),
+      0,
+      'an identifier that resolves to nothing removes nothing',
+    );
+    assert.true(
+      loader.isModuleLoaded(server.url('leaf.js')),
+      'invalidating an unknown module leaves the cache alone',
+    );
+  });
+
+  test('a response that arrives after its fetch was invalidated does not replace the newer module', async function (assert) {
+    server.park('gen.js');
+    let stale = loader.import<{ value(): string }>(server.url('gen.js'));
+    await waitFor(() => server.parkedCount('gen.js') === 1, 'the first fetch');
+
+    assert.strictEqual(
+      loader.invalidateModule(server.url('gen.js')),
+      1,
+      'the in-flight fetch is the entry that gets removed',
+    );
+    server.sources.set(
+      server.url('gen.js'),
+      `export function value() { return 'v2'; }`,
+    );
+    let current = loader.import<{ value(): string }>(server.url('gen.js'));
+    await waitFor(() => server.parkedCount('gen.js') === 2, 'the second fetch');
+
+    server.release('gen.js', 1, 'source');
+    assert.strictEqual((await current).value(), 'v2');
+
+    server.release('gen.js', 0, 'source');
+    assert.strictEqual(
+      (await stale).value(),
+      'v2',
+      'the invalidated import resolves against the replacement',
+    );
+
+    let later = await loader.import<{ value(): string }>(server.url('gen.js'));
+    assert.strictEqual(
+      later.value(),
+      'v2',
+      'the stale response did not overwrite the cached module',
+    );
+  });
+
+  test('a failure that arrives after its fetch was invalidated does not evict the newer module', async function (assert) {
+    server.park('gen.js');
+    let stale = loader.import<{ value(): string }>(server.url('gen.js'));
+    await waitFor(() => server.parkedCount('gen.js') === 1, 'the first fetch');
+
+    loader.invalidateModule(server.url('gen.js'));
+    let current = loader.import<{ value(): string }>(server.url('gen.js'));
+    await waitFor(() => server.parkedCount('gen.js') === 2, 'the second fetch');
+
+    server.release('gen.js', 1, 'source');
+    assert.strictEqual((await current).value(), 'v1');
+
+    server.release('gen.js', 0, 'failure');
+    assert.strictEqual(
+      (await stale).value(),
+      'v1',
+      'the invalidated import resolves against the replacement',
+    );
+    assert.true(
+      loader.isModuleLoaded(server.url('gen.js')),
+      'the stale failure did not evict the module that replaced it',
+    );
+  });
+});

--- a/packages/host/tests/unit/loader-seams-test.ts
+++ b/packages/host/tests/unit/loader-seams-test.ts
@@ -794,6 +794,36 @@ module('Unit | loader seams', function (hooks) {
     );
   });
 
+  test('a dependency walk taken while a module is still fetching is not memoized', async function (assert) {
+    await loader.import(server.url('top.js'));
+
+    // The re-import holds `top` in the map as a fetching record for the whole
+    // round trip, so unlike an evicted module it is present — and present with
+    // no dependencies named yet.
+    server.park('top.js');
+    loader.invalidateModule(server.url('leaf'));
+    let reimport = loader.import(server.url('top.js'));
+    await waitFor(
+      () => server.parkedCount('top.js') === 1,
+      'the re-import to be in flight',
+    );
+
+    assert.deepEqual(
+      loader.getKnownConsumedModules(server.url('top.js')),
+      [],
+      'a module that has not named its dependencies yet reports none',
+    );
+
+    server.unpark('top.js');
+    server.release('top.js', 0, 'source');
+    await reimport;
+    assert.deepEqual(
+      loader.getKnownConsumedModules(server.url('top.js')).sort(),
+      [server.url('leaf'), server.url('middle')],
+      'that walk did not outlive the fetch it was taken during',
+    );
+  });
+
   test('an eviction landing after the graph is walked re-enters instead of failing the import', async function (assert) {
     // The read this covers happens after the walk has resolved, so no fetch
     // can reach it — driving the interleaving means stepping in where the

--- a/packages/host/tests/unit/loader-seams-test.ts
+++ b/packages/host/tests/unit/loader-seams-test.ts
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 
+import { VirtualNetwork } from '@cardstack/runtime-common';
 import {
   Loader,
   type ModuleEvaluator,
@@ -70,6 +71,10 @@ class SourceServer {
     return this.#parked.filter((entry) => entry.url === url).length;
   }
 
+  unpark(path: string) {
+    this.#parkedURLs.delete(this.url(path));
+  }
+
   // Releases one parked fetch by its arrival position, so a test can choose
   // the order two generations of a module complete in.
   release(path: string, arrival: number, outcome: 'source' | 'failure') {
@@ -109,6 +114,20 @@ const fixtures = {
     export function metaLoader() { return import.meta.loader; }
   `,
   'gen.js': `export function value() { return 'v1'; }`,
+  // `./race-b` before `./race-slow`, and a two-module cycle through race-b,
+  // is what leaves race-a's dependency list frozen with both edges still
+  // completing — see the concurrent-completion test below.
+  'race-a.js': `
+    import { b } from './race-b';
+    import { slow } from './race-slow';
+    export function a() { return 'a'; }
+    export function reads() { return b + slow; }
+  `,
+  'race-b.js': `
+    import { a } from './race-a';
+    export const b = 'b';
+  `,
+  'race-slow.js': `export const slow = 'v1';`,
 };
 
 async function waitFor(condition: () => boolean, description: string) {
@@ -229,32 +248,64 @@ module('Unit | loader seams', function (hooks) {
   });
 
   test('a registration the loader cannot use fails the module by name', async function (assert) {
-    let calls = 0;
-    let stubLoader = makeLoader({
-      moduleEvaluator: () => {
-        calls++;
-        return {
-          dependencyList: 'not a list',
-        } as unknown as ModuleRegistration;
+    let unusable: Record<string, unknown> = {
+      'nothing at all': undefined,
+      'a dependency list that is not a list': { dependencyList: 'not a list' },
+      'an implementation that is not callable': {
+        dependencyList: [],
+        implementation: 'not callable',
       },
-    });
+    };
 
-    for (let attempt of ['first', 'second']) {
-      await assert.rejects(
-        stubLoader.import(server.url('leaf.js')),
-        (err: Error) =>
-          err.message.includes(
-            `Module evaluator returned an invalid registration for ${server.url(
-              'leaf.js',
-            )}`,
-          ),
-        `the ${attempt} import fails with the named registration error`,
+    for (let [description, registration] of Object.entries(unusable)) {
+      let calls = 0;
+      let stubLoader = makeLoader({
+        moduleEvaluator: () => {
+          calls++;
+          return registration as unknown as ModuleRegistration;
+        },
+      });
+
+      for (let attempt of ['first', 'second']) {
+        await assert.rejects(
+          stubLoader.import(server.url('leaf.js')),
+          (err: Error) =>
+            err.message.includes(
+              `Module evaluator returned an invalid registration for ${server.url(
+                'leaf.js',
+              )}`,
+            ),
+          `${description}: the ${attempt} import fails with the named registration error`,
+        );
+      }
+      assert.strictEqual(
+        calls,
+        1,
+        `${description}: the failure is cached, so the evaluator is not asked again`,
       );
     }
-    assert.strictEqual(
-      calls,
-      1,
-      'the failure is cached, so the evaluator is not asked again',
+  });
+
+  test('a realm-mapping change discards what a fetch answered with', async function (assert) {
+    let virtualNetwork = new VirtualNetwork(async () => {
+      let response = new Response();
+      (response as any)[Symbol.for('shimmed-module')] = { shimmed: true };
+      return response;
+    });
+    virtualNetwork.addRealmMapping('@seams-remap/', origin);
+    let mappedLoader = new Loader(
+      virtualNetwork.fetch,
+      virtualNetwork.resolveImport,
+      { virtualNetwork },
+    );
+
+    await mappedLoader.import('@seams-remap/served-shim.gts');
+    assert.true(mappedLoader.isShimmedModule('@seams-remap/served-shim'));
+
+    virtualNetwork.addRealmMapping('@seams-remap-other/', origin);
+    assert.false(
+      mappedLoader.isShimmedModule('@seams-remap/served-shim'),
+      'the record is keyed by a spelling only the previous mapping set defines',
     );
   });
 
@@ -478,6 +529,151 @@ module('Unit | loader seams', function (hooks) {
       loader.getKnownConsumedModules(server.url('top.js')).sort(),
       [server.url('leaf'), server.url('middle'), server.url('unrelated')],
       'the dependency set is rebuilt on the replaced module',
+    );
+  });
+
+  // The loader records a dependency as `completing-dep` when it is still
+  // completing on the recording task's own recursion stack. A second import
+  // root entering during that window (the interleaving
+  // `loader-concurrent-cycle-test` pins) leaves the first module evaluating
+  // straight out of that state, so those edges are the only record of what it
+  // imported — and one of them here is not part of any cycle.
+  test('invalidateModule reaches a dependency that was still completing when its importer evaluated', async function (assert) {
+    server.park('race-slow');
+    // Every module here is named by its extensionless spelling, the one
+    // race-b's import of race-a produces: the completing-dep bookkeeping
+    // compares raw identifiers, so a root imported by a different spelling of
+    // the same module does not enter this interleaving at all.
+    let root1 = loader.import<{ reads(): string }>(server.url('race-a'));
+    await waitFor(
+      () => server.parkedCount('race-slow') === 1,
+      'the slow dependency to be requested',
+    );
+    let root2 = loader.import(server.url('race-b'));
+    server.release('race-slow', 0, 'source');
+    let [moduleA] = await Promise.all([root1, root2]);
+    assert.strictEqual(moduleA.reads(), 'bv1');
+
+    server.unpark('race-slow');
+    server.sources.set(server.url('race-slow.js'), `export const slow = 'v2';`);
+    assert.strictEqual(
+      loader.invalidateModule(server.url('race-slow')),
+      3,
+      'the importer whose edges were still completing is a dependent too',
+    );
+
+    let reimported = await loader.import<{ reads(): string }>(
+      server.url('race-a'),
+    );
+    assert.strictEqual(
+      reimported.reads(),
+      'bv2',
+      'no copy of the replaced module survives in an importer',
+    );
+  });
+
+  test('invalidateModule reaches an importer whose dependency is still completing', async function (assert) {
+    server.park('race-slow');
+    let root1 = loader.import(server.url('race-a'));
+    await waitFor(
+      () => server.parkedCount('race-slow') === 1,
+      'the slow dependency to be requested',
+    );
+    // Entering at race-b while the first root is suspended leaves race-b
+    // holding race-a as a dependency that is still completing — the state the
+    // eviction has to read before either module reaches evaluation.
+    let root2 = loader.import(server.url('race-b'));
+    await waitFor(
+      () => loader.isModuleLoaded(server.url('race-b')),
+      'the second root to register race-b',
+    );
+
+    assert.strictEqual(
+      loader.invalidateModule(server.url('race-a')),
+      2,
+      'the importer goes even though neither module has evaluated',
+    );
+
+    server.unpark('race-slow');
+    server.release('race-slow', 0, 'source');
+    let settled = await Promise.allSettled([root1, root2]);
+    assert.deepEqual(
+      settled.map((outcome) => outcome.status),
+      ['fulfilled', 'fulfilled'],
+      'both in-flight roots complete against the refetched modules',
+    );
+  });
+
+  test('invalidateModule evicts importers that have registered but not evaluated', async function (assert) {
+    server.park('leaf');
+    let pending = loader.import<{ top(): string }>(server.url('top.js'));
+    await waitFor(
+      () => server.parkedCount('leaf') === 1,
+      'the leaf fetch to be issued',
+    );
+
+    assert.strictEqual(
+      loader.invalidateModule(server.url('leaf')),
+      3,
+      'a registered importer names its dependencies before it evaluates',
+    );
+
+    server.sources.set(
+      server.url('leaf.js'),
+      `export function leaf() { return 'leaf-v2'; }`,
+    );
+    server.unpark('leaf');
+    server.release('leaf', 0, 'source');
+    assert.strictEqual(
+      (await pending).top(),
+      'top-middle-leaf-v2',
+      'the suspended import completes against the replacement',
+    );
+  });
+
+  // Every loader the host builds carries a VirtualNetwork and its import
+  // resolution, which is what folds a module's realm-prefix, virtual-alias and
+  // real-URL spellings onto one cache key.
+  test('the seams address a module by any spelling a realm mapping gives it', async function (assert) {
+    let virtualNetwork = new VirtualNetwork(server.fetch);
+    virtualNetwork.addRealmMapping('@seams-test/', origin);
+    let mappedLoader = new Loader(
+      virtualNetwork.fetch,
+      virtualNetwork.resolveImport,
+      { virtualNetwork },
+    );
+
+    await mappedLoader.import(server.url('top.js'));
+    mappedLoader.shimModule('@seams-test/shimmed.gts', { shimmed: true });
+
+    for (let spelling of [
+      '@seams-test/shimmed',
+      '@seams-test/shimmed.gts',
+      `${origin}shimmed.ts`,
+    ]) {
+      assert.true(
+        mappedLoader.isShimmedModule(spelling),
+        `${spelling} names the shimmed module`,
+      );
+    }
+
+    assert.strictEqual(
+      mappedLoader.invalidateModule('@seams-test/middle'),
+      2,
+      'the realm-prefix spelling names the module the cache keyed by',
+    );
+    assert.false(mappedLoader.isModuleLoaded(server.url('middle.js')));
+    assert.true(mappedLoader.isModuleLoaded(server.url('leaf.js')));
+
+    // A bare package specifier is a module identity too, and only import
+    // resolution turns it into the URL the loader files it under — the form
+    // authored code names a trusted package by.
+    mappedLoader.shimModule('a-bare-package', { bare: true });
+    assert.true(mappedLoader.isShimmedModule('a-bare-package'));
+    assert.strictEqual(
+      mappedLoader.invalidateModule('a-bare-package'),
+      1,
+      'a bare specifier resolves to the module it was filed under',
     );
   });
 

--- a/packages/host/tests/unit/loader-seams-test.ts
+++ b/packages/host/tests/unit/loader-seams-test.ts
@@ -481,6 +481,40 @@ module('Unit | loader seams', function (hooks) {
     );
   });
 
+  test('invalidating a module forgets that its last fetch answered with a shim', async function (assert) {
+    let shim = { fromTheNetwork: () => 'shimmed' };
+    let servesShim = true;
+    let switching = new Loader(async () => {
+      if (servesShim) {
+        let response = new Response();
+        (response as any)[Symbol.for('shimmed-module')] = shim;
+        return response;
+      }
+      return new Response(`export function value() { return 'source'; }`, {
+        headers: { 'content-type': 'text/javascript' },
+      });
+    });
+
+    await switching.import(server.url('switching.gts'));
+    assert.true(switching.isShimmedModule(server.url('switching.gts')));
+
+    servesShim = false;
+    switching.invalidateModule(server.url('switching.gts'));
+    assert.false(
+      switching.isShimmedModule(server.url('switching.gts')),
+      'the eviction forgets what the last fetch answered with',
+    );
+
+    let module = await switching.import<{ value(): string }>(
+      server.url('switching.gts'),
+    );
+    assert.strictEqual(module.value(), 'source');
+    assert.false(
+      switching.isShimmedModule(server.url('switching.gts')),
+      'a module now served as source is not a shim',
+    );
+  });
+
   test('invalidateModule accepts the spellings a caller can hold', async function (assert) {
     await loader.import(server.url('leaf.js'));
     assert.strictEqual(

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -45,6 +45,11 @@ type RegisteredWithDepsModule = {
   implementation: Function;
 };
 
+// Import edges that were still completing when a module's dependency list was
+// frozen — recorded apart from `consumedModules`, which holds only the edges
+// that had resolved by then. Both together are the module's imports.
+type CompletingDependencies = { completingDependencies: string[] };
+
 type PreparingModule = {
   // this state represents the *synchronous* window of time where this
   // module's dependencies are moving from registered to preparing to
@@ -55,19 +60,19 @@ type PreparingModule = {
   implementation: Function;
   moduleInstance: object;
   consumedModules: Set<string>;
-};
+} & CompletingDependencies;
 
 type EvaluatedModule = {
   state: 'evaluated';
   moduleInstance: object;
   consumedModules: Set<string>;
-};
+} & CompletingDependencies;
 
 type BrokenModule = {
   state: 'broken';
   exception: any;
   consumedModules: Set<string>;
-};
+} & CompletingDependencies;
 
 type Module =
   | FetchingModule
@@ -122,9 +127,12 @@ export type ModuleEvaluator = (
   moduleIdentifier: string,
 ) => ModuleRegistration;
 
+// The parameter names are deliberately unlikely ones: `eval` runs the module
+// inside this function's scope, so every local here is a name the module can
+// read instead of getting the ReferenceError an undeclared identifier owes it.
 function evaluateModuleInCurrentRealm(
-  source: string,
-  moduleIdentifier: string,
+  amdSource: string,
+  amdModuleIdentifier: string,
 ): ModuleRegistration {
   type DefineFunc = ((
     mid: string,
@@ -141,9 +149,9 @@ function evaluateModuleInCurrentRealm(
   let define = ((_mid: string, dependencyList: string[], impl: Function) => {
     define.registration = { dependencyList, implementation: impl };
   }) as DefineFunc;
-  eval(source);
+  eval(amdSource);
   if (!define.registration) {
-    throw new Error(`Module ${moduleIdentifier} did not register itself`);
+    throw new Error(`Module ${amdModuleIdentifier} did not register itself`);
   }
   return define.registration;
 }
@@ -237,13 +245,23 @@ export class Loader {
   private modules = new Map<string, Module>();
 
   private moduleShims = new Map<string, Record<string, any>>();
-  // Module identifiers whose fetch answered with a host-registered value
+  // Cache keys of modules whose fetch answered with a host-registered value
   // instead of source (a realm or the package-shim handler marks the response
   // with `Symbol.for('shimmed-module')`). Recorded so `isShimmedModule` is
   // truthful about every shim this loader has loaded, not only the ones
-  // registered here through `shimModule`. Kept apart from `moduleShims` so
-  // discovering a shim over the network doesn't also make this loader answer
-  // fetches for it or seed it into a clone.
+  // registered here through `shimModule`. This is where nearly every shim
+  // lands, because the host registers its externals on the virtual network
+  // rather than on the loader.
+  //
+  // Deliberately not `moduleShims`, which is read for three other decisions a
+  // shim discovered over the network must not change: `_fetch` answers from
+  // it without going to the network, `cloneLoader` re-registers all of it into
+  // the clone, and `import` skips dependency tracking for anything in it — so
+  // writing there would drop index dependency edges for every realm-served
+  // module after its first load.
+  //
+  // Keys are only stable between realm-mapping changes, so this is discarded
+  // with the other mapping-derived caches when a mapping changes.
   private fetchedModuleShims = new Set<string>();
   private moduleCanonicalURLs = new Map<string, string>();
   // Cache the flattened dependency sets for evaluated modules. Once a module is
@@ -277,7 +295,7 @@ export class Loader {
   // setTimeout so the retry actually fires.
   private retrySleep: ((ms: number) => Promise<void>) | undefined;
   private moduleEvaluator: ModuleEvaluator;
-  private moduleMeta: ((moduleIdentifier: string) => object) | undefined;
+  private moduleMeta: ((moduleURL: string) => object) | undefined;
 
   constructor(
     fetch: Fetch,
@@ -286,7 +304,9 @@ export class Loader {
       retrySleep?: (ms: number) => Promise<void>;
       virtualNetwork?: VirtualNetwork;
       moduleEvaluator?: ModuleEvaluator;
-      moduleMeta?: (moduleIdentifier: string) => object;
+      // Receives what `import.meta.url` carries for the module: its canonical
+      // URL where one is known, otherwise the identifier it was reached by.
+      moduleMeta?: (moduleURL: string) => object;
     },
   ) {
     this.fetchImplementation = fetch;
@@ -399,6 +419,7 @@ export class Loader {
       state: 'evaluated',
       moduleInstance: module,
       consumedModules: new Set(),
+      completingDependencies: [],
     });
   }
 
@@ -414,21 +435,18 @@ export class Loader {
   // one spelling while a captured class identity carries another.
   isShimmedModule(moduleIdentifier: string): boolean {
     let resolved = this.resolveImport(moduleIdentifier);
-    if (
-      this.moduleShims.has(resolved) ||
-      this.fetchedModuleShims.has(resolved)
-    ) {
+    if (this.moduleShims.has(resolved)) {
       return true;
     }
     let key = this.moduleCacheKey(resolved);
-    for (let identifiers of [
-      this.moduleShims.keys(),
-      this.fetchedModuleShims,
-    ]) {
-      for (let shimIdentifier of identifiers) {
-        if (this.moduleCacheKey(shimIdentifier) === key) {
-          return true;
-        }
+    if (this.fetchedModuleShims.has(key)) {
+      return true;
+    }
+    // `moduleShims` is keyed by the identifier it was registered under, so
+    // reaching the rest of the identity family means folding each one.
+    for (let shimIdentifier of this.moduleShims.keys()) {
+      if (this.moduleCacheKey(shimIdentifier) === key) {
+        return true;
       }
     }
     return false;
@@ -440,16 +458,17 @@ export class Loader {
   //
   // Importers go too because an evaluated module closed over the exports of
   // the one being replaced and would keep serving the old code. The fan-in
-  // reaches only the import edges this loader already knows about: a module
-  // this loader never loaded holds nothing that can go stale.
+  // reaches only modules this loader has cached: one it never loaded holds
+  // nothing that can go stale.
   invalidateModule(moduleIdentifier: string): number {
     let resolved = this.resolveImport(moduleIdentifier);
     let target: string;
     try {
       // Normalize through `URL` so a caller holding a non-canonical URL
-      // spelling still names the key the module was stored under. A
-      // realm-prefix identifier is not a URL at all and is already in the
-      // canonical key form, so it passes through untouched.
+      // spelling still names the key the module was stored under. An
+      // identifier that is not a URL — what a loader with no import
+      // resolution is handed, and the form `shimModule` accepts — is already
+      // the key form and passes through untouched.
       target = this.moduleCacheKey(new URL(resolved).href);
     } catch (error) {
       if (!(error instanceof TypeError)) {
@@ -459,8 +478,8 @@ export class Loader {
     }
 
     // Reverse the import edges in one pass over the module map, then walk out
-    // from the target. This runs on every authored-code edit, so the map is
-    // scanned once rather than once per level of the dependent chain.
+    // from the target, so the map is scanned once rather than once per level
+    // of the dependent chain.
     let importers = new Map<string, string[]>();
     for (let [key, module] of this.modules) {
       for (let dependency of this.directModuleDependencies(module)) {
@@ -491,17 +510,13 @@ export class Loader {
         removed++;
       }
       this.moduleCanonicalURLs.delete(key);
-    }
-    // What an evicted module's last fetch answered with is part of what is
-    // being evicted: a module that answered with a host-registered value once
-    // may answer with source next time, and `isShimmedModule` would otherwise
-    // keep routing that source away from evaluation. A shim registered here
-    // through `shimModule` is a standing registration rather than something
-    // learned from a fetch, so it survives and re-serves the next import.
-    for (let identifier of this.fetchedModuleShims) {
-      if (invalidated.has(this.moduleCacheKey(identifier))) {
-        this.fetchedModuleShims.delete(identifier);
-      }
+      // What a module's last fetch answered with is part of what is being
+      // evicted: a module that answered with a host-registered value once may
+      // answer with source next time, and `isShimmedModule` would otherwise
+      // keep routing that source away from evaluation. A shim registered
+      // through `shimModule` is a standing registration rather than something
+      // learned from a fetch, so it survives and re-serves the next import.
+      this.fetchedModuleShims.delete(key);
     }
     // Any cached dependency set that reached an evicted module is stale, and
     // deciding which ones costs the same walk as recomputing them on demand.
@@ -510,16 +525,16 @@ export class Loader {
   }
 
   // The modules a cached module imports, in whatever state it is in. The
-  // registered states carry their dependency list, cycle-completing edges
-  // included — an import that closed a cycle is still an import. An
-  // evaluated, preparing, or broken module carries the set it consumed, and a
-  // module still fetching has named nothing yet.
+  // registered states carry their dependency list; the states past them carry
+  // it split in two, because `consumedModules` — the set the dependency
+  // tracker reads — holds only the edges that had resolved when the list was
+  // frozen. A module still fetching has named nothing yet.
   private directModuleDependencies(module: Module): string[] {
     switch (module.state) {
       case 'evaluated':
       case 'preparing':
       case 'broken':
-        return [...module.consumedModules];
+        return [...module.consumedModules, ...module.completingDependencies];
       case 'registered':
         return module.dependencyList.flatMap((entry) =>
           entry.type === 'dep' ? [entry.moduleURL.href] : [],
@@ -1277,12 +1292,13 @@ export class Loader {
 
     if (loaded.type === 'shimmed') {
       this.captureIdentitiesOfModuleExports(loaded.module, moduleIdentifier);
-      this.fetchedModuleShims.add(moduleIdentifier);
+      this.fetchedModuleShims.add(this.moduleCacheKey(moduleIdentifier));
 
       this.setModule(moduleIdentifier, {
         state: 'evaluated',
         moduleInstance: loaded.module,
         consumedModules: new Set(),
+        completingDependencies: [],
       });
       module.deferred.fulfill();
       return;
@@ -1297,6 +1313,7 @@ export class Loader {
         state: 'broken',
         exception,
         consumedModules: new Set(), // we blew up before we could understand what was inside ourselves
+        completingDependencies: [],
       });
       module.deferred.fulfill();
       throw exception;
@@ -1349,6 +1366,7 @@ export class Loader {
         state: 'broken',
         exception,
         consumedModules: new Set(), // we blew up before we could understand what was inside ourselves
+        completingDependencies: [],
       });
       module.deferred.fulfill();
       throw exception;
@@ -1380,12 +1398,21 @@ export class Loader {
         dep.type === 'dep' ? [dep.moduleURL.href] : [],
       ),
     );
+    // A dependency that was still completing when this module's list was
+    // frozen is an import all the same, and this is the last place it is
+    // written down: the entry is dropped as the module leaves the registered
+    // states. Invalidation reads it, so a module does not survive the
+    // eviction of something whose exports it holds.
+    let completingDependencies = flatMap(module.dependencies, (dep) =>
+      dep.type === 'completing-dep' ? [dep.moduleURL.href] : [],
+    );
 
     this.setModule(moduleIdentifier, {
       state: 'preparing',
       implementation: module.implementation,
       moduleInstance: moduleProxy,
       consumedModules,
+      completingDependencies,
     });
 
     try {
@@ -1450,6 +1477,7 @@ export class Loader {
         state: 'evaluated',
         moduleInstance: moduleProxy,
         consumedModules,
+        completingDependencies,
       });
       return moduleProxy;
     } catch (exception) {
@@ -1457,6 +1485,7 @@ export class Loader {
         state: 'broken',
         exception,
         consumedModules,
+        completingDependencies,
       });
       throw exception;
     }

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -106,6 +106,48 @@ export type RequestHandler = (req: Request) => Promise<Response | null>;
 
 type Fetch = typeof fetch;
 
+export interface ModuleRegistration {
+  dependencyList: string[];
+  implementation: Function;
+}
+
+// Evaluates the AMD registration wrapper `transpileAmd` produces and hands
+// back what the module registered. This is the seam that decides *where* a
+// module's code runs: the default evaluates it in the loader's own realm,
+// while a caller that must run authored code somewhere else — a SES
+// Compartment, an iframe child — supplies an evaluator whose `define` binding
+// lives there.
+export type ModuleEvaluator = (
+  source: string,
+  moduleIdentifier: string,
+) => ModuleRegistration;
+
+function evaluateModuleInCurrentRealm(
+  source: string,
+  moduleIdentifier: string,
+): ModuleRegistration {
+  type DefineFunc = ((
+    mid: string,
+    dependencyList: string[],
+    impl: Function,
+  ) => void) & {
+    registration?: ModuleRegistration;
+  };
+
+  // this local is here for the evals to see. We're sticking the registration
+  // onto the function itself because that's a convenient way to ensure that
+  // build tools like Rollup don't optimize it away. Rollup violates the JS
+  // spec by removing a local that's visible to `eval`.
+  let define = ((_mid: string, dependencyList: string[], impl: Function) => {
+    define.registration = { dependencyList, implementation: impl };
+  }) as DefineFunc;
+  eval(source);
+  if (!define.registration) {
+    throw new Error(`Module ${moduleIdentifier} did not register itself`);
+  }
+  return define.registration;
+}
+
 // Transient upstream statuses that we briefly retry on module-source fetches
 // (e.g. nginx returning 502/503/504 while the single-writer realm server is
 // momentarily stalled under reindex load — see CS-10820). Kept private so
@@ -195,6 +237,14 @@ export class Loader {
   private modules = new Map<string, Module>();
 
   private moduleShims = new Map<string, Record<string, any>>();
+  // Module identifiers whose fetch answered with a host-registered value
+  // instead of source (a realm or the package-shim handler marks the response
+  // with `Symbol.for('shimmed-module')`). Recorded so `isShimmedModule` is
+  // truthful about every shim this loader has loaded, not only the ones
+  // registered here through `shimModule`. Kept apart from `moduleShims` so
+  // discovering a shim over the network doesn't also make this loader answer
+  // fetches for it or seed it into a clone.
+  private fetchedModuleShims = new Set<string>();
   private moduleCanonicalURLs = new Map<string, string>();
   // Cache the flattened dependency sets for evaluated modules. Once a module is
   // evaluated its consumedModules never change, so the result of
@@ -226,6 +276,8 @@ export class Loader {
   // host injects a sleep that goes through the native (unblocked)
   // setTimeout so the retry actually fires.
   private retrySleep: ((ms: number) => Promise<void>) | undefined;
+  private moduleEvaluator: ModuleEvaluator;
+  private moduleMeta: ((moduleIdentifier: string) => object) | undefined;
 
   constructor(
     fetch: Fetch,
@@ -233,6 +285,8 @@ export class Loader {
     options?: {
       retrySleep?: (ms: number) => Promise<void>;
       virtualNetwork?: VirtualNetwork;
+      moduleEvaluator?: ModuleEvaluator;
+      moduleMeta?: (moduleIdentifier: string) => object;
     },
   ) {
     this.fetchImplementation = fetch;
@@ -240,6 +294,9 @@ export class Loader {
       resolveImport ?? ((moduleIdentifier) => moduleIdentifier);
     this.retrySleep = options?.retrySleep;
     this.virtualNetwork = options?.virtualNetwork;
+    this.moduleEvaluator =
+      options?.moduleEvaluator ?? evaluateModuleInCurrentRealm;
+    this.moduleMeta = options?.moduleMeta;
     // Module caches are keyed by canonical RRI form (see moduleCacheKey), whose
     // relationship to a real URL is only stable between realm-mapping changes.
     // Discard the RRI-keyed caches whenever a mapping is added or removed so an
@@ -249,6 +306,7 @@ export class Loader {
       this.moduleCanonicalURLs.clear();
       this.knownDepsCache.clear();
       this.trackingKeyCache.clear();
+      this.fetchedModuleShims.clear();
     });
   }
 
@@ -269,6 +327,8 @@ export class Loader {
     let clone = new Loader(loader.fetchImplementation, loader.resolveImport, {
       retrySleep: loader.retrySleep,
       virtualNetwork: loader.virtualNetwork,
+      moduleEvaluator: loader.moduleEvaluator,
+      moduleMeta: loader.moduleMeta,
     });
     for (let [moduleIdentifier, module] of loader.moduleShims) {
       clone.shimModule(moduleIdentifier, module);
@@ -340,6 +400,131 @@ export class Loader {
       moduleInstance: module,
       consumedModules: new Set(),
     });
+  }
+
+  // A shimmed module's executable identity IS a host-registered value: the
+  // module object itself is what this loader holds, whether it was registered
+  // here through `shimModule` or arrived on a response that carried the value
+  // in place of source. There is no source to fetch, classify, or evaluate
+  // anywhere else, so callers that route execution use this to keep a shim in
+  // the host runtime.
+  //
+  // Spelling-insensitive over the identity family `moduleCacheKey` collapses
+  // (`.gts` / `.ts` / extensionless), because a shim can be registered under
+  // one spelling while a captured class identity carries another.
+  isShimmedModule(moduleIdentifier: string): boolean {
+    let resolved = this.resolveImport(moduleIdentifier);
+    if (
+      this.moduleShims.has(resolved) ||
+      this.fetchedModuleShims.has(resolved)
+    ) {
+      return true;
+    }
+    let key = this.moduleCacheKey(resolved);
+    for (let identifiers of [
+      this.moduleShims.keys(),
+      this.fetchedModuleShims,
+    ]) {
+      for (let shimIdentifier of identifiers) {
+        if (this.moduleCacheKey(shimIdentifier) === key) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  // Evicts one module and the modules that transitively import it, leaving
+  // every other cached module — including the ones the evicted module
+  // imported — in place. Returns how many cached modules were removed.
+  //
+  // Importers go too because an evaluated module closed over the exports of
+  // the one being replaced and would keep serving the old code. The fan-in
+  // reaches only the import edges this loader already knows about: a module
+  // this loader never loaded holds nothing that can go stale.
+  invalidateModule(moduleIdentifier: string): number {
+    let resolved = this.resolveImport(moduleIdentifier);
+    let target: string;
+    try {
+      // Normalize through `URL` so a caller holding a non-canonical URL
+      // spelling still names the key the module was stored under. A
+      // realm-prefix identifier is not a URL at all and is already in the
+      // canonical key form, so it passes through untouched.
+      target = this.moduleCacheKey(new URL(resolved).href);
+    } catch (error) {
+      if (!(error instanceof TypeError)) {
+        throw error;
+      }
+      target = this.moduleCacheKey(resolved);
+    }
+
+    // Reverse the import edges in one pass over the module map, then walk out
+    // from the target. This runs on every authored-code edit, so the map is
+    // scanned once rather than once per level of the dependent chain.
+    let importers = new Map<string, string[]>();
+    for (let [key, module] of this.modules) {
+      for (let dependency of this.directModuleDependencies(module)) {
+        let dependencyKey = this.moduleCacheKey(dependency);
+        let existing = importers.get(dependencyKey);
+        if (existing) {
+          existing.push(key);
+        } else {
+          importers.set(dependencyKey, [key]);
+        }
+      }
+    }
+
+    let invalidated = new Set([target]);
+    let frontier = [target];
+    while (frontier.length > 0) {
+      for (let importer of importers.get(frontier.pop()!) ?? []) {
+        if (!invalidated.has(importer)) {
+          invalidated.add(importer);
+          frontier.push(importer);
+        }
+      }
+    }
+
+    let removed = 0;
+    for (let key of invalidated) {
+      if (this.modules.delete(key)) {
+        removed++;
+      }
+      this.moduleCanonicalURLs.delete(key);
+    }
+    // Any cached dependency set that reached an evicted module is stale, and
+    // deciding which ones costs the same walk as recomputing them on demand.
+    this.knownDepsCache.clear();
+    return removed;
+  }
+
+  // The modules a cached module imports, in whatever state it is in. The
+  // registered states carry their dependency list, cycle-completing edges
+  // included — an import that closed a cycle is still an import. An
+  // evaluated, preparing, or broken module carries the set it consumed, and a
+  // module still fetching has named nothing yet.
+  private directModuleDependencies(module: Module): string[] {
+    switch (module.state) {
+      case 'evaluated':
+      case 'preparing':
+      case 'broken':
+        return [...module.consumedModules];
+      case 'registered':
+        return module.dependencyList.flatMap((entry) =>
+          entry.type === 'dep' ? [entry.moduleURL.href] : [],
+        );
+      case 'registered-completing-deps':
+      case 'registered-with-deps':
+        return module.dependencies.flatMap((entry) =>
+          entry.type === 'dep' || entry.type === 'completing-dep'
+            ? [entry.moduleURL.href]
+            : [],
+        );
+      case 'fetching':
+        return [];
+      default:
+        throw assertNever(module);
+    }
   }
 
   // Returns the transitive consumed modules of `moduleIdentifier` in
@@ -1037,6 +1222,14 @@ export class Loader {
     try {
       loaded = await this.load(moduleURL);
     } catch (exception) {
+      // `invalidateModule` may have dropped this fetch while transport was in
+      // flight, and a later import may already have installed a replacement.
+      // The fetching record is the generation token: a stale failure must not
+      // delete or reject the newer generation.
+      if (this.getModule(moduleIdentifier) !== module) {
+        module.deferred.fulfill();
+        return;
+      }
       // A failure to OBTAIN the module — a network failure or an error
       // HTTP response — is never cached as `broken`. The modules map keys
       // entries by the extension-trimmed identifier (see
@@ -1057,6 +1250,14 @@ export class Loader {
       throw exception;
     }
 
+    // Same generation check for a response that arrives after its fetch was
+    // invalidated: without it an old response restores its source and
+    // dependency edges over the entry that replaced it.
+    if (this.getModule(moduleIdentifier) !== module) {
+      module.deferred.fulfill();
+      return;
+    }
+
     let canonicalURL =
       loaded.url ||
       this.getCanonicalModuleURL(moduleIdentifier) ||
@@ -1065,6 +1266,7 @@ export class Loader {
 
     if (loaded.type === 'shimmed') {
       this.captureIdentitiesOfModuleExports(loaded.module, moduleIdentifier);
+      this.fetchedModuleShims.add(moduleIdentifier);
 
       this.setModule(moduleIdentifier, {
         state: 'evaluated',
@@ -1089,37 +1291,8 @@ export class Loader {
       throw exception;
     }
 
-    type DefineFunc = ((
-      mid: string,
-      depList: string[],
-      impl: Function,
-    ) => void) & {
-      dependencyList: UnregisteredDep[];
-      implementation: Function;
-    };
-
-    // this local is here for the evals to see. We're sticking the
-    // dependencyList and implementation onto the function itself because that's
-    // a convenient way to ensure that build tools like Rollup don't optimize it
-    // away. Rollup violates the JS spec by removing a local that's visible to `eval`.
-    let define = ((_mid: string, depList: string[], impl: Function) => {
-      define.dependencyList = depList.map((depId) => {
-        if (depId === 'exports') {
-          return { type: 'exports' };
-        } else if (depId === '__import_meta__') {
-          return { type: '__import_meta__' };
-        } else {
-          return {
-            type: 'dep',
-            moduleURL: new URL(
-              this.resolveImport(depId),
-              new URL(moduleIdentifier),
-            ),
-          };
-        }
-      });
-      define.implementation = impl;
-    }) as DefineFunc;
+    let registration: ModuleRegistration;
+    let dependencyList: UnregisteredDep[];
 
     try {
       // Append `sourceURL` so stack traces from inside the eval-ed AMD
@@ -1127,7 +1300,39 @@ export class Loader {
       // Strip any CR/LF from the identifier so a maliciously-crafted
       // module URL can't terminate the comment and inject extra source
       // text into the eval-ed program.
-      eval(src + '\n//# sourceURL=' + moduleIdentifier.replace(/[\r\n]/g, ''));
+      registration = this.moduleEvaluator(
+        src + '\n//# sourceURL=' + moduleIdentifier.replace(/[\r\n]/g, ''),
+        moduleIdentifier,
+      );
+      // An evaluator is arbitrary injected code, so what comes back is
+      // checked before it becomes a cached module: a registration the loader
+      // can't use has to name itself here rather than surface later as a
+      // shapeless failure while the module is being evaluated.
+      if (
+        !registration ||
+        !Array.isArray(registration.dependencyList) ||
+        typeof registration.implementation !== 'function'
+      ) {
+        throw new Error(
+          `Module evaluator returned an invalid registration for ${moduleIdentifier}`,
+        );
+      }
+      dependencyList = registration.dependencyList.map(
+        (depId): UnregisteredDep => {
+          if (depId === 'exports') {
+            return { type: 'exports' };
+          } else if (depId === '__import_meta__') {
+            return { type: '__import_meta__' };
+          }
+          return {
+            type: 'dep',
+            moduleURL: new URL(
+              this.resolveImport(depId),
+              new URL(moduleIdentifier),
+            ),
+          };
+        },
+      );
     } catch (exception) {
       this.setModule(moduleIdentifier, {
         state: 'broken',
@@ -1140,8 +1345,8 @@ export class Loader {
 
     let registeredModule: RegisteredModule = {
       state: 'registered',
-      dependencyList: define.dependencyList,
-      implementation: define.implementation,
+      dependencyList,
+      implementation: registration.implementation,
     };
 
     this.setModule(moduleIdentifier, registeredModule);
@@ -1177,13 +1382,17 @@ export class Loader {
         switch (entry.type) {
           case 'exports':
             return privateModuleInstance;
-          case '__import_meta__':
-            return {
-              url:
-                this.getCanonicalModuleURL(moduleIdentifier) ??
-                moduleIdentifier,
-              loader: this,
-            };
+          case '__import_meta__': {
+            let url =
+              this.getCanonicalModuleURL(moduleIdentifier) ?? moduleIdentifier;
+            // Whoever evaluates a module decides what `import.meta` exposes
+            // to it. The default hands over the Loader itself, which is only
+            // safe because the default evaluates the module in the loader's
+            // own realm — code already holding everything the loader has.
+            return this.moduleMeta
+              ? this.moduleMeta(url)
+              : { url, loader: this };
+          }
           case 'completing-dep':
           case 'dep': {
             let depModule = this.getModule(entry.moduleURL.href);

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -810,10 +810,14 @@ export class Loader {
 
     let pending = [rootModuleIdentifier];
     let visited = new Set<string>();
-    // A walk that reached a module this loader does not hold saw only part of
-    // the graph. Memoizing that would outlive the gap — the cache is consulted
-    // before the module map, so a set collected while a module was evicted
-    // would still be answered after the module came back.
+    // A walk that reached a module whose dependencies this loader does not know
+    // yet — one it does not hold at all, or one still fetching — saw only part
+    // of the graph. Memoizing that would outlive the gap: the cache is
+    // consulted before the module map and nothing clears it when a module
+    // registers, so a set collected during the gap would still be answered
+    // afterwards. Every other state names its dependencies, `broken` included:
+    // a module that failed before it could name any has none to know, and it
+    // cannot gain any without an invalidation, which clears this cache.
     let complete = true;
 
     while (pending.length > 0) {
@@ -863,6 +867,7 @@ export class Loader {
           }
           break;
         case 'fetching':
+          complete = false;
           break;
         default:
           throw assertNever(module);

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -492,6 +492,17 @@ export class Loader {
       }
       this.moduleCanonicalURLs.delete(key);
     }
+    // What an evicted module's last fetch answered with is part of what is
+    // being evicted: a module that answered with a host-registered value once
+    // may answer with source next time, and `isShimmedModule` would otherwise
+    // keep routing that source away from evaluation. A shim registered here
+    // through `shimModule` is a standing registration rather than something
+    // learned from a fetch, so it survives and re-serves the next import.
+    for (let identifier of this.fetchedModuleShims) {
+      if (invalidated.has(this.moduleCacheKey(identifier))) {
+        this.fetchedModuleShims.delete(identifier);
+      }
+    }
     // Any cached dependency set that reached an evicted module is stale, and
     // deciding which ones costs the same walk as recomputing them on demand.
     this.knownDepsCache.clear();

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -47,7 +47,15 @@ type RegisteredWithDepsModule = {
 
 // Import edges that were still completing when a module's dependency list was
 // frozen — recorded apart from `consumedModules`, which holds only the edges
-// that had resolved by then. Both together are the module's imports.
+// that had resolved by then.
+//
+// The two readers want different halves, deliberately. Eviction reads both,
+// through `directModuleDependencies`: an edge that was still completing is an
+// import, and a module holding another's exports goes stale with it.
+// Dependency tracking — `getConsumedModules` and
+// `collectKnownModuleDependencies` — reads only `consumedModules`, because
+// that set is what the index records module dependencies from, and widening
+// it widens invalidation fan-out across indexing.
 type CompletingDependencies = { completingDependencies: string[] };
 
 type PreparingModule = {
@@ -119,9 +127,14 @@ export interface ModuleRegistration {
 // Evaluates the AMD registration wrapper `transpileAmd` produces and hands
 // back what the module registered. This is the seam that decides *where* a
 // module's code runs: the default evaluates it in the loader's own realm,
-// while a caller that must run authored code somewhere else — a SES
-// Compartment, an iframe child — supplies an evaluator whose `define` binding
-// lives there.
+// while a caller that must run authored code somewhere else supplies an
+// evaluator whose `define` binding lives there.
+//
+// The contract is synchronous, which bounds where the seam applies: an
+// evaluation context reachable synchronously from this loader — a SES
+// Compartment is one. A context that can only be reached by message passing
+// runs its own Loader on its own side of the boundary and injects its
+// evaluator there, rather than answering this one.
 export type ModuleEvaluator = (
   source: string,
   moduleIdentifier: string,
@@ -651,22 +664,24 @@ export class Loader {
       );
     }
 
-    await this.advanceToState(resolvedModule, 'evaluated');
-    this.trackKnownModuleDependencies(
-      resolvedModuleIdentifier,
-      dependencyTrackingContext,
-    );
-    let module = this.getModule(resolvedModuleIdentifier);
-    switch (module?.state) {
-      case 'evaluated':
-      case 'preparing':
-        return module.moduleInstance as T;
-      case 'broken':
-        throw module.exception;
-      default:
-        throw new Error(
-          `bug: advanceToState('${moduleIdentifier}', 'evaluated') resulted in state ${module?.state}`,
-        );
+    // `advanceToState` re-reads the module map after each of its own awaits,
+    // but this read happens after it has resolved. An eviction landing in
+    // between leaves nothing to return, so advance the replacement rather than
+    // reporting the state the eviction produced as a bug.
+    for (;;) {
+      await this.advanceToState(resolvedModule, 'evaluated');
+      this.trackKnownModuleDependencies(
+        resolvedModuleIdentifier,
+        dependencyTrackingContext,
+      );
+      let module = this.getModule(resolvedModuleIdentifier);
+      switch (module?.state) {
+        case 'evaluated':
+        case 'preparing':
+          return module.moduleInstance as T;
+        case 'broken':
+          throw module.exception;
+      }
     }
   }
 
@@ -795,6 +810,11 @@ export class Loader {
 
     let pending = [rootModuleIdentifier];
     let visited = new Set<string>();
+    // A walk that reached a module this loader does not hold saw only part of
+    // the graph. Memoizing that would outlive the gap — the cache is consulted
+    // before the module map, so a set collected while a module was evicted
+    // would still be answered after the module came back.
+    let complete = true;
 
     while (pending.length > 0) {
       let moduleIdentifier = pending.pop()!;
@@ -815,6 +835,7 @@ export class Loader {
 
       let module = this.getModule(moduleIdentifier);
       if (!module) {
+        complete = false;
         continue;
       }
 
@@ -848,7 +869,9 @@ export class Loader {
       }
     }
 
-    this.knownDepsCache.set(rootModuleIdentifier, visited);
+    if (complete) {
+      this.knownDepsCache.set(rootModuleIdentifier, visited);
+    }
     return visited;
   }
 
@@ -1339,6 +1362,9 @@ export class Loader {
       if (
         !registration ||
         !Array.isArray(registration.dependencyList) ||
+        !registration.dependencyList.every(
+          (entry) => typeof entry === 'string',
+        ) ||
         typeof registration.implementation !== 'function'
       ) {
         throw new Error(


### PR DESCRIPTION
The sandboxing work needs three things from the Loader that it does not have
today, and it needs them without changing anything for the callers that exist
now. This adds the seams; nothing is wired to them yet.

**Where a module evaluates has to be injectable.** Evaluation of the AMD
registration wrapper moves behind a `moduleEvaluator` option:
`(source, moduleIdentifier) => {dependencyList, implementation}`. The default,
`evaluateModuleInCurrentRealm`, is exactly today's `eval` — including the
`define.registration` trick, which exists because Rollup violates the JS spec
by optimizing away a local that is visible to `eval`. A caller that must run
authored code somewhere else supplies an evaluator whose `define` binding lives
there; the loader keeps resolving the dependency URLs the registration names,
so the evaluator is only an evaluator.

The loader checks what comes back before caching it. An evaluator is arbitrary
injected code, and a registration the loader can't use has to name itself
(`Module evaluator returned an invalid registration for <url>`) instead of
surfacing later as a shapeless failure mid-evaluation.

**What `import.meta` exposes has to be injectable too.** `moduleMeta` decides
that per module. The default still hands over `{url, loader}`, which is only
safe because the default evaluates the module in the loader's own realm — code
that already holds everything the loader has.

**Invalidating one module must not blow away the world.** `invalidateModule`
evicts a module and the modules that transitively import it, leaves everything
else — including that module's own dependencies — in place, and returns how
many entries it removed. Importers have to go because an evaluated module
closed over the exports of the one being replaced; nothing else does, which is
the whole point of the primitive.

**Shims must be recognizable.** `isShimmedModule` answers whether a module's
executable identity is a host-registered value rather than fetchable source.
It is spelling-insensitive over the identity family `moduleCacheKey` collapses
(`.gts` / `.ts` / extensionless), because a shim can be registered under one
spelling while a captured class identity carries another.

**The generation race.** Under live invalidation the fetching record is a
generation token. A response — or a failure — that arrives after its fetch was
invalidated is now discarded rather than written back: without the guard, an
old response restores its source and dependency edges over the entry that
replaced it, and an old failure deletes that entry outright. Both are tested
by holding one fetch, invalidating it, starting a second, and completing them
in that order.

Both options thread through `Loader.cloneLoader`.

## Decisions a reviewer may want to revisit

- **A shim discovered over the network is recorded separately from
  `shimModule`'s registry.** Realms and the package-shim handler answer a
  module fetch with the value on the response and no body, so without this
  `isShimmedModule` is false for every package shim — the trusted modules that
  most need to stay in the host runtime. Putting those identifiers into
  `moduleShims` instead would also make this loader answer fetches for them and
  seed them into every clone, which is a behavior change for existing callers;
  a separate set that only `isShimmedModule` reads is not.
- **`invalidateModule` accepts a realm-prefix identifier**, not only a URL. The
  cache keys itself by that form, so refusing it would silently remove nothing
  for a canonical spelling.
- **The eviction set comes from one reverse pass over the module map**, then a
  walk out from the target, rather than re-scanning the map once per level of
  the dependent chain. This runs on every authored-code edit.
- **Not exported from `runtime-common/index.ts`.** `Loader` already is; the two
  new types are reachable at `@cardstack/runtime-common/loader`, which is how
  the host imports the loader today.
- **A dependency still completing when a module's list was frozen rides on the
  module record**, in `completingDependencies`, rather than joining
  `consumedModules`. Those edges are real imports and eviction has to see them
  (below); `consumedModules` is what `getConsumedModules` returns and what the
  indexer records dependency edges from, so widening it would change indexing
  fan-out — a behavior change with no option to gate it on.

## The under-eviction this had to solve

A `completing-dep` is not only a cycle edge. When a second import root enters
while the first is suspended — the interleaving
`loader-concurrent-cycle-test.ts` already pins — a module can evaluate straight
out of `registered-completing-deps` with *every* edge still completing, so
`consumedModules` records nothing at all, including edges to modules in no
cycle. Reproduced: `/a` imports `/b` and `/slow`, `/b` imports `/a`, and after
the race `/a` reports no consumed modules. An eviction reading only that set
left `/a` alive holding the exports of a `/slow` that had just been replaced —
two live copies of one module in one loader. `directModuleDependencies` now
reads both halves.

`getConsumedModules` still reports the same gap, so the indexer records no
dependencies for a module caught in that interleaving. That is pre-existing —
it reproduces identically on `main` — and wants its own ticket rather than a
change to indexing fan-out inside this one.

One change the reference implementation makes to this file is deliberately not
here, because it changes behavior for existing callers with no option to gate
it on: skipping identity capture for a re-exported function that another loader
already owns.

## Also worth noting

Moving the `eval` out of `fetchModule` shrinks what an evaluated module retains
for the life of the loader: its implementation used to close over that
function's whole activation, including the raw untranspiled source. Measured at
300 modules of 40KB, that is ~12MB. It also changes which loader locals an
evaluated module can read — `module`, the CJS/UMD probe target, is no longer
among them (no occurrences in base, catalog, skills, or experiments), and the
evaluator's own locals are named so they cannot stand in for an undeclared
identifier.

Three reads that an eviction can land in the middle of are closed: a
dependency walk is no longer memoized when it reached a module the loader does
not hold or one still fetching — either way it saw part of the graph, and the
cache is read before the module map, so the truncated set was answered long
after the module had named its imports, leaving it indexed with no dependency
edges; `import`'s final read of the module map advances the replacement rather
than reporting the eviction's state as a bug; and a dependency list whose
elements are not identifiers is refused by name instead of failing later as
whatever resolving `42` as a URL throws.

`invalidateModule` builds its reverse-edge map before checking whether the
target is cached, so a miss costs the same scan as a hit (~12ms on a
5000-module map). Left as is: nothing calls it yet, and the obvious early
return would stop it evicting registered importers of a never-fetched
dependency, which is a semantic call better made against a real caller.

## Testing

`packages/host/tests/unit/loader-seams-test.ts` — 30 tests, covering evaluator
injection (a shim never reaches it; all three ways a registration can be
unusable are cached as broken), `import.meta` injection, `cloneLoader`
threading, shim detection across spellings, across both registration paths, and
discarded on a realm-mapping change, surgical invalidation (importer fan-in,
through an import cycle, through the concurrent-completion interleaving in both
directions, an importer evicted before it evaluates, dependencies and unrelated
modules untouched, the dependency-set cache discarded, re-import picking up new
source), every spelling a realm mapping gives a module including a bare package
specifier, and both halves of the generation race.

Every mechanism above is mutation-tested: 29 mutations, each removing one
mechanism, each turning a test red. That is how the under-eviction above was
confirmed, and it is also what caught four tests certifying mechanisms they
could not distinguish — a regression test naming a module by a spelling that
never enters the interleaving it claimed to test, a spelling test using
identifiers the cache key already folds, an unusable-registration case that
tripped a different arm than the one it named, and a `moduleMeta` test whose
canonical URL and requested identifier were the same string.

Green locally against a `dev-all` stack: `Unit | loader` (78 tests / 202
assertions across all three loader test files) and `Integration | card-basics`
(101 tests / 431 assertions) as a smoke test over the base-realm modules that
reach `import.meta.loader`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
