### PR TITLE
feat: add --timeout flag to boxel test

### DIFF
--- a/packages/boxel-cli/src/commands/test.ts
+++ b/packages/boxel-cli/src/commands/test.ts
@@ -15,6 +15,7 @@ interface TestCliOptions {
   hostDistDir?: string;
   debug?: boolean;
   json?: boolean;
+  timeout?: string;
 }
 
 export function registerTestCommand(program: Command): void {
@@ -41,7 +42,21 @@ export function registerTestCommand(program: Command): void {
     )
     .option('--debug', 'Stream browser console output to stderr')
     .option('--json', 'Output structured JSON result')
+    .option(
+      '--timeout <ms>',
+      'Maximum time to wait for the whole QUnit suite to finish, in milliseconds. Defaults to 300000 (5 minutes).',
+    )
     .action(async (pathArg: string | undefined, opts: TestCliOptions) => {
+      let timeoutMs: number | undefined;
+      if (opts.timeout !== undefined) {
+        timeoutMs = Number(opts.timeout);
+        if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+          console.error(
+            `${FG_RED}Error:${RESET} --timeout must be a positive integer number of milliseconds`,
+          );
+          process.exit(1);
+        }
+      }
       let result: RunTestsResult;
       try {
         if (opts.realm) {
@@ -49,6 +64,7 @@ export function registerTestCommand(program: Command): void {
             ...(opts.hostAppUrl ? { hostAppUrl: opts.hostAppUrl } : {}),
             ...(opts.hostDistDir ? { hostDistDir: opts.hostDistDir } : {}),
             ...(opts.debug ? { debug: true } : {}),
+            ...(timeoutMs ? { timeoutMs } : {}),
           });
         } else {
           let workspaceDir = resolve(pathArg ?? process.cwd());
@@ -56,6 +72,7 @@ export function registerTestCommand(program: Command): void {
             workspaceDir,
             ...(opts.hostDistDir ? { hostDistDir: opts.hostDistDir } : {}),
             ...(opts.debug ? { debug: true } : {}),
+            ...(timeoutMs ? { timeoutMs } : {}),
           });
         }
       } catch (err) {

--- a/packages/boxel-cli/src/lib/test-engine.ts
+++ b/packages/boxel-cli/src/lib/test-engine.ts
@@ -179,6 +179,8 @@ export interface RunTestsOptions {
   hostDistDir?: string;
   /** Stream browser console output to stderr for debugging. */
   debug?: boolean;
+  /** Wait-for-runEnd timeout in ms; defaults to 300_000. */
+  timeoutMs?: number;
   profileManager?: ProfileManager;
 }
 
@@ -248,6 +250,7 @@ export async function runTestsForRealm(
       hostAppUrl,
       hostDistDir: options?.hostDistDir,
       debug: options?.debug,
+      timeoutMs: options?.timeoutMs,
     });
 
     let summary = summarizeQunitResults(qunitResults);
@@ -279,6 +282,8 @@ export interface RunTestsLocallyOptions {
   workspaceDir: string;
   hostDistDir?: string;
   debug?: boolean;
+  /** Wait-for-runEnd timeout in ms; defaults to 300_000. */
+  timeoutMs?: number;
   /** Override the bundled-realms root for tests; defaults to the CLI's vendored copy. */
   bundledRealmsDir?: string;
 }
@@ -317,6 +322,7 @@ export async function runTestsLocally(
       hostAppUrl: '__local__:',
       hostDistDir: options.hostDistDir,
       debug: options.debug,
+      timeoutMs: options.timeoutMs,
       realmMounts: [
         { prefix: 'workspace', root: workspaceDir },
         { prefix: 'base', root: baseDir },

--- a/packages/boxel-cli/tests/commands/test-cli.test.ts
+++ b/packages/boxel-cli/tests/commands/test-cli.test.ts
@@ -34,24 +34,18 @@ async function runTestCli(argv: string[]): Promise<void> {
 }
 
 describe('boxel test CLI flags', () => {
-  let exitSpy: ReturnType<typeof vi.spyOn>;
-  let errorSpy: ReturnType<typeof vi.spyOn>;
-  let logSpy: ReturnType<typeof vi.spyOn>;
-
   beforeEach(() => {
     runTestsLocally.mockReset().mockResolvedValue(passedResult);
     runTestsForRealm.mockReset().mockResolvedValue(passedResult);
-    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`process.exit(${code})`);
     }) as never);
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    exitSpy.mockRestore();
-    errorSpy.mockRestore();
-    logSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 
   it('forwards --timeout to runTestsLocally as numeric timeoutMs', async () => {
@@ -89,7 +83,7 @@ describe('boxel test CLI flags', () => {
       );
       expect(runTestsLocally).not.toHaveBeenCalled();
       expect(runTestsForRealm).not.toHaveBeenCalled();
-      expect(errorSpy).toHaveBeenCalledWith(
+      expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('--timeout must be a positive integer'),
       );
     });

--- a/packages/boxel-cli/tests/commands/test-cli.test.ts
+++ b/packages/boxel-cli/tests/commands/test-cli.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+
+// The engine drives a headless Chromium, so these tests mock both engine
+// entry points and assert on the options the CLI action actually forwards —
+// in particular that `--timeout` reaches local and --realm modes as a
+// numeric `timeoutMs`, is omitted when the flag is absent, and never
+// reaches the engine when the value is invalid.
+
+const runTestsLocally = vi.fn();
+const runTestsForRealm = vi.fn();
+
+vi.mock('../../src/lib/test-engine.ts', () => ({
+  runTestsLocally: (...args: unknown[]) => runTestsLocally(...args),
+  runTestsForRealm: (...args: unknown[]) => runTestsForRealm(...args),
+}));
+
+import { registerTestCommand } from '../../src/commands/test.ts';
+
+const passedResult = {
+  status: 'passed',
+  passedCount: 1,
+  failedCount: 0,
+  skippedCount: 0,
+  durationMs: 5,
+  testFiles: ['sample.test.gts'],
+  failures: [],
+};
+
+async function runTestCli(argv: string[]): Promise<void> {
+  const program = new Command().exitOverride();
+  registerTestCommand(program);
+  await program.parseAsync(['test', ...argv], { from: 'user' });
+}
+
+describe('boxel test CLI flags', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    runTestsLocally.mockReset().mockResolvedValue(passedResult);
+    runTestsForRealm.mockReset().mockResolvedValue(passedResult);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('forwards --timeout to runTestsLocally as numeric timeoutMs', async () => {
+    await runTestCli(['.', '--timeout', '900000']);
+    expect(runTestsLocally).toHaveBeenCalledTimes(1);
+    expect(runTestsLocally.mock.calls[0][0]).toMatchObject({
+      timeoutMs: 900000,
+    });
+  });
+
+  it('forwards --timeout to runTestsForRealm as numeric timeoutMs', async () => {
+    await runTestCli([
+      '--realm',
+      'http://realm.localhost/',
+      '--timeout',
+      '60000',
+    ]);
+    expect(runTestsForRealm).toHaveBeenCalledTimes(1);
+    expect(runTestsForRealm.mock.calls[0][0]).toBe('http://realm.localhost/');
+    expect(runTestsForRealm.mock.calls[0][1]).toMatchObject({
+      timeoutMs: 60000,
+    });
+  });
+
+  it('omits timeoutMs entirely when --timeout is not given', async () => {
+    await runTestCli(['.']);
+    expect(runTestsLocally).toHaveBeenCalledTimes(1);
+    expect('timeoutMs' in runTestsLocally.mock.calls[0][0]).toBe(false);
+  });
+
+  for (const bad of ['abc', '0', '-5', '1.5']) {
+    it(`rejects --timeout ${bad} before reaching the engine`, async () => {
+      await expect(runTestCli(['.', '--timeout', bad])).rejects.toThrow(
+        'process.exit(1)',
+      );
+      expect(runTestsLocally).not.toHaveBeenCalled();
+      expect(runTestsForRealm).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('--timeout must be a positive integer'),
+      );
+    });
+  }
+});


### PR DESCRIPTION
`boxel test` waits a fixed 300 seconds for the QUnit suite to reach `runEnd`; a large workspace suite can exceed that on slower hardware (a 53-file suite completes ~64% of its 1354 tests inside the window on a standard GitHub Actions runner, then errors with zero results). This exposes the engine's existing `timeoutMs` as `--timeout <ms>` in both local and `--realm` modes, validated as a positive integer; the default stays 300000.

Verification: `tsc`, eslint, and the unit suite pass (one pre-existing machine-local `checkpoint-manager` timeout also fails on an untouched checkout); a built CLI run with `--timeout 5000` against a 54-file workspace fails with `did not reach runEnd within 5000ms`, proving the value reaches the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)