### PR TITLE
Hold the source classifier's parser accept-set to the realm's

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -62,13 +62,15 @@ jobs:
         # set the harness knows about.
         if: ${{ !cancelled() }}
         run: pnpm run lint:tier-registry
-      - name: Check content-tag parity across the packages that preprocess templates
-        # The realm transpiles authored `<template>` source with
-        # runtime-common's content-tag, and the source classifier analyzes what
-        # host's own copy emits. Two versions read the compiled form
-        # differently, which shows up as servable modules classifying as
-        # drafts — never as a failing test, since a suite bundles whatever it
-        # resolved.
+      - name: Check every package declaring content-tag resolves one version
+        # Several packages preprocess authored `<template>` source with their
+        # own copy — the realm with runtime-common's, the source classifier with
+        # host's, the CLI with its own. Two versions read the compiled form
+        # differently, which shows up as servable modules classifying as drafts.
+        # The host suite bundles two of those copies and would catch a
+        # behavioral divergence between them incidentally; the declaration
+        # drifting, and a divergence in a package no suite bundles both sides
+        # of, are what this holds.
         if: ${{ !cancelled() }}
         run: pnpm run lint:content-tag-parity
       - name: Lint Boxel Icons

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -62,6 +62,15 @@ jobs:
         # set the harness knows about.
         if: ${{ !cancelled() }}
         run: pnpm run lint:tier-registry
+      - name: Check content-tag parity across the packages that preprocess templates
+        # The realm transpiles authored `<template>` source with
+        # runtime-common's content-tag, and the source classifier analyzes what
+        # host's own copy emits. Two versions read the compiled form
+        # differently, which shows up as servable modules classifying as
+        # drafts — never as a failing test, since a suite bundles whatever it
+        # resolved.
+        if: ${{ !cancelled() }}
+        run: pnpm run lint:content-tag-parity
       - name: Lint Boxel Icons
         if: ${{ !cancelled() }}
         run: pnpm run lint

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "prepare-worktree-types": "pnpm --filter @cardstack/boxel-icons build && pnpm --filter @cardstack/boxel-ui build",
     "prepare": "husky",
     "lint:protocol-closure": "node ./scripts/check-protocol-import-closure.mts",
-    "lint:tier-registry": "node ./scripts/check-execution-tier-registry.mts"
+    "lint:tier-registry": "node ./scripts/check-execution-tier-registry.mts",
+    "lint:content-tag-parity": "node ./scripts/check-content-tag-parity.mts"
   },
   "devDependencies": {
     "@actions/core": "catalog:",

--- a/packages/host/app/lib/boxel-source-classifier.ts
+++ b/packages/host/app/lib/boxel-source-classifier.ts
@@ -233,6 +233,45 @@ const pinnedBabelOptions = {
   configFile: false,
 } as const;
 
+/**
+ * The accept-set: the syntax a Boxel module may use and still be read as
+ * itself here. It is not chosen, it is MIRRORED — a module the realm serves
+ * but this parse refuses is reported `source-parse-pending`, an unfinished
+ * draft, which classifies it Capsule with no signals at all. That direction is
+ * right for a genuine draft and wrong for working code, and its only symptom
+ * is a card rendering in the wrong cage.
+ *
+ * What is being mirrored is `transpile.ts`'s `realmBabelPlugins`. A Babel
+ * plugin widens the parser only through `manipulateOptions`, and exactly two
+ * of the realm's plugins do: this same TypeScript plugin, contributing
+ * `typescript` (along with `objectRestSpread` and `classProperties`), and
+ * `decorator-transforms`, contributing `decorators-legacy`. The rest — the
+ * template compiler, scoped CSS, the concurrency and loader plugins — carry no
+ * syntax. So `decorators-legacy` is here because `decorator-transforms` puts
+ * it there, and moving the realm to a different decorator proposal has to move
+ * this too.
+ *
+ * Nothing about that reasoning is self-enforcing, which is why it is exported
+ * rather than written inline: `RP-6.4: the parser accept-set is the realm's,
+ * plugin for plugin` drives Babel over both lists and compares what each
+ * contributes, so a plugin added to the realm's pipeline fails a comparison
+ * instead of quietly serving syntax this file cannot read.
+ *
+ * A function, not a constant, because Babel appends every plugin's
+ * contribution to the very `parserOpts.plugins` array it is handed — a shared
+ * one would accumulate `typescript` once per parse and report an accept-set
+ * that grows with use.
+ */
+export function sourceParseOptions(): {
+  plugins: babel.PluginItem[];
+  parserOpts: NonNullable<babel.TransformOptions['parserOpts']>;
+} {
+  return {
+    plugins: [[typescriptPlugin, { allowDeclareFields: true }]],
+    parserOpts: { plugins: ['decorators-legacy'] },
+  };
+}
+
 // The one import content-tag adds to a module that contains a template, to
 // compile the blocks it replaced. It is not an authored edge, so it is not a
 // graph member — and it is named here rather than pattern-matched so a
@@ -492,23 +531,9 @@ function analyzeJavaScript(source: string): {
    */
   hasEagerGlobal: boolean;
 } {
-  // These two lines ARE the accept-set, and it has to stay the realm's. A
-  // Babel plugin can only widen the parser through `manipulateOptions`, and in
-  // `transpile.ts` exactly two of its plugins do: this same TypeScript plugin
-  // contributes `typescript`, and `decorator-transforms` contributes
-  // `decorators-legacy`. The rest — the template compiler, scoped CSS, the
-  // concurrency and loader plugins — contribute no syntax.
-  //
-  // So `decorators-legacy` is mirrored from `decorator-transforms`, not chosen.
-  // If the realm ever moves to a different decorator proposal, narrowing this
-  // list turns servable modules into drafts, which classifies them Capsule with
-  // no signals — and the shape of that failure is a card that renders wrong
-  // rather than a test that goes red. `RP-6.4: syntax the realm serves is
-  // analyzed, not mistaken for a draft` is what holds the current set.
   let ast = babel.parseSync(source, {
     ...pinnedBabelOptions,
-    plugins: [[typescriptPlugin, { allowDeclareFields: true }]],
-    parserOpts: { plugins: ['decorators-legacy'] },
+    ...sourceParseOptions(),
   });
   if (!ast) {
     throw new Error('the parser returned no AST');
@@ -710,10 +735,7 @@ function analyzeJavaScript(source: string): {
     // Only the traverse is wanted; nothing reads generated code.
     code: false,
     cloneInputAst: false,
-    plugins: [
-      [typescriptPlugin, { allowDeclareFields: true }],
-      collectBrowserSignals,
-    ],
+    plugins: [...sourceParseOptions().plugins, collectBrowserSignals],
   });
 
   return {

--- a/packages/host/app/lib/boxel-source-classifier.ts
+++ b/packages/host/app/lib/boxel-source-classifier.ts
@@ -233,6 +233,10 @@ const pinnedBabelOptions = {
   configFile: false,
 } as const;
 
+// Frozen and shared by every parse, because the plugin instance Babel builds
+// against it outlives any one of them.
+const typescriptPluginOptions = Object.freeze({ allowDeclareFields: true });
+
 /**
  * The accept-set: the syntax a Boxel module may use and still be read as
  * itself here. It is not chosen, it is MIRRORED — a module the realm serves
@@ -257,18 +261,28 @@ const pinnedBabelOptions = {
  * configuration each produces, so a plugin added to the realm's pipeline fails
  * a comparison instead of quietly serving syntax this file cannot read.
  *
- * A function, not a constant, because Babel appends every plugin's
- * contribution to the very `parserOpts.plugins` array it is handed. A shared
- * one would take on three more entries per parse — `objectRestSpread`,
- * `classProperties` and `typescript` — and report an accept-set that grows with
- * use.
+ * What that comparison cannot see: the realm's Babel stage is not the only gate
+ * on what it serves. content-tag preprocesses first with an accept-set of its
+ * own, and under Node the realm's Babel merges any config file it discovers from
+ * the working directory — so a caller transpiling inside another project's tree
+ * can serve syntax this parse refuses, with no comparison going red. A false
+ * negative traceable to neither list is worth checking there.
+ *
+ * A function, not a constant, because Babel appends every plugin's contribution
+ * to the very `parserOpts.plugins` array it is handed. A shared array would take
+ * on three more entries per parse — `objectRestSpread`, `classProperties` and
+ * `typescript` — and report an accept-set that grows with use.
  */
 export function sourceParseOptions(): {
   plugins: babel.PluginItem[];
   parserOpts: NonNullable<babel.TransformOptions['parserOpts']>;
 } {
   return {
-    plugins: [[typescriptPlugin, { allowDeclareFields: true }]],
+    // Fresh arrays, shared options. Babel caches an instantiated plugin against
+    // the `(plugin, options)` pair it was handed, so reusing the options object
+    // is what keeps this from building a new TypeScript plugin on every call —
+    // twice per module classified. The arrays cannot be shared, per above.
+    plugins: [[typescriptPlugin, typescriptPluginOptions]],
     parserOpts: { plugins: ['decorators-legacy'] },
   };
 }

--- a/packages/host/app/lib/boxel-source-classifier.ts
+++ b/packages/host/app/lib/boxel-source-classifier.ts
@@ -251,16 +251,17 @@ const pinnedBabelOptions = {
  * it there, and moving the realm to a different decorator proposal has to move
  * this too.
  *
- * Nothing about that reasoning is self-enforcing, which is why it is exported
- * rather than written inline: `RP-6.4: the parser accept-set is the realm's,
- * plugin for plugin` drives Babel over both lists and compares what each
- * contributes, so a plugin added to the realm's pipeline fails a comparison
- * instead of quietly serving syntax this file cannot read.
+ * Nothing about that reasoning is self-enforcing, which is why these options
+ * are exported: `RP-6.4: the parser accept-set is the realm's, contribution
+ * for contribution` drives Babel over both lists and compares the parser
+ * configuration each produces, so a plugin added to the realm's pipeline fails
+ * a comparison instead of quietly serving syntax this file cannot read.
  *
  * A function, not a constant, because Babel appends every plugin's
- * contribution to the very `parserOpts.plugins` array it is handed — a shared
- * one would accumulate `typescript` once per parse and report an accept-set
- * that grows with use.
+ * contribution to the very `parserOpts.plugins` array it is handed. A shared
+ * one would take on three more entries per parse — `objectRestSpread`,
+ * `classProperties` and `typescript` — and report an accept-set that grows with
+ * use.
  */
 export function sourceParseOptions(): {
   plugins: babel.PluginItem[];

--- a/packages/host/tests/unit/rp-6-classification-test.ts
+++ b/packages/host/tests/unit/rp-6-classification-test.ts
@@ -1,11 +1,10 @@
 import * as babel from '@babel/core';
-// @ts-ignore no upstream types are available
-import typescriptPlugin from '@babel/plugin-transform-typescript';
 import { module, test } from 'qunit';
 
 import { PACKAGES_FAKE_ORIGIN } from '@cardstack/runtime-common/package-shim-handler';
 import {
   realmBabelPlugins,
+  realmTypescriptPlugin,
   transpileJS,
 } from '@cardstack/runtime-common/transpile';
 
@@ -20,44 +19,57 @@ import {
   isTrustedModule,
 } from '@cardstack/host/lib/trusted-modules';
 
-// The erasure half of what the realm does to card source: the TypeScript
-// transform, with the options `packages/runtime-common/transpile.ts` passes it.
-// Whether a module name survives this is the fact the classifier's import
-// collection has to agree with.
+// Babel options the probes below share. Neither side of a comparison reads
+// anything off `process`, and neither consults a Babel config file, so what a
+// probe reports is a property of the plugin list it was handed.
+const probeBabelOptions = {
+  cwd: '/',
+  root: '/',
+  envName: 'production',
+  babelrc: false,
+  configFile: false,
+} as const;
+
+// The erasure half of what the realm does to card source: its TypeScript
+// transform alone. Whether a module name survives this is the fact the
+// classifier's import collection has to agree with.
 function transformedByRealm(source: string): string {
   return (
     babel.transformSync(source, {
-      cwd: '/',
-      root: '/',
-      envName: 'production',
+      ...probeBabelOptions,
       filename: 'card.ts',
-      babelrc: false,
-      configFile: false,
       compact: true,
-      plugins: [[typescriptPlugin, { allowDeclareFields: true }]],
+      plugins: [realmTypescriptPlugin],
     })?.code ?? ''
   );
 }
 
-// What a Babel plugin list widens the parser to, computed BY Babel rather than
-// read off the plugins: `manipulateOptions` is the only hook that can widen the
-// parser, and Babel calls each plugin's before parsing, accumulating into the
-// one `parserOpts.plugins` array it also seeds from the caller's own. So a
-// recorder placed last in the list sees the finished accept-set without this
-// file knowing which plugin contributed what — which is the point, since the
-// contributions are what is under comparison.
+// How a Babel plugin list widens the parser, computed BY Babel rather than read
+// off the plugins: `manipulateOptions` is the only hook that can widen it, and
+// Babel calls each plugin's before parsing against one `parserOpts` object,
+// seeded by identity from the caller's own. So a recorder appended last to the
+// list observes the finished parser configuration without this file knowing
+// which plugin contributed what — which is the point, since the contributions
+// are what is under comparison.
 //
-// The array handed in is copied because Babel appends to the one it is given,
-// and both lists here are the values the shipping code parses with.
-function parserPluginsContributedBy(options: babel.TransformOptions): string[] {
-  let recorded: unknown[] = [];
+// The WHOLE object is reported, not just `plugins`. A plugin widens the parser
+// through any field of it — `allowReturnOutsideFunction` and
+// `allowAwaitOutsideFunction` admit syntax on their own — and a probe that read
+// only the plugin list would compare two identical lists and call a real
+// divergence equal.
+//
+// The arrays handed in are copied, because Babel appends to the ones it is
+// given and both sides here are the values the shipping code parses with.
+function acceptSetContributedBy(options: babel.TransformOptions): {
+  plugins: unknown[];
+  [key: string]: unknown;
+} {
+  let recorded: Record<string, unknown> | undefined;
   babel.transformSync('', {
-    cwd: '/',
-    root: '/',
-    envName: 'production',
+    ...probeBabelOptions,
+    // Neither side's real filename: a probe reports what a plugin list
+    // contributes, and no plugin in either list varies that by filename.
     filename: 'accept-set.ts',
-    babelrc: false,
-    configFile: false,
     parserOpts: { plugins: [...(options.parserOpts?.plugins ?? [])] },
     plugins: [
       ...(options.plugins ?? []),
@@ -65,22 +77,58 @@ function parserPluginsContributedBy(options: babel.TransformOptions): string[] {
         name: 'record-accept-set',
         manipulateOptions(
           _options: unknown,
-          parserOpts: { plugins: unknown[] },
+          parserOpts: Record<string, unknown>,
         ) {
-          recorded = [...parserOpts.plugins];
+          recorded = { ...parserOpts };
         },
         visitor: {},
       }),
     ],
   });
+  if (!recorded) {
+    throw new Error('Babel did not call the recorder, so nothing was measured');
+  }
   // A contribution is either a bare name or a `[name, options]` tuple, and the
   // two spellings widen the parser identically — so both normalize to the tuple
-  // form. The options stay in the comparison: a plugin can widen differently
-  // depending on them. Sorted because reaching the same syntax in a different
-  // order is not a difference.
-  return recorded
-    .map((entry) => JSON.stringify(Array.isArray(entry) ? entry : [entry, {}]))
-    .sort();
+  // form, and the options stay in the comparison because a plugin can widen
+  // differently depending on them. Deduped, because two plugins contributing
+  // the same syntax reach the same accept-set as one; and sorted, because the
+  // order a list arrives at that accept-set in is not a difference.
+  let plugins = [...((recorded.plugins as unknown[] | undefined) ?? [])].map(
+    (entry) =>
+      Array.isArray(entry) ? [entry[0], entry[1] ?? {}] : [entry, {}],
+  );
+  let byIdentity = new Map<string, unknown>();
+  for (let entry of plugins) {
+    byIdentity.set(JSON.stringify(canonicalized(entry)), entry);
+  }
+  return {
+    ...recorded,
+    plugins: [...byIdentity.keys()].sort().map((key) => byIdentity.get(key)),
+  };
+}
+
+// Recursively key-sorted, so a value serializes to one string however its
+// object literals were written. Two plugins reaching the same accept-set must
+// dedupe against each other, and a multi-key option bag — the decorators
+// syntax plugin contributes `decoratorsBeforeExport` and
+// `allowCallParenthesized` together — must not read as a divergence because
+// someone wrote its keys in the other order.
+function canonicalized(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalized);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [
+          key,
+          canonicalized((value as Record<string, unknown>)[key]),
+        ]),
+    );
+  }
+  return value;
 }
 
 // A card module around whatever the case under test is, so every row of the
@@ -876,7 +924,7 @@ module('Unit | RP-6 classification', function () {
     }
   });
 
-  test("RP-6.4: the parser accept-set is the realm's, plugin for plugin", async function (assert) {
+  test("RP-6.4: the parser accept-set is the realm's, contribution for contribution", async function (assert) {
     // The mirroring the classifier's parse rests on, compared rather than
     // restated. `the realm and the classifier agree on which source is
     // servable` covers the syntax someone thought to write a fixture for; this
@@ -888,18 +936,25 @@ module('Unit | RP-6 classification', function () {
     // to the realm's pipeline, or swapped for one that widens differently,
     // moves one side and fails here. Narrowing the classifier's list fails here
     // too, from the other direction.
-    let realm = parserPluginsContributedBy({ plugins: realmBabelPlugins });
-    let classifier = parserPluginsContributedBy(sourceParseOptions());
+    //
+    // Equality rather than "the classifier admits at least the realm's syntax",
+    // because the classifier's options are a mirror and not a choice: slack in
+    // either direction means the mirror has stopped tracking, and the direction
+    // that is merely untidy today is the one that hides the direction that
+    // costs an iframe tomorrow.
+    let realm = acceptSetContributedBy({ plugins: [...realmBabelPlugins] });
+    let classifier = acceptSetContributedBy(sourceParseOptions());
     assert.deepEqual(
       classifier,
       realm,
-      'the two lists widen the parser to the same syntax',
+      'the two lists configure the parser the same way',
     );
-    // Two empty sets compare equal, so the comparison above passes for a
-    // reading that failed to read anything — a recorder Babel never calls, or
-    // a plugin list it declines to instantiate. Both come back bare.
+    // Two empty accept-sets compare equal, so the comparison above would pass
+    // for a reading that measured nothing. The recorder throws when Babel never
+    // calls it; this catches the subtler shape, where it is called against a
+    // parserOpts no plugin ever contributed to.
     assert.true(
-      realm.length > 0,
+      (realm.plugins as unknown[]).length > 0,
       'the realm contributes syntax, so the comparison above is not vacuous',
     );
   });
@@ -907,9 +962,11 @@ module('Unit | RP-6 classification', function () {
   test('RP-6.4: the realm and the classifier agree on which source is servable', async function (assert) {
     // The mirroring, checked end to end: each fixture goes through the realm's
     // own `transpileJS` and through classification, and the two have to agree
-    // that it is servable. Whatever the realm transpiles, the classifier must
-    // parse — the reverse slack is harmless, since source the realm refuses
-    // never reaches a render.
+    // that it is servable. This is the direction that costs something —
+    // whatever the realm transpiles, the classifier must read — and it is the
+    // only direction a fixture can observe, since source the realm refuses
+    // never reaches a render either way. `the parser accept-set is the realm's,
+    // contribution for contribution` is what holds the mirror exact.
     //
     // Asserting the agreement rather than the syntax is what keeps this honest
     // as the pipeline moves: a fixture the realm stops serving switches to the
@@ -970,6 +1027,22 @@ module('Unit | RP-6 classification', function () {
         'a satisfies expression',
         'export const t = document.title satisfies string;',
       ],
+      [
+        'an import attribute clause',
+        `import d from './d.json' with { type: 'json' };\nexport const t = [d, document.title];`,
+      ],
+      [
+        'a decorator ahead of export',
+        'const dec = (t: unknown) => t;\nexport @dec class A { x = document.title; }',
+      ],
+      [
+        'a using declaration',
+        'using r = { [Symbol.dispose]() {} };\nexport const t = document.title;',
+      ],
+      [
+        'an await using declaration',
+        'export async function f() { await using r = {}; return document.title; }',
+      ],
       // The negative cases. `accessor` needs a decorator proposal the realm's
       // `decorator-transforms` does not enable, and JSX is syntax content-tag
       // refuses ahead of Babel — so the realm serves neither, and the
@@ -988,15 +1061,22 @@ module('Unit | RP-6 classification', function () {
       } else {
         refused++;
       }
-      let parsed =
-        (await classifyBoxelSource(source)).reason !== 'source-parse-pending';
+      // Every servable fixture reads `document`, and the classifier has to
+      // report that read — not merely decline to call the source a draft. What
+      // a missed accept-set costs is the module's SIGNALS: the parse is all or
+      // nothing, so a refusal takes the template signals with it and the module
+      // classifies Capsule with an empty list. Asserting only that the reason
+      // is not `source-parse-pending` would pass for a parse that succeeds and
+      // an analysis that finds nothing.
+      let analysis = await classifyBoxelSource(source);
+      let analyzed = analysis.signals.join(',') === 'document';
       // The one combination the mirroring forbids: source the realm hands out
       // that classification cannot read. The other three are all fine — the
       // realm refusing it makes the classifier's answer moot either way.
-      let holeInTheMirror = servable && !parsed;
+      let holeInTheMirror = servable && !analyzed;
       assert.false(
         holeInTheMirror,
-        `${shape} — the realm ${servable ? 'transpiles' : 'refuses'} it and the classifier ${parsed ? 'parses' : 'reads it as a draft'}`,
+        `${shape} — the realm ${servable ? 'transpiles' : 'refuses'} it and the classifier reports ${analysis.reason}`,
       );
     }
     // Each row above rules out one combination, which a fixture the realm

--- a/packages/host/tests/unit/rp-6-classification-test.ts
+++ b/packages/host/tests/unit/rp-6-classification-test.ts
@@ -4,11 +4,16 @@ import typescriptPlugin from '@babel/plugin-transform-typescript';
 import { module, test } from 'qunit';
 
 import { PACKAGES_FAKE_ORIGIN } from '@cardstack/runtime-common/package-shim-handler';
+import {
+  realmBabelPlugins,
+  transpileJS,
+} from '@cardstack/runtime-common/transpile';
 
 import {
   BoxelModuleGraphClassifier,
   CLASSIFICATION_REASON_KINDS,
   classifyBoxelSource,
+  sourceParseOptions,
 } from '@cardstack/host/lib/boxel-source-classifier';
 import {
   isTrustedImport,
@@ -32,6 +37,50 @@ function transformedByRealm(source: string): string {
       plugins: [[typescriptPlugin, { allowDeclareFields: true }]],
     })?.code ?? ''
   );
+}
+
+// What a Babel plugin list widens the parser to, computed BY Babel rather than
+// read off the plugins: `manipulateOptions` is the only hook that can widen the
+// parser, and Babel calls each plugin's before parsing, accumulating into the
+// one `parserOpts.plugins` array it also seeds from the caller's own. So a
+// recorder placed last in the list sees the finished accept-set without this
+// file knowing which plugin contributed what — which is the point, since the
+// contributions are what is under comparison.
+//
+// The array handed in is copied because Babel appends to the one it is given,
+// and both lists here are the values the shipping code parses with.
+function parserPluginsContributedBy(options: babel.TransformOptions): string[] {
+  let recorded: unknown[] = [];
+  babel.transformSync('', {
+    cwd: '/',
+    root: '/',
+    envName: 'production',
+    filename: 'accept-set.ts',
+    babelrc: false,
+    configFile: false,
+    parserOpts: { plugins: [...(options.parserOpts?.plugins ?? [])] },
+    plugins: [
+      ...(options.plugins ?? []),
+      () => ({
+        name: 'record-accept-set',
+        manipulateOptions(
+          _options: unknown,
+          parserOpts: { plugins: unknown[] },
+        ) {
+          recorded = [...parserOpts.plugins];
+        },
+        visitor: {},
+      }),
+    ],
+  });
+  // A contribution is either a bare name or a `[name, options]` tuple, and the
+  // two spellings widen the parser identically — so both normalize to the tuple
+  // form. The options stay in the comparison: a plugin can widen differently
+  // depending on them. Sorted because reaching the same syntax in a different
+  // order is not a difference.
+  return recorded
+    .map((entry) => JSON.stringify(Array.isArray(entry) ? entry : [entry, {}]))
+    .sort();
 }
 
 // A card module around whatever the case under test is, so every row of the
@@ -825,6 +874,144 @@ module('Unit | RP-6 classification', function () {
         `${shape} is analyzed, so its read is seen`,
       );
     }
+  });
+
+  test("RP-6.4: the parser accept-set is the realm's, plugin for plugin", async function (assert) {
+    // The mirroring the classifier's parse rests on, compared rather than
+    // restated. `the realm and the classifier agree on which source is
+    // servable` covers the syntax someone thought to write a fixture for; this
+    // covers the syntax nobody has written one for yet, because it reads the
+    // accept-set off the plugin lists themselves.
+    //
+    // Both sides are the values the shipping code parses with — `transpile.ts`'s
+    // plugin array and the classifier's own parse options — so a plugin added
+    // to the realm's pipeline, or swapped for one that widens differently,
+    // moves one side and fails here. Narrowing the classifier's list fails here
+    // too, from the other direction.
+    let realm = parserPluginsContributedBy({ plugins: realmBabelPlugins });
+    let classifier = parserPluginsContributedBy(sourceParseOptions());
+    assert.deepEqual(
+      classifier,
+      realm,
+      'the two lists widen the parser to the same syntax',
+    );
+    // Two empty sets compare equal, so the comparison above passes for a
+    // reading that failed to read anything — a recorder Babel never calls, or
+    // a plugin list it declines to instantiate. Both come back bare.
+    assert.true(
+      realm.length > 0,
+      'the realm contributes syntax, so the comparison above is not vacuous',
+    );
+  });
+
+  test('RP-6.4: the realm and the classifier agree on which source is servable', async function (assert) {
+    // The mirroring, checked end to end: each fixture goes through the realm's
+    // own `transpileJS` and through classification, and the two have to agree
+    // that it is servable. Whatever the realm transpiles, the classifier must
+    // parse — the reverse slack is harmless, since source the realm refuses
+    // never reaches a render.
+    //
+    // Asserting the agreement rather than the syntax is what keeps this honest
+    // as the pipeline moves: a fixture the realm stops serving switches to the
+    // negative branch by itself, and one it starts serving becomes a demand on
+    // the classifier without anyone editing a list.
+    let served = 0;
+    let refused = 0;
+    for (let [shape, source] of [
+      [
+        'a type-only import and an annotated field',
+        `import type { Scene } from 'three';\nexport class C { s?: Scene; t = document.title; }`,
+      ],
+      [
+        'a declare field',
+        'export class C { declare id: string; t = document.title; }',
+      ],
+      [
+        'a legacy decorator on a class',
+        'const dec = (t: unknown) => t;\n@dec\nexport class C { t = document.title; }',
+      ],
+      [
+        'a legacy decorator on a field',
+        'const field = (..._a: unknown[]) => {};\nexport class C { @field y = document.title; }',
+      ],
+      [
+        'a legacy decorator on a method',
+        'const action = (..._a: unknown[]) => {};\nexport class C { @action run() { return document.title; } }',
+      ],
+      [
+        'a template as a class member',
+        'export class C { static isolated = class { <template>hi</template> }; t = document.title; }',
+      ],
+      [
+        'a template in expression position',
+        'const Row = <template>hi</template>;\nexport const t = [Row, document.title];',
+      ],
+      [
+        'a constrained type parameter',
+        'export function f<T extends object>(v: T): T { void document.title; return v; }',
+      ],
+      [
+        'a parameter property',
+        'export class C { constructor(private x: string) { void [x, document.title]; } }',
+      ],
+      [
+        'an enum',
+        'export enum E { A }\nexport const t = [E.A, document.title];',
+      ],
+      [
+        'an abstract member',
+        'export abstract class C { abstract go(): void; t = document.title; }',
+      ],
+      [
+        'a namespace',
+        'export namespace N { export const x = 1; }\nexport const t = [N.x, document.title];',
+      ],
+      [
+        'a satisfies expression',
+        'export const t = document.title satisfies string;',
+      ],
+      // The negative cases. `accessor` needs a decorator proposal the realm's
+      // `decorator-transforms` does not enable, and JSX is syntax content-tag
+      // refuses ahead of Babel — so the realm serves neither, and the
+      // classifier reading them as drafts is the answer it should give.
+      ['an accessor field', 'export class C { accessor x = document.title; }'],
+      ['a JSX element', 'export const t = <div>{document.title}</div>;'],
+    ] as [string, string][]) {
+      let servable = true;
+      try {
+        await transpileJS(source, '/accept-set.gts');
+      } catch {
+        servable = false;
+      }
+      if (servable) {
+        served++;
+      } else {
+        refused++;
+      }
+      let parsed =
+        (await classifyBoxelSource(source)).reason !== 'source-parse-pending';
+      // The one combination the mirroring forbids: source the realm hands out
+      // that classification cannot read. The other three are all fine — the
+      // realm refusing it makes the classifier's answer moot either way.
+      let holeInTheMirror = servable && !parsed;
+      assert.false(
+        holeInTheMirror,
+        `${shape} — the realm ${servable ? 'transpiles' : 'refuses'} it and the classifier ${parsed ? 'parses' : 'reads it as a draft'}`,
+      );
+    }
+    // Each row above rules out one combination, which a fixture the realm
+    // refuses does without demanding anything of the classifier. So the table
+    // has to keep exercising both branches: an all-refused table would pass
+    // while checking nothing, and an all-served one would drop the negative
+    // case the mirroring is allowed to miss.
+    assert.true(
+      served > 0,
+      `some fixture is servable (${served} of ${served + refused})`,
+    );
+    assert.true(
+      refused > 0,
+      `some fixture is not, so the negative case is still exercised (${refused} of ${served + refused})`,
+    );
   });
 
   test('RP-6.4: the import content-tag adds to compile a template is not a graph edge', async function (assert) {

--- a/packages/host/tests/unit/rp-6-classification-test.ts
+++ b/packages/host/tests/unit/rp-6-classification-test.ts
@@ -70,7 +70,15 @@ function acceptSetContributedBy(options: babel.TransformOptions): {
     // Neither side's real filename: a probe reports what a plugin list
     // contributes, and no plugin in either list varies that by filename.
     filename: 'accept-set.ts',
-    parserOpts: { plugins: [...(options.parserOpts?.plugins ?? [])] },
+    // Every field the side under test passes, not just its plugin list: a
+    // `parserOpts` flag set directly is as real a widening as one a plugin
+    // contributes, and rebuilding the object from `plugins` alone would drop it
+    // before the comparison ever saw it. Only the array is copied, because
+    // Babel appends to the one it is handed.
+    parserOpts: {
+      ...options.parserOpts,
+      plugins: [...(options.parserOpts?.plugins ?? [])],
+    },
     plugins: [
       ...(options.plugins ?? []),
       () => ({

--- a/packages/runtime-common/transpile.ts
+++ b/packages/runtime-common/transpile.ts
@@ -46,6 +46,30 @@ const compiler = {
   },
 };
 
+const templateOptions: EmberTemplatePluginOptions = {
+  compiler,
+  transforms: [scopedCSSTransform],
+};
+
+// The Babel half of the realm's pipeline, a value rather than an inline literal
+// because the SYNTAX the realm serves is a property of this list and of nothing
+// else. A Babel plugin can widen the parser only through `manipulateOptions`,
+// so driving Babel over this array reports the accept-set a module has to fall
+// inside to be transpiled at all.
+//
+// The Boxel source classifier in `packages/host` parses card source with a
+// hand-written mirror of these contributions, and a mirror that falls behind
+// reads servable modules as unfinished drafts. It holds itself to this array
+// rather than to a restatement of it, so adding a plugin here that contributes
+// syntax fails that comparison instead of passing silently.
+export const realmBabelPlugins: babel.PluginItem[] = [
+  emberConcurrencyAsyncPlugin,
+  [typescriptPlugin, { allowDeclareFields: true }],
+  [decoratorTransforms],
+  [makeEmberTemplatePlugin, templateOptions],
+  loaderPlugin,
+];
+
 export async function transpileJS(
   content: string,
   debugFilename: string,
@@ -69,21 +93,10 @@ export async function transpileJS(
     inline_source_map: true,
   }).code;
 
-  const templateOptions: EmberTemplatePluginOptions = {
-    compiler,
-    transforms: [scopedCSSTransform],
-  };
-
   const transformed = await babel.transformAsync(content, {
     filename: debugFilename,
     compact: false, // this helps for readability when debugging
-    plugins: [
-      emberConcurrencyAsyncPlugin,
-      [typescriptPlugin, { allowDeclareFields: true }],
-      [decoratorTransforms],
-      [makeEmberTemplatePlugin, templateOptions],
-      loaderPlugin,
-    ],
+    plugins: realmBabelPlugins,
     highlightCode: false, // Do not output ANSI color codes in error messages so that the client can display them plainly
   });
   const src = transformed?.code;

--- a/packages/runtime-common/transpile.ts
+++ b/packages/runtime-common/transpile.ts
@@ -46,29 +46,51 @@ const compiler = {
   },
 };
 
-const templateOptions: EmberTemplatePluginOptions = {
+const templateOptions: EmberTemplatePluginOptions = Object.freeze({
   compiler,
-  transforms: [scopedCSSTransform],
-};
+  transforms: Object.freeze([
+    scopedCSSTransform,
+  ]) as (typeof scopedCSSTransform)[],
+});
 
-// The Babel half of the realm's pipeline, a value rather than an inline literal
-// because the SYNTAX the realm serves is a property of this list and of nothing
-// else. A Babel plugin can widen the parser only through `manipulateOptions`,
-// so driving Babel over this array reports the accept-set a module has to fall
-// inside to be transpiled at all.
+// The realm's TypeScript entry, named on its own because which imports survive
+// to runtime is a fact other code has to agree with: the source classifier
+// reads a module's import graph off the parsed statements and has to reach the
+// same answer this erasure does. Code checking that agreement uses this value,
+// so it cannot be checking against a restatement that has drifted.
+export const realmTypescriptPlugin: babel.PluginItem = Object.freeze([
+  typescriptPlugin,
+  Object.freeze({ allowDeclareFields: true }),
+]) as babel.PluginItem;
+
+// The Babel half of the realm's pipeline. Which JavaScript syntax survives
+// transpilation is a property of this array: a Babel plugin can widen the
+// parser only through `manipulateOptions`, so driving Babel over these plugins
+// reports the accept-set the Babel stage admits. content-tag's preprocessor
+// runs ahead of it with an accept-set of its own, so this is the second of two
+// gates rather than the only one — and Babel additionally merges any config
+// file it finds from the working directory, which a caller transpiling inside
+// someone else's project can move.
 //
 // The Boxel source classifier in `packages/host` parses card source with a
 // hand-written mirror of these contributions, and a mirror that falls behind
 // reads servable modules as unfinished drafts. It holds itself to this array
 // rather than to a restatement of it, so adding a plugin here that contributes
 // syntax fails that comparison instead of passing silently.
-export const realmBabelPlugins: babel.PluginItem[] = [
+//
+// One array and one options object serve every transpile, which is also what
+// lets Babel instantiate each plugin once for the life of the process instead
+// of per module. They are frozen because a plugin instance shared that widely
+// must not be reachable for mutation; nothing writes to them today
+// (`babel-plugin-ember-template-compilation` normalizes its options into a
+// fresh object and never writes back).
+export const realmBabelPlugins: readonly babel.PluginItem[] = Object.freeze([
   emberConcurrencyAsyncPlugin,
-  [typescriptPlugin, { allowDeclareFields: true }],
+  realmTypescriptPlugin,
   [decoratorTransforms],
   [makeEmberTemplatePlugin, templateOptions],
   loaderPlugin,
-];
+] as babel.PluginItem[]);
 
 export async function transpileJS(
   content: string,
@@ -96,7 +118,10 @@ export async function transpileJS(
   const transformed = await babel.transformAsync(content, {
     filename: debugFilename,
     compact: false, // this helps for readability when debugging
-    plugins: realmBabelPlugins,
+    // Cast rather than spread: Babel caches instantiated plugins against the
+    // identity of the array it is handed, so a fresh copy per call would build
+    // five plugin instances per module.
+    plugins: realmBabelPlugins as babel.PluginItem[],
     highlightCode: false, // Do not output ANSI color codes in error messages so that the client can display them plainly
   });
   const src = transformed?.code;

--- a/packages/runtime-common/transpile.ts
+++ b/packages/runtime-common/transpile.ts
@@ -63,14 +63,18 @@ export const realmTypescriptPlugin: babel.PluginItem = Object.freeze([
   Object.freeze({ allowDeclareFields: true }),
 ]) as babel.PluginItem;
 
-// The Babel half of the realm's pipeline. Which JavaScript syntax survives
-// transpilation is a property of this array: a Babel plugin can widen the
-// parser only through `manipulateOptions`, so driving Babel over these plugins
-// reports the accept-set the Babel stage admits. content-tag's preprocessor
-// runs ahead of it with an accept-set of its own, so this is the second of two
-// gates rather than the only one — and Babel additionally merges any config
-// file it finds from the working directory, which a caller transpiling inside
-// someone else's project can move.
+// The Babel half of the realm's pipeline, and the second of two gates on which
+// JavaScript syntax survives transpilation. Two things widen that accept-set
+// from outside this array, so it is not the whole of it: content-tag's
+// preprocessor runs ahead with an accept-set of its own, and Babel merges any
+// config file it discovers from the working directory — under Node, a caller
+// transpiling inside someone else's project inherits that project's Babel
+// config (the browser build stubs config-file discovery out, so it cannot
+// happen there).
+//
+// What IS a property of this array is the syntax the Babel stage itself admits:
+// a plugin can widen the parser only through `manipulateOptions`, so driving
+// Babel over these plugins reports exactly that.
 //
 // The Boxel source classifier in `packages/host` parses card source with a
 // hand-written mirror of these contributions, and a mirror that falls behind
@@ -78,10 +82,12 @@ export const realmTypescriptPlugin: babel.PluginItem = Object.freeze([
 // rather than to a restatement of it, so adding a plugin here that contributes
 // syntax fails that comparison instead of passing silently.
 //
-// One array and one options object serve every transpile, which is also what
-// lets Babel instantiate each plugin once for the life of the process instead
-// of per module. They are frozen because a plugin instance shared that widely
-// must not be reachable for mutation; nothing writes to them today
+// The options objects here are hoisted, not rebuilt per call, and that is what
+// lets Babel instantiate each plugin once for the life of the process: it caches
+// an instantiated plugin against the `(plugin, options)` pair it was handed, so
+// a fresh options literal per transpile builds a fresh instance per module.
+// Everything is frozen because an instance shared that widely must not be
+// reachable for mutation; nothing writes to them today
 // (`babel-plugin-ember-template-compilation` normalizes its options into a
 // fresh object and never writes back).
 export const realmBabelPlugins: readonly babel.PluginItem[] = Object.freeze([
@@ -118,9 +124,9 @@ export async function transpileJS(
   const transformed = await babel.transformAsync(content, {
     filename: debugFilename,
     compact: false, // this helps for readability when debugging
-    // Cast rather than spread: Babel caches instantiated plugins against the
-    // identity of the array it is handed, so a fresh copy per call would build
-    // five plugin instances per module.
+    // The cast only discards `readonly`; Babel accepts a copy of this array
+    // just as happily. What earns the shared plugin instances is the options
+    // objects above being hoisted, not the array.
     plugins: realmBabelPlugins as babel.PluginItem[],
     highlightCode: false, // Do not output ANSI color codes in error messages so that the client can display them plainly
   });

--- a/scripts/check-content-tag-parity.mts
+++ b/scripts/check-content-tag-parity.mts
@@ -1,0 +1,97 @@
+#!/usr/bin/env -S node
+// Holds `packages/host` and `packages/runtime-common` on the same content-tag.
+//
+// Both packages preprocess authored `<template>` source, and each uses its own
+// copy: the realm transpiles with runtime-common's (`transpile.ts`), while the
+// Boxel source classifier in host analyzes what host's copy emits. Those two
+// copies have to agree about what the compiled form looks like. Where they do
+// not, the classifier reads a module the realm serves as an unfinished draft —
+// or reads the injected template-compiler import as an authored graph edge, and
+// adds a module to every templated card's graph.
+//
+// Nothing today fails when they diverge. Parity is a side effect of both
+// packages spelling the dependency `catalog:`, which resolves to one version
+// for the whole workspace; pinning either side to a literal range, or adding a
+// pnpm override for one of them, breaks it silently and in a shape no test can
+// see, since a test suite bundles whatever it resolved.
+//
+// So both the declared range and the installed version are compared. The
+// declared range catches the edit, in the diff that makes it; the installed
+// version catches the ways a range is not the last word — an override, a
+// patch, a stale store.
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const packages = ['packages/host', 'packages/runtime-common'];
+const dependency = 'content-tag';
+
+function readJSON(path: string): Record<string, any> {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+const declared = new Map<string, string>();
+const installed = new Map<string, string>();
+const offenders: string[] = [];
+
+for (let pkg of packages) {
+  let manifest = readJSON(join(repoRoot, pkg, 'package.json'));
+  let range =
+    manifest.dependencies?.[dependency] ??
+    manifest.devDependencies?.[dependency];
+  if (!range) {
+    offenders.push(`${pkg} does not declare ${dependency}`);
+    continue;
+  }
+  declared.set(pkg, range);
+
+  // Read through the package's own node_modules rather than resolving from
+  // here: under pnpm's isolated layout that directory IS what the package's
+  // imports see, which is the copy whose behavior matters.
+  try {
+    installed.set(
+      pkg,
+      readJSON(join(repoRoot, pkg, 'node_modules', dependency, 'package.json'))
+        .version,
+    );
+  } catch {
+    offenders.push(
+      `${pkg} has no installed ${dependency} — run pnpm install before this check`,
+    );
+  }
+}
+
+function disagreement(label: string, values: Map<string, string>): string[] {
+  if (new Set(values.values()).size <= 1) {
+    return [];
+  }
+  return [
+    `${values.size} packages disagree on the ${label} ${dependency}:\n` +
+      [...values].map(([pkg, value]) => `  ${pkg}: ${value}`).join('\n'),
+  ];
+}
+
+offenders.push(
+  ...disagreement('declared', declared),
+  ...disagreement('installed', installed),
+);
+
+console.log(
+  `${dependency} parity: ` +
+    [...installed]
+      .map(([pkg, version]) => `${pkg} ${version} (${declared.get(pkg)})`)
+      .join(', '),
+);
+
+if (offenders.length > 0) {
+  console.error(
+    `\n${offenders.join('\n')}\n\n` +
+      `Both packages preprocess authored \`<template>\` source with their own copy,\n` +
+      `and the source classifier analyzes what its copy emits. Put them back on one\n` +
+      `version — \`catalog:\` on both sides is what holds this without an override.`,
+  );
+}
+
+process.exit(offenders.length > 0 ? 1 : 0);

--- a/scripts/check-content-tag-parity.mts
+++ b/scripts/check-content-tag-parity.mts
@@ -1,35 +1,70 @@
 #!/usr/bin/env -S node
-// Holds `packages/host` and `packages/runtime-common` on the same content-tag.
+// Holds every package that declares content-tag on one version of it.
 //
-// Both packages preprocess authored `<template>` source, and each uses its own
-// copy: the realm transpiles with runtime-common's (`transpile.ts`), while the
-// Boxel source classifier in host analyzes what host's copy emits. Those two
-// copies have to agree about what the compiled form looks like. Where they do
-// not, the classifier reads a module the realm serves as an unfinished draft —
-// or reads the injected template-compiler import as an authored graph edge, and
-// adds a module to every templated card's graph.
+// Several packages preprocess authored `<template>` source with their own copy:
+// the realm transpiles with runtime-common's, the Boxel source classifier in
+// host analyzes what host's emits, and the CLI drives its own. Those copies have
+// to agree about what the compiled form looks like. Where they do not, the
+// classifier reads a module the realm serves as an unfinished draft — or reads
+// the injected template-compiler import as an authored graph edge, and adds a
+// module to every templated card's graph.
 //
-// Nothing today fails when they diverge. Parity is a side effect of both
-// packages spelling the dependency `catalog:`, which resolves to one version
-// for the whole workspace; pinning either side to a literal range, or adding a
-// pnpm override for one of them, breaks it silently and in a shape no test can
-// see, since a test suite bundles whatever it resolved.
+// Parity is a side effect of every package spelling the dependency `catalog:`,
+// which resolves to one version for the whole workspace, and nothing declares
+// that it matters. The host browser suite bundles host's copy and
+// runtime-common's into one process, so a divergence that changes behavior on
+// the syntax those tests cover does surface there — but only incidentally, and
+// only for that pair. What no test sees is the declaration itself drifting, or a
+// divergence in a package no suite bundles both sides of.
 //
 // So both the declared range and the installed version are compared. The
 // declared range catches the edit, in the diff that makes it; the installed
-// version catches the ways a range is not the last word — an override, a
-// patch, a stale store.
+// version catches the ways a range is not the last word — an override scoped to
+// one package, a patch, a stale store.
 
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const packages = ['packages/host', 'packages/runtime-common'];
 const dependency = 'content-tag';
 
 function readJSON(path: string): Record<string, any> {
   return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function declaredRange(manifest: Record<string, any>): string | undefined {
+  return (
+    manifest.dependencies?.[dependency] ??
+    manifest.devDependencies?.[dependency]
+  );
+}
+
+// Every package that declares it, discovered rather than listed: a new one
+// joining is the case this check exists for, and a hand-maintained list would
+// silently omit it.
+const packages = readdirSync(join(repoRoot, 'packages'), {
+  withFileTypes: true,
+})
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => `packages/${entry.name}`)
+  .filter((pkg) => {
+    try {
+      return (
+        declaredRange(readJSON(join(repoRoot, pkg, 'package.json'))) !==
+        undefined
+      );
+    } catch {
+      return false;
+    }
+  })
+  .sort();
+
+if (packages.length < 2) {
+  console.error(
+    `only ${packages.length} package declares ${dependency}; this check compares copies, so it has nothing to hold`,
+  );
+  process.exit(1);
 }
 
 const declared = new Map<string, string>();
@@ -37,14 +72,7 @@ const installed = new Map<string, string>();
 const offenders: string[] = [];
 
 for (let pkg of packages) {
-  let manifest = readJSON(join(repoRoot, pkg, 'package.json'));
-  let range =
-    manifest.dependencies?.[dependency] ??
-    manifest.devDependencies?.[dependency];
-  if (!range) {
-    offenders.push(`${pkg} does not declare ${dependency}`);
-    continue;
-  }
+  let range = declaredRange(readJSON(join(repoRoot, pkg, 'package.json')))!;
   declared.set(pkg, range);
 
   // Read through the package's own node_modules rather than resolving from
@@ -88,9 +116,9 @@ console.log(
 if (offenders.length > 0) {
   console.error(
     `\n${offenders.join('\n')}\n\n` +
-      `Both packages preprocess authored \`<template>\` source with their own copy,\n` +
+      `These packages preprocess authored \`<template>\` source with their own copy,\n` +
       `and the source classifier analyzes what its copy emits. Put them back on one\n` +
-      `version — \`catalog:\` on both sides is what holds this without an override.`,
+      `version — \`catalog:\` everywhere is what holds this without an override.`,
   );
 }
 


### PR DESCRIPTION
The source classifier's parse has to accept exactly the syntax the realm serves. Its front end is the realm's own — content-tag's `process()`, then a Babel parse — and a module the realm transpiles that the parse refuses is reported `source-parse-pending`: an unfinished draft, which classifies Capsule with no signals at all. That is the right answer for a genuine draft and the wrong one for working code, and it is the only approximation in the classifier that errs toward more isolation on input that is not ambiguous. Its symptom is an unnecessary iframe on a card that renders, with nothing failing anywhere.

The mirroring itself is sound, and nothing about it is self-enforcing. A Babel plugin can widen the parser only through `manipulateOptions`, and of the realm's plugins exactly two do — `@babel/plugin-transform-typescript` and `decorator-transforms` — so the classifier enables those two and nothing else. That reasoning sits where the options are declared, and on its own nothing fails when it stops holding: a decorator-proposal change in `decorator-transforms`, a plugin added to the realm's pipeline, or a plugin swapped for one that widens differently all move the realm's accept-set without moving the classifier's.

## Both accept-sets are values

`packages/runtime-common/transpile.ts` exports `realmBabelPlugins` and, separately, `realmTypescriptPlugin`; `packages/host/app/lib/boxel-source-classifier.ts` exports `sourceParseOptions()` — the options its parse actually runs with. Behavior is unchanged on both sides: the realm transforms with the same plugins in the same order, and the classifier parses with the same plugin and the same `parserOpts`.

Three details worth a reviewer's attention:

- `sourceParseOptions` is a **function**, not a constant, and it has to be. Babel appends every plugin's `manipulateOptions` contribution to the very `parserOpts.plugins` array it is handed, so a shared array takes on three more entries per parse and reports an accept-set that grows with use. A module-level constant here would be a slow leak that also corrupts the value the guard reads.
- `realmBabelPlugins`, `realmTypescriptPlugin` and `templateOptions` are frozen and typed `readonly`. Hoisting the **options objects** is what lets Babel instantiate each plugin once per process rather than once per module: it caches an instantiated plugin against the `(plugin, options)` pair, so a fresh options literal per transpile builds a fresh instance per module. Counting the factory calls confirms the array's identity is irrelevant — passing a copy caches identically — so the cast at the call site only discards `readonly`. The classifier's plugin options are hoisted the same way; its *arrays* stay fresh, per the point above.
- `realmTypescriptPlugin` is named on its own so the suite's erasure helper uses the realm's own options instead of restating them. Matching it out of the plugin array by identity does **not** work: both packages resolve the same physical plugin file, but the bundler gives each import site its own interop binding, so `===` fails in the browser build.

## The guard is two comparisons, not a syntax list

**`RP-6.4: the parser accept-set is the realm's, contribution for contribution`** reads each side's accept-set *off the plugin lists*, computed by Babel rather than by the test: a recorder plugin appended last sees the finished `parserOpts` after every earlier plugin has contributed to it, including whatever the caller supplied directly.

It compares the **whole `parserOpts`**, not just `plugins`. A plugin widens the parser through any field of that object — `allowReturnOutsideFunction` alone makes `return 1;` parse at top level while contributing no plugin entry — so a probe reading only the plugin list would compare two identical lists and call a real divergence equal. Fields a side passes directly are carried through for the same reason, rather than the object being rebuilt from its plugin list.

Contributions normalize to `[name, options]`, deduped (two plugins contributing the same syntax reach the same accept-set as one) with recursively sorted option keys — `@babel/plugin-syntax-decorators` at `version: "2022-03"` contributes a two-key bag, so raw JSON comparison would misfire on exactly the decorator migration this exists to catch.

This is the half that covers syntax nobody has written a fixture for, which is the only kind a future plugin change introduces. It asserts equality rather than "the classifier admits at least the realm's syntax", because the classifier's options are a mirror and not a choice.

**`RP-6.4: the realm and the classifier agree on which source is servable`** runs each of 19 fixtures through the realm's own `transpileJS` and through classification, and rules out the one combination the mirroring forbids: source the realm hands out that the classifier cannot read. Every servable fixture reads `document` and the classifier has to **report that read** — not merely decline to call the source a draft. The parse is all or nothing, so what a missed accept-set costs is the module's signals; asserting only that the reason is not `source-parse-pending` would pass for a parse that succeeds and an analysis that finds nothing.

Fixtures cover TypeScript type positions, `declare` fields, parameter properties, enums, namespaces, `satisfies`, legacy decorators on classes, fields and methods, a decorator ahead of `export`, import attributes, `using` and `await using`, and a template block in both statement and expression position so content-tag's output is exercised on both paths.

It asserts the *agreement*, so the table stays honest as the pipeline moves: a fixture the realm stops serving drops into the negative branch by itself, and one it starts serving becomes a demand on the classifier without anyone editing a list. `accessor` fields and JSX are the negative cases — the realm refuses both (`decorator-transforms` does not enable `decoratorAutoAccessors`; content-tag rejects JSX ahead of Babel), so the classifier reading them as drafts is the answer it should give. Two closing assertions keep both branches populated, because an all-refused table would pass while checking nothing.

Verified against deliberate divergence, since a guard that cannot fail is not one:

| divergence | contribution comparison | differential fixtures |
| --- | --- | --- |
| baseline | equal | agrees on all 19 |
| a plugin added to the realm's list that widens via `parserOpts.plugins` | **red**, reporting the extra `["jsx",{}]` | green — no fixture uses it |
| a plugin added that widens via a `parserOpts` **flag** | **red** | green — no fixture uses it |
| a `parserOpts` flag passed directly by one side | **red** | green — no fixture uses it |
| `decorators-legacy` dropped from `sourceParseOptions` | **red**, naming the missing entry | **red** on the legacy-decorator rows |

The two flag rows are the ones a plugin-list-only probe reports as equal; the first was confirmed red in both Node and the browser harness. The middle rows are why the contribution comparison exists at all: fixtures cannot see a widening nobody has written syntax for yet.

Also confirmed not to misfire: a second plugin contributing syntax the realm already has, the same contribution set in a different order, and a multi-key option bag written in either key order all compare equal — while a changed option *value* still diverges.

## Scope of the accept-set claim

The Babel plugin list is the **second of two gates**, not the only one: content-tag's preprocessor runs ahead of it with an accept-set of its own (which is what refuses the JSX fixture). And `transpileJS` does not pin `configFile`/`babelrc`, so under Node, Babel merges any config file it discovers from the working directory — an ambient `babel.config.json` adding `decoratorAutoAccessors` makes `transpileJS` serve `accessor` fields it otherwise refuses. `packages/boxel-cli` calls `transpileJS` with the user's project as cwd, so a CLI user's own Babel config moves what the realm accepts there.

The comments say so rather than the code pinning it closed, and the classifier's docblock says it too, since that is the text someone chasing a false negative reads. Pinning `configFile: false, babelrc: false` would make the accept-set solely a property of the plugin list and is arguably right, but it changes the realm's serving behavior and could break a CLI user relying on their own config — worth a decision rather than a drive-by.

Not a regression and narrow in reach: the base branch does not pin it either, the browser build stubs config-file discovery out entirely, and there is no `babel.config.*` at the repo root, so realm-server and the worker are unaffected. The cost where it does reach is a false-negative classification — an unnecessary iframe — not incorrect serving.

## content-tag parity

Six packages declare content-tag and several preprocess authored template source with their own copy — the realm with runtime-common's, the source classifier with host's, the CLI with its own — so those copies have to agree about what the compiled form looks like. Parity is a side effect of every package spelling the dependency `catalog:`, and nothing declares that it matters.

The host suite bundles host's copy and runtime-common's into one process, so a divergence that changes behavior on the syntax those tests cover would surface there — but incidentally, and only for that pair. What no test sees is the declaration drifting, or a divergence in a package no suite bundles both sides of.

`scripts/check-content-tag-parity.mts` compares the declared range and the installed version across every package that declares it, discovered by reading manifests rather than from a hard-coded list, and runs in CI Lint beside the other cross-package protocol checks.

## Test plan

- `packages/host/tests/unit/rp-6-classification-test.ts` — 2 new tests. All 49 tests in the module pass in the real browser harness (`ember test --filter "RP-6 classification"`), verified against a bundle confirmed to contain the new exports rather than a stale build.
- Green: `packages/host` eslint and `ember-tsc --noEmit`; full `packages/runtime-common` lint (eslint + `ember-tsc`); `pnpm lint:scripts` (which enforces `erasableSyntaxOnly`); `pnpm lint:rp-bijection` (102 uncovered, unchanged — RP-6.4 already has an owner); `pnpm lint:content-tag-parity`; prettier across all touched files.
- `transpileJS` output byte-identical to the base branch across the `.gts` modules in `packages/base` and `packages/experiments-realm`, sequentially, repeated, and concurrently — which is what confirms the frozen plugin array and shared options survive reuse under the concurrency the realm actually transpiles with.
- All 19 fixtures checked outside the suite against real `transpileJS` + `classifyBoxelSource`: 17 served, every one reporting exactly `['document']`; 2 refused.
- Parity check confirmed red for a divergent declared range (including in a package the widened discovery newly covers) and for a missing install.

## Dependencies

None added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EURkdPK1ZY95mgfaByczA9