### PR TITLE
Complete a dependency whose cache entry is discarded mid-walk instead of dropping it

### DIFF
--- a/packages/host/tests/unit/loader-mapping-change-test.ts
+++ b/packages/host/tests/unit/loader-mapping-change-test.ts
@@ -52,6 +52,17 @@ module('Unit | loader mapping change during traversal', function () {
   // namespace and reads an uninitialized binding off it — `undefined`, the
   // value a cycle owes it. With the edge dropped, `b`'s factory is handed one
   // argument fewer and reads that binding off nothing at all.
+  //
+  // Every axis of the interleaving below is load-bearing: the two-node cycle,
+  // the parked fetch of `/b` (so the walk is suspended with `/a` registered and
+  // on the stack), and the mapping change landing inside that suspension. The
+  // drop it reproduces also only commits because `/a` is the last dep `/b`
+  // declares — a dep after it that still needs work would leave through
+  // `break outer_switch` and discard the truncated list. Anyone restructuring
+  // this module must re-verify it fails with the branch in `advanceToState`'s
+  // `registered` case narrowed back to recording a completing-dep only
+  // `else if (isRegistered(depModule))`, which should reject both tests with
+  // `Cannot read properties of undefined (reading 'a')`.
   let cycleSources: Record<string, string> = {
     '/a': `import { b } from './b'; export const a = 'a' + b;`,
     '/b': `import { a } from './a'; export const b = 'b' + String(a);`,

--- a/packages/host/tests/unit/loader-mapping-change-test.ts
+++ b/packages/host/tests/unit/loader-mapping-change-test.ts
@@ -62,11 +62,12 @@ module('Unit | loader mapping change during traversal', function () {
   //
   // Anyone restructuring this module must re-verify it still has teeth. A
   // `registered` case that records a completing-dep only when the dep is
-  // already registered drops `/b`'s edge to `/a`, and both tests reject with
-  // `bug: dependency list for http://mapping.example/b recorded 1 of the 2
-  // dependencies it declares` — the length invariant catches the drop before
-  // the factory is ever called. Remove that invariant too and the rejection
-  // becomes the mis-binding it exists to prevent:
+  // already registered drops `/b`'s edge to `/a`, and every test here rejects
+  // on the length invariant, which catches the drop before the factory is ever
+  // called — `bug: dependency list for http://mapping.example/b recorded 1 of
+  // the 2 dependencies it declares` for the two-module cycle, and the same for
+  // `/c.js` at 2 of 3 in the mixed-spelling one. Remove that invariant too and
+  // the rejection becomes the mis-binding it exists to prevent:
   // `Cannot read properties of undefined (reading 'a')`.
   let cycleSources: Record<string, string> = {
     '/a': `import { b } from './b'; export const a = 'a' + b;`,
@@ -160,8 +161,8 @@ module('Unit | loader mapping change during traversal', function () {
   // raw href the edge spelled `./b` does not match the ancestor pushed as
   // `./b.js`, so the cycle reads as unvisited and the walk takes a level it
   // does not need, reaching the same result by more work. The outcome is
-  // identical either way, so no assertion here distinguishes the two — the
-  // difference is visible only in the level count.
+  // identical either way, so no assertion here distinguishes the two — what
+  // differs is the number of descents, not the depth they reach.
   test('a cycle whose edges spell the shared module differently is walked as one cycle', async function (assert) {
     // `/b` is reached as `./b.js` from the root and as `./b` from `/c`; `/slow`
     // is what suspends the walk so the mapping change lands inside it.
@@ -177,9 +178,6 @@ module('Unit | loader mapping change during traversal', function () {
     let sources = new Proxy(mixedSources, {
       get(target, path: string) {
         return target[path] ?? target[`${path}.js`];
-      },
-      has(target, path: string) {
-        return path in target || `${path}.js` in target;
       },
     });
     let { fetchImpl, requested, release } = parkedFetch(sources, '/slow.js');

--- a/packages/host/tests/unit/loader-mapping-change-test.ts
+++ b/packages/host/tests/unit/loader-mapping-change-test.ts
@@ -58,10 +58,15 @@ module('Unit | loader mapping change during traversal', function () {
   // on the stack), and the mapping change landing inside that suspension. The
   // drop it reproduces also only commits because `/a` is the last dep `/b`
   // declares — a dep after it that still needs work would leave through
-  // `break outer_switch` and discard the truncated list. Anyone restructuring
-  // this module must re-verify it fails with the branch in `advanceToState`'s
-  // `registered` case narrowed back to recording a completing-dep only
-  // `else if (isRegistered(depModule))`, which should reject both tests with
+  // `break outer_switch` and discard the truncated list.
+  //
+  // Anyone restructuring this module must re-verify it still has teeth. A
+  // `registered` case that records a completing-dep only when the dep is
+  // already registered drops `/b`'s edge to `/a`, and both tests reject with
+  // `bug: dependency list for http://mapping.example/b recorded 1 of the 2
+  // dependencies it declares` — the length invariant catches the drop before
+  // the factory is ever called. Remove that invariant too and the rejection
+  // becomes the mis-binding it exists to prevent:
   // `Cannot read properties of undefined (reading 'a')`.
   let cycleSources: Record<string, string> = {
     '/a': `import { b } from './b'; export const a = 'a' + b;`,
@@ -142,6 +147,79 @@ module('Unit | loader mapping change during traversal', function () {
       (await loader.getConsumedModules('http://mapping.example/a')).sort(),
       ['http://mapping.example/b'],
       'its importer reports the edge it was walked through',
+    );
+  });
+
+  // The cache key folds every spelling of a module onto one entry, so a cycle
+  // whose two edges name the shared module differently is still one cycle, and
+  // still resolves to one module instance across both spellings — which is what
+  // this pins, alongside the same mid-walk cache clear as the tests above.
+  //
+  // Note what it cannot pin. Comparing the completing stack by cache key
+  // rather than by raw href only changes how many levels the walk descends: by
+  // raw href the edge spelled `./b` does not match the ancestor pushed as
+  // `./b.js`, so the cycle reads as unvisited and the walk takes a level it
+  // does not need, reaching the same result by more work. The outcome is
+  // identical either way, so no assertion here distinguishes the two — the
+  // difference is visible only in the level count.
+  test('a cycle whose edges spell the shared module differently is walked as one cycle', async function (assert) {
+    // `/b` is reached as `./b.js` from the root and as `./b` from `/c`; `/slow`
+    // is what suspends the walk so the mapping change lands inside it.
+    let mixedSources: Record<string, string> = {
+      '/a.js': `import { b } from './b.js'; export const a = 'a' + b;`,
+      '/b.js': `import { c } from './c.js'; export const b = 'b' + c;`,
+      '/c.js': `import { b } from './b'; import { slow } from './slow.js';
+                export const c = 'c' + String(b) + slow;`,
+      '/slow.js': `export const slow = 'S';`,
+    };
+    // The loader trims executable extensions to build a cache key, but a fetch
+    // still goes out under the spelling the importer used, so both answer.
+    let sources = new Proxy(mixedSources, {
+      get(target, path: string) {
+        return target[path] ?? target[`${path}.js`];
+      },
+      has(target, path: string) {
+        return path in target || `${path}.js` in target;
+      },
+    });
+    let { fetchImpl, requested, release } = parkedFetch(sources, '/slow.js');
+    let virtualNetwork = new VirtualNetwork(fetchImpl);
+    let loader = new Loader(
+      virtualNetwork.fetch,
+      virtualNetwork.resolveImport,
+      {
+        virtualNetwork,
+      },
+    );
+
+    let root = loader.import<{ a: string }>('http://mapping.example/a.js');
+    await requested.promise;
+    virtualNetwork.addURLMapping(
+      new URL('http://alias.example/'),
+      new URL('http://real.example/'),
+    );
+    release.fulfill();
+    await root;
+
+    // One cache entry, so one module instance — the property the fold exists
+    // for. Two instances here would diverge under `instanceof` and
+    // polymorphic-field identity checks across the two spellings.
+    let viaExtension = await loader.import('http://mapping.example/b.js');
+    let viaBare = await loader.import('http://mapping.example/b');
+    assert.strictEqual(
+      viaExtension,
+      viaBare,
+      'both spellings resolve to one module instance',
+    );
+
+    // Consumed edges carry the spelling the importer wrote, which is a
+    // different question from cache identity: the fold gives the two spellings
+    // one module instance, and each importer still reports the one it named.
+    // `/c` closing the cycle keeps both of its edges either way.
+    assert.deepEqual(
+      (await loader.getConsumedModules('http://mapping.example/c.js')).sort(),
+      ['http://mapping.example/b', 'http://mapping.example/slow.js'],
+      'the module closing the cycle reports both of its imports',
     );
   });
 });

--- a/packages/host/tests/unit/loader-mapping-change-test.ts
+++ b/packages/host/tests/unit/loader-mapping-change-test.ts
@@ -1,0 +1,136 @@
+import { module, test } from 'qunit';
+
+import { Deferred, Loader, VirtualNetwork } from '@cardstack/runtime-common';
+
+// A realm-mapping change discards the loader's module caches: the keys they are
+// filed under are derived from the mappings, so an entry cannot outlive the
+// spelling it was keyed under. Mapping changes fire routinely — registering or
+// removing a realm is enough — and nothing coordinates them with an import that
+// happens to be in flight, so a walk suspended at a fetch resumes to find that
+// modules it has already visited, including its own ancestors, have no entry.
+//
+// Every module the walk has passed through has to come back out of it with the
+// full set of edges its implementation declares. `evaluate` binds factory
+// arguments positionally, so an edge lost here is not an error at the point it
+// was lost: the arguments after the gap shift down and the factory reads its
+// imports off the wrong module, or off nothing.
+module('Unit | loader mapping change during traversal', function () {
+  // Fetches `sources` by pathname, parking the first request for `parkPath`
+  // until the returned `release` is fulfilled so a caller can act while a walk
+  // is suspended mid-fetch.
+  function parkedFetch(sources: Record<string, string>, parkPath: string) {
+    let requested = new Deferred<void>();
+    let release = new Deferred<void>();
+    let parked = false;
+    let fetchImpl: typeof globalThis.fetch = async (input) => {
+      let url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      let path = new URL(url).pathname;
+      if (path === parkPath && !parked) {
+        parked = true;
+        requested.fulfill();
+        await release.promise;
+      }
+      let source = sources[path];
+      if (!source) {
+        return new Response('not found', { status: 404 });
+      }
+      return new Response(source, {
+        status: 200,
+        headers: { 'content-type': 'text/javascript' },
+      });
+    };
+    return { fetchImpl, requested, release };
+  }
+
+  // `/b` reads `a` at evaluation time, which is what makes a dropped edge
+  // observable: with the edge recorded, `b`'s factory is handed `/a`'s
+  // namespace and reads an uninitialized binding off it — `undefined`, the
+  // value a cycle owes it. With the edge dropped, `b`'s factory is handed one
+  // argument fewer and reads that binding off nothing at all.
+  let cycleSources: Record<string, string> = {
+    '/a': `import { b } from './b'; export const a = 'a' + b;`,
+    '/b': `import { a } from './a'; export const b = 'b' + String(a);`,
+  };
+
+  test('a cycle participant whose cache entry is discarded mid-walk still evaluates', async function (assert) {
+    let { fetchImpl, requested, release } = parkedFetch(cycleSources, '/b');
+    let virtualNetwork = new VirtualNetwork(fetchImpl);
+    let loader = new Loader(
+      virtualNetwork.fetch,
+      virtualNetwork.resolveImport,
+      {
+        virtualNetwork,
+      },
+    );
+
+    // The walk reaches `/b` with `/a` registered and on its own recursion
+    // stack, then suspends on `/b`'s bytes. Clearing the caches here is what
+    // leaves `/b` resuming into a walk whose ancestor `/a` has no entry — the
+    // one shape in which "already being completed further up" and "nothing
+    // recorded yet" hold at once.
+    let root = loader.import<{ a: string }>('http://mapping.example/a');
+    await requested.promise;
+    virtualNetwork.addURLMapping(
+      new URL('http://alias.example/'),
+      new URL('http://real.example/'),
+    );
+    release.fulfill();
+
+    let modA = await root;
+    assert.strictEqual(
+      modA.a,
+      'abundefined',
+      'the factory binds its imports positionally and reads the cycle through them',
+    );
+
+    // The failure this guards against is cached, not transient: a factory that
+    // throws leaves the module `broken` for the life of the loader, so every
+    // later import of it throws the same error and nothing short of a new
+    // loader recovers. Re-importing is the assertion that matters most here.
+    let again = await loader.import<{ a: string }>('http://mapping.example/a');
+    assert.strictEqual(
+      again.a,
+      'abundefined',
+      'a later import of the same module is unaffected',
+    );
+  });
+
+  test('a cycle participant whose cache entry is discarded mid-walk reports every module it imported', async function (assert) {
+    let { fetchImpl, requested, release } = parkedFetch(cycleSources, '/b');
+    let virtualNetwork = new VirtualNetwork(fetchImpl);
+    let loader = new Loader(
+      virtualNetwork.fetch,
+      virtualNetwork.resolveImport,
+      {
+        virtualNetwork,
+      },
+    );
+
+    let root = loader.import<{ a: string }>('http://mapping.example/a');
+    await requested.promise;
+    virtualNetwork.addURLMapping(
+      new URL('http://alias.example/'),
+      new URL('http://real.example/'),
+    );
+    release.fulfill();
+    await root;
+
+    // The index records module dependencies from this, so an edge missing here
+    // is an edit to that module never invalidating its importer.
+    assert.deepEqual(
+      (await loader.getConsumedModules('http://mapping.example/b')).sort(),
+      ['http://mapping.example/a'],
+      'the module that resumed into the cleared caches reports its import',
+    );
+    assert.deepEqual(
+      (await loader.getConsumedModules('http://mapping.example/a')).sort(),
+      ['http://mapping.example/b'],
+      'its importer reports the edge it was walked through',
+    );
+  });
+});

--- a/packages/host/tests/unit/loader-mapping-change-test.ts
+++ b/packages/host/tests/unit/loader-mapping-change-test.ts
@@ -62,11 +62,12 @@ module('Unit | loader mapping change during traversal', function () {
   //
   // Anyone restructuring this module must re-verify it still has teeth. A
   // `registered` case that records a completing-dep only when the dep is
-  // already registered drops `/b`'s edge to `/a`, and every test here rejects
-  // on the length invariant, which catches the drop before the factory is ever
-  // called — `bug: dependency list for http://mapping.example/b recorded 1 of
-  // the 2 dependencies it declares` for the two-module cycle, and the same for
-  // `/c.js` at 2 of 3 in the mixed-spelling one. Remove that invariant too and
+  // already registered, and otherwise falls through without either recording
+  // the edge or advancing the dep, drops `/b`'s edge to `/a`. Every test here
+  // then rejects on the length invariant, which catches the drop before the
+  // factory is ever called — `bug: dependency list for http://mapping.example/b
+  // recorded 1 of the 2 dependencies it declares` for the two-module cycle, and
+  // the same for `/c.js` at 2 of 3 in the mixed-spelling one. Remove that invariant too and
   // the rejection becomes the mis-binding it exists to prevent:
   // `Cannot read properties of undefined (reading 'a')`.
   let cycleSources: Record<string, string> = {

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -869,6 +869,12 @@ export class Loader {
       | 'registered-completing-deps'
       | 'registered-with-deps'
       | 'evaluated',
+    // The modules whose own advance to each state is in flight further up this
+    // recursion, so a dep that lands back on one of them is a cycle edge rather
+    // than work to do. Held as cache keys, the same form `getModule` looks a
+    // module up under, so an ancestor reached by a different spelling of itself
+    // — extensionless against `.js`, an alias against the real URL — is still
+    // recognized as the ancestor it is.
     stack: {
       'registered-completing-deps': string[];
       'registered-with-deps': string[];
@@ -899,14 +905,32 @@ export class Loader {
             }
             let depModule = this.getModule(entry.moduleURL.href);
             if (!isEvaluatable(depModule)) {
-              // we always only await the first dep that actually needs work and
-              // then break back to the top-level state machine, so that we'll
-              // be working from the latest state.
+              // A dep short of evaluatable is either a cycle edge back into a
+              // walk already in flight, or work to do. Being on the stack is
+              // not enough to make it the former: an ancestor is only safe to
+              // record and leave to its own walk once it has registered, because
+              // registering is what gives it a dependency list of its own. An
+              // ancestor with no entry — or one still fetching, its caches
+              // discarded by a realm-mapping change while this walk was
+              // suspended — has named nothing yet, so it is work like any other
+              // dep, and re-entering the state machine is what re-establishes
+              // it. Recursing on it terminates for the same reason the first
+              // walk did: the fetch registers it, and the walk it starts finds
+              // this module on the stack and registered.
               if (
-                !stack['registered-completing-deps'].includes(
-                  entry.moduleURL.href,
+                isRegistered(depModule) &&
+                stack['registered-completing-deps'].includes(
+                  this.moduleCacheKey(entry.moduleURL.href),
                 )
               ) {
+                maybeReadyDeps.push({
+                  type: 'completing-dep',
+                  moduleURL: entry.moduleURL,
+                });
+              } else {
+                // we always only await the first dep that actually needs work and
+                // then break back to the top-level state machine, so that we'll
+                // be working from the latest state.
                 await this.advanceToState(
                   entry.moduleURL,
                   'registered-completing-deps',
@@ -915,17 +939,12 @@ export class Loader {
                     ...{
                       'registered-completing-deps': [
                         ...stack['registered-completing-deps'],
-                        resolvedURL.href,
+                        this.moduleCacheKey(resolvedURL.href),
                       ],
                     },
                   },
                 );
                 break outer_switch;
-              } else if (isRegistered(depModule)) {
-                maybeReadyDeps.push({
-                  type: 'completing-dep',
-                  moduleURL: entry.moduleURL,
-                });
               }
             } else if (depModule.state === 'registered-completing-deps') {
               maybeReadyDeps.push({
@@ -939,6 +958,11 @@ export class Loader {
               });
             }
           }
+          this.assertEveryDepRecorded(
+            resolvedURL.href,
+            maybeReadyDeps,
+            module.dependencyList,
+          );
           this.setModule(resolvedURL.href, {
             state: 'registered-completing-deps',
             implementation: module.implementation,
@@ -987,7 +1011,7 @@ export class Loader {
                     ...{
                       'registered-completing-deps': [
                         ...stack['registered-completing-deps'],
-                        resolvedURL.href,
+                        this.moduleCacheKey(resolvedURL.href),
                       ],
                     },
                   },
@@ -996,7 +1020,9 @@ export class Loader {
               }
               case 'registered-completing-deps': {
                 if (
-                  !stack['registered-with-deps'].includes(entry.moduleURL.href)
+                  !stack['registered-with-deps'].includes(
+                    this.moduleCacheKey(entry.moduleURL.href),
+                  )
                 ) {
                   await this.advanceToState(
                     entry.moduleURL,
@@ -1006,7 +1032,7 @@ export class Loader {
                       ...{
                         'registered-with-deps': [
                           ...stack['registered-with-deps'],
-                          resolvedURL.href,
+                          this.moduleCacheKey(resolvedURL.href),
                         ],
                       },
                     },
@@ -1030,6 +1056,11 @@ export class Loader {
                 });
             }
           }
+          this.assertEveryDepRecorded(
+            resolvedURL.href,
+            readyDeps,
+            module.dependencies,
+          );
           this.setModule(resolvedURL.href, {
             state: 'registered-with-deps',
             implementation: module.implementation,
@@ -1052,6 +1083,28 @@ export class Loader {
         default:
           throw assertNever(module);
       }
+    }
+  }
+
+  // `evaluate` binds a module's factory arguments positionally from the
+  // dependency list the registered-state transitions build, so a list that
+  // comes out shorter than the one the module declared does not fail where the
+  // entry was lost: the arguments after the gap shift down, and the factory is
+  // handed either the wrong module or nothing at all. Both transitions rebuild
+  // the list entry by entry and reach the commit only by running the loop to
+  // completion — every path that has work to do leaves through
+  // `break outer_switch` with nothing committed — so a length mismatch is a
+  // dropped edge and can be nothing else. Raising here names the module that
+  // dropped it instead of leaving a mis-bound factory to fail somewhere else.
+  private assertEveryDepRecorded(
+    moduleIdentifier: string,
+    recorded: EvaluatableDep[],
+    declared: (UnregisteredDep | EvaluatableDep)[],
+  ) {
+    if (recorded.length !== declared.length) {
+      throw new Error(
+        `bug: dependency list for ${moduleIdentifier} recorded ${recorded.length} of the ${declared.length} dependencies it declares`,
+      );
     }
   }
 

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -914,9 +914,18 @@ export class Loader {
               // discarded by a realm-mapping change while this walk was
               // suspended — has named nothing yet, so it is work like any other
               // dep, and re-entering the state machine is what re-establishes
-              // it. Recursing on it terminates for the same reason the first
-              // walk did: the fetch registers it, and the walk it starts finds
-              // this module on the stack and registered.
+              // it.
+              //
+              // What bounds that recursion is the cache clear itself, not the
+              // graph. A clear landing inside the re-fetch trips the generation
+              // check in `fetchModule`, which abandons the response without
+              // registering, so the level retries and finds the ancestor gone
+              // again — one extra level per clear that lands inside a single
+              // walk, and one more unit of work for every level, since each
+              // copies and rescans the stack. Realm mappings are registered as
+              // realms are mounted, so a walk normally spans zero or one of
+              // them; a walk racing an unbounded stream of them descends
+              // without a bound.
               if (
                 isRegistered(depModule) &&
                 stack['registered-completing-deps'].includes(

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -922,10 +922,11 @@ export class Loader {
               // registering, so the level retries and finds the ancestor gone
               // again — one extra level per clear that lands inside a single
               // walk, and one more unit of work for every level, since each
-              // copies and rescans the stack. Realm mappings are registered as
-              // realms are mounted, so a walk normally spans zero or one of
-              // them; a walk racing an unbounded stream of them descends
-              // without a bound.
+              // copies and rescans the stack. Only adding or removing a realm
+              // mapping fires a clear, and that happens as the process wires up
+              // its realms rather than while it serves them, so a walk normally
+              // spans zero of them; a walk racing an unbounded stream of them
+              // descends without a bound.
               if (
                 isRegistered(depModule) &&
                 stack['registered-completing-deps'].includes(

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -923,10 +923,11 @@ export class Loader {
               // again — one extra level per clear that lands inside a single
               // walk, and one more unit of work for every level, since each
               // copies and rescans the stack. Only adding or removing a realm
-              // mapping fires a clear, and that happens as the process wires up
-              // its realms rather than while it serves them, so a walk normally
-              // spans zero of them; a walk racing an unbounded stream of them
-              // descends without a bound.
+              // mapping fires a clear, which happens as a realm is registered or
+              // torn down — rare, discrete events, and reachable on a process
+              // already serving, since creating a realm can remap it — so a walk
+              // normally spans zero of them; a walk racing an unbounded stream
+              // of them descends without a bound.
               if (
                 isRegistered(depModule) &&
                 stack['registered-completing-deps'].includes(


### PR DESCRIPTION
## The problem

`advanceToState`'s `registered` transition rebuilds a module's dependency list entry by entry, and in `packages/runtime-common/loader.ts` it classified each dep three ways while recording only two of them:

```ts
let depModule = this.getModule(entry.moduleURL.href);
if (!isEvaluatable(depModule)) {
  if (!stack['registered-completing-deps'].includes(entry.moduleURL.href)) {
    await this.advanceToState(entry.moduleURL, 'registered-completing-deps', …);
    break outer_switch;
  } else if (isRegistered(depModule)) {
    maybeReadyDeps.push({ type: 'completing-dep', moduleURL: entry.moduleURL });
  }
  // no else
}
```

A dep that is on the completing stack **and** has no cache entry — or is still `fetching` — matches neither arm. The entry never reaches `maybeReadyDeps`, and the module transitions to `registered-completing-deps` holding fewer dependencies than its implementation declares.

`evaluate` binds factory arguments positionally from that list, so the truncation does not fail where the entry was lost. The module is handed one argument fewer than it declared and reads an import off `undefined`; that throws, and the module is cached `broken` for the life of the loader, so every later import of it throws the same error. Nothing short of a new loader recovers. Where a dep positioned after the gap is already evaluatable, the same truncation shifts arguments down instead of running off the end, and the factory binds the wrong modules with no error at all.

**How a dep on the stack loses its entry.** Anything that clears `this.modules` while the walk is suspended at a fetch. The `onMappingChange` subscription does exactly that: the module caches are keyed by a form derived from the realm mappings, so they are discarded whenever a mapping is added or removed. An ancestor that was `registered` when it was pushed onto the stack is simply gone when the walk returns to it. Registering or removing a realm is enough to fire one, and nothing coordinates that with an import in flight.

### Not an exotic race

A two-module cycle reproduces it deterministically — no artificial graph, one mapping change while one fetch is parked:

```
/a: import { b } from './b'; export const a = 'a' + b;
/b: import { a } from './a'; export const b = 'b' + String(a);
```

Park `/b`'s fetch, fire `addURLMapping`, release:

```
                        before          after
root import             TypeError       'abundefined'
second import           TypeError       'abundefined'
```

The second line is the one that matters: the failure is cached, not transient. `'abundefined'` is what the same graph produces with no mapping change at all — `/b` reading an uninitialized binding through the cycle is the value it is owed.

The dropped edge is `importer=/b dep=/a`, with `/a` in state `fetching`. The drop commits only when the lost dep is the last one in the list needing work; a later dep that needs work leaves through `break outer_switch` and discards the partial list, which is part of why this surfaces intermittently rather than constantly.

## The change

Invert the branch so the fall-through is unrepresentable. A registered ancestor on the stack is recorded as a `completing-dep` and left to its own walk — registering is what gives it a dependency list of its own for `evaluate` to bind. Everything else, including an ancestor with no entry, is work to advance: re-entering the state machine is what re-establishes it. What bounds that recursion is the cache clear rather than the graph — a clear landing inside the re-fetch abandons it without registering, costing one more level — which is measured under **Test plan** below.

Both registered-state transitions now also assert the rebuilt list is as long as the one the module declared. That holds structurally: every path with work to do leaves through `break outer_switch` having committed nothing, so the commit is reached only by running the loop to completion. A length mismatch is a dropped edge and can be nothing else, and raising there names the module that dropped it instead of leaving a mis-bound factory to fail somewhere else.

### The stack now holds cache keys

`stack['registered-completing-deps']` held raw hrefs while `getModule` looks a module up under its cache key, which folds every spelling of a module — extensionless against `.js`, an alias against the real URL — onto one entry. Comparing raw hrefs made the cycle check spelling-exact: the same graph reached with `.js` on one edge and extensionless on the other missed the check, took the recursing arm, and walked correctly by luck rather than by design.

Holding cache keys makes the cycle check agree with the map it is reasoning about. It also makes the branch above genuinely reachable in cases where the spelling mismatch was papering over it, so landing it alone would make things worse — measured under **Not covered by a test** below, which is why it is one commit.

## Test plan

New unit module `packages/host/tests/unit/loader-mapping-change-test.ts`, 3/3 in Chrome: the two-module cycle above, asserting the root evaluates, that a **later** import of the same module is unaffected (the cached-failure half), and that both modules report every edge they imported; plus a mixed-spelling cycle whose two edges name the shared module with and without its extension, resolving to one module instance through the same mid-walk clear. The first two have teeth: run against the unmodified loader under node, that scenario rejects with `Cannot read properties of undefined (reading 'a')` on the first import and again on the second. The third is a fold-contract guard rather than a regression test for this change — see **Not covered by a test** below.

Every realm-free loader module passes in Chrome against this branch — 57 tests total, including the two guards on cycle completion under concurrent roots and the 30 `loader seams` tests that cover module eviction and `invalidateModule` fan-in:

| module | |
| --- | --- |
| `loader seams` | 30/30 |
| `loader concurrent cycle completion` | 2/2 |
| `loader mapping change during traversal` | 3/3 |
| `loader fetch-failure caching` | 2/2 |
| `Loader transient 5xx retry` | 11/11 |
| `loader \| missing boxel icon` | 2/2 |
| `loader \| iconNotFoundMessage` | 7/7 |

`Unit | loader` and `Unit | loader prefetch` need a realm server and are left to CI.

Verified against randomized graphs (2–6 modules, 0–2 edges each, self-imports and duplicate imports, up to three concurrent import roots, a fetch parked at a varying depth) with a mapping change injected while the walk is suspended. Each run checks three things: no unexpected rejection, no factory handed a module other than the one that argument position names, and no consumed-module set naming anything outside that module's true static import closure. This harness drives the loader directly under node; the unit module above is the browser-side guard.

- **1,800 graphs with a mapping change injected: all clean.**
- **The fix is a no-op when no mapping change fires.** Across 300 graphs with the injection disabled, the full snapshot — every module's consumed-module set and every root factory's view of its bound arguments — is byte-identical before and after.
- **With the injection enabled, the differences are exactly the damage.** 8 of 300 graphs differ; those 8 are precisely the 8 that rejected before, and none rejects now. Their consumed-module sets also widen back to the true import closure in the same 8, so the drop was costing edges even where it did not kill the load.
- **The length assertion never fired** across the ~2,100 graph runs above — and it is not decoration: restore the unrecorded-edge branch while leaving the assertion in place and both mapping-change tests reject with `bug: dependency list for http://mapping.example/b recorded 1 of the 2 dependencies it declares`, catching the dropped edge before the factory is ever called.
- **Recursion depth grows with the number of cache clears that land inside one walk — this is the cost of the trade.** One extra level per clear, measured exactly: 1 clear → depth 3, 2 → 4, 5 → 7, 20 → 22, 100 → 102. A clear landing inside the re-fetch trips the generation check in `fetchModule`, which abandons the response without registering, so the level retries and finds the ancestor gone again. Each level also copies and rescans the stack, so the work grows faster than the depth. It degrades rather than crashes — every level unwinds to a microtask, so no `RangeError` — but the bound is the clear rate, not the graph. Only adding or removing a realm mapping fires a clear — rare, discrete events as a realm is registered or torn down, and reachable on a process already serving, since handling `/_create-realm` calls `addURLMapping` when a virtual-to-real remap applies — so a walk normally spans zero of them. The alternative is the silent corruption above at constant depth.

  Worth recording because it is easy to measure wrongly: clearing on *every* fetch never reaches this branch at all. It saturates at depth 2, spinning in the pre-existing top-level `case undefined → fetchModule → generation check abandons` retry. Only a clear that lands while the walk is suspended at a *dependency's* fetch, with the ancestor already registered, gets there.
- **Mixed spellings are unchanged.** A cycle whose two edges name the shared module with and without its extension resolves identically before and after, with and without a mapping change, and both spellings still collapse to one module instance.

## Not covered by a test

**The cache-key conversion has no test that fails without it, and cannot.** Comparing the completing stack by cache key rather than raw href changes only how many levels the walk descends, never the result — the same graph resolves identically either way. Measured on 250 spelling-varied graphs (each edge independently naming its target with or without `.js`): maxDepth 7 → 6 and `advanceToState` calls 998 → 842, ~16% fewer levels. The mixed-spelling test pins the fold's observable contract and passes with the conversion reverted; its comment says so rather than implying coverage it does not have.

**It must not land on its own, which is measured.** On those same graphs under an injected mapping change:

| configuration | clean |
| --- | --- |
| unrecorded-edge branch, raw-href stack | 242/250 |
| unrecorded-edge branch, cache-key stack | **235/250** |
| both changes together | **250/250** |

The cache-key stack *alone* is worse than neither change, because agreeing with the fold makes the dropped-edge branch more reachable — the spelling mismatch was partly masking it. Only together do they reach zero failures.

The second `assertEveryDepRecorded` call site — the `registered-completing-deps` → `registered-with-deps` commit — is likewise reached by no test, only by the randomized harness. And the "no cache entry at all" dep state is not exercised by the unit tests: `register` → `prefetchDependencies` installs a `fetching` entry synchronously, so the tests always hit the `fetching` half of that branch.

Checks: `ember-tsc --noEmit` reports no errors in `loader.ts` and the same 88 pre-existing `@cardstack/base` type-generation errors in `packages/runtime-common` before and after; no errors in the new test module in `packages/host`. eslint and prettier clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017E5smKgfiZSpvonRA3PDxb