### PR TITLE
Update prerender manager to recycle on first host shell token

### DIFF
--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -67,8 +67,11 @@ type Registry = {
   lastAccessByAffinity: Map<string, number>;
   // Latest host-shell token reported by a realm server (POST /host-shell).
   // Echoed to prerender servers on every heartbeat response so they recycle
-  // when it changes (host redeployed). Undefined until first reported; reset
-  // on manager restart, re-learned from the next realm-server boot report.
+  // when it differs from the shell they warmed against. Undefined until first
+  // reported; reset on manager restart, re-learned from the next realm-server
+  // boot report. The reset is not load-bearing: a prerender server compares
+  // the echoed token against its own baseline, and a token it has not warmed
+  // against is a recycle whether or not this manager saw an earlier one.
   hostShellHash?: string;
 };
 
@@ -564,8 +567,17 @@ export function buildPrerenderManagerApp(options?: {
         return;
       }
       if (registry.hostShellHash !== hash) {
+        // Two distinct events, kept distinct in the log. A manager holding no
+        // token has usually just restarted in the same deploy train as the
+        // realm server reporting to it, so it cannot tell a new host bundle
+        // from the one already deployed — and it is the prerender servers,
+        // comparing against their own baselines, that decide to recycle. Only
+        // a token succeeding a different token is evidence of a host change
+        // this manager actually observed.
         log.info(
-          `host shell token changed (${registry.hostShellHash ?? 'none'} -> ${hash}); prerender servers will recycle on next heartbeat`,
+          registry.hostShellHash === undefined
+            ? `host shell token learned (${hash}); no earlier token on this manager, so prerender servers reconcile it against their own baselines`
+            : `host shell token changed (${registry.hostShellHash} -> ${hash}); prerender servers will recycle on next heartbeat`,
         );
         registry.hostShellHash = hash;
       }

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -1328,6 +1328,16 @@ export class PagePool {
       clearInterval(this.#contractionInterval);
       this.#contractionInterval = undefined;
     }
+    // Awaiting an in-flight standby refill is a contract, not teardown
+    // hygiene. A caller that closes the pool in order to replace the browser
+    // under it — the host-shell recycle does this on every prerender boot,
+    // where the initial warm is often still running — closes that browser as
+    // soon as this resolves. A standby that completed afterwards would add
+    // itself to `#standbys` holding a page on the replaced browser, where a
+    // later `getPage` can commandeer it, and its `#creatingStandbys--` would
+    // land below the zero this method resets the counter to, under-reporting
+    // pool occupancy for the life of the process. Pinned by
+    // `tests/page-pool-standby-refill-test.ts`.
     let ensuring = this.#ensuringStandbys;
     this.#ensuringStandbys = null;
     if (ensuring) {

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -70,11 +70,23 @@ export function decorateRenderErrorDiagnostics(
 // manager last reported (`reported`, null when it doesn't know one yet) and
 // the token this server warmed against (`warmed`, undefined before the first
 // report), decide whether to recycle and what the baseline token becomes:
-//   - no report          → keep the current baseline, don't recycle
-//   - first report seen   → adopt it as the baseline, don't recycle (we just
-//                           warmed against whatever shell is current)
-//   - same as baseline    → no-op
-//   - differs from baseline → recycle and advance the baseline
+//   - no report            → keep the current baseline, don't recycle
+//   - matches the baseline → no-op
+//   - anything else        → recycle and adopt the reported token
+//
+// "Anything else" covers the first token a fresh process sees, and that case
+// is the whole point rather than an edge: a prerender server has no way to
+// know which host shell its pages loaded, and the shell it warmed against is
+// most likely stale precisely when it boots. The deploy train restarts
+// prerender BEFORE the realm server, and a page loads its shell FROM the
+// realm server, so a server coming up mid-train warms against the outgoing
+// bundle. Adopting the first reported token as a silent baseline would take
+// that warm to be current and never reload it — the pages then render
+// post-deploy realm source against the pre-deploy bundle, which surfaces as
+// `has no exported member` module errors and persists as error docs served
+// from cache. Recycling once per prerender restart is the cheaper side of
+// that trade: the standbys are re-warmed either way.
+//
 // Exported for unit testing; the live caller layers the draining / in-flight
 // guards and the async recycle on top.
 export function decideHostShellRecycle(
@@ -84,7 +96,7 @@ export function decideHostShellRecycle(
   if (!reported) {
     return { recycle: false, nextWarmed: warmed };
   }
-  if (warmed === undefined || warmed === reported) {
+  if (warmed === reported) {
     return { recycle: false, nextWarmed: reported };
   }
   return { recycle: true, nextWarmed: reported };
@@ -1324,14 +1336,16 @@ export function createPrerenderHttpServer(options?: {
       warmedHostShellHash,
     );
     if (!recycle) {
-      // Either nothing reported, or we adopted a baseline / matched — record
-      // the (possibly newly-adopted) token and we're done.
+      // Either nothing was reported or the token matches the baseline —
+      // record it and we're done.
       warmedHostShellHash = nextWarmed;
       return;
     }
     recyclingForHostChange = true;
     log.info(
-      `host shell changed (${warmedHostShellHash} -> ${hash}); recycling prerender browser`,
+      warmedHostShellHash === undefined
+        ? `host shell token first seen (${hash}); recycling prerender browser, which may have warmed against an earlier shell`
+        : `host shell changed (${warmedHostShellHash} -> ${hash}); recycling prerender browser`,
     );
     void prerenderer
       .recycle()

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -1327,6 +1327,13 @@ export function createPrerenderHttpServer(options?: {
   // Compare the manager's current host-shell token against the one we warmed
   // against. A change means the host was redeployed, so recycle the browser
   // (fire-and-forget; the heartbeat itself must not block on the restart).
+  //
+  // This can fire on the very first heartbeat, while the pool's initial
+  // standby warm is still running: the heartbeat loop starts as soon as the
+  // server is listening, and that warm is deliberately not awaited. The
+  // restart serializes behind the warm rather than racing it — `closeAll`
+  // awaits any in-flight standby refill before closing — so pages the warm is
+  // mid-way through creating can't outlive the browser the restart replaces.
   function reconcileHostShell(hash: string | null) {
     if (draining || recyclingForHostChange) {
       return;

--- a/packages/realm-server/prerender/prerender-constants.ts
+++ b/packages/realm-server/prerender/prerender-constants.ts
@@ -2,13 +2,18 @@ export const PRERENDER_SERVER_STATUS_HEADER = 'X-Boxel-Prerender-Server-Status';
 export const PRERENDER_SERVER_STATUS_DRAINING = 'draining';
 export const PRERENDER_SERVER_DRAINING_STATUS_CODE = 410;
 
-// Opaque token for the current host shell (the realm server's rewritten
-// index.html). The realm server reports it to the manager at boot
-// (POST /host-shell); the manager echoes the latest value on every
-// heartbeat response via this header, and a prerender server recycles its
-// browser when the value differs from the shell it last warmed against —
-// i.e. the host was redeployed. The token only has to change when the host
-// bundle changes; prerender servers treat it opaquely.
+// Opaque token for the current host shell: a truncated hash of the host app's
+// index.html as the realm server fetches it from its host-app URL, before the
+// per-request config rewrite `serve-index` applies when serving that HTML. The
+// realm server reports the token to the manager at boot and again from the
+// post-deployment hook (POST /host-shell); the manager echoes the latest value
+// on every heartbeat response via this header.
+//
+// A prerender server recycles its browser for any token that isn't the one it
+// last warmed against — the first token it sees included, since a server that
+// booted mid-deploy warmed against the outgoing shell and holds no baseline to
+// compare against. The token only has to change when the host bundle changes;
+// prerender servers treat it opaquely.
 export const PRERENDER_HOST_SHELL_HASH_HEADER =
   'X-Boxel-Prerender-Host-Shell-Hash';
 

--- a/packages/realm-server/tests/page-pool-standby-refill-test.ts
+++ b/packages/realm-server/tests/page-pool-standby-refill-test.ts
@@ -27,6 +27,7 @@ interface BrowserStubOptions {
   // toggle this to make standby refill arbitrarily slow.
   gate: () => Promise<void>;
   onContextCreated?: () => void;
+  onContextClosed?: () => void;
 }
 
 function makeBrowserStub(opts: BrowserStubOptions) {
@@ -53,7 +54,9 @@ function makeBrowserStub(opts: BrowserStubOptions) {
             on() {},
           };
         },
-        async close() {},
+        async close() {
+          opts.onContextClosed?.();
+        },
       };
       return context;
     },
@@ -89,6 +92,22 @@ function makeManualGate() {
       return waiters.length;
     },
   };
+}
+
+// Poll for a condition instead of sleeping a guessed interval, so a test that
+// needs the pool to reach a state waits exactly as long as that takes.
+async function waitUntil(
+  predicate: () => boolean,
+  description: string,
+  timeoutMs = 2000,
+): Promise<void> {
+  let deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
 }
 
 module(basename(import.meta.filename), function (hooks) {
@@ -192,6 +211,62 @@ module(basename(import.meta.filename), function (hooks) {
     );
 
     result.release();
+  });
+
+  // `closeAll` awaiting the in-flight refill is a contract rather than
+  // teardown hygiene, because a caller can be closing the pool in order to
+  // replace the browser under it: the prerender server's host-shell recycle
+  // does exactly that, on a boot where the initial warm is usually still
+  // running. If `closeAll` returned first, the browser would be replaced while
+  // a standby was still being created, and that standby would land in the live
+  // standby set holding a page on a browser that no longer exists — a tab a
+  // later `getPage` can commandeer, and a `#creatingStandbys` decrement below
+  // the zero `closeAll` resets, which under-reports pool occupancy for the
+  // life of the process.
+  test('closeAll waits for an in-flight standby refill and closes what it created', async function (assert) {
+    let gate = makeManualGate();
+    let created = 0;
+    let closed = 0;
+    let browserManager = makeBrowserStub({
+      gate: gate.gate,
+      onContextCreated: () => created++,
+      onContextClosed: () => closed++,
+    });
+    let pool = makePool({ maxPages: 2, browserManager });
+
+    // Park the refill inside `createBrowserContext`, so it is provably
+    // mid-creation — not merely scheduled — when `closeAll` runs.
+    gate.block();
+    let refill = pool.warmStandbys();
+    await waitUntil(
+      () => gate.waiterCount() > 0,
+      'the standby refill to park on the gate',
+    );
+    assert.strictEqual(created, 0, 'no context exists yet');
+
+    let closeAllSettled = false;
+    let closeAll = pool.closeAll().then(() => {
+      closeAllSettled = true;
+    });
+    // Everything else `closeAll` does resolves within a few turns of the
+    // event loop against an empty pool, so still-pending here isolates the
+    // await being asserted.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.false(
+      closeAllSettled,
+      'closeAll is still pending while a standby is mid-creation',
+    );
+
+    gate.unblockAll();
+    await closeAll;
+    await refill;
+
+    assert.true(created > 0, 'the refill created at least one context');
+    assert.strictEqual(
+      closed,
+      created,
+      'every context the refill created was closed by closeAll',
+    );
   });
 
   test('a stalled refill on affinity A does not block a concurrent reused-tab caller on affinity B', async function (assert) {

--- a/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
+++ b/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
@@ -9,8 +9,10 @@ import {
 
 // Unit tests for the host-shell recycle decision a prerender server makes on
 // every heartbeat: the manager echoes the current host-shell token, and the
-// server recycles its browser when that token differs from the one it warmed
-// against (the host was redeployed). See PRERENDER_HOST_SHELL_HASH_HEADER.
+// server recycles its browser for any token that isn't the one it warmed
+// against — including the first token it ever sees, since a server that boots
+// mid-deploy has warmed against the outgoing host bundle. See
+// PRERENDER_HOST_SHELL_HASH_HEADER.
 module(basename(import.meta.filename), function () {
   module('decideHostShellRecycle', function () {
     test('no token reported yet → no recycle, baseline unchanged', function (assert) {
@@ -24,9 +26,17 @@ module(basename(import.meta.filename), function () {
       });
     });
 
-    test('first token seen → adopt as baseline, no recycle', function (assert) {
+    // The regression this guards is the one that disarms the whole mechanism.
+    // A prerender server has no record of which host shell its pages loaded,
+    // and the deploy train restarts it before the realm server it loads that
+    // shell from — so on the first token it sees, "I warmed against something
+    // else" is the assumption that keeps stale pages out of the pool. Silently
+    // adopting the token as a baseline instead leaves a server rendering new
+    // realm source against an old bundle until ordinary pool churn replaces
+    // the tab.
+    test('first token seen → recycle, since the warm predates knowing the token', function (assert) {
       assert.deepEqual(decideHostShellRecycle('aaa', undefined), {
-        recycle: false,
+        recycle: true,
         nextWarmed: 'aaa',
       });
     });


### PR DESCRIPTION
This is another mitigation for last night’s over-an-hour host mode site downtime. #5205 added a recycle signal for prerenders but there was a logic gap that helped contribute to the downtime.

Claude: The host-shell recycle exists to replace prerender pages holding a stale host bundle, and the case it most needed to catch was the one it declined to act on. `decideHostShellRecycle` treated the first token a process saw as a baseline to adopt rather than a shell to reload, on the grounds that "we just warmed against whatever shell is current". That is false during the deploy that creates a stale page: the train restarts prerender before the realm server, a page loads its shell from the realm server, so a prerender server booting mid-train warms against the outgoing bundle. Both baselines that could have flagged it — the manager's in-memory token and the prerender server's warmed token — reset in that same train.

In production on 2026-08-26 the manager logged `host shell token changed (none -> 73310b41)` 58 seconds before a page on the old bundle rendered newly deployed base source, threw `has no exported member 'googleFontImportsFor'`, and persisted it as an error doc on base/Theme/boxel-brand-guide. Zero recycles were logged, the old bundle went away through ordinary pool churn seven minutes later, and anonymous card+json reads 500'd on every realm linking the base theme until that row was reindexed.

Any reported token that isn't the one this process warmed against is now a recycle, "we don't know" included. The cost is one extra browser restart per prerender restart, and the standbys are re-warmed either way.

The manager's log line also stops claiming a recycle it can't predict: a token arriving with no earlier token on that manager reads as "learned", and only a token succeeding a different one reads as "changed". Making the manager's token durable across its own restart would need persistence it doesn't have, and with the prerender side comparing against its own baseline it would buy nothing.

Residual, unchanged here: a recycle triggered by the boot-time report can re-warm through the load balancer onto a realm-server task that hasn't rolled yet, and the baseline advances regardless. The deploy pipeline's own prerender-recycle step, which runs once the realm server is live, is the backstop for that.