### PR TITLE
Add the v1 module classifier: trusted-URL check and the sandbox module graph

### DIFF
--- a/docs/boxel-rendering-protocol.md
+++ b/docs/boxel-rendering-protocol.md
@@ -307,8 +307,13 @@ unambiguously a path inside an `@cardstack` package — decodable, free of
 `\`, `%`, `?` and `#`, and free of `.`/`..` segments — and is rejected
 rather than normalized otherwise. Nothing derived from a module's SOURCE
 participates in this decision, so no cache, hash, or graph result can reach
-it. A wider set of import origins is Host-provided — the Catalog realm, the
-icons host, the framework stand-ins, and whatever else a runtime shims —
+it. The scope `@cardstack/<name>/` is NOT by itself the predicate: it is also
+the realm-alias namespace (`addRealmMapping` registers one such prefix per
+mapped realm, generically), so provenance within the scope is decided by an
+allowlist of Host package names. A realm's alias spelling and its URL spelling
+must always agree about that realm; the Base realm is on the list because it
+is trusted on its own account. A wider set of import origins is Host-provided
+— the icons host, the framework stand-ins, and whatever else a runtime shims —
 which is the graph walk's pruning test (RP-6.7) and NOT a grant of Direct
 execution: what a module may import says nothing about who wrote it
 (`trusted-modules.ts`).
@@ -317,7 +322,11 @@ execution: what a module may import says nothing about who wrote it
 set reachable from the entry over static import edges and literal-specifier
 dynamic imports, collected in full before anything is read off it, with
 Host-provided modules (RP-6.6) recorded as edges but never fetched or
-followed, and bounded at 256 authored modules. The graph is the exact read
+followed, and bounded at 256 module reads — attempted reads, not successful
+ones, so unreadable imports cannot outrun the bound. Pruning is sound only
+where trust begins: a pruned module's closure is the Host's to resolve, so
+published realm content is walked like any other authored source however
+Host-owned its realm. The graph is the exact read
 authority a stronger runtime is given — a Sandbox authorizes a module fetch
 against it before any authenticated request fires — so it is reported with
 an availability flag, and it is an authorization list only when that flag
@@ -327,7 +336,15 @@ graph unavailable and name the failure; a render over an unavailable graph
 fails closed with that diagnostic rather than authorizing a wider set, and
 an unavailable result is not memoized. Computed dynamic specifiers cannot
 be statically authorized, are absent from the graph, and are refused at
-runtime. The result is a property of the graph, not of traversal: a diamond
+runtime. The graph is over the specifiers the author wrote; a module the
+compiler synthesizes from one of them is not an authored edge and is not in it.
+The scoped-CSS sibling of a module carries its own content in its URL and is
+resolved by the loader without a realm read, so it is not part of the read
+authority — a gate that is asked for one admits it exactly when the module it
+was derived from is in the graph, and never on its own. Graph entries are not
+in one canonical spelling: a gate must fold the same identifier family the
+Loader does rather than compare strings exactly. The result is a property of
+the graph, not of traversal: a diamond
 reached from either side and a cycle entered from either end yield the same
 graph and the same reported failure. A caller-supplied draft revision is
 classified for that caller alone and never enters the memo other entries
@@ -335,11 +352,16 @@ read, so an unsaved buffer cannot decide the read authority of a card it is
 not the source of.
 
 **RP-6.8** Classification reports whether a module's own source declares any
-`static edit = …` template — on the card class or on any FieldDef the module
-defines. This is the fact RP-6.3's exception reads, and it is a property of
-the module's declaration rather than of its graph: a module that declares
-none contributes no authored code to the edit surface. It is established for
+`static edit = …` template — on any class the module defines, whether that is
+the card class or a FieldDef, and whether or not the declaration carries a type
+annotation. This is the fact RP-6.3's exception reads, and it is a property of
+the module's declaration rather than of its graph: a module that declares none
+contributes no authored code to the edit surface. It is established for
 authored modules only, since a trusted module renders every format Direct.
+The two errors are not symmetric and the detection errs deliberately: reporting
+a declaration that is not there keeps the surface in the stronger context,
+which R5 always permits, while missing one hands a surface containing authored
+code to trusted Base chrome, which R5 forbids.
 
 ## RP-7 Relationships and lazy loading
 

--- a/docs/boxel-rendering-protocol.md
+++ b/docs/boxel-rendering-protocol.md
@@ -353,8 +353,9 @@ not the source of.
 
 **RP-6.8** Classification reports whether a module's own source declares any
 `static edit = …` template — on any class the module defines, whether that is
-the card class or a FieldDef, and whether or not the declaration carries a type
-annotation. This is the fact RP-6.3's exception reads, and it is a property of
+the card class or a FieldDef, under any spelling that names one declaration:
+with or without a type annotation, with the modifiers TypeScript allows before
+the name, under a string-literal computed key, and as a static getter. This is the fact RP-6.3's exception reads, and it is a property of
 the module's declaration rather than of its graph: a module that declares none
 contributes no authored code to the edit surface. It is established for
 authored modules only, since a trusted module renders every format Direct.

--- a/docs/boxel-rendering-protocol.md
+++ b/docs/boxel-rendering-protocol.md
@@ -298,6 +298,49 @@ is ignored with a diagnostic, because honoring it host-side would execute
 the module's authored field templates in the main document. This is an
 instance of R5: nothing may de-escalate isolation.
 
+**RP-6.6** R1's trusted-provenance predicate is a test on the module's
+identifier and admits nothing else: the Base realm, the Cardstack packages
+pseudo-origin, and `@cardstack/*` bare specifiers. A bare specifier reaches
+the predicate BEFORE the Loader resolves it, so URL normalization has not
+run and cannot protect it; that form is therefore admitted only when it is
+unambiguously a path inside an `@cardstack` package — decodable, free of
+`\`, `%`, `?` and `#`, and free of `.`/`..` segments — and is rejected
+rather than normalized otherwise. Nothing derived from a module's SOURCE
+participates in this decision, so no cache, hash, or graph result can reach
+it. A wider set of import origins is Host-provided — the Catalog realm, the
+icons host, the framework stand-ins, and whatever else a runtime shims —
+which is the graph walk's pruning test (RP-6.7) and NOT a grant of Direct
+execution: what a module may import says nothing about who wrote it
+(`trusted-modules.ts`).
+
+**RP-6.7** An authored module's classification yields its module graph: the
+set reachable from the entry over static import edges and literal-specifier
+dynamic imports, collected in full before anything is read off it, with
+Host-provided modules (RP-6.6) recorded as edges but never fetched or
+followed, and bounded at 256 authored modules. The graph is the exact read
+authority a stronger runtime is given — a Sandbox authorizes a module fetch
+against it before any authenticated request fires — so it is reported with
+an availability flag, and it is an authorization list only when that flag
+says the walk read every module it reached. An unresolvable specifier, an
+unreadable or unparseable dependency, and an exceeded bound each mark the
+graph unavailable and name the failure; a render over an unavailable graph
+fails closed with that diagnostic rather than authorizing a wider set, and
+an unavailable result is not memoized. Computed dynamic specifiers cannot
+be statically authorized, are absent from the graph, and are refused at
+runtime. The result is a property of the graph, not of traversal: a diamond
+reached from either side and a cycle entered from either end yield the same
+graph and the same reported failure. A caller-supplied draft revision is
+classified for that caller alone and never enters the memo other entries
+read, so an unsaved buffer cannot decide the read authority of a card it is
+not the source of.
+
+**RP-6.8** Classification reports whether a module's own source declares any
+`static edit = …` template — on the card class or on any FieldDef the module
+defines. This is the fact RP-6.3's exception reads, and it is a property of
+the module's declaration rather than of its graph: a module that declares
+none contributes no authored code to the edit surface. It is established for
+authored modules only, since a trusted module renders every format Direct.
+
 ## RP-7 Relationships and lazy loading
 
 **RP-7.1** Link state is a five-way union: `present`, `not-loaded`,

--- a/packages/host/app/lib/boxel-module-classifier.ts
+++ b/packages/host/app/lib/boxel-module-classifier.ts
@@ -65,10 +65,12 @@ export interface BoxelModuleClassification {
    * Spellings are mixed by construction: an authored dependency appears as
    * `resolveImport` returned it, while a module the Host provides appears as
    * the specifier the author wrote, because resolving one can evaluate it. A
-   * gate comparing a requested URL against this list must therefore fold the
-   * same identity family the Loader does (`moduleCacheKey`,
-   * `trimExecutableExtension`) rather than compare strings exactly, or it will
-   * refuse a fetch for a module that is in the list under a sibling spelling.
+   * gate comparing a requested URL against this list must therefore reproduce
+   * the runtime's own resolution before comparing — the Loader's identifier
+   * folding (`moduleCacheKey`, `trimExecutableExtension`) AND the import-map
+   * transforms that send a package specifier somewhere else entirely, as
+   * `@cardstack/boxel-icons/mail` is rewritten onto the icons host. An exact
+   * string comparison refuses fetches for modules that are in the list.
    */
   moduleGraph: readonly string[];
 
@@ -142,8 +144,9 @@ export interface BoxelModuleClassifierOptions {
   isHostProvidedModule?(moduleIdentifier: string): boolean;
 
   /**
-   * The number of authored modules one walk will read. Modules the walk prunes
-   * at do not count against it, since they are never fetched.
+   * The number of module reads one walk will attempt. A read that fails counts,
+   * so unreadable imports cannot outrun the bound; modules the walk prunes at
+   * do not, since they are never read.
    */
   maxModules?: number;
 }

--- a/packages/host/app/lib/boxel-module-classifier.ts
+++ b/packages/host/app/lib/boxel-module-classifier.ts
@@ -180,12 +180,19 @@ const templateCompilerModule = '@ember/template-compiler';
 // nothing.
 //
 // The two ways this can be wrong are not symmetric. A false POSITIVE — the
-// text appearing in a comment, a string, or a template body — keeps the edit
-// surface in the stronger cage, which is always allowed. A false NEGATIVE
-// hands a surface that does contain authored code to the trusted Base editor,
-// which is a containment failure, so the pattern is written to err toward
-// matching.
-const authoredEditTemplatePattern = /\bstatic\s+edit\s*[:=]/;
+// text appearing in a comment, a string, or a template body, or a `declare`
+// field that holds no runtime value — keeps the edit surface in the stronger
+// cage, which is always allowed. A false NEGATIVE hands a surface that does
+// contain authored code to the trusted Base editor, which is a containment
+// failure. So the pattern admits every spelling of the declaration that
+// carries one: the modifiers TypeScript allows between `static` and the name,
+// a string-literal computed key, and a static getter.
+//
+// What it cannot cover is a computed key that is not a literal
+// (`static [chooseKey()] = …`), which no reading of the source can resolve.
+// That residue belongs to the AST-based extraction, not to a longer pattern.
+const authoredEditTemplatePattern =
+  /\bstatic\s+(?:(?:readonly|override|get)\s+)*(?:edit\s*[:=(]|\[\s*(['"])edit\1\s*\]\s*[:=])/;
 
 const preprocessor = new ContentTag.Preprocessor();
 

--- a/packages/host/app/lib/boxel-module-classifier.ts
+++ b/packages/host/app/lib/boxel-module-classifier.ts
@@ -53,8 +53,16 @@ export interface BoxelModuleClassification {
    * module fetch against it before any authenticated request fires.
    *
    * An authorization list only when `moduleGraphComplete` says so.
+   *
+   * Spellings are mixed by construction: an authored dependency appears as
+   * `resolveImport` returned it, while a module the Host provides appears as
+   * the specifier the author wrote, because resolving one can evaluate it. A
+   * gate comparing a requested URL against this list must therefore fold the
+   * same identity family the Loader does (`moduleCacheKey`,
+   * `trimExecutableExtension`) rather than compare strings exactly, or it will
+   * refuse a fetch for a module that is in the list under a sibling spelling.
    */
-  moduleGraph: string[];
+  moduleGraph: readonly string[];
 
   /**
    * Whether the walk read every module it reached. When false, `moduleGraph`
@@ -117,6 +125,11 @@ export interface BoxelModuleClassifierOptions {
    * import (`date-fns`, `lodash`, `ember-concurrency`). Such a module is
    * recorded as a graph edge and not walked — there is no authored source
    * behind it, and a walk that went looking would fail the whole graph closed.
+   *
+   * Asked about BOTH spellings: the specifier as authored, before anything is
+   * resolved, and the resolved identifier of a dependency. A predicate that
+   * answers only one of the two half-works — it prunes some edges and sends
+   * the walk after others.
    */
   isHostProvidedModule?(moduleIdentifier: string): boolean;
 
@@ -135,20 +148,48 @@ const defaultMaxModules = 256;
 const preprocessorFilename = 'boxel-source.gts';
 
 // Preprocessing a `<template>` block rewrites it into a call, and content-tag
-// adds this import to supply the callee. It is an artifact of the compile
-// step, not an edge the author wrote, so it is dropped rather than admitted to
-// every templated card's graph. A card that imports the module itself loses
-// only the recorded edge: the Host provides it, so the walk would prune there
-// anyway.
+// adds this import to supply the callee. It is an artifact of reading the
+// source, not an edge the author wrote and not one the realm serves — the
+// realm's own pipeline runs Babel after this step, which rewrites the call and
+// removes the import again — so it is dropped rather than admitted to every
+// templated card's graph. A card importing the module itself loses the
+// recorded edge with it; no runtime serves that specifier, so the edge would
+// have failed the graph closed rather than authorizing anything.
 const templateCompilerModule = '@ember/template-compiler';
 
 // `static edit = …` in a class body declares an authored in-place editor
 // (RP-6.8). Matched against the preprocessed JavaScript, where a template
 // block has become a call rather than markup, so the class-body assignment is
 // what this reads.
-const authoredEditTemplatePattern = /\bstatic\s+edit\s*=/;
+//
+// The annotated form matters as much as the bare one: content-tag does not
+// strip TypeScript (the realm's Babel pass does, later), and
+// `static edit: BaseDefComponent = Editor` is what the Base realm's own cards
+// write, so an author following that example must not read as declaring
+// nothing.
+//
+// The two ways this can be wrong are not symmetric. A false POSITIVE — the
+// text appearing in a comment, a string, or a template body — keeps the edit
+// surface in the stronger cage, which is always allowed. A false NEGATIVE
+// hands a surface that does contain authored code to the trusted Base editor,
+// which is a containment failure, so the pattern is written to err toward
+// matching.
+const authoredEditTemplatePattern = /\bstatic\s+edit\s*[:=]/;
 
 const preprocessor = new ContentTag.Preprocessor();
+
+/**
+ * A memoized result is handed to every caller that asks for the same module,
+ * so one consumer sorting the graph in place or pushing to it would corrupt
+ * the read authority every other holder is checking against. Both the list and
+ * the record around it are frozen before anyone sees them.
+ */
+function sealed(
+  classification: BoxelModuleClassification,
+): BoxelModuleClassification {
+  Object.freeze(classification.moduleGraph);
+  return Object.freeze(classification);
+}
 
 /** What one module's source says about itself. */
 interface SourceAnalysis {
@@ -331,13 +372,15 @@ export class BoxelModuleClassifier {
     source?: string,
   ): Promise<BoxelModuleClassification> {
     if (isTrustedModule(moduleIdentifier)) {
-      return Promise.resolve({
-        trusted: true,
-        moduleGraph: [moduleIdentifier],
-        moduleGraphComplete: true,
-        authoredEditTemplate: false,
-        reason: 'trusted-module',
-      });
+      return Promise.resolve(
+        sealed({
+          trusted: true,
+          moduleGraph: [moduleIdentifier],
+          moduleGraphComplete: true,
+          authoredEditTemplate: false,
+          reason: 'trusted-module',
+        }),
+      );
     }
     let sourceHash = source === undefined ? undefined : md5(source);
     let existing = this.entries.get(moduleIdentifier);
@@ -405,6 +448,15 @@ export class BoxelModuleClassifier {
     // end produce the same graph and the same reported failure: traversal
     // order cannot reach the result.
     let analyzed = new Map<string, ModuleAnalysis>();
+    // Every identifier the walk has taken a turn on, whether or not it yielded
+    // an analysis. The bound counts these rather than the successful analyses:
+    // a module that fails to load or resolve contributes nothing to
+    // `analyzed`, so counting successes would let one module declaring
+    // thousands of unreadable imports issue thousands of authenticated loads
+    // inside a walk that reports itself bounded. It is also what dedupes a
+    // failure within one walk — a failed module self-evicts from the shared
+    // memo, so a second importer reaching it would otherwise read it again.
+    let attempted = new Set<string>();
     let failures: string[] = [];
     let exceededLimit = false;
     let queue: { identifier: string; suppliedSource?: string }[] = [
@@ -413,14 +465,15 @@ export class BoxelModuleClassifier {
 
     while (queue.length > 0) {
       let { identifier, suppliedSource } = queue.shift()!;
-      if (analyzed.has(identifier)) {
+      if (attempted.has(identifier)) {
         continue;
       }
-      if (analyzed.size >= maxModules) {
+      if (attempted.size >= maxModules) {
         exceededLimit = true;
         walk.incomplete = true;
         break;
       }
+      attempted.add(identifier);
       let analysis: ModuleAnalysis;
       try {
         analysis = await this.analyzeModule(identifier, suppliedSource);
@@ -462,13 +515,13 @@ export class BoxelModuleClassifier {
         .sort(),
     ];
     let root = analyzed.get(moduleIdentifier);
-    return {
+    return sealed({
       trusted: false,
       moduleGraph,
       moduleGraphComplete: !walk.incomplete,
       authoredEditTemplate: root?.source?.authoredEditTemplate ?? false,
       reason: reasonFor({ exceededLimit, failures }),
-    };
+    });
   }
 
   /**
@@ -558,9 +611,13 @@ export class BoxelModuleClassifier {
         continue;
       }
       try {
-        dependencies.add(
-          this.options.resolveImport(specifier, moduleIdentifier),
-        );
+        let resolved = this.options.resolveImport(specifier, moduleIdentifier);
+        if (typeof resolved !== 'string') {
+          throw new TypeError(
+            `resolveImport did not answer with an identifier`,
+          );
+        }
+        dependencies.add(resolved);
       } catch {
         // Collected rather than thrown, so a module with several unresolvable
         // imports reports all of them and the walk's chosen diagnostic does

--- a/packages/host/app/lib/boxel-module-classifier.ts
+++ b/packages/host/app/lib/boxel-module-classifier.ts
@@ -24,6 +24,14 @@ import { isTrustedImport, isTrustedModule } from './trusted-modules';
  * walk could not establish the graph, which RP-6.7 fails closed: the module
  * graph is a read-authorization list, so a truncated one would refuse fetches
  * the render needs rather than merely render something stale.
+ *
+ * Which failure a given cause reports depends on the resolver it is given, and
+ * the Host's does not throw: `VirtualNetwork.resolveImport` answers an unknown
+ * bare specifier with a `packages` pseudo-origin URL rather than refusing it,
+ * so such an import is reported as `module-load:` when nothing serves that URL.
+ * `module-resolve:` is for a resolver that refuses outright. Both fail closed;
+ * a consumer that presents these to an author should treat them as one
+ * condition with two spellings rather than as two different diagnoses.
  */
 export const MODULE_CLASSIFICATION_REASON_KINDS = [
   'trusted-module',

--- a/packages/host/app/lib/boxel-module-classifier.ts
+++ b/packages/host/app/lib/boxel-module-classifier.ts
@@ -1,0 +1,578 @@
+import * as ContentTag from 'content-tag';
+import { init as lexerReady, parse as lexImports } from 'es-module-lexer';
+import { md5 } from 'super-fast-md5';
+
+import { isTrustedImport, isTrustedModule } from './trusted-modules';
+
+/**
+ * The reason kinds classification can produce, declared rather than spelled
+ * inline at each return, because a reason string is API: it feeds the
+ * named-diagnostics catalog, the classification telemetry event, and the
+ * author-facing security-context indicator. A consumer parses a reason by
+ * splitting on the first `:` — the kind is the whole string for the four that
+ * carry no payload, and the prefix for the rest.
+ *
+ *   `trusted-module`               the entry is Host-owned and runs Direct
+ *   `authored-module`              authored code with an established graph
+ *   `source-parse-pending`         the ENTRY's source did not parse
+ *   `module-graph-limit`           the reachable graph exceeded its bound
+ *   `module-load:<url>`            a graph member's source did not load
+ *   `module-parse:<url>`           a DEPENDENCY's source did not parse
+ *   `module-resolve:<specifier>`   an import specifier did not resolve
+ *
+ * Only the first two describe an established result. The rest each mean the
+ * walk could not establish the graph, which RP-6.7 fails closed: the module
+ * graph is a read-authorization list, so a truncated one would refuse fetches
+ * the render needs rather than merely render something stale.
+ */
+export const MODULE_CLASSIFICATION_REASON_KINDS = [
+  'trusted-module',
+  'authored-module',
+  'source-parse-pending',
+  'module-graph-limit',
+  'module-load',
+  'module-parse',
+  'module-resolve',
+] as const;
+
+export type ModuleClassificationReasonKind =
+  (typeof MODULE_CLASSIFICATION_REASON_KINDS)[number];
+
+/** One module's classification. */
+export interface BoxelModuleClassification {
+  /**
+   * The module is Host-owned and executes Direct (RP-6.1 R1, RP-6.6). Decided
+   * from the identifier alone by `isTrustedModule`, so nothing in this
+   * result's own construction — no source, no cache, no hash — can reach it.
+   */
+  trusted: boolean;
+
+  /**
+   * Every module identifier the walk reached, entry first and the rest sorted.
+   * This is the exact set a stronger runtime may read: a Sandbox authorizes a
+   * module fetch against it before any authenticated request fires.
+   *
+   * An authorization list only when `moduleGraphComplete` says so.
+   */
+  moduleGraph: string[];
+
+  /**
+   * Whether the walk read every module it reached. When false, `moduleGraph`
+   * is whatever it got to before something could not be loaded, parsed,
+   * resolved, or fitted inside the bound — a diagnostic, not an authorization
+   * list, and a runtime that checked fetches against it would refuse reads the
+   * render needs. Such a result is never memoized, so the caller's move is to
+   * classify again rather than to authorize against it.
+   *
+   * This is the field to gate on rather than the reason string. The two agree
+   * while every reason but the first two names a failure, and they stop
+   * agreeing the moment classification also reports positive findings about a
+   * module: a settled reason can then accompany a graph that stopped where an
+   * unreadable member did.
+   */
+  moduleGraphComplete: boolean;
+
+  /**
+   * The module's own source declares at least one `static edit = …` template —
+   * on the card class or on any FieldDef it defines (RP-6.8). It is the input
+   * RP-6.3's exception reads: the `edit` surface drops to the Host's trusted
+   * Base editor only when no authored template would run in it.
+   *
+   * Established for authored modules only. A trusted module renders every
+   * format Direct, so no surface reads this and the walk does not fetch its
+   * source to establish it.
+   */
+  authoredEditTemplate: boolean;
+
+  /** One of `MODULE_CLASSIFICATION_REASON_KINDS`, with a payload where noted. */
+  reason: string;
+
+  /**
+   * Reserved for the browser-authority findings a later analyzer reports about
+   * the same module. Never populated here, so a consumer that reads it gets
+   * `undefined` rather than an empty list that would read as "analyzed, none
+   * found".
+   */
+  signals?: string[];
+}
+
+export interface BoxelModuleClassifierOptions {
+  /** Authored source for one module, as the realm serves it. */
+  loadSource(moduleIdentifier: string): Promise<string>;
+
+  /**
+   * One import specifier as the runtime would resolve it, or a throw when it
+   * does not resolve. Both halves of resolution belong to the caller — mapping
+   * a bare specifier to the identifier its runtime serves it under, and
+   * resolving a relative one against the importing module — because the
+   * classifier must not assume either.
+   */
+  resolveImport(specifier: string, relativeTo: string): string;
+
+  /**
+   * Modules the runtime answers from its own registry rather than by fetching
+   * authored source: the loader's shims. Consulted in addition to
+   * `isTrustedImport`, whose set is the framework floor every runtime
+   * provides, because a runtime also shims ordinary libraries a card may
+   * import (`date-fns`, `lodash`, `ember-concurrency`). Such a module is
+   * recorded as a graph edge and not walked — there is no authored source
+   * behind it, and a walk that went looking would fail the whole graph closed.
+   */
+  isHostProvidedModule?(moduleIdentifier: string): boolean;
+
+  /**
+   * The number of authored modules one walk will read. Modules the walk prunes
+   * at do not count against it, since they are never fetched.
+   */
+  maxModules?: number;
+}
+
+const defaultMaxModules = 256;
+
+// content-tag surfaces this in "Parse Error at ..." messages. Classification
+// discards those — an unreadable module is reported by identifier — so the
+// name is a constant rather than the module's own URL.
+const preprocessorFilename = 'boxel-source.gts';
+
+// Preprocessing a `<template>` block rewrites it into a call, and content-tag
+// adds this import to supply the callee. It is an artifact of the compile
+// step, not an edge the author wrote, so it is dropped rather than admitted to
+// every templated card's graph. A card that imports the module itself loses
+// only the recorded edge: the Host provides it, so the walk would prune there
+// anyway.
+const templateCompilerModule = '@ember/template-compiler';
+
+// `static edit = …` in a class body declares an authored in-place editor
+// (RP-6.8). Matched against the preprocessed JavaScript, where a template
+// block has become a call rather than markup, so the class-body assignment is
+// what this reads.
+const authoredEditTemplatePattern = /\bstatic\s+edit\s*=/;
+
+const preprocessor = new ContentTag.Preprocessor();
+
+/** What one module's source says about itself. */
+interface SourceAnalysis {
+  /** Import specifiers as authored, before resolution. */
+  imports: string[];
+  authoredEditTemplate: boolean;
+}
+
+/**
+ * Reads one module's source. The code is never executed to read it.
+ *
+ * The front end is the realm's own: content-tag's `process()`, which is what
+ * `transpile.ts` runs before Babel. Matching it is what makes "the front end
+ * refused this" mean "an in-progress draft" rather than "syntax the realm
+ * serves and this file cannot read", and that distinction is expensive to get
+ * wrong: a draft result yields an EMPTY module graph, and the module graph is
+ * a sandbox child's fetch authority.
+ *
+ * `process()` rewrites each `<template>` block into a call, so its output
+ * parses wherever a template can appear — including expression position
+ * (`const Row = <template>…</template>;`), where blanking the block instead
+ * would leave a hole an expression has to fill and make a finished, servable
+ * module read as unparseable.
+ *
+ * Returns undefined when the source did not parse.
+ */
+async function analyzeSource(
+  source: string,
+): Promise<SourceAnalysis | undefined> {
+  await lexerReady;
+  let javascript: string;
+  try {
+    javascript = preprocessor.process(source, {
+      filename: preprocessorFilename,
+    }).code;
+  } catch {
+    return undefined;
+  }
+  let specifiers: (string | undefined)[];
+  try {
+    // The lexer reports a literal dynamic import (`import('./x')`) with its
+    // specifier set, so it joins the graph as an ordinary edge. A computed one
+    // — including a template literal — is reported with no specifier: it
+    // cannot be statically authorized, so it is simply absent from the graph
+    // and the runtime's fetch gate refuses it.
+    specifiers = lexImports(javascript)[0].map((entry) => entry.n);
+  } catch {
+    return undefined;
+  }
+  let imports = new Set<string>();
+  for (let specifier of specifiers) {
+    if (specifier !== undefined && specifier !== templateCompilerModule) {
+      imports.add(specifier);
+    }
+  }
+  return {
+    imports: [...imports],
+    authoredEditTemplate: authoredEditTemplatePattern.test(javascript),
+  };
+}
+
+/**
+ * Everything one module's analysis could not establish. Plural because a
+ * module with two unresolvable imports has two facts to report, and reporting
+ * only the first one reached would make the diagnostic depend on the order the
+ * imports appear in.
+ */
+class ModuleGraphFailure extends Error {
+  constructor(readonly reasons: string[]) {
+    super(reasons.join(', '));
+  }
+}
+
+interface ModuleAnalysis {
+  /** Absent when the module's source did not parse. */
+  source: SourceAnalysis | undefined;
+  /** Resolved dependency identifiers, deduplicated and sorted. */
+  dependencies: string[];
+}
+
+/**
+ * The one reason a result carries, out of everything the walk observed.
+ *
+ * An entry whose own source did not parse is reported as the draft it is. That
+ * case excludes every other: a module whose imports are unknown enqueues
+ * nothing, so there is no graph behind it to have failed — it is written first
+ * for the reader rather than to win a contest. An entry that could not be READ
+ * at all is not a draft, and falls through to the failure that says so. The bound
+ * comes next — once it is hit the walk stopped early, so which OTHER modules
+ * failed is an artifact of where it stopped. Remaining failures are sorted, so
+ * the reported one is a property of the graph rather than of the order the
+ * walk reached its members in.
+ */
+function reasonFor({
+  exceededLimit,
+  failures,
+}: {
+  exceededLimit: boolean;
+  failures: string[];
+}): string {
+  if (failures.includes('source-parse-pending')) {
+    return 'source-parse-pending';
+  }
+  if (exceededLimit) {
+    return 'module-graph-limit';
+  }
+  return failures.length > 0
+    ? [...failures].sort()[0]!
+    : ('authored-module' satisfies ModuleClassificationReasonKind);
+}
+
+interface WalkState {
+  /** Every identifier reached, so invalidation can find the entry by any. */
+  graph: Set<string>;
+  /** Set the moment the walk fails to read something it reached. */
+  incomplete: boolean;
+}
+
+/**
+ * Classifies an authored module graph — the entry module and everything
+ * reachable from it — rather than only the entry file.
+ *
+ * The walk prunes at modules the Host serves itself (RP-6.6): their source is
+ * never fetched and their own imports are never followed, because the Host
+ * resolves them for whichever runtime asked. Everything else is authored and
+ * is read. A dependency that cannot be resolved, loaded, or parsed, and a
+ * graph that outgrows its bound, mark the result's graph unavailable with a
+ * diagnostic reason (RP-6.7).
+ *
+ * Two caches, invalidated together:
+ *
+ *   - a per-MODULE memo, shared across every entry, so two cards sharing a
+ *     dependency subtree read and analyze it once and the second card fetches
+ *     none of it. It holds only what the loader served, never a caller's
+ *     draft.
+ *   - a per-ENTRY memo of the finished classification, which records the graph
+ *     it was computed from so invalidating any member evicts it.
+ *
+ * `invalidate(module)` evicts that module's analysis and every entry whose
+ * graph reached it. A result that reports what could not be established is
+ * never memoized, so the next request retries rather than pinning a transient
+ * fetch failure or an in-progress draft.
+ *
+ * Neither cache has a size bound: both hold what they are told about until
+ * `invalidate` drops it, since the invalidation signal is the realm's and
+ * arrives per changed module rather than under memory pressure. `maxModules`
+ * bounds one WALK, not the caches. A holder that outlives many module graphs
+ * wants `invalidate()` at whatever point its own module identities stop being
+ * meaningful — a loader reset, a session ending.
+ */
+export class BoxelModuleClassifier {
+  // Promises rather than values, so entries walking concurrently share one
+  // fetch and one analysis of a module they both reach.
+  private moduleAnalyses = new Map<string, Promise<ModuleAnalysis>>();
+  private entries = new Map<
+    string,
+    {
+      classification: Promise<BoxelModuleClassification>;
+      /** Set when the caller supplied source; absent when it was fetched. */
+      sourceHash?: string;
+      graph: Set<string>;
+    }
+  >();
+
+  constructor(private readonly options: BoxelModuleClassifierOptions) {}
+
+  /**
+   * Classifies `moduleIdentifier` and its reachable graph. Pass `source` to
+   * classify a revision the loader cannot fetch — an unsaved draft. Such a
+   * result is keyed by that source's hash and answers only this caller: a
+   * draft never enters the memo other entries read, so an unsaved buffer
+   * cannot decide the graph of a card it is not the source of.
+   *
+   * A trusted entry is answered from its identifier alone, without a fetch:
+   * it executes Direct with the Host's own loader, which resolves its imports
+   * itself, so there is no authored closure to establish.
+   */
+  classifyModule(
+    moduleIdentifier: string,
+    source?: string,
+  ): Promise<BoxelModuleClassification> {
+    if (isTrustedModule(moduleIdentifier)) {
+      return Promise.resolve({
+        trusted: true,
+        moduleGraph: [moduleIdentifier],
+        moduleGraphComplete: true,
+        authoredEditTemplate: false,
+        reason: 'trusted-module',
+      });
+    }
+    let sourceHash = source === undefined ? undefined : md5(source);
+    let existing = this.entries.get(moduleIdentifier);
+    if (existing && existing.sourceHash === sourceHash) {
+      return existing.classification;
+    }
+    // The walk fills both fields as it goes: `graph` so invalidation can find
+    // this entry by any member, and `incomplete` so a result computed over a
+    // graph the walk could not establish is not kept as an answer.
+    let walk: WalkState = {
+      graph: new Set<string>([moduleIdentifier]),
+      incomplete: false,
+    };
+    let classification = this.walkGraph(moduleIdentifier, source, walk);
+    let entry = { classification, sourceHash, graph: walk.graph };
+    this.entries.set(moduleIdentifier, entry);
+    let evict = () => {
+      if (this.entries.get(moduleIdentifier) === entry) {
+        this.entries.delete(moduleIdentifier);
+      }
+    };
+    // An incomplete walk is not an answer to keep: the module may load next
+    // time, the draft may parse next time — and until then the graph it
+    // produced is a read-authorization list drawn over a hole. The eviction
+    // reads the resolved value rather than only catching a rejection, because
+    // the walk reports such a result rather than throwing it.
+    void classification.then(
+      ({ moduleGraphComplete }) => (moduleGraphComplete ? undefined : evict()),
+      evict,
+    );
+    return classification;
+  }
+
+  /**
+   * Drops cached work. With a module identifier, that is the module's own
+   * analysis plus every entry whose graph reached it — an entry's graph is the
+   * closure of its dependencies, so a stale importer is as wrong as a stale
+   * dependency. With no argument, everything.
+   */
+  invalidate(moduleIdentifier?: string): void {
+    if (moduleIdentifier === undefined) {
+      this.moduleAnalyses.clear();
+      this.entries.clear();
+      return;
+    }
+    this.moduleAnalyses.delete(moduleIdentifier);
+    for (let [identifier, entry] of this.entries) {
+      if (
+        identifier === moduleIdentifier ||
+        entry.graph.has(moduleIdentifier)
+      ) {
+        this.entries.delete(identifier);
+      }
+    }
+  }
+
+  private async walkGraph(
+    moduleIdentifier: string,
+    entrySource: string | undefined,
+    walk: WalkState,
+  ): Promise<BoxelModuleClassification> {
+    let maxModules = this.options.maxModules ?? defaultMaxModules;
+    // The complete reachable graph is collected before anything is read off
+    // it, so a diamond reached from either side and a cycle entered at either
+    // end produce the same graph and the same reported failure: traversal
+    // order cannot reach the result.
+    let analyzed = new Map<string, ModuleAnalysis>();
+    let failures: string[] = [];
+    let exceededLimit = false;
+    let queue: { identifier: string; suppliedSource?: string }[] = [
+      { identifier: moduleIdentifier, suppliedSource: entrySource },
+    ];
+
+    while (queue.length > 0) {
+      let { identifier, suppliedSource } = queue.shift()!;
+      if (analyzed.has(identifier)) {
+        continue;
+      }
+      if (analyzed.size >= maxModules) {
+        exceededLimit = true;
+        walk.incomplete = true;
+        break;
+      }
+      let analysis: ModuleAnalysis;
+      try {
+        analysis = await this.analyzeModule(identifier, suppliedSource);
+      } catch (error) {
+        if (!(error instanceof ModuleGraphFailure)) {
+          throw error;
+        }
+        failures.push(...error.reasons);
+        walk.incomplete = true;
+        continue;
+      }
+      analyzed.set(identifier, analysis);
+      // Source that did not parse leaves the walk with no imports for that
+      // module, so its closure is unproven either way. The entry's own draft
+      // says so as `source-parse-pending`, which is the ordinary state of a
+      // module being typed into; a DEPENDENCY that will not parse is a fact
+      // about saved code and is named as one.
+      if (analysis.source === undefined) {
+        walk.incomplete = true;
+        failures.push(
+          identifier === moduleIdentifier
+            ? 'source-parse-pending'
+            : `module-parse:${identifier}`,
+        );
+        continue;
+      }
+      for (let dependency of analysis.dependencies) {
+        walk.graph.add(dependency);
+        if (!this.isGraphLeaf(dependency)) {
+          queue.push({ identifier: dependency });
+        }
+      }
+    }
+
+    let moduleGraph = [
+      moduleIdentifier,
+      ...[...walk.graph]
+        .filter((identifier) => identifier !== moduleIdentifier)
+        .sort(),
+    ];
+    let root = analyzed.get(moduleIdentifier);
+    return {
+      trusted: false,
+      moduleGraph,
+      moduleGraphComplete: !walk.incomplete,
+      authoredEditTemplate: root?.source?.authoredEditTemplate ?? false,
+      reason: reasonFor({ exceededLimit, failures }),
+    };
+  }
+
+  /**
+   * Whether the walk records this dependency as an edge without following it.
+   * A module the Host serves — a trusted one, or one the runtime shims — has
+   * no authored source behind it to read, and its own dependencies are the
+   * Host's to resolve for whichever runtime asked.
+   */
+  private isGraphLeaf(moduleIdentifier: string): boolean {
+    return (
+      isTrustedImport(moduleIdentifier) ||
+      (this.options.isHostProvidedModule?.(moduleIdentifier) ?? false)
+    );
+  }
+
+  /**
+   * Returns one module's analysis, from the shared memo when it holds one.
+   *
+   * With no supplied source the memo is authoritative and nothing is fetched —
+   * that is what lets a second entry traverse a shared subtree for free.
+   */
+  private async analyzeModule(
+    moduleIdentifier: string,
+    suppliedSource?: string,
+  ): Promise<ModuleAnalysis> {
+    // Supplied source is one caller's revision of the module, not the module.
+    // The shared memo answers every entry that reaches this identifier, so
+    // seating a draft in it would let an unsaved editor buffer decide the
+    // module graph — the read authority — of a card it is not the source of.
+    // A draft is therefore analyzed for its own caller and neither read from
+    // nor written to the shared memo; the entry memo, keyed by the draft's
+    // hash, is what keeps an unchanged draft from re-analyzing.
+    if (suppliedSource !== undefined) {
+      return this.freshAnalysis(moduleIdentifier, suppliedSource);
+    }
+    let pending = this.moduleAnalyses.get(moduleIdentifier);
+    if (pending) {
+      // A rejection propagates to this caller rather than being retried
+      // mid-walk: the module already self-evicted, so the retry is the next
+      // classification, and this walk reports the failure as it should.
+      return pending;
+    }
+    let fresh = this.freshAnalysis(moduleIdentifier);
+    this.moduleAnalyses.set(moduleIdentifier, fresh);
+    let evict = () => {
+      if (this.moduleAnalyses.get(moduleIdentifier) === fresh) {
+        this.moduleAnalyses.delete(moduleIdentifier);
+      }
+    };
+    // A rejection is not an answer, and neither is source that did not parse:
+    // an in-progress draft is a state the module leaves, so keeping it would
+    // pin the module to it until something invalidated the module by name.
+    // The current walk still uses the value it already holds.
+    void fresh.then(
+      ({ source }) => (source === undefined ? evict() : undefined),
+      evict,
+    );
+    return fresh;
+  }
+
+  private async freshAnalysis(
+    moduleIdentifier: string,
+    suppliedSource?: string,
+  ): Promise<ModuleAnalysis> {
+    let source: string;
+    try {
+      source =
+        suppliedSource ?? (await this.options.loadSource(moduleIdentifier));
+    } catch {
+      throw new ModuleGraphFailure([`module-load:${moduleIdentifier}`]);
+    }
+    let analysis = await analyzeSource(source);
+    if (analysis === undefined) {
+      return { source: undefined, dependencies: [] };
+    }
+    let dependencies = new Set<string>();
+    let unresolved: string[] = [];
+    for (let specifier of analysis.imports) {
+      // A specifier the Host serves is already a canonical leaf, so it is
+      // recorded without being resolved. Resolving one can evaluate the module
+      // merely to discover its URL — an async package shim does exactly that —
+      // which would turn classification into an eager module load and pull in
+      // that module's own transitive network dependencies. The runtime
+      // resolves the reference only if authored code actually uses the export.
+      if (this.isGraphLeaf(specifier)) {
+        dependencies.add(specifier);
+        continue;
+      }
+      try {
+        dependencies.add(
+          this.options.resolveImport(specifier, moduleIdentifier),
+        );
+      } catch {
+        // Collected rather than thrown, so a module with several unresolvable
+        // imports reports all of them and the walk's chosen diagnostic does
+        // not depend on which one appears first in the file.
+        unresolved.push(`module-resolve:${specifier}`);
+      }
+    }
+    if (unresolved.length > 0) {
+      // Not memoized: a partially resolved module is not a fact about the
+      // module, and resolution depends on loader state rather than on source.
+      throw new ModuleGraphFailure(unresolved);
+    }
+    return { source: analysis, dependencies: [...dependencies].sort() };
+  }
+}

--- a/packages/host/app/lib/trusted-modules.ts
+++ b/packages/host/app/lib/trusted-modules.ts
@@ -1,0 +1,146 @@
+import { PACKAGES_FAKE_ORIGIN } from '@cardstack/runtime-common/package-shim-handler';
+
+import config from '@cardstack/host/config/environment';
+
+/**
+ * The Host's trusted-module boundary: rule R1 of the routing function
+ * (RP-6.1), stated as a predicate by RP-6.6. A module inside this boundary is
+ * Host-owned code and executes Direct — with the Host's own loader, DOM, and
+ * session. Everything outside it is authored code and is caged.
+ *
+ * This is the ONE classification decision that is a security boundary rather
+ * than a smoothness choice. Every other fact classification establishes
+ * describes an authored module's closure, where a wrong answer costs a refused
+ * fetch or an unnecessary walk. A wrong answer HERE means authored code
+ * running uncaged, so this file is written to reject rather than to normalize:
+ * a spelling it does not positively recognize as Host-owned is not trusted.
+ *
+ * Nothing computed from a module's source can reach this decision — it is a
+ * function of the identifier alone, so no cache, hash, or module graph
+ * participates in it.
+ *
+ * `isTrustedImport` answers a different, wider question: which modules the
+ * Host serves from its own stand-ins rather than as authored source. That is
+ * the module-graph walk's pruning test (RP-6.7) — such a module is recorded as
+ * an edge and never fetched — and it is NOT a grant of Direct execution.
+ * Being allowed to import `@glimmer/component` says nothing about who wrote
+ * the importing module, so classification asks `isTrustedModule` for the
+ * Direct decision and `isTrustedImport` for the walk; nothing here answers
+ * both.
+ */
+export function isTrustedModule(moduleIdentifier: string): boolean {
+  return (
+    isSafeCardstackPackageSpecifier(moduleIdentifier) ||
+    isURLWithin(moduleIdentifier, `${PACKAGES_FAKE_ORIGIN}@cardstack/`) ||
+    isURLWithin(moduleIdentifier, 'https://cardstack.com/base/') ||
+    isURLWithin(moduleIdentifier, config.resolvedBaseRealmURL)
+  );
+}
+
+export function isTrustedImport(moduleIdentifier: string): boolean {
+  return (
+    isTrustedModule(moduleIdentifier) ||
+    isURLWithin(moduleIdentifier, 'https://cardstack.com/catalog/') ||
+    (config.resolvedCatalogRealmURL !== undefined &&
+      isURLWithin(moduleIdentifier, config.resolvedCatalogRealmURL)) ||
+    isURLWithin(moduleIdentifier, config.iconsURL) ||
+    hostProvidedFrameworkModules.has(moduleIdentifier)
+  );
+}
+
+// Framework and Host-runtime modules a cage receives as a stand-in rather than
+// as authored source. Exact identifiers only: these are bare specifiers with
+// no path structure to bound, so a prefix test on any of them would admit an
+// unrelated package whose name merely starts the same way.
+//
+// This is the framework floor, not the whole of what `externals.ts` registers:
+// a runtime shims further libraries (date-fns, lodash, ember-concurrency) that
+// a card may import, and the walk learns those from the runtime's own registry
+// rather than from a second copy of the list here.
+const hostProvidedFrameworkModules = new Set([
+  '@cardstack/runtime-common',
+  '@ember/component',
+  '@ember/component/template-only',
+  '@ember/helper',
+  '@ember/modifier',
+  '@ember/object',
+  '@ember/template-factory',
+  '@glimmer/component',
+  '@glimmer/tracking',
+  'ember-provide-consume-context',
+  `${PACKAGES_FAKE_ORIGIN}ember-provide-consume-context`,
+]);
+
+/**
+ * A bare package spelling reaches this boundary BEFORE the Loader resolves it
+ * to a URL, so `new URL()` normalization — which is what collapses `..` and
+ * decodes escapes for every other identifier here — has not run and cannot
+ * protect it. `@cardstack/base/../../evil/card` is a valid ESM specifier that
+ * a resolver may take outside the package root while reading as trusted to a
+ * naive prefix test.
+ *
+ * So the specifier is admitted only when it is unambiguously a path inside an
+ * `@cardstack` package: decodable, free of the characters that carry a second
+ * layer of interpretation (`\` as a separator on some resolvers, `%` for a
+ * further encoding round, `?`/`#` for a query or fragment that could hide the
+ * real path), and free of dot segments. Rejecting `%` outright is what makes
+ * the single `decodeURIComponent` sufficient — a doubly-encoded `%252e%252e`
+ * decodes to `%2e%2e`, which still carries a `%` and is refused, so there is
+ * no need to decode to a fixed point.
+ */
+function isSafeCardstackPackageSpecifier(identifier: string): boolean {
+  if (!identifier.startsWith('@cardstack/')) {
+    return false;
+  }
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(identifier);
+  } catch {
+    return false;
+  }
+  if (
+    decoded.includes('\\') ||
+    decoded.includes('%') ||
+    decoded.includes('?') ||
+    decoded.includes('#')
+  ) {
+    return false;
+  }
+  let segments = decoded.split('/');
+  return (
+    segments.length >= 2 &&
+    segments[0] === '@cardstack' &&
+    segments[1] !== '' &&
+    segments.every((segment) => segment !== '.' && segment !== '..')
+  );
+}
+
+/**
+ * Origin-and-path containment for an absolute module URL. The boundary path is
+ * compared with its trailing slash present so a sibling whose name merely
+ * begins with the same characters — `/base-evil/` against `/base/` — is
+ * outside it, while the boundary directory itself is still inside.
+ *
+ * A non-URL identifier (a bare specifier, a relative path) is not within any
+ * URL boundary and returns false rather than throwing; `new URL()` also
+ * resolves the dot segments and percent-escapes of the identifiers that do
+ * parse, which is why the comparison here can be a plain prefix test.
+ */
+function isURLWithin(identifier: string, root: string): boolean {
+  try {
+    let candidate = new URL(identifier);
+    let boundary = new URL(root);
+    if (candidate.origin !== boundary.origin) {
+      return false;
+    }
+    let boundaryPath = boundary.pathname.endsWith('/')
+      ? boundary.pathname
+      : `${boundary.pathname}/`;
+    return (
+      candidate.pathname === boundaryPath.slice(0, -1) ||
+      candidate.pathname.startsWith(boundaryPath)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/host/app/lib/trusted-modules.ts
+++ b/packages/host/app/lib/trusted-modules.ts
@@ -35,6 +35,13 @@ import config from '@cardstack/host/config/environment';
  * however Host-owned the realm is: it is authored source with its own import
  * graph, and pruning at it would report a complete graph while dropping
  * everything behind it.
+ *
+ * The icons host is here and not in `isTrustedModule`, so an icon module's
+ * package spelling answers the provenance question and its CDN URL does not.
+ * That asymmetry is deliberate: the boundary has no path of its own, and an
+ * origin-wide grant is exactly what provenance refuses (see `isURLWithin`).
+ * The two answers differ only in how strongly the module is contained, never
+ * in whether the walk stops there, and the stricter one is what the URL gets.
  */
 export function isTrustedModule(moduleIdentifier: string): boolean {
   return (
@@ -74,10 +81,17 @@ export function isTrustedImport(moduleIdentifier: string): boolean {
  * right direction for a stale list — visible, and never an escalation — and
  * it does not break the graph walk, which prunes on the runtime's own shim
  * registry rather than on this list.
+ *
+ * The list carries one constraint in the other direction, which nothing here
+ * can enforce: no realm may ever be mapped under a name on it. A realm named
+ * for a Host package would have its authored content admitted by this test,
+ * which is the hazard above running backwards. The wiring that registers realm
+ * mappings is where that belongs as an assertion.
  */
 const hostPackages = new Set([
   'base',
   'boxel-host',
+  'host',
   'boxel-icons',
   'boxel-ui',
   'bxl',

--- a/packages/host/app/lib/trusted-modules.ts
+++ b/packages/host/app/lib/trusted-modules.ts
@@ -27,10 +27,18 @@ import config from '@cardstack/host/config/environment';
  * the importing module, so classification asks `isTrustedModule` for the
  * Direct decision and `isTrustedImport` for the walk; nothing here answers
  * both.
+ *
+ * What it widens by is deliberately narrow: the framework stand-ins and the
+ * icons host, both of which bottom out in modules the Host provides. Pruning
+ * is only sound where trust begins — a pruned module's own closure becomes
+ * the Host's problem to resolve. Published realm content does not qualify
+ * however Host-owned the realm is: it is authored source with its own import
+ * graph, and pruning at it would report a complete graph while dropping
+ * everything behind it.
  */
 export function isTrustedModule(moduleIdentifier: string): boolean {
   return (
-    isSafeCardstackPackageSpecifier(moduleIdentifier) ||
+    isHostPackageSpecifier(moduleIdentifier) ||
     isURLWithin(moduleIdentifier, `${PACKAGES_FAKE_ORIGIN}@cardstack/`) ||
     isURLWithin(moduleIdentifier, 'https://cardstack.com/base/') ||
     isURLWithin(moduleIdentifier, config.resolvedBaseRealmURL)
@@ -40,13 +48,42 @@ export function isTrustedModule(moduleIdentifier: string): boolean {
 export function isTrustedImport(moduleIdentifier: string): boolean {
   return (
     isTrustedModule(moduleIdentifier) ||
-    isURLWithin(moduleIdentifier, 'https://cardstack.com/catalog/') ||
-    (config.resolvedCatalogRealmURL !== undefined &&
-      isURLWithin(moduleIdentifier, config.resolvedCatalogRealmURL)) ||
-    isURLWithin(moduleIdentifier, config.iconsURL) ||
+    isURLWithin(moduleIdentifier, config.iconsURL, { allowOriginWide: true }) ||
     hostProvidedFrameworkModules.has(moduleIdentifier)
   );
 }
+
+/**
+ * The Host packages whose modules the Host itself provides — from its own
+ * bundle, from a shim, or from the Base realm. The first path segment after
+ * the scope is matched against this list rather than the scope being admitted
+ * wholesale, because `@cardstack/<name>/` is NOT only an npm scope in this
+ * codebase: it is also the realm-alias namespace. `addRealmMapping` registers
+ * one such prefix per realm — `network.ts` for the catalog, skills and
+ * OpenRouter realms, and `main.ts`/`worker.ts` generically for every
+ * `https://cardstack.com/<name>/` mapping, so the namespace acquires new
+ * members without this file being touched. Admitting the scope would hand
+ * Direct execution to authored realm content under its alias spelling while
+ * the same module's URL spelling classified as authored.
+ *
+ * `base` is on the list because the Base realm is trusted on its own account,
+ * so its alias and its URL agree.
+ *
+ * A Host package missing from this list fails closed: its modules classify as
+ * authored, which cages them and makes the walk try to read them. That is the
+ * right direction for a stale list — visible, and never an escalation — and
+ * it does not break the graph walk, which prunes on the runtime's own shim
+ * registry rather than on this list.
+ */
+const hostPackages = new Set([
+  'base',
+  'boxel-host',
+  'boxel-icons',
+  'boxel-ui',
+  'bxl',
+  'runtime-common',
+  'view-transitions',
+]);
 
 // Framework and Host-runtime modules a cage receives as a stand-in rather than
 // as authored source. Exact identifiers only: these are bare specifiers with
@@ -88,7 +125,7 @@ const hostProvidedFrameworkModules = new Set([
  * decodes to `%2e%2e`, which still carries a `%` and is refused, so there is
  * no need to decode to a fixed point.
  */
-function isSafeCardstackPackageSpecifier(identifier: string): boolean {
+function isHostPackageSpecifier(identifier: string): boolean {
   if (!identifier.startsWith('@cardstack/')) {
     return false;
   }
@@ -110,7 +147,7 @@ function isSafeCardstackPackageSpecifier(identifier: string): boolean {
   return (
     segments.length >= 2 &&
     segments[0] === '@cardstack' &&
-    segments[1] !== '' &&
+    hostPackages.has(segments[1]!) &&
     segments.every((segment) => segment !== '.' && segment !== '..')
   );
 }
@@ -126,7 +163,11 @@ function isSafeCardstackPackageSpecifier(identifier: string): boolean {
  * resolves the dot segments and percent-escapes of the identifiers that do
  * parse, which is why the comparison here can be a plain prefix test.
  */
-function isURLWithin(identifier: string, root: string): boolean {
+function isURLWithin(
+  identifier: string,
+  root: string,
+  { allowOriginWide = false }: { allowOriginWide?: boolean } = {},
+): boolean {
   try {
     let candidate = new URL(identifier);
     let boundary = new URL(root);
@@ -136,6 +177,14 @@ function isURLWithin(identifier: string, root: string): boolean {
     let boundaryPath = boundary.pathname.endsWith('/')
       ? boundary.pathname
       : `${boundary.pathname}/`;
+    // A boundary with no path of its own covers its whole origin. That is what
+    // the icons host is — one origin serving nothing else — and it is the one
+    // degenerate input here that fails OPEN, so it is opted into rather than
+    // inherited. A realm boundary misconfigured to an origin root would
+    // otherwise make every realm on that host trusted, silently.
+    if (boundaryPath === '/' && !allowOriginWide) {
+      return false;
+    }
     return (
       candidate.pathname === boundaryPath.slice(0, -1) ||
       candidate.pathname.startsWith(boundaryPath)

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -146,6 +146,7 @@
     "ember-test-selectors": "^6.0.0",
     "ember-velcro": "^2.1.3",
     "ember-window-mock": "^1.0.1",
+    "es-module-lexer": "^1.7.0",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "eslint-plugin-ember": "catalog:",

--- a/packages/host/tests/unit/rp-6-module-classification-test.ts
+++ b/packages/host/tests/unit/rp-6-module-classification-test.ts
@@ -1,0 +1,643 @@
+import * as ContentTag from 'content-tag';
+import { init as lexerReady, parse as lexImports } from 'es-module-lexer';
+import { module, test } from 'qunit';
+
+import { PACKAGES_FAKE_ORIGIN } from '@cardstack/runtime-common/package-shim-handler';
+
+import {
+  BoxelModuleClassifier,
+  MODULE_CLASSIFICATION_REASON_KINDS,
+  type BoxelModuleClassifierOptions,
+} from '@cardstack/host/lib/boxel-module-classifier';
+import {
+  isTrustedImport,
+  isTrustedModule,
+} from '@cardstack/host/lib/trusted-modules';
+
+const realmOrigin = 'http://test-realm/';
+
+// Stands in for a realm serving authored module source, and for the runtime's
+// import resolution. Both are counted, because "a second card re-reads nothing
+// of a subtree it shares" and "a trusted import is never resolved" are claims
+// about calls that did NOT happen.
+class TestRealm {
+  private sources = new Map<string, string>();
+  loads: string[] = [];
+  resolutions: string[] = [];
+
+  constructor(sources: Record<string, string>) {
+    for (let [path, source] of Object.entries(sources)) {
+      this.sources.set(this.url(path), source);
+    }
+  }
+
+  url(path: string): string {
+    return `${realmOrigin}${path}`;
+  }
+
+  write(path: string, source: string): void {
+    this.sources.set(this.url(path), source);
+  }
+
+  remove(path: string): void {
+    this.sources.delete(this.url(path));
+  }
+
+  // One load is one analysis: nothing is parsed that was not just read, so a
+  // load count is also the count of analyses the shared memo did not save.
+  loadCount(path: string): number {
+    return this.loads.filter((url) => url === this.url(path)).length;
+  }
+
+  loadSource = async (moduleIdentifier: string): Promise<string> => {
+    this.loads.push(moduleIdentifier);
+    let source = this.sources.get(moduleIdentifier);
+    if (source === undefined) {
+      throw new Error(`no such module ${moduleIdentifier}`);
+    }
+    return source;
+  };
+
+  resolveImport = (specifier: string, relativeTo: string): string => {
+    this.resolutions.push(specifier);
+    if (/^\.{0,2}\//.test(specifier) || /^https?:/.test(specifier)) {
+      return new URL(specifier, relativeTo).href;
+    }
+    throw new Error(`cannot resolve ${specifier}`);
+  };
+}
+
+function classifierFor(
+  realm: TestRealm,
+  options: Partial<BoxelModuleClassifierOptions> = {},
+): BoxelModuleClassifier {
+  return new BoxelModuleClassifier({
+    loadSource: realm.loadSource,
+    resolveImport: realm.resolveImport,
+    ...options,
+  });
+}
+
+const cardApi = 'https://cardstack.com/base/card-api';
+
+module('Unit | rendering protocol | module classification', function () {
+  module('the trusted boundary', function () {
+    test('RP-6.6: Host-owned spellings are trusted and neighbouring ones are not', function (assert) {
+      for (let identifier of [
+        cardApi,
+        'https://cardstack.com/base/',
+        'https://cardstack.com/base',
+        'https://cardstack.com/base/fields/nested/thing',
+        `${PACKAGES_FAKE_ORIGIN}@cardstack/boxel-ui/components`,
+        '@cardstack/boxel-ui/components',
+        '@cardstack/runtime-common',
+      ]) {
+        assert.true(isTrustedModule(identifier), `trusted: ${identifier}`);
+      }
+      for (let identifier of [
+        'https://cardstack.com/base-evil/card-api',
+        'https://cardstack.com.evil.example/base/card-api',
+        'http://cardstack.com/base/card-api',
+        'https://evil.example/base/card-api',
+        `${PACKAGES_FAKE_ORIGIN}@cardstack-evil/thing`,
+        '@cardstack-evil/thing',
+        '@cardstack',
+        '@cardstack/',
+        './card-api',
+        `${realmOrigin}person`,
+      ]) {
+        assert.false(isTrustedModule(identifier), `untrusted: ${identifier}`);
+      }
+    });
+
+    test('RP-6.6: a package specifier carrying a second layer of interpretation is rejected rather than normalized', function (assert) {
+      for (let identifier of [
+        '@cardstack/base/../../evil/card',
+        '@cardstack/base/./card',
+        '@cardstack/../evil/card',
+        '@cardstack/base/%2e%2e/%2e%2e/evil/card',
+        '@cardstack/base/%252e%252e/evil/card',
+        '@cardstack\\base\\card',
+        '@cardstack/base\\..\\evil',
+        '@cardstack/base?../evil',
+        '@cardstack/base#/../evil',
+        '@cardstack/base/%zz',
+      ]) {
+        assert.false(isTrustedModule(identifier), `rejected: ${identifier}`);
+      }
+    });
+
+    test('RP-6.6: being importable as a Host stand-in is not trusted provenance', function (assert) {
+      for (let identifier of [
+        '@glimmer/component',
+        '@ember/modifier',
+        'https://cardstack.com/catalog/blog-post',
+      ]) {
+        assert.true(
+          isTrustedImport(identifier),
+          `Host-provided: ${identifier}`,
+        );
+        assert.false(
+          isTrustedModule(identifier),
+          `not Direct provenance: ${identifier}`,
+        );
+      }
+      // The narrower predicate is contained in the wider one, so the walk can
+      // prune on the wider one alone.
+      for (let identifier of [cardApi, '@cardstack/boxel-ui/components']) {
+        assert.true(isTrustedImport(identifier), `contained: ${identifier}`);
+      }
+      assert.false(isTrustedImport(`${realmOrigin}person`), 'authored module');
+    });
+  });
+
+  module('the module graph', function () {
+    test('RP-6.7: the entry is reported first and its reachable graph sorted after it', async function (assert) {
+      let realm = new TestRealm({
+        person: `import Address from './address';\nimport Pet from './pet';\nexport class Person {}\n`,
+        address: `import Zip from './zip';\nexport class Address {}\n`,
+        pet: `import Zip from './zip';\nexport class Pet {}\n`,
+        zip: `export class Zip {}\n`,
+      });
+      let result = await classifierFor(realm).classifyModule(
+        realm.url('person'),
+      );
+
+      assert.false(result.trusted, 'authored');
+      assert.true(result.moduleGraphComplete, 'graph established');
+      assert.strictEqual(result.reason, 'authored-module');
+      assert.deepEqual(result.moduleGraph, [
+        realm.url('person'),
+        realm.url('address'),
+        realm.url('pet'),
+        realm.url('zip'),
+      ]);
+      assert.strictEqual(realm.loadCount('zip'), 1, 'the diamond read once');
+    });
+
+    test('RP-6.7: a cycle entered from either end yields the same graph', async function (assert) {
+      let realm = new TestRealm({
+        a: `import B from './b';\nexport class A {}\n`,
+        b: `import C from './c';\nexport class B {}\n`,
+        c: `import A from './a';\nexport class C {}\n`,
+      });
+      let fromA = await classifierFor(realm).classifyModule(realm.url('a'));
+      let fromB = await classifierFor(realm).classifyModule(realm.url('b'));
+
+      assert.deepEqual(fromA.moduleGraph, [
+        realm.url('a'),
+        realm.url('b'),
+        realm.url('c'),
+      ]);
+      assert.deepEqual(fromB.moduleGraph, [
+        realm.url('b'),
+        realm.url('a'),
+        realm.url('c'),
+      ]);
+      assert.true(fromA.moduleGraphComplete, 'established from a');
+      assert.true(fromB.moduleGraphComplete, 'established from b');
+      assert.deepEqual(
+        [...fromA.moduleGraph].sort(),
+        [...fromB.moduleGraph].sort(),
+        'the same set either way',
+      );
+    });
+
+    test('RP-6.7: a trusted import is an edge that is neither resolved nor read', async function (assert) {
+      let realm = new TestRealm({
+        person: [
+          `import { CardDef, field, contains } from '${cardApi}';`,
+          `import StringField from 'https://cardstack.com/base/string';`,
+          `import GlimmerComponent from '@glimmer/component';`,
+          `import { Button } from '@cardstack/boxel-ui/components';`,
+          `export class Person extends CardDef {`,
+          `  @field name = contains(StringField);`,
+          `}`,
+        ].join('\n'),
+      });
+      let result = await classifierFor(realm).classifyModule(
+        realm.url('person'),
+      );
+
+      assert.deepEqual(result.moduleGraph, [
+        realm.url('person'),
+        '@cardstack/boxel-ui/components',
+        '@glimmer/component',
+        cardApi,
+        'https://cardstack.com/base/string',
+      ]);
+      assert.true(result.moduleGraphComplete, 'nothing failed');
+      assert.deepEqual(realm.loads, [realm.url('person')], 'only the entry');
+      assert.deepEqual(realm.resolutions, [], 'nothing resolved');
+    });
+
+    test('RP-6.7: a module the runtime shims is an edge the walk stops at', async function (assert) {
+      let realm = new TestRealm({
+        person: `import { format } from 'date-fns';\nexport class Person {}\n`,
+      });
+      let shimmed = new Set(['date-fns']);
+      let result = await classifierFor(realm, {
+        isHostProvidedModule: (identifier) => shimmed.has(identifier),
+      }).classifyModule(realm.url('person'));
+
+      assert.deepEqual(result.moduleGraph, [realm.url('person'), 'date-fns']);
+      assert.true(result.moduleGraphComplete, 'a shim is not a failure');
+      assert.deepEqual(realm.loads, [realm.url('person')], 'only the entry');
+    });
+
+    test('RP-6.7: an unresolvable import marks the graph unavailable and names every specifier deterministically', async function (assert) {
+      let realm = new TestRealm({
+        person: `import z from 'zebra';\nimport a from 'aardvark';\nexport class Person {}\n`,
+      });
+      let reversed = new TestRealm({
+        person: `import a from 'aardvark';\nimport z from 'zebra';\nexport class Person {}\n`,
+      });
+      let result = await classifierFor(realm).classifyModule(
+        realm.url('person'),
+      );
+      let sameGraphOtherOrder = await classifierFor(reversed).classifyModule(
+        reversed.url('person'),
+      );
+
+      assert.false(result.moduleGraphComplete, 'fails closed');
+      assert.strictEqual(result.reason, 'module-resolve:aardvark');
+      assert.strictEqual(
+        sameGraphOtherOrder.reason,
+        result.reason,
+        'the reported specifier does not depend on source order',
+      );
+    });
+
+    test('RP-6.7: a dependency that cannot be read marks the graph unavailable', async function (assert) {
+      let realm = new TestRealm({
+        person: `import Address from './address';\nexport class Person {}\n`,
+      });
+      let result = await classifierFor(realm).classifyModule(
+        realm.url('person'),
+      );
+
+      assert.false(result.moduleGraphComplete);
+      assert.strictEqual(result.reason, `module-load:${realm.url('address')}`);
+      assert.deepEqual(
+        result.moduleGraph,
+        [realm.url('person'), realm.url('address')],
+        'the edge is reported, but as a diagnostic rather than an authorization',
+      );
+    });
+
+    test('RP-6.7: a dependency that does not parse is named rather than treated as a draft', async function (assert) {
+      let realm = new TestRealm({
+        person: `import Address from './address';\nexport class Person {}\n`,
+        address: `export class Address { <template>`,
+      });
+      let result = await classifierFor(realm).classifyModule(
+        realm.url('person'),
+      );
+
+      assert.false(result.moduleGraphComplete);
+      assert.strictEqual(result.reason, `module-parse:${realm.url('address')}`);
+    });
+
+    test('RP-6.7: an entry that does not parse is a pending draft with an empty graph, not a throw', async function (assert) {
+      let realm = new TestRealm({});
+      let result = await classifierFor(realm).classifyModule(
+        realm.url('person'),
+        `export class Person { <template>`,
+      );
+
+      assert.strictEqual(result.reason, 'source-parse-pending');
+      assert.false(result.moduleGraphComplete, 'nothing may be authorized');
+      assert.deepEqual(result.moduleGraph, [realm.url('person')]);
+      assert.false(result.authoredEditTemplate, 'nothing was established');
+    });
+
+    test('RP-6.7: an entry that cannot be read is reported as unreadable rather than as a draft', async function (assert) {
+      let realm = new TestRealm({});
+      let result = await classifierFor(realm).classifyModule(
+        realm.url('person'),
+      );
+
+      assert.strictEqual(result.reason, `module-load:${realm.url('person')}`);
+      assert.false(result.moduleGraphComplete);
+    });
+
+    test('RP-6.7: the bound is met exactly, and exceeding it outranks the failures of a walk that stopped early', async function (assert) {
+      // The absent module sorts ahead of `b`, so the walk reaches it — and
+      // records its failure — before it runs out of room. Both narrower runs
+      // below therefore have a failure in hand when the bound is hit, which is
+      // what makes the precedence between them observable.
+      let realm = new TestRealm({
+        a: `import Absent from './absent';\nimport B from './b';\nexport class A {}\n`,
+        b: `import C from './c';\nexport class B {}\n`,
+        c: `export class C {}\n`,
+      });
+      let met = await classifierFor(realm, { maxModules: 3 }).classifyModule(
+        realm.url('a'),
+      );
+      assert.strictEqual(
+        met.reason,
+        `module-load:${realm.url('absent')}`,
+        'three modules fit, so the unreadable one is the news',
+      );
+
+      let exceeded = await classifierFor(realm, {
+        maxModules: 2,
+      }).classifyModule(realm.url('a'));
+      assert.strictEqual(
+        exceeded.reason,
+        'module-graph-limit',
+        'a walk that stopped early reports that, not what it happened to reach first',
+      );
+      assert.false(exceeded.moduleGraphComplete);
+    });
+
+    test('RP-6.7: a literal dynamic import is an edge and a computed one is absent', async function (assert) {
+      let realm = new TestRealm({
+        person: [
+          `export class Person {`,
+          `  async chart() { return import('./chart'); }`,
+          `  async other(name) { return import(name); }`,
+          `}`,
+        ].join('\n'),
+        chart: `export class Chart {}\n`,
+      });
+      let result = await classifierFor(realm).classifyModule(
+        realm.url('person'),
+      );
+
+      assert.deepEqual(result.moduleGraph, [
+        realm.url('person'),
+        realm.url('chart'),
+      ]);
+      assert.true(
+        result.moduleGraphComplete,
+        'a computed specifier is not a failure to establish the graph',
+      );
+    });
+
+    test('RP-6.7: the import preprocessing adds to compile a template is not an edge', async function (assert) {
+      let realm = new TestRealm({
+        person: `export class Person {\n  static isolated = <template><h1>hi</h1></template>;\n}\n`,
+      });
+      let result = await classifierFor(realm).classifyModule(
+        realm.url('person'),
+      );
+
+      assert.deepEqual(
+        result.moduleGraph,
+        [realm.url('person')],
+        'a templated card with no imports has a graph of one',
+      );
+      assert.strictEqual(
+        result.reason,
+        'authored-module',
+        'nor does the injected specifier reach resolution',
+      );
+      assert.true(result.moduleGraphComplete, 'so the graph is established');
+      // Pins what is being filtered: preprocessing still injects exactly this
+      // specifier, so a rename upstream fails here rather than quietly adding
+      // a module to every templated card's authorization list.
+      await lexerReady;
+      let compiled = new ContentTag.Preprocessor().process(
+        `<template>hi</template>`,
+        { filename: 'probe.gts' },
+      ).code;
+      assert.deepEqual(
+        lexImports(compiled)[0].map((entry) => entry.n),
+        ['@ember/template-compiler'],
+      );
+    });
+
+    test('RP-6.7: a trusted entry is answered from its identifier without a read', async function (assert) {
+      let realm = new TestRealm({});
+      let result = await classifierFor(realm).classifyModule(cardApi);
+
+      assert.true(result.trusted);
+      assert.strictEqual(result.reason, 'trusted-module');
+      assert.deepEqual(result.moduleGraph, [cardApi]);
+      assert.true(result.moduleGraphComplete);
+      assert.deepEqual(realm.loads, [], 'no source was read');
+    });
+
+    test('RP-6.7: every declared reason kind is reachable', async function (assert) {
+      let realm = new TestRealm({
+        settled: `export class Settled {}\n`,
+        unresolvable: `import x from 'nope';\nexport class X {}\n`,
+        missingDependency: `import x from './gone';\nexport class X {}\n`,
+        brokenDependency: `import x from './broken';\nexport class X {}\n`,
+        broken: `export class Broken { <template>`,
+        deep: `import x from './settled';\nexport class Deep {}\n`,
+      });
+      let classifier = classifierFor(realm);
+      let produced = new Set<string>();
+      let observe = ({ reason }: { reason: string }) =>
+        produced.add(reason.split(':')[0]!);
+
+      observe(await classifier.classifyModule(cardApi));
+      observe(await classifier.classifyModule(realm.url('settled')));
+      observe(
+        await classifier.classifyModule(
+          realm.url('draft'),
+          `class Draft { <template>`,
+        ),
+      );
+      observe(await classifier.classifyModule(realm.url('unresolvable')));
+      observe(await classifier.classifyModule(realm.url('missingDependency')));
+      observe(await classifier.classifyModule(realm.url('brokenDependency')));
+      observe(
+        await classifierFor(realm, { maxModules: 1 }).classifyModule(
+          realm.url('deep'),
+        ),
+      );
+
+      assert.deepEqual(
+        [...produced].sort(),
+        [...MODULE_CLASSIFICATION_REASON_KINDS].sort(),
+        'the declared vocabulary is exactly what classification can produce',
+      );
+    });
+  });
+
+  module('caching', function () {
+    test('RP-6.7: a second entry reads none of the subtree it shares with the first', async function (assert) {
+      let realm = new TestRealm({
+        person: `import Address from './address';\nexport class Person {}\n`,
+        employee: `import Address from './address';\nexport class Employee {}\n`,
+        address: `import Zip from './zip';\nexport class Address {}\n`,
+        zip: `export class Zip {}\n`,
+      });
+      let classifier = classifierFor(realm);
+      await classifier.classifyModule(realm.url('person'));
+      realm.loads.length = 0;
+      let second = await classifier.classifyModule(realm.url('employee'));
+
+      assert.deepEqual(
+        realm.loads,
+        [realm.url('employee')],
+        'only the second entry itself was read',
+      );
+      assert.deepEqual(second.moduleGraph, [
+        realm.url('employee'),
+        realm.url('address'),
+        realm.url('zip'),
+      ]);
+    });
+
+    test('RP-6.7: invalidating a dependency evicts every entry whose graph reached it', async function (assert) {
+      let realm = new TestRealm({
+        person: `import Address from './address';\nexport class Person {}\n`,
+        address: `export class Address {}\n`,
+      });
+      let classifier = classifierFor(realm);
+      await classifier.classifyModule(realm.url('person'));
+
+      realm.write('address', `import Zip from './zip';\nexport class A {}\n`);
+      realm.write('zip', `export class Zip {}\n`);
+      classifier.invalidate(realm.url('address'));
+      realm.loads.length = 0;
+      let again = await classifier.classifyModule(realm.url('person'));
+
+      assert.deepEqual(again.moduleGraph, [
+        realm.url('person'),
+        realm.url('address'),
+        realm.url('zip'),
+      ]);
+      // The graph grew, so the importer's entry was re-walked rather than
+      // answered from its stale one — while the importer's own source, which
+      // did not change, was not re-read: eviction is scoped to what was
+      // invalidated, and the shared memo still holds the rest of the walk.
+      assert.strictEqual(realm.loadCount('address'), 1, 'the changed module');
+      assert.strictEqual(
+        realm.loadCount('person'),
+        0,
+        'the unchanged importer',
+      );
+    });
+
+    test('RP-6.7: a result that could not establish the graph is retried rather than remembered', async function (assert) {
+      let realm = new TestRealm({
+        person: `import Address from './address';\nexport class Person {}\n`,
+      });
+      let classifier = classifierFor(realm);
+      let failed = await classifier.classifyModule(realm.url('person'));
+      assert.false(failed.moduleGraphComplete);
+
+      realm.write('address', `export class Address {}\n`);
+      let recovered = await classifier.classifyModule(realm.url('person'));
+
+      assert.true(
+        recovered.moduleGraphComplete,
+        'no invalidate call was needed',
+      );
+      assert.strictEqual(recovered.reason, 'authored-module');
+    });
+
+    test('RP-6.7: a draft answers only its own caller and never seats itself in the shared memo', async function (assert) {
+      let realm = new TestRealm({
+        person: `import Address from './address';\nexport class Person {}\n`,
+        employee: `import Person from './person';\nexport class Employee {}\n`,
+        address: `export class Address {}\n`,
+        secret: `export class Secret {}\n`,
+      });
+      let classifier = classifierFor(realm);
+      let draft = await classifier.classifyModule(
+        realm.url('person'),
+        `import Secret from './secret';\nexport class Person {}\n`,
+      );
+      assert.deepEqual(
+        draft.moduleGraph,
+        [realm.url('person'), realm.url('secret')],
+        "the draft's own imports",
+      );
+
+      let importer = await classifier.classifyModule(realm.url('employee'));
+      assert.deepEqual(
+        importer.moduleGraph,
+        [realm.url('employee'), realm.url('address'), realm.url('person')],
+        'another card sees the module the realm serves, not the buffer someone is typing in',
+      );
+    });
+
+    test('RP-6.7: an unchanged draft is answered from the entry memo and a changed one replaces it', async function (assert) {
+      let realm = new TestRealm({ address: `export class Address {}\n` });
+      let classifier = classifierFor(realm);
+      let draft = `import Address from './address';\nexport class Person {}\n`;
+
+      await classifier.classifyModule(realm.url('person'), draft);
+      let loadsAfterFirst = realm.loads.length;
+      await classifier.classifyModule(realm.url('person'), draft);
+      assert.strictEqual(
+        realm.loads.length,
+        loadsAfterFirst,
+        'the same draft re-walked nothing',
+      );
+
+      let changed = await classifier.classifyModule(
+        realm.url('person'),
+        `export class Person {}\n`,
+      );
+      assert.deepEqual(
+        changed.moduleGraph,
+        [realm.url('person')],
+        'the changed draft replaced the memoized answer',
+      );
+    });
+  });
+
+  module('the authored edit surface', function () {
+    async function editTemplateFor(source: string): Promise<boolean> {
+      let realm = new TestRealm({ person: source });
+      let result = await classifierFor(realm).classifyModule(
+        realm.url('person'),
+      );
+      return result.authoredEditTemplate;
+    }
+
+    test('RP-6.8: a module declaring an authored edit template says so', async function (assert) {
+      assert.true(
+        await editTemplateFor(
+          `export class Person {\n  static edit = <template><input /></template>;\n}\n`,
+        ),
+        'an inline editor on the card class',
+      );
+      assert.true(
+        await editTemplateFor(
+          `import Editor from '@glimmer/component';\nexport class Person {\n  static edit = Editor;\n}\n`,
+        ),
+        'an imported editor is authored code on the edit surface too',
+      );
+      assert.true(
+        await editTemplateFor(
+          [
+            `export class Person {`,
+            `  static isolated = <template><h1>hi</h1></template>;`,
+            `}`,
+            `export class Rating {`,
+            `  static edit = <template><input type='range' /></template>;`,
+            `}`,
+          ].join('\n'),
+        ),
+        "a field's authored editor counts as much as the card's",
+      );
+    });
+
+    test('RP-6.8: a module with no authored edit template says so', async function (assert) {
+      assert.false(
+        await editTemplateFor(
+          `export class Person {\n  static isolated = <template><h1>hi</h1></template>;\n}\n`,
+        ),
+        'other formats are not the edit surface',
+      );
+      assert.false(
+        await editTemplateFor(
+          `export class Person {\n  static editable = true;\n  edit = 1;\n}\n`,
+        ),
+        'a longer name and a non-static field are neither',
+      );
+      assert.false(
+        await editTemplateFor(`export class Person {}\n`),
+        'nothing declared',
+      );
+    });
+  });
+});

--- a/packages/host/tests/unit/rp-6-module-classification-test.ts
+++ b/packages/host/tests/unit/rp-6-module-classification-test.ts
@@ -789,6 +789,24 @@ module('Unit | rendering protocol | module classification', function () {
         ),
         'the annotated form the Base realm itself writes',
       );
+      // Every modifier TypeScript allows between `static` and the name, plus
+      // the key spellings that still name one declaration.
+      for (let declaration of [
+        'static readonly edit = Edit;',
+        'static override edit = Edit;',
+        'static readonly override edit: BaseDefComponent = Edit;',
+        'declare static edit: BaseDefComponent;',
+        'static ["edit"] = Edit;',
+        "static ['edit'] = Edit;",
+        'static get edit() { return Edit; }',
+      ]) {
+        assert.true(
+          await editTemplateFor(
+            `class Edit {}\nexport class Person {\n  ${declaration}\n}\n`,
+          ),
+          declaration,
+        );
+      }
       assert.true(
         await editTemplateFor(
           [
@@ -820,6 +838,12 @@ module('Unit | rendering protocol | module classification', function () {
       assert.false(
         await editTemplateFor(`export class Person {}\n`),
         'nothing declared',
+      );
+      assert.false(
+        await editTemplateFor(
+          `export class Person {\n  static edited = 1;\n  static [key] = 2;\n}\n`,
+        ),
+        'a longer name, and a computed key no reading of the source resolves',
       );
     });
   });

--- a/packages/host/tests/unit/rp-6-module-classification-test.ts
+++ b/packages/host/tests/unit/rp-6-module-classification-test.ts
@@ -4,6 +4,7 @@ import { module, test } from 'qunit';
 
 import { PACKAGES_FAKE_ORIGIN } from '@cardstack/runtime-common/package-shim-handler';
 
+import config from '@cardstack/host/config/environment';
 import {
   BoxelModuleClassifier,
   MODULE_CLASSIFICATION_REASON_KINDS,
@@ -127,12 +128,88 @@ module('Unit | rendering protocol | module classification', function () {
       }
     });
 
-    test('RP-6.6: being importable as a Host stand-in is not trusted provenance', function (assert) {
+    test('RP-6.6: a realm alias under the Cardstack scope is not a Host package', function (assert) {
+      // `addRealmMapping` registers `@cardstack/<realm>/` for every realm the
+      // Host maps, so the scope is a namespace authored content also lives in.
+      // A realm's two spellings have to agree, or one module gets two tiers
+      // depending on which string the caller happens to be holding.
       for (let identifier of [
-        '@glimmer/component',
-        '@ember/modifier',
-        'https://cardstack.com/catalog/blog-post',
+        '@cardstack/catalog/commands/listing-create',
+        '@cardstack/skills/some-skill',
+        '@cardstack/openrouter/some-model',
+        '@cardstack/experiments-realm/person',
+        '@cardstack/not-a-real-package/thing',
       ]) {
+        assert.false(isTrustedModule(identifier), `authored: ${identifier}`);
+        assert.false(isTrustedImport(identifier), `not pruned: ${identifier}`);
+      }
+      // The Base realm is trusted on its own account, so its alias agrees with
+      // its URL rather than contradicting it.
+      assert.true(isTrustedModule('@cardstack/base/card-api'), 'base alias');
+      assert.true(
+        isTrustedModule('https://cardstack.com/base/card-api'),
+        'base URL',
+      );
+    });
+
+    test('RP-6.6: the realm URLs this deployment resolves are classified from config', function (assert) {
+      // The hardcoded literals are only half the boundary; these are the
+      // inputs that vary per deployment and can be degenerate.
+      assert.true(
+        isTrustedModule(`${config.resolvedBaseRealmURL}card-api`),
+        'the resolved Base realm is trusted',
+      );
+      assert.false(
+        isTrustedModule(
+          new URL('../experiments/person', config.resolvedBaseRealmURL).href,
+        ),
+        'a sibling realm on the same origin is not',
+      );
+      assert.true(
+        isTrustedImport(`${config.iconsURL}/@cardstack/boxel-icons/v1/x.js`),
+        'the icons host is Host-provided',
+      );
+      assert.false(
+        isTrustedModule(`${config.iconsURL}/@cardstack/boxel-icons/v1/x.js`),
+        'which is not a grant of Direct execution',
+      );
+    });
+
+    test('RP-6.6: an origin-wide boundary is opted into, never inherited', function (assert) {
+      // The icons host legitimately has no path of its own.
+      assert.true(
+        isTrustedImport(`${config.iconsURL}/anything/at/all`),
+        'the icons host covers its origin',
+      );
+      let iconsOrigin = new URL(config.iconsURL).origin;
+      assert.false(
+        isTrustedModule(`${iconsOrigin}/anything/at/all`),
+        'which is not a rule realm boundaries share',
+      );
+
+      // A realm boundary is read from deployment config, and pointing one at
+      // an origin root is the one misconfiguration here that would fail OPEN —
+      // every realm on that host trusted, silently. Driven directly, because
+      // no boundary this environment configures has a root path.
+      let configured = config.resolvedBaseRealmURL;
+      try {
+        config.resolvedBaseRealmURL = `${iconsOrigin}/`;
+        assert.false(
+          isTrustedModule(`${iconsOrigin}/someone-elses-realm/card`),
+          'a realm boundary at an origin root is refused, not honoured',
+        );
+      } finally {
+        config.resolvedBaseRealmURL = configured;
+      }
+      assert.strictEqual(
+        config.resolvedBaseRealmURL,
+        configured,
+        'the environment is left as it was found',
+      );
+    });
+
+    test('RP-6.6: being importable as a Host stand-in is not trusted provenance', function (assert) {
+      for (let identifier of ['@glimmer/component', '@ember/modifier']) {
         assert.true(
           isTrustedImport(identifier),
           `Host-provided: ${identifier}`,
@@ -331,13 +408,13 @@ module('Unit | rendering protocol | module classification', function () {
         b: `import C from './c';\nexport class B {}\n`,
         c: `export class C {}\n`,
       });
-      let met = await classifierFor(realm, { maxModules: 3 }).classifyModule(
+      let met = await classifierFor(realm, { maxModules: 4 }).classifyModule(
         realm.url('a'),
       );
       assert.strictEqual(
         met.reason,
         `module-load:${realm.url('absent')}`,
-        'three modules fit, so the unreadable one is the news',
+        'all four reads fit, so the unreadable one is the news',
       );
 
       let exceeded = await classifierFor(realm, {
@@ -349,6 +426,65 @@ module('Unit | rendering protocol | module classification', function () {
         'a walk that stopped early reports that, not what it happened to reach first',
       );
       assert.false(exceeded.moduleGraphComplete);
+    });
+
+    test('RP-6.7: the bound counts reads, so unreadable imports cannot outrun it', async function (assert) {
+      let imports = Array.from(
+        { length: 40 },
+        (_, index) => `import M${index} from './missing-${index}';`,
+      ).join('\n');
+      let realm = new TestRealm({ person: `${imports}\nexport class P {}\n` });
+      let result = await classifierFor(realm, { maxModules: 5 }).classifyModule(
+        realm.url('person'),
+      );
+
+      assert.strictEqual(result.reason, 'module-graph-limit');
+      assert.false(result.moduleGraphComplete);
+      // A module that fails to load yields no analysis, so a bound counted
+      // over successful analyses would never advance and every one of the 40
+      // would be fetched.
+      assert.strictEqual(realm.loads.length, 5, 'reads stopped at the bound');
+    });
+
+    test('RP-6.7: one failing dependency is read once however many importers reach it', async function (assert) {
+      let realm = new TestRealm({
+        person: `import A from './a';\nimport B from './b';\nexport class P {}\n`,
+        a: `import Gone from './gone';\nexport class A {}\n`,
+        b: `import Gone from './gone';\nexport class B {}\n`,
+      });
+      let result = await classifierFor(realm).classifyModule(
+        realm.url('person'),
+      );
+
+      assert.strictEqual(result.reason, `module-load:${realm.url('gone')}`);
+      // A failed analysis self-evicts from the shared memo, so without a
+      // per-walk record of what was attempted the second importer re-reads it.
+      assert.strictEqual(realm.loadCount('gone'), 1, 'read once');
+    });
+
+    test('RP-6.7: a resolver that answers with something other than an identifier fails closed', async function (assert) {
+      let realm = new TestRealm({
+        person: `import A from './a';\nexport class P {}\n`,
+      });
+      let result = await classifierFor(realm, {
+        resolveImport: () => undefined as unknown as string,
+      }).classifyModule(realm.url('person'));
+
+      assert.strictEqual(result.reason, 'module-resolve:./a');
+      assert.false(result.moduleGraphComplete, 'rather than escaping');
+    });
+
+    test('RP-6.7: the reported graph cannot be mutated by one of its holders', async function (assert) {
+      let realm = new TestRealm({ person: `export class P {}\n` });
+      let classifier = classifierFor(realm);
+      let result = await classifier.classifyModule(realm.url('person'));
+
+      assert.throws(
+        () => (result.moduleGraph as string[]).push('http://evil/'),
+        'a memoized authorization list is shared, so it is frozen',
+      );
+      let again = await classifier.classifyModule(realm.url('person'));
+      assert.deepEqual(again.moduleGraph, [realm.url('person')]);
     });
 
     test('RP-6.7: a literal dynamic import is an edge and a computed one is absent', async function (assert) {
@@ -563,14 +699,18 @@ module('Unit | rendering protocol | module classification', function () {
       let classifier = classifierFor(realm);
       let draft = `import Address from './address';\nexport class Person {}\n`;
 
-      await classifier.classifyModule(realm.url('person'), draft);
+      let first = await classifier.classifyModule(realm.url('person'), draft);
       let loadsAfterFirst = realm.loads.length;
-      await classifier.classifyModule(realm.url('person'), draft);
+      let second = await classifier.classifyModule(realm.url('person'), draft);
       assert.strictEqual(
         realm.loads.length,
         loadsAfterFirst,
-        'the same draft re-walked nothing',
+        'the same draft re-read nothing',
       );
+      // Identity, not read counts: the draft's own source is supplied either
+      // way and its dependency is in the shared memo, so a read count alone
+      // holds even with no entry memo at all.
+      assert.strictEqual(second, first, 'answered from the entry memo');
 
       let changed = await classifier.classifyModule(
         realm.url('person'),
@@ -605,6 +745,20 @@ module('Unit | rendering protocol | module classification', function () {
           `import Editor from '@glimmer/component';\nexport class Person {\n  static edit = Editor;\n}\n`,
         ),
         'an imported editor is authored code on the edit surface too',
+      );
+      assert.true(
+        await editTemplateFor(
+          [
+            `import { Component, type BaseDefComponent } from '${cardApi}';`,
+            `class Edit extends Component<any> {`,
+            `  static template = <template><input /></template>;`,
+            `}`,
+            `export class Person {`,
+            `  static edit: BaseDefComponent = Edit;`,
+            `}`,
+          ].join('\n'),
+        ),
+        'the annotated form the Base realm itself writes',
       );
       assert.true(
         await editTemplateFor(

--- a/packages/host/tests/unit/rp-6-module-classification-test.ts
+++ b/packages/host/tests/unit/rp-6-module-classification-test.ts
@@ -92,6 +92,8 @@ module('Unit | rendering protocol | module classification', function () {
         `${PACKAGES_FAKE_ORIGIN}@cardstack/boxel-ui/components`,
         '@cardstack/boxel-ui/components',
         '@cardstack/runtime-common',
+        '@cardstack/host/tests/helpers/setup',
+        `${PACKAGES_FAKE_ORIGIN}@cardstack/host/tests/helpers/setup`,
       ]) {
         assert.true(isTrustedModule(identifier), `trusted: ${identifier}`);
       }
@@ -149,6 +151,33 @@ module('Unit | rendering protocol | module classification', function () {
       assert.true(
         isTrustedModule('https://cardstack.com/base/card-api'),
         'base URL',
+      );
+    });
+
+    test('RP-6.7: a published realm is walked rather than pruned, by either spelling', function (assert) {
+      // Pruning is sound only where trust begins, so a realm the Host
+      // publishes is not a leaf: it is authored source with its own import
+      // graph, and stopping there would report a complete graph while dropping
+      // everything behind it. The URL spelling has to say so as loudly as the
+      // alias does.
+      assert.false(
+        isTrustedImport('https://cardstack.com/catalog/blog-post'),
+        'the Catalog realm is not a Host stand-in',
+      );
+      let configured = config.resolvedCatalogRealmURL;
+      try {
+        config.resolvedCatalogRealmURL = 'https://realms.example/catalog/';
+        assert.false(
+          isTrustedImport('https://realms.example/catalog/blog-post'),
+          'nor is it one once this deployment resolves it',
+        );
+      } finally {
+        config.resolvedCatalogRealmURL = configured;
+      }
+      assert.strictEqual(
+        config.resolvedCatalogRealmURL,
+        configured,
+        'the environment is left as it was found',
       );
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2403,6 +2403,9 @@ importers:
       ember-window-mock:
         specifier: ^1.0.1
         version: 1.0.2(@babel/core@7.29.7)(@glint/template@1.7.7)
+      es-module-lexer:
+        specifier: ^1.7.0
+        version: 1.7.0
       eslint:
         specifier: 'catalog:'
         version: 8.57.1


### PR DESCRIPTION
## What this is for

The sandboxing work rests on a promise: user-authored card code renders without any authority over the Host app. Two things have to be decided *before* a single line of a card runs, and both are decided by looking at the module's identifier and its source — the code is never executed to decide them.

**Is this module ours?** Base-realm modules and `@cardstack/*` packages are code we wrote, and they run Direct — in the Host page, with the Host's loader, DOM and session, exactly as everything does today. Everything else is authored code and gets caged. This is the one classification decision that is a real security boundary. Every other fact classification produces only describes an authored module, where a wrong answer costs a refused fetch or some wasted work; a wrong answer *here* means someone else's code running with our authority.

**What exactly does this module reach?** A card's module imports other modules, which import others. That full set — the module graph — is what a sandboxed child is allowed to read and nothing more. The child has no credentials of its own; when it wants a module, it asks the Host, and the Host checks the request against this list before performing the authenticated fetch. So the list has to be complete and it has to be exact: too small and the card can't load its own code, too large and the cage leaks.

Nothing here is wired into a render path. This is the piece the sandbox's module authority, the routing function, the telemetry event and the diagnostics catalog all build on.

## The trusted boundary

`packages/host/app/lib/trusted-modules.ts` is the security-critical half, and it is written to reject rather than to normalize: a spelling it does not positively recognize as Host-owned is not trusted.

The reason it can't be a prefix test is a sequencing detail worth spelling out. Most module identifiers are URLs, and `new URL()` is what collapses `..` segments and decodes percent-escapes for them — so by the time we compare, the identifier is already in canonical form. But a *bare* package specifier like `@cardstack/boxel-ui/components` is not a URL yet; it reaches this check before the Loader has resolved it, so none of that normalization has happened. `@cardstack/base/../../evil/card` is a perfectly legal ESM specifier that a resolver may take outside the package root, and it reads as trusted to a naive `startsWith('@cardstack/')`.

So the specifier form is admitted only when it is unambiguously a path inside an `@cardstack` package: it decodes cleanly, it contains no `\` (a path separator to some resolvers), no `%` (a further round of encoding), no `?` or `#` (a query or fragment that could hide the real path), and no `.` or `..` segments. Rejecting `%` outright is what makes a single `decodeURIComponent` sufficient — a doubly-encoded `%252e%252e` decodes to `%2e%2e`, which still carries a `%` and is refused, so there's no need to decode to a fixed point.

The other half of the predicate is the scope itself, and this is where the shape matters: `@cardstack/<name>/` is **not only an npm scope in this codebase — it is also the realm-alias namespace**. `addRealmMapping` registers one such prefix per mapped realm: `network.ts` does it for the catalog, skills and OpenRouter realms, and `main.ts` / `worker.ts` do it generically for every `https://cardstack.com/<name>/` mapping, so the namespace gains members without this file being touched. Those realms hold authored card modules, and the alias spelling is live — `packages/base/Skill/catalog-listing.json` ships `"module": "@cardstack/catalog/commands/listing-create"` as a code ref.

So provenance within the scope is decided by an allowlist of Host package names (`base`, `boxel-ui`, `boxel-icons`, `boxel-host`, `runtime-common`, `bxl`, `view-transitions`), not by the scope. Admitting the scope would hand Direct execution to authored realm content under its alias while the same module's URL spelling classified as authored — one module, two tiers, decided by which string the caller happened to hold. The Base realm is on the list because it is trusted on its own account, so its alias and its URL agree.

A Host package missing from that list fails closed: its modules classify as authored, which cages them. That is the right direction for a stale list — visible, never an escalation — and it doesn't break the graph walk, which prunes on the runtime's own shim registry rather than on this list.

Alongside it is a second, wider predicate: `isTrustedImport`, which adds the icons host and the framework stand-ins (`@glimmer/component`, `@ember/modifier`, …). This answers a different question — "will the Host serve this module from its own stand-in rather than as authored source?" — and it is deliberately **not** a grant of Direct execution. Being allowed to import `@glimmer/component` says nothing about who wrote the importing module.

What it widens by is deliberately narrow, and the rule is that **pruning is only sound where trust begins**: a pruned module's own closure becomes the Host's problem to resolve. The framework stand-ins qualify, and so does the icons host — an icon module's own imports are `@ember/component`, `@ember/template-factory` and `@ember/component/template-only`, all in the framework floor. Published realm content does not qualify however Host-owned the realm is: it is authored source with its own import graph, so pruning at it would report a complete graph while silently dropping everything behind it.

## Reading one module

`packages/host/app/lib/boxel-module-classifier.ts` reads a module's source in two steps.

First, `content-tag`'s `process()`. Card source is `.gts` — JavaScript with `<template>` blocks in it — which is not JavaScript any parser will accept. `process()` is what the realm's own transpiler (`packages/runtime-common/transpile.ts`) runs first, rewriting each template block into a function call. Using the same front end is what makes "this didn't parse" mean *an in-progress draft* rather than *syntax the realm happily serves that this file can't read*. That distinction is expensive to get wrong here, because a draft answer yields an empty module graph, and an empty module graph means a card whose sandbox can't load its own modules — a card that renders fine today failing with refusals.

Note that `process()` handles a template in *expression* position (`const Row = <template>…</template>;`) as well as in a class body. Simply blanking the template spans would leave a hole where an expression has to be, and a finished, servable module would read as unparseable.

Second, `es-module-lexer` over that output for the import list. A dynamic import written with a literal string — `import('./chart')` — is reported with its specifier and joins the graph as an ordinary edge. A computed one — `import(name)` — is reported without a specifier, because there is nothing to statically authorize; it is simply absent from the graph, and the runtime's fetch gate refuses it when it happens.

One further fact comes out of the same pass: whether the module declares any `static edit = …` template, on any class it defines, with or without a type annotation. The routing rule is that a view may drop to a weaker context only when *zero* authored code would run in it — so the edit screen falls back to Boxel's own trusted editor only when the author wrote no editor of their own.

This stays a match on the source text rather than an AST read, which keeps it to one parse, but the two ways it can be wrong are not symmetric and it errs deliberately toward matching. A false positive — the text appearing in a comment, a string, or a template body — keeps the edit surface in the stronger context, which the escalation rule always permits. A false negative hands a surface that *does* contain authored code to the trusted Base editor, which the containment rule forbids. The annotated form matters for exactly that reason: `static edit: BaseDefComponent = Editor` is what the Base realm's own cards write, six times, three of them in `card-api.gts`, so an author following that example is the likely case rather than an edge case.

## Walking the graph

The walk collects the complete reachable set before anything is read off it, so a diamond reached from either side and a cycle entered from either end produce the same answer — traversal order cannot reach the result. It is bounded at 256 module **reads**, counted as attempts rather than successes: a module that fails to load or resolve yields no analysis, so a bound counted over successful analyses would never advance for failures and one module declaring thousands of unreadable imports could drive thousands of authenticated loads inside a walk reporting itself bounded. Counting attempts is also what stops a failed dependency from being read once per importer — a failed analysis self-evicts from the shared memo, so the second importer would otherwise read it again.

It stops at modules the Host serves itself. Two reasons this matters:

- There is no authored source behind them to read. A walk that went looking for `@glimmer/component` would fail, and since an unestablished graph fails the render closed, that would break essentially every real card.
- Resolving one can be worse than useless. Some packages are registered as *async* shims, so asking the loader for the URL evaluates the module — turning a static analysis into an eager module load that drags in that module's own transitive dependencies. The edge is therefore recorded by its authored specifier and never resolved.

Compiler-synthesized siblings are worth being precise about, because the module the realm actually serves is Babel's output and its import list is not the same as content-tag's. The one that matters is the scoped-CSS sibling every `<style scoped>` block produces. It is not in the graph and deliberately so: that URL carries its own CSS content baked into it and the loader resolves it locally, without a realm read, so it is not part of the read authority. RP-6.7 states the rule a gate needs instead — such a request is admitted exactly when the module it was derived from is in the graph, and never on its own.

Because a runtime shims more than the framework floor (`date-fns`, `lodash`, `ember-concurrency` are all in `externals.ts`), the classifier takes an optional `isHostProvidedModule` predicate so the wiring can consult the loader's actual registry rather than a second copy of the list going stale in this file.

Anything the walk could not read — an unresolvable specifier, a dependency that won't load or won't parse, a graph that outgrew the bound — marks the result's graph **unavailable** and names the failure. This is the part that fails closed: an unavailable graph is a diagnostic, not an authorization list, and a runtime checking fetches against a truncated one would refuse reads the render needs. Such a result is never memoized, so the next request retries rather than pinning a transient fetch failure. Diagnostics are deterministic — a module reports every unresolvable specifier rather than the first one reached, and the walk sorts, so the reported reason is a property of the graph rather than of the order imports happen to appear in.

There are two caches. A per-module memo, shared across every entry, means two cards sharing a dependency subtree read and analyze it once — the second card fetches only its own file. A per-entry memo of the finished result records the graph it was computed from, so invalidating any member evicts it: an entry's answer is the closure of its dependencies, and a stale importer is as wrong as a stale dependency. Neither is size-bounded, because the invalidation signal is the realm's and arrives per changed module rather than under memory pressure; `maxModules` bounds one walk, not the caches.

Drafts get one specific rule. Classifying an unsaved buffer is answered for that caller alone, keyed by the source's hash, and never enters the shared memo — otherwise an editor buffer someone is mid-keystroke in could decide the read authority of a different card that merely imports the module.

## Deliberately not here

The frozen prototype's classifier did considerably more: Babel-confirmed browser-global and DOM-method detection, browser-only package vocabularies, template style and CSS signals, and promotion of that evidence up the import chain. All of that exists to choose between two *cages*, a choice this version doesn't make — so none of it is ported. The result type carries an optional `signals` field, unpopulated, so that analysis can extend the same shape later without reshaping consumers.

A consequence of using `es-module-lexer` rather than a TypeScript parser is that a type-only import (`import type { Foo } from './foo'`) is reported as an edge even though the realm's transform erases it. That widens the graph by a module the author's own source names — it is not an escalation, since a value import of the same module would be admitted anyway — but it does cost a fetch during the walk, and a type-only import of something unservable would fail the graph closed. Tightening the extraction, along with agreement fixtures that run the same sources through the realm's transpiler and this front end, is the follow-up work.

## Spec

Three statements are added under RP-6 for the behavior above: **RP-6.6** (the trusted-provenance predicate and its hygiene), **RP-6.7** (the module graph, its bound, its availability flag, the fail-closed rule and determinism), and **RP-6.8** (the authored-edit-template fact). Each has a citing test, so the bijection checker's uncovered count is unchanged at 104 while the statement inventory rises from 115 to 118.

## Where the changes live

- `packages/host/app/lib/trusted-modules.ts` — the two predicates.
- `packages/host/app/lib/boxel-module-classifier.ts` — source reading, the walk, the caches.
- `packages/host/tests/unit/rp-6-module-classification-test.ts` — the conformance suite.
- `docs/boxel-rendering-protocol.md` — RP-6.6 through RP-6.8.
- `packages/host/package.json` — adds `es-module-lexer`, at the version `runtime-common` already declares.

## A note on what the graph holds

Entries are not in one canonical spelling: an authored dependency appears as `resolveImport` returned it, while a Host-provided module appears as the specifier the author wrote, because resolving one can eagerly evaluate it. A gate comparing a requested URL against the list must therefore fold the same identifier family the Loader does (`moduleCacheKey`, `trimExecutableExtension`) rather than compare strings exactly, or it will refuse a fetch for a module that *is* in the list under a sibling spelling. That is stated on the field and in RP-6.7 so the gate ticket inherits the question rather than rediscovering it. Results are frozen, since a memoized one is handed to every caller and a read-authorization list that one holder can sort in place is not one.

## Testing

31 tests / 129 assertions, green in the real browser harness.

The trusted-boundary suite covers Host-owned spellings and their lookalikes (`/base-evil/`, a `cardstack.com.evil.example` host, plain `http`); every hygiene case (dot segments, encoded and doubly-encoded dot segments, backslashes, query and fragment characters, an undecodable escape); the realm-alias namespace under the Cardstack scope, asserting each alias agrees with its realm's URL spelling; the config-driven boundaries this deployment resolves, which are the inputs that actually vary per environment; and a realm boundary pointed at an origin root, driven through config because no boundary this environment configures has a root path.

Graph tests cover the diamond and the cycle from either end, stop-at-trusted (asserting the trusted import is neither fetched nor resolved), a shimmed module as a leaf, unresolvable imports reported deterministically regardless of source order, a dependency that won't load and one that won't parse, an entry draft returning a pending result rather than throwing, an entry that can't be read at all being reported as unreadable rather than as a draft, the bound both exactly met and exceeded, the bound holding against forty unreadable imports, one failing dependency read once across two importers, a resolver answering with a non-string failing closed, the frozen result, literal versus computed dynamic imports, and the preprocessing-injected import not becoming an edge. Cache tests prove shared reuse with read counters, importer eviction, retry-after-failure without an explicit invalidate, draft isolation, and draft replacement on changed source — the last pinned by result identity, since a read count alone holds even with no entry memo at all.

Nineteen mutations were applied to the implementation and each run against the suite; eighteen turn a specific test red. Among them: admitting the whole Cardstack scope, dropping the origin-wide guard, counting successes rather than reads against the bound, rejecting annotated `static edit` declarations, dropping the injected-import filter, pruning the walk on the narrower predicate, seating drafts in the shared memo, disabling the entry memo entirely, never self-evicting an incomplete result, reporting failures unsorted, letting failures outrank the bound, accepting `%` in a package specifier, walking a trusted entry, a non-content-addressed draft key, invalidation skipping importers, resolving trusted specifiers, and unfreezing the result. The one survivor is an equivalent mutant: reordering the draft case against the other reasons, where an entry whose imports are unknown enqueues nothing, so there is no competing failure to outrank.

Also green: full `packages/host` eslint and `ember-tsc --noEmit`, and the four protocol CI checks (`lint:scripts`, `lint:rp-bijection`, `lint:protocol-closure`, `lint:tier-registry`) plus the execution-runtime evidence runner.
