### PR TITLE
Report every dependency edge, and evaluate only out of a finished cycle

### DIFF
--- a/packages/host/tests/unit/loader-concurrent-cycle-test.ts
+++ b/packages/host/tests/unit/loader-concurrent-cycle-test.ts
@@ -149,14 +149,21 @@ module('Unit | loader concurrent cycle completion', function () {
     // before returning, so only a concurrent root can observe a participant in
     // the window where it looks ready and is not.
     //
-    // Every axis of this graph is load-bearing, each of these alone making it
-    // resolve by luck rather than by design: three roots rather than two, this
-    // entry order, fetch latency the walk actually suspends on, and `/m1`'s
-    // dep list being forward dep then back-edge then self-import in that order.
-    // The self-import is what puts `/m1` on its own completing stack while its
-    // dep list is being resolved. Anyone restructuring this test must
-    // re-verify it fails with the closure check before `evaluate` removed,
-    // which should reject every root with
+    // The graph is the smallest one that reaches it: `/m1`'s dep list is
+    // forward dep, then back-edge, then self-import, and the self-import is
+    // what puts `/m1` on its own completing stack while that list is being
+    // resolved. Drop any of the three edges, or the third root, and the window
+    // never opens.
+    //
+    // The interleaving is driven rather than raced. Each module's bytes are
+    // held behind its own gate and released in the order `/m0`, `/m2`, `/m1`,
+    // draining between releases so every walk runs as far as it can before the
+    // next module arrives — that release order is what suspends `/m1`'s walk
+    // inside `/m2`'s completion with `/m0` still 'registered'. Reorder the
+    // releases and the test still passes while covering nothing: against the
+    // loader with the closure check removed this order rejects on every run,
+    // and other orders on none. That check is the only thing this exercises, so
+    // anyone restructuring the test must re-verify it fails without it, with
     // `Cannot evaluate the module http://selfcycle.example/m0, it is not
     // evaluatable--it is in state 'registered'`.
     let sources: Record<string, string> = {
@@ -164,6 +171,11 @@ module('Unit | loader concurrent cycle completion', function () {
       '/m1': `import './m2'; import './m0'; import './m1'; export const id = 'm1';`,
       '/m2': `import './m1'; export const id = 'm2';`,
     };
+    let gates: Record<string, Deferred<void>> = {};
+    let gateFor = (path: string) => (gates[path] ??= new Deferred<void>());
+    for (let path of Object.keys(sources)) {
+      gateFor(path);
+    }
     let fetchImpl: typeof globalThis.fetch = async (input) => {
       let url =
         typeof input === 'string'
@@ -171,10 +183,9 @@ module('Unit | loader concurrent cycle completion', function () {
           : input instanceof URL
             ? input.href
             : input.url;
-      // A macrotask of real latency: with the bytes handed back synchronously
-      // the roots never interleave and the cycle completes under one walk.
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
-      let source = sources[new URL(url).pathname];
+      let path = new URL(url).pathname;
+      await gateFor(path).promise;
+      let source = sources[path];
       if (!source) {
         return new Response('not found', { status: 404 });
       }
@@ -186,12 +197,26 @@ module('Unit | loader concurrent cycle completion', function () {
     let loader = new Loader(fetchImpl);
 
     let origin = 'http://selfcycle.example';
-    let [m0, m2, m1] = await Promise.all([
+    let roots = [
       loader.import<{ id: string }>(`${origin}/m0`),
       loader.import<{ id: string }>(`${origin}/m2`),
       loader.import<{ id: string }>(`${origin}/m1`),
-    ]);
+    ];
+    // Every walk suspended on a gate resumes on a macrotask, and resuming can
+    // suspend it again a level deeper, so one turn is not enough to let it
+    // settle against what has been released so far.
+    let drain = async () => {
+      for (let i = 0; i < 12; i++) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+    };
+    await drain();
+    for (let path of ['/m0', '/m2', '/m1']) {
+      gateFor(path).fulfill();
+      await drain();
+    }
 
+    let [m0, m2, m1] = await Promise.all(roots);
     assert.strictEqual(m0.id, 'm0', 'the first root evaluates');
     assert.strictEqual(m2.id, 'm2', 'the second root evaluates');
     assert.strictEqual(m1.id, 'm1', 'the cycle participant evaluates');

--- a/packages/host/tests/unit/loader-concurrent-cycle-test.ts
+++ b/packages/host/tests/unit/loader-concurrent-cycle-test.ts
@@ -139,4 +139,77 @@ module('Unit | loader concurrent cycle completion', function () {
       'a leaf module consumes nothing',
     );
   });
+
+  test('concurrent roots over a cycle whose middle module imports itself all evaluate', async function (assert) {
+    // `evaluate` descends a module's whole dependency closure synchronously, so
+    // every module in it has to be past 'registered' before the first factory
+    // runs. Reaching 'registered-with-deps' does not establish that on its own:
+    // a cycle completes one participant at a time, and each is committed while
+    // its cycle edges are still completing. A single root closes that gap
+    // before returning, so only a concurrent root can observe a participant in
+    // the window where it looks ready and is not.
+    //
+    // Every axis of this graph is load-bearing, each of these alone making it
+    // resolve by luck rather than by design: three roots rather than two, this
+    // entry order, fetch latency the walk actually suspends on, and `/m1`'s
+    // dep list being forward dep then back-edge then self-import in that order.
+    // The self-import is what puts `/m1` on its own completing stack while its
+    // dep list is being resolved. Anyone restructuring this test must
+    // re-verify it fails with the closure check before `evaluate` removed,
+    // which should reject every root with
+    // `Cannot evaluate the module http://selfcycle.example/m0, it is not
+    // evaluatable--it is in state 'registered'`.
+    let sources: Record<string, string> = {
+      '/m0': `import './m1'; export const id = 'm0';`,
+      '/m1': `import './m2'; import './m0'; import './m1'; export const id = 'm1';`,
+      '/m2': `import './m1'; export const id = 'm2';`,
+    };
+    let fetchImpl: typeof globalThis.fetch = async (input) => {
+      let url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      // A macrotask of real latency: with the bytes handed back synchronously
+      // the roots never interleave and the cycle completes under one walk.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      let source = sources[new URL(url).pathname];
+      if (!source) {
+        return new Response('not found', { status: 404 });
+      }
+      return new Response(source, {
+        status: 200,
+        headers: { 'content-type': 'text/javascript' },
+      });
+    };
+    let loader = new Loader(fetchImpl);
+
+    let origin = 'http://selfcycle.example';
+    let [m0, m2, m1] = await Promise.all([
+      loader.import<{ id: string }>(`${origin}/m0`),
+      loader.import<{ id: string }>(`${origin}/m2`),
+      loader.import<{ id: string }>(`${origin}/m1`),
+    ]);
+
+    assert.strictEqual(m0.id, 'm0', 'the first root evaluates');
+    assert.strictEqual(m2.id, 'm2', 'the second root evaluates');
+    assert.strictEqual(m1.id, 'm1', 'the cycle participant evaluates');
+
+    // A root that rejects here leaves its modules cached in a state that does
+    // not self-heal, so a later import of the same module is the half that
+    // shows the failure was cached rather than transient.
+    let again = await loader.import<{ id: string }>(`${origin}/m0`);
+    assert.strictEqual(
+      again.id,
+      'm0',
+      'a later import of the same module is unaffected',
+    );
+
+    assert.deepEqual(
+      (await loader.getConsumedModules(`${origin}/m1`)).sort(),
+      [`${origin}/m0`, `${origin}/m2`],
+      'the self-importing module reports the modules it imports, itself excluded',
+    );
+  });
 });

--- a/packages/host/tests/unit/loader-consumed-modules-truncation-test.ts
+++ b/packages/host/tests/unit/loader-consumed-modules-truncation-test.ts
@@ -1,0 +1,102 @@
+import { module, test } from 'qunit';
+
+import { Loader } from '@cardstack/runtime-common';
+
+// `getConsumedModules` and `getKnownConsumedModules` answer the same question
+// about the same loader — which modules a module imports, transitively — and
+// have to answer it the same way. Every state past `fetching` names the modules
+// a module imports, so every one of them has edges to descend; a walk that
+// descends only the two terminal states truncates at exactly the modules an
+// import failure leaves behind, which are the ones the answer matters most for.
+//
+// The index records a module's dependencies from `getConsumedModules`,
+// including on the path where the import threw. A module indexed without the
+// edge to the dependency that broke it is never invalidated when that
+// dependency is fixed, so it stays broken in the index until something else
+// forces a reindex. Both graphs below reach that with a single import root and
+// no interleaving.
+module('Unit | loader consumed modules truncation', function () {
+  test('a module whose import failed on a missing dependency reports every edge it declared', async function (assert) {
+    // `/nope` is served by nothing, so importing `/a` throws before `/a` can
+    // leave 'registered' — the state carrying its dependency list. Both the
+    // module that could not be fetched and the sibling that was fetched fine
+    // are edges `/a` declared, and an index that does not hold the first one
+    // never learns that creating `/nope` should invalidate `/a`.
+    let sources: Record<string, string> = {
+      '/a': `import './b'; import './nope'; export const a = 'a';`,
+      '/b': `export const b = 'b';`,
+    };
+    let loader = new Loader(sourceFetch(sources));
+    let origin = 'http://trunc.example';
+
+    await assert.rejects(
+      loader.import(`${origin}/a`),
+      /unable to fetch .*\/nope/,
+      'the import fails on the dependency nothing serves',
+    );
+
+    assert.deepEqual(
+      (await loader.getConsumedModules(`${origin}/a`)).sort(),
+      [`${origin}/b`, `${origin}/nope`],
+      'the failed module reports the missing dependency and its sibling',
+    );
+    assert.deepEqual(
+      (await loader.getConsumedModules(`${origin}/a`)).sort(),
+      loader.getKnownConsumedModules(`${origin}/a`).sort(),
+      'both walks describe one loader the same way',
+    );
+  });
+
+  test('a sibling that throws does not truncate the branch that loaded', async function (assert) {
+    // `/thrower` throws while evaluating, which aborts the root import before
+    // `/good` is advanced past the registered states. `/good` still imports
+    // `/deep`, and a walk that stops at `/good` loses that subtree entirely —
+    // the deeper the good branch, the more edges go missing.
+    let sources: Record<string, string> = {
+      '/root': `import './thrower'; import './good'; export const root = 1;`,
+      '/thrower': `throw new Error('boom'); export const t = 1;`,
+      '/good': `import './deep'; export const good = 1;`,
+      '/deep': `export const deep = 1;`,
+    };
+    let loader = new Loader(sourceFetch(sources));
+    let origin = 'http://trunc2.example';
+
+    await assert.rejects(
+      loader.import(`${origin}/root`),
+      /boom/,
+      'the import fails on the module that throws',
+    );
+
+    assert.deepEqual(
+      (await loader.getConsumedModules(`${origin}/root`)).sort(),
+      [`${origin}/deep`, `${origin}/good`, `${origin}/thrower`],
+      'the walk descends through the good branch the failure stranded',
+    );
+    assert.deepEqual(
+      (await loader.getConsumedModules(`${origin}/root`)).sort(),
+      loader.getKnownConsumedModules(`${origin}/root`).sort(),
+      'both walks describe one loader the same way',
+    );
+  });
+});
+
+// Serves `sources` by pathname, 404ing anything absent, so a graph is written
+// as the modules it contains and the names it reaches past them.
+function sourceFetch(sources: Record<string, string>): typeof globalThis.fetch {
+  return async (input) => {
+    let url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    let source = sources[new URL(url).pathname.replace(/\.js$/, '')];
+    if (source === undefined) {
+      return new Response('not found', { status: 404 });
+    }
+    return new Response(source, {
+      status: 200,
+      headers: { 'content-type': 'text/javascript' },
+    });
+  };
+}

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -838,34 +838,17 @@ export class Loader {
         continue;
       }
 
-      switch (module.state) {
-        case 'evaluated':
-        case 'preparing':
-        case 'broken':
-          for (let consumed of module.consumedModules) {
-            pending.push(consumed);
-          }
-          break;
-        case 'registered':
-          for (let entry of module.dependencyList) {
-            if (entry.type === 'dep') {
-              pending.push(entry.moduleURL.href);
-            }
-          }
-          break;
-        case 'registered-completing-deps':
-        case 'registered-with-deps':
-          for (let entry of module.dependencies) {
-            if (entry.type === 'dep' || entry.type === 'completing-dep') {
-              pending.push(entry.moduleURL.href);
-            }
-          }
-          break;
-        case 'fetching':
-          complete = false;
-          break;
-        default:
-          throw assertNever(module);
+      // Which entries of which state count as an edge is `directModuleDependencies`'s
+      // to answer, so this walk, `getConsumedModules` and `invalidateModule` cannot
+      // come to disagree about what a module imports — they answer the same question
+      // and are asserted against each other. Completeness is the one thing this walk
+      // needs on top: a module still fetching has named nothing yet, so a set
+      // collected over it is partial and must not be memoized.
+      if (module.state === 'fetching') {
+        complete = false;
+      }
+      for (let dependency of this.directModuleDependencies(module)) {
+        pending.push(dependency);
       }
     }
 
@@ -1064,13 +1047,20 @@ export class Loader {
                   // A dep already being advanced to 'registered-with-deps'
                   // further up this recursion is a cycle edge: the walk holding
                   // it cannot finish until this one returns, so recursing into
-                  // it would not terminate. It is recorded for what it is
-                  // rather than as a plain `dep`, which would claim a module
-                  // still completing its own dependencies is ready to bind.
-                  // The cycle is what makes the claim unverifiable here — the
-                  // dep reaches 'registered-with-deps' only after this module
-                  // does — so the check that it ever became true belongs at
-                  // evaluation, in `findIncompleteDependency` below.
+                  // it would not terminate, and it is recorded rather than
+                  // waited for.
+                  //
+                  // Which of the two types it is recorded as is documentary at
+                  // this state and nothing more. Every reader of a
+                  // 'registered-with-deps' module's dependency list — `evaluate`,
+                  // `directModuleDependencies`, `findIncompleteDependency` —
+                  // accepts both alike; the one place that branches on `dep`
+                  // reads the previous state's list, not this one. So this
+                  // records what is true, that the dep is still completing, but
+                  // nothing downstream is stopped by it: what actually keeps a
+                  // module from binding a dep that never finished is
+                  // `findIncompleteDependency` below. Removing that check does
+                  // not become safe by leaving this type in place.
                   readyDeps.push({
                     type: 'completing-dep',
                     moduleURL: entry.moduleURL,
@@ -1112,8 +1102,17 @@ export class Loader {
           // A single walk closes that gap before returning, but the module is
           // in the map the whole time, so a concurrent import root that resumes
           // mid-cycle finds it in a state that normally licenses evaluation.
-          // Advancing what the closure is still missing is what makes it true,
-          // and it converges because module states only move forward.
+          // Advancing what the closure is still missing is what makes it true.
+          //
+          // Absent a cache clear that converges: each pass leaves one more
+          // module past 'registered' and nothing walks it back. A realm-mapping
+          // change discards the module caches, which is what takes a state
+          // backwards, and costs another pass round this loop the same way it
+          // costs the 'registered' arm above another level of recursion — the
+          // bound is the clear rate rather than the graph. A clear landing on
+          // every fetch never reaches here at all: the walk stalls in
+          // `case undefined` re-fetching a module that is discarded again
+          // before it can register.
           let incompleteDependency = this.findIncompleteDependency(
             resolvedURL.href,
           );

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -1061,11 +1061,18 @@ export class Loader {
                   );
                   break outer_switch;
                 } else {
-                  // the dep module is actually evaluatable now--we only got
-                  // here because we were already in the process of trying to
-                  // move the state of the dep to 'registered-with-deps'
+                  // A dep already being advanced to 'registered-with-deps'
+                  // further up this recursion is a cycle edge: the walk holding
+                  // it cannot finish until this one returns, so recursing into
+                  // it would not terminate. It is recorded for what it is
+                  // rather than as a plain `dep`, which would claim a module
+                  // still completing its own dependencies is ready to bind.
+                  // The cycle is what makes the claim unverifiable here — the
+                  // dep reaches 'registered-with-deps' only after this module
+                  // does — so the check that it ever became true belongs at
+                  // evaluation, in `findIncompleteDependency` below.
                   readyDeps.push({
-                    type: 'dep',
+                    type: 'completing-dep',
                     moduleURL: entry.moduleURL,
                   });
                 }
@@ -1091,12 +1098,36 @@ export class Loader {
           break;
         }
 
-        case 'registered-with-deps':
+        case 'registered-with-deps': {
           if (targetState === 'registered-with-deps') {
             return;
           }
+          // `evaluate` descends the whole dependency closure in one synchronous
+          // pass, so every module in it has to be past 'registered' before the
+          // first factory runs; finding one that is not, it can only throw, and
+          // the module it was evaluating is cached `broken` for the life of the
+          // loader. Reaching 'registered-with-deps' does not establish that on
+          // its own: a cycle completes one participant at a time, and each is
+          // committed holding cycle edges whose targets are still completing.
+          // A single walk closes that gap before returning, but the module is
+          // in the map the whole time, so a concurrent import root that resumes
+          // mid-cycle finds it in a state that normally licenses evaluation.
+          // Advancing what the closure is still missing is what makes it true,
+          // and it converges because module states only move forward.
+          let incompleteDependency = this.findIncompleteDependency(
+            resolvedURL.href,
+          );
+          if (incompleteDependency) {
+            await this.advanceToState(
+              incompleteDependency,
+              'registered-completing-deps',
+              stack,
+            );
+            break;
+          }
           this.evaluate(resolvedURL.href, module);
           break;
+        }
         case 'broken':
           return;
         case 'evaluated':
@@ -1106,6 +1137,57 @@ export class Loader {
           throw assertNever(module);
       }
     }
+  }
+
+  // The first module in `moduleIdentifier`'s dependency closure that `evaluate`
+  // would refuse, or undefined when the closure is ready. Mirrors the descent
+  // `evaluate` makes: it follows the same dependency entries, and stops where
+  // `evaluate` stops — a module already evaluated, preparing, or broken is
+  // answered from its own entry without its dependencies being read, so what
+  // lies beyond it cannot fail this pass either.
+  //
+  // Scoped to one module's closure rather than memoized across the loader
+  // because completeness is a property of an instant: a module reached through
+  // a cycle mid-completion is incomplete now and complete a moment later, and a
+  // remembered answer would outlive the state it described. The walk is bounded
+  // by the states it descends through, which a module leaves permanently, so
+  // the cost falls away as the graph evaluates rather than repeating per
+  // import.
+  private findIncompleteDependency(moduleIdentifier: string): URL | undefined {
+    let seen = new Set<string>();
+    let pending: URL[] = [];
+    // Only the registered states hold a dependency list to descend. The states
+    // past them are where `evaluate` stops reading, and a module short of them
+    // is the answer rather than something to descend into.
+    let pushDependencies = (module: Module | undefined) => {
+      if (
+        module?.state === 'registered-completing-deps' ||
+        module?.state === 'registered-with-deps'
+      ) {
+        for (let entry of module.dependencies) {
+          if (entry.type === 'dep' || entry.type === 'completing-dep') {
+            pending.push(entry.moduleURL);
+          }
+        }
+      }
+    };
+    pushDependencies(this.getModule(moduleIdentifier));
+    while (pending.length > 0) {
+      let moduleURL = pending.pop()!;
+      // Keyed the way `getModule` files a module, so a module reached by a
+      // second spelling of itself is recognized as one already seen.
+      let key = this.moduleCacheKey(moduleURL.href);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      let module = this.getModule(moduleURL.href);
+      if (!isEvaluatable(module)) {
+        return moduleURL;
+      }
+      pushDependencies(module);
+    }
+    return undefined;
   }
 
   // `evaluate` binds a module's factory arguments positionally from the

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -586,8 +586,20 @@ export class Loader {
         }
         module = this.getModule(href);
       }
-      if (module?.state === 'evaluated' || module?.state === 'broken') {
-        for (let consumedModule of module.consumedModules) {
+      // Every state a module can be holding past `fetching` names the modules
+      // it imports — the registered states in their dependency list, the states
+      // past them in `consumedModules` — so every one of them has edges to
+      // descend. Stopping at the two terminal states instead would truncate the
+      // walk at exactly the modules an import failure leaves behind: a module
+      // whose own import threw is `broken` and reports its edges, but the
+      // siblings that import threw *past* are stranded in a registered state,
+      // and dropping their subtrees is what leaves a failed module indexed
+      // without the dependency that broke it. Editing that dependency would
+      // then never invalidate it. `directModuleDependencies` reads the same
+      // per-state shapes `collectKnownModuleDependencies` does, so the two
+      // walks describe one loader the same way at any instant.
+      if (module) {
+        for (let consumedModule of this.directModuleDependencies(module)) {
           await walk(consumedModule, resolveHref(consumedModule));
         }
       }

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -1121,7 +1121,15 @@ export class Loader {
             await this.advanceToState(
               incompleteDependency,
               'registered-completing-deps',
-              stack,
+              {
+                ...stack,
+                ...{
+                  'registered-completing-deps': [
+                    ...stack['registered-completing-deps'],
+                    this.moduleCacheKey(resolvedURL.href),
+                  ],
+                },
+              },
             );
             break;
           }
@@ -1139,12 +1147,18 @@ export class Loader {
     }
   }
 
-  // The first module in `moduleIdentifier`'s dependency closure that `evaluate`
-  // would refuse, or undefined when the closure is ready. Mirrors the descent
-  // `evaluate` makes: it follows the same dependency entries, and stops where
-  // `evaluate` stops — a module already evaluated, preparing, or broken is
-  // answered from its own entry without its dependencies being read, so what
-  // lies beyond it cannot fail this pass either.
+  // Some module in `moduleIdentifier`'s dependency closure that `evaluate`
+  // would refuse, or undefined when the closure is ready. Which one is not
+  // defined: the traversal is depth-first over a stack, so it reaches siblings
+  // in the reverse of the order `evaluate` binds them. Nothing depends on that
+  // — the caller advances whatever comes back and re-enters, so any incomplete
+  // module in the closure is an equally good answer and the loop is what makes
+  // the search exhaustive.
+  //
+  // Where it stops is load-bearing, and matches `evaluate`: a module already
+  // evaluated, preparing, or broken is answered from its own entry without its
+  // dependencies being read, so what lies beyond one cannot fail this pass
+  // either.
   //
   // Scoped to one module's closure rather than memoized across the loader
   // because completeness is a property of an instant: a module reached through


### PR DESCRIPTION
Stacked on `claude/cs-12647-cs-12496-yjdfcb` — the top three commits are this change.

Two independent truncations of the same thing: the set of module edges the loader reports and relies on.

## The consumed-modules walk stopped at two states

`getConsumedModules` descended only `evaluated` and `broken`:

```ts
if (module?.state === 'evaluated' || module?.state === 'broken') {
  for (let consumedModule of module.consumedModules) {
    await walk(consumedModule, resolveHref(consumedModule));
  }
}
```

A module left in `registered`, `registered-completing-deps`, `registered-with-deps`, or `preparing` contributed nothing — it was marked visited if something reached it, but its own edges were never followed. Every one of those states carries a dependency list, and `collectKnownModuleDependencies` already reads all of them, so the two walks disagreed about one loader at one instant.

It truncates hardest on exactly the graphs the answer matters most for, and a single import root reaches both — no concurrency:

| graph | `getConsumedModules` | true closure |
| --- | --- | --- |
| `/a` imports `/b` and `/nope`, nothing serves `/nope` | `[]` | `/b`, `/nope` |
| `/root` imports a thrower and `/good`, which imports `/deep` | `/thrower`, `/good` | + `/deep` |

The module route records `deps` from `getConsumedModules` **on the import-error path**, which is the first row. A card module that failed to load was indexed with essentially no dependency edges, so creating the module it was missing never invalidated it and it stayed broken in the index until something else forced a reindex.

Which entries of which state count as an edge now has one home — `directModuleDependencies` — and all three walks read it: `getConsumedModules`, `invalidateModule`, and `collectKnownModuleDependencies`, which had been hand-rolling the same seven-state switch. It keeps only the `fetching` flag it needs to decide whether a set is complete enough to memoize. Since the tests below assert the two walks agree, one shared table is what keeps that assertion from being a coincidence maintained by hand.

## A cycle could be evaluated out of before it finished completing

Three concurrent roots over a small cycle whose middle module imports itself left one participant stuck in `registered` while another was being evaluated, and **every** root rejected:

```
Cannot evaluate the module https://min.test/m0, it is not evaluatable--it is in state 'registered'
```

No mapping change, no cache eviction, no parked fetch — three roots, ordinary fetch latency, and this graph:

```
m0 -> [m1]
m1 -> [m2, m0, m1]     // forward dep, back-edge, self-import
m2 -> [m1]
```

The `registered-completing-deps` → `registered-with-deps` transition recorded a dep already on the completing stack as a plain `dep`, reasoning that "the dep module is actually evaluatable now--we only got here because we were already in the process of trying to move the state of the dep". With interleaved walks that premise does not hold: the walk that put the module on the stack is not necessarily the one that resumes. Traced, the fatal commit is

```
COMMIT /m2 -> registered-with-deps :: dep:/m1[registered-completing-deps]
```

`/m2` is declared ready to bind while `/m1` is still completing and still holds a cycle edge to `/m0`, which is `registered`. A concurrent root sitting on `/m2` takes that at face value and evaluates, `evaluate` descends into `/m0`, and all three roots reject. The modules are then cached in a state that does not self-heal.

### The change

`evaluate` descends a module's whole closure in one synchronous pass and needs every module in it past `registered`; finding one that is not, it can only throw. Reaching `registered-with-deps` does not establish that on its own, because a cycle commits one participant at a time while its edges are still completing. A single walk closes that gap before returning — which is why this needs a concurrent root to observe — but the module is in the map throughout. `findIncompleteDependency` walks the closure before evaluating and advances whatever is still short of it.

That closure check is the whole fix. The cycle edge is also now recorded as `completing-dep` rather than `dep`, but that is documentary at this state and nothing more: all four readers of a `registered-with-deps` dependency list accept both alike, and the one site that branches on `dep` reads the previous state's list. The comment says so, so that nobody drops the closure check on the strength of the type.

Convergence is scoped rather than absolute: each pass leaves one more module past `registered` and nothing walks it back, but a realm-mapping change discards the module caches and costs another pass round the loop — the same bound, on the same cause, that the `registered` arm above already carries for its own recursion. A clear landing on every fetch never reaches the gate at all; the walk stalls in `case undefined` re-fetching a module that is discarded again before it can register.

The two fixes are independent; neither is needed for the other.

## Test plan

**New tests, all three verified to fail against the unmodified loader in Chrome**, not only under node. The cycle test fails with the exact error above; the two truncation tests fail on their reported edge sets.

- `loader-consumed-modules-truncation-test.ts` (new module, 2 tests) — the two single-root graphs in the table, each also asserting the two walks agree.
- `loader-concurrent-cycle-test.ts` (+1 test) — the three-root self-importing cycle, asserting every root evaluates, that a **later** import of the same module is unaffected (the cached-failure half), and the reported edges.

The cycle test drives its interleaving rather than racing it: each module's bytes wait on their own `Deferred`, released in the fixed order `/m0`, `/m2`, `/m1` with the queue drained between releases, so what suspends `/m1`'s walk inside `/m2`'s completion is the release order and not relative fetch latency. This matters because that release order is the fixture — against the unmodified loader this order rejects on every run and other orders on none, so a test that merely raced would go quietly green on a loader with the bug back, taking all coverage of the repair branch with it. The comment records that.

Every realm-free loader module passes in Chrome against this branch — **60 tests**:

| module | |
| --- | --- |
| `loader seams` | 30/30 |
| `Loader transient 5xx retry` | 11/11 |
| `loader \| iconNotFoundMessage` | 7/7 |
| `loader concurrent cycle completion` | 3/3 |
| `loader mapping change during traversal` | 3/3 |
| `loader consumed modules truncation` | 2/2 |
| `loader fetch-failure caching` | 2/2 |
| `loader \| missing boxel icon` | 2/2 |

`Unit | loader` and `Unit | loader prefetch` need a realm server and are left to CI.

### Measured against the unmodified loader

Randomized harnesses drive the loader directly under node, each checking three things: no unexpected rejection, no factory handed a module other than the one that argument position names, and no consumed-module set differing from that module's true static import closure.

- **Cycle sweep — 16,692 configurations** of three-module graphs (every dep list of length 0–3 over three names, sampled across the cross-product; all six root orderings; self-imports and duplicate edges; real fetch latency). Every graph is sound, so any rejection is the loader's own doing.

  **35 failing → 0.** Every failure carried the `it is not evaluatable--it is in state 'registered'` signature, and every failing graph had a self-import in the middle module.

- **Randomized graphs — 400** (2–6 modules, 0–3 edges each, self-imports, duplicates, 1–3 concurrent roots, half with fetch latency), with throwing and 404 modules mixed in.

  **126 graphs under-reported edges → 0.** The 126 graphs whose full snapshot differs are exactly the 126 that were under-reporting.

- **The two walks agree.** `getConsumedModules` and `getKnownConsumedModules` returned identical sets on **1750/1750** queries across 500 randomized graphs with throwers, missing modules, cycles and self-imports.

- **It is a no-op when nothing is broken.** Across 400 sound graphs the full snapshot — every module's consumed-module set and every root's settle status — is **byte-identical** before and after.

- **The 6 remaining flags are identical before and after** and are the harness being too strict, not a regression: seeds 34, 274, 294, 332, 384, 393 in both runs. In each, the module reading `undefined` is the thrower itself or is reachable only through it, so its exports were never assigned — correct JS semantics for a module that threw.

### Cost of the closure walk

The gate runs once per import root that reaches `registered-with-deps`, not once per module — `evaluate` handles the closure itself. On a 361-module layered graph (12 layers, wide fan-out, cross edges and back-edges) imported from 4 concurrent roots:

| | before | after |
| --- | --- | --- |
| `advanceToState` calls | 2219 | 2219 |
| gate invocations | — | 2 |
| module-map reads inside the gate | — | 402 (357 + 45) |
| elapsed | 180–205 ms | 187–211 ms |

No extra recursion, one synchronous pass over the closure per import root, and elapsed time inside run-to-run noise. The walk stops where `evaluate` stops — at a module already `evaluated`, `preparing`, or `broken` — so its cost falls away as the graph evaluates.

### Adjacent, not addressed here

`case 'registered-with-deps'` returns early only for `targetState === 'registered-with-deps'`, so a call that asked only for `registered-completing-deps` falls through and evaluates the module whenever a concurrent walk has already advanced it past the target. That predates this change and the gate makes the path safer rather than worse, but it does mean the gate fires from calls that never asked to evaluate anything — worth knowing for whoever next reasons about this recursion.

### Checks

`tsc --noEmit` reports no errors in `loader.ts`, and the same 98 pre-existing `@cardstack/base` type-generation errors in `packages/runtime-common` before and after. eslint and prettier clean on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gfn7hRYaoSCfy1Qjedeh4L