### PR TITLE
Gate published-realm test setup on rendered HTML, not just the index

### DIFF
--- a/packages/realm-server/tests/helpers/indexing.ts
+++ b/packages/realm-server/tests/helpers/indexing.ts
@@ -243,11 +243,26 @@ export async function settlePrerenderHtmlJobs(
   let lastState = '';
   await waitUntil(
     async () => {
+      // Only id/status/active_reservations drive the wait; the rest are what
+      // the timeout message needs to be actionable. The two ways this wait
+      // ends up stuck present identically in the first three — one unfulfilled
+      // row holding one reservation — and separate cleanly in the rest. A
+      // render still working through a large realm shows files_completed
+      // climbing against total_files and a small progress_age_sec. A worker
+      // that died or wedged mid-render shows a frozen files_completed, a
+      // progress_age_sec that keeps growing, and a reservation that ages past
+      // its locked_until.
       let rows = (await query(dbAdapter, [
-        `SELECT j.id, j.status,
+        `SELECT j.id, j.status, j.job_type,
+           EXTRACT(EPOCH FROM (NOW() - j.created_at))::int AS job_age_sec,
            (SELECT COUNT(*)::int FROM job_reservations r
-             WHERE r.job_id = j.id AND r.completed_at IS NULL) AS active_reservations
-         FROM jobs j WHERE`,
+             WHERE r.job_id = j.id AND r.completed_at IS NULL) AS active_reservations,
+           (SELECT COUNT(*)::int FROM job_reservations r
+             WHERE r.job_id = j.id AND r.completed_at IS NULL
+               AND r.locked_until <= NOW()) AS expired_reservations,
+           jp.files_completed, jp.total_files,
+           EXTRACT(EPOCH FROM (NOW() - jp.last_progress_at))::int AS progress_age_sec
+         FROM jobs j LEFT JOIN job_progress jp ON jp.job_id = j.id WHERE`,
         ...every([['j.concurrency_group =', param(concurrencyGroup)]]),
       ] as Expression)) as {
         id: number;
@@ -276,7 +291,10 @@ export async function settlePrerenderHtmlJobs(
       timeout: opts?.timeout ?? 30000,
       interval: 50,
       timeoutMessage: () =>
-        `waiting for prerender_html jobs to settle for ${concurrencyGroup}; last state: ${lastState}`,
+        `waiting for prerender_html jobs to settle for ${concurrencyGroup}; ` +
+        `last state (a rising files_completed with a low progress_age_sec is a render that needs longer; ` +
+        `a frozen files_completed, a growing progress_age_sec, or expired_reservations > 0 is a wedged or dead worker): ` +
+        lastState,
     },
   );
 }

--- a/packages/realm-server/tests/helpers/indexing.ts
+++ b/packages/realm-server/tests/helpers/indexing.ts
@@ -221,6 +221,26 @@ export async function maxPrerenderHtmlJobId(
   return rows[0]?.max_id ?? 0;
 }
 
+// Ids of a realm's prerender-html jobs that rejected.
+//
+// A rejection never reaches the batch swap, so no row lands in
+// `prerendered_html` and the published-HTML readiness predicate stays false
+// for good. Anything polling that readiness would otherwise spend its entire
+// budget on a render that has already failed, and report a stage name rather
+// than the job that failed. Checking this alongside such a poll turns that
+// into an immediate, named failure.
+export async function rejectedPrerenderHtmlJobIds(
+  dbAdapter: DBAdapter,
+  realmURL: string | URL,
+): Promise<number[]> {
+  let concurrencyGroup = `prerender-html:${typeof realmURL === 'string' ? realmURL : realmURL.href}`;
+  let rows = (await query(dbAdapter, [
+    `SELECT j.id FROM jobs j WHERE j.status = 'rejected' AND`,
+    ...every([['j.concurrency_group =', param(concurrencyGroup)]]),
+  ] as Expression)) as { id: number }[];
+  return rows.map((row) => row.id);
+}
+
 // HTML lands on its own channel: the index pass fires a `prerender_html`
 // job (fire-and-forget) and completes without waiting for it, so a test
 // that writes and then asserts prerendered HTML must settle that channel
@@ -243,31 +263,36 @@ export async function settlePrerenderHtmlJobs(
   let lastState = '';
   await waitUntil(
     async () => {
-      // Only id/status/active_reservations drive the wait; the rest are what
-      // the timeout message needs to be actionable. The two ways this wait
-      // ends up stuck present identically in the first three — one unfulfilled
-      // row holding one reservation — and separate cleanly in the rest. A
-      // render still working through a large realm shows files_completed
-      // climbing against total_files and a small progress_age_sec. A worker
-      // that died or wedged mid-render shows a frozen files_completed, a
-      // progress_age_sec that keeps growing, and a reservation that ages past
-      // its locked_until.
+      // id/status/active_reservations drive the wait; the two ages are what
+      // the timeout message needs to be actionable, and both are readable in
+      // a test process. `job_progress` is not: it is populated by the
+      // standalone worker-manager's event sink, and tests construct their
+      // Worker without a `reportProgress`, so per-file render progress simply
+      // does not exist here. Neither does an expired lease — a from-scratch
+      // render's reservation is held for FROM_SCRATCH_JOB_TIMEOUT_SEC, orders
+      // of magnitude beyond any settle budget — so lease expiry can't
+      // discriminate anything either.
+      //
+      // What the ages do separate: reservation_age_sec near the wait's own
+      // budget is a worker that claimed the job and is still inside the
+      // render. A row with no reservation whose job_age_sec keeps climbing is
+      // a job queued behind another holder of the channel, never claimed.
       let rows = (await query(dbAdapter, [
-        `SELECT j.id, j.status, j.job_type,
+        `SELECT j.id, j.status,
            EXTRACT(EPOCH FROM (NOW() - j.created_at))::int AS job_age_sec,
            (SELECT COUNT(*)::int FROM job_reservations r
              WHERE r.job_id = j.id AND r.completed_at IS NULL) AS active_reservations,
-           (SELECT COUNT(*)::int FROM job_reservations r
-             WHERE r.job_id = j.id AND r.completed_at IS NULL
-               AND r.locked_until <= NOW()) AS expired_reservations,
-           jp.files_completed, jp.total_files,
-           EXTRACT(EPOCH FROM (NOW() - jp.last_progress_at))::int AS progress_age_sec
-         FROM jobs j LEFT JOIN job_progress jp ON jp.job_id = j.id WHERE`,
+           (SELECT MAX(EXTRACT(EPOCH FROM (NOW() - r.created_at)))::int
+              FROM job_reservations r
+             WHERE r.job_id = j.id AND r.completed_at IS NULL) AS reservation_age_sec
+         FROM jobs j WHERE`,
         ...every([['j.concurrency_group =', param(concurrencyGroup)]]),
       ] as Expression)) as {
         id: number;
         status: string;
+        job_age_sec: number;
         active_reservations: number;
+        reservation_age_sec: number | null;
       }[];
       let rejected = rows.filter((row) => row.status === 'rejected');
       if (rejected.length > 0) {
@@ -292,8 +317,8 @@ export async function settlePrerenderHtmlJobs(
       interval: 50,
       timeoutMessage: () =>
         `waiting for prerender_html jobs to settle for ${concurrencyGroup}; ` +
-        `last state (a rising files_completed with a low progress_age_sec is a render that needs longer; ` +
-        `a frozen files_completed, a growing progress_age_sec, or expired_reservations > 0 is a wedged or dead worker): ` +
+        `last state (a reservation_age_sec near this wait's budget is a worker still inside the render; ` +
+        `a null reservation_age_sec with a climbing job_age_sec is a job that was never claimed): ` +
         lastState,
     },
   );

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -1350,6 +1350,14 @@ module(basename(import.meta.filename), function () {
       // asserts the gating invariant: once readiness reports ready, the
       // published index already reflects the updated source.
       test('a cold republish does not report ready before the swapped files are reindexed (CS-11362)', async function (assert) {
+        // QUnit arms one timeout per test promise, from `test.timeout` or the
+        // suite-wide `QUnit.config.testTimeout`, at the moment that promise is
+        // awaited. The readiness poll below declares a budget larger than the
+        // suite-wide one, so without raising it here the poll can never reach
+        // its own deadline and its message can never be the one a failure
+        // reports. Sized to clear that poll plus the republish work ahead of
+        // it.
+        assert.timeout(300_000);
         let sourceRealmURL = new URL(sourceRealmUrlString);
         let sourceRealmFsPath = join(
           dir.name,

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -30,6 +30,48 @@ import fsExtra from 'fs-extra';
 const { ensureDirSync } = fsExtra;
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 
+// Wait for a freshly published realm to be both indexed and rendered.
+//
+// `awaitPrerenderHtml=true` is the gate every publish consumer uses
+// (boxel-cli's publish command, the host app, the publish handler's own
+// Location header): a published realm's deliverable is its HTML, and the
+// index pass spawns the prerender_html job fire-and-forget, so index-only
+// readiness answers ready while the render is still running. Holding here is
+// what keeps the render's duration off whatever budget the caller's next wait
+// carries — a from-scratch published-realm render runs the module pre-warm
+// sweep and takes as long as the realm is large and the runner is loaded.
+//
+// Poll rather than asking once: readiness bounds how long it holds a single
+// request and answers 503 with `Retry-After` once that budget is spent, so a
+// pass longer than the budget takes more than one request to observe.
+// `X-Boxel-Not-Ready` names the stage still outstanding, which is the whole
+// diagnosis when this times out — index vs prerender-html are different
+// failures with different causes.
+async function waitForPublishedRealmReady(
+  request: SuperTest<Test>,
+  publishedRealmPath: string,
+  publishedRealmHost: string,
+): Promise<void> {
+  let lastStatus = 'no response';
+  await waitUntil(
+    async () => {
+      let response = await request
+        .get(`${publishedRealmPath}_readiness-check?awaitPrerenderHtml=true`)
+        .set('Host', publishedRealmHost)
+        .set('Accept', 'application/vnd.api+json');
+      let stage = response.headers['x-boxel-not-ready'];
+      lastStatus = `HTTP ${response.status}${stage ? ` (not ready: ${stage})` : ''}`;
+      return response.status === 200;
+    },
+    {
+      timeout: 120_000,
+      interval: 1000,
+      timeoutMessage: () =>
+        `published realm ${publishedRealmHost}${publishedRealmPath} never passed its readiness check; last response: ${lastStatus}`,
+    },
+  );
+}
+
 module(`server-endpoints/${basename(import.meta.filename)}`, function () {
   module(
     'Realm Server Endpoints (not specific to one realm)',
@@ -1615,31 +1657,20 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
           }
 
           // `_publish-realm` returns 202 before indexing finishes. Drive a
-          // reconcile pass to mount the published realm, then poll its
-          // readiness check until it reports ready, so the assertions below
-          // query indexed content. Poll rather than asking once: readiness
-          // bounds how long it will hold a single request and answers 503 with
-          // `Retry-After` once that budget is spent, so a from-scratch index
-          // longer than the budget takes more than one request to observe.
+          // reconcile pass to mount the published realm, then wait for it to
+          // report ready, so the assertions below query indexed, rendered
+          // content.
           await testRealmServer.testingOnlyReconcile();
-          await waitUntil(
-            async () =>
-              (
-                await request
-                  .get(`${publishedRealmPath}_readiness-check`)
-                  .set('Host', publishedRealmHost)
-                  .set('Accept', 'application/vnd.api+json')
-              ).status === 200,
-            {
-              timeout: 120_000,
-              interval: 1000,
-              timeoutMessage:
-                'published realm never passed its readiness check',
-            },
+          await waitForPublishedRealmReady(
+            request,
+            publishedRealmPath,
+            publishedRealmHost,
           );
-          // Readiness drains the index channel only; head HTML lands via the
-          // realm's prerender_html job, so settle that channel before the
-          // assertions read it.
+          // Readiness clears once every row's HTML is live for its generation;
+          // the job that wrote it finalizes a moment later. Settle the channel
+          // so the assertions never race that tail, and so a render that
+          // rejected fails here instead of surfacing as a missing-markup
+          // assertion.
           await settlePrerenderHtmlJobs(dbAdapter, publishedRealmURLString);
         },
         afterEach: async () => {
@@ -1905,15 +1936,16 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
           }
 
           await testRealmServer.testingOnlyReconcile();
-          let readinessResponse = await request
-            .get(`${publishedRealmPath}_readiness-check`)
-            .set('Host', publishedRealmHost)
-            .set('Accept', 'application/vnd.api+json');
-          if (readinessResponse.status !== 200) {
-            throw new Error(
-              `Published realm not ready: ${readinessResponse.status} ${readinessResponse.text}`,
-            );
-          }
+          await waitForPublishedRealmReady(
+            request,
+            publishedRealmPath,
+            publishedRealmHost,
+          );
+          // Readiness clears once every row's HTML is live for its generation;
+          // the job that wrote it finalizes a moment later. Settle the channel
+          // so the assertions never race that tail, and so a render that
+          // rejected fails here instead of surfacing as a wrong-status
+          // assertion.
           await settlePrerenderHtmlJobs(dbAdapter, publishedRealmURLString);
         },
         afterEach: async () => {

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -30,6 +30,14 @@ import fsExtra from 'fs-extra';
 const { ensureDirSync } = fsExtra;
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 
+// Budget for a publish setup hook: realm boot, the fixture writes, the
+// from-scratch index of the published copy, and its render. Sized to sit
+// clear of the waits nested inside it (READINESS_POLL_TIMEOUT_MS plus the
+// settle that follows plus the write traffic before either), so whichever
+// stage stalls is the one that reports the failure.
+const PUBLISHED_REALM_SETUP_TIMEOUT_MS = 240_000;
+const READINESS_POLL_TIMEOUT_MS = 120_000;
+
 // Wait for a freshly published realm to be both indexed and rendered.
 //
 // `awaitPrerenderHtml=true` is the gate every publish consumer uses
@@ -64,7 +72,7 @@ async function waitForPublishedRealmReady(
       return response.status === 200;
     },
     {
-      timeout: 120_000,
+      timeout: READINESS_POLL_TIMEOUT_MS,
       interval: 1000,
       timeoutMessage: () =>
         `published realm ${publishedRealmHost}${publishedRealmPath} never passed its readiness check; last response: ${lastStatus}`,
@@ -1494,7 +1502,15 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       let publishedRealmPath: string;
       let ownerUserId = '@mango:localhost';
 
-      hooks.beforeEach(function () {
+      hooks.beforeEach(function (assert) {
+        // QUnit arms one timeout per hook promise, so the whole publish setup
+        // below — realm boot, the writes, the from-scratch index, and the
+        // render — shares a single window, and the suite-wide
+        // `QUnit.config.testTimeout` is too small to hold it. Raise it past
+        // the waits inside that hook so their timeout messages, which name the
+        // stage that stalled, are what a failure reports rather than QUnit's
+        // stageless "test timed out".
+        assert.timeout(PUBLISHED_REALM_SETUP_TIMEOUT_MS);
         dir = dirSync();
       });
       setupDB(hooks, {
@@ -1757,7 +1773,9 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       let publishedRealmPath: string;
       let ownerUserId = '@mango:localhost';
 
-      hooks.beforeEach(function () {
+      hooks.beforeEach(function (assert) {
+        // Same single-window-per-hook reasoning as the theme module above.
+        assert.timeout(PUBLISHED_REALM_SETUP_TIMEOUT_MS);
         dir = dirSync();
       });
       setupDB(hooks, {

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -14,7 +14,10 @@ import {
 } from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
 import { testRealmURL } from './helpers.ts';
-import { settlePrerenderHtmlJobs } from '../helpers/indexing.ts';
+import {
+  rejectedPrerenderHtmlJobIds,
+  settlePrerenderHtmlJobs,
+} from '../helpers/indexing.ts';
 import {
   closeServer,
   createVirtualNetwork,
@@ -30,13 +33,20 @@ import fsExtra from 'fs-extra';
 const { ensureDirSync } = fsExtra;
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 
+// A single readiness request holds for as long as its own gates take:
+// READINESS_REQUEST_BUDGET_MS across startup / in-flight index / index-lane
+// settle, then `awaitPublishedHtmlReady`'s own budget on top. Roughly 70s
+// today. `waitUntil` tests its deadline between attempts and never abandons
+// one in flight, so a poll can overshoot its budget by a whole request.
+const READINESS_POLL_TIMEOUT_MS = 90_000;
+
 // Budget for a publish setup hook: realm boot, the fixture writes, the
-// from-scratch index of the published copy, and its render. Sized to sit
-// clear of the waits nested inside it (READINESS_POLL_TIMEOUT_MS plus the
-// settle that follows plus the write traffic before either), so whichever
-// stage stalls is the one that reports the failure.
-const PUBLISHED_REALM_SETUP_TIMEOUT_MS = 240_000;
-const READINESS_POLL_TIMEOUT_MS = 120_000;
+// from-scratch index of the published copy, its render, and the settle that
+// follows. Sized against the worst case those add up to — the readiness poll
+// plus one request's overshoot, plus the settle, plus the write traffic
+// before either — so a stalled stage is reported by the wait that owns it
+// rather than by QUnit's stageless timeout.
+const PUBLISHED_REALM_SETUP_TIMEOUT_MS = 300_000;
 
 // Wait for a freshly published realm to be both indexed and rendered.
 //
@@ -55,21 +65,52 @@ const READINESS_POLL_TIMEOUT_MS = 120_000;
 // `X-Boxel-Not-Ready` names the stage still outstanding, which is the whole
 // diagnosis when this times out — index vs prerender-html are different
 // failures with different causes.
+//
+// 503 is the only status worth another attempt. Anything else — the realm
+// never mounted, an auth misconfiguration, a throw out of the handler — is
+// settled, and retrying it to the end of the budget only converts a specific
+// error into a slow generic one.
+//
+// A rejected render is settled too, and invisible to readiness: the job never
+// reaches its batch swap, so no HTML lands and the readiness predicate stays
+// false for good. Reading the channel each attempt keeps that failure
+// reported as the job that failed rather than as a wait that ran out.
 async function waitForPublishedRealmReady(
   request: SuperTest<Test>,
+  dbAdapter: DBAdapter,
+  publishedRealmURL: string,
   publishedRealmPath: string,
   publishedRealmHost: string,
 ): Promise<void> {
   let lastStatus = 'no response';
   await waitUntil(
     async () => {
+      let rejected = await rejectedPrerenderHtmlJobIds(
+        dbAdapter,
+        publishedRealmURL,
+      );
+      if (rejected.length > 0) {
+        throw new Error(
+          `prerender_html job(s) rejected while awaiting readiness for ${publishedRealmURL}: ${rejected.join(', ')}`,
+        );
+      }
       let response = await request
         .get(`${publishedRealmPath}_readiness-check?awaitPrerenderHtml=true`)
         .set('Host', publishedRealmHost)
         .set('Accept', 'application/vnd.api+json');
+      if (response.status === 200) {
+        return true;
+      }
       let stage = response.headers['x-boxel-not-ready'];
-      lastStatus = `HTTP ${response.status}${stage ? ` (not ready: ${stage})` : ''}`;
-      return response.status === 200;
+      lastStatus = `HTTP ${response.status}${stage ? ` (not ready: ${stage})` : ''}${
+        response.text ? ` ${response.text.slice(0, 300)}` : ''
+      }`;
+      if (response.status !== 503) {
+        throw new Error(
+          `published realm ${publishedRealmHost}${publishedRealmPath} answered a settled failure to its readiness check: ${lastStatus}`,
+        );
+      }
+      return false;
     },
     {
       timeout: READINESS_POLL_TIMEOUT_MS,
@@ -1679,6 +1720,8 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
           await testRealmServer.testingOnlyReconcile();
           await waitForPublishedRealmReady(
             request,
+            dbAdapter,
+            publishedRealmURLString,
             publishedRealmPath,
             publishedRealmHost,
           );
@@ -1956,6 +1999,8 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
           await testRealmServer.testingOnlyReconcile();
           await waitForPublishedRealmReady(
             request,
+            dbAdapter,
+            publishedRealmURLString,
             publishedRealmPath,
             publishedRealmHost,
           );


### PR DESCRIPTION
Fixes a flaky realm-server test. The reported failure was in `index-responses-test.ts`:

```
Promise rejected before "a redirect rule drops a query string made up entirely of the host app's params":
Timeout waiting for condition: waiting for prerender_html jobs to settle for
prerender-html:http://routingtest.localhost:4444/routing-source/;
last state: [{"id":7,"status":"unfulfilled","active_reservations":1}]

at settlePrerenderHtmlJobs (tests/helpers/indexing.ts:244:3)
at Object.beforeEach (tests/server-endpoints/index-responses-test.ts:1917:11)
```

## Root cause

`active_reservations: 1` on an `unfulfilled` job means a worker holds it and is actively rendering — the job is slow, not lost.

It is slow because the setup never waits for it. Both published-realm `beforeEach` blocks drove `_readiness-check` **without** `awaitPrerenderHtml=true`. Readiness with that param off clears as soon as the index lane drains, and the index pass spawns the `prerender_html` job fire-and-forget — so the realm reports ready while its render is still running. The entire from-scratch published-realm render, including the O(realm module count) pre-warm sweep a from-scratch spawn performs, then had to fit inside `settlePrerenderHtmlJobs`' 30s default. On a loaded runner it doesn't.

## The fix

Both blocks poll `_readiness-check?awaitPrerenderHtml=true` through a shared `waitForPublishedRealmReady` helper — the same gate `boxel-cli`'s publish command, the host app's realm-server service, and the publish handler's own `Location` header use. The render is then waited for by the endpoint whose contract covers it, rather than landing on whatever budget the next wait happens to carry.

That gate is a genuine superset of what the settle was covering: the prerender-html visit writes into a working table and calls `batch.done()` once, after the whole loop, so rows become visible atomically at the swap. Readiness cannot clear mid-render.

`settlePrerenderHtmlJobs` stays after readiness, covering the short window between the swap becoming visible and the job finalizing. Its 30s default is left alone deliberately: with readiness absorbing the render, a settle that still takes 30s means something is genuinely stuck, and raising it would only hide that.

### Three failure modes the setup could not report

- **A readiness answer that will never change.** The poll retried every non-200, so a realm that never mounted, an auth misconfiguration, or a throw out of the handler cost the whole budget per test and reported a stage name instead of the status that explains it. Only 503 — the documented not-yet-ready answer — is retried; the response body rides along in the reported status.
- **A rejected render.** A rejection never reaches the batch swap, so no HTML lands and the published-HTML predicate stays false for good. Readiness alone would spend its full budget and report a stage. The poll reads the realm's prerender-html channel each attempt and fails immediately with the offending job ids.
- **A wait outliving its budget.** QUnit arms one timeout per hook or test promise, from `test.timeout` or the suite-wide `QUnit.config.testTimeout` (60s), at the moment that promise is awaited. A wait declaring a budget larger than the suite-wide one can therefore never reach its own deadline, and its message can never be the one a failure reports — the stageless `test timed out` wins instead. Three sites carried that shape: both publish setup hooks here, and the cold-republish readiness poll in `publish-unpublish-realm-test.ts`. Each now raises its budget via `assert.timeout`, which QUnit passes to hooks and tests alike and which takes effect before the timer is armed. Values are sized against the waits nested inside — for the setup hooks, the readiness poll plus one request's overshoot (a request holds for the request budget plus the published-HTML wait, and `waitUntil` never abandons one in flight), plus the settle, plus the preamble.

The cold-republish poll keeps driving `_readiness-check` **without** `awaitPrerenderHtml`. That index-only gate is what the test is about — a cold republish must not report ready before the swapped files are reindexed — so only its budget changes, not which gate it asserts. That same distinction is why `waitForPublishedRealmReady`, which hardcodes the published-HTML gate, stays module-local rather than moving to the shared helpers: the one candidate caller elsewhere wants the other gate.

## Diagnostics bundled with the fix

`settlePrerenderHtmlJobs`' timeout message reports reservation age against job age. A `reservation_age_sec` near the wait's own budget is a worker that claimed the job and is still inside the render; a null `reservation_age_sec` with a climbing `job_age_sec` is a job queued behind another holder of the channel, never claimed.

Per-file render progress and lease expiry are deliberately **not** reported, because neither is observable from a test process: `job_progress` is written by the standalone worker-manager's event sink and tests construct their `Worker` without a `reportProgress`, and a from-scratch render's reservation is leased for `FROM_SCRATCH_JOB_TIMEOUT_SEC` — orders of magnitude past any settle budget, so it can never age out inside one.

## Relationship to earlier work on this helper

The existing `afterJobId` / `maxPrerenderHtmlJobId` machinery addresses the **opposite** failure — settling too early, before the fire-and-forget enqueue is visible. It is not applicable here and is left untouched: this job was visible and claimed. This change is complementary.

## Scope

Test-only. No production code paths change.

## Test plan

Verification is CI. This is a load-dependent timing flake — a local pass would not be evidence either way — and this environment's toolchain (Node 24 / pnpm 11) and the realm-server test stack aren't available here, so the suite was not executed locally. Type-check and Prettier were run against the changed files and are clean.

Worth watching across a few runs of the realm-server shards: the `Published realm index responses` and routing modules in `index-responses-test.ts`, and the cold-republish test in `publish-unpublish-realm-test.ts`.

## Known follow-ups, not addressed here

- `realm-endpoints-test.ts` raises the same per-hook budget by saving and restoring `QUnit.config.testTimeout` around the module, where the three sites above use `assert.timeout`. Both work; two idioms for one need is a coin-flip for the next author, so converging on one is worth a decision.
- `settlePrerenderHtmlJobs` has no `dbAdapter.kind !== 'pg'` guard, unlike `awaitRealmIndexSettled`. Every caller today is a realm-server test where `setupDB` builds a `PgAdapter`, so this is latent rather than broken.