### PR TITLE
host: Remove creation date from Percy

### DIFF
--- a/packages/base/file-formats/file-shell-isolated.gts
+++ b/packages/base/file-formats/file-shell-isolated.gts
@@ -442,7 +442,16 @@ export class FileIsolatedShell extends GlimmerComponent<FileIsolatedShellSignatu
             {{#if this.created}}
               <div class='insp-row'>
                 <dt>Created</dt>
-                <dd>{{this.created}}</dd>
+                {{! Unlike Modified, which reads an mtime CI normalises to a
+                function of file content, this reads realm_file_meta.created_at
+                — written as `Date.now()` the first time a path is indexed, and
+                pinned by nothing. Two runs on different days therefore disagree
+                and Percy reports a diff. Hidden from Percy rather than
+                normalised: it is a database column rather than a file
+                attribute, and a screenshot is the wrong place to verify a
+                timestamp. The label stays visible, so the row and the layout
+                around it are still compared. }}
+                <dd data-test-percy-hide>{{this.created}}</dd>
               </div>
             {{/if}}
             {{#if this.modified}}


### PR DESCRIPTION
No need for diffs like this (zoomed in):

<img width="1156" height="668" alt="image" src="https://github.com/user-attachments/assets/a73aec7f-ca80-4787-8c0c-6932c32370e5" />
