### PR TITLE
feat: add `boxel screenshot` command

### DIFF
--- a/packages/boxel-cli/src/build-program.ts
+++ b/packages/boxel-cli/src/build-program.ts
@@ -7,6 +7,7 @@ import { registerReadTranspiledCommand } from './commands/read-transpiled.ts';
 import { registerRealmCommand } from './commands/realm/index.ts';
 import { registerFileCommand } from './commands/file/index.ts';
 import { registerRunCommand } from './commands/run-command.ts';
+import { registerScreenshotCommand } from './commands/screenshot.ts';
 import { registerSearchCommand } from './commands/search.ts';
 import { registerTestCommand } from './commands/test.ts';
 import { setQuiet } from './lib/cli-log.ts';
@@ -132,6 +133,7 @@ Environment variables (for 'add'):
   registerParseCommand(program);
   registerRealmCommand(program);
   registerRunCommand(program);
+  registerScreenshotCommand(program);
   registerSearchCommand(program);
   registerTestCommand(program);
   registerReadTranspiledCommand(program);

--- a/packages/boxel-cli/src/commands/screenshot.ts
+++ b/packages/boxel-cli/src/commands/screenshot.ts
@@ -1,0 +1,805 @@
+import type { Command } from 'commander';
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+import { resolveRealmAuthenticator } from '../lib/auth-resolver.ts';
+import { cliLog } from '../lib/cli-log.ts';
+import { FG_CYAN, FG_GREEN, FG_RED, RESET } from '../lib/colors.ts';
+import { describeFetchError } from '../lib/describe-fetch-error.ts';
+import {
+  getProfileManager,
+  type ProfileManager,
+} from '../lib/profile-manager.ts';
+import { resolveRealmSecretSeed } from '../lib/prompt.ts';
+import type { RealmAuthenticator } from '../lib/realm-authenticator.ts';
+import { resolveRealmIdentifier } from '../lib/resolve-realm-identifier.ts';
+import {
+  deriveOwnerUserId,
+  deriveRealmServerUrl,
+  mintRealmServerToken,
+} from '../lib/seed-auth.ts';
+
+/**
+ * Thin client over the realm server's `POST /_screenshot-card` endpoint
+ * (contract documented at
+ * `packages/realm-server/handlers/handle-screenshot-card.ts`). The CLI
+ * builds the request body and passes the capture spec through verbatim —
+ * the server owns validation, so new spec capabilities work here without a
+ * CLI change (an unsupported field comes back as a named 400).
+ *
+ * Image bytes are taken from the response's inline base64 when present,
+ * else downloaded from the capture's served MediaCache URL. `--url-only`
+ * skips bytes entirely and prints the served URLs; note a served URL is
+ * only durable for captures the server persists (canonical captures) — a
+ * capture returned inline-only has `url: null` and is reported as an error
+ * in that mode.
+ */
+
+const DEFAULT_MAX_WAIT_SECONDS = 120;
+// Wait between busy-retries when the server's 503 carries no Retry-After.
+const DEFAULT_RETRY_AFTER_SECONDS = 5;
+const MANIFEST_FILE_NAME = 'screenshot-manifest.json';
+
+const EXTENSION_BY_CONTENT_TYPE: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+};
+
+export interface CaptureManifestEntry {
+  card: string;
+  /** Batch capture name; null for a singular (unnamed) capture. */
+  name: string | null;
+  status: 'ok' | 'error';
+  /** Path the image was written to (absent for --url-only and errors). */
+  file?: string;
+  width?: number | null;
+  height?: number | null;
+  deviceScaleFactor?: number | null;
+  /** Hex SHA-256 of the written image bytes. */
+  sha256?: string;
+  /** Served MediaCache URL; null when the server returned the bytes inline only. */
+  url: string | null;
+  error?: string;
+}
+
+export interface ScreenshotResult {
+  /** True only when every requested capture succeeded. */
+  ok: boolean;
+  captures: CaptureManifestEntry[];
+  /** Region inventory per card URL, when the spec requested discovery. */
+  regions?: Record<string, unknown>;
+  /** Where the manifest JSON was written (--spec mode only). */
+  manifestPath?: string;
+  /** Failure that prevented any capture from being attempted. */
+  error?: string;
+}
+
+export interface ScreenshotOptions {
+  /** Render format: isolated, embedded, or fitted. Server-validated. */
+  format?: string;
+  /** Capture spec built from flags (single-card mode). Passed through verbatim. */
+  captureSpec?: Record<string, unknown> | null;
+  /** Path to a JSON batch spec: an entry or array of `{card, format?, captureSpec?}`. */
+  specPath?: string;
+  /** Directory image files (and the batch manifest) are written to. Default: cwd. */
+  out?: string;
+  /** Print served URLs instead of downloading image bytes. */
+  urlOnly?: boolean;
+  /** Realm URL containing the card(s); skips per-card realm discovery. */
+  realm?: string;
+  /** Total budget for busy (503) retries, milliseconds. */
+  maxWaitMs?: number;
+  /** Administrative auth: mint tokens locally from the realm secret seed. */
+  realmSecretSeed?: string;
+  /** Matrix id for the seed-minted server token (default: owner derived from the card URL). */
+  asUser?: string;
+  /** Realm-server base URL override (default: derived from each card's origin). */
+  realmServerUrl?: string;
+  /** @internal Override the ProfileManager (tests). */
+  profileManager?: ProfileManager;
+  /** @internal Already-constructed authenticator for realm fetches (tests). */
+  authenticator?: RealmAuthenticator;
+  /** @internal Fetch used for the realm-server POST (tests). */
+  serverFetch?: (url: string, init?: RequestInit) => Promise<Response>;
+  /** @internal Sleep between busy-retries (tests). */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+interface ScreenshotJob {
+  card: string;
+  format: string;
+  captureSpec: unknown;
+}
+
+interface ResponseCapture {
+  name?: string | null;
+  url?: string | null;
+  width?: number | null;
+  height?: number | null;
+  deviceScaleFactor?: number | null;
+  base64?: string;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function topLevelError(error: string): ScreenshotResult {
+  return { ok: false, captures: [], error };
+}
+
+/** Capture names a job asks for, so a job-level failure can report each. */
+function requestedNames(captureSpec: unknown): (string | null)[] {
+  if (isPlainObject(captureSpec) && Array.isArray(captureSpec.captures)) {
+    return captureSpec.captures.map((entry) =>
+      isPlainObject(entry) && typeof entry.name === 'string'
+        ? entry.name
+        : null,
+    );
+  }
+  return [null];
+}
+
+function slugify(value: string): string {
+  let slug = value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return slug || 'card';
+}
+
+export async function screenshot(
+  cardUrl: string | undefined,
+  options: ScreenshotOptions = {},
+): Promise<ScreenshotResult> {
+  // Assemble the jobs: one server request (one settle) per card.
+  let jobs: ScreenshotJob[];
+  if (options.specPath) {
+    if (cardUrl) {
+      return topLevelError('Provide either a card URL or --spec, not both');
+    }
+    if (options.captureSpec) {
+      return topLevelError(
+        'Capture flags cannot be combined with --spec; put the overrides in the spec file',
+      );
+    }
+    let parsed = readSpecFile(options.specPath);
+    if ('error' in parsed) {
+      return topLevelError(parsed.error);
+    }
+    jobs = parsed.jobs;
+  } else {
+    if (!cardUrl) {
+      return topLevelError('A card URL is required (or pass --spec <file>)');
+    }
+    jobs = [
+      {
+        card: cardUrl,
+        format: options.format ?? 'isolated',
+        captureSpec: options.captureSpec ?? null,
+      },
+    ];
+  }
+
+  // Resolve each card identifier to an absolute, extensionless instance URL.
+  for (let job of jobs) {
+    let resolved = resolveRealmIdentifier(job.card, {
+      profileManager: options.profileManager,
+    });
+    if (!resolved.ok) {
+      return topLevelError(resolved.error);
+    }
+    let url = resolved.url.replace(/\.json$/, '');
+    try {
+      new URL(url);
+    } catch {
+      return topLevelError(`Not a valid card URL: ${job.card}`);
+    }
+    job.card = url;
+  }
+
+  let realmFlag = options.realm
+    ? ensureTrailingSlash(options.realm)
+    : undefined;
+
+  let resolution = resolveRealmAuthenticator({
+    realmUrl: realmFlag ?? jobs[0].card,
+    realmSecretSeed: options.realmSecretSeed,
+    profileManager: options.profileManager,
+    authenticator: options.authenticator,
+  });
+  if (!resolution.ok) {
+    return topLevelError(resolution.error);
+  }
+  let authenticator = resolution.authenticator;
+
+  let serverFetch = options.serverFetch;
+  if (!serverFetch) {
+    if (options.realmSecretSeed) {
+      let base = realmFlag ?? jobs[0].card;
+      let asUser: string;
+      try {
+        asUser = options.asUser ?? deriveOwnerUserId(base);
+      } catch (e) {
+        return topLevelError(
+          `${e instanceof Error ? e.message : String(e)} — pass --as-user`,
+        );
+      }
+      let token = mintRealmServerToken(options.realmSecretSeed, asUser);
+      serverFetch = async (url, init) => {
+        let headers = new Headers(init?.headers);
+        headers.set('Authorization', token);
+        return fetch(url, { ...init, headers });
+      };
+    } else if (resolution.mode === 'injected') {
+      // Test fakes route every URL through the one injected authenticator.
+      serverFetch = (url, init) => authenticator.authedRealmFetch(url, init);
+    } else {
+      let pm = options.profileManager ?? getProfileManager();
+      serverFetch = (url, init) => pm.authedRealmServerFetch(url, init);
+    }
+  }
+
+  let outDir = options.out ?? '.';
+  if (!options.urlOnly) {
+    mkdirSync(outDir, { recursive: true });
+  }
+
+  let usedFileNames = new Set<string>();
+  let entries: CaptureManifestEntry[] = [];
+  let regions: Record<string, unknown> = {};
+  for (let job of jobs) {
+    let jobResult = await runJob(job, {
+      authenticator,
+      serverFetch,
+      realmFlag,
+      realmServerUrl: options.realmServerUrl,
+      urlOnly: options.urlOnly === true,
+      outDir,
+      usedFileNames,
+      maxWaitMs: options.maxWaitMs ?? DEFAULT_MAX_WAIT_SECONDS * 1000,
+      sleep: options.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms))),
+    });
+    entries.push(...jobResult.entries);
+    if (jobResult.regions !== undefined) {
+      regions[job.card] = jobResult.regions;
+    }
+  }
+
+  let result: ScreenshotResult = {
+    ok: entries.every((entry) => entry.status === 'ok'),
+    captures: entries,
+    ...(Object.keys(regions).length ? { regions } : {}),
+  };
+  if (options.specPath && !options.urlOnly) {
+    let manifestPath = join(outDir, MANIFEST_FILE_NAME);
+    writeFileSync(manifestPath, JSON.stringify(result, null, 2));
+    result.manifestPath = manifestPath;
+  }
+  return result;
+}
+
+function readSpecFile(
+  specPath: string,
+): { jobs: ScreenshotJob[] } | { error: string } {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(specPath, 'utf8'));
+  } catch (e) {
+    return {
+      error: `Could not read --spec file ${specPath}: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    };
+  }
+  let entries = Array.isArray(raw) ? raw : [raw];
+  if (entries.length === 0) {
+    return { error: `--spec file ${specPath} contains no entries` };
+  }
+  let jobs: ScreenshotJob[] = [];
+  for (let [i, entry] of entries.entries()) {
+    if (!isPlainObject(entry) || typeof entry.card !== 'string') {
+      return {
+        error: `--spec entry ${i} must be an object with a "card" URL`,
+      };
+    }
+    jobs.push({
+      card: entry.card,
+      format: typeof entry.format === 'string' ? entry.format : 'isolated',
+      captureSpec: entry.captureSpec ?? null,
+    });
+  }
+  return { jobs };
+}
+
+interface JobContext {
+  authenticator: RealmAuthenticator;
+  serverFetch: (url: string, init?: RequestInit) => Promise<Response>;
+  realmFlag: string | undefined;
+  realmServerUrl: string | undefined;
+  urlOnly: boolean;
+  outDir: string;
+  usedFileNames: Set<string>;
+  maxWaitMs: number;
+  sleep: (ms: number) => Promise<void>;
+}
+
+async function runJob(
+  job: ScreenshotJob,
+  ctx: JobContext,
+): Promise<{ entries: CaptureManifestEntry[]; regions?: unknown }> {
+  let fail = (error: string) => ({
+    entries: requestedNames(job.captureSpec).map(
+      (name): CaptureManifestEntry => ({
+        card: job.card,
+        name,
+        status: 'error',
+        url: null,
+        error,
+      }),
+    ),
+  });
+
+  // The POST body needs the card's realm URL. Take it from --realm when
+  // given, otherwise discover it from the `x-boxel-realm-url` header every
+  // realm response carries. The probe reads the instance's source file
+  // rather than the rendered card JSON so it works even when the instance
+  // hasn't (or can't be) indexed — and it confirms the card exists before a
+  // render is queued.
+  let realmURL: string;
+  if (ctx.realmFlag) {
+    if (!job.card.startsWith(ctx.realmFlag)) {
+      return fail(`Card is not within --realm ${ctx.realmFlag}`);
+    }
+    realmURL = ctx.realmFlag;
+  } else {
+    let response: Response;
+    try {
+      response = await ctx.authenticator.authedRealmFetch(`${job.card}.json`, {
+        headers: { Accept: 'application/vnd.card+source' },
+      });
+    } catch (e) {
+      return fail(describeFetchError(e));
+    }
+    let body = await response.text().catch(() => '');
+    if (!response.ok) {
+      return fail(
+        `Could not load card (HTTP ${response.status}): ${body.slice(0, 200)}`,
+      );
+    }
+    let header = response.headers.get('x-boxel-realm-url');
+    if (!header) {
+      return fail(
+        'Could not determine the realm: response carries no x-boxel-realm-url header (pass --realm)',
+      );
+    }
+    realmURL = ensureTrailingSlash(header);
+  }
+
+  let endpoint = `${
+    ctx.realmServerUrl
+      ? ensureTrailingSlash(ctx.realmServerUrl)
+      : deriveRealmServerUrl(job.card)
+  }_screenshot-card`;
+  let body = JSON.stringify({
+    data: {
+      type: 'screenshot-card',
+      attributes: {
+        realmURL,
+        cardId: job.card,
+        format: job.format,
+        // URLs-only needs no bytes; otherwise inline base64 is the primary
+        // byte source (a capture the server does not persist has no URL).
+        includeBase64: !ctx.urlOnly,
+        captureSpec: job.captureSpec ?? null,
+      },
+    },
+  });
+
+  // The server answers 503 + Retry-After when the render outlasts its
+  // bounded sync wait; a canonical capture still lands in the MediaCache, so
+  // the retry is cheap. Keep retrying within the budget.
+  let started = Date.now();
+  let response: Response;
+  for (;;) {
+    try {
+      response = await ctx.serverFetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/vnd.api+json',
+          Accept: 'application/vnd.api+json',
+        },
+        body,
+      });
+    } catch (e) {
+      return fail(describeFetchError(e));
+    }
+    if (response.status !== 503) {
+      break;
+    }
+    await response.text().catch(() => '');
+    let retryAfterSeconds = Number.parseInt(
+      response.headers.get('retry-after') ?? '',
+      10,
+    );
+    if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds <= 0) {
+      retryAfterSeconds = DEFAULT_RETRY_AFTER_SECONDS;
+    }
+    let elapsed = Date.now() - started;
+    if (elapsed + retryAfterSeconds * 1000 > ctx.maxWaitMs) {
+      return fail(
+        `Server busy: gave up after ${Math.round(
+          elapsed / 1000,
+        )}s (raise --max-wait or retry later)`,
+      );
+    }
+    console.log(`Server busy; retrying ${job.card} in ${retryAfterSeconds}s…`);
+    await ctx.sleep(retryAfterSeconds * 1000);
+  }
+
+  let text = await response.text().catch(() => '');
+  if (!response.ok) {
+    return fail(`HTTP ${response.status}: ${text.slice(0, 300)}`);
+  }
+  let attrs: Record<string, unknown> | undefined;
+  try {
+    let doc = JSON.parse(text);
+    attrs = isPlainObject(doc?.data?.attributes)
+      ? doc.data.attributes
+      : undefined;
+  } catch {
+    return fail('Invalid JSON response from server');
+  }
+  if (!attrs) {
+    return fail('Malformed response: missing data.attributes');
+  }
+  if (attrs.status !== 'ready') {
+    return fail(
+      attrs.error
+        ? String(attrs.error)
+        : `Capture failed (status: ${String(attrs.status ?? 'unknown')})`,
+    );
+  }
+
+  let captures: ResponseCapture[] = Array.isArray(attrs.captures)
+    ? (attrs.captures as ResponseCapture[])
+    : attrs.base64 != null || attrs.width != null
+      ? [
+          {
+            name: null,
+            url: null,
+            width: (attrs.width as number | undefined) ?? null,
+            height: (attrs.height as number | undefined) ?? null,
+            deviceScaleFactor: null,
+            base64: attrs.base64 as string | undefined,
+          },
+        ]
+      : [];
+  if (captures.length === 0) {
+    return fail('Response contained no captures');
+  }
+
+  let entries: CaptureManifestEntry[];
+  if (ctx.urlOnly) {
+    entries = captures.map((capture) =>
+      capture.url
+        ? {
+            card: job.card,
+            name: capture.name ?? null,
+            status: 'ok' as const,
+            url: capture.url,
+            width: capture.width ?? null,
+            height: capture.height ?? null,
+            deviceScaleFactor: capture.deviceScaleFactor ?? null,
+          }
+        : {
+            card: job.card,
+            name: capture.name ?? null,
+            status: 'error' as const,
+            url: null,
+            error:
+              'No served URL for this capture: the server returns URLs only for captures it persists (canonical specs)',
+          },
+    );
+  } else {
+    let contentType =
+      typeof attrs.contentType === 'string' ? attrs.contentType : 'image/png';
+    let extension = EXTENSION_BY_CONTENT_TYPE[contentType] ?? 'png';
+    let localPath = job.card.startsWith(realmURL)
+      ? job.card.slice(realmURL.length)
+      : new URL(job.card).pathname.replace(/^\//, '');
+    entries = [];
+    for (let capture of captures) {
+      entries.push(
+        await writeCapture(job, capture, {
+          ctx,
+          baseName: slugify(localPath),
+          extension,
+        }),
+      );
+    }
+  }
+
+  return {
+    entries,
+    ...(attrs.regions !== undefined ? { regions: attrs.regions } : {}),
+  };
+}
+
+async function writeCapture(
+  job: ScreenshotJob,
+  capture: ResponseCapture,
+  {
+    ctx,
+    baseName,
+    extension,
+  }: { ctx: JobContext; baseName: string; extension: string },
+): Promise<CaptureManifestEntry> {
+  let name = capture.name ?? null;
+  let common = {
+    card: job.card,
+    name,
+    url: capture.url ?? null,
+    width: capture.width ?? null,
+    height: capture.height ?? null,
+    deviceScaleFactor: capture.deviceScaleFactor ?? null,
+  };
+
+  let bytes: Buffer | undefined;
+  if (typeof capture.base64 === 'string' && capture.base64.length > 0) {
+    bytes = Buffer.from(capture.base64, 'base64');
+  } else if (capture.url) {
+    let response: Response;
+    try {
+      response = await ctx.authenticator.authedRealmFetch(capture.url);
+    } catch (e) {
+      return { ...common, status: 'error', error: describeFetchError(e) };
+    }
+    if (!response.ok) {
+      await response.text().catch(() => '');
+      return {
+        ...common,
+        status: 'error',
+        error: `Download failed (HTTP ${response.status}): ${capture.url}`,
+      };
+    }
+    bytes = Buffer.from(await response.arrayBuffer());
+  } else {
+    return {
+      ...common,
+      status: 'error',
+      error: 'Capture carried neither image data nor a served URL',
+    };
+  }
+
+  let stem = name ? `${baseName}--${slugify(name)}` : baseName;
+  let fileName = `${stem}.${extension}`;
+  for (let counter = 2; ctx.usedFileNames.has(fileName); counter++) {
+    fileName = `${stem}-${counter}.${extension}`;
+  }
+  ctx.usedFileNames.add(fileName);
+  let filePath = join(ctx.outDir, fileName);
+  writeFileSync(filePath, bytes);
+
+  return {
+    ...common,
+    status: 'ok',
+    file: filePath,
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+  };
+}
+
+interface ScreenshotCliOptions {
+  format?: string;
+  viewport?: { width: number; height: number };
+  envelope?: { width: number; height: number };
+  dsf?: number;
+  clip?: { x: number; y: number; width: number; height: number };
+  target?: string;
+  fullPage?: boolean;
+  out?: string;
+  spec?: string;
+  urlOnly?: boolean;
+  realm?: string;
+  maxWait?: number;
+  realmSecretSeed?: boolean;
+  asUser?: string;
+  json?: boolean;
+}
+
+export function captureSpecFromFlags(
+  opts: ScreenshotCliOptions,
+): Record<string, unknown> | null {
+  let spec: Record<string, unknown> = {};
+  if (opts.viewport) {
+    spec.viewport = opts.viewport;
+  }
+  if (opts.envelope) {
+    spec.envelope = opts.envelope;
+  }
+  if (opts.dsf !== undefined) {
+    spec.deviceScaleFactor = opts.dsf;
+  }
+  if (opts.clip) {
+    spec.clip = opts.clip;
+  }
+  if (opts.target) {
+    spec.target = opts.target;
+  }
+  if (opts.fullPage) {
+    spec.fullPage = true;
+  }
+  return Object.keys(spec).length ? spec : null;
+}
+
+function parseDimensions(flag: string): (value: string) => {
+  width: number;
+  height: number;
+} {
+  return (value: string) => {
+    let match = /^(\d+)x(\d+)$/i.exec(value.trim());
+    if (!match) {
+      throw new Error(`${flag} must be WxH (e.g. 800x600)`);
+    }
+    return { width: Number(match[1]), height: Number(match[2]) };
+  };
+}
+
+function parseDeviceScaleFactor(value: string): number {
+  let n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error('--dsf must be a positive number');
+  }
+  return n;
+}
+
+function parseClip(value: string): {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+} {
+  let parts = value.split(',').map((part) => Number(part.trim()));
+  if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n))) {
+    throw new Error('--clip must be x,y,w,h (e.g. 0,0,400,300)');
+  }
+  let [x, y, width, height] = parts;
+  return { x, y, width, height };
+}
+
+function parseMaxWait(value: string): number {
+  let n = Number.parseInt(value, 10);
+  if (!Number.isFinite(n) || n < 0 || String(n) !== value.trim()) {
+    throw new Error('--max-wait must be a non-negative integer (seconds)');
+  }
+  return n;
+}
+
+export function registerScreenshotCommand(program: Command): void {
+  program
+    .command('screenshot')
+    .description(
+      'Capture screenshots of a card via the realm server: writes image files (or prints served URLs) plus a per-capture manifest',
+    )
+    .argument(
+      '[card-url]',
+      'Card instance URL or @cardstack/<realm>/<path> identifier (omit when using --spec)',
+    )
+    .option(
+      '--format <format>',
+      'Render format: isolated, embedded, or fitted (fitted requires --envelope)',
+      'isolated',
+    )
+    .option(
+      '--viewport <WxH>',
+      'Render viewport in CSS pixels, e.g. 800x600',
+      parseDimensions('--viewport'),
+    )
+    .option(
+      '--envelope <WxH>',
+      'Parent box a fitted card lays out into, in CSS pixels, e.g. 400x300',
+      parseDimensions('--envelope'),
+    )
+    .option(
+      '--dsf <n>',
+      'Device scale factor (e.g. 2 doubles the physical pixel density)',
+      parseDeviceScaleFactor,
+    )
+    .option(
+      '--clip <x,y,w,h>',
+      'Capture only this CSS-pixel rectangle',
+      parseClip,
+    )
+    .option(
+      '--target <selector>',
+      'Capture the element matching this CSS selector',
+    )
+    .option('--full-page', 'Capture the full scrollable page height')
+    .option(
+      '--out <dir>',
+      'Directory to write image files into (default: current directory)',
+    )
+    .option(
+      '--spec <file>',
+      'JSON batch spec — an entry or array of {card, format?, captureSpec?}; one request per card, writes screenshot-manifest.json into --out',
+    )
+    .option(
+      '--url-only',
+      'Print served screenshot URLs without downloading image bytes',
+    )
+    .option(
+      '--realm <realm-url>',
+      'Realm URL containing the card (skips realm auto-discovery)',
+    )
+    .option(
+      '--max-wait <seconds>',
+      'Total time to keep retrying while the server is busy',
+      parseMaxWait,
+      DEFAULT_MAX_WAIT_SECONDS,
+    )
+    .option(
+      '--realm-secret-seed',
+      'Administrative auth: prompt for a realm secret seed and mint tokens locally instead of using a Matrix profile (env: BOXEL_REALM_SECRET_SEED)',
+    )
+    .option(
+      '--as-user <matrix-id>',
+      'Matrix id to authorize as in seed mode (defaults to the owner derived from the card URL)',
+    )
+    .option('--json', 'Output the capture manifest as JSON')
+    .action(async (cardUrl: string | undefined, opts: ScreenshotCliOptions) => {
+      try {
+        let realmSecretSeed = await resolveRealmSecretSeed(
+          opts.realmSecretSeed === true,
+        );
+        let result = await screenshot(cardUrl, {
+          format: opts.format,
+          captureSpec: captureSpecFromFlags(opts),
+          specPath: opts.spec,
+          out: opts.out,
+          urlOnly: opts.urlOnly,
+          realm: opts.realm,
+          maxWaitMs: (opts.maxWait ?? DEFAULT_MAX_WAIT_SECONDS) * 1000,
+          realmSecretSeed,
+          asUser: opts.asUser,
+        });
+
+        if (opts.json) {
+          cliLog.output(JSON.stringify(result, null, 2));
+          if (!result.ok) {
+            process.exit(1);
+          }
+          return;
+        }
+
+        if (result.error) {
+          console.error(`${FG_RED}Error:${RESET} ${result.error}`);
+          process.exit(1);
+        }
+        for (let entry of result.captures) {
+          let label = entry.name ? `${entry.card} [${entry.name}]` : entry.card;
+          if (entry.status !== 'ok') {
+            console.error(`${FG_RED}✗ ${label}:${RESET} ${entry.error}`);
+          } else if (opts.urlOnly) {
+            cliLog.output(entry.url!);
+          } else {
+            let dims =
+              entry.width != null && entry.height != null
+                ? ` (${entry.width}×${entry.height})`
+                : '';
+            console.log(
+              `${FG_GREEN}✓${RESET} ${label} → ${FG_CYAN}${entry.file}${RESET}${dims}`,
+            );
+          }
+        }
+        if (result.manifestPath) {
+          console.log(`Manifest: ${FG_CYAN}${result.manifestPath}${RESET}`);
+        }
+        if (!result.ok) {
+          process.exit(1);
+        }
+      } catch (err) {
+        let message = err instanceof Error ? err.message : String(err);
+        console.error(`${FG_RED}Error:${RESET} ${message}`);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/boxel-cli/src/commands/screenshot.ts
+++ b/packages/boxel-cli/src/commands/screenshot.ts
@@ -215,10 +215,29 @@ export async function screenshot(
   let serverFetch = options.serverFetch;
   if (!serverFetch) {
     if (options.realmSecretSeed) {
+      // Seed mode mints one realm-server token for the whole invocation, so
+      // every card must resolve to the same server origin and (absent an
+      // explicit --as-user) the same derived owner — otherwise later cards
+      // would be authorized as the first card's owner, and the server would
+      // quietly skip the ledger identity for them (bytes returned, nothing
+      // persisted).
       let base = realmFlag ?? jobs[0].card;
       let asUser: string;
       try {
         asUser = options.asUser ?? deriveOwnerUserId(base);
+        let baseIdentity = `${deriveRealmServerUrl(base)} ${
+          options.asUser ?? deriveOwnerUserId(base)
+        }`;
+        for (let job of jobs) {
+          let jobIdentity = `${deriveRealmServerUrl(job.card)} ${
+            options.asUser ?? deriveOwnerUserId(job.card)
+          }`;
+          if (jobIdentity !== baseIdentity) {
+            return topLevelError(
+              'Seed mode authorizes one realm owner per invocation, but the --spec cards span more than one realm server or owner. Pass --as-user for a shared identity, or split the spec by realm.',
+            );
+          }
+        }
       } catch (e) {
         return topLevelError(
           `${e instanceof Error ? e.message : String(e)} — pass --as-user`,
@@ -432,7 +451,11 @@ async function runJob(
         )}s (raise --max-wait or retry later)`,
       );
     }
-    console.log(`Server busy; retrying ${job.card} in ${retryAfterSeconds}s…`);
+    // Progress goes to stderr: stdout is the --json / --url-only contract
+    // stream, and a busy retry mid-batch must not corrupt it.
+    console.error(
+      `Server busy; retrying ${job.card} in ${retryAfterSeconds}s…`,
+    );
     await ctx.sleep(retryAfterSeconds * 1000);
   }
 
@@ -460,6 +483,11 @@ async function runJob(
     );
   }
 
+  // A ready response can omit `captures` when the render engine returned
+  // only the singular mirror fields (base64/width/height) — the endpoint's
+  // own suite exercises this stub-engine shape. Such a capture was not
+  // persisted, so it carries no served URL; synthesize the one entry from
+  // the mirror.
   let captures: ResponseCapture[] = Array.isArray(attrs.captures)
     ? (attrs.captures as ResponseCapture[])
     : attrs.base64 != null || attrs.width != null
@@ -711,7 +739,7 @@ export function registerScreenshotCommand(program: Command): void {
     )
     .option(
       '--target <selector>',
-      'Capture the element matching this CSS selector',
+      'Capture the element matching this CSS selector (requires a realm server that supports target captures; older servers reject it with a named 400)',
     )
     .option('--full-page', 'Capture the full scrollable page height')
     .option(

--- a/packages/boxel-cli/tests/commands/screenshot.test.ts
+++ b/packages/boxel-cli/tests/commands/screenshot.test.ts
@@ -1,0 +1,580 @@
+import { describe, it, expect } from 'vitest';
+import { Command } from 'commander';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+import {
+  captureSpecFromFlags,
+  registerScreenshotCommand,
+  screenshot,
+} from '../../src/commands/screenshot.ts';
+import type { RealmAuthenticator } from '../../src/lib/realm-authenticator.ts';
+
+const REALM_URL = 'http://realms.example.test/owner/workspace/';
+const CARD_URL = `${REALM_URL}Person/fadhlan`;
+const ENDPOINT = 'http://realms.example.test/_screenshot-card';
+
+interface RecordedRequest {
+  url: string;
+  method: string;
+  headers: Headers;
+  body?: unknown;
+}
+
+/**
+ * Fake authenticator standing in for both the per-realm fetches (card
+ * discovery GET, image download GET) and — via the command's injected-mode
+ * fallback — the realm-server POST. Routes by method + URL.
+ */
+function makeFake(options: {
+  realmHeader?: string | null;
+  cardStatus?: number;
+  postResponses: (() => Response)[];
+  downloads?: Record<string, Response>;
+}): { authenticator: RealmAuthenticator; requests: RecordedRequest[] } {
+  let requests: RecordedRequest[] = [];
+  let postIndex = 0;
+  return {
+    requests,
+    authenticator: {
+      async authedRealmFetch(input, init) {
+        let url = typeof input === 'string' ? input : input.toString();
+        let headers = new Headers(init?.headers);
+        let method = init?.method ?? 'GET';
+        requests.push({
+          url,
+          method,
+          headers,
+          body: init?.body ? JSON.parse(init.body as string) : undefined,
+        });
+        if (method === 'POST') {
+          let make = options.postResponses[postIndex];
+          postIndex = Math.min(postIndex + 1, options.postResponses.length - 1);
+          return make();
+        }
+        if (options.downloads && url in options.downloads) {
+          return options.downloads[url];
+        }
+        // Card discovery GET
+        let responseHeaders = new Headers();
+        let realmHeader =
+          options.realmHeader === undefined ? REALM_URL : options.realmHeader;
+        if (realmHeader) {
+          responseHeaders.set('x-boxel-realm-url', realmHeader);
+        }
+        return new Response('{}', {
+          status: options.cardStatus ?? 200,
+          headers: responseHeaders,
+        });
+      },
+    },
+  };
+}
+
+function readyResponse(attrs: Record<string, unknown>): Response {
+  return new Response(
+    JSON.stringify({
+      data: { type: 'screenshot-card-result', attributes: attrs },
+    }),
+    { status: 201, headers: { 'Content-Type': 'application/vnd.api+json' } },
+  );
+}
+
+const PNG_BYTES = Buffer.from('fake-png-bytes');
+const PNG_BASE64 = PNG_BYTES.toString('base64');
+const PNG_SHA256 = createHash('sha256').update(PNG_BYTES).digest('hex');
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'boxel-screenshot-test-'));
+}
+
+describe('boxel screenshot: single capture', () => {
+  it('discovers the realm, posts a canonical request, and writes the image from base64', async () => {
+    let { authenticator, requests } = makeFake({
+      postResponses: [
+        () =>
+          readyResponse({
+            status: 'ready',
+            base64: PNG_BASE64,
+            width: 800,
+            height: 600,
+            contentType: 'image/png',
+            captures: [
+              {
+                name: null,
+                url: `${REALM_URL}_screenshot/Person/fadhlan`,
+                width: 800,
+                height: 600,
+                deviceScaleFactor: null,
+                base64: PNG_BASE64,
+              },
+            ],
+          }),
+      ],
+    });
+    let out = tempDir();
+    let result = await screenshot(`${CARD_URL}.json`, { authenticator, out });
+
+    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
+    expect(result.captures).toHaveLength(1);
+    let entry = result.captures[0];
+    expect(entry.status).toBe('ok');
+    expect(entry.name).toBeNull();
+    expect(entry.url).toBe(`${REALM_URL}_screenshot/Person/fadhlan`);
+    expect(entry.width).toBe(800);
+    expect(entry.sha256).toBe(PNG_SHA256);
+    expect(entry.file).toBe(join(out, 'Person-fadhlan.png'));
+    expect(readFileSync(entry.file!)).toEqual(PNG_BYTES);
+
+    // Discovery GET (instance source file) then the POST.
+    expect(requests[0].method).toBe('GET');
+    expect(requests[0].url).toBe(`${CARD_URL}.json`);
+    expect(requests[0].headers.get('Accept')).toBe(
+      'application/vnd.card+source',
+    );
+    expect(requests[1].method).toBe('POST');
+    expect(requests[1].url).toBe(ENDPOINT);
+    expect(requests[1].body).toEqual({
+      data: {
+        type: 'screenshot-card',
+        attributes: {
+          realmURL: REALM_URL,
+          cardId: CARD_URL,
+          format: 'isolated',
+          includeBase64: true,
+          captureSpec: null,
+        },
+      },
+    });
+  });
+
+  it('passes the capture spec through verbatim (including target)', async () => {
+    let { authenticator, requests } = makeFake({
+      postResponses: [
+        () =>
+          readyResponse({
+            status: 'ready',
+            captures: [
+              {
+                name: 'default',
+                url: null,
+                width: 400,
+                height: 300,
+                deviceScaleFactor: 2,
+                base64: PNG_BASE64,
+              },
+            ],
+          }),
+      ],
+    });
+    let spec = {
+      viewport: { width: 1280, height: 800 },
+      deviceScaleFactor: 2,
+      target: '[data-card-field="avatar"]',
+    };
+    let result = await screenshot(CARD_URL, {
+      authenticator,
+      out: tempDir(),
+      captureSpec: spec,
+    });
+    expect(result.ok).toBe(true);
+    let post = requests.find((r) => r.method === 'POST')!;
+    expect((post.body as any).data.attributes.captureSpec).toEqual(spec);
+  });
+
+  it('skips discovery when --realm is given and rejects a card outside it', async () => {
+    let { authenticator, requests } = makeFake({
+      postResponses: [
+        () =>
+          readyResponse({
+            status: 'ready',
+            captures: [
+              {
+                name: null,
+                url: null,
+                width: 1,
+                height: 1,
+                deviceScaleFactor: null,
+                base64: PNG_BASE64,
+              },
+            ],
+          }),
+      ],
+    });
+    let result = await screenshot(CARD_URL, {
+      authenticator,
+      out: tempDir(),
+      realm: REALM_URL,
+    });
+    expect(result.ok).toBe(true);
+    expect(requests.filter((r) => r.method === 'GET')).toHaveLength(0);
+
+    let outside = await screenshot('http://elsewhere.test/Person/1', {
+      authenticator,
+      out: tempDir(),
+      realm: REALM_URL,
+    });
+    expect(outside.ok).toBe(false);
+    expect(outside.captures[0].error).toContain('not within --realm');
+  });
+
+  it('downloads from the served URL when the response carries no base64', async () => {
+    let servedUrl = `${REALM_URL}_screenshot/Person/fadhlan`;
+    let { authenticator } = makeFake({
+      postResponses: [
+        () =>
+          readyResponse({
+            status: 'ready',
+            captures: [
+              {
+                name: null,
+                url: servedUrl,
+                width: 800,
+                height: 600,
+                deviceScaleFactor: null,
+              },
+            ],
+          }),
+      ],
+      downloads: {
+        [servedUrl]: new Response(PNG_BYTES, {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        }),
+      },
+    });
+    let result = await screenshot(CARD_URL, {
+      authenticator,
+      out: tempDir(),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.captures[0].sha256).toBe(PNG_SHA256);
+  });
+
+  it('reports the server error body on a non-ok POST', async () => {
+    let { authenticator } = makeFake({
+      postResponses: [
+        () =>
+          new Response(
+            JSON.stringify({
+              errors: ['captureSpec.target is not a supported field'],
+            }),
+            { status: 400 },
+          ),
+      ],
+    });
+    let result = await screenshot(CARD_URL, {
+      authenticator,
+      out: tempDir(),
+      captureSpec: { target: '.foo' },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.captures[0].status).toBe('error');
+    expect(result.captures[0].error).toContain('HTTP 400');
+    expect(result.captures[0].error).toContain('target is not a supported');
+  });
+
+  it('reports a job error when the card cannot be loaded', async () => {
+    let { authenticator } = makeFake({
+      cardStatus: 404,
+      postResponses: [],
+    });
+    let result = await screenshot(CARD_URL, {
+      authenticator,
+      out: tempDir(),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.captures[0].error).toContain('HTTP 404');
+  });
+});
+
+describe('boxel screenshot: busy-server retry', () => {
+  it('honors Retry-After and succeeds on the retry', async () => {
+    let sleeps: number[] = [];
+    let { authenticator, requests } = makeFake({
+      postResponses: [
+        () =>
+          new Response(null, {
+            status: 503,
+            headers: { 'retry-after': '2' },
+          }),
+        () =>
+          readyResponse({
+            status: 'ready',
+            captures: [
+              {
+                name: null,
+                url: null,
+                width: 1,
+                height: 1,
+                deviceScaleFactor: null,
+                base64: PNG_BASE64,
+              },
+            ],
+          }),
+      ],
+    });
+    let result = await screenshot(CARD_URL, {
+      authenticator,
+      out: tempDir(),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(sleeps).toEqual([2000]);
+    expect(requests.filter((r) => r.method === 'POST')).toHaveLength(2);
+  });
+
+  it('gives up when the Retry-After wait would exceed --max-wait', async () => {
+    let { authenticator } = makeFake({
+      postResponses: [
+        () =>
+          new Response(null, {
+            status: 503,
+            headers: { 'retry-after': '30' },
+          }),
+      ],
+    });
+    let result = await screenshot(CARD_URL, {
+      authenticator,
+      out: tempDir(),
+      maxWaitMs: 5000,
+      sleep: async () => {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.captures[0].error).toContain('Server busy');
+  });
+});
+
+describe('boxel screenshot: --url-only', () => {
+  it('requests no base64 and reports served URLs; a null URL is an error', async () => {
+    let servedUrl = `${REALM_URL}_screenshot/Person/fadhlan`;
+    let { authenticator, requests } = makeFake({
+      postResponses: [
+        () =>
+          readyResponse({
+            status: 'ready',
+            captures: [
+              {
+                name: 'wide',
+                url: servedUrl,
+                width: 1280,
+                height: 800,
+                deviceScaleFactor: null,
+              },
+              {
+                name: 'thumb',
+                url: null,
+                width: 200,
+                height: 200,
+                deviceScaleFactor: null,
+              },
+            ],
+          }),
+      ],
+    });
+    let result = await screenshot(CARD_URL, {
+      authenticator,
+      urlOnly: true,
+      captureSpec: {
+        captures: [{ name: 'wide' }, { name: 'thumb' }],
+      },
+    });
+    let post = requests.find((r) => r.method === 'POST')!;
+    expect((post.body as any).data.attributes.includeBase64).toBe(false);
+    expect(result.ok).toBe(false);
+    expect(result.captures[0]).toMatchObject({
+      name: 'wide',
+      status: 'ok',
+      url: servedUrl,
+    });
+    expect(result.captures[1]).toMatchObject({
+      name: 'thumb',
+      status: 'error',
+    });
+    expect(result.captures[1].error).toContain('No served URL');
+  });
+});
+
+describe('boxel screenshot: --spec batch', () => {
+  it('posts once per card, writes named files, and writes a manifest', async () => {
+    let { authenticator, requests } = makeFake({
+      postResponses: [
+        () =>
+          readyResponse({
+            status: 'ready',
+            captures: [
+              {
+                name: 'wide',
+                url: null,
+                width: 1280,
+                height: 800,
+                deviceScaleFactor: 1,
+                base64: PNG_BASE64,
+              },
+              {
+                name: 'thumb',
+                url: null,
+                width: 200,
+                height: 200,
+                deviceScaleFactor: 1,
+                base64: PNG_BASE64,
+              },
+            ],
+          }),
+      ],
+    });
+    let out = tempDir();
+    let specPath = join(out, 'captures.json');
+    writeFileSync(
+      specPath,
+      JSON.stringify([
+        {
+          card: CARD_URL,
+          captureSpec: {
+            captures: [
+              { name: 'wide', viewport: { width: 1280, height: 800 } },
+              { name: 'thumb', clip: { x: 0, y: 0, width: 200, height: 200 } },
+            ],
+          },
+        },
+        { card: `${REALM_URL}Person/second`, format: 'embedded' },
+      ]),
+    );
+
+    let result = await screenshot(undefined, {
+      authenticator,
+      out,
+      specPath,
+    });
+    expect(result.ok).toBe(true);
+    expect(requests.filter((r) => r.method === 'POST')).toHaveLength(2);
+    let posts = requests.filter((r) => r.method === 'POST');
+    expect((posts[1].body as any).data.attributes.format).toBe('embedded');
+
+    expect(result.captures.map((c) => c.file)).toEqual([
+      join(out, 'Person-fadhlan--wide.png'),
+      join(out, 'Person-fadhlan--thumb.png'),
+      join(out, 'Person-second--wide.png'),
+      join(out, 'Person-second--thumb.png'),
+    ]);
+
+    expect(result.manifestPath).toBe(join(out, 'screenshot-manifest.json'));
+    let manifest = JSON.parse(readFileSync(result.manifestPath!, 'utf8'));
+    expect(manifest.ok).toBe(true);
+    expect(manifest.captures).toHaveLength(4);
+    expect(manifest.captures[0]).toMatchObject({
+      card: CARD_URL,
+      name: 'wide',
+      status: 'ok',
+      sha256: PNG_SHA256,
+    });
+  });
+
+  it('lists every requested capture name when a card-level request fails', async () => {
+    let { authenticator } = makeFake({
+      postResponses: [() => new Response('boom', { status: 500 })],
+    });
+    let out = tempDir();
+    let specPath = join(out, 'captures.json');
+    writeFileSync(
+      specPath,
+      JSON.stringify({
+        card: CARD_URL,
+        captureSpec: { captures: [{ name: 'a' }, { name: 'b' }] },
+      }),
+    );
+    let result = await screenshot(undefined, { authenticator, out, specPath });
+    expect(result.ok).toBe(false);
+    expect(result.captures.map((c) => c.name)).toEqual(['a', 'b']);
+    expect(result.captures.every((c) => c.status === 'error')).toBe(true);
+  });
+
+  it('rejects combining a card URL or capture flags with --spec', async () => {
+    let out = tempDir();
+    let specPath = join(out, 'captures.json');
+    writeFileSync(specPath, JSON.stringify({ card: CARD_URL }));
+
+    let both = await screenshot(CARD_URL, { specPath });
+    expect(both.error).toContain('not both');
+
+    let flags = await screenshot(undefined, {
+      specPath,
+      captureSpec: { fullPage: true },
+    });
+    expect(flags.error).toContain('spec file');
+  });
+
+  it('rejects a spec entry without a card URL', async () => {
+    let out = tempDir();
+    let specPath = join(out, 'captures.json');
+    writeFileSync(specPath, JSON.stringify([{ format: 'isolated' }]));
+    let result = await screenshot(undefined, { specPath });
+    expect(result.error).toContain('"card"');
+  });
+});
+
+describe('boxel screenshot: CLI flag parsing', () => {
+  function parseFlags(extra: string[]): Record<string, unknown> {
+    let captured: Record<string, unknown> | null = null;
+    let program = new Command().exitOverride();
+    registerScreenshotCommand(program);
+    let cmd = program.commands.find((c) => c.name() === 'screenshot')!;
+    cmd.action((_cardUrl: string | undefined, opts: object) => {
+      captured = { ...opts };
+    });
+    program.parse(['screenshot', CARD_URL, ...extra], { from: 'user' });
+    return captured!;
+  }
+
+  it('parses dimension, clip, and scale flags into structured values', () => {
+    let opts = parseFlags([
+      '--viewport',
+      '800x600',
+      '--envelope',
+      '400x300',
+      '--dsf',
+      '2',
+      '--clip',
+      '0,0,200,150',
+      '--target',
+      '.avatar',
+      '--full-page',
+      '--max-wait',
+      '30',
+    ]);
+    expect(opts.viewport).toEqual({ width: 800, height: 600 });
+    expect(opts.envelope).toEqual({ width: 400, height: 300 });
+    expect(opts.dsf).toBe(2);
+    expect(opts.clip).toEqual({ x: 0, y: 0, width: 200, height: 150 });
+    expect(opts.target).toBe('.avatar');
+    expect(opts.fullPage).toBe(true);
+    expect(opts.maxWait).toBe(30);
+  });
+
+  it('defaults format to isolated and max-wait to 120', () => {
+    let opts = parseFlags([]);
+    expect(opts.format).toBe('isolated');
+    expect(opts.maxWait).toBe(120);
+  });
+
+  it('translates flags into a capture spec, eliding an empty one to null', () => {
+    expect(captureSpecFromFlags({})).toBeNull();
+    expect(
+      captureSpecFromFlags({
+        viewport: { width: 800, height: 600 },
+        dsf: 2,
+        target: '.foo',
+        fullPage: true,
+      }),
+    ).toEqual({
+      viewport: { width: 800, height: 600 },
+      deviceScaleFactor: 2,
+      target: '.foo',
+      fullPage: true,
+    });
+  });
+});

--- a/packages/boxel-cli/tests/commands/screenshot.test.ts
+++ b/packages/boxel-cli/tests/commands/screenshot.test.ts
@@ -515,6 +515,39 @@ describe('boxel screenshot: --spec batch', () => {
     let result = await screenshot(undefined, { specPath });
     expect(result.error).toContain('"card"');
   });
+
+  it('rejects a seed-mode spec whose cards span more than one realm owner', async () => {
+    let out = tempDir();
+    let specPath = join(out, 'captures.json');
+    writeFileSync(
+      specPath,
+      JSON.stringify([
+        { card: 'http://realms.example.test/owner-a/workspace/Person/1' },
+        { card: 'http://realms.example.test/owner-b/workspace/Person/2' },
+      ]),
+    );
+    let result = await screenshot(undefined, {
+      specPath,
+      realmSecretSeed: 'test-seed',
+    });
+    expect(result.error).toContain('one realm owner per invocation');
+
+    // An explicit --as-user unifies the identity across owners on the same
+    // server, so the guard only trips across server origins then.
+    writeFileSync(
+      specPath,
+      JSON.stringify([
+        { card: 'http://realms.example.test/owner-a/workspace/Person/1' },
+        { card: 'http://elsewhere.example.test/owner-a/workspace/Person/2' },
+      ]),
+    );
+    let crossOrigin = await screenshot(undefined, {
+      specPath,
+      realmSecretSeed: 'test-seed',
+      asUser: '@owner-a:example.test',
+    });
+    expect(crossOrigin.error).toContain('one realm owner per invocation');
+  });
 });
 
 describe('boxel screenshot: CLI flag parsing', () => {

--- a/packages/boxel-cli/tests/integration/screenshot.test.ts
+++ b/packages/boxel-cli/tests/integration/screenshot.test.ts
@@ -1,0 +1,207 @@
+import '../helpers/setup-realm-server.ts';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createHash } from 'node:crypto';
+import type {
+  Prerenderer,
+  ScreenshotPrerenderResponse,
+} from '@cardstack/runtime-common';
+import {
+  startTestRealmServer,
+  stopTestRealmServer,
+  createTestHome,
+  setupTestProfile,
+  TEST_REALM_SERVER_URL,
+} from '../helpers/integration.ts';
+import { runBoxel } from '../helpers/run-boxel.ts';
+import { TINY_PNG_BYTES } from '../helpers/binary-fixtures.ts';
+
+// Drives `boxel screenshot` end-to-end through the real realm server, queue,
+// and screenshot-card worker task. The prerenderer is a stub that returns a
+// fixed PNG per requested capture, so no Chrome is involved; what's under
+// test is the CLI's request construction, auth, response handling, file
+// writing, and manifest/exit-code contract.
+
+const TINY_PNG_BASE64 = Buffer.from(TINY_PNG_BYTES).toString('base64');
+const TINY_PNG_SHA256 = createHash('sha256')
+  .update(TINY_PNG_BYTES)
+  .digest('hex');
+
+const screenshotStubPrerenderer: Prerenderer = {
+  prerenderModule: async () => ({ html: '', status: 200 }) as any,
+  prerenderVisit: async () => ({}) as any,
+  runCommand: async () => ({ status: 'ready' }),
+  prerenderScreenshot: async (args): Promise<ScreenshotPrerenderResponse> => {
+    let entries = args.captureSpec?.captures ?? [{ name: 'default' }];
+    let captures = entries.map((entry: any) => ({
+      name: entry.name ?? 'default',
+      base64: TINY_PNG_BASE64,
+      width: entry.viewport?.width ?? 800,
+      height: entry.viewport?.height ?? 600,
+      deviceScaleFactor: entry.deviceScaleFactor ?? 1,
+    }));
+    return {
+      status: 'ready',
+      captures,
+      base64: captures[0].base64,
+      width: captures[0].width,
+      height: captures[0].height,
+      contentType: 'image/png',
+    };
+  },
+};
+
+const CARD_JSON = JSON.stringify({
+  data: {
+    type: 'card',
+    attributes: { title: 'Screenshot Target' },
+    meta: {
+      adoptsFrom: { module: '@cardstack/base/card-api', name: 'CardDef' },
+    },
+  },
+});
+
+interface ManifestJson {
+  ok: boolean;
+  error?: string;
+  captures: {
+    card: string;
+    name: string | null;
+    status: string;
+    file?: string;
+    width?: number | null;
+    height?: number | null;
+    sha256?: string;
+    url: string | null;
+    error?: string;
+  }[];
+  manifestPath?: string;
+}
+
+let home: string;
+let cleanupProfile: () => void;
+let realmUrl: string;
+let cardUrl: string;
+
+beforeAll(async () => {
+  await startTestRealmServer({
+    fileSystem: { 'screenshot-target.json': CARD_JSON },
+    prerenderer: screenshotStubPrerenderer,
+  });
+  realmUrl = `${TEST_REALM_SERVER_URL}/test/`;
+  cardUrl = `${realmUrl}screenshot-target`;
+
+  let testHome = createTestHome();
+  home = testHome.home;
+  cleanupProfile = testHome.cleanup;
+  await setupTestProfile(testHome.profileManager);
+}, 60_000);
+
+afterAll(async () => {
+  cleanupProfile?.();
+  await stopTestRealmServer();
+});
+
+function tempOutDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-screenshot-out-'));
+}
+
+describe('screenshot (integration)', () => {
+  it('captures a card and writes the image with a manifest entry', async () => {
+    let out = tempOutDir();
+    let res = await runBoxel(['screenshot', cardUrl, '--out', out, '--json'], {
+      home,
+    });
+    let result = res.json<ManifestJson>();
+
+    expect(result.ok, `screenshot failed: ${JSON.stringify(result)}`).toBe(
+      true,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(result.captures).toHaveLength(1);
+    let entry = result.captures[0];
+    expect(entry.status).toBe('ok');
+    expect(entry.card).toBe(cardUrl);
+    expect(entry.sha256).toBe(TINY_PNG_SHA256);
+    expect(entry.file).toBeTruthy();
+    expect(new Uint8Array(fs.readFileSync(entry.file!))).toEqual(
+      TINY_PNG_BYTES,
+    );
+  });
+
+  it('runs a --spec batch and writes named files plus screenshot-manifest.json', async () => {
+    let out = tempOutDir();
+    let specPath = path.join(out, 'captures.json');
+    fs.writeFileSync(
+      specPath,
+      JSON.stringify([
+        {
+          card: cardUrl,
+          captureSpec: {
+            captures: [
+              { name: 'wide', viewport: { width: 1280, height: 800 } },
+              { name: 'thumb', viewport: { width: 200, height: 200 } },
+            ],
+          },
+        },
+      ]),
+    );
+
+    let res = await runBoxel(
+      ['screenshot', '--spec', specPath, '--out', out, '--json'],
+      { home },
+    );
+    let result = res.json<ManifestJson>();
+
+    expect(result.ok, `batch failed: ${JSON.stringify(result)}`).toBe(true);
+    expect(res.exitCode).toBe(0);
+    expect(result.captures.map((c) => c.name)).toEqual(['wide', 'thumb']);
+    expect(result.captures.map((c) => c.width)).toEqual([1280, 200]);
+    for (let entry of result.captures) {
+      expect(entry.sha256).toBe(TINY_PNG_SHA256);
+      expect(new Uint8Array(fs.readFileSync(entry.file!))).toEqual(
+        TINY_PNG_BYTES,
+      );
+    }
+
+    let manifest = JSON.parse(
+      fs.readFileSync(path.join(out, 'screenshot-manifest.json'), 'utf8'),
+    ) as ManifestJson;
+    expect(manifest.ok).toBe(true);
+    expect(manifest.captures).toHaveLength(2);
+  });
+
+  it('surfaces a server-side capture-spec rejection and exits non-zero', async () => {
+    let out = tempOutDir();
+    let specPath = path.join(out, 'captures.json');
+    fs.writeFileSync(
+      specPath,
+      JSON.stringify({ card: cardUrl, captureSpec: { bogus: true } }),
+    );
+
+    let res = await runBoxel(
+      ['screenshot', '--spec', specPath, '--out', out, '--json'],
+      { home },
+    );
+    let result = res.json<ManifestJson>();
+
+    expect(res.exitCode).toBe(1);
+    expect(result.ok).toBe(false);
+    expect(result.captures[0].status).toBe('error');
+    expect(result.captures[0].error).toContain('bogus');
+  });
+
+  it('reports a missing card as an error and exits non-zero', async () => {
+    let res = await runBoxel(
+      ['screenshot', `${realmUrl}no-such-card`, '--json'],
+      { home },
+    );
+    let result = res.json<ManifestJson>();
+
+    expect(res.exitCode).toBe(1);
+    expect(result.ok).toBe(false);
+    expect(result.captures[0].error).toContain('HTTP 404');
+  });
+});


### PR DESCRIPTION
Adds a `boxel screenshot` command: a thin client over the realm server's `POST /_screenshot-card` endpoint (contract documented at `packages/realm-server/handlers/handle-screenshot-card.ts`).

## What it does

**Single capture (local dev iteration):**

```
boxel screenshot <card-url> [--format isolated|embedded|fitted] \
  [--viewport WxH] [--envelope WxH] [--dsf N] [--clip x,y,w,h] \
  [--target <selector>] [--full-page] [--out dir] [--json]
```

**Batch (CI / scripted):** `--spec captures.json` takes an entry or array of `{card, format?, captureSpec?}` — one request (one settle) per card, with the captureSpec passed through verbatim — and writes a `screenshot-manifest.json` into `--out` (per capture: card, name, file path, dims, sha256, served url, status). Exit code is 0 only when every capture succeeds; failures are listed per capture.

**URL-only:** `--url-only` requests no image bytes (`includeBase64: false`) and prints the served MediaCache URLs. A capture the server returns inline-only (`url: null`) is reported as an error in this mode, since only persisted captures have durable URLs.

## Design notes

- **The server owns spec validation.** Capture flags and spec-file contents are passed through verbatim, so new engine capabilities (e.g. `target`, which the endpoint does not accept yet) work here without a CLI change — an unsupported field surfaces as the server's named 400.
- **Realm discovery:** the card's realm URL comes from the `x-boxel-realm-url` header on a GET of the instance's source file (works even when the instance isn't indexed, and confirms the card exists before a render is queued). `--realm` skips the probe; seed mode (`--realm-secret-seed`, `--as-user`) works like the other admin-capable commands.
- **Bytes:** written from the response's inline base64 when present, else downloaded (authed) from the capture's served URL.
- **Busy handling:** a `503` + `Retry-After` is retried within a `--max-wait` budget (default 120s) — for canonical captures the interrupted render still persists, so the retry is a cheap ledger hit.

## Testing

- `tests/commands/screenshot.test.ts` — 16 unit tests over an injected authenticator: request construction, spec passthrough, realm discovery/skip, base64-vs-URL byte sourcing, 503 retry + budget exhaustion, `--url-only`, batch manifest + per-name error fan-out, flag parsing.
- `tests/integration/screenshot.test.ts` — drives the built CLI subprocess end-to-end through a real realm server, queue, and screenshot-card worker task (prerenderer stubbed with a fixed PNG, no Chrome): single capture, `--spec` batch with named files + manifest, server-side spec rejection, missing card. All pass locally against test-pg; full `test:unit` suite (522 tests) also green.

Not included: the command is not yet mapped into any plugin skill (`scripts/build-plugin.ts` `SKILL_SPECS`); that can follow once the workflow settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)