### PR TITLE
Prevent choking Synapse with ~100k index events every night when the OpenRouter model sync runs

### DIFF
--- a/packages/bot-runner/lib/command-runner.ts
+++ b/packages/bot-runner/lib/command-runner.ts
@@ -51,6 +51,7 @@ export function makeEnqueueRunCommand(
         runAs,
         command,
         commandInput,
+        dedupeKey: null,
       },
       queuePublisher,
       dbAdapter,

--- a/packages/bot-runner/tests/bot-runner-test.ts
+++ b/packages/bot-runner/tests/bot-runner-test.ts
@@ -227,6 +227,7 @@ module('timeline handler', () => {
           realmURL: 'http://localhost:4201/test/',
           realmUsername: '@alice:localhost',
           runAs: '@alice:localhost',
+          dedupeKey: null,
           command: '@cardstack/boxel-host/commands/show-card/default',
           commandInput: {},
         },

--- a/packages/bot-runner/tests/command-runner-test.ts
+++ b/packages/bot-runner/tests/command-runner-test.ts
@@ -131,6 +131,7 @@ module('command runner', () => {
           realmURL: 'http://localhost:4201/test/',
           realmUsername: '@alice:localhost',
           runAs: '@alice:localhost',
+          dedupeKey: null,
           command: '@cardstack/boxel-host/commands/show-card/default',
           commandInput: { cardId: 'http://localhost:4201/test/Person/1' },
         },
@@ -322,6 +323,7 @@ module('command runner', () => {
         realmURL: 'http://localhost:4201/test/',
         realmUsername: '@alice:localhost',
         runAs: '@alice:localhost',
+        dedupeKey: null,
         command: '@cardstack/boxel-host/commands/patch-card-instance/default',
         commandInput: {
           cardId: submissionCardUrl,
@@ -338,6 +340,7 @@ module('command runner', () => {
         realmURL: 'http://localhost:4201/test/',
         realmUsername: '@alice:localhost',
         runAs: '@alice:localhost',
+        dedupeKey: null,
         command: '@cardstack/boxel-host/commands/patch-card-instance/default',
         commandInput: {
           cardId: submissionCardUrl,
@@ -358,6 +361,7 @@ module('command runner', () => {
         realmURL: SUBMISSION_REALM_URL,
         realmUsername: SUBMISSION_BOT_USER_ID,
         runAs: SUBMISSION_BOT_USER_ID,
+        dedupeKey: null,
         command: '@cardstack/catalog/commands/create-pr-card/default',
         commandInput: {
           realm: SUBMISSION_REALM_URL,
@@ -381,6 +385,7 @@ module('command runner', () => {
         realmURL: 'http://localhost:4201/test/',
         realmUsername: '@alice:localhost',
         runAs: '@alice:localhost',
+        dedupeKey: null,
         command: '@cardstack/boxel-host/commands/patch-card-instance/default',
         commandInput: {
           cardId: submissionCardUrl,
@@ -403,6 +408,7 @@ module('command runner', () => {
         realmURL: 'http://localhost:4201/test/',
         realmUsername: '@alice:localhost',
         runAs: '@alice:localhost',
+        dedupeKey: null,
         command: '@cardstack/boxel-host/commands/patch-card-instance/default',
         commandInput: {
           cardId: submissionCardUrl,

--- a/packages/host/app/tools/sync-openrouter-models.ts
+++ b/packages/host/app/tools/sync-openrouter-models.ts
@@ -125,7 +125,6 @@ function buildCardJson(model: OpenRouterApiModel) {
             }
           : null,
         deprecated: false,
-        lastSeenInApi: Math.floor(Date.now() / 1000),
         expirationDate: model.expiration_date ?? null,
         cardInfo: {
           name: null,

--- a/packages/host/tests/integration/tools/sync-openrouter-models-test.gts
+++ b/packages/host/tests/integration/tools/sync-openrouter-models-test.gts
@@ -146,10 +146,19 @@ module('Integration | tools | sync-openrouter-models', function (hooks) {
 
     // The existing, still-listed model is discovered via search, so it is updated
     // in place rather than re-added.
+    let gpt4Op = opFor('OpenRouterModel/openai-gpt-4.json');
     assert.strictEqual(
-      opFor('OpenRouterModel/openai-gpt-4.json')?.op,
+      gpt4Op?.op,
       'update',
       'existing listed model resolves to an update',
+    );
+
+    // The generated card must not carry any per-run value. The realm skips a
+    // write whose content matches what is on disk, and one changing attribute
+    // would turn every daily sync into a rewrite of every model.
+    assert.false(
+      'lastSeenInApi' in ((gpt4Op?.data as any)?.attributes ?? {}),
+      'generated model card carries no per-run timestamp',
     );
 
     // The model not previously in the realm is added.

--- a/packages/realm-server/handlers/handle-run-command.ts
+++ b/packages/realm-server/handlers/handle-run-command.ts
@@ -82,6 +82,7 @@ export default function handleRunCommand({
           runAs: userId,
           command,
           commandInput: commandInput ?? null,
+          dedupeKey: null,
         },
         queue,
         dbAdapter,

--- a/packages/realm-server/handlers/handle-webhook-receiver.ts
+++ b/packages/realm-server/handlers/handle-webhook-receiver.ts
@@ -157,6 +157,7 @@ export default function handleWebhookReceiverRequest({
             runAs,
             command: commandURL,
             commandInput,
+            dedupeKey: null,
           },
           queue,
           dbAdapter,

--- a/packages/realm-server/scripts/sync-openrouter-models.ts
+++ b/packages/realm-server/scripts/sync-openrouter-models.ts
@@ -55,6 +55,9 @@ export async function enqueueSyncOpenRouterModels({
     runAs: REALM_USERNAME,
     command: COMMAND_SPECIFIER,
     commandInput: { realmIdentifier: realmURL },
+    // The sync is idempotent; the cron enqueues it from every worker task, so
+    // identical enqueues join one pending job instead of each running a sync.
+    dedupeKey: `sync-openrouter-models:${realmURL}`,
   };
 
   try {

--- a/packages/realm-server/tests/queue-test.ts
+++ b/packages/realm-server/tests/queue-test.ts
@@ -298,6 +298,66 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('run-command joins a pending twin with identical args and inserts for differing args', async function (assert) {
+      await runner.destroy();
+
+      let args = {
+        realmURL: 'http://localhost:4201/openrouter/',
+        realmUsername: 'openrouter_realm',
+        runAs: 'openrouter_realm',
+        command:
+          '@cardstack/boxel-host/commands/sync-openrouter-models/default',
+        commandInput: { realmIdentifier: 'http://localhost:4201/openrouter/' },
+      };
+      let publishRunCommand = (jobArgs: typeof args) =>
+        publisher.publish({
+          jobType: 'run-command',
+          concurrencyGroup: `command:${jobArgs.realmURL}`,
+          timeout: 300,
+          priority: 1,
+          args: jobArgs,
+        });
+
+      let first = await publishRunCommand(args);
+      // Same invocation with the same args but a different key order — the
+      // twin check is structural, not textual.
+      let twin = await publishRunCommand({
+        commandInput: { realmIdentifier: args.commandInput.realmIdentifier },
+        command: args.command,
+        runAs: args.runAs,
+        realmUsername: args.realmUsername,
+        realmURL: args.realmURL,
+      });
+      let differentInput = await publishRunCommand({
+        ...args,
+        commandInput: { realmIdentifier: 'http://localhost:4201/other/' },
+      });
+
+      assert.strictEqual(
+        twin.id,
+        first.id,
+        'an identical run-command invocation joins the pending job',
+      );
+      assert.notStrictEqual(
+        differentInput.id,
+        first.id,
+        'a run-command with different args gets its own job',
+      );
+
+      let rows = (await adapter.execute(
+        `SELECT id
+         FROM jobs
+         WHERE concurrency_group=$1
+           AND status='unfulfilled'`,
+        { bind: [`command:${args.realmURL}`] },
+      )) as { id: number }[];
+      assert.strictEqual(
+        rows.length,
+        2,
+        'two distinct invocations leave two pending rows, the twin adds none',
+      );
+    });
+
     test('incremental coalesce merges mixed operations and persists per-caller metadata', async function (assert) {
       await runner.destroy();
 

--- a/packages/realm-server/tests/queue-test.ts
+++ b/packages/realm-server/tests/queue-test.ts
@@ -9,6 +9,7 @@ import {
 } from '@cardstack/postgres';
 
 import type {
+  PgPrimitive,
   QueueCoalesceContext,
   QueuePublisher,
   QueueRunner,
@@ -298,64 +299,126 @@ module(basename(import.meta.filename), function () {
       );
     });
 
-    test('run-command joins a pending twin with identical args and inserts for differing args', async function (assert) {
-      await runner.destroy();
-
-      let args = {
-        realmURL: 'http://localhost:4201/openrouter/',
+    module('run-command coalesce', function () {
+      const realmURL = 'http://localhost:4201/openrouter/';
+      const dedupedArgs = {
+        realmURL,
         realmUsername: 'openrouter_realm',
         runAs: 'openrouter_realm',
         command:
           '@cardstack/boxel-host/commands/sync-openrouter-models/default',
-        commandInput: { realmIdentifier: 'http://localhost:4201/openrouter/' },
+        commandInput: { realmIdentifier: realmURL },
+        dedupeKey: `sync-openrouter-models:${realmURL}`,
       };
-      let publishRunCommand = (jobArgs: typeof args) =>
-        publisher.publish({
+      function publishRunCommand(args: PgPrimitive) {
+        return publisher.publish<{ status: string }>({
           jobType: 'run-command',
-          concurrencyGroup: `command:${jobArgs.realmURL}`,
+          concurrencyGroup: `command:${realmURL}`,
           timeout: 300,
           priority: 1,
-          args: jobArgs,
+          args,
+        });
+      }
+      async function pendingRowCount() {
+        let rows = (await adapter.execute(
+          `SELECT id
+           FROM jobs
+           WHERE concurrency_group=$1
+             AND status='unfulfilled'`,
+          { bind: [`command:${realmURL}`] },
+        )) as { id: number }[];
+        return rows.length;
+      }
+
+      test('a keyed enqueue joins a pending twin with identical args', async function (assert) {
+        await runner.destroy();
+
+        let first = await publishRunCommand(dedupedArgs);
+        // Same invocation, same key, different property order — the twin
+        // check is structural, not textual.
+        let twin = await publishRunCommand({
+          dedupeKey: dedupedArgs.dedupeKey,
+          commandInput: { realmIdentifier: realmURL },
+          command: dedupedArgs.command,
+          runAs: dedupedArgs.runAs,
+          realmUsername: dedupedArgs.realmUsername,
+          realmURL,
+        });
+        let differentInput = await publishRunCommand({
+          ...dedupedArgs,
+          commandInput: { realmIdentifier: 'http://localhost:4201/other/' },
         });
 
-      let first = await publishRunCommand(args);
-      // Same invocation with the same args but a different key order — the
-      // twin check is structural, not textual.
-      let twin = await publishRunCommand({
-        commandInput: { realmIdentifier: args.commandInput.realmIdentifier },
-        command: args.command,
-        runAs: args.runAs,
-        realmUsername: args.realmUsername,
-        realmURL: args.realmURL,
-      });
-      let differentInput = await publishRunCommand({
-        ...args,
-        commandInput: { realmIdentifier: 'http://localhost:4201/other/' },
+        assert.strictEqual(
+          twin.id,
+          first.id,
+          'an identical keyed invocation joins the pending job',
+        );
+        assert.notStrictEqual(
+          differentInput.id,
+          first.id,
+          'a keyed invocation with different args gets its own job',
+        );
+        assert.strictEqual(
+          await pendingRowCount(),
+          2,
+          'two distinct invocations leave two pending rows, the twin adds none',
+        );
       });
 
-      assert.strictEqual(
-        twin.id,
-        first.id,
-        'an identical run-command invocation joins the pending job',
-      );
-      assert.notStrictEqual(
-        differentInput.id,
-        first.id,
-        'a run-command with different args gets its own job',
-      );
+      test('an enqueue without a dedupeKey never joins, even when args are identical', async function (assert) {
+        await runner.destroy();
 
-      let rows = (await adapter.execute(
-        `SELECT id
-         FROM jobs
-         WHERE concurrency_group=$1
-           AND status='unfulfilled'`,
-        { bind: [`command:${args.realmURL}`] },
-      )) as { id: number }[];
-      assert.strictEqual(
-        rows.length,
-        2,
-        'two distinct invocations leave two pending rows, the twin adds none',
-      );
+        let plainArgs = { ...dedupedArgs, dedupeKey: null };
+        let first = await publishRunCommand(plainArgs);
+        let second = await publishRunCommand({ ...plainArgs });
+
+        assert.notStrictEqual(
+          second.id,
+          first.id,
+          'identical unkeyed run-command requests are two executions',
+        );
+        assert.strictEqual(
+          await pendingRowCount(),
+          2,
+          'both unkeyed requests are pending as separate jobs',
+        );
+      });
+
+      test('a keyed enqueue joins an in-flight twin and shares its result', async function (assert) {
+        let started = new Deferred<void>();
+        let release = new Deferred<void>();
+        let executions = 0;
+        runner.register('run-command', async () => {
+          executions++;
+          started.fulfill();
+          await release.promise;
+          return { status: 'synced' };
+        });
+
+        let running = await publishRunCommand(dedupedArgs);
+        await started.promise;
+
+        let lateTwin = await publishRunCommand({ ...dedupedArgs });
+        assert.strictEqual(
+          lateTwin.id,
+          running.id,
+          'a keyed twin published after the job was claimed joins it',
+        );
+
+        release.fulfill();
+        let [runningResult, twinResult] = await Promise.all([
+          running.done,
+          lateTwin.done,
+        ]);
+        assert.deepEqual(runningResult, { status: 'synced' });
+        assert.deepEqual(
+          twinResult,
+          { status: 'synced' },
+          'the late twin receives the single execution result',
+        );
+        assert.strictEqual(executions, 1, 'the command ran exactly once');
+      });
     });
 
     test('incremental coalesce merges mixed operations and persists per-caller metadata', async function (assert) {

--- a/packages/runtime-common/tasks/run-command.ts
+++ b/packages/runtime-common/tasks/run-command.ts
@@ -23,27 +23,47 @@ export interface RunCommandArgs extends JSONTypes.Object {
   runAs: string;
   command: string;
   commandInput: JSONTypes.Object | null;
+  // Opt-in deduplication. A publisher that knows its invocation is
+  // idempotent (a scheduled sync, a periodic sweep) sets this so a second
+  // identical enqueue joins the pending or running job instead of running
+  // the command again. Ordinary run-command jobs pass null: they execute
+  // arbitrary commands with side effects, and two identical requests can
+  // legitimately mean two executions.
+  dedupeKey: string | null;
 }
 
-// Two run-command enqueues are the same invocation only when every argument
-// matches — same realm, same principal, same command, same input. Such twins
-// produce the same result, so a second caller can safely wait on the first
-// job instead of running the command again. This is what keeps a scheduled
-// command that is enqueued from several worker tasks at once (one cron tick
-// per task) down to a single run. Anything that differs in any argument is a
-// distinct invocation with its own result and is never joined.
+// Coalescing is opt-in via `dedupeKey`. Without a key every enqueue inserts,
+// so a command that writes files, creates rooms or sends events is never
+// silently collapsed into an earlier request. With a key, a twin is a job of
+// the same type carrying the same key and identical args; it produces the
+// same result, so the second caller can wait on it. This is what keeps a
+// scheduled command that is enqueued from several worker tasks at once (one
+// cron tick per task) down to a single run.
 function chooseRunCommandCoalesceDecision(
   context: QueueCoalesceContext,
 ): QueueCoalesceDecision {
   let { incoming, candidates, inFlightCandidates } = context;
+  let incomingKey = dedupeKeyOf(incoming.args);
+  if (!incomingKey) {
+    return { type: 'insert' };
+  }
   let isTwin = (candidate: { jobType: string; args: unknown }) =>
     candidate.jobType === incoming.jobType &&
+    dedupeKeyOf(candidate.args) === incomingKey &&
     isEqual(candidate.args, incoming.args);
   let twin = candidates.find(isTwin) ?? inFlightCandidates.find(isTwin);
   if (!twin) {
     return { type: 'insert' };
   }
   return { type: 'join', jobId: twin.id };
+}
+
+function dedupeKeyOf(args: unknown): string | undefined {
+  if (args && typeof args === 'object' && 'dedupeKey' in args) {
+    let key = (args as { dedupeKey?: unknown }).dedupeKey;
+    return typeof key === 'string' && key.length > 0 ? key : undefined;
+  }
+  return undefined;
 }
 
 registerQueueJobDefinition({

--- a/packages/runtime-common/tasks/run-command.ts
+++ b/packages/runtime-common/tasks/run-command.ts
@@ -10,6 +10,12 @@ import {
   ensureFullMatrixUserId,
   ensureTrailingSlash,
 } from '../index.ts';
+import { isEqual } from 'lodash-es';
+import {
+  registerQueueJobDefinition,
+  type QueueCoalesceContext,
+  type QueueCoalesceDecision,
+} from '../queue.ts';
 
 export interface RunCommandArgs extends JSONTypes.Object {
   realmURL: string;
@@ -19,10 +25,31 @@ export interface RunCommandArgs extends JSONTypes.Object {
   commandInput: JSONTypes.Object | null;
 }
 
-// No coalesce handler: each run-command enqueue is a distinct invocation
-// (different `command`/`runAs`/`commandInput`) whose result is returned to its
-// caller. Joining would route one caller's response to another. The realm
-// concurrency group already serializes per-realm execution.
+// Two run-command enqueues are the same invocation only when every argument
+// matches — same realm, same principal, same command, same input. Such twins
+// produce the same result, so a second caller can safely wait on the first
+// job instead of running the command again. This is what keeps a scheduled
+// command that is enqueued from several worker tasks at once (one cron tick
+// per task) down to a single run. Anything that differs in any argument is a
+// distinct invocation with its own result and is never joined.
+function chooseRunCommandCoalesceDecision(
+  context: QueueCoalesceContext,
+): QueueCoalesceDecision {
+  let { incoming, candidates, inFlightCandidates } = context;
+  let isTwin = (candidate: { jobType: string; args: unknown }) =>
+    candidate.jobType === incoming.jobType &&
+    isEqual(candidate.args, incoming.args);
+  let twin = candidates.find(isTwin) ?? inFlightCandidates.find(isTwin);
+  if (!twin) {
+    return { type: 'insert' };
+  }
+  return { type: 'join', jobId: twin.id };
+}
+
+registerQueueJobDefinition({
+  jobType: 'run-command',
+  coalesce: chooseRunCommandCoalesceDecision,
+});
 
 export { runCommand };
 

--- a/packages/runtime-common/tests/run-command-task-shared-tests.ts
+++ b/packages/runtime-common/tests/run-command-task-shared-tests.ts
@@ -109,6 +109,7 @@ const tests = Object.freeze({
       runAs: '@alice:localhost',
       command: '@cardstack/boxel-host/commands/show-card/default',
       commandInput: {},
+      dedupeKey: null,
       jobInfo: { id: 1 } as any,
     });
 
@@ -150,6 +151,7 @@ const tests = Object.freeze({
       runAs: '@alice:localhost',
       command: '   ',
       commandInput: {},
+      dedupeKey: null,
       jobInfo: { id: 2 } as any,
     });
 
@@ -201,6 +203,7 @@ const tests = Object.freeze({
       runAs: '@alice',
       command: 'http://localhost:4200/commands/create-submission',
       commandInput: null,
+      dedupeKey: null,
       jobInfo: { id: 3 } as any,
     });
 
@@ -255,6 +258,7 @@ const tests = Object.freeze({
       runAs: '@alice:localhost',
       command: '@cardstack/catalog/commands/create-submission/default',
       commandInput: { listingId: 'http://localhost:4201/catalog/AppListing/1' },
+      dedupeKey: null,
       jobInfo: { id: 4 } as any,
     });
 


### PR DESCRIPTION
Prevent choking Synapse when the nightly OpenRouter model sync runs. Each night the sync rewrote all ~400 model cards, once per worker task, and every rewrite broadcast an index event to every user's session room. On staging that came to about 110,000 Matrix events in 25 minutes. Synapse had to persist and fan out every one of them, and the AI assistant slowed to a crawl for every user while the sync ran. The same code and cron run in production.

Why once per worker task: `worker-manager.ts` is PID 1 of every container in the worker ECS service. It spawns that container's `worker.ts` processes and also calls `startCronJobs()`. Nothing elects one container as the scheduler, so a service scaled to 4 tasks has 4 schedulers, and each 4:00am tick enqueued 4 identical sync jobs. The other crons (`daily-credit-grant`, `media-cache-gc`, `prerender-html-reconcile`) already survive this because their job types coalesce or are idempotent; `run-command` had no coalesce handler.

Two changes remove the flood:

1. Model cards no longer carry a per-run `lastSeenInApi` timestamp. Nothing read it, and `deprecated` already records when a model leaves the API. The realm's unchanged-content check now works, so a file is written only when the model itself changed.
2. `run-command` jobs can opt in to deduplication with a `dedupeKey`. A keyed enqueue whose key and args match a pending or running job joins that job, and every enqueuer gets the one result. Only the scheduled sync sets a key; user and webhook triggered commands pass `null` and always run separately, because two identical requests there can mean two executions.

```
N worker tasks, each on cron tick ──► publish run-command ──► dedupeKey set and twin pending/in flight? ──► join (1 run total)
                                                                             │
                                                                             └── no ──► insert
sync run ──► _atomic batch ──► writeMany ──► content unchanged? ──► skip (no write, no event)
                                                    │
                                                    └── changed ──► write + index event
```

Result: one sync per night instead of one per worker task, and a handful of writes instead of ~400 × N.

Tests: a keyed publish with the same args (different property order) joins the pending job, a different `commandInput` inserts, an unkeyed publish never joins, and a keyed twin published while the first job runs joins it with one handler run and both waiters receiving the result. The sync integration test asserts the generated model card has no per-run timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

