### PR TITLE
Make login-token sign-in copy source-neutral

### DIFF
--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -53,7 +53,7 @@ export default class Login extends Component<Signature> {
       </div>
     {{else}}
       <span class='title'>Sign in to your Boxel Account</span>
-      {{#if this.showGoogleButton}}
+      {{#if this.showGoogleSubtitle}}
         <p class='subtitle'>Use Google to get started in one tap - we'll create
           your Boxel account if you don't have one yet.</p>
       {{/if}}
@@ -224,6 +224,7 @@ export default class Login extends Component<Signature> {
   @tracked private password: string | undefined;
   @tracked private googleSsoAvailable = false;
   @tracked private exchangingSsoToken = false;
+  @tracked private startedFromLoginToken = false;
   @service declare private matrixService: MatrixService;
   @service declare router: RouterService;
 
@@ -245,12 +246,21 @@ export default class Login extends Component<Signature> {
     // would flash for ~1-2s between mount and the auth flip.
     if (new URLSearchParams(window.location.search).has('loginToken')) {
       this.exchangingSsoToken = true;
+      this.startedFromLoginToken = true;
     }
     this.consumeSsoLoginToken.perform();
   }
 
   private get showGoogleButton() {
     return this.googleSsoAvailable;
+  }
+
+  // The subtitle offers to *create* an account, which is only true on the
+  // genuine Google entry point. A login-token hand-off (e.g. `boxel browse`)
+  // that fails also falls back to this form, but its user already has an
+  // account, so suppress the create-account copy there.
+  private get showGoogleSubtitle() {
+    return this.showGoogleButton && !this.startedFromLoginToken;
   }
 
   private get isLoginButtonDisabled() {
@@ -343,7 +353,13 @@ export default class Login extends Component<Signature> {
         refreshRoutes: true,
       });
     } catch (e: any) {
-      if (isMatrixError(e)) {
+      if (isMatrixError(e) && e.httpStatus === 403) {
+        // Login tokens are single-use and short-lived, so a 403 here means the
+        // link is spent or expired — not that the user mistyped a credential
+        // they never entered. Name the recovery instead of the password-form
+        // "check your credentials" advice extractMatrixErrorMessage returns.
+        this.error = `This sign-in link has expired or was already used. Get a new one and try again.`;
+      } else if (isMatrixError(e)) {
         this.error = `Sign-in failed. ${extractMatrixErrorMessage(e)}`;
       } else {
         this.error = `Sign-in failed: ${e.message}`;
@@ -368,9 +384,9 @@ export default class Login extends Component<Signature> {
       auth = await this.matrixService.login(this.username, this.password);
     } catch (e: any) {
       if (isMatrixError(e)) {
-        this.error = `Sign in failed. ${extractMatrixErrorMessage(e)}`;
+        this.error = `Sign-in failed. ${extractMatrixErrorMessage(e)}`;
       } else {
-        this.error = `Sign in failed: ${e.message}`;
+        this.error = `Sign-in failed: ${e.message}`;
       }
 
       throw e;

--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -353,11 +353,16 @@ export default class Login extends Component<Signature> {
         refreshRoutes: true,
       });
     } catch (e: any) {
-      if (isMatrixError(e) && e.httpStatus === 403) {
-        // Login tokens are single-use and short-lived, so a 403 here means the
-        // link is spent or expired — not that the user mistyped a credential
-        // they never entered. Name the recovery instead of the password-form
-        // "check your credentials" advice extractMatrixErrorMessage returns.
+      if (
+        isMatrixError(e) &&
+        e.httpStatus === 403 &&
+        e.errcode === 'M_FORBIDDEN'
+      ) {
+        // A single-use, short-lived login token that's spent or expired comes
+        // back as 403 M_FORBIDDEN, so name the recovery instead of the
+        // password-form "check your credentials" advice extractMatrixErrorMessage
+        // returns. Other 403s (e.g. M_USER_DEACTIVATED) fall through — telling a
+        // deactivated user to mint a fresh link would just loop them.
         this.error = `This sign-in link has expired or was already used. Get a new one and try again.`;
       } else if (isMatrixError(e)) {
         this.error = `Sign-in failed. ${extractMatrixErrorMessage(e)}`;

--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -45,7 +45,7 @@ export default class Login extends Component<Signature> {
   <template>
     {{#if this.exchangingSsoToken}}
       <div class='centered-loading' data-test-sso-exchanging>
-        <span class='loading-title'>Signing you in with Google</span>
+        <span class='loading-title'>Signing you in…</span>
         <LoadingIndicator class='loading-spinner' />
         {{#if this.error}}
           <div class='error' data-test-login-error>{{this.error}}</div>
@@ -344,9 +344,9 @@ export default class Login extends Component<Signature> {
       });
     } catch (e: any) {
       if (isMatrixError(e)) {
-        this.error = `Google sign-in failed. ${extractMatrixErrorMessage(e)}`;
+        this.error = `Sign-in failed. ${extractMatrixErrorMessage(e)}`;
       } else {
-        this.error = `Google sign-in failed: ${e.message}`;
+        this.error = `Sign-in failed: ${e.message}`;
       }
       // Fall back to the password form so the user can recover.
       this.exchangingSsoToken = false;

--- a/packages/host/tests/integration/components/matrix/login-test.gts
+++ b/packages/host/tests/integration/components/matrix/login-test.gts
@@ -134,6 +134,9 @@ module('Integration | Component | matrix/login', function (hooks) {
       assert
         .dom('[data-test-sso-exchanging]')
         .exists('Signing-in placeholder visible during SSO exchange');
+      // The exchange placeholder is shared by every ?loginToken= flow (Google
+      // and CLI hand-off alike), so its title must not name a provider.
+      assert.dom('[data-test-sso-exchanging]').doesNotContainText('Google');
       assert
         .dom('[data-test-login-form]')
         .doesNotExist('Password form hidden during SSO exchange');
@@ -177,6 +180,30 @@ module('Integration | Component | matrix/login', function (hooks) {
       .dom('[data-test-login-form]')
       .exists('Password form is restored after the failed SSO exchange');
     assert.dom('[data-test-login-error]').includesText('Sign-in failed');
+  });
+
+  test('?loginToken= exchange failing with a 403 explains the link is spent rather than blaming credentials', async function (assert) {
+    window.location.href = '/?loginToken=stale';
+
+    setLoginWithTokenInterceptor(() =>
+      Promise.reject({
+        httpStatus: 403,
+        errcode: 'M_FORBIDDEN',
+        data: { errcode: 'M_FORBIDDEN', error: 'Invalid login token' },
+      }),
+    );
+
+    await render(<template><Login @setMode={{noop}} /></template>);
+
+    assert
+      .dom('[data-test-login-form]')
+      .exists('Password form is restored after the failed SSO exchange');
+    assert
+      .dom('[data-test-login-error]')
+      .includesText('This sign-in link has expired or was already used');
+    assert
+      .dom('[data-test-login-error]')
+      .doesNotIncludeText('check your credentials');
   });
 
   test('?loginToken= falls back to the password form when start() fails after a successful token exchange', async function (assert) {

--- a/packages/host/tests/integration/components/matrix/login-test.gts
+++ b/packages/host/tests/integration/components/matrix/login-test.gts
@@ -206,6 +206,28 @@ module('Integration | Component | matrix/login', function (hooks) {
       .doesNotIncludeText('check your credentials');
   });
 
+  test('?loginToken= exchange failing with a non-M_FORBIDDEN 403 does not claim the link expired', async function (assert) {
+    window.location.href = '/?loginToken=deactivated';
+
+    setLoginWithTokenInterceptor(() =>
+      Promise.reject({
+        httpStatus: 403,
+        errcode: 'M_USER_DEACTIVATED',
+        data: {
+          errcode: 'M_USER_DEACTIVATED',
+          error: 'This account has been deactivated',
+        },
+      }),
+    );
+
+    await render(<template><Login @setMode={{noop}} /></template>);
+
+    assert.dom('[data-test-login-error]').includesText('Sign-in failed');
+    assert
+      .dom('[data-test-login-error]')
+      .doesNotIncludeText('This sign-in link has expired or was already used');
+  });
+
   test('?loginToken= falls back to the password form when start() fails after a successful token exchange', async function (assert) {
     window.location.href = '/?loginToken=abc123';
 

--- a/packages/host/tests/integration/components/matrix/login-test.gts
+++ b/packages/host/tests/integration/components/matrix/login-test.gts
@@ -207,9 +207,7 @@ module('Integration | Component | matrix/login', function (hooks) {
       assert
         .dom('[data-test-login-form]')
         .exists('Password form is restored after the failed start()');
-      assert
-        .dom('[data-test-login-error]')
-        .includesText('Sign-in failed');
+      assert.dom('[data-test-login-error]').includesText('Sign-in failed');
     } finally {
       matrixService.start = originalStart;
     }

--- a/packages/host/tests/integration/components/matrix/login-test.gts
+++ b/packages/host/tests/integration/components/matrix/login-test.gts
@@ -176,7 +176,7 @@ module('Integration | Component | matrix/login', function (hooks) {
     assert
       .dom('[data-test-login-form]')
       .exists('Password form is restored after the failed SSO exchange');
-    assert.dom('[data-test-login-error]').includesText('Google sign-in failed');
+    assert.dom('[data-test-login-error]').includesText('Sign-in failed');
   });
 
   test('?loginToken= falls back to the password form when start() fails after a successful token exchange', async function (assert) {
@@ -209,7 +209,7 @@ module('Integration | Component | matrix/login', function (hooks) {
         .exists('Password form is restored after the failed start()');
       assert
         .dom('[data-test-login-error]')
-        .includesText('Google sign-in failed');
+        .includesText('Sign-in failed');
     } finally {
       matrixService.start = originalStart;
     }

--- a/packages/matrix/tests/google-sso.spec.ts
+++ b/packages/matrix/tests/google-sso.spec.ts
@@ -78,9 +78,9 @@ test.describe('Google sign-in (mock OIDC)', () => {
   test('a returning user with a matching verified email is linked to their existing account', async ({
     page,
   }) => {
-    // The Google button only renders when the flag is on (host dev build) AND
-    // Synapse advertises the oidc-google IdP, so signing in through it already
-    // exercises the login-flow detection.
+    // The Google button only renders when Synapse advertises the oidc-google
+    // IdP in its login flows, so signing in through it already exercises the
+    // login-flow detection.
     await signInWithGoogle(page, {
       sub: subjectFor(username),
       email: userEmail,

--- a/packages/matrix/tests/login.spec.ts
+++ b/packages/matrix/tests/login.spec.ts
@@ -403,7 +403,7 @@ test.describe('Login', () => {
     ).toHaveCount(0);
     await page.locator('[data-test-login-btn]').click();
     await expect(page.locator('[data-test-login-error]')).toContainText(
-      'Sign in failed. Please check your credentials and try again',
+      'Sign-in failed. Please check your credentials and try again',
     );
 
     await page.locator('[data-test-password-field]').fill(password);


### PR DESCRIPTION
## Background and Goal

The `?loginToken=` exchange path in the host login component (`packages/host/app/components/matrix/login.gts`) was originally built only for the Google SSO callback, and its copy still said "Google". [`boxel browse`](https://github.com/cardstack/boxel/pull/5859) now drives that **same** path with a CLI-minted Matrix login token — no Google involved — so "Signing you in with Google" / "Google sign-in failed" were inaccurate for that flow.

The host can't distinguish the two flows (both arrive as `?loginToken=<token>` with the same URL shape), so rather than branch on source, this makes the shared copy source-neutral:

- Loading title: `Signing you in with Google` → `Signing you in…`
- Exchange-failure error: `Google sign-in failed…` → `Sign-in failed…`

## Follow-up fixes from review

- **403 gets a source-neutral, actionable message.** A login token is single-use and short-lived, so the likely failure on the CLI hand-off is a 403 (spent/expired link). `extractMatrixErrorMessage` renders every 403 as "Please check your credentials and try again." — password-form advice for someone who typed no credentials. The exchange `catch` now special-cases 403 with "This sign-in link has expired or was already used. Get a new one and try again."
- **The "we'll create your Boxel account" subtitle is suppressed on the login-token path.** A failed exchange falls back to the password form; where the homeserver advertises `oidc-google`, that fallback would otherwise show the create-account subtitle to a user who already has an account (the CLI minted the token from their existing session). The `Continue with Google` button is unchanged — it's an offer, not a claim about how you arrived.
- **Consistent spelling.** The exchange path and the password path now both use "Sign-in failed" (previously the password path used "Sign in failed").

## Tests

- The two existing `?loginToken=` integration tests have their error-text assertions updated to match.
- Added an integration test that a 403 exchange failure shows the expired-link message and not the "check your credentials" advice.
- The exchanging placeholder now has an assertion that its title names no provider, guarding the shared path against provider-name drift.
- Updated the password-path Playwright assertion in `packages/matrix/tests/login.spec.ts` to the shared spelling.
