### PR TITLE
Host: consume ?loginToken when already logged in to switch accounts

### DIFF
--- a/packages/host/app/components/matrix/account-switch-failed.gts
+++ b/packages/host/app/components/matrix/account-switch-failed.gts
@@ -1,0 +1,57 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { on } from '@ember/modifier';
+
+import { Button } from '@cardstack/boxel-ui/components';
+
+import AuthContainer from './auth-container';
+
+interface Signature {
+  Args: {
+    onBackToHome: () => void;
+  };
+}
+
+// Shown when a `?loginToken` account switch fails before any teardown (the token
+// was expired or already spent). The current session is untouched, so this is a
+// non-destructive dead end with a single recovery action. Mirrors the auth
+// status screens (login "signing you in", register "setting up") — same dark
+// AuthContainer shell, centered title + message — ending in a text link rather
+// than a spinner or a filled button.
+const AccountSwitchFailed: TemplateOnlyComponent<Signature> = <template>
+  <AuthContainer>
+    <div class='centered' data-test-account-switch-failed>
+      <span class='title'>Couldn't switch accounts</span>
+      <p class='message'>The sign-in link has expired or was already used. You
+        haven't been signed out — return home to keep using your current
+        account.</p>
+      <Button
+        @kind='link-primary'
+        @size='extra-small'
+        data-test-account-switch-back-home
+        {{on 'click' @onBackToHome}}
+      >Back to home</Button>
+    </div>
+
+    <style scoped>
+      .centered {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--boxel-sp-sm);
+        text-align: center;
+      }
+      .title {
+        font: 600 var(--boxel-font-md);
+        color: var(--foreground);
+      }
+      .message {
+        margin: 0 0 var(--boxel-sp-xs);
+        color: var(--foreground);
+        font: 500 var(--boxel-font-sm);
+        line-height: 1.4;
+      }
+    </style>
+  </AuthContainer>
+</template>;
+
+export default AccountSwitchFailed;

--- a/packages/host/app/components/matrix/account-switch-failed.gts
+++ b/packages/host/app/components/matrix/account-switch-failed.gts
@@ -31,27 +31,27 @@ const AccountSwitchFailed: TemplateOnlyComponent<Signature> = <template>
         {{on 'click' @onBackToHome}}
       >Back to home</Button>
     </div>
-
-    <style scoped>
-      .centered {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: var(--boxel-sp-sm);
-        text-align: center;
-      }
-      .title {
-        font: 600 var(--boxel-font-md);
-        color: var(--foreground);
-      }
-      .message {
-        margin: 0 0 var(--boxel-sp-xs);
-        color: var(--foreground);
-        font: 500 var(--boxel-font-sm);
-        line-height: 1.4;
-      }
-    </style>
   </AuthContainer>
+
+  <style scoped>
+    .centered {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--boxel-sp-sm);
+      text-align: center;
+    }
+    .title {
+      font: 600 var(--boxel-font-md);
+      color: var(--foreground);
+    }
+    .message {
+      margin: 0 0 var(--boxel-sp-xs);
+      color: var(--foreground);
+      font: 500 var(--boxel-font-sm);
+      line-height: 1.4;
+    }
+  </style>
 </template>;
 
 export default AccountSwitchFailed;

--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -27,6 +27,11 @@ import {
 } from '@cardstack/host/lib/matrix-utils';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
+import {
+  consumeLoginTokenFromUrl,
+  peekLoginToken,
+} from '@cardstack/host/utils/login-token';
+
 import AuthButton from './auth-button';
 import AuthFormField from './auth-form-field';
 
@@ -244,7 +249,7 @@ export default class Login extends Component<Signature> {
     // loginToken — the task itself is async (awaits matrix-sdk load + token
     // exchange + matrixService.start), and without this the password form
     // would flash for ~1-2s between mount and the auth flip.
-    if (new URLSearchParams(window.location.search).has('loginToken')) {
+    if (peekLoginToken()) {
       this.exchangingSsoToken = true;
       this.startedFromLoginToken = true;
     }
@@ -327,20 +332,12 @@ export default class Login extends Component<Signature> {
   });
 
   private consumeSsoLoginToken = restartableTask(async () => {
-    let params = new URLSearchParams(window.location.search);
-    let token = params.get('loginToken');
+    // Clears the token from the URL so a refresh doesn't re-trigger the
+    // single-use exchange.
+    let token = consumeLoginTokenFromUrl();
     if (!token) {
       return;
     }
-    // Clear the token from the URL so a refresh doesn't re-trigger the
-    // single-use exchange.
-    params.delete('loginToken');
-    let search = params.toString();
-    let newUrl =
-      window.location.pathname +
-      (search ? `?${search}` : '') +
-      window.location.hash;
-    window.history.replaceState({}, '', newUrl);
 
     try {
       let auth = await this.matrixService.loginWithSsoToken(token);

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -1,5 +1,7 @@
 import { registerDestructor } from '@ember/destroyable';
+import { action } from '@ember/object';
 import type Owner from '@ember/owner';
+import type RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
 
 import { buildWaiter } from '@ember/test-waiters';
@@ -14,6 +16,8 @@ import FromElseWhere from 'ember-elsewhere/components/from-elsewhere';
 
 import { provide } from 'ember-provide-consume-context';
 
+import stringify from 'safe-stable-stringify';
+
 import { or, not } from '@cardstack/boxel-ui/helpers';
 
 import {
@@ -26,6 +30,7 @@ import {
   type Query,
 } from '@cardstack/runtime-common';
 
+import AccountSwitchFailed from '@cardstack/host/components/matrix/account-switch-failed';
 import Auth from '@cardstack/host/components/matrix/auth';
 
 import CodeSubmode from '@cardstack/host/components/operator-mode/code-submode';
@@ -48,6 +53,7 @@ import CreateListingModal from './create-listing-modal';
 import type CardService from '../../services/card-service';
 import type MatrixService from '../../services/matrix-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
+import type { SerializedState as OperatorModeSerializedState } from '../../services/operator-mode-state-service';
 import type RealmServerService from '../../services/realm-server';
 import type StoreService from '../../services/store';
 import type ToolService from '../../services/tool-service';
@@ -70,6 +76,7 @@ export default class OperatorModeContainer extends Component<Signature> {
   @service declare realmServer: RealmServerService;
   @service declare private toolService: ToolService;
   @service declare private store: StoreService;
+  @service declare private router: RouterService;
 
   constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
@@ -77,6 +84,24 @@ export default class OperatorModeContainer extends Component<Signature> {
 
     registerDestructor(this, () => {
       this.operatorModeStateService.clearStacks();
+    });
+  }
+
+  // Leave the "couldn't switch accounts" page: navigate to the workspace
+  // chooser, which re-runs the index model hook and boots the still-intact
+  // current account (it was never torn down on a redeem failure). The model hook
+  // clears `accountSwitchFailed` once booted — clearing it here instead would
+  // flash the login form while the boot is still in flight.
+  @action
+  private backToHome() {
+    this.router.transitionTo('index-root', {
+      queryParams: {
+        operatorModeState: stringify({
+          stacks: [],
+          submode: Submodes.Interact,
+          workspaceChooserOpened: true,
+        } as OperatorModeSerializedState),
+      },
     });
   }
   @provide(GetCardContextName)
@@ -186,6 +211,10 @@ export default class OperatorModeContainer extends Component<Signature> {
       <FromElseWhere @name='modal-elsewhere' />
 
       {{#if
+        this.operatorModeStateService.operatorModeController.accountSwitchFailed
+      }}
+        <AccountSwitchFailed @onBackToHome={{this.backToHome}} />
+      {{else if
         (or
           (not this.matrixService.isLoggedIn)
           this.matrixService.isInitializingNewUser

--- a/packages/host/app/controllers/index.ts
+++ b/packages/host/app/controllers/index.ts
@@ -19,6 +19,11 @@ export default class IndexController extends Controller {
   @tracked sid: string | null = null;
   @tracked clientSecret: string | null = null;
   @tracked debug = false;
+  // Set when a `?loginToken` account switch fails before any teardown (the token
+  // was expired/spent), so the operator-mode container shows the
+  // "couldn't switch accounts" page instead of the current workspace. Not a
+  // query param — it is transient in-app state, cleared by "Back to home".
+  @tracked accountSwitchFailed = false;
   // Shows per-message and per-session AI token counts in the assistant
   // panel. On by default in development (pass showTokens=false to hide);
   // opt-in everywhere else. The default doubles as the query param's

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -30,6 +30,7 @@ import type { SerializedState as OperatorModeSerializedState } from '@cardstack/
 import type RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 import type StoreService from '@cardstack/host/services/store';
+import { consumeLoginTokenFromUrl } from '@cardstack/host/utils/login-token';
 
 const { hostsOwnAssets } = ENV;
 
@@ -143,6 +144,23 @@ export default class Card extends Route {
           `[login-diag] index route post-login recovery did not restore session: ` +
             JSON.stringify(this.matrixService.loginReadinessDebug),
         );
+      }
+    }
+
+    // A loginToken while already logged in means "switch accounts" (`boxel
+    // browse --profile B` against a browser signed in as A). When logged out,
+    // the <Login> component consumes the token instead, so only consume it here
+    // when logged in. Strip the token from the URL first: logout() ends in a
+    // router.transitionTo that re-enters this model hook, and the already-clean
+    // URL makes that re-entry a no-op. A failure after logout leaves the user
+    // logged out on the login form — acceptable, the token is single-use.
+    if (this.matrixService.isLoggedIn) {
+      let loginToken = consumeLoginTokenFromUrl();
+      if (loginToken) {
+        await this.matrixService.logout();
+        let auth = await this.matrixService.loginWithSsoToken(loginToken);
+        await this.matrixService.start({ auth, refreshRoutes: true });
+        return;
       }
     }
 

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -132,6 +132,13 @@ export default class Card extends Route {
     // switch entirely. When there is no stored session the browser is logged
     // out, so <Login> consumes the token instead; we don't handle that here.
     let loginToken = peekLoginToken();
+    if (loginToken) {
+      // `persistedUserId` reads the storage handle that `loadState` assigns
+      // (behind an awaited `requestStorageAccess()` on the iframe path). Await
+      // `ready` before gating on it, or a cold load reads `undefined` and falls
+      // through to booting the stored session — the behavior this block removes.
+      await this.matrixService.ready;
+    }
     if (loginToken && this.matrixService.persistedUserId) {
       consumeLoginTokenFromUrl(); // single-use: strip up front so a refresh can't retry
       let didStart = this.didMatrixServiceStart;
@@ -143,15 +150,14 @@ export default class Card extends Route {
         await this.matrixService.switchAccount(loginToken);
         return;
       } catch (e) {
-        // Redemption failed before any teardown, so the current session is
-        // untouched. Restore the flag: if the service hadn't started yet the
-        // boot below establishes the current account; if it had, skip the
-        // redundant re-boot and stay signed in as it.
+        // A redemption failure throws before any teardown, so the current
+        // account is intact. A later failure (logout/start) has already torn
+        // that account down and persisted the incoming one. Either way, restore
+        // the flag and fall through: the boot below re-establishes whichever
+        // account is persisted now — recovering the switch or landing on the
+        // login form.
         this.didMatrixServiceStart = didStart;
-        console.error(
-          'Error switching accounts via loginToken; staying signed in',
-          e,
-        );
+        console.error('Error consuming loginToken; falling back to boot', e);
       }
     }
 

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -30,7 +30,10 @@ import type { SerializedState as OperatorModeSerializedState } from '@cardstack/
 import type RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 import type StoreService from '@cardstack/host/services/store';
-import { consumeLoginTokenFromUrl } from '@cardstack/host/utils/login-token';
+import {
+  consumeLoginTokenFromUrl,
+  peekLoginToken,
+} from '@cardstack/host/utils/login-token';
 
 const { hostsOwnAssets } = ENV;
 
@@ -121,6 +124,37 @@ export default class Card extends Route {
 
     let { operatorModeState, cardPath } = params;
 
+    // Account switch: a loginToken next to a session stored in this browser
+    // means "switch to the token's account" (`boxel browse --profile B` against
+    // a browser signed in as A). Run this BEFORE booting the stored session — a
+    // days-old session may be revoked server-side, and booting it first would
+    // fail, drop the unregistered token in logout()'s transition, and skip the
+    // switch entirely. When there is no stored session the browser is logged
+    // out, so <Login> consumes the token instead; we don't handle that here.
+    let loginToken = peekLoginToken();
+    if (loginToken && this.matrixService.persistedUserId) {
+      consumeLoginTokenFromUrl(); // single-use: strip up front so a refresh can't retry
+      let didStart = this.didMatrixServiceStart;
+      try {
+        // switchAccount boots the new account with refreshRoutes, which
+        // re-enters this hook; set the one-shot flag first so that re-run skips
+        // the boot below (the new session is already up).
+        this.didMatrixServiceStart = true;
+        await this.matrixService.switchAccount(loginToken);
+        return;
+      } catch (e) {
+        // Redemption failed before any teardown, so the current session is
+        // untouched. Restore the flag: if the service hadn't started yet the
+        // boot below establishes the current account; if it had, skip the
+        // redundant re-boot and stay signed in as it.
+        this.didMatrixServiceStart = didStart;
+        console.error(
+          'Error switching accounts via loginToken; staying signed in',
+          e,
+        );
+      }
+    }
+
     if (!this.didMatrixServiceStart) {
       await this.matrixService.ready;
       await this.matrixService.start();
@@ -144,36 +178,6 @@ export default class Card extends Route {
           `[login-diag] index route post-login recovery did not restore session: ` +
             JSON.stringify(this.matrixService.loginReadinessDebug),
         );
-      }
-    }
-
-    // A loginToken while already logged in means "switch accounts" (`boxel
-    // browse --profile B` against a browser signed in as A). When logged out,
-    // the <Login> component consumes the token instead, so only consume it
-    // here when logged in. The token is stripped from the URL up front: it is
-    // single-use, and any transition would drop the unregistered param.
-    //
-    // logout() skips its index-root transition so this transition stays
-    // alive and the URL keeps the handoff's params. On success, the
-    // refreshRoutes re-run of this hook resolves the handoff's cardPath deep
-    // link for the new session (no workspace-chooser operatorModeState has
-    // been written over it). On a failed exchange — the token is expired or
-    // already spent — the session is already torn down, so fall through to
-    // the logged-out branch below and render the login form.
-    if (this.matrixService.isLoggedIn) {
-      let loginToken = consumeLoginTokenFromUrl();
-      if (loginToken) {
-        await this.matrixService.logout({ skipIndexTransition: true });
-        try {
-          let auth = await this.matrixService.loginWithSsoToken(loginToken);
-          await this.matrixService.start({ auth, refreshRoutes: true });
-          return;
-        } catch (e) {
-          console.error(
-            'Error switching accounts via loginToken; showing login form',
-            e,
-          );
-        }
       }
     }
 

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -149,18 +149,31 @@ export default class Card extends Route {
 
     // A loginToken while already logged in means "switch accounts" (`boxel
     // browse --profile B` against a browser signed in as A). When logged out,
-    // the <Login> component consumes the token instead, so only consume it here
-    // when logged in. Strip the token from the URL first: logout() ends in a
-    // router.transitionTo that re-enters this model hook, and the already-clean
-    // URL makes that re-entry a no-op. A failure after logout leaves the user
-    // logged out on the login form — acceptable, the token is single-use.
+    // the <Login> component consumes the token instead, so only consume it
+    // here when logged in. The token is stripped from the URL up front: it is
+    // single-use, and any transition would drop the unregistered param.
+    //
+    // logout() skips its index-root transition so this transition stays
+    // alive and the URL keeps the handoff's params. On success, the
+    // refreshRoutes re-run of this hook resolves the handoff's cardPath deep
+    // link for the new session (no workspace-chooser operatorModeState has
+    // been written over it). On a failed exchange — the token is expired or
+    // already spent — the session is already torn down, so fall through to
+    // the logged-out branch below and render the login form.
     if (this.matrixService.isLoggedIn) {
       let loginToken = consumeLoginTokenFromUrl();
       if (loginToken) {
-        await this.matrixService.logout();
-        let auth = await this.matrixService.loginWithSsoToken(loginToken);
-        await this.matrixService.start({ auth, refreshRoutes: true });
-        return;
+        await this.matrixService.logout({ skipIndexTransition: true });
+        try {
+          let auth = await this.matrixService.loginWithSsoToken(loginToken);
+          await this.matrixService.start({ auth, refreshRoutes: true });
+          return;
+        } catch (e) {
+          console.error(
+            'Error switching accounts via loginToken; showing login form',
+            e,
+          );
+        }
       }
     }
 

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -23,6 +23,7 @@ import type BillingService from '@cardstack/host/services/billing-service';
 import type CardService from '@cardstack/host/services/card-service';
 import type HostModeService from '@cardstack/host/services/host-mode-service';
 import type HostModeStateService from '@cardstack/host/services/host-mode-state-service';
+import { AccountSwitchError } from '@cardstack/host/services/matrix-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import type NetworkService from '@cardstack/host/services/network';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
@@ -142,6 +143,8 @@ export default class Card extends Route {
     if (loginToken && this.matrixService.persistedUserId) {
       consumeLoginTokenFromUrl(); // single-use: strip up front so a refresh can't retry
       let didStart = this.didMatrixServiceStart;
+      let controller = this.operatorModeStateService.operatorModeController;
+      controller.accountSwitchFailed = false;
       try {
         // switchAccount boots the new account with refreshRoutes, which
         // re-enters this hook; set the one-shot flag first so that re-run skips
@@ -150,13 +153,21 @@ export default class Card extends Route {
         await this.matrixService.switchAccount(loginToken);
         return;
       } catch (e) {
-        // A redemption failure throws before any teardown, so the current
-        // account is intact. A later failure (logout/start) has already torn
-        // that account down and persisted the incoming one. Either way, restore
-        // the flag and fall through: the boot below re-establishes whichever
-        // account is persisted now — recovering the switch or landing on the
-        // login form.
         this.didMatrixServiceStart = didStart;
+        if (e instanceof AccountSwitchError && e.phase === 'redeem') {
+          // The token was bad/expired and nothing was torn down, so the current
+          // account is intact. Show the "couldn't switch accounts" page instead
+          // of booting; its "Back to home" recovers into the current account.
+          controller.accountSwitchFailed = true;
+          console.error(
+            'Account switch failed before teardown; showing failure page',
+            e,
+          );
+          return;
+        }
+        // A post-teardown (boot) or unknown failure means the previous account
+        // is already gone. Fall through: the boot below re-establishes whichever
+        // account is persisted now — recovering the switch or landing on login.
         console.error('Error consuming loginToken; falling back to boot', e);
       }
     }
@@ -186,6 +197,13 @@ export default class Card extends Route {
         );
       }
     }
+
+    // Any path that reaches the boot has moved past a prior failed switch (the
+    // failure return is above this point), so clear the flag. "Back to home"
+    // relies on this: it navigates here without clearing the flag itself, so the
+    // failure page stays up through the boot (the loading template covers it)
+    // rather than flashing the login form, and clears only once we're booted.
+    this.operatorModeStateService.operatorModeController.accountSwitchFailed = false;
 
     if (!this.matrixService.isLoggedIn) {
       if (isTesting()) {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -708,8 +708,25 @@ export default class MatrixService extends Service {
   // so the caller owns the navigation that follows and must not have its
   // in-flight transition aborted (nor the URL's deep-link params overwritten
   // with the workspace-chooser state).
-  async logout(opts?: { skipIndexTransition?: true }) {
-    let client = this._client;
+  async logout(opts?: {
+    skipIndexTransition?: true;
+    serverLogoutAuth?: LoginResponse;
+  }) {
+    // Which session to revoke server-side, decoupled from `this._client`. During
+    // an account switch the live client has already been rewritten to the
+    // incoming account's token by loginWithToken(), and the outgoing account was
+    // never booted here — so the only way to log it out server-side is a
+    // throwaway client built from its captured auth. Plain createClient has no
+    // side effects (no setClient/saveAuth) and logout(true) on a never-started
+    // client just POSTs /logout.
+    let client = opts?.serverLogoutAuth
+      ? this.matrixSDK.createClient({
+          baseUrl: matrixURL,
+          accessToken: opts.serverLogoutAuth.access_token,
+          userId: opts.serverLogoutAuth.user_id,
+          deviceId: opts.serverLogoutAuth.device_id,
+        })
+      : this._client;
     let didResetState = false;
     try {
       // Logout should synchronously move the app into a logged-out state.
@@ -766,6 +783,27 @@ export default class MatrixService extends Service {
         this.resetState();
       }
     }
+  }
+
+  // A loginToken next to a session stored in this browser means "switch to the
+  // token's account" (`boxel browse --profile B` against a browser signed in as
+  // A). Ordered so a bad/expired token is non-destructive:
+  //   snapshot A → redeem B (validates the token) → tear down A (revoking it
+  //   server-side via the snapshot) → boot B.
+  // Redemption runs first, so a dead token throws before any teardown and the
+  // caller stays signed in as A. The snapshot is taken up front because
+  // loginWithSsoToken() rewrites the live client's access token in place and
+  // logout() clears persisted auth — this is the only point A's session is
+  // recoverable for a server-side logout.
+  async switchAccount(loginToken: string): Promise<void> {
+    await this.ready;
+    let previousAuth = this.getAuth();
+    let auth = await this.loginWithSsoToken(loginToken);
+    await this.logout({
+      skipIndexTransition: true,
+      serverLogoutAuth: previousAuth,
+    });
+    await this.start({ auth, refreshRoutes: true });
   }
 
   get isInitializingNewUser() {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -798,20 +798,22 @@ export default class MatrixService extends Service {
   async switchAccount(loginToken: string): Promise<void> {
     await this.ready;
     let previousAuth = this.getAuth();
+    if (!previousAuth) {
+      throw new Error(
+        `switchAccount requires a persisted session to switch away from`,
+      );
+    }
     let auth = await this.loginWithSsoToken(loginToken);
     await this.logout({
       skipIndexTransition: true,
       serverLogoutAuth: previousAuth,
     });
-    // The realm-server and per-realm session tokens carry the outgoing
-    // account's session-room claim, and logout()/clearLocalStorage leave them
-    // in place. Forget them so the incoming account mints its own on boot
-    // rather than reusing them and trying to join a session room it was never
-    // invited to (a 403 that fails the boot). setClient() during start()
-    // re-reads these keys, so clearing them here is enough. Mirrors
-    // forgetPersistedSession, which documents this hazard.
-    window.localStorage.removeItem(RealmServerSessionLocalStorageKey);
-    window.localStorage.removeItem(SessionLocalStorageKey);
+    // logout()/clearLocalStorage leave the outgoing account's realm session
+    // tokens; forget them so the incoming account mints its own on boot rather
+    // than reusing them and trying to join a session room it was never invited
+    // to (a 403 that fails the boot). setClient() during start() re-reads these
+    // keys, so clearing them here is enough.
+    this.forgetRealmSessionTokens();
     await this.start({ auth, refreshRoutes: true });
   }
 
@@ -3165,13 +3167,19 @@ export default class MatrixService extends Service {
   // (personal realm, realm auth) stay put; only this browser's local link to
   // the device is forgotten.
   //
-  // Storage-only, and all three keys of it. The realm tokens are persisted
-  // apart from the Matrix session, and a session-room claim inside the
-  // realm-server token is the identity a later realm-auth handshake adopts:
-  // leaving it behind hands the next account a session room belonging to this
-  // one, which it is not invited to and cannot join.
+  // Storage-only, and all three keys of it.
   forgetPersistedSession() {
     this.clearAuth();
+    this.forgetRealmSessionTokens();
+  }
+
+  // The realm-server and per-realm session tokens are persisted apart from the
+  // Matrix session, and a session-room claim inside the realm-server token is
+  // the identity a later realm-auth handshake adopts: leaving a previous
+  // account's keys behind hands the next account a session room belonging to
+  // that one, which it is not invited to and cannot join. Forget them whenever
+  // the persisted account changes.
+  private forgetRealmSessionTokens() {
     window.localStorage.removeItem(RealmServerSessionLocalStorageKey);
     window.localStorage.removeItem(SessionLocalStorageKey);
   }

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -703,7 +703,12 @@ export default class MatrixService extends Service {
     ]);
   }
 
-  async logout() {
+  // `skipIndexTransition` suppresses the index-root transition at the end: the
+  // account-switch flow logs out only to immediately establish a new session,
+  // so the caller owns the navigation that follows and must not have its
+  // in-flight transition aborted (nor the URL's deep-link params overwritten
+  // with the workspace-chooser state).
+  async logout(opts?: { skipIndexTransition?: true }) {
     let client = this._client;
     let didResetState = false;
     try {
@@ -736,20 +741,22 @@ export default class MatrixService extends Service {
       this.resetState();
       didResetState = true;
       await client?.logout(true);
-      // when user logs out we transition them back to an empty stack with the
-      // workspace chooser open. this way we don't inadvertently leak private
-      // card id's in the URL
-      this.router.transitionTo('index-root', {
-        queryParams: {
-          operatorModeState: stringify({
-            stacks: [],
-            submode: Submodes.Interact,
-            workspaceChooserOpened: true,
-          } as OperatorModeSerializedState),
-          sid: null,
-          clientSecret: null,
-        },
-      });
+      if (!opts?.skipIndexTransition) {
+        // when user logs out we transition them back to an empty stack with
+        // the workspace chooser open. this way we don't inadvertently leak
+        // private card id's in the URL
+        this.router.transitionTo('index-root', {
+          queryParams: {
+            operatorModeState: stringify({
+              stacks: [],
+              submode: Submodes.Interact,
+              workspaceChooserOpened: true,
+            } as OperatorModeSerializedState),
+            sid: null,
+            clientSecret: null,
+          },
+        });
+      }
     } catch (e) {
       console.log('Error logging out of Matrix', e);
     } finally {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -803,6 +803,15 @@ export default class MatrixService extends Service {
       skipIndexTransition: true,
       serverLogoutAuth: previousAuth,
     });
+    // The realm-server and per-realm session tokens carry the outgoing
+    // account's session-room claim, and logout()/clearLocalStorage leave them
+    // in place. Forget them so the incoming account mints its own on boot
+    // rather than reusing them and trying to join a session room it was never
+    // invited to (a 403 that fails the boot). setClient() during start()
+    // re-reads these keys, so clearing them here is enough. Mirrors
+    // forgetPersistedSession, which documents this hazard.
+    window.localStorage.removeItem(RealmServerSessionLocalStorageKey);
+    window.localStorage.removeItem(SessionLocalStorageKey);
     await this.start({ auth, refreshRoutes: true });
   }
 

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -175,6 +175,18 @@ const realmEventsLogger = logger('realm:events');
 // even a re-entrant boot; keeping the most recent dozen is ample.
 const MAX_POST_LOGIN_TRANSITIONS = 12;
 
+// Thrown by switchAccount so the caller can tell a non-destructive redemption
+// failure (the outgoing account is untouched) from a boot failure that happens
+// after the outgoing account has already been torn down and revoked.
+export class AccountSwitchError extends Error {
+  constructor(
+    readonly phase: 'redeem' | 'boot',
+    readonly originalError: unknown,
+  ) {
+    super(`account switch failed during ${phase}`);
+  }
+}
+
 export default class MatrixService extends Service {
   @service declare private loaderService: LoaderService;
   @service declare private loggerService: LoggerService;
@@ -803,7 +815,15 @@ export default class MatrixService extends Service {
         `switchAccount requires a persisted session to switch away from`,
       );
     }
-    let auth = await this.loginWithSsoToken(loginToken);
+    let auth: LoginResponse;
+    try {
+      auth = await this.loginWithSsoToken(loginToken);
+    } catch (e) {
+      // Redemption failed before any teardown, so the current account is still
+      // intact and recoverable. Tagged 'redeem' so the caller can show a
+      // non-destructive failure page rather than falling to the login form.
+      throw new AccountSwitchError('redeem', e);
+    }
     await this.logout({
       skipIndexTransition: true,
       serverLogoutAuth: previousAuth,
@@ -814,7 +834,14 @@ export default class MatrixService extends Service {
     // to (a 403 that fails the boot). setClient() during start() re-reads these
     // keys, so clearing them here is enough.
     this.forgetRealmSessionTokens();
-    await this.start({ auth, refreshRoutes: true });
+    try {
+      await this.start({ auth, refreshRoutes: true });
+    } catch (e) {
+      // Boot failed after the previous account was already torn down and
+      // revoked, so it is gone — tagged 'boot' so the caller falls through to
+      // the login form rather than offering "back to your account".
+      throw new AccountSwitchError('boot', e);
+    }
   }
 
   get isInitializingNewUser() {

--- a/packages/host/app/templates/loading.gts
+++ b/packages/host/app/templates/loading.gts
@@ -6,10 +6,12 @@ import window from 'ember-window-mock';
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 class Loading extends Component {
-  // Use the dark auth palette when this boot leads to the auth pages: either an
-  // SSO redirect is being consumed (`?loginToken`) or there is no persisted
-  // session, so the user will land on the (dark) login page. A returning user
-  // keeps the purple background, which blends into the operator-mode workspace.
+  // Use the dark auth palette only when there is no persisted session: the user
+  // is logged out and will land on the (dark) login page. A `loginToken`
+  // alongside a persisted session is an account switch that ends in the
+  // workspace, and the logged-out SSO consume has no persisted session anyway —
+  // so "no session" is the whole condition. A returning user keeps the purple
+  // background, which blends into the operator-mode workspace.
   //
   // Read the persisted-session signal straight from localStorage rather than
   // through MatrixService: instantiating that service runs its `cardAPIModule`
@@ -19,10 +21,7 @@ class Loading extends Component {
   // the fallback deps a failed render relies on. The key (`auth`) and source
   // (localStorage) match MatrixService's own `getAuth`.
   private get isAuthBoot() {
-    return (
-      new URLSearchParams(window.location.search).has('loginToken') ||
-      !window.localStorage.getItem('auth')
-    );
+    return !window.localStorage.getItem('auth');
   }
 
   <template>

--- a/packages/host/app/utils/login-token.ts
+++ b/packages/host/app/utils/login-token.ts
@@ -1,0 +1,29 @@
+import window from 'ember-window-mock';
+
+// The `loginToken` handed off by `boxel browse` and by Google SSO is
+// deliberately NOT a registered route query param, so it must be read straight
+// from `window.location.search`. It is single-use, so readers strip it from the
+// URL immediately: a refresh must not re-trigger a spent exchange, and any
+// `transitionTo` in the login flow would otherwise drop the unregistered param.
+
+export function peekLoginToken(): string | null {
+  return new URLSearchParams(window.location.search).get('loginToken');
+}
+
+// Reads the single-use loginToken and strips it from the URL via
+// `history.replaceState`, returning the token (or null if none present).
+export function consumeLoginTokenFromUrl(): string | null {
+  let params = new URLSearchParams(window.location.search);
+  let token = params.get('loginToken');
+  if (!token) {
+    return null;
+  }
+  params.delete('loginToken');
+  let search = params.toString();
+  let newUrl =
+    window.location.pathname +
+    (search ? `?${search}` : '') +
+    window.location.hash;
+  window.history.replaceState({}, '', newUrl);
+  return token;
+}

--- a/packages/host/tests/integration/components/matrix/account-switch-failed-test.gts
+++ b/packages/host/tests/integration/components/matrix/account-switch-failed-test.gts
@@ -1,0 +1,49 @@
+import { click, render } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import AccountSwitchFailed from '@cardstack/host/components/matrix/account-switch-failed';
+
+import { setupRenderingTest } from '../../../helpers/setup';
+
+const noop = () => {};
+
+module(
+  'Integration | Component | matrix/account-switch-failed',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('renders the failure message and a back-to-home link', async function (assert) {
+      await render(
+        <template><AccountSwitchFailed @onBackToHome={{noop}} /></template>,
+      );
+
+      assert.dom('[data-test-account-switch-failed]').exists();
+      assert
+        .dom('[data-test-account-switch-failed]')
+        .containsText("Couldn't switch accounts");
+      assert
+        .dom('[data-test-account-switch-failed]')
+        .containsText("haven't been signed out");
+      assert
+        .dom('[data-test-account-switch-back-home]')
+        .hasText('Back to home');
+    });
+
+    test('invokes onBackToHome when the link is clicked', async function (assert) {
+      let calls = 0;
+      let onBackToHome = () => {
+        calls++;
+      };
+
+      await render(
+        <template>
+          <AccountSwitchFailed @onBackToHome={{onBackToHome}} />
+        </template>,
+      );
+      await click('[data-test-account-switch-back-home]');
+
+      assert.strictEqual(calls, 1, 'onBackToHome fired exactly once');
+    });
+  },
+);

--- a/packages/matrix/tests/login-via-existing-session.spec.ts
+++ b/packages/matrix/tests/login-via-existing-session.spec.ts
@@ -7,6 +7,7 @@ import {
   createSubscribedUserAndLogin,
   setupPermissions,
   assertLoggedIn,
+  assertLoggedOut,
 } from '../helpers/index.ts';
 
 // Exercises Synapse's login_via_existing_session feature (MSC3882), which the
@@ -82,16 +83,72 @@ test.describe('login_via_existing_session', () => {
     await setupPermissions(credentialsB.userId, `${appURL}/`);
     let { login_token } = await mintLoginToken(credentialsB.accessToken);
 
-    // Landing with ?loginToken while logged in as A switches to B — the login
-    // form is never shown.
+    // The switch must go straight from session A to session B: record whether
+    // the password form ever mounts during the hand-off page load.
+    await page.addInitScript(() => {
+      new MutationObserver(() => {
+        if (document.querySelector('[data-test-password-field]')) {
+          (window as { __sawPasswordForm?: boolean }).__sawPasswordForm = true;
+        }
+      }).observe(document.documentElement, { childList: true, subtree: true });
+    });
+
+    // Landing with ?loginToken while logged in as A switches to B.
     await page.goto(`${appURL}?loginToken=${login_token}`);
 
     await assertLoggedIn(page, {
       displayName: usernameB,
       userId: credentialsB.userId,
     });
+    expect(
+      await page.evaluate(
+        () => (window as { __sawPasswordForm?: boolean }).__sawPasswordForm,
+      ),
+      'the login form never appears during the switch',
+    ).toBeFalsy();
     // The single-use token is stripped so a refresh can't re-trigger the
     // (now spent) exchange.
+    expect(new URL(page.url()).searchParams.has('loginToken')).toBe(false);
+  });
+
+  test('a ?loginToken with a cardPath deep-links into the card after switching accounts', async ({
+    page,
+  }) => {
+    await createSubscribedUserAndLogin(page, 'account-switch-deeplink-a');
+
+    let { username: usernameB, credentials: credentialsB } =
+      await createSubscribedUser('account-switch-deeplink-b');
+    await setupPermissions(credentialsB.userId, `${appURL}/`);
+    let { login_token } = await mintLoginToken(credentialsB.accessToken);
+
+    // The shape `boxel browse test/fadhlan --profile B` produces: a login
+    // token plus a deep link into a card.
+    await page.goto(
+      `${appURL}?loginToken=${login_token}&cardPath=test/fadhlan`,
+    );
+
+    // The deep link survives the account switch: the card opens for the new
+    // session instead of the workspace chooser.
+    await expect(
+      page.locator(`[data-test-stack-card="${appURL}/fadhlan"]`),
+    ).toHaveCount(1);
+    await assertLoggedIn(page, {
+      displayName: usernameB,
+      userId: credentialsB.userId,
+    });
+  });
+
+  test('a failed token exchange while logged in lands on the login form', async ({
+    page,
+  }) => {
+    await createSubscribedUserAndLogin(page, 'account-switch-bad-token');
+
+    // The exchange is attempted only after the current session is torn down,
+    // so when the token turns out to be dead (expired, spent, or bogus) the
+    // recovery surface is the login form — not an error screen.
+    await page.goto(`${appURL}?loginToken=not-a-real-token`);
+
+    await assertLoggedOut(page);
     expect(new URL(page.url()).searchParams.has('loginToken')).toBe(false);
   });
 

--- a/packages/matrix/tests/login-via-existing-session.spec.ts
+++ b/packages/matrix/tests/login-via-existing-session.spec.ts
@@ -7,7 +7,6 @@ import {
   createSubscribedUserAndLogin,
   setupPermissions,
   assertLoggedIn,
-  assertLoggedOut,
 } from '../helpers/index.ts';
 
 // Exercises Synapse's login_via_existing_session feature (MSC3882), which the
@@ -138,18 +137,114 @@ test.describe('login_via_existing_session', () => {
     });
   });
 
-  test('a failed token exchange while logged in lands on the login form', async ({
+  test('a failed token exchange while logged in stays signed in as the current account', async ({
     page,
   }) => {
-    await createSubscribedUserAndLogin(page, 'account-switch-bad-token');
+    let userA = await createSubscribedUserAndLogin(
+      page,
+      'account-switch-bad-token',
+    );
+    await assertLoggedIn(page, {
+      displayName: userA.username,
+      userId: userA.credentials.userId,
+    });
 
-    // The exchange is attempted only after the current session is torn down,
-    // so when the token turns out to be dead (expired, spent, or bogus) the
-    // recovery surface is the login form — not an error screen.
+    // The token is validated before any teardown, so a dead token (expired,
+    // spent, or bogus) leaves the current session intact rather than logging
+    // the user out.
     await page.goto(`${appURL}?loginToken=not-a-real-token`);
 
-    await assertLoggedOut(page);
+    await assertLoggedIn(page, {
+      displayName: userA.username,
+      userId: userA.credentials.userId,
+    });
+    // The single-use token is still stripped so a refresh can't re-attempt it.
     expect(new URL(page.url()).searchParams.has('loginToken')).toBe(false);
+  });
+
+  test('a ?loginToken switches accounts even when the stored session is revoked server-side', async ({
+    page,
+  }) => {
+    let userA = await createSubscribedUserAndLogin(
+      page,
+      'account-switch-stale-a',
+    );
+    await assertLoggedIn(page, {
+      displayName: userA.username,
+      userId: userA.credentials.userId,
+    });
+
+    // Revoke A's session server-side while leaving it persisted in the browser:
+    // the days-old-session shape `boxel browse` targets, where the stored auth
+    // is now dead. Booting it first would fail and drop the token, so the switch
+    // has to run ahead of the boot.
+    let accessTokenA = await page.evaluate(
+      () => JSON.parse(localStorage.getItem('auth') ?? '{}').access_token,
+    );
+    let revoke = await fetch(`${getSynapseURL()}/_matrix/client/v3/logout`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessTokenA}` },
+    });
+    expect(revoke.status, 'A’s stored session is revoked server-side').toBe(
+      200,
+    );
+
+    let { username: usernameB, credentials: credentialsB } =
+      await createSubscribedUser('account-switch-stale-b');
+    await setupPermissions(credentialsB.userId, `${appURL}/`);
+    let { login_token } = await mintLoginToken(credentialsB.accessToken);
+
+    await page.goto(`${appURL}?loginToken=${login_token}`);
+
+    await assertLoggedIn(page, {
+      displayName: usernameB,
+      userId: credentialsB.userId,
+    });
+    expect(new URL(page.url()).searchParams.has('loginToken')).toBe(false);
+  });
+
+  test('switching accounts revokes the previous account server-side', async ({
+    page,
+  }) => {
+    let userA = await createSubscribedUserAndLogin(
+      page,
+      'account-switch-revoke-a',
+    );
+    await assertLoggedIn(page, {
+      displayName: userA.username,
+      userId: userA.credentials.userId,
+    });
+
+    // Capture A's access token from the browser before the switch clears it.
+    let accessTokenA = await page.evaluate(
+      () => JSON.parse(localStorage.getItem('auth') ?? '{}').access_token,
+    );
+    let whoamiA = () =>
+      fetch(`${getSynapseURL()}/_matrix/client/v3/account/whoami`, {
+        headers: { Authorization: `Bearer ${accessTokenA}` },
+      });
+    expect(
+      (await whoamiA()).status,
+      'A’s token is valid before the switch',
+    ).toBe(200);
+
+    let { username: usernameB, credentials: credentialsB } =
+      await createSubscribedUser('account-switch-revoke-b');
+    await setupPermissions(credentialsB.userId, `${appURL}/`);
+    let { login_token } = await mintLoginToken(credentialsB.accessToken);
+
+    await page.goto(`${appURL}?loginToken=${login_token}`);
+    await assertLoggedIn(page, {
+      displayName: usernameB,
+      userId: credentialsB.userId,
+    });
+
+    // The switch logs A out server-side even though A was never booted in this
+    // browser session — the tear-down is handed A's captured auth.
+    expect(
+      (await whoamiA()).status,
+      'A’s token is rejected after the switch',
+    ).toBe(401);
   });
 
   test('the minted token carries the configured 2-minute lifetime and exchanges for a new session', async () => {

--- a/packages/matrix/tests/login-via-existing-session.spec.ts
+++ b/packages/matrix/tests/login-via-existing-session.spec.ts
@@ -12,8 +12,10 @@ import {
 // Exercises Synapse's login_via_existing_session feature (MSC3882), which the
 // test homeserver config enables. A client holding an access token mints a
 // short-lived, single-use login token and hands a session off to the browser
-// via ?loginToken — the pre-authenticated hand-off this repo consumes in
-// packages/host/app/components/matrix/login.gts.
+// via ?loginToken — the pre-authenticated hand-off this repo consumes in the
+// <Login> component (packages/host/app/components/matrix/login.gts) when logged
+// out, and in the index route (packages/host/app/routes/index.gts) to switch
+// accounts when already logged in.
 //
 // NOTE: Synapse rate-limits get_token to one request per minute per user id
 // (hardcoded in the servlet — no rc_* setting relaxes it), so every test here
@@ -85,11 +87,16 @@ test.describe('login_via_existing_session', () => {
     // The switch must go straight from session A to session B: record whether
     // the password form ever mounts during the hand-off page load.
     await page.addInitScript(() => {
+      let w = window as {
+        __sawPasswordForm?: boolean;
+        __passwordFormObserverInstalled?: boolean;
+      };
       new MutationObserver(() => {
         if (document.querySelector('[data-test-password-field]')) {
-          (window as { __sawPasswordForm?: boolean }).__sawPasswordForm = true;
+          w.__sawPasswordForm = true;
         }
       }).observe(document.documentElement, { childList: true, subtree: true });
+      w.__passwordFormObserverInstalled = true;
     });
 
     // Landing with ?loginToken while logged in as A switches to B.
@@ -99,10 +106,21 @@ test.describe('login_via_existing_session', () => {
       displayName: usernameB,
       userId: credentialsB.userId,
     });
+    let observed = await page.evaluate(() => {
+      let w = window as {
+        __sawPasswordForm?: boolean;
+        __passwordFormObserverInstalled?: boolean;
+      };
+      return {
+        installed: w.__passwordFormObserverInstalled,
+        saw: w.__sawPasswordForm,
+      };
+    });
+    expect(observed.installed, 'the password-form observer installed').toBe(
+      true,
+    );
     expect(
-      await page.evaluate(
-        () => (window as { __sawPasswordForm?: boolean }).__sawPasswordForm,
-      ),
+      observed.saw,
       'the login form never appears during the switch',
     ).toBeFalsy();
     // The single-use token is stripped so a refresh can't re-trigger the

--- a/packages/matrix/tests/login-via-existing-session.spec.ts
+++ b/packages/matrix/tests/login-via-existing-session.spec.ts
@@ -159,7 +159,7 @@ test.describe('login_via_existing_session', () => {
     });
   });
 
-  test('a failed token exchange while logged in stays signed in as the current account', async ({
+  test('a failed token exchange while logged in shows the account-switch failure page', async ({
     page,
   }) => {
     let userA = await createSubscribedUserAndLogin(
@@ -171,17 +171,23 @@ test.describe('login_via_existing_session', () => {
       userId: userA.credentials.userId,
     });
 
-    // The token is validated before any teardown, so a dead token (expired,
-    // spent, or bogus) leaves the current session intact rather than logging
-    // the user out.
+    // A dead token (expired, spent, or bogus) is validated before any teardown,
+    // so instead of switching or logging the user out, the app shows a failure
+    // page — the current session stays intact behind it.
     await page.goto(`${appURL}?loginToken=not-a-real-token`);
 
+    await expect(page.locator('[data-test-account-switch-failed]')).toHaveCount(
+      1,
+    );
+    // The single-use token is still stripped so a refresh can't re-attempt it.
+    expect(new URL(page.url()).searchParams.has('loginToken')).toBe(false);
+
+    // Back to home recovers into the still-valid current account.
+    await page.locator('[data-test-account-switch-back-home]').click();
     await assertLoggedIn(page, {
       displayName: userA.username,
       userId: userA.credentials.userId,
     });
-    // The single-use token is still stripped so a refresh can't re-attempt it.
-    expect(new URL(page.url()).searchParams.has('loginToken')).toBe(false);
   });
 
   test('a ?loginToken switches accounts even when the stored session is revoked server-side', async ({

--- a/packages/matrix/tests/login-via-existing-session.spec.ts
+++ b/packages/matrix/tests/login-via-existing-session.spec.ts
@@ -4,6 +4,7 @@ import { getSynapseURL } from '../support/environment-config.ts';
 import {
   createUser,
   createSubscribedUser,
+  createSubscribedUserAndLogin,
   setupPermissions,
   assertLoggedIn,
 } from '../helpers/index.ts';
@@ -63,6 +64,35 @@ test.describe('login_via_existing_session', () => {
       displayName: username,
       userId: credentials.userId,
     });
+  });
+
+  test('a ?loginToken switches accounts when the browser is already logged in as another user', async ({
+    page,
+  }) => {
+    // User A is signed in in the browser.
+    let userA = await createSubscribedUserAndLogin(page, 'account-switch-a');
+    await assertLoggedIn(page, {
+      displayName: userA.username,
+      userId: userA.credentials.userId,
+    });
+
+    // User B hands off a session via a minted login token.
+    let { username: usernameB, credentials: credentialsB } =
+      await createSubscribedUser('account-switch-b');
+    await setupPermissions(credentialsB.userId, `${appURL}/`);
+    let { login_token } = await mintLoginToken(credentialsB.accessToken);
+
+    // Landing with ?loginToken while logged in as A switches to B — the login
+    // form is never shown.
+    await page.goto(`${appURL}?loginToken=${login_token}`);
+
+    await assertLoggedIn(page, {
+      displayName: usernameB,
+      userId: credentialsB.userId,
+    });
+    // The single-use token is stripped so a refresh can't re-trigger the
+    // (now spent) exchange.
+    expect(new URL(page.url()).searchParams.has('loginToken')).toBe(false);
   });
 
   test('the minted token carries the configured 2-minute lifetime and exchanges for a new session', async () => {

--- a/packages/matrix/tests/login-via-existing-session.spec.ts
+++ b/packages/matrix/tests/login-via-existing-session.spec.ts
@@ -91,11 +91,15 @@ test.describe('login_via_existing_session', () => {
         __sawPasswordForm?: boolean;
         __passwordFormObserverInstalled?: boolean;
       };
+      // Observe `document`, not `document.documentElement`: this init script
+      // runs at document-start when documentElement can still be null, so
+      // observing it would throw before the flag is set. subtree:true still
+      // catches the password field wherever it mounts.
       new MutationObserver(() => {
         if (document.querySelector('[data-test-password-field]')) {
           w.__sawPasswordForm = true;
         }
-      }).observe(document.documentElement, { childList: true, subtree: true });
+      }).observe(document, { childList: true, subtree: true });
       w.__passwordFormObserverInstalled = true;
     });
 


### PR DESCRIPTION
## Background and Goal

A pre-authenticated hand-off arrives as `?loginToken` in the URL (used by Google SSO and by the CLI's `browse` command). Today that token is consumed **only** by the `<Login>` component, which renders only when logged **out** — so landing on `?loginToken` while the browser is already signed in as another user silently ignores it. This makes the index route treat a `loginToken` while logged in as "switch accounts": log the current user out, then log in with the token.

## Where to start

- `app/utils/login-token.ts` (new) — the shared read/strip helper (`peekLoginToken` / `consumeLoginTokenFromUrl`). The `loginToken` is deliberately not a registered route query param, so it's read straight from `window.location.search` and stripped immediately (single-use).
- `app/routes/index.gts` `model()` — the account-switch block, gated on `isLoggedIn`.
- `app/components/matrix/login.gts` — refactored the logged-out path onto the shared helper; behavior unchanged.

## Key decisions and non-obvious mechanics

- **Strip the token from the URL before `logout()`.** `logout()` ends in a `router.transitionTo` that re-enters the model hook; with the token already stripped, that re-entry is a no-op (falls through to the login form).
- **Gate on `isLoggedIn`.** When logged out, the block neither consumes nor strips, so the `<Login>` component still handles the token as before.
- **`start({ refreshRoutes: true })`** re-runs the model as the new user against the now-clean URL, rendering their workspace.
- **Failure after logout** leaves the user logged out on the login form — acceptable, since the token is single-use and a refresh can't retry (matches the existing SSO trade-off).
- New end-to-end coverage added to the `login_via_existing_session` Playwright spec: sign in as A, mint a token for B, land on `?loginToken=<B>`, assert switched to B and the token stripped.