### PR TITLE
feat: boxel browse opens published realms without signing in

### DIFF
--- a/packages/boxel-cli/src/commands/browse.ts
+++ b/packages/boxel-cli/src/commands/browse.ts
@@ -77,11 +77,15 @@ export interface BrowseOptions {
   log?: (message: string) => void;
 }
 
-// Resolve the target profile: the named one, or the active one.
+// Resolve the target profile: the named one, or the active one. A missing
+// *named* profile is always an error (the user asked for it by name), but a
+// missing active profile returns null so the caller can still try the
+// anonymous published-realm path — which needs no credentials — before
+// insisting on a profile for the token flow.
 function resolveProfile(
   pm: ProfileManager,
   profileId: string | undefined,
-): { id: string; profile: Profile } {
+): { id: string; profile: Profile } | null {
   if (profileId) {
     let profile = pm.getProfile(profileId);
     if (!profile) {
@@ -91,11 +95,7 @@ function resolveProfile(
     }
     return { id: profileId, profile };
   }
-  let active = pm.getActiveProfile();
-  if (!active) {
-    throw new Error(NO_ACTIVE_PROFILE_ERROR);
-  }
-  return active;
+  return pm.getActiveProfile();
 }
 
 export async function browse(
@@ -109,7 +109,7 @@ export async function browse(
   let openBrowserFn = options.openBrowserFn ?? openBrowser;
   let log = options.log ?? ((message: string) => console.log(message));
 
-  let { id: profileId, profile } = resolveProfile(pm, options.profile);
+  let resolved = resolveProfile(pm, options.profile);
 
   // Fast path: a *published* realm is served on its own origin, which the host
   // renders with no sign-in. When the given card path is such a URL, open it
@@ -118,9 +118,12 @@ export async function browse(
   // URLs, so the path states which one the user wants. Only attempted with a
   // card path (bare `browse` has no card to resolve) and without `--host-url`
   // (which explicitly targets the operator app for the token flow).
+  //
+  // Tried before requiring a profile so a fresh install with no profile can
+  // still open an absolute published URL, which needs no credentials.
   if (cardPath && !options.hostUrl) {
     let anonymousUrl = await resolveAnonymousBrowseUrl(
-      profile.realmServerUrl,
+      resolved?.profile.realmServerUrl,
       cardPath,
     );
     if (anonymousUrl) {
@@ -139,6 +142,13 @@ export async function browse(
       return;
     }
   }
+
+  // The token flow needs a profile; the anonymous path above didn't apply, so
+  // insist on one now.
+  if (!resolved) {
+    throw new Error(NO_ACTIVE_PROFILE_ERROR);
+  }
+  let { id: profileId, profile } = resolved;
 
   // Mint the login token, recovering once from a rejected access token via the
   // profile manager's interactive re-auth (same pattern as the other commands).

--- a/packages/boxel-cli/src/commands/browse.ts
+++ b/packages/boxel-cli/src/commands/browse.ts
@@ -11,6 +11,7 @@ import {
   requestLoginToken as defaultRequestLoginToken,
   MatrixAuthError,
 } from '../lib/auth.ts';
+import { resolveAnonymousBrowseUrl as defaultResolveAnonymousBrowseUrl } from '../lib/published-realm.ts';
 import { openBrowser } from '../lib/open-browser.ts';
 import { FG_RED, RESET } from '../lib/colors.ts';
 import { cliLog } from '../lib/cli-log.ts';
@@ -71,6 +72,7 @@ export interface BrowseOptions {
   // Injectable seams for testing.
   profileManager?: ProfileManager;
   requestLoginToken?: typeof defaultRequestLoginToken;
+  resolveAnonymousBrowseUrl?: typeof defaultResolveAnonymousBrowseUrl;
   openBrowserFn?: (url: string) => Promise<boolean>;
   log?: (message: string) => void;
 }
@@ -102,10 +104,40 @@ export async function browse(
 ): Promise<void> {
   let pm = options.profileManager ?? getProfileManager();
   let requestLoginToken = options.requestLoginToken ?? defaultRequestLoginToken;
+  let resolveAnonymousBrowseUrl =
+    options.resolveAnonymousBrowseUrl ?? defaultResolveAnonymousBrowseUrl;
   let openBrowserFn = options.openBrowserFn ?? openBrowser;
   let log = options.log ?? ((message: string) => console.log(message));
 
   let { id: profileId, profile } = resolveProfile(pm, options.profile);
+
+  // Fast path: a card in a *published* realm is served on its own origin, which
+  // the host renders with no sign-in. When browsing such a card, open that
+  // public URL directly and skip minting a token entirely. Only attempted with
+  // a card path (bare `browse` has no card to resolve) and without `--host-url`
+  // (which explicitly targets the operator app for the token flow).
+  if (cardPath && !options.hostUrl) {
+    let anonymousUrl = await resolveAnonymousBrowseUrl(
+      profile.realmServerUrl,
+      cardPath,
+      { authedRealmFetch: (input, init) => pm.authedRealmFetch(input, init) },
+    );
+    if (anonymousUrl) {
+      // No credential in this URL — it's a plain public link.
+      if (options.printUrl) {
+        cliLog.output(anonymousUrl);
+        return;
+      }
+      log(`Opening ${anonymousUrl} (published realm — no sign-in needed)`);
+      let opened = await openBrowserFn(anonymousUrl);
+      if (!opened) {
+        cliLog.warn(
+          `Couldn't open a browser automatically. Open this URL:\n  ${anonymousUrl}`,
+        );
+      }
+      return;
+    }
+  }
 
   // Mint the login token, recovering once from a rejected access token via the
   // profile manager's interactive re-auth (same pattern as the other commands).
@@ -157,7 +189,8 @@ export function registerBrowseCommand(program: Command): void {
   program
     .command('browse')
     .description(
-      'Open the Boxel app in your browser, already signed in as your active profile',
+      'Open the Boxel app in your browser, already signed in as your active ' +
+        'profile (a card in a published realm opens directly, no sign-in needed)',
     )
     .argument(
       '[card-path]',

--- a/packages/boxel-cli/src/commands/browse.ts
+++ b/packages/boxel-cli/src/commands/browse.ts
@@ -111,16 +111,17 @@ export async function browse(
 
   let { id: profileId, profile } = resolveProfile(pm, options.profile);
 
-  // Fast path: a card in a *published* realm is served on its own origin, which
-  // the host renders with no sign-in. When browsing such a card, open that
-  // public URL directly and skip minting a token entirely. Only attempted with
-  // a card path (bare `browse` has no card to resolve) and without `--host-url`
+  // Fast path: a *published* realm is served on its own origin, which the host
+  // renders with no sign-in. When the given card path is such a URL, open it
+  // as-is and skip minting a token entirely. A source-realm path always takes
+  // the token flow — the live card and its published snapshot are different
+  // URLs, so the path states which one the user wants. Only attempted with a
+  // card path (bare `browse` has no card to resolve) and without `--host-url`
   // (which explicitly targets the operator app for the token flow).
   if (cardPath && !options.hostUrl) {
     let anonymousUrl = await resolveAnonymousBrowseUrl(
       profile.realmServerUrl,
       cardPath,
-      { authedRealmFetch: (input, init) => pm.authedRealmFetch(input, init) },
     );
     if (anonymousUrl) {
       // No credential in this URL — it's a plain public link.
@@ -190,11 +191,12 @@ export function registerBrowseCommand(program: Command): void {
     .command('browse')
     .description(
       'Open the Boxel app in your browser, already signed in as your active ' +
-        'profile (a card in a published realm opens directly, no sign-in needed)',
+        'profile (a published-realm card URL opens directly, no sign-in needed)',
     )
     .argument(
       '[card-path]',
-      'Card path to deep-link to after signing in (e.g. a realm-relative path)',
+      'Card to open: a realm-relative path (opens signed in) or a ' +
+        'published-realm URL (opens directly, no sign-in)',
     )
     .option('--profile <id>', 'Profile to use (default: the active profile)')
     .option(

--- a/packages/boxel-cli/src/lib/published-realm.ts
+++ b/packages/boxel-cli/src/lib/published-realm.ts
@@ -6,6 +6,13 @@ import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 // `lint:types`).
 const CARD_JSON_MIME = 'application/vnd.card+json';
 
+// The one Boxel signature the published-realm HTML shell always carries: the
+// host reads its build-time config from this meta tag. A routed/vanity path
+// (see the text/html fallback below) is served as this shell and stamps no
+// `x-boxel-realm-url` header, so the tag is what proves the origin is a Boxel
+// host rather than an unrelated site that happens to return 200.
+const HOST_CONFIG_META = '@cardstack/host/config/environment';
+
 export interface AnonymousBrowseDeps {
   // Unauthenticated fetch used to confirm the URL really serves a Boxel card
   // without a session. Defaults to the global `fetch`.
@@ -22,37 +29,86 @@ export interface AnonymousBrowseDeps {
  * login, even for world-readable realms. Published and source cards live at
  * different URLs, so the URL itself states which one the user wants:
  *
- *   1. Resolve the path against the realm server. A relative path (or an
- *      absolute URL on the realm server's own origin) is operator-app
- *      territory and takes the token flow — the same origin test the host
- *      uses to decide host mode vs operator mode.
- *   2. Probe the resolved URL unauthenticated. A 2xx carrying the
- *      `x-boxel-realm-url` header (stamped on every realm response) proves a
- *      Boxel realm serves it anonymously; a non-Boxel URL that happens to
- *      return 200 doesn't qualify.
+ *   1. Resolve the path. With a `realmServerUrl` in hand, a relative path (or
+ *      an absolute URL on the realm server's own origin) is operator-app
+ *      territory and takes the token flow — the same origin test the host uses
+ *      to decide host mode vs operator mode. Without one (a fresh install with
+ *      no profile), only an absolute URL can name a published realm, so a
+ *      relative path falls through to the token flow.
+ *   2. Probe the resolved URL unauthenticated. A card+json HEAD that returns
+ *      2xx with the `x-boxel-realm-url` header (stamped on every realm
+ *      response) proves a Boxel realm serves the card anonymously.
+ *   3. If that 404s, the path may be a host-routed/vanity URL (e.g. `/pricing`
+ *      mapped to `/pages/pricing`) that is not itself an indexed card, so the
+ *      card+json probe bypasses the routing map the realm server only applies
+ *      to browser navigations. Re-probe the way a browser would — a text/html
+ *      GET — and confirm the response is the Boxel host shell.
  */
 export async function resolveAnonymousBrowseUrl(
-  realmServerUrl: string,
+  realmServerUrl: string | undefined,
   cardPath: string,
   deps: AnonymousBrowseDeps = {},
 ): Promise<string | undefined> {
   let publicFetch = deps.publicFetch ?? fetch;
   try {
-    let serverBase = ensureTrailingSlash(realmServerUrl);
-    let resolved = new URL(cardPath, serverBase);
-    if (resolved.origin === new URL(serverBase).origin) {
-      return undefined;
+    let resolved: URL;
+    if (realmServerUrl) {
+      let serverBase = ensureTrailingSlash(realmServerUrl);
+      resolved = new URL(cardPath, serverBase);
+      if (resolved.origin === new URL(serverBase).origin) {
+        return undefined;
+      }
+    } else {
+      // No realm server to resolve a relative path against, so only an
+      // absolute URL can be a published realm. `new URL` throws for a relative
+      // path, which the catch below turns into the token-flow fallback.
+      resolved = new URL(cardPath);
     }
-    let response = await publicFetch(resolved.href, {
-      headers: { Accept: CARD_JSON_MIME },
-    });
-    if (!response.ok || !response.headers.get('x-boxel-realm-url')) {
-      return undefined;
+
+    if (
+      (await servesPublishedCard(resolved, publicFetch)) ||
+      (await servesPublishedShell(resolved, publicFetch))
+    ) {
+      return resolved.href;
     }
-    return resolved.href;
+    return undefined;
   } catch {
     // Malformed path, unreachable origin, etc. — not the anonymous path; fall
     // back to the token flow.
     return undefined;
   }
+}
+
+// A published card serves its card+json representation anonymously and stamps
+// the realm header. HEAD is enough — we only read the status and the header,
+// never the body — and it's the common case (a direct card URL), so keep it
+// cheap.
+async function servesPublishedCard(
+  url: URL,
+  publicFetch: typeof fetch,
+): Promise<boolean> {
+  let response = await publicFetch(url.href, {
+    method: 'HEAD',
+    headers: { Accept: CARD_JSON_MIME },
+  });
+  return response.ok && response.headers.get('x-boxel-realm-url') != null;
+}
+
+// A host-routed/vanity path is served as the Boxel host shell, which carries
+// no `x-boxel-realm-url` header, so the shell's config meta tag is the only
+// signal that the origin is a Boxel host. That means reading the body, hence a
+// GET rather than a HEAD — but only on this fallback, after the cheap card
+// probe has already missed.
+async function servesPublishedShell(
+  url: URL,
+  publicFetch: typeof fetch,
+): Promise<boolean> {
+  let response = await publicFetch(url.href, {
+    headers: { Accept: 'text/html' },
+  });
+  if (!response.ok) {
+    return false;
+  }
+  let body = await response.text();
+  return body.includes(HOST_CONFIG_META);
 }

--- a/packages/boxel-cli/src/lib/published-realm.ts
+++ b/packages/boxel-cli/src/lib/published-realm.ts
@@ -1,160 +1,58 @@
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 
-// MIME wire values, kept as local literals so boxel-cli's type-check stays
-// dependency-light (these mirror runtime-common's SupportedMimeType.CardJson
-// and .RealmInfo — importing that module would drag base-realm types into the
-// CLI's `lint:types`).
+// MIME wire value, kept as a local literal so boxel-cli's type-check stays
+// dependency-light (mirrors runtime-common's SupportedMimeType.CardJson —
+// importing that module would drag base-realm types into the CLI's
+// `lint:types`).
 const CARD_JSON_MIME = 'application/vnd.card+json';
-const REALM_INFO_MIME = 'application/vnd.api+json';
-
-// The published-origin map carried on a realm's RealmInfo:
-// `{ <publishedRealmURL>: <epoch-ms timestamp> }`. Older realms may report a
-// bare string or `null`; only the object form names published origins.
-export type LastPublishedAt =
-  | string
-  | Record<string, string>
-  | null
-  | undefined;
-
-// A published realm is served on its own origin, which the host renders
-// anonymously (host mode) — unlike the operator app, which always forces a
-// login. So a card in a published realm can be opened with no sign-in.
-//
-// Pick the most-recently published origin from a realm's `lastPublishedAt`,
-// mirroring the host's own newest-first ordering
-// (host-mode-service.ts `publishedRealmMetadata` / `parsePublishedAt`).
-export function pickLatestPublishedOrigin(
-  lastPublishedAt: LastPublishedAt,
-): string | undefined {
-  if (!lastPublishedAt || typeof lastPublishedAt !== 'object') {
-    return undefined;
-  }
-  let entries = Object.entries(lastPublishedAt);
-  if (entries.length === 0) {
-    return undefined;
-  }
-  entries.sort((a, b) => publishedAtValue(b[1]) - publishedAtValue(a[1]));
-  return entries[0][0];
-}
-
-function publishedAtValue(value: unknown): number {
-  let n = Number(value ?? 0);
-  return Number.isFinite(n) ? n : 0;
-}
-
-// Build the host-mode (published-origin) URL for a card, mirroring the host's
-// `host-mode-service.ts` `fullURL`: the published origin plus the card id taken
-// relative to its source realm, with a trailing `index` stripped (the realm's
-// index card lives at the origin root).
-export function resolvePublishedCardUrl(opts: {
-  publishedOrigin: string;
-  sourceRealmUrl: string;
-  cardId: string;
-}): string | undefined {
-  let base = ensureTrailingSlash(opts.publishedOrigin);
-  let sourceRealmUrl = ensureTrailingSlash(opts.sourceRealmUrl);
-  if (!opts.cardId.startsWith(sourceRealmUrl)) {
-    // The card id should be absolute under its own realm; if it isn't we can't
-    // rebase it onto the published origin, so signal "no anonymous URL".
-    return undefined;
-  }
-  let relative = opts.cardId.slice(sourceRealmUrl.length);
-  let full = base + relative;
-  if (full === `${base}index`) {
-    full = base;
-  }
-  return full;
-}
 
 export interface AnonymousBrowseDeps {
-  // Authed fetch against the realm server (the CLI authenticating to discover
-  // the card's realm and its published origins — not the browser signing in).
-  authedRealmFetch: (input: string, init?: RequestInit) => Promise<Response>;
-  // Unauthenticated fetch used to confirm the published URL really renders
+  // Unauthenticated fetch used to confirm the URL really serves a Boxel card
   // without a session. Defaults to the global `fetch`.
   publicFetch?: typeof fetch;
 }
 
 /**
- * Resolve a no-sign-in browse URL for a card, or `undefined` when there isn't
- * one (so the caller falls back to the authenticated login-token flow).
+ * Return `cardPath` resolved to a no-sign-in browse URL, or `undefined` when
+ * it isn't one (so the caller falls back to the authenticated login-token
+ * flow).
  *
- * Returns a URL only when the card lives in a *published* realm — the one case
- * the host renders anonymously. The steps, all best-effort (any failure yields
- * `undefined`):
- *   1. Fetch the card (authed) to learn its source realm (`x-boxel-realm-url`
- *      header) and canonical id (`data.id`).
- *   2. Read the realm's `_info` (authed) for its `lastPublishedAt` origins.
- *   3. Rebase the card id onto the newest published origin.
- *   4. Confirm that published URL returns content *without* auth.
+ * Only a *published* realm — a realm copy served on its own origin — renders
+ * anonymously; the operator app on the realm server's origin always forces a
+ * login, even for world-readable realms. Published and source cards live at
+ * different URLs, so the URL itself states which one the user wants:
+ *
+ *   1. Resolve the path against the realm server. A relative path (or an
+ *      absolute URL on the realm server's own origin) is operator-app
+ *      territory and takes the token flow — the same origin test the host
+ *      uses to decide host mode vs operator mode.
+ *   2. Probe the resolved URL unauthenticated. A 2xx carrying the
+ *      `x-boxel-realm-url` header (stamped on every realm response) proves a
+ *      Boxel realm serves it anonymously; a non-Boxel URL that happens to
+ *      return 200 doesn't qualify.
  */
 export async function resolveAnonymousBrowseUrl(
   realmServerUrl: string,
   cardPath: string,
-  deps: AnonymousBrowseDeps,
+  deps: AnonymousBrowseDeps = {},
 ): Promise<string | undefined> {
   let publicFetch = deps.publicFetch ?? fetch;
   try {
-    let cardUrl = new URL(cardPath, ensureTrailingSlash(realmServerUrl)).href;
-    let cardResponse = await deps.authedRealmFetch(cardUrl, {
+    let serverBase = ensureTrailingSlash(realmServerUrl);
+    let resolved = new URL(cardPath, serverBase);
+    if (resolved.origin === new URL(serverBase).origin) {
+      return undefined;
+    }
+    let response = await publicFetch(resolved.href, {
       headers: { Accept: CARD_JSON_MIME },
     });
-    if (!cardResponse.ok) {
+    if (!response.ok || !response.headers.get('x-boxel-realm-url')) {
       return undefined;
     }
-    let sourceRealmUrl = cardResponse.headers.get('x-boxel-realm-url');
-    let cardJson = (await cardResponse.json()) as { data?: { id?: string } };
-    let cardId = cardJson?.data?.id;
-    if (!sourceRealmUrl || !cardId) {
-      return undefined;
-    }
-    sourceRealmUrl = ensureTrailingSlash(sourceRealmUrl);
-
-    let infoResponse = await deps.authedRealmFetch(`${sourceRealmUrl}_info`, {
-      method: 'QUERY',
-      headers: { Accept: REALM_INFO_MIME, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ realms: [sourceRealmUrl] }),
-    });
-    if (!infoResponse.ok) {
-      return undefined;
-    }
-    let infoJson = (await infoResponse.json()) as {
-      data?:
-        | { attributes?: { lastPublishedAt?: LastPublishedAt } }
-        | { attributes?: { lastPublishedAt?: LastPublishedAt } }[];
-    };
-    let realmData = Array.isArray(infoJson?.data)
-      ? infoJson.data[0]
-      : infoJson?.data;
-    let publishedOrigin = pickLatestPublishedOrigin(
-      realmData?.attributes?.lastPublishedAt,
-    );
-    if (!publishedOrigin) {
-      return undefined;
-    }
-
-    let publishedUrl = resolvePublishedCardUrl({
-      publishedOrigin,
-      sourceRealmUrl,
-      cardId,
-    });
-    if (!publishedUrl) {
-      return undefined;
-    }
-
-    // The published copy is world-readable; confirm it actually serves without
-    // a token (guards a stale `lastPublishedAt` after an unpublish, or a card
-    // absent from the published copy).
-    let verify = await publicFetch(publishedUrl, {
-      headers: { Accept: CARD_JSON_MIME },
-    });
-    if (!verify.ok) {
-      return undefined;
-    }
-    return publishedUrl;
+    return resolved.href;
   } catch {
-    // Unreachable published origin, missing realm token, unparseable body, etc.
-    // — none of these are the anonymous path; fall back to the token flow.
+    // Malformed path, unreachable origin, etc. — not the anonymous path; fall
+    // back to the token flow.
     return undefined;
   }
 }

--- a/packages/boxel-cli/src/lib/published-realm.ts
+++ b/packages/boxel-cli/src/lib/published-realm.ts
@@ -1,0 +1,160 @@
+import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
+
+// MIME wire values, kept as local literals so boxel-cli's type-check stays
+// dependency-light (these mirror runtime-common's SupportedMimeType.CardJson
+// and .RealmInfo — importing that module would drag base-realm types into the
+// CLI's `lint:types`).
+const CARD_JSON_MIME = 'application/vnd.card+json';
+const REALM_INFO_MIME = 'application/vnd.api+json';
+
+// The published-origin map carried on a realm's RealmInfo:
+// `{ <publishedRealmURL>: <epoch-ms timestamp> }`. Older realms may report a
+// bare string or `null`; only the object form names published origins.
+export type LastPublishedAt =
+  | string
+  | Record<string, string>
+  | null
+  | undefined;
+
+// A published realm is served on its own origin, which the host renders
+// anonymously (host mode) — unlike the operator app, which always forces a
+// login. So a card in a published realm can be opened with no sign-in.
+//
+// Pick the most-recently published origin from a realm's `lastPublishedAt`,
+// mirroring the host's own newest-first ordering
+// (host-mode-service.ts `publishedRealmMetadata` / `parsePublishedAt`).
+export function pickLatestPublishedOrigin(
+  lastPublishedAt: LastPublishedAt,
+): string | undefined {
+  if (!lastPublishedAt || typeof lastPublishedAt !== 'object') {
+    return undefined;
+  }
+  let entries = Object.entries(lastPublishedAt);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  entries.sort((a, b) => publishedAtValue(b[1]) - publishedAtValue(a[1]));
+  return entries[0][0];
+}
+
+function publishedAtValue(value: unknown): number {
+  let n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// Build the host-mode (published-origin) URL for a card, mirroring the host's
+// `host-mode-service.ts` `fullURL`: the published origin plus the card id taken
+// relative to its source realm, with a trailing `index` stripped (the realm's
+// index card lives at the origin root).
+export function resolvePublishedCardUrl(opts: {
+  publishedOrigin: string;
+  sourceRealmUrl: string;
+  cardId: string;
+}): string | undefined {
+  let base = ensureTrailingSlash(opts.publishedOrigin);
+  let sourceRealmUrl = ensureTrailingSlash(opts.sourceRealmUrl);
+  if (!opts.cardId.startsWith(sourceRealmUrl)) {
+    // The card id should be absolute under its own realm; if it isn't we can't
+    // rebase it onto the published origin, so signal "no anonymous URL".
+    return undefined;
+  }
+  let relative = opts.cardId.slice(sourceRealmUrl.length);
+  let full = base + relative;
+  if (full === `${base}index`) {
+    full = base;
+  }
+  return full;
+}
+
+export interface AnonymousBrowseDeps {
+  // Authed fetch against the realm server (the CLI authenticating to discover
+  // the card's realm and its published origins — not the browser signing in).
+  authedRealmFetch: (input: string, init?: RequestInit) => Promise<Response>;
+  // Unauthenticated fetch used to confirm the published URL really renders
+  // without a session. Defaults to the global `fetch`.
+  publicFetch?: typeof fetch;
+}
+
+/**
+ * Resolve a no-sign-in browse URL for a card, or `undefined` when there isn't
+ * one (so the caller falls back to the authenticated login-token flow).
+ *
+ * Returns a URL only when the card lives in a *published* realm — the one case
+ * the host renders anonymously. The steps, all best-effort (any failure yields
+ * `undefined`):
+ *   1. Fetch the card (authed) to learn its source realm (`x-boxel-realm-url`
+ *      header) and canonical id (`data.id`).
+ *   2. Read the realm's `_info` (authed) for its `lastPublishedAt` origins.
+ *   3. Rebase the card id onto the newest published origin.
+ *   4. Confirm that published URL returns content *without* auth.
+ */
+export async function resolveAnonymousBrowseUrl(
+  realmServerUrl: string,
+  cardPath: string,
+  deps: AnonymousBrowseDeps,
+): Promise<string | undefined> {
+  let publicFetch = deps.publicFetch ?? fetch;
+  try {
+    let cardUrl = new URL(cardPath, ensureTrailingSlash(realmServerUrl)).href;
+    let cardResponse = await deps.authedRealmFetch(cardUrl, {
+      headers: { Accept: CARD_JSON_MIME },
+    });
+    if (!cardResponse.ok) {
+      return undefined;
+    }
+    let sourceRealmUrl = cardResponse.headers.get('x-boxel-realm-url');
+    let cardJson = (await cardResponse.json()) as { data?: { id?: string } };
+    let cardId = cardJson?.data?.id;
+    if (!sourceRealmUrl || !cardId) {
+      return undefined;
+    }
+    sourceRealmUrl = ensureTrailingSlash(sourceRealmUrl);
+
+    let infoResponse = await deps.authedRealmFetch(`${sourceRealmUrl}_info`, {
+      method: 'QUERY',
+      headers: { Accept: REALM_INFO_MIME, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ realms: [sourceRealmUrl] }),
+    });
+    if (!infoResponse.ok) {
+      return undefined;
+    }
+    let infoJson = (await infoResponse.json()) as {
+      data?:
+        | { attributes?: { lastPublishedAt?: LastPublishedAt } }
+        | { attributes?: { lastPublishedAt?: LastPublishedAt } }[];
+    };
+    let realmData = Array.isArray(infoJson?.data)
+      ? infoJson.data[0]
+      : infoJson?.data;
+    let publishedOrigin = pickLatestPublishedOrigin(
+      realmData?.attributes?.lastPublishedAt,
+    );
+    if (!publishedOrigin) {
+      return undefined;
+    }
+
+    let publishedUrl = resolvePublishedCardUrl({
+      publishedOrigin,
+      sourceRealmUrl,
+      cardId,
+    });
+    if (!publishedUrl) {
+      return undefined;
+    }
+
+    // The published copy is world-readable; confirm it actually serves without
+    // a token (guards a stale `lastPublishedAt` after an unpublish, or a card
+    // absent from the published copy).
+    let verify = await publicFetch(publishedUrl, {
+      headers: { Accept: CARD_JSON_MIME },
+    });
+    if (!verify.ok) {
+      return undefined;
+    }
+    return publishedUrl;
+  } catch {
+    // Unreachable published origin, missing realm token, unparseable body, etc.
+    // — none of these are the anonymous path; fall back to the token flow.
+    return undefined;
+  }
+}

--- a/packages/boxel-cli/tests/commands/browse.test.ts
+++ b/packages/boxel-cli/tests/commands/browse.test.ts
@@ -220,9 +220,6 @@ describe('browse', () => {
         deviceId: 'DEVICE',
         matrixUrl: 'http://localhost:8008',
       }),
-      // Default: the card isn't reachable, so the anonymous (published-realm)
-      // pre-flight yields nothing and browse falls back to the token flow.
-      authedRealmFetch: async () => fakeResponse(404, 'not found'),
       ...overrides,
     } as unknown as ProfileManager;
   }
@@ -412,14 +409,14 @@ describe('browse', () => {
     );
   });
 
-  it('opens the published URL with no token when the card is in a published realm', async () => {
+  it('opens a published-realm URL as-is, with no token', async () => {
     let openBrowserFn = vi.fn().mockResolvedValue(true);
     let requestLoginTokenFn = vi.fn();
     let resolveAnonymousBrowseUrl = vi
       .fn()
       .mockResolvedValue('https://alice.boxel.space/Post/1');
 
-    await browse('alice/blog/Post/1', {
+    await browse('https://alice.boxel.space/Post/1', {
       profileManager: fakeProfileManager(),
       requestLoginToken: requestLoginTokenFn,
       resolveAnonymousBrowseUrl,
@@ -429,8 +426,7 @@ describe('browse', () => {
 
     expect(resolveAnonymousBrowseUrl).toHaveBeenCalledWith(
       'https://localhost:4201/',
-      'alice/blog/Post/1',
-      expect.anything(),
+      'https://alice.boxel.space/Post/1',
     );
     // No token minted, and the opened URL carries no loginToken.
     expect(requestLoginTokenFn).not.toHaveBeenCalled();
@@ -446,7 +442,7 @@ describe('browse', () => {
       .spyOn(process.stdout, 'write')
       .mockImplementation(() => true);
 
-    await browse('alice/blog/Post/1', {
+    await browse('https://alice.boxel.space/Post/1', {
       printUrl: true,
       profileManager: fakeProfileManager(),
       requestLoginToken: requestLoginTokenFn,
@@ -463,7 +459,7 @@ describe('browse', () => {
     stdout.mockRestore();
   });
 
-  it('falls back to the login-token flow when the card is not a published realm', async () => {
+  it('falls back to the login-token flow when the card path is not a published-realm URL', async () => {
     let openBrowserFn = vi.fn().mockResolvedValue(true);
     let requestLoginTokenFn = vi
       .fn()

--- a/packages/boxel-cli/tests/commands/browse.test.ts
+++ b/packages/boxel-cli/tests/commands/browse.test.ts
@@ -435,6 +435,48 @@ describe('browse', () => {
     );
   });
 
+  it('opens an absolute published-realm URL with no active profile', async () => {
+    // A fresh install (no profile) can still open a published URL: the
+    // anonymous path runs before the token flow insists on a profile.
+    let openBrowserFn = vi.fn().mockResolvedValue(true);
+    let requestLoginTokenFn = vi.fn();
+    let resolveAnonymousBrowseUrl = vi
+      .fn()
+      .mockResolvedValue('https://alice.boxel.space/Post/1');
+
+    await browse('https://alice.boxel.space/Post/1', {
+      profileManager: fakeProfileManager({ getActiveProfile: () => null }),
+      requestLoginToken: requestLoginTokenFn,
+      resolveAnonymousBrowseUrl,
+      openBrowserFn,
+      log: () => {},
+    });
+
+    // No profile, so no realm-server URL is passed to the resolver.
+    expect(resolveAnonymousBrowseUrl).toHaveBeenCalledWith(
+      undefined,
+      'https://alice.boxel.space/Post/1',
+    );
+    expect(requestLoginTokenFn).not.toHaveBeenCalled();
+    expect(openBrowserFn).toHaveBeenCalledWith(
+      'https://alice.boxel.space/Post/1',
+    );
+  });
+
+  it('errors with no active profile when the URL is not a published realm', async () => {
+    // The anonymous path missed, so the token flow needs a profile — and
+    // there is none.
+    await expect(
+      browse('alice/blog/Post/1', {
+        profileManager: fakeProfileManager({ getActiveProfile: () => null }),
+        requestLoginToken: vi.fn(),
+        resolveAnonymousBrowseUrl: vi.fn().mockResolvedValue(undefined),
+        openBrowserFn: vi.fn(),
+        log: () => {},
+      }),
+    ).rejects.toThrow(/No active profile/);
+  });
+
   it('prints the published URL under --print-url without minting a token', async () => {
     let openBrowserFn = vi.fn().mockResolvedValue(true);
     let requestLoginTokenFn = vi.fn();

--- a/packages/boxel-cli/tests/commands/browse.test.ts
+++ b/packages/boxel-cli/tests/commands/browse.test.ts
@@ -220,6 +220,9 @@ describe('browse', () => {
         deviceId: 'DEVICE',
         matrixUrl: 'http://localhost:8008',
       }),
+      // Default: the card isn't reachable, so the anonymous (published-realm)
+      // pre-flight yields nothing and browse falls back to the token flow.
+      authedRealmFetch: async () => fakeResponse(404, 'not found'),
       ...overrides,
     } as unknown as ProfileManager;
   }
@@ -407,6 +410,110 @@ describe('browse', () => {
     expect(openBrowserFn).toHaveBeenCalledWith(
       'https://cs-123.localhost:4200/?loginToken=lt_abc',
     );
+  });
+
+  it('opens the published URL with no token when the card is in a published realm', async () => {
+    let openBrowserFn = vi.fn().mockResolvedValue(true);
+    let requestLoginTokenFn = vi.fn();
+    let resolveAnonymousBrowseUrl = vi
+      .fn()
+      .mockResolvedValue('https://alice.boxel.space/Post/1');
+
+    await browse('alice/blog/Post/1', {
+      profileManager: fakeProfileManager(),
+      requestLoginToken: requestLoginTokenFn,
+      resolveAnonymousBrowseUrl,
+      openBrowserFn,
+      log: () => {},
+    });
+
+    expect(resolveAnonymousBrowseUrl).toHaveBeenCalledWith(
+      'https://localhost:4201/',
+      'alice/blog/Post/1',
+      expect.anything(),
+    );
+    // No token minted, and the opened URL carries no loginToken.
+    expect(requestLoginTokenFn).not.toHaveBeenCalled();
+    expect(openBrowserFn).toHaveBeenCalledWith(
+      'https://alice.boxel.space/Post/1',
+    );
+  });
+
+  it('prints the published URL under --print-url without minting a token', async () => {
+    let openBrowserFn = vi.fn().mockResolvedValue(true);
+    let requestLoginTokenFn = vi.fn();
+    let stdout = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+
+    await browse('alice/blog/Post/1', {
+      printUrl: true,
+      profileManager: fakeProfileManager(),
+      requestLoginToken: requestLoginTokenFn,
+      resolveAnonymousBrowseUrl: vi
+        .fn()
+        .mockResolvedValue('https://alice.boxel.space/Post/1'),
+      openBrowserFn,
+      log: () => {},
+    });
+
+    expect(openBrowserFn).not.toHaveBeenCalled();
+    expect(requestLoginTokenFn).not.toHaveBeenCalled();
+    expect(stdout).toHaveBeenCalledWith('https://alice.boxel.space/Post/1\n');
+    stdout.mockRestore();
+  });
+
+  it('falls back to the login-token flow when the card is not a published realm', async () => {
+    let openBrowserFn = vi.fn().mockResolvedValue(true);
+    let requestLoginTokenFn = vi
+      .fn()
+      .mockResolvedValue({ loginToken: 'lt_abc', expiresInMs: 120000 });
+
+    await browse('alice/blog/Post/1', {
+      profileManager: fakeProfileManager(),
+      requestLoginToken: requestLoginTokenFn,
+      resolveAnonymousBrowseUrl: vi.fn().mockResolvedValue(undefined),
+      openBrowserFn,
+      log: () => {},
+    });
+
+    expect(requestLoginTokenFn).toHaveBeenCalledTimes(1);
+    expect(openBrowserFn).toHaveBeenCalledWith(
+      'https://localhost:4200/?loginToken=lt_abc&cardPath=alice%2Fblog%2FPost%2F1',
+    );
+  });
+
+  it('does not attempt the anonymous path for bare browse (no card path)', async () => {
+    let resolveAnonymousBrowseUrl = vi.fn();
+
+    await browse(undefined, {
+      profileManager: fakeProfileManager(),
+      requestLoginToken: vi
+        .fn()
+        .mockResolvedValue({ loginToken: 'lt_abc', expiresInMs: 120000 }),
+      resolveAnonymousBrowseUrl,
+      openBrowserFn: vi.fn().mockResolvedValue(true),
+      log: () => {},
+    });
+
+    expect(resolveAnonymousBrowseUrl).not.toHaveBeenCalled();
+  });
+
+  it('does not attempt the anonymous path when --host-url is given', async () => {
+    let resolveAnonymousBrowseUrl = vi.fn();
+
+    await browse('alice/blog/Post/1', {
+      hostUrl: 'https://cs-123.localhost:4200',
+      profileManager: fakeProfileManager(),
+      requestLoginToken: vi
+        .fn()
+        .mockResolvedValue({ loginToken: 'lt_abc', expiresInMs: 120000 }),
+      resolveAnonymousBrowseUrl,
+      openBrowserFn: vi.fn().mockResolvedValue(true),
+      log: () => {},
+    });
+
+    expect(resolveAnonymousBrowseUrl).not.toHaveBeenCalled();
   });
 
   it('warns with the URL when the browser cannot be opened', async () => {

--- a/packages/boxel-cli/tests/lib/published-realm.test.ts
+++ b/packages/boxel-cli/tests/lib/published-realm.test.ts
@@ -1,221 +1,128 @@
 import { describe, it, expect, vi } from 'vitest';
 
-import {
-  pickLatestPublishedOrigin,
-  resolvePublishedCardUrl,
-  resolveAnonymousBrowseUrl,
-} from '../../src/lib/published-realm.js';
+import { resolveAnonymousBrowseUrl } from '../../src/lib/published-realm.js';
 
 // A minimal Response stand-in shaped to what the resolver reads.
 function fakeResponse(
   status: number,
-  body: unknown,
   headers: Record<string, string> = {},
 ): Response {
-  let lower = new Headers(headers);
+  let realHeaders = new Headers(headers);
   return {
     ok: status >= 200 && status < 300,
     status,
     headers: {
-      get: (name: string) => lower.get(name),
+      get: (name: string) => realHeaders.get(name),
     },
-    json: async () => body,
-    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
   } as unknown as Response;
 }
 
-describe('pickLatestPublishedOrigin', () => {
-  it('returns undefined for null / string / empty maps', () => {
-    expect(pickLatestPublishedOrigin(null)).toBeUndefined();
-    expect(pickLatestPublishedOrigin(undefined)).toBeUndefined();
-    expect(pickLatestPublishedOrigin('2026-01-01')).toBeUndefined();
-    expect(pickLatestPublishedOrigin({})).toBeUndefined();
-  });
-
-  it('returns the single origin when there is one', () => {
-    expect(
-      pickLatestPublishedOrigin({ 'https://alice.boxel.space/': '1700000000' }),
-    ).toBe('https://alice.boxel.space/');
-  });
-
-  it('returns the most-recently published origin', () => {
-    expect(
-      pickLatestPublishedOrigin({
-        'https://old.boxel.space/': '1700000000',
-        'https://new.boxel.space/': '1800000000',
-      }),
-    ).toBe('https://new.boxel.space/');
-  });
-});
-
-describe('resolvePublishedCardUrl', () => {
-  it('rebases the card id onto the published origin', () => {
-    expect(
-      resolvePublishedCardUrl({
-        publishedOrigin: 'https://alice.boxel.space/',
-        sourceRealmUrl: 'https://app.boxel.ai/alice/blog/',
-        cardId: 'https://app.boxel.ai/alice/blog/Post/1',
-      }),
-    ).toBe('https://alice.boxel.space/Post/1');
-  });
-
-  it('strips a trailing index (the realm index card)', () => {
-    expect(
-      resolvePublishedCardUrl({
-        publishedOrigin: 'https://alice.boxel.space/',
-        sourceRealmUrl: 'https://app.boxel.ai/alice/blog/',
-        cardId: 'https://app.boxel.ai/alice/blog/index',
-      }),
-    ).toBe('https://alice.boxel.space/');
-  });
-
-  it('normalizes a published origin missing its trailing slash', () => {
-    expect(
-      resolvePublishedCardUrl({
-        publishedOrigin: 'https://alice.boxel.space',
-        sourceRealmUrl: 'https://app.boxel.ai/alice/blog/',
-        cardId: 'https://app.boxel.ai/alice/blog/Post/1',
-      }),
-    ).toBe('https://alice.boxel.space/Post/1');
-  });
-
-  it('returns undefined when the card id is not under the source realm', () => {
-    expect(
-      resolvePublishedCardUrl({
-        publishedOrigin: 'https://alice.boxel.space/',
-        sourceRealmUrl: 'https://app.boxel.ai/alice/blog/',
-        cardId: 'https://elsewhere.example.com/Post/1',
-      }),
-    ).toBeUndefined();
-  });
-});
+// Every realm response carries this header; its presence is what marks the
+// probed URL as a Boxel realm rather than an arbitrary site that returns 200.
+const REALM_HEADERS = { 'x-boxel-realm-url': 'https://alice.boxel.space/' };
 
 describe('resolveAnonymousBrowseUrl', () => {
   const REALM_SERVER = 'https://app.boxel.ai/';
-  const SOURCE_REALM = 'https://app.boxel.ai/alice/blog/';
-  const CARD_ID = 'https://app.boxel.ai/alice/blog/Post/1';
 
-  function publishedInfo(origin = 'https://alice.boxel.space/') {
-    return {
-      data: {
-        id: SOURCE_REALM,
-        attributes: { lastPublishedAt: { [origin]: '1800000000' } },
-      },
-    };
-  }
-
-  it('returns the published URL for a card in a published realm', async () => {
-    let authedRealmFetch = vi
+  it('returns a published-realm URL as-is when it serves anonymously', async () => {
+    let publicFetch = vi
       .fn()
-      // card fetch: realm header + canonical id
-      .mockResolvedValueOnce(
-        fakeResponse(
-          200,
-          { data: { id: CARD_ID } },
-          { 'x-boxel-realm-url': SOURCE_REALM },
-        ),
-      )
-      // _info fetch: lastPublishedAt map
-      .mockResolvedValueOnce(fakeResponse(200, publishedInfo()));
-    let publicFetch = vi.fn().mockResolvedValue(fakeResponse(200, {}));
+      .mockResolvedValue(fakeResponse(200, REALM_HEADERS));
 
     let url = await resolveAnonymousBrowseUrl(
       REALM_SERVER,
-      'alice/blog/Post/1',
-      {
-        authedRealmFetch,
-        publicFetch: publicFetch as unknown as typeof fetch,
-      },
+      'https://alice.boxel.space/Post/1',
+      { publicFetch: publicFetch as unknown as typeof fetch },
     );
 
     expect(url).toBe('https://alice.boxel.space/Post/1');
-    // The published URL was confirmed with an unauthenticated fetch.
+    // Probed unauthenticated, asking for the card representation.
     expect(publicFetch).toHaveBeenCalledWith(
       'https://alice.boxel.space/Post/1',
-      expect.anything(),
-    );
-  });
-
-  it('returns undefined when the card fetch is not found (fall back to auth)', async () => {
-    let authedRealmFetch = vi
-      .fn()
-      .mockResolvedValue(fakeResponse(404, 'not found'));
-
-    let url = await resolveAnonymousBrowseUrl(
-      REALM_SERVER,
-      'alice/blog/Post/1',
       {
-        authedRealmFetch,
+        headers: { Accept: 'application/vnd.card+json' },
       },
     );
-
-    expect(url).toBeUndefined();
   });
 
-  it('returns undefined when the realm is not published', async () => {
-    let authedRealmFetch = vi
+  it('handles a published site root (the realm serves its index card there)', async () => {
+    let publicFetch = vi
       .fn()
-      .mockResolvedValueOnce(
-        fakeResponse(
-          200,
-          { data: { id: CARD_ID } },
-          { 'x-boxel-realm-url': SOURCE_REALM },
-        ),
-      )
-      .mockResolvedValueOnce(
-        fakeResponse(200, {
-          data: { id: SOURCE_REALM, attributes: { lastPublishedAt: null } },
-        }),
-      );
+      .mockResolvedValue(fakeResponse(200, REALM_HEADERS));
 
     let url = await resolveAnonymousBrowseUrl(
       REALM_SERVER,
-      'alice/blog/Post/1',
-      {
-        authedRealmFetch,
-      },
+      'https://alice.boxel.space',
+      { publicFetch: publicFetch as unknown as typeof fetch },
     );
 
-    expect(url).toBeUndefined();
+    expect(url).toBe('https://alice.boxel.space/');
   });
 
-  it('returns undefined when the published URL does not render anonymously', async () => {
-    let authedRealmFetch = vi
-      .fn()
-      .mockResolvedValueOnce(
-        fakeResponse(
-          200,
-          { data: { id: CARD_ID } },
-          { 'x-boxel-realm-url': SOURCE_REALM },
-        ),
-      )
-      .mockResolvedValueOnce(fakeResponse(200, publishedInfo()));
-    // Stale lastPublishedAt: the published copy 404s without auth.
-    let publicFetch = vi.fn().mockResolvedValue(fakeResponse(404, 'gone'));
+  it('returns undefined for a relative card path (realm-server origin) without probing', async () => {
+    let publicFetch = vi.fn();
 
     let url = await resolveAnonymousBrowseUrl(
       REALM_SERVER,
       'alice/blog/Post/1',
       {
-        authedRealmFetch,
         publicFetch: publicFetch as unknown as typeof fetch,
       },
     );
 
     expect(url).toBeUndefined();
+    expect(publicFetch).not.toHaveBeenCalled();
   });
 
-  it('returns undefined when the authed fetch throws (no realm token, etc.)', async () => {
-    let authedRealmFetch = vi
-      .fn()
-      .mockRejectedValue(new Error('No realm token available'));
+  it('returns undefined for an absolute URL on the realm-server origin without probing', async () => {
+    let publicFetch = vi.fn();
 
     let url = await resolveAnonymousBrowseUrl(
       REALM_SERVER,
-      'alice/blog/Post/1',
-      {
-        authedRealmFetch,
-      },
+      'https://app.boxel.ai/alice/blog/Post/1',
+      { publicFetch: publicFetch as unknown as typeof fetch },
+    );
+
+    expect(url).toBeUndefined();
+    expect(publicFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when a foreign URL responds 200 without the realm header', async () => {
+    let publicFetch = vi.fn().mockResolvedValue(fakeResponse(200));
+
+    let url = await resolveAnonymousBrowseUrl(
+      REALM_SERVER,
+      'https://example.com/some/page',
+      { publicFetch: publicFetch as unknown as typeof fetch },
+    );
+
+    expect(url).toBeUndefined();
+  });
+
+  it('returns undefined when the anonymous probe is not ok', async () => {
+    // e.g. the realm was unpublished, or the card is absent from the copy.
+    let publicFetch = vi
+      .fn()
+      .mockResolvedValue(fakeResponse(404, REALM_HEADERS));
+
+    let url = await resolveAnonymousBrowseUrl(
+      REALM_SERVER,
+      'https://alice.boxel.space/Post/1',
+      { publicFetch: publicFetch as unknown as typeof fetch },
+    );
+
+    expect(url).toBeUndefined();
+  });
+
+  it('returns undefined when the probe throws (unreachable origin, etc.)', async () => {
+    let publicFetch = vi
+      .fn()
+      .mockRejectedValue(new Error('getaddrinfo ENOTFOUND'));
+
+    let url = await resolveAnonymousBrowseUrl(
+      REALM_SERVER,
+      'https://gone.boxel.space/Post/1',
+      { publicFetch: publicFetch as unknown as typeof fetch },
     );
 
     expect(url).toBeUndefined();

--- a/packages/boxel-cli/tests/lib/published-realm.test.ts
+++ b/packages/boxel-cli/tests/lib/published-realm.test.ts
@@ -6,6 +6,7 @@ import { resolveAnonymousBrowseUrl } from '../../src/lib/published-realm.js';
 function fakeResponse(
   status: number,
   headers: Record<string, string> = {},
+  body = '',
 ): Response {
   let realHeaders = new Headers(headers);
   return {
@@ -14,12 +15,18 @@ function fakeResponse(
     headers: {
       get: (name: string) => realHeaders.get(name),
     },
+    text: async () => body,
   } as unknown as Response;
 }
 
 // Every realm response carries this header; its presence is what marks the
 // probed URL as a Boxel realm rather than an arbitrary site that returns 200.
 const REALM_HEADERS = { 'x-boxel-realm-url': 'https://alice.boxel.space/' };
+
+// The Boxel host shell always carries the host config meta tag; the routing
+// fallback keys on it because the shell stamps no realm header.
+const SHELL_BODY =
+  '<!DOCTYPE html><meta name="@cardstack/host/config/environment" content="%7B%7D"><body></body>';
 
 describe('resolveAnonymousBrowseUrl', () => {
   const REALM_SERVER = 'https://app.boxel.ai/';
@@ -36,10 +43,12 @@ describe('resolveAnonymousBrowseUrl', () => {
     );
 
     expect(url).toBe('https://alice.boxel.space/Post/1');
-    // Probed unauthenticated, asking for the card representation.
+    // Probed unauthenticated with a HEAD, asking for the card representation —
+    // we only read the status and realm header, never a body.
     expect(publicFetch).toHaveBeenCalledWith(
       'https://alice.boxel.space/Post/1',
       {
+        method: 'HEAD',
         headers: { Accept: 'application/vnd.card+json' },
       },
     );
@@ -57,6 +66,74 @@ describe('resolveAnonymousBrowseUrl', () => {
     );
 
     expect(url).toBe('https://alice.boxel.space/');
+  });
+
+  it('recognizes a host-routed/vanity path the card probe cannot see', async () => {
+    // `/pricing` (mapped to a card elsewhere) is not itself an indexed card, so
+    // the card+json HEAD 404s; a browser reaches it with a text/html
+    // navigation that applies the routing map and gets the host shell.
+    let publicFetch = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse(404))
+      .mockResolvedValueOnce(fakeResponse(200, {}, SHELL_BODY));
+
+    let url = await resolveAnonymousBrowseUrl(
+      REALM_SERVER,
+      'https://alice.boxel.space/pricing',
+      { publicFetch: publicFetch as unknown as typeof fetch },
+    );
+
+    expect(url).toBe('https://alice.boxel.space/pricing');
+    // Second probe is the browser-style navigation.
+    expect(publicFetch).toHaveBeenNthCalledWith(
+      2,
+      'https://alice.boxel.space/pricing',
+      { headers: { Accept: 'text/html' } },
+    );
+  });
+
+  it('rejects a foreign 200 that is not the Boxel host shell', async () => {
+    // Card probe misses and the text/html fallback returns some other site's
+    // 200 — no host config meta tag, so it is not a published realm.
+    let publicFetch = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse(404))
+      .mockResolvedValueOnce(fakeResponse(200, {}, '<html>not boxel</html>'));
+
+    let url = await resolveAnonymousBrowseUrl(
+      REALM_SERVER,
+      'https://example.com/pricing',
+      { publicFetch: publicFetch as unknown as typeof fetch },
+    );
+
+    expect(url).toBeUndefined();
+  });
+
+  it('resolves an absolute published URL with no profile (undefined realm server)', async () => {
+    // A fresh install has no active profile, hence no realm-server URL, but an
+    // absolute published URL still needs no credentials.
+    let publicFetch = vi
+      .fn()
+      .mockResolvedValue(fakeResponse(200, REALM_HEADERS));
+
+    let url = await resolveAnonymousBrowseUrl(
+      undefined,
+      'https://alice.boxel.space/Post/1',
+      { publicFetch: publicFetch as unknown as typeof fetch },
+    );
+
+    expect(url).toBe('https://alice.boxel.space/Post/1');
+  });
+
+  it('returns undefined for a relative path with no profile (no origin to resolve)', async () => {
+    let publicFetch = vi.fn();
+
+    let url = await resolveAnonymousBrowseUrl(undefined, 'alice/blog/Post/1', {
+      publicFetch: publicFetch as unknown as typeof fetch,
+    });
+
+    expect(url).toBeUndefined();
+    expect(publicFetch).not.toHaveBeenCalled();
   });
 
   it('returns undefined for a relative card path (realm-server origin) without probing', async () => {
@@ -88,7 +165,11 @@ describe('resolveAnonymousBrowseUrl', () => {
   });
 
   it('returns undefined when a foreign URL responds 200 without the realm header', async () => {
-    let publicFetch = vi.fn().mockResolvedValue(fakeResponse(200));
+    // Card probe: 200 but no realm header. Fallback: still no host shell.
+    let publicFetch = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse(200))
+      .mockResolvedValueOnce(fakeResponse(200, {}, '<html>not boxel</html>'));
 
     let url = await resolveAnonymousBrowseUrl(
       REALM_SERVER,
@@ -99,11 +180,12 @@ describe('resolveAnonymousBrowseUrl', () => {
     expect(url).toBeUndefined();
   });
 
-  it('returns undefined when the anonymous probe is not ok', async () => {
+  it('returns undefined when both probes miss (unpublished, or card absent)', async () => {
     // e.g. the realm was unpublished, or the card is absent from the copy.
     let publicFetch = vi
       .fn()
-      .mockResolvedValue(fakeResponse(404, REALM_HEADERS));
+      .mockResolvedValueOnce(fakeResponse(404, REALM_HEADERS))
+      .mockResolvedValueOnce(fakeResponse(404));
 
     let url = await resolveAnonymousBrowseUrl(
       REALM_SERVER,

--- a/packages/boxel-cli/tests/lib/published-realm.test.ts
+++ b/packages/boxel-cli/tests/lib/published-realm.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  pickLatestPublishedOrigin,
+  resolvePublishedCardUrl,
+  resolveAnonymousBrowseUrl,
+} from '../../src/lib/published-realm.js';
+
+// A minimal Response stand-in shaped to what the resolver reads.
+function fakeResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  let lower = new Headers(headers);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) => lower.get(name),
+    },
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('pickLatestPublishedOrigin', () => {
+  it('returns undefined for null / string / empty maps', () => {
+    expect(pickLatestPublishedOrigin(null)).toBeUndefined();
+    expect(pickLatestPublishedOrigin(undefined)).toBeUndefined();
+    expect(pickLatestPublishedOrigin('2026-01-01')).toBeUndefined();
+    expect(pickLatestPublishedOrigin({})).toBeUndefined();
+  });
+
+  it('returns the single origin when there is one', () => {
+    expect(
+      pickLatestPublishedOrigin({ 'https://alice.boxel.space/': '1700000000' }),
+    ).toBe('https://alice.boxel.space/');
+  });
+
+  it('returns the most-recently published origin', () => {
+    expect(
+      pickLatestPublishedOrigin({
+        'https://old.boxel.space/': '1700000000',
+        'https://new.boxel.space/': '1800000000',
+      }),
+    ).toBe('https://new.boxel.space/');
+  });
+});
+
+describe('resolvePublishedCardUrl', () => {
+  it('rebases the card id onto the published origin', () => {
+    expect(
+      resolvePublishedCardUrl({
+        publishedOrigin: 'https://alice.boxel.space/',
+        sourceRealmUrl: 'https://app.boxel.ai/alice/blog/',
+        cardId: 'https://app.boxel.ai/alice/blog/Post/1',
+      }),
+    ).toBe('https://alice.boxel.space/Post/1');
+  });
+
+  it('strips a trailing index (the realm index card)', () => {
+    expect(
+      resolvePublishedCardUrl({
+        publishedOrigin: 'https://alice.boxel.space/',
+        sourceRealmUrl: 'https://app.boxel.ai/alice/blog/',
+        cardId: 'https://app.boxel.ai/alice/blog/index',
+      }),
+    ).toBe('https://alice.boxel.space/');
+  });
+
+  it('normalizes a published origin missing its trailing slash', () => {
+    expect(
+      resolvePublishedCardUrl({
+        publishedOrigin: 'https://alice.boxel.space',
+        sourceRealmUrl: 'https://app.boxel.ai/alice/blog/',
+        cardId: 'https://app.boxel.ai/alice/blog/Post/1',
+      }),
+    ).toBe('https://alice.boxel.space/Post/1');
+  });
+
+  it('returns undefined when the card id is not under the source realm', () => {
+    expect(
+      resolvePublishedCardUrl({
+        publishedOrigin: 'https://alice.boxel.space/',
+        sourceRealmUrl: 'https://app.boxel.ai/alice/blog/',
+        cardId: 'https://elsewhere.example.com/Post/1',
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('resolveAnonymousBrowseUrl', () => {
+  const REALM_SERVER = 'https://app.boxel.ai/';
+  const SOURCE_REALM = 'https://app.boxel.ai/alice/blog/';
+  const CARD_ID = 'https://app.boxel.ai/alice/blog/Post/1';
+
+  function publishedInfo(origin = 'https://alice.boxel.space/') {
+    return {
+      data: {
+        id: SOURCE_REALM,
+        attributes: { lastPublishedAt: { [origin]: '1800000000' } },
+      },
+    };
+  }
+
+  it('returns the published URL for a card in a published realm', async () => {
+    let authedRealmFetch = vi
+      .fn()
+      // card fetch: realm header + canonical id
+      .mockResolvedValueOnce(
+        fakeResponse(
+          200,
+          { data: { id: CARD_ID } },
+          { 'x-boxel-realm-url': SOURCE_REALM },
+        ),
+      )
+      // _info fetch: lastPublishedAt map
+      .mockResolvedValueOnce(fakeResponse(200, publishedInfo()));
+    let publicFetch = vi.fn().mockResolvedValue(fakeResponse(200, {}));
+
+    let url = await resolveAnonymousBrowseUrl(
+      REALM_SERVER,
+      'alice/blog/Post/1',
+      {
+        authedRealmFetch,
+        publicFetch: publicFetch as unknown as typeof fetch,
+      },
+    );
+
+    expect(url).toBe('https://alice.boxel.space/Post/1');
+    // The published URL was confirmed with an unauthenticated fetch.
+    expect(publicFetch).toHaveBeenCalledWith(
+      'https://alice.boxel.space/Post/1',
+      expect.anything(),
+    );
+  });
+
+  it('returns undefined when the card fetch is not found (fall back to auth)', async () => {
+    let authedRealmFetch = vi
+      .fn()
+      .mockResolvedValue(fakeResponse(404, 'not found'));
+
+    let url = await resolveAnonymousBrowseUrl(
+      REALM_SERVER,
+      'alice/blog/Post/1',
+      {
+        authedRealmFetch,
+      },
+    );
+
+    expect(url).toBeUndefined();
+  });
+
+  it('returns undefined when the realm is not published', async () => {
+    let authedRealmFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        fakeResponse(
+          200,
+          { data: { id: CARD_ID } },
+          { 'x-boxel-realm-url': SOURCE_REALM },
+        ),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse(200, {
+          data: { id: SOURCE_REALM, attributes: { lastPublishedAt: null } },
+        }),
+      );
+
+    let url = await resolveAnonymousBrowseUrl(
+      REALM_SERVER,
+      'alice/blog/Post/1',
+      {
+        authedRealmFetch,
+      },
+    );
+
+    expect(url).toBeUndefined();
+  });
+
+  it('returns undefined when the published URL does not render anonymously', async () => {
+    let authedRealmFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        fakeResponse(
+          200,
+          { data: { id: CARD_ID } },
+          { 'x-boxel-realm-url': SOURCE_REALM },
+        ),
+      )
+      .mockResolvedValueOnce(fakeResponse(200, publishedInfo()));
+    // Stale lastPublishedAt: the published copy 404s without auth.
+    let publicFetch = vi.fn().mockResolvedValue(fakeResponse(404, 'gone'));
+
+    let url = await resolveAnonymousBrowseUrl(
+      REALM_SERVER,
+      'alice/blog/Post/1',
+      {
+        authedRealmFetch,
+        publicFetch: publicFetch as unknown as typeof fetch,
+      },
+    );
+
+    expect(url).toBeUndefined();
+  });
+
+  it('returns undefined when the authed fetch throws (no realm token, etc.)', async () => {
+    let authedRealmFetch = vi
+      .fn()
+      .mockRejectedValue(new Error('No realm token available'));
+
+    let url = await resolveAnonymousBrowseUrl(
+      REALM_SERVER,
+      'alice/blog/Post/1',
+      {
+        authedRealmFetch,
+      },
+    );
+
+    expect(url).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

`boxel browse <card-path>` now opens the URL **as-is, with no login token**, when `card-path` is a URL in a **published** realm — the one case the host renders anonymously (host mode, on the realm's own origin). Every other case keeps the existing authenticated login-token flow. The command interface is unchanged.

## Why open-as-is, not source→published rebasing

A published realm is a filesystem **snapshot** taken at publish time. Automatically rebasing a source-realm path onto its published origin would silently swap the live, editable card for a possibly-stale read-only copy — worst for realm owners in an edit → sync → browse loop. Since a published card and its source card always live at **different URLs**, the URL the user passes already states which one they want:

- a published-realm URL → open it anonymously, exactly as given;
- a source path/URL → the live card → token flow, as today.

A world-readable-but-unpublished realm has no anonymous render URL (its origin serves the login-gated operator app), so it also correctly takes the token flow.

## How

Only with a card path and no `--host-url`, before minting a token:
1. Resolve the path. With a profile, same origin as its realm server (including every relative path) → token flow — mirrors the host's own origin-based host-mode detection. With no profile (a fresh install), an absolute URL still resolves; a relative path has no origin to resolve against, so it takes the token flow.
2. Probe the resolved URL unauthenticated, cheapest-first:
   - a card+json **`HEAD`** — a `2xx` carrying the `x-boxel-realm-url` header (stamped on every realm response) proves a published card renders anonymously;
   - if that `404`s, the path may be a host-routed/vanity URL (e.g. `/pricing` mapped to a card elsewhere) that isn't itself an indexed card, so the card probe bypasses the routing map the realm server only applies to browser navigations. Re-probe the way a browser would — a `text/html` `GET` — and confirm the response is the Boxel host shell (its config meta tag; the routed HTML path stamps no realm header).
3. Open the resolved URL — no `loginToken`. Anything else falls back to today's login-token flow, unchanged.

The anonymous path runs **before** the token flow insists on a profile, so a fresh install with no profile can still open an absolute published URL.

## Tests

- `tests/lib/published-realm.test.ts`: published URL opens as-is (incl. site root and no-profile absolute URLs); host-routed/vanity paths recognized via the shell fallback; relative paths and realm-server-origin URLs skip the probe entirely; foreign 200s (no realm header, not the host shell), both-probes-miss, and thrown probes all fall back.
- `tests/commands/browse.test.ts`: a published-realm URL opens with no token minted (incl. with no active profile); `--print-url` prints it; non-published falls back to the token flow (and still errors when no profile exists); bare `browse` and `--host-url` skip the anonymous path.
- boxel-cli unit suite passes (546). `tsc --noEmit`, prettier, and eslint clean.

## Not covered here

- Auto-redirecting a **source** path to its published copy — deliberately excluded (staleness + silent read-only downgrade). If wanted later, it fits as an explicit `--published` flag.
- Anonymous browsing of *unpublished* world-readable realms — no anonymous render URL exists for those; it would require a host operator-route change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
