### PR TITLE
ci: Add index cache worker and raise timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1097,8 +1097,8 @@ jobs:
     needs: [change-check, test-web-assets]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    # Must exceed the 45-minute ceiling on the index step below.
-    timeout-minutes: 60
+    # Must exceed the ceiling on the index step below.
+    timeout-minutes: 70
     concurrency:
       group: cache-index-${{ github.run_id }}
       cancel-in-progress: false
@@ -1121,7 +1121,12 @@ jobs:
         run: |
           set -o pipefail
           mise run ci:cache-index 2>&1 | tee /tmp/cache-index.log
-        timeout-minutes: 45
+        # Outer bound on the task's own readiness budget (READINESS_TIMEOUT_MS,
+        # 40m) plus the test-realm wait and the dump that follow it. It has to
+        # stay the looser of the two: when the task's budget expires first it
+        # says how long it waited and against what, and a step timeout that
+        # fired first would replace that with nothing.
+        timeout-minutes: 55
       - name: Upload service logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1098,7 +1098,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     # Must exceed the ceiling on the index step below.
-    timeout-minutes: 70
+    timeout-minutes: 75
     concurrency:
       group: cache-index-${{ github.run_id }}
       cancel-in-progress: false
@@ -1121,12 +1121,19 @@ jobs:
         run: |
           set -o pipefail
           mise run ci:cache-index 2>&1 | tee /tmp/cache-index.log
-        # Outer bound on the task's own readiness budget (READINESS_TIMEOUT_MS,
-        # 40m) plus the test-realm wait and the dump that follow it. It has to
-        # stay the looser of the two: when the task's budget expires first it
-        # says how long it waited and against what, and a step timeout that
-        # fired first would replace that with nothing.
-        timeout-minutes: 55
+        # Must exceed every wait the task can sit through, summed — a step
+        # killed here reports neither which wait was outstanding nor for how
+        # long, and that diagnosis is the point of the task's own budgets.
+        # Both waits can expire in the same run, so the bound is their sum
+        # plus the work around them:
+        #   READINESS_TIMEOUT_MS       40m  (realm readiness)
+        # + TEST_READINESS_TIMEOUT_MS  10m  (test-realm readiness)
+        # + service startup             2m
+        # + dump, verify, gzip          4m
+        # = 56m, so 60 leaves a small margin. Raising either budget in
+        # mise-tasks/ci/cache-index means raising this and the job's ceiling
+        # with it.
+        timeout-minutes: 60
       - name: Upload service logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -84,21 +84,48 @@ pnpm --dir=../matrix register-realm-users
 ensure_services_running
 
 echo "Waiting for realm readiness..."
+# The budget is the whole boot index of every realm this job serves, and one
+# all-priority worker walks them serially — the experiments realm alone is
+# ~1500 files. That total sits close enough to the ceiling that a slightly
+# slow runner pushes past it, so the ceiling is reported alongside the time
+# actually taken (below): "the job timed out" is not actionable, "readiness
+# took 28m against a 40m budget" is. Keep this under the enclosing step's
+# `timeout-minutes` in .github/workflows/ci.yaml, which has to be the outer
+# bound or the timeout arrives with no log line explaining it.
+READINESS_TIMEOUT_MS="${READINESS_TIMEOUT_MS:-2400000}"
+READINESS_START=$(date +%s)
+
 # Probe-only TLS relaxation: the realm-server / host now serve the
 # self-signed mkcert leaf on https://localhost:42XX and wait-on's
 # in-process axios doesn't pick up NODE_EXTRA_CA_CERTS reliably on CI
 # runners. The actual services under test still validate normally.
 NODE_TLS_REJECT_UNAUTHORIZED=0 \
-  wait-on -t 1800000 $(echo "$READINESS_URLS" | tr '|' ' ') &
+  wait-on -t "$READINESS_TIMEOUT_MS" $(echo "$READINESS_URLS" | tr '|' ' ') &
 WAIT_ON_PID=$!
 
 while kill -0 "$WAIT_ON_PID" 2>/dev/null; do
   ensure_services_running
   sleep 1
 done
-wait "$WAIT_ON_PID"
 
-echo "All realms ready."
+# The status is captured rather than left to `set -e` so the duration below
+# gets printed on a timeout too — "gave up after 40m" next to the budget is
+# what says whether the budget is wrong or the indexing is, and exiting here
+# would take the one number worth having with it.
+if wait "$WAIT_ON_PID"; then
+  READINESS_STATUS=0
+else
+  READINESS_STATUS=$?
+fi
+READINESS_ELAPSED=$(( $(date +%s) - READINESS_START ))
+READINESS_TOOK="$((READINESS_ELAPSED / 60))m$((READINESS_ELAPSED % 60))s (budget $((READINESS_TIMEOUT_MS / 60000))m, workers=${WORKER_ALL_PRIORITY_COUNT:-1})"
+
+if [ "$READINESS_STATUS" -ne 0 ]; then
+  echo "::error title=Realm readiness timed out::Gave up after ${READINESS_TOOK}. The boot index is serial behind the all-priority workers; raise READINESS_TIMEOUT_MS or WORKER_ALL_PRIORITY_COUNT."
+  exit "$READINESS_STATUS"
+fi
+
+echo "All realms ready in ${READINESS_TOOK}."
 
 # Bring up the live test realms (`/test/`, `/node-test/`) once the dev stack is
 # serving. They run in their own realm-server process against their own

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -105,9 +105,10 @@ echo "Waiting for realm readiness..."
 # ~1500 files. That total sits close enough to the ceiling that a slightly
 # slow runner pushes past it, so the ceiling is reported alongside the time
 # actually taken (below): "the job timed out" is not actionable, "readiness
-# took 28m against a 40m budget" is. Keep this under the enclosing step's
-# `timeout-minutes` in .github/workflows/ci.yaml, which has to be the outer
-# bound or the timeout arrives with no log line explaining it.
+# took 28m against a 40m budget" is. This budget and the test-realm one below
+# have to sum to less than the enclosing step's `timeout-minutes` in
+# .github/workflows/ci.yaml, which spells the arithmetic out: both can expire
+# in one run, and a step killed by GitHub first reports neither number.
 READINESS_TIMEOUT_MS="${READINESS_TIMEOUT_MS:-2400000}"
 READINESS_START=$(date +%s)
 
@@ -137,7 +138,7 @@ READINESS_ELAPSED=$(( $(date +%s) - READINESS_START ))
 READINESS_TOOK="$((READINESS_ELAPSED / 60))m$((READINESS_ELAPSED % 60))s (budget $((READINESS_TIMEOUT_MS / 60000))m, workers=${WORKER_ALL_PRIORITY_COUNT:-1})"
 
 if [ "$READINESS_STATUS" -ne 0 ]; then
-  echo "::error title=Realm readiness timed out::Gave up after ${READINESS_TOOK}. The boot index is serial behind the all-priority workers; raise READINESS_TIMEOUT_MS or WORKER_ALL_PRIORITY_COUNT."
+  echo "::error title=Realm readiness timed out::Gave up after ${READINESS_TOOK}. The boot index is serial behind the all-priority workers; raise READINESS_TIMEOUT_MS or CACHE_INDEX_WORKER_COUNT. Not WORKER_ALL_PRIORITY_COUNT — this task overwrites it."
   exit "$READINESS_STATUS"
 fi
 
@@ -181,8 +182,17 @@ for realm in test node-test; do
 done
 
 echo "Waiting for test realm readiness..."
+# Two realms of a few dozen files each, indexing against a base realm that is
+# already served by the time this runs — it settles in about a minute. The
+# budget is deliberately far tighter than the one above, because it and that
+# one have to *sum* to less than the enclosing step's `timeout-minutes`: a
+# step killed by GitHub reports neither which wait was outstanding nor for how
+# long, which is the diagnosis this task exists to provide. See the arithmetic
+# in .github/workflows/ci.yaml.
+TEST_READINESS_TIMEOUT_MS="${TEST_READINESS_TIMEOUT_MS:-600000}"
+
 NODE_TLS_REJECT_UNAUTHORIZED=0 \
-  wait-on -t 1800000 $(echo "$TEST_READINESS_URLS" | tr '|' ' ') &
+  wait-on -t "$TEST_READINESS_TIMEOUT_MS" $(echo "$TEST_READINESS_URLS" | tr '|' ' ') &
 TEST_WAIT_ON_PID=$!
 
 while kill -0 "$TEST_WAIT_ON_PID" 2>/dev/null; do

--- a/mise-tasks/ci/cache-index
+++ b/mise-tasks/ci/cache-index
@@ -50,6 +50,22 @@ node "$REPO_ROOT/scripts/normalize-realm-mtimes.mjs" \
   ../base ../skills-realm/contents ../openrouter-realm
 
 echo "Starting services..."
+# This job's cost is almost entirely the boot index of every realm it serves,
+# and the workers are what walk it — one of them takes the whole set serially.
+# The readiness line below reports this count alongside the time taken, so a
+# change here is measurable against the previous run rather than guessed at.
+# Raising it trades against the runner's four vCPUs and the prerender page
+# pool the index drives, so it does not scale indefinitely.
+#
+# The override is its own variable, and it is assigned unconditionally.
+# `WORKER_ALL_PRIORITY_COUNT="${WORKER_ALL_PRIORITY_COUNT:-2}"` looks
+# equivalent and silently is not: .mise.toml sources mise-tasks/lib/env-vars.sh
+# into `[env]`, so every task starts with that variable already exported as 1
+# and the `:-` default can never fire. The failure is quiet — the job runs at
+# the old count and only the reported worker count gives it away.
+CACHE_INDEX_WORKER_COUNT="${CACHE_INDEX_WORKER_COUNT:-2}"
+export WORKER_ALL_PRIORITY_COUNT="$CACHE_INDEX_WORKER_COUNT"
+
 SKIP_BOXEL_HOMEPAGE=true \
   NODE_NO_WARNINGS=1 \
   run-p -ln start:icons start:host-dist start:pg start:prerender-dev start:prerender-manager-dev start:matrix start:smtp start:worker-development start:development &


### PR DESCRIPTION
The indexing-caching job on `main` has been timing out. Via a workflow hack to iterate on the caching, this:
* adds a second worker, which sped up the cache by ≈50%
* raises the timeout
* logs the timing more explicitly for future analysis

<details><summary>Claude explanation</summary>The cache-index job waited 30 minutes for every realm it serves to finish its boot index, and that boot index now takes about that long: one all-priority worker walks the realms serially and the experiments realm alone is ~1500 files. Runs landed on either side of the line, so the job failed 44 of its last 53 attempts on main, always at exactly the timeout, and the boxel-index-cache artifacts stopped being refreshed.

Raise the wait to 40 minutes and report how long readiness actually took, against the budget and the worker count, on both the success and the timeout path. The duration is the number that says whether the budget is wrong or the indexing is, and the previous code exited on `set -e` before printing anything.

The step and job ceilings move out to stay the looser bound, so the task's own budget is what expires first and explains itself.

Includes a temporary trigger so this job runs on the branch; both halves are marked REVERT BEFORE MERGE.</details>