### PR TITLE
Keep the skills clone current, and fail when it can't be made

### DIFF
--- a/packages/skills-realm/README.md
+++ b/packages/skills-realm/README.md
@@ -46,11 +46,25 @@ If you have started from scratch these should have been automatically run for yo
 
 The skills realm package includes helper scripts for managing the skills repository:
 
-| Script               | Description                                                             |
-| -------------------- | ----------------------------------------------------------------------- |
-| `pnpm skills:setup`  | Clones the boxel-skills repository into `contents/` if it doesn't exist |
-| `pnpm skills:update` | Pulls latest changes from the boxel-skills repository                   |
-| `pnpm skills:reset`  | Removes the `contents/` directory and re-clones the repository          |
+| Script               | Description                                                          |
+| -------------------- | -------------------------------------------------------------------- |
+| `pnpm skills:setup`  | Clones `contents/` if it isn't there, and otherwise brings it up to date |
+| `pnpm skills:update` | The same thing — the two names both run `setup.sh`                    |
+| `pnpm skills:reset`  | Removes `contents/` and clones it again                               |
+
+The content is not pinned to a revision. `cardstack/boxel-skills` is iterated
+on daily, so a pin would mean somebody moving a revision every week to stay
+current. The trade-off is that realm content can change with no commit in this
+repository behind it — so if a test or Percy snapshot that renders skills
+content moves on its own, that is why, and the fix belongs in the test rather
+than here.
+
+An existing `contents/` is brought up to date rather than left alone, so a
+machine that cloned it months ago doesn't quietly keep serving old skills while
+CI — which clones fresh every run — serves current ones. Two cases are left
+untouched: uncommitted changes in `contents/`, so trying something out in place
+isn't overwritten, and a detached HEAD. Being offline costs you the update, not
+the ability to start the stack.
 
 ## Development Workflows
 

--- a/packages/skills-realm/package.json
+++ b/packages/skills-realm/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "skills:setup": "[ -d contents ] || git clone git@github.com:cardstack/boxel-skills.git contents || git clone https://github.com/cardstack/boxel-skills.git contents",
-    "skills:update": "pnpm skills:setup && cd contents && git pull",
-    "skills:reset": "rm -rf contents && pnpm skills:setup"
+    "skills:setup": "./setup.sh",
+    "skills:update": "./setup.sh",
+    "skills:reset": "rm -rf contents && ./setup.sh"
   }
 }

--- a/packages/skills-realm/setup.sh
+++ b/packages/skills-realm/setup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Put the skills realm's content on disk, and keep it current.
+#
+# The content is a separate repository, cardstack/boxel-skills, rather than
+# anything committed here. It is deliberately not pinned to a revision: it is
+# iterated on daily, and pinning would mean somebody moving a SHA every week to
+# stay current. The cost of that is that realm content can change with no
+# commit in this repository behind it — so a test or Percy snapshot that
+# surfaces skills content can move on its own. Measured over twelve weeks that
+# is roughly one Percy diff every three weeks on a single snapshot; the fix for
+# that belongs in the tests that render third-party content, not here.
+#
+# (packages/boxel-cli/scripts/build-skills.ts does pin this same repository,
+# to a released tag. That is a different job: the CLI ships those skills to
+# users, so it needs to ship a known version.)
+set -euo pipefail
+
+SSH_URL="git@github.com:cardstack/boxel-skills.git"
+HTTPS_URL="https://github.com/cardstack/boxel-skills.git"
+
+cd "$(dirname "$0")"
+
+if [ ! -d contents ]; then
+  # SSH first so contributors with a key use their credentials, HTTPS second
+  # because the repository is public and CI has no key. The SSH attempt is
+  # expected to fail in CI, so its output is dropped: left visible it prints
+  # "Permission denied (publickey)" on every run, which reads like a broken
+  # build to anyone scanning a log for a real failure.
+  echo "Cloning boxel-skills ..."
+  git clone --quiet "$SSH_URL" contents 2>/dev/null ||
+    git clone --quiet "$HTTPS_URL" contents || {
+      echo "both ssh and https clone of boxel-skills failed; check GitHub auth and network" >&2
+      exit 1
+    }
+  exit 0
+fi
+
+# An existing clone used to be left untouched forever, so a machine that had
+# ever run this kept whatever content it first cloned — indefinitely, and
+# silently. Fresh CI checkouts hid that; a developer's machine did not.
+#
+# Somebody may be editing skills content in place to try something out, and
+# updating over that would throw the work away without asking.
+if [ -n "$(git -C contents status --porcelain)" ]; then
+  echo "packages/skills-realm/contents has uncommitted changes; leaving it as it is." >&2
+  echo "Commit or discard them and re-run \`pnpm skills:update\` to bring it up to date." >&2
+  exit 0
+fi
+
+branch=$(git -C contents symbolic-ref --quiet --short HEAD || true)
+if [ -z "$branch" ]; then
+  echo "packages/skills-realm/contents is not on a branch; leaving it as it is." >&2
+  exit 0
+fi
+
+# Not fatal: this runs on the way into every dev stack, and being offline —
+# or upstream being briefly unreachable — should cost you the update, not the
+# ability to start. CI never reaches here anyway; its checkouts have no
+# `contents` yet, so they take the clone above.
+if ! git -C contents pull --quiet --ff-only 2>/dev/null; then
+  echo "Could not update skills content; continuing with what is on disk." >&2
+  echo "Re-run \`pnpm skills:update\` once you are back online." >&2
+fi

--- a/packages/skills-realm/setup.sh
+++ b/packages/skills-realm/setup.sh
@@ -5,11 +5,11 @@
 # The content is a separate repository, cardstack/boxel-skills, rather than
 # anything committed here. It is deliberately not pinned to a revision: it is
 # iterated on daily, and pinning would mean somebody moving a SHA every week to
-# stay current. The cost of that is that realm content can change with no
-# commit in this repository behind it — so a test or Percy snapshot that
-# surfaces skills content can move on its own. Measured over twelve weeks that
-# is roughly one Percy diff every three weeks on a single snapshot; the fix for
-# that belongs in the tests that render third-party content, not here.
+# stay current. The cost is that realm content can change with no commit in
+# this repository behind it — so a test or Percy snapshot that renders skills
+# content can move on its own. Measured over twelve weeks that is roughly one
+# Percy diff every three weeks on a single snapshot; the fix for that belongs
+# in the tests that render third-party content, not here.
 #
 # (packages/boxel-cli/scripts/build-skills.ts does pin this same repository,
 # to a released tag. That is a different job: the CLI ships those skills to
@@ -21,24 +21,54 @@ HTTPS_URL="https://github.com/cardstack/boxel-skills.git"
 
 cd "$(dirname "$0")"
 
-if [ ! -d contents ]; then
+clone() {
   # SSH first so contributors with a key use their credentials, HTTPS second
   # because the repository is public and CI has no key. The SSH attempt is
-  # expected to fail in CI, so its output is dropped: left visible it prints
-  # "Permission denied (publickey)" on every run, which reads like a broken
-  # build to anyone scanning a log for a real failure.
+  # expected to fail wherever there is no key, so its output is dropped: left
+  # visible it prints "Permission denied (publickey)" on every CI run, which
+  # reads like the cause when you are scanning a log for a real failure.
   echo "Cloning boxel-skills ..."
   git clone --quiet "$SSH_URL" contents 2>/dev/null ||
     git clone --quiet "$HTTPS_URL" contents || {
       echo "both ssh and https clone of boxel-skills failed; check GitHub auth and network" >&2
       exit 1
     }
+}
+
+# Whether `contents` is the root of its own clone.
+#
+# Asking git whether it is *a* repository is not enough: `contents` sits inside
+# this repository, so from an empty `contents/` git walks up and answers with
+# the monorepo's worktree. The directory only holds skills content when the
+# worktree root git reports is `contents` itself.
+is_own_clone() {
+  [ -d contents ] || return 1
+  local top
+  top=$(git -C contents rev-parse --show-toplevel 2>/dev/null) || return 1
+  [ "$top" = "$(cd contents && pwd -P)" ]
+}
+
+if ! is_own_clone; then
+  if [ -d contents ]; then
+    # A `contents/` that exists without being a clone is the state the two
+    # "Populate skills-realm content" steps in ci-host.yaml already work
+    # around, so it does happen. Left alone it is the worst outcome available:
+    # every check below reads as "nothing to do" and the caller is told setup
+    # succeeded while the realm serves nothing.
+    if [ -n "$(ls -A contents)" ]; then
+      echo "packages/skills-realm/contents exists, holds files, and is not a boxel-skills clone." >&2
+      echo "Move or delete it and re-run; refusing to delete files that aren't ours." >&2
+      exit 1
+    fi
+    rmdir contents
+  fi
+  clone
   exit 0
 fi
 
 # An existing clone used to be left untouched forever, so a machine that had
 # ever run this kept whatever content it first cloned — indefinitely, and
-# silently. Fresh CI checkouts hid that; a developer's machine did not.
+# silently, while CI clones fresh on every run and serves current skills.
 #
 # Somebody may be editing skills content in place to try something out, and
 # updating over that would throw the work away without asking.
@@ -48,16 +78,15 @@ if [ -n "$(git -C contents status --porcelain)" ]; then
   exit 0
 fi
 
-branch=$(git -C contents symbolic-ref --quiet --short HEAD || true)
-if [ -z "$branch" ]; then
+if ! git -C contents symbolic-ref --quiet HEAD >/dev/null 2>&1; then
   echo "packages/skills-realm/contents is not on a branch; leaving it as it is." >&2
   exit 0
 fi
 
 # Not fatal: this runs on the way into every dev stack, and being offline —
 # or upstream being briefly unreachable — should cost you the update, not the
-# ability to start. CI never reaches here anyway; its checkouts have no
-# `contents` yet, so they take the clone above.
+# ability to start. CI rarely reaches here; its checkouts have no `contents`
+# yet, so they take the clone above.
 if ! git -C contents pull --quiet --ff-only 2>/dev/null; then
   echo "Could not update skills content; continuing with what is on disk." >&2
   echo "Re-run \`pnpm skills:update\` once you are back online." >&2


### PR DESCRIPTION
This is a Percy stability step, though it mostly would help diagnosis of diffs, as pinning the `boxel-skills` version would be the real stability fix but would be too annoying, I think.

Claude: Three things about `skills:setup` were worth fixing, none of them the version it clones.

An existing `contents/` was never looked at again, so a machine that cloned it once kept that content indefinitely while CI — which clones fresh every run — served current skills. It is now brought up to date. Two cases are deliberately left alone: uncommitted changes, so trying something out in place is not overwritten, and a detached HEAD. Being offline costs the update rather than the ability to start a dev stack, since this runs on the way into one.

A failed clone left an empty realm behind to be discovered later as something else entirely. It now fails immediately, naming both attempts, which is what the neighbouring catalog clone already did.

The SSH attempt's output is dropped. It is expected to fail wherever there is no key, and in CI it printed `Permission denied (publickey)` on every run — which reads like the cause when you are scanning a log for a real failure, and recently was mistaken for one.

Not pinning the revision is deliberate, and the README says so. Upstream is iterated on daily, so a pin would need moving every week; measured against twelve weeks of Percy history, unpinned upstream accounts for roughly one diff every three weeks on a single snapshot. That is not worth a weekly chore, and the fix for it belongs in the tests that render third-party content.