### PR TITLE
Make the preview-realm publish readiness budget configurable

### DIFF
--- a/.github/workflows/preview-realm.yml
+++ b/.github/workflows/preview-realm.yml
@@ -50,6 +50,14 @@ on:
       boxel-cli-version:
         type: string
         default: latest
+      publish-timeout-ms:
+        description: |
+          Readiness-poll budget for `boxel realm publish`. Covers indexing
+          *and* prerendering every instance in every format, so it scales
+          with realm render cost rather than file count. The CLI's own
+          default is 300000, which a render-heavy realm outgrows.
+        type: number
+        default: 900000
     secrets:
       matrix-username:
         description: |
@@ -143,6 +151,7 @@ jobs:
           MATRIX_USERNAME: ${{ secrets.matrix-username }}
           REALM_ENDPOINT: ${{ inputs.realm-endpoint-prefix }}${{ github.event.pull_request.number }}
           PUBLISHED_BASE: ${{ inputs.published-realm-base }}
+          PUBLISH_TIMEOUT_MS: ${{ inputs.publish-timeout-ms }}
         run: |
           # `boxel realm publish` defaults to retrying on 400/409 by
           # auto-unpublishing the previous publication first, so PR
@@ -151,7 +160,8 @@ jobs:
           SOURCE_REALM_URL="${REALM_SERVER%/}/${MATRIX_USERNAME}/${REALM_ENDPOINT}/"
           PUBLISHED_REALM_URL="${PUBLISHED_BASE%/}/${REALM_ENDPOINT}/"
           echo "Publishing ${SOURCE_REALM_URL} to ${PUBLISHED_REALM_URL}"
-          boxel realm publish "${SOURCE_REALM_URL}" "${PUBLISHED_REALM_URL}"
+          boxel realm publish "${SOURCE_REALM_URL}" "${PUBLISHED_REALM_URL}" \
+            --timeout "${PUBLISH_TIMEOUT_MS}"
 
       - name: Compute comment fields
         if: ${{ !cancelled() }}


### PR DESCRIPTION
`boxel realm publish` polls until the published realm passes its readiness check, then gives up at its own default of 300000ms. That budget covers indexing *and* prerendering every instance in every format, so it scales with a realm's render cost rather than its file count. A render-heavy realm exhausts it while the render is still progressing normally, and the job fails with `503 (not ready: prerender-html)`.

`publish-timeout-ms` exposes the budget as a workflow input, defaulting to 900000. A caller with a small realm can pass a lower value.

Only failure latency changes. A publish that passes readiness returns as soon as it does, and the realm server's indexing and prerendering run to completion whether or not the CLI is still waiting — so a longer budget adds no load there. A wedged publish reports at 15 minutes instead of 5.

## Test plan

- `cardstack/boxel-home` is the only caller and tracks this workflow at `@main`, so it picks up the default on its next PR run: a preview publish that previously timed out mid-render should complete and comment its URL.
- `preview-realm-actions-integration.yml` passes its own explicit `--timeout` and is unaffected.

Closes https://linear.app/cardstack/issue/CS-12688/preview-realm-publishes-time-out-before-prerendering-finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
