### PR TITLE
Add ability to inspect staging and production AI rooms with the inspect-ai-room skill

### DIFF
--- a/.claude/skills/inspect-ai-room/SKILL.md
+++ b/.claude/skills/inspect-ai-room/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inspect-ai-room
-description: Inspect an AI assistant room's Matrix events on local, staging, or production — token usage/cost per turn, decoded timeline (edits, tool requests/results, streaming flags), room state (LLM model, mode, skills). Use when the user hands over a room id (local or staging) and wants the session analyzed, when analyzing benchmark sessions, diagnosing a stalled/stuck assistant response, or checking whether prompt caching is working.
+description: Inspect an AI assistant room's Matrix events on local, staging, or production — token usage/cost per turn, decoded timeline (edits, tool requests/results, streaming flags), room state (LLM model, mode, skills). Use when the user hands over a room id (local, staging, or production) and wants the session analyzed, when analyzing benchmark sessions, diagnosing a stalled/stuck assistant response, or checking whether prompt caching is working.
 ---
 
 # Inspect an AI assistant room

--- a/.claude/skills/inspect-ai-room/SKILL.md
+++ b/.claude/skills/inspect-ai-room/SKILL.md
@@ -33,8 +33,9 @@ node scripts/inspect-room.mjs --profile @me:stack.cards rooms 10
 ```
 
 `--profile` takes a profile id or a substring of its `matrixUrl`
-(`staging`, `boxel.ai`). Every subcommand works; `rooms` lists the profile
-user's rooms, not all rooms. Room ids on staging end in `:stack.cards`;
+(`staging`, `boxel.ai`). A substring that matches more than one profile is
+rejected; pass the exact id then. Every subcommand works; `rooms` lists the
+profile user's rooms, not all rooms. Room ids on staging end in `:stack.cards`;
 quote them in the shell because of the `!`.
 
 Limits: the profile's user must be a member of the room (the user who ran the

--- a/.claude/skills/inspect-ai-room/SKILL.md
+++ b/.claude/skills/inspect-ai-room/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: inspect-ai-room
-description: Inspect a local AI assistant room's Matrix events — token usage/cost per turn, decoded timeline (edits, tool requests/results, streaming flags), room state (LLM model, mode, skills). Use when analyzing benchmark sessions, diagnosing a stalled/stuck assistant response, or checking whether prompt caching is working.
+description: Inspect an AI assistant room's Matrix events on local, staging, or production — token usage/cost per turn, decoded timeline (edits, tool requests/results, streaming flags), room state (LLM model, mode, skills). Use when the user hands over a room id (local or staging) and wants the session analyzed, when analyzing benchmark sessions, diagnosing a stalled/stuck assistant response, or checking whether prompt caching is working.
 ---
 
-# Inspect a local AI assistant room
+# Inspect an AI assistant room
 
-All inspection goes through the Matrix client API on the local synapse
-(`http://localhost:8008`), logged in as `aibot` (password `pass`), which is a
-member of every assistant room. The consolidated script:
+All inspection goes through the Matrix client API. Locally the script logs in
+as `aibot` (password `pass`), which is a member of every assistant room. The
+consolidated script:
 
 ```sh
 node scripts/inspect-room.mjs rooms [N]           # N most recent rooms, newest first
@@ -18,6 +18,46 @@ node scripts/inspect-room.mjs raw <roomId> [str]  # full event JSON, filtered by
 ```
 
 (paths relative to this skill's base directory)
+
+## Staging / production rooms
+
+The aibot password for deployed environments is not readable by the
+`boxel-claude-readonly` AWS role (checked; `ssm:GetParameter` on
+`BOXEL_AIBOT_PASSWORD` is denied by design). Instead the script reuses the
+Matrix token that boxel-cli stores in `~/.boxel-cli/profiles.json`:
+
+```sh
+node scripts/inspect-room.mjs --profile staging timeline '!abc:stack.cards'
+node scripts/inspect-room.mjs --profile staging usage    '!abc:stack.cards'
+node scripts/inspect-room.mjs --profile @me:stack.cards rooms 10
+```
+
+`--profile` takes a profile id or a substring of its `matrixUrl`
+(`staging`, `boxel.ai`). Every subcommand works; `rooms` lists the profile
+user's rooms, not all rooms. Room ids on staging end in `:stack.cards`;
+quote them in the shell because of the `!`.
+
+Limits: the profile's user must be a member of the room (the user who ran the
+session — that is the normal case when the user tests on staging with the same
+account boxel-cli is logged in as). If the token was revoked, `boxel profile
+add` re-authenticates. `MATRIX_URL` + `MATRIX_TOKEN` env vars are the raw
+fallback for a token from elsewhere (e.g. copied from the browser's
+`auth` localStorage entry).
+
+## Analysis procedure for a "this session is full of errors" report
+
+1. `state` — confirm model, `act`/`ask` mode, which skills were enabled.
+2. `usage` — check the cache line per turn; a `cached` reset mid-session means
+   history was rewritten.
+3. `timeline` — walk the tool requests and their results. For each
+   `toolResult`/`codePatchResult` with an error, pull the full payload with
+   `raw <roomId> <substring>` and classify: model error (wrong API, bad
+   import, hallucinated field), skill-text gap (the skill did not say it),
+   or platform error (indexing, realm 4xx/5xx, host command failure).
+4. For platform errors on staging, correlate with realm-server logs via the
+   `tail-logs` / `aws-access` skills using the event timestamps.
+5. Report per error: what the model tried, what failed, root cause class, and
+   the fix location (skill text vs. model vs. platform).
 
 ## Reading the timeline
 

--- a/.claude/skills/inspect-ai-room/scripts/inspect-room.mjs
+++ b/.claude/skills/inspect-ai-room/scripts/inspect-room.mjs
@@ -35,9 +35,18 @@ const [cmd, arg1, arg2] = argv;
 function loadProfile(idOrHint) {
   let file = path.join(os.homedir(), '.boxel-cli', 'profiles.json');
   let profiles = JSON.parse(fs.readFileSync(file, 'utf8')).profiles ?? {};
-  let p =
-    profiles[idOrHint] ??
-    Object.values(profiles).find((x) => x.matrixUrl?.includes(idOrHint));
+  let p = profiles[idOrHint];
+  if (!p) {
+    let matches = Object.entries(profiles).filter(([, x]) =>
+      x.matrixUrl?.includes(idOrHint),
+    );
+    if (matches.length > 1) {
+      throw new Error(
+        `"${idOrHint}" matches several boxel-cli profiles (${matches.map(([id]) => id).join(', ')}); pass the exact profile id`,
+      );
+    }
+    p = matches[0]?.[1];
+  }
   if (!p) {
     throw new Error(
       `no boxel-cli profile matching "${idOrHint}"; have: ${Object.keys(profiles).join(', ')}`,

--- a/.claude/skills/inspect-ai-room/scripts/inspect-room.mjs
+++ b/.claude/skills/inspect-ai-room/scripts/inspect-room.mjs
@@ -1,5 +1,6 @@
-// Inspect local AI assistant rooms via the Matrix client API, logged in as
-// the aibot user (which is a member of every assistant room).
+// Inspect AI assistant rooms via the Matrix client API. Locally this logs in
+// as the aibot user (a member of every assistant room); against staging /
+// production it reuses a boxel-cli profile's Matrix token (see Auth below).
 //
 //   node inspect-room.mjs rooms [N]          list the N most recent rooms (default 10)
 //   node inspect-room.mjs timeline <roomId>  decoded event timeline (edits, tools, results)
@@ -8,14 +9,56 @@
 //   node inspect-room.mjs raw <roomId> [filter]  full event JSON, optionally
 //                                            only events whose JSON contains `filter`
 //
-// Env: MATRIX_URL (default http://localhost:8008),
-//      BOXEL_AIBOT_PASSWORD (default 'pass').
+// Auth (first match wins):
+//   --profile <id>   use a boxel-cli profile from ~/.boxel-cli/profiles.json
+//                    (its matrixUrl + matrixAccessToken); this is how staging /
+//                    production rooms are inspected — the profile's user must be
+//                    a member of the room. `--profile staging` matches any
+//                    profile whose matrixUrl contains "staging".
+//   MATRIX_TOKEN     env: raw access token, used with MATRIX_URL
+//   aibot login      env MATRIX_URL (default http://localhost:8008) +
+//                    BOXEL_AIBOT_PASSWORD (default 'pass'); local synapse only.
 
-const MATRIX_URL = process.env.MATRIX_URL || 'http://localhost:8008';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let argv = process.argv.slice(2);
+let profileArg;
+let pi = argv.indexOf('--profile');
+if (pi !== -1) {
+  profileArg = argv[pi + 1];
+  argv.splice(pi, 2);
+}
+const [cmd, arg1, arg2] = argv;
+
+function loadProfile(idOrHint) {
+  let file = path.join(os.homedir(), '.boxel-cli', 'profiles.json');
+  let profiles = JSON.parse(fs.readFileSync(file, 'utf8')).profiles ?? {};
+  let p =
+    profiles[idOrHint] ??
+    Object.values(profiles).find((x) => x.matrixUrl?.includes(idOrHint));
+  if (!p) {
+    throw new Error(
+      `no boxel-cli profile matching "${idOrHint}"; have: ${Object.keys(profiles).join(', ')}`,
+    );
+  }
+  if (!p.matrixAccessToken) {
+    throw new Error(
+      `profile ${p.matrixUserId} has no stored Matrix token; run \`boxel profile add\``,
+    );
+  }
+  return p;
+}
+
+let profile = profileArg ? loadProfile(profileArg) : undefined;
+const MATRIX_URL =
+  profile?.matrixUrl || process.env.MATRIX_URL || 'http://localhost:8008';
 const PASSWORD = process.env.BOXEL_AIBOT_PASSWORD || 'pass';
-const [, , cmd, arg1, arg2] = process.argv;
 
 async function login() {
+  if (profile) return profile.matrixAccessToken;
+  if (process.env.MATRIX_TOKEN) return process.env.MATRIX_TOKEN;
   let res = await fetch(new URL('/_matrix/client/v3/login', MATRIX_URL), {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -112,8 +155,7 @@ if (cmd === 'rooms') {
       parts.push(`fin=${c.isStreamingFinished}`);
     // Rooms from before the command→tool rename carry requests under the
     // legacy key; read both, like runtime-common's getToolRequests().
-    let tools =
-      c['app.boxel.toolRequests'] ?? c['app.boxel.commandRequests'];
+    let tools = c['app.boxel.toolRequests'] ?? c['app.boxel.commandRequests'];
     if (tools?.length)
       parts.push('tools=' + tools.map((t) => t.name).join(','));
     let agent = eventData(c)?.context?.agentId;
@@ -146,7 +188,12 @@ if (cmd === 'rooms') {
       else turns.push({ key, usage });
     }
   }
-  let sum = { promptTokens: 0, completionTokens: 0, cachedTokens: 0, costUsd: 0 };
+  let sum = {
+    promptTokens: 0,
+    completionTokens: 0,
+    cachedTokens: 0,
+    costUsd: 0,
+  };
   for (let [i, t] of turns.entries()) {
     let u = t.usage;
     console.log(

--- a/.claude/skills/inspect-ai-room/scripts/inspect-room.mjs
+++ b/.claude/skills/inspect-ai-room/scripts/inspect-room.mjs
@@ -28,6 +28,11 @@ let profileArg;
 let pi = argv.indexOf('--profile');
 if (pi !== -1) {
   profileArg = argv[pi + 1];
+  if (!profileArg || profileArg.startsWith('--')) {
+    throw new Error(
+      '--profile needs a value: a boxel-cli profile id or a matrixUrl substring',
+    );
+  }
   argv.splice(pi, 2);
 }
 const [cmd, arg1, arg2] = argv;


### PR DESCRIPTION
Add ability to inspect AI assistant rooms on staging and production with the inspect-ai-room skill. Until now the skill could only reach the local synapse, because it logs in as aibot with the dev password. Against deployed environments the aibot password is not available to the read-only AWS role, so the script now accepts `--profile <id|matrixUrl-substring>` and reuses the Matrix access token that boxel-cli already stores in `~/.boxel-cli/profiles.json`. A raw `MATRIX_TOKEN` env var works as a fallback. The aibot login path is unchanged for local use.

The profile's user must be a member of the room, which is the normal case when the person who ran the session is also the boxel-cli user. All subcommands (rooms, timeline, usage, state, raw) work this way; verified against a staging room.

SKILL.md documents the staging path and adds a short procedure for triaging a session that produced many errors: state, usage, timeline, then the raw payload of each failed tool result or code patch, classified as model, skill-text, or platform error, with realm-server logs for the platform ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)