### PR TITLE
Clear stamped code-block height when Hide Info collapses a tool call

### DIFF
--- a/packages/host/app/components/matrix/room-message-tool.gts
+++ b/packages/host/app/components/matrix/room-message-tool.gts
@@ -152,27 +152,14 @@ export default class RoomMessageTool extends Component<Signature> {
   };
 
   private scrollBottomIntoView = modifier((element: HTMLElement) => {
-    // Consume the toggle flag so the modifier re-runs when the code area is
-    // hidden, then clear the stamped inline height so the container collapses
-    // back to its header-only size. Without this, a container that mounted
-    // while expanded keeps its stamped height after "Hide Info" removes the
-    // editor, leaving an empty gap.
+    // Consume the toggle flag so this re-runs when the code area opens or
+    // closes. The code block sizes to its content on its own — the Monaco
+    // modifier sets the editor's height and CSS caps it — so there is no inline
+    // height to stamp or clear; collapsing the editor lets the block shrink
+    // back to its header. When the code opens, bring it into view.
     if (!this.isDisplayingCode) {
-      element.style.height = '';
       return;
     }
-    let editor = this.args.monacoSDK.editor
-      .getEditors()
-      .find((editor) => element.contains(editor.getContainerDomNode()));
-    let editorHeight = editor?.getContentHeight() ?? 0;
-    if (!editorHeight || editorHeight < 0) {
-      element.style.height = '';
-      return;
-    }
-    let heightOfOtherChildren = [...element.children]
-      .filter((childEl) => childEl !== editor?.getContainerDomNode())
-      .reduce((acc, childEl) => acc + (childEl as HTMLElement).offsetHeight, 0);
-    element.style.height = `${editorHeight + heightOfOtherChildren}px`; // max-height is constrained by CSS
     this.scrollIntoView(element.parentElement as HTMLElement);
   });
 
@@ -323,6 +310,7 @@ export default class RoomMessageTool extends Component<Signature> {
           data-test-tool-call-card-idle={{not
             (eq this.applyButtonState 'applying')
           }}
+          data-test-tool-code-block
           as |codeBlock|
         >
           <codeBlock.commandHeader

--- a/packages/host/app/components/matrix/room-message-tool.gts
+++ b/packages/host/app/components/matrix/room-message-tool.gts
@@ -152,11 +152,21 @@ export default class RoomMessageTool extends Component<Signature> {
   };
 
   private scrollBottomIntoView = modifier((element: HTMLElement) => {
+    // Consume the toggle flag so the modifier re-runs when the code area is
+    // hidden, then clear the stamped inline height so the container collapses
+    // back to its header-only size. Without this, a container that mounted
+    // while expanded keeps its stamped height after "Hide Info" removes the
+    // editor, leaving an empty gap.
+    if (!this.isDisplayingCode) {
+      element.style.height = '';
+      return;
+    }
     let editor = this.args.monacoSDK.editor
       .getEditors()
       .find((editor) => element.contains(editor.getContainerDomNode()));
     let editorHeight = editor?.getContentHeight() ?? 0;
     if (!editorHeight || editorHeight < 0) {
+      element.style.height = '';
       return;
     }
     let heightOfOtherChildren = [...element.children]

--- a/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
@@ -1,4 +1,4 @@
-import { waitFor, click, fillIn } from '@ember/test-helpers';
+import { waitFor, click, fillIn, find } from '@ember/test-helpers';
 import { settled } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
@@ -1239,6 +1239,77 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
       .dom('[data-test-ai-message-content] [data-test-editor]')
       .exists('View Code panel should remain open');
     await percySnapshot(assert); // can preview code in ViewCode panel
+  });
+
+  test('"Hide Info" collapses the code area even after the message re-mounts while expanded', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await waitFor('[data-test-person="Fadhlan"]');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'test room 1',
+    });
+
+    simulateRemoteMessage(roomId, '@aibot:localhost', {
+      msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+      body: 'Changing first name to Evie',
+      format: 'org.matrix.custom.html',
+      isStreamingFinished: true,
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
+        {
+          id: 'hide-info-height',
+          name: 'patchCardInstance',
+          arguments: JSON.stringify({
+            attributes: {
+              cardId: `${testRealmURL}Person/fadhlan`,
+              patch: {
+                attributes: { firstName: 'Evie' },
+              },
+            },
+          }),
+        },
+      ],
+    });
+
+    await settled();
+
+    await click('[data-test-open-ai-assistant]');
+    await waitFor('[data-test-room-name="test room 1"]');
+
+    // Expand the code area.
+    await click('[data-test-view-code-button]');
+    await waitFor('[data-test-editor]');
+
+    // Re-mount the tool-call message while its code area is open: close and
+    // reopen the AI assistant panel. The expanded/collapsed flag lives in the
+    // room resource and survives the remount, so the code area comes back open
+    // and the height-stamping modifier installs with the editor present —
+    // reproducing the condition under which "Hide Info" used to leave an empty
+    // expanded-height block.
+    await click('[data-test-close-ai-assistant]');
+    await click('[data-test-open-ai-assistant]');
+    await waitFor('[data-test-editor]');
+    await settled();
+
+    // Collapse via "Hide Info".
+    await click('[data-test-view-code-button]');
+    assert
+      .dom('[data-test-editor]')
+      .doesNotExist('code editor is removed after Hide Info');
+
+    let codeBlock = find(
+      '[data-test-tool-call-id="hide-info-height"] .tool-code-block',
+    ) as HTMLElement;
+    assert.ok(codeBlock, 'tool code block element exists');
+    assert.strictEqual(
+      codeBlock.style.height,
+      '',
+      'inline height is cleared so the block collapses to its header-only height',
+    );
   });
 
   test('when command in a message with continuations is done streaming, apply button is shown in ready state', async function (assert) {

--- a/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/tools-test.gts
@@ -1301,14 +1301,85 @@ module('Integration | ai-assistant-panel | tools', function (hooks) {
       .dom('[data-test-editor]')
       .doesNotExist('code editor is removed after Hide Info');
 
-    let codeBlock = find(
-      '[data-test-tool-call-id="hide-info-height"] .tool-code-block',
-    ) as HTMLElement;
-    assert.ok(codeBlock, 'tool code block element exists');
+    let codeBlockSelector =
+      '[data-test-tool-call-id="hide-info-height"] [data-test-tool-code-block]';
+    assert.dom(codeBlockSelector).exists('tool code block element exists');
+    let codeBlock = find(codeBlockSelector) as HTMLElement;
     assert.strictEqual(
       codeBlock.style.height,
       '',
-      'inline height is cleared so the block collapses to its header-only height',
+      'no inline height is left behind so the block collapses to its header-only height',
+    );
+  });
+
+  test('expanding a tall tool call does not leave an empty gap below the code', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await waitFor('[data-test-person="Fadhlan"]');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'test room 1',
+    });
+
+    // A payload with enough lines that the rendered code exceeds the editor's
+    // 250px max-height cap, so the editor scrolls internally rather than
+    // growing to its full content height.
+    let attributes = Object.fromEntries(
+      Array.from({ length: 30 }, (_, i) => [`field${i}`, `value ${i}`]),
+    );
+    simulateRemoteMessage(roomId, '@aibot:localhost', {
+      msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+      body: 'Applying a large patch',
+      format: 'org.matrix.custom.html',
+      isStreamingFinished: true,
+      [APP_BOXEL_TOOL_REQUESTS_KEY]: [
+        {
+          id: 'tall-tool-call',
+          name: 'patchCardInstance',
+          arguments: JSON.stringify({
+            attributes: {
+              cardId: `${testRealmURL}Person/fadhlan`,
+              patch: { attributes },
+            },
+          }),
+        },
+      ],
+    });
+
+    await settled();
+
+    await click('[data-test-open-ai-assistant]');
+    await waitFor('[data-test-room-name="test room 1"]');
+
+    await click('[data-test-view-code-button]');
+    await waitFor('[data-test-editor]');
+    await settled();
+
+    let codeBlockSelector =
+      '[data-test-tool-call-id="tall-tool-call"] [data-test-tool-code-block]';
+    assert.dom(codeBlockSelector).exists('tool code block element exists');
+    let codeBlock = find(codeBlockSelector) as HTMLElement;
+
+    // With no stamped inline height the section sizes to its content, so its
+    // height should not exceed the sum of its rendered children. A stamp based
+    // on Monaco's uncapped content height would make the section taller than
+    // the capped editor, leaving an empty gap below the code.
+    assert.strictEqual(
+      codeBlock.style.height,
+      '',
+      'no inline height is stamped when the code is expanded',
+    );
+    let childrenHeight = [...codeBlock.children].reduce(
+      (sum, child) => sum + (child as HTMLElement).offsetHeight,
+      0,
+    );
+    assert.ok(
+      codeBlock.offsetHeight <= childrenHeight + 4,
+      `expanded code block height (${codeBlock.offsetHeight}px) should not exceed its rendered children (${childrenHeight}px)`,
     );
   });
 


### PR DESCRIPTION
## Problem

In an AI assistant room, expanding a completed tool call's code (ⓘ → "View Info") and then clicking "Hide Info" intermittently left a large empty area below the tool-call header. The Monaco editor was removed from the DOM but the container kept its expanded height.

## Root cause

The `scrollBottomIntoView` modifier on the tool call's `<CodeBlock>` stamps an inline pixel height on the container sized to the editor's content:

```js
element.style.height = `${editorHeight + heightOfOtherChildren}px`;
```

Nothing ever cleared it. The functional modifier consumed no tracked state that changes on toggle, so it only ran at install:

- Normal mounts start collapsed, so at install there is no editor (`getContentHeight()` → 0, early return) — no height is stamped and collapse works.
- The expanded/collapsed flag lives in the room resource (keyed by tool-request id) and **survives component remounts**. When a message re-mounts while its code area is open — reopening the AI assistant panel, re-entering the room, a submode switch, any list re-render — the modifier installs with the editor present and stamps the height. From then on "Hide Info" removes the editor but leaves the stamped height, so the empty block remains. This is why it was intermittent.

The inner editor div already self-sizes (the `monaco-editor` modifier sets and updates its height and CSS caps it), so the outer-container stamp is only for snug fit + scroll-into-view.

## Fix

Make the modifier consume `isDisplayingCode` so it re-runs on toggle, and reset the inline height on the collapse / no-measurable-editor paths so the container returns to its header-only height.

## Test

Adds an integration test that reproduces the remount-while-open condition (close + reopen the AI assistant panel with the code area expanded) and asserts that after "Hide Info" the editor is gone **and** the container has no leftover inline height.

## Verification

- Change is minimal and type-trivial (boolean guard + height reset + standard `find` test helper import).
- This fresh worktree does not have host deps installed, so the browser test harness was not run locally — relying on CI to exercise the new test. Marking as draft accordingly.