### PR TITLE
Move runtime-dependency-tracker tests to the host browser suite

### DIFF
--- a/packages/host/tests/unit/runtime-dependency-tracker-test.ts
+++ b/packages/host/tests/unit/runtime-dependency-tracker-test.ts
@@ -1,6 +1,5 @@
-import QUnit from 'qunit';
-const { module, test } = QUnit;
-import { basename } from 'path';
+import { module, test } from 'qunit';
+
 import {
   Loader,
   beginRuntimeDependencyTrackingSession,
@@ -15,7 +14,18 @@ import {
   withRuntimeDependencyTrackingContext,
 } from '@cardstack/runtime-common';
 
-module(basename(import.meta.filename), function (hooks) {
+// The runtime dependency tracker records what a card reached for while it
+// rendered, and every production caller of it runs in a browser tab: the host
+// app's render route, store, and search resources, `packages/base`'s card API
+// and serialization, and the `Loader` whose import-time module-graph walk feeds
+// it module deps. Nothing constructs a `Loader` under node, so a tracker suite
+// there would drive a runtime that ships nothing — it would stay green while
+// the browser behavior it stands in for diverged, and it would advertise the
+// loader as node-supported to anyone reading the test tree.
+module('Unit | runtime dependency tracker', function (hooks) {
+  // Sessions, contexts, and the probe dedup tables are module-global state in
+  // `runtime-common`, and the whole host suite shares one page. A test that
+  // leaves a session open is visible to every test that runs after it.
   hooks.afterEach(() => {
     endRuntimeDependencyTrackingSession();
     resetRuntimeDependencyTracker();

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -399,7 +399,6 @@ const ALL_TEST_FILES: string[] = [
   './realm-auth-test',
   './queries-test',
   './remote-prerenderer-test',
-  './runtime-dependency-tracker-test',
   './markdown-fallback-server-isolation-test',
   './sanitize-head-html-test',
   './node-realm-test',


### PR DESCRIPTION
## What

`runtime-dependency-tracker-test.ts` moves from the realm-server node suite to
the host browser suite (`packages/host/tests/unit/`).

## Why this shape

Every production caller of the runtime dependency tracker runs in a browser tab:

- `packages/host/app` — the render route and its meta route, the store, the search resource, the GC card store, the file-extract runner, the render service, the card-prerender component
- `packages/base` — the card API, card serialization, query-field support
- `packages/runtime-common/loader.ts` — the `Loader`'s import-time module-graph walk, which is what feeds the tracker its module deps

Nothing constructs a `Loader` under node, and `packages/realm-server` does not
import it at all. Three of the suite's tests build a real `Loader` and drive the
tracker through `loader.import()`, so under node they exercised a runtime that
ships nothing: they would stay green while the browser-side behavior they stand
in for diverged. They also made the loader read as node-supported to anyone
scanning the test tree.

The whole file moves rather than splitting. The other 18 tests drive the
tracker's session, context, and snapshot API directly, and the tracker's context
propagation is a plain synchronous stack rather than `AsyncLocalStorage`, so
they are environment-agnostic and belong beside their subject — which is
browser-side in full.

Only the file header changed: the qunit import and the module name (from a
node `basename(import.meta.filename)` to `'Unit | runtime dependency tracker'`),
plus comments stating why the suite is browser-side and why the `afterEach`
cleanup is load-bearing. All 910 lines of test bodies are byte-identical.

## Coverage

Test inventory is unchanged: the same 21 tests and 64 assertions, name for name.
That includes the guards for transitive runtime dependency capture during
prerendering and for the canonical-RRI form the tracker records.

No `Loader` is constructed outside a browser suite anywhere in the repo —
`new Loader(` appears only under `packages/host/` and in
`runtime-common/loader.ts` itself.

The host shard packer gives a test file absent from
`tests/test-module-timings.json` the median known weight, so the moved file runs
on exactly one shard without the timings file needing regeneration.

## Test plan

- The moved suite runs green in the host browser suite: 21 passed, 0 failed
  (`ember test --path dist --filter="Unit | runtime dependency tracker"`,
  headless Chrome 141), including all three loader tests.
- Test inventory diffed before and after the move: identical, 21 names and
  64 assertions.
- `packages/host`: `pnpm lint:types` and `pnpm lint:js` clean.
- `packages/realm-server`: `pnpm lint:js` clean. `lint:types` reports only
  pre-existing unresolved `@cardstack/boxel-icons` / `boxel-ui` paths under
  `packages/base`, none in files this touches.
- `packages/realm-server/tests/index.ts` requires each entry as
  `require(file + '.ts')`, so a stale entry throws at load: all 185 remaining
  entries were confirmed to resolve on disk, with no duplicates. The moved file
  exported nothing and its only top-level statement was its `module()`
  registration, so no other node test could depend on it. The node suite itself
  needs the dockerised test postgres, so it runs in CI rather than here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X124uTcZNdxDxbRZfNEu1p)_