### PR TITLE
Only offer cards the consuming realm can fetch in the card chooser

### DIFF
--- a/packages/host/app/components/card-chooser/modal.gts
+++ b/packages/host/app/components/card-chooser/modal.gts
@@ -75,6 +75,8 @@ type State = {
   dismissModal: boolean;
   errorMessage?: string;
   baseFilter?: Filter;
+  // The realms this chooser searches, and the only ones its realm picker
+  // offers: those whose cards the consuming realm can fetch once linked.
   availableRealmUrls: string[];
   hasPreselectedCard?: boolean;
   consumingRealm?: URL;
@@ -114,6 +116,7 @@ export default class CardChooserModal extends Component<Signature> {
           <SearchPanel
             @searchKey={{state.searchKey}}
             @baseFilter={{state.baseFilter}}
+            @availableRealms={{state.availableRealmUrls}}
             @initialSelectedRealms={{this.initialSelectedRealmsForPanel}}
             @initialSelectedTypes={{this.initialSelectedTypesForPanel}}
             @lockSelectedRealms={{state.lockConsumingRealm}}
@@ -350,6 +353,9 @@ export default class CardChooserModal extends Component<Signature> {
       } = {},
     ) => {
       await this.realmServer.ready;
+      // In flight alongside the title / preselection work below, awaited only
+      // where the chooser's realm scope is finally needed.
+      let linkableRealms = this.linkableRealms(opts.consumingRealm);
       // Preload realm info without blocking the modal from opening.
       let prefetchRealmInfo = Promise.all(
         this.realmServer.availableRealmIdentifiers.map(async (realmURL) => {
@@ -409,7 +415,7 @@ export default class CardChooserModal extends Component<Signature> {
         searchKey: '',
         dismissModal: false,
         baseFilter: query.filter,
-        availableRealmUrls: this.realmServer.availableRealmIdentifiers,
+        availableRealmUrls: await linkableRealms,
         selectedCards: preselectedCardUrls,
         multiSelect: opts?.multiSelect ?? false,
         hasPreselectedCard: preselectedCardUrls.length > 0,
@@ -421,6 +427,32 @@ export default class CardChooserModal extends Component<Signature> {
       return await request.deferred.promise;
     },
   );
+
+  // The realms the chooser draws from. A card linked into `consumingRealm`
+  // is fetched by that realm under its own owner's identity, so a card in a
+  // realm that owner cannot read errors the moment the linking card is
+  // assembled — offering it hands the author a broken link. The realm server
+  // resolves the set; a failure there leaves the chooser at the user's full
+  // reach rather than an empty one, which the pick-time fetch still guards.
+  private async linkableRealms(consumingRealm?: URL): Promise<string[]> {
+    let availableRealms = this.realmServer.availableRealmIdentifiers;
+    if (!consumingRealm) {
+      return availableRealms;
+    }
+    try {
+      return await this.realmServer.fetchLinkableRealms(
+        consumingRealm.href,
+        availableRealms,
+      );
+    } catch (error) {
+      console.warn(
+        'Failed to resolve linkable realms for',
+        consumingRealm.href,
+        error,
+      );
+      return availableRealms;
+    }
+  }
 
   @action
   private setSearchKey(searchKey: string) {

--- a/packages/host/app/components/card-chooser/modal.gts
+++ b/packages/host/app/components/card-chooser/modal.gts
@@ -432,8 +432,12 @@ export default class CardChooserModal extends Component<Signature> {
   // is fetched by that realm under its own owner's identity, so a card in a
   // realm that owner cannot read errors the moment the linking card is
   // assembled — offering it hands the author a broken link. The realm server
-  // resolves the set; a failure there leaves the chooser at the user's full
-  // reach rather than an empty one, which the pick-time fetch still guards.
+  // resolves the set. Nothing downstream re-checks it: what the chooser
+  // returns is linked as-is, and the store read that follows a pick runs as
+  // the user, who could always read the card. So a failure here reopens the
+  // gap for as long as it lasts — the chooser falls back to the user's full
+  // reach because a chooser that offers nothing is worse than one that offers
+  // too much, not because anything else is covering it.
   private async linkableRealms(consumingRealm?: URL): Promise<string[]> {
     let availableRealms = this.realmServer.availableRealmIdentifiers;
     if (!consumingRealm) {

--- a/packages/host/app/components/realm-picker/index.gts
+++ b/packages/host/app/components/realm-picker/index.gts
@@ -16,6 +16,12 @@ export interface RealmFilter {
   selectedURLs: string[];
   /** When true, the realm scope is locked and the picker UI is disabled. */
   locked?: boolean;
+  /**
+   * The realms the picker offers, and what select-all resolves to. Omitted
+   * for a search over everything the user can reach; a card picker narrows it
+   * to the realms its result may come from.
+   */
+  available?: string[];
 }
 
 interface Signature {
@@ -36,9 +42,17 @@ export default class RealmPicker extends Component<Signature> {
   // fires onChange to the parent. Without this, Picker sees an empty @selected
   // on first render and calls onChange([select-all]), which the parent
   // interprets as a user-initiated filter change (expanding the search sheet).
+  // The realm set on offer: the filter's own scope when it declares one,
+  // otherwise every realm the user can reach.
+  private get availableRealms(): readonly string[] {
+    return (
+      this.args.filter.available ?? this.realmServer.availableRealmIdentifiers
+    );
+  }
+
   @cached
   get selectAllOption(): PickerOption {
-    const urls = this.realmServer.availableRealmIdentifiers;
+    const urls = this.availableRealms;
     return {
       id: 'select-all',
       label: `Select All (${urls.length})`,
@@ -62,7 +76,7 @@ export default class RealmPicker extends Component<Signature> {
   }
 
   get realmOptions(): PickerOption[] {
-    const urls = this.realmServer.availableRealmIdentifiers;
+    const urls = this.availableRealms;
     const options: PickerOption[] = [this.selectAllOption];
     for (const realmURL of urls) {
       const info = this.realm.info(realmURL);

--- a/packages/host/app/components/realm-picker/index.gts
+++ b/packages/host/app/components/realm-picker/index.gts
@@ -17,9 +17,11 @@ export interface RealmFilter {
   /** When true, the realm scope is locked and the picker UI is disabled. */
   locked?: boolean;
   /**
-   * The realms the picker offers, and what select-all resolves to. Omitted
-   * for a search over everything the user can reach; a card picker narrows it
-   * to the realms its result may come from.
+   * The bound the caller puts on which realms this search may draw from: the
+   * realms the picker offers, what select-all resolves to, and the limit a
+   * pasted card URL has to fall inside. Omitted for a search over everything
+   * the user can reach; a card picker narrows it to the realms whose cards
+   * its result may come from.
    */
   available?: string[];
 }

--- a/packages/host/app/components/search/panel-content.gts
+++ b/packages/host/app/components/search/panel-content.gts
@@ -398,11 +398,15 @@ export default class PanelContent extends Component<Signature> {
     return this.args.searchKey?.trim();
   }
 
+  // The realm scope the searches run against: whatever the realm filter
+  // resolved (select-all already expanded to the filter's available set), or
+  // every realm the user can reach when the filter has nothing.
   get realms() {
     const urls =
       this.args.realmFilter.selectedURLs.length > 0
         ? this.args.realmFilter.selectedURLs
-        : this.realmServer.availableRealmIdentifiers;
+        : (this.args.realmFilter.available ??
+          this.realmServer.availableRealmIdentifiers);
     return urls ?? [];
   }
 
@@ -486,6 +490,7 @@ export default class PanelContent extends Component<Signature> {
                 @isCardResourceLoaded={{this.isCardResourceLoaded}}
                 @realms={{this.realms}}
                 @realmsLocked={{@realmFilter.locked}}
+                @availableRealms={{@realmFilter.available}}
                 @baseFilter={{@baseFilter}}
                 @offerToCreate={{@offerToCreate}}
                 @recentCardBareIds={{this.recentCardBareIds}}

--- a/packages/host/app/components/search/panel-content.gts
+++ b/packages/host/app/components/search/panel-content.gts
@@ -414,6 +414,18 @@ export default class PanelContent extends Component<Signature> {
     return this.recentCardsService.recentCardIds;
   }
 
+  // The recent ids the live fallback may resolve. That fallback loads cards
+  // by id rather than through the realm-scoped search, so the realm scope has
+  // to be applied here too — otherwise a search error would resurface a
+  // recent from a realm the scope excludes, which for a card chooser is a
+  // realm whose cards its consuming realm cannot fetch. Matched by realm
+  // prefix, as `recentsSearchRealms` matches.
+  get scopedRecentCardIds(): string[] {
+    return this.recentCardIds.filter((id) =>
+      this.realms.some((realm) => id.startsWith(realm)),
+    );
+  }
+
   @action
   onChangeView(id: string) {
     if (this.args.onViewIdChange) {
@@ -471,7 +483,7 @@ export default class PanelContent extends Component<Signature> {
             as |recentsResults|
           >
             <LiveRecentsProvider
-              @cardIds={{this.recentCardIds}}
+              @cardIds={{this.scopedRecentCardIds}}
               @recentsResults={{recentsResults}}
               as |liveRecentCards|
             >

--- a/packages/host/app/components/search/panel.gts
+++ b/packages/host/app/components/search/panel.gts
@@ -85,6 +85,8 @@ export default class SearchPanel extends Component<Signature> {
     return `realm:${realmURLs[0].href}`;
   }
 
+  // The realms searched when no realm is picked: the caller's narrowed set
+  // when it declares one, otherwise everything the user can reach.
   private get availableRealms(): string[] {
     return (
       this.args.availableRealms ?? this.realmServer.availableRealmIdentifiers
@@ -106,7 +108,7 @@ export default class SearchPanel extends Component<Signature> {
       onChange: this.onRealmChange,
       selectedURLs: this.selectedRealmURLs,
       locked: this.args.lockSelectedRealms,
-      available: this.availableRealms,
+      available: this.args.availableRealms,
     };
   }
 

--- a/packages/host/app/components/search/panel.gts
+++ b/packages/host/app/components/search/panel.gts
@@ -24,6 +24,13 @@ interface Signature {
     initialSelectedTypes?: ResolvedCodeRef[];
     initialSelectedRealms?: URL[];
     /**
+     * The realms this panel searches when no realm is picked, and the only
+     * ones its realm picker offers. Defaults to every realm the user can
+     * reach; a card picker narrows it to the realms whose cards its caller
+     * can actually use.
+     */
+    availableRealms?: string[];
+    /**
      * Hard-scope: when true, selectedRealms is fixed to initialSelectedRealms
      * and the realm picker is disabled.
      */
@@ -78,9 +85,15 @@ export default class SearchPanel extends Component<Signature> {
     return `realm:${realmURLs[0].href}`;
   }
 
+  private get availableRealms(): string[] {
+    return (
+      this.args.availableRealms ?? this.realmServer.availableRealmIdentifiers
+    );
+  }
+
   private get selectedRealmURLs(): string[] {
     if (this.selectedRealms.length === 0) {
-      return this.realmServer.availableRealmIdentifiers;
+      return this.availableRealms;
     }
     return this.selectedRealms.map((url) => url.href);
   }
@@ -93,6 +106,7 @@ export default class SearchPanel extends Component<Signature> {
       onChange: this.onRealmChange,
       selectedURLs: this.selectedRealmURLs,
       locked: this.args.lockSelectedRealms,
+      available: this.availableRealms,
     };
   }
 

--- a/packages/host/app/components/search/sheet-results.gts
+++ b/packages/host/app/components/search/sheet-results.gts
@@ -70,6 +70,11 @@ interface Signature {
     // locked). A pasted URL that resolves outside the scope is then
     // suppressed rather than offered.
     realmsLocked?: boolean;
+    // Every realm this search may draw from, before the realm picker narrows
+    // it. `realms` is a user-chosen slice of this; a pasted URL outside it is
+    // outside the caller's reach entirely, so it is suppressed even though
+    // the picker stays open. Omitted when the caller imposes no such bound.
+    availableRealms?: string[];
     baseFilter?: Filter;
     offerToCreate?: { ref: CodeRef; relativeTo: URL | undefined };
     // The recent card ids stripped of any `.json`, for most-recent-first
@@ -143,28 +148,54 @@ export default class SheetResults extends Component<Signature> {
     return buildRecentsSection([...entries]);
   }
 
-  // The URL-paste section. When the realm scope is locked (the chooser is
-  // hard-scoped to a consuming realm), a pasted URL that resolves to a card
-  // outside the scope is suppressed — otherwise the tile would be
-  // selectable and Go could return a cross-realm card. `buildUrlSection`
-  // resolves `realmUrl` against `realms` (normalizing id forms), so an
-  // in-scope card always yields one of the `realms` entries verbatim.
+  // The URL-paste section. A pasted URL that resolves to a card outside the
+  // scope its caller imposes is suppressed — otherwise the tile would be
+  // selectable and Go could return a card the caller cannot use. Two bounds
+  // do that, each checked against the realm `buildUrlSection` resolved (it
+  // matches `realms` first, normalizing id forms, and falls back to the
+  // card's own realm when none matches): a locked realm scope, which pins the
+  // paste to `realms`, and `availableRealms`, the realms the caller can draw
+  // from at all — the realm picker only ever narrows that set, so a paste
+  // outside it is out of reach however the picker is set. A caller that
+  // imposes neither accepts any URL the user can resolve.
   private get urlSection(): UrlSection | undefined {
     let section = buildUrlSection(
       this.args.resolvedCard,
       this.args.searchKeyIsURL,
-      this.args.realms,
+      this.urlSectionRealms,
       this.realm,
       (url) => this.network.virtualNetwork.unresolveURL(url),
     );
+    if (!section) {
+      return undefined;
+    }
     if (
-      section &&
       this.args.realmsLocked &&
       !this.args.realms.includes(section.realmUrl)
     ) {
       return undefined;
     }
+    if (
+      this.args.availableRealms &&
+      !this.urlSectionRealms.includes(section.realmUrl)
+    ) {
+      return undefined;
+    }
     return section;
+  }
+
+  // Realms `buildUrlSection` matches the pasted card against, picked realms
+  // first so a card in one resolves to the picked form. A card in an
+  // available-but-unpicked realm would otherwise fall to the path-derived
+  // realm, which names a sub-path rather than a realm root and so reads as
+  // out of scope; carrying every available realm resolves it verbatim
+  // instead, leaving the fallback to mean what the scope check takes it to
+  // mean — the card is in none of these realms.
+  private get urlSectionRealms(): string[] {
+    if (!this.args.availableRealms) {
+      return this.args.realms;
+    }
+    return [...new Set([...this.args.realms, ...this.args.availableRealms])];
   }
 
   private get sections(): SearchSheetSection[] {

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -884,7 +884,17 @@ export default class RealmServerService extends Service {
     let json = (await response.json()) as {
       data?: { attributes?: { realms?: string[] } };
     };
-    return json.data?.attributes?.realms ?? [];
+    let realms = json.data?.attributes?.realms;
+    // The consuming realm is always linkable, so a well-formed answer is never
+    // empty. Refusing an empty one keeps it from being read as a realm scope:
+    // downstream, an empty realm list means "search everything", which would
+    // widen the search while leaving the realm picker with nothing to offer.
+    if (!realms?.length) {
+      throw new Error(
+        `Linkable realms for ${consuming} came back empty; expected at least the consuming realm`,
+      );
+    }
+    return realms;
   }
 
   async fetchCardTypeSummaries(

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -837,6 +837,56 @@ export default class RealmServerService extends Service {
     return json.data ?? [];
   }
 
+  // The realms among `realmUrls` whose cards a card stored in
+  // `consumingRealm` can link to. A realm resolves its cards' links under its
+  // own owner's identity, so a target the owner cannot read makes the linking
+  // card unfetchable regardless of who authored the link. Card pickers scope
+  // their search to this set so a chosen card still resolves once linked.
+  //
+  // `consumingRealm` rides along in the realm list, which the realm server
+  // authorizes against this user — the answer is always a subset of the
+  // realms passed in.
+  async fetchLinkableRealms(
+    consumingRealm: string,
+    realmUrls: string[],
+  ): Promise<string[]> {
+    let consuming = ensureTrailingSlash(consumingRealm);
+    let uniqueRealmUrls = Array.from(new Set([consuming, ...realmUrls]));
+    let realmServerURLs = this.getRealmServersForRealms(uniqueRealmUrls);
+    // TODO remove this assertion after multi-realm server/federated identity is supported
+    this.assertOwnRealmServer(realmServerURLs);
+    let [realmServerURL] = realmServerURLs;
+
+    await this.login();
+
+    let response = await this.authedFetch(
+      new URL('_linkable-realms', realmServerURL).href,
+      {
+        method: 'QUERY',
+        headers: {
+          Accept: SupportedMimeType.JSONAPI,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          realms: uniqueRealmUrls,
+          consumingRealm: consuming,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      let responseText = await response.text();
+      throw new Error(
+        `Failed to fetch linkable realms for ${consuming}: ${response.status} - ${responseText}`,
+      );
+    }
+
+    let json = (await response.json()) as {
+      data?: { attributes?: { realms?: string[] } };
+    };
+    return json.data?.attributes?.realms ?? [];
+  }
+
   async fetchCardTypeSummaries(
     realmUrls: string[],
     options?: {

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -91,10 +91,12 @@ export { createJWT, testRealmSecretSeed } from './test-auth';
 export {
   registerRealmAuthSessionRoomEnsurer,
   resetCatalogRealmURL,
+  resetLinkableRealms,
   setRealmArchived,
   setRealmAuthFailure,
   setupAuthEndpoints,
   setCatalogRealmURL,
+  setLinkableRealms,
 } from './realm-server-mock';
 export { setupOperatorModeStateCleanup } from './operator-mode-state';
 export * from '@cardstack/runtime-common/helpers';

--- a/packages/host/tests/helpers/realm-server-mock/index.ts
+++ b/packages/host/tests/helpers/realm-server-mock/index.ts
@@ -13,10 +13,17 @@ import {
   getRealmServerRoute,
   registerDefaultRoutes,
   resetCatalogRealmURL,
+  resetLinkableRealms,
   setCatalogRealmURL,
+  setLinkableRealms,
 } from './routes';
 
-export { resetCatalogRealmURL, setCatalogRealmURL };
+export {
+  resetCatalogRealmURL,
+  resetLinkableRealms,
+  setCatalogRealmURL,
+  setLinkableRealms,
+};
 
 import type { EnsureSessionRoom, RealmServerMockState } from './types';
 

--- a/packages/host/tests/helpers/realm-server-mock/routes.ts
+++ b/packages/host/tests/helpers/realm-server-mock/routes.ts
@@ -47,6 +47,23 @@ export function resetCatalogRealmURL() {
   catalogRealmURLOverrides = [];
 }
 
+// Realms the mocked `/_linkable-realms` endpoint reports back, over and above
+// the consuming realm itself. Unset means every requested realm is linkable —
+// the answer for a fixture whose realms share one owner, which is what a test
+// gets unless it says otherwise. Module-level for the same reason
+// `catalogRealmURLOverrides` is: route handlers are registered once at module
+// load and shared across the run. Pair `setLinkableRealms` with
+// `resetLinkableRealms` in afterEach so the narrowing does not leak.
+let linkableRealmsOverride: string[] | undefined;
+
+export function setLinkableRealms(...urls: string[]) {
+  linkableRealmsOverride = urls.map(ensureTrailingSlash);
+}
+
+export function resetLinkableRealms() {
+  linkableRealmsOverride = undefined;
+}
+
 const realmServerRoutes = new Map<string, RealmServerMockRoute>();
 
 function normalizeRoutePath(path: string): string {
@@ -71,6 +88,7 @@ export function registerDefaultRoutes() {
   registerAuthRoutes();
   registerArchiveRoutes();
   registerPublishRoutes();
+  registerLinkableRealmsRoutes();
 }
 
 // The test environment points `ENV.realmServerURL` at the fake `http://test-realm`
@@ -247,6 +265,49 @@ function registerInfoRoutes() {
         status: 200,
         headers,
       });
+    },
+  });
+}
+
+// Which of the requested realms a card in the consuming realm can link to.
+// The realm server derives this from the consuming realm's owner's read
+// permissions; here it is whatever `setLinkableRealms` declared, with the
+// consuming realm always linkable to itself.
+function registerLinkableRealmsRoutes() {
+  registerRealmServerRoute({
+    path: '/_linkable-realms',
+    handler: async (req) => {
+      let payload: unknown;
+      let realmList: string[];
+      try {
+        payload = await parseSearchRequestPayload(req.clone());
+        realmList = parseRealmsFromPayload(payload);
+      } catch (e) {
+        if (e instanceof SearchRequestError) {
+          return buildSearchErrorResponse(e.message);
+        }
+        throw e;
+      }
+      let consumingRealm = ensureTrailingSlash(
+        String((payload as Record<string, unknown>).consumingRealm ?? ''),
+      );
+      let realms = linkableRealmsOverride
+        ? realmList.filter(
+            (realmURL) =>
+              realmURL === consumingRealm ||
+              linkableRealmsOverride!.includes(realmURL),
+          )
+        : realmList;
+      return new Response(
+        JSON.stringify({
+          data: {
+            type: 'linkable-realms',
+            id: consumingRealm,
+            attributes: { realms },
+          },
+        }),
+        { status: 200, headers: { 'content-type': SupportedMimeType.JSONAPI } },
+      );
     },
   });
 }

--- a/packages/host/tests/integration/components/operator-mode-card-chooser-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-chooser-test.gts
@@ -38,16 +38,18 @@ module('Integration | operator-mode | card chooser', function (hooks) {
 
   let noop = () => {};
 
+  // The linkable-realm narrowing is module-level state in the realm-server
+  // mock, so clear it after every test in this file whether or not that test
+  // set it — a narrowing left behind would silently scope an unrelated test's
+  // chooser.
+  hooks.afterEach(function () {
+    resetLinkableRealms();
+  });
+
   module('recents section', function (hooks) {
     // The helper's realm-building beforeEach runs for these tests too, and caches
     // under this module's name, which the outer teardown's prefix cannot match.
     setupRealmCacheTeardown(hooks);
-
-    // The linkable-realm narrowing is module-level state in the realm-server
-    // mock, so clear it after every test whether or not that test set it.
-    hooks.afterEach(function () {
-      resetLinkableRealms();
-    });
 
     test(`displays recently accessed card`, async function (assert) {
       ctx.setCardInOperatorModeState(`${testRealmURL}grid`);

--- a/packages/host/tests/integration/components/operator-mode-card-chooser-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-chooser-test.gts
@@ -402,8 +402,8 @@ module('Integration | operator-mode | card chooser', function (hooks) {
 
       assert
         .dom('[data-test-search-label]')
-        .hasText(
-          '5 results across 1 realm',
+        .containsText(
+          'across 1 realm',
           'the search is scoped to the one linkable realm',
         );
 

--- a/packages/host/tests/integration/components/operator-mode-card-chooser-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-chooser-test.gts
@@ -23,6 +23,8 @@ import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
 import {
   percySnapshot,
+  resetLinkableRealms,
+  setLinkableRealms,
   setupRealmCacheTeardown,
   testModuleRealm,
   testRealmURL,
@@ -40,6 +42,12 @@ module('Integration | operator-mode | card chooser', function (hooks) {
     // The helper's realm-building beforeEach runs for these tests too, and caches
     // under this module's name, which the outer teardown's prefix cannot match.
     setupRealmCacheTeardown(hooks);
+
+    // The linkable-realm narrowing is module-level state in the realm-server
+    // mock, so clear it after every test whether or not that test set it.
+    hooks.afterEach(function () {
+      resetLinkableRealms();
+    });
 
     test(`displays recently accessed card`, async function (assert) {
       ctx.setCardInOperatorModeState(`${testRealmURL}grid`);
@@ -370,6 +378,42 @@ module('Integration | operator-mode | card chooser', function (hooks) {
       assert
         .dom(`[data-test-recent-card-result]`)
         .exists({ count: 2 }, 'non-Pet recent cards are filtered out');
+    });
+
+    test(`omits realms the consuming realm cannot fetch links from`, async function (assert) {
+      // A card's links are resolved by the realm that stores it, under its
+      // own owner's identity — so a card in a realm that owner cannot read
+      // breaks the moment the linking card is assembled. Here only the
+      // consuming realm is linkable, and the chooser must offer nothing else
+      // even though the user can read the other realms.
+      setLinkableRealms(testRealmURL);
+
+      ctx.setCardInOperatorModeState(`${testRealmURL}Person/hassan`, 'edit');
+      await renderComponent(
+        class TestDriver extends GlimmerComponent {
+          <template><OperatorMode @onClose={{noop}} /></template>
+        },
+      );
+      await waitFor(`[data-test-stack-card="${testRealmURL}Person/hassan"]`);
+      await waitFor(`[data-test-add-new="friends"]`);
+      await click(`[data-test-add-new="friends"]`); // linksToMany add button
+      await waitFor('[data-test-card-chooser-modal]');
+      await settled();
+
+      assert
+        .dom('[data-test-search-label]')
+        .hasText(
+          '5 results across 1 realm',
+          'the search is scoped to the one linkable realm',
+        );
+
+      await click('[data-test-realm-picker] [data-test-boxel-picker-trigger]');
+      assert
+        .dom(`[data-test-boxel-picker-option-row="${testRealmURL}"]`)
+        .exists('the linkable realm is offered');
+      assert
+        .dom(`[data-test-boxel-picker-option-row="${baseRealm.url}"]`)
+        .doesNotExist('a realm the consuming realm cannot read is not offered');
     });
 
     test('type picker is hidden when baseFilter constrains type', async function (assert) {

--- a/packages/realm-server/handlers/handle-linkable-realms.ts
+++ b/packages/realm-server/handlers/handle-linkable-realms.ts
@@ -1,0 +1,83 @@
+import type Koa from 'koa';
+import type { DBAdapter } from '@cardstack/runtime-common';
+import {
+  ensureTrailingSlash,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
+import {
+  sendResponseForBadRequest,
+  setContextResponse,
+} from '../middleware/index.ts';
+import {
+  getMultiRealmAuthorization,
+  getSearchRequestPayload,
+} from '../middleware/multi-realm-authorization.ts';
+import { fetchLinkableRealms } from '../utils/realm-readability.ts';
+
+export interface LinkableRealmsDocument {
+  data: {
+    type: 'linkable-realms';
+    id: string;
+    attributes: { realms: string[] };
+  };
+}
+
+// Which of the caller's realms a card stored in `consumingRealm` can link to.
+// A realm resolves its cards' links under its own owner's identity, so a link
+// whose target sits in a realm that owner cannot read is unfetchable no matter
+// who authored it — the card errors when the realm assembles it. Card pickers
+// call this to scope their search to realms whose cards will still resolve
+// once linked.
+//
+// `realms` carries the candidate list and is authorized against the caller by
+// `multiRealmAuthorization`, so the answer is always a subset of what the
+// caller can already read: it never enumerates the owner's other realms.
+// `consumingRealm` must be one of them.
+export default function handleLinkableRealms({
+  dbAdapter,
+}: {
+  dbAdapter: DBAdapter;
+}): (ctxt: Koa.Context) => Promise<void> {
+  return async function (ctxt: Koa.Context) {
+    let { realmList } = getMultiRealmAuthorization(ctxt);
+    let payload = getSearchRequestPayload(ctxt) as
+      | { consumingRealm?: unknown }
+      | undefined;
+    let rawConsumingRealm = payload?.consumingRealm;
+    if (typeof rawConsumingRealm !== 'string' || !rawConsumingRealm.trim()) {
+      await sendResponseForBadRequest(
+        ctxt,
+        'consumingRealm must be supplied in request body',
+      );
+      return;
+    }
+    let consumingRealm = ensureTrailingSlash(rawConsumingRealm.trim());
+    if (!realmList.includes(consumingRealm)) {
+      await sendResponseForBadRequest(
+        ctxt,
+        `consumingRealm ${consumingRealm} must be included in realms`,
+      );
+      return;
+    }
+
+    let realms = await fetchLinkableRealms(
+      dbAdapter,
+      consumingRealm,
+      realmList,
+    );
+
+    let doc: LinkableRealmsDocument = {
+      data: {
+        type: 'linkable-realms',
+        id: consumingRealm,
+        attributes: { realms },
+      },
+    };
+    await setContextResponse(
+      ctxt,
+      new Response(JSON.stringify(doc, null, 2), {
+        headers: { 'content-type': SupportedMimeType.JSONAPI },
+      }),
+    );
+  };
+}

--- a/packages/realm-server/handlers/handle-linkable-realms.ts
+++ b/packages/realm-server/handlers/handle-linkable-realms.ts
@@ -2,10 +2,12 @@ import type Koa from 'koa';
 import type { DBAdapter } from '@cardstack/runtime-common';
 import {
   ensureTrailingSlash,
+  fetchUserPermissions,
   SupportedMimeType,
 } from '@cardstack/runtime-common';
 import {
   sendResponseForBadRequest,
+  sendResponseForForbiddenRequest,
   setContextResponse,
 } from '../middleware/index.ts';
 import {
@@ -31,15 +33,20 @@ export interface LinkableRealmsDocument {
 //
 // `realms` carries the candidate list and is authorized against the caller by
 // `multiRealmAuthorization`, so the answer is always a subset of what the
-// caller can already read: it never enumerates the owner's other realms.
-// `consumingRealm` must be one of them.
+// caller can already read. Read alone is not enough to ask, though: the answer
+// describes the consuming realm owner's access, which is a third party's when
+// the caller is not that owner. Requiring write on `consumingRealm` keeps the
+// question to realms the caller can actually author into — otherwise anyone
+// could name a realm they merely read (a catalog realm, say) and probe its
+// owner's membership in every private realm the caller can see.
+// `consumingRealm` must be one of `realms`.
 export default function handleLinkableRealms({
   dbAdapter,
 }: {
   dbAdapter: DBAdapter;
 }): (ctxt: Koa.Context) => Promise<void> {
   return async function (ctxt: Koa.Context) {
-    let { realmList } = getMultiRealmAuthorization(ctxt);
+    let { realmList, userId } = getMultiRealmAuthorization(ctxt);
     let payload = getSearchRequestPayload(ctxt) as
       | { consumingRealm?: unknown }
       | undefined;
@@ -56,6 +63,22 @@ export default function handleLinkableRealms({
       await sendResponseForBadRequest(
         ctxt,
         `consumingRealm ${consumingRealm} must be included in realms`,
+      );
+      return;
+    }
+
+    let callerPermissions = userId
+      ? await fetchUserPermissions(dbAdapter, { userId, onlyOwnRealms: false })
+      : {};
+    let canWriteConsumingRealm = Object.entries(callerPermissions).some(
+      ([realmURL, actions]) =>
+        ensureTrailingSlash(realmURL) === consumingRealm &&
+        actions.includes('write'),
+    );
+    if (!canWriteConsumingRealm) {
+      await sendResponseForForbiddenRequest(
+        ctxt,
+        `Insufficient permissions to write realm: ${consumingRealm}`,
       );
       return;
     }

--- a/packages/realm-server/middleware/multi-realm-authorization.ts
+++ b/packages/realm-server/middleware/multi-realm-authorization.ts
@@ -34,6 +34,10 @@ import {
 
 export type MultiRealmAuthorizationState = {
   realmList: string[];
+  // The authenticated caller, absent for an anonymous request (which reaches a
+  // handler only when every requested realm is world-readable). A handler that
+  // needs more than the read this middleware enforces resolves it from here.
+  userId?: string;
 };
 
 const MULTI_REALM_AUTH_STATE = 'multiRealmAuthorization';
@@ -117,6 +121,7 @@ export function multiRealmAuthorization({
 
     let publishedRealmURLs = await getPublishedRealmURLs(dbAdapter, realmList);
 
+    let callerUserId: string | undefined;
     let readableRealms = new Set<string>();
     let authorization = ctxt.req.headers['authorization'];
     if (!authorization) {
@@ -177,10 +182,12 @@ export function multiRealmAuthorization({
         );
         return;
       }
+      callerUserId = token.user;
     }
 
     (ctxt.state as Record<string, unknown>)[MULTI_REALM_AUTH_STATE] = {
       realmList,
+      ...(callerUserId !== undefined ? { userId: callerUserId } : {}),
     } satisfies MultiRealmAuthorizationState;
 
     await next();

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -58,6 +58,7 @@ import type { JobScopedSearchCache } from './job-scoped-search-cache.ts';
 import handleRealmIndexCounts from './handlers/handle-realm-index-counts.ts';
 import handleRealmInfo from './handlers/handle-realm-info.ts';
 import handleFederatedTypes from './handlers/handle-federated-types.ts';
+import handleLinkableRealms from './handlers/handle-linkable-realms.ts';
 import { multiRealmAuthorization } from './middleware/multi-realm-authorization.ts';
 import handleDownloadRealm from './handlers/handle-download-realm.ts';
 import {
@@ -258,6 +259,11 @@ export function createRoutes(args: CreateRoutesArgs) {
       dbAdapter: args.dbAdapter,
       reconciler: args.reconciler,
     }),
+  );
+  router.all(
+    '/_linkable-realms',
+    multiRealmAuthorization(args),
+    handleLinkableRealms({ dbAdapter: args.dbAdapter }),
   );
   router.post(
     '/_prerender-card',

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -340,6 +340,7 @@ const ALL_TEST_FILES: string[] = [
   './server-endpoints/download-realm-test',
   './server-endpoints/federated-types-test',
   './server-endpoints/index-responses-test',
+  './server-endpoints/linkable-realms-test',
   './server-endpoints/maintenance-endpoints-test',
   './server-endpoints/publish-progress-test',
   './server-endpoints/queue-status-test',

--- a/packages/realm-server/tests/server-endpoints/linkable-realms-test.ts
+++ b/packages/realm-server/tests/server-endpoints/linkable-realms-test.ts
@@ -40,6 +40,8 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
     let sharedRealmURL = new URL('http://127.0.0.1:4444/shared/');
     let authorOnlyRealmURL = new URL('http://127.0.0.1:4444/author-only/');
     let publicRealmURL = new URL('http://127.0.0.1:4444/public/');
+    // No `realm-owner` row, so it has no identity to resolve links under.
+    let ownerlessRealmURL = new URL('http://127.0.0.1:4444/ownerless/');
 
     async function startLinkableRealmsServer({
       dbAdapter,
@@ -93,6 +95,15 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
             permissions: {
               '*': ['read'],
               [authorUserId]: ['read', 'write', 'realm-owner'],
+            },
+          },
+          {
+            realmURL: ownerlessRealmURL,
+            fileSystem: {
+              'realm.json': realmConfigCardJSON({ name: 'Ownerless Realm' }),
+            },
+            permissions: {
+              [authorUserId]: ['read', 'write'],
             },
           },
         ],
@@ -160,6 +171,42 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
           sharedRealmURL.href,
         ].sort(),
         'the realm the author owns alone is dropped; the consuming, shared, and world-readable realms remain',
+      );
+    });
+
+    test('QUERY /_linkable-realms refuses a consuming realm the caller cannot write', async function (assert) {
+      // The answer describes the consuming realm owner's access. A caller who
+      // merely reads that realm would be asking about a third party, so read
+      // is not enough to ask — otherwise a world-readable realm becomes a
+      // probe for its owner's membership in any realm the caller can name.
+      let response = await makeRequest({
+        consumingRealm: sharedRealmURL.href,
+        realms: [sharedRealmURL.href, consumingRealmURL.href],
+      });
+
+      assert.strictEqual(response.status, 403, 'HTTP 403 status');
+      assert.ok(
+        response.body.errors?.[0]?.includes(sharedRealmURL.href),
+        'response names the realm the caller cannot write',
+      );
+    });
+
+    test('QUERY /_linkable-realms leaves an ownerless realm able to link only its own cards', async function (assert) {
+      let response = await makeRequest({
+        consumingRealm: ownerlessRealmURL.href,
+        realms: [
+          ownerlessRealmURL.href,
+          publicRealmURL.href,
+          sharedRealmURL.href,
+        ],
+      });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let body = response.body as LinkableRealmsDocument;
+      assert.deepEqual(
+        body.data.attributes.realms,
+        [ownerlessRealmURL.href],
+        'a realm with no owner resolves links under no identity, so not even a world-readable realm is linkable from it',
       );
     });
 

--- a/packages/realm-server/tests/server-endpoints/linkable-realms-test.ts
+++ b/packages/realm-server/tests/server-endpoints/linkable-realms-test.ts
@@ -1,0 +1,225 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import supertest from 'supertest';
+import type { Test, SuperTest } from 'supertest';
+import { basename, join } from 'path';
+import { dirSync } from 'tmp';
+import type {
+  QueuePublisher,
+  QueueRunner,
+  Realm,
+} from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
+import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms.ts';
+import {
+  closeServer,
+  createVirtualNetwork,
+  setupDB,
+  matrixURL,
+  realmSecretSeed,
+  runTestRealmServerWithRealms,
+  realmConfigCardJSON,
+} from '../helpers/index.ts';
+import { createJWT as createRealmServerJWT } from '../../utils/jwt.ts';
+import type { RealmHttpServer as Server } from '../../server.ts';
+import type { LinkableRealmsDocument } from '../../handlers/handle-linkable-realms.ts';
+
+module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
+  module('Realm Server Endpoints | /_linkable-realms', function (hooks) {
+    let request: SuperTest<Test>;
+    let testRealmHttpServer: Server;
+    let realms: Realm[];
+
+    // The author writes into a realm someone else owns, and can read a realm
+    // that owner cannot. That split is what the endpoint exists to report:
+    // the consuming realm resolves links under its owner, not its author.
+    let authorUserId = '@author:localhost';
+    let ownerUserId = '@owner:localhost';
+
+    let consumingRealmURL = new URL('http://127.0.0.1:4444/consuming/');
+    let sharedRealmURL = new URL('http://127.0.0.1:4444/shared/');
+    let authorOnlyRealmURL = new URL('http://127.0.0.1:4444/author-only/');
+    let publicRealmURL = new URL('http://127.0.0.1:4444/public/');
+
+    async function startLinkableRealmsServer({
+      dbAdapter,
+      publisher,
+      runner,
+    }: {
+      dbAdapter: PgAdapter;
+      publisher: QueuePublisher;
+      runner: QueueRunner;
+    }) {
+      let virtualNetwork = createVirtualNetwork();
+      let dir = dirSync();
+      let result = await runTestRealmServerWithRealms({
+        virtualNetwork,
+        realmsRootPath: join(dir.name, 'realm_server_1'),
+        realms: [
+          {
+            realmURL: consumingRealmURL,
+            fileSystem: {
+              'realm.json': realmConfigCardJSON({ name: 'Consuming Realm' }),
+            },
+            permissions: {
+              [ownerUserId]: ['read', 'write', 'realm-owner'],
+              [authorUserId]: ['read', 'write'],
+            },
+          },
+          {
+            realmURL: sharedRealmURL,
+            fileSystem: {
+              'realm.json': realmConfigCardJSON({ name: 'Shared Realm' }),
+            },
+            permissions: {
+              [ownerUserId]: ['read'],
+              [authorUserId]: ['read'],
+            },
+          },
+          {
+            realmURL: authorOnlyRealmURL,
+            fileSystem: {
+              'realm.json': realmConfigCardJSON({ name: 'Author Only Realm' }),
+            },
+            permissions: {
+              [authorUserId]: ['read', 'write', 'realm-owner'],
+            },
+          },
+          {
+            realmURL: publicRealmURL,
+            fileSystem: {
+              'realm.json': realmConfigCardJSON({ name: 'Public Realm' }),
+            },
+            permissions: {
+              '*': ['read'],
+              [authorUserId]: ['read', 'write', 'realm-owner'],
+            },
+          },
+        ],
+        dbAdapter,
+        publisher,
+        runner,
+        matrixURL,
+      });
+
+      testRealmHttpServer = result.testRealmHttpServer;
+      realms = result.realms;
+      request = supertest(result.testRealmHttpServer);
+    }
+
+    setupDB(hooks, {
+      beforeEach: async (dbAdapter, publisher, runner) => {
+        await startLinkableRealmsServer({ dbAdapter, publisher, runner });
+      },
+      afterEach: async () => {
+        for (let realm of realms) {
+          realm.unsubscribe();
+        }
+        await closeServer(testRealmHttpServer);
+        resetCatalogRealms();
+      },
+    });
+
+    function makeRequest(body: Record<string, unknown>, user = authorUserId) {
+      let realmServerToken = createRealmServerJWT(
+        { user, sessionRoom: 'session-room-test' },
+        realmSecretSeed,
+      );
+      return request
+        .post('/_linkable-realms')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${realmServerToken}`)
+        .send(body);
+    }
+
+    test('QUERY /_linkable-realms drops realms the consuming realm’s owner cannot read', async function (assert) {
+      let response = await makeRequest({
+        consumingRealm: consumingRealmURL.href,
+        realms: [
+          consumingRealmURL.href,
+          sharedRealmURL.href,
+          authorOnlyRealmURL.href,
+          publicRealmURL.href,
+        ],
+      });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let body = response.body as LinkableRealmsDocument;
+      assert.strictEqual(body.data.type, 'linkable-realms', 'document type');
+      assert.strictEqual(
+        body.data.id,
+        consumingRealmURL.href,
+        'document is keyed by the consuming realm',
+      );
+      assert.deepEqual(
+        body.data.attributes.realms.sort(),
+        [
+          consumingRealmURL.href,
+          publicRealmURL.href,
+          sharedRealmURL.href,
+        ].sort(),
+        'the realm the author owns alone is dropped; the consuming, shared, and world-readable realms remain',
+      );
+    });
+
+    test('QUERY /_linkable-realms keeps the consuming realm itself', async function (assert) {
+      let response = await makeRequest({
+        consumingRealm: consumingRealmURL.href,
+        realms: [consumingRealmURL.href],
+      });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let body = response.body as LinkableRealmsDocument;
+      assert.deepEqual(
+        body.data.attributes.realms,
+        [consumingRealmURL.href],
+        'a realm can always link to its own cards',
+      );
+    });
+
+    test('QUERY /_linkable-realms answers only for realms the caller can read', async function (assert) {
+      // `@owner` has no permission on the author-only realm, so the request
+      // is refused outright rather than answered with a filtered list — the
+      // response can never disclose a realm the caller cannot already reach.
+      let response = await makeRequest(
+        {
+          consumingRealm: consumingRealmURL.href,
+          realms: [consumingRealmURL.href, authorOnlyRealmURL.href],
+        },
+        ownerUserId,
+      );
+
+      assert.strictEqual(response.status, 403, 'HTTP 403 status');
+      assert.ok(
+        response.body.errors?.[0]?.includes(authorOnlyRealmURL.href),
+        'response names the realm the caller cannot read',
+      );
+    });
+
+    test('QUERY /_linkable-realms requires a consumingRealm', async function (assert) {
+      let response = await makeRequest({ realms: [consumingRealmURL.href] });
+
+      assert.strictEqual(response.status, 400, 'HTTP 400 status');
+      assert.ok(
+        response.body.errors?.[0]?.includes(
+          'consumingRealm must be supplied in request body',
+        ),
+        'response explains the missing consumingRealm',
+      );
+    });
+
+    test('QUERY /_linkable-realms requires the consuming realm to be among the realms', async function (assert) {
+      let response = await makeRequest({
+        consumingRealm: sharedRealmURL.href,
+        realms: [consumingRealmURL.href],
+      });
+
+      assert.strictEqual(response.status, 400, 'HTTP 400 status');
+      assert.ok(
+        response.body.errors?.[0]?.includes('must be included in realms'),
+        'response explains that the consuming realm must ride along in realms',
+      );
+    });
+  });
+});

--- a/packages/realm-server/utils/realm-readability.ts
+++ b/packages/realm-server/utils/realm-readability.ts
@@ -95,6 +95,10 @@ export async function fetchLinkableRealms(
   realmList: string[],
 ): Promise<string[]> {
   let ownerUserId = await fetchRealmOwnerUserId(dbAdapter, consumingRealm);
+  // A realm with no `realm-owner` row has no identity to resolve links under
+  // at all: its outbound fetch fails while resolving the owner, before any
+  // request goes out, so every cross-realm link from it is unfetchable. Only
+  // its own cards are linkable.
   let readable = ownerUserId
     ? buildReadableRealms(
         await fetchUserPermissions(dbAdapter, {
@@ -103,9 +107,7 @@ export async function fetchLinkableRealms(
         }),
         await getPublishedRealmURLs(dbAdapter, realmList),
       )
-    : // An ownerless realm (no `realm-owner` permission row) resolves links
-      // under no identity beyond what the world can read.
-      await getPublicReadableRealms(dbAdapter, realmList);
+    : new Set<string>();
   readable.add(ensureTrailingSlash(consumingRealm));
   return realmList.filter((realmURL) => readable.has(realmURL));
 }

--- a/packages/realm-server/utils/realm-readability.ts
+++ b/packages/realm-server/utils/realm-readability.ts
@@ -1,6 +1,7 @@
 import type { DBAdapter } from '@cardstack/runtime-common';
 import {
   ensureTrailingSlash,
+  fetchRealmPermissions,
   fetchUserPermissions,
   param,
   query,
@@ -61,4 +62,50 @@ export async function getPublicReadableRealms(
   return new Set(
     normalizedRealmList.filter((realmURL) => publicReadable.has(realmURL)),
   );
+}
+
+// The identity a realm resolves its cards' links under: its human owner. A
+// realm assumes that user for every fetch it makes on a card's behalf — the
+// `included` assembly behind a card GET, the index pass, and the prerender —
+// so the owner's read permissions bound which realms a card stored here can
+// link to. A realm co-owned by a `@realm/…` bot resolves as the human.
+export async function fetchRealmOwnerUserId(
+  dbAdapter: DBAdapter,
+  realmURL: string,
+): Promise<string | undefined> {
+  let permissions = await fetchRealmPermissions(
+    dbAdapter,
+    new URL(ensureTrailingSlash(realmURL)),
+  );
+  let owners = Object.entries(permissions)
+    .filter(([, actions]) => actions.includes('realm-owner'))
+    .map(([userId]) => userId);
+  let humanOwners = owners.filter((userId) => !userId.startsWith('@realm/'));
+  return (humanOwners.length > 0 ? humanOwners : owners)[0];
+}
+
+// The subset of `realmList` whose cards a card in `consumingRealm` can link
+// to. A link only resolves when the consuming realm's owner can read the
+// realm holding the target, so a chooser that offers anything wider hands the
+// author a link its own realm cannot fetch. The consuming realm is always
+// included — a realm can always read itself.
+export async function fetchLinkableRealms(
+  dbAdapter: DBAdapter,
+  consumingRealm: string,
+  realmList: string[],
+): Promise<string[]> {
+  let ownerUserId = await fetchRealmOwnerUserId(dbAdapter, consumingRealm);
+  let readable = ownerUserId
+    ? buildReadableRealms(
+        await fetchUserPermissions(dbAdapter, {
+          userId: ownerUserId,
+          onlyOwnRealms: false,
+        }),
+        await getPublishedRealmURLs(dbAdapter, realmList),
+      )
+    : // An ownerless realm (no `realm-owner` permission row) resolves links
+      // under no identity beyond what the world can read.
+      await getPublicReadableRealms(dbAdapter, realmList);
+  readable.add(ensureTrailingSlash(consumingRealm));
+  return realmList.filter((realmURL) => readable.has(realmURL));
 }


### PR DESCRIPTION
## The problem

Which identity resolves a card's links depends on who is doing the resolving:

- The **host** loads a card as `application/vnd.card+source` — the raw file, no server-side `included` assembly — and then resolves each link itself, **as the signed-in user** (`card-api.gts` `lazilyLoadLink` → `store.loadCardDocument`).
- The **realm** resolves links under its own **owner's** identity: its outbound fetch stamps the owner into `X-Boxel-Assume-User` (`realm.ts:1136-1141`), and that is what backs the `included` assembly on a `card+json` GET, cross-realm link fetches, the index pass, and the prerender (`tasks/indexer.ts:361-367`, `tasks/prerender-html.ts:259-265`).

The card chooser scoped its search to every realm the **user** could read. Those two sets diverge whenever an author writes into a realm someone else owns: the author can pick a card from a realm the consuming realm's owner cannot read. The link saves, and the author sees it resolve fine — they can read it. But everything resolved under the realm's identity cannot, so the link comes back broken there (a `link-error` sentinel, recorded in `diagnostics.brokenLinks`) while looking healthy to the person who created it.

`linksToMany(() => CardDef)` makes this easy to reach, since every card in every realm the user can read is a candidate.

Scope note: this closes a real gap in the chooser. It is not established as the mechanism behind any particular reported breakage, and it does not change how an unresolvable link renders — that stays a broken-link sentinel.

## The fix

**`/_linkable-realms` on the realm server.** Given a candidate realm list and the consuming realm among them, it answers with the subset that realm's owner can read (world-readable and published realms included, same `buildReadableRealms` the search authorization uses), plus the consuming realm itself — a realm can always read its own cards.

It sits behind the existing `multiRealmAuthorization` middleware, so the candidate list is already authorized against the caller. Read alone is not enough to ask, though: the answer describes the consuming realm owner's access, which is a third party's whenever the caller is not that owner. So the handler also requires **write** on `consumingRealm`. Without that, anyone could name a realm they merely read — a catalog realm, say — and use the answer to probe its owner's membership in every private realm the caller can name. Write matches the use case exactly, since the chooser only ever opens from a field editor in a realm the author writes.

**The chooser uses that set as its realm scope.** `CardChooserModal` resolves it as the modal opens (in flight alongside the title and preselection work) and hands it to `SearchPanel` as `@availableRealms`. From there it is the search scope, the realm picker's option list and select-all target, the bound a pasted card URL has to fall inside, and the bound on the live-recents fallback (which loads recents by id rather than through the scoped search, so it needs the scope applied separately).

Nothing changes for the common case — a user linking between realms they own, where the two sets are identical. A chooser with no consuming realm (the create-card and markdown-embed pickers), and a request the server can't answer, both keep the user's full reach; the search sheet imposes no bound at all and still resolves any card URL its user can.

## Notes for review

- `RealmFilter.available` means "the caller declares a bound", not "the resolved realm set" — absent is the unbounded case, which is what keeps the search sheet's URL paste unchanged.
- `SheetResults` matches a pasted URL against picked ∪ available realms, picked first. Matching only the picked realms would leave a card from an available-but-unpicked realm to `realmUrlForCard`'s path-derived fallback, which names a sub-path rather than a realm root and would read as out of scope.
- A realm with no `realm-owner` row can link only its own cards: it has no identity to resolve links under, and its outbound fetch fails resolving the owner before any request goes out.
- The host refuses an empty realm list rather than adopting it as a scope — downstream an empty list means "search every realm", so a malformed answer would widen the search while leaving the picker with nothing to offer.
- The chooser falls back to the user's full reach when the request fails. Nothing downstream re-checks the scope (the store read after a pick runs as the user, who could always read the card), so that fallback reopens the gap for as long as it lasts. It is chosen because a chooser that offers nothing is worse than one that offers too much.

## Tests

- `packages/realm-server/tests/server-endpoints/linkable-realms-test.ts` — a fixture where the author writes into a realm someone else owns and can read a realm that owner cannot: the endpoint drops that realm and keeps the consuming, owner-readable, and world-readable ones. Plus the write requirement, the ownerless realm, the 403 for a realm the caller can't read, and the two 400s.
- `packages/host/tests/integration/components/operator-mode-card-chooser-test.gts` — with only the consuming realm linkable, the `linksToMany` chooser searches one realm and its realm picker offers only that one. The realm-server mock grows a `/_linkable-realms` route (`setLinkableRealms` / `resetLinkableRealms`), echoing the requested realms unless a test narrows them.

Known coverage gaps: the published-realm add-back (the fixture's public realm is `'*': ['read']`, not `kind='published'`), the client fallback path, and the URL-paste guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157KBRgCXsZYgXVWAJFJpMG
