### PR TITLE
Let a pool close cancel a failing standby refill instead of waiting it out

### DIFF
--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -426,6 +426,12 @@ export class PagePool {
   #renderSemaphore: RenderSemaphore | undefined;
   #disableStandbyRefill: boolean;
   #ensuringStandbys: Promise<void> | null = null;
+  // Bumped by every `closeAll`. The standby refill reads it on entry and gives
+  // up once it moves, which is how a close cancels a refill it would otherwise
+  // have to wait out. A counter rather than a flag because `Prerenderer`'s
+  // browser restart closes the pool and then keeps using it, so there is no
+  // single point at which a flag could be cleared.
+  #closeGeneration = 0;
   #creatingStandbys = 0;
   #consoleErrorsByPageId = new Map<string, Map<string, ConsoleErrorEntry>>();
   // Per-pageId map of CDP exceptionId -> bucket key, owned alongside
@@ -1338,6 +1344,14 @@ export class PagePool {
     // land below the zero this method resets the counter to, under-reporting
     // pool occupancy for the life of the process. Pinned by
     // `tests/page-pool-standby-refill-test.ts`.
+    //
+    // Bumping the close generation first is what keeps that wait bounded. The
+    // refill gives up when the generation moves, so this awaits the attempt
+    // already in flight and nothing beyond it. Waiting out the rest costs
+    // `STANDBY_CREATION_RETRIES` standby timeouts plus backoff — long enough
+    // for a caller closing the pool in order to shut down to blow its own
+    // shutdown budget, leaving the process it was tearing down alive.
+    this.#closeGeneration++;
     let ensuring = this.#ensuringStandbys;
     this.#ensuringStandbys = null;
     if (ensuring) {
@@ -1395,7 +1409,14 @@ export class PagePool {
   }
 
   async #ensureStandbyPoolInternal(): Promise<void> {
+    let generation = this.#closeGeneration;
     for (;;) {
+      // A `closeAll` that began after this refill did has already decided the
+      // pool's pages are going away, so anything created from here would be
+      // orphaned on the outgoing browser.
+      if (this.#closeGeneration !== generation) {
+        return;
+      }
       let desired = this.#desiredStandbyCount();
       let current = this.#currentStandbyCount();
       if (current >= desired) {
@@ -1465,9 +1486,15 @@ export class PagePool {
   }
 
   async #createStandbyWithRetries(): Promise<StandbyEntry | undefined> {
+    let generation = this.#closeGeneration;
     let attempt = 0;
     let backoffMs = STANDBY_BACKOFF_MS;
     while (attempt < STANDBY_CREATION_RETRIES) {
+      // Checked before every attempt, so a close that lands during a backoff
+      // ends the retries rather than being made to wait for them.
+      if (this.#closeGeneration !== generation) {
+        return undefined;
+      }
       attempt++;
       try {
         return await this.#createStandby();

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -1409,6 +1409,9 @@ export class PagePool {
   }
 
   async #ensureStandbyPoolInternal(): Promise<void> {
+    // One snapshot for the whole refill, threaded into the retry loop below.
+    // Every await in here is a window for a `closeAll` to bump the counter, so
+    // a second read anywhere downstream would be a read of the new value.
     let generation = this.#closeGeneration;
     for (;;) {
       // A `closeAll` that began after this refill did has already decided the
@@ -1426,7 +1429,7 @@ export class PagePool {
       if (!prepared) {
         return;
       }
-      let standby = await this.#createStandbyWithRetries();
+      let standby = await this.#createStandbyWithRetries(generation);
       if (!standby) {
         return;
       }
@@ -1485,14 +1488,21 @@ export class PagePool {
     await this.disposeAffinity(lruAffinity);
   }
 
-  async #createStandbyWithRetries(): Promise<StandbyEntry | undefined> {
-    let generation = this.#closeGeneration;
+  // Takes the refill's generation rather than reading the counter itself. The
+  // caller yields at `#prepareSlotForStandby` between its own check and this
+  // call, so a `closeAll` landing in that window has already bumped the
+  // counter by the time this is entered: a fresh read here would compare the
+  // new value against itself, find no mismatch, and run every attempt — the
+  // exact wait the counter exists to cut short.
+  async #createStandbyWithRetries(
+    refillGeneration: number,
+  ): Promise<StandbyEntry | undefined> {
     let attempt = 0;
     let backoffMs = STANDBY_BACKOFF_MS;
     while (attempt < STANDBY_CREATION_RETRIES) {
       // Checked before every attempt, so a close that lands during a backoff
       // ends the retries rather than being made to wait for them.
-      if (this.#closeGeneration !== generation) {
+      if (this.#closeGeneration !== refillGeneration) {
         return undefined;
       }
       attempt++;

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -191,6 +191,12 @@ export class Prerenderer {
   }
 
   async stop(): Promise<void> {
+    // Set before anything is torn down rather than after. The render entry
+    // points and `#runRestart`'s trailing re-warm all read this, and a stop
+    // that lands while a restart is in flight has to be visible to them
+    // before `closeAll()` starts — otherwise the re-warm relaunches the
+    // browser this method is on its way to closing.
+    this.#stopped = true;
     if (this.#cleanupInterval) {
       clearInterval(this.#cleanupInterval);
       this.#cleanupInterval = undefined;
@@ -202,7 +208,6 @@ export class Prerenderer {
     this.#affinitySnapshotSampler.shutdown();
     await this.#pagePool.closeAll();
     await this.#browserManager.stop();
-    this.#stopped = true;
   }
 
   async disposeAffinity({
@@ -935,6 +940,13 @@ export class Prerenderer {
     log.warn('Restarting prerender browser');
     this.#browserRestartCount++;
     await this.#pagePool.closeAll();
+    if (this.#stopped) {
+      // `stop()` arrived while this restart was in flight. Bringing a browser
+      // back up now would outlive the shutdown that is already underway, and
+      // re-warming into it would hold that shutdown open behind a pool the
+      // process no longer needs.
+      return;
+    }
     await this.#browserManager.restartBrowser();
     await this.#pagePool.warmStandbys().catch((e) => {
       log.error('Failed to warm standby pages after browser restart:', e);

--- a/packages/realm-server/tests/page-pool-standby-refill-test.ts
+++ b/packages/realm-server/tests/page-pool-standby-refill-test.ts
@@ -223,6 +223,36 @@ module(basename(import.meta.filename), function (hooks) {
   // later `getPage` can commandeer, and a `#creatingStandbys` decrement below
   // the zero `closeAll` resets, which under-reports pool occupancy for the
   // life of the process.
+  // The refill takes one generation snapshot and threads it downstream. It has
+  // to, because it yields between taking it and reaching the retry loop: a
+  // close landing in that window has already bumped the counter, so a second
+  // read there would compare the new value against itself, see no change, and
+  // work through every attempt — leaving the close waiting for exactly the
+  // retries it cancelled.
+  test('a close during standby preparation still cancels the retries', async function (assert) {
+    let attempts = 0;
+    let browserManager = makeBrowserStub({
+      gate: async () => {
+        attempts++;
+        throw new Error('standby creation failed');
+      },
+    });
+    let pool = makePool({ maxPages: 2, browserManager });
+
+    // Not awaited: the refill runs to its first await — inside
+    // `#prepareSlotForStandby`, before any context is created — and the close
+    // below lands in that window.
+    let refill = pool.warmStandbys();
+    await pool.closeAll();
+    await refill;
+
+    assert.strictEqual(
+      attempts,
+      0,
+      'the refill gave up without attempting a creation the close had already ruled out',
+    );
+  });
+
   // The other side of that contract: waiting for the refill must not mean
   // waiting out its retries. A refill whose attempts keep failing runs
   // `STANDBY_CREATION_RETRIES` of them, each bounded only by the standby

--- a/packages/realm-server/tests/page-pool-standby-refill-test.ts
+++ b/packages/realm-server/tests/page-pool-standby-refill-test.ts
@@ -223,6 +223,44 @@ module(basename(import.meta.filename), function (hooks) {
   // later `getPage` can commandeer, and a `#creatingStandbys` decrement below
   // the zero `closeAll` resets, which under-reports pool occupancy for the
   // life of the process.
+  // The other side of that contract: waiting for the refill must not mean
+  // waiting out its retries. A refill whose attempts keep failing runs
+  // `STANDBY_CREATION_RETRIES` of them, each bounded only by the standby
+  // navigation timeout, with backoff in between — so a caller that closes the
+  // pool in order to shut down (`Prerenderer.stop`, and the prerender server's
+  // teardown behind it) would sit behind attempts it has already decided it
+  // doesn't want, long enough to overrun its own shutdown budget and leave the
+  // process alive with its ports still bound.
+  test('closeAll ends a failing refill rather than waiting out its retries', async function (assert) {
+    let attempts = 0;
+    let browserManager = makeBrowserStub({
+      gate: async () => {
+        attempts++;
+        throw new Error('standby creation failed');
+      },
+    });
+    let pool = makePool({ maxPages: 2, browserManager });
+
+    let refill = pool.warmStandbys();
+    await waitUntil(
+      () => attempts >= 1,
+      'the first standby creation attempt to fail',
+    );
+
+    // Called during the backoff that follows the failed attempt. Attempt count
+    // rather than elapsed time is the assertion: it distinguishes "the close
+    // ended the retries" from "the close outlasted them" without depending on
+    // how long a retry takes.
+    await pool.closeAll();
+    await refill;
+
+    assert.strictEqual(
+      attempts,
+      1,
+      'no further creation attempt was made once closeAll began',
+    );
+  });
+
   test('closeAll waits for an in-flight standby refill and closes what it created', async function (assert) {
     let gate = makeManualGate();
     let created = 0;


### PR DESCRIPTION
`PagePool.closeAll` awaits an in-flight standby refill, and must: a standby completing afterwards would join `#standbys` holding a page on the browser the caller is about to replace, and its `#creatingStandbys--` would land below the zero `closeAll` resets. But what it awaited was the whole refill loop, retries included — `STANDBY_CREATION_RETRIES` attempts, each bounded only by the standby navigation timeout, with backoff between them. A caller closing the pool in order to shut down inherited that wait.

The prerender server's teardown is such a caller, and the host-shell recycle now guarantees a restart-and-refill early in every process's life, so the two meet: a refill left failing against the torn-down browser holds `stop()` open long past the caller's shutdown budget, leaving the server alive with its port still bound. In the CLI integration suites that surfaces as a 10s `afterAll` timeout followed by `EADDRINUSE` in the next file, since the prerender server it was supposed to stop is still listening.

`closeAll` now bumps a close generation before awaiting, and both the refill loop and its retry loop give up once that generation moves. The close waits for the attempt already in flight and nothing beyond it, so the invariant it exists for is unchanged — asserted by the existing test, which still passes. A generation rather than a flag because the browser restart closes the pool and then keeps using it, so there is no point at which a flag could be reset.

`Prerenderer.stop` also sets `#stopped` before tearing down rather than after, and the browser restart now returns early when it sees it. A stop arriving mid-restart previously let the trailing re-warm relaunch the browser that stop was on its way to closing.

Covered by page-pool-standby-refill-test: a refill whose attempts all fail makes exactly one of them once the close begins. Removing the retry-loop check takes that to three.