### PR TITLE
Re-render a module failure that the host shell moved under

### DIFF
--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -13,6 +13,7 @@ import {
   type PrerenderVisitType,
   type RenderRouteOptions,
   type ModuleRenderResponse,
+  type RenderVisitResponse,
   type RunCommandResponse,
   type ScreenshotCaptureSpec,
   type ScreenshotCaptureSpecParse,
@@ -41,6 +42,7 @@ import {
   sanitizePrerenderRequestId,
 } from './prerender-constants.ts';
 import { randomUUID } from 'crypto';
+import { isMissingExportMessage } from '@cardstack/runtime-common/package-shim-handler';
 
 type PrerenderServer = Server & {
   __stopPrerenderer?: () => Promise<void>;
@@ -104,6 +106,73 @@ export function decideHostShellRecycle(
     return { recycle: false, nextWarmed: reported };
   }
   return { recycle: true, nextWarmed: reported };
+}
+
+// Whether a visit's result should be re-rendered rather than believed.
+//
+// The two tokens are what this server had adopted when the render started and
+// when its response came back. A render that straddled a change between them
+// ran on a page whose bundle the realm server may already have stopped
+// serving. On its own that is unremarkable — most renders spanning a deploy
+// still produce correct output — and it matters for one class of failure:
+// `has no exported member`, which is exactly what a page resolving current
+// realm source against the previous bundle throws.
+//
+// That failure is worth one more render because of what happens to it
+// downstream. The indexer stores a failed render as the card's content, so a
+// transient bundle mismatch becomes an error document served from cache to
+// every anonymous reader until an unrelated reindex revisits the row.
+// Re-rendering on a page warmed against the current shell costs one render;
+// believing it costs an outage that lasts until something else repairs it.
+export function shouldRerenderForShellChange({
+  response,
+  shellAtStart,
+  shellAtCompletion,
+}: {
+  response: RenderVisitResponse;
+  shellAtStart: string | undefined;
+  shellAtCompletion: string | undefined;
+}): boolean {
+  // A server that has never been told a token knows nothing about which shell
+  // it is running, so an unknown on either side is left alone rather than
+  // guessed at in one direction or the other.
+  if (shellAtStart === undefined || shellAtCompletion === undefined) {
+    return false;
+  }
+  if (shellAtStart === shellAtCompletion) {
+    return false;
+  }
+  return hasMissingExportError(response);
+}
+
+function hasMissingExportError(response: RenderVisitResponse): boolean {
+  for (let candidate of [response.card?.error, response.pageUnusableError]) {
+    let message = candidate?.error?.message;
+    if (typeof message === 'string' && isMissingExportMessage(message)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Record which host shell produced this response. Kept whether or not the
+// render failed: on a failure it is the evidence for how the failure should be
+// read, and on a success it is what lets an operator attribute a render to a
+// bundle without matching timestamps against deploy logs.
+export function stampHostShellTokens(
+  response: RenderVisitResponse,
+  tokens: { atStart: string | undefined; atCompletion: string | undefined },
+): void {
+  if (tokens.atStart === undefined && tokens.atCompletion === undefined) {
+    return;
+  }
+  response.meta = {
+    ...(response.meta ?? {}),
+    ...(tokens.atStart !== undefined ? { hostShellHash: tokens.atStart } : {}),
+    ...(tokens.atCompletion !== undefined
+      ? { hostShellHashAtCompletion: tokens.atCompletion }
+      : {}),
+  };
 }
 
 // A one-shot notification that shutdown has begun, which the holder releases
@@ -204,6 +273,10 @@ export function buildPrerenderApp(options: {
   maxPages?: number;
   isDraining?: () => boolean;
   drainingPromise?: Promise<void>;
+  // The host-shell token this server has adopted, read at render start and
+  // again at render end so a visit can tell whether the shell moved under it.
+  // Owned by the HTTP server, which learns it from the manager's heartbeat.
+  getHostShellHash?: () => string | undefined;
 }): {
   app: Koa<Koa.DefaultState, Koa.Context>;
   prerenderer: Prerenderer;
@@ -975,23 +1048,27 @@ export function buildPrerenderApp(options: {
       let jobId = sanitizePrerenderJobId(ctxt.get(PRERENDER_JOB_ID_HEADER));
 
       let start = Date.now();
+      // Hoisted so a re-render after a host-shell change replays the same
+      // visit rather than an approximation of it.
+      let visitArgs: Parameters<typeof prerenderer.prerenderVisit>[0] = {
+        affinityType,
+        affinityValue,
+        realm,
+        url,
+        auth,
+        ...(visitType ? { visitType } : {}),
+        renderOptions,
+        ...(fileData ? { fileData } : {}),
+        ...(Array.isArray(types) ? { types } : {}),
+        ...(cardTypes?.length ? { cardTypes } : {}),
+        ...(batchId ? { batchId } : {}),
+        ...(priority !== undefined ? { priority } : {}),
+        ...(jobId ? { jobId } : {}),
+        signal: ac.signal,
+      };
+      let shellAtStart = options.getHostShellHash?.();
       let execPromise = prerenderer
-        .prerenderVisit({
-          affinityType,
-          affinityValue,
-          realm,
-          url,
-          auth,
-          ...(visitType ? { visitType } : {}),
-          renderOptions,
-          ...(fileData ? { fileData } : {}),
-          ...(Array.isArray(types) ? { types } : {}),
-          ...(cardTypes?.length ? { cardTypes } : {}),
-          ...(batchId ? { batchId } : {}),
-          ...(priority !== undefined ? { priority } : {}),
-          ...(jobId ? { jobId } : {}),
-          signal: ac.signal,
-        })
+        .prerenderVisit(visitArgs)
         .then((result) => ({ result }));
       let raceResult = await raceAgainstDrain(execPromise, subscribeToDrain);
       if ('draining' in raceResult) {
@@ -1017,6 +1094,37 @@ export function buildPrerenderApp(options: {
         return;
       }
       let { response, timings, pool } = raceResult.result;
+      let shellAtCompletion = options.getHostShellHash?.();
+      if (
+        !options.isDraining?.() &&
+        shouldRerenderForShellChange({
+          response,
+          shellAtStart,
+          shellAtCompletion,
+        })
+      ) {
+        log.warn(
+          'visit of %s failed to resolve a module on host shell %s, which this server has since replaced with %s; re-rendering before returning that failure',
+          url,
+          shellAtStart,
+          shellAtCompletion,
+        );
+        // The token moved because `reconcileHostShell` saw it move, so the
+        // browser is being recycled around now and this visit lands on a page
+        // warmed against the current shell. One attempt only: if it fails
+        // again the failure is the card's, and the caller is owed an answer.
+        shellAtStart = shellAtCompletion;
+        try {
+          ({ response, timings, pool } =
+            await prerenderer.prerenderVisit(visitArgs));
+          shellAtCompletion = options.getHostShellHash?.();
+        } catch (e) {
+          log.warn(
+            `re-render of ${url} after a host-shell change threw; keeping the original result:`,
+            e,
+          );
+        }
+      }
       let totalMs = Date.now() - start;
       let poolFlags = Object.entries({
         reused: pool.reused,
@@ -1045,6 +1153,10 @@ export function buildPrerenderApp(options: {
         poolFlagSuffix,
       );
       decorateRenderErrorDiagnostics(response, requestId);
+      stampHostShellTokens(response, {
+        atStart: shellAtStart,
+        atCompletion: shellAtCompletion,
+      });
       // Timings are already inside `response.meta.diagnostics`. Here
       // we just populate the JSON:API envelope `meta.timing` that
       // existing telemetry consumers still read.
@@ -1255,6 +1367,7 @@ export function createPrerenderHttpServer(options?: {
   let fatalExitOnUncaught = options?.fatalExitOnUncaught ?? true;
   let serverURL = resolvePrerenderServerURL(options?.port);
   let { app, prerenderer } = buildPrerenderApp({
+    getHostShellHash: () => warmedHostShellHash,
     maxPages: options?.maxPages,
     serverURL,
     isDraining: () => draining,

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -149,12 +149,17 @@ export function shouldRerenderForShellChange({
   shellAtStart: string | undefined;
   shellAtCompletion: string | undefined;
 }): boolean {
-  // A server that has never been told a token knows nothing about which shell
-  // it is running, so an unknown on either side is left alone rather than
-  // guessed at in one direction or the other.
-  if (shellAtStart === undefined || shellAtCompletion === undefined) {
+  // Nothing reported by the end of the render: this server has never been told
+  // which shell is current, so it has no grounds in either direction.
+  if (shellAtCompletion === undefined) {
     return false;
   }
+  // `undefined -> X` counts as a change, and it is the deploy shape this
+  // exists for. The train restarts prerender before the realm server, so a
+  // server booting mid-train warms against the outgoing bundle and the first
+  // token it ever hears is the new one — on such a server there is no
+  // `X -> Y` to observe until some later deploy. `decideHostShellRecycle`
+  // treats that first token as a definite change for the same reason.
   if (shellAtStart === shellAtCompletion) {
     return false;
   }
@@ -173,9 +178,23 @@ function hasMissingExportError(response: RenderVisitResponse): boolean {
     response.fileRender?.error,
     response.pageUnusableError,
   ]) {
-    let message = candidate?.error?.message;
-    if (typeof message === 'string' && isMissingExportMessage(message)) {
-      return true;
+    let error = candidate?.error;
+    if (!error) {
+      continue;
+    }
+    // The visit's own message, plus the console errors `RenderRunner` merges
+    // onto `additionalErrors`: a render whose own failure is a timeout or a
+    // wedge can carry the module error only in that array, and it is
+    // persisted with the row either way. Absent when `clampSerializedError`
+    // dropped the array from an oversized error, which is a coverage limit
+    // rather than a signal that the render was clean.
+    for (let message of [
+      error.message,
+      ...(error.additionalErrors ?? []).map((e) => e?.message),
+    ]) {
+      if (typeof message === 'string' && isMissingExportMessage(message)) {
+        return true;
+      }
     }
   }
   return false;
@@ -192,12 +211,21 @@ export function stampHostShellTokens(
   if (tokens.atStart === undefined && tokens.atCompletion === undefined) {
     return;
   }
+  // Under `diagnostics` rather than beside it: `flattenPrerenderMeta` carries
+  // that key onto `boxel_index.diagnostics` (and its prerender-html twin onto
+  // `prerendered_html.diagnostics`) and drops every other meta key, so a
+  // token stamped anywhere else never reaches the row an operator inspects.
   response.meta = {
     ...(response.meta ?? {}),
-    ...(tokens.atStart !== undefined ? { hostShellHash: tokens.atStart } : {}),
-    ...(tokens.atCompletion !== undefined
-      ? { hostShellHashAtCompletion: tokens.atCompletion }
-      : {}),
+    diagnostics: {
+      ...(response.meta?.diagnostics ?? {}),
+      ...(tokens.atStart !== undefined
+        ? { hostShellHash: tokens.atStart }
+        : {}),
+      ...(tokens.atCompletion !== undefined
+        ? { hostShellHashAtCompletion: tokens.atCompletion }
+        : {}),
+    },
   };
 }
 
@@ -299,10 +327,20 @@ export function buildPrerenderApp(options: {
   maxPages?: number;
   isDraining?: () => boolean;
   drainingPromise?: Promise<void>;
-  // The host-shell token this server has adopted, read at render start and
+  // The host-shell token the manager last *reported*, read at render start and
   // again at render end so a visit can tell whether the shell moved under it.
-  // Owned by the HTTP server, which learns it from the manager's heartbeat.
+  // Deliberately the reported token rather than the one the pool has adopted:
+  // the adopted value only advances once `recycle()` resolves, and a recycle
+  // cannot resolve until every in-flight visit has released its tab lease — so
+  // a render that was running when the shell changed would sample the same
+  // value twice and read as steady, which is precisely the case worth
+  // catching. Owned by the HTTP server, which learns it from the heartbeat.
   getHostShellHash?: () => string | undefined;
+  // The recycle triggered by the last token change, if one is still running.
+  // A re-render awaits it so it lands on a page warmed against the current
+  // shell instead of racing the teardown. Always resolves — the caller
+  // handles recycle failure by leaving its own baseline alone.
+  awaitHostShellRecycle?: () => Promise<void> | undefined;
 }): {
   app: Koa<Koa.DefaultState, Koa.Context>;
   prerenderer: Prerenderer;
@@ -1118,9 +1156,9 @@ export function buildPrerenderApp(options: {
         })
       ) {
         log.warn(
-          'visit of %s failed to resolve a module on host shell %s, which this server has since replaced with %s; re-rendering before returning that failure',
+          'visit of %s failed to resolve a module while the reported host shell moved from %s to %s; re-rendering before returning that failure',
           url,
-          shellAtStart,
+          shellAtStart ?? 'none',
           shellAtCompletion,
         );
         // The token moved because `reconcileHostShell` saw it move, so the
@@ -1128,16 +1166,32 @@ export function buildPrerenderApp(options: {
         // warmed against the current shell. One attempt only: if it fails
         // again the failure is the card's, and the caller is owed an answer.
         //
-        // Raced against the drain like the first attempt, not merely guarded
-        // by the `isDraining` check above: a signal arriving after that check
-        // would otherwise let this render hold `server.close()` open for its
-        // full timeout. Draining winning is reported as such rather than
+        // Waits for the recycle the token change triggered before rendering
+        // again. The reported token moves the moment the change is learned,
+        // while the pool is still tearing down, so rendering immediately would
+        // race `closeAll` and pay a browser restart inside `prerenderVisit`'s
+        // own recovery lane. Awaiting it is what makes "lands on a page warmed
+        // against the current shell" true rather than aspirational.
+        //
+        // Both waits sit inside the drain race, not merely behind the
+        // `isDraining` check above: a signal arriving after that check would
+        // otherwise let this hold `server.close()` open for a browser restart
+        // plus a full render. Draining winning is reported as such rather than
         // answered with the stale-shell failure — the manager routes the visit
         // to another server, which is a better outcome than persisting a
         // result this server has already decided it doesn't trust.
-        let retryPromise = prerenderer
-          .prerenderVisit(visitArgs)
-          .then((result) => ({ result }));
+        //
+        // A rejection is deliberately not caught. It unwinds to the route's
+        // outer handler and answers 500, which `remote-prerenderer` maps to a
+        // retryable error, so the visit is retried elsewhere — the same
+        // disposition as draining, and better than returning a failure this
+        // server distrusts. A recycle is exactly when a visit is most likely
+        // to reject, so this is the expected path rather than a corner.
+        let discardedMs = Date.now() - start;
+        let retryPromise = (async () => {
+          await options.awaitHostShellRecycle?.();
+          return { result: await prerenderer.prerenderVisit(visitArgs) };
+        })();
         let retryResult = await raceAgainstDrain(
           retryPromise,
           subscribeToDrain,
@@ -1152,20 +1206,20 @@ export function buildPrerenderApp(options: {
           respondDraining(ctxt);
           return;
         }
-        try {
-          ({ response, timings, pool } = retryResult.result);
-          // Moved only once the replacement has landed. Advancing it earlier
-          // would make a retained stale-shell failure claim it started under
-          // the replacement shell — usually stamping the same token twice,
-          // erasing the one piece of evidence that it straddled a deploy.
-          shellAtStart = shellAtCompletion;
-          shellAtCompletion = options.getHostShellHash?.();
-        } catch (e) {
-          log.warn(
-            `re-render of ${url} after a host-shell change threw; keeping the original result:`,
-            e,
-          );
-        }
+        ({ response, timings, pool } = retryResult.result);
+        // The clock restarts with the render the response actually came from,
+        // so `totalMs` and `timings` describe the same attempt. The discarded
+        // attempt's cost is logged rather than folded into either.
+        start = Date.now();
+        shellAtStart = shellAtCompletion;
+        shellAtCompletion = options.getHostShellHash?.();
+        log.info(
+          'visit of %s re-rendered on host shell %s after discarding a %dms attempt on %s',
+          url,
+          shellAtCompletion,
+          discardedMs,
+          shellAtStart,
+        );
       }
       let totalMs = Date.now() - start;
       let poolFlags = Object.entries({
@@ -1404,12 +1458,22 @@ export function createPrerenderHttpServer(options?: {
   // server is now serving a new shell — the browser is recycled so pages
   // reload it. Undefined until the first heartbeat that carries a token.
   let warmedHostShellHash: string | undefined;
+  // The token the manager last reported, recorded the moment it arrives. Kept
+  // separate from `warmedHostShellHash`, which must keep meaning "the shell
+  // the pool has actually been re-warmed against" so a failed recycle still
+  // retries on the next heartbeat. A visit samples this one, because it moves
+  // when the change is learned rather than when the teardown finishes.
+  let reportedHostShellHash: string | undefined;
+  // The recycle in flight for the last token change, so a visit can wait for
+  // the pool to be replaced before rendering again. Never rejects.
+  let hostShellRecycle: Promise<void> | undefined;
   let recyclingForHostChange = false;
   let isClosing = false;
   let fatalExitOnUncaught = options?.fatalExitOnUncaught ?? true;
   let serverURL = resolvePrerenderServerURL(options?.port);
   let { app, prerenderer } = buildPrerenderApp({
-    getHostShellHash: () => warmedHostShellHash,
+    getHostShellHash: () => reportedHostShellHash,
+    awaitHostShellRecycle: () => hostShellRecycle,
     maxPages: options?.maxPages,
     serverURL,
     isDraining: () => draining,
@@ -1497,6 +1561,11 @@ export function createPrerenderHttpServer(options?: {
   // awaits any in-flight standby refill before closing — so pages the warm is
   // mid-way through creating can't outlive the browser the restart replaces.
   function reconcileHostShell(hash: string | null) {
+    // Recorded before the guards below, because what the manager reported is
+    // true whether or not this server is in a position to act on it.
+    if (hash) {
+      reportedHostShellHash = hash;
+    }
     if (draining || recyclingForHostChange) {
       return;
     }
@@ -1516,7 +1585,7 @@ export function createPrerenderHttpServer(options?: {
         ? `host shell token first seen (${hash}); recycling prerender browser, which may have warmed against an earlier shell`
         : `host shell changed (${warmedHostShellHash} -> ${hash}); recycling prerender browser`,
     );
-    void prerenderer
+    hostShellRecycle = prerenderer
       .recycle()
       .then(() => {
         warmedHostShellHash = nextWarmed;
@@ -1528,6 +1597,7 @@ export function createPrerenderHttpServer(options?: {
       .finally(() => {
         recyclingForHostChange = false;
       });
+    void hostShellRecycle;
   }
 
   function startHeartbeatLoop() {

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -108,6 +108,22 @@ export function decideHostShellRecycle(
   return { recycle: true, nextWarmed: reported };
 }
 
+// The answer a visit gives when shutdown wins the race: the manager reads this
+// status, marks the server draining and routes the visit elsewhere. Shared by
+// both render attempts so a caller can't tell which one was interrupted.
+function respondDraining(ctxt: Koa.Context): void {
+  ctxt.status = PRERENDER_SERVER_DRAINING_STATUS_CODE;
+  ctxt.set(PRERENDER_SERVER_STATUS_HEADER, PRERENDER_SERVER_STATUS_DRAINING);
+  ctxt.body = {
+    errors: [
+      {
+        status: PRERENDER_SERVER_DRAINING_STATUS_CODE,
+        message: 'Prerender server draining',
+      },
+    ],
+  };
+}
+
 // Whether a visit's result should be re-rendered rather than believed.
 //
 // The two tokens are what this server had adopted when the render started and
@@ -146,7 +162,17 @@ export function shouldRerenderForShellChange({
 }
 
 function hasMissingExportError(response: RenderVisitResponse): boolean {
-  for (let candidate of [response.card?.error, response.pageUnusableError]) {
+  // Every sub-response that can carry a render failure, because every one of
+  // them is persisted the same way: `prerender-html-visit` writes
+  // `fileRender.error` as a cached `file-error` row exactly as the card path
+  // writes `instance-error`, so a FileDef render (Markdown and friends) stays
+  // poisoned on the same terms if it is left out.
+  for (let candidate of [
+    response.card?.error,
+    response.fileExtract?.error,
+    response.fileRender?.error,
+    response.pageUnusableError,
+  ]) {
     let message = candidate?.error?.message;
     if (typeof message === 'string' && isMissingExportMessage(message)) {
       return true;
@@ -1078,19 +1104,7 @@ export function buildPrerenderApp(options: {
             e,
           ),
         );
-        ctxt.status = PRERENDER_SERVER_DRAINING_STATUS_CODE;
-        ctxt.set(
-          PRERENDER_SERVER_STATUS_HEADER,
-          PRERENDER_SERVER_STATUS_DRAINING,
-        );
-        ctxt.body = {
-          errors: [
-            {
-              status: PRERENDER_SERVER_DRAINING_STATUS_CODE,
-              message: 'Prerender server draining',
-            },
-          ],
-        };
+        respondDraining(ctxt);
         return;
       }
       let { response, timings, pool } = raceResult.result;
@@ -1113,10 +1127,38 @@ export function buildPrerenderApp(options: {
         // browser is being recycled around now and this visit lands on a page
         // warmed against the current shell. One attempt only: if it fails
         // again the failure is the card's, and the caller is owed an answer.
-        shellAtStart = shellAtCompletion;
+        //
+        // Raced against the drain like the first attempt, not merely guarded
+        // by the `isDraining` check above: a signal arriving after that check
+        // would otherwise let this render hold `server.close()` open for its
+        // full timeout. Draining winning is reported as such rather than
+        // answered with the stale-shell failure — the manager routes the visit
+        // to another server, which is a better outcome than persisting a
+        // result this server has already decided it doesn't trust.
+        let retryPromise = prerenderer
+          .prerenderVisit(visitArgs)
+          .then((result) => ({ result }));
+        let retryResult = await raceAgainstDrain(
+          retryPromise,
+          subscribeToDrain,
+        );
+        if ('draining' in retryResult) {
+          retryPromise.catch((e) =>
+            log.debug(
+              'visit re-render settled after drain (ignored):',
+              e as any,
+            ),
+          );
+          respondDraining(ctxt);
+          return;
+        }
         try {
-          ({ response, timings, pool } =
-            await prerenderer.prerenderVisit(visitArgs));
+          ({ response, timings, pool } = retryResult.result);
+          // Moved only once the replacement has landed. Advancing it earlier
+          // would make a retained stale-shell failure claim it started under
+          // the replacement shell — usually stamping the same token twice,
+          // erasing the one piece of evidence that it straddled a deploy.
+          shellAtStart = shellAtCompletion;
           shellAtCompletion = options.getHostShellHash?.();
         } catch (e) {
           log.warn(

--- a/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
+++ b/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
@@ -1,10 +1,14 @@
 import QUnit from 'qunit';
 const { module, test } = QUnit;
 import { basename } from 'path';
+import type { RenderVisitResponse } from '@cardstack/runtime-common';
+import { isMissingExportMessage } from '@cardstack/runtime-common/package-shim-handler';
 import {
   createDrainSubscriber,
   decideHostShellRecycle,
   raceAgainstDrain,
+  shouldRerenderForShellChange,
+  stampHostShellTokens,
 } from '../prerender/prerender-app.ts';
 
 // Unit tests for the host-shell recycle decision a prerender server makes on
@@ -53,6 +57,137 @@ module(basename(import.meta.filename), function () {
         recycle: true,
         nextWarmed: 'bbb',
       });
+    });
+  });
+
+  module('shouldRerenderForShellChange', function () {
+    // The message a page throws when it resolves current realm source against
+    // a bundle that predates the export — the shape both production poisonings
+    // took, minted in `package-shim-handler`.
+    const MISSING_EXPORT =
+      "Module 'https://packages/@cardstack/boxel-ui/components' has no " +
+      "exported member 'MarkdownContentShell'. If this is a card, check the " +
+      "import statement that names 'MarkdownContentShell'.";
+
+    function visitResponse(message?: string): RenderVisitResponse {
+      return (message === undefined
+        ? { card: { isolatedHTML: '<div></div>' } }
+        : {
+            card: { error: { error: { message } } },
+          }) as unknown as RenderVisitResponse;
+    }
+
+    test('a module error under a changed shell is re-rendered', function (assert) {
+      assert.true(
+        shouldRerenderForShellChange({
+          response: visitResponse(MISSING_EXPORT),
+          shellAtStart: 'babf3612',
+          shellAtCompletion: 'b778fe76',
+        }),
+      );
+    });
+
+    test("the same error under a steady shell is the card's own", function (assert) {
+      assert.false(
+        shouldRerenderForShellChange({
+          response: visitResponse(MISSING_EXPORT),
+          shellAtStart: 'b778fe76',
+          shellAtCompletion: 'b778fe76',
+        }),
+        'nothing moved under the render, so the failure describes the card',
+      );
+    });
+
+    test('a changed shell alone does not re-render', function (assert) {
+      assert.false(
+        shouldRerenderForShellChange({
+          response: visitResponse(),
+          shellAtStart: 'babf3612',
+          shellAtCompletion: 'b778fe76',
+        }),
+        'a render that straddled a deploy and succeeded is left alone',
+      );
+      assert.false(
+        shouldRerenderForShellChange({
+          response: visitResponse('Card is not found at http://example/x'),
+          shellAtStart: 'babf3612',
+          shellAtCompletion: 'b778fe76',
+        }),
+        'only module resolution is suspect when the bundle changes',
+      );
+    });
+
+    test('an unknown token on either side is left alone', function (assert) {
+      for (let [atStart, atCompletion] of [
+        [undefined, 'b778fe76'],
+        ['babf3612', undefined],
+        [undefined, undefined],
+      ] as [string | undefined, string | undefined][]) {
+        assert.false(
+          shouldRerenderForShellChange({
+            response: visitResponse(MISSING_EXPORT),
+            shellAtStart: atStart,
+            shellAtCompletion: atCompletion,
+          }),
+          `(${atStart} -> ${atCompletion}) says nothing about which bundle rendered`,
+        );
+      }
+    });
+
+    test('the error also counts when it made the page unusable', function (assert) {
+      assert.true(
+        shouldRerenderForShellChange({
+          response: {
+            pageUnusableError: { error: { message: MISSING_EXPORT } },
+          } as unknown as RenderVisitResponse,
+          shellAtStart: 'babf3612',
+          shellAtCompletion: 'b778fe76',
+        }),
+      );
+    });
+
+    test('the message matcher tracks what the loader actually throws', function (assert) {
+      assert.true(isMissingExportMessage(MISSING_EXPORT));
+      assert.true(
+        isMissingExportMessage(`ReferenceError: ${MISSING_EXPORT}`),
+        'matches when the error was stringified with its class name',
+      );
+      assert.false(
+        isMissingExportMessage('Module not found: @cardstack/boxel-ui'),
+        'a missing module is a different failure from a missing export',
+      );
+    });
+  });
+
+  module('stampHostShellTokens', function () {
+    test('records both tokens without disturbing the rest of meta', function (assert) {
+      let response = {
+        meta: { requestId: 'abc' },
+      } as unknown as RenderVisitResponse;
+      stampHostShellTokens(response, {
+        atStart: 'babf3612',
+        atCompletion: 'b778fe76',
+      });
+      assert.deepEqual(response.meta, {
+        requestId: 'abc',
+        hostShellHash: 'babf3612',
+        hostShellHashAtCompletion: 'b778fe76',
+      });
+    });
+
+    test('a server that knows no token stamps nothing', function (assert) {
+      let response = {
+        meta: { requestId: 'abc' },
+      } as unknown as RenderVisitResponse;
+      stampHostShellTokens(response, {
+        atStart: undefined,
+        atCompletion: undefined,
+      });
+      assert.deepEqual(
+        response.meta,
+        { requestId: 'abc' },
+        'no empty keys added for what the server does not know',
+      );
     });
   });
 

--- a/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
+++ b/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
@@ -117,19 +117,31 @@ module(basename(import.meta.filename), function () {
       );
     });
 
-    test('an unknown token on either side is left alone', function (assert) {
-      for (let [atStart, atCompletion] of [
-        [undefined, 'b778fe76'],
-        ['babf3612', undefined],
-        [undefined, undefined],
-      ] as [string | undefined, string | undefined][]) {
+    // The deploy shape this exists for: the train restarts prerender before the
+    // realm server, so a server booting mid-train warms against the outgoing
+    // bundle and the first token it hears is the new one. On such a server
+    // there is no `X -> Y` to observe, so excluding `undefined -> X` excluded
+    // the whole boot window — the same transition `decideHostShellRecycle`
+    // treats as a definite change.
+    test('the first token learned mid-render counts as a change', function (assert) {
+      assert.true(
+        shouldRerenderForShellChange({
+          response: visitResponse(MISSING_EXPORT),
+          shellAtStart: undefined,
+          shellAtCompletion: 'b778fe76',
+        }),
+      );
+    });
+
+    test('a server that has heard no token at all is left alone', function (assert) {
+      for (let atStart of [undefined, 'babf3612']) {
         assert.false(
           shouldRerenderForShellChange({
             response: visitResponse(MISSING_EXPORT),
             shellAtStart: atStart,
-            shellAtCompletion: atCompletion,
+            shellAtCompletion: undefined,
           }),
-          `(${atStart} -> ${atCompletion}) says nothing about which bundle rendered`,
+          `(${atStart} -> undefined) says nothing about which bundle rendered`,
         );
       }
     });
@@ -175,6 +187,28 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    // A render whose own failure is a timeout or a wedge can carry the module
+    // error only in the console errors `RenderRunner` merges onto
+    // `additionalErrors` — and the row is persisted with it either way.
+    test('the error counts when it is only among the merged console errors', function (assert) {
+      assert.true(
+        shouldRerenderForShellChange({
+          response: {
+            card: {
+              error: {
+                error: {
+                  message: 'Render timed out after 30000ms',
+                  additionalErrors: [{ message: MISSING_EXPORT }],
+                },
+              },
+            },
+          } as unknown as RenderVisitResponse,
+          shellAtStart: 'babf3612',
+          shellAtCompletion: 'b778fe76',
+        }),
+      );
+    });
+
     test('the message matcher tracks what the loader actually throws', function (assert) {
       assert.true(isMissingExportMessage(MISSING_EXPORT));
       assert.true(
@@ -189,9 +223,12 @@ module(basename(import.meta.filename), function () {
   });
 
   module('stampHostShellTokens', function () {
-    test('records both tokens without disturbing the rest of meta', function (assert) {
+    // Under `diagnostics`, because that is the only meta key
+    // `flattenPrerenderMeta` carries onto the persisted row — a token stamped
+    // beside it never reaches the row an operator inspects.
+    test('records both tokens under diagnostics, beside the render breakdown', function (assert) {
       let response = {
-        meta: { requestId: 'abc' },
+        meta: { requestId: 'abc', diagnostics: { renderMs: 12 } },
       } as unknown as RenderVisitResponse;
       stampHostShellTokens(response, {
         atStart: 'babf3612',
@@ -199,9 +236,12 @@ module(basename(import.meta.filename), function () {
       });
       assert.deepEqual(response.meta, {
         requestId: 'abc',
-        hostShellHash: 'babf3612',
-        hostShellHashAtCompletion: 'b778fe76',
-      });
+        diagnostics: {
+          renderMs: 12,
+          hostShellHash: 'babf3612',
+          hostShellHashAtCompletion: 'b778fe76',
+        },
+      } as unknown as typeof response.meta);
     });
 
     test('a server that knows no token stamps nothing', function (assert) {
@@ -214,8 +254,8 @@ module(basename(import.meta.filename), function () {
       });
       assert.deepEqual(
         response.meta,
-        { requestId: 'abc' },
-        'no empty keys added for what the server does not know',
+        { requestId: 'abc' } as unknown as typeof response.meta,
+        'no empty keys, and no diagnostics object invented',
       );
     });
   });

--- a/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
+++ b/packages/realm-server/tests/prerender-host-shell-recycle-test.ts
@@ -134,6 +134,35 @@ module(basename(import.meta.filename), function () {
       }
     });
 
+    // A FileDef render's failure is persisted on the same terms as a card's —
+    // `prerender-html-visit` writes `fileRender.error` as a cached
+    // `file-error` row — so leaving these sub-responses out would let Markdown
+    // and friends stay poisoned by exactly the failure this recovers from.
+    test('the error counts from any sub-response that gets persisted', function (assert) {
+      for (let key of ['fileRender', 'fileExtract'] as const) {
+        assert.true(
+          shouldRerenderForShellChange({
+            response: {
+              [key]: { error: { error: { message: MISSING_EXPORT } } },
+            } as unknown as RenderVisitResponse,
+            shellAtStart: 'babf3612',
+            shellAtCompletion: 'b778fe76',
+          }),
+          `${key}.error is checked`,
+        );
+        assert.false(
+          shouldRerenderForShellChange({
+            response: {
+              [key]: { error: { error: { message: 'Card is not found' } } },
+            } as unknown as RenderVisitResponse,
+            shellAtStart: 'babf3612',
+            shellAtCompletion: 'b778fe76',
+          }),
+          `${key} is still only suspect for module resolution`,
+        );
+      }
+    });
+
     test('the error also counts when it made the page unusable', function (assert) {
       assert.true(
         shouldRerenderForShellChange({

--- a/packages/realm-server/tests/prerender-server-test.ts
+++ b/packages/realm-server/tests/prerender-server-test.ts
@@ -832,6 +832,243 @@ module(basename(import.meta.filename), function () {
       await built.prerenderer.stop();
     });
 
+    // The stale-shell re-render, at the route rather than through its
+    // predicate. What matters here is the plumbing the predicate can't see:
+    // which token the handler samples, that the re-render waits for the
+    // recycle, that it happens exactly once, and what a drain or a rejection
+    // during it answers.
+    module('stale-shell re-render', function () {
+      const MISSING_EXPORT =
+        "Module 'https://packages/@cardstack/boxel-ui/components' has no " +
+        "exported member 'MarkdownContentShell'.";
+
+      function poolMeta() {
+        return {
+          pageId: 'p',
+          affinityType: 'realm',
+          affinityValue: realmURL.href,
+          reused: false,
+          evicted: false,
+          timedOut: false,
+        };
+      }
+
+      // The handler's success log reads every `waits` field, so a stub that
+      // omits them throws there rather than at the assertion.
+      function timings() {
+        return {
+          launchMs: 0,
+          renderMs: 0,
+          waits: {
+            semaphoreMs: 0,
+            admissionMs: 0,
+            tabQueueMs: 0,
+            tabStartupMs: 0,
+            tabProbeMs: 0,
+          },
+        };
+      }
+
+      function moduleFailure() {
+        return {
+          response: { card: { error: { error: { message: MISSING_EXPORT } } } },
+          timings: timings(),
+          pool: poolMeta(),
+        };
+      }
+
+      function rendered() {
+        return {
+          response: { card: { isolatedHTML: '<div>fresh</div>' } },
+          timings: timings(),
+          pool: poolMeta(),
+        };
+      }
+
+      // Reports `babf3612` on the first sample and `b778fe76` after, which is
+      // a shell change learned while the render was in flight.
+      function shellThatMovesOnce() {
+        let samples = 0;
+        return () => (++samples > 1 ? 'b778fe76' : 'babf3612');
+      }
+
+      function visitRequest(
+        request: SuperTest<Test>,
+        url: string,
+        auth: string,
+      ) {
+        return request
+          .post('/prerender-visit')
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .send({
+            data: {
+              type: 'prerender-visit-request',
+              attributes: {
+                url,
+                auth,
+                realm: realmURL.href,
+                affinityType: 'realm',
+                affinityValue: realmURL.href,
+                renderOptions: { cardRender: true },
+              },
+            },
+          });
+      }
+
+      function authFor() {
+        return testCreatePrerenderAuth(testUserId, {
+          [realmURL.href]: ['read', 'write', 'realm-owner'],
+        });
+      }
+
+      test('a module failure under a moved shell is re-rendered once, after the recycle', async function (assert) {
+        let recycleSettled = false;
+        let recycleDeferred = new Deferred<void>();
+        let built = buildPrerenderApp({
+          serverURL: 'http://127.0.0.1:4222',
+          getHostShellHash: shellThatMovesOnce(),
+          awaitHostShellRecycle: () =>
+            recycleDeferred.promise.then(() => {
+              recycleSettled = true;
+            }),
+        });
+        let request: SuperTest<Test> = supertest(built.app.callback());
+
+        let calls = 0;
+        let sawRecycleSettled: boolean[] = [];
+        (built.prerenderer as any).prerenderVisit = async () => {
+          calls++;
+          sawRecycleSettled.push(recycleSettled);
+          return calls === 1 ? moduleFailure() : rendered();
+        };
+
+        let resPromise = visitRequest(
+          request,
+          `${realmURL.href}stale-shell`,
+          authFor(),
+        );
+        // The re-render must be waiting on the recycle, not already done.
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        assert.strictEqual(calls, 1, 're-render has not started yet');
+        recycleDeferred.fulfill();
+
+        let res = await resPromise;
+        assert.strictEqual(res.status, 201, 'answers with the replacement');
+        assert.strictEqual(calls, 2, 'exactly one re-render');
+        assert.deepEqual(
+          sawRecycleSettled,
+          [false, true],
+          'the second render ran only after the recycle settled',
+        );
+        assert.strictEqual(
+          res.body.data.attributes.card.isolatedHTML,
+          '<div>fresh</div>',
+          "the replacement's result is what is returned",
+        );
+        assert.strictEqual(
+          res.body.data.attributes.meta.diagnostics.hostShellHashAtCompletion,
+          'b778fe76',
+          'the tokens ride under diagnostics, where they reach a row',
+        );
+        await built.prerenderer.stop();
+      });
+
+      test("a module failure under a steady shell is returned as the card's own", async function (assert) {
+        let built = buildPrerenderApp({
+          serverURL: 'http://127.0.0.1:4222',
+          getHostShellHash: () => 'b778fe76',
+        });
+        let request: SuperTest<Test> = supertest(built.app.callback());
+
+        let calls = 0;
+        (built.prerenderer as any).prerenderVisit = async () => {
+          calls++;
+          return moduleFailure();
+        };
+
+        let res = await visitRequest(
+          request,
+          `${realmURL.href}steady-shell`,
+          authFor(),
+        );
+        assert.strictEqual(res.status, 201);
+        assert.strictEqual(calls, 1, 'no re-render');
+        assert.strictEqual(
+          res.body.data.attributes.card.error.error.message,
+          MISSING_EXPORT,
+          'the failure is returned for the caller to persist',
+        );
+        await built.prerenderer.stop();
+      });
+
+      test('a rejecting re-render answers 500 so the visit is retried elsewhere', async function (assert) {
+        let built = buildPrerenderApp({
+          serverURL: 'http://127.0.0.1:4222',
+          getHostShellHash: shellThatMovesOnce(),
+        });
+        let request: SuperTest<Test> = supertest(built.app.callback());
+
+        let calls = 0;
+        (built.prerenderer as any).prerenderVisit = async () => {
+          if (++calls === 1) {
+            return moduleFailure();
+          }
+          throw new Error('page closed mid-recycle');
+        };
+
+        let res = await visitRequest(
+          request,
+          `${realmURL.href}rejecting-rerender`,
+          authFor(),
+        );
+        assert.strictEqual(
+          res.status,
+          500,
+          'remote-prerenderer maps this to a retryable error rather than persisting the distrusted result',
+        );
+        assert.strictEqual(calls, 2, 'the re-render was attempted');
+        await built.prerenderer.stop();
+      });
+
+      test('a drain during the re-render answers draining', async function (assert) {
+        let localDraining = false;
+        let drainingDeferred = new Deferred<void>();
+        let built = buildPrerenderApp({
+          serverURL: 'http://127.0.0.1:4222',
+          isDraining: () => localDraining,
+          drainingPromise: drainingDeferred.promise,
+          getHostShellHash: shellThatMovesOnce(),
+          awaitHostShellRecycle: () => new Promise<void>(() => {}),
+        });
+        let request: SuperTest<Test> = supertest(built.app.callback());
+
+        let calls = 0;
+        (built.prerenderer as any).prerenderVisit = async () => {
+          calls++;
+          return moduleFailure();
+        };
+
+        let resPromise = visitRequest(
+          request,
+          `${realmURL.href}drain-during-rerender`,
+          authFor(),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        localDraining = true;
+        drainingDeferred.fulfill();
+
+        let res = await resPromise;
+        assert.strictEqual(
+          res.status,
+          PRERENDER_SERVER_DRAINING_STATUS_CODE,
+          'reports draining rather than the failure it distrusts',
+        );
+        assert.strictEqual(calls, 1, 'the re-render never ran');
+        await built.prerenderer.stop();
+      });
+    });
+
     test('draining race does not leak unhandled rejection from execute', async function (assert) {
       let unhandled = 0;
       let onUnhandled = () => unhandled++;

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -640,15 +640,6 @@ export interface PrerenderResponseMeta {
   // Lets operators join client → manager → prerender-server logs for
   // a single request. Absent for in-process (non-HTTP) callers.
   requestId?: string;
-  // Host-shell token the prerender server had adopted when this render
-  // started, and again when its response was assembled. Two different values
-  // mean the render straddled a host redeploy: the page resolved modules
-  // against a bundle the realm server may already have stopped serving. That
-  // is unremarkable for a render that succeeded, and decisive for one that
-  // failed to resolve a module — the failure then describes the environment
-  // rather than the card. Absent while the server has never been told a token.
-  hostShellHash?: string;
-  hostShellHashAtCompletion?: string;
 }
 
 // Per-visit client-side overhead the indexer spent producing a row, measured
@@ -707,6 +698,18 @@ export interface Diagnostics
   extends RenderTimeoutDiagnostics, PrerenderMetaDiagnostics {
   invalidationId?: string;
   indexedAt?: number;
+  // Host-shell token the prerender server had been told was current when this
+  // render started, and again when its response was assembled. Two different
+  // values mean the render straddled a host redeploy: the page resolved
+  // modules against a bundle the realm server may already have stopped
+  // serving. Unremarkable for a render that succeeded, and decisive for one
+  // that failed to resolve a module — that failure then describes the
+  // environment rather than the card, which is what an operator reading the
+  // error row needs to know. Lives here rather than on the response meta
+  // because `flattenPrerenderMeta` carries `diagnostics` onto the persisted
+  // row and drops every other meta key.
+  hostShellHash?: string;
+  hostShellHashAtCompletion?: string;
   // A row is produced by two prerender visits (index + prerender-html),
   // each its own HTTP request. `requestId` always carries the index visit's
   // id and this always carries the prerender-html visit's, whichever table

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -640,6 +640,15 @@ export interface PrerenderResponseMeta {
   // Lets operators join client → manager → prerender-server logs for
   // a single request. Absent for in-process (non-HTTP) callers.
   requestId?: string;
+  // Host-shell token the prerender server had adopted when this render
+  // started, and again when its response was assembled. Two different values
+  // mean the render straddled a host redeploy: the page resolved modules
+  // against a bundle the realm server may already have stopped serving. That
+  // is unremarkable for a render that succeeded, and decisive for one that
+  // failed to resolve a module — the failure then describes the environment
+  // rather than the card. Absent while the server has never been told a token.
+  hostShellHash?: string;
+  hostShellHashAtCompletion?: string;
 }
 
 // Per-visit client-side overhead the indexer spent producing a row, measured

--- a/packages/runtime-common/package-shim-handler.ts
+++ b/packages/runtime-common/package-shim-handler.ts
@@ -154,6 +154,19 @@ const MISSING_EXPORT_TAIL =
   `which then surfaces as confusing downstream errors. This Proxy ` +
   `surfaces the missing import directly.)`;
 
+// The Proxy above is the only place this message is minted, so this is the
+// only other place that has to agree with its wording. Exported because the
+// failure it names is not always the card's: a prerender page still running
+// the previous host bundle resolves current realm source against the wrong
+// module and fails exactly this way. A caller that can see the host shell
+// moved under the render needs to recognize the message to treat it as
+// retryable rather than persist it as the card's content.
+const MISSING_EXPORT_MESSAGE = /Module '[^']+' has no exported member '[^']+'/;
+
+export function isMissingExportMessage(message: string): boolean {
+  return MISSING_EXPORT_MESSAGE.test(message);
+}
+
 function buildMissingExportMessage(
   moduleIdentifier: string,
   prop: string,


### PR DESCRIPTION
This relates to the Tuesday production hosted site downtime, which happened again today.

Claude: The indexer stores a failed render as the card's content, which is right when the card is broken and wrong when the page that rendered it was running a bundle the realm server has already stopped serving. A prerender tab holding the pre-deploy host bundle, rendering post-deploy realm source, throws `has no exported member` — a fact about a transient bundle mismatch. Persisted as an error document it becomes what every anonymous reader gets, in ~25ms from cache, until an unrelated reindex happens to revisit the row. Twice in three days that turned a bundle-coexistence window of a few minutes into an outage of roughly seventy.

The prerender server is the only party that can tell those apart, because it is the one that learns the shell changed. It now reads its adopted host-shell token when a visit starts and again when the render returns, and a visit whose two tokens differ AND whose result is a module-resolution failure is rendered once more before being returned. The recycle that moved the token is already in flight by then, so the second attempt lands on a page warmed against the current shell. One attempt only: if it fails again the failure is the card's, and the caller is owed an answer.

The tokens are recorded on the response either way. On a failure they are the evidence for how it should be read; on a success they let an operator attribute a render to a bundle without matching timestamps against deploy logs.

Two limits worth stating. A render that both starts and finishes before this server hears about the change still looks steady to it — narrowing that needs the token stamped per page rather than per server. And a page that warmed its shell from a realm-server task that had not rolled yet carries a token that never appears to move at all; the cross-artifact CI guard is what removes that class rather than this.