### PR TITLE
Contain the workspace chooser's background realm loads

### DIFF
--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -7,7 +7,7 @@ import { tracked } from '@glimmer/tracking';
 import ArchiveIcon from '@cardstack/boxel-icons/archive';
 import Home from '@cardstack/boxel-icons/home';
 import Shapes from '@cardstack/boxel-icons/shapes';
-import { dropTask } from 'ember-concurrency';
+import { didCancel, dropTask } from 'ember-concurrency';
 import { modifier } from 'ember-modifier';
 
 import { BoxelSelect, LoadingIndicator } from '@cardstack/boxel-ui/components';
@@ -22,7 +22,7 @@ import {
 } from '@cardstack/boxel-ui/icons';
 import type { Icon } from '@cardstack/boxel-ui/icons';
 
-import { ri } from '@cardstack/runtime-common';
+import { logger, ri } from '@cardstack/runtime-common';
 
 import config from '@cardstack/host/config/environment';
 import type MatrixService from '@cardstack/host/services/matrix-service';
@@ -46,6 +46,8 @@ interface Signature {
     topBarCenterElement: Element | null;
   };
 }
+
+const log = logger('component:workspace-chooser');
 
 export default class WorkspaceChooser extends Component<Signature> {
   @service declare matrixService: MatrixService;
@@ -118,7 +120,17 @@ export default class WorkspaceChooser extends Component<Signature> {
       !this.loadArchivedRealmsTask.lastSuccessful &&
       !this.loadArchivedRealmsTask.isRunning
     ) {
-      this.loadArchivedRealmsTask.perform();
+      // Nothing awaits the perform, and an unconsumed ember-concurrency task
+      // instance rethrows its error globally — under a test run that fails
+      // whichever test is executing rather than this one. The disclosure
+      // already handles a failed load by leaving `lastSuccessful` unset so the
+      // next expand retries, so a failure is logged here rather than escaping.
+      this.loadArchivedRealmsTask.perform().catch((error: unknown) => {
+        if (didCancel(error)) {
+          return;
+        }
+        log.warn(`loading archived realms failed: ${error}`);
+      });
     }
   }
 

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -121,10 +121,10 @@ export default class WorkspaceChooser extends Component<Signature> {
       !this.loadArchivedRealmsTask.isRunning
     ) {
       // Nothing awaits the perform, and an unconsumed ember-concurrency task
-      // instance rethrows its error globally — under a test run that fails
-      // whichever test is executing rather than this one. The disclosure
-      // already handles a failed load by leaving `lastSuccessful` unset so the
-      // next expand retries, so a failure is logged here rather than escaping.
+      // instance reports its error globally — under a test run that fails
+      // whichever test is executing rather than this one. A rejection leaves
+      // `lastSuccessful` unset, so re-expanding the section retries; until
+      // then it reads the same as a section with nothing archived.
       this.loadArchivedRealmsTask.perform().catch((error: unknown) => {
         if (didCancel(error)) {
           return;

--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -2,6 +2,7 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
+import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
 
@@ -11,7 +12,7 @@ import FileSettingsIcon from '@cardstack/boxel-icons/file-settings';
 import Home from '@cardstack/boxel-icons/home';
 import RefreshIcon from '@cardstack/boxel-icons/refresh-cw';
 import { format as formatDate } from 'date-fns';
-import { dropTask, task } from 'ember-concurrency';
+import { didCancel, dropTask, task } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
 import pluralize from 'pluralize';
 
@@ -39,6 +40,7 @@ import {
 import {
   ensureTrailingSlash,
   hasExecutableExtension,
+  logger,
   RealmPaths,
   SupportedMimeType,
   type RealmIdentifier,
@@ -75,6 +77,8 @@ interface Signature {
     navIndex?: number;
   };
 }
+
+const log = logger('component:workspace-chooser/workspace');
 
 export default class Workspace extends Component<Signature> {
   <template>
@@ -1656,7 +1660,9 @@ export default class Workspace extends Component<Signature> {
 
   constructor(...args: [any, any]) {
     super(...args);
-    this.loadRealmTask.perform();
+    this.loadRealmTask
+      .perform()
+      .catch((error: unknown) => this.reportRealmLoadFailure(error));
   }
 
   willDestroy() {
@@ -1664,10 +1670,54 @@ export default class Workspace extends Component<Signature> {
     this.clearReindexError();
   }
 
+  // Fills in the session and the realm metadata the tile renders from. The
+  // tile renders immediately off `realm.info()`, which answers synchronously
+  // with a placeholder, so this runs in the background and nothing awaits it.
+  //
+  // `loadRealmStage` records how far it got. Both steps talk to the realm
+  // server and both can fail transiently with the same `TypeError: Failed to
+  // fetch`, so the rejection alone doesn't say which one did; the stage names
+  // it in the diagnostic below.
+  private loadRealmStage: 'login' | 'realm-meta' = 'login';
+
   private loadRealmTask = task(async () => {
+    this.loadRealmStage = 'login';
     await this.realm.login(this.args.realmIdentifier);
+    this.loadRealmStage = 'realm-meta';
     await this.realm.ensureRealmMeta(this.args.realmIdentifier);
   });
+
+  // An unconsumed ember-concurrency task instance rethrows its error globally,
+  // which under a test run fails whichever test happens to be executing rather
+  // than the one that rendered this tile. The load is best-effort — the tile
+  // keeps the placeholder name and no stats, and a later render's
+  // `realm.info()` re-attempts the `_info` fetch — so a failure is recorded
+  // here instead of escaping. Cancellation is the ordinary teardown path
+  // (the chooser closes while the load is in flight) and stays silent.
+  private reportRealmLoadFailure(error: unknown) {
+    if (didCancel(error)) {
+      return;
+    }
+    log.warn(
+      `background realm load failed at ${this.loadRealmStage} for ${this.args.realmIdentifier}: ${error}`,
+    );
+    // The service logger is off by default in a test build, so the same detail
+    // goes to the console under test — this is the record a CI run leaves
+    // behind when a tile's load fails. The stack is included because the
+    // fetch's own message ("Failed to fetch") names neither the request nor
+    // the caller, and it is the only thing that distinguishes this load from
+    // any other background fetch failing the same way.
+    if (isTesting()) {
+      console.warn(
+        `[workspace-chooser] background realm load failed ${JSON.stringify({
+          realmURL: this.args.realmIdentifier,
+          stage: this.loadRealmStage,
+          error: String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        })}`,
+      );
+    }
+  }
 
   @cached
   private get realmInfo() {

--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -2,7 +2,6 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
 
@@ -1673,50 +1672,34 @@ export default class Workspace extends Component<Signature> {
   // Fills in the session and the realm metadata the tile renders from. The
   // tile renders immediately off `realm.info()`, which answers synchronously
   // with a placeholder, so this runs in the background and nothing awaits it.
-  //
-  // `loadRealmStage` records how far it got. Both steps talk to the realm
-  // server and both can fail transiently with the same `TypeError: Failed to
-  // fetch`, so the rejection alone doesn't say which one did; the stage names
-  // it in the diagnostic below.
-  private loadRealmStage: 'login' | 'realm-meta' = 'login';
-
   private loadRealmTask = task(async () => {
-    this.loadRealmStage = 'login';
     await this.realm.login(this.args.realmIdentifier);
-    this.loadRealmStage = 'realm-meta';
     await this.realm.ensureRealmMeta(this.args.realmIdentifier);
   });
 
-  // An unconsumed ember-concurrency task instance rethrows its error globally,
-  // which under a test run fails whichever test happens to be executing rather
-  // than the one that rendered this tile. The load is best-effort — the tile
-  // keeps the placeholder name and no stats, and a later render's
-  // `realm.info()` re-attempts the `_info` fetch — so a failure is recorded
-  // here instead of escaping. Cancellation is the ordinary teardown path
-  // (the chooser closes while the load is in flight) and stays silent.
+  // An unconsumed ember-concurrency task instance reports its error through
+  // `Ember.onerror`, or throws it from a run-loop timer when nothing sets
+  // that. Without a catch here a rejected load fails whichever test is
+  // running rather than the one that rendered this tile.
+  //
+  // The load is best-effort: on failure the tile keeps the placeholder name
+  // `realm.info()` returns and an empty stats row. It does not re-request on
+  // its own — the real values arrive whenever something else populates the
+  // realm resource's info. Cancellation is the ordinary teardown path, when
+  // the chooser closes mid-load, and stays silent.
+  //
+  // The stack is logged alongside the message because `TypeError: Failed to
+  // fetch` — how a realm round trip fails when the connection drops rather
+  // than answering an error status — names neither the request nor the
+  // caller on its own.
   private reportRealmLoadFailure(error: unknown) {
     if (didCancel(error)) {
       return;
     }
     log.warn(
-      `background realm load failed at ${this.loadRealmStage} for ${this.args.realmIdentifier}: ${error}`,
+      `workspace tile background realm load failed for ${this.args.realmIdentifier}: ${error}`,
+      error instanceof Error ? error.stack : undefined,
     );
-    // The service logger is off by default in a test build, so the same detail
-    // goes to the console under test — this is the record a CI run leaves
-    // behind when a tile's load fails. The stack is included because the
-    // fetch's own message ("Failed to fetch") names neither the request nor
-    // the caller, and it is the only thing that distinguishes this load from
-    // any other background fetch failing the same way.
-    if (isTesting()) {
-      console.warn(
-        `[workspace-chooser] background realm load failed ${JSON.stringify({
-          realmURL: this.args.realmIdentifier,
-          stage: this.loadRealmStage,
-          error: String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-        })}`,
-      );
-    }
   }
 
   @cached

--- a/packages/host/tests/acceptance/workspace-chooser-test.gts
+++ b/packages/host/tests/acceptance/workspace-chooser-test.gts
@@ -32,6 +32,7 @@ import {
 import { setupBaseRealm } from '../helpers/base-realm';
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupApplicationTest } from '../helpers/setup';
+import { suspendGlobalErrorHook } from '../helpers/uncaught-exceptions';
 
 const realmAURL = 'http://test-realm/testuser/workspace-a/';
 const realmBURL = 'http://test-realm/testuser/workspace-b/';
@@ -1255,6 +1256,46 @@ module('Acceptance | workspace-chooser', function (hooks) {
         .doesNotExist('dropdown closed on mouseleave');
 
       restoreA();
+    });
+  });
+
+  // Each tile fills in its realm session and metadata from a background load
+  // started in the component constructor. Nothing awaits that load, and
+  // ember-concurrency rethrows an unconsumed task instance's error globally:
+  // an escaping rejection lands as `Global error: Uncaught TypeError: Failed
+  // to fetch` against whichever test happens to be running, which is not
+  // necessarily the one whose tile failed. `suspendGlobalErrorHook` collects
+  // what would otherwise be that global failure so it can be asserted on.
+  module('background tile loads', function (hooks) {
+    let { capturedExceptions } = suspendGlobalErrorHook(hooks);
+
+    test('a rejected realm load does not surface as a global error', async function (assert) {
+      let realmService = getService('realm') as any;
+      let originalLogin = realmService.login.bind(realmService);
+      realmService.login = async (realmURL: string) => {
+        if (realmURL === realmAURL) {
+          // What a realm-server round trip rejects with when the connection
+          // fails outright rather than answering an error status.
+          throw new TypeError('Failed to fetch');
+        }
+        return originalLogin(realmURL);
+      };
+
+      try {
+        await visitOperatorMode({ workspaceChooserOpened: true });
+        await settled();
+      } finally {
+        realmService.login = originalLogin;
+      }
+
+      assert.deepEqual(
+        capturedExceptions.map((error) => String(error)),
+        [],
+        'the rejected load raised nothing globally',
+      );
+      assert
+        .dom('[data-test-workspace-list] [data-test-workspace]')
+        .exists('the chooser still renders its workspace tiles');
     });
   });
 });

--- a/packages/host/tests/acceptance/workspace-chooser-test.gts
+++ b/packages/host/tests/acceptance/workspace-chooser-test.gts
@@ -1260,20 +1260,24 @@ module('Acceptance | workspace-chooser', function (hooks) {
   });
 
   // Each tile fills in its realm session and metadata from a background load
-  // started in the component constructor. Nothing awaits that load, and
-  // ember-concurrency rethrows an unconsumed task instance's error globally:
-  // an escaping rejection lands as `Global error: Uncaught TypeError: Failed
-  // to fetch` against whichever test happens to be running, which is not
-  // necessarily the one whose tile failed. `suspendGlobalErrorHook` collects
-  // what would otherwise be that global failure so it can be asserted on.
+  // started in the component constructor. Nothing awaits that load, and an
+  // unconsumed ember-concurrency task instance reports its error through
+  // `Ember.onerror` — or throws it from a run-loop timer when nothing sets
+  // that. An escaping rejection therefore lands as `Global error: Uncaught
+  // TypeError: Failed to fetch` against whichever test happens to be running,
+  // which is not necessarily the one whose tile failed.
+  // `suspendGlobalErrorHook` collects what would otherwise be that global
+  // failure so it can be asserted on.
   module('background tile loads', function (hooks) {
     let { capturedExceptions } = suspendGlobalErrorHook(hooks);
 
     test('a rejected realm load does not surface as a global error', async function (assert) {
       let realmService = getService('realm') as any;
       let originalLogin = realmService.login.bind(realmService);
+      let rejectedLoads = 0;
       realmService.login = async (realmURL: string) => {
         if (realmURL === realmAURL) {
+          rejectedLoads++;
           // What a realm-server round trip rejects with when the connection
           // fails outright rather than answering an error status.
           throw new TypeError('Failed to fetch');
@@ -1288,6 +1292,13 @@ module('Acceptance | workspace-chooser', function (hooks) {
         realmService.login = originalLogin;
       }
 
+      // An empty capture proves nothing unless the load it stands for
+      // actually ran: were the tile to stop asking for this realm by this
+      // URL, both assertions below would still hold with nothing exercised.
+      assert.ok(
+        rejectedLoads > 0,
+        `the tile's realm load ran and rejected, ${rejectedLoads} time(s)`,
+      );
       assert.deepEqual(
         capturedExceptions.map((error) => String(error)),
         [],


### PR DESCRIPTION
## What

Every workspace tile performs `loadRealmTask` from its constructor to establish the realm session (`realm.login`) and load the realm's metadata (`realm.ensureRealmMeta`). Nothing awaits that perform — the tile renders straight away off `realm.info()`, which answers synchronously with a placeholder — and an unconsumed ember-concurrency task instance reports its error through `Ember.onerror`, or throws it from a run-loop timer when nothing sets that.

So a transient realm-server failure escapes as a global `TypeError: Failed to fetch` and fails **whichever test QUnit has running at that moment**, not the one whose tile failed. The perform carries a catch. The load is best-effort: on failure the tile keeps the placeholder name and empty stats row it already shows while the load is in flight. It does not re-request on its own — its `realmInfo` getter is `@cached` and the failure path leaves the realm resource's `info` unset, so nothing dirties the tag that would recompute it; the real values land whenever something else populates that resource.

The chooser's archived-realms disclosure performs its lazy load the same fire-and-forget way and gets the same treatment. A rejection leaves `lastSuccessful` unset, so re-expanding the section retries; until then it reads the same as a section with nothing archived.

## The reported failure

[Host Tests (7, 16)](https://github.com/cardstack/boxel/actions/runs/33216969882/job/99003220927), attributed to `workspace-chooser > favorite tile metadata: counts refresh after the realm re-indexes, without blanking first`:

```
Global error: Uncaught TypeError: Failed to fetch
  at http://localhost:7357/assets/async-arrow-runtime-B2ZdpTWx.js, line 1479
```

That chunk carries ember-concurrency's task machinery: `async-arrow-runtime` pulls in `task-factory → task → task-instance → executor → ember-environment`, whose `reportUncaughtRejection` is the one place ember-concurrency puts an arbitrary task error into global scope — via `next(null, …)`, which is why it lands as a `window.onerror` with a file and line rather than an unhandled rejection. So the throw came out of a task instance nobody consumed, and the attributed test is just the one that happened to be running. Every test in the module renders the chooser, so any of their tiles' in-flight loads could be the one that rejected.

The shard died with it: it ran 4.5 minutes against ~9 for its siblings and left a 5.7 KB testem log against their 26–197 KB, so ~219 of its tests never ran. A throw out of the run loop leaves the browser producing no further results until testem's `browser_no_activity_timeout` ends the shard.

## Relation to the existing handling

The realm service attaches a catch to the background loads `info()` starts (the realm-identifying `HEAD` and the `_info` fetch), for exactly this failure signature. Those are plain promises; a task instance is a separate fire-and-forget path with its own global report, and the tile's constructor perform sits on that path. This is the complement, not a repeat.

Two components outside the chooser — `with-known-realms-loaded` and `with-loaded-realm` — perform `ensureRealmMeta` the same unguarded way. They are not on this render path, so they are left alone here; each already renders its own "Failed to load…" branch, and only the unconsumed task instance leaks.

## Diagnostics

A caught failure is logged with the realm, the error and its stack. `TypeError: Failed to fetch` names neither the request nor the caller on its own, and the stack is what separates this load from any other background fetch failing the same way. The message is distinct from the realm service's own `_info` warning, so the same global error recurring *without* it points the search at one of the other unconsumed task performs elsewhere in the app rather than at the tile.

There is deliberately no per-half breakdown: the realm resource's login task swallows its own failures, so the only await that can reject in either half is the realm's `_info` fetch — `login` reaches it through `subscribe()`, and `ensureRealmMeta` is that same memoized `fetchInfo`. A label would name which await was entered first, not which subsystem failed.

## Test

`workspace-chooser-test.gts` gains a nested module that stubs `realm.login` to reject for one workspace, opens the chooser, and asserts through `suspendGlobalErrorHook` that nothing was raised globally — and that the chooser still renders its tiles. It counts the rejections it injects and requires at least one, since an empty error capture is satisfied just as well by a stub that never ran.

## Verification

- `ember-tsc --noEmit`, ESLint, `ember-template-lint`, and Prettier pass on the change.
- The host acceptance suite needs the full service stack (Postgres, Synapse under Docker, realm/worker/prerender servers), so the new test's first run is in CI.
- The fix only converts an escaping rejection into a caught-and-logged one, so it cannot change any passing test's success path.
