### PR TITLE
Add NativeScript 9.1 offline messenger SQLite prototype

### DIFF
--- a/docs/nativescript-offline-messenger.md
+++ b/docs/nativescript-offline-messenger.md
@@ -1,0 +1,130 @@
+# NativeScript iOS / Mac messenger on the SQLite indexer path
+
+This document records whether a NativeScript iOS app (and a Mac app via Mac Catalyst) can reuse Boxel's existing **filesystem → indexer → SQLite** path, with a Matrix-style messenger and later sync that matches `boxel realm sync`.
+
+The working prototype lives in `prototypes/boxel-native/`. It is a proof of the *data plane*, not a replacement for the Ember host.
+
+## Verdict
+
+**Yes for the data plane. No for full card execution/render.**
+
+The pieces that already exist and can run on-device:
+
+| Surface | What exists today | What a native app can reuse |
+| --- | --- | --- |
+| Card storage | Realm files on disk (JSON:API instances + modules) | App Documents / shared container as the local realm directory |
+| Index | `boxel_index` schema; query engine is SQLite-first | Native SQLite (`@nativescript-community/sqlite`) with the same table shape |
+| Host SQLite adapter | `@sqlite.org/sqlite-wasm` in the browser host | Same SQL dialect; swap the adapter, keep the schema |
+| Sync | `packages/boxel-cli/src/lib/sync-logic.ts` — classify local/remote, conflict flags | Identical functions on-device; push/pull against realm-server when online |
+| Messenger | Host uses `matrix-js-sdk`; Element X uses `matrix-sdk-rust` | Native app uses **matrix-sdk-rust** (SQLite store + UniFFI). Host keeps JS. |
+
+The pieces that **do not** fit on a phone/Mac Catalyst process:
+
+- The production indexer walks files, then **renders** each card through the headless prerenderer (Chromium + built host app) to produce `search_doc`, HTML formats, and deps. See `docs/indexing.md`.
+- Card modules are Glimmer/Ember (`CardDef` in `.gts`). NativeScript UI cannot load those modules as native views without the host execution runtime.
+- `matrix-js-sdk` is the browser SDK. It is the wrong client on NativeScript (see Matrix client below).
+
+So the native app's indexer is a **lite indexer**: parse JSON:API files from the filesystem, write `pristine_doc` + a field-level `search_doc` into `boxel_index`, and skip prerender HTML. Search, open-as-JSON, attach-to-message, and sync all work. Isolated/embedded card *rendering* stays a host (or later Sandbox) concern.
+
+## Recommended native architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  NativeScript UI (iOS + Mac Catalyst)                       │
+│  Chats · Cards · Sync                                       │
+└────────────┬──────────────────────────┬─────────────────────┘
+             │                          │
+             ▼                          ▼
+┌────────────────────────┐   ┌───────────────────────────────┐
+│  Local realm directory │   │  boxel-index.sqlite           │
+│  (card JSON files)     │──▶│  lite indexer → boxel_index   │
+└────────────┬───────────┘   │  matrix.sqlite                │
+             │               │  matrix-sdk-rust (UniFFI)     │
+             │ lite indexer  └───────────────────────────────┘
+             ▼  when online
+┌────────────────────────────────────────────────────────────┐
+│  File sync: boxel realm sync (hashes, _mtimes, manifest)   │
+│  Message sync: matrix-sdk-rust sliding sync → Synapse      │
+└────────────────────────────────────────────────────────────┘
+```
+
+Three runtimes share one TypeScript core (`prototypes/boxel-native/core/`):
+
+1. **Node + `node:sqlite`** — this prototype's server (and unit tests). Proves the SQLite path without Xcode.
+2. **NativeScript iOS** — `@nativescript-community/sqlite` talking to the OS SQLite. Same SQL.
+3. **Mac** — not a separate NativeScript desktop target. Ship the iOS app through **Mac Catalyst** (`@nativescript/ios` already carries Catalyst build support). One binary family, one Documents-directory realm.
+
+## Why SQLite is the right on-device store
+
+The index query engine (`packages/runtime-common/index-query-engine.ts`) is designed so **SQLite is the floor**. Postgres mirrors SQLite's `json_tree` with `jsonb_tree`; the host already runs the same schema in-process via `packages/host/app/lib/sqlite-adapter.ts`. An iOS SQLite file is not a fork of the data model — it is the model the query engine already compiles to.
+
+A lite indexer writes the same `boxel_index` columns the host/schema file defines (`url`, `file_alias`, `type`, `realm_url`, `pristine_doc`, `search_doc`, `types`, `display_names`, `generation`, …). When the device later syncs files up, the *server* re-indexes through the prerenderer and replaces the lite `search_doc` with the full rendered one. The device does not need Chromium for that.
+
+## Matrix client: rust on device, JS in the host
+
+**NativeScript iOS / Mac Catalyst: `matrix-sdk-rust` (the UniFFI FFI, same stack as Element X). Do not ship `matrix-js-sdk` there.**
+
+The host, VS Code tools, and Playwright matrix tests stay on `matrix-js-sdk`. That is the browser/Node client this repo already patches and mocks. Two clients against one Synapse is the Matrix model (Element Web + Element X already do this). Card attachments stay `m.room.message` / `app.boxel.*` event JSON either SDK can send.
+
+Why rust on the device:
+
+| Constraint | `matrix-js-sdk` | `matrix-sdk-rust` |
+| --- | --- | --- |
+| On-device store | IndexedDB / memory. NativeScript has neither as a first-class store. | SQLite state + crypto store. Same disk model as `boxel_index`. |
+| Crypto | Rust crypto compiled to WASM (`matrix-sdk-crypto-wasm`). NativeScript V8 is `--jitless`; WASM Olm/vodozemac on that path is the slow, fragile option. | Native vodozemac via UniFFI. No WASM. |
+| Sync | JS `/sync` or sliding-sync helper; host already wraps this. | Sliding sync is native; built for resume-after-offline. |
+| NativeScript 9.1 fit | Runnable in theory now that 9.1 has `AbortController`, `TextEncoder`, `URL`, `fetch`-class globals, and a real event loop — still a browser SDK on a jitless embedder. | Call the iOS XCFramework from TypeScript. 9.1's pitch is that the platform SDK *is* the API; UniFFI-generated ObjC/Swift is that. Node-API is the fallback if a `napi` wrapper is easier than raw interop. |
+| Mac | Would need the same JS+WASM stack under Catalyst. | Same XCFramework slice Catalyst already uses; 9.1's Catalyst metadata generation is what makes those UIKit types show up. |
+
+Keep **two SQLite files** in the app container, not one mashed schema:
+
+- `boxel-index.sqlite` — lite indexer (`boxel_index`, realm file hashes, sync manifest)
+- `matrix.sqlite` — rust SDK store (rooms, timeline, crypto)
+
+A card attached to a chat is a Matrix event whose content points at a realm URL / file alias. File bytes move through `boxel realm sync`, not through Matrix, except when the host already uploads media to Matrix (local `FileDef` attach). The native messenger should follow that split.
+
+Do not take the Element Web hybrid (JS client + rust-crypto WASM). On NativeScript that is the worst of both: a JS sync loop and WASM crypto on jitless V8.
+
+The prototype's `rooms` / `messages` tables are a stand-in for `matrix.sqlite`, not a port of `matrix-js-sdk`.
+
+## Offline messenger + cards
+
+The host messenger is Matrix. A native offline-first cut uses matrix-sdk-rust's SQLite store for rooms and timeline. The prototype fakes that with `rooms` / `messages` tables until the UniFFI client is wired.
+
+- optional `card_url` on a message (a `boxel_index.url` / file alias)
+- outbound `sync_state`: `local` → `queued` → `synced` (rust SDK local-echo fills this role later)
+
+Cards are not a second database. Opening a card is: read the realm file, show `pristine_doc` (and later, when online, the prerendered HTML from the server if you want host-fidelity). Attaching a card to a chat is storing that URL. Creating a card is writing a JSON:API file into the realm directory and running the lite indexer on that path — the same "filesystem to indexer" loop the realm server uses, without the render visit.
+
+When the device is online, two independent syncs fire:
+
+1. **Files** — `boxel realm sync` semantics (hash + mtime + manifest, `--prefer-local` / `--prefer-remote` / `--prefer-newest`).
+2. **Messages** — matrix-sdk-rust sliding sync + send, with `matrix.sqlite` as the cache.
+
+They must not be one job. File sync is realm-server; message sync is Synapse. A card attachment is just metadata that becomes meaningful after file sync has uploaded the instance.
+
+## NativeScript vs wrapping the host in a web view
+
+Wrapping `packages/host` in a WKWebView (Capacitor, Cordova, or NativeScript WebView) would give full card render, but it is not the SQLite/filesystem path this design is about, and it is a poor offline story (the host indexer still expects a prerenderer). NativeScript native UI + SQLite + a realm directory is the honest mapping of "use the sqlite path."
+
+Mac: NativeScript does not ship a first-class AppKit target. Catalyst is the supported way to run the same iOS UI on macOS. A later Electron/Tauri shell could reuse the same `core/` against `better-sqlite3` if Catalyst UX is not enough.
+
+## What the prototype proves
+
+`prototypes/boxel-native/` runs a single process that:
+
+- keeps a virtual realm filesystem of JSON:API cards
+- indexes those files into an in-memory SQLite `boxel_index` (lite `search_doc`)
+- searches/opens cards from that index
+- hosts a messenger whose messages can attach indexed cards
+- queues file changes while "offline" and applies `sync-logic` against a simulated remote when "online"
+
+The web page is an **iPhone chrome** around that process so the flow is visible without Xcode. On a Mac, `ns run ios` against `nativescript-app/` is the same core behind native widgets.
+
+## Out of scope for a first native cut
+
+- Loading `.gts` card modules or running Glimmer in NativeScript
+- Prerender HTML / computed-field evaluation that requires the host
+- Real Matrix login (the prototype uses a local event log standing in for matrix-sdk-rust)
+- Real realm-server HTTPS (the prototype uses an in-process remote map; wiring `RealmSyncer` is a follow-up)
+- Android (same core would work; not exercised here)

--- a/docs/nativescript-offline-messenger.md
+++ b/docs/nativescript-offline-messenger.md
@@ -24,7 +24,7 @@ The pieces that **do not** fit on a phone/Mac Catalyst process:
 - Card modules are Glimmer/Ember (`CardDef` in `.gts`). NativeScript UI cannot load those modules as native views without the host execution runtime.
 - `matrix-js-sdk` is the browser SDK. It is the wrong client on NativeScript (see Matrix client below).
 
-So the native app's indexer is a **lite indexer**: parse JSON:API files from the filesystem, write `pristine_doc` + a field-level `search_doc` into `boxel_index`, and skip prerender HTML. Search, open-as-JSON, attach-to-message, and sync all work. Isolated/embedded card *rendering* stays a host (or later Sandbox) concern.
+So the native app's indexer is a **lite indexer**: parse JSON:API files from the filesystem, write `pristine_doc` + a field-level `search_doc` into `boxel_index`, and skip prerender HTML. Search, open-as-JSON, attach-to-message, and sync all work. Isolated/embedded card *rendering* stays a host (or later Sandbox) concern. Search is `json_extract` on `boxel_index.search_doc` (including computed keys stamped at index time), not a scan of the JSON files.
 
 ## Recommended native architecture
 

--- a/prototypes/boxel-native/README.md
+++ b/prototypes/boxel-native/README.md
@@ -10,7 +10,9 @@ From this directory:
 node web-simulator/server.mjs
 ```
 
-Computed fields (`_title`, `fullName`, `initials`, `handle`) are evaluated at index time and stored on `boxel_index.search_doc`. Search is `json_extract` against that column only — the JSON files on disk are not queried. The Cards tab shows index hits vs a contrast JSON-file scan so a query like `@maple.grove` or `MG` is visibly an index hit and a source miss.
+Then open http://127.0.0.1:4173/
+
+Computed fields (`_title`, `fullName`, `initials`, `handle`) are evaluated at index time and stored on `boxel_index.search_doc`. Search is `json_extract` against that column only — the JSON files on disk are not queried. On the Cards tab try `MG` or `@maple.grove`: index hits, JSON-file scan misses.
 
 ```bash
 node --test tests/core.test.js

--- a/prototypes/boxel-native/README.md
+++ b/prototypes/boxel-native/README.md
@@ -10,9 +10,7 @@ From this directory:
 node web-simulator/server.mjs
 ```
 
-Then open http://127.0.0.1:4173/
-
-The page is an iPhone chrome around `node:sqlite`: realm JSON files on a virtual disk, lite `boxel_index`, queued chats, then `boxel realm sync --prefer-newest` classify/push/pull against a simulated remote.
+Computed fields (`_title`, `fullName`, `initials`, `handle`) are evaluated at index time and stored on `boxel_index.search_doc`. Search is `json_extract` against that column only — the JSON files on disk are not queried. The Cards tab shows index hits vs a contrast JSON-file scan so a query like `@maple.grove` or `MG` is visibly an index hit and a source miss.
 
 ```bash
 node --test tests/core.test.js

--- a/prototypes/boxel-native/README.md
+++ b/prototypes/boxel-native/README.md
@@ -1,0 +1,23 @@
+# Boxel native prototype
+
+Offline messenger + lite SQLite indexer. NativeScript 9.1 iOS / Mac Catalyst is the target; this folder runs the same data plane locally without Xcode.
+
+## Run locally
+
+From this directory:
+
+```bash
+node web-simulator/server.mjs
+```
+
+Then open http://127.0.0.1:4173/
+
+The page is an iPhone chrome around `node:sqlite`: realm JSON files on a virtual disk, lite `boxel_index`, queued chats, then `boxel realm sync --prefer-newest` classify/push/pull against a simulated remote.
+
+```bash
+node --test tests/core.test.js
+```
+
+## Matrix
+
+On a real device this messenger should be **matrix-sdk-rust** (UniFFI, SQLite store), not `matrix-js-sdk`. The `rooms` / `messages` tables here stand in for that store. See `docs/nativescript-offline-messenger.md`.

--- a/prototypes/boxel-native/core/computed-fields.js
+++ b/prototypes/boxel-native/core/computed-fields.js
@@ -1,0 +1,61 @@
+// Lite stand-in for CardDef computeVia. The JSON:API instance on disk holds
+// only stored attributes. These values are written into boxel_index.search_doc
+// at index time — the same split the host indexer uses for cardTitle / _title.
+// Search reads search_doc through SQLite json_extract and never greps files.
+
+export const COMPUTED_KEYS = [
+  '_title',
+  '_cardType',
+  'fullName',
+  'initials',
+  'sortName',
+  'handle',
+  'kindLabel',
+];
+
+export function computeSearchDoc({ attributes = {}, adoptsFrom = {}, fileAlias }) {
+  const typeName = adoptsFrom.name || 'Card';
+  const first = String(attributes.firstName ?? '').trim();
+  const last = String(attributes.lastName ?? '').trim();
+  const storedTitle = String(attributes.title ?? '').trim();
+  const displayTitle =
+    [first, last].filter(Boolean).join(' ') || storedTitle || fileAlias;
+
+  const fullName = last && first ? `${last}, ${first}` : displayTitle;
+  const initials = [first, last]
+    .map((part) => part.charAt(0))
+    .join('')
+    .toUpperCase();
+  const sortName = fullName.toUpperCase();
+  const handleParts = [first, last].filter(Boolean).map((p) => p.toLowerCase());
+  const handle = handleParts.length ? `@${handleParts.join('.')}` : `@${fileAlias}`;
+  const kindLabel =
+    typeName === 'Person'
+      ? 'person'
+      : typeName === 'Pet'
+        ? 'pet'
+        : typeName === 'Note'
+          ? 'note'
+          : 'card';
+
+  return {
+    ...attributes,
+    title: displayTitle,
+    _cardTitle: displayTitle,
+    _title: displayTitle,
+    _cardType: typeName,
+    fullName,
+    initials,
+    sortName,
+    handle,
+    kindLabel,
+  };
+}
+
+export function computedOnly(searchDoc) {
+  const out = {};
+  for (const key of COMPUTED_KEYS) {
+    out[key] = searchDoc[key];
+  }
+  return out;
+}

--- a/prototypes/boxel-native/core/lite-indexer.js
+++ b/prototypes/boxel-native/core/lite-indexer.js
@@ -1,0 +1,282 @@
+export const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS boxel_index (
+  url TEXT NOT NULL,
+  file_alias TEXT NOT NULL,
+  type TEXT NOT NULL,
+  generation INTEGER NOT NULL,
+  realm_url TEXT NOT NULL,
+  pristine_doc TEXT,
+  search_doc TEXT,
+  error_doc TEXT,
+  deps TEXT DEFAULT '[]',
+  types TEXT,
+  indexed_at INTEGER,
+  is_deleted INTEGER DEFAULT 0,
+  last_modified INTEGER,
+  display_names TEXT,
+  resource_created_at INTEGER,
+  icon_html TEXT,
+  has_error INTEGER DEFAULT 0 NOT NULL,
+  last_known_good_deps TEXT,
+  diagnostics TEXT,
+  PRIMARY KEY (url, realm_url, type)
+);
+
+CREATE TABLE IF NOT EXISTS rooms (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  subtitle TEXT,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id TEXT PRIMARY KEY,
+  room_id TEXT NOT NULL,
+  sender TEXT NOT NULL,
+  body TEXT NOT NULL,
+  card_url TEXT,
+  created_at INTEGER NOT NULL,
+  sync_state TEXT NOT NULL DEFAULT 'local',
+  FOREIGN KEY (room_id) REFERENCES rooms(id)
+);
+
+CREATE TABLE IF NOT EXISTS sync_manifest (
+  realm_url TEXT PRIMARY KEY,
+  files_json TEXT NOT NULL,
+  remote_mtimes_json TEXT NOT NULL
+);
+`;
+
+const REALM_URL = 'https://local.boxel/preview/';
+
+function cardTitle(attributes, fileAlias) {
+  const first = attributes.firstName || attributes.title || '';
+  const last = attributes.lastName || '';
+  const name = `${first} ${last}`.trim();
+  if (name) return name;
+  return fileAlias.replace(/\.json$/, '');
+}
+
+function fileAliasFromPath(relativePath) {
+  return relativePath.replace(/\.json$/, '');
+}
+
+function instanceUrl(relativePath) {
+  return new URL(relativePath.replace(/\.json$/, ''), REALM_URL).href;
+}
+
+export class LiteIndexer {
+  constructor(db, realmUrl = REALM_URL) {
+    this.db = db;
+    this.realmUrl = realmUrl;
+    this.generation = 1;
+  }
+
+  /**
+   * Walk a realm filesystem and upsert JSON:API card instances into
+   * boxel_index. Modules and other non-card files are stored as type='file'
+   * rows so the index still knows they exist.
+   */
+  indexFilesystem(fs) {
+    this.generation += 1;
+    const seen = new Set();
+
+    for (const relativePath of fs.list()) {
+      if (relativePath.startsWith('.') || relativePath.includes('/.')) {
+        continue;
+      }
+      const stat = fs.stat(relativePath);
+      const content = fs.read(relativePath);
+      seen.add(relativePath);
+
+      if (relativePath.endsWith('.json')) {
+        this.#indexCard(relativePath, content, stat);
+      } else {
+        this.#indexFile(relativePath, content, stat);
+      }
+    }
+
+    const existing = this.db.all(
+      `SELECT file_alias FROM boxel_index WHERE realm_url = ? AND is_deleted = 0`,
+      [this.realmUrl],
+    );
+    for (const row of existing) {
+      const asJson = `${row.file_alias}.json`;
+      const asFile = row.file_alias;
+      if (!seen.has(asJson) && !seen.has(asFile) && !seen.has(row.file_alias)) {
+        this.db.run(
+          `UPDATE boxel_index SET is_deleted = 1, indexed_at = ? WHERE file_alias = ? AND realm_url = ?`,
+          [Date.now(), row.file_alias, this.realmUrl],
+        );
+      }
+    }
+
+    return this.stats();
+  }
+
+  #indexCard(relativePath, content, stat) {
+    let parsed;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      this.#writeError(relativePath, 'invalid JSON', stat);
+      return;
+    }
+    const resource = parsed?.data;
+    if (!resource || resource.type !== 'card') {
+      this.#indexFile(relativePath, content, stat);
+      return;
+    }
+
+    const attributes = resource.attributes ?? {};
+    const adoptsFrom = resource.meta?.adoptsFrom ?? { module: '', name: '' };
+    const alias = fileAliasFromPath(relativePath);
+    const url = resource.id || instanceUrl(relativePath);
+    const title = cardTitle(attributes, alias);
+    const searchDoc = {
+      title,
+      _cardTitle: title,
+      ...attributes,
+    };
+    const types = [
+      `${adoptsFrom.module ?? ''}/${adoptsFrom.name ?? 'CardDef'}`,
+    ];
+
+    this.db.run(
+      `INSERT INTO boxel_index (
+         url, file_alias, type, generation, realm_url,
+         pristine_doc, search_doc, deps, types, indexed_at,
+         is_deleted, last_modified, display_names, resource_created_at,
+         has_error
+       ) VALUES (?, ?, 'instance', ?, ?, ?, ?, '[]', ?, ?, 0, ?, ?, ?, 0)
+       ON CONFLICT(url, realm_url, type) DO UPDATE SET
+         file_alias = excluded.file_alias,
+         generation = excluded.generation,
+         pristine_doc = excluded.pristine_doc,
+         search_doc = excluded.search_doc,
+         types = excluded.types,
+         indexed_at = excluded.indexed_at,
+         is_deleted = 0,
+         last_modified = excluded.last_modified,
+         display_names = excluded.display_names,
+         has_error = 0,
+         error_doc = NULL`,
+      [
+        url,
+        alias,
+        this.generation,
+        this.realmUrl,
+        JSON.stringify(resource),
+        JSON.stringify(searchDoc),
+        JSON.stringify(types),
+        Date.now(),
+        stat?.mtimeMs ?? Date.now(),
+        JSON.stringify([title]),
+        stat?.mtimeMs ?? Date.now(),
+      ],
+    );
+  }
+
+  #indexFile(relativePath, _content, stat) {
+    const url = new URL(relativePath, this.realmUrl).href;
+    this.db.run(
+      `INSERT INTO boxel_index (
+         url, file_alias, type, generation, realm_url,
+         indexed_at, is_deleted, last_modified, has_error
+       ) VALUES (?, ?, 'file', ?, ?, ?, 0, ?, 0)
+       ON CONFLICT(url, realm_url, type) DO UPDATE SET
+         generation = excluded.generation,
+         indexed_at = excluded.indexed_at,
+         is_deleted = 0,
+         last_modified = excluded.last_modified`,
+      [
+        url,
+        relativePath,
+        this.generation,
+        this.realmUrl,
+        Date.now(),
+        stat?.mtimeMs ?? Date.now(),
+      ],
+    );
+  }
+
+  #writeError(relativePath, message, stat) {
+    const url = new URL(relativePath, this.realmUrl).href;
+    this.db.run(
+      `INSERT INTO boxel_index (
+         url, file_alias, type, generation, realm_url,
+         error_doc, indexed_at, is_deleted, last_modified, has_error
+       ) VALUES (?, ?, 'file', ?, ?, ?, ?, 0, ?, 1)
+       ON CONFLICT(url, realm_url, type) DO UPDATE SET
+         error_doc = excluded.error_doc,
+         has_error = 1,
+         indexed_at = excluded.indexed_at`,
+      [
+        url,
+        relativePath,
+        this.generation,
+        this.realmUrl,
+        JSON.stringify({ message }),
+        Date.now(),
+        stat?.mtimeMs ?? Date.now(),
+      ],
+    );
+  }
+
+  search(queryText = '') {
+    const q = queryText.trim();
+    if (!q) {
+      return this.db.all(
+        `SELECT url, file_alias, types, search_doc, pristine_doc, indexed_at
+         FROM boxel_index
+         WHERE type = 'instance' AND is_deleted = 0 AND realm_url = ?
+         ORDER BY json_extract(search_doc, '$.title') COLLATE NOCASE`,
+        [this.realmUrl],
+      );
+    }
+    const like = `%${q}%`;
+    return this.db.all(
+      `SELECT url, file_alias, types, search_doc, pristine_doc, indexed_at
+       FROM boxel_index
+       WHERE type = 'instance'
+         AND is_deleted = 0
+         AND realm_url = ?
+         AND (
+           file_alias LIKE ? COLLATE NOCASE
+           OR json_extract(search_doc, '$.title') LIKE ? COLLATE NOCASE
+           OR json_extract(search_doc, '$.firstName') LIKE ? COLLATE NOCASE
+           OR json_extract(search_doc, '$.lastName') LIKE ? COLLATE NOCASE
+         )
+       ORDER BY json_extract(search_doc, '$.title') COLLATE NOCASE`,
+      [this.realmUrl, like, like, like, like],
+    );
+  }
+
+  getByAlias(alias) {
+    return this.db.get(
+      `SELECT url, file_alias, types, search_doc, pristine_doc, indexed_at
+       FROM boxel_index
+       WHERE file_alias = ? AND realm_url = ? AND is_deleted = 0
+       LIMIT 1`,
+      [alias, this.realmUrl],
+    );
+  }
+
+  stats() {
+    const instances = this.db.get(
+      `SELECT COUNT(*) AS n FROM boxel_index WHERE type = 'instance' AND is_deleted = 0 AND realm_url = ?`,
+      [this.realmUrl],
+    );
+    const files = this.db.get(
+      `SELECT COUNT(*) AS n FROM boxel_index WHERE type = 'file' AND is_deleted = 0 AND realm_url = ?`,
+      [this.realmUrl],
+    );
+    return {
+      instances: Number(instances?.n ?? 0),
+      files: Number(files?.n ?? 0),
+      generation: this.generation,
+    };
+  }
+}
+
+export { REALM_URL };

--- a/prototypes/boxel-native/core/lite-indexer.js
+++ b/prototypes/boxel-native/core/lite-indexer.js
@@ -1,3 +1,5 @@
+import { computeSearchDoc, COMPUTED_KEYS } from './computed-fields.js';
+
 export const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS boxel_index (
   url TEXT NOT NULL,
@@ -49,13 +51,19 @@ CREATE TABLE IF NOT EXISTS sync_manifest (
 
 const REALM_URL = 'https://local.boxel/preview/';
 
-function cardTitle(attributes, fileAlias) {
-  const first = attributes.firstName || attributes.title || '';
-  const last = attributes.lastName || '';
-  const name = `${first} ${last}`.trim();
-  if (name) return name;
-  return fileAlias.replace(/\.json$/, '');
-}
+const SEARCH_DOC_PATHS = [
+  '$._title',
+  '$.fullName',
+  '$.initials',
+  '$.sortName',
+  '$.handle',
+  '$.kindLabel',
+  '$._cardType',
+  '$.firstName',
+  '$.lastName',
+  '$.title',
+  '$.body',
+];
 
 function fileAliasFromPath(relativePath) {
   return relativePath.replace(/\.json$/, '');
@@ -132,12 +140,12 @@ export class LiteIndexer {
     const adoptsFrom = resource.meta?.adoptsFrom ?? { module: '', name: '' };
     const alias = fileAliasFromPath(relativePath);
     const url = resource.id || instanceUrl(relativePath);
-    const title = cardTitle(attributes, alias);
-    const searchDoc = {
-      title,
-      _cardTitle: title,
-      ...attributes,
-    };
+    const searchDoc = computeSearchDoc({
+      attributes,
+      adoptsFrom,
+      fileAlias: alias,
+    });
+    const title = searchDoc._title;
     const types = [
       `${adoptsFrom.module ?? ''}/${adoptsFrom.name ?? 'CardDef'}`,
     ];
@@ -223,33 +231,66 @@ export class LiteIndexer {
     );
   }
 
-  search(queryText = '') {
+  searchSql(queryText = '') {
     const q = queryText.trim();
     if (!q) {
-      return this.db.all(
-        `SELECT url, file_alias, types, search_doc, pristine_doc, indexed_at
+      return {
+        sql: `SELECT url, file_alias, types, search_doc, pristine_doc, indexed_at
          FROM boxel_index
          WHERE type = 'instance' AND is_deleted = 0 AND realm_url = ?
-         ORDER BY json_extract(search_doc, '$.title') COLLATE NOCASE`,
-        [this.realmUrl],
-      );
+         ORDER BY json_extract(search_doc, '$._title') COLLATE NOCASE`,
+        bind: [this.realmUrl],
+      };
     }
-    const like = `%${q}%`;
-    return this.db.all(
-      `SELECT url, file_alias, types, search_doc, pristine_doc, indexed_at
+    const extracts = SEARCH_DOC_PATHS.map(
+      (path) => `json_extract(search_doc, '${path}') LIKE ? COLLATE NOCASE`,
+    ).join('\n           OR ');
+    return {
+      sql: `SELECT url, file_alias, types, search_doc, pristine_doc, indexed_at
        FROM boxel_index
        WHERE type = 'instance'
          AND is_deleted = 0
          AND realm_url = ?
          AND (
-           file_alias LIKE ? COLLATE NOCASE
-           OR json_extract(search_doc, '$.title') LIKE ? COLLATE NOCASE
-           OR json_extract(search_doc, '$.firstName') LIKE ? COLLATE NOCASE
-           OR json_extract(search_doc, '$.lastName') LIKE ? COLLATE NOCASE
+           ${extracts}
          )
-       ORDER BY json_extract(search_doc, '$.title') COLLATE NOCASE`,
-      [this.realmUrl, like, like, like, like],
-    );
+       ORDER BY json_extract(search_doc, '$._title') COLLATE NOCASE`,
+      bind: [this.realmUrl, ...SEARCH_DOC_PATHS.map(() => `%${q}%`)],
+    };
+  }
+
+  search(queryText = '') {
+    const { sql, bind } = this.searchSql(queryText);
+    return this.db.all(sql, bind);
+  }
+
+  /**
+   * Index query plus a filesystem scan used only as a contrast: the scan is
+   * not the search path. Computed keys live in search_doc and are absent
+   * from the JSON:API files.
+   */
+  searchIndex(queryText, fs) {
+    const q = queryText.trim();
+    const { sql, bind } = this.searchSql(q);
+    const rows = this.db.all(sql, bind);
+    const jsonSourceHits = [];
+    if (q && fs) {
+      const needle = q.toLowerCase();
+      for (const path of fs.list()) {
+        if (!path.endsWith('.json')) continue;
+        const content = fs.read(path) ?? '';
+        if (content.toLowerCase().includes(needle)) {
+          jsonSourceHits.push(path);
+        }
+      }
+    }
+    return {
+      sql: sql.replace(/\s+/g, ' ').trim(),
+      query: q,
+      computedKeys: COMPUTED_KEYS,
+      jsonSourceHits,
+      rows,
+    };
   }
 
   getByAlias(alias) {

--- a/prototypes/boxel-native/core/messenger.js
+++ b/prototypes/boxel-native/core/messenger.js
@@ -1,0 +1,72 @@
+// Stand-in for matrix-sdk-rust's SQLite timeline store (Element X), not
+// matrix-js-sdk. The host keeps JS; the NativeScript app should bind the
+// UniFFI MatrixRustSDK and keep this schema only until that FFI is wired.
+export class Messenger {
+  constructor(db) {
+    this.db = db;
+  }
+
+  listRooms() {
+    return this.db
+      .all(
+        `SELECT r.id, r.title, r.subtitle, r.updated_at,
+                (SELECT COUNT(*) FROM messages m WHERE m.room_id = r.id) AS message_count,
+                (SELECT COUNT(*) FROM messages m WHERE m.room_id = r.id AND m.sync_state != 'synced') AS unsynced_count
+         FROM rooms r
+         ORDER BY r.updated_at DESC`,
+      )
+      .map((row) => ({
+        ...row,
+        message_count: Number(row.message_count),
+        unsynced_count: Number(row.unsynced_count),
+      }));
+  }
+
+  getRoom(id) {
+    return this.db.get(`SELECT * FROM rooms WHERE id = ?`, [id]);
+  }
+
+  listMessages(roomId) {
+    return this.db.all(
+      `SELECT * FROM messages WHERE room_id = ? ORDER BY created_at ASC`,
+      [roomId],
+    );
+  }
+
+  send({ roomId, sender, body, cardUrl = null, syncState = 'queued' }) {
+    const id = `m-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const createdAt = Date.now();
+    this.db.run(
+      `INSERT INTO messages (id, room_id, sender, body, card_url, created_at, sync_state)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [id, roomId, sender, body, cardUrl, createdAt, syncState],
+    );
+    this.db.run(`UPDATE rooms SET updated_at = ?, subtitle = ? WHERE id = ?`, [
+      createdAt,
+      body.slice(0, 80),
+      roomId,
+    ]);
+    return this.db.get(`SELECT * FROM messages WHERE id = ?`, [id]);
+  }
+
+  markSynced(messageId) {
+    this.db.run(`UPDATE messages SET sync_state = 'synced' WHERE id = ?`, [
+      messageId,
+    ]);
+  }
+
+  queuedMessages() {
+    return this.db.all(
+      `SELECT * FROM messages WHERE sync_state = 'queued' ORDER BY created_at ASC`,
+    );
+  }
+
+  createRoom({ id, title, subtitle = '' }) {
+    this.db.run(
+      `INSERT INTO rooms (id, title, subtitle, updated_at) VALUES (?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET title = excluded.title`,
+      [id, title, subtitle, Date.now()],
+    );
+    return this.getRoom(id);
+  }
+}

--- a/prototypes/boxel-native/core/realm-fs.js
+++ b/prototypes/boxel-native/core/realm-fs.js
@@ -1,0 +1,95 @@
+import { createHash } from 'node:crypto';
+
+export function md5(content) {
+  return createHash('md5').update(content).digest('hex');
+}
+
+export class RealmFs {
+  constructor() {
+    /** @type {Map<string, { content: string, mtimeMs: number }>} */
+    this.files = new Map();
+  }
+
+  list() {
+    return [...this.files.keys()].sort();
+  }
+
+  read(relativePath) {
+    const entry = this.files.get(relativePath);
+    if (!entry) return null;
+    return entry.content;
+  }
+
+  stat(relativePath) {
+    const entry = this.files.get(relativePath);
+    if (!entry) return null;
+    return { mtimeMs: entry.mtimeMs, hash: md5(entry.content) };
+  }
+
+  write(relativePath, content, mtimeMs = Date.now()) {
+    this.files.set(relativePath, { content, mtimeMs });
+  }
+
+  delete(relativePath) {
+    this.files.delete(relativePath);
+  }
+
+  hashes() {
+    const out = new Map();
+    for (const [path, entry] of this.files) {
+      out.set(path, md5(entry.content));
+    }
+    return out;
+  }
+
+  mtimes() {
+    const out = new Map();
+    for (const [path, entry] of this.files) {
+      out.set(path, entry.mtimeMs);
+    }
+    return out;
+  }
+
+  snapshot() {
+    const out = {};
+    for (const [path, entry] of this.files) {
+      out[path] = { content: entry.content, mtimeMs: entry.mtimeMs };
+    }
+    return out;
+  }
+}
+
+export class SimulatedRemote {
+  constructor() {
+    /** @type {Map<string, { content: string, mtimeSec: number }>} */
+    this.files = new Map();
+  }
+
+  mtimes() {
+    const out = new Map();
+    for (const [path, entry] of this.files) {
+      out.set(path, entry.mtimeSec);
+    }
+    return out;
+  }
+
+  hashes() {
+    const out = new Map();
+    for (const [path, entry] of this.files) {
+      out.set(path, md5(entry.content));
+    }
+    return out;
+  }
+
+  read(relativePath) {
+    return this.files.get(relativePath)?.content ?? null;
+  }
+
+  write(relativePath, content, mtimeSec = Math.floor(Date.now() / 1000)) {
+    this.files.set(relativePath, { content, mtimeSec });
+  }
+
+  delete(relativePath) {
+    this.files.delete(relativePath);
+  }
+}

--- a/prototypes/boxel-native/core/runtime.js
+++ b/prototypes/boxel-native/core/runtime.js
@@ -1,0 +1,324 @@
+import { LiteIndexer, REALM_URL } from './lite-indexer.js';
+import { RealmFs, SimulatedRemote, md5 } from './realm-fs.js';
+import { Messenger } from './messenger.js';
+import { planSync } from './sync-logic.js';
+
+export { REALM_URL };
+
+const MANIFEST_PATH = '.boxel-sync.json';
+
+export class BoxelNativeRuntime {
+  constructor(db) {
+    this.db = db;
+    this.fs = new RealmFs();
+    this.remote = new SimulatedRemote();
+    this.indexer = new LiteIndexer(db);
+    this.messenger = new Messenger(db);
+    this.online = false;
+    this.lastPlan = [];
+    this.lastSyncLog = [];
+  }
+
+  bootstrap(seed) {
+    for (const [path, content] of Object.entries(seed.localFiles)) {
+      this.fs.write(path, content, seed.localMtimeMs ?? Date.now() - 60_000);
+    }
+    for (const [path, content] of Object.entries(seed.remoteFiles)) {
+      this.remote.write(
+        path,
+        content,
+        seed.remoteMtimeSec ?? Math.floor(Date.now() / 1000),
+      );
+    }
+    if (seed.manifest) {
+      this.#saveManifest(seed.manifest);
+    }
+    this.reindex();
+    for (const room of seed.rooms ?? []) {
+      this.messenger.createRoom(room);
+    }
+    for (const msg of seed.messages ?? []) {
+      const card = msg.cardAlias
+        ? this.indexer.getByAlias(msg.cardAlias)
+        : null;
+      this.messenger.send({
+        roomId: msg.roomId,
+        sender: msg.sender,
+        body: msg.body,
+        cardUrl: card?.url ?? msg.cardUrl ?? null,
+        syncState: msg.syncState ?? 'synced',
+      });
+    }
+    this.lastPlan = this.previewSync('newest');
+    return this.snapshot();
+  }
+
+  reindex() {
+    return this.indexer.indexFilesystem(this.fs);
+  }
+
+  snapshot() {
+    return {
+      online: this.online,
+      realmUrl: REALM_URL,
+      index: this.indexer.stats(),
+      files: this.fs
+        .list()
+        .filter((path) => !path.startsWith('.'))
+        .map((path) => {
+          const stat = this.fs.stat(path);
+          return { path, hash: stat.hash, mtimeMs: stat.mtimeMs };
+        }),
+      cards: this.indexer.search().map(decorateCard),
+      rooms: this.messenger.listRooms(),
+      queuedMessages: this.messenger.queuedMessages().length,
+      sync: {
+        plan: this.lastPlan,
+        log: this.lastSyncLog,
+        summary: summarizePlan(this.lastPlan),
+      },
+    };
+  }
+
+  searchCards(q) {
+    return this.indexer.search(q).map(decorateCard);
+  }
+
+  getCard(alias) {
+    const row = this.indexer.getByAlias(alias);
+    return row ? decorateCard(row) : null;
+  }
+
+  createPersonCard({ firstName, lastName, fileStem }) {
+    const stem =
+      fileStem ||
+      `${firstName}-${lastName}`
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+    const relativePath = `${stem}.json`;
+    const resource = {
+      type: 'card',
+      attributes: { firstName, lastName },
+      meta: { adoptsFrom: { module: './person.gts', name: 'Person' } },
+    };
+    const content = JSON.stringify({ data: resource }, null, 2);
+    this.fs.write(relativePath, content);
+    this.reindex();
+    this.lastPlan = this.previewSync('newest');
+    return this.getCard(stem);
+  }
+
+  listMessages(roomId) {
+    return this.messenger.listMessages(roomId).map((row) => ({
+      ...row,
+      card: row.card_url
+        ? this.indexer.getByAlias(aliasFromUrl(row.card_url))
+        : null,
+    }));
+  }
+
+  sendMessage({ roomId, body, cardAlias, sender = 'you' }) {
+    const card = cardAlias ? this.indexer.getByAlias(cardAlias) : null;
+    const msg = this.messenger.send({
+      roomId,
+      sender,
+      body,
+      cardUrl: card?.url ?? null,
+      syncState: this.online ? 'synced' : 'queued',
+    });
+    return {
+      ...msg,
+      card: card ? decorateCard(card) : null,
+    };
+  }
+
+  setOnline(online) {
+    this.online = Boolean(online);
+    if (this.online) {
+      for (const queued of this.messenger.queuedMessages()) {
+        this.messenger.markSynced(queued.id);
+      }
+    }
+    this.lastPlan = this.previewSync('newest');
+    return this.snapshot();
+  }
+
+  #syncLocalHashes() {
+    return new Map(
+      [...this.fs.hashes()].filter(([path]) => !path.startsWith('.')),
+    );
+  }
+
+  #syncLocalMtimes() {
+    return new Map(
+      [...this.fs.mtimes()].filter(([path]) => !path.startsWith('.')),
+    );
+  }
+
+  previewSync(prefer = 'newest') {
+    const manifest = this.#loadManifest();
+    return planSync({
+      localHashes: this.#syncLocalHashes(),
+      localMtimes: this.#syncLocalMtimes(),
+      remoteMtimes: this.remote.mtimes(),
+      manifest,
+      prefer,
+    });
+  }
+
+  sync({ prefer = 'newest', deleteSync = false } = {}) {
+    if (!this.online) {
+      throw new Error(
+        'Device is offline. File sync waits until the device is online, the same way `boxel realm sync` needs the realm server.',
+      );
+    }
+    const manifest = this.#loadManifest() ?? {
+      realmUrl: REALM_URL,
+      files: {},
+      remoteMtimes: {},
+    };
+    const plan = planSync({
+      localHashes: this.#syncLocalHashes(),
+      localMtimes: this.#syncLocalMtimes(),
+      remoteMtimes: this.remote.mtimes(),
+      manifest,
+      prefer,
+      deleteSync,
+    });
+    const log = [];
+    const nextFiles = { ...manifest.files };
+    const nextRemoteMtimes = { ...manifest.remoteMtimes };
+
+    for (const item of plan) {
+      const { relativePath, action } = item;
+      if (action === 'noop') continue;
+      if (action === 'conflict') {
+        log.push({ relativePath, action, detail: 'skipped conflict' });
+        continue;
+      }
+      if (action === 'push') {
+        const content = this.fs.read(relativePath);
+        this.remote.write(relativePath, content);
+        nextFiles[relativePath] = md5(content);
+        nextRemoteMtimes[relativePath] =
+          this.remote.files.get(relativePath).mtimeSec;
+        log.push({ relativePath, action, detail: 'uploaded to remote realm' });
+      } else if (action === 'pull') {
+        const content = this.remote.read(relativePath);
+        const mtimeMs =
+          (this.remote.files.get(relativePath)?.mtimeSec ?? 0) * 1000;
+        this.fs.write(relativePath, content, mtimeMs);
+        nextFiles[relativePath] = md5(content);
+        nextRemoteMtimes[relativePath] =
+          this.remote.files.get(relativePath).mtimeSec;
+        log.push({ relativePath, action, detail: 'downloaded into local FS' });
+      } else if (action === 'push-delete') {
+        this.remote.delete(relativePath);
+        delete nextFiles[relativePath];
+        delete nextRemoteMtimes[relativePath];
+        log.push({ relativePath, action, detail: 'deleted on remote' });
+      } else if (action === 'pull-delete') {
+        this.fs.delete(relativePath);
+        delete nextFiles[relativePath];
+        delete nextRemoteMtimes[relativePath];
+        log.push({ relativePath, action, detail: 'deleted locally' });
+      }
+    }
+
+    this.#saveManifest({
+      realmUrl: REALM_URL,
+      files: nextFiles,
+      remoteMtimes: nextRemoteMtimes,
+    });
+    this.reindex();
+    this.lastPlan = this.previewSync(prefer);
+    this.lastSyncLog = log;
+    return { plan, log, snapshot: this.snapshot() };
+  }
+
+  #loadManifest() {
+    const raw = this.fs.read(MANIFEST_PATH);
+    if (!raw) {
+      const row = this.db.get(
+        `SELECT files_json, remote_mtimes_json, realm_url FROM sync_manifest WHERE realm_url = ?`,
+        [REALM_URL],
+      );
+      if (!row) return null;
+      return {
+        realmUrl: row.realm_url,
+        files: JSON.parse(row.files_json),
+        remoteMtimes: JSON.parse(row.remote_mtimes_json),
+      };
+    }
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  #saveManifest(manifest) {
+    this.fs.write(MANIFEST_PATH, JSON.stringify(manifest, null, 2));
+    this.db.run(
+      `INSERT INTO sync_manifest (realm_url, files_json, remote_mtimes_json)
+       VALUES (?, ?, ?)
+       ON CONFLICT(realm_url) DO UPDATE SET
+         files_json = excluded.files_json,
+         remote_mtimes_json = excluded.remote_mtimes_json`,
+      [
+        manifest.realmUrl,
+        JSON.stringify(manifest.files ?? {}),
+        JSON.stringify(manifest.remoteMtimes ?? {}),
+      ],
+    );
+  }
+}
+
+function decorateCard(row) {
+  const search = safeJson(row.search_doc) ?? {};
+  const pristine = safeJson(row.pristine_doc) ?? {};
+  return {
+    url: row.url,
+    fileAlias: row.file_alias,
+    title: search.title || row.file_alias,
+    types: safeJson(row.types) ?? [],
+    searchDoc: search,
+    pristineDoc: pristine,
+    indexedAt: row.indexed_at,
+  };
+}
+
+function aliasFromUrl(url) {
+  try {
+    const path = new URL(url).pathname.replace(/^\//, '');
+    return path.replace(/\.json$/, '');
+  } catch {
+    return url;
+  }
+}
+
+function safeJson(value) {
+  if (value == null) return null;
+  if (typeof value === 'object') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function summarizePlan(plan) {
+  const counts = {
+    push: 0,
+    pull: 0,
+    conflict: 0,
+    noop: 0,
+    'push-delete': 0,
+    'pull-delete': 0,
+  };
+  for (const item of plan) {
+    counts[item.action] = (counts[item.action] ?? 0) + 1;
+  }
+  return counts;
+}

--- a/prototypes/boxel-native/core/runtime.js
+++ b/prototypes/boxel-native/core/runtime.js
@@ -1,4 +1,5 @@
 import { LiteIndexer, REALM_URL } from './lite-indexer.js';
+import { computedOnly } from './computed-fields.js';
 import { RealmFs, SimulatedRemote, md5 } from './realm-fs.js';
 import { Messenger } from './messenger.js';
 import { planSync } from './sync-logic.js';
@@ -81,7 +82,20 @@ export class BoxelNativeRuntime {
   }
 
   searchCards(q) {
-    return this.indexer.search(q).map(decorateCard);
+    return this.searchIndex(q).cards;
+  }
+
+  searchIndex(q = '') {
+    const result = this.indexer.searchIndex(q, this.fs);
+    return {
+      query: result.query,
+      sql: result.sql,
+      computedKeys: result.computedKeys,
+      jsonSourceHits: result.jsonSourceHits,
+      cards: result.rows.map(decorateCard),
+      searched: 'boxel_index.search_doc',
+      notSearched: 'realm JSON files',
+    };
   }
 
   getCard(alias) {
@@ -281,7 +295,11 @@ function decorateCard(row) {
   return {
     url: row.url,
     fileAlias: row.file_alias,
-    title: search.title || row.file_alias,
+    title: search._title || search.title || row.file_alias,
+    handle: search.handle,
+    initials: search.initials,
+    fullName: search.fullName,
+    computed: computedOnly(search),
     types: safeJson(row.types) ?? [],
     searchDoc: search,
     pristineDoc: pristine,

--- a/prototypes/boxel-native/core/seed.js
+++ b/prototypes/boxel-native/core/seed.js
@@ -6,6 +6,16 @@ export class Person extends CardDef {
   static displayName = 'Person';
   @field firstName = contains(StringField);
   @field lastName = contains(StringField);
+  @field fullName = contains(StringField, {
+    computeVia: function () {
+      return [this.lastName, this.firstName].filter(Boolean).join(', ');
+    },
+  });
+  @field initials = contains(StringField, {
+    computeVia: function () {
+      return \`\${this.firstName?.[0] ?? ''}\${this.lastName?.[0] ?? ''}\`.toUpperCase();
+    },
+  });
 }
 `;
 

--- a/prototypes/boxel-native/core/seed.js
+++ b/prototypes/boxel-native/core/seed.js
@@ -1,0 +1,126 @@
+import { md5 } from './realm-fs.js';
+
+const PERSON_MODULE = `import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
+
+export class Person extends CardDef {
+  static displayName = 'Person';
+  @field firstName = contains(StringField);
+  @field lastName = contains(StringField);
+}
+`;
+
+function personCard(firstName, lastName) {
+  return `${JSON.stringify(
+    {
+      data: {
+        type: 'card',
+        attributes: { firstName, lastName },
+        meta: {
+          adoptsFrom: { module: './person.gts', name: 'Person' },
+        },
+      },
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function noteCard(title, body) {
+  return `${JSON.stringify(
+    {
+      data: {
+        type: 'card',
+        attributes: { title, body, firstName: title },
+        meta: {
+          adoptsFrom: { module: './note.gts', name: 'Note' },
+        },
+      },
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+const nimbusCard = `${JSON.stringify(
+  {
+    data: {
+      type: 'card',
+      attributes: { firstName: 'Nimbus', species: 'cat' },
+      meta: { adoptsFrom: { module: './pet.gts', name: 'Pet' } },
+    },
+  },
+  null,
+  2,
+)}\n`;
+
+const maple = personCard('Maple', 'Grove');
+const river = personCard('River', 'Stone');
+const remoteMtimeSec = Math.floor(Date.now() / 1000) - 180;
+
+const sharedFiles = {
+  'person.gts': PERSON_MODULE,
+  'maple-grove.json': maple,
+  'river-stone.json': river,
+  'nimbus.json': nimbusCard,
+};
+
+export const seed = {
+  localMtimeMs: Date.now() - 90_000,
+  remoteMtimeSec,
+  localFiles: {
+    ...sharedFiles,
+    'offline-draft.json': noteCard(
+      'Offline draft',
+      'Written on device. Not on the remote realm yet.',
+    ),
+  },
+  remoteFiles: {
+    ...sharedFiles,
+    'server-welcome.json': noteCard(
+      'Server welcome',
+      'This card exists only on the remote realm until you pull.',
+    ),
+  },
+  manifest: {
+    realmUrl: 'https://local.boxel/preview/',
+    files: Object.fromEntries(
+      Object.entries(sharedFiles).map(([path, content]) => [path, md5(content)]),
+    ),
+    remoteMtimes: Object.fromEntries(
+      Object.keys(sharedFiles).map((path) => [path, remoteMtimeSec]),
+    ),
+  },
+  rooms: [
+    {
+      id: 'realm-team',
+      title: 'Realm team',
+      subtitle: 'Cards stay on disk. The index is SQLite.',
+    },
+    {
+      id: 'offline-notes',
+      title: 'Offline notes',
+      subtitle: 'Messages queue until you go online.',
+    },
+  ],
+  messages: [
+    {
+      roomId: 'realm-team',
+      sender: 'runtime',
+      body: 'Local realm is a folder of JSON:API card files. The lite indexer writes boxel_index in SQLite.',
+      syncState: 'synced',
+    },
+    {
+      roomId: 'realm-team',
+      sender: 'runtime',
+      body: 'Open Maple Grove — that row came from maple-grove.json via json_extract on search_doc.',
+      cardAlias: 'maple-grove',
+      syncState: 'synced',
+    },
+    {
+      roomId: 'offline-notes',
+      sender: 'runtime',
+      body: 'You are offline. Send a message or create a card, then use Sync the way `boxel realm sync --prefer-newest` would.',
+      syncState: 'synced',
+    },
+  ],
+};

--- a/prototypes/boxel-native/core/sqlite.js
+++ b/prototypes/boxel-native/core/sqlite.js
@@ -1,0 +1,25 @@
+import { DatabaseSync } from 'node:sqlite';
+import { SCHEMA_SQL } from './lite-indexer.js';
+
+export function createSqlite(filename = ':memory:') {
+  const db = new DatabaseSync(filename);
+  db.exec(SCHEMA_SQL);
+  return wrap(db);
+}
+
+function wrap(db) {
+  return {
+    exec(sql) {
+      db.exec(sql);
+    },
+    all(sql, params = []) {
+      return db.prepare(sql).all(...params);
+    },
+    get(sql, params = []) {
+      return db.prepare(sql).get(...params);
+    },
+    run(sql, params = []) {
+      return db.prepare(sql).run(...params);
+    },
+  };
+}

--- a/prototypes/boxel-native/core/sync-logic.js
+++ b/prototypes/boxel-native/core/sync-logic.js
@@ -1,0 +1,155 @@
+// Keep aligned with packages/boxel-cli/src/lib/sync-logic.ts.
+// This copy is dependency-free so the native prototype can run without
+// importing the CLI package.
+
+export function classifyLocal(relativePath, localHashes, manifest) {
+  const hasLocal = localHashes.has(relativePath);
+  const inManifest = manifest?.files[relativePath] !== undefined;
+
+  if (hasLocal && inManifest) {
+    return localHashes.get(relativePath) === manifest.files[relativePath]
+      ? 'unchanged'
+      : 'changed';
+  }
+  if (hasLocal && !inManifest) return 'added';
+  if (!hasLocal && inManifest) return 'deleted';
+  return 'unchanged';
+}
+
+export function classifyRemote(relativePath, remoteMtimes, manifest) {
+  const hasRemote = remoteMtimes.has(relativePath);
+  const inManifestMtimes = manifest?.remoteMtimes?.[relativePath] !== undefined;
+  const inManifestFiles = manifest?.files[relativePath] !== undefined;
+  const knownInManifest = inManifestMtimes || inManifestFiles;
+
+  if (hasRemote && inManifestMtimes) {
+    return remoteMtimes.get(relativePath) ===
+      manifest.remoteMtimes[relativePath]
+      ? 'unchanged'
+      : 'changed';
+  }
+  if (hasRemote && inManifestFiles) return 'changed';
+  if (hasRemote && !knownInManifest) return 'added';
+  if (!hasRemote && knownInManifest) return 'deleted';
+  return 'unchanged';
+}
+
+export function determineAction(local, remote, syncOptions) {
+  if (local === 'unchanged' && remote === 'unchanged') return 'noop';
+  if (local === 'changed' && remote === 'unchanged') return 'push';
+  if (local === 'unchanged' && remote === 'changed') return 'pull';
+  if (local === 'added' && remote === 'unchanged') return 'push';
+  if (local === 'unchanged' && remote === 'added') return 'pull';
+  if (
+    (local === 'changed' && remote === 'changed') ||
+    (local === 'added' && remote === 'added')
+  ) {
+    return 'conflict';
+  }
+  if (
+    (local === 'changed' && remote === 'added') ||
+    (local === 'added' && remote === 'changed')
+  ) {
+    return 'conflict';
+  }
+  if (local === 'deleted' && remote === 'unchanged') {
+    return syncOptions.deleteSync || syncOptions.preferLocal
+      ? 'push-delete'
+      : 'noop';
+  }
+  if (local === 'unchanged' && remote === 'deleted') {
+    return syncOptions.deleteSync || syncOptions.preferRemote
+      ? 'pull-delete'
+      : 'noop';
+  }
+  if (local === 'deleted' && remote === 'changed') return 'conflict';
+  if (local === 'changed' && remote === 'deleted') return 'conflict';
+  if (local === 'deleted' && remote === 'deleted') return 'noop';
+  if (local === 'added' && remote === 'deleted') return 'push';
+  if (local === 'deleted' && remote === 'added') return 'pull';
+  return 'noop';
+}
+
+export function resolveConflict(
+  classification,
+  localFilesWithMtimes,
+  remoteMtimes,
+  strategy,
+) {
+  const { localStatus, remoteStatus, relativePath } = classification;
+  if (!strategy) return null;
+
+  switch (strategy) {
+    case 'prefer-local':
+      if (localStatus === 'deleted') return 'push-delete';
+      return 'push';
+    case 'prefer-remote':
+      if (remoteStatus === 'deleted') return 'pull-delete';
+      return 'pull';
+    case 'prefer-newest': {
+      if (localStatus === 'deleted' && remoteStatus === 'changed')
+        return 'pull';
+      if (localStatus === 'changed' && remoteStatus === 'deleted')
+        return 'push';
+      const localInfo = localFilesWithMtimes.get(relativePath);
+      const remoteMtime = remoteMtimes.get(relativePath);
+      if (localInfo && remoteMtime !== undefined) {
+        return localInfo.mtime > remoteMtime * 1000 ? 'push' : 'pull';
+      }
+      return 'push';
+    }
+  }
+}
+
+export function planSync({
+  localHashes,
+  localMtimes,
+  remoteMtimes,
+  manifest,
+  prefer,
+  deleteSync = false,
+}) {
+  const syncOptions = {
+    deleteSync,
+    preferLocal: prefer === 'local',
+    preferRemote: prefer === 'remote',
+  };
+  const strategy =
+    prefer === 'local' || prefer === 'remote' || prefer === 'newest'
+      ? prefer === 'newest'
+        ? 'prefer-newest'
+        : prefer === 'local'
+          ? 'prefer-local'
+          : 'prefer-remote'
+      : null;
+
+  const allPaths = new Set([
+    ...localHashes.keys(),
+    ...remoteMtimes.keys(),
+    ...Object.keys(manifest?.files ?? {}),
+    ...Object.keys(manifest?.remoteMtimes ?? {}),
+  ]);
+
+  const localFilesWithMtimes = new Map();
+  for (const [rel, mtime] of localMtimes) {
+    localFilesWithMtimes.set(rel, { path: rel, mtime });
+  }
+
+  const plan = [];
+  for (const relativePath of allPaths) {
+    const localStatus = classifyLocal(relativePath, localHashes, manifest);
+    const remoteStatus = classifyRemote(relativePath, remoteMtimes, manifest);
+    let action = determineAction(localStatus, remoteStatus, syncOptions);
+    if (action === 'conflict') {
+      const resolved = resolveConflict(
+        { relativePath, localStatus, remoteStatus, action },
+        localFilesWithMtimes,
+        remoteMtimes,
+        strategy,
+      );
+      action = resolved ?? 'conflict';
+    }
+    plan.push({ relativePath, localStatus, remoteStatus, action });
+  }
+  return plan.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}

--- a/prototypes/boxel-native/package.json
+++ b/prototypes/boxel-native/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@cardstack/boxel-native-proto",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node web-simulator/server.mjs",
+    "test": "node --test tests/core.test.js"
+  }
+}

--- a/prototypes/boxel-native/tests/core.test.js
+++ b/prototypes/boxel-native/tests/core.test.js
@@ -32,6 +32,32 @@ test('search uses sqlite json_extract against search_doc', () => {
   assert.equal(hits[0].fileAlias, 'nimbus');
 });
 
+test('computed values are in search_doc and absent from the JSON source', () => {
+  const runtime = boot();
+  const maple = runtime.getCard('maple-grove');
+  const source = runtime.fs.read('maple-grove.json');
+  assert.equal(maple.computed.handle, '@maple.grove');
+  assert.equal(maple.computed.initials, 'MG');
+  assert.equal(maple.computed.fullName, 'Grove, Maple');
+  assert.equal(maple.computed._title, 'Maple Grove');
+  assert.equal(source.includes('@maple.grove'), false);
+  assert.equal(source.includes('"initials"'), false);
+  assert.equal(source.includes('Grove, Maple'), false);
+});
+
+test('search hits SQLite computed keys that a JSON-file scan misses', () => {
+  const runtime = boot();
+  for (const q of ['@maple.grove', 'MG', 'Grove, Maple']) {
+    const result = runtime.searchIndex(q);
+    assert.equal(result.searched, 'boxel_index.search_doc');
+    assert.equal(result.notSearched, 'realm JSON files');
+    assert.ok(result.sql.includes('json_extract(search_doc'));
+    assert.equal(result.cards.length, 1, `index should hit for ${q}`);
+    assert.equal(result.cards[0].fileAlias, 'maple-grove');
+    assert.deepEqual(result.jsonSourceHits, [], `JSON scan should miss ${q}`);
+  }
+});
+
 test('creating a card writes a JSON file then reindexes', () => {
   const runtime = boot();
   const card = runtime.createPersonCard({

--- a/prototypes/boxel-native/tests/core.test.js
+++ b/prototypes/boxel-native/tests/core.test.js
@@ -1,0 +1,103 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSqlite } from '../core/sqlite.js';
+import { BoxelNativeRuntime } from '../core/runtime.js';
+import { seed } from '../core/seed.js';
+import { planSync } from '../core/sync-logic.js';
+
+function boot() {
+  const db = createSqlite();
+  const runtime = new BoxelNativeRuntime(db);
+  runtime.bootstrap(seed);
+  return runtime;
+}
+
+test('lite indexer writes boxel_index rows from the realm filesystem', () => {
+  const runtime = boot();
+  const cards = runtime.searchCards();
+  const titles = cards.map((c) => c.title).sort();
+  assert.ok(titles.includes('Maple Grove'));
+  assert.ok(titles.includes('River Stone'));
+  assert.ok(titles.includes('Nimbus'));
+  assert.ok(titles.includes('Offline draft'));
+  const maple = runtime.getCard('maple-grove');
+  assert.equal(maple.searchDoc.firstName, 'Maple');
+  assert.equal(maple.pristineDoc.meta.adoptsFrom.name, 'Person');
+});
+
+test('search uses sqlite json_extract against search_doc', () => {
+  const runtime = boot();
+  const hits = runtime.searchCards('nimbus');
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].fileAlias, 'nimbus');
+});
+
+test('creating a card writes a JSON file then reindexes', () => {
+  const runtime = boot();
+  const card = runtime.createPersonCard({
+    firstName: 'Cedar',
+    lastName: 'Hollow',
+  });
+  assert.equal(card.title, 'Cedar Hollow');
+  assert.ok(runtime.fs.read('cedar-hollow.json'));
+  assert.equal(runtime.searchCards('Cedar').length, 1);
+  const plan = runtime.previewSync('newest');
+  const created = plan.find((p) => p.relativePath === 'cedar-hollow.json');
+  assert.equal(created.action, 'push');
+});
+
+test('offline messages queue; going online marks them synced', () => {
+  const runtime = boot();
+  assert.equal(runtime.online, false);
+  runtime.sendMessage({
+    roomId: 'offline-notes',
+    body: 'queued on device',
+    cardAlias: 'offline-draft',
+  });
+  assert.equal(runtime.messenger.queuedMessages().length, 1);
+  runtime.setOnline(true);
+  assert.equal(runtime.messenger.queuedMessages().length, 0);
+});
+
+test('sync plan matches boxel-cli classify: local-only push, remote-only pull', () => {
+  const runtime = boot();
+  const plan = runtime.previewSync('newest');
+  const byPath = Object.fromEntries(plan.map((p) => [p.relativePath, p]));
+  assert.equal(byPath['offline-draft.json'].action, 'push');
+  assert.equal(byPath['server-welcome.json'].action, 'pull');
+  assert.equal(byPath['maple-grove.json'].action, 'noop');
+});
+
+test('online sync with prefer-newest pushes the draft and pulls the server card', () => {
+  const runtime = boot();
+  runtime.setOnline(true);
+  const result = runtime.sync({ prefer: 'newest' });
+  const actions = result.log.map((l) => `${l.action}:${l.relativePath}`).sort();
+  assert.ok(actions.includes('push:offline-draft.json'));
+  assert.ok(actions.includes('pull:server-welcome.json'));
+  assert.ok(runtime.fs.read('server-welcome.json'));
+  assert.ok(runtime.remote.read('offline-draft.json'));
+  assert.ok(runtime.getCard('server-welcome'));
+  const after = runtime.previewSync('newest');
+  assert.ok(after.every((p) => p.action === 'noop'));
+});
+
+test('sync refuses to run while offline', () => {
+  const runtime = boot();
+  assert.throws(() => runtime.sync({ prefer: 'newest' }), /offline/i);
+});
+
+test('planSync conflict without a strategy stays conflict', () => {
+  const plan = planSync({
+    localHashes: new Map([['a.json', 'local']]),
+    localMtimes: new Map([['a.json', Date.now()]]),
+    remoteMtimes: new Map([['a.json', 1]]),
+    manifest: {
+      realmUrl: 'https://local.boxel/preview/',
+      files: { 'a.json': 'old' },
+      remoteMtimes: { 'a.json': 0 },
+    },
+    prefer: null,
+  });
+  assert.equal(plan[0].action, 'conflict');
+});

--- a/prototypes/boxel-native/web-simulator/app.js
+++ b/prototypes/boxel-native/web-simulator/app.js
@@ -184,19 +184,42 @@ function aliasFromUrl(url) {
 }
 
 function renderCards() {
-  const cards = view.query
-    ? state.cards.filter((c) =>
-        `${c.title} ${c.fileAlias}`.toLowerCase().includes(view.query),
-      )
-    : state.cards;
+  fetchCards();
+}
+
+async function fetchCards() {
+  const result = await api(
+    `/api/cards?q=${encodeURIComponent(view.query || '')}`,
+  );
+  const cards = result.cards;
+  const jsonMiss =
+    result.query && result.jsonSourceHits.length === 0 && cards.length > 0;
   app.innerHTML = `
     <div class="nav-title">
       <h2>Cards</h2>
-      <p class="muted">${state.index.instances} instances in boxel_index · gen ${state.index.generation}</p>
+      <p class="muted">SQLite <code>boxel_index.search_doc</code> · gen ${state.index.generation}</p>
     </div>
     <div class="search">
-      <input id="q" placeholder="Search sqlite json_extract(search_doc)" value="${escapeHtml(view.query)}" />
+      <input id="q" placeholder="Search computed index: MG, Grove, Maple, @maple.grove" value="${escapeHtml(view.query)}" />
     </div>
+    ${
+      result.query
+        ? `<div class="proof">
+        <div class="kv"><span>Searched</span><strong>${escapeHtml(result.searched)}</strong></div>
+        <div class="kv"><span>Not searched</span><strong>${escapeHtml(result.notSearched)}</strong></div>
+        <div class="kv"><span>Index hits</span><strong class="action-push">${cards.length}</strong></div>
+        <div class="kv"><span>JSON file hits</span><strong class="${jsonMiss ? 'action-push' : ''}">${result.jsonSourceHits.length}</strong></div>
+        ${
+          jsonMiss
+            ? `<p class="muted proof-note">This query matches computed <code>search_doc</code> keys and does not appear in any realm JSON file.</p>`
+            : result.jsonSourceHits.length
+              ? `<p class="muted proof-note">JSON also contains this string in ${result.jsonSourceHits.map(escapeHtml).join(', ')} — try <code>MG</code> or <code>@maple.grove</code>.</p>`
+              : ''
+        }
+        <pre class="sql-view">${escapeHtml(result.sql)}</pre>
+      </div>`
+        : `<p class="muted" style="padding:0 0.85rem 0.7rem">Computed at index time (not stored in JSON): <code>_title</code> <code>fullName</code> <code>initials</code> <code>handle</code></p>`
+    }
     <form class="form" id="new-card">
       <input name="firstName" placeholder="First name" required />
       <input name="lastName" placeholder="Last name" />
@@ -208,17 +231,22 @@ function renderCards() {
       <button class="list-row" data-open-card="${escapeHtml(c.fileAlias)}">
         <div>
           <strong>${escapeHtml(c.title)}</strong>
-          <small>${escapeHtml(c.fileAlias)}.json · ${escapeHtml(c.types[0] || '')}</small>
+          <small>${escapeHtml(c.handle || '')} · ${escapeHtml(c.fullName || '')} · ${escapeHtml(c.initials || '')}</small>
         </div>
       </button>`,
       )
       .join('')}
   `;
-  app.querySelector('#q').addEventListener('input', (e) => {
-    view.query = e.target.value.trim().toLowerCase();
-    renderCards();
-    app.querySelector('#q').focus();
-    app.querySelector('#q').setSelectionRange(view.query.length, view.query.length);
+  const input = app.querySelector('#q');
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      view.query = input.value.trim();
+      fetchCards();
+    }
+  });
+  input.addEventListener('change', () => {
+    view.query = input.value.trim();
+    fetchCards();
   });
   app.querySelector('#new-card').addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -230,7 +258,9 @@ function renderCards() {
         lastName: data.get('lastName'),
       }),
     });
-    await refresh();
+    state = await api('/api/state');
+    view.query = '';
+    fetchCards();
   });
   app.querySelectorAll('[data-open-card]').forEach((btn) => {
     btn.addEventListener('click', () => {
@@ -238,6 +268,8 @@ function renderCards() {
       renderCard();
     });
   });
+  input.focus();
+  input.setSelectionRange(input.value.length, input.value.length);
 }
 
 async function renderCard() {
@@ -246,7 +278,12 @@ async function renderCard() {
     <button class="back" data-back>‹ Cards</button>
     <div class="nav-title">
       <h2>${escapeHtml(card.title)}</h2>
-      <p class="muted">${escapeHtml(card.url)}</p>
+      <p class="muted">${escapeHtml(card.handle || '')} · computed, not in the JSON file</p>
+    </div>
+    <div class="proof" style="padding-top:0">
+      <p class="muted proof-note">search_doc computed keys (SQLite)</p>
+      <pre class="sql-view">${escapeHtml(JSON.stringify(card.computed, null, 2))}</pre>
+      <p class="muted proof-note">JSON:API source on disk</p>
     </div>
     <pre class="json-view">${escapeHtml(JSON.stringify(card.pristineDoc, null, 2))}</pre>
   `;

--- a/prototypes/boxel-native/web-simulator/app.js
+++ b/prototypes/boxel-native/web-simulator/app.js
@@ -1,0 +1,324 @@
+const app = document.getElementById('app');
+const tabs = [...document.querySelectorAll('[data-tab]')];
+
+let state = null;
+let view = { tab: 'chats', roomId: null, cardAlias: null, query: '' };
+
+tabs.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    view.tab = btn.dataset.tab;
+    view.roomId = null;
+    view.cardAlias = null;
+    tabs.forEach((b) => b.classList.toggle('is-active', b === btn));
+    render();
+  });
+});
+
+async function api(path, opts) {
+  const res = await fetch(path, {
+    headers: { 'content-type': 'application/json' },
+    ...opts,
+  });
+  const body = await res.json();
+  if (!res.ok) throw new Error(body.error || res.statusText);
+  return body;
+}
+
+async function refresh() {
+  state = await api('/api/state');
+  render();
+}
+
+function pill() {
+  return state.online
+    ? '<span class="pill online">online</span>'
+    : '<span class="pill">offline</span>';
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function render() {
+  if (!state) {
+    app.innerHTML = '<p class="muted" style="padding:1rem">Loading SQLite…</p>';
+    return;
+  }
+  if (view.tab === 'chats' && view.roomId) return void renderThread();
+  if (view.tab === 'cards' && view.cardAlias) return void renderCard();
+  if (view.tab === 'chats') return void renderChats();
+  if (view.tab === 'cards') return void renderCards();
+  renderSync();
+}
+
+function renderChats() {
+  app.innerHTML = `
+    <div class="nav-title">
+      <h2>Chats</h2>
+      ${pill()}
+      <p class="muted">${state.queuedMessages} queued · ${state.index.instances} indexed cards</p>
+    </div>
+    ${state.rooms
+      .map(
+        (room) => `
+      <button class="list-row" data-open-room="${escapeHtml(room.id)}">
+        <div>
+          <strong>${escapeHtml(room.title)}</strong>
+          <small>${escapeHtml(room.subtitle || '')}</small>
+        </div>
+        ${
+          room.unsynced_count
+            ? `<span class="badge">${room.unsynced_count}</span>`
+            : `<span class="muted">${room.message_count}</span>`
+        }
+      </button>`,
+      )
+      .join('')}
+  `;
+  app.querySelectorAll('[data-open-room]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      view.roomId = btn.dataset.openRoom;
+      renderThread();
+    });
+  });
+}
+
+async function renderThread() {
+  const { room, messages } = await api(`/api/rooms/${view.roomId}/messages`);
+  app.innerHTML = `
+    <div class="thread">
+      <button class="back" data-back>‹ Chats</button>
+      <div class="nav-title">
+        <h2>${escapeHtml(room.title)}</h2>
+        ${pill()}
+      </div>
+      <div class="messages">
+        ${messages
+          .map((m) => {
+            const card = m.card
+              ? decorateMaybe(m.card)
+              : m.card_url
+                ? { title: m.card_url, fileAlias: aliasFromUrl(m.card_url) }
+                : null;
+            return `
+          <div class="bubble ${m.sender === 'you' ? 'you' : ''}">
+            <div class="who">${escapeHtml(m.sender)} · ${escapeHtml(m.sync_state)}</div>
+            <div>${escapeHtml(m.body)}</div>
+            ${
+              card
+                ? `<div class="card-chip" data-open-card="${escapeHtml(card.fileAlias || '')}">📎 ${escapeHtml(card.title || card.fileAlias)}</div>`
+                : ''
+            }
+          </div>`;
+          })
+          .join('')}
+      </div>
+      <div class="composer">
+        <select id="attach">
+          <option value="">No card</option>
+          ${state.cards
+            .map(
+              (c) =>
+                `<option value="${escapeHtml(c.fileAlias)}">${escapeHtml(c.title)}</option>`,
+            )
+            .join('')}
+        </select>
+        <button class="primary" id="send">Send</button>
+        <input id="draft" placeholder="Message (queues while offline)" style="grid-column:1 / -1" />
+      </div>
+    </div>
+  `;
+  app.querySelector('[data-back]').addEventListener('click', () => {
+    view.roomId = null;
+    renderChats();
+  });
+  app.querySelectorAll('[data-open-card]').forEach((el) => {
+    el.addEventListener('click', () => {
+      view.tab = 'cards';
+      view.cardAlias = el.dataset.openCard;
+      tabs.forEach((b) =>
+        b.classList.toggle('is-active', b.dataset.tab === 'cards'),
+      );
+      renderCard();
+    });
+  });
+  app.querySelector('#send').addEventListener('click', sendFromComposer);
+  app.querySelector('#draft').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') sendFromComposer();
+  });
+}
+
+async function sendFromComposer() {
+  const input = app.querySelector('#draft');
+  const attach = app.querySelector('#attach');
+  const body = input.value.trim();
+  if (!body) return;
+  await api(`/api/rooms/${view.roomId}/messages`, {
+    method: 'POST',
+    body: JSON.stringify({ body, cardAlias: attach.value || null }),
+  });
+  state = await api('/api/state');
+  await renderThread();
+}
+
+function decorateMaybe(card) {
+  if (card.title) return card;
+  try {
+    const search = JSON.parse(card.search_doc || '{}');
+    return { ...card, title: search.title, fileAlias: card.file_alias };
+  } catch {
+    return card;
+  }
+}
+
+function aliasFromUrl(url) {
+  try {
+    return new URL(url).pathname.replace(/^\//, '').replace(/\.json$/, '');
+  } catch {
+    return url;
+  }
+}
+
+function renderCards() {
+  const cards = view.query
+    ? state.cards.filter((c) =>
+        `${c.title} ${c.fileAlias}`.toLowerCase().includes(view.query),
+      )
+    : state.cards;
+  app.innerHTML = `
+    <div class="nav-title">
+      <h2>Cards</h2>
+      <p class="muted">${state.index.instances} instances in boxel_index · gen ${state.index.generation}</p>
+    </div>
+    <div class="search">
+      <input id="q" placeholder="Search sqlite json_extract(search_doc)" value="${escapeHtml(view.query)}" />
+    </div>
+    <form class="form" id="new-card">
+      <input name="firstName" placeholder="First name" required />
+      <input name="lastName" placeholder="Last name" />
+      <button class="primary" type="submit">Write JSON + index</button>
+    </form>
+    ${cards
+      .map(
+        (c) => `
+      <button class="list-row" data-open-card="${escapeHtml(c.fileAlias)}">
+        <div>
+          <strong>${escapeHtml(c.title)}</strong>
+          <small>${escapeHtml(c.fileAlias)}.json · ${escapeHtml(c.types[0] || '')}</small>
+        </div>
+      </button>`,
+      )
+      .join('')}
+  `;
+  app.querySelector('#q').addEventListener('input', (e) => {
+    view.query = e.target.value.trim().toLowerCase();
+    renderCards();
+    app.querySelector('#q').focus();
+    app.querySelector('#q').setSelectionRange(view.query.length, view.query.length);
+  });
+  app.querySelector('#new-card').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = new FormData(e.target);
+    await api('/api/cards', {
+      method: 'POST',
+      body: JSON.stringify({
+        firstName: data.get('firstName'),
+        lastName: data.get('lastName'),
+      }),
+    });
+    await refresh();
+  });
+  app.querySelectorAll('[data-open-card]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      view.cardAlias = btn.dataset.openCard;
+      renderCard();
+    });
+  });
+}
+
+async function renderCard() {
+  const { card } = await api(`/api/cards/${view.cardAlias}`);
+  app.innerHTML = `
+    <button class="back" data-back>‹ Cards</button>
+    <div class="nav-title">
+      <h2>${escapeHtml(card.title)}</h2>
+      <p class="muted">${escapeHtml(card.url)}</p>
+    </div>
+    <pre class="json-view">${escapeHtml(JSON.stringify(card.pristineDoc, null, 2))}</pre>
+  `;
+  app.querySelector('[data-back]').addEventListener('click', () => {
+    view.cardAlias = null;
+    renderCards();
+  });
+}
+
+function renderSync() {
+  const summary = state.sync.summary;
+  const pending = state.sync.plan.filter((p) => p.action !== 'noop');
+  app.innerHTML = `
+    <div class="nav-title">
+      <h2>Sync</h2>
+      ${pill()}
+      <p class="muted">Same classify/push/pull as <code>boxel realm sync --prefer-newest</code></p>
+    </div>
+    <div class="sync-grid">
+      <div class="kv"><span>Indexed cards</span><strong>${state.index.instances}</strong></div>
+      <div class="kv"><span>Local files</span><strong>${state.files.length}</strong></div>
+      <div class="kv"><span>Push</span><strong class="action-push">${summary.push || 0}</strong></div>
+      <div class="kv"><span>Pull</span><strong class="action-pull">${summary.pull || 0}</strong></div>
+      <div class="kv"><span>Conflict</span><strong class="action-conflict">${summary.conflict || 0}</strong></div>
+    </div>
+    <div class="toolbar">
+      <button class="primary" id="toggle-online">${state.online ? 'Go offline' : 'Go online'}</button>
+      <button class="primary" id="run-sync">Sync now</button>
+    </div>
+    ${pending
+      .map(
+        (p) => `
+      <div class="list-row" style="cursor:default">
+        <div>
+          <strong>${escapeHtml(p.relativePath)}</strong>
+          <small>${escapeHtml(p.localStatus)} local · ${escapeHtml(p.remoteStatus)} remote</small>
+        </div>
+        <span class="action-${escapeHtml(p.action)}">${escapeHtml(p.action)}</span>
+      </div>`,
+      )
+      .join('') || '<p class="muted" style="padding:0 1rem">In sync.</p>'}
+    ${
+      state.sync.log?.length
+        ? `<p class="muted" style="padding:0.5rem 1rem 0">Last run</p>${state.sync.log
+            .map(
+              (l) =>
+                `<div class="list-row" style="cursor:default"><div><strong>${escapeHtml(l.relativePath)}</strong><small>${escapeHtml(l.detail)}</small></div><span>${escapeHtml(l.action)}</span></div>`,
+            )
+            .join('')}`
+        : ''
+    }
+  `;
+  app.querySelector('#toggle-online').addEventListener('click', async () => {
+    await api('/api/online', {
+      method: 'POST',
+      body: JSON.stringify({ online: !state.online }),
+    });
+    await refresh();
+  });
+  app.querySelector('#run-sync').addEventListener('click', async () => {
+    try {
+      await api('/api/sync', {
+        method: 'POST',
+        body: JSON.stringify({ prefer: 'newest' }),
+      });
+    } catch (err) {
+      alert(err.message);
+    }
+    await refresh();
+  });
+}
+
+refresh().catch((err) => {
+  app.innerHTML = `<p class="muted" style="padding:1rem">${escapeHtml(err.message)}</p>`;
+});

--- a/prototypes/boxel-native/web-simulator/index.html
+++ b/prototypes/boxel-native/web-simulator/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Boxel Native — iPhone Simulator</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="stage">
+      <header class="stage-copy">
+        <p class="eyebrow">NativeScript 9.1 · SQLite path</p>
+        <h1>Boxel offline messenger</h1>
+        <p>
+          iPhone chrome around the same data plane a NativeScript 9.1 iOS / Mac
+          Catalyst app would use: realm files on disk, lite indexer into
+          <code>boxel_index</code>, queued chat, then
+          <code>boxel realm sync</code>-shaped reconcile when online.
+        </p>
+        <ul class="legend">
+          <li>Chats attach indexed cards</li>
+          <li>Cards are JSON files → SQLite</li>
+          <li>Sync uses prefer-newest</li>
+        </ul>
+      </header>
+
+      <section class="phone" aria-label="iPhone simulator">
+        <div class="phone-bezel">
+          <div class="dynamic-island"></div>
+          <div class="phone-screen">
+            <div class="status-bar">
+              <span>9:41</span>
+              <span class="status-icons">5G ●●●●</span>
+            </div>
+            <div id="app" class="app"></div>
+            <nav class="tab-bar" role="tablist">
+              <button data-tab="chats" class="tab is-active">
+                <span class="tab-icon">💬</span>Chats
+              </button>
+              <button data-tab="cards" class="tab">
+                <span class="tab-icon">🗂️</span>Cards
+              </button>
+              <button data-tab="sync" class="tab">
+                <span class="tab-icon">🔄</span>Sync
+              </button>
+            </nav>
+          </div>
+          <div class="home-indicator"></div>
+        </div>
+      </section>
+    </main>
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/prototypes/boxel-native/web-simulator/server.mjs
+++ b/prototypes/boxel-native/web-simulator/server.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createSqlite } from '../core/sqlite.js';
+import { BoxelNativeRuntime } from '../core/runtime.js';
+import { seed } from '../core/seed.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = Number(process.env.PORT || 4173);
+
+const db = createSqlite();
+const runtime = new BoxelNativeRuntime(db);
+runtime.bootstrap(seed);
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.json': 'application/json; charset=utf-8',
+};
+
+function json(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+  });
+  res.end(payload);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (!raw) return resolve({});
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+async function handleApi(req, res, url) {
+  const route = url.pathname.replace(/\/$/, '') || '/';
+  if (req.method === 'GET' && route === '/api/state') {
+    return json(res, 200, runtime.snapshot());
+  }
+  if (req.method === 'GET' && route === '/api/cards') {
+    return json(res, 200, {
+      cards: runtime.searchCards(url.searchParams.get('q') || ''),
+    });
+  }
+  if (req.method === 'GET' && route.startsWith('/api/cards/')) {
+    const alias = decodeURIComponent(route.slice('/api/cards/'.length));
+    const card = runtime.getCard(alias);
+    return card
+      ? json(res, 200, { card })
+      : json(res, 404, { error: 'card not found' });
+  }
+  if (req.method === 'POST' && route === '/api/cards') {
+    const body = await readBody(req);
+    const card = runtime.createPersonCard({
+      firstName: String(body.firstName || '').trim() || 'Untitled',
+      lastName: String(body.lastName || '').trim(),
+    });
+    return json(res, 201, { card, state: runtime.snapshot() });
+  }
+  if (req.method === 'GET' && route.startsWith('/api/rooms/')) {
+    const roomId = decodeURIComponent(
+      route.slice('/api/rooms/'.length).replace(/\/messages$/, ''),
+    );
+    const room = runtime.messenger.getRoom(roomId);
+    if (!room) return json(res, 404, { error: 'room not found' });
+    return json(res, 200, {
+      room,
+      messages: runtime.listMessages(roomId),
+    });
+  }
+  if (req.method === 'POST' && /\/api\/rooms\/[^/]+\/messages$/.test(route)) {
+    const roomId = decodeURIComponent(route.split('/')[3]);
+    const body = await readBody(req);
+    const message = runtime.sendMessage({
+      roomId,
+      body: String(body.body || '').trim(),
+      cardAlias: body.cardAlias || null,
+    });
+    return json(res, 201, { message, state: runtime.snapshot() });
+  }
+  if (req.method === 'POST' && route === '/api/online') {
+    const body = await readBody(req);
+    return json(res, 200, runtime.setOnline(Boolean(body.online)));
+  }
+  if (req.method === 'GET' && route === '/api/sync') {
+    return json(res, 200, {
+      plan: runtime.previewSync(url.searchParams.get('prefer') || 'newest'),
+      online: runtime.online,
+      log: runtime.lastSyncLog,
+    });
+  }
+  if (req.method === 'POST' && route === '/api/sync') {
+    const body = await readBody(req);
+    try {
+      const result = runtime.sync({
+        prefer: body.prefer || 'newest',
+        deleteSync: Boolean(body.deleteSync),
+      });
+      return json(res, 200, result);
+    } catch (err) {
+      return json(res, 409, { error: err.message });
+    }
+  }
+  return json(res, 404, { error: `no route ${req.method} ${route}` });
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, `http://127.0.0.1:${PORT}`);
+    if (url.pathname.startsWith('/api/')) {
+      return await handleApi(req, res, url);
+    }
+    let filePath = url.pathname === '/' ? '/index.html' : url.pathname;
+    const abs = path.normalize(path.join(__dirname, filePath));
+    if (!abs.startsWith(__dirname)) {
+      res.writeHead(403);
+      return res.end('forbidden');
+    }
+    const data = await fs.promises.readFile(abs);
+    const ext = path.extname(abs);
+    res.writeHead(200, { 'content-type': MIME[ext] || 'application/octet-stream' });
+    res.end(data);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      res.writeHead(404);
+      return res.end('not found');
+    }
+    console.error(err);
+    res.writeHead(500);
+    res.end(String(err.message || err));
+  }
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`Boxel native prototype (iPhone chrome) → http://127.0.0.1:${PORT}/`);
+  console.log('SQLite lite indexer is in-process via node:sqlite.');
+});

--- a/prototypes/boxel-native/web-simulator/server.mjs
+++ b/prototypes/boxel-native/web-simulator/server.mjs
@@ -54,9 +54,7 @@ async function handleApi(req, res, url) {
     return json(res, 200, runtime.snapshot());
   }
   if (req.method === 'GET' && route === '/api/cards') {
-    return json(res, 200, {
-      cards: runtime.searchCards(url.searchParams.get('q') || ''),
-    });
+    return json(res, 200, runtime.searchIndex(url.searchParams.get('q') || ''));
   }
   if (req.method === 'GET' && route.startsWith('/api/cards/')) {
     const alias = decodeURIComponent(route.slice('/api/cards/'.length));

--- a/prototypes/boxel-native/web-simulator/styles.css
+++ b/prototypes/boxel-native/web-simulator/styles.css
@@ -347,15 +347,27 @@ button.primary {
   flex: 1;
 }
 
-.json-view {
+.proof {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0 0.85rem 0.85rem;
+}
+
+.proof-note {
+  margin: 0.15rem 0 0;
+}
+
+.sql-view {
   white-space: pre-wrap;
   font-family: var(--mono);
-  font-size: 0.72rem;
-  color: #c7d0e0;
-  margin: 0 0.85rem;
+  font-size: 0.62rem;
+  color: #9ad7c2;
   background: #15161c;
-  border-radius: 1rem;
-  padding: 0.9rem;
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  margin: 0;
+  max-height: 7rem;
+  overflow: auto;
 }
 
 @media (max-width: 860px) {

--- a/prototypes/boxel-native/web-simulator/styles.css
+++ b/prototypes/boxel-native/web-simulator/styles.css
@@ -1,0 +1,366 @@
+:root {
+  --boxel-teal: #00ffba;
+  --boxel-dark-teal: #00da9f;
+  --bg: #07080a;
+  --panel: #111217;
+  --phone: #0b0c10;
+  --screen: #0e0f14;
+  --row: #1a1c24;
+  --text: #f4f6fb;
+  --muted: #9aa3b5;
+  --line: rgba(255, 255, 255, 0.08);
+  --font: 'IBM Plex Sans', 'SF Pro Text', ui-sans-serif, system-ui, sans-serif;
+  --mono: 'IBM Plex Mono', ui-monospace, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background: radial-gradient(1200px 600px at 10% -10%, #163328, transparent),
+    var(--bg);
+  color: var(--text);
+  font: 16px / 1.4 var(--font);
+}
+
+code {
+  font-family: var(--mono);
+  font-size: 0.85em;
+  color: var(--boxel-teal);
+}
+
+.stage {
+  display: grid;
+  grid-template-columns: minmax(18rem, 28rem) auto;
+  gap: 3rem;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 3rem 2rem;
+}
+
+.stage-copy h1 {
+  font-size: 2.25rem;
+  letter-spacing: -0.04em;
+  margin: 0.35rem 0 0.75rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  color: var(--boxel-teal);
+  margin: 0;
+}
+
+.legend {
+  padding: 0;
+  margin: 1.5rem 0 0;
+  list-style: none;
+  color: var(--muted);
+}
+
+.legend li {
+  padding: 0.35rem 0;
+}
+
+.phone-bezel {
+  width: 24.5rem;
+  height: 50.5rem;
+  background: #1a1b20;
+  border-radius: 3.1rem;
+  padding: 0.72rem;
+  box-shadow:
+    0 0 0 0.14rem #3a3d48,
+    0 2.5rem 5rem rgba(0, 0, 0, 0.55);
+  position: relative;
+}
+
+.dynamic-island {
+  position: absolute;
+  top: 1.15rem;
+  left: 50%;
+  width: 7.4rem;
+  height: 2.1rem;
+  transform: translateX(-50%);
+  background: #000;
+  border-radius: 1.2rem;
+  z-index: 3;
+}
+
+.phone-screen {
+  height: 100%;
+  background: var(--screen);
+  border-radius: 2.45rem;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.status-bar {
+  display: flex;
+  justify-content: space-between;
+  padding: 1.05rem 1.7rem 0.35rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.app {
+  flex: 1;
+  overflow: auto;
+  padding: 0.5rem 0 4.8rem;
+}
+
+.tab-bar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  background: rgba(14, 15, 20, 0.92);
+  backdrop-filter: blur(18px);
+  border-top: 1px solid var(--line);
+  padding: 0.45rem 0 1.15rem;
+}
+
+.tab {
+  background: none;
+  border: 0;
+  color: var(--muted);
+  font: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  align-items: center;
+  font-size: 0.72rem;
+}
+
+.tab.is-active {
+  color: var(--boxel-teal);
+}
+
+.tab-icon {
+  font-size: 1.05rem;
+}
+
+.home-indicator {
+  position: absolute;
+  width: 8rem;
+  height: 0.32rem;
+  background: #fff;
+  border-radius: 99px;
+  left: 50%;
+  bottom: 0.55rem;
+  transform: translateX(-50%);
+}
+
+.nav-title {
+  padding: 0.2rem 1.25rem 0.85rem;
+}
+
+.nav-title h2 {
+  margin: 0;
+  font-size: 2rem;
+  letter-spacing: -0.04em;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 99px;
+  padding: 0.15rem 0.55rem;
+  font-size: 0.72rem;
+  background: #3a2410;
+  color: #ffb45a;
+}
+
+.pill.online {
+  background: #113528;
+  color: var(--boxel-teal);
+}
+
+.list-row,
+.card-tile,
+.bubble {
+  margin: 0 0.85rem 0.55rem;
+  background: var(--row);
+  border-radius: 1rem;
+  padding: 0.85rem 1rem;
+}
+
+.list-row {
+  width: calc(100% - 1.7rem);
+  border: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.35rem 0.75rem;
+  cursor: pointer;
+}
+
+.list-row strong,
+.card-tile strong {
+  display: block;
+}
+
+.muted,
+.list-row small,
+.meta {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.badge {
+  background: var(--boxel-teal);
+  color: #06281c;
+  border-radius: 99px;
+  min-width: 1.4rem;
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.1rem 0.4rem;
+  align-self: center;
+}
+
+.thread {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.back {
+  background: none;
+  border: 0;
+  color: var(--boxel-teal);
+  font: inherit;
+  padding: 0.35rem 1.1rem;
+}
+
+.messages {
+  flex: 1;
+  padding-bottom: 0.5rem;
+}
+
+.bubble.you {
+  background: #163d33;
+  margin-left: 3.2rem;
+}
+
+.bubble .who {
+  font-size: 0.72rem;
+  color: var(--boxel-teal);
+  margin-bottom: 0.25rem;
+}
+
+.card-chip {
+  margin-top: 0.55rem;
+  background: #0b0c10;
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.7rem;
+  font-size: 0.82rem;
+}
+
+.composer {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.45rem;
+  padding: 0.55rem 0.85rem 0.2rem;
+}
+
+input,
+select,
+button.primary {
+  font: inherit;
+}
+
+input,
+select {
+  width: 100%;
+  background: #232530;
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 0.85rem;
+  padding: 0.7rem 0.8rem;
+}
+
+button.primary {
+  background: var(--boxel-teal);
+  color: #06281c;
+  border: 0;
+  border-radius: 0.85rem;
+  font-weight: 700;
+  padding: 0.7rem 0.95rem;
+}
+
+.search {
+  padding: 0 0.85rem 0.7rem;
+}
+
+.form {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0 0.85rem 0.9rem;
+}
+
+.sync-grid {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0 0.85rem;
+}
+
+.kv {
+  display: flex;
+  justify-content: space-between;
+  background: var(--row);
+  border-radius: 0.8rem;
+  padding: 0.7rem 0.9rem;
+}
+
+.action-push {
+  color: var(--boxel-teal);
+}
+
+.action-pull {
+  color: #8ec8ff;
+}
+
+.action-conflict {
+  color: #ffb45a;
+}
+
+.toolbar {
+  display: flex;
+  gap: 0.45rem;
+  padding: 0.85rem;
+}
+
+.toolbar button {
+  flex: 1;
+}
+
+.json-view {
+  white-space: pre-wrap;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: #c7d0e0;
+  margin: 0 0.85rem;
+  background: #15161c;
+  border-radius: 1rem;
+  padding: 0.9rem;
+}
+
+@media (max-width: 860px) {
+  .stage {
+    grid-template-columns: 1fr;
+    padding: 1.5rem 1rem 3rem;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Background and Goal

This adds a local, runnable prototype of an offline Boxel messenger that indexes realm card JSON files into SQLite and later reconciles with the same classify/push/pull rules as `boxel realm sync`. It is the data plane a NativeScript 9.1 iOS / Mac Catalyst app would share; it is not a replacement for the Ember host or for prerendered card execution.

The native Matrix client on that path is **matrix-sdk-rust** (UniFFI, SQLite store, same stack as Element X). `matrix-js-sdk` stays in the host. The prototype’s `rooms` / `messages` tables stand in for `matrix.sqlite` until that FFI is wired.

Search is **SQLite `boxel_index.search_doc`**, not the JSON files. Computed keys (`_title`, `fullName`, `initials`, `handle`) are stamped at index time and queried with `json_extract`. A query such as `MG` or `@maple.grove` hits the index and misses a filesystem scan of the JSON:API source.

## Where to start

- `docs/nativescript-offline-messenger.md` — feasibility, NativeScript 9.1 fit, rust-vs-JS Matrix choice, two-SQLite-file layout.
- `prototypes/boxel-native/core/` — filesystem, lite indexer (`boxel_index`), computed `search_doc`, sync-logic port, messenger stand-in.
- `prototypes/boxel-native/web-simulator/` — iPhone chrome UI. Run with `node web-simulator/server.mjs` and open http://127.0.0.1:4173/

## Key decisions and non-obvious mechanics

- Lite indexer writes `pristine_doc` plus a `search_doc` that includes computed fields the JSON file does not store. Search never greps realm files.
- Sync classify/push/pull is aligned with `packages/boxel-cli/src/lib/sync-logic.ts` (dependency-free copy in the prototype).
- Keep `boxel-index.sqlite` and `matrix.sqlite` separate. Card bytes move through realm file sync; chat attachments are Matrix events pointing at a realm URL.
- This Linux environment cannot run the iOS Simulator. The web iPhone chrome plus `node:sqlite` is the local stand-in; `ns debug ios` on a Mac with Xcode is the NativeScript 9.1 path.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b58db699-dcca-4499-be85-2e5a0a739d55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b58db699-dcca-4499-be85-2e5a0a739d55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

