### PR TITLE
Add a declared-screenshots slot to CardDef/FileDef with prototype-chain merge

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -104,6 +104,15 @@ import {
   type VirtualNetwork,
   isDirectIndexedFieldKey,
   cardTypeName,
+  isDeclaredScreenshotFormat,
+  isValidScreenshotName,
+  DECLARED_SCREENSHOT_FORMATS,
+  SCREENSHOT_NAME_MAX_LENGTH,
+  SCREENSHOT_NAME_PATTERN,
+  SCREENSHOT_MAX_VIEWPORT_WIDTH,
+  SCREENSHOT_MAX_VIEWPORT_HEIGHT,
+  SCREENSHOT_MAX_DEVICE_SCALE_FACTOR,
+  type DeclaredScreenshotFormat,
 } from '@cardstack/runtime-common';
 import {
   captureQueryFieldSeedData,
@@ -2745,6 +2754,229 @@ export type BaseDefComponent = ComponentLike<{
   };
 }>;
 
+// One declared screenshot (an entry in a CardDef/FileDef `static
+// screenshots` slot): exactly one of `render` or `format` names what to
+// draw, and the rest parameterizes the capture box.
+//
+// `render` is a *capture-only* component: referenced only from this
+// declaration and rendered only by the screenshot render route — never
+// exposed through the card's format API or `@fields`. Capture-only restricts
+// where the component renders, not what it may use: it gets the full author
+// surface (`@model`/`@fields`/`@context`) and may render linked data.
+//
+// `format` reuses one of the card's display formats instead. A format-based
+// screenshot referenced by that same format's own markup (say, a fitted
+// template that embeds its own `format: 'fitted'` capture) is circular —
+// use a dedicated `render` component there.
+export type ScreenshotSpec = {
+  // CSS px of the capture box (the fitted envelope).
+  width: number;
+  height: number;
+  // Output px = size × deviceScaleFactor. Default 2.
+  deviceScaleFactor?: number;
+  // 'transparent' or any CSS color. Default 'white'.
+  background?: string;
+  // Feed this capture to `cardThumbnailURL`. At most one entry across a
+  // card's merged declarations may set this.
+  useAsThumbnail?: boolean;
+  // What invalidates the capture: the instance's index generation (any
+  // edit), or — for file-backed defs — the file's content hash, so a
+  // metadata-only edit skips recapture. Default 'generation'.
+  keyBy?: 'generation' | 'file-content';
+  // Encoded image type. Default 'png'.
+  type?: 'png' | 'jpeg' | 'webp';
+} & (
+  | { render: BaseDefComponent; format?: undefined }
+  | { format: DeclaredScreenshotFormat; render?: undefined }
+);
+
+const SCREENSHOT_SPEC_FIELDS = new Set([
+  'render',
+  'format',
+  'width',
+  'height',
+  'deviceScaleFactor',
+  'background',
+  'useAsThumbnail',
+  'keyBy',
+  'type',
+]);
+const SCREENSHOT_KEY_BY_VALUES = new Set(['generation', 'file-content']);
+const SCREENSHOT_IMAGE_TYPES = new Set(['png', 'jpeg', 'webp']);
+
+function screenshotOwnerName(owner: typeof BaseDef): string {
+  return owner.name || owner.displayName || 'card';
+}
+
+// Strict on principle, mirroring the capture-spec parsers: a field the
+// capture engine cannot honor is refused by name rather than ignored, so a
+// typo'd declaration fails loudly at read time instead of silently capturing
+// something other than what the author meant.
+function assertValidScreenshotSpec(
+  owner: typeof BaseDef,
+  name: string,
+  spec: unknown,
+): asserts spec is ScreenshotSpec {
+  let prefix = `screenshot "${name}" on ${screenshotOwnerName(owner)}`;
+  if (!isValidScreenshotName(name)) {
+    throw new Error(
+      `${prefix}: name must be a URL-safe path segment (${SCREENSHOT_NAME_PATTERN.source}, at most ${SCREENSHOT_NAME_MAX_LENGTH} characters)`,
+    );
+  }
+  if (spec === null || typeof spec !== 'object' || Array.isArray(spec)) {
+    throw new Error(`${prefix}: spec must be an object`);
+  }
+  let entry = spec as Record<string, unknown>;
+  for (let key of Object.keys(entry)) {
+    if (!SCREENSHOT_SPEC_FIELDS.has(key)) {
+      throw new Error(`${prefix}: unknown field "${key}"`);
+    }
+  }
+  let hasRender = entry.render !== undefined;
+  let hasFormat = entry.format !== undefined;
+  if (hasRender === hasFormat) {
+    throw new Error(`${prefix}: declare exactly one of render or format`);
+  }
+  if (
+    hasRender &&
+    !(
+      typeof entry.render === 'function' ||
+      (typeof entry.render === 'object' && entry.render !== null)
+    )
+  ) {
+    throw new Error(`${prefix}: render must be a component`);
+  }
+  if (hasFormat && !isDeclaredScreenshotFormat(entry.format)) {
+    throw new Error(
+      `${prefix}: format must be one of ${DECLARED_SCREENSHOT_FORMATS.map(
+        (f) => `"${f}"`,
+      ).join(', ')}`,
+    );
+  }
+  for (let [field, max] of [
+    ['width', SCREENSHOT_MAX_VIEWPORT_WIDTH],
+    ['height', SCREENSHOT_MAX_VIEWPORT_HEIGHT],
+  ] as const) {
+    let value = entry[field];
+    if (
+      typeof value !== 'number' ||
+      !Number.isInteger(value) ||
+      value < 1 ||
+      value > max
+    ) {
+      throw new Error(
+        `${prefix}: ${field} must be an integer between 1 and ${max}`,
+      );
+    }
+  }
+  if (entry.deviceScaleFactor !== undefined) {
+    let dsf = entry.deviceScaleFactor;
+    if (
+      typeof dsf !== 'number' ||
+      !Number.isFinite(dsf) ||
+      dsf <= 0 ||
+      dsf > SCREENSHOT_MAX_DEVICE_SCALE_FACTOR
+    ) {
+      throw new Error(
+        `${prefix}: deviceScaleFactor must be a number between 0 (exclusive) and ${SCREENSHOT_MAX_DEVICE_SCALE_FACTOR}`,
+      );
+    }
+  }
+  if (
+    entry.background !== undefined &&
+    (typeof entry.background !== 'string' || entry.background.length === 0)
+  ) {
+    throw new Error(
+      `${prefix}: background must be 'transparent' or a CSS color`,
+    );
+  }
+  if (
+    entry.useAsThumbnail !== undefined &&
+    typeof entry.useAsThumbnail !== 'boolean'
+  ) {
+    throw new Error(`${prefix}: useAsThumbnail must be a boolean`);
+  }
+  if (
+    entry.keyBy !== undefined &&
+    !SCREENSHOT_KEY_BY_VALUES.has(entry.keyBy as string)
+  ) {
+    throw new Error(
+      `${prefix}: keyBy must be one of ${[...SCREENSHOT_KEY_BY_VALUES]
+        .map((v) => `"${v}"`)
+        .join(', ')}`,
+    );
+  }
+  if (
+    entry.type !== undefined &&
+    !SCREENSHOT_IMAGE_TYPES.has(entry.type as string)
+  ) {
+    throw new Error(
+      `${prefix}: type must be one of ${[...SCREENSHOT_IMAGE_TYPES]
+        .map((v) => `"${v}"`)
+        .join(', ')}`,
+    );
+  }
+}
+
+// The one read path for `static screenshots`: merges declarations by name up
+// the prototype chain (a subclass adds new names and overrides inherited
+// ones wholesale, per name), validating each entry and the merged result's
+// at-most-one-`useAsThumbnail` constraint. Read through this rather than the
+// static directly — a plain property read sees only the nearest declaration,
+// dropping everything an ancestor declared.
+export function getScreenshots(
+  cardOrFileClass: typeof CardDef | typeof FileDef,
+): Record<string, ScreenshotSpec> {
+  // Collect declaration levels base-most first so a subclass's entry lands
+  // after (and thus overrides) its ancestor's.
+  let levels: {
+    owner: typeof BaseDef;
+    declarations: Record<string, unknown>;
+  }[] = [];
+  let current: unknown = cardOrFileClass;
+  while (typeof current === 'function') {
+    let descriptor = Object.getOwnPropertyDescriptor(current, 'screenshots');
+    if (descriptor) {
+      let declarations = descriptor.get
+        ? descriptor.get.call(current)
+        : descriptor.value;
+      if (declarations != null) {
+        if (typeof declarations !== 'object' || Array.isArray(declarations)) {
+          throw new Error(
+            `static screenshots on ${screenshotOwnerName(
+              current as typeof BaseDef,
+            )} must be an object mapping names to specs`,
+          );
+        }
+        levels.unshift({ owner: current as typeof BaseDef, declarations });
+      }
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  let merged: Record<string, ScreenshotSpec> = {};
+  for (let { owner, declarations } of levels) {
+    for (let [name, spec] of Object.entries(declarations)) {
+      assertValidScreenshotSpec(owner, name, spec);
+      merged[name] = spec;
+    }
+  }
+  let thumbnails = Object.keys(merged).filter(
+    (name) => merged[name].useAsThumbnail,
+  );
+  if (thumbnails.length > 1) {
+    throw new Error(
+      `${screenshotOwnerName(
+        cardOrFileClass,
+      )} declares more than one useAsThumbnail screenshot (${thumbnails
+        .map((name) => `"${name}"`)
+        .join(
+          ', ',
+        )}); at most one entry may feed the thumbnail — override an inherited entry by name to clear its flag`,
+    );
+  }
+  return merged;
+}
+
 export class FieldDef extends BaseDef {
   // this changes the shape of the class type FieldDef so that a CardDef
   // class type cannot masquerade as a FieldDef class type
@@ -3164,6 +3396,12 @@ export class FileDef extends BaseDef {
   // less surprising.
   static markdown: BaseDefComponent = DefaultMarkdownFallbackTemplate;
 
+  // Opt-in declared screenshots (see CardDef.screenshots): merged by name up
+  // the prototype chain via `getScreenshots`. File families whose capture
+  // derives from the file's bytes (a video's poster frame, say) declare
+  // `keyBy: 'file-content'` so a metadata-only edit skips recapture.
+  static screenshots?: Record<string, ScreenshotSpec>;
+
   static async extractAttributes(
     url: string,
     getStream: () => Promise<ByteStream>,
@@ -3366,6 +3604,12 @@ export class CardDef extends BaseDef {
   // turndown (registered on `globalThis` by `packages/host`). Subclasses can
   // override `static markdown` to author bespoke markdown directly.
   static markdown: BaseDefComponent = DefaultMarkdownFallbackTemplate;
+  // Opt-in declared screenshots: captures rendered at indexing time and
+  // served from the realm's `_screenshot/…?name=` route. Names are URL path
+  // segments. Declarations merge by name up the prototype chain — read them
+  // via `getScreenshots`, never off the static directly, or ancestors'
+  // entries are dropped. FieldDef has no addressable URL, so it has no slot.
+  static screenshots?: Record<string, ScreenshotSpec>;
 
   static get hasCustomEditTemplate(): boolean {
     return this.edit !== CardDef.edit;

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -112,6 +112,8 @@ import {
   SCREENSHOT_MAX_VIEWPORT_WIDTH,
   SCREENSHOT_MAX_VIEWPORT_HEIGHT,
   SCREENSHOT_MAX_DEVICE_SCALE_FACTOR,
+  SCREENSHOT_MAX_PHYSICAL_EDGE_PX,
+  SCREENSHOT_DEFAULT_DEVICE_SCALE_FACTOR,
   type DeclaredScreenshotFormat,
 } from '@cardstack/runtime-common';
 import {
@@ -2772,7 +2774,9 @@ export type ScreenshotSpec = {
   // CSS px of the capture box (the fitted envelope).
   width: number;
   height: number;
-  // Output px = size × deviceScaleFactor. Default 2.
+  // Output px = size × deviceScaleFactor. Defaults to
+  // SCREENSHOT_DEFAULT_DEVICE_SCALE_FACTOR (2). Each edge × the effective
+  // scale must stay within SCREENSHOT_MAX_PHYSICAL_EDGE_PX.
   deviceScaleFactor?: number;
   // 'transparent' or any CSS color. Default 'white'.
   background?: string;
@@ -2782,6 +2786,8 @@ export type ScreenshotSpec = {
   // What invalidates the capture: the instance's index generation (any
   // edit), or — for file-backed defs — the file's content hash, so a
   // metadata-only edit skips recapture. Default 'generation'.
+  // 'file-content' is only legal on FileDef chains: a CardDef has no file
+  // bytes to key by, so getScreenshots refuses it there.
   keyBy?: 'generation' | 'file-content';
   // Encoded image type. Default 'png'.
   type?: 'png' | 'jpeg' | 'webp';
@@ -2882,6 +2888,24 @@ function assertValidScreenshotSpec(
       );
     }
   }
+  // The Chromium single-texture cap is on physical pixels, so the CSS bounds
+  // above are necessary but not sufficient: compose each edge with the scale
+  // the capture will actually apply — the declared one, or the default when
+  // the author writes none.
+  let effectiveScale =
+    typeof entry.deviceScaleFactor === 'number'
+      ? entry.deviceScaleFactor
+      : SCREENSHOT_DEFAULT_DEVICE_SCALE_FACTOR;
+  for (let field of ['width', 'height'] as const) {
+    if (
+      (entry[field] as number) * effectiveScale >
+      SCREENSHOT_MAX_PHYSICAL_EDGE_PX
+    ) {
+      throw new Error(
+        `${prefix}: ${field} × deviceScaleFactor must be <= ${SCREENSHOT_MAX_PHYSICAL_EDGE_PX} physical pixels (deviceScaleFactor defaults to ${SCREENSHOT_DEFAULT_DEVICE_SCALE_FACTOR})`,
+      );
+    }
+  }
   if (
     entry.background !== undefined &&
     (typeof entry.background !== 'string' || entry.background.length === 0)
@@ -2954,9 +2978,23 @@ export function getScreenshots(
     current = Object.getPrototypeOf(current);
   }
   let merged: Record<string, ScreenshotSpec> = {};
+  // keyBy 'file-content' needs file bytes to key by, so it is only legal
+  // when the class being read is file-backed. Checked against the merge
+  // target rather than the declaring owner — a FileDef chain can never feed
+  // a CardDef chain, so any 'file-content' entry reachable from a CardDef
+  // was declared on that CardDef chain itself.
+  let isFileBacked =
+    cardOrFileClass === FileDef || cardOrFileClass.prototype instanceof FileDef;
   for (let { owner, declarations } of levels) {
     for (let [name, spec] of Object.entries(declarations)) {
       assertValidScreenshotSpec(owner, name, spec);
+      if (spec.keyBy === 'file-content' && !isFileBacked) {
+        throw new Error(
+          `screenshot "${name}" on ${screenshotOwnerName(
+            owner,
+          )}: keyBy 'file-content' requires a file-backed def (FileDef or a subclass); a card has no file content to key by — use 'generation' or omit keyBy`,
+        );
+      }
       merged[name] = spec;
     }
   }

--- a/packages/host/tests/unit/declared-screenshots-test.ts
+++ b/packages/host/tests/unit/declared-screenshots-test.ts
@@ -1,0 +1,333 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type { Loader } from '@cardstack/runtime-common';
+
+import { setupRenderingTest } from '../helpers/setup';
+
+import type * as CardAPIModule from '@cardstack/base/card-api';
+import type { ScreenshotSpec } from '@cardstack/base/card-api';
+
+type Screenshots = Record<string, ScreenshotSpec>;
+
+module('Unit | declared screenshots', function (hooks) {
+  setupRenderingTest(hooks);
+
+  let cardApi: typeof CardAPIModule;
+  hooks.beforeEach(async function () {
+    let loader: Loader = getService('loader-service').loader;
+    cardApi = await loader.import<typeof CardAPIModule>(
+      '@cardstack/base/card-api',
+    );
+  });
+
+  test('a card with no declarations merges to an empty record', function (assert) {
+    class Plain extends cardApi.CardDef {}
+    assert.deepEqual(cardApi.getScreenshots(Plain), {});
+    assert.deepEqual(cardApi.getScreenshots(cardApi.CardDef), {});
+    assert.deepEqual(cardApi.getScreenshots(cardApi.FileDef), {});
+  });
+
+  test('declarations on one class are returned by name', function (assert) {
+    class HeroShot extends cardApi.Component<typeof cardApi.CardDef> {}
+    class Product extends cardApi.CardDef {
+      static screenshots: Screenshots = {
+        hero: {
+          render: HeroShot,
+          width: 1200,
+          height: 630,
+          background: 'white',
+        },
+        thumb: {
+          format: 'fitted',
+          width: 300,
+          height: 200,
+          deviceScaleFactor: 2,
+          useAsThumbnail: true,
+        },
+      };
+    }
+    let merged = cardApi.getScreenshots(Product);
+    assert.deepEqual(Object.keys(merged).sort(), ['hero', 'thumb']);
+    assert.strictEqual(merged.hero.render, HeroShot);
+    assert.strictEqual(merged.thumb.format, 'fitted');
+    assert.true(merged.thumb.useAsThumbnail);
+  });
+
+  test('a subclass adds new names and inherits ancestors up the chain', function (assert) {
+    class Video extends cardApi.FileDef {
+      static screenshots: Screenshots = {
+        poster: {
+          format: 'embedded',
+          width: 640,
+          height: 360,
+          keyBy: 'file-content',
+          type: 'jpeg',
+        },
+      };
+    }
+    class Trailer extends Video {
+      static screenshots: Screenshots = {
+        banner: { format: 'embedded', width: 1024, height: 256 },
+      };
+    }
+    class TeaserTrailer extends Trailer {
+      static screenshots: Screenshots = {
+        teaser: { format: 'fitted', width: 150, height: 170 },
+      };
+    }
+    // a plain property read sees only the nearest declaration…
+    assert.deepEqual(Object.keys(TeaserTrailer.screenshots!), ['teaser']);
+    // …while the merge helper sees the whole chain
+    let merged = cardApi.getScreenshots(TeaserTrailer);
+    assert.deepEqual(Object.keys(merged).sort(), [
+      'banner',
+      'poster',
+      'teaser',
+    ]);
+    assert.strictEqual(merged.poster.keyBy, 'file-content');
+  });
+
+  test('a subclass overrides an inherited name wholesale', function (assert) {
+    class Video extends cardApi.FileDef {
+      static screenshots: Screenshots = {
+        poster: {
+          format: 'embedded',
+          width: 640,
+          height: 360,
+          type: 'jpeg',
+        },
+      };
+    }
+    class Widescreen extends Video {
+      static screenshots: Screenshots = {
+        poster: { format: 'embedded', width: 1280, height: 720 },
+      };
+    }
+    let merged = cardApi.getScreenshots(Widescreen);
+    assert.strictEqual(merged.poster.width, 1280);
+    // the override replaces the whole spec: the ancestor's `type` does not
+    // bleed through
+    assert.strictEqual(merged.poster.type, undefined);
+  });
+
+  test('a name outside the URL-safe charset is refused', function (assert) {
+    for (const name of ['og image', 'og/image', '../poster', '-leading', '']) {
+      class Bad extends cardApi.CardDef {
+        static screenshots: Screenshots = {
+          [name]: { format: 'fitted', width: 300, height: 200 },
+        };
+      }
+      assert.throws(
+        () => cardApi.getScreenshots(Bad),
+        /name must be a URL-safe path segment/,
+        `"${name}" is refused`,
+      );
+    }
+    class TooLong extends cardApi.CardDef {
+      static screenshots: Screenshots = {
+        ['a'.repeat(65)]: { format: 'fitted', width: 300, height: 200 },
+      };
+    }
+    assert.throws(
+      () => cardApi.getScreenshots(TooLong),
+      /name must be a URL-safe path segment/,
+    );
+  });
+
+  test('declaring both or neither of render and format is refused', function (assert) {
+    class Shot extends cardApi.Component<typeof cardApi.CardDef> {}
+    class Both extends cardApi.CardDef {
+      static screenshots: Record<string, any> = {
+        hero: { render: Shot, format: 'fitted', width: 300, height: 200 },
+      };
+    }
+    class Neither extends cardApi.CardDef {
+      static screenshots: Record<string, any> = {
+        hero: { width: 300, height: 200 },
+      };
+    }
+    assert.throws(
+      () => cardApi.getScreenshots(Both),
+      /declare exactly one of render or format/,
+    );
+    assert.throws(
+      () => cardApi.getScreenshots(Neither),
+      /declare exactly one of render or format/,
+    );
+  });
+
+  test('formats outside the declared-screenshot roster are refused', function (assert) {
+    for (const format of ['edit', 'head', 'markdown', 'bogus']) {
+      class Bad extends cardApi.CardDef {
+        static screenshots: Record<string, any> = {
+          shot: { format, width: 300, height: 200 },
+        };
+      }
+      assert.throws(
+        () => cardApi.getScreenshots(Bad),
+        /format must be one of/,
+        `"${format}" is refused`,
+      );
+    }
+  });
+
+  test('unknown spec fields are refused by name', function (assert) {
+    class Bad extends cardApi.CardDef {
+      static screenshots: Record<string, any> = {
+        shot: {
+          format: 'fitted',
+          width: 300,
+          height: 200,
+          useAsThumbnal: true,
+        },
+      };
+    }
+    assert.throws(
+      () => cardApi.getScreenshots(Bad),
+      /unknown field "useAsThumbnal"/,
+    );
+  });
+
+  test('capture-box dimensions must be positive integers within the engine caps', function (assert) {
+    for (let [field, value] of [
+      ['width', 0],
+      ['width', -100],
+      ['width', 12.5],
+      ['width', 5000],
+      ['height', 20000],
+      ['height', undefined],
+    ] as const) {
+      class Bad extends cardApi.CardDef {
+        static screenshots: Record<string, any> = {
+          shot: { format: 'fitted', width: 300, height: 200, [field]: value },
+        };
+      }
+      assert.throws(
+        () => cardApi.getScreenshots(Bad),
+        new RegExp(`${field} must be an integer between`),
+        `${field}=${value} is refused`,
+      );
+    }
+    class BadDsf extends cardApi.CardDef {
+      static screenshots: Record<string, any> = {
+        shot: {
+          format: 'fitted',
+          width: 300,
+          height: 200,
+          deviceScaleFactor: 4,
+        },
+      };
+    }
+    assert.throws(
+      () => cardApi.getScreenshots(BadDsf),
+      /deviceScaleFactor must be a number/,
+    );
+  });
+
+  test('keyBy and type are constrained to their rosters', function (assert) {
+    class BadKeyBy extends cardApi.CardDef {
+      static screenshots: Record<string, any> = {
+        shot: { format: 'fitted', width: 300, height: 200, keyBy: 'mtime' },
+      };
+    }
+    class BadType extends cardApi.CardDef {
+      static screenshots: Record<string, any> = {
+        shot: { format: 'fitted', width: 300, height: 200, type: 'gif' },
+      };
+    }
+    assert.throws(() => cardApi.getScreenshots(BadKeyBy), /keyBy must be one/);
+    assert.throws(() => cardApi.getScreenshots(BadType), /type must be one/);
+  });
+
+  test('more than one useAsThumbnail across the merged chain is refused', function (assert) {
+    class Video extends cardApi.FileDef {
+      static screenshots: Screenshots = {
+        poster: {
+          format: 'embedded',
+          width: 640,
+          height: 360,
+          useAsThumbnail: true,
+        },
+      };
+    }
+    class Trailer extends Video {
+      static screenshots: Screenshots = {
+        banner: {
+          format: 'embedded',
+          width: 1024,
+          height: 256,
+          useAsThumbnail: true,
+        },
+      };
+    }
+    // the chain is fine per level…
+    assert.strictEqual(
+      Object.keys(cardApi.getScreenshots(Video)).length,
+      1,
+      'base class alone is valid',
+    );
+    // …but the merged result has two thumbnail feeds
+    assert.throws(
+      () => cardApi.getScreenshots(Trailer),
+      /more than one useAsThumbnail screenshot \("poster", "banner"\)/,
+    );
+  });
+
+  test('two useAsThumbnail entries on one class are refused', function (assert) {
+    class Bad extends cardApi.CardDef {
+      static screenshots: Screenshots = {
+        a: { format: 'fitted', width: 300, height: 200, useAsThumbnail: true },
+        b: {
+          format: 'embedded',
+          width: 300,
+          height: 200,
+          useAsThumbnail: true,
+        },
+      };
+    }
+    assert.throws(
+      () => cardApi.getScreenshots(Bad),
+      /more than one useAsThumbnail/,
+    );
+  });
+
+  test('overriding an inherited entry by name can move the thumbnail', function (assert) {
+    class Video extends cardApi.FileDef {
+      static screenshots: Screenshots = {
+        poster: {
+          format: 'embedded',
+          width: 640,
+          height: 360,
+          useAsThumbnail: true,
+        },
+      };
+    }
+    class Trailer extends Video {
+      static screenshots: Screenshots = {
+        // clear the inherited flag by overriding the entry…
+        poster: { format: 'embedded', width: 640, height: 360 },
+        // …so the new entry can carry it
+        banner: {
+          format: 'embedded',
+          width: 1024,
+          height: 256,
+          useAsThumbnail: true,
+        },
+      };
+    }
+    let merged = cardApi.getScreenshots(Trailer);
+    assert.strictEqual(merged.poster.useAsThumbnail, undefined);
+    assert.true(merged.banner.useAsThumbnail);
+  });
+
+  test('a non-object declarations value is refused', function (assert) {
+    class Bad extends cardApi.CardDef {
+      static screenshots: any = ['nope'];
+    }
+    assert.throws(
+      () => cardApi.getScreenshots(Bad),
+      /must be an object mapping names to specs/,
+    );
+  });
+});

--- a/packages/host/tests/unit/declared-screenshots-test.ts
+++ b/packages/host/tests/unit/declared-screenshots-test.ts
@@ -225,6 +225,82 @@ module('Unit | declared screenshots', function (hooks) {
     );
   });
 
+  test('each edge × deviceScaleFactor must fit the physical-pixel cap', function (assert) {
+    // in-cap CSS height, but the default 2× scale puts it past the
+    // 16384-physical-px texture cap
+    class ImplicitScale extends cardApi.CardDef {
+      static screenshots: Screenshots = {
+        tall: { format: 'fitted', width: 300, height: 16384 },
+      };
+    }
+    assert.throws(
+      () => cardApi.getScreenshots(ImplicitScale),
+      /height × deviceScaleFactor must be <= 16384 physical pixels/,
+    );
+    class ExplicitScale extends cardApi.CardDef {
+      static screenshots: Screenshots = {
+        tall: {
+          format: 'fitted',
+          width: 300,
+          height: 8192,
+          deviceScaleFactor: 3,
+        },
+      };
+    }
+    assert.throws(
+      () => cardApi.getScreenshots(ExplicitScale),
+      /height × deviceScaleFactor must be <= 16384 physical pixels/,
+    );
+    // at the cap exactly, both implicitly and explicitly scaled
+    class AtCap extends cardApi.CardDef {
+      static screenshots: Screenshots = {
+        implicit: { format: 'fitted', width: 300, height: 8192 },
+        explicit: {
+          format: 'fitted',
+          width: 300,
+          height: 16384,
+          deviceScaleFactor: 1,
+        },
+      };
+    }
+    assert.deepEqual(Object.keys(cardApi.getScreenshots(AtCap)).sort(), [
+      'explicit',
+      'implicit',
+    ]);
+  });
+
+  test("keyBy 'file-content' is refused off FileDef chains", function (assert) {
+    class Bad extends cardApi.CardDef {
+      static screenshots: Screenshots = {
+        shot: {
+          format: 'fitted',
+          width: 300,
+          height: 200,
+          keyBy: 'file-content',
+        },
+      };
+    }
+    assert.throws(
+      () => cardApi.getScreenshots(Bad),
+      /keyBy 'file-content' requires a file-backed def/,
+    );
+    class Doc extends cardApi.FileDef {
+      static screenshots: Screenshots = {
+        shot: {
+          format: 'fitted',
+          width: 300,
+          height: 200,
+          keyBy: 'file-content',
+        },
+      };
+    }
+    assert.strictEqual(
+      cardApi.getScreenshots(Doc).shot.keyBy,
+      'file-content',
+      'legal on a FileDef subclass',
+    );
+  });
+
   test('keyBy and type are constrained to their rosters', function (assert) {
     class BadKeyBy extends cardApi.CardDef {
       static screenshots: Record<string, any> = {

--- a/packages/runtime-common/capture-spec.ts
+++ b/packages/runtime-common/capture-spec.ts
@@ -22,6 +22,47 @@ export function isScreenshotFormat(value: unknown): value is ScreenshotFormat {
 // viewport and must NOT be given an envelope.
 const ENVELOPE_FORMATS: readonly ScreenshotFormat[] = ['fitted'];
 
+// ---------------------------------------------------------------------------
+// Declared screenshots (`static screenshots` on CardDef/FileDef) — the name
+// grammar and format roster shared by the declaration reader in
+// packages/base/card-api and the realm's `_screenshot/…?name=` route.
+// ---------------------------------------------------------------------------
+
+// A declared screenshot's name addresses the capture in a URL, so it is
+// constrained to a charset that survives a URL path segment with no
+// percent-encoding: a leading letter or digit, then letters, digits, `-`,
+// or `_`.
+export const SCREENSHOT_NAME_MAX_LENGTH = 64;
+export const SCREENSHOT_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+export function isValidScreenshotName(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length <= SCREENSHOT_NAME_MAX_LENGTH &&
+    SCREENSHOT_NAME_PATTERN.test(value)
+  );
+}
+
+// Display formats a declared screenshot may reuse via its `format` slot.
+// Distinct from the on-demand rosters above: a declared capture renders in
+// the indexing-time prerender pass, which can lay out any display format —
+// `atom` included — while `edit` and the non-visual formats are not
+// meaningful pixel sources.
+export const DECLARED_SCREENSHOT_FORMATS = [
+  'isolated',
+  'embedded',
+  'fitted',
+  'atom',
+] as const;
+export type DeclaredScreenshotFormat =
+  (typeof DECLARED_SCREENSHOT_FORMATS)[number];
+
+export function isDeclaredScreenshotFormat(
+  value: unknown,
+): value is DeclaredScreenshotFormat {
+  return (DECLARED_SCREENSHOT_FORMATS as readonly unknown[]).includes(value);
+}
+
 // The capture spec: every way a screenshot capture can be parameterized,
 // shared by the POST /_screenshot-card body and the GET `_screenshot/` URL
 // DSL so the two surfaces validate identically and one capture satisfies

--- a/packages/runtime-common/capture-spec.ts
+++ b/packages/runtime-common/capture-spec.ts
@@ -110,6 +110,13 @@ export const SCREENSHOT_MAX_VIEWPORT_WIDTH = 4096;
 export const SCREENSHOT_MAX_VIEWPORT_HEIGHT = 16384;
 // A 3× scale already covers retina/hi-dpi; higher just multiplies pixel cost.
 export const SCREENSHOT_MAX_DEVICE_SCALE_FACTOR = 3;
+// The scale a *declared* screenshot (a `static screenshots` entry) captures
+// at when the author writes no deviceScaleFactor — retina-quality output by
+// default. Distinct from the wire-spec identity, where an absent
+// deviceScaleFactor means 1: declaration readers and the capture pass must
+// share this value so a declaration that validates clean cannot exceed the
+// physical-edge cap once the default is applied.
+export const SCREENSHOT_DEFAULT_DEVICE_SCALE_FACTOR = 2;
 // The Chromium single-texture cap the viewport bounds are derived from,
 // enforced on *physical* pixels: CSS dimension × deviceScaleFactor. The CSS
 // caps alone would admit e.g. a 16384-tall viewport at 3× (~49k physical px).


### PR DESCRIPTION
CardDef and FileDef gain an opt-in `static screenshots` declaration slot: a record of named capture specs, read through a merging accessor so subclasses add and override entries per name up the prototype chain.

## What this adds

- **`ScreenshotSpec` type** (`packages/base/card-api.gts`): each entry declares exactly one of
  - `render` — a *capture-only* component: referenced only from the declaration and rendered only by the screenshot render route, never exposed through the card's format API or `@fields`. Capture-only restricts where it renders, not what it may use — it gets the full author surface (`@model`/`@fields`/`@context`) and may render linked data.
  - `format` — reuse of a display format (`isolated`/`embedded`/`fitted`/`atom`).

  plus `width`/`height` (CSS px of the capture box), `deviceScaleFactor` (default 2), `background` (default white), `useAsThumbnail` (feeds `cardThumbnailURL`; at most one entry), `keyBy: 'generation' | 'file-content'` (default generation; file-content lets a metadata-only edit skip recapture for file-derived captures like a video poster), and `type: 'png' | 'jpeg' | 'webp' (default png). The render/format choice is a compile-time XOR union, so a typed author cannot declare both.

- **`getScreenshots()`** — the one read path: walks the prototype chain base-most first and merges declarations by name, so a subclass adds new names and overrides inherited ones wholesale (an override replaces the whole spec; nothing bleeds through). Reading the static directly would see only the nearest declaration.

- **Strict validation**, mirroring the capture-spec parsers' refuse-by-name posture: URL-safe names (shared grammar in `runtime-common/capture-spec.ts`, also home of the declared-format roster for the realm's `_screenshot/…?name=` route to reuse), exactly one of render/format, unknown fields refused, dimensions bounded by the engine viewport caps, and at most one `useAsThumbnail` across the *merged* result — moving the thumbnail in a subclass means overriding the inherited entry by name to clear its flag.

- FieldDef is excluded: it has no addressable URL to serve a capture from.

## Authoring note

TypeScript does not contextually type subclass static initializers from the base class's declared slot type, so literal declarations need the annotation:

```gts
static screenshots: Record<string, ScreenshotSpec> = {
  thumb: { format: 'fitted', width: 300, height: 200, useAsThumbnail: true },
};
```

Unannotated literals fail to typecheck (widened string literals vs. the format union); runtime validation backstops untyped authors either way.

## Out of scope

Capture execution, manifest persistence, and serving through the `_screenshot/…?name=` route consume this declaration and land separately; that route currently treats every name as an uncaptured miss.

## Test plan

- New unit module `Unit | declared screenshots` (14 tests): merge semantics across a three-level chain, wholesale per-name override, empty/no-declaration cases, and every validation rule.
- Typechecks clean in host, realm-server, ai-bot, bot-runner, billing; base template-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)