### PR TITLE
Say what the definition lookup's second key is for

### DIFF
--- a/packages/host/tests/unit/internal-key-canonicalization-test.ts
+++ b/packages/host/tests/unit/internal-key-canonicalization-test.ts
@@ -1,0 +1,119 @@
+import { module, test } from 'qunit';
+
+import { VirtualNetwork, internalKeyFor, rri } from '@cardstack/runtime-common';
+
+const REAL_BASE = 'https://realms.example.test/base/';
+const ALIAS_BASE = 'https://cardstack.com/base/';
+const REAL_CATALOG = 'https://realms.example.test/catalog/';
+
+// The definition store is keyed by `internalKeyFor`, and the lookup does a
+// single keyed read. That is only correct because `internalKeyFor` is a
+// canonicalization rather than a formatting choice: it resolves the module
+// reference to a real URL and unresolves that back through the registered realm
+// mappings, so every spelling of one module reduces to one string. If that ever
+// stopped holding, a definition would be stored under a key no lookup produces
+// — a miss that surfaces as "definition not found" rather than as a form bug.
+module('Unit | internalKeyFor canonicalization', function () {
+  function configuredNetwork() {
+    let virtualNetwork = new VirtualNetwork();
+    // Registered the way every process on the definition-lookup path does it:
+    // the base realm gets both its alias URL mapping and its prefix mapping,
+    // other prefix realms just the prefix.
+    virtualNetwork.addURLMapping(new URL(ALIAS_BASE), new URL(REAL_BASE));
+    virtualNetwork.addRealmMapping('@cardstack/base/', REAL_BASE);
+    virtualNetwork.addRealmMapping('@cardstack/catalog/', REAL_CATALOG);
+    return virtualNetwork;
+  }
+
+  test('every spelling of a base-realm module yields one key', function (assert) {
+    let virtualNetwork = configuredNetwork();
+    let keys = [
+      '@cardstack/base/card-api',
+      `${ALIAS_BASE}card-api`,
+      `${REAL_BASE}card-api`,
+    ].map((module) =>
+      internalKeyFor(
+        { module: rri(module), name: 'CardDef' },
+        undefined,
+        virtualNetwork,
+      ),
+    );
+
+    assert.strictEqual(
+      new Set(keys).size,
+      1,
+      'the prefix, alias and served spellings agree',
+    );
+    assert.strictEqual(
+      keys[0],
+      '@cardstack/base/card-api/CardDef',
+      'and they agree on the prefix form, which is the stored key',
+    );
+  });
+
+  test('a realm with only a prefix mapping canonicalizes too', function (assert) {
+    let virtualNetwork = configuredNetwork();
+    let keys = ['@cardstack/catalog/listing', `${REAL_CATALOG}listing`].map(
+      (module) =>
+        internalKeyFor(
+          { module: rri(module), name: 'Listing' },
+          undefined,
+          virtualNetwork,
+        ),
+    );
+
+    assert.deepEqual(
+      keys,
+      [
+        '@cardstack/catalog/listing/Listing',
+        '@cardstack/catalog/listing/Listing',
+      ],
+      'a realm needs no alias for its two spellings to collapse',
+    );
+  });
+
+  test('the executable extension is trimmed out of the key', function (assert) {
+    let virtualNetwork = configuredNetwork();
+    assert.strictEqual(
+      internalKeyFor(
+        { module: rri('@cardstack/base/card-api.gts'), name: 'CardDef' },
+        undefined,
+        virtualNetwork,
+      ),
+      '@cardstack/base/card-api/CardDef',
+      'so a reference carrying .gts keys the same as one without',
+    );
+  });
+
+  test('an unregistered realm does not canonicalize, which is why the mappings matter', function (assert) {
+    // The negative case, recorded because it is the reason the prefix set has
+    // to be the same in every process: without the prefix mapping the alias and
+    // served spellings stay distinct, and neither becomes the prefix-form key
+    // that a configured process stores under.
+    let virtualNetwork = new VirtualNetwork();
+    virtualNetwork.addURLMapping(new URL(ALIAS_BASE), new URL(REAL_BASE));
+
+    let aliasKey = internalKeyFor(
+      { module: rri(`${ALIAS_BASE}card-api`), name: 'CardDef' },
+      undefined,
+      virtualNetwork,
+    );
+    let servedKey = internalKeyFor(
+      { module: rri(`${REAL_BASE}card-api`), name: 'CardDef' },
+      undefined,
+      virtualNetwork,
+    );
+
+    assert.notStrictEqual(
+      aliasKey,
+      servedKey,
+      'the two spellings split when no realm mapping covers them',
+    );
+    for (let key of [aliasKey, servedKey]) {
+      assert.false(
+        key.startsWith('@cardstack/base/'),
+        `${key} is not the prefix-form key a configured process would use`,
+      );
+    }
+  });
+});

--- a/packages/host/tests/unit/internal-key-canonicalization-test.ts
+++ b/packages/host/tests/unit/internal-key-canonicalization-test.ts
@@ -5,14 +5,19 @@ import { VirtualNetwork, internalKeyFor, rri } from '@cardstack/runtime-common';
 const REAL_BASE = 'https://realms.example.test/base/';
 const ALIAS_BASE = 'https://cardstack.com/base/';
 const REAL_CATALOG = 'https://realms.example.test/catalog/';
+// A realm reached by a URL mapping with no prefix of its own, the shape the
+// test realm takes in environment mode.
+const VIRTUAL_TEST = 'https://localhost:4202/test/';
+const REAL_TEST = 'https://realm-test.example.test/test/';
 
-// The definition store is keyed by `internalKeyFor`, and the lookup does a
-// single keyed read. That is only correct because `internalKeyFor` is a
-// canonicalization rather than a formatting choice: it resolves the module
+// The definition store is keyed by `internalKeyFor`, which resolves a module
 // reference to a real URL and unresolves that back through the registered realm
-// mappings, so every spelling of one module reduces to one string. If that ever
-// stopped holding, a definition would be stored under a key no lookup produces
-// — a miss that surfaces as "definition not found" rather than as a form bug.
+// mappings. Whether that collapses every spelling of one module into one key
+// depends on the realm having a prefix mapping, and `definitionEntryFor` reads
+// under two keys precisely because some realms do not have one. These tests pin
+// both halves of that, because the difference decides whether a definition can
+// be stored under a key no lookup produces — a miss that surfaces as
+// "definition not found" rather than as anything recognisable as a form bug.
 module('Unit | internalKeyFor canonicalization', function () {
   function configuredNetwork() {
     let virtualNetwork = new VirtualNetwork();
@@ -85,35 +90,60 @@ module('Unit | internalKeyFor canonicalization', function () {
     );
   });
 
-  test('an unregistered realm does not canonicalize, which is why the mappings matter', function (assert) {
-    // The negative case, recorded because it is the reason the prefix set has
-    // to be the same in every process: without the prefix mapping the alias and
-    // served spellings stay distinct, and neither becomes the prefix-form key
-    // that a configured process stores under.
+  test('a realm mapped by URL alone keys its two spellings separately', function (assert) {
+    // The reason `definitionEntryFor` reads under two keys. The test realm in
+    // environment mode has this exact shape — a URL mapping onto a
+    // per-environment host and no prefix of its own — so a definition stored
+    // under one spelling is invisible to a lookup holding the other.
     let virtualNetwork = new VirtualNetwork();
-    virtualNetwork.addURLMapping(new URL(ALIAS_BASE), new URL(REAL_BASE));
+    virtualNetwork.addURLMapping(new URL(VIRTUAL_TEST), new URL(REAL_TEST));
 
-    let aliasKey = internalKeyFor(
-      { module: rri(`${ALIAS_BASE}card-api`), name: 'CardDef' },
+    let servedKey = internalKeyFor(
+      { module: rri(`${REAL_TEST}captain`), name: 'Captain' },
       undefined,
       virtualNetwork,
     );
-    let servedKey = internalKeyFor(
-      { module: rri(`${REAL_BASE}card-api`), name: 'CardDef' },
+    let virtualKey = internalKeyFor(
+      { module: rri(`${VIRTUAL_TEST}captain`), name: 'Captain' },
       undefined,
       virtualNetwork,
     );
 
     assert.notStrictEqual(
-      aliasKey,
       servedKey,
-      'the two spellings split when no realm mapping covers them',
+      virtualKey,
+      'without a prefix to fold onto, each URL spelling keys its own entry',
     );
-    for (let key of [aliasKey, servedKey]) {
-      assert.false(
-        key.startsWith('@cardstack/base/'),
-        `${key} is not the prefix-form key a configured process would use`,
-      );
-    }
+    assert.strictEqual(
+      servedKey,
+      `${REAL_TEST}captain/Captain`,
+      'the served spelling keys under the served URL',
+    );
+    assert.strictEqual(
+      virtualKey,
+      `${VIRTUAL_TEST}captain/Captain`,
+      'and the virtual spelling under the virtual URL',
+    );
+  });
+
+  test('giving that realm a prefix collapses both spellings', function (assert) {
+    // And the condition under which the second lookup becomes redundant.
+    let virtualNetwork = new VirtualNetwork();
+    virtualNetwork.addURLMapping(new URL(VIRTUAL_TEST), new URL(REAL_TEST));
+    virtualNetwork.addRealmMapping('@test/realm/', REAL_TEST);
+
+    let keys = [`${REAL_TEST}captain`, `${VIRTUAL_TEST}captain`].map((module) =>
+      internalKeyFor(
+        { module: rri(module), name: 'Captain' },
+        undefined,
+        virtualNetwork,
+      ),
+    );
+
+    assert.deepEqual(
+      keys,
+      ['@test/realm/captain/Captain', '@test/realm/captain/Captain'],
+      'a prefix mapping is what makes the key independent of the spelling',
+    );
   });
 });

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -44,7 +44,7 @@ import {
   hasExecutableExtension,
   trimExecutableExtension,
 } from './index.ts';
-import { rri } from './realm-identifiers.ts';
+import { rri, type RealmResourceIdentifier } from './realm-identifiers.ts';
 import type { VirtualNetwork } from './virtual-network.ts';
 
 const MODULES_TABLE = 'modules';
@@ -457,7 +457,11 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         resolvedRealmURL,
       );
       if (cached) {
-        let entry = this.definitionEntryFor(cached.definitions, codeRef);
+        let entry = this.definitionEntryFor(
+          cached.definitions,
+          codeRef,
+          canonicalModuleURL,
+        );
         if (entry && 'definition' in entry) {
           return entry.definition;
         }
@@ -860,24 +864,40 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     });
   }
 
-  // The definition store keys entries by internalKeyFor. Across virtual
-  // networks the registered-prefix form and the canonical fetchable (alias)
-  // form do not always unresolve to the same key, and a given module may be
-  // stored under either. Try the prefix form (from the original codeRef)
-  // first, then the canonical form.
+  // Two keys, because `internalKeyFor` is a total canonicalization only for a
+  // realm that has a registered prefix mapping. For one that does, the prefix
+  // identifier, the url-mapped alias and the served URL all reduce to the same
+  // prefix-form string and the second lookup recomputes the first key.
+  //
+  // A realm reached through a URL mapping alone does not reduce: `unresolveURL`
+  // finds no prefix to fold onto, so the key keeps whichever URL spelling it
+  // arrived in, and `canonicalURL` deliberately produces the other one — it
+  // maps real back to virtual for fetching. The two spellings therefore key
+  // separate entries, and which one a module is stored under depends on the
+  // spelling its writer held. The test realm in environment mode is exactly
+  // this shape: mapped from `https://localhost:4202/test/` to a per-environment
+  // host, with no prefix of its own.
+  //
+  // So this is not a cross-process concern — both keys come from one
+  // VirtualNetwork. It is a same-network, two-URL-spellings concern, and it
+  // stops being needed when every realm on this path has a prefix mapping (or
+  // the key becomes a total fold over url-mapped aliases).
   private definitionEntryFor(
     definitions: Record<string, ModuleDefinitionResult | ErrorEntry>,
     codeRef: ResolvedCodeRef,
+    canonicalModuleURL: string,
   ): ModuleDefinitionResult | ErrorEntry | undefined {
-    // One key, because `internalKeyFor` is already a canonicalization: it
-    // resolves the module reference to a real URL and then unresolves that back
-    // through the registered realm mappings, so a prefix identifier, a
-    // url-mapped alias and the served URL all reduce to the same string. A
-    // second lookup under the fetchable spelling would recompute the identical
-    // key.
-    return definitions[
-      internalKeyFor(codeRef, undefined, this.#virtualNetwork)
-    ];
+    let entry =
+      definitions[internalKeyFor(codeRef, undefined, this.#virtualNetwork)];
+    if (!entry && canonicalModuleURL !== codeRef.module) {
+      let canonicalModuleId = internalKeyFor(
+        { ...codeRef, module: canonicalModuleURL as RealmResourceIdentifier },
+        undefined,
+        this.#virtualNetwork,
+      );
+      entry = definitions[canonicalModuleId];
+    }
+    return entry;
   }
 
   private async lookupDefinitionWithContext(
@@ -928,7 +948,11 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       });
     }
 
-    let defOrError = this.definitionEntryFor(moduleEntry.definitions, codeRef);
+    let defOrError = this.definitionEntryFor(
+      moduleEntry.definitions,
+      codeRef,
+      canonicalModuleURL,
+    );
     if (!defOrError) {
       throw new FilterRefersToNonexistentTypeError(codeRef, {
         cause: `Definition for ${codeRef.name} in module ${codeRef.module} not found`,

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -44,7 +44,7 @@ import {
   hasExecutableExtension,
   trimExecutableExtension,
 } from './index.ts';
-import { rri, type RealmResourceIdentifier } from './realm-identifiers.ts';
+import { rri } from './realm-identifiers.ts';
 import type { VirtualNetwork } from './virtual-network.ts';
 
 const MODULES_TABLE = 'modules';
@@ -457,11 +457,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         resolvedRealmURL,
       );
       if (cached) {
-        let entry = this.definitionEntryFor(
-          cached.definitions,
-          codeRef,
-          canonicalModuleURL,
-        );
+        let entry = this.definitionEntryFor(cached.definitions, codeRef);
         if (entry && 'definition' in entry) {
           return entry.definition;
         }
@@ -872,19 +868,16 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   private definitionEntryFor(
     definitions: Record<string, ModuleDefinitionResult | ErrorEntry>,
     codeRef: ResolvedCodeRef,
-    canonicalModuleURL: string,
   ): ModuleDefinitionResult | ErrorEntry | undefined {
-    let entry =
-      definitions[internalKeyFor(codeRef, undefined, this.#virtualNetwork)];
-    if (!entry && canonicalModuleURL !== codeRef.module) {
-      let canonicalModuleId = internalKeyFor(
-        { ...codeRef, module: canonicalModuleURL as RealmResourceIdentifier },
-        undefined,
-        this.#virtualNetwork,
-      );
-      entry = definitions[canonicalModuleId];
-    }
-    return entry;
+    // One key, because `internalKeyFor` is already a canonicalization: it
+    // resolves the module reference to a real URL and then unresolves that back
+    // through the registered realm mappings, so a prefix identifier, a
+    // url-mapped alias and the served URL all reduce to the same string. A
+    // second lookup under the fetchable spelling would recompute the identical
+    // key.
+    return definitions[
+      internalKeyFor(codeRef, undefined, this.#virtualNetwork)
+    ];
   }
 
   private async lookupDefinitionWithContext(
@@ -935,11 +928,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       });
     }
 
-    let defOrError = this.definitionEntryFor(
-      moduleEntry.definitions,
-      codeRef,
-      canonicalModuleURL,
-    );
+    let defOrError = this.definitionEntryFor(moduleEntry.definitions, codeRef);
     if (!defOrError) {
       throw new FilterRefersToNonexistentTypeError(codeRef, {
         cause: `Definition for ${codeRef.name} in module ${codeRef.module} not found`,


### PR DESCRIPTION
Documents what the definition lookup's two-key read is actually for, and pins it with tests. No behaviour change.

## Why

`definitionEntryFor` reads under the codeRef's module spelling and then, on a miss, under its fetchable canonical spelling. The comment above it attributed that to keys differing *across* virtual networks. Both keys come from one network, so that reading sends anyone auditing it looking for a cross-process problem that isn't there — and it implies a precondition (agreement between processes) that is not the one which would retire the fallback.

## What is actually going on

`internalKeyFor` resolves a module reference to a real URL and unresolves it back through the registered realm mappings. For a realm **with a prefix mapping** that is a total canonicalization — the prefix identifier, the url-mapped alias and the served URL all reduce to one key, and the second read recomputes the first.

For a realm reached through a **URL mapping alone** there is no prefix to fold onto, so the key keeps whichever URL spelling arrived, and `canonicalURL` produces the other one by design — it maps real back to virtual for fetching. Those two spellings key separate entries, and which one a module is stored under depends on the spelling its writer held.

The test realm in environment mode is exactly that shape: mapped from `https://localhost:4202/test/` to a per-environment host, with no prefix of its own. Removing the second read turns `Integration | serialization: can serialize a card that is constructed by another card (test realm)` into a `FilterRefersToNonexistentTypeError` — the definition is stored under `https://localhost:4202/test/captain/Captain` and looked up under `https://realm-test.<env>/test/captain/Captain`.

## Changes

- The comment now describes the same-network, two-URL-spellings mechanism, and names the condition that would retire the fallback: every realm on this path having a prefix mapping, or the key becoming a total fold over url-mapped aliases.
- A unit test pins both halves — spellings collapse when the realm has a prefix, and key separately when it has only a URL mapping.

The lookup itself is byte-identical to `main`.