### PR TITLE
Skip a realm event when the user has no session room

### DIFF
--- a/packages/realm-server/handlers/send-event.ts
+++ b/packages/realm-server/handlers/send-event.ts
@@ -21,22 +21,22 @@ export function createSendEvent({
   dbAdapter,
 }: SendEventDeps): SendEvent {
   return async function sendEvent(user, eventType, data) {
-    // The room lookup comes first because it is the step that can make this a
-    // no-op, and it is a local database read that cannot fail the way logging
-    // in can. Reaching Matrix first meant a user with no session room could
-    // still surface an unreachable homeserver or a bad credential as a failed
-    // notify — the same noise the skip below exists to remove, arrived at by
-    // another route.
+    // The room lookup runs before any Matrix call: it is the step that can
+    // make this a no-op, and it is a local database read, so a user with
+    // nothing to receive never depends on the homeserver being reachable.
     let roomId = await fetchSessionRoom(dbAdapter, user);
     if (!roomId) {
-      // No session room means nobody is listening: the user has never
-      // established a session, which is ordinary for a realm created by the
-      // CLI, by an admin, or by a test fixture. There is nothing to deliver
-      // and nowhere to deliver it, so this is a skip rather than a failure —
-      // sending anyway addressed a `null` room, which Matrix answered `403`
-      // and every caller logged as a failed notify with a stack trace.
+      // No session room means nowhere to deliver to. Usually the user has
+      // never established one, which is ordinary for a realm created by the
+      // CLI, by an admin, or by a test fixture. `clearSessionRoom` also nulls
+      // the column for a live session whose DM the realm server has left,
+      // until that session mints a fresh room on its next `_server-session`
+      // or realm auth — inside that window a notify the user would have
+      // received is dropped here, at a level nothing surfaces, so an absent
+      // row is not proof that nobody is listening. Either way there is
+      // nothing addressable, and callers treat the notify as best-effort.
       log.debug(
-        `skipping ${eventType} for ${user}: no session room, nothing is listening`,
+        `skipping ${eventType} for ${user}: no session room to deliver to`,
       );
       return;
     }

--- a/packages/realm-server/handlers/send-event.ts
+++ b/packages/realm-server/handlers/send-event.ts
@@ -21,9 +21,12 @@ export function createSendEvent({
   dbAdapter,
 }: SendEventDeps): SendEvent {
   return async function sendEvent(user, eventType, data) {
-    if (!matrixClient.isLoggedIn()) {
-      await matrixClient.login();
-    }
+    // The room lookup comes first because it is the step that can make this a
+    // no-op, and it is a local database read that cannot fail the way logging
+    // in can. Reaching Matrix first meant a user with no session room could
+    // still surface an unreachable homeserver or a bad credential as a failed
+    // notify — the same noise the skip below exists to remove, arrived at by
+    // another route.
     let roomId = await fetchSessionRoom(dbAdapter, user);
     if (!roomId) {
       // No session room means nobody is listening: the user has never
@@ -36,6 +39,10 @@ export function createSendEvent({
         `skipping ${eventType} for ${user}: no session room, nothing is listening`,
       );
       return;
+    }
+
+    if (!matrixClient.isLoggedIn()) {
+      await matrixClient.login();
     }
 
     await matrixClient.sendEvent(roomId, 'm.room.message', {

--- a/packages/realm-server/handlers/send-event.ts
+++ b/packages/realm-server/handlers/send-event.ts
@@ -1,7 +1,9 @@
 import type { DBAdapter } from '@cardstack/runtime-common';
-import { fetchSessionRoom } from '@cardstack/runtime-common';
+import { fetchSessionRoom, logger } from '@cardstack/runtime-common';
 import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import { APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE } from '@cardstack/runtime-common/matrix-constants';
+
+const log = logger('realm-server:send-event');
 
 export type SendEventDeps = {
   matrixClient: MatrixClient;
@@ -24,12 +26,19 @@ export function createSendEvent({
     }
     let roomId = await fetchSessionRoom(dbAdapter, user);
     if (!roomId) {
-      console.error(
-        `Failed to send event: ${eventType}, cannot find session room for user: ${user}`,
+      // No session room means nobody is listening: the user has never
+      // established a session, which is ordinary for a realm created by the
+      // CLI, by an admin, or by a test fixture. There is nothing to deliver
+      // and nowhere to deliver it, so this is a skip rather than a failure —
+      // sending anyway addressed a `null` room, which Matrix answered `403`
+      // and every caller logged as a failed notify with a stack trace.
+      log.debug(
+        `skipping ${eventType} for ${user}: no session room, nothing is listening`,
       );
+      return;
     }
 
-    await matrixClient.sendEvent(roomId!, 'm.room.message', {
+    await matrixClient.sendEvent(roomId, 'm.room.message', {
       body: JSON.stringify({ eventType, data }),
       msgtype: APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE,
     });

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -306,6 +306,7 @@ const ALL_TEST_FILES: string[] = [
   './realm-advisory-locks-test',
   './realm-cleanup-transaction-test',
   './data-plane-write-lock-test',
+  './send-event-test',
   './realm-registry-backfill-test',
   './realm-registry-reconciler-test',
   './realm-registry-writes-test',

--- a/packages/realm-server/tests/send-event-test.ts
+++ b/packages/realm-server/tests/send-event-test.ts
@@ -9,21 +9,34 @@ import { createSendEvent } from '../handlers/send-event.ts';
 // notify as best-effort and catch its failures, so what matters here is that
 // an ordinary condition — a user with no session room — doesn't produce one.
 module(basename(import.meta.filename), function () {
-  function fakeDeps(sessionRoomId: string | null) {
+  function fakeDeps(
+    sessionRoomId: string | null,
+    opts: { loggedIn?: boolean; loginFails?: boolean } = {},
+  ) {
     let sent: { roomId: string; body: unknown }[] = [];
+    let logins = 0;
     let dbAdapter = {
       kind: 'pg',
       execute: async () =>
         sessionRoomId === null ? [] : [{ session_room_id: sessionRoomId }],
     } as unknown as DBAdapter;
     let matrixClient = {
-      isLoggedIn: () => true,
-      login: async () => {},
+      isLoggedIn: () => opts.loggedIn ?? true,
+      login: async () => {
+        logins++;
+        if (opts.loginFails) {
+          throw new Error('homeserver unreachable');
+        }
+      },
       sendEvent: async (roomId: string, _type: string, body: unknown) => {
         sent.push({ roomId, body });
       },
     } as unknown as MatrixClient;
-    return { sendEvent: createSendEvent({ matrixClient, dbAdapter }), sent };
+    return {
+      sendEvent: createSendEvent({ matrixClient, dbAdapter }),
+      sent,
+      loginCount: () => logins,
+    };
   }
 
   test('an event for a user with no session room is skipped, not attempted', async function (assert) {
@@ -34,6 +47,32 @@ module(basename(import.meta.filename), function () {
     await sendEvent('@mango:localhost', 'realms-list-updated');
 
     assert.deepEqual(sent, [], 'no room event was addressed to a null room');
+  });
+
+  // The room lookup has to come before the login, or a user with no session
+  // room can still turn an unreachable homeserver into a failed notify — the
+  // noise this skip exists to remove, reached the other way round.
+  test('a skipped event does not reach Matrix at all', async function (assert) {
+    let { sendEvent, sent, loginCount } = fakeDeps(null, {
+      loggedIn: false,
+      loginFails: true,
+    });
+
+    await sendEvent('@mango:localhost', 'realms-list-updated');
+
+    assert.strictEqual(loginCount(), 0, 'no login was attempted');
+    assert.deepEqual(sent, [], 'nothing was sent');
+  });
+
+  test('a deliverable event still logs in when the client is cold', async function (assert) {
+    let { sendEvent, sent, loginCount } = fakeDeps('!room-abc:localhost', {
+      loggedIn: false,
+    });
+
+    await sendEvent('@mango:localhost', 'realms-list-updated');
+
+    assert.strictEqual(loginCount(), 1, 'logged in before sending');
+    assert.strictEqual(sent.length, 1, 'and delivered the event');
   });
 
   test('an event for a user with a session room is delivered to it', async function (assert) {

--- a/packages/realm-server/tests/send-event-test.ts
+++ b/packages/realm-server/tests/send-event-test.ts
@@ -1,0 +1,52 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import type { DBAdapter } from '@cardstack/runtime-common';
+import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
+import { createSendEvent } from '../handlers/send-event.ts';
+
+// Realm events are addressed to a user's session room. Callers treat the
+// notify as best-effort and catch its failures, so what matters here is that
+// an ordinary condition — a user with no session room — doesn't produce one.
+module(basename(import.meta.filename), function () {
+  function fakeDeps(sessionRoomId: string | null) {
+    let sent: { roomId: string; body: unknown }[] = [];
+    let dbAdapter = {
+      kind: 'pg',
+      execute: async () =>
+        sessionRoomId === null ? [] : [{ session_room_id: sessionRoomId }],
+    } as unknown as DBAdapter;
+    let matrixClient = {
+      isLoggedIn: () => true,
+      login: async () => {},
+      sendEvent: async (roomId: string, _type: string, body: unknown) => {
+        sent.push({ roomId, body });
+      },
+    } as unknown as MatrixClient;
+    return { sendEvent: createSendEvent({ matrixClient, dbAdapter }), sent };
+  }
+
+  test('an event for a user with no session room is skipped, not attempted', async function (assert) {
+    let { sendEvent, sent } = fakeDeps(null);
+
+    // Resolves rather than rejects: the send is the thing that used to fail,
+    // by addressing a `null` room that Matrix answered 403.
+    await sendEvent('@mango:localhost', 'realms-list-updated');
+
+    assert.deepEqual(sent, [], 'no room event was addressed to a null room');
+  });
+
+  test('an event for a user with a session room is delivered to it', async function (assert) {
+    let { sendEvent, sent } = fakeDeps('!room-abc:localhost');
+
+    await sendEvent('@mango:localhost', 'realms-list-updated', { a: 1 });
+
+    assert.strictEqual(sent.length, 1, 'one room event sent');
+    assert.strictEqual(sent[0].roomId, '!room-abc:localhost');
+    assert.deepEqual(
+      JSON.parse((sent[0].body as { body: string }).body),
+      { eventType: 'realms-list-updated', data: { a: 1 } },
+      'the event type and payload ride in the message body',
+    );
+  });
+});

--- a/packages/realm-server/tests/send-event-test.ts
+++ b/packages/realm-server/tests/send-event-test.ts
@@ -11,7 +11,11 @@ import { createSendEvent } from '../handlers/send-event.ts';
 module(basename(import.meta.filename), function () {
   function fakeDeps(
     sessionRoomId: string | null,
-    opts: { loggedIn?: boolean; loginFails?: boolean } = {},
+    opts: {
+      loggedIn?: boolean;
+      loginFails?: boolean;
+      sendFails?: boolean;
+    } = {},
   ) {
     let sent: { roomId: string; body: unknown }[] = [];
     let logins = 0;
@@ -29,6 +33,9 @@ module(basename(import.meta.filename), function () {
         }
       },
       sendEvent: async (roomId: string, _type: string, body: unknown) => {
+        if (opts.sendFails) {
+          throw new Error('homeserver rejected the event');
+        }
         sent.push({ roomId, body });
       },
     } as unknown as MatrixClient;
@@ -42,16 +49,15 @@ module(basename(import.meta.filename), function () {
   test('an event for a user with no session room is skipped, not attempted', async function (assert) {
     let { sendEvent, sent } = fakeDeps(null);
 
-    // Resolves rather than rejects: the send is the thing that used to fail,
-    // by addressing a `null` room that Matrix answered 403.
+    // Resolves rather than rejects: a null room id is not addressable, so
+    // there is nothing to send and nothing to fail.
     await sendEvent('@mango:localhost', 'realms-list-updated');
 
     assert.deepEqual(sent, [], 'no room event was addressed to a null room');
   });
 
-  // The room lookup has to come before the login, or a user with no session
-  // room can still turn an unreachable homeserver into a failed notify — the
-  // noise this skip exists to remove, reached the other way round.
+  // The room lookup gates the login, so a user with nothing to receive is
+  // never exposed to an unreachable homeserver.
   test('a skipped event does not reach Matrix at all', async function (assert) {
     let { sendEvent, sent, loginCount } = fakeDeps(null, {
       loggedIn: false,
@@ -73,6 +79,20 @@ module(basename(import.meta.filename), function () {
 
     assert.strictEqual(loginCount(), 1, 'logged in before sending');
     assert.strictEqual(sent.length, 1, 'and delivered the event');
+  });
+
+  // The other half of the header's reasoning: callers can only catch what
+  // reaches them. A send failure has to keep propagating, or a `try/catch`
+  // added here in the name of quieting things further would swallow it past
+  // every caller's own handling with this file still green.
+  test('a real send failure still propagates to the caller', async function (assert) {
+    let { sendEvent } = fakeDeps('!room-abc:localhost', { sendFails: true });
+
+    await assert.rejects(
+      sendEvent('@mango:localhost', 'realms-list-updated'),
+      /homeserver rejected the event/,
+      'the caller decides what a failed delivery means',
+    );
   });
 
   test('an event for a user with a session room is delivered to it', async function (assert) {


### PR DESCRIPTION
`createSendEvent` logged that it couldn't find the user's session room and then sent the event anyway, so a null room id reached Matrix, which answered `403 M_FORBIDDEN: User … not in room null`. Every caller catches that — the notify is best-effort by design, since the realm is already created and the response already sent — but each occurrence left two log lines and a stack trace behind, on every realm create, archive, unarchive and delete for a user without a session room. In a passing CI job that reads exactly like a failure, and it was mistaken for one.

Nothing was being lost to a bug: a user with no session room has never established a session, which is ordinary for a realm created by the CLI, by an admin, or by a test fixture. There is nothing to deliver and nowhere to deliver it, and the send could not have succeeded under any circumstances. It is now a skip recorded at debug level, and `roomId` is no longer asserted non-null on its way into a call that can't accept null.