### PR TITLE
refactor: seed a Home README into a user's personal (first) realm

### DIFF
--- a/packages/boxel-cli/src/lib/personal-realm.ts
+++ b/packages/boxel-cli/src/lib/personal-realm.ts
@@ -1,6 +1,7 @@
 import {
   iconURLFor,
   getRandomBackgroundURL,
+  PERSONAL_REALM_ENDPOINT,
 } from '@cardstack/runtime-common/realm-display-defaults';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 
@@ -10,12 +11,6 @@ import {
   requireUserRealmsFromMatrixAccountData,
   type MatrixAuth,
 } from './auth.ts';
-
-// The web app's signup flow ends by creating this realm for the new account
-// (see MatrixService.initializeNewUser in the host); these values mirror it so
-// an account bootstrapped from the CLI is indistinguishable from one
-// bootstrapped from the web.
-const PERSONAL_REALM_ENDPOINT = 'personal';
 
 export type EnsurePersonalRealmResult =
   // The account already has at least one realm; nothing was done.
@@ -65,6 +60,10 @@ export async function ensurePersonalRealm(
       body: JSON.stringify({
         data: {
           type: 'realm',
+          // These attributes mirror the web app's signup flow (see
+          // MatrixService.initializeNewUser in the host) so an account
+          // bootstrapped from the CLI is indistinguishable from one
+          // bootstrapped from the web.
           attributes: {
             endpoint: PERSONAL_REALM_ENDPOINT,
             name,

--- a/packages/host/app/lib/utils.ts
+++ b/packages/host/app/lib/utils.ts
@@ -9,6 +9,7 @@ import {
 export {
   iconURLFor,
   getRandomBackgroundURL,
+  PERSONAL_REALM_ENDPOINT,
 } from '@cardstack/runtime-common/realm-display-defaults';
 
 import ENV from '@cardstack/host/config/environment';

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -89,7 +89,11 @@ import type IndexController from '@cardstack/host/controllers/index';
 
 import type { TempEvent } from '@cardstack/host/lib/matrix-classes/room';
 import Room from '@cardstack/host/lib/matrix-classes/room';
-import { getRandomBackgroundURL, iconURLFor } from '@cardstack/host/lib/utils';
+import {
+  getRandomBackgroundURL,
+  iconURLFor,
+  PERSONAL_REALM_ENDPOINT,
+} from '@cardstack/host/lib/utils';
 import { getMatrixProfile } from '@cardstack/host/resources/matrix-profile';
 import {
   clearLocalStorage,
@@ -788,7 +792,7 @@ export default class MatrixService extends Service {
 
     await Promise.all([
       this.createPersonalRealmForUser({
-        endpoint: 'personal',
+        endpoint: PERSONAL_REALM_ENDPOINT,
         name: `${displayName}'s Workspace`,
         iconURL: iconURLFor(displayName),
         backgroundURL: getRandomBackgroundURL(),

--- a/packages/realm-server/handlers/create-realm.ts
+++ b/packages/realm-server/handlers/create-realm.ts
@@ -1,8 +1,7 @@
 import type Koa from 'koa';
 import { resolve, join } from 'path';
-import { writeFileSync } from 'fs';
 import fsExtra from 'fs-extra';
-const { ensureDirSync, writeJSONSync } = fsExtra;
+const { ensureDirSync, writeFileSync, writeJSONSync } = fsExtra;
 import * as Sentry from '@sentry/node';
 import type {
   DBAdapter,

--- a/packages/realm-server/handlers/create-realm.ts
+++ b/packages/realm-server/handlers/create-realm.ts
@@ -1,5 +1,6 @@
 import type Koa from 'koa';
 import { resolve, join } from 'path';
+import { writeFileSync } from 'fs';
 import fsExtra from 'fs-extra';
 const { ensureDirSync, writeJSONSync } = fsExtra;
 import * as Sentry from '@sentry/node';
@@ -22,6 +23,11 @@ import {
 import { getMatrixUsername } from '@cardstack/runtime-common/matrix-client';
 import { REALMS_LIST_UPDATED_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 import { insertSourceRealmInRegistry } from '../lib/realm-registry-writes.ts';
+import {
+  REALM_README_FILENAME,
+  realmReadmeTemplate,
+  shouldSeedRealmReadme,
+} from '../lib/realm-readme.ts';
 import type { SendEvent } from './send-event.ts';
 import type { RealmRegistryReconciler } from '../lib/realm-registry-reconciler.ts';
 import {
@@ -189,7 +195,7 @@ export async function createRealm(
         },
       },
     });
-    writeJSONSync(join(realmPath, 'index.json'), {
+    let indexCard: Record<string, any> = {
       data: {
         type: 'card',
         meta: {
@@ -199,7 +205,29 @@ export async function createRealm(
           },
         },
       },
-    });
+    };
+    // Seed a Home README into the user's personal (first) realm. Best-effort:
+    // a template read/write hiccup must not fail realm creation, so on error we
+    // fall back to a README-less index card. When it succeeds, link the file via
+    // the Workspace card's `readme` field so it renders on Home.
+    if (shouldSeedRealmReadme(endpoint)) {
+      try {
+        writeFileSync(
+          join(realmPath, REALM_README_FILENAME),
+          realmReadmeTemplate(),
+        );
+        indexCard.data.relationships = {
+          readme: {
+            links: { self: `./${REALM_README_FILENAME}` },
+            data: { type: 'file-meta', id: `./${REALM_README_FILENAME}` },
+          },
+        };
+      } catch (err) {
+        log.error(`failed to seed README for realm ${url}: ${err}`);
+        Sentry.captureException(err);
+      }
+    }
+    writeJSONSync(join(realmPath, 'index.json'), indexCard);
 
     // Register the source realm in realm_registry. The INSERT emits
     // NOTIFY realm_registry; the reconciler on every instance picks

--- a/packages/realm-server/lib/realm-readme-template.md
+++ b/packages/realm-server/lib/realm-readme-template.md
@@ -1,0 +1,33 @@
+# Welcome to Boxel
+
+This is your personal workspace — your own space in Boxel to build, organize,
+and use **cards**.
+
+## What is Boxel?
+
+Boxel is a place where everything is a card. A card can be a document, a list,
+a contact, a chart, or a whole app — and cards link to each other, so your
+notes, your data, and your tools all live in one connected space.
+
+- **Cards are composable.** Start from an existing card and extend it to fit
+  your needs — no reinventing the wheel.
+- **Cards are searchable.** Find anything within this space, or across all of
+  your spaces.
+- **Cards adapt.** The same card renders differently depending on where it
+  appears — a compact tile in a list, a full page on its own.
+
+## What you can do here
+
+- **Browse the Library** to see every card and file in this space.
+- **Install a starter from the catalog** — ready-made cards and apps you can
+  use as-is or remix.
+- **Ask the assistant** to draft a document, create a card, or build a small
+  app for you.
+- **Pin the cards you reach for most** so they stay one click away.
+
+## Make it yours
+
+This workspace starts empty and it's yours to shape — keep notes, track work,
+collect references, or build something new.
+
+> This README is yours too — edit it any time to describe what this space is for.

--- a/packages/realm-server/lib/realm-readme.ts
+++ b/packages/realm-server/lib/realm-readme.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+// The user's first realm is always created at this endpoint (both the host's
+// signup flow and boxel-cli's ensurePersonalRealm post `endpoint: 'personal'`),
+// and the endpoint collides on a second attempt — so it uniquely identifies the
+// user's personal, first-created realm.
+const PERSONAL_REALM_ENDPOINT = 'personal';
+
+// Filename of the seeded Home README, relative to the realm root. The Workspace
+// card's `readme` field (linksTo MarkdownDef) links to this so it renders on Home.
+export const REALM_README_FILENAME = 'README.md';
+
+// Whether to seed a Home README into a newly created realm. Gated by
+// SEED_REALM_README so the mechanism can ship ahead of the finalized copy, and
+// scoped to the personal endpoint so only the user's first realm gets one.
+export function shouldSeedRealmReadme(endpoint: string): boolean {
+  return (
+    process.env.SEED_REALM_README === 'true' &&
+    endpoint === PERSONAL_REALM_ENDPOINT
+  );
+}
+
+// Placeholder README content, kept as a sibling markdown file so the copy is
+// easy to refine without touching code. Read lazily and cached — the template
+// ships with the realm-server source.
+let cached: string | undefined;
+export function realmReadmeTemplate(): string {
+  if (cached === undefined) {
+    cached = readFileSync(
+      fileURLToPath(new URL('./realm-readme-template.md', import.meta.url)),
+      'utf8',
+    );
+  }
+  return cached;
+}

--- a/packages/realm-server/lib/realm-readme.ts
+++ b/packages/realm-server/lib/realm-readme.ts
@@ -1,11 +1,6 @@
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
-
-// The user's first realm is always created at this endpoint (both the host's
-// signup flow and boxel-cli's ensurePersonalRealm post `endpoint: 'personal'`),
-// and the endpoint collides on a second attempt — so it uniquely identifies the
-// user's personal, first-created realm.
-const PERSONAL_REALM_ENDPOINT = 'personal';
+import { PERSONAL_REALM_ENDPOINT } from '@cardstack/runtime-common/realm-display-defaults';
 
 // Filename of the seeded Home README, relative to the realm root. The Workspace
 // card's `readme` field (linksTo MarkdownDef) links to this so it renders on Home.

--- a/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
+++ b/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
@@ -64,7 +64,10 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
               JSON.stringify({
                 data: {
                   type: 'realm',
-                  attributes: { ...testRealmInfo, endpoint },
+                  // Only name + endpoint: spreading testRealmInfo would send
+                  // backgroundURL/iconURL as null, which the endpoint rejects
+                  // as non-strings (400).
+                  attributes: { name: testRealmInfo.name, endpoint },
                 },
               }),
             );

--- a/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
+++ b/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
@@ -33,6 +33,111 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
     function (hooks) {
       let context = setupServerEndpointsTest(hooks);
 
+      module('POST /_create-realm README seeding', function (hooks) {
+        let originalFlag: string | undefined;
+
+        hooks.beforeEach(function () {
+          originalFlag = process.env.SEED_REALM_README;
+        });
+        hooks.afterEach(function () {
+          if (originalFlag === undefined) {
+            delete process.env.SEED_REALM_README;
+          } else {
+            process.env.SEED_REALM_README = originalFlag;
+          }
+        });
+
+        async function postCreateRealm(endpoint: string, owner: string) {
+          let ownerUserId = `@${owner}:localhost`;
+          return context.request
+            .post('/_create-realm')
+            .set('Accept', 'application/vnd.api+json')
+            .set('Content-Type', 'application/json')
+            .set(
+              'Authorization',
+              `Bearer ${createRealmServerJWT(
+                { user: ownerUserId, sessionRoom: 'session-room-test' },
+                realmSecretSeed,
+              )}`,
+            )
+            .send(
+              JSON.stringify({
+                data: {
+                  type: 'realm',
+                  attributes: { ...testRealmInfo, endpoint },
+                },
+              }),
+            );
+        }
+
+        function realmPathFor(owner: string, endpoint: string) {
+          return join(context.dir.name, 'realm_server_1', owner, endpoint);
+        }
+
+        test('seeds a Home README into the personal realm when the flag is on', async function (assert) {
+          process.env.SEED_REALM_README = 'true';
+          // random owner isolates matrix/permission state; the endpoint must be
+          // exactly 'personal' to exercise the gate, so it can't be randomized.
+          let owner = `user-${uuidv4()}`;
+          let response = await postCreateRealm('personal', owner);
+          assert.strictEqual(response.status, 202, 'HTTP 202 status');
+
+          let realmPath = realmPathFor(owner, 'personal');
+          assert.ok(
+            existsSync(join(realmPath, 'README.md')),
+            'README.md is seeded into the personal realm',
+          );
+          let indexCard = readJSONSync(join(realmPath, 'index.json'));
+          assert.deepEqual(
+            indexCard.data.relationships,
+            {
+              readme: {
+                links: { self: './README.md' },
+                data: { type: 'file-meta', id: './README.md' },
+              },
+            },
+            'index.json links the seeded README via the Workspace readme field',
+          );
+        });
+
+        test('does not seed a README for a non-personal realm even when the flag is on', async function (assert) {
+          process.env.SEED_REALM_README = 'true';
+          let owner = `user-${uuidv4()}`;
+          let endpoint = `workspace-${uuidv4()}`;
+          let response = await postCreateRealm(endpoint, owner);
+          assert.strictEqual(response.status, 202, 'HTTP 202 status');
+
+          let realmPath = realmPathFor(owner, endpoint);
+          assert.notOk(
+            existsSync(join(realmPath, 'README.md')),
+            'no README.md for a non-personal realm',
+          );
+          let indexCard = readJSONSync(join(realmPath, 'index.json'));
+          assert.notOk(
+            indexCard.data.relationships,
+            'index.json has no readme relationship for a non-personal realm',
+          );
+        });
+
+        test('does not seed a README when the flag is off', async function (assert) {
+          delete process.env.SEED_REALM_README;
+          let owner = `user-${uuidv4()}`;
+          let response = await postCreateRealm('personal', owner);
+          assert.strictEqual(response.status, 202, 'HTTP 202 status');
+
+          let realmPath = realmPathFor(owner, 'personal');
+          assert.notOk(
+            existsSync(join(realmPath, 'README.md')),
+            'no README.md seeded when SEED_REALM_README is unset',
+          );
+          let indexCard = readJSONSync(join(realmPath, 'index.json'));
+          assert.notOk(
+            indexCard.data.relationships,
+            'index.json has no readme relationship when the flag is off',
+          );
+        });
+      });
+
       test('POST /_create-realm', async function (assert) {
         // we randomize the realm and owner names so that we can isolate matrix
         // test state--there is no "delete user" matrix API
@@ -1041,110 +1146,4 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       });
     },
   );
-
-  module('POST /_create-realm README seeding', function (hooks) {
-    let context = setupServerEndpointsTest(hooks);
-    let originalFlag: string | undefined;
-
-    hooks.beforeEach(function () {
-      originalFlag = process.env.SEED_REALM_README;
-    });
-    hooks.afterEach(function () {
-      if (originalFlag === undefined) {
-        delete process.env.SEED_REALM_README;
-      } else {
-        process.env.SEED_REALM_README = originalFlag;
-      }
-    });
-
-    async function postCreateRealm(endpoint: string, owner: string) {
-      let ownerUserId = `@${owner}:localhost`;
-      return context.request
-        .post('/_create-realm')
-        .set('Accept', 'application/vnd.api+json')
-        .set('Content-Type', 'application/json')
-        .set(
-          'Authorization',
-          `Bearer ${createRealmServerJWT(
-            { user: ownerUserId, sessionRoom: 'session-room-test' },
-            realmSecretSeed,
-          )}`,
-        )
-        .send(
-          JSON.stringify({
-            data: {
-              type: 'realm',
-              attributes: { ...testRealmInfo, endpoint },
-            },
-          }),
-        );
-    }
-
-    function realmPathFor(owner: string, endpoint: string) {
-      return join(context.dir.name, 'realm_server_1', owner, endpoint);
-    }
-
-    test('seeds a Home README into the personal realm when the flag is on', async function (assert) {
-      process.env.SEED_REALM_README = 'true';
-      // random owner isolates matrix/permission state; the endpoint must be
-      // exactly 'personal' to exercise the gate, so it can't be randomized.
-      let owner = `user-${uuidv4()}`;
-      let response = await postCreateRealm('personal', owner);
-      assert.strictEqual(response.status, 202, 'HTTP 202 status');
-
-      let realmPath = realmPathFor(owner, 'personal');
-      assert.ok(
-        existsSync(join(realmPath, 'README.md')),
-        'README.md is seeded into the personal realm',
-      );
-      let indexCard = readJSONSync(join(realmPath, 'index.json'));
-      assert.deepEqual(
-        indexCard.data.relationships,
-        {
-          readme: {
-            links: { self: './README.md' },
-            data: { type: 'file-meta', id: './README.md' },
-          },
-        },
-        'index.json links the seeded README via the Workspace readme field',
-      );
-    });
-
-    test('does not seed a README for a non-personal realm even when the flag is on', async function (assert) {
-      process.env.SEED_REALM_README = 'true';
-      let owner = `user-${uuidv4()}`;
-      let endpoint = `workspace-${uuidv4()}`;
-      let response = await postCreateRealm(endpoint, owner);
-      assert.strictEqual(response.status, 202, 'HTTP 202 status');
-
-      let realmPath = realmPathFor(owner, endpoint);
-      assert.notOk(
-        existsSync(join(realmPath, 'README.md')),
-        'no README.md for a non-personal realm',
-      );
-      let indexCard = readJSONSync(join(realmPath, 'index.json'));
-      assert.notOk(
-        indexCard.data.relationships,
-        'index.json has no readme relationship for a non-personal realm',
-      );
-    });
-
-    test('does not seed a README when the flag is off', async function (assert) {
-      delete process.env.SEED_REALM_README;
-      let owner = `user-${uuidv4()}`;
-      let response = await postCreateRealm('personal', owner);
-      assert.strictEqual(response.status, 202, 'HTTP 202 status');
-
-      let realmPath = realmPathFor(owner, 'personal');
-      assert.notOk(
-        existsSync(join(realmPath, 'README.md')),
-        'no README.md seeded when SEED_REALM_README is unset',
-      );
-      let indexCard = readJSONSync(join(realmPath, 'index.json'));
-      assert.notOk(
-        indexCard.data.relationships,
-        'index.json has no readme relationship when the flag is off',
-      );
-    });
-  });
 });

--- a/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
+++ b/packages/realm-server/tests/server-endpoints/realm-lifecycle-test.ts
@@ -1041,4 +1041,110 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function () {
       });
     },
   );
+
+  module('POST /_create-realm README seeding', function (hooks) {
+    let context = setupServerEndpointsTest(hooks);
+    let originalFlag: string | undefined;
+
+    hooks.beforeEach(function () {
+      originalFlag = process.env.SEED_REALM_README;
+    });
+    hooks.afterEach(function () {
+      if (originalFlag === undefined) {
+        delete process.env.SEED_REALM_README;
+      } else {
+        process.env.SEED_REALM_README = originalFlag;
+      }
+    });
+
+    async function postCreateRealm(endpoint: string, owner: string) {
+      let ownerUserId = `@${owner}:localhost`;
+      return context.request
+        .post('/_create-realm')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Content-Type', 'application/json')
+        .set(
+          'Authorization',
+          `Bearer ${createRealmServerJWT(
+            { user: ownerUserId, sessionRoom: 'session-room-test' },
+            realmSecretSeed,
+          )}`,
+        )
+        .send(
+          JSON.stringify({
+            data: {
+              type: 'realm',
+              attributes: { ...testRealmInfo, endpoint },
+            },
+          }),
+        );
+    }
+
+    function realmPathFor(owner: string, endpoint: string) {
+      return join(context.dir.name, 'realm_server_1', owner, endpoint);
+    }
+
+    test('seeds a Home README into the personal realm when the flag is on', async function (assert) {
+      process.env.SEED_REALM_README = 'true';
+      // random owner isolates matrix/permission state; the endpoint must be
+      // exactly 'personal' to exercise the gate, so it can't be randomized.
+      let owner = `user-${uuidv4()}`;
+      let response = await postCreateRealm('personal', owner);
+      assert.strictEqual(response.status, 202, 'HTTP 202 status');
+
+      let realmPath = realmPathFor(owner, 'personal');
+      assert.ok(
+        existsSync(join(realmPath, 'README.md')),
+        'README.md is seeded into the personal realm',
+      );
+      let indexCard = readJSONSync(join(realmPath, 'index.json'));
+      assert.deepEqual(
+        indexCard.data.relationships,
+        {
+          readme: {
+            links: { self: './README.md' },
+            data: { type: 'file-meta', id: './README.md' },
+          },
+        },
+        'index.json links the seeded README via the Workspace readme field',
+      );
+    });
+
+    test('does not seed a README for a non-personal realm even when the flag is on', async function (assert) {
+      process.env.SEED_REALM_README = 'true';
+      let owner = `user-${uuidv4()}`;
+      let endpoint = `workspace-${uuidv4()}`;
+      let response = await postCreateRealm(endpoint, owner);
+      assert.strictEqual(response.status, 202, 'HTTP 202 status');
+
+      let realmPath = realmPathFor(owner, endpoint);
+      assert.notOk(
+        existsSync(join(realmPath, 'README.md')),
+        'no README.md for a non-personal realm',
+      );
+      let indexCard = readJSONSync(join(realmPath, 'index.json'));
+      assert.notOk(
+        indexCard.data.relationships,
+        'index.json has no readme relationship for a non-personal realm',
+      );
+    });
+
+    test('does not seed a README when the flag is off', async function (assert) {
+      delete process.env.SEED_REALM_README;
+      let owner = `user-${uuidv4()}`;
+      let response = await postCreateRealm('personal', owner);
+      assert.strictEqual(response.status, 202, 'HTTP 202 status');
+
+      let realmPath = realmPathFor(owner, 'personal');
+      assert.notOk(
+        existsSync(join(realmPath, 'README.md')),
+        'no README.md seeded when SEED_REALM_README is unset',
+      );
+      let indexCard = readJSONSync(join(realmPath, 'index.json'));
+      assert.notOk(
+        indexCard.data.relationships,
+        'index.json has no readme relationship when the flag is off',
+      );
+    });
+  });
 });

--- a/packages/runtime-common/realm-display-defaults.ts
+++ b/packages/runtime-common/realm-display-defaults.ts
@@ -5,6 +5,15 @@
  * Pure JS — no external dependencies.
  */
 
+/**
+ * Endpoint of the realm every account-bootstrap flow creates first — the
+ * host's signup flow and boxel-cli's ensurePersonalRealm both post it, and
+ * the realm-server keys personal-realm behavior (e.g. README seeding) off
+ * it. The endpoint collides on a second attempt, so it uniquely identifies
+ * a user's personal, first-created realm.
+ */
+export const PERSONAL_REALM_ENDPOINT = 'personal';
+
 const ICON_URLS: { [letter: string]: string } = Object.freeze({
   a: 'https://boxel-images.boxel.ai/icons/Letter-a.png',
   b: 'https://boxel-images.boxel.ai/icons/Letter-b.png',


### PR DESCRIPTION
## What

When a user's **personal (first) realm** is created, seed a placeholder `README.md` into it and link it as the realm's Home README via the `Workspace` card's `readme` field, so it renders on the workspace landing page.

## How

- **Where:** `createRealm` in `packages/realm-server/handlers/create-realm.ts`, alongside the existing `realm.json` / `index.json` seed writes — one place that covers both the host signup flow and boxel-cli's `ensurePersonalRealm`.
- **Scope:** gated to the `personal` endpoint, so only the user's first, auto-created realm gets a README — additional workspaces the user creates later do not.
- **Feature flag:** off by default behind the `SEED_REALM_README` env var, so the mechanism can land ahead of the finalized copy. Existing realms are not backfilled.
- **Content:** placeholder copy lives in a sibling markdown template (`lib/realm-readme-template.md`) for easy editing. Pure rich markdown — no embedded cards, so there are no cross-realm or broken-link concerns.
- **Safety:** seeding is best-effort — a template read/write failure falls back to a README-less index card rather than failing realm creation.

## Wiring the README to Home

The seeded `index.json` (Workspace card) links the file via:

```json
"relationships": {
  "readme": { "links": { "self": "./README.md" },
              "data": { "type": "file-meta", "id": "./README.md" } }
}
```

`Workspace.readme` (`linksTo(MarkdownDef)`) already renders on Home — as the hero on an empty realm, and collapsed under "About this space" once the realm has pinned cards.

## Tests

New `POST /_create-realm README seeding` module in `realm-lifecycle-test.ts`:
- flag on + `personal` endpoint → `README.md` written and `index.json` links it
- flag on + non-personal endpoint → no README
- flag off → no README

## Follow-ups (not in this PR)

- Refine the placeholder copy (edits to the template file).
- Flip `SEED_REALM_README` on in deploy config once the copy is finalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)