### PR TITLE
Throw a plain Error when directory refresh partially fails

### DIFF
--- a/packages/runtime-common/directory-view-refresher.ts
+++ b/packages/runtime-common/directory-view-refresher.ts
@@ -69,7 +69,10 @@ export class DirectoryViewRefresher {
       throw errors[0];
     }
     if (errors.length > 1) {
-      throw new AggregateError(errors, 'directory refresh partially failed');
+      let messages = errors
+        .map((err) => (err instanceof Error ? err.message : String(err)))
+        .join('; ');
+      throw new Error(`directory refresh partially failed: ${messages}`);
     }
   }
 


### PR DESCRIPTION
CI Lint is red on main: `directory-view-refresher.ts` throws `AggregateError`, which is an ES2021 global, while the runtime-common and postgres packages type-check with `target: es2020` — so `tsc` fails with "Cannot find name 'AggregateError'".

The multi-error throw now uses a plain `Error` whose message joins the individual failure messages, so the type check passes without raising the language target. The single-error path is unchanged (the original error is rethrown as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)