### PR TITLE
Survive transient fetch failures during file indexing and SystemCard load

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -641,6 +641,13 @@ export interface Field<
   ): Promise<any>;
   emptyValue(instance: BaseDef): any;
   validate(instance: BaseDef, value: any): void;
+  // Deserialization-only guard, applied before `validate` when a document is
+  // being loaded. A link field's target lives in another document — its index
+  // row can be wrong or stale independently of this card — so a target that
+  // does not satisfy the field's declared type is dropped (with a warning)
+  // rather than making this whole card unloadable. Direct assignment does not
+  // pass through here: `validate` still throws for a user-set mismatch.
+  sanitizeDeserialized?(instance: BaseDef, value: any): any;
   component(model: Box<BaseDef>): BoxComponent;
   getter(instance: BaseDef): BaseInstanceType<CardT> | undefined;
   queryableValue(value: any, stack: BaseDef[]): SearchT;
@@ -1592,6 +1599,26 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
     return value;
   }
 
+  sanitizeDeserialized(_instance: CardDef, value: any) {
+    if (!value || isNonPresentLink(value) || primitive in this.card) {
+      return value;
+    }
+    if (
+      instanceOf(value, this.card) &&
+      !(isFileDef(this.card) && !value.id)
+    ) {
+      return value;
+    }
+    console.warn(
+      `dropping deserialized linksTo '${this.name}' target: ${
+        value.constructor?.name
+      } does not satisfy ${this.card.name}${
+        isFileDef(this.card) && !value.id ? ' (missing id)' : ''
+      }`,
+    );
+    return null;
+  }
+
   captureQueryFieldSeedData(
     instance: BaseDef,
     value: CardDef,
@@ -2254,6 +2281,34 @@ class LinksToMany<FieldT extends LinkableDefConstructor> implements Field<
       rawArrayValues(values),
       { hideSlot: isNonPresentLink },
     );
+  }
+
+  sanitizeDeserialized(_instance: BaseDef, values: any[] | null) {
+    if (values == null || !Array.isArray(values) || primitive in this.card) {
+      return values;
+    }
+    let expectedCard = this.declaredCard;
+    let conforms = (value: any) =>
+      isNonPresentLink(value) ||
+      value == null ||
+      (instanceOf(value, expectedCard) &&
+        !(isFileDef(expectedCard) && !value.id));
+    let raw = rawArrayValues(values);
+    if (raw.every(conforms)) {
+      return values;
+    }
+    for (let value of raw) {
+      if (!conforms(value)) {
+        console.warn(
+          `dropping deserialized linksToMany '${this.name}' entry: ${
+            value.constructor?.name
+          } does not satisfy ${expectedCard.name}${
+            isFileDef(expectedCard) && !value.id ? ' (missing id)' : ''
+          }`,
+        );
+      }
+    }
+    return raw.filter(conforms);
   }
 
   captureQueryFieldSeedData(
@@ -4659,6 +4714,9 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
         );
       }
       propagateRealmContext(value, realmURLString);
+      if (field.sanitizeDeserialized) {
+        value = field.sanitizeDeserialized(instance, value);
+      }
       field.validate(instance, value);
 
       // Before updating field's value, we also have to make sure

--- a/packages/host/app/services/ai-assistant-panel-service.ts
+++ b/packages/host/app/services/ai-assistant-panel-service.ts
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import type Owner from '@ember/owner';
 import { service } from '@ember/service';
 import Service from '@ember/service';
+import { isTesting } from '@embroider/macros';
 import { tracked } from '@glimmer/tracking';
 
 import { allSettled, restartableTask } from 'ember-concurrency';
@@ -261,6 +262,50 @@ export default class AiAssistantPanelService extends Service {
     if (hidePastSessionsList) {
       this.hidePastSessions();
     }
+    void this.ensureDefaultSkillsApplied(roomId);
+  }
+
+  // Rooms this session has already checked for a missing default-skill state
+  // (or repaired). Rechecking on every entry would re-run the skills tool for
+  // rooms the user deliberately keeps skill-less mid-session.
+  private skillBackfillCheckedRooms = new Set<string>();
+
+  // A room created while the default-skill lookup was failing (the SystemCard
+  // unavailable, the skills realm unreachable) carries an empty skills state
+  // permanently: room state is persisted, the panel reuses the unused room as
+  // the "new session", and nothing re-applies the defaults. On entering a
+  // room that has no messages and has never had a skill attached, apply the
+  // defaults now. A room where the user disabled every skill is untouched —
+  // disabling moves a skill to the disabled list rather than removing it.
+  private async ensureDefaultSkillsApplied(roomId: string) {
+    if (isTesting()) {
+      // Tests assert on room skill state they set up themselves; a background
+      // backfill would mutate it nondeterministically.
+      return;
+    }
+    if (this.skillBackfillCheckedRooms.has(roomId)) {
+      return;
+    }
+    if (this.doCreateRoom.isRunning) {
+      // Room creation applies (or defers) the defaults itself.
+      return;
+    }
+    let resource = this.matrixService.roomResources.get(roomId);
+    let room = resource?.matrixRoom;
+    if (!room) {
+      // Room state has not synced yet; a later entry re-checks.
+      return;
+    }
+    let { enabledSkillCards = [], disabledSkillCards = [] } =
+      room.skillsConfig ?? {};
+    this.skillBackfillCheckedRooms.add(roomId);
+    if (enabledSkillCards.length || disabledSkillCards.length) {
+      return;
+    }
+    if (resource!.messages.length > 0) {
+      return;
+    }
+    await this.applyDefaultSkillsToRoom(roomId);
   }
 
   @action

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -163,6 +163,10 @@ const STATE_EVENTS_OF_INTEREST = ['m.room.create', 'm.room.name'];
 // so a persistently-down server doesn't spin forever.
 const UNREACHABLE_RETRY_INTERVAL_MS = 10_000;
 const MAX_UNREACHABLE_RETRY_ATTEMPTS = 6;
+// Pause before each retry of a failed SystemCard load. Without a retry, one
+// transient failure at boot locks the whole session into the fallback model
+// list and the hardcoded default skills.
+const SYSTEM_CARD_RETRY_DELAYS_MS = [5_000, 15_000, 60_000, 5 * 60_000];
 
 const realmEventsLogger = logger('realm:events');
 
@@ -3227,6 +3231,9 @@ export default class MatrixService extends Service {
       envDefaultFailed ||
       (userChoiceFailed && !envDefaultId) ||
       (this._systemCardWasLost && !loadedCard);
+    if (this._systemCardLoadFailed) {
+      this.scheduleSystemCardRetry();
+    }
 
     if (loadedCard?.id !== this._systemCard?.id) {
       this._systemCardInvalidationUnsub?.();
@@ -3245,6 +3252,41 @@ export default class MatrixService extends Service {
       this._systemCard = loadedCard;
     }
   }
+
+  private scheduleSystemCardRetry() {
+    if (isTesting()) {
+      // Tests drive recovery via `setSystemCard` directly so the assertions
+      // are deterministic; skip the background timer loop, which would
+      // otherwise keep firing while a stubbed card stays unloadable.
+      return;
+    }
+    if (!this._systemCardLoadFailed || this.retrySystemCardLoadTask.isRunning) {
+      return;
+    }
+    this.retrySystemCardLoadTask.perform();
+  }
+
+  // Bounded like retryUnreachableRealmServersTask: after the schedule is
+  // exhausted the session stays on the fallback SystemCard until something
+  // else re-enters setSystemCard (an account-data change, a reload).
+  private retrySystemCardLoadTask = restartableTask(async () => {
+    for (
+      let attempt = 0;
+      this._systemCardLoadFailed &&
+      attempt < SYSTEM_CARD_RETRY_DELAYS_MS.length;
+      attempt++
+    ) {
+      await rawTimeout(SYSTEM_CARD_RETRY_DELAYS_MS[attempt]);
+      if (this.isDestroying || this.isDestroyed) {
+        return;
+      }
+      try {
+        await this.setSystemCard(this._userChoiceId);
+      } catch (err) {
+        console.error('Failed to retry SystemCard load', err);
+      }
+    }
+  });
 
   // Fires when the active SystemCard is deleted in the same session (either
   // via the in-tab UI or via a matrix-auth-room invalidation originating

--- a/packages/host/app/utils/file-def-attributes-extractor.ts
+++ b/packages/host/app/utils/file-def-attributes-extractor.ts
@@ -64,6 +64,41 @@ export type FileDefExtractResult = {
   frontmatterDiagnostics?: Partial<Diagnostics>;
 };
 
+// A failure to obtain the file's bytes: the fetch rejected, returned non-ok,
+// or the body stream errored mid-read. The extractor's class-chain fallback
+// exists for parse failures — a subclass that cannot make sense of the
+// content hands off to its parent. A byte-acquisition failure is different in
+// kind: every class faces the same missing bytes, and the base FileDef
+// "succeeds" without reading them, which would index the file as a bare
+// FileDef — permanently dropping its subtype fields (a markdown skill loses
+// `kind`, an image loses its dimensions) with nothing to retry the row. The
+// stream plumbing tags these errors so `extract()` can abort the chain and
+// return `status: 'error'`, which the indexer persists as a retryable error
+// row instead.
+export class FileBytesUnavailableError extends Error {
+  isFileBytesUnavailable = true;
+  cause: unknown;
+  constructor(fileURL: string, cause: unknown) {
+    super(
+      `could not obtain file bytes for ${fileURL}: ${
+        (cause as Error)?.message ?? String(cause)
+      }`,
+    );
+    this.name = 'FileBytesUnavailableError';
+    this.cause = cause;
+  }
+}
+
+export function isFileBytesUnavailableError(
+  error: unknown,
+): error is FileBytesUnavailableError {
+  return (
+    typeof error === 'object' &&
+    error != null &&
+    (error as FileBytesUnavailableError).isFileBytesUnavailable === true
+  );
+}
+
 export class FileDefAttributesExtractor {
   #loaderService: LoaderService;
   #network: NetworkService;
@@ -160,6 +195,7 @@ export class FileDefAttributesExtractor {
     let deps = [this.#fileDefCodeRef.module];
     let error: RenderError | undefined;
     let mismatch = false;
+    let bytesUnavailable: FileBytesUnavailableError | undefined;
 
     let recordError = (err: unknown) => {
       if (!error) {
@@ -194,7 +230,14 @@ export class FileDefAttributesExtractor {
           `[file-extract] ${(klass as any).displayName ?? (klass as any).name ?? 'unknown'}.extractAttributes failed for ${this.#fileURL}:`,
           err,
         );
-        recordError(err);
+        // A byte-acquisition failure aborts the whole chain (see
+        // FileBytesUnavailableError) — falling back to a parent class would
+        // misclassify the file rather than repair anything.
+        if (isFileBytesUnavailableError(err)) {
+          bytesUnavailable = err;
+        } else {
+          recordError(err);
+        }
         return undefined;
       }
     };
@@ -233,6 +276,9 @@ export class FileDefAttributesExtractor {
           ? 'Base FileDef module did not export extractAttributes'
           : 'FileDef module did not export extractAttributes';
       let searchDoc = await tryExtract(klass, missingMessage);
+      if (bytesUnavailable) {
+        break;
+      }
       if (searchDoc) {
         let typeCodeRefs = getTypes(klass);
         let types = typeCodeRefs.map((type) =>
@@ -307,6 +353,19 @@ export class FileDefAttributesExtractor {
       }
     }
 
+    if (bytesUnavailable) {
+      return {
+        status: 'error',
+        searchDoc: null,
+        deps,
+        error: this.#buildError(
+          this.#fileURL,
+          bytesUnavailable.cause ?? bytesUnavailable,
+        ),
+        ...(mismatch ? { mismatch: true } : {}),
+      };
+    }
+
     return {
       status: 'error',
       searchDoc: null,
@@ -334,12 +393,24 @@ export class FileDefAttributesExtractor {
   // runtime-common/stream.ts does this (it cancels in a `finally`), and is what
   // the header-only extractors (the image defs) already use; partial readers
   // should go through it rather than draining the stream by hand.
+  //
+  // Failures anywhere in this plumbing — the fetch itself, buffering, or a
+  // mid-read error on the live body — are surfaced as
+  // FileBytesUnavailableError so the extract aborts instead of falling back
+  // down the class chain.
   #getStreamForAttempt = async () => {
-    if (!this.#primaryUsed) {
-      this.#primaryUsed = true;
-      return this.#getPrimaryStream();
+    try {
+      if (!this.#primaryUsed) {
+        this.#primaryUsed = true;
+        return await this.#getPrimaryStream();
+      }
+      return await this.#getRetryStream();
+    } catch (err) {
+      if (isFileBytesUnavailableError(err)) {
+        throw err;
+      }
+      throw new FileBytesUnavailableError(this.#fileURL, err);
     }
-    return this.#getRetryStream();
   };
 
   async #getPrimaryStream(): Promise<ReadableStream<Uint8Array> | Uint8Array> {
@@ -351,9 +422,38 @@ export class FileDefAttributesExtractor {
     // back to a buffered read only when the body isn't a stream (real fetches
     // always expose one; this keeps non-streaming environments working).
     if (response.body) {
-      return response.body;
+      return this.#tagStreamErrors(response.body);
     }
     return new Uint8Array(await response.arrayBuffer());
+  }
+
+  // A pass-through over the live body whose read failures reject with
+  // FileBytesUnavailableError, so a connection reset mid-stream is
+  // classified the same way as a failed fetch.
+  #tagStreamErrors(
+    stream: ReadableStream<Uint8Array>,
+  ): ReadableStream<Uint8Array> {
+    let reader = stream.getReader();
+    let fileURL = this.#fileURL;
+    return new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        let result: ReadableStreamReadResult<Uint8Array>;
+        try {
+          result = await reader.read();
+        } catch (err) {
+          controller.error(new FileBytesUnavailableError(fileURL, err));
+          return;
+        }
+        if (result.done) {
+          controller.close();
+        } else {
+          controller.enqueue(result.value);
+        }
+      },
+      cancel(reason) {
+        return reader.cancel(reason);
+      },
+    });
   }
 
   async #getRetryStream(): Promise<Uint8Array> {

--- a/packages/host/tests/integration/components/deserialize-mismatched-link-test.gts
+++ b/packages/host/tests/integration/components/deserialize-mismatched-link-test.gts
@@ -1,0 +1,125 @@
+// A link field's target lives in another document, and its index row can be
+// wrong independently of the card that links to it — a file the indexer
+// misclassified serializes with the wrong adoptsFrom, so it rehydrates as a
+// type the field does not accept. Deserialization drops such a target (with a
+// warning) instead of failing the whole document: one bad row in a linked
+// realm must not make every card that references it unloadable. Direct
+// assignment keeps strict validation.
+
+import { module, test } from 'qunit';
+
+import { baseRRI } from '@cardstack/runtime-common';
+
+import {
+  setupBaseRealm,
+  createFromSerialized,
+  FileDef,
+} from '../../helpers/base-realm';
+import { setupRenderingTest } from '../../helpers/setup';
+
+const REALM = 'https://test-realm/';
+
+function fileMetaResource(
+  id: string,
+  adoptsFrom: { module: string; name: string },
+  attributes: Record<string, unknown> = {},
+) {
+  return {
+    id,
+    type: 'file-meta' as const,
+    attributes: {
+      name: id.split('/').pop(),
+      url: id,
+      sourceUrl: id,
+      contentType: 'text/markdown',
+      ...attributes,
+    },
+    meta: { adoptsFrom },
+    links: { self: id },
+  };
+}
+
+module('Integration | deserialize mismatched link', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  function systemCardDoc() {
+    let goodSkill = fileMetaResource(
+      `${REALM}skill.md`,
+      { module: baseRRI('markdown-file-def'), name: 'MarkdownDef' },
+      { kind: 'skill' },
+    );
+    // The shape a misclassified index row serves: the file rehydrates as a
+    // plain FileDef, which does not satisfy linksToMany(MarkdownDef).
+    let misclassifiedSkill = fileMetaResource(`${REALM}index.md`, {
+      module: baseRRI('card-api'),
+      name: 'FileDef',
+    });
+    let resource = {
+      id: `${REALM}SystemCard/default`,
+      type: 'card' as const,
+      attributes: { title: 'Default System Configuration' },
+      relationships: {
+        'defaultSkillFiles.0': {
+          links: { self: misclassifiedSkill.id },
+          data: { type: 'file-meta', id: misclassifiedSkill.id },
+        },
+        'defaultSkillFiles.1': {
+          links: { self: goodSkill.id },
+          data: { type: 'file-meta', id: goodSkill.id },
+        },
+      },
+      meta: {
+        adoptsFrom: { module: baseRRI('system-card'), name: 'SystemCard' },
+      },
+    };
+    return {
+      resource,
+      doc: { data: resource, included: [misclassifiedSkill, goodSkill] },
+    };
+  }
+
+  test('a linksToMany target that does not satisfy the field type is dropped, not fatal', async function (assert) {
+    let { resource, doc } = systemCardDoc();
+
+    let instance: any = await createFromSerialized(
+      resource as any,
+      doc as any,
+      undefined,
+    );
+
+    assert.ok(instance, 'the document deserializes despite the bad target');
+    assert.strictEqual(
+      instance.defaultSkillFiles.length,
+      1,
+      'the mismatched target is dropped',
+    );
+    assert.strictEqual(
+      instance.defaultSkillFiles[0]?.sourceUrl,
+      `${REALM}skill.md`,
+      'the conforming target survives',
+    );
+  });
+
+  test('direct assignment of a mismatched link still throws', async function (assert) {
+    let { resource, doc } = systemCardDoc();
+    let instance: any = await createFromSerialized(
+      resource as any,
+      doc as any,
+      undefined,
+    );
+    let plainFile = new FileDef({
+      id: `${REALM}note.txt`,
+      name: 'note.txt',
+      contentType: 'text/plain',
+    });
+
+    assert.throws(
+      () => {
+        instance.defaultSkillFiles = [plainFile];
+      },
+      /field validation error/,
+      'user-set values keep strict validation',
+    );
+  });
+});

--- a/packages/host/tests/integration/file-def-attributes-extractor-test.gts
+++ b/packages/host/tests/integration/file-def-attributes-extractor-test.gts
@@ -1,0 +1,131 @@
+// The FileDefAttributesExtractor walks the FileDef class chain: a subclass
+// that cannot parse the content hands off to its parent, so a malformed file
+// still indexes as a plain FileDef. These tests pin the boundary of that
+// fallback: a failure to OBTAIN the bytes (fetch rejected, non-ok response,
+// or the body stream erroring mid-read) must abort the extract with
+// `status: 'error'` instead — the base FileDef would "succeed" without
+// reading the bytes and permanently misclassify the file (a markdown skill
+// loses `kind`, so it stops being a skill).
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm, rri } from '@cardstack/runtime-common';
+
+import type LoaderService from '@cardstack/host/services/loader-service';
+import type NetworkService from '@cardstack/host/services/network';
+import { FileDefAttributesExtractor } from '@cardstack/host/utils/file-def-attributes-extractor';
+import { buildFileExtractError } from '@cardstack/host/utils/file-extract-runner';
+
+import { setupLocalIndexing, testRealmURL } from '../helpers';
+import { setupBaseRealm } from '../helpers/base-realm';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupRenderingTest } from '../helpers/setup';
+
+const SKILL_MD = `---
+boxel:
+  kind: skill
+---
+# A Markdown Skill
+
+Body paragraph.
+`;
+
+module('Integration | file-def-attributes-extractor', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+  setupMockMatrix(hooks);
+
+  let loaderService: LoaderService;
+  let network: NetworkService;
+
+  hooks.beforeEach(function () {
+    loaderService = getService('loader-service');
+    network = getService('network');
+  });
+
+  function makeExtractor(authedFetch: (request: Request) => Promise<Response>) {
+    return new FileDefAttributesExtractor({
+      loaderService,
+      network: {
+        virtualNetwork: network.virtualNetwork,
+        authedFetch,
+      } as unknown as NetworkService,
+      fileURL: `${testRealmURL}index.md`,
+      fileDefCodeRef: {
+        module: rri(`${baseRealm.url}markdown-file-def`),
+        name: 'MarkdownDef',
+      },
+      baseFileDefCodeRef: {
+        module: rri(`${baseRealm.url}card-api`),
+        name: 'FileDef',
+      },
+      contentHash: undefined,
+      contentSize: undefined,
+      buildError: buildFileExtractError,
+    });
+  }
+
+  test('extracts markdown attributes when the bytes stream cleanly', async function (assert) {
+    let extractor = makeExtractor(
+      async () => new Response(new TextEncoder().encode(SKILL_MD)),
+    );
+
+    let result = await extractor.extract();
+
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(result.searchDoc?.kind, 'skill');
+    assert.true(
+      (result.types ?? []).some((type) => type.endsWith('/MarkdownDef')),
+      `types carry the markdown subtype: ${JSON.stringify(result.types)}`,
+    );
+  });
+
+  test('a rejected byte fetch aborts the extract instead of falling back to FileDef', async function (assert) {
+    let fetchCount = 0;
+    let extractor = makeExtractor(async () => {
+      fetchCount++;
+      throw new TypeError('network error');
+    });
+
+    let result = await extractor.extract();
+
+    assert.strictEqual(result.status, 'error');
+    assert.strictEqual(
+      result.types,
+      undefined,
+      'no fallback type chain is stamped for a file whose bytes never arrived',
+    );
+    assert.ok(result.error, 'the failure is carried on the result');
+    assert.ok(fetchCount >= 1, 'the fetch was attempted');
+  });
+
+  test('a body stream erroring mid-read aborts the extract instead of falling back to FileDef', async function (assert) {
+    let body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(SKILL_MD.slice(0, 10)));
+        controller.error(new TypeError('connection reset mid-stream'));
+      },
+    });
+    let served = false;
+    let extractor = makeExtractor(async () => {
+      if (served) {
+        // The retry stream re-fetches; fail that too so the extract cannot
+        // quietly recover through the buffered path.
+        throw new TypeError('connection reset');
+      }
+      served = true;
+      return new Response(body);
+    });
+
+    let result = await extractor.extract();
+
+    assert.strictEqual(result.status, 'error');
+    assert.strictEqual(
+      result.types,
+      undefined,
+      'no fallback type chain is stamped when the stream died mid-read',
+    );
+  });
+});

--- a/packages/observability/provisioning/alerting/indexing-status-group.json
+++ b/packages/observability/provisioning/alerting/indexing-status-group.json
@@ -1,0 +1,152 @@
+{
+  "apiVersion": 1,
+  "groups": [
+    {
+      "orgId": 1,
+      "name": "indexing-status-group",
+      "folder": "defd2d156sav4d",
+      "interval": "60s",
+      "rules": [
+        {
+          "id": 1,
+          "uid": "idxfileextractfb",
+          "orgID": 1,
+          "folderUID": "defd2d156sav4d",
+          "ruleGroup": "indexing-status-group",
+          "title": "File Extract Fallback",
+          "condition": "B",
+          "data": [
+            {
+              "refId": "A",
+              "queryType": "",
+              "relativeTimeRange": {
+                "from": 10800,
+                "to": 0
+              },
+              "datasourceUid": "cef5x9o3yzawwf",
+              "model": {
+                "datasource": {
+                  "type": "cloudwatch",
+                  "uid": "cef5x9o3yzawwf"
+                },
+                "dimensions": {},
+                "expression": "filter @message like /extractor fallback while indexing file/\n| stats count() by bin(5m)",
+                "id": "",
+                "intervalMs": 1000,
+                "label": "",
+                "logGroups": [
+                  {
+                    "accountId": "${WORKER_LOG_GROUP_ACCOUNT_ID}",
+                    "arn": "arn:aws:logs:us-east-1:${WORKER_LOG_GROUP_ACCOUNT_ID}:log-group:${WORKER_LOG_GROUP_NAME}",
+                    "name": "${WORKER_LOG_GROUP_NAME}"
+                  }
+                ],
+                "matchExact": true,
+                "maxDataPoints": 43200,
+                "metricEditorMode": 0,
+                "metricName": "",
+                "metricQueryType": 0,
+                "namespace": "",
+                "period": "",
+                "queryMode": "Logs",
+                "refId": "A",
+                "region": "default",
+                "sqlExpression": "",
+                "statistic": "Average",
+                "statsGroups": ["bin(5m)"]
+              }
+            },
+            {
+              "refId": "B",
+              "queryType": "",
+              "relativeTimeRange": {
+                "from": 10800,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "conditions": [
+                  {
+                    "evaluator": {
+                      "params": [0, 0],
+                      "type": "gt"
+                    },
+                    "operator": {
+                      "type": "and"
+                    },
+                    "query": {
+                      "params": []
+                    },
+                    "reducer": {
+                      "params": [],
+                      "type": "avg"
+                    },
+                    "type": "query"
+                  }
+                ],
+                "datasource": {
+                  "name": "Expression",
+                  "type": "__expr__",
+                  "uid": "__expr__"
+                },
+                "expression": "C",
+                "intervalMs": 1000,
+                "maxDataPoints": 43200,
+                "refId": "B",
+                "type": "threshold"
+              }
+            },
+            {
+              "refId": "C",
+              "queryType": "",
+              "relativeTimeRange": {
+                "from": 0,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "conditions": [
+                  {
+                    "evaluator": {
+                      "params": [0, 0],
+                      "type": "gt"
+                    },
+                    "operator": {
+                      "type": "and"
+                    },
+                    "query": {
+                      "params": []
+                    },
+                    "reducer": {
+                      "params": [],
+                      "type": "avg"
+                    },
+                    "type": "query"
+                  }
+                ],
+                "datasource": {
+                  "name": "Expression",
+                  "type": "__expr__",
+                  "uid": "__expr__"
+                },
+                "expression": "A",
+                "intervalMs": 1000,
+                "maxDataPoints": 43200,
+                "reducer": "max",
+                "refId": "C",
+                "type": "reduce"
+              }
+            }
+          ],
+          "updated": "2026-09-01T00:00:00Z",
+          "noDataState": "OK",
+          "execErrState": "Alerting",
+          "for": "30s",
+          "provenance": "api",
+          "isPaused": false,
+          "notification_settings": null
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
There was a situation in staging where the AI assistant showed 0 skills and single model:

<img width="752" height="226" alt="image" src="https://github.com/user-attachments/assets/a149efa3-79b1-4920-8a24-9e6c0ba6387a" />
<img width="964" height="612" alt="image" src="https://github.com/user-attachments/assets/819edc92-f550-4d31-bf27-75a0dd0abd4a" />

The reason this happened:

1. The indexer re-indexed a file — `skills/index.md`, the default room skill. To do that it downloads the file's bytes, and that one download failed with `net::ERR_HTTP2_PROTOCOL_ERROR` — the HTTP/2 connection between the prerender page and the realm server was reset mid-request — so the markdown parser could not run.
2. Instead of trying again, the indexer fell back to indexing the file as a generic file, and saved that as a normal success — so nothing ever retried it. The file permanently lost its markdown fields, including `kind: skill`.
3. The SystemCard — the card that lists the available LLM models and the default skills — links to that file through a field typed "markdown file". A generic file does not satisfy that type, so loading the SystemCard threw and the whole card became unloadable.
4. The host caches that failure for the entire session: the model picker drops to the built-in fallback list, and new chat rooms are created with an empty skill list. The empty list is saved into the room's state, so the room stays at 0 skills even after the index is repaired.

Net effect: one reset connection during indexing broke the assistant until someone manually reindexed.

Reindexing solved it for staging — the fresh pass rewrote the bad row, and models and skills came back. (Rooms created during the broken window keep their empty skill list, since room state is persisted; they need the skill re-added or a new session.)

Steps taken to not have this happen again, one commit each:

1. A failed download now produces an error row instead of a wrong success row. Error rows are retried on the next indexing pass, so the index heals itself. The generic-file fallback stays for its real purpose: content the specific parser cannot handle.
2. The download retries twice with a short pause before giving up, so most dropped connections never surface at all.
3. A linked card or file that does not satisfy the field's type is dropped from that field (with a console warning) instead of making the whole linking card unloadable. Direct assignment still validates strictly.
4. The host retries a failed SystemCard load on a backoff schedule, and applies the default skills when it opens an empty room that never had any — so neither failure is permanent anymore.
5. A Grafana alert fires on the log line that signals the generic-file fallback, which was previously the only — and unwatched — sign that a file row silently degraded.
