### PR TITLE
feat: ScreenshotCardTool served-URL parity and download-file-to-realm

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -204,6 +204,17 @@ export class ReadBinaryFileResult extends CardDef {
   @field contentType = contains(StringField);
 }
 
+export class DownloadFileToRealmInput extends CardDef {
+  @field sourceUrl = contains(StringField); // the URL to download
+  @field realm = contains(StringField); // target realm (defaults to the writable realm)
+  @field path = contains(StringField); // destination path within the realm, e.g. "Screenshots/card.png"
+  @field useNonConflictingFilename = contains(BooleanField);
+}
+
+export class DownloadFileToRealmResult extends CardDef {
+  @field fileIdentifier = contains(StringField);
+}
+
 export class GenerateThumbnailInput extends CardDef {
   @field prompt = contains(StringField);
   @field sourceImageUrl = contains(StringField);
@@ -221,10 +232,78 @@ export class GenerateThumbnailOutput extends CardDef {
 export class ScreenshotCardInput extends CardDef {
   @field card = linksTo(CardDef);
   @field format = contains(StringField); // 'isolated' | 'embedded'
+  // The capture surface, exposed one JSON-primitive field per parameter.
+  // `run-command`'s headless input path is `new InputType(rawJson)` with no
+  // card resolution, so a non-primitive (linksTo/containsMany-of-object)
+  // input can't be fed there — the geometry is flattened into
+  // StringField/NumberField/BooleanField fields the tool reassembles into the
+  // endpoint's nested `captureSpec` (see capture-spec.ts). Every field is
+  // optional; each is part of the canonical capture identity, so a capture
+  // with any of them persists and serves under its own durable URL.
+  @field viewportWidth = contains(NumberField);
+  @field viewportHeight = contains(NumberField);
+  @field deviceScaleFactor = contains(NumberField);
+  @field fullPage = contains(BooleanField);
+  @field clipX = contains(NumberField);
+  @field clipY = contains(NumberField);
+  @field clipWidth = contains(NumberField);
+  @field clipHeight = contains(NumberField);
+}
+
+// One captured image. `url` is the durable served MediaCache URL the capture
+// persisted under — the only reference the tool returns; a re-capture rotates
+// its bytes, never the URL.
+export class ScreenshotCapture extends FieldDef {
+  @field name = contains(StringField);
+  @field url = contains(StringField);
+  @field width = contains(NumberField);
+  @field height = contains(NumberField);
 }
 
 export class ScreenshotCardOutput extends CardDef {
-  @field imageDefUrl = contains(StringField);
+  static displayName = 'Screenshot Result';
+
+  @field captures = containsMany(ScreenshotCapture);
+
+  static embedded = class Embedded extends Component<
+    typeof ScreenshotCardOutput
+  > {
+    <template>
+      <div class='screenshot-result'>
+        {{#each @model.captures as |capture|}}
+          <figure class='capture'>
+            {{#if capture.url}}
+              <img src={{capture.url}} alt={{capture.name}} />
+              <figcaption><a href={{capture.url}}>{{capture.url}}</a></figcaption>
+            {{/if}}
+          </figure>
+        {{/each}}
+      </div>
+      <style scoped>
+        .screenshot-result {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-sm);
+          padding: var(--boxel-sp-sm);
+        }
+        .capture {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-xxs);
+        }
+        .capture img {
+          max-width: 100%;
+          border: 1px solid var(--boxel-200);
+          border-radius: var(--boxel-border-radius);
+        }
+        .capture figcaption {
+          font-size: var(--boxel-font-sm);
+          word-break: break-all;
+        }
+      </style>
+    </template>
+  };
 }
 
 export class CreateInstanceInput extends CardDef {

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -233,9 +233,11 @@ export class ScreenshotCardInput extends CardDef {
   @field card = linksTo(CardDef);
   @field format = contains(StringField); // 'isolated' | 'embedded'
   // The capture surface, exposed one JSON-primitive field per parameter.
-  // `run-command`'s headless input path is `new InputType(rawJson)` with no
-  // card resolution, so a non-primitive (linksTo/containsMany-of-object)
-  // input can't be fed there — the geometry is flattened into
+  // `run-command`'s headless input path builds this card via
+  // `new InputType(rawJson)`; it resolves `linksTo` ids to instances (that is
+  // how `card` above reaches the tool) but cannot construct a nested
+  // `contains(SomeFieldDef)` from a plain JSON object — the field validator
+  // rejects a non-instance value. So the geometry is flattened into
   // StringField/NumberField/BooleanField fields the tool reassembles into the
   // endpoint's nested `captureSpec` (see capture-spec.ts). Every field is
   // optional; each is part of the canonical capture identity, so a capture

--- a/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/README.md
+++ b/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/README.md
@@ -15,15 +15,15 @@ validated: source-proven
 - **Audit / approval trails** — capture the visible state when a workflow card transitions.
 - **AI assistant** — let the model take a screenshot of a card and fetch the served URL to inspect (and improve) the render.
 
-**The insight:** `ScreenshotCardCommand` (from `@cardstack/boxel-host/tools/screenshot-card`) is a Boxel host command that orchestrates the realm-server screenshot job end-to-end. You pass the target card (as a `linksTo` reference), a format string, and optionally a few capture-tuning primitives; you get back a `captures` array. Each capture has a served `url` you can render straight into an `<img>` or hand to another card. The realm-server enqueues the job, the worker drives a Puppeteer browser through the prerender pool, and the capture is persisted to the media cache — the tool no longer writes a PNG file into a realm. When the tool runs inside the AI assistant, the served URL is posted into the room, where it renders inline and the model can fetch it.
+**The insight:** `ScreenshotCardTool` (from `@cardstack/boxel-host/tools/screenshot-card`) is a Boxel host tool that orchestrates the realm-server screenshot job end-to-end. You pass the target card (as a `linksTo` reference), a format string, and optionally a few capture-tuning primitives; you get back a `captures` array. Each capture has a served `url` you can render straight into an `<img>` or hand to another card. The realm-server enqueues the job, the worker drives a Puppeteer browser through the prerender pool, and the capture is persisted to the media cache; nothing is written into a realm. When the tool runs inside the AI assistant, the served URL is posted into the room, where it renders inline and the model can fetch it.
 
 ## Recipe shape
 
 ```ts
-import ScreenshotCardCommand from '@cardstack/boxel-host/tools/screenshot-card';
+import ScreenshotCardTool from '@cardstack/boxel-host/tools/screenshot-card';
 
 // Inside an @action method:
-let result = await new ScreenshotCardCommand(commandContext).execute({
+let result = await new ScreenshotCardTool(toolContext).execute({
   card,                  // the linked CardDef instance to screenshot
   format: 'isolated',    // 'isolated' or 'embedded' — nothing else
 });
@@ -37,13 +37,13 @@ The full demo card (`example.gts`) wraps this in a CardDef that:
 - Holds the target via `@field card = linksTo(CardDef)`.
 - Holds the format via `@field format = contains(enumField(StringField, { options: ['isolated', 'embedded'] }))`.
 - Owns `@tracked isRunning`, `@tracked errorMessage`, `@tracked imageUrl` for UI state.
-- Disables the action button until `commandContext` is available and a card is linked.
+- Disables the action button until `toolContext` is available and a card is linked.
 
 ## API surface
 
 | Input field | Type | Required | Notes |
 |---|---|---|---|
-| `card` | `linksTo(CardDef)` | yes | Must already be saved — the command needs a card id. |
+| `card` | `linksTo(CardDef)` | yes | Must already be saved — the tool needs a card id. |
 | `format` | `'isolated' \| 'embedded'` | yes | **No other values accepted.** Fitted / atom / edit / markdown will throw. |
 | `viewportWidth` / `viewportHeight` | `number` | no | Viewport size in CSS px. Provide **both** or neither. |
 | `deviceScaleFactor` | `number` | no | Retina/hi-dpi multiplier (≤ 3). |
@@ -60,21 +60,21 @@ Every capture field is a JSON primitive, deliberately: the headless `run-command
 
 ## How the realm-server does the work
 
-1. `ScreenshotCardCommand.run()` POSTs `{ realmURL, cardId, format, includeBase64: false, captureSpec? }` to `/_screenshot-card` on the realm-server, authenticated with the card realm's JWT.
+1. `ScreenshotCardTool.run()` POSTs `{ realmURL, cardId, format, includeBase64: false, captureSpec? }` to `/_screenshot-card` on the realm-server, authenticated with the card realm's JWT.
 2. The handler (`packages/realm-server/handlers/handle-screenshot-card.ts`) answers from the media-cache ledger when the capture already exists, else enqueues a `screenshot-card` job.
 3. The worker task (`runtime-common/tasks/screenshot-card.ts`) drives Puppeteer through the prerender pool to render the card at the requested format and geometry.
 4. Puppeteer waits for the page to settle (data loads, animations, font swap, prerender hooks) before capturing.
 5. The capture — format-only or with geometry — is persisted to the media cache under its full capture identity (format + `viewport` / `deviceScaleFactor` / `fullPage` / `clip`), and the response carries its served `url`.
 
-You don't see any of this from the consumer side — `await new ScreenshotCardCommand(ctx).execute({ card, format })` returns when the capture is ready.
+You don't see any of this from the consumer side — `await new ScreenshotCardTool(ctx).execute({ card, format })` returns when the capture is ready.
 
 ## Wire as a card menu item
 
-To make "Screenshot this card" a right-click affordance on every CardDef, compose with the [`link-command-menu-item`](../link-command-menu-item/README.md) pattern. The action body calls `ScreenshotCardCommand` with `this` as the card and a fixed format (or branches on a sub-menu):
+To make "Screenshot this card" a right-click affordance on every CardDef, compose with the [`link-command-menu-item`](../link-command-menu-item/README.md) pattern. The action body calls `ScreenshotCardTool` with `this` as the card and a fixed format (or branches on a sub-menu):
 
 ```ts
 import { getCardMenuItems, type GetCardMenuItemParams, type MenuItemOptions } from '@cardstack/runtime-common';
-import ScreenshotCardCommand from '@cardstack/boxel-host/tools/screenshot-card';
+import ScreenshotCardTool from '@cardstack/boxel-host/tools/screenshot-card';
 import CameraIcon from '@cardstack/boxel-icons/camera';
 
 class MyCard extends CardDef {
@@ -84,7 +84,7 @@ class MyCard extends CardDef {
         label: 'Screenshot isolated',
         icon: CameraIcon,
         action: async () => {
-          let result = await new ScreenshotCardCommand(params.commandContext)
+          let result = await new ScreenshotCardTool(params.toolContext)
             .execute({ card: this as any, format: 'isolated' });
           // Optionally show toast with result.captures[0]?.url
         },
@@ -93,7 +93,7 @@ class MyCard extends CardDef {
         label: 'Screenshot embedded',
         icon: CameraIcon,
         action: async () => {
-          await new ScreenshotCardCommand(params.commandContext)
+          await new ScreenshotCardTool(params.toolContext)
             .execute({ card: this as any, format: 'embedded' });
         },
       },
@@ -107,18 +107,18 @@ This gives every instance of `MyCard` two menu items that capture a settled PNG 
 
 ## Gotchas
 
-- **Format is restricted to `isolated` or `embedded`.** `fitted`, `atom`, `edit`, `markdown` will throw. The reason: only those two formats have stable browser-viewport semantics; fitted is container-driven and needs an explicit size envelope that the command doesn't expose.
-- **Target card must be saved.** The command needs a card id. If you're in a draft / pre-save flow, save first.
-- **Read access, not write.** The command reads the target card and captures it; it no longer writes a file back. If the current user can't read the target's realm, it fails fast.
+- **Format is restricted to `isolated` or `embedded`.** `fitted`, `atom`, `edit`, `markdown` will throw. The reason: only those two formats have stable browser-viewport semantics; fitted is container-driven and needs an explicit size envelope that the tool doesn't expose.
+- **Target card must be saved.** The tool needs a card id. If you're in a draft / pre-save flow, save first.
+- **Read access, not write.** The tool reads the target card and captures it; nothing is written into a realm. If the current user can't read the target's realm, it fails fast.
 - **Geometry captures are URL-served too.** Supplying `viewport*` / `deviceScaleFactor` / `fullPage` / `clip*` is part of the capture's canonical identity, so the capture persists and comes back with its own `captures[].url` (the geometry encoded in the query string) — no base64, no special-casing versus a format-only capture.
 - **Paired fields are all-or-nothing.** Provide both `viewportWidth` and `viewportHeight`, or all four `clip*` edges — a half-specified viewport or region throws with a clear message.
-- **Long renders can time out to a retry.** The realm-server waits for the job within a bounded budget; a slow render answers `503` with a `Retry-After`, which the command surfaces as a "still rendering; retry" error. A canonical capture resumes cheaply on retry (ledger hit); a custom spec re-renders.
-- **commandContext must exist.** Only available in host interact mode — the prerenderer / SSR context doesn't have a live host. Feature-detect with `this.args.context?.commandContext` before calling.
-- **`listing-create` does not use this command.** The catalog's listing-creation flow uses `GenerateThumbnailCommand` (AI-generated stylized icon, not a real screenshot). Use `ScreenshotCardCommand` when you want the actual rendered card, not an interpretation.
+- **Long renders can time out to a retry.** The realm-server waits for the job within a bounded budget; a slow render answers `503` with a `Retry-After`, which the tool surfaces as a "still rendering; retry" error. A canonical capture resumes cheaply on retry (ledger hit); a custom spec re-renders.
+- **toolContext must exist.** Only available in host interact mode — the prerenderer / SSR context doesn't have a live host. Feature-detect with `this.args.context?.toolContext` before calling.
+- **`listing-create` does not use this tool.** The catalog's listing-creation flow uses `GenerateThumbnailCommand` (AI-generated stylized icon, not a real screenshot). Use `ScreenshotCardTool` when you want the actual rendered card, not an interpretation.
 
 ## Source
 
-- Host command: `@cardstack/boxel-host/tools/screenshot-card` — `packages/host/app/tools/screenshot-card.ts` in the boxel monorepo.
+- Host tool: `@cardstack/boxel-host/tools/screenshot-card` — `packages/host/app/tools/screenshot-card.ts` in the boxel monorepo.
 - Realm-server endpoint: `POST /_screenshot-card` → `packages/realm-server/handlers/handle-screenshot-card.ts`.
 - Worker task: `packages/runtime-common/tasks/screenshot-card.ts`.
 - Capture spec (bounds + strict parse): `packages/runtime-common/capture-spec.ts`.

--- a/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/README.md
+++ b/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/README.md
@@ -4,18 +4,18 @@ validated: source-proven
 
 # integrate-screenshot-card-format — Capture a settled PNG of any card at `isolated` or `embedded` format
 
-**What this gives you:** A reliable way for one card to take a *picture* of another card — at the format you choose — and store it as a real PNG file linked through `ImageDef`. The realm-server drives Puppeteer through the prerender pool to capture a fully-settled render (after data loads, animations resolve, layout completes), so the snapshot reflects what a user would see, not a half-loaded skeleton.
+**What this gives you:** A reliable way for one card to take a *picture* of another card — at the format you choose — and get back a served URL for the capture. The realm-server drives Puppeteer through the prerender pool to capture a fully-settled render (after data loads, animations resolve, layout completes), so the snapshot reflects what a user would see, not a half-loaded skeleton.
 
 **Sibling pattern:** [`integrate-thumbnail-card-ai`](../integrate-thumbnail-card-ai/README.md) — for **AI-generated** stylised thumbnails (designed icons, brand-mark tiles, catalog hero images). Use that when the user wants a *designed representation* of a card; use **this** pattern when the user wants the *actual rendering*. The catalog's `listing-create.autoGenerateThumbnail` uses the AI sibling; doc/audit/Open-Graph flows want this one.
 
 **When to use:**
-- **Documentation cards / changelogs / before-after diffs** — snapshot a card at a point in time, store the PNG alongside the doc.
+- **Documentation cards / changelogs / before-after diffs** — snapshot a card at a point in time.
 - **Social-share cards / Open Graph images** — render a designed `embedded` format, screenshot it, serve as `og:image`.
 - **Marketing pages, design-system snapshots, portfolio captures** — programmatically render card galleries.
 - **Audit / approval trails** — capture the visible state when a workflow card transitions.
-- **Test fixtures** — anywhere a `.png` of a real render beats a hand-curated mock.
+- **AI assistant** — let the model take a screenshot of a card and fetch the served URL to inspect (and improve) the render.
 
-**The insight:** `ScreenshotCardCommand` (from `@cardstack/boxel-host/tools/screenshot-card`) is a Boxel host command that orchestrates the realm-server screenshot job end-to-end. You pass two inputs — the target card (as a `linksTo` reference) and a format string — and you get back an `imageDefUrl` you can render straight into an `<img>` or link from another card via `ImageDef` / `PngDef`. The realm-server enqueues the job, the worker drives a Puppeteer browser through the prerender pool, the PNG comes back as base64, and `WriteBinaryFileCommand` writes it to `Screenshots/<slug>-<uuid>.png` in the **target card's own realm**. Cards never see the bytes; you get a clean URL.
+**The insight:** `ScreenshotCardCommand` (from `@cardstack/boxel-host/tools/screenshot-card`) is a Boxel host command that orchestrates the realm-server screenshot job end-to-end. You pass the target card (as a `linksTo` reference), a format string, and optionally a few capture-tuning primitives; you get back a `captures` array. Each capture has a served `url` you can render straight into an `<img>` or hand to another card. The realm-server enqueues the job, the worker drives a Puppeteer browser through the prerender pool, and the capture is persisted to the media cache — the tool no longer writes a PNG file into a realm. When the tool runs inside the AI assistant, the served URL is posted into the room, where it renders inline and the model can fetch it.
 
 ## Recipe shape
 
@@ -28,11 +28,9 @@ let result = await new ScreenshotCardCommand(commandContext).execute({
   format: 'isolated',    // 'isolated' or 'embedded' — nothing else
 });
 
-this.imageDefUrl = result.imageDefUrl;
+this.imageUrl = result.captures?.[0]?.url ?? null;
 // Now render directly:
-//   <img src={{this.imageDefUrl}} />
-// Or assign to a linksTo(ImageDef) field on another card:
-//   anotherCard.thumbnail = new ImageDef({ id, url, sourceUrl: result.imageDefUrl });
+//   <img src={{this.imageUrl}} />
 ```
 
 The full demo card (`example.gts`) wraps this in a CardDef that:
@@ -47,21 +45,28 @@ The full demo card (`example.gts`) wraps this in a CardDef that:
 |---|---|---|---|
 | `card` | `linksTo(CardDef)` | yes | Must already be saved — the command needs a card id. |
 | `format` | `'isolated' \| 'embedded'` | yes | **No other values accepted.** Fitted / atom / edit / markdown will throw. |
+| `viewportWidth` / `viewportHeight` | `number` | no | Viewport size in CSS px. Provide **both** or neither. |
+| `deviceScaleFactor` | `number` | no | Retina/hi-dpi multiplier (≤ 3). |
+| `fullPage` | `boolean` | no | Capture the whole scrollable document. Mutually exclusive with `clip`. |
+| `clipX` / `clipY` / `clipWidth` / `clipHeight` | `number` | no | Crop to a region. Provide **all four** or none. |
+
+Every capture field is a JSON primitive, deliberately: the headless `run-command` input path is `new InputType(rawJson)` with no card resolution, so the nested `captureSpec` the endpoint accepts is flattened into primitive fields the tool reassembles. The geometry fields are all part of the capture's canonical identity, so a capture carrying any of them still persists and serves under its own durable URL.
 
 | Output field | Type | Notes |
 |---|---|---|
-| `imageDefUrl` | `string` | The file identifier returned by `WriteBinaryFileCommand`. Render with `<img src={{...}} />`, or use as the `sourceUrl` on a fresh `ImageDef` / `PngDef`. |
+| `captures` | `ScreenshotCapture[]` | One entry per capture. |
+| `captures[].url` | `string` | The durable served media-cache URL — the only reference the tool returns. A re-capture rotates its bytes, never the URL. The geometry (if any) rides in the query string. |
+| `captures[].width` / `.height` | `number` | Reported pixel dimensions. |
 
 ## How the realm-server does the work
 
-1. `ScreenshotCardCommand.run()` POSTs `{ realmURL, cardId, format }` to `/_screenshot-card` on the realm-server.
-2. The handler (`packages/realm-server/handlers/handle-screenshot-card.ts`) enqueues a `screenshot-card` job via the queue system.
-3. The worker task (`runtime-common/tasks/screenshot-card.ts`) drives Puppeteer through the prerender pool to render the card at the requested format.
+1. `ScreenshotCardCommand.run()` POSTs `{ realmURL, cardId, format, includeBase64: false, captureSpec? }` to `/_screenshot-card` on the realm-server, authenticated with the card realm's JWT.
+2. The handler (`packages/realm-server/handlers/handle-screenshot-card.ts`) answers from the media-cache ledger when the capture already exists, else enqueues a `screenshot-card` job.
+3. The worker task (`runtime-common/tasks/screenshot-card.ts`) drives Puppeteer through the prerender pool to render the card at the requested format and geometry.
 4. Puppeteer waits for the page to settle (data loads, animations, font swap, prerender hooks) before capturing.
-5. The PNG comes back as base64, and the command writes it via `WriteBinaryFileCommand` to `Screenshots/<slug>-<uuid>.png` in the **target card's own realm**.
-6. The realm indexer promotes the PNG into a `PngDef` / `ImageDef` card automatically.
+5. The capture — format-only or with geometry — is persisted to the media cache under its full capture identity (format + `viewport` / `deviceScaleFactor` / `fullPage` / `clip`), and the response carries its served `url`.
 
-You don't see any of this from the consumer side — `await new ScreenshotCardCommand(ctx).execute({ card, format })` returns when the file is on disk.
+You don't see any of this from the consumer side — `await new ScreenshotCardCommand(ctx).execute({ card, format })` returns when the capture is ready.
 
 ## Wire as a card menu item
 
@@ -81,7 +86,7 @@ class MyCard extends CardDef {
         action: async () => {
           let result = await new ScreenshotCardCommand(params.commandContext)
             .execute({ card: this as any, format: 'isolated' });
-          // Optionally show toast with result.imageDefUrl
+          // Optionally show toast with result.captures[0]?.url
         },
       },
       {
@@ -98,16 +103,16 @@ class MyCard extends CardDef {
 }
 ```
 
-This gives every instance of `MyCard` two menu items that capture a settled PNG of itself into its own realm's `Screenshots/` directory — without needing a dedicated demo card.
+This gives every instance of `MyCard` two menu items that capture a settled PNG of itself — without needing a dedicated demo card.
 
 ## Gotchas
 
 - **Format is restricted to `isolated` or `embedded`.** `fitted`, `atom`, `edit`, `markdown` will throw. The reason: only those two formats have stable browser-viewport semantics; fitted is container-driven and needs an explicit size envelope that the command doesn't expose.
 - **Target card must be saved.** The command needs a card id. If you're in a draft / pre-save flow, save first.
-- **Permission check is strict.** The command saves to the target card's realm. If the current user can't write there, it fails fast — no silent fallback to the user's home realm.
-- **Output lands in `Screenshots/` of the target's realm, not the caller's.** If you screenshot a third-party realm's card and you have write access, the PNG lives over there.
-- **Filenames are slug + uuid.** `<lowercased-last-url-segment>-<8-char-uuid>.png`. Stable for known cards, unique on collisions.
-- **Long renders block the request.** The realm-server polls the job until completion (Puppeteer needs to settle the page). On a slow card or under load, expect a few seconds. Wrap in `@tracked isRunning` / show a spinner; don't `await` inside `getCardMenuItems` without surfacing progress.
+- **Read access, not write.** The command reads the target card and captures it; it no longer writes a file back. If the current user can't read the target's realm, it fails fast.
+- **Geometry captures are URL-served too.** Supplying `viewport*` / `deviceScaleFactor` / `fullPage` / `clip*` is part of the capture's canonical identity, so the capture persists and comes back with its own `captures[].url` (the geometry encoded in the query string) — no base64, no special-casing versus a format-only capture.
+- **Paired fields are all-or-nothing.** Provide both `viewportWidth` and `viewportHeight`, or all four `clip*` edges — a half-specified viewport or region throws with a clear message.
+- **Long renders can time out to a retry.** The realm-server waits for the job within a bounded budget; a slow render answers `503` with a `Retry-After`, which the command surfaces as a "still rendering; retry" error. A canonical capture resumes cheaply on retry (ledger hit); a custom spec re-renders.
 - **commandContext must exist.** Only available in host interact mode — the prerenderer / SSR context doesn't have a live host. Feature-detect with `this.args.context?.commandContext` before calling.
 - **`listing-create` does not use this command.** The catalog's listing-creation flow uses `GenerateThumbnailCommand` (AI-generated stylized icon, not a real screenshot). Use `ScreenshotCardCommand` when you want the actual rendered card, not an interpretation.
 
@@ -116,12 +121,13 @@ This gives every instance of `MyCard` two menu items that capture a settled PNG 
 - Host command: `@cardstack/boxel-host/tools/screenshot-card` — `packages/host/app/tools/screenshot-card.ts` in the boxel monorepo.
 - Realm-server endpoint: `POST /_screenshot-card` → `packages/realm-server/handlers/handle-screenshot-card.ts`.
 - Worker task: `packages/runtime-common/tasks/screenshot-card.ts`.
+- Capture spec (bounds + strict parse): `packages/runtime-common/capture-spec.ts`.
 - Input/output types: `ScreenshotCardInput` / `ScreenshotCardOutput` in `packages/base/command.gts`.
 - Proven example: `packages/experiments-realm/screenshot-card-demo.gts` — copied verbatim into this pattern's `example.gts`.
 
 ## See also
 
-- [`integrate-thumbnail-card-ai`](../integrate-thumbnail-card-ai/README.md) — **paired sibling**: AI-generated thumbnails (`GenerateThumbnailCommand`) instead of real rendered captures. Same composition surface (file in realm + optional `cardInfo.cardThumbnail` patch).
+- [`integrate-thumbnail-card-ai`](../integrate-thumbnail-card-ai/README.md) — **paired sibling**: AI-generated thumbnails (`GenerateThumbnailCommand`) instead of real rendered captures.
 - [`link-command-menu-item`](../link-command-menu-item/README.md) — wire screenshot capture as a card menu action.
 - [`integrate-filedef-generated-image`](../integrate-filedef-generated-image/README.md) — the storage half of any generated-media workflow; explains how `WriteBinaryFileCommand` + `ImageDef` / `PngDef` compose with binary outputs.
 - [`integrate-openrouter-image-generation`](../integrate-openrouter-image-generation/README.md) — lower-level OpenRouter image primitive that `GenerateThumbnailCommand` is built on top of.

--- a/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/README.md
+++ b/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/README.md
@@ -36,7 +36,7 @@ this.imageUrl = result.captures?.[0]?.url ?? null;
 The full demo card (`example.gts`) wraps this in a CardDef that:
 - Holds the target via `@field card = linksTo(CardDef)`.
 - Holds the format via `@field format = contains(enumField(StringField, { options: ['isolated', 'embedded'] }))`.
-- Owns `@tracked isRunning`, `@tracked errorMessage`, `@tracked imageDefUrl` for UI state.
+- Owns `@tracked isRunning`, `@tracked errorMessage`, `@tracked imageUrl` for UI state.
 - Disables the action button until `commandContext` is available and a card is linked.
 
 ## API surface
@@ -50,7 +50,7 @@ The full demo card (`example.gts`) wraps this in a CardDef that:
 | `fullPage` | `boolean` | no | Capture the whole scrollable document. Mutually exclusive with `clip`. |
 | `clipX` / `clipY` / `clipWidth` / `clipHeight` | `number` | no | Crop to a region. Provide **all four** or none. |
 
-Every capture field is a JSON primitive, deliberately: the headless `run-command` input path is `new InputType(rawJson)` with no card resolution, so the nested `captureSpec` the endpoint accepts is flattened into primitive fields the tool reassembles. The geometry fields are all part of the capture's canonical identity, so a capture carrying any of them still persists and serves under its own durable URL.
+Every capture field is a JSON primitive, deliberately: the headless `run-command` input path builds the input via `new InputType(rawJson)`, which resolves `linksTo` ids to card instances but cannot construct a nested `contains(SomeFieldDef)` from a plain JSON object — so the nested `captureSpec` the endpoint accepts is flattened into primitive fields the tool reassembles. The geometry fields are all part of the capture's canonical identity, so a capture carrying any of them still persists and serves under its own durable URL.
 
 | Output field | Type | Notes |
 |---|---|---|

--- a/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/example.gts
+++ b/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/example.gts
@@ -67,7 +67,7 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
         card,
         format: this.effectiveFormat,
       });
-      this.imageDefUrl = result.imageDefUrl;
+      this.imageDefUrl = result.captures?.[0]?.url ?? null;
     } catch (error) {
       this.errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -81,9 +81,8 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
       <header>
         <h2>Screenshot Card Demo</h2>
         <p>
-          Pick a card and a format, then capture a settled PNG into the
-          card's own realm under
-          <code>Screenshots/</code>.
+          Pick a card and a format, then capture a settled PNG. The capture is
+          persisted to the media cache and its served URL is shown below.
         </p>
       </header>
 

--- a/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/example.gts
+++ b/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/example.gts
@@ -11,7 +11,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 
-import ScreenshotCardCommand from '@cardstack/boxel-host/tools/screenshot-card';
+import ScreenshotCardTool from '@cardstack/boxel-host/tools/screenshot-card';
 import { Button } from '@cardstack/boxel-ui/components';
 
 type ScreenshotFormat = 'isolated' | 'embedded';
@@ -28,8 +28,8 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
   @tracked errorMessage: string | null = null;
   @tracked imageUrl: string | null = null;
 
-  get hasCommandContext() {
-    return Boolean(this.args.context?.commandContext);
+  get hasToolContext() {
+    return Boolean(this.args.context?.toolContext);
   }
 
   get hasLinkedCard() {
@@ -37,7 +37,7 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
   }
 
   get isDisabled() {
-    return this.isRunning || !this.hasCommandContext || !this.hasLinkedCard;
+    return this.isRunning || !this.hasToolContext || !this.hasLinkedCard;
   }
 
   get effectiveFormat(): ScreenshotFormat {
@@ -47,11 +47,11 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
 
   @action
   async takeScreenshot() {
-    let commandContext = this.args.context?.commandContext;
+    let toolContext = this.args.context?.toolContext;
     let card = (this.args.model as any)?.card;
-    if (!commandContext) {
+    if (!toolContext) {
       this.errorMessage =
-        'Command context is unavailable. Open this card in host interact mode.';
+        'Tool context is unavailable. Open this card in host interact mode.';
       return;
     }
     if (!card) {
@@ -63,7 +63,7 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
     this.errorMessage = null;
     this.imageUrl = null;
     try {
-      let result = await new ScreenshotCardCommand(commandContext).execute({
+      let result = await new ScreenshotCardTool(toolContext).execute({
         card,
         format: this.effectiveFormat,
       });

--- a/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/example.gts
+++ b/packages/boxel-cli/plugin/skills/boxel-patterns/patterns/integrate-screenshot-card-format/example.gts
@@ -26,7 +26,7 @@ const FormatField = enumField(StringField, {
 class Isolated extends Component<typeof ScreenshotCardDemo> {
   @tracked isRunning = false;
   @tracked errorMessage: string | null = null;
-  @tracked imageDefUrl: string | null = null;
+  @tracked imageUrl: string | null = null;
 
   get hasCommandContext() {
     return Boolean(this.args.context?.commandContext);
@@ -61,13 +61,13 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
 
     this.isRunning = true;
     this.errorMessage = null;
-    this.imageDefUrl = null;
+    this.imageUrl = null;
     try {
       let result = await new ScreenshotCardCommand(commandContext).execute({
         card,
         format: this.effectiveFormat,
       });
-      this.imageDefUrl = result.captures?.[0]?.url ?? null;
+      this.imageUrl = result.captures?.[0]?.url ?? null;
     } catch (error) {
       this.errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -106,11 +106,11 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
         </Button>
       </section>
 
-      {{#if this.imageDefUrl}}
+      {{#if this.imageUrl}}
         <section class='result'>
           <p>Saved to:</p>
-          <code class='url'>{{this.imageDefUrl}}</code>
-          <img src={{this.imageDefUrl}} alt='Card screenshot' />
+          <code class='url'>{{this.imageUrl}}</code>
+          <img src={{this.imageUrl}} alt='Card screenshot' />
         </section>
       {{/if}}
 

--- a/packages/experiments-realm/screenshot-card-demo.gts
+++ b/packages/experiments-realm/screenshot-card-demo.gts
@@ -67,7 +67,7 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
         card,
         format: this.effectiveFormat,
       });
-      this.imageDefUrl = result.imageDefUrl;
+      this.imageDefUrl = result.captures?.[0]?.url ?? null;
     } catch (error) {
       this.errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -81,9 +81,8 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
       <header>
         <h2>Screenshot Card Demo</h2>
         <p>
-          Pick a card and a format, then capture a settled PNG into the
-          card's own realm under
-          <code>Screenshots/</code>.
+          Pick a card and a format, then capture a settled PNG. The capture is
+          persisted to the media cache and its served URL is shown below.
         </p>
       </header>
 

--- a/packages/experiments-realm/screenshot-card-demo.gts
+++ b/packages/experiments-realm/screenshot-card-demo.gts
@@ -26,7 +26,7 @@ const FormatField = enumField(StringField, {
 class Isolated extends Component<typeof ScreenshotCardDemo> {
   @tracked isRunning = false;
   @tracked errorMessage: string | null = null;
-  @tracked imageDefUrl: string | null = null;
+  @tracked imageUrl: string | null = null;
 
   get hasCommandContext() {
     return Boolean(this.args.context?.toolContext);
@@ -61,13 +61,13 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
 
     this.isRunning = true;
     this.errorMessage = null;
-    this.imageDefUrl = null;
+    this.imageUrl = null;
     try {
       let result = await new ScreenshotCardTool(toolContext).execute({
         card,
         format: this.effectiveFormat,
       });
-      this.imageDefUrl = result.captures?.[0]?.url ?? null;
+      this.imageUrl = result.captures?.[0]?.url ?? null;
     } catch (error) {
       this.errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -106,11 +106,11 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
         </Button>
       </section>
 
-      {{#if this.imageDefUrl}}
+      {{#if this.imageUrl}}
         <section class='result'>
           <p>Saved to:</p>
-          <code class='url'>{{this.imageDefUrl}}</code>
-          <img src={{this.imageDefUrl}} alt='Card screenshot' />
+          <code class='url'>{{this.imageUrl}}</code>
+          <img src={{this.imageUrl}} alt='Card screenshot' />
         </section>
       {{/if}}
 

--- a/packages/experiments-realm/screenshot-card-demo.gts
+++ b/packages/experiments-realm/screenshot-card-demo.gts
@@ -11,7 +11,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 
-import ScreenshotCardTool from '@cardstack/boxel-host/commands/screenshot-card';
+import ScreenshotCardTool from '@cardstack/boxel-host/tools/screenshot-card';
 import { Button } from '@cardstack/boxel-ui/components';
 
 type ScreenshotFormat = 'isolated' | 'embedded';
@@ -28,7 +28,7 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
   @tracked errorMessage: string | null = null;
   @tracked imageUrl: string | null = null;
 
-  get hasCommandContext() {
+  get hasToolContext() {
     return Boolean(this.args.context?.toolContext);
   }
 
@@ -37,7 +37,7 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
   }
 
   get isDisabled() {
-    return this.isRunning || !this.hasCommandContext || !this.hasLinkedCard;
+    return this.isRunning || !this.hasToolContext || !this.hasLinkedCard;
   }
 
   get effectiveFormat(): ScreenshotFormat {
@@ -51,7 +51,7 @@ class Isolated extends Component<typeof ScreenshotCardDemo> {
     let card = (this.args.model as any)?.card;
     if (!toolContext) {
       this.errorMessage =
-        'Command context is unavailable. Open this card in host interact mode.';
+        'Tool context is unavailable. Open this card in host interact mode.';
       return;
     }
     if (!card) {

--- a/packages/host/app/tools/download-file-to-realm.ts
+++ b/packages/host/app/tools/download-file-to-realm.ts
@@ -1,0 +1,95 @@
+import { service } from '@ember/service';
+
+import HostBaseTool from '../lib/host-base-tool';
+
+import WriteBinaryFileTool from './write-binary-file';
+
+import type NetworkService from '../services/network';
+import type * as BaseToolModule from '@cardstack/base/command';
+
+// Encode raw bytes as base64 without a text round-trip. `Buffer` when it exists
+// (Node / prerender); otherwise `btoa` over the binary string, chunked so a
+// large file doesn't blow the argument limit of `String.fromCharCode`.
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  const maybeBuffer = (globalThis as any).Buffer as
+    | { from(input: Uint8Array): { toString(encoding: string): string } }
+    | undefined;
+  if (typeof maybeBuffer !== 'undefined') {
+    return maybeBuffer.from(bytes).toString('base64');
+  }
+  if (typeof btoa === 'function') {
+    let binary = '';
+    const CHUNK = 0x8000;
+    for (let i = 0; i < bytes.length; i += CHUNK) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+    }
+    return btoa(binary);
+  }
+  throw new Error('No base64 encoder available in this environment');
+}
+
+export default class DownloadFileToRealmTool extends HostBaseTool<
+  typeof BaseToolModule.DownloadFileToRealmInput,
+  typeof BaseToolModule.DownloadFileToRealmResult
+> {
+  @service declare private network: NetworkService;
+
+  static actionVerb = 'Download';
+  description =
+    "Download a file from a URL and write it into a realm. Give the destination a path with the right extension (e.g. 'Screenshots/card.png') — the realm infers the file type from it.";
+
+  async getInputType() {
+    let commandModule = await this.loadToolModule();
+    const { DownloadFileToRealmInput } = commandModule;
+    return DownloadFileToRealmInput;
+  }
+
+  requireInputFields = ['sourceUrl', 'path'];
+
+  protected async run(
+    input: BaseToolModule.DownloadFileToRealmInput,
+  ): Promise<BaseToolModule.DownloadFileToRealmResult> {
+    let { sourceUrl, realm, path, useNonConflictingFilename } = input;
+    if (!sourceUrl) {
+      throw new Error('A sourceUrl is required to download a file.');
+    }
+    if (!path) {
+      throw new Error('A destination path is required.');
+    }
+
+    // `authedFetch` attaches the per-realm token when the URL belongs to a
+    // known realm (so a gated realm's `_screenshot/` URL downloads), and is a
+    // plain fetch for anything else. We read the body as bytes, not text, so a
+    // binary file survives the download intact.
+    let response = await this.network.authedFetch(sourceUrl, { method: 'GET' });
+    if (!response.ok) {
+      let text = await response.text().catch(() => '');
+      throw new Error(
+        `Failed to download ${sourceUrl} (${response.status} ${response.statusText}): ${text}`,
+      );
+    }
+
+    let bytes = new Uint8Array(await response.arrayBuffer());
+    let base64Content = uint8ArrayToBase64(bytes);
+
+    // Persist through the existing binary-write path so the non-conflicting
+    // filename handling, upload plumbing, and indexer promotion all stay in one
+    // place — the caller never has to touch the bytes.
+    let writeResult = await new WriteBinaryFileTool(this.toolContext).execute({
+      path,
+      realm,
+      base64Content,
+      contentType: response.headers.get('content-type') ?? undefined,
+      useNonConflictingFilename,
+    });
+
+    let commandModule = await this.loadToolModule();
+    const { DownloadFileToRealmResult } = commandModule;
+    return new DownloadFileToRealmResult({
+      fileIdentifier: writeResult.fileIdentifier,
+    });
+  }
+}
+
+// Pre-rename spelling parity with the other tools' command aliases.
+export { DownloadFileToRealmTool as DownloadFileToRealmCommand };

--- a/packages/host/app/tools/download-file-to-realm.ts
+++ b/packages/host/app/tools/download-file-to-realm.ts
@@ -75,11 +75,13 @@ export default class DownloadFileToRealmTool extends HostBaseTool<
     // Persist through the existing binary-write path so the non-conflicting
     // filename handling, upload plumbing, and indexer promotion all stay in one
     // place — the caller never has to touch the bytes.
+    // No content type is forwarded: the binary-write path always posts
+    // octet-stream and the realm infers the file type from the destination
+    // path's extension — which is why the description asks for one.
     let writeResult = await new WriteBinaryFileTool(this.toolContext).execute({
       path,
       realm,
       base64Content,
-      contentType: response.headers.get('content-type') ?? undefined,
       useNonConflictingFilename,
     });
 

--- a/packages/host/app/tools/download-file-to-realm.ts
+++ b/packages/host/app/tools/download-file-to-realm.ts
@@ -5,6 +5,7 @@ import HostBaseTool from '../lib/host-base-tool';
 import WriteBinaryFileTool from './write-binary-file';
 
 import type NetworkService from '../services/network';
+import type RealmService from '../services/realm';
 import type * as BaseToolModule from '@cardstack/base/command';
 
 // Encode raw bytes as base64 without a text round-trip. `Buffer` when it exists
@@ -33,10 +34,11 @@ export default class DownloadFileToRealmTool extends HostBaseTool<
   typeof BaseToolModule.DownloadFileToRealmResult
 > {
   @service declare private network: NetworkService;
+  @service declare private realm: RealmService;
 
   static actionVerb = 'Download';
   description =
-    "Download a file from a URL and write it into a realm. Give the destination a path with the right extension (e.g. 'Screenshots/card.png') — the realm infers the file type from it.";
+    "Download a file from a URL and write it into a realm. Give the destination a path with the right extension (e.g. 'Screenshots/card.png') — the realm infers the file type from it. `realm` selects the target realm; when omitted, the default writable realm is used.";
 
   async getInputType() {
     let commandModule = await this.loadToolModule();
@@ -55,6 +57,19 @@ export default class DownloadFileToRealmTool extends HostBaseTool<
     }
     if (!path) {
       throw new Error('A destination path is required.');
+    }
+    // The input's documented default. Resolved here — before the download —
+    // because the binary-write path has no default of its own: handing it an
+    // undefined realm would surface as an opaque `Invalid URL` TypeError
+    // after the whole body had already been fetched.
+    if (!realm) {
+      let fallback = this.realm.defaultWritableRealm?.path;
+      if (!fallback) {
+        throw new Error(
+          'No realm provided and no writable realm is available.',
+        );
+      }
+      realm = fallback;
     }
 
     // `authedFetch` attaches the per-realm token when the URL belongs to a

--- a/packages/host/app/tools/index.ts
+++ b/packages/host/app/tools/index.ts
@@ -21,6 +21,7 @@ import * as CreateAIAssistantRoomToolModule from './create-ai-assistant-room';
 import * as CreateAndOpenSubmissionWorkflowCard from './create-and-open-submission-workflow-card';
 import * as CreateSpecToolModule from './create-specs';
 import * as CreateSubmissionWorkflowToolModule from './create-submission-workflow';
+import * as DownloadFileToRealmToolModule from './download-file-to-realm';
 import * as EvaluateModuleToolModule from './evaluate-module';
 import * as ExecuteAtomicOperationsToolModule from './execute-atomic-operations';
 import * as FetchCardJsonToolModule from './fetch-card-json';
@@ -146,6 +147,11 @@ export function shimHostTools(virtualNetwork: VirtualNetwork) {
   );
   shimHostToolModule(virtualNetwork, 'copy-source', CopySourceToolModule);
   shimHostToolModule(virtualNetwork, 'copy-and-edit', CopyAndEditToolModule);
+  shimHostToolModule(
+    virtualNetwork,
+    'download-file-to-realm',
+    DownloadFileToRealmToolModule,
+  );
   shimHostToolModule(
     virtualNetwork,
     'create-ai-assistant-room',
@@ -466,6 +472,7 @@ export const HostToolClasses: (typeof HostBaseTool<any, any>)[] = [
   CopyCardToStackToolModule.default,
   CopyFileToRealmToolModule.default,
   CopySourceToolModule.default,
+  DownloadFileToRealmToolModule.default,
   AuthedFetchToolModule.default,
   CanReadRealmToolModule.default,
   CreateAIAssistantRoomToolModule.default,

--- a/packages/host/app/tools/screenshot-card.ts
+++ b/packages/host/app/tools/screenshot-card.ts
@@ -1,33 +1,34 @@
 import { service } from '@ember/service';
 
-import { v4 as uuidv4 } from 'uuid';
-
 import { rri } from '@cardstack/runtime-common';
 
 import HostBaseTool from '../lib/host-base-tool';
-
-import WriteBinaryFileTool from './write-binary-file';
 
 import type RealmService from '../services/realm';
 import type RealmServerService from '../services/realm-server';
 import type * as BaseToolModule from '@cardstack/base/command';
 
-function generateFilenameFromCard(cardId: string): string {
-  const uniqueId = uuidv4().split('-')[0];
-  let url: URL;
-  try {
-    url = new URL(cardId);
-  } catch {
-    return `screenshot-${uniqueId}`;
-  }
-  let lastSegment = decodeURIComponent(
-    url.pathname.split('/').filter(Boolean).pop() ?? '',
-  );
-  let slug = lastSegment
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  return slug ? `${slug}-${uniqueId}` : `screenshot-${uniqueId}`;
+// The nested capture spec the `/_screenshot-card` endpoint accepts, assembled
+// from the tool's flat JSON-primitive input fields. Only the fields the caller
+// supplied are set; an empty spec is the canonical (format-only) capture. Every
+// field here is part of the capture's canonical identity, so a capture carrying
+// any of them persists and serves under its own durable URL just like a
+// format-only one.
+interface CaptureSpecBody {
+  viewport?: { width: number; height: number };
+  deviceScaleFactor?: number;
+  fullPage?: boolean;
+  clip?: { x: number; y: number; width: number; height: number };
+}
+
+// One capture as the endpoint reports it. `url` is the durable served URL the
+// capture persisted under — the only reference this tool consumes.
+interface EndpointCapture {
+  name: string | null;
+  url: string | null;
+  width: number | null;
+  height: number | null;
+  deviceScaleFactor: number | null;
 }
 
 export default class ScreenshotCardTool extends HostBaseTool<
@@ -39,7 +40,9 @@ export default class ScreenshotCardTool extends HostBaseTool<
 
   static actionVerb = 'Screenshot';
   description =
-    "Screenshot a rendered card and save it as an ImageDef in the card's own realm";
+    'Screenshot a rendered card. The capture is persisted to the media cache ' +
+    'and its served URL is returned into the room, where it renders inline; ' +
+    'fetch the URL to inspect the render.';
 
   async getInputType() {
     let commandModule = await this.loadToolModule();
@@ -77,40 +80,66 @@ export default class ScreenshotCardTool extends HostBaseTool<
     let vn = this.loaderService.loader.getVirtualNetwork()!;
     let cardURL = vn.toURL(cardId).href;
 
-    // Target realm = the card's own realm. If the caller can't write there,
-    // fail fast — no silent fallback to a different realm.
     let cardRealm = this.realm.realmOf(rri(cardURL));
     if (!cardRealm) {
       throw new Error(`Cannot determine realm for card ${cardURL}.`);
     }
-    if (!this.realm.canWrite(cardRealm)) {
+    // Screenshotting reads the card; it no longer writes a file back, so read
+    // access is what it needs. The ungated POST endpoint enforces realm read
+    // itself (and the worker enforces it on the render path); this is a fast,
+    // clear local failure for a caller who plainly can't see the realm.
+    if (!this.realm.canRead(cardRealm)) {
       throw new Error(
-        `Cannot screenshot ${cardURL}: no write access to its realm ${cardRealm}.`,
+        `Cannot screenshot ${cardURL}: no read access to its realm ${cardRealm}.`,
       );
     }
 
-    // Hit /_screenshot-card on the realm-server. The realm-server enqueues a
-    // screenshot-card job; the worker drives Puppeteer through the prerender
-    // pool to capture a settled PNG and we get base64 back.
+    let captureSpec = this.buildCaptureSpec(input);
+    let hasGeometry = Object.keys(captureSpec).length > 0;
+
+    // Realm-JWT auth: send the card realm's token as the bearer. The endpoint
+    // stays on `jwtMiddleware`, which validates a realm token the same as a
+    // realm-server session token — and unlike `realmServer.authedFetch`, a
+    // realm token needs no Matrix client, so this works in headless
+    // (run-command) contexts too.
+    let token = this.realm.token(cardRealm);
+    let headers: Record<string, string> = {
+      Accept: 'application/vnd.api+json',
+      'Content-Type': 'application/vnd.api+json',
+    };
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
     let endpoint = new URL('/_screenshot-card', this.realmServer.url);
-    let response = await this.realmServer.authedFetch(endpoint.href, {
+    let response = await vn.fetch(endpoint.href, {
       method: 'POST',
-      headers: {
-        Accept: 'application/vnd.api+json',
-        'Content-Type': 'application/vnd.api+json',
-      },
+      headers,
       body: JSON.stringify({
         data: {
           type: 'screenshot-card',
           attributes: {
             realmURL: cardRealm,
-            cardId: cardURL, // wire field name kept as-is; CS-11458 will update endpoint to accept RRI
+            cardId: cardURL,
             format: normalizedFormat,
+            // We only ever want the served URL — never the bytes. Every capture
+            // this tool makes is canonical (format + geometry), so it persists
+            // and answers with a `captures[].url`.
+            includeBase64: false,
+            ...(hasGeometry ? { captureSpec } : {}),
           },
         },
       }),
     });
 
+    if (response.status === 503) {
+      let retryAfter = response.headers.get('retry-after');
+      throw new Error(
+        `Screenshot is still rendering; retry${
+          retryAfter ? ` after ${retryAfter}s` : ''
+        }.`,
+      );
+    }
     if (!response.ok) {
       let text = await response.text().catch(() => '');
       throw new Error(
@@ -120,32 +149,97 @@ export default class ScreenshotCardTool extends HostBaseTool<
 
     let body: any = await response.json();
     let attrs = body?.data?.attributes;
-    if (!attrs || attrs.status !== 'ready' || !attrs.base64) {
+    if (!attrs || attrs.status !== 'ready') {
       let detail = attrs?.error ?? JSON.stringify(body);
       throw new Error(`Screenshot job did not produce a PNG: ${detail}`);
     }
 
-    // Write binary to the card's realm under Screenshots/. The realm indexer
-    // promotes the PNG into a PngDef / ImageDef card automatically.
-    let filename = `${generateFilenameFromCard(cardURL)}.png`;
-    let filePath = `Screenshots/${filename}`;
-    let writeResult = await new WriteBinaryFileTool(this.toolContext).execute({
-      path: filePath,
-      realm: cardRealm,
-      base64Content: attrs.base64,
-      contentType: 'image/png',
-      useNonConflictingFilename: true,
-    });
+    let endpointCaptures: EndpointCapture[] = Array.isArray(attrs.captures)
+      ? attrs.captures
+      : [];
+    if (endpointCaptures.length === 0) {
+      throw new Error('Screenshot job returned no captures.');
+    }
 
-    if (!writeResult?.fileIdentifier) {
-      throw new Error('Failed to write screenshot PNG to realm.');
+    // The capture persists and comes back with a served URL. If it doesn't —
+    // the instance isn't indexed yet, or the server has no media-cache store —
+    // there is nothing servable to return, so say so plainly rather than hand
+    // back a blank capture.
+    if (!endpointCaptures[0]?.url) {
+      throw new Error(
+        'Screenshot could not be persisted (the card may not be indexed yet); retry once indexing completes.',
+      );
     }
 
     let commandModule = await this.loadToolModule();
-    const { ScreenshotCardOutput } = commandModule;
-    return new ScreenshotCardOutput({
-      imageDefUrl: writeResult.fileIdentifier,
-    });
+    const { ScreenshotCardOutput, ScreenshotCapture } = commandModule;
+    let captures = endpointCaptures.map(
+      (capture) =>
+        new ScreenshotCapture({
+          name: capture.name ?? undefined,
+          url: capture.url ?? '',
+          width: capture.width ?? undefined,
+          height: capture.height ?? undefined,
+        }),
+    );
+
+    return new ScreenshotCardOutput({ captures });
+  }
+
+  // Fold the flat primitive input fields back into the endpoint's nested
+  // capture spec. Only supplied fields are emitted; the paired fields
+  // (viewport width/height, the four clip edges) are all-or-nothing so a
+  // half-specified region fails here with a clear message rather than as an
+  // opaque 400 downstream. `fullPage` is emitted only when true — false is the
+  // engine default and would needlessly perturb the canonical capture identity.
+  private buildCaptureSpec(
+    input: BaseToolModule.ScreenshotCardInput,
+  ): CaptureSpecBody {
+    let {
+      viewportWidth,
+      viewportHeight,
+      deviceScaleFactor,
+      fullPage,
+      clipX,
+      clipY,
+      clipWidth,
+      clipHeight,
+    } = input;
+    let spec: CaptureSpecBody = {};
+
+    if (viewportWidth != null || viewportHeight != null) {
+      if (viewportWidth == null || viewportHeight == null) {
+        throw new Error(
+          'viewportWidth and viewportHeight must be provided together.',
+        );
+      }
+      spec.viewport = { width: viewportWidth, height: viewportHeight };
+    }
+
+    if (deviceScaleFactor != null) {
+      spec.deviceScaleFactor = deviceScaleFactor;
+    }
+
+    if (fullPage === true) {
+      spec.fullPage = true;
+    }
+
+    let clipEdges = [clipX, clipY, clipWidth, clipHeight];
+    if (clipEdges.some((edge) => edge != null)) {
+      if (clipEdges.some((edge) => edge == null)) {
+        throw new Error(
+          'clipX, clipY, clipWidth, and clipHeight must be provided together.',
+        );
+      }
+      spec.clip = {
+        x: clipX!,
+        y: clipY!,
+        width: clipWidth!,
+        height: clipHeight!,
+      };
+    }
+
+    return spec;
   }
 }
 

--- a/packages/host/app/tools/screenshot-card.ts
+++ b/packages/host/app/tools/screenshot-card.ts
@@ -84,10 +84,11 @@ export default class ScreenshotCardTool extends HostBaseTool<
     if (!cardRealm) {
       throw new Error(`Cannot determine realm for card ${cardURL}.`);
     }
-    // Screenshotting reads the card; it no longer writes a file back, so read
-    // access is what it needs. The ungated POST endpoint enforces realm read
-    // itself (and the worker enforces it on the render path); this is a fast,
-    // clear local failure for a caller who plainly can't see the realm.
+    // Screenshotting reads the card and captures it; nothing is written into
+    // a realm, so read access is what it needs. The ungated POST endpoint
+    // enforces realm read itself (and the worker enforces it on the render
+    // path); this is a fast, clear local failure for a caller who plainly
+    // can't see the realm.
     if (!this.realm.canRead(cardRealm)) {
       throw new Error(
         `Cannot screenshot ${cardURL}: no read access to its realm ${cardRealm}.`,
@@ -103,13 +104,17 @@ export default class ScreenshotCardTool extends HostBaseTool<
     // realm token needs no Matrix client, so this works in headless
     // (run-command) contexts too.
     let token = this.realm.token(cardRealm);
-    if (!token) {
+    if (!token && this.realmServer.hasClient) {
       // A publicly-readable realm can be known without a session (public
       // reads need no auth), but the endpoint sits behind `jwtMiddleware`,
       // which rejects an unauthenticated POST outright. Mint a session
-      // rather than sending a request that can only 401. Headless contexts
-      // restore sessions from storage inside `token()`, so this login only
-      // runs where a Matrix client is available to serve it.
+      // rather than sending a request that can only 401. The mint is gated
+      // on a Matrix client being present: `createRealmSession` awaits the
+      // client, so without one the login would wait indefinitely instead of
+      // failing. Headless contexts get their sessions up front — the
+      // command-runner route restores them from storage before any tool
+      // runs — so a missing token with no client falls through to the clear
+      // no-session error below.
       await this.realm.login(cardRealm);
       token = this.realm.token(cardRealm);
     }
@@ -186,10 +191,15 @@ export default class ScreenshotCardTool extends HostBaseTool<
 
     let commandModule = await this.loadToolModule();
     const { ScreenshotCardOutput, ScreenshotCapture } = commandModule;
+    // The endpoint names only declared-slot captures; the canonical captures
+    // this tool requests come back unnamed. Synthesize a name from what the
+    // tool knows — it becomes the rendered image's alt text in the room.
+    let cardTitle = (card as any).cardTitle as string | undefined;
+    let fallbackName = `${cardTitle ?? cardURL} (${normalizedFormat})`;
     let captures = endpointCaptures.map(
       (capture) =>
         new ScreenshotCapture({
-          name: capture.name ?? undefined,
+          name: capture.name ?? fallbackName,
           url: capture.url ?? '',
           width: capture.width ?? undefined,
           height: capture.height ?? undefined,

--- a/packages/host/app/tools/screenshot-card.ts
+++ b/packages/host/app/tools/screenshot-card.ts
@@ -103,13 +103,26 @@ export default class ScreenshotCardTool extends HostBaseTool<
     // realm token needs no Matrix client, so this works in headless
     // (run-command) contexts too.
     let token = this.realm.token(cardRealm);
+    if (!token) {
+      // A publicly-readable realm can be known without a session (public
+      // reads need no auth), but the endpoint sits behind `jwtMiddleware`,
+      // which rejects an unauthenticated POST outright. Mint a session
+      // rather than sending a request that can only 401. Headless contexts
+      // restore sessions from storage inside `token()`, so this login only
+      // runs where a Matrix client is available to serve it.
+      await this.realm.login(cardRealm);
+      token = this.realm.token(cardRealm);
+    }
+    if (!token) {
+      throw new Error(
+        `Cannot screenshot ${cardURL}: no session for realm ${cardRealm}.`,
+      );
+    }
     let headers: Record<string, string> = {
       Accept: 'application/vnd.api+json',
       'Content-Type': 'application/vnd.api+json',
+      Authorization: `Bearer ${token}`,
     };
-    if (token) {
-      headers.Authorization = `Bearer ${token}`;
-    }
 
     let endpoint = new URL('/_screenshot-card', this.realmServer.url);
     let response = await vn.fetch(endpoint.href, {
@@ -190,8 +203,10 @@ export default class ScreenshotCardTool extends HostBaseTool<
   // capture spec. Only supplied fields are emitted; the paired fields
   // (viewport width/height, the four clip edges) are all-or-nothing so a
   // half-specified region fails here with a clear message rather than as an
-  // opaque 400 downstream. `fullPage` is emitted only when true — false is the
-  // engine default and would needlessly perturb the canonical capture identity.
+  // opaque 400 downstream. `fullPage` is emitted only when true — false is
+  // the engine default, and the shared parse elides default-valued fields
+  // before the capture identity is derived anyway (see `elideDefaults` in
+  // capture-spec.ts), so an explicit false adds nothing.
   private buildCaptureSpec(
     input: BaseToolModule.ScreenshotCardInput,
   ): CaptureSpecBody {

--- a/packages/host/tests/integration/tools/download-file-to-realm-test.gts
+++ b/packages/host/tests/integration/tools/download-file-to-realm-test.gts
@@ -38,6 +38,13 @@ class StubRealmService extends RealmService {
     };
   }
 
+  get defaultWritableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+
   realmOf(input: URL | string) {
     let str = input instanceof URL ? input.href : input;
     if (str.startsWith(testRealmURL)) {
@@ -109,6 +116,60 @@ module('Integration | tools | download-file-to-realm', function (hooks) {
       Array.from(sourceBytes),
       'stored bytes match the downloaded content byte-for-byte',
     );
+  });
+
+  test('an omitted realm falls back to the default writable realm', async function (assert) {
+    let sourceBytes = Uint8Array.from(atob(TINY_PNG_BASE64), (char) =>
+      char.charCodeAt(0),
+    );
+    mountSource(async (req: Request) => {
+      if (req.url === sourceURL) {
+        return new Response(sourceBytes, {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        });
+      }
+      return null;
+    });
+
+    let command = new DownloadFileToRealmTool(
+      getService('tool-service').toolContext,
+    );
+    let result = await command.execute({
+      sourceUrl: sourceURL,
+      path: 'downloads/defaulted.png',
+    });
+    assert.strictEqual(
+      result.fileIdentifier,
+      `${testRealmURL}downloads/defaulted.png`,
+      'the file lands in the default writable realm',
+    );
+  });
+
+  test('with no realm and no writable realm, the failure is clear and nothing downloads', async function (assert) {
+    let downloads = 0;
+    mountSource(async (req: Request) => {
+      if (req.url === sourceURL) {
+        downloads++;
+        return new Response('bytes', { status: 200 });
+      }
+      return null;
+    });
+    Object.defineProperty(getService('realm'), 'defaultWritableRealm', {
+      value: null,
+    });
+
+    let command = new DownloadFileToRealmTool(
+      getService('tool-service').toolContext,
+    );
+    await assert.rejects(
+      command.execute({
+        sourceUrl: sourceURL,
+        path: 'downloads/nowhere.png',
+      }),
+      /No realm provided and no writable realm is available/,
+    );
+    assert.strictEqual(downloads, 0, 'the download never started');
   });
 
   test('a failed download surfaces the status and writes nothing', async function (assert) {

--- a/packages/host/tests/integration/tools/download-file-to-realm-test.gts
+++ b/packages/host/tests/integration/tools/download-file-to-realm-test.gts
@@ -1,0 +1,138 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type NetworkService from '@cardstack/host/services/network';
+
+import RealmService from '@cardstack/host/services/realm';
+import DownloadFileToRealmTool from '@cardstack/host/tools/download-file-to-realm';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+  testRealmInfo,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+let fetch: NetworkService['fetch'];
+
+// A tiny valid PNG (1x1 transparent pixel) encoded in base64
+const TINY_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQABNjN9GQAAAABJRkhJRkFJAA==';
+
+// A non-realm source URL, served by a mounted virtual-network handler so the
+// download path is exercised without touching a real network.
+const sourceURL = 'https://media.example/captures/pet.png';
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+
+  realmOf(input: URL | string) {
+    let str = input instanceof URL ? input.href : input;
+    if (str.startsWith(testRealmURL)) {
+      return testRealmURL;
+    }
+    return undefined;
+  }
+}
+
+module('Integration | tools | download-file-to-realm', function (hooks) {
+  setupRenderingTest(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks);
+
+  hooks.beforeEach(function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    fetch = getService('network').fetch;
+  });
+
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function () {
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {},
+      }),
+    );
+  });
+
+  function mountSource(responder: (req: Request) => Promise<Response | null>) {
+    getService('network').virtualNetwork.mount(responder, { prepend: true });
+  }
+
+  test('downloads a URL and persists it through the binary-write path', async function (assert) {
+    let sourceBytes = Uint8Array.from(atob(TINY_PNG_BASE64), (char) =>
+      char.charCodeAt(0),
+    );
+    mountSource(async (req: Request) => {
+      if (req.url === sourceURL) {
+        return new Response(sourceBytes, {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        });
+      }
+      return null;
+    });
+
+    let command = new DownloadFileToRealmTool(
+      getService('tool-service').toolContext,
+    );
+    let result = await command.execute({
+      sourceUrl: sourceURL,
+      realm: testRealmURL,
+      path: 'downloads/pet.png',
+    });
+    assert.strictEqual(
+      result.fileIdentifier,
+      `${testRealmURL}downloads/pet.png`,
+      'returns the written file URL',
+    );
+
+    let response = await fetch(new URL('downloads/pet.png', testRealmURL));
+    assert.strictEqual(response.status, 200, 'file is accessible after write');
+    let actualBytes = new Uint8Array(await response.arrayBuffer());
+    assert.deepEqual(
+      Array.from(actualBytes),
+      Array.from(sourceBytes),
+      'stored bytes match the downloaded content byte-for-byte',
+    );
+  });
+
+  test('a failed download surfaces the status and writes nothing', async function (assert) {
+    mountSource(async (req: Request) => {
+      if (req.url === sourceURL) {
+        return new Response('gone', { status: 404, statusText: 'Not Found' });
+      }
+      return null;
+    });
+
+    let command = new DownloadFileToRealmTool(
+      getService('tool-service').toolContext,
+    );
+    await assert.rejects(
+      command.execute({
+        sourceUrl: sourceURL,
+        realm: testRealmURL,
+        path: 'downloads/missing.png',
+      }),
+      /Failed to download .*\(404/,
+      'the error names the source URL and status',
+    );
+
+    let response = await fetch(new URL('downloads/missing.png', testRealmURL));
+    assert.strictEqual(response.status, 404, 'nothing was written');
+  });
+});

--- a/packages/host/tests/integration/tools/screenshot-card-test.gts
+++ b/packages/host/tests/integration/tools/screenshot-card-test.gts
@@ -1,0 +1,330 @@
+import { getOwner } from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import RealmService from '@cardstack/host/services/realm';
+import ScreenshotCardTool from '@cardstack/host/tools/screenshot-card';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmServerEndpoints,
+  testRealmInfo,
+  testRealmURL,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+import type { CardDef } from '@cardstack/base/card-api';
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+}
+
+// The served URL a persisted (canonical) capture answers with.
+const servedURL = `${testRealmURL}_screenshot/Pet/mango`;
+
+interface CapturedRequest {
+  authorization: string | null;
+  method: string | null;
+  pathname: string | null;
+  body: any;
+}
+
+module('Integration | tools | screenshot-card', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  let captured: CapturedRequest;
+  // Each test sets the response the mocked endpoint should return.
+  let respondWith: (req: Request) => Promise<Response>;
+
+  setupRealmServerEndpoints(hooks, [
+    {
+      route: '_screenshot-card',
+      getResponse: async (req: Request) => {
+        captured.authorization = req.headers.get('Authorization');
+        captured.method = req.method;
+        captured.pathname = new URL(req.url).pathname;
+        captured.body = await req.clone().json();
+        return respondWith(req);
+      },
+    },
+  ]);
+
+  setupRealmCacheTeardown(hooks);
+
+  function readyResponse(attributes: Record<string, unknown>): Response {
+    return new Response(
+      JSON.stringify({
+        data: { type: 'screenshot-card-result', attributes },
+      }),
+      {
+        status: 201,
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+      },
+    );
+  }
+
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    captured = {
+      authorization: null,
+      method: null,
+      pathname: null,
+      body: undefined,
+    };
+    respondWith = async () =>
+      readyResponse({
+        status: 'ready',
+        width: 800,
+        height: 600,
+        contentType: 'image/png',
+        captures: [
+          {
+            name: null,
+            url: servedURL,
+            width: 800,
+            height: 600,
+            deviceScaleFactor: 1,
+          },
+        ],
+      });
+
+    await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {
+          'pet.gts': `
+            import { contains, field, CardDef } from "@cardstack/base/card-api";
+            import StringField from "@cardstack/base/string";
+            export class Pet extends CardDef {
+              static displayName = 'Pet';
+              @field firstName = contains(StringField);
+            }
+          `,
+          'Pet/mango.json': {
+            data: {
+              type: 'card',
+              attributes: { firstName: 'Mango' },
+              meta: { adoptsFrom: { module: '../pet', name: 'Pet' } },
+            },
+          },
+        },
+      }),
+    );
+
+    await getService('realm').login(testRealmURL);
+  });
+
+  async function getPet(): Promise<CardDef> {
+    let store = getService('store');
+    return (await store.get(`${testRealmURL}Pet/mango`)) as CardDef;
+  }
+
+  test('canonical capture posts format-only body with a realm-scoped JWT and returns the served URL', async function (assert) {
+    let toolService = getService('tool-service');
+    let realmServer = getService('realm-server');
+    let command = new ScreenshotCardTool(toolService.toolContext);
+
+    let result = await command.execute({
+      card: await getPet(),
+      format: 'isolated',
+    });
+
+    assert.strictEqual(captured.method, 'POST', 'uses POST');
+    assert.strictEqual(
+      captured.pathname,
+      '/_screenshot-card',
+      'hits the realm-server endpoint',
+    );
+
+    let attrs = captured.body?.data?.attributes;
+    assert.strictEqual(
+      attrs?.cardId,
+      `${testRealmURL}Pet/mango`,
+      'sends cardId',
+    );
+    assert.strictEqual(attrs?.realmURL, testRealmURL, 'sends realmURL');
+    assert.strictEqual(attrs?.format, 'isolated', 'sends format');
+    assert.false(
+      attrs?.includeBase64,
+      'a canonical capture opts out of base64 — it will get a served URL',
+    );
+    assert.strictEqual(
+      attrs?.captureSpec,
+      undefined,
+      'no captureSpec is sent for a format-only capture',
+    );
+
+    // Realm-JWT auth: a realm-scoped token, not the realm-server session token.
+    assert.ok(
+      captured.authorization?.startsWith('Bearer '),
+      'authorization uses Bearer scheme',
+    );
+    let payload = JSON.parse(
+      atob(captured.authorization!.replace('Bearer ', '').split('.')[1]),
+    ) as { realm?: string; permissions?: string[] };
+    // A realm session token carries realm + permissions claims; a realm-server
+    // session token carries neither. This is the ticket's auth contract.
+    assert.ok(payload.realm, 'token is scoped to a realm');
+    assert.ok(
+      payload.permissions?.includes('read'),
+      'token carries realm permissions',
+    );
+    assert.notStrictEqual(
+      captured.authorization,
+      `Bearer ${realmServer.token}`,
+      'does not use the realm-server session token',
+    );
+
+    assert.strictEqual(result.captures.length, 1, 'one capture returned');
+    assert.strictEqual(result.captures[0].url, servedURL, 'carries served URL');
+  });
+
+  test('capture-geometry primitives are folded into a nested captureSpec and still resolve to a served URL', async function (assert) {
+    // On the full-capture-identity server (CS-12635 / #5893) a geometry
+    // capture persists under its own spec hash and serves on its own URL — the
+    // query string carries the geometry.
+    let geometryURL = `${servedURL}?dsf=2&viewport=800x600`;
+    respondWith = async () =>
+      readyResponse({
+        status: 'ready',
+        width: 1600,
+        height: 1200,
+        contentType: 'image/png',
+        captures: [
+          {
+            name: null,
+            url: geometryURL,
+            width: 1600,
+            height: 1200,
+            deviceScaleFactor: 2,
+          },
+        ],
+      });
+
+    let command = new ScreenshotCardTool(
+      getService('tool-service').toolContext,
+    );
+    let result = await command.execute({
+      card: await getPet(),
+      format: 'embedded',
+      viewportWidth: 800,
+      viewportHeight: 600,
+      deviceScaleFactor: 2,
+    });
+
+    let attrs = captured.body?.data?.attributes;
+    assert.false(
+      attrs?.includeBase64,
+      'the tool never asks for bytes — only the served URL',
+    );
+    assert.deepEqual(
+      attrs?.captureSpec,
+      {
+        viewport: { width: 800, height: 600 },
+        deviceScaleFactor: 2,
+      },
+      'flat primitives are reassembled into the nested captureSpec',
+    );
+
+    assert.strictEqual(
+      result.captures[0].url,
+      geometryURL,
+      'a geometry capture returns its own durable served URL',
+    );
+  });
+
+  test('a clip region is sent only when all four edges are provided', async function (assert) {
+    let command = new ScreenshotCardTool(
+      getService('tool-service').toolContext,
+    );
+    await command.execute({
+      card: await getPet(),
+      format: 'isolated',
+      clipX: 0,
+      clipY: 10,
+      clipWidth: 400,
+      clipHeight: 300,
+    });
+    assert.deepEqual(
+      captured.body?.data?.attributes?.captureSpec,
+      { clip: { x: 0, y: 10, width: 400, height: 300 } },
+      'the clip is assembled from the four edge primitives',
+    );
+  });
+
+  test('a half-specified viewport is rejected before any request', async function (assert) {
+    let command = new ScreenshotCardTool(
+      getService('tool-service').toolContext,
+    );
+    await assert.rejects(
+      command.execute({
+        card: await getPet(),
+        format: 'isolated',
+        viewportWidth: 800,
+      }),
+      /viewportWidth and viewportHeight must be provided together/,
+    );
+    assert.strictEqual(captured.method, null, 'no request was made');
+  });
+
+  test('a partial clip region is rejected before any request', async function (assert) {
+    let command = new ScreenshotCardTool(
+      getService('tool-service').toolContext,
+    );
+    await assert.rejects(
+      command.execute({
+        card: await getPet(),
+        format: 'isolated',
+        clipX: 0,
+        clipWidth: 400,
+      }),
+      /clipX, clipY, clipWidth, and clipHeight must be provided together/,
+    );
+    assert.strictEqual(captured.method, null, 'no request was made');
+  });
+
+  test('an invalid format is rejected before any request', async function (assert) {
+    let command = new ScreenshotCardTool(
+      getService('tool-service').toolContext,
+    );
+    await assert.rejects(
+      command.execute({ card: await getPet(), format: 'fitted' }),
+      /Format must be "isolated" or "embedded"/,
+    );
+    assert.strictEqual(captured.method, null, 'no request was made');
+  });
+
+  test('a 503 timeout surfaces as a retryable error', async function (assert) {
+    respondWith = async () =>
+      new Response(null, { status: 503, headers: { 'retry-after': '3' } });
+
+    let command = new ScreenshotCardTool(
+      getService('tool-service').toolContext,
+    );
+    await assert.rejects(
+      command.execute({ card: await getPet(), format: 'isolated' }),
+      /still rendering; retry after 3s/,
+    );
+  });
+});

--- a/packages/host/tests/integration/tools/screenshot-card-test.gts
+++ b/packages/host/tests/integration/tools/screenshot-card-test.gts
@@ -184,7 +184,7 @@ module('Integration | tools | screenshot-card', function (hooks) {
       atob(captured.authorization!.replace('Bearer ', '').split('.')[1]),
     ) as { realm?: string; permissions?: string[] };
     // A realm session token carries realm + permissions claims; a realm-server
-    // session token carries neither. This is the ticket's auth contract.
+    // session token carries neither.
     assert.ok(payload.realm, 'token is scoped to a realm');
     assert.ok(
       payload.permissions?.includes('read'),
@@ -198,12 +198,18 @@ module('Integration | tools | screenshot-card', function (hooks) {
 
     assert.strictEqual(result.captures.length, 1, 'one capture returned');
     assert.strictEqual(result.captures[0].url, servedURL, 'carries served URL');
+    // The endpoint reports canonical captures unnamed; the tool synthesizes a
+    // name (the rendered image's alt text) from the card title and format.
+    assert.strictEqual(
+      result.captures[0].name,
+      'Untitled Pet (isolated)',
+      'an unnamed capture gets a synthesized title + format name',
+    );
   });
 
   test('capture-geometry primitives are folded into a nested captureSpec and still resolve to a served URL', async function (assert) {
-    // On the full-capture-identity server (CS-12635 / #5893) a geometry
-    // capture persists under its own spec hash and serves on its own URL — the
-    // query string carries the geometry.
+    // A geometry capture persists under its own spec hash and serves on its
+    // own durable URL — the query string carries the geometry.
     let geometryURL = `${servedURL}?dsf=2&viewport=800x600`;
     respondWith = async () =>
       readyResponse({
@@ -329,6 +335,11 @@ module('Integration | tools | screenshot-card', function (hooks) {
       loginCalls.push(realmURL);
       minted = true;
     };
+    // The mint is gated on a Matrix client being available; pin the gate
+    // open so this test exercises the mint independent of harness wiring.
+    Object.defineProperty(getService('realm-server'), 'hasClient', {
+      value: true,
+    });
 
     let command = new ScreenshotCardTool(
       getService('tool-service').toolContext,
@@ -355,8 +366,12 @@ module('Integration | tools | screenshot-card', function (hooks) {
     let realm = getService('realm');
     let card = await getPet();
     realm.token = () => undefined;
-    // A login that cannot mint — e.g. no Matrix client available to serve it.
+    // A login that resolves without minting — the login task swallows its
+    // failure and leaves the token unset.
     realm.login = async () => {};
+    Object.defineProperty(getService('realm-server'), 'hasClient', {
+      value: true,
+    });
 
     let command = new ScreenshotCardTool(
       getService('tool-service').toolContext,
@@ -366,6 +381,75 @@ module('Integration | tools | screenshot-card', function (hooks) {
       /no session for realm/,
     );
     assert.strictEqual(captured.method, null, 'no request was made');
+  });
+
+  // Minting a session awaits the Matrix client, so on a page that never
+  // starts one the login would wait indefinitely — the tool must skip the
+  // mint entirely and fail with the clear no-session error instead.
+  test('with no Matrix client, no mint is attempted and the failure is clear', async function (assert) {
+    let realm = getService('realm');
+    let realmServer = getService('realm-server');
+    let card = await getPet();
+    realm.token = () => undefined;
+    let loginCalls = 0;
+    realm.login = async () => {
+      loginCalls++;
+    };
+    Object.defineProperty(realmServer, 'hasClient', { value: false });
+
+    let command = new ScreenshotCardTool(
+      getService('tool-service').toolContext,
+    );
+    await assert.rejects(
+      command.execute({ card, format: 'isolated' }),
+      /no session for realm/,
+    );
+    assert.strictEqual(loginCalls, 0, 'no mint was attempted');
+    assert.strictEqual(captured.method, null, 'no request was made');
+  });
+
+  test('a job that resolves un-ready surfaces its error detail', async function (assert) {
+    respondWith = async () =>
+      readyResponse({
+        status: 'error',
+        error: 'render failed: card threw during isolated render',
+        captures: [],
+      });
+
+    let command = new ScreenshotCardTool(
+      getService('tool-service').toolContext,
+    );
+    await assert.rejects(
+      command.execute({ card: await getPet(), format: 'isolated' }),
+      /Screenshot job did not produce a PNG: render failed: card threw during isolated render/,
+    );
+  });
+
+  test('a capture that could not persist fails with the unpersisted message', async function (assert) {
+    respondWith = async () =>
+      readyResponse({
+        status: 'ready',
+        width: 800,
+        height: 600,
+        contentType: 'image/png',
+        captures: [
+          {
+            name: null,
+            url: null,
+            width: 800,
+            height: 600,
+            deviceScaleFactor: 1,
+          },
+        ],
+      });
+
+    let command = new ScreenshotCardTool(
+      getService('tool-service').toolContext,
+    );
+    await assert.rejects(
+      command.execute({ card: await getPet(), format: 'isolated' }),
+      /could not be persisted .*retry once indexing completes/,
+    );
   });
 
   test('a 503 timeout surfaces as a retryable error', async function (assert) {

--- a/packages/host/tests/integration/tools/screenshot-card-test.gts
+++ b/packages/host/tests/integration/tools/screenshot-card-test.gts
@@ -315,6 +315,59 @@ module('Integration | tools | screenshot-card', function (hooks) {
     assert.strictEqual(captured.method, null, 'no request was made');
   });
 
+  // A publicly-readable realm can pass the read guard (public reads need no
+  // auth) while holding no session token — the tool must mint one, since the
+  // endpoint rejects an unauthenticated POST.
+  test('a missing realm session is minted before the request', async function (assert) {
+    let realm = getService('realm');
+    let realToken = realm.token;
+    let loginCalls: string[] = [];
+    let minted = false;
+    let card = await getPet();
+    realm.token = (url: string) => (minted ? realToken(url) : undefined);
+    realm.login = async (realmURL: string) => {
+      loginCalls.push(realmURL);
+      minted = true;
+    };
+
+    let command = new ScreenshotCardTool(
+      getService('tool-service').toolContext,
+    );
+    let result = await command.execute({ card, format: 'isolated' });
+
+    assert.deepEqual(
+      loginCalls,
+      [testRealmURL],
+      'the card realm session is minted',
+    );
+    assert.ok(
+      captured.authorization?.startsWith('Bearer '),
+      'the request carries the minted bearer',
+    );
+    assert.strictEqual(
+      result.captures[0].url,
+      servedURL,
+      'capture succeeds after the mint',
+    );
+  });
+
+  test('a realm session that cannot be minted fails clearly before any request', async function (assert) {
+    let realm = getService('realm');
+    let card = await getPet();
+    realm.token = () => undefined;
+    // A login that cannot mint — e.g. no Matrix client available to serve it.
+    realm.login = async () => {};
+
+    let command = new ScreenshotCardTool(
+      getService('tool-service').toolContext,
+    );
+    await assert.rejects(
+      command.execute({ card, format: 'isolated' }),
+      /no session for realm/,
+    );
+    assert.strictEqual(captured.method, null, 'no request was made');
+  });
+
   test('a 503 timeout surfaces as a retryable error', async function (assert) {
     respondWith = async () =>
       new Response(null, { status: 503, headers: { 'retry-after': '3' } });


### PR DESCRIPTION
**Stacked on #5893** (`cs-12635-persist-custom-capturespec-screenshots-extend-the-canonical`) — this PR targets that branch and depends on its full-capture-identity server work for geometry captures to return served URLs. Rebase onto `main` once #5893 merges.

Linear: CS-12093.

## What this does

Exposes the screenshot capture surface through the host `ScreenshotCardTool` and returns served MediaCache URLs into the assistant room, instead of writing a PNG file into a realm.

- **Input** — `ScreenshotCardInput` gains JSON-primitive capture fields (`viewportWidth`/`viewportHeight`, `deviceScaleFactor`, `fullPage`, `clipX`/`clipY`/`clipWidth`/`clipHeight`). They're primitives because the headless `run-command` path builds the input via `new InputType(rawJson)` with no card/object resolution, so a nested/`linksTo` input can't be fed there. The tool reassembles them into the endpoint's nested `captureSpec`, with all-or-nothing validation for the viewport pair and the four clip edges.
- **Auth** — the tool POSTs with the card realm's JWT (via the virtual network), not `realmServer.authedFetch`, so it needs no Matrix client and works in headless contexts. The endpoint stays on `jwtMiddleware`. It now requires realm **read** (it no longer writes a file back).
- **Output** — no realm-file write. `ScreenshotCardOutput` carries `captures[]` (`{ name, url, width, height }`); each renders inline in the room via an embedded `<img>`, and the served `url` is what the model fetches to inspect the render. `includeBase64: false` always — the tool consumes only `captures[].url`.
- **`download-file-to-realm`** — new host command: fetch a URL binary-safe and persist through `write-binary-file`. Turns a served screenshot URL (or any URL) into a realm file without round-tripping base64 by hand.
- **Docs** — updated the screenshot-card demo, the `boxel-patterns` example, and its README to the served-URL model.

## Notes

- Depends on #5893: a geometry capture only serves on its own URL once the full capture identity lands. `target` was intentionally dropped — it's no longer part of the capture spec on that branch.

## Testing

- New `screenshot-card-test.gts` (host integration): format-only and geometry captures return served URLs; realm-JWT auth (asserts a realm-scoped token, not a realm-server session token); `captureSpec` assembly from the primitives; all-or-nothing viewport/clip validation; invalid format; 503 → retryable error.
- `ember-tsc` (glint) and eslint clean on the changed files. Browser QUnit not yet run in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GsYGsuCqHJz9GAti4jheG
