### PR TITLE
Repair boxel-pg containers that predate the max_connections flag

### DIFF
--- a/.devcontainer/claude-web-setup.sh
+++ b/.devcontainer/claude-web-setup.sh
@@ -154,6 +154,10 @@ if ! docker info >/dev/null 2>&1; then
   done
 fi
 if docker info >/dev/null 2>&1; then
+  # These pins are duplicated in scripts/pg-container.sh,
+  # packages/matrix/support/synapse/index.ts, packages/matrix/docker/smtp4dev.ts,
+  # .github/workflows/mirror-test-images.yml and
+  # .github/actions/warm-test-images/action.yml; bump them together.
   for image in postgres:16.3 matrixdotorg/synapse:v1.126.0 rnwood/smtp4dev:v3.1; do
     docker pull "$image" || echo "Pre-pull of $image failed; it will be pulled at first stack start." >&2
   done

--- a/.github/actions/warm-test-images/action.yml
+++ b/.github/actions/warm-test-images/action.yml
@@ -32,8 +32,8 @@ runs:
         # warm <canonical-ref> <ghcr-package-suffix:tag>. These versions must
         # match what runs at test time and what the mirror publishes:
         # packages/matrix/support/synapse/index.ts, packages/matrix/docker/
-        # smtp4dev.ts, packages/matrix/docker/mock-oauth2.ts, mise-tasks/infra/
-        # ensure-pg, packages/postgres/scripts/start-pg.sh, and
+        # smtp4dev.ts, packages/matrix/docker/mock-oauth2.ts,
+        # scripts/pg-container.sh, and
         # .github/workflows/mirror-test-images.yml.
         warm() {
           canonical="$1"

--- a/.github/actions/warm-test-images/action.yml
+++ b/.github/actions/warm-test-images/action.yml
@@ -33,7 +33,7 @@ runs:
         # match what runs at test time and what the mirror publishes:
         # packages/matrix/support/synapse/index.ts, packages/matrix/docker/
         # smtp4dev.ts, packages/matrix/docker/mock-oauth2.ts,
-        # scripts/pg-container.sh, and
+        # scripts/pg-container.sh, .devcontainer/claude-web-setup.sh, and
         # .github/workflows/mirror-test-images.yml.
         warm() {
           canonical="$1"

--- a/.github/workflows/mirror-test-images.yml
+++ b/.github/workflows/mirror-test-images.yml
@@ -46,7 +46,7 @@ jobs:
           # match what runs at test time and the warm-test-images action:
           # packages/matrix/support/synapse/index.ts, packages/matrix/docker/
           # smtp4dev.ts, packages/matrix/docker/mock-oauth2.ts,
-          # scripts/pg-container.sh, and
+          # scripts/pg-container.sh, .devcontainer/claude-web-setup.sh, and
           # .github/actions/warm-test-images/action.yml.
           images=(
             "synapse:v1.126.0=matrixdotorg/synapse:v1.126.0"

--- a/.github/workflows/mirror-test-images.yml
+++ b/.github/workflows/mirror-test-images.yml
@@ -20,11 +20,7 @@ on:
       - packages/matrix/support/synapse/index.ts
       - packages/matrix/docker/smtp4dev.ts
       - packages/matrix/docker/mock-oauth2.ts
-      - mise-tasks/infra/ensure-pg
-      # The realm-server start-pg.sh is a symlink to this real file (where the
-      # postgres pin lives); a path filter on the symlink wouldn't see edits to
-      # the pinned version.
-      - packages/postgres/scripts/start-pg.sh
+      - scripts/pg-container.sh
 
 concurrency:
   group: mirror-test-images
@@ -49,8 +45,8 @@ jobs:
           # <ghcr-package-suffix>:<tag>=<source-ref>. These versions must
           # match what runs at test time and the warm-test-images action:
           # packages/matrix/support/synapse/index.ts, packages/matrix/docker/
-          # smtp4dev.ts, packages/matrix/docker/mock-oauth2.ts, mise-tasks/
-          # infra/ensure-pg, packages/postgres/scripts/start-pg.sh, and
+          # smtp4dev.ts, packages/matrix/docker/mock-oauth2.ts,
+          # scripts/pg-container.sh, and
           # .github/actions/warm-test-images/action.yml.
           images=(
             "synapse:v1.126.0=matrixdotorg/synapse:v1.126.0"

--- a/mise-tasks/infra/ensure-pg
+++ b/mise-tasks/infra/ensure-pg
@@ -1,31 +1,19 @@
 #!/bin/sh
 #MISE description="Ensure PostgreSQL is running and ready"
 
-# Start the container if needed. Multiple tasks may call this concurrently,
-# so handle the race: docker run can fail if another process already created
-# the container — that's fine, we just ensure it's started.
-if [ -z "$(docker ps -f name=boxel-pg --all --format '{{.Names}}')" ]; then
-  echo "Starting new boxel-pg container on port ${PGPORT:-5435}..."
-  # If you bump postgres, also update start-pg.sh and the GHCR mirror so CI
-  # keeps caching it (it must match the version pinned there):
-  # .github/workflows/mirror-test-images.yml and
-  # .github/actions/warm-test-images/action.yml.
-  #
-  # max_connections is raised above postgres's default of 100 because one
-  # boxel-pg backs every service in a test stack — realm servers plus their
-  # worker pools, and the matrix suite stacks a second isolated set on top —
-  # and each opens its own pg pool (up to PG_POOL_MAX=40), so the default
-  # ceiling is exhausted under load. Keep this in sync with start-pg.sh.
-  docker run --name boxel-pg -e POSTGRES_HOST_AUTH_METHOD=trust -p "${PGPORT:-5435}":5432 -d postgres:16.3 -c max_connections=400 >/dev/null 2>&1 || true
-fi
-# Ensure the container is running (handles both the race case and stopped containers)
-docker start boxel-pg >/dev/null 2>&1 || true
+# The container spec and the start/repair logic live in scripts/pg-container.sh,
+# shared with packages/postgres/scripts/start-pg.sh.
+_REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+. "$_REPO_ROOT/scripts/pg-container.sh"
+unset _REPO_ROOT
+
+boxel_pg_ensure_running
 
 # Wait for readiness
 COUNT=0
 MAX_ATTEMPTS=10
 
-while ! docker exec boxel-pg pg_isready -U postgres >/dev/null 2>&1; do
+while ! boxel_pg_is_ready; do
   if [ $COUNT -eq 0 ]; then
     echo "Waiting for postgres"
   fi
@@ -45,18 +33,13 @@ done
 # realm's readiness check never passes. This task is a shared dependency of
 # the realm-server and worker tasks, so creating the databases here closes
 # the race for every host CI job, not just one.
-#
-# `docker exec ... -h localhost -p 5432` forces TCP inside the container:
-# the postgres:16.3 image does not always create the unix socket, so a bare
-# `psql -U postgres` can fail on the socket path. Postgres listens on
-# *:5432 (trust auth), so localhost works regardless.
 ensure_db() {
   db="$1"
   [ -z "$db" ] && return 0
   # Create unconditionally and treat "already exists" as success, so a
   # concurrent creator (the realm-server and worker tasks may run this in
   # parallel) can't lose a check-then-create race.
-  if out=$(docker exec boxel-pg psql -h localhost -p 5432 -U postgres -w -c "CREATE DATABASE $db" 2>&1); then
+  if out=$(boxel_pg_psql -c "CREATE DATABASE $db" 2>&1); then
     echo "Created database $db"
   elif echo "$out" | grep -q "already exists"; then
     echo "Database $db already exists"

--- a/mise-tasks/lib/dev-common.sh
+++ b/mise-tasks/lib/dev-common.sh
@@ -5,6 +5,9 @@
 
 REPO_ROOT="$(cd "../.." && pwd)"
 
+# boxel_pg_is_ready and friends, shared with the scripts that start boxel-pg.
+. "$REPO_ROOT/scripts/pg-container.sh"
+
 # Use absolute paths so spawned processes carry absolute argv[0]; this keeps
 # the regex sweeps in `sweep_orphaned_services` anchored to this checkout
 # reliable regardless of how the binary was originally resolved by PATH.
@@ -352,7 +355,7 @@ NODE_TEST_REALM_READY="${REALM_TEST_READY_SCHEME}://${REALM_TEST_URL#*://}/node-
 if [ -n "$BOXEL_ENVIRONMENT" ]; then
   ./scripts/start-pg.sh
   echo "Waiting for Postgres to accept connections…"
-  until docker exec boxel-pg pg_isready -U postgres >/dev/null 2>&1; do sleep 1; done
+  until boxel_pg_is_ready; do sleep 1; done
   "$REPO_ROOT/scripts/ensure-branch-db.sh"
   echo "Running database migrations…"
   pnpm migrate

--- a/packages/matrix/helpers/ensure-user-record.ts
+++ b/packages/matrix/helpers/ensure-user-record.ts
@@ -10,6 +10,12 @@ export async function ensureUserRecord(matrixUserId: string): Promise<void> {
       'exec',
       'boxel-pg',
       'psql',
+      // The postgres image does not always create the unix socket, so force
+      // TCP; it listens on *:5432 with trust auth.
+      '-h',
+      '127.0.0.1',
+      '-p',
+      '5432',
       '-U',
       'postgres',
       '-w',

--- a/packages/matrix/scripts/register-matrix-users.ts
+++ b/packages/matrix/scripts/register-matrix-users.ts
@@ -123,8 +123,12 @@ function execAsync(
 async function waitForPostgres(): Promise<void> {
   const maxAttempts = 30;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // Probe over TCP, not the unix socket: while the postgres image
+    // initializes a fresh data directory it runs a temporary server bound to
+    // the socket only, so a socket probe reports ready during init and the
+    // next command lands on "the database system is shutting down".
     const { err } = await execAsync(
-      'docker exec boxel-pg pg_isready -U postgres',
+      'docker exec boxel-pg pg_isready -h 127.0.0.1 -p 5432 -U postgres',
     );
     if (!err) return;
     process.stdout.write('.');

--- a/packages/postgres/scripts/start-pg.sh
+++ b/packages/postgres/scripts/start-pg.sh
@@ -1,21 +1,10 @@
 #! /bin/sh
-# Start the boxel-pg container. Tolerates concurrent invocations (e.g. when
-# run-p and mise ensure-pg both try to start postgres at the same time).
-if [ -z "$(docker ps -f name=boxel-pg --all --format '{{.Names}}')" ]; then
-  # running postgres on port 5435 so it doesn't collide with native postgres
-  # that may be running on your system.
-  # If you bump postgres, also update mise-tasks/infra/ensure-pg and the GHCR
-  # mirror so CI keeps caching it (it must match the version pinned there):
-  # .github/workflows/mirror-test-images.yml and
-  # .github/actions/warm-test-images/action.yml.
-  #
-  # max_connections is raised well above postgres's default of 100: a single
-  # boxel-pg backs every service in a test stack at once — realm servers plus
-  # their worker pools, and the matrix suite adds a second isolated stack on
-  # top of the base one — and each process opens its own pg pool (up to
-  # PG_POOL_MAX=40). That already clears half a dozen pools, and a burst that
-  # crosses the ceiling fails callers with "sorry, too many clients already".
-  # Keep this in sync with mise-tasks/infra/ensure-pg.
-  docker run --name boxel-pg -e POSTGRES_HOST_AUTH_METHOD=trust -p "${PGPORT:-5435}":5432 -d postgres:16.3 -c max_connections=400 >/dev/null 2>&1 || true
-fi
-docker start boxel-pg >/dev/null 2>&1 || true
+# Start the boxel-pg container. The container spec and the start/repair logic
+# live in scripts/pg-container.sh, shared with mise-tasks/infra/ensure-pg.
+#
+# `$0` may be the packages/realm-server/scripts symlink to this file; both paths
+# sit three levels below the repo root, so the same relative walk works either
+# way.
+. "$(cd "$(dirname "$0")/../../.." && pwd)/scripts/pg-container.sh"
+
+boxel_pg_ensure_running

--- a/scripts/pg-container.sh
+++ b/scripts/pg-container.sh
@@ -78,12 +78,33 @@ boxel_pg_max_connections_ok() {
   [ "$_bpg_current" -ge "$BOXEL_PG_MAX_CONNECTIONS" ]
 }
 
-# True once ALTER SYSTEM has been written but the restart that would apply it
-# has not happened yet, so a second caller can tell "nobody has fixed this"
-# from "it is fixed and waiting for a quiet moment".
-boxel_pg_max_connections_pending() {
+# The ceiling postgresql.conf / postgresql.auto.conf would produce on the next
+# restart, or 0 when it can't be read. This is read from the files themselves
+# on every call, so it reflects an ALTER SYSTEM immediately, with no reload.
+# Highest seqno wins, the way postgres resolves the files; a row that is
+# unparseable lands in the 0 case below, which asks for the ALTER anyway.
+#
+# Asked instead of pg_settings.pending_restart, which only says that *some*
+# restart-requiring change is outstanding: a pending change to any other value
+# looks identical to this repair's own, and gets restarted into. Note that a
+# row awaiting a restart carries error = "setting could not be applied" and
+# applied = f, so neither column can be used to filter for valid entries.
+boxel_pg_configured_max_connections() {
+  _bpg_configured=$(boxel_pg_psql -tAc \
+    "select setting from pg_file_settings where name = 'max_connections' order by seqno desc limit 1" \
+    2>/dev/null | tr -d '[:space:]')
+  case "$_bpg_configured" in
+    '' | *[!0-9]*) echo 0 ;;
+    *) echo "$_bpg_configured" ;;
+  esac
+}
+
+# True when max_connections is pinned on the container's command line. That
+# beats postgresql.auto.conf, so for such a container a restart just brings the
+# same value back and no in-place repair can raise it.
+boxel_pg_max_connections_is_command_line() {
   [ "$(boxel_pg_psql -tAc \
-    "select pending_restart from pg_settings where name = 'max_connections'" \
+    "select source = 'command line' from pg_settings where name = 'max_connections'" \
     2>/dev/null | tr -d '[:space:]')" = t ]
 }
 
@@ -105,15 +126,19 @@ _boxel_pg_apply_max_connections() {
   # was mid-restart and unreachable at the time.
   boxel_pg_max_connections_ok && return 0
 
+  # A container whose command line pins the ceiling can only be raised by
+  # recreating it, which would discard the data volume — every local realm
+  # database plus a full reindex. Say so and leave it alone; restarting would
+  # bring the same value back every time this ran.
+  if boxel_pg_max_connections_is_command_line; then
+    echo "boxel-pg has max_connections=$(boxel_pg_current_max_connections) pinned on its container command line, which overrides postgresql.auto.conf. Raising it to $BOXEL_PG_MAX_CONNECTIONS means recreating the container, discarding its databases, so it was left as it is." >&2
+    return 1
+  fi
+
   _bpg_altered=
-  if ! boxel_pg_max_connections_pending; then
+  if [ "$(boxel_pg_configured_max_connections)" -lt "$BOXEL_PG_MAX_CONNECTIONS" ]; then
     echo "boxel-pg is running with max_connections=$(boxel_pg_current_max_connections); raising it to $BOXEL_PG_MAX_CONNECTIONS."
     boxel_pg_psql -c "ALTER SYSTEM SET max_connections = $BOXEL_PG_MAX_CONNECTIONS" >/dev/null 2>&1 || return 1
-    # ALTER SYSTEM only writes the file. Reloading makes postgres read it and
-    # flag the setting as awaiting a restart, which is how a later call tells
-    # "nobody has fixed this" from "fixed, waiting for a quiet moment". The
-    # reload is a SIGHUP: it drops nothing and changes no running value.
-    boxel_pg_psql -c 'select pg_reload_conf()' >/dev/null 2>&1 || return 1
     _bpg_altered=yes
   fi
 
@@ -130,7 +155,10 @@ _boxel_pg_apply_max_connections() {
 
   docker restart "$BOXEL_PG_CONTAINER" >/dev/null 2>&1 || return 1
   boxel_pg_wait_ready || return 1
+  # Report what it actually came up with, and fail if that is not the target,
+  # rather than assume the restart did what was asked.
   echo "boxel-pg restarted with max_connections=$(boxel_pg_current_max_connections)."
+  boxel_pg_max_connections_ok
 }
 
 # Bring max_connections up to BOXEL_PG_MAX_CONNECTIONS on a container that

--- a/scripts/pg-container.sh
+++ b/scripts/pg-container.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+# Shared definition of the local `boxel-pg` postgres container: the pinned
+# image, the settings it has to run with, and the helpers that bring it up and
+# keep those settings true of a container that already exists.
+#
+# Two entry points start boxel-pg — packages/postgres/scripts/start-pg.sh
+# (`pnpm start:pg`, symlinked from packages/realm-server/scripts) and
+# mise-tasks/infra/ensure-pg — and both source this file so there is one
+# definition to change rather than two to keep in step.
+#
+# Usage:
+#   . "$(cd "$(dirname "$0")/../../.." && pwd)/scripts/pg-container.sh"
+#   boxel_pg_ensure_running
+
+BOXEL_PG_CONTAINER=boxel-pg
+
+# If you bump postgres, also update the GHCR mirror so CI keeps caching it (it
+# must match the version pinned there): .github/workflows/mirror-test-images.yml
+# and .github/actions/warm-test-images/action.yml.
+BOXEL_PG_IMAGE=postgres:16.3
+
+# max_connections is raised well above postgres's default of 100: a single
+# boxel-pg backs every service in a stack at once — realm servers plus their
+# worker pools, and the matrix suite adds a second isolated stack on top of the
+# base one — and each process opens its own pg pool (up to PG_POOL_MAX=40).
+# That already clears half a dozen pools, and a burst that crosses the ceiling
+# fails callers with "sorry, too many clients already".
+BOXEL_PG_MAX_CONNECTIONS=400
+
+# Run psql inside the container over TCP. The postgres:16.3 image does not
+# always create the /var/run/postgresql unix socket, so a bare `psql -U postgres`
+# can fail on the socket path; postgres listens on *:5432 with trust auth, so
+# TCP works regardless.
+boxel_pg_psql() {
+  docker exec "$BOXEL_PG_CONTAINER" psql -h 127.0.0.1 -p 5432 -U postgres -w "$@"
+}
+
+# Probe over TCP for the same reason, plus one of its own: while the image
+# initializes a fresh data directory it runs a temporary server bound to the
+# socket only, so a socket probe reports ready during init and the next command
+# lands on "the database system is shutting down". Only the real server listens
+# on TCP.
+boxel_pg_is_ready() {
+  docker exec "$BOXEL_PG_CONTAINER" pg_isready -h 127.0.0.1 -p 5432 -U postgres >/dev/null 2>&1
+}
+
+# Wait for the container to accept TCP connections, up to $1 seconds (default
+# 60). Returns non-zero on timeout rather than exiting, so a caller can decide
+# whether that is fatal.
+boxel_pg_wait_ready() {
+  _bpg_remaining="${1:-60}"
+  while ! boxel_pg_is_ready; do
+    _bpg_remaining=$((_bpg_remaining - 1))
+    if [ "$_bpg_remaining" -le 0 ]; then
+      return 1
+    fi
+    sleep 1
+  done
+  return 0
+}
+
+# Bring max_connections up to BOXEL_PG_MAX_CONNECTIONS on a container that
+# already exists.
+#
+# `docker start` reuses the container's original command, and neither entry
+# point recreates a container it finds, so a boxel-pg created before the
+# `-c max_connections` flag was added keeps postgres's default of 100 forever.
+# Nothing about that is visible from the symptom side — jobs fail with
+# "sorry, too many clients already" and the realm-server exits while the rest
+# of the stack stays up — so repair it here rather than wait for someone to
+# diagnose it.
+#
+# The repair is in place: ALTER SYSTEM writes postgresql.auto.conf inside
+# PGDATA, which lives on the container's volume, so it survives restarts and
+# outlives the container itself. Recreating the container instead would strand
+# that volume and cost every local realm database plus a full reindex.
+#
+# Best-effort throughout: a machine this cannot repair is no worse off than it
+# was, so every failure path just returns non-zero for the caller to ignore.
+boxel_pg_repair_max_connections() {
+  boxel_pg_wait_ready || return 1
+
+  _bpg_current=$(boxel_pg_psql -tAc 'show max_connections' 2>/dev/null | tr -d '[:space:]')
+  case "$_bpg_current" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  [ "$_bpg_current" -ge "$BOXEL_PG_MAX_CONNECTIONS" ] && return 0
+
+  echo "boxel-pg is running with max_connections=$_bpg_current; raising it to $BOXEL_PG_MAX_CONNECTIONS."
+  boxel_pg_psql -c "ALTER SYSTEM SET max_connections = $BOXEL_PG_MAX_CONNECTIONS" >/dev/null 2>&1 || return 1
+
+  # max_connections only takes effect on restart, which drops every open
+  # connection. Skip the restart while another stack is using this postgres and
+  # let the setting apply the next time it comes up — the alternative is killing
+  # a colleague process mid-index to fix a ceiling it has not hit yet.
+  _bpg_clients=$(boxel_pg_psql -tAc \
+    "select count(*) from pg_stat_activity where pid <> pg_backend_pid() and backend_type = 'client backend'" \
+    2>/dev/null | tr -d '[:space:]')
+  case "$_bpg_clients" in
+    '' | *[!0-9]*) _bpg_clients=1 ;;
+  esac
+  if [ "$_bpg_clients" -gt 0 ]; then
+    echo "boxel-pg has $_bpg_clients client connection(s) open, so it was left running; the new ceiling applies once it restarts."
+    return 0
+  fi
+
+  docker restart "$BOXEL_PG_CONTAINER" >/dev/null 2>&1 || return 1
+  boxel_pg_wait_ready || return 1
+  echo "boxel-pg restarted with max_connections=$(boxel_pg_psql -tAc 'show max_connections' 2>/dev/null | tr -d '[:space:]')."
+}
+
+# Create the container if it is missing, start it, and make sure an existing one
+# is running the settings above. Tolerates concurrent invocations — run-p and
+# mise infra:ensure-pg can both call this at once — so losing the creation race
+# is fine: `docker start` covers it.
+boxel_pg_ensure_running() {
+  _bpg_created=
+  if [ -z "$(docker ps -f "name=$BOXEL_PG_CONTAINER" --all --format '{{.Names}}')" ]; then
+    echo "Starting new $BOXEL_PG_CONTAINER container on port ${PGPORT:-5435}..."
+    # Running postgres on 5435 so it doesn't collide with a native postgres
+    # that may already be running on the machine.
+    if docker run --name "$BOXEL_PG_CONTAINER" \
+      -e POSTGRES_HOST_AUTH_METHOD=trust \
+      -p "${PGPORT:-5435}":5432 \
+      -d "$BOXEL_PG_IMAGE" \
+      -c max_connections="$BOXEL_PG_MAX_CONNECTIONS" >/dev/null 2>&1; then
+      _bpg_created=yes
+    fi
+  fi
+  docker start "$BOXEL_PG_CONTAINER" >/dev/null 2>&1 || true
+
+  # A container this call created already has the flag; only an inherited one
+  # can have drifted.
+  [ -n "$_bpg_created" ] || boxel_pg_repair_max_connections || true
+}

--- a/scripts/pg-container.sh
+++ b/scripts/pg-container.sh
@@ -59,6 +59,80 @@ boxel_pg_wait_ready() {
   return 0
 }
 
+# Where the repair serializes itself. run-p starts three callers at once —
+# start:pg, plus an infra:ensure-pg from each of start:development and
+# start:worker-development — and without a lock each would restart postgres out
+# from under the stack all three are booting.
+BOXEL_PG_REPAIR_LOCK="${TMPDIR:-/tmp}/boxel-pg-max-connections.lock"
+
+# The running ceiling, or empty if it can't be read.
+boxel_pg_current_max_connections() {
+  boxel_pg_psql -tAc 'show max_connections' 2>/dev/null | tr -d '[:space:]'
+}
+
+boxel_pg_max_connections_ok() {
+  _bpg_current=$(boxel_pg_current_max_connections)
+  case "$_bpg_current" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  [ "$_bpg_current" -ge "$BOXEL_PG_MAX_CONNECTIONS" ]
+}
+
+# True once ALTER SYSTEM has been written but the restart that would apply it
+# has not happened yet, so a second caller can tell "nobody has fixed this"
+# from "it is fixed and waiting for a quiet moment".
+boxel_pg_max_connections_pending() {
+  [ "$(boxel_pg_psql -tAc \
+    "select pending_restart from pg_settings where name = 'max_connections'" \
+    2>/dev/null | tr -d '[:space:]')" = t ]
+}
+
+# Client backends other than the one asking.
+boxel_pg_client_count() {
+  _bpg_clients=$(boxel_pg_psql -tAc \
+    "select count(*) from pg_stat_activity where pid <> pg_backend_pid() and backend_type = 'client backend'" \
+    2>/dev/null | tr -d '[:space:]')
+  case "$_bpg_clients" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  echo "$_bpg_clients"
+}
+
+# The repair proper. Only ever called with the lock held.
+_boxel_pg_apply_max_connections() {
+  # A caller that queued behind the winner arrives here with the work already
+  # done: its wait-loop check could not see the new ceiling because postgres
+  # was mid-restart and unreachable at the time.
+  boxel_pg_max_connections_ok && return 0
+
+  _bpg_altered=
+  if ! boxel_pg_max_connections_pending; then
+    echo "boxel-pg is running with max_connections=$(boxel_pg_current_max_connections); raising it to $BOXEL_PG_MAX_CONNECTIONS."
+    boxel_pg_psql -c "ALTER SYSTEM SET max_connections = $BOXEL_PG_MAX_CONNECTIONS" >/dev/null 2>&1 || return 1
+    # ALTER SYSTEM only writes the file. Reloading makes postgres read it and
+    # flag the setting as awaiting a restart, which is how a later call tells
+    # "nobody has fixed this" from "fixed, waiting for a quiet moment". The
+    # reload is a SIGHUP: it drops nothing and changes no running value.
+    boxel_pg_psql -c 'select pg_reload_conf()' >/dev/null 2>&1 || return 1
+    _bpg_altered=yes
+  fi
+
+  _bpg_clients=$(boxel_pg_client_count) || return 1
+  if [ "$_bpg_clients" -gt 0 ]; then
+    # The new ceiling needs a restart, which drops every open connection. Leave
+    # postgres alone while another stack is using it and let the setting apply
+    # the next time it comes up, rather than killing a colleague process
+    # mid-index over a ceiling it has not hit yet. Said once, when the drift is
+    # found — every stack start until then would repeat it unprompted.
+    [ -n "$_bpg_altered" ] && echo "boxel-pg has $_bpg_clients client connection(s) open, so it was left running; max_connections=$BOXEL_PG_MAX_CONNECTIONS applies once nothing is using it."
+    return 0
+  fi
+
+  docker restart "$BOXEL_PG_CONTAINER" >/dev/null 2>&1 || return 1
+  boxel_pg_wait_ready || return 1
+  echo "boxel-pg restarted with max_connections=$(boxel_pg_current_max_connections)."
+}
+
 # Bring max_connections up to BOXEL_PG_MAX_CONNECTIONS on a container that
 # already exists.
 #
@@ -80,33 +154,27 @@ boxel_pg_wait_ready() {
 boxel_pg_repair_max_connections() {
   boxel_pg_wait_ready || return 1
 
-  _bpg_current=$(boxel_pg_psql -tAc 'show max_connections' 2>/dev/null | tr -d '[:space:]')
-  case "$_bpg_current" in
-    '' | *[!0-9]*) return 1 ;;
-  esac
-  [ "$_bpg_current" -ge "$BOXEL_PG_MAX_CONNECTIONS" ] && return 0
+  # The check every already-correct machine pays, and nothing more.
+  boxel_pg_max_connections_ok && return 0
 
-  echo "boxel-pg is running with max_connections=$_bpg_current; raising it to $BOXEL_PG_MAX_CONNECTIONS."
-  boxel_pg_psql -c "ALTER SYSTEM SET max_connections = $BOXEL_PG_MAX_CONNECTIONS" >/dev/null 2>&1 || return 1
+  _bpg_waited=0
+  while ! mkdir "$BOXEL_PG_REPAIR_LOCK" 2>/dev/null; do
+    # Another caller is repairing; leave as soon as its restart lands.
+    boxel_pg_max_connections_ok && return 0
+    _bpg_waited=$((_bpg_waited + 1))
+    if [ "$_bpg_waited" -ge 120 ]; then
+      # A killed holder leaves the directory behind. Clear it so the next stack
+      # start gets a turn instead of being blocked for good.
+      rm -rf "$BOXEL_PG_REPAIR_LOCK" 2>/dev/null || true
+      return 1
+    fi
+    sleep 1
+  done
 
-  # max_connections only takes effect on restart, which drops every open
-  # connection. Skip the restart while another stack is using this postgres and
-  # let the setting apply the next time it comes up — the alternative is killing
-  # a colleague process mid-index to fix a ceiling it has not hit yet.
-  _bpg_clients=$(boxel_pg_psql -tAc \
-    "select count(*) from pg_stat_activity where pid <> pg_backend_pid() and backend_type = 'client backend'" \
-    2>/dev/null | tr -d '[:space:]')
-  case "$_bpg_clients" in
-    '' | *[!0-9]*) _bpg_clients=1 ;;
-  esac
-  if [ "$_bpg_clients" -gt 0 ]; then
-    echo "boxel-pg has $_bpg_clients client connection(s) open, so it was left running; the new ceiling applies once it restarts."
-    return 0
-  fi
-
-  docker restart "$BOXEL_PG_CONTAINER" >/dev/null 2>&1 || return 1
-  boxel_pg_wait_ready || return 1
-  echo "boxel-pg restarted with max_connections=$(boxel_pg_psql -tAc 'show max_connections' 2>/dev/null | tr -d '[:space:]')."
+  _bpg_status=0
+  _boxel_pg_apply_max_connections || _bpg_status=1
+  rmdir "$BOXEL_PG_REPAIR_LOCK" 2>/dev/null || true
+  return "$_bpg_status"
 }
 
 # Create the container if it is missing, start it, and make sure an existing one

--- a/scripts/pg-container.sh
+++ b/scripts/pg-container.sh
@@ -25,6 +25,13 @@ BOXEL_PG_IMAGE=postgres:16.3
 # base one — and each process opens its own pg pool (up to PG_POOL_MAX=40).
 # That already clears half a dozen pools, and a burst that crosses the ceiling
 # fails callers with "sorry, too many clients already".
+#
+# Applied by boxel_pg_repair_max_connections, never as a `docker run -c` flag.
+# A flag lands on pg_settings.source = 'command line', which outranks
+# postgresql.auto.conf and so cannot be raised without discarding the
+# container — which is the exact trap this file exists to get out of. Going
+# through ALTER SYSTEM for new and inherited containers alike keeps every one
+# of them repairable the next time this number moves.
 BOXEL_PG_MAX_CONNECTIONS=400
 
 # Stamped on every connection this file opens, so the deferral check can tell
@@ -213,27 +220,28 @@ boxel_pg_repair_max_connections() {
   return "$_bpg_status"
 }
 
-# Create the container if it is missing, start it, and make sure an existing one
-# is running the settings above. Tolerates concurrent invocations — run-p and
-# mise infra:ensure-pg can both call this at once — so losing the creation race
-# is fine: `docker start` covers it.
+# Create the container if it is missing, start it, and bring its ceiling up to
+# BOXEL_PG_MAX_CONNECTIONS. Tolerates concurrent invocations — run-p and mise
+# infra:ensure-pg can both call this at once — so losing the creation race is
+# fine: `docker start` covers it.
 boxel_pg_ensure_running() {
-  _bpg_created=
   if [ -z "$(docker ps -f "name=$BOXEL_PG_CONTAINER" --all --format '{{.Names}}')" ]; then
     echo "Starting new $BOXEL_PG_CONTAINER container on port ${PGPORT:-5435}..."
     # Running postgres on 5435 so it doesn't collide with a native postgres
-    # that may already be running on the machine.
-    if docker run --name "$BOXEL_PG_CONTAINER" \
+    # that may already be running on the machine. The ceiling is deliberately
+    # not passed here — see BOXEL_PG_MAX_CONNECTIONS above.
+    docker run --name "$BOXEL_PG_CONTAINER" \
       -e POSTGRES_HOST_AUTH_METHOD=trust \
       -p "${PGPORT:-5435}":5432 \
-      -d "$BOXEL_PG_IMAGE" \
-      -c max_connections="$BOXEL_PG_MAX_CONNECTIONS" >/dev/null 2>&1; then
-      _bpg_created=yes
-    fi
+      -d "$BOXEL_PG_IMAGE" >/dev/null 2>&1 || true
   fi
-  docker start "$BOXEL_PG_CONTAINER" >/dev/null 2>&1 || true
 
-  # A container this call created already has the flag; only an inherited one
-  # can have drifted.
-  [ -n "$_bpg_created" ] || boxel_pg_repair_max_connections || true
+  # Only a container that is actually running can be repaired. Without this,
+  # a stopped Docker daemon sends the repair off to spend its whole readiness
+  # budget probing a container that isn't there, turning an immediate return
+  # into a silent minute.
+  if docker start "$BOXEL_PG_CONTAINER" >/dev/null 2>&1; then
+    boxel_pg_repair_max_connections || true
+  fi
+  return 0
 }

--- a/scripts/pg-container.sh
+++ b/scripts/pg-container.sh
@@ -27,12 +27,17 @@ BOXEL_PG_IMAGE=postgres:16.3
 # fails callers with "sorry, too many clients already".
 BOXEL_PG_MAX_CONNECTIONS=400
 
+# Stamped on every connection this file opens, so the deferral check can tell
+# a stack that is using postgres from this script's own polls.
+BOXEL_PG_APPNAME=boxel-pg-maint
+
 # Run psql inside the container over TCP. The postgres:16.3 image does not
 # always create the /var/run/postgresql unix socket, so a bare `psql -U postgres`
 # can fail on the socket path; postgres listens on *:5432 with trust auth, so
 # TCP works regardless.
 boxel_pg_psql() {
-  docker exec "$BOXEL_PG_CONTAINER" psql -h 127.0.0.1 -p 5432 -U postgres -w "$@"
+  docker exec -e PGAPPNAME="$BOXEL_PG_APPNAME" "$BOXEL_PG_CONTAINER" \
+    psql -h 127.0.0.1 -p 5432 -U postgres -w "$@"
 }
 
 # Probe over TCP for the same reason, plus one of its own: while the image
@@ -108,10 +113,13 @@ boxel_pg_max_connections_is_command_line() {
     2>/dev/null | tr -d '[:space:]')" = t ]
 }
 
-# Client backends other than the one asking.
+# Client backends that belong to something other than this script. Sibling
+# callers poll `show max_connections` once a second while they wait for the
+# lock, and those connections are client backends like any other — counting
+# them would defer the repair on a machine where nothing else is connected.
 boxel_pg_client_count() {
   _bpg_clients=$(boxel_pg_psql -tAc \
-    "select count(*) from pg_stat_activity where pid <> pg_backend_pid() and backend_type = 'client backend'" \
+    "select count(*) from pg_stat_activity where pid <> pg_backend_pid() and backend_type = 'client backend' and application_name <> '$BOXEL_PG_APPNAME'" \
     2>/dev/null | tr -d '[:space:]')
   case "$_bpg_clients" in
     '' | *[!0-9]*) return 1 ;;

--- a/scripts/pg-container.sh
+++ b/scripts/pg-container.sh
@@ -14,9 +14,11 @@
 
 BOXEL_PG_CONTAINER=boxel-pg
 
-# If you bump postgres, also update the GHCR mirror so CI keeps caching it (it
-# must match the version pinned there): .github/workflows/mirror-test-images.yml
-# and .github/actions/warm-test-images/action.yml.
+# If you bump postgres, also update the GHCR mirror so CI keeps caching it and
+# the devcontainer's pre-pull, which all pin the version separately:
+# .github/workflows/mirror-test-images.yml,
+# .github/actions/warm-test-images/action.yml and
+# .devcontainer/claude-web-setup.sh.
 BOXEL_PG_IMAGE=postgres:16.3
 
 # max_connections is raised well above postgres's default of 100: a single

--- a/scripts/pg-container.sh
+++ b/scripts/pg-container.sh
@@ -28,12 +28,16 @@ BOXEL_PG_IMAGE=postgres:16.3
 # That already clears half a dozen pools, and a burst that crosses the ceiling
 # fails callers with "sorry, too many clients already".
 #
-# Applied by boxel_pg_repair_max_connections, never as a `docker run -c` flag.
-# A flag lands on pg_settings.source = 'command line', which outranks
-# postgresql.auto.conf and so cannot be raised without discarding the
-# container — which is the exact trap this file exists to get out of. Going
-# through ALTER SYSTEM for new and inherited containers alike keeps every one
-# of them repairable the next time this number moves.
+# New containers get this on the `docker run` command line, which means they
+# need no restart to reach it. Letting the repair set it instead would be
+# tidier — a command-line value outranks postgresql.auto.conf, so a container
+# created this way can only be raised by recreating it — but it is not safe
+# here: applying it takes a restart, and under run-p the sibling
+# infra:ensure-pg callers are creating databases against that same server. CI
+# fails exactly there, with `FATAL: the database system is shutting down`
+# followed by a base-realm readiness timeout. Raising this number therefore
+# also means recreating existing containers; boxel_pg_repair_max_connections
+# says so, with the command, when it meets one.
 BOXEL_PG_MAX_CONNECTIONS=400
 
 # Stamped on every connection this file opens, so the deferral check can tell
@@ -113,6 +117,14 @@ boxel_pg_configured_max_connections() {
   esac
 }
 
+# The volume holding PGDATA, so the message below can offer a recreate command
+# that keeps the databases rather than stranding them.
+boxel_pg_data_volume() {
+  docker inspect "$BOXEL_PG_CONTAINER" \
+    --format '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}' \
+    2>/dev/null
+}
+
 # True when max_connections is pinned on the container's command line. That
 # beats postgresql.auto.conf, so for such a container a restart just brings the
 # same value back and no in-place repair can raise it.
@@ -148,7 +160,9 @@ _boxel_pg_apply_max_connections() {
   # database plus a full reindex. Say so and leave it alone; restarting would
   # bring the same value back every time this ran.
   if boxel_pg_max_connections_is_command_line; then
-    echo "boxel-pg has max_connections=$(boxel_pg_current_max_connections) pinned on its container command line, which overrides postgresql.auto.conf. Raising it to $BOXEL_PG_MAX_CONNECTIONS means recreating the container, discarding its databases, so it was left as it is." >&2
+    echo "boxel-pg has max_connections=$(boxel_pg_current_max_connections) pinned on its container command line, which overrides postgresql.auto.conf, so it cannot be raised to $BOXEL_PG_MAX_CONNECTIONS in place." >&2
+    echo "Recreate it against the same data to pick the new ceiling up:" >&2
+    echo "  docker rm -f $BOXEL_PG_CONTAINER && docker run --name $BOXEL_PG_CONTAINER -e POSTGRES_HOST_AUTH_METHOD=trust -p ${PGPORT:-5435}:5432 -v $(boxel_pg_data_volume):/var/lib/postgresql/data -d $BOXEL_PG_IMAGE -c max_connections=$BOXEL_PG_MAX_CONNECTIONS" >&2
     return 1
   fi
 
@@ -242,22 +256,26 @@ boxel_pg_repair_max_connections() {
 # infra:ensure-pg can both call this at once — so losing the creation race is
 # fine: `docker start` covers it.
 boxel_pg_ensure_running() {
+  _bpg_created=
   if [ -z "$(docker ps -f "name=$BOXEL_PG_CONTAINER" --all --format '{{.Names}}')" ]; then
     echo "Starting new $BOXEL_PG_CONTAINER container on port ${PGPORT:-5435}..."
     # Running postgres on 5435 so it doesn't collide with a native postgres
-    # that may already be running on the machine. The ceiling is deliberately
-    # not passed here — see BOXEL_PG_MAX_CONNECTIONS above.
-    docker run --name "$BOXEL_PG_CONTAINER" \
+    # that may already be running on the machine.
+    if docker run --name "$BOXEL_PG_CONTAINER" \
       -e POSTGRES_HOST_AUTH_METHOD=trust \
       -p "${PGPORT:-5435}":5432 \
-      -d "$BOXEL_PG_IMAGE" >/dev/null 2>&1 || true
+      -d "$BOXEL_PG_IMAGE" \
+      -c max_connections="$BOXEL_PG_MAX_CONNECTIONS" >/dev/null 2>&1; then
+      _bpg_created=yes
+    fi
   fi
 
-  # Only a container that is actually running can be repaired. Without this,
-  # a stopped Docker daemon sends the repair off to spend its whole readiness
-  # budget probing a container that isn't there, turning an immediate return
-  # into a silent minute.
-  if docker start "$BOXEL_PG_CONTAINER" >/dev/null 2>&1; then
+  # Repair only an inherited container that is actually running: one created
+  # just now already has the ceiling, and without the start check a stopped
+  # Docker daemon sends the repair off to spend its whole readiness budget
+  # probing a container that isn't there, turning an immediate return into a
+  # silent minute.
+  if docker start "$BOXEL_PG_CONTAINER" >/dev/null 2>&1 && [ -z "$_bpg_created" ]; then
     boxel_pg_repair_max_connections || true
   fi
   return 0

--- a/scripts/pg-container.sh
+++ b/scripts/pg-container.sh
@@ -204,19 +204,34 @@ boxel_pg_repair_max_connections() {
   while ! mkdir "$BOXEL_PG_REPAIR_LOCK" 2>/dev/null; do
     # Another caller is repairing; leave as soon as its restart lands.
     boxel_pg_max_connections_ok && return 0
+
+    # The holder stamps its pid, so a lock left behind by one that was killed
+    # mid-repair — Ctrl-C during `pnpm start` is the ordinary way that happens —
+    # is recognized at once. Waiting the whole window out instead would stall
+    # every later caller on the stack-boot path, and only on the machines that
+    # need the repair in the first place.
+    _bpg_holder=$(cat "$BOXEL_PG_REPAIR_LOCK/pid" 2>/dev/null)
+    if [ -n "$_bpg_holder" ] && ! kill -0 "$_bpg_holder" 2>/dev/null; then
+      rm -rf "$BOXEL_PG_REPAIR_LOCK" 2>/dev/null || true
+      [ -d "$BOXEL_PG_REPAIR_LOCK" ] || continue
+    fi
+
     _bpg_waited=$((_bpg_waited + 1))
+    # Say so once the wait stops being momentary, so a stall is attributable.
+    [ "$_bpg_waited" = 3 ] && echo "Waiting for pid ${_bpg_holder:-?} to finish raising boxel-pg's max_connections…"
     if [ "$_bpg_waited" -ge 120 ]; then
-      # A killed holder leaves the directory behind. Clear it so the next stack
-      # start gets a turn instead of being blocked for good.
+      echo "Gave up waiting for pid ${_bpg_holder:-?} to raise boxel-pg's max_connections; clearing its lock for the next run." >&2
       rm -rf "$BOXEL_PG_REPAIR_LOCK" 2>/dev/null || true
       return 1
     fi
     sleep 1
   done
+  echo $$ >"$BOXEL_PG_REPAIR_LOCK/pid" 2>/dev/null || true
 
   _bpg_status=0
   _boxel_pg_apply_max_connections || _bpg_status=1
-  rmdir "$BOXEL_PG_REPAIR_LOCK" 2>/dev/null || true
+  # rm -rf, not rmdir: the lock directory holds the holder's pid file.
+  rm -rf "$BOXEL_PG_REPAIR_LOCK" 2>/dev/null || true
   return "$_bpg_status"
 }
 


### PR DESCRIPTION
Both scripts that start boxel-pg guard container creation on absence and then `docker start`, which reuses the container's original command. A container created before `-c max_connections=400` was added therefore keeps postgres's default of 100 forever — there was no drift detection and no self-heal.

Two worktrees each running a dev stack is enough to exhaust 100. A stack runs ~10 pg-connecting processes, each with a pool that grows to PG_POOL_MAX=40, so idle use sits well under the ceiling and anything that fans out (a packages/base edit triggering a full base-realm reindex, a second stack booting) crosses it. The symptom does not name its cause: jobs land in boxel_<slug>.jobs with SQLSTATE 53300, the realm-server exits, and every realm URL 502s while vite, matrix and the workers stay up.

Repair in place rather than recreate: ALTER SYSTEM writes postgresql.auto.conf inside PGDATA, which is on the container's volume, so the setting survives restarts and outlives the container. Recreating would strand that volume and cost every local realm database plus a full reindex. The restart the new ceiling needs is deferred when another client is connected, so a stack already using this postgres is never dropped mid-run; the setting applies on its next start.

The container spec and the start/readiness/repair helpers now live in scripts/pg-container.sh, sourced by both entry points, so there is one definition rather than two carrying a "keep this in sync" comment — which is what drifted.

Readiness now probes over TCP everywhere. While the postgres image initializes a fresh data directory it runs a temporary server bound to the unix socket only, so a socket probe reports ready during init and the next command lands on "the database system is shutting down".