### PR TITLE
test: reap CLI commands that outlive their test and name integration failures in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1207,6 +1207,39 @@ jobs:
         run: |
           echo "Full log is the boxel-cli-test-dev-stack-log artifact; tail follows."
           tail -n 500 /tmp/server.log
+      # Last step in the job, so the failing test names are the last thing in
+      # the log. The artifact holds the full report, but downloading it takes
+      # a browser: this keeps the diagnosis reachable by anything that can
+      # only read the log, which is how CI failures usually get triaged.
+      - name: Print failing tests
+        if: ${{ failure() }}
+        run: |
+          python3 - "${{ github.workspace }}/junit/boxel-cli-integration.xml" <<'PY'
+          import os, sys, xml.etree.ElementTree as ET
+
+          path = sys.argv[1]
+          if not os.path.exists(path):
+              print(f'No junit report at {path}; the suite died before writing one.')
+              raise SystemExit(0)
+          print('=== failing tests (full report: boxel-cli-test-report artifact) ===')
+          found = False
+          for case in ET.parse(path).getroot().iter('testcase'):
+              for problem in list(case.iter('failure')) + list(case.iter('error')):
+                  found = True
+                  print(f"\n{case.get('classname')} > {case.get('name')}")
+                  print(f"  {problem.get('message', '(no message)')}")
+                  body = (problem.text or '').strip()
+                  if body:
+                      print('  ' + '\n  '.join(body.splitlines()[:40]))
+              for err in case.iter('system-err'):
+                  body = (err.text or '').strip()
+                  if 'runBoxel' in body:
+                      print(f"\n{case.get('classname')} > {case.get('name')} (harness)")
+                      print('  ' + '\n  '.join(body.splitlines()[:40]))
+          if not found:
+              print('No failing testcase in the report — the suite failed outside')
+              print('any test or hook (a crashed worker, a non-zero exit).')
+          PY
 
   deploy:
     name: Deploy boxel to staging

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1178,6 +1178,12 @@ jobs:
       # tens of thousands of lines of realm-server request logging and
       # dev-stack output, so a reader that fetches the log's tail — the API,
       # and anyone scrolling — never reaches it.
+      # upload-artifact only warns on a missing file, so without this a run
+      # that dies before vitest writes the report is indistinguishable from
+      # one that passed — the same guard ci-host.yaml puts on its shards.
+      - name: Assert junit report was produced
+        if: ${{ !cancelled() }}
+        run: test -s junit/boxel-cli-integration.xml
       - name: Upload junit report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
@@ -1192,10 +1198,10 @@ jobs:
           name: boxel-cli-test-dev-stack-log
           path: /tmp/server.log
           retention-days: 30
-      # A bounded tail, because the full log is the artifact above: printing
-      # all of it here is what buries the suite's summary, and the last few
-      # hundred lines are the ones that describe the stack's state when the
-      # suite stopped.
+      # A bounded tail keeps the suite's own summary near the end of the job
+      # log, where a tail read can reach it. The full log is the artifact
+      # above; these last lines describe the stack's state when the suite
+      # stopped.
       - name: Print dev stack log tail
         if: ${{ !cancelled() }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1171,9 +1171,36 @@ jobs:
       - name: Run integration tests against the packed npm install
         run: pnpm test:cli:tarball
         working-directory: packages/boxel-cli
-      - name: Print server logs
+        env:
+          JUNIT_OUTPUT_FILE: ${{ github.workspace }}/junit/boxel-cli-integration.xml
+      # The junit report is what makes a failure here nameable. The suite's
+      # own console summary is separated from both ends of the job log by
+      # tens of thousands of lines of realm-server request logging and
+      # dev-stack output, so a reader that fetches the log's tail — the API,
+      # and anyone scrolling — never reaches it.
+      - name: Upload junit report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
-        run: cat /tmp/server.log
+        with:
+          name: boxel-cli-test-report
+          path: junit/boxel-cli-integration.xml
+          retention-days: 30
+      - name: Upload dev stack log
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: boxel-cli-test-dev-stack-log
+          path: /tmp/server.log
+          retention-days: 30
+      # A bounded tail, because the full log is the artifact above: printing
+      # all of it here is what buries the suite's summary, and the last few
+      # hundred lines are the ones that describe the stack's state when the
+      # suite stopped.
+      - name: Print dev stack log tail
+        if: ${{ !cancelled() }}
+        run: |
+          echo "Full log is the boxel-cli-test-dev-stack-log artifact; tail follows."
+          tail -n 500 /tmp/server.log
 
   deploy:
     name: Deploy boxel to staging

--- a/packages/boxel-cli/tests/fixtures/run-boxel/echo-json.cjs
+++ b/packages/boxel-cli/tests/fixtures/run-boxel/echo-json.cjs
@@ -1,0 +1,2 @@
+// A stand-in CLI that exits immediately with JSON on stdout.
+console.log(JSON.stringify({ args: process.argv.slice(2) }));

--- a/packages/boxel-cli/tests/fixtures/run-boxel/hang-with-grandchild.cjs
+++ b/packages/boxel-cli/tests/fixtures/run-boxel/hang-with-grandchild.cjs
@@ -1,0 +1,13 @@
+// A stand-in CLI that spawns a grandchild inheriting its stdio and then hangs
+// — the shape of `boxel parse` running ember-tsc, or `boxel test` launching
+// chromium. The command only reports `close` once every inherited pipe is
+// released, so signalling the command alone leaves the caller waiting on a
+// grandchild nothing has killed.
+const { spawn } = require('node:child_process');
+const { resolve } = require('node:path');
+
+spawn(process.execPath, [resolve(__dirname, 'hang.cjs'), 'grandchild'], {
+  stdio: 'inherit',
+});
+console.log('parent started');
+setInterval(() => {}, 1_000);

--- a/packages/boxel-cli/tests/fixtures/run-boxel/hang.cjs
+++ b/packages/boxel-cli/tests/fixtures/run-boxel/hang.cjs
@@ -1,0 +1,16 @@
+// A stand-in CLI that never exits and ignores SIGTERM, so the harness has to
+// escalate to SIGKILL to get rid of it — the same shape as a `boxel` command
+// wedged inside its own signal handler.
+//
+// With RUN_BOXEL_READY_FILE set it touches that path once it is running, so a
+// test can wait on a live child instead of a fixed sleep.
+const fs = require('node:fs');
+
+process.on('SIGTERM', () => {
+  console.log('ignoring SIGTERM');
+});
+console.log(`hang.cjs started with args: ${process.argv.slice(2).join(' ')}`);
+if (process.env.RUN_BOXEL_READY_FILE) {
+  fs.writeFileSync(process.env.RUN_BOXEL_READY_FILE, 'ready');
+}
+setInterval(() => {}, 1_000);

--- a/packages/boxel-cli/tests/helpers/run-boxel.ts
+++ b/packages/boxel-cli/tests/helpers/run-boxel.ts
@@ -1,6 +1,7 @@
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { afterEach, expect } from 'vitest';
 
 /**
  * Drive the `boxel` CLI as a subprocess — its real external interface
@@ -60,7 +61,11 @@ export interface RunBoxelOptions {
   env?: NodeJS.ProcessEnv;
   /** Text piped to the command's stdin. */
   input?: string;
-  /** Kill the command after this many ms (default 60s). */
+  /**
+   * Kill the command after this many ms (default 60s). A command that
+   * needs longer than the enclosing test's own timeout must raise both,
+   * or vitest abandons the test while the command is still running.
+   */
   timeout?: number;
 }
 
@@ -70,6 +75,8 @@ export interface BoxelResult {
   exitCode: number | null;
   /** True when the command exited 0. */
   ok: boolean;
+  /** True when the command was killed for exceeding `options.timeout`. */
+  timedOut: boolean;
   /**
    * Parse stdout as JSON (for commands run with `--json`). Throws with
    * the captured stdout/stderr attached when stdout isn't valid JSON, so
@@ -91,6 +98,74 @@ function sanitizedParentEnv(): NodeJS.ProcessEnv {
   );
 }
 
+const DEFAULT_TIMEOUT_MS = 60_000;
+/** How long a command gets to honor SIGTERM before it is SIGKILLed. */
+const KILL_GRACE_MS = 2_000;
+/** How much of a killed command's output is worth printing. */
+const OUTPUT_TAIL_CHARS = 2_000;
+
+interface InFlightCommand {
+  child: ChildProcess;
+  argv: string;
+  startedAt: number;
+  readStdout: () => string;
+  readStderr: () => string;
+}
+
+const inFlight = new Set<InFlightCommand>();
+
+function outputTail(text: string): string {
+  if (text.length === 0) {
+    return '(empty)';
+  }
+  return text.length <= OUTPUT_TAIL_CHARS
+    ? text
+    : `…${text.slice(-OUTPUT_TAIL_CHARS)}`;
+}
+
+function describeCommand(entry: InFlightCommand): string {
+  return [
+    `command: ${entry.argv}`,
+    `pid: ${entry.child.pid ?? 'n/a'}`,
+    `elapsed: ${Date.now() - entry.startedAt}ms`,
+    `--- stdout so far ---\n${outputTail(entry.readStdout())}`,
+    `--- stderr so far ---\n${outputTail(entry.readStderr())}`,
+  ].join('\n');
+}
+
+/**
+ * Kill any command still running when a test ends, and say what it was.
+ *
+ * vitest's default 30s `testTimeout` is shorter than this helper's 60s
+ * command deadline, so a wedged command outlives the test that started it
+ * and keeps writing to the realm server the *next* test is using — pushing
+ * files, creating realms, or queueing index jobs behind a test that never
+ * asked for any of it. Reaping at test boundaries keeps a single slow
+ * command from becoming a cascade of unrelated failures.
+ *
+ * The report matters as much as the kill: on its own, a timed-out test
+ * reports only `Test timed out in 30000ms`, which names neither the command
+ * that hung nor what it had printed before it did.
+ */
+export function reapInFlightCommands(testName: string): number {
+  let survivors = [...inFlight];
+  inFlight.clear();
+  for (let entry of survivors) {
+    console.error(
+      `[runBoxel] command outlived "${testName}"; killing it.\n${describeCommand(entry)}`,
+    );
+    entry.child.kill('SIGKILL');
+  }
+  return survivors.length;
+}
+
+afterEach(() => {
+  if (inFlight.size === 0) {
+    return;
+  }
+  reapInFlightCommands(expect.getState().currentTestName ?? 'unknown test');
+});
+
 export function runBoxel(
   args: string[],
   options: RunBoxelOptions = {},
@@ -102,12 +177,13 @@ export function runBoxel(
     ...options.env,
   };
 
+  let timeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
+
   return new Promise<BoxelResult>((resolvePromise, reject) => {
     let child = spawn(command, [...baseArgs, ...args], {
       cwd: options.cwd,
       env,
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: options.timeout ?? 60_000,
     });
 
     let stdout = '';
@@ -123,13 +199,51 @@ export function runBoxel(
     child.stdout.on('data', (chunk) => (stdout += chunk));
     child.stderr.on('data', (chunk) => (stderr += chunk));
 
-    child.on('error', reject);
+    let entry: InFlightCommand = {
+      child,
+      argv: [command, ...baseArgs, ...args].join(' '),
+      startedAt: Date.now(),
+      readStdout: () => stdout,
+      readStderr: () => stderr,
+    };
+    inFlight.add(entry);
+
+    // The deadline lives here rather than in `spawn`'s own `timeout` for
+    // two reasons: `spawn` sends SIGTERM only, and `boxel realm watch`
+    // installs a SIGTERM handler, so a command wedged inside that handler
+    // needs the SIGKILL follow-up; and the caller needs to be told the
+    // command was killed instead of inferring it from a null exit code.
+    let timedOut = false;
+    let killTimer: NodeJS.Timeout | undefined;
+    let deadline = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      killTimer = setTimeout(() => child.kill('SIGKILL'), KILL_GRACE_MS);
+    }, timeoutMs);
+
+    let settle = () => {
+      clearTimeout(deadline);
+      if (killTimer) {
+        clearTimeout(killTimer);
+      }
+      inFlight.delete(entry);
+    };
+
+    child.on('error', (err) => {
+      settle();
+      reject(err);
+    });
     child.on('close', (code) => {
+      settle();
+      if (timedOut) {
+        stderr += `\n[runBoxel] killed after exceeding its ${timeoutMs}ms deadline: ${entry.argv}\n`;
+      }
       resolvePromise({
         stdout,
         stderr,
         exitCode: code,
         ok: code === 0,
+        timedOut,
         json<T = unknown>(): T {
           try {
             return JSON.parse(stdout) as T;

--- a/packages/boxel-cli/tests/helpers/run-boxel.ts
+++ b/packages/boxel-cli/tests/helpers/run-boxel.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { afterEach, expect } from 'vitest';
+import { afterAll, afterEach, expect } from 'vitest';
 
 /**
  * Drive the `boxel` CLI as a subprocess — its real external interface
@@ -62,9 +62,10 @@ export interface RunBoxelOptions {
   /** Text piped to the command's stdin. */
   input?: string;
   /**
-   * Kill the command after this many ms (default 60s). A command that
-   * needs longer than the enclosing test's own timeout must raise both,
-   * or vitest abandons the test while the command is still running.
+   * Kill the command after this many ms (default 60s). Keep this strictly
+   * below the enclosing test's or hook's own timeout: whichever is smaller
+   * fires first, and only this one reports which command was killed and what
+   * it had printed.
    */
   timeout?: number;
 }
@@ -110,6 +111,28 @@ interface InFlightCommand {
   startedAt: number;
   readStdout: () => string;
   readStderr: () => string;
+  /** Disarms the command's deadline and marks its result as reaped. */
+  abandon: () => void;
+}
+
+/**
+ * Signal the command *and anything it spawned*. `boxel parse` runs
+ * ember-tsc, `boxel test` launches chromium, and several commands shell out
+ * to git; signalling the command's pid alone leaves those grandchildren
+ * running — burning a core for the rest of the job, and holding the stdio
+ * pipes open so the command never reports `close`. Every command is spawned
+ * `detached`, which puts it in its own process group, so the negative pid
+ * reaches the whole tree.
+ */
+function killTree(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (child.pid === undefined) {
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    // The group is already gone, which is the outcome we wanted.
+  }
 }
 
 const inFlight = new Set<InFlightCommand>();
@@ -134,27 +157,30 @@ function describeCommand(entry: InFlightCommand): string {
 }
 
 /**
- * Kill any command still running when a test ends, and say what it was.
+ * Kill any command still running at a test or hook boundary, and say what it
+ * was.
  *
- * vitest's default 30s `testTimeout` is shorter than this helper's 60s
- * command deadline, so a wedged command outlives the test that started it
- * and keeps writing to the realm server the *next* test is using — pushing
- * files, creating realms, or queueing index jobs behind a test that never
- * asked for any of it. Reaping at test boundaries keeps a single slow
+ * The suite's configured `testTimeout` is shorter than this helper's
+ * `DEFAULT_TIMEOUT_MS`, so vitest gives up on a wedged command before its own
+ * deadline does. The command keeps writing to the realm server the *next*
+ * test is using — pushing files, creating realms, queueing index jobs behind
+ * a test that never asked for any of it — because the whole suite shares one
+ * process and one server. Reaping at every boundary keeps a single slow
  * command from becoming a cascade of unrelated failures.
  *
- * The report matters as much as the kill: on its own, a timed-out test
- * reports only `Test timed out in 30000ms`, which names neither the command
- * that hung nor what it had printed before it did.
+ * The report matters as much as the kill: on its own, an abandoned test
+ * reports only that it timed out, naming neither the command that hung nor
+ * what it had printed before it did.
  */
-export function reapInFlightCommands(testName: string): number {
+export function reapInFlightCommands(scope: string): number {
   let survivors = [...inFlight];
   inFlight.clear();
   for (let entry of survivors) {
     console.error(
-      `[runBoxel] command outlived "${testName}"; killing it.\n${describeCommand(entry)}`,
+      `[runBoxel] command outlived ${scope}; killing it.\n${describeCommand(entry)}`,
     );
-    entry.child.kill('SIGKILL');
+    entry.abandon();
+    killTree(entry.child, 'SIGKILL');
   }
   return survivors.length;
 }
@@ -163,7 +189,21 @@ afterEach(() => {
   if (inFlight.size === 0) {
     return;
   }
-  reapInFlightCommands(expect.getState().currentTestName ?? 'unknown test');
+  reapInFlightCommands(
+    `test "${expect.getState().currentTestName ?? 'unknown test'}"`,
+  );
+});
+
+// `afterEach` never sees a command a hook started, and the hooks are where
+// the longest-running commands live: `realm ingest-card` runs from a
+// `beforeAll`, so a hook that gives up on it leaves it writing to the realm
+// server for every remaining file in the run — the suite shares one process
+// and one server under `--poolOptions.forks.singleFork`.
+afterAll(() => {
+  if (inFlight.size === 0) {
+    return;
+  }
+  reapInFlightCommands("this file's hooks");
 });
 
 export function runBoxel(
@@ -184,6 +224,9 @@ export function runBoxel(
       cwd: options.cwd,
       env,
       stdio: ['pipe', 'pipe', 'pipe'],
+      // Its own process group, so `killTree` can reach whatever the command
+      // spawns.
+      detached: true,
     });
 
     let stdout = '';
@@ -199,33 +242,49 @@ export function runBoxel(
     child.stdout.on('data', (chunk) => (stdout += chunk));
     child.stderr.on('data', (chunk) => (stderr += chunk));
 
+    let timedOut = false;
+    let reaped = false;
+    let killTimer: NodeJS.Timeout | undefined;
+
+    // The deadline escalates SIGTERM to SIGKILL because `boxel realm watch`
+    // installs a SIGTERM handler of its own, and it reports the kill through
+    // `timedOut` and a stderr note so the caller reads a killed command as
+    // killed rather than as a bare null exit code.
+    let deadline = setTimeout(() => {
+      // `close` waits on the stdio pipes as well as the exit, so a command
+      // that has already exited can still be here with a grandchild holding
+      // a pipe. Killing it now, and calling it a timeout, would both be
+      // false.
+      if (child.exitCode !== null || child.signalCode !== null) {
+        return;
+      }
+      timedOut = true;
+      killTree(child, 'SIGTERM');
+      killTimer = setTimeout(() => killTree(child, 'SIGKILL'), KILL_GRACE_MS);
+    }, timeoutMs);
+
+    let disarm = () => {
+      clearTimeout(deadline);
+      if (killTimer) {
+        clearTimeout(killTimer);
+      }
+    };
+
     let entry: InFlightCommand = {
       child,
       argv: [command, ...baseArgs, ...args].join(' '),
       startedAt: Date.now(),
       readStdout: () => stdout,
       readStderr: () => stderr,
+      abandon: () => {
+        reaped = true;
+        disarm();
+      },
     };
     inFlight.add(entry);
 
-    // The deadline lives here rather than in `spawn`'s own `timeout` for
-    // two reasons: `spawn` sends SIGTERM only, and `boxel realm watch`
-    // installs a SIGTERM handler, so a command wedged inside that handler
-    // needs the SIGKILL follow-up; and the caller needs to be told the
-    // command was killed instead of inferring it from a null exit code.
-    let timedOut = false;
-    let killTimer: NodeJS.Timeout | undefined;
-    let deadline = setTimeout(() => {
-      timedOut = true;
-      child.kill('SIGTERM');
-      killTimer = setTimeout(() => child.kill('SIGKILL'), KILL_GRACE_MS);
-    }, timeoutMs);
-
     let settle = () => {
-      clearTimeout(deadline);
-      if (killTimer) {
-        clearTimeout(killTimer);
-      }
+      disarm();
       inFlight.delete(entry);
     };
 
@@ -237,6 +296,8 @@ export function runBoxel(
       settle();
       if (timedOut) {
         stderr += `\n[runBoxel] killed after exceeding its ${timeoutMs}ms deadline: ${entry.argv}\n`;
+      } else if (reaped) {
+        stderr += `\n[runBoxel] killed when its test ended: ${entry.argv}\n`;
       }
       resolvePromise({
         stdout,

--- a/packages/boxel-cli/tests/integration/realm-ingest-card.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-ingest-card.test.ts
@@ -194,7 +194,10 @@ beforeAll(async () => {
       '--realm',
       realmHref,
     ],
-    { home, timeout: 600_000 },
+    // Strictly under the hook's own 600s budget, so an ingest that wedges is
+    // reported as a killed command rather than abandoned by the hook and
+    // left running against the realm server every later file shares.
+    { home, timeout: 570_000 },
   );
 }, 600_000);
 
@@ -252,7 +255,7 @@ describe('realm ingest-card (integration)', () => {
           '--realm',
           '@cardstack/test/',
         ],
-        { home, timeout: 120_000 },
+        { home, timeout: 110_000 },
       );
       expect(rriResult.ok, rriResult.stderr).toBe(true);
       expect(listIngested(rriDir)).toEqual(EXPECTED_INGESTED);

--- a/packages/boxel-cli/tests/run-boxel-harness.test.ts
+++ b/packages/boxel-cli/tests/run-boxel-harness.test.ts
@@ -35,15 +35,30 @@ describe('runBoxel harness', () => {
   it('kills a command past its deadline and says so', async () => {
     process.env.BOXEL_CLI_BIN = fixture('hang.cjs');
 
-    let res = await runBoxel(['wedged'], { timeout: 250 });
+    // Comfortably past interpreter startup: a deadline that races `node`'s
+    // own boot kills the command before it installs its SIGTERM handler,
+    // which silently stops exercising the escalation this asserts.
+    let res = await runBoxel(['wedged'], { timeout: 3_000 });
 
     expect(res.timedOut).toBe(true);
     expect(res.ok).toBe(false);
     // Without this the caller sees only a null exit code and an empty
     // stderr, which reads like a command that failed on its own terms.
-    expect(res.stderr).toContain('killed after exceeding its 250ms deadline');
+    expect(res.stderr).toContain('killed after exceeding its 3000ms deadline');
     // A command that ignores SIGTERM still dies, and its output survives.
     expect(res.stdout).toContain('hang.cjs started with args: wedged');
+  });
+
+  it('kills what the command spawned, not just the command', async () => {
+    process.env.BOXEL_CLI_BIN = fixture('hang-with-grandchild.cjs');
+
+    // The grandchild holds the stdio pipes, so this resolves at all only
+    // because the whole process group is signalled.
+    let res = await runBoxel([], { timeout: 3_000 });
+
+    expect(res.timedOut).toBe(true);
+    expect(res.stdout).toContain('parent started');
+    expect(res.stdout).toContain('hang.cjs started with args: grandchild');
   });
 
   it('leaves a command that exits on its own untouched', async () => {
@@ -63,16 +78,27 @@ describe('runBoxel harness', () => {
 
     // vitest abandons a test at its own timeout while the command it started
     // keeps running against the shared realm server, so the harness reaps
-    // survivors at every test boundary.
-    void runBoxel(['abandoned', '--flag'], {
+    // survivors at every test and hook boundary.
+    let abandoned = runBoxel(['abandoned', '--flag'], {
       env: { RUN_BOXEL_READY_FILE: readyFile },
     });
-    await vi.waitFor(() => expect(existsSync(readyFile)).toBe(true));
+    // Generous, because this waits on `node` starting under whatever else
+    // the runner is doing, and a tight budget here is its own flake.
+    await vi.waitFor(() => expect(existsSync(readyFile)).toBe(true), {
+      timeout: 10_000,
+    });
 
-    expect(reapInFlightCommands('some abandoning test')).toBe(1);
+    expect(reapInFlightCommands('test "some abandoning test"')).toBe(1);
     let report = errors.mock.calls.map(([message]) => message).join('\n');
-    expect(report).toContain('command outlived "some abandoning test"');
+    expect(report).toContain('command outlived test "some abandoning test"');
     expect(report).toContain('hang.cjs abandoned --flag');
+
+    // A reaped command reads as reaped rather than as a command that failed
+    // on its own terms.
+    let res = await abandoned;
+    expect(res.ok).toBe(false);
+    expect(res.timedOut).toBe(false);
+    expect(res.stderr).toContain('killed when its test ended');
   });
 
   it('reaps nothing when every command has already exited', async () => {

--- a/packages/boxel-cli/tests/run-boxel-harness.test.ts
+++ b/packages/boxel-cli/tests/run-boxel-harness.test.ts
@@ -1,0 +1,85 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { reapInFlightCommands, runBoxel } from './helpers/run-boxel.ts';
+
+function fixture(name: string): string {
+  return resolve(import.meta.dirname, 'fixtures/run-boxel', name);
+}
+
+let previousBin = process.env.BOXEL_CLI_BIN;
+let scratchDirs: string[] = [];
+
+function scratchFile(name: string): string {
+  let dir = mkdtempSync(join(tmpdir(), 'boxel-run-boxel-test-'));
+  scratchDirs.push(dir);
+  return join(dir, name);
+}
+
+afterEach(() => {
+  if (previousBin === undefined) {
+    delete process.env.BOXEL_CLI_BIN;
+  } else {
+    process.env.BOXEL_CLI_BIN = previousBin;
+  }
+  for (let dir of scratchDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  scratchDirs = [];
+  vi.restoreAllMocks();
+});
+
+describe('runBoxel harness', () => {
+  it('kills a command past its deadline and says so', async () => {
+    process.env.BOXEL_CLI_BIN = fixture('hang.cjs');
+
+    let res = await runBoxel(['wedged'], { timeout: 250 });
+
+    expect(res.timedOut).toBe(true);
+    expect(res.ok).toBe(false);
+    // Without this the caller sees only a null exit code and an empty
+    // stderr, which reads like a command that failed on its own terms.
+    expect(res.stderr).toContain('killed after exceeding its 250ms deadline');
+    // A command that ignores SIGTERM still dies, and its output survives.
+    expect(res.stdout).toContain('hang.cjs started with args: wedged');
+  });
+
+  it('leaves a command that exits on its own untouched', async () => {
+    process.env.BOXEL_CLI_BIN = fixture('echo-json.cjs');
+
+    let res = await runBoxel(['--json', 'ping']);
+
+    expect(res.ok).toBe(true);
+    expect(res.timedOut).toBe(false);
+    expect(res.json<{ args: string[] }>().args).toEqual(['--json', 'ping']);
+  });
+
+  it('reaps a command its test abandoned, naming the command', async () => {
+    process.env.BOXEL_CLI_BIN = fixture('hang.cjs');
+    let readyFile = scratchFile('ready');
+    let errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // vitest abandons a test at its own timeout while the command it started
+    // keeps running against the shared realm server, so the harness reaps
+    // survivors at every test boundary.
+    void runBoxel(['abandoned', '--flag'], {
+      env: { RUN_BOXEL_READY_FILE: readyFile },
+    });
+    await vi.waitFor(() => expect(existsSync(readyFile)).toBe(true));
+
+    expect(reapInFlightCommands('some abandoning test')).toBe(1);
+    let report = errors.mock.calls.map(([message]) => message).join('\n');
+    expect(report).toContain('command outlived "some abandoning test"');
+    expect(report).toContain('hang.cjs abandoned --flag');
+  });
+
+  it('reaps nothing when every command has already exited', async () => {
+    process.env.BOXEL_CLI_BIN = fixture('echo-json.cjs');
+
+    await runBoxel([]);
+
+    expect(reapInFlightCommands('a well behaved test')).toBe(0);
+  });
+});

--- a/packages/boxel-cli/tests/scripts/run-integration-with-test-pg.sh
+++ b/packages/boxel-cli/tests/scripts/run-integration-with-test-pg.sh
@@ -7,6 +7,22 @@ REALM_SERVER_SCRIPTS="$(cd "$SCRIPT_DIR/../../../realm-server/tests/scripts" && 
 "${REALM_SERVER_SCRIPTS}/prepare-test-pg.sh"
 trap '"${REALM_SERVER_SCRIPTS}/stop-test-pg.sh" >/dev/null 2>&1 || true' EXIT INT TERM
 
+# A junit report is the only record of *which* integration test failed that
+# survives CI: the suite prints tens of thousands of lines of realm-server
+# request logging, and the dev-stack log printed after it adds tens of
+# thousands more, so vitest's own summary sits too far from either end of the
+# job log for a log reader to reach. CI sets JUNIT_OUTPUT_FILE and uploads the
+# report as an artifact; locally the console reporter alone is enough.
+VITEST_ARGS=(run --pool=forks --poolOptions.forks.singleFork)
+if [ -n "${JUNIT_OUTPUT_FILE:-}" ]; then
+  mkdir -p "$(dirname "${JUNIT_OUTPUT_FILE}")"
+  VITEST_ARGS+=(
+    --reporter=default
+    --reporter=junit
+    "--outputFile.junit=${JUNIT_OUTPUT_FILE}"
+  )
+fi
+
 NODE_NO_WARNINGS=1 \
 PGPORT=55436 \
-  vitest run --pool=forks --poolOptions.forks.singleFork tests/integration/**
+  vitest "${VITEST_ARGS[@]}" tests/integration/**


### PR DESCRIPTION
Reported flake: `Boxel CLI Tests` on [run 33543965834](https://github.com/cardstack/boxel/actions/runs/33543965834/job/99977937791) (PR [#5948](https://github.com/cardstack/boxel/pull/5948)). Attempt 2 of the same commit passed.

## This is not a one-off

Mining the last 300 failed CI runs: **39 of them had `Boxel CLI Tests` fail**, always at `Run integration tests against the packed npm install`, on `main` as well as PR branches, spread evenly from mid-July to now. Four of them landed on Sept 1 alone.

## The failing assertion is not recoverable, and that is the first thing to fix

The suite's own summary names the failing test, but nothing can reach it:

- The suite prints tens of thousands of lines of realm-server request logging.
- `Print server logs` then `cat /tmp/server.log`, adding tens of thousands more.

So the summary sits far from both ends of the job log. The Actions API caps a job-log read at 5000 trailing lines, and on every one of these failures those 5000 lines fall entirely inside the dev-stack dump — for the reported run, the readable window starts 2 seconds *after* the test step ended. I could not read the assertion for the reported failure, and neither can anything else reading the log programmatically.

This PR closes that hole three ways:

- **The failing tests are printed as the job's last step**, parsed out of the junit report: each failing test's name, message and body, plus any harness report filed against it. Being last puts them inside any tail read. This is the part that matters most for automated triage — the artifact below needs a browser to fetch, and its signed URL sits on the same host as the log's, so an environment that can read the log cannot necessarily download the artifact beside it.
- **A junit report** is written when `JUNIT_OUTPUT_FILE` is set and uploaded as the `boxel-cli-test-report` artifact — the same mechanism the realm-server and host suites already use, which is why their flakes are diagnosable and this one is not. The job asserts the report exists before uploading, matching the guard `ci-host.yaml` puts on its shards.
- **`/tmp/server.log` becomes the `boxel-cli-test-dev-stack-log` artifact**, and the job log prints a bounded 500-line tail instead of all of it. Nothing is lost, and the suite's own summary stays within reach of a tail read too.

## A wedged command can no longer outlive the test or hook that started it

`testTimeout` is 30s; `runBoxel`'s command deadline is 60s. A command that hangs is therefore abandoned by its test with up to 30s left to run — still pushing files, creating realms, and queueing index jobs against the realm server the **next** test is using, since the whole suite shares one process and one server under `singleFork`. That turns one slow command into a cascade of unrelated failures.

The timing fits that shape: failing step durations run 32s / 43s / 74s / 109s longer than a passing run of the same step, i.e. one to three 30s timeouts per failure rather than one.

`runBoxel` now tracks in-flight commands and reaps survivors at every test **and hook** boundary. Commands spawn `detached` and are killed by process group, because `boxel parse` runs ember-tsc, `boxel test` launches chromium, and several commands shell out to git — signalling one pid orphans those, and an orphan that inherited stdio holds the pipes open so the command never reports `close` at all.

The reaping is also the diagnostic. An abandoned test reports only `Test timed out in 30000ms`, naming neither the command nor its output, so the reaper prints the command line, pid, elapsed time, and the partial stdout/stderr it had produced — and that lands in the junit report and the end-of-job summary under the test that abandoned it.

**Where the deadline actually fires.** In the suite as configured every `runBoxel` deadline is at or above its enclosing vitest budget, so vitest abandons first and the reaper is the mechanism that runs; the deadline is a backstop for callers that set a shorter one. Two sites had budgets exactly equal to their hook/test timeout — `realm-ingest-card.test.ts`, including a `beforeAll` running `realm ingest-card`, the longest-lived command in the suite — and those now sit strictly below, so a wedge there is reported rather than abandoned.

## Scope, honestly stated

The cascade containment is a real defect fix, not a guess: the timeout mismatch is in the harness and the contamination window follows from it. But it is **not** established as the first domino — that assertion is exactly what the buried log hides. With the diagnostics in place, the next occurrence (at the observed rate, within a day or two on `main`) names the failing test, its assertion, and — if a hung CLI command is involved — which command hung and what it had printed.

**Open lead worth a second opinion:** `vitest.config.mjs` sets `testTimeout: 30000` but no `hookTimeout`, so every `beforeAll` runs on vitest's 10s default. 30 of 32 integration files boot Postgres, a realm server, and an initial index inside a bare `beforeAll` — and the two files that don't (`search.test.ts`, `realm-ingest-card.test.ts`) both override theirs to 600s, which suggests someone already hit this. An occasionally-slow boot under CI load fits the flake's shape as well as anything here. I have deliberately **not** raised `hookTimeout`: without a failing run's report that would be raising a timeout on speculation, which is what we are trying to stop doing. vitest files a hook failure against a testcase named for the file, so the new end-of-job summary names it, and the next occurrence settles it either way.

No test is skipped, retried, or given a longer timeout to pass.

## Verification

`packages/boxel-cli/tests/run-boxel-harness.test.ts` covers the deadline kill and its report, the process-group kill, a normal command left untouched, an abandoned command reaped and named, and no-op reaping when everything exited. It runs in the job's existing unit-test step, before the dev stack starts.

Against the real helper in a standalone vitest 2.1.9 sandbox (this container cannot boot the full stack — no mise, no docker daemon):

- 5/5 pass idle, and **8/8 runs pass at loadavg 21 on 4 vCPUs** — the condition that matters, since an earlier revision of this test raced node's own interpreter startup and failed 7 of 8 runs there.
- Deadline-lands-while-a-pipe-is-held: 25/25 attempts report the true exit code, none falsely flagged as timed out.
- A `beforeAll` that spawns and then throws leaves no surviving process.
- The end-of-job summariser was run against a real report containing an assertion failure, an abandoned test with a reaper record, and a hook timeout; it names all three.

In CI on the first commit of this branch, `Boxel CLI Tests` passed and both artifacts were produced. `yamllint` (repo config) and `prettier` are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbdT1tCe4W8gkyWcboZMLq