### PR TITLE
Show an error in the assistant when a generation hits the output-token limit

### DIFF
--- a/packages/ai-bot/constants.ts
+++ b/packages/ai-bot/constants.ts
@@ -1,1 +1,7 @@
 export const thinkingMessage = 'Thinking...';
+
+// Shown when the provider stops a generation at its maximum output-token
+// limit (finish_reason 'length'): the answer is cut off, not withdrawn, so
+// the partial content stays in the room and this rides alongside it.
+export const maxOutputTokensErrorMessage =
+  'The response reached the maximum output length before it could finish. Ask the assistant to continue, or break the request into smaller steps.';

--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -5,7 +5,10 @@ import {
   READ_REALM_FILE_TOOL_NAME,
   readFilesLabel,
 } from '../read-realm-file.ts';
-import { thinkingMessage } from '../../constants.ts';
+import {
+  maxOutputTokensErrorMessage,
+  thinkingMessage,
+} from '../../constants.ts';
 import type ResponseState from '../response-state.ts';
 import {
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
@@ -193,6 +196,18 @@ export default class MatrixResponsePublisher {
           ...(usageIncluded ? { usage: usageIncluded } : {}),
         },
       };
+      // The provider cut the generation at its output-token limit: the answer
+      // is incomplete, so tell the user. The error rides the final part of the
+      // answer (like tools and usage) rather than replacing it — the partial
+      // content is still worth keeping. A canceled turn is cut off on purpose
+      // and already labeled as such.
+      if (
+        responseStateSnapshot.isStreamingFinished &&
+        !responseStateSnapshot.isCanceled &&
+        responseStateSnapshot.finishReason === 'length'
+      ) {
+        extraData.errorMessage = maxOutputTokensErrorMessage;
+      }
       if (this.currentResponseEvent.needsContinuation) {
         extraData[APP_BOXEL_CONTINUATION_OF_CONTENT_KEY] =
           this.currentResponseEventId;

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -266,6 +266,11 @@ export class Responder {
       Boolean(call),
     );
 
+    // Record the finish_reason regardless of streaming mode: the final
+    // consolidated edit surfaces an error to the user when the provider cut
+    // the generation at its output-token limit ('length').
+    this.responseState.updateFinishReason(chunk.choices?.[0]?.finish_reason);
+
     // When we're not sending mid-turn, `finalize()` owns the
     // `isStreamingFinished` transition — otherwise the flag would flip here,
     // the mid-turn send would be gated off, and `finalize()` would see no

--- a/packages/ai-bot/lib/response-state.ts
+++ b/packages/ai-bot/lib/response-state.ts
@@ -10,6 +10,16 @@ export default class ResponseState {
   private allowedToolNames: Set<string> | undefined;
   isStreamingFinished = false;
   isCanceled = false;
+  // The provider's finish_reason for this turn. Only the chunk that ends the
+  // generation carries one; keep the last non-null value so trailing chunks
+  // (e.g. the usage report) cannot clear it.
+  finishReason: string | undefined;
+
+  updateFinishReason(finishReason: string | null | undefined) {
+    if (finishReason) {
+      this.finishReason = finishReason;
+    }
+  }
 
   setAllowedToolNames(names: Iterable<string> | undefined) {
     this.allowedToolNames = names ? new Set(names) : undefined;
@@ -116,6 +126,7 @@ export default class ResponseState {
       toolCalls: this.toolCalls,
       isStreamingFinished: this.isStreamingFinished,
       isCanceled: this.isCanceled,
+      finishReason: this.finishReason,
     };
   }
 }

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -3,7 +3,7 @@ const { module, test, assert } = QUnit;
 import { Responder } from '../lib/responder.ts';
 import { DEFAULT_EVENT_SIZE_MAX } from '../lib/matrix/response-publisher.ts';
 import FakeTimers from '@sinonjs/fake-timers';
-import { thinkingMessage } from '../constants.ts';
+import { maxOutputTokensErrorMessage, thinkingMessage } from '../constants.ts';
 import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
 import type { ToolRequest } from '@cardstack/runtime-common/commands';
 import {
@@ -597,6 +597,110 @@ module('Responding', (hooks) => {
     } finally {
       delete process.env.AI_BOT_STREAMING_MODE;
     }
+  });
+
+  test('a generation cut off at the output-token limit surfaces an error on the final event, keeping the partial answer', async () => {
+    await responder.ensureThinkingMessageSent();
+    await responder.onChunk({} as any, snapshotWithContent('partial answer'));
+    await clock.tickAsync(300);
+    // The provider stops the generation at its max output tokens.
+    await responder.onChunk(
+      {
+        choices: [{ delta: {}, finish_reason: 'length', index: 0 }],
+      } as any,
+      snapshotWithContent('partial answer'),
+    );
+    await clock.tickAsync(300);
+    await responder.finalize();
+
+    let sentEvents = fakeMatrixClient.getSentEvents();
+    let last = sentEvents[sentEvents.length - 1].content;
+    assert.equal(
+      last.body,
+      'partial answer',
+      'the partial answer is kept, not replaced by the error',
+    );
+    assert.equal(
+      last.errorMessage,
+      maxOutputTokensErrorMessage,
+      'the final event carries the output-limit error',
+    );
+    assert.true(last.isStreamingFinished, 'the answer is marked finished');
+  });
+
+  test('an answer split across continuation events carries the output-limit error only on its final part', async () => {
+    responder.matrixResponsePublisher.eventSizeMax = 1024; // 1KB max event size
+    let longContent = 'a'.repeat(512) + 'b'.repeat(1024) + 'c'.repeat(1024);
+
+    await responder.ensureThinkingMessageSent();
+    await responder.onChunk({} as any, snapshotWithContent(longContent));
+    await responder.onChunk(
+      {
+        choices: [{ delta: {}, finish_reason: 'length', index: 0 }],
+      } as any,
+      snapshotWithContent(longContent),
+    );
+    await responder.finalize();
+
+    let sentEvents = fakeMatrixClient.getSentEvents();
+    let continuationParts = sentEvents.filter(
+      (e) => e.content[APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY],
+    );
+    assert.ok(continuationParts.length > 0, 'the answer was split');
+    for (let part of continuationParts) {
+      assert.strictEqual(
+        part.content.errorMessage,
+        undefined,
+        'a continuation fragment carries no error',
+      );
+    }
+    let last = sentEvents[sentEvents.length - 1].content;
+    assert.equal(
+      last.errorMessage,
+      maxOutputTokensErrorMessage,
+      'the final part carries the output-limit error',
+    );
+  });
+
+  test('a normally finished generation carries no error message', async () => {
+    await responder.ensureThinkingMessageSent();
+    await responder.onChunk({} as any, snapshotWithContent('the answer'));
+    await clock.tickAsync(300);
+    await responder.onChunk(
+      {
+        choices: [{ delta: {}, finish_reason: 'stop', index: 0 }],
+      } as any,
+      snapshotWithContent('the answer'),
+    );
+    await clock.tickAsync(300);
+    await responder.finalize();
+
+    let sentEvents = fakeMatrixClient.getSentEvents();
+    let last = sentEvents[sentEvents.length - 1].content;
+    assert.strictEqual(last.errorMessage, undefined, 'no error on the event');
+  });
+
+  test('a canceled generation carries no error message even if the last chunk reported length', async () => {
+    await responder.ensureThinkingMessageSent();
+    await responder.onChunk({} as any, snapshotWithContent('partial answer'));
+    await clock.tickAsync(300);
+    await responder.onChunk(
+      {
+        choices: [{ delta: {}, finish_reason: 'length', index: 0 }],
+      } as any,
+      snapshotWithContent('partial answer'),
+    );
+    await clock.tickAsync(300);
+    await responder.finalize({ isCanceled: true });
+
+    let sentEvents = fakeMatrixClient.getSentEvents();
+    let last = sentEvents[sentEvents.length - 1].content;
+    assert.true(last.isCanceled, 'the turn is marked canceled');
+    assert.strictEqual(
+      last.errorMessage,
+      undefined,
+      'a canceled turn is cut off on purpose, so no error',
+    );
   });
 
   test('per-turn telemetry counts room-edits mid-turn events (the comparison baseline)', async () => {

--- a/packages/host/app/lib/matrix-classes/message.ts
+++ b/packages/host/app/lib/matrix-classes/message.ts
@@ -72,7 +72,7 @@ export class Message implements RoomMessageInterface {
   attachedSkillCardIds?: string[] | null;
   index?: number;
   transactionId?: string | null;
-  @tracked errorMessage?: string;
+  @tracked private _errorMessage?: string;
   clientGeneratedId?: string;
   isDebugMessage?: boolean;
   reloadBillingData?: boolean;
@@ -111,6 +111,17 @@ export class Message implements RoomMessageInterface {
     this.codePatchResults = new TrackedArray<MessageCodePatchResult>();
     this.instanceId = guidFor(this);
     this.isCodePatchCorrectness = false;
+  }
+
+  // Like tools, body, and usage, an error that ends a split answer (e.g. the
+  // provider's output-token limit) rides the final part of the continuation
+  // chain; the head chases it so the one rendered message shows it.
+  get errorMessage(): string | undefined {
+    return this.continuedInMessage?.errorMessage ?? this._errorMessage;
+  }
+
+  set errorMessage(errorMessage: string | undefined) {
+    this._errorMessage = errorMessage;
   }
 
   get isRetryable() {


### PR DESCRIPTION
Output token limit can happen when the model does so much thinking that the reasoning tokens use up the whole output budget before it writes any of the answer.

This bug was observed when I tried to generate cards using Sonnet 5, which by default has high reasoning effort (next piece of work will reduce that effort to a lower level)

This adds an error message when that happens (previously the generation just stopped, but now we show an error)

<img width="682" height="73" alt="image" src="https://github.com/user-attachments/assets/8c89dee3-328f-4d9e-b038-15b65ef196f2" />

