### PR TITLE
Fail a change that exports from boxel-ui and imports it from base

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -34,6 +34,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The cross-artifact check compares this change against its merge
+          # base, which a depth-1 checkout cannot reach.
+          fetch-depth: 0
       - uses: ./.github/actions/init
 
       - name: Type-check repo-root scripts
@@ -55,6 +59,16 @@ jobs:
       - name: Check the execution protocol's runtime import closure
         if: ${{ !cancelled() }}
         run: pnpm run lint:protocol-closure
+      - name: Check for a boxel-ui export imported from packages/base
+        # boxel-ui compiles into the host bundle and base ships as realm
+        # source, so a commit adding an export and its import together cannot
+        # deploy atomically: during the overlap the new source renders against
+        # a bundle without the name, throws `has no exported member`, and the
+        # indexer caches that as the card's content. Two ~70-minute outages
+        # (CS-12669) came from this shape, and a third instance shipped
+        # unnoticed. Needs the base branch present to diff against.
+        if: ${{ !cancelled() }}
+        run: pnpm run lint:cross-artifact-imports
       - name: Check every execution tier is registered for record parity
         # RP-14.4: the parity harness compares the tiers it is handed, so an
         # adapter nobody registered is not a failing comparison but an absent

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "prepare-worktree-types": "pnpm --filter @cardstack/boxel-icons build && pnpm --filter @cardstack/boxel-ui build",
     "prepare": "husky",
     "lint:protocol-closure": "node ./scripts/check-protocol-import-closure.mts",
-    "lint:tier-registry": "node ./scripts/check-execution-tier-registry.mts"
+    "lint:tier-registry": "node ./scripts/check-execution-tier-registry.mts",
+    "lint:cross-artifact-imports": "node ./scripts/check-cross-artifact-imports.mts"
   },
   "devDependencies": {
     "@actions/core": "catalog:",

--- a/scripts/check-cross-artifact-imports.mts
+++ b/scripts/check-cross-artifact-imports.mts
@@ -1,0 +1,226 @@
+#!/usr/bin/env -S node
+// Guards against a commit that adds an export to `packages/boxel-ui` and, in
+// the same change, imports it from `packages/base`.
+//
+// Those two packages look like neighbors in git and are not neighbors in
+// deployment. `boxel-ui` is compiled into the host bundle; `base` ships as
+// realm source, fetched at index time. They reach production by separate,
+// non-atomic paths, and the deploy train brings the new source up while pages
+// are still running the previous bundle — so for a few minutes a render of the
+// new source resolves its imports against a bundle that has never heard of
+// them, and throws `has no exported member '…'`.
+//
+// That failure is not confined to the render. The indexer stores it as the
+// card's content, so a transient window becomes an error document served from
+// cache to every anonymous reader until something reindexes the row. Twice in
+// three days that turned a ~6-minute bundle overlap into a ~70-minute outage
+// across every realm linking a base-realm card (see CS-12669, CS-12696).
+//
+// Nothing else can see this. Both halves type-check, both pass their tests,
+// and the pair is only wrong in the interval between two deploys — so the
+// signal has to come from the shape of the change itself.
+//
+// The rule: for every name this change newly exports from a `boxel-ui` barrel,
+// no file under `packages/base` may import that name. Landing the export
+// first, and the import in a later deploy, satisfies it.
+//
+// Type-only exports and imports are ignored, following the same reasoning as
+// `check-protocol-import-closure.mts`: they are erased before anything can
+// access a member, so they cannot throw.
+
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// The barrels realm source imports through: a name is only reachable from
+// `packages/base` if one of these exports it. Located by pattern at each
+// revision rather than by fixed path, because the package has been
+// restructured before — and a barrel that simply moved would otherwise read as
+// a barrel whose every name is new, which is the difference between a check
+// that fires on a hazard and one that fires on a refactor.
+const BARREL_PATTERN = /(^|\/)src\/(components|helpers|icons|modifiers)\.gts$/;
+
+function barrelPaths(ref: string | undefined): string[] {
+  let listing =
+    ref === undefined
+      ? git(['ls-tree', '-r', '--name-only', 'HEAD', 'packages/boxel-ui'])
+      : git(['ls-tree', '-r', '--name-only', ref, 'packages/boxel-ui']);
+  return listing.split('\n').filter((path) => BARREL_PATTERN.test(path));
+}
+
+function git(args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+function gitOrEmpty(args: string[]): string {
+  try {
+    return git(args);
+  } catch {
+    // A path that does not exist at that revision, which reads as "nothing
+    // exported there yet" — the correct answer for a newly added barrel.
+    return '';
+  }
+}
+
+// `--head` exists so the check can be pointed at a historical commit, which is
+// how its own behavior is verified against the two commits that caused the
+// outages. Unset means the working tree, which is what CI checks.
+function arg(name: string): string | undefined {
+  let flag = `--${name}`;
+  let index = process.argv.indexOf(flag);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+let headRef = arg('head');
+let baseRef =
+  arg('base') ??
+  process.env.CROSS_ARTIFACT_BASE ??
+  (process.env.GITHUB_BASE_REF
+    ? `origin/${process.env.GITHUB_BASE_REF}`
+    : 'origin/main');
+
+// The merge base, not the base tip: a branch that has not caught up with main
+// must not be told that main's newer exports are its own.
+let mergeBase: string;
+try {
+  mergeBase = git(['merge-base', baseRef, headRef ?? 'HEAD']).trim();
+} catch {
+  // Loudly, rather than passing: a check that cannot see the base has not
+  // found the change clean, and a shallow clone is the likely reason.
+  console.error(
+    `Cannot resolve a merge base between ${baseRef} and ${headRef ?? 'HEAD'}.\n` +
+      `This check diffs against the base branch, so it needs that history —\n` +
+      `\`fetch-depth: 0\` on checkout, or \`--base <ref>\` locally.`,
+  );
+  process.exit(1);
+}
+
+function readAt(ref: string | undefined, path: string): string {
+  return ref === undefined
+    ? gitOrEmpty(['show', `HEAD:${path}`])
+    : gitOrEmpty(['show', `${ref}:${path}`]);
+}
+
+// Names an `export { … }` block makes available at runtime. `type` entries are
+// dropped; `x as y` exports `y`.
+function exportedNames(source: string): Set<string> {
+  let names = new Set<string>();
+  for (let [, body] of source.matchAll(/export\s*\{([^}]*)\}/g)) {
+    for (let entry of body.split(',')) {
+      let specifier = entry.trim();
+      if (!specifier || /^type\s/.test(specifier)) {
+        continue;
+      }
+      let parts = specifier.split(/\s+as\s+/);
+      let name = (parts[1] ?? parts[0]).trim();
+      if (/^[A-Za-z_$][\w$]*$/.test(name) && name !== 'default') {
+        names.add(name);
+      }
+    }
+  }
+  for (let [, name] of source.matchAll(
+    /export\s+(?:async\s+)?(?:const|let|function|class)\s+([A-Za-z_$][\w$]*)/g,
+  )) {
+    names.add(name);
+  }
+  return names;
+}
+
+// Names a file imports from `@cardstack/boxel-ui/*` at runtime. `import type`
+// statements and `type` specifiers are dropped for the same reason.
+function boxelUiImports(source: string): Map<string, string[]> {
+  let byName = new Map<string, string[]>();
+  let pattern =
+    /import\s+(type\s+)?\{([^}]*)\}\s*from\s*['"](@cardstack\/boxel-ui\/[^'"]+)['"]/g;
+  for (let [, typeOnly, body, module] of source.matchAll(pattern)) {
+    if (typeOnly) {
+      continue;
+    }
+    for (let entry of body.split(',')) {
+      let specifier = entry.trim();
+      if (!specifier || /^type\s/.test(specifier)) {
+        continue;
+      }
+      let name = specifier.split(/\s+as\s+/)[0].trim();
+      if (!/^[A-Za-z_$][\w$]*$/.test(name)) {
+        continue;
+      }
+      let modules = byName.get(name) ?? [];
+      modules.push(module);
+      byName.set(name, modules);
+    }
+  }
+  return byName;
+}
+
+function baseFiles(ref: string | undefined): string[] {
+  let listing =
+    ref === undefined
+      ? git(['ls-tree', '-r', '--name-only', 'HEAD', 'packages/base'])
+      : git(['ls-tree', '-r', '--name-only', ref, 'packages/base']);
+  return listing
+    .split('\n')
+    .filter((path) => /\.(gts|ts)$/.test(path) && !path.endsWith('.d.ts'));
+}
+
+// Compared as one set across every barrel, not barrel by barrel: a name moved
+// between them is still a name the deployed bundle already provides.
+function reachableNames(ref: string | undefined): Set<string> {
+  let names = new Set<string>();
+  for (let barrel of barrelPaths(ref)) {
+    for (let name of exportedNames(readAt(ref, barrel))) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
+let before = reachableNames(mergeBase);
+let newExports = new Set<string>();
+for (let name of reachableNames(headRef)) {
+  if (!before.has(name)) {
+    newExports.add(name);
+  }
+}
+
+type Offender = { name: string; file: string; module: string };
+let offenders: Offender[] = [];
+if (newExports.size > 0) {
+  for (let file of baseFiles(headRef)) {
+    let imports = boxelUiImports(readAt(headRef, file));
+    for (let [name, modules] of imports) {
+      if (newExports.has(name)) {
+        offenders.push({ name, file, module: modules[0] });
+      }
+    }
+  }
+}
+
+console.log(
+  `cross-artifact imports: ${newExports.size} name(s) newly exported from boxel-ui since ${mergeBase.slice(0, 9)}` +
+    (newExports.size > 0 ? ` — ${[...newExports].sort().join(', ')}` : ''),
+);
+
+if (offenders.length > 0) {
+  console.error(
+    `\nThese names are exported from boxel-ui for the first time in this change` +
+      ` and imported from packages/base by it:\n` +
+      offenders
+        .map(({ name, file, module }) => `  ${name}  ${file} → ${module}`)
+        .join('\n') +
+      `\n\nboxel-ui ships in the host bundle and base ships as realm source, so` +
+      `\nthis pair cannot be deployed atomically: for the length of the deploy` +
+      `\nthe new source renders against a bundle without these names, throws` +
+      `\n'has no exported member', and that failure is cached as the card's` +
+      `\ncontent until something reindexes the row.` +
+      `\n\nLand the boxel-ui export first and the base import in a later deploy.`,
+  );
+}
+
+process.exit(offenders.length > 0 ? 1 : 0);


### PR DESCRIPTION
This is a mitigation for the two recent production downtimes, which were caused by new `boxel-ui` exports imported in `@cardstack/base`, which breaks during deployments, because the new exports aren’t available yet by the time indexing starts. This approach is quite restrictive though: it won’t allow a single PR to both add a new export and import it in the base realm. Is this acceptable?

Claude: `boxel-ui` compiles into the host bundle; `base` ships as realm source. They reach production by separate, non-atomic paths, so a commit that adds an export and its import together cannot deploy atomically: for the length of the deploy the new source renders against a bundle that has never heard of the name and throws `has no exported member`. The indexer then stores that as the card's content, which is how a few minutes of bundle overlap became roughly seventy minutes of anonymous 500s across every realm linking a base-realm card, twice in three days.

Nothing else can see the shape. Both halves type-check, both pass their tests, and the pair is only wrong between two deploys — so the check reads the change itself: for every name newly reachable from a boxel-ui barrel, no file under `packages/base` may import it. Landing the export first and the import in a later deploy satisfies it.

Two details the first cut got wrong, both found by running the check across real history rather than reasoning about it:

- Comparing barrel files by path made "change boxel-ui to flat directory structure" (46b2aad1ac) report every name in the package as new. Barrels are now located by pattern at each revision and compared as one set, so a name that moved is a name the deployed bundle already provides.
- A base that cannot be resolved now fails rather than passing. A check that cannot see the base has not found the change clean, and the likely cause is a shallow clone — which is also why the lint checkout now takes full history.

Verified against the history it exists for: both outage triggers fail the check (212e02e772 for `googleFontImportsFor`, 79f40e90d1 for `MarkdownContentShell`), and the flat-directory refactor passes. It also found a third instance nobody noticed — #5648 added `toSelectedItemComponent` to a barrel and imported it from `packages/base/enum.gts` in the same commit, on 2026-08-10, without a visible outage.

That third case is the argument for reading the failure carefully rather than treating it as a lint nit: this shape reaches main regularly, and the check will block legitimate work until it is split across two deploys. Softening it to a warning is a one-line change if that trade turns out to be wrong.